### PR TITLE
Remove Explicit prefetch argument from forward

### DIFF
--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -627,7 +627,7 @@ def cache(  # noqa C901
             (emb.lxu_cache_state != old_lxu_cache_state).sum().item()
         )
         cache_misses.append((emb.lxu_cache_locations_list[0] == NOT_FOUND).sum().item())
-        emb.forward(indices.long(), offsets.long(), prefetch=False)
+        emb.forward(indices.long(), offsets.long())
     logging.info(
         f"Exchanged cache lines -- mean: {sum(exchanged_cache_lines)/len(requests): .2f}, "
         f"max: {max(exchanged_cache_lines)}, min: {min(exchanged_cache_lines)}"
@@ -645,7 +645,7 @@ def cache(  # noqa C901
         requests,
         lambda indices, offsets, indices_weights: emb.prefetch(indices, offsets),
         lambda indices, offsets, indices_weights: emb.forward(
-            indices, offsets, indices_weights, prefetch=False
+            indices, offsets, indices_weights
         ).backward(grad_output),
     )
     e2e_time = prefetch_time + forward_backward_time


### PR DESCRIPTION
Summary:
* Removed prefetch argument from SplitTable*, that logic is now
    implicitly determined rather than explicitly specified. This is useful
    because if there is a train pipeline that doesn't call prefetch, the
    forward call will still call prefetch (if it's necessary for that operator)

Reviewed By: jianyuh

Differential Revision: D27146163

