### PR TITLE
add 2-stage EmbeddingSpMDM interface

### DIFF
--- a/bench/BenchUtils.cc
+++ b/bench/BenchUtils.cc
@@ -74,6 +74,14 @@ void llc_flush(std::vector<char>& llc) {
   }
 }
 
+int fbgemm_get_max_threads() {
+#if defined(FBGEMM_MEASURE_TIME_BREAKDOWN) || !defined(_OPENMP)
+  return 1;
+#else
+  return omp_get_max_threads();
+#endif
+}
+
 int fbgemm_get_num_threads() {
 #if defined(FBGEMM_MEASURE_TIME_BREAKDOWN) || !defined(_OPENMP)
   return 1;

--- a/bench/BenchUtils.h
+++ b/bench/BenchUtils.h
@@ -27,7 +27,11 @@ aligned_vector<float> getRandomSparseVector(
 
 void llc_flush(std::vector<char>& llc);
 
+// Same as omp_get_max_threads() when OpenMP is available, otherwise 1
+int fbgemm_get_max_threads();
+// Same as omp_get_num_threads() when OpenMP is available, otherwise 1
 int fbgemm_get_num_threads();
+// Same as omp_get_thread_num() when OpenMP is available, otherwise 0
 int fbgemm_get_thread_num();
 
 template <typename T>

--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -6,10 +6,35 @@
  */
 #pragma once
 #include <cstdint>
+#include <functional>
 
 #include "fbgemm/FbgemmBuild.h"
 
 namespace fbgemm {
+
+template <typename inType, typename IndexType>
+class EmbeddingSpMDMKernelSignature {
+ public:
+  using Type = std::function<bool(
+      std::int64_t output_size,
+      std::int64_t index_size,
+      std::int64_t data_size,
+      const inType* input,
+      const IndexType* indices,
+      const int* lengths,
+      const float* weights, // optional, can be null for non-weighted sum
+      float* out)>;
+};
+
+template <typename inType, typename IndexType>
+FBGEMM_API typename EmbeddingSpMDMKernelSignature<inType, IndexType>::Type
+GenerateEmbeddingSpMDM(
+    const std::int64_t block_size,
+    bool has_weight,
+    bool normalize_by_lengths,
+    int prefetch = 16,
+    bool is_weight_positional = false);
+
 template <typename inType = std::uint8_t, typename IndexType = std::int64_t>
 FBGEMM_API bool EmbeddingSpMDM(
     const std::int64_t block_size,
@@ -22,6 +47,29 @@ FBGEMM_API bool EmbeddingSpMDM(
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
     float* out,
+    int prefetch = 16,
+    bool is_weight_positional = false);
+
+template <typename IndexType>
+class EmbeddingSpMDM4BitKernelSignature {
+ public:
+  using Type = std::function<bool(
+      std::int64_t output_size,
+      std::int64_t index_size,
+      std::int64_t data_size,
+      const std::uint8_t* input,
+      const IndexType* indices,
+      const int* lengths,
+      const float* weights, // optional, can be null for non-weighted sum
+      float* out)>;
+};
+
+template <typename IndexType>
+FBGEMM_API typename EmbeddingSpMDM4BitKernelSignature<IndexType>::Type
+GenerateEmbeddingSpMDM4Bit(
+    const std::int64_t block_size,
+    bool has_weight,
+    bool normalize_by_lengths,
     int prefetch = 16,
     bool is_weight_positional = false);
 

--- a/src/CodeCache.h
+++ b/src/CodeCache.h
@@ -17,18 +17,19 @@ namespace fbgemm {
  * @tparam Key Type of unique key (typically a tuple)
  * @tparam Value Type of the microkernel function (Typically a function pointer)
  */
-template <typename KEY, typename VALUE> class CodeCache {
-private:
+template <typename KEY, typename VALUE>
+class CodeCache {
+ private:
   std::map<KEY, std::shared_future<VALUE>> values_;
   std::mutex mutex_;
 
-public:
-  CodeCache(const CodeCache &) = delete;
-  CodeCache &operator=(const CodeCache &) = delete;
+ public:
+  CodeCache(const CodeCache&) = delete;
+  CodeCache& operator=(const CodeCache&) = delete;
 
   CodeCache(){};
 
-  VALUE getOrCreate(const KEY &key, std::function<VALUE()> generatorFunction) {
+  VALUE getOrCreate(const KEY& key, std::function<VALUE()> generatorFunction) {
     std::shared_future<VALUE> returnFuture;
     std::promise<VALUE> returnPromise;
     bool needsToGenerate = false;


### PR DESCRIPTION
Summary:
Add an option for user to keep JIT'ed EmbeddingSpMDM kernel (similar to sparse matmul and conv kernels in FbgemmSpMM.h and FbgemmSpConv.h).

This can reduce overhead of code cache lookup and contention from locking, which is especially important for functions like EmbeddingSpMDM that is lighter than GEMM.

Added the benchmark an option by setting stress_multi_threading to true for testing contention behavior.
Commenting out #define PRE_GENERATE in the benchmark will test the original 1-stage interface.

Differential Revision: D19425982

