### PR TITLE
call fbgemmAlignedAlloc instead of posix_memalign

### DIFF
--- a/include/fbgemm/Fbgemm.h
+++ b/include/fbgemm/Fbgemm.h
@@ -1452,17 +1452,6 @@ template <int SPATIAL_DIM>
 FBGEMM_API bool takePointWiseFastPath(const conv_param_t<SPATIAL_DIM>& conv_p);
 
 /**
- * @brief Allocate __size bytes of uninitialized storage whose alignment is
- * specified by __align.
- */
-static void* fbgemmAlignedAlloc(size_t __align, size_t __size) {
-  void* aligned_mem;
-  if (posix_memalign(&aligned_mem, __align, __size))
-    return 0;
-  return aligned_mem;
-}
-
-/**
  * @brief Are we running on a fbgemm supported cpu?
  */
 FBGEMM_API bool fbgemmSupportedCPU();

--- a/include/fbgemm/FbgemmFP16.h
+++ b/include/fbgemm/FbgemmFP16.h
@@ -48,10 +48,7 @@ class PackedGemmMatrixFP16 {
       const float alpha,
       const float* smat,
       const int brow = 512)
-      : nrow_(nrow),
-        ncol_(ncol),
-        brow_(brow),
-        kernel_ncol_blocks_(2) {
+      : nrow_(nrow), ncol_(ncol), brow_(brow), kernel_ncol_blocks_(2) {
     initializeParam();
     initializeMemory();
     // copy source matrix into packed matrix
@@ -113,9 +110,8 @@ class PackedGemmMatrixFP16 {
     // allocate and initialize packed memory
     const int padding = 1024; // required by sw pipelined kernels
     size_ = (blockRowSize() * nbrow_) * (blockColSize() * nbcol_);
-    // pmat_ = (float16 *)aligned_alloc(64, matSize() * sizeof(float16) +
-    // padding);
-    posix_memalign((void**)&pmat_, 64, matSize() * sizeof(float16) + padding);
+    pmat_ = static_cast<float16*>(
+        fbgemmAlignedAlloc(64, matSize() * sizeof(float16) + padding));
     for (auto i = 0; i < matSize(); i++) {
       pmat_[i] = tconv(0.f, pmat_[i]);
     }

--- a/include/fbgemm/UtilsAvx2.h
+++ b/include/fbgemm/UtilsAvx2.h
@@ -44,7 +44,7 @@ struct block_type_t {
  * QuantUtilsAvx2.h as it combines all the parameters needed for various
  * quantization granularities
  */
-template<typename BIAS_TYPE = std::int32_t>
+template <typename BIAS_TYPE = std::int32_t>
 struct requantizationParams_t {
   using BIAS_T = BIAS_TYPE;
   std::int32_t A_zero_point;
@@ -73,5 +73,14 @@ struct requantizationForFloatParams_t {
   std::uint32_t ncols;
   int groups;
 };
+
+/**
+ * @brief Allocate size bytes of uninitialized storage whose alignment is
+ * specified by align.
+ */
+void* fbgemmAlignedAlloc(
+    size_t align,
+    size_t size,
+    bool raiseException = false);
 
 } // namespace fbgemm

--- a/src/PackAMatrix.cc
+++ b/src/PackAMatrix.cc
@@ -72,8 +72,8 @@ PackAMatrix<T, accT>::PackAMatrix(
     BaseType::buf_ = pmat;
   } else {
     BaseType::bufAllocatedHere_ = true;
-    BaseType::buf_ = (T*)fbgemmAlignedAlloc(
-        64, BaseType::brow_ * BaseType::bcol_ * sizeof(T));
+    BaseType::buf_ = static_cast<T*>(fbgemmAlignedAlloc(
+        64, BaseType::brow_ * BaseType::bcol_ * sizeof(T)));
   }
 }
 

--- a/src/PackAWithQuantRowOffset.cc
+++ b/src/PackAWithQuantRowOffset.cc
@@ -85,12 +85,12 @@ PackAWithQuantRowOffset<T, accT>::PackAWithQuantRowOffset(
     BaseType::buf_ = pmat;
   } else {
     BaseType::bufAllocatedHere_ = true;
-    BaseType::buf_ = (T*)fbgemmAlignedAlloc(
-        64, BaseType::brow_ * BaseType::bcol_ * sizeof(T));
+    BaseType::buf_ = static_cast<T*>(fbgemmAlignedAlloc(
+        64, BaseType::brow_ * BaseType::bcol_ * sizeof(T)));
   }
   if (!row_offset_) {
     rowOffsetAllocatedHere = true;
-    row_offset_ = reinterpret_cast<int32_t*>(
+    row_offset_ = static_cast<int32_t*>(
         fbgemmAlignedAlloc(64, BaseType::brow_ * sizeof(accT)));
   }
 }

--- a/src/PackAWithRowOffset.cc
+++ b/src/PackAWithRowOffset.cc
@@ -79,8 +79,8 @@ PackAWithRowOffset<T, accT>::PackAWithRowOffset(
     BaseType::buf_ = pmat;
   } else {
     BaseType::bufAllocatedHere_ = true;
-    BaseType::buf_ = (T*)fbgemmAlignedAlloc(
-        64, BaseType::brow_ * BaseType::bcol_ * sizeof(T));
+    BaseType::buf_ = static_cast<T*>(fbgemmAlignedAlloc(
+        64, BaseType::brow_ * BaseType::bcol_ * sizeof(T)));
   }
   if (!row_offset_) {
     rowOffsetAllocatedHere = true;

--- a/src/PackBMatrix.cc
+++ b/src/PackBMatrix.cc
@@ -229,10 +229,10 @@ PackBMatrix<T, accT>::PackBMatrix(
   BaseType::packedBlock(block);
   if (!pmat) {
     BaseType::bufAllocatedHere_ = true;
-    BaseType::buf_ = (T*)fbgemmAlignedAlloc(
+    BaseType::buf_ = static_cast<T*>(fbgemmAlignedAlloc(
         64,
         BaseType::numGroups() * BaseType::blockRows() * BaseType::brow_ *
-            BaseType::blockCols() * BaseType::bcol_ * sizeof(T));
+            BaseType::blockCols() * BaseType::bcol_ * sizeof(T)));
   }
   pack(block, params);
 }

--- a/src/PackDepthwiseConvMatrixAvx2.cc
+++ b/src/PackDepthwiseConvMatrixAvx2.cc
@@ -9,6 +9,7 @@
 #include <immintrin.h>
 
 #include "MaskAvx2.h"
+#include "fbgemm/UtilsAvx2.h"
 
 using namespace std;
 
@@ -29,12 +30,8 @@ PackedDepthWiseConvMatrix::PackedDepthWiseConvMatrix(
 
   // Allocate packed arrays
   int kernel_prod_aligned = (kernel_prod + 1) / 2 * 2;
-  // pmat_ = static_cast<int8_t *>(fbgemmAlignedAlloc(
-  //     64, ((K + 31) / 32) * KERNEL_PROD_ALIGNED * 32 * sizeof(int8_t)));
-  posix_memalign(
-      (void**)&pmat_,
-      64,
-      ((K + 31) / 32) * kernel_prod_aligned * 32 * sizeof(int8_t));
+  pmat_ = static_cast<int8_t*>(fbgemmAlignedAlloc(
+      64, ((K + 31) / 32) * kernel_prod_aligned * 32 * sizeof(int8_t)));
 
   // Pack input matrix
   // The layout is optimized to use vpmaddubsw efficiently (see

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -12,6 +12,7 @@
 #include <iomanip>
 #include <iostream>
 #include <limits>
+#include <new>
 #include <stdexcept>
 #include "TransposeUtils.h"
 
@@ -236,4 +237,19 @@ void fbgemmPartition1DBlocked(
       ? std::max(end_block * block_size, total_work)
       : std::min(end_block * block_size, total_work);
 }
+
+void* fbgemmAlignedAlloc(
+    size_t align,
+    size_t size,
+    bool raiseException /*=false*/) {
+  void* aligned_mem;
+  if (posix_memalign(&aligned_mem, align, size)) {
+    if (raiseException) {
+      throw std::bad_alloc();
+    }
+    return nullptr;
+  }
+  return aligned_mem;
+}
+
 } // namespace fbgemm


### PR DESCRIPTION
Summary: Also reduces the number of warnings in OSS CI.

Reviewed By: jianyuh

Differential Revision: D18186854

