### PR TITLE
optimize avx512 transpose

### DIFF
--- a/bench/TransposeBenchmark.cc
+++ b/bench/TransposeBenchmark.cc
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <algorithm>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include "fbgemm/Utils.h"
+#include "src/TransposeUtils.h"
+
+using namespace std;
+using namespace fbgemm;
+
+void performance_test() {
+  constexpr int NWARMUP = 4;
+  constexpr int NITER = 256;
+
+  normal_distribution dist;
+  default_random_engine engine;
+
+  cout << setw(4) << "M" << setw(4) << "N" << " B_elements_per_sec" << endl;
+
+  int dims[] = {1,  2,  3,  4,  5,  6,  8,   9,   10,  15,  16,
+                17, 32, 33, 63, 64, 65, 127, 128, 129, 255, 256};
+  for (int M : dims) {
+    for (int N : dims) {
+      vector<float> a(M * N);
+      vector<float> b(N * M), b_ref(N * M);
+
+      generate(a.begin(), a.end(), [&dist, &engine] { return dist(engine); });
+      transpose_ref(M, N, a.data(), N, b_ref.data(), M);
+
+      chrono::time_point<chrono::high_resolution_clock> begin, end;
+      for (int i = 0; i < NWARMUP + NITER; ++i) {
+        if (i == NWARMUP) {
+          begin = chrono::high_resolution_clock::now();
+        }
+        transpose_simd(M, N, a.data(), N, b.data(), M);
+      }
+      end = chrono::high_resolution_clock::now();
+
+      auto duration = chrono::duration_cast<chrono::nanoseconds>(end - begin);
+
+      cout << setw(4) << M << setw(4) << N << setw(10) << setprecision(3)
+           << static_cast<double>(M * N) * NITER / duration.count() << endl;
+
+      compare_buffers(b_ref.data(), b.data(), M, N, N, 5);
+    } // N
+  } // M
+} // performance_test
+
+int main() {
+  performance_test();
+  return 0;
+}

--- a/src/GroupwiseConvAcc32Avx2.cc
+++ b/src/GroupwiseConvAcc32Avx2.cc
@@ -1627,7 +1627,7 @@ void fbgemmGroupwiseConvBase_(
               W,
               rowOffsetBuf);
           // Transpose to get row offsets in the format G x IH*IW
