### PR TITLE
Improve performance of sparse fp32 GEMMs

### DIFF
--- a/src/FbgemmSparseDenseAvx512.cc
+++ b/src/FbgemmSparseDenseAvx512.cc
@@ -142,6 +142,5 @@ void SparseDenseMMAvx512(
     }
   }
 }
-
 } // namespace internal
 } // namespace fbgemm


### PR DESCRIPTION
Summary: Modified both Avx2 and Avx512 to have both the loop orders in them.

Reviewed By: dskhudia

Differential Revision: D29924403

