### PR TITLE
Add special handler on is_uvm_tensor checker for CPU tensor

### DIFF
--- a/fbgemm_gpu/src/cumem_utils.cu
+++ b/fbgemm_gpu/src/cumem_utils.cu
@@ -113,6 +113,9 @@ Tensor new_host_mapped_tensor(Tensor self, std::vector<std::int64_t> sizes) {
 
 // Check if a tensor is allocated with UVM or host-mapped memory
 bool is_uvm_tensor(Tensor t) {
+  if (t.device().is_cpu()) {
+    return false;
+  }
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(t.get_device());
 

--- a/fbgemm_gpu/src/cumem_utils_host.cpp
+++ b/fbgemm_gpu/src/cumem_utils_host.cpp
@@ -25,7 +25,7 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
   m.def("is_uvm_tensor(Tensor t) -> bool");
   m.impl(
       "is_uvm_tensor",
-      torch::dispatch(c10::DispatchKey::CUDA, TORCH_FN(is_uvm_tensor)));
+      torch::dispatch(c10::DispatchKey::Math, TORCH_FN(is_uvm_tensor)));
   m.def("uvm_to_cpu(Tensor t) -> Tensor");
   m.impl(
       "uvm_to_cpu",


### PR DESCRIPTION
Summary:
To increase the coverage of `is_uvm_tensor` for CPU tensors. This mainly enables the checkpointing  supports for UVM tensor.

Before this Diff:
```
>>> b = torch.Tensor([3]).cpu()
>>> torch.ops.fb.is_uvm_tensor(b)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: Could not run 'fb::is_uvm_tensor' with arguments from the 'CPU' backend. This could be because the operator doesn't exist for this backend, or was omitted during the selective/custom build process (if using custom build). If you are a Facebook employee using PyTorch on mobile, please visit https://fburl.com/ptmfixes for possible resolutions. 'fb::is_uvm_tensor' is only available for these backends: [CUDA, BackendSelect, Named, AutogradOther, AutogradCPU, AutogradCUDA, AutogradXLA, Tracer, Autocast, Batched, VmapMode].

CUDA: registered at /data/users/jianyuhuang/fbsource/fbcode/deeplearning/fbgemm/fbgemm_gpu/src/cumem_utils_host.cpp:24 [kernel]
BackendSelect: fallthrough registered at /opt/conda/conda-bld/pytorch_1607156213789/work/aten/src/ATen/core/BackendSelectFallbackKernel.cpp:3 [backend fallback]
Named: registered at /opt/conda/conda-bld/pytorch_1607156213789/work/aten/src/ATen/core/NamedRegistrations.cpp:7 [backend fallback]
AutogradOther: fallthrough registered at /opt/conda/conda-bld/pytorch_1607156213789/work/aten/src/ATen/core/VariableFallbackKernel.cpp:35 [backend fallback]
AutogradCPU: fallthrough registered at /opt/conda/conda-bld/pytorch_1607156213789/work/aten/src/ATen/core/VariableFallbackKernel.cpp:39 [backend fallback]
AutogradCUDA: fallthrough registered at /opt/conda/conda-bld/pytorch_1607156213789/work/aten/src/ATen/core/VariableFallbackKernel.cpp:43 [backend fallback]
AutogradXLA: fallthrough registered at /opt/conda/conda-bld/pytorch_1607156213789/work/aten/src/ATen/core/VariableFallbackKernel.cpp:47 [backend fallback]
Tracer: fallthrough registered at /opt/conda/conda-bld/pytorch_1607156213789/work/torch/csrc/jit/frontend/tracer.cpp:970 [backend fallback]
Autocast: fallthrough registered at /opt/conda/conda-bld/pytorch_1607156213789/work/aten/src/ATen/autocast_mode.cpp:254 [backend fallback]
Batched: registered at /opt/conda/conda-bld/pytorch_1607156213789/work/aten/src/ATen/BatchingRegistrations.cpp:957 [backend fallback]
VmapMode: fallthrough registered at /opt/conda/conda-bld/pytorch_1607156213789/work/aten/src/ATen/VmapModeRegistrations.cpp:33 [backend fallback]
```

After the Diff:
```
>>> torch.ops.fb.is_uvm_tensor(b)
False
```

Differential Revision: D26166647

