### PR TITLE
call proper sparse_adagrad_ref on non-AVX2/512 machines

### DIFF
--- a/src/SparseAdagrad.cc
+++ b/src/SparseAdagrad.cc
@@ -950,19 +950,35 @@ typename SparseAdaGradSignature<IndexType>::Type GenerateSparseAdaGrad(
                float weight_decay,
                const double* counter,
                std::int64_t counter_halflife) {
-      return sparse_adagrad_ref(
-          num_rows, // number of rows reading
-          block_size, // number of parameters per rows
-          param_size, // total number of parameters
-          w, // input/output parameters
-          g, // input gradients
-          h, // input/output momentums
-          indices,
-          epsilon,
-          lr,
-          weight_decay,
-          counter,
-          counter_halflife);
+      if (rowwise) {
+        return rowwise_sparse_adagrad_ref(
+            num_rows, // number of rows reading
+            block_size, // number of parameters per rows
+            param_size, // total number of parameters
+            w, // input/output parameters
+            g, // input gradients
+            h, // input/output momentums
+            indices,
+            epsilon,
+            lr,
+            weight_decay,
+            counter,
+            counter_halflife);
+      } else {
+        return sparse_adagrad_ref(
+            num_rows, // number of rows reading
+            block_size, // number of parameters per rows
+            param_size, // total number of parameters
+            w, // input/output parameters
+            g, // input gradients
+            h, // input/output momentums
+            indices,
+            epsilon,
+            lr,
+            weight_decay,
+            counter,
+            counter_halflife);
+      }
     };
   }
 }


### PR DESCRIPTION
Summary:
`GenerateSparseAdaGrad()` falls back to a reference CPU implementation (`sparse_adagrad_ref()`) if neither AVX2 nor AVX512 is supported.
However, it does not call a row-wise version even if `rowwise` is true, which results in incorrect calculation and, in the worst case, SEGV.
This patch fixes this issue.

Reviewed By: jspark1105

Differential Revision: D30843582

