### PR TITLE
Use 40MB instead of 6 MB for flushing the cache

### DIFF
--- a/fbgemm_gpu/bench/verify_fp16_stochastic_algo.cu
+++ b/fbgemm_gpu/bench/verify_fp16_stochastic_algo.cu
@@ -170,7 +170,7 @@ int main(int argc, char* argv[]) {
 
   std::cout << "Start stochastic algorithm tests with test_size = " << test_size
             << std::endl;
-  int cache_size = 6 * 1024 * 1024; // V100 6MB L2 cache
+  int cache_size = 40 * 1024 * 1024; // A100 40MB L2 cache
 
   f32_array.reserve(test_size);
   f16_direct_array.reserve(test_size);

--- a/fbgemm_gpu/include/fbgemm_gpu/bench_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/bench_utils.cuh
@@ -17,8 +17,8 @@ __global__ void flush_gpu(char* d_flush, char* d_flush2) {
   d_flush2[idx] = d_flush[idx];
 }
 
-void flush_cache() {
-  const int cache_size = 6 * 1024 * 1024; // V100 6MB L2 cache
+void flush_cache(int cache_size_mb=40) {
+  const int cache_size = cache_size_mb * 1024 * 1024; // A100 40MB L2 cache
   std::vector<char> flush(cache_size, (char)255);
   char* d_flush;
   char* d_flush2;
@@ -50,7 +50,7 @@ float benchmark_function(int iters, Lambda&& f) {
   CUDA_CHECK(cudaEventCreate(&stop));
   for (int i = 0; i < iters; i++) {
     float local_elapsed = 0;
-    flush_cache();
+    flush_cache(40); // A100 40MB L2 cache
     CUDA_CHECK(cudaGetLastError());
     CUDA_CHECK(cudaEventRecord(start, 0));
 


### PR DESCRIPTION
Summary: A100 has 40 MB L2 cache, while V100 has 6 MB L2 cache.

Differential Revision: D25920854

