### PR TITLE
use 2-stage EmbeddingSpMDM interface from benchmark and test

### DIFF
--- a/test/EmbeddingSpMDM4BitTest.cc
+++ b/test/EmbeddingSpMDM4BitTest.cc
@@ -154,7 +154,7 @@ TEST_P(Fused4BitRowwiseEmbeddingLookupTest, basicTest) {
     bool success, success_ref;
 
     if (isIndex64b) {
-      success_ref = fbgemm::EmbeddingSpMDM4Bit_ref<int64_t>(
+      success_ref = EmbeddingSpMDM4Bit_ref<int64_t>(
           embedding_dim,
           batch_size,
           lengths_sum,
@@ -167,8 +167,13 @@ TEST_P(Fused4BitRowwiseEmbeddingLookupTest, basicTest) {
           output_ref.data(),
           is_wt_positional);
 
-      success = fbgemm::EmbeddingSpMDM4Bit<int64_t>(
+      auto kernel = GenerateEmbeddingSpMDM4Bit<int64_t>(
           embedding_dim,
+          use_weight,
+          normalize_by_lengths,
+          prefetch,
+          is_wt_positional);
+      success = kernel(
           batch_size,
           lengths_sum,
           num_rows,
@@ -176,12 +181,9 @@ TEST_P(Fused4BitRowwiseEmbeddingLookupTest, basicTest) {
           empty_indices ? nullptr : indices.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
-          normalize_by_lengths,
-          output.data(),
-          prefetch,
-          is_wt_positional);
+          output.data());
     } else {
-      success_ref = fbgemm::EmbeddingSpMDM4Bit_ref<int32_t>(
+      success_ref = EmbeddingSpMDM4Bit_ref<int32_t>(
           embedding_dim,
           batch_size,
           lengths_sum,
@@ -194,8 +196,13 @@ TEST_P(Fused4BitRowwiseEmbeddingLookupTest, basicTest) {
           output_ref.data(),
           is_wt_positional);
 
-      success = fbgemm::EmbeddingSpMDM4Bit<int32_t>(
+      auto kernel = GenerateEmbeddingSpMDM4Bit<int32_t>(
           embedding_dim,
+          use_weight,
+          normalize_by_lengths,
+          prefetch,
+          is_wt_positional);
+      success = kernel(
           batch_size,
           lengths_sum,
           num_rows,
@@ -203,10 +210,7 @@ TEST_P(Fused4BitRowwiseEmbeddingLookupTest, basicTest) {
           empty_indices ? nullptr : indices_32.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
-          normalize_by_lengths,
-          output.data(),
-          prefetch,
-          is_wt_positional);
+          output.data());
     }
 
     // Check correctness

--- a/test/EmbeddingSpMDM8BitTest.cc
+++ b/test/EmbeddingSpMDM8BitTest.cc
@@ -148,7 +148,7 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
     bool success, success_ref;
 
     if (isIndex64b) {
-      success_ref = fbgemm::EmbeddingSpMDM_ref<uint8_t, int64_t>(
+      success_ref = EmbeddingSpMDM_ref<uint8_t, int64_t>(
           embedding_dim,
           batch_size,
           lengths_sum,
@@ -161,8 +161,13 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
           output_ref.data(),
           is_wt_positional);
 
-      success = fbgemm::EmbeddingSpMDM<uint8_t, int64_t>(
+      auto kernel = GenerateEmbeddingSpMDM<uint8_t, int64_t>(
           embedding_dim,
+          use_weight,
+          normalize_by_lengths,
+          prefetch,
+          is_wt_positional);
+      success = kernel(
           batch_size,
           lengths_sum,
           num_rows,
@@ -170,12 +175,9 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
           empty_indices ? nullptr : indices.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
-          normalize_by_lengths,
-          output.data(),
-          prefetch,
-          is_wt_positional);
+          output.data());
     } else {
-      success_ref = fbgemm::EmbeddingSpMDM_ref<uint8_t, int32_t>(
+      success_ref = EmbeddingSpMDM_ref<uint8_t, int32_t>(
           embedding_dim,
           batch_size,
           lengths_sum,
@@ -188,8 +190,13 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
           output_ref.data(),
           is_wt_positional);
 
-      success = fbgemm::EmbeddingSpMDM<uint8_t, int32_t>(
+      auto kernel = GenerateEmbeddingSpMDM<uint8_t, int32_t>(
           embedding_dim,
+          use_weight,
+          normalize_by_lengths,
+          prefetch,
+          is_wt_positional);
+      success = kernel(
           batch_size,
           lengths_sum,
           num_rows,
@@ -197,10 +204,7 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
           empty_indices ? nullptr : indices_32.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
-          normalize_by_lengths,
-          output.data(),
-          prefetch,
-          is_wt_positional);
+          output.data());
     }
 
     // Check correctness

--- a/test/EmbeddingSpMDMTest.cc
+++ b/test/EmbeddingSpMDMTest.cc
@@ -66,7 +66,7 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Bool(), // use_weight
         ::testing::Bool(), // normalize_by_lengths
         ::testing::Bool(), // empty_indices
-        ::testing::Bool())); // empty_indices
+        ::testing::Bool())); // out_of_bounds
 
 TEST_P(EmbeddingSpMDMTest, basicTest) {
   vector<vector<int>> inputs(GetInputs_());
@@ -160,7 +160,7 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
 
     if (isIndex64b) {
       if (isFp16) {
-        success_ref = fbgemm::EmbeddingSpMDM_ref(
+        success_ref = EmbeddingSpMDM_ref(
             embedding_dim,
             batch_size,
             lengths_sum,
@@ -173,8 +173,13 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
             output_ref.data(),
             is_wt_positional);
 
-        success = fbgemm::EmbeddingSpMDM<float16, int64_t>(
+        auto kernel = GenerateEmbeddingSpMDM<float16, int64_t>(
             embedding_dim,
+            use_weight,
+            normalize_by_lengths,
+            prefetch,
+            is_wt_positional);
+        success = kernel(
             batch_size,
             lengths_sum,
             num_rows,
@@ -182,12 +187,9 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
             empty_indices ? nullptr : indices.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
-            normalize_by_lengths,
-            output.data(),
-            prefetch,
-            is_wt_positional);
+            output.data());
       } else {
-        success_ref = fbgemm::EmbeddingSpMDM_ref(
+        success_ref = EmbeddingSpMDM_ref(
             embedding_dim,
             batch_size,
             lengths_sum,
@@ -200,8 +202,13 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
             output_ref.data(),
             is_wt_positional);
 
-        success = fbgemm::EmbeddingSpMDM<float, int64_t>(
+        auto kernel = GenerateEmbeddingSpMDM<float, int64_t>(
             embedding_dim,
+            use_weight,
+            normalize_by_lengths,
+            prefetch,
+            is_wt_positional);
+        success = kernel(
             batch_size,
             lengths_sum,
             num_rows,
@@ -209,14 +216,11 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
             empty_indices ? nullptr : indices.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
-            normalize_by_lengths,
-            output.data(),
-            prefetch,
-            is_wt_positional);
+            output.data());
       }
     } else {
       if (isFp16) {
-        success_ref = fbgemm::EmbeddingSpMDM_ref(
+        success_ref = EmbeddingSpMDM_ref(
             embedding_dim,
             batch_size,
             lengths_sum,
@@ -229,8 +233,13 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
             output_ref.data(),
             is_wt_positional);
 
-        success = fbgemm::EmbeddingSpMDM<float16, int32_t>(
+        auto kernel = GenerateEmbeddingSpMDM<float16, int32_t>(
             embedding_dim,
+            use_weight,
+            normalize_by_lengths,
+            prefetch,
+            is_wt_positional);
+        success = kernel(
             batch_size,
             lengths_sum,
             num_rows,
@@ -238,12 +247,9 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
             empty_indices ? nullptr : indices_32.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
-            normalize_by_lengths,
-            output.data(),
-            prefetch,
-            is_wt_positional);
+            output.data());
       } else {
-        success_ref = fbgemm::EmbeddingSpMDM_ref(
+        success_ref = EmbeddingSpMDM_ref(
             embedding_dim,
             batch_size,
             lengths_sum,
@@ -256,8 +262,13 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
             output_ref.data(),
             is_wt_positional);
 
-        success = fbgemm::EmbeddingSpMDM<float, int32_t>(
+        auto kernel = GenerateEmbeddingSpMDM<float, int32_t>(
             embedding_dim,
+            use_weight,
+            normalize_by_lengths,
+            prefetch,
+            is_wt_positional);
+        success = kernel(
             batch_size,
             lengths_sum,
             num_rows,
@@ -265,10 +276,7 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
             empty_indices ? nullptr : indices_32.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
-            normalize_by_lengths,
-            output.data(),
-            prefetch,
-            is_wt_positional);
+            output.data());
       }
     }
 


### PR DESCRIPTION
Summary: Remove the dependency to the old 1-stage EmbeddingSpMDM interface

Differential Revision: D19460063

