### PR TITLE
add more comments and make test name more accurate

### DIFF
--- a/src/GenerateI8Depthwise.cc
+++ b/src/GenerateI8Depthwise.cc
@@ -59,7 +59,8 @@ static void genMaddEpi16xNPacked(
     x86::Ymm one_epi8,
     x86::Ymm one_epi16,
     x86::Ymm zero) {
-  // Interleave inputs. Reuse a[1] and a[3] to save registers
+  // Interleave inputs corresponding to 4 filter positions.
+  // Reuse a[1] and a[3] to save registers
   x86::Ymm a01_lo(0), a01_hi(1), a23_lo(a[1]), a23_hi(a[3]);
   e->vpunpcklbw(a01_lo, a[0], n == 1 ? zero : a[1]);
   if (remainder >= 8) {
@@ -458,6 +459,7 @@ GenI8Depthwise::jit_kernel_signature GenI8Depthwise::getOrCreate(
 
               if (K - i / 4 * 4 >= 3 && K - i / 4 * 4 <= 6) {
                 for (int r = 0; r < (main_loop ? 4 : remainder / 8); ++r) {
+                  // fix? output layout (see genMaddEpi16xNPacked for details)
                   e->vperm2f128(
                       a[r],
                       c[r % 2 * 2],

--- a/test/I8DepthwiseTest.cc
+++ b/test/I8DepthwiseTest.cc
@@ -104,7 +104,7 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(
         ::testing::Bool(), // a_symmetric
         ::testing::Bool(), // b_symmetric
-        ::testing::Values(1, 2)));
+        ::testing::Values(1, 2))); // oc_per_g
 
 INSTANTIATE_TEST_CASE_P(
     InstantiationName,
@@ -118,7 +118,7 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Values(8, 16, 24, 32, 40, 64, 72),
         ::testing::Values(1, 2, 3, 4, 5, 9, 10, 11, 27)));
 
-TEST_P(FBGemmDepthWiseTest, Test3x3) {
+TEST_P(FBGemmDepthWiseTest, Test2D) {
   bool a_symmetric, b_symmetric;
   int oc_per_g;
   tie(a_symmetric, b_symmetric, oc_per_g) = GetParam();
@@ -406,7 +406,7 @@ TEST_P(FBGemmDepthWiseTest, Test3x3x3) {
 
 TEST_P(
     FBGemmDepthWisePerChannelQuantizationTest,
-    Test3x3PerChannelQuantization) {
+    Test2DPerChannelQuantization) {
   int oc_per_g = GetParam();
 
   for (auto shape : shapes) {


### PR DESCRIPTION
Summary: depthwise 2D test is no longer limited to 3x3

Reviewed By: shz0116

Differential Revision: D22138658

