### PR TITLE
Add support for AVX512-256(YMM) in FBGEMM16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ set(FBGEMM_AVX512_SRCS
   src/FbgemmBfloat16ConvertAvx512.cc
   src/FbgemmFP16UKernelsAvx512.cc
   src/FbgemmFloat16ConvertAvx512.cc
+  src/FbgemmFP16UKernelsAvx512_256.cc
   src/UtilsAvx512.cc)
 
 set(FBGEMM_PUBLIC_HEADERS include/fbgemm/Fbgemm.h

--- a/bench/FP16Benchmark.cc
+++ b/bench/FP16Benchmark.cc
@@ -383,6 +383,8 @@ int main(int argc, const char* argv[]) {
   int repetitions = parseArgumentInt(argc, argv, "--repit=", 1, 1);
   bool no_flush = parseArgumentBool(argc, argv, "--no-flush", false);
   bool no_mkl = parseArgumentBool(argc, argv, "--no-mkl", false);
+  bool enableAvx512_ymm = parseArgumentBool(argc, argv, "--avx512-256", false);
+  fbgemmEnableAvx512Ymm(enableAvx512_ymm);
 
   performance_test(num_instances, !no_flush, repetitions, !no_mkl);
 }

--- a/include/fbgemm/FbgemmFP16.h
+++ b/include/fbgemm/FbgemmFP16.h
@@ -83,7 +83,7 @@ class PackedGemmMatrixFP16 {
     if (!cpuinfo_initialize()) {
       throw std::runtime_error("Failed to initialize cpuinfo!");
     }
-    bcol_ = (fbgemmHasAvx512Support()
+    bcol_ = (isZmm(fbgemmInstructionSet())
                  ? simd_info<inst_set_t::avx512>::WIDTH_32BIT_ELEMS
                  : simd_info<inst_set_t::avx2>::WIDTH_32BIT_ELEMS) *
         kernelNumColBlocks();

--- a/src/FbgemmFP16Common.h
+++ b/src/FbgemmFP16Common.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include <array>
+#include <fbgemm/Types.h>
+#include <fbgemm/Utils.h>
+
+namespace fbgemm {
+using partition_array_t = std::array<std::array<std::array<int, 2>, 2>, 121>;
+
+template<typename T>
+struct GemmParams {
+  uint64_t k;
+  float* A;
+  const T* B;
+  float beta;
+  float* C;
+  uint64_t ldc;
+  uint64_t b_block_cols;
+  uint64_t b_block_size;
+};
+
+template<typename T>
+using funcptr_t = void(*)(GemmParams<T>*);
+
+using fp16 = float16;
+using fp32 = float;
+using GemmParamsFP16 = GemmParams<fp16>;
+
+}

--- a/src/FbgemmFP16UKernelsAvx2.h
+++ b/src/FbgemmFP16UKernelsAvx2.h
@@ -8,29 +8,21 @@
 #include <cstdint>
 #include "fbgemm/Types.h"
 
+#include "./FbgemmFP16Common.h"
+
 namespace fbgemm {
 
-using fp16 = float16;
-using fp32 = float;
-struct GemmParams {
-  uint64_t k;
-  float* A;
-  const fp16* B;
-  float* beta;
-  uint64_t accum;
-  float* C;
-  uint64_t ldc;
-  uint64_t b_block_cols;
-  uint64_t b_block_size;
-};
-void __attribute__((noinline)) gemmkernel_1x2_Avx2_fA0fB0fC0(GemmParams* gp);
-void __attribute__((noinline)) gemmkernel_2x2_Avx2_fA0fB0fC0(GemmParams* gp);
-void __attribute__((noinline)) gemmkernel_3x2_Avx2_fA0fB0fC0(GemmParams* gp);
-void __attribute__((noinline)) gemmkernel_4x2_Avx2_fA0fB0fC0(GemmParams* gp);
-void __attribute__((noinline)) gemmkernel_5x2_Avx2_fA0fB0fC0(GemmParams* gp);
-void __attribute__((noinline)) gemmkernel_6x2_Avx2_fA0fB0fC0(GemmParams* gp);
-typedef void (*funcptr_fp16)(GemmParams* gp);
-;
+void __attribute__((noinline))
+gemmkernel_1x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_2x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_3x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_4x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_5x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_6x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp);
 
 } // namespace fbgemm
-

--- a/src/FbgemmFP16UKernelsAvx512.h
+++ b/src/FbgemmFP16UKernelsAvx512.h
@@ -6,26 +6,39 @@
  */
 #pragma once
 #include <cstdint>
-#include "./FbgemmFP16UKernelsAvx2.h"
 #include "fbgemm/Types.h"
+
+#include "./FbgemmFP16Common.h"
 
 namespace fbgemm {
 
-void __attribute__((noinline)) gemmkernel_1x2_Avx512_fA0fB0fC0(GemmParams* gp);
-void __attribute__((noinline)) gemmkernel_2x2_Avx512_fA0fB0fC0(GemmParams* gp);
-void __attribute__((noinline)) gemmkernel_3x2_Avx512_fA0fB0fC0(GemmParams* gp);
-void __attribute__((noinline)) gemmkernel_4x2_Avx512_fA0fB0fC0(GemmParams* gp);
-void __attribute__((noinline)) gemmkernel_5x2_Avx512_fA0fB0fC0(GemmParams* gp);
-void __attribute__((noinline)) gemmkernel_6x2_Avx512_fA0fB0fC0(GemmParams* gp);
-void __attribute__((noinline)) gemmkernel_7x2_Avx512_fA0fB0fC0(GemmParams* gp);
-void __attribute__((noinline)) gemmkernel_8x2_Avx512_fA0fB0fC0(GemmParams* gp);
-void __attribute__((noinline)) gemmkernel_9x2_Avx512_fA0fB0fC0(GemmParams* gp);
-void __attribute__((noinline)) gemmkernel_10x2_Avx512_fA0fB0fC0(GemmParams* gp);
-void __attribute__((noinline)) gemmkernel_11x2_Avx512_fA0fB0fC0(GemmParams* gp);
-void __attribute__((noinline)) gemmkernel_12x2_Avx512_fA0fB0fC0(GemmParams* gp);
-void __attribute__((noinline)) gemmkernel_13x2_Avx512_fA0fB0fC0(GemmParams* gp);
-void __attribute__((noinline)) gemmkernel_14x2_Avx512_fA0fB0fC0(GemmParams* gp);
-typedef void (*funcptr_fp16)(GemmParams* gp);
-;
+void __attribute__((noinline))
+gemmkernel_1x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_2x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_3x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_4x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_5x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_6x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_7x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_8x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_9x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_10x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_11x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_12x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_13x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_14x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp);
 
 } // namespace fbgemm

--- a/src/FbgemmFP16UKernelsAvx512_256.cc
+++ b/src/FbgemmFP16UKernelsAvx512_256.cc
@@ -1,0 +1,1652 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include "./FbgemmFP16UKernelsAvx512_256.h"
+
+namespace fbgemm {
+
+void __attribute__((noinline))
+gemmkernel_7x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  asm volatile(
+#if !defined(__clang__)
+      "mov r14, %[gp]\t\n"
+#else
+      "mov %[gp], %%r14\t\n"
+      ".intel_syntax noprefix\t\n"
+#endif
+
+      // Copy parameters
+      // k
+      "mov r8, [r14 + 0]\t\n"
+      // A
+      "mov r9, [r14 + 8]\t\n"
+      // B
+      "mov r10, [r14 + 16]\t\n"
+      // beta
+      "vbroadcastss ymm31,DWORD PTR [r14 + 24]\t\n"
+      // C
+      "mov r12, [r14 + 32]\t\n"
+      // ldc
+      "mov r13, [r14 + 40]\t\n"
+      // b_block_cols
+      "mov rdi, [r14 + 48]\t\n"
+      // b_block_size
+      "mov rsi, [r14 + 56]\t\n"
+
+      // Make copies of A and C
+      "mov rax, r9\t\n"
+      "mov rcx, r12\t\n"
+
+      "mov rbx, 0\t\n"
+      "loop_outter%=:\t\n"
+      "mov r14, 0\t\n"
+      "vxorps xmm0, xmm0, xmm0\t\n"
+      "vcomiss xmm31, xmm0\t\n"
+      "jz zero_regs%=\t\n"
+
+      // Setup values with beta multiplication
+      "vmulps ymm0, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm1, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm2, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm3, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm4, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm5, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm6, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm7, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm8, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm9, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm10, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm11, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm12, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm13, ymm31, [r12 + 32]\t\n"
+      "mov r12, rcx\t\n"
+      "jmp loop_inner%=\t\n"
+
+      "zero_regs%=:\t\n"
+
+      "vxorps ymm0, ymm0, ymm0\t\n"
+      "vxorps ymm1, ymm1, ymm1\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm2, ymm2, ymm2\t\n"
+      "vxorps ymm3, ymm3, ymm3\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm4, ymm4, ymm4\t\n"
+      "vxorps ymm5, ymm5, ymm5\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm6, ymm6, ymm6\t\n"
+      "vxorps ymm7, ymm7, ymm7\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm8, ymm8, ymm8\t\n"
+      "vxorps ymm9, ymm9, ymm9\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm10, ymm10, ymm10\t\n"
+      "vxorps ymm11, ymm11, ymm11\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm12, ymm12, ymm12\t\n"
+      "vxorps ymm13, ymm13, ymm13\t\n"
+      "mov r12, rcx\t\n"
+
+      "loop_inner%=:\t\n"
+
+      "vcvtph2ps ymm15,XMMWORD PTR [r10 + 0]\t\n"
+      "vcvtph2ps ymm16,XMMWORD PTR [r10 + 16]\t\n"
+      "vbroadcastss ymm14,DWORD PTR [r9+0]\t\n"
+      "vfmadd231ps ymm0,ymm15,ymm14\t\n"
+      "vfmadd231ps ymm1,ymm16,ymm14\t\n"
+      "vbroadcastss ymm14,DWORD PTR [r9+4]\t\n"
+      "vfmadd231ps ymm2,ymm15,ymm14\t\n"
+      "vfmadd231ps ymm3,ymm16,ymm14\t\n"
+      "vbroadcastss ymm14,DWORD PTR [r9+8]\t\n"
+      "vfmadd231ps ymm4,ymm15,ymm14\t\n"
+      "vfmadd231ps ymm5,ymm16,ymm14\t\n"
+      "vbroadcastss ymm14,DWORD PTR [r9+12]\t\n"
+      "vfmadd231ps ymm6,ymm15,ymm14\t\n"
+      "vfmadd231ps ymm7,ymm16,ymm14\t\n"
+      "vbroadcastss ymm14,DWORD PTR [r9+16]\t\n"
+      "vfmadd231ps ymm8,ymm15,ymm14\t\n"
+      "vfmadd231ps ymm9,ymm16,ymm14\t\n"
+      "vbroadcastss ymm14,DWORD PTR [r9+20]\t\n"
+      "vfmadd231ps ymm10,ymm15,ymm14\t\n"
+      "vfmadd231ps ymm11,ymm16,ymm14\t\n"
+      "vbroadcastss ymm14,DWORD PTR [r9+24]\t\n"
+      "vfmadd231ps ymm12,ymm15,ymm14\t\n"
+      "vfmadd231ps ymm13,ymm16,ymm14\t\n"
+      "add r9,28\t\n"
+      "add r10,32\t\n"
+      "inc r14\t\n"
+      "cmp r14, r8\t\n"
+      "jl loop_inner%=\t\n"
+
+      // Dump C
+      "vmovups ymmword PTR [r12 + 0], ymm0\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm1\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm2\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm3\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm4\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm5\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm6\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm7\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm8\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm9\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm10\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm11\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm12\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm13\t\n"
+
+      // next outer iteration
+      "add rcx, 64\t\n"
+      "mov r12, rcx\t\n"
+      "mov r9, rax\t\n"
+      "inc rbx\t\n"
+      "cmp rbx, rdi\t\n"
+      "jl loop_outter%=\t\n"
+      :
+      : [gp] "rm"(gp)
+      : "r8",
+        "r9",
+        "r10",
+        "r11",
+        "r13",
+        "r14",
+        "rax",
+        "rcx",
+        "rsi",
+        "rdi",
+        "rbx",
+        "r12",
+        "memory");
+}
+void __attribute__((noinline))
+gemmkernel_8x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  asm volatile(
+#if !defined(__clang__)
+      "mov r14, %[gp]\t\n"
+#else
+      "mov %[gp], %%r14\t\n"
+      ".intel_syntax noprefix\t\n"
+#endif
+
+      // Copy parameters
+      // k
+      "mov r8, [r14 + 0]\t\n"
+      // A
+      "mov r9, [r14 + 8]\t\n"
+      // B
+      "mov r10, [r14 + 16]\t\n"
+      // beta
+      "vbroadcastss ymm31,DWORD PTR [r14 + 24]\t\n"
+      // C
+      "mov r12, [r14 + 32]\t\n"
+      // ldc
+      "mov r13, [r14 + 40]\t\n"
+      // b_block_cols
+      "mov rdi, [r14 + 48]\t\n"
+      // b_block_size
+      "mov rsi, [r14 + 56]\t\n"
+
+      // Make copies of A and C
+      "mov rax, r9\t\n"
+      "mov rcx, r12\t\n"
+
+      "mov rbx, 0\t\n"
+      "loop_outter%=:\t\n"
+      "mov r14, 0\t\n"
+      "vxorps xmm0, xmm0, xmm0\t\n"
+      "vcomiss xmm31, xmm0\t\n"
+      "jz zero_regs%=\t\n"
+
+      // Setup values with beta multiplication
+      "vmulps ymm0, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm1, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm2, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm3, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm4, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm5, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm6, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm7, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm8, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm9, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm10, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm11, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm12, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm13, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm14, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm15, ymm31, [r12 + 32]\t\n"
+      "mov r12, rcx\t\n"
+      "jmp loop_inner%=\t\n"
+
+      "zero_regs%=:\t\n"
+
+      "vxorps ymm0, ymm0, ymm0\t\n"
+      "vxorps ymm1, ymm1, ymm1\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm2, ymm2, ymm2\t\n"
+      "vxorps ymm3, ymm3, ymm3\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm4, ymm4, ymm4\t\n"
+      "vxorps ymm5, ymm5, ymm5\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm6, ymm6, ymm6\t\n"
+      "vxorps ymm7, ymm7, ymm7\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm8, ymm8, ymm8\t\n"
+      "vxorps ymm9, ymm9, ymm9\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm10, ymm10, ymm10\t\n"
+      "vxorps ymm11, ymm11, ymm11\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm12, ymm12, ymm12\t\n"
+      "vxorps ymm13, ymm13, ymm13\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm14, ymm14, ymm14\t\n"
+      "vxorps ymm15, ymm15, ymm15\t\n"
+      "mov r12, rcx\t\n"
+
+      "loop_inner%=:\t\n"
+
+      "vcvtph2ps ymm17,XMMWORD PTR [r10 + 0]\t\n"
+      "vcvtph2ps ymm18,XMMWORD PTR [r10 + 16]\t\n"
+      "vbroadcastss ymm16,DWORD PTR [r9+0]\t\n"
+      "vfmadd231ps ymm0,ymm17,ymm16\t\n"
+      "vfmadd231ps ymm1,ymm18,ymm16\t\n"
+      "vbroadcastss ymm16,DWORD PTR [r9+4]\t\n"
+      "vfmadd231ps ymm2,ymm17,ymm16\t\n"
+      "vfmadd231ps ymm3,ymm18,ymm16\t\n"
+      "vbroadcastss ymm16,DWORD PTR [r9+8]\t\n"
+      "vfmadd231ps ymm4,ymm17,ymm16\t\n"
+      "vfmadd231ps ymm5,ymm18,ymm16\t\n"
+      "vbroadcastss ymm16,DWORD PTR [r9+12]\t\n"
+      "vfmadd231ps ymm6,ymm17,ymm16\t\n"
+      "vfmadd231ps ymm7,ymm18,ymm16\t\n"
+      "vbroadcastss ymm16,DWORD PTR [r9+16]\t\n"
+      "vfmadd231ps ymm8,ymm17,ymm16\t\n"
+      "vfmadd231ps ymm9,ymm18,ymm16\t\n"
+      "vbroadcastss ymm16,DWORD PTR [r9+20]\t\n"
+      "vfmadd231ps ymm10,ymm17,ymm16\t\n"
+      "vfmadd231ps ymm11,ymm18,ymm16\t\n"
+      "vbroadcastss ymm16,DWORD PTR [r9+24]\t\n"
+      "vfmadd231ps ymm12,ymm17,ymm16\t\n"
+      "vfmadd231ps ymm13,ymm18,ymm16\t\n"
+      "vbroadcastss ymm16,DWORD PTR [r9+28]\t\n"
+      "vfmadd231ps ymm14,ymm17,ymm16\t\n"
+      "vfmadd231ps ymm15,ymm18,ymm16\t\n"
+      "add r9,32\t\n"
+      "add r10,32\t\n"
+      "inc r14\t\n"
+      "cmp r14, r8\t\n"
+      "jl loop_inner%=\t\n"
+
+      // Dump C
+      "vmovups ymmword PTR [r12 + 0], ymm0\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm1\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm2\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm3\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm4\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm5\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm6\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm7\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm8\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm9\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm10\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm11\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm12\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm13\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm14\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm15\t\n"
+
+      // next outer iteration
+      "add rcx, 64\t\n"
+      "mov r12, rcx\t\n"
+      "mov r9, rax\t\n"
+      "inc rbx\t\n"
+      "cmp rbx, rdi\t\n"
+      "jl loop_outter%=\t\n"
+      :
+      : [gp] "rm"(gp)
+      : "r8",
+        "r9",
+        "r10",
+        "r11",
+        "r13",
+        "r14",
+        "rax",
+        "rcx",
+        "rsi",
+        "rdi",
+        "rbx",
+        "r12",
+        "memory");
+}
+void __attribute__((noinline))
+gemmkernel_9x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  asm volatile(
+#if !defined(__clang__)
+      "mov r14, %[gp]\t\n"
+#else
+      "mov %[gp], %%r14\t\n"
+      ".intel_syntax noprefix\t\n"
+#endif
+
+      // Copy parameters
+      // k
+      "mov r8, [r14 + 0]\t\n"
+      // A
+      "mov r9, [r14 + 8]\t\n"
+      // B
+      "mov r10, [r14 + 16]\t\n"
+      // beta
+      "vbroadcastss ymm31,DWORD PTR [r14 + 24]\t\n"
+      // C
+      "mov r12, [r14 + 32]\t\n"
+      // ldc
+      "mov r13, [r14 + 40]\t\n"
+      // b_block_cols
+      "mov rdi, [r14 + 48]\t\n"
+      // b_block_size
+      "mov rsi, [r14 + 56]\t\n"
+
+      // Make copies of A and C
+      "mov rax, r9\t\n"
+      "mov rcx, r12\t\n"
+
+      "mov rbx, 0\t\n"
+      "loop_outter%=:\t\n"
+      "mov r14, 0\t\n"
+      "vxorps xmm0, xmm0, xmm0\t\n"
+      "vcomiss xmm31, xmm0\t\n"
+      "jz zero_regs%=\t\n"
+
+      // Setup values with beta multiplication
+      "vmulps ymm0, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm1, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm2, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm3, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm4, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm5, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm6, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm7, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm8, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm9, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm10, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm11, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm12, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm13, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm14, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm15, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm16, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm17, ymm31, [r12 + 32]\t\n"
+      "mov r12, rcx\t\n"
+      "jmp loop_inner%=\t\n"
+
+      "zero_regs%=:\t\n"
+
+      "vxorps ymm0, ymm0, ymm0\t\n"
+      "vxorps ymm1, ymm1, ymm1\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm2, ymm2, ymm2\t\n"
+      "vxorps ymm3, ymm3, ymm3\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm4, ymm4, ymm4\t\n"
+      "vxorps ymm5, ymm5, ymm5\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm6, ymm6, ymm6\t\n"
+      "vxorps ymm7, ymm7, ymm7\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm8, ymm8, ymm8\t\n"
+      "vxorps ymm9, ymm9, ymm9\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm10, ymm10, ymm10\t\n"
+      "vxorps ymm11, ymm11, ymm11\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm12, ymm12, ymm12\t\n"
+      "vxorps ymm13, ymm13, ymm13\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm14, ymm14, ymm14\t\n"
+      "vxorps ymm15, ymm15, ymm15\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm16, ymm16, ymm16\t\n"
+      "vxorps ymm17, ymm17, ymm17\t\n"
+      "mov r12, rcx\t\n"
+
+      "loop_inner%=:\t\n"
+
+      "vcvtph2ps ymm19,XMMWORD PTR [r10 + 0]\t\n"
+      "vcvtph2ps ymm20,XMMWORD PTR [r10 + 16]\t\n"
+      "vbroadcastss ymm18,DWORD PTR [r9+0]\t\n"
+      "vfmadd231ps ymm0,ymm19,ymm18\t\n"
+      "vfmadd231ps ymm1,ymm20,ymm18\t\n"
+      "vbroadcastss ymm18,DWORD PTR [r9+4]\t\n"
+      "vfmadd231ps ymm2,ymm19,ymm18\t\n"
+      "vfmadd231ps ymm3,ymm20,ymm18\t\n"
+      "vbroadcastss ymm18,DWORD PTR [r9+8]\t\n"
+      "vfmadd231ps ymm4,ymm19,ymm18\t\n"
+      "vfmadd231ps ymm5,ymm20,ymm18\t\n"
+      "vbroadcastss ymm18,DWORD PTR [r9+12]\t\n"
+      "vfmadd231ps ymm6,ymm19,ymm18\t\n"
+      "vfmadd231ps ymm7,ymm20,ymm18\t\n"
+      "vbroadcastss ymm18,DWORD PTR [r9+16]\t\n"
+      "vfmadd231ps ymm8,ymm19,ymm18\t\n"
+      "vfmadd231ps ymm9,ymm20,ymm18\t\n"
+      "vbroadcastss ymm18,DWORD PTR [r9+20]\t\n"
+      "vfmadd231ps ymm10,ymm19,ymm18\t\n"
+      "vfmadd231ps ymm11,ymm20,ymm18\t\n"
+      "vbroadcastss ymm18,DWORD PTR [r9+24]\t\n"
+      "vfmadd231ps ymm12,ymm19,ymm18\t\n"
+      "vfmadd231ps ymm13,ymm20,ymm18\t\n"
+      "vbroadcastss ymm18,DWORD PTR [r9+28]\t\n"
+      "vfmadd231ps ymm14,ymm19,ymm18\t\n"
+      "vfmadd231ps ymm15,ymm20,ymm18\t\n"
+      "vbroadcastss ymm18,DWORD PTR [r9+32]\t\n"
+      "vfmadd231ps ymm16,ymm19,ymm18\t\n"
+      "vfmadd231ps ymm17,ymm20,ymm18\t\n"
+      "add r9,36\t\n"
+      "add r10,32\t\n"
+      "inc r14\t\n"
+      "cmp r14, r8\t\n"
+      "jl loop_inner%=\t\n"
+
+      // Dump C
+      "vmovups ymmword PTR [r12 + 0], ymm0\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm1\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm2\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm3\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm4\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm5\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm6\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm7\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm8\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm9\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm10\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm11\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm12\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm13\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm14\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm15\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm16\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm17\t\n"
+
+      // next outer iteration
+      "add rcx, 64\t\n"
+      "mov r12, rcx\t\n"
+      "mov r9, rax\t\n"
+      "inc rbx\t\n"
+      "cmp rbx, rdi\t\n"
+      "jl loop_outter%=\t\n"
+      :
+      : [gp] "rm"(gp)
+      : "r8",
+        "r9",
+        "r10",
+        "r11",
+        "r13",
+        "r14",
+        "rax",
+        "rcx",
+        "rsi",
+        "rdi",
+        "rbx",
+        "r12",
+        "memory");
+}
+void __attribute__((noinline))
+gemmkernel_10x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  asm volatile(
+#if !defined(__clang__)
+      "mov r14, %[gp]\t\n"
+#else
+      "mov %[gp], %%r14\t\n"
+      ".intel_syntax noprefix\t\n"
+#endif
+
+      // Copy parameters
+      // k
+      "mov r8, [r14 + 0]\t\n"
+      // A
+      "mov r9, [r14 + 8]\t\n"
+      // B
+      "mov r10, [r14 + 16]\t\n"
+      // beta
+      "vbroadcastss ymm31,DWORD PTR [r14 + 24]\t\n"
+      // C
+      "mov r12, [r14 + 32]\t\n"
+      // ldc
+      "mov r13, [r14 + 40]\t\n"
+      // b_block_cols
+      "mov rdi, [r14 + 48]\t\n"
+      // b_block_size
+      "mov rsi, [r14 + 56]\t\n"
+
+      // Make copies of A and C
+      "mov rax, r9\t\n"
+      "mov rcx, r12\t\n"
+
+      "mov rbx, 0\t\n"
+      "loop_outter%=:\t\n"
+      "mov r14, 0\t\n"
+      "vxorps xmm0, xmm0, xmm0\t\n"
+      "vcomiss xmm31, xmm0\t\n"
+      "jz zero_regs%=\t\n"
+
+      // Setup values with beta multiplication
+      "vmulps ymm0, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm1, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm2, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm3, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm4, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm5, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm6, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm7, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm8, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm9, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm10, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm11, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm12, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm13, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm14, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm15, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm16, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm17, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm18, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm19, ymm31, [r12 + 32]\t\n"
+      "mov r12, rcx\t\n"
+      "jmp loop_inner%=\t\n"
+
+      "zero_regs%=:\t\n"
+
+      "vxorps ymm0, ymm0, ymm0\t\n"
+      "vxorps ymm1, ymm1, ymm1\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm2, ymm2, ymm2\t\n"
+      "vxorps ymm3, ymm3, ymm3\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm4, ymm4, ymm4\t\n"
+      "vxorps ymm5, ymm5, ymm5\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm6, ymm6, ymm6\t\n"
+      "vxorps ymm7, ymm7, ymm7\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm8, ymm8, ymm8\t\n"
+      "vxorps ymm9, ymm9, ymm9\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm10, ymm10, ymm10\t\n"
+      "vxorps ymm11, ymm11, ymm11\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm12, ymm12, ymm12\t\n"
+      "vxorps ymm13, ymm13, ymm13\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm14, ymm14, ymm14\t\n"
+      "vxorps ymm15, ymm15, ymm15\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm16, ymm16, ymm16\t\n"
+      "vxorps ymm17, ymm17, ymm17\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm18, ymm18, ymm18\t\n"
+      "vxorps ymm19, ymm19, ymm19\t\n"
+      "mov r12, rcx\t\n"
+
+      "loop_inner%=:\t\n"
+
+      "vcvtph2ps ymm21,XMMWORD PTR [r10 + 0]\t\n"
+      "vcvtph2ps ymm22,XMMWORD PTR [r10 + 16]\t\n"
+      "vbroadcastss ymm20,DWORD PTR [r9+0]\t\n"
+      "vfmadd231ps ymm0,ymm21,ymm20\t\n"
+      "vfmadd231ps ymm1,ymm22,ymm20\t\n"
+      "vbroadcastss ymm20,DWORD PTR [r9+4]\t\n"
+      "vfmadd231ps ymm2,ymm21,ymm20\t\n"
+      "vfmadd231ps ymm3,ymm22,ymm20\t\n"
+      "vbroadcastss ymm20,DWORD PTR [r9+8]\t\n"
+      "vfmadd231ps ymm4,ymm21,ymm20\t\n"
+      "vfmadd231ps ymm5,ymm22,ymm20\t\n"
+      "vbroadcastss ymm20,DWORD PTR [r9+12]\t\n"
+      "vfmadd231ps ymm6,ymm21,ymm20\t\n"
+      "vfmadd231ps ymm7,ymm22,ymm20\t\n"
+      "vbroadcastss ymm20,DWORD PTR [r9+16]\t\n"
+      "vfmadd231ps ymm8,ymm21,ymm20\t\n"
+      "vfmadd231ps ymm9,ymm22,ymm20\t\n"
+      "vbroadcastss ymm20,DWORD PTR [r9+20]\t\n"
+      "vfmadd231ps ymm10,ymm21,ymm20\t\n"
+      "vfmadd231ps ymm11,ymm22,ymm20\t\n"
+      "vbroadcastss ymm20,DWORD PTR [r9+24]\t\n"
+      "vfmadd231ps ymm12,ymm21,ymm20\t\n"
+      "vfmadd231ps ymm13,ymm22,ymm20\t\n"
+      "vbroadcastss ymm20,DWORD PTR [r9+28]\t\n"
+      "vfmadd231ps ymm14,ymm21,ymm20\t\n"
+      "vfmadd231ps ymm15,ymm22,ymm20\t\n"
+      "vbroadcastss ymm20,DWORD PTR [r9+32]\t\n"
+      "vfmadd231ps ymm16,ymm21,ymm20\t\n"
+      "vfmadd231ps ymm17,ymm22,ymm20\t\n"
+      "vbroadcastss ymm20,DWORD PTR [r9+36]\t\n"
+      "vfmadd231ps ymm18,ymm21,ymm20\t\n"
+      "vfmadd231ps ymm19,ymm22,ymm20\t\n"
+      "add r9,40\t\n"
+      "add r10,32\t\n"
+      "inc r14\t\n"
+      "cmp r14, r8\t\n"
+      "jl loop_inner%=\t\n"
+
+      // Dump C
+      "vmovups ymmword PTR [r12 + 0], ymm0\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm1\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm2\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm3\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm4\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm5\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm6\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm7\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm8\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm9\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm10\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm11\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm12\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm13\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm14\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm15\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm16\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm17\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm18\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm19\t\n"
+
+      // next outer iteration
+      "add rcx, 64\t\n"
+      "mov r12, rcx\t\n"
+      "mov r9, rax\t\n"
+      "inc rbx\t\n"
+      "cmp rbx, rdi\t\n"
+      "jl loop_outter%=\t\n"
+      :
+      : [gp] "rm"(gp)
+      : "r8",
+        "r9",
+        "r10",
+        "r11",
+        "r13",
+        "r14",
+        "rax",
+        "rcx",
+        "rsi",
+        "rdi",
+        "rbx",
+        "r12",
+        "memory");
+}
+void __attribute__((noinline))
+gemmkernel_11x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  asm volatile(
+#if !defined(__clang__)
+      "mov r14, %[gp]\t\n"
+#else
+      "mov %[gp], %%r14\t\n"
+      ".intel_syntax noprefix\t\n"
+#endif
+
+      // Copy parameters
+      // k
+      "mov r8, [r14 + 0]\t\n"
+      // A
+      "mov r9, [r14 + 8]\t\n"
+      // B
+      "mov r10, [r14 + 16]\t\n"
+      // beta
+      "vbroadcastss ymm31,DWORD PTR [r14 + 24]\t\n"
+      // C
+      "mov r12, [r14 + 32]\t\n"
+      // ldc
+      "mov r13, [r14 + 40]\t\n"
+      // b_block_cols
+      "mov rdi, [r14 + 48]\t\n"
+      // b_block_size
+      "mov rsi, [r14 + 56]\t\n"
+
+      // Make copies of A and C
+      "mov rax, r9\t\n"
+      "mov rcx, r12\t\n"
+
+      "mov rbx, 0\t\n"
+      "loop_outter%=:\t\n"
+      "mov r14, 0\t\n"
+      "vxorps xmm0, xmm0, xmm0\t\n"
+      "vcomiss xmm31, xmm0\t\n"
+      "jz zero_regs%=\t\n"
+
+      // Setup values with beta multiplication
+      "vmulps ymm0, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm1, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm2, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm3, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm4, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm5, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm6, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm7, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm8, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm9, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm10, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm11, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm12, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm13, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm14, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm15, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm16, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm17, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm18, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm19, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm20, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm21, ymm31, [r12 + 32]\t\n"
+      "mov r12, rcx\t\n"
+      "jmp loop_inner%=\t\n"
+
+      "zero_regs%=:\t\n"
+
+      "vxorps ymm0, ymm0, ymm0\t\n"
+      "vxorps ymm1, ymm1, ymm1\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm2, ymm2, ymm2\t\n"
+      "vxorps ymm3, ymm3, ymm3\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm4, ymm4, ymm4\t\n"
+      "vxorps ymm5, ymm5, ymm5\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm6, ymm6, ymm6\t\n"
+      "vxorps ymm7, ymm7, ymm7\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm8, ymm8, ymm8\t\n"
+      "vxorps ymm9, ymm9, ymm9\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm10, ymm10, ymm10\t\n"
+      "vxorps ymm11, ymm11, ymm11\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm12, ymm12, ymm12\t\n"
+      "vxorps ymm13, ymm13, ymm13\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm14, ymm14, ymm14\t\n"
+      "vxorps ymm15, ymm15, ymm15\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm16, ymm16, ymm16\t\n"
+      "vxorps ymm17, ymm17, ymm17\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm18, ymm18, ymm18\t\n"
+      "vxorps ymm19, ymm19, ymm19\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm20, ymm20, ymm20\t\n"
+      "vxorps ymm21, ymm21, ymm21\t\n"
+      "mov r12, rcx\t\n"
+
+      "loop_inner%=:\t\n"
+
+      "vcvtph2ps ymm23,XMMWORD PTR [r10 + 0]\t\n"
+      "vcvtph2ps ymm24,XMMWORD PTR [r10 + 16]\t\n"
+      "vbroadcastss ymm22,DWORD PTR [r9+0]\t\n"
+      "vfmadd231ps ymm0,ymm23,ymm22\t\n"
+      "vfmadd231ps ymm1,ymm24,ymm22\t\n"
+      "vbroadcastss ymm22,DWORD PTR [r9+4]\t\n"
+      "vfmadd231ps ymm2,ymm23,ymm22\t\n"
+      "vfmadd231ps ymm3,ymm24,ymm22\t\n"
+      "vbroadcastss ymm22,DWORD PTR [r9+8]\t\n"
+      "vfmadd231ps ymm4,ymm23,ymm22\t\n"
+      "vfmadd231ps ymm5,ymm24,ymm22\t\n"
+      "vbroadcastss ymm22,DWORD PTR [r9+12]\t\n"
+      "vfmadd231ps ymm6,ymm23,ymm22\t\n"
+      "vfmadd231ps ymm7,ymm24,ymm22\t\n"
+      "vbroadcastss ymm22,DWORD PTR [r9+16]\t\n"
+      "vfmadd231ps ymm8,ymm23,ymm22\t\n"
+      "vfmadd231ps ymm9,ymm24,ymm22\t\n"
+      "vbroadcastss ymm22,DWORD PTR [r9+20]\t\n"
+      "vfmadd231ps ymm10,ymm23,ymm22\t\n"
+      "vfmadd231ps ymm11,ymm24,ymm22\t\n"
+      "vbroadcastss ymm22,DWORD PTR [r9+24]\t\n"
+      "vfmadd231ps ymm12,ymm23,ymm22\t\n"
+      "vfmadd231ps ymm13,ymm24,ymm22\t\n"
+      "vbroadcastss ymm22,DWORD PTR [r9+28]\t\n"
+      "vfmadd231ps ymm14,ymm23,ymm22\t\n"
+      "vfmadd231ps ymm15,ymm24,ymm22\t\n"
+      "vbroadcastss ymm22,DWORD PTR [r9+32]\t\n"
+      "vfmadd231ps ymm16,ymm23,ymm22\t\n"
+      "vfmadd231ps ymm17,ymm24,ymm22\t\n"
+      "vbroadcastss ymm22,DWORD PTR [r9+36]\t\n"
+      "vfmadd231ps ymm18,ymm23,ymm22\t\n"
+      "vfmadd231ps ymm19,ymm24,ymm22\t\n"
+      "vbroadcastss ymm22,DWORD PTR [r9+40]\t\n"
+      "vfmadd231ps ymm20,ymm23,ymm22\t\n"
+      "vfmadd231ps ymm21,ymm24,ymm22\t\n"
+      "add r9,44\t\n"
+      "add r10,32\t\n"
+      "inc r14\t\n"
+      "cmp r14, r8\t\n"
+      "jl loop_inner%=\t\n"
+
+      // Dump C
+      "vmovups ymmword PTR [r12 + 0], ymm0\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm1\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm2\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm3\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm4\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm5\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm6\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm7\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm8\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm9\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm10\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm11\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm12\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm13\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm14\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm15\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm16\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm17\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm18\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm19\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm20\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm21\t\n"
+
+      // next outer iteration
+      "add rcx, 64\t\n"
+      "mov r12, rcx\t\n"
+      "mov r9, rax\t\n"
+      "inc rbx\t\n"
+      "cmp rbx, rdi\t\n"
+      "jl loop_outter%=\t\n"
+      :
+      : [gp] "rm"(gp)
+      : "r8",
+        "r9",
+        "r10",
+        "r11",
+        "r13",
+        "r14",
+        "rax",
+        "rcx",
+        "rsi",
+        "rdi",
+        "rbx",
+        "r12",
+        "memory");
+}
+void __attribute__((noinline))
+gemmkernel_12x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  asm volatile(
+#if !defined(__clang__)
+      "mov r14, %[gp]\t\n"
+#else
+      "mov %[gp], %%r14\t\n"
+      ".intel_syntax noprefix\t\n"
+#endif
+
+      // Copy parameters
+      // k
+      "mov r8, [r14 + 0]\t\n"
+      // A
+      "mov r9, [r14 + 8]\t\n"
+      // B
+      "mov r10, [r14 + 16]\t\n"
+      // beta
+      "vbroadcastss ymm31,DWORD PTR [r14 + 24]\t\n"
+      // C
+      "mov r12, [r14 + 32]\t\n"
+      // ldc
+      "mov r13, [r14 + 40]\t\n"
+      // b_block_cols
+      "mov rdi, [r14 + 48]\t\n"
+      // b_block_size
+      "mov rsi, [r14 + 56]\t\n"
+
+      // Make copies of A and C
+      "mov rax, r9\t\n"
+      "mov rcx, r12\t\n"
+
+      "mov rbx, 0\t\n"
+      "loop_outter%=:\t\n"
+      "mov r14, 0\t\n"
+      "vxorps xmm0, xmm0, xmm0\t\n"
+      "vcomiss xmm31, xmm0\t\n"
+      "jz zero_regs%=\t\n"
+
+      // Setup values with beta multiplication
+      "vmulps ymm0, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm1, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm2, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm3, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm4, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm5, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm6, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm7, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm8, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm9, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm10, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm11, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm12, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm13, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm14, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm15, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm16, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm17, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm18, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm19, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm20, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm21, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm22, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm23, ymm31, [r12 + 32]\t\n"
+      "mov r12, rcx\t\n"
+      "jmp loop_inner%=\t\n"
+
+      "zero_regs%=:\t\n"
+
+      "vxorps ymm0, ymm0, ymm0\t\n"
+      "vxorps ymm1, ymm1, ymm1\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm2, ymm2, ymm2\t\n"
+      "vxorps ymm3, ymm3, ymm3\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm4, ymm4, ymm4\t\n"
+      "vxorps ymm5, ymm5, ymm5\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm6, ymm6, ymm6\t\n"
+      "vxorps ymm7, ymm7, ymm7\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm8, ymm8, ymm8\t\n"
+      "vxorps ymm9, ymm9, ymm9\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm10, ymm10, ymm10\t\n"
+      "vxorps ymm11, ymm11, ymm11\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm12, ymm12, ymm12\t\n"
+      "vxorps ymm13, ymm13, ymm13\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm14, ymm14, ymm14\t\n"
+      "vxorps ymm15, ymm15, ymm15\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm16, ymm16, ymm16\t\n"
+      "vxorps ymm17, ymm17, ymm17\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm18, ymm18, ymm18\t\n"
+      "vxorps ymm19, ymm19, ymm19\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm20, ymm20, ymm20\t\n"
+      "vxorps ymm21, ymm21, ymm21\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm22, ymm22, ymm22\t\n"
+      "vxorps ymm23, ymm23, ymm23\t\n"
+      "mov r12, rcx\t\n"
+
+      "loop_inner%=:\t\n"
+
+      "vcvtph2ps ymm25,XMMWORD PTR [r10 + 0]\t\n"
+      "vcvtph2ps ymm26,XMMWORD PTR [r10 + 16]\t\n"
+      "vbroadcastss ymm24,DWORD PTR [r9+0]\t\n"
+      "vfmadd231ps ymm0,ymm25,ymm24\t\n"
+      "vfmadd231ps ymm1,ymm26,ymm24\t\n"
+      "vbroadcastss ymm24,DWORD PTR [r9+4]\t\n"
+      "vfmadd231ps ymm2,ymm25,ymm24\t\n"
+      "vfmadd231ps ymm3,ymm26,ymm24\t\n"
+      "vbroadcastss ymm24,DWORD PTR [r9+8]\t\n"
+      "vfmadd231ps ymm4,ymm25,ymm24\t\n"
+      "vfmadd231ps ymm5,ymm26,ymm24\t\n"
+      "vbroadcastss ymm24,DWORD PTR [r9+12]\t\n"
+      "vfmadd231ps ymm6,ymm25,ymm24\t\n"
+      "vfmadd231ps ymm7,ymm26,ymm24\t\n"
+      "vbroadcastss ymm24,DWORD PTR [r9+16]\t\n"
+      "vfmadd231ps ymm8,ymm25,ymm24\t\n"
+      "vfmadd231ps ymm9,ymm26,ymm24\t\n"
+      "vbroadcastss ymm24,DWORD PTR [r9+20]\t\n"
+      "vfmadd231ps ymm10,ymm25,ymm24\t\n"
+      "vfmadd231ps ymm11,ymm26,ymm24\t\n"
+      "vbroadcastss ymm24,DWORD PTR [r9+24]\t\n"
+      "vfmadd231ps ymm12,ymm25,ymm24\t\n"
+      "vfmadd231ps ymm13,ymm26,ymm24\t\n"
+      "vbroadcastss ymm24,DWORD PTR [r9+28]\t\n"
+      "vfmadd231ps ymm14,ymm25,ymm24\t\n"
+      "vfmadd231ps ymm15,ymm26,ymm24\t\n"
+      "vbroadcastss ymm24,DWORD PTR [r9+32]\t\n"
+      "vfmadd231ps ymm16,ymm25,ymm24\t\n"
+      "vfmadd231ps ymm17,ymm26,ymm24\t\n"
+      "vbroadcastss ymm24,DWORD PTR [r9+36]\t\n"
+      "vfmadd231ps ymm18,ymm25,ymm24\t\n"
+      "vfmadd231ps ymm19,ymm26,ymm24\t\n"
+      "vbroadcastss ymm24,DWORD PTR [r9+40]\t\n"
+      "vfmadd231ps ymm20,ymm25,ymm24\t\n"
+      "vfmadd231ps ymm21,ymm26,ymm24\t\n"
+      "vbroadcastss ymm24,DWORD PTR [r9+44]\t\n"
+      "vfmadd231ps ymm22,ymm25,ymm24\t\n"
+      "vfmadd231ps ymm23,ymm26,ymm24\t\n"
+      "add r9,48\t\n"
+      "add r10,32\t\n"
+      "inc r14\t\n"
+      "cmp r14, r8\t\n"
+      "jl loop_inner%=\t\n"
+
+      // Dump C
+      "vmovups ymmword PTR [r12 + 0], ymm0\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm1\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm2\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm3\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm4\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm5\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm6\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm7\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm8\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm9\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm10\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm11\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm12\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm13\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm14\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm15\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm16\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm17\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm18\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm19\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm20\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm21\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm22\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm23\t\n"
+
+      // next outer iteration
+      "add rcx, 64\t\n"
+      "mov r12, rcx\t\n"
+      "mov r9, rax\t\n"
+      "inc rbx\t\n"
+      "cmp rbx, rdi\t\n"
+      "jl loop_outter%=\t\n"
+      :
+      : [gp] "rm"(gp)
+      : "r8",
+        "r9",
+        "r10",
+        "r11",
+        "r13",
+        "r14",
+        "rax",
+        "rcx",
+        "rsi",
+        "rdi",
+        "rbx",
+        "r12",
+        "memory");
+}
+void __attribute__((noinline))
+gemmkernel_13x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  asm volatile(
+#if !defined(__clang__)
+      "mov r14, %[gp]\t\n"
+#else
+      "mov %[gp], %%r14\t\n"
+      ".intel_syntax noprefix\t\n"
+#endif
+
+      // Copy parameters
+      // k
+      "mov r8, [r14 + 0]\t\n"
+      // A
+      "mov r9, [r14 + 8]\t\n"
+      // B
+      "mov r10, [r14 + 16]\t\n"
+      // beta
+      "vbroadcastss ymm31,DWORD PTR [r14 + 24]\t\n"
+      // C
+      "mov r12, [r14 + 32]\t\n"
+      // ldc
+      "mov r13, [r14 + 40]\t\n"
+      // b_block_cols
+      "mov rdi, [r14 + 48]\t\n"
+      // b_block_size
+      "mov rsi, [r14 + 56]\t\n"
+
+      // Make copies of A and C
+      "mov rax, r9\t\n"
+      "mov rcx, r12\t\n"
+
+      "mov rbx, 0\t\n"
+      "loop_outter%=:\t\n"
+      "mov r14, 0\t\n"
+      "vxorps xmm0, xmm0, xmm0\t\n"
+      "vcomiss xmm31, xmm0\t\n"
+      "jz zero_regs%=\t\n"
+
+      // Setup values with beta multiplication
+      "vmulps ymm0, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm1, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm2, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm3, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm4, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm5, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm6, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm7, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm8, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm9, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm10, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm11, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm12, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm13, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm14, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm15, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm16, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm17, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm18, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm19, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm20, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm21, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm22, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm23, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm24, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm25, ymm31, [r12 + 32]\t\n"
+      "mov r12, rcx\t\n"
+      "jmp loop_inner%=\t\n"
+
+      "zero_regs%=:\t\n"
+
+      "vxorps ymm0, ymm0, ymm0\t\n"
+      "vxorps ymm1, ymm1, ymm1\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm2, ymm2, ymm2\t\n"
+      "vxorps ymm3, ymm3, ymm3\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm4, ymm4, ymm4\t\n"
+      "vxorps ymm5, ymm5, ymm5\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm6, ymm6, ymm6\t\n"
+      "vxorps ymm7, ymm7, ymm7\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm8, ymm8, ymm8\t\n"
+      "vxorps ymm9, ymm9, ymm9\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm10, ymm10, ymm10\t\n"
+      "vxorps ymm11, ymm11, ymm11\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm12, ymm12, ymm12\t\n"
+      "vxorps ymm13, ymm13, ymm13\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm14, ymm14, ymm14\t\n"
+      "vxorps ymm15, ymm15, ymm15\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm16, ymm16, ymm16\t\n"
+      "vxorps ymm17, ymm17, ymm17\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm18, ymm18, ymm18\t\n"
+      "vxorps ymm19, ymm19, ymm19\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm20, ymm20, ymm20\t\n"
+      "vxorps ymm21, ymm21, ymm21\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm22, ymm22, ymm22\t\n"
+      "vxorps ymm23, ymm23, ymm23\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm24, ymm24, ymm24\t\n"
+      "vxorps ymm25, ymm25, ymm25\t\n"
+      "mov r12, rcx\t\n"
+
+      "loop_inner%=:\t\n"
+
+      "vcvtph2ps ymm27,XMMWORD PTR [r10 + 0]\t\n"
+      "vcvtph2ps ymm28,XMMWORD PTR [r10 + 16]\t\n"
+      "vbroadcastss ymm26,DWORD PTR [r9+0]\t\n"
+      "vfmadd231ps ymm0,ymm27,ymm26\t\n"
+      "vfmadd231ps ymm1,ymm28,ymm26\t\n"
+      "vbroadcastss ymm26,DWORD PTR [r9+4]\t\n"
+      "vfmadd231ps ymm2,ymm27,ymm26\t\n"
+      "vfmadd231ps ymm3,ymm28,ymm26\t\n"
+      "vbroadcastss ymm26,DWORD PTR [r9+8]\t\n"
+      "vfmadd231ps ymm4,ymm27,ymm26\t\n"
+      "vfmadd231ps ymm5,ymm28,ymm26\t\n"
+      "vbroadcastss ymm26,DWORD PTR [r9+12]\t\n"
+      "vfmadd231ps ymm6,ymm27,ymm26\t\n"
+      "vfmadd231ps ymm7,ymm28,ymm26\t\n"
+      "vbroadcastss ymm26,DWORD PTR [r9+16]\t\n"
+      "vfmadd231ps ymm8,ymm27,ymm26\t\n"
+      "vfmadd231ps ymm9,ymm28,ymm26\t\n"
+      "vbroadcastss ymm26,DWORD PTR [r9+20]\t\n"
+      "vfmadd231ps ymm10,ymm27,ymm26\t\n"
+      "vfmadd231ps ymm11,ymm28,ymm26\t\n"
+      "vbroadcastss ymm26,DWORD PTR [r9+24]\t\n"
+      "vfmadd231ps ymm12,ymm27,ymm26\t\n"
+      "vfmadd231ps ymm13,ymm28,ymm26\t\n"
+      "vbroadcastss ymm26,DWORD PTR [r9+28]\t\n"
+      "vfmadd231ps ymm14,ymm27,ymm26\t\n"
+      "vfmadd231ps ymm15,ymm28,ymm26\t\n"
+      "vbroadcastss ymm26,DWORD PTR [r9+32]\t\n"
+      "vfmadd231ps ymm16,ymm27,ymm26\t\n"
+      "vfmadd231ps ymm17,ymm28,ymm26\t\n"
+      "vbroadcastss ymm26,DWORD PTR [r9+36]\t\n"
+      "vfmadd231ps ymm18,ymm27,ymm26\t\n"
+      "vfmadd231ps ymm19,ymm28,ymm26\t\n"
+      "vbroadcastss ymm26,DWORD PTR [r9+40]\t\n"
+      "vfmadd231ps ymm20,ymm27,ymm26\t\n"
+      "vfmadd231ps ymm21,ymm28,ymm26\t\n"
+      "vbroadcastss ymm26,DWORD PTR [r9+44]\t\n"
+      "vfmadd231ps ymm22,ymm27,ymm26\t\n"
+      "vfmadd231ps ymm23,ymm28,ymm26\t\n"
+      "vbroadcastss ymm26,DWORD PTR [r9+48]\t\n"
+      "vfmadd231ps ymm24,ymm27,ymm26\t\n"
+      "vfmadd231ps ymm25,ymm28,ymm26\t\n"
+      "add r9,52\t\n"
+      "add r10,32\t\n"
+      "inc r14\t\n"
+      "cmp r14, r8\t\n"
+      "jl loop_inner%=\t\n"
+
+      // Dump C
+      "vmovups ymmword PTR [r12 + 0], ymm0\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm1\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm2\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm3\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm4\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm5\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm6\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm7\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm8\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm9\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm10\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm11\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm12\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm13\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm14\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm15\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm16\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm17\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm18\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm19\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm20\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm21\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm22\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm23\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm24\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm25\t\n"
+
+      // next outer iteration
+      "add rcx, 64\t\n"
+      "mov r12, rcx\t\n"
+      "mov r9, rax\t\n"
+      "inc rbx\t\n"
+      "cmp rbx, rdi\t\n"
+      "jl loop_outter%=\t\n"
+      :
+      : [gp] "rm"(gp)
+      : "r8",
+        "r9",
+        "r10",
+        "r11",
+        "r13",
+        "r14",
+        "rax",
+        "rcx",
+        "rsi",
+        "rdi",
+        "rbx",
+        "r12",
+        "memory");
+}
+void __attribute__((noinline))
+gemmkernel_14x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  asm volatile(
+#if !defined(__clang__)
+      "mov r14, %[gp]\t\n"
+#else
+      "mov %[gp], %%r14\t\n"
+      ".intel_syntax noprefix\t\n"
+#endif
+
+      // Copy parameters
+      // k
+      "mov r8, [r14 + 0]\t\n"
+      // A
+      "mov r9, [r14 + 8]\t\n"
+      // B
+      "mov r10, [r14 + 16]\t\n"
+      // beta
+      "vbroadcastss ymm31,DWORD PTR [r14 + 24]\t\n"
+      // C
+      "mov r12, [r14 + 32]\t\n"
+      // ldc
+      "mov r13, [r14 + 40]\t\n"
+      // b_block_cols
+      "mov rdi, [r14 + 48]\t\n"
+      // b_block_size
+      "mov rsi, [r14 + 56]\t\n"
+
+      // Make copies of A and C
+      "mov rax, r9\t\n"
+      "mov rcx, r12\t\n"
+
+      "mov rbx, 0\t\n"
+      "loop_outter%=:\t\n"
+      "mov r14, 0\t\n"
+      "vxorps xmm0, xmm0, xmm0\t\n"
+      "vcomiss xmm31, xmm0\t\n"
+      "jz zero_regs%=\t\n"
+
+      // Setup values with beta multiplication
+      "vmulps ymm0, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm1, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm2, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm3, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm4, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm5, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm6, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm7, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm8, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm9, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm10, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm11, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm12, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm13, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm14, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm15, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm16, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm17, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm18, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm19, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm20, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm21, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm22, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm23, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm24, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm25, ymm31, [r12 + 32]\t\n"
+      "add r12, r13\t\n"
+      "vmulps ymm26, ymm31, [r12 + 0]\t\n"
+      "vmulps ymm27, ymm31, [r12 + 32]\t\n"
+      "mov r12, rcx\t\n"
+      "jmp loop_inner%=\t\n"
+
+      "zero_regs%=:\t\n"
+
+      "vxorps ymm0, ymm0, ymm0\t\n"
+      "vxorps ymm1, ymm1, ymm1\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm2, ymm2, ymm2\t\n"
+      "vxorps ymm3, ymm3, ymm3\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm4, ymm4, ymm4\t\n"
+      "vxorps ymm5, ymm5, ymm5\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm6, ymm6, ymm6\t\n"
+      "vxorps ymm7, ymm7, ymm7\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm8, ymm8, ymm8\t\n"
+      "vxorps ymm9, ymm9, ymm9\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm10, ymm10, ymm10\t\n"
+      "vxorps ymm11, ymm11, ymm11\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm12, ymm12, ymm12\t\n"
+      "vxorps ymm13, ymm13, ymm13\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm14, ymm14, ymm14\t\n"
+      "vxorps ymm15, ymm15, ymm15\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm16, ymm16, ymm16\t\n"
+      "vxorps ymm17, ymm17, ymm17\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm18, ymm18, ymm18\t\n"
+      "vxorps ymm19, ymm19, ymm19\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm20, ymm20, ymm20\t\n"
+      "vxorps ymm21, ymm21, ymm21\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm22, ymm22, ymm22\t\n"
+      "vxorps ymm23, ymm23, ymm23\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm24, ymm24, ymm24\t\n"
+      "vxorps ymm25, ymm25, ymm25\t\n"
+      "add r12, r13\t\n"
+      "vxorps ymm26, ymm26, ymm26\t\n"
+      "vxorps ymm27, ymm27, ymm27\t\n"
+      "mov r12, rcx\t\n"
+
+      "loop_inner%=:\t\n"
+
+      "vcvtph2ps ymm29,XMMWORD PTR [r10 + 0]\t\n"
+      "vcvtph2ps ymm30,XMMWORD PTR [r10 + 16]\t\n"
+      "vbroadcastss ymm28,DWORD PTR [r9+0]\t\n"
+      "vfmadd231ps ymm0,ymm29,ymm28\t\n"
+      "vfmadd231ps ymm1,ymm30,ymm28\t\n"
+      "vbroadcastss ymm28,DWORD PTR [r9+4]\t\n"
+      "vfmadd231ps ymm2,ymm29,ymm28\t\n"
+      "vfmadd231ps ymm3,ymm30,ymm28\t\n"
+      "vbroadcastss ymm28,DWORD PTR [r9+8]\t\n"
+      "vfmadd231ps ymm4,ymm29,ymm28\t\n"
+      "vfmadd231ps ymm5,ymm30,ymm28\t\n"
+      "vbroadcastss ymm28,DWORD PTR [r9+12]\t\n"
+      "vfmadd231ps ymm6,ymm29,ymm28\t\n"
+      "vfmadd231ps ymm7,ymm30,ymm28\t\n"
+      "vbroadcastss ymm28,DWORD PTR [r9+16]\t\n"
+      "vfmadd231ps ymm8,ymm29,ymm28\t\n"
+      "vfmadd231ps ymm9,ymm30,ymm28\t\n"
+      "vbroadcastss ymm28,DWORD PTR [r9+20]\t\n"
+      "vfmadd231ps ymm10,ymm29,ymm28\t\n"
+      "vfmadd231ps ymm11,ymm30,ymm28\t\n"
+      "vbroadcastss ymm28,DWORD PTR [r9+24]\t\n"
+      "vfmadd231ps ymm12,ymm29,ymm28\t\n"
+      "vfmadd231ps ymm13,ymm30,ymm28\t\n"
+      "vbroadcastss ymm28,DWORD PTR [r9+28]\t\n"
+      "vfmadd231ps ymm14,ymm29,ymm28\t\n"
+      "vfmadd231ps ymm15,ymm30,ymm28\t\n"
+      "vbroadcastss ymm28,DWORD PTR [r9+32]\t\n"
+      "vfmadd231ps ymm16,ymm29,ymm28\t\n"
+      "vfmadd231ps ymm17,ymm30,ymm28\t\n"
+      "vbroadcastss ymm28,DWORD PTR [r9+36]\t\n"
+      "vfmadd231ps ymm18,ymm29,ymm28\t\n"
+      "vfmadd231ps ymm19,ymm30,ymm28\t\n"
+      "vbroadcastss ymm28,DWORD PTR [r9+40]\t\n"
+      "vfmadd231ps ymm20,ymm29,ymm28\t\n"
+      "vfmadd231ps ymm21,ymm30,ymm28\t\n"
+      "vbroadcastss ymm28,DWORD PTR [r9+44]\t\n"
+      "vfmadd231ps ymm22,ymm29,ymm28\t\n"
+      "vfmadd231ps ymm23,ymm30,ymm28\t\n"
+      "vbroadcastss ymm28,DWORD PTR [r9+48]\t\n"
+      "vfmadd231ps ymm24,ymm29,ymm28\t\n"
+      "vfmadd231ps ymm25,ymm30,ymm28\t\n"
+      "vbroadcastss ymm28,DWORD PTR [r9+52]\t\n"
+      "vfmadd231ps ymm26,ymm29,ymm28\t\n"
+      "vfmadd231ps ymm27,ymm30,ymm28\t\n"
+      "add r9,56\t\n"
+      "add r10,32\t\n"
+      "inc r14\t\n"
+      "cmp r14, r8\t\n"
+      "jl loop_inner%=\t\n"
+
+      // Dump C
+      "vmovups ymmword PTR [r12 + 0], ymm0\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm1\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm2\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm3\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm4\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm5\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm6\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm7\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm8\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm9\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm10\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm11\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm12\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm13\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm14\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm15\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm16\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm17\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm18\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm19\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm20\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm21\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm22\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm23\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm24\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm25\t\n"
+      "add r12, r13\t\n"
+      "vmovups ymmword PTR [r12 + 0], ymm26\t\n"
+      "vmovups ymmword PTR [r12 + 32], ymm27\t\n"
+
+      // next outer iteration
+      "add rcx, 64\t\n"
+      "mov r12, rcx\t\n"
+      "mov r9, rax\t\n"
+      "inc rbx\t\n"
+      "cmp rbx, rdi\t\n"
+      "jl loop_outter%=\t\n"
+      :
+      : [gp] "rm"(gp)
+      : "r8",
+        "r9",
+        "r10",
+        "r11",
+        "r13",
+        "r14",
+        "rax",
+        "rcx",
+        "rsi",
+        "rdi",
+        "rbx",
+        "r12",
+        "memory");
+}
+
+} // namespace fbgemm

