### PR TITLE
Add functions for dequantizing rowwise-quantized int2/int4/int8 + fp16 scale/bias to fp16 embeddings.

### DIFF
--- a/include/fbgemm/QuantUtils.h
+++ b/include/fbgemm/QuantUtils.h
@@ -295,6 +295,7 @@ FBGEMM_API void ToFusedNBitRowwiseQuantizedSBHalf(
  * the row itself (fused) at the end.
  *
  * @param bit_rate can be 2, 4, or 8
+ * TODO(T91361248): deprecate and replace with FusedNBitRowwiseQuantizedSBHalf.
  */
 FBGEMM_API void FusedNBitRowwiseQuantizedSBHalfToFloat(
     int bit_rate,
@@ -302,6 +303,24 @@ FBGEMM_API void FusedNBitRowwiseQuantizedSBHalfToFloat(
     int input_rows,
     int input_columns,
     float* output);
+
+/**
+ * Convert fused rowwise quantized inputs to float (fp32 or fp16).
+ * bitrate specifies the number of bits in quantized input.
+ * Scale and Bias are in fp16. Each row's Scale and Bias are stored in
+ * the row itself (fused) at the end.
+ *
+ * @param bit_rate can be 2, 4, or 8
+ * TODO(T91361248): after deprecating FusedNBitRowwiseQuantizedSBHalfToFloat,
+ * rename this one to FusedNBitRowwiseQuantizedSBHalfToFloat.
+ */
+template <typename OutputType>
+FBGEMM_API void FusedNBitRowwiseQuantizedSBHalf(
+    int bit_rate,
+    const uint8_t* input,
+    int input_rows,
+    int input_columns,
+    OutputType* output);
 
 /**
  * Convert float inputs to rowwise quantized (8-bit) outputs.
@@ -337,6 +356,8 @@ FBGEMM_API void Fused8BitRowwiseQuantizedSBFloatToFloat(
 /**
  * Same as ToFusedNBitRowwiseQuantizedSBHalf but unoptimized.
  * This should not be called directly except in testing.
+ * TODO(T91361248): after deprecating FloatToFusedNBitRowwiseQuantizedSBHalf,
+ * rename this one to FloatToFusedNBitRowwiseQuantizedSBHalfRef.
  */
 template <typename InputType>
 FBGEMM_API void ToFusedNBitRowwiseQuantizedSBHalfRef(
@@ -359,13 +380,17 @@ FBGEMM_API void FloatToFused8BitRowwiseQuantizedSBFloatRef(
 /**
  * Same as FusedNBitRowwiseQuantizedSBHalfToFloat but unoptimized.
  * This should not be called directly except in testing.
+ * TODO(T91361248): after deprecating FusedNBitRowwiseQuantizedSBHalfToFloat,
+ * rename this one to FusedNBitRowwiseQuantizedSBHalfToFloatRef.
  */
-FBGEMM_API void FusedNBitRowwiseQuantizedSBHalfToFloatRef(
+template <typename OutputType>
+FBGEMM_API void FusedNBitRowwiseQuantizedSBHalfRef(
     int bit_rate,
     const uint8_t* input,
     int input_rows,
     int input_columns,
-    float* output);
+    OutputType* output);
+
 /**
  * Same as Fused8BitRowwiseQuantizedSBFloatToFloat but unoptimized.
  * This should not be called directly except in testing.

--- a/include/fbgemm/QuantUtilsAvx2.h
+++ b/include/fbgemm/QuantUtilsAvx2.h
@@ -125,6 +125,8 @@ FBGEMM_API void requantizeForFloatAvx2(
     int ld_in,
     const requantizationForFloatParams_t& r);
 
+ // TODO(T91361248): after deprecating FloatToFusedNBitRowwiseQuantizedSBHalf,
+ // rename this one to FloatToFusedNBitRowwiseQuantizedSBHalfAvx2.
 template <typename InputType, int BIT_RATE>
 void ToFusedNBitRowwiseQuantizedSBHalfAvx2(
     const InputType* input,
@@ -138,12 +140,14 @@ void FloatToFused8BitRowwiseQuantizedSBFloatAvx2(
     int input_columns,
     std::uint8_t* output);
 
-template <int BIT_RATE>
-void FusedNBitRowwiseQuantizedSBHalfToFloatAvx2(
+ // TODO(T91361248): after deprecating FusedNBitRowwiseQuantizedSBHalfToFloat,
+ // rename this one to FusedNBitRowwiseQuantizedSBHalfToFloatAvx2.
+template <typename OutputType, int BIT_RATE>
+void FusedNBitRowwiseQuantizedSBHalfAvx2(
     const std::uint8_t* input,
     int input_rows,
     int input_columns,
-    float* output);
+    OutputType* output);
 
 void Fused8BitRowwiseQuantizedSBFloatToFloatAvx2(
     const std::uint8_t* input,

--- a/src/QuantUtilsAvx2.cc
+++ b/src/QuantUtilsAvx2.cc
@@ -6,7 +6,6 @@
  */
 #define FBGEMM_EXPORTS
 #include "fbgemm/QuantUtilsAvx2.h"
-#include "fbgemm/Types.h"
 #include <immintrin.h>
 #include <algorithm> //for std::min/std::max
 #include <cassert> //for assert
@@ -15,6 +14,7 @@
 #include <cstring> //for memcpy
 #include <limits> //for numeric_limits
 #include "./MaskAvx2.h"
+#include "fbgemm/Types.h"
 
 namespace fbgemm {
 
@@ -1679,27 +1679,11 @@ void ToFusedNBitRowwiseQuantizedSBHalfAvx2(
   }
 }
 
-#define INSTANTIATE_ToFusedNBitRowwiseQuantizedSBHalfAvx2(type, bit_rate) \
-  template void ToFusedNBitRowwiseQuantizedSBHalfAvx2<type, bit_rate>(    \
-      const type* input,                                                  \
-      int input_rows,                                                     \
-      int input_columns,                                                  \
-      std::uint8_t* output);
-
-INSTANTIATE_ToFusedNBitRowwiseQuantizedSBHalfAvx2(float, 2)
-INSTANTIATE_ToFusedNBitRowwiseQuantizedSBHalfAvx2(float, 4)
-INSTANTIATE_ToFusedNBitRowwiseQuantizedSBHalfAvx2(float, 8)
-INSTANTIATE_ToFusedNBitRowwiseQuantizedSBHalfAvx2(float16, 2)
-INSTANTIATE_ToFusedNBitRowwiseQuantizedSBHalfAvx2(float16, 4)
-INSTANTIATE_ToFusedNBitRowwiseQuantizedSBHalfAvx2(float16, 8)
-
-#undef INSTANTIATE_ToFusedNBitRowwiseQuantizedSBHalfAvx2
-
 void FloatToFused8BitRowwiseQuantizedSBFloatAvx2(
-  const float* input,
-  int input_rows,
-  int input_columns,
-  std::uint8_t* output) {
+    const float* input,
+    int input_rows,
+    int input_columns,
+    std::uint8_t* output) {
   constexpr int VLEN = 8;
   constexpr float kEpsilon = 1e-8f;
 
@@ -1796,12 +1780,15 @@ void FloatToFused8BitRowwiseQuantizedSBFloatAvx2(
   }
 }
 
-template <int BIT_RATE>
-void FusedNBitRowwiseQuantizedSBHalfToFloatAvx2(
+template <typename OutputType, int BIT_RATE>
+void FusedNBitRowwiseQuantizedSBHalfAvx2(
     const std::uint8_t* input,
     int input_rows,
     int input_columns,
-    float* output) {
+    OutputType* output) {
+  static_assert(
+      std::is_same<OutputType, float>() || std::is_same<OutputType, float16>(),
+      "Only float and float16 types are allowed.");
   constexpr int VLEN = 8;
   constexpr int NUM_ELEM_PER_BYTE = 8 / BIT_RATE;
   int output_columns =
@@ -1814,31 +1801,55 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatAvx2(
   constexpr int NUM_ELEM_PER_32BIT = 32 / BIT_RATE;
   // multiply by 4 because we're handling 4 vlen per iteration
   constexpr int NUM_OF_32BIT_PER_VLOAD = VLEN * 4 / NUM_ELEM_PER_32BIT;
-  int remainder_32bit_granularity = (output_columns + NUM_ELEM_PER_32BIT - 1) /
-      NUM_ELEM_PER_32BIT % NUM_OF_32BIT_PER_VLOAD;
-  __m128i vmask_load = _mm_lddqu_si128(reinterpret_cast<const __m128i*>(
-      internal::avx2_ps_or_epi32_combined_mask + NUM_OF_32BIT_PER_VLOAD +
-      (NUM_OF_32BIT_PER_VLOAD - remainder_32bit_granularity) %
-          NUM_OF_32BIT_PER_VLOAD));
-  int remainder = output_columns % (4 * VLEN);
-  __m256i vmask_store0 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(
-      internal::avx2_ps_or_epi32_combined_mask +
-      (VLEN - std::min(output_columns % (4 * VLEN), VLEN) % (VLEN + 1))));
-  __m256i vmask_store1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(
-      internal::avx2_ps_or_epi32_combined_mask +
-      (VLEN -
-       std::max(0, std::min(output_columns % (4 * VLEN) - VLEN, VLEN)) %
-           (VLEN + 1))));
-  __m256i vmask_store2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(
-      internal::avx2_ps_or_epi32_combined_mask +
-      (VLEN -
-       std::max(0, std::min(output_columns % (4 * VLEN) - 2 * VLEN, VLEN)) %
-           (VLEN + 1))));
-  __m256i vmask_store3 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(
-      internal::avx2_ps_or_epi32_combined_mask +
-      (VLEN -
-       std::max(0, std::min(output_columns % (4 * VLEN) - 3 * VLEN, VLEN)) %
-           (VLEN + 1))));
+
+  int remainder_32bit_granularity, remainder;
+  __m128i vmask_load;
+  __m256i vmask_store0, vmask_store1, vmask_store2, vmask_store3;
+  if (BIT_RATE == 4 || BIT_RATE == 2) {
+    remainder_32bit_granularity = (output_columns + NUM_ELEM_PER_32BIT - 1) /
+        NUM_ELEM_PER_32BIT % NUM_OF_32BIT_PER_VLOAD;
+    vmask_load = _mm_lddqu_si128(reinterpret_cast<const __m128i*>(
+        internal::avx2_ps_or_epi32_combined_mask + NUM_OF_32BIT_PER_VLOAD +
+        (NUM_OF_32BIT_PER_VLOAD - remainder_32bit_granularity) %
+            NUM_OF_32BIT_PER_VLOAD));
+    remainder = output_columns % (4 * VLEN);
+    int remainder_ratio = 1;
+    if (std::is_same<OutputType, float16>()) {
+      // For fp16 we only need half of the mask.
+      //
+      // For instance, if reminder is 2, for FP32 the masks are
+      // {-1, -1, 0, ..., 0}, {0, ..., 0}, {0, ..., 0}, {0, ..., 0}
+      // (8 32-bit integers for each mask)
+      // for FP16 we only need
+      // {-1, 0, 0, 0}, {0, ..., 0}, {0, ..., 0}, {0, ..., 0}
+      // (4 32-bit integers for each mask)
+      //
+      // Or, if reminder is 30, for FP32 the masks are
+      // {-1, ..., -1}, {-1, ..., -1}, {-1, ..., -1}, {-1, .., -1, 0, 0}
+      // for FP16 we only need
+      // {-1, ..., -1}, {-1, ..., -1}, {-1, ..., -1}, {-1, -1, -1, 0}
+      // (NOTE: for bit_rate 4 or 2, reminder are always multiple of 2 or 4).
+      remainder_ratio = 2;
+    }
+    vmask_store0 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(
+        internal::avx2_ps_or_epi32_combined_mask +
+        (VLEN - std::min(remainder, VLEN) / remainder_ratio % (VLEN + 1))));
+    vmask_store1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(
+        internal::avx2_ps_or_epi32_combined_mask +
+        (VLEN -
+         std::max(0, std::min(remainder - VLEN, VLEN) / remainder_ratio) %
+             (VLEN + 1))));
+    vmask_store2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(
+        internal::avx2_ps_or_epi32_combined_mask +
+        (VLEN -
+         std::max(0, std::min(remainder - 2 * VLEN, VLEN) / remainder_ratio) %
+             (VLEN + 1))));
+    vmask_store3 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(
+        internal::avx2_ps_or_epi32_combined_mask +
+        (VLEN -
+         std::max(0, std::min(remainder - 3 * VLEN, VLEN) / remainder_ratio) %
+             (VLEN + 1))));
+  }
 
   for (std::size_t row = 0; row < input_rows; ++row) {
     const std::uint8_t* input_row = input + row * input_columns;
@@ -1847,7 +1858,14 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatAvx2(
         (output_columns + NUM_ELEM_PER_BYTE - 1) / NUM_ELEM_PER_BYTE);
     float scale = halfToFloat(input_row_scale_bias[0]);
     float bias = halfToFloat(input_row_scale_bias[1]);
-    float* output_row = output + row * output_columns;
+    OutputType* output_row = output + row * output_columns;
+    float* output_row_float;
+    if (std::is_same<OutputType, float>()) {
+      // NOTE: this reinterpret_cast is only to workaround c++
+      // type requirements -- `output_row` HAS to be float* type.
+      // Remove it and use constexpr when pytorch allows C++11.
+      output_row_float = reinterpret_cast<float*>(output_row);
+    }
 
     std::size_t col = 0;
     if (BIT_RATE == 4 || BIT_RATE == 2) {
@@ -1887,10 +1905,28 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatAvx2(
         vinq1 = _mm256_fmadd_ps(vscale, vinq1, vbias);
         vinq2 = _mm256_fmadd_ps(vscale, vinq2, vbias);
         vinq3 = _mm256_fmadd_ps(vscale, vinq3, vbias);
-        _mm256_storeu_ps(output_row + col, vinq0);
-        _mm256_storeu_ps(output_row + col + VLEN, vinq1);
-        _mm256_storeu_ps(output_row + col + 2 * VLEN, vinq2);
-        _mm256_storeu_ps(output_row + col + 3 * VLEN, vinq3);
+
+        if (std::is_same<OutputType, float>()) {
+          _mm256_storeu_ps(output_row_float + col, vinq0);
+          _mm256_storeu_ps(output_row_float + col + VLEN, vinq1);
+          _mm256_storeu_ps(output_row_float + col + 2 * VLEN, vinq2);
+          _mm256_storeu_ps(output_row_float + col + 3 * VLEN, vinq3);
+        } else {
+          constexpr int sae =
+              0; //_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+          _mm_storeu_si128(
+              reinterpret_cast<__m128i*>(output_row + col),
+              _mm256_cvtps_ph(vinq0, sae));
+          _mm_storeu_si128(
+              reinterpret_cast<__m128i*>(output_row + col + VLEN),
+              _mm256_cvtps_ph(vinq1, sae));
+          _mm_storeu_si128(
+              reinterpret_cast<__m128i*>(output_row + col + 2 * VLEN),
+              _mm256_cvtps_ph(vinq2, sae));
+          _mm_storeu_si128(
+              reinterpret_cast<__m128i*>(output_row + col + 3 * VLEN),
+              _mm256_cvtps_ph(vinq3, sae));
+        }
       }
 
       if (remainder) {
@@ -1929,39 +1965,50 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatAvx2(
         vinq2 = _mm256_fmadd_ps(vscale, vinq2, vbias);
         vinq3 = _mm256_fmadd_ps(vscale, vinq3, vbias);
 
-        _mm256_maskstore_ps(output_row + col, vmask_store0, vinq0);
-        _mm256_maskstore_ps(output_row + col + VLEN, vmask_store1, vinq1);
-        _mm256_maskstore_ps(output_row + col + 2 * VLEN, vmask_store2, vinq2);
-        _mm256_maskstore_ps(output_row + col + 3 * VLEN, vmask_store3, vinq3);
+        if (std::is_same<OutputType, float>()) {
+          _mm256_maskstore_ps(output_row_float + col, vmask_store0, vinq0);
+          _mm256_maskstore_ps(
+              output_row_float + col + VLEN, vmask_store1, vinq1);
+          _mm256_maskstore_ps(
+              output_row_float + col + 2 * VLEN, vmask_store2, vinq2);
+          _mm256_maskstore_ps(
+              output_row_float + col + 3 * VLEN, vmask_store3, vinq3);
+        } else {
+          constexpr int sae =
+              0; //_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+          _mm_maskstore_epi32(
+              reinterpret_cast<int*>(output_row + col),
+              _mm256_castsi256_si128(vmask_store0),
+              _mm256_cvtps_ph(vinq0, sae));
+          _mm_maskstore_epi32(
+              reinterpret_cast<int*>(output_row + col + VLEN),
+              _mm256_castsi256_si128(vmask_store1),
+              _mm256_cvtps_ph(vinq1, sae));
+          _mm_maskstore_epi32(
+              reinterpret_cast<int*>(output_row + col + 2 * VLEN),
+              _mm256_castsi256_si128(vmask_store2),
+              _mm256_cvtps_ph(vinq2, sae));
+          _mm_maskstore_epi32(
+              reinterpret_cast<int*>(output_row + col + 3 * VLEN),
+              _mm256_castsi256_si128(vmask_store3),
+              _mm256_cvtps_ph(vinq3, sae));
+        }
       }
     } else {
       for (; col < output_columns; ++col) {
         std::uint8_t quantized = input_row[col / NUM_ELEM_PER_BYTE];
         quantized >>= (col % NUM_ELEM_PER_BYTE) * BIT_RATE;
         quantized &= (1 << BIT_RATE) - 1;
-        output_row[col] = scale * quantized + bias;
+        float output_value = scale * quantized + bias;
+        if (std::is_same<OutputType, float>()) {
+          output_row[col] = output_value;
+        } else {
+          output_row[col] = cpu_float2half_rn(output_value);
+        }
       }
     }
   }
 }
