### PR TITLE
Add the the FP16 <-> FP32 conversion benchmark

### DIFF
--- a/bench/ConvertBenchmark.cc
+++ b/bench/ConvertBenchmark.cc
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include "./BenchUtils.h"
+#include "fbgemm/FbgemmConvert.h"
+#include "fbgemm/Utils.h"
+
+using namespace std;
+using namespace fbgemm;
+
+void performance_test() {
+  constexpr int NWARMUP = 4;
+  constexpr int NITER = 256;
+
+  normal_distribution<float> dist;
+  default_random_engine engine;
+
+  cout << setw(4) << "M"
+       << " elements_per_sec_ref"
+       << " elements_per_sec_simd)" << endl;
+
+  array<int, 8> dims{1, 10, 32, 40, 129, 256, 1024, 8000};
+
+  for (int M : dims) {
+    vector<float> a(M);
+    vector<float> b(M), b_ref(M);
+    vector<float16> t(M);
+
+    generate(a.begin(), a.end(), [&dist, &engine] { return dist(engine); });
+
+    double duration_ref = measureWithWarmup(
+        [&]() {
+          FloatToFloat16_ref(a.data(), t.data(), M);
+          Float16ToFloat_ref(t.data(), b_ref.data(), M);
+        },
+        NWARMUP,
+        NITER);
+    duration_ref *= 1e9; // convert to ns
+
+    double duration_simd = measureWithWarmup(
+        [&]() {
+          FloatToFloat16_simd(a.data(), t.data(), M);
+          Float16ToFloat_simd(t.data(), b.data(), M);
+        },
+        NWARMUP,
+        NITER);
+    duration_simd *= 1e9; // convert to ns
+
+    cout << setw(4) << M << setw(10) << setprecision(3) << M / duration_ref
+         << setw(10) << setprecision(3) << M / duration_simd << endl;
+
+    compare_buffers(b_ref.data(), b.data(), M, 1, 1, 5);
+  } // M
+} // performance_test
+
+int main() {
+  performance_test();
+  return 0;
+}


### PR DESCRIPTION
Summary:
Benchmark result:
```
[root@rtptest10054.frc2 ~/jhuang_test/fbgemm]# numactl --physcpubind 20 --membind 1 ./ConvertBenchmark
   M elements_per_sec_ref elements_per_sec_simd)
   1    0.0217    0.0145
  10    0.0982     0.118
  32     0.131     0.455
  40     0.132     0.504
 129     0.147      1.55
 256      0.15      3.09
1024     0.147      4.25
8000     0.153      4.01
```

The speedup for simd vs. ref is larger than 16x, because the reference implementation uses the slow `cpu_float2half_rn` and `cpu_half2float` implementation.

Reviewed By: dskhudia

Differential Revision: D18889118

