### PR TITLE
Move batched_unary_embeddings from hpc/ops to fbgemm_gpu.

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/batched_unary_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/batched_unary_embeddings_ops.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+# pyre-unsafe
+
+from math import sqrt
+from typing import List
+
+import torch
+
+try:
+    torch.ops.load_library("fbgemm_gpu_py.so")
+except Exception:
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
+
+def wrap_weight_to_parameter(weights: List[torch.Tensor]) -> List[torch.Tensor]:
+    for i, v in enumerate(weights):
+        if not isinstance(v, torch.nn.Parameter):
+            weights[i] = torch.nn.Parameter(v)
+    return weights
+
+
+class BatchedUnaryEmbeddingBag(torch.nn.Module):
+    def __init__(self, num_tasks: int, hash_sizes: List[int], long_index: bool = False):
+        super().__init__()
+        self.num_tasks = num_tasks
+        self.hash_sizes = hash_sizes
+        # [N][sum(E)][1]
+        embedding_data = torch.randn(size=(num_tasks, sum(self.hash_sizes), 1))
+        self.weight = torch.nn.Parameter(embedding_data)
+        index_dtype = torch.int64 if long_index else torch.int32
+        table_offsets_tensor = torch.cat(
+            [
+                torch.tensor([0], dtype=index_dtype),
+                torch.cumsum(
+                    torch.tensor(hash_sizes),
+                    dim=0,
+                    dtype=index_dtype,
+                ),
+            ]
+        )
+        self.register_buffer("table_offsets_tensor", table_offsets_tensor)
+        self.init_parameters()
+
+    def forward(self, offsets: torch.Tensor, input: torch.Tensor):
+        # output is [N][B][T]
+        return torch.ops.fbgemm.batched_unary_embeddings(
+            self.weight,
+            self.table_offsets_tensor,
+            offsets,
+            input,
+        )
+
+    @torch.jit.export
+    def split_embedding_weights(self):
+        embedding_weights = []
+        for n in range(self.num_tasks):
+            for t in range(len(self.hash_sizes)):
+                embedding_weights.append(
+                    self.weight.detach()[
+                        n,
+                        self.table_offsets_tensor[t] : self.table_offsets_tensor[t + 1],
+                        :,
+                    ]
+                )
+        return embedding_weights
+
+    @torch.jit.export
+    def init_parameters(self):
+        for (num_emb, param) in zip(
+            self.hash_sizes * self.num_tasks,
+            wrap_weight_to_parameter(self.split_embedding_weights())
+        ):
+            assert param.shape == (num_emb, 1)
+            param.data.uniform_(-sqrt(1 / num_emb), sqrt(1 / num_emb))

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -127,4 +127,18 @@ at::Tensor recat_embedding_grad_output_mixed_D_batch_cuda(
 at::Tensor recat_embedding_grad_output_mixed_D_cpu(
     const at::Tensor& grad_output, // [B_local][Sum_T_global(D)]
     const std::vector<int64_t>& dim_sum_per_rank);
+
+at::Tensor batched_unary_embeddings_forward_cuda(
+    const at::Tensor& weight,
+    const at::Tensor& table_offsets,
+    const at::Tensor& offsets,
+    const at::Tensor& indices);
+
+at::Tensor batched_unary_embeddings_backward_cuda(
+    const at::Tensor& grad_output,
+    const at::Tensor& weight,
+    const at::Tensor& table_offsets,
+    const at::Tensor& offsets,
+    const at::Tensor& indices);
+
 } // namespace fbgemm

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
@@ -95,6 +95,13 @@ inline bool torch_tensor_on_cuda_gpu_check(
       "Found ",                            \
       (ten).ndimension())
 
