### PR TITLE
Remove the dups in sparse_ops (vs. FBGEMM_GPU)

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/permute_pooled_embedding_ops.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/permute_pooled_embedding_ops.cuh
@@ -1,18 +1,1 @@
 #pragma once
-
-#include <ATen/ATen.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/Exceptions.h>
-#include <cuda.h>
-#include "cub/block/block_reduce.cuh"
-#include "cub/device/device_scan.cuh"
-#include "./layout_transform_ops.cuh"
-
-namespace at {
-Tensor permute_pooled_embs(
-    const Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
-    const Tensor& offset_dim_list,
-    const Tensor& permute_list,
-    const Tensor& inv_offset_dim_list,
-    const Tensor& inv_permute_list);
-} // namespace at

--- a/fbgemm_gpu/include/fbgemm_gpu/permute_pooled_embedding_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/permute_pooled_embedding_ops.h
@@ -4,11 +4,18 @@
 
 #include <ATen/ATen.h>
 
-namespace at {
-Tensor permute_pooled_embs(
-    const Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
-    const Tensor& offset_dim_list,
-    const Tensor& permute_list,
-    const Tensor& inv_offset_dim_list,
-    const Tensor& inv_permute_list);
-}
+namespace fbgemm {
+at::Tensor permute_pooled_embs_cpu(
+    const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
+    const at::Tensor& offset_dim_list,
+    const at::Tensor& permute_list,
+    const at::Tensor& inv_offset_dim_list,
+    const at::Tensor& inv_permute_list);
+
+at::Tensor permute_pooled_embs_gpu(
+    const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
+    const at::Tensor& offset_dim_list,
+    const at::Tensor& permute_list,
+    const at::Tensor& inv_offset_dim_list,
+    const at::Tensor& inv_permute_list);
+} // namespace fbgemm

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -9,7 +9,6 @@
 
 #include <ATen/ATen.h>
 
