### PR TITLE
vectorize split_embedding_backward_exact_cpu_dense_kernel()

### DIFF
--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -352,7 +352,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             rtol=8.0e-3 if weights_precision == SparseType.FP16 else 1.0e-5,
         )
 
-    @unittest.skipIf(not torch.cuda.is_available(), "Skip when CUDA is not available")
     @given(
         T=st.integers(min_value=1, max_value=3),
         D=st.integers(min_value=2, max_value=128),


### PR DESCRIPTION
Summary:
This patch promotes vectorization of `split_embedding_backward_exact_cpu_dense_kernel()`. The obtained performance improvement is marginal (14% speedup), though, since this kernel is memory intensive.  The following is the average `T` of `ForwardBackward` (10 executions on a Skylake machine).
```
          Original   This Patch
T         884804.8   773768.3
stdev(T)   18101.5    12423.2
```

## Optimizations

[1] The previous kernel uses `double`, which confuses the compiler and results in inefficient non-vectorized code when `scalar_t` is `float`.  In reality, the original kernel (`perf report`: left values are approx. percentage of execution time in that function) requires `double <=> single` conversion in `split_embedding_backward_exact_cpu_dense_kernel()`.
```
  ...
  2.88 │       vcvtss2sd %xmm2,%xmm2,%xmm2
  5.52 │       vmulsd    %xmm2,%xmm1,%xmm2
  3.99 │       vmovss    (%rbx,%rcx,4),%xmm3
 50.64 │       vcvtss2sd %xmm3,%xmm3,%xmm3
  8.29 │       vaddsd    %xmm3,%xmm2,%xmm2
  3.32 │       vcvtsd2ss %xmm2,%xmm2,%xmm2
  7.47 │       vmovss    %xmm2,(%rbx,%rcx,4)
  ...
```
After changing `double` to `scalar_t`, the kernel does not involve in any type conversion.
```
  ...
  3.79 │       vmulss    %xmm1,%xmm2,%xmm2
  4.10 │       vaddss    (%rbx,%rcx,4),%xmm2,%xmm2
 70.15 │       vmovss    %xmm2,(%rbx,%rcx,4)
  ...
```
 ---
[2] Put a loop-invariant variable `indice_weights_data[p]` as `indice_weight` outside the loop can promote vectorization since the compiler cannot understand whether this `indice_weights_data[p]` is loop invariant or not.  This change enables vectorization.
```
  ...
       │       vmulps       %ymm5,%ymm4,%ymm5
  0.16 │       vmulps       %ymm2,%ymm5,%ymm5
  0.21 │       vaddps       -0x20(%r10,%rsi,4),%ymm5,%ymm5
 80.35 │       vmovups      %ymm5,-0x20(%r10,%rsi,4)
  1.09 │       vmovups      (%r8,%r13,1),%ymm5
  ...
```
 ---
[3] Clean up the code.  This change allows better vectorization (it seems that `scale_factor * indice_weight` is pre-computed).
```
// Original
for (int64_t d ...)
  grad_data[embedding_begin + d] += scale_factor *
                                    (indice_weights.defined()
                                     ? grad_output_data[b][D_begin + d] * indice_weight
                                     : grad_output_data[b][D_begin + d]);
// This Diff
const scalar_t v = indice_weights.defined() ? (scale_factor * indice_weight) : scale_factor;
for (int64_t d ...)
  grad_data[embedding_begin + d] +=  grad_output_data[b][D_begin + d] * v;
```
The loop kernel becomes as follows:
```
  ...
  0.40 │       vmulps       -0x20(%r13),%ymm3,%ymm4
  5.91 │       vmulps       0x0(%r13),%ymm3,%ymm5
  0.76 │       vaddps       -0x20(%rsi,%rdx,4),%ymm4,%ymm4
 77.55 │       vaddps       (%rsi,%rdx,4),%ymm5,%ymm5
  6.26 │       vmovups      %ymm4,-0x20(%rsi,%rdx,4)
  1.48 │       vmovups      %ymm5,(%rsi,%rdx,4)
  ...
```

## Note
1. Other time-consuming kernels are not in this source file.  Those functions look properly vectorized (at least, with FMA) and that optimization (if necessary) should be out of scope of this patch.
2. I did not turn on AVX-512, but I don't think this helps much since 256-bit vectorization did not improve the performance a lot. No optimization in this patch is specific to certain SIMD instruction sets.
3. Pragmas such as `#pragma clang vectorize` and `#pragma omp simd` do not improve the performance since this loop is already vectorized well.  Note that FMA instructions cannot be efficiently used here because AVX FMA cannot take two memory references.

Reviewed By: jspark1105, mustafaozdal

Differential Revision: D30795070

