### PR TITLE
Adding FP 32 SLS, and unifying it with 8 Bit SLS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 #All the source files that either use avx2 instructions statically or JIT
 #avx2/avx512 instructions.
-set(FBGEMM_GENERIC_SRCS src/ExecuteKernel.cc
+set(FBGEMM_GENERIC_SRCS src/EmbeddingSpMDM.cc
+                src/ExecuteKernel.cc
                 src/ExecuteKernelU8S8.cc
                 src/Fbgemm.cc
                 src/FbgemmBfloat16Convert.cc
@@ -36,7 +37,6 @@ set(FBGEMM_GENERIC_SRCS src/ExecuteKernel.cc
                 src/FbgemmI8Spmdm.cc
                 src/FbgemmSpConv.cc
                 src/FbgemmSpMM.cc
-                src/Fused8BitRowwiseEmbeddingLookup.cc
                 src/GenerateKernelU8S8S32ACC16.cc
                 src/GenerateKernelU8S8S32ACC16Avx512.cc
                 src/GenerateKernelU8S8S32ACC16Avx512VNNI.cc

--- a/bench/EmbeddingSpMDM8BitBenchmark.cc
+++ b/bench/EmbeddingSpMDM8BitBenchmark.cc
@@ -1,0 +1,354 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <immintrin.h>
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <random>
+#include <set>
+#include <vector>
+
+#include "fbgemm/Fbgemm.h"
+#include "fbgemm/Utils.h"
+#include "src/RefImplementations.h"
+
+using namespace std;
+using namespace fbgemm;
+
+namespace {
+template <typename T>
+void llc_flush(std::vector<T>& v) {
+  constexpr int CACHE_LINE_SIZE = 64;
+  for (int i = 0; i < v.size(); i += CACHE_LINE_SIZE / sizeof(T)) {
+    _mm_clflush(&v[i]);
+  }
+}
+
+void llc_flush_fused_table(const uint8_t* table, int size) {
+  constexpr int CACHE_LINE_SIZE = 64;
+  for (int i = 0; i < size; i += CACHE_LINE_SIZE) {
+    _mm_clflush(&table[i]);
+  }
+}
+} // anonymous namespace
+
+void print_outupt(int rows, int embedding_dim, const float* output) {
+  for (int i = 0; i < rows; i++) {
+    std::cout << "output row: " << i << " : " << std::endl;
+    for (int ii = 0; ii < embedding_dim; ii++) {
+      std::cout << output[i * embedding_dim + ii] << ",";
+    }
+    std::cout << std::endl;
+  }
+}
+
+void print_fused_table(int rows, int embedding_dim, const uint8_t* table) {
+  for (int i = 0; i < rows; i++) {
+    std::cout << "row: " << i << " : " << std::endl;
+    for (int ii = 0; ii < embedding_dim; ii++) {
+      std::cout << (int)table[i * (embedding_dim + 2 * sizeof(float)) + ii]
+                << ",";
+    }
+    std::cout << std::endl;
+  }
+}
+
+static vector<vector<int>> GetInputs_() {
+  vector<vector<int>> input_dims = {
+      // batch size, number of rows of table, emb dim , avg lengthl
+      // TODO: Add more inputs
+      // Use these -- but they are slow.
+      //{100, 4000000, 32, 100},
+      // {10, 4000000, 64, 100},
+      // {10, 4000000, 128, 100},
+      // {10, 4000000, 256, 100},
+      // Use these for debugging
+      {2, 16, 128, 10},
+      {10, 4000, 128, 100},
+      {10, 4000, 128, 100},
+      {10, 4000, 128, 100},
+  };
+  return input_dims;
+}
+
+int run_benchmark(
+    int batch_size,
+    int num_unique_ids,
+    int embedding_dim,
+    int average_len,
+    bool normalize_by_lengths,
+    bool use_32_bit_indices = false,
+    bool prefetch = false) {
+  // Create embedding table
+  vector<uint8_t> embedding_table(
+      num_unique_ids * (embedding_dim + 2 * sizeof(float)));
+  default_random_engine generator;
+  normal_distribution<float> embedding_distribution;
+
+  uint8_t* fused_embedding_table =
+      new uint8_t[num_unique_ids * (embedding_dim + 2 * sizeof(float))];
+  for (int i = 0; i < num_unique_ids; i++) {
+    for (int ii = 0; ii < embedding_dim; ii++) {
+      fused_embedding_table[i * (embedding_dim + 2 * sizeof(float)) + ii] = 2;
+    }
+    float* scale_bias = reinterpret_cast<float*>(
+        fused_embedding_table + i * (embedding_dim + 2 * sizeof(float)) +
+        embedding_dim);
+    scale_bias[0] = 2.0;
+    scale_bias[1] = 1.0;
+  }
+
+  // print_fused_table(num_unique_ids, embedding_dim, fused_embedding_table);
+
+  // Generate lengths
+  uniform_int_distribution<int> length_distribution(1, 2 * average_len + 1);
+  vector<int> lengths(batch_size);
+  for (int i = 0; i < batch_size; ++i) {
+    lengths[i] = length_distribution(generator);
+  }
+
+  // Compute the number of indices
+  int lengths_sum = accumulate(lengths.begin(), lengths.end(), 0);
+  cout << "lengths_sum " << lengths_sum << endl;
+
+  // Generate indices
+  vector<int64_t> indices;
+  vector<int32_t> indices_32;
+
+  vector<int> container(num_unique_ids);
+  map<int64_t, set<int>> dedup_map; // index -> set(output index)
+
+  // please note we generate unique indices
+  for (int i = 0; i < batch_size; ++i) {
+    iota(container.begin(), container.end(), 0);
+    random_shuffle(container.begin(), container.end());
+    copy(
+        container.begin(),
+        container.begin() + lengths[i],
+        back_inserter(indices));
+  }
+  copy(begin(indices), end(indices), back_inserter(indices_32));
+
+  // Generate weights
+  vector<float> weights(lengths_sum);
+  for (int i = 0; i < lengths_sum; ++i) {
+    weights[i] = embedding_distribution(generator);
+  }
+
+  vector<float> output_sls_ref(batch_size * embedding_dim);
+  vector<float> output_slws_ref(output_sls_ref.size()),
+      output_sls(output_sls_ref.size()), output_slws(output_sls_ref.size());
+
+  chrono::time_point<chrono::system_clock> t_begin, t_end;
+  double t;
+
+  constexpr int NUM_WARMUP = 4;
+  constexpr int NUM_ITER = 10;
+  // Only counts the number of bytes for reading embedding table and ignore
+  // others. Should be good enough as long as embdding_dim is big enough.
+  double bytes = static_cast<double>(NUM_ITER) * lengths_sum *
+      (embedding_dim * sizeof(uint8_t) + 2 * sizeof(float));
+  double bytes_padded =
+      static_cast<double>(NUM_ITER) * lengths_sum * 64 *
+      static_cast<int>(
+          (embedding_dim * sizeof(uint8_t) + 2 * sizeof(float) + 63) / 64);
+
+  for (bool has_weight : {false, true}) {
+    vector<float>& output_ref = has_weight ? output_slws_ref : output_sls_ref;
+
+    for (int i = 0; i < NUM_WARMUP + NUM_ITER; ++i) {
+      if (use_32_bit_indices) {
+        fbgemm::EmbeddingSpMDM_ref(
+            embedding_dim,
+            batch_size,
+            lengths_sum,
+            num_unique_ids,
+            fused_embedding_table,
+            indices_32.data(),
+            lengths.data(),
+            has_weight ? weights.data() : nullptr,
+            normalize_by_lengths,
+            output_ref.data());
+
+      } else {
+        fbgemm::EmbeddingSpMDM_ref(
+            embedding_dim,
+            batch_size,
+            lengths_sum,
+            num_unique_ids,
+            fused_embedding_table,
+            indices.data(),
+            lengths.data(),
+            has_weight ? weights.data() : nullptr,
+            normalize_by_lengths,
+            output_ref.data());
+      }
+    }
+
+    vector<float>& output = has_weight ? output_slws : output_sls;
+    for (bool flush_cache : {false, true}) {
+      t = 0;
+      for (int i = 0; i < NUM_WARMUP + NUM_ITER; ++i) {
+        if (flush_cache) {
+          llc_flush_fused_table(
+              fused_embedding_table, num_unique_ids * (embedding_dim + 8));
+          llc_flush(indices);
+          llc_flush(indices_32);
+          llc_flush(lengths);
+          llc_flush(weights);
+          llc_flush(output);
+        }
+
+        if (use_32_bit_indices) {
+          t_begin = chrono::system_clock::now();
+
+          fbgemm::EmbeddingSpMDM<uint8_t, int32_t>(
+              embedding_dim,
+              batch_size,
+              lengths_sum,
+              num_unique_ids,
+              fused_embedding_table,
+              indices_32.data(),
+              lengths.data(),
+              has_weight ? weights.data() : nullptr,
+              normalize_by_lengths,
+              output.data(),
+              prefetch ? 16 : 0);
+
+          t_end = chrono::system_clock::now();
+
+        } else {
+          t_begin = chrono::system_clock::now();
+
+          fbgemm::EmbeddingSpMDM<uint8_t, int64_t>(
+              embedding_dim,
+              batch_size,
+              lengths_sum,
+              num_unique_ids,
+              fused_embedding_table,
+              indices.data(),
+              lengths.data(),
+              has_weight ? weights.data() : nullptr,
+              normalize_by_lengths,
+              output.data(),
+              prefetch ? 16 : 0);
+
+          t_end = chrono::system_clock::now();
+        }
+
+        if (i >= NUM_WARMUP) {
+          t += chrono::duration<double>(t_end - t_begin).count();
+        }
+      }
+
+      // print_outupt(batch_size, embedding_dim, output.data());
+      // print_outupt(batch_size, embedding_dim, output_ref.data());
+      // Check correctness
+      if (!flush_cache) {
+        // vector<float>& output_ref =
+        //     has_weight ? output_slws_ref : output_sls_ref;
+        for (int i = 0; i < output.size(); ++i) {
+          assert(fabs(output[i] - output_ref[i]) < 1e-3);
+          if (fabs(output[i] - output_ref[i]) >= 1e-3) {
+            cout << i << " " << output[i] << " " << output_ref[i] << endl;
+          }
+        }
+      }
+
+      if (has_weight) {
+        cout << setw(16) << "SLW(WEIGHTED) ";
+      } else {
+        cout << setw(16) << "SLS ";
+      }
+      if (flush_cache) {
+        cout << setw(20) << "cache flushed";
+      } else {
+        cout << setw(20) << "cache not flushed";
+      }
+      if (prefetch) {
+        cout << setw(16) << "prefetch on";
+      } else {
+        cout << setw(16) << "prefetch off";
+      }
+
+      cout << setw(8) << "b/w" << setw(10) << bytes / 1e9 / t << " GB/s"
+           << setw(20) << "effective b/w: " << setw(16)
+           << bytes_padded / 1e9 / t << "GB/s" << setw(8) << " time "
+           << setw(16) << t << endl;
+    } // flush_cache
+  } // has_weight
+  return 0;
+}
+
+int main() {
+  int batch_size;
+  int num_unique_ids;
+  int embedding_dim;
+  int average_len;
+
+  vector<vector<int>> inputs(GetInputs_());
+
+  for (auto& input : inputs) {
+    assert(input.size() > 3);
+    batch_size = input[0];
+    num_unique_ids = input[1];
+    embedding_dim = input[2];
+    average_len = input[3];
+
+    cout << "batch size" << setw(6) << batch_size << setw(10) << "num rows"
+         << setw(16) << num_unique_ids << setw(10) << "emb dim" << setw(6)
+         << embedding_dim << setw(16) << "avg length" << setw(6) << average_len
+         << endl;
+    // args: batch sz, num rows, emb dim, avg len, normalize, use 32b, prefetch
+    cout << "64 bit indices, ";
+    run_benchmark(
+        batch_size, num_unique_ids, embedding_dim, average_len, false);
+
+    cout << "64 bit indices with prefetching, ";
+    run_benchmark(
+        batch_size,
+        num_unique_ids,
+        embedding_dim,
+        average_len,
+        false,
+        false,
+        true);
+
+    cout << "32 bit indices, ";
+    run_benchmark(
+        batch_size, num_unique_ids, embedding_dim, average_len, false, true);
+
+    cout << "32 bit indices with prefetching, ";
+    run_benchmark(
+        batch_size,
+        num_unique_ids,
+        embedding_dim,
+        average_len,
+        false,
+        true,
+        true);
+
+    // running with normalize by lengths
+    // run_benchmark(batch_size, num_unique_ids, embedding_dim, average_len,
+    // true); run_benchmark(
+    //     batch_size, num_unique_ids, embedding_dim, average_len, true, true);
+    // run_benchmark(
+    //     batch_size,
+    //     num_unique_ids,
+    //     embedding_dim,
+    //     average_len,
+    //     false,
+    //     true,
+    //     true);
+  }
+  return 0;
+}

--- a/include/fbgemm/Fbgemm.h
+++ b/include/fbgemm/Fbgemm.h
@@ -16,9 +16,10 @@
 #include <type_traits>
 #include "./ConvUtils.h"
 #include "./FbgemmBuild.h"
-#include "./FbgemmI8Spmdm.h"
-#include "./QuantUtilsAvx2.h"
 #include "./FbgemmI8DepthwiseAvx2.h"
+#include "./FbgemmI8Spmdm.h"
+#include "./FbgemmEmbedding.h"
+#include "./QuantUtilsAvx2.h"
 #include "./Types.h"
 #include "./Utils.h"
 
@@ -1485,20 +1486,4 @@ FBGEMM_API int fbgemmConv(
 template <int SPATIAL_DIM = 2, typename ACC_T = std::int32_t>
 FBGEMM_API optimized_conv_t
 ConvFastPath(const conv_param_t<SPATIAL_DIM>& conv_p);
-
-template <typename IndexType = std::int64_t >
-FBGEMM_API bool Fused8BitRowwiseEmbeddingLookup(
-    const std::int64_t block_size,
-    const std::int64_t output_size,
-    const std::int64_t index_size,
-    const std::int64_t data_size,
-    const std::uint8_t* input,
-    const IndexType* indices,
-    const int* lengths,
-    const float* weights, // optional, can be null for non-weighted sum
-    bool normalize_by_lengths,
-    float* out,
-    int prefetch = 16, // prefetch distance -- 0 for no prefetch
-    bool IS_WEIGHT_POSITIONAL = false);
-
 } // namespace fbgemm

--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+#include <cstdint>
+
+namespace fbgemm {
+template <typename inType = std::uint8_t, typename IndexType = std::int64_t>
+FBGEMM_API bool EmbeddingSpMDM(
+    const std::int64_t block_size,
+    const std::int64_t output_size,
+    const std::int64_t index_size,
+    const std::int64_t data_size,
+    const inType* input,
+    const IndexType* indices,
+    const int* lengths,
+    const float* weights, // optional, can be null for non-weighted sum
+    bool normalize_by_lengths,
+    float* out,
+    int prefetch = 16,
+    bool IS_WEIGHT_POSITIONAL = false);
+} // namespace fbgemm

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -196,7 +196,7 @@ uint64_t umul64wide(uint64_t a, uint64_t b) {
 
   return p0 + (p1 << 32) + (p2 << 32);
 }
-} // anonymous namepsace
+} // namespace
 
 #ifdef __clang__
 // Expected to have overflows
@@ -769,6 +769,104 @@ template bool Fused8BitRowwiseEmbeddingLookup_ref(
     bool normalize_by_lengths,
     float* out);
 
+template <typename inType, typename IndexType>
+bool EmbeddingSpMDM_ref(
+    const std::int64_t block_size,
+    const std::int64_t output_size,
+    const std::int64_t index_size,
+    const std::int64_t data_size,
+    const inType* input,
+    const IndexType* indices,
+    const int* lengths,
+    const float* weights, // optional, can be null for non-weighted sum
+    bool normalize_by_lengths,
+    float* out,
+    bool IS_WEIGHT_POSITIONAL) {
+  bool is8bit = std::is_same<inType, std::uint8_t>::value;
+
+  if (is8bit) {
+    // block_size is the number of elements and fused_block_size is the size of
+    // an entire row, including scale and bias.
+    const auto scale_bias_offset = 8 / sizeof(inType);
+    const int64_t fused_block_size = block_size + scale_bias_offset;
+    int64_t current = 0;
+    for (int m = 0; m < output_size; ++m) {
+      memset(out, 0, sizeof(float) * block_size);
+      if (current + lengths[m] > index_size) {
+        return false;
+      }
+      for (int i = 0; i < lengths[m]; ++i) {
+        int64_t idx = indices[current];
+        if (idx < 0 || idx >= data_size) {
+          return false;
+        }
+
+        const float* scale_bias = reinterpret_cast<const float*>(
+            input + fused_block_size * indices[current] + block_size);
+
+        float weight = 1.0f;
+        if (weights) {
+          weight = weights[IS_WEIGHT_POSITIONAL ? i : current];
+        }
+        const float scale = weight * scale_bias[0];
+        const float bias = weight * scale_bias[1];
+
+        for (int j = 0; j < block_size; ++j) {
+          out[j] = std::fma(
+              scale,
+              input[fused_block_size * indices[current] + j],
+              out[j] + bias);
+        }
+
+        ++current;
+      }
+      if (normalize_by_lengths && lengths[m]) {
+        float scale = 1.f / lengths[m];
+        for (int j = 0; j < block_size; ++j) {
+          out[j] *= scale;
+        }
+      }
+      out += block_size;
+    }
+    return true;
+  } else {
+    // Reference implementation of FP32 SLS
+    int64_t current = 0;
+    for (int m = 0; m < output_size; ++m) {
+      memset(out, 0, sizeof(float) * block_size);
+      if (current + lengths[m] > index_size) {
+        return false;
+      }
+      for (int i = 0; i < lengths[m]; ++i) {
+        int64_t idx = indices[current];
+        if (idx < 0 || idx >= data_size) {
+          return false;
+        }
+
+        float w = 1.f;
+        if (weights) {
+          w = weights[IS_WEIGHT_POSITIONAL ? i : current];
+        }
+
+        for (int j = 0; j < block_size; ++j) {
+          out[j] =
+              std::fma(w, input[block_size * indices[current] + j], out[j]);
+        }
+
+        ++current;
+      }
+      if (normalize_by_lengths && lengths[m]) {
+        float scale = 1.f / lengths[m];
+        for (int j = 0; j < block_size; ++j) {
+          out[j] *= scale;
+        }
+      }
+      out += block_size;
+    }
+    return current == index_size;
+  }
+}
+
 template void transposeConvWeights(
     const conv_param_t<2>& conv_p,
     const std::int8_t* src,
@@ -779,4 +877,55 @@ template void transposeConvWeights(
     const std::int8_t* src,
     std::int8_t* dest);
 
+template bool EmbeddingSpMDM_ref(
+    const std::int64_t block_size,
+    const std::int64_t output_size,
+    const std::int64_t index_size,
+    const std::int64_t data_size,
+    const std::uint8_t* input,
+    const std::int64_t* indices,
+    const int* lengths,
+    const float* weights, // optional, can be null for non-weighted sum
+    bool normalize_by_lengths,
+    float* out,
+    bool IS_WEIGHT_POSITIONAL);
+
+template bool EmbeddingSpMDM_ref(
+    const std::int64_t block_size,
+    const std::int64_t output_size,
+    const std::int64_t index_size,
+    const std::int64_t data_size,
+    const std::uint8_t* input,
+    const std::int32_t* indices,
+    const int* lengths,
+    const float* weights, // optional, can be null for non-weighted sum
+    bool normalize_by_lengths,
+    float* out,
+    bool IS_WEIGHT_POSITIONAL);
+
+template bool EmbeddingSpMDM_ref(
+    const std::int64_t block_size,
+    const std::int64_t output_size,
+    const std::int64_t index_size,
+    const std::int64_t data_size,
+    const float* input,
+    const std::int64_t* indices,
+    const int* lengths,
+    const float* weights, // optional, can be null for non-weighted sum
+    bool normalize_by_lengths,
+    float* out,
+    bool IS_WEIGHT_POSITIONAL);
+
+template bool EmbeddingSpMDM_ref(
+    const std::int64_t block_size,
+    const std::int64_t output_size,
+    const std::int64_t index_size,
+    const std::int64_t data_size,
+    const float* input,
+    const std::int32_t* indices,
+    const int* lengths,
+    const float* weights, // optional, can be null for non-weighted sum
+    bool normalize_by_lengths,
+    float* out,
+    bool IS_WEIGHT_POSITIONAL);
 } // namespace fbgemm

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -242,4 +242,17 @@ FBGEMM_API bool Fused8BitRowwiseEmbeddingLookup_ref(
     bool normalize_by_lengths,
     OutType* out);
 
+template <typename inType = std::uint8_t, typename IndexType = std::int64_t>
+FBGEMM_API bool EmbeddingSpMDM_ref(
+    const std::int64_t block_size,
+    const std::int64_t output_size,
+    const std::int64_t index_size,
+    const std::int64_t data_size,
+    const inType* input,
+    const IndexType* indices,
+    const int* lengths,
+    const float* weights, // optional, can be null for non-weighted sum
+    bool normalize_by_lengths,
+    float* out,
+    bool IS_WEIGHT_POSITIONAL = false);
 } // namespace fbgemm

