### PR TITLE
Use output_dtype as the argument for determing the output type for training TBE

### DIFF
--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -236,7 +236,7 @@ def cli() -> None:
 @click.option("--weighted-num-requires-grad", type=int, default=None)
 @click.option("--flush-gpu-cache-size-mb", default=0)
 @click.option("--dense", is_flag=True, default=False)
-@click.option("--pooled-embedding-precision", type=SparseType, default=SparseType.FP32)
+@click.option("--output-dtype", type=SparseType, default=SparseType.FP32)
 def device(  # noqa C901
     alpha: float,
     bag_size: int,
@@ -255,7 +255,7 @@ def device(  # noqa C901
     weighted_num_requires_grad: Optional[int],
     flush_gpu_cache_size_mb: int,
     dense: bool,
-    pooled_embedding_precision: SparseType,
+    output_dtype: SparseType,
 ) -> None:
     np.random.seed(42)
     torch.manual_seed(42)
@@ -326,7 +326,7 @@ def device(  # noqa C901
             eps=0.1,
             weights_precision=weights_precision,
             stochastic_rounding=stoc,
-            pooled_output_precision=pooled_embedding_precision,
+            output_dtype=output_dtype,
         )
     emb = emb.to(get_device())
 
@@ -375,7 +375,7 @@ def device(  # noqa C901
         f"T: {time_per_iter * 1.0e6:.0f}us"
     )
 
-    if pooled_embedding_precision == SparseType.INT8:
+    if output_dtype == SparseType.INT8:
         # backward bench not representative
         return
 
@@ -811,7 +811,6 @@ def benchmark_cpu_requests(
 @click.option("--reuse", default=0.0)
 @click.option("--row-wise/--no-row-wise", default=True)
 @click.option("--weighted", is_flag=True, default=False)
-@click.option("--int4", is_flag=True, default=False)
 @click.option("--index-remapping", is_flag=True, default=False)
 def cpu(  # noqa C901
     alpha: float,
@@ -828,7 +827,6 @@ def cpu(  # noqa C901
     reuse: float,
     row_wise: bool,
     weighted: bool,
-    int4: bool,
     index_remapping: bool,
 ) -> None:
     np.random.seed(42)
@@ -857,7 +855,7 @@ def cpu(  # noqa C901
 
     nparams = sum(w.numel() for (w, _) in emb.split_embedding_weights())
     logging.info(
-        f"Int4 Embedding parameters: {nparams * 2 / 1.0e9: .2f} GParam, "
+        f"Int NBit Embedding parameters: {nparams * 2 / 1.0e9: .2f} GParam, "
         f"{nparams / 1.0e9: .2f}GB"
     )
     logging.info(f"Accessed weights per batch: {B * T * L * D * 0.5 / 1.0e6: .2f}MB")

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -191,7 +191,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         cache_reserved_memory: float = 0.0,
         cache_precision: SparseType = SparseType.FP32,
         weights_precision: SparseType = SparseType.FP32,
-        pooled_output_precision: SparseType = SparseType.FP32,
+        output_dtype: SparseType = SparseType.FP32,
         enforce_hbm: bool = False,  # place all weights/momentums in HBM when using cache
         optimizer: OptimType = OptimType.EXACT_SGD,
         record_cache_metrics: Optional[RecordCacheMetrics] = None,
@@ -215,7 +215,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.pooling_mode = pooling_mode
         self.bounds_check_mode_int: int = bounds_check_mode.value
         self.weights_precision = weights_precision
-        self.pooled_output_precision: int = pooled_output_precision.as_int()
+        self.output_dtype: int = output_dtype.as_int()
 
         if record_cache_metrics is not None:
             self.record_cache_metrics = record_cache_metrics
@@ -239,7 +239,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         ), "ComputeDevice.CPU is only for EmbeddingLocation.HOST!"
         if self.use_cpu:
             assert (
-                pooled_output_precision == SparseType.FP32
+                output_dtype == SparseType.FP32
             ), "Fused pooled embedding quantization only supported for cuda."
 
         if device is not None:
@@ -604,7 +604,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             indice_weights=per_sample_weights,
             feature_requires_grad=feature_requires_grad,
             lxu_cache_locations=lxu_cache_locations,
-            output_dtype=self.pooled_output_precision,
+            output_dtype=self.output_dtype,
         )
 
         if self.optimizer == OptimType.EXACT_SGD:


### PR DESCRIPTION
Summary:
- Use output_dtype as the argument name to unify between training and inference TBE
- Remove "-int4" in the benchmark arguments.

Reviewed By: caogao, brad-mengchi

Differential Revision: D32521994

