### PR TITLE
row-wise sparse fp32/fp16/int8 EmbeddingSpMDM

### DIFF
--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -26,6 +26,10 @@ class EmbeddingSpMDMKernelSignature {
       float* out)>;
 };
 
+/**
+ * @tparam inType can be float or uint8_t
+ * @tparam IndexType can be int32_t or int64_t
+ */
 template <typename inType, typename IndexType>
 FBGEMM_API typename EmbeddingSpMDMKernelSignature<inType, IndexType>::Type
 GenerateEmbeddingSpMDM(
@@ -35,6 +39,10 @@ GenerateEmbeddingSpMDM(
     int prefetch = 16,
     bool is_weight_positional = false);
 
+/**
+ * @tparam IndexType can be int32_t or int64_t
+ * @param bit_rate can be 2 or 4
+ */
 template <typename IndexType>
 FBGEMM_API typename EmbeddingSpMDMKernelSignature<std::uint8_t, IndexType>::Type
 GenerateEmbeddingSpMDMNBit(
@@ -45,16 +53,15 @@ GenerateEmbeddingSpMDMNBit(
     int prefetch = 16,
     bool is_weight_positional = false);
 
-template <typename IndexType>
+template <typename inType, typename IndexType>
 class EmbeddingSpMDMRowWiseSparseKernelSignature {
  public:
   using Type = std::function<bool(
-
       std::int64_t output_size,
       std::int64_t index_size,
       std::int64_t uncompressed_data_size,
       // TODO: add compressed_data_size and check array bound
-      const std::uint8_t* input,
+      const inType* input,
       const IndexType* indices,
       const int* lengths,
       const float* weights, // optional, can be null for non-weighted sum
@@ -62,8 +69,28 @@ class EmbeddingSpMDMRowWiseSparseKernelSignature {
       const IndexType* compressed_indices_table)>;
 };
 
+/**
+ * @tparam inType can be float or uint8_t
+ * @tparam IndexType can be int32_t or int64_t
+ */
+template <typename inType, typename IndexType>
+FBGEMM_API
+    typename EmbeddingSpMDMRowWiseSparseKernelSignature<inType, IndexType>::Type
+    GenerateEmbeddingSpMDMRowWiseSparse(
+        const std::int64_t block_size,
+        bool has_weight,
+        bool normalize_by_lengths,
+        int prefetch = 16,
+        bool is_weight_positional = false);
+
+/**
+ * @tparam IndexType can be int32_t or int64_t
+ * @param bit_rate can be 2 or 4
+ */
 template <typename IndexType>
-FBGEMM_API typename EmbeddingSpMDMRowWiseSparseKernelSignature<IndexType>::Type
+FBGEMM_API typename EmbeddingSpMDMRowWiseSparseKernelSignature<
+    std::uint8_t,
+    IndexType>::Type
 GenerateEmbeddingSpMDMNBitRowWiseSparse(
     int bit_rate,
     const std::int64_t block_size,

--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -28,8 +28,11 @@ namespace {
 
 namespace x86 = asmjit::x86;
 
-template <typename inType = std::uint8_t, typename indxType = std::int64_t>
-class ReturnFunctionSignature {
+template <typename inType, typename indxType, bool ROWWISE_SPARSE>
+class ReturnFunctionSignature {};
+
+template <typename inType, typename indxType>
+class ReturnFunctionSignature<inType, indxType, false> {
  public:
   using jit_embedding_kernel = bool (*)(
       std::int64_t output_size,
@@ -42,18 +45,38 @@ class ReturnFunctionSignature {
       float* out);
 };
 
-template <typename inType = std::uint8_t, typename indxType = std::int64_t>
+template <typename inType, typename indxType>
+class ReturnFunctionSignature<inType, indxType, true> {
+ public:
+  using jit_embedding_kernel = bool (*)(
+      std::int64_t output_size,
+      std::int64_t index_size,
+      int64_t uncompressed_data_size,
+      // int64_t compressed_data_size,
+      const inType* input,
+      const indxType* indices,
+      const int* lengths,
+      const float* weights,
+      float* out,
+      const indxType* compressed_indices_table);
+};
+
+template <
+    typename inType = std::uint8_t,
+    typename indxType = std::int64_t,
+    bool ROWWISE_SPARSE = false>
 class GenEmbeddingSpMDMLookup {
  public:
   GenEmbeddingSpMDMLookup() {}
   template <inst_set_t instSet>
-  typename ReturnFunctionSignature<inType, indxType>::jit_embedding_kernel
-  getOrCreate(
-      int block_size,
-      bool has_weight,
-      bool is_weight_positional,
-      bool normalize_by_lengths,
-      int prefetch);
+  typename ReturnFunctionSignature<inType, indxType, ROWWISE_SPARSE>::
+      jit_embedding_kernel
+      getOrCreate(
+          int block_size,
+          bool has_weight,
+          bool is_weight_positional,
+          bool normalize_by_lengths,
+          int prefetch);
 
  private:
   static asmjit::JitRuntime& runtime() {
@@ -70,43 +93,31 @@ class GenEmbeddingSpMDMLookup {
   // positional weights, normalize by lenths, and prefetch distance
   static CodeCache<
       std::tuple<int, bool, bool, bool, int>,
-      typename ReturnFunctionSignature<inType, indxType>::jit_embedding_kernel>
+      typename ReturnFunctionSignature<inType, indxType, ROWWISE_SPARSE>::
+          jit_embedding_kernel>
       codeCache_; ///< JIT Code Cache for reuse.
-
-  // These are the registers shared
-  // between uint8 and fp32 implementations
-  x86::Gp output_size;
-  x86::Gp index_size;
-  x86::Gp data_size;
-  x86::Gp input;
-  x86::Gp indices;
-  x86::Gp lengths;
-  x86::Gp weights;
-  x86::Gp out;
-  x86::Gp scratchReg1_;
-  x86::Gp scratchReg1D_;
-  x86::Gp scratchReg2_;
-  x86::Gpd lengths_R_;
 }; // GenEmbeddingSpmDMLookup
 
-template <typename inType, typename indxType>
-std::mutex GenEmbeddingSpMDMLookup<inType, indxType>::rtMutex_;
+template <typename inType, typename indxType, bool ROWWISE_SPARSE>
+std::mutex GenEmbeddingSpMDMLookup<inType, indxType, ROWWISE_SPARSE>::rtMutex_;
 
-template <typename inType, typename indxType>
+template <typename inType, typename indxType, bool ROWWISE_SPARSE>
 CodeCache<
     std::tuple<int, bool, bool, bool, int>,
-    typename ReturnFunctionSignature<inType, indxType>::jit_embedding_kernel>
-    GenEmbeddingSpMDMLookup<inType, indxType>::codeCache_;
+    typename ReturnFunctionSignature<inType, indxType, ROWWISE_SPARSE>::
+        jit_embedding_kernel>
+    GenEmbeddingSpMDMLookup<inType, indxType, ROWWISE_SPARSE>::codeCache_;
 
-template <typename inType, typename indxType>
+template <typename inType, typename indxType, bool ROWWISE_SPARSE>
 template <inst_set_t instSet>
-typename ReturnFunctionSignature<inType, indxType>::jit_embedding_kernel
-GenEmbeddingSpMDMLookup<inType, indxType>::getOrCreate(
-    int block_size,
-    bool has_weight,
-    bool is_weight_positional,
-    bool normalize_by_lengths,
-    int prefetch) {
+typename ReturnFunctionSignature<inType, indxType, ROWWISE_SPARSE>::
+    jit_embedding_kernel
+    GenEmbeddingSpMDMLookup<inType, indxType, ROWWISE_SPARSE>::getOrCreate(
+        int block_size,
+        bool has_weight,
+        bool is_weight_positional,
+        bool normalize_by_lengths,
+        int prefetch) {
   std::tuple<int, bool, bool, bool, int> kernelSig = std::make_tuple(
       block_size,
       has_weight,
@@ -116,8 +127,10 @@ GenEmbeddingSpMDMLookup<inType, indxType>::getOrCreate(
 
   return codeCache_.getOrCreate(
       kernelSig,
-      [&]() ->
-      typename ReturnFunctionSignature<inType, indxType>::jit_embedding_kernel {
+      [&]() -> typename ReturnFunctionSignature<
+                inType,
+                indxType,
+                ROWWISE_SPARSE>::jit_embedding_kernel {
         bool is8bit = std::is_same<inType, std::uint8_t>::value;
         bool is16bit = std::is_same<inType, float16>::value;
 
@@ -148,39 +161,69 @@ GenEmbeddingSpMDMLookup<inType, indxType>::getOrCreate(
         if (normalize_by_lengths) {
           filename += "_normalize_by_lengths";
         }
+        if (ROWWISE_SPARSE) {
+          filename += "_rowwise_sparse";
+        }
         filename += ".txt";
         FILE* codeLogFile = fopen(filename.c_str(), "w");
         asmjit::FileLogger* codeLogger = new asmjit::FileLogger(codeLogFile);
         code.setLogger(codeLogger);
 #endif
         // arguments to the function created
-        output_size = a->zdi();
+        x86::Gp output_size = a->zdi();
         // index_size will be overwritten to hold the end address of indices
-        index_size = a->zsi();
-        data_size = a->zdx();
-        input = a->zcx();
-        indices = a->gpz(8);
-        lengths = a->gpz(9);
-        weights = a->gpz(10);
-        out = a->gpz(11);
-        lengths_R_ = a->gpz(12).r32();
+        x86::Gp index_size = a->zsi();
+        x86::Gp data_size = a->zdx();
+        x86::Gp input = a->zcx();
+        int reg_id = 8;
+        x86::Gp indices = a->gpz(reg_id); // 8
+        ++reg_id;
+        x86::Gp lengths = a->gpz(reg_id); // 9
+        ++reg_id;
+        x86::Gp weights = a->gpz(reg_id); // 10
+        ++reg_id;
+        x86::Gp out = a->gpz(reg_id); // 11
 
-        scratchReg1_ = a->gpz(13);
-        scratchReg1D_ = a->gpz(13).r32();
-        scratchReg2_ = a->gpz(14);
+        x86::Gp compressed_indices_table;
+        if (ROWWISE_SPARSE) {
+          ++reg_id;
+          compressed_indices_table = a->gpz(reg_id); // 12
+        }
+
+        ++reg_id;
+        x86::Gpd lengths_R_ = a->gpz(reg_id).r32(); // 12 or 13
+        ++reg_id;
+        x86::Gp scratchReg1_ = a->gpz(reg_id); // 13 or 14
+        ++reg_id;
+        x86::Gp scratchReg2_ = a->gpz(reg_id); // 14 or 15
 
         asmjit::FuncDetail func;
 
-        func.init(asmjit::FuncSignatureT<
-                  bool,
-                  std::int64_t, // output_size
-                  std::int64_t, // index_size
-                  std::int64_t, // data_size
-                  const inType*, // input uint8_t or float
-                  const indxType*, // indices
-                  const int*, // lengths
-                  const float*, // weights
-                  float*>(asmjit::CallConv::kIdHost));
+        if (ROWWISE_SPARSE) {
+          func.init(asmjit::FuncSignatureT<
+                    bool,
+                    std::int64_t, // output_size
+                    std::int64_t, // index_size
+                    std::int64_t, // uncompressed_data_size
+                    const inType*, // input uint8_t or float
+                    const indxType*, // indices
+                    const int*, // lengths
+                    const float*, // weights
+                    float*, // out
+                    const indxType* /* compressed_indices_table */>(
+              asmjit::CallConv::kIdHost));
+        } else {
+          func.init(asmjit::FuncSignatureT<
+                    bool,
+                    std::int64_t, // output_size
+                    std::int64_t, // index_size
+                    std::int64_t, // data_size
+                    const inType*, // input uint8_t or float
+                    const indxType*, // indices
+                    const int*, // lengths
+                    const float*, // weights
+                    float* /* out */>(asmjit::CallConv::kIdHost));
+        }
 
         asmjit::FuncFrame frame;
         frame.init(func);
@@ -201,18 +244,33 @@ GenEmbeddingSpMDMLookup<inType, indxType>::getOrCreate(
 
         frame.setDirtyRegs(
             x86::Reg::kGroupGp,
-            asmjit::Support::bitMask(8, 9, 10, 11, 12, 13, 14));
+            reg_id == 15
+                ? asmjit::Support::bitMask(8, 9, 10, 11, 12, 13, 14, 15)
+                : asmjit::Support::bitMask(8, 9, 10, 11, 12, 13, 14));
 
         asmjit::FuncArgsAssignment args(&func);
-        args.assignAll(
-            output_size,
-            index_size,
-            data_size,
-            input,
-            indices,
-            lengths,
-            weights,
-            out);
+        if (ROWWISE_SPARSE) {
+          args.assignAll(
+              output_size,
+              index_size,
+              data_size,
+              input,
+              indices,
+              lengths,
+              weights,
+              out,
+              compressed_indices_table);
+        } else {
+          args.assignAll(
+              output_size,
+              index_size,
+              data_size,
+              input,
+              indices,
+              lengths,
+              weights,
+              out);
+        }
 
         args.updateFuncFrame(frame);
         frame.finalize();
@@ -389,15 +447,27 @@ GenEmbeddingSpMDMLookup<inType, indxType>::getOrCreate(
           a->cmp(scratchReg1_, data_size);
           a->jge(error);
 
-          int fused_block_size =
-              block_size * sizeof(uint8_t) + 2 * sizeof(float);
-          if (is8bit) {
-            a->imul(scratchReg1_, static_cast<asmjit::Imm>(fused_block_size));
-          } else {
-            a->imul(
-                scratchReg1_,
-                static_cast<asmjit::Imm>(block_size * sizeof(inType)));
+          if (ROWWISE_SPARSE) {
+            if (areIndices64b) {
+              a->mov(
+                  scratchReg1_,
+                  x86::qword_ptr(
+                      compressed_indices_table,
+                      scratchReg1_,
+                      3)); // use of 3 is to multiply by 8
+            } else {
+              a->mov(
+                  scratchReg1_.r32(),
+                  x86::dword_ptr(
+                      compressed_indices_table,
+                      scratchReg1_,
+                      2)); // use of 2 is to multiply by 4
+            }
           }
+
+          int fused_block_size = is8bit
+              ? block_size * sizeof(uint8_t) + 2 * sizeof(float)
+              : block_size * sizeof(inType);
 
           if (pref_dist) {
             asmjit::Label pref_dist_reset_start = a->newLabel();
@@ -438,17 +508,43 @@ GenEmbeddingSpMDMLookup<inType, indxType>::getOrCreate(
             }
 
             a->bind(pref_dist_reset_end);
-            if (is8bit) {
-              // This has to be fused_block_size
-              a->imul(scratchReg2_, static_cast<asmjit::Imm>(fused_block_size));
-            } else {
-              a->imul(
-                  scratchReg2_,
-                  static_cast<asmjit::Imm>(block_size * sizeof(float)));
+            if (ROWWISE_SPARSE) {
+              if (areIndices64b) {
+                a->mov(
+                    scratchReg2_,
+                    x86::qword_ptr(
+                        compressed_indices_table,
+                        scratchReg2_,
+                        3)); // use of 3 is to multiply by 8
+              } else {
+                a->mov(
+                    scratchReg2_.r32(),
+                    x86::dword_ptr(
+                        compressed_indices_table,
+                        scratchReg2_,
+                        2)); // use of 2 is to multiply by 4
+              }
             }
+            a->imul(scratchReg2_, static_cast<asmjit::Imm>(fused_block_size));
           }
 
           a->add(indices, static_cast<asmjit::Imm>(sizeof(indxType)));
+
+          if (has_weight) {
+            a->vbroadcastss(w_vreg, x86::dword_ptr(weights));
+            a->add(weights, static_cast<asmjit::Imm>(sizeof(float)));
+          }
+
+          if (ROWWISE_SPARSE) {
+            if (areIndices64b) {
+              a->cmp(scratchReg1_, static_cast<asmjit::Imm>(-1));
+            } else {
+              a->cmp(scratchReg1_.r32(), static_cast<asmjit::Imm>(-1));
+            }
+            a->je(LoopDataIndexBegin);
+          }
+
+          a->imul(scratchReg1_, static_cast<asmjit::Imm>(fused_block_size));
 
           // broadcast the scale
           x86::Mem scale_src, bias_src;
@@ -464,13 +560,9 @@ GenEmbeddingSpMDMLookup<inType, indxType>::getOrCreate(
             a->vbroadcastss(bias_vreg, bias_src);
           }
 
-          if (has_weight) {
-            a->vbroadcastss(w_vreg, x86::dword_ptr(weights));
-            if (is8bit) {
-              a->vmulps(scale_vreg, scale_vreg, w_vreg);
-              a->vmulps(bias_vreg, bias_vreg, w_vreg);
-            }
-            a->add(weights, static_cast<asmjit::Imm>(sizeof(float)));
+          if (has_weight && is8bit) {
+            a->vmulps(scale_vreg, scale_vreg, w_vreg);
+            a->vmulps(bias_vreg, bias_vreg, w_vreg);
           }
 
           // The main computation
@@ -659,8 +751,8 @@ GenEmbeddingSpMDMLookup<inType, indxType>::getOrCreate(
         a->emitEpilog(frame);
 
         // jit_fused8bitembedding_kernel fn;
-        typename ReturnFunctionSignature<inType, indxType>::jit_embedding_kernel
-            fn;
+        typename ReturnFunctionSignature<inType, indxType, ROWWISE_SPARSE>::
+            jit_embedding_kernel fn;
         asmjit::Error err;
         {
           std::unique_lock<std::mutex> lock(rtMutex_);
@@ -760,6 +852,67 @@ GenerateEmbeddingSpMDM(
   }
 }
 
+template <typename inType, typename indxType>
+typename EmbeddingSpMDMRowWiseSparseKernelSignature<inType, indxType>::Type
+GenerateEmbeddingSpMDMRowWiseSparse(
+    const int64_t block_size,
+    bool has_weight,
+    bool normalize_by_lengths,
+    int prefetch,
+    bool is_weight_positional) {
+  if (!cpuinfo_initialize()) {
+    throw std::runtime_error("Failed to initialize cpuinfo!");
+  }
+  if (fbgemmHasAvx512Support()) {
+    static GenEmbeddingSpMDMLookup<inType, indxType, true /* rowwise_sparse */>
+        kernel_generator;
+    return kernel_generator.template getOrCreate<inst_set_t::avx512>(
+        block_size,
+        has_weight,
+        is_weight_positional,
+        normalize_by_lengths,
+        prefetch);
+  } else if (fbgemmHasAvx2Support()) {
+    static GenEmbeddingSpMDMLookup<inType, indxType, true /* rowwise_sparse */>
+        kernel_generator;
+    return kernel_generator.template getOrCreate<inst_set_t::avx2>(
+        block_size,
+        has_weight,
+        is_weight_positional,
+        normalize_by_lengths,
+        prefetch);
+  } else {
+#ifdef VLOG
+    VLOG(0) << "AVX2 or AVX512 not found, taking the slow path";
+#endif
+    return
+        [=](int64_t output_size,
+            int64_t index_size,
+            int64_t uncompressed_data_size,
+            const inType* input,
+            const indxType* indices,
+            const int* lengths,
+            const float* weights, // optional, can be null for non-weighted sum
+            float* out,
+            const indxType* compressed_indices_table) {
+          return EmbeddingSpMDMRowWiseSparse_ref(
+              block_size,
+              output_size,
+              index_size,
+              uncompressed_data_size,
+              // compressed_data_size,
+              input,
+              indices,
+              compressed_indices_table,
+              lengths,
+              weights,
+              normalize_by_lengths,
+              out,
+              is_weight_positional);
+        };
+  }
+}
+
 template FBGEMM_API
     typename EmbeddingSpMDMKernelSignature<float, std::int64_t>::Type
     GenerateEmbeddingSpMDM<float, std::int64_t>(
@@ -809,6 +962,60 @@ template FBGEMM_API
     typename EmbeddingSpMDMKernelSignature<std::uint8_t, std::int32_t>::Type
     GenerateEmbeddingSpMDM<std::uint8_t, std::int32_t>(
         const std::int64_t block_size,
+        bool has_weight,
+        bool normalize_by_lengths,
+        int prefetch,
+        bool is_weight_positional);
+
+template FBGEMM_API
+    typename EmbeddingSpMDMRowWiseSparseKernelSignature<float, int64_t>::Type
+    GenerateEmbeddingSpMDMRowWiseSparse<float, int64_t>(
+        const int64_t block_size,
+        bool has_weight,
+        bool normalize_by_lengths,
+        int prefetch,
+        bool is_weight_positional);
+
+template FBGEMM_API
+    typename EmbeddingSpMDMRowWiseSparseKernelSignature<float, int32_t>::Type
+    GenerateEmbeddingSpMDMRowWiseSparse<float, int32_t>(
+        const int64_t block_size,
+        bool has_weight,
+        bool normalize_by_lengths,
+        int prefetch,
+        bool is_weight_positional);
+
+template FBGEMM_API
+    typename EmbeddingSpMDMRowWiseSparseKernelSignature<float16, int64_t>::Type
+    GenerateEmbeddingSpMDMRowWiseSparse<float16, int64_t>(
+        const int64_t block_size,
+        bool has_weight,
+        bool normalize_by_lengths,
+        int prefetch,
+        bool is_weight_positional);
+
+template FBGEMM_API
+    typename EmbeddingSpMDMRowWiseSparseKernelSignature<float16, int32_t>::Type
+    GenerateEmbeddingSpMDMRowWiseSparse<float16, int32_t>(
+        const int64_t block_size,
+        bool has_weight,
+        bool normalize_by_lengths,
+        int prefetch,
+        bool is_weight_positional);
+
+template FBGEMM_API
+    typename EmbeddingSpMDMRowWiseSparseKernelSignature<uint8_t, int64_t>::Type
+    GenerateEmbeddingSpMDMRowWiseSparse<uint8_t, int64_t>(
+        const int64_t block_size,
+        bool has_weight,
+        bool normalize_by_lengths,
+        int prefetch,
+        bool is_weight_positional);
+
+template FBGEMM_API
+    typename EmbeddingSpMDMRowWiseSparseKernelSignature<uint8_t, int32_t>::Type
+    GenerateEmbeddingSpMDMRowWiseSparse<uint8_t, int32_t>(
+        const int64_t block_size,
         bool has_weight,
         bool normalize_by_lengths,
         int prefetch,

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -158,7 +158,7 @@ GenEmbeddingSpMDMNBitLookup<indxType, ROWWISE_SPARSE>::getOrCreate(
         if (normalize_by_lengths) {
           filename += "_normalize_by_lengths";
         }
-        if (rowwise_sparse) {
+        if (ROWWISE_SPARSE) {
           filename += "_rowwise_sparse";
         }
         filename += ".txt";
@@ -191,7 +191,6 @@ GenEmbeddingSpMDMNBitLookup<indxType, ROWWISE_SPARSE>::getOrCreate(
         x86::Gpd lengths_R_ = a->gpz(reg_id).r32(); // 12 or 13
         ++reg_id;
         x86::Gp scratchReg1_ = a->gpz(reg_id); // 13 or 14
-        x86::Gp scratchReg1D_ = a->gpz(reg_id).r32();
         ++reg_id;
         x86::Gp scratchReg2_ = a->gpz(reg_id); // 14 or 15
         x86::Gp scratchReg3_;
@@ -224,7 +223,7 @@ GenEmbeddingSpMDMNBitLookup<indxType, ROWWISE_SPARSE>::getOrCreate(
                     const indxType*, // indices
                     const int*, // lengths
                     const float*, // weights
-                    float*>(asmjit::CallConv::kIdHost));
+                    float* /* out */>(asmjit::CallConv::kIdHost));
         }
 
         asmjit::FuncFrame frame;
@@ -907,7 +906,7 @@ GenerateEmbeddingSpMDMNBit(
 }
 
 template <typename indxType>
-typename EmbeddingSpMDMRowWiseSparseKernelSignature<indxType>::Type
+typename EmbeddingSpMDMRowWiseSparseKernelSignature<uint8_t, indxType>::Type
 GenerateEmbeddingSpMDMNBitRowWiseSparse(
     int bit_rate,
     const int64_t block_size,
@@ -968,7 +967,7 @@ GenerateEmbeddingSpMDMNBitRowWiseSparse(
               weights,
               normalize_by_lengths,
               out,
-              /*is_weight_positional*/ false);
+              is_weight_positional);
         };
   }
 }
@@ -994,7 +993,7 @@ template FBGEMM_API
         bool is_weight_positional);
 
 template FBGEMM_API
-    typename EmbeddingSpMDMRowWiseSparseKernelSignature<int64_t>::Type
+    typename EmbeddingSpMDMRowWiseSparseKernelSignature<uint8_t, int64_t>::Type
     GenerateEmbeddingSpMDMNBitRowWiseSparse<int64_t>(
         int bit_rate,
         const int64_t block_size,
@@ -1004,7 +1003,7 @@ template FBGEMM_API
         bool is_weight_positional);
 
 template FBGEMM_API
-    typename EmbeddingSpMDMRowWiseSparseKernelSignature<int32_t>::Type
+    typename EmbeddingSpMDMRowWiseSparseKernelSignature<uint8_t, int32_t>::Type
     GenerateEmbeddingSpMDMNBitRowWiseSparse<int32_t>(
         int bit_rate,
         const int64_t block_size,

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -254,6 +254,22 @@ FBGEMM_API bool EmbeddingSpMDMNBit_ref(
     float* out,
     bool is_weight_positional = false);
 
+template <typename inType = std::uint8_t, typename IndexType = std::int64_t>
+FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(
+    const std::int64_t block_size,
+    const std::int64_t output_size,
+    const std::int64_t index_size,
+    const std::int64_t uncompressed_data_size,
+    // const std::int64_t compressed_data_size,
+    const inType* input,
+    const IndexType* indices,
+    const IndexType* compressed_indices_table,
+    const int* lengths,
+    const float* weights, // optional, can be null for non-weighted sum
+    bool normalize_by_lengths,
+    float* out,
+    bool is_weight_positional = false);
+
 template <typename IndexType = std::int64_t>
 FBGEMM_API bool EmbeddingSpMDMNBitRowWiseSparse_ref(
     int bit_rate,

--- a/test/EmbeddingSpMDMTest.cc
+++ b/test/EmbeddingSpMDMTest.cc
@@ -82,13 +82,11 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
       empty_indices,
       out_of_bounds) = GetParam();
 
-  int batch_size, num_rows, embedding_dim, average_len;
-
   for (auto input : inputs) {
-    batch_size = input[0];
-    num_rows = input[1];
-    embedding_dim = input[2];
-    average_len = input[3];
+    int batch_size = input[0];
+    int num_rows = input[1];
+    int embedding_dim = input[2];
+    int average_len = input[3];
 
     // Create embedding table
     vector<float> embedding_table(num_rows * embedding_dim);
@@ -278,6 +276,259 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
             lengths.data(),
             use_weight ? weights.data() : nullptr,
             output.data());
+      }
+    }
+
+    // Check correctness
+    EXPECT_EQ(success, success_ref)
+        << "Reference and JIT impl did not both succeed";
+    if (success) {
+      for (int i = 0; i < output.size(); ++i) {
+        EXPECT_EQ(output[i], output_ref[i])
+            << "results differ at (" << i << ") reference: " << output_ref[i]
+            << ", FBGEMM: " << output[i] << " emb dim :" << embedding_dim;
+      }
+    }
+  } // end for input
+}
+
+TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
+  vector<vector<int>> inputs(GetInputs_());
+  bool isFp16, isIndex64b, is_wt_positional, use_weight, normalize_by_lengths,
+      empty_indices, out_of_bounds;
+  int prefetch;
+  tie(isFp16,
+      isIndex64b,
+      is_wt_positional,
+      prefetch,
+      use_weight,
+      normalize_by_lengths,
+      empty_indices,
+      out_of_bounds) = GetParam();
+
+  constexpr float sparsity = 0.7;
+
+  for (auto input : inputs) {
+    int batch_size = input[0];
+    int num_rows = input[1];
+    int embedding_dim = input[2];
+    int average_len = input[3];
+
+    // Create embedding table
+    vector<float> embedding_table(num_rows * embedding_dim);
+    default_random_engine generator;
+    normal_distribution<float> embedding_distribution;
+    for (int i = 0; i < embedding_table.size(); ++i) {
+      embedding_table[i] = embedding_distribution(generator);
+    }
+    vector<float16> embedding_table_fp16;
+    if (isFp16) {
+      embedding_table_fp16.resize(embedding_table.size());
+      FloatToFloat16_simd(
+          embedding_table.data(),
+          embedding_table_fp16.data(),
+          embedding_table.size());
+    }
+
+    // Create mapping table for rowwise sparsity
+    vector<int64_t> mapping_table(num_rows);
+    bernoulli_distribution row_prune_dist(sparsity);
+    int num_compressed_rows = 0;
+    for (int i = 0; i < num_rows; ++i) {
+      if (row_prune_dist(generator)) {
+        // pruned
+        mapping_table[i] = -1;
+      } else {
+        mapping_table[i] = num_compressed_rows;
+        ++num_compressed_rows;
+      }
+    }
+    vector<int32_t> mapping_table_32;
+    copy(
+        mapping_table.begin(),
+        mapping_table.end(),
+        back_inserter(mapping_table_32));
+
+    // Generate lengths
+    uniform_int_distribution<int> length_distribution(
+        1, std::min(2 * average_len + 1, num_rows));
+    vector<int> lengths(batch_size);
+    for (int i = 0; i < batch_size; ++i) {
+      lengths[i] = empty_indices ? 0 : length_distribution(generator);
+    }
+
+    // Compute the number of indices
+    int lengths_sum = accumulate(lengths.begin(), lengths.end(), 0);
+    // cout << "lengths_sum " << lengths_sum << endl;
+
+    // Generate indices
+    vector<int64_t> indices;
+    vector<int32_t> indices_32;
+
+    // Generate indices
+    vector<int> container(num_rows);
+    for (int i = 0; i < batch_size; ++i) {
+      iota(container.begin(), container.end(), 0);
+      random_shuffle(container.begin(), container.end());
+      copy(
+          container.begin(),
+          container.begin() + lengths[i],
+          back_inserter(indices));
+    }
+    // use same indices for 32b and 64b
+    copy(begin(indices), end(indices), back_inserter(indices_32));
+    assert(indices.size() == lengths_sum);
+    assert(indices_32.size() == lengths_sum);
+    if (!empty_indices && out_of_bounds) {
+      int idx = uniform_int_distribution<int>(0, lengths_sum - 1)(generator);
+      indices_32[idx] = indices[idx] = num_rows;
+    }
+    if (!empty_indices) {
+      // To make sure to exercise out-of-bound cases
+      indices_32[0] = indices[0] = num_rows - 1;
+    }
+
+    // Generate weights
+    vector<float> weights(lengths_sum);
+    for (int i = 0; i < lengths_sum; ++i) {
+      weights[i] = embedding_distribution(generator);
+    }
+
+    vector<float> output_sls_ref(batch_size * embedding_dim);
+    vector<float> output_slws_ref(output_sls_ref.size()),
+        output_sls(output_sls_ref.size()), output_slws(output_sls_ref.size());
+
+    vector<float>& output_ref = use_weight ? output_slws_ref : output_sls_ref;
+    vector<float>& output = use_weight ? output_slws : output_sls;
+    bool success, success_ref;
+
+    if (isIndex64b) {
+      if (isFp16) {
+        success_ref = EmbeddingSpMDMRowWiseSparse_ref(
+            embedding_dim,
+            batch_size,
+            lengths_sum,
+            num_rows,
+            embedding_table_fp16.data(),
+            empty_indices ? nullptr : indices.data(),
+            mapping_table.data(),
+            lengths.data(),
+            use_weight ? weights.data() : nullptr,
+            normalize_by_lengths,
+            output_ref.data(),
+            is_wt_positional);
+
+        auto kernel = GenerateEmbeddingSpMDMRowWiseSparse<float16, int64_t>(
+            embedding_dim,
+            use_weight,
+            normalize_by_lengths,
+            prefetch,
+            is_wt_positional);
+        success = kernel(
+            batch_size,
+            lengths_sum,
+            num_rows,
+            embedding_table_fp16.data(),
+            empty_indices ? nullptr : indices.data(),
+            lengths.data(),
+            use_weight ? weights.data() : nullptr,
+            output.data(),
+            mapping_table.data());
+      } else {
+        success_ref = EmbeddingSpMDMRowWiseSparse_ref(
+            embedding_dim,
+            batch_size,
+            lengths_sum,
+            num_rows,
+            embedding_table.data(),
+            empty_indices ? nullptr : indices.data(),
+            mapping_table.data(),
+            lengths.data(),
+            use_weight ? weights.data() : nullptr,
+            normalize_by_lengths,
+            output_ref.data(),
+            is_wt_positional);
+
+        auto kernel = GenerateEmbeddingSpMDMRowWiseSparse<float, int64_t>(
+            embedding_dim,
+            use_weight,
+            normalize_by_lengths,
+            prefetch,
+            is_wt_positional);
+        success = kernel(
+            batch_size,
+            lengths_sum,
+            num_rows,
+            embedding_table.data(),
+            empty_indices ? nullptr : indices.data(),
+            lengths.data(),
+            use_weight ? weights.data() : nullptr,
+            output.data(),
+            mapping_table.data());
+      }
+    } else {
+      if (isFp16) {
+        success_ref = EmbeddingSpMDMRowWiseSparse_ref(
+            embedding_dim,
+            batch_size,
+            lengths_sum,
+            num_rows,
+            embedding_table_fp16.data(),
+            empty_indices ? nullptr : indices_32.data(),
+            mapping_table_32.data(),
+            lengths.data(),
+            use_weight ? weights.data() : nullptr,
+            normalize_by_lengths,
+            output_ref.data(),
+            is_wt_positional);
+
+        auto kernel = GenerateEmbeddingSpMDMRowWiseSparse<float16, int32_t>(
+            embedding_dim,
+            use_weight,
+            normalize_by_lengths,
+            prefetch,
+            is_wt_positional);
+        success = kernel(
+            batch_size,
+            lengths_sum,
+            num_rows,
+            embedding_table_fp16.data(),
+            empty_indices ? nullptr : indices_32.data(),
+            lengths.data(),
+            use_weight ? weights.data() : nullptr,
+            output.data(),
+            mapping_table_32.data());
+      } else {
+        success_ref = EmbeddingSpMDMRowWiseSparse_ref(
+            embedding_dim,
+            batch_size,
+            lengths_sum,
+            num_rows,
+            embedding_table.data(),
+            empty_indices ? nullptr : indices_32.data(),
+            mapping_table_32.data(),
+            lengths.data(),
+            use_weight ? weights.data() : nullptr,
+            normalize_by_lengths,
+            output_ref.data(),
+            is_wt_positional);
+
+        auto kernel = GenerateEmbeddingSpMDMRowWiseSparse<float, int32_t>(
+            embedding_dim,
+            use_weight,
+            normalize_by_lengths,
+            prefetch,
+            is_wt_positional);
+        success = kernel(
+            batch_size,
+            lengths_sum,
+            num_rows,
+            embedding_table.data(),
+            empty_indices ? nullptr : indices_32.data(),
+            lengths.data(),
+            use_weight ? weights.data() : nullptr,
+            output.data(),
+            mapping_table_32.data());
       }
     }
 


### PR DESCRIPTION
Summary: Expand the support for row-wise sparse EmbeddingSpMDM from int2/4 to fp32/fp16/int8

Differential Revision: D19753082

