### PR TITLE
remove NewType in SparseAdaGradSignature

### DIFF
--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -168,7 +168,6 @@ class SparseAdaGradSignature {
       float epsilon,
       float lr,
       float weight_decay)>;
-  using NewType = Type;
 };
 
 template <typename IndexType>


### PR DESCRIPTION
Summary: Left over of D24197727 (https://github.com/pytorch/FBGEMM/commit/da05c8db75799f2e88e722fce3bdda0d667ce361)

Differential Revision: D24279008

