### PR TITLE
avoid initializing embedding bag output to zeros

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_dense_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_dense_host_cpu.cpp
@@ -69,6 +69,7 @@ class SplitLookupFunction_Dense_Op
         weights_offsets,
         D_offsets,
         total_D,
+        hash_size_cumsum,
         indices,
         offsets,
         pooling_mode,

--- a/fbgemm_gpu/codegen/embedding_backward_split_host_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_cpu_template.cpp
@@ -75,6 +75,7 @@ class SplitLookupFunction_{{ optimizer }}_Op : public torch::autograd::Function<
         weights_offsets,
         D_offsets,
         total_D,
+        hash_size_cumsum,
         indices,
         offsets,
         pooling_mode,

--- a/fbgemm_gpu/codegen/embedding_backward_template_helpers.cuh
+++ b/fbgemm_gpu/codegen/embedding_backward_template_helpers.cuh
@@ -83,7 +83,7 @@ __global__ void linearize_index_kernel(
     at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> infos,
     at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         linear_indices) {
-  int32_t T = hash_size_cumsum.size(0);
+  int32_t T = hash_size_cumsum.size(0) - 1;
   int32_t B = (offsets.size(0) - 1) / T;
   int32_t b_t = blockIdx.x * blockDim.x + threadIdx.x;
   int32_t b = b_t % B;

--- a/fbgemm_gpu/codegen/embedding_forward_split_cpu.h
+++ b/fbgemm_gpu/codegen/embedding_forward_split_cpu.h
@@ -16,6 +16,7 @@ at::Tensor split_embedding_codegen_forward_cpu(
     at::Tensor weights_offsets,
     at::Tensor D_offsets,
     int64_t total_D,
+    at::Tensor hash_size_cumsum,
     at::Tensor indices,
     at::Tensor offsets,
     int64_t pooling_mode,

--- a/fbgemm_gpu/src/split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/split_table_batched_embeddings.cpp
@@ -16,7 +16,6 @@ int64_t host_lxu_cache_slot(int64_t h_in, int64_t C);
 // Linearize the indices of all tables to make it be unique
 Tensor linearize_cache_indices_cuda(
     Tensor cache_hash_size_cumsum,
-    int64_t total_cache_hash_size,
     Tensor indices,
     Tensor offsets);
 
@@ -74,7 +73,7 @@ namespace {
 
 TORCH_LIBRARY_FRAGMENT(fb, m) {
   m.def(
-      "linearize_cache_indices(Tensor cache_hash_size_cumsum, int total_cache_hash_size, Tensor indices, Tensor offsets) -> Tensor");
+      "linearize_cache_indices(Tensor cache_hash_size_cumsum, Tensor indices, Tensor offsets) -> Tensor");
   m.impl(
       "linearize_cache_indices",
       torch::dispatch(


### PR DESCRIPTION
Summary: No need to zero out the embedding output up front, and we can fuse it into the embedding bag loop. fbgemm CPU code does in JIT'ed code.

Reviewed By: jianyuh

Differential Revision: D27202277

