### PR TITLE
add output stride option to embedding spmdm

### DIFF
--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -74,6 +74,24 @@ FBGEMM_API
         bool use_offsets = true);
 
 /**
+ * @param output_stride If not -1, output_stride is not same as block_size
+ */
+template <
+    typename InType,
+    typename IndexType,
+    typename OffsetType = std::int32_t>
+FBGEMM_API
+    typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType>::Type
+    GenerateEmbeddingSpMDMWithOutputStride(
+        const std::int64_t block_size,
+        bool has_weight,
+        bool normalize_by_lengths,
+        int prefetch = 16,
+        bool is_weight_positional = false,
+        bool use_offsets = true,
+        std::int64_t output_stride = -1);
+
+/**
  * @tparam IndexType can be int32_t or int64_t
  * @tparam OffsetType can be int32_t or int64_t
  * @param bit_rate can be 2 or 4

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -1097,8 +1097,12 @@ bool EmbeddingSpMDM_ref(
     bool normalize_by_lengths,
     float* out,
     bool is_weight_positional,
-    bool use_offsets) {
+    bool use_offsets,
+    int64_t output_stride /*=-1*/) {
   bool is8bit = is_same<InType, uint8_t>::value;
+  if (output_stride == -1) {
+    output_stride = block_size;
+  }
 
   if (is8bit) {
     // block_size is the number of elements and fused_block_size is the size of
@@ -1142,7 +1146,7 @@ bool EmbeddingSpMDM_ref(
           out[j] *= scale;
         }
       }
-      out += block_size;
+      out += output_stride;
     }
     return current == index_size;
   } else {
@@ -1182,7 +1186,7 @@ bool EmbeddingSpMDM_ref(
           out[j] *= scale;
         }
       }
-      out += block_size;
+      out += output_stride;
     }
     return current == index_size;
   }
@@ -1740,7 +1744,8 @@ template FBGEMM_API void transposeConvWeights(
       bool normalize_by_lengths,                                 \
       float* out,                                                \
       bool is_weight_positional,                                 \
-      bool use_offsets);                                         \
+      bool use_offsets,                                          \
+      int64_t output_stride);                                    \
   template FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(      \
       const int64_t block_size,                                  \
       const int64_t output_size,                                 \

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -230,7 +230,8 @@ FBGEMM_API bool EmbeddingSpMDM_ref(
     bool normalize_by_lengths,
     float* out,
     bool is_weight_positional = false,
-    bool use_offsets = true);
+    bool use_offsets = true,
+    std::int64_t output_stride = -1);
 
 template <typename IndexType = std::int64_t, typename OffsetType = std::int32_t>
 FBGEMM_API bool EmbeddingSpMDMNBit_ref(

--- a/test/EmbeddingSpMDMTest.cc
+++ b/test/EmbeddingSpMDMTest.cc
@@ -24,23 +24,17 @@ static vector<vector<int>> GetInputs_() {
   vector<vector<int>> input_dims = {
       // batch size, number of rows of table, emb dim , avg length
       {1, 8, 8, 4},
-      {2, 8, 16, 4},
       {10, 4000, 32, 100},
       {100, 4000, 32, 100},
-      {10, 4000, 64, 100},
       {10, 4000, 128, 100},
       {4, 400, 256, 10},
-      {10, 4000, 48, 100},
       {10, 4000, 48, 100},
       {10, 4000, 40, 100},
       {10, 4000, 56, 100},
       {10, 4000, 1, 100},
-      {10, 4000, 4, 100},
       // These were  from C2 tests
       {10, 40, 16, 10},
       {10, 40, 85, 10},
-      {10, 40, 8, 10},
-      {10, 40, 96, 10},
       {10, 40, 163, 10},
   };
   return input_dims;
@@ -57,7 +51,8 @@ class EmbeddingSpMDMTest : public testing::TestWithParam<tuple<
                                bool,
                                bool,
                                bool,
-                               EmbeddingSpMDMCornerCase>> {};
+                               EmbeddingSpMDMCornerCase,
+                               bool>> {};
 }; // namespace
 
 vector<int> prefetch_distances = {0, 16, 1000000};
@@ -78,12 +73,13 @@ INSTANTIATE_TEST_CASE_P(
             NONE,
             EMPTY_INDICES,
             OUT_OF_BOUND_INDICES,
-            UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM)));
+            UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM),
+        ::testing::Bool())); // output_stride != block_size
 
 TEST_P(EmbeddingSpMDMTest, basicTest) {
   vector<vector<int>> inputs(GetInputs_());
   bool isFp16, isIndex64b, isOffset64b, is_wt_positional, use_weight,
-      normalize_by_lengths, use_offsets;
+      normalize_by_lengths, use_offsets, use_output_stride;
   int prefetch;
   EmbeddingSpMDMCornerCase corner_case;
   tie(isFp16,
@@ -94,13 +90,15 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
       use_weight,
       normalize_by_lengths,
       use_offsets,
-      corner_case) = GetParam();
+      corner_case,
+      use_output_stride) = GetParam();
 
   for (auto input : inputs) {
     int batch_size = input[0];
     int num_rows = input[1];
     int embedding_dim = input[2];
     int average_len = input[3];
+    int output_stride = use_output_stride ? embedding_dim * 2 + 3 : -1;
 
     // Create embedding table
     vector<float> embedding_table(num_rows * embedding_dim);
@@ -139,7 +137,8 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
     const int32_t* offsets_or_lengths_32 =
         (use_offsets ? offsets_32 : lengths_32).data();
 
-    vector<float> output_sls_ref(batch_size * embedding_dim);
+    vector<float> output_sls_ref(
+        batch_size * (use_output_stride ? output_stride : embedding_dim));
     vector<float> output_slws_ref(output_sls_ref.size()),
         output_sls(output_sls_ref.size()), output_slws(output_sls_ref.size());
 
@@ -162,15 +161,18 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
               normalize_by_lengths,
               output_ref.data(),
               is_wt_positional,
-              use_offsets);
+              use_offsets,
+              output_stride);
 
