### PR TITLE
minor fixes in embedding benchmarks

### DIFF
--- a/bench/EmbeddingSpMDM8BitBenchmark.cc
+++ b/bench/EmbeddingSpMDM8BitBenchmark.cc
@@ -66,8 +66,6 @@ int run_benchmark(
     bool prefetch = false,
     bool stress_multi_threading = false) {
   // Create embedding table
-  vector<uint8_t> embedding_table(
-      num_rows * (embedding_dim + 2 * sizeof(float)));
   default_random_engine generator;
   normal_distribution<float> embedding_distribution;
 

--- a/bench/EmbeddingSpMDMBenchmark.cc
+++ b/bench/EmbeddingSpMDMBenchmark.cc
@@ -112,11 +112,12 @@ void run_benchmark(
 
   constexpr int NUM_WARMUP = 4;
   constexpr int NUM_ITER = 10;
+  int elem_bytes = use_fp16_inputs ? sizeof(float16) : sizeof(float);
   double bytes = lengths_sum *
-          (embedding_dim * sizeof(float) + (use_32_bit_indices ? 4 : 8)) +
+          (embedding_dim * elem_bytes + (use_32_bit_indices ? 4 : 8)) +
       batch_size * sizeof(int);
   double bytes_padded = lengths_sum *
-          ((embedding_dim * sizeof(float) + 63) / 64 * 64 +
+          ((embedding_dim * elem_bytes + 63) / 64 * 64 +
            (use_32_bit_indices ? 4 : 8)) +
       batch_size * sizeof(int);
 

--- a/bench/EmbeddingSpMDMNBitBenchmark.cc
+++ b/bench/EmbeddingSpMDMNBitBenchmark.cc
@@ -70,7 +70,6 @@ int run_benchmark(
   int fused_embedding_dim =
       (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte +
       2 * sizeof(float16);
-  vector<uint8_t> embedding_table(num_rows * fused_embedding_dim);
   default_random_engine generator;
   normal_distribution<float> embedding_distribution;
 

--- a/bench/EmbeddingSpMDMNBitRowWiseSparseBenchmark.cc
+++ b/bench/EmbeddingSpMDMNBitRowWiseSparseBenchmark.cc
@@ -86,7 +86,6 @@ int run_benchmark(
   int fused_embedding_dim =
       (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte +
       2 * sizeof(float16);
-  vector<uint8_t> embedding_table(num_compressed_rows * fused_embedding_dim);
   normal_distribution<float> embedding_distribution;
 
   vector<uint8_t> fused_embedding_table(


### PR DESCRIPTION
Summary:
Remove unused embedding_table (fused_embedding_table is the one actually used).
Correct account of memory traffic for fp16 embedding table

Differential Revision: D20588787

