### PR TITLE
use lea to simplify code

### DIFF
--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -411,12 +411,8 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
         }
 
         // Compute the end address of indices
-        a->imul(
-            scratchReg1_,
-            index_size,
-            static_cast<asmjit::Imm>(sizeof(indxType)));
-        a->add(scratchReg1_, indices);
-        a->mov(index_size, scratchReg1_);
+        a->lea(
+            index_size, x86::ptr(indices, index_size, areIndices64b ? 3 : 2));
 
         asmjit::Label exit = a->newLabel();
         asmjit::Label error = a->newLabel();
@@ -481,12 +477,9 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
           }
 
           // Array out of bound check
-          a->imul(
+          a->lea(
               scratchReg1_,
-              lengths_R_,
-              static_cast<asmjit::Imm>(sizeof(indxType)));
-
-          a->add(scratchReg1_, indices);
+              x86::ptr(indices, lengths_R_, areIndices64b ? 3 : 2));
           a->cmp(scratchReg1_, index_size);
           a->jg(error);
 
@@ -527,10 +520,8 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
             asmjit::Label pref_dist_reset_start = a->newLabel();
             asmjit::Label pref_dist_reset_end = a->newLabel();
             // out of bound handling for prefetch
-            a->mov(scratchReg2_, indices);
-            a->add(
-                scratchReg2_,
-                static_cast<asmjit::Imm>(pref_dist * sizeof(indxType)));
+            a->lea(
+                scratchReg2_, x86::ptr(indices, pref_dist * sizeof(indxType)));
             a->cmp(scratchReg2_, index_size);
             a->jge(pref_dist_reset_start);
 

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -430,12 +430,8 @@ typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
         }
 
         // Compute the end address of indices
-        a->imul(
-            scratchReg1_,
-            index_size,
-            static_cast<asmjit::Imm>(sizeof(indxType)));
-        a->add(scratchReg1_, indices);
-        a->mov(index_size, scratchReg1_);
+        a->lea(
+            index_size, x86::ptr(indices, index_size, areIndices64b ? 3 : 2));
 
         asmjit::Label exit = a->newLabel();
         asmjit::Label error = a->newLabel();
@@ -499,12 +495,9 @@ typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
           }
 
           // Array out of bound check
-          a->imul(
+          a->lea(
               scratchReg1_,
-              lengths_R_,
-              static_cast<asmjit::Imm>(sizeof(indxType)));
-
-          a->add(scratchReg1_, indices);
+              x86::ptr(indices, lengths_R_, areIndices64b ? 3 : 2));
           a->cmp(scratchReg1_, index_size);
           a->jg(error);
 
@@ -544,10 +537,8 @@ typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
             asmjit::Label pref_dist_reset_start = a->newLabel();
             asmjit::Label pref_dist_reset_end = a->newLabel();
             // out of bound handling for prefetch
-            a->mov(scratchReg2_, indices);
-            a->add(
-                scratchReg2_,
-                static_cast<asmjit::Imm>(pref_dist * sizeof(indxType)));
+            a->lea(
+                scratchReg2_, x86::ptr(indices, pref_dist * sizeof(indxType)));
             a->cmp(scratchReg2_, index_size);
             a->jge(pref_dist_reset_start);
 


### PR DESCRIPTION
Summary:
Reapplying D21525517 that was mistakenly reverted in D21419886

Shouldn't affect performance because the changes are not inner loops. Mostly code size reduction.

Differential Revision: D21813141

