### PR TITLE
int8 specialization for AVX2 Quantize routine

### DIFF
--- a/include/fbgemm/QuantUtilsAvx2.h
+++ b/include/fbgemm/QuantUtilsAvx2.h
@@ -40,9 +40,10 @@ struct FBGEMM_API RequantizationParams {
 ////////////////////////////////////////////////////////////////////////////////
 // Utility functions
 
+template <typename T=std::uint8_t>
 void QuantizeAvx2(
     const float* src,
-    std::uint8_t* dst,
+    T* dst,
     int len,
     const TensorQuantizationParams& qparams);
 


### PR DESCRIPTION
This adds a specialization for `int8` to the AVX2 `Quantize` routine.

I tried also adding a specialization for `int32` (the final datatype we support in PyTorch quantization), but it seemed to introduce numerical issues stemming from the difference in implementations:

https://github.com/pytorch/FBGEMM/blob/master/include/fbgemm/QuantUtils.h#L63

vs

https://github.com/pytorch/FBGEMM/blob/master/src/QuantUtilsAvx2.cc#L82