### PR TITLE
use simd_info in more places

### DIFF
--- a/include/fbgemm/FbgemmFP16.h
+++ b/include/fbgemm/FbgemmFP16.h
@@ -80,7 +80,10 @@ class PackedGemmMatrixFP16 {
     if (!cpuinfo_initialize()) {
       throw std::runtime_error("Failed to initialize cpuinfo!");
     }
-    bcol_ = (fbgemmHasAvx512Support() ? 16 : 8) * kernelNumColBlocks();
+    bcol_ = (fbgemmHasAvx512Support()
+                 ? simd_info<inst_set_t::avx512>::WIDTH_32BIT_ELEMS
+                 : simd_info<inst_set_t::avx2>::WIDTH_32BIT_ELEMS) *
+        kernelNumColBlocks();
 
     // set up internal packing parameters
     nbrow_ = (numRows() + blockRowSize() - 1) / blockRowSize();


### PR DESCRIPTION
Summary: As title. Also simplifies FbgemmFP16.cc by eliminating kernel_ncols variable which is same as blockColSize()

Reviewed By: dskhudia

Differential Revision: D18286936

