### PR TITLE
another minor changes in GenerateKernel files

### DIFF
--- a/src/ExecuteKernelU8S8.cc
+++ b/src/ExecuteKernelU8S8.cc
@@ -98,7 +98,7 @@ ExecuteKernel<
       nrMinSize_ = PackingTraits<
           int8_t,
           typename packingAMatrix::accType,
-          inst_set_t::avx2>::NR;
+          inst_set_t::avx2>::NR_MIN;
     } else {
       assert(0 && "unsupported architecure");
     }
@@ -140,30 +140,26 @@ void ExecuteKernel<
           accum,
           packed_rows_A,
           packedB_.blockColSize(),
-          packedA_.numPackedCols(),
-          nbSize_);
+          packedA_.numPackedCols());
     } else {
       fn = BaseType::template getOrCreate<inst_set_t::avx512_vnni>(
           accum,
           packed_rows_A,
           packedB_.blockColSize(),
-          packedA_.numPackedCols(),
-          nbSize_);
+          packedA_.numPackedCols());
     }
   } else if (fbgemmHasAvx512Support()) {
     fn = BaseType::template getOrCreate<inst_set_t::avx512>(
         accum,
         packed_rows_A,
         packedB_.blockColSize(),
-        packedA_.numPackedCols(),
-        nbSize_);
+        packedA_.numPackedCols());
   } else if (fbgemmHasAvx2Support()) {
     fn = BaseType::template getOrCreate<inst_set_t::avx2>(
         accum,
         packed_rows_A,
         packedB_.blockColSize(),
-        packedA_.numPackedCols(),
-        nbSize_);
+        packedA_.numPackedCols());
   } else {
     // TODO: Have default slower path
     assert(0 && "unsupported architecture");
@@ -182,13 +178,13 @@ void ExecuteKernel<
       if (nc != nbSize_) {
         if (fbgemmHasAvx512VnniSupport()) {
           fn = BaseType::template getOrCreate<inst_set_t::avx512_vnni>(
-              accum, packed_rows_A, nc, packedA_.numPackedCols(), nbSize_);
+              accum, packed_rows_A, nc, packedA_.numPackedCols());
         } else if (fbgemmHasAvx512Support()) {
           fn = BaseType::template getOrCreate<inst_set_t::avx512>(
-              accum, packed_rows_A, nc, packedA_.numPackedCols(), nbSize_);
+              accum, packed_rows_A, nc, packedA_.numPackedCols());
         } else if (fbgemmHasAvx2Support()) {
           fn = BaseType::template getOrCreate<inst_set_t::avx2>(
-              accum, packed_rows_A, nc, packedA_.numPackedCols(), nbSize_);
+              accum, packed_rows_A, nc, packedA_.numPackedCols());
         } else {
           // TODO: Have default slower path
           assert(0 && "unsupported architecture");

--- a/src/GenerateKernelU8S8S32ACC16Avx512VNNI.cc
+++ b/src/GenerateKernelU8S8S32ACC16Avx512VNNI.cc
@@ -23,8 +23,6 @@ void CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::initCRegs<
     int rowRegs,
     int colRegs,
     int leadingDimCReg) {
-  assert(0 && "Accumulation to int16_t is not available for VNNI!");
-
   // For AVX512VNNI, redirect to int32_t accumulation.
   CodeGenBase<uint8_t, int8_t, int32_t, int32_t> codeObj;
   codeObj.initCRegs<inst_set_t::avx512_vnni>(
@@ -47,8 +45,6 @@ void CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::genComputeBlock<
     int colRegs,
     int lda,
     int leadingDimCReg) {
-  assert(0 && "Accumulation to int16_t is not available for VNNI!");
-
   // For AVX512VNNI, redirect to int32_t accumulation.
   CodeGenBase<uint8_t, int8_t, int32_t, int32_t> codeObj;
   codeObj.genComputeBlock<inst_set_t::avx512_vnni>(
@@ -70,8 +66,6 @@ void CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::storeCRegs<
     x86::Gp ldcReg,
     bool accum,
     int leadingDimCReg) {
-  assert(0 && "Accumulation to int16_t is not available for VNNI!");
-
   // For AVX512VNNI, redirect to int32_t accumulation.
   CodeGenBase<uint8_t, int8_t, int32_t, int32_t> codeObj;
   codeObj.storeCRegs<inst_set_t::avx512_vnni>(
@@ -92,8 +86,6 @@ CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate<
     int32_t nc,
     int32_t kc,
     int32_t /* unused */) {
-  assert(0 && "Accumulation to int16_t is not available for VNNI!");
-
   // For AVX512VNNI, redirect to int32_t accumulation.
   CodeGenBase<uint8_t, int8_t, int32_t, int32_t> codeObj;
   return codeObj.getOrCreate<inst_set_t::avx512_vnni>(accum, mc, nc, kc, kc);

--- a/src/GenerateKernelU8S8S32ACC16Avx512VNNI.cc
+++ b/src/GenerateKernelU8S8S32ACC16Avx512VNNI.cc
@@ -18,15 +18,10 @@ namespace x86 = asmjit::x86;
 template <>
 template <>
 void CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::initCRegs<
-    inst_set_t::avx512_vnni>(
-    x86::Emitter* a,
-    int rowRegs,
-    int colRegs,
-    int leadingDimCReg) {
+    inst_set_t::avx512_vnni>(x86::Emitter* a, int rowRegs, int colRegs) {
   // For AVX512VNNI, redirect to int32_t accumulation.
   CodeGenBase<uint8_t, int8_t, int32_t, int32_t> codeObj;
-  codeObj.initCRegs<inst_set_t::avx512_vnni>(
-      a, rowRegs, colRegs, leadingDimCReg);
+  codeObj.initCRegs<inst_set_t::avx512_vnni>(a, rowRegs, colRegs);
 }
 
 /**
@@ -43,12 +38,11 @@ void CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::genComputeBlock<
     x86::Gp /* unused (reserved for prefetching)*/,
     int rowRegs,
     int colRegs,
-    int lda,
-    int leadingDimCReg) {
+    int lda) {
   // For AVX512VNNI, redirect to int32_t accumulation.
   CodeGenBase<uint8_t, int8_t, int32_t, int32_t> codeObj;
   codeObj.genComputeBlock<inst_set_t::avx512_vnni>(
-      a, buffer_A, buffer_B, buffer_B, rowRegs, colRegs, lda, leadingDimCReg);
+      a, buffer_A, buffer_B, buffer_B, rowRegs, colRegs, lda);
 }
 
 /**
@@ -64,12 +58,11 @@ void CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::storeCRegs<
     int colRegs,
     x86::Gp C_Offset,
     x86::Gp ldcReg,
-    bool accum,
-    int leadingDimCReg) {
+    bool accum) {
   // For AVX512VNNI, redirect to int32_t accumulation.
   CodeGenBase<uint8_t, int8_t, int32_t, int32_t> codeObj;
   codeObj.storeCRegs<inst_set_t::avx512_vnni>(
-      a, rowRegs, colRegs, C_Offset, ldcReg, accum, leadingDimCReg);
+      a, rowRegs, colRegs, C_Offset, ldcReg, accum);
 }
 
 /**
@@ -80,15 +73,10 @@ template <>
 template <>
 CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::jit_micro_kernel_fp
 CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate<
-    inst_set_t::avx512_vnni>(
-    bool accum,
-    int32_t mc,
-    int32_t nc,
-    int32_t kc,
-    int32_t /* unused */) {
+    inst_set_t::avx512_vnni>(bool accum, int32_t mc, int32_t nc, int32_t kc) {
   // For AVX512VNNI, redirect to int32_t accumulation.
   CodeGenBase<uint8_t, int8_t, int32_t, int32_t> codeObj;
-  return codeObj.getOrCreate<inst_set_t::avx512_vnni>(accum, mc, nc, kc, kc);
+  return codeObj.getOrCreate<inst_set_t::avx512_vnni>(accum, mc, nc, kc);
 }
 
 } // namespace fbgemm


### PR DESCRIPTION
Summary:
Fix bug in computing colRegs (doesn't affect correctness for int8_t)
Remove unused parameter

Differential Revision: D18442555

