### PR TITLE
Use the latest philox_cuda_state API for stochastic rounding

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_template_helpers.cuh
+++ b/fbgemm_gpu/codegen/embedding_forward_template_helpers.cuh
@@ -20,5 +20,5 @@
 #include <curand_kernel.h>
 #include <mutex>
 
-#include "fbgemm_gpu/fbgemm_cuda_utils.cuh"
 #include "fbgemm_gpu/dispatch_macros.h"
+#include "fbgemm_gpu/fbgemm_cuda_utils.cuh"


### PR DESCRIPTION
Summary:
Follow up on the failure case on FP16 stochastic rounding:
- https://github.com/pytorch/pytorch/pull/50148
- D26006041 (https://github.com/pytorch/FBGEMM/commit/ceb16c985b518df45224fe50c29bcdf4e95ac1af)

From Natalia:
- https://github.com/pytorch/pytorch/pull/50916 is the fix, philox_engine_inputs is deprecated btw so if you could refactor it to use philox_cuda_state that would be great.
- instructions to change the call https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/CUDAGeneratorImpl.h#L48-L83, it will be important to use philox_cuda_state with graph capture.

Differential Revision: D26038596

