### PR TITLE
Add quantize and dequantize functions between rowwise-quantized int8 + fp32 scale/bias and fp32 embeddings.

### DIFF
--- a/include/fbgemm/QuantUtils.h
+++ b/include/fbgemm/QuantUtils.h
@@ -326,10 +326,26 @@ FBGEMM_API void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf(
  * This version intentionally supports only 8-bit because we want to discourage
  * the usage of float scale and bias with 2 and 4 bit cases as that diminishes
  * the overall memory savings.
- *
+ * TODO(T91361248): deprecate and replace with FloatOrHalfToFused8BitRowwiseQuantizedSBFloat.
  */
 FBGEMM_API void FloatToFused8BitRowwiseQuantizedSBFloat(
     const float* input,
+    int input_rows,
+    int input_columns,
+    std::uint8_t* output);
+
+/**
+ * Convert float or half inputs to rowwise quantized (8-bit) outputs.
+ * Scale and Bias are in float. Each row's Scale and Bias are stored in
+ * the row itself (fused) at the end.
+ *
+ * This version intentionally supports only 8-bit because we want to discourage
+ * the usage of float scale and bias with 2 and 4 bit cases as that diminishes
+ * the overall memory savings.
+ */
+template <typename InputType>
+FBGEMM_API void FloatOrHalfToFused8BitRowwiseQuantizedSBFloat(
+    const InputType* input,
     int input_rows,
     int input_columns,
     std::uint8_t* output);
@@ -341,13 +357,28 @@ FBGEMM_API void FloatToFused8BitRowwiseQuantizedSBFloat(
  *
  * This version intentionally supports only 8-bit because
  * the corresponding quantize version only supports 8-bit.
- *
+ * TODO(T91361248): deprecate and replace with Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf.
  */
 FBGEMM_API void Fused8BitRowwiseQuantizedSBFloatToFloat(
     const uint8_t* input,
     int input_rows,
     int input_columns,
     float* output);
+
+/**
+ * Convert fused rowwise quantized (8-bit) inputs to float or half outputs.
+ * Scale and Bias are in float. Each row's Scale and Bias are stored in
+ * the row itself (fused) at the end.
+ *
+ * This version intentionally supports only 8-bit because
+ * the corresponding quantize version only supports 8-bit.
+ */
+template <typename OutputType>
+FBGEMM_API void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf(
+    const uint8_t* input,
+    int input_rows,
+    int input_columns,
+    OutputType* output);
 
 /**
  * Same as ToFusedNBitRowwiseQuantizedSBHalf but unoptimized.
@@ -362,11 +393,12 @@ FBGEMM_API void FloatOrHalfToFusedNBitRowwiseQuantizedSBHalfRef(
     std::uint8_t* output);
 
 /**
- * Same as FloatToFused8BitRowwiseQuantizedSBFloat but unoptimized.
+ * Same as FloatOrHalfToFused8BitRowwiseQuantizedSBFloat but unoptimized.
  * This should not be called directly except in testing.
  */
-FBGEMM_API void FloatToFused8BitRowwiseQuantizedSBFloatRef(
-    const float* input,
+template <typename InputType>
+FBGEMM_API void FloatOrHalfToFused8BitRowwiseQuantizedSBFloatRef(
+    const InputType* input,
     int input_rows,
     int input_columns,
     std::uint8_t* output);
@@ -384,13 +416,14 @@ FBGEMM_API void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef(
     OutputType* output);
 
 /**
- * Same as Fused8BitRowwiseQuantizedSBFloatToFloat but unoptimized.
+ * Same as Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf but unoptimized.
  * This should not be called directly except in testing.
  */
-FBGEMM_API void Fused8BitRowwiseQuantizedSBFloatToFloatRef(
+template <typename OutputType>
+FBGEMM_API void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfRef(
     const uint8_t* input,
     int input_rows,
     int input_columns,
-    float* output);
+    OutputType* output);
 
 } // namespace fbgemm

--- a/include/fbgemm/QuantUtilsAvx2.h
+++ b/include/fbgemm/QuantUtilsAvx2.h
@@ -132,8 +132,9 @@ void FloatOrHalfToFusedNBitRowwiseQuantizedSBHalfAvx2(
     int input_columns,
     std::uint8_t* output);
 
-void FloatToFused8BitRowwiseQuantizedSBFloatAvx2(
-    const float* input,
+template <typename InputType>
+void FloatOrHalfToFused8BitRowwiseQuantizedSBFloatAvx2(
+    const InputType* input,
     int input_rows,
     int input_columns,
     std::uint8_t* output);
@@ -145,10 +146,11 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfAvx2(
     int input_columns,
     OutputType* output);
 
-void Fused8BitRowwiseQuantizedSBFloatToFloatAvx2(
+template <typename OutputType>
+void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfAvx2(
     const std::uint8_t* input,
     int input_rows,
     int input_columns,
-    float* output);
+    OutputType* output);
 
 } // namespace fbgemm


### PR DESCRIPTION
Summary:
Template-ize FloatToFused8BitRowwiseQuantizedSBFloat and Fused8BitRowwiseQuantizedSBFloatToFloat, for opt and ref versions.
Similar to D28620537 (https://github.com/pytorch/FBGEMM/commit/9cb33bcfe545ec1c209f3b1000824833a5db7454) and D28875981 (https://github.com/pytorch/FBGEMM/commit/77a4792062a0b4b21c5f75b46a61f0fc1b3b4381).

Differential Revision: D28918591

