### PR TITLE
fix avx512 build with non-avx code

### DIFF
--- a/src/GroupwiseConvAcc32Avx512.cc
+++ b/src/GroupwiseConvAcc32Avx512.cc
@@ -8,7 +8,6 @@
 #include <asmjit/asmjit.h>
 #include "./CodeGenHelpers.h"
 #include "./GroupwiseConv.h"
-#include "fbgemm/Fbgemm.h"
 
 namespace fbgemm {
 

--- a/src/QuantUtilsAvx512.cc
+++ b/src/QuantUtilsAvx512.cc
@@ -9,8 +9,8 @@
 #include <immintrin.h>
 #include <algorithm> //for std::min/std::max
 #include <cmath> //for nearbyint
+#include <assert.h>
 #include <limits> //for numeric_limits
-#include "fbgemm/Fbgemm.h" //for ReQuantizeOutput
 
 namespace fbgemm {
 


### PR DESCRIPTION
Summary: do not include fbgemm.h in avx512 code

Differential Revision: D23234306

