### PR TITLE
Add output_dtype support for infer TBE

### DIFF
--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -917,6 +917,7 @@ def cpu(  # noqa C901
 @click.option("--iters", default=100)
 @click.option("--runs-of-iters", default=5)
 @click.option("--warmup-runs", default=2)
+@click.option("--output-dtype", type=SparseType, default=SparseType.FP16)
 def nbit_device(  # noqa C901
     alpha: float,
     bag_size: int,
@@ -940,6 +941,7 @@ def nbit_device(  # noqa C901
     iters: int,
     runs_of_iters: int,
     warmup_runs: int,
+    output_dtype: SparseType,
 ) -> None:
     np.random.seed(42)
     torch.manual_seed(42)
@@ -987,6 +989,7 @@ def nbit_device(  # noqa C901
         index_remapping=index_remapping,
         load_factor=load_factor,
         use_array_for_index_remapping=use_array_for_index_remapping,
+        output_dtype=output_dtype,
     ).cuda()
     emb.fill_random_weights()
 

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
@@ -28,6 +28,7 @@ Tensor int_nbit_split_embedding_codegen_forward_unweighted_cuda(
     Tensor indices,
     Tensor offsets,
     int64_t pooling_mode,
+    int64_t output_dtype,
     int64_t unused);
 
 Tensor int_nbit_split_embedding_codegen_forward_weighted_cuda(
@@ -47,6 +48,7 @@ Tensor int_nbit_split_embedding_codegen_forward_weighted_cuda(
     Tensor offsets,
     int64_t pooling_mode,
     Tensor indice_weights,
+    int64_t output_dtype,
     int64_t unused);
 
 Tensor int_nbit_split_embedding_codegen_lookup_function(
@@ -65,7 +67,8 @@ Tensor int_nbit_split_embedding_codegen_lookup_function(
     Tensor indices,
     Tensor offsets,
     int64_t pooling_mode,
-    c10::optional<Tensor> indice_weights) {
+    c10::optional<Tensor> indice_weights,
+    int64_t output_dtype) {
   if (!indice_weights) {
     return int_nbit_split_embedding_codegen_forward_unweighted_cuda(
         dev_weights,
@@ -83,6 +86,7 @@ Tensor int_nbit_split_embedding_codegen_lookup_function(
         indices,
         offsets,
         pooling_mode,
+        output_dtype,
         0);
   }
   return int_nbit_split_embedding_codegen_forward_weighted_cuda(
@@ -102,6 +106,7 @@ Tensor int_nbit_split_embedding_codegen_lookup_function(
       offsets,
       pooling_mode,
       *indice_weights,
+      output_dtype,
       0);
 }
 
@@ -119,7 +124,7 @@ Tensor pruned_array_lookup_cuda(
 
 TORCH_LIBRARY_FRAGMENT(fb, m) {
   m.def(
-      "int_nbit_split_embedding_codegen_lookup_function(Tensor dev_weights, Tensor uvm_weights, Tensor weights_placements, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, int total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, int max_float32_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights) -> Tensor");
+      "int_nbit_split_embedding_codegen_lookup_function(Tensor dev_weights, Tensor uvm_weights, Tensor weights_placements, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, int total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, int max_float32_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, int output_dtype=1) -> Tensor");
   m.impl(
       "int_nbit_split_embedding_codegen_lookup_function",
       torch::dispatch(

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
@@ -30,6 +30,7 @@ Tensor int_nbit_split_embedding_codegen_forward_unweighted_cpu(
     Tensor indices,
     Tensor offsets,
     int64_t pooling_mode,
+    int64_t output_dtype,
     int64_t unused);
 
 Tensor int_nbit_split_embedding_codegen_forward_weighted_cpu(
@@ -44,6 +45,7 @@ Tensor int_nbit_split_embedding_codegen_forward_weighted_cpu(
     Tensor offsets,
     int64_t pooling_mode,
     Tensor indice_weights,
+    int64_t output_dtype,
     int64_t unused);
 
 Tensor int_nbit_split_embedding_codegen_lookup_function_cpu(
@@ -62,7 +64,8 @@ Tensor int_nbit_split_embedding_codegen_lookup_function_cpu(
     Tensor indices,
     Tensor offsets,
     int64_t pooling_mode,
-    c10::optional<Tensor> indice_weights) {
+    c10::optional<Tensor> indice_weights,
+    int64_t output_dtype) {
   if (!indice_weights) {
     return int_nbit_split_embedding_codegen_forward_unweighted_cpu(
         dev_weights,
@@ -75,6 +78,7 @@ Tensor int_nbit_split_embedding_codegen_lookup_function_cpu(
         indices,
         offsets,
         pooling_mode,
+        output_dtype,
         0);
   }
   return int_nbit_split_embedding_codegen_forward_weighted_cpu(
@@ -89,6 +93,7 @@ Tensor int_nbit_split_embedding_codegen_lookup_function_cpu(
       offsets,
       pooling_mode,
       *indice_weights,
+      output_dtype,
       0);
 }
 

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -1567,6 +1567,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         weight_lists: Optional[List[Tuple[Tensor, Tensor]]] = None,
         load_factor: float = 0.5,
         use_array_for_index_remapping: bool = True,
+        output_dtype: SparseType = SparseType.FP16,
     ) -> None:  # noqa C901  # tuple of (rows, dims,)
         super(IntNBitTableBatchedEmbeddingBagsCodegen, self).__init__()
 
@@ -1584,6 +1585,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.pooling_mode = pooling_mode
         self.bounds_check_mode_int: int = bounds_check_mode.value
         self.embedding_specs = embedding_specs
+        self.output_dtype: int = output_dtype.as_int()
         # (feature_names, rows, dims, weights_tys, locations) = zip(*embedding_specs)
         # Pyre workaround
         self.feature_names: List[str] = [e[0] for e in embedding_specs]
@@ -1781,6 +1783,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
             max_int8_D=self.max_int8_D,
             max_float16_D=self.max_float16_D,
             max_float32_D=self.max_float32_D,
+            output_dtype=self.output_dtype,
             indices=indices,
             offsets=offsets,
             pooling_mode=self.pooling_mode,

--- a/fbgemm_gpu/include/fbgemm_gpu/dispatch_macros.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/dispatch_macros.h
@@ -96,3 +96,25 @@
             "'");                                                  \
     }                                                              \
   }()
+
+#define PRIVATE_CASE_TYPE_OUTPUT2(enum_type, type, ...) \
+  case enum_type: {                                     \
+    using output_t = type;                              \
+    return __VA_ARGS__();                               \
+  }
+
+#define DISPATCH_OUTPUT_TYPES(OUTPUT_TYPE, NAME, ...)                        \
+  [&] {                                                                      \
+    const auto& output_type = OUTPUT_TYPE;                                   \
+    at::ScalarType _output_t = ::detail::scalar_type(output_type);           \
+    switch (_output_t) {                                                     \
+      PRIVATE_CASE_TYPE_OUTPUT2(at::ScalarType::Half, at::Half, __VA_ARGS__) \
+      PRIVATE_CASE_TYPE_OUTPUT2(at::ScalarType::Float, float, __VA_ARGS__)   \
+      default:                                                               \
+        AT_ERROR(                                                            \
+            #NAME,                                                           \
+            " not implemented for output_t '",                               \
+            toString(_output_t),                                             \
+            "'");                                                            \
+    }                                                                        \
+  }()


### PR DESCRIPTION
Summary: Generate the output_dtype to be FP32, FP16 (WIP: INT8/INT4) such that we can fuse the embedding output with the quantization (e.g., for quantized comm evaluations).

Differential Revision: D32055270