--- a/test/EmbeddingSpMDM8BitTest.cc
+++ b/test/EmbeddingSpMDM8BitTest.cc
@@ -129,7 +129,7 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
 
     // Compute the number of indices
     int lengths_sum = accumulate(lengths.begin(), lengths.end(), 0);
-    cout << "lenths sum " << lengths_sum;
+    //cout << "lenths sum " << lengths_sum;
 
     // Generate indices
     vector<int64_t> indices;
@@ -168,7 +168,7 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
               normalize_by_lengths,
               output_ref.data());
 
-      fbgemm::Fused8BitRowwiseEmbeddingLookup<int64_t>(
+      fbgemm::EmbeddingSpMDM<uint8_t, int64_t>(
           embedding_dim,
           batch_size,
           lengths_sum,
@@ -195,7 +195,7 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
               normalize_by_lengths,
               output_ref.data());
 
-      fbgemm::Fused8BitRowwiseEmbeddingLookup<int32_t>(
+      fbgemm::EmbeddingSpMDM<uint8_t, int32_t>(
           embedding_dim,
           batch_size,
           lengths_sum,

--- a/test/EmbeddingSpMDMTest.cc
+++ b/test/EmbeddingSpMDMTest.cc
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <algorithm>
+#include <ostream>
+#include <random>
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include "fbgemm/Fbgemm.h"
+#include "fbgemm/Utils.h"
+#include "src/RefImplementations.h"
+
+using namespace std;
+using namespace fbgemm;
+
+static vector<vector<int>> GetInputs_() {
+  vector<vector<int>> input_dims = {
+      // batch size, number of rows of table, emb dim , avg lengthl
+      {1, 8, 8, 4},
+      {2, 8, 16, 4},
+      {10, 4000, 32, 100},
+      {100, 4000, 32, 100},
+      {10, 4000, 64, 100},
+      {10, 4000, 128, 100},
+      {4, 400, 256, 10},
+      {10, 4000, 48, 100},
+      {10, 4000, 48, 100},
+      {10, 4000, 40, 100},
+      {10, 4000, 56, 100},
+      {10, 4000, 1, 100},
+      {10, 4000, 4, 100},
+      // These were  from C2 tests
+      {10, 40, 16, 10},
+      {10, 40, 85, 10},
+      {10, 40, 8, 10},
+      {10, 40, 96, 10},
+      {10, 40, 163, 10},
+  };
+  return input_dims;
+}
+
+namespace {
+
+class EmbeddingSpMDMTest : public testing::TestWithParam<
+                               tuple<bool, bool, bool, int, bool, bool, bool>> {
+};
+}; // namespace
+
+vector<int> prefetch_distances = {0, 16, 1000000};
+
+INSTANTIATE_TEST_CASE_P(
+    InstantiationName,
+    EmbeddingSpMDMTest,
+    ::testing::Combine(
+        ::testing::Bool(),
+        ::testing::Bool(),
+        ::testing::Values(false),
+        ::testing::ValuesIn(prefetch_distances),
+        ::testing::Bool(),
+        ::testing::Bool(),
+        ::testing::Bool()));
+
+TEST_P(EmbeddingSpMDMTest, basicTest) {
+  vector<vector<int>> inputs(GetInputs_());
+  bool isavx2, isIndex64b, is_wt_positional, use_weight, normalize_by_lengths,
+      empty_indices;
+  int prefetch;
+  tie(isavx2,
+      isIndex64b,
+      is_wt_positional,
+      prefetch,
+      use_weight,
+      normalize_by_lengths,
+      empty_indices) = GetParam();
+
+  if (!fbgemmHasAvx512Support()) {
+    isavx2 = true; // only use avx2
+  }
+
+  inst_set_t isa;
+  isa = isavx2 ? inst_set_t::avx2 : inst_set_t::avx512;
+  int batch_size, num_unique_ids, embedding_dim, average_len;
+
+  for (auto input : inputs) {
+    batch_size = input[0];
+    num_unique_ids = input[1];
+    embedding_dim = input[2];
+    average_len = input[3];
+
+    // Create embedding table
+    vector<float> embedding_table(num_unique_ids * embedding_dim);
+    default_random_engine generator;
+    normal_distribution<float> embedding_distribution;
+    for (int i = 0; i < embedding_table.size(); ++i) {
+      embedding_table[i] = embedding_distribution(generator);
+    }
+
+    // Generate lengths
+    uniform_int_distribution<int> length_distribution(1, 2 * average_len + 1);
+    vector<int> lengths(batch_size);
+    for (int i = 0; i < batch_size; ++i) {
+      lengths[i] = empty_indices ? 0 : length_distribution(generator);
+    }
+
+    // Compute the number of indices
+    int lengths_sum = accumulate(lengths.begin(), lengths.end(), 0);
+    // cout << "lengths_sum " << lengths_sum << endl;
+
+    // Generate indices
+    vector<int64_t> indices;
+    vector<int32_t> indices_32;
+
+    // Generate indices
+    vector<int> container(num_unique_ids);
+    for (int i = 0; i < batch_size; ++i) {
+      iota(container.begin(), container.end(), 0);
+      random_shuffle(container.begin(), container.end());
+      copy(
+          container.begin(),
+          container.begin() + lengths[i],
+          back_inserter(indices));
+    }
+    // use same indices for 32b and 64b
+    copy(begin(indices), end(indices), back_inserter(indices_32));
+
+    // Generate weights
+    vector<float> weights(lengths_sum);
+    for (int i = 0; i < lengths_sum; ++i) {
+      weights[i] = embedding_distribution(generator);
+    }
+
+    vector<float> output_sls_ref(batch_size * embedding_dim);
+    vector<float> output_slws_ref(output_sls_ref.size()),
+        output_sls(output_sls_ref.size()), output_slws(output_sls_ref.size());
+
+    vector<float>& output_ref = use_weight ? output_slws_ref : output_sls_ref;
+    vector<float>& output = use_weight ? output_slws : output_sls;
+    bool success, success_ref;
+
+    if (isIndex64b) {
+      success_ref = fbgemm::EmbeddingSpMDM_ref(
+          embedding_dim,
+          batch_size,
+          lengths_sum,
+          num_unique_ids,
+          embedding_table.data(),
+          empty_indices ? nullptr : indices.data(),
+          lengths.data(),
+          use_weight ? weights.data() : nullptr,
+          normalize_by_lengths,
+          output_ref.data());
+
+      success = fbgemm::EmbeddingSpMDM<float, int64_t>(
+          embedding_dim,
+          batch_size,
+          lengths_sum,
+          num_unique_ids,
+          embedding_table.data(),
+          empty_indices ? nullptr : indices.data(),
+          lengths.data(),
+          use_weight ? weights.data() : nullptr,
+          normalize_by_lengths,
+          output.data(),
+          prefetch ? 16 : 0);
+    } else {
+      success_ref = fbgemm::EmbeddingSpMDM_ref(
+          embedding_dim,
+          batch_size,
+          lengths_sum,
+          num_unique_ids,
+          embedding_table.data(),
+          empty_indices ? nullptr : indices_32.data(),
+          lengths.data(),
+          use_weight ? weights.data() : nullptr,
+          normalize_by_lengths,
+          output_ref.data());
+
+      success = fbgemm::EmbeddingSpMDM<float, int32_t>(
+          embedding_dim,
+          batch_size,
+          lengths_sum,
+          num_unique_ids,
+          embedding_table.data(),
+          empty_indices ? nullptr : indices_32.data(),
+          lengths.data(),
+          use_weight ? weights.data() : nullptr,
+          normalize_by_lengths,
+          output.data(),
+          prefetch ? 16 : 0);
+    }
+
+    // Check correctness
+    EXPECT_EQ(success, success_ref)
+        << "Reference and JIT impl did not both succeed";
+    output_ref = use_weight ? output_slws_ref : output_sls_ref;
+    if (success) {
+      for (int i = 0; i < output.size(); ++i) {
+        EXPECT_EQ(output[i], output_ref[i])
+            << "results differ at (" << i << ") reference: " << output_ref[i]
+            << ", FBGEMM: " << output[i] << " emb dim :" << embedding_dim;
+      }
+    }
+  } // end for input
+}


### PR DESCRIPTION
Summary:
This adds support for 32 bit indices to JITed FP 32  SLS Op.

This diff includes the following features of SLS:

1. Normalize by lengths
2. modified prefetch distances for avx2 vs. avx512
3. adds support for 32 bit indices
4. has support for weighted SLS, and supports positional weights
5. Does not specialize for blocksize 1 for avx512 as this reorders reduction.

Reviewed By: jspark1105

Differential Revision: D18210640

