### PR TITLE
avoid unused variable warning for approx sgd

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_backward_code_generator.py
@@ -405,7 +405,9 @@ def sgd():
 
 def approx_sgd():
     split_weight_update = """
-      // approx_sgd not supported for GPU
+      // approx_sgd not supported for GPU.
+      // Just do the same thing as exact sgd to avoid unused variable warning.
+      weight_new.fma_(grad, -learning_rate);
     """
     split_weight_update_cpu = """
       host_weights_data[embedding_begin + d] += learning_rate * grad_val;


### PR DESCRIPTION
Summary:
To reduce noise from build msgs

TODO: we could add assertion in CUDA code to make sure approx sgd is not used on GPU

Differential Revision: D27222955

