### PR TITLE
Use empty instead rand to initialize table batched embedding weights

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -1487,9 +1487,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         ).tolist()
         self.register_buffer(
             "weights",
-            torch.randint(
-                0,
-                255,
+            torch.empty(
                 size=(weights_offsets[-1],),
                 dtype=torch.uint8,
                 device=self.current_device,
@@ -1629,3 +1627,15 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 )
 
         return splits
+
+    def fill_random_weights(self) -> None:
+        """
+        Fill the buffer with random weights
+        """
+        self.weights = torch.randint(
+            0,
+            255,
+            size=(self.weights_offsets[-1],),
+            dtype=torch.uint8,
+            device=self.current_device,
+        )


### PR DESCRIPTION
Summary: Make model materialization much faster and defer random weight filling only if we want to generate random weight. This will save a lot of time when we actually want to do checkpoints with meaningful data. Should also solve the process group timeout issue.

Differential Revision: D30567043

