### PR TITLE
Intrinsic implementation of FP16 kernels for windows build (#254)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,14 @@ set(FBGEMM_AVX512_SRCS
 #for MSVC is different. Also, MSVC doesn't support inline assembly
 #for x64 builds. We fallback to default slower kernel for MSVC builds
 #for now.
-if(NOT MSVC)
+if(MSVC)
+  list(APPEND FBGEMM_AVX2_SRCS
+    src/FbgemmFP16UKernelsIntrinsicAvx2.cc)
+
+  list(APPEND FBGEMM_AVX512_SRCS
+    src/FbgemmFP16UKernelsIntrinsicAvx512.cc
+    src/FbgemmFP16UKernelsIntrinsicAvx512_256.cc)
+else()
   list(APPEND FBGEMM_AVX2_SRCS
     src/FbgemmFP16UKernelsAvx2.cc)
 

--- a/bench/FP16Benchmark.cc
+++ b/bench/FP16Benchmark.cc
@@ -365,13 +365,7 @@ int main(int argc, const char* argv[]) {
   if (num_instances > 1) {
     // Set-up execution for multi-instance mode
     // Number of threads in OpenMP parallel region is explicitly
-    // set to the number of instances to be executed
-    // If not previosly set by KMP_AFFINITY env. variable
-    // threads are affinitized sequentially to logical processors
-    char env_var[1024];
-    sprintf(
-        env_var, "granularity=fine,explicit,proclist=[1-%d]", num_instances);
-    setenv("KMP_AFFINITY", env_var, 0); // Don't overide if already set
+    // set to the number of instances to be executed.
     omp_set_num_threads(num_instances);
 #ifdef USE_MKL
     // each instance should be run with a single thread

--- a/bench/PackedRequantizeAcc16Benchmark.cc
+++ b/bench/PackedRequantizeAcc16Benchmark.cc
@@ -9,9 +9,9 @@
 #include <cmath>
 #include <iomanip>
 #include <iostream>
+#include <numeric>
 #include <random>
 #include <vector>
-#include <numeric>
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -156,7 +156,7 @@ void performance_test() {
         },
         NWARMUP,
         NITER,
-        [&] () {
+        [&]() {
           if (flush) {
             llc_flush(llc);
           }

--- a/include/fbgemm/FbgemmBuild.h
+++ b/include/fbgemm/FbgemmBuild.h
@@ -55,7 +55,8 @@
 #if __clang__ || __GNUC__ >= 4 || __INTEL_COMPILER
 #define ALWAYS_INLINE inline __attribute__((__always_inline__))
 #elif _MSC_VER
-#define ALWAYS_INLINE __forceinline
+ // commenting out because __forceinline takes too long time in MSVC
+#define ALWAYS_INLINE // __forceinline
 #else
 #define ALWAYS_INLINE inline
 #endif

--- a/src/FbgemmFP16.cc
+++ b/src/FbgemmFP16.cc
@@ -356,7 +356,7 @@ constexpr std::array<knl_ptr, 15> kernel_avx512 = {
 
 // define this to debug fp16 kernel using a reference C implementation
 // #define FBGEMM_FP16_FALLBACK_TO_REF_KERNEL
-#if defined(FBGEMM_FP16_FALLBACK_TO_REF_KERNEL) || defined(_MSC_VER)
+#if defined(FBGEMM_FP16_FALLBACK_TO_REF_KERNEL)
 namespace {
 void ref_kernel(
     int kernel_nrows,
@@ -394,7 +394,7 @@ void ref_kernel(
   }
 }
 } // anonymous namespace
-#endif // FBGEMM_FP16_FALLBACK_TO_REF_KERNEL || _MSC_VER
+#endif // FBGEMM_FP16_FALLBACK_TO_REF_KERNEL
 
 // autotuned kernel splits for various cases m = 1:mb_max
 void cblas_gemm_compute(
@@ -495,7 +495,7 @@ void cblas_gemm_compute(
             gp.C += Bp.blockColSize() * jb_begin;
             gp.b_block_cols = jb_end - jb_begin;
             if (gp.b_block_cols) {
-#if defined(FBGEMM_FP16_FALLBACK_TO_REF_KERNEL) || defined(_MSC_VER)
+#if defined(FBGEMM_FP16_FALLBACK_TO_REF_KERNEL)
               ref_kernel(kernel_nrows, &gp, C, m, n, use_avx512);
 #else
               kernels[kernel_nrows](&gp);
@@ -511,7 +511,7 @@ void cblas_gemm_compute(
               gp.C += Bp.blockColSize() * jb_begin;
               gp.b_block_cols = jb_end - jb_begin;
               if (gp.b_block_cols) {
-#if defined(FBGEMM_FP16_FALLBACK_TO_REF_KERNEL) || defined(_MSC_VER)
+#if defined(FBGEMM_FP16_FALLBACK_TO_REF_KERNEL)
                 ref_kernel(kernel_nrows, &gp, C, m, n, use_avx512);
 #else
                 kernels[kernel_nrows](&gp);
@@ -537,7 +537,7 @@ void cblas_gemm_compute(
               gp.C = c_tmp;
               gp.ldc = Bp.blockColSize() * sizeof(C[0]);
               gp.b_block_cols = 1;
-#if defined(FBGEMM_FP16_FALLBACK_TO_REF_KERNEL) || defined(_MSC_VER)
+#if defined(FBGEMM_FP16_FALLBACK_TO_REF_KERNEL)
               ref_kernel(kernel_nrows, &gp, c_tmp, 14, 32, use_avx512);
 #else
               kernels[kernel_nrows](&gp);

--- a/src/FbgemmFP16UKernelsIntrinsicAvx2.cc
+++ b/src/FbgemmFP16UKernelsIntrinsicAvx2.cc
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include "./FbgemmFP16UKernelsAvx2.h"
+#include <immintrin.h>
+
+namespace fbgemm {
+
+// Intrinsic kernel for MSVC
+void gemmkernel_Avx2_fp16_fA0fB0fC0(
+    GemmParamsFP16* gp,
+    const size_t kernel_nrows) {
+  // register buffer
+  __m256 ymmSum[12];
+  size_t idxA = 0, idxB = 0, idxC = 0;
+  // ldc in float size
+  size_t ldc_floatsize = gp->ldc / sizeof(float);
+  // load beta
+  __m256 ymmBeta;
+  if (gp->beta != 0)
+    ymmBeta = _mm256_broadcast_ss(&gp->beta);
+
+  // outer loop - block columns
+  for (uint64_t ii = 0; ii < gp->b_block_cols; ii++) {
+    // reset index
+    idxA = 0;
+    // inner loop - k
+    for (uint64_t kk = 0; kk < gp->k; kk++) {
+      // load B
+      __m256 ymmB0 = _mm256_cvtph_ps(_mm_load_si128((__m128i*)(gp->B + idxB)));
+      __m256 ymmB1 =
+          _mm256_cvtph_ps(_mm_load_si128((__m128i*)(gp->B + idxB + 8)));
+      idxB += 16;
+
+      // first element
+      if (kk == 0) {
+        if (gp->beta != 0) { // accumulate
+          for (size_t jj = 0; jj < kernel_nrows; jj++) {
+            // load A
+            __m256 ymmA = _mm256_broadcastss_ps(
+                _mm_broadcast_ss((float const*)(gp->A + idxA + jj)));
+            // C = A * B + beta * C
+            ymmSum[2 * jj] = _mm256_fmadd_ps(
+                ymmA,
+                ymmB0,
+                _mm256_mul_ps(
+                    ymmBeta,
+                    _mm256_loadu_ps(gp->C + idxC + jj * ldc_floatsize)));
+            ymmSum[2 * jj + 1] = _mm256_fmadd_ps(
+                ymmA,
+                ymmB1,
+                _mm256_mul_ps(
+                    ymmBeta,
+                    _mm256_loadu_ps(gp->C + idxC + 8 + jj * ldc_floatsize)));
+          }
+          idxA += kernel_nrows;
+        } else { // set zero
+          for (size_t jj = 0; jj < kernel_nrows; jj++) {
+            // load A
+            __m256 ymmA = _mm256_broadcastss_ps(
+                _mm_broadcast_ss((float const*)(gp->A + idxA + jj)));
+            // C = A * B
+            ymmSum[2 * jj] = _mm256_mul_ps(ymmA, ymmB0);
+            ymmSum[2 * jj + 1] = _mm256_mul_ps(ymmA, ymmB1);
+          }
+          idxA += kernel_nrows;
+        }
+      } else {
+        for (size_t jj = 0; jj < kernel_nrows; jj++) {
+          // load A
+          __m256 ymmA = _mm256_broadcastss_ps(
+              _mm_broadcast_ss((float const*)(gp->A + idxA + jj)));
+          // C = A * B + C
+          ymmSum[2 * jj] = _mm256_fmadd_ps(ymmA, ymmB0, ymmSum[2 * jj]);
+          ymmSum[2 * jj + 1] = _mm256_fmadd_ps(ymmA, ymmB1, ymmSum[2 * jj + 1]);
+        }
+        idxA += kernel_nrows;
+      }
+    }
+    // store C
+    for (size_t jj = 0; jj < kernel_nrows; jj++) {
+      _mm256_storeu_ps(gp->C + idxC + jj * ldc_floatsize, ymmSum[2 * jj]);
+      _mm256_storeu_ps(
+          gp->C + idxC + 8 + jj * ldc_floatsize, ymmSum[2 * jj + 1]);
+    }
+    idxC += 16;
+  }
+}
+
+} // namespace fbgemm

--- a/src/FbgemmFP16UKernelsIntrinsicAvx512.cc
+++ b/src/FbgemmFP16UKernelsIntrinsicAvx512.cc
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include "./FbgemmFP16UKernelsAvx512.h"
+#include <immintrin.h>
+
+namespace fbgemm {
+
+// Intrinsic kernel for MSVC
+void gemmkernel_Avx512_fp16_fA0fB0fC0(
+    GemmParamsFP16* gp,
+    const size_t kernel_nrows) {
+  // register buffer
+  __m512 zmmSum[28];
+  size_t idxA = 0, idxB = 0, idxC = 0;
+  // ldc in float size
+  size_t ldc_floatsize = gp->ldc / sizeof(float);
+  // load beta
+  __m512 zmmBeta;
+  if (gp->beta != 0)
+    zmmBeta = _mm512_broadcastss_ps(_mm_broadcast_ss(&gp->beta));
+
+  // outer loop - block columns
+  for (uint64_t ii = 0; ii < gp->b_block_cols; ii++) {
+    // reset index
+    idxA = 0;
+    // inner loop - k
+    for (uint64_t kk = 0; kk < gp->k; kk++) {
+      // load B
+      __m512 zmmB0 =
+          _mm512_cvtph_ps(_mm256_load_si256((__m256i*)(gp->B + idxB)));
+      __m512 zmmB1 =
+          _mm512_cvtph_ps(_mm256_load_si256((__m256i*)(gp->B + idxB + 16)));
+      idxB += 32;
+
+      // first element
+      if (kk == 0) {
+        if (gp->beta != 0) { // accumulate
+          for (size_t jj = 0; jj < kernel_nrows; jj++) {
+            // load A
+            __m512 zmmA = _mm512_broadcastss_ps(
+                _mm_broadcast_ss((float const*)(gp->A + idxA + jj)));
+            // C = A * B + beta * C
+            zmmSum[2 * jj] = _mm512_fmadd_ps(
+                zmmA,
+                zmmB0,
+                _mm512_mul_ps(
+                    zmmBeta,
+                    _mm512_loadu_ps(gp->C + idxC + jj * ldc_floatsize)));
+            zmmSum[2 * jj + 1] = _mm512_fmadd_ps(
+                zmmA,
+                zmmB1,
+                _mm512_mul_ps(
+                    zmmBeta,
+                    _mm512_loadu_ps(gp->C + idxC + 16 + jj * ldc_floatsize)));
+          }
+          idxA += kernel_nrows;
+        } else { // set zero
+          for (size_t jj = 0; jj < kernel_nrows; jj++) {
+            // load A
+            __m512 zmmA = _mm512_broadcastss_ps(
+                _mm_broadcast_ss((float const*)(gp->A + idxA + jj)));
+            // C = A * B
+            zmmSum[2 * jj] = _mm512_mul_ps(zmmA, zmmB0);
+            zmmSum[2 * jj + 1] = _mm512_mul_ps(zmmA, zmmB1);
+          }
+          idxA += kernel_nrows;
+        }
+      } else {
+        for (size_t jj = 0; jj < kernel_nrows; jj++) {
+          // load A
+          __m512 zmmA = _mm512_broadcastss_ps(
+              _mm_broadcast_ss((float const*)(gp->A + idxA + jj)));
+          // C = A * B + C
+          zmmSum[2 * jj] = _mm512_fmadd_ps(zmmA, zmmB0, zmmSum[2 * jj]);
+          zmmSum[2 * jj + 1] = _mm512_fmadd_ps(zmmA, zmmB1, zmmSum[2 * jj + 1]);
+        }
+        idxA += kernel_nrows;
+      }
+    }
+    // store C
+    for (size_t jj = 0; jj < kernel_nrows; jj++) {
+      _mm512_storeu_ps(gp->C + idxC + jj * ldc_floatsize, zmmSum[2 * jj]);
+      _mm512_storeu_ps(
+          gp->C + idxC + 16 + jj * ldc_floatsize, zmmSum[2 * jj + 1]);
+    }
+    idxC += 32;
+  }
+}
+
+void NOINLINE gemmkernel_1x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 1);
+}
+void NOINLINE gemmkernel_2x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 2);
+}
+void NOINLINE gemmkernel_3x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 3);
+}
+void NOINLINE gemmkernel_4x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 4);
+}
+void NOINLINE gemmkernel_5x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 5);
+}
+void NOINLINE gemmkernel_6x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 6);
+}
+void NOINLINE gemmkernel_7x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 7);
+}
+void NOINLINE gemmkernel_8x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 8);
+}
+void NOINLINE gemmkernel_9x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 9);
+}
+void NOINLINE gemmkernel_10x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 10);
+}
+void NOINLINE gemmkernel_11x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 11);
+}
+void NOINLINE gemmkernel_12x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 12);
+}
+void NOINLINE gemmkernel_13x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 13);
+}
+void NOINLINE gemmkernel_14x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 14);
+}
+
+} // namespace fbgemm

