### PR TITLE
Move embedding quantization kernels to fbgemm for better sharing between C2/PT

### DIFF
--- a/bench/EmbeddingQuantizeBenchmark.cc
+++ b/bench/EmbeddingQuantizeBenchmark.cc
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <chrono>
+#include <initializer_list>
+#include <iomanip>
+#include <iostream>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#include "./BenchUtils.h"
+#include "fbgemm/QuantUtils.h"
+#include "fbgemm/Types.h"
+
+using namespace std;
+using namespace fbgemm;
+
+void performance_test() {
+  constexpr int NWARMUP = 4;
+  constexpr int NITER = 256;
+
+  cout << setw(8) << "bit_rate"
+       << ", " << setw(6) << "rows"
+       << "," << setw(6) << "cols"
+       << "," << setw(16) << "elems_per_usec"
+       << "," << setw(10) << "GB/Sec" << endl;
+  for (int bit_rate : {2, 4, 8}) {
+    for (int rowSize : {100, 120, 1000}) {
+      for (int colSize : {16, 64, 128, 256, 512, 1024, 2048}) {
+        aligned_vector<float> inpVec(rowSize * colSize);
+        randFill<float>(inpVec, -10.0f, 10.0f);
+
+        int elements_per_byte = 8 / bit_rate;
+        int out_emb_cols =
+            (colSize + elements_per_byte - 1) / elements_per_byte;
+        int outVecSize = rowSize * (out_emb_cols + 2 * sizeof(float16));
+        aligned_vector<uint8_t> outVec(outVecSize);
+
+        double duration = 0.0f;
+
+        duration = measureWithWarmup(
+            [&]() {
+              FloatToFusedNBitRowwiseQuantizedSBHalf(
+                  bit_rate, inpVec.data(), rowSize, colSize, outVec.data());
+            },
+            NWARMUP,
+            NITER,
+            [&]() {
+              cache_evict(inpVec);
+              cache_evict(outVec);
+            });
+
+        float elements_per_usec = rowSize * colSize / (duration * 1e6);
+
+        duration *= 1e9; // convert to ns
+        long bytes_read = rowSize * colSize * sizeof(float);
+        float gigabyes_per_sec = bytes_read / duration;
+
+        cout << setw(8) << bit_rate << "," << setw(6) << rowSize << ", "
+             << setw(6) << colSize << ",";
+        cout << setw(16) << std::fixed << std::setprecision(2) << elements_per_usec << ", ";
+        cout << setw(10) << std::fixed << std::setprecision(2) << gigabyes_per_sec << endl;
+      } // for each cols
+    } // for each rows
+  } // for each bit_rate
+} // performance_test
+
+int main() {
+#ifdef _OPENMP
+  // Use 1 thread unless OMP_NUM_THREADS is explicit set.
+  const char* val = getenv("OMP_NUM_THREADS");
+  if (val == nullptr || !*val) {
+    omp_set_num_threads(1);
+  }
+#endif
+  performance_test();
+  return 0;
+}

--- a/include/fbgemm/QuantUtils.h
+++ b/include/fbgemm/QuantUtils.h
@@ -155,14 +155,15 @@ void Dequantize(
 
 template <typename T>
 T FusedQuantizeDequantize(float src, const TensorQuantizationParams& qparams) {
-  T q = Quantize<T, false>(src, qparams.zero_point, qparams.scale, qparams.precision);
+  T q = Quantize<T, false>(
+      src, qparams.zero_point, qparams.scale, qparams.precision);
   return Dequantize<T>(q, qparams);
 }
 
 /*
-Fused integer quantization dequantization kernel to accelerate quantization-aware training.
-Quantize fp32 values in src to (u)int8 using the provided qparams, and dequantize quantized
-integer values back into fp32.
+Fused integer quantization dequantization kernel to accelerate
+quantization-aware training. Quantize fp32 values in src to (u)int8 using the
+provided qparams, and dequantize quantized integer values back into fp32.
 */
 template <typename T>
 FBGEMM_API void FusedQuantizeDequantize(
@@ -248,4 +249,29 @@ FBGEMM_API void Requantize(
     int thread_id = 0,
     int num_threads = 1);
 
+/**
+ * Convert float inputs to rowwise quantized outputs.
+ * bitrate specifies the number of bits in quantized output.
+ * Scale and Bias are in fp16. Each row's Scale and Bias are stored in
+ * the row itself (fused) at the end.
+ *
+ * @param bit_rate can be 2, 4, or 8
+ */
+FBGEMM_API void FloatToFusedNBitRowwiseQuantizedSBHalf(
+    int bit_rate,
+    const float* input,
+    int input_rows,
+    int input_columns,
+    std::uint8_t* output);
+
+/**
+ * Same as FloatToFusedNBitRowwiseQuantizedSBHalf but unoptimized.
+ * This should not be called directly except in testing.
+ */
+FBGEMM_API void FloatToFusedNBitRowwiseQuantizedSBHalfRef(
+    int bit_rate,
+    const float* input,
+    int input_rows,
+    int input_columns,
+    std::uint8_t* output);
 } // namespace fbgemm

--- a/include/fbgemm/QuantUtilsAvx2.h
+++ b/include/fbgemm/QuantUtilsAvx2.h
@@ -119,4 +119,11 @@ FBGEMM_API void requantizeForFloatAvx2(
     int ld_in,
     const requantizationForFloatParams_t& r);
 
+template <int BIT_RATE>
+void FloatToFusedNBitRowwiseQuantizedSBHalfAvx2(
+    const float* input,
+    int input_rows,
+    int input_columns,
+    std::uint8_t* output);
+
 } // namespace fbgemm


### PR DESCRIPTION
Summary: Moves the kernel to fbgemm that quantizes embedding to 8, 4 or 2 bits with half scale/bias.

Differential Revision: D23320018

