### PR TITLE
use xor instead of mov 0

### DIFF
--- a/src/FbgemmFP16UKernelsAvx2.cc
+++ b/src/FbgemmFP16UKernelsAvx2.cc
@@ -40,7 +40,7 @@ void NOINLINE gemmkernel_1x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss ymm15,DWORD PTR [r15]\t\n"
@@ -162,7 +162,7 @@ void NOINLINE gemmkernel_2x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss ymm15,DWORD PTR [r15]\t\n"
@@ -305,7 +305,7 @@ void NOINLINE gemmkernel_3x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss ymm15,DWORD PTR [r15]\t\n"
@@ -467,7 +467,7 @@ void NOINLINE gemmkernel_4x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss ymm15,DWORD PTR [r15]\t\n"
@@ -648,7 +648,7 @@ void NOINLINE gemmkernel_5x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss ymm15,DWORD PTR [r15]\t\n"
@@ -848,7 +848,7 @@ void NOINLINE gemmkernel_6x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss ymm15,DWORD PTR [r15]\t\n"

--- a/src/FbgemmFP16UKernelsAvx512.cc
+++ b/src/FbgemmFP16UKernelsAvx512.cc
@@ -40,7 +40,7 @@ void NOINLINE gemmkernel_1x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss zmm31,DWORD PTR [r15]\t\n"
@@ -162,7 +162,7 @@ void NOINLINE gemmkernel_2x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss zmm31,DWORD PTR [r15]\t\n"
@@ -305,7 +305,7 @@ void NOINLINE gemmkernel_3x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss zmm31,DWORD PTR [r15]\t\n"
@@ -467,7 +467,7 @@ void NOINLINE gemmkernel_4x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss zmm31,DWORD PTR [r15]\t\n"
@@ -648,7 +648,7 @@ void NOINLINE gemmkernel_5x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss zmm31,DWORD PTR [r15]\t\n"
@@ -848,7 +848,7 @@ void NOINLINE gemmkernel_6x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss zmm31,DWORD PTR [r15]\t\n"
@@ -1067,7 +1067,7 @@ void NOINLINE gemmkernel_7x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss zmm31,DWORD PTR [r15]\t\n"
@@ -1305,7 +1305,7 @@ void NOINLINE gemmkernel_8x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss zmm31,DWORD PTR [r15]\t\n"
@@ -1562,7 +1562,7 @@ void NOINLINE gemmkernel_9x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss zmm31,DWORD PTR [r15]\t\n"
@@ -1838,7 +1838,7 @@ void NOINLINE gemmkernel_10x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss zmm31,DWORD PTR [r15]\t\n"
@@ -2133,7 +2133,7 @@ void NOINLINE gemmkernel_11x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss zmm31,DWORD PTR [r15]\t\n"
@@ -2447,7 +2447,7 @@ void NOINLINE gemmkernel_12x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss zmm31,DWORD PTR [r15]\t\n"
@@ -2780,7 +2780,7 @@ void NOINLINE gemmkernel_13x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss zmm31,DWORD PTR [r15]\t\n"
@@ -3132,7 +3132,7 @@ void NOINLINE gemmkernel_14x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss zmm31,DWORD PTR [r15]\t\n"

--- a/src/FbgemmFP16UKernelsAvx512_256.cc
+++ b/src/FbgemmFP16UKernelsAvx512_256.cc
@@ -40,7 +40,7 @@ void NOINLINE gemmkernel_7x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss ymm31,DWORD PTR [r15]\t\n"
@@ -278,7 +278,7 @@ void NOINLINE gemmkernel_8x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss ymm31,DWORD PTR [r15]\t\n"
@@ -535,7 +535,7 @@ void NOINLINE gemmkernel_9x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss ymm31,DWORD PTR [r15]\t\n"
@@ -811,7 +811,7 @@ void NOINLINE gemmkernel_10x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss ymm31,DWORD PTR [r15]\t\n"
@@ -1106,7 +1106,7 @@ void NOINLINE gemmkernel_11x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss ymm31,DWORD PTR [r15]\t\n"
@@ -1420,7 +1420,7 @@ void NOINLINE gemmkernel_12x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss ymm31,DWORD PTR [r15]\t\n"
@@ -1753,7 +1753,7 @@ void NOINLINE gemmkernel_13x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss ymm31,DWORD PTR [r15]\t\n"
@@ -2105,7 +2105,7 @@ void NOINLINE gemmkernel_14x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "mov rax, r9\t\n"
       "mov rcx, r12\t\n"
 
