### PR TITLE
Fix use of isA

### DIFF
--- a/src/PackMatrix.cc
+++ b/src/PackMatrix.cc
@@ -29,7 +29,7 @@ PackMatrix<PT, inpType, accType>::PackMatrix(
 template <typename PT, typename inpType, typename accType>
 int PackMatrix<PT, inpType, accType>::packedBufferSize(int rows, int cols) {
   if (cpuinfo_has_x86_avx512f()) {
-    if (isA) {
+    if (isA()) {
       return PackingTraits<inpType, accType, inst_set_t::avx512>::MCB *
           PackingTraits<inpType, accType, inst_set_t::avx512>::KCB;
     } else {
@@ -39,7 +39,7 @@ int PackMatrix<PT, inpType, accType>::packedBufferSize(int rows, int cols) {
           (((cols + colBlock - 1) / colBlock) * colBlock);
     }
   } else if (cpuinfo_has_x86_avx2()) {
-    if (isA) {
+    if (isA()) {
       return PackingTraits<inpType, accType, inst_set_t::avx2>::MCB *
           PackingTraits<inpType, accType, inst_set_t::avx2>::KCB;
     } else {


### PR DESCRIPTION
During build I was receiving warnings saying that the boolean value of the functions `isA`'s address will always evaluate true. I believe the intention here was to call `isA` rather than find the truthiness of its address