### PR TITLE
Permute Indices to FBGEMM

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ATen/ATen.h>
+
+namespace at {
+
+// // Return array of size T_in.numel(), representing incomplete exclusive cumsum
+Tensor asynchronous_exclusive_cumsum(const Tensor& t_in);
+
+std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_data_cuda(
+    const Tensor& permute,
+    const Tensor& lengths,
+    const Tensor& indices,
+    const c10::optional<Tensor>& weights);
+
+std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_data_cpu(
+    const Tensor& permute,
+    const Tensor& lengths,
+    const Tensor& indices,
+    const c10::optional<Tensor>& weights);
+
+}

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ATen/ATen.h>
+
+inline bool torch_tensor_on_cpu_check(const c10::optional<at::Tensor>& ten) {
+  return !ten.has_value() ||
+      !ten->is_cuda(); // TODO: Should be a better way to do this
+}
+
+inline std::string torch_tensor_device_name(const at::Tensor& ten) {
+  return c10::DeviceTypeName(ten.device().type());
+}
+
+inline std::string torch_tensor_device_name(
+    const c10::optional<at::Tensor>& ten) {
+  if (ten.has_value()) {
+    return c10::DeviceTypeName(ten->device().type());
+  } else {
+    return "No device: optional tensor unused.";
+  }
+}
+
+inline bool torch_tensor_on_same_device_check(
+    const at::Tensor& ten1,
+    const at::Tensor& ten2) {
+  return ten1.get_device() == ten2.get_device();
+}
+
+inline bool torch_tensor_on_same_device_check(
+    const at::Tensor& ten1,
+    const c10::optional<at::Tensor>& ten2) {
+  return !ten2.has_value() || ten1.get_device() == ten2->get_device();
+}
+
+inline bool torch_tensor_on_cuda_gpu_check(const at::Tensor& ten) {
+  return ten.is_cuda();
+}
+
+inline bool torch_tensor_on_cuda_gpu_check(
+    const c10::optional<at::Tensor>& ten) {
+  return !ten.has_value() || ten->is_cuda();
+}
+
+#define DISPATCH_TO_CUDA(name, function) \
+  m.impl(name, torch::dispatch(c10::DispatchKey::CUDA, TORCH_FN(function)))
+
+#define TENSOR_ON_CPU(x)                                      \
+  TORCH_CHECK(                                                \
+      torch_tensor_on_cpu_check(x),                           \
+      #x " must be a CPU tensor; it is currently on device ", \
+      torch_tensor_device_name(x))
+
+#define TENSORS_HAVE_SAME_TYPE(x, y)                       \
+  TORCH_CHECK(                                             \
+      (x).dtype() == (y).dtype(),                          \
+      #x " must have the same type as " #y " types were ", \
+      (x).dtype().name(),                                  \
+      " and ",                                             \
+      (y).dtype().name())
+
+#define TENSOR_ON_CUDA_GPU(x)                                  \
+  TORCH_CHECK(                                                 \
+      torch_tensor_on_cuda_gpu_check(x),                       \
+      #x " must be a CUDA tensor; it is currently on device ", \
+      torch_tensor_device_name(x))
+
+#define TENSORS_ON_SAME_DEVICE(x, y)                                       \
+  TORCH_CHECK(                                                             \
+      torch_tensor_on_same_device_check(x, y),                             \
+      #x " must be on the same device as " #y "! " #x " is currently on ", \
+      torch_tensor_device_name(x),                                         \
+      #y " is currently on ",                                              \
+      torch_tensor_device_name(y))
+
+#define TENSORS_HAVE_SAME_TYPE(x, y)                       \
+  TORCH_CHECK(                                             \
+      (x).dtype() == (y).dtype(),                          \
+      #x " must have the same type as " #y " types were ", \
+      (x).dtype().name(),                                  \
+      " and ",                                             \
+      (y).dtype().name())
+
+/// Determine an appropriate CUDA block count along the x axis
+///
+/// When launching CUDA kernels the number of blocks B is often calculated
+/// w.r.t. the number of threads T and items to be processed N as
+/// B=(N+T-1)/T - which is integer division rounding up.
+/// This function abstracts that calculation, performs it in an
+/// overflow-safe manner, and limits the return value appropriately.
+///
+/// This is a general function for all integral data types.
+/// The goal of this set of functions is to ensure correct calculations
+/// across a variety of data types without forcing the programmer to
+/// cast to an appropriate type (which is dangerous because we don't
+/// have conversion warnings enabled). The values of the variables
+/// can then be checked for correctness at run-time.
+/// Specialized functions below handle various combinations of signed
+/// and unsigned inputs. This system prevents "pointless comparison
+/// against zero" warnings from the compiler for unsigned types
+/// (simpler ways of suppressing this warning didn't work) while
+/// maintaining the various warnings.
+///
+/// Function is designed to facilitate run-time value checking.
+template <
+    typename Integer1,
+    typename Integer2,
+    std::enable_if_t<std::is_integral<Integer1>::value, bool> = true,
+    std::enable_if_t<std::is_integral<Integer2>::value, bool> = true>
+constexpr uint32_t cuda_calc_xblock_count_base(
+    Integer1 num_items,
+    Integer2 threads_per_block) {
+  // The number of threads can be as high as 2048 on some newer architectures,
+  // but this is not portable.
+  TORCH_CHECK(threads_per_block <= 1024, "Number of threads must be <=1024!");
+  // The CUDA specification at
+  // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications
+  // states that for compute capability 3.5-* the grid dimension of a kernel
+  // launch must must be <=2^31-1.
+  constexpr uint64_t max_blocks = 2147483647;
+  const auto u_num_items = static_cast<uint64_t>(num_items);
+  const auto u_threads = static_cast<uint64_t>(threads_per_block);
+  // Overflow safe variant of (a + b - 1) / b
+  const uint64_t blocks =
+      u_num_items / u_threads + (u_num_items % u_threads != 0);
+  return static_cast<uint32_t>(std::min(blocks, max_blocks));
+}
+
+// See: cuda_calc_xblock_count_base
+template <
+    typename Integer1,
+    typename Integer2,
+    std::enable_if_t<
+        std::is_integral<Integer1>::value && std::is_signed<Integer2>::value,
+        bool> = true,
+    std::enable_if_t<
+        std::is_integral<Integer2>::value && std::is_unsigned<Integer2>::value,
+        bool> = true>
+constexpr uint32_t cuda_calc_xblock_count(
+    Integer1 num_items,
+    Integer2 threads_per_block) {
+  TORCH_CHECK(
+      num_items >= 0,
+      "When calculating block counts, the number of items must be positive!");
+  return cuda_calc_xblock_count_base(num_items, threads_per_block);
+}
+
+// See: cuda_calc_xblock_count_base
+template <
+    typename Integer1,
+    typename Integer2,
+    std::enable_if_t<
+        std::is_integral<Integer1>::value && std::is_unsigned<Integer2>::value,
+        bool> = true,
+    std::enable_if_t<
+        std::is_integral<Integer2>::value && std::is_signed<Integer2>::value,
+        bool> = true>
+constexpr uint32_t cuda_calc_xblock_count(
+    Integer1 num_items,
+    Integer2 threads_per_block) {
+  TORCH_CHECK(
+      threads_per_block >= 0,
+      "When calculating thread counts, the number of threads must be positive!");
+  return cuda_calc_xblock_count_base(num_items, threads_per_block);
+}
+
+// See: cuda_calc_xblock_count_base
+template <
+    typename Integer1,
+    typename Integer2,
+    std::enable_if_t<
+        std::is_integral<Integer1>::value && std::is_signed<Integer2>::value,
+        bool> = true,
+    std::enable_if_t<
+        std::is_integral<Integer2>::value && std::is_signed<Integer2>::value,
+        bool> = true>
+constexpr uint32_t cuda_calc_xblock_count(
+    Integer1 num_items,
+    Integer2 threads_per_block) {
+  TORCH_CHECK(
+      num_items >= 0,
+      "When calculating block counts, the number of items must be positive!");
+  TORCH_CHECK(
+      threads_per_block >= 0,
+      "When calculating thread counts, the number of threads must be positive!");
+  return cuda_calc_xblock_count_base(num_items, threads_per_block);
+}
+
+// See: cuda_calc_xblock_count_base
+template <
+    typename Integer1,
+    typename Integer2,
+    std::enable_if_t<
+        std::is_integral<Integer1>::value && std::is_unsigned<Integer2>::value,
+        bool> = true,
+    std::enable_if_t<
+        std::is_integral<Integer2>::value && std::is_unsigned<Integer2>::value,
+        bool> = true>
+constexpr uint32_t cuda_calc_xblock_count(
+    Integer1 num_items,
+    Integer2 threads_per_block) {
+  return cuda_calc_xblock_count_base(num_items, threads_per_block);
+}
+
+/// Determine an appropriate CUDA block count.
+///
+/// See cuda_calc_xblock_count_base() for details.
+template <
+    typename Integer1,
+    typename Integer2,
+    std::enable_if_t<std::is_integral<Integer1>::value, bool> = true,
+    std::enable_if_t<std::is_integral<Integer2>::value, bool> = true>
+constexpr uint32_t cuda_calc_block_count(
+    Integer1 num_items,
+    Integer2 threads_per_block) {
+  // The CUDA specification at
+  // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications
+  // states that the grid dimension of a kernel launch must generally
+  // be <=65535. (For compute capability 3.5-* the grid's x-dimension must
+  // be <=2^31-1.) Because this function does not know which dimension
+  // is being calculated, we use the smaller limit.
+  constexpr uint32_t max_blocks = 65535;
+  return std::min(
+      cuda_calc_xblock_count(num_items, threads_per_block), max_blocks);
+}

