### PR TITLE
Refactor at, nbit, fbgemm and fbgemm_gpu namespaces used in fbgemm_gpu.

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_dense_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_dense_host.cpp
@@ -11,7 +11,7 @@
 
 #include "codegen/embedding_common.h"
 
-using namespace at;
+using Tensor = at::Tensor;
 
 Tensor dense_embedding_codegen_forward_unweighted_cuda(
     Tensor dev_weights,
@@ -343,7 +343,7 @@ class SplitNoBagLookupFunction_Dense_Op
   }
 };
 
-at::Tensor split_embedding_codegen_lookup_dense_function(
+Tensor split_embedding_codegen_lookup_dense_function(
     Tensor dev_weights,
     Tensor weights_offsets,
     Tensor D_offsets,

--- a/fbgemm_gpu/codegen/embedding_backward_dense_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_dense_host_cpu.cpp
@@ -11,7 +11,7 @@
 #include "codegen/embedding_common.h"
 #include "codegen/embedding_forward_split_cpu.h"
 
-using namespace at;
+using Tensor = at::Tensor;
 
 Tensor split_embedding_backward_codegen_dense_cpu(
     Tensor grad_output,

--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
@@ -17,7 +17,7 @@
 #include "fbgemm/FbgemmEmbedding.h"
 #include "fbgemm/Types.h"
 
-using namespace at;
+using Tensor = at::Tensor;
 
 namespace internal {
 template <typename T>
@@ -36,8 +36,8 @@ template <typename scalar_t>
 void split_embedding_backward_exact_cpu_kernel(
     Tensor grad_output,
     Tensor host_weights,
-    const TensorAccessor<int64_t, 1> weights_offsets_data,
-    const TensorAccessor<int, 1> D_offsets_data,
+    const at::TensorAccessor<int64_t, 1> weights_offsets_data,
+    const at::TensorAccessor<int, 1> D_offsets_data,
     Tensor hash_size_cumsum,
     Tensor indices,
     Tensor offsets,
@@ -47,13 +47,13 @@ void split_embedding_backward_exact_cpu_kernel(
     int B,
     const int* table_to_feature_offset,
     {% if "momentum1_offsets" in args.split_function_arg_names %}
-    const TensorAccessor<int64_t, 1> momentum1_offsets_data,
+    const at::TensorAccessor<int64_t, 1> momentum1_offsets_data,
     {% endif %}
     {% if "momentum2_offsets" in args.split_function_arg_names %}
-    const TensorAccessor<int64_t, 1> momentum2_offsets_data,
+    const at::TensorAccessor<int64_t, 1> momentum2_offsets_data,
     {% endif %}
     {{ args.split_cpu_kernel_args | join(", ") }}) {
-  using grad_t = acc_type<scalar_t, true>;
+  using grad_t = at::acc_type<scalar_t, true>;
 
   // const auto grad_output_accessor = grad_output.accessor<grad_t, 2>();
   const grad_t* grad_output_data = grad_output.data_ptr<grad_t>();
@@ -92,7 +92,7 @@ void split_embedding_backward_exact_cpu_kernel(
         indices.accessor<int64_t, 1>(),
         indice_weights.defined()
             ? indice_weights.accessor<grad_t, 1>()
-            : TensorAccessor<grad_t, 1>(nullptr, nullptr, nullptr),
+            : at::TensorAccessor<grad_t, 1>(nullptr, nullptr, nullptr),
         pooling_mode,
         table_to_feature_offset + t,
         hash_size);
@@ -214,8 +214,8 @@ template <typename scalar_t>
 void split_embedding_backward_exact_cpu_dense_kernel(
     Tensor grad,
     Tensor grad_output,
-    const TensorAccessor<int64_t, 1> weights_offsets_data,
-    const TensorAccessor<int, 1> D_offsets_data,
+    const at::TensorAccessor<int64_t, 1> weights_offsets_data,
+    const at::TensorAccessor<int, 1> D_offsets_data,
     Tensor indices,
     Tensor offsets,
     int64_t pooling_mode,

--- a/fbgemm_gpu/codegen/embedding_backward_split_host_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_cpu_template.cpp
@@ -13,7 +13,7 @@
 
 #include "codegen/embedding_common.h"
 
-using namespace at;
+using Tensor = at::Tensor;
 
 void split_embedding_backward_codegen_{{ optimizer }}_cpu(
     Tensor grad_output,

--- a/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
@@ -12,7 +12,7 @@
 
 #include "codegen/embedding_common.h"
 
-using namespace at;
+using Tensor = at::Tensor;
 
 Tensor split_embedding_codegen_forward_unweighted_cuda(
     Tensor dev_weights,

--- a/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
@@ -7,7 +7,7 @@
 // clang-format off
 #include "codegen/embedding_forward_template_helpers.cuh"
 
-using namespace at;
+using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
 
 {% if not dense %}
@@ -21,29 +21,29 @@ template <typename emb_t, typename cache_t, size_t kMaxVecsPerThread>
 __global__
 __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights_kernel(
     // [\sum_t E_t x D_t]
-    const PackedTensorAccessor32<acc_type<cache_t, true>, 2, RestrictPtrTraits>
+    const at::PackedTensorAccessor32<at::acc_type<cache_t, true>, 2, at::RestrictPtrTraits>
         grad_output,
-    PackedTensorAccessor64<emb_t, 1, RestrictPtrTraits> dev_weights,
+    at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
     {% if not dense %}
-    PackedTensorAccessor64<emb_t, 1, RestrictPtrTraits> uvm_weights,
-    PackedTensorAccessor64<cache_t, 2, RestrictPtrTraits> lxu_cache_weights,
-    const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits>
+    at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> uvm_weights,
+    at::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         weights_placements,
     {% endif %}
-    const PackedTensorAccessor32<int64_t, 1, RestrictPtrTraits> weights_offsets,
-    const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> D_offsets,
-    const PackedTensorAccessor32<int64_t, 1, RestrictPtrTraits>
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         indices, // [N = \sum_{b,t} L_{b,t} total indices, i.e. flattened
                  // [B][T][L]
-    const PackedTensorAccessor32<int64_t, 1, RestrictPtrTraits>
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         offsets, // [B x T + 1]
     {% if not dense %}
-    const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits>
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         lxu_cache_locations,
     {% endif %}
-    PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits>
+    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         feature_requires_grad, // [T],
-    PackedTensorAccessor32<acc_type<cache_t, true>, 1, RestrictPtrTraits>
+    at::PackedTensorAccessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits>
         grad_indice_weights
     ) {
     int32_t B = grad_output.size(0);
@@ -86,13 +86,13 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
     {% endif %}
 
 
-    Vec4T<acc_type<cache_t, true>> grad_out[kMaxVecsPerThread];
+    Vec4T<at::acc_type<cache_t, true>> grad_out[kMaxVecsPerThread];
     #pragma unroll kMaxVecsPerThread
     for (int32_t i = 0;
         i < kMaxVecsPerThread && 4 * kWarpSize * i + threadIdx.x * 4 < D;
         ++i) {
         int32_t d = 4 * kWarpSize * i + threadIdx.x * 4;
-        Vec4T<acc_type<cache_t, true>> go((&grad_output[b][0]) + D_start + d);
+        Vec4T<at::acc_type<cache_t, true>> go((&grad_output[b][0]) + D_start + d);
         grad_out[i] = go;
     }
 
@@ -107,7 +107,7 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
             {% if not dense %}
             int32_t cache_idx_j = __shfl_sync(0xFFFFFFFF, cache_idx, j);
             {% endif %}
-            acc_type<cache_t, true> grad_indice_weight = 0.0;
+            at::acc_type<cache_t, true> grad_indice_weight = 0.0;
 
         #pragma unroll kMaxVecsPerThread
             for (int32_t i = 0;
@@ -125,7 +125,7 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
                     if (std::is_same<emb_t, uint8_t>::value) {
                         D_emb += kINT8QparamsBytes;
                     }
-                    auto weight_row = WeightRow<emb_t, cache_t, acc_type<cache_t, true>>(
+                    auto weight_row = WeightRow<emb_t, cache_t, at::acc_type<cache_t, true>>(
                         const_cast<emb_t*>(&weights[idx_j * D_emb]),
                         nullptr,
                         D,
@@ -134,7 +134,7 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
                     if (std::is_same<emb_t, uint8_t>::value) {
                         qparams = weight_row.load_qparams();
                     }
-                    Vec4T<acc_type<cache_t, true>> weight =
+                    Vec4T<at::acc_type<cache_t, true>> weight =
                     weight_row.load(d, qparams);
                     grad_indice_weight += weight.acc.x * grad_out[i].acc.x +
                         weight.acc.y * grad_out[i].acc.y +
@@ -145,7 +145,7 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
                 if (std::is_same<emb_t, uint8_t>::value) {
                     D_emb += kINT8QparamsBytes;
                 }
-                auto weight_row = WeightRow<emb_t, cache_t, acc_type<cache_t, true>>(
+                auto weight_row = WeightRow<emb_t, cache_t, at::acc_type<cache_t, true>>(
                     const_cast<emb_t*>(&weights[idx_j * D_emb]),
                     nullptr,
                     D,
@@ -154,7 +154,7 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
                 if (std::is_same<emb_t, uint8_t>::value) {
                     qparams = weight_row.load_qparams();
                 }
-                Vec4T<acc_type<cache_t, true>> weight =
+                Vec4T<at::acc_type<cache_t, true>> weight =
                 weight_row.load(d, qparams);
                 grad_indice_weight += weight.acc.x * grad_out[i].acc.x +
                     weight.acc.y * grad_out[i].acc.y +
@@ -162,7 +162,7 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
                 {% endif %}
             }
             grad_indice_weight =
-                warpReduceAllSum<acc_type<cache_t, true>>(grad_indice_weight);
+                warpReduceAllSum<at::acc_type<cache_t, true>>(grad_indice_weight);
             if (threadIdx.x == 0) {
                 grad_indice_weights[indices_start + l_start + j] = grad_indice_weight;
             }
@@ -199,7 +199,7 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights
     if (B == 0) {
       return grad_indice_weights;
     }
-    feature_requires_grad = feature_requires_grad.defined() ? feature_requires_grad : empty({0}, indices.options().dtype(kInt));
+    feature_requires_grad = feature_requires_grad.defined() ? feature_requires_grad : at::empty({0}, indices.options().dtype(at::kInt));
     {% if not dense %}
     DISPATCH_EMB_CACHE_TYPES(
     {% else %}
@@ -228,34 +228,34 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights
                 at::cuda::getCurrentCUDAStream()>>>(
                 {% if not dense %}
                 grad_output.packed_accessor32<
-                    acc_type<cache_t, true>,
+                    at::acc_type<cache_t, true>,
                     2,
-                    RestrictPtrTraits>(),
-                dev_weights.packed_accessor64<emb_t, 1, RestrictPtrTraits>(),
+                    at::RestrictPtrTraits>(),
+                dev_weights.packed_accessor64<emb_t, 1, at::RestrictPtrTraits>(),
                 {% else %}
                 grad_output.packed_accessor32<
-                    acc_type<scalar_t, true>,
+                    at::acc_type<scalar_t, true>,
                     2,
-                    RestrictPtrTraits>(),
-                dev_weights.packed_accessor64<scalar_t, 1, RestrictPtrTraits>(),
+                    at::RestrictPtrTraits>(),
+                dev_weights.packed_accessor64<scalar_t, 1, at::RestrictPtrTraits>(),
                 {% endif %}
                 {% if not dense %}
-                uvm_weights.packed_accessor64<emb_t, 1, RestrictPtrTraits>(),
-                lxu_cache_weights.packed_accessor64<cache_t, 2, RestrictPtrTraits>(),
-                weights_placements.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+                uvm_weights.packed_accessor64<emb_t, 1, at::RestrictPtrTraits>(),
+                lxu_cache_weights.packed_accessor64<cache_t, 2, at::RestrictPtrTraits>(),
+                weights_placements.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
                 {% endif %}
-                weights_offsets.packed_accessor32<int64_t, 1, RestrictPtrTraits>(),
-                D_offsets.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
-                indices.packed_accessor32<int64_t, 1, RestrictPtrTraits>(),
-                offsets.packed_accessor32<int64_t, 1, RestrictPtrTraits>(),
+                weights_offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
+                D_offsets.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+                indices.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
+                offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
                 {% if not dense %}
-                lxu_cache_locations.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+                lxu_cache_locations.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
                 {% endif %}
-                feature_requires_grad.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+                feature_requires_grad.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
                 {% if not dense %}
-                grad_indice_weights.packed_accessor32<acc_type<cache_t, true>, 1, RestrictPtrTraits>()
+                grad_indice_weights.packed_accessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits>()
                 {% else %}
-                grad_indice_weights.packed_accessor32<acc_type<scalar_t, true>, 1, RestrictPtrTraits>()
+                grad_indice_weights.packed_accessor32<at::acc_type<scalar_t, true>, 1, at::RestrictPtrTraits>()
                 {% endif %}
             );
             return;

--- a/fbgemm_gpu/codegen/embedding_bounds_check.cu
+++ b/fbgemm_gpu/codegen/embedding_bounds_check.cu
@@ -6,7 +6,7 @@
  */
 #include "codegen/embedding_backward_template_helpers.cuh"
 
-using namespace at;
+using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
 
 template <typename index_t>

--- a/fbgemm_gpu/codegen/embedding_bounds_check_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host.cpp
@@ -10,7 +10,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <torch/script.h>
 
-using namespace at;
+using Tensor = at::Tensor;
 
 void bounds_check_indices_cuda(
     Tensor rows_per_table,

--- a/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
@@ -10,7 +10,7 @@
 #include <torch/script.h>
 #include "codegen/embedding_common.h"
 
-using namespace at;
+using Tensor = at::Tensor;
 
 namespace {
 

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
@@ -18,7 +18,7 @@
 
 namespace {
 
-using namespace at;
+using Tensor = at::Tensor;
 
 // From https://stackoverflow.com/questions/55084047/intel-vector-instruction-to-zero-extend-8-4-bit-values-packed-in-a-32-bit-int-to
 // TODO: dispatch at architecture time?
@@ -187,7 +187,7 @@ void store_result(
             // To check D_tail_elements size
             std::copy(vs.data(), vs.data() + D_tail_elements, &output_acc[8 * (D_vecs - 1)]);
         } else if (std::is_same<output_t, at::Half>::value) {
-            std::array<Half, 8> vs;
+            std::array<at::Half, 8> vs;
             auto acci = acc_scaling ? _mm256_mul_ps(acc[D_vecs - 1], scale_vec) : acc[D_vecs - 1];
             store_vec(vs.data(), acci);
             std::copy(vs.data(), vs.data() + D_tail_elements, &output_acc[8 * (D_vecs - 1)]);
@@ -223,7 +223,7 @@ Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
       pinned_memory = true;
     }
 
-    at::Tensor output;
+    Tensor output;
     const int kINT8QparamsBytes = 8;
     SparseType o_dtype = static_cast<SparseType>(output_dtype);
     TORCH_CHECK(o_dtype == SparseType::FP32 || o_dtype == SparseType::FP16 || o_dtype == SparseType::INT8);

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
@@ -11,7 +11,7 @@
 #include <torch/script.h>
 #include "c10/core/ScalarType.h"
 
-using namespace at;
+using Tensor = at::Tensor;
 
 Tensor int_nbit_split_embedding_codegen_forward_unweighted_cuda(
     Tensor dev_weights,

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
@@ -17,7 +17,7 @@
 #include <torch/serialize/input-archive.h>
 #include <torch/serialize/output-archive.h>
 
-using namespace at;
+using Tensor = at::Tensor;
 
 Tensor int_nbit_split_embedding_codegen_forward_unweighted_cpu(
     Tensor dev_weights,
@@ -353,7 +353,7 @@ struct TensorQueue : torch::CustomClassHolder {
     archive.load_from(serialized.data(), serialized.size());
 
     archive.read(std::string("init_tensor"), init_tensor_);
-    string key = "queue";
+    std::string key = "queue";
     Tensor size_tensor;
     archive.read(std::string(key + "/size"), size_tensor);
     const auto* size_tensor_acc = size_tensor.data_ptr<int64_t>();
@@ -371,7 +371,7 @@ struct TensorQueue : torch::CustomClassHolder {
         std::make_shared<torch::jit::CompilationUnit>());
     std::ostringstream oss;
     archive.write(std::string("init_tensor"), init_tensor_);
-    string key = "queue";
+    std::string key = "queue";
     archive.write(
         key + "/size", torch::tensor(static_cast<int64_t>(queue_.size())));
     for (const auto index : c10::irange(queue_.size())) {

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_split_template.cu
@@ -10,9 +10,9 @@
 
 using namespace fbgemm_gpu;
 
-namespace nbit {
+using Tensor = at::Tensor;
 
-using namespace at;
+namespace nbit {
 
 constexpr int32_t kCacheLocationMissing = -1;
 
@@ -174,23 +174,23 @@ void cp_async_zfill(void *smem_ptr, void const *global_ptr, bool pred_guard) {
 template<typename index_t, typename output_t, size_t OutputRowsPerThread, size_t WarpsPerBlock, size_t InputRowsInFlight, size_t MinNum128BRows, size_t MaxNum128BRows>
 __launch_bounds__(WarpsPerBlock * 32)
 __global__ void fp32_split_embedding_codegen_forward_{{ wdesc }}_kernel_small_L(
-  const PackedTensorAccessor64<uint8_t, 1, RestrictPtrTraits> dev_weights,
-  const PackedTensorAccessor64<uint8_t, 1, RestrictPtrTraits> uvm_weights,
-  const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> weights_placements,
-  const PackedTensorAccessor32<int64_t, 1, RestrictPtrTraits> weights_offsets,
-  const PackedTensorAccessor32<uint8_t, 1, RestrictPtrTraits> weights_tys,
-  const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> D_offsets,
-  const PackedTensorAccessor32<index_t, 1, RestrictPtrTraits> indices,
-  const PackedTensorAccessor32<index_t, 1, RestrictPtrTraits> offsets,
+  const at::PackedTensorAccessor64<uint8_t, 1, at::RestrictPtrTraits> dev_weights,
+  const at::PackedTensorAccessor64<uint8_t, 1, at::RestrictPtrTraits> uvm_weights,
+  const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
+  const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
+  const at::PackedTensorAccessor32<uint8_t, 1, at::RestrictPtrTraits> weights_tys,
+  const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
+  const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
+  const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
   int64_t pooling_mode,
   {% if weighted %}
-  PackedTensorAccessor32<float, 1, RestrictPtrTraits>
+  at::PackedTensorAccessor32<float, 1, at::RestrictPtrTraits>
       indice_weights,
   {% endif %}
-  PackedTensorAccessor32<output_t, 2, RestrictPtrTraits>
+  at::PackedTensorAccessor32<output_t, 2, at::RestrictPtrTraits>
       output, // [B][total_D],
-  const PackedTensorAccessor64<uint8_t, 2, RestrictPtrTraits> lxu_cache_weights,
-  const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> lxu_cache_locations
+  const at::PackedTensorAccessor64<uint8_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
+  const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> lxu_cache_locations
   ) {
   int32_t B = output.size(0);
   int32_t T = D_offsets.size(0) - 1;
@@ -370,23 +370,23 @@ __global__ void fp32_split_embedding_codegen_forward_{{ wdesc }}_kernel_small_L(
 template<typename index_t, typename output_t, size_t OutputRowsPerThread, size_t WarpsPerBlock, size_t InputRowsInFlight, size_t MinNum128BRows, size_t MaxNum128BRows>
 __launch_bounds__(WarpsPerBlock * 32)
 __global__ void fp16_split_embedding_codegen_forward_{{ wdesc }}_kernel_small_L(
-  const PackedTensorAccessor64<uint8_t, 1, RestrictPtrTraits> dev_weights,
-  const PackedTensorAccessor64<uint8_t, 1, RestrictPtrTraits> uvm_weights,
-  const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> weights_placements,
-  const PackedTensorAccessor32<int64_t, 1, RestrictPtrTraits> weights_offsets,
-  const PackedTensorAccessor32<uint8_t, 1, RestrictPtrTraits> weights_tys,
-  const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> D_offsets,
-  const PackedTensorAccessor32<index_t, 1, RestrictPtrTraits> indices,
-  const PackedTensorAccessor32<index_t, 1, RestrictPtrTraits> offsets,
+  const at::PackedTensorAccessor64<uint8_t, 1, at::RestrictPtrTraits> dev_weights,
+  const at::PackedTensorAccessor64<uint8_t, 1, at::RestrictPtrTraits> uvm_weights,
+  const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
+  const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
+  const at::PackedTensorAccessor32<uint8_t, 1, at::RestrictPtrTraits> weights_tys,
+  const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
+  const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
+  const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
   int64_t pooling_mode,
   {% if weighted %}
-  PackedTensorAccessor32<float, 1, RestrictPtrTraits>
+  at::PackedTensorAccessor32<float, 1, at::RestrictPtrTraits>
       indice_weights,
   {% endif %}
-  PackedTensorAccessor32<output_t, 2, RestrictPtrTraits>
+  at::PackedTensorAccessor32<output_t, 2, at::RestrictPtrTraits>
       output, // [B][total_D],
-  const PackedTensorAccessor64<uint8_t, 2, RestrictPtrTraits> lxu_cache_weights,
-  const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> lxu_cache_locations
+  const at::PackedTensorAccessor64<uint8_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
+  const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> lxu_cache_locations
   ) {
   int32_t B = output.size(0);
   int32_t T = D_offsets.size(0) - 1;
@@ -572,23 +572,23 @@ __global__ void fp16_split_embedding_codegen_forward_{{ wdesc }}_kernel_small_L(
 template<typename index_t, typename output_t, size_t OutputRowsPerThread, size_t WarpsPerBlock, size_t InputRowsInFlight, size_t MinNum128BRows, size_t MaxNum128BRows>
 __launch_bounds__(WarpsPerBlock * 32)
 __global__ void int_8bit_split_embedding_codegen_forward_{{ wdesc }}_kernel_small_L(
-  const PackedTensorAccessor64<uint8_t, 1, RestrictPtrTraits> dev_weights,
-  const PackedTensorAccessor64<uint8_t, 1, RestrictPtrTraits> uvm_weights,
-  const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> weights_placements,
-  const PackedTensorAccessor32<int64_t, 1, RestrictPtrTraits> weights_offsets,
-  const PackedTensorAccessor32<uint8_t, 1, RestrictPtrTraits> weights_tys,
-  const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> D_offsets,
-  const PackedTensorAccessor32<index_t, 1, RestrictPtrTraits> indices,
-  const PackedTensorAccessor32<index_t, 1, RestrictPtrTraits> offsets,
+  const at::PackedTensorAccessor64<uint8_t, 1, at::RestrictPtrTraits> dev_weights,
+  const at::PackedTensorAccessor64<uint8_t, 1, at::RestrictPtrTraits> uvm_weights,
+  const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
+  const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
+  const at::PackedTensorAccessor32<uint8_t, 1, at::RestrictPtrTraits> weights_tys,
+  const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
+  const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
+  const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
   int64_t pooling_mode,
   {% if weighted %}
-  PackedTensorAccessor32<float, 1, RestrictPtrTraits>
+  at::PackedTensorAccessor32<float, 1, at::RestrictPtrTraits>
       indice_weights,
   {% endif %}
-  PackedTensorAccessor32<output_t, 2, RestrictPtrTraits>
+  at::PackedTensorAccessor32<output_t, 2, at::RestrictPtrTraits>
       output, // [B][total_D]
-  const PackedTensorAccessor64<uint8_t, 2, RestrictPtrTraits> lxu_cache_weights,
-  const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> lxu_cache_locations
+  const at::PackedTensorAccessor64<uint8_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
+  const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> lxu_cache_locations
   ) {
   int32_t B = output.size(0);
   int32_t T = D_offsets.size(0) - 1;
@@ -775,23 +775,23 @@ __global__ void int_8bit_split_embedding_codegen_forward_{{ wdesc }}_kernel_smal
 template<typename index_t, typename output_t, size_t OutputRowsPerThread, size_t WarpsPerBlock, size_t InputRowsInFlight, size_t MinNum128BRows, size_t MaxNum128BRows>
 __launch_bounds__(WarpsPerBlock * 32)
 __global__ void int_4bit_split_embedding_codegen_forward_{{ wdesc }}_kernel_small_L(
-  const PackedTensorAccessor64<uint8_t, 1, RestrictPtrTraits> dev_weights,
-  const PackedTensorAccessor64<uint8_t, 1, RestrictPtrTraits> uvm_weights,
-  const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> weights_placements,
-  const PackedTensorAccessor32<int64_t, 1, RestrictPtrTraits> weights_offsets,
-  const PackedTensorAccessor32<uint8_t, 1, RestrictPtrTraits> weights_tys,
-  const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> D_offsets,
-  const PackedTensorAccessor32<index_t, 1, RestrictPtrTraits> indices,
-  const PackedTensorAccessor32<index_t, 1, RestrictPtrTraits> offsets,
+  const at::PackedTensorAccessor64<uint8_t, 1, at::RestrictPtrTraits> dev_weights,
+  const at::PackedTensorAccessor64<uint8_t, 1, at::RestrictPtrTraits> uvm_weights,
+  const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
+  const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
+  const at::PackedTensorAccessor32<uint8_t, 1, at::RestrictPtrTraits> weights_tys,
+  const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
+  const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
+  const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
   int64_t pooling_mode,
   {% if weighted %}
-  PackedTensorAccessor32<float, 1, RestrictPtrTraits>
+  at::PackedTensorAccessor32<float, 1, at::RestrictPtrTraits>
       indice_weights,
   {% endif %}
-  PackedTensorAccessor32<output_t, 2, RestrictPtrTraits>
+  at::PackedTensorAccessor32<output_t, 2, at::RestrictPtrTraits>
       output, // [B][total_D],
-  const PackedTensorAccessor64<uint8_t, 2, RestrictPtrTraits> lxu_cache_weights,
-  const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> lxu_cache_locations
+  const at::PackedTensorAccessor64<uint8_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
+  const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> lxu_cache_locations
   ) {
   int32_t B = output.size(0);
   int32_t T = D_offsets.size(0) - 1;
@@ -987,13 +987,13 @@ __device__ inline uint32_t pruned_hash_function(uint32_t h) {
 }
 
 __global__ void int_nbit_split_embedding_codegen_forward_pruned_hashmap_lookup_{{ wdesc }}_kernel(
-    const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> indices,
-    const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> offsets,
-    const PackedTensorAccessor64<int32_t, 2, RestrictPtrTraits> hash_table,
-    const PackedTensorAccessor32<int64_t, 1, RestrictPtrTraits> hash_table_offsets,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> indices,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> offsets,
+    const at::PackedTensorAccessor64<int32_t, 2, at::RestrictPtrTraits> hash_table,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> hash_table_offsets,
     int32_t B,
     int32_t T,
-    PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> dense_indices) {
+    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> dense_indices) {
     // uint32_t capacity = hash_table.size(0);
     int32_t b_t = blockIdx.x * blockDim.y + threadIdx.y;
     int32_t t = b_t / B;
@@ -1050,13 +1050,13 @@ __global__ void int_nbit_split_embedding_codegen_forward_pruned_hashmap_lookup_{
 
 {% if not weighted %}
 __global__ void int_nbit_split_embedding_codegen_forward_pruned_array_lookup_kernel(
-    const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> indices,
-    const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> offsets,
-    const PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> index_remappings,
-    const PackedTensorAccessor32<int64_t, 1, RestrictPtrTraits> index_remappings_offsets,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> indices,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> offsets,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> index_remappings,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> index_remappings_offsets,
     int32_t B,
     int32_t T,
-    PackedTensorAccessor32<int32_t, 1, RestrictPtrTraits> dense_indices) {
+    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> dense_indices) {
   int32_t b_t = blockIdx.x * blockDim.y + threadIdx.y;
   int32_t t = b_t / B;
   int32_t b = b_t % B;
@@ -1080,28 +1080,28 @@ __global__ void int_nbit_split_embedding_codegen_forward_pruned_array_lookup_ker
 
 }
 
-at::Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cuda(
-    at::Tensor dev_weights,
-    at::Tensor uvm_weights,
-    at::Tensor weights_placements,
-    at::Tensor weights_offsets,
-    at::Tensor weights_tys,
-    at::Tensor D_offsets,
+Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cuda(
+    Tensor dev_weights,
+    Tensor uvm_weights,
+    Tensor weights_placements,
+    Tensor weights_offsets,
+    Tensor weights_tys,
+    Tensor D_offsets,
     int64_t total_D,
     int64_t max_int2_D,
     int64_t max_int4_D,
     int64_t max_int8_D,
     int64_t max_float16_D,
     int64_t max_float32_D,
-    at::Tensor indices,
-    at::Tensor offsets,
+    Tensor indices,
+    Tensor offsets,
     int64_t pooling_mode,
     {% if weighted %}
-    at::Tensor indice_weights,
+    Tensor indice_weights,
     {% endif %}
     int64_t output_dtype,
-    at::Tensor lxu_cache_weights,
-    at::Tensor lxu_cache_locations,
+    Tensor lxu_cache_weights,
+    Tensor lxu_cache_locations,
     int64_t unused
 ) {
     at::cuda::OptionalCUDAGuard device_guard;
@@ -1116,7 +1116,7 @@ at::Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cuda(
     TORCH_CHECK(total_D > 0);
     TORCH_CHECK(max_int2_D == 0);
 
-    at::Tensor output;
+    Tensor output;
     const int kINT8QparamsBytes = 8;
     SparseType o_dtype = static_cast<SparseType>(output_dtype);
     TORCH_CHECK(o_dtype == SparseType::FP32 || o_dtype == SparseType::FP16 || o_dtype == SparseType::INT8);
@@ -1298,11 +1298,11 @@ at::Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cuda(
     return output;
 }
 
-at::Tensor pruned_hashmap_lookup_{{ wdesc }}_cuda(
-    at::Tensor indices,
-    at::Tensor offsets,
-    at::Tensor hash_table,
-    at::Tensor hash_table_offsets) {
+Tensor pruned_hashmap_lookup_{{ wdesc }}_cuda(
+    Tensor indices,
+    Tensor offsets,
+    Tensor hash_table,
+    Tensor hash_table_offsets) {
     at::cuda::OptionalCUDAGuard device_guard;
     device_guard.set_index(indices.get_device());
     auto dense_indices = at::empty_like(indices);
@@ -1329,11 +1329,11 @@ at::Tensor pruned_hashmap_lookup_{{ wdesc }}_cuda(
 }
 
 {% if not weighted %}
-at::Tensor pruned_array_lookup_cuda(
-    at::Tensor indices,
-    at::Tensor offsets,
-    at::Tensor index_remappings,
-    at::Tensor index_remappings_offsets) {
+Tensor pruned_array_lookup_cuda(
+    Tensor indices,
+    Tensor offsets,
+    Tensor index_remappings,
+    Tensor index_remappings_offsets) {
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(indices.get_device());
   auto dense_indices = at::empty_like(indices);

--- a/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
@@ -19,7 +19,7 @@
 
 #include <ATen/AccumulateType.h>
 
-using namespace at;
+using Tensor = at::Tensor;
 
 namespace {
 void report_error_(
@@ -205,18 +205,18 @@ Tensor split_embedding_codegen_forward_cpu(
 
   Tensor output;
   if (weights.scalar_type() == at::kHalf ||
-      weights.scalar_type() == ScalarType::Byte) {
-    output = empty({B, total_D}, weights.options().dtype(at::kFloat));
+      weights.scalar_type() == at::ScalarType::Byte) {
+    output = at::empty({B, total_D}, weights.options().dtype(at::kFloat));
   } else {
-    output = empty({B, total_D}, weights.options());
+    output = at::empty({B, total_D}, weights.options());
   }
 
   // It is assumed that the indice_weights will always be float
   TORCH_CHECK(
       !indice_weights.defined() || indice_weights.scalar_type() != at::kHalf);
   AT_DISPATCH_FLOATING_TYPES_AND2(
-      ScalarType::Half,
-      ScalarType::Byte,
+      at::ScalarType::Half,
+      at::ScalarType::Byte,
       weights.scalar_type(),
       "split_embedding_cpu_forward",
       [&]() {
@@ -332,9 +332,9 @@ void batched_csr2csc(
     BatchedHyperCompressedSparseColumn& batched_csc,
     int B,
     // TODO: use accessor for the following 3 parameters
-    const TensorAccessor<int64_t, 1>& batched_csr_offsets,
-    const TensorAccessor<int64_t, 1>& batched_csr_indices,
-    const TensorAccessor<scalar_t, 1>& batched_csr_weights,
+    const at::TensorAccessor<int64_t, 1>& batched_csr_offsets,
+    const at::TensorAccessor<int64_t, 1>& batched_csr_indices,
+    const at::TensorAccessor<scalar_t, 1>& batched_csr_weights,
     int64_t pooling_mode,
     const int* table_to_feature_offset,
     int64_t num_embeddings) {
@@ -396,7 +396,7 @@ void batched_csr2csc(
     int* sorted_col_row_index_keys = nullptr;
     int* sorted_col_row_index_values = nullptr;
     std::tie(sorted_col_row_index_keys, sorted_col_row_index_values) =
-        fbgemm::radix_sort_parallel(
+        fbgemm_gpu::radix_sort_parallel(
             tmpBufKeys,
             tmpBufValues,
             tmpBuf1Keys,
@@ -574,9 +574,9 @@ void batched_csr2csc(
 template void batched_csr2csc<float>(
     BatchedHyperCompressedSparseColumn& batched_csc,
     int B,
-    const TensorAccessor<int64_t, 1>& batched_csr_offsets,
-    const TensorAccessor<int64_t, 1>& batched_csr_indices,
-    const TensorAccessor<float, 1>& batched_csr_weights,
+    const at::TensorAccessor<int64_t, 1>& batched_csr_offsets,
+    const at::TensorAccessor<int64_t, 1>& batched_csr_indices,
+    const at::TensorAccessor<float, 1>& batched_csr_weights,
     int64_t pooling_mode,
     const int* table_to_feature_offset,
     int64_t num_embeddings);
@@ -584,9 +584,9 @@ template void batched_csr2csc<float>(
 template void batched_csr2csc<double>(
     BatchedHyperCompressedSparseColumn& batched_csc,
     int B,
-    const TensorAccessor<int64_t, 1>& batched_csr_offsets,
-    const TensorAccessor<int64_t, 1>& batched_csr_indices,
-    const TensorAccessor<double, 1>& batched_csr_weights,
+    const at::TensorAccessor<int64_t, 1>& batched_csr_offsets,
+    const at::TensorAccessor<int64_t, 1>& batched_csr_indices,
+    const at::TensorAccessor<double, 1>& batched_csr_weights,
     int64_t pooling_mode,
     const int* table_to_feature_offset,
     int64_t num_embeddings);

--- a/fbgemm_gpu/include/fbgemm_gpu/batched_unary_embedding_ops.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/batched_unary_embedding_ops.cuh
@@ -33,7 +33,7 @@ __global__ void batched_unary_embeddings_forward_kernel(
   index_t indices_start = offsets[t * B + b];
   index_t indices_end = offsets[t * B + b + 1];
   int32_t L = indices_end - indices_start;
-  // TODO: this should be acc_type<scalar_t, true>
+  // TODO: this should be at::acc_type<scalar_t, true>
   scalar_t sum = 0.0;
   for (int32_t l = 0; l < L; ++l) {
     auto idx = __ldg(&indices[indices_start + l]);

--- a/fbgemm_gpu/include/fbgemm_gpu/cpu_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/cpu_utils.h
@@ -10,7 +10,7 @@
 #include <cstdint>
 #include <utility>
 
-namespace fbgemm {
+namespace fbgemm_gpu {
 
 template <typename K, typename V>
 std::pair<K*, V*> radix_sort_parallel(
@@ -21,4 +21,4 @@ std::pair<K*, V*> radix_sort_parallel(
     int64_t elements_count,
     int64_t max_value);
 
-} // namespace fbgemm
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/include/fbgemm_gpu/input_combine.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/input_combine.h
@@ -9,7 +9,7 @@
 
 #include <ATen/ATen.h>
 
-namespace fbgemm {
+namespace fbgemm_gpu {
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor> tbe_input_combine_cpu(
     const std::vector<at::Tensor>& indices_list,
@@ -17,4 +17,4 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> tbe_input_combine_cpu(
     const std::vector<at::Tensor>& per_sample_weights,
     const at::Tensor& include_last_offsets);
 
-} // namespace fbgemm
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/include/fbgemm_gpu/permute_pooled_embedding_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/permute_pooled_embedding_ops.h
@@ -9,7 +9,7 @@
 
 #include <ATen/ATen.h>
 
-namespace fbgemm {
+namespace fbgemm_gpu {
 at::Tensor permute_pooled_embs_cpu(
     const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
     const at::Tensor& offset_dim_list,
@@ -23,4 +23,4 @@ at::Tensor permute_pooled_embs_gpu(
     const at::Tensor& permute_list,
     const at::Tensor& inv_offset_dim_list,
     const at::Tensor& inv_permute_list);
-} // namespace fbgemm
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -9,7 +9,7 @@
 
 #include <ATen/ATen.h>
 
-namespace fbgemm {
+namespace fbgemm_gpu {
 
 // Return array of size T_in.numel(), representing incomplete exclusive cumsum
 at::Tensor asynchronous_exclusive_cumsum_gpu(const at::Tensor& t_in);
@@ -298,4 +298,4 @@ histogram_binning_calibration_by_feature_cuda(
     int64_t bin_ctr_in_use_after = 0,
     double bin_ctr_weight_value = 1.0);
 
-} // namespace fbgemm
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/cpu_utils.cpp
+++ b/fbgemm_gpu/src/cpu_utils.cpp
@@ -11,7 +11,7 @@
 #include <omp.h>
 #include "c10/util/Exception.h"
 
-namespace fbgemm {
+namespace fbgemm_gpu {
 
 namespace {
 
@@ -173,4 +173,4 @@ template std::pair<int64_t*, int*> radix_sort_parallel(
     int64_t elements_count,
     int64_t max_value);
 
-} // namespace fbgemm
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/cumem_utils.cu
+++ b/fbgemm_gpu/src/cumem_utils.cu
@@ -14,7 +14,7 @@
 #include "fbgemm_gpu/enum_utils.h"
 #include "fbgemm_gpu/fbgemm_cuda_utils.cuh"
 
-using namespace at;
+using Tensor = at::Tensor;
 
 namespace fbgemm_gpu {
 

--- a/fbgemm_gpu/src/cumem_utils_host.cpp
+++ b/fbgemm_gpu/src/cumem_utils_host.cpp
@@ -10,7 +10,8 @@
 
 #include "cumem_utils.h"
 
-using namespace at;
+using Tensor = at::Tensor;
+
 namespace fbgemm_gpu {
 
 TORCH_LIBRARY_FRAGMENT(fb, m) {

--- a/fbgemm_gpu/src/layout_transform_ops_cpu.cpp
+++ b/fbgemm_gpu/src/layout_transform_ops_cpu.cpp
@@ -10,15 +10,17 @@
 #include "ATen/Parallel.h"
 #include "fbgemm_gpu/sparse_ops_utils.h"
 
-namespace fbgemm {
+using Tensor = at::Tensor;
 
-at::Tensor recat_embedding_grad_output_mixed_D_cpu(
-    const at::Tensor& grad_output, // [B_local][Sum_T_global(D)]
+namespace fbgemm_gpu {
+
+Tensor recat_embedding_grad_output_mixed_D_cpu(
+    const Tensor& grad_output, // [B_local][Sum_T_global(D)]
     const std::vector<int64_t>& dim_sum_per_rank) {
   TORCH_CHECK(grad_output.is_contiguous());
   const auto B_local = grad_output.sizes()[0];
 
-  at::Tensor sharded_grad_output =
+  Tensor sharded_grad_output =
       at::empty({grad_output.numel()}, grad_output.options());
 
   int n = dim_sum_per_rank.size();
@@ -59,7 +61,7 @@ at::Tensor recat_embedding_grad_output_mixed_D_cpu(
   return sharded_grad_output;
 }
 
-} // namespace fbgemm
+} // namespace fbgemm_gpu
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
@@ -73,5 +75,5 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
   m.impl(
       "recat_embedding_grad_output_mixed_D",
-      fbgemm::recat_embedding_grad_output_mixed_D_cpu);
+      fbgemm_gpu::recat_embedding_grad_output_mixed_D_cpu);
 }

--- a/fbgemm_gpu/src/layout_transform_ops_gpu.cpp
+++ b/fbgemm_gpu/src/layout_transform_ops_gpu.cpp
@@ -15,10 +15,10 @@
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   DISPATCH_TO_CUDA(
       "recat_embedding_grad_output_mixed_D_batch",
-      fbgemm::recat_embedding_grad_output_mixed_D_batch_cuda);
+      fbgemm_gpu::recat_embedding_grad_output_mixed_D_batch_cuda);
   DISPATCH_TO_CUDA(
       "recat_embedding_grad_output_mixed_D",
-      fbgemm::recat_embedding_grad_output_mixed_D_cuda);
+      fbgemm_gpu::recat_embedding_grad_output_mixed_D_cuda);
   DISPATCH_TO_CUDA(
-      "recat_embedding_grad_output", fbgemm::recat_embedding_grad_output_cuda);
+      "recat_embedding_grad_output", fbgemm_gpu::recat_embedding_grad_output_cuda);
 }

--- a/fbgemm_gpu/src/merge_pooled_embeddings_cpu.cpp
+++ b/fbgemm_gpu/src/merge_pooled_embeddings_cpu.cpp
@@ -9,18 +9,20 @@
 #include <c10/core/TensorOptions.h>
 #include <torch/library.h>
 
-namespace fbgemm {
+using Tensor = at::Tensor;
 
-at::Tensor merge_pooled_embeddings_cpu(
-    std::vector<at::Tensor> pooled_embeddings,
+namespace fbgemm_gpu {
+
+Tensor merge_pooled_embeddings_cpu(
+    std::vector<Tensor> pooled_embeddings,
     int64_t batch_size,
     at::Device target_device) {
-  auto cat_host_0 = [&](const std::vector<at::Tensor>& ts) {
+  auto cat_host_0 = [&](const std::vector<Tensor>& ts) {
     int64_t n = 0;
     for (auto& t : ts) {
       n += t.numel();
     }
-    at::Tensor r;
+    Tensor r;
     if (n == 0) {
       r = at::empty({n});
     } else {
@@ -32,8 +34,8 @@ at::Tensor merge_pooled_embeddings_cpu(
   return cat_host_0(pooled_embeddings);
 }
 
-} // namespace fbgemm
+} // namespace fbgemm_gpu
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
-  m.impl("merge_pooled_embeddings", fbgemm::merge_pooled_embeddings_cpu);
+  m.impl("merge_pooled_embeddings", fbgemm_gpu::merge_pooled_embeddings_cpu);
 }

--- a/fbgemm_gpu/src/merge_pooled_embeddings_gpu.cpp
+++ b/fbgemm_gpu/src/merge_pooled_embeddings_gpu.cpp
@@ -19,7 +19,7 @@
 
 #include <algorithm>
 
-using namespace at;
+using Tensor = at::Tensor;
 
 #define NVML_CHECK(fn)                  \
   do {                                  \
@@ -308,6 +308,8 @@ Tensor cat_dim_1(
 }
 } // namespace
 
+namespace fbgemm_gpu {
+
 // TODO: Add device arg.
 Tensor merge_pooled_embeddings(
     std::vector<Tensor> pooled_embeddings,
@@ -337,6 +339,8 @@ Tensor merge_pooled_embeddings(
   return cat_dim_1(pooled_embeddings, batch_size, target_device);
 }
 
+} // namespace fbgemm_gpu
+
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "merge_pooled_embeddings(Tensor[] pooled_embeddings, int batch_size, Device target_device) -> Tensor");
@@ -346,5 +350,5 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   m.impl(
       "merge_pooled_embeddings",
       torch::dispatch(
-          c10::DispatchKey::CUDA, TORCH_FN(merge_pooled_embeddings)));
+          c10::DispatchKey::CUDA, TORCH_FN(fbgemm_gpu::merge_pooled_embeddings)));
 }

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops.cu
@@ -15,13 +15,16 @@
 #include "fbgemm_gpu/layout_transform_ops.cuh"
 #include "fbgemm_gpu/permute_pooled_embedding_ops.h"
 
-namespace fbgemm {
-at::Tensor permute_pooled_embs_gpu(
-    const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
-    const at::Tensor& offset_dim_list,
-    const at::Tensor& permute_list,
-    const at::Tensor& inv_offset_dim_list,
-    const at::Tensor& inv_permute_list) {
+using Tensor = at::Tensor;
+
+namespace fbgemm_gpu {
+
+Tensor permute_pooled_embs_gpu(
+    const Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
+    const Tensor& offset_dim_list,
+    const Tensor& permute_list,
+    const Tensor& inv_offset_dim_list,
+    const Tensor& inv_permute_list) {
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(pooled_embs.get_device());
   // We couldn't pass the "pooled_embs.is_contiguous()" check in the backward
@@ -37,7 +40,7 @@ at::Tensor permute_pooled_embs_gpu(
   TORCH_CHECK(pooled_embs_contiguous.device() == inv_offset_dim_list.device());
   TORCH_CHECK(offset_dim_list.numel() == permute_list.numel() + 1);
   TORCH_CHECK(offset_dim_list.numel() == inv_offset_dim_list.numel());
-  at::Tensor permuted_pooled_embs = at::empty_like(pooled_embs_contiguous);
+  Tensor permuted_pooled_embs = at::empty_like(pooled_embs_contiguous);
 
   // This kernel is moving D elements per warp.
   // We are launching ( div_round_up(T, warp_per_block), B ) blocks.
@@ -69,4 +72,4 @@ at::Tensor permute_pooled_embs_gpu(
 
   return permuted_pooled_embs;
 }
-} // namespace fbgemm
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/quantize_ops_cpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops_cpu.cpp
@@ -10,11 +10,13 @@
 #include "fbgemm/QuantUtils.h"
 #include "fbgemm_gpu/sparse_ops_utils.h"
 
-namespace fbgemm {
+using Tensor = at::Tensor;
 
-at::Tensor& _float_to_fused8bitrowwise_cpu_out(
-    at::Tensor& output,
-    const at::Tensor& input) {
+namespace fbgemm_gpu {
+
+Tensor& _float_to_fused8bitrowwise_cpu_out(
+    Tensor& output,
+    const Tensor& input) {
   TENSOR_ON_CPU(input);
   TORCH_CHECK(
       input.dim() >= 2,
@@ -37,9 +39,9 @@ at::Tensor& _float_to_fused8bitrowwise_cpu_out(
   return output;
 }
 
-at::Tensor& _fused8bitrowwise_to_float_cpu_out(
-    at::Tensor& output,
-    const at::Tensor& input) {
+Tensor& _fused8bitrowwise_to_float_cpu_out(
+    Tensor& output,
+    const Tensor& input) {
   TENSOR_ON_CPU(input);
   TORCH_CHECK(
       input.dim() >= 2,
@@ -62,8 +64,8 @@ at::Tensor& _fused8bitrowwise_to_float_cpu_out(
   return output;
 }
 
-at::Tensor _float_to_fusednbitrowwise_cpu(
-    const at::Tensor& input,
+Tensor _float_to_fusednbitrowwise_cpu(
+    const Tensor& input,
     const int64_t bit_rate) {
   TENSOR_ON_CPU(input);
   TENSOR_NDIM_EQUALS(input, 2);
@@ -92,8 +94,8 @@ at::Tensor _float_to_fusednbitrowwise_cpu(
   return output;
 }
 
-at::Tensor _fusednbitrowwise_to_float_cpu(
-    const at::Tensor& input,
+Tensor _fusednbitrowwise_to_float_cpu(
+    const Tensor& input,
     const int64_t bit_rate) {
   TENSOR_ON_CPU(input);
   TENSOR_NDIM_EQUALS(input, 2);
@@ -121,14 +123,14 @@ at::Tensor _fusednbitrowwise_to_float_cpu(
 
 namespace {
 
-at::Tensor _float_to_fused8bitrowwise_cpu(const at::Tensor& input) {
+Tensor _float_to_fused8bitrowwise_cpu(const Tensor& input) {
   auto output = at::empty(
       {0},
       input.options().dtype(at::kByte)); // at::kBytes for uint8_t
   return _float_to_fused8bitrowwise_cpu_out(output, input);
 }
 
-at::Tensor _fused8bitrowwise_to_float_cpu(const at::Tensor& input) {
+Tensor _fused8bitrowwise_to_float_cpu(const Tensor& input) {
   auto output = at::empty(
       {0},
       input.options().dtype(at::kFloat)); // at::kBytes for uint8_t
@@ -136,7 +138,7 @@ at::Tensor _fused8bitrowwise_to_float_cpu(const at::Tensor& input) {
 }
 
 } // namespace
-} // namespace fbgemm
+} // namespace fbgemm_gpu
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def("FloatToFused8BitRowwiseQuantized(Tensor t) -> Tensor");
@@ -154,20 +156,20 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
   m.impl(
       "FloatToFused8BitRowwiseQuantized",
-      fbgemm::_float_to_fused8bitrowwise_cpu);
+      fbgemm_gpu::_float_to_fused8bitrowwise_cpu);
   m.impl(
       "FloatToFused8BitRowwiseQuantizedOut",
-      fbgemm::_float_to_fused8bitrowwise_cpu_out);
+      fbgemm_gpu::_float_to_fused8bitrowwise_cpu_out);
   m.impl(
       "Fused8BitRowwiseQuantizedToFloat",
-      fbgemm::_fused8bitrowwise_to_float_cpu);
+      fbgemm_gpu::_fused8bitrowwise_to_float_cpu);
   m.impl(
       "Fused8BitRowwiseQuantizedToFloatOut",
-      fbgemm::_fused8bitrowwise_to_float_cpu_out);
+      fbgemm_gpu::_fused8bitrowwise_to_float_cpu_out);
   m.impl(
       "FloatToFusedNBitRowwiseQuantizedSBHalf",
-      fbgemm::_float_to_fusednbitrowwise_cpu);
+      fbgemm_gpu::_float_to_fusednbitrowwise_cpu);
   m.impl(
       "FusedNBitRowwiseQuantizedSBHalfToFloat",
-      fbgemm::_fusednbitrowwise_to_float_cpu);
+      fbgemm_gpu::_fusednbitrowwise_to_float_cpu);
 }

--- a/fbgemm_gpu/src/quantize_ops_gpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops_gpu.cpp
@@ -13,14 +13,14 @@
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   DISPATCH_TO_CUDA(
       "FloatToFused8BitRowwiseQuantized",
-      fbgemm::_float_to_fused8bitrowwise_gpu);
+      fbgemm_gpu::_float_to_fused8bitrowwise_gpu);
   DISPATCH_TO_CUDA(
       "Fused8BitRowwiseQuantizedToFloat",
-      fbgemm::_fused8bitrowwise_to_float_gpu);
+      fbgemm_gpu::_fused8bitrowwise_to_float_gpu);
   DISPATCH_TO_CUDA(
       "FloatToFusedNBitRowwiseQuantizedSBHalf",
-      fbgemm::_float_to_fusednbitrowwise_gpu);
+      fbgemm_gpu::_float_to_fusednbitrowwise_gpu);
   DISPATCH_TO_CUDA(
       "FusedNBitRowwiseQuantizedSBHalfToFloat",
-      fbgemm::_fusednbitrowwise_to_float_gpu);
+      fbgemm_gpu::_fusednbitrowwise_to_float_gpu);
 }

--- a/fbgemm_gpu/src/split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/split_table_batched_embeddings.cpp
@@ -8,7 +8,7 @@
 #include <ATen/core/op_registration/op_registration.h>
 #include <torch/library.h>
 
-using namespace at;
+using Tensor = at::Tensor;
 
 // Map index to cache_set. h_in: linear_indices; C: #cache_sets.
 int64_t host_lxu_cache_slot(int64_t h_in, int64_t C);


### PR DESCRIPTION
Summary:
Move fbgemm_gpu code into fbgemm_gpu namespace.  Normalize use of at namespace.

First Diff to address task T106696656.  Additional Diffs to follow that update the python api.

Reviewed By: suphoff

Differential Revision: D32933112

