### PR TITLE
Deprecate old quanzation / dequantization util functions. (#59637)

### DIFF
--- a/bench/EmbeddingQuantizeBenchmark.cc
+++ b/bench/EmbeddingQuantizeBenchmark.cc
@@ -64,13 +64,13 @@ void performance_test() {
         duration = measureWithWarmup(
             [&]() {
               is_same<T, float16>::value
-                  ? FloatToFusedNBitRowwiseQuantizedSBHalf(
+                  ? FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf<float>(
                         bit_rate,
                         inpVec.data(),
                         rowSize,
                         colSize,
                         outVec.data())
-                  : FloatToFused8BitRowwiseQuantizedSBFloat(
+                  : FloatOrHalfToFused8BitRowwiseQuantizedSBFloat<float>(
                         inpVec.data(), rowSize, colSize, outVec.data());
             },
             NWARMUP,

--- a/fbgemm_gpu/src/quantize_ops_cpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops_cpu.cpp
@@ -31,7 +31,7 @@ at::Tensor& _float_to_fused8bitrowwise_cpu_out(
   output_dims[last_dim] = output_columns;
   at::native::resize_(output, output_dims, c10::nullopt);
 
-  fbgemm::FloatToFused8BitRowwiseQuantizedSBFloat(
+  fbgemm::FloatOrHalfToFused8BitRowwiseQuantizedSBFloat<float>(
       input.data_ptr<float>(), nrows, ncols, output.data_ptr<uint8_t>());
 
   return output;
@@ -56,7 +56,7 @@ at::Tensor& _fused8bitrowwise_to_float_cpu_out(
   output_dims[last_dim] = output_columns;
   at::native::resize_(output, output_dims, c10::nullopt);
 
-  fbgemm::Fused8BitRowwiseQuantizedSBFloatToFloat(
+  fbgemm::Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf<float>(
       input.data_ptr<uint8_t>(), nrows, ncols, output.data_ptr<float>());
 
   return output;


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/59637

Deprecate FloatToFusedNBitRowwiseQuantizedSBHalf, FusedNBitRowwiseQuantizedSBHalfToFloat, FloatToFused8BitRowwiseQuantizedSBFloat, and Fused8BitRowwiseQuantizedSBFloatToFloat.

Differential Revision: D28918581

