### PR TITLE
remove unnecessary bound check for prefetching; avoid prefetching for -1 index

### DIFF
--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -485,8 +485,7 @@ typename ReturnFunctionSignature<inType, indxType, ROWWISE_SPARSE>::
                   x86::dword_ptr(indices, pref_dist * sizeof(indxType)));
             }
 
-            a->cmp(scratchReg2_, data_size);
-            a->jb(pref_dist_reset_end);
+            a->jmp(pref_dist_reset_end);
 
             a->bind(pref_dist_reset_start);
             // things are not okay just get the current row
@@ -499,12 +498,26 @@ typename ReturnFunctionSignature<inType, indxType, ROWWISE_SPARSE>::
 
             a->bind(pref_dist_reset_end);
             if (ROWWISE_SPARSE) {
+              asmjit::Label rowwise_sparse_pref_corner_case_begin =
+                  a->newLabel();
+              asmjit::Label rowwise_sparse_pref_corner_case_end = a->newLabel();
+              a->cmp(scratchReg2_, data_size);
+              a->jae(rowwise_sparse_pref_corner_case_begin);
+
               a->mov(
                   scratchReg2_.r32(),
                   x86::dword_ptr(
                       compressed_indices_table,
                       scratchReg2_,
                       2)); // use of 2 is to multiply by 4
+              a->test(scratchReg2_.r32(), scratchReg2_.r32());
+              // Check negative
+              a->jns(rowwise_sparse_pref_corner_case_end);
+
+              a->bind(rowwise_sparse_pref_corner_case_begin);
+              // For corner case, just set prefetch row id to 0.
+              a->xor_(scratchReg2_.r32(), scratchReg2_.r32());
+              a->bind(rowwise_sparse_pref_corner_case_end);
             }
             a->imul(scratchReg2_, static_cast<asmjit::Imm>(fused_block_size));
           }

--- a/src/RowWiseSparseAdagradFused.cc
+++ b/src/RowWiseSparseAdagradFused.cc
@@ -370,8 +370,7 @@ GenRowWiseSparseAdagradFused<indxType, instSet>::getOrCreate(
                 x86::dword_ptr(indices, prefetch * sizeof(indxType)));
           }
 
-          a->cmp(scratchReg2, data_size);
-          a->jb(pref_dist_reset_end);
+          a->jmp(pref_dist_reset_end);
 
           a->bind(pref_dist_reset_start);
           // things are not okay just get the current row


### PR DESCRIPTION
Summary:
Except for cases with row-wise sparsity, we don't need to check the bound of addresses to be used by prefetch because that's a rare case that the caller side should report errors and prefetching with an invalid address doesn't segfault.

On the other hand, for embedding tables with row-wise sparsity, we do want to avoid prefetching with -1 (indicating the row is pruned) because this can happen often and prefetching with an invalid address can have performance consequences

Reviewed By: dskhudia

Differential Revision: D20588734

