### PR TITLE
Fused 8 bit Rowwise Sparse Lengths Sum (#191)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(FBGEMM_GENERIC_SRCS src/ExecuteKernel.cc
                 src/FbgemmI8Spmdm.cc
                 src/FbgemmSpConv.cc
                 src/FbgemmSpMM.cc
+                src/Fused8BitRowwiseEmbeddingLookup.cc
                 src/GenerateKernelU8S8S32ACC16.cc
                 src/GenerateKernelU8S8S32ACC16Avx512.cc
                 src/GenerateKernelU8S8S32ACC16Avx512VNNI.cc

--- a/bench/Fused8BitRowwiseEmbeddingBenchmark.cc
+++ b/bench/Fused8BitRowwiseEmbeddingBenchmark.cc
@@ -1,0 +1,357 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <immintrin.h>
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <random>
+#include <set>
+#include <vector>
+
+#include "fbgemm/Fbgemm.h"
+#include "fbgemm/Utils.h"
+#include "src/RefImplementations.h"
+
+using namespace std;
+using namespace fbgemm;
+
+namespace {
+template <typename T>
+void llc_flush(std::vector<T>& v) {
+  constexpr int CACHE_LINE_SIZE = 64;
+  for (int i = 0; i < v.size(); i += CACHE_LINE_SIZE / sizeof(T)) {
+    _mm_clflush(&v[i]);
+  }
+}
+
+void llc_flush_fused_table(const uint8_t* table, int size) {
+  constexpr int CACHE_LINE_SIZE = 64;
+  for (int i = 0; i < size; i += CACHE_LINE_SIZE) {
+    _mm_clflush(&table[i]);
+  }
+}
+} // anonymous namespace
+
+void print_outupt(int rows, int embedding_dim, const float* output) {
+  for (int i = 0; i < rows; i++) {
+    std::cout << "output row: " << i << " : " << std::endl;
+    for (int ii = 0; ii < embedding_dim; ii++) {
+      std::cout << output[i * embedding_dim + ii] << ",";
+    }
+    std::cout << std::endl;
+  }
+}
+
+void print_fused_table(int rows, int embedding_dim, const uint8_t* table) {
+  for (int i = 0; i < rows; i++) {
+    std::cout << "row: " << i << " : " << std::endl;
+    for (int ii = 0; ii < embedding_dim; ii++) {
+      std::cout << (int)table[i * (embedding_dim + 2 * sizeof(float)) + ii]
+                << ",";
+    }
+    std::cout << std::endl;
+  }
+}
+
+static vector<vector<int>> GetInputs_() {
+  vector<vector<int>> input_dims = {
+      // batch size, number of rows of table, emb dim , avg lengthl
+      // TODO: Add more inputs
+      // Use these -- but they are slow.
+      //{100, 4000000, 32, 100},
+      // {10, 4000000, 64, 100},
+      // {10, 4000000, 128, 100},
+      // {10, 4000000, 256, 100},
+      // Use these for debugging
+       {2, 16, 128, 10},
+       {10, 4000, 128, 100},
+       {10, 4000, 128, 100},
+       {10, 4000, 128, 100},
+  };
+  return input_dims;
+}
+
+int run_benchmark(
+    int batch_size,
+    int num_unique_ids,
+    int embedding_dim,
+    int average_len,
+    bool normalize_by_lengths,
+    bool use_32_bit_indices = false,
+    bool prefetch = false) {
+  // Create embedding table
+  vector<uint8_t> embedding_table(
+      num_unique_ids * (embedding_dim + 2 * sizeof(float)));
+  default_random_engine generator;
+  normal_distribution<float> embedding_distribution;
+
+  uint8_t* fused_embedding_table =
+      new uint8_t[num_unique_ids * (embedding_dim + 2 * sizeof(float))];
+  for (int i = 0; i < num_unique_ids; i++) {
+    for (int ii = 0; ii < embedding_dim; ii++) {
+      fused_embedding_table[i * (embedding_dim + 2 * sizeof(float)) + ii] = 2;
+    }
+    float* scale_bias = reinterpret_cast<float*>(
+        fused_embedding_table + i * (embedding_dim + 2 * sizeof(float)) +
+        embedding_dim);
+    scale_bias[0] = 2.0;
+    scale_bias[1] = 1.0;
+  }
+
+  // print_fused_table(num_unique_ids, embedding_dim, fused_embedding_table);
+
+  // Generate lengths
+  uniform_int_distribution<int> length_distribution(1, 2 * average_len + 1);
+  vector<int> lengths(batch_size);
+  for (int i = 0; i < batch_size; ++i) {
+    lengths[i] = length_distribution(generator);
+  }
+
+  // Compute the number of indices
+  int lengths_sum = accumulate(lengths.begin(), lengths.end(), 0);
+  cout << "lengths_sum " << lengths_sum << endl;
+
+  // Generate indices
+  vector<int64_t> indices;
+  vector<int32_t> indices_32;
+
+  vector<int> container(num_unique_ids);
+  map<int64_t, set<int>> dedup_map; // index -> set(output index)
+
+  // please note we generate unique indices
+  for (int i = 0; i < batch_size; ++i) {
+    iota(container.begin(), container.end(), 0);
+    random_shuffle(container.begin(), container.end());
+    copy(
+        container.begin(),
+        container.begin() + lengths[i],
+        back_inserter(indices));
+  }
+  copy(begin(indices), end(indices), back_inserter(indices_32));
+
+  // Generate weights
+  vector<float> weights(lengths_sum);
+  for (int i = 0; i < lengths_sum; ++i) {
+    weights[i] = embedding_distribution(generator);
+  }
+
+  vector<float> output_sls_ref(batch_size * embedding_dim);
+  vector<float> output_slws_ref(output_sls_ref.size()),
+      output_sls(output_sls_ref.size()), output_slws(output_sls_ref.size());
+
+  chrono::time_point<chrono::system_clock> t_begin, t_end;
+  double t;
+
+  constexpr int NUM_WARMUP = 4;
+  constexpr int NUM_ITER = 10;
+  // Only counts the number of bytes for reading embedding table and ignore
+  // others. Should be good enough as long as embdding_dim is big enough.
+  double bytes = static_cast<double>(NUM_ITER) * lengths_sum *
+      (embedding_dim * sizeof(uint8_t) + 2 * sizeof(float));
+  double bytes_padded =
+      static_cast<double>(NUM_ITER) * lengths_sum * 64 *
+      static_cast<int>(
+          (embedding_dim * sizeof(uint8_t) + 2 * sizeof(float) + 63) / 64);
+
+  for (bool has_weight : {false, true}) {
+    vector<float>& output_ref = has_weight ? output_slws_ref : output_sls_ref;
+
+    for (int i = 0; i < NUM_WARMUP + NUM_ITER; ++i) {
+      if (use_32_bit_indices) {
+        fbgemm::
+            Fused8BitRowwiseEmbeddingLookup_ref<int32_t, uint8_t, float, false>(
+                embedding_dim,
+                batch_size,
+                lengths_sum,
+                num_unique_ids,
+                fused_embedding_table,
+                indices_32.data(),
+                lengths.data(),
+                has_weight ? weights.data() : nullptr,
+                normalize_by_lengths,
+                output_ref.data());
+
+      } else {
+        fbgemm::
+            Fused8BitRowwiseEmbeddingLookup_ref<int64_t, uint8_t, float, false>(
+                embedding_dim,
+                batch_size,
+                lengths_sum,
+                num_unique_ids,
+                fused_embedding_table,
+                indices.data(),
+                lengths.data(),
+                has_weight ? weights.data() : nullptr,
+                normalize_by_lengths,
+                output_ref.data());
+      }
+    }
+
+    vector<float>& output = has_weight ? output_slws : output_sls;
+    for (bool flush_cache : {false, true}) {
+      t = 0;
+      for (int i = 0; i < NUM_WARMUP + NUM_ITER; ++i) {
+        if (flush_cache) {
+          llc_flush(embedding_table);
+          llc_flush_fused_table(
+              fused_embedding_table, num_unique_ids * (embedding_dim + 8));
+          llc_flush(indices);
+          llc_flush(indices_32);
+          llc_flush(lengths);
+          llc_flush(weights);
+          llc_flush(output);
+        }
+
+        if (use_32_bit_indices) {
+          t_begin = chrono::system_clock::now();
+
+          fbgemm::Fused8BitRowwiseEmbeddingLookup<int32_t>(
+              embedding_dim,
+              batch_size,
+              lengths_sum,
+              num_unique_ids,
+              fused_embedding_table,
+              indices_32.data(),
+              lengths.data(),
+              has_weight ? weights.data() : nullptr,
+              normalize_by_lengths,
+              output.data(),
+              prefetch ? 16 : 0);
+
+          t_end = chrono::system_clock::now();
+
+        } else {
+          t_begin = chrono::system_clock::now();
+
+          fbgemm::Fused8BitRowwiseEmbeddingLookup<int64_t>(
+              embedding_dim,
+              batch_size,
+              lengths_sum,
+              num_unique_ids,
+              fused_embedding_table,
+              indices.data(),
+              lengths.data(),
+              has_weight ? weights.data() : nullptr,
+              normalize_by_lengths,
+              output.data(),
+              prefetch ? 16 : 0);
+
+          t_end = chrono::system_clock::now();
+        }
+
+        if (i >= NUM_WARMUP) {
+          t += chrono::duration<double>(t_end - t_begin).count();
+        }
+      }
+
+      // print_outupt(batch_size, embedding_dim, output.data());
+      // print_outupt(batch_size, embedding_dim, output_ref.data());
+      // Check correctness
+      if (!flush_cache) {
+        // vector<float>& output_ref =
+        //     has_weight ? output_slws_ref : output_sls_ref;
+        for (int i = 0; i < output.size(); ++i) {
+          assert(fabs(output[i] - output_ref[i]) < 1e-3);
+          if (fabs(output[i] - output_ref[i]) >= 1e-3) {
+            cout << i << " " << output[i] << " " << output_ref[i] << endl;
+          }
+        }
+      }
+
+      if (has_weight) {
+        cout << setw(16) << "SLW(WEIGHTED) ";
+      } else {
+        cout << setw(16) << "SLS ";
+      }
+      if (flush_cache) {
+        cout << setw(20) << "cache flushed";
+      } else {
+        cout << setw(20) << "cache not flushed";
+      }
+      if (prefetch) {
+        cout << setw(16) << "prefetch on";
+      } else {
+        cout << setw(16) << "prefetch off";
+      }
+
+      cout << setw(8) << "b/w" << setw(10) << bytes / 1e9 / t << " GB/s"
+           << setw(20) << "effective b/w: " << setw(16)
+           << bytes_padded / 1e9 / t << "GB/s" << setw(8) << " time "
+           << setw(16) << t << endl;
+    } // flush_cache
+  } // has_weight
+  return 0;
+}
+
+int main() {
+  int batch_size;
+  int num_unique_ids;
+  int embedding_dim;
+  int average_len;
+
+  vector<vector<int>> inputs(GetInputs_());
+
+  for (auto& input : inputs) {
+    assert(input.size() > 3);
+    batch_size = input[0];
+    num_unique_ids = input[1];
+    embedding_dim = input[2];
+    average_len = input[3];
+
+    cout << "batch size" << setw(6) << batch_size << setw(10) << "num rows"
+         << setw(16) << num_unique_ids << setw(10) << "emb dim" << setw(6)
+         << embedding_dim << setw(16) << "avg length" << setw(6) << average_len
+         << endl;
+    // args: batch sz, num rows, emb dim, avg len, normalize, use 32b, prefetch
+    cout << "64 bit indices, ";
+    run_benchmark(
+        batch_size, num_unique_ids, embedding_dim, average_len, false);
+
+    cout << "64 bit indices with prefetching, ";
+    run_benchmark(
+        batch_size,
+        num_unique_ids,
+        embedding_dim,
+        average_len,
+        false,
+        false,
+        true);
+
+    cout << "32 bit indices, ";
+    run_benchmark(
+        batch_size, num_unique_ids, embedding_dim, average_len, false, true);
+
+    cout << "32 bit indices with prefetching, ";
+    run_benchmark(
+        batch_size,
+        num_unique_ids,
+        embedding_dim,
+        average_len,
+        false,
+        true,
+        true);
+
+    // running with normalize by lengths
+    // run_benchmark(batch_size, num_unique_ids, embedding_dim, average_len,
+    // true); run_benchmark(
+    //     batch_size, num_unique_ids, embedding_dim, average_len, true, true);
+    // run_benchmark(
+    //     batch_size,
+    //     num_unique_ids,
+    //     embedding_dim,
+    //     average_len,
+    //     false,
+    //     true,
+    //     true);
+  }
+  return 0;
+}

--- a/include/fbgemm/Fbgemm.h
+++ b/include/fbgemm/Fbgemm.h
@@ -450,8 +450,9 @@ class FBGEMM_API PackBMatrix final
   /**
    * @brief Print the packed block.
    */
-  void printPackedMatrix(std::string name,
-                         const BlockingFactors* params = nullptr);
+  void printPackedMatrix(
+      std::string name,
+      const BlockingFactors* params = nullptr);
 
   /**
    * @return true if meta information like matrix shape is the same.
@@ -723,8 +724,7 @@ class FBGEMM_API PackAWithIm2Col
   /**
    * @return Size of row offset buffer in number of elements
    */
-  static int rowOffsetBufferSize(
-      const BlockingFactors* params = nullptr);
+  static int rowOffsetBufferSize(const BlockingFactors* params = nullptr);
 
   ~PackAWithIm2Col() {
     if (rowOffsetAllocatedHere) {
@@ -814,8 +814,7 @@ class FBGEMM_API PackAWithRowOffset final
   /**
    * @return size of row offset buffer in number of elements
    */
-  static int rowOffsetBufferSize(
-      const BlockingFactors* params = nullptr);
+  static int rowOffsetBufferSize(const BlockingFactors* params = nullptr);
 
   ~PackAWithRowOffset() {
     if (rowOffsetAllocatedHere) {
@@ -907,8 +906,7 @@ class FBGEMM_API PackAWithQuantRowOffset final
   /**
    * @return Size of row offset buffer in number of elements
    */
-  static int rowOffsetBufferSize(
-      const BlockingFactors* params = nullptr);
+  static int rowOffsetBufferSize(const BlockingFactors* params = nullptr);
 
   ~PackAWithQuantRowOffset() {
     if (rowOffsetAllocatedHere) {
@@ -1487,5 +1485,20 @@ FBGEMM_API int fbgemmConv(
 template <int SPATIAL_DIM = 2, typename ACC_T = std::int32_t>
 FBGEMM_API optimized_conv_t
 ConvFastPath(const conv_param_t<SPATIAL_DIM>& conv_p);
+
+template <typename IndexType = std::int64_t >
+FBGEMM_API bool Fused8BitRowwiseEmbeddingLookup(
+    const std::int64_t block_size,
+    const std::int64_t output_size,
+    const std::int64_t index_size,
+    const std::int64_t data_size,
+    const std::uint8_t* input,
+    const IndexType* indices,
+    const int* lengths,
+    const float* weights, // optional, can be null for non-weighted sum
+    bool normalize_by_lengths,
+    float* out,
+    int prefetch = 16, // prefetch distance -- 0 for no prefetch
+    bool IS_WEIGHT_POSITIONAL = false);
 
 } // namespace fbgemm

--- a/src/Fused8BitRowwiseEmbeddingLookup.cc
+++ b/src/Fused8BitRowwiseEmbeddingLookup.cc
@@ -1,0 +1,690 @@
+#include <asmjit/asmjit.h>
+#include <cpuinfo.h>
+#include <immintrin.h>
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <string>
+#include <tuple>
+#include "CodeCache.h"
+#include "RefImplementations.h"
+#include "fbgemm/Fbgemm.h"
+
+namespace fbgemm {
+
+namespace {
+namespace x86 = asmjit::x86;
+
+template <typename indxType = std::int64_t>
+class ReturnFunctionSignature {};
+
+template <>
+class ReturnFunctionSignature<std::int64_t> {
+ public:
+  using jit_fused8bitembedding_kernel = bool (*)(
+      std::int64_t output_size,
+      std::int64_t index_size,
+      std::int64_t data_size,
+      const uint8_t* input,
+      const std::int64_t* indices,
+      const int* lengths,
+      const float* weights,
+      float* out);
+};
+
+template <>
+class ReturnFunctionSignature<std::int32_t> {
+ public:
+  using jit_fused8bitembedding_kernel = bool (*)(
+      std::int64_t output_size,
+      std::int64_t index_size,
+      std::int64_t data_size,
+      const uint8_t* input,
+      const std::int32_t* indices,
+      const int* lengths,
+      const float* weights,
+      float* out);
+};
+
+template <typename indxType = std::int64_t>
+class GenFused8BitEmbeddingLookup {
+ public:
+  GenFused8BitEmbeddingLookup() {}
+  template <inst_set_t instSet>
+  typename ReturnFunctionSignature<indxType>::jit_fused8bitembedding_kernel
+  getOrCreate(
+      int block_size,
+      bool has_weight,
+      bool is_weight_positional,
+      bool normalize_by_lengths,
+      int prefetch);
+
+ private:
+  static asmjit::JitRuntime& runtime() {
+    static asmjit::JitRuntime rt; //< JIT Runtime for asmjit,
+                                  // depents on other static
+                                  // variables.  Required to prevent
+                                  // initialization order fiasco
+    return rt;
+  }
+
+  static std::mutex rtMutex_; ///< Controll access to runtime;
+
+  // The hash depends on embedding dimension (block size), weighted sls,
+  // positional weights, normalize by lenths, and prefetch distance
+  static CodeCache<
+      std::tuple<int, bool, bool, bool, int>,
+      typename ReturnFunctionSignature<indxType>::jit_fused8bitembedding_kernel>
+      codeCache_; ///< JIT Code Cache for reuse.
+
+}; // GenEmbeddingLookup
+
+template <typename indxType>
+std::mutex GenFused8BitEmbeddingLookup<indxType>::rtMutex_;
+
+template <typename indxType>
+CodeCache<
+    std::tuple<int, bool, bool, bool, int>,
+    typename ReturnFunctionSignature<indxType>::jit_fused8bitembedding_kernel>
+    GenFused8BitEmbeddingLookup<indxType>::codeCache_;
+
+// A trait class to handle ISA specifics
+template <inst_set_t instSet>
+struct InstSetTrait {};
+
+template <>
+struct InstSetTrait<inst_set_t::avx2> {
+  typedef x86::Ymm vec_reg_t;
+
+  constexpr static int VLEN = 8;
+  constexpr static int NUM_VEC_REG = 16;
+  static const vec_reg_t GetVecReg(int idx) {
+    return vec_reg_t(idx);
+  }
+};
+
+template <>
+struct InstSetTrait<inst_set_t::avx512> {
+  typedef x86::Zmm vec_reg_t;
+
+  constexpr static int VLEN = 16;
+  constexpr static int NUM_VEC_REG = 32;
+  static const vec_reg_t GetVecReg(int idx) {
+    return vec_reg_t(idx);
+  }
+};
+
+template <typename indxType>
+template <inst_set_t instSet>
+typename ReturnFunctionSignature<indxType>::jit_fused8bitembedding_kernel
+GenFused8BitEmbeddingLookup<indxType>::getOrCreate(
+    int block_size,
+    bool has_weight,
+    bool is_weight_positional,
+    bool normalize_by_lengths,
+    int prefetch) {
+  std::tuple<int, bool, bool, bool, int> kernelSig = std::make_tuple(
+      block_size,
+      has_weight,
+      is_weight_positional,
+      normalize_by_lengths,
+      prefetch);
+
+  return codeCache_.getOrCreate(
+      kernelSig,
+      [&]() -> typename ReturnFunctionSignature<
+                indxType>::jit_fused8bitembedding_kernel {
+        // TODO: Make this tunable
+        int pref_dist = prefetch;
+        bool areIndices64b = std::is_same<indxType, std::int64_t>::value;
+
+        asmjit::CodeHolder code;
+        code.init(runtime().codeInfo());
+        x86::Assembler assembler(&code);
+        x86::Emitter* a = assembler.as<x86::Emitter>();
+#if defined(FBGEMM_LOG_CODE)
+        std::string filename = "fused8bitsls";
+        filename += "_emd_dim_" + std::to_string(block_size);
+        if (!areIndices64b)
+          filename += "_32bit";
+        if (areIndices64b)
+          filename += "_64bit";
+        if (instSet == inst_set_t::avx2)
+          filename += "_avx2";
+        if (instSet == inst_set_t::avx512)
+          filename += "_avx512";
+        if (prefetch)
+          filename += "_prefetch";
+        if (has_weight)
+          filename += "_hasweight";
+        if (normalize_by_lengths)
+          filename += "_normalize_by_lengths";
+        filename += ".txt";
+        FILE* codeLogFile = fopen(filename.c_str(), "w");
+        asmjit::FileLogger* codeLogger = new asmjit::FileLogger(codeLogFile);
+        code.setLogger(codeLogger);
+#endif
+        // arguments to the function created
+        x86::Gp output_size = a->zdi();
+        // index_size will be overwritten to hold the end address of indices
+        x86::Gp index_size = a->zsi();
+        x86::Gp data_size = a->zdx();
+        x86::Gp input = a->zcx();
+        x86::Gp indices = a->gpz(8);
+        x86::Gp lengths = a->gpz(9);
+        x86::Gp weights = a->gpz(10);
+        x86::Gp out = a->gpz(11);
+
+        x86::Gp scratchReg1_ = a->gpz(12);
+        x86::Gp scratchReg1D_ = a->gpz(12).r32();
+        x86::Gp scratchReg2_ = a->gpz(13);
+        x86::Gp scratchReg3_ = a->gpz(15);
+        x86::Gpd lengths_R_ = a->gpz(14).r32();
+
+        asmjit::FuncDetail func;
+
+        func.init(asmjit::FuncSignatureT<
+                  bool,
+                  std::int64_t, // output_size
+                  std::int64_t, // index_size
+                  std::int64_t, // data_size
+                  const uint8_t*, // input
+                  const indxType*, // indices
+                  const int*, // lengths
+                  const float*, // weights
+                  float*>(asmjit::CallConv::kIdHost));
+
+        asmjit::FuncFrame frame;
+        frame.init(func);
+
+        if (instSet == inst_set_t::avx2) {
+          frame.setDirtyRegs(
+              x86::Reg::kGroupVec,
+              asmjit::Support::bitMask(0, 1, 2, 3, 4, 5, 6, 7) |
+                  asmjit::Support::bitMask(8, 9, 10, 11, 12, 13, 14, 15));
+        } else {
+          frame.setDirtyRegs(
+              x86::Reg::kGroupVec,
+              asmjit::Support::bitMask(0, 1, 2, 3, 4, 5, 6, 7) |
+                  asmjit::Support::bitMask(8, 9, 10, 11, 12, 13, 14, 15) |
+                  asmjit::Support::bitMask(16, 17, 18, 19, 20, 21, 22, 23) |
+                  asmjit::Support::bitMask(24, 25, 26, 27, 28, 29, 30, 31));
+        }
+
+        frame.setDirtyRegs(
+            x86::Reg::kGroupGp,
+            asmjit::Support::bitMask(8, 9, 10, 11, 12, 13, 14, 15));
+
+        asmjit::FuncArgsAssignment args(&func);
+        args.assignAll(
+            output_size,
+            index_size,
+            data_size,
+            input,
+            indices,
+            lengths,
+            weights,
+            out);
+
+        args.updateFuncFrame(frame);
+        frame.finalize();
+
+        a->emitProlog(frame);
+        a->emitArgsAssignment(frame, args);
+
+        InstSetTrait<instSet> inst_trait;
+        constexpr int vlen = inst_trait.VLEN;
+        constexpr int NUM_VEC_REG = inst_trait.NUM_VEC_REG;
+        int unroll_factor = NUM_VEC_REG;
+
+        typedef typename InstSetTrait<instSet>::vec_reg_t vec_reg_t;
+
+        int num_vec_regs_per_block = (block_size + vlen - 1) / vlen;
+        int remainder = block_size % vlen;
+
+        vec_reg_t scale_vreg; // holds scale
+        vec_reg_t bias_vreg; // holds bias
+        vec_reg_t w_vreg; // for weighted sls -- weights
+        vec_reg_t
+            vlen_inv_vreg; // used for normalize by lengths -- 1/ lengths[i]
+        vec_reg_t temp_vreg_cvt_uint2flt; // for converting uint8->int32->float
+        x86::Ymm mask_vreg; // mask for avx2
+        x86::Xmm temp_xmm; // a shadow xmm reg of temp_vreg_cvt_uint2flt
+        x86::Xmm vlen_inv_vreg_xmm; // a shadow xmm reg of vlen_inv_vreg
+
+        // We need 2 vec registers for 1. scale 2. bias
+        --unroll_factor;
+        scale_vreg = inst_trait.GetVecReg(unroll_factor);
+        --unroll_factor;
+        bias_vreg = inst_trait.GetVecReg(unroll_factor);
+
+        // We need 1 vec register to convert from uint8->int32->float
+        --unroll_factor;
+        temp_vreg_cvt_uint2flt = inst_trait.GetVecReg(unroll_factor);
+        if (instSet == inst_set_t::avx2) {
+          temp_xmm = x86::Xmm(temp_vreg_cvt_uint2flt.id());
+        }
+
+        if (has_weight) {
+          --unroll_factor;
+          w_vreg = inst_trait.GetVecReg(unroll_factor);
+        }
+
+        if (remainder) {
+          // AVX512 doesn't need to use vector register for masking
+          unroll_factor -= (instSet == inst_set_t::avx2 ? 2 : 1);
+          if (instSet == inst_set_t::avx2) {
+            mask_vreg = x86::ymm(unroll_factor + 1);
+          }
+        }
+
+        if (normalize_by_lengths) {
+          --unroll_factor;
+          vlen_inv_vreg = inst_trait.GetVecReg(
+              remainder ? unroll_factor + 1 : unroll_factor);
+          if (instSet == inst_set_t::avx2) {
+            vlen_inv_vreg_xmm = x86::Xmm(vlen_inv_vreg.id());
+          }
+        }
+
+        if (remainder) {
+          if (instSet == inst_set_t::avx2) {
+            a->lea(
+                x86::rsp,
+                x86::dword_ptr(x86::rsp, (int32_t)(-vlen * sizeof(int32_t))));
+            for (int i = 0; i < remainder; i++) {
+              a->mov(x86::dword_ptr(x86::rsp, i * sizeof(int32_t)), -1);
+            }
+            for (int i = remainder; i < vlen; i++) {
+              a->mov(x86::dword_ptr(x86::rsp, i * sizeof(int32_t)), 0);
+            }
+            a->vmovups(mask_vreg, x86::dword_ptr(x86::rsp));
+            a->lea(
+                x86::rsp,
+                x86::dword_ptr(x86::rsp, (int32_t)(vlen * sizeof(int32_t))));
+
+          } else {
+            a->mov(scratchReg1_, (1 << remainder) - 1);
+            a->kmovw(x86::k(1), scratchReg1_);
+          }
+        }
+
+        // Compute the end address of indices
+        a->imul(
+            scratchReg1_,
+            index_size,
+            static_cast<asmjit::Imm>(sizeof(indxType)));
+        a->add(scratchReg1_, indices);
+        a->mov(index_size, scratchReg1_);
+
+        asmjit::Label exit = a->newLabel();
+        asmjit::Label error = a->newLabel();
+        asmjit::Label LoopRangeIndexBegin = a->newLabel();
+        asmjit::Label LoopRangeIndexEnd = a->newLabel();
+
+        if (has_weight && is_weight_positional) {
+          a->mov(scratchReg3_, weights);
+        }
+
+        // rangeIndex loop begins (iterate output_size times)
+        a->bind(LoopRangeIndexBegin);
+        a->dec(output_size);
+        a->jl(LoopRangeIndexEnd);
+
+        if (normalize_by_lengths) {
+          asmjit::Label IfLengthsBegin = a->newLabel();
+          asmjit::Label IfLengthsEnd = a->newLabel();
+          a->bind(IfLengthsBegin);
+          a->cmp(x86::dword_ptr(lengths), 1);
+          a->vxorps(vlen_inv_vreg, vlen_inv_vreg, vlen_inv_vreg);
+          a->jl(IfLengthsEnd);
+
+          if (instSet == inst_set_t::avx2) {
+            a->mov(lengths_R_, 1);
+            a->cvtsi2ss(vlen_inv_vreg_xmm, lengths_R_);
+            a->cvtsi2ss(temp_xmm, x86::dword_ptr(lengths));
+            a->divss(vlen_inv_vreg_xmm, temp_xmm);
+            a->vpbroadcastd(vlen_inv_vreg, vlen_inv_vreg_xmm);
+          } else { // avx512
+            a->mov(lengths_R_, 1);
+            a->cvtsi2ss(x86::xmm0, lengths_R_);
+            a->vpbroadcastd(vlen_inv_vreg, x86::xmm0);
+            a->vpbroadcastd(temp_vreg_cvt_uint2flt, x86::dword_ptr(lengths));
+            a->vcvtdq2ps(temp_vreg_cvt_uint2flt, temp_vreg_cvt_uint2flt);
+            a->vdivps(vlen_inv_vreg, vlen_inv_vreg, temp_vreg_cvt_uint2flt);
+          }
+          a->bind(IfLengthsEnd);
+        }
+
+        for (int vec_idx = 0; vec_idx < num_vec_regs_per_block;
+             vec_idx += unroll_factor) {
+          int cur_unroll_factor =
+              std::min(unroll_factor, num_vec_regs_per_block - vec_idx);
+
+          // Initialize output regs
+          for (int v = 0; v < cur_unroll_factor; ++v) {
+            vec_reg_t out_vreg = inst_trait.GetVecReg(v);
+            a->vxorps(out_vreg, out_vreg, out_vreg);
+          }
+
+          a->mov(lengths_R_, x86::dword_ptr(lengths));
+
+          // Array out of bound check
+          a->imul(
+              scratchReg1_,
+              lengths_R_,
+              static_cast<asmjit::Imm>(sizeof(indxType)));
+
+          a->add(scratchReg1_, indices);
+          a->cmp(scratchReg1_, index_size);
+          a->jg(error);
+
+          asmjit::Label LoopDataIndexBegin = a->newLabel();
+          asmjit::Label LoopDataIndexEnd = a->newLabel();
+
+          if (has_weight && is_weight_positional) {
+            a->mov(weights, scratchReg3_);
+          }
+          // dataIndex loop begins (iterate lengths_R_ times)
+          a->bind(LoopDataIndexBegin);
+          a->dec(lengths_R_);
+          a->jl(LoopDataIndexEnd);
+
+          // Array out of bound check
+          if (areIndices64b) {
+            a->mov(scratchReg1_, x86::qword_ptr(indices));
+          } else {
+            a->mov(scratchReg1_.r32(), x86::dword_ptr(indices));
+          }
+          a->cmp(scratchReg1_, 0);
+          a->jl(error);
+          a->cmp(scratchReg1_, data_size);
+          a->jge(error);
+
+          int fused_block_size =
+              block_size * sizeof(uint8_t) + 2 * sizeof(float);
+          a->imul(scratchReg1_, static_cast<asmjit::Imm>(fused_block_size));
+
+          if (pref_dist) {
+            asmjit::Label pref_dist_reset_start = a->newLabel();
+            asmjit::Label pref_dist_reset_end = a->newLabel();
+            // out of bound handling for prefetch
+            a->mov(scratchReg2_, indices);
+            a->add(
+                scratchReg2_,
+                static_cast<asmjit::Imm>(pref_dist * sizeof(indxType)));
+            a->cmp(scratchReg2_, index_size);
+            a->jge(pref_dist_reset_start);
+
+            if (areIndices64b) {
+              a->mov(
+                  scratchReg2_,
+                  x86::qword_ptr(indices, pref_dist * sizeof(indxType)));
+            } else {
+              a->mov(
+                  scratchReg2_.r32(),
+                  x86::dword_ptr(indices, pref_dist * sizeof(indxType)));
+            }
+            // Keeping these out for now for perf
+            a->cmp(scratchReg2_, 0);
+            a->jl(pref_dist_reset_start);
+            a->cmp(scratchReg2_, data_size);
+            a->jge(pref_dist_reset_start);
+
+            // everything is okay, prefetch a few rows ahead
+            a->jmp(pref_dist_reset_end);
+
+            a->bind(pref_dist_reset_start);
+            // things are not okay just get the current row
+            // this can be improved to getting the max dist row.
+            if (areIndices64b) {
+              a->mov(scratchReg2_, x86::qword_ptr(indices));
+            } else {
+              a->mov(scratchReg2_.r32(), x86::dword_ptr(indices));
+            }
+
+            a->bind(pref_dist_reset_end);
+            // This has to be fused_block_size
+            a->imul(scratchReg2_, static_cast<asmjit::Imm>(fused_block_size));
+          }
+
+          a->add(indices, static_cast<asmjit::Imm>(sizeof(indxType)));
+
+          // broadcast the scale
+          auto scale_src = x86::dword_ptr(
+              input, scratchReg1_, 0, block_size * sizeof(uint8_t));
+          auto bias_src = x86::dword_ptr(
+              input,
+              scratchReg1_,
+              0,
+              block_size * sizeof(uint8_t) + sizeof(float));
+          a->vbroadcastss(scale_vreg, scale_src);
+          a->vbroadcastss(bias_vreg, bias_src);
+
+          if (has_weight) {
+            a->vbroadcastss(w_vreg, x86::dword_ptr(weights));
+            a->vmulps(scale_vreg, scale_vreg, w_vreg);
+            a->vmulps(bias_vreg, bias_vreg, w_vreg);
+            a->add(weights, static_cast<asmjit::Imm>(sizeof(float)));
+          }
+
+          // The main computation
+          for (int v = 0; v < cur_unroll_factor; ++v) {
+            auto src_addr = x86::dword_ptr(
+                input,
+                scratchReg1_,
+                0,
+                (vec_idx + v) * (vlen) * sizeof(uint8_t));
+            vec_reg_t out_vreg = inst_trait.GetVecReg(v);
+
+            // convert usigned 8-bit to 32bit int, then to float
+            // multiply with scale and then add with bias
+            if (remainder && vec_idx + v == num_vec_regs_per_block - 1 &&
+                instSet == inst_set_t::avx512) {
+              a->k(x86::k(1)).vpmovzxbd(temp_vreg_cvt_uint2flt, src_addr);
+              a->k(x86::k(1)).vcvtdq2ps(
+                  temp_vreg_cvt_uint2flt, temp_vreg_cvt_uint2flt);
+              a->k(x86::k(1)).vaddps(out_vreg, out_vreg, bias_vreg);
+              a->k(x86::k(1)).vfmadd231ps(
+                  out_vreg, temp_vreg_cvt_uint2flt, scale_vreg);
+            } else {
+              // We don't use a mask for AVX2 since we can use the extra
+              //"padding" of the 2 floats (= 8 chars) scale and bias
+              // this ensures we never access out of bound data
+              a->vpmovzxbd(temp_vreg_cvt_uint2flt, src_addr);
+              a->vcvtdq2ps(temp_vreg_cvt_uint2flt, temp_vreg_cvt_uint2flt);
+              a->vaddps(out_vreg, out_vreg, bias_vreg);
+              a->vfmadd231ps(out_vreg, temp_vreg_cvt_uint2flt, scale_vreg);
+            }
+
+            if (pref_dist && v % (64 / vlen) == 0) {
+              a->prefetcht0(x86::dword_ptr(
+                  input,
+                  scratchReg2_,
+                  0,
+                  (vec_idx + v) * vlen * sizeof(uint8_t)));
+            }
+          }
+
+          a->jmp(LoopDataIndexBegin);
+          a->bind(LoopDataIndexEnd);
+
+          // This loop is for writing back out_vreg (results)
+          // back to memory
+          for (int v = 0; v < cur_unroll_factor; ++v) {
+            auto dst_addr =
+                x86::dword_ptr(out, (vec_idx + v) * vlen * sizeof(float));
+            vec_reg_t out_vreg = inst_trait.GetVecReg(v);
+
+            if (normalize_by_lengths) {
+              a->vmulps(out_vreg, out_vreg, vlen_inv_vreg);
+            }
+
+            if (remainder && vec_idx + v == num_vec_regs_per_block - 1) {
+              if (instSet == inst_set_t::avx2) {
+                a->vmaskmovps(dst_addr, mask_vreg, x86::Ymm(out_vreg.id()));
+              } else {
+                a->k(x86::k(1)).vmovups(dst_addr, out_vreg);
+              }
+            } else {
+              a->vmovups(dst_addr, out_vreg);
+            }
+          }
+
+          if (vec_idx + unroll_factor < num_vec_regs_per_block) {
+            // Reset lengths_R_, indices, weights to run the dataIndex loop
+            // again
+            a->mov(lengths_R_, x86::dword_ptr(lengths));
+
+            if (has_weight) {
+              a->imul(
+                  scratchReg1_,
+                  lengths_R_,
+                  static_cast<asmjit::Imm>(sizeof(float)));
+              a->sub(weights, scratchReg1_);
+              a->imul(
+                  scratchReg1_,
+                  static_cast<asmjit::Imm>(sizeof(indxType) / sizeof(float)));
+              a->sub(indices, scratchReg1_);
+            } else {
+              a->imul(
+                  scratchReg1_,
+                  lengths_R_,
+                  static_cast<asmjit::Imm>(sizeof(indxType)));
+              a->sub(indices, scratchReg1_);
+            }
+          }
+        }
+
+        a->add(lengths, static_cast<asmjit::Imm>(sizeof(int)));
+        a->add(out, static_cast<asmjit::Imm>(block_size * sizeof(float)));
+
+        a->jmp(LoopRangeIndexBegin);
+        a->bind(LoopRangeIndexEnd);
+
+        a->cmp(indices, index_size);
+        a->jne(error);
+        a->mov(x86::eax, true);
+        a->jmp(exit);
+        a->bind(error);
+        a->mov(x86::eax, false);
+        a->bind(exit);
+
+        a->emitEpilog(frame);
+
+        // jit_fused8bitembedding_kernel fn;
+        typename ReturnFunctionSignature<
+            indxType>::jit_fused8bitembedding_kernel fn;
+        asmjit::Error err;
+        {
+          std::unique_lock<std::mutex> lock(rtMutex_);
+          err = runtime().add(&fn, &code);
+        }
+        if (err) {
+          std::cout << "Error: in fn add" << std::endl;
+          return nullptr;
+        }
+
+#if defined(FBGEMM_LOG_CODE)
+        fclose(codeLogFile);
+        delete codeLogger;
+#endif
+        return fn;
+      });
+}
+} // namespace
+
+template <typename indxType>
+bool Fused8BitRowwiseEmbeddingLookup(
+    const std::int64_t block_size,
+    const std::int64_t output_size,
+    const std::int64_t index_size,
+    const std::int64_t data_size,
+    const std::uint8_t* input,
+    const indxType* indices,
+    const int* lengths,
+    const float* weights, // optional, can be null for non-weighted sum
+    bool normalize_by_lengths,
+    float* out,
+    int prefetch,
+    bool IS_WEIGHT_POSITIONAL) {
+  static GenFused8BitEmbeddingLookup<indxType> kernel_generator;
+  if (!cpuinfo_initialize()) {
+    throw std::runtime_error("Failed to initialize cpuinfo!");
+  }
+  typename ReturnFunctionSignature<indxType>::jit_fused8bitembedding_kernel fn;
+  if (fbgemmHasAvx512Support()) {
+    fn = kernel_generator.template getOrCreate<inst_set_t::avx512>(
+        block_size,
+        weights ? true : false,
+        IS_WEIGHT_POSITIONAL,
+        normalize_by_lengths,
+        prefetch);
+  } else if (fbgemmHasAvx2Support()) {
+    fn = kernel_generator.template getOrCreate<inst_set_t::avx2>(
+        block_size,
+        weights ? true : false,
+        IS_WEIGHT_POSITIONAL,
+        normalize_by_lengths,
+        prefetch);
+  } else {
+#ifdef VLOG
+    VLOG(0) << "AVX2 or AVX512 not found, taking the slow path";
+#endif
+    auto success = Fused8BitRowwiseEmbeddingLookup_ref(
+        block_size,
+        output_size,
+        index_size,
+        data_size,
+        input,
+        indices,
+        lengths,
+        weights, // optional, can be null for non-weighted sum
+        normalize_by_lengths,
+        out);
+    return success;
+  }
+
+  auto success =
+      fn(output_size,
+         index_size,
+         data_size,
+         input,
+         indices,
+         lengths,
+         weights,
+         out);
+  return success;
+}
+
+template bool Fused8BitRowwiseEmbeddingLookup<std::int64_t>(
+    const std::int64_t block_size,
+    const std::int64_t output_size,
+    const std::int64_t index_size,
+    const std::int64_t data_size,
+    const std::uint8_t* input,
+    const std::int64_t* indices,
+    const int* lengths,
+    const float* weights, // optional, can be null for non-weighted sum
+    bool normalize_by_lengths,
+    float* out,
+    int prefetch,
+    bool IS_WEIGHT_POSITIONAL);
+
+template bool Fused8BitRowwiseEmbeddingLookup<std::int32_t>(
+    const std::int64_t block_size,
+    const std::int64_t output_size,
+    const std::int64_t index_size,
+    const std::int64_t data_size,
+    const std::uint8_t* input,
+    const std::int32_t* indices,
+    const int* lengths,
+    const float* weights, // optional, can be null for non-weighted sum
+    bool normalize_by_lengths,
+    float* out,
+    int prefetch,
+    bool IS_WEIGHT_POSITIONAL);
+
+} // namespace fbgemm

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -683,6 +683,92 @@ void transposeConvWeights(
   }
 }
 
+template <
+    typename IndexType,
+    typename InType,
+    typename OutType,
+    bool IS_WEIGHT_POSITIONAL>
+bool Fused8BitRowwiseEmbeddingLookup_ref(
+    const int64_t block_size,
+    const int64_t output_size,
+    const int64_t index_size,
+    const int64_t data_size,
+    const InType* input,
+    const IndexType* indices,
+    const int* lengths,
+    const float* weights, // optional, can be null for sum reducer
+    bool normalize_by_lengths,
+    OutType* out) {
+  // block_size is the number of elements and fused_block_size is the size of
+  // an entire row, including scale and bias.
+  const auto scale_bias_offset = 8 / sizeof(InType);
+  const int64_t fused_block_size = block_size + scale_bias_offset;
+  int64_t current = 0;
+  for (int m = 0; m < output_size; ++m) {
+    memset(out, 0, sizeof(OutType) * block_size);
+    if (current + lengths[m] > index_size) {
+      return false;
+    }
+    for (int i = 0; i < lengths[m]; ++i) {
+      int64_t idx = indices[current];
+      if (idx < 0 || idx >= data_size) {
+        return false;
+      }
+
+      const float* scale_bias = reinterpret_cast<const float*>(
+          input + fused_block_size * indices[current] + block_size);
+
+      float weight = 1.0f;
+      if (weights) {
+        weight = weights[IS_WEIGHT_POSITIONAL ? i : current];
+      }
+      const float scale = weight * scale_bias[0];
+      const float bias = weight * scale_bias[1];
+
+      for (int j = 0; j < block_size; ++j) {
+        out[j] = std::fma(
+            scale,
+            input[fused_block_size * indices[current] + j],
+            out[j] + bias);
+      }
+
+      ++current;
+    }
+    if (normalize_by_lengths && lengths[m]) {
+      float scale = 1.f / lengths[m];
+      for (int j = 0; j < block_size; ++j) {
+        out[j] *= scale;
+      }
+    }
+    out += block_size;
+  }
+  return true;
+}
+
+template bool Fused8BitRowwiseEmbeddingLookup_ref(
+    const std::int64_t block_size,
+    const std::int64_t output_size,
+    const std::int64_t index_size,
+    const std::int64_t data_size,
+    const uint8_t* input,
+    const std::int64_t* indices,
+    const int* lengths,
+    const float* weights, // optional, can be null for non-weighted sum
+    bool normalize_by_lengths,
+    float* out);
+
+template bool Fused8BitRowwiseEmbeddingLookup_ref(
+    const std::int64_t block_size,
+    const std::int64_t output_size,
+    const std::int64_t index_size,
+    const std::int64_t data_size,
+    const uint8_t* input,
+    const std::int32_t* indices,
+    const int* lengths,
+    const float* weights, // optional, can be null for non-weighted sum
+    bool normalize_by_lengths,
+    float* out);
+
 template void transposeConvWeights(
     const conv_param_t<2>& conv_p,
     const std::int8_t* src,

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -225,4 +225,21 @@ FBGEMM_API void im2col_ref(
     std::int32_t A_zero_point,
     std::uint8_t* Ao);
 
+template <
+    typename IndexType,
+    typename InType,
+    typename OutType,
+    bool IS_WEIGHT_POSITIONAL = false>
+FBGEMM_API bool Fused8BitRowwiseEmbeddingLookup_ref(
+    const std::int64_t block_size,
+    const std::int64_t output_size,
+    const std::int64_t index_size,
+    const std::int64_t data_size,
+    const InType* input,
+    const IndexType* indices,
+    const int* lengths,
+    const float* weights, // optional, can be null for non-weighted sum
+    bool normalize_by_lengths,
+    OutType* out);
+
 } // namespace fbgemm

--- a/test/Fused8BitRowwiseEmbLookupTest.cc
+++ b/test/Fused8BitRowwiseEmbLookupTest.cc
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <algorithm>
+#include <ostream>
+#include <random>
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include "fbgemm/Fbgemm.h"
+#include "fbgemm/Utils.h"
+#include "src/RefImplementations.h"
+
+using namespace std;
+using namespace fbgemm;
+
+static vector<vector<int>> GetInputs_() {
+  vector<vector<int>> input_dims = {
+      // batch size, number of rows of table, emb dim , avg lengthl
+      {1, 8, 8, 4},
+      {2, 8, 16, 4},
+      {10, 4000, 32, 100},
+      {100, 4000, 32, 100},
+      {10, 4000, 64, 100},
+      {10, 4000, 128, 100},
+      {4, 400, 256, 10},
+      {10, 4000, 48, 100},
+      {10, 4000, 48, 100},
+      {10, 4000, 40, 100},
+      {10, 4000, 56, 100},
+      {10, 4000, 1, 100},
+      {10, 4000, 4, 100},
+      // These were  from C2 tests
+      {10, 40, 16, 10},
+      {10, 40, 85, 10},
+      {10, 40, 8, 10},
+      {10, 40, 96, 10},
+      {10, 40, 163, 10},
+  };
+  return input_dims;
+}
+
+vector<int> prefetch_distances{0, 16, 1000000};
+
+namespace {
+
+// tuple represents MB, IC, OC, IT, IH, IW, KH/KW, stride, pad
+class Fused8BitRowwiseEmbeddingLookupTest
+    : public testing::TestWithParam<
+          tuple<bool, bool, bool, int, bool, bool, bool>> {};
+}; // namespace
+
+INSTANTIATE_TEST_CASE_P(
+    InstantiationName,
+    Fused8BitRowwiseEmbeddingLookupTest,
+    ::testing::Combine(
+        ::testing::Bool(),
+        ::testing::Bool(),
+        ::testing::Values(false),
+        ::testing::ValuesIn(prefetch_distances),
+        ::testing::Bool(),
+        ::testing::Bool(),
+        ::testing::Bool()));
+
+TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
+  vector<vector<int>> inputs(GetInputs_());
+  bool isavx2, isIndex64b, is_wt_positional, use_weight, normalize_by_lengths,
+      empty_indices;
+  int prefetch;
+  tie(isavx2,
+      isIndex64b,
+      is_wt_positional,
+      prefetch,
+      use_weight,
+      normalize_by_lengths,
+      empty_indices) = GetParam();
+
+  if (!fbgemmHasAvx512Support()) {
+    isavx2 = true; // only use avx2
+  }
+
+  inst_set_t isa;
+  isa = isavx2 ? inst_set_t::avx2 : inst_set_t::avx512;
+  int batch_size, num_unique_ids, embedding_dim, average_len;
+
+  for (auto input : inputs) {
+    batch_size = input[0];
+    num_unique_ids = input[1];
+    embedding_dim = input[2];
+    average_len = input[3];
+
+    // Create embedding table
+    vector<uint8_t> embedding_table(
+        num_unique_ids * (embedding_dim + 2 * sizeof(float)));
+    default_random_engine generator;
+    normal_distribution<float> embedding_distribution;
+    uniform_int_distribution<int> entries(0, 16);
+
+    uint8_t* fused_embedding_table =
+        new uint8_t[num_unique_ids * (embedding_dim + 2 * sizeof(float))];
+    for (int i = 0; i < num_unique_ids; i++) {
+      for (int ii = 0; ii < embedding_dim; ii++) {
+        fused_embedding_table[i * (embedding_dim + 2 * sizeof(float)) + ii] =
+            entries(generator);
+      }
+      float* scale_bias = reinterpret_cast<float*>(
+          fused_embedding_table + i * (embedding_dim + 2 * sizeof(float)) +
+          embedding_dim);
+      scale_bias[0] = embedding_distribution(generator);
+      scale_bias[1] = embedding_distribution(generator);
+    }
+
+    // Generate lengths
+    uniform_int_distribution<int> length_distribution(1, average_len);
+    vector<int> lengths(batch_size);
+    for (int i = 0; i < batch_size; ++i) {
+      lengths[i] = length_distribution(generator);
+    }
+
+    if (empty_indices) {
+      for (int i = 0; i < batch_size; ++i) {
+        lengths[i] = 0;
+      }
+    }
+
+    // Compute the number of indices
+    int lengths_sum = accumulate(lengths.begin(), lengths.end(), 0);
+    cout << "lenths sum " << lengths_sum;
+
+    // Generate indices
+    vector<int64_t> indices;
+    vector<int32_t> indices_32;
+
+    uniform_int_distribution<int> index_entry(0, num_unique_ids - 1);
+    for (int i = 0; i < lengths_sum; ++i) {
+      indices.push_back(index_entry(generator));
+    }
+    // use same indices for 32b and 64b
+    copy(begin(indices), end(indices), back_inserter(indices_32));
+
+    // Generate weights
+    vector<float> weights(lengths_sum);
+    for (int i = 0; i < lengths_sum; ++i) {
+      weights[i] = embedding_distribution(generator);
+    }
+
+    vector<float> output_sls_ref(batch_size * embedding_dim);
+    vector<float> output_slws_ref(output_sls_ref.size()),
+        output_sls(output_sls_ref.size()), output_slws(output_sls_ref.size());
+
+    vector<float>& output_ref = use_weight ? output_slws_ref : output_sls_ref;
+    vector<float>& output = use_weight ? output_slws : output_sls;
+    if (isIndex64b) {
+      fbgemm::
+          Fused8BitRowwiseEmbeddingLookup_ref<int64_t, uint8_t, float, false>(
+              embedding_dim,
+              batch_size,
+              lengths_sum,
+              num_unique_ids,
+              fused_embedding_table,
+              empty_indices ? nullptr : indices.data(),
+              lengths.data(),
+              use_weight ? weights.data() : nullptr,
+              normalize_by_lengths,
+              output_ref.data());
+
+      fbgemm::Fused8BitRowwiseEmbeddingLookup<int64_t>(
+          embedding_dim,
+          batch_size,
+          lengths_sum,
+          num_unique_ids,
+          fused_embedding_table,
+          empty_indices ? nullptr : indices.data(),
+          lengths.data(),
+          use_weight ? weights.data() : nullptr,
+          normalize_by_lengths,
+          output.data(),
+          prefetch ? 16 : 0);
+
+    } else {
+      fbgemm::
+          Fused8BitRowwiseEmbeddingLookup_ref<int32_t, uint8_t, float, false>(
+              embedding_dim,
+              batch_size,
+              lengths_sum,
+              num_unique_ids,
+              fused_embedding_table,
+              empty_indices ? nullptr : indices_32.data(),
+              lengths.data(),
+              use_weight ? weights.data() : nullptr,
+              normalize_by_lengths,
+              output_ref.data());
+
+      fbgemm::Fused8BitRowwiseEmbeddingLookup<int32_t>(
+          embedding_dim,
+          batch_size,
+          lengths_sum,
+          num_unique_ids,
+          fused_embedding_table,
+          empty_indices ? nullptr : indices_32.data(),
+          lengths.data(),
+          use_weight ? weights.data() : nullptr,
+          normalize_by_lengths,
+          output.data(),
+          prefetch ? 16 : 0);
+    }
+    // Check correctness
+    output_ref = use_weight ? output_slws_ref : output_sls_ref;
+    for (int i = 0; i < output.size(); ++i) {
+      EXPECT_EQ(output[i], output_ref[i])
+          << "results differ at (" << i << ") reference: " << output_ref[i]
+          << ", FBGEMM: " << output[i] << " emb dim :" << embedding_dim;
+    }
+    delete[] fused_embedding_table;
+  } // end for input
+}


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/FBGEMM/pull/191

JIT fused 8 bit Sparse Length Sum.
Relevant workplace notes here:
https://fb.workplace.com/notes/protonu-basu/building-a-case-for-jiting-embedding-lookup-operators/445571922968637/

TO DO:
1. Change the name of the functions to reflect linear algebra ops. In this case sparse matrix - dense matrix muliplication. We should also mention de-quantization. Further more we should mention CSR format of sparse matrix.
~~1. CHANGE THE INTERFACE TO EXPOSE A FUNCTION CALL NOT A CLASS~~
~~2. WRITE FBGEMM SPECIFIC TEST CASE~~
~~3. WRITE FBGEMM SPECIFIC BENCHMARK~~
~~4. WRITE OUT JIT SPECIFIC TO FILES WITH MORE APPROPRIATE NAMES~~
~~5. VERIFY NORMALIZE BY LENGTH, THE DIV OPERATION THROWS DIFF AT TIMES, POSSIBLY DUE TO BENCHMARKING A LARGE NUMBER OF ITERATIONS~~
~~6. CLEAN UP C2 SIDE PERF BENCHMARK IF NEEDED~~

Differential Revision: D18572657

