### PR TITLE
throw an exception when use 2-bit quantization

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
@@ -530,6 +530,8 @@ Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
                         std::copy(vs.data(), vs.data() + D_tail_elements, &output_acc[b * total_D + D_start + 8 * (D_vecs - 1)]);
                     }
                 }
+            } else {
+                throw std::logic_error("Unsupported SparseType: " + std::to_string((int)weight_ty));
             }
         }
         return;


### PR DESCRIPTION
Summary:

fbgemm is not supporting 2-bit quantization without throwing exceptions, and it creates problems when the high level code tries to use 2-bit quantization. Adding a exception here to warn the user that 2-bit is not supported yet in fbgemm is helpful.

Reviewed By: jianyuh

Differential Revision: D32190286

