### PR TITLE
clean up depthwise conv interface

### DIFF
--- a/bench/Depthwise3DBenchmark.cc
+++ b/bench/Depthwise3DBenchmark.cc
@@ -131,72 +131,7 @@ int main() {
     double ops =
         double(NITER) * N * T_OUT * H_OUT * W_OUT * K * K_T * K_H * K_W * 2;
     chrono::time_point<chrono::system_clock> t_begin, t_end;
-    for (int i = 0; i < NWARMUP + NITER; ++i) {
-      llc_flush();
 
-      t_begin = chrono::system_clock::now();
-#pragma omp parallel
-      {
-        int num_threads = fbgemm_get_num_threads();
-        int tid = fbgemm_get_thread_num();
-        depthwise_3x3x3_pad_1(
-            N,
-            T,
-            H,
-            W,
-            K,
-            stride_t,
-            stride_h,
-            stride_w,
-            A_zero_point,
-            A.data(),
-            Bp,
-            C.data(),
-            tid,
-            num_threads);
-      }
-      t_end = chrono::system_clock::now();
-      if (i >= NWARMUP) {
-        double dt = chrono::duration<double>(t_end - t_begin).count();
-        ttot += dt;
-      }
-    }
-
-    // correctness check
-    for (int n = 0; n < N; ++n) {
-      for (int t = 0; t < T_OUT; ++t) {
-        for (int h = 0; h < H_OUT; ++h) {
-          for (int w = 0; w < W_OUT; ++w) {
-            for (int g = 0; g < K; ++g) {
-              int32_t expected =
-                  C_ref[(((n * T_OUT + t) * H_OUT + h) * W_OUT + w) * K + g];
-              int32_t actual =
-                  C[(((n * T_OUT + t) * H_OUT + h) * W_OUT + w) * K + g];
-              if (expected != actual) {
-                cerr << "Depthwise 3x3 results differ at (" << n << ", " << t
-                     << ", " << h << ", " << w << ", " << g << "). expected "
-                     << expected << " actual " << actual << endl;
-                return -1;
-              }
-              assert(expected == actual);
-            }
-          } // w
-        } // h
-      } // t
-    } // n
-
-    // Report performance
-    printf(
-        "N = %d K = %d T = %d H = %d W = %d stride = %d\n",
-        N,
-        K,
-        T,
-        H,
-        W,
-        stride_h);
-    printf("GB/s = %f Gops/s = %f\n", bytes / ttot / 1e9, ops / ttot / 1e9);
-
-    ttot = 0;
     for (int i = 0; i < NWARMUP + NITER; ++i) {
       llc_flush();
 

--- a/bench/DepthwiseBenchmark.cc
+++ b/bench/DepthwiseBenchmark.cc
@@ -240,59 +240,6 @@ int main() {
             stride_w,
             A_zero_point,
             A.data(),
-            Bp,
-            C.data(),
-            tid,
-            num_threads);
-      }
-      t_end = chrono::system_clock::now();
-      if (i >= NWARMUP) {
-        double dt = chrono::duration<double>(t_end - t_begin).count();
-        ttot += dt;
-      }
-    }
-
-    // correctness check
-    for (int n = 0; n < N; ++n) {
-      for (int h = 0; h < H_OUT; ++h) {
-        for (int w = 0; w < W_OUT; ++w) {
-          for (int g = 0; g < G; ++g) {
-            int32_t expected = C_ref[((n * H_OUT + h) * W_OUT + w) * G + g];
-            int32_t actual = C[((n * H_OUT + h) * W_OUT + w) * G + g];
-            if (expected != actual) {
-              cerr << "Depthwise 3x3 results differ at (" << n << ", " << h
-                   << ", " << w << ", " << g << "). expected " << expected
-                   << " actual " << actual << endl;
-              return -1;
-            }
-            assert(expected == actual);
-          }
-        }
-      }
-    }
-
-    // Report performance
-    printf("N = %d G = %d H = %d W = %d stride = %d\n", N, G, H, W, stride_h);
-    printf("GB/s = %f Gops/s = %f\n", bytes / ttot / 1e9, ops / ttot / 1e9);
-
-    ttot = 0;
-    for (int i = 0; i < NWARMUP + NITER; ++i) {
-      llc_flush();
-
-      t_begin = chrono::system_clock::now();
-#pragma omp parallel
-      {
-        int num_threads = fbgemm_get_num_threads();
-        int tid = fbgemm_get_thread_num();
-        depthwise_3x3_pad_1(
-            N,
-            H,
-            W,
-            G,
-            stride_h,
-            stride_w,
-            A_zero_point,
-            A.data(),
             B_zero_point,
             Bp,
             C_multiplier,

--- a/include/fbgemm/OutputProcessing-inl.h
+++ b/include/fbgemm/OutputProcessing-inl.h
@@ -81,7 +81,9 @@ inline int ReQuantizeOutput<FUSE_RELU, Q_GRAN, outT, inT, nextOPType>::f(
     for (int i = block.row_start; i < block.row_start + block.row_size; ++i) {
       for (int j = block.col_start; j < block.col_start + block.col_size; ++j) {
         inT raw = inp[(i - block.row_start) * ld_in + (j - block.col_start)];
-        raw -= Aq_zero_point_ * q_col_offsets_[j];
+        if (Aq_zero_point_) {
+          raw -= Aq_zero_point_ * q_col_offsets_[j];
+        }
         int Bq_zero_point_idx;
         if (Q_GRAN == QuantizationGranularity::TENSOR) {
           Bq_zero_point_idx = 0;
@@ -225,7 +227,9 @@ inline int ReQuantizeForFloat<FUSE_RELU, Q_GRAN, outT, inT, nextOPType>::f(
   for (int i = block.row_start; i < block.row_start + block.row_size; ++i) {
     for (int j = block.col_start; j < block.col_start + block.col_size; ++j) {
       inT raw = inp[(i - block.row_start) * ld_in + j - block.col_start];
-      raw -= Aq_zero_point_ * q_col_offsets_[j];
+      if (Aq_zero_point_) {
+        raw -= Aq_zero_point_ * q_col_offsets_[j];
+      }
       int Bq_zero_point_idx;
       if (Q_GRAN == QuantizationGranularity::TENSOR) {
         Bq_zero_point_idx = 0;

--- a/src/ExecuteKernelU8S8.cc
+++ b/src/ExecuteKernelU8S8.cc
@@ -362,23 +362,28 @@ template class ExecuteKernel<
 
 ////////////////////////////////////////////////////////////////////////////////
 // DoSpmdmOnInpBuffer
-#define INSTANTIATE_BASE(RELU, Q_GRAN)      \
-  template class ExecuteKernel<             \
-      PackAWithRowOffset<uint8_t, int16_t>, \
-      PackBMatrix<int8_t, int16_t>,         \
-      uint8_t,                              \
+#define INSTANTIATE_BASE(PACK_A, RELU, Q_GRAN) \
+  template class ExecuteKernel<                \
+      PACK_A<uint8_t, int16_t>,                \
+      PackBMatrix<int8_t, int16_t>,            \
+      uint8_t,                                 \
       DoSpmdmOnInpBuffer<uint8_t, int32_t, ReQuantizeOutput<RELU, Q_GRAN>>>;
 
-#define INSTANTIATE_Q_GRANS(RELU)                          \
-  INSTANTIATE_BASE(RELU, QuantizationGranularity::TENSOR); \
-  INSTANTIATE_BASE(RELU, QuantizationGranularity::GROUP);  \
-  INSTANTIATE_BASE(RELU, QuantizationGranularity::OUT_CHANNEL);
+#define INSTANTIATE_Q_GRANS(PACK_A, RELU)                          \
+  INSTANTIATE_BASE(PACK_A, RELU, QuantizationGranularity::TENSOR); \
+  INSTANTIATE_BASE(PACK_A, RELU, QuantizationGranularity::GROUP);  \
+  INSTANTIATE_BASE(PACK_A, RELU, QuantizationGranularity::OUT_CHANNEL);
 
-INSTANTIATE_Q_GRANS(false);
-INSTANTIATE_Q_GRANS(true);
+#define INSTANTIATE_RELU(PACK_A)      \
+  INSTANTIATE_Q_GRANS(PACK_A, false); \
+  INSTANTIATE_Q_GRANS(PACK_A, true);
+
+INSTANTIATE_RELU(PackAMatrix);
+INSTANTIATE_RELU(PackAWithRowOffset);
 
 #undef INSTANTIATE_Q_GRANS
 #undef INSTANTIATE_BASE
+#undef INSTANTIATE_RELU
 
 #define INSTANTIATE_BASE(RELU, Q_GRAN)   \
   template class ExecuteKernel<          \

--- a/src/Fbgemm.cc
+++ b/src/Fbgemm.cc
@@ -360,31 +360,35 @@ template void fbgemmPacked(
 
 ////////////////////////////////////////////////////////////////////////////////
 // DoSpmdmOnInpBuffer
-#define INSTANTIATE_BASE(RELU, Q_GRAN)                                    \
-  template void fbgemmPacked(                                             \
-      PackMatrix<PackAWithRowOffset<uint8_t, int16_t>, uint8_t, int16_t>& \
-          packA,                                                          \
-      PackMatrix<PackBMatrix<int8_t, int16_t>, int8_t, int16_t>& packB,   \
-      uint8_t* C,                                                         \
-      int32_t* C_buffer,                                                  \
-      uint32_t ldc,                                                       \
-      const DoSpmdmOnInpBuffer<                                           \
-          uint8_t,                                                        \
-          int32_t,                                                        \
-          ReQuantizeOutput<RELU, Q_GRAN>>& outProcess,                    \
-      int thread_id,                                                      \
+#define INSTANTIATE_BASE(PACK_A, RELU, Q_GRAN)                          \
+  template void fbgemmPacked(                                           \
+      PackMatrix<PACK_A<uint8_t, int16_t>, uint8_t, int16_t>& packA,    \
+      PackMatrix<PackBMatrix<int8_t, int16_t>, int8_t, int16_t>& packB, \
+      uint8_t* C,                                                       \
+      int32_t* C_buffer,                                                \
+      uint32_t ldc,                                                     \
+      const DoSpmdmOnInpBuffer<                                         \
+          uint8_t,                                                      \
+          int32_t,                                                      \
+          ReQuantizeOutput<RELU, Q_GRAN>>& outProcess,                  \
+      int thread_id,                                                    \
       int num_threads);
 
-#define INSTANTIATE_Q_GRANS(RELU)                          \
-  INSTANTIATE_BASE(RELU, QuantizationGranularity::TENSOR); \
-  INSTANTIATE_BASE(RELU, QuantizationGranularity::GROUP);  \
-  INSTANTIATE_BASE(RELU, QuantizationGranularity::OUT_CHANNEL);
+#define INSTANTIATE_Q_GRANS(PACK_A, RELU)                          \
+  INSTANTIATE_BASE(PACK_A, RELU, QuantizationGranularity::TENSOR); \
+  INSTANTIATE_BASE(PACK_A, RELU, QuantizationGranularity::GROUP);  \
+  INSTANTIATE_BASE(PACK_A, RELU, QuantizationGranularity::OUT_CHANNEL);
 
-INSTANTIATE_Q_GRANS(false);
-INSTANTIATE_Q_GRANS(true);
+#define INSTANTIATE_RELU(PACK_A)      \
+  INSTANTIATE_Q_GRANS(PACK_A, false); \
+  INSTANTIATE_Q_GRANS(PACK_A, true);
+
+INSTANTIATE_RELU(PackAMatrix);
+INSTANTIATE_RELU(PackAWithRowOffset);
 
 #undef INSTANTIATE_Q_GRANS
 #undef INSTANTIATE_BASE
+#undef INSTANTIATE_RELU
 
 #define INSTANTIATE_BASE(RELU, Q_GRAN)                                        \
   template void fbgemmPacked(                                                 \

--- a/src/FbgemmI8DepthwiseAvx2.h
+++ b/src/FbgemmI8DepthwiseAvx2.h
@@ -34,26 +34,9 @@ using Packed3x3x3ConvMatrix = PackedDepthWiseConvMatrix<3 * 3 * 3>;
 
 /**
  * Depth-wise 3x3 convolution with pad=1 and stride=1 and K a multiple of 8
+ *
  * @params A The input image in NHWK layout
  * @params Bp The pre-packed filter
- */
-FBGEMM_API void depthwise_3x3_pad_1(
-    int N,
-    int H,
-    int W,
-    int K,
-    int stride_h,
-    int stride_w,
-    std::int32_t A_zero_point,
-    const std::uint8_t* A,
-    const Packed3x3ConvMatrix& Bp,
-    std::int32_t* C,
-    int thread_id = 0,
-    int num_threads = 1);
-
-/**
- * Depth-wise 3x3 convolution with pad=1 and stride=1 and K a multiple of 8
- * This version is fused with requantization.
  */
 FBGEMM_API void depthwise_3x3_pad_1(
     int N,
@@ -96,22 +79,6 @@ FBGEMM_API void depthwise_3x3_per_channel_quantization_pad_1(
     const std::int32_t* col_offsets,
     const std::int32_t* bias,
     bool fuse_relu = false,
-    int thread_id = 0,
-    int num_threads = 1);
-
-FBGEMM_API void depthwise_3x3x3_pad_1(
-    int N,
-    int T,
-    int H,
-    int W,
-    int K,
-    int stride_t,
-    int stride_h,
-    int stride_w,
-    std::int32_t A_zero_point,
-    const std::uint8_t* A,
-    const Packed3x3x3ConvMatrix& Bp,
-    std::int32_t* C,
     int thread_id = 0,
     int num_threads = 1);
 

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -34,8 +34,12 @@ void requantize_u8acc32_ref(
   for (int i = 0; i < M; ++i) {
     for (int j = 0; j < N; ++j) {
       int32_t raw = inp[i * ld + j];
-      raw -= A_zero_point * col_offsets[j];
-      raw -= B_zero_point * row_offsets[i];
+      if (A_zero_point) {
+        raw -= A_zero_point * col_offsets[j];
+      }
+      if (B_zero_point) {
+        raw -= B_zero_point * row_offsets[i];
+      }
       if (bias) {
         raw += bias[j];
       }
@@ -69,7 +73,9 @@ void requantize_u8acc32_ref(
   for (int i = 0; i < M; ++i) {
     for (int j = 0; j < N; ++j) {
       int32_t raw = inp[i * ld + j];
-      raw -= A_zero_point * col_offsets[j];
+      if (A_zero_point) {
+        raw -= A_zero_point * col_offsets[j];
+      }
       raw -= B_zero_point[j / ncols_per_quant_group] * row_offsets[i];
       if (bias) {
         raw += bias[j];

--- a/test/I8DepthwiseTest.cc
+++ b/test/I8DepthwiseTest.cc
@@ -135,24 +135,6 @@ TEST(FBGemmDepthWiseTest, Test3x3) {
     Packed3x3ConvMatrix Bp(K, B.data());
 
     depthwise_3x3_pad_1(
-        N, H, W, K, stride_h, stride_w, A_zero_point, A.data(), Bp, C.data());
-
-    // correctness check
-    for (int n = 0; n < N; ++n) {
-      for (int h = 0; h < H_OUT; ++h) {
-        for (int w = 0; w < W_OUT; ++w) {
-          for (int k = 0; k < K; ++k) {
-            int32_t expected = C_ref[((n * H_OUT + h) * W_OUT + w) * K + k];
-            int32_t actual = C[((n * H_OUT + h) * W_OUT + w) * K + k];
-            EXPECT_EQ(expected, actual)
-                << "Depthwise 3x3 results differ at (" << n << ", " << h << ", "
-                << w << ", " << k << ").";
-          }
-        }
-      }
-    }
-
-    depthwise_3x3_pad_1(
         N,
         H,
         W,
@@ -264,41 +246,6 @@ TEST(FBGemmDepthWiseTest, Test3x3x3) {
         bias.data());
 
     Packed3x3x3ConvMatrix Bp(K, B.data());
-
-    depthwise_3x3x3_pad_1(
-        N,
-        T,
-        H,
-        W,
-        K,
-        stride_t,
-        stride_h,
-        stride_w,
-        A_zero_point,
-        A.data(),
-        Bp,
-        C.data());
-
-    // correctness check
-    for (int n = 0; n < N; ++n) {
-      for (int t = 0; t < T_OUT; ++t) {
-        for (int h = 0; h < H_OUT; ++h) {
-          for (int w = 0; w < W_OUT; ++w) {
-            for (int k = 0; k < K; ++k) {
-              int32_t expected =
-                  C_ref[(((n * T_OUT + t) * H_OUT + h) * W_OUT + w) * K + k];
-              int32_t actual =
-                  C[(((n * T_OUT + t) * H_OUT + h) * W_OUT + w) * K + k];
-              ASSERT_EQ(expected, actual)
-                  << "Depthwise 3x3 results differ at (" << n << ", " << t
-                  << ", " << h << ", " << w << ", " << k << ") " << shape[0]
-                  << " " << shape[1] << " " << shape[2] << " " << shape[3]
-                  << " " << shape[4] << " " << shape[5];
-            }
-          } // w
-        } // h
-      } // t
-    } // n
 
     depthwise_3x3x3_pad_1(
         N,


### PR DESCRIPTION
Summary: depthwise conv without requantization is not really useful and was generating more template parameter options

Differential Revision: D14021514
