### PR TITLE
Make IntNBitTableBatchedEmbeddingBagsCodegen compatible with torch.jit.script

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -1659,15 +1659,15 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.dev_size: int = weight_split.dev_size
         self.uvm_size: int = weight_split.uvm_size
 
-        # Assign weights after weights and weights_offsets are initialized.
-        if weight_lists:
-            self._apply_split(
+        self._apply_split(
                 self.dev_size,
                 self.host_size,
                 self.uvm_size,
                 self.weights_physical_placements,
                 self.weights_physical_offsets,
             )
+        # Assign weights after weights and weights_offsets are initialized.
+        if weight_lists:
             self.assign_embedding_weights(weight_lists)  # type: ignore
 
         # Handle index remapping for embedding pruning.


### PR DESCRIPTION
Summary: Without weight lists, the script is broken. The issue was probably introduced in D30824731 (https://github.com/pytorch/FBGEMM/commit/10c3f6a4f9238ffad9e30479f959f5f5a452d388).

Differential Revision: D31436538

