### PR TITLE
Fix OSS build and run issues

### DIFF
--- a/fbgemm_gpu/codegen/__init__.template
+++ b/fbgemm_gpu/codegen/__init__.template
@@ -5,13 +5,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import split_embedding_codegen_lookup_invokers.lookup_adagrad as lookup_adagrad  # noqa: F401
-import split_embedding_codegen_lookup_invokers.lookup_adam as lookup_adam  # noqa: F401
-import split_embedding_codegen_lookup_invokers.lookup_args as lookup_args  # noqa: F401
-import split_embedding_codegen_lookup_invokers.lookup_lamb as lookup_lamb  # noqa: F401
-import split_embedding_codegen_lookup_invokers.lookup_lars_sgd as lookup_lars_sgd  # noqa: F401
-import split_embedding_codegen_lookup_invokers.lookup_partial_rowwise_adam as lookup_partial_rowwise_adam  # noqa: F401
-import split_embedding_codegen_lookup_invokers.lookup_partial_rowwise_lamb as lookup_partial_rowwise_lamb  # noqa: F401
-import split_embedding_codegen_lookup_invokers.lookup_rowwise_adagrad as lookup_rowwise_adagrad  # noqa: F401
-import split_embedding_codegen_lookup_invokers.lookup_sgd as lookup_sgd  # noqa: F401
-import split_embedding_codegen_lookup_invokers.lookup_approx_sgd as lookup_approx_sgd  # noqa: F401
+import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_adagrad as lookup_adagrad  # noqa: F401
+import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_adam as lookup_adam  # noqa: F401
+import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_args as lookup_args  # noqa: F401
+import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_lamb as lookup_lamb  # noqa: F401
+import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_lars_sgd as lookup_lars_sgd  # noqa: F401
+import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_partial_rowwise_adam as lookup_partial_rowwise_adam  # noqa: F401
+import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_partial_rowwise_lamb as lookup_partial_rowwise_lamb  # noqa: F401
+import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_rowwise_adagrad as lookup_rowwise_adagrad  # noqa: F401
+import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_sgd as lookup_sgd  # noqa: F401
+import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_approx_sgd as lookup_approx_sgd  # noqa: F401

--- a/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
@@ -17,7 +17,7 @@ torch.ops.load_library(
     "//deeplearning/fbgemm/fbgemm_gpu:split_table_batched_embeddings"
 )
 {% else %}
-torch.ops.load_library("fbgemm_gpu.so")
+torch.ops.load_library("fbgemm_gpu_py.so")
 {% endif %}
 
 

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -12,7 +12,7 @@ from math import log2
 from numbers import Number
 from typing import Dict, List, Optional, Tuple
 
-import split_embedding_codegen_lookup_invokers as invokers
+import fbgemm_gpu.split_embedding_codegen_lookup_invokers as invokers
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType
 from fbgemm_gpu.split_embedding_configs import SparseType

--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -104,7 +104,7 @@ setup(
     long_description=long_description,
     ext_modules=[
         CUDAExtension(
-            name="fbgemm_gpu",
+            name="fbgemm_gpu_py",
             sources=[
                 os.path.join(cur_dir, build_codegen_path, "{}".format(f))
                 for f in cpp_cuda_output_files + cpp_cpu_output_files


### PR DESCRIPTION
Summary:
Fix the OSS build issues of FBGEMM_GPU reported by Jiong Gong from Intel:
```
$ python test/split_table_batched_embeddings_test.py
Traceback (most recent call last):
  File "test/split_table_batched_embeddings_test.py", line 12, in <module>
    import fbgemm_gpu.split_table_batched_embeddings_ops as split_table_batched_embeddings_ops
ImportError: dynamic module does not define module export function (PyInit_fbgemm_gpu)
```

The PT ops in FBGEMM_GPU are registered with TorchScript custom ops:
https://pytorch.org/tutorials/advanced/torch_script_custom_ops.html

However, currently we can only use local "*.so" file instead of install it in Python dependency folder (e.g., ~/miniconda3/lib/python3.8/site-packages). Otherwise, it reports "ImportError: dynamic module does not define module export function (PyInit_fbgemm_gpu)" error. TODO: figure out the way to automatically load *.so file when installing FBGEMM_GPU in Python dependency folder.

The OSS issue is caused by the ambiguity of "import fbgemm_gpu" under fbgemm_gpu folder. It can refer to load "fbgemm_gpu.so", or import the Python files in "fbgemm_gpu" folder. By renaming the so file to "fbgemm_gpu_py.so", we bypass this issue.

Differential Revision: D27132794

