### PR TITLE
Python logging.warn to logging.warning in fbcode/deeplearning directory (#477)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_inference_converter.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_inference_converter.py
@@ -141,7 +141,7 @@ class SplitEmbInferenceConverter:
                 for (E, D, _, _) in child.embedding_specs:
                     weights_ty = self.quantize_type
                     if D % weights_ty.align_size() != 0:
-                        logging.warn(
+                        logging.warning(
                             f"Embedding dim {D} couldn't be divided by align size {weights_ty.align_size()}!"
                         )
                         assert D % 4 == 0


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/vissl/pull/477

logging.warn() is deprecated in recent Python 3 versions in favor of logging.warning(), which exists even in Python 2.
Replace logging.warn() with logging.warning() for the Python files in fbcode.

Differential Revision: D32690020

