### PR TITLE
Remove inappropriate consts

### DIFF
--- a/include/fbgemm/Fbgemm.h
+++ b/include/fbgemm/Fbgemm.h
@@ -1027,7 +1027,7 @@ class FBGEMM_API ReQuantizeOutput {
   const float* getCMultiplier() const {
     return C_multiplier_;
   }
-  const std::int32_t getCZeroPoint() const {
+  std::int32_t getCZeroPoint() const {
     return C_zero_point_;
   }
   const std::int32_t* getBZeroPoint() const {
@@ -1039,7 +1039,7 @@ class FBGEMM_API ReQuantizeOutput {
   const std::int32_t* getBias() const {
     return bias_;
   }
-  const std::uint32_t getNCols() const {
+  std::uint32_t getNCols() const {
     return ncols_;
   }
 


### PR DESCRIPTION
Summary:
The inappropriate consts will fail the builds of pytorch. Let's remove them.
Please check https://circleci.com/api/v1.1/project/github/pytorch/pytorch/704282/output/104/0?file=true

Reviewed By: bddppq, BIT-silence

Differential Revision: D13935557
