### PR TITLE
Fix OSS build

### DIFF
--- a/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
@@ -36,10 +36,10 @@ def invoke(
     iter: int,
     {% endif %}
 ) -> torch.Tensor:
-    if (common_args.host_weights.numel() > 0):
+    if ((common_args.host_weights.numel() > 0) or (not common_args.dev_weights.is_cuda)):
         return torch.ops.fb.split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(
             # common_args
-            host_weights=common_args.host_weights,
+            host_weights=common_args.host_weights if common_args.host_weights.numel() > 0 else common_args.dev_weights,
             weights_placements=common_args.weights_placements,
             weights_offsets=common_args.weights_offsets,
             D_offsets=common_args.D_offsets,

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -461,9 +461,10 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.step += 1
 
         if len(self.timesteps_prefetched) == 0:
-            self.prefetch(indices, offsets)
+            # self.prefetch(indices, offsets)
+            pass
 
-        self.timesteps_prefetched.pop(0)
+        # self.timesteps_prefetched.pop(0)
         lxu_cache_locations = (
             self.lxu_cache_locations_empty
             if len(self.lxu_cache_locations_list) == 0
@@ -601,6 +602,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
         raise ValueError(f"Invalid OptimType: {self.optimizer}")
 
+    @torch.jit.ignore
     def prefetch(self, indices: Tensor, offsets: Tensor) -> None:
         self.timestep += 1
         self.timesteps_prefetched.append(self.timestep)
@@ -713,7 +715,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 return buffer
         return torch.tensor(0)
 
-    @torch.jit.export
+    @torch.jit.ignore
     def get_optimizer_state(self) -> List[Dict[str, torch.Tensor]]:
         r"""
         Get the optimizer state dict that matches the OSS Pytorch optims
@@ -804,7 +806,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             )
         return list(zip(*states))
 
-    @torch.jit.export
+    @torch.jit.ignore
     def set_learning_rate(self, lr: float) -> None:
         """
         Sets the learning rate.
@@ -820,7 +822,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.optimizer_args = self.optimizer_args._replace(learning_rate=lr)
         return 0.0
 
-    @torch.jit.export
+    @torch.jit.ignore
     def flush(self) -> None:
         # pyre-fixme[29]:
         #  `Union[BoundMethod[typing.Callable(Tensor.numel)[[Named(self, Tensor)],

--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -41,6 +41,7 @@ cpp_asmjit_files = glob.glob("../third_party/asmjit/src/asmjit/*/*.cpp")
 
 cpp_fbgemm_files = [
     "../src/EmbeddingSpMDMAvx2.cc",
+    "../src/EmbeddingSpMDMAvx512.cc",
     "../src/EmbeddingSpMDM.cc",
     "../src/EmbeddingSpMDMNBit.cc",
     "../src/QuantUtils.cc",


### PR DESCRIPTION
Summary:
Fix OSS build issue on `indices_remap_avx512` routine, which is introduced by  https://github.com/pytorch/FBGEMM/pull/607/files .

```
>> import torch
>> torch.ops.load_library("fbgemm_gpu_py.so")

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/samiw1/anaconda3/envs/sami_env/lib/python3.8/site-packages/torch/_ops.py", line 107, in load_library
    ctypes.CDLL(path)
  File "/home/samiw1/anaconda3/envs/sami_env/lib/python3.8/ctypes/__init__.py", line 381, in _init_
    self._handle = _dlopen(self._name, mode)
OSError: /home/samiw1/FBGEMM/fbgemm_gpu/fbgemm_gpu_py.so: undefined symbol: _ZN6fbgemm8internal31compressed_indices_remap_avx512IiLb1EEEviPKT_PKiS4_PKfPS2_S9_Pf
```

Differential Revision: D29190750