-          auto kernel = GenerateEmbeddingSpMDM<float16, int64_t, int64_t>(
-              embedding_dim,
-              use_weight,
-              normalize_by_lengths,
-              prefetch,
-              is_wt_positional,
-              use_offsets);
+          auto kernel =
+              GenerateEmbeddingSpMDMWithOutputStride<float16, int64_t, int64_t>(
+                  embedding_dim,
+                  use_weight,
+                  normalize_by_lengths,
+                  prefetch,
+                  is_wt_positional,
+                  use_offsets,
+                  output_stride);
           success = kernel(
               batch_size,
               lengths_sum,
@@ -193,15 +195,18 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
               normalize_by_lengths,
               output_ref.data(),
               is_wt_positional,
-              use_offsets);
+              use_offsets,
+              output_stride);
 
-          auto kernel = GenerateEmbeddingSpMDM<float, int64_t, int64_t>(
-              embedding_dim,
-              use_weight,
-              normalize_by_lengths,
-              prefetch,
-              is_wt_positional,
-              use_offsets);
+          auto kernel =
+              GenerateEmbeddingSpMDMWithOutputStride<float, int64_t, int64_t>(
+                  embedding_dim,
+                  use_weight,
+                  normalize_by_lengths,
+                  prefetch,
+                  is_wt_positional,
+                  use_offsets,
+                  output_stride);
           success = kernel(
               batch_size,
               lengths_sum,
@@ -226,15 +231,18 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
               normalize_by_lengths,
               output_ref.data(),
               is_wt_positional,
-              use_offsets);
+              use_offsets,
+              output_stride);
 
-          auto kernel = GenerateEmbeddingSpMDM<float16, int32_t, int64_t>(
-              embedding_dim,
-              use_weight,
-              normalize_by_lengths,
-              prefetch,
-              is_wt_positional,
-              use_offsets);
+          auto kernel =
+              GenerateEmbeddingSpMDMWithOutputStride<float16, int32_t, int64_t>(
+                  embedding_dim,
+                  use_weight,
+                  normalize_by_lengths,
+                  prefetch,
+                  is_wt_positional,
+                  use_offsets,
+                  output_stride);
           success = kernel(
               batch_size,
               lengths_sum,
@@ -257,15 +265,18 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
               normalize_by_lengths,
               output_ref.data(),
               is_wt_positional,
-              use_offsets);
+              use_offsets,
+              output_stride);
 
-          auto kernel = GenerateEmbeddingSpMDM<float, int32_t, int64_t>(
-              embedding_dim,
-              use_weight,
-              normalize_by_lengths,
-              prefetch,
-              is_wt_positional,
-              use_offsets);
+          auto kernel =
+              GenerateEmbeddingSpMDMWithOutputStride<float, int32_t, int64_t>(
+                  embedding_dim,
+                  use_weight,
+                  normalize_by_lengths,
+                  prefetch,
+                  is_wt_positional,
+                  use_offsets,
+                  output_stride);
           success = kernel(
               batch_size,
               lengths_sum,
@@ -292,15 +303,18 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
               normalize_by_lengths,
               output_ref.data(),
               is_wt_positional,
-              use_offsets);
+              use_offsets,
+              output_stride);
 
