### PR TITLE
Fix OSS build of fbgemm_gpu.

### DIFF
--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -164,7 +164,8 @@ setup(
                 os.path.join(cur_dir, "../third_party/cpuinfo/include"),
                 cub_include_path,
             ],
-            extra_compile_args={"cxx": extra_compile_args},
+            extra_compile_args={"cxx": extra_compile_args,
+                                "nvcc": ["-U__CUDA_NO_HALF_CONVERSIONS__"]},
         )
     ],
     cmdclass={"build_ext": FBGEMM_GPU_BuildExtension},


### PR DESCRIPTION
Summary: Build requires that CUDA half-conversion be defined.

Reviewed By: jianyuh

Differential Revision: D30082586