-namespace at {
 namespace fbgemm {
 
 // Return array of size T_in.numel(), representing incomplete exclusive cumsum
@@ -29,27 +28,27 @@ at::Tensor offsets_range_cuda(const at::Tensor& offsets, int64_t range_size);
 
 at::Tensor offsets_range_cpu(const at::Tensor& offsets, int64_t range_size);
 
-std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_data_cuda(
-    const Tensor& permute,
-    const Tensor& lengths,
-    const Tensor& indices,
-    const c10::optional<Tensor>& weights,
+std::tuple<at::Tensor, at::Tensor, c10::optional<at::Tensor>> permute_sparse_data_cuda(
+    const at::Tensor& permute,
+    const at::Tensor& lengths,
+    const at::Tensor& indices,
+    const c10::optional<at::Tensor>& weights,
     const c10::optional<int64_t>& permuted_lengths_sum);
 
 std::tuple<
-    Tensor,
-    Tensor,
-    c10::optional<Tensor>,
-    c10::optional<Tensor>,
-    c10::optional<Tensor>>
+    at::Tensor,
+    at::Tensor,
+    c10::optional<at::Tensor>,
+    c10::optional<at::Tensor>,
+    c10::optional<at::Tensor>>
 block_bucketize_sparse_features_cuda(
-    Tensor lengths,
-    Tensor indices,
+    at::Tensor lengths,
+    at::Tensor indices,
     bool bucketize_pos,
     bool sequence,
-    Tensor block_sizes,
+    at::Tensor block_sizes,
     int64_t my_size,
-    c10::optional<Tensor> weights);
+    c10::optional<at::Tensor> weights);
 
 std::tuple<
     at::Tensor,
@@ -66,11 +65,11 @@ block_bucketize_sparse_features_cpu(
     int64_t my_size,
     c10::optional<at::Tensor> weights);
 
-std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_data_cpu(
-    const Tensor& permute,
-    const Tensor& lengths,
-    const Tensor& indices,
-    const c10::optional<Tensor>& weights,
+std::tuple<at::Tensor, at::Tensor, c10::optional<at::Tensor>> permute_sparse_data_cpu(
+    const at::Tensor& permute,
+    const at::Tensor& lengths,
+    const at::Tensor& indices,
+    const c10::optional<at::Tensor>& weights,
     const c10::optional<int64_t>& permuted_lengths_sum);
 
 at::Tensor _float_to_fused8bitrowwise_gpu(const at::Tensor& input);
@@ -81,29 +80,35 @@ at::Tensor _float_to_fusednbitrowwise_gpu(
 at::Tensor _fusednbitrowwise_to_float_gpu(
     const at::Tensor& input,
     const int64_t bit_rate);
+at::Tensor& _fused8bitrowwise_to_float_cpu_out(
+    at::Tensor& output,
+    const at::Tensor& input);
+at::Tensor& _float_to_fused8bitrowwise_cpu_out(
+    at::Tensor& output,
+    const at::Tensor& input);
 
-Tensor reorder_batched_ad_lengths_gpu(
-    const Tensor& cat_ad_lengths,
-    const Tensor& batch_offsets,
+at::Tensor reorder_batched_ad_lengths_gpu(
+    const at::Tensor& cat_ad_lengths,
+    const at::Tensor& batch_offsets,
     const int64_t num_ads_in_batch);
 
-Tensor reorder_batched_ad_indices_gpu(
-    const Tensor& cat_ad_offsets,
-    const Tensor& cat_ad_indices,
-    const Tensor& reordered_cat_ad_offsets,
-    const Tensor& batch_offsets,
+at::Tensor reorder_batched_ad_indices_gpu(
+    const at::Tensor& cat_ad_offsets,
+    const at::Tensor& cat_ad_indices,
+    const at::Tensor& reordered_cat_ad_offsets,
+    const at::Tensor& batch_offsets,
     const int64_t num_ads_in_batch);
 
-Tensor reorder_batched_ad_lengths_cpu(
-    const Tensor& cat_ad_lengths,
-    const Tensor& batch_offsets,
+at::Tensor reorder_batched_ad_lengths_cpu(
+    const at::Tensor& cat_ad_lengths,
+    const at::Tensor& batch_offsets,
     const int64_t num_ads_in_batch);
 
-Tensor reorder_batched_ad_indices_cpu(
-    const Tensor& cat_ad_offsets,
-    const Tensor& cat_ad_indices,
-    const Tensor& reordered_cat_ad_offsets,
-    const Tensor& batch_offsets,
+at::Tensor reorder_batched_ad_indices_cpu(
+    const at::Tensor& cat_ad_offsets,
+    const at::Tensor& cat_ad_indices,
+    const at::Tensor& reordered_cat_ad_offsets,
+    const at::Tensor& batch_offsets,
     const int64_t num_ads_in_batch);
 
 at::Tensor recat_embedding_grad_output_cuda(
@@ -111,16 +116,15 @@ at::Tensor recat_embedding_grad_output_cuda(
     std::vector<int64_t> num_features_per_rank);
 
 at::Tensor recat_embedding_grad_output_mixed_D_cuda(
-    const Tensor& grad_output, // [B_local][Sum_T_global(D)]
+    const at::Tensor& grad_output, // [B_local][Sum_T_global(D)]
     const std::vector<int64_t>& dim_sum_per_rank);
 
 at::Tensor recat_embedding_grad_output_mixed_D_batch_cuda(
-    const Tensor& grad_output, // [B_local][Sum_T_global(D)]
-    const Tensor& dim_sum_per_rank,
-    const Tensor& cumsum_dim_sum_per_rank);
+    const at::Tensor& grad_output, // [B_local][Sum_T_global(D)]
+    const at::Tensor& dim_sum_per_rank,
+    const at::Tensor& cumsum_dim_sum_per_rank);
 
 at::Tensor recat_embedding_grad_output_mixed_D_cpu(
-    const Tensor& grad_output, // [B_local][Sum_T_global(D)]
+    const at::Tensor& grad_output, // [B_local][Sum_T_global(D)]
     const std::vector<int64_t>& dim_sum_per_rank);
 } // namespace fbgemm
-} // namespace at

--- a/fbgemm_gpu/src/layout_transform_ops_cpu.cpp
+++ b/fbgemm_gpu/src/layout_transform_ops_cpu.cpp
@@ -10,16 +10,15 @@
 #include "ATen/Parallel.h"
 #include "fbgemm_gpu/sparse_ops_utils.h"
 
-namespace at {
 namespace fbgemm {
 
-Tensor recat_embedding_grad_output_mixed_D_cpu(
-    const Tensor& grad_output, // [B_local][Sum_T_global(D)]
+at::Tensor recat_embedding_grad_output_mixed_D_cpu(
+    const at::Tensor& grad_output, // [B_local][Sum_T_global(D)]
     const std::vector<int64_t>& dim_sum_per_rank) {
   TORCH_CHECK(grad_output.is_contiguous());
   const auto B_local = grad_output.sizes()[0];
 
-  Tensor sharded_grad_output =
+  at::Tensor sharded_grad_output =
       at::empty({grad_output.numel()}, grad_output.options());
 
   int n = dim_sum_per_rank.size();
@@ -61,7 +60,7 @@ Tensor recat_embedding_grad_output_mixed_D_cpu(
 }
 
 } // namespace fbgemm
-} // namespace at
+
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
@@ -75,5 +74,5 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
   m.impl(
       "recat_embedding_grad_output_mixed_D",
-      at::fbgemm::recat_embedding_grad_output_mixed_D_cpu);
+      fbgemm::recat_embedding_grad_output_mixed_D_cpu);
 }

--- a/fbgemm_gpu/src/layout_transform_ops_gpu.cpp
+++ b/fbgemm_gpu/src/layout_transform_ops_gpu.cpp
@@ -15,10 +15,10 @@
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   DISPATCH_TO_CUDA(
       "recat_embedding_grad_output_mixed_D_batch",
-      at::fbgemm::recat_embedding_grad_output_mixed_D_batch_cuda);
+      fbgemm::recat_embedding_grad_output_mixed_D_batch_cuda);
   DISPATCH_TO_CUDA(
       "recat_embedding_grad_output_mixed_D",
-      at::fbgemm::recat_embedding_grad_output_mixed_D_cuda);
+      fbgemm::recat_embedding_grad_output_mixed_D_cuda);
   DISPATCH_TO_CUDA(
-      "recat_embedding_grad_output", at::fbgemm::recat_embedding_grad_output_cuda);
+      "recat_embedding_grad_output", fbgemm::recat_embedding_grad_output_cuda);
 }

--- a/fbgemm_gpu/src/merge_pooled_embeddings_cpu.cpp
+++ b/fbgemm_gpu/src/merge_pooled_embeddings_cpu.cpp
@@ -9,12 +9,10 @@
 #include <c10/core/TensorOptions.h>
 #include <torch/library.h>
 
-using namespace at;
-
-namespace at {
+namespace fbgemm {
 
 at::Tensor merge_pooled_embeddings_cpu(
-    std::vector<Tensor> pooled_embeddings,
+    std::vector<at::Tensor> pooled_embeddings,
     int64_t batch_size,
     at::Device target_device) {
   auto cat_host_0 = [&](const std::vector<at::Tensor>& ts) {
@@ -34,8 +32,8 @@ at::Tensor merge_pooled_embeddings_cpu(
   return cat_host_0(pooled_embeddings);
 }
 
-} // namespace at
+} // namespace fbgemm
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
-  m.impl("merge_pooled_embeddings", at::merge_pooled_embeddings_cpu);
+  m.impl("merge_pooled_embeddings", fbgemm::merge_pooled_embeddings_cpu);
 }

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops.cu
@@ -5,15 +5,17 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
-#include <fbgemm_gpu/permute_pooled_embedding_ops.cuh>
+#include "fbgemm_gpu/fbgemm_cuda_utils.cuh"
+#include "fbgemm_gpu/layout_transform_ops.cuh"
+#include "fbgemm_gpu/permute_pooled_embedding_ops.h"
 
-namespace at {
-Tensor permute_pooled_embs(
-    const Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
-    const Tensor& offset_dim_list,
-    const Tensor& permute_list,
-    const Tensor& inv_offset_dim_list,
-    const Tensor& inv_permute_list) {
+namespace fbgemm {
+at::Tensor permute_pooled_embs_gpu(
+    const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
+    const at::Tensor& offset_dim_list,
+    const at::Tensor& permute_list,
+    const at::Tensor& inv_offset_dim_list,
+    const at::Tensor& inv_permute_list) {
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(pooled_embs.get_device());
   // We couldn't pass the "pooled_embs.is_contiguous()" check in the backward
@@ -29,7 +31,7 @@ Tensor permute_pooled_embs(
   TORCH_CHECK(pooled_embs_contiguous.device() == inv_offset_dim_list.device());
   TORCH_CHECK(offset_dim_list.numel() == permute_list.numel() + 1);
   TORCH_CHECK(offset_dim_list.numel() == inv_offset_dim_list.numel());
-  Tensor permuted_pooled_embs = at::empty_like(pooled_embs_contiguous);
+  at::Tensor permuted_pooled_embs = at::empty_like(pooled_embs_contiguous);
 
   // This kernel is moving D elements per warp.
   // We are launching ( div_round_up(T, warp_per_block), B ) blocks.
@@ -61,4 +63,4 @@ Tensor permute_pooled_embs(
 
   return permuted_pooled_embs;
 }
-} // namespace at
+} // namespace fbgemm

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops_gpu.cpp
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops_gpu.cpp
@@ -17,14 +17,14 @@
 #include <type_traits>
 #include <vector>
 
-namespace at {
+namespace fbgemm {
 
-Tensor permute_pooled_embs_cpu(
-    const Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
-    const Tensor& offset_dim_list,
-    const Tensor& permute_list,
-    const Tensor& inv_offset_dim_list,
-    const Tensor& inv_permute_list) {
+at::Tensor permute_pooled_embs_cpu(
+    const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
+    const at::Tensor& offset_dim_list,
+    const at::Tensor& permute_list,
+    const at::Tensor& inv_offset_dim_list,
+    const at::Tensor& inv_permute_list) {
   TORCH_CHECK(
       offset_dim_list.scalar_type() == at::ScalarType::Long,
       "offset_dim_list needs to have long/int64 type")
@@ -39,7 +39,7 @@ Tensor permute_pooled_embs_cpu(
     dims.push_back(offset_dim_list[i].item<int64_t>());
   }
   auto ts = pooled_embs.tensor_split(dims, 1);
-  std::vector<Tensor> permuted_ts;
+  std::vector<at::Tensor> permuted_ts;
   permuted_ts.reserve(n);
   for (const auto i : c10::irange(n)) {
     permuted_ts.push_back(ts[permute[i]]);
@@ -52,22 +52,22 @@ using torch::autograd::Variable;
 using torch::autograd::variable_list;
 
 template <torch::autograd::Variable (*permute_pooled_embs_op)(
-    const Tensor&, // [B_local][Sum_T_global(D)]
-    const Tensor&,
-    const Tensor&,
-    const Tensor&,
-    const Tensor&)>
+    const at::Tensor&, // [B_local][Sum_T_global(D)]
+    const at::Tensor&,
+    const at::Tensor&,
+    const at::Tensor&,
+    const at::Tensor&)>
 class PermutePooledEmbsFunction
     : public torch::autograd::Function<
           PermutePooledEmbsFunction<permute_pooled_embs_op>> {
  public:
   static Variable forward(
       AutogradContext* ctx,
-      const Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
-      const Tensor& offset_dim_list,
-      const Tensor& permute_list,
-      const Tensor& inv_offset_dim_list,
-      const Tensor& inv_permute_list) {
+      const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
+      const at::Tensor& offset_dim_list,
+      const at::Tensor& permute_list,
+      const at::Tensor& inv_offset_dim_list,
+      const at::Tensor& inv_permute_list) {
     ctx->saved_data["offset_dim_list"] = offset_dim_list;
     ctx->saved_data["permute_list"] = permute_list;
     ctx->saved_data["inv_offset_dim_list"] = inv_offset_dim_list;
@@ -105,13 +105,13 @@ class PermutePooledEmbsFunction
   }
 };
 
-Tensor permute_pooled_embs_auto_grad_gpu(
-    const Tensor& pooled_embs,
-    const Tensor& offset_dim_list,
-    const Tensor& permute_list,
-    const Tensor& inv_offset_dim_list,
-    const Tensor& inv_permute_list) {
-  return PermutePooledEmbsFunction<permute_pooled_embs>::apply(
+at::Tensor permute_pooled_embs_auto_grad_gpu(
+    const at::Tensor& pooled_embs,
+    const at::Tensor& offset_dim_list,
+    const at::Tensor& permute_list,
+    const at::Tensor& inv_offset_dim_list,
+    const at::Tensor& inv_permute_list) {
+  return PermutePooledEmbsFunction<permute_pooled_embs_gpu>::apply(
       pooled_embs,
       offset_dim_list,
       permute_list,
@@ -119,12 +119,12 @@ Tensor permute_pooled_embs_auto_grad_gpu(
       inv_permute_list);
 }
 
-Tensor permute_pooled_embs_auto_grad_cpu(
-    const Tensor& pooled_embs,
-    const Tensor& offset_dim_list,
-    const Tensor& permute_list,
-    const Tensor& inv_offset_dim_list,
-    const Tensor& inv_permute_list) {
+at::Tensor permute_pooled_embs_auto_grad_cpu(
+    const at::Tensor& pooled_embs,
+    const at::Tensor& offset_dim_list,
+    const at::Tensor& permute_list,
+    const at::Tensor& inv_offset_dim_list,
+    const at::Tensor& inv_permute_list) {
   return PermutePooledEmbsFunction<permute_pooled_embs_cpu>::apply(
       pooled_embs,
       offset_dim_list,
@@ -132,7 +132,7 @@ Tensor permute_pooled_embs_auto_grad_cpu(
       inv_offset_dim_list,
       inv_permute_list);
 }
-} // namespace at
+} // namespace fbgemm
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
@@ -140,17 +140,17 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.impl(
       "permute_pooled_embs",
       torch::dispatch(
-          c10::DispatchKey::CUDA, TORCH_FN(at::permute_pooled_embs)));
+          c10::DispatchKey::CUDA, TORCH_FN(fbgemm::permute_pooled_embs_gpu)));
   m.def(
       "permute_pooled_embs_auto_grad(Tensor pooled_embs, Tensor offset_dim_list, Tensor permute_list, Tensor inv_offset_dim_list, Tensor inv_permute_list) -> Tensor");
   m.impl(
       "permute_pooled_embs_auto_grad",
       torch::dispatch(
           c10::DispatchKey::CPU,
-          TORCH_FN(at::permute_pooled_embs_auto_grad_cpu)));
+          TORCH_FN(fbgemm::permute_pooled_embs_auto_grad_cpu)));
   m.impl(
       "permute_pooled_embs_auto_grad",
       torch::dispatch(
           c10::DispatchKey::CUDA,
-          TORCH_FN(at::permute_pooled_embs_auto_grad_gpu)));
+          TORCH_FN(fbgemm::permute_pooled_embs_auto_grad_gpu)));
 }

--- a/fbgemm_gpu/src/quantize_ops_cpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops_cpu.cpp
@@ -10,7 +10,7 @@
 #include "fbgemm/QuantUtils.h"
 #include "fbgemm_gpu/sparse_ops_utils.h"
 
-namespace at {
+namespace fbgemm {
 
 at::Tensor& _float_to_fused8bitrowwise_cpu_out(
     at::Tensor& output,
@@ -139,7 +139,7 @@ at::Tensor _fused8bitrowwise_to_float_cpu(const at::Tensor& input) {
 
 
 } // namespace
-} // namespace at
+} // namespace fbgemm
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def("FloatToFused8BitRowwiseQuantized(Tensor t) -> Tensor");
@@ -155,15 +155,15 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
-  m.impl("FloatToFused8BitRowwiseQuantized", at::_float_to_fused8bitrowwise_cpu);
+  m.impl("FloatToFused8BitRowwiseQuantized", fbgemm::_float_to_fused8bitrowwise_cpu);
   m.impl(
-      "FloatToFused8BitRowwiseQuantizedOut", at::_float_to_fused8bitrowwise_cpu_out);
+      "FloatToFused8BitRowwiseQuantizedOut", fbgemm::_float_to_fused8bitrowwise_cpu_out);
   m.impl(
-      "Fused8BitRowwiseQuantizedToFloat", at::_fused8bitrowwise_to_float_cpu);
+      "Fused8BitRowwiseQuantizedToFloat", fbgemm::_fused8bitrowwise_to_float_cpu);
   m.impl(
-      "Fused8BitRowwiseQuantizedToFloatOut", at::_fused8bitrowwise_to_float_cpu_out);
+      "Fused8BitRowwiseQuantizedToFloatOut", fbgemm::_fused8bitrowwise_to_float_cpu_out);
   m.impl(
-      "FloatToFusedNBitRowwiseQuantizedSBHalf", at::_float_to_fusednbitrowwise_cpu);
+      "FloatToFusedNBitRowwiseQuantizedSBHalf", fbgemm::_float_to_fusednbitrowwise_cpu);
   m.impl(
-      "FusedNBitRowwiseQuantizedSBHalfToFloat", at::_fusednbitrowwise_to_float_cpu);
+      "FusedNBitRowwiseQuantizedSBHalfToFloat", fbgemm::_fusednbitrowwise_to_float_cpu);
 }

--- a/fbgemm_gpu/src/quantize_ops_gpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops_gpu.cpp
@@ -12,11 +12,11 @@
 
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   DISPATCH_TO_CUDA(
-      "FloatToFused8BitRowwiseQuantized", at::fbgemm::_float_to_fused8bitrowwise_gpu);
+      "FloatToFused8BitRowwiseQuantized", fbgemm::_float_to_fused8bitrowwise_gpu);
   DISPATCH_TO_CUDA(
-      "Fused8BitRowwiseQuantizedToFloat", at::fbgemm::_fused8bitrowwise_to_float_gpu);
+      "Fused8BitRowwiseQuantizedToFloat", fbgemm::_fused8bitrowwise_to_float_gpu);
   DISPATCH_TO_CUDA(
-      "FloatToFusedNBitRowwiseQuantizedSBHalf", at::fbgemm::_float_to_fusednbitrowwise_gpu);
+      "FloatToFusedNBitRowwiseQuantizedSBHalf", fbgemm::_float_to_fusednbitrowwise_gpu);
   DISPATCH_TO_CUDA(
-      "FusedNBitRowwiseQuantizedSBHalfToFloat", at::fbgemm::_fusednbitrowwise_to_float_gpu);
+      "FusedNBitRowwiseQuantizedSBHalfToFloat", fbgemm::_fusednbitrowwise_to_float_gpu);
 }

