### PR TITLE
Add UVM support for infer version of table batched embedding bag

### DIFF
--- a/fbgemm_gpu/bench/merge_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/merge_embeddings_benchmark.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+# pyre-unsafe
+
+import click
+import numpy as np
+import tabulate
+import torch
+
+try:
+    torch.ops.load_library("fbgemm_gpu_py.so")
+except Exception:
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:merge_pooled_embeddings")
+
+
+@click.command()
+@click.option("--num-ads", default=1024, type=int)
+@click.option("--embedding-dimension", default=300, type=int)
+@click.option("--ads-tables", default=400, type=int)
+@click.option("--iters", default=10, type=int)
+@click.option("--p2p_bw", is_flag=True, default=False)
+@click.option("--dst-device", default=0, type=int)
+def main(num_ads, embedding_dimension, ads_tables, iters, p2p_bw, dst_device) -> None:
+    torch.cuda.set_device(dst_device)
+    num_gpus = torch.cuda.device_count()
+    ad_ds = [embedding_dimension * ads_tables for _ in range(num_gpus)]
+    batch_indices = torch.zeros(num_ads).long().cuda()
+    pooled_ad_embeddings = [
+        torch.randn(
+            num_ads, ad_d, dtype=torch.float16, device=torch.device(f"cuda:{i}")
+        )
+        for i, ad_d in enumerate(ad_ds)
+    ]
+
+    def benchmark_torch_function(iters: int, f, *args) -> float:
+        f(*args)
+        torch.cuda.synchronize()
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
+        for _ in range(iters):
+            f(*args)
+        end_event.record()
+        torch.cuda.synchronize()
+        return (start_event.elapsed_time(end_event) * 1.0e-3) / iters
+    if p2p_bw:
+        print("Pairwise GPU Copy Bandwidth (GB/s)")
+        p2p_copy_bw = np.zeros((num_gpus, num_gpus))
+        for i in range(num_gpus):
+            for j in range(num_gpus):
+                with torch.cuda.device(i):
+                    t = benchmark_torch_function(
+                        iters,
+                        lambda: pooled_ad_embeddings[i].copy_(pooled_ad_embeddings[j])
+                        if i != j
+                        else pooled_ad_embeddings[i].clone(),
+                    )
+                    p2p_copy_bw[i, j] = pooled_ad_embeddings[i].numel() * 2 / t / 1.0e9
+        table = tabulate.tabulate(
+            p2p_copy_bw,
+            headers=[f"GPU {i}" for i in range(num_gpus)],
+            tablefmt="fancy_grid",
+            floatfmt=".0f",
+        )
+        print(table)
+
+    streams = [torch.cuda.Stream(device=i) for i in range(num_gpus)]
+    import contextlib
+
+    with contextlib.ExitStack() as stack:
+        for stream in streams:
+            stack.enter_context(torch.cuda.stream(stream))
+
+        t = benchmark_torch_function(
+            iters,
+            lambda: torch.ops.fbgemm.merge_pooled_embeddings(
+                pooled_ad_embeddings, batch_indices
+            ),
+        )
+        merged = torch.ops.fbgemm.merge_pooled_embeddings(
+            pooled_ad_embeddings, batch_indices
+        )
+    print(
+        f"Merge, B: {num_ads}, D: {embedding_dimension}, T: {ads_tables}, Num GPUs: {num_gpus}, Destination GPU: {dst_device} Output Size: {merged.numel() * 2 / 1.0e6:.2f}MB, BW: {merged.numel() * 2 / t / 1.0e9:.2f}GB/s, t: {t * 1.0e3:.2f}ms"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -835,7 +835,7 @@ def cpu(  # noqa C901
         Ds = [D] * T
 
     emb = IntNBitTableBatchedEmbeddingBagsCodegen(
-        [("", E, d, weights_precision) for d in Ds],
+        [("", E, d, weights_precision, EmbeddingLocation.HOST) for d in Ds],
         use_cpu=True,
         index_remapping=[torch.arange(E) for _ in Ds] if index_remapping else None,
     ).cpu()
@@ -969,8 +969,13 @@ def nbit_device(  # noqa C901
                 mapping[idx] = i
             index_remapping.append(mapping)
 
+    if managed == "device":
+        managed_option = EmbeddingLocation.DEVICE
+    else:
+        managed_option = EmbeddingLocation.MANAGED
+
     emb = IntNBitTableBatchedEmbeddingBagsCodegen(
-        [("", E, d, weights_precision) for d in Ds],
+        [("", E, d, weights_precision, managed_option) for d in Ds],
         bounds_check_mode=BoundsCheckMode(bounds_check_mode),
         index_remapping=index_remapping, load_factor=load_factor,
     ).cuda()
@@ -1133,6 +1138,7 @@ def hashtable(  # noqa C901
             f"T: {time_per_iter * 1.0e6:.0f}us, load factor: {E * T / hash_table.shape[0] * 100:.1f}%, hit rate: {empirical_hit_rate * 100:.2f}%, Table size: {hash_table.numel() * 4 / 1.0e6:.0f}MB"
         )
 
+
 @cli.command()
 @click.option("--bag-size", default=20)
 @click.option("--batch-size", default=512)
@@ -1184,6 +1190,7 @@ def bounds_check_indices(  # noqa C901
         f"BW: {(8 * B * T * L + 8 * (B * T + 1)) / time_per_iter / 1.0e9: .2f}GB/s, "  # noqa: B950
         f"T: {time_per_iter * 1.0e6:.0f}us"
     )
+
 
 if __name__ == "__main__":
     cli()

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
@@ -5,15 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include <ATen/ATen.h>
-#include <ATen/cuda/CUDAContext.h>
 #include <ATen/TypeDefault.h>
 #include <ATen/core/op_registration/op_registration.h>
+#include <ATen/cuda/CUDAContext.h>
 #include <torch/script.h>
 
 using namespace at;
 
 Tensor int_nbit_split_embedding_codegen_forward_unweighted_cuda(
     Tensor dev_weights,
+    Tensor uvm_weights,
+    Tensor weights_placements,
     Tensor weights_offsets,
     Tensor weights_tys,
     Tensor D_offsets,
@@ -29,22 +31,8 @@ Tensor int_nbit_split_embedding_codegen_forward_unweighted_cuda(
 
 Tensor int_nbit_split_embedding_codegen_forward_weighted_cuda(
     Tensor dev_weights,
-    Tensor weights_offsets,
-    Tensor weights_tys,
-    Tensor D_offsets,
-    int64_t total_D,
-    int64_t max_int2_D,
-    int64_t max_int4_D,
-    int64_t max_int8_D,
-    int64_t max_float16_D,
-    Tensor indices,
-    Tensor offsets,
-    int64_t pooling_mode,
-    Tensor indice_weights,
-    int64_t unused);
-
-Tensor int_nbit_split_embedding_codegen_forward_weighted_cuda(
-    Tensor dev_weights,
+    Tensor uvm_weights,
+    Tensor weights_placements,
     Tensor weights_offsets,
     Tensor weights_tys,
     Tensor D_offsets,
@@ -61,6 +49,8 @@ Tensor int_nbit_split_embedding_codegen_forward_weighted_cuda(
 
 Tensor int_nbit_split_embedding_codegen_lookup_function(
     Tensor dev_weights,
+    Tensor uvm_weights,
+    Tensor weights_placements,
     Tensor weights_offsets,
     Tensor weights_tys,
     Tensor D_offsets,
@@ -76,6 +66,8 @@ Tensor int_nbit_split_embedding_codegen_lookup_function(
   if (!indice_weights) {
     return int_nbit_split_embedding_codegen_forward_unweighted_cuda(
         dev_weights,
+        uvm_weights,
+        weights_placements,
         weights_offsets,
         weights_tys,
         D_offsets,
@@ -91,6 +83,8 @@ Tensor int_nbit_split_embedding_codegen_lookup_function(
   }
   return int_nbit_split_embedding_codegen_forward_weighted_cuda(
       dev_weights,
+      uvm_weights,
+      weights_placements,
       weights_offsets,
       weights_tys,
       D_offsets,
@@ -114,7 +108,7 @@ Tensor pruned_hashmap_lookup_unweighted_cuda(
 
 TORCH_LIBRARY_FRAGMENT(fb, m) {
   m.def(
-      "int_nbit_split_embedding_codegen_lookup_function(Tensor dev_weights, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, int total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights) -> Tensor");
+      "int_nbit_split_embedding_codegen_lookup_function(Tensor dev_weights, Tensor uvm_weights, Tensor weights_placements, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, int total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights) -> Tensor");
   m.impl(
       "int_nbit_split_embedding_codegen_lookup_function",
       torch::dispatch(

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
@@ -95,8 +95,11 @@ Tensor pruned_hashmap_lookup_unweighted_cpu(
     Tensor hash_table_offsets);
 
 TORCH_LIBRARY_FRAGMENT(fb, m) {
+
+  m.def(
+      "int_nbit_split_embedding_codegen_lookup_function_cpu(Tensor dev_weights, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, int total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights) -> Tensor");
   m.impl(
-      "int_nbit_split_embedding_codegen_lookup_function",
+      "int_nbit_split_embedding_codegen_lookup_function_cpu",
       torch::dispatch(
           c10::DispatchKey::CPU,
           TORCH_FN(int_nbit_split_embedding_codegen_lookup_function_cpu)));

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -1469,16 +1469,62 @@ def unpadded_row_size_in_bytes(dim: int, weight_ty: SparseType) -> int:
     return r
 
 
+def intn_construct_split_state(
+    embedding_specs: List[Tuple[str, int, int, SparseType, EmbeddingLocation]],
+    cacheable: bool,
+) -> SplitState:
+    placements = []
+    offsets = []
+    dev_size = 0
+    host_size = 0
+    uvm_size = 0
+    for (_, num_embeddings, embedding_dim, weight_ty, location) in embedding_specs:
+
+        def align_to_cacheline(a: int) -> int:
+            # align each table to 128b cache line boundary.
+            return round_up(a, 128)
+
+        embedding_dim = rounded_row_size_in_bytes(embedding_dim, weight_ty)
+        state_size = align_to_cacheline(num_embeddings * embedding_dim)
+        if location == EmbeddingLocation.HOST:
+            placements.append(EmbeddingLocation.HOST)
+            offsets.append(host_size)
+            host_size += state_size
+        elif location == EmbeddingLocation.DEVICE:
+            placements.append(EmbeddingLocation.DEVICE)
+            offsets.append(dev_size)
+            dev_size += state_size
+        else:
+            if cacheable and location == EmbeddingLocation.MANAGED_CACHING:
+                placements.append(
+                    EmbeddingLocation.MANAGED_CACHING
+                )  # Note: this isn't supported yet.
+                raise AssertionError("MANAGED_CACHING is not supported yet")
+            else:
+                placements.append(EmbeddingLocation.MANAGED)
+            offsets.append(uvm_size)
+            uvm_size += state_size
+    assert len(placements) == len(offsets)
+    return SplitState(
+        dev_size=dev_size,
+        host_size=host_size,
+        uvm_size=uvm_size,
+        placements=placements,
+        offsets=offsets,
+    )
+
+
 class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
     """
     Table-batched version of nn.EmbeddingBag(sparse=False)
+    Inference version, with FP16/INT8/INT4 supports
     """
 
     def __init__(
         self,
         embedding_specs: List[
-            Tuple[str, int, int, SparseType]
-        ],  # tuple of (feature_names, rows, dims, SparseType)
+            Tuple[str, int, int, SparseType, EmbeddingLocation]
+        ],  # tuple of (feature_names, rows, dims, SparseType, EmbeddingLocation/placement)
         feature_table_map: Optional[List[int]] = None,  # [T]
         index_remapping: Optional[List[Tensor]] = None,
         pooling_mode: PoolingMode = PoolingMode.SUM,
@@ -1488,7 +1534,6 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         load_factor: float = 0.5,
     ) -> None:  # noqa C901  # tuple of (rows, dims,)
         super(IntNBitTableBatchedEmbeddingBagsCodegen, self).__init__()
-        import numpy as np
 
         self.use_cpu = use_cpu
         self.current_device: torch.device = (
@@ -1498,12 +1543,17 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.pooling_mode = pooling_mode
         self.bounds_check_mode_int: int = bounds_check_mode.value
         self.embedding_specs = embedding_specs
-        # (feature_names, rows, dims, weights_tys, ) = zip(*embedding_specs)
+        # (feature_names, rows, dims, weights_tys, locations) = zip(*embedding_specs)
         # Pyre workaround
         self.feature_names: List[str] = [e[0] for e in embedding_specs]
         rows: List[int] = [e[1] for e in embedding_specs]
         dims: List[int] = [e[2] for e in embedding_specs]
         weights_tys: List[SparseType] = [e[3] for e in embedding_specs]
+        locations: List[EmbeddingLocation] = [e[4] for e in embedding_specs]
+
+        assert not self.use_cpu or all(
+            loc == EmbeddingLocation.HOST for loc in locations
+        ), "ComputeDevice.CPU is only for EmbeddingLocation.HOST!"
 
         T_ = len(self.embedding_specs)
 
@@ -1511,13 +1561,17 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         for (dim, weight_ty) in zip(dims, weights_tys):
             assert dim % weight_ty.align_size() == 0
 
-        feature_table_map = (
+        self.feature_table_map: List[int] = (
             feature_table_map if feature_table_map is not None else list(range(T_))
         )
-        T = len(feature_table_map)
+        T = len(self.feature_table_map)
         assert T_ <= T
-        D_offsets = [dims[t] for t in feature_table_map]
-        D_offsets = [0] + np.cumsum(D_offsets).tolist()
+        table_has_feature = [False] * T_
+        for t in self.feature_table_map:
+            table_has_feature[t] = True
+        assert all(table_has_feature), "Each table must have at least one feature!"
+        D_offsets = [dims[t] for t in self.feature_table_map]
+        D_offsets = [0] + list(accumulate(D_offsets))
         self.total_D: int = D_offsets[-1]
 
         def max_ty_D(ty: SparseType) -> int:
@@ -1540,7 +1594,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.register_buffer(
             "rows_per_table",
             torch.tensor(
-                [rows[t] for t in feature_table_map],
+                [rows[t] for t in self.feature_table_map],
                 device=self.current_device,
                 dtype=torch.int64,
             ),
@@ -1554,45 +1608,19 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
             # align each table to 128b cache line boundary.
             return round_up(a, 128)
 
-        weights_offsets = [0] + np.cumsum(
-            [
-                align_to_cacheline(row * rounded_row_size_in_bytes(dim, weight_ty))
-                for _, row, dim, weight_ty in embedding_specs
-            ]
-        ).tolist()
-        self.table_size: int = weights_offsets[-1]
-        weights = torch.randint(
-            0,
-            255,
-            size=(self.table_size,),
-            dtype=torch.uint8,
-            device=self.current_device,
-        )
-        self.register_buffer("weights", weights)
-
-        for feature in range(T):
-            t = feature_table_map[feature]
-            _, row, dim, weight_ty = embedding_specs[t]
-            assert self.weights[
-                weights_offsets[t] : weights_offsets[t + 1]
-            ].numel() == align_to_cacheline(
-                row * rounded_row_size_in_bytes(dim, weight_ty)
-            )
-
-        weights_offsets = [weights_offsets[t] for t in feature_table_map]
-        weights_tys_int = [weights_tys[t].as_int() for t in feature_table_map]
-
-        self.register_buffer(
-            "weights_offsets",
-            torch.tensor(
-                weights_offsets, device=self.current_device, dtype=torch.int64
-            ),
-        )
+        weights_tys_int = [weights_tys[t].as_int() for t in self.feature_table_map]
         self.register_buffer(
             "weights_tys",
             torch.tensor(
                 weights_tys_int, device=self.current_device, dtype=torch.uint8
             ),
+        )
+        weight_split = intn_construct_split_state(
+            embedding_specs,
+            cacheable=True,
+        )
+        self._apply_split(
+            weight_split,
         )
 
         # Assign weights after weights and weights_offsets are initialized.
@@ -1611,13 +1639,11 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 dtype=torch.int32,
             )
             hash_table[:, :] = -1
-            hash_table_offsets = torch.tensor(
-                [0] + np.cumsum(capacities).tolist()
-            ).long()
+            hash_table_offsets = torch.tensor([0] + list(accumulate(capacities))).long()
 
             # Note: feature remapping does not work for pruned tables because we use both
             # the start and end-point of the offsets.
-            np.testing.assert_equal(feature_table_map, list(range(T_)))
+            assert self.feature_table_map == list(range(T_))
 
             merged_index_remappings = [
                 mapping if mapping is not None else Tensor(list(range(spec[1])))
@@ -1630,9 +1656,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
             indices = torch.cat(
                 [torch.arange(row) for row in original_feature_rows], dim=0
             ).int()
-            offsets = torch.tensor(
-                [0] + np.cumsum(original_feature_rows).tolist()
-            ).int()
+            offsets = torch.tensor([0] + list(accumulate(original_feature_rows))).int()
             torch.ops.fb.pruned_hashmap_insert(
                 indices, dense_indices, offsets, hash_table, hash_table_offsets
             )
@@ -1687,21 +1711,105 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 self.bounds_check_mode_int,
                 self.bounds_check_warning,
             )
-        return torch.ops.fb.int_nbit_split_embedding_codegen_lookup_function(
-            dev_weights=self.weights,
-            weights_offsets=self.weights_offsets,
-            weights_tys=self.weights_tys,
-            D_offsets=self.D_offsets,
-            total_D=self.total_D,
-            max_int2_D=self.max_int2_D,
-            max_int4_D=self.max_int4_D,
-            max_int8_D=self.max_int8_D,
-            max_float16_D=self.max_float16_D,
-            indices=indices,
-            offsets=offsets,
-            pooling_mode=self.pooling_mode,
-            indice_weights=per_sample_weights,
+        # pyre-fixme[29]:
+        #  `Union[BoundMethod[typing.Callable(Tensor.numel)[[Named(self, Tensor)],
+        #  int], Tensor], Tensor, nn.Module]` is not a function.
+        if self.weights_host.numel() > 0:
+            return torch.ops.fb.int_nbit_split_embedding_codegen_lookup_function_cpu(
+                dev_weights=self.weights_host,
+                weights_offsets=self.weights_offsets,
+                weights_tys=self.weights_tys,
+                D_offsets=self.D_offsets,
+                total_D=self.total_D,
+                max_int2_D=self.max_int2_D,
+                max_int4_D=self.max_int4_D,
+                max_int8_D=self.max_int8_D,
+                max_float16_D=self.max_float16_D,
+                indices=indices,
+                offsets=offsets,
+                pooling_mode=self.pooling_mode,
+                indice_weights=per_sample_weights,
+            )
+        else:
+            return torch.ops.fb.int_nbit_split_embedding_codegen_lookup_function(
+                dev_weights=self.weights_dev,
+                uvm_weights=self.weights_uvm,
+                weights_placements=self.weights_placements,
+                weights_offsets=self.weights_offsets,
+                weights_tys=self.weights_tys,
+                D_offsets=self.D_offsets,
+                total_D=self.total_D,
+                max_int2_D=self.max_int2_D,
+                max_int4_D=self.max_int4_D,
+                max_int8_D=self.max_int8_D,
+                max_float16_D=self.max_float16_D,
+                indices=indices,
+                offsets=offsets,
+                pooling_mode=self.pooling_mode,
+                indice_weights=per_sample_weights,
+            )
+
+    def _apply_split(
+        self,
+        split: SplitState,
+    ) -> None:
+        self.weights_physical_placements = split.placements
+        self.weights_physical_offsets = split.offsets
+        self.table_size: int = split.offsets[-1]
+
+        offsets = [split.offsets[t] for t in self.feature_table_map]
+        placements = [split.placements[t] for t in self.feature_table_map]
+        self.register_buffer(
+            "weights_offsets",
+            torch.tensor(offsets, device=self.current_device, dtype=torch.int64),
         )
+        self.register_buffer(
+            "weights_placements",
+            torch.tensor(placements, device=self.current_device, dtype=torch.int32),
+        )
+        if split.dev_size > 0:
+            self.register_buffer(
+                "weights_dev",
+                torch.zeros(
+                    split.dev_size,
+                    device=self.current_device,
+                    dtype=torch.uint8,
+                ),
+            )
+        else:
+            self.register_buffer(
+                "weights_dev",
+                torch.empty(0, device=self.current_device, dtype=torch.uint8),
+            )
+        if split.host_size > 0:
+            self.register_buffer(
+                "weights_host",
+                torch.zeros(
+                    split.host_size, device=self.current_device, dtype=torch.uint8
+                ),
+            )
+        else:
+            self.register_buffer(
+                "weights_host",
+                torch.empty(0, device=self.current_device, dtype=torch.uint8),
+            )
+        if split.uvm_size > 0:
+            assert not self.use_cpu
+            self.register_buffer(
+                "weights_uvm",
+                torch.zeros(
+                    split.uvm_size,
+                    out=torch.ops.fb.new_managed_tensor(
+                        torch.zeros(1, device=self.current_device, dtype=torch.uint8),
+                        [split.uvm_size],
+                    ),
+                ),
+            )
+        else:
+            self.register_buffer(
+                "weights_uvm",
+                torch.empty(0, device=self.current_device, dtype=torch.uint8),
+            )
 
     @torch.jit.export
     def split_embedding_weights(self) -> List[Tuple[Tensor, Optional[Tensor]]]:
@@ -1709,9 +1817,19 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         Returns a list of weights, split by table
         """
         splits: List[Tuple[Tensor, Optional[Tensor]]] = []
-        for t, (_, rows, dim, weight_ty) in enumerate(self.embedding_specs):
-            offset = self.weights_offsets[t]
-            weights_shifts = self.weights.detach()[
+        for t, (_, rows, dim, weight_ty, _) in enumerate(self.embedding_specs):
+            placement = self.weights_physical_placements[t]
+            if placement == EmbeddingLocation.DEVICE.value:
+                weights = self.weights_dev
+            elif placement == EmbeddingLocation.HOST.value:
+                weights = self.weights_host
+            else:
+                weights = self.weights_uvm
+            offset = self.weights_physical_offsets[t]
+            # pyre-fixme[29]:
+            #  `Union[BoundMethod[typing.Callable(Tensor.detach)[[Named(self, Tensor)],
+            #  Tensor], Tensor], Tensor, nn.Module]` is not a function.
+            weights_shifts = weights.detach()[
                 offset : offset + rows * rounded_row_size_in_bytes(dim, weight_ty)
             ].view(rows, rounded_row_size_in_bytes(dim, weight_ty))
             # remove the padding at the end of each row.
@@ -1742,15 +1860,20 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
     def fill_random_weights(self) -> None:
         """
-        Fill the buffer with random weights
+        Fill the buffer with random weights, table by table
+        FIXME: make it in-place fill.
         """
-        self.weights = torch.randint(
-            0,
-            255,
-            size=(self.table_size,),
-            dtype=torch.uint8,
-            device=self.current_device,
-        )
+        weights = self.split_embedding_weights()
+        for dest_weight in weights:
+            dest_weight[0].copy_(
+                torch.randint(
+                    0,
+                    255,
+                    size=dest_weight[0].shape,
+                    dtype=torch.uint8,
+                    device=self.current_device,
+                )
+            )
 
     def assign_embedding_weights(
         self, q_weight_list: List[Tuple[Tensor, Optional[Tensor]]]

--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -155,6 +155,7 @@ setup(
                 os.path.join(cur_dir, "src/sparse_ops_cpu.cpp"),
                 os.path.join(cur_dir, "src/sparse_ops_gpu.cpp"),
                 os.path.join(cur_dir, "src/sparse_ops.cu"),
+                os.path.join(cur_dir, "src/merge_pooled_embeddings_gpu.cpp"),
             ],
             include_dirs=[
                 cur_dir,

--- a/fbgemm_gpu/src/merge_pooled_embeddings_cpu.cpp
+++ b/fbgemm_gpu/src/merge_pooled_embeddings_cpu.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <ATen/ATen.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <c10/core/TensorOptions.h>
+#include <torch/library.h>
+
+using namespace at;
+
+namespace at {
+
+at::Tensor merge_pooled_embeddings_cpu(
+    std::vector<Tensor> ad_pooled_embeddings,
+    Tensor batch_indices) {
+  auto cat_host_0 = [&](const std::vector<at::Tensor>& ts) {
+    int64_t n = 0;
+    for (auto& t : ts) {
+      n += t.numel();
+    }
+    at::Tensor r;
+    if (n == 0) {
+      r = at::empty({n});
+    } else {
+      r = at::empty({n}, ts[0].options());
+    }
+    return at::cat_out(r, ts, 1); // concat the tensor list in dim = 1
+  };
+  return cat_host_0(ad_pooled_embeddings);
+}
+
+} // namespace at
+
+TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  m.def(
+      "merge_pooled_embeddings(Tensor[] ad_pooled_embeddings, Tensor batch_indices) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
+  m.impl("merge_pooled_embeddings", at::merge_pooled_embeddings_cpu);
+}

--- a/fbgemm_gpu/src/merge_pooled_embeddings_gpu.cpp
+++ b/fbgemm_gpu/src/merge_pooled_embeddings_gpu.cpp
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <ATen/ATen.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAEvent.h>
+#include <ATen/native/TensorAdvancedIndexing.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <algorithm>
+#include <c10/core/Device.h>
+#include <c10/core/TensorOptions.h>
+#include <torch/library.h>
+
+#include <nvml.h>
+
+using namespace at;
+
+#define NVML_CHECK(fn)                  \
+  do {                                  \
+    nvmlReturn_t ret = (fn);            \
+    TORCH_CHECK((ret) == NVML_SUCCESS); \
+  } while (0)
+
+using Node = int64_t;
+using Links = int64_t;
+template <typename T>
+using AdjacencyMatrix = std::function<T(Node, Node)>;
+
+AdjacencyMatrix<Links> get_nvlink_matrix() {
+  auto world_size = at::cuda::getNumGPUs();
+  NVML_CHECK(nvmlInit());
+
+  // Note that NVML uses a different numbering method to CUDA runtime,
+  // so we need to learn the mapping by using the bus ID.
+  uint32_t device_count;
+  NVML_CHECK(nvmlDeviceGetCount(&device_count));
+
+  std::map<std::array<char, NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE>, Node>
+      pci_bus_ids;
+  std::unordered_map<Node, uint32_t> cuda_device_to_nvml_device;
+
+  for (Node i = 0; i < device_count; ++i) {
+    nvmlDevice_t handle;
+    NVML_CHECK(nvmlDeviceGetHandleByIndex(i, &handle));
+    nvmlPciInfo_t pci_info;
+    NVML_CHECK(nvmlDeviceGetPciInfo(handle, &pci_info));
+    std::array<char, NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE> pci_bus_id;
+    std::copy(
+        &pci_info.busId[0],
+        &pci_info.busId[NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE],
+        pci_bus_id.data());
+    int32_t node = 0;
+    auto err = cudaDeviceGetByPCIBusId(&node, pci_bus_id.data());
+    if (err == cudaSuccess) {
+      pci_bus_ids.insert({pci_bus_id, node});
+      cuda_device_to_nvml_device.insert({node, i});
+    } else {
+      // flush the last error - this can occur when e.g. we set
+      // CUDA_VISIBLE_DEVICES to a subset of the available GPUs in the system.
+      cudaGetLastError();
+    }
+  }
+
+  std::vector<Links> links(world_size * world_size);
+  for (auto i = 0; i < world_size; ++i) {
+    nvmlDevice_t handle;
+    NVML_CHECK(
+        nvmlDeviceGetHandleByIndex(cuda_device_to_nvml_device[i], &handle));
+    for (auto link = 0; link < NVML_NVLINK_MAX_LINKS; ++link) {
+      nvmlEnableState_t is_active;
+      auto nvmlRet = nvmlDeviceGetNvLinkState(handle, link, &is_active);
+      if (nvmlRet == NVML_ERROR_INVALID_ARGUMENT ||
+          nvmlRet == NVML_ERROR_NOT_SUPPORTED) {
+        continue;
+      }
+      if (is_active != NVML_FEATURE_ENABLED) {
+        continue;
+      }
+      nvmlPciInfo_t pci_info;
+      NVML_CHECK(nvmlDeviceGetNvLinkRemotePciInfo(handle, link, &pci_info));
+      std::array<char, NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE> pci_bus_id;
+      std::copy(
+          &pci_info.busId[0],
+          &pci_info.busId[NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE],
+          pci_bus_id.data());
+      auto dst = pci_bus_ids.find(pci_bus_id);
+      if (dst != pci_bus_ids.end()) {
+        auto j = dst->second;
+        links[i * world_size + j] += 1;
+      }
+    }
+  }
+
+  return [=](Node i, Node j) { return links[i * world_size + j]; };
+}
+
+// Hilariously unoptimized, but algorithmic correctness matters more here, and
+// we only do it once.
+AdjacencyMatrix<Node> get_intermediate_node(AdjacencyMatrix<Links> links) {
+  auto world_size = at::cuda::getNumGPUs();
+  auto intermediate_node = [&](Node i, Node j) {
+    if (i == j) {
+      return std::vector<Node>{-1};
+    }
+    if (links(i, j) != 0) {
+      return std::vector<Node>{-1};
+    }
+
+    std::vector<std::pair<Node, Links>> paths;
+    for (auto k = 0; k < world_size; ++k) {
+      if (k != i && k != j && links(i, k) != 0 && links(k, j) != 0) {
+        paths.push_back({k, links(i, k) + links(k, j)});
+      }
+    }
+    if (paths.empty()) {
+      LOG(WARNING)
+          << "Expect very bad performance for p2p copies, we are going via sys path for GPU "
+          << i << " -> GPU " << j;
+      return std::vector<Node>{-1};
+    }
+    auto mp = std::max_element(
+                  paths.begin(),
+                  paths.end(),
+                  [](std::pair<Node, Links> a, std::pair<Node, Links> b) {
+                    return a.second < b.second;
+                  })
+                  ->second;
+    std::vector<Node> candidates;
+    for (const auto& p : paths) {
+      if (p.second == mp) {
+        candidates.push_back(p.first);
+      }
+    }
+    return candidates;
+  };
+
+  std::vector<Node> assignments(world_size * world_size);
+  // Use a two-phase assignment protocol as the greedy approach
+  // can lead to unbalanced usage.
+  std::unordered_map<Node, int64_t> uses;
+  for (auto i = 0; i < world_size; ++i) {
+    for (auto j = 0; j < world_size; ++j) {
+      auto ims = intermediate_node(i, j);
+      if (ims.size() == 1) {
+        auto v = ims.front();
+        if (v != -1) {
+          uses[v] += 1;
+        }
+        assignments[i * world_size + j] = v;
+      }
+    }
+  }
+
+  for (auto i = 0; i < world_size; ++i) {
+    for (auto j = 0; j < world_size; ++j) {
+      auto ims = intermediate_node(i, j);
+      if (ims.size() > 1) {
+        auto v = *std::min_element(ims.begin(), ims.end(), [&](Node a, Node b) {
+          return uses[a] < uses[b];
+        });
+        uses[v] += 1;
+        assignments[i * world_size + j] = v;
+      }
+    }
+  }
+  if (std::any_of(assignments.begin(), assignments.end(), [](Node n) {
+        return n != -1;
+      })) {
+    auto tensor = at::from_blob(
+        assignments.data(),
+        {world_size, world_size},
+        at::TensorOptions().dtype(at::kLong));
+    LOG(INFO) << "Detected a multi-hop NVLink configuration: \n" << tensor;
+    return [=](Node i, Node j) { return assignments[i * world_size + j]; };
+  } else {
+    return [](Node, Node) { return -1; };
+  }
+}
+namespace {
+Tensor cat_dim_1(
+    std::vector<Tensor> tensors,
+    int batch_size,
+    at::Device output_device) {
+  if (tensors.size() == 0) {
+    return at::empty({0}, at::TensorOptions().device(output_device));
+  }
+  int64_t total_dim_1 = 0;
+  std::vector<int64_t> cumulative_dims;
+  cumulative_dims.push_back(0);
+  for (auto t : tensors) {
+    TORCH_CHECK(t.dim() == 2);
+    TORCH_CHECK(t.size(0) == batch_size);
+    total_dim_1 += t.size(-1);
+    cumulative_dims.push_back(total_dim_1);
+  }
+
+  auto* prop = at::cuda::getCurrentDeviceProperties();
+  auto output = at::empty(
+      {batch_size, total_dim_1},
+      tensors.front().options().device(output_device));
+  TORCH_CHECK(output.stride(0) * output.element_size() <= prop->memPitch);
+
+  std::vector<at::cuda::CUDAEvent> copy_begin_events(tensors.size());
+  std::vector<at::cuda::CUDAEvent> copy_completion_events(tensors.size());
+
+  Node dst_device_id = output_device.index();
+  static auto intermediate_nodes = get_intermediate_node(get_nvlink_matrix());
+  // Do the intermediate copies, if required by our multi-hop config.
+  for (auto i = 0; i < tensors.size(); ++i) {
+    Node src_device_id = tensors[i].device().index();
+    auto intermediate_node = intermediate_nodes(src_device_id, dst_device_id);
+    if (intermediate_node != -1) {
+      tensors[i] = tensors[i].to(at::Device(at::kCUDA, intermediate_node));
+    }
+  }
+
+  // synchronize source streams and launch copies on source stream.
+  for (auto i = 0; i < tensors.size(); ++i) {
+    auto src = tensors[i];
+    if (src.device() != output.device()) {
+      auto dst = output.slice(1, cumulative_dims[i], cumulative_dims[i + 1]);
+
+      at::Device dst_device = dst.device();
+      at::Device src_device = src.device();
+      at::cuda::CUDAGuard device_guard(src_device);
+      // We always perform the copy on the source device, using the current
+      // stream on the source device, and we fully synchronize on both src and
+      // dst's current streams for completion of the copy. We have to explicitly
+      // do this for non-contig copies. This mimics the behavior of cross-device
+      // cudaMemcpyAsync on the default stream.
+
+      at::cuda::CUDAStream copy_stream =
+          at::cuda::getCurrentCUDAStream(src_device.index());
+      // This is a cross-device copy on the src current stream and dst current
+      // stream. We perform a two-way barrier between both devices' streams
+      // before the copy. This ensures that any write-after-write and
+      // write-after-read dependencies on the destination side are handled, so
+      // that no one is operating on the dst memory when we perform the copy.
+      // src waits on dst barrier (src already waits on src)
+      auto& dst_ready = copy_begin_events[i];
+      device_guard.set_device(dst_device);
+      dst_ready.record(at::cuda::getCurrentCUDAStream(dst_device.index()));
+      device_guard.set_device(src_device);
+      dst_ready.block(copy_stream);
+      // on source device, launch memcpy.
+      AT_CUDA_CHECK(cudaMemcpy2DAsync(
+          dst.data_ptr(),
+          dst.stride(0) * dst.element_size(),
+          src.data_ptr(),
+          src.stride(0) * dst.element_size(),
+          src.size(1) * src.element_size(),
+          src.size(0),
+          cudaMemcpyDeviceToDevice,
+          copy_stream));
+    }
+  }
+
+  // Do the same-GPU cases.
+  for (auto i = 0; i < tensors.size(); ++i) {
+    auto src = tensors[i];
+    if (src.device() == output.device()) {
+      auto dst = output.slice(1, cumulative_dims[i], cumulative_dims[i + 1]);
+      at::Device src_device = src.device();
+      // single device memcpy, not that src_device == dst_device.
+      at::cuda::CUDAStream copy_stream =
+          at::cuda::getCurrentCUDAStream(src_device.index());
+      AT_CUDA_CHECK(cudaMemcpy2DAsync(
+          dst.data_ptr(),
+          dst.stride(0) * dst.element_size(),
+          src.data_ptr(),
+          src.stride(0) * src.element_size(),
+          src.size(1) * src.element_size(),
+          src.size(0),
+          cudaMemcpyDeviceToDevice,
+          copy_stream));
+    }
+  }
+  // wait for cross-device copies to complete.
+  for (auto i = 0; i < tensors.size(); ++i) {
+    auto src = tensors[i];
+    if (src.device() != output.device()) {
+      auto dst = output.slice(1, cumulative_dims[i], cumulative_dims[i + 1]);
+      at::Device dst_device = dst.device();
+      at::Device src_device = src.device();
+      // Still on src_device, record stream event
+      at::cuda::CUDAGuard device_guard(src_device);
+      at::cuda::CUDAStream copy_stream =
+          at::cuda::getCurrentCUDAStream(src_device.index());
+
+      auto& src_ready = copy_completion_events[i];
+      src_ready.record(copy_stream);
+
+      device_guard.set_device(dst_device);
+      src_ready.block(at::cuda::getCurrentCUDAStream(dst_device.index()));
+    }
+  }
+  AT_CUDA_CHECK(cudaGetLastError());
+
+  return output;
+}
+} // namespace
+
+// TODO: Add device arg.
+Tensor merge_pooled_embeddings(
+    std::vector<Tensor> ad_pooled_embeddings,
+    Tensor batch_indices) {
+  static std::once_flag flag;
+  std::call_once(flag, []() {
+    for (auto i = 0; i < at::cuda::getNumGPUs(); ++i) {
+      for (auto j = 0; j < at::cuda::getNumGPUs(); ++j) {
+        if (i != j) {
+          at::cuda::CUDAGuard g(i);
+          auto err = cudaDeviceEnablePeerAccess(j, 0);
+          if (err == cudaErrorPeerAccessAlreadyEnabled) {
+            // ignore and clear the error if access was already enabled
+            cudaGetLastError();
+          } else {
+            AT_CUDA_CHECK(err);
+          }
+        }
+      }
+    }
+  });
+
+  at::cuda::CUDAGuard g(batch_indices.device());
+
+  TORCH_CHECK(!ad_pooled_embeddings.empty());
+  auto B = batch_indices.size(0);
+  return cat_dim_1(ad_pooled_embeddings, B, batch_indices.device());
+}
+
+TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
+  m.impl(
+      "merge_pooled_embeddings",
+      torch::dispatch(
+          c10::DispatchKey::CUDA, TORCH_FN(merge_pooled_embeddings)));
+}

--- a/fbgemm_gpu/test/merge_pooled_embeddings_test.py
+++ b/fbgemm_gpu/test/merge_pooled_embeddings_test.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+# pyre-unsafe
+
+import unittest
+
+import hypothesis.strategies as st
+import torch
+from hypothesis import Verbosity, given, settings
+
+try:
+    torch.ops.load_library("fbgemm_gpu_py.so")
+except Exception:
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:merge_pooled_embeddings")
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:merge_pooled_embeddings_cpu")
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "Skip when CUDA is not available")
+class MergePooledEmbeddingsTest(unittest.TestCase):
+    @given(
+        num_ads=st.integers(min_value=1, max_value=10),
+        embedding_dimension=st.integers(min_value=1, max_value=32),
+        ads_tables=st.integers(min_value=1, max_value=32),
+        user_tables=st.integers(min_value=1, max_value=32),
+        num_gpus=st.integers(min_value=1, max_value=torch.cuda.device_count()),
+        non_default_stream=st.booleans(),
+        r=st.randoms(use_true_random=False),
+    )
+    # Can instantiate 8 contexts which takes a long time.
+    @settings(verbosity=Verbosity.verbose, max_examples=40, deadline=None)
+    def test_merge(
+        self,
+        num_ads,
+        embedding_dimension,
+        ads_tables,
+        user_tables,
+        num_gpus,
+        non_default_stream,
+        r,
+    ) -> None:
+        dst_device = r.randint(0, num_gpus - 1)
+        torch.cuda.set_device(dst_device)
+        ad_ds = [embedding_dimension * ads_tables for _ in range(num_gpus)]
+        user_ds = [user_tables * embedding_dimension]
+        num_users = 1
+        batch_indices = torch.zeros(num_ads).long().cuda()
+        pooled_ad_embeddings = [
+            torch.randn(
+                num_ads, ad_d, dtype=torch.float16, device=torch.device(f"cuda:{i}")
+            )
+            for i, ad_d in enumerate(ad_ds)
+        ]
+        r.shuffle(pooled_ad_embeddings)
+
+        streams = [torch.cuda.Stream(device=i) for i in range(num_gpus)]
+        import contextlib
+
+        with contextlib.ExitStack() as stack:
+            if non_default_stream:
+                for stream in streams:
+                    stack.enter_context(torch.cuda.stream(stream))
+            output = torch.ops.fbgemm.merge_pooled_embeddings(
+                pooled_ad_embeddings, batch_indices
+            )
+
+        def ref(pooled_ad_embeddings, batch_indices):
+            return torch.cat([p.cpu() for p in pooled_ad_embeddings], dim=1)
+
+        output_ref = ref(pooled_ad_embeddings, batch_indices)
+
+        output_cpu = torch.ops.fbgemm.merge_pooled_embeddings(
+            [pe.cpu() for pe in pooled_ad_embeddings], batch_indices.cpu()
+        )
+        self.assertEqual(output.device, torch.device(f"cuda:{dst_device}"))
+        torch.testing.assert_allclose(output_ref, output.cpu())
+        torch.testing.assert_allclose(output_ref, output_cpu)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
Add UVM (no caching) option for the infer version of table batched embedding bag.
- Change the interface of "embedding_specs": add "managed" as the last parameter in the Tuple;
- Add UVM option in the kernel
- Separate 3 pieces of weights: weights_dev, weights_uvm, weights_host, similar to the convention of training version.

Reviewed By: yinghai

Differential Revision: D30770515

