### PR TITLE
Further increase the supported embedding dimension for Ads limit study models

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_backward_code_generator.py
@@ -22,7 +22,7 @@ args, _ = parser.parse_known_args()
 env = jinja2.Environment(
     loader=jinja2.FileSystemLoader(os.path.dirname(os.path.abspath(__file__)))
 )
-env.globals["max_embedding_dim"] = 1024
+env.globals["max_embedding_dim"] = 4096
 env.globals["dense"] = False
 
 

--- a/fbgemm_gpu/codegen/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_template.cu
@@ -863,7 +863,7 @@ __global__ void __launch_bounds__(kMaxThreads) grad_mean_kernel(
             if (max_D <= {{ 128 * kMaxVecsPerThread }}) {
             // Stay under 64K of shared memory (96K in total), BT_block_size must be a power of two.
             // B
-            while(BT_block_size * sizeof(acc_type<{{ "scalar_t" if dense else "cache_t" }}, true>) * 4 * kWarpSize * {{ kMaxVecsPerThread }} >= 64 * 1024) {
+            while (BT_block_size * sizeof(acc_type<{{ "scalar_t" if dense else "cache_t" }}, true>) * 4 * kWarpSize * {{ kMaxVecsPerThread }} >= 64 * 1024) {
                 BT_block_size /= 2;
             }
             if (std::is_same<{{ "scalar_t" if dense else "emb_t" }}, double>::value) {


### PR DESCRIPTION
Summary:
The largest dim can be 3840 according to YazhiGao.

Downside: with larger dimension, it might take longer time to build.

Reviewed By: jspark1105

Differential Revision: D26612502

