### PR TITLE
Move reorder_batched_ad_lengths and indices from caffe2/fb to fbgemm_gpu.

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -77,4 +77,28 @@ at::Tensor _fusednbitrowwise_to_float_gpu(
     const at::Tensor& input,
     const int64_t bit_rate);
 
+Tensor reorder_batched_ad_lengths_gpu(
+    const Tensor& cat_ad_lengths,
+    const Tensor& batch_offsets,
+    const int64_t num_ads_in_batch);
+
+Tensor reorder_batched_ad_indices_gpu(
+    const Tensor& cat_ad_offsets,
+    const Tensor& cat_ad_indices,
+    const Tensor& reordered_cat_ad_offsets,
+    const Tensor& batch_offsets,
+    const int64_t num_ads_in_batch);
+
+Tensor reorder_batched_ad_lengths_cpu(
+    const Tensor& cat_ad_lengths,
+    const Tensor& batch_offsets,
+    const int64_t num_ads_in_batch);
+
+Tensor reorder_batched_ad_indices_cpu(
+    const Tensor& cat_ad_offsets,
+    const Tensor& cat_ad_indices,
+    const Tensor& reordered_cat_ad_offsets,
+    const Tensor& batch_offsets,
+    const int64_t num_ads_in_batch);
+
 } // namespace at

--- a/fbgemm_gpu/src/sparse_ops.cu
+++ b/fbgemm_gpu/src/sparse_ops.cu
@@ -908,4 +908,158 @@ at::Tensor _fusednbitrowwise_to_float_gpu(
   return output;
 }
 