-      "mov rbx, 0\t\n"
+      "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
       "vbroadcastss ymm31,DWORD PTR [r15]\t\n"

--- a/src/FbgemmI64.cc
+++ b/src/FbgemmI64.cc
@@ -116,7 +116,7 @@ void CodeGenBase<int64_t, int64_t, int64_t, int64_t>::storeCRegs<
     if (i != 0) {
       a->add(C_Offset, ldcReg);
     } else {
-      a->mov(C_Offset, static_cast<asmjit::Imm>(0));
+      a->xor_(C_Offset.r32(), C_Offset.r32());
     }
     for (int j = 0; j < colRegs; ++j) {
       if (accum) {
@@ -255,11 +255,11 @@ CodeGenBase<int64_t, int64_t, int64_t, int64_t>::getOrCreate<
     int colRegs = std::min(currColRegs, maxNRegs);
     if (mRegBlocks > 0) {
       // move 0 to iteration variables
-      a->mov(iIdx, 0);
+      a->xor_(iIdx.r32(), iIdx.r32());
 
       a->bind(LoopMBlocks);
       a->inc(iIdx);
-      a->mov(jIdx, 0);
+      a->xor_(jIdx.r32(), jIdx.r32());
 
       a->bind(LoopNBlocks);
       a->inc(jIdx);
@@ -270,7 +270,7 @@ CodeGenBase<int64_t, int64_t, int64_t, int64_t>::getOrCreate<
       initCRegs<inst_set_t::avx512>(a, rowRegs, colRegs);
 
       // init k loop index
-      a->mov(kIdx, 0);
+      a->xor_(kIdx.r32(), kIdx.r32());
       a->bind(Loopk);
 
       // k is incremented by 1
@@ -342,7 +342,7 @@ CodeGenBase<int64_t, int64_t, int64_t, int64_t>::getOrCreate<
       asmjit::Label LoopkRem = a->newLabel();
       int rowRegs = mRegBlocksRem;
 
-      a->mov(jIdx, 0);
+      a->xor_(jIdx.r32(), jIdx.r32());
       a->bind(LoopNRem);
       a->inc(jIdx);
 
@@ -350,7 +350,7 @@ CodeGenBase<int64_t, int64_t, int64_t, int64_t>::getOrCreate<
       initCRegs<inst_set_t::avx512>(a, rowRegs, colRegs);
 
       // init k loop index
-      a->mov(kIdx, 0);
+      a->xor_(kIdx.r32(), kIdx.r32());
       a->bind(LoopkRem);
 
       // k is incremented by 1

--- a/src/GenerateKernelU8S8S32ACC16.cc
+++ b/src/GenerateKernelU8S8S32ACC16.cc
@@ -235,7 +235,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate<inst_set_t::avx2>(
     int colRegs = nc * row_interleave / VLEN_;
     if (mRegBlocks > 0) {
       // move 0 to iteration variables
-      a->mov(iIdx, 0);
+      a->xor_(iIdx.r32(), iIdx.r32());
 
       // save B_buffer address
       a->mov(buffer_B_saved, buffer_B);
@@ -250,7 +250,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate<inst_set_t::avx2>(
       initCRegs<inst_set_t::avx2>(a, rowRegs, colRegs);
 
       // init k loop index
-      a->mov(kIdx, 0);
+      a->xor_(kIdx.r32(), kIdx.r32());
       a->bind(Loopk);
       // k is incremented by row_interleave
       a->add(kIdx, static_cast<asmjit::Imm>(row_interleave));
@@ -303,7 +303,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate<inst_set_t::avx2>(
       initCRegs<inst_set_t::avx2>(a, rowRegs, colRegs);
 
       // init k loop index
-      a->mov(kIdx, 0);
+      a->xor_(kIdx.r32(), kIdx.r32());
       a->bind(LoopkRem);
 
       // k is incremented by row_interleave

--- a/src/GenerateKernelU8S8S32ACC16Avx512.cc
+++ b/src/GenerateKernelU8S8S32ACC16Avx512.cc
@@ -249,11 +249,11 @@ CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate<inst_set_t::avx512>(
     int colRegs = std::min(currColRegs, maxNRegs);
     if (mRegBlocks > 0) {
       // move 0 to iteration variables
-      a->mov(iIdx, 0);
+      a->xor_(iIdx.r32(), iIdx.r32());
 
       a->bind(LoopMBlocks);
       a->inc(iIdx);
-      a->mov(jIdx, 0);
+      a->xor_(jIdx.r32(), jIdx.r32());
 
       a->bind(LoopNBlocks);
       a->inc(jIdx);
@@ -264,7 +264,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate<inst_set_t::avx512>(
       initCRegs<inst_set_t::avx512>(a, rowRegs, colRegs);
 
       // init k loop index
-      a->mov(kIdx, 0);
+      a->xor_(kIdx.r32(), kIdx.r32());
       a->bind(Loopk);
       // k is incremented by row_interleave
       a->add(kIdx, static_cast<asmjit::Imm>(row_interleave));
@@ -341,7 +341,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate<inst_set_t::avx512>(
       asmjit::Label LoopkRem = a->newLabel();
       int rowRegs = mRegBlocksRem;
 
-      a->mov(jIdx, 0);
+      a->xor_(jIdx.r32(), jIdx.r32());
       a->bind(LoopNRem);
       a->inc(jIdx);
 
@@ -349,7 +349,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate<inst_set_t::avx512>(
       initCRegs<inst_set_t::avx512>(a, rowRegs, colRegs);
 
       // init k loop index
-      a->mov(kIdx, 0);
+      a->xor_(kIdx.r32(), kIdx.r32());
       a->bind(LoopkRem);
 
       // k is incremented by row_interleave

--- a/src/GenerateKernelU8S8S32ACC32.cc
+++ b/src/GenerateKernelU8S8S32ACC32.cc
@@ -242,7 +242,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate<inst_set_t::avx2>(
     a->vpcmpeqw(oneReg, oneReg, oneReg);
     a->vpsrlw(oneReg, oneReg, 15);
     a->imul(ldcReg, ldcReg, static_cast<asmjit::Imm>(sizeof(int32_t)));
-    a->mov(C_Offset, 0);
+    a->xor_(C_Offset.r32(), C_Offset.r32());
 
     int colRegs = nc * row_interleave / VLEN_;
 
@@ -253,7 +253,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate<inst_set_t::avx2>(
       initCRegs<inst_set_t::avx2>(a, rowRegs, colRegs);
 
       // Loops over K
-      a->mov(kIdx, 0);
+      a->xor_(kIdx.r32(), kIdx.r32());
       a->bind(LoopKLabel);
 
       // k is incremented by row_interleave
@@ -284,7 +284,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate<inst_set_t::avx2>(
 
     if (mRegBlocks > 0) {
       // move 0 to iteration variables
-      a->mov(iIdx, 0);
+      a->xor_(iIdx.r32(), iIdx.r32());
 
       // save B_buffer address
       a->mov(buffer_B_saved, buffer_B);
@@ -305,7 +305,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate<inst_set_t::avx2>(
       // increment C for next block
       a->imul(C_Offset, ldcReg, static_cast<asmjit::Imm>(rowRegs));
       a->add(CBase, C_Offset);
-      a->mov(C_Offset, 0);
+      a->xor_(C_Offset.r32(), C_Offset.r32());
 
       // reset B
       a->mov(buffer_B, buffer_B_saved);

--- a/src/GenerateKernelU8S8S32ACC32Avx512.cc
+++ b/src/GenerateKernelU8S8S32ACC32Avx512.cc
@@ -92,7 +92,7 @@ void CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::storeCRegs<
     if (i != 0) {
       a->add(C_Offset, ldcReg);
     } else {
-      a->mov(C_Offset, static_cast<asmjit::Imm>(0));
+      a->xor_(C_Offset.r32(), C_Offset.r32());
     }
     for (int j = 0; j < colRegs; ++j) {
       if (accum) {
@@ -255,11 +255,11 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate<inst_set_t::avx512>(
     int colRegs = std::min(currColRegs, maxNRegs);
     if (mRegBlocks > 0) {
       // move 0 to iteration variables
-      a->mov(iIdx, 0);
+      a->xor_(iIdx.r32(), iIdx.r32());
 
       a->bind(LoopMBlocks);
       a->inc(iIdx);
-      a->mov(jIdx, 0);
+      a->xor_(jIdx.r32(), jIdx.r32());
 
       a->bind(LoopNBlocks);
       a->inc(jIdx);
@@ -270,7 +270,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate<inst_set_t::avx512>(
       initCRegs<inst_set_t::avx512>(a, rowRegs, colRegs);
 
       // init k loop index
-      a->mov(kIdx, 0);
+      a->xor_(kIdx.r32(), kIdx.r32());
       a->bind(Loopk);
 
       // k is incremented by row_interleave
@@ -349,7 +349,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate<inst_set_t::avx512>(
       asmjit::Label LoopkRem = a->newLabel();
       int rowRegs = mRegBlocksRem;
 
-      a->mov(jIdx, 0);
+      a->xor_(jIdx.r32(), jIdx.r32());
       a->bind(LoopNRem);
       a->inc(jIdx);
 
@@ -357,7 +357,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate<inst_set_t::avx512>(
       initCRegs<inst_set_t::avx512>(a, rowRegs, colRegs);
 
       // init k loop index
-      a->mov(kIdx, 0);
+      a->xor_(kIdx.r32(), kIdx.r32());
       a->bind(LoopkRem);
 
       // k is incremented by row_interleave

--- a/src/GenerateKernelU8S8S32ACC32Avx512VNNI.cc
+++ b/src/GenerateKernelU8S8S32ACC32Avx512VNNI.cc
@@ -222,11 +222,11 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate<
     int colRegs = std::min(currColRegs, maxNRegs);
     if (mRegBlocks > 0) {
       // move 0 to iteration variables
-      a->mov(iIdx, 0);
+      a->xor_(iIdx.r32(), iIdx.r32());
 
       a->bind(LoopMBlocks);
       a->inc(iIdx);
-      a->mov(jIdx, 0);
+      a->xor_(jIdx.r32(), jIdx.r32());
 
       a->bind(LoopNBlocks);
       a->inc(jIdx);
@@ -237,7 +237,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate<
       initCRegs<inst_set_t::avx512_vnni>(a, rowRegs, colRegs);
 
       // init k loop index
-      a->mov(kIdx, 0);
+      a->xor_(kIdx.r32(), kIdx.r32());
       a->bind(Loopk);
 
       // k is incremented by row_interleave
@@ -316,7 +316,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate<
       asmjit::Label LoopkRem = a->newLabel();
       int rowRegs = mRegBlocksRem;
 
-      a->mov(jIdx, 0);
+      a->xor_(jIdx.r32(), jIdx.r32());
       a->bind(LoopNRem);
       a->inc(jIdx);
 
@@ -324,7 +324,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate<
       initCRegs<inst_set_t::avx512_vnni>(a, rowRegs, colRegs);
 
       // init k loop index
-      a->mov(kIdx, 0);
+      a->xor_(kIdx.r32(), kIdx.r32());
       a->bind(LoopkRem);
 
       // k is incremented by row_interleave

--- a/src/codegen_fp16fp32.cc
+++ b/src/codegen_fp16fp32.cc
@@ -423,7 +423,7 @@ int main(int argc, const char* argv[]) {
         addi(srcfile, "mov rcx, r12");
         srcfile << "\n";
 
-        addi(srcfile, "mov rbx, 0");
+        addi(srcfile, "xor ebx, ebx");
         addi(srcfile, label_outer + ":");
         addi(srcfile, "mov r14, r8");
 


### PR DESCRIPTION
Summary:
Use "xor eax eax" instead of "mov rax 0" to follow the best practices to save code size.
See more details in https://stackoverflow.com/a/33668295

Differential Revision: D20588183

