### PR TITLE
fix index mapping table type to int32_t

### DIFF
--- a/bench/EmbeddingSpMDMNBitRowWiseSparseBenchmark.cc
+++ b/bench/EmbeddingSpMDMNBitRowWiseSparseBenchmark.cc
@@ -68,7 +68,7 @@ int run_benchmark(
   // Generate mapping table
   default_random_engine generator;
   constexpr float sparsity = 0.7;
-  vector<int64_t> mapping_table(num_rows);
+  vector<int32_t> mapping_table(num_rows);
   bernoulli_distribution row_prune_dist(sparsity);
   int num_compressed_rows = 0;
   for (int i = 0; i < num_rows; ++i) {
@@ -80,11 +80,6 @@ int run_benchmark(
       ++num_compressed_rows;
     }
   }
-  vector<int32_t> mapping_table_32;
-  copy(
-      mapping_table.begin(),
-      mapping_table.end(),
-      back_inserter(mapping_table_32));
 
   // Create embedding table
   int num_elem_per_byte = 8 / bit_rate;
@@ -192,7 +187,7 @@ int run_benchmark(
             num_rows,
             fused_embedding_table.data(),
             indices_32.data(),
-            mapping_table_32.data(),
+            mapping_table.data(),
             lengths.data(),
             has_weight ? weights.data() : nullptr,
             normalize_by_lengths,
@@ -243,7 +238,7 @@ int run_benchmark(
                   lengths.data(),
                   has_weight ? weights.data() : nullptr,
                   output.data(),
-                  mapping_table_32.data());
+                  mapping_table.data());
             } else {
               success = kernel_64(
                   batch_size,

--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -66,7 +66,7 @@ class EmbeddingSpMDMRowWiseSparseKernelSignature {
       const int* lengths,
       const float* weights, // optional, can be null for non-weighted sum
       float* out,
-      const IndexType* compressed_indices_table)>;
+      const std::int32_t* compressed_indices_table)>;
 };
 
 /**

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -859,7 +859,7 @@ bool EmbeddingSpMDMRowWiseSparse_ref(
     // const int64_t compressed_data_size,
     const inType* input,
     const IndexType* indices,
-    const IndexType* compressed_indices_table,
+    const int32_t* compressed_indices_table,
     const int* lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
@@ -979,7 +979,7 @@ bool EmbeddingSpMDMNBitRowWiseSparse_ref(
     // const int64_t compressed_data_size,
     const uint8_t* input,
     const IndexType* indices,
-    const IndexType* compressed_indices_table,
+    const int32_t* compressed_indices_table,
     const int* lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
@@ -1322,14 +1322,14 @@ template FBGEMM_API bool EmbeddingSpMDMNBit_ref(
     bool is_weight_positional);
 
 template FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(
-    const std::int64_t block_size,
-    const std::int64_t output_size,
-    const std::int64_t index_size,
-    const std::int64_t uncompressed_data_size,
-    // const std::int64_t compressed_data_size,
+    const int64_t block_size,
+    const int64_t output_size,
+    const int64_t index_size,
+    const int64_t uncompressed_data_size,
+    // const int64_t compressed_data_size,
     const float16* input,
-    const std::int64_t* indices,
-    const std::int64_t* compressed_indices_table,
+    const int64_t* indices,
+    const int32_t* compressed_indices_table,
     const int* lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
@@ -1337,14 +1337,14 @@ template FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(
     bool is_weight_positional);
 
 template FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(
-    const std::int64_t block_size,
-    const std::int64_t output_size,
-    const std::int64_t index_size,
-    const std::int64_t uncompressed_data_size,
-    // const std::int64_t compressed_data_size,
+    const int64_t block_size,
+    const int64_t output_size,
+    const int64_t index_size,
+    const int64_t uncompressed_data_size,
+    // const int64_t compressed_data_size,
     const float16* input,
-    const std::int32_t* indices,
-    const std::int32_t* compressed_indices_table,
+    const int32_t* indices,
+    const int32_t* compressed_indices_table,
     const int* lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
@@ -1352,14 +1352,14 @@ template FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(
     bool is_weight_positional);
 
 template FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(
-    const std::int64_t block_size,
-    const std::int64_t output_size,
-    const std::int64_t index_size,
-    const std::int64_t uncompressed_data_size,
-    // const std::int64_t compressed_data_size,
+    const int64_t block_size,
+    const int64_t output_size,
+    const int64_t index_size,
+    const int64_t uncompressed_data_size,
+    // const int64_t compressed_data_size,
     const float* input,
-    const std::int64_t* indices,
-    const std::int64_t* compressed_indices_table,
+    const int64_t* indices,
+    const int32_t* compressed_indices_table,
     const int* lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
@@ -1367,14 +1367,14 @@ template FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(
     bool is_weight_positional);
 
 template FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(
-    const std::int64_t block_size,
-    const std::int64_t output_size,
-    const std::int64_t index_size,
-    const std::int64_t uncompressed_data_size,
-    // const std::int64_t compressed_data_size,
+    const int64_t block_size,
+    const int64_t output_size,
+    const int64_t index_size,
+    const int64_t uncompressed_data_size,
+    // const int64_t compressed_data_size,
     const float* input,
-    const std::int32_t* indices,
-    const std::int32_t* compressed_indices_table,
+    const int32_t* indices,
+    const int32_t* compressed_indices_table,
     const int* lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
@@ -1382,14 +1382,14 @@ template FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(
     bool is_weight_positional);
 
 template FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(
-    const std::int64_t block_size,
-    const std::int64_t output_size,
-    const std::int64_t index_size,
-    const std::int64_t uncompressed_data_size,
-    // const std::int64_t compressed_data_size,
-    const std::uint8_t* input,
-    const std::int64_t* indices,
-    const std::int64_t* compressed_indices_table,
+    const int64_t block_size,
+    const int64_t output_size,
+    const int64_t index_size,
+    const int64_t uncompressed_data_size,
+    // const int64_t compressed_data_size,
+    const uint8_t* input,
+    const int64_t* indices,
+    const int32_t* compressed_indices_table,
     const int* lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
@@ -1397,14 +1397,14 @@ template FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(
     bool is_weight_positional);
 
 template FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(
-    const std::int64_t block_size,
-    const std::int64_t output_size,
-    const std::int64_t index_size,
-    const std::int64_t uncompressed_data_size,
-    // const std::int64_t compressed_data_size,
-    const std::uint8_t* input,
-    const std::int32_t* indices,
-    const std::int32_t* compressed_indices_table,
+    const int64_t block_size,
+    const int64_t output_size,
+    const int64_t index_size,
+    const int64_t uncompressed_data_size,
+    // const int64_t compressed_data_size,
+    const uint8_t* input,
+    const int32_t* indices,
+    const int32_t* compressed_indices_table,
     const int* lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
@@ -1413,14 +1413,14 @@ template FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(
 
 template FBGEMM_API bool EmbeddingSpMDMNBitRowWiseSparse_ref(
     int bit_rate,
-    const std::int64_t block_size,
-    const std::int64_t output_size,
-    const std::int64_t index_size,
-    const std::int64_t uncompressed_data_size,
-    // const std::int64_t compressed_data_size,
-    const std::uint8_t* input,
-    const std::int64_t* indices,
-    const std::int64_t* compressed_indices_table,
+    const int64_t block_size,
+    const int64_t output_size,
+    const int64_t index_size,
+    const int64_t uncompressed_data_size,
+    // const int64_t compressed_data_size,
+    const uint8_t* input,
+    const int64_t* indices,
+    const int32_t* compressed_indices_table,
     const int* lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
@@ -1429,14 +1429,14 @@ template FBGEMM_API bool EmbeddingSpMDMNBitRowWiseSparse_ref(
 
 template FBGEMM_API bool EmbeddingSpMDMNBitRowWiseSparse_ref(
     int bit_rate,
-    const std::int64_t block_size,
-    const std::int64_t output_size,
-    const std::int64_t index_size,
-    const std::int64_t uncompressed_data_size,
-    // const std::int64_t compressed_data_size,
-    const std::uint8_t* input,
-    const std::int32_t* indices,
-    const std::int32_t* compressed_indices_table,
+    const int64_t block_size,
+    const int64_t output_size,
+    const int64_t index_size,
+    const int64_t uncompressed_data_size,
+    // const int64_t compressed_data_size,
+    const uint8_t* input,
+    const int32_t* indices,
+    const int32_t* compressed_indices_table,
     const int* lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -740,7 +740,7 @@ bool EmbeddingSpMDM_ref(
       }
       out += block_size;
     }
-    return true;
+    return current == index_size;
   } else {
     // Reference implementation of FP32 SLS
     int64_t current = 0;

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -263,7 +263,7 @@ FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(
     // const std::int64_t compressed_data_size,
     const inType* input,
     const IndexType* indices,
-    const IndexType* compressed_indices_table,
+    const std::int32_t* compressed_indices_table,
     const int* lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
@@ -280,7 +280,7 @@ FBGEMM_API bool EmbeddingSpMDMNBitRowWiseSparse_ref(
     // const std::int64_t compressed_data_size,
     const std::uint8_t* input,
     const IndexType* indices,
-    const IndexType* compressed_indices_table,
+    const std::int32_t* compressed_indices_table,
     const int* lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 
 macro(add_gtest TESTNAME)
   add_executable(${TESTNAME} ${ARGN}
-    ../bench/BenchUtils.cc QuantizationHelpers.cc TestUtils.cc)
+    ../bench/BenchUtils.cc EmbeddingSpMDMTestUtils.cc QuantizationHelpers.cc TestUtils.cc)
   set_target_properties(${TESTNAME} PROPERTIES
           CXX_STANDARD 11
           CXX_EXTENSIONS NO)

--- a/test/EmbeddingSpMDM8BitTest.cc
+++ b/test/EmbeddingSpMDM8BitTest.cc
@@ -227,10 +227,9 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
     int average_len = input[3];
 
     // Create mapping table for rowwise sparsity
-    vector<int64_t> mapping_table;
-    vector<int32_t> mapping_table_32;
-    int num_compressed_rows = CreateMappingTableForRowWiseSparsity(
-        mapping_table, mapping_table_32, num_rows, sparsity);
+    vector<int32_t> mapping_table;
+    int num_compressed_rows =
+        CreateMappingTableForRowWiseSparsity(mapping_table, num_rows, sparsity);
 
     // Create embedding table
     default_random_engine generator;
@@ -314,7 +313,7 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
           num_rows,
           fused_embedding_table.data(),
           corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
-          mapping_table_32.data(),
+          mapping_table.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
           normalize_by_lengths,
@@ -336,7 +335,7 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
           lengths.data(),
           use_weight ? weights.data() : nullptr,
           output.data(),
-          mapping_table_32.data());
+          mapping_table.data());
     }
 
     // Check correctness

--- a/test/EmbeddingSpMDM8BitTest.cc
+++ b/test/EmbeddingSpMDM8BitTest.cc
@@ -12,6 +12,7 @@
 
 #include <gtest/gtest.h>
 
+#include "./EmbeddingSpMDMTestUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "fbgemm/Utils.h"
 #include "src/RefImplementations.h"
@@ -48,10 +49,9 @@ vector<int> prefetch_distances{0, 16, 1000000};
 
 namespace {
 
-// tuple represents MB, IC, OC, IT, IH, IW, KH/KW, stride, pad
 class Fused8BitRowwiseEmbeddingLookupTest
     : public testing::TestWithParam<
-          tuple<bool, bool, int, bool, bool, bool, bool>> {};
+          tuple<bool, bool, int, bool, bool, EmbeddingSpMDMCornerCase>> {};
 }; // namespace
 
 INSTANTIATE_TEST_CASE_P(
@@ -63,21 +63,23 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::ValuesIn(prefetch_distances),
         ::testing::Bool(), // use_weight
         ::testing::Bool(), // normalize_by_lengths
-        ::testing::Bool(), // empty_indices
-        ::testing::Bool())); // out of bounds
+        ::testing::Values(
+            NONE,
+            EMPTY_INDICES,
+            OUT_OF_BOUND_INDICES,
+            UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM)));
 
 TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
   vector<vector<int>> inputs(GetInputs_());
-  bool isIndex64b, is_wt_positional, use_weight, normalize_by_lengths,
-      empty_indices, out_of_bounds;
+  bool isIndex64b, is_wt_positional, use_weight, normalize_by_lengths;
   int prefetch;
+  EmbeddingSpMDMCornerCase corner_case;
   tie(isIndex64b,
       is_wt_positional,
       prefetch,
       use_weight,
       normalize_by_lengths,
-      empty_indices,
-      out_of_bounds) = GetParam();
+      corner_case) = GetParam();
 
   for (auto input : inputs) {
     int batch_size = input[0];
@@ -104,39 +106,20 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
       scale_bias[1] = embedding_distribution(generator);
     }
 
-    // Generate lengths
-    uniform_int_distribution<int> length_distribution(
-        1, std::min(2 * average_len + 1, num_rows));
-    vector<int> lengths(batch_size);
-    for (int i = 0; i < batch_size; ++i) {
-      lengths[i] = empty_indices ? 0 : length_distribution(generator);
-    }
-
-    // Compute the number of indices
-    int lengths_sum = accumulate(lengths.begin(), lengths.end(), 0);
-
-    // Generate indices
-    vector<int64_t> indices(lengths_sum);
-    vector<int32_t> indices_32(lengths_sum);
-
-    uniform_int_distribution<int> index_distribution(0, num_rows - 1);
-    for (int i = 0; i < lengths_sum; ++i) {
-      indices_32[i] = indices[i] = index_distribution(generator);
-    }
-    if (!empty_indices && out_of_bounds) {
-      int idx = uniform_int_distribution<int>(0, lengths_sum - 1)(generator);
-      indices_32[idx] = indices[idx] = num_rows;
-    }
-    if (!empty_indices) {
-      // To make sure to exercise out-of-bound cases
-      indices_32[0] = indices[0] = num_rows - 1;
-    }
-
-    // Generate weights
-    vector<float> weights(lengths_sum);
-    for (int i = 0; i < lengths_sum; ++i) {
-      weights[i] = embedding_distribution(generator);
-    }
+    vector<int> lengths;
+    vector<int64_t> indices;
+    vector<int32_t> indices_32;
+    vector<float> weights;
+    int lengths_sum = GenerateLengthsIndicesWeights(
+        lengths,
+        indices,
+        indices_32,
+        weights,
+        batch_size,
+        num_rows,
+        embedding_dim,
+        average_len,
+        corner_case);
 
     vector<float> output_sls_ref(batch_size * embedding_dim);
     vector<float> output_slws_ref(output_sls_ref.size()),
@@ -153,7 +136,7 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
           lengths_sum,
           num_rows,
           fused_embedding_table.data(),
-          empty_indices ? nullptr : indices.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
           normalize_by_lengths,
@@ -171,7 +154,7 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
           lengths_sum,
           num_rows,
           fused_embedding_table.data(),
-          empty_indices ? nullptr : indices.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
           output.data());
@@ -182,7 +165,7 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
           lengths_sum,
           num_rows,
           fused_embedding_table.data(),
-          empty_indices ? nullptr : indices_32.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
           normalize_by_lengths,
@@ -200,7 +183,7 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
           lengths_sum,
           num_rows,
           fused_embedding_table.data(),
-          empty_indices ? nullptr : indices_32.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
           output.data());
@@ -209,6 +192,10 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
     // Check correctness
     EXPECT_EQ(success, success_ref)
         << "Reference and JIT impl did not both succeed";
+    if (corner_case == OUT_OF_BOUND_INDICES ||
+        corner_case == UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM) {
+      EXPECT_EQ(success, false);
+    }
     if (success) {
       for (int i = 0; i < output.size(); ++i) {
         EXPECT_EQ(output[i], output_ref[i])
@@ -221,16 +208,15 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
 
 TEST_P(Fused8BitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
   vector<vector<int>> inputs(GetInputs_());
-  bool isIndex64b, is_wt_positional, use_weight, normalize_by_lengths,
-      empty_indices, out_of_bounds;
+  bool isIndex64b, is_wt_positional, use_weight, normalize_by_lengths;
   int prefetch;
+  EmbeddingSpMDMCornerCase corner_case;
   tie(isIndex64b,
       is_wt_positional,
       prefetch,
       use_weight,
       normalize_by_lengths,
-      empty_indices,
-      out_of_bounds) = GetParam();
+      corner_case) = GetParam();
 
   constexpr float sparsity = 0.7;
 
@@ -240,33 +226,21 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
     int embedding_dim = input[2];
     int average_len = input[3];
 
+    // Create mapping table for rowwise sparsity
+    vector<int64_t> mapping_table;
+    vector<int32_t> mapping_table_32;
+    int num_compressed_rows = CreateMappingTableForRowWiseSparsity(
+        mapping_table, mapping_table_32, num_rows, sparsity);
+
     // Create embedding table
     default_random_engine generator;
     normal_distribution<float> embedding_distribution;
     uniform_int_distribution<int> entries(0, 16);
 
-    // Create mapping table for rowwise sparsity
-    vector<int64_t> mapping_table(num_rows);
-    bernoulli_distribution row_prune_dist(sparsity);
-    int num_compressed_rows = 0;
-    for (int i = 0; i < num_rows; ++i) {
-      if (row_prune_dist(generator)) {
-        // pruned
-        mapping_table[i] = -1;
-      } else {
-        mapping_table[i] = num_compressed_rows;
-        ++num_compressed_rows;
-      }
-    }
-    vector<int32_t> mapping_table_32;
-    copy(
-        mapping_table.begin(),
-        mapping_table.end(),
-        back_inserter(mapping_table_32));
-
     int fused_embedding_dim = embedding_dim + 2 * sizeof(float);
-    vector<uint8_t> fused_embedding_table(num_rows * fused_embedding_dim);
-    for (int i = 0; i < num_rows; i++) {
+    vector<uint8_t> fused_embedding_table(
+        num_compressed_rows * fused_embedding_dim);
+    for (int i = 0; i < num_compressed_rows; i++) {
       for (int ii = 0; ii < embedding_dim; ii++) {
         fused_embedding_table[i * fused_embedding_dim + ii] =
             entries(generator);
@@ -278,42 +252,20 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
       scale_bias[1] = embedding_distribution(generator);
     }
 
-    // Generate lengths
-    uniform_int_distribution<int> length_distribution(
-        1, std::min(2 * average_len + 1, num_rows));
-    vector<int> lengths(batch_size);
-    for (int i = 0; i < batch_size; ++i) {
-      lengths[i] = empty_indices ? 0 : length_distribution(generator);
-    }
-
-    // Compute the number of indices
-    int lengths_sum = accumulate(lengths.begin(), lengths.end(), 0);
-
-    // Generate indices
-    vector<int64_t> indices(lengths_sum);
-    vector<int32_t> indices_32(lengths_sum);
-
-    uniform_int_distribution<int> index_distribution(0, num_rows - 1);
-    for (int i = 0; i < lengths_sum; ++i) {
-      indices_32[i] = indices[i] = index_distribution(generator);
-    }
-    if (!empty_indices && out_of_bounds) {
-      int idx = uniform_int_distribution<int>(0, lengths_sum - 1)(generator);
-      indices_32[idx] = indices[idx] = num_rows;
-
-      // idx = uniform_int_distribution<int>(0, num_rows - 1)(generator);
-      // mapping_table_32[idx] = mapping_table[idx] = num_compressed_rows;
-    }
-    if (!empty_indices) {
-      // To make sure to exercise out-of-bound cases
-      indices_32[0] = indices[0] = num_rows - 1;
-    }
-
-    // Generate weights
-    vector<float> weights(lengths_sum);
-    for (int i = 0; i < lengths_sum; ++i) {
-      weights[i] = embedding_distribution(generator);
-    }
+    vector<int> lengths;
+    vector<int64_t> indices;
+    vector<int32_t> indices_32;
+    vector<float> weights;
+    int lengths_sum = GenerateLengthsIndicesWeights(
+        lengths,
+        indices,
+        indices_32,
+        weights,
+        batch_size,
+        num_rows,
+        embedding_dim,
+        average_len,
+        corner_case);
 
     vector<float> output_sls_ref(batch_size * embedding_dim);
     vector<float> output_slws_ref(output_sls_ref.size()),
@@ -330,7 +282,7 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
           lengths_sum,
           num_rows,
           fused_embedding_table.data(),
-          empty_indices ? nullptr : indices.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
           mapping_table.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
@@ -349,7 +301,7 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
           lengths_sum,
           num_rows,
           fused_embedding_table.data(),
-          empty_indices ? nullptr : indices.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
           output.data(),
@@ -361,7 +313,7 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
           lengths_sum,
           num_rows,
           fused_embedding_table.data(),
-          empty_indices ? nullptr : indices_32.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
           mapping_table_32.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
@@ -380,7 +332,7 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
           lengths_sum,
           num_rows,
           fused_embedding_table.data(),
-          empty_indices ? nullptr : indices_32.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
           output.data(),
@@ -390,6 +342,10 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
     // Check correctness
     EXPECT_EQ(success, success_ref)
         << "Reference and JIT impl did not both succeed";
+    if (corner_case == OUT_OF_BOUND_INDICES ||
+        corner_case == UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM) {
+      EXPECT_EQ(success, false);
+    }
     if (success) {
       for (int i = 0; i < output.size(); ++i) {
         EXPECT_EQ(output[i], output_ref[i])

--- a/test/EmbeddingSpMDMNBitTest.cc
+++ b/test/EmbeddingSpMDMNBitTest.cc
@@ -12,6 +12,7 @@
 
 #include <gtest/gtest.h>
 
+#include "./EmbeddingSpMDMTestUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "fbgemm/FbgemmConvert.h"
 #include "fbgemm/Utils.h"
@@ -51,10 +52,9 @@ vector<int> prefetch_distances{0, 16, 1000000};
 
 namespace {
 
-// tuple represents MB, IC, OC, IT, IH, IW, KH/KW, stride, pad
 class FusedNBitRowwiseEmbeddingLookupTest
     : public testing::TestWithParam<
-          tuple<int, bool, bool, int, bool, bool, bool, bool>> {};
+          tuple<int, bool, bool, int, bool, bool, EmbeddingSpMDMCornerCase>> {};
 }; // namespace
 
 INSTANTIATE_TEST_CASE_P(
@@ -67,22 +67,24 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::ValuesIn(prefetch_distances),
         ::testing::Bool(), // use_weight
         ::testing::Bool(), // normalize_by_lengths
-        ::testing::Bool(), // empty_indices
-        ::testing::Bool())); // out of bounds
+        ::testing::Values(
+            NONE,
+            EMPTY_INDICES,
+            OUT_OF_BOUND_INDICES,
+            UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM)));
 
 TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
   vector<vector<int>> inputs(GetInputs_());
-  bool isIndex64b, is_wt_positional, use_weight, normalize_by_lengths,
-      empty_indices, out_of_bounds;
+  bool isIndex64b, is_wt_positional, use_weight, normalize_by_lengths;
   int bit_rate, prefetch;
+  EmbeddingSpMDMCornerCase corner_case;
   tie(bit_rate,
       isIndex64b,
       is_wt_positional,
       prefetch,
       use_weight,
       normalize_by_lengths,
-      empty_indices,
-      out_of_bounds) = GetParam();
+      corner_case) = GetParam();
 
   int num_elem_per_byte = 8 / bit_rate;
 
@@ -117,39 +119,20 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
       FloatToFloat16_ref(&bias, scale_bias + 1, 1, true /* clip */);
     }
 
