### PR TITLE
Enable AVX512_256 for accum16/accum32 kernels

### DIFF
--- a/include/fbgemm/PackingTraits-inl.h
+++ b/include/fbgemm/PackingTraits-inl.h
@@ -48,7 +48,7 @@
  * integers.
  *
  * This is picked when T is of int8 type (signed or unsigned) and instruction
- * set is avx2.
+ * set is avx2
  */
 template <typename T>
 struct PackingTraits<
@@ -176,7 +176,7 @@ struct PackingTraits<float, float, inst_set_t::avx2> {
  * accumulation.
  *
  * This is picked when template parameter T is of float16 type and instruction
- * set is avx2.
+ * set is avx2
  */
 template <>
 struct PackingTraits<float16, float, inst_set_t::avx2> {
@@ -235,6 +235,53 @@ struct PackingTraits<
 };
 
 /**
+ * @brief Packing parameter specialization for accumulation into 32-bit
+ * integers.
+ *
+ * This is picked when T is of int8 type (signed or unsigned) and instruction
+ * set is avx512_ymm.
+ */
+template <typename T>
+struct PackingTraits<
+    T,
+    std::int32_t,
+    inst_set_t::avx512_ymm,
+    typename std::enable_if<is_8bit<T>::value>::type> {
+  static constexpr int MR{12}; ///< Register block for M dimension.
+  static constexpr int NR_MIN{8}; ///< Minimum register block for N dimension.
+                                  ///< 8 because 8*ROW_INTERLEAVE int8 elements
+                                  ///< completely fill a 256-bit wide vector.
+  static constexpr int NR{8}; ///< Register block for N dimension.
+                              ///< NR = VLEN/8/ROW_INTERLEAVE = 256 / 8 / 4 = 8.
+                              ///< Total registers used for N dimension: NCB/NR.
+                              ///< Here we use 12 x 1 ymm register blocking for
+                              ///< the registers used for accumulation C.
+
+  static constexpr int ROW_INTERLEAVE{
+      4}; ///< 4 rows are interleaved to use vpmaddubsw instruction for packing
+          ///< B matrix.
+
+  static constexpr int MCB{
+      120}; ///< Cache block for M dimension (multiple of MR).
+  static constexpr int NCB{
+      8}; ///< Cache block for N dimension (multiple of NR).
+  static constexpr int KCB{512}; ///< Cache block for K dimension.
+
+  static std::tuple<int, int, int> getCacheBlockParams() {
+      return std::tuple<int, int, int>(int(MCB), int(KCB), int(MR));
+  }
+  static std::tuple<int, int, int> getKernelParams() {
+      return std::tuple<int, int, int>(int(MCB), int(NCB), int(NR_MIN));
+  }
+  static std::tuple<int, int, int> getMatrixPackAParams() {
+      return std::tuple<int, int, int>(int(MCB), int(KCB), int(ROW_INTERLEAVE));
+  }
+  static std::tuple<int, int, int> getMatrixPackBParams() {
+      return std::tuple<int, int, int>(int(KCB), int(NCB), int(ROW_INTERLEAVE));
+  }
+};
+
+/**
  * @brief Packing parameter specialization for accumulation into 16-bit
  * integers.
  *
@@ -268,6 +315,56 @@ struct PackingTraits<
       60}; ///< Cache block for M dimension (multiple of MR).
   static constexpr int NCB{
       128}; ///< Cache block for N dimension (multiple of NR).
+  static constexpr int KCB{256}; ///< Cache block for K dimension.
+
+  static std::tuple<int, int, int> getCacheBlockParams() {
+      return std::tuple<int, int, int>(int(MCB), int(KCB), int(MR));
+  }
+  static std::tuple<int, int, int> getKernelParams() {
+      return std::tuple<int, int, int>(int(MCB), int(NCB), int(NR_MIN));
+  }
+  static std::tuple<int, int, int> getMatrixPackAParams() {
+      return std::tuple<int, int, int>(int(MCB), int(KCB), int(ROW_INTERLEAVE));
+  }
+  static std::tuple<int, int, int> getMatrixPackBParams() {
+      return std::tuple<int, int, int>(int(KCB), int(NCB), int(ROW_INTERLEAVE));
+  }
+};
+
+/**
+ * @brief Packing parameter specialization for accumulation into 16-bit
+ * integers.
+ *
+ * This is picked when T is of int8 type (signed or unsigned) and instruction
+ * set is avx512_ymm.
+ */
+template <typename T>
+struct PackingTraits<
+    T,
+    std::int16_t,
+    inst_set_t::avx512_ymm,
+    typename std::enable_if<is_8bit<T>::value>::type> {
+  static constexpr int MR{6}; ///< Register block for M dimension.
+  static constexpr int NR_MIN{
+      16}; ///< Minimum register block for N dimension.
+           ///< 16 because 16*ROW_INTERLEAVE int8 elements
+           ///< completely fill a 256-bit wide vector.
+
+  static constexpr int NR{
+      16}; ///< Register block for N dimension;
+           ///< NR = VLEN/8/ROW_INTERLEAVE = 256 / 8 / 2 = 16.
+           ///< Total registers used for N dimension: NCB/NR.
+           ///< Here we use 3 x 4 ymm register blocking for the
+           ///< registers used for accumulation C.
+
+  static constexpr int ROW_INTERLEAVE{
+      2}; ///< 2 rows are interleaved to use vpmaddubsw instruction for packing
+          ///< B matrix.
+
+  static constexpr int MCB{
+      60}; ///< Cache block for M dimension (multiple of MR).
+  static constexpr int NCB{
+      64}; ///< Cache block for N dimension (multiple of NR).
   static constexpr int KCB{256}; ///< Cache block for K dimension.
 
   static std::tuple<int, int, int> getCacheBlockParams() {

--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -98,6 +98,15 @@ template <>
 struct simd_info<inst_set_t::avx512_vnni>
     : public simd_info<inst_set_t::avx512> {};
 
+template <>
+struct simd_info<inst_set_t::avx512_ymm> {
+  static constexpr int WIDTH_BITS = 256;
+  static constexpr int WIDTH_BYTES = 32;
+  static constexpr int WIDTH_32BIT_ELEMS = 8;
+  static constexpr int NUM_VEC_REGS = 32;
+
+  using vec_reg_t = asmjit::x86::Ymm;
+};
 /**
  * @brief A function to compare data in two buffers for closeness/equality.
  */

--- a/src/CodeGenHelpers.h
+++ b/src/CodeGenHelpers.h
@@ -35,6 +35,7 @@ template<
     typename T,
     typename std::enable_if<
         instSet == inst_set_t::avx512 ||
+        instSet == inst_set_t::avx512_ymm ||
         instSet == inst_set_t::avx512_vnni,
         int>::type = 0>
 void gen16BitVectorOne(x86::Emitter* a, T dest) {
@@ -63,11 +64,47 @@ template<
     typename T,
     typename std::enable_if<
         instSet == inst_set_t::avx512 ||
+        instSet == inst_set_t::avx512_ymm ||
         instSet == inst_set_t::avx512_vnni,
         int>::type = 0>
 void emitLoadDWord(
   x86::Emitter* a, T dest, const x86::Mem& ptr) {
     a->vmovdqa32(dest, ptr);
+}
+
+/**
+ * @brief Emit partial extract from Wide regiter to Half Register, eg.
+ *        Zmm -> Ymm or Ymm -> Xmm
+ * @tparam instSet instruction set to be used
+ *
+ * @param half Destination (half) vector register
+ * @param vec Source (full) vector register
+ * @param idx Index of of the half vector 0 or 1
+ */
+template<
+    inst_set_t instSet,
+    typename T,
+    typename std::enable_if<
+        instSet == inst_set_t::avx512 ||
+        instSet == inst_set_t::avx512_ymm ||
+        instSet == inst_set_t::avx512_vnni,
+        int>::type = 0>
+void emitExtractHalfVector(
+    x86::Emitter* a, x86::Ymm half, const x86::Zmm vec, int idx) {
+  a->vextracti32x8(half, vec, idx);
+}
+
+template<
+    inst_set_t instSet,
+    typename T,
+    typename std::enable_if<
+        instSet == inst_set_t::avx512 ||
+        instSet == inst_set_t::avx512_ymm ||
+        instSet == inst_set_t::avx512_vnni,
+        int>::type = 0>
+void emitExtractHalfVector(
+    x86::Emitter* a, x86::Xmm half, x86::Ymm vec, int idx) {
+  a->vextracti32x4(half, vec, idx);
 }
 
 /**

--- a/src/ExecuteKernelU8S8.cc
+++ b/src/ExecuteKernelU8S8.cc
@@ -74,6 +74,13 @@ ExecuteKernel<
             inst_set_t::avx512>::getKernelParams();
         break;
 
+      case inst_set_t::avx512_ymm:
+        std::tie(mbSize_, nbSize_, nrMinSize_) = PackingTraits<
+            typename packingAMatrix::inpType,
+            typename packingAMatrix::accType,
+            inst_set_t::avx512_ymm>::getKernelParams();
+        break;
+
       case inst_set_t::avx2:
         std::tie(mbSize_, nbSize_, nrMinSize_) = PackingTraits<
             typename packingAMatrix::inpType,
@@ -143,6 +150,14 @@ void ExecuteKernel<
           packedA_.numPackedCols());
       break;
 
+    case inst_set_t::avx512_ymm:
+      fn = BaseType::template getOrCreate<inst_set_t::avx512_ymm>(
+          accum,
+          packed_rows_A,
+          packedB_.blockColSize(),
+          packedA_.numPackedCols());
+      break;
+
     case inst_set_t::avx2:
       fn = BaseType::template getOrCreate<inst_set_t::avx2>(
           accum,
@@ -190,6 +205,11 @@ void ExecuteKernel<
 
           case inst_set_t::avx512:
             fn = BaseType::template getOrCreate<inst_set_t::avx512>(
+                accum, packed_rows_A, nc, packedA_.numPackedCols());
+            break;
+
+          case inst_set_t::avx512_ymm:
+            fn = BaseType::template getOrCreate<inst_set_t::avx512_ymm>(
                 accum, packed_rows_A, nc, packedA_.numPackedCols());
             break;
 

--- a/src/Fbgemm.cc
+++ b/src/Fbgemm.cc
@@ -81,6 +81,13 @@ void fbgemmPacked(
             inst_set_t::avx512>::getCacheBlockParams();
         break;
 
+      case inst_set_t::avx512_ymm:
+        std::tie(MCB, KCB, MR) = PackingTraits<
+            typename packingAMatrix::inpType,
+            typename packingAMatrix::accType,
+            inst_set_t::avx512_ymm>::getCacheBlockParams();
+        break;
+
       case inst_set_t::avx2:
         std::tie(MCB, KCB, MR) = PackingTraits<
             typename packingAMatrix::inpType,

--- a/src/GenerateKernel.h
+++ b/src/GenerateKernel.h
@@ -120,6 +120,8 @@ class CodeGenBase {
       oss << "_avx512vnni";
     } else if (instSet == inst_set_t::avx512) {
       oss << "_avx512";
+    } else if (instSet == inst_set_t::avx512_ymm) {
+      oss << "_avx512_ymm";
     } else if (instSet == inst_set_t::avx2) {
       oss << "_avx2";
     }

--- a/src/GenerateKernelU8S8S32ACC16Avx512.cc
+++ b/src/GenerateKernelU8S8S32ACC16Avx512.cc
@@ -6,6 +6,7 @@
  */
 #include <iostream>
 #include "./GenerateKernel.h"
+#include "./CodeGenHelpers.h"
 
 namespace fbgemm {
 
@@ -77,7 +78,10 @@ void CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::storeCRegs(
     a->imul(C_Offset, ldcReg, static_cast<asmjit::Imm>(i * sizeof(int32_t)));
     for (int j = 0; j < colRegs; ++j) {
       for (int idx = 0; idx < 2; ++idx) {
-        a->vextracti32x8(extractDestHalf, VecT(i * colRegs + j), idx);
+        // Use generilzed AVX512 instruction set, as this file currently
+        // handles only AVX512 cases
+        emitExtractHalfVector<inst_set_t::avx512, VecT>(
+            a, extractDestHalf, VecT(i * colRegs + j), idx);
         a->vpmovsxwd(extractDestFull, extractDestHalf);
         x86::Mem destAddr = x86::dword_ptr(
             a->zcx(), C_Offset, 0, (j * 2 + idx) * 16 * sizeof(int32_t));
@@ -409,5 +413,14 @@ template
 CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::jit_micro_kernel_fp
 CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::
 getOrCreate<inst_set_t::avx512>(bool accum, int32_t mc, int32_t nc, int32_t kc);
+
+/**
+ * Instatiate the AVX512_256 instructions for 16-bit Accumulation macro-kernel.
+ *
+ */
+template
+CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::jit_micro_kernel_fp
+CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::
+getOrCreate<inst_set_t::avx512_ymm>(bool accum, int32_t mc, int32_t nc, int32_t kc);
 
 } // namespace fbgemm

--- a/src/GenerateKernelU8S8S32ACC32.cc
+++ b/src/GenerateKernelU8S8S32ACC32.cc
@@ -382,6 +382,15 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::
 getOrCreate<inst_set_t::avx512>(bool accum, int32_t mc, int32_t nc, int32_t kc);
 
 /**
+ * Instatiate the AVX512_256 instructions for 32-bit Accumulation macro-kernel.
+ *
+ */
+template
+CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::jit_micro_kernel_fp
+CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::
+getOrCreate<inst_set_t::avx512_ymm>(bool accum, int32_t mc, int32_t nc, int32_t kc);
+
+/**
  * Instantiate the AVX2 instructions for 32-bit Accumulation macro-kernel.
  *
  */

--- a/src/PackAMatrix.cc
+++ b/src/PackAMatrix.cc
@@ -58,6 +58,12 @@ PackAMatrix<T, accT>::PackAMatrix(
             PackingTraits<T, accT, inst_set_t::avx512>::getMatrixPackAParams();
         break;
 
+      case inst_set_t::avx512_ymm:
+        std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
+            PackingTraits<T, accT, inst_set_t::avx512_ymm>::
+              getMatrixPackAParams();
+        break;
+
       case inst_set_t::avx2:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
             PackingTraits<T, accT, inst_set_t::avx2>::getMatrixPackAParams();

--- a/src/PackAWithIm2Col.cc
+++ b/src/PackAWithIm2Col.cc
@@ -71,6 +71,12 @@ PackAWithIm2Col<T, accT, SPATIAL_DIM>::PackAWithIm2Col(
             PackingTraits<T, accT, inst_set_t::avx512>::getMatrixPackAParams();
         break;
 
+      case inst_set_t::avx512_ymm:
+        std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
+            PackingTraits<T, accT, inst_set_t::avx512_ymm>::
+              getMatrixPackAParams();
+        break;
+
       case inst_set_t::avx2:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
             PackingTraits<T, accT, inst_set_t::avx2>::getMatrixPackAParams();

--- a/src/PackAWithQuantRowOffset.cc
+++ b/src/PackAWithQuantRowOffset.cc
@@ -75,6 +75,12 @@ PackAWithQuantRowOffset<T, accT>::PackAWithQuantRowOffset(
             PackingTraits<T, accT, inst_set_t::avx512>::getMatrixPackAParams();
         break;
 
+      case inst_set_t::avx512_ymm:
+        std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
+            PackingTraits<T, accT, inst_set_t::avx512_ymm>::
+              getMatrixPackAParams();
+        break;
+
       case inst_set_t::avx2:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
             PackingTraits<T, accT, inst_set_t::avx2>::getMatrixPackAParams();

--- a/src/PackAWithRowOffset.cc
+++ b/src/PackAWithRowOffset.cc
@@ -63,6 +63,12 @@ PackAWithRowOffset<T, accT>::PackAWithRowOffset(
             PackingTraits<T, accT, inst_set_t::avx512>::getMatrixPackAParams();
         break;
 
+      case inst_set_t::avx512_ymm:
+        std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
+            PackingTraits<T, accT, inst_set_t::avx512_ymm>::
+              getMatrixPackAParams();
+        break;
+
       case inst_set_t::avx2:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_B_) =
             PackingTraits<T, accT, inst_set_t::avx2>::getMatrixPackAParams();

--- a/src/PackBMatrix.cc
+++ b/src/PackBMatrix.cc
@@ -207,6 +207,12 @@ PackBMatrix<T, accT>::PackBMatrix(
             PackingTraits<T, accT, inst_set_t::avx512>::getMatrixPackBParams();
         break;
 
+      case inst_set_t::avx512_ymm:
+        std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_) =
+            PackingTraits<T, accT, inst_set_t::avx512_ymm>::
+              getMatrixPackBParams();
+        break;
+
       case inst_set_t::avx2:
         std::tie(BaseType::brow_, BaseType::bcol_, row_interleave_) =
             PackingTraits<T, accT, inst_set_t::avx2>::getMatrixPackBParams();

--- a/src/PackMatrix.cc
+++ b/src/PackMatrix.cc
@@ -63,6 +63,12 @@ int PackMatrix<PT, inpType, accType>::packedBufferSize(
         KCB = PackingTraits<inpType, accType, inst_set_t::avx512>::KCB;
         break;
 
+      case inst_set_t::avx512_ymm:
+        MCB = PackingTraits<inpType, accType, inst_set_t::avx512_ymm>::MCB;
+        NCB = PackingTraits<inpType, accType, inst_set_t::avx512_ymm>::NCB;
+        KCB = PackingTraits<inpType, accType, inst_set_t::avx512_ymm>::KCB;
+        break;
+
       case inst_set_t::avx2:
         MCB = PackingTraits<inpType, accType, inst_set_t::avx2>::MCB;
         NCB = PackingTraits<inpType, accType, inst_set_t::avx2>::NCB;


### PR DESCRIPTION
Summary:
Add support for AVX512_256(YMM)
Extend Packing Trains to be close to AVX2, it will require further calibration based on common dimensions
Provide template specialization for the new uArch, differences between AVX2 / AVX512_256 handled by specialization of generators for conflicting instructions

Differential Revision: D22921051

