### PR TITLE
add missing cpuinfo initialize in weight packing for group conv

### DIFF
--- a/src/PackWeightMatrixForGConv.cc
+++ b/src/PackWeightMatrixForGConv.cc
@@ -21,6 +21,9 @@ PackWeightMatrixForGConv<T, accT, SPATIAL_DIM>::PackWeightMatrixForGConv(
     const T* sdata,
     T* pdata)
     : trans_(trans), conv_param_(conv_param), sdata_(sdata) {
+  if (!cpuinfo_initialize()) {
+    throw std::runtime_error("Failed to initialize cpuinfo!");
+  }
   if (!pdata) {
     bufAllocatedHere_ = true;
     int kernel_prod = std::accumulate(


### PR DESCRIPTION
Summary: fix a bug where groupwise convolution weight packing code path is always default to avx2

Reviewed By: dskhudia

Differential Revision: D23003412