-
-template void FusedNBitRowwiseQuantizedSBHalfToFloatAvx2<2>(
-    const std::uint8_t* input,
-    int input_rows,
-    int input_columns,
-    float* output);
-
-template void FusedNBitRowwiseQuantizedSBHalfToFloatAvx2<4>(
-    const std::uint8_t* input,
-    int input_rows,
-    int input_columns,
-    float* output);
-
-template void FusedNBitRowwiseQuantizedSBHalfToFloatAvx2<8>(
-    const std::uint8_t* input,
-    int input_rows,
-    int input_columns,
-    float* output);
 
 void Fused8BitRowwiseQuantizedSBFloatToFloatAvx2(
     const std::uint8_t* input,
@@ -1995,5 +2042,28 @@ void Fused8BitRowwiseQuantizedSBFloatToFloatAvx2(
     }
   }
 }
+
+// clang-format off
+#define INSTANTIATE_QuantizationAvx2Functions(type, bit_rate)          \
+  template void ToFusedNBitRowwiseQuantizedSBHalfAvx2<type, bit_rate>( \
+      const type* input,                                               \
+      int input_rows,                                                  \
+      int input_columns,                                               \
+      std::uint8_t* output);                                           \
+  template void FusedNBitRowwiseQuantizedSBHalfAvx2<type, bit_rate>(   \
+      const std::uint8_t* input,                                       \
+      int input_rows,                                                  \
+      int input_columns,                                               \
+      type* output);
+
+INSTANTIATE_QuantizationAvx2Functions(float, 2)
+INSTANTIATE_QuantizationAvx2Functions(float, 4)
+INSTANTIATE_QuantizationAvx2Functions(float, 8)
+INSTANTIATE_QuantizationAvx2Functions(float16, 2)
+INSTANTIATE_QuantizationAvx2Functions(float16, 4)
+INSTANTIATE_QuantizationAvx2Functions(float16, 8)
+
+#undef INSTANTIATE_QuantizationAvx2Functions
+// clang-format on
 
 } // namespace fbgemm

