### PR TITLE
remove old PackedDepthWiseConvMatrix interface

### DIFF
--- a/include/fbgemm/Fbgemm.h
+++ b/include/fbgemm/Fbgemm.h
@@ -592,14 +592,6 @@ class FBGEMM_API PackWeightsForConv {
     return W_dw_packed_;
   }
 
-  std::shared_ptr<PackedDepthWiseConvMatrix> getPackedWFor2DDW() {
-    return W_dw_packed_;
-  }
-
-  std::shared_ptr<PackedDepthWiseConvMatrix> getPackedWFor3DDW() {
-    return W_dw_packed_;
-  }
-
   std::shared_ptr<PackWeightMatrixForGConv<T, accT, SPATIAL_DIM>>
   getPackedWForGroupwise() {
     return W_gconv_packed_;

--- a/include/fbgemm/FbgemmI8DepthwiseAvx2.h
+++ b/include/fbgemm/FbgemmI8DepthwiseAvx2.h
@@ -48,18 +48,6 @@ class FBGEMM_API PackedDepthWiseConvMatrix {
   std::int8_t* pmat_; /** packed weight */
 }; // PackedDepthWiseConvMatrix
 
-class FBGEMM_API Packed3x3ConvMatrix : public PackedDepthWiseConvMatrix {
- public:
-  Packed3x3ConvMatrix(int K, const std::int8_t* smat)
-      : PackedDepthWiseConvMatrix(K, 3 * 3, smat) {}
-};
-
-class FBGEMM_API Packed3x3x3ConvMatrix : public PackedDepthWiseConvMatrix {
- public:
-  Packed3x3x3ConvMatrix(int K, const std::int8_t* smat)
-      : PackedDepthWiseConvMatrix(K, 3 * 3 * 3, smat) {}
-};
-
 /** To be removed. Keeping it just to make sure we don't change C2 files and
  * fbgemm files in a single diff
  *


### PR DESCRIPTION
Summary: Follow up of D17514003 . Remove old PackedDepthWiseConvMatrix interface from fbgemm .

Reviewed By: jianyuh

Differential Revision: D17515322

