### PR TITLE
Avoid clang format when applying CUB prefix/suffix header file

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_template_helpers.cuh
+++ b/fbgemm_gpu/codegen/embedding_backward_template_helpers.cuh
@@ -6,11 +6,13 @@
  */
 
 
+// clang-format off
 #include "fbgemm_gpu/cub_namespace_prefix.cuh"
 #include <cub/device/device_radix_sort.cuh>
 #include <cub/device/device_run_length_encode.cuh>
 #include <cub/device/device_scan.cuh>
 #include "fbgemm_gpu/cub_namespace_postfix.cuh"
+// clang-format on
 
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>

--- a/fbgemm_gpu/codegen/embedding_forward_template_helpers.cuh
+++ b/fbgemm_gpu/codegen/embedding_forward_template_helpers.cuh
@@ -12,17 +12,19 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <THC/THCAtomics.cuh>
 
+// clang-format off
 #include "fbgemm_gpu/cub_namespace_prefix.cuh"
 #include <cub/device/device_radix_sort.cuh>
 #include <cub/device/device_run_length_encode.cuh>
 #include <cub/device/device_scan.cuh>
 #include "fbgemm_gpu/cub_namespace_postfix.cuh"
+// clang-format on
 
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
-#include <mutex>
 #include <limits>
+#include <mutex>
 
 #include "fbgemm_gpu/dispatch_macros.h"
 #include "fbgemm_gpu/fbgemm_cuda_utils.cuh"

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.cuh
@@ -8,10 +8,11 @@
 
 #include <cuda.h>
 
+// clang-format off
 #include "./cub_namespace_prefix.cuh"
 #include "cub/block/block_reduce.cuh"
 #include "./cub_namespace_postfix.cuh"
-
+// clang-format on
 
 // Kernel for index hashing (template type scalar_t)
 template <typename scalar_t>

--- a/fbgemm_gpu/src/layout_transform_ops.cu
+++ b/fbgemm_gpu/src/layout_transform_ops.cu
@@ -5,9 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// clang-format off
 #include "fbgemm_gpu/cub_namespace_prefix.cuh"
 #include "cub/device/device_scan.cuh"
 #include "fbgemm_gpu/cub_namespace_postfix.cuh"
+// clang-format on
 
 #include "fbgemm_gpu/layout_transform_ops.cuh"
 #include "fbgemm_gpu/sparse_ops.h"

--- a/fbgemm_gpu/src/split_embeddings_cache_cuda.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache_cuda.cu
@@ -5,11 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// clang-format off
 #include "fbgemm_gpu/cub_namespace_prefix.cuh"
 #include "cub/device/device_radix_sort.cuh"
 #include "cub/device/device_run_length_encode.cuh"
 #include "cub/device/device_select.cuh"
 #include "fbgemm_gpu/cub_namespace_postfix.cuh"
+// clang-format on
 
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>


### PR DESCRIPTION
Summary:
As title. When applying clang format, the header order is reorder as something like
```
#include <cub/device/device_radix_sort.cuh>
#include <cub/device/device_run_length_encode.cuh>
#include <cub/device/device_scan.cuh>
#include "fbgemm_gpu/cub_namespace_postfix.cuh"
#include "fbgemm_gpu/cub_namespace_prefix.cuh"
```
which is not what we want. So we forbid clang format on the files.

Reviewed By: suphoff

Differential Revision: D32638234

