### PR TITLE
Fix for illegal instruction issue on windows

### DIFF
--- a/src/GenerateKernelU8S8S32ACC16.cc
+++ b/src/GenerateKernelU8S8S32ACC16.cc
@@ -55,8 +55,8 @@ genComputeBlock<inst_set_t::avx2>(
  * 16-bit Accumulation kernel.
  */
 template <>
-template <typename VecT, int VecLen>
-void CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::storeCRegs(
+template <>
+void CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::storeCRegs<x86::Ymm, 32>(
     x86::Emitter* a,
     int rowRegs,
     int colRegs,


### PR DESCRIPTION
Summary: Windows tests sometimes fail with illegal instructions. I think this should fix it. I believe storeCRegs was getting picked from avx512 implementation.

Reviewed By: efiks

Differential Revision: D23034784

