### PR TITLE
add offset-based interface for PyTorch

### DIFF
--- a/src/EmbeddingSpMDMAvx2.cc
+++ b/src/EmbeddingSpMDMAvx2.cc
@@ -22,15 +22,18 @@ bool EmbeddingSpMDMBlockSize1_(
     const std::int64_t data_size, // the number of rows in input
     const inType* input,
     const IndexType* indices,
-    const int* lengths,
+    const int* offsets_or_lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
     float* out,
-    bool is_weight_positional) {
+    bool is_weight_positional,
+    bool use_offsets) {
   int64_t current = 0;
   for (int m = 0; m < output_size; ++m) {
     out[m] = 0;
-    if (current + lengths[m] > index_size) {
+    int len = use_offsets ? offsets_or_lengths[m + 1] - offsets_or_lengths[m]
+                          : offsets_or_lengths[m];
+    if (current + len > index_size) {
       return false;
     }
     int i = 0;
@@ -97,7 +100,7 @@ bool EmbeddingSpMDMBlockSize1_(
     }
 #endif
 
-    for (; i < lengths[m]; ++i) {
+    for (; i < len; ++i) {
       int64_t idx = indices[current];
       if (idx < 0 || idx >= data_size) {
         return false;
@@ -117,8 +120,8 @@ bool EmbeddingSpMDMBlockSize1_(
 
       ++current;
     }
-    if (normalize_by_lengths && lengths[m]) {
-      float scale = 1.f / lengths[m];
+    if (normalize_by_lengths && len) {
+      float scale = 1.f / len;
       out[m] *= scale;
     }
   }
@@ -131,11 +134,12 @@ template bool EmbeddingSpMDMBlockSize1_(
     const std::int64_t data_size, // the number of rows in input
     const float* input,
     const std::int64_t* indices,
-    const int* lengths,
+    const int* offsets_or_lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
     float* out,
-    bool is_weight_positional);
+    bool is_weight_positional,
+    bool use_offsets);
 
 template bool EmbeddingSpMDMBlockSize1_(
     const std::int64_t output_size,
@@ -143,11 +147,12 @@ template bool EmbeddingSpMDMBlockSize1_(
     const std::int64_t data_size, // the number of rows in input
     const float* input,
     const std::int32_t* indices,
-    const int* lengths,
+    const int* offsets_or_lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
     float* out,
-    bool is_weight_positional);
+    bool is_weight_positional,
+    bool use_offsets);
 
 template bool EmbeddingSpMDMBlockSize1_(
     const std::int64_t output_size,
@@ -155,11 +160,12 @@ template bool EmbeddingSpMDMBlockSize1_(
     const std::int64_t data_size, // the number of rows in input
     const float16* input,
     const std::int64_t* indices,
-    const int* lengths,
+    const int* offsets_or_lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
     float* out,
-    bool is_weight_positional);
+    bool is_weight_positional,
+    bool use_offsets);
 
 template bool EmbeddingSpMDMBlockSize1_(
     const std::int64_t output_size,
@@ -167,11 +173,12 @@ template bool EmbeddingSpMDMBlockSize1_(
     const std::int64_t data_size, // the number of rows in input
     const float16* input,
     const std::int32_t* indices,
-    const int* lengths,
+    const int* offsets_or_lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
     float* out,
-    bool is_weight_positional);
+    bool is_weight_positional,
+    bool use_offsets);
 
 template bool EmbeddingSpMDMBlockSize1_(
     const std::int64_t output_size,
@@ -179,11 +186,12 @@ template bool EmbeddingSpMDMBlockSize1_(
     const std::int64_t data_size, // the number of rows in input
     const std::uint8_t* input,
     const std::int64_t* indices,
-    const int* lengths,
+    const int* offsets_or_lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
     float* out,
-    bool is_weight_positional);
+    bool is_weight_positional,
+    bool use_offsets);
 
 template bool EmbeddingSpMDMBlockSize1_(
     const std::int64_t output_size,
@@ -191,11 +199,12 @@ template bool EmbeddingSpMDMBlockSize1_(
     const std::int64_t data_size, // the number of rows in input
     const std::uint8_t* input,
     const std::int32_t* indices,
-    const int* lengths,
+    const int* offsets_or_lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
     float* out,
-    bool is_weight_positional);
+    bool is_weight_positional,
+    bool use_offsets);
 
 } // namespace internal
 } // namespace fbgemm

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -222,11 +222,12 @@ FBGEMM_API bool EmbeddingSpMDM_ref(
     const std::int64_t data_size,
     const inType* input,
     const IndexType* indices,
-    const int* lengths,
+    const int* offsets_or_lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
     float* out,
-    bool is_weight_positional = false);
+    bool is_weight_positional = false,
+    bool use_offsets = false);
 
 template <typename IndexType = std::int64_t>
 FBGEMM_API bool EmbeddingSpMDMNBit_ref(
@@ -237,11 +238,12 @@ FBGEMM_API bool EmbeddingSpMDMNBit_ref(
     const std::int64_t data_size,
     const std::uint8_t* input,
     const IndexType* indices,
-    const int* lengths,
+    const int* offsets_or_lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
     float* out,
-    bool is_weight_positional = false);
+    bool is_weight_positional = false,
+    bool use_offsets = false);
 
 template <typename inType = std::uint8_t, typename IndexType = std::int64_t>
 FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(
@@ -253,11 +255,12 @@ FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(
     const inType* input,
     const IndexType* indices,
     const std::int32_t* compressed_indices_table,
-    const int* lengths,
+    const int* offsets_or_lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
     float* out,
-    bool is_weight_positional = false);
+    bool is_weight_positional = false,
+    bool use_offsets = false);
 
 template <typename IndexType = std::int64_t>
 FBGEMM_API bool EmbeddingSpMDMNBitRowWiseSparse_ref(
@@ -270,11 +273,12 @@ FBGEMM_API bool EmbeddingSpMDMNBitRowWiseSparse_ref(
     const std::uint8_t* input,
     const IndexType* indices,
     const std::int32_t* compressed_indices_table,
-    const int* lengths,
+    const int* offsets_or_lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
     float* out,
-    bool is_weight_positional = false);
+    bool is_weight_positional = false,
+    bool use_offsets = false);
 
 template <typename IndexType>
 FBGEMM_API int sparse_adagrad_ref(
@@ -310,8 +314,9 @@ FBGEMM_API int rowwise_sparse_adagrad_fused_ref(
     const float* g, // inupt gradients
     float* h, // input/output momentums
     const IndexType* indices,
-    const int* lengths,
+    const int* offsets_or_lengths,
     float epsilon,
-    float lr);
+    float lr,
+    bool use_offsets = false);
 
 } // namespace fbgemm

--- a/test/EmbeddingSpMDMTestUtils.cc
+++ b/test/EmbeddingSpMDMTestUtils.cc
@@ -15,6 +15,7 @@ using namespace std;
 
 int GenerateLengthsIndicesWeights(
     vector<int>& lengths,
+    vector<int>& offsets,
     vector<int64_t>& indices,
     vector<int32_t>& indices_32,
     vector<float>& weights,
@@ -58,6 +59,13 @@ int GenerateLengthsIndicesWeights(
     } else {
       --lengths[batch_size - 1];
     }
+  }
+
+  // Generate offsets
+  offsets.resize(lengths.size() + 1);
+  offsets[0] = 0;
+  for (int i = 0; i < lengths.size(); ++i) {
+    offsets[i + 1] = offsets[i] + lengths[i];
   }
 
   // Generate weights

--- a/test/EmbeddingSpMDMTestUtils.h
+++ b/test/EmbeddingSpMDMTestUtils.h
@@ -23,6 +23,7 @@ enum EmbeddingSpMDMCornerCase {
  */
 int GenerateLengthsIndicesWeights(
     std::vector<int>& lengths,
+    std::vector<int>& offsets,
     std::vector<std::int64_t>& indices,
     std::vector<std::int32_t>& indices_32,
     std::vector<float>& weights,


### PR DESCRIPTION
Summary:
Add a variation of embedding operators using offsets rather than lengths. This is for PyTorch EmbeddingBag. Assume the length of offsets is output_size + 1 where offsets[output_size] == indices_size, confirming the standard compressed sparse row (CSR) convention.

This diff maintains a backward compatibility (use_offsets = false).
We'll have a separate follow-up Caffe2 diff that explicitly passes use_offsets = false, then another diff will change the default of use_offsets to true (making PyTorch as a default). The last diff will break backward compatibility but should be fine because we have only a few call-sites in Caffe2 that we can modify accordingly.

Differential Revision: D20746569

