### PR TITLE
More fixes to enable USE_FBGEMM for PyTorch on Windows (#33000)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,8 @@ target_include_directories(fbgemm BEFORE
     PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}>
     PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}/include>)
 
-target_link_libraries(fbgemm asmjit cpuinfo)
+target_link_libraries(fbgemm $<BUILD_INTERFACE:asmjit>
+  $<BUILD_INTERFACE:cpuinfo>)
 add_dependencies(fbgemm asmjit cpuinfo)
 
 install(TARGETS fbgemm EXPORT fbgemmLibraryConfig
@@ -284,6 +285,9 @@ install(TARGETS fbgemm EXPORT fbgemmLibraryConfig
 
 install(FILES ${FBGEMM_PUBLIC_HEADERS}
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/fbgemm")
+
+install(EXPORT fbgemmLibraryConfig DESTINATION share/cmake/fbgemm
+  FILE fbgemmLibraryConfig.cmake)
 
 #Make project importable from the build directory
 #export(TARGETS fbgemm asmjit FILE fbgemmLibraryConfig.cmake)

--- a/include/fbgemm/FbgemmConvert.h
+++ b/include/fbgemm/FbgemmConvert.h
@@ -46,25 +46,27 @@ FBGEMM_API void Bfloat16ToFloat_simd(const bfloat16* src, float* dst, int size);
  * @brief AVX2 implementation to convert fp32 numbers to bf16 numbers.
  *
  */
-void FloatToBfloat16_avx2(const float* src, bfloat16* dst, int size);
+FBGEMM_API void FloatToBfloat16_avx2(const float* src, bfloat16* dst, int size);
 
 /**
  * @brief AVX512 implementation to convert fp32 numbers to bf16 numbers.
  *
  */
-void FloatToBfloat16_avx512(const float* src, bfloat16* dst, int size);
+FBGEMM_API void
+FloatToBfloat16_avx512(const float* src, bfloat16* dst, int size);
 
 /**
  * @brief AVX2 implementation to convert bf16 numbers to fp32 numbers.
  *
  */
-void Bfloat16ToFloat_avx2(const bfloat16* src, float* dst, int size);
+FBGEMM_API void Bfloat16ToFloat_avx2(const bfloat16* src, float* dst, int size);
 
 /**
  * @brief AVX512 implementation to convert bf16 numbers to fp32 numbers.
  *
  */
-void Bfloat16ToFloat_avx512(const bfloat16* src, float* dst, int size);
+FBGEMM_API void
+Bfloat16ToFloat_avx512(const bfloat16* src, float* dst, int size);
 
 /**
  * @ Transform all entries in a matrix from fp32 to float16: reference
@@ -106,7 +108,7 @@ FBGEMM_API void Float16ToFloat_simd(const float16* src, float* dst, int size);
  * @brief AVX2 implementation to convert fp32 numbers to fp16 numbers.
  *
  */
-void FloatToFloat16_avx2(
+FBGEMM_API void FloatToFloat16_avx2(
     const float* src,
     float16* dst,
     int size,
@@ -116,7 +118,7 @@ void FloatToFloat16_avx2(
  * @brief AVX512 implementation to convert fp32 numbers to fp16 numbers.
  *
  */
-void FloatToFloat16_avx512(
+FBGEMM_API void FloatToFloat16_avx512(
     const float* src,
     float16* dst,
     int size,
@@ -126,12 +128,12 @@ void FloatToFloat16_avx512(
  * @brief AVX2 implementation to convert fp16 numbers to fp32 numbers.
  *
  */
-void Float16ToFloat_avx2(const float16* src, float* dst, int size);
+FBGEMM_API void Float16ToFloat_avx2(const float16* src, float* dst, int size);
 
 /**
  * @brief AVX512 implementation to convert fp16 numbers to fp32 numbers.
  *
  */
-void Float16ToFloat_avx512(const float16* src, float* dst, int size);
+FBGEMM_API void Float16ToFloat_avx512(const float16* src, float* dst, int size);
 
 }; // namespace fbgemm

--- a/src/Fbgemm.cc
+++ b/src/Fbgemm.cc
@@ -247,8 +247,8 @@ bool fbgemmOptimizedGConv(const conv_param_t<SPATIAL_DIM>& conv_p) {
            std::bind(areEqual, std::placeholders::_1, 2)));
 }
 
-template bool fbgemmOptimizedGConv(const conv_param_t<2>& conv_p);
-template bool fbgemmOptimizedGConv(const conv_param_t<3>& conv_p);
+template FBGEMM_API bool fbgemmOptimizedGConv(const conv_param_t<2>& conv_p);
+template FBGEMM_API bool fbgemmOptimizedGConv(const conv_param_t<3>& conv_p);
 
 bool fbgemmSupportedCPU() {
   return (cpuinfo_initialize() && fbgemmHasAvx2Support());
@@ -455,7 +455,7 @@ INSTANTIATE_RELU(int16_t);
 #undef INSTANTIATE_Q_GRANS
 #undef INSTANTIATE_BASE
 
-template void fbgemmPacked(
+template FBGEMM_API void fbgemmPacked(
     PackMatrix<PackAWithRowOffset<uint8_t, int16_t>, uint8_t, int16_t>& packA,
     PackMatrix<PackBMatrix<int8_t, int16_t>, int8_t, int16_t>& packB,
     float* C,
@@ -525,7 +525,7 @@ INSTANTIATE_Q_GRANS(true);
 #undef INSTANTIATE_Q_GRANS
 #undef INSTANTIATE_BASE
 
-template void fbgemmPacked(
+template FBGEMM_API void fbgemmPacked(
     PackMatrix<PackAWithRowOffset<uint8_t, int16_t>, uint8_t, int16_t>& packA,
     PackMatrix<PackBMatrix<int8_t, int16_t>, int8_t, int16_t>& packB,
     float* C,
@@ -586,7 +586,7 @@ INSTANTIATE_SPATIAL_DIM(int16_t);
 #undef INSTANTIATE_SPATIAL_DIM
 #undef INSTANTIATE_BASE
 
-template void fbgemmPacked(
+template FBGEMM_API void fbgemmPacked(
     PackMatrix<PackAWithQuantRowOffset<uint8_t, int32_t>, uint8_t, int32_t>&
         packA,
     PackMatrix<PackBMatrix<int8_t, int32_t>, int8_t, int32_t>& packB,
@@ -598,7 +598,7 @@ template void fbgemmPacked(
     int num_threads,
     const BlockingFactors* blocking_params);
 
-template void fbgemmPacked(
+template FBGEMM_API void fbgemmPacked(
     PackMatrix<PackAMatrix<uint8_t, int16_t>, uint8_t, int16_t>& packA,
     PackMatrix<PackBMatrix<int8_t, int16_t>, int8_t, int16_t>& packB,
     int32_t* C,

--- a/src/QuantUtils.cc
+++ b/src/QuantUtils.cc
@@ -337,7 +337,7 @@ FBGEMM_SPECIALIZED_REQUANTIZE(int32_t)
 #undef FBGEMM_SPECIALIZED_REQUANTIZE
 
 template <>
-void Requantize<uint8_t>(
+FBGEMM_API void Requantize<uint8_t>(
     const int32_t* src,
     uint8_t* dst,
     const int len,


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/33000

As suggested by @peterjc123 in
https://github.com/pytorch/pytorch/pull/33000#issuecomment-582893875, we would like to fix the configuration of the PyTorch CMake scripts by modifying the `CMakeList.txt` at FBGEMM.

In addition, we add more `FBGEMM_API` instances to address the issues on using dllimport and dllexport in C++ classes on Windows.

We split FBGEMM changes as a separate Diff so that PyTorch master branch will not be broken due to the asynchronization between FBGEMM and PyTorch.
ghstack-source-id: 97914400

Differential Revision: D19786708

