### PR TITLE
fix bounds_check_indices aten op signature definition to reflect offset is now mutable

### DIFF
--- a/fbgemm_gpu/codegen/embedding_bounds_check_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host.cpp
@@ -23,7 +23,7 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
   // The (a!) tells PyTorch this is an impure operation and so cannot be CSE'd
   // or DCE'd, etc.
   m.def(
-      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor offsets, int bounds_check_mode, Tensor(a!) warning) -> ()");
+      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(a!) offsets, int bounds_check_mode, Tensor(a!) warning) -> ()");
   m.impl(
       "bounds_check_indices",
       torch::dispatch(


### PR DESCRIPTION
Summary: Follow-up D33005532 (https://github.com/pytorch/FBGEMM/commit/8824ecce3079dfbab40626897e9264a4d0bb7d6e)

Differential Revision: D33034791

