### PR TITLE
Reduce the number of launched threads in the backward pass

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_template.cu
@@ -868,7 +868,7 @@ __global__ void __launch_bounds__(kMaxThreads) grad_mean_kernel(
                 scalar_t,
                 {% endif %}
                 {{ kMaxVecsPerThread }}>
-                <<<div_round_up(linear_indices.numel(), 32 * kWarpSize),
+                <<<div_round_up(sorted_linear_indices_cumulative_run_lengths.numel(), 32 * kWarpSize),
                     dim3(kWarpSize, BT_block_size),
                     BT_block_size * sizeof(acc_type<{{ "scalar_t" if dense else "cache_t" }}, true>) * 4 * kWarpSize *
                         {{ kMaxVecsPerThread }},
@@ -919,7 +919,7 @@ __global__ void __launch_bounds__(kMaxThreads) grad_mean_kernel(
                 scalar_t,
                 {% endif %}
                 {{ kMaxVecsPerThread }}>
-                <<<div_round_up(linear_indices.numel(), kBackwardMaxThreads / kWarpSize),
+                <<<div_round_up(sorted_linear_indices_cumulative_run_lengths.numel(), kBackwardMaxThreads / kWarpSize),
                     dim3(kWarpSize, kBackwardMaxThreads / kWarpSize),
                     BT_block_size * sizeof(
                     acc_type<

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -441,7 +441,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         L=st.integers(min_value=0, max_value=20),
         fp16=st.booleans(),
         weighted=st.booleans(),
-        exact=st.booleans(),
         mixed=st.booleans(),
         use_cache=st.booleans(),
         cache_algorithm=st.sampled_from(
@@ -463,7 +462,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         L,
         fp16,
         weighted,
-        exact,
         mixed,
         use_cache,
         cache_algorithm,
@@ -486,8 +484,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             else "mean"
         )
 
-        # only non-exact supports caching
-        assume(not exact or not use_cache)
         E = int(10 ** log_E)
         if use_cpu:
             D = (D + 15) // 16 * 4
@@ -626,7 +622,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         stochastic_rounding=st.booleans(),
         weighted=st.booleans(),
         row_wise=st.booleans(),
-        exact=st.booleans(),
         mixed=st.booleans(),
         use_cache=st.booleans(),
         cache_algorithm=st.sampled_from(
@@ -650,7 +645,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         stochastic_rounding,
         weighted,
         row_wise,
-        exact,
         mixed,
         use_cache,
         cache_algorithm,
@@ -659,6 +653,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
     ):
         # NOTE: cache is not applicable to CPU version.
         assume(not use_cpu or not use_cache)
+        exact = True # Only exact sparse optimizers are supported
 
         # NOTE: torch.autograd.gradcheck() is too time-consuming for CPU version
         #       so we have to limit (T * B * L * D)!
@@ -676,8 +671,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
 
         # stochastic rounding only implemented for rowwise
         assume(not stochastic_rounding or row_wise)
-        # exact only implemented for rowwise non-weighted
-        assume(not exact or (row_wise and not weighted))
         # need unique indices for non-exact tests
         assume(exact or int(10 ** log_E) > int(2.1 * B * L))
         # only row-wise supports caching


### PR DESCRIPTION
Summary:
We only need to spawn `sorted_linear_indices_cumulative_run_lengths.numel()` for gridDim.x instead of `linear_indices.numel() `.

Note that the second is always bigger than the first due to run-length encoding: https://nvlabs.github.io/cub/structcub_1_1_device_run_length_encode.html).

Differential Revision: D26159054

