### PR TITLE
minor changes in GenerateKernel files (#176)

### DIFF
--- a/src/GenerateKernelU8S8S32ACC16Avx512.cc
+++ b/src/GenerateKernelU8S8S32ACC16Avx512.cc
@@ -230,7 +230,9 @@ CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate<inst_set_t::avx512>(
     frame.setDirtyRegs(
         x86::Reg::kGroupVec,
         asmjit::Support::bitMask(0, 1, 2, 3, 4, 5, 6, 7) |
-            asmjit::Support::bitMask(8, 9, 10, 11, 12, 13, 14, 15));
+            asmjit::Support::bitMask(8, 9, 10, 11, 12, 13, 14, 15) |
+            asmjit::Support::bitMask(16, 17, 18, 19, 20, 21, 22, 23) |
+            asmjit::Support::bitMask(24, 25, 26, 27, 28, 29, 30, 31));
     frame.setDirtyRegs(
         x86::Reg::kGroupGp,
         asmjit::Support::bitMask(8, 9, 10, 11, 12, 13, 14, 15));

--- a/src/GenerateKernelU8S8S32ACC32.cc
+++ b/src/GenerateKernelU8S8S32ACC32.cc
@@ -105,10 +105,10 @@ void CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::storeCRegs<
         a->vpaddd(
             CRegs(i * leadingDimCReg + j),
             CRegs(i * leadingDimCReg + j),
-            x86::dword_ptr(a->zcx(), C_Offset, 0, j * 8 * sizeof(int32_t)));
+            x86::dword_ptr(a->zcx(), C_Offset, 0, j * VLEN_ * sizeof(int8_t)));
       }
       a->vmovups(
-          x86::dword_ptr(a->zcx(), C_Offset, 0, j * 8 * sizeof(int32_t)),
+          x86::dword_ptr(a->zcx(), C_Offset, 0, j * VLEN_ * sizeof(int8_t)),
           CRegs(i * leadingDimCReg + j));
     }
   }
@@ -189,6 +189,16 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate<inst_set_t::avx2>(
 #endif
 
     // assert(mc <= 12 && "mc must be <= 12 (available registers constraint)");
+    assert(
+        kc % row_interleave == 0 && "kc must be a multiple of row_interleave");
+    assert(nc % nRegBlockSizeMin == 0 && "nc must be a multiple of NR_MIN");
+    int maxMRegs = mRegBlockSize;
+    int maxNRegs = nRegBlockSize * row_interleave / VLEN_;
+    assert(
+        maxMRegs * maxNRegs <= 12 &&
+        "MR*(NR*ROW_INTERLEAVE*8/256) \
+        must be <= 12(available registers constraint)");
+
     int mRegBlocks = mc / mRegBlockSize;
     int mRegBlocksRem = mc % mRegBlockSize;
 

--- a/src/GenerateKernelU8S8S32ACC32Avx512.cc
+++ b/src/GenerateKernelU8S8S32ACC32Avx512.cc
@@ -106,10 +106,10 @@ void CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::storeCRegs<
         a->vpaddd(
             CRegs(i * leadingDimCReg + j),
             CRegs(i * leadingDimCReg + j),
-            x86::dword_ptr(a->zcx(), C_Offset, 0, j * 16 * sizeof(int32_t)));
+            x86::dword_ptr(a->zcx(), C_Offset, 0, j * VLEN_ * sizeof(int8_t)));
       }
       a->vmovups(
-          x86::dword_ptr(a->zcx(), C_Offset, 0, j * 16 * sizeof(int32_t)),
+          x86::dword_ptr(a->zcx(), C_Offset, 0, j * VLEN_ * sizeof(int8_t)),
           CRegs(i * leadingDimCReg + j));
     }
   }
@@ -226,7 +226,9 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate<inst_set_t::avx512>(
     frame.setDirtyRegs(
         x86::Reg::kGroupVec,
         asmjit::Support::bitMask(0, 1, 2, 3, 4, 5, 6, 7) |
-            asmjit::Support::bitMask(8, 9, 10, 11, 12, 13, 14, 15));
+            asmjit::Support::bitMask(8, 9, 10, 11, 12, 13, 14, 15) |
+            asmjit::Support::bitMask(16, 17, 18, 19, 20, 21, 22, 23) |
+            asmjit::Support::bitMask(24, 25, 26, 27, 28, 29, 30, 31));
     frame.setDirtyRegs(
         x86::Reg::kGroupGp,
         asmjit::Support::bitMask(8, 9, 10, 11, 12, 13, 14, 15));


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/FBGEMM/pull/176

Clear zmm16-zmm31
Reuse avx512 code gen from avx512_vnni code gen

Reviewed By: jianyuh

Differential Revision: D18445573

