### PR TITLE
Move `transpose_simd` to TransposeUtils.cc

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,13 +1,19 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
-load("defs.bzl", "get_fbgemm_generic_srcs", "get_fbgemm_avx2_srcs", "get_fbgemm_avx512_srcs", "get_fbgemm_public_headers")
+load("defs.bzl", "get_fbgemm_avx2_srcs", "get_fbgemm_avx512_srcs", "get_fbgemm_base_srcs", "get_fbgemm_generic_srcs", "get_fbgemm_public_headers", "get_fbgemm_tests")
 
 cc_library(
-    name = "fbgemm_src_headers",
-    hdrs = [
-        "src/RefImplementations.h",
+    name = "fbgemm_base",
+    srcs = get_fbgemm_base_srcs()  + glob(["src/*.h"]),
+    includes = [
+        "src",
     ],
-    include_prefix = "fbgemm",
+    deps = [
+        ":fbgemm_headers",
+        "@cpuinfo",
+        "@asmjit",
+    ],
+    linkstatic = 1,
 )
 
 cc_library(
@@ -20,10 +26,7 @@ cc_library(
     deps = [
         ":fbgemm_avx2",
         ":fbgemm_avx512",
-        ":fbgemm_headers",
-        ":fbgemm_src_headers",
-        "@asmjit",
-        "@cpuinfo",
+        ":fbgemm_base",
     ],
     linkstatic = 1,
 )
@@ -39,8 +42,7 @@ cc_library(
         "-masm=intel",
     ],
     deps = [
-        ":fbgemm_headers",
-        "@asmjit",
+        ":fbgemm_base",
     ],
     linkstatic = 1,
 )
@@ -58,7 +60,7 @@ cc_library(
         "-masm=intel",
     ],
     deps = [
-        ":fbgemm_headers",
+        ":fbgemm_base",
     ],
     linkstatic = 1,
 )
@@ -71,6 +73,17 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
 )
+
+# This header is included from pytorch/caffe2/quantization/server/conv_dnnlowp_op.cc
+cc_library(
+    name = "fbgemm_src_headers",
+    hdrs = [
+        "src/RefImplementations.h",
+    ],
+    include_prefix = "fbgemm",
+    visibility = ["//visibility:public"],
+)
+
 
 cc_library(
     name = "test_utils",
@@ -94,15 +107,16 @@ cc_library(
           "@com_google_googletest//:gtest_main",
     ],
 )
+
 [
   cc_test(
       name = paths.split_extension(paths.basename(filename))[0],
-      size = "small",
+      size = "medium",
       srcs = [
           filename,
       ],
       deps = [
           ":test_utils",
       ],
-  ) for filename in ["test/GConvTest.cc", "test/TransposeTest.cc", "test/QuantUtilsTest.cc", "test/I64Test.cc"]
+  ) for filename in get_fbgemm_tests()
 ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ else()
 endif()
 
 # Define file lists
-get_filelist("get_fbgemm_generic_srcs()" FBGEMM_GENERIC_SRCS)
+get_filelist("get_fbgemm_generic_srcs(with_base=True)" FBGEMM_GENERIC_SRCS)
 get_filelist("get_fbgemm_avx2_srcs(msvc=${MSVC_BOOL})" FBGEMM_AVX2_SRCS)
 get_filelist("get_fbgemm_avx512_srcs(msvc=${MSVC_BOOL})" FBGEMM_AVX512_SRCS)
 get_filelist("get_fbgemm_public_headers()" FBGEMM_PUBLIC_HEADERS)

