### PR TITLE
remove temp interface for sparse adagrad

### DIFF
--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -175,41 +175,9 @@ class SparseAdaGradSignature {
       std::int64_t counter_halflife)>; // frequency adjust happens only after
 };
 
-/**
- * @return The number of rows processed. If smaller than num_rows, an error
- *         must have happened at the last row processed.
- */
-template <typename IndexType>
-class SparseAdaGradSignatureNew {
- public:
-  using Type = std::function<int(
-      int num_rows, // number of rows reading
-      std::uint64_t param_size, // total number of parameters
-      float* w, // input/output parameters
-      const float* g, // input gradients
-      float* h, // input/output momentums
-      const IndexType* indices, // indices of each row
-      float epsilon,
-      float lr,
-      float weight_decay,
-      const double* counter, // used for weight_decay adjusted for frequency
-                             // nullptr when frequency adjustment is not used.
-                             // ignored when the kernel is generated with
-                             // use_weight_decay = false.
-      std::int64_t counter_halflife)>; // frequency adjust happens only after
-};
-
 template <typename IndexType>
 FBGEMM_API typename SparseAdaGradSignature<IndexType>::Type
 GenerateSparseAdaGrad(
-    int block_size, // number of parameters per row
-    bool rowwise = false,
-    int prefetch = 16,
-    bool use_weight_decay = false);
-
-template <typename IndexType>
-FBGEMM_API typename SparseAdaGradSignatureNew<IndexType>::Type
-GenerateSparseAdaGradNew(
     int block_size, // number of parameters per row
     bool rowwise = false,
     int prefetch = 16,

--- a/src/SparseAdagrad.cc
+++ b/src/SparseAdagrad.cc
@@ -979,28 +979,4 @@ GenerateSparseAdaGrad<std::int32_t>(
     int prefetch,
     bool use_weight_decay);
 
-template <typename IndexType>
-typename SparseAdaGradSignatureNew<IndexType>::Type GenerateSparseAdaGradNew(
-    int block_size,
-    bool rowwise,
-    int prefetch,
-    bool use_weight_decay) {
-  return GenerateSparseAdaGrad<IndexType>(
-      block_size, rowwise, prefetch, use_weight_decay);
-}
-
-template FBGEMM_API typename SparseAdaGradSignatureNew<std::int64_t>::Type
-GenerateSparseAdaGradNew<std::int64_t>(
-    int block_size, // number of parameters per rows
-    bool rowwise,
-    int prefetch,
-    bool use_weight_decay);
-
-template FBGEMM_API typename SparseAdaGradSignatureNew<std::int32_t>::Type
-GenerateSparseAdaGradNew<std::int32_t>(
-    int block_size, // number of parameters per rows
-    bool rowwise,
-    int prefetch,
-    bool use_weight_decay);
-
 } // namespace fbgemm


### PR DESCRIPTION
Summary: As a final step, we remove the temp duplicated interface.

Reviewed By: dskhudia

Differential Revision: D26232204

