### PR TITLE
use read-write lock in CodeCache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ add_library(fbgemm_avx2 OBJECT ${FBGEMM_AVX2_SRCS})
 add_library(fbgemm_avx512 OBJECT ${FBGEMM_AVX512_SRCS})
 
 set_target_properties(fbgemm_generic fbgemm_avx2 fbgemm_avx512 PROPERTIES
-      CXX_STANDARD 11
+      CXX_STANDARD 14
       CXX_STANDARD_REQUIRED YES
       CXX_EXTENSIONS NO
       CXX_VISIBILITY_PRESET hidden)

--- a/src/CodeCache.h
+++ b/src/CodeCache.h
@@ -8,7 +8,18 @@
 #include <condition_variable>
 #include <future>
 #include <map>
+
+#if __cplusplus >= 201402L && !defined(__APPLE__)
+// For C++14, use shared_timed_mutex.
+// some macOS C++14 compilers don't support shared_timed_mutex.
+#define FBGEMM_USE_SHARED_TIMED_MUTEX
+#endif
+
+#ifdef FBGEMM_USE_SHARED_TIMED_MUTEX
+#include <shared_mutex>
+#else
 #include <mutex>
+#endif
 
 namespace fbgemm {
 
@@ -21,7 +32,11 @@ template <typename KEY, typename VALUE>
 class CodeCache {
  private:
   std::map<KEY, std::shared_future<VALUE>> values_;
+#ifdef FBGEMM_USE_SHARED_TIMED_MUTEX
+  std::shared_timed_mutex mutex_;
+#else
   std::mutex mutex_;
+#endif
 
  public:
   CodeCache(const CodeCache&) = delete;
@@ -36,14 +51,36 @@ class CodeCache {
 
     // Check for existance of the key
     {
+#ifdef FBGEMM_USE_SHARED_TIMED_MUTEX
+      mutex_.lock_shared();
+#else
       std::unique_lock<std::mutex> lock(mutex_);
+#endif
 
       auto it = values_.find(key);
       if (it != values_.end()) {
         returnFuture = it->second;
+#ifdef FBGEMM_USE_SHARED_TIMED_MUTEX
+        mutex_.unlock_shared();
+#endif
       } else {
-        values_[key] = returnFuture = returnPromise.get_future().share();
-        needsToGenerate = true;
+#ifdef FBGEMM_USE_SHARED_TIMED_MUTEX
+        mutex_.unlock_shared();
+
+        mutex_.lock();
+        // Need to look up again because there could be race condition from
+        // the time gap between mutex_.unlock_shared() and mutex_.lock()
+        it = values_.find(key);
+        if (it == values_.end()) {
+#endif
+          values_[key] = returnFuture = returnPromise.get_future().share();
+          needsToGenerate = true;
+#ifdef FBGEMM_USE_SHARED_TIMED_MUTEX
+        } else {
+          returnFuture = it->second;
+        }
+        mutex_.unlock();
+#endif
       }
     }
 


### PR DESCRIPTION
Summary: Use read-write lock to reduce the contention. Need to use c++14

Differential Revision: D20860370

