### PR TITLE
Fix the Lint issue for the header files

### DIFF
--- a/bench/BenchUtils.cc
+++ b/bench/BenchUtils.cc
@@ -4,7 +4,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-#include "BenchUtils.h"
+#include "./BenchUtils.h"
 
 #include <algorithm>
 #include <random>

--- a/bench/BenchUtils.h
+++ b/bench/BenchUtils.h
@@ -10,7 +10,7 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
-#include "AlignedVec.h"
+#include "./AlignedVec.h"
 
 namespace fbgemm {
 

--- a/bench/ConvUnifiedBenchmark.cc
+++ b/bench/ConvUnifiedBenchmark.cc
@@ -16,7 +16,7 @@
 #include <omp.h>
 #endif
 
-#include "BenchUtils.h"
+#include "./BenchUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "src/RefImplementations.h"
 

--- a/bench/Depthwise3DBenchmark.cc
+++ b/bench/Depthwise3DBenchmark.cc
@@ -16,8 +16,8 @@
 #include <omp.h>
 #endif
 
-#include "AlignedVec.h"
-#include "BenchUtils.h"
+#include "./AlignedVec.h"
+#include "./BenchUtils.h"
 #include "fbgemm/FbgemmI8DepthwiseAvx2.h"
 #include "fbgemm/Utils.h"
 #include "src/RefImplementations.h"

--- a/bench/DepthwiseBenchmark.cc
+++ b/bench/DepthwiseBenchmark.cc
@@ -15,8 +15,8 @@
 #include <omp.h>
 #endif
 
-#include "AlignedVec.h"
-#include "BenchUtils.h"
+#include "./AlignedVec.h"
+#include "./BenchUtils.h"
 #include "fbgemm/FbgemmI8DepthwiseAvx2.h"
 #include "fbgemm/Utils.h"
 #include "src/RefImplementations.h"

--- a/bench/GEMMsBenchmark.cc
+++ b/bench/GEMMsBenchmark.cc
@@ -19,7 +19,7 @@
 #include <mkl.h>
 #endif
 
-#include "BenchUtils.h"
+#include "./BenchUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "src/RefImplementations.h"
 #include "test/QuantizationHelpers.h"

--- a/bench/GroupwiseConvRequantizeBenchmark.cc
+++ b/bench/GroupwiseConvRequantizeBenchmark.cc
@@ -16,7 +16,7 @@
 #include <omp.h>
 #endif
 
-#include "BenchUtils.h"
+#include "./BenchUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "src/RefImplementations.h"
 

--- a/bench/I8SpmdmBenchmark.cc
+++ b/bench/I8SpmdmBenchmark.cc
@@ -17,7 +17,7 @@
 #include <omp.h>
 #endif
 
-#include "BenchUtils.h"
+#include "./BenchUtils.h"
 #include "fbgemm/FbgemmI8Spmdm.h"
 #include "src/RefImplementations.h"
 

--- a/bench/Im2ColFusedRequantizeBenchmark.cc
+++ b/bench/Im2ColFusedRequantizeBenchmark.cc
@@ -16,7 +16,7 @@
 #include <omp.h>
 #endif
 
-#include "BenchUtils.h"
+#include "./BenchUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "src/RefImplementations.h"
 

--- a/bench/PackedFloatInOutBenchmark.cc
+++ b/bench/PackedFloatInOutBenchmark.cc
@@ -19,7 +19,7 @@
 #include <mkl.h>
 #endif
 
-#include "BenchUtils.h"
+#include "./BenchUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "src/RefImplementations.h"
 #include "test/QuantizationHelpers.h"

--- a/bench/PackedRequantizeAcc16Benchmark.cc
+++ b/bench/PackedRequantizeAcc16Benchmark.cc
@@ -20,7 +20,7 @@
 #include <mkl.h>
 #endif
 
-#include "BenchUtils.h"
+#include "./BenchUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "src/RefImplementations.h"
 

--- a/bench/PackedRequantizeAcc32Benchmark.cc
+++ b/bench/PackedRequantizeAcc32Benchmark.cc
@@ -19,7 +19,7 @@
 #include <mkl.h>
 #endif
 
-#include "BenchUtils.h"
+#include "./BenchUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "src/RefImplementations.h"
 #include "test/QuantizationHelpers.h"

--- a/bench/RequantizeBenchmark.cc
+++ b/bench/RequantizeBenchmark.cc
@@ -13,7 +13,7 @@
 #include <omp.h>
 #endif
 
-#include "BenchUtils.h"
+#include "./BenchUtils.h"
 #include "fbgemm/Fbgemm.h"
 
 using namespace std;

--- a/bench/RowOffsetBenchmark.cc
+++ b/bench/RowOffsetBenchmark.cc
@@ -13,7 +13,7 @@
 #include <omp.h>
 #endif
 
-#include "BenchUtils.h"
+#include "./BenchUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "src/OptimizedKernelsAvx2.h"
 

--- a/bench/TransposeBenchmark.cc
+++ b/bench/TransposeBenchmark.cc
@@ -11,7 +11,7 @@
 #include <random>
 #include <vector>
 
-#include "BenchUtils.h"
+#include "./BenchUtils.h"
 #include "fbgemm/Utils.h"
 #include "src/TransposeUtils.h"
 

--- a/include/fbgemm/Fbgemm.h
+++ b/include/fbgemm/Fbgemm.h
@@ -14,13 +14,13 @@
 #include <limits>
 #include <memory>
 #include <type_traits>
-#include "ConvUtils.h"
-#include "FbgemmBuild.h"
-#include "FbgemmI8Spmdm.h"
-#include "QuantUtilsAvx2.h"
-#include "FbgemmI8DepthwiseAvx2.h"
-#include "Types.h"
-#include "Utils.h"
+#include "./ConvUtils.h"
+#include "./FbgemmBuild.h"
+#include "./FbgemmI8Spmdm.h"
+#include "./QuantUtilsAvx2.h"
+#include "./FbgemmI8DepthwiseAvx2.h"
+#include "./Types.h"
+#include "./Utils.h"
 
 // Turning on this option will print out time breakdown of each stage (e.g.,
 // input packing, the main GEMM kernel, each output processing pipeline).
@@ -57,7 +57,7 @@ template <
 struct PackingTraits;
 
 // type specialized implementation in an include file
-#include "PackingTraits-inl.h"
+#include "./PackingTraits-inl.h"
 
 /**
  * @brief Base class for packing matrices for higher GEMM performance.
@@ -1316,7 +1316,7 @@ class FBGEMM_API ReQuantizeForFloat {
 };
 
 // type specialized implementation in an include file
-#include "OutputProcessing-inl.h"
+#include "./OutputProcessing-inl.h"
 
 /*
  *

--- a/include/fbgemm/FbgemmFP16.h
+++ b/include/fbgemm/FbgemmFP16.h
@@ -15,8 +15,8 @@
 #include <memory>
 #include <vector>
 
-#include "Types.h"
-#include "Utils.h"
+#include "./Types.h"
+#include "./Utils.h"
 
 namespace fbgemm {
 

--- a/include/fbgemm/FbgemmI8Spmdm.h
+++ b/include/fbgemm/FbgemmI8Spmdm.h
@@ -8,9 +8,9 @@
 
 #include <cstdint>
 #include <vector>
-#include "ConvUtils.h"
-#include "FbgemmBuild.h"
-#include "Utils.h"
+#include "./ConvUtils.h"
+#include "./FbgemmBuild.h"
+#include "./Utils.h"
 
 // #define FBGEMM_MEASURE_TIME_BREAKDOWN
 

--- a/include/fbgemm/FbgemmSpMM.h
+++ b/include/fbgemm/FbgemmSpMM.h
@@ -11,7 +11,7 @@
 #include <cstdint>
 #include <functional>
 
-#include "FbgemmBuild.h"
+#include "./FbgemmBuild.h"
 
 namespace fbgemm {
 

--- a/include/fbgemm/QuantUtils.h
+++ b/include/fbgemm/QuantUtils.h
@@ -5,9 +5,9 @@
 #include <cmath>
 #include <cstdint>
 #include <limits>
-#include "FbgemmBuild.h"
-#include "QuantUtilsAvx2.h"
-#include "Utils.h"
+#include "./FbgemmBuild.h"
+#include "./QuantUtilsAvx2.h"
+#include "./Utils.h"
 
 namespace fbgemm {
 

--- a/include/fbgemm/QuantUtilsAvx2.h
+++ b/include/fbgemm/QuantUtilsAvx2.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <cstdint>
-#include "FbgemmBuild.h"
-#include "UtilsAvx2.h"
+#include "./FbgemmBuild.h"
+#include "./UtilsAvx2.h"
 
 namespace fbgemm {
 

--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -10,8 +10,8 @@
 #include <cmath>
 #include <string>
 #include <type_traits>
-#include "FbgemmBuild.h"
-#include "UtilsAvx2.h"
+#include "./FbgemmBuild.h"
+#include "./UtilsAvx2.h"
 
 // forward declarations to asmjit
 namespace asmjit {

--- a/src/ExecuteKernel.cc
+++ b/src/ExecuteKernel.cc
@@ -4,7 +4,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-#include "ExecuteKernel.h"
+#include "./ExecuteKernel.h"
 #include "fbgemm/Fbgemm.h"
 #include "fbgemm/Utils.h"
 

--- a/src/ExecuteKernel.h
+++ b/src/ExecuteKernel.h
@@ -6,6 +6,6 @@
  */
 #pragma once
 #include <cstdint>
-#include "ExecuteKernelGeneric.h"
-#include "ExecuteKernelU8S8.h"
+#include "./ExecuteKernelGeneric.h"
+#include "./ExecuteKernelU8S8.h"
 #include "fbgemm/Fbgemm.h"

--- a/src/ExecuteKernelGeneric.h
+++ b/src/ExecuteKernelGeneric.h
@@ -6,7 +6,7 @@
  */
 #pragma once
 #include <cstdint>
-#include "GenerateKernel.h"
+#include "./GenerateKernel.h"
 #include "fbgemm/Fbgemm.h"
 
 namespace fbgemm {

--- a/src/ExecuteKernelU8S8.cc
+++ b/src/ExecuteKernelU8S8.cc
@@ -4,7 +4,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-#include "ExecuteKernelU8S8.h"
+#include "./ExecuteKernelU8S8.h"
 #include <cpuinfo.h>
 #include <chrono>
 

--- a/src/ExecuteKernelU8S8.h
+++ b/src/ExecuteKernelU8S8.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 #pragma once
-#include "ExecuteKernel.h"
+#include "./ExecuteKernel.h"
 
 namespace fbgemm {
 

--- a/src/Fbgemm.cc
+++ b/src/Fbgemm.cc
@@ -8,7 +8,7 @@
 #include <cpuinfo.h>
 #include <stdexcept>
 #include <functional>
-#include "ExecuteKernel.h"
+#include "./ExecuteKernel.h"
 
 #ifdef FBGEMM_MEASURE_TIME_BREAKDOWN
 double packing_time = 0.0;

--- a/src/FbgemmFP16.cc
+++ b/src/FbgemmFP16.cc
@@ -13,8 +13,8 @@
 #include <cmath>
 #include <utility>
 
-#include "FbgemmFP16UKernelsAvx2.h"
-#include "FbgemmFP16UKernelsAvx512.h"
+#include "./FbgemmFP16UKernelsAvx2.h"
+#include "./FbgemmFP16UKernelsAvx512.h"
 
 using namespace std;
 

--- a/src/FbgemmFP16UKernelsAvx2.cc
+++ b/src/FbgemmFP16UKernelsAvx2.cc
@@ -4,7 +4,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-#include "FbgemmFP16UKernelsAvx2.h"
+#include "./FbgemmFP16UKernelsAvx2.h"
 
 namespace fbgemm {
 

--- a/src/FbgemmFP16UKernelsAvx512.cc
+++ b/src/FbgemmFP16UKernelsAvx512.cc
@@ -4,7 +4,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-#include "FbgemmFP16UKernelsAvx512.h"
+#include "./FbgemmFP16UKernelsAvx512.h"
 
 namespace fbgemm {
 

--- a/src/FbgemmFP16UKernelsAvx512.h
+++ b/src/FbgemmFP16UKernelsAvx512.h
@@ -6,7 +6,7 @@
  */
 #pragma once
 #include <cstdint>
-#include "FbgemmFP16UKernelsAvx2.h"
+#include "./FbgemmFP16UKernelsAvx2.h"
 #include "fbgemm/Types.h"
 
 namespace fbgemm {

--- a/src/FbgemmI8Depthwise3DAvx2.cc
+++ b/src/FbgemmI8Depthwise3DAvx2.cc
@@ -9,8 +9,8 @@
 #include <string>
 #include <tuple> // for tie
 
-#include "FbgemmI8DepthwiseAvx2-inl.h"
-#include "MaskAvx2.h"
+#include "./FbgemmI8DepthwiseAvx2-inl.h"
+#include "./MaskAvx2.h"
 
 using namespace std;
 

--- a/src/FbgemmI8Depthwise3x3Avx2.cc
+++ b/src/FbgemmI8Depthwise3x3Avx2.cc
@@ -8,7 +8,7 @@
 
 #include <string>
 
-#include "FbgemmI8Depthwise2DAvx2-inl.h"
+#include "./FbgemmI8Depthwise2DAvx2-inl.h"
 
 using namespace std;
 

--- a/src/FbgemmI8DepthwiseAvx2.cc
+++ b/src/FbgemmI8DepthwiseAvx2.cc
@@ -8,7 +8,7 @@
 
 #include <string>
 
-#include "FbgemmI8Depthwise2DAvx2-inl.h"
+#include "./FbgemmI8Depthwise2DAvx2-inl.h"
 
 using namespace std;
 

--- a/src/FbgemmI8DepthwisePerChannelQuantAvx2.cc
+++ b/src/FbgemmI8DepthwisePerChannelQuantAvx2.cc
@@ -8,7 +8,7 @@
 
 #include <string>
 
-#include "FbgemmI8Depthwise2DAvx2-inl.h"
+#include "./FbgemmI8Depthwise2DAvx2-inl.h"
 
 using namespace std;
 

--- a/src/FbgemmI8Spmdm.cc
+++ b/src/FbgemmI8Spmdm.cc
@@ -11,7 +11,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstring>
-#include "OptimizedKernelsAvx2.h"
+#include "./OptimizedKernelsAvx2.h"
 
 #ifdef FBGEMM_MEASURE_TIME_BREAKDOWN
 double spmdm_initial_time = 0.0;

--- a/src/FbgemmSpConv.cc
+++ b/src/FbgemmSpConv.cc
@@ -304,7 +304,7 @@ generateSpConv(
       to_exec;
   to_exec.reserve(9);
 
-  to_exec.push_back({sgemms[1][1], 0, 0, 0, groupsOf16[0][0]});
+  to_exec.push_back(make_tuple(sgemms[1][1], 0, 0, 0, groupsOf16[0][0]));
 
   for (int ky = 0; ky < 3; ++ky) {
     for (int kx = 0; kx < 3; ++kx) {
@@ -325,12 +325,13 @@ generateSpConv(
           del_in += 1;
         }
 
-        to_exec.push_back({sgemms[ky][kx],
-                           // When ACC_T == int32_t, 4 rows are interleaved in B
-                           del_in * (is_same<ACC_T, int32_t>::value ? 4 : 1),
-                           del_out,
-                           maskOffsets[ky != 1][kx != 1],
-                           groupsOf16[ky != 1][kx != 1]});
+        to_exec.push_back(make_tuple(
+            sgemms[ky][kx],
+            // When ACC_T == int32_t, 4 rows are interleaved in B
+            del_in * (is_same<ACC_T, int32_t>::value ? 4 : 1),
+            del_out,
+            maskOffsets[ky != 1][kx != 1],
+            groupsOf16[ky != 1][kx != 1]));
       }
     }
   }

--- a/src/GenerateKernel.h
+++ b/src/GenerateKernel.h
@@ -12,7 +12,7 @@
 #include <sstream>
 #include <string>
 #include <tuple>
-#include "CodeCache.h"
+#include "./CodeCache.h"
 #include "fbgemm/Fbgemm.h"
 /*#define FBGEMM_LOG_CODE 1*/
 

--- a/src/GenerateKernelU8S8S32ACC16.cc
+++ b/src/GenerateKernelU8S8S32ACC16.cc
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include <iostream>
-#include "GenerateKernel.h"
+#include "./GenerateKernel.h"
 
 namespace fbgemm {
 

--- a/src/GenerateKernelU8S8S32ACC16Avx512.cc
+++ b/src/GenerateKernelU8S8S32ACC16Avx512.cc
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include <iostream>
-#include "GenerateKernel.h"
+#include "./GenerateKernel.h"
 
 namespace fbgemm {
 

--- a/src/GenerateKernelU8S8S32ACC16Avx512VNNI.cc
+++ b/src/GenerateKernelU8S8S32ACC16Avx512VNNI.cc
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include <iostream>
-#include "GenerateKernel.h"
+#include "./GenerateKernel.h"
 
 namespace fbgemm {
 

--- a/src/GenerateKernelU8S8S32ACC32.cc
+++ b/src/GenerateKernelU8S8S32ACC32.cc
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include <iostream>
-#include "GenerateKernel.h"
+#include "./GenerateKernel.h"
 
 namespace fbgemm {
 

--- a/src/GenerateKernelU8S8S32ACC32Avx512.cc
+++ b/src/GenerateKernelU8S8S32ACC32Avx512.cc
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include <iostream>
-#include "GenerateKernel.h"
+#include "./GenerateKernel.h"
 
 namespace fbgemm {
 

--- a/src/GenerateKernelU8S8S32ACC32Avx512VNNI.cc
+++ b/src/GenerateKernelU8S8S32ACC32Avx512VNNI.cc
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include <iostream>
-#include "GenerateKernel.h"
+#include "./GenerateKernel.h"
 
 namespace fbgemm {
 

--- a/src/GroupwiseConv.h
+++ b/src/GroupwiseConv.h
@@ -15,7 +15,7 @@
 #include <string>
 #include <tuple>
 #include <type_traits>
-#include "CodeCache.h"
+#include "./CodeCache.h"
 #include "fbgemm/ConvUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "fbgemm/Utils.h"

--- a/src/GroupwiseConvAcc32Avx2.cc
+++ b/src/GroupwiseConvAcc32Avx2.cc
@@ -13,10 +13,10 @@
 #include <stdexcept>
 #include <tuple>
 #include <type_traits>
-#include "CodeGenHelpers.h"
-#include "GroupwiseConv.h"
-#include "RefImplementations.h"
-#include "TransposeUtils.h"
+#include "./CodeGenHelpers.h"
+#include "./GroupwiseConv.h"
+#include "./RefImplementations.h"
+#include "./TransposeUtils.h"
 #include "fbgemm/Fbgemm.h"
 
 namespace fbgemm {

--- a/src/OptimizedKernelsAvx2.cc
+++ b/src/OptimizedKernelsAvx2.cc
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "OptimizedKernelsAvx2.h"
+#include "./OptimizedKernelsAvx2.h"
 #include <immintrin.h>
 
 using namespace std;

--- a/src/PackAWithIm2Col.cc
+++ b/src/PackAWithIm2Col.cc
@@ -11,7 +11,7 @@
 #include <iostream>
 #include <numeric>
 
-#include "OptimizedKernelsAvx2.h"
+#include "./OptimizedKernelsAvx2.h"
 #include "fbgemm/Fbgemm.h"
 
 namespace fbgemm {

--- a/src/PackAWithQuantRowOffset.cc
+++ b/src/PackAWithQuantRowOffset.cc
@@ -11,7 +11,7 @@
 #include <iomanip>
 #include <iostream>
 #include <stdexcept>
-#include "OptimizedKernelsAvx2.h"
+#include "./OptimizedKernelsAvx2.h"
 #include "fbgemm/Fbgemm.h"
 #include "fbgemm/QuantUtilsAvx2.h"
 

--- a/src/PackAWithRowOffset.cc
+++ b/src/PackAWithRowOffset.cc
@@ -10,7 +10,7 @@
 #include <iomanip>
 #include <iostream>
 #include <stdexcept>
-#include "OptimizedKernelsAvx2.h"
+#include "./OptimizedKernelsAvx2.h"
 #include "fbgemm/Fbgemm.h"
 
 namespace fbgemm {

--- a/src/PackDepthwiseConvMatrixAvx2.cc
+++ b/src/PackDepthwiseConvMatrixAvx2.cc
@@ -8,7 +8,7 @@
 
 #include <immintrin.h>
 
-#include "MaskAvx2.h"
+#include "./MaskAvx2.h"
 #include "fbgemm/UtilsAvx2.h"
 
 using namespace std;

--- a/src/PackWeightMatrixForGConv.cc
+++ b/src/PackWeightMatrixForGConv.cc
@@ -8,7 +8,7 @@
 #include <cassert>
 #include <iomanip>
 #include <numeric>
-#include "RefImplementations.h"
+#include "./RefImplementations.h"
 #include "fbgemm/Fbgemm.h"
 
 namespace fbgemm {

--- a/src/QuantUtilsAvx2.cc
+++ b/src/QuantUtilsAvx2.cc
@@ -10,7 +10,7 @@
 #include <algorithm> //for std::min/std::max
 #include <cmath> //for nearbyint
 #include <limits> //for numeric_limits
-#include "MaskAvx2.h"
+#include "./MaskAvx2.h"
 #include "fbgemm/Fbgemm.h" //for ReQuantizeOutput
 
 namespace fbgemm {

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -4,7 +4,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-#include "RefImplementations.h"
+#include "./RefImplementations.h"
 
 #include "fbgemm/Types.h"
 

--- a/src/TransposeUtilsAvx2.h
+++ b/src/TransposeUtilsAvx2.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <immintrin.h>
-#include "MaskAvx2.h"
+#include "./MaskAvx2.h"
 
 namespace fbgemm {
 

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -15,7 +15,7 @@
 #include <limits>
 #include <new>
 #include <stdexcept>
-#include "TransposeUtils.h"
+#include "./TransposeUtils.h"
 
 namespace fbgemm {
 

--- a/src/UtilsAvx2.cc
+++ b/src/UtilsAvx2.cc
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include <immintrin.h>
-#include "TransposeUtils.h"
-#include "TransposeUtilsAvx2.h"
+#include "./TransposeUtils.h"
+#include "./TransposeUtilsAvx2.h"
 
 namespace fbgemm {
 

--- a/src/UtilsAvx512.cc
+++ b/src/UtilsAvx512.cc
@@ -6,8 +6,8 @@
  */
 
 #include <immintrin.h>
-#include "TransposeUtils.h"
-#include "TransposeUtilsAvx2.h"
+#include "./TransposeUtils.h"
+#include "./TransposeUtilsAvx2.h"
 
 namespace fbgemm {
 

--- a/test/FP16Test.cc
+++ b/test/FP16Test.cc
@@ -12,7 +12,7 @@
 
 #include <gtest/gtest.h>
 
-#include "TestUtils.h"
+#include "./TestUtils.h"
 #include "bench/BenchUtils.h"
 #include "fbgemm/FbgemmFP16.h"
 #include "src/RefImplementations.h"

--- a/test/GConvTest.cc
+++ b/test/GConvTest.cc
@@ -16,8 +16,8 @@
 
 #include <gtest/gtest.h>
 
-#include "QuantizationHelpers.h"
-#include "TestUtils.h"
+#include "./QuantizationHelpers.h"
+#include "./TestUtils.h"
 #include "bench/BenchUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "src/RefImplementations.h"

--- a/test/I8SpmdmTest.cc
+++ b/test/I8SpmdmTest.cc
@@ -17,7 +17,7 @@
 #include <omp.h>
 #endif
 
-#include "TestUtils.h"
+#include "./TestUtils.h"
 #include "bench/BenchUtils.h"
 #include "fbgemm/FbgemmI8Spmdm.h"
 #include "src/RefImplementations.h"

--- a/test/Im2ColFusedRequantizeTest.cc
+++ b/test/Im2ColFusedRequantizeTest.cc
@@ -14,7 +14,7 @@
 
 #include <gtest/gtest.h>
 
-#include "TestUtils.h"
+#include "./TestUtils.h"
 #include "bench/AlignedVec.h"
 #include "bench/BenchUtils.h"
 #include "fbgemm/Fbgemm.h"

--- a/test/PackedRequantizeAcc16Test.cc
+++ b/test/PackedRequantizeAcc16Test.cc
@@ -17,8 +17,8 @@
 
 #include <gtest/gtest.h>
 
-#include "QuantizationHelpers.h"
-#include "TestUtils.h"
+#include "./QuantizationHelpers.h"
+#include "./TestUtils.h"
 #include "bench/BenchUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "src/RefImplementations.h"

--- a/test/PackedRequantizeTest.cc
+++ b/test/PackedRequantizeTest.cc
@@ -16,8 +16,8 @@
 
 #include <gtest/gtest.h>
 
-#include "QuantizationHelpers.h"
-#include "TestUtils.h"
+#include "./QuantizationHelpers.h"
+#include "./TestUtils.h"
 #include "bench/BenchUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "src/RefImplementations.h"

--- a/test/QuantizationHelpers.cc
+++ b/test/QuantizationHelpers.cc
@@ -4,7 +4,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-#include "QuantizationHelpers.h"
+#include "./QuantizationHelpers.h"
 #include <algorithm>
 #include <cassert>
 #include <cmath>

--- a/test/RequantizeOnlyTest.cc
+++ b/test/RequantizeOnlyTest.cc
@@ -13,7 +13,7 @@
 
 #include <gtest/gtest.h>
 
-#include "TestUtils.h"
+#include "./TestUtils.h"
 #include "bench/BenchUtils.h"
 #include "fbgemm/Fbgemm.h"
 

--- a/test/TestUtils.cc
+++ b/test/TestUtils.cc
@@ -4,7 +4,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-#include "TestUtils.h"
+#include "./TestUtils.h"
 #include <gtest/gtest.h>
 #include "fbgemm/Fbgemm.h"
 

--- a/test/UniConvTest.cc
+++ b/test/UniConvTest.cc
@@ -11,8 +11,8 @@
 
 #include <gtest/gtest.h>
 
-#include "QuantizationHelpers.h"
-#include "TestUtils.h"
+#include "./QuantizationHelpers.h"
+#include "./TestUtils.h"
 #include "bench/BenchUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "src/RefImplementations.h"


### PR DESCRIPTION
Summary:
Add "./" for accessing the header files in the same directory to make Linter happy.

```
strings=(
    AlignedVec.h
    BenchUtils.h
    QuantizationHelpers.h
    TestUtils.h
    CodeCache.h
    CodeGenHelpers.h
    ExecuteKernelGeneric.h
    ExecuteKernel.h
    ExecuteKernelU8S8.h
    FbgemmFP16UKernelsAvx2_2.h
    FbgemmFP16UKernelsAvx2.h
    FbgemmFP16UKernelsAvx512.h
    FbgemmI8Depthwise2DAvx2-inl.h
    FbgemmI8DepthwiseAvx2.h
    FbgemmI8DepthwiseAvx2-inl.h
    FbgemmSpMM-inl.h
    GenerateKernel.h
    GroupwiseConv.h
    MaskAvx2.h
    OptimizedKernelsAvx2.h
    RefImplementations.h
    TransposeUtilsAvx2.h
    TransposeUtils.h
    ConvUtils.h
    FbgemmBuild.h
    FbgemmFP16.h
    Fbgemm.h
    FbgemmI64.h
    FbgemmI8DepthwiseAvx2.h
    FbgemmI8Spmdm.h
    FbgemmSpConv.h
    FbgemmSpMM.h
    OutputProcessing-inl.h
    PackingTraits-inl.h
    QuantUtilsAvx2.h
    QuantUtils.h
    Types.h
    UtilsAvx2.h
    Utils.h
)
for i in "${strings[@]}"; do
    echo $i
    replace_str=s:\"$i\":\"\.\/$i\":g
    find ./ -type f -exec sed -i -e $replace_str {} \;
done
```

Reviewed By: jspark1105

Differential Revision: D18568051

