### PR TITLE
follow EXPECT_EQ(actual, expected) convention

### DIFF
--- a/test/FP16Test.cc
+++ b/test/FP16Test.cc
@@ -125,7 +125,7 @@ TEST_P(FBGemmFP16Test, Test) {
       for (int j = 0; j < n; ++j) {
         float expected = C_ref[i * n + j];
         float actual = C[i * n + j];
-        EXPECT_EQ(expected, actual)
+        EXPECT_EQ(actual, expected)
             << "GEMM results differ at (" << i << ", " << j << "). ref "
             << expected << " FBGemm " << actual;
       }
@@ -193,7 +193,7 @@ TEST_P(FBGemmFP16Test, Unpack) {
     memcpy(tmp.data(), Bp.pmat(), Bp.matSize() * sizeof(float16));
     for (int i = 0; i < k; ++i) {
       for (int j = 0; j < n; ++j) {
-        EXPECT_EQ(B[i * n + j], cpu_half2float(tmp[i * n + j]));
+        EXPECT_EQ(cpu_half2float(tmp[i * n + j]), B[i * n + j]);
       }
     }
 
@@ -217,7 +217,7 @@ TEST_P(FBGemmFP16Test, Unpack) {
       for (int j = 0; j < n; ++j) {
         float expected = C_ref[i * n + j];
         float actual = C[i * n + j];
-        EXPECT_EQ(expected, actual)
+        EXPECT_EQ(actual, expected)
             << "GEMM results differ at (" << i << ", " << j << "). ref "
             << expected << " FBGemm " << actual;
       }

--- a/test/GConvTest.cc
+++ b/test/GConvTest.cc
@@ -623,7 +623,7 @@ void runPackUnpackTest(matrix_op_t btrans) {
 
     // Sanity check
     for (int i = 0; i < weight_len; ++i) {
-      EXPECT_EQ(Bint8.data()[i], unpack_buf.data()[i])
+      EXPECT_EQ(unpack_buf.data()[i], Bint8.data()[i])
         << "Pack/Unpack results differ at index " << i
         << ", Reference: " << static_cast<int>(Bint8.data()[i])
         << ", Pack-Unpacked: " << static_cast<int>(unpack_buf.data()[i]);

--- a/test/I8DepthwiseTest.cc
+++ b/test/I8DepthwiseTest.cc
@@ -226,7 +226,7 @@ TEST_P(FBGemmDepthWiseTest, Test3x3) {
             int32_t expected =
                 C_uint8_ref[((n * H_OUT + h) * W_OUT + w) * K + k];
             int32_t actual = C_uint8[((n * H_OUT + h) * W_OUT + w) * K + k];
-            EXPECT_EQ(expected, actual)
+            EXPECT_EQ(actual, expected)
                 << "Depthwise " << R << "x" << S << " results differ at (" << n
                 << ", " << h << ", " << w << ", " << k << ").";
           }
@@ -367,7 +367,7 @@ TEST_P(FBGemmDepthWiseTest, Test3x3x3) {
                   [(((n * T_OUT + t) * H_OUT + h) * W_OUT + w) * K + k];
               int32_t actual =
                   C_uint8[(((n * T_OUT + t) * H_OUT + h) * W_OUT + w) * K + k];
-              EXPECT_EQ(expected, actual)
+              EXPECT_EQ(actual, expected)
                   << "Depthwise 3x3 results differ at (" << n << ", " << t
                   << ", " << h << ", " << w << ", " << k << ").";
             }
@@ -499,7 +499,7 @@ TEST(FBGemmDepthWiseTest, Test3x3PerChannelQuantization) {
             int32_t expected =
                 C_uint8_ref[((n * H_OUT + h) * W_OUT + w) * K + k];
             int32_t actual = C_uint8[((n * H_OUT + h) * W_OUT + w) * K + k];
-            EXPECT_EQ(expected, actual)
+            EXPECT_EQ(actual, expected)
                 << "Depthwise " << R << "x" << S << " results differ at (" << n
                 << ", " << h << ", " << w << ", " << k << ").";
           }
@@ -637,7 +637,7 @@ TEST(FBGemmDepthWiseTest, Test3x3x3PerChannelQuantization) {
                   [(((n * T_OUT + t) * H_OUT + h) * W_OUT + w) * K + k];
               int32_t actual =
                   C_uint8[(((n * T_OUT + t) * H_OUT + h) * W_OUT + w) * K + k];
-              ASSERT_EQ(expected, actual)
+              ASSERT_EQ(actual, expected)
                   << "Depthwise 3x3 results differ at (" << n << ", " << t
                   << ", " << h << ", " << w << ", " << k << ").";
             }
@@ -662,7 +662,7 @@ TEST_P(FBGemmDepthWisePackUnpackTest, TestPackUnpack) {
   PackedDepthWiseConvMatrix BPacked(K, kernel_prod, B.data());
   BPacked.unpack(BUnpacked.data());
 
-  ASSERT_EQ(B, BUnpacked)
+  ASSERT_EQ(BUnpacked, B)
       << "Original and unpacked data elements are not the same";
 } // TestPackUnpack
 

--- a/test/Im2ColFusedRequantizeTest.cc
+++ b/test/Im2ColFusedRequantizeTest.cc
@@ -222,7 +222,7 @@ static void Im2colTest(bool b_symmetric) {
                   [((n * conv_p.OUT_DIM[0] + h) * conv_p.OUT_DIM[1] + w) *
                        conv_p.OC +
                    k];
-              EXPECT_EQ(expected, actual)
+              EXPECT_EQ(actual, expected)
                   << "Im2Col fused results differ at (" << n << ", " << h
                   << ", " << w << ", " << k << ").";
             }
@@ -456,7 +456,7 @@ void SConvTest() {
                   [((n * conv_p.OUT_DIM[0] + h) * conv_p.OUT_DIM[1] + w) *
                        conv_p.OC +
                    k];
-              EXPECT_EQ(expected, actual)
+              EXPECT_EQ(actual, expected)
                   << "Im2Col fused results differ at (" << n << ", " << h
                   << ", " << w << ", " << k << ").";
             }
@@ -728,7 +728,7 @@ static void Im2col3DTest(bool b_symmetric) {
                       w) *
                          conv_p.OC +
                      k];
-                EXPECT_EQ(expected, actual)
+                EXPECT_EQ(actual, expected)
                     << "Im2Col fused results differ at (" << n << ", " << t
                     << ", " << h << ", " << w << ", " << k << ").";
               }

--- a/test/PackedRequantizeAcc16Test.cc
+++ b/test/PackedRequantizeAcc16Test.cc
@@ -905,7 +905,7 @@ TEST_P(fbgemmPackUnpackAcc16Test, TestPackUnpack) {
         // Sanity check
         for (int i = 0; i < k; i++) {
           for (int j = 0; j < n_adjusted; j++) {
-            EXPECT_EQ(Bint8.data()[i * n + j], unpack_buf.data()[i * n + j])
+            EXPECT_EQ(unpack_buf.data()[i * n + j], Bint8.data()[i * n + j])
                 << "Pack/Unpack results differ at index (" << i << ", " << j
                 << ", Reference: " << static_cast<int>(Bint8.data()[i * n + j])
                 << ", Pack-Unpacked: "

--- a/test/PackedRequantizeTest.cc
+++ b/test/PackedRequantizeTest.cc
@@ -762,7 +762,7 @@ TEST_P(fbgemmu8s8acc32Test, TestSymmetricQuantizedInputOutput) {
         for (int j = 0; j < groups * n_adjusted; ++j) {
           float expected = Cfp32_ref[i * groups * n + j];
           int32_t actual = Cint32_fb[i * groups * n + j];
-          EXPECT_EQ(expected, actual)
+          EXPECT_EQ(actual, expected)
               << "GEMM results differ at (" << i << ", " << j << "). ref "
               << expected << " FBGemm " << actual;
         }
@@ -835,7 +835,7 @@ TEST_P(fbgemmPackUnpackAcc32Test, TestPackUnpack) {
         // Sanity check
         for (int i = 0; i < k; i++) {
           for (int j = 0; j < n_adjusted; j++) {
-            EXPECT_EQ(Bint8.data()[i * n + j], unpack_buf.data()[i * n + j])
+            EXPECT_EQ(unpack_buf.data()[i * n + j], Bint8.data()[i * n + j])
                 << "Pack/Unpack results differ at index (" << i << ", " << j
                 << ", Reference: " << static_cast<int>(Bint8.data()[i * n + j])
                 << ", Pack-Unpacked: "

--- a/test/TestUtils.cc
+++ b/test/TestUtils.cc
@@ -21,7 +21,7 @@ int compare_validate_buffers(
   for (int i = 0; i < m; ++i) {
     for (int j = 0; j < n; ++j) {
       if (std::is_integral<T>::value) {
-        EXPECT_EQ(ref[i * ld + j], test[i * ld + j])
+        EXPECT_EQ(test[i * ld + j], ref[i * ld + j])
             << "GEMM results differ at (" << i << ", " << j
             << ") reference: " << (int64_t)ref[i * ld + j]
             << ", FBGEMM: " << (int64_t)test[i * ld + j];

--- a/test/TransposeTest.cc
+++ b/test/TransposeTest.cc
@@ -42,7 +42,7 @@ TEST(TransposeTest, TransposeTest) {
       for (int j = 0; j < n; ++j) {
         int expected = a[i * ld_src + j];
         int actual = b[i + j * ld_dst];
-        EXPECT_EQ(expected, actual)
+        EXPECT_EQ(actual, expected)
             << "Transpose results differ at (" << i << ", " << j << "). ref "
             << expected << " actual " << actual;
       }

--- a/test/UniConvTest.cc
+++ b/test/UniConvTest.cc
@@ -282,7 +282,7 @@ TEST_P(uniConvTest, packUnpackTest) {
 
   packedB_2D.unpack(Bint8_2d_unpacked.data());
 
-  ASSERT_EQ(Bint8_2d, Bint8_2d_unpacked)
+  ASSERT_EQ(Bint8_2d_unpacked, Bint8_2d)
       << "Original and unpacked data elements are not the same [2D]";
 
   conv_param_t<3> conv_p_3d(
@@ -307,7 +307,7 @@ TEST_P(uniConvTest, packUnpackTest) {
 
   packedB_3D.unpack(Bint8_3d_unpacked.data());
 
-  ASSERT_EQ(Bint8_3d, Bint8_3d_unpacked)
+  ASSERT_EQ(Bint8_3d_unpacked, Bint8_3d)
       << "Original and unpacked data elements are not the same [3D]";
 }
 


### PR DESCRIPTION
Summary: EXPECT_EQ and ASSERT_EQ has convention that the first argument is actual and the second is expected

Differential Revision: D20983264

