### PR TITLE
int8 table batched embedding bag on cpu

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -870,15 +870,23 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 torch.empty(0, device=self.current_device, dtype=dtype),
             )
         if split.host_size > 0:
-            setattr(
-                self,
-                f"{prefix}_host",
-                nn.Parameter(
+            if dtype == torch.uint8:
+                self.register_buffer(
+                    f"{prefix}_host",
                     torch.zeros(
                         split.host_size, device=self.current_device, dtype=dtype
-                    )
-                ),
-            )
+                    ),
+                )
+            else:
+                setattr(
+                    self,
+                    f"{prefix}_host",
+                    nn.Parameter(
+                        torch.zeros(
+                            split.host_size, device=self.current_device, dtype=dtype
+                        )
+                    ),
+                )
         else:
             self.register_buffer(
                 f"{prefix}_host",


### PR DESCRIPTION
Summary:
GPU table batched embedding bag already supports int8 and this diff matches CPU to support it as well.
This requires moving a few quantization ops to fbgemm_gpu

Reviewed By: jianyuh

Differential Revision: D28141945

