### PR TITLE
Remember cuda device for managed allocations and use it to release the managed memory.

### DIFF
--- a/fbgemm_gpu/src/cumem_utils.cu
+++ b/fbgemm_gpu/src/cumem_utils.cu
@@ -13,62 +13,64 @@
 using namespace at;
 using namespace fbgemm_gpu;
 
-// Registered CUDA managed memory (UVM) deleter
-static void CUDAManagedDeleter(void* ptr) {
-  AT_CUDA_CHECK(cudaFree(ptr));
-}
+// Freeing host/uvm memory with cudaFree[Host] requires a cuda context.
+// If a uvm tensor is released from an arbitrary thread without a context
+// then cuda helpfully create a new default context on the default device.
+// If we have not used the default device before in this process cuda
+// needs to also allocate a device context. However creating a device
+// context requires device resources and may fail with out of memory error
+// causing  cudaFree[Host] to fail with out of memory error.
+// The solution is simply to remember the device from the allocation context
+// and set the correct device in the thread before calling cudaFree[Host]
 
-// Wrapper for CUDA managed memory (UVM) allocator
-struct CUDAManagedAllocator final : public at::Allocator {
-  at::DataPtr allocate(size_t size) const override {
-    void* ptr;
-    AT_CUDA_CHECK(cudaMallocManaged(&ptr, size));
-    // User hints with "preferred location": Here the kernel will page fault
-    // and generate direct mapping to data on the CPU.
-    AT_CUDA_CHECK(cudaMemAdvise(
-        ptr, size, cudaMemAdviseSetPreferredLocation, cudaCpuDeviceId));
-    // User hints with "accessed by": GPU will establish direct mapping of data
-    // in CPU memory, no page faults will be generated
-    AT_CUDA_CHECK(cudaMemAdvise(
-        ptr, size, cudaMemAdviseSetAccessedBy, at::cuda::current_device()));
-    return {ptr,
-            ptr,
-            &CUDAManagedDeleter,
-            {at::DeviceType::CUDA, at::cuda::current_device()}};
+namespace {
+struct CUDAManagedContext {
+  void* ptr_;
+  int cuda_device_;
+
+  CUDAManagedContext(void* ptr, int cuda_device)
+      : ptr_(ptr), cuda_device_(cuda_device){};
+
+  ~CUDAManagedContext() {
+    at::cuda::OptionalCUDAGuard device_guard;
+    device_guard.set_index(cuda_device_);
+    AT_CUDA_CHECK(cudaFree(ptr_));
   }
 
-  at::DeleterFnPtr raw_deleter() const override {
-    return &CUDAManagedDeleter;
-  }
-};
-
-// Registered CUDA host-mapped memory deleter
-static void CUDAHostMappedDeleter(void* ptr) {
-  AT_CUDA_CHECK(cudaFreeHost(ptr));
-}
-
-// Wrapper for CUDA host-mapped memory allocator
-struct CUDAHostMappedAllocator final : public at::Allocator {
-  at::DataPtr allocate(size_t size) const override {
-    void* ptr;
-    AT_CUDA_CHECK(cudaHostAlloc(
-        &ptr, size, cudaHostAllocWriteCombined | cudaHostAllocMapped));
-
-    void* dev_ptr;
-    AT_CUDA_CHECK(cudaHostGetDevicePointer(&dev_ptr, ptr, 0));
-    return {dev_ptr,
-            ptr,
-            &CUDAHostMappedDeleter,
-            {at::DeviceType::CUDA, at::cuda::current_device()}};
-  }
-
-  at::DeleterFnPtr raw_deleter() const override {
-    return &CUDAHostMappedDeleter;
+  static void release(void* ptr) {
+    delete static_cast<CUDAManagedContext*>(ptr);
   }
 };
 
-static CUDAManagedAllocator g_managed_allocator;
-static CUDAHostMappedAllocator g_host_mapped_allocator;
+struct CUDAHostMappedContext {
+  void* ptr_;
+  int cuda_device_;
+
+  CUDAHostMappedContext(void* ptr, int cuda_device)
+      : ptr_(ptr), cuda_device_(cuda_device){};
+
+  ~CUDAHostMappedContext() {
+    at::cuda::OptionalCUDAGuard device_guard;
+    device_guard.set_index(cuda_device_);
+    AT_CUDA_CHECK(cudaFreeHost(ptr_));
+  }
+
+  static void release(void* ptr) {
+    delete static_cast<CUDAHostMappedContext*>(ptr);
+  }
+};
+
+// Keep a reference to the UVM memory allocation from the associated
+// CPU Tensor to prevent lifetime issues (use after free)
+struct CUDAManagedCpuContext {
+  Storage storage_;
+
+  CUDAManagedCpuContext(Storage storage) : storage_(std::move(storage)){};
+
+  static void release(void* ptr) {
+    delete static_cast<CUDAManagedCpuContext*>(ptr);
+  }
+};
 
 // Get the default strides from the input Tensor dimensions
 std::vector<int64_t> defaultStrides(IntArrayRef sizes) {
@@ -80,6 +82,7 @@ std::vector<int64_t> defaultStrides(IntArrayRef sizes) {
   }
   return strides;
 }
+} // namespace
 
 // Allocate the ATen Tensor with unified managed memory (UVM)
 Tensor new_managed_tensor(Tensor self, std::vector<std::int64_t> sizes) {
@@ -87,13 +90,30 @@ Tensor new_managed_tensor(Tensor self, std::vector<std::int64_t> sizes) {
   device_guard.set_index(self.get_device());
 
   auto strides = defaultStrides(sizes);
+  size_t size_bytes =
+      at::detail::computeStorageNbytes(sizes, strides, self.dtype().itemsize());
+  void* ptr;
+  AT_CUDA_CHECK(cudaMallocManaged(&ptr, size_bytes));
+  // User hints with "preferred location": Here the kernel will page fault
+  // and generate direct mapping to data on the CPU.
+  AT_CUDA_CHECK(cudaMemAdvise(
+      ptr, size_bytes, cudaMemAdviseSetPreferredLocation, cudaCpuDeviceId));
+  // User hints with "accessed by": GPU will establish direct mapping of data
+  // in CPU memory, no page faults will be generated
+  AT_CUDA_CHECK(cudaMemAdvise(
+      ptr, size_bytes, cudaMemAdviseSetAccessedBy, at::cuda::current_device()));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
   auto storage = Storage(
       Storage::use_byte_size_t(),
-      at::detail::computeStorageNbytes(sizes, strides, self.dtype().itemsize()),
-      &g_managed_allocator,
+      size_bytes,
+      at::DataPtr(
+          ptr,
+          new CUDAManagedContext(ptr, self.get_device()),
+          &CUDAManagedContext::release,
+          {at::DeviceType::CUDA, self.device().index()}),
+      nullptr, /* allocator */
       /*resizable=*/false);
-  auto tensor = at::empty({0}, self.options()).set_(storage, 0, sizes, strides);
-  return tensor;
+  return at::empty({0}, self.options()).set_(storage, 0, sizes, strides);
 }
 
 // Allocate the ATen Tensor with host-mapped memory
@@ -102,13 +122,26 @@ Tensor new_host_mapped_tensor(Tensor self, std::vector<std::int64_t> sizes) {
   device_guard.set_index(self.get_device());
 
   auto strides = defaultStrides(sizes);
+  size_t size_bytes =
+      at::detail::computeStorageNbytes(sizes, strides, self.dtype().itemsize());
+  void* ptr;
+  AT_CUDA_CHECK(cudaHostAlloc(
+      &ptr, size_bytes, cudaHostAllocWriteCombined | cudaHostAllocMapped));
+  void* dev_ptr;
+  AT_CUDA_CHECK(cudaHostGetDevicePointer(&dev_ptr, ptr, 0));
+
   auto storage = Storage(
       Storage::use_byte_size_t(),
-      at::detail::computeStorageNbytes(sizes, strides, self.dtype().itemsize()),
-      &g_host_mapped_allocator,
+      size_bytes,
+      at::DataPtr(
+          dev_ptr,
+          new CUDAHostMappedContext(ptr, self.get_device()),
+          &CUDAHostMappedContext::release,
+          {at::DeviceType::CUDA, self.device().index()}),
+      nullptr, /* allocator */
       /*resizable=*/false);
-  auto tensor = at::empty({0}, self.options()).set_(storage, 0, sizes, strides);
-  return tensor;
+  return at::empty({0}, self.options())
+      .set_(std::move(storage), 0, sizes, strides);
 }
 
 // Check if a tensor is allocated with UVM or host-mapped memory
@@ -116,20 +149,25 @@ bool is_uvm_tensor(Tensor t) {
   if (t.device().is_cpu()) {
     return false;
   }
-  at::cuda::OptionalCUDAGuard device_guard;
-  device_guard.set_index(t.get_device());
-
-  return t.storage().allocator() == &g_managed_allocator ||
-      t.storage().allocator() == &g_host_mapped_allocator;
+  auto deleter = t.storage().data_ptr().get_deleter();
+  return deleter == &CUDAManagedContext::release ||
+      deleter == &CUDAHostMappedContext::release;
 }
 
 // Convert a UVM tensor to a CPU tensor
 Tensor uvm_to_cpu(Tensor t) {
-  at::cuda::OptionalCUDAGuard device_guard;
-  device_guard.set_index(t.get_device());
-
   TORCH_CHECK(is_uvm_tensor(t));
-  // not copy the storage
-  return at::from_blob(
-      t.data_ptr(), t.sizes(), t.strides(), t.options().device(kCPU));
+  // Don't copy the storage - just keep a reference to the original storage
+  auto storage = Storage(
+      Storage::use_byte_size_t(),
+      t.storage().nbytes(),
+      at::DataPtr(
+          t.data_ptr(),
+          new CUDAManagedCpuContext(t.storage()),
+          &CUDAManagedCpuContext::release,
+          {at::DeviceType::CPU}),
+      nullptr, /* allocator */
+      /*resizable=*/false);
+  return at::empty({0}, t.options().device(Device::Type::CPU))
+      .set_(std::move(storage), 0, t.sizes(), t.strides());
 }

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -1298,6 +1298,9 @@ class CUMemTest(unittest.TestCase):
         assert not torch.ops.fb.is_uvm_tensor(cpu_t)
         uvm_t.copy_(cpu_t)
         assert torch.ops.fb.is_uvm_tensor(uvm_t)
+        # Test use of cpu tensor after freeing the uvm tensor
+        del uvm_t
+        cpu_t.mul_(42)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
The CUDA C-API is build around a per thread context. This context is explicitly created with cudaSetDevice() or implicitly with default device 0 by just using most cuda functions. All per thread contexts usually (unless special cuda driver API is used) share per device contexts. Those per device contexts actually require GPU device resources (memory).
When releasing the uvm tensor from an arbitrary thread  cudaFree() can be called from a thread that never had a cuda context - and cuda helpfully allocates one on device 0. For multi GPU training not all processes will have used device 0 before and will need to allocate a device context. If there are not enough resources on device 0 to create a new device context cudaFree() will fail with out of memory error.

This change creates release contexts that remember the device used on allocation and use it to set the correct device before cudaFree[Host].

While being here add a release context to the tensor created by uvm_to_cpu that keeps a reference to the uvm storage to prevent memory lifetime issues. (Use of cpu tensor after freeing original uvm tensor)

Reviewed By: jianyuh

Differential Revision: D26744596

