### PR TITLE
Fix multi-instance benchmarking for fp16

### DIFF
--- a/bench/FP16Benchmark.cc
+++ b/bench/FP16Benchmark.cc
@@ -373,6 +373,10 @@ int main(int argc, const char* argv[]) {
         env_var, "granularity=fine,explicit,proclist=[1-%d]", num_instances);
     setenv("KMP_AFFINITY", env_var, 0); // Don't overide if already set
     omp_set_num_threads(num_instances);
+#ifdef USE_MKL
+    // each instance should be run with a single thread
+    mkl_set_num_threads(1);
+#endif
   } else {
     // When running single instance use OMP_NUM_THREADS to determine
     // parallelism. Default behaviour is using a single thread.


### PR DESCRIPTION
Summary:
In multi-instance mode, MKL should also use 1 thread per instance. By default, MKL uses the same as OMP_NUM_THREADS for each sgemm call.

### Before:
```
[root@rtptest10036.frc2 ~/dskhudia]# ./FP16Benchmark --inst=10 --repit=30
Running 10 instances

                      MKL_FP32 m =    40 n =  2048 k =   488 Gflops = 392.7878 GBytes =  11.8131
                         FBP_t m =    40 n =  2048 k =   488 Gflops = 112.7093 GBytes =   3.3897
```

### After:
```
Running 10 instances

                      MKL_FP32 m =    40 n =  2048 k =   488 Gflops = 106.6754 GBytes =   3.2083
                         FBP_t m =    40 n =  2048 k =   488 Gflops = 112.3782 GBytes =   3.3798
```

Differential Revision: D19375377

