### PR TITLE
HBC to return same tensor shape as logit input.

### DIFF
--- a/fbgemm_gpu/src/sparse_ops.cu
+++ b/fbgemm_gpu/src/sparse_ops.cu
@@ -1542,8 +1542,7 @@ std::tuple<at::Tensor, at::Tensor> histogram_binning_calibration_cuda(
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(logit.get_device());
 
-  at::Tensor calibrated_prediction =
-      at::empty({logit.numel()}, logit.options());
+  at::Tensor calibrated_prediction = at::empty_like(logit);
   at::Tensor bin_ids =
       at::empty({logit.numel()}, logit.options().dtype(at::kLong));
   const double recalibrate_value = std::log(positive_weight);
@@ -1688,8 +1687,7 @@ histogram_binning_calibration_by_feature_cuda(
                 dense_segment_value_packed.data_ptr<int64_t>());
       });
 
-  at::Tensor calibrated_prediction =
-      at::empty({logit.numel()}, logit.options());
+  at::Tensor calibrated_prediction = at::empty_like(logit);
   at::Tensor bin_ids =
       at::empty({logit.numel()}, logit.options().dtype(at::kLong));
   const double recalibrate_value = std::log(positive_weight);

--- a/fbgemm_gpu/src/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_cpu.cpp
@@ -1009,8 +1009,7 @@ std::tuple<at::Tensor, at::Tensor> histogram_binning_calibration_cpu(
   TENSOR_ON_CPU(bin_num_positives);
   TORCH_CHECK(bin_num_examples.numel() == bin_num_positives.numel());
 
-  at::Tensor calibrated_prediction =
-      at::empty({logit.numel()}, logit.options());
+  at::Tensor calibrated_prediction = at::empty_like(logit);
   at::Tensor bin_ids =
       at::empty({logit.numel()}, logit.options().dtype(at::kLong));
   const double recalibrate_value = std::log(positive_weight);
@@ -1108,8 +1107,7 @@ std::tuple<at::Tensor, at::Tensor> histogram_binning_calibration_by_feature_cpu(
   // dense_segment_value is used as a temporary storage.
   at::Tensor dense_segment_value =
       at::zeros({logit.numel()}, segment_value.options());
-  at::Tensor calibrated_prediction =
-      at::empty({logit.numel()}, logit.options());
+  at::Tensor calibrated_prediction = at::empty_like(logit);
   at::Tensor bin_ids =
       at::empty({logit.numel()}, logit.options().dtype(at::kLong));
   const double recalibrate_value = std::log(positive_weight);

--- a/fbgemm_gpu/test/sparse_ops_test.py
+++ b/fbgemm_gpu/test/sparse_ops_test.py
@@ -1049,7 +1049,7 @@ class SparseOpsTest(unittest.TestCase):
         )
 
         expected_calibrated_prediction = torch.tensor(
-            [0.2853, 0.2875, 0.2876, 0.2858, 0.2863]
+            [[0.2853], [0.2875], [0.2876], [0.2858], [0.2863]]
         ).type(data_type)
         expected_bin_ids = torch.tensor(
             [1426, 1437, 1437, 1428, 1431], dtype=torch.long
@@ -1107,9 +1107,7 @@ class SparseOpsTest(unittest.TestCase):
         num_bins = 5000
         num_segments = 42
 
-        logit = torch.tensor([[-0.0018], [0.0085], [0.0090], [0.0003], [0.0029]]).type(
-            data_type
-        )
+        logit = torch.tensor([-0.0018, 0.0085, 0.0090, 0.0003, 0.0029]).type(data_type)
 
         segment_value = torch.tensor([40, 31, 32, 13, 31])
         lengths = torch.tensor([[1], [1], [1], [1], [1]])


### PR DESCRIPTION
Summary:
Instead of returning 1D tensor, return the same shape as input to match with existing implementation.

clang-format to format entire file, which touches unrelated portions as well.

Differential Revision: D33026199