+#define TENSOR_CONTIGUOUS(x) \
+  TORCH_CHECK((x).is_contiguous(), #x " must be contiguous")
+
+#define TENSOR_CONTIGUOUS_AND_ON_CUDA_GPU(x) \
+  TENSOR_ON_CUDA_GPU(x);                     \
+  TENSOR_CONTIGUOUS(x)
+
 /// Determine an appropriate CUDA block count along the x axis
 ///
 /// When launching CUDA kernels the number of blocks B is often calculated

--- a/fbgemm_gpu/src/sparse_ops_gpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_gpu.cpp
@@ -11,6 +11,49 @@
 #include <ATen/ATen.h>
 #include <ATen/core/op_registration/op_registration.h>
 #include <torch/library.h>
+#include "autograd/custom_function.h"
+
+namespace fbgemm {
+
+class LookupFunctionBatchedUnaryEmbeddingOp : public torch::autograd::Function<LookupFunctionBatchedUnaryEmbeddingOp> {
+ public:
+  static torch::autograd::variable_list forward(
+      torch::autograd::AutogradContext* ctx,
+      const at::Tensor& weight,
+      const at::Tensor& table_offsets,
+      const at::Tensor& offsets,
+      const at::Tensor& indices) {
+    ctx->save_for_backward({weight, table_offsets, offsets, indices});
+    auto output = fbgemm::batched_unary_embeddings_forward_cuda(
+        weight, table_offsets, offsets, indices);
+    return {output};
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext* ctx,
+      torch::autograd::variable_list grad_outputs) {
+    const auto saved = ctx->get_saved_variables();
+    auto savedItr = std::begin(saved);
+    auto weight = *savedItr++;
+    auto table_offsets = *savedItr++;
+    auto offsets = *savedItr++;
+    auto indices = *savedItr++;
+    TORCH_CHECK(grad_outputs.size() == 1);
+    auto grad_weight = fbgemm::batched_unary_embeddings_backward_cuda(
+        grad_outputs[0], weight, table_offsets, offsets, indices);
+    return {grad_weight, at::Tensor(), at::Tensor(), at::Tensor()};
+  }
+};
+
+at::Tensor lookup_batched_unary_embedding_function(
+    const at::Tensor& weight,
+    const at::Tensor& table_offsets,
+    const at::Tensor& offsets,
+    const at::Tensor& indices) {
+  return LookupFunctionBatchedUnaryEmbeddingOp::apply(weight, table_offsets, offsets, indices)[0];
+}
+
+}
 
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   DISPATCH_TO_CUDA("permute_sparse_data", fbgemm::permute_sparse_data_cuda);
@@ -26,4 +69,5 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   DISPATCH_TO_CUDA("reorder_batched_ad_lengths", fbgemm::reorder_batched_ad_lengths_gpu);
   DISPATCH_TO_CUDA("reorder_batched_ad_indices", fbgemm::reorder_batched_ad_indices_gpu);
   DISPATCH_TO_CUDA("offsets_range", fbgemm::offsets_range_cuda);
+  DISPATCH_TO_CUDA("batched_unary_embeddings", fbgemm::lookup_batched_unary_embedding_function);
 }

