### PR TITLE
2/4-bit EmbeddingSPMDM with rowwise sparsity

### DIFF
--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -35,21 +35,6 @@ GenerateEmbeddingSpMDM(
     int prefetch = 16,
     bool is_weight_positional = false);
 
-template <typename inType = std::uint8_t, typename IndexType = std::int64_t>
-FBGEMM_API bool EmbeddingSpMDM(
-    const std::int64_t block_size,
-    const std::int64_t output_size,
-    const std::int64_t index_size,
-    const std::int64_t data_size, // the number of rows in input
-    const inType* input,
-    const IndexType* indices,
-    const int* lengths,
-    const float* weights, // optional, can be null for non-weighted sum
-    bool normalize_by_lengths,
-    float* out,
-    int prefetch = 16,
-    bool is_weight_positional = false);
-
 template <typename IndexType>
 FBGEMM_API typename EmbeddingSpMDMKernelSignature<std::uint8_t, IndexType>::Type
 GenerateEmbeddingSpMDMNBit(
@@ -59,6 +44,32 @@ GenerateEmbeddingSpMDMNBit(
     bool normalize_by_lengths,
     int prefetch = 16,
     bool is_weight_positional = false);
+
+template <typename IndexType>
+class EmbeddingSpMDMRowWiseSparseKernelSignature {
+ public:
+  using Type = std::function<bool(
+
+      std::int64_t output_size,
+      std::int64_t index_size,
+      std::int64_t uncompressed_data_size,
+      // TODO: add compressed_data_size and check array bound
+      const std::uint8_t* input,
+      const IndexType* indices,
+      const int* lengths,
+      const float* weights, // optional, can be null for non-weighted sum
+      float* out,
+      const IndexType* compressed_indices_table)>;
+};
+
+template <typename IndexType>
+FBGEMM_API typename EmbeddingSpMDMRowWiseSparseKernelSignature<IndexType>::Type
+GenerateEmbeddingSpMDMNBitRowWiseSparse(
+    int bit_rate,
+    const std::int64_t block_size,
+    bool has_weight,
+    bool normalize_by_lengths,
+    int prefetch = 16);
 
 /**
  * @return The number of rows processed. If smaller than num_rows, an error

--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -760,37 +760,6 @@ GenerateEmbeddingSpMDM(
   }
 }
 
-template <typename inType, typename indxType>
-bool EmbeddingSpMDM(
-    const std::int64_t block_size,
-    const std::int64_t output_size,
-    const std::int64_t index_size,
-    const std::int64_t data_size,
-    const inType* input,
-    const indxType* indices,
-    const int* lengths,
-    const float* weights, // optional, can be null for non-weighted sum
-    bool normalize_by_lengths,
-    float* out,
-    int prefetch,
-    bool is_weight_positional) {
-  auto fn = GenerateEmbeddingSpMDM<inType, indxType>(
-      block_size,
-      weights != nullptr,
-      normalize_by_lengths,
-      prefetch,
-      is_weight_positional);
-  return fn(
-      output_size,
-      index_size,
-      data_size,
-      input,
-      indices,
-      lengths,
-      weights,
-      out);
-}
-
 template typename EmbeddingSpMDMKernelSignature<float, std::int64_t>::Type
 GenerateEmbeddingSpMDM<float, std::int64_t>(
     const std::int64_t block_size,
@@ -840,89 +809,5 @@ template
         bool normalize_by_lengths,
         int prefetch,
         bool is_weight_positional);
-
-template bool EmbeddingSpMDM(
-    const std::int64_t block_size,
-    const std::int64_t output_size,
-    const std::int64_t index_size,
-    const std::int64_t data_size,
-    const float* input,
-    const std::int64_t* indices,
-    const int* lengths,
-    const float* weights, // optional, can be null for non-weighted sum
-    bool normalize_by_lengths,
-    float* out,
-    int prefetch,
-    bool is_weight_positional);
-
-template bool EmbeddingSpMDM(
-    const std::int64_t block_size,
-    const std::int64_t output_size,
-    const std::int64_t index_size,
-    const std::int64_t data_size,
-    const float* input,
-    const std::int32_t* indices,
-    const int* lengths,
-    const float* weights, // optional, can be null for non-weighted sum
-    bool normalize_by_lengths,
-    float* out,
-    int prefetch,
-    bool is_weight_positional);
-
-template bool EmbeddingSpMDM(
-    const std::int64_t block_size,
-    const std::int64_t output_size,
-    const std::int64_t index_size,
-    const std::int64_t data_size,
-    const float16* input,
-    const std::int64_t* indices,
-    const int* lengths,
-    const float* weights, // optional, can be null for non-weighted sum
-    bool normalize_by_lengths,
-    float* out,
-    int prefetch,
-    bool is_weight_positional);
-
-template bool EmbeddingSpMDM(
-    const std::int64_t block_size,
-    const std::int64_t output_size,
-    const std::int64_t index_size,
-    const std::int64_t data_size,
-    const float16* input,
-    const std::int32_t* indices,
-    const int* lengths,
-    const float* weights, // optional, can be null for non-weighted sum
-    bool normalize_by_lengths,
-    float* out,
-    int prefetch,
-    bool is_weight_positional);
-
-template bool EmbeddingSpMDM(
-    const std::int64_t block_size,
-    const std::int64_t output_size,
-    const std::int64_t index_size,
-    const std::int64_t data_size,
-    const std::uint8_t* input,
-    const std::int64_t* indices,
-    const int* lengths,
-    const float* weights, // optional, can be null for non-weighted sum
-    bool normalize_by_lengths,
-    float* out,
-    int prefetch,
-    bool is_weight_positional);
-
-template bool EmbeddingSpMDM(
-    const std::int64_t block_size,
-    const std::int64_t output_size,
-    const std::int64_t index_size,
-    const std::int64_t data_size,
-    const std::uint8_t* input,
-    const std::int32_t* indices,
-    const int* lengths,
-    const float* weights, // optional, can be null for non-weighted sum
-    bool normalize_by_lengths,
-    float* out,
-    int prefetch,
-    bool is_weight_positional);
 
 } // namespace fbgemm

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -254,6 +254,23 @@ FBGEMM_API bool EmbeddingSpMDMNBit_ref(
     float* out,
     bool is_weight_positional = false);
 
+template <typename IndexType = std::int64_t>
+FBGEMM_API bool EmbeddingSpMDMNBitRowWiseSparse_ref(
+    int bit_rate,
+    const std::int64_t block_size,
+    const std::int64_t output_size,
+    const std::int64_t index_size,
+    const std::int64_t uncompressed_data_size,
+    // const std::int64_t compressed_data_size,
+    const std::uint8_t* input,
+    const IndexType* indices,
+    const IndexType* compressed_indices_table,
+    const int* lengths,
+    const float* weights, // optional, can be null for non-weighted sum
+    bool normalize_by_lengths,
+    float* out,
+    bool is_weight_positional = false);
+
 template <typename IndexType>
 FBGEMM_API int sparse_adagrad_ref(
     int num_rows, // number of rows reading

--- a/test/EmbeddingSpMDMNBitTest.cc
+++ b/test/EmbeddingSpMDMNBitTest.cc
@@ -236,3 +236,184 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
     delete[] fused_embedding_table;
   } // end for input
 }
+
+TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
+  vector<vector<int>> inputs(GetInputs_());
+  bool isIndex64b, is_wt_positional, use_weight, normalize_by_lengths,
+      empty_indices, out_of_bounds;
+  int bit_rate, prefetch;
+  tie(bit_rate,
+      isIndex64b,
+      is_wt_positional, // ignored
+      prefetch,
+      use_weight,
+      normalize_by_lengths,
+      empty_indices,
+      out_of_bounds) = GetParam();
+
+  int num_elem_per_byte = 8 / bit_rate;
+  constexpr float sparsity = 0.7;
+
+  for (auto input : inputs) {
+    int batch_size = input[0];
+    int num_rows = input[1];
+    int embedding_dim = input[2];
+    int average_len = input[3];
+
+    // Create embedding table
+    default_random_engine generator;
+    normal_distribution<float> embedding_distribution;
+    uniform_int_distribution<int> entries(0, 16);
+
+    vector<int64_t> mapping_table(num_rows);
+    bernoulli_distribution row_prune_dist(sparsity);
+    int num_compressed_rows = 0;
+    for (int i = 0; i < num_rows; ++i) {
+      if (row_prune_dist(generator)) {
+        // pruned
+        mapping_table[i] = -1;
+      } else {
+        mapping_table[i] = num_compressed_rows;
+        ++num_compressed_rows;
+      }
+    }
+    vector<int32_t> mapping_table_32;
+    copy(
+        mapping_table.begin(),
+        mapping_table.end(),
+        back_inserter(mapping_table_32));
+
+    int fused_embedding_dim =
+        (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte +
+        2 * sizeof(float16);
+    uint8_t* fused_embedding_table =
+        new uint8_t[num_compressed_rows * fused_embedding_dim];
+    for (int i = 0; i < num_compressed_rows; i++) {
+      for (int ii = 0;
+           ii < (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte;
+           ii++) {
+        fused_embedding_table[i * fused_embedding_dim + ii] =
+            entries(generator);
+      }
+      float16* scale_bias = reinterpret_cast<float16*>(
+          fused_embedding_table + i * fused_embedding_dim +
+          (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte);
+      float scale = embedding_distribution(generator);
+      float bias = embedding_distribution(generator);
+      FloatToFloat16_ref(&scale, scale_bias, 1, true /* clip */);
+      FloatToFloat16_ref(&bias, scale_bias + 1, 1, true /* clip */);
+    }
+
+    // Generate lengths
+    uniform_int_distribution<int> length_distribution(1, 2 * average_len + 1);
+    vector<int> lengths(batch_size);
+    for (int i = 0; i < batch_size; ++i) {
+      lengths[i] = empty_indices ? 0 : length_distribution(generator);
+    }
+
+    // Compute the number of indices
+    int lengths_sum = accumulate(lengths.begin(), lengths.end(), 0);
+
+    // Generate indices
+    vector<int64_t> indices(lengths_sum);
+    vector<int32_t> indices_32(lengths_sum);
+
+    uniform_int_distribution<int> index_distribution(0, num_rows - 1);
+    for (int i = 0; i < lengths_sum; ++i) {
+      indices_32[i] = indices[i] = index_distribution(generator);
+    }
+    if (!empty_indices && out_of_bounds) {
+      int idx = uniform_int_distribution<int>(0, lengths_sum - 1)(generator);
+      indices_32[idx] = indices[idx] = num_rows;
+
+      // idx = uniform_int_distribution<int>(0, num_rows - 1)(generator);
+      // mapping_table_32[idx] = mapping_table[idx] = num_compressed_rows;
+    }
+    if (!empty_indices) {
+      // to make sure to exercise out-of-bound cases
+      indices_32[0] = indices[0] = num_rows - 1;
+    }
+
+    // Generate weights
+    vector<float> weights(lengths_sum);
+    for (int i = 0; i < lengths_sum; ++i) {
+      weights[i] = embedding_distribution(generator);
+    }
+
+    vector<float> output_sls_ref(batch_size * embedding_dim);
+    vector<float> output_slws_ref(output_sls_ref.size()),
+        output_sls(output_sls_ref.size()), output_slws(output_sls_ref.size());
+
+    vector<float>& output_ref = use_weight ? output_slws_ref : output_sls_ref;
+    vector<float>& output = use_weight ? output_slws : output_sls;
+    bool success, success_ref;
+
+    if (isIndex64b) {
+      success_ref = fbgemm::EmbeddingSpMDMNBitRowWiseSparse_ref<int64_t>(
+          bit_rate,
+          embedding_dim,
+          batch_size,
+          lengths_sum,
+          num_rows,
+          fused_embedding_table,
+          empty_indices ? nullptr : indices.data(),
+          mapping_table.data(),
+          lengths.data(),
+          use_weight ? weights.data() : nullptr,
+          normalize_by_lengths,
+          output_ref.data());
+
+      auto kernel = GenerateEmbeddingSpMDMNBitRowWiseSparse<int64_t>(
+          bit_rate, embedding_dim, use_weight, normalize_by_lengths, prefetch);
+      success = kernel(
+          batch_size,
+          lengths_sum,
+          num_rows,
+          fused_embedding_table,
+          empty_indices ? nullptr : indices.data(),
+          lengths.data(),
+          use_weight ? weights.data() : nullptr,
+          output.data(),
+          mapping_table.data());
+    } else {
+      success_ref = EmbeddingSpMDMNBitRowWiseSparse_ref<int32_t>(
+          bit_rate,
+          embedding_dim,
+          batch_size,
+          lengths_sum,
+          num_rows,
+          fused_embedding_table,
+          empty_indices ? nullptr : indices_32.data(),
+          mapping_table_32.data(),
+          lengths.data(),
+          use_weight ? weights.data() : nullptr,
+          normalize_by_lengths,
+          output_ref.data());
+
+      auto kernel = GenerateEmbeddingSpMDMNBitRowWiseSparse<int32_t>(
+          bit_rate, embedding_dim, use_weight, normalize_by_lengths, prefetch);
+      success = kernel(
+          batch_size,
+          lengths_sum,
+          num_rows,
+          fused_embedding_table,
+          empty_indices ? nullptr : indices_32.data(),
+          lengths.data(),
+          use_weight ? weights.data() : nullptr,
+          output.data(),
+          mapping_table_32.data());
+    }
+
+    // Check correctness
+    EXPECT_EQ(success, success_ref)
+        << "Reference and JIT impl did not both succeed";
+    if (success) {
+      for (int i = 0; i < output.size(); ++i) {
+        EXPECT_EQ(output[i], output_ref[i])
+            << "results differ at (" << i << ") reference: " << output_ref[i]
+            << ", FBGEMM: " << output[i] << " emb dim :" << embedding_dim;
+      }
+    }
+    delete[] fused_embedding_table;
+  } // end for input
+}


### PR DESCRIPTION
Summary: SpMDM for embedding lookup where embedding table has a row-wise sparsity. We have an additional table that maps uncompressed row ids to compressed row ids.

Reviewed By: dskhudia

Differential Revision: D19359178

