### PR TITLE
add option to use int64_t offsets/lengths in embedding operators

### DIFF
--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -12,22 +12,26 @@
 
 namespace fbgemm {
 
-template <typename inType, typename IndexType>
+template <
+    typename InType,
+    typename IndexType,
+    typename OffsetType = std::int32_t>
 class EmbeddingSpMDMKernelSignature {
  public:
   using Type = std::function<bool(
       std::int64_t output_size,
       std::int64_t index_size,
       std::int64_t data_size,
-      const inType* input,
+      const InType* input,
       const IndexType* indices,
-      const int* offsets_or_lengths,
+      const OffsetType* offsets_or_lengths,
       const float* weights, // optional, can be null for non-weighted sum
       float* out)>;
 };
 
 /**
- * @tparam inType can be float or uint8_t
+ * @tparam InType can be float, float16, or uint8_t
+ * @tparam IndexType can be int32_t or int64_t
  * @tparam IndexType can be int32_t or int64_t
  *
  * @param use_offsets If true, the generated code assumes we will pass offsets
@@ -38,55 +42,13 @@ class EmbeddingSpMDMKernelSignature {
  *                    If false, the generate code assumes we will pass lengths
  *                    that confirms Caffe2 SparseLengthsSum interface.
  */
-template <typename inType, typename IndexType>
-FBGEMM_API typename EmbeddingSpMDMKernelSignature<inType, IndexType>::Type
-GenerateEmbeddingSpMDM(
-    const std::int64_t block_size,
-    bool has_weight,
-    bool normalize_by_lengths,
-    int prefetch = 16,
-    bool is_weight_positional = false,
-    bool use_offsets = true);
-
-/**
- * @tparam IndexType can be int32_t or int64_t
- * @param bit_rate can be 2 or 4
- */
-template <typename IndexType>
-FBGEMM_API typename EmbeddingSpMDMKernelSignature<std::uint8_t, IndexType>::Type
-GenerateEmbeddingSpMDMNBit(
-    int bit_rate,
-    const std::int64_t block_size,
-    bool has_weight,
-    bool normalize_by_lengths,
-    int prefetch = 16,
-    bool is_weight_positional = false,
-    bool use_offsets = true);
-
-template <typename inType, typename IndexType>
-class EmbeddingSpMDMRowWiseSparseKernelSignature {
- public:
-  using Type = std::function<bool(
-      std::int64_t output_size,
-      std::int64_t index_size,
-      std::int64_t uncompressed_data_size,
-      // TODO: add compressed_data_size and check array bound
-      const inType* input,
-      const IndexType* indices,
-      const int* offsets_or_lengths,
-      const float* weights, // optional, can be null for non-weighted sum
-      float* out,
-      const std::int32_t* compressed_indices_table)>;
-};
-
-/**
- * @tparam inType can be float or uint8_t
- * @tparam IndexType can be int32_t or int64_t
- */
-template <typename inType, typename IndexType>
+template <
+    typename InType,
+    typename IndexType,
+    typename OffsetType = std::int32_t>
 FBGEMM_API
-    typename EmbeddingSpMDMRowWiseSparseKernelSignature<inType, IndexType>::Type
-    GenerateEmbeddingSpMDMRowWiseSparse(
+    typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType>::Type
+    GenerateEmbeddingSpMDM(
         const std::int64_t block_size,
         bool has_weight,
         bool normalize_by_lengths,
@@ -96,12 +58,73 @@ FBGEMM_API
 
 /**
  * @tparam IndexType can be int32_t or int64_t
+ * @tparam OffsetType can be int32_t or int64_t
  * @param bit_rate can be 2 or 4
  */
-template <typename IndexType>
+template <typename IndexType, typename OffsetType = std::int32_t>
+FBGEMM_API typename EmbeddingSpMDMKernelSignature<
+    std::uint8_t,
+    IndexType,
+    OffsetType>::Type
+GenerateEmbeddingSpMDMNBit(
+    int bit_rate,
+    const std::int64_t block_size,
+    bool has_weight,
+    bool normalize_by_lengths,
+    int prefetch = 16,
+    bool is_weight_positional = false,
+    bool use_offsets = true);
+
+template <
+    typename InType,
+    typename IndexType,
+    typename OffsetType = std::int32_t>
+class EmbeddingSpMDMRowWiseSparseKernelSignature {
+ public:
+  using Type = std::function<bool(
+      std::int64_t output_size,
+      std::int64_t index_size,
+      std::int64_t uncompressed_data_size,
+      // TODO: add compressed_data_size and check array bound
+      const InType* input,
+      const IndexType* indices,
+      const OffsetType* offsets_or_lengths,
+      const float* weights, // optional, can be null for non-weighted sum
+      float* out,
+      const std::int32_t* compressed_indices_table)>;
+};
+
+/**
+ * @tparam InType can be float, float16, or uint8_t
+ * @tparam IndexType can be int32_t or int64_t
+ * @tparam OffsetType can be int32_t or int64_t
+ */
+template <
+    typename InType,
+    typename IndexType,
+    typename OffsetType = std::int32_t>
+FBGEMM_API typename EmbeddingSpMDMRowWiseSparseKernelSignature<
+    InType,
+    IndexType,
+    OffsetType>::Type
+GenerateEmbeddingSpMDMRowWiseSparse(
+    const std::int64_t block_size,
+    bool has_weight,
+    bool normalize_by_lengths,
+    int prefetch = 16,
+    bool is_weight_positional = false,
+    bool use_offsets = true);
+
+/**
+ * @tparam IndexType can be int32_t or int64_t
+ * @tparam OffsetType can be int32_t or int64_t
+ * @param bit_rate can be 2 or 4
+ */
+template <typename IndexType, typename OffsetType = std::int32_t>
 FBGEMM_API typename EmbeddingSpMDMRowWiseSparseKernelSignature<
     std::uint8_t,
-    IndexType>::Type
+    IndexType,
+    OffsetType>::Type
 GenerateEmbeddingSpMDMNBitRowWiseSparse(
     int bit_rate,
     const std::int64_t block_size,
@@ -151,7 +174,7 @@ FBGEMM_API int SparseAdaGrad(
     int prefetch = 16);
 
 // RowWiseSparseAdaGrad fused with SLS gradient
-template <typename IndexType>
+template <typename IndexType, typename OffsetType = std::int32_t>
 class RowWiseSparseAdaGradFusedSignature {
  public:
   using Type = std::function<bool(
@@ -162,28 +185,29 @@ class RowWiseSparseAdaGradFusedSignature {
       const float* g, // input gradients
       float* h, // input/output momentums
       const IndexType* indices, // indices of each row
-      const int* offsets_or_lengths,
+      const OffsetType* offsets_or_lengths,
       float epsilon,
       float lr)>;
 };
 
-template <typename IndexType>
-FBGEMM_API typename RowWiseSparseAdaGradFusedSignature<IndexType>::Type
-GenerateRowWiseSparseAdaGradFused(
-    int block_size, // number of parameters per row
-    int prefetch = 16,
-    bool use_offsets = true);
+template <typename IndexType, typename OffsetType = std::int32_t>
+FBGEMM_API
+    typename RowWiseSparseAdaGradFusedSignature<IndexType, OffsetType>::Type
+    GenerateRowWiseSparseAdaGradFused(
+        int block_size, // number of parameters per row
+        int prefetch = 16,
+        bool use_offsets = true);
 
 namespace internal {
 // Specialization for block size 1 internally called by GenerateEmbeddingSpMDM
-template <typename inType = float, typename IndexType = std::int64_t>
+template <typename InType, typename IndexType, typename OffsetType>
 FBGEMM_API bool EmbeddingSpMDMBlockSize1_(
     const std::int64_t output_size,
     const std::int64_t index_size,
     const std::int64_t data_size, // the number of rows in input
-    const inType* input,
+    const InType* input,
     const IndexType* indices,
-    const int* offsets_or_lengths,
+    const OffsetType* offsets_or_lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
     float* out,

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -108,8 +108,7 @@ FBGEMM_API void cblas_sgemm_ref(
     int ldb,
     float beta,
     float* Cfp32,
-    int ldc
-    );
+    int ldc);
 
 FBGEMM_API void cblas_gemm_i64_i64acc_ref(
     matrix_op_t transa,
@@ -214,22 +213,25 @@ FBGEMM_API void im2col_ref(
     std::int32_t A_zero_point,
     std::uint8_t* Ao);
 
-template <typename inType = std::uint8_t, typename IndexType = std::int64_t>
+template <
+    typename InType = std::uint8_t,
+    typename IndexType = std::int64_t,
+    typename OffsetType = std::int32_t>
 FBGEMM_API bool EmbeddingSpMDM_ref(
     const std::int64_t block_size,
     const std::int64_t output_size,
     const std::int64_t index_size,
     const std::int64_t data_size,
-    const inType* input,
+    const InType* input,
     const IndexType* indices,
-    const int* offsets_or_lengths,
+    const OffsetType* offsets_or_lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
     float* out,
     bool is_weight_positional = false,
     bool use_offsets = true);
 
-template <typename IndexType = std::int64_t>
+template <typename IndexType = std::int64_t, typename OffsetType = std::int32_t>
 FBGEMM_API bool EmbeddingSpMDMNBit_ref(
     int bit_rate,
     const std::int64_t block_size,
@@ -238,31 +240,34 @@ FBGEMM_API bool EmbeddingSpMDMNBit_ref(
     const std::int64_t data_size,
     const std::uint8_t* input,
     const IndexType* indices,
-    const int* offsets_or_lengths,
+    const OffsetType* offsets_or_lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
     float* out,
     bool is_weight_positional = false,
     bool use_offsets = true);
 
-template <typename inType = std::uint8_t, typename IndexType = std::int64_t>
+template <
+    typename InType = std::uint8_t,
+    typename IndexType = std::int64_t,
+    typename OffsetType = std::int32_t>
 FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(
     const std::int64_t block_size,
     const std::int64_t output_size,
     const std::int64_t index_size,
     const std::int64_t uncompressed_data_size,
     // const std::int64_t compressed_data_size,
-    const inType* input,
+    const InType* input,
     const IndexType* indices,
     const std::int32_t* compressed_indices_table,
-    const int* offsets_or_lengths,
+    const OffsetType* offsets_or_lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
     float* out,
     bool is_weight_positional = false,
     bool use_offsets = true);
 
-template <typename IndexType = std::int64_t>
+template <typename IndexType = std::int64_t, typename OffsetType = std::int32_t>
 FBGEMM_API bool EmbeddingSpMDMNBitRowWiseSparse_ref(
     int bit_rate,
     const std::int64_t block_size,
@@ -273,7 +278,7 @@ FBGEMM_API bool EmbeddingSpMDMNBitRowWiseSparse_ref(
     const std::uint8_t* input,
     const IndexType* indices,
     const std::int32_t* compressed_indices_table,
-    const int* offsets_or_lengths,
+    const OffsetType* offsets_or_lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
     float* out,
@@ -304,7 +309,7 @@ FBGEMM_API int rowwise_sparse_adagrad_ref(
     float epsilon,
     float lr);
 
-template <typename IndexType>
+template <typename IndexType, typename OffsetType>
 FBGEMM_API int rowwise_sparse_adagrad_fused_ref(
     std::int64_t block_size,
     std::int64_t output_size,
@@ -314,7 +319,7 @@ FBGEMM_API int rowwise_sparse_adagrad_fused_ref(
     const float* g, // inupt gradients
     float* h, // input/output momentums
     const IndexType* indices,
-    const int* offsets_or_lengths,
+    const OffsetType* offsets_or_lengths,
     float epsilon,
     float lr,
     bool use_offsets = true);

--- a/test/EmbeddingSpMDMNBitTest.cc
+++ b/test/EmbeddingSpMDMNBitTest.cc
@@ -56,6 +56,7 @@ class FusedNBitRowwiseEmbeddingLookupTest : public testing::TestWithParam<tuple<
                                                 int,
                                                 bool,
                                                 bool,
+                                                bool,
                                                 int,
                                                 bool,
                                                 bool,
@@ -69,6 +70,7 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(
         ::testing::Values(2, 4), // bit_rate
         ::testing::Bool(), // isIndex64b
+        ::testing::Bool(), // isOffset64b
         ::testing::Bool(), // is_wt_positional
         ::testing::ValuesIn(prefetch_distances),
         ::testing::Bool(), // use_weight
@@ -82,12 +84,13 @@ INSTANTIATE_TEST_CASE_P(
 
 TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
   vector<vector<int>> inputs(GetInputs_());
-  bool isIndex64b, is_wt_positional, use_weight, normalize_by_lengths,
-      use_offsets;
+  bool isIndex64b, isOffset64b, is_wt_positional, use_weight,
+      normalize_by_lengths, use_offsets;
   int bit_rate, prefetch;
   EmbeddingSpMDMCornerCase corner_case;
   tie(bit_rate,
       isIndex64b,
+      isOffset64b,
       is_wt_positional,
       prefetch,
       use_weight,
@@ -128,13 +131,14 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
       FloatToFloat16_ref(&bias, scale_bias + 1, 1, true /* clip */);
     }
 
-    vector<int> lengths, offsets;
-    vector<int64_t> indices;
-    vector<int32_t> indices_32;
+    vector<int64_t> lengths, offsets, indices;
+    vector<int32_t> lengths_32, offsets_32, indices_32;
     vector<float> weights;
     int lengths_sum = GenerateLengthsIndicesWeights(
         lengths,
+        lengths_32,
         offsets,
+        offsets_32,
         indices,
         indices_32,
         weights,
@@ -143,7 +147,10 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
         embedding_dim,
         average_len,
         corner_case);
-    const int* offsets_or_lengths = (use_offsets ? offsets : lengths).data();
+    const int64_t* offsets_or_lengths =
+        (use_offsets ? offsets : lengths).data();
+    const int32_t* offsets_or_lengths_32 =
+        (use_offsets ? offsets_32 : lengths_32).data();
 
     vector<float> output_sls_ref(batch_size * embedding_dim);
     vector<float> output_slws_ref(output_sls_ref.size()),
@@ -153,72 +160,142 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
     vector<float>& output = use_weight ? output_slws : output_sls;
     bool success, success_ref;
 
-    if (isIndex64b) {
-      success_ref = EmbeddingSpMDMNBit_ref<int64_t>(
-          bit_rate,
-          embedding_dim,
-          batch_size,
-          lengths_sum,
-          num_rows,
-          fused_embedding_table.data(),
-          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
-          offsets_or_lengths,
-          use_weight ? weights.data() : nullptr,
-          normalize_by_lengths,
-          output_ref.data(),
-          is_wt_positional,
-          use_offsets);
+    if (isOffset64b) {
+      if (isIndex64b) {
+        success_ref = EmbeddingSpMDMNBit_ref<int64_t>(
+            bit_rate,
+            embedding_dim,
+            batch_size,
+            lengths_sum,
+            num_rows,
+            fused_embedding_table.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+            offsets_or_lengths,
+            use_weight ? weights.data() : nullptr,
+            normalize_by_lengths,
+            output_ref.data(),
+            is_wt_positional,
+            use_offsets);
 
-      auto kernel = GenerateEmbeddingSpMDMNBit<int64_t>(
-          bit_rate,
-          embedding_dim,
-          use_weight,
-          normalize_by_lengths,
-          prefetch,
-          is_wt_positional,
-          use_offsets);
-      success = kernel(
-          batch_size,
-          lengths_sum,
-          num_rows,
-          fused_embedding_table.data(),
-          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
-          offsets_or_lengths,
-          use_weight ? weights.data() : nullptr,
-          output.data());
+        auto kernel = GenerateEmbeddingSpMDMNBit<int64_t, int64_t>(
+            bit_rate,
+            embedding_dim,
+            use_weight,
+            normalize_by_lengths,
+            prefetch,
+            is_wt_positional,
+            use_offsets);
+        success = kernel(
+            batch_size,
+            lengths_sum,
+            num_rows,
+            fused_embedding_table.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+            offsets_or_lengths,
+            use_weight ? weights.data() : nullptr,
+            output.data());
+      } else {
+        success_ref = EmbeddingSpMDMNBit_ref<int32_t>(
+            bit_rate,
+            embedding_dim,
+            batch_size,
+            lengths_sum,
+            num_rows,
+            fused_embedding_table.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
+            offsets_or_lengths,
+            use_weight ? weights.data() : nullptr,
+            normalize_by_lengths,
+            output_ref.data(),
+            is_wt_positional,
+            use_offsets);
+
+        auto kernel = GenerateEmbeddingSpMDMNBit<int32_t, int64_t>(
+            bit_rate,
+            embedding_dim,
+            use_weight,
+            normalize_by_lengths,
+            prefetch,
+            is_wt_positional,
+            use_offsets);
+        success = kernel(
+            batch_size,
+            lengths_sum,
+            num_rows,
+            fused_embedding_table.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
+            offsets_or_lengths,
+            use_weight ? weights.data() : nullptr,
+            output.data());
+      }
     } else {
-      success_ref = EmbeddingSpMDMNBit_ref<int32_t>(
-          bit_rate,
-          embedding_dim,
-          batch_size,
-          lengths_sum,
-          num_rows,
-          fused_embedding_table.data(),
-          corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
-          offsets_or_lengths,
-          use_weight ? weights.data() : nullptr,
-          normalize_by_lengths,
-          output_ref.data(),
-          is_wt_positional,
-          use_offsets);
+      if (isIndex64b) {
+        success_ref = EmbeddingSpMDMNBit_ref<int64_t>(
+            bit_rate,
+            embedding_dim,
+            batch_size,
+            lengths_sum,
+            num_rows,
+            fused_embedding_table.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+            offsets_or_lengths,
+            use_weight ? weights.data() : nullptr,
+            normalize_by_lengths,
+            output_ref.data(),
+            is_wt_positional,
+            use_offsets);
 
-      auto kernel = GenerateEmbeddingSpMDMNBit<int32_t>(
-          bit_rate,
-          embedding_dim,
-          use_weight,
-          normalize_by_lengths,
-          prefetch,
-          is_wt_positional,
-          use_offsets);
-      success = kernel(
-          batch_size,
-          lengths_sum,
-          num_rows,
-          fused_embedding_table.data(),
-          corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
-          offsets_or_lengths,
-          use_weight ? weights.data() : nullptr,
-          output.data());
+        auto kernel = GenerateEmbeddingSpMDMNBit<int64_t>(
+            bit_rate,
+            embedding_dim,
+            use_weight,
+            normalize_by_lengths,
+            prefetch,
+            is_wt_positional,
+            use_offsets);
+        success = kernel(
+            batch_size,
+            lengths_sum,
+            num_rows,
+            fused_embedding_table.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+            offsets_or_lengths_32,
+            use_weight ? weights.data() : nullptr,
+            output.data());
+      } else {
+        success_ref = EmbeddingSpMDMNBit_ref<int32_t>(
+            bit_rate,
+            embedding_dim,
+            batch_size,
+            lengths_sum,
+            num_rows,
+            fused_embedding_table.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
+            offsets_or_lengths,
+            use_weight ? weights.data() : nullptr,
+            normalize_by_lengths,
+            output_ref.data(),
+            is_wt_positional,
+            use_offsets);
+
+        auto kernel = GenerateEmbeddingSpMDMNBit<int32_t>(
+            bit_rate,
+            embedding_dim,
+            use_weight,
+            normalize_by_lengths,
+            prefetch,
+            is_wt_positional,
+            use_offsets);
+        success = kernel(
+            batch_size,
+            lengths_sum,
+            num_rows,
+            fused_embedding_table.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
+            offsets_or_lengths_32,
+            use_weight ? weights.data() : nullptr,
+            output.data());
+      }
     }
 
     // Check correctness
@@ -240,12 +317,13 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
 
 TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
   vector<vector<int>> inputs(GetInputs_());
-  bool isIndex64b, is_wt_positional, use_weight, normalize_by_lengths,
-      use_offsets;
+  bool isIndex64b, isOffset64b, is_wt_positional, use_weight,
+      normalize_by_lengths, use_offsets;
   int bit_rate, prefetch;
   EmbeddingSpMDMCornerCase corner_case;
   tie(bit_rate,
       isIndex64b,
+      isOffset64b,
       is_wt_positional,
       prefetch,
       use_weight,
@@ -293,13 +371,14 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
       FloatToFloat16_ref(&bias, scale_bias + 1, 1, true /* clip */);
     }
 
-    vector<int> lengths, offsets;
-    vector<int64_t> indices;
-    vector<int32_t> indices_32;
+    vector<int64_t> lengths, offsets, indices;
+    vector<int32_t> lengths_32, offsets_32, indices_32;
     vector<float> weights;
     int lengths_sum = GenerateLengthsIndicesWeights(
         lengths,
+        lengths_32,
         offsets,
+        offsets_32,
         indices,
         indices_32,
         weights,
@@ -308,7 +387,10 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
         embedding_dim,
         average_len,
         corner_case);
-    const int* offsets_or_lengths = (use_offsets ? offsets : lengths).data();
+    const int64_t* offsets_or_lengths =
+        (use_offsets ? offsets : lengths).data();
+    const int32_t* offsets_or_lengths_32 =
+        (use_offsets ? offsets_32 : lengths_32).data();
 
     vector<float> output_sls_ref(batch_size * embedding_dim);
     vector<float> output_slws_ref(output_sls_ref.size()),
@@ -318,76 +400,150 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
     vector<float>& output = use_weight ? output_slws : output_sls;
     bool success, success_ref;
 
-    if (isIndex64b) {
-      success_ref = fbgemm::EmbeddingSpMDMNBitRowWiseSparse_ref<int64_t>(
-          bit_rate,
-          embedding_dim,
-          batch_size,
-          lengths_sum,
-          num_rows,
-          fused_embedding_table.data(),
-          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
-          mapping_table.data(),
-          offsets_or_lengths,
-          use_weight ? weights.data() : nullptr,
-          normalize_by_lengths,
-          output_ref.data(),
-          is_wt_positional,
-          use_offsets);
+    if (isOffset64b) {
+      if (isIndex64b) {
+        success_ref = fbgemm::EmbeddingSpMDMNBitRowWiseSparse_ref<int64_t>(
+            bit_rate,
+            embedding_dim,
+            batch_size,
+            lengths_sum,
+            num_rows,
+            fused_embedding_table.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+            mapping_table.data(),
+            offsets_or_lengths,
+            use_weight ? weights.data() : nullptr,
+            normalize_by_lengths,
+            output_ref.data(),
+            is_wt_positional,
+            use_offsets);
 
-      auto kernel = GenerateEmbeddingSpMDMNBitRowWiseSparse<int64_t>(
-          bit_rate,
-          embedding_dim,
-          use_weight,
-          normalize_by_lengths,
-          prefetch,
-          is_wt_positional,
-          use_offsets);
-      success = kernel(
-          batch_size,
-          lengths_sum,
-          num_rows,
-          fused_embedding_table.data(),
-          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
-          offsets_or_lengths,
-          use_weight ? weights.data() : nullptr,
-          output.data(),
-          mapping_table.data());
+        auto kernel = GenerateEmbeddingSpMDMNBitRowWiseSparse<int64_t, int64_t>(
+            bit_rate,
+            embedding_dim,
+            use_weight,
+            normalize_by_lengths,
+            prefetch,
+            is_wt_positional,
+            use_offsets);
+        success = kernel(
+            batch_size,
+            lengths_sum,
+            num_rows,
+            fused_embedding_table.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+            offsets_or_lengths,
+            use_weight ? weights.data() : nullptr,
+            output.data(),
+            mapping_table.data());
+      } else {
+        success_ref = EmbeddingSpMDMNBitRowWiseSparse_ref<int32_t>(
+            bit_rate,
+            embedding_dim,
+            batch_size,
+            lengths_sum,
+            num_rows,
+            fused_embedding_table.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
+            mapping_table.data(),
+            offsets_or_lengths,
+            use_weight ? weights.data() : nullptr,
+            normalize_by_lengths,
+            output_ref.data(),
+            is_wt_positional,
+            use_offsets);
+
+        auto kernel = GenerateEmbeddingSpMDMNBitRowWiseSparse<int32_t, int64_t>(
+            bit_rate,
+            embedding_dim,
+            use_weight,
+            normalize_by_lengths,
+            prefetch,
+            is_wt_positional,
+            use_offsets);
+        success = kernel(
+            batch_size,
+            lengths_sum,
+            num_rows,
+            fused_embedding_table.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
+            offsets_or_lengths,
+            use_weight ? weights.data() : nullptr,
+            output.data(),
+            mapping_table.data());
+      }
     } else {
-      success_ref = EmbeddingSpMDMNBitRowWiseSparse_ref<int32_t>(
-          bit_rate,
-          embedding_dim,
-          batch_size,
-          lengths_sum,
-          num_rows,
-          fused_embedding_table.data(),
-          corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
-          mapping_table.data(),
-          offsets_or_lengths,
-          use_weight ? weights.data() : nullptr,
-          normalize_by_lengths,
-          output_ref.data(),
-          is_wt_positional,
-          use_offsets);
+      if (isIndex64b) {
+        success_ref = fbgemm::EmbeddingSpMDMNBitRowWiseSparse_ref<int64_t>(
+            bit_rate,
+            embedding_dim,
+            batch_size,
+            lengths_sum,
+            num_rows,
+            fused_embedding_table.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+            mapping_table.data(),
+            offsets_or_lengths,
+            use_weight ? weights.data() : nullptr,
+            normalize_by_lengths,
+            output_ref.data(),
+            is_wt_positional,
+            use_offsets);
 
-      auto kernel = GenerateEmbeddingSpMDMNBitRowWiseSparse<int32_t>(
-          bit_rate,
-          embedding_dim,
-          use_weight,
-          normalize_by_lengths,
-          prefetch,
-          is_wt_positional,
-          use_offsets);
-      success = kernel(
-          batch_size,
-          lengths_sum,
-          num_rows,
-          fused_embedding_table.data(),
-          corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
-          offsets_or_lengths,
-          use_weight ? weights.data() : nullptr,
-          output.data(),
-          mapping_table.data());
+        auto kernel = GenerateEmbeddingSpMDMNBitRowWiseSparse<int64_t>(
+            bit_rate,
+            embedding_dim,
+            use_weight,
+            normalize_by_lengths,
+            prefetch,
+            is_wt_positional,
+            use_offsets);
+        success = kernel(
+            batch_size,
+            lengths_sum,
+            num_rows,
+            fused_embedding_table.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+            offsets_or_lengths_32,
+            use_weight ? weights.data() : nullptr,
+            output.data(),
+            mapping_table.data());
+      } else {
+        success_ref = EmbeddingSpMDMNBitRowWiseSparse_ref<int32_t>(
+            bit_rate,
+            embedding_dim,
+            batch_size,
+            lengths_sum,
+            num_rows,
+            fused_embedding_table.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
+            mapping_table.data(),
+            offsets_or_lengths,
+            use_weight ? weights.data() : nullptr,
+            normalize_by_lengths,
+            output_ref.data(),
+            is_wt_positional,
+            use_offsets);
+
+        auto kernel = GenerateEmbeddingSpMDMNBitRowWiseSparse<int32_t>(
+            bit_rate,
+            embedding_dim,
+            use_weight,
+            normalize_by_lengths,
+            prefetch,
+            is_wt_positional,
+            use_offsets);
+        success = kernel(
+            batch_size,
+            lengths_sum,
+            num_rows,
+            fused_embedding_table.data(),
+            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
+            offsets_or_lengths_32,
+            use_weight ? weights.data() : nullptr,
+            output.data(),
+            mapping_table.data());
+      }
     }
 
     // Check correctness

--- a/test/EmbeddingSpMDMTestUtils.cc
+++ b/test/EmbeddingSpMDMTestUtils.cc
@@ -14,8 +14,10 @@ namespace fbgemm {
 using namespace std;
 
 int GenerateLengthsIndicesWeights(
-    vector<int>& lengths,
-    vector<int>& offsets,
+    vector<int64_t>& lengths,
+    vector<int32_t>& lengths_32,
+    vector<int64_t>& offsets,
+    vector<int32_t>& offsets_32,
     vector<int64_t>& indices,
     vector<int32_t>& indices_32,
     vector<float>& weights,
@@ -63,9 +65,13 @@ int GenerateLengthsIndicesWeights(
 
   // Generate offsets
   offsets.resize(lengths.size() + 1);
+  lengths_32.resize(lengths.size());
+  offsets_32.resize(offsets.size());
   offsets[0] = 0;
+  offsets_32[0] = 0;
   for (int i = 0; i < lengths.size(); ++i) {
-    offsets[i + 1] = offsets[i] + lengths[i];
+    offsets_32[i + 1] = offsets[i + 1] = offsets[i] + lengths[i];
+    lengths_32[i] = lengths[i];
   }
 
   // Generate weights

--- a/test/EmbeddingSpMDMTestUtils.h
+++ b/test/EmbeddingSpMDMTestUtils.h
@@ -22,8 +22,10 @@ enum EmbeddingSpMDMCornerCase {
  * @return lengths_sum
  */
 int GenerateLengthsIndicesWeights(
-    std::vector<int>& lengths,
-    std::vector<int>& offsets,
+    std::vector<std::int64_t>& lengths,
+    std::vector<std::int32_t>& lengths_32,
+    std::vector<std::int64_t>& offsets,
+    std::vector<std::int32_t>& offsets_32,
     std::vector<std::int64_t>& indices,
     std::vector<std::int32_t>& indices_32,
     std::vector<float>& weights,


### PR DESCRIPTION
Summary:
PyTorch passes int64_t offsets.

Other changes:
Move inst_set_t template parameter from generate function to class template parameter to follow the changes in other code generators in fbgemm

Differential Revision: D20959297

