### PR TITLE
correct use of contiguous in cpu embedding ops

### DIFF
--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -277,7 +277,7 @@ def device(  # noqa C901
         f"{nparams * param_size_multiplier / 1.0e9: .2f}GB"
     )
     logging.info(
-        f"Accessed weights per batch: {B * T * L * D * param_size_multiplier / 1.0e6: .2f}MB"
+        f"Accessed weights per batch: {B * sum(Ds) * L * param_size_multiplier / 1.0e6: .2f}MB"
     )
 
     requests = generate_requests(
@@ -305,7 +305,7 @@ def device(  # noqa C901
     logging.info(
         f"Forward, B: {B}, "
         f"E: {E}, T: {T}, D: {D}, L: {L}, W: {weighted}, "
-        f"BW: {param_size_multiplier * B * T * L * D / time_per_iter / 1.0e9: .2f}GB/s, "  # noqa: B950
+        f"BW: {param_size_multiplier * B * sum(Ds) * L / time_per_iter / 1.0e9: .2f}GB/s, "  # noqa: B950
         f"T: {time_per_iter * 1.0e6:.0f}us"
     )
 
@@ -481,7 +481,7 @@ def uvm(
     logging.info(
         f"GPU Forward, B: {B}, "
         f"E: {E}, T: {T_gpu}, D: {D}, L: {L}, W: {weighted}, "
-        f"BW: {param_size_multiplier * B * T_gpu * L * D / time_per_iter / 1.0e9: .2f}GB/s, "  # noqa: B950
+        f"BW: {param_size_multiplier * B * sum(Ds[T_uvm:]) * L / time_per_iter / 1.0e9: .2f}GB/s, "  # noqa: B950
         f"T: {time_per_iter * 1.0e6:.0f}us"
     )
 
@@ -495,8 +495,8 @@ def uvm(
     )
     logging.info(
         f"UVM Forward, B: {B}, "
-        f"E: {E}, T: {T_gpu}, D: {D}, L: {L}, W: {weighted}, "
-        f"BW: {param_size_multiplier * B * T_gpu * L * D / time_per_iter / 1.0e9: .2f}GB/s, "  # noqa: B950
+        f"E: {E}, T: {T_uvm}, D: {D}, L: {L}, W: {weighted}, "
+        f"BW: {param_size_multiplier * B * sum(Ds[:T_uvm]) * L / time_per_iter / 1.0e9: .2f}GB/s, "  # noqa: B950
         f"T: {time_per_iter * 1.0e6:.0f}us"
     )
 
@@ -510,8 +510,8 @@ def uvm(
     )
     logging.info(
         f"Mixed Forward, B: {B}, "
-        f"E: {E}, T: {T_gpu}, D: {D}, L: {L}, W: {weighted}, "
-        f"BW: {param_size_multiplier * B * T_gpu * L * D / time_per_iter / 1.0e9: .2f}GB/s, "  # noqa: B950
+        f"E: {E}, T: {T}, D: {D}, L: {L}, W: {weighted}, "
+        f"BW: {param_size_multiplier * B * sum(Ds) * L / time_per_iter / 1.0e9: .2f}GB/s, "  # noqa: B950
         f"T: {time_per_iter * 1.0e6:.0f}us"
     )
 

--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_approx_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_approx_template.cpp
@@ -15,6 +15,68 @@
 
 using namespace at;
 
+namespace {
+template <typename scalar_t, typename grad_t>
+void split_embedding_backward_approx_cpu_kernel(
+    Tensor grad_output,
+    Tensor host_weights,
+    const TensorAccessor<int64_t, 1> weights_offsets_data,
+    const TensorAccessor<int, 1> D_offsets_data,
+    Tensor indices,
+    Tensor offsets,
+    int64_t pooling_mode,
+    Tensor indice_weights,
+    int T,
+    int B,
+    {% if "momentum1_offsets" in args.split_function_arg_names %}
+    const TensorAccessor<int64_t, 1> momentum1_offsets_data,
+    {% endif %}
+    {% if "momentum2_offsets" in args.split_function_arg_names %}
+    const TensorAccessor<int64_t, 1> momentum2_offsets_data,
+    {% endif %}
+    {{ args.split_cpu_kernel_args | join(", ") }}) {
+  auto grad_output_data = grad_output.accessor<grad_t, 2>();
+  auto host_weights_data = host_weights.accessor<scalar_t, 1>();
+  const auto indices_data = indices.accessor<int64_t, 1>();
+  const auto offsets_data = offsets.accessor<int64_t, 1>();
+  // If indice_weights are not defined, then this accessor won't be used
+  auto indice_weights_data = indice_weights.defined()
+      ? indice_weights.accessor<grad_t, 1>()
+      : TensorAccessor<grad_t, 1>(nullptr, nullptr, nullptr);
+
+  for (int64_t t = 0; t < T; ++t) {
+    int feature_begin = t; // to conform interface with exact
+    const auto D_begin = D_offsets_data[t];
+    const auto D = D_offsets_data[t + 1] - D_offsets_data[t];
+    const auto table_begin = weights_offsets_data[t];
+    at::parallel_for(0, B, 0, [&](int64_t b_begin, int64_t b_end) {
+      for (int64_t b = b_begin; b < b_end; ++b) {
+        const auto pool_begin = offsets_data[t * B + b];
+        const auto pool_end = offsets_data[t * B + b + 1];
+        const auto L = pool_end - pool_begin;
+        const double scale_factor =
+            // NOTE: MEAN pooling will not work with indice_weights!
+            (pooling_mode == MEAN && !indice_weights.defined() && L > 0)
+            ? 1.0 / L
+            : 1.0;
+        for (auto p = pool_begin; p < pool_end; ++p) {
+          auto idx = indices_data[p];
+          const int64_t embedding_begin = table_begin + idx * D;
+          scalar_t grad_buffer[D];
+          for (int64_t d = 0; d < D; ++d) {
+            grad_buffer[d] = scale_factor *
+                (indice_weights.defined()
+                     ? grad_output_data[b][D_begin + d] * indice_weights_data[p]
+                     : grad_output_data[b][D_begin + d]);
+          }
+          {{ split_weight_update_cpu }};
+        } // for each p
+      } // for each b
+    }); // parallel for B
+  } // for each t
+}
+} // namespace
+
 // The template for approximate optimizers
 {{ "void" if not dense else "Tensor" }}
 split_embedding_backward_codegen_{{ optimizer }}_cpu(
@@ -43,9 +105,8 @@ split_embedding_backward_codegen_{{ optimizer }}_cpu(
   int64_t B = (offsets.size(0) - 1) / T;
   TORCH_CHECK(B > 0);
 
-  const auto D_offsets_data = D_offsets.accessor<int, 1>();
   const auto weights_offsets_data = weights_offsets.accessor<int64_t, 1>();
-  const auto hash_size_cumsum_data = hash_size_cumsum.accessor<int64_t, 1>();
+  const auto D_offsets_data = D_offsets.accessor<int, 1>();
   {%if "momentum1_offsets" in args.split_function_arg_names %}
   const auto momentum1_offsets_data = momentum1_offsets.accessor<int64_t, 1>();
   {% endif %}
@@ -66,11 +127,12 @@ split_embedding_backward_codegen_{{ optimizer }}_cpu(
 
   if (use_fbgemm) {
     auto grad_stride = grad_output.size(1);
-    float* host_weights_data = host_weights.data_ptr<float>();
-    float* momentum1_data = momentum1_host.data_ptr<float>();
     const float* grad_output_data = grad_output.data_ptr<float>();
-    const int64_t* offsets_data = offsets.data_ptr<int64_t>();
+    float* host_weights_data = host_weights.data_ptr<float>();
     const int64_t* indices_data = indices.data_ptr<int64_t>();
+    const int64_t* offsets_data = offsets.data_ptr<int64_t>();
+    const auto hash_size_cumsum_data = hash_size_cumsum.accessor<int64_t, 1>();
+    float* momentum1_data = momentum1_host.data_ptr<float>();
 
     at::parallel_for(0, T * B, 0, [&](int64_t tb_begin, int64_t tb_end) {
       int t_begin = tb_begin / B;
@@ -121,58 +183,31 @@ split_embedding_backward_codegen_{{ optimizer }}_cpu(
 
   {% endif %}
 
-  const auto offsets_data = offsets.accessor<int64_t, 1>();
-  const auto indices_data = indices.accessor<int64_t, 1>();
-
   AT_DISPATCH_FLOATING_TYPES(
       grad_output.scalar_type(), "split_embedding_backward_cpu", [&]() {
-        // If indice_weights are not defined, then this accessor won't be
-        // used
-        auto indice_weights_data = indice_weights.defined()
-            ? indice_weights.accessor<scalar_t, 1>()
-            : TensorAccessor<scalar_t, 1>(nullptr, nullptr, nullptr);
-
-        auto grad_output_data = grad_output.accessor<scalar_t, 2>();
+        using grad_t = scalar_t;
         AT_DISPATCH_FLOATING_TYPES_AND_HALF(
             host_weights.scalar_type(),
             "split_embedding_backward_cpu_inner",
             [&]() {
-              {{ args.split_host_accessor_constructors | join("; ") }}
-
-              auto host_weights_data = host_weights.accessor<scalar_t, 1>();
-
-              for (int64_t t = 0; t < T; ++t) {
-                int feature_begin = t; // to conform interface with exact
-                const auto D_begin = D_offsets_data[t];
-                const auto D = D_offsets_data[t + 1] - D_offsets_data[t];
-                const auto table_begin = weights_offsets_data[t];
-                at::parallel_for(0, B, 0, [&](int64_t b_begin, int64_t b_end) {
-                  for (int64_t b = b_begin; b < b_end; ++b) {
-                    const auto pool_begin = offsets_data[t * B + b];
-                    const auto pool_end = offsets_data[t * B + b + 1];
-                    const auto L = pool_end - pool_begin;
-                    const double scale_factor =
-                      // NOTE: MEAN pooling will not work with indice_weights!
-                      (pooling_mode == MEAN && !indice_weights.defined() &&
-                       L > 0)
-                      ? 1.0 / L
-                      : 1.0;
-                    for (auto p = pool_begin; p < pool_end; ++p) {
-                      auto idx = indices_data[p];
-                      const int64_t embedding_begin = table_begin + idx * D;
-                      scalar_t grad_buffer[D];
-                      for (int64_t d = 0; d < D; ++d) {
-                        grad_buffer[d] = scale_factor *
-                          (indice_weights.defined()
-                               ? grad_output_data[b][D_begin + d] *
-                                   indice_weights_data[p]
-                               : grad_output_data[b][D_begin + d]);
-                      }
-                      {{ split_weight_update_cpu }};
-                    } // for each p
-                  } // for each b
-                }); // parallel for B
-              } // for each t
+              split_embedding_backward_approx_cpu_kernel<scalar_t, grad_t>(
+                  grad_output,
+                  host_weights,
+                  weights_offsets_data,
+                  D_offsets_data,
+                  indices,
+                  offsets,
+                  pooling_mode,
+                  indice_weights,
+                  T,
+                  B,
+                  {% if "momentum1_offsets" in args.split_function_arg_names %}
+                  momentum1_offsets_data,
+                  {% endif %}
+                  {% if "momentum2_offsets" in args.split_function_arg_names %}
+                  momentum2_offsets_data,
+                  {% endif %}
+                  {{ args.split_cpu_kernel_arg_constructors | join(", ") }});
             }); // dispatch host_weights.scalar_type()
       }); // dispatch grad_output.scalar_type()
 

--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
@@ -42,9 +42,11 @@ void split_embedding_backward_exact_cpu_kernel(
       batched_csc,
       num_tables,
       B,
-      offsets.data_ptr<int64_t>(),
-      indices.data_ptr<int64_t>(),
-      indice_weights.defined() ? indice_weights.data_ptr<grad_t>() : nullptr,
+      offsets.accessor<int64_t, 1>(),
+      indices.accessor<int64_t, 1>(),
+      indice_weights.defined()
+          ? indice_weights.accessor<grad_t, 1>()
+          : TensorAccessor<grad_t, 1>(nullptr, nullptr, nullptr),
       pooling_mode,
       table_to_feature_offset);
   std::vector<int>& table_ptr = batched_csc.table_ptr;
@@ -197,10 +199,6 @@ void split_embedding_backward_exact_cpu_dense_kernel(
   {% if "momentum2_offsets" in args.split_function_arg_names %}
   const auto momentum2_offsets_data = momentum2_offsets.accessor<int64_t, 1>();
   {% endif %}
-
-  offsets.contiguous();
-  indices.contiguous();
-  indice_weights.contiguous();
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       host_weights.scalar_type(), "split_embedding_backward_exact_cpu", [&]() {

--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
@@ -15,6 +15,134 @@
 
 using namespace at;
 
+namespace {
+template <typename scalar_t>
+void split_embedding_backward_exact_cpu_kernel(
+    Tensor grad_output,
+    Tensor host_weights,
+    const TensorAccessor<int64_t, 1> weights_offsets_data,
+    const TensorAccessor<int, 1> D_offsets_data,
+    Tensor indices,
+    Tensor offsets,
+    int64_t pooling_mode,
+    Tensor indice_weights,
+    int num_tables,
+    int B,
+    const int* table_to_feature_offset,
+    {% if "momentum1_offsets" in args.split_function_arg_names %}
+    const TensorAccessor<int64_t, 1> momentum1_offsets_data,
+    {% endif %}
+    {% if "momentum2_offsets" in args.split_function_arg_names %}
+    const TensorAccessor<int64_t, 1> momentum2_offsets_data,
+    {% endif %}
+    {{ args.split_cpu_kernel_args | join(", ") }}) {
+  using grad_t = acc_type<scalar_t, true>;
+  ::internal::BatchedHyperCompressedSparseColumn batched_csc;
+  ::internal::batched_csr2csc(
+      batched_csc,
+      num_tables,
+      B,
+      offsets.data_ptr<int64_t>(),
+      indices.data_ptr<int64_t>(),
+      indice_weights.defined() ? indice_weights.data_ptr<grad_t>() : nullptr,
+      pooling_mode,
+      table_to_feature_offset);
+  std::vector<int>& table_ptr = batched_csc.table_ptr;
+  std::vector<int>& column_ptr = batched_csc.column_ptr;
+
+  auto grad_output_data = grad_output.accessor<grad_t, 2>();
+  auto host_weights_data = host_weights.accessor<scalar_t, 1>();
+
+  const bool has_weights = !batched_csc.weights.empty();
+
+  for (int t = 0; t < num_tables; ++t) {
+    int feature_begin = table_to_feature_offset[t];
+    const auto D_begin = D_offsets_data[feature_begin];
+    const auto D =
+        D_offsets_data[feature_begin + 1] - D_offsets_data[feature_begin];
+    const auto table_begin = weights_offsets_data[feature_begin];
+    grad_t grad_buffer[D];
+    for (int c = table_ptr[t]; c < table_ptr[t + 1]; ++c) {
+      memset(grad_buffer, 0, D * sizeof(grad_t));
+      int idx = batched_csc.column_indices[c];
+      const int64_t embedding_begin = table_begin + idx * D;
+      for (int r = column_ptr[c]; r < column_ptr[c + 1]; ++r) {
+        int f_times_b = batched_csc.row_indices[r];
+        int feature = f_times_b / B;
+        int b = f_times_b % B;
+        int D_offset = D_begin + (feature - feature_begin) * D;
+        for (int64_t d = 0; d < D; ++d) {
+          grad_buffer[d] += has_weights
+              ? grad_output_data[b][D_offset + d] * batched_csc.weights[r]
+              : grad_output_data[b][D_offset + d];
+        }
+      }
+      {{ split_weight_update_cpu }}
+    }
+  } // for each table
+}
+
+template <typename scalar_t>
+void split_embedding_backward_exact_cpu_dense_kernel(
+    Tensor grad,
+    Tensor grad_output,
+    Tensor host_weights,
+    const TensorAccessor<int64_t, 1> weights_offsets_data,
+    const TensorAccessor<int, 1> D_offsets_data,
+    Tensor indices,
+    Tensor offsets,
+    int64_t pooling_mode,
+    Tensor indice_weights,
+    int num_tables,
+    int B,
+    const int* table_to_feature_offset) {
+  using grad_t = acc_type<scalar_t, true>;
+  auto grad_data = grad.data_ptr<grad_t>();
+
+  auto grad_output_data = grad_output.accessor<grad_t, 2>();
+  auto host_weights_data = host_weights.accessor<scalar_t, 1>();
+
+  const auto indices_data = indices.accessor<int64_t, 1>();
+  const auto offsets_data = offsets.accessor<int64_t, 1>();
+  const auto indice_weights_data = indice_weights.defined()
+      ?
+      // If indice_weights are not defined, then this accessor won't be
+      // used
+      indice_weights.accessor<grad_t, 1>()
+      : grad.accessor<grad_t, 1>(); // this is just to make compiler
+                                    // happy
+
+  at::parallel_for(0, num_tables, 0, [&](int64_t t_begin, int64_t t_end) {
+    for (int64_t t = table_to_feature_offset[t_begin];
+          t < table_to_feature_offset[t_end];
+          ++t) {
+      const auto D_begin = D_offsets_data[t];
+      const auto D = D_offsets_data[t + 1] - D_offsets_data[t];
+      const auto table_begin = weights_offsets_data[t];
+      for (int64_t b = 0; b < B; ++b) {
+        const auto pool_begin = offsets_data[t * B + b];
+        const auto pool_end = offsets_data[t * B + b + 1];
+        const auto L = pool_end - pool_begin;
+        const double scale_factor =
+            // NOTE: MEAN pooling will not work with indice_weights!
+            (pooling_mode == MEAN && !indice_weights.defined() && L > 0)
+            ? 1.0 / L
+            : 1.0;
+        for (auto p = pool_begin; p < pool_end; ++p) {
+          const int64_t embedding_begin = table_begin + indices_data[p] * D;
+          for (int64_t d = 0; d < D; ++d) {
+            grad_data[embedding_begin + d] += scale_factor *
+                (indice_weights.defined()
+                      ? grad_output_data[b][D_begin + d] * indice_weights_data[p]
+                      : grad_output_data[b][D_begin + d]);
+          }
+        }
+      }
+    }
+  }); // parallel_for
+}
+} // namespace
+
 // The template for exact optimizers
 {{ "void" if not dense else "Tensor" }}  split_embedding_backward_codegen_{{ optimizer }}_cpu(
     Tensor grad_output,
@@ -43,23 +171,10 @@ using namespace at;
   int64_t B = (offsets.size(0) - 1) / T;
   TORCH_CHECK(B > 0);
 
-  {% if not dense %}
-  offsets.contiguous();
-  indices.contiguous();
-  indice_weights.contiguous();
-  {% endif %}
-
-  const auto D_offsets_data = D_offsets.accessor<int, 1>();
   const auto weights_offsets_data = weights_offsets.accessor<int64_t, 1>();
-  const auto offsets_data = offsets.accessor<int64_t, 1>();
-  const auto indices_data = indices.accessor<int64_t, 1>();
+  const auto D_offsets_data = D_offsets.accessor<int, 1>();
+
   const auto hash_size_cumsum_data = hash_size_cumsum.accessor<int64_t, 1>();
-  {% if "momentum1_offsets" in args.split_function_arg_names %}
-  const auto momentum1_offsets_data = momentum1_offsets.accessor<int64_t, 1>();
-  {% endif %}
-  {% if "momentum2_offsets" in args.split_function_arg_names %}
-  const auto momentum2_offsets_data = momentum2_offsets.accessor<int64_t, 1>();
-  {% endif %}
 
   int num_tables = 0; // # of physical tables
   int table_to_feature_offset[T + 1];
@@ -76,57 +191,39 @@ using namespace at;
   TORCH_CHECK(host_weights.dim() == 1);
 
   {% if not dense %}
+  {% if "momentum1_offsets" in args.split_function_arg_names %}
+  const auto momentum1_offsets_data = momentum1_offsets.accessor<int64_t, 1>();
+  {% endif %}
+  {% if "momentum2_offsets" in args.split_function_arg_names %}
+  const auto momentum2_offsets_data = momentum2_offsets.accessor<int64_t, 1>();
+  {% endif %}
+
+  offsets.contiguous();
+  indices.contiguous();
+  indice_weights.contiguous();
+
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       host_weights.scalar_type(), "split_embedding_backward_exact_cpu", [&]() {
-        {{ args.split_host_accessor_constructors | join("; ") }}
-
-        using grad_t = acc_type<scalar_t, true>;
-        ::internal::BatchedHyperCompressedSparseColumn batched_csc;
-        ::internal::batched_csr2csc(
-            batched_csc,
+        split_embedding_backward_exact_cpu_kernel<scalar_t>(
+            grad_output,
+            host_weights,
+            weights_offsets_data,
+            D_offsets_data,
+            indices,
+            offsets,
+            pooling_mode,
+            indice_weights,
             num_tables,
             B,
-            offsets.data_ptr<int64_t>(),
-            indices.data_ptr<int64_t>(),
-            indice_weights.defined() ? indice_weights.data_ptr<grad_t>()
-                                     : nullptr,
-            pooling_mode,
-            table_to_feature_offset);
-        std::vector<int>& table_ptr = batched_csc.table_ptr;
-        std::vector<int>& column_ptr = batched_csc.column_ptr;
-
-        auto grad_output_data = grad_output.accessor<grad_t, 2>();
-        auto host_weights_data = host_weights.accessor<scalar_t, 1>();
-
-        const bool has_weights = !batched_csc.weights.empty();
-
-        for (int t = 0; t < num_tables; ++t) {
-          int feature_begin = table_to_feature_offset[t];
-          const auto D_begin = D_offsets_data[feature_begin];
-          const auto D =
-              D_offsets_data[feature_begin + 1] - D_offsets_data[feature_begin];
-          const auto table_begin = weights_offsets_data[feature_begin];
-          grad_t grad_buffer[D];
-          for (int c = table_ptr[t]; c < table_ptr[t + 1]; ++c) {
-            memset(grad_buffer, 0, D * sizeof(grad_t));
-            auto idx = batched_csc.column_indices[c];
-            const int64_t embedding_begin = table_begin + idx * D;
-            for (int r = column_ptr[c]; r < column_ptr[c + 1]; ++r) {
-              int f_times_b = batched_csc.row_indices[r];
-              int feature = f_times_b / B;
-              int b = f_times_b % B;
-              int D_offset = D_begin + (feature - feature_begin) * D;
-              for (int64_t d = 0; d < D; ++d) {
-                grad_buffer[d] += has_weights
-                    ? grad_output_data[b][D_offset + d] * batched_csc.weights[r]
-                    : grad_output_data[b][D_offset + d];
-              }
-            }
-            {{ split_weight_update_cpu }}
-          }
-        } // for each table
+            table_to_feature_offset,
+            {% if "momentum1_offsets" in args.split_function_arg_names %}
+            momentum1_offsets_data,
+            {% endif %}
+            {% if "momentum2_offsets" in args.split_function_arg_names %}
+            momentum2_offsets_data,
+            {% endif %}
+            {{ args.split_cpu_kernel_arg_constructors | join(", ") }});
       });
-
 
   return;
 
@@ -134,54 +231,22 @@ using namespace at;
 
   // When input is dense enough, avoid sorting and just treat as dense.
   auto grad = zeros_like(host_weights, grad_output.dtype());
-
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       host_weights.scalar_type(), "split_embedding_backward_exact_cpu", [&]() {
-        {{ args.split_host_accessor_constructors | join("; ") }}
 
-        using grad_t = acc_type<scalar_t, true>;
-        auto grad_data = grad.data_ptr<grad_t>();
-        const auto indice_weights_data = indice_weights.defined()
-            ?
-            // If indice_weights are not defined, then this accessor won't be
-            // used
-            indice_weights.accessor<grad_t, 1>()
-            : grad.accessor<grad_t, 1>(); // this is just to make compiler
-                                          // happy
-
-        auto grad_output_data = grad_output.accessor<grad_t, 2>();
-        auto host_weights_data = host_weights.accessor<scalar_t, 1>();
-
-        at::parallel_for(0, num_tables, 0, [&](int64_t t_begin, int64_t t_end) {
-          for (int64_t t = table_to_feature_offset[t_begin];
-               t < table_to_feature_offset[t_end];
-               ++t) {
-            const auto D_begin = D_offsets_data[t];
-            const auto D = D_offsets_data[t + 1] - D_offsets_data[t];
-            const auto table_begin = weights_offsets_data[t];
-            for (int64_t b = 0; b < B; ++b) {
-              const auto pool_begin = offsets_data[t * B + b];
-              const auto pool_end = offsets_data[t * B + b + 1];
-              const auto L = pool_end - pool_begin;
-              const double scale_factor =
-                  // NOTE: MEAN pooling will not work with indice_weights!
-                  (pooling_mode == MEAN && !indice_weights.defined() && L > 0)
-                  ? 1.0 / L
-                  : 1.0;
-              for (auto p = pool_begin; p < pool_end; ++p) {
-                const int64_t embedding_begin =
-                    table_begin + indices_data[p] * D;
-                for (int64_t d = 0; d < D; ++d) {
-                  grad_data[embedding_begin + d] += scale_factor *
-                      (indice_weights.defined()
-                           ? grad_output_data[b][D_begin + d] *
-                               indice_weights_data[p]
-                           : grad_output_data[b][D_begin + d]);
-                }
-              }
-            }
-          }
-        }); // parallel_for
+        split_embedding_backward_exact_cpu_dense_kernel<scalar_t>(
+            grad,
+            grad_output,
+            host_weights,
+            weights_offsets_data,
+            D_offsets_data,
+            indices,
+            offsets,
+            pooling_mode,
+            indice_weights,
+            num_tables,
+            B,
+            table_to_feature_offset);
       }); // dispatch host_weights.scalar_type()
 
   return grad;

--- a/fbgemm_gpu/codegen/embedding_forward_split_cpu.h
+++ b/fbgemm_gpu/codegen/embedding_forward_split_cpu.h
@@ -51,9 +51,9 @@ void batched_csr2csc(
     BatchedHyperCompressedSparseColumn& batched_csc,
     int num_tables, // number of tables, not number of features
     int B,
-    const int64_t* batched_csr_offsets,
-    const int64_t* batched_csr_indices,
-    const scalar_t* batched_csr_weights,
+    const at::TensorAccessor<int64_t, 1>& batched_csr_offsets,
+    const at::TensorAccessor<int64_t, 1>& batched_csr_indices,
+    const at::TensorAccessor<scalar_t, 1>& batched_csr_weights,
     int64_t pooling_mode,
     const int* table_to_feature_offset);
 } // namespace internal


### PR DESCRIPTION
Summary: contiguous() doesn't mutate and returns a new tensor. Minimize contiguous calls by using TensorAccessor in csr2csc

Reviewed By: jianyuh

Differential Revision: D27560846

