### PR TITLE
fix cpu approx sparse adagrad

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
@@ -109,8 +109,8 @@ using namespace at;
           grad_t grad_buffer[D];
           for (int c = table_ptr[t]; c < table_ptr[t + 1]; ++c) {
             memset(grad_buffer, 0, D * sizeof(grad_t));
-            const int64_t embedding_begin =
-                table_begin + batched_csc.column_indices[c] * D;
+            auto idx = batched_csc.column_indices[c];
+            const int64_t embedding_begin = table_begin + idx * D;
             for (int r = column_ptr[c]; r < column_ptr[c + 1]; ++r) {
               int f_times_b = batched_csc.row_indices[r];
               int feature = f_times_b / B;


### PR DESCRIPTION
Summary:
D27251867 (https://github.com/pytorch/FBGEMM/commit/a2b58dfab5a6926217848c1692df9018cbfa8c57) was not correct leaving a few bugs.
* The unit test was exercising cases not handled by fbgemm while the fallback path was doing nop for approx sparse adagrad.
* fbgemm code path doesn't handle weighted embedding bag and max pooling yet so we need to fallback
* In test_backward_sgd , when not exact we shouldn't repeated indices to avoid races

Differential Revision: D27556297

