### PR TITLE
Fix a bug in FbgemmFP16

### DIFF
--- a/src/FbgemmFP16.cc
+++ b/src/FbgemmFP16.cc
@@ -229,7 +229,7 @@ FBGEMM_API void cblas_gemm_compute(
 
       const int kb = std::min(Bp.blockRowSize(), Bp.numRows() - k_ind);
 
-      auto m1 = 0;
+      auto m1 = m0;
       for (auto c = 0; c < 2; c++) {
         auto kernel_nrows = KernelInfo::partition[mb][c][0];
         auto nkernel_nrows = KernelInfo::partition[mb][c][1];

--- a/test/FP16Test.cc
+++ b/test/FP16Test.cc
@@ -43,7 +43,7 @@ TEST_P(FBGemmFP16Test, Test) {
   vector<vector<int>> shapes;
   random_device r;
   default_random_engine generator(r());
-  uniform_int_distribution<int> dm(1, 100);
+  uniform_int_distribution<int> dm(1, 256);
   uniform_int_distribution<int> dnk(1, 1024);
   for (int i = 0; i < 10; i++) {
     int m = dm(generator);


### PR DESCRIPTION
https://github.com/pytorch/FBGEMM/blob/master/test/FP16Test.cc#L46 will fail if batch_size (e.g. m) is larger than 120.