### PR TITLE
optimize exact row-wise sparse adagrad on cpu

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_approx_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_approx_template.cpp
@@ -175,7 +175,9 @@ split_embedding_backward_codegen_{{ optimizer }}_cpu(
             eps,
             // fbgemm follows caffe2 convention of negative learning rate
             -learning_rate);
-        TORCH_CHECK(success); // TODO more friendly error msg
+        // TODO: more friendly error msg.
+        // See report_error_ in embedding_forward_split_cpu.cpp
+        TORCH_CHECK(success);
       }
     }); // parallel_for
     return;

--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
@@ -12,8 +12,22 @@
 #include <ATen/AccumulateType.h>
 
 #include "codegen/embedding_forward_split_cpu.h"
+#include "fbgemm/FbgemmEmbedding.h"
+#include "fbgemm/Types.h"
 
 using namespace at;
+
+namespace internal {
+template <typename T>
+struct half2float16 {
+  using type = T;
+};
+
+template <>
+struct half2float16<at::Half> {
+  using type = fbgemm::float16;
+};
+} // namespace internal
 
 namespace {
 template <typename scalar_t>
@@ -22,6 +36,7 @@ void split_embedding_backward_exact_cpu_kernel(
     Tensor host_weights,
     const TensorAccessor<int64_t, 1> weights_offsets_data,
     const TensorAccessor<int, 1> D_offsets_data,
+    Tensor hash_size_cumsum,
     Tensor indices,
     Tensor offsets,
     int64_t pooling_mode,
@@ -37,50 +52,146 @@ void split_embedding_backward_exact_cpu_kernel(
     {% endif %}
     {{ args.split_cpu_kernel_args | join(", ") }}) {
   using grad_t = acc_type<scalar_t, true>;
-  ::internal::BatchedHyperCompressedSparseColumn batched_csc;
-  ::internal::batched_csr2csc(
-      batched_csc,
-      num_tables,
-      B,
-      offsets.accessor<int64_t, 1>(),
-      indices.accessor<int64_t, 1>(),
-      indice_weights.defined()
-          ? indice_weights.accessor<grad_t, 1>()
-          : TensorAccessor<grad_t, 1>(nullptr, nullptr, nullptr),
-      pooling_mode,
-      table_to_feature_offset);
-  std::vector<int>& table_ptr = batched_csc.table_ptr;
-  std::vector<int>& column_ptr = batched_csc.column_ptr;
 
-  auto grad_output_data = grad_output.accessor<grad_t, 2>();
+  // const auto grad_output_accessor = grad_output.accessor<grad_t, 2>();
+  const grad_t* grad_output_data = grad_output.data_ptr<grad_t>();
   auto host_weights_data = host_weights.accessor<scalar_t, 1>();
+  const auto hash_size_cumsum_data = hash_size_cumsum.accessor<int64_t, 1>();
 
-  const bool has_weights = !batched_csc.weights.empty();
+  const bool has_weights = indice_weights.defined();
+  auto grad_stride = grad_output.size(1);
+
+  std::vector<::internal::BatchedHyperCompressedSparseColumn> batched_cscs(
+      num_tables);
+
+  at::parallel_for(0, num_tables, 0, [&](int64_t t_begin, int64_t t_end) {
+    for (int t = t_begin; t < t_end; ++t) {
+      int feature_begin = table_to_feature_offset[t];
+
+      ::internal::batched_csr2csc(
+          batched_cscs[t],
+          1,
+          B,
+          offsets.accessor<int64_t, 1>(),
+          indices.accessor<int64_t, 1>(),
+          indice_weights.defined()
+              ? indice_weights.accessor<grad_t, 1>()
+              : TensorAccessor<grad_t, 1>(nullptr, nullptr, nullptr),
+          pooling_mode,
+          table_to_feature_offset + t);
+    }
+  });
 
   for (int t = 0; t < num_tables; ++t) {
     int feature_begin = table_to_feature_offset[t];
+
+    int c_begin = batched_cscs[t].table_ptr[0];
+    int c_end = batched_cscs[t].table_ptr[1];
+    std::vector<int>& col_segment_ptr = batched_cscs[t].column_segment_ptr;
+    std::vector<int64_t>& col_segment_indices =
+        batched_cscs[t].column_segment_indices;
+
+    int64_t hash_size;
+    int t_temp = feature_begin + 1;
+    do {
+      hash_size =
+          hash_size_cumsum_data[t_temp] - hash_size_cumsum_data[feature_begin];
+      ++t_temp;
+    } while (hash_size == 0);
+
     const auto D_begin = D_offsets_data[feature_begin];
     const auto D =
         D_offsets_data[feature_begin + 1] - D_offsets_data[feature_begin];
     const auto table_begin = weights_offsets_data[feature_begin];
-    grad_t grad_buffer[D];
-    for (int c = table_ptr[t]; c < table_ptr[t + 1]; ++c) {
-      memset(grad_buffer, 0, D * sizeof(grad_t));
-      int idx = batched_csc.column_indices[c];
-      const int64_t embedding_begin = table_begin + idx * D;
-      for (int r = column_ptr[c]; r < column_ptr[c + 1]; ++r) {
-        int f_times_b = batched_csc.row_indices[r];
-        int feature = f_times_b / B;
-        int b = f_times_b % B;
-        int D_offset = D_begin + (feature - feature_begin) * D;
-        for (int64_t d = 0; d < D; ++d) {
-          grad_buffer[d] += has_weights
-              ? grad_output_data[b][D_offset + d] * batched_csc.weights[r]
-              : grad_output_data[b][D_offset + d];
+
+    {% if optimizer == "rowwise_adagrad" %}
+    constexpr bool use_fbgemm = std::is_same<scalar_t, float>::value;
+    // || std::is_same<scalar_t, at::Half>::value;
+    if (use_fbgemm &&
+        table_to_feature_offset[t + 1] == table_to_feature_offset[t] + 1) {
+      // fbgemm handles common case of no shared table
+      using fbgemm_weight_t = typename ::internal::half2float16<scalar_t>::type;
+      auto spmdm_kernel = fbgemm::GenerateEmbeddingSpMDMWithStrides<
+          fbgemm_weight_t,
+          /*IndexType=*/int32_t,
+          /*OffsetType=*/int32_t>(
+          D,
+          !batched_cscs[t].weights.empty(),
+          /*normalize_by_lengths=*/false,
+          /*prefetch=*/16,
+          /*is_weight_positional=*/false,
+          /*use_offsets=*/true,
+          /*output_stride=*/-1,
+          /*input_stride=*/grad_stride);
+      auto rowwise_adagrad_kernel =
+          fbgemm::GenerateSparseAdaGrad</*IndexType=*/int64_t>(
+              D, /*rowwise=*/true);
+
+      constexpr int C_BLOCK = 64;
+      at::parallel_for(c_begin, c_end, C_BLOCK, [&](int64_t c0, int64_t c1) {
+        grad_t grad_blocked_buffer[C_BLOCK * D];
+        for (int64_t c = c0; c < c1; c += C_BLOCK) {
+          const int* offsets_begin_ptr = col_segment_ptr.data() + c;
+          int64_t c_block_end = std::min(c + C_BLOCK, c1);
+          bool success = spmdm_kernel(
+              c_block_end - c,
+              col_segment_ptr[c_block_end] - *offsets_begin_ptr,
+              B,
+              reinterpret_cast<const fbgemm_weight_t*>(
+                  grad_output_data + D_begin),
+              batched_cscs[t].row_indices.data() + *offsets_begin_ptr,
+              offsets_begin_ptr,
+              batched_cscs[t].weights.empty()
+                  ? nullptr
+                  : batched_cscs[t].weights.data() + *offsets_begin_ptr,
+              reinterpret_cast<float*>(grad_blocked_buffer));
+          // TODO: more friendly error msg.
+          TORCH_CHECK(success);
+          int num_rows_processed = rowwise_adagrad_kernel(
+              c_block_end - c,
+              hash_size * D,
+              reinterpret_cast<float*>(&host_weights_data[table_begin]),
+              reinterpret_cast<const float*>(grad_blocked_buffer),
+              reinterpret_cast<float*>(
+                  &momentum1_host[momentum1_offsets_data[feature_begin]]),
+              col_segment_indices.data() + c,
+              eps,
+              -learning_rate,
+              /*weight_decay=*/0,
+              /*counter=*/nullptr,
+              /*counter_halflife=*/0);
+          // TODO: more friendly error msg.
+          TORCH_CHECK(num_rows_processed == c_block_end - c);
+        } // for each c
+      }); // parallel for
+    } else
+    {% endif %}
+    {
+      // no fbgemm
+      // TODO: to parallelize, we should easily identify segments belong to
+      // the same column.
+      grad_t grad_buffer[D];
+      for (int c = c_begin; c < c_end; ++c) {
+        int64_t idx = col_segment_indices[c];
+        if (c == c_begin || col_segment_indices[c - 1] != idx) {
+          memset(grad_buffer, 0, D * sizeof(grad_t));
         }
-      }
-      {{ split_weight_update_cpu }}
-    }
+        const int64_t embedding_begin = table_begin + idx * D;
+        int D_offset = D_begin + batched_cscs[t].column_segment_ids[c] * D;
+        for (int r = col_segment_ptr[c]; r < col_segment_ptr[c + 1]; ++r) {
+          int b = batched_cscs[t].row_indices[r];
+          for (int64_t d = 0; d < D; ++d) {
+            grad_buffer[d] += !batched_cscs[t].weights.empty()
+                ? grad_output_data[b * grad_stride + D_offset + d] *
+                    batched_cscs[t].weights[r]
+                : grad_output_data[b * grad_stride + D_offset + d];
+          }
+        }
+        if (c == c_end - 1 || col_segment_indices[c + 1] != idx) {
+          {{ split_weight_update_cpu }}
+        }
+      } // for each c
+    } // no fbgemm
   } // for each table
 }
 
@@ -200,6 +311,8 @@ void split_embedding_backward_exact_cpu_dense_kernel(
   const auto momentum2_offsets_data = momentum2_offsets.accessor<int64_t, 1>();
   {% endif %}
 
+  grad_output = grad_output.contiguous();
+
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       host_weights.scalar_type(), "split_embedding_backward_exact_cpu", [&]() {
         split_embedding_backward_exact_cpu_kernel<scalar_t>(
@@ -207,6 +320,7 @@ void split_embedding_backward_exact_cpu_dense_kernel(
             host_weights,
             weights_offsets_data,
             D_offsets_data,
+            hash_size_cumsum,
             indices,
             offsets,
             pooling_mode,

--- a/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
@@ -129,7 +129,7 @@ void split_embedding_forward_cpu_kernel(
       if (use_fbgemm) {
         using fbgemm_weight_t =
             typename ::internal::half2float16<weights_t>::type;
-        auto kernel = fbgemm::GenerateEmbeddingSpMDMWithOutputStride<
+        auto kernel = fbgemm::GenerateEmbeddingSpMDMWithStrides<
             fbgemm_weight_t,
             /*IndexType=*/int64_t,
             /*OffsetType=*/int64_t>(

--- a/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
@@ -107,24 +107,19 @@ void split_embedding_forward_cpu_kernel(
   constexpr bool use_fbgemm = std::is_same<weights_t, float>::value ||
       std::is_same<weights_t, at::Half>::value;
 
-  at::parallel_for(0, T * B, 0, [&](int64_t tb_begin, int64_t tb_end) {
-    int t_begin = tb_begin / B;
-    int t_end = (tb_end + B - 1) / B;
-    for (int t = t_begin; t < t_end; ++t) {
-      const auto D_begin = D_offsets_data[t];
-      const auto D = D_offsets_data[t + 1] - D_offsets_data[t];
-      const auto table_begin = weights_offsets_data[t];
+  for (int t = 0; t < T; ++t) {
+    const auto D_begin = D_offsets_data[t];
+    const auto D = D_offsets_data[t + 1] - D_offsets_data[t];
+    const auto table_begin = weights_offsets_data[t];
 
-      int64_t hash_size;
-      int t_temp = t + 1;
-      do {
-        hash_size = hash_size_cumsum_data[t_temp] - hash_size_cumsum_data[t];
-        ++t_temp;
-      } while (hash_size == 0);
+    int64_t hash_size;
+    int t_temp = t + 1;
+    do {
+      hash_size = hash_size_cumsum_data[t_temp] - hash_size_cumsum_data[t];
+      ++t_temp;
+    } while (hash_size == 0);
 
-      int b_begin = (t == t_begin) ? tb_begin % B : 0;
-      int b_end = (t == t_end - 1 && tb_end % B != 0) ? tb_end % B : B;
-
+    at::parallel_for(0, B, 0, [&](int64_t b_begin, int64_t b_end) {
       bool success = true;
       if (use_fbgemm) {
         using fbgemm_weight_t =
@@ -201,8 +196,8 @@ void split_embedding_forward_cpu_kernel(
         report_error_(
             t, B, b_begin, b_end, offsets_data, indices_data, hash_size);
       } // !success
-    } // for each t
-  }); // parallel for
+    }); // parallel for
+  } // for each t
 }
 
 Tensor split_embedding_codegen_forward_cpu(
@@ -273,8 +268,8 @@ void split_embedding_grad_indice_weights_cpu_kernel(
   const auto offsets_data = offsets.accessor<int64_t, 1>();
   const auto indices_data = indices.accessor<int64_t, 1>();
 
-  auto weights_data = weights.accessor<weights_t, 1>();
-  auto grad_output_data = grad_output.accessor<grad_t, 2>();
+  const auto weights_data = weights.accessor<weights_t, 1>();
+  const auto grad_output_data = grad_output.accessor<grad_t, 2>();
   auto grad_indice_weights_data = grad_indice_weights.accessor<grad_t, 1>();
   for (int64_t t = 0; t < T; ++t) {
     if (feature_requires_grad.defined() &&

--- a/fbgemm_gpu/codegen/embedding_forward_split_cpu.h
+++ b/fbgemm_gpu/codegen/embedding_forward_split_cpu.h
@@ -38,10 +38,14 @@ struct BatchedHyperCompressedSparseColumn {
   int num_tables; // # of matrices (or tables)
   // pointers to the beginning of each table in column_ptr (length T + 1)
   std::vector<int> table_ptr;
-  // pointers to the beginning of each column in row_indices
+  // pointers to the beginning of each column segment in row_indices
   // (length table_ptr[T] + 1)
-  std::vector<int> column_ptr;
-  std::vector<int64_t> column_indices; // length table_ptr[T]
+  // For a shared table, a column can have multiple segments, each for a
+  // feature sharing the table. In this case, the segments will have the
+  // same column_segment_indices but different column_segment_ids.
+  std::vector<int> column_segment_ptr;
+  std::vector<int64_t> column_segment_indices; // length table_ptr[T]
+  std::vector<int64_t> column_segment_ids; // length table_ptr[T]
   std::vector<int> row_indices; // length column_ptr[table_ptr[T]]
   std::vector<float> weights; // length column_ptr[table_ptr[T]]
 };

--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -75,6 +75,7 @@ FBGEMM_API
 
 /**
  * @param output_stride If -1, output_stride is same as block_size
+ * @param input_stride If -1, input_stride is same as block_size
  */
 template <
     typename InType,
@@ -82,14 +83,15 @@ template <
     typename OffsetType = std::int32_t>
 FBGEMM_API
     typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType>::Type
-    GenerateEmbeddingSpMDMWithOutputStride(
+    GenerateEmbeddingSpMDMWithStrides(
         const std::int64_t block_size,
         bool has_weight,
         bool normalize_by_lengths,
         int prefetch = 16,
         bool is_weight_positional = false,
         bool use_offsets = true,
-        std::int64_t output_stride = -1);
+        std::int64_t output_stride = -1,
+        std::int64_t input_stride = -1);
 
 /**
  * @tparam IndexType can be int32_t or int64_t

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -231,7 +231,8 @@ FBGEMM_API bool EmbeddingSpMDM_ref(
     float* out,
     bool is_weight_positional = false,
     bool use_offsets = true,
-    std::int64_t output_stride = -1);
+    std::int64_t output_stride = -1,
+    std::int64_t input_stride = -1);
 
 template <typename IndexType = std::int64_t, typename OffsetType = std::int32_t>
 FBGEMM_API bool EmbeddingSpMDMNBit_ref(

--- a/test/EmbeddingSpMDM8BitTest.cc
+++ b/test/EmbeddingSpMDM8BitTest.cc
@@ -51,9 +51,8 @@ namespace {
 class Fused8BitRowwiseEmbeddingLookupTest : public testing::TestWithParam<tuple<
                                                 bool,
                                                 bool,
-                                                bool,
                                                 int,
-                                                bool,
+                                                EmbeddingSpMDMWeightChoice,
                                                 bool,
                                                 bool,
                                                 EmbeddingSpMDMCornerCase>> {};
@@ -65,9 +64,11 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(
         ::testing::Bool(), // isIndex64b
         ::testing::Bool(), // isOffset64b
-        ::testing::Bool(), // is_wt_positional
         ::testing::ValuesIn(prefetch_distances),
-        ::testing::Bool(), // use_weight
+        ::testing::Values(
+            UNWEIGHTED,
+            WEIGHTED,
+            POSITIONAL_WEIGHTED), // use_weight
         ::testing::Bool(), // normalize_by_lengths
         ::testing::Bool(), // use_offsets
         ::testing::Values(
@@ -81,15 +82,17 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
   bool isIndex64b, isOffset64b, is_wt_positional, use_weight,
       normalize_by_lengths, use_offsets;
   int prefetch;
+  EmbeddingSpMDMWeightChoice weight_choice;
   EmbeddingSpMDMCornerCase corner_case;
   tie(isIndex64b,
       isOffset64b,
-      is_wt_positional,
       prefetch,
-      use_weight,
+      weight_choice,
       normalize_by_lengths,
       use_offsets,
       corner_case) = GetParam();
+  is_wt_positional = weight_choice == POSITIONAL_WEIGHTED;
+  use_weight = weight_choice != UNWEIGHTED;
 
   for (auto input : inputs) {
     int batch_size = input[0];
@@ -297,15 +300,17 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
   bool isIndex64b, isOffset64b, is_wt_positional, use_weight,
       normalize_by_lengths, use_offsets;
   int prefetch;
+  EmbeddingSpMDMWeightChoice weight_choice;
   EmbeddingSpMDMCornerCase corner_case;
   tie(isIndex64b,
       isOffset64b,
-      is_wt_positional,
       prefetch,
-      use_weight,
+      weight_choice,
       normalize_by_lengths,
       use_offsets,
       corner_case) = GetParam();
+  is_wt_positional = weight_choice == POSITIONAL_WEIGHTED;
+  use_weight = weight_choice != UNWEIGHTED;
 
   constexpr float sparsity = 0.7;
 

--- a/test/EmbeddingSpMDMNBitTest.cc
+++ b/test/EmbeddingSpMDMNBitTest.cc
@@ -55,9 +55,8 @@ class FusedNBitRowwiseEmbeddingLookupTest : public testing::TestWithParam<tuple<
                                                 int,
                                                 bool,
                                                 bool,
-                                                bool,
                                                 int,
-                                                bool,
+                                                EmbeddingSpMDMWeightChoice,
                                                 bool,
                                                 bool,
                                                 EmbeddingSpMDMCornerCase>> {};
@@ -70,9 +69,11 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Values(2, 4), // bit_rate
         ::testing::Bool(), // isIndex64b
         ::testing::Bool(), // isOffset64b
-        ::testing::Bool(), // is_wt_positional
         ::testing::ValuesIn(prefetch_distances),
-        ::testing::Bool(), // use_weight
+        ::testing::Values(
+            UNWEIGHTED,
+            WEIGHTED,
+            POSITIONAL_WEIGHTED), // use_weight
         ::testing::Bool(), // normalize_by_lengths
         ::testing::Bool(), // use_offsets
         ::testing::Values(
@@ -86,16 +87,18 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
   bool isIndex64b, isOffset64b, is_wt_positional, use_weight,
       normalize_by_lengths, use_offsets;
   int bit_rate, prefetch;
+  EmbeddingSpMDMWeightChoice weight_choice;
   EmbeddingSpMDMCornerCase corner_case;
   tie(bit_rate,
       isIndex64b,
       isOffset64b,
-      is_wt_positional,
       prefetch,
-      use_weight,
+      weight_choice,
       normalize_by_lengths,
       use_offsets,
       corner_case) = GetParam();
+  is_wt_positional = weight_choice == POSITIONAL_WEIGHTED;
+  use_weight = weight_choice != UNWEIGHTED;
 
   int num_elem_per_byte = 8 / bit_rate;
 
@@ -319,16 +322,18 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
   bool isIndex64b, isOffset64b, is_wt_positional, use_weight,
       normalize_by_lengths, use_offsets;
   int bit_rate, prefetch;
+  EmbeddingSpMDMWeightChoice weight_choice;
   EmbeddingSpMDMCornerCase corner_case;
   tie(bit_rate,
       isIndex64b,
       isOffset64b,
-      is_wt_positional,
       prefetch,
-      use_weight,
+      weight_choice,
       normalize_by_lengths,
       use_offsets,
       corner_case) = GetParam();
+  is_wt_positional = weight_choice == POSITIONAL_WEIGHTED;
+  use_weight = weight_choice != UNWEIGHTED;
 
   int num_elem_per_byte = 8 / bit_rate;
   constexpr float sparsity = 0.7;

--- a/test/EmbeddingSpMDMTestUtils.h
+++ b/test/EmbeddingSpMDMTestUtils.h
@@ -18,6 +18,12 @@ enum EmbeddingSpMDMCornerCase {
   UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM,
 };
 
+enum EmbeddingSpMDMWeightChoice {
+  UNWEIGHTED,
+  WEIGHTED,
+  POSITIONAL_WEIGHTED,
+};
+
 /**
  * @return lengths_sum
  */


### PR DESCRIPTION
Summary: Use embedding spmdm JIT'ed FBGEMM kernel for gradient coalescing and also use rowwise sparses adagrad JIT'ed kernel

Reviewed By: jiyuanzFB

Differential Revision: D27562367

