### PR TITLE
optimize dw conv for symmetric quant

### DIFF
--- a/src/FbgemmI8DepthwiseAvx2.h
+++ b/src/FbgemmI8DepthwiseAvx2.h
@@ -34,9 +34,28 @@ using Packed3x3x3ConvMatrix = PackedDepthWiseConvMatrix<3 * 3 * 3>;
 
 /**
  * Depth-wise 3x3 convolution with pad=1 and stride=1 and K a multiple of 8
- *
  * @params A The input image in NHWK layout
  * @params Bp The pre-packed filter
+ */
+FBGEMM_API void depthwise_3x3_pad_1(
+    int N,
+    int H,
+    int W,
+    int K,
+    int stride_h,
+    int stride_w,
+    std::int32_t A_zero_point,
+    const std::uint8_t* A,
+    const Packed3x3ConvMatrix& Bp,
+    std::int32_t* C,
+    int thread_id = 0,
+    int num_threads = 1);
+
+/**
+ * Depth-wise 3x3 convolution with pad=1 and stride=1 and K a multiple of 8
+ * This version is fused with requantization.
+ *
+ * @col_offsets nullptr if col_offsets are folded into bias
  */
 FBGEMM_API void depthwise_3x3_pad_1(
     int N,
@@ -61,6 +80,8 @@ FBGEMM_API void depthwise_3x3_pad_1(
 /**
  * Depth-wise 3x3 convolution with pad=1 and stride=1 and K a multiple of 8
  * This version is fused with requantization and uses per-channel quantization.
+ *
+ * @col_offsets nullptr if col_offsets are folded into bias
  */
 FBGEMM_API void depthwise_3x3_per_channel_quantization_pad_1(
     int N,
@@ -93,6 +114,25 @@ FBGEMM_API void depthwise_3x3x3_pad_1(
     int stride_w,
     std::int32_t A_zero_point,
     const std::uint8_t* A,
+    const Packed3x3x3ConvMatrix& Bp,
+    std::int32_t* C,
+    int thread_id = 0,
+    int num_threads = 1);
+
+/**
+ * @col_offsets nullptr if col_offsets are folded into bias
+ */
+FBGEMM_API void depthwise_3x3x3_pad_1(
+    int N,
+    int T,
+    int H,
+    int W,
+    int K,
+    int stride_t,
+    int stride_h,
+    int stride_w,
+    std::int32_t A_zero_point,
+    const std::uint8_t* A,
     std::int32_t B_zero_point,
     const Packed3x3x3ConvMatrix& Bp,
     float C_multiplier,
@@ -104,6 +144,9 @@ FBGEMM_API void depthwise_3x3x3_pad_1(
     int thread_id = 0,
     int num_threads = 1);
 
+/**
+ * @col_offsets nullptr if col_offsets are folded into bias
+ */
 FBGEMM_API void depthwise_3x3x3_per_channel_quantization_pad_1(
     int N,
     int T,

--- a/test/I8DepthwiseTest.cc
+++ b/test/I8DepthwiseTest.cc
@@ -68,7 +68,20 @@ static vector<vector<int>> shapes = {
   {   1,    8,   4,   4, 1, },
 };
 
-TEST(FBGemmDepthWiseTest, Test3x3) {
+namespace {
+class FBGemmDepthWiseTest
+    : public testing::TestWithParam<tuple<bool, bool>> {};
+} // namespace
+
+INSTANTIATE_TEST_CASE_P(
+    InstantiationName,
+    FBGemmDepthWiseTest,
+    ::testing::Combine(::testing::Bool(), ::testing::Bool()));
+
+TEST_P(FBGemmDepthWiseTest, Test3x3) {
+  bool a_symmetric, b_symmetric;
+  tie(a_symmetric, b_symmetric) = GetParam();
+
   for (auto shape : shapes) {
     int N = shape[0];
     int K = shape[1];
@@ -86,10 +99,10 @@ TEST(FBGemmDepthWiseTest, Test3x3) {
     aligned_vector<int32_t> C_ref(N * H_OUT * W_OUT * K), C(C_ref.size());
 
     randFill<uint8_t>(A, 0, 86);
-    int32_t A_zero_point = 43;
+    int32_t A_zero_point = a_symmetric ? 0 : 43;
 
     randFill<int8_t>(B, -16, 16);
-    int32_t B_zero_point = 5;
+    int32_t B_zero_point = b_symmetric ? 0 : 5;
 
     depthwise_3x3_pad_1_ref(
         N,
@@ -148,7 +161,7 @@ TEST(FBGemmDepthWiseTest, Test3x3) {
         C_multiplier,
         C_zero_point,
         C_uint8.data(),
-        col_offsets.data(),
+        a_symmetric ? nullptr : col_offsets.data(),
         bias.data(),
         false, /* fuse_relu */
         0,
@@ -172,8 +185,15 @@ TEST(FBGemmDepthWiseTest, Test3x3) {
   } // for each shape
 } // Test3x3
 
-TEST(FBGemmDepthWiseTest, Test3x3x3) {
-  for (auto shape : shapes_3d) {
+TEST_P(FBGemmDepthWiseTest, Test3x3x3) {
+  bool a_symmetric, b_symmetric;
+  tie(a_symmetric, b_symmetric) = GetParam();
+
+  // 3x3x3 tests take a long time so for a symmetric quantization, we only
+  // test with 2 shapes.
+  for (auto shape : a_symmetric || b_symmetric
+           ? vector<vector<int>>(shapes_3d.cbegin(), shapes_3d.cbegin() + 2)
+           : shapes_3d) {
     int N = shape[0];
     int K = shape[1];
     int T = shape[2];
@@ -195,7 +215,7 @@ TEST(FBGemmDepthWiseTest, Test3x3x3) {
         C(C_ref.size());
 
     randFill<uint8_t>(A, 0, 86);
-    int32_t A_zero_point = 43;
+    int32_t A_zero_point = a_symmetric ? 0 : 43;
 
     randFill<int8_t>(B, -16, 16);
     int32_t B_zero_point = 5;
@@ -277,8 +297,8 @@ TEST(FBGemmDepthWiseTest, Test3x3x3) {
             for (int k = 0; k < K; ++k) {
               int32_t expected = C_uint8_ref
                   [(((n * T_OUT + t) * H_OUT + h) * W_OUT + w) * K + k];
-              int32_t actual =
-                  C_uint8[(((n * T_OUT + t) * H_OUT + h) * W_OUT + w) * K + k];
+              int32_t actual = C_uint8
+                  [(((n * T_OUT + t) * H_OUT + h) * W_OUT + w) * K + k];
               EXPECT_EQ(expected, actual)
                   << "Depthwise 3x3 results differ at (" << n << ", " << t
                   << ", " << h << ", " << w << ", " << k << ").";
@@ -343,8 +363,6 @@ TEST(FBGemmDepthWiseTest, Test3x3PerChannelQuantization) {
       int32_t minimum = *min_element(C_ref_k_begin, C_ref_k_end);
       int32_t maximum = *max_element(C_ref_k_begin, C_ref_k_end);
       C_multiplier[k] = 255. / (maximum - minimum);
-      cerr << "k " << k << " minimum " << minimum << " maximum " << maximum
-           << " multiplier " << C_multiplier[k] << endl;
     }
     int32_t C_zero_point = 5;
 
@@ -470,8 +488,6 @@ TEST(FBGemmDepthWiseTest, Test3x3x3PerChannelQuantization) {
       int32_t minimum = *min_element(C_ref_k_begin, C_ref_k_end);
       int32_t maximum = *max_element(C_ref_k_begin, C_ref_k_end);
       C_multiplier[k] = 255. / (maximum - minimum);
-      cerr << "k " << k << " minimum " << minimum << " maximum " << maximum
-           << " multiplier " << C_multiplier[k] << endl;
     }
     int32_t C_zero_point = 5;
 


### PR DESCRIPTION
Summary: Skip computing row_offset if B uses symmetric quantization. Skip adding col_offset if A uses symmetric quantization.

Differential Revision: D14055973
