### PR TITLE
disable asan for QuantizeAvx2

### DIFF
--- a/src/QuantUtilsAvx2.cc
+++ b/src/QuantUtilsAvx2.cc
@@ -19,8 +19,11 @@ using namespace std;
 ////////////////////////////////////////////////////////////////////////////////
 // Utility functions
 
+// ASAN seems to have a false-positive for _mm_maskmoveu_si128
 template <typename T>
-void QuantizeAvx2(
+void
+NO_SANITIZE("address")
+QuantizeAvx2(
     const float* src,
     T* dst,
     int len,


### PR DESCRIPTION
Summary: ASAN seems to have a false-positive for _mm_maskmoveu_si128

Differential Revision: D20761218

