### PR TITLE
Fix ref call in GenerateEmbeddingSpMDMWithStrides

### DIFF
--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -978,6 +978,7 @@ GenerateEmbeddingSpMDMWithStrides(
           normalize_by_lengths,
           out,
           is_weight_positional,
+          use_offsets,
           output_stride,
           input_stride);
     };


### PR DESCRIPTION
GenerateEmbeddingSpMDMWithStrides takes two booleans and than two ints (strides) after output pointer