### PR TITLE
Add quantized::fbgemm_linear_unpack operator for serialization (#20721)

### DIFF
--- a/include/fbgemm/Fbgemm.h
+++ b/include/fbgemm/Fbgemm.h
@@ -216,6 +216,13 @@ class PackMatrix {
   }
 
   /**
+   * @return The first column of the block we're working on.
+   */
+  std::int32_t packedColStart() const {
+    return packedBlock_.col_start;
+  }
+
+  /**
    * @return The beginning of (rowBlockNum, colBlockNum)th block
    */
   inpType* getBuf(std::int32_t rowBlockNum = 0, std::int32_t colBlockNum = 0) {
@@ -450,6 +457,12 @@ class FBGEMM_API PackBMatrix final
    * @return true if matrices are the same.
    */
   bool equals(const PackBMatrix<T, accT>& that) const;
+
+  /**
+   * @brief Unpack pmat buffer to the origin_buf (Used for the serialization to
+   * recover weight matrix).
+   */
+  void unpack(T* origin_buf);
 
   ~PackBMatrix() {}
 

--- a/src/PackBMatrix.cc
+++ b/src/PackBMatrix.cc
@@ -241,9 +241,9 @@ void PackBMatrix<T, accT>::pack(const block_type_t& block) {
 
   BaseType::packedBlock(block);
   bool tr = (trans_ == matrix_op_t::Transpose);
-  for (int g = 0; g < this->numGroups(); ++g) {
+  for (int g = 0; g < BaseType::numGroups(); ++g) {
     T* out = BaseType::getBuf() +
-        g * this->packedBufferSize(block.row_size, block.col_size);
+        g * BaseType::packedBufferSize(block.row_size, block.col_size);
     for (int i = block.row_start; i < block.row_start + block.row_size; ++i) {
       int r_offset = ((i / BaseType::blockRowSize()) * BaseType::blockCols()) *
               (BaseType::blockRowSize() * BaseType::blockColSize()) +
@@ -298,6 +298,63 @@ void PackBMatrix<T, accT>::pack(const block_type_t& block) {
 
         int out_idx = r_offset + c_offset;
         out[out_idx] = 0;
+      }
+    }
+  } // for each group
+}
+
+template <typename T, typename accT>
+void PackBMatrix<T, accT>::unpack(T* origin_buf) {
+  bool tr = (trans_ == matrix_op_t::Transpose);
+  for (int g = 0; g < this->numGroups(); ++g) {
+    T* out = BaseType::getBuf() +
+        g *
+            BaseType::packedBufferSize(
+                BaseType::numPackedRows(), BaseType::numPackedCols());
+    for (int i = BaseType::packedRowStart();
+         i < BaseType::packedRowStart() + BaseType::numPackedRows();
+         ++i) {
+      int r_offset = ((i / BaseType::blockRowSize()) * BaseType::blockCols()) *
+              (BaseType::blockRowSize() * BaseType::blockColSize()) +
+          (i % BaseType::blockRowSize() / row_interleave_) *
+              BaseType::blockColSize() * row_interleave_ +
+          i % row_interleave_;
+
+      int c_start_offset =
+          (BaseType::packedColStart() / BaseType::blockColSize()) *
+              BaseType::blockRowSize() * BaseType::blockColSize() +
+          (BaseType::packedColStart() % BaseType::blockColSize()) *
+              row_interleave_;
+
+      int c_idx_offset = 0;
+      int c_blk_offset = 0;
+      for (int j = BaseType::packedColStart();
+           j < BaseType::packedColStart() + BaseType::numPackedCols();
+           ++j) {
+        // int c_offset = (j / BaseType::blockColSize()) *
+        //         BaseType::blockRowSize() * BaseType::blockColSize() +
+        //     (j % BaseType::blockColSize()) * row_interleave_;
+        // 1. Loop invariant hoisting (move block offset calculation out of
+        // inner loop); 2. Strength reduction (change modulus in inner loop to
+        // an increment + rollover).
+        int c_offset = c_start_offset +
+            c_blk_offset * BaseType::blockRowSize() * BaseType::blockColSize() +
+            c_idx_offset * row_interleave_;
+
+        int out_idx = r_offset + c_offset;
+
+        T val = out[out_idx];
+        if (tr) {
+          origin_buf[i + (g * BaseType::numPackedCols() + j) * ld_] = val;
+        } else {
+          origin_buf[(g * BaseType::numPackedRows() + i) * ld_ + j] = val;
+        }
+
+        c_idx_offset++;
+        if (c_idx_offset == BaseType::blockColSize()) {
+          c_idx_offset = 0;
+          c_blk_offset++;
+        }
       }
     }
   } // for each group


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/20721

- FBGEMM: Add unpack function for PackBMatrix class: Unpack pmat buffer to the origin_buf (Used for the serialization to recover weight matrix).
- PyTorch Quantizer: Add quantized::fbgemm_linear_unpack operator for serialization.

Differential Revision: D15314568

