### PR TITLE
Fix zero_point calculation

### DIFF
--- a/src/QuantUtils.cc
+++ b/src/QuantUtils.cc
@@ -105,7 +105,7 @@ TensorQuantizationParams ChooseQuantizationParams(
   // to be a middle value between qmin and qmax.
   // If either min or max is 0, then we just use 0 as zero_point.
   if (min < 0 && max > 0 && preserve_sparsity) {
-    initial_zero_point = (qmin + qmax) / 2 + 1;
+    initial_zero_point = static_cast<double>(qmin + qmax) / 2 + 1;
   }
 
   // Now we need to nudge the zero point to be an integer

--- a/test/QuantUtilsTest.cc
+++ b/test/QuantUtilsTest.cc
@@ -440,6 +440,20 @@ TEST(QuantizeTest, cornerCases) {
   EXPECT_EQ(dst_int16[1], -32768);
 }
 
+TEST(QuantizeTestQParams, chooseQParamsSymmetric) {
+  // Test that symmetric quantization of weights set zero point exactly to 0.
+  float min = -1.6165;
+  float max = 0.5685;
+  int32_t qmin = -128;
+  int32_t qmax = 127;
+
+  bool preserve_sparsity = true;
+
+  TensorQuantizationParams result = ChooseQuantizationParams(min, max, qmin, qmax, preserve_sparsity);
+  EXPECT_FLOAT_EQ(result.scale, 0.012628906);
+  EXPECT_EQ(result.zero_point, 0);
+}
+
 template <typename T>
 void runFusedQuantizeDequantizeTests(
     const vector<float>& src,


### PR DESCRIPTION
Summary:
Before this change we were incorrectly setting the zero_point to 1 when we enable preserve_sparsity flag. This is due to the integer division in the current code that doesn't do the rounding correctly.

For symmetric quantization of weights we need to map the weight zero_point to 0.

Reviewed By: dskhudia

Differential Revision: D27485368

