### PR TITLE
remove unnecessary prefetch for scale/bias in corner cases

### DIFF
--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -541,7 +541,7 @@ typename ReturnFunctionSignature<inType, indxType, ROWWISE_SPARSE>::
             a->vbroadcastss(scale_vreg, scale_src);
             a->vbroadcastss(bias_vreg, bias_src);
 
-            if (pref_dist &&
+            if (pref_dist && fused_block_size % CACHE_LINE_LEN > 0 &&
                 fused_block_size % CACHE_LINE_LEN <= 2 * sizeof(float)) {
               a->prefetcht0(x86::dword_ptr(
                   input,

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -585,7 +585,7 @@ GenEmbeddingSpMDMNBitLookup<indxType, ROWWISE_SPARSE>::getOrCreate(
           a->vcvtph2ps(
               vec_reg_t(bias_vreg.id()), half_vec_reg_t(bias_vreg.id()));
           constexpr int CACHE_LINE_LEN = 64;
-          if (pref_dist &&
+          if (pref_dist && fused_block_size % CACHE_LINE_LEN > 0 &&
               fused_block_size % CACHE_LINE_LEN <= 2 * sizeof(float16)) {
             a->prefetcht0(x86::dword_ptr(
                 input,


### PR DESCRIPTION
Summary: In D20582936 we missed a case when fused_block_size is exactly a multiple of 64 we don't need extra prefetch for scale and bias

Differential Revision: D20585862

