### PR TITLE
Enable avx512_vnni_256

### DIFF
--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -41,7 +41,14 @@ enum class matrix_op_t { NoTranspose, Transpose };
 /**
  * @brief Typed enum for supported instruction sets.
  */
-enum class inst_set_t { anyarch, avx2, avx512, avx512_ymm, avx512_vnni };
+enum class inst_set_t {
+  anyarch,
+  avx2,
+  avx512,
+  avx512_ymm,
+  avx512_vnni,
+  avx512_vnni_ymm
+};
 
 /**
  * @brief Typed enum for optimized paths for convolutions
@@ -107,6 +114,11 @@ struct simd_info<inst_set_t::avx512_ymm> {
 
   using vec_reg_t = asmjit::x86::Ymm;
 };
+
+template <>
+struct simd_info<inst_set_t::avx512_vnni_ymm>
+    : public simd_info<inst_set_t::avx512_ymm> {};
+
 /**
  * @brief A function to compare data in two buffers for closeness/equality.
  */

--- a/src/CodeGenHelpers.h
+++ b/src/CodeGenHelpers.h
@@ -36,7 +36,8 @@ template<
     typename std::enable_if<
         instSet == inst_set_t::avx512 ||
         instSet == inst_set_t::avx512_ymm ||
-        instSet == inst_set_t::avx512_vnni,
+        instSet == inst_set_t::avx512_vnni ||
+        instSet == inst_set_t::avx512_vnni_ymm,
         int>::type = 0>
 void gen16BitVectorOne(x86::Emitter* a, T dest) {
   a->vpternlogd(dest, dest, dest, 0xff);
@@ -65,7 +66,8 @@ template<
     typename std::enable_if<
         instSet == inst_set_t::avx512 ||
         instSet == inst_set_t::avx512_ymm ||
-        instSet == inst_set_t::avx512_vnni,
+        instSet == inst_set_t::avx512_vnni ||
+        instSet == inst_set_t::avx512_vnni_ymm,
         int>::type = 0>
 void emitLoadDWord(
   x86::Emitter* a, T dest, const x86::Mem& ptr) {
@@ -87,7 +89,8 @@ template<
     typename std::enable_if<
         instSet == inst_set_t::avx512 ||
         instSet == inst_set_t::avx512_ymm ||
-        instSet == inst_set_t::avx512_vnni,
+        instSet == inst_set_t::avx512_vnni ||
+        instSet == inst_set_t::avx512_vnni_ymm,
         int>::type = 0>
 void emitExtractHalfVector(
     x86::Emitter* a, x86::Ymm half, const x86::Zmm vec, int idx) {
@@ -100,7 +103,8 @@ template<
     typename std::enable_if<
         instSet == inst_set_t::avx512 ||
         instSet == inst_set_t::avx512_ymm ||
-        instSet == inst_set_t::avx512_vnni,
+        instSet == inst_set_t::avx512_vnni ||
+        instSet == inst_set_t::avx512_vnni_ymm,
         int>::type = 0>
 void emitExtractHalfVector(
     x86::Emitter* a, x86::Xmm half, x86::Ymm vec, int idx) {

--- a/src/Fbgemm.cc
+++ b/src/Fbgemm.cc
@@ -74,6 +74,13 @@ void fbgemmPacked(
             inst_set_t::avx512_vnni>::getCacheBlockParams();
         break;
 
+      case inst_set_t::avx512_vnni_ymm:
+        std::tie(MCB, KCB, MR) = PackingTraits<
+            typename packingAMatrix::inpType,
+            typename packingAMatrix::accType,
+            inst_set_t::avx512_vnni_ymm>::getCacheBlockParams();
+        break;
+
       case inst_set_t::avx512:
         std::tie(MCB, KCB, MR) = PackingTraits<
             typename packingAMatrix::inpType,

--- a/src/GenerateKernelU8S8S32ACC16Avx512VNNI.cc
+++ b/src/GenerateKernelU8S8S32ACC16Avx512VNNI.cc
@@ -27,4 +27,20 @@ CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate<
   return codeObj.getOrCreate<inst_set_t::avx512_vnni>(accum, mc, nc, kc);
 }
 
+/**
+ * Get or Create the AVX512 instructions for 16-bit Accumulation macro-kernel.
+ *
+ */
+template <>
+template <>
+CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::jit_micro_kernel_fp
+CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate<
+    inst_set_t::avx512_vnni_ymm>(bool accum, int32_t mc, int32_t nc, int32_t kc) {
+  assert(0 && "Accumulation to int16_t is not available for VNNI!");
+
+  // For AVX512VNNI, redirect to int32_t accumulation.
+  CodeGenBase<uint8_t, int8_t, int32_t, int32_t> codeObj;
+  return codeObj.getOrCreate<inst_set_t::avx512_vnni_ymm>(accum, mc, nc, kc);
+}
+
 } // namespace fbgemm

--- a/src/GenerateKernelU8S8S32ACC32Avx512VNNI.cc
+++ b/src/GenerateKernelU8S8S32ACC32Avx512VNNI.cc
@@ -55,7 +55,9 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::jit_micro_kernel_fp
 CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate(
     bool accum, int32_t mc, int32_t nc, int32_t kc) {
   static constexpr int vectorLen = simd_info<instSet>::WIDTH_BYTES;
-  static constexpr inst_set_t storeInstType = inst_set_t::avx512;
+  static constexpr inst_set_t storeInstType = simd_info<instSet>::WIDTH_BITS == 512
+      ? inst_set_t::avx512
+      : inst_set_t::avx512_ymm;
 
   std::tuple<bool, int, int, int, int, int, int> kernelSig;
   int kBlock;
@@ -368,5 +370,14 @@ template
 CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::jit_micro_kernel_fp
 CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::
 getOrCreate<inst_set_t::avx512_vnni>(bool accum, int32_t mc, int32_t nc, int32_t kc);
+
+/**
+ * Instatiate the AVX512_VNNI_256 instructions for 32-bit Accumulation macro-kernel.
+ *
+ */
+template
+CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::jit_micro_kernel_fp
+CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::
+getOrCreate<inst_set_t::avx512_vnni_ymm>(bool accum, int32_t mc, int32_t nc, int32_t kc);
 
 } // namespace fbgemm

--- a/src/PackAMatrix.cc
+++ b/src/PackAMatrix.cc
@@ -53,6 +53,12 @@ PackAMatrix<T, accT>::PackAMatrix(
               getMatrixPackAParams();
         break;
 
+      case inst_set_t::avx512_vnni_ymm:
+        std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
+            PackingTraits<T, accT, inst_set_t::avx512_vnni_ymm>::
+              getMatrixPackAParams();
+        break;
+
       case inst_set_t::avx512:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
             PackingTraits<T, accT, inst_set_t::avx512>::getMatrixPackAParams();

--- a/src/PackAWithIm2Col.cc
+++ b/src/PackAWithIm2Col.cc
@@ -66,6 +66,12 @@ PackAWithIm2Col<T, accT, SPATIAL_DIM>::PackAWithIm2Col(
               getMatrixPackAParams();
         break;
 
+      case inst_set_t::avx512_vnni_ymm:
+        std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
+            PackingTraits<T, accT, inst_set_t::avx512_vnni_ymm>::
+              getMatrixPackAParams();
+        break;
+
       case inst_set_t::avx512:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
             PackingTraits<T, accT, inst_set_t::avx512>::getMatrixPackAParams();

--- a/src/PackAWithQuantRowOffset.cc
+++ b/src/PackAWithQuantRowOffset.cc
@@ -70,6 +70,12 @@ PackAWithQuantRowOffset<T, accT>::PackAWithQuantRowOffset(
               getMatrixPackAParams();
         break;
 
+      case inst_set_t::avx512_vnni_ymm:
+        std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
+            PackingTraits<T, accT, inst_set_t::avx512_vnni_ymm>::
+              getMatrixPackAParams();
+        break;
+
       case inst_set_t::avx512:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
             PackingTraits<T, accT, inst_set_t::avx512>::getMatrixPackAParams();

--- a/src/PackAWithRowOffset.cc
+++ b/src/PackAWithRowOffset.cc
@@ -58,6 +58,12 @@ PackAWithRowOffset<T, accT>::PackAWithRowOffset(
               getMatrixPackAParams();
         break;
 
+      case inst_set_t::avx512_vnni_ymm:
+        std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
+            PackingTraits<T, accT, inst_set_t::avx512_vnni_ymm>::
+              getMatrixPackAParams();
+        break;
+
       case inst_set_t::avx512:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
             PackingTraits<T, accT, inst_set_t::avx512>::getMatrixPackAParams();

--- a/src/PackBMatrix.cc
+++ b/src/PackBMatrix.cc
@@ -202,6 +202,12 @@ PackBMatrix<T, accT>::PackBMatrix(
               getMatrixPackBParams();
         break;
 
+      case inst_set_t::avx512_vnni_ymm:
+        std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_) =
+            PackingTraits<T, accT, inst_set_t::avx512_vnni_ymm>::
+              getMatrixPackBParams();
+        break;
+
       case inst_set_t::avx512:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_) =
             PackingTraits<T, accT, inst_set_t::avx512>::getMatrixPackBParams();

--- a/src/PackMatrix.cc
+++ b/src/PackMatrix.cc
@@ -57,6 +57,12 @@ int PackMatrix<PT, inpType, accType>::packedBufferSize(
         KCB = PackingTraits<inpType, accType, inst_set_t::avx512_vnni>::KCB;
         break;
 
+      case inst_set_t::avx512_vnni_ymm:
+        MCB = PackingTraits<inpType, accType, inst_set_t::avx512_vnni_ymm>::MCB;
+        NCB = PackingTraits<inpType, accType, inst_set_t::avx512_vnni_ymm>::NCB;
+        KCB = PackingTraits<inpType, accType, inst_set_t::avx512_vnni_ymm>::KCB;
+        break;
+
       case inst_set_t::avx512:
         MCB = PackingTraits<inpType, accType, inst_set_t::avx512>::MCB;
         NCB = PackingTraits<inpType, accType, inst_set_t::avx512>::NCB;


### PR DESCRIPTION
Summary:
Add support for AVX512_VNNI_256(YMM)
- Extend utils to support new uArch avx512_vnni_ymm
- Extend Packing Trains to be close to AVX2, it will require further calibration based on common dimensions
- Provide template specialization for the new uArch

Differential Revision: D22597705

