### PR TITLE
set link_whole = True to sparse_ops

### DIFF
--- a/fbgemm_gpu/src/layout_transform_ops_cpu.cpp
+++ b/fbgemm_gpu/src/layout_transform_ops_cpu.cpp
@@ -11,6 +11,7 @@
 #include "fbgemm_gpu/sparse_ops_utils.h"
 
 namespace at {
+namespace fbgemm {
 
 Tensor recat_embedding_grad_output_mixed_D_cpu(
     const Tensor& grad_output, // [B_local][Sum_T_global(D)]
@@ -59,6 +60,7 @@ Tensor recat_embedding_grad_output_mixed_D_cpu(
   return sharded_grad_output;
 }
 
+} // namespace fbgemm
 } // namespace at
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
@@ -73,5 +75,5 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
   m.impl(
       "recat_embedding_grad_output_mixed_D",
-      at::recat_embedding_grad_output_mixed_D_cpu);
+      at::fbgemm::recat_embedding_grad_output_mixed_D_cpu);
 }

--- a/fbgemm_gpu/src/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_cpu.cpp
@@ -11,6 +11,7 @@
 #include "fbgemm_gpu/sparse_ops_utils.h"
 
 namespace at {
+namespace fbgemm {
 
 namespace {
 // To avoid multiple threads are touching the same cache line.
@@ -675,6 +676,7 @@ Tensor reorder_batched_ad_indices_cpu(
   return reordered_cat_ad_indices;
 }
 
+} // namespace fbgemm
 } // namespace at
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
@@ -692,15 +694,21 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
-  m.impl("permute_sparse_data", at::permute_sparse_data_cpu);
+  m.impl("permute_sparse_data", at::fbgemm::permute_sparse_data_cpu);
   m.impl(
       "block_bucketize_sparse_features",
-      at::block_bucketize_sparse_features_cpu);
+      at::fbgemm::block_bucketize_sparse_features_cpu);
   m.impl(
-      "asynchronous_exclusive_cumsum", at::asynchronous_exclusive_cumsum_cpu);
+      "asynchronous_exclusive_cumsum",
+      at::fbgemm::asynchronous_exclusive_cumsum_cpu);
   m.impl(
-      "asynchronous_inclusive_cumsum", at::asynchronous_inclusive_cumsum_cpu);
-  m.impl("asynchronous_complete_cumsum", at::asynchronous_complete_cumsum_cpu);
-  m.impl("reorder_batched_ad_lengths", at::reorder_batched_ad_lengths_cpu);
-  m.impl("reorder_batched_ad_indices", at::reorder_batched_ad_indices_cpu);
+      "asynchronous_inclusive_cumsum",
+      at::fbgemm::asynchronous_inclusive_cumsum_cpu);
+  m.impl(
+      "asynchronous_complete_cumsum",
+      at::fbgemm::asynchronous_complete_cumsum_cpu);
+  m.impl(
+      "reorder_batched_ad_lengths", at::fbgemm::reorder_batched_ad_lengths_cpu);
+  m.impl(
+      "reorder_batched_ad_indices", at::fbgemm::reorder_batched_ad_indices_cpu);
 }


### PR DESCRIPTION
Summary:
w/o `link_whole = True`, torch deploy cannot access to fbgemm in Python interpreter thread since it won't be linked.

Added a new namespace inside `sparse_ops_cpu.cpp` so it won't conflict with `caffe2/torch/fb/sparsenn/sparsenn_operators.cpp`.

https://www.internalfb.com/code/fbsource/[bba11620fd4dbcffb1fc08bf2c89d7801ca0dcfd]/fbcode/caffe2/torch/fb/sparsenn/sparsenn_operators.cpp?lines=2845%2C2852%2C6142%2C6295

Reviewed By: jianyuh

Differential Revision: D30617456

