### PR TITLE
Implement a separate kernel for array-based index remapping lookup.

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
@@ -106,6 +106,12 @@ Tensor pruned_hashmap_lookup_unweighted_cuda(
     Tensor hash_table,
     Tensor hash_table_offsets);
 
+Tensor pruned_array_lookup_cuda(
+    Tensor indices,
+    Tensor offsets,
+    Tensor index_remappings,
+    Tensor index_remappings_offsets);
+
 TORCH_LIBRARY_FRAGMENT(fb, m) {
   m.def(
       "int_nbit_split_embedding_codegen_lookup_function(Tensor dev_weights, Tensor uvm_weights, Tensor weights_placements, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, int total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights) -> Tensor");
@@ -122,4 +128,12 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
       torch::dispatch(
           c10::DispatchKey::CUDA,
           TORCH_FN(pruned_hashmap_lookup_unweighted_cuda)));
+
+  m.def(
+      "pruned_array_lookup(Tensor indices, Tensor offsets, Tensor index_remappings, Tensor index_remappings_offsets) -> Tensor");
+  m.impl(
+      "pruned_array_lookup",
+      torch::dispatch(
+          c10::DispatchKey::CUDA,
+          TORCH_FN(pruned_array_lookup_cuda)));
 }

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
@@ -104,6 +104,12 @@ Tensor pruned_hashmap_lookup_unweighted_cpu(
     Tensor hash_table,
     Tensor hash_table_offsets);
 
+Tensor pruned_array_lookup_cpu(
+    Tensor indices,
+    Tensor offsets,
+    Tensor index_remappings,
+    Tensor index_remappings_offsets);
+
 TORCH_LIBRARY_FRAGMENT(fb, m) {
 
   m.impl(
@@ -122,13 +128,20 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
           c10::DispatchKey::CPU,
           TORCH_FN(pruned_hashmap_insert_unweighted_cpu)));
 
-  // CPU version of Lookup isn't used. For CPUs, we should use PrunedMapCPU
-  // below.
+  // CPU version of hashmap Lookup isn't used. For CPUs, we should use
+  // PrunedMapCPU below.
   m.impl(
       "pruned_hashmap_lookup",
       torch::dispatch(
           c10::DispatchKey::CPU,
           TORCH_FN(pruned_hashmap_lookup_unweighted_cpu)));
+
+  // CPU version of array lookup.
+  m.impl(
+      "pruned_array_lookup",
+      torch::dispatch(
+          c10::DispatchKey::CPU,
+          TORCH_FN(pruned_array_lookup_cpu)));
 }
 
 class PrunedMapCPU : public torch::jit::CustomClassHolder {

--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_inference_converter.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_inference_converter.py
@@ -23,10 +23,14 @@ torch.ops.load_library("//caffe2/torch/fb/sparsenn:sparsenn_operators")
 # TODO: add per-feature based converter option (based on embedding_specs during inference)
 # TODO: optimize embedding pruning and quantization latency.
 class SplitEmbInferenceConverter:
-    def __init__(self, quantize_type: SparseType, pruning_ratio: Optional[float]):
+    def __init__(
+            self, quantize_type: SparseType, pruning_ratio: Optional[float],
+            use_array_for_index_remapping: bool = True,
+    ):
         self.quantize_type = quantize_type
         # TODO(yingz): Change the pruning ratio to per-table settings.
         self.pruning_ratio = pruning_ratio
+        self.use_array_for_index_remapping = use_array_for_index_remapping
 
     def convert_model(self, model: torch.nn.Module) -> nn.Module:
         self._process_split_embs(model)
@@ -165,6 +169,7 @@ class SplitEmbInferenceConverter:
                     pooling_mode=child.pooling_mode,
                     use_cpu=use_cpu,
                     weight_lists=weight_lists,
+                    use_array_for_index_remapping=self.use_array_for_index_remapping,
                 )
                 setattr(model, name, q_child)
             else:

--- a/fbgemm_gpu/test/split_embedding_inference_converter_test.py
+++ b/fbgemm_gpu/test/split_embedding_inference_converter_test.py
@@ -200,11 +200,13 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
 
     @given(
         use_cpu=st.booleans() if torch.cuda.is_available() else st.just(True),
+        use_array_for_index_remapping=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
     def test_l2_norm_pruning_workflow(
         self,
         use_cpu: bool,
+        use_array_for_index_remapping: bool,
     ) -> None:
         D = 128
         T = 2
@@ -252,6 +254,7 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
             split_emb_infer_converter = SplitEmbInferenceConverter(
                 quantize_type=SparseType.FP16,
                 pruning_ratio=pruning_ratio,
+                use_array_for_index_remapping=use_array_for_index_remapping,
             )
             split_emb_infer_converter.convert_model(sparse_arch)
             assert (
@@ -277,6 +280,7 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
         log_E=st.integers(min_value=3, max_value=5),
         pruning_ratio=st.floats(min_value=0.0, max_value=1.0, exclude_max=True),
         use_cpu=st.booleans() if torch.cuda.is_available() else st.just(True),
+        use_array_for_index_remapping=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
     def test_pruning_workflow_large_scale(
@@ -286,6 +290,7 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
         log_E: int,
         pruning_ratio: Optional[float],
         use_cpu: bool,
+        use_array_for_index_remapping: bool,
     ) -> None:
         E = int(10 ** log_E)
         D_alignment = 8
@@ -305,6 +310,7 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
         split_emb_infer_converter = SplitEmbInferenceConverter(
             quantize_type=SparseType.FP16,
             pruning_ratio=pruning_ratio,
+            use_array_for_index_remapping=use_array_for_index_remapping,
         )
         split_emb_infer_converter.convert_model(sparse_arch)
         embedding_weights_after = sparse_arch.emb_module.split_embedding_weights()

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -1589,6 +1589,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             ]
         ),
         use_cpu=st.booleans() if torch.cuda.is_available() else st.just(True),
+        use_array_for_index_remapping=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
     def test_nbit_forward(
@@ -1603,6 +1604,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         pooling_mode: split_table_batched_embeddings_ops.PoolingMode,
         weights_ty: SparseType,
         use_cpu: bool,
+        use_array_for_index_remapping: bool,
     ) -> None:
         assume(
             pooling_mode == split_table_batched_embeddings_ops.PoolingMode.SUM
@@ -1666,8 +1668,9 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 for (E, D, M) in zip(Es, Ds, managed)
             ],
             pooling_mode=pooling_mode,
-            index_remapping=[torch.arange(E) for E in Es],
+            index_remapping=[torch.arange(E, dtype=torch.int32) for E in Es],
             use_cpu=use_cpu,
+            use_array_for_index_remapping=use_array_for_index_remapping,
         )
         # Initilize the random weights for int nbit table split embedding bag
         cc.fill_random_weights()


### PR DESCRIPTION
Summary:
This diff:
* implements an array-based lookup kernel for embedding index remapping and makes it default;
* adds a new benchmark for array-based pruning lookup;
* adds new features into the nbit-device benchmark to run multiple iterations and ignore the warmup runs;

Differential Revision: D30556183

