### PR TITLE
Remove usage of `if constexpr` from D28620537.

### DIFF
--- a/src/QuantUtils.cc
+++ b/src/QuantUtils.cc
@@ -520,7 +520,7 @@ void ToFusedNBitRowwiseQuantizedSBHalfRef(
     // NOTE: this can be optimized, however we don't care much about performance for
     // reference implementation.
     for (std::size_t col = 0; col < input_columns; ++col) {
-      if constexpr (std::is_same<InputType, float>()) {
+      if (std::is_same<InputType, float>()) {
         input_row_float[col] = input_row[col];
       } else {
         input_row_float[col] = cpu_half2float(input_row[col]);


### PR DESCRIPTION
Summary: D28620537 (https://github.com/pytorch/FBGEMM/commit/9cb33bcfe545ec1c209f3b1000824833a5db7454) used `if constexpr` which is C++17 feature. It turns out some of PyTorch's build is using pre-C++17 compiler and [build is failing](https://app.circleci.com/pipelines/github/pytorch/pytorch/330114/workflows/55cdae0a-92d5-422e-92f0-4cbbb7624704/jobs/13852690), so we cannot use it in FBGemm.

Differential Revision: D28852938

