### PR TITLE
Optimize the performance of recat_embedding_grad_output

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
@@ -622,4 +622,11 @@ struct SharedMemory<Vec4T<at::acc_type<double, true>>> {
   }
 };
 
+// Return if the address is aligned to the type (mainly for Vec4T).
+template <class T>
+DEVICE_INLINE bool is_aligned(const void* ptr) {
+  auto iptr = reinterpret_cast<std::uintptr_t>(ptr);
+  return !(iptr % alignof(T));
+}
+
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.cuh
@@ -9,6 +9,8 @@
 #include <cuda.h>
 #include "cub/block/block_reduce.cuh"
 
+#include "./fbgemm_cuda_utils.cuh"
+
 // Kernel for index hashing (template type scalar_t)
 template <typename scalar_t>
 __global__ void _index_hash_cuda_kernel(
@@ -310,24 +312,44 @@ __global__ void construct_offsets_kernel(
 // support
 template <typename scalar_t>
 __global__ void recat_copy_async_kernel(
-    const int64_t* __restrict__ dim_sum_per_rank, // 1D, dim_num
-    const int64_t* __restrict__ cum_dim_sum_per_rank, // 1D, dim_num
+    const int64_t* __restrict__ dim_sum_per_rank, // 1D, T
+    const int64_t* __restrict__ cum_dim_sum_per_rank, // 1D, T
     const scalar_t* __restrict__ go, // 2D, B x sum(mixed_D)
     scalar_t* __restrict__ sgo, // 1D, B * sum(mixed_D)
-    const int64_t dim_num,
+    const int64_t T,
     const int64_t B,
     const int64_t dim_sum) {
-  auto b_w = blockIdx.x * blockDim.y + threadIdx.y;
-  auto dim_id = b_w % dim_num;
-  auto b = b_w / dim_num;
-  if (b >= B) {
+  auto b_t = blockIdx.x * blockDim.y + threadIdx.y;
+  auto b = b_t % B;
+  auto t = b_t / B;
+
+  if (b_t >= B * T) {
     return;
   }
-  auto D_current = dim_sum_per_rank[dim_id];
-  const auto tgt_base_addr = B * cum_dim_sum_per_rank[dim_id];
-  const auto src_base_addr = cum_dim_sum_per_rank[dim_id];
-  for (int32_t d = threadIdx.x; d < D_current; d += blockDim.x) {
-    sgo[tgt_base_addr + b * D_current + d] =
-        go[b * dim_sum + src_base_addr + d];
+  auto dim_current = dim_sum_per_rank[t];
+  const auto tgt_base_addr = B * cum_dim_sum_per_rank[t];
+  const auto src_base_addr = cum_dim_sum_per_rank[t];
+
+  if (fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(
+          &sgo[tgt_base_addr + b * dim_current]) &&
+      fbgemm_gpu::is_aligned<fbgemm_gpu::Vec4T<scalar_t>>(
+          &go[src_base_addr + b * dim_sum])) {
+    int32_t d_base = dim_current / 4 * 4;
+    for (int32_t d = threadIdx.x * 4; d < d_base; d += blockDim.x * 4) {
+      fbgemm_gpu::Vec4T<scalar_t>::copy(
+          &go[src_base_addr + b * dim_sum + d],
+          &sgo[tgt_base_addr + b * dim_current + d]);
+    }
+    // Use elementwise access for the last incomplete vector.
+    for (int32_t d_left = threadIdx.x; d_base + d_left < dim_current;
+         d_left += blockDim.x) {
+      sgo[tgt_base_addr + b * dim_current + d_base + d_left] =
+          go[src_base_addr + b * dim_sum + d_base + d_left];
+    }
+  } else {
+    for (int32_t d = threadIdx.x; d < dim_current; d += blockDim.x) {
+      sgo[tgt_base_addr + b * dim_current + d] =
+          go[src_base_addr + b * dim_sum + d];
+    }
   }
 }


### PR DESCRIPTION
Summary: Apply the similar blocking strategy like D25602396. Will rebase to D25954966 before landing.

Reviewed By: jspark1105

Differential Revision: D25949447