-    // Generate lengths
-    uniform_int_distribution<int> length_distribution(
-        1, std::min(2 * average_len + 1, num_rows));
-    vector<int> lengths(batch_size);
-    for (int i = 0; i < batch_size; ++i) {
-      lengths[i] = empty_indices ? 0 : length_distribution(generator);
-    }
-
-    // Compute the number of indices
-    int lengths_sum = accumulate(lengths.begin(), lengths.end(), 0);
-
-    // Generate indices
-    vector<int64_t> indices(lengths_sum);
-    vector<int32_t> indices_32(lengths_sum);
-
-    uniform_int_distribution<int> index_distribution(0, num_rows - 1);
-    for (int i = 0; i < lengths_sum; ++i) {
-      indices_32[i] = indices[i] = index_distribution(generator);
-    }
-    if (!empty_indices && out_of_bounds) {
-      int idx = uniform_int_distribution<int>(0, lengths_sum - 1)(generator);
-      indices_32[idx] = indices[idx] = num_rows;
-    }
-    if (!empty_indices) {
-      // to make sure to exercise out-of-bound cases
-      indices_32[0] = indices[0] = num_rows - 1;
-    }
-
-    // Generate weights
-    vector<float> weights(lengths_sum);
-    for (int i = 0; i < lengths_sum; ++i) {
-      weights[i] = embedding_distribution(generator);
-    }
+    vector<int> lengths;
+    vector<int64_t> indices;
+    vector<int32_t> indices_32;
+    vector<float> weights;
+    int lengths_sum = GenerateLengthsIndicesWeights(
+        lengths,
+        indices,
+        indices_32,
+        weights,
+        batch_size,
+        num_rows,
+        embedding_dim,
+        average_len,
+        corner_case);
 
     vector<float> output_sls_ref(batch_size * embedding_dim);
     vector<float> output_slws_ref(output_sls_ref.size()),
