### PR TITLE
Remove unused numpy deps

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -1534,7 +1534,6 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         load_factor: float = 0.5,
     ) -> None:  # noqa C901  # tuple of (rows, dims,)
         super(IntNBitTableBatchedEmbeddingBagsCodegen, self).__init__()
-        import numpy as np
 
         self.use_cpu = use_cpu
         self.current_device: torch.device = (


### PR DESCRIPTION
Summary: As title: numpy is no longer used in `split_table_batched_embeddings_ops.py`.

Reviewed By: jspark1105

Differential Revision: D30890817

