### PR TITLE
use JIT'ed approx rowwise sparse adagrad on CPU

### DIFF
--- a/fbgemm_gpu/codegen/__init__.template
+++ b/fbgemm_gpu/codegen/__init__.template
@@ -15,3 +15,4 @@ import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_partial_rowwise
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_rowwise_adagrad as lookup_rowwise_adagrad  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_sgd as lookup_sgd  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_approx_sgd as lookup_approx_sgd  # noqa: F401
+import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_approx_rowwise_adagrad as lookup_approx_rowwise_adagrad  # noqa: F401

--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
@@ -129,9 +129,9 @@ using namespace at;
 
 
   return;
-  {% endif %}
 
-  {% if dense %}
+  {% else %}
+
   // When input is dense enough, avoid sorting and just treat as dense.
   auto grad = zeros_like(host_weights, grad_output.dtype());
 

--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_codegen_lookup_invokers.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_codegen_lookup_invokers.py
@@ -7,6 +7,8 @@
 
 import python.lookup_adagrad as lookup_adagrad  # noqa: F401
 import python.lookup_adam as lookup_adam  # noqa: F401
+import python.lookup_approx_rowwise_adagrad as lookup_approx_rowwise_adagrad  # noqa: F401
+import python.lookup_approx_sgd as lookup_approx_sgd  # noqa: F401
 import python.lookup_args as lookup_args  # noqa: F401
 import python.lookup_lamb as lookup_lamb  # noqa: F401
 import python.lookup_lars_sgd as lookup_lars_sgd  # noqa: F401
@@ -14,4 +16,3 @@ import python.lookup_partial_rowwise_adam as lookup_partial_rowwise_adam  # noqa
 import python.lookup_partial_rowwise_lamb as lookup_partial_rowwise_lamb  # noqa: F401
 import python.lookup_rowwise_adagrad as lookup_rowwise_adagrad  # noqa: F401
 import python.lookup_sgd as lookup_sgd  # noqa: F401
-import python.lookup_approx_sgd as lookup_approx_sgd  # noqa: F401

--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
@@ -23,6 +23,7 @@ class EmbOptimType(enum.Enum):
     LARS_SGD = "lars_sgd"
     PARTIAL_ROWWISE_ADAM = "partial_row_wise_adam"
     PARTIAL_ROWWISE_LAMB = "partial_row_wise_lamb"
+    ROWWISE_ADAGRAD = "row_wise_adagrad"
 
     def __str__(self):
         return self.value


### PR DESCRIPTION
Summary: Until we have an optimized implementation of exact rowwise sparse adagrad we can use approx rowwise sparse adagrad JIT kernel in fbgemm cpu

Reviewed By: jianyuh

Differential Revision: D27251867