@@ -167,7 +150,7 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
           lengths_sum,
           num_rows,
           fused_embedding_table.data(),
-          empty_indices ? nullptr : indices.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
           normalize_by_lengths,
@@ -186,7 +169,7 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
           lengths_sum,
           num_rows,
           fused_embedding_table.data(),
-          empty_indices ? nullptr : indices.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
           output.data());
@@ -198,7 +181,7 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
           lengths_sum,
           num_rows,
           fused_embedding_table.data(),
-          empty_indices ? nullptr : indices_32.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
           normalize_by_lengths,
@@ -217,7 +200,7 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
           lengths_sum,
           num_rows,
           fused_embedding_table.data(),
-          empty_indices ? nullptr : indices_32.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
           output.data());
@@ -226,6 +209,10 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
     // Check correctness
     EXPECT_EQ(success, success_ref)
         << "Reference and JIT impl did not both succeed";
+    if (corner_case == OUT_OF_BOUND_INDICES ||
+        corner_case == UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM) {
+      EXPECT_EQ(success, false);
+    }
     if (success) {
       for (int i = 0; i < output.size(); ++i) {
         EXPECT_EQ(output[i], output_ref[i])
@@ -238,17 +225,16 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
 
 TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
   vector<vector<int>> inputs(GetInputs_());
-  bool isIndex64b, is_wt_positional, use_weight, normalize_by_lengths,
-      empty_indices, out_of_bounds;
+  bool isIndex64b, is_wt_positional, use_weight, normalize_by_lengths;
   int bit_rate, prefetch;
+  EmbeddingSpMDMCornerCase corner_case;
   tie(bit_rate,
       isIndex64b,
       is_wt_positional,
       prefetch,
       use_weight,
       normalize_by_lengths,
-      empty_indices,
-      out_of_bounds) = GetParam();
+      corner_case) = GetParam();
 
   int num_elem_per_byte = 8 / bit_rate;
   constexpr float sparsity = 0.7;
@@ -259,29 +245,16 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
     int embedding_dim = input[2];
     int average_len = input[3];
 
+    // Create mapping table for rowwise sparsity
+    vector<int64_t> mapping_table;
+    vector<int32_t> mapping_table_32;
+    int num_compressed_rows = CreateMappingTableForRowWiseSparsity(
+        mapping_table, mapping_table_32, num_rows, sparsity);
+
     // Create embedding table
     default_random_engine generator;
     normal_distribution<float> embedding_distribution;
     uniform_int_distribution<int> entries(0, 16);
-
-    // Create mapping table for rowwise sparsity
-    vector<int64_t> mapping_table(num_rows);
-    bernoulli_distribution row_prune_dist(sparsity);
-    int num_compressed_rows = 0;
-    for (int i = 0; i < num_rows; ++i) {
-      if (row_prune_dist(generator)) {
-        // pruned
-        mapping_table[i] = -1;
-      } else {
-        mapping_table[i] = num_compressed_rows;
-        ++num_compressed_rows;
-      }
-    }
-    vector<int32_t> mapping_table_32;
-    copy(
-        mapping_table.begin(),
-        mapping_table.end(),
-        back_inserter(mapping_table_32));
 
     int fused_embedding_dim =
         (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte +
@@ -304,42 +277,20 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
       FloatToFloat16_ref(&bias, scale_bias + 1, 1, true /* clip */);
     }
 
-    // Generate lengths
-    uniform_int_distribution<int> length_distribution(
-        1, std::min(2 * average_len + 1, num_rows));
-    vector<int> lengths(batch_size);
-    for (int i = 0; i < batch_size; ++i) {
-      lengths[i] = empty_indices ? 0 : length_distribution(generator);
-    }
-
-    // Compute the number of indices
-    int lengths_sum = accumulate(lengths.begin(), lengths.end(), 0);
-
-    // Generate indices
-    vector<int64_t> indices(lengths_sum);
-    vector<int32_t> indices_32(lengths_sum);
-
-    uniform_int_distribution<int> index_distribution(0, num_rows - 1);
-    for (int i = 0; i < lengths_sum; ++i) {
-      indices_32[i] = indices[i] = index_distribution(generator);
-    }
-    if (!empty_indices && out_of_bounds) {
-      int idx = uniform_int_distribution<int>(0, lengths_sum - 1)(generator);
-      indices_32[idx] = indices[idx] = num_rows;
-
-      // idx = uniform_int_distribution<int>(0, num_rows - 1)(generator);
-      // mapping_table_32[idx] = mapping_table[idx] = num_compressed_rows;
-    }
-    if (!empty_indices) {
-      // to make sure to exercise out-of-bound cases
-      indices_32[0] = indices[0] = num_rows - 1;
-    }
-
-    // Generate weights
-    vector<float> weights(lengths_sum);
-    for (int i = 0; i < lengths_sum; ++i) {
-      weights[i] = embedding_distribution(generator);
-    }
+    vector<int> lengths;
+    vector<int64_t> indices;
+    vector<int32_t> indices_32;
+    vector<float> weights;
+    int lengths_sum = GenerateLengthsIndicesWeights(
+        lengths,
+        indices,
+        indices_32,
+        weights,
+        batch_size,
+        num_rows,
+        embedding_dim,
+        average_len,
+        corner_case);
 
     vector<float> output_sls_ref(batch_size * embedding_dim);
     vector<float> output_slws_ref(output_sls_ref.size()),
@@ -357,7 +308,7 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
           lengths_sum,
           num_rows,
           fused_embedding_table.data(),
-          empty_indices ? nullptr : indices.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
           mapping_table.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
@@ -377,7 +328,7 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
           lengths_sum,
           num_rows,
           fused_embedding_table.data(),
-          empty_indices ? nullptr : indices.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
           output.data(),
@@ -390,7 +341,7 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
           lengths_sum,
           num_rows,
           fused_embedding_table.data(),
-          empty_indices ? nullptr : indices_32.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
           mapping_table_32.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
@@ -410,7 +361,7 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
           lengths_sum,
           num_rows,
           fused_embedding_table.data(),
-          empty_indices ? nullptr : indices_32.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
           output.data(),
@@ -420,6 +371,10 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
     // Check correctness
     EXPECT_EQ(success, success_ref)
         << "Reference and JIT impl did not both succeed";
+    if (corner_case == OUT_OF_BOUND_INDICES ||
+        corner_case == UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM) {
+      EXPECT_EQ(success, false);
+    }
     if (success) {
       for (int i = 0; i < output.size(); ++i) {
         EXPECT_EQ(output[i], output_ref[i])

--- a/test/EmbeddingSpMDMNBitTest.cc
+++ b/test/EmbeddingSpMDMNBitTest.cc
@@ -246,10 +246,9 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
     int average_len = input[3];
 
     // Create mapping table for rowwise sparsity
-    vector<int64_t> mapping_table;
-    vector<int32_t> mapping_table_32;
-    int num_compressed_rows = CreateMappingTableForRowWiseSparsity(
-        mapping_table, mapping_table_32, num_rows, sparsity);
+    vector<int32_t> mapping_table;
+    int num_compressed_rows =
+        CreateMappingTableForRowWiseSparsity(mapping_table, num_rows, sparsity);
 
     // Create embedding table
     default_random_engine generator;
@@ -342,7 +341,7 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
           num_rows,
           fused_embedding_table.data(),
           corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
-          mapping_table_32.data(),
+          mapping_table.data(),
           lengths.data(),
           use_weight ? weights.data() : nullptr,
           normalize_by_lengths,
@@ -365,7 +364,7 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
           lengths.data(),
           use_weight ? weights.data() : nullptr,
           output.data(),
-          mapping_table_32.data());
+          mapping_table.data());
     }
 
     // Check correctness

