### PR TITLE
Refactor enum type for TBE

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_dense_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_dense_host.cpp
@@ -356,7 +356,7 @@ at::Tensor split_embedding_codegen_lookup_dense_function(
     int64_t pooling_mode,
     c10::optional<Tensor> indice_weights,
     c10::optional<Tensor> feature_requires_grad) {
-  if (pooling_mode == NONE) {
+  if (static_cast<PoolingMode>(pooling_mode) == PoolingMode::NONE) {
     return SplitNoBagLookupFunction_Dense_Op::apply(
         dev_weights,
         weights_offsets,

--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_approx_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_approx_template.cpp
@@ -10,6 +10,7 @@
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>
 
+#include "codegen/embedding_common.h"
 #include "codegen/embedding_forward_split_cpu.h"
 #include "fbgemm/FbgemmEmbedding.h"
 
@@ -58,7 +59,7 @@ void split_embedding_backward_approx_cpu_kernel(
         const auto L = pool_end - pool_begin;
         const double scale_factor =
             // NOTE: MEAN pooling will not work with indice_weights!
-            (pooling_mode == MEAN && !indice_weights.defined() && L > 0)
+            (static_cast<PoolingMode>(pooling_mode) == PoolingMode::MEAN && !indice_weights.defined() && L > 0)
             ? 1.0 / L
             : 1.0;
         for (auto p = pool_begin; p < pool_end; ++p) {
@@ -125,7 +126,7 @@ split_embedding_backward_codegen_{{ optimizer }}_cpu(
       (host_weights.scalar_type() == ScalarType::Float/* ||
        host_weights.scalar_type() == ScalarType::Half*/) &&
       grad_output.scalar_type() == ScalarType::Float &&
-      !indice_weights.defined() && pooling_mode == SUM;
+      !indice_weights.defined() && static_cast<PoolingMode>(pooling_mode) == PoolingMode::SUM;
 
   if (use_fbgemm) {
     auto grad_stride = grad_output.size(1);

--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
@@ -11,6 +11,7 @@
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>
 
+#include "codegen/embedding_common.h"
 #include "codegen/embedding_forward_split_cpu.h"
 #include "fbgemm/FbgemmEmbedding.h"
 #include "fbgemm/Types.h"
@@ -250,7 +251,7 @@ void split_embedding_backward_exact_cpu_dense_kernel(
         const auto L = pool_end - pool_begin;
         const scalar_t scale_factor =
             // NOTE: MEAN pooling will not work with indice_weights!
-            (pooling_mode == MEAN && !indice_weights.defined() && L > 0)
+            (static_cast<PoolingMode>(pooling_mode) == PoolingMode::MEAN && !indice_weights.defined() && L > 0)
             ? 1.0 / L
             : 1.0;
         for (auto p = pool_begin; p < pool_end; ++p) {

--- a/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
@@ -435,7 +435,7 @@ Tensor split_embedding_codegen_lookup_{{ optimizer }}_function(
     bool stochastic_rounding,
     {{ args.split_function_args | join(", ") }},
     int64_t output_dtype) {
-  if (pooling_mode == NONE){
+  if (static_cast<PoolingMode>(pooling_mode) == PoolingMode::NONE) {
     return SplitNoBagLookupFunction_{{ optimizer }}_Op::apply(
       placeholder_autograd_tensor,
       dev_weights,

--- a/fbgemm_gpu/codegen/embedding_backward_template_helpers.cuh
+++ b/fbgemm_gpu/codegen/embedding_backward_template_helpers.cuh
@@ -28,6 +28,7 @@
 #include <curand_kernel.h>
 #include <mutex>
 
+#include "codegen/embedding_common.h"
 #include "fbgemm_gpu/dispatch_macros.h"
 #include "fbgemm_gpu/fbgemm_cuda_utils.cuh"
 #include "codegen/embedding_common.h"

--- a/fbgemm_gpu/codegen/embedding_bounds_check.cu
+++ b/fbgemm_gpu/codegen/embedding_bounds_check.cu
@@ -9,12 +9,6 @@
 using namespace at;
 using namespace fbgemm_gpu;
 
-enum class BoundsCheckMode {
-  FATAL = 0,
-  WARNING = 1,
-  IGNORE = 2,
-};
-
 template <typename index_t>
 __global__ void bounds_check_indices_kernel(
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>

--- a/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
@@ -8,15 +8,11 @@
 #include <ATen/TypeDefault.h>
 #include <ATen/core/op_registration/op_registration.h>
 #include <torch/script.h>
+#include "codegen/embedding_common.h"
 
 using namespace at;
 
 namespace {
-enum class BoundsCheckMode {
-  FATAL = 0,
-  WARNING = 1,
-  IGNORE = 2,
-};
 
 void bounds_check_indices_cpu(
     Tensor rows_per_table,

--- a/fbgemm_gpu/codegen/embedding_common.h
+++ b/fbgemm_gpu/codegen/embedding_common.h
@@ -7,6 +7,8 @@
 #pragma once
 #include <stdint.h>
 
+namespace {
+
 // Keep in sync with split_embedding_configs.py:SparseType
 enum class SparseType : uint8_t {
   FP32 = 0,
@@ -17,4 +19,20 @@ enum class SparseType : uint8_t {
   INVALID = 5,
 };
 
-enum PoolingMode { SUM = 0, MEAN = 1, NONE = 2 };
+enum class PoolingMode : uint8_t { SUM = 0, MEAN = 1, NONE = 2 };
+
+// Keep in sync with EmbeddingLocation in split_table_batched_embeddings_ops.py
+enum class PlacementType : uint8_t {
+  DEVICE = 0,
+  MANAGED = 1,
+  MANAGED_CACHING = 2,
+  HOST = 3,
+};
+
+enum class BoundsCheckMode : uint8_t {
+  FATAL = 0,
+  WARNING = 1,
+  IGNORE = 2,
+};
+
+} // namespace

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
@@ -18,14 +18,6 @@
 
 namespace {
 
-// Keep in sync with EmbeddingLocation in split_table_batched_embeddings_ops.py
-enum {
-  DEVICE = 0,
-  MANAGED = 1,
-  MANAGED_CACHING = 2,
-  HOST = 3,
-};
-
 using namespace at;
 
 // From https://stackoverflow.com/questions/55084047/intel-vector-instruction-to-zero-extend-8-4-bit-values-packed-in-a-32-bit-int-to
@@ -273,9 +265,9 @@ Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
             for (int32_t t = 0; t < T; ++t) {
                 const int32_t D_start = D_offsets_acc[t];
                 const int32_t D = D_offsets_acc[t+1] - D_offsets_acc[t];
-                const auto placement = weights_placements_ptr[t];
-                TORCH_CHECK(placement != DEVICE);
-                if (placement == HOST) {
+                const auto placement = static_cast<PlacementType>(weights_placements_ptr[t]);
+                TORCH_CHECK(placement != PlacementType::DEVICE);
+                if (placement == PlacementType::HOST) {
                     weights_acc = dev_weights.data_ptr<uint8_t>();
                 } else {
                     weights_acc = uvm_weights.data_ptr<uint8_t>();
@@ -316,7 +308,7 @@ Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
                             }
                         }
 
-                        const bool acc_scaling = (pooling_mode == MEAN && L > 0);
+                        const bool acc_scaling = (static_cast<PoolingMode>(pooling_mode) == PoolingMode::MEAN && L > 0);
                         const float acc_scale_factor = acc_scaling ? 1.0 / L : 1.0;
                         __m256 scale_vec = _mm256_set1_ps(acc_scale_factor);
                         store_result<output_t>(D_vecs, D_tail_elements, acc, scale_vec, output_acc + b * total_D + D_start, acc_scaling);
@@ -378,7 +370,7 @@ Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
                             }
                         }
 
-                        const bool acc_scaling = (pooling_mode == MEAN && L > 0);
+                        const bool acc_scaling = (static_cast<PoolingMode>(pooling_mode) == PoolingMode::MEAN && L > 0);
                         const float acc_scale_factor = acc_scaling ? 1.0 / L : 1.0;
                         __m256 scale_vec = _mm256_set1_ps(acc_scale_factor);
                         store_result<output_t>(D_vecs, D_tail_elements, acc, scale_vec, output_acc + b * total_D + D_start, acc_scaling);
@@ -457,7 +449,7 @@ Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
                             }
                         }
 
-                        const bool acc_scaling = (pooling_mode == MEAN && L > 0);
+                        const bool acc_scaling = (static_cast<PoolingMode>(pooling_mode) == PoolingMode::MEAN && L > 0);
                         const float acc_scale_factor = acc_scaling ? 1.0 / L : 1.0;
                         __m256 scale_vec = _mm256_set1_ps(acc_scale_factor);
                         store_result<output_t>(D_vecs, D_tail_elements, acc, scale_vec, output_acc + b * total_D + D_start, acc_scaling);
@@ -534,7 +526,7 @@ Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
                             }
                         }
 
-                        const bool acc_scaling = (pooling_mode == MEAN && L > 0);
+                        const bool acc_scaling = (static_cast<PoolingMode>(pooling_mode) == PoolingMode::MEAN && L > 0);
                         const float acc_scale_factor = acc_scaling ? 1.0 / L : 1.0;
                         __m256 scale_vec = _mm256_set1_ps(acc_scale_factor);
                         store_result<output_t>(D_vecs, D_tail_elements, acc, scale_vec, output_acc + b * total_D + D_start, acc_scaling);

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
@@ -29,6 +29,8 @@ Tensor int_nbit_split_embedding_codegen_forward_unweighted_cuda(
     Tensor offsets,
     int64_t pooling_mode,
     int64_t output_dtype,
+    Tensor lxu_cache_weights,
+    Tensor lxu_cache_locations,
     int64_t unused);
 
 Tensor int_nbit_split_embedding_codegen_forward_weighted_cuda(
@@ -49,6 +51,8 @@ Tensor int_nbit_split_embedding_codegen_forward_weighted_cuda(
     int64_t pooling_mode,
     Tensor indice_weights,
     int64_t output_dtype,
+    Tensor lxu_cache_weights,
+    Tensor lxu_cache_locations,
     int64_t unused);
 
 Tensor int_nbit_split_embedding_codegen_lookup_function(
@@ -68,7 +72,9 @@ Tensor int_nbit_split_embedding_codegen_lookup_function(
     Tensor offsets,
     int64_t pooling_mode,
     c10::optional<Tensor> indice_weights,
-    int64_t output_dtype) {
+    int64_t output_dtype,
+    c10::optional<Tensor> lxu_cache_weights,
+    c10::optional<Tensor> lxu_cache_locations) {
   if (!indice_weights) {
     return int_nbit_split_embedding_codegen_forward_unweighted_cuda(
         dev_weights,
@@ -87,6 +93,8 @@ Tensor int_nbit_split_embedding_codegen_lookup_function(
         offsets,
         pooling_mode,
         output_dtype,
+        lxu_cache_weights.value_or(Tensor()),
+        lxu_cache_locations.value_or(Tensor()),
         0);
   }
   return int_nbit_split_embedding_codegen_forward_weighted_cuda(
@@ -107,6 +115,8 @@ Tensor int_nbit_split_embedding_codegen_lookup_function(
       pooling_mode,
       *indice_weights,
       output_dtype,
+      lxu_cache_weights.value_or(Tensor()),
+      lxu_cache_locations.value_or(Tensor()),
       0);
 }
 
@@ -124,7 +134,7 @@ Tensor pruned_array_lookup_cuda(
 
 TORCH_LIBRARY_FRAGMENT(fb, m) {
   m.def(
-      "int_nbit_split_embedding_codegen_lookup_function(Tensor dev_weights, Tensor uvm_weights, Tensor weights_placements, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, int total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, int max_float32_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, int output_dtype=1) -> Tensor");
+      "int_nbit_split_embedding_codegen_lookup_function(Tensor dev_weights, Tensor uvm_weights, Tensor weights_placements, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, int total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, int max_float32_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, int output_dtype=1, Tensor? lxu_cache_weights=None, Tensor? lxu_cache_locations=None) -> Tensor");
   m.impl(
       "int_nbit_split_embedding_codegen_lookup_function",
       torch::dispatch(

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
@@ -65,7 +65,9 @@ Tensor int_nbit_split_embedding_codegen_lookup_function_cpu(
     Tensor offsets,
     int64_t pooling_mode,
     c10::optional<Tensor> indice_weights,
-    int64_t output_dtype) {
+    int64_t output_dtype,
+    c10::optional<Tensor> lxu_cache_weights,  // Not used, to match cache interface for CUDA op
+    c10::optional<Tensor> lxu_cache_locations) {
   if (!indice_weights) {
     return int_nbit_split_embedding_codegen_forward_unweighted_cpu(
         dev_weights,

--- a/fbgemm_gpu/codegen/embedding_forward_template_helpers.cuh
+++ b/fbgemm_gpu/codegen/embedding_forward_template_helpers.cuh
@@ -26,6 +26,7 @@
 #include <limits>
 #include <mutex>
 
+#include "codegen/embedding_common.h"
 #include "fbgemm_gpu/dispatch_macros.h"
 #include "fbgemm_gpu/fbgemm_cuda_utils.cuh"
 #include "codegen/embedding_common.h"

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -2696,6 +2696,8 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         mixed: bool,
         pooling_mode: split_table_batched_embeddings_ops.PoolingMode,
         weights_ty: SparseType,
+        use_cache: bool,
+        cache_algorithm: split_table_batched_embeddings_ops.CacheAlgorithm,
         use_cpu: bool,
         use_array_for_index_remapping: bool,
         mixed_weights_ty: bool,
@@ -2746,6 +2748,18 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
 
         if use_cpu:
             managed = [split_table_batched_embeddings_ops.EmbeddingLocation.HOST] * T
+        elif use_cache:
+            managed = [
+                split_table_batched_embeddings_ops.EmbeddingLocation.MANAGED_CACHING,
+            ] * T
+            if mixed:
+                average_D = sum(Ds) // T
+                for t, d in enumerate(Ds):
+                    managed[t] = (
+                        split_table_batched_embeddings_ops.EmbeddingLocation.DEVICE
+                        if d < average_D
+                        else managed[t]
+                    )
         else:
             managed = [
                 np.random.choice(
@@ -2777,6 +2791,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             if B != 0
             else None,
             device="cpu" if use_cpu else torch.cuda.current_device(),
+            cache_algorithm=cache_algorithm,
             use_array_for_index_remapping=use_array_for_index_remapping,
             output_dtype=output_dtype,
         )
@@ -2936,6 +2951,10 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 # TODO: implement for SparseType.INT2,
             ]
         ),
+        use_cache=st.booleans(),
+        cache_algorithm=st.sampled_from(
+            split_table_batched_embeddings_ops.CacheAlgorithm
+        ),
         use_cpu=st.booleans() if gpu_available else st.just(True),
         use_array_for_index_remapping=st.booleans(),
         mixed_weights_ty=st.booleans(),
@@ -2962,6 +2981,8 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         mixed: bool,
         pooling_mode: split_table_batched_embeddings_ops.PoolingMode,
         weights_ty: SparseType,
+        use_cache: bool,
+        cache_algorithm: split_table_batched_embeddings_ops.CacheAlgorithm,
         use_cpu: bool,
         use_array_for_index_remapping: bool,
         mixed_weights_ty: bool,
@@ -2977,6 +2998,8 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             mixed,
             pooling_mode,
             weights_ty,
+            use_cache,
+            cache_algorithm,
             use_cpu,
             use_array_for_index_remapping,
             mixed_weights_ty,
@@ -3004,6 +3027,10 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 SparseType.FP32,
             ]
         ),
+        use_cache=st.booleans(),
+        cache_algorithm=st.sampled_from(
+            split_table_batched_embeddings_ops.CacheAlgorithm
+        ),
         use_cpu=st.booleans() if gpu_available else st.just(True),
         use_array_for_index_remapping=st.booleans(),
         mixed_weights_ty=st.booleans(),
@@ -3030,6 +3057,8 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         mixed: bool,
         pooling_mode: split_table_batched_embeddings_ops.PoolingMode,
         weights_ty: SparseType,
+        use_cache: bool,
+        cache_algorithm: split_table_batched_embeddings_ops.CacheAlgorithm,
         use_cpu: bool,
         use_array_for_index_remapping: bool,
         mixed_weights_ty: bool,
@@ -3045,6 +3074,8 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             mixed,
             pooling_mode,
             weights_ty,
+            use_cache,
+            cache_algorithm,
             use_cpu,
             use_array_for_index_remapping,
             mixed_weights_ty,


### PR DESCRIPTION
Summary:
Extract the common enum types in embedding_common.h and apply the related changes:
```

// Keep in sync with split_embedding_configs.py:SparseType
enum class SparseType : uint8_t {
  FP32 = 0,
  FP16 = 1,
  INT8 = 2,
  INT4 = 3,
  INT2 = 4,
  INVALID = 5,
};

enum class PoolingMode : uint8_t { SUM = 0, MEAN = 1, NONE = 2 };

// Keep in sync with EmbeddingLocation in split_table_batched_embeddings_ops.py
enum class PlacementType : uint8_t {
  DEVICE = 0,
  MANAGED = 1,
  MANAGED_CACHING = 2,
  HOST = 3,
};

enum class BoundsCheckMode : uint8_t {
  FATAL = 0,
  WARNING = 1,
  IGNORE = 2,
};
```

Reviewed By: suphoff

Differential Revision: D32649799

