### PR TITLE
extract embedding input transpose out of embedding_backward_split_template.cu

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -110,7 +110,6 @@ set(codegen_dependencies
     ${CMAKE_CODEGEN_DIR}/embedding_backward_split_host_template.cpp
     ${CMAKE_CODEGEN_DIR}/embedding_backward_split_indice_weights_template.cu
     ${CMAKE_CODEGEN_DIR}/embedding_backward_split_template.cu
-    ${CMAKE_CODEGEN_DIR}/embedding_backward_template_helpers.cuh
     ${CMAKE_CODEGEN_DIR}/embedding_forward_quantized_cpu_template.cpp
     ${CMAKE_CODEGEN_DIR}/embedding_forward_quantized_host.cpp
     ${CMAKE_CODEGEN_DIR}/embedding_forward_quantized_host_cpu.cpp
@@ -122,6 +121,14 @@ set(codegen_dependencies
     ${CMAKE_CODEGEN_DIR}/__init__.template
     ${CMAKE_CODEGEN_DIR}/lookup_args.py
     ${CMAKE_CODEGEN_DIR}/split_embedding_codegen_lookup_invoker.template
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/fbgemm_gpu/cpu_utils.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/fbgemm_gpu/cub_namespace_postfix.cuh
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/fbgemm_gpu/dispatch_macros.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/fbgemm_gpu/embedding_backward_template_helpers.cuh
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/fbgemm_gpu/embedding_common.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/fbgemm_gpu/split_embeddings_utils.cuh
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/fbgemm_gpu/sparse_ops_utils.h
 )
 
 add_custom_command(
@@ -224,7 +231,8 @@ set(fbgemm_gpu_sources_gpu
     codegen/embedding_bounds_check.cu src/cumem_utils.cu
     src/histogram_binning_calibration_ops.cu src/jagged_tensor_ops.cu
     src/layout_transform_ops.cu src/permute_pooled_embedding_ops.cu
-    src/quantize_ops.cu src/sparse_ops.cu src/split_embeddings_cache_cuda.cu)
+    src/quantize_ops.cu src/sparse_ops.cu src/split_embeddings_cache_cuda.cu
+    src/split_embeddings_utils.cu)
 
 set_source_files_properties(${fbgemm_gpu_sources_gpu}
                             PROPERTIES COMPILE_OPTIONS "${TORCH_CUDA_OPTIONS}")

--- a/fbgemm_gpu/codegen/embedding_backward_dense_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_dense_host.cpp
@@ -9,7 +9,7 @@
 #include <ATen/core/op_registration/op_registration.h>
 #include <torch/script.h>
 
-#include "codegen/embedding_common.h"
+#include "fbgemm_gpu/embedding_common.h"
 
 using Tensor = at::Tensor;
 

--- a/fbgemm_gpu/codegen/embedding_backward_dense_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_dense_host_cpu.cpp
@@ -8,8 +8,8 @@
 #include <ATen/core/op_registration/op_registration.h>
 #include <torch/script.h>
 
-#include "codegen/embedding_common.h"
 #include "codegen/embedding_forward_split_cpu.h"
+#include "fbgemm_gpu/embedding_common.h"
 
 using Tensor = at::Tensor;
 

--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_approx_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_approx_template.cpp
@@ -11,9 +11,9 @@
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>
 
-#include "codegen/embedding_common.h"
 #include "codegen/embedding_forward_split_cpu.h"
 #include "fbgemm/FbgemmEmbedding.h"
+#include "fbgemm_gpu/embedding_common.h"
 
 using Tensor = at::Tensor;
 

--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
@@ -12,10 +12,10 @@
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>
 
-#include "codegen/embedding_common.h"
 #include "codegen/embedding_forward_split_cpu.h"
 #include "fbgemm/FbgemmEmbedding.h"
 #include "fbgemm/Types.h"
+#include "fbgemm_gpu/embedding_common.h"
 
 using Tensor = at::Tensor;
 

--- a/fbgemm_gpu/codegen/embedding_backward_split_host_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_cpu_template.cpp
@@ -10,8 +10,7 @@
 #include <torch/script.h>
 
 #include "codegen/embedding_forward_split_cpu.h"
-
-#include "codegen/embedding_common.h"
+#include "fbgemm_gpu/embedding_common.h"
 
 using Tensor = at::Tensor;
 

--- a/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
@@ -10,7 +10,7 @@
 #include <ATen/core/op_registration/op_registration.h>
 #include <torch/script.h>
 
-#include "codegen/embedding_common.h"
+#include "fbgemm_gpu/embedding_common.h"
 
 using Tensor = at::Tensor;
 

--- a/fbgemm_gpu/codegen/embedding_bounds_check.cu
+++ b/fbgemm_gpu/codegen/embedding_bounds_check.cu
@@ -4,7 +4,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-#include "codegen/embedding_backward_template_helpers.cuh"
+#include "fbgemm_gpu/embedding_backward_template_helpers.cuh"
 
 using Tensor = at::Tensor;
 using namespace fbgemm_gpu;

--- a/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
@@ -8,7 +8,7 @@
 #include <ATen/TypeDefault.h>
 #include <ATen/core/op_registration/op_registration.h>
 #include <torch/script.h>
-#include "codegen/embedding_common.h"
+#include "fbgemm_gpu/embedding_common.h"
 
 using Tensor = at::Tensor;
 

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
@@ -10,8 +10,8 @@
 #include <ATen/ATen.h>
 #include <ATen/Context.h>
 
-#include "codegen/embedding_common.h"
 #include "fbgemm_gpu/dispatch_macros.h"
+#include "fbgemm_gpu/embedding_common.h"
 
 #include <immintrin.h>
 #include <emmintrin.h>

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
@@ -10,7 +10,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <torch/script.h>
 #include "c10/core/ScalarType.h"
-#include "codegen/embedding_common.h"
+#include "fbgemm_gpu/embedding_common.h"
 
 using Tensor = at::Tensor;
 

--- a/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include "codegen/embedding_forward_split_cpu.h"
-#include "codegen/embedding_common.h"
 #include "fbgemm/FbgemmEmbedding.h"
 #include "fbgemm/Types.h"
 #include "fbgemm/Utils.h"
-#include "include/fbgemm_gpu/cpu_utils.h"
+#include "fbgemm_gpu/cpu_utils.h"
+#include "fbgemm_gpu/embedding_common.h"
 #ifdef FBCODE_CAFFE2
 #include <libdivide.h>
 #include "folly/container/F14Map.h"

--- a/fbgemm_gpu/codegen/embedding_forward_template_helpers.cuh
+++ b/fbgemm_gpu/codegen/embedding_forward_template_helpers.cuh
@@ -26,7 +26,7 @@
 #include <limits>
 #include <mutex>
 
-#include "codegen/embedding_common.h"
 #include "fbgemm_gpu/dispatch_macros.h"
+#include "fbgemm_gpu/embedding_common.h"
 #include "fbgemm_gpu/fbgemm_cuda_utils.cuh"
 #include "fbgemm_gpu/sparse_ops_utils.h"

--- a/fbgemm_gpu/include/fbgemm_gpu/embedding_common.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/embedding_common.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 #pragma once
-#include <stdint.h>
+#include <cstdint>
 
 namespace {
 

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.cuh
@@ -108,3 +108,23 @@ std::pair<at::Tensor, at::Tensor> lru_cache_find_uncached_cuda(
     at::Tensor lxu_cache_state,
     int64_t time_stamp,
     at::Tensor lru_state);
+
+/**
+ * "Transpose" embedding inputs by sorting indices by their values.
+ * Logically this transpose compressed sparse row (CSR) representation
+ * stored in indices and offsets to compressed sparse column (CSC).
+ */
+std::tuple<
+    at::Tensor /*linear_indices*/,
+    at::Tensor /*linear_indices_sorted*/,
+    at::Tensor /*infos_sorted*/,
+    at::Tensor /*sorted_linear_indices_run*/,
+    at::Tensor /*sorted_linear_indices_run_lengths*/,
+    at::Tensor /*sorted_linear_indices_num_runs*/,
+    at::Tensor /*sorted_linear_indices_cumulative_run_lengths*/>
+transpose_embedding_input(
+    at::Tensor hash_size_cumsum,
+    int64_t total_hash_size_bits,
+    at::Tensor indices,
+    at::Tensor offsets,
+    bool nobag = false);

--- a/fbgemm_gpu/src/split_embeddings_cache_cuda.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache_cuda.cu
@@ -29,11 +29,10 @@
 #include <mutex>
 
 #include "fbgemm_gpu/dispatch_macros.h"
+#include "fbgemm_gpu/embedding_common.h"
 #include "fbgemm_gpu/fbgemm_cuda_utils.cuh"
 #include "fbgemm_gpu/sparse_ops_utils.h"
-
-#include "../codegen/embedding_common.h"
-#include "split_embeddings_utils.cuh"
+#include "fbgemm_gpu/split_embeddings_utils.cuh"
 
 constexpr size_t kCacheMaxThreads = 512;
 

--- a/fbgemm_gpu/src/split_embeddings_utils.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils.cu
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include "fbgemm_gpu/split_embeddings_utils.cuh"
+
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAStream.h>
+#include "fbgemm_gpu/embedding_backward_template_helpers.cuh"
+
+using Tensor = at::Tensor;
+
+using namespace fbgemm_gpu;
+
+template <typename index_t>
+__global__ void linearize_index_kernel(
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
+        hash_size_cumsum,
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
+    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> infos,
+    at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
+        linear_indices) {
+  int32_t T = hash_size_cumsum.size(0) - 1;
+  int32_t B = (offsets.size(0) - 1) / T;
+  int32_t b_t = blockIdx.x * blockDim.x + threadIdx.x;
+  int32_t b = b_t % B;
+  int32_t t = b_t / B;
+  bool valid = t < T;
+
+  index_t hash_offset = valid ? hash_size_cumsum[t] : -1;
+  index_t indices_start = valid ? offsets[t * B + b] : -1;
+  int32_t L = valid ? offsets[t * B + b + 1] - indices_start : 0;
+  int32_t lane_id = threadIdx.x % fbgemm_gpu::kWarpSize;
+
+  for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
+    index_t indices_start_warp = __shfl_sync(0xFFFFFFFF, indices_start, j);
+    int32_t b_t_warp = __shfl_sync(0xFFFFFFFF, b_t, j);
+    int32_t L_warp = __shfl_sync(0xFFFFFFFF, L, j);
+    index_t hash_offset_warp = __shfl_sync(0xFFFFFFFF, hash_offset, j);
+    for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
+      index_t idx = __ldg(&indices[indices_start_warp + i]);
+      infos[indices_start_warp + i] = b_t_warp;
+      linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
+    }
+  }
+}
+
+template <typename index_t>
+__global__ void nobag_linearize_index_kernel(
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
+        hash_size_cumsum,
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
+    at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> infos,
+    at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
+        linear_indices) {
+  int32_t T = hash_size_cumsum.size(0) - 1;
+  int32_t B = (offsets.size(0) - 1) / T;
+  int32_t b_t = blockIdx.x * blockDim.x + threadIdx.x;
+  int32_t b = b_t % B;
+  int32_t t = b_t / B;
+  bool valid = t < T;
+
+  index_t hash_offset = valid ? hash_size_cumsum[t] : -1;
+  index_t indices_start = valid ? offsets[t * B + b] : -1;
+  int32_t L = valid ? offsets[t * B + b + 1] - indices_start : 0;
+  int32_t lane_id = threadIdx.x % fbgemm_gpu::kWarpSize;
+
+  for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
+    index_t indices_start_warp = __shfl_sync(0xFFFFFFFF, indices_start, j);
+    int32_t t_warp = __shfl_sync(0xFFFFFFFF, t, j);
+    int32_t L_warp = __shfl_sync(0xFFFFFFFF, L, j);
+    index_t hash_offset_warp = __shfl_sync(0xFFFFFFFF, hash_offset, j);
+    for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
+      index_t idx = __ldg(&indices[indices_start_warp + i]);
+      int64_t l_t = (indices_start_warp + i) * T + t_warp;
+      infos[indices_start_warp + i] = l_t;
+      linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
+    }
+  }
+}
+
+std::tuple<
+    Tensor /*linear_indices*/,
+    Tensor /*linear_indices_sorted*/,
+    Tensor /*infos_sorted*/,
+    Tensor /*sorted_linear_indices_run*/,
+    Tensor /*sorted_linear_indices_run_lengths*/,
+    Tensor /*sorted_linear_indices_num_runs*/,
+    Tensor /*sorted_linear_indices_cumulative_run_lengths*/>
+transpose_embedding_input(
+    Tensor hash_size_cumsum,
+    int64_t total_hash_size_bits,
+    Tensor indices,
+    Tensor offsets,
+    bool nobag) {
+  int32_t T = hash_size_cumsum.size(0) - 1;
+  int32_t B = (offsets.size(0) - 1) / T;
+
+  auto infos = at::empty_like(
+      indices, indices.options().dtype(nobag ? at::kLong : at::kInt));
+  auto infos_sorted = at::empty_like(infos);
+  auto linear_indices = at::empty_like(indices);
+  auto linear_indices_sorted = at::empty_like(indices);
+
+  Tensor sorted_linear_indices_run;
+  Tensor sorted_linear_indices_run_lengths;
+  Tensor sorted_linear_indices_num_runs;
+
+  using at::RestrictPtrTraits;
+
+  AT_DISPATCH_INDEX_TYPES(
+      infos.scalar_type(), "transpose_embedding_input1", ([&] {
+        using info_t = index_t;
+        AT_DISPATCH_INDEX_TYPES(
+            indices.scalar_type(), "transpose_embedding_input2", ([&] {
+              if (!nobag) {
+                linearize_index_kernel<<<
+                    div_round_up(B * T, kMaxThreads),
+                    kMaxThreads,
+                    0,
+                    at::cuda::getCurrentCUDAStream()>>>(
+                    hash_size_cumsum
+                        .packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+                    indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+                    offsets.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+                    infos.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+                    linear_indices
+                        .packed_accessor32<index_t, 1, RestrictPtrTraits>());
+              } else {
+                nobag_linearize_index_kernel<<<
+                    div_round_up(B * T, kMaxThreads),
+                    kMaxThreads,
+                    0,
+                    at::cuda::getCurrentCUDAStream()>>>(
+                    hash_size_cumsum
+                        .packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+                    indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+                    offsets.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+                    infos.packed_accessor32<int64_t, 1, RestrictPtrTraits>(),
+                    linear_indices
+                        .packed_accessor32<index_t, 1, RestrictPtrTraits>());
+              }
+              C10_CUDA_KERNEL_LAUNCH_CHECK();
+              {
+                size_t temp_storage_bytes = 0;
+                AT_CUDA_CHECK(
+                    FBGEMM_GPU_CUB_NS_PREFIX cub::DeviceRadixSort::SortPairs(
+                        nullptr,
+                        temp_storage_bytes,
+                        linear_indices.data_ptr<index_t>(),
+                        linear_indices_sorted.data_ptr<index_t>(),
+                        infos.data_ptr<info_t>(),
+                        infos_sorted.data_ptr<info_t>(),
+                        linear_indices.numel(),
+                        0,
+                        total_hash_size_bits,
+                        at::cuda::getCurrentCUDAStream(),
+                        false));
+                auto temp_storage = at::empty(
+                    {static_cast<int64_t>(temp_storage_bytes)},
+                    indices.options().dtype(at::kByte));
+                AT_CUDA_CHECK(
+                    FBGEMM_GPU_CUB_NS_PREFIX cub::DeviceRadixSort::SortPairs(
+                        temp_storage.data_ptr(),
+                        temp_storage_bytes,
+                        linear_indices.data_ptr<index_t>(),
+                        linear_indices_sorted.data_ptr<index_t>(),
+                        infos.data_ptr<info_t>(),
+                        infos_sorted.data_ptr<info_t>(),
+                        linear_indices.numel(),
+                        0,
+                        total_hash_size_bits,
+                        at::cuda::getCurrentCUDAStream(),
+                        false));
+              }
+
+              sorted_linear_indices_run = at::empty_like(indices);
+              sorted_linear_indices_run_lengths =
+                  at::zeros_like(indices, indices.options().dtype(at::kInt));
+              sorted_linear_indices_num_runs =
+                  at::zeros({1}, indices.options().dtype(at::kInt));
+
+              {
+                size_t temp_storage_bytes = 0;
+                AT_CUDA_CHECK(
+                    FBGEMM_GPU_CUB_NS_PREFIX cub::DeviceRunLengthEncode::Encode(
+                        nullptr,
+                        temp_storage_bytes,
+                        linear_indices_sorted.data_ptr<index_t>(),
+                        sorted_linear_indices_run.data_ptr<index_t>(),
+                        sorted_linear_indices_run_lengths.data_ptr<int32_t>(),
+                        sorted_linear_indices_num_runs.data_ptr<int32_t>(),
+                        linear_indices_sorted.numel(),
+                        at::cuda::getCurrentCUDAStream()));
+                // Allocate temporary storage
+                auto temp_storage = at::empty(
+                    {static_cast<int64_t>(temp_storage_bytes)},
+                    indices.options().dtype(at::kByte));
+                // Run encoding
+                AT_CUDA_CHECK(
+                    FBGEMM_GPU_CUB_NS_PREFIX cub::DeviceRunLengthEncode::Encode(
+                        temp_storage.data_ptr(),
+                        temp_storage_bytes,
+                        linear_indices_sorted.data_ptr<index_t>(),
+                        sorted_linear_indices_run.data_ptr<index_t>(),
+                        sorted_linear_indices_run_lengths.data_ptr<int32_t>(),
+                        sorted_linear_indices_num_runs.data_ptr<int32_t>(),
+                        linear_indices_sorted.numel(),
+                        at::cuda::getCurrentCUDAStream()));
+              }
+            }));
+      }));
+
+  auto sorted_linear_indices_cumulative_run_lengths =
+      asynchronous_complete_cumsum(sorted_linear_indices_run_lengths);
+
+  return {
+      linear_indices,
+      linear_indices_sorted,
+      infos_sorted,
+      sorted_linear_indices_run,
+      sorted_linear_indices_run_lengths,
+      sorted_linear_indices_num_runs,
+      sorted_linear_indices_cumulative_run_lengths};
+}


### PR DESCRIPTION
Summary:
Refactoring to prepare D33381126
Other minor changes
* Remove unused sorted_linear_indices_run_lengths parameter from bwd kernels

Differential Revision: D33380032

