### PR TITLE
Fix the OSS build failure

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+set(CMAKE_CXX_STANDARD 11)
 
 if(FBGEMM_BUILD_TESTS AND NOT TARGET gtest)
   #Download Googletest framework from github if


### PR DESCRIPTION
Summary:
As title. It can pass the OSS unit tests in the PR (e.g., https://github.com/pytorch/FBGEMM/pull/473, check the green check symbol), but failed the CircleCI unit tests when committing to the trunk:
https://app.circleci.com/pipelines/github/pytorch/FBGEMM/95/workflows/f13cd5ce-8787-4564-a96d-2d7b2597b67f/jobs/476

```
/root/project/third_party/googletest/googletest/include/gtest/internal/gtest-internal.h: At global scope:
/root/project/third_party/googletest/googletest/include/gtest/internal/gtest-internal.h:1239:21: error: variadic templates only available with -std=c++11 or -std=gnu++11 [-Werror]
 template <size_t... Idx, typename... T>
                     ^
/root/project/third_party/googletest/googletest/include/gtest/internal/gtest-internal.h:1239:34: error: variadic templates only available with -std=c++11 or -std=gnu++11 [-Werror]
 template <size_t... Idx, typename... T>
```

Maybe due to c++11 support?

Differential Revision: D25799546

