### PR TITLE
Add is_aligned<T>() device utility function in fbgemm_cuda_utils.cuh

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
@@ -622,4 +622,11 @@ struct SharedMemory<Vec4T<at::acc_type<double, true>>> {
   }
 };
 
+// Return if the address is aligned to the type (mainly for Vec4T).
+template <class T>
+DEVICE_INLINE bool is_aligned(const void* ptr) {
+  auto iptr = reinterpret_cast<std::uintptr_t>(ptr);
+  return !(iptr % alignof(T));
+}
+
 } // namespace fbgemm_gpu


### PR DESCRIPTION
Summary:
Add `is_aligned<T>()` device utility function in `fbgemm_cuda_utils.cuh`.
Mainly will be used to check the vector types are properly aligned before accessing.

Differential Revision: D25964805

