### PR TITLE
change ci setting to use main instead of master branch

### DIFF
--- a/.github/workflows/fbgemmci.yml
+++ b/.github/workflows/fbgemmci.yml
@@ -3,10 +3,10 @@ name: FBGEMMCI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
 ## Pull Requests
 We actively welcome your pull requests.
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.


### PR DESCRIPTION
Summary: D30560986 missed a few references to master branch, and was not triggering github CI

Differential Revision: D30628706