--- a/test/EmbeddingSpMDMTest.cc
+++ b/test/EmbeddingSpMDMTest.cc
@@ -12,6 +12,7 @@
 
 #include <gtest/gtest.h>
 
+#include "./EmbeddingSpMDMTestUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "fbgemm/FbgemmConvert.h"
 #include "fbgemm/Utils.h"
@@ -50,7 +51,8 @@ namespace {
 
 class EmbeddingSpMDMTest
     : public testing::TestWithParam<
-          tuple<bool, bool, bool, int, bool, bool, bool, bool>> {};
+          tuple<bool, bool, bool, int, bool, bool, EmbeddingSpMDMCornerCase>> {
+};
 }; // namespace
 
 vector<int> prefetch_distances = {0, 16, 1000000};
@@ -65,22 +67,24 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::ValuesIn(prefetch_distances),
         ::testing::Bool(), // use_weight
         ::testing::Bool(), // normalize_by_lengths
-        ::testing::Bool(), // empty_indices
-        ::testing::Bool())); // out_of_bounds
+        ::testing::Values(
+            NONE,
+            EMPTY_INDICES,
+            OUT_OF_BOUND_INDICES,
+            UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM)));
 
 TEST_P(EmbeddingSpMDMTest, basicTest) {
   vector<vector<int>> inputs(GetInputs_());
-  bool isFp16, isIndex64b, is_wt_positional, use_weight, normalize_by_lengths,
-      empty_indices, out_of_bounds;
+  bool isFp16, isIndex64b, is_wt_positional, use_weight, normalize_by_lengths;
   int prefetch;
+  EmbeddingSpMDMCornerCase corner_case;
   tie(isFp16,
       isIndex64b,
       is_wt_positional,
       prefetch,
       use_weight,
       normalize_by_lengths,
-      empty_indices,
-      out_of_bounds) = GetParam();
+      corner_case) = GetParam();
 
   for (auto input : inputs) {
     int batch_size = input[0];
@@ -104,50 +108,20 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
           embedding_table.size());
     }
 
