### PR TITLE
Move FusedNBitRowwiseQuantizedSBHalfToFloat and FloatToFusedNBitRowwiseQuantizedSBHalf to FBGEMM_GPU

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -60,5 +60,11 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_data_cpu(
 
 at::Tensor _float_to_fused8bitrowwise_gpu(const at::Tensor& input);
 at::Tensor _fused8bitrowwise_to_float_gpu(const at::Tensor& input);
+at::Tensor _float_to_fusednbitrowwise_gpu(
+    const at::Tensor& input,
+    const int64_t bit_rate);
+at::Tensor _fusednbitrowwise_to_float_gpu(
+    const at::Tensor& input,
+    const int64_t bit_rate);
 
 } // namespace at

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
@@ -87,6 +87,14 @@ inline bool torch_tensor_on_cuda_gpu_check(
       " and ",                                             \
       (y).dtype().name())
 
+#define TENSOR_NDIM_EQUALS(ten, dims)      \
+  TORCH_CHECK(                             \
+      (ten).ndimension() == (dims),        \
+      "Tensor '" #ten "' must have " #dims \
+      " dimension(s). "                    \
+      "Found ",                            \
+      (ten).ndimension())
+
 /// Determine an appropriate CUDA block count along the x axis
 ///
 /// When launching CUDA kernels the number of blocks B is often calculated

--- a/fbgemm_gpu/src/quantize_ops_gpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops_gpu.cpp
@@ -16,4 +16,8 @@ TORCH_LIBRARY_IMPL(fb, CUDA, m) {
       "FloatToFused8BitRowwiseQuantized", _float_to_fused8bitrowwise_gpu);
   DISPATCH_TO_CUDA(
       "Fused8BitRowwiseQuantizedToFloat", _fused8bitrowwise_to_float_gpu);
+  DISPATCH_TO_CUDA(
+      "FloatToFusedNBitRowwiseQuantizedSBHalf", _float_to_fusednbitrowwise_gpu);
+  DISPATCH_TO_CUDA(
+      "FusedNBitRowwiseQuantizedSBHalfToFloat", _fusednbitrowwise_to_float_gpu);
 }


### PR DESCRIPTION
Summary: Move the FusedNBit operators from PyTorch internal ops into FBGEMM_GPU directory to open source.

Differential Revision: D29332354

