### PR TITLE
Enhance benchmark to include cache eviction and multi instance with OMP

### DIFF
--- a/bench/BenchUtils.cc
+++ b/bench/BenchUtils.cc
@@ -68,7 +68,7 @@ aligned_vector<float> getRandomSparseVector(
 
 void llc_flush(std::vector<char>& llc) {
   volatile char* data = llc.data();
-  for (int i = 0; i < llc.size(); i++) {
+  for (auto i = 0; i < llc.size(); i++) {
     data[i]++;
   }
 }

--- a/bench/BenchUtils.h
+++ b/bench/BenchUtils.h
@@ -7,6 +7,10 @@
 #pragma once
 #include <chrono>
 #include <vector>
+#include <functional>
+
+#include <immintrin.h>
+
 #ifdef _OPENMP
 #include <omp.h>
 #endif
@@ -26,20 +30,32 @@ void llc_flush(std::vector<char>& llc);
 int fbgemm_get_num_threads();
 int fbgemm_get_thread_num();
 
+template <typename T>
+void cache_evict(const T& vec) {
+  auto const size = vec.size();
+  auto const elemSize = sizeof(typename T::value_type);
+  auto const dataSize = size * elemSize;
+
+  const char* data = (const char*)vec.data();
+  for(auto i = 0; i < dataSize; i += 64) {
+    _mm_clflush((void*)&data[i]);
+  }
+}
+
 /**
- * @param llc if not nullptr, flush llc
+ * @param Fn functor to execute
+ * @param Fe data eviction functor
  */
-template <class Fn>
+template <class Fn, class Fe = std::function<void()>>
 double measureWithWarmup(
     Fn&& fn,
     int warmupIterations,
     int measuredIterations,
-    std::vector<char>* llc = nullptr,
+    Fe&& fe = [] () {},
     bool useOpenMP = false) {
   for (int i = 0; i < warmupIterations; ++i) {
-    if (llc) {
-      llc_flush(*llc);
-    }
+    // Evict data first
+    fe();
     fn();
   }
 
@@ -57,8 +73,9 @@ double measureWithWarmup(
       thread_id = omp_get_thread_num();
     }
 #endif
-    if (llc && thread_id == 0) {
-      llc_flush(*llc);
+
+    if (thread_id == 0) {
+      fe();
     }
 
 #ifdef _OPENMP

--- a/bench/Depthwise3DBenchmark.cc
+++ b/bench/Depthwise3DBenchmark.cc
@@ -198,7 +198,11 @@ int main() {
         },
         NWARMUP,
         NITER,
-        flush ? &llc : nullptr,
+        [&]() {
+          if (flush) {
+            llc_flush(llc);
+          }
+        },
         true /*useOpenMP*/);
 
     // correctness check

--- a/bench/DepthwiseBenchmark.cc
+++ b/bench/DepthwiseBenchmark.cc
@@ -303,7 +303,11 @@ int main() {
         },
         NWARMUP,
         NITER,
-        flush ? &llc : nullptr,
+        [&]() {
+          if (flush) {
+            llc_flush(llc);
+          }
+        },
         true /*useOpenMP*/);
 
     // correctness check

--- a/bench/FP16Benchmark.cc
+++ b/bench/FP16Benchmark.cc
@@ -28,14 +28,7 @@
 using namespace std;
 using namespace fbgemm;
 
-void performance_test() {
-  // cache flush
-  bool flush = true;
-  std::vector<char> llc;
-  if (flush) {
-    llc.resize(64L * 1024L * 1024L, 1.0);
-  }
-
+void performance_test(int num_instances, bool flush) {
   float alpha = 1.f, beta = 1.f;
   matrix_op_t btran = matrix_op_t::Transpose;
 
@@ -78,24 +71,43 @@ void performance_test() {
     int n = s[1];
     int k = s[2];
 
-    aligned_vector<float> C_ref(m * n, 1.f);
-    aligned_vector<float> C_fb(m * n, NAN);
-
     // initialize with small numbers
     aligned_vector<int> Aint(m * k);
     randFill(Aint, 0, 4);
-    aligned_vector<float> A(Aint.begin(), Aint.end());
+    vector<aligned_vector<float>> A;
+    for(int i = 0; i < num_instances; ++i) {
+      A.push_back(aligned_vector<float>(Aint.begin(), Aint.end()));
+    }
 
     aligned_vector<int> Bint(k * n);
     randFill(Bint, 0, 4);
-    aligned_vector<float> B(Bint.begin(), Bint.end());
-    PackedGemmMatrixFP16 Bp(btran, k, n, alpha, B.data());
+    vector<aligned_vector<float>> B;
+    for(int i = 0; i < num_instances; ++i) {
+      B.push_back(aligned_vector<float>(Bint.begin(), Bint.end()));
+    }
 
+
+    vector<unique_ptr<PackedGemmMatrixFP16>> Bp;
+    for(int i = 0; i < num_instances; ++i) {
+      Bp.push_back(
+        make_unique<PackedGemmMatrixFP16>(btran, k, n, alpha, B[i].data()));
+    }
+
+
+    vector<aligned_vector<float>> C_ref;
+    vector<aligned_vector<float>> C_fb;
     if (beta != 0.0f) {
-      aligned_vector<int> Cint(C_ref.size());
+      aligned_vector<int> Cint(m * n);
       randFill(Cint, 0, 4);
-      C_ref.assign(Cint.begin(), Cint.end());
-      C_fb = C_ref;
+      for(int i = 0; i < num_instances; ++i) {
+        C_ref.push_back(aligned_vector<float>(Cint.begin(), Cint.end()));
+        C_fb.push_back(aligned_vector<float>(Cint.begin(), Cint.end()));
+      }
+    } else {
+      for(int i = 0; i < num_instances; ++i) {
+        C_ref.push_back(aligned_vector<float>(m * n, 1.f));
+        C_fb.push_back(aligned_vector<float>(m * n, NAN));
+      }
     }
 
     double nflops = 2.0 * m * n * k;
@@ -113,12 +125,12 @@ void performance_test() {
           n,
           k,
           alpha,
-          A.data(),
+          A[0].data(),
           k,
-          B.data(),
+          B[0].data(),
           (btran == matrix_op_t::NoTranspose) ? n : k,
           beta,
-          C_ref.data(),
+          C_ref[0].data(),
           n);
 #else
       cblas_sgemm_ref(
@@ -128,40 +140,41 @@ void performance_test() {
           n,
           k,
           alpha,
-          A.data(),
+          A[0].data(),
           k,
-          B.data(),
+          B[0].data(),
           (btran == matrix_op_t::NoTranspose) ? n : k,
           beta,
-          C_ref.data(),
+          C_ref[0].data(),
           n);
 #endif
 #ifdef _OPENMP
-#pragma omp parallel
+#pragma omp parallel if (num_instances == 1)
 #endif
       {
-        int num_threads = fbgemm_get_num_threads();
-        int tid = fbgemm_get_thread_num();
+        int num_threads = num_instances == 1 ? fbgemm_get_num_threads() : 1;
+        int tid = num_instances == 1 ? fbgemm_get_thread_num() : 0;
         cblas_gemm_compute(
             matrix_op_t::NoTranspose,
             m,
-            A.data(),
-            Bp,
+            A[0].data(),
+            *Bp[0],
             beta,
-            C_fb.data(),
+            C_fb[0].data(),
             tid,
             num_threads);
       }
 
 #if defined(USE_MKL) || defined(USE_BLAS)
       // Compare results
-      for (auto i = 0; i < C_ref.size(); i++) {
-        if (std::abs(C_ref[i] - C_fb[i]) > 1e-3) {
+      for (auto i = 0; i < C_ref[0].size(); i++) {
+        if (std::abs(C_ref[0][i] - C_fb[0][i]) > 1e-3) {
           fprintf(
               stderr,
-              "Error: too high diff between fp32 ref %f and fp16 %f\n",
-              C_ref[i],
-              C_fb[i]);
+              "Error: too high diff between fp32 ref %f and fp16 %f at %d\n",
+              C_ref[0][i],
+              C_fb[0][i],
+              i);
           return;
         }
       }
@@ -179,6 +192,7 @@ void performance_test() {
 
     ttot = measureWithWarmup(
         [&]() {
+          int copy = num_instances == 1 ? 0 : fbgemm_get_thread_num();
 #if defined(USE_MKL) || defined(USE_BLAS)
           cblas_sgemm(
               CblasRowMajor,
@@ -188,12 +202,12 @@ void performance_test() {
               n,
               k,
               alpha,
-              A.data(),
+              A[copy].data(),
               k,
-              B.data(),
+              B[copy].data(),
               (btran == matrix_op_t::NoTranspose) ? n : k,
               beta,
-              C_ref.data(),
+              C_ref[copy].data(),
               n);
 #else
           cblas_sgemm_ref(
@@ -203,18 +217,27 @@ void performance_test() {
               n,
               k,
               alpha,
-              A.data(),
+              A[copy].data(),
               k,
-              B.data(),
+              B[copy].data(),
               (btran == matrix_op_t::NoTranspose) ? n : k,
               beta,
-              C_ref.data(),
+              C_ref[copy].data(),
               n);
 #endif
         },
         3,
         NITER,
-        flush ? &llc : nullptr);
+        [&]() {
+          if (flush) {
+            int copy = num_instances == 1 ? 0 : fbgemm_get_thread_num();
+            cache_evict(A[copy]);
+            cache_evict(B[copy]);
+            cache_evict(C_ref[copy]);
+          }
+        },
+        // Use OpenMP if num instances > 1
+        num_instances > 1);
 
     gflops = nflops / ttot / 1e9;
     gbs = nbytes / ttot / 1e9;
@@ -226,28 +249,44 @@ void performance_test() {
         k,
         gflops,
         gbs);
-    ((volatile char*)(llc.data()));
 
     type = "FBP_" + std::string(typeid(btype).name());
 
     ttot = measureWithWarmup(
         [&]() {
-          int num_threads = fbgemm_get_num_threads();
-          int tid = fbgemm_get_thread_num();
+          // When executing in data decomposition (single-instance) mode
+          // Different threads will access different regions of the same
+          // matrices. Thus, copy to be used is always 0. The numbers of
+          // threads would be the as number of threads in the parallel
+          // region.
+          // When running in functional decomposition (multi-instance) mode
+          // different matrices are used. The copy to be used selected by
+          // thread_id (thread_num), and the number of threads performance
+          // the compute of the same instance is 1.
+          int copy = num_instances == 1 ? 0 : fbgemm_get_thread_num();
+          int num_threads = num_instances == 1 ? fbgemm_get_num_threads() : 1;
+          int tid = num_instances == 1 ? fbgemm_get_thread_num() : 0;
 
           cblas_gemm_compute(
               matrix_op_t::NoTranspose,
               m,
-              A.data(),
-              Bp,
+              A[copy].data(),
+              *Bp[copy],
               beta,
-              C_fb.data(),
+              C_fb[copy].data(),
               tid,
               num_threads);
         },
         3,
         NITER,
-        flush ? &llc : nullptr,
+        [&]() {
+          if (flush) {
+            int copy = num_instances == 1 ? 0 : fbgemm_get_thread_num();
+            cache_evict(A[copy]);
+            cache_evict(*Bp[copy]);
+            cache_evict(C_fb[copy]);
+          }
+        },
         true /*useOpenMP*/);
 
     gflops = nflops / ttot / 1e9;
@@ -260,17 +299,57 @@ void performance_test() {
         k,
         gflops,
         gbs);
-    ((volatile char*)(llc.data()));
   }
 }
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
 #ifdef _OPENMP
-  // Use 1 thread unless OMP_NUM_THREADS is explicit set.
-  const char* val = getenv("OMP_NUM_THREADS");
-  if (val == nullptr || !*val) {
-    omp_set_num_threads(1);
+  const char* inst = getenv("GEMMBENCH_NUM_INSTANCES");
+  int num_instances = 1;
+  if (inst != nullptr && *inst) {
+    num_instances = std::max(atoi(inst), num_instances);
   }
+
+  for (auto i = 1; i < argc; ++i) {
+    static const char param[] = "--inst=";
+    const char* ptr = strstr(argv[i], param);
+    if (ptr) {
+      ptr += sizeof(param) - 1; // null terminated
+      num_instances = std::max(atoi(ptr), num_instances);
+    }
+  }
+  printf("Running %d instances\n", num_instances);
+  if (num_instances > 1) {
+      // Set-up execution for multi-instance mode
+      // Number of threads in OpenMP parallel region is explicitly
+      // set to the number of instances to be executed
+      // If not previosly set by KMP_AFFINITY env. variable
+      // threads are affinitized sequentially to logical processors
+      char env_var[1024];
+      sprintf(
+          env_var, "granularity=fine,explicit,proclist=[1-%d]", num_instances);
+      setenv("KMP_AFFINITY", env_var, 0); // Don't overide if already set
+      omp_set_num_threads(num_instances);
+  } else {
+    // When running single instance use OMP_NUM_THREADS to determine
+    // parallelism. Default behaviour is using a single thread.
+    // Use 1 thread unless OMP_NUM_THREADS is explicit set.
+    const char* val = getenv("OMP_NUM_THREADS");
+    if (val == nullptr || !*val) {
+      omp_set_num_threads(1);
+    }
+  }
+
 #endif
-  performance_test();
+
+  bool flush = true;
+  for (auto i = 1; i < argc; ++i) {
+    static const char param[] = "--no-flush";
+    const char* ptr = strstr(argv[i], param);
+    if (ptr) {
+      flush = false;
+    }
+  }
+
+  performance_test(num_instances, flush);
 }

--- a/bench/GEMMsBenchmark.cc
+++ b/bench/GEMMsBenchmark.cc
@@ -114,7 +114,11 @@ void performance_test() {
         },
         NWARMUP,
         NITER,
-        flush ? &llc : nullptr);
+        [&]() {
+          if (flush) {
+            llc_flush(llc);
+          }
+        });
     ttot *= 1e9; // convert to ns
 
     ((volatile char*)(llc.data()));

--- a/bench/I64Benchmark.cc
+++ b/bench/I64Benchmark.cc
@@ -69,7 +69,9 @@ int main() {
         },
         NWARMUP,
         NITER,
-        &llc);
+        [&]() {
+          llc_flush(llc);
+        });
 
     const double ops = 2.0 * m * n * k;
     cout << "Gops/s = " << ops / ttot / 1e9 << endl;
@@ -122,7 +124,9 @@ int main() {
         },
         NWARMUP,
         NITER,
-        &llc);
+        [&]() {
+          llc_flush(llc);
+        });
 
     cout << "Gops/s = " << ops / ttot / 1e9 << endl;
     compare_buffers(C_ref.data(), C_acc.data(), m, n, n, 5);

--- a/bench/PackedFloatInOutBenchmark.cc
+++ b/bench/PackedFloatInOutBenchmark.cc
@@ -160,7 +160,11 @@ void performance_test() {
         },
         NWARMUP,
         NITER,
-        flush ? &llc : nullptr);
+        [&]() {
+          if (flush) {
+            llc_flush(llc);
+          }
+        });
     ttot *= 1e9; // convert to ns
 
     ((volatile char*)(llc.data()));

