### PR TITLE
minor optimization in handling zero points for row offset

### DIFF
--- a/src/GroupwiseConv.h
+++ b/src/GroupwiseConv.h
@@ -169,6 +169,10 @@ class GenConvKernel {
   template <inst_set_t instSet>
   void gen8BitSum(asmjit::X86Emitter* a, asmjit::X86Ymm aReg);
 
+  // Use scratchReg1_ and tmpReg1Avx2_ internally
+  template <inst_set_t instSet>
+  void genZeroPtSum(asmjit::X86Emitter* a, int multiplier);
+
   template <inst_set_t instSet>
   void genForTopEdgeRowoffset(asmjit::X86Emitter* a);
 


### PR DESCRIPTION
Summary:
During row_offset compute, pre-multiply zero point by C_per_G .
Instead of generating multiple vpaddd instructions for adding zero points, we just multiply by a constant.

Differential Revision: D13833686
