### PR TITLE
Allways set dontfork on managed Tensor + new uvm clone

### DIFF
--- a/fbgemm_gpu/src/cumem_utils.h
+++ b/fbgemm_gpu/src/cumem_utils.h
@@ -44,6 +44,10 @@ void uvm_cuda_mem_prefetch_async(Tensor t, c10::optional<Tensor> device_t);
 // table on fork - causing slowdown on the next access from a CPU.
 void uvm_mem_advice_dont_fork(Tensor t);
 
+// Copy a contigious uvm Tensor (uvm_storage(t) is true) into a CPU Tensor
+// The copy uses single threaded memcpy
+Tensor uvm_to_cpu_clone(Tensor t);
+
 FBGEMM_GPU_ENUM_CREATE_TAG(uvm)
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/cumem_utils_host.cpp
+++ b/fbgemm_gpu/src/cumem_utils_host.cpp
@@ -43,6 +43,8 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
       "uvm_mem_advice_dont_fork(Tensor t) -> ()",
       TORCH_FN(uvm_mem_advice_dont_fork));
 
+  m.def("uvm_to_cpu_clone(Tensor t) -> Tensor", TORCH_FN(uvm_to_cpu_clone));
+
   m.def(FBGEMM_GPU_ENUM_OP(uvm, fbgemm_gpu_uvm_enum_query));
 }
 


### PR DESCRIPTION
Summary:
Workaround for S256045.
UVM Tensors are unmapped from the process page table on fork (spawn).
The UVM fault handler then slows down the UVM CPU<->CPU copy substantially reestablishing those mappings.
The workaround sets MADV_DONTFORK on the addresses (rounded down to page size) of UVM allocations - this prevents the removal from UVM pages from the original process page table.
Additionally this introduces a single threaded UVM->CPU tensor copy to
1) Avoid 8 trainers on a host to concurrently all threads with copy_
2) Avoid high concurency in the fault handler of the uvm kernel driver.

Reviewed By: jianyuh

Differential Revision: D33192043

