### PR TITLE
add one more entry to hash_size_cum to easier compute of hash size of each table

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_template_helpers.cuh
+++ b/fbgemm_gpu/codegen/embedding_backward_template_helpers.cuh
@@ -83,7 +83,7 @@ __global__ void linearize_index_kernel(
     at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> infos,
     at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         linear_indices) {
-  int32_t T = hash_size_cumsum.size(0);
+  int32_t T = hash_size_cumsum.size(0) - 1;
   int32_t B = (offsets.size(0) - 1) / T;
   int32_t b_t = blockIdx.x * blockDim.x + threadIdx.x;
   int32_t b = b_t % B;

--- a/fbgemm_gpu/src/split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/split_table_batched_embeddings.cpp
@@ -16,7 +16,6 @@ int64_t host_lxu_cache_slot(int64_t h_in, int64_t C);
 // Linearize the indices of all tables to make it be unique
 Tensor linearize_cache_indices_cuda(
     Tensor cache_hash_size_cumsum,
-    int64_t total_cache_hash_size,
     Tensor indices,
     Tensor offsets);
 
@@ -74,7 +73,7 @@ namespace {
 
 TORCH_LIBRARY_FRAGMENT(fb, m) {
   m.def(
-      "linearize_cache_indices(Tensor cache_hash_size_cumsum, int total_cache_hash_size, Tensor indices, Tensor offsets) -> Tensor");
+      "linearize_cache_indices(Tensor cache_hash_size_cumsum, Tensor indices, Tensor offsets) -> Tensor");
   m.impl(
       "linearize_cache_indices",
       torch::dispatch(


### PR DESCRIPTION
Summary: Make hash_cum_size T+1 (like rowptr of CSR format) to make computing hash size of each table easier.

Reviewed By: jianyuh

Differential Revision: D27200018

