### PR TITLE
Fix gcc-9 compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,10 +112,16 @@ if(MSVC)
   target_compile_options(fbgemm_avx512 PRIVATE "/arch:AVX512")
 else(MSVC)
   target_compile_options(fbgemm_avx2 PRIVATE
-    "-m64" "-mavx2" "-mf16c" "-mfma" "-masm=intel")
+    "-m64" "-mavx2" "-mf16c" "-mfma")
   target_compile_options(fbgemm_avx512 PRIVATE
     "-m64" "-mavx2" "-mfma" "-mavx512f" "-mavx512bw" "-mavx512dq"
-    "-mavx512vl" "-masm=intel")
+    "-mavx512vl")
+  set_source_files_properties(src/FbgemmFP16UKernelsAvx2.cc
+    PROPERTIES COMPILE_FLAGS "-masm=intel")
+  set_source_files_properties(src/FbgemmFP16UKernelsAvx512.cc
+    PROPERTIES COMPILE_FLAGS "-masm=intel")
+  set_source_files_properties(src/FbgemmFP16UKernelsAvx512_256.cc
+    PROPERTIES COMPILE_FLAGS "-masm=intel")
 endif(MSVC)
 
 if(USE_SANITIZER)


### PR DESCRIPTION
Do not compile FBGEMM code with `-masm=intel` flag by default, because it would emit invalid assembly for `_mm512_mul_ps`