### PR TITLE
Reduce run-times of fbgemm_gpu unit tests.

### DIFF
--- a/fbgemm_gpu/test/layout_transform_ops_test.py
+++ b/fbgemm_gpu/test/layout_transform_ops_test.py
@@ -11,13 +11,15 @@ import unittest
 import hypothesis.strategies as st
 
 import torch
-from hypothesis import Verbosity, given, settings
+from hypothesis import given, settings
 
 try:
     torch.ops.load_library("fbgemm_gpu_py.so")
 except Exception:
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
+
+MAX_EXAMPLES = 15
 
 class LayoutTransformOpsTest(unittest.TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "Skip when CUDA is not available")
@@ -28,7 +30,7 @@ class LayoutTransformOpsTest(unittest.TestCase):
         D=st.integers(min_value=2, max_value=20),
         W=st.integers(min_value=1, max_value=20),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(max_examples=MAX_EXAMPLES, deadline=None)
     def test_recat_embedding_grad_output(self, B: int, T: int, D: int, W: int) -> None:
         num_features_per_rank = np.random.randint(low=1, high=20, size=(W,)).tolist()
         grad_output = torch.randn(B, sum(num_features_per_rank), D).float().cuda()
@@ -52,7 +54,7 @@ class LayoutTransformOpsTest(unittest.TestCase):
         W=st.integers(min_value=1, max_value=20),
         cuda=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(max_examples=MAX_EXAMPLES, deadline=None)
     def test_recat_embedding_grad_output_mixed_D(self, B: int, W: int, cuda: bool) -> None:
         num_features_per_rank = np.random.randint(low=1, high=20, size=(W,)).tolist()
         global_T = sum(num_features_per_rank)
@@ -90,7 +92,7 @@ class LayoutTransformOpsTest(unittest.TestCase):
         B=st.integers(min_value=1, max_value=20),
         W=st.integers(min_value=1, max_value=20),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(max_examples=MAX_EXAMPLES, deadline=None)
     def test_recat_embedding_grad_output_mixed_D_batch(self, B: int, W: int) -> None:
         num_features_per_rank = np.random.randint(low=1, high=20, size=(W,)).tolist()
         global_T = sum(num_features_per_rank)


### PR DESCRIPTION
Summary: Attempt to reduce worst-case run-times of occasionally long running unit tests.

Reviewed By: jianyuh

Differential Revision: D31998929

