### PR TITLE
Move fb.embedding_bag_rowwise_prune to fbgemm_gpu OSS.

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_inference_converter.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_inference_converter.py
@@ -17,13 +17,6 @@ import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
 from torch import Tensor, nn
 
-# TODO: move torch.ops.fb.embedding_bag_rowwise_prune to OSS
-try:
-    # pyre-ignore[21]
-    from fbgemm_gpu import open_source  # noqa: F401
-except Exception:
-    torch.ops.load_library("//caffe2/torch/fb/sparsenn:sparsenn_operators")
-
 # TODO: add per-feature based converter option (based on embedding_specs during inference)
 # TODO: optimize embedding pruning and quantization latency.
 class SplitEmbInferenceConverter:
@@ -75,7 +68,7 @@ class SplitEmbInferenceConverter:
 
         (indicators, threshold) = self._prune_by_weights_l2_norm(new_num_rows, weights)
 
-        return torch.ops.fb.embedding_bag_rowwise_prune(
+        return torch.ops.fbgemm.embedding_bag_rowwise_prune(
             weights, indicators, threshold, torch.int32
         )
 

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -328,4 +328,13 @@ generic_histogram_binning_calibration_by_feature_cuda(
     int64_t bin_ctr_in_use_after = 0,
     double bin_ctr_weight_value = 1.0);
 
+std::tuple<at::Tensor, at::Tensor> embedding_bag_rowwise_prune(
+    const at::Tensor& weights,
+    const at::Tensor& indicator,
+    const double threshold,
+    at::ScalarType compressed_indices_dtype,
+    const bool abs,
+    const int64_t min_non_pruned_rows,
+    const c10::optional<double>& min_save_ratio);
+
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/test/split_embedding_inference_converter_test.py
+++ b/fbgemm_gpu/test/split_embedding_inference_converter_test.py
@@ -207,7 +207,6 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
             rtol=1.0e-1,
         )
 
-    @unittest.skipIf(open_source, "Not yet in OSS")
     @given(
         use_cpu=st.booleans() if gpu_available else st.just(True),
         use_array_for_index_remapping=st.booleans(),
@@ -284,7 +283,6 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
                 rtol=1.0e-1,
             )
 
-    @unittest.skipIf(open_source, "Not yet in OSS")
     @given(
         T=st.integers(min_value=1, max_value=10),
         D=st.integers(min_value=2, max_value=128),


### PR DESCRIPTION
Summary: Move the fb.embedding_bag_rowwise_prune op from caffe2/fb/sparsenn to fbgemm_gpu.

Reviewed By: jianyuh

Differential Revision: D33240318

