### PR TITLE
Add MSFP option for ads hpc model numeric emulations

### DIFF
--- a/fbgemm_gpu/test/quantize_ops_test.py
+++ b/fbgemm_gpu/test/quantize_ops_test.py
@@ -25,6 +25,8 @@ try:
 except Exception:
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
+    torch.ops.load_library("//caffe2/torch/fb/sparsenn:sparsenn_operators_gpu")
+    torch.ops.load_library("//caffe2/torch/fb/sparsenn:sparsenn_operators")
     from fbgemm_gpu.test.test_utils import (
         fused_rowwise_8bit_quantize_reference,
         fused_rowwise_8bit_dequantize_reference,
@@ -241,6 +243,39 @@ class TestFusedNBitRowwiseQuantizationConversion(unittest.TestCase):
             )
             # compare quantized data
             torch.testing.assert_allclose(dequantized_data_gpu.cpu(), reference)
+
+
+class TestDenseMLPQuantizationConversion(unittest.TestCase):
+    # pyre-ignore [56]: Invalid decoration, was not able to infer the type of argument
+    @given(
+        nrows=st.integers(min_value=0, max_value=100),
+        ncols=st.integers(min_value=0, max_value=100),
+    )
+    @settings(deadline=10000, suppress_health_check=[HealthCheck.filter_too_much])
+    def test_quantize_op(self, nrows: int, ncols: int) -> None:
+        ebits = 8
+        mbits = 7
+        bias = 127
+        max_pos = (1 << ((1 << ebits) - 2 - bias)) * (2 - 2 ** (-mbits))
+        min_pos = 2 ** (1 - bias - mbits)
+        bounding_box_size = 16
+        print("MSFP parameters", bounding_box_size, ebits, mbits, bias)
+        input_data = torch.rand(nrows, ncols).float()
+        quantized_data = torch.ops.fb.FloatToMSFPQuantized(
+            input_data.cuda(),
+            bounding_box_size,
+            ebits,
+            mbits,
+            bias,
+            min_pos,
+            max_pos,
+        )
+        dequantized_data = torch.ops.fb.MSFPQuantizedToFloat(
+            quantized_data.cuda(), ebits, mbits, bias
+        )
+        torch.testing.assert_allclose(
+            dequantized_data.cpu(), input_data, rtol=1, atol=0
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Add fake conversions between MSFP and fp32 in both forward and backward pass of the hpc ads model training.

TODO: Add compute kernels that split the FC operator into gemms for column_blocks of activations and row_blocks of weights

Reviewed By: jspark1105

Differential Revision: D30942234

