### PR TITLE
Add Avx512BW check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,8 @@ set_target_properties(fbgemm_generic fbgemm_avx2 fbgemm_avx512 PROPERTIES
 target_compile_options(fbgemm_avx2 PRIVATE
   "-m64" "-mavx2" "-mfma" "-masm=intel")
 target_compile_options(fbgemm_avx512 PRIVATE
-  "-m64" "-mavx2" "-mfma" "-mavx512f" "-masm=intel")
+  "-m64" "-mavx2" "-mfma" "-mavx512f" "-mavx512bw" "-mavx512dq"
+  "-mavx512vl" "-masm=intel")
 
 if(NOT TARGET asmjit)
   #Download asmjit from github if ASMJIT_SRC_DIR is not specified.

--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -77,4 +77,14 @@ void transpose_simd(
     float* dst,
     int ld_dst);
 
+/**
+ * @brief Are we running on a AVX512 supported cpu?
+ */
+FBGEMM_API bool fbgemmHasAvx512Support();
+
+/**
+ * @brief Are we running on a AVX2 supported cpu?
+ */
+FBGEMM_API bool fbgemmHasAvx2Support();
+
 } // namespace fbgemm

--- a/src/Fbgemm.cc
+++ b/src/Fbgemm.cc
@@ -48,7 +48,7 @@ void fbgemmPacked(
 
   // Run time CPU detection
   if (cpuinfo_initialize()) {
-    if (cpuinfo_has_x86_avx512f()) {
+    if (fbgemmHasAvx512Support()) {
       MCB = PackingTraits<
           typename packingAMatrix::inpType,
           typename packingAMatrix::accType,
@@ -61,7 +61,7 @@ void fbgemmPacked(
           typename packingAMatrix::inpType,
           typename packingAMatrix::accType,
           inst_set_t::avx512>::MR;
-    } else if (cpuinfo_has_x86_avx2()) {
+    } else if (fbgemmHasAvx2Support()) {
       MCB = PackingTraits<
           typename packingAMatrix::inpType,
           typename packingAMatrix::accType,

--- a/src/GenerateKernel.h
+++ b/src/GenerateKernel.h
@@ -60,9 +60,9 @@ class CodeGenBase {
         } {
     // vector width in bits
     if (cpuinfo_initialize()) {
-      if (cpuinfo_has_x86_avx512f()) {
+      if (fbgemmHasAvx512Support()) {
         vectorWidth_ = 512;
-      } else if (cpuinfo_has_x86_avx2()) {
+      } else if (fbgemmHasAvx2Support()) {
         vectorWidth_ = 256;
       } else {
         // TODO: Have default path

--- a/src/GroupwiseConv.h
+++ b/src/GroupwiseConv.h
@@ -51,10 +51,10 @@ class GenConvKernel {
                     x86::ymm8} {
     // vector width in bits
     if (cpuinfo_initialize()) {
-      if (cpuinfo_has_x86_avx512f()) {
+      if (fbgemmHasAvx512Support()) {
         // TODO: change this to 512 once we have avx512f version
         vectorWidth_ = 256;
-      } else if (cpuinfo_has_x86_avx2()) {
+      } else if (fbgemmHasAvx2Support()) {
         vectorWidth_ = 256;
       } else {
         // TODO: Have default path

--- a/src/GroupwiseConvAcc32Avx2.cc
+++ b/src/GroupwiseConvAcc32Avx2.cc
@@ -1681,7 +1681,7 @@ void fbgemmGroupwiseConvBase_(
             // current group
             memcpy(rowOffsetBuf, rowOffsetForCurG, ih_iw * sizeof(int32_t));
 
-            if (cpuinfo_has_x86_avx512f()) {
+            if (fbgemmHasAvx512Support()) {
               // Currently use avx2 code
               outProcess.template f<inst_set_t::avx2>(
                   out,
@@ -1689,7 +1689,7 @@ void fbgemmGroupwiseConvBase_(
                   {i * oh_ow, oh_ow, (g + j) * K_per_G, K_per_G},
                   K_per_G * G,
                   K_per_G * G);
-            } else if (cpuinfo_has_x86_avx2()) {
+            } else if (fbgemmHasAvx2Support()) {
               outProcess.template f<inst_set_t::avx2>(
                   out,
                   currOutBuf + j * K_per_G,
@@ -1790,7 +1790,7 @@ void fbgemmGroupwiseConv(
   typedef ReQuantizeOutput<FUSE_RELU, Q_GRAN> processOutputType;
 
   if (!fbgemmOptimizedGConv<SPATIAL_DIM>(conv_param) ||
-      (!cpuinfo_has_x86_avx512f() && !cpuinfo_has_x86_avx2())) {
+      (!fbgemmHasAvx512Support() && !fbgemmHasAvx2Support())) {
     return fbgemmGroupwiseConvBase_<
         packed_W,
         outType,
@@ -2150,7 +2150,7 @@ int rowOffsetBufferSizeGConv(const conv_param_t<SPATIAL_DIM>& conv_param) {
   // row offset buffer should be a able to hold row offsets for however
   // number of groups we process at a time.
   if (cpuinfo_initialize()) {
-    if (cpuinfo_has_x86_avx512f()) {
+    if (fbgemmHasAvx512Support()) {
       int bufferSize = conv_param.OUT_DIM[0] * conv_param.OUT_DIM[1];
       int C_per_G = conv_param.IC / conv_param.G;
       int K_per_G = conv_param.OC / conv_param.G;
@@ -2160,7 +2160,7 @@ int rowOffsetBufferSizeGConv(const conv_param_t<SPATIAL_DIM>& conv_param) {
       } else {
         return conv_param.G * bufferSize;
       }
-    } else if (cpuinfo_has_x86_avx2()) {
+    } else if (fbgemmHasAvx2Support()) {
       int bufferSize = conv_param.OUT_DIM[0] * conv_param.OUT_DIM[1];
       int C_per_G = conv_param.IC / conv_param.G;
       int K_per_G = conv_param.OC / conv_param.G;

--- a/src/PackAMatrix.cc
+++ b/src/PackAMatrix.cc
@@ -25,12 +25,12 @@ PackAMatrix<T, accT>::PackAMatrix(
       trans_(trans),
       smat_(smat),
       ld_(ld) {
-  if (cpuinfo_has_x86_avx512f()) {
+  if (fbgemmHasAvx512Support()) {
     BaseType::brow_ = PackingTraits<T, accT, inst_set_t::avx512>::MCB;
     BaseType::bcol_ = PackingTraits<T, accT, inst_set_t::avx512>::KCB;
     row_interleave_B_ =
         PackingTraits<T, accT, inst_set_t::avx512>::ROW_INTERLEAVE;
-  } else if (cpuinfo_has_x86_avx2()) {
+  } else if (fbgemmHasAvx2Support()) {
     BaseType::brow_ = PackingTraits<T, accT, inst_set_t::avx2>::MCB;
     BaseType::bcol_ = PackingTraits<T, accT, inst_set_t::avx2>::KCB;
     row_interleave_B_ =

--- a/src/PackAWithIm2Col.cc
+++ b/src/PackAWithIm2Col.cc
@@ -44,12 +44,12 @@ PackAWithIm2Col<T, accT, SPATIAL_DIM>::PackAWithIm2Col(
       a_zero_pt_(a_zero_pt) {
   static_assert(
       SPATIAL_DIM == 2 || SPATIAL_DIM == 3, "unsupported conv dimension ");
-  if (cpuinfo_has_x86_avx512f()) {
+  if (fbgemmHasAvx512Support()) {
     BaseType::brow_ = PackingTraits<T, accT, inst_set_t::avx512>::MCB;
     BaseType::bcol_ = PackingTraits<T, accT, inst_set_t::avx512>::KCB;
     row_interleave_B_ =
         PackingTraits<T, accT, inst_set_t::avx512>::ROW_INTERLEAVE;
-  } else if (cpuinfo_has_x86_avx2()) {
+  } else if (fbgemmHasAvx2Support()) {
     BaseType::brow_ = PackingTraits<T, accT, inst_set_t::avx2>::MCB;
     BaseType::bcol_ = PackingTraits<T, accT, inst_set_t::avx2>::KCB;
     row_interleave_B_ =
@@ -461,9 +461,9 @@ void PackAWithIm2Col<T, accT, SPATIAL_DIM>::printPackedMatrix(
 template <typename T, typename accT, int SPATIAL_DIM>
 int PackAWithIm2Col<T, accT, SPATIAL_DIM>::rowOffsetBufferSize() {
   if (cpuinfo_initialize()) {
-    if (cpuinfo_has_x86_avx512f()) {
+    if (fbgemmHasAvx512Support()) {
       return PackingTraits<T, accT, inst_set_t::avx512>::MCB;
-    } else if (cpuinfo_has_x86_avx2()) {
+    } else if (fbgemmHasAvx2Support()) {
       return PackingTraits<T, accT, inst_set_t::avx2>::MCB;
     } else {
       // TODO: Have default slower path

--- a/src/PackAWithQuantRowOffset.cc
+++ b/src/PackAWithQuantRowOffset.cc
@@ -42,12 +42,12 @@ PackAWithQuantRowOffset<T, accT>::PackAWithQuantRowOffset(
       row_offset_(row_offset) {
   rowOffsetAllocatedHere = false;
 
-  if (cpuinfo_has_x86_avx512f()) {
+  if (fbgemmHasAvx512Support()) {
     BaseType::brow_ = PackingTraits<T, accT, inst_set_t::avx512>::MCB;
     BaseType::bcol_ = PackingTraits<T, accT, inst_set_t::avx512>::KCB;
     row_interleave_B_ =
         PackingTraits<T, accT, inst_set_t::avx512>::ROW_INTERLEAVE;
-  } else if (cpuinfo_has_x86_avx2()) {
+  } else if (fbgemmHasAvx2Support()) {
     BaseType::brow_ = PackingTraits<T, accT, inst_set_t::avx2>::MCB;
     BaseType::bcol_ = PackingTraits<T, accT, inst_set_t::avx2>::KCB;
     row_interleave_B_ =
@@ -181,9 +181,9 @@ void PackAWithQuantRowOffset<T, accT>::printPackedMatrix(std::string name) {
 template <typename T, typename accT>
 int PackAWithQuantRowOffset<T, accT>::rowOffsetBufferSize() {
   if (cpuinfo_initialize()) {
-    if (cpuinfo_has_x86_avx512f()) {
+    if (fbgemmHasAvx512Support()) {
       return PackingTraits<T, accT, inst_set_t::avx512>::MCB;
-    } else if (cpuinfo_has_x86_avx2()) {
+    } else if (fbgemmHasAvx2Support()) {
       return PackingTraits<T, accT, inst_set_t::avx2>::MCB;
     } else {
       assert(0 && "unsupported architecture");

--- a/src/PackAWithRowOffset.cc
+++ b/src/PackAWithRowOffset.cc
@@ -36,12 +36,12 @@ PackAWithRowOffset<T, accT>::PackAWithRowOffset(
       row_offset_(row_offset) {
   rowOffsetAllocatedHere = false;
 
-  if (cpuinfo_has_x86_avx512f()) {
+  if (fbgemmHasAvx512Support()) {
     BaseType::brow_ = PackingTraits<T, accT, inst_set_t::avx512>::MCB;
     BaseType::bcol_ = PackingTraits<T, accT, inst_set_t::avx512>::KCB;
     row_interleave_B_ =
         PackingTraits<T, accT, inst_set_t::avx512>::ROW_INTERLEAVE;
-  } else if (cpuinfo_has_x86_avx2()) {
+  } else if (fbgemmHasAvx2Support()) {
     BaseType::brow_ = PackingTraits<T, accT, inst_set_t::avx2>::MCB;
     BaseType::bcol_ = PackingTraits<T, accT, inst_set_t::avx2>::KCB;
     row_interleave_B_ =
@@ -171,9 +171,9 @@ void PackAWithRowOffset<T, accT>::printPackedMatrix(std::string name) {
 template <typename T, typename accT>
 int PackAWithRowOffset<T, accT>::rowOffsetBufferSize() {
   if (cpuinfo_initialize()) {
-    if (cpuinfo_has_x86_avx512f()) {
+    if (fbgemmHasAvx512Support()) {
       return PackingTraits<T, accT, inst_set_t::avx512>::MCB;
-    } else if (cpuinfo_has_x86_avx2()) {
+    } else if (fbgemmHasAvx2Support()) {
       return PackingTraits<T, accT, inst_set_t::avx2>::MCB;
     } else {
       // TODO: Have default slower path

--- a/src/PackBMatrix.cc
+++ b/src/PackBMatrix.cc
@@ -25,12 +25,12 @@ PackBMatrix<T, accT>::PackBMatrix(
       trans_(trans),
       smat_(smat),
       ld_(ld) {
-  if (cpuinfo_has_x86_avx512f()) {
+  if (fbgemmHasAvx512Support()) {
     BaseType::brow_ = PackingTraits<T, accT, inst_set_t::avx512>::KCB;
     BaseType::bcol_ = PackingTraits<T, accT, inst_set_t::avx512>::NCB;
     row_interleave_ =
         PackingTraits<T, accT, inst_set_t::avx512>::ROW_INTERLEAVE;
-  } else if (cpuinfo_has_x86_avx2()) {
+  } else if (fbgemmHasAvx2Support()) {
     BaseType::brow_ = PackingTraits<T, accT, inst_set_t::avx2>::KCB;
     BaseType::bcol_ = PackingTraits<T, accT, inst_set_t::avx2>::NCB;
     row_interleave_ = PackingTraits<T, accT, inst_set_t::avx2>::ROW_INTERLEAVE;

--- a/src/PackMatrix.cc
+++ b/src/PackMatrix.cc
@@ -28,7 +28,7 @@ PackMatrix<PT, inpType, accType>::PackMatrix(
 
 template <typename PT, typename inpType, typename accType>
 int PackMatrix<PT, inpType, accType>::packedBufferSize(int rows, int cols) {
-  if (cpuinfo_has_x86_avx512f()) {
+  if (fbgemmHasAvx512Support()) {
     if (isA()) {
       return PackingTraits<inpType, accType, inst_set_t::avx512>::MCB *
           PackingTraits<inpType, accType, inst_set_t::avx512>::KCB;
@@ -38,7 +38,7 @@ int PackMatrix<PT, inpType, accType>::packedBufferSize(int rows, int cols) {
       return (((rows + rowBlock - 1) / rowBlock) * rowBlock) *
           (((cols + colBlock - 1) / colBlock) * colBlock);
     }
-  } else if (cpuinfo_has_x86_avx2()) {
+  } else if (fbgemmHasAvx2Support()) {
     if (isA()) {
       return PackingTraits<inpType, accType, inst_set_t::avx2>::MCB *
           PackingTraits<inpType, accType, inst_set_t::avx2>::KCB;

--- a/src/QuantUtils.cc
+++ b/src/QuantUtils.cc
@@ -176,7 +176,7 @@ void Quantize<uint8_t>(
     uint8_t* dst,
     int len,
     const TensorQuantizationParams& qparams) {
-  bool avx2_support = cpuinfo_has_x86_avx2();
+  bool avx2_support = fbgemmHasAvx2Support();
   bool fma_support = cpuinfo_has_x86_fma3();
   if (avx2_support && fma_support && qparams.precision == 8) {
     // fast path
@@ -221,7 +221,7 @@ void Requantize<uint8_t>(
     uint8_t* dst,
     const int len,
     const RequantizationParams& params) {
-  if (params.target_qparams.precision == 8 && cpuinfo_has_x86_avx2()) {
+  if (params.target_qparams.precision == 8 && fbgemmHasAvx2Support()) {
     RequantizeAvx2(src, dst, len, params);
   } else {
     for (int i = 0; i < len; ++i) {
@@ -237,7 +237,7 @@ void RequantizeFixedPoint(
     int len,
     const RequantizationParams& params) {
   if (std::is_same<T, uint8_t>::value && params.target_qparams.precision == 8 &&
-      cpuinfo_has_x86_avx2()) {
+      fbgemmHasAvx2Support()) {
     RequantizeFixedPointAvx2(src, dst, len, params);
   } else {
     for (int i = 0; i < len; ++i) {
@@ -267,7 +267,7 @@ void RequantizeFixedPoint<uint8_t>(
     uint8_t* dst,
     const int len,
     const RequantizationParams& params) {
-  if (params.target_qparams.precision == 8 && cpuinfo_has_x86_avx2()) {
+  if (params.target_qparams.precision == 8 && fbgemmHasAvx2Support()) {
     RequantizeFixedPointAvx2(src, dst, len, params);
   } else {
     for (int i = 0; i < len; ++i) {

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -179,9 +179,9 @@ void transpose_simd(
     int ld_dst) {
   // Run time CPU detection
   if (cpuinfo_initialize()) {
-    if (cpuinfo_has_x86_avx512f()) {
+    if (fbgemmHasAvx512Support()) {
       internal::transpose_16x16(M, N, src, ld_src, dst, ld_dst);
-    } else if (cpuinfo_has_x86_avx2()) {
+    } else if (fbgemmHasAvx2Support()) {
       internal::transpose_8x8(M, N, src, ld_src, dst, ld_dst);
     } else {
       transpose_ref(M, N, src, ld_src, dst, ld_dst);
@@ -190,6 +190,16 @@ void transpose_simd(
   } else {
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
+}
+
+bool fbgemmHasAvx512Support() {
+  return (
+      cpuinfo_has_x86_avx512f() && cpuinfo_has_x86_avx512bw() &&
+      cpuinfo_has_x86_avx512dq() && cpuinfo_has_x86_avx512vl());
+}
+
+bool fbgemmHasAvx2Support() {
+  return (cpuinfo_has_x86_avx2());
 }
 
 } // namespace fbgemm


### PR DESCRIPTION
Summary:
Add AVX512BW check:
AVX-512 Byte and Word Instructions add support for for 8-bit and 16-bit integer operations such as vpmaddubsw.

Differential Revision: D14321050
