### PR TITLE
Andrew's int4 table batched embedding implementation

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_backward_code_generator.py
@@ -804,6 +804,20 @@ def forward_split() -> None:
     src_cu = template.render(weighted=True, dense=True)
     write("gen_embedding_forward_dense_weighted_codegen_cuda.cu", src_cu)
 
+def forward_quantized() -> None:
+    template = env.get_template("embedding_forward_quantized_split_template.cu")
+
+    src_cu = template.render(weighted=False)
+    write("gen_embedding_forward_quantized_split_unweighted_codegen_cuda.cu", src_cu)
+    src_cu = template.render(weighted=True)
+    write("gen_embedding_forward_quantized_split_weighted_codegen_cuda.cu", src_cu)
+
+    template = env.get_template("embedding_forward_quantized_cpu_template.cpp")
+    src_cu = template.render(weighted=False)
+    write("gen_embedding_forward_quantized_unweighted_codegen_cpu.cpp", src_cu)
+    src_cu = template.render(weighted=True)
+    write("gen_embedding_forward_quantized_weighted_codegen_cpu.cpp", src_cu)
+
 
 def backward_indices() -> None:
     template = env.get_template("embedding_backward_split_indice_weights_template.cu")
@@ -839,6 +853,7 @@ def emb_codegen(install_dir: Optional[str] = None, is_fbcode: bool = True) -> No
     adam()
     backward_indices()
     backward_dense()
