### PR TITLE
Fix the TorchScript issue for IntNBitTableBatchedEmbeddingBagsCodegen

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
@@ -42,12 +42,13 @@ class SparseType(enum.Enum):
 
     def as_int(self) -> int:
         return {
-            SparseType.FP32: 0,
-            SparseType.FP16: 1,
-            SparseType.INT8: 2,
-            SparseType.INT4: 3,
-            SparseType.INT2: 4,
-        }[self]
+            SparseType.FP32.value: 0,
+            SparseType.FP16.value: 1,
+            SparseType.INT8.value: 2,
+            SparseType.INT4.value: 3,
+            SparseType.INT2.value: 4,
+        }[self.value]
+
 
 ELEMENT_SIZE: Dict[SparseType, int] = {
     SparseType.FP32: 4,

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -1640,6 +1640,9 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             index_remapping=[torch.arange(E) for E in Es],
             use_cpu=cpu,
         )
+        # NOTE: test TorchScript-compatible!
+        cc = torch.jit.script(cc)
+
         for t in range(T):
             (weights, scale_shift) = cc.split_embedding_weights()[t]
             # weights.zero_()


### PR DESCRIPTION
Summary:
Resolve the torch.jit.script issues with SparseType (Enum).

This seems to be a bug with the torch.jit.script support. If we use the Enum type (e.g., `fbgemm_gpu.split_embedding_configs.SparseType`) as the key to the dict or check if Enum type is part of a Tuple, there is no issue with eager mode code, but when we call torch.jit.script, it will report the following error:
```
Cannot create dict for key type __torch__.fbgemm_gpu.split_embedding_configs.SparseType
```
or
```
  __contains__(str self, str key) -> (bool):
  Expected a value of type 'str' for argument 'self' but instead found type 'Tuple[__torch__.fbgemm_gpu.split_embedding_configs
.SparseType, __torch__.fbgemm_gpu.split_embedding_configs.SparseType]'.
```

Something maybe related: https://github.com/pytorch/pytorch/issues/16453

To fix this issue, we explicitly use the value of the Enum (here it is `str`) and avoid using the Tuple.

Differential Revision: D29056288