--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -137,6 +137,8 @@ setup(
                 os.path.join(cur_dir, "src/quantize_wrappers.cu"),
                 os.path.join(cur_dir, "src/quantize_ops_host.cpp"),
                 os.path.join(cur_dir, "src/quantize_ops.cpp"),
+                os.path.join(cur_dir, "src/sparse_ops_host.cpp"),
+                os.path.join(cur_dir, "src/sparse_ops.cu"),
             ],
             include_dirs=[
                 cur_dir,

--- a/fbgemm_gpu/src/sparse_ops.cu
+++ b/fbgemm_gpu/src/sparse_ops.cu
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include "fbgemm_gpu/sparse_ops.cuh"
+#include "fbgemm_gpu/sparse_ops.h"
+#include "fbgemm_gpu/sparse_ops_utils.h"
+
+#include <ATen/ATen.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/Exceptions.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include <torch/library.h>
+
+#include "ATen/Parallel.h"
+#include "cub/device/device_scan.cuh"
+
+namespace at {
+
+Tensor asynchronous_exclusive_cumsum(const Tensor& t_in) {
+  at::cuda::OptionalCUDAGuard device_guard;
+  device_guard.set_index(t_in.get_device());
+  size_t temp_storage_bytes = 0;
+  TORCH_CHECK(t_in.is_contiguous());
+  TORCH_CHECK(t_in.dtype() == kInt || t_in.dtype() == kLong);
+  // CUB only handles up to INT_MAX elements.
+  TORCH_CHECK(t_in.numel() < std::numeric_limits<int32_t>::max());
+  auto t_out = at::empty_like(t_in);
+  AT_DISPATCH_INTEGRAL_TYPES(
+      t_in.scalar_type(), "cub_exclusive_sum_wrapper1", ([&] {
+        AT_CUDA_CHECK(cub::DeviceScan::ExclusiveSum(
+            nullptr,
+            temp_storage_bytes,
+            t_in.data_ptr<scalar_t>(),
+            t_out.data_ptr<scalar_t>(),
+            t_in.numel(),
+            at::cuda::getCurrentCUDAStream()));
+      }));
+  auto temp_storage = at::empty(
+      {static_cast<int64_t>(temp_storage_bytes)}, t_in.options().dtype(kByte));
+  AT_DISPATCH_INTEGRAL_TYPES(
+      t_in.scalar_type(), "cub_exclusive_sum_wrapper2", ([&] {
+        AT_CUDA_CHECK(cub::DeviceScan::ExclusiveSum(
+            temp_storage.data_ptr(),
+            temp_storage_bytes,
+            t_in.data_ptr<scalar_t>(),
+            t_out.data_ptr<scalar_t>(),
+            t_in.numel(),
+            at::cuda::getCurrentCUDAStream()));
+      }));
+  return t_out;
+}
+
+std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_data_cuda(
+    const Tensor& permute,
+    const Tensor& lengths,
+    const Tensor& indices,
+    const c10::optional<Tensor>& weights) {
+  TENSOR_ON_CUDA_GPU(permute);
+  TENSOR_ON_CUDA_GPU(lengths);
+  TENSOR_ON_CUDA_GPU(indices);
+  TENSOR_ON_CUDA_GPU(weights);
+
+  TENSORS_ON_SAME_DEVICE(permute, lengths);
+  TENSORS_ON_SAME_DEVICE(permute, indices);
+  TENSORS_ON_SAME_DEVICE(permute, weights);
+
+  at::cuda::OptionalCUDAGuard device_guard;
+  device_guard.set_index(indices.get_device());
+
+  const auto permute_contig = permute.contiguous();
+  const auto lengths_contig = lengths.contiguous();
+  const auto indices_contig = indices.contiguous();
+  // the data to permute over can be less or more with or without
+  // repetitions
+  const auto T = permute.numel();
+  const auto T_ = lengths.size(0);
+  const auto B = lengths.view({ lengths.sizes()[0], -1 }).sizes()[1];
+
+  Tensor permuted_lengths;
+  Tensor permuted_indices;
+  Tensor permuted_weights;
+
+  permuted_lengths = at::empty({T, B}, lengths.options());
+
+  constexpr int32_t threads_1 = 256;
+  const auto blocks_1 =
+      cuda_calc_xblock_count(B * T, threads_1);
+  AT_DISPATCH_INDEX_TYPES(
+      lengths.scalar_type(), "permute_lengths_kernel", ([&] {
+        permute_lengths_kernel<index_t>
+            <<<blocks_1, threads_1, 0, at::cuda::getCurrentCUDAStream()>>>(
+                T,
+                B,
+                lengths_contig.data_ptr<index_t>(),
+                permute.data_ptr<int32_t>(),
+                permuted_lengths.data_ptr<index_t>());
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      }));
+
+  // convert lengths to offsets
+  const auto input_offsets = asynchronous_exclusive_cumsum(lengths_contig);
+  const auto output_offsets = asynchronous_exclusive_cumsum(permuted_lengths);
+  int64_t permuted_lengths_sum = indices.numel();
+
+  /* TODO: Remove the condition protecting the slow path because even when the
+   * condition below is true permuted_lengths.sum() could still be needed. For
+   * instance if there are three features with indices `[0, 1, 2]`, `permute`
+   * can be `[0, 1, 1]` for which permuted lengths sum would be needed to create
+   * permuted_{indices, weights} and `permuted_lengths_sum = indices.numel() or
+   * weights.numdel() would be incorrect.
+   */
+  if (T_ != T) {
+    permuted_lengths_sum = permuted_lengths.sum().item<int64_t>();
+  }
+
+  constexpr int32_t BT_blocks = 32;
+  dim3 threads_2(32, BT_blocks);
+  const auto blocks_2 =
+      cuda_calc_xblock_count(B * T, BT_blocks);
+  permuted_indices = at::empty(permuted_lengths_sum, indices.options());
+
+  AT_DISPATCH_INDEX_TYPES(
+      input_offsets.scalar_type(), "permute_data_kernel_1", ([&] {
+        using offsets_t = index_t;
+        AT_DISPATCH_ALL_TYPES(
+          indices.scalar_type(), "permute_data_kernel_2", ([&] {
+            using indices_t = scalar_t;
+            if (weights.has_value()) {
+              const Tensor weights_value = weights.value();
+              const auto weights_value_contig = weights_value.contiguous();
+              permuted_weights = at::empty(permuted_lengths_sum, weights_value.options());
+              AT_DISPATCH_FLOATING_TYPES(
+                weights_value.scalar_type(), "permute_data_kernel_3", ([&] {
+                  using weights_t = scalar_t;
+                  permute_data_kernel<true, offsets_t, indices_t, weights_t>
+                      <<<blocks_2,
+                        threads_2,
+                        0,
+                        at::cuda::getCurrentCUDAStream()>>>(
+                          permuted_lengths_sum,
+                          T,
+                          B,
+                          indices_contig.data_ptr<indices_t>(),
+                          weights_value_contig.data_ptr<weights_t>(),
+                          permute_contig.data_ptr<int32_t>(),
+                          input_offsets.data_ptr<offsets_t>(),
+                          output_offsets.data_ptr<offsets_t>(),
+                          permuted_indices.data_ptr<indices_t>(),
+                          permuted_weights.data_ptr<weights_t>());
+                  C10_CUDA_KERNEL_LAUNCH_CHECK();
+                })); // for each weights_t
+              } else {
+                permute_data_kernel<false, offsets_t, indices_t, std::nullptr_t>
+                    <<<blocks_2,
+                      threads_2,
+                      0,
+                      at::cuda::getCurrentCUDAStream()>>>(
+                        permuted_lengths_sum,
+                        T,
+                        B,
+                        indices_contig.data_ptr<indices_t>(),
+                        nullptr,
+                        permute_contig.data_ptr<int32_t>(),
+                        input_offsets.data_ptr<offsets_t>(),
+                        output_offsets.data_ptr<offsets_t>(),
+                        permuted_indices.data_ptr<indices_t>(),
+                        nullptr);
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+              }
+          })); // for each indices_t
+        })); // for each offsets_t
+  return {permuted_lengths, permuted_indices, permuted_weights};
+}
+
+} // namespace at

--- a/fbgemm_gpu/src/sparse_ops_host.cpp
+++ b/fbgemm_gpu/src/sparse_ops_host.cpp
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbgemm_gpu/sparse_ops.h"
+#include "fbgemm_gpu/sparse_ops_utils.h"
+
+#include <ATen/ATen.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <torch/library.h>
+
+#include "ATen/Parallel.h"
+
+namespace at {
+
+namespace {
+// To avoid multiple threads are touching the same cache line.
+// Assume cache line size is 64B and element size is at least 4B like float or
+// int32.
+constexpr int FALSE_SHARING_PAD = 16;
+
+} // namespace
+
+// NOTE : _permute_indices_weights_kernel_cpu and _permute_lengths_cpu_kernel
+// have to use the same grain size for consistent partitioning across threads.
+template <bool has_weight, typename offsets_t, typename indices_t, typename weights_t>
+void _permute_indices_weights_kernel_cpu(
+    const int32_t T,
+    const int32_t B,
+    const indices_t* const __restrict__ indices,
+    const weights_t* const __restrict__ weights,
+    const int32_t* const __restrict__ permute,
+    const offsets_t* const __restrict__ input_offsets,
+    const int64_t* const __restrict__ output_offsets_per_thread_cumsum,
+    indices_t* const __restrict__ permuted_indices,
+    weights_t* const __restrict__ permuted_weights,
+    const offsets_t* const __restrict__ permuted_lengths) {
+  at::parallel_for(
+      0, T * B, FALSE_SHARING_PAD, [&](int64_t tb_begin, int64_t tb_end) {
+        offsets_t output_start = output_offsets_per_thread_cumsum
+            [get_thread_num() * FALSE_SHARING_PAD];
+        int64_t t_begin = tb_begin / B;
+        int64_t t_end = (tb_end + B - 1) / B;
+        for (int t = t_begin; t < t_end; ++t) {
+          int64_t b_begin = (t == t_begin) ? tb_begin % B : 0;
+          int64_t b_end = (t == t_end - 1 && tb_end % B != 0) ? tb_end % B : B;
+          for (int b = b_begin; b < b_end; ++b) {
+            offsets_t permuted_length = permuted_lengths[t * B + b];
+            const offsets_t input_start = input_offsets[permute[t] * B + b];
+            for (const auto i : c10::irange(permuted_length)) {
+              permuted_indices[output_start + i] = indices[input_start + i];
+              if (has_weight) {
+                permuted_weights[output_start + i] = weights[input_start + i];
+              }
+            }
+            output_start += permuted_length;
+          } // for each b
+        } // for each t
+      }); // parallel_for T * B
+}
+
+template <typename index_t>
+void _permute_lengths_cpu_kernel(
+    const int32_t T,
+    const int32_t B,
+    const index_t* const __restrict__ lengths,
+    int64_t lengths_size,
+    const int32_t* const __restrict__ permute,
+    index_t* const __restrict__ permuted_lengths,
+    index_t* const __restrict__ input_offsets,
+    int64_t* const __restrict__ output_offsets_per_thread_cumsum) {
+  int num_threads = get_num_threads();
+  std::vector<int> input_offsets_per_thread_cumsum(
+      (num_threads + 1) * FALSE_SHARING_PAD, 0);
+
+  // First parallel for: populate permuted_lengths, and compute per-thread
+  // summation of lengths (input_offsets_per_thread_cumsum) and permuted_lengths
+  // (output_offsets_per_thread_cumsum)
+  at::parallel_for(
+      0, T * B, FALSE_SHARING_PAD, [&](int64_t tb_begin, int64_t tb_end) {
+        index_t current_input_offset = 0;
+        // Have a separate loop for summing up lengths because lengths_size
+        // can be smaller than T * B.
+        for (int tb = tb_begin; tb < std::min(tb_end, lengths_size); ++tb) {
+          current_input_offset += lengths[tb];
+        }
+
+        index_t current_output_offset = 0;
+        int64_t t_begin = tb_begin / B;
+        int64_t t_end = (tb_end + B - 1) / B;
+        for (int t = t_begin; t < t_end; ++t) {
+          int64_t b_begin = (t == t_begin) ? tb_begin % B : 0;
+          int64_t b_end = (t == t_end - 1 && tb_end % B != 0) ? tb_end % B : B;
+          for (int b = b_begin; b < b_end; ++b) {
+            auto permuted_length = lengths[permute[t] * B + b];
+            permuted_lengths[t * B + b] = permuted_length;
+            current_output_offset += permuted_length;
+          }
+        }
+        input_offsets_per_thread_cumsum
+            [(get_thread_num() + 1) * FALSE_SHARING_PAD] = current_input_offset;
+        output_offsets_per_thread_cumsum
+            [(get_thread_num() + 1) * FALSE_SHARING_PAD] =
+                current_output_offset;
+      });
+
+  // Inter-thread reduction
+  for (int t = 1; t < num_threads; ++t) {
+    input_offsets_per_thread_cumsum[(t + 1) * FALSE_SHARING_PAD] +=
+        input_offsets_per_thread_cumsum[t * FALSE_SHARING_PAD];
+    output_offsets_per_thread_cumsum[(t + 1) * FALSE_SHARING_PAD] +=
+        output_offsets_per_thread_cumsum[t * FALSE_SHARING_PAD];
+  }
+
+  // Second parallel for: populate input_offsets
+  // NOTE: this works assuming the partitioning will be the same as the
+  // first parallel_for.
+  at::parallel_for(
+      0, T * B, FALSE_SHARING_PAD, [&](int64_t tb_begin, int64_t tb_end) {
+        index_t current_input_offset = input_offsets_per_thread_cumsum
+            [get_thread_num() * FALSE_SHARING_PAD];
+        if (tb_begin < lengths_size) {
+          input_offsets[tb_begin] = current_input_offset;
+        }
+        for (int tb = tb_begin; tb < std::min(tb_end - 1, lengths_size); ++tb) {
+          current_input_offset += lengths[tb];
+          input_offsets[tb + 1] = current_input_offset;
+        }
+      });
+  if (lengths_size >= T * B) {
+    input_offsets[T * B] =
+        input_offsets_per_thread_cumsum[num_threads * FALSE_SHARING_PAD];
+  }
+
+  // Handle cases when lengths_size > T * B
+  for (auto i = T * B; i < lengths_size; ++i) {
+    input_offsets[i + 1] = lengths[i] + input_offsets[i];
+  }
+}
+
+std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_data_cpu(
+    const Tensor& permute,
+    const Tensor& lengths,
+    const Tensor& indices,
+    const c10::optional<Tensor>& weights) {
+  TENSOR_ON_CPU(permute);
+  TENSOR_ON_CPU(lengths);
+  TENSOR_ON_CPU(indices);
+  TENSOR_ON_CPU(weights);
+
+  const auto permute_contig = permute.expect_contiguous();
+  const auto lengths_contig = lengths.expect_contiguous();
+  const auto indices_contig = indices.expect_contiguous();
+  // the data to permute over can be less or more with or without
+  // repetitions
+  const auto T = permute.numel();
+  const auto B = lengths.view({ lengths.sizes()[0], -1 }).sizes()[1];
+
+  Tensor permuted_lengths;
+  Tensor permuted_indices;
+  Tensor permuted_weights;
+
+  permuted_lengths = at::empty({T, B}, lengths.options());
+
+  const auto lengths_size = lengths.numel();
+  auto input_offsets = at::empty({lengths_size + 1}, lengths.options());
+
+  int num_threads = get_num_threads();
+  std::vector<int64_t> output_offsets_per_thread_cumsum(
+      (num_threads + 1) * FALSE_SHARING_PAD, 0);
+
+  AT_DISPATCH_INDEX_TYPES(
+      lengths.scalar_type(), "permute_lengths_cpu_kernel", ([&] {
+        _permute_lengths_cpu_kernel(
+            T,
+            B,
+            lengths_contig->data_ptr<index_t>(),
+            lengths_size,
+            permute.data_ptr<int32_t>(),
+            permuted_lengths.data_ptr<index_t>(),
+            input_offsets.data_ptr<index_t>(),
+            output_offsets_per_thread_cumsum.data());
+      })); // for each scalar_t
+
+  auto permuted_lengths_sum =
+      output_offsets_per_thread_cumsum[num_threads * FALSE_SHARING_PAD];
+  permuted_indices = at::empty(permuted_lengths_sum, indices.options());
+  AT_DISPATCH_INDEX_TYPES(
+      input_offsets.scalar_type(), "permute_indices_weights_kernel_1", ([&] {
+        using offsets_t = index_t;
+        AT_DISPATCH_ALL_TYPES(
+          indices.scalar_type(), "permute_indices_weights_kernel_2", ([&] {
+            using indices_t = scalar_t;
+            AT_DISPATCH_FLOATING_TYPES(
+                weights.has_value() ? weights.value().scalar_type()
+                                    : ScalarType::Float,
+                "permute_indices_weights_kernel_3",
+                ([&] {
+                  using weights_t = scalar_t;
+                  if (weights.has_value()) {
+                    const auto weights_value_contig =
+                        weights.value().expect_contiguous();
+                    permuted_weights =
+                        at::empty(permuted_lengths_sum, weights.value().options());
+                    _permute_indices_weights_kernel_cpu<true, index_t, indices_t, weights_t>(
+                        T,
+                        B,
+                        indices_contig->data_ptr<indices_t>(),
+                        weights_value_contig->data_ptr<weights_t>(),
+                        permute_contig->data_ptr<int32_t>(),
+                        input_offsets.data_ptr<offsets_t>(),
+                        output_offsets_per_thread_cumsum.data(),
+                        permuted_indices.data_ptr<indices_t>(),
+                        permuted_weights.data_ptr<weights_t>(),
+                        permuted_lengths.data_ptr<offsets_t>());
+                  } else {
+                    _permute_indices_weights_kernel_cpu<false, index_t, indices_t, weights_t>(
+                        T,
+                        B,
+                        indices_contig->data_ptr<indices_t>(),
+                        nullptr,
+                        permute_contig->data_ptr<int32_t>(),
+                        input_offsets.data_ptr<offsets_t>(),
+                        output_offsets_per_thread_cumsum.data(),
+                        permuted_indices.data_ptr<indices_t>(),
+                        nullptr,
+                        permuted_lengths.data_ptr<offsets_t>());
+                  }
+            })); // for each weights_t
+          })); // for each indices_t
+      })); // for each offsets_t
+  return {permuted_lengths, permuted_indices, permuted_weights};
+}
+
+} // namespace at
+
+TORCH_LIBRARY_FRAGMENT(fb, m) {
+  m.def("asynchronous_exclusive_cumsum(Tensor t_in) -> Tensor");
+  m.def(
+      "permute_sparse_data(Tensor permute, Tensor lengths, Tensor values, Tensor? weights=None) -> (Tensor, Tensor, Tensor?)");
+}
+
+TORCH_LIBRARY_IMPL(fb, CPU, m) {
+  m.impl("permute_sparse_data", at::permute_sparse_data_cpu);
+}
+
+TORCH_LIBRARY_IMPL(fb, CUDA, m) {
+  DISPATCH_TO_CUDA(
+      "asynchronous_exclusive_cumsum", at::asynchronous_exclusive_cumsum);
+  DISPATCH_TO_CUDA("permute_sparse_data", at::permute_sparse_data_cuda);
+}

--- a/fbgemm_gpu/test/sparse_ops_test.py
+++ b/fbgemm_gpu/test/sparse_ops_test.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+
+import unittest
+import random
+from typing import Optional, Tuple
+from itertools import accumulate
+
+import hypothesis.strategies as st
+
+import torch
+from hypothesis import Verbosity, given, settings
+
+try:
+    torch.ops.load_library("fbgemm_gpu_py.so")
+except Exception:
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
+
+
+class SparseOpsTest(unittest.TestCase):
+    @staticmethod
+    def permute_indices_ref_(
+        lengths: torch.Tensor,
+        indices: torch.Tensor,
+        weights: Optional[torch.Tensor],
+        permute: torch.LongTensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+        T = lengths.size(0)
+        permuted_lengths = torch.index_select(lengths.view(T, -1), 0, permute)
+
+        # pyre-fixme[28]: Unexpected keyword argument `dtype`.
+        original_segment_lengths = lengths.view(T, -1).sum(dim=1, dtype=torch.int32)
+        original_segment_start = [0] + list(
+            accumulate(original_segment_lengths.view(-1))
+        )
+
+        permuted_indices = []
+        permuted_weights = []
+        for i in range(permute.size(0)):
+            start = original_segment_start[permute[i]]
+            end = start + original_segment_lengths[permute[i]]
+            permuted_indices.append(indices[start:end])
+            if weights is not None:
+                permuted_weights.append(weights[start:end])
+
+        permuted_indices = torch.cat(permuted_indices, dim=0).flatten()
+
+        if weights is None:
+            permuted_weights = None
+        else:
+            permuted_weights = torch.cat(permuted_weights, dim=0).flatten()
+
+        return permuted_lengths, permuted_indices, permuted_weights
+
+
+    # pyre-ignore [56]: Invalid decoration, was not able to infer the type of argument
+    @given(
+        B=st.integers(min_value=1, max_value=20),
+        T=st.integers(min_value=1, max_value=20),
+        L=st.integers(min_value=2, max_value=20),
+        long_index=st.booleans(),
+        has_weight=st.booleans(),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    def test_permute_indices(
+        self, B: int, T: int, L: int, long_index: bool, has_weight: bool
+    ) -> None:
+        index_dtype = torch.int64 if long_index else torch.int32
+        lengths = torch.randint(low=1, high=L, size=(T, B)).type(index_dtype)
+        weights = torch.rand(lengths.sum().item()).float() if has_weight else None
+        indices = torch.randint(
+            low=1,
+            high=int(1e5),
+            # pyre-fixme[6]: Expected `Union[int, typing.Tuple[int, ...]]` for 3rd
+            #  param but got `Tuple[typing.Union[float, int]]`.
+            size=(lengths.sum().item(),),
+        ).type(index_dtype)
+        permute_list = list(range(T))
+        random.shuffle(permute_list)
+        permute = torch.IntTensor(permute_list)
+
+        (
+            permuted_lengths_cpu,
+            permuted_indices_cpu,
+            permuted_weights_cpu,
+        ) = torch.ops.fb.permute_sparse_data(permute, lengths, indices, weights)
+        (
+            permuted_lengths_ref,
+            permuted_indices_ref,
+            permuted_weights_ref,
+        ) = self.permute_indices_ref_(lengths, indices, weights, permute.long())
+        torch.testing.assert_allclose(permuted_indices_cpu, permuted_indices_ref)
+        torch.testing.assert_allclose(permuted_lengths_cpu, permuted_lengths_ref)
+        if has_weight:
+            torch.testing.assert_allclose(permuted_weights_cpu, permuted_weights_ref)
+        else:
+            assert permuted_weights_cpu is None and permuted_weights_ref is None
+
+        if torch.cuda.is_available():
+            (
+                permuted_lengths_gpu,
+                permuted_indices_gpu,
+                permuted_weights_gpu,
+            ) = torch.ops.fb.permute_sparse_data(
+                permute.cuda(),
+                lengths.cuda(),
+                indices.cuda(),
+                weights.cuda() if has_weight else None,
+            )
+            torch.testing.assert_allclose(
+                permuted_indices_gpu.cpu(), permuted_indices_cpu
+            )
+            torch.testing.assert_allclose(
+                permuted_lengths_gpu.cpu(), permuted_lengths_cpu
+            )
+            if has_weight:
+                torch.testing.assert_allclose(
+                    permuted_weights_gpu.cpu(), permuted_weights_cpu
+                )
+            else:
+                assert permuted_weights_gpu is None
+
+    # pyre-ignore [56]: Invalid decoration, was not able to infer the type of argument
+    @given(
+        B=st.integers(min_value=1, max_value=20),
+        T=st.integers(min_value=1, max_value=20),
+        L=st.integers(min_value=2, max_value=20),
+        long_index=st.booleans(),
+        has_weight=st.booleans(),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    def test_permute_indices_with_repeats(
+        self, B: int, T: int, L: int, long_index: bool, has_weight: bool
+    ) -> None:
+        index_dtype = torch.int64 if long_index else torch.int32
+        lengths = torch.randint(low=1, high=L, size=(T, B)).type(index_dtype)
+        weights = torch.rand(lengths.sum().item()).float() if has_weight else None
+        indices = torch.randint(
+            low=1,
+            high=int(1e5),
+            # pyre-fixme[6]: Expected `Union[int, typing.Tuple[int, ...]]` for 3rd
+            #  param but got `Tuple[typing.Union[float, int]]`.
+            size=(lengths.sum().item(),),
+        ).type(index_dtype)
+        permute_list = list(range(T))
+
+        num_repeats = random.randint(0, T)
+        for _ in range(num_repeats):
+            permute_list.append(random.randint(0, T - 1))
+
+        random.shuffle(permute_list)
+        permute = torch.IntTensor(permute_list)
+
+        (
+            permuted_lengths_cpu,
+            permuted_indices_cpu,
+            permuted_weights_cpu,
+        ) = torch.ops.fb.permute_sparse_data(permute, lengths, indices, weights)
+        (
+            permuted_lengths_ref,
+            permuted_indices_ref,
+            permuted_weights_ref,
+        ) = self.permute_indices_ref_(lengths, indices, weights, permute.long())
+        torch.testing.assert_allclose(permuted_indices_cpu, permuted_indices_ref)
+        torch.testing.assert_allclose(permuted_lengths_cpu, permuted_lengths_ref)
+        if has_weight:
+            torch.testing.assert_allclose(permuted_weights_cpu, permuted_weights_ref)
+        else:
+            assert permuted_weights_cpu is None and permuted_weights_ref is None
+
+        if torch.cuda.is_available():
+            (
+                permuted_lengths_gpu,
+                permuted_indices_gpu,
+                permuted_weights_gpu,
+            ) = torch.ops.fb.permute_sparse_data(
+                permute.cuda(),
+                lengths.cuda(),
+                indices.cuda(),
+                weights.cuda() if has_weight else None,
+            )
+            torch.testing.assert_allclose(
+                permuted_indices_gpu.cpu(), permuted_indices_cpu
+            )
+            torch.testing.assert_allclose(
+                permuted_lengths_gpu.cpu(), permuted_lengths_cpu
+            )
+            if has_weight:
+                torch.testing.assert_allclose(
+                    permuted_weights_gpu.cpu(), permuted_weights_cpu
+                )
+            else:
+                assert permuted_weights_cpu is None
+
+    # pyre-ignore [56]: Invalid decoration, was not able to infer the type of argument
+    @given(
+        D=st.integers(min_value=5, max_value=20),
+        B=st.integers(min_value=1, max_value=20),
+        T=st.integers(min_value=1, max_value=20),
+        L=st.integers(min_value=2, max_value=20),
+        long_index=st.booleans(),
+        has_weight=st.booleans(),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    def test_permute_indices_multi_dimension(
+        self, D: int, B: int, T: int, L: int, long_index: bool, has_weight: bool
+    ) -> None:
+        index_dtype = torch.int64 if long_index else torch.int32
+        lengths = torch.randint(low=1, high=L, size=(T, B, D)).type(index_dtype)
+        weights = torch.rand(lengths.sum().item()).float() if has_weight else None
+        indices = torch.randint(
+            low=1,
+            high=int(1e5),
+            # pyre-fixme[6]: Expected `Union[int, typing.Tuple[int, ...]]` for 3rd
+            #  param but got `Tuple[typing.Union[float, int]]`.
+            size=(lengths.sum().item(),),
+        ).type(index_dtype)
+        permute_list = list(range(T))
+        random.shuffle(permute_list)
+        permute = torch.IntTensor(permute_list)
+
+        (
+            permuted_lengths_cpu,
+            permuted_indices_cpu,
+            permuted_weights_cpu,
+        ) = torch.ops.fb.permute_sparse_data(permute, lengths, indices, weights)
+        (
+            permuted_lengths_ref,
+            permuted_indices_ref,
+            permuted_weights_ref,
+        ) = self.permute_indices_ref_(lengths, indices, weights, permute.long())
+        torch.testing.assert_allclose(permuted_indices_cpu, permuted_indices_ref)
+        torch.testing.assert_allclose(permuted_lengths_cpu, permuted_lengths_ref)
+        if has_weight:
+            torch.testing.assert_allclose(permuted_weights_cpu, permuted_weights_ref)
+        else:
+            assert permuted_weights_cpu is None and permuted_weights_ref is None
+
+        if torch.cuda.is_available():
+            (
+                permuted_lengths_gpu,
+                permuted_indices_gpu,
+                permuted_weights_gpu,
+            ) = torch.ops.fb.permute_sparse_data(
+                permute.cuda(),
+                lengths.cuda(),
+                indices.cuda(),
+                weights.cuda() if has_weight else None,
+            )
+            torch.testing.assert_allclose(
+                permuted_indices_gpu.cpu(), permuted_indices_cpu
+            )
+            torch.testing.assert_allclose(
+                permuted_lengths_gpu.cpu(), permuted_lengths_cpu
+            )
+            if has_weight:
+                torch.testing.assert_allclose(
+                    permuted_weights_gpu.cpu(), permuted_weights_cpu
+                )
+            else:
+                assert permuted_weights_cpu is None
+
+    # pyre-ignore [56]: Invalid decoration, was not able to infer the type of argument
+    @given(
+        B=st.integers(min_value=1, max_value=20),
+        T=st.integers(min_value=1, max_value=20),
+        L=st.integers(min_value=2, max_value=20),
+        long_index=st.booleans(),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    def test_permute_embeddings(self, B: int, T: int, L: int, long_index: bool) -> None:
+        index_dtype = torch.int32 if long_index else torch.int32
+        lengths = torch.randint(low=1, high=L, size=(T, B)).type(index_dtype)
+        embeddings = torch.rand(lengths.sum().item()).float()
+        permute_list = list(range(T))
+        random.shuffle(permute_list)
+        permute = torch.IntTensor(permute_list)
+
+        (
+            permuted_lengths_cpu,
+            permuted_embeddings_cpu,
+            _,
+        ) = torch.ops.fb.permute_sparse_data(permute, lengths, embeddings, None)
+        (
+            permuted_lengths_ref,
+            permuted_embeddings_ref,
+            _,
+        ) = self.permute_indices_ref_(lengths, embeddings, None, permute.long())
+        torch.testing.assert_allclose(permuted_embeddings_cpu, permuted_embeddings_ref)
+        torch.testing.assert_allclose(permuted_lengths_cpu, permuted_lengths_ref)
+
+        if torch.cuda.is_available():
+            (
+                permuted_lengths_gpu,
+                permuted_embeddings_gpu,
+                _,
+            ) = torch.ops.fb.permute_sparse_data(
+                permute.cuda(),
+                lengths.cuda(),
+                embeddings.cuda(),
+                None,
+            )
+            torch.testing.assert_allclose(
+                permuted_embeddings_gpu.cpu(), permuted_embeddings_cpu
+            )
+            torch.testing.assert_allclose(
+                permuted_lengths_gpu.cpu(), permuted_lengths_cpu
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
permute_sparse_data op

Supports permuting "indices" (index or subsequent embedding), and optional weights.

Reviewed By: jianyuh

Differential Revision: D27699170

