### PR TITLE
a bug fix when computing VLEN_

### DIFF
--- a/src/GenerateKernel.h
+++ b/src/GenerateKernel.h
@@ -59,7 +59,7 @@ class CodeGenBase {
       throw std::runtime_error("Failed to initialize cpuinfo!");
     }
     // vector width in elements
-    VLEN_ = vectorWidth_ / 8 * sizeof(TA);
+    VLEN_ = vectorWidth_ / (8 * sizeof(TA));
   }
 
   /**


### PR DESCRIPTION
Summary: Shouldn't affect correctness because so far sizeof(TA) always has been 1 but better to fix

Differential Revision: D18422993

