### PR TITLE
block_bucketize op for jagged tensor in row-wise sharding

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -21,6 +21,36 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_data_cuda(
     const c10::optional<Tensor>& weights,
     const c10::optional<int64_t>& permuted_lengths_sum);
 
+std::tuple<
+    Tensor,
+    Tensor,
+    c10::optional<Tensor>,
+    c10::optional<Tensor>,
+    c10::optional<Tensor>>
+block_bucketize_sparse_features_cuda(
+    Tensor lengths,
+    Tensor indices,
+    bool bucketize_pos,
+    bool sequence,
+    Tensor block_sizes,
+    int64_t my_size,
+    c10::optional<Tensor> weights);
+
+std::tuple<
+    at::Tensor,
+    at::Tensor,
+    c10::optional<at::Tensor>,
+    c10::optional<at::Tensor>,
+    c10::optional<at::Tensor>>
+block_bucketize_sparse_features_cpu(
+    at::Tensor lengths,
+    at::Tensor indices,
+    bool bucketize_pos,
+    bool sequence,
+    at::Tensor block_sizes,
+    int64_t my_size,
+    c10::optional<at::Tensor> weights);
+
 std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_data_cpu(
     const Tensor& permute,
     const Tensor& lengths,

--- a/fbgemm_gpu/src/sparse_ops_gpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_gpu.cpp
@@ -12,6 +12,7 @@
 #include <ATen/core/op_registration/op_registration.h>
 #include <torch/library.h>
 
-TORCH_LIBRARY_IMPL(fb, CUDA, m) {
+TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   DISPATCH_TO_CUDA("permute_sparse_data", at::permute_sparse_data_cuda);
+  DISPATCH_TO_CUDA("block_bucketize_sparse_features", at::block_bucketize_sparse_features_cuda);
 }


### PR DESCRIPTION
Summary:
* open source block_bucketize op in fbgemm_gpu for row-wise and twrw
* add python op for `KeyedJaggedTensor` needed for row-wise and twrw sharding

Differential Revision: D29042321

