### PR TITLE
Cmake changes for MSVC build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,11 @@ set(FBGEMM_GENERIC_SRCS src/EmbeddingSpMDM.cc
 
 #check if compiler supports avx512
 include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG(-mavx512f COMPILER_SUPPORTS_AVX512)
+if(MSVC)
+  CHECK_CXX_COMPILER_FLAG(/arch:AVX512 COMPILER_SUPPORTS_AVX512)
+else(MSVC)
+  CHECK_CXX_COMPILER_FLAG(-mavx512f COMPILER_SUPPORTS_AVX512)
+endif(MSVC)
 if(NOT COMPILER_SUPPORTS_AVX512)
   message(FATAL_ERROR "A compiler with AVX512 support is required.")
 endif()
@@ -85,7 +89,6 @@ endif()
 #All the source files that either use avx2 instructions statically
 set(FBGEMM_AVX2_SRCS
   src/FbgemmBfloat16ConvertAvx2.cc
-  src/FbgemmFP16UKernelsAvx2.cc
   src/FbgemmFloat16ConvertAvx2.cc
   src/FbgemmI8Depthwise3DAvx2.cc
   src/FbgemmI8Depthwise3x3Avx2.cc
@@ -99,10 +102,21 @@ set(FBGEMM_AVX2_SRCS
 #All the source files that use avx512 instructions statically
 set(FBGEMM_AVX512_SRCS
   src/FbgemmBfloat16ConvertAvx512.cc
-  src/FbgemmFP16UKernelsAvx512.cc
   src/FbgemmFloat16ConvertAvx512.cc
-  src/FbgemmFP16UKernelsAvx512_256.cc
   src/UtilsAvx512.cc)
+
+#FP16 kernels contain inline assembly and inline assembly syntax
+#for MSVC is different. Also, MSVC doesn't support inline assembly
+#for x64 builds. We fallback to default slower kernel for MSVC builds
+#for now.
+if(NOT MSVC)
+  list(APPEND FBGEMM_AVX2_SRCS
+    src/FbgemmFP16UKernelsAvx2.cc)
+
+  list(APPEND FBGEMM_AVX512_SRCS
+    src/FbgemmFP16UKernelsAvx512.cc
+    src/FbgemmFP16UKernelsAvx512_256.cc)
+endif()
 
 set(FBGEMM_PUBLIC_HEADERS include/fbgemm/Fbgemm.h
                           include/fbgemm/FbgemmBuild.h
@@ -125,14 +139,20 @@ add_library(fbgemm_avx512 OBJECT ${FBGEMM_AVX512_SRCS})
 
 set_target_properties(fbgemm_generic fbgemm_avx2 fbgemm_avx512 PROPERTIES
       CXX_STANDARD 11
+      CXX_STANDARD_REQUIRED YES
       CXX_EXTENSIONS NO
       CXX_VISIBILITY_PRESET hidden)
 
-target_compile_options(fbgemm_avx2 PRIVATE
-  "-m64" "-mavx2" "-mf16c" "-mfma" "-masm=intel")
-target_compile_options(fbgemm_avx512 PRIVATE
-  "-m64" "-mavx2" "-mfma" "-mavx512f" "-mavx512bw" "-mavx512dq"
-  "-mavx512vl" "-masm=intel")
+if(MSVC)
+  target_compile_options(fbgemm_avx2 PRIVATE "/arch:AVX2")
+  target_compile_options(fbgemm_avx512 PRIVATE "/arch:AVX512")
+else(MSVC)
+  target_compile_options(fbgemm_avx2 PRIVATE
+    "-m64" "-mavx2" "-mf16c" "-mfma" "-masm=intel")
+  target_compile_options(fbgemm_avx512 PRIVATE
+    "-m64" "-mavx2" "-mfma" "-mavx512f" "-mavx512bw" "-mavx512dq"
+    "-mavx512vl" "-masm=intel")
+endif(MSVC)
 
 if(NOT TARGET asmjit)
   #Download asmjit from github if ASMJIT_SRC_DIR is not specified.

--- a/include/fbgemm/QuantUtils.h
+++ b/include/fbgemm/QuantUtils.h
@@ -32,7 +32,7 @@ FBGEMM_API void ChooseRequantizationMultiplier(
 // TODO: T26263653 fix signed-integer-overflow undefined behavior
 template <typename T1, typename T2 = std::uint8_t>
 NO_SANITIZE("signed-integer-overflow")
-FBGEMM_API T2 clamp(T1 src, int precision, bool is_signed = false) {
+T2 clamp(T1 src, int precision, bool is_signed = false) {
   std::int32_t min = is_signed ? -(1LL << (precision - 1)) : 0;
   std::int32_t max =
       is_signed ? ((1LL << (precision - 1)) - 1) : (1LL << precision) - 1;
@@ -49,7 +49,7 @@ FBGEMM_API T2 clamp(T1 src, int precision, bool is_signed = false) {
 /// Quantize src using zero_point and scale, clamp to the specified precision,
 /// and convert it to type T
 template <typename T>
-FBGEMM_API T Quantize(
+T Quantize(
     float src,
     std::int32_t zero_point,
     float scale,
@@ -63,7 +63,7 @@ FBGEMM_API T Quantize(
 }
 
 template <typename T>
-FBGEMM_API T Quantize(float src, const TensorQuantizationParams& qparams) {
+T Quantize(float src, const TensorQuantizationParams& qparams) {
   return Quantize<T>(src, qparams.zero_point, qparams.scale, qparams.precision);
 }
 
@@ -109,12 +109,12 @@ FBGEMM_API void QuantizeGroupwise(
     T* dst);
 
 template <typename T>
-FBGEMM_API float Dequantize(T src, const TensorQuantizationParams& qparams) {
+float Dequantize(T src, const TensorQuantizationParams& qparams) {
   return qparams.scale * (src - qparams.zero_point);
 }
 
 template <typename T>
-FBGEMM_API void Dequantize(
+void Dequantize(
     const T* src,
     float* dst,
     int len,
@@ -131,7 +131,7 @@ FBGEMM_API std::int64_t
 SaturatingRoundingMulWithShift(std::int32_t a, std::int32_t b, int right_shift);
 
 template <typename T>
-FBGEMM_API T Requantize(
+T Requantize(
     std::int32_t src, // int32 input before requantization
     std::int32_t zero_point,
     std::int32_t multiplier,
@@ -145,7 +145,7 @@ FBGEMM_API T Requantize(
 }
 
 template <typename T>
-FBGEMM_API T RequantizeFixedPoint(
+T RequantizeFixedPoint(
     std::int32_t src, // int32 input before requantization
     const RequantizationParams& params) {
   return Requantize<T>(
@@ -167,7 +167,7 @@ FBGEMM_API void RequantizeFixedPoint(
 // Requantization (with floats)
 
 template <typename T>
-FBGEMM_API T Requantize(
+T Requantize(
     std::int32_t src, // int32 input before requantization
     std::int32_t zero_point,
     float multiplier,
@@ -178,7 +178,7 @@ FBGEMM_API T Requantize(
 }
 
 template <typename T>
-FBGEMM_API T Requantize(
+T Requantize(
     std::int32_t src, // int32 input before requantization
     const RequantizationParams& params) {
   return Requantize<T>(

--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -245,7 +245,7 @@ FBGEMM_API thread_type_t fbgemmGetThreadPartition(
     int n_align = 64);
 
 template <int SIZE, typename T = std::int32_t>
-FBGEMM_API std::string arrayToString(const std::array<T, SIZE>& inp) {
+std::string arrayToString(const std::array<T, SIZE>& inp) {
   std::string out = "[";
   for (int i = 0; i < SIZE; ++i) {
     out += std::to_string(inp[i]);
@@ -255,7 +255,7 @@ FBGEMM_API std::string arrayToString(const std::array<T, SIZE>& inp) {
 }
 
 template <typename accT = std::int32_t>
-FBGEMM_API bool isValidBlockingFactor(BlockingFactors* param) {
+bool isValidBlockingFactor(BlockingFactors* param) {
   constexpr bool is_32bit = std::is_same<accT, int32_t>::value;
   constexpr bool is_16bit = std::is_same<accT, int16_t>::value;
   static const auto iset = fbgemmInstructionSet();

--- a/src/FbgemmFP16.cc
+++ b/src/FbgemmFP16.cc
@@ -356,7 +356,7 @@ constexpr std::array<knl_ptr, 15> kernel_avx512 = {
 
 // define this to debug fp16 kernel using a reference C implementation
 // #define FBGEMM_FP16_FALLBACK_TO_REF_KERNEL
-#ifdef FBGEMM_FP16_FALLBACK_TO_REF_KERNEL
+#if defined(FBGEMM_FP16_FALLBACK_TO_REF_KERNEL) || defined(_MSC_VER)
 namespace {
 void ref_kernel(
     int kernel_nrows,
@@ -392,7 +392,7 @@ void ref_kernel(
   }
 }
 } // anonymous namespace
-#endif // FBGEMM_FP16_FALLBACK_TO_REF_KERNEL
+#endif // FBGEMM_FP16_FALLBACK_TO_REF_KERNEL || _MSC_VER
 
 // autotuned kernel splits for various cases m = 1:mb_max
 void cblas_gemm_compute(
@@ -493,7 +493,7 @@ void cblas_gemm_compute(
             gp.C += Bp.blockColSize() * jb_begin;
             gp.b_block_cols = jb_end - jb_begin;
             if (gp.b_block_cols) {
-#ifdef FBGEMM_FP16_FALLBACK_TO_REF_KERNEL
+#if defined(FBGEMM_FP16_FALLBACK_TO_REF_KERNEL) || defined(_MSC_VER)
               ref_kernel(kernel_nrows, &gp, C, m, n, use_avx512);
 #else
               kernels[kernel_nrows](&gp);
@@ -509,7 +509,7 @@ void cblas_gemm_compute(
               gp.C += Bp.blockColSize() * jb_begin;
               gp.b_block_cols = jb_end - jb_begin;
               if (gp.b_block_cols) {
-#ifdef FBGEMM_FP16_FALLBACK_TO_REF_KERNEL
+#if defined(FBGEMM_FP16_FALLBACK_TO_REF_KERNEL) || defined(_MSC_VER)
                 ref_kernel(kernel_nrows, &gp, C, m, n, use_avx512);
 #else
                 kernels[kernel_nrows](&gp);
@@ -535,7 +535,7 @@ void cblas_gemm_compute(
               gp.C = c_tmp;
               gp.ldc = Bp.blockColSize() * sizeof(C[0]);
               gp.b_block_cols = 1;
-#ifdef FBGEMM_FP16_FALLBACK_TO_REF_KERNEL
+#if defined(FBGEMM_FP16_FALLBACK_TO_REF_KERNEL) || defined(_MSC_VER)
               ref_kernel(kernel_nrows, &gp, c_tmp, 14, 32, use_avx512);
 #else
               kernels[kernel_nrows](&gp);

--- a/src/FbgemmI8Spmdm.cc
+++ b/src/FbgemmI8Spmdm.cc
@@ -71,10 +71,19 @@ void CompressedSparseColumn::SpMDM(
   t_very_start = std::chrono::high_resolution_clock::now();
 #endif
 
+// Note: These (and others below) cause a ~2-3% overall performance drop in
+// resnet/resnext so we are keeping arrays with dynamic size for gcc/clang and
+// dynamically allocated memory for MSVC even though dynamically allocated
+// memory works for all compilers.
+#ifdef _MSC_VER
   uint8_t* A_buffer =
       static_cast<uint8_t*>(fbgemmAlignedAlloc(64, K * 32 * sizeof(uint8_t)));
   int32_t* C_buffer =
       static_cast<int32_t*>(fbgemmAlignedAlloc(64, N * 32 * sizeof(int32_t)));
+#else
+  alignas(64) uint8_t A_buffer[K * 32];
+  alignas(64) int32_t C_buffer[N * 32];
+#endif
 
   // If we compute C = C + A * B, where B is a sparse matrix in CSC format, for
   // each non-zero in B, we'd need to access the corresponding column in A.
@@ -85,8 +94,12 @@ void CompressedSparseColumn::SpMDM(
     // The cost of transpose is O(K*N) and we do O(NNZ*N) multiplications.
     // If NNZ/K is small, it's not worth doing transpose so we just use this
     // scalar loop.
+#ifdef _MSC_VER
     int32_t* C_temp = static_cast<int32_t*>(
         fbgemmAlignedAlloc(64, block.row_size * sizeof(int32_t)));
+#else
+    int32_t C_temp[block.row_size];
+#endif
     if (accumulation) {
       for (int j = 0; j < block.col_size; ++j) {
         int k = colptr_[block.col_start + j];
@@ -145,9 +158,11 @@ void CompressedSparseColumn::SpMDM(
         }
       } // for each column of B
     }
+#ifdef _MSC_VER
     fbgemmAlignedFree(A_buffer);
     fbgemmAlignedFree(C_buffer);
     fbgemmAlignedFree(C_temp);
+#endif
     return;
   }
 
@@ -164,7 +179,12 @@ void CompressedSparseColumn::SpMDM(
   for (int i1 = block.row_start; i1 < i_end; i1 += 32) {
     // Transpose 32 x K submatrix of A
     if (i_end - i1 < 32) {
+#ifdef _MSC_VER
+      uint8_t* C_temp = static_cast<uint8_t*>(
+          fbgemmAlignedAlloc(64, K * 32 * sizeof(uint8_t)));
+#else
       alignas(64) uint8_t A_temp_buffer[K * 32];
+#endif
       for (int i2 = 0; i2 < (i_end - i1) / 8 * 8; i2 += 8) {
         transpose_8rows(K, A + (i1 + i2) * lda, lda, A_buffer + i2, 32);
       }
@@ -180,6 +200,9 @@ void CompressedSparseColumn::SpMDM(
       for (int i2 = (i_end - i1) / 8 * 8; i2 < 32; i2 += 8) {
         transpose_8rows(K, A_temp_buffer + i2 * K, K, A_buffer + i2, 32);
       }
+#ifdef _MSC_VER
+    fbgemmAlignedFree(A_temp_buffer);
+#endif
     } else {
       for (int i2 = 0; i2 < 32; i2 += 8) {
         transpose_8rows(K, A + (i1 + i2) * lda, lda, A_buffer + i2, 32);
@@ -257,8 +280,10 @@ void CompressedSparseColumn::SpMDM(
   spmdm_run_time += (dt);
   t_start = std::chrono::high_resolution_clock::now();
 #endif
+#ifdef _MSC_VER
   fbgemmAlignedFree(A_buffer);
   fbgemmAlignedFree(C_buffer);
+#endif
 }
 
 void CompressedSparseColumn::SparseConv(


### PR DESCRIPTION
Summary:
Exclude Fp16 kernels from MSVC build. They fallback to the slower reference implementation. CMake changes to make it work on windows are also included here.

cmake command used to build:
```
 cmake -G Ninja -DFBGEMM_BUILD_BENCHMARKS=OFF -DFBGEMM_BUILD_TESTS=OFF -DFBGEMM
_LIBRARY_TYPE=static -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe"
..

ninja -k 0 all
```
With this change it should build fine but we still need to make tests work and make sure all the tests are passing.

Differential Revision: D19332940

