### PR TITLE
Fix the error in calling getCodeLoggingFile()

### DIFF
--- a/src/GenerateKernelU8S8S32ACC16.cc
+++ b/src/GenerateKernelU8S8S32ACC16.cc
@@ -162,8 +162,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate<inst_set_t::avx2>(
             nBlock,
             kBlock,
             mRegBlockSize,
-            nRegBlockSize,
-            nRegBlockSizeMin)
+            nRegBlockSize)
             .c_str(),
         "w");
     asmjit::FileLogger* codeLogger = new asmjit::FileLogger(codeLogfile);

--- a/src/GenerateKernelU8S8S32ACC16Avx512.cc
+++ b/src/GenerateKernelU8S8S32ACC16Avx512.cc
@@ -168,8 +168,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate<inst_set_t::avx512>(
             nBlock,
             kBlock,
             mRegBlockSize,
-            nRegBlockSize,
-            nRegBlockSizeMin)
+            nRegBlockSize)
             .c_str(),
         "w");
     asmjit::FileLogger* codeLogger = new asmjit::FileLogger(codeLogfile);

--- a/src/GenerateKernelU8S8S32ACC32.cc
+++ b/src/GenerateKernelU8S8S32ACC32.cc
@@ -167,8 +167,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate<inst_set_t::avx2>(
             nBlock,
             kBlock,
             mRegBlockSize,
-            nRegBlockSize,
-            nRegBlockSizeMin)
+            nRegBlockSize)
             .c_str(),
         "w");
     asmjit::FileLogger* codeLogger = new asmjit::FileLogger(codeLogfile);

--- a/src/GenerateKernelU8S8S32ACC32Avx512.cc
+++ b/src/GenerateKernelU8S8S32ACC32Avx512.cc
@@ -164,8 +164,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate<inst_set_t::avx512>(
             nBlock,
             kBlock,
             mRegBlockSize,
-            nRegBlockSize,
-            nRegBlockSizeMin)
+            nRegBlockSize)
             .c_str(),
         "w");
     asmjit::FileLogger* codeLogger = new asmjit::FileLogger(codeLogfile);

--- a/src/GenerateKernelU8S8S32ACC32Avx512VNNI.cc
+++ b/src/GenerateKernelU8S8S32ACC32Avx512VNNI.cc
@@ -131,8 +131,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate<
             nBlock,
             kBlock,
             mRegBlockSize,
-            nRegBlockSize,
-            nRegBlockSizeMin)
+            nRegBlockSize)
             .c_str(),
         "w");
     asmjit::FileLogger* codeLogger = new asmjit::FileLogger(codeLogfile);


### PR DESCRIPTION
Summary: Fix the error in ```getCodeLoggingFile()```  when enabling ```FBGEMM_LOG_CODE``` in ```src/GenerateKernel.h```. An extra parameter ```nRegBlockSizeMin``` needs to be removed from the function call.

Reviewed By: jspark1105

Differential Revision: D20182868

