### PR TITLE
Update gcc requirement to 5+ as c++11 constructs such as is_trivially_copyable don't exist pre-gcc 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ nop) fused with inner GEMM macro kernel.
 FBGEMM uses the standard CMAKE-based build flow.
 
 ### Dependencies
-FBGEMM requires gcc 4.9+ and a CPU with support for avx2 instruction set or
+FBGEMM requires gcc 5+ and a CPU with support for avx2 instruction set or
 higher. It's been tested on Mac OS X and Linux.
 
 + ###### asmjit


### PR DESCRIPTION
Summary:
Same as title

Thanks James Reed for pointing this out here: https://github.com/pytorch/FBGEMM/pull/151

More details in:

https://stackoverflow.com/questions/25123458/is-trivially-copyable-is-not-a-member-of-std

Differential Revision: D18305625

