### PR TITLE
remove assumption number of rows is in 32 bit

### DIFF
--- a/include/fbgemm/QuantUtils.h
+++ b/include/fbgemm/QuantUtils.h
@@ -266,7 +266,7 @@ template <typename InputType>
 FBGEMM_API void FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf(
     int bit_rate,
     const InputType* input,
-    int input_rows,
+    size_t input_rows,
     int input_columns,
     std::uint8_t* output);
 
@@ -282,7 +282,7 @@ template <typename OutputType>
 FBGEMM_API void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf(
     int bit_rate,
     const uint8_t* input,
-    int input_rows,
+    size_t input_rows,
     int input_columns,
     OutputType* output);
 
@@ -298,7 +298,7 @@ FBGEMM_API void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf(
 template <typename InputType>
 FBGEMM_API void FloatOrHalfToFused8BitRowwiseQuantizedSBFloat(
     const InputType* input,
-    int input_rows,
+    size_t input_rows,
     int input_columns,
     std::uint8_t* output);
 
@@ -313,7 +313,7 @@ FBGEMM_API void FloatOrHalfToFused8BitRowwiseQuantizedSBFloat(
 template <typename OutputType>
 FBGEMM_API void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf(
     const uint8_t* input,
-    int input_rows,
+    size_t input_rows,
     int input_columns,
     OutputType* output);
 
@@ -325,7 +325,7 @@ template <typename InputType>
 FBGEMM_API void FloatOrHalfToFusedNBitRowwiseQuantizedSBHalfRef(
     int bit_rate,
     const InputType* input,
-    int input_rows,
+    size_t input_rows,
     int input_columns,
     std::uint8_t* output);
 
@@ -336,7 +336,7 @@ FBGEMM_API void FloatOrHalfToFusedNBitRowwiseQuantizedSBHalfRef(
 template <typename InputType>
 FBGEMM_API void FloatOrHalfToFused8BitRowwiseQuantizedSBFloatRef(
     const InputType* input,
-    int input_rows,
+    size_t input_rows,
     int input_columns,
     std::uint8_t* output);
 
@@ -348,7 +348,7 @@ template <typename OutputType>
 FBGEMM_API void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef(
     int bit_rate,
     const uint8_t* input,
-    int input_rows,
+    size_t input_rows,
     int input_columns,
     OutputType* output);
 
@@ -359,7 +359,7 @@ FBGEMM_API void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef(
 template <typename OutputType>
 FBGEMM_API void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfRef(
     const uint8_t* input,
-    int input_rows,
+    size_t input_rows,
     int input_columns,
     OutputType* output);
 

--- a/include/fbgemm/QuantUtilsAvx2.h
+++ b/include/fbgemm/QuantUtilsAvx2.h
@@ -128,28 +128,28 @@ FBGEMM_API void requantizeForFloatAvx2(
 template <typename InputType, int BIT_RATE>
 void FloatOrHalfToFusedNBitRowwiseQuantizedSBHalfAvx2(
     const InputType* input,
-    int input_rows,
+    size_t input_rows,
     int input_columns,
     std::uint8_t* output);
 
 template <typename InputType>
 void FloatOrHalfToFused8BitRowwiseQuantizedSBFloatAvx2(
     const InputType* input,
-    int input_rows,
+    size_t input_rows,
     int input_columns,
     std::uint8_t* output);
 
 template <typename OutputType, int BIT_RATE>
 void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfAvx2(
     const std::uint8_t* input,
-    int input_rows,
+    size_t input_rows,
     int input_columns,
     OutputType* output);
 
 template <typename OutputType>
 void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfAvx2(
     const std::uint8_t* input,
-    int input_rows,
+    size_t input_rows,
     int input_columns,
     OutputType* output);
 


### PR DESCRIPTION
Summary: And remove unnecessary looping inside parallel_for despite fbgemm routines support batching multiple rows

Differential Revision: D32715453