--- a/bench/PackedRequantizeAcc16Benchmark.cc
+++ b/bench/PackedRequantizeAcc16Benchmark.cc
@@ -155,7 +155,11 @@ void performance_test() {
         },
         NWARMUP,
         NITER,
-        flush ? &llc : nullptr);
+        [&] () {
+          if (flush) {
+            llc_flush(llc);
+          }
+        });
     ttot *= 1e9; // convert to ns
 
     ((volatile char*)(llc.data()));

--- a/bench/PackedRequantizeAcc32Benchmark.cc
+++ b/bench/PackedRequantizeAcc32Benchmark.cc
@@ -160,7 +160,11 @@ void performance_test() {
         },
         NWARMUP,
         NITER,
-        flush ? &llc : nullptr);
+        [&]() {
+          if (flush) {
+            llc_flush(llc);
+          }
+        });
     ttot *= 1e9; // convert to ns
 
     ((volatile char*)(llc.data()));

--- a/bench/SpConvFP32Benchmark.cc
+++ b/bench/SpConvFP32Benchmark.cc
@@ -32,7 +32,14 @@ int main(int, char**) {
       double effective_flop = IY * IX * Cin * Cout * 9 * 2;
 
       auto secs = fbgemm::measureWithWarmup(
-          [&]() { fn(bData.data(), cData.data()); }, 5, 10, &llc);
+          [&]() {
+            fn(bData.data(), cData.data());
+          },
+          5,
+          10,
+          [&]() {
+            llc_flush(llc);
+          });
 
       double effective_gflops = effective_flop / secs / 1e9;
       cout << fnz << "," << effective_gflops << "," << fnz * effective_gflops