--- a/fbgemm_gpu/test/batched_unary_embeddings_test.py
+++ b/fbgemm_gpu/test/batched_unary_embeddings_test.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+
+# pyre-unsafe
+
+import unittest
+from math import sqrt
+from typing import List, Tuple
+
+import numpy as np
+import torch
+import deeplearning.fbgemm.fbgemm_gpu.fbgemm_gpu.batched_unary_embeddings_ops as batched_unary_embeddings_ops
+
+try:
+    torch.ops.load_library("fbgemm_gpu_py.so")
+except Exception:
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
+
+class TableBatchedEmbeddingsTest(unittest.TestCase):
+    class RefEmb(torch.nn.Module):
+        def __init__(self, num_tasks: int, hash_sizes: List[int]) -> None:
+            super().__init__()
+            self.num_tasks = num_tasks
+            self.hash_sizes = hash_sizes
+            self.emb_modules = torch.nn.ModuleList()
+            for _ in range(num_tasks):
+                for h in self.hash_sizes:
+                    emb = torch.nn.EmbeddingBag(
+                        num_embeddings=h,
+                        embedding_dim=1,
+                        mode="sum",
+                        sparse=False,
+                        include_last_offset=True,
+                    )
+                    emb.weight = torch.nn.Parameter(
+                        torch.empty([h, 1]).uniform_(-sqrt(1 / h), sqrt(1 / h))
+                    )
+                    self.emb_modules.append(emb)
+
+        def forward(
+            self, offsets: List[torch.Tensor], indices: List[torch.Tensor]
+        ) -> torch.Tensor:
+            tt_list = []
+            for n in range(self.num_tasks):
+                t_list = []
+                for i in range(len(self.hash_sizes)):
+                    t = self.emb_modules[n * len(self.hash_sizes) + i](
+                        offsets=offsets[i].long(), input=indices[i].long()
+                    )
+                    t_list.append(t)
+                tt = torch.cat(t_list, dim=1)
+                tt_list.append(tt)
+            return torch.cat(tt_list).view(self.num_tasks, -1, len(self.hash_sizes))
+
+    def _generate_unary_features(
+        self, batch_size: int, num_embeddings: int
+    ) -> Tuple[List, List, List]:
+        lengths = []
+        offsets = []
+        indices = []
+        offset = 0
+        for _ in range(batch_size):
+            n_indices = 1
+            indices += np.round(
+                np.random.random(n_indices) * (num_embeddings - 1)
+            ).tolist()
+            offsets.append(offset)
+            offset += 1
+            lengths.append(n_indices)
+        offsets.append(offset)
+        return (lengths, offsets, indices)
+
+    def _test_main(self, gpu_infer: bool):
+        if gpu_infer:
+            device = torch.device("cuda:0")
+            torch.cuda.set_device(device)
+        else:
+            device = torch.device("cpu")
+        batch_size = 128
+        hash_sizes = [100, 200]
+        num_tasks = 3
+        # generate unary features
+        lengths = []
+        offsets = []
+        indices = []
+        for h in hash_sizes:
+            l, o, i = self._generate_unary_features(batch_size, h)
+            lengths.append(torch.IntTensor(l).to(device))
+            offsets.append(torch.IntTensor(o).to(device))
+            indices.append(torch.IntTensor(i).to(device))
+        lengths_tensor = torch.cat(lengths)
+        indices_tensor = torch.cat(indices)
+        offsets_tensor = torch.zeros(
+            lengths_tensor.numel() + 1,
+            dtype=lengths_tensor.dtype,
+            device=lengths_tensor.device,
+        )
+        offsets_tensor[1:] = torch.ops.fbgemm.asynchronous_inclusive_cumsum(
+            lengths_tensor.view(-1)
+        )
+        # forward with int_32
+        ref_emb = self.RefEmb(num_tasks, hash_sizes).to(device)
+        unary_emb = batched_unary_embeddings_ops.BatchedUnaryEmbeddingBag(
+            num_tasks, hash_sizes
+        ).to(device)
+        for i, param in enumerate(unary_emb.split_embedding_weights()):
+            param.detach().copy_(ref_emb.emb_modules[i].weight)
+        output_ref = ref_emb(offsets, indices)
+        output = unary_emb(offsets_tensor, indices_tensor)
+        torch.testing.assert_allclose(output_ref, output)
+
+        # forward with int_64
+        ref_emb = self.RefEmb(num_tasks, hash_sizes).to(device)
+        unary_emb = batched_unary_embeddings_ops.BatchedUnaryEmbeddingBag(
+            num_tasks=num_tasks, hash_sizes=hash_sizes, long_index=True
+        ).to(device)
+        for i, param in enumerate(unary_emb.split_embedding_weights()):
+            param.detach().copy_(ref_emb.emb_modules[i].weight)
+        output_ref = ref_emb(offsets, indices)
+        output = unary_emb(offsets_tensor.long(), indices_tensor.long())
+        torch.testing.assert_allclose(output_ref, output)
+
+        # No implementation for CPU backprop yet
+        if not gpu_infer:
+            return
+
+        d_output = (
+            torch.randn([num_tasks, batch_size, len(hash_sizes)]).to(device) * 0.1
+        )
+        output_ref.backward(d_output)
+        output.backward(d_output)
+        d_weight_ref = []
+        for emb in ref_emb.emb_modules:
+            d_weight_ref.append(emb.weight.grad)
+        d_weight_ref = torch.cat(d_weight_ref).view(num_tasks, sum(hash_sizes), -1)
+        d_weight = unary_emb.weight.grad
+        torch.testing.assert_allclose(d_weight_ref, d_weight)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "Skip when CUDA is not available")
+    def test_gpu(self):
+        self._test_main(gpu_infer=True)
+
+    def test_cpu(self):
+        self._test_main(gpu_infer=False)


### PR DESCRIPTION
Summary:
Move the whole batched unary embedding op
   (https://www.internalfb.com/code/fbsource/fbcode/hpc/ops/batched_unary_embeddings_ops.py)
   and its related CPU/GPU kernels into FBGEMM_GPU

Reviewed By: jianyuh

Differential Revision: D32008835

