### PR TITLE
Early return when B==0 in int_nbit_split_embedding_codegen_forward

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
@@ -169,7 +169,7 @@ Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
     TORCH_CHECK(T > 0);
     // offsets = [B x T  + 1]
     int32_t B = (offsets.size(0) - 1) / T;
-    TORCH_CHECK(B > 0);
+    TORCH_CHECK(B >= 0);
     TORCH_CHECK(total_D > 0);
     bool pined_memory = false;
 #ifdef FBGEMM_GPU_WITH_CUDA
@@ -179,6 +179,9 @@ Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
 #endif
 
     auto output = empty({B, total_D}, dev_weights.options().dtype(at::kHalf).pinned_memory(pined_memory));
+    if (B == 0) {
+        return output;
+    }
 
     const int32_t* weights_placements_ptr = weights_placements.data_ptr<int32_t>();
     const uint8_t* weights_acc;

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_split_template.cu
@@ -1244,12 +1244,16 @@ at::Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cuda(
     TORCH_CHECK(T > 0);
     // offsets = [B x T  + 1]
     int32_t B = (offsets.size(0) - 1) / T;
-    TORCH_CHECK(B > 0);
+    TORCH_CHECK(B >= 0);
 
     TORCH_CHECK(total_D > 0);
     TORCH_CHECK(max_int2_D == 0);
 
     auto output = at::empty({B, total_D}, dev_weights.options().dtype(at::kHalf));
+    if (B == 0) {
+      return output;
+    }
+
     using index_t = int32_t;
 
     // launch 4-bit kernel

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -2101,7 +2101,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 for (E, D, M, W_TY) in zip(Es, Ds, managed, weights_ty_list)
             ],
             pooling_mode=pooling_mode,
-            index_remapping=[torch.arange(E, dtype=torch.int32) for E in Es],
+            index_remapping=[torch.arange(E, dtype=torch.int32) for E in Es] if B != 0 else None,
             device="cpu" if use_cpu else torch.cuda.current_device(),
             use_array_for_index_remapping=use_array_for_index_remapping,
         )
@@ -2219,6 +2219,10 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 else cc(indices.int(), offsets.int(), xw.contiguous().view(-1).cpu())
             )
 
+        if B == 0:
+            self.assertEqual(fc2.size(), (0, cc.total_D))
+            return
+
         fs = (
             [b_indices(b, x, use_cpu=use_cpu) for (b, x) in zip(bs, xs)]
             if not weighted
@@ -2239,7 +2243,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
     @given(
         T=st.integers(min_value=1, max_value=50),
         D=st.integers(min_value=2, max_value=1024 - 8),
-        B=st.integers(min_value=1, max_value=128),
+        B=st.integers(min_value=0, max_value=128),
         log_E=st.integers(min_value=2, max_value=4),
         L=st.integers(min_value=0, max_value=32),
         weighted=st.booleans(),
@@ -2300,7 +2304,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
     @given(
         T=st.integers(min_value=1, max_value=50),
         D=st.integers(min_value=2, max_value=1024 - 8),
-        B=st.integers(min_value=1, max_value=128),
+        B=st.integers(min_value=0, max_value=128),
         log_E=st.integers(min_value=2, max_value=4),
         L=st.integers(min_value=0, max_value=32),
         weighted=st.booleans(),


### PR DESCRIPTION
Summary: Allow `B` to be 0 and in this case just return `output` directly.

Reviewed By: jianyuh

Differential Revision: D31813597