+
+
+__global__ void reorder_batched_ad_lengths_kernel(
+    // reorder lengths from (ragged) [B  x T x #num_ads_b)] to
+    // [T][B][#num_ads_b], i.e. [T][sum(#num_ads_b)].
+    const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> cat_ad_lengths,
+    const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> batch_offsets,
+    PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits>
+        reordered_cat_ad_lengths,
+    int32_t T) {
+  const int32_t B = batch_offsets.size(0) - 1;
+
+  const int32_t num_ads_in_batch = batch_offsets[B];
+  // warp-per-segment.
+  const int32_t b_t = blockIdx.x * blockDim.y + threadIdx.y;
+  const int32_t b = b_t % B;
+  const int32_t t = b_t / B;
+  if (t >= T) {
+    return;
+  }
+
+  const int32_t num_ads_b = batch_offsets[b + 1] - batch_offsets[b];
+  const int32_t input_segment_start = T * batch_offsets[b] + t * num_ads_b;
+  const int32_t output_segment_start = t * num_ads_in_batch + batch_offsets[b];
+
+  for (int32_t i = threadIdx.x; i < num_ads_b; i += blockDim.x) {
+    reordered_cat_ad_lengths[output_segment_start + i] =
+        cat_ad_lengths[input_segment_start + i];
+  }
+}
+
+Tensor reorder_batched_ad_lengths_gpu(
+    const Tensor& cat_ad_lengths,
+    const Tensor& batch_offsets,
+    const int64_t num_ads_in_batch) {
+  TENSOR_ON_CUDA_GPU(cat_ad_lengths);
+  TENSOR_ON_CUDA_GPU(batch_offsets);
+  TENSORS_ON_SAME_DEVICE(cat_ad_lengths, batch_offsets);
+
+  at::cuda::OptionalCUDAGuard device_guard;
+  device_guard.set_index(cat_ad_lengths.get_device());
+
+  const int64_t B = batch_offsets.numel() - 1;
+  const int64_t T = cat_ad_lengths.numel() / num_ads_in_batch;
+
+  Tensor reordered_cat_ad_lengths = at::empty_like(cat_ad_lengths);
+
+  const dim3 threads(32, 32);
+  const dim3 blocks((B * T + 32 - 1) / 32);
+
+  reorder_batched_ad_lengths_kernel<<<
+      blocks,
+      threads,
+      0,
+      at::cuda::getCurrentCUDAStream()>>>(
+      cat_ad_lengths.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+      batch_offsets.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+      reordered_cat_ad_lengths
+          .packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+      T);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  return reordered_cat_ad_lengths;
+}
+
+__global__ void reorder_batched_ad_indices_kernel(
+    // reorder indices from (ragged) [B  x T x #num_ads_b x length_{b, t, a})]
+    // to [T][B][#num_ads_b][length_{b, t, a}], i.e. [sum(length_{b, t, a})],
+    // laid out as [T][B][A][L] (if all lengths were equal).
+    const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> cat_ad_offsets,
+    const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> cat_ad_indices,
+    const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits>
+        reordered_cat_ad_offsets,
+    PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits>
+        reordered_cat_ad_indices,
+    const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> batch_offsets,
+    int32_t T) {
+  const int32_t B = batch_offsets.size(0) - 1;
+  const int32_t num_ads_in_batch = batch_offsets[B];
+  // warp-per-segment.
+  const int32_t b_t = blockIdx.x * blockDim.y + threadIdx.y;
+  const int32_t b = b_t % B;
+  const int32_t t = b_t / B;
+  if (t >= T) {
+    return;
+  }
+  // for each ad,
+  const int32_t num_ads_b = batch_offsets[b + 1] - batch_offsets[b];
+  const int32_t b_t_start = T * batch_offsets[b] + t * num_ads_b;
+  const int32_t input_segment_offset_start =
+      T * batch_offsets[b] + t * num_ads_b;
+  const int32_t input_segment_offset_end =
+      T * batch_offsets[b] + t * num_ads_b + num_ads_b;
+
+  // Idea: we want to copy the entire segment of size sum_a(length_{b, t, a})
+  // from starting point (given by cat_ad_offsets[b, t])
+  // to end point (given by reordered_cat_ad_indices[t][b])
+  const int32_t input_segment_start =
+      cat_ad_offsets[input_segment_offset_start];
+  const int32_t input_segment_end = cat_ad_offsets[input_segment_offset_end];
+
+  const int32_t output_segment_offset_start =
+      t * num_ads_in_batch + batch_offsets[b];
+  const int32_t output_segment_start =
+      reordered_cat_ad_offsets[output_segment_offset_start];
+
+  for (auto i = threadIdx.x; i < input_segment_end - input_segment_start;
+       i += blockDim.x) {
+    reordered_cat_ad_indices[output_segment_start + i] =
+        cat_ad_indices[input_segment_start + i];
+  }
+}
+
+Tensor reorder_batched_ad_indices_gpu(
+    const Tensor& cat_ad_offsets,
+    const Tensor& cat_ad_indices,
+    const Tensor& reordered_cat_ad_offsets,
+    const Tensor& batch_offsets,
+    const int64_t num_ads_in_batch) {
+  TENSOR_ON_CUDA_GPU(cat_ad_offsets);
+  TENSOR_ON_CUDA_GPU(cat_ad_indices);
+  TENSOR_ON_CUDA_GPU(reordered_cat_ad_offsets);
+  TENSOR_ON_CUDA_GPU(batch_offsets);
+  TENSORS_ON_SAME_DEVICE(cat_ad_offsets, cat_ad_indices);
+  TENSORS_ON_SAME_DEVICE(cat_ad_offsets, reordered_cat_ad_offsets);
+  TENSORS_ON_SAME_DEVICE(cat_ad_offsets, batch_offsets);
+
+  at::cuda::OptionalCUDAGuard device_guard;
+  device_guard.set_index(cat_ad_offsets.get_device());
+
+  const int64_t B = batch_offsets.numel() - 1;
+  const int64_t T = (cat_ad_offsets.numel() - 1) / num_ads_in_batch;
+  Tensor reordered_cat_ad_indices = at::empty_like(cat_ad_indices);
+
+  const dim3 threads(32, 32);
+  const dim3 blocks((B * T + 32 - 1) / 32);
+
+  reorder_batched_ad_indices_kernel<<<
+      blocks,
+      threads,
+      0,
+      at::cuda::getCurrentCUDAStream()>>>(
+      cat_ad_offsets.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+      cat_ad_indices.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+      reordered_cat_ad_offsets
+          .packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+      reordered_cat_ad_indices
+          .packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+      batch_offsets.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+      T);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return reordered_cat_ad_indices;
+}
+
 } // namespace at

