### PR TITLE
add bound check of offset values

### DIFF
--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -1791,8 +1791,8 @@ def bounds_check_indices(  # noqa C901
     )
     # requests = [(a.int(), b.int(), c if c else None) for (a, b, c) in requests]
 
-    warning = torch.tensor([0]).long().cuda()
-    rows_per_table = torch.tensor([E for _ in range(T)]).long().cuda()
+    warning = torch.tensor([0]).long().to(get_device())
+    rows_per_table = torch.tensor([E for _ in range(T)]).long().to(get_device())
     # forward
     time_per_iter = benchmark_requests(
         requests,


### PR DESCRIPTION
Summary:
It's possible offsets have invalid values.

Also made bounds_check_indices in split_table_batched_embeddings_benchmark.py working with CPU

Reviewed By: jianyuh

Differential Revision: D33005532

