### PR TITLE
Add UVM caching support in inference version of TBE

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
@@ -29,6 +29,8 @@ Tensor int_nbit_split_embedding_codegen_forward_unweighted_cuda(
     Tensor offsets,
     int64_t pooling_mode,
     int64_t output_dtype,
+    Tensor lxu_cache_weights,
+    Tensor lxu_cache_locations,
     int64_t unused);
 
 Tensor int_nbit_split_embedding_codegen_forward_weighted_cuda(
@@ -49,6 +51,8 @@ Tensor int_nbit_split_embedding_codegen_forward_weighted_cuda(
     int64_t pooling_mode,
     Tensor indice_weights,
     int64_t output_dtype,
+    Tensor lxu_cache_weights,
+    Tensor lxu_cache_locations,
     int64_t unused);
 
 Tensor int_nbit_split_embedding_codegen_lookup_function(
@@ -68,7 +72,9 @@ Tensor int_nbit_split_embedding_codegen_lookup_function(
     Tensor offsets,
     int64_t pooling_mode,
     c10::optional<Tensor> indice_weights,
-    int64_t output_dtype) {
+    int64_t output_dtype,
+    c10::optional<Tensor> lxu_cache_weights,
+    c10::optional<Tensor> lxu_cache_locations) {
   if (!indice_weights) {
     return int_nbit_split_embedding_codegen_forward_unweighted_cuda(
         dev_weights,
@@ -87,6 +93,8 @@ Tensor int_nbit_split_embedding_codegen_lookup_function(
         offsets,
         pooling_mode,
         output_dtype,
+        lxu_cache_weights.value_or(Tensor()),
+        lxu_cache_locations.value_or(Tensor()),
         0);
   }
   return int_nbit_split_embedding_codegen_forward_weighted_cuda(
@@ -107,6 +115,8 @@ Tensor int_nbit_split_embedding_codegen_lookup_function(
       pooling_mode,
       *indice_weights,
       output_dtype,
+      lxu_cache_weights.value_or(Tensor()),
+      lxu_cache_locations.value_or(Tensor()),
       0);
 }
 
@@ -124,7 +134,7 @@ Tensor pruned_array_lookup_cuda(
 
 TORCH_LIBRARY_FRAGMENT(fb, m) {
   m.def(
-      "int_nbit_split_embedding_codegen_lookup_function(Tensor dev_weights, Tensor uvm_weights, Tensor weights_placements, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, int total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, int max_float32_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, int output_dtype=1) -> Tensor");
+      "int_nbit_split_embedding_codegen_lookup_function(Tensor dev_weights, Tensor uvm_weights, Tensor weights_placements, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, int total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, int max_float32_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, int output_dtype=1, Tensor? lxu_cache_weights=None, Tensor? lxu_cache_locations=None) -> Tensor");
   m.impl(
       "int_nbit_split_embedding_codegen_lookup_function",
       torch::dispatch(

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
@@ -65,7 +65,9 @@ Tensor int_nbit_split_embedding_codegen_lookup_function_cpu(
     Tensor offsets,
     int64_t pooling_mode,
     c10::optional<Tensor> indice_weights,
-    int64_t output_dtype) {
+    int64_t output_dtype,
+    c10::optional<Tensor> lxu_cache_weights,  // Not used, to match cache interface for CUDA op
+    c10::optional<Tensor> lxu_cache_locations) {
   if (!indice_weights) {
     return int_nbit_split_embedding_codegen_forward_unweighted_cpu(
         dev_weights,

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -2696,6 +2696,8 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         mixed: bool,
         pooling_mode: split_table_batched_embeddings_ops.PoolingMode,
         weights_ty: SparseType,
+        use_cache: bool,
+        cache_algorithm: split_table_batched_embeddings_ops.CacheAlgorithm,
         use_cpu: bool,
         use_array_for_index_remapping: bool,
         mixed_weights_ty: bool,
@@ -2746,6 +2748,18 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
 
         if use_cpu:
             managed = [split_table_batched_embeddings_ops.EmbeddingLocation.HOST] * T
+        elif use_cache:
+            managed = [
+                split_table_batched_embeddings_ops.EmbeddingLocation.MANAGED_CACHING,
+            ] * T
+            if mixed:
+                average_D = sum(Ds) // T
+                for t, d in enumerate(Ds):
+                    managed[t] = (
+                        split_table_batched_embeddings_ops.EmbeddingLocation.DEVICE
+                        if d < average_D
+                        else managed[t]
+                    )
         else:
             managed = [
                 np.random.choice(
@@ -2777,6 +2791,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             if B != 0
             else None,
             device="cpu" if use_cpu else torch.cuda.current_device(),
+            cache_algorithm=cache_algorithm,
             use_array_for_index_remapping=use_array_for_index_remapping,
             output_dtype=output_dtype,
         )
@@ -2936,6 +2951,10 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 # TODO: implement for SparseType.INT2,
             ]
         ),
+        use_cache=st.booleans(),
+        cache_algorithm=st.sampled_from(
+            split_table_batched_embeddings_ops.CacheAlgorithm
+        ),
         use_cpu=st.booleans() if gpu_available else st.just(True),
         use_array_for_index_remapping=st.booleans(),
         mixed_weights_ty=st.booleans(),
@@ -2962,6 +2981,8 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         mixed: bool,
         pooling_mode: split_table_batched_embeddings_ops.PoolingMode,
         weights_ty: SparseType,
+        use_cache: bool,
+        cache_algorithm: split_table_batched_embeddings_ops.CacheAlgorithm,
         use_cpu: bool,
         use_array_for_index_remapping: bool,
         mixed_weights_ty: bool,
@@ -2977,6 +2998,8 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             mixed,
             pooling_mode,
             weights_ty,
+            use_cache,
+            cache_algorithm,
             use_cpu,
             use_array_for_index_remapping,
             mixed_weights_ty,
@@ -3004,6 +3027,10 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 SparseType.FP32,
             ]
         ),
+        use_cache=st.booleans(),
+        cache_algorithm=st.sampled_from(
+            split_table_batched_embeddings_ops.CacheAlgorithm
+        ),
         use_cpu=st.booleans() if gpu_available else st.just(True),
         use_array_for_index_remapping=st.booleans(),
         mixed_weights_ty=st.booleans(),
@@ -3030,6 +3057,8 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         mixed: bool,
         pooling_mode: split_table_batched_embeddings_ops.PoolingMode,
         weights_ty: SparseType,
+        use_cache: bool,
+        cache_algorithm: split_table_batched_embeddings_ops.CacheAlgorithm,
         use_cpu: bool,
         use_array_for_index_remapping: bool,
         mixed_weights_ty: bool,
@@ -3045,6 +3074,8 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             mixed,
             pooling_mode,
             weights_ty,
+            use_cache,
+            cache_algorithm,
             use_cpu,
             use_array_for_index_remapping,
             mixed_weights_ty,


### PR DESCRIPTION
Summary:
Skeleton of the code for enabling UVM caching support in inference TBE. In this Diff we mainly change the interface and reserve the arguments in the ops (avoid BC/FC issues).

TODO:
- embedding kernel to load the weights from lxu_cache_weights
- evict and insert cache logics (LRU/LFU)
- unit test
- perf evaluation with benchmark

Reviewed By: jspark1105

Differential Revision: D32523411

