### PR TITLE
Fix the _aligned_free() issue on Windows

### DIFF
--- a/test/PackedRequantizeTest.cc
+++ b/test/PackedRequantizeTest.cc
@@ -277,7 +277,8 @@ TEST_P(fbgemmu8s8acc32WithQuantGranularityTest, Test) {
               Aint8.data(),
               (atrans == matrix_op_t::Transpose) ? m : k,
               nullptr,
-              groups);
+              groups,
+              row_offset_buf.data());
 
           int num_threads = fbgemm_get_num_threads();
           int tid = fbgemm_get_thread_num();


### PR DESCRIPTION
Summary:
When we run `PackedRequantizeTest` on Windows, it shows the following error:
"The Block at XXX was allocated by aligned routines, use _aligned_free()".

{F227468367}

The root cause should be the inappropriate allocation API (not Windows compatible) in the Packing routines in FBGEMM. This Diff provides a quick fix in the unit tests (Previously our tests also had bugs as ` row_offset_buf` is declared but not used.

Differential Revision: D19659649

