### PR TITLE
Use output_dtype in v0 version of training TBE op

### DIFF
--- a/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
@@ -100,7 +100,6 @@ def invoke(
             # common_args
             {% if not dense %}
             placeholder_autograd_tensor=common_args.placeholder_autograd_tensor,
-            # output_dtype=common_args.output_dtype,
             {% endif %}
             dev_weights=common_args.dev_weights,
             uvm_weights=common_args.uvm_weights,
@@ -161,4 +160,5 @@ def invoke(
             {% if "iter" in args.split_function_arg_names %}
             iter=iter,
             {% endif %}
+            output_dtype=common_args.output_dtype,
         )


### PR DESCRIPTION
Summary: Addressing s251694

Differential Revision: D32400300

