### PR TITLE
Add missing copyright header

### DIFF
--- a/include/fbgemm/FbgemmPackMatrixB.h
+++ b/include/fbgemm/FbgemmPackMatrixB.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 #pragma once
 
 #include <assert.h>


### PR DESCRIPTION
Summary: Copyright header is missing in a recently added file

Differential Revision: D24363307

