### PR TITLE
parallelize across T rather than B to avoid race condition in exact sgd

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
@@ -44,6 +44,7 @@ using namespace at;
   const auto weights_offsets_data = weights_offsets.accessor<int64_t, 1>();
   const auto offsets_data = offsets.accessor<int64_t, 1>();
   const auto indices_data = indices.accessor<int64_t, 1>();
+  const auto hash_size_cumsum_data = hash_size_cumsum.accessor<int64_t, 1>();
   {% if "momentum1_offsets" in args.split_function_arg_names %}
   const auto momentum1_offsets_data = momentum1_offsets.accessor<int64_t, 1>();
   {% endif %}
@@ -51,13 +52,25 @@ using namespace at;
   const auto momentum2_offsets_data = momentum2_offsets.accessor<int64_t, 1>();
   {% endif %}
 
+  int num_tables = 0; // # of physical tables
+  int table_to_feature_offset[T + 1];
+  table_to_feature_offset[0] = 0;
+  for (int feature = 0; feature < T - 1; ++feature) {
+    if (hash_size_cumsum_data[feature + 1] != hash_size_cumsum_data[feature]) {
+      ++num_tables;
+      table_to_feature_offset[num_tables] = feature + 1;
+    }
+  }
+  ++num_tables;
+  table_to_feature_offset[num_tables] = T;
+
   TORCH_CHECK(host_weights.dim() == 1);
   auto grad = zeros_like(host_weights, grad_output.dtype());
 
   AT_DISPATCH_FLOATING_TYPES(
       grad_output.scalar_type(), "split_embedding_backward_exact_cpu", [&]() {
         auto grad_data = grad.accessor<scalar_t, 1>();
-        auto indice_weights_data = indice_weights.defined()
+        const auto indice_weights_data = indice_weights.defined()
             ?
             // If indice_weights are not defined, then this accessor won't be
             // used
@@ -65,36 +78,38 @@ using namespace at;
             : grad.accessor<scalar_t, 1>(); // this is just to make compiler
                                             // happy
 
-        auto grad_output_data = grad_output.accessor<scalar_t, 2>();
+        const auto grad_output_data = grad_output.accessor<scalar_t, 2>();
 
-        for (int64_t t = 0; t < T; ++t) {
-          const auto D_begin = D_offsets_data[t];
-          const auto D = D_offsets_data[t + 1] - D_offsets_data[t];
-          const auto table_begin = weights_offsets_data[t];
-          at::parallel_for(0, B, 0, [&](int64_t b_begin, int64_t b_end) {
-            for (int64_t b = b_begin; b < b_end; ++b) {
+        at::parallel_for(0, num_tables, 0, [&](int64_t t_begin, int64_t t_end) {
+          for (int64_t t = table_to_feature_offset[t_begin];
+               t < table_to_feature_offset[t_end];
+               ++t) {
+            const auto D_begin = D_offsets_data[t];
+            const auto D = D_offsets_data[t + 1] - D_offsets_data[t];
+            const auto table_begin = weights_offsets_data[t];
+            for (int64_t b = 0; b < B; ++b) {
               const auto pool_begin = offsets_data[t * B + b];
               const auto pool_end = offsets_data[t * B + b + 1];
               const auto L = pool_end - pool_begin;
               const double scale_factor =
-                // NOTE: MEAN pooling will not work with indice_weights!
-                (pooling_mode == MEAN && !indice_weights.defined() && L > 0)
-                ? 1.0 / L
-                : 1.0;
+                  // NOTE: MEAN pooling will not work with indice_weights!
+                  (pooling_mode == MEAN && !indice_weights.defined() && L > 0)
+                  ? 1.0 / L
+                  : 1.0;
               for (auto p = pool_begin; p < pool_end; ++p) {
                 const int64_t embedding_begin =
-                  table_begin + indices_data[p] * D;
+                    table_begin + indices_data[p] * D;
                 for (int64_t d = 0; d < D; ++d) {
                   grad_data[embedding_begin + d] += scale_factor *
-                    (indice_weights.defined()
-                         ? grad_output_data[b][D_begin + d] *
-                             indice_weights_data[p]
-                         : grad_output_data[b][D_begin + d]);
+                      (indice_weights.defined()
+                           ? grad_output_data[b][D_begin + d] *
+                               indice_weights_data[p]
+                           : grad_output_data[b][D_begin + d]);
                 }
               }
-            }
-          });
-        }
+            } // for each b
+          } // for each t
+        });
       });
 
   {{ split_weight_update_cpu }}


### PR DESCRIPTION
Summary: Different batch examples can access the same embedding row

Differential Revision: D27037027

