### PR TITLE
To match interface with existing HBC by feature, take in sparse representation and densify internally.

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -236,12 +236,9 @@ std::tuple<at::Tensor, at::Tensor> histogram_binning_calibration_cuda(
 // Assumes positive weight calibration is used for calibartion target, and
 // "positive_weight" is passed as input argument.
 //
-// "dense_segment_value":
-// KeyJaggedTensor should have been made to dense format using
-// torch.ops.fb.to_dense_representation.
-//
-// "segment_lengths":
-// Lengths in KeyJaggedTensor.
+// "segment_value/lengths":
+// Values and lengths in KeyJaggedTensor. Assumes value of length is either 0
+// or 1.
 //
 // "num_bins":
 // # of bins is no longer the same as "bin_num_examples", and
@@ -263,7 +260,7 @@ std::tuple<at::Tensor, at::Tensor> histogram_binning_calibration_cuda(
 // bin_ctr_weight) * calibration_target.
 // Default: 1.0
 std::tuple<at::Tensor, at::Tensor> histogram_binning_calibration_by_feature_cpu(
-    const at::Tensor& logit, const at::Tensor& dense_segment_value,
+    const at::Tensor& logit, const at::Tensor& segment_value,
     const at::Tensor& segment_lengths, int64_t num_segments,
     const at::Tensor& bin_num_examples, const at::Tensor& bin_num_positives,
     int64_t num_bins, double positive_weight,
@@ -272,7 +269,7 @@ std::tuple<at::Tensor, at::Tensor> histogram_binning_calibration_by_feature_cpu(
     double bin_ctr_weight_value = 1.0);
 
 std::tuple<at::Tensor, at::Tensor> histogram_binning_calibration_by_feature_cuda(
-    const at::Tensor& logit, const at::Tensor& dense_segment_value,
+    const at::Tensor& logit, const at::Tensor& segment_value,
     const at::Tensor& segment_lengths, int64_t num_segments,
     const at::Tensor& bin_num_examples, const at::Tensor& bin_num_positives,
     int64_t num_bins, double positive_weight,

--- a/fbgemm_gpu/test/sparse_ops_test.py
+++ b/fbgemm_gpu/test/sparse_ops_test.py
@@ -1111,8 +1111,7 @@ class SparseOpsTest(unittest.TestCase):
             data_type
         )
 
-        # add 1 to distinguish between 0 inserted by densification vs. original value.
-        dense_segment_value = torch.tensor([40, 31, 32, 13, 31]) + 1
+        segment_value = torch.tensor([40, 31, 32, 13, 31])
         lengths = torch.tensor([[1], [1], [1], [1], [1]])
 
         num_interval = num_bins * (num_segments + 1)
@@ -1124,7 +1123,7 @@ class SparseOpsTest(unittest.TestCase):
             bin_ids,
         ) = torch.ops.fbgemm.histogram_binning_calibration_by_feature(
             logit=logit,
-            dense_segment_value=dense_segment_value,
+            segment_value=segment_value,
             segment_lengths=lengths,
             num_segments=num_segments,
             bin_num_examples=bin_num_examples,
@@ -1164,7 +1163,7 @@ class SparseOpsTest(unittest.TestCase):
                 bin_ids_gpu,
             ) = torch.ops.fbgemm.histogram_binning_calibration_by_feature(
                 logit=logit.cuda(),
-                dense_segment_value=dense_segment_value.cuda(),
+                segment_value=segment_value.cuda(),
                 segment_lengths=lengths.cuda(),
                 num_segments=num_segments,
                 bin_num_examples=bin_num_examples.cuda(),


### PR DESCRIPTION
Summary: HBC by feature in fbgemm to take in sparse representation directly to make it easier to compare with existing implementations.

Reviewed By: jianyuh

Differential Revision: D32898190

