### PR TITLE
fix ref call in RowWiseSparseAdagradFused

### DIFF
--- a/src/RowWiseSparseAdagradFused.cc
+++ b/src/RowWiseSparseAdagradFused.cc
@@ -931,6 +931,7 @@ GenerateRowWiseSparseAdaGradFused(
           lr,
           use_offsets,
           use_stochastic_rounding,
+          /*emu_vector_size=*/8,
           grad_stride);
     };
   }


### PR DESCRIPTION
Summary: Similar to D28247900 (https://github.com/pytorch/FBGEMM/commit/5acd437fdb0c8168e164c1c9f4a22d1c7c8af924) error related to default argument

Reviewed By: malfet

Differential Revision: D28247980

