### PR TITLE
implement L2 regularization for Adagrad

### DIFF
--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -149,7 +149,8 @@ class SparseAdaGradSignature {
       float* h, // input/output momentums
       const IndexType* indices, // indices of each row
       float epsilon,
-      float lr)>;
+      float lr,
+      float weight_decay)>;
 };
 
 template <typename IndexType>
@@ -171,7 +172,8 @@ FBGEMM_API int SparseAdaGrad(
     float epsilon,
     float lr,
     bool rowwise = false,
-    int prefetch = 16);
+    int prefetch = 16,
+    float weight_decay = 0.f);
 
 // RowWiseSparseAdaGrad fused with SLS gradient
 template <typename IndexType, typename OffsetType = std::int32_t>

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -295,7 +295,8 @@ FBGEMM_API int sparse_adagrad_ref(
     float* h, // input momentums
     const IndexType* indices, // indices of each row
     float epsilon,
-    float lr);
+    float lr,
+    float weight_decay = 0.f);
 
 template <typename IndexType>
 FBGEMM_API int rowwise_sparse_adagrad_ref(
@@ -307,7 +308,8 @@ FBGEMM_API int rowwise_sparse_adagrad_ref(
     float* h, // input momentums
     const IndexType* indices, // indices of each row
     float epsilon,
-    float lr);
+    float lr,
+    float weight_decay = 0.f);
 
 template <typename IndexType, typename OffsetType>
 FBGEMM_API int rowwise_sparse_adagrad_fused_ref(


### PR DESCRIPTION
Summary:
Posted note: [Regularizing SparseNN Against Over-fitting](https://fb.workplace.com/notes/taiqing-wang/regularizing-sparsenn-against-over-fitting/220306075902708/)

**Problem formulation**

L(w) = J(w) + lambda/2 * ||w||^2
J(w) is the empirical loss, and ||w||^2 is the squared L2 norm of the parameters, a.k.a. L2 regularizer.

dL(w)/ dw_i = dJ(w)/dw_i + lambda w_i
dL(w)/ dw_i is the gradient of L(w) w.r.t. w_i.

To implement the L2 regularizer, the gradient of J(w) w.r.t. w_i is added with w_i. lambda is called as weight decay in this implementation.

**Code changes**
* In the initialization method of AdagradOptimizer, a new input argument, weight_decay, is added.
* In the _run function of AdagradOptimizer, the weight decay will be skipped for 1d bias vectors.
* In the parameter update functions of Adagrad, the gradient is updated by weight_decay * w_i. The default value for weight_decay is zero.

Differential Revision: D21236605

