### PR TITLE
Add quantize workflow for inference table batched embeddings

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
@@ -8,6 +8,7 @@
 import enum
 from typing import Dict
 
+
 @enum.unique
 class EmbOptimType(enum.Enum):
     SGD = "sgd"  # uses non-deterministic updates (atomicAdd(..)) with duplicate ids
@@ -47,6 +48,24 @@ class SparseType(enum.Enum):
             SparseType.INT8.value: 2,
             SparseType.INT4.value: 3,
             SparseType.INT2.value: 4,
+        }[self.value]
+
+    def bit_rate(self) -> int:
+        return {
+            SparseType.FP32.value: 32,
+            SparseType.FP16.value: 16,
+            SparseType.INT8.value: 8,
+            SparseType.INT4.value: 4,
+            SparseType.INT2.value: 2,
+        }[self.value]
+
+    def align_size(self) -> int:
+        return {
+            SparseType.FP32.value: 1,
+            SparseType.FP16.value: 4,
+            SparseType.INT8.value: 8,
+            SparseType.INT4.value: 8,
+            SparseType.INT2.value: 16,
         }[self.value]
 
 

--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_inference_converter.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_inference_converter.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+# pyre-unsafe
+
+import logging
+
+import fbgemm_gpu.split_table_batched_embeddings_ops as split_table_batched_embeddings_ops
+import numpy as np
+import torch
+from fbgemm_gpu.split_embedding_configs import SparseType
+from torch import nn
+
+
+# TODO: add per-feature based converter option (based on embedding_specs during inference)
+class SplitEmbInferenceConverter:
+    def __init__(self, quantize_type: SparseType):
+        self.quantize_type = quantize_type
+
+    def convert_model(self, model: torch.nn.Module) -> nn.Module:
+        self._quantize_split_embs(model)
+        return model
+
+    def _quantize_split_embs(self, model: nn.Module) -> None:
+        # pyre-fixme[29]: `Union[nn.Module, torch.Tensor]` is not a function.
+        for name, child in model.named_children():
+            if isinstance(
+                child,
+                split_table_batched_embeddings_ops.SplitTableBatchedEmbeddingBagsCodegen,
+            ):
+                embedding_specs = []
+                use_cpu = (
+                    child.embedding_specs[0][3]
+                    == split_table_batched_embeddings_ops.ComputeDevice.CPU
+                )
+                for (E, D, _, _) in child.embedding_specs:
+                    weights_ty = self.quantize_type
+                    if D % weights_ty.align_size() != 0:
+                        logging.warn(
+                            f"Embedding dim {D} couldn't be divided by align size {weights_ty.align_size()}!"
+                        )
+                        assert D % 4 == 0
+                        weights_ty = (
+                            SparseType.FP16
+                        )  # fall back to FP16 if dimension couldn't be aligned with the required size
+                    embedding_specs.append((E, D, weights_ty))
+
+                q_child = split_table_batched_embeddings_ops.IntNBitTableBatchedEmbeddingBagsCodegen(
+                    embedding_specs=embedding_specs,
+                    pooling_mode=child.pooling_mode,
+                    use_cpu=use_cpu,
+                )
+                for t, (_, _, weight_ty) in enumerate(embedding_specs):
+                    if weight_ty == SparseType.FP16:
+                        original_weight = child.split_embedding_weights()[t]
+                        q_weight = original_weight.half()
+                        # FIXME: How to view the PyTorch Tensor as a different type (e.g., uint8)
+                        # Here it uses numpy and it will introduce DtoH/HtoD overhead.
+                        weights = torch.tensor(q_weight.cpu().numpy().view(np.uint8))
+                        q_child.split_embedding_weights()[t][0].data.copy_(weights)
+
+                    elif weight_ty == SparseType.INT8:
+                        original_weight = child.split_embedding_weights()[t]
+                        q_weight = torch.ops.fbgemm.FloatToFused8BitRowwiseQuantized(
+                            original_weight
+                        )
+                        weights = q_weight[:, :-8]
+                        scale_shift = torch.tensor(
+                            q_weight[:, -8:]
+                            .contiguous()
+                            .cpu()
+                            .numpy()
+                            .view(np.float32)
+                            .astype(np.float16)
+                            .view(np.uint8)
+                        )  # [-4, -2]: scale; [-2:]: bias
+
+                        q_child.split_embedding_weights()[t][0].data.copy_(weights)
+                        q_child.split_embedding_weights()[t][1].data.copy_(scale_shift)
+
+                    elif weight_ty == SparseType.INT4 or weight_ty == SparseType.INT2:
+                        original_weight = child.split_embedding_weights()[t]
+                        q_weight = (
+                            torch.ops.fbgemm.FloatToFusedNBitRowwiseQuantizedSBHalf(
+                                original_weight,
+                                bit_rate=self.quantize_type.bit_rate(),
+                            )
+                        )
+                        weights = q_weight[:, :-4]
+                        scale_shift = torch.tensor(
+                            q_weight[:, -4:].contiguous().cpu().numpy().view(np.uint8)
+                        )  # [-4, -2]: scale; [-2:]: bias
+                        q_child.split_embedding_weights()[t][0].data.copy_(weights)
+                        q_child.split_embedding_weights()[t][1].data.copy_(scale_shift)
+
+                setattr(model, name, q_child)
+            else:
+                self._quantize_split_embs(child)

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -60,5 +60,11 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_data_cpu(
 
 at::Tensor _float_to_fused8bitrowwise_gpu(const at::Tensor& input);
 at::Tensor _fused8bitrowwise_to_float_gpu(const at::Tensor& input);
+at::Tensor _float_to_fusednbitrowwise_gpu(
+    const at::Tensor& input,
+    const int64_t bit_rate);
+at::Tensor _fusednbitrowwise_to_float_gpu(
+    const at::Tensor& input,
+    const int64_t bit_rate);
 
 } // namespace at

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
@@ -87,6 +87,14 @@ inline bool torch_tensor_on_cuda_gpu_check(
       " and ",                                             \
       (y).dtype().name())
 
