### PR TITLE
Remove "step" from table batched Rowwise Adagrad optimizer state

### DIFF
--- a/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -558,9 +558,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         TODO: populate the supported list of optimizers
         """
         if self.optimizer == OptimType.EXACT_ROWWISE_ADAGRAD:
-            step = self.get_optimizer_buffer("iter")
             list_of_state_dict = [
-                {"step": step, "sum": _sum[0]} for _sum in self.split_optimizer_states()
+                {"sum": _sum[0]} for _sum in self.split_optimizer_states()
             ]
         else:
             raise NotImplementedError(


### PR DESCRIPTION
We have been following the open source adagrad implementation here (https://github.com/pytorch/pytorch/blob/master/torch/optim/adagrad.py#L44)
and are expecting a step for table batched rw adagrad.
Actually the OSS adagrad step is only used for lr_decay
https://github.com/pytorch/pytorch/blob/51157e802f7ad1b6cfc3c277788cc0e06e778f57/torch/optim/functional.py#L35
and table_batched has a set learning rate function
https://github.com/pytorch/FBGEMM/blob/master/fbgemm_gpu/split_table_batched_embeddings_ops.py#L653
that eliminates the need to store a step.
This diff is to remove the unnecessary step from the optimizer state.
It does not cause any code breakage or correctness issue because we set the step to a default but never used value here.
https://github.com/pytorch/FBGEMM/blob/master/fbgemm_gpu/split_table_batched_embeddings_ops.py#L544-L550
