### PR TITLE
fix bug in group conv + avx512

### DIFF
--- a/src/GroupwiseConv.h
+++ b/src/GroupwiseConv.h
@@ -52,7 +52,8 @@ class GenConvKernel {
     // vector width in bits
     if (cpuinfo_initialize()) {
       if (cpuinfo_has_x86_avx512f()) {
-        vectorWidth_ = 512;
+        // TODO: change this to 512 once we have avx512f version
+        vectorWidth_ = 256;
       } else if (cpuinfo_has_x86_avx2()) {
         vectorWidth_ = 256;
       } else {


### PR DESCRIPTION
Summary: In group convolution we're always using avx2 but there was still code that assumed avx512 will be used if cpuid has avx512

Reviewed By: protonu

Differential Revision: D14073329
