### PR TITLE
fix thread block size issue for cooperlake

### DIFF
--- a/src/ExecuteKernelU8S8.cc
+++ b/src/ExecuteKernelU8S8.cc
@@ -127,6 +127,17 @@ void ExecuteKernel<
   bool lastKBlock = packedB_.isThisLastKBlock(kBlock % packedB_.blockRows());
   bool accum = (kBlock % packedB_.blockRows()) > 0;
 
+  int jb_begin, jb_end;
+  fbgemmPartition1D(
+      th_info_.n_thread_id,
+      th_info_.n_num_threads,
+      bColBlocks,
+      jb_begin,
+      jb_end);
+  if (jb_end == jb_begin) {
+    return;
+  }
+
   typename BaseType::jit_micro_kernel_fp fn;
 
   const inst_set_t isa = fbgemmInstructionSet();
@@ -203,13 +214,6 @@ void ExecuteKernel<
   t_start = std::chrono::high_resolution_clock::now();
 #endif
 
-  int jb_begin, jb_end;
-  fbgemmPartition1D(
-      th_info_.n_thread_id,
-      th_info_.n_num_threads,
-      bColBlocks,
-      jb_begin,
-      jb_end);
   for (int jb = jb_begin; jb < jb_end; ++jb) {
     if (jb == bColBlocks - 1) {
       int nc = ((packedB_.lastBcol() - 1) / nrMinSize_ + 1) * nrMinSize_;

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -419,13 +419,22 @@ int fbgemmGet2DPartition(
   // bm: number of rows assigned per thread block (bm = ceil(m/mb)).
   // bn: number of cols assigned per thread block (bn = ceil(n/nb)).
   // find mb and nb such that bm / bn is as close as possible to aspect_ratio.
+
+  // for large thread numbers, we would like to reduce the aspect_ratio ---
+  // if the matrix is short-and-fat
+  // this allows us to assign more parallelism to i-dimension
+  if (nthreads > 16 && m/n < 0.2) {
+    aspect_ratio = 0.2;
+  }
   int mb = 1;
   int nb = nthreads / mb;
   int bm = (m + mb - 1) / mb;
   int bn = ((n + n_align - 1) / n_align + nb - 1) / nb * n_align;
   double best_delta = std::abs(static_cast<double>(bm) / bn - aspect_ratio);
+
   for (int mb_candidate = 2; mb_candidate <= nthreads; mb_candidate++) {
-    if (nthreads % mb_candidate != 0) {
+    // so mb does not need to divide nthreads
+    if (nthreads % mb_candidate != 0 && nthreads <=16) {
       continue;
     }
     int nb_candidate = nthreads / mb_candidate;


### PR DESCRIPTION
Summary:
Only machines like cooperlake which has relatively large number of cores (26 cores), current FBGEMM didn't spawn enough threads.
For example, when the input matrix size is 42 300 300, running with 26 threads would have lower GOps than 16 threads.
One reason is that FBGEMM would only spawn 7 threads due to the current thread partition logic --- 1 partition at i-dimenion, and 7-partitions at j-dimension.
In this fix, we lowered the aspect_ratio limit for the thread partitioner so that it allows more partitions on the i-dimension when the input matrix is short-and-fat.
After the fix, the partitioner can spawn 21 threads ( 3 x 7) .

Before this fix
{F364946463}

 After this fix:
{F365007641}

Differential Revision: D26107796

