### PR TITLE
Add missing optimizers to FBGEMM_GPU OSS build.

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -56,6 +56,7 @@ set(OPTIMIZERS
   partial_rowwise_adam
   partial_rowwise_lamb
   rowwise_adagrad
+  rowwise_weighted_adagrad
   sgd)
 
 set(gen_gpu_source_files


### PR DESCRIPTION
Summary: Add missing rowwise_weight_adagrad optimizer to OSS build.

Reviewed By: suphoff, jianyuh

Differential Revision: D32604643

