### PR TITLE
Fix the int8 embedding bench/test build

### DIFF
--- a/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
@@ -13,6 +13,8 @@ from .lookup_args import *
 torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops")
 torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops_cpu")
 torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:cumem_utils")
+torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
+torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
 torch.ops.load_library(
     "//deeplearning/fbgemm/fbgemm_gpu:split_table_batched_embeddings"
 )

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -23,9 +23,6 @@ from torch import Tensor
 MAX_EXAMPLES = 40
 Deviceable = TypeVar("Deviceable", torch.nn.EmbeddingBag, Tensor)
 
-torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
-torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
-
 
 def div_round_up(a: int, b: int) -> int:
     return int((a + b - 1) // b) * b


### PR DESCRIPTION
Summary:
- Int8 bench reports error like https://www.internalfb.com/phabricator/paste/view/P414947420. Now the code requires
```
torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
```

- However, it breaks the OSS
 build/unit tests/benchmark when loading these library with `torch.ops.load_library(//XXXX)`.

- We adopted the same approach using the codegen (`fbcode/deeplearning/fbgemm/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template`) to determine if we need torch.ops.load_library.

Differential Revision: D28461096

