### PR TITLE
Template CodeCache::getOrCreate over function

### DIFF
--- a/src/CodeCache.h
+++ b/src/CodeCache.h
@@ -44,7 +44,8 @@ class CodeCache {
 
   CodeCache(){};
 
-  VALUE getOrCreate(const KEY& key, std::function<VALUE()> generatorFunction) {
+  template<typename GENFUNC>
+  VALUE getOrCreate(const KEY& key, GENFUNC generatorFunction) {
     // Check for existence of the key
     {
 #ifdef FBGEMM_USE_SHARED_TIMED_MUTEX


### PR DESCRIPTION
Summary:
This should avoid overhead of creating & destroying a
`std::function` wrapper around the `generatorFunction` lambda every
time.

Differential Revision: D25906976

