### PR TITLE
remove old sparse adagrad interface

### DIFF
--- a/bench/RowwiseAdagradBenchmark.cc
+++ b/bench/RowwiseAdagradBenchmark.cc
@@ -85,7 +85,9 @@ void run_benchmark(
            indices.data(), // indices of each row
            epsilon,
            lr,
-           0.0f); // weight_decay
+           0.0f, // weight_decay
+           nullptr, // counters
+           0); // counter_halflife
       },
       NUM_WARMUP,
       NUM_ITER,

--- a/bench/SparseAdagradBenchmark.cc
+++ b/bench/SparseAdagradBenchmark.cc
@@ -93,7 +93,9 @@ void run_benchmark(
               indices.data(), // indices of each row
               epsilon,
               lr,
-              0.0f); // weight_decay
+              0.0f, // weight_decay
+              nullptr, // counters
+              0); // counter_halflife
         },
         NUM_WARMUP,
         NUM_ITER,
@@ -125,7 +127,9 @@ void run_benchmark(
               indices_32.data(), // indices of each row
               epsilon,
               lr,
-              0.0f); // weight_decay
+              0.0f, // weight_decay
+              nullptr, // counters
+              0); // weight_decay
         },
         NUM_WARMUP,
         NUM_ITER,

--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -167,7 +167,12 @@ class SparseAdaGradSignature {
       const IndexType* indices, // indices of each row
       float epsilon,
       float lr,
-      float weight_decay)>;
+      float weight_decay,
+      const double* counter, // used for weight_decay adjusted for frequency
+                             // nullptr when frequency adjustment is not used.
+                             // ignored when the kernel is generated with
+                             // use_weight_decay = false.
+      std::int64_t counter_halflife)>; // frequency adjust happens only after
 };
 
 /**

--- a/src/SparseAdagrad.cc
+++ b/src/SparseAdagrad.cc
@@ -667,7 +667,8 @@ GenSparseAdagrad<indxType, instSet>::getOrCreate(
           a->cvtsi2sd(counter_halflife_vreg.xmm(), counter_halflife);
           a->movq(counter_vreg, temp3_);
           a->divpd(counter_halflife_vreg.xmm(), counter_vreg);
-          a->vcvtpd2ps(counter_halflife_vreg.xmm(), counter_halflife_vreg.ymm());
+          a->vcvtpd2ps(
+              counter_halflife_vreg.xmm(), counter_halflife_vreg.ymm());
           a->vbroadcastss(counter_halflife_vreg, counter_halflife_vreg.xmm());
           a->vmulps(
               adjusted_weight_decay_vreg,
@@ -883,115 +884,6 @@ typename SparseAdaGradSignature<IndexType>::Type GenerateSparseAdaGrad(
                  const IndexType* indices, // indices of each row
                  float epsilon,
                  float lr,
-                 float weight_decay) {
-        return SparseAdaGradBlockSize1_(
-            num_rows,
-            param_size,
-            w,
-            g,
-            h,
-            indices,
-            epsilon,
-            lr,
-            rowwise,
-            weight_decay,
-            nullptr,
-            0);
-      };
-    }
-    static GenSparseAdagrad<IndexType, inst_set_t::avx2> kernel_generator;
-    constexpr int VLEN = simd_info<inst_set_t::avx2>::WIDTH_32BIT_ELEMS;
-    const int* mask_avx2 = &internal::avx2_ps_or_epi32_combined_mask
-                               [(VLEN - (block_size % VLEN)) % VLEN];
-    const auto original_func = kernel_generator.getOrCreate(
-        block_size, prefetch, rowwise, use_weight_decay);
-    return [=](int num_rows, // number of rows reading
-               std::uint64_t param_size, // total number of parameters
-               float* w, // input/output parameters
-               const float* g, // input gradients
-               float* h, // input/output momentums
-               const IndexType* indices, // indices of each row
-               float epsilon,
-               float lr,
-               float weight_decay) {
-      return original_func(
-          num_rows, // number of rows reading
-          param_size, // total number of parameters
-          w, // input/output parameters
-          g, // input gradients
-          h, // input/output momentums
-          indices, // indices of each row
-          epsilon,
-          lr,
-          mask_avx2,
-          weight_decay,
-          nullptr,
-          0);
-    };
-  } else {
-#ifdef VLOG
-    VLOG(0) << "AVX2 or AVX512 not found, taking the slow path";
-#endif
-    return [=](int num_rows, // number of rows reading
-               std::uint64_t param_size, // total number of parameters
-               float* w, // input/output parameters
-               const float* g, // input gradients
-               float* h, // input/output momentums
-               const IndexType* indices, // indices of each row
-               float epsilon,
-               float lr,
-               float weight_decay) {
-      return sparse_adagrad_ref(
-          num_rows, // number of rows reading
-          block_size, // number of parameters per rows
-          param_size, // total number of parameters
-          w, // input/output parameters
-          g, // input gradients
-          h, // input/output momentums
-          indices,
-          epsilon,
-          lr,
-          weight_decay,
-          nullptr,
-          0);
-    };
-  }
-}
-
-template FBGEMM_API typename SparseAdaGradSignature<std::int64_t>::Type
-GenerateSparseAdaGrad<std::int64_t>(
-    int block_size, // number of parameters per rows
-    bool rowwise,
-    int prefetch,
-    bool use_weight_decay);
-
-template FBGEMM_API typename SparseAdaGradSignature<std::int32_t>::Type
-GenerateSparseAdaGrad<std::int32_t>(
-    int block_size, // number of parameters per rows
-    bool rowwise,
-    int prefetch,
-    bool use_weight_decay);
-
-template <typename IndexType>
-typename SparseAdaGradSignatureNew<IndexType>::Type GenerateSparseAdaGradNew(
-    int block_size,
-    bool rowwise,
-    int prefetch,
-    bool use_weight_decay) {
-  if (!cpuinfo_initialize()) {
-    throw std::runtime_error("Failed to initialize cpuinfo!");
-  }
-
-  if (fbgemmHasAvx512Support() || fbgemmHasAvx2Support()) {
-    if (block_size == 1) {
-      return [=](int num_rows, // number of rows reading
-                 std::uint64_t param_size, // total number of parameters
-                 float* w, // input/output parameters
-                 const float* g, // input gradients
-                 float* h, // input/output momentums
-                 const IndexType* indices, // indices of each row
-                 float epsilon,
-                 float lr,
                  float weight_decay,
                  const double* counter,
                  std::int64_t counter_halflife) {
@@ -1071,6 +963,30 @@ typename SparseAdaGradSignatureNew<IndexType>::Type GenerateSparseAdaGradNew(
           counter_halflife);
     };
   }
+}
+
+template FBGEMM_API typename SparseAdaGradSignature<std::int64_t>::Type
+GenerateSparseAdaGrad<std::int64_t>(
+    int block_size, // number of parameters per rows
+    bool rowwise,
+    int prefetch,
+    bool use_weight_decay);
+
+template FBGEMM_API typename SparseAdaGradSignature<std::int32_t>::Type
+GenerateSparseAdaGrad<std::int32_t>(
+    int block_size, // number of parameters per rows
+    bool rowwise,
+    int prefetch,
+    bool use_weight_decay);
+
+template <typename IndexType>
+typename SparseAdaGradSignatureNew<IndexType>::Type GenerateSparseAdaGradNew(
+    int block_size,
+    bool rowwise,
+    int prefetch,
+    bool use_weight_decay) {
+  return GenerateSparseAdaGrad<IndexType>(
+      block_size, rowwise, prefetch, use_weight_decay);
 }
 
 template FBGEMM_API typename SparseAdaGradSignatureNew<std::int64_t>::Type

--- a/test/SparseAdagradTest.cc
+++ b/test/SparseAdagradTest.cc
@@ -135,7 +135,7 @@ TEST_P(SparseAdagradTest, basicTest_two_stages) {
           adjust_weight_decay ? counters.data() : nullptr,
           counter_halflife);
 
-      auto fn_fbgemm = GenerateSparseAdaGradNew<std::int64_t>(
+      auto fn_fbgemm = GenerateSparseAdaGrad<std::int64_t>(
           block_size, false, prefetch, use_weight_decay);
 
       ret_fbgemm = fn_fbgemm(
@@ -165,7 +165,7 @@ TEST_P(SparseAdagradTest, basicTest_two_stages) {
           adjust_weight_decay ? counters.data() : nullptr,
           counter_halflife);
 
-      auto fn_fbgemm = GenerateSparseAdaGradNew<std::int32_t>(
+      auto fn_fbgemm = GenerateSparseAdaGrad<std::int32_t>(
           block_size, false, prefetch, use_weight_decay);
 
       ret_fbgemm = fn_fbgemm(
@@ -273,7 +273,7 @@ TEST_P(SparseAdagradTest, rowwiseTest_two_stages) {
           adjust_weight_decay ? counters.data() : nullptr,
           counter_halflife);
 
-      auto fn_fbgemm = GenerateSparseAdaGradNew<std::int64_t>(
+      auto fn_fbgemm = GenerateSparseAdaGrad<std::int64_t>(
           block_size, true, prefetch, use_weight_decay);
 
       ret_fbgemm = fn_fbgemm(
@@ -303,7 +303,7 @@ TEST_P(SparseAdagradTest, rowwiseTest_two_stages) {
           adjust_weight_decay ? counters.data() : nullptr,
           counter_halflife);
 
-      auto fn_fbgemm = GenerateSparseAdaGradNew<std::int32_t>(
+      auto fn_fbgemm = GenerateSparseAdaGrad<std::int32_t>(
           block_size, true, prefetch, use_weight_decay);
 
       ret_fbgemm = fn_fbgemm(


### PR DESCRIPTION
Summary: In this step, we change the old interface name (we no longer have dependency to do this after the previous diff) to incorporate new behavior.

Reviewed By: dskhudia

Differential Revision: D26232103