--- a/fbgemm_gpu/src/sparse_ops_gpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_gpu.cpp
@@ -23,4 +23,6 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
       "asynchronous_complete_cumsum", at::asynchronous_complete_cumsum_gpu);
   DISPATCH_TO_CUDA(
       "asynchronous_inclusive_cumsum", at::asynchronous_inclusive_cumsum_gpu);
+  DISPATCH_TO_CUDA("reorder_batched_ad_lengths", at::reorder_batched_ad_lengths_gpu);
+  DISPATCH_TO_CUDA("reorder_batched_ad_indices", at::reorder_batched_ad_indices_gpu);
 }

--- a/fbgemm_gpu/test/sparse_ops_test.py
+++ b/fbgemm_gpu/test/sparse_ops_test.py
@@ -588,6 +588,147 @@ class SparseOpsTest(unittest.TestCase):
             )
             torch.testing.assert_allclose(unbucketized_indices, indices, 0, 0)
 
+    @unittest.skipIf(not torch.cuda.is_available(), "Skip when CUDA is not available")
+    # pyre-ignore [56]: Invalid decoration, was not able to infer the type of argument
+    @given(
+        B=st.integers(min_value=1, max_value=20),
+        T=st.integers(min_value=1, max_value=20),
+        L=st.integers(min_value=2, max_value=20),
+        A=st.integers(min_value=1, max_value=20),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    def test_reorder_batched_ad_lengths(self, B: int, T: int, L: int, A: int) -> None:
+        cat_ad_lengths = (
+            torch.cat([torch.tensor([L for _ in range(T * A)]) for _ in range(B)], 0)
+            .int()
+            .cuda()
+        )
+        batch_offsets = torch.tensor([A * b for b in range(B + 1)]).int().cuda()
+        num_ads_in_batch = B * A
+        reordered_batched_ad_lengths = torch.ops.fbgemm.reorder_batched_ad_lengths(
+            cat_ad_lengths, batch_offsets, num_ads_in_batch
+        )
+        torch.testing.assert_allclose(cat_ad_lengths, reordered_batched_ad_lengths)
+
+        cat_ad_lengths_cpu = cat_ad_lengths.cpu()
+        batch_offsets_cpu = batch_offsets.cpu()
+        reordered_batched_ad_lengths_cpu = torch.ops.fbgemm.reorder_batched_ad_lengths(
+            cat_ad_lengths_cpu, batch_offsets_cpu, num_ads_in_batch
+        )
+        torch.testing.assert_allclose(
+            reordered_batched_ad_lengths_cpu, reordered_batched_ad_lengths.cpu()
+        )
+
+    # pyre-ignore [56]: Invalid decoration, was not able to infer the type of argument
+    @given(
+        B=st.integers(min_value=1, max_value=20),
+        T=st.integers(min_value=1, max_value=20),
+        L=st.integers(min_value=2, max_value=20),
+        A=st.integers(min_value=1, max_value=20),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=40, deadline=None)
+    def test_reorder_batched_ad_lengths_cpu(
+        self, B: int, T: int, L: int, A: int
+    ) -> None:
+        cat_ad_lengths = torch.cat(
+            [torch.tensor([L for _ in range(T * A)]) for _ in range(B)], 0
+        ).int()
+        batch_offsets = torch.tensor([A * b for b in range(B + 1)]).int()
+        num_ads_in_batch = B * A
+        reordered_batched_ad_lengths = torch.ops.fbgemm.reorder_batched_ad_lengths(
+            cat_ad_lengths, batch_offsets, num_ads_in_batch
+        )
+        torch.testing.assert_allclose(cat_ad_lengths, reordered_batched_ad_lengths)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "Skip when CUDA is not available")
+    # pyre-ignore [56]: Invalid decoration, was not able to infer the type of argument
+    @given(
+        B=st.integers(min_value=1, max_value=20),
+        T=st.integers(min_value=1, max_value=20),
+        L=st.integers(min_value=2, max_value=20),
+        A=st.integers(min_value=1, max_value=20),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    def test_reorder_batched_ad_indices(self, B: int, T: int, L: int, A: int) -> None:
+        cat_ad_indices = (
+            torch.randint(low=0, high=100, size=(B * T * A * L,)).int().cuda()
+        )
+        cat_ad_lengths = (
+            torch.cat([torch.tensor([L for _ in range(T * A)]) for _ in range(B)], 0)
+            .int()
+            .cuda()
+        )
+        batch_offsets = torch.tensor([A * b for b in range(B + 1)]).int().cuda()
+        num_ads_in_batch = B * A
+        reordered_cat_ad_lengths = torch.ops.fbgemm.reorder_batched_ad_lengths(
+            cat_ad_lengths, batch_offsets, num_ads_in_batch
+        )
+        torch.testing.assert_allclose(cat_ad_lengths, reordered_cat_ad_lengths)
+
+        cat_ad_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(cat_ad_lengths)
+        reordered_cat_ad_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
+            reordered_cat_ad_lengths
+        )
+        reordered_cat_ad_indices = torch.ops.fbgemm.reorder_batched_ad_indices(
+            cat_ad_offsets,
+            cat_ad_indices,
+            reordered_cat_ad_offsets,
+            batch_offsets,
+            num_ads_in_batch,
+        )
+        torch.testing.assert_allclose(
+            reordered_cat_ad_indices.view(T, B, A, L).permute(1, 0, 2, 3),
+            cat_ad_indices.view(B, T, A, L),
+        )
+
+        reordered_cat_ad_indices_cpu = torch.ops.fbgemm.reorder_batched_ad_indices(
+            cat_ad_offsets.cpu(),
+            cat_ad_indices.cpu(),
+            reordered_cat_ad_offsets.cpu(),
+            batch_offsets.cpu(),
+            num_ads_in_batch,
+        )
+        torch.testing.assert_allclose(
+            reordered_cat_ad_indices_cpu.view(T, B, A, L).permute(1, 0, 2, 3),
+            cat_ad_indices.view(B, T, A, L).cpu(),
+        )
+
+    # pyre-ignore [56]: Invalid decoration, was not able to infer the type of argument
+    @given(
+        B=st.integers(min_value=1, max_value=20),
+        T=st.integers(min_value=1, max_value=20),
+        L=st.integers(min_value=2, max_value=20),
+        A=st.integers(min_value=1, max_value=20),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=40, deadline=None)
+    def test_reorder_batched_ad_indices_cpu(
+        self, B: int, T: int, L: int, A: int
+    ) -> None:
+        cat_ad_indices = torch.randint(low=0, high=100, size=(B * T * A * L,)).int()
+        cat_ad_lengths = torch.cat(
+            [torch.tensor([L for _ in range(T * A)]) for _ in range(B)], 0
+        ).int()
+        batch_offsets = torch.tensor([A * b for b in range(B + 1)]).int()
+        num_ads_in_batch = B * A
+        reordered_cat_ad_lengths = torch.ops.fbgemm.reorder_batched_ad_lengths(
+            cat_ad_lengths, batch_offsets, num_ads_in_batch
+        )
+        torch.testing.assert_allclose(cat_ad_lengths, reordered_cat_ad_lengths)
+        cat_ad_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(cat_ad_lengths)
+        reordered_cat_ad_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
+            reordered_cat_ad_lengths
+        )
+        reordered_cat_ad_indices = torch.ops.fbgemm.reorder_batched_ad_indices(
+            cat_ad_offsets,
+            cat_ad_indices,
+            reordered_cat_ad_offsets,
+            batch_offsets,
+            num_ads_in_batch,
+        )
+        torch.testing.assert_allclose(
+            reordered_cat_ad_indices.view(T, B, A, L).permute(1, 0, 2, 3),
+            cat_ad_indices.view(B, T, A, L),
+        )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary: Move torch.ops.fb.reorder_batched_ad_lengths and reorder_batched_ad_indices CPU/GPU ops into FBGEMM_GPU.

Reviewed By: jianyuh

Differential Revision: D31450659