+#define TENSOR_NDIM_EQUALS(ten, dims)      \
+  TORCH_CHECK(                             \
+      (ten).ndimension() == (dims),        \
+      "Tensor '" #ten "' must have " #dims \
+      " dimension(s). "                    \
+      "Found ",                            \
+      (ten).ndimension())
+
 /// Determine an appropriate CUDA block count along the x axis
 ///
 /// When launching CUDA kernels the number of blocks B is often calculated

--- a/fbgemm_gpu/src/quantize_ops_cpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops_cpu.cpp
@@ -62,7 +62,66 @@ at::Tensor& _fused8bitrowwise_to_float_cpu_out(
   return output;
 }
 
+
+at::Tensor _float_to_fusednbitrowwise_cpu(
+    const at::Tensor& input,
+    const int64_t bit_rate) {
+  TENSOR_ON_CPU(input);
+  TENSOR_NDIM_EQUALS(input, 2);
+
+  const auto input_sizes = input.sizes();
+  const int32_t nrows = input_sizes[0];
+  const int32_t ncols = input_sizes[1];
+  const int32_t num_elem_per_byte = 8 / bit_rate;
+  TORCH_CHECK(
+      ncols % (2 * num_elem_per_byte) == 0,
+      "ncols needs to be multiple of 2 Bytes (half type size) to make the address aligned");
+  const int32_t output_columns =
+      (ncols + num_elem_per_byte - 1) / num_elem_per_byte +
+      2 * sizeof(at::Half);
+  auto output = at::empty(
+      {nrows, output_columns},
+      input.options().dtype(at::kByte)); // at::kBytes for uint8_t
+
+  fbgemm::FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf<float>(
+      bit_rate,
+      input.data_ptr<float>(),
+      nrows,
+      ncols,
+      output.data_ptr<uint8_t>());
+
+  return output;
+}
+
+at::Tensor _fusednbitrowwise_to_float_cpu(
+    const at::Tensor& input,
+    const int64_t bit_rate) {
+  TENSOR_ON_CPU(input);
+  TENSOR_NDIM_EQUALS(input, 2);
+
+  const auto input_sizes = input.sizes();
+  const int32_t nrows = input_sizes[0];
+  const int32_t ncols = input_sizes[1];
+  const int32_t num_elem_per_byte = 8 / bit_rate;
+  const int32_t output_columns =
+      (ncols - 2 * sizeof(at::Half)) * num_elem_per_byte;
+
+  auto output = at::empty(
+      {nrows, output_columns}, // 4 = sizeof(float)
+      input.options().dtype(at::kFloat)); // at::kBytes for uint8_t
+
+  fbgemm::FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf<float>(
+      bit_rate,
+      input.data_ptr<uint8_t>(),
+      nrows,
+      ncols,
+      output.data_ptr<float>());
+
+  return output;
+}
+
 namespace {
+
 
 at::Tensor _float_to_fused8bitrowwise_cpu(const at::Tensor& input) {
   auto output = at::empty(
@@ -78,27 +137,33 @@ at::Tensor _fused8bitrowwise_to_float_cpu(const at::Tensor& input) {
   return _fused8bitrowwise_to_float_cpu_out(output, input);
 }
 
+
 } // namespace
 } // namespace at
 
-using namespace at;
-TORCH_LIBRARY_FRAGMENT(fb, m) {
+TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def("FloatToFused8BitRowwiseQuantized(Tensor t) -> Tensor");
   m.def(
       "FloatToFused8BitRowwiseQuantizedOut(Tensor output, Tensor input) -> Tensor");
   m.def("Fused8BitRowwiseQuantizedToFloat(Tensor input) -> Tensor");
   m.def(
       "Fused8BitRowwiseQuantizedToFloatOut(Tensor output, Tensor input) -> Tensor");
+  m.def(
+      "FloatToFusedNBitRowwiseQuantizedSBHalf(Tensor input, int bit_rate) -> Tensor");
+  m.def(
+      "FusedNBitRowwiseQuantizedSBHalfToFloat(Tensor input, int bit_rate) -> Tensor");
 }
 
-TORCH_LIBRARY_IMPL(fb, CPU, m) {
-  m.impl("FloatToFused8BitRowwiseQuantized", _float_to_fused8bitrowwise_cpu);
+TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
+  m.impl("FloatToFused8BitRowwiseQuantized", at::_float_to_fused8bitrowwise_cpu);
   m.impl(
-      "FloatToFused8BitRowwiseQuantizedOut",
-      _float_to_fused8bitrowwise_cpu_out);
+      "FloatToFused8BitRowwiseQuantizedOut", at::_float_to_fused8bitrowwise_cpu_out);
   m.impl(
       "Fused8BitRowwiseQuantizedToFloat", at::_fused8bitrowwise_to_float_cpu);
   m.impl(
-      "Fused8BitRowwiseQuantizedToFloatOut",
-      at::_fused8bitrowwise_to_float_cpu_out);
+      "Fused8BitRowwiseQuantizedToFloatOut", at::_fused8bitrowwise_to_float_cpu_out);
+  m.impl(
+      "FloatToFusedNBitRowwiseQuantizedSBHalf", at::_float_to_fusednbitrowwise_cpu);
+  m.impl(
+      "FusedNBitRowwiseQuantizedSBHalfToFloat", at::_fusednbitrowwise_to_float_cpu);
 }