-          auto kernel = GenerateEmbeddingSpMDM<float16, int64_t>(
-              embedding_dim,
-              use_weight,
-              normalize_by_lengths,
-              prefetch,
-              is_wt_positional,
-              use_offsets);
+          auto kernel =
+              GenerateEmbeddingSpMDMWithOutputStride<float16, int64_t>(
+                  embedding_dim,
+                  use_weight,
+                  normalize_by_lengths,
+                  prefetch,
+                  is_wt_positional,
+                  use_offsets,
+                  output_stride);
           success = kernel(
               batch_size,
               lengths_sum,
@@ -323,15 +337,17 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
               normalize_by_lengths,
               output_ref.data(),
               is_wt_positional,
-              use_offsets);
+              use_offsets,
+              output_stride);
 
-          auto kernel = GenerateEmbeddingSpMDM<float, int64_t>(
+          auto kernel = GenerateEmbeddingSpMDMWithOutputStride<float, int64_t>(
               embedding_dim,
               use_weight,
               normalize_by_lengths,
               prefetch,
               is_wt_positional,
-              use_offsets);
+              use_offsets,
+              output_stride);
           success = kernel(
               batch_size,
               lengths_sum,
@@ -356,15 +372,18 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
               normalize_by_lengths,
               output_ref.data(),
               is_wt_positional,
-              use_offsets);
+              use_offsets,
+              output_stride);
 
-          auto kernel = GenerateEmbeddingSpMDM<float16, int32_t>(
-              embedding_dim,
-              use_weight,
-              normalize_by_lengths,
-              prefetch,
-              is_wt_positional,
-              use_offsets);
+          auto kernel =
+              GenerateEmbeddingSpMDMWithOutputStride<float16, int32_t>(
+                  embedding_dim,
+                  use_weight,
+                  normalize_by_lengths,
+                  prefetch,
+                  is_wt_positional,
+                  use_offsets,
+                  output_stride);
           success = kernel(
               batch_size,
               lengths_sum,
@@ -387,15 +406,17 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
               normalize_by_lengths,
               output_ref.data(),
               is_wt_positional,
-              use_offsets);
+              use_offsets,
+              output_stride);
 
-          auto kernel = GenerateEmbeddingSpMDM<float, int32_t>(
+          auto kernel = GenerateEmbeddingSpMDMWithOutputStride<float, int32_t>(
               embedding_dim,
               use_weight,
               normalize_by_lengths,
               prefetch,
               is_wt_positional,
-              use_offsets);
+              use_offsets,
+              output_stride);
           success = kernel(
               batch_size,
               lengths_sum,
@@ -417,10 +438,14 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
       EXPECT_EQ(success, false);
     }
     if (success) {
-      for (int i = 0; i < output.size(); ++i) {
-        EXPECT_EQ(output[i], output_ref[i])
-            << "results differ at (" << i << ") reference: " << output_ref[i]
-            << ", FBGEMM: " << output[i] << " emb dim :" << embedding_dim;
+      for (int i = 0; i < batch_size; ++i) {
+        for (int j = 0; j < embedding_dim; ++j) {
+          int offset =
+              i * (use_output_stride ? output_stride : embedding_dim) + j;
+          EXPECT_EQ(output[offset], output_ref[offset])
+              << "results differ at (" << i << ") reference: " << output_ref[i]
+              << ", FBGEMM: " << output[i] << " emb dim :" << embedding_dim;
+        }
       }
     }
   } // end for input
@@ -430,6 +455,7 @@ TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
   vector<vector<int>> inputs(GetInputs_());
   bool isFp16, isIndex64b, isOffset64b, is_wt_positional, use_weight,
       normalize_by_lengths, use_offsets;
+  bool use_output_stride; // not used
   int prefetch;
   EmbeddingSpMDMCornerCase corner_case;
   tie(isFp16,
@@ -440,7 +466,8 @@ TEST_P(EmbeddingSpMDMTest, rowwiseSparseTest) {
       use_weight,
       normalize_by_lengths,
       use_offsets,
-      corner_case) = GetParam();
+      corner_case,
+      use_output_stride) = GetParam();
 
   constexpr float sparsity = 0.7;
 


### PR DESCRIPTION
Summary: This is to support table batched embedding where output for multiple tables are concatenated.

Reviewed By: jianyuh

Differential Revision: D27035065