--- a/bench/SpConvI8Benchmark.cc
+++ b/bench/SpConvI8Benchmark.cc
@@ -47,7 +47,15 @@ int main(int, char**) {
       double effective_flop = IY * IX * Cin * Cout * KY * KX * 2;
 
       auto secs =
-          fbgemm::measureWithWarmup([&]() { fn(bptr, cptr); }, 5, 10, &llc);
+          fbgemm::measureWithWarmup(
+            [&]() {
+              fn(bptr, cptr);
+            },
+            5,
+            10,
+            [&]() {
+              llc_flush(llc);
+            });
 
       double effective_gflops = effective_flop / secs / 1e9;
       cout << fnz << "," << effective_gflops << "," << fnz * effective_gflops

--- a/bench/SpMMFP32Benchmark.cc
+++ b/bench/SpMMFP32Benchmark.cc
@@ -38,7 +38,14 @@ int main(int, char**) {
       constexpr int NWARMUP = 5;
       constexpr int NITER = 32;
       auto secs = measureWithWarmup(
-          [&]() { fn(bData.data(), cData.data(), 0); }, NWARMUP, NITER, &llc);
+          [&]() {
+            fn(bData.data(), cData.data(), 0);
+          },
+          NWARMUP,
+          NITER,
+          [&]() {
+            llc_flush(llc);
+          });
 
       auto secs_varying_n = measureWithWarmup(
           [&]() {
@@ -52,7 +59,9 @@ int main(int, char**) {
           },
           NWARMUP,
           NITER,
-          &llc);
+          [&]() {
+            llc_flush(llc);
+          });
 
       double effective_gflops = effective_flop / secs / 1e9;
       double effective_gflops_varying_n = effective_flop / secs_varying_n / 1e9;

--- a/bench/SpMMI8Benchmark.cc
+++ b/bench/SpMMI8Benchmark.cc
@@ -50,8 +50,15 @@ int main(int, char**) {
 
       constexpr int NWARMUP = 5;
       constexpr int NITER = 32;
-      auto secs =
-          measureWithWarmup([&]() { fn(bptr, cptr, 0); }, NWARMUP, NITER, &llc);
+      auto secs = measureWithWarmup(
+          [&]() {
+            fn(bptr, cptr, 0);
+          },
+          NWARMUP,
+          NITER,
+          [&]() {
+            llc_flush(llc);
+          });
 
       auto secs_varying_n = measureWithWarmup(
           [&]() {
@@ -60,7 +67,9 @@ int main(int, char**) {
           },
           NWARMUP,
           NITER,
-          &llc);
+          [&]() {
+            llc_flush(llc);
+          });
 
       cout << fnz << "," << (FLOPs / secs / 1e9) << ","
            << (fnz * FLOPs / secs / 1e9) << ","

--- a/include/fbgemm/FbgemmFP16.h
+++ b/include/fbgemm/FbgemmFP16.h
@@ -25,6 +25,9 @@ namespace fbgemm {
 /// internal packed blocked-row major format
 class PackedGemmMatrixFP16 {
  public:
+   using value_type = float16;
+   using size_type  = uint64_t;
+
   // takes smat input mamtrix in row-major format;
   // packs it into gemm-friendly blocked format;
   // allocate space and sets up all the internal variables;
@@ -231,6 +234,14 @@ class PackedGemmMatrixFP16 {
   }
   inline int kernelNumColBlocks() const {
     return kernel_ncol_blocks_;
+  }
+
+  const value_type* data() const {
+    return pmat_;
+  }
+
+  const uint64_t size() const {
+    return size_ / sizeof(value_type);
   }
 
   int nrow_, ncol_;


### PR DESCRIPTION
Summary:
Enhance FBGEMM benchmark to better cover cache eviction and allow execution of  multiple instances simultaneously with OpenMP.

Add runtime flags:
--no-flush - disable cache eviction
--inst=n - execute n instances in parallel on threads 1-n

Differential Revision: D18819759

