### PR TITLE
pass the number of rows to EmbeddingSpMDM4Bit

### DIFF
--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -15,7 +15,7 @@ FBGEMM_API bool EmbeddingSpMDM(
     const std::int64_t block_size,
     const std::int64_t output_size,
     const std::int64_t index_size,
-    const std::int64_t data_size,
+    const std::int64_t data_size, // the number of rows in input
     const inType* input,
     const IndexType* indices,
     const int* lengths,
@@ -30,7 +30,7 @@ FBGEMM_API bool EmbeddingSpMDM4Bit(
     const std::int64_t block_size,
     const std::int64_t output_size,
     const std::int64_t index_size,
-    const std::int64_t data_size,
+    const std::int64_t data_size, // the number of rows in input
     const std::uint8_t* input,
     const IndexType* indices,
     const int* lengths,


### PR DESCRIPTION
Summary: To check out of bound errors we need to pass the number of rows not the number of elements of embedding table.

Differential Revision: D19361172

