### PR TITLE
remove matmul_fp_ref and use cblas_sgemm_ref instead

### DIFF
--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -147,27 +147,6 @@ void matmul_u8i8acc16_ref(
   }
 }
 
-void matmul_fp_ref(
-    int M,
-    int N,
-    int K,
-    int lda,
-    int ldb,
-    int ldc,
-    const float* Afp32,
-    const float* Bfp32,
-    float* Cfp32) {
-  for (int i = 0; i < M; ++i) {
-    for (int j = 0; j < N; ++j) {
-      float sum = 0;
-      for (int k = 0; k < K; ++k) {
-        sum += Afp32[i * lda + k] * Bfp32[k * ldb + j];
-      }
-      Cfp32[i * ldc + j] = sum;
-    }
-  }
-}
-
 void cblas_sgemm_ref(
     const matrix_op_t transa,
     const matrix_op_t transb,

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -93,21 +93,6 @@ void FBGEMM_API matmul_u8i8acc16_ref(
     std::int32_t* Cint32);
 
 /**
- * @brief Reference implementation of matrix multiply with fp32 (single
- * precision) floating point number.
- */
-void FBGEMM_API matmul_fp_ref(
-    int M,
-    int N,
-    int K,
-    int lda,
-    int ldb,
-    int ldc,
-    const float* Afp32,
-    const float* Bfp32,
-    float* Cfp32);
-
-/**
  * @brief Reference implementation of cblas_sgemm in MKL/BLAS.
  */
 void FBGEMM_API cblas_sgemm_ref(

--- a/test/FP16Test.cc
+++ b/test/FP16Test.cc
@@ -91,15 +91,21 @@ TEST_P(FBGemmFP16Test, Test) {
 
     aligned_vector<float> A_ref(A), B_ref(B), C_ref(C);
 
-    if (atrans == matrix_op_t::Transpose) {
-      transpose_matrix(A_ref.data(), k, m);
-    }
-    if (btrans == matrix_op_t::Transpose) {
-      transpose_matrix(B_ref.data(), n, k);
-    }
-
     // Gold via reference sgemm
-    matmul_fp_ref(m, n, k, k, n, n, A_ref.data(), B_ref.data(), C_ref.data());
+    cblas_sgemm_ref(
+        atrans,
+        btrans,
+        m,
+        n,
+        k,
+        1.0f,
+        A_ref.data(),
+        atrans == matrix_op_t::Transpose ? m : k,
+        B_ref.data(),
+        btrans == matrix_op_t::Transpose ? k : n,
+        0.0f,
+        C_ref.data(),
+        n);
 
     // fbgemm fp16
     PackedGemmMatrixFP16 Bp(btrans, k, n, alpha, B.data());
@@ -159,15 +165,21 @@ TEST_P(FBGemmFP16Test, Unpack) {
 
     aligned_vector<float> A_ref(A), B_ref(B), C_ref(C);
 
-    if (atrans == matrix_op_t::Transpose) {
-      transpose_matrix(A_ref.data(), k, m);
-    }
-    if (btrans == matrix_op_t::Transpose) {
-      transpose_matrix(B_ref.data(), n, k);
-    }
-
     // Gold via reference sgemm
-    matmul_fp_ref(m, n, k, k, n, n, A_ref.data(), B_ref.data(), C_ref.data());
+    cblas_sgemm_ref(
+        atrans,
+        btrans,
+        m,
+        n,
+        k,
+        1.0f,
+        A_ref.data(),
+        atrans == matrix_op_t::Transpose ? m : k,
+        B_ref.data(),
+        btrans == matrix_op_t::Transpose ? k : n,
+        0.0f,
+        C_ref.data(),
+        n);
 
     // fbgemm fp16
     PackedGemmMatrixFP16 Bp(btrans, k, n, alpha, B.data());

--- a/test/PackedRequantizeTest.cc
+++ b/test/PackedRequantizeTest.cc
@@ -475,16 +475,20 @@ TEST_P(fbgemmu8s8acc32WithQuantGranularityTest, TestFloatInputOutput) {
       }
 
       for (int g = 0; g < groups; ++g) {
-        matmul_fp_ref(
+        cblas_sgemm_ref(
+            matrix_op_t::NoTranspose,
+            matrix_op_t::NoTranspose,
             m,
             n_adjusted,
             k_per_group,
-            k,
-            n,
-            groups * n,
+            1.0f,
             Afp32.data() + g * k_per_group,
+            k,
             Bfp32.data() + g * k_per_group * n,
-            Cfp32_ref.data() + g * n_adjusted);
+            n,
+            0.0f,
+            Cfp32_ref.data() + g * n_adjusted,
+            groups * n);
       }
 
       if (atrans == matrix_op_t::Transpose) {
@@ -692,16 +696,20 @@ TEST_P(fbgemmu8s8acc32Test, TestSymmetricQuantizedInputOutput) {
       }
 
       for (int g = 0; g < groups; ++g) {
-        matmul_fp_ref(
+        cblas_sgemm_ref(
+            matrix_op_t::NoTranspose,
+            matrix_op_t::NoTranspose,
             m,
             n_adjusted,
             k_per_group,
-            k,
-            n,
-            groups * n,
+            1.0f,
             Afp32.data() + g * k_per_group,
+            k,
             Bfp32.data() + g * k_per_group * n,
-            Cfp32_ref.data() + g * n_adjusted);
+            n,
+            0.0f,
+            Cfp32_ref.data() + g * n_adjusted,
+            groups * n);
       }
 
       // B zero point defaults to 0

--- a/test/SpMMFP32Test.cc
+++ b/test/SpMMFP32Test.cc
@@ -59,8 +59,20 @@ TEST_F(SpMMTest, fp32) {
 
     transpose_matrix(cDataJIT.data(), n, m);
 
-    matmul_fp_ref(
-        m, n, k, k, n, n, aData.data(), bData.data(), cDataNaive.data());
+    cblas_sgemm_ref(
+        matrix_op_t::NoTranspose,
+        matrix_op_t::NoTranspose,
+        m,
+        n,
+        k,
+        1.0f,
+        aData.data(),
+        k,
+        bData.data(),
+        n,
+        0.0f,
+        cDataNaive.data(),
+        n);
 
     for (int i = 0; i < cDataJIT.size(); ++i) {
       float expected = cDataNaive[i];


### PR DESCRIPTION
Summary: matmul_fp_ref is redundant

Differential Revision: D18418731