-    // Generate lengths
-    uniform_int_distribution<int> length_distribution(
-        1, std::min(2 * average_len + 1, num_rows));
-    vector<int> lengths(batch_size);
-    for (int i = 0; i < batch_size; ++i) {
-      lengths[i] = empty_indices ? 0 : length_distribution(generator);
-    }
-
-    // Compute the number of indices
-    int lengths_sum = accumulate(lengths.begin(), lengths.end(), 0);
-    // cout << "lengths_sum " << lengths_sum << endl;
-
-    // Generate indices
+    vector<int> lengths;
     vector<int64_t> indices;
     vector<int32_t> indices_32;
-
-    // Generate indices
-    vector<int> container(num_rows);
-    for (int i = 0; i < batch_size; ++i) {
-      iota(container.begin(), container.end(), 0);
-      random_shuffle(container.begin(), container.end());
-      copy(
-          container.begin(),
-          container.begin() + lengths[i],
-          back_inserter(indices));
-    }
-    // use same indices for 32b and 64b
-    copy(begin(indices), end(indices), back_inserter(indices_32));
-    assert(indices.size() == lengths_sum);
-    assert(indices_32.size() == lengths_sum);
-    if (!empty_indices && out_of_bounds) {
-      int idx = uniform_int_distribution<int>(0, lengths_sum - 1)(generator);
-      indices_32[idx] = indices[idx] = num_rows;
-    }
-    if (!empty_indices) {
-      // To make sure to exercise out-of-bound cases
-      indices_32[0] = indices[0] = num_rows - 1;
-    }
-
-    // Generate weights
-    vector<float> weights(lengths_sum);
-    for (int i = 0; i < lengths_sum; ++i) {
-      weights[i] = embedding_distribution(generator);
-    }
+    vector<float> weights;
+    int lengths_sum = GenerateLengthsIndicesWeights(
+        lengths,
+        indices,
+        indices_32,
+        weights,
+        batch_size,
+        num_rows,
+        embedding_dim,
+        average_len,
+        corner_case);
 
     vector<float> output_sls_ref(batch_size * embedding_dim);
     vector<float> output_slws_ref(output_sls_ref.size()),
