### PR TITLE
fix build error in D18137995

### DIFF
--- a/test/SpMMFP32Test.cc
+++ b/test/SpMMFP32Test.cc
@@ -25,10 +25,11 @@ class SpMMTest : public testing::Test {
     uniform_int_distribution<int> dist_dim(1, 128);
     uniform_real_distribution<float> dist_fnz(0, 1.0);
     for (int i = 0; i < 256; ++i) {
-      shapes.push_back({dist_dim(generator),
-                        dist_dim(generator),
-                        dist_dim(generator),
-                        dist_fnz(generator)});
+      shapes.push_back(make_tuple(
+          dist_dim(generator),
+          dist_dim(generator),
+          dist_dim(generator),
+          dist_fnz(generator)));
     }
     return shapes;
   }

--- a/test/SpMMI8Test.cc
+++ b/test/SpMMI8Test.cc
@@ -25,11 +25,12 @@ class SpMMTest : public testing::Test {
     uniform_int_distribution<int> dist_dim(1, 128);
     uniform_real_distribution<float> dist_fnz(0, 1.0);
     for (int i = 0; i < 256; ++i) {
-      shapes.push_back({dist_dim(generator),
-                        dist_dim(generator),
-                        // By design, k must be a multiple of 4
-                        dist_dim(generator) * 4,
-                        dist_fnz(generator)});
+      shapes.push_back(make_tuple(
+          dist_dim(generator),
+          dist_dim(generator),
+          // By design, k must be a multiple of 4
+          dist_dim(generator) * 4,
+          dist_fnz(generator)));
     }
     return shapes;
   }


### PR DESCRIPTION
Summary:
Fix the following error
```
/root/project/test/SpMMI8Test.cc: In member function 'std::vector<std::tuple<int, int, int, float> > {anonymous}::SpMMTest::GenParams()':
/root/project/test/SpMMI8Test.cc:32:45: error: converting to 'std::vector<std::tuple<int, int, int, float> >::value_type {aka std::tuple<int, int, int, float>}' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {int, int, int, float}; <template-parameter-2-2> = void; _Elements = {int, int, int, float}]'
                         dist_fnz(generator)});
```

Differential Revision: D18286166

