### PR TITLE
Add pooled embedding permute

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -1564,6 +1564,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.feature_names: List[str] = [e[0] for e in embedding_specs]
         rows: List[int] = [e[1] for e in embedding_specs]
         dims: List[int] = [e[2] for e in embedding_specs]
+        self.dims: List[int] = dims
         weights_tys: List[SparseType] = [e[3] for e in embedding_specs]
         locations: List[EmbeddingLocation] = [e[4] for e in embedding_specs]
 


### PR DESCRIPTION
Summary:
Add per embedding group pooled embedding permute to HPC inference table sharded embedding wrapper.

Permute tensor is passed from model sharder and permutes pooled embeddings after merge_pooled_embeddings for each embedding group.

Refactor PermutePooledEmbeddings module to send arg tensors to runtime cuda device on-demand. We could not create multiple copies of PermutePooledEmbeddings each pinned to different device essentially due to the complexity of torch-jit of list[list[module]].

Use disagg_inference_config.permute_pooled_emb=True arg to enable pooled embedding permute.

Next:
- NE test if this helps recover the crazy NE measured with GPU eval runner?
- QPS regression?

Reviewed By: yinghai

Differential Revision: D31184357

