### PR TITLE
fbgemm_gpu: remove new_host_mapped_tensor

### DIFF
--- a/fbgemm_gpu/src/cumem_utils.cu
+++ b/fbgemm_gpu/src/cumem_utils.cu
@@ -42,24 +42,6 @@ struct CUDAManagedContext {
   }
 };
 
-struct CUDAHostMappedContext {
-  void* ptr_;
-  int cuda_device_;
-
-  CUDAHostMappedContext(void* ptr, int cuda_device)
-      : ptr_(ptr), cuda_device_(cuda_device){};
-
-  ~CUDAHostMappedContext() {
-    at::cuda::OptionalCUDAGuard device_guard;
-    device_guard.set_index(cuda_device_);
-    AT_CUDA_CHECK(cudaFreeHost(ptr_));
-  }
-
-  static void release(void* ptr) {
-    delete static_cast<CUDAHostMappedContext*>(ptr);
-  }
-};
-
 // Keep a reference to the UVM memory allocation from the associated
 // CPU Tensor to prevent lifetime issues (use after free)
 struct CUDAManagedCpuContext {
@@ -116,42 +98,13 @@ Tensor new_managed_tensor(Tensor self, std::vector<std::int64_t> sizes) {
   return at::empty({0}, self.options()).set_(storage, 0, sizes, strides);
 }
 
-// Allocate the ATen Tensor with host-mapped memory
-Tensor new_host_mapped_tensor(Tensor self, std::vector<std::int64_t> sizes) {
-  at::cuda::OptionalCUDAGuard device_guard;
-  device_guard.set_index(self.get_device());
-
-  auto strides = defaultStrides(sizes);
-  size_t size_bytes =
-      at::detail::computeStorageNbytes(sizes, strides, self.dtype().itemsize());
-  void* ptr;
-  AT_CUDA_CHECK(cudaHostAlloc(
-      &ptr, size_bytes, cudaHostAllocWriteCombined | cudaHostAllocMapped));
-  void* dev_ptr;
-  AT_CUDA_CHECK(cudaHostGetDevicePointer(&dev_ptr, ptr, 0));
-
-  auto storage = Storage(
-      Storage::use_byte_size_t(),
-      size_bytes,
-      at::DataPtr(
-          dev_ptr,
-          new CUDAHostMappedContext(ptr, self.get_device()),
-          &CUDAHostMappedContext::release,
-          {at::DeviceType::CUDA, self.device().index()}),
-      nullptr, /* allocator */
-      /*resizable=*/false);
-  return at::empty({0}, self.options())
-      .set_(std::move(storage), 0, sizes, strides);
-}
-
 // Check if a tensor is allocated with UVM or host-mapped memory
 bool is_uvm_tensor(Tensor t) {
   if (t.device().is_cpu()) {
     return false;
   }
   auto deleter = t.storage().data_ptr().get_deleter();
-  return deleter == &CUDAManagedContext::release ||
-      deleter == &CUDAHostMappedContext::release;
+  return deleter == &CUDAManagedContext::release;
 }
 
 // Convert a UVM tensor to a CPU tensor

--- a/fbgemm_gpu/src/cumem_utils_host.cpp
+++ b/fbgemm_gpu/src/cumem_utils_host.cpp
@@ -12,9 +12,6 @@ using namespace at;
 // Allocate the ATen Tensor with unified managed memory (UVM)
 Tensor new_managed_tensor(Tensor self, std::vector<std::int64_t> sizes);
 
-// Allocate the ATen Tensor with host-mapped memory
-Tensor new_host_mapped_tensor(Tensor self, std::vector<std::int64_t> sizes);
-
 // Check if a tensor is allocated with UVM or host-mapped memory
 bool is_uvm_tensor(Tensor t);
 
@@ -31,9 +28,4 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
   m.impl(
       "new_managed_tensor",
       torch::dispatch(c10::DispatchKey::CUDA, TORCH_FN(new_managed_tensor)));
-  m.def("new_host_mapped_tensor(Tensor self, int[] sizes) -> Tensor");
-  m.impl(
-      "new_host_mapped_tensor",
-      torch::dispatch(
-          c10::DispatchKey::CUDA, TORCH_FN(new_host_mapped_tensor)));
 }


### PR DESCRIPTION
Summary:
Remove unused new_host_mapped_tensor.
The returned tensor was not an uvm tensor but interacted with is_uvm_tensor and uvm_to_cpu.
I plan to add generic uvm functionality to fbgemm_gpu that will not work with tensors returned from new_host_mapped_tensor and as such want to remove  new_host_mapped_tensor before it causes issues.

Reviewed By: jianyuh

Differential Revision: D30226760

