### PR TITLE
clean up PackAWithQuantRowOffset from avx2 intrinsics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,10 @@ set(FBGEMM_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set(FBGEMM_THIRDPARTY_DIR ${FBGEMM_BINARY_DIR}/third_party)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+
 #All the source files that either use avx2 instructions statically or JIT
 #avx2/avx512 instructions.
-set(FBGEMM_AVX2_SRCS src/ExecuteKernel.cc
+set(FBGEMM_GENERIC_SRCS src/ExecuteKernel.cc
                 src/ExecuteKernelU8S8.cc
                 src/Fbgemm.cc
                 src/FbgemmFP16.cc
@@ -62,6 +63,9 @@ else()
   message(WARNING "OpenMP is not supported by the compiler")
 endif()
 
+#All the source files that either use avx2 instructions statically
+set(FBGEMM_AVX2_SRCS src/Utils_avx2.cc)
+
 #All the source files that use avx512 instructions statically
 set(FBGEMM_AVX512_SRCS src/Utils_avx512.cc)
 
@@ -74,14 +78,17 @@ set(FBGEMM_PUBLIC_HEADERS include/fbgemm/Fbgemm.h
                           include/fbgemm/FbgemmI8Spmdm.h)
 
 
+add_library(fbgemm_generic OBJECT ${FBGEMM_GENERIC_SRCS})
 add_library(fbgemm_avx2 OBJECT ${FBGEMM_AVX2_SRCS})
 add_library(fbgemm_avx512 OBJECT ${FBGEMM_AVX512_SRCS})
 
-set_target_properties(fbgemm_avx2 fbgemm_avx512 PROPERTIES
+set_target_properties(fbgemm_generic fbgemm_avx2 fbgemm_avx512 PROPERTIES
       CXX_STANDARD 11
       CXX_EXTENSIONS NO
       CXX_VISIBILITY_PRESET hidden)
 
+target_compile_options(fbgemm_generic PRIVATE
+  "-m64" "-mavx2" "-mfma" "-masm=intel")
 target_compile_options(fbgemm_avx2 PRIVATE
   "-m64" "-mavx2" "-mfma" "-masm=intel")
 target_compile_options(fbgemm_avx512 PRIVATE
@@ -132,6 +139,12 @@ if(NOT TARGET cpuinfo)
   set_property(TARGET cpuinfo PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 
+target_include_directories(fbgemm_generic BEFORE
+      PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}>
+      PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}/include>
+      PRIVATE "${ASMJIT_SRC_DIR}/src"
+      PRIVATE "${CPUINFO_SOURCE_DIR}/include")
+
 target_include_directories(fbgemm_avx2 BEFORE
       PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}>
       PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}/include>
@@ -145,17 +158,24 @@ target_include_directories(fbgemm_avx512 BEFORE
       PRIVATE "${CPUINFO_SOURCE_DIR}/include")
 
 if(FBGEMM_LIBRARY_TYPE STREQUAL "default")
-  add_library(fbgemm $<TARGET_OBJECTS:fbgemm_avx2>
+  add_library(fbgemm
+    $<TARGET_OBJECTS:fbgemm_generic>
+    $<TARGET_OBJECTS:fbgemm_avx2>
     $<TARGET_OBJECTS:fbgemm_avx512>)
 elseif(FBGEMM_LIBRARY_TYPE STREQUAL "shared")
-  add_library(fbgemm SHARED $<TARGET_OBJECTS:fbgemm_avx2>
+  add_library(fbgemm SHARED
+    $<TARGET_OBJECTS:fbgemm_generic>
+    $<TARGET_OBJECTS:fbgemm_avx2>
     $<TARGET_OBJECTS:fbgemm_avx512>)
+  set_property(TARGET fbgemm_generic PROPERTY POSITION_INDEPENDENT_CODE ON)
   set_property(TARGET fbgemm_avx2 PROPERTY POSITION_INDEPENDENT_CODE ON)
   set_property(TARGET fbgemm_avx512 PROPERTY POSITION_INDEPENDENT_CODE ON)
   set_target_properties(fbgemm PROPERTIES
     CXX_VISIBILITY_PRESET hidden)
 elseif(FBGEMM_LIBRARY_TYPE STREQUAL "static")
-  add_library(fbgemm STATIC $<TARGET_OBJECTS:fbgemm_avx2>
+  add_library(fbgemm STATIC
+    $<TARGET_OBJECTS:fbgemm_generic>
+    $<TARGET_OBJECTS:fbgemm_avx2>
     $<TARGET_OBJECTS:fbgemm_avx512>)
   target_compile_definitions(fbgemm_avx2 PRIVATE FBGEMM_STATIC)
   target_compile_definitions(fbgemm_avx512 PRIVATE FBGEMM_STATIC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,9 @@ else()
 endif()
 
 #All the source files that either use avx2 instructions statically
-set(FBGEMM_AVX2_SRCS src/Utils_avx2.cc)
+set(FBGEMM_AVX2_SRCS
+  src/QuantUtilsAvx2.cc
+  src/Utils_avx2.cc)
 
 #All the source files that use avx512 instructions statically
 set(FBGEMM_AVX512_SRCS src/Utils_avx512.cc)
@@ -72,6 +74,8 @@ set(FBGEMM_AVX512_SRCS src/Utils_avx512.cc)
 set(FBGEMM_PUBLIC_HEADERS include/fbgemm/Fbgemm.h
                           include/fbgemm/OutputProcessing-inl.h
                           include/fbgemm/PackingTraits-inl.h
+                          include/fbgemm/QuantUtils.h
+                          include/fbgemm/QuantUtilsAvx2.h
                           include/fbgemm/Utils.h
                           include/fbgemm/ConvUtils.h
                           include/fbgemm/Types.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ endif()
 
 #All the source files that either use avx2 instructions statically
 set(FBGEMM_AVX2_SRCS
+  src/OptimizedKernelsAvx2.cc
   src/QuantUtilsAvx2.cc
   src/Utils_avx2.cc)
 

--- a/include/fbgemm/QuantUtilsAvx2.h
+++ b/include/fbgemm/QuantUtilsAvx2.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstdint>
+#include "FbgemmBuild.h"
+
+namespace fbgemm {
+
+// Copied from gemmlowp
+//
+// A structure to hold quantization parameters 'scale' and 'zero_point'.
+// The meaning of these values is as the constants in the quantization equation
+//
+//   real_value = scale * (quantized_value - zero_point)
+//
+// In other words, 'zero_point' is the quantized value that corresponds
+// to the real value 0, and 'scale' is the difference of real values
+// corresponding to consecutive quantized values.
+struct FBGEMM_API TensorQuantizationParams {
+  float scale;
+  std::int32_t zero_point;
+  int precision;
+  float Min() const;
+  float Max() const;
+};
+
+// Parameters when we scale from int32 intermediate matrix multiplication
+// results to 8-bit integers
+struct FBGEMM_API RequantizationParams {
+  // For floating-point requantization
+  float real_multiplier;
+
+  // For fixed-point requantization
+  std::int32_t multiplier;
+  int right_shift;
+
+  TensorQuantizationParams target_qparams;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Utility functions
+
+void QuantizeAvx2(
+    const float* src,
+    std::uint8_t* dst,
+    int len,
+    const TensorQuantizationParams& qparams);
+
+/**
+ * @brief Find the min and max value in a float matrix.
+ */
+void FBGEMM_API FindMinMax(const float* m, float* min, float* max, int len);
+
+void RequantizeFixedPointAvx2(
+    const std::int32_t* src,
+    std::uint8_t* dst,
+    int len,
+    const RequantizationParams& params);
+
+void RequantizeAvx2(
+    const std::int32_t* src,
+    std::uint8_t* dst,
+    int len,
+    const RequantizationParams& params);
+
+} // namespace fbgemm

--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -95,34 +95,4 @@ void transpose_simd(
     float* dst,
     int ld_dst);
 
-namespace internal {
-
-/**
- * @brief Transpose a matrix using Intel AVX2.
- *
- * This is called if the code is running on a CPU with Intel AVX2 support.
- */
-void transpose_8x8(
-    int M,
-    int N,
-    const float* src,
-    int ld_src,
-    float* dst,
-    int ld_dst);
-
-/**
- * @brief Transpose a matrix using Intel AVX512.
- *
- * This is called if the code is running on a CPU with Intel AVX512 support.
- */
-void transpose_16x16(
-    int M,
-    int N,
-    const float* src,
-    int ld_src,
-    float* dst,
-    int ld_dst);
-
-} // namespace internal
-
 } // namespace fbgemm

--- a/src/ExecuteKernel.cc
+++ b/src/ExecuteKernel.cc
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include "ExecuteKernel.h"
-#include <immintrin.h>
 #include "fbgemm/Fbgemm.h"
 #include "fbgemm/Utils.h"
 

--- a/src/OptimizedKernelsAvx2.cc
+++ b/src/OptimizedKernelsAvx2.cc
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "OptimizedKernelsAvx2.h"
+#include <immintrin.h>
+
+namespace fbgemm {
+
+std::int32_t reduceAvx2(const std::uint8_t* A, int len) {
+  std::int32_t row_sum = 0;
+#if defined(__AVX2__)
+  __m256i sum_v = _mm256_setzero_si256();
+  __m256i one_epi16_v = _mm256_set1_epi16(1);
+  __m256i one_epi8_v = _mm256_set1_epi8(1);
+
+  int i;
+  // vectorized
+  for (i = 0; i < len / 32 * 32; i += 32) {
+    __m256i src_v = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(A + i));
+    sum_v = _mm256_add_epi32(
+        sum_v,
+        _mm256_madd_epi16(
+            _mm256_maddubs_epi16(src_v, one_epi8_v), one_epi16_v));
+  }
+
+  alignas(64) std::int32_t temp[8];
+  _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v);
+  for (int k = 0; k < 8; ++k) {
+    row_sum += temp[k];
+  }
+
+  // scalar
+  for (; i < len; ++i) {
+    row_sum += A[i];
+  }
+
+#else
+  for (int i = 0; i < len; ++i) {
+    row_sum += A[i];
+  }
+#endif
+  return row_sum;
+}
+
+} // namespace fbgemm

--- a/src/OptimizedKernelsAvx2.h
+++ b/src/OptimizedKernelsAvx2.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include <cstdint> // for std::int32_t
+
+namespace fbgemm {
+
+/**
+ * @brief Sum a given vector
+ */
+std::int32_t reduceAvx2(const std::uint8_t* A, int len);
+
+} // namespace fbgemm

--- a/src/PackAWithIm2Col.cc
+++ b/src/PackAWithIm2Col.cc
@@ -12,6 +12,7 @@
 #include <numeric>
 
 #include "fbgemm/Fbgemm.h"
+#include "OptimizedKernelsAvx2.h"
 
 namespace fbgemm {
 
@@ -108,6 +109,10 @@ void PackAWithIm2Col<T, accT, SPATIAL_DIM>::pack(const block_type_t& block) {
     }
   }
 
+  // reduceAvx2 only written for T == uint8_t
+  static_assert(
+      std::is_same<T, uint8_t>::value,
+      "PackAWithIm2Col<T, accT>::pack only works for T == uint8_t");
   if (point_wise) {
     int32_t ld = this->numCols();
     for (int i = block.row_start; i < block.row_start + block.row_size; ++i) {
@@ -122,31 +127,7 @@ void PackAWithIm2Col<T, accT, SPATIAL_DIM>::pack(const block_type_t& block) {
       }
       int32_t row_sum =
           row_offset_acc ? row_offset_buf[i - block.row_start] : 0;
-      __m256i sum_v = _mm256_setzero_si256();
-      __m256i one_epi16_v = _mm256_set1_epi16(1);
-      __m256i one_epi8_v = _mm256_set1_epi8(1);
-      for (int j = block.col_start;
-           j < block.col_start + block.col_size / 32 * 32;
-           j += 32) {
-        __m256i src_v = _mm256_loadu_si256(
-            reinterpret_cast<__m256i const*>(sdata_ + i * ld + j));
-        sum_v = _mm256_add_epi32(
-            sum_v,
-            _mm256_madd_epi16(
-                _mm256_maddubs_epi16(src_v, one_epi8_v), one_epi16_v));
-      }
-      for (int j = block.col_start + block.col_size / 32 * 32;
-           j < block.col_start + block.col_size;
-           ++j) {
-        row_sum += sdata_[i * ld + j];
-      }
-      // alignas(64) std::array<int32_t, 8> temp;
-      alignas(64) std::int32_t temp[8];
-      //_mm256_store_si256(reinterpret_cast<__m256i*>(temp.data()), sum_v);
-      _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v);
-      for (int k = 0; k < 8; ++k) {
-        row_sum += temp[k];
-      }
+      row_sum += reduceAvx2(sdata_ + i * ld + block.col_start, block.col_size);
       row_offset_buf[i - block.row_start] = row_sum;
     }
 
@@ -273,27 +254,8 @@ void PackAWithIm2Col<T, accT, SPATIAL_DIM>::pack(const block_type_t& block) {
 
     // TODO: skip row_offset computation when B_zero_point is 0
     int32_t row_sum = row_offset_acc ? row_offset_buf[i - block.row_start] : 0;
-
-    __m256i sum_v = _mm256_setzero_si256();
-    __m256i one_epi16_v = _mm256_set1_epi16(1);
-    __m256i one_epi8_v = _mm256_set1_epi8(1);
-    for (int j = 0; j < block.col_size / 32 * 32; j += 32) {
-      __m256i src_v = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(
-          out + (i - block.row_start) * this->blockColSize() + j));
-      sum_v = _mm256_add_epi32(
-          sum_v,
-          _mm256_madd_epi16(
-              _mm256_maddubs_epi16(src_v, one_epi8_v), one_epi16_v));
-    }
-    for (int j = block.col_size / 32 * 32; j < block.col_size; ++j) {
-      row_sum += out[(i - block.row_start) * this->blockColSize() + j];
-    }
-    alignas(64) int32_t temp[8];
-    _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v);
-    for (int k = 0; k < 8; ++k) {
-      row_sum += temp[k];
-    }
-
+    row_sum += reduceAvx2(
+        out + (i - block.row_start) * this->blockColSize(), block.col_size);
     row_offset_buf[i - block.row_start] = row_sum;
   } // for each i
 }

--- a/src/QuantUtils.cc
+++ b/src/QuantUtils.cc
@@ -1,7 +1,6 @@
 #include "fbgemm/QuantUtils.h"
 
 #include <cpuinfo.h>
-#include <immintrin.h>
 
 #include "fbgemm/Fbgemm.h"
 
@@ -154,119 +153,39 @@ void ChooseRequantizationMultiplier(
 ////////////////////////////////////////////////////////////////////////////////
 // Utility functions
 
-// FIXME: code duplication with PackAWithQuantRowOffset
-template <typename T>
-void Quantize(
-    const float* src,
-    T* dst,
-    int len,
-    const TensorQuantizationParams& qparams) {
-#if defined(__AVX2__) && defined(__FMA__)
-  bool avx2_support = cpuinfo_has_x86_avx2();
-  bool fma_support = cpuinfo_has_x86_fma3();
-  if (avx2_support && fma_support && qparams.precision == 8 &&
-      std::is_same<T, uint8_t>::value) {
-    // fast path
-    constexpr int VLEN = 8;
-    std::size_t i = 0;
-    __m256 inverse_scale_v = _mm256_set1_ps(1.f / qparams.scale);
-    for (; i < len / VLEN * VLEN; i += VLEN) {
-      __m256 src_v = _mm256_loadu_ps(src + i);
-      __m256 transformed_v = _mm256_fmadd_ps(
-          src_v, inverse_scale_v, _mm256_set1_ps(qparams.zero_point));
-      __m256 clipped_v = _mm256_min_ps(
-          _mm256_max_ps(transformed_v, _mm256_set1_ps(0.f)),
-          _mm256_set1_ps(255.f));
-      __m256i rounded_v = _mm256_cvtps_epi32(clipped_v);
-      alignas(64) std::int32_t temp_int32[VLEN];
-      _mm256_store_si256((__m256i*)temp_int32, rounded_v);
-      for (int j = 0; j < VLEN; ++j) {
-        dst[i + j] = temp_int32[j];
-      }
-    }
-
-    for (; i < len; ++i) {
-      float transformed = qparams.zero_point + src[i] / qparams.scale;
-      float clipped = std::min(std::max(transformed, 0.f), 255.f);
-      // Not exactly the same behavior as the vectorized code.
-      // The vectorized code above always rounds to even in halfway cases
-      // (https://software.intel.com/en-us/node/523819), but std::nearbyint
-      // does the same only when the current rounding mode is FE_TONEAREST.
-      // However, in practice, this should not be a problem because most cases
-      // use the default rounding mode FE_TONEAREST.
-      // Note that we cannot implement the same behavior as the vectorized code
-      // using std::round because it does rounding away from zero in halfway
-      // cases.
-      dst[i] = nearbyint(clipped);
-    }
-  } else
-#endif
-  {
-    for (std::size_t i = 0; i < len; ++i) {
-      dst[i] = Quantize<T>(src[i], qparams);
-    }
+#define FBGEMM_SPECIALIZED_QUANTIZE(T)      \
+  template <>                                 \
+  void Quantize<T>(                         \
+      const float* src,                     \
+      T* dst,                                 \
+      const int len,                          \
+      const TensorQuantizationParams& qparams) {   \
+    for (int i = 0; i < len; ++i) {           \
+      dst[i] = Quantize<T>(src[i], qparams); \
+    }                                         \
   }
-}
+FBGEMM_SPECIALIZED_QUANTIZE(int8_t)
+FBGEMM_SPECIALIZED_QUANTIZE(uint16_t)
+FBGEMM_SPECIALIZED_QUANTIZE(int16_t)
+FBGEMM_SPECIALIZED_QUANTIZE(int32_t)
+#undef FBGEMM_SPECIALIZED_QUANTIZE
 
-template void Quantize<uint8_t>(
+template <>
+void Quantize<uint8_t>(
     const float* src,
     uint8_t* dst,
     int len,
-    const TensorQuantizationParams& qparams);
-
-template void Quantize<int8_t>(
-    const float* src,
-    int8_t* dst,
-    int len,
-    const TensorQuantizationParams& qparams);
-
-template void Quantize<uint16_t>(
-    const float* src,
-    uint16_t* dst,
-    int len,
-    const TensorQuantizationParams& qparams);
-
-template void Quantize<int16_t>(
-    const float* src,
-    int16_t* dst,
-    int len,
-    const TensorQuantizationParams& qparams);
-
-void FindMinMax(const float* a, float* min, float* max, int len) {
-  if (len <= 0) {
-    *min = 0.0f;
-    *max = 0.0f;
-    return;
-  }
-
-  float temp_min = *a, temp_max = *a;
-  int i = 0;
-
-#ifdef __AVX__
-  __m256 min_v = _mm256_set1_ps(*a), max_v = _mm256_set1_ps(*a);
-  constexpr int VLEN = 8;
-  if (len >= VLEN) {
-    for (; i < len / VLEN * VLEN; i += VLEN) {
-      min_v = _mm256_min_ps(min_v, _mm256_loadu_ps(a + i));
-      max_v = _mm256_max_ps(max_v, _mm256_loadu_ps(a + i));
-    }
-
-    float min_buf[VLEN], max_buf[VLEN];
-    _mm256_storeu_ps(min_buf, min_v);
-    _mm256_storeu_ps(max_buf, max_v);
-    for (int j = 0; j < VLEN; ++j) {
-      temp_min = std::min(temp_min, min_buf[j]);
-      temp_max = std::max(temp_max, max_buf[j]);
+    const TensorQuantizationParams& qparams) {
+  bool avx2_support = cpuinfo_has_x86_avx2();
+  bool fma_support = cpuinfo_has_x86_fma3();
+  if (avx2_support && fma_support && qparams.precision == 8) {
+    // fast path
+    QuantizeAvx2(src, dst, len, qparams);
+  } else {
+    for (std::size_t i = 0; i < len; ++i) {
+      dst[i] = Quantize<uint8_t>(src[i], qparams);
     }
   }
-#endif
-
-  for (; i < len; i++) {
-    temp_min = std::min(temp_min, a[i]);
-    temp_max = std::max(temp_max, a[i]);
-  }
-  *min = temp_min;
-  *max = temp_max;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -281,101 +200,33 @@ int64_t SaturatingRoundingMulWithShift(int32_t a, int32_t b, int right_shift) {
   return (ab_64 + nudge) >> right_shift;
 }
 
-#ifdef __AVX2__
-void RequantizeFixedPointAvx2(
+#define FBGEMM_SPECIALIZED_REQUANTIZE(T)      \
+  template <>                                 \
+  void Requantize<T>(                         \
+      const int32_t* src,                     \
+      T* dst,                                 \
+      const int len,                          \
+      const RequantizationParams& params) {   \
+    for (int i = 0; i < len; ++i) {           \
+      dst[i] = Requantize<T>(src[i], params); \
+    }                                         \
+  }
+FBGEMM_SPECIALIZED_REQUANTIZE(uint16_t)
+FBGEMM_SPECIALIZED_REQUANTIZE(int32_t)
+#undef FBGEMM_SPECIALIZED_REQUANTIZE
+
+template <>
+void Requantize<uint8_t>(
     const int32_t* src,
     uint8_t* dst,
-    int len,
+    const int len,
     const RequantizationParams& params) {
-  constexpr int VLEN = 8;
-
-  __m256i b = _mm256_set1_epi32(params.multiplier);
-
-  // AVX2 doesn't support arithmetic right shift.
-  // As a work around, we convert 64-bit multiplied results to uint64_t by
-  // adding 0x8000000000000000ULL, logical right shift, and subtract by
-  // (0x8000000000000000ULL >> right_shift).
-  __m256i pre_shift_nudge = _mm256_set1_epi64x(
-      (1ll << (params.right_shift - 1)) + 0x8000000000000000ULL);
-  __m256i post_shift_nudge = _mm256_set1_epi64x(
-      params.target_qparams.zero_point -
-      (0x8000000000000000ULL >> params.right_shift));
-
-  __m256i min_v = _mm256_set1_epi32(numeric_limits<uint8_t>::min());
-  __m256i max_v = _mm256_set1_epi32(numeric_limits<uint8_t>::max());
-
-  __m256i shuffle_mask_v = _mm256_set_epi8(
-      0xff,
-      0xff,
-      0xff,
-      0xff,
-      0xff,
-      0xff,
-      0xff,
-      0xff,
-      0xff,
-      0xff,
-      0xff,
-      0xff,
-      0x0c,
-      0x08,
-      0x04,
-      0x00,
-      0xff,
-      0xff,
-      0xff,
-      0xff,
-      0xff,
-      0xff,
-      0xff,
-      0xff,
-      0xff,
-      0xff,
-      0xff,
-      0xff,
-      0x0c,
-      0x08,
-      0x04,
-      0x00);
-  __m256i permute_mask_v =
-      _mm256_set_epi32(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00);
-
-  int i = 0;
-  for (; i < len / VLEN * VLEN; i += VLEN) {
-    __m256i a_v = _mm256_loadu_si256((const __m256i*)(src + i));
-
-    // a = a0 | a1 | a2 | a3 | a4 | a5 | a6 | a7
-    // b = b0 | b1 | b3 | b3 | b4 | b5 | b6 | b7
-    __m256i a_even_v = a_v;
-    __m256i a_odd_v = _mm256_srli_si256(a_v, 4);
-
-    __m256i ab_even_v = _mm256_mul_epi32(a_even_v, b);
-    __m256i ab_odd_v = _mm256_mul_epi32(a_odd_v, b);
-
-    __m256i even_rounded_v = _mm256_add_epi64(ab_even_v, pre_shift_nudge);
-    __m256i odd_rounded_v = _mm256_add_epi64(ab_odd_v, pre_shift_nudge);
-
-    __m256i even_result_v = _mm256_add_epi64(
-        _mm256_srli_epi64(even_rounded_v, params.right_shift),
-        post_shift_nudge);
-    __m256i odd_result_v = _mm256_add_epi64(
-        _mm256_srli_epi64(odd_rounded_v, params.right_shift), post_shift_nudge);
-    odd_result_v = _mm256_slli_si256(odd_result_v, 4);
-
-    // even_result_v has numbers we want in its even 32-bit SIMD lanes, and
-    // odd_result_v has numbers we want in its odd 32-bit SIMD lanes.
-    // Use blend to combine them.
-    __m256i result_v = _mm256_blend_epi32(even_result_v, odd_result_v, 0xaa);
-    __m256i clipped_v =
-        _mm256_max_epi32(min_v, _mm256_min_epi32(max_v, result_v));
-
-    clipped_v = _mm256_shuffle_epi8(clipped_v, shuffle_mask_v);
-    clipped_v = _mm256_permutevar8x32_epi32(clipped_v, permute_mask_v);
-    *(int64_t*)(dst + i) = _mm256_extract_epi64(clipped_v, 0);
-  }
-
-  for (; i < len; ++i) {
-    dst[i] = RequantizeFixedPoint<uint8_t>(src[i], params);
+  if (params.target_qparams.precision == 8 && cpuinfo_has_x86_avx2()) {
+    RequantizeAvx2(src, dst, len, params);
+  } else {
+    for (int i = 0; i < len; ++i) {
+      dst[i] = Requantize<uint8_t>(src[i], params);
+    }
   }
 }
 
@@ -421,59 +272,6 @@ void RequantizeFixedPoint<uint8_t>(
   } else {
     for (int i = 0; i < len; ++i) {
       dst[i] = RequantizeFixedPoint<uint8_t>(src[i], params);
-    }
-  }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Requantization (with floats)
-
-void RequantizeAvx2(
-    const int32_t* src,
-    uint8_t* dst,
-    int len,
-    const RequantizationParams& params) {
-  DoNothing<> doNothingObj{};
-  ReQuantizeOutput<false /* FUSE_RELU */> requantizeObj(
-    doNothingObj,
-    &params.real_multiplier,
-    params.target_qparams.zero_point,
-    0,
-    0,
-    nullptr,
-    nullptr,
-    nullptr,
-    len);
-  requantizeObj.f<inst_set_t::avx2>(dst, src, {0, 1, 0, len}, 0, 0);
-}
-#endif
-
-#define FBGEMM_SPECIALIZED_REQUANTIZE(T)      \
-  template <>                                 \
-  void Requantize<T>(                         \
-      const int32_t* src,                     \
-      T* dst,                                 \
-      const int len,                          \
-      const RequantizationParams& params) {   \
-    for (int i = 0; i < len; ++i) {           \
-      dst[i] = Requantize<T>(src[i], params); \
-    }                                         \
-  }
-FBGEMM_SPECIALIZED_REQUANTIZE(uint16_t)
-FBGEMM_SPECIALIZED_REQUANTIZE(int32_t)
-#undef FBGEMM_SPECIALIZED_REQUANTIZE
-
-template <>
-void Requantize<uint8_t>(
-    const int32_t* src,
-    uint8_t* dst,
-    const int len,
-    const RequantizationParams& params) {
-  if (params.target_qparams.precision == 8 && cpuinfo_has_x86_avx2()) {
-    RequantizeAvx2(src, dst, len, params);
-  } else {
-    for (int i = 0; i < len; ++i) {
-      dst[i] = Requantize<uint8_t>(src[i], params);
     }
   }
 }

--- a/src/QuantUtilsAvx2.cc
+++ b/src/QuantUtilsAvx2.cc
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbgemm/QuantUtilsAvx2.h"
+#include <immintrin.h>
+#include <algorithm> //for std::min/std::max
+#include <cmath> //for nearbyint
+#include <limits> //for numeric_limits
+#include "fbgemm/Fbgemm.h" //for ReQuantizeOutput
+
+namespace fbgemm {
+
+using namespace std;
+////////////////////////////////////////////////////////////////////////////////
+// Utility functions
+
+// FIXME: code duplication with PackAWithQuantRowOffset
+void QuantizeAvx2(
+    const float* src,
+    uint8_t* dst,
+    int len,
+    const TensorQuantizationParams& qparams) {
+#if defined(__AVX2__) && defined(__FMA__)
+  constexpr int VLEN = 8;
+  std::size_t i = 0;
+  __m256 inverse_scale_v = _mm256_set1_ps(1.f / qparams.scale);
+  for (; i < len / VLEN * VLEN; i += VLEN) {
+    __m256 src_v = _mm256_loadu_ps(src + i);
+    __m256 transformed_v = _mm256_fmadd_ps(
+        src_v, inverse_scale_v, _mm256_set1_ps(qparams.zero_point));
+    __m256 clipped_v = _mm256_min_ps(
+        _mm256_max_ps(transformed_v, _mm256_set1_ps(0.f)),
+        _mm256_set1_ps(255.f));
+    __m256i rounded_v = _mm256_cvtps_epi32(clipped_v);
+    alignas(64) std::int32_t temp_int32[VLEN];
+    _mm256_store_si256((__m256i*)temp_int32, rounded_v);
+    for (int j = 0; j < VLEN; ++j) {
+      dst[i + j] = temp_int32[j];
+    }
+  }
+
+  for (; i < len; ++i) {
+    float transformed = qparams.zero_point + src[i] / qparams.scale;
+    float clipped = std::min(std::max(transformed, 0.f), 255.f);
+    // Not exactly the same behavior as the vectorized code.
+    // The vectorized code above always rounds to even in halfway cases
+    // (https://software.intel.com/en-us/node/523819), but std::nearbyint
+    // does the same only when the current rounding mode is FE_TONEAREST.
+    // However, in practice, this should not be a problem because most cases
+    // use the default rounding mode FE_TONEAREST.
+    // Note that we cannot implement the same behavior as the vectorized code
+    // using std::round because it does rounding away from zero in halfway
+    // cases.
+    dst[i] = nearbyint(clipped);
+  }
+#endif
+}
+
+void FindMinMax(const float* a, float* min, float* max, int len) {
+  if (len <= 0) {
+    *min = 0.0f;
+    *max = 0.0f;
+    return;
+  }
+
+  float temp_min = *a, temp_max = *a;
+  int i = 0;
+
+#ifdef __AVX__
+  __m256 min_v = _mm256_set1_ps(*a), max_v = _mm256_set1_ps(*a);
+  constexpr int VLEN = 8;
+  if (len >= VLEN) {
+    for (; i < len / VLEN * VLEN; i += VLEN) {
+      min_v = _mm256_min_ps(min_v, _mm256_loadu_ps(a + i));
+      max_v = _mm256_max_ps(max_v, _mm256_loadu_ps(a + i));
+    }
+
+    float min_buf[VLEN], max_buf[VLEN];
+    _mm256_storeu_ps(min_buf, min_v);
+    _mm256_storeu_ps(max_buf, max_v);
+    for (int j = 0; j < VLEN; ++j) {
+      temp_min = std::min(temp_min, min_buf[j]);
+      temp_max = std::max(temp_max, max_buf[j]);
+    }
+  }
+#endif
+
+  for (; i < len; i++) {
+    temp_min = std::min(temp_min, a[i]);
+    temp_max = std::max(temp_max, a[i]);
+  }
+  *min = temp_min;
+  *max = temp_max;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Requantization (with floats)
+
+#ifdef __AVX2__
+void RequantizeAvx2(
+    const int32_t* src,
+    uint8_t* dst,
+    int len,
+    const RequantizationParams& params) {
+  DoNothing<> doNothingObj{};
+  ReQuantizeOutput<false /* FUSE_RELU */> requantizeObj(
+      doNothingObj,
+      &params.real_multiplier,
+      params.target_qparams.zero_point,
+      0,
+      nullptr,
+      nullptr,
+      nullptr,
+      nullptr,
+      len);
+  requantizeObj.f<inst_set_t::avx2>(dst, src, {0, 1, 0, len}, 0, 0);
+}
+
+void RequantizeFixedPointAvx2(
+    const int32_t* src,
+    uint8_t* dst,
+    int len,
+    const RequantizationParams& params) {
+  constexpr int VLEN = 8;
+
+  __m256i b = _mm256_set1_epi32(params.multiplier);
+
+  // AVX2 doesn't support arithmetic right shift.
+  // As a work around, we convert 64-bit multiplied results to uint64_t by
+  // adding 0x8000000000000000ULL, logical right shift, and subtract by
+  // (0x8000000000000000ULL >> right_shift).
+  __m256i pre_shift_nudge = _mm256_set1_epi64x(
+      (1ll << (params.right_shift - 1)) + 0x8000000000000000ULL);
+  __m256i post_shift_nudge = _mm256_set1_epi64x(
+      params.target_qparams.zero_point -
+      (0x8000000000000000ULL >> params.right_shift));
+
+  __m256i min_v = _mm256_set1_epi32(numeric_limits<uint8_t>::min());
+  __m256i max_v = _mm256_set1_epi32(numeric_limits<uint8_t>::max());
+
+  __m256i shuffle_mask_v = _mm256_set_epi8(
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0x0c,
+      0x08,
+      0x04,
+      0x00,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      0x0c,
+      0x08,
+      0x04,
+      0x00);
+  __m256i permute_mask_v =
+      _mm256_set_epi32(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00);
+
+  int i = 0;
+  for (; i < len / VLEN * VLEN; i += VLEN) {
+    __m256i a_v = _mm256_loadu_si256((const __m256i*)(src + i));
+
+    // a = a0 | a1 | a2 | a3 | a4 | a5 | a6 | a7
+    // b = b0 | b1 | b3 | b3 | b4 | b5 | b6 | b7
+    __m256i a_even_v = a_v;
+    __m256i a_odd_v = _mm256_srli_si256(a_v, 4);
+
+    __m256i ab_even_v = _mm256_mul_epi32(a_even_v, b);
+    __m256i ab_odd_v = _mm256_mul_epi32(a_odd_v, b);
+
+    __m256i even_rounded_v = _mm256_add_epi64(ab_even_v, pre_shift_nudge);
+    __m256i odd_rounded_v = _mm256_add_epi64(ab_odd_v, pre_shift_nudge);
+
+    __m256i even_result_v = _mm256_add_epi64(
+        _mm256_srli_epi64(even_rounded_v, params.right_shift),
+        post_shift_nudge);
+    __m256i odd_result_v = _mm256_add_epi64(
+        _mm256_srli_epi64(odd_rounded_v, params.right_shift), post_shift_nudge);
+    odd_result_v = _mm256_slli_si256(odd_result_v, 4);
+
+    // even_result_v has numbers we want in its even 32-bit SIMD lanes, and
+    // odd_result_v has numbers we want in its odd 32-bit SIMD lanes.
+    // Use blend to combine them.
+    __m256i result_v = _mm256_blend_epi32(even_result_v, odd_result_v, 0xaa);
+    __m256i clipped_v =
+        _mm256_max_epi32(min_v, _mm256_min_epi32(max_v, result_v));
+
+    clipped_v = _mm256_shuffle_epi8(clipped_v, shuffle_mask_v);
+    clipped_v = _mm256_permutevar8x32_epi32(clipped_v, permute_mask_v);
+    *(int64_t*)(dst + i) = _mm256_extract_epi64(clipped_v, 0);
+  }
+
+  for (; i < len; ++i) {
+    int64_t ab_64 =
+        static_cast<int64_t>(src[i]) * static_cast<int64_t>(params.multiplier);
+    int64_t nudge = 1ll << std::max(0, params.right_shift - 1);
+    int64_t quantized_down = params.target_qparams.zero_point +
+        ((ab_64 + nudge) >> params.right_shift);
+    dst[i] = std::min<int64_t>(std::max<int64_t>(quantized_down, 0l), 255l);
+  }
+}
+#endif
+
+} // namespace fbgemm

--- a/src/TransposeUtils.h
+++ b/src/TransposeUtils.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+namespace fbgemm {
+
+/**
+ * @brief Reference implementation of matrix transposition: B = A^T.
+ * @param M The height of the matrix.
+ * @param N The width of the matrix.
+ * @param src The memory buffer of the source matrix A.
+ * @param ld_src The leading dimension of the source matrix A.
+ * @param dst The memory buffer of the destination matrix B.
+ * @param ld_dst The leading dimension of the destination matrix B.
+ */
+void transpose_ref(
+    int M,
+    int N,
+    const float* src,
+    int ld_src,
+    float* dst,
+    int ld_dst);
+
+namespace internal {
+
+/**
+ * @brief Transpose a matrix using Intel AVX2.
+ *
+ * This is called if the code is running on a CPU with Intel AVX2 support.
+ */
+void transpose_8x8(
+    int M,
+    int N,
+    const float* src,
+    int ld_src,
+    float* dst,
+    int ld_dst);
+
+/**
+ * @brief Transpose a matrix using Intel AVX512.
+ *
+ * This is called if the code is running on a CPU with Intel AVX512 support.
+ */
+void transpose_16x16(
+    int M,
+    int N,
+    const float* src,
+    int ld_src,
+    float* dst,
+    int ld_dst);
+
+} // namespace internal
+
+} // namespace fbgemm

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include "fbgemm/Utils.h"
+#include "TransposeUtils.h"
 #include <cpuinfo.h>
 #include <immintrin.h>
 #include <cassert>
@@ -156,16 +157,7 @@ template void printMatrix<int32_t>(
     size_t ld,
     std::string name);
 
-/**
- * @brief Reference implementation of matrix transposition: B = A^T.
- * @param M The height of the matrix.
- * @param N The width of the matrix.
- * @param src The memory buffer of the source matrix A.
- * @param ld_src The leading dimension of the source matrix A.
- * @param dst The memory buffer of the destination matrix B.
- * @param ld_dst The leading dimension of the destination matrix B.
- */
-inline void transpose_ref(
+void transpose_ref(
     int M,
     int N,
     const float* src,
@@ -178,161 +170,6 @@ inline void transpose_ref(
     }
   } // for each output row
 }
-
-inline void
-transpose_kernel_4x4_sse(const float* src, int ld_src, float* dst, int ld_dst) {
-  // load from src to registers
-  // a : a0 a1 a2 a3
-  // b : b0 b1 b2 b3
-  // c : c0 c1 c2 c3
-  // d : d0 d1 d2 d3
-  __m128 a = _mm_loadu_ps(&src[0 * ld_src]);
-  __m128 b = _mm_loadu_ps(&src[1 * ld_src]);
-  __m128 c = _mm_loadu_ps(&src[2 * ld_src]);
-  __m128 d = _mm_loadu_ps(&src[3 * ld_src]);
-
-  // transpose the 4x4 matrix formed by 32-bit elements: Macro from SSE
-  // a : a0 b0 c0 d0
-  // b : a1 b1 c1 d1
-  // c : a2 b2 c2 d2
-  // d : a3 b3 c3 d3
-  _MM_TRANSPOSE4_PS(a, b, c, d);
-
-  // store from registers to dst
-  _mm_storeu_ps(&dst[0 * ld_dst], a);
-  _mm_storeu_ps(&dst[1 * ld_dst], b);
-  _mm_storeu_ps(&dst[2 * ld_dst], c);
-  _mm_storeu_ps(&dst[3 * ld_dst], d);
-}
-inline void transpose_4x4(
-    int M,
-    int N,
-    const float* src,
-    int ld_src,
-    float* dst,
-    int ld_dst) {
-  int ib = 0, jb = 0;
-  for (ib = 0; ib + 4 <= M; ib += 4) {
-    for (jb = 0; jb + 4 <= N; jb += 4) {
-      transpose_kernel_4x4_sse(
-          &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
-    }
-  }
-  transpose_ref(ib, N - jb, &src[jb], ld_src, &dst[jb * ld_dst], ld_dst);
-  transpose_ref(M - ib, N, &src[ib * ld_src], ld_src, &dst[ib], ld_dst);
-}
-
-inline void transpose_kernel_8x8_avx2(
-    const float* src,
-    int ld_src,
-    float* dst,
-    int ld_dst) {
-  // load from src to registers
-  // a : a0 a1 a2 a3 a4 a5 a6 a7
-  // b : b0 b1 b2 b3 b4 b5 b6 b7
-  // c : c0 c1 c2 c3 c4 c5 c6 c7
-  // d : d0 d1 d2 d3 d4 d5 d6 d7
-  // e : e0 e1 e2 e3 e4 e5 e6 e7
-  // f : f0 f1 f2 f3 f4 f5 f6 f7
-  // g : g0 g1 g2 g3 g4 g5 g6 g7
-  // h : h0 h1 h2 h3 h4 h5 h6 h7
-  __m256 a = _mm256_loadu_ps(&src[0 * ld_src]);
-  __m256 b = _mm256_loadu_ps(&src[1 * ld_src]);
-  __m256 c = _mm256_loadu_ps(&src[2 * ld_src]);
-  __m256 d = _mm256_loadu_ps(&src[3 * ld_src]);
-  __m256 e = _mm256_loadu_ps(&src[4 * ld_src]);
-  __m256 f = _mm256_loadu_ps(&src[5 * ld_src]);
-  __m256 g = _mm256_loadu_ps(&src[6 * ld_src]);
-  __m256 h = _mm256_loadu_ps(&src[7 * ld_src]);
-
-  __m256 ab0145, ab2367, cd0145, cd2367, ef0145, ef2367, gh0145, gh2367;
-  __m256 abcd04, abcd15, efgh04, efgh15, abcd26, abcd37, efgh26, efgh37;
-  // unpacking and interleaving 32-bit elements
-  // ab0145 : a0 b0 a1 b1 a4 b4 a5 b5
-  // ab2367 : a2 b2 a3 b3 a6 b6 a7 b7
-  // cd0145 : c0 d0 c1 d1 c4 d4 c5 d5
-  // cd2367 : c2 d2 c3 d3 c6 d6 c7 d7
-  // ef0145 : e0 f0 e1 f1 e4 f4 e5 f5
-  // ef2367 : e2 f2 e3 f3 e6 f6 e7 f7
-  // gh0145 : g0 h0 g1 h1 g4 h4 g5 h5
-  // gh2367 : g2 h2 g3 h3 g6 h6 g7 h7
-  ab0145 = _mm256_unpacklo_ps(a, b);
-  ab2367 = _mm256_unpackhi_ps(a, b);
-  cd0145 = _mm256_unpacklo_ps(c, d);
-  cd2367 = _mm256_unpackhi_ps(c, d);
-  ef0145 = _mm256_unpacklo_ps(e, f);
-  ef2367 = _mm256_unpackhi_ps(e, f);
-  gh0145 = _mm256_unpacklo_ps(g, h);
-  gh2367 = _mm256_unpackhi_ps(g, h);
-
-  // shuffling the 32-bit elements
-  // abcd04 : a0 b0 c0 d0 a4 b4 c4 d4
-  // abcd15 : a1 b1 c1 d1 a5 b5 c5 d5
-  // efgh04 : e0 f0 g0 h0 e4 f4 g4 h4
-  // efgh15 : e1 f1 g1 h1 e5 b5 c5 d5
-  // abcd26 : a2 b2 c2 d2 a6 b6 c6 d6
-  // abcd37 : a3 b3 c3 d3 a7 b7 c7 d7
-  // efgh26 : e2 f2 g2 h2 e6 f6 g6 h6
-  // efgh37 : e3 f3 g3 h3 e7 f7 g7 h7
-  abcd04 = _mm256_shuffle_ps(ab0145, cd0145, 0x44);
-  abcd15 = _mm256_shuffle_ps(ab0145, cd0145, 0xee);
-  efgh04 = _mm256_shuffle_ps(ef0145, gh0145, 0x44);
-  efgh15 = _mm256_shuffle_ps(ef0145, gh0145, 0xee);
-  abcd26 = _mm256_shuffle_ps(ab2367, cd2367, 0x44);
-  abcd37 = _mm256_shuffle_ps(ab2367, cd2367, 0xee);
-  efgh26 = _mm256_shuffle_ps(ef2367, gh2367, 0x44);
-  efgh37 = _mm256_shuffle_ps(ef2367, gh2367, 0xee);
-
-  // shuffling 128-bit elements
-  // a : a0 b0 c0 d0 e0 f0 g0 h0
-  // b : a1 b1 c1 d1 e1 f1 g1 h1
-  // c : a2 b2 c2 d2 e2 f2 g2 h2
-  // d : a3 b3 c3 d3 e3 f3 g3 h3
-  // e : a4 b4 c4 d4 e4 f4 g4 h4
-  // f : a5 b5 c5 d5 e5 f5 g5 h5
-  // g : a6 b6 c6 d6 e6 f6 g6 h6
-  // h : a7 b7 c7 d7 e7 f7 g7 h7
-  a = _mm256_permute2f128_ps(efgh04, abcd04, 0x02);
-  b = _mm256_permute2f128_ps(efgh15, abcd15, 0x02);
-  c = _mm256_permute2f128_ps(efgh26, abcd26, 0x02);
-  d = _mm256_permute2f128_ps(efgh37, abcd37, 0x02);
-  e = _mm256_permute2f128_ps(efgh04, abcd04, 0x13);
-  f = _mm256_permute2f128_ps(efgh15, abcd15, 0x13);
-  g = _mm256_permute2f128_ps(efgh26, abcd26, 0x13);
-  h = _mm256_permute2f128_ps(efgh37, abcd37, 0x13);
-
-  // store from registers to dst
-  _mm256_storeu_ps(&dst[0 * ld_dst], a);
-  _mm256_storeu_ps(&dst[1 * ld_dst], b);
-  _mm256_storeu_ps(&dst[2 * ld_dst], c);
-  _mm256_storeu_ps(&dst[3 * ld_dst], d);
-  _mm256_storeu_ps(&dst[4 * ld_dst], e);
-  _mm256_storeu_ps(&dst[5 * ld_dst], f);
-  _mm256_storeu_ps(&dst[6 * ld_dst], g);
-  _mm256_storeu_ps(&dst[7 * ld_dst], h);
-}
-
-namespace internal {
-
-void transpose_8x8(
-    int M,
-    int N,
-    const float* src,
-    int ld_src,
-    float* dst,
-    int ld_dst) {
-  int ib = 0, jb = 0;
-  for (ib = 0; ib + 8 <= M; ib += 8) {
-    for (jb = 0; jb + 8 <= N; jb += 8) {
-      transpose_kernel_8x8_avx2(
-          &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
-    }
-  }
-  transpose_4x4(ib, N - jb, &src[jb], ld_src, &dst[jb * ld_dst], ld_dst);
-  transpose_4x4(M - ib, N, &src[ib * ld_src], ld_src, &dst[ib], ld_dst);
-}
-
-} // namespace internal
 
 void transpose_simd(
     int M,

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -7,7 +7,6 @@
 #include "fbgemm/Utils.h"
 #include "TransposeUtils.h"
 #include <cpuinfo.h>
-#include <immintrin.h>
 #include <cassert>
 #include <cinttypes>
 #include <cmath>

--- a/src/Utils_avx2.cc
+++ b/src/Utils_avx2.cc
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include "TransposeUtils.h"
+#include <immintrin.h>
+
+namespace fbgemm {
+
+namespace internal {
+
+inline void
+transpose_kernel_4x4_sse(const float* src, int ld_src, float* dst, int ld_dst) {
+  // load from src to registers
+  // a : a0 a1 a2 a3
+  // b : b0 b1 b2 b3
+  // c : c0 c1 c2 c3
+  // d : d0 d1 d2 d3
+  __m128 a = _mm_loadu_ps(&src[0 * ld_src]);
+  __m128 b = _mm_loadu_ps(&src[1 * ld_src]);
+  __m128 c = _mm_loadu_ps(&src[2 * ld_src]);
+  __m128 d = _mm_loadu_ps(&src[3 * ld_src]);
+
+  // transpose the 4x4 matrix formed by 32-bit elements: Macro from SSE
+  // a : a0 b0 c0 d0
+  // b : a1 b1 c1 d1
+  // c : a2 b2 c2 d2
+  // d : a3 b3 c3 d3
+  _MM_TRANSPOSE4_PS(a, b, c, d);
+
+  // store from registers to dst
+  _mm_storeu_ps(&dst[0 * ld_dst], a);
+  _mm_storeu_ps(&dst[1 * ld_dst], b);
+  _mm_storeu_ps(&dst[2 * ld_dst], c);
+  _mm_storeu_ps(&dst[3 * ld_dst], d);
+}
+
+inline void transpose_4x4(
+    int M,
+    int N,
+    const float* src,
+    int ld_src,
+    float* dst,
+    int ld_dst) {
+  int ib = 0, jb = 0;
+  for (ib = 0; ib + 4 <= M; ib += 4) {
+    for (jb = 0; jb + 4 <= N; jb += 4) {
+      transpose_kernel_4x4_sse(
+          &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+    }
+  }
+  transpose_ref(ib, N - jb, &src[jb], ld_src, &dst[jb * ld_dst], ld_dst);
+  transpose_ref(M - ib, N, &src[ib * ld_src], ld_src, &dst[ib], ld_dst);
+}
+
+inline void transpose_kernel_8x8_avx2(
+    const float* src,
+    int ld_src,
+    float* dst,
+    int ld_dst) {
+  // load from src to registers
+  // a : a0 a1 a2 a3 a4 a5 a6 a7
+  // b : b0 b1 b2 b3 b4 b5 b6 b7
+  // c : c0 c1 c2 c3 c4 c5 c6 c7
+  // d : d0 d1 d2 d3 d4 d5 d6 d7
+  // e : e0 e1 e2 e3 e4 e5 e6 e7
+  // f : f0 f1 f2 f3 f4 f5 f6 f7
+  // g : g0 g1 g2 g3 g4 g5 g6 g7
+  // h : h0 h1 h2 h3 h4 h5 h6 h7
+  __m256 a = _mm256_loadu_ps(&src[0 * ld_src]);
+  __m256 b = _mm256_loadu_ps(&src[1 * ld_src]);
+  __m256 c = _mm256_loadu_ps(&src[2 * ld_src]);
+  __m256 d = _mm256_loadu_ps(&src[3 * ld_src]);
+  __m256 e = _mm256_loadu_ps(&src[4 * ld_src]);
+  __m256 f = _mm256_loadu_ps(&src[5 * ld_src]);
+  __m256 g = _mm256_loadu_ps(&src[6 * ld_src]);
+  __m256 h = _mm256_loadu_ps(&src[7 * ld_src]);
+
+  __m256 ab0145, ab2367, cd0145, cd2367, ef0145, ef2367, gh0145, gh2367;
+  __m256 abcd04, abcd15, efgh04, efgh15, abcd26, abcd37, efgh26, efgh37;
+  // unpacking and interleaving 32-bit elements
+  // ab0145 : a0 b0 a1 b1 a4 b4 a5 b5
+  // ab2367 : a2 b2 a3 b3 a6 b6 a7 b7
+  // cd0145 : c0 d0 c1 d1 c4 d4 c5 d5
+  // cd2367 : c2 d2 c3 d3 c6 d6 c7 d7
+  // ef0145 : e0 f0 e1 f1 e4 f4 e5 f5
+  // ef2367 : e2 f2 e3 f3 e6 f6 e7 f7
+  // gh0145 : g0 h0 g1 h1 g4 h4 g5 h5
+  // gh2367 : g2 h2 g3 h3 g6 h6 g7 h7
+  ab0145 = _mm256_unpacklo_ps(a, b);
+  ab2367 = _mm256_unpackhi_ps(a, b);
+  cd0145 = _mm256_unpacklo_ps(c, d);
+  cd2367 = _mm256_unpackhi_ps(c, d);
+  ef0145 = _mm256_unpacklo_ps(e, f);
+  ef2367 = _mm256_unpackhi_ps(e, f);
+  gh0145 = _mm256_unpacklo_ps(g, h);
+  gh2367 = _mm256_unpackhi_ps(g, h);
+
+  // shuffling the 32-bit elements
+  // abcd04 : a0 b0 c0 d0 a4 b4 c4 d4
+  // abcd15 : a1 b1 c1 d1 a5 b5 c5 d5
+  // efgh04 : e0 f0 g0 h0 e4 f4 g4 h4
+  // efgh15 : e1 f1 g1 h1 e5 b5 c5 d5
+  // abcd26 : a2 b2 c2 d2 a6 b6 c6 d6
+  // abcd37 : a3 b3 c3 d3 a7 b7 c7 d7
+  // efgh26 : e2 f2 g2 h2 e6 f6 g6 h6
+  // efgh37 : e3 f3 g3 h3 e7 f7 g7 h7
+  abcd04 = _mm256_shuffle_ps(ab0145, cd0145, 0x44);
+  abcd15 = _mm256_shuffle_ps(ab0145, cd0145, 0xee);
+  efgh04 = _mm256_shuffle_ps(ef0145, gh0145, 0x44);
+  efgh15 = _mm256_shuffle_ps(ef0145, gh0145, 0xee);
+  abcd26 = _mm256_shuffle_ps(ab2367, cd2367, 0x44);
+  abcd37 = _mm256_shuffle_ps(ab2367, cd2367, 0xee);
+  efgh26 = _mm256_shuffle_ps(ef2367, gh2367, 0x44);
+  efgh37 = _mm256_shuffle_ps(ef2367, gh2367, 0xee);
+
+  // shuffling 128-bit elements
+  // a : a0 b0 c0 d0 e0 f0 g0 h0
+  // b : a1 b1 c1 d1 e1 f1 g1 h1
+  // c : a2 b2 c2 d2 e2 f2 g2 h2
+  // d : a3 b3 c3 d3 e3 f3 g3 h3
+  // e : a4 b4 c4 d4 e4 f4 g4 h4
+  // f : a5 b5 c5 d5 e5 f5 g5 h5
+  // g : a6 b6 c6 d6 e6 f6 g6 h6
+  // h : a7 b7 c7 d7 e7 f7 g7 h7
+  a = _mm256_permute2f128_ps(efgh04, abcd04, 0x02);
+  b = _mm256_permute2f128_ps(efgh15, abcd15, 0x02);
+  c = _mm256_permute2f128_ps(efgh26, abcd26, 0x02);
+  d = _mm256_permute2f128_ps(efgh37, abcd37, 0x02);
+  e = _mm256_permute2f128_ps(efgh04, abcd04, 0x13);
+  f = _mm256_permute2f128_ps(efgh15, abcd15, 0x13);
+  g = _mm256_permute2f128_ps(efgh26, abcd26, 0x13);
+  h = _mm256_permute2f128_ps(efgh37, abcd37, 0x13);
+
+  // store from registers to dst
+  _mm256_storeu_ps(&dst[0 * ld_dst], a);
+  _mm256_storeu_ps(&dst[1 * ld_dst], b);
+  _mm256_storeu_ps(&dst[2 * ld_dst], c);
+  _mm256_storeu_ps(&dst[3 * ld_dst], d);
+  _mm256_storeu_ps(&dst[4 * ld_dst], e);
+  _mm256_storeu_ps(&dst[5 * ld_dst], f);
+  _mm256_storeu_ps(&dst[6 * ld_dst], g);
+  _mm256_storeu_ps(&dst[7 * ld_dst], h);
+}
+
+
+void transpose_8x8(
+    int M,
+    int N,
+    const float* src,
+    int ld_src,
+    float* dst,
+    int ld_dst) {
+  int ib = 0, jb = 0;
+  for (ib = 0; ib + 8 <= M; ib += 8) {
+    for (jb = 0; jb + 8 <= N; jb += 8) {
+      transpose_kernel_8x8_avx2(
+          &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+    }
+  }
+  transpose_4x4(ib, N - jb, &src[jb], ld_src, &dst[jb * ld_dst], ld_dst);
+  transpose_4x4(M - ib, N, &src[ib * ld_src], ld_src, &dst[ib], ld_dst);
+}
+
+} // namespace internal
+
+} // namespace fbgemm

--- a/src/Utils_avx512.cc
+++ b/src/Utils_avx512.cc
@@ -5,8 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "fbgemm/Utils.h"
-
+#include "TransposeUtils.h"
 #include <immintrin.h>
 
 namespace fbgemm {


### PR DESCRIPTION
Summary: Isolate avx2 usage from quantization fusion with packing.

Reviewed By: jianyuh

Differential Revision: D13311108
