### PR TITLE
Use more compact syntax for is_uvm_tensor

### DIFF
--- a/fbgemm_gpu/src/cumem_utils_host.cpp
+++ b/fbgemm_gpu/src/cumem_utils_host.cpp
@@ -22,10 +22,7 @@ bool is_uvm_tensor(Tensor t);
 Tensor uvm_to_cpu(Tensor t);
 
 TORCH_LIBRARY_FRAGMENT(fb, m) {
-  m.def("is_uvm_tensor(Tensor t) -> bool");
-  m.impl(
-      "is_uvm_tensor",
-      torch::dispatch(c10::DispatchKey::Math, TORCH_FN(is_uvm_tensor)));
+  m.def("is_uvm_tensor(Tensor t) -> bool", TORCH_FN(is_uvm_tensor));
   m.def("uvm_to_cpu(Tensor t) -> Tensor");
   m.impl(
       "uvm_to_cpu",


### PR DESCRIPTION
Summary:
For simple definitions you can just specify the Math implementation
directly in the def; no need to split it out.

Reviewed By: jianyuh

Differential Revision: D27269705

