### PR TITLE
test 1024^3 matrix mulmat performance

### DIFF
--- a/bench/BenchUtils.cc
+++ b/bench/BenchUtils.cc
@@ -114,4 +114,37 @@ bool parseArgumentBool(
   }
   return def_val;
 }
+
+aligned_vector<float> getRandomSparseVector(
+    unsigned size,
+    float fractionNonZeros) {
+  aligned_vector<float> res(size);
+
+  std::mt19937 gen(345);
+
+  std::uniform_real_distribution<double> dis(0.0, 1.0);
+
+  for (auto& f : res) {
+    f = dis(gen);
+  }
+
+  // Create exactly fractionNonZeros in result
+  aligned_vector<float> sorted_res(res);
+  std::sort(sorted_res.begin(), sorted_res.end());
+  int32_t numZeros =
+      size - static_cast<int32_t>(std::round(size * fractionNonZeros));
+  float thr;
+  if (numZeros) {
+    thr = sorted_res[numZeros - 1];
+
+    for (auto& f : res) {
+      if (f <= thr) {
+        f = 0.0f;
+      }
+    }
+  }
+
+  return res;
+}
+
 } // namespace fbgemm

--- a/bench/BenchUtils.h
+++ b/bench/BenchUtils.h
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <functional>
 #include <vector>
+#include <random>
 
 #include <immintrin.h>
 
@@ -154,4 +155,7 @@ void transpose_matrix(T* ref, int n, int k) {
   memcpy(ref, local.data(), n * k * sizeof(T));
 }
 
+aligned_vector<float> getRandomSparseVector(
+    unsigned size,
+    float fractionNonZeros = 1.0);
 } // namespace fbgemm

--- a/include/fbgemm/PackingTraits-inl.h
+++ b/include/fbgemm/PackingTraits-inl.h
@@ -254,7 +254,7 @@ struct PackingTraits<
            ///< 16 because 16*ROW_INTERLEAVE int8 elements
            ///< completely fill a 512-bit wide vector.
   static constexpr int NR{
-      32}; ///< Register block for N dimension.
+      48}; ///< Register block for N dimension.
            ///< Must be a multiple of 16 because 16*ROW_INTERLEAVE int8 elements
            ///< completely fill a 512-bit wide vector. Total registers used for
            ///< N dimension: NR*ROW_INTERLEAVE*8/VLEN. We use MR x
@@ -266,8 +266,8 @@ struct PackingTraits<
           ///< B matrix.
 
   static constexpr int MCB{
-      128}; ///< Cache block for M dimension (multiple of MR).
+      384}; ///< Cache block for M dimension (multiple of MR).
   static constexpr int NCB{
-      32}; ///< Cache block for N dimension (multiple of NR).
-  static constexpr int KCB{256}; ///< Cache block for K dimension.
+      48}; ///< Cache block for N dimension (multiple of NR).
+  static constexpr int KCB{512}; ///< Cache block for K dimension.
 };

--- a/src/MaskAvx2.h
+++ b/src/MaskAvx2.h
@@ -30,7 +30,7 @@ alignas(64) static const int avx2_ps_or_epi32_masks[9][8] = {
 // clang-format on
 
 // mask can be accessed by avx2_ps_or_epi32_combined_mask[(8 - remainder) % 8]
-static const int avx2_ps_or_epi32_combined_mask[16] = {
+alignas(64) static const int avx2_ps_or_epi32_combined_mask[16] = {
   -1, -1, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0,
 };
 

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -319,4 +319,17 @@ FBGEMM_API int rowwise_sparse_adagrad_fused_ref(
     float lr,
     bool use_offsets = false);
 
+template <typename TA, typename TB, typename TC>
+FBGEMM_API void sparseDenseMMRef(
+    int M,
+    int N,
+    const int* row_ptr,
+    const int* col_idx,
+    const TA* values,
+    const TB* B,
+    int ldb,
+    TC* C,
+    int ldc,
+    bool accum = false);
+
 } // namespace fbgemm


### PR DESCRIPTION
Summary:
Test the approach to improve 1024^3 matmul performance. On cooper lake, it can achieve 370GFlops/s, much better than 270Gflops/s before, close to 390 GFlops/s for MKL-DNN.
Probably need to add some prefetching to get 390 GFlops/s.

However, it significantly slows down the performance of other matrix shapes.
Need to figure out an approach for all matrix shapes.
This diff is for insight only now.

Probably we need to perform tuning inside getOrCreate function instead of inside
genComputeBlock function.

After removing time breakdown measurement, the performance difference for relatively small shapes becomes much smaller, roughly within 10%. For relatively larger shapes, performance keeps much higher.

Reviewed By: jianyuh

Differential Revision: D20472356

