### PR TITLE
Bug fix in depthwise conv

### DIFF
--- a/src/FbgemmI8Depthwise2DAvx2-inl.h
+++ b/src/FbgemmI8Depthwise2DAvx2-inl.h
@@ -177,8 +177,8 @@ static ALWAYS_INLINE void depthwise_2d_(
     int h = 0;
     int w = 0;
 
-    for (h = h_begin; h < PAD_T; ++h) {
-      for (w = w_begin; w < PAD_L; ++w) {
+    for (h = h_begin; h < std::min(PAD_T, h_end); ++h) {
+      for (w = w_begin; w < std::min(PAD_L, w_end); ++w) {
         depthwise_2d_kernel_<
             S,
             FUSE_RELU,
@@ -285,7 +285,7 @@ static ALWAYS_INLINE void depthwise_2d_(
     // h_in + S - H <= PAD_B * (1 - stride_h) + 1 + (1 - stride_h) * stride_h
     //              <= -PAD_B + 1 - stride_h <= 0
     for (; h < std::min(H_OUT - PAD_B - stride_h + 1, h_end); ++h) {
-      for (w = w_begin; w < PAD_L; ++w) {
+      for (w = w_begin; w < std::min(PAD_L, w_end); ++w) {
         depthwise_2d_kernel_<
             S,
             FUSE_RELU,
@@ -399,7 +399,7 @@ static ALWAYS_INLINE void depthwise_2d_(
     }
 
     for (; h < h_end; ++h) {
-      for (w = w_begin; w < PAD_L; ++w) {
+      for (w = w_begin; w < std::min(PAD_L, w_end); ++w) {
         depthwise_2d_kernel_<
             S,
             FUSE_RELU,

--- a/test/I8DepthwiseTest.cc
+++ b/test/I8DepthwiseTest.cc
@@ -25,6 +25,7 @@ static vector<vector<int>> shapes = {
   // NOTE: clang-format wants to use a different formatting but the current
   // formatting should be easier to read.
   // N, G, H_in, W_in, stride, kernel
+  {   1,  72,  47, 125, 1, 3 },
   {   1,  272,  47, 125, 1, 3 },
   {   1,  272,  47, 125, 1, 5 },
 //  {   1,  272,  64, 125, 1, 3 },
@@ -68,6 +69,10 @@ static vector<vector<int>> shapes = {
 //  { 100,  544,  14,  14, 2, 3 },
 
   {   1,    8,   4,   4, 1, 3 },
+  // Tests for the shapes when OH/OW is less than padding
+  {   1,  72,  1, 1, 2, 5 },
+  {   1,  72,  7, 1, 2, 5 },
+  {   1,  72,  1, 7, 2, 5 },
 };
 
 static vector<vector<int>> shapes_3d = {


### PR DESCRIPTION
Summary:
Depthwise conv was crashing when output image height or width was less than the pad size.

Fixes: https://github.com/pytorch/pytorch/issues/41406

Differential Revision: D22645420

