### PR TITLE
Fix the unit test on the trunk

### DIFF
--- a/include/fbgemm/QuantUtils.h
+++ b/include/fbgemm/QuantUtils.h
@@ -154,7 +154,7 @@ void Dequantize(
 }
 
 template <typename T>
-T FusedQuantizeDequantize(float src, const TensorQuantizationParams& qparams) {
+float FusedQuantizeDequantize(float src, const TensorQuantizationParams& qparams) {
   T q = Quantize<T, false>(
       src, qparams.zero_point, qparams.scale, qparams.precision);
   return Dequantize<T>(q, qparams);

--- a/test/GConvTest.cc
+++ b/test/GConvTest.cc
@@ -35,8 +35,8 @@ vector<QuantizationGranularity> qGranularityVals{
     QuantizationGranularity::OUT_CHANNEL};
 
 namespace {
-class fbgemmGConvAcc32Test
-    : public testing::TestWithParam<tuple<matrix_op_t, matrix_op_t>> {};
+// class fbgemmGConvAcc32Test
+//     : public testing::TestWithParam<tuple<matrix_op_t, matrix_op_t>> {};
 class fbgemmGConvAcc32WithQuantGranularityTest
     : public testing::TestWithParam<tuple<
           matrix_op_t,
@@ -47,12 +47,12 @@ class fbgemmGConvAcc32WithQuantGranularityTest
 class fbgemmGConvPackTest : public testing::TestWithParam<matrix_op_t> {};
 }; // namespace
 
-INSTANTIATE_TEST_CASE_P(
-    InstantiationName,
-    fbgemmGConvAcc32Test,
-    ::testing::Combine(
-        ::testing::Values(matrix_op_t::NoTranspose),
-        ::testing::ValuesIn(transposeVals)));
+// INSTANTIATE_TEST_CASE_P(
+//     InstantiationName,
+//     fbgemmGConvAcc32Test,
+//     ::testing::Combine(
+//         ::testing::Values(matrix_op_t::NoTranspose),
+//         ::testing::ValuesIn(transposeVals)));
 
 INSTANTIATE_TEST_CASE_P(
     InstantiationName,

--- a/test/QuantUtilsTest.cc
+++ b/test/QuantUtilsTest.cc
@@ -56,6 +56,11 @@ INSTANTIATE_TEST_CASE_P(
 
 INSTANTIATE_TEST_CASE_P(
     InstantiationName,
+    FusedQuantizeDequantizeTest,
+    ::testing::Values(1, 2, 5, 8, 9, 16, 20, 28, 32, 33));
+
+INSTANTIATE_TEST_CASE_P(
+    InstantiationName,
     EmbeddingQuantizeTest,
     ::testing::Combine(
         ::testing::ValuesIn({2, 4, 8}),


### PR DESCRIPTION
Summary: Fix the unit test failures on the FBGEMM trunk. This is for enabling D25772009

Reviewed By: jspark1105

Differential Revision: D25776605

