### PR TITLE
Per channel support in fbgemmConv

### DIFF
--- a/include/fbgemm/Fbgemm.h
+++ b/include/fbgemm/Fbgemm.h
@@ -1134,6 +1134,7 @@ template <
 class FBGEMM_API ReQuantizeOutput {
  public:
   static constexpr int RELU_FUSED = FUSE_RELU;
+  static constexpr QuantizationGranularity QGRANType = Q_GRAN;
   using outType = outT;
   using inpType = inT;
   /**


### PR DESCRIPTION
Summary: Some paths in fbgemmConv had missing support for per channel quantization. Adding support for per channel as well as groupwise quantization support with this diff.

Differential Revision: D16894740

