### PR TITLE
Support for sequence embeddings (Embedding list no bag)

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
@@ -197,9 +197,12 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights
     TORCH_CHECK(T > 0);
     // offsets = [B x T  + 1]
     const auto B = (offsets.size(0) - 1) / T;
-    TORCH_CHECK(B > 0);
+    TORCH_CHECK(B >= 0);
     TORCH_CHECK(max_D <= {{ max_embedding_dim }});
     auto grad_indice_weights = empty_like(indices, indices.options().dtype(grad_output.dtype()));
+    if (B == 0) {
+      return grad_indice_weights;
+    }
     feature_requires_grad = feature_requires_grad.defined() ? feature_requires_grad : empty({0}, indices.options().dtype(kInt));
     {% if not dense %}
     DISPATCH_EMB_CACHE_TYPES(

--- a/fbgemm_gpu/codegen/embedding_forward_split_cpu.h
+++ b/fbgemm_gpu/codegen/embedding_forward_split_cpu.h
@@ -9,7 +9,7 @@
 #include <ATen/ATen.h>
 #include <ATen/Parallel.h>
 
-enum PoolingMode { SUM = 0, MEAN = 1 };
+enum PoolingMode { SUM = 0, MEAN = 1, NONE = 2 };
 
 at::Tensor split_embedding_codegen_forward_cpu(
     at::Tensor weights,

--- a/fbgemm_gpu/codegen/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_template.cu
@@ -210,7 +210,7 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_forward_{{ wdesc }}
     TORCH_CHECK(T > 0);
     // offsets = [B x T  + 1]
     int32_t B = (offsets.size(0) - 1) / T;
-    TORCH_CHECK(B > 0);
+    TORCH_CHECK(B >= 0);
     TORCH_CHECK(total_D > 0);
     TORCH_CHECK(total_D % 4 == 0);
     TORCH_CHECK(max_D <= {{ max_embedding_dim }});
@@ -219,6 +219,9 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_forward_{{ wdesc }}
         output = empty({B, total_D}, dev_weights.options().dtype(at::kFloat));
     } else {
         output = empty({B, total_D}, dev_weights.options());
+    }
+    if (B == 0) {
+        return output;
     }
 
     {% if not dense %}

--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
@@ -32,7 +32,7 @@ will be stored at the end of each row in FP32 formats, appending a total of
 static constexpr float kINT8QparamsBytes = 8;
 
 // Pooling Mode: currently SUM and MEAN pooling are supported
-enum PoolingMode { SUM, MEAN };
+enum PoolingMode { SUM, MEAN, NONE };
 
 // Customized Half4 data types with two half2 (64-bit in total)
 struct Half4 {

--- a/fbgemm_gpu/src/split_embeddings_cache_cuda.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache_cuda.cu
@@ -233,9 +233,12 @@ Tensor linearize_cache_indices_cuda(
   TORCH_CHECK(T > 0);
   // offsets = [B x T  + 1]
   auto B = (offsets.size(0) - 1) / T;
-  TORCH_CHECK(B > 0);
+  TORCH_CHECK(B >= 0);
 
   auto linear_cache_indices = at::empty_like(indices);
+  if (B == 0) {
+    return linear_cache_indices;
+  }
   linearize_cache_indices_kernel<<<
       div_round_up(B * T, kMaxThreads),
       kMaxThreads,


### PR DESCRIPTION
Summary: Simple use of the “fake” offsets with full_cumsum(torch.ones(indices.numel())) ([0, 1, 2, ..., length of indices]) to EmbeddingBag to get the Embedding (no bag; no pooling) op. However, it couldn't be table batched.

Differential Revision: D27392165

