### PR TITLE
support 8bit rowwise quantize op in OSS tests

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/quantize_ops.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/quantize_ops.cuh
@@ -241,8 +241,8 @@ __global__ void _fusednbitrowwise_to_float_cuda_kernel(
       const __half* input_row_scale_bias = reinterpret_cast<const __half*>(
           input_row +
           (output_columns + num_elem_per_byte - 1) / num_elem_per_byte);
-      float scale = input_row_scale_bias[0];
-      float bias = input_row_scale_bias[1];
+      float scale = __half2float (input_row_scale_bias[0]);
+      float bias = __half2float (input_row_scale_bias[1]);
       float* output_row = output + row * output_columns;
 
       std::uint8_t quantized = input_row[col / num_elem_per_byte];

--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -64,9 +64,7 @@ cpp_cuda_output_files = (
     ]
 )
 
-py_output_files = ["lookup_{}.py".format(optimizer) for optimizer in OPTIMIZERS] + [
-    "__init__.py",
-]
+py_output_files = ["lookup_{}.py".format(optimizer) for optimizer in OPTIMIZERS]
 
 
 def generate_jinja_files():

--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -112,6 +112,8 @@ setup(
                 os.path.join(cur_dir, "src/split_table_batched_embeddings.cpp"),
                 os.path.join(cur_dir, "src/cumem_utils.cu"),
                 os.path.join(cur_dir, "src/cumem_utils_host.cpp"),
+                os.path.join(cur_dir, "src/quantize_wrappers.cu"),
+                os.path.join(cur_dir, "src/quantize_ops_host.cpp"),
             ],
             include_dirs=[
                 cur_dir,

--- a/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -559,7 +559,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 shape = [emb.shape[0], emb.shape[1] - self.int8_emb_row_dim_offset]
                 tmp_emb = torch.zeros(shape)
                 tmp_emb.uniform_(min_val, max_val)
-                tmp_emb_i8 = torch.ops.fb.FloatToFused8BitRowwiseQuantized(tmp_emb)
+                tmp_emb_i8 = torch.ops.fb.FloatToFused8BitRowwiseQuantized(tmp_emb.cuda())
                 emb.data.copy_(tmp_emb_i8)
         else:
             for param in splits:

--- a/fbgemm_gpu/src/quantize_ops_host.cpp
+++ b/fbgemm_gpu/src/quantize_ops_host.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <ATen/ATen.h>
+#include <torch/library.h>
+
+at::Tensor _float_to_fused8bitrowwise_gpu(const at::Tensor& input);
+
+using namespace at;
+TORCH_LIBRARY_FRAGMENT(fb, m) {
+    m.def("FloatToFused8BitRowwiseQuantized(Tensor t) -> Tensor");
+    m.impl("FloatToFused8BitRowwiseQuantized", torch::dispatch(c10::DispatchKey::CUDA, TORCH_FN(_float_to_fused8bitrowwise_gpu)));
+}

--- a/fbgemm_gpu/src/quantize_wrappers.cu
+++ b/fbgemm_gpu/src/quantize_wrappers.cu
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 // Copyright 2004-present Facebook. All Rights Reserved.
+#include <ATen/ATen.h>
 #include <cuda.h>
 #include <cassert>
+#include <c10/cuda/CUDAGuard.h>
 #include "fbgemm_gpu/cuda_utils.cuh"
 #include "fbgemm_gpu/quantize_ops.cuh"
 #include "fbgemm_gpu/quantize_wrappers.cuh"
@@ -105,4 +107,31 @@ void fbgemm_gpu_test::FusedNBitRowwiseQuantizedSBHalfToFloat(
       bit_rate, input, nrows, ncols, output);
 
   CUDA_CHECK(cudaGetLastError());
+}
+
+at::Tensor _float_to_fused8bitrowwise_gpu(const at::Tensor& input) {
+  TORCH_CHECK(input.is_cuda());
+  TORCH_CHECK(input.is_contiguous());
+
+  c10::cuda::OptionalCUDAGuard device_guard;
+  device_guard.set_index(input.get_device());
+
+  const auto input_sizes = input.sizes();
+  const auto last_dim = input_sizes.size() - 1;
+  const int nrows = c10::size_to_dim_(last_dim, input_sizes);
+  const int ncols = input_sizes[last_dim];
+  const int ncols_aligned = (ncols + 4 - 1) / 4 * 4;
+  const int output_columns = ncols_aligned + 2 * sizeof(float);
+
+  auto output_dims = input_sizes.vec();
+  output_dims[last_dim] = output_columns;
+  auto output = at::empty(
+      output_dims, // 4 = sizeof(float)
+      input.options().dtype(at::kByte));
+
+  if (nrows == 0 || ncols == 0) {
+    return output;
+  }
+  fbgemm_gpu_test::FloatToFused8BitRowwiseQuantized(nrows, ncols, input.data_ptr<float>(), output.data_ptr<std::uint8_t>());
+  return output;
 }


### PR DESCRIPTION
Summary: add torch ops wrapper and python binding to enable rowwise int8 kernel for split table batched embeddings bench and unit test

Differential Revision: D26629760

