### PR TITLE
Fix the OSS CMakefile build

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -62,7 +62,7 @@ add_custom_target(defs.bzl DEPENDS defs.bzl)
 add_dependencies(fbgemm_gpu_generic defs.bzl)
 
 set_target_properties(fbgemm_gpu_generic PROPERTIES
-      CUDA_SEPARABLE_COMPILATION ON
+      CUDA_SEPARABLE_COMPILATION OFF
       CXX_STANDARD 14
       CXX_STANDARD_REQUIRED YES
       CXX_EXTENSIONS NO

--- a/fbgemm_gpu/bench/CMakeLists.txt
+++ b/fbgemm_gpu/bench/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 macro(add_benchmark BENCHNAME)
   add_executable(${BENCHNAME} ${ARGN})
   set_target_properties(${BENCHNAME} PROPERTIES
+          CUDA_SEPARABLE_COMPILATION OFF
           CXX_STANDARD 11
           CXX_EXTENSIONS NO)
   target_link_libraries(${BENCHNAME} fbgemm_gpu -lcurand)

--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -119,6 +119,7 @@ setup(
                 os.path.join(cur_dir, "src/cumem_utils_host.cpp"),
                 os.path.join(cur_dir, "src/quantize_wrappers.cu"),
                 os.path.join(cur_dir, "src/quantize_ops_host.cpp"),
+                os.path.join(cur_dir, "src/quantize_ops.cpp"),
             ],
             include_dirs=[
                 cur_dir,

--- a/fbgemm_gpu/src/quantize_ops.cpp
+++ b/fbgemm_gpu/src/quantize_ops.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// Copyright 2004-present Facebook. All Rights Reserved.
+#include <ATen/ATen.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include "fbgemm_gpu/quantize_wrappers.cuh"
+
+at::Tensor _float_to_fused8bitrowwise_gpu(const at::Tensor& input) {
+  TORCH_CHECK(input.is_cuda());
+  TORCH_CHECK(input.is_contiguous());
+
+  c10::cuda::OptionalCUDAGuard device_guard;
+  device_guard.set_index(input.get_device());
+
+  const auto input_sizes = input.sizes();
+  const auto last_dim = input_sizes.size() - 1;
+  const int nrows = c10::size_to_dim_(last_dim, input_sizes);
+  const int ncols = input_sizes[last_dim];
+  const int ncols_aligned = (ncols + 4 - 1) / 4 * 4;
+  const int output_columns = ncols_aligned + 2 * sizeof(float);
+
+  auto output_dims = input_sizes.vec();
+  output_dims[last_dim] = output_columns;
+  auto output = at::empty(
+      output_dims, // 4 = sizeof(float)
+      input.options().dtype(at::kByte));
+
+  if (nrows == 0 || ncols == 0) {
+    return output;
+  }
+  fbgemm_gpu_test::FloatToFused8BitRowwiseQuantized(
+      nrows, ncols, input.data_ptr<float>(), output.data_ptr<std::uint8_t>());
+  return output;
+}

--- a/fbgemm_gpu/src/quantize_wrappers.cu
+++ b/fbgemm_gpu/src/quantize_wrappers.cu
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 // Copyright 2004-present Facebook. All Rights Reserved.
-#include <ATen/ATen.h>
-#include <c10/cuda/CUDAGuard.h>
 #include <cuda.h>
 #include <cassert>
 #include "fbgemm_gpu/cuda_utils.cuh"
@@ -107,32 +105,4 @@ void fbgemm_gpu_test::FusedNBitRowwiseQuantizedSBHalfToFloat(
       bit_rate, input, nrows, ncols, output);
 
   CUDA_CHECK(cudaGetLastError());
-}
-
-at::Tensor _float_to_fused8bitrowwise_gpu(const at::Tensor& input) {
-  TORCH_CHECK(input.is_cuda());
-  TORCH_CHECK(input.is_contiguous());
-
-  c10::cuda::OptionalCUDAGuard device_guard;
-  device_guard.set_index(input.get_device());
-
-  const auto input_sizes = input.sizes();
-  const auto last_dim = input_sizes.size() - 1;
-  const int nrows = c10::size_to_dim_(last_dim, input_sizes);
-  const int ncols = input_sizes[last_dim];
-  const int ncols_aligned = (ncols + 4 - 1) / 4 * 4;
-  const int output_columns = ncols_aligned + 2 * sizeof(float);
-
-  auto output_dims = input_sizes.vec();
-  output_dims[last_dim] = output_columns;
-  auto output = at::empty(
-      output_dims, // 4 = sizeof(float)
-      input.options().dtype(at::kByte));
-
-  if (nrows == 0 || ncols == 0) {
-    return output;
-  }
-  fbgemm_gpu_test::FloatToFused8BitRowwiseQuantized(
-      nrows, ncols, input.data_ptr<float>(), output.data_ptr<std::uint8_t>());
-  return output;
 }

--- a/fbgemm_gpu/test/CMakeLists.txt
+++ b/fbgemm_gpu/test/CMakeLists.txt
@@ -29,7 +29,7 @@ macro(add_gtest TESTNAME)
   add_executable(${TESTNAME} ${ARGN}
   )
   set_target_properties(${TESTNAME} PROPERTIES
-          CUDA_SEPARABLE_COMPILATION ON
+          CUDA_SEPARABLE_COMPILATION OFF
           CXX_STANDARD 11
           CXX_EXTENSIONS NO)
   #To compile test files with AVX2 turned on


### PR DESCRIPTION
Summary: Fix the failure for OSS CMakefile build: remove the PyTorch dependency in fbcode/deeplearning/fbgemm/fbgemm_gpu/src/quantize_wrappers.cu .

Differential Revision: D27140562

