### PR TITLE
Don't copy isa_descriptor in cblas_gemm_compute

### DIFF
--- a/include/fbgemm/FbgemmFPCommon.h
+++ b/include/fbgemm/FbgemmFPCommon.h
@@ -87,10 +87,10 @@ void cblas_gemm_compute(
   static thread_local std::unique_ptr<std::array<float, 256 * 1024>>
       scratchpad(new std::array<float, 256 * 1024>());
 
-  auto isaHandlers = getIsaHandlers<T>(iset, T());
+  const auto& isaHandlers = getIsaHandlers<T>(iset, T());
 
-  auto kernels = std::get<0>(isaHandlers);
-  auto partition = std::get<1>(isaHandlers);
+  const auto& kernels = std::get<0>(isaHandlers);
+  const auto& partition = std::get<1>(isaHandlers);
 
   // constants
   const int n = Bp.numCols(), k = Bp.numRows(), ldc = n;


### PR DESCRIPTION
Summary:
`getIsaHandlers` returns a reference to an isa_descriptor,
which is a pair of biggish (more than 1 cache line) arrays. The code
used plain old `auto`, so it forced the array to be copied, with
attendant excess memory traffic. Now it uses `const auto&` to 1)
preserve the original reference and 2) not also copy the inner arrays.

Reviewed By: jianyuh

Differential Revision: D25377581

