### PR TITLE
fix perf regression in resnet50 and resnet101

### DIFF
--- a/src/FbgemmI8Spmdm.cc
+++ b/src/FbgemmI8Spmdm.cc
@@ -71,10 +71,19 @@ void CompressedSparseColumn::SpMDM(
   t_very_start = std::chrono::high_resolution_clock::now();
 #endif
 
+// Note: These (and others below) cause a ~2-3% overall performance drop in
+// resnet/resnext so we are keeping arrays with dynamic size for gcc/clang and
+// dynamically allocated memory for MSVC even though dynamically allocated
+// memory works for all compilers.
+#ifdef _MSC_VER
   uint8_t* A_buffer =
       static_cast<uint8_t*>(fbgemmAlignedAlloc(64, K * 32 * sizeof(uint8_t)));
   int32_t* C_buffer =
       static_cast<int32_t*>(fbgemmAlignedAlloc(64, N * 32 * sizeof(int32_t)));
+#else
+  alignas(64) uint8_t A_buffer[K * 32];
+  alignas(64) int32_t C_buffer[N * 32];
+#endif
 
   // If we compute C = C + A * B, where B is a sparse matrix in CSC format, for
   // each non-zero in B, we'd need to access the corresponding column in A.
@@ -85,8 +94,12 @@ void CompressedSparseColumn::SpMDM(
     // The cost of transpose is O(K*N) and we do O(NNZ*N) multiplications.
     // If NNZ/K is small, it's not worth doing transpose so we just use this
     // scalar loop.
+#ifdef _MSC_VER
     int32_t* C_temp = static_cast<int32_t*>(
         fbgemmAlignedAlloc(64, block.row_size * sizeof(int32_t)));
+#else
+    int32_t C_temp[block.row_size];
+#endif
     if (accumulation) {
       for (int j = 0; j < block.col_size; ++j) {
         int k = colptr_[block.col_start + j];
@@ -145,9 +158,11 @@ void CompressedSparseColumn::SpMDM(
         }
       } // for each column of B
     }
+#ifdef _MSC_VER
     fbgemmAlignedFree(A_buffer);
     fbgemmAlignedFree(C_buffer);
     fbgemmAlignedFree(C_temp);
+#endif
     return;
   }
 
@@ -164,7 +179,12 @@ void CompressedSparseColumn::SpMDM(
   for (int i1 = block.row_start; i1 < i_end; i1 += 32) {
     // Transpose 32 x K submatrix of A
     if (i_end - i1 < 32) {
+#ifdef _MSC_VER
+      uint8_t* C_temp = static_cast<uint8_t*>(
+          fbgemmAlignedAlloc(64, K * 32 * sizeof(uint8_t)));
+#else
       alignas(64) uint8_t A_temp_buffer[K * 32];
+#endif
       for (int i2 = 0; i2 < (i_end - i1) / 8 * 8; i2 += 8) {
         transpose_8rows(K, A + (i1 + i2) * lda, lda, A_buffer + i2, 32);
       }
@@ -180,6 +200,9 @@ void CompressedSparseColumn::SpMDM(
       for (int i2 = (i_end - i1) / 8 * 8; i2 < 32; i2 += 8) {
         transpose_8rows(K, A_temp_buffer + i2 * K, K, A_buffer + i2, 32);
       }
+#ifdef _MSC_VER
+    fbgemmAlignedFree(A_temp_buffer);
+#endif
     } else {
       for (int i2 = 0; i2 < 32; i2 += 8) {
         transpose_8rows(K, A + (i1 + i2) * lda, lda, A_buffer + i2, 32);
@@ -257,8 +280,10 @@ void CompressedSparseColumn::SpMDM(
   spmdm_run_time += (dt);
   t_start = std::chrono::high_resolution_clock::now();
 #endif
+#ifdef _MSC_VER
   fbgemmAlignedFree(A_buffer);
   fbgemmAlignedFree(C_buffer);
+#endif
 }
 
 void CompressedSparseColumn::SparseConv(


### PR DESCRIPTION
Summary: Making fbgemm work on windows caused a perf regression. Fixing it.

Reviewed By: jspark1105

Differential Revision: D19318092

