### PR TITLE
simple spmdm optimization

### DIFF
--- a/bench/I8SpmdmBenchmark.cc
+++ b/bench/I8SpmdmBenchmark.cc
@@ -76,7 +76,7 @@ int main() {
 #endif
 
   for (const auto& shape : shapes) {
-    for (float density : {0.0001f, 0.001f, 0.01f, 0.1f, 1.0f}) {
+    for (float density : {0.00001f, 0.0001f, 0.001f, 0.01f, 0.1f, 1.0f}) {
       for (bool accumulation : {false, true}) {
         int M = shape[0];
         int N = shape[1];


### PR DESCRIPTION
Summary:
Create a temp buffer for accumulating results instead of directly accessing C matrix with strides.
This speeds up hyper-sparse case implemented w/o transpose so we adjust the threshold between the implementation w/o transpose and w/ transpose accordingly.

Differential Revision: D14097154
