### PR TITLE
minor fix

### DIFF
--- a/src/GenerateKernel.h
+++ b/src/GenerateKernel.h
@@ -131,7 +131,7 @@ class CodeGenBase {
     }
     oss << "accum-" + std::to_string(accum) << "_MC-" + std::to_string(mc)
         << "_NC-" + std::to_string(nc) << "_NCB-" + std::to_string(NCB)
-        << "_NCB-" + std::to_string(KCB) << "_MR-" + std::to_string(MR)
+        << "_KCB-" + std::to_string(KCB) << "_MR-" + std::to_string(MR)
         << "_NR-" + std::to_string(NR);
     if (instSet == inst_set_t::avx512_vnni) {
       oss << "_avx512vnni";

--- a/test/GConvTest.cc
+++ b/test/GConvTest.cc
@@ -319,9 +319,9 @@ void runRequantizeTest(matrix_op_t /* unused */,
     aligned_vector<int32_t> Bint8_zero_point(
         G * OC_per_G / ncols_per_quant_group);
     if (b_symmetric) {
-      randFill(Bint8_zero_point, -3, -1);
-    } else {
       randFill(Bint8_zero_point, 0, 0);
+    } else {
+      randFill(Bint8_zero_point, -3, -1);
     }
 
     // matrix dimensions after im2col for each GEMM.


### PR DESCRIPTION
Summary:
Reapplying D21516315 that was mistakenly reverted in D21419886

Minor fix:
1. bzero setting for symmetric test case
2. name for getCodeLoggingFile

Differential Revision: D21813156

