### PR TITLE
Adaptive Weight decay based on Sparse feature ID frequency.

### DIFF
--- a/.github/workflows/fbgemmci.yml
+++ b/.github/workflows/fbgemmci.yml
@@ -54,7 +54,7 @@ jobs:
         mkdir build_static
         cd build_static
         cmake -DUSE_SANITIZER=address -DFBGEMM_LIBRARY_TYPE=static ..
-        make -j
+        make
 
     - name: Test static FBGEMM lib
       if: contains(runner.os, 'linux')   # not run on macos-latest now due to supporting AVX2
@@ -69,7 +69,7 @@ jobs:
         mkdir build_shared
         cd build_shared
         cmake -DUSE_SANITIZER=address -DFBGEMM_LIBRARY_TYPE=shared ..
-        make -j
+        make
 
     - name: Test shared FBGEMM lib
       if: contains(runner.os, 'linux')   # not run on macos-latest now due to supporting AVX2

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,7 +5,7 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
-load("defs.bzl", "get_fbgemm_avx2_srcs", "get_fbgemm_avx512_srcs", "get_fbgemm_base_srcs", "get_fbgemm_generic_srcs", "get_fbgemm_public_headers", "get_fbgemm_tests")
+load("defs.bzl", "get_fbgemm_avx2_srcs", "get_fbgemm_inline_avx2_srcs", "get_fbgemm_avx512_srcs", "get_fbgemm_inline_avx512_srcs", "get_fbgemm_base_srcs", "get_fbgemm_generic_srcs", "get_fbgemm_public_headers", "get_fbgemm_tests")
 
 cc_library(
     name = "fbgemm_base",
@@ -32,7 +32,9 @@ cc_library(
     ],
     deps = [
         ":fbgemm_avx2",
+        ":fbgemm_inline_avx2",
         ":fbgemm_avx512",
+        ":fbgemm_inline_avx512",
         ":fbgemm_base",
         ":fbgemm_headers",
     ],
@@ -42,6 +44,23 @@ cc_library(
 cc_library(
     name = "fbgemm_avx2",
     srcs = get_fbgemm_avx2_srcs(),
+    hdrs = glob(["src/*.h"]),
+    copts = [
+        "-m64",
+        "-mavx2",
+        "-mfma",
+        "-mf16c",
+    ],
+    deps = [
+        ":fbgemm_base",
+        ":fbgemm_headers",
+    ],
+    linkstatic = 1,
+)
+
+cc_library(
+    name = "fbgemm_inline_avx2",
+    srcs = get_fbgemm_inline_avx2_srcs(),
     hdrs = glob(["src/*.h"]),
     copts = [
         "-m64",
@@ -60,6 +79,25 @@ cc_library(
 cc_library(
     name = "fbgemm_avx512",
     srcs = get_fbgemm_avx512_srcs(),
+    hdrs = glob(["src/*.h"]),
+    copts = [
+        "-m64",
+        "-mfma",
+        "-mavx512f",
+        "-mavx512bw",
+        "-mavx512dq",
+        "-mavx512vl",
+    ],
+    deps = [
+        ":fbgemm_base",
+        ":fbgemm_headers",
+    ],
+    linkstatic = 1,
+)
+
+cc_library(
+    name = "fbgemm_inline_avx512",
+    srcs = get_fbgemm_inline_avx512_srcs(),
     hdrs = glob(["src/*.h"]),
     copts = [
         "-m64",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,12 +71,17 @@ endif()
 # Define file lists
 get_filelist("get_fbgemm_generic_srcs(with_base=True)" FBGEMM_GENERIC_SRCS)
 get_filelist("get_fbgemm_avx2_srcs(msvc=${MSVC_BOOL})" FBGEMM_AVX2_SRCS)
+get_filelist("get_fbgemm_inline_avx2_srcs(msvc=${MSVC_BOOL})"
+  FBGEMM_AVX2_INLINE_SRCS)
 get_filelist("get_fbgemm_avx512_srcs(msvc=${MSVC_BOOL})" FBGEMM_AVX512_SRCS)
+get_filelist("get_fbgemm_inline_avx512_srcs(msvc=${MSVC_BOOL})"
+  FBGEMM_AVX512_INLINE_SRCS)
 get_filelist("get_fbgemm_public_headers()" FBGEMM_PUBLIC_HEADERS)
 
 add_library(fbgemm_generic OBJECT ${FBGEMM_GENERIC_SRCS})
-add_library(fbgemm_avx2 OBJECT ${FBGEMM_AVX2_SRCS})
-add_library(fbgemm_avx512 OBJECT ${FBGEMM_AVX512_SRCS})
+add_library(fbgemm_avx2 OBJECT ${FBGEMM_AVX2_SRCS} ${FBGEMM_AVX2_INLINE_SRCS})
+add_library(fbgemm_avx512 OBJECT
+  ${FBGEMM_AVX512_SRCS} ${FBGEMM_AVX512_INLINE_SRCS})
 
 # Make libraries depend on defs.bzl
 add_custom_target(defs.bzl DEPENDS defs.bzl)

--- a/defs.bzl
+++ b/defs.bzl
@@ -83,6 +83,10 @@ def get_fbgemm_avx2_srcs(msvc = False):
         "src/PackDepthwiseConvMatrixAvx2.cc",
         "src/QuantUtilsAvx2.cc",
         "src/UtilsAvx2.cc",
+    ]
+
+def get_fbgemm_inline_avx2_srcs(msvc = False):
+    return [
         #FP16 kernels contain inline assembly and inline assembly syntax for MSVC is different.
         "src/FbgemmFP16UKernelsAvx2.cc" if not msvc else "src/FbgemmFP16UKernelsIntrinsicAvx2.cc",
     ]
@@ -94,6 +98,10 @@ def get_fbgemm_avx512_srcs(msvc = False):
         "src/FbgemmFloat16ConvertAvx512.cc",
         "src/QuantUtilsAvx512.cc",
         "src/UtilsAvx512.cc",
+    ]
+
+def get_fbgemm_inline_avx512_srcs(msvc = False):
+    return [
         #FP16 kernels contain inline assembly and inline assembly syntax for MSVC is different.
         "src/FbgemmFP16UKernelsAvx512.cc" if not msvc else "src/FbgemmFP16UKernelsIntrinsicAvx512.cc",
         "src/FbgemmFP16UKernelsAvx512_256.cc" if not msvc else "src/FbgemmFP16UKernelsIntrinsicAvx512_256.cc",

--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -170,9 +170,41 @@ class SparseAdaGradSignature {
       float weight_decay)>;
 };
 
+/**
+ * @return The number of rows processed. If smaller than num_rows, an error
+ *         must have happened at the last row processed.
+ */
+template <typename IndexType>
+class SparseAdaGradSignatureNew {
+ public:
+  using Type = std::function<int(
+      int num_rows, // number of rows reading
+      std::uint64_t param_size, // total number of parameters
+      float* w, // input/output parameters
+      const float* g, // input gradients
+      float* h, // input/output momentums
+      const IndexType* indices, // indices of each row
+      float epsilon,
+      float lr,
+      float weight_decay,
+      const double* counter, // used for weight_decay adjusted for frequency
+                             // nullptr when frequency adjustment is not used.
+                             // ignored when the kernel is generated with
+                             // use_weight_decay = false.
+      std::int64_t counter_halflife)>; // frequency adjust happens only after
+};
+
 template <typename IndexType>
 FBGEMM_API typename SparseAdaGradSignature<IndexType>::Type
 GenerateSparseAdaGrad(
+    int block_size, // number of parameters per row
+    bool rowwise = false,
+    int prefetch = 16,
+    bool use_weight_decay = false);
+
+template <typename IndexType>
+FBGEMM_API typename SparseAdaGradSignatureNew<IndexType>::Type
+GenerateSparseAdaGradNew(
     int block_size, // number of parameters per row
     bool rowwise = false,
     int prefetch = 16,

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -9,9 +9,9 @@
 #include <algorithm>
 #include <cstdint>
 
-#include "fbgemm/Types.h"
 #include "fbgemm/ConvUtils.h"
 #include "fbgemm/FbgemmI8Spmdm.h"
+#include "fbgemm/Types.h"
 
 namespace fbgemm {
 
@@ -286,31 +286,63 @@ FBGEMM_API bool EmbeddingSpMDMNBitRowWiseSparse_ref(
     bool is_weight_positional = false,
     bool use_offsets = true);
 
+/**
+ * @param num_rows number of rows reading
+ * @param block_size number of parameters per rows
+ * @param param_size total number of parameters
+ * @param w input parameters
+ * @param g input gradients
+ * @param h input momentum
+ * @param indices indices of each row
+ * @param counter used for weight_decay adjusted for frequency. nullptr when
+ *                frequency adjustment is not used. Ignored when weight_decay
+ *                == 0
+ * @param counter_halflife weight_decay is adjusted only after this number of
+ *                         iterations
+ */
 template <typename IndexType>
 FBGEMM_API int sparse_adagrad_ref(
-    int num_rows, // number of rows reading
-    int block_size, // number of parameters per rows
-    std::uint64_t param_size, // total number of parameters
-    float* w, // input parameters
-    const float* g, // input gradients
-    float* h, // input momentums
-    const IndexType* indices, // indices of each row
+    int num_rows,
+    int block_size,
+    std::uint64_t param_size,
+    float* w,
+    const float* g,
+    float* h,
+    const IndexType* indices,
     float epsilon,
     float lr,
-    float weight_decay = 0.f);
+    float weight_decay = 0.f,
+    const double* counter = nullptr,
+    const int64_t counter_halflife = 0);
 
+/**
+ * @param num_rows number of rows reading
+ * @param block_size number of parameters per rows
+ * @param param_size total number of parameters
+ * @param w input parameters
+ * @param g input gradients
+ * @param h input momentum
+ * @param indices indices of each row
+ * @param counter used for weight_decay adjusted for frequency. nullptr when
+ *                frequency adjustment is not used. Ignored when weight_decay
+ *                == 0
+ * @param counter_halflife weight_decay is adjusted only after this number of
+ *                         iterations
+ */
 template <typename IndexType>
 FBGEMM_API int rowwise_sparse_adagrad_ref(
-    int num_rows, // number of rows reading
-    int block_size, // number of parameters per rows
-    std::uint64_t param_size, // total number of parameters
-    float* w, // input parameters
-    const float* g, // input gradients
-    float* h, // input momentums
-    const IndexType* indices, // indices of each row
+    int num_rows,
+    int block_size,
+    std::uint64_t param_size,
+    float* w,
+    const float* g,
+    float* h,
+    const IndexType* indices,
     float epsilon,
     float lr,
-    float weight_decay = 0.f);
+    float weight_decay = 0.f,
+    const double* counter = nullptr,
+    const int64_t counter_halflife = 0);
 
 template <typename DataType, typename IndexType, typename OffsetType>
 FBGEMM_API int rowwise_sparse_adagrad_fused_ref(


### PR DESCRIPTION
Summary:
Add an option to adjust weight decay based on the update frequency of each embedding
Add a new interface to maintain backward compatibility. Will need multiple steps of changes btw fbgemm and Caffe2.

Differential Revision: D26210974