--- a/src/FbgemmFP16UKernelsAvx512_256.h
+++ b/src/FbgemmFP16UKernelsAvx512_256.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+#include <cstdint>
+#include "fbgemm/Types.h"
+
+#include "./FbgemmFP16Common.h"
+
+namespace fbgemm {
+
+void __attribute__((noinline))
+gemmkernel_7x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_8x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_9x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_10x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_11x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_12x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_13x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+void __attribute__((noinline))
+gemmkernel_14x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+
+} // namespace fbgemm

--- a/src/codegen_fp16fp32.cc
+++ b/src/codegen_fp16fp32.cc
@@ -4,6 +4,12 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+/* Arguments to code gen
+ * --prefetch[=n] - use prefetch in code generation, n == prefetch len
+ * --fp32         - generate code for FBGEMM32 (SGEMM)
+ */
+
 #include <assert.h>
 #include <cpuid.h>
 #include <stdlib.h>
@@ -15,6 +21,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <unordered_set>
 
 using namespace std;
 
@@ -24,14 +31,66 @@ void addi(ofstream& of, string i, bool disable = false) {
 }
 
 struct ISA {
-  unsigned avx; // 1, 2 or 3
+  enum class isaType { avx, avx2, avx512, avx512_256 };
+  isaType iset;
   string name;
   vector<vector<unsigned>> shapes;
 };
 
