### PR TITLE
fix gpu device bug in split_table_batched_embeddings_benchmark

### DIFF
--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -37,7 +37,7 @@ def div_round_up(a: int, b: int) -> int:
 
 def get_device() -> torch.device:
     return (
-        torch.cuda.current_device if torch.cuda.is_available() else torch.device("cpu")
+        torch.cuda.current_device() if torch.cuda.is_available() else torch.device("cpu")
     )
 
 


### PR DESCRIPTION
Summary: Bug in get_device() function, where on a gpu machine (torch.cuda.is_available() == True) it returns torch.cuda.current_device instead of torch.cuda.current_device(). Therefore the return value for get_device() ends up being a function rather than a torch.device, causing the benchmark to crash at the first instance of device placement based on get_device().

Reviewed By: bilgeacun, jianyuh

Differential Revision: D27606621

