### PR TITLE
move multiplication with b_zp from jit'ed code to requantization

### DIFF
--- a/src/FbgemmI8Depthwise2DAvx2-inl.h
+++ b/src/FbgemmI8Depthwise2DAvx2-inl.h
@@ -48,8 +48,6 @@ static ALWAYS_INLINE void depthwise_2d_kernel_(
   int h_in = -PAD_T + h * stride_h;
   int w_in = -PAD_L + w * stride_w;
 
-  constexpr int KERNEL_PROD_ALIGNED = (S * S + 1) / 2 * 2;
-
   int remainder = K % 32;
   if (remainder == 0) {
     remainder = 32;
@@ -61,7 +59,6 @@ static ALWAYS_INLINE void depthwise_2d_kernel_(
             /*D=*/2,
             S,
             /*compute_a_sum=*/!B_SYMMETRIC,
-            PER_CHANNEL_QUANTIZAITON,
             remainder,
             0,
             0,
@@ -79,8 +76,7 @@ static ALWAYS_INLINE void depthwise_2d_kernel_(
       W,
       K,
       internal::avx2_ps_or_epi32_combined_mask,
-      A_zero_point,
-      B_zero_point);
+      A_zero_point);
 
   requantize_<
       FUSE_RELU,
@@ -90,6 +86,7 @@ static ALWAYS_INLINE void depthwise_2d_kernel_(
       B_SYMMETRIC,
       BIAS_TYPE>(
       A_zero_point,
+      B_zero_point,
       C_multiplier,
       C_zero_point,
       C_int32,
@@ -313,7 +310,6 @@ static ALWAYS_INLINE void depthwise_2d_(
               /*D=*/2,
               S,
               /*compute_a_sum=*/!B_SYMMETRIC,
-              PER_CHANNEL_QUANTIZATION,
               remainder,
               0,
               0,

--- a/src/FbgemmI8Depthwise3DAvx2.cc
+++ b/src/FbgemmI8Depthwise3DAvx2.cc
@@ -70,7 +70,6 @@ static ALWAYS_INLINE void depthwise_3x3x3_kernel_(
             /*D=*/3,
             /*S=*/3,
             /*compute_a_sum=*/!B_SYMMETRIC,
-            PER_CHANNEL_QUANTIZATION,
             remainder,
             /*prev_skip=*/std::max(-t_in, 0),
             /*next_skip=*/std::max(t_in + 3 - T, 0),
@@ -87,8 +86,7 @@ static ALWAYS_INLINE void depthwise_3x3x3_kernel_(
       W,
       K,
       internal::avx2_ps_or_epi32_combined_mask,
-      A_zero_point,
-      B_zero_point);
+      A_zero_point);
 
   requantize_<
       FUSE_RELU,
@@ -97,6 +95,7 @@ static ALWAYS_INLINE void depthwise_3x3x3_kernel_(
       A_SYMMETRIC,
       B_SYMMETRIC>(
       A_zero_point,
+      B_zero_point,
       C_multiplier,
       C_zero_point,
       C_int32,
@@ -251,7 +250,6 @@ static ALWAYS_INLINE void depthwise_3x3x3_pad_1_(
                 /*D=*/3,
                 /*F=*/3,
                 /*compute_a_sum=*/!B_SYMMETRIC,
-                /*per_chnnale_quantization=*/PER_CHANNEL_QUANTIZATION,
                 remainder,
                 /*prev_skip=*/std::max(-t_in, 0),
                 /*next_skip=*/std::max(t_in + 3 - T, 0),
@@ -435,7 +433,6 @@ static ALWAYS_INLINE void depthwise_3x3x3_pad_1_(
                 /*D=*/3,
                 /*F=*/3,
                 /*compute_a_sum=*/!B_SYMMETRIC,
-                /*per_chnnale_quantization=*/PER_CHANNEL_QUANTIZATION,
                 remainder,
                 0,
                 0,
@@ -621,7 +618,6 @@ static ALWAYS_INLINE void depthwise_3x3x3_pad_1_(
                 /*D=*/3,
                 /*F=*/3,
                 /*compute_a_sum=*/!B_SYMMETRIC,
-                /*per_chnnale_quantization=*/PER_CHANNEL_QUANTIZATION,
                 remainder,
                 /*prev_skip=*/std::max(-t_in, 0),
                 /*next_skip=*/std::max(t_in + 3 - T, 0),

--- a/src/GenerateI8Depthwise.h
+++ b/src/GenerateI8Depthwise.h
@@ -21,14 +21,12 @@ class GenI8Depthwise {
       int w,
       int c_in, // the number of input channels
       const int* mask,
-      int A_zero_point,
-      const int32_t* B_zero_point);
+      int A_zero_point);
 
   jit_kernel_signature getOrCreate(
       int D, // dimension
       int F, // filter size per dimension
       bool compute_a_sum,
-      bool per_channel_quantization,
       int remainder, // the number of channels in the remainder loop
       int prev_skip,
       int next_skip,


### PR DESCRIPTION
Summary: To prepare depth-wise conv with OC != G . We can no longer multiply b_zp to row_offsets in the JIT'ed code because the length of b_zp and the length of row_offsets is different when OC != G.

Differential Revision: D20983918

