### PR TITLE
use fbgemm cpu embedding spmdm jit kernel

### DIFF
--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -74,6 +74,24 @@ FBGEMM_API
         bool use_offsets = true);
 
 /**
+ * @param output_stride If not -1, output_stride is not same as block_size
+ */
+template <
+    typename InType,
+    typename IndexType,
+    typename OffsetType = std::int32_t>
+FBGEMM_API
+    typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType>::Type
+    GenerateEmbeddingSpMDMWithOutputStride(
+        const std::int64_t block_size,
+        bool has_weight,
+        bool normalize_by_lengths,
+        int prefetch = 16,
+        bool is_weight_positional = false,
+        bool use_offsets = true,
+        std::int64_t output_stride = -1);
+
+/**
  * @tparam IndexType can be int32_t or int64_t
  * @tparam OffsetType can be int32_t or int64_t
  * @param bit_rate can be 2 or 4

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -1097,8 +1097,12 @@ bool EmbeddingSpMDM_ref(
     bool normalize_by_lengths,
     float* out,
     bool is_weight_positional,
-    bool use_offsets) {
+    bool use_offsets,
+    int64_t output_stride /*=-1*/) {
   bool is8bit = is_same<InType, uint8_t>::value;
+  if (output_stride == -1) {
+    output_stride = block_size;
+  }
 
   if (is8bit) {
     // block_size is the number of elements and fused_block_size is the size of
@@ -1142,7 +1146,7 @@ bool EmbeddingSpMDM_ref(
           out[j] *= scale;
         }
       }
-      out += block_size;
+      out += output_stride;
     }
     return current == index_size;
   } else {
@@ -1182,7 +1186,7 @@ bool EmbeddingSpMDM_ref(
           out[j] *= scale;
         }
       }
-      out += block_size;
+      out += output_stride;
     }
     return current == index_size;
   }
@@ -1740,7 +1744,8 @@ template FBGEMM_API void transposeConvWeights(
       bool normalize_by_lengths,                                 \
       float* out,                                                \
       bool is_weight_positional,                                 \
-      bool use_offsets);                                         \
+      bool use_offsets,                                          \
+      int64_t output_stride);                                    \
   template FBGEMM_API bool EmbeddingSpMDMRowWiseSparse_ref(      \
       const int64_t block_size,                                  \
       const int64_t output_size,                                 \

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -230,7 +230,8 @@ FBGEMM_API bool EmbeddingSpMDM_ref(
     bool normalize_by_lengths,
     float* out,
     bool is_weight_positional = false,
-    bool use_offsets = true);
+    bool use_offsets = true,
+    std::int64_t output_stride = -1);
 
 template <typename IndexType = std::int64_t, typename OffsetType = std::int32_t>
 FBGEMM_API bool EmbeddingSpMDMNBit_ref(


### PR DESCRIPTION
Summary: Use FBGEMM JIT'ed kernel except when weight is in double

Reviewed By: jiyuanzFB

Differential Revision: D27039292