--- a/fbgemm_gpu/src/quantize_ops_gpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops_gpu.cpp
@@ -11,9 +11,13 @@
 #include "fbgemm_gpu/sparse_ops_utils.h"
 
 using namespace at;
-TORCH_LIBRARY_IMPL(fb, CUDA, m) {
+TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   DISPATCH_TO_CUDA(
       "FloatToFused8BitRowwiseQuantized", _float_to_fused8bitrowwise_gpu);
   DISPATCH_TO_CUDA(
       "Fused8BitRowwiseQuantizedToFloat", _fused8bitrowwise_to_float_gpu);
+  DISPATCH_TO_CUDA(
+      "FloatToFusedNBitRowwiseQuantizedSBHalf", _float_to_fusednbitrowwise_gpu);
+  DISPATCH_TO_CUDA(
+      "FusedNBitRowwiseQuantizedSBHalfToFloat", _fusednbitrowwise_to_float_gpu);
 }

--- a/fbgemm_gpu/test/split_embedding_inference_converter_test.py
+++ b/fbgemm_gpu/test/split_embedding_inference_converter_test.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+
+# pyre-unsafe
+
+import unittest
+from typing import Tuple
+
+import fbgemm_gpu.split_table_batched_embeddings_ops as split_table_batched_embeddings_ops
+import hypothesis.strategies as st
+import numpy as np
+import torch
+from fbgemm_gpu.split_embedding_configs import SparseType
+from fbgemm_gpu.split_embedding_inference_converter import SplitEmbInferenceConverter
+from fbgemm_gpu.split_table_batched_embeddings_ops import OptimType
+from hypothesis import Verbosity, given, settings
+from torch import nn
+
+
+EMB_WEIGHT_UNIFORM_INIT_BOUND = 0.000316
+MAX_EXAMPLES = 40
+
+
+def div_round_up(a: int, b: int) -> int:
+    return int((a + b - 1) // b) * b
+
+
+def to_device(t: torch.Tensor, use_cpu: bool) -> torch.Tensor:
+    return t.cpu() if use_cpu else t.cuda()
+
+
+def get_table_batched_offsets_from_dense(
+    merged_indices: torch.Tensor, use_cpu: bool = False
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    (T, B, L) = merged_indices.size()
+    lengths = np.ones((T, B)) * L
+    flat_lengths = lengths.flatten()
+    return (
+        to_device(merged_indices.contiguous().view(-1), use_cpu),
+        to_device(
+            torch.tensor(([0] + np.cumsum(flat_lengths).tolist())).long(),
+            use_cpu,
+        ),
+    )
+
+
+class SparseArch(nn.Module):
+    """
+    The testing module with split table batched embedding op
+    """
+
+    def __init__(
+        self,
+        emb_dim,
+        num_tables,
+        num_rows,
+        use_cpu,
+    ):
+        super().__init__()
+        pooling_mode = split_table_batched_embeddings_ops.PoolingMode.SUM
+        Ds = [emb_dim] * num_tables
+        Es = [num_rows] * num_tables
+
+        device = (
+            split_table_batched_embeddings_ops.ComputeDevice.CPU
+            if use_cpu
+            else split_table_batched_embeddings_ops.ComputeDevice.CUDA
+        )
+        loc = (
+            split_table_batched_embeddings_ops.EmbeddingLocation.HOST
+            if use_cpu
+            else split_table_batched_embeddings_ops.EmbeddingLocation.DEVICE
+        )
+
+        self.emb_module = (
+            split_table_batched_embeddings_ops.SplitTableBatchedEmbeddingBagsCodegen(
+                embedding_specs=[
+                    (
+                        E,
+                        D,
+                        loc,
+                        device,
+                    )
+                    for (E, D) in zip(Es, Ds)
+                ],
+                weights_precision=SparseType.FP32,
+                optimizer=OptimType.EXACT_SGD,
+                learning_rate=0.05,
+                pooling_mode=pooling_mode,
+            )
+        )
+
+        self.emb_module.init_embedding_weights_uniform(
+            -EMB_WEIGHT_UNIFORM_INIT_BOUND, +EMB_WEIGHT_UNIFORM_INIT_BOUND
+        )
+
+    def forward(self, indices, offsets):
+        return self.emb_module(indices, offsets)
+
+
+class QuantizedSplitEmbeddingsTest(unittest.TestCase):
+    @given(
+        T=st.integers(min_value=1, max_value=10),
+        D=st.integers(min_value=2, max_value=128),
+        B=st.integers(min_value=1, max_value=128),
+        log_E=st.integers(min_value=3, max_value=5),
+        L=st.integers(min_value=0, max_value=20),
+        pooling_mode=st.sampled_from(
+            [
+                split_table_batched_embeddings_ops.PoolingMode.SUM,
+                split_table_batched_embeddings_ops.PoolingMode.MEAN,
+            ]
+        ),
+        quantize_type=st.sampled_from(
+            [
+                SparseType.INT8,
+                SparseType.INT4,
+                SparseType.INT2,
+                SparseType.FP16,
+            ]
+        ),
+        use_cpu=st.booleans() if torch.cuda.is_available() else st.just(True),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    def test_quantize_workflow(
+        self,
+        T: int,
+        D: int,
+        B: int,
+        log_E: int,
+        L: int,
+        pooling_mode: split_table_batched_embeddings_ops.PoolingMode,
+        quantize_type: SparseType,
+        use_cpu: bool,
+    ) -> None:
+        E = int(10 ** log_E)
+        Es = [E] * T
+        D_alignment = 8 if not quantize_type == SparseType.INT2 else 16
+        D = div_round_up(D, D_alignment)
+
+        xs = [torch.randint(low=0, high=e, size=(B, L)) for e in Es]
+        x = torch.cat([x.view(1, B, L) for x in xs], dim=0)
+        # indices: T, B, L; offsets: T * B + 1
+        (indices, offsets) = get_table_batched_offsets_from_dense(x, use_cpu=use_cpu)
+        sparse_arch = SparseArch(emb_dim=D, num_tables=T, num_rows=E, use_cpu=use_cpu)
+
+        # Fake quantize to make the original weight in FP32 all be exactly
+        # representable by INT8 row-wise quantized values
+        if quantize_type == quantize_type.INT8:
+            for t in range(T):
+                sparse_arch.emb_module.split_embedding_weights()[t].data.copy_(
+                    torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloat(
+                        torch.ops.fbgemm.FloatToFused8BitRowwiseQuantized(
+                            sparse_arch.emb_module.split_embedding_weights()[t].data
+                        )
+                    )
+                )
+        elif quantize_type == quantize_type.INT4 or quantize_type == quantize_type.INT2:
+            for t in range(T):
+                sparse_arch.emb_module.split_embedding_weights()[t].data.copy_(
+                    torch.ops.fbgemm.FusedNBitRowwiseQuantizedSBHalfToFloat(
+                        torch.ops.fbgemm.FloatToFusedNBitRowwiseQuantizedSBHalf(
+                            sparse_arch.emb_module.split_embedding_weights()[t].data,
+                            bit_rate=quantize_type.bit_rate(),
+                        ),
+                        bit_rate=quantize_type.bit_rate(),
+                    )
+                )
+
+        emb_out = sparse_arch(indices, offsets)  # B, T, D
+
+        # Apply the quantization transformations on the model!
+        split_emb_infer_converter = SplitEmbInferenceConverter(
+            quantize_type=quantize_type
+        )
+        split_emb_infer_converter.convert_model(sparse_arch)
+        assert (
+            type(sparse_arch.emb_module)
+            == split_table_batched_embeddings_ops.IntNBitTableBatchedEmbeddingBagsCodegen
+        )
+        assert sparse_arch.emb_module.use_cpu == use_cpu
+        quantized_emb_out = sparse_arch(indices.int(), offsets.int())  # B, T, D
+
+        # Compare FP32 emb module vs. quantize_type (FP16, INT8, INT4, INT2) emb module
+        torch.testing.assert_allclose(
+            emb_out.float().cpu(),
+            quantized_emb_out.float().cpu(),
+            atol=1.0e-1,
+            rtol=1.0e-1,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -1575,8 +1575,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 SparseType.FP16,
             ]
         ),
-
-        cpu=st.booleans(),
+        cpu=st.booleans() if torch.cuda.is_available() else st.just(True),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
     def test_nbit_forward(
@@ -1589,8 +1588,8 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         weighted: bool,
         mixed: bool,
         pooling_mode: split_table_batched_embeddings_ops.PoolingMode,
-        cpu: bool,
         weights_ty: SparseType,
+        cpu: bool,
     ) -> None:
         assume(
             pooling_mode == split_table_batched_embeddings_ops.PoolingMode.SUM
@@ -1693,7 +1692,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 comps = comps.reshape(E, D)
                 bs[t].weight.detach().copy_(torch.tensor(comps).cuda())
 
-            if weights_ty == SparseType.INT2:
+            elif weights_ty == SparseType.INT2:
                 (E, D_4) = np_weights.shape
                 D = D_4 * 4
 
@@ -1716,7 +1715,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 bs[t].weight.detach().copy_(torch.tensor(comps).cuda())
 
 
-            if weights_ty == SparseType.INT8:
+            elif weights_ty == SparseType.INT8:
                 (E, D) = np_weights.shape
                 comps = np_weights.astype(np.float32) * scale_shift[:, 0].reshape(
                         -1, 1
@@ -1725,7 +1724,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 )
                 bs[t].weight.detach().copy_(torch.tensor(comps).cuda())
 
-            if weights_ty == SparseType.FP16:
+            elif weights_ty == SparseType.FP16:
                 comps = bs[t].weight.detach().half().cpu().numpy().view(np.uint8)
                 weights.copy_(torch.tensor(comps))
 

--- a/fbgemm_gpu/test/test_utils.py
+++ b/fbgemm_gpu/test/test_utils.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import struct
+import math
 from typing import Callable
 
 import numpy as np
@@ -32,6 +33,25 @@ def floats_to_bytes(floats: np.ndarray) -> np.ndarray:
     return byte_matrix
 
 
+def bytes_to_half_floats(byte_matrix: np.ndarray) -> np.ndarray:
+    floats = np.empty([np.shape(byte_matrix)[0], 1], dtype=np.float16)
+    for i, byte_values in enumerate(byte_matrix):
+        (floats[i],) = np.frombuffer(
+            memoryview(byte_values).tobytes(), dtype=np.float16
+        )
+    return floats
+
+
+def half_floats_to_bytes(floats: np.ndarray) -> np.ndarray:
+    byte_matrix = np.empty([np.shape(floats)[0], 2], dtype=np.uint8)
+    for i, value in enumerate(floats):
+        assert isinstance(value, np.float16), (value, floats)
+        byte_matrix[i] = np.frombuffer(
+            memoryview(value.tobytes()).tobytes(), dtype=np.uint8
+        )
+    return byte_matrix
+
+
 def fused_rowwise_8bit_quantize_reference(data: np.ndarray) -> np.ndarray:
     minimum = np.min(data, axis=-1, keepdims=True)
     maximum = np.max(data, axis=-1, keepdims=True)
@@ -54,3 +74,67 @@ def fused_rowwise_8bit_dequantize_reference(fused_quantized: np.ndarray) -> np.n
     bias = bias.reshape(fused_quantized.shape[:-1] + (bias.shape[-1],))
     quantized_data = fused_quantized[..., :-8]
     return quantized_data * scale + bias
+
+
+def fused_rowwise_nbit_quantize_reference(data: np.ndarray, bit: int) -> np.ndarray:
+    minimum = np.min(data, axis=1).astype(np.float16).astype(np.float32)
+    maximum = np.max(data, axis=1)
+    span = maximum - minimum
+    qmax = (1 << bit) - 1
+    scale = (span / qmax).astype(np.float16).astype(np.float32)
+    bias = np.zeros(data.shape[0])
+    quantized_data = np.zeros(data.shape).astype(np.uint8)
+
+    for i in range(data.shape[0]):
+        bias[i] = minimum[i]
+        inverse_scale = 1.0 if scale[i] == 0.0 else 1 / scale[i]
+        if scale[i] == 0.0 or math.isinf(inverse_scale):
+            scale[i] = 1.0
+            inverse_scale = 1.0
+        quantized_data[i] = np.clip(
+            np.round((data[i, :] - minimum[i]) * inverse_scale), 0, qmax
+        )
+
+    # pack
+    assert 8 % bit == 0
+    num_elem_per_byte = 8 // bit
+    packed_dim = (data.shape[1] + num_elem_per_byte - 1) // num_elem_per_byte
+    packed_data = np.zeros([data.shape[0], packed_dim]).astype(np.uint8)
+    for i in range(data.shape[0]):
+        for j in range(data.shape[1]):
+            if j % num_elem_per_byte == 0:
+                packed_data[i, j // num_elem_per_byte] = quantized_data[i, j]
+            else:
+                packed_data[i, j // num_elem_per_byte] += quantized_data[i, j] << (
+                    (j % num_elem_per_byte) * bit
+                )
+
+    scale_bytes = half_floats_to_bytes(scale.astype(np.float16))
+    bias_bytes = half_floats_to_bytes(bias.astype(np.float16))
+    return np.concatenate([packed_data, scale_bytes, bias_bytes], axis=1)
+
+
+def fused_rowwise_nbit_quantize_dequantize_reference(data: np.ndarray, bit: int) -> np.ndarray:
+    fused_quantized = fused_rowwise_nbit_quantize_reference(data, bit)
+    scale = bytes_to_half_floats(fused_quantized[:, -4:-2].astype(np.uint8)).astype(
+        np.float32
+    )
+    bias = bytes_to_half_floats(fused_quantized[:, -2:].astype(np.uint8)).astype(
+        np.float32
+    )
+    quantized_data = fused_quantized[:, :-4]
+
+    # unpack
+    packed_dim = fused_quantized.shape[1] - 4
+    assert 8 % bit == 0
+    num_elem_per_byte = 8 // bit
+    assert packed_dim == ((data.shape[1] + num_elem_per_byte - 1) // num_elem_per_byte)
+    unpacked_data = np.zeros(data.shape).astype(np.uint8)
+    for i in range(data.shape[0]):
+        for j in range(data.shape[1]):
+            unpacked_data[i, j] = (
+                quantized_data[i, j // num_elem_per_byte]
+                >> ((j % num_elem_per_byte) * bit)
+            ) & ((1 << bit) - 1)
+
+    return scale * unpacked_data + bias


### PR DESCRIPTION
Summary:
Add the conversion workflow from FP32 trained embedding tables to FP16/INT8/INT4/INT2 quantized embedding tables during GPU inference.
- Convert FP32 -> FP16/INT8/INT4/INT2 weights and replace the FP32 op with IntN op.

TODO:
- ~~move "FusedNBitRowwiseQuantizedSBHalfToFloat" to fbgemm_gpu;~~
- quantize according the inference per-feature precisions (The current Diff only quantize all tables to FP16 or INT8 or INT4 or INT2);
- ~~CPU supports/tests.~~

Reviewed By: yinghai

Differential Revision: D29252193

