### PR TITLE
Quantize should work even if the value after quantization becomes inf

### DIFF
--- a/include/fbgemm/QuantUtils.h
+++ b/include/fbgemm/QuantUtils.h
@@ -56,10 +56,8 @@ T Quantize(
     int result_precision,
     bool result_is_signed = std::is_signed<T>::value) {
   const float transformed_val = zero_point + src / scale;
-  return clamp<std::int64_t, T>(
-      static_cast<std::int64_t>(std::nearbyint(transformed_val)),
-      result_precision,
-      result_is_signed);
+  return clamp<float, T>(
+      std::nearbyint(transformed_val), result_precision, result_is_signed);
 }
 
 template <typename T>


### PR DESCRIPTION
Summary:
With small `scale` and large `src` (value to be quantized) the `src/scale` may become +inf or -inf. We should quantized to max/min in this case.

Without this fix, we get the following error.

```
> buck-out/dev/gen/deeplearning/fbgemm/fbgemm_generic#header-mode-symlink-tree-with-header-map,headers/fbgemm/QuantUtils.h:66:35: runtime error: inf is outside the range of representable values of type 'long'

```

Differential Revision: D16234008