--- a/defs.bzl
+++ b/defs.bzl
@@ -1,4 +1,11 @@
-def get_fbgemm_generic_srcs():
+def get_fbgemm_base_srcs():
+    return [
+        "src/GenerateI8Depthwise.cc",
+        "src/RefImplementations.cc",
+        "src/Utils.cc",
+    ]
+
+def get_fbgemm_generic_srcs(with_base = False):
     return [
         "src/EmbeddingSpMDM.cc",
         "src/EmbeddingSpMDMNBit.cc",
@@ -11,7 +18,6 @@ def get_fbgemm_generic_srcs():
         "src/FbgemmFloat16Convert.cc",
         "src/FbgemmI64.cc",
         "src/FbgemmI8Spmdm.cc",
-        "src/GenerateI8Depthwise.cc",
         "src/GenerateKernelU8S8S32ACC16.cc",
         "src/GenerateKernelU8S8S32ACC16Avx512.cc",  # Acc16 AVX512 JIT code gen
         "src/GenerateKernelU8S8S32ACC16Avx512VNNI.cc",
@@ -28,11 +34,10 @@ def get_fbgemm_generic_srcs():
         "src/PackWeightMatrixForGConv.cc",
         "src/PackWeightsForConv.cc",
         "src/QuantUtils.cc",
-        "src/RefImplementations.cc",
         "src/RowWiseSparseAdagradFused.cc",
         "src/SparseAdagrad.cc",
-        "src/Utils.cc",
-    ]
+        "src/TransposeUtils.cc",
+    ] + (get_fbgemm_base_srcs() if with_base else [])
 
 def get_fbgemm_public_headers():
     return [

--- a/src/FbgemmBfloat16Convert.cc
+++ b/src/FbgemmBfloat16Convert.cc
@@ -42,21 +42,6 @@ using namespace std;
 
 namespace fbgemm {
 
-void FloatToBfloat16_ref(const float* src, bfloat16* dst, int size) {
-  for (int i = 0; i < size; i++) {
-    // Add 2^15 and right shift 16 to do round-nearest
-    dst[i] = (*reinterpret_cast<const uint32_t*>(src + i) + (1 << 15)) >> 16;
-  }
-}
-
-void Bfloat16ToFloat_ref(const bfloat16* src, float* dst, int size) {
-  for (int i = 0; i < size; i++) {
-    uint32_t val_fp32 =
-        static_cast<uint32_t>(reinterpret_cast<const uint16_t*>(src)[i]) << 16;
-    reinterpret_cast<uint32_t*>(dst)[i] = val_fp32;
-  }
-}
-
 void FloatToBfloat16_simd(const float* src, bfloat16* dst, int size) {
   // Run time CPU detection
   if (cpuinfo_initialize()) {

--- a/src/FbgemmFloat16Convert.cc
+++ b/src/FbgemmFloat16Convert.cc
@@ -32,30 +32,6 @@ using namespace std;
 
 namespace fbgemm {
 
-void FloatToFloat16_ref(
-    const float* src,
-    float16* dst,
-    int size,
-    bool do_clip) {
-  constexpr float FP16_MAX = 65504.f;
-  if (do_clip) {
-    for (int i = 0; i < size; i++) {
-      float cur_src = std::max(-FP16_MAX, std::min(src[i], FP16_MAX));
-      dst[i] = cpu_float2half_rn(cur_src);
-    }
-  } else {
-    for (int i = 0; i < size; i++) {
-      dst[i] = cpu_float2half_rn(src[i]);
-    }
-  }
-}
-
-void Float16ToFloat_ref(const float16* src, float* dst, int size) {
-  for (int i = 0; i < size; i++) {
-    dst[i] = cpu_half2float(src[i]);
-  }
-}
-
 void FloatToFloat16_simd(
     const float* src,
     float16* dst,

--- a/src/TransposeUtils.cc
+++ b/src/TransposeUtils.cc
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#define FBGEMM_EXPORTS
+#include "./TransposeUtils.h"
+#include "fbgemm/Utils.h"
+#include <cstring>
+
+namespace fbgemm {
+
+void transpose_ref(
+    int M,
+    int N,
+    const float* src,
+    int ld_src,
+    float* dst,
+    int ld_dst) {
+  for (int j = 0; j < N; j++) {
+    for (int i = 0; i < M; i++) {
+      dst[i + j * ld_dst] = src[i * ld_src + j];
+    }
+  } // for each output row
+}
+
+void transpose_simd(
+    int M,
+    int N,
+    const float* src,
+    int ld_src,
+    float* dst,
+    int ld_dst) {
+  if ((M == 1 && ld_dst == 1) || (N == 1 && ld_src == 1)) {
+    if (dst != src) {
+      memcpy(dst, src, M * N * sizeof(float));
+    }
+    return;
+  }
+  static const auto iset = fbgemmInstructionSet();
+  // Run time CPU detection
+  if (isZmm(iset)) {
+    internal::transpose_avx512(M, N, src, ld_src, dst, ld_dst);
+  } else if (isYmm(iset)) {
+    internal::transpose_avx2(M, N, src, ld_src, dst, ld_dst);
+  } else {
+    transpose_ref(M, N, src, ld_src, dst, ld_dst);
+  }
+}
+
+} // namespace fbgemm

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -18,7 +18,6 @@
 #include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
-#include "./TransposeUtils.h"
 
 namespace fbgemm {
 
@@ -169,44 +168,6 @@ template void printMatrix<int32_t>(
     size_t C,
     size_t ld,
     std::string name);
-
-void transpose_ref(
-    int M,
-    int N,
-    const float* src,
-    int ld_src,
-    float* dst,
-    int ld_dst) {
-  for (int j = 0; j < N; j++) {
-    for (int i = 0; i < M; i++) {
-      dst[i + j * ld_dst] = src[i * ld_src + j];
-    }
-  } // for each output row
-}
-
-void transpose_simd(
-    int M,
-    int N,
-    const float* src,
-    int ld_src,
-    float* dst,
-    int ld_dst) {
-  if ((M == 1 && ld_dst == 1) || (N == 1 && ld_src == 1)) {
-    if (dst != src) {
-      memcpy(dst, src, M * N * sizeof(float));
-    }
-    return;
-  }
-  static const auto iset = fbgemmInstructionSet();
-  // Run time CPU detection
-  if (isZmm(iset)) {
-    internal::transpose_avx512(M, N, src, ld_src, dst, ld_dst);
-  } else if (isYmm(iset)) {
-    internal::transpose_avx2(M, N, src, ld_src, dst, ld_dst);
-  } else {
-    transpose_ref(M, N, src, ld_src, dst, ld_dst);
-  }
-}
 
 namespace {
 inst_set_t g_forced_isa = inst_set_t::anyarch;


### PR DESCRIPTION
Summary:
Also create `fbgemm_base` filelist, which solves circular symbol dependency issue during bazel compilation
Bazel (or rather gold linker) does not allow circular symbols dependency between static library.
i.e. if library A have some external symbols inplemented in library B(i.e. A depends on B), then library B can not have use any symbols from library A
`Utils.cc` was one such example: `transpose_simd` used symbols from `fbgemm_avx512` and `fbgemm_avx2`, while both `fbgemm_avx[2|512]` libs depend on `fbgemmAlignedAlloc` defined in `Utils.cc`

On github this PR  need to be landed in conjunction with https://github.com/pytorch/pytorch/pull/36339

Reviewed By: houseroad

Differential Revision: D20975069