--- a/test/QuantUtilsTest.cc
+++ b/test/QuantUtilsTest.cc
@@ -152,10 +152,13 @@ template <typename T>
     return ::testing::AssertionFailure() << " Quantized results do not match";
 }
 
+// atol: absolute tolerance. <=0 means do not consider atol.
+// rtol: relative tolerance. <=0 means do not consider rtol.
 ::testing::AssertionResult floatCloseAll(
     vector<float>& a,
     vector<float>& b,
-    float atol = std::numeric_limits<float>::epsilon()) {
+    float atol = std::numeric_limits<float>::epsilon(),
+    float rtol = 0) {
   std::stringstream ss;
   bool match = true;
   if (a.size() != b.size()) {
@@ -164,12 +167,36 @@ template <typename T>
   }
   if (match) {
     for (int i = 0; i < a.size(); i++) {
-      float absDiff = fabs(a[i] - b[i]);
-      if (absDiff > atol) {
-        ss << " mismatch at (" << i << ") " << endl;
-        ss << "\t  ref: " << a[i] << " test: " << b[i] << endl;
-        ss << "\t diff: " << absDiff << " > " << atol << endl;
-        match = false;
+      const bool consider_absDiff = atol > 0;
+      const bool consider_relDiff = rtol > 0 &&
+          fabs(a[i]) > std::numeric_limits<float>::epsilon() &&
+          fabs(b[i]) > std::numeric_limits<float>::epsilon();
+
+      const float absDiff = fabs(a[i] - b[i]);
+      const float relDiff = absDiff / fabs(a[i]);
+
+      if (consider_absDiff && consider_relDiff) {
+        if (absDiff > atol && relDiff > rtol) {
+          ss << " mismatch at (" << i << ") " << endl;
+          ss << "\t  ref: " << a[i] << " test: " << b[i] << endl;
+          ss << "\t absolute diff: " << absDiff << " > " << atol << endl;
+          ss << "\t relative diff: " << relDiff << " > " << rtol << endl;
+          match = false;
+        }
+      } else if (consider_absDiff) {
+        if (absDiff > atol) {
+          ss << " mismatch at (" << i << ") " << endl;
+          ss << "\t  ref: " << a[i] << " test: " << b[i] << endl;
+          ss << "\t absolute diff: " << absDiff << " > " << atol << endl;
+          match = false;
+        }
+      } else if (consider_relDiff) {
+        if (relDiff > rtol) {
+          ss << " mismatch at (" << i << ") " << endl;
+          ss << "\t  ref: " << a[i] << " test: " << b[i] << endl;
+          ss << "\t relative diff: " << relDiff << " > " << rtol << endl;
+          match = false;
+        }
       }
     }
   }
@@ -178,6 +205,30 @@ template <typename T>
   else
     return ::testing::AssertionFailure()
         << " results do not match. " << ss.str();
+}
+
+::testing::AssertionResult floatCloseAll(
+    vector<float>& a,
+    vector<float16>& b,
+    float atol = std::numeric_limits<float>::epsilon(),
+    float rtol = 0) {
+  vector<float> b_float(b.size());
+  const auto transform = [](float16 input) { return cpu_half2float(input); };
+  std::transform(b.begin(), b.end(), b_float.begin(), transform);
+  return floatCloseAll(a, b_float, atol, rtol);
+}
+
+::testing::AssertionResult floatCloseAll(
+    vector<float16>& a,
+    vector<float16>& b,
+    float atol = std::numeric_limits<float>::epsilon(),
+    float rtol = 0) {
+  vector<float> a_float(a.size());
+  vector<float> b_float(b.size());
+  const auto transform = [](float16 input) { return cpu_half2float(input); };
+  std::transform(a.begin(), a.end(), a_float.begin(), transform);
+  std::transform(b.begin(), b.end(), b_float.begin(), transform);
+  return floatCloseAll(a_float, b_float, atol, rtol);
 }
 
 template <typename T>
@@ -580,8 +631,9 @@ TEST(FusedQuantizeDequantizeTest, cornerCases) {
 
 // Parameter are bit_rate (i.e., the number of bits in quantized values).
 class EmbeddingQuantizeFixedNumberTest : public testing::TestWithParam<int> {
-  protected:
-   EmbeddingQuantizeFixedNumberTest() {
+ protected:
+  // clang-format off
+  EmbeddingQuantizeFixedNumberTest() {
     float_test_input = {
       1, 1, 1, 1,               // All the same. Range: 0, min: 1
       -64, -2.75, 61.625, 191,  // Range: 255, min: -64. Picking 61.625 because it differs under FP16 (will become 61.5).
@@ -589,9 +641,11 @@ class EmbeddingQuantizeFixedNumberTest : public testing::TestWithParam<int> {
     assert(float_test_input.size() == row * col);
 
     float16_test_input.reserve(float_test_input.size());
-    std::transform(float_test_input.begin(), float_test_input.end(), float16_test_input.begin(),
-      [](float input) {return cpu_float2half_rn(input); }
-    );
+    std::transform(
+        float_test_input.begin(),
+        float_test_input.end(),
+        float16_test_input.begin(),
+        [](float input) { return cpu_float2half_rn(input); });
 
     // Results are hand calculated.
     expected_output[8] = {
@@ -609,13 +663,14 @@ class EmbeddingQuantizeFixedNumberTest : public testing::TestWithParam<int> {
       0, 0, 0, 0, 0, 0                       // Padding
     };
   }
+  // clang-format on
 
   const int row = 2;
   const int col = 4;
   const int out_cols = col + 2 * sizeof(float16);
   std::vector<float> float_test_input;
   std::vector<float16> float16_test_input;
-  std::map</*bit_rate*/int, /*output*/std::vector<uint8_t>> expected_output;
+  std::map</*bit_rate*/ int, /*output*/ std::vector<uint8_t>> expected_output;
 };
 
 INSTANTIATE_TEST_CASE_P(
@@ -629,17 +684,21 @@ TEST_P(EmbeddingQuantizeFixedNumberTest, embeddingFloatToQuantizedSBHalfTest) {
 
   ToFusedNBitRowwiseQuantizedSBHalfRef<float>(
       bit_rate, float_test_input.data(), row, col, outVecTest.data());
-  EXPECT_TRUE(isQEmbeddingClose<float16>(expected_output[bit_rate], outVecTest, row, col));
+  EXPECT_TRUE(isQEmbeddingClose<float16>(
+      expected_output[bit_rate], outVecTest, row, col));
   ToFusedNBitRowwiseQuantizedSBHalf<float>(
       bit_rate, float_test_input.data(), row, col, outVecTest.data());
-  EXPECT_TRUE(isQEmbeddingClose<float16>(expected_output[bit_rate], outVecTest, row, col));
+  EXPECT_TRUE(isQEmbeddingClose<float16>(
+      expected_output[bit_rate], outVecTest, row, col));
 
   ToFusedNBitRowwiseQuantizedSBHalfRef<float16>(
       bit_rate, float16_test_input.data(), row, col, outVecTest.data());
-  EXPECT_TRUE(isQEmbeddingClose<float16>(expected_output[bit_rate], outVecTest, row, col));
+  EXPECT_TRUE(isQEmbeddingClose<float16>(
+      expected_output[bit_rate], outVecTest, row, col));
   ToFusedNBitRowwiseQuantizedSBHalf<float16>(
       bit_rate, float16_test_input.data(), row, col, outVecTest.data());
-  EXPECT_TRUE(isQEmbeddingClose<float16>(expected_output[bit_rate], outVecTest, row, col));
+  EXPECT_TRUE(isQEmbeddingClose<float16>(
+      expected_output[bit_rate], outVecTest, row, col));
 }
 
 // Scale and bias are of type float16
@@ -676,32 +735,49 @@ TEST_P(EmbeddingQuantizeTest, embeddingHalfTest) {
   EXPECT_TRUE(
       isQEmbeddingClose<float16>(outVecRef, outVecTest, rows, out_emb_cols));
 
-  FusedNBitRowwiseQuantizedSBHalfToFloatRef(
+  FusedNBitRowwiseQuantizedSBHalfRef<float>(
       bit_rate, outVecTest.data(), rows, out_cols, dequantOutRef.data());
-  FusedNBitRowwiseQuantizedSBHalfToFloat(
+  FusedNBitRowwiseQuantizedSBHalf<float>(
       bit_rate, outVecTest.data(), rows, out_cols, dequantOutTest.data());
   EXPECT_TRUE(floatCloseAll(dequantOutRef, dequantOutTest, 1e-3));
-
 
   generate(inpVec.begin(), inpVec.end(), [&, disFP]() mutable {
     return cpu_half2float(cpu_float2half_rn(disFP(gen)));
   });
   vector<float16> inpHalfVec(rows * cols);
-  std::transform(inpVec.begin(), inpVec.end(), inpHalfVec.begin(),
-    [](float input) {return cpu_float2half_rn(input); }
-  );
+  std::transform(
+      inpVec.begin(), inpVec.end(), inpHalfVec.begin(), [](float input) {
+        return cpu_float2half_rn(input);
+      });
   vector<uint8_t> outVecRefFromHalf(outVecSize);
   vector<uint8_t> outVecTestFromHalf(outVecSize);
   ToFusedNBitRowwiseQuantizedSBHalfRef<float>(
       bit_rate, inpVec.data(), rows, cols, outVecRef.data());
   ToFusedNBitRowwiseQuantizedSBHalfRef<float16>(
       bit_rate, inpHalfVec.data(), rows, cols, outVecRefFromHalf.data());
-  EXPECT_TRUE(
-      isQEmbeddingClose<float16>(outVecRefFromHalf, outVecRef, rows, out_emb_cols));
+  EXPECT_TRUE(isQEmbeddingClose<float16>(
+      outVecRefFromHalf, outVecRef, rows, out_emb_cols));
   ToFusedNBitRowwiseQuantizedSBHalf<float16>(
       bit_rate, inpHalfVec.data(), rows, cols, outVecTestFromHalf.data());
-  EXPECT_TRUE(
-      isQEmbeddingClose<float16>(outVecRefFromHalf, outVecTestFromHalf, rows, out_emb_cols));
+  EXPECT_TRUE(isQEmbeddingClose<float16>(
+      outVecRefFromHalf, outVecTestFromHalf, rows, out_emb_cols));
+
+  vector<float16> dequantOutHalfRef(rows * cols);
+  vector<float16> dequantOutHalfTest(rows * cols);
+  FusedNBitRowwiseQuantizedSBHalfRef<float>(
+      bit_rate, outVecRef.data(), rows, out_cols, dequantOutRef.data());
+  FusedNBitRowwiseQuantizedSBHalfRef<float16>(
+      bit_rate, outVecRef.data(), rows, out_cols, dequantOutHalfRef.data());
+  constexpr int NumberOfFP16Matissa = 9;
+  EXPECT_TRUE(floatCloseAll(
+      dequantOutRef, dequantOutHalfRef, 1e-3, pow(2, NumberOfFP16Matissa)));
+  FusedNBitRowwiseQuantizedSBHalf<float16>(
+      bit_rate, outVecRef.data(), rows, out_cols, dequantOutHalfTest.data());
+  EXPECT_TRUE(floatCloseAll(
+      dequantOutHalfRef,
+      dequantOutHalfTest,
+      1e-3,
+      pow(2, NumberOfFP16Matissa)));
 }
 
 // Scale and bias are of type float


### PR DESCRIPTION
Summary:
Template-ize FusedNBitRowwiseQuantizedSBHalfToFloat as FusedNBitRowwiseQuantizedSBHalf, for fp32 and fp16 outputs, with both opt and ref version.
Implementation-wise, both versions convert fp32 outputs to fp16 outputs, while reusing existing code in FusedNBitRowwiseQuantizedSBHalfToFloat as much as possible.

Differential Revision: D28875981

