### PR TITLE
Change the input of merge_pooled_embeddings to be more specific inputs

### DIFF
--- a/fbgemm_gpu/bench/merge_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/merge_embeddings_benchmark.py
@@ -75,11 +75,11 @@ def main(num_ads, embedding_dimension, ads_tables, iters, p2p_bw, dst_device) ->
         t = benchmark_torch_function(
             iters,
             lambda: torch.ops.fbgemm.merge_pooled_embeddings(
-                pooled_ad_embeddings, batch_indices
+                pooled_ad_embeddings, batch_indices.size(0), batch_indices.device
             ),
         )
         merged = torch.ops.fbgemm.merge_pooled_embeddings(
-            pooled_ad_embeddings, batch_indices
+            pooled_ad_embeddings, batch_indices.size(0), batch_indices.device
         )
     print(
         f"Merge, B: {num_ads}, D: {embedding_dimension}, T: {ads_tables}, Num GPUs: {num_gpus}, Destination GPU: {dst_device} Output Size: {merged.numel() * 2 / 1.0e6:.2f}MB, BW: {merged.numel() * 2 / t / 1.0e9:.2f}GB/s, t: {t * 1.0e3:.2f}ms"

--- a/fbgemm_gpu/src/merge_pooled_embeddings_cpu.cpp
+++ b/fbgemm_gpu/src/merge_pooled_embeddings_cpu.cpp
@@ -15,7 +15,8 @@ namespace at {
 
 at::Tensor merge_pooled_embeddings_cpu(
     std::vector<Tensor> pooled_embeddings,
-    Tensor batch_indices) {
+    int64_t batch_size,
+    at::Device target_device) {
   auto cat_host_0 = [&](const std::vector<at::Tensor>& ts) {
     int64_t n = 0;
     for (auto& t : ts) {

--- a/fbgemm_gpu/test/merge_pooled_embeddings_test.py
+++ b/fbgemm_gpu/test/merge_pooled_embeddings_test.py
@@ -56,7 +56,7 @@ class MergePooledEmbeddingsTest(unittest.TestCase):
                 for stream in streams:
                     stack.enter_context(torch.cuda.stream(stream))
             output = torch.ops.fbgemm.merge_pooled_embeddings(
-                pooled_ad_embeddings, batch_indices
+                pooled_ad_embeddings, batch_indices.size(0), batch_indices.device
             )
 
         def ref(pooled_ad_embeddings, batch_indices):
@@ -65,7 +65,7 @@ class MergePooledEmbeddingsTest(unittest.TestCase):
         output_ref = ref(pooled_ad_embeddings, batch_indices)
 
         output_cpu = torch.ops.fbgemm.merge_pooled_embeddings(
-            [pe.cpu() for pe in pooled_ad_embeddings], batch_indices.cpu()
+            [pe.cpu() for pe in pooled_ad_embeddings], batch_indices.size(0), batch_indices.cpu().device
         )
         self.assertEqual(output.device, torch.device(f"cuda:{dst_device}"))
         torch.testing.assert_allclose(output_ref, output.cpu())


### PR DESCRIPTION
Summary: batch_indices tensor is not needed by merge_pooled_embeddings, we can replace Tensor batch_indices with at::Device target_device, int64_t batch_size.

Differential Revision: D31466348

