### PR TITLE
make sure cpuinfo_initialize called before fbgemmHasAvx2/512Support

### DIFF
--- a/bench/GEMMsTunableBenchmark.cc
+++ b/bench/GEMMsTunableBenchmark.cc
@@ -291,6 +291,8 @@ int main(int /* unused */, char** /* unused */) {
       assert(0 && "architecture not supported");
       return 0;
     }
+  } else {
+    throw std::runtime_error("Failed to initialize cpuinfo!");
   }
 
   set<vector<int>> incorrect_configs;

--- a/src/Fbgemm.cc
+++ b/src/Fbgemm.cc
@@ -50,9 +50,11 @@ void fbgemmPacked(
   // Run time CPU detection
   if (cpuinfo_initialize()) {
     if (blocking_params) {
-      MCB = blocking_params->MCB;
-      KCB = blocking_params->KCB;
-      MR = blocking_params->MR;
+      if (fbgemmHasAvx512Support() || fbgemmHasAvx2Support()) {
+        MCB = blocking_params->MCB;
+        KCB = blocking_params->KCB;
+        MR = blocking_params->MR;
+      }
     } else {
       if (fbgemmHasAvx512Support()) {
         MCB = PackingTraits<

--- a/src/GroupwiseConvAcc32Avx2.cc
+++ b/src/GroupwiseConvAcc32Avx2.cc
@@ -1789,6 +1789,9 @@ void fbgemmGroupwiseConv(
     int num_threads) {
   typedef ReQuantizeOutput<FUSE_RELU, Q_GRAN> processOutputType;
 
+  if (!cpuinfo_initialize()) {
+    throw std::runtime_error("Failed to initialize cpuinfo!");
+  }
   if (!fbgemmOptimizedGConv<SPATIAL_DIM>(conv_param) ||
       (!fbgemmHasAvx512Support() && !fbgemmHasAvx2Support())) {
     return fbgemmGroupwiseConvBase_<

--- a/src/PackAMatrix.cc
+++ b/src/PackAMatrix.cc
@@ -31,10 +31,18 @@ PackAMatrix<T, accT>::PackAMatrix(
       trans_(trans),
       smat_(smat),
       ld_(ld) {
+  if (!cpuinfo_initialize()) {
+    throw std::runtime_error("Failed to initialize cpuinfo!");
+  }
   if (params) {
+    if (fbgemmHasAvx512Support() || fbgemmHasAvx2Support()) {
       BaseType::brow_ = params->MCB;
       BaseType::bcol_ = params->KCB;
       row_interleave_B_ = params->ROW_INTERLEAVE;
+    } else {
+      // TODO: Have default slower path
+      assert(0 && "unsupported architecure");
+    }
   } else {
     if (fbgemmHasAvx512Support()) {
       BaseType::brow_ = PackingTraits<T, accT, inst_set_t::avx512>::MCB;

--- a/src/PackAWithQuantRowOffset.cc
+++ b/src/PackAWithQuantRowOffset.cc
@@ -42,6 +42,9 @@ PackAWithQuantRowOffset<T, accT>::PackAWithQuantRowOffset(
       scale_(scale),
       zero_pt_(zero_pt),
       row_offset_(row_offset) {
+  if (!cpuinfo_initialize()) {
+    throw std::runtime_error("Failed to initialize cpuinfo!");
+  }
   rowOffsetAllocatedHere = false;
   if (params) {
     if (fbgemmHasAvx512Support() || fbgemmHasAvx2Support()) {

--- a/src/PackBMatrix.cc
+++ b/src/PackBMatrix.cc
@@ -185,10 +185,18 @@ PackBMatrix<T, accT>::PackBMatrix(
       trans_(trans),
       smat_(smat),
       ld_(ld) {
+  if (!cpuinfo_initialize()) {
+    throw std::runtime_error("Failed to initialize cpuinfo!");
+  }
   if (params) {
+    if (fbgemmHasAvx512Support() || fbgemmHasAvx2Support()) {
       BaseType::brow_ = params->KCB;
       BaseType::bcol_ = params->NCB;
       row_interleave_ = params->ROW_INTERLEAVE;
+    } else {
+      // TODO: Have default slower path
+      assert(0 && "unsupported architecure");
+    }
   } else {
     if (fbgemmHasAvx512Support()) {
       BaseType::brow_ = PackingTraits<T, accT, inst_set_t::avx512>::KCB;

--- a/src/PackMatrix.cc
+++ b/src/PackMatrix.cc
@@ -33,11 +33,19 @@ int PackMatrix<PT, inpType, accType>::packedBufferSize(
     int rows,
     int cols,
     const BlockingFactors* params) {
+  if (!cpuinfo_initialize()) {
+    throw std::runtime_error("Failed to initialize cpuinfo!");
+  }
   int MCB, KCB, NCB;
   if (params) {
-    MCB = params->MCB;
-    NCB = params->NCB;
-    KCB = params->KCB;
+    if (fbgemmHasAvx512Support() || fbgemmHasAvx2Support()) {
+      MCB = params->MCB;
+      NCB = params->NCB;
+      KCB = params->KCB;
+    } else {
+      // TODO: Have default slower path
+      assert(0 && "unsupported architecure");
+    }
   } else {
     if (fbgemmHasAvx512Support()) {
       MCB = PackingTraits<inpType, accType, inst_set_t::avx512>::MCB;

--- a/src/QuantUtils.cc
+++ b/src/QuantUtils.cc
@@ -176,7 +176,7 @@ void Quantize<uint8_t>(
     uint8_t* dst,
     int len,
     const TensorQuantizationParams& qparams) {
-  bool avx2_support = fbgemmHasAvx2Support();
+  bool avx2_support = cpuinfo_initialize() && fbgemmHasAvx2Support();
   bool fma_support = cpuinfo_has_x86_fma3();
   if (avx2_support && fma_support && qparams.precision == 8) {
     // fast path
@@ -221,7 +221,8 @@ void Requantize<uint8_t>(
     uint8_t* dst,
     const int len,
     const RequantizationParams& params) {
-  if (params.target_qparams.precision == 8 && fbgemmHasAvx2Support()) {
+  if (params.target_qparams.precision == 8 && cpuinfo_initialize() &&
+      fbgemmHasAvx2Support()) {
     RequantizeAvx2(src, dst, len, params);
   } else {
     for (int i = 0; i < len; ++i) {
@@ -237,7 +238,7 @@ void RequantizeFixedPoint(
     int len,
     const RequantizationParams& params) {
   if (std::is_same<T, uint8_t>::value && params.target_qparams.precision == 8 &&
-      fbgemmHasAvx2Support()) {
+      cpuinfo_initialize() && fbgemmHasAvx2Support()) {
     RequantizeFixedPointAvx2(src, dst, len, params);
   } else {
     for (int i = 0; i < len; ++i) {
@@ -267,7 +268,8 @@ void RequantizeFixedPoint<uint8_t>(
     uint8_t* dst,
     const int len,
     const RequantizationParams& params) {
-  if (params.target_qparams.precision == 8 && fbgemmHasAvx2Support()) {
+  if (params.target_qparams.precision == 8 && cpuinfo_initialize() &&
+      fbgemmHasAvx2Support()) {
     RequantizeFixedPointAvx2(src, dst, len, params);
   } else {
     for (int i = 0; i < len; ++i) {

--- a/src/QuantUtilsAvx2.cc
+++ b/src/QuantUtilsAvx2.cc
@@ -142,16 +142,17 @@ void RequantizeAvx2(
     int len,
     const RequantizationParams& params) {
   DoNothing<> doNothingObj{};
+  int32_t Bq_zero_point[] = { 0 };
   ReQuantizeOutput<false /* FUSE_RELU */> requantizeObj(
       doNothingObj,
       &params.real_multiplier,
       params.target_qparams.zero_point,
-      0,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      len);
+      0, // Aq_zero_point
+      Bq_zero_point, // Bq_zero_point
+      nullptr, // row_offsets
+      nullptr, // col_offsets
+      nullptr, // bias
+      len); // ncol
   requantizeObj.f<inst_set_t::avx2>(dst, src, {0, 1, 0, len}, 0, 0);
 }
 


### PR DESCRIPTION
Summary: If we don't call cpuinfo_initialize before hand, fbgemmHasAvx2/512Support will always return false. We should really careful about this.

Differential Revision: D14994129

