### PR TITLE
Performance optimization of HBC module in fbgemm.

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -178,9 +178,11 @@ at::Tensor jagged_1d_to_dense_gpu(
 // Assumes positive weight calibration is used for calibartion target, and
 // "positive_weight" is passed as input argument.
 //
-// # of bins and lower/upper bounds are automatically derived from
-// "bin_boundaries", "bin_num_examples", and "bin_num_positives", all of which
-// should be the same size.
+// # of bins is automatically derived from "bin_num_examples", and
+// "bin_num_positives", all of which should be the same size.
+//
+// "lower/upper_bound":
+// Bounds of the bins.
 //
 // "bin_ctr_in_use_after":
 // We will use the calibration_target for the final calibrated prediction if we
@@ -195,15 +197,15 @@ at::Tensor jagged_1d_to_dense_gpu(
 // bin_ctr_weight) * calibration_target.
 // Default: 1.0
 std::tuple<at::Tensor, at::Tensor> histogram_binning_calibration_cpu(
-    const at::Tensor& logit, const at::Tensor& bin_boundaries,
-    const at::Tensor& bin_num_examples, const at::Tensor& bin_num_positives,
-    double positive_weight, int64_t bin_ctr_in_use_after = 0,
-    double bin_ctr_weight_value = 1.0);
+    const at::Tensor& logit, const at::Tensor& bin_num_examples,
+    const at::Tensor& bin_num_positives, double positive_weight,
+    double lower_bound = 0.0, double upper_bound = 1.0,
+    int64_t bin_ctr_in_use_after = 0, double bin_ctr_weight_value = 1.0);
 
 std::tuple<at::Tensor, at::Tensor> histogram_binning_calibration_cuda(
-    const at::Tensor& logit, const at::Tensor& bin_boundaries,
-    const at::Tensor& bin_num_examples, const at::Tensor& bin_num_positives,
-    double positive_weight, int64_t bin_ctr_in_use_after = 0,
-    double bin_ctr_weight_value = 1.0);
+    const at::Tensor& logit, const at::Tensor& bin_num_examples,
+    const at::Tensor& bin_num_positives, double positive_weight,
+    double lower_bound = 0.0, double upper_bound = 1.0,
+    int64_t bin_ctr_in_use_after = 0, double bin_ctr_weight_value = 1.0);
 
 } // namespace fbgemm

