### PR TITLE
Support batched benchmark execution and fix benchmark stats reporting

### DIFF
--- a/fbgemm_gpu/bench/scripts/README.md
+++ b/fbgemm_gpu/bench/scripts/README.md
@@ -1,0 +1,54 @@
+# Running `batch_benchmark_run.py`
+This script acts as a wrapper around the existing `split_table_batched_embeddings_benchmark.py`
+benchmark to execute multiple benchmark instances and aggregate the results.
+
+Options for each execution are to be specified in individual lines of an input file that is
+passed to the script via the `--command-file` argument.  To accommodate various build
+configurations, the command used to invoke `split_table_batched_embeddings_benchmark` instances
+is passed to the script via the `--benchmark-command` argument.
+
+An example of a typical execution is:
+```
+python batch_benchmark_run.py --benchmark-command "python split_table_batched_embeddings_benchmark.py" --command-file batch_input.txt
+```
+
+which will provide something like the following output:
+```
+Running command 0: [<command_0_arguments>]
+...
+<command_0_output>
+...
+Running command 1: [<command_1_arguments>]
+...
+<command_1_output>
+...
+Number of commands run: 2
+Average FWD BW: 1197.9126493108731 GB/s
+        FWDBWD BW: 859.5188964175346 GB/s
+```
+
+Any commands failed will be reported to ease debugging.
+
+## Expected use-case
+This script is intended to be used in conjunction with synthetic datasets provided
+in the [dlrm_datasets repository](https://github.com/facebookresearch/dlrm_datasets).
+Simply clone this repository to obtain the datasets.
+
+Datasets in this repository provide inputs to the `split_table_batched_embeddings_benchmark.py`
+benchmark and can be specified with the `--requests_data_file` argument.  A subset of tables
+provided in the input dataset can be used for benchmarking through the `--tables` arguemnt.
+
+Please note that in order to use this feature, dimensions of the tables in the dataset
+must conform to the corresponding arguments of the benchmark; these being the following:
+* `--batch-size`
+* `--num-tables`
+* `--num-embeddings`
+* `--bag-size`
+
+Hence, a typical line in the input file to `batch_benchmark_run.py` will look something like the following:
+```
+device --requests_data_file ./fbgemm_t856_bs65536.pt --batch-size 65536 --num-tables 1 --tables "44" --num-embeddings 6618839 --bag-size 194
+```
+
+An error will be shown if any of these arguments do not align with the data provided.  This is
+in order to ensure proper accounting when metric reporting is performed.

--- a/fbgemm_gpu/bench/scripts/batch_benchmark_run.py
+++ b/fbgemm_gpu/bench/scripts/batch_benchmark_run.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+# (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import re
+import subprocess
+
+import click
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+@click.command()
+@click.option(
+    "--benchmark-command",
+    default="python split_table_batched_embeddings_benchmark.py",
+    help="Benchmark command to run",
+)
+@click.option(
+    "--command-file",
+    default="batch_input.txt",
+    help="File containing input commands to evaluate",
+)
+def batch_benchmark(
+    benchmark_command: str,
+    command_file: str,
+) -> None:
+    assert (
+        "split_table_batched_embeddings_benchmark" in benchmark_command
+    ), "split_table_batched_embeddings benchmark required for execution"
+
+    benchmark_cmd = benchmark_command.strip().split()
+
+    cmds_run = 0
+    failed_runs = []
+    total_fwd_bytes_read_gb = 0
+    total_fwdbwd_bytes_read_gb = 0
+    total_fwd_time_us = 0
+    total_fwdbwd_time_us = 0
+    with open(command_file) as cmd_file:
+        for line in cmd_file:
+            options = line.replace('"', "").strip().split()
+            cmd = benchmark_cmd + options
+            logging.info(f"Running command {cmds_run}: {cmd}")
+            result = subprocess.run(
+                cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+            )
+            logging.info(result.stdout.decode("utf-8"))
+            # Parse results
+            found_fwd_results = False
+            found_fwdbwd_results = False
+            for line in result.stdout.decode("utf-8").splitlines():
+                re_match = re.search(r"BW:  ([\.\d]+) GB/s, T: ([\.\d]+)us", line)
+                if re_match:
+                    bw_gb = float(re_match.groups()[0])
+                    time_us = int(re_match.groups()[1])
+                    total_bytes_read_gb = bw_gb * time_us / 1e6
+
+                    if "Forward, " in line:
+                        total_fwd_bytes_read_gb += total_bytes_read_gb
+                        total_fwd_time_us += time_us
+                        found_fwd_results = True
+                    elif "ForwardBackward, " in line:
+                        total_fwdbwd_bytes_read_gb += total_bytes_read_gb
+                        total_fwdbwd_time_us += time_us
+                        found_fwdbwd_results = True
+                    else:
+                        raise Exception(
+                            f"Unexpected reported metric for line: '{line}'"
+                        )
+            if not (found_fwd_results and found_fwdbwd_results):
+                failed_runs.append(cmds_run)
+            cmds_run += 1
+    logging.info(f"Number of commands run: {cmds_run}")
+    if failed_runs:
+        logging.info(f"Failed runs: {failed_runs}")
+    logging.info(
+        f"Average FWD BW: {total_fwd_bytes_read_gb / total_fwd_time_us * 1e6} GB/s"
+    )
+    logging.info(
+        f"        FWDBWD BW: {total_fwdbwd_bytes_read_gb / total_fwdbwd_time_us * 1e6} GB/s"
+    )
+
+
+if __name__ == "__main__":
+    batch_benchmark()


### PR DESCRIPTION
Summary:
As title, support multiple execution of benchmark scripts and report aggregated metric.

Further, require `--bag-size` argument to conform to input data file for proper metric accounting.

Differential Revision: D33182257

