### PR TITLE
fix overflow in cache flush

### DIFF
--- a/bench/BenchUtils.h
+++ b/bench/BenchUtils.h
@@ -42,7 +42,7 @@ void cache_evict(const T& vec) {
 
   const char* data = reinterpret_cast<const char*>(vec.data());
   constexpr int CACHE_LINE_SIZE = 64;
-  for (auto i = 0; i < dataSize; i += CACHE_LINE_SIZE) {
+  for (std::size_t i = 0; i < dataSize; i += CACHE_LINE_SIZE) {
     _mm_clflush(&data[i]);
   }
 }


### PR DESCRIPTION
Summary: As title. When benchmarking with a big embedding table, we were getting overflow UBSAN error

Differential Revision: D19462823