--- a/fbgemm_gpu/src/sparse_ops.cu
+++ b/fbgemm_gpu/src/sparse_ops.cu
@@ -1457,9 +1457,9 @@ at::Tensor jagged_1d_to_dense_gpu(
 template <typename T>
 __global__ void histogram_binning_calibration_kernel(
     const int64_t num_logits, const int64_t num_bins,
-    const double recalibrate_value, const int64_t bin_ctr_in_use_after,
-    const double bin_ctr_weight_value, const T* const logit_data,
-    const float* const bin_boundaries_data,
+    const double recalibrate_value, const double step,
+    const int64_t bin_ctr_in_use_after, const double bin_ctr_weight_value,
+    const T* const logit_data,
     const double* const bin_num_examples_data,
     const double* const bin_num_positives_data,
     T* const calibrated_prediction_data, int64_t* const bin_ids_data) {
@@ -1471,12 +1471,7 @@ __global__ void histogram_binning_calibration_kernel(
   const T pre_sigmoid = logit_data[index] + recalibrate_value;
   const double uncalibrated = 1.0 / (1.0 + exp(-pre_sigmoid));
 
-  for (int bin_id = 0; bin_id < num_bins; ++bin_id) {
-    if (uncalibrated <= bin_boundaries_data[bin_id]) {
-      bin_ids_data[index] = bin_id;
-      break;
-    }
-  }
+  bin_ids_data[index] = ceil(uncalibrated / step) - 1;
 
   const auto curr_bin_num_examples = bin_num_examples_data[bin_ids_data[index]];
   if (curr_bin_num_examples > bin_ctr_in_use_after) {
@@ -1490,12 +1485,11 @@ __global__ void histogram_binning_calibration_kernel(
 }
 
 std::tuple<at::Tensor, at::Tensor> histogram_binning_calibration_cuda(
-    const at::Tensor& logit, const at::Tensor& bin_boundaries,
-    const at::Tensor& bin_num_examples, const at::Tensor& bin_num_positives,
-    double positive_weight, int64_t bin_ctr_in_use_after,
+    const at::Tensor& logit, const at::Tensor& bin_num_examples,
+    const at::Tensor& bin_num_positives, double positive_weight,
+    double lower_bound, double upper_bound, int64_t bin_ctr_in_use_after,
     double bin_ctr_weight_value) {
   TENSOR_ON_CUDA_GPU(logit);
-  TENSOR_ON_CUDA_GPU(bin_boundaries);
   TENSOR_ON_CUDA_GPU(bin_num_examples);
   TENSOR_ON_CUDA_GPU(bin_num_positives);
   TORCH_CHECK(bin_num_examples.numel() == bin_num_positives.numel());
@@ -1506,10 +1500,11 @@ std::tuple<at::Tensor, at::Tensor> histogram_binning_calibration_cuda(
   at::Tensor calibrated_prediction = at::empty({logit.numel()}, logit.options());
   at::Tensor bin_ids = at::empty({logit.numel()}, logit.options().dtype(at::kLong));
   const double recalibrate_value = std::log(positive_weight);
+  const double step =
+    (upper_bound - lower_bound) / static_cast<double>(bin_num_examples.numel());
 
   const int32_t num_threads = 512;
   const auto logit_packed = logit.contiguous();
-  const auto bin_boundaries_packed = bin_boundaries.contiguous();
   const auto bin_num_examples_packed = bin_num_examples.contiguous();
   const auto bin_num_positives_packed = bin_num_positives.contiguous();
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
@@ -1517,10 +1512,9 @@ std::tuple<at::Tensor, at::Tensor> histogram_binning_calibration_cuda(
         histogram_binning_calibration_kernel<scalar_t>
             <<<fbgemm_gpu::div_round_up(logit.numel(), num_threads),
                 num_threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-                    logit.numel(), bin_boundaries.numel(), recalibrate_value,
-                    bin_ctr_in_use_after, bin_ctr_weight_value,
+                    logit.numel(), bin_num_examples.numel(), recalibrate_value,
+                    step, bin_ctr_in_use_after, bin_ctr_weight_value,
                     logit_packed.data_ptr<scalar_t>(),
-                    bin_boundaries_packed.data_ptr<float>(),
                     bin_num_examples_packed.data_ptr<double>(),
                     bin_num_positives_packed.data_ptr<double>(),
                     calibrated_prediction.data_ptr<scalar_t>(),

--- a/fbgemm_gpu/test/sparse_ops_test.py
+++ b/fbgemm_gpu/test/sparse_ops_test.py
@@ -1021,20 +1021,19 @@ class SparseOpsTest(unittest.TestCase):
     @settings(verbosity=Verbosity.verbose, deadline=None)
     def test_histogram_binning_calibration(self, data_type: torch.dtype) -> None:
         num_bins = 5000
-        step = 1.0 / float(num_bins)
 
         logit = torch.tensor([[-0.0018], [0.0085], [0.0090], [0.0003], [0.0029]]).type(data_type)
 
-        bin_boundaries = torch.arange(step, 1.0 - step / 2, step)
         bin_num_examples = torch.empty([num_bins], dtype=torch.float64).fill_(0.0)
         bin_num_positives = torch.empty([num_bins], dtype=torch.float64).fill_(0.0)
 
         calibrated_prediction, bin_ids = torch.ops.fbgemm.histogram_binning_calibration(
                 logit=logit,
-                bin_boundaries = bin_boundaries,
                 bin_num_examples = bin_num_examples,
                 bin_num_positives = bin_num_positives,
                 positive_weight=0.4,
+                lower_bound=0.0,
+                upper_bound=1.0,
                 bin_ctr_in_use_after=10000,
                 bin_ctr_weight_value=0.9995)
 
@@ -1058,10 +1057,11 @@ class SparseOpsTest(unittest.TestCase):
         if torch.cuda.is_available():
             calibrated_prediction_gpu, bin_ids_gpu = torch.ops.fbgemm.histogram_binning_calibration(
                     logit=logit.cuda(),
-                    bin_boundaries = bin_boundaries.cuda(),
                     bin_num_examples = bin_num_examples.cuda(),
                     bin_num_positives = bin_num_positives.cuda(),
                     positive_weight=0.4,
+                    lower_bound=0.0,
+                    upper_bound=1.0,
                     bin_ctr_in_use_after=10000,
                     bin_ctr_weight_value=0.9995)
 


### PR DESCRIPTION
Summary: Directly calculate bin_id rather than relying on bin_boundaries.

Reviewed By: jianyuh

Differential Revision: D32740638

