### PR TITLE
enable positional weight for EmbeddingSpMDMNBitRowWiseSparse

### DIFF
--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -69,7 +69,8 @@ GenerateEmbeddingSpMDMNBitRowWiseSparse(
     const std::int64_t block_size,
     bool has_weight,
     bool normalize_by_lengths,
-    int prefetch = 16);
+    int prefetch = 16,
+    bool is_weight_positional = false);
 
 /**
  * @return The number of rows processed. If smaller than num_rows, an error

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -196,9 +196,7 @@ GenEmbeddingSpMDMNBitLookup<indxType, ROWWISE_SPARSE>::getOrCreate(
         x86::Gp scratchReg2_ = a->gpz(reg_id); // 14 or 15
         x86::Gp scratchReg3_;
         if (instSet == inst_set_t::avx2) {
-          // Can't be combined with ROWWISE_SPARSE
-          ++reg_id;
-          scratchReg3_ = a->gpz(reg_id); // 15
+          scratchReg3_ = a->zax();
         }
 
         asmjit::FuncDetail func;
@@ -925,6 +923,16 @@ GenerateEmbeddingSpMDMNBitRowWiseSparse(
     static GenEmbeddingSpMDMNBitLookup<indxType, true /* rowwise_sparse */>
         kernel_generator;
     return kernel_generator.template getOrCreate<inst_set_t::avx512>(
+        bit_rate,
+        block_size,
+        has_weight,
+        /*is_weight_positional*/ false,
+        normalize_by_lengths,
+        prefetch);
+  } else if (fbgemmHasAvx2Support()) {
+    static GenEmbeddingSpMDMNBitLookup<indxType, true /* rowwise_sparse */>
+        kernel_generator;
+    return kernel_generator.template getOrCreate<inst_set_t::avx2>(
         bit_rate,
         block_size,
         has_weight,

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -913,7 +913,8 @@ GenerateEmbeddingSpMDMNBitRowWiseSparse(
     const int64_t block_size,
     bool has_weight,
     bool normalize_by_lengths,
-    int prefetch) {
+    int prefetch,
+    bool is_weight_positional) {
   assert((bit_rate == 2 || bit_rate == 4) && "bit_rate must be 2 or 4");
 
   if (!cpuinfo_initialize()) {
@@ -926,7 +927,7 @@ GenerateEmbeddingSpMDMNBitRowWiseSparse(
         bit_rate,
         block_size,
         has_weight,
-        /*is_weight_positional*/ false,
+        is_weight_positional,
         normalize_by_lengths,
         prefetch);
   } else if (fbgemmHasAvx2Support()) {
@@ -936,7 +937,7 @@ GenerateEmbeddingSpMDMNBitRowWiseSparse(
         bit_rate,
         block_size,
         has_weight,
-        /*is_weight_positional*/ false,
+        is_weight_positional,
         normalize_by_lengths,
         prefetch);
   } else {
@@ -996,7 +997,8 @@ GenerateEmbeddingSpMDMNBitRowWiseSparse<int64_t>(
     const int64_t block_size,
     bool has_weight,
     bool normalize_by_lengths,
-    int prefetch);
+    int prefetch,
+    bool is_weight_positional);
 
 template typename EmbeddingSpMDMRowWiseSparseKernelSignature<int32_t>::Type
 GenerateEmbeddingSpMDMNBitRowWiseSparse<int32_t>(
@@ -1004,6 +1006,7 @@ GenerateEmbeddingSpMDMNBitRowWiseSparse<int32_t>(
     const int64_t block_size,
     bool has_weight,
     bool normalize_by_lengths,
-    int prefetch);
+    int prefetch,
+    bool is_weight_positional);
 
 } // namespace fbgemm

--- a/test/EmbeddingSpMDMNBitTest.cc
+++ b/test/EmbeddingSpMDMNBitTest.cc
@@ -244,7 +244,7 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
   int bit_rate, prefetch;
   tie(bit_rate,
       isIndex64b,
-      is_wt_positional, // ignored
+      is_wt_positional,
       prefetch,
       use_weight,
       normalize_by_lengths,
@@ -361,10 +361,16 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
           lengths.data(),
           use_weight ? weights.data() : nullptr,
           normalize_by_lengths,
-          output_ref.data());
+          output_ref.data(),
+          is_wt_positional);
 
       auto kernel = GenerateEmbeddingSpMDMNBitRowWiseSparse<int64_t>(
-          bit_rate, embedding_dim, use_weight, normalize_by_lengths, prefetch);
+          bit_rate,
+          embedding_dim,
+          use_weight,
+          normalize_by_lengths,
+          prefetch,
+          is_wt_positional);
       success = kernel(
           batch_size,
           lengths_sum,
@@ -388,10 +394,16 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
           lengths.data(),
           use_weight ? weights.data() : nullptr,
           normalize_by_lengths,
-          output_ref.data());
+          output_ref.data(),
+          is_wt_positional);
 
       auto kernel = GenerateEmbeddingSpMDMNBitRowWiseSparse<int32_t>(
-          bit_rate, embedding_dim, use_weight, normalize_by_lengths, prefetch);
+          bit_rate,
+          embedding_dim,
+          use_weight,
+          normalize_by_lengths,
+          prefetch,
+          is_wt_positional);
       success = kernel(
           batch_size,
           lengths_sum,


### PR DESCRIPTION
Summary: To make interface of EmbeddingSpMDMNbit with row-wise sparsity and without more consistent

Differential Revision: D19686830

