### PR TITLE
fix bug in mixed hbm/uvm bandwidth reporting in split_table_batched_embeddings_benchmark

### DIFF
--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -535,8 +535,8 @@ def uvm(
         )
         logging.info(
             f"Mixed Forward, B: {B}, "
-            f"E: {E}, T: {T}, D: {D}, L: {L}, W: {weighted}, "
-            f"BW: {param_size_multiplier * B * sum(Ds) * L / time_per_iter / 1.0e9: .2f}GB/s, "  # noqa: B950
+            f"E: {E}, T_GPU: {T_gpu}, T_UVM: {T_uvm}, D: {D}, L_GPU: {L}, L_UVM: {L_uvm}, W: {weighted}, "
+            f"BW: {((param_size_multiplier * B)*((sum(Ds[:T_uvm]) * L_uvm) + sum(Ds[T_uvm:]) * L)) / time_per_iter / 1.0e9: .2f}GB/s, "  # noqa: B950
             f"T: {time_per_iter * 1.0e6:.0f}us"
         )
 


### PR DESCRIPTION
Summary:
Mixed HBM/UVM bandwidth was incorrectly being calculated using
```
param_size_multiplier * B * sum(Ds) * L
```
for bytes read, instead of
``` ((param_size_multiplier * B)*((sum(Ds[:T_uvm]) * L_uvm) + sum(Ds[T_uvm:]) * L))
```
The dimension and pooling factor of the UVM tables is separately specified from the HBM tables, and the allocated tables and requests from the individual HBM and UVM benchmark runs are reused within the mixed case.

Reviewed By: jspark1105

Differential Revision: D29783498

