### PR TITLE
remove unncessary context saving

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
@@ -128,7 +128,6 @@ class SplitLookupFunction_{{ optimizer }}_Op : public torch::autograd::Function<
         dev_weights, uvm_weights, lxu_cache_weights, weights_placements, weights_offsets, D_offsets, hash_size_cumsum,
         indices, offsets, indice_weights.value_or(Tensor()), feature_requires_grad.value_or(Tensor()), lxu_cache_locations, {{ args.split_saved_tensors | join(", ") }} });
 
-    ctx->saved_data["total_D"] = total_D;
     ctx->saved_data["max_D"] = max_D;
     ctx->saved_data["total_hash_size_bits"] = total_hash_size_bits;
     ctx->saved_data["pooling_mode"] = pooling_mode;
@@ -173,7 +172,6 @@ class SplitLookupFunction_{{ optimizer }}_Op : public torch::autograd::Function<
     auto {{ tensor }} = *savedItr++;
     {% endfor %}
 
-    auto total_D = ctx->saved_data["total_D"].toInt();
     auto max_D = ctx->saved_data["max_D"].toInt();
     auto total_hash_size_bits = ctx->saved_data["total_hash_size_bits"].toInt();
     auto pooling_mode = ctx->saved_data["pooling_mode"].toInt();

--- a/fbgemm_gpu/include/fbgemm_gpu/quantize_ops.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/quantize_ops.cuh
@@ -23,7 +23,7 @@ __device__ inline __attribute__((always_inline)) T quantize_ops_shfl_xor(const T
 #endif
 }
 
-__global__ void _get_8bit_qparam_cuda_kernel(
+__global__ inline void _get_8bit_qparam_cuda_kernel(
     const float* __restrict__ input,
     int nrows,
     int ncols,
@@ -78,7 +78,7 @@ __global__ void _get_8bit_qparam_cuda_kernel(
   range_list[row] = range;
 }
 
-__global__ void _compute_8bit_quantize_cuda_kernel(
+__global__ inline void _compute_8bit_quantize_cuda_kernel(
     const float* const __restrict__ input,
     const float* const __restrict__ range_list,
     const int nrows,
@@ -110,7 +110,7 @@ __global__ void _compute_8bit_quantize_cuda_kernel(
 }
 
 // FP32 -> Fused 8-bit rowwise kernel
-__global__ void _float_to_fused8bitrowwise_cuda_kernel(
+__global__ inline void _float_to_fused8bitrowwise_cuda_kernel(
     const float* __restrict__ input,
     int nrows,
     int ncols,
@@ -145,7 +145,7 @@ __global__ void _float_to_fused8bitrowwise_cuda_kernel(
 }
 
 // Fused 8-bit rowwise -> FP32 kernel
-__global__ void _fused8bitrowwise_to_float_cuda_kernel(
+__global__ inline void _fused8bitrowwise_to_float_cuda_kernel(
     const std::uint8_t* const __restrict__ input,
     const int nrows,
     const int ncols,
@@ -169,7 +169,7 @@ __global__ void _fused8bitrowwise_to_float_cuda_kernel(
 }
 
 // Fake 8-bit quantize kernel: FP32 -> UINT8 rowwise -> FP32
-__global__ void _fake_8bit_quantize_cuda_kernel(
+__global__ inline void _fake_8bit_quantize_cuda_kernel(
     const float* __restrict__ input,
     int nrows,
     int ncols,
@@ -197,7 +197,7 @@ __global__ void _fake_8bit_quantize_cuda_kernel(
 }
 
 // FP32 -> Fused 4/2-bit rowwise kernel
-__global__ void _float_to_fusednbitrowwise_cuda_kernel(
+__global__ inline void _float_to_fusednbitrowwise_cuda_kernel(
     int bit_rate,
     const float* __restrict__ input,
     int nrows,
@@ -259,7 +259,7 @@ __global__ void _float_to_fusednbitrowwise_cuda_kernel(
 }
 
 // Fused 4/2-bit rowwise -> FP32 kernel
-__global__ void _fusednbitrowwise_to_float_cuda_kernel(
+__global__ inline void _fusednbitrowwise_to_float_cuda_kernel(
     const int bit_rate,
     const std::uint8_t* input,
     const int nrows,
@@ -290,7 +290,7 @@ __global__ void _fusednbitrowwise_to_float_cuda_kernel(
 }
 
 // FP32 -> BF16 kernel
-__global__ void _float_to_bfloat16_cuda_kernel(
+__global__ inline void _float_to_bfloat16_cuda_kernel(
     const float* __restrict__ input,
     const int nrows,
     const int ncols,
@@ -312,7 +312,7 @@ __global__ void _float_to_bfloat16_cuda_kernel(
 }
 
 // BF16 -> FP32 kernel
-__global__ void _bfloat16_to_float_cuda_kernel(
+__global__ inline void _bfloat16_to_float_cuda_kernel(
     const uint16_t* __restrict__ input,
     const int nrows,
     const int ncols,
@@ -340,7 +340,7 @@ typedef union {
 
 // TODO: add a flag later to control whether underflow
 // flushes to 0 or clips to smallest denorm number.
-__device__ uint8_t float_to_hfp8(
+__device__ inline uint8_t float_to_hfp8(
     float val_fp,
     int ebits,
     int mbits,
@@ -399,7 +399,7 @@ __device__ uint8_t float_to_hfp8(
   return bfp8_val;
 }
 
-__device__ float
+__device__ inline float
 hfp8_to_float(uint8_t hfp8_val, int ebits, int mbits, int bias) {
   fint32 val_out, sign, multiplier;
 
@@ -429,7 +429,7 @@ hfp8_to_float(uint8_t hfp8_val, int ebits, int mbits, int bias) {
   return val_out.F;
 }
 
-__global__ void _float_to_hfp8_cuda_kernel(
+__global__ inline void _float_to_hfp8_cuda_kernel(
     const float* __restrict__ input,
     const int nrows,
     const int ncols,
@@ -452,7 +452,7 @@ __global__ void _float_to_hfp8_cuda_kernel(
   }
 }
 
-__global__ void _hfp8_to_float_cuda_kernel(
+__global__ inline void _hfp8_to_float_cuda_kernel(
     const uint8_t* __restrict__ input,
     const int nrows,
     const int ncols,

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -730,7 +730,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             ],
             optimizer=OptimType.EXACT_SGD if exact else OptimType.SGD,
             feature_table_map=feature_table_map,
-            learning_rate=0.05,
+            learning_rate=lr,
             weights_precision=weights_precision,
             cache_algorithm=cache_algorithm,
             pooling_mode=pooling_mode,


### PR DESCRIPTION
Summary:
total_D is not used in backward
should use variable lr instead of repeating magic numbers

Differential Revision: D28633003