--- a/fbgemm_gpu/src/sparse_ops_gpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_gpu.cpp
@@ -13,17 +13,17 @@
 #include <torch/library.h>
 
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
-  DISPATCH_TO_CUDA("permute_sparse_data", at::fbgemm::permute_sparse_data_cuda);
+  DISPATCH_TO_CUDA("permute_sparse_data", fbgemm::permute_sparse_data_cuda);
   DISPATCH_TO_CUDA(
       "block_bucketize_sparse_features",
-      at::fbgemm::block_bucketize_sparse_features_cuda);
+      fbgemm::block_bucketize_sparse_features_cuda);
   DISPATCH_TO_CUDA(
-      "asynchronous_exclusive_cumsum", at::fbgemm::asynchronous_exclusive_cumsum_gpu);
+      "asynchronous_exclusive_cumsum", fbgemm::asynchronous_exclusive_cumsum_gpu);
   DISPATCH_TO_CUDA(
-      "asynchronous_complete_cumsum", at::fbgemm::asynchronous_complete_cumsum_gpu);
+      "asynchronous_complete_cumsum", fbgemm::asynchronous_complete_cumsum_gpu);
   DISPATCH_TO_CUDA(
-      "asynchronous_inclusive_cumsum", at::fbgemm::asynchronous_inclusive_cumsum_gpu);
-  DISPATCH_TO_CUDA("reorder_batched_ad_lengths", at::fbgemm::reorder_batched_ad_lengths_gpu);
-  DISPATCH_TO_CUDA("reorder_batched_ad_indices", at::fbgemm::reorder_batched_ad_indices_gpu);
-  DISPATCH_TO_CUDA("offsets_range", at::fbgemm::offsets_range_cuda);
+      "asynchronous_inclusive_cumsum", fbgemm::asynchronous_inclusive_cumsum_gpu);
+  DISPATCH_TO_CUDA("reorder_batched_ad_lengths", fbgemm::reorder_batched_ad_lengths_gpu);
+  DISPATCH_TO_CUDA("reorder_batched_ad_indices", fbgemm::reorder_batched_ad_indices_gpu);
+  DISPATCH_TO_CUDA("offsets_range", fbgemm::offsets_range_cuda);
 }


### PR DESCRIPTION
Summary:
Remove duplicated ops from caffe2/torch/fb/sparsenn that have been moved to fbgemm_gpu.

Removed operators:
block_bucketize_sparse_features
asynchronous_exclusive_cumsum
asynchronous_inclusive_cumsum
asynchronous_complete_cumsum

Maintain binary compatibility with exising torch/fb/sparesenn python methods by wrapping affected operators with old name in addition to new name.  Moved operators may be accessed via the fb or fbgemm namespace.

Put all fbgemm_gpu ops in fbgemm namespace.
Tidied up usage of at (ATen) namespace in fbgemm_gpu.

Reviewed By: jianyuh

Differential Revision: D31587426