@@ -165,7 +139,7 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
             lengths_sum,
             num_rows,
             embedding_table_fp16.data(),
-            empty_indices ? nullptr : indices.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
             normalize_by_lengths,
@@ -183,7 +157,7 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
             lengths_sum,
             num_rows,
             embedding_table_fp16.data(),
-            empty_indices ? nullptr : indices.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
             output.data());
@@ -194,7 +168,7 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
             lengths_sum,
             num_rows,
             embedding_table.data(),
-            empty_indices ? nullptr : indices.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
             normalize_by_lengths,
@@ -212,7 +186,7 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
             lengths_sum,
             num_rows,
             embedding_table.data(),
-            empty_indices ? nullptr : indices.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
             output.data());
@@ -225,7 +199,7 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
             lengths_sum,
             num_rows,
             embedding_table_fp16.data(),
-            empty_indices ? nullptr : indices_32.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
             normalize_by_lengths,
@@ -243,7 +217,7 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
             lengths_sum,
             num_rows,
             embedding_table_fp16.data(),
-            empty_indices ? nullptr : indices_32.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
             output.data());
@@ -254,7 +228,7 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
             lengths_sum,
             num_rows,
             embedding_table.data(),
-            empty_indices ? nullptr : indices_32.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
             normalize_by_lengths,
@@ -272,7 +246,7 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
             lengths_sum,
             num_rows,
             embedding_table.data(),
-            empty_indices ? nullptr : indices_32.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
             output.data());
@@ -282,6 +256,10 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
     // Check correctness
     EXPECT_EQ(success, success_ref)
         << "Reference and JIT impl did not both succeed";
