### PR TITLE
make order btw div and mul in adgrad consistent

### DIFF
--- a/src/SparseAdagrad.cc
+++ b/src/SparseAdagrad.cc
@@ -158,9 +158,9 @@ void GenSparseAdagrad<indxType, instSet>::genSparseAdagrad(
           a->vsqrtps(out_vreg, out_vreg);
           a->vaddps(out_vreg, out_vreg, epsilon_vreg);
 
+          a->vmulps(g_vreg, lr_vreg, g_vreg);
           a->vdivps(out_vreg, g_vreg, out_vreg);
 
-          a->vmulps(out_vreg, out_vreg, lr_vreg);
           a->vmaskmovps(x86::ymm(temp_vreg.id()), mask_vreg, w_ptr);
           a->vaddps(out_vreg, out_vreg, temp_vreg);
 
@@ -175,9 +175,9 @@ void GenSparseAdagrad<indxType, instSet>::genSparseAdagrad(
           a->k(x86::k(1)).vsqrtps(out_vreg, out_vreg);
           a->k(x86::k(1)).vaddps(out_vreg, out_vreg, epsilon_vreg);
 
+          a->k(x86::k(1)).vmulps(g_vreg, lr_vreg, g_vreg);
           a->k(x86::k(1)).vdivps(out_vreg, g_vreg, out_vreg);
 
-          a->k(x86::k(1)).vmulps(out_vreg, out_vreg, lr_vreg);
           a->k(x86::k(1)).vaddps(out_vreg, out_vreg, w_ptr);
 
           a->k(x86::k(1)).vmovups(w_ptr, out_vreg);
@@ -192,9 +192,9 @@ void GenSparseAdagrad<indxType, instSet>::genSparseAdagrad(
         a->vsqrtps(out_vreg, out_vreg);
         a->vaddps(out_vreg, out_vreg, epsilon_vreg);
 
+        a->vmulps(g_vreg, lr_vreg, g_vreg);
         a->vdivps(out_vreg, g_vreg, out_vreg);
 
-        a->vmulps(out_vreg, out_vreg, lr_vreg);
         a->vaddps(out_vreg, out_vreg, w_ptr);
 
         a->vmovups(w_ptr, out_vreg);


### PR DESCRIPTION
Summary:
Re-attempt of D18805426 . Decided to be consistent with PyTorch Adagrad

There was an inconsistency in the order of operation between scalar and SIMD code when we compute Adagrad. This diff make them consistent by doing w += lr * grad / (sqrt(moment) + epsilon) in Adagrad and w += lr / (sqrt(moment) + epsilon) * grad in RowWiseSparseAdagrad.

The Adagrad order is consistent with PyTorch (see aten/src/ATen/native/cpu/PointwiseOpsKernel.cpp addcmul_cpu_kernel function). The RowWiseSparseAdagrad order is to make compute more efficient. In RowWiseSparseAdagrad, lr / (sqrt(moment) + epsilon) is shared among all elements in the row

And, we're not going to use FMA to be consistent with PyTorch (even though it provides a little accuracy benefit)

Differential Revision: D19342865

