### PR TITLE
open-source segment_sum_csr()

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -28,6 +28,14 @@ at::Tensor offsets_range_cuda(const at::Tensor& offsets, int64_t range_size);
 
 at::Tensor offsets_range_cpu(const at::Tensor& offsets, int64_t range_size);
 
+at::Tensor segment_sum_csr_cuda(const int64_t batch_size,
+                                const at::Tensor& csr_seg,
+                                const at::Tensor& values);
+
+at::Tensor segment_sum_csr_cpu(const int64_t batch_size,
+                               const at::Tensor& csr_seg,
+                               const at::Tensor& values);
+
 std::tuple<at::Tensor, at::Tensor, c10::optional<at::Tensor>>
 permute_sparse_data_cuda(
     const at::Tensor& permute,

--- a/fbgemm_gpu/src/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_cpu.cpp
@@ -1092,6 +1092,42 @@ std::tuple<at::Tensor, at::Tensor> histogram_binning_calibration_by_feature_cpu(
   return std::make_tuple(calibrated_prediction, bin_ids);
 }
 
+template <typename scalar_t>
+void _segment_sum_csr_cpu_kernel(
+    const int num_segments,
+    const int batch_size,
+    const int* const csr_seg_data,
+    const scalar_t* const values_data,
+    scalar_t* const output_data) {
+  for (const auto i : c10::irange(num_segments)) {
+    const int seg_start = csr_seg_data[i] * batch_size;
+    const int seg_end = csr_seg_data[i + 1] * batch_size;
+    scalar_t v = 0;
+    for (const auto j : c10::irange(seg_start, seg_end)) {
+      v += values_data[j];
+    }
+    output_data[i] = v;
+  }
+}
+
+at::Tensor segment_sum_csr_cpu(
+    const int64_t batch_size,
+    const at::Tensor& csr_seg,
+    const at::Tensor& values) {
+  TENSOR_ON_CPU(csr_seg);
+  TENSOR_ON_CPU(values);
+
+  auto output = at::empty(csr_seg.numel() - 1, values.options());
+  AT_DISPATCH_ALL_TYPES(values.type(), "_segment_sum_csr_cpu", ([&] {
+                          _segment_sum_csr_cpu_kernel<scalar_t>(
+                              csr_seg.numel() - 1,
+                              batch_size,
+                              csr_seg.data_ptr<int>(),
+                              values.data_ptr<scalar_t>(),
+                              output.data_ptr<scalar_t>());
+                        }));
+  return output;
+}
 } // namespace fbgemm
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
@@ -1117,6 +1153,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "histogram_binning_calibration(Tensor logit, Tensor bin_num_examples, Tensor bin_num_positives, float positive_weight, float lower_bound, float upper_bound, int bin_ctr_in_use_after, float bin_ctr_weight_value) -> (Tensor, Tensor)");
   m.def(
       "histogram_binning_calibration_by_feature(Tensor logit, Tensor dense_segment_value, Tensor segment_lengths, int num_segments, Tensor bin_num_examples, Tensor bin_num_positives, int num_bins, float positive_weight, float lower_bound, float upper_bound, int bin_ctr_in_use_after, float bin_ctr_weight_value) -> (Tensor, Tensor)");
+  m.def("segment_sum_csr(int batch_size, Tensor csr_seg, Tensor values) -> Tensor");
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
@@ -1141,4 +1178,5 @@ TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
   m.impl("jagged_1d_to_dense", fbgemm::jagged_1d_to_dense_cpu);
   m.impl("histogram_binning_calibration", fbgemm::histogram_binning_calibration_cpu);
   m.impl("histogram_binning_calibration_by_feature", fbgemm::histogram_binning_calibration_by_feature_cpu);
+  m.impl("segment_sum_csr", fbgemm::segment_sum_csr_cpu);
 }

--- a/fbgemm_gpu/src/sparse_ops_gpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_gpu.cpp
@@ -128,4 +128,5 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
                    fbgemm::histogram_binning_calibration_cuda);
   DISPATCH_TO_CUDA("histogram_binning_calibration_by_feature",
                    fbgemm::histogram_binning_calibration_by_feature_cuda);
+  DISPATCH_TO_CUDA("segment_sum_csr", fbgemm::segment_sum_csr_cuda);
 }

--- a/fbgemm_gpu/test/sparse_ops_test.py
+++ b/fbgemm_gpu/test/sparse_ops_test.py
@@ -1191,6 +1191,28 @@ class SparseOpsTest(unittest.TestCase):
                 )
             )
 
+    @settings(verbosity=Verbosity.verbose, deadline=None)
+    def test_segment_sum_csr(self) -> None:
+        segment_sum_cpu = torch.ops.fbgemm.segment_sum_csr(
+            2,
+            torch.IntTensor([0, 2, 3, 5]),
+            torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]),
+        )
+        torch.testing.assert_allclose(
+            segment_sum_cpu, torch.Tensor([10.0, 11.0, 34.0]), 0, 0
+        )
+        if torch.cuda.is_available():
+            segment_sum_cuda = torch.ops.fbgemm.segment_sum_csr(
+                2,
+                torch.IntTensor([0, 2, 3, 5]).cuda(),
+                torch.Tensor(
+                    [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+                ).cuda(),
+            )
+            torch.testing.assert_allclose(
+                segment_sum_cuda.cpu(), torch.Tensor([10.0, 11.0, 34.0]), 0, 0
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary: This commit open-sources `segment_sum_csr()` like D31843250 (https://github.com/pytorch/FBGEMM/commit/858365fe12b05023e83ff52380a1a88395ef0908).

Reviewed By: jianyuh

Differential Revision: D32547672

