### PR TITLE
Revert the changes on reducing the thread block number in BWD

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_template.cu
@@ -879,7 +879,7 @@ __global__ void __launch_bounds__(kMaxThreads) grad_mean_kernel(
                 scalar_t,
                 {% endif %}
                 {{ kMaxVecsPerThread }}>
-                <<<div_round_up(sorted_linear_indices_cumulative_run_lengths.numel(), 32 * kWarpSize),
+                <<<div_round_up(linear_indices.numel(), 32 * kWarpSize),
                     dim3(kWarpSize, BT_block_size),
                     BT_block_size * sizeof(acc_type<{{ "scalar_t" if dense else "cache_t" }}, true>) * 4 * kWarpSize *
                         {{ kMaxVecsPerThread }},
@@ -930,7 +930,7 @@ __global__ void __launch_bounds__(kMaxThreads) grad_mean_kernel(
                 scalar_t,
                 {% endif %}
                 {{ kMaxVecsPerThread }}>
-                <<<div_round_up(sorted_linear_indices_cumulative_run_lengths.numel(), kBackwardMaxThreads / kWarpSize),
+                <<<div_round_up(linear_indices.numel(), kBackwardMaxThreads / kWarpSize),
                     dim3(kWarpSize, kBackwardMaxThreads / kWarpSize),
                     BT_block_size * sizeof(
                     acc_type<


### PR DESCRIPTION
Summary: As pointed out by Andrew in D26159054 (https://github.com/pytorch/FBGEMM/commit/1962324c964c482056e35139eb1b4baca396935d), we need the explicit DtoH synchronization to make sure `sorted_linear_indices_cumulative_run_lengths` or `sorted_linear_indices_num_runs` or `sorted_linear_indices_run_lengths.numel() ` is read correctly on the host side for the number of the thread block we launch. This will cause some overhead and it might not be worth it.

Reviewed By: jspark1105

Differential Revision: D26178974