+    if (corner_case == OUT_OF_BOUND_INDICES ||
+        corner_case == UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM) {
+      EXPECT_EQ(success, false);
+    }
     if (success) {
       for (int i = 0; i < output.size(); ++i) {
         EXPECT_EQ(output[i], output_ref[i])
@@ -294,17 +272,16 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
 
 TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
   vector<vector<int>> inputs(GetInputs_());
-  bool isFp16, isIndex64b, is_wt_positional, use_weight, normalize_by_lengths,
-      empty_indices, out_of_bounds;
+  bool isFp16, isIndex64b, is_wt_positional, use_weight, normalize_by_lengths;
   int prefetch;
+  EmbeddingSpMDMCornerCase corner_case;
   tie(isFp16,
       isIndex64b,
       is_wt_positional,
       prefetch,
       use_weight,
       normalize_by_lengths,
-      empty_indices,
-      out_of_bounds) = GetParam();
+      corner_case) = GetParam();
 
   constexpr float sparsity = 0.7;
 
@@ -314,8 +291,14 @@ TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
     int embedding_dim = input[2];
     int average_len = input[3];
 
+    // Create mapping table for rowwise sparsity
+    vector<int64_t> mapping_table;
+    vector<int32_t> mapping_table_32;
+    int num_compressed_rows = CreateMappingTableForRowWiseSparsity(
+        mapping_table, mapping_table_32, num_rows, sparsity);
+
     // Create embedding table
-    vector<float> embedding_table(num_rows * embedding_dim);
+    vector<float> embedding_table(num_compressed_rows * embedding_dim);
     default_random_engine generator;
     normal_distribution<float> embedding_distribution;
     for (int i = 0; i < embedding_table.size(); ++i) {
@@ -330,69 +313,20 @@ TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
           embedding_table.size());
     }
 
-    // Create mapping table for rowwise sparsity
-    vector<int64_t> mapping_table(num_rows);
-    bernoulli_distribution row_prune_dist(sparsity);
-    int num_compressed_rows = 0;
-    for (int i = 0; i < num_rows; ++i) {
-      if (row_prune_dist(generator)) {
-        // pruned
-        mapping_table[i] = -1;
-      } else {
-        mapping_table[i] = num_compressed_rows;
-        ++num_compressed_rows;
-      }
-    }
-    vector<int32_t> mapping_table_32;
-    copy(
-        mapping_table.begin(),
-        mapping_table.end(),
-        back_inserter(mapping_table_32));
-
-    // Generate lengths
-    uniform_int_distribution<int> length_distribution(
-        1, std::min(2 * average_len + 1, num_rows));
-    vector<int> lengths(batch_size);
-    for (int i = 0; i < batch_size; ++i) {
-      lengths[i] = empty_indices ? 0 : length_distribution(generator);
-    }
-
-    // Compute the number of indices
-    int lengths_sum = accumulate(lengths.begin(), lengths.end(), 0);
-    // cout << "lengths_sum " << lengths_sum << endl;
-
-    // Generate indices
+    vector<int> lengths;
     vector<int64_t> indices;
     vector<int32_t> indices_32;
-
-    // Generate indices
-    vector<int> container(num_rows);
-    for (int i = 0; i < batch_size; ++i) {
-      iota(container.begin(), container.end(), 0);
-      random_shuffle(container.begin(), container.end());
-      copy(
-          container.begin(),
-          container.begin() + lengths[i],
-          back_inserter(indices));
-    }
-    // use same indices for 32b and 64b
-    copy(begin(indices), end(indices), back_inserter(indices_32));
-    assert(indices.size() == lengths_sum);
-    assert(indices_32.size() == lengths_sum);
-    if (!empty_indices && out_of_bounds) {
-      int idx = uniform_int_distribution<int>(0, lengths_sum - 1)(generator);
-      indices_32[idx] = indices[idx] = num_rows;
-    }
-    if (!empty_indices) {
-      // To make sure to exercise out-of-bound cases
-      indices_32[0] = indices[0] = num_rows - 1;
-    }
-
-    // Generate weights
-    vector<float> weights(lengths_sum);
-    for (int i = 0; i < lengths_sum; ++i) {
-      weights[i] = embedding_distribution(generator);
-    }
+    vector<float> weights;
+    int lengths_sum = GenerateLengthsIndicesWeights(
+        lengths,
+        indices,
+        indices_32,
+        weights,
+        batch_size,
+        num_rows,
+        embedding_dim,
+        average_len,
+        corner_case);
 
     vector<float> output_sls_ref(batch_size * embedding_dim);
     vector<float> output_slws_ref(output_sls_ref.size()),
@@ -410,7 +344,7 @@ TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
             lengths_sum,
             num_rows,
             embedding_table_fp16.data(),
-            empty_indices ? nullptr : indices.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
             mapping_table.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
@@ -429,7 +363,7 @@ TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
             lengths_sum,
             num_rows,
             embedding_table_fp16.data(),
-            empty_indices ? nullptr : indices.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
             output.data(),
@@ -441,7 +375,7 @@ TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
             lengths_sum,
             num_rows,
             embedding_table.data(),
-            empty_indices ? nullptr : indices.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
             mapping_table.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
@@ -460,7 +394,7 @@ TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
             lengths_sum,
             num_rows,
             embedding_table.data(),
-            empty_indices ? nullptr : indices.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
             output.data(),
@@ -474,7 +408,7 @@ TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
             lengths_sum,
             num_rows,
             embedding_table_fp16.data(),
-            empty_indices ? nullptr : indices_32.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
             mapping_table_32.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
@@ -493,7 +427,7 @@ TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
             lengths_sum,
             num_rows,
             embedding_table_fp16.data(),
-            empty_indices ? nullptr : indices_32.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
             output.data(),
@@ -505,7 +439,7 @@ TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
             lengths_sum,
             num_rows,
             embedding_table.data(),
-            empty_indices ? nullptr : indices_32.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
             mapping_table_32.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
@@ -524,7 +458,7 @@ TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
             lengths_sum,
             num_rows,
             embedding_table.data(),
-            empty_indices ? nullptr : indices_32.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
             output.data(),
@@ -535,6 +469,10 @@ TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
     // Check correctness
     EXPECT_EQ(success, success_ref)
         << "Reference and JIT impl did not both succeed";
+    if (corner_case == OUT_OF_BOUND_INDICES ||
+        corner_case == UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM) {
+      EXPECT_EQ(success, false);
+    }
     if (success) {
       for (int i = 0; i < output.size(); ++i) {
         EXPECT_EQ(output[i], output_ref[i])

--- a/test/EmbeddingSpMDMTest.cc
+++ b/test/EmbeddingSpMDMTest.cc
@@ -292,10 +292,9 @@ TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
     int average_len = input[3];
 
     // Create mapping table for rowwise sparsity
-    vector<int64_t> mapping_table;
-    vector<int32_t> mapping_table_32;
-    int num_compressed_rows = CreateMappingTableForRowWiseSparsity(
-        mapping_table, mapping_table_32, num_rows, sparsity);
+    vector<int32_t> mapping_table;
+    int num_compressed_rows =
+        CreateMappingTableForRowWiseSparsity(mapping_table, num_rows, sparsity);
 
     // Create embedding table
     vector<float> embedding_table(num_compressed_rows * embedding_dim);
@@ -409,7 +408,7 @@ TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
             num_rows,
             embedding_table_fp16.data(),
             corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
-            mapping_table_32.data(),
+            mapping_table.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
             normalize_by_lengths,
@@ -431,7 +430,7 @@ TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
             lengths.data(),
             use_weight ? weights.data() : nullptr,
             output.data(),
-            mapping_table_32.data());
+            mapping_table.data());
       } else {
         success_ref = EmbeddingSpMDMRowWiseSparse_ref(
             embedding_dim,
@@ -440,7 +439,7 @@ TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
             num_rows,
             embedding_table.data(),
             corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
-            mapping_table_32.data(),
+            mapping_table.data(),
             lengths.data(),
             use_weight ? weights.data() : nullptr,
             normalize_by_lengths,
@@ -462,7 +461,7 @@ TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
             lengths.data(),
             use_weight ? weights.data() : nullptr,
             output.data(),
-            mapping_table_32.data());
+            mapping_table.data());
       }
     }
 