-          internal::transpose_8x8(
+          internal::transpose_avx2(
               ih_iw,
               8,
               reinterpret_cast<const float*>(rowOffsetBuf),
@@ -1843,7 +1843,7 @@ void fbgemmGroupwiseConv(
         fpRowoffset(
             actStartBatch + gOuter * C_per_G, a_zero_point, H, W, rowOffsetBuf);
         // Transpose to get row offsets in the format G x IH*IW
-        internal::transpose_8x8(
+        internal::transpose_avx2(
             ih_iw,
             8,
             reinterpret_cast<const float*>(rowOffsetBuf),

--- a/src/MaskAvx2.h
+++ b/src/MaskAvx2.h
@@ -13,7 +13,7 @@ namespace internal {
 // A constant array to initialize an AVX2 register to be used as a 32-bit
 // granularity mask.
 // clang-format off
-alignas(64) static const int avx2_ps_or_epi32_masks[8][8] = {
+alignas(64) static const int avx2_ps_or_epi32_masks[9][8] = {
   // NOTE: clang-format wants to use a different formatting but the current
   // formatting should be easier to read.
   {  0,  0,  0,  0,  0,  0,  0,  0,  },
@@ -24,6 +24,7 @@ alignas(64) static const int avx2_ps_or_epi32_masks[8][8] = {
   { -1, -1, -1, -1, -1,  0,  0,  0,  },
   { -1, -1, -1, -1, -1, -1,  0,  0,  },
   { -1, -1, -1, -1, -1, -1, -1,  0,  },
+  { -1, -1, -1, -1, -1, -1, -1, -1,  },
 };
 // clang-format on
 

--- a/src/TransposeUtils.h
+++ b/src/TransposeUtils.h
@@ -32,7 +32,7 @@ namespace internal {
  *
  * This is called if the code is running on a CPU with Intel AVX2 support.
  */
-void transpose_8x8(
+void transpose_avx2(
     int M,
     int N,
     const float* src,
@@ -45,7 +45,7 @@ void transpose_8x8(
  *
  * This is called if the code is running on a CPU with Intel AVX512 support.
  */
-void transpose_16x16(
+void transpose_avx512(
     int M,
     int N,
     const float* src,

--- a/src/TransposeUtilsAvx2.h
+++ b/src/TransposeUtilsAvx2.h
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include <immintrin.h>
+#include "MaskAvx2.h"
+
+namespace fbgemm {
+
+namespace internal {
+
+#ifdef __AVX2__
+// 4 * 4 = 16 instructions
+inline void
+transpose_kernel_4x4_sse(const float* src, int ld_src, float* dst, int ld_dst) {
+  // load from src to registers
+  // a : a0 a1 a2 a3
+  // b : b0 b1 b2 b3
+  // c : c0 c1 c2 c3
+  // d : d0 d1 d2 d3
+  __m128 a = _mm_loadu_ps(&src[0 * ld_src]);
+  __m128 b = _mm_loadu_ps(&src[1 * ld_src]);
+  __m128 c = _mm_loadu_ps(&src[2 * ld_src]);
+  __m128 d = _mm_loadu_ps(&src[3 * ld_src]);
+
+  // transpose the 4x4 matrix formed by 32-bit elements: Macro from SSE
+  // a : a0 b0 c0 d0
+  // b : a1 b1 c1 d1
+  // c : a2 b2 c2 d2
+  // d : a3 b3 c3 d3
+  _MM_TRANSPOSE4_PS(a, b, c, d);
+
+  // store from registers to dst
+  _mm_storeu_ps(&dst[0 * ld_dst], a);
+  _mm_storeu_ps(&dst[1 * ld_dst], b);
+  _mm_storeu_ps(&dst[2 * ld_dst], c);
+  _mm_storeu_ps(&dst[3 * ld_dst], d);
+}
+
+// kernel for transpose mxn where m, n <= 4
+// M + (M + 1) / 2 * 2 + 2 * N instructions
+template <int M>
+void transpose_kernel_mxn_sse(
+    int N,
+    const float* src,
+    int ld_src,
+    float* dst,
+    int ld_dst) {
+  // clang-format off
+  alignas(64) static const int masks[5][4] = {
+    {  0,  0,  0,  0, },
+    { -1,  0,  0,  0, },
+    { -1, -1,  0,  0, },
+    { -1, -1, -1,  0, },
+    { -1, -1, -1, -1, },
+  };
+  // clang-format on
+
+  // load from src to registers
+  __m128i mask_v = _mm_load_si128(reinterpret_cast<const __m128i*>(masks[N]));
+  __m128 input[4];
+  int i;
+  for (i = 0; i < M; ++i) {
+    input[i] = _mm_maskload_ps(&src[i * ld_src], mask_v);
+  }
+  for (; i < 4; ++i) {
+    // Not really needed but to avoid uninitialized variable warning.
+    // Shouldn't be much overhead because xor can be executed in parallel with
+    // other instructions.
+    input[i] = _mm_setzero_ps();
+  }
+
+  __m128 temp[4];
+  for (i = 0; i < (M + 1) / 2; ++i) {
+    temp[2 * i] = _mm_unpacklo_ps(input[2 * i], input[2 * i + 1]);
+    temp[2 * i + 1] = _mm_unpackhi_ps(input[2 * i], input[2 * i + 1]);
+  }
+  for (i = i * 2; i < 4; ++i) {
+    temp[i] = _mm_setzero_ps();
+  }
+
+  mask_v = _mm_load_si128(reinterpret_cast<const __m128i*>(masks[M]));
+  for (i = 0; i < N; ++i) {
+    if (i % 2 == 0) {
+      input[i] = _mm_movelh_ps(temp[i / 2], temp[2 + i / 2]);
+    } else {
+      input[i] = _mm_movehl_ps(temp[2 + i / 2], temp[i / 2]);
+    }
+    _mm_maskstore_ps(&dst[i * ld_dst], mask_v, input[i]);
+  }
+}
+
+// 8 * 5 = 40 instructions
+inline void transpose_kernel_8x8_avx2(
+    const float* src,
+    int ld_src,
+    float* dst,
+    int ld_dst) {
+  // load from src to registers
+  // a : a0 a1 a2 a3 a4 a5 a6 a7
+  // b : b0 b1 b2 b3 b4 b5 b6 b7
+  // c : c0 c1 c2 c3 c4 c5 c6 c7
+  // d : d0 d1 d2 d3 d4 d5 d6 d7
+  // e : e0 e1 e2 e3 e4 e5 e6 e7
+  // f : f0 f1 f2 f3 f4 f5 f6 f7
+  // g : g0 g1 g2 g3 g4 g5 g6 g7
+  // h : h0 h1 h2 h3 h4 h5 h6 h7
+  __m256 a = _mm256_loadu_ps(&src[0 * ld_src]);
+  __m256 b = _mm256_loadu_ps(&src[1 * ld_src]);
+  __m256 c = _mm256_loadu_ps(&src[2 * ld_src]);
+  __m256 d = _mm256_loadu_ps(&src[3 * ld_src]);
+  __m256 e = _mm256_loadu_ps(&src[4 * ld_src]);
+  __m256 f = _mm256_loadu_ps(&src[5 * ld_src]);
+  __m256 g = _mm256_loadu_ps(&src[6 * ld_src]);
+  __m256 h = _mm256_loadu_ps(&src[7 * ld_src]);
+
+  __m256 ab0145, ab2367, cd0145, cd2367, ef0145, ef2367, gh0145, gh2367;
+  __m256 abcd04, abcd15, efgh04, efgh15, abcd26, abcd37, efgh26, efgh37;
+  // unpacking and interleaving 32-bit elements
+  // ab0145 : a0 b0 a1 b1 a4 b4 a5 b5
+  // ab2367 : a2 b2 a3 b3 a6 b6 a7 b7
+  // cd0145 : c0 d0 c1 d1 c4 d4 c5 d5
+  // cd2367 : c2 d2 c3 d3 c6 d6 c7 d7
+  // ef0145 : e0 f0 e1 f1 e4 f4 e5 f5
+  // ef2367 : e2 f2 e3 f3 e6 f6 e7 f7
+  // gh0145 : g0 h0 g1 h1 g4 h4 g5 h5
+  // gh2367 : g2 h2 g3 h3 g6 h6 g7 h7
+  ab0145 = _mm256_unpacklo_ps(a, b);
+  ab2367 = _mm256_unpackhi_ps(a, b);
+  cd0145 = _mm256_unpacklo_ps(c, d);
+  cd2367 = _mm256_unpackhi_ps(c, d);
+  ef0145 = _mm256_unpacklo_ps(e, f);
+  ef2367 = _mm256_unpackhi_ps(e, f);
+  gh0145 = _mm256_unpacklo_ps(g, h);
+  gh2367 = _mm256_unpackhi_ps(g, h);
+
+  // shuffling the 32-bit elements
+  // abcd04 : a0 b0 c0 d0 a4 b4 c4 d4
+  // abcd15 : a1 b1 c1 d1 a5 b5 c5 d5
+  // efgh04 : e0 f0 g0 h0 e4 f4 g4 h4
+  // efgh15 : e1 f1 g1 h1 e5 b5 c5 d5
+  // abcd26 : a2 b2 c2 d2 a6 b6 c6 d6
+  // abcd37 : a3 b3 c3 d3 a7 b7 c7 d7
+  // efgh26 : e2 f2 g2 h2 e6 f6 g6 h6
+  // efgh37 : e3 f3 g3 h3 e7 f7 g7 h7
+  abcd04 = _mm256_shuffle_ps(ab0145, cd0145, 0x44);
+  abcd15 = _mm256_shuffle_ps(ab0145, cd0145, 0xee);
+  efgh04 = _mm256_shuffle_ps(ef0145, gh0145, 0x44);
+  efgh15 = _mm256_shuffle_ps(ef0145, gh0145, 0xee);
+  abcd26 = _mm256_shuffle_ps(ab2367, cd2367, 0x44);
+  abcd37 = _mm256_shuffle_ps(ab2367, cd2367, 0xee);
+  efgh26 = _mm256_shuffle_ps(ef2367, gh2367, 0x44);
+  efgh37 = _mm256_shuffle_ps(ef2367, gh2367, 0xee);
+
+  // shuffling 128-bit elements
+  // a : a0 b0 c0 d0 e0 f0 g0 h0
+  // b : a1 b1 c1 d1 e1 f1 g1 h1
+  // c : a2 b2 c2 d2 e2 f2 g2 h2
+  // d : a3 b3 c3 d3 e3 f3 g3 h3
+  // e : a4 b4 c4 d4 e4 f4 g4 h4
+  // f : a5 b5 c5 d5 e5 f5 g5 h5
+  // g : a6 b6 c6 d6 e6 f6 g6 h6
+  // h : a7 b7 c7 d7 e7 f7 g7 h7
+  a = _mm256_permute2f128_ps(efgh04, abcd04, 0x02);
+  b = _mm256_permute2f128_ps(efgh15, abcd15, 0x02);
+  c = _mm256_permute2f128_ps(efgh26, abcd26, 0x02);
+  d = _mm256_permute2f128_ps(efgh37, abcd37, 0x02);
+  e = _mm256_permute2f128_ps(efgh04, abcd04, 0x13);
+  f = _mm256_permute2f128_ps(efgh15, abcd15, 0x13);
+  g = _mm256_permute2f128_ps(efgh26, abcd26, 0x13);
+  h = _mm256_permute2f128_ps(efgh37, abcd37, 0x13);
+
+  // store from registers to dst
+  _mm256_storeu_ps(&dst[0 * ld_dst], a);
+  _mm256_storeu_ps(&dst[1 * ld_dst], b);
+  _mm256_storeu_ps(&dst[2 * ld_dst], c);
+  _mm256_storeu_ps(&dst[3 * ld_dst], d);
+  _mm256_storeu_ps(&dst[4 * ld_dst], e);
+  _mm256_storeu_ps(&dst[5 * ld_dst], f);
+  _mm256_storeu_ps(&dst[6 * ld_dst], g);
+  _mm256_storeu_ps(&dst[7 * ld_dst], h);
+}
+
+// kernel for transposing mxn where m, n <= 8
+// M + (M + 1) / 2 * 2 + (M + 3) / 4 * 4 + 2 * N instructions
+template <int M>
+void transpose_kernel_mxn_avx2(
+    int N,
+    const float* src,
+    int ld_src,
+    float* dst,
+    int ld_dst) {
+  // load from src to registers
+  __m256i mask_v = _mm256_load_si256(
+      reinterpret_cast<const __m256i*>(internal::avx2_ps_or_epi32_masks[N]));
+  __m256 input[8];
+  int i;
+  for (i = 0; i < M; ++i) {
+    input[i] = _mm256_maskload_ps(&src[i * ld_src], mask_v);
+  }
+  for (; i < 8; ++i) {
+    // Not really needed but to avoid uninitialized variable warning.
+    // Shouldn't be much overhead because xor can be executed in parallel with
+    // other instructions.
+    input[i] = _mm256_setzero_ps();
+  }
+
+  // unpacking and interleaving 32-bit elements
+  __m256 temp[8];
+  for (i = 0; i < (M + 1) / 2; ++i) {
+    temp[2 * i] = _mm256_unpacklo_ps(input[2 * i], input[2 * i + 1]);
+    temp[2 * i + 1] = _mm256_unpackhi_ps(input[2 * i], input[2 * i + 1]);
+  }
+  for (i = i * 2; i < 8; ++i) {
+    temp[i] = _mm256_setzero_ps();
+  }
+
+  // shuffling the 32-bit elements
+  for (i = 0; i < (M + 3) / 4; ++i) {
+    input[4 * i] = _mm256_shuffle_ps(temp[4 * i], temp[4 * i + 2], 0x44);
+    input[4 * i + 1] = _mm256_shuffle_ps(temp[4 * i], temp[4 * i + 2], 0xee);
+    input[4 * i + 2] =
+        _mm256_shuffle_ps(temp[4 * i + 1], temp[4 * i + 3], 0x44);
+    input[4 * i + 3] =
+        _mm256_shuffle_ps(temp[4 * i + 1], temp[4 * i + 3], 0xee);
+  }
+
+  // shuffling 128-bit elements
+  // store from registers to dst
+  mask_v = _mm256_load_si256(
+      reinterpret_cast<const __m256i*>(internal::avx2_ps_or_epi32_masks[M]));
+  for (i = 0; i < N; ++i) {
+    if (i < 4) {
+      temp[i] = _mm256_permute2f128_ps(input[4 + i], input[i], 0x02);
+    } else {
+      temp[i] = _mm256_permute2f128_ps(input[i], input[i - 4], 0x13);
+    }
+    _mm256_maskstore_ps(&dst[i * ld_dst], mask_v, temp[i]);
+  }
+}
+
+#endif
+
+} // namespace internal
+
+} // namespace fbgemm

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -180,9 +180,9 @@ void transpose_simd(
   // Run time CPU detection
   if (cpuinfo_initialize()) {
     if (fbgemmHasAvx512Support()) {
-      internal::transpose_16x16(M, N, src, ld_src, dst, ld_dst);
+      internal::transpose_avx512(M, N, src, ld_src, dst, ld_dst);
     } else if (fbgemmHasAvx2Support()) {
-      internal::transpose_8x8(M, N, src, ld_src, dst, ld_dst);
+      internal::transpose_avx2(M, N, src, ld_src, dst, ld_dst);
     } else {
       transpose_ref(M, N, src, ld_src, dst, ld_dst);
       return;

--- a/src/UtilsAvx2.cc
+++ b/src/UtilsAvx2.cc
@@ -6,38 +6,13 @@
  */
 #include <immintrin.h>
 #include "TransposeUtils.h"
+#include "TransposeUtilsAvx2.h"
 
 namespace fbgemm {
 
 namespace internal {
 
-inline void
-transpose_kernel_4x4_sse(const float* src, int ld_src, float* dst, int ld_dst) {
-  // load from src to registers
-  // a : a0 a1 a2 a3
-  // b : b0 b1 b2 b3
-  // c : c0 c1 c2 c3
-  // d : d0 d1 d2 d3
-  __m128 a = _mm_loadu_ps(&src[0 * ld_src]);
-  __m128 b = _mm_loadu_ps(&src[1 * ld_src]);
-  __m128 c = _mm_loadu_ps(&src[2 * ld_src]);
-  __m128 d = _mm_loadu_ps(&src[3 * ld_src]);
-
-  // transpose the 4x4 matrix formed by 32-bit elements: Macro from SSE
-  // a : a0 b0 c0 d0
-  // b : a1 b1 c1 d1
-  // c : a2 b2 c2 d2
-  // d : a3 b3 c3 d3
-  _MM_TRANSPOSE4_PS(a, b, c, d);
-
-  // store from registers to dst
-  _mm_storeu_ps(&dst[0 * ld_dst], a);
-  _mm_storeu_ps(&dst[1 * ld_dst], b);
-  _mm_storeu_ps(&dst[2 * ld_dst], c);
-  _mm_storeu_ps(&dst[3 * ld_dst], d);
-}
-
-inline void transpose_4x4(
+void transpose_avx2(
     int M,
     int N,
     const float* src,
@@ -45,122 +20,153 @@ inline void transpose_4x4(
     float* dst,
     int ld_dst) {
   int ib = 0, jb = 0;
-  for (ib = 0; ib + 4 <= M; ib += 4) {
-    for (jb = 0; jb + 4 <= N; jb += 4) {
-      transpose_kernel_4x4_sse(
-          &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+  if (N % 8 > 0 && N % 8 < 4) {
+    // If the remainder has n < 4 columns, we use the SSE kernel for the
+    // remainder because it requires 2 * (2 * 4 + 2 * N) = 16 + 4N instructions
+    // instead of 3 * 8 + 2 * N = 24 + 2N instructions in the masked AVX2
+    // kernel.
+    for (ib = 0; ib + 8 <= M; ib += 8) {
+      for (jb = 0; jb + 8 <= N; jb += 8) {
+        transpose_kernel_8x8_avx2(
+            &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+      }
+      for (int i = ib; i < ib + 8; i += 4) {
+        transpose_kernel_mxn_sse<4>(
+            N - jb,
+            &src[i * ld_src + jb],
+            ld_src,
+            &dst[i + jb * ld_dst],
+            ld_dst);
+      }
+    }
+  } else if (N % 8 == 4) {
+    // If the remainder has 4 columns, we use the SSE kernel for the remainder
+    // because it requires 2 * 16 = 32 instructions instead of 3 * 8 + 2 * 4 =
+    // 32 instructions + looping overhead needed in the masked AVX2 kernel.
+    for (ib = 0; ib + 8 <= M; ib += 8) {
+      for (jb = 0; jb + 8 <= N; jb += 8) {
+        transpose_kernel_8x8_avx2(
+            &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+      }
+      for (int i = ib; i < ib + 8; i += 4) {
+        transpose_kernel_4x4_sse(
+            &src[i * ld_src + jb], ld_src, &dst[i + jb * ld_dst], ld_dst);
+      }
+    }
+  } else {
+    for (ib = 0; ib + 8 <= M; ib += 8) {
+      for (jb = 0; jb + 8 <= N; jb += 8) {
+        transpose_kernel_8x8_avx2(
+            &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_avx2<8>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
     }
   }
-  transpose_ref(ib, N - jb, &src[jb], ld_src, &dst[jb * ld_dst], ld_dst);
-  transpose_ref(M - ib, N, &src[ib * ld_src], ld_src, &dst[ib], ld_dst);
-}
 
-inline void transpose_kernel_8x8_avx2(
-    const float* src,
-    int ld_src,
-    float* dst,
-    int ld_dst) {
-  // load from src to registers
-  // a : a0 a1 a2 a3 a4 a5 a6 a7
-  // b : b0 b1 b2 b3 b4 b5 b6 b7
-  // c : c0 c1 c2 c3 c4 c5 c6 c7
-  // d : d0 d1 d2 d3 d4 d5 d6 d7
-  // e : e0 e1 e2 e3 e4 e5 e6 e7
-  // f : f0 f1 f2 f3 f4 f5 f6 f7
-  // g : g0 g1 g2 g3 g4 g5 g6 g7
-  // h : h0 h1 h2 h3 h4 h5 h6 h7
-  __m256 a = _mm256_loadu_ps(&src[0 * ld_src]);
-  __m256 b = _mm256_loadu_ps(&src[1 * ld_src]);
-  __m256 c = _mm256_loadu_ps(&src[2 * ld_src]);
-  __m256 d = _mm256_loadu_ps(&src[3 * ld_src]);
-  __m256 e = _mm256_loadu_ps(&src[4 * ld_src]);
-  __m256 f = _mm256_loadu_ps(&src[5 * ld_src]);
-  __m256 g = _mm256_loadu_ps(&src[6 * ld_src]);
-  __m256 h = _mm256_loadu_ps(&src[7 * ld_src]);
-
-  __m256 ab0145, ab2367, cd0145, cd2367, ef0145, ef2367, gh0145, gh2367;
-  __m256 abcd04, abcd15, efgh04, efgh15, abcd26, abcd37, efgh26, efgh37;
-  // unpacking and interleaving 32-bit elements
-  // ab0145 : a0 b0 a1 b1 a4 b4 a5 b5
-  // ab2367 : a2 b2 a3 b3 a6 b6 a7 b7
-  // cd0145 : c0 d0 c1 d1 c4 d4 c5 d5
-  // cd2367 : c2 d2 c3 d3 c6 d6 c7 d7
-  // ef0145 : e0 f0 e1 f1 e4 f4 e5 f5
-  // ef2367 : e2 f2 e3 f3 e6 f6 e7 f7
-  // gh0145 : g0 h0 g1 h1 g4 h4 g5 h5
-  // gh2367 : g2 h2 g3 h3 g6 h6 g7 h7
-  ab0145 = _mm256_unpacklo_ps(a, b);
-  ab2367 = _mm256_unpackhi_ps(a, b);
-  cd0145 = _mm256_unpacklo_ps(c, d);
-  cd2367 = _mm256_unpackhi_ps(c, d);
-  ef0145 = _mm256_unpacklo_ps(e, f);
-  ef2367 = _mm256_unpackhi_ps(e, f);
-  gh0145 = _mm256_unpacklo_ps(g, h);
-  gh2367 = _mm256_unpackhi_ps(g, h);
-
-  // shuffling the 32-bit elements
-  // abcd04 : a0 b0 c0 d0 a4 b4 c4 d4
-  // abcd15 : a1 b1 c1 d1 a5 b5 c5 d5
-  // efgh04 : e0 f0 g0 h0 e4 f4 g4 h4
-  // efgh15 : e1 f1 g1 h1 e5 b5 c5 d5
-  // abcd26 : a2 b2 c2 d2 a6 b6 c6 d6
-  // abcd37 : a3 b3 c3 d3 a7 b7 c7 d7
-  // efgh26 : e2 f2 g2 h2 e6 f6 g6 h6
-  // efgh37 : e3 f3 g3 h3 e7 f7 g7 h7
-  abcd04 = _mm256_shuffle_ps(ab0145, cd0145, 0x44);
-  abcd15 = _mm256_shuffle_ps(ab0145, cd0145, 0xee);
-  efgh04 = _mm256_shuffle_ps(ef0145, gh0145, 0x44);
-  efgh15 = _mm256_shuffle_ps(ef0145, gh0145, 0xee);
-  abcd26 = _mm256_shuffle_ps(ab2367, cd2367, 0x44);
-  abcd37 = _mm256_shuffle_ps(ab2367, cd2367, 0xee);
-  efgh26 = _mm256_shuffle_ps(ef2367, gh2367, 0x44);
-  efgh37 = _mm256_shuffle_ps(ef2367, gh2367, 0xee);
-
-  // shuffling 128-bit elements
-  // a : a0 b0 c0 d0 e0 f0 g0 h0
-  // b : a1 b1 c1 d1 e1 f1 g1 h1
-  // c : a2 b2 c2 d2 e2 f2 g2 h2
-  // d : a3 b3 c3 d3 e3 f3 g3 h3
-  // e : a4 b4 c4 d4 e4 f4 g4 h4
-  // f : a5 b5 c5 d5 e5 f5 g5 h5
-  // g : a6 b6 c6 d6 e6 f6 g6 h6
-  // h : a7 b7 c7 d7 e7 f7 g7 h7
-  a = _mm256_permute2f128_ps(efgh04, abcd04, 0x02);
-  b = _mm256_permute2f128_ps(efgh15, abcd15, 0x02);
-  c = _mm256_permute2f128_ps(efgh26, abcd26, 0x02);
-  d = _mm256_permute2f128_ps(efgh37, abcd37, 0x02);
-  e = _mm256_permute2f128_ps(efgh04, abcd04, 0x13);
-  f = _mm256_permute2f128_ps(efgh15, abcd15, 0x13);
-  g = _mm256_permute2f128_ps(efgh26, abcd26, 0x13);
-  h = _mm256_permute2f128_ps(efgh37, abcd37, 0x13);
-
-  // store from registers to dst
-  _mm256_storeu_ps(&dst[0 * ld_dst], a);
-  _mm256_storeu_ps(&dst[1 * ld_dst], b);
-  _mm256_storeu_ps(&dst[2 * ld_dst], c);
-  _mm256_storeu_ps(&dst[3 * ld_dst], d);
-  _mm256_storeu_ps(&dst[4 * ld_dst], e);
-  _mm256_storeu_ps(&dst[5 * ld_dst], f);
-  _mm256_storeu_ps(&dst[6 * ld_dst], g);
-  _mm256_storeu_ps(&dst[7 * ld_dst], h);
-}
-
-void transpose_8x8(
-    int M,
-    int N,
-    const float* src,
-    int ld_src,
-    float* dst,
-    int ld_dst) {
-  int ib = 0, jb = 0;
-  for (ib = 0; ib + 8 <= M; ib += 8) {
-    for (jb = 0; jb + 8 <= N; jb += 8) {
-      transpose_kernel_8x8_avx2(
-          &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
-    }
+  // Specialization for small M - ib cases so that the compiler can inline
+  // transpose_kernel_mxn_avx2 and unroll the loops whose iteration count
+  // depends on by M - ib .
+  // Specialization for m helps more than for n in transpose_kernel_mxn_avx2
+  // because we have more loops in that function whose iteration count depends
+  // on m.
+  switch (M - ib) {
+    case 1:
+      for (int j = 0; j < N; ++j) {
+        dst[ib + j * ld_dst] = src[ib * ld_src + j];
+      }
+      break;
+    case 2:
+      for (jb = 0; jb + 4 <= N; jb += 4) {
+        transpose_kernel_mxn_sse<2>(
+            4, &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_sse<2>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+    case 3:
+      for (jb = 0; jb + 4 <= N; jb += 4) {
+        transpose_kernel_mxn_sse<3>(
+            4, &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_sse<3>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+    case 4:
+      for (jb = 0; jb + 4 <= N; jb += 4) {
+        transpose_kernel_4x4_sse(
+            &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_sse<4>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+    case 5:
+      for (jb = 0; jb + 8 <= N; jb += 8) {
+        transpose_kernel_mxn_avx2<5>(
+            8, &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_avx2<5>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+    case 6:
+      for (jb = 0; jb + 8 <= N; jb += 8) {
+        transpose_kernel_mxn_avx2<6>(
+            8, &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_avx2<6>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+    case 7:
+      for (jb = 0; jb + 8 <= N; jb += 8) {
+        transpose_kernel_mxn_avx2<7>(
+            8, &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_avx2<7>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
   }
-  transpose_4x4(ib, N - jb, &src[jb], ld_src, &dst[jb * ld_dst], ld_dst);
-  transpose_4x4(M - ib, N, &src[ib * ld_src], ld_src, &dst[ib], ld_dst);
 }
 
 } // namespace internal

--- a/src/UtilsAvx512.cc
+++ b/src/UtilsAvx512.cc
@@ -7,11 +7,13 @@
 
 #include <immintrin.h>
 #include "TransposeUtils.h"
+#include "TransposeUtilsAvx2.h"
 
 namespace fbgemm {
 
-namespace internal {
+namespace {
 
+// 16 * 6 = 96 instructions
 inline void transpose_kernel_16x16_avx512(
     const float* src,
     int ld_src,
@@ -223,7 +225,91 @@ inline void transpose_kernel_16x16_avx512(
   _mm512_storeu_ps(&dst[15 * ld_dst], p);
 }
 
-void transpose_16x16(
+// kernel for transposing mxn where m, n <= 16
+// M + (M + 1) / 2 * 2 + (M + 3) / 4 * 4 + (M + 7) / 8 * 8 + 2 * N instructions
+template <int M>
+void transpose_kernel_mxn_avx512(
+    int N,
+    const float* src,
+    int ld_src,
+    float* dst,
+    int ld_dst) {
+  // load from src to registers
+  __mmask16 src_mask = (1 << N) - 1;
+  __m512 input[16];
+  int i;
+  for (i = 0; i < M; ++i) {
+    input[i] = _mm512_maskz_loadu_ps(src_mask, &src[i * ld_src]);
+  }
+  for (; i < 16; ++i) {
+    // Not really needed but to avoid uninitialized variable warning.
+    // Shouldn't be much overhead because xor can be executed in parallel with
+    // other instructions.
+    input[i] = _mm512_setzero_ps();
+  }
+
+  // unpacking and interleaving 32-bit elements
+  __m512 temp[16];
+  for (i = 0; i < (M + 1) / 2; ++i) {
+    temp[2 * i] = _mm512_unpacklo_ps(input[2 * i], input[2 * i + 1]);
+    temp[2 * i + 1] = _mm512_unpackhi_ps(input[2 * i], input[2 * i + 1]);
+  }
+  for (i = i * 2; i < 16; ++i) {
+    temp[i] = _mm512_setzero_ps();
+  }
+
+  // unpacking and interleaving 64-bit elements
+  for (i = 0; i < (M + 3) / 4; ++i) {
+    input[4 * i] = reinterpret_cast<__m512>(_mm512_unpacklo_pd(
+        reinterpret_cast<__m512d>(temp[4 * i]),
+        reinterpret_cast<__m512d>(temp[4 * i + 2])));
+    input[4 * i + 1] = reinterpret_cast<__m512>(_mm512_unpackhi_pd(
+        reinterpret_cast<__m512d>(temp[4 * i]),
+        reinterpret_cast<__m512d>(temp[4 * i + 2])));
+    input[4 * i + 2] = reinterpret_cast<__m512>(_mm512_unpacklo_pd(
+        reinterpret_cast<__m512d>(temp[4 * i + 1]),
+        reinterpret_cast<__m512d>(temp[4 * i + 3])));
+    input[4 * i + 3] = reinterpret_cast<__m512>(_mm512_unpackhi_pd(
+        reinterpret_cast<__m512d>(temp[4 * i + 1]),
+        reinterpret_cast<__m512d>(temp[4 * i + 3])));
+  }
+
+  //  shuffle 128-bits (composed of 4 32-bit elements)
+  for (i = 0; i < (M + 7) / 8; ++i) {
+    temp[8 * i] = _mm512_shuffle_f32x4(input[8 * i], input[8 * i + 4], 0x88);
+    temp[8 * i + 1] =
+        _mm512_shuffle_f32x4(input[8 * i + 1], input[8 * i + 5], 0x88);
+    temp[8 * i + 2] =
+        _mm512_shuffle_f32x4(input[8 * i + 2], input[8 * i + 6], 0x88);
+    temp[8 * i + 3] =
+        _mm512_shuffle_f32x4(input[8 * i + 3], input[8 * i + 7], 0x88);
+    temp[8 * i + 4] =
+        _mm512_shuffle_f32x4(input[8 * i], input[8 * i + 4], 0xdd);
+    temp[8 * i + 5] =
+        _mm512_shuffle_f32x4(input[8 * i + 1], input[8 * i + 5], 0xdd);
+    temp[8 * i + 6] =
+        _mm512_shuffle_f32x4(input[8 * i + 2], input[8 * i + 6], 0xdd);
+    temp[8 * i + 7] =
+        _mm512_shuffle_f32x4(input[8 * i + 3], input[8 * i + 7], 0xdd);
+  }
+
+  // store from registers to dst
+  __mmask16 dst_mask = (1 << M) - 1;
+  for (i = 0; i < N; ++i) {
+    if (i < 8) {
+      input[i] = _mm512_shuffle_f32x4(temp[i], temp[8 + i], 0x88);
+    } else {
+      input[i] = _mm512_shuffle_f32x4(temp[i - 8], temp[i], 0xdd);
+    }
+    _mm512_mask_storeu_ps(&dst[i * ld_dst], dst_mask, input[i]);
+  }
+}
+
+} // namespace
+
+namespace internal {
+
+void transpose_avx512(
     int M,
     int N,
     const float* src,
@@ -231,14 +317,327 @@ void transpose_16x16(
     float* dst,
     int ld_dst) {
   int ib = 0, jb = 0;
-  for (ib = 0; ib + 16 <= M; ib += 16) {
-    for (jb = 0; jb + 16 <= N; jb += 16) {
-      transpose_kernel_16x16_avx512(
-          &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+  if (N % 16 > 0 && N % 16 < 4) {
+    // If the remainder has n < 4 columns, we use the SSE kernel for the
+    // remainder because it requires 4 * (2 * 4 + 2 * N) = 32 + 8N instructions
+    // instead of 4 * 16 + 2 * N = 64 + 2N instructions needed in the masked
+    // AVX512 kernel.
+    for (ib = 0; ib + 16 <= M; ib += 16) {
+      for (jb = 0; jb + 16 <= N; jb += 16) {
+        transpose_kernel_16x16_avx512(
+            &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+      }
+      for (int i = ib; i < ib + 16; i += 4) {
+        transpose_kernel_mxn_sse<4>(
+            N - jb,
+            &src[i * ld_src + jb],
+            ld_src,
+            &dst[i + jb * ld_dst],
+            ld_dst);
+      }
+    }
+  } else if (N % 16 == 4) {
+    // If the remainder has 4 columns, we use the SSE kernel for the remainder
+    // because it requires 4 * 16 = 64 instructions instead of 4 * 16 + 2 * 4 =
+    // 72 instructions needed in the masked AVX512 kernel.
+    for (ib = 0; ib + 16 <= M; ib += 16) {
+      for (jb = 0; jb + 16 <= N; jb += 16) {
+        transpose_kernel_16x16_avx512(
+            &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+      }
+      for (int i = ib; i < ib + 16; i += 4) {
+        transpose_kernel_4x4_sse(
+            &src[i * ld_src + jb], ld_src, &dst[i + jb * ld_dst], ld_dst);
+      }
+    }
+  } else if (N % 16 == 8) {
+    // If the remainder has 8 columns, we use the AVX kenrel for the remainder
+    // because it requires 2 * 40 = 80 instructions instead of 4 * 16 + 2 * 8 =
+    // 80 instructions + looping overhead in the masked AVX512 kernel.
+    for (ib = 0; ib + 16 <= M; ib += 16) {
+      for (jb = 0; jb + 16 <= N; jb += 16) {
+        transpose_kernel_16x16_avx512(
+            &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+      }
+      for (int i = ib; i < ib + 16; i += 8) {
+        transpose_kernel_8x8_avx2(
+            &src[i * ld_src + jb], ld_src, &dst[i + jb * ld_dst], ld_dst);
+      }
+    }
+  } else {
+    for (ib = 0; ib + 16 <= M; ib += 16) {
+      for (jb = 0; jb + 16 <= N; jb += 16) {
+        transpose_kernel_16x16_avx512(
+            &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_avx512<16>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
     }
   }
-  transpose_8x8(ib, N - jb, &src[jb], ld_src, &dst[jb * ld_dst], ld_dst);
-  transpose_8x8(M - ib, N, &src[ib * ld_src], ld_src, &dst[ib], ld_dst);
+
+  // Specialization for small M - ib cases so that the compiler can inline
+  // transpose_kernel_mxn_avx512 and unroll the loops whose iteration count
+  // depends on by M - ib .
+  // Specialization for m helps more than for n in transpose_kernel_mxn_avx512
+  // because we have more loops in that function whose iteration count depends
+  // on m.
+  switch (M - ib) {
+    case 1:
+      for (int j = 0; j < N; ++j) {
+        dst[ib + j * ld_dst] = src[ib * ld_src + j];
+      }
+      break;
+    case 2:
+      for (jb = 0; jb + 4 <= N; jb += 4) {
+        transpose_kernel_mxn_sse<2>(
+            4,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_sse<2>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+    case 3:
+      for (jb = 0; jb + 4 <= N; jb += 4) {
+        transpose_kernel_mxn_sse<3>(
+            4,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_sse<3>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+    case 4:
+      for (jb = 0; jb + 4 <= N; jb += 4) {
+        transpose_kernel_4x4_sse(
+            &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_sse<4>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+    case 5:
+      for (jb = 0; jb + 8 <= N; jb += 8) {
+        transpose_kernel_mxn_avx2<5>(
+            8,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_avx2<5>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+    case 6:
+      for (jb = 0; jb + 8 <= N; jb += 8) {
+        transpose_kernel_mxn_avx2<6>(
+            8,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_avx2<6>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+    case 7:
+      for (jb = 0; jb + 16 <= N; jb += 16) {
+        transpose_kernel_mxn_avx512<7>(
+            16,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_avx512<7>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+    case 8:
+      for (jb = 0; jb + 8 <= N; jb += 8) {
+        transpose_kernel_8x8_avx2(
+            &src[ib * ld_src + jb], ld_src, &dst[ib + jb * ld_dst], ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_avx2<8>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+    case 9:
+      for (jb = 0; jb + 16 <= N; jb += 16) {
+        transpose_kernel_mxn_avx512<9>(
+            16,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_avx512<9>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+    case 10:
+      for (jb = 0; jb + 16 <= N; jb += 16) {
+        transpose_kernel_mxn_avx512<10>(
+            16,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_avx512<10>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+    case 11:
+      for (jb = 0; jb + 16 <= N; jb += 16) {
+        transpose_kernel_mxn_avx512<11>(
+            16,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_avx512<11>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+    case 12:
+      for (jb = 0; jb + 16 <= N; jb += 16) {
+        transpose_kernel_mxn_avx512<12>(
+            16,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_avx512<12>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+    case 13:
+      for (jb = 0; jb + 16 <= N; jb += 16) {
+        transpose_kernel_mxn_avx512<13>(
+            16,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_avx512<13>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+    case 14:
+      for (jb = 0; jb + 16 <= N; jb += 16) {
+        transpose_kernel_mxn_avx512<14>(
+            16,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_avx512<14>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+    case 15:
+      for (jb = 0; jb + 16 <= N; jb += 16) {
+        transpose_kernel_mxn_avx512<15>(
+            16,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      if (jb < N) {
+        transpose_kernel_mxn_avx512<15>(
+            N - jb,
+            &src[ib * ld_src + jb],
+            ld_src,
+            &dst[ib + jb * ld_dst],
+            ld_dst);
+      }
+      break;
+  }
 }
 
 } // namespace internal

--- a/test/TransposeTest.cc
+++ b/test/TransposeTest.cc
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <random>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "fbgemm/Utils.h"
+
+using namespace std;
+using namespace fbgemm;
+
+TEST(TransposeTest, TransposeTest) {
+  // Generate shapes to test
+  vector<tuple<int, int, int, int>> shapes;
+  uniform_int_distribution<int> dist(0, 32);
+  default_random_engine generator;
+  for (int i = 0; i < 1024; ++i) {
+    int m = dist(generator);
+    int n = dist(generator);
+    int ld_src = n + dist(generator);
+    int ld_dst = m + dist(generator);
+    shapes.push_back({m, n, ld_src, ld_dst});
+  }
+
+  for (const auto& shape : shapes) {
+    int m, n, ld_src, ld_dst;
+    tie(m, n, ld_src, ld_dst) = shape;
+
+    vector<float> a(m * ld_src);
+    vector<float> b(n * ld_dst);
+    generate(
+        a.begin(), a.end(), [&dist, &generator] { return dist(generator); });
+
+    transpose_simd(m, n, a.data(), ld_src, b.data(), ld_dst);
+
+    for (int i = 0; i < m; ++i) {
+      for (int j = 0; j < n; ++j) {
+        int expected = a[i * ld_src + j];
+        int actual = b[i + j * ld_dst];
+        EXPECT_EQ(expected, actual)
+            << "Transpose results differ at (" << i << ", " << j << "). ref "
+            << expected << " actual " << actual;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Summary:
Use intrinsics with masking for non-multiple of 16 cases.
Moved transpose_kernel_4x4_sse and transpose_kernel_8x8_avx2 to a header file to reuse from UtilsAvx512.cc

Differential Revision: D17897732