+    forward_quantized()
     forward_split()
     lamb()
     lars_sgd()

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+{% set wdesc =  "weighted" if weighted else "unweighted" %}
+
+#include <ATen/ATen.h>
+
+#include <immintrin.h>
+#include <emmintrin.h>
+
+enum PoolingMode { SUM = 0, MEAN = 1, NONE = 2 };
+
+using namespace at;
+
+// From https://stackoverflow.com/questions/55084047/intel-vector-instruction-to-zero-extend-8-4-bit-values-packed-in-a-32-bit-int-to
+// TODO: dispatch at architecture time?
+__attribute__((always_inline)) inline __m256i cvt_nib_epi32_HSW(uint32_t x) {
+    __uint64_t x_b = _pdep_u64(x, 0x0F0F0F0F0F0F0F0F);
+    __m128i x_v = _mm_cvtsi64_si128(x_b);
+    return _mm256_cvtepu8_epi32(x_v);
+}
+
+__attribute__((always_inline)) inline __m256i cvt_nib_epi32_SKL(uint32_t x) {
+    __m256i input = _mm256_set1_epi32(x);
+    __m256i shifted = _mm256_srlv_epi32(input,_mm256_set_epi32(28,24,20,16,12,8,4,0));
+    return _mm256_and_si256(shifted, _mm256_set1_epi32(0xF));
+}
+
+Tensor int4_split_embedding_codegen_forward_{{ wdesc }}_cpu(
+    Tensor dev_weights,
+    Tensor weights_offsets,
+    Tensor D_offsets,
+    int64_t total_D,
+    int64_t max_D,
+    Tensor indices,
+    Tensor offsets,
+    int64_t pooling_mode,
+    {% if weighted %}
+    Tensor indice_weights,
+    {% endif %}
+    int64_t unused
+) {
+    int32_t T = D_offsets.numel() - 1;
+    TORCH_CHECK(T > 0);
+    // offsets = [B x T  + 1]
+    int32_t B = (offsets.size(0) - 1) / T;
+    TORCH_CHECK(B > 0);
+    TORCH_CHECK(total_D > 0);
+    TORCH_CHECK(total_D % 8 == 0);
+    TORCH_CHECK(max_D <= {{ max_embedding_dim }});
+    auto output = empty({B, total_D}, dev_weights.options().dtype(at::kHalf).pinned_memory(true));
+    const auto* weights_acc = dev_weights.data_ptr<uint8_t>();
+    auto* output_acc = output.data_ptr<Half>();
+    {% if weighted %}
+    const float* indice_weights_acc = indice_weights.data_ptr<float>();
+    {% endif %}
+    // Empty vector filled with zeros (thus accumulating to zero).
+    std::vector<uint8_t> zero_row(max_D / 2 + 4, 0);
+    AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "int4_split_embedding_codegen_forward_", [&] () {
+        const auto* indices_acc = indices.data_ptr<index_t>();
+        const auto* offsets_acc = offsets.data_ptr<index_t>();
+        const auto* D_offsets_acc = D_offsets.data_ptr<int32_t>();
+        const auto* weights_offsets_acc = weights_offsets.data_ptr<int64_t>();
+
+        int32_t num_indices_m_1 = indices.numel() - 1;
+
+
+        // special cases - D = 56, 64, 120, 128, 160, 240, and 376.
+        {% for kMaxVecsPerThread in [7, 8, 15, 16, 20, 30, 47] %}
+        // 8 values per vector.
+        if (max_D <= {{ 8 * kMaxVecsPerThread }}) {
+            for (int32_t t = 0; t < T; ++t) {
+                const int32_t D_start = D_offsets_acc[t];
+                const int32_t D = D_offsets_acc[t+1] - D_offsets_acc[t];
+                const uint8_t* weights = &weights_acc[weights_offsets_acc[t]];
+                const int32_t D_total = D + 8;
+                const int32_t D_vecs = D / 8;
+                // 0.5 bytes per D, plus 2 * 2 bytes for fp16 scale/shift.
+                const int64_t D_bytes = D / 2 + 4;
+                for (int32_t b = 0; b < B; ++b) {
+                    int32_t indices_start = offsets_acc[t * B + b];
+                    int32_t indices_end = offsets_acc[t * B + b + 1];
+                    int32_t L = indices_end - indices_start;
+                    std::array<__m256, {{ kMaxVecsPerThread }} > acc;
+                    // TODO: try fbgemm when I figure out how to adjust the bias/scale setting (first vs last element) and cache the codegen state.
+                    if (D_vecs == {{ kMaxVecsPerThread }}) {
+                        {% for i in range(kMaxVecsPerThread) %}
+                            acc[{{ i }}] = _mm256_setzero_ps();
+                        {% endfor %}
+                        int32_t l = 0;
+                        int32_t LUnroll = (L / 2) * 2;
+                        for (; l < LUnroll; l += 2) {
+                            int64_t idx0 = indices_acc[indices_start + l + 0];
+                            int64_t idx1 = indices_acc[indices_start + l + 1];
+
+                            const uint32_t* row0 = idx0 == -1 ? reinterpret_cast<const uint32_t*>(zero_row.data()) : reinterpret_cast<const uint32_t*>(&weights[idx0 * D_bytes]);
+                            const uint32_t* row1 = idx1 == -1 ? reinterpret_cast<const uint32_t*>(zero_row.data()) : reinterpret_cast<const uint32_t*>(&weights[idx1 * D_bytes]);
+
+                            uint32_t scale_shift0 = row0[0];
+                            uint32_t scale_shift1 = row1[0];
+
+                            int64_t prefetch_idx0 = indices_acc[std::min<int32_t>(indices_start + l + 2, num_indices_m_1)];
+                            int64_t prefetch_idx1 = indices_acc[std::min<int32_t>(indices_start + l + 3, num_indices_m_1)];
+                            _mm_prefetch(&weights[prefetch_idx0 * D_bytes], _MM_HINT_T0);
+                            _mm_prefetch(&weights[prefetch_idx1 * D_bytes], _MM_HINT_T0);
+
+                            auto scale0 = _mm256_cvtph_ps(_mm_set1_epi16(static_cast<uint16_t>(scale_shift0 & 0xFFFF)));
+                            auto scale1 = _mm256_cvtph_ps(_mm_set1_epi16(static_cast<uint16_t>(scale_shift1 & 0xFFFF)));
+                            auto shift0 = _mm256_cvtph_ps(_mm_set1_epi16(static_cast<uint16_t>((scale_shift0 >> 16) & 0xFFFF)));
+                            auto shift1 = _mm256_cvtph_ps(_mm_set1_epi16(static_cast<uint16_t>((scale_shift1 >> 16) & 0xFFFF)));
+
+                            {% if weighted %}
+                            auto idx_weight0 = _mm256_set1_ps(indice_weights_acc[indices_start + l + 0]);
+                            auto idx_weight1 = _mm256_set1_ps(indice_weights_acc[indices_start + l + 1]);
+                            scale0 = _mm256_mul_ps(scale0, idx_weight0);
+                            scale1 = _mm256_mul_ps(scale1, idx_weight1);
+
+                            shift0 = _mm256_mul_ps(shift0, idx_weight0);
+                            shift1 = _mm256_mul_ps(shift1, idx_weight1);
+                            {% endif %}
+
+                            {% for i in range(kMaxVecsPerThread) %}
+                                {% if weighted %}
+                                acc[{{ i }}] = _mm256_fmadd_ps(scale0, _mm256_cvtepi32_ps(cvt_nib_epi32_SKL(row0[{{ i }} + 1])), _mm256_add_ps(acc[{{ i }}], shift0));
+                                acc[{{ i }}] = _mm256_fmadd_ps(scale1, _mm256_cvtepi32_ps(cvt_nib_epi32_SKL(row1[{{ i }} + 1])), _mm256_add_ps(acc[{{ i }}], shift1));
+                                {% else %}
+                                acc[{{ i }} ] = _mm256_fmadd_ps(scale0, _mm256_cvtepi32_ps(cvt_nib_epi32_SKL(row0[{{ i }} + 1])), _mm256_add_ps(acc[{{ i }} ], shift0));
+                                acc[{{ i }} ] = _mm256_fmadd_ps(scale1, _mm256_cvtepi32_ps(cvt_nib_epi32_SKL(row1[{{ i }} + 1])), _mm256_add_ps(acc[{{ i }} ], shift1));
+                                {% endif %}
+                            {% endfor %}
+                        }
+                        for (; l < L; ++l) {
+                            int64_t idx = indices_acc[indices_start + l];
+                            // std::array<uint32_t, {{ kMaxVecsPerThread }} + 1> row;
+                            const uint32_t* row = idx == -1 ? reinterpret_cast<const uint32_t*>(zero_row.data()) : reinterpret_cast<const uint32_t*>(&weights[idx * D_bytes]);
+                            // std::copy(&weights[idx * D_bytes], &weights[idx * D_bytes + D_bytes], (uint8_t*)row.data());
+                            uint32_t scale_shift = row[0];
+
+                            int64_t prefetch_idx = indices_acc[std::min<int32_t>(indices_start + l + 1, num_indices_m_1)];
+                            _mm_prefetch(&weights[prefetch_idx * D_bytes], _MM_HINT_T0);
+
+                            auto scale = _mm256_cvtph_ps(_mm_set1_epi16(static_cast<uint16_t>(scale_shift & 0xFFFF)));
+                            auto shift = _mm256_cvtph_ps(_mm_set1_epi16(static_cast<uint16_t>((scale_shift >> 16) & 0xFFFF)));
+
+                            {% if weighted %}
+                            auto idx_weight = _mm256_set1_ps(indice_weights_acc[indices_start + l]);
+                            scale = _mm256_mul_ps(scale, idx_weight);
+                            shift = _mm256_mul_ps(shift, idx_weight);
+                            {% endif %}
+
+                            {% for i in range(kMaxVecsPerThread) %}
+                                {% if weighted %}
+                                acc[{{ i }}] = _mm256_fmadd_ps(scale, _mm256_cvtepi32_ps(cvt_nib_epi32_SKL(row[{{ i }} + 1])), _mm256_add_ps(acc[{{ i }}], shift));
+                                {% else %}
+                                acc[{{ i }} ] = _mm256_fmadd_ps(scale, _mm256_cvtepi32_ps(cvt_nib_epi32_SKL(row[{{ i }} + 1])), _mm256_add_ps(acc[{{ i }} ], shift));
+                                {% endif %}
+                            {% endfor %}
+                        }
+
+                        const float scale_factor =
+                        // NOTE: MEAN pooling will not work with indice_weights!
+                        (pooling_mode == MEAN && L > 0)
+                                      ? 1.0 / L : 1.0;
+
+                        __m256 scale_vec, scale_acc;
+                        {% for i in range(kMaxVecsPerThread) %}
+                            scale_vec = _mm256_set1_ps(scale_factor);
+                            scale_acc = _mm256_mul_ps(acc[{{ i }}], scale_vec);
+                            _mm_storeu_si128(reinterpret_cast<__m128i*>(&output_acc[b * total_D + D_start + 8 * {{ i }}]), _mm256_cvtps_ph(scale_acc, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
+                        {% endfor %}
+                    } else {
+                        for (auto i = 0; i < D_vecs; ++i) {
+                            acc[i] = _mm256_setzero_ps();
+                        }
+                        for (int32_t l = 0; l < L; ++l) {
+                            int64_t idx = indices_acc[indices_start + l];
+                            const uint32_t* row = reinterpret_cast<const uint32_t*>(&weights[idx * D_bytes]);
+                            uint32_t scale_shift = row[0];
+
+                            int64_t prefetch_idx = indices_acc[std::min<int32_t>(indices_start + l + 1, num_indices_m_1)];
+                            _mm_prefetch(&weights[prefetch_idx * D_bytes], _MM_HINT_T0);
+
+                            auto scale = _mm256_cvtph_ps(_mm_set1_epi16(static_cast<uint16_t>(scale_shift & 0xFFFF)));
+                            auto shift = _mm256_cvtph_ps(_mm_set1_epi16(static_cast<uint16_t>((scale_shift >> 16) & 0xFFFF)));
+
+                            {% if weighted %}
+                            auto idx_weight = _mm256_set1_ps(indice_weights_acc[indices_start + l]);
+                            scale = _mm256_mul_ps(scale, idx_weight);
+                            shift = _mm256_mul_ps(shift, idx_weight);
+                            {% endif %}
+
+                            for (auto i = 0; i < D_vecs; ++i) {
+                                auto bits = cvt_nib_epi32_SKL(row[i + 1]);
+                                auto fbits = _mm256_cvtepi32_ps(bits);
+                                {% if weighted %}
+                                acc[i] = _mm256_fmadd_ps(scale, fbits, _mm256_add_ps(acc[i], shift));
+                                {% else %}
+                                acc[i] = _mm256_fmadd_ps(scale, fbits, _mm256_add_ps(acc[i], shift));
+                                {% endif %}
+                            }
+                        }
+                        const float scale_factor =
+                        // NOTE: MEAN pooling will not work with indice_weights!
+                        (pooling_mode == MEAN && L > 0)
+                                      ? 1.0 / L : 1.0;
+                        for (auto i = 0; i < D_vecs; ++i) {
+                            auto scale_vec = _mm256_set1_ps(scale_factor);
+                            auto scale_acc = _mm256_mul_ps(acc[i], scale_vec);
+                            auto acc_half = _mm256_cvtps_ph(scale_acc, 0); //_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+                            _mm_storeu_si128(reinterpret_cast<__m128i*>(&output_acc[b * total_D + D_start + 8 * i]), acc_half);
+                        }
+                    }
+                }
+            }
+            return;
+        }
+        {% endfor %}
+        TORCH_CHECK(false, "Unhandled max_D");
+    });
+    return output;
+
+}
+
+#define BIG_CONSTANT(x) (x##LLU)
+
+inline uint32_t pruned_hash_function(int32_t key, int32_t table) {
+    uint64_t k = (static_cast<uint64_t>(key) << 32) | static_cast<uint64_t>(table);
+    k ^= k >> 33;
+    k *= BIG_CONSTANT(0xff51afd7ed558ccd);
+    k ^= k >> 33;
+    k *= BIG_CONSTANT(0xc4ceb9fe1a85ec53);
+    k ^= k >> 33;
+    return static_cast<uint32_t>(k >> 32);
+}
+
+void pruned_hashmap_insert_{{ wdesc }}_cpu(
+    Tensor indices,
+    Tensor dense_indices,
+    Tensor offsets,
+    Tensor hash_table,
+    int64_t T) {
+
+    int32_t B = (offsets.size(0) - 1) / T;
+    TORCH_CHECK(B > 0);
+    const auto* indices_acc = indices.data_ptr<int32_t>();
+    const auto* dense_indices_acc = dense_indices.data_ptr<int32_t>();
+
+    const auto* offsets_acc = offsets.data_ptr<int32_t>();
+    auto hash_table_acc = hash_table.accessor<int32_t, 2>();
+    uint32_t capacity = hash_table.size(0);
+    for (int32_t t = 0; t < T; ++t) {
+        for (int32_t b = 0; b < B; ++b) {
+            int32_t indices_start = offsets_acc[t * B + b];
+            int32_t indices_end = offsets_acc[t * B + b + 1];
+            int32_t L = indices_end - indices_start;
+            for (int32_t l = 0; l < L; ++l) {
+                int32_t idx = indices_acc[indices_start + l];
+                int32_t dense_idx = dense_indices_acc[indices_start + l];
+
+                uint32_t slot = static_cast<uint32_t>(pruned_hash_function(idx, t)) % capacity;
+                while (true) {
+                    int32_t sidx = hash_table_acc[slot][0];
+                    int32_t stable = hash_table_acc[slot][1];
+
+                    // empty slot
+                    if (sidx == -1) {
+                        hash_table_acc[slot][0] = idx;
+                        hash_table_acc[slot][1] = t;
+                        hash_table_acc[slot][2] = dense_idx;
+                        break;
+                    }
+                    // already exists (shouldn't happen in practice)
+                    if (sidx == idx && stable == t) {
+                        hash_table_acc[slot][2] = dense_idx;
+                        break;
+                    }
+                    // linear probe
+                    slot = (slot + 1) % capacity;
+                }
+            }
+        }
+    }
+    return;
+}
+
+Tensor pruned_hashmap_lookup_{{ wdesc }}_cpu(
+    Tensor indices,
+    Tensor offsets,
+    Tensor hash_table,
+    int64_t T) {
+
+    int32_t B = (offsets.size(0) - 1) / T;
+    TORCH_CHECK(B > 0);
+    auto dense_indices = empty_like(indices);
+    const auto* indices_acc = indices.data_ptr<int32_t>();
+    auto* dense_indices_acc = dense_indices.data_ptr<int32_t>();
+
+    const auto* offsets_acc = offsets.data_ptr<int32_t>();
+    const auto hash_table_acc = hash_table.accessor<int32_t, 2>();
+    int32_t capacity = hash_table.size(0);
+    for (int32_t t = 0; t < T; ++t) {
+        for (int32_t b = 0; b < B; ++b) {
+            int32_t indices_start = offsets_acc[t * B + b];
+            int32_t indices_end = offsets_acc[t * B + b + 1];
+            int32_t L = indices_end - indices_start;
+            for (int32_t l = 0; l < L; ++l) {
+                int32_t idx = indices_acc[indices_start + l];
+
+                uint32_t slot = static_cast<uint32_t>(pruned_hash_function(idx, t)) % capacity;
+                while (true) {
+                    int32_t sidx = hash_table_acc[slot][0];
+                    int32_t stable = hash_table_acc[slot][1];
+
+                    // empty slot
+                    if (sidx == -1) {
+                        dense_indices_acc[indices_start + l] = -1;
+                        break;
+                    }
+                    // already exists
+                    if (sidx == idx && stable == t) {
+                        dense_indices_acc[indices_start + l] = hash_table_acc[slot][2];
+                        break;
+                    }
+                    // linear probe
+                    slot = (slot + 1) % capacity;
+                }
+            }
+        }
+    }
+    return dense_indices;
+}

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <ATen/ATen.h>
+#include <ATen/TypeDefault.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <torch/script.h>
+
+using namespace at;
+
+Tensor int4_split_embedding_codegen_forward_unweighted_cuda(
+    Tensor dev_weights,
+    Tensor weights_offsets,
+    Tensor D_offsets,
+    int64_t total_D,
+    int64_t max_D,
+    Tensor indices,
+    Tensor offsets,
+    int64_t pooling_mode,
+    int64_t unused);
+
+Tensor int4_split_embedding_codegen_forward_weighted_cuda(
+    Tensor dev_weights,
+    Tensor weights_offsets,
+    Tensor D_offsets,
+    int64_t total_D,
+    int64_t max_D,
+    Tensor indices,
+    Tensor offsets,
+    int64_t pooling_mode,
+    Tensor indice_weights,
+    int64_t unused);
+
+Tensor int4_split_embedding_codegen_lookup_function(
+    Tensor dev_weights,
+    Tensor weights_offsets,
+    Tensor D_offsets,
+    int64_t total_D,
+    int64_t max_D,
+    Tensor indices,
+    Tensor offsets,
+    int64_t pooling_mode,
+    c10::optional<Tensor> indice_weights) {
+  if (!indice_weights) {
+    return int4_split_embedding_codegen_forward_unweighted_cuda(
+        dev_weights,
+        weights_offsets,
+        D_offsets,
+        total_D,
+        max_D,
+        indices,
+        offsets,
+        pooling_mode,
+        0);
+  }
+  return int4_split_embedding_codegen_forward_weighted_cuda(
+      dev_weights,
+      weights_offsets,
+      D_offsets,
+      total_D,
+      max_D,
+      indices,
+      offsets,
+      pooling_mode,
+      *indice_weights,
+      0);
+}
+
+Tensor pruned_hashmap_lookup_unweighted_cuda(
+    Tensor indices,
+    Tensor offsets,
+    Tensor hash_table,
+    int64_t T);
+
+TORCH_LIBRARY_FRAGMENT(fb, m) {
+  m.def(
+      "int4_split_embedding_codegen_lookup_function(Tensor dev_weights, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights) -> Tensor");
+  m.impl(
+      "int4_split_embedding_codegen_lookup_function",
+      torch::dispatch(
+          c10::DispatchKey::CUDA,
+          TORCH_FN(int4_split_embedding_codegen_lookup_function)));
+
+  m.def(
+      "pruned_hashmap_lookup(Tensor indices, Tensor offsets, Tensor hash_table, int T) -> Tensor");
+  m.impl(
+      "pruned_hashmap_lookup",
+      torch::dispatch(
+          c10::DispatchKey::CUDA,
+          TORCH_FN(pruned_hashmap_lookup_unweighted_cuda)));
+}

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <ATen/ATen.h>
+#include <ATen/TypeDefault.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <torch/custom_class.h>
+#include <torch/script.h>
+#include <ostream>
+#ifdef FBCODE_CAFFE2
+#include <folly/container/Enumerate.h>
+#include <folly/container/F14Map.h>
+#endif
+#include <torch/serialize/input-archive.h>
+#include <torch/serialize/output-archive.h>
+
+using namespace at;
+
+Tensor int4_split_embedding_codegen_forward_unweighted_cpu(
+    Tensor dev_weights,
+    Tensor weights_offsets,
+    Tensor D_offsets,
+    int64_t total_D,
+    int64_t max_D,
+    Tensor indices,
+    Tensor offsets,
+    int64_t pooling_mode,
+    int64_t unused);
+
+Tensor int4_split_embedding_codegen_forward_weighted_cpu(
+    Tensor dev_weights,
+    Tensor weights_offsets,
+    Tensor D_offsets,
+    int64_t total_D,
+    int64_t max_D,
+    Tensor indices,
+    Tensor offsets,
+    int64_t pooling_mode,
+    Tensor indice_weights,
+    int64_t unused);
+
+Tensor int4_split_embedding_codegen_lookup_function_cpu(
+    Tensor dev_weights,
+    Tensor weights_offsets,
+    Tensor D_offsets,
+    int64_t total_D,
+    int64_t max_D,
+    Tensor indices,
+    Tensor offsets,
+    int64_t pooling_mode,
+    c10::optional<Tensor> indice_weights) {
+  if (!indice_weights) {
+    return int4_split_embedding_codegen_forward_unweighted_cpu(
+        dev_weights,
+        weights_offsets,
+        D_offsets,
+        total_D,
+        max_D,
+        indices,
+        offsets,
+        pooling_mode,
+        0);
+  }
+  return int4_split_embedding_codegen_forward_weighted_cpu(
+      dev_weights,
+      weights_offsets,
+      D_offsets,
+      total_D,
+      max_D,
+      indices,
+      offsets,
+      pooling_mode,
+      *indice_weights,
+      0);
+}
+
+void pruned_hashmap_insert_unweighted_cpu(
+    Tensor indices,
+    Tensor dense_indices,
+    Tensor offsets,
+    Tensor hash_table,
+    int64_t T);
+
+Tensor pruned_hashmap_lookup_unweighted_cpu(
+    Tensor indices,
+    Tensor offsets,
+    Tensor hash_table,
+    int64_t T);
+
+TORCH_LIBRARY_FRAGMENT(fb, m) {
+  m.impl(
+      "int4_split_embedding_codegen_lookup_function",
+      torch::dispatch(
+          c10::DispatchKey::CPU,
+          TORCH_FN(int4_split_embedding_codegen_lookup_function_cpu)));
+
+  // GPU version of pruned_hashmap needs to use CPU version of
+  // pruned_hashmap_insert
+  m.def(
+      "pruned_hashmap_insert(Tensor indices, Tensor dense_indices, Tensor offsets, Tensor hash_table, int T) -> ()");
+  m.impl(
+      "pruned_hashmap_insert",
+      torch::dispatch(
+          c10::DispatchKey::CPU,
+          TORCH_FN(pruned_hashmap_insert_unweighted_cpu)));
+
+  // CPU version of Lookup isn't used. For CPUs, we should use PrunedMapCPU
+  // below.
+  m.impl(
+      "pruned_hashmap_lookup",
+      torch::dispatch(
+          c10::DispatchKey::CPU,
+          TORCH_FN(pruned_hashmap_lookup_unweighted_cpu)));
+}
+
+// TODO: 1) switch from doing a single flat table keyed on (table_idx, idx) ->
+// value (i.e. 3x32bits per entry) and instead have T separate tables with
+// idx->value (i.e. 2x32bits per entry).
+// 2) Possibly reuse the concurrent hash table.
+class PrunedMapCPU : public torch::jit::CustomClassHolder {
+ public:
+  PrunedMapCPU() {}
+  explicit PrunedMapCPU(std::string serialized) {
+    torch::serialize::InputArchive archive;
+    archive.load_from(serialized.data(), serialized.size());
+    Tensor values;
+    archive.read(std::string("table"), values);
+    auto values_acc = values.accessor<int32_t, 2>();
+    map_.reserve(values.size(0));
+    for (auto i = 0; i < values.size(0); ++i) {
+      auto index = values_acc[i][0];
+      auto table = values_acc[i][1];
+      auto value = values_acc[i][2];
+      std::pair<int32_t, int32_t> key = {index, table};
+      map_.emplace(key, value);
+    }
+  }
+  std::string serialize() const {
+    torch::serialize::OutputArchive archive(
+        std::make_shared<torch::jit::CompilationUnit>());
+    int64_t N = map_.size();
+    auto values =
+        at::empty({N, 3}, at::TensorOptions(at::kCPU).dtype(at::kInt));
+    auto values_acc = values.accessor<int32_t, 2>();
+#ifdef FBCODE_CAFFE2
+    for (const auto& [index, kv] : folly::enumerate(map_)) {
+#else
+    int index = 0;
+    for (auto& kv : map_) {
+#endif
+      values_acc[index][0] = kv.first.first;
+      values_acc[index][1] = kv.first.second;
+      values_acc[index][2] = kv.second;
+#ifndef FBCODE_CAFFE2
+      index++;
+#endif
+    }
+    std::ostringstream oss;
+    archive.write(std::string("table"), values);
+    archive.save_to(oss);
+    return oss.str();
+  }
+
+  void insert(Tensor indices, Tensor dense_indices, Tensor offsets, int64_t T) {
+    int32_t B = (offsets.size(0) - 1) / T;
+    TORCH_CHECK(B > 0);
+    const auto* indices_acc = indices.data_ptr<int32_t>();
+    auto* dense_indices_acc = dense_indices.data_ptr<int32_t>();
+    const auto* offsets_acc = offsets.data_ptr<int32_t>();
+    for (int32_t t = 0; t < T; ++t) {
+      for (int32_t b = 0; b < B; ++b) {
+        int32_t indices_start = offsets_acc[t * B + b];
+        int32_t indices_end = offsets_acc[t * B + b + 1];
+        int32_t L = indices_end - indices_start;
+        for (int32_t l = 0; l < L; ++l) {
+          int32_t idx = indices_acc[indices_start + l];
+          int32_t value = dense_indices_acc[indices_start + l];
+          std::pair<int32_t, int32_t> key = {idx, t};
+          map_.emplace(key, value);
+        }
+      }
+    }
+  }
+
+  Tensor lookup(Tensor indices, Tensor offsets, int64_t T) const {
+    int32_t B = (offsets.size(0) - 1) / T;
+    TORCH_CHECK(B > 0);
+    auto dense_indices = empty_like(indices);
+    const auto* indices_acc = indices.data_ptr<int32_t>();
+    auto* dense_indices_acc = dense_indices.data_ptr<int32_t>();
+    const auto* offsets_acc = offsets.data_ptr<int32_t>();
+    for (int32_t t = 0; t < T; ++t) {
+      for (int32_t b = 0; b < B; ++b) {
+        int32_t indices_start = offsets_acc[t * B + b];
+        int32_t indices_end = offsets_acc[t * B + b + 1];
+        int32_t L = indices_end - indices_start;
+        for (int32_t l = 0; l < L; ++l) {
+          int32_t idx = indices_acc[indices_start + l];
+          auto it = map_.find({idx, t});
+          dense_indices_acc[indices_start + l] =
+              it != map_.end() ? it->second : -1;
+        }
+      }
+    }
+    return dense_indices;
+  }
+
+ private:
+#ifdef FBCODE_CAFFE2
+  folly::F14FastMap<std::pair<int32_t, int32_t>, int32_t> map_;
+#else
+  struct pair_hash {
+    template <class T1, class T2>
+    std::size_t operator()(const std::pair<T1, T2>& pair) const {
+      return std::hash<T1>()(pair.first) ^ std::hash<T2>()(pair.second);
+    }
+  };
+  std::unordered_map<std::pair<int32_t, int32_t>, int32_t, pair_hash> map_;
+#endif
+};
+
+static auto PrunedMapCPURegistry =
+    torch::class_<PrunedMapCPU>("fb", "PrunedMapCPU")
+        .def(torch::init<>())
+        .def("insert", &PrunedMapCPU::insert)
+        .def("lookup", &PrunedMapCPU::lookup)
+        .def_pickle(
+            // __getstate__
+            [](const c10::intrusive_ptr<PrunedMapCPU>& self) -> std::string {
+              return self->serialize();
+            },
+            // __setstate__
+            [](std::string data) -> c10::intrusive_ptr<PrunedMapCPU> {
+              return c10::make_intrusive<PrunedMapCPU>(data);
+            });

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_split_template.cu
@@ -1,0 +1,603 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+{% set wdesc =  "weighted" if weighted else "unweighted" %}
+#include "codegen/embedding_forward_template_helpers.cuh"
+
+enum {
+  DEVICE = 0,
+  MANAGED = 1,
+  MANAGED_CACHING = 2,
+};
+
+constexpr size_t kForwardMaxThreads = 256;
+
+
+struct __align__(8) half4 {
+  __host__ __device__ half4() {}
+  __host__ __device__ half4(const half4 &other) : v(other.v) {}
+  __host__ __device__ half4 &operator=(const half4 &other) {
+    v = other.v;
+    return *this;
+  }
+  union {
+    half2 vals[2];
+    int2 v;
+  };
+};
+
+__device__ __forceinline__ half2 make_half2(float x, float y) {
+  half2 t;
+
+  t.x = __float2half_rn(x);
+  t.y = __float2half_rn(y);
+
+  return t;
+}
+
+__forceinline__ __device__ half2 make_zero_half2() {
+  return make_half2(0.0, 0.0);
+}
+
+__forceinline__ __device__ half4 make_zero_half4() {
+  half4 result;
+  result.vals[0] = make_zero_half2();
+  result.vals[1] = make_zero_half2();
+  return result;
+}
+
+struct __align__(16) half8 {
+  __host__ __device__ half8() {}
+  __host__ __device__ half8(const half8 &other) : v(other.v) {}
+  __host__ __device__ half8 &operator=(const half8 &other) {
+    v = other.v;
+    return *this;
+  }
+  union {
+    half4 vals[2];
+    int4 v;
+  };
+};
+
+__forceinline__ __device__ half8 make_zero_half8() {
+  half8 result;
+  result.vals[0] = make_zero_half4();
+  result.vals[1] = make_zero_half4();
+  return result;
+}
+
+struct __align__(32) float8 {
+  __host__ __device__ float8() {}
+  float4 vals[2];
+};
+
+__device__ __forceinline__ float8 make_zero_float8() {
+  float8 t;
+  t.vals[0] = make_float4(0, 0, 0, 0);
+  t.vals[1] = make_float4(0, 0, 0, 0);
+  return t;
+}
+
+__device__ __forceinline__ half8 to_half8(float8 v) {
+  half8 t;
+  t.vals[0].vals[0] = __float22half2_rn(make_float2(v.vals[0].x, v.vals[0].y));
+  t.vals[0].vals[1] = __float22half2_rn(make_float2(v.vals[0].z, v.vals[0].w));
+  t.vals[1].vals[0] = __float22half2_rn(make_float2(v.vals[1].x, v.vals[1].y));
+  t.vals[1].vals[1] = __float22half2_rn(make_float2(v.vals[1].z, v.vals[1].w));
+  return t;
+}
+
+__device__ __forceinline__ __half hbfe(uint32_t val, uint32_t pos, uint32_t len) {
+  uint32_t ret;
+  // Get the bit field of [pos, pos+len) bits from val:
+  // (val >> pos) && ( (1u << len) - 1u )
+  asm("bfe.u32 %0, %1, %2, %3;" : "=r"(ret) : "r"(val), "r"(pos), "r"(len));
+  return __uint2half_rn(ret);
+}
+
+__forceinline__ __device__ half2 hfma2(const half2 a, const half2 b, const half2 c) {
+  // TODO: We might need to use FMA with FP16 input and FP32 output.
+#if __CUDA_ARCH__ >= 530 && __CUDA_ARCH__ != 610
+  return __hfma2(a, b, c);
+#else
+  float2 fa, fb, fc;
+  fa = __half22float2(a);
+  fb = __half22float2(b);
+  fc = __half22float2(c);
+  fc.x = fa.x * fb.x + fc.x;
+  fc.y = fa.y * fb.y + fc.y;
+  return __float22half2_rn(fc);
+#endif
+}
+
+__forceinline__ __device__ half8  dequantize_int4(uint32_t packedVals, __half2 shift_scale) {
+  half8 res;
+  res.vals[0].vals[0].x =
+      hbfe(packedVals, 0,
+           4); // __short2half_rn((uint8_t)((packedVals >> 0) & 0x0F));
+  res.vals[0].vals[0].y =
+      hbfe(packedVals, 4,
+           4); // __short2half_rn((uint8_t)((packedVals >> 4) & 0x0F));
+  res.vals[0].vals[1].x =
+      hbfe(packedVals, 8,
+           4); // __short2half_rn((uint8_t)((packedVals >> 8) & 0x0F));
+  res.vals[0].vals[1].y =
+      hbfe(packedVals, 12,
+           4); // __short2half_rn((uint8_t)((packedVals >> 12) & 0x0F));
+  res.vals[1].vals[0].x =
+      hbfe(packedVals, 16,
+           4); // __short2half_rn((uint8_t)((packedVals >> 16) & 0x0F));
+  res.vals[1].vals[0].y =
+      hbfe(packedVals, 20,
+           4); // __short2half_rn((uint8_t)((packedVals >> 20) & 0x0F));
+  res.vals[1].vals[1].x =
+      hbfe(packedVals, 24,
+           4); // __short2half_rn((uint8_t)((packedVals >> 24) & 0x0F));
+  res.vals[1].vals[1].y =
+      hbfe(packedVals, 28,
+           4); // __short2half_rn((uint8_t)((packedVals >> 28) & 0x0F));
+
+  res.vals[0].vals[0] =
+      hfma2(res.vals[0].vals[0], __half2(shift_scale.x, shift_scale.x),
+              __half2(shift_scale.y, shift_scale.y));
+  res.vals[0].vals[1] =
+      hfma2(res.vals[0].vals[1], __half2(shift_scale.x, shift_scale.x),
+              __half2(shift_scale.y, shift_scale.y));
+  res.vals[1].vals[0] =
+      hfma2(res.vals[1].vals[0], __half2(shift_scale.x, shift_scale.x),
+              __half2(shift_scale.y, shift_scale.y));
+  res.vals[1].vals[1] =
+      hfma2(res.vals[1].vals[1], __half2(shift_scale.x, shift_scale.x),
+              __half2(shift_scale.y, shift_scale.y));
+  return res;
+}
+
+__forceinline__ __device__ float8 accumulate_packed_int4(float8 acc,
+                                                        uint32_t packedVals,
+                                                        __half2 shift_scale) {
+  half8 res = dequantize_int4(packedVals, shift_scale);
+  // Accumulate in float32.
+  float2 v0 = __half22float2(res.vals[0].vals[0]);
+  float2 v1 = __half22float2(res.vals[0].vals[1]);
+  float2 v2 = __half22float2(res.vals[1].vals[0]);
+  float2 v3 = __half22float2(res.vals[1].vals[1]);
+  acc.vals[0].x += v0.x;
+  acc.vals[0].y += v0.y;
+  acc.vals[0].z += v1.x;
+  acc.vals[0].w += v1.y;
+  acc.vals[1].x += v2.x;
+  acc.vals[1].y += v2.y;
+  acc.vals[1].z += v3.x;
+  acc.vals[1].w += v3.y;
+  return acc;
+}
+
+__forceinline__ __device__ float8 weighted_accumulate_packed_int4(float8 acc,
+                                                        uint32_t packedVals,
+                                                        __half2 shift_scale,
+                                                        float weight) {
+  half8 res = dequantize_int4(packedVals, shift_scale);
+  // Accumulate in float32.
+  float2 v0 = __half22float2(res.vals[0].vals[0]);
+  float2 v1 = __half22float2(res.vals[0].vals[1]);
+  float2 v2 = __half22float2(res.vals[1].vals[0]);
+  float2 v3 = __half22float2(res.vals[1].vals[1]);
+
+  acc.vals[0].x = fmaf(v0.x, weight, acc.vals[0].x);
+  acc.vals[0].y = fmaf(v0.y, weight, acc.vals[0].y);
+  acc.vals[0].z = fmaf(v1.x, weight, acc.vals[0].z);
+  acc.vals[0].w = fmaf(v1.y, weight, acc.vals[0].w);
+
+  acc.vals[1].x = fmaf(v2.x, weight, acc.vals[1].x);
+  acc.vals[1].y = fmaf(v2.y, weight, acc.vals[1].y);
+  acc.vals[1].z = fmaf(v3.x, weight, acc.vals[1].z);
+  acc.vals[1].w = fmaf(v3.y, weight, acc.vals[1].w);
+
+  return acc;
+}
+
+using namespace at;
+using namespace fbgemm_gpu;
+
+template<typename index_t, size_t kMaxVecsPerThread, size_t kThreadsPerRow>
+__launch_bounds__(kForwardMaxThreads)
+__global__ void int4_split_embedding_codegen_forward_{{ wdesc }}_kernel(
+    const PackedTensorAccessor64<uint8_t, 1, RestrictPtrTraits> dev_weights,
+     const PackedTensorAccessor32<int64_t, 1, RestrictPtrTraits> weights_offsets,
+    const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> D_offsets,
+     const PackedTensorAccessor32<index_t, 1, RestrictPtrTraits> indices,
+    const PackedTensorAccessor32<index_t, 1, RestrictPtrTraits> offsets,
+    int64_t pooling_mode,
+    int32_t max_D,
+    {% if weighted %}
+    PackedTensorAccessor32<float, 1, RestrictPtrTraits>
+        indice_weights,
+    {% endif %}
+    PackedTensorAccessor32<Half, 2, RestrictPtrTraits>
+        output // [B][total_D],
+    ) {
+    int32_t B = output.size(0);
+    int32_t T = D_offsets.size(0) - 1;
+    int32_t b_t = blockIdx.x * blockDim.y + threadIdx.y;
+    if (b_t >= B * T) {
+        return;
+    }
+    int32_t t = b_t / B;
+    int32_t b = b_t % B;
+    constexpr int32_t kRowsPerWarp = 32 / kThreadsPerRow;
+    const int32_t row_in_warp = threadIdx.y % kRowsPerWarp;
+    uint32_t subwarp_mask;
+    if (kThreadsPerRow == 8) {
+        subwarp_mask = uint32_t(0xFF) << row_in_warp;
+    }
+    if (kThreadsPerRow == 16) {
+        subwarp_mask = uint32_t(0xFFFF) << row_in_warp;
+    }
+    if (kThreadsPerRow == 32) {
+        subwarp_mask = uint32_t(0xFFFFFFFF) << row_in_warp;
+    }
+    int64_t weights_offset = weights_offsets[t];
+
+    int32_t D_start = D_offsets[t];
+    int32_t D_end = D_offsets[t + 1];
+    int32_t D = D_end - D_start;
+    // 2 * 2 bytes = 8 extra elements for the full row in 4-bit precision.
+    int32_t D_total = D + 8;
+    // 0.5 bytes per D, plus 2 * 2 bytes for fp16 scale/shift.
+    const int32_t D_bytes = D / 2 + 4;
+
+    int64_t indices_start = offsets[t * B + b];
+    int64_t indices_end = offsets[t * B + b + 1];
+    int32_t L = indices_end - indices_start;
+    const uint8_t* __restrict__ weights = &dev_weights[weights_offset];
+
+    float8 accumulators[kMaxVecsPerThread];
+    for (auto i = 0; i < kMaxVecsPerThread; ++i) {
+        accumulators[i] = make_zero_float8();
+    }
+
+    for (int32_t l_start = 0; l_start < L; l_start += kThreadsPerRow) {
+        int32_t l = l_start + threadIdx.x;
+        int64_t idx = l < L ? indices[indices_start + l] : 0;
+        int32_t JLim = L - l_start < kThreadsPerRow ? L - l_start : kThreadsPerRow;
+
+        // negative indices represent "pruned out" values.
+        const uint8_t* __restrict__ row = idx >= 0 ? &weights[idx * D_bytes] : nullptr;
+
+        {% if weighted %}
+        float idx_weight = l < L ? indice_weights[indices_start + l] : 0.0;
+        {% endif %}
+
+        int32_t j = 0;
+        constexpr size_t kUnroll = 4;
+        int32_t jUnroll = (JLim / kUnroll) * kUnroll;
+        for (; j < jUnroll; j += kUnroll) {
+            const uint32_t *row_j0 = reinterpret_cast<const uint32_t *>(__shfl_sync(subwarp_mask, intptr_t(row), j + 0 + row_in_warp * kThreadsPerRow));
+            const uint32_t *row_j1 = reinterpret_cast<const uint32_t *>(__shfl_sync(subwarp_mask, intptr_t(row), j + 1 + row_in_warp * kThreadsPerRow));
+            const uint32_t *row_j2 = reinterpret_cast<const uint32_t *>(__shfl_sync(subwarp_mask, intptr_t(row), j + 2 + row_in_warp * kThreadsPerRow));
+            const uint32_t *row_j3 = reinterpret_cast<const uint32_t *>(__shfl_sync(subwarp_mask, intptr_t(row), j + 3 + row_in_warp * kThreadsPerRow));
+
+            // scale and bias are at the biginning of each row.
+            // rationale: have scale/shift at start since these get loaded first
+            // and then broadcasted around so it might speed up the first cache
+            // miss.
+            half2 shift_scale_j0 = row ? (reinterpret_cast<const half2*>(row_j0))[0] : make_half2(0.0, 0.0);
+            half2 shift_scale_j1 = row ? (reinterpret_cast<const half2*>(row_j1))[0] : make_half2(0.0, 0.0);
+            half2 shift_scale_j2 = row ? (reinterpret_cast<const half2*>(row_j2))[0] : make_half2(0.0, 0.0);
+            half2 shift_scale_j3 = row ? (reinterpret_cast<const half2*>(row_j3))[0] : make_half2(0.0, 0.0);
+
+            {% if weighted %}
+            float idx_weight_j0 = __shfl_sync(subwarp_mask, idx_weight, j + 0 + row_in_warp * kThreadsPerRow);
+            float idx_weight_j1 = __shfl_sync(subwarp_mask, idx_weight, j + 1 + row_in_warp * kThreadsPerRow);
+            float idx_weight_j2 = __shfl_sync(subwarp_mask, idx_weight, j + 2 + row_in_warp * kThreadsPerRow);
+            float idx_weight_j3 = __shfl_sync(subwarp_mask, idx_weight, j + 3 + row_in_warp * kThreadsPerRow);
+
+            {% endif %}
+            #pragma unroll kMaxVecsPerThread
+            for (int32_t i = 0;
+                i < kMaxVecsPerThread && 8 * kThreadsPerRow * i + threadIdx.x * 8 < D_total;
+                ++i) {
+                // Read the int4 values: note that first 8 Bytes will be ditched
+                // later: // We shift back by 8 elements to remove the first 8
+                // elements (which is garbage due to the scale/shift handling)
+                // int32_t d = 8 * kThreadsPerRow * i + threadIdx.x * 8 - 8;
+                // Reason: to avoid divergence the first thread in the warp
+                // computes garbage.
+                uint32_t v0 = row_j0 ? row_j0[kThreadsPerRow * i + threadIdx.x] : 0;
+                uint32_t v1 = row_j1 ? row_j1[kThreadsPerRow * i + threadIdx.x] : 0;
+                uint32_t v2 = row_j2 ? row_j2[kThreadsPerRow * i + threadIdx.x] : 0;
+                uint32_t v3 = row_j3 ? row_j3[kThreadsPerRow * i + threadIdx.x] : 0;
+
+                {% if weighted %}
+                accumulators[i] = weighted_accumulate_packed_int4(
+                    accumulators[i], v0,
+                    shift_scale_j0, idx_weight_j0);
+                accumulators[i] = weighted_accumulate_packed_int4(
+                    accumulators[i], v1,
+                    shift_scale_j1, idx_weight_j1);
+                accumulators[i] = weighted_accumulate_packed_int4(
+                    accumulators[i], v2,
+                    shift_scale_j2, idx_weight_j2);
+                accumulators[i] = weighted_accumulate_packed_int4(
+                    accumulators[i], v3,
+                    shift_scale_j3, idx_weight_j3);
+
+                {% else %}
+                accumulators[i] = accumulate_packed_int4(
+                    accumulators[i], v0,
+                    shift_scale_j0);
+                accumulators[i] = accumulate_packed_int4(
+                    accumulators[i], v1,
+                    shift_scale_j1);
+                accumulators[i] = accumulate_packed_int4(
+                    accumulators[i], v2,
+                    shift_scale_j2);
+                accumulators[i] = accumulate_packed_int4(
+                    accumulators[i], v3,
+                    shift_scale_j3);
+
+                {% endif %}
+            }
+        }
+        for (; j < JLim; ++j) {
+            const uint32_t *row_j0 = reinterpret_cast<const uint32_t *>(__shfl_sync(subwarp_mask, intptr_t(row), j + 0 + row_in_warp * kThreadsPerRow));
+            half2 shift_scale_j0 = row ? (reinterpret_cast<const half2*>(row_j0))[0] : make_half2(0.0, 0.0);
+
+            {% if weighted %}
+            float idx_weight_j = __shfl_sync(subwarp_mask, idx_weight, j + row_in_warp * kThreadsPerRow);
+            {% endif %}
+            #pragma unroll kMaxVecsPerThread
+            for (int32_t i = 0;
+                i < kMaxVecsPerThread && 8 * kThreadsPerRow * i + threadIdx.x * 8 < D_total;
+                ++i) {
+                uint32_t v0 = row_j0 ? row_j0[kThreadsPerRow * i + threadIdx.x] : 0;
+
+                {% if weighted %}
+                accumulators[i] = weighted_accumulate_packed_int4(
+                    accumulators[i], v0,
+                    shift_scale_j0, idx_weight_j);
+                {% else %}
+                accumulators[i] = accumulate_packed_int4(
+                    accumulators[i], v0,
+                    shift_scale_j0);
+                {% endif %}
+            }
+        }
+    }
+
+#pragma unroll kMaxVecsPerThread
+    for (int32_t i = 0;
+        i < kMaxVecsPerThread && 8 * kThreadsPerRow * i + threadIdx.x * 8 < D_total;
+        ++i) {
+        // We shift back by 8 elements to remove the first 8 elements (which is
+        // garbage due to the scale/shift handling)
+        int32_t d = 8 * kThreadsPerRow * i + threadIdx.x * 8 - 8;
+        if (pooling_mode == MEAN && L != 0) {
+            float inv_L = 1.0 / L;
+            accumulators[i].vals[0].x *= inv_L;
+            accumulators[i].vals[0].y *= inv_L;
+            accumulators[i].vals[0].z *= inv_L;
+            accumulators[i].vals[0].w *= inv_L;
+            accumulators[i].vals[1].x *= inv_L;
+            accumulators[i].vals[1].y *= inv_L;
+            accumulators[i].vals[1].z *= inv_L;
+            accumulators[i].vals[1].w *= inv_L;
+        }
+        if (d >= 0 && d < D) {
+            *(half8 *)(&output[b][D_start + d]) = to_half8(accumulators[i]);
+        }
+    }
+}
+
+Tensor int4_split_embedding_codegen_forward_{{ wdesc }}_cuda(
+    Tensor dev_weights,
+    Tensor weights_offsets,
+    Tensor D_offsets,
+    int64_t total_D,
+    int64_t max_D,
+    Tensor indices,
+    Tensor offsets,
+    int64_t pooling_mode,
+    {% if weighted %}
+    Tensor indice_weights,
+    {% endif %}
+    int64_t unused
+) {
+    at::cuda::OptionalCUDAGuard device_guard;
+    device_guard.set_index(dev_weights.get_device());
+
+    int32_t T = D_offsets.numel() - 1;
+    TORCH_CHECK(T > 0);
+    // offsets = [B x T  + 1]
+    int32_t B = (offsets.size(0) - 1) / T;
+    TORCH_CHECK(B > 0);
+    TORCH_CHECK(total_D > 0);
+    TORCH_CHECK(total_D % 4 == 0);
+    TORCH_CHECK(max_D <= {{ max_embedding_dim }});
+    auto output = empty({B, total_D}, dev_weights.options().dtype(at::kHalf));
+
+    int32_t kThreads = 128;
+    using index_t = int32_t;
+    // AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "int4_split_embedding_codegen_forward_", [&] () {
+    if (max_D + 8 <= 64) {
+        constexpr size_t kThreadsPerRow = 8;
+        int4_split_embedding_codegen_forward_{{ wdesc }}_kernel<index_t, 1, kThreadsPerRow><<<
+            div_round_up((B * T), kThreads / kThreadsPerRow),
+            dim3(kThreadsPerRow, kThreads / kThreadsPerRow),
+            0,
+            at::cuda::getCurrentCUDAStream()>>>(
+            dev_weights.packed_accessor64<uint8_t, 1, RestrictPtrTraits>(),
+            weights_offsets.packed_accessor32<int64_t, 1, RestrictPtrTraits>(),
+            D_offsets.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+            indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+            offsets.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+            pooling_mode,
+            max_D,
+            {% if weighted %}
+            indice_weights.packed_accessor32<float, 1, RestrictPtrTraits>(),
+            {% endif %}
+            output.packed_accessor32<Half, 2, RestrictPtrTraits>()
+            );
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        return output;
+
+    }
+    if (max_D + 8 <= 128) {
+        constexpr size_t kThreadsPerRow = 16;
+        int4_split_embedding_codegen_forward_{{ wdesc }}_kernel<index_t, 1, kThreadsPerRow><<<
+            div_round_up((B * T), kThreads / kThreadsPerRow),
+            dim3(kThreadsPerRow, kThreads / kThreadsPerRow),
+            0,
+            at::cuda::getCurrentCUDAStream()>>>(
+            dev_weights.packed_accessor64<uint8_t, 1, RestrictPtrTraits>(),
+            weights_offsets.packed_accessor32<int64_t, 1, RestrictPtrTraits>(),
+            D_offsets.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+            indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+            offsets.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+            pooling_mode,
+            max_D,
+            {% if weighted %}
+            indice_weights.packed_accessor32<float, 1, RestrictPtrTraits>(),
+            {% endif %}
+            output.packed_accessor32<Half, 2, RestrictPtrTraits>()
+            );
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        return output;
+
+    }
+    if (max_D + 8 <= 256) {
+        constexpr size_t kThreadsPerRow = 32;
+        int4_split_embedding_codegen_forward_{{ wdesc }}_kernel<index_t, 1, kThreadsPerRow><<<
+            div_round_up((B * T), kThreads / kThreadsPerRow),
+            dim3(kThreadsPerRow, kThreads / kThreadsPerRow),
+            0,
+            at::cuda::getCurrentCUDAStream()>>>(
+            dev_weights.packed_accessor64<uint8_t, 1, RestrictPtrTraits>(),
+            weights_offsets.packed_accessor32<int64_t, 1, RestrictPtrTraits>(),
+            D_offsets.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+            indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+            offsets.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+            pooling_mode,
+            max_D,
+            {% if weighted %}
+            indice_weights.packed_accessor32<float, 1, RestrictPtrTraits>(),
+            {% endif %}
+            output.packed_accessor32<Half, 2, RestrictPtrTraits>()
+            );
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        return output;
+    }
+    if (max_D + 8 <= 512) {
+        constexpr size_t kThreadsPerRow = 32;
+        int4_split_embedding_codegen_forward_{{ wdesc }}_kernel<index_t, 2, kThreadsPerRow><<<
+            div_round_up((B * T), kThreads / kThreadsPerRow),
+            dim3(kThreadsPerRow, kThreads / kThreadsPerRow),
+            0,
+            at::cuda::getCurrentCUDAStream()>>>(
+            dev_weights.packed_accessor64<uint8_t, 1, RestrictPtrTraits>(),
+            weights_offsets.packed_accessor32<int64_t, 1, RestrictPtrTraits>(),
+            D_offsets.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+            indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+            offsets.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+            pooling_mode,
+            max_D,
+            {% if weighted %}
+            indice_weights.packed_accessor32<float, 1, RestrictPtrTraits>(),
+            {% endif %}
+            output.packed_accessor32<Half, 2, RestrictPtrTraits>()
+            );
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        return output;
+    }
+
+    TORCH_CHECK(false, "Unhandled max_D");
+    return output;
+}
+
+#define BIG_CONSTANT(x) (x##LLU)
+
+__device__ inline uint32_t pruned_hash_function(int32_t key, int32_t table) {
+    uint64_t k = (static_cast<uint64_t>(key) << 32) | static_cast<uint64_t>(table);
+    k ^= k >> 33;
+    k *= BIG_CONSTANT(0xff51afd7ed558ccd);
+    k ^= k >> 33;
+    k *= BIG_CONSTANT(0xc4ceb9fe1a85ec53);
+    k ^= k >> 33;
+    return static_cast<uint32_t>(k >> 32);
+}
+
+__global__ void int4_split_embedding_codegen_forward_pruned_hashmap_lookup_{{ wdesc }}_kernel(
+    const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> indices,
+    const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> offsets,
+    const PackedTensorAccessor64<int32_t, 2, RestrictPtrTraits> hash_table,
+    int32_t B,
+    int32_t T,
+    PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> dense_indices) {
+    uint32_t capacity = hash_table.size(0);
+    int32_t b_t = blockIdx.x * blockDim.y + threadIdx.y;
+    int32_t t = b_t / B;
+    int32_t b = b_t % B;
+    if (b_t >= B * T) {
+        return;
+    }
+    int32_t indices_start = offsets[t * B + b];
+    int32_t indices_end = offsets[t * B + b + 1];
+    int32_t L = indices_end - indices_start;
+    uint32_t subwarp_id = threadIdx.x / 4;
+    uint32_t subwarp_tid = threadIdx.x % 4;
+    uint32_t subwarp_mask = static_cast<uint32_t>(0xF) << (4 * subwarp_id);
+    for (int32_t l_start = 0; l_start + subwarp_id < L; l_start += kWarpSize / 4) {
+        int32_t idx = indices[indices_start + l_start + subwarp_id];
+        uint32_t slot_start = static_cast<uint32_t>(pruned_hash_function(idx, t));
+        while (true) {
+            uint32_t slot = (slot_start + subwarp_tid) % capacity;
+            int32_t sidx = hash_table[slot][0];
+            int32_t stable = hash_table[slot][1];
+            bool found = false;
+            bool empty = false;
+            if (sidx == -1) {
+                empty = true;
+            } else if (sidx == idx && stable == t) {
+                found = true;
+                dense_indices[indices_start + l_start + subwarp_id] = hash_table[slot][2];
+            }
+            if (__any_sync(subwarp_mask, found)) {
+                break;
+            } else if (__any_sync(subwarp_mask, empty)) {
+                dense_indices[indices_start + l_start + subwarp_id] = -1;
+                break;
+            }
+            slot_start += 4;
+        }
+    }
+}
+
+Tensor pruned_hashmap_lookup_{{ wdesc }}_cuda(
+    Tensor indices,
+    Tensor offsets,
+    Tensor hash_table,
+    int64_t T) {
+    at::cuda::OptionalCUDAGuard device_guard;
+    device_guard.set_index(indices.get_device());
+    auto dense_indices = empty_like(indices);
+    int32_t B = (offsets.size(0) - 1) / T;
+    TORCH_CHECK(B > 0);
+    TORCH_CHECK(hash_table.size(0) < std::numeric_limits<int32_t>::max());
+    int4_split_embedding_codegen_forward_pruned_hashmap_lookup_{{ wdesc }}_kernel<<<
+        div_round_up(B * T + 1, kForwardMaxThreads / kWarpSize),
+        dim3(kWarpSize, kForwardMaxThreads / kWarpSize),
+        0,
+        at::cuda::getCurrentCUDAStream()>>>(
+            indices.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+            offsets.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+            hash_table.packed_accessor64<int32_t, 2, RestrictPtrTraits>(),
+            B,
+            T,
+            dense_indices.packed_accessor32<int32_t, 1, RestrictPtrTraits>()
+    );
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return dense_indices;
+}

--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -53,6 +53,8 @@ cpp_fbgemm_files = [
 
 cpp_cpu_output_files = (
     [
+        "gen_embedding_forward_quantized_unweighted_codegen_cpu.cpp",
+        "gen_embedding_forward_quantized_weighted_codegen_cpu.cpp",
         "gen_embedding_backward_dense_split_cpu.cpp",
     ]
     + [
@@ -67,10 +69,12 @@ cpp_cpu_output_files = (
 
 cpp_cuda_output_files = (
     [
-        "gen_embedding_forward_split_weighted_codegen_cuda.cu",
-        "gen_embedding_forward_split_unweighted_codegen_cuda.cu",
         "gen_embedding_forward_dense_weighted_codegen_cuda.cu",
         "gen_embedding_forward_dense_unweighted_codegen_cuda.cu",
+        "gen_embedding_forward_quantized_split_unweighted_codegen_cuda.cu",
+        "gen_embedding_forward_quantized_split_weighted_codegen_cuda.cu",
+        "gen_embedding_forward_split_weighted_codegen_cuda.cu",
+        "gen_embedding_forward_split_unweighted_codegen_cuda.cu",
         "gen_embedding_backward_split_indice_weights_codegen_cuda.cu",
         "gen_embedding_backward_dense_indice_weights_codegen_cuda.cu",
         "gen_embedding_backward_dense_split_unweighted_cuda.cu",
@@ -134,6 +138,8 @@ setup(
             + cpp_fbgemm_files
             + [
                 os.path.join(cur_dir, "codegen/embedding_forward_split_cpu.cpp"),
+                os.path.join(cur_dir, "codegen/embedding_forward_quantized_host_cpu.cpp"),
+                os.path.join(cur_dir, "codegen/embedding_forward_quantized_host.cpp"),
                 os.path.join(cur_dir, "codegen/embedding_backward_dense_host_cpu.cpp"),
                 os.path.join(cur_dir, "codegen/embedding_backward_dense_host.cpp"),
                 os.path.join(cur_dir, "src/split_embeddings_cache_cuda.cu"),


### PR DESCRIPTION
Summary:
This is directly from Andrew's Diff D27264950.
- Fix `__hadd` / `__hfma` issues for different CUDA versions
- Fix several small issues like pyre stuff.

The int8 table batched embeddings were added for high-precision cache implementation (in CUDA) and recent Diff D28141945 (https://github.com/pytorch/FBGEMM/commit/dc6633120072ce84840eaa02fda84f2c4f847b19) for CPU.

Reviewed By: ajtulloch

Differential Revision: D28248236

