### PR TITLE
Add missing <algorithm> include

### DIFF
--- a/src/FbgemmI8DepthwiseAvx2.cc
+++ b/src/FbgemmI8DepthwiseAvx2.cc
@@ -6,7 +6,7 @@
  */
 #include "FbgemmI8DepthwiseAvx2.h"
 
-#include <algorithm>
+#include <algorithm> // for min and max
 #include <cassert>
 #include <cmath> // for lrintf and sqrt
 #include <tuple> // for tie

--- a/src/FbgemmI8DepthwiseAvx2.cc
+++ b/src/FbgemmI8DepthwiseAvx2.cc
@@ -6,6 +6,7 @@
  */
 #include "FbgemmI8DepthwiseAvx2.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cmath> // for lrintf and sqrt
 #include <tuple> // for tie


### PR DESCRIPTION
std::max and std::min are defined in the standard library header <algorithm> (https://en.cppreference.com/w/cpp/algorithm/max), but this include is not present, leading to build failures on my mac.