### PR TITLE
Add functions for quantizing fp16 embeddings to rowwise quantized int2/int4/int8 + fp16 scale/bias.

### DIFF
--- a/include/fbgemm/QuantUtilsAvx2.h
+++ b/include/fbgemm/QuantUtilsAvx2.h
@@ -125,9 +125,9 @@ FBGEMM_API void requantizeForFloatAvx2(
     int ld_in,
     const requantizationForFloatParams_t& r);
 
-template <int BIT_RATE>
-void FloatToFusedNBitRowwiseQuantizedSBHalfAvx2(
-    const float* input,
+template <typename InputType, int BIT_RATE>
+void ToFusedNBitRowwiseQuantizedSBHalfAvx2(
+    const InputType* input,
     int input_rows,
     int input_columns,
     std::uint8_t* output);


### PR DESCRIPTION
Summary:
Add sibling functions, Float16ToFusedNBitRowwiseQuantizedSBHalf, for FloatToFusedNBitRowwiseQuantizedSBHalf, with both opt and ref version.

Implementation-wise, both versions first convert fp16 inputs to fp32 inputs, then reuse existing code in FloatToFusedNBitRowwiseQuantizedSBHalf as much as possible.

Also, added some tests and vscode-auto-formatting changes.

Differential Revision: D28620537

