### PR TITLE
Reduce maximum number of test iterations to reduce likelyhood of test timeouts.

### DIFF
--- a/fbgemm_gpu/test/sparse_ops_test.py
+++ b/fbgemm_gpu/test/sparse_ops_test.py
@@ -90,7 +90,7 @@ class SparseOpsTest(unittest.TestCase):
         long_index=st.booleans(),
         has_weight=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
     def test_permute_indices(
         self, B: int, T: int, L: int, long_index: bool, has_weight: bool
     ) -> None:
@@ -157,7 +157,7 @@ class SparseOpsTest(unittest.TestCase):
         long_index=st.booleans(),
         has_weight=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
     def test_permute_indices_with_repeats(
         self, B: int, T: int, L: int, long_index: bool, has_weight: bool
     ) -> None:
@@ -230,7 +230,7 @@ class SparseOpsTest(unittest.TestCase):
         long_index=st.booleans(),
         has_weight=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
     def test_permute_indices_multi_dimension(
         self, D: int, B: int, T: int, L: int, long_index: bool, has_weight: bool
     ) -> None:
@@ -296,7 +296,7 @@ class SparseOpsTest(unittest.TestCase):
         L=st.integers(min_value=2, max_value=20),
         long_index=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
     def test_permute_embeddings(self, B: int, T: int, L: int, long_index: bool) -> None:
         index_dtype = torch.int32 if long_index else torch.int32
         lengths = torch.randint(low=1, high=L, size=(T, B)).type(index_dtype)


### PR DESCRIPTION
Summary:
Reduce the number of iterations of potentially long-running tests to reduce the
chance that the tests will result in timeouts.

Reviewed By: amylittleyang

Differential Revision: D31067269