-int main() {
+enum class DataType { Float32, Float16, BFloat16 };
+
+std::array<std::pair<DataType, std::string>, 2> types_to_gen = {
+    std::make_pair(DataType::Float32, "FP32"),
+    std::make_pair(DataType::Float16, "FP16")};
+
+constexpr int cache_line_size = 64;
+constexpr int prefetch_len_default = cache_line_size * 12;
+
+int parseArgumentInt(
+    int argc,
+    const char* argv[],
+    const char* arg,
+    int non_exist_val,
+    int def_val) {
+  int val = non_exist_val;
+  int arg_len = strlen(arg);
+  for (auto i = 1; i < argc; ++i) {
+    const char* ptr = strstr(argv[i], arg);
+    if (ptr) {
+      val = (*(ptr + arg_len) == '=') ? atoi(ptr + arg_len + 1) : def_val;
+      break;
+    }
+  }
+  return val;
+}
+
+bool parseArgumentBool(
+    int argc,
+    const char* argv[],
+    const char* arg,
+    bool def_val) {
+  int arg_len = strlen(arg);
+  for (auto i = 1; i < argc; ++i) {
+    const char* ptr = strstr(argv[i], arg);
+    if (ptr) {
+      return true;
+    }
+  }
+  return def_val;
+}
+
+int main(int argc, const char* argv[]) {
   bool iaca = false;
   bool disable = false;
+  unordered_set<string> enabledDataType;
+
+  // Always generate FP16
+  enabledDataType.insert("FP16");
+  if (parseArgumentBool(argc, argv, "--fp32", false)) {
+    enabledDataType.insert("FP32");
+  }
+  const int prefetch_len =
+      parseArgumentInt(argc, argv, "--prefetch", 0, prefetch_len_default);
 
   bool fixedA = true, fixedB = true, fixedC = true;
 
@@ -39,12 +98,20 @@ int main() {
   __cpuid(1 /* ecx = vendor string */, eax, ebx, ecx, edx);
   printf("FC16 is %s supported\n", ((ecx & bit_F16C) ? " " : "not"));
 
+  static const string license =
+      "/*\n"
+      " * Copyright (c) Facebook, Inc. and its affiliates.\n"
+      " * All rights reserved.\n"
+      " * This source code is licensed under the BSD-style license found in the\n"
+      " * LICENSE file in the root directory of this source tree.\n"
+      " */\n";
+
   string comma = ",";
 
   vector<ISA> isa = {
       // {1, "AVX", {{4, 1, 0}, {4, 2, 0}, {4, 3, 0}, {3, 1, 0}, {3, 2, 0}, {3,
       // 3, 0}}},
-      {2,
+      {ISA::isaType::avx2,
        "Avx2",
        {
            // 4x3 register layout
@@ -77,7 +144,7 @@ int main() {
            // {13, 1, 0},
            // {14, 1, 0},
        }},
-      {3,
+      {ISA::isaType::avx512,
        "Avx512",
        {
            // 14x2 register layout
@@ -95,330 +162,363 @@ int main() {
            {12, 2, 0},
            {13, 2, 0},
            {14, 2, 0},
+       }},
+      {ISA::isaType::avx512_256,
+       "Avx512_256",
+       {
+           // 14x2 register layout
+           // Implemented by AVX2
+           //{1, 2, 0},
+           //{2, 2, 0},
+           //{3, 2, 0},
+           //{4, 2, 0},
+           //{5, 2, 0},
+           //{6, 2, 0},
+           {7, 2, 0},
+           {8, 2, 0},
+           {9, 2, 0},
+           {10, 2, 0},
+           {11, 2, 0},
+           {12, 2, 0},
+           {13, 2, 0},
+           {14, 2, 0},
        }}};
 
-  for (auto s : isa) {
-    string const& isa_file_name = s.name;
-
-    // open all files
-    ofstream srcfile;
-    srcfile.open("FbgemmFP16UKernels" + isa_file_name + ".cc");
-    srcfile
-        << "/*\n"
-           " * Copyright (c) Facebook, Inc. and its affiliates.\n"
-           " * All rights reserved.\n"
-           " * This source code is licensed under the BSD-style license found in the\n"
-           " * LICENSE file in the root directory of this source tree.\n"
-           " */\n";
-    srcfile << "#include \"FbgemmFP16UKernels" + isa_file_name + ".h\"\n\n";
-    srcfile << "namespace fbgemm {\n\n";
-    if (iaca) {
-      srcfile << "#include \"iacaMarks.h\"\n";
+  for (auto& d_type : types_to_gen) {
+    if (enabledDataType.count(d_type.second) == 0) {
+      continue;
     }
+    for (auto s : isa) {
+      bool const isFp16 = d_type.first != DataType::Float32;
+      string const B_type = [&]() {
+        if (d_type.first == DataType::Float32)
+          return "fp32";
+        if (d_type.first == DataType::Float16)
+          return "fp16";
+      }();
 
-    ofstream hdrfile;
-    hdrfile.open("FbgemmFP16UKernels" + isa_file_name + ".h");
-    hdrfile
-        << "/*\n"
-           " * Copyright (c) Facebook, Inc. and its affiliates.\n"
-           " * All rights reserved.\n"
-           " * This source code is licensed under the BSD-style license found in the\n"
-           " * LICENSE file in the root directory of this source tree.\n"
-           " */\n";
+      string isa_file_name = "Fbgemm" + d_type.second + "UKernels" + s.name;
 
-    hdrfile << "#pragma once\n";
-    hdrfile << "#include <cstdint>\n";
-    if (s.avx == 3) {
-      hdrfile << "#include \"FbgemmFP16UKernelsAvx2.h\"\n";
-    }
-    hdrfile << "#include \"fbgemm/Types.h\"\n\n";
-    hdrfile << "namespace fbgemm {\n\n";
-    if (s.avx == 2) {
-      hdrfile << "using fp16 = float16;\n";
-      hdrfile << "using fp32 = float;\n";
-      hdrfile
-          << "struct GemmParams {\n  uint64_t k;\n  float* A;\n  const fp16* B;\n"
-             "  float* beta;\n  uint64_t accum;\n  float* C;\n  uint64_t ldc;\n"
-             "  uint64_t b_block_cols;\n  uint64_t b_block_size;\n};\n";
-    }
+      // open all files
+      ofstream srcfile;
+      srcfile.open(isa_file_name + ".cc");
+      srcfile << license;
+      srcfile << "#include \"./" + isa_file_name + ".h\"\n\n";
+      srcfile << "namespace fbgemm {\n\n";
+      if (iaca) {
+        srcfile << "#include \"iacaMarks.h\"\n";
+      }
 
-    map<string, string> fptr_typedef;
-    fptr_typedef["fp16"] = "";
-    fptr_typedef["fp32"] = "";
+      ofstream hdrfile;
+      hdrfile.open(isa_file_name + ".h");
+      hdrfile << license;
 
-    unsigned labelId = 0;
+      hdrfile << "#pragma once\n";
+      hdrfile << "#include <cstdint>\n";
+      hdrfile << "#include \"fbgemm/Types.h\"\n\n";
+      hdrfile << "#include \"./Fbgemm" + d_type.second + "Common.h\"\n\n";
+      hdrfile << "namespace fbgemm {\n\n";
 
-    bool fixedA = false, fixedB = false, fixedC = false;
-    bool fp16 = true;
+      unsigned labelId = 0;
 
-    vector<vector<unsigned>>& ukernel_shape = s.shapes;
+      bool fixedA = false, fixedB = false, fixedC = false;
 
-    vector<string> funcname(ukernel_shape.size()),
-        fheader(ukernel_shape.size());
-    string fargs;
+      vector<vector<unsigned>>& ukernel_shape = s.shapes;
 
-    string B_type = ((fp16) ? "fp16" : "fp32");
-    string prefix = s.name + /*"_" + B_type */ + "_" + "fA" +
-        to_string(fixedA) + "fB" + to_string(fixedB) + "fC" + to_string(fixedC);
-    cout << "Generating code for " << s.name << " " << B_type << "\n";
+      vector<string> funcname(ukernel_shape.size()),
+          fheader(ukernel_shape.size());
+      string fargs;
 
-    string vec_reg_prefix = s.avx <= 2 ? "ymm" : "zmm";
-    int num_vec_regs = s.avx <= 2 ? 16 : 32;
-    int vec_len_in_bytes = s.avx <= 2 ? 32 : 64;
+      string prefix = s.name + "_" + B_type + "_" + "fA" + to_string(fixedA) +
+          "fB" + to_string(fixedB) + "fC" + to_string(fixedC);
+      cout << "Generating code for " << s.name << " " << B_type << "\n";
 
-    for (unsigned k = 0; k < ukernel_shape.size(); k++) {
-      printf("shape: %d x %d * 32\n", ukernel_shape[k][0], ukernel_shape[k][1]);
+      string vec_reg_prefix = s.iset == ISA::isaType::avx512 ? "zmm" : "ymm";
+      int num_vec_regs = s.iset == ISA::isaType::avx2 ? 16 : 32;
+      int vec_len_in_bytes = s.iset == ISA::isaType::avx512 ? 64 : 32;
 
-      string p1 = "GemmParams* gp";
+      for (unsigned k = 0; k < ukernel_shape.size(); k++) {
+        printf(
+            "shape: %d x %d * 32\n", ukernel_shape[k][0], ukernel_shape[k][1]);
 
-      funcname[k] = "gemmkernel_" + to_string(ukernel_shape[k][0]) + "x" +
-          to_string(ukernel_shape[k][1]) + "_";
-      funcname[k] += prefix;
+        string p1 = "GemmParams" + d_type.second + "* gp";
 
-      fargs = "(" + p1 + ")";
+        funcname[k] = "gemmkernel_" + to_string(ukernel_shape[k][0]) + "x" +
+            to_string(ukernel_shape[k][1]) + "_";
+        funcname[k] += prefix;
 
-      fheader[k] = "void __attribute__((noinline)) " + funcname[k] + fargs;
-      srcfile << fheader[k] << " {\n";
+        fargs = "(" + p1 + ")";
 
-      unsigned last_free_vecreg = 0;
-      // produce register block of C
-      vector<vector<string>> vCtile(ukernel_shape[k][0]);
-      for (auto r = 0; r < ukernel_shape[k][0]; r++)
+        fheader[k] = "void __attribute__((noinline))\n" + funcname[k] + fargs;
+        srcfile << fheader[k] << " {\n";
+
+        unsigned last_free_vecreg = 0;
+        // produce register block of C
+        vector<vector<string>> vCtile(ukernel_shape[k][0]);
+        for (auto r = 0; r < ukernel_shape[k][0]; r++)
+          for (auto c = 0; c < ukernel_shape[k][1]; c++) {
+            vCtile[r].push_back(vec_reg_prefix + to_string(last_free_vecreg));
+            last_free_vecreg++;
+          }
+        assert(last_free_vecreg <= num_vec_regs - 2);
+
+        string vAtmp = vec_reg_prefix + to_string(last_free_vecreg++);
+        // produce register block of B col
+        vector<string> vBcol(ukernel_shape[k][1]);
+
         for (auto c = 0; c < ukernel_shape[k][1]; c++) {
-          vCtile[r].push_back(vec_reg_prefix + to_string(last_free_vecreg));
+          vBcol[c] = (vec_reg_prefix + to_string(last_free_vecreg));
           last_free_vecreg++;
         }
-      assert(last_free_vecreg <= num_vec_regs - 2);
+        assert(last_free_vecreg <= num_vec_regs);
 
-      string vAtmp = vec_reg_prefix + to_string(last_free_vecreg++);
-      // produce register block of B col
-      vector<string> vBcol(ukernel_shape[k][1]);
+        srcfile << "  asm volatile(\n";
 
-      for (auto c = 0; c < ukernel_shape[k][1]; c++) {
-        vBcol[c] = (vec_reg_prefix + to_string(last_free_vecreg));
-        last_free_vecreg++;
-      }
+        srcfile << "#if !defined(__clang__)"
+                << "\n";
+        addi(srcfile, "mov r14, %[gp]");
+        srcfile << "#else\n";
+        addi(srcfile, "mov %[gp], %%r14");
+        addi(srcfile, ".intel_syntax noprefix");
+        srcfile << "#endif\n";
 
-      assert(last_free_vecreg <= num_vec_regs);
-
-      srcfile << "  asm volatile(\n";
-
-      srcfile << "#if !defined(__clang__)"
-              << "\n";
-      addi(srcfile, "mov r14, %[gp]");
-      srcfile << "#else\n";
-      addi(srcfile, "mov %[gp], %%r14");
-      addi(srcfile, ".intel_syntax noprefix");
-      srcfile << "#endif\n";
-
-      srcfile << "\n      // Copy parameters\n";
-      srcfile << "      // k\n";
-      addi(srcfile, "mov r8, [r14 + 0]");
-      srcfile << "      // A\n";
-      addi(srcfile, "mov r9, [r14 + 8]");
-      srcfile << "      // B\n";
-      addi(srcfile, "mov r10, [r14 + 16]");
-      srcfile << "      // beta\n";
-      addi(srcfile, "mov r15, [r14 + 24]");
-      srcfile << "      // accum\n";
-      addi(srcfile, "mov rdx, [r14 + 32]");
-      srcfile << "      // C\n";
-      addi(srcfile, "mov r12, [r14 + 40]");
-      srcfile << "      // ldc\n";
-      addi(srcfile, "mov r13, [r14 + 48]");
-      srcfile << "      // b_block_cols\n";
-      addi(srcfile, "mov rdi, [r14 + 56]");
-      srcfile << "      // b_block_size\n";
-      addi(srcfile, "mov rsi, [r14 + 64]");
-      srcfile << "      // Make copies of A and C\n";
-      addi(srcfile, "mov rax, r9");
-      addi(srcfile, "mov rcx, r12");
-      srcfile << "\n";
-
-      addi(srcfile, "mov rbx, 0");
-
-      string exitlabel = "L_exit%=";
-      string label2 = "loop_outter%=";
-      addi(srcfile, label2 + ":");
-      addi(srcfile, "mov r14, 0");
-
-      // set all vCtile regs to zeros
-      for (auto r = 0; r < vCtile.size(); r++) {
-        for (auto c = 0; c < vCtile[r].size(); c++) {
-          addi(
-              srcfile,
-              "vxorps " + vCtile[r][c] + "," + vCtile[r][c] + "," +
-                  vCtile[r][c]);
-        }
-      }
-
-      // start marker
-      if (iaca) {
-        addi(srcfile, "mov ebx, 111");
-        addi(srcfile, ".byte 0x64, 0x67, 0x90");
-      }
-
-      srcfile << "\n";
-
-      srcfile << "\n";
-      string label = "loop_inner%=";
-      addi(srcfile, label + ":");
-      srcfile << "\n";
-
-      for (int c = 0; c < vCtile[0].size(); c++) {
+        srcfile << "\n";
+        srcfile << "      // Copy parameters\n";
+        srcfile << "      // k\n";
+        addi(srcfile, "mov r8, [r14 + 0]");
+        srcfile << "      // A\n";
+        addi(srcfile, "mov r9, [r14 + 8]");
+        srcfile << "      // B\n";
+        addi(srcfile, "mov r10, [r14 + 16]");
+        srcfile << "      // beta\n";
+        string r_spare = vec_reg_prefix +
+            to_string(num_vec_regs - (s.iset == ISA::isaType::avx ? 2 : 1));
         addi(
             srcfile,
-            "vcvtph2ps " + vBcol[c] + "," + (s.avx <= 2 ? "XMM" : "YMM") +
-                "WORD PTR [r10 + " + to_string(vec_len_in_bytes / 2 * c) + "]");
-      }
+            "vbroadcastss " + r_spare + string(",DWORD PTR [r14 + 24]"),
+            fixedC);
+        srcfile << "      // C\n";
+        addi(srcfile, "mov r12, [r14 + 32]");
+        srcfile << "      // ldc\n";
+        addi(srcfile, "mov r13, [r14 + 40]");
+        srcfile << "      // b_block_cols\n";
+        addi(srcfile, "mov rdi, [r14 + 48]");
+        srcfile << "      // b_block_size\n";
+        addi(srcfile, "mov rsi, [r14 + 56]");
+        srcfile << "\n";
+        srcfile << "      // Make copies of A and C\n";
+        addi(srcfile, "mov rax, r9");
+        addi(srcfile, "mov rcx, r12");
+        srcfile << "\n";
 
-      for (int r = 0; r < vCtile.size(); r++) {
-        addi(
-            srcfile,
-            "vbroadcastss " + vAtmp + ",DWORD PTR [r9+" + to_string(4 * r) +
-                "]");
-        for (int c = 0; c < vCtile[0].size(); c++) {
-          addi(
-              srcfile,
-              "vfmadd231ps " + vCtile[r][c] + "," + vBcol[c] + "," + vAtmp);
-        }
-      }
+        addi(srcfile, "mov rbx, 0");
 
-      addi(
-          srcfile,
-          "add r9," + to_string(4 * ukernel_shape[k][0]),
-          fixedA); // move A ptr
+        string label_outer = "loop_outter%=";
+        addi(srcfile, label_outer + ":");
+        addi(srcfile, "mov r14, 0");
 
-      addi(
-          srcfile,
-          "add r10," + to_string(vec_len_in_bytes / 2 * ukernel_shape[k][1]),
-          fixedA); // move A ptr
+        string label_inner = "loop_inner%=";
+        string label_zero = "zero_regs%=";
+        string r_spare_cmp = "xmm" +
+            to_string(num_vec_regs - (s.iset == ISA::isaType::avx ? 2 : 1));
+        addi(srcfile, "vxorps xmm0, xmm0, xmm0");
+        addi(srcfile, "vcomiss " + r_spare_cmp + ", xmm0");
+        addi(srcfile, "jz " + label_zero);
 
-      addi(srcfile, "inc r14");
-      addi(srcfile, "cmp r14, r8");
-      addi(srcfile, "jl " + label);
-
-      srcfile << "\n";
-
-      addi(srcfile, exitlabel + ":");
-
-      // addi(srcfile, "add r10, rsi");
-      srcfile << "\n";
-
-      // end marker
-      if (iaca) {
-        addi(srcfile, "mov ebx, 222");
-        addi(srcfile, ".byte 0x64, 0x67, 0x90");
-      }
-
-      addi(srcfile, "cmp rdx, 1");
-      addi(srcfile, "je L_accum%=");
-      srcfile << "      // Dump C\n";
-
-      for (auto r = 0; r < vCtile.size(); r++) {
-        for (auto c = 0; c < vCtile[r].size(); c++) {
-          addi(
-              srcfile,
-              "vmovups " + vec_reg_prefix + "word PTR [r12 + " +
-                  to_string(vec_len_in_bytes * c) + "], " + vCtile[r][c],
-              fixedC);
-        }
-        addi(srcfile, "add r12, r13", fixedC); // move C ptr
-      }
-      addi(srcfile, "jmp L_done%=");
-
-      srcfile << "\n";
-      addi(srcfile, "L_accum%=:");
-      srcfile << "      // Dump C with accumulate\n";
-
-      string r_spare =
-          vec_reg_prefix + to_string(num_vec_regs - (s.avx == 1 ? 2 : 1));
-      string r_last = vec_reg_prefix + to_string(num_vec_regs - 1);
-      addi(
-          srcfile,
-          "vbroadcastss " + r_spare + string(",DWORD PTR [r15]"),
-          fixedC);
-      // store out C
-      for (auto r = 0; r < vCtile.size(); r++) {
-        for (auto c = 0; c < vCtile[r].size(); c++) {
-          switch (s.avx) {
-            case 1:
-              addi(
-                  srcfile,
-                  string("vmulps " + r_last + ", ") + r_spare + comma +
-                      "YMMWORD PTR [r12 + " + to_string(vec_len_in_bytes * c) +
-                      "]",
-                  fixedC);
-              addi(
-                  srcfile,
-                  "vaddps " + vCtile[r][c] + "," + vCtile[r][c] + "," + r_last,
-                  fixedC);
-              break;
-            case 2:
-            case 3:
-              addi(
-                  srcfile,
-                  "vfmadd231ps " + vCtile[r][c] + "," + r_spare + "," +
-                      vec_reg_prefix + "word PTR [r12 + " +
-                      to_string(vec_len_in_bytes * c) + "]",
-                  fixedC);
-              break;
-            default:
-              assert(0);
+        srcfile << "\n";
+        srcfile << "      // Setup values with beta multiplication\n";
+        string r_last = vec_reg_prefix + to_string(num_vec_regs - 1);
+        // store out C
+        for (auto r = 0; r < vCtile.size(); r++) {
+          if (r > 0) {
+            addi(srcfile, "add r12, r13", fixedC); // move C ptr
           }
+          for (auto c = 0; c < vCtile[r].size(); c++) {
+            switch (s.iset) {
+              case ISA::isaType::avx:
+              case ISA::isaType::avx2:
+              case ISA::isaType::avx512:
+              case ISA::isaType::avx512_256:
+                if (prefetch_len &&
+                    ((vec_len_in_bytes * c) % cache_line_size == 0)) {
+                  addi(
+                      srcfile,
+                      "prefetcht0 [r12 + " +
+                          to_string(
+                              vec_len_in_bytes * ukernel_shape[k][1] +
+                              c * cache_line_size) +
+                          "]",
+                      fixedC);
+                }
+                addi(
+                    srcfile,
+                    "vmulps " + vCtile[r][c] + ", " + r_spare + ", " +
+                        "[r12 + " + to_string(vec_len_in_bytes * c) + "]",
+                    fixedC);
+                break;
+              default:
+                assert(0);
+            }
+          }
+        }
+        if (vCtile.size() > 1) {
+          addi(srcfile, "mov r12, rcx");
+        }
+        addi(srcfile, "jmp " + label_inner);
+
+        srcfile << "\n";
+        addi(srcfile, label_zero + ":");
+        srcfile << "\n";
+
+        // set all vCtile regs to zeros
+        for (auto r = 0; r < vCtile.size(); r++) {
+          if (r > 0) {
+            addi(srcfile, "add r12, r13", fixedC); // move C ptr
+          }
+          for (auto c = 0; c < vCtile[r].size(); c++) {
+            if (prefetch_len &&
+                ((vec_len_in_bytes * c) % cache_line_size == 0)) {
+              addi(
+                  srcfile,
+                  "prefetcht0 [r12 + " + std::to_string(c * prefetch_len) + "]",
+                  fixedC);
+            }
+            addi(
+                srcfile,
+                "vxorps " + vCtile[r][c] + ", " + vCtile[r][c] + ", " +
+                    vCtile[r][c]);
+          }
+        }
+        if (vCtile.size() > 1) {
+          addi(srcfile, "mov r12, rcx");
+        }
+
+        // start marker
+        if (iaca) {
+          addi(srcfile, "mov ebx, 111");
+          addi(srcfile, ".byte 0x64, 0x67, 0x90");
+        }
+
+        srcfile << "\n";
+        addi(srcfile, label_inner + ":");
+        srcfile << "\n";
+
+        auto const B_load = [&](int c) {
+          if (d_type.first == DataType::Float32) {
+            addi(
+                srcfile,
+                "vmovups " + vBcol[c] + "," +
+                    (s.iset == ISA::isaType::avx512 ? "ZMM" : "YMM") +
+                    "WORD PTR [r10 + " + to_string(vec_len_in_bytes * c) + "]");
+          } else if (d_type.first == DataType::Float16) {
+            addi(
+                srcfile,
+                "vcvtph2ps " + vBcol[c] + "," +
+                    (s.iset == ISA::isaType::avx512 ? "YMM" : "XMM") +
+                    "WORD PTR [r10 + " + to_string(vec_len_in_bytes / 2 * c) +
+                    "]");
+          }
+        };
+
+        for (int c = 0; c < vCtile[0].size(); c++) {
+          B_load(c);
+          if (prefetch_len && ((vec_len_in_bytes * c) % cache_line_size == 0)) {
+            addi(
+                srcfile,
+                "prefetcht0 [r10 + " +
+                    to_string(vec_len_in_bytes * c + prefetch_len) + "]",
+                fixedC);
+          }
+        }
+
+        for (int r = 0; r < vCtile.size(); r++) {
           addi(
               srcfile,
-              "vmovups " + vec_reg_prefix + "word PTR [r12 + " +
-                  to_string(vec_len_in_bytes * c) + "], " + vCtile[r][c],
-              fixedC);
+              "vbroadcastss " + vAtmp + ",DWORD PTR [r9+" + to_string(4 * r) +
+                  "]");
+          for (int c = 0; c < vCtile[0].size(); c++) {
+            addi(
+                srcfile,
+                "vfmadd231ps " + vCtile[r][c] + "," + vBcol[c] + "," + vAtmp);
+          }
         }
-        addi(srcfile, "add r12, r13", fixedC); // move C ptr
+
+        addi(
+            srcfile,
+            "add r9," + to_string(4 * ukernel_shape[k][0]),
+            fixedA); // move A ptr
+
+        addi(
+            srcfile,
+            "add r10," +
+                to_string(
+                    (vec_len_in_bytes >> (int)isFp16) * ukernel_shape[k][1]),
+            fixedA); // move A ptr
+
+        addi(srcfile, "inc r14");
+        addi(srcfile, "cmp r14, r8");
+        addi(srcfile, "jl " + label_inner);
+
+        srcfile << "\n";
+
+        // end marker
+        if (iaca) {
+          addi(srcfile, "mov ebx, 222");
+          addi(srcfile, ".byte 0x64, 0x67, 0x90");
+        }
+
+        srcfile << "      // Dump C\n";
+
+        for (auto r = 0; r < vCtile.size(); r++) {
+          if (r > 0) {
+            addi(srcfile, "add r12, r13", fixedC); // move C ptr
+          }
+          for (auto c = 0; c < vCtile[r].size(); c++) {
+            addi(
+                srcfile,
+                "vmovups " + vec_reg_prefix + "word PTR [r12 + " +
+                    to_string(vec_len_in_bytes * c) + "], " + vCtile[r][c],
+                fixedC);
+          }
+        }
+
+        srcfile << "\n      // next outer iteration\n";
+        // C
+        addi(
+            srcfile,
+            "add rcx, " + to_string(vec_len_in_bytes * ukernel_shape[k][1]),
+            fixedC);
+        addi(srcfile, "mov r12, rcx", fixedC);
+        // A
+        addi(srcfile, "mov r9, rax");
+
+        addi(srcfile, "inc rbx");
+        addi(srcfile, "cmp rbx, rdi");
+        addi(srcfile, "jl " + label_outer);
+
+        // output
+        srcfile << "      :\n";
+        // input
+        srcfile << "      : [gp] \"rm\"(gp)\n";
+
+        // clobbered
+        srcfile << "      : \"r8\",\n        \"r9\",\n        \"r10\",\n"
+                   "        \"r11\",\n        \"r13\",\n"
+                   "        \"r14\",\n        \"rax\",\n        \"rcx\",\n"
+                   "        \"rsi\",\n        \"rdi\",\n"
+                   "        \"rbx\",\n        \"r12\",\n"
+                   "        \"memory\");\n";
+        srcfile << "}\n";
       }
 
-      srcfile << "\n";
-      addi(srcfile, "L_done%=:");
+      for (unsigned k = 0; k < ukernel_shape.size(); k++) {
+        hdrfile << fheader[k] << ";\n";
+      }
 
-      srcfile << "\n      // next outer iteration\n";
-      // C
-      addi(
-          srcfile,
-          "add rcx, " + to_string(vec_len_in_bytes * ukernel_shape[k][1]),
-          fixedC);
-      addi(srcfile, "mov r12, rcx", fixedC);
-      // A
-      addi(srcfile, "mov r9, rax");
-
-      addi(srcfile, "inc rbx");
-      addi(srcfile, "cmp rbx, rdi");
-      addi(srcfile, "jl " + label2);
-
-      // output
-      srcfile << "      :\n";
-      // input
-      srcfile << "      : [gp] \"rm\"(gp)\n";
-
-      // clobbered
-      srcfile << "      : \"r8\",\n        \"r9\",\n        \"r10\",\n"
-                 "        \"r11\",\n        \"r15\",\n        \"r13\",\n"
-                 "        \"r14\",\n        \"rax\",\n        \"rcx\",\n"
-                 "        \"rdx\",\n        \"rsi\",\n        \"rdi\",\n"
-                 "        \"rbx\",\n        \"r12\",\n"
-                 "        \"memory\");\n";
-      srcfile << "}\n";
-    }
-
-    for (unsigned k = 0; k < ukernel_shape.size(); k++) {
-      hdrfile << fheader[k] << ";\n";
-    }
-
-    fptr_typedef[B_type] = "typedef void (*funcptr_" + B_type + ")" + fargs;
-
-    srcfile << "\n} // namespace fbgemm\n";
-    srcfile.close();
-
-    hdrfile << fptr_typedef["fp16"] << ";\n";
-    hdrfile << fptr_typedef["fp32"] << ";\n";
-    hdrfile << "\n} // namespace fbgemm\n\n";
-    hdrfile.close();
-  } // isa
+      srcfile << "\n} // namespace fbgemm\n";
+      srcfile.close();
+      hdrfile << "\n} // namespace fbgemm\n";
+      hdrfile.close();
+    } // isa
+  }
 }


### PR DESCRIPTION
Summary: Add AVX512-256 support to FBGEMM operation. This benefits Intel(r) Xeon(r) D processors by running at higher turbo frequency.

Differential Revision: D18138146

