### PR TITLE
Quantize should work even if the value after quantization becomes inf (#107)

### DIFF
--- a/include/fbgemm/QuantUtils.h
+++ b/include/fbgemm/QuantUtils.h
@@ -56,10 +56,11 @@ T Quantize(
     int result_precision,
     bool result_is_signed = std::is_signed<T>::value) {
   const float transformed_val = zero_point + src / scale;
-  return clamp<std::int64_t, T>(
-      static_cast<std::int64_t>(std::nearbyint(transformed_val)),
-      result_precision,
-      result_is_signed);
+  // Please note the use of double. Unlike float, a double can represent
+  // all int32 values exactly. Using a float results in a float value >
+  // INT32_MAX conversion to int32 in clamp function and hence an UBSAN error.
+  return clamp<double, T>(
+      std::nearbyint(transformed_val), result_precision, result_is_signed);
 }
 
 template <typename T>


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/FBGEMM/pull/107

With small `scale` and large `src` (value to be quantized) the `src/scale` may become +inf or -inf. We should quantized to max/min in this case.

Without this fix, we get the following error.

```
> buck-out/dev/gen/deeplearning/fbgemm/fbgemm_generic#header-mode-symlink-tree-with-header-map,headers/fbgemm/QuantUtils.h:66:35: runtime error: inf is outside the range of representable values of type 'long'

buck-out/dev/gen/deeplearning/fbgemm/fbgemm_generic#header-mode-symlink-tree-with-header-map,headers/fbgemm/QuantUtils.h:66:35: runtime error: 1.38809e+38 is outside the range of representable values of type 'long'

```

Reviewed By: jspark1105

Differential Revision: D20515006