--- a/src/FbgemmFP16UKernelsIntrinsicAvx512_256.cc
+++ b/src/FbgemmFP16UKernelsIntrinsicAvx512_256.cc
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include "./FbgemmFP16UKernelsAvx512_256.h"
+#include <immintrin.h>
+
+namespace fbgemm {
+
+// Intrinsic kernel for MSVC
+void gemmkernel_Avx512_256_fp16_fA0fB0fC0(
+    GemmParamsFP16* gp,
+    const size_t kernel_nrows) {
+  // register buffer
+  __m256 ymmSum[28];
+  size_t idxA = 0, idxB = 0, idxC = 0;
+  // ldc in float size
+  size_t ldc_floatsize = gp->ldc / sizeof(float);
+  // load beta
+  __m256 ymmBeta;
+  if (gp->beta != 0)
+    ymmBeta = _mm256_broadcast_ss(&gp->beta);
+
+  // outer loop - block columns
+  for (uint64_t ii = 0; ii < gp->b_block_cols; ii++) {
+    // reset index
+    idxA = 0;
+    // inner loop - k
+    for (uint64_t kk = 0; kk < gp->k; kk++) {
+      // load B
+      __m256 ymmB0 = _mm256_cvtph_ps(_mm_load_si128((__m128i*)(gp->B + idxB)));
+      __m256 ymmB1 =
+          _mm256_cvtph_ps(_mm_load_si128((__m128i*)(gp->B + idxB + 8)));
+      idxB += 16;
+
+      // first element
+      if (kk == 0) {
+        if (gp->beta != 0) { // accumulate
+          for (size_t jj = 0; jj < kernel_nrows; jj++) {
+            // load A
+            __m256 ymmA = _mm256_broadcastss_ps(
+                _mm_broadcast_ss((float const*)(gp->A + idxA + jj)));
+            // C = A * B + beta * C
+            ymmSum[2 * jj] = _mm256_fmadd_ps(
+                ymmA,
+                ymmB0,
+                _mm256_mul_ps(
+                    ymmBeta,
+                    _mm256_loadu_ps(gp->C + idxC + jj * ldc_floatsize)));
+            ymmSum[2 * jj + 1] = _mm256_fmadd_ps(
+                ymmA,
+                ymmB1,
+                _mm256_mul_ps(
+                    ymmBeta,
+                    _mm256_loadu_ps(gp->C + idxC + 8 + jj * ldc_floatsize)));
+          }
+          idxA += kernel_nrows;
+        } else { // set zero
+          for (size_t jj = 0; jj < kernel_nrows; jj++) {
+            // load A
+            __m256 ymmA = _mm256_broadcastss_ps(
+                _mm_broadcast_ss((float const*)(gp->A + idxA + jj)));
+            // C = A * B
+            ymmSum[2 * jj] = _mm256_mul_ps(ymmA, ymmB0);
+            ymmSum[2 * jj + 1] = _mm256_mul_ps(ymmA, ymmB1);
+          }
+          idxA += kernel_nrows;
+        }
+      } else {
+        for (size_t jj = 0; jj < kernel_nrows; jj++) {
+          // load A
+          __m256 ymmA = _mm256_broadcastss_ps(
+              _mm_broadcast_ss((float const*)(gp->A + idxA + jj)));
+          // C = A * B + C
+          ymmSum[2 * jj] = _mm256_fmadd_ps(ymmA, ymmB0, ymmSum[2 * jj]);
+          ymmSum[2 * jj + 1] = _mm256_fmadd_ps(ymmA, ymmB1, ymmSum[2 * jj + 1]);
+        }
+        idxA += kernel_nrows;
+      }
+    }
+    // store C
+    for (size_t jj = 0; jj < kernel_nrows; jj++) {
+      _mm256_storeu_ps(gp->C + idxC + jj * ldc_floatsize, ymmSum[2 * jj]);
+      _mm256_storeu_ps(
+          gp->C + idxC + 8 + jj * ldc_floatsize, ymmSum[2 * jj + 1]);
+    }
+    idxC += 16;
+  }
+}
+
+void NOINLINE gemmkernel_7x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_256_fp16_fA0fB0fC0(gp, 7);
+}
+void NOINLINE gemmkernel_8x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_256_fp16_fA0fB0fC0(gp, 8);
+}
+void NOINLINE gemmkernel_9x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_256_fp16_fA0fB0fC0(gp, 9);
+}
+void NOINLINE gemmkernel_10x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_256_fp16_fA0fB0fC0(gp, 10);
+}
+void NOINLINE gemmkernel_11x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_256_fp16_fA0fB0fC0(gp, 11);
+}
+void NOINLINE gemmkernel_12x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_256_fp16_fA0fB0fC0(gp, 12);
+}
+void NOINLINE gemmkernel_13x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_256_fp16_fA0fB0fC0(gp, 13);
+}
+void NOINLINE gemmkernel_14x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
+  gemmkernel_Avx512_256_fp16_fA0fB0fC0(gp, 14);
+}
+
+} // namespace fbgemm

--- a/test/Im2ColFusedRequantizeTest.cc
+++ b/test/Im2ColFusedRequantizeTest.cc
@@ -6,8 +6,8 @@
  */
 #include <cmath>
 #include <cstdio>
-#include <random>
 #include <numeric>
+#include <random>
 
 #ifdef _OPENMP
 #include <omp.h>

--- a/test/PackedRequantizeAcc16Test.cc
+++ b/test/PackedRequantizeAcc16Test.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <numeric>
 #include <random>
 #include <vector>
 


### PR DESCRIPTION
Summary:
This PR includes instrinsic API based implementation of FP16 kernels for windows build.
AVX2 is slightly slower or similar speed to the inline assembly version.
AVX512 is slower than inline assembly version for large m size.

Anyway, they are much faster than the reference implementation.

I've done accuracy tests for AVX2 and AVX512.

This is for https://github.com/pytorch/FBGEMM/issues/150 .
Pull Request resolved: https://github.com/pytorch/FBGEMM/pull/254

Differential Revision: D19460473

Pulled By: jspark1105

