### PR TITLE
fix warning count check in test_bounds_check

### DIFF
--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -3515,7 +3515,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             if bounds_check_mode == BoundsCheckMode.WARNING:
                 # -1 because when we have 2 elements in offsets, we have only 1
                 # warning for the pair.
-                self.assertEqual(warning.item(), min(2, offsets.numel() - 1))
+                self.assertGreaterEqual(warning.item(), min(2, offsets.numel() - 1))
         else:
             if use_cpu and indices.numel():
                 with self.assertRaises(RuntimeError):


### PR DESCRIPTION
Summary: In GPU multiple threads in a thread block can increase warning count for the same bound errors in offset array

Differential Revision: D33379301

