### PR TITLE
Add seq embedding kernel for infer TBE

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
@@ -10,6 +10,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <torch/script.h>
 #include "c10/core/ScalarType.h"
+#include "codegen/embedding_common.h"
 
 using Tensor = at::Tensor;
 
@@ -56,6 +57,25 @@ Tensor int_nbit_split_embedding_codegen_forward_weighted_cuda(
     Tensor lxu_cache_locations,
     int64_t unused);
 
+Tensor int_nbit_split_embedding_nobag_codegen_forward_unweighted_cuda(
+    Tensor dev_weights,
+    Tensor uvm_weights,
+    Tensor weights_placements,
+    Tensor weights_offsets,
+    Tensor weights_tys,
+    int64_t D,
+    int64_t max_int2_D,
+    int64_t max_int4_D,
+    int64_t max_int8_D,
+    int64_t max_float16_D,
+    int64_t max_float32_D,
+    Tensor indices,
+    Tensor offsets,
+    int64_t output_dtype,
+    Tensor lxu_cache_weights,
+    Tensor lxu_cache_locations,
+    int64_t unused);
+
 Tensor int_nbit_split_embedding_codegen_lookup_function(
     Tensor dev_weights,
     Tensor uvm_weights,
@@ -76,6 +96,29 @@ Tensor int_nbit_split_embedding_codegen_lookup_function(
     int64_t output_dtype,
     c10::optional<Tensor> lxu_cache_weights,
     c10::optional<Tensor> lxu_cache_locations) {
+  if (static_cast<PoolingMode>(pooling_mode) == PoolingMode::NONE) {
+    std::vector<int64_t> max_D_list{
+        max_int2_D, max_int4_D, max_int8_D, max_float16_D, max_float32_D};
+    int64_t max_D = *std::max_element(max_D_list.begin(), max_D_list.end());
+    return int_nbit_split_embedding_nobag_codegen_forward_unweighted_cuda(
+        dev_weights,
+        uvm_weights,
+        weights_placements,
+        weights_offsets,
+        weights_tys,
+        max_D,
+        max_int2_D,
+        max_int4_D,
+        max_int8_D,
+        max_float16_D,
+        max_float32_D,
+        indices,
+        offsets,
+        output_dtype,
+        lxu_cache_weights.value_or(at::empty({0, 0}, at::kByte)),
+        lxu_cache_locations.value_or(at::empty({0}, at::kInt)),
+        0);
+  }
   if (!indice_weights) {
     return int_nbit_split_embedding_codegen_forward_unweighted_cuda(
         dev_weights,

--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
@@ -1166,9 +1166,15 @@ struct VecNT {};
 template <>
 struct VecNT<1> {
   float acc;
+
   DEVICE_INLINE VecNT() {
     acc = 0;
   }
+
+  DEVICE_INLINE VecNT(float a) {
+    acc = a;
+  }
+
   DEVICE_INLINE void store(float* output_ptr) {
     *output_ptr = acc;
   }
@@ -1214,8 +1220,13 @@ struct VecNT<1> {
 template <>
 struct VecNT<2> {
   float2 acc;
+
   DEVICE_INLINE VecNT() {
     acc = make_zero_float2();
+  }
+
+  DEVICE_INLINE VecNT(half2 a) {
+    acc = __half22float2(a);
   }
 
   DEVICE_INLINE void store(float* output_ptr) {
@@ -1265,9 +1276,16 @@ struct VecNT<2> {
 template <>
 struct VecNT<4> {
   float4 acc;
+
   DEVICE_INLINE VecNT() {
     acc = make_zero_float4();
   }
+
+  DEVICE_INLINE VecNT(uint32_t v, half2 shift_scale) {
+    acc = make_zero_float4();
+    acc = accumulate_packed_int8(acc, v, shift_scale);
+  }
+
   DEVICE_INLINE void store(float* output_ptr) {
     bool aligned_16b = intptr_t(output_ptr) % 16 == 0;
     bool aligned_8b = intptr_t(output_ptr) % 8 == 0;
@@ -1347,8 +1365,14 @@ struct VecNT<4> {
 template <>
 struct VecNT<8> {
   float8 acc;
+
   DEVICE_INLINE VecNT() {
     acc = make_zero_float8();
+  }
+
+  DEVICE_INLINE VecNT(uint32_t v, half2 shift_scale) {
+    acc = make_zero_float8();
+    acc = accumulate_packed_int4(acc, v, shift_scale);
   }
 
   DEVICE_INLINE void store(float* output_ptr) {


### PR DESCRIPTION
Summary:
- Add sequence embedding support in infer TBE kernel

- TODO: "mask" solution for the duplicated embedding row access.

Differential Revision: D33341863

