### PR TITLE
Fix the GEMM benchmark number

### DIFF
--- a/bench/GEMMsBenchmark.cc
+++ b/bench/GEMMsBenchmark.cc
@@ -115,6 +115,7 @@ void performance_test() {
         NWARMUP,
         NITER,
         flush ? &llc : nullptr);
+    ttot *= 1e9; // convert to ns
 
     ((volatile char*)(llc.data()));
 


### PR DESCRIPTION
Summary:
The time result from `measureWithWarmup` is measured in second. We need to convert that into ns for the same measurement between MKL and FBGEMM.

Before this Diff:
```
     M,      N,      K,             Type,  GOPS
    64,    800,    320,         MKL_fp32, 57236541255.6
    64,    800,    320,  FBGEMM_i8_acc32,  68.8
    64,    800,    320,  FBGEMM_i8_acc16,  99.7

    64,    768,    512,         MKL_fp32, 43456330666.9
    64,    768,    512,  FBGEMM_i8_acc32,  72.4
    64,    768,    512,  FBGEMM_i8_acc16, 117.1

    16,    256,    512,         MKL_fp32, 22071659811.7
    16,    256,    512,  FBGEMM_i8_acc32,  45.7
    16,    256,    512,  FBGEMM_i8_acc16,  61.0
```

After this Diff:
```
     M,      N,      K,             Type,  GOPS
    64,    800,    320,         MKL_fp32,  62.2
    64,    800,    320,  FBGEMM_i8_acc32,  69.3
    64,    800,    320,  FBGEMM_i8_acc16,  93.4

    64,    768,    512,         MKL_fp32,  43.6
    64,    768,    512,  FBGEMM_i8_acc32,  70.8
    64,    768,    512,  FBGEMM_i8_acc16, 124.4

    16,    256,    512,         MKL_fp32,  24.7
    16,    256,    512,  FBGEMM_i8_acc32,  49.1
    16,    256,    512,  FBGEMM_i8_acc16,  62.5
```

Reviewed By: dskhudia

Differential Revision: D18374929

