### PR TITLE
Re-apply "D18566687: [fbgemm] Fix the OSS build issue for FP16Benchmark when MKL/BLAS is not available"

### DIFF
--- a/bench/FP16Benchmark.cc
+++ b/bench/FP16Benchmark.cc
@@ -20,9 +20,10 @@
 #include <omp.h>
 #endif
 
-#include "AlignedVec.h"
+#include "./AlignedVec.h"
 #include "bench/BenchUtils.h"
 #include "fbgemm/FbgemmFP16.h"
+#include "src/RefImplementations.h"
 
 using namespace std;
 using namespace fbgemm;
@@ -119,6 +120,21 @@ void performance_test() {
           beta,
           C_ref.data(),
           n);
+#else
+      cblas_sgemm_ref(
+          matrix_op_t::NoTranspose,
+          btran,
+          m,
+          n,
+          k,
+          alpha,
+          A.data(),
+          k,
+          B.data(),
+          (btran == matrix_op_t::NoTranspose) ? n : k,
+          beta,
+          C_ref.data(),
+          n);
 #endif
 #ifdef _OPENMP
 #pragma omp parallel
@@ -152,16 +168,18 @@ void performance_test() {
 #endif
     }
 
-#if defined(USE_MKL) || defined(USE_BLAS)
-    // Gold via MKL sgemm
 #if defined(USE_MKL)
+    // Gold via MKL sgemm
     type = "MKL_FP32";
-#else
+#elif defined(USE_BLAS)
     type = "BLAS_FP32";
+#else
+    type = "REF_FP32";
 #endif
 
     ttot = measureWithWarmup(
         [&]() {
+#if defined(USE_MKL) || defined(USE_BLAS)
           cblas_sgemm(
               CblasRowMajor,
               CblasNoTrans,
@@ -177,6 +195,22 @@ void performance_test() {
               beta,
               C_ref.data(),
               n);
+#else
+          cblas_sgemm_ref(
+              matrix_op_t::NoTranspose,
+              btran,
+              m,
+              n,
+              k,
+              alpha,
+              A.data(),
+              k,
+              B.data(),
+              (btran == matrix_op_t::NoTranspose) ? n : k,
+              beta,
+              C_ref.data(),
+              n);
+#endif
         },
         3,
         NITER,
@@ -193,7 +227,6 @@ void performance_test() {
         gflops,
         gbs);
     ((volatile char*)(llc.data()));
-#endif
 
     type = "FBP_" + std::string(typeid(btype).name());
 


### PR DESCRIPTION
Summary:
Original commit changeset: d0210b52d9e6

The original Diff D18566687 is reverted in D18571147. However, that Diff is not the real culprit for the OSS build failure.

The reason is in https://github.com/pytorch/FBGEMM/pull/195, we add the missing entry `src/FbgemmSpConv.cc` in CMakeLists.txt, which triggered more signals in OSS tests:
```
/root/project/src/FbgemmSpConv.cc:328:9: error: converting to 'std::vector<std::tuple<void (*)(const float*, float*, long unsigned int, const short unsigned int*, long unsigned int), int, int, int, int>, std::allocator<std::tuple<void (*)(const float*, float*, long unsigned int, const short unsigned int*, long unsigned int), int, int, int, int> > >::value_type {aka std::tuple<void (*)(const float*, float*, long unsigned int, const short unsigned int*, long unsigned int), int, int, int, int>}' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {void (*&)(const float*, float*, long unsigned int, const short unsigned int*, long unsigned int), int, int&, int&, int&}; <template-parameter-2-2> = void; _Elements = {void (*)(const float*, float*, long unsigned int, const short unsigned int*, long unsigned int), int, int, int, int}]'
         to_exec.push_back({sgemms[ky][kx],
         ^
```

The issue is quickly fixed in
https://github.com/pytorch/FBGEMM/pull/197, by using `make_tuple` to create the tuples.

Differential Revision: D18575250