--- a/test/EmbeddingSpMDMTestUtils.cc
+++ b/test/EmbeddingSpMDMTestUtils.cc
@@ -1,0 +1,93 @@
+#include "EmbeddingSpMDMTestUtils.h"
+
+#include <numeric>
+#include <random>
+
+namespace fbgemm {
+
+using namespace std;
+
+int GenerateLengthsIndicesWeights(
+    vector<int>& lengths,
+    vector<int64_t>& indices,
+    vector<int32_t>& indices_32,
+    vector<float>& weights,
+    int batch_size,
+    int num_rows,
+    int embedding_dim,
+    int average_len,
+    EmbeddingSpMDMCornerCase corner_case) {
+  // Generate lengths
+  default_random_engine generator;
+  uniform_int_distribution<int> length_distribution(
+      1, std::min(2 * average_len + 1, num_rows));
+  lengths.resize(batch_size);
+  for (int i = 0; i < batch_size; ++i) {
+    lengths[i] =
+        corner_case == EMPTY_INDICES ? 0 : length_distribution(generator);
+  }
+
+  // Compute the number of indices
+  int lengths_sum = accumulate(lengths.begin(), lengths.end(), 0);
+
+  // Generate indices
+  indices.resize(lengths_sum);
+  indices_32.resize(lengths_sum);
+
+  uniform_int_distribution<int> index_distribution(0, num_rows - 1);
+  for (int i = 0; i < lengths_sum; ++i) {
+    indices_32[i] = indices[i] = index_distribution(generator);
+  }
+  if (corner_case != EMPTY_INDICES) {
+    // to make sure to exercise out-of-bound cases
+    indices_32[0] = indices[0] = num_rows - 1;
+  }
+  if (corner_case == OUT_OF_BOUND_INDICES) {
+    int idx = uniform_int_distribution<int>(0, lengths_sum - 1)(generator);
+    indices_32[idx] = indices[idx] = num_rows;
+  }
+  if (corner_case == UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM) {
+    if (bernoulli_distribution(0.5)(generator)) {
+      ++lengths[batch_size - 1];
+    } else {
+      --lengths[batch_size - 1];
+    }
+  }
+
+  // Generate weights
+  weights.resize(lengths_sum);
+  normal_distribution<float> embedding_distribution;
+  for (int i = 0; i < lengths_sum; ++i) {
+    weights[i] = embedding_distribution(generator);
+  }
+
+  return lengths_sum;
+}
+
+int CreateMappingTableForRowWiseSparsity(
+    vector<int64_t>& mapping_table,
+    vector<int32_t>& mapping_table_32,
+    int num_rows,
+    float sparsity) {
+  default_random_engine generator;
+  mapping_table.resize(num_rows);
+  bernoulli_distribution row_prune_dist(sparsity);
+  int num_compressed_rows = 0;
+  for (int i = 0; i < num_rows; ++i) {
+    if (row_prune_dist(generator)) {
+      // pruned
+      mapping_table[i] = -1;
+    } else {
+      mapping_table[i] = num_compressed_rows;
+      ++num_compressed_rows;
+    }
+  }
+  copy(
+      mapping_table.begin(),
+      mapping_table.end(),
+      back_inserter(mapping_table_32));
+
+  return num_compressed_rows;
+}
+
+} // namespace fbgemm

--- a/test/EmbeddingSpMDMTestUtils.cc
+++ b/test/EmbeddingSpMDMTestUtils.cc
@@ -65,8 +65,7 @@ int GenerateLengthsIndicesWeights(
 }
 
 int CreateMappingTableForRowWiseSparsity(
-    vector<int64_t>& mapping_table,
-    vector<int32_t>& mapping_table_32,
+    vector<int32_t>& mapping_table,
     int num_rows,
     float sparsity) {
   default_random_engine generator;
@@ -82,10 +81,6 @@ int CreateMappingTableForRowWiseSparsity(
       ++num_compressed_rows;
     }
   }
-  copy(
-      mapping_table.begin(),
-      mapping_table.end(),
-      back_inserter(mapping_table_32));
 
   return num_compressed_rows;
 }

--- a/test/EmbeddingSpMDMTestUtils.h
+++ b/test/EmbeddingSpMDMTestUtils.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace fbgemm {
+
+enum EmbeddingSpMDMCornerCase {
+  NONE,
+  EMPTY_INDICES,
+  OUT_OF_BOUND_INDICES,
+  UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM,
+};
+
+/**
+ * @return lengths_sum
+ */
+int GenerateLengthsIndicesWeights(
+    std::vector<int>& lengths,
+    std::vector<std::int64_t>& indices,
+    std::vector<std::int32_t>& indices_32,
+    std::vector<float>& weights,
+    int batch_size,
+    int num_rows,
+    int embedding_dim,
+    int average_len,
+    EmbeddingSpMDMCornerCase corner_case);
+
+/**
+ * @return num_compressed_rows
+ */
+int CreateMappingTableForRowWiseSparsity(
+    std::vector<std::int64_t>& mapping_table,
+    std::vector<std::int32_t>& mapping_table_32,
+    int num_rows,
+    float sparsity);
+
+}; // namespace fbgemm

--- a/test/EmbeddingSpMDMTestUtils.h
+++ b/test/EmbeddingSpMDMTestUtils.h
@@ -30,8 +30,7 @@ int GenerateLengthsIndicesWeights(
  * @return num_compressed_rows
  */
 int CreateMappingTableForRowWiseSparsity(
-    std::vector<std::int64_t>& mapping_table,
-    std::vector<std::int32_t>& mapping_table_32,
+    std::vector<std::int32_t>& mapping_table,
     int num_rows,
     float sparsity);
 


### PR DESCRIPTION
Summary: To address a challenge of detecting index type during model transformation. We shouldn't expect the number of rows in an embedding table will exceed int32_t range especially after row-wise pruning

Differential Revision: D19954308

