### PR TITLE
scale_bias_last option to support TBE layout

### DIFF
--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -15,7 +15,8 @@ namespace fbgemm {
 template <
     typename InType,
     typename IndexType,
-    typename OffsetType = std::int32_t>
+    typename OffsetType = std::int32_t,
+    typename OutType = float>
 class EmbeddingSpMDMKernelSignature {
  public:
   /**
@@ -43,7 +44,7 @@ class EmbeddingSpMDMKernelSignature {
       const IndexType* indices,
       const OffsetType* offsets_or_lengths,
       const float* weights, // optional, can be null for non-weighted sum
-      float* out)>;
+      OutType* out)>;
 };
 
 /**
@@ -62,16 +63,20 @@ class EmbeddingSpMDMKernelSignature {
 template <
     typename InType,
     typename IndexType,
-    typename OffsetType = std::int32_t>
-FBGEMM_API
-    typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType>::Type
-    GenerateEmbeddingSpMDM(
-        const std::int64_t block_size,
-        bool has_weight,
-        bool normalize_by_lengths,
-        int prefetch = 16,
-        bool is_weight_positional = false,
-        bool use_offsets = true);
+    typename OffsetType = std::int32_t,
+    typename OutType = float>
+FBGEMM_API typename EmbeddingSpMDMKernelSignature<
+    InType,
+    IndexType,
+    OffsetType,
+    OutType>::Type
+GenerateEmbeddingSpMDM(
+    const std::int64_t block_size,
+    bool has_weight,
+    bool normalize_by_lengths,
+    int prefetch = 16,
+    bool is_weight_positional = false,
+    bool use_offsets = true);
 
 /**
  * @param output_stride If -1, output_stride is same as block_size
@@ -80,29 +85,38 @@ FBGEMM_API
 template <
     typename InType,
     typename IndexType,
-    typename OffsetType = std::int32_t>
-FBGEMM_API
-    typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType>::Type
-    GenerateEmbeddingSpMDMWithStrides(
-        const std::int64_t block_size,
-        bool has_weight,
-        bool normalize_by_lengths,
-        int prefetch = 16,
-        bool is_weight_positional = false,
-        bool use_offsets = true,
-        std::int64_t output_stride = -1,
-        std::int64_t input_stride = -1);
+    typename OffsetType = std::int32_t,
+    typename OutType = float>
+FBGEMM_API typename EmbeddingSpMDMKernelSignature<
+    InType,
+    IndexType,
+    OffsetType,
+    OutType>::Type
+GenerateEmbeddingSpMDMWithStrides(
+    const std::int64_t block_size,
+    bool has_weight,
+    bool normalize_by_lengths,
+    int prefetch = 16,
+    bool is_weight_positional = false,
+    bool use_offsets = true,
+    std::int64_t output_stride = -1,
+    std::int64_t input_stride = -1,
+    bool scale_bias_last = true);
 
 /**
  * @tparam IndexType can be int32_t or int64_t
  * @tparam OffsetType can be int32_t or int64_t
  * @param bit_rate can be 2 or 4
  */
-template <typename IndexType, typename OffsetType = std::int32_t>
+template <
+    typename IndexType,
+    typename OffsetType = std::int32_t,
+    typename OutType = float>
 FBGEMM_API typename EmbeddingSpMDMKernelSignature<
     std::uint8_t,
     IndexType,
-    OffsetType>::Type
+    OffsetType,
+    OutType>::Type
 GenerateEmbeddingSpMDMNBit(
     int bit_rate,
     const std::int64_t block_size,
@@ -111,6 +125,32 @@ GenerateEmbeddingSpMDMNBit(
     int prefetch = 16,
     bool is_weight_positional = false,
     bool use_offsets = true);
+
+/**
+ * @param output_stride If -1, output_stride is same as block_size
+ * @param input_stride in Bytes. If -1, input_stride is same as
+ *                     block_size / num_elem_per_byte + 2 * sizeof(float16)
+ */
+template <
+    typename IndexType,
+    typename OffsetType = std::int32_t,
+    typename OutType = float>
+FBGEMM_API typename EmbeddingSpMDMKernelSignature<
+    std::uint8_t,
+    IndexType,
+    OffsetType,
+    OutType>::Type
+GenerateEmbeddingSpMDMNBitWithStrides(
+    int bit_rate,
+    const std::int64_t block_size,
+    bool has_weight,
+    bool normalize_by_lengths,
+    int prefetch = 16,
+    bool is_weight_positional = false,
+    bool use_offsets = true,
+    std::int64_t output_stride = -1,
+    std::int64_t input_stride = -1,
+    bool scale_bias_last = true);
 
 template <
     typename InType,

--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -32,11 +32,16 @@ template <
     typename inType,
     typename indxType,
     typename offsetType,
+    typename outType,
     bool ROWWISE_SPARSE>
 class ReturnFunctionSignature {};
 
-template <typename inType, typename indxType, typename offsetType>
-class ReturnFunctionSignature<inType, indxType, offsetType, false> {
+template <
+    typename inType,
+    typename indxType,
+    typename offsetType,
+    typename outType>
+class ReturnFunctionSignature<inType, indxType, offsetType, outType, false> {
  public:
   using jit_embedding_kernel = bool (*)(
       int64_t output_size,
@@ -46,12 +51,16 @@ class ReturnFunctionSignature<inType, indxType, offsetType, false> {
       const indxType* indices,
       const offsetType* offsets_or_lengths,
       const float* weights,
-      float* out,
+      outType* out,
       const int* mask);
 };
 
-template <typename inType, typename indxType, typename offsetType>
-class ReturnFunctionSignature<inType, indxType, offsetType, true> {
+template <
+    typename inType,
+    typename indxType,
+    typename offsetType,
+    typename outType>
+class ReturnFunctionSignature<inType, indxType, offsetType, outType, true> {
  public:
   using jit_embedding_kernel = bool (*)(
       int64_t output_size,
@@ -62,7 +71,7 @@ class ReturnFunctionSignature<inType, indxType, offsetType, true> {
       const indxType* indices,
       const offsetType* offsets_or_lengths,
       const float* weights,
-      float* out,
+      outType* out,
       const int32_t* compressed_indices_table,
       const int* mask);
 };
@@ -71,6 +80,7 @@ template <
     typename inType,
     typename indxType,
     typename offsetType,
+    typename outType,
     inst_set_t instSet,
     bool ROWWISE_SPARSE = false>
 class GenEmbeddingSpMDMLookup {
@@ -80,6 +90,7 @@ class GenEmbeddingSpMDMLookup {
       inType,
       indxType,
       offsetType,
+      outType,
       ROWWISE_SPARSE>::jit_embedding_kernel
   getOrCreate(
       int block_size,
@@ -89,7 +100,8 @@ class GenEmbeddingSpMDMLookup {
       int prefetch,
       bool use_offsets,
       int output_stride,
-      int input_stride);
+      int input_stride,
+      bool scale_bias_last);
 
  private:
   static asmjit::JitRuntime& runtime() {
@@ -104,13 +116,14 @@ class GenEmbeddingSpMDMLookup {
 
   // The hash depends on embedding dimension (block size), weighted sls,
   // positional weights, normalize by lenths, prefetch distance, use_offsets,
-  // output_stride, and input_stride
+  // output_stride, input_stride, and scale_bias_last
   static CodeCache<
-      std::tuple<int, bool, bool, bool, int, bool, int, int>,
+      std::tuple<int, bool, bool, bool, int, bool, int, int, bool>,
       typename ReturnFunctionSignature<
           inType,
           indxType,
           offsetType,
+          outType,
           ROWWISE_SPARSE>::jit_embedding_kernel>
       codeCache_; ///< JIT Code Cache for reuse.
 }; // GenEmbeddingSpmDMLookup
@@ -119,12 +132,14 @@ template <
     typename inType,
     typename indxType,
     typename offsetType,
+    typename outType,
     inst_set_t instSet,
     bool ROWWISE_SPARSE>
 std::mutex GenEmbeddingSpMDMLookup<
     inType,
     indxType,
     offsetType,
+    outType,
     instSet,
     ROWWISE_SPARSE>::rtMutex_;
 
@@ -132,19 +147,22 @@ template <
     typename inType,
     typename indxType,
     typename offsetType,
+    typename outType,
     inst_set_t instSet,
     bool ROWWISE_SPARSE>
 CodeCache<
-    std::tuple<int, bool, bool, bool, int, bool, int, int>,
+    std::tuple<int, bool, bool, bool, int, bool, int, int, bool>,
     typename ReturnFunctionSignature<
         inType,
         indxType,
         offsetType,
+        outType,
         ROWWISE_SPARSE>::jit_embedding_kernel>
     GenEmbeddingSpMDMLookup<
         inType,
         indxType,
         offsetType,
+        outType,
         instSet,
         ROWWISE_SPARSE>::codeCache_;
 
@@ -152,14 +170,22 @@ template <
     typename inType,
     typename indxType,
     typename offsetType,
+    typename outType,
     inst_set_t instSet,
     bool ROWWISE_SPARSE>
 typename ReturnFunctionSignature<
     inType,
     indxType,
     offsetType,
+    outType,
     ROWWISE_SPARSE>::jit_embedding_kernel
-GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
+GenEmbeddingSpMDMLookup<
+    inType,
+    indxType,
+    offsetType,
+    outType,
+    instSet,
+    ROWWISE_SPARSE>::
     getOrCreate(
         int block_size,
         bool has_weight,
@@ -168,8 +194,9 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
         int prefetch,
         bool use_offsets,
         int output_stride,
-        int input_stride) {
-  std::tuple<int, bool, bool, bool, int, bool, int, int> kernelSig =
+        int input_stride,
+        bool scale_bias_last) {
+  std::tuple<int, bool, bool, bool, int, bool, int, int, bool> kernelSig =
       std::make_tuple(
           block_size,
           has_weight,
@@ -178,7 +205,8 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
           prefetch,
           use_offsets,
           output_stride,
-          input_stride);
+          input_stride,
+          scale_bias_last);
 
   return codeCache_.getOrCreate(
       kernelSig,
@@ -186,6 +214,7 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
                 inType,
                 indxType,
                 offsetType,
+                outType,
                 ROWWISE_SPARSE>::jit_embedding_kernel {
         bool is8bit = std::is_same<inType, uint8_t>::value;
         bool is16bit = std::is_same<inType, float16>::value;
@@ -224,6 +253,9 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
           filename += "_rowwise_sparse";
         }
         filename += "_out_stride_" + std::to_string(output_stride);
+        if (!scale_bias_last) {
+          filename += "_scale_bias_first"
+        }
         filename += ".txt";
         FILE* codeLogFile = fopen(filename.c_str(), "w");
         asmjit::FileLogger* codeLogger = new asmjit::FileLogger(codeLogFile);
@@ -270,7 +302,7 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
                   const indxType*, // indices
                   const offsetType*, // offsets or lengths
                   const float*, // weights
-                  float*, // out
+                  outType*, // out
                   const int32_t*, // compressed_indices_table and then mask
                   const int*>(asmjit::CallConv::kIdHost),
               a->environment());
@@ -285,7 +317,7 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
                   const indxType*, // indices
                   const offsetType*, // offsets or lengths
                   const float*, // weights
-                  float*, // out and then mask
+                  outType*, // out and then mask
                   const int*>(asmjit::CallConv::kIdHost),
               a->environment());
         }
@@ -385,7 +417,8 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
           // AVX512 doesn't need to use vector register for masking
           --unroll_factor;
           mask_vreg = x86::ymm(unroll_factor);
-          if (remainder > 1 && is16bit) {
+          if (remainder > 1 &&
+              (is16bit || std::is_same<outType, float16>::value)) {
             --unroll_factor;
             mask_fp16_vreg = x86::xmm(unroll_factor);
           }
@@ -402,13 +435,14 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
                 mask_vreg,
                 x86::ymmword_ptr(
                     scratchReg1_, (vlen - remainder) % vlen * sizeof(int32_t)));
-            if (remainder > 1 && is16bit) {
-              a->vmovups(
-                  mask_fp16_vreg,
-                  x86::xmmword_ptr(
-                      scratchReg1_,
-                      (vlen / 2 - remainder / 2) % (vlen / 2) *
-                          sizeof(int32_t)));
+            if (is16bit || std::is_same<outType, float16>::value) {
+              if (remainder > 1) {
+                a->vmovups(
+                    mask_fp16_vreg,
+                    x86::xmmword_ptr(
+                        scratchReg1_,
+                        (vlen - remainder / 2) * sizeof(int32_t)));
+              }
               // We need to keep using the stack during the main loop
               a->lea(
                   x86::rsp,
@@ -496,6 +530,7 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
 
           asmjit::Label LoopDataIndexBegin = a->newLabel();
           asmjit::Label LoopDataIndexEnd = a->newLabel();
+          asmjit::Label ValidIndexLabel = a->newLabel();
 
           // dataIndex loop begins (iterate lengths_R_ times)
           a->bind(LoopDataIndexBegin);
@@ -507,6 +542,19 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
             a->mov(scratchReg1_, x86::qword_ptr(indices));
           } else {
             a->mov(scratchReg1_.r32(), x86::dword_ptr(indices));
+          }
+          if (!scale_bias_last) {
+            // When scale_bias_last == false, assume this is for table batched
+            // embedding (TBE) that can get -1 for pruned rows.
+            if (areIndices64b) {
+              a->cmp(scratchReg1_, static_cast<asmjit::Imm>(-1));
+            } else {
+              a->cmp(scratchReg1_.r32(), static_cast<asmjit::Imm>(-1));
+            }
+            a->jne(ValidIndexLabel);
+            a->add(indices, static_cast<asmjit::Imm>(sizeof(indxType)));
+            a->jmp(LoopDataIndexBegin);
+            a->bind(ValidIndexLabel);
           }
           // A trick to check x >= data_size or x < 0 in one shot by treating
           // scratchReg1_ as if it has unsigned value
@@ -599,15 +647,24 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
           x86::Mem scale_src, bias_src;
           constexpr int CACHE_LINE_LEN = 64;
           if (is8bit) {
-            scale_src = x86::dword_ptr(
-                input, scratchReg1_, 0, block_size * sizeof(uint8_t));
-            bias_src = x86::dword_ptr(
-                input,
-                scratchReg1_,
-                0,
-                block_size * sizeof(uint8_t) + sizeof(float));
-            a->vbroadcastss(scale_vreg, scale_src);
-            a->vbroadcastss(bias_vreg, bias_src);
+            if (scale_bias_last) {
+              scale_src = x86::dword_ptr(
+                  input, scratchReg1_, 0, block_size * sizeof(uint8_t));
+              bias_src = x86::dword_ptr(
+                  input,
+                  scratchReg1_,
+                  0,
+                  block_size * sizeof(uint8_t) + sizeof(float));
+              a->vbroadcastss(scale_vreg, scale_src);
+              a->vbroadcastss(bias_vreg, bias_src);
+            } else {
+              scale_src = x86::word_ptr(input, scratchReg1_);
+              bias_src = x86::word_ptr(input, scratchReg1_, 0, sizeof(float16));
+              a->vpbroadcastw(scale_vreg.half(), scale_src);
+              a->vpbroadcastw(bias_vreg.half(), bias_src);
+              a->vcvtph2ps(scale_vreg, scale_vreg.half());
+              a->vcvtph2ps(bias_vreg, bias_vreg.half());
+            }
 
             if (pref_dist && fused_block_size % CACHE_LINE_LEN > 0 &&
                 fused_block_size % CACHE_LINE_LEN <= 2 * sizeof(float)) {
@@ -625,10 +682,15 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
           }
 
           // The main computation
+          int src_addr_offset =
+              is8bit && !scale_bias_last ? 2 * sizeof(float16) : 0;
           for (int v = 0; v < cur_unroll_factor; ++v) {
             constexpr int BYTES_PER_VLOAD = vlen * sizeof(inType);
             auto src_addr = x86::dword_ptr(
-                input, scratchReg1_, 0, (vec_idx + v) * BYTES_PER_VLOAD);
+                input,
+                scratchReg1_,
+                0,
+                src_addr_offset + (vec_idx + v) * BYTES_PER_VLOAD);
             vec_reg_t out_vreg = vec_reg_t(v);
 
             // For 8bit SLS convert usigned 8-bit to 32bit int, then to float
@@ -658,7 +720,7 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
                             input,
                             scratchReg1_,
                             0,
-                            (vec_idx + v) * BYTES_PER_VLOAD +
+                            src_addr_offset + (vec_idx + v) * BYTES_PER_VLOAD +
                                 (remainder - 1) * sizeof(inType)));
                     if (remainder > 1) {
                       // AVX2 can't do masking for the last 16-bit so we store
@@ -733,21 +795,55 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
           // back to memory
           for (int v = 0; v < cur_unroll_factor; ++v) {
             auto dst_addr =
-                x86::dword_ptr(out, (vec_idx + v) * vlen * sizeof(float));
+                x86::dword_ptr(out, (vec_idx + v) * vlen * sizeof(outType));
             vec_reg_t out_vreg = vec_reg_t(v);
 
             if (normalize_by_lengths) {
               a->vmulps(out_vreg, out_vreg, vlen_inv_vreg);
             }
 
-            if (remainder && vec_idx + v == num_vec_regs_per_block - 1) {
-              if (instSet == inst_set_t::avx2) {
-                a->vmaskmovps(dst_addr, mask_vreg, out_vreg.ymm());
+            if (std::is_same<outType, float>::value) {
+              if (remainder && vec_idx + v == num_vec_regs_per_block - 1) {
+                if (instSet == inst_set_t::avx2) {
+                  a->vmaskmovps(dst_addr, mask_vreg, out_vreg.ymm());
+                } else {
+                  a->k(x86::k(1)).vmovups(dst_addr, out_vreg);
+                }
               } else {
-                a->k(x86::k(1)).vmovups(dst_addr, out_vreg);
+                a->vmovups(dst_addr, out_vreg);
               }
             } else {
-              a->vmovups(dst_addr, out_vreg);
+              // fp16 output
+              if (instSet == inst_set_t::avx2) {
+                // round nearest with no exception
+                a->vcvtps2ph(out_vreg.xmm(), out_vreg, 8);
+                if (remainder && vec_idx + v == num_vec_regs_per_block - 1) {
+                  if (remainder > 1) {
+                    a->vmaskmovps(dst_addr, mask_fp16_vreg, out_vreg.xmm());
+                  }
+                  if (remainder % 2 != 0) {
+                    a->vmovups(x86::xmmword_ptr(x86::rsp), out_vreg.xmm());
+                    a->mov(
+                        scratchReg1_.r16(),
+                        x86::word_ptr(
+                            x86::rsp, (remainder - 1) * sizeof(outType)));
+                    a->mov(
+                        x86::word_ptr(
+                            out,
+                            ((vec_idx + v) * vlen + (remainder - 1)) *
+                                sizeof(outType)),
+                        scratchReg1_.r16());
+                  }
+                } else {
+                  a->vmovups(dst_addr, out_vreg.xmm());
+                }
+              } else {
+                if (remainder && vec_idx + v == num_vec_regs_per_block - 1) {
+                  a->k(x86::k(1)).vcvtps2ph(dst_addr, out_vreg, 8);
+                } else {
+                  a->vcvtps2ph(dst_addr, out_vreg, 8);
+                }
+              }
             }
           }
 
@@ -786,7 +882,7 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
         }
 
         a->add(lengths, static_cast<asmjit::Imm>(sizeof(offsetType)));
-        a->add(out, static_cast<asmjit::Imm>(output_stride * sizeof(float)));
+        a->add(out, static_cast<asmjit::Imm>(output_stride * sizeof(outType)));
 
         a->jmp(LoopRangeIndexBegin);
         a->bind(LoopRangeIndexEnd);
@@ -799,7 +895,8 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
         a->mov(x86::eax, false);
         a->bind(exit);
 
-        if (remainder > 1 && instSet == inst_set_t::avx2 && is16bit) {
+        if (remainder && instSet == inst_set_t::avx2 &&
+            (is16bit || std::is_same<outType, float16>::value)) {
           a->lea(x86::rsp, x86::ymmword_ptr(x86::rsp, vlen * sizeof(int32_t)));
         }
 
@@ -810,6 +907,7 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
             inType,
             indxType,
             offsetType,
+            outType,
             ROWWISE_SPARSE>::jit_embedding_kernel fn;
         asmjit::Error err;
         {
@@ -831,17 +929,23 @@ GenEmbeddingSpMDMLookup<inType, indxType, offsetType, instSet, ROWWISE_SPARSE>::
 
 } // namespace
 
-template <typename inType, typename indxType, typename offsetType>
-typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType>::Type
-GenerateEmbeddingSpMDMWithStrides(
-    const int64_t block_size,
-    bool has_weight,
-    bool normalize_by_lengths,
-    int prefetch,
-    bool is_weight_positional,
-    bool use_offsets,
-    int64_t output_stride /*=-1*/,
-    int64_t input_stride /*=-1*/) {
+template <
+    typename inType,
+    typename indxType,
+    typename offsetType,
+    typename outType>
+typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType, outType>::
+    Type
+    GenerateEmbeddingSpMDMWithStrides(
+        const int64_t block_size,
+        bool has_weight,
+        bool normalize_by_lengths,
+        int prefetch,
+        bool is_weight_positional,
+        bool use_offsets,
+        int64_t output_stride /*=-1*/,
+        int64_t input_stride /*=-1*/,
+        bool scale_bias_last /*=true*/) {
   if (!cpuinfo_initialize()) {
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
@@ -850,7 +954,8 @@ GenerateEmbeddingSpMDMWithStrides(
   }
   if (input_stride == -1) {
     if (std::is_same<inType, uint8_t>::value) {
-      const auto scale_bias_offset = 2 * sizeof(float);
+      const auto scale_bias_offset =
+          2 * (scale_bias_last ? sizeof(float) : sizeof(float16));
       input_stride = block_size + scale_bias_offset;
     } else {
       input_stride = block_size;
@@ -860,7 +965,7 @@ GenerateEmbeddingSpMDMWithStrides(
   if ((std::is_same<inType, float>::value ||
        std::is_same<inType, float16>::value) &&
       block_size == 1 && isYmm(isa) && output_stride == block_size &&
-      input_stride == block_size) {
+      input_stride == block_size && std::is_same<outType, float>::value) {
     return
         [=](int64_t output_size,
             int64_t index_size,
@@ -869,7 +974,7 @@ GenerateEmbeddingSpMDMWithStrides(
             const indxType* indices,
             const offsetType* offsets_or_lengths,
             const float* weights, // optional, can be null for non-weighted sum
-            float* out) {
+            outType* out) {
           return internal::EmbeddingSpMDMBlockSize1_(
               output_size,
               index_size,
@@ -879,7 +984,7 @@ GenerateEmbeddingSpMDMWithStrides(
               offsets_or_lengths,
               weights,
               normalize_by_lengths,
-              out,
+              reinterpret_cast<float*>(out),
               is_weight_positional,
               use_offsets);
         };
@@ -888,6 +993,7 @@ GenerateEmbeddingSpMDMWithStrides(
         inType,
         indxType,
         offsetType,
+        outType,
         inst_set_t::avx512>
         kernel_generator;
     const auto original_func = kernel_generator.getOrCreate(
@@ -898,7 +1004,8 @@ GenerateEmbeddingSpMDMWithStrides(
         prefetch,
         use_offsets,
         output_stride,
-        input_stride);
+        input_stride,
+        scale_bias_last);
     return [=](int64_t output_size,
                int64_t index_size,
                int64_t data_size,
@@ -906,7 +1013,7 @@ GenerateEmbeddingSpMDMWithStrides(
                const indxType* indices,
                const offsetType* offsets_or_lengths,
                const float* weights,
-               float* out) {
+               outType* out) {
       return original_func(
           output_size,
           index_size,
@@ -923,6 +1030,7 @@ GenerateEmbeddingSpMDMWithStrides(
         inType,
         indxType,
         offsetType,
+        outType,
         inst_set_t::avx2>
         kernel_generator;
     const auto original_func = kernel_generator.getOrCreate(
@@ -933,7 +1041,8 @@ GenerateEmbeddingSpMDMWithStrides(
         prefetch,
         use_offsets,
         output_stride,
-        input_stride);
+        input_stride,
+        scale_bias_last);
     return [=](int64_t output_size,
                int64_t index_size,
                int64_t data_size,
@@ -941,7 +1050,7 @@ GenerateEmbeddingSpMDMWithStrides(
                const indxType* indices,
                const offsetType* offsets_or_lengths,
                const float* weights,
-               float* out) {
+               outType* out) {
       return original_func(
           output_size,
           index_size,
@@ -964,7 +1073,7 @@ GenerateEmbeddingSpMDMWithStrides(
                const indxType* indices,
                const offsetType* offsets_or_lengths,
                const float* weights,
-               float* out) {
+               outType* out) {
       return EmbeddingSpMDM_ref(
           block_size,
           output_size,
@@ -979,29 +1088,37 @@ GenerateEmbeddingSpMDMWithStrides(
           is_weight_positional,
           use_offsets,
           output_stride,
-          input_stride);
+          input_stride,
+          scale_bias_last);
     };
   }
 }
 
-template <typename inType, typename indxType, typename offsetType>
-typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType>::Type
-GenerateEmbeddingSpMDM(
-    const int64_t block_size,
-    bool has_weight,
-    bool normalize_by_lengths,
-    int prefetch,
-    bool is_weight_positional,
-    bool use_offsets) {
-  return GenerateEmbeddingSpMDMWithStrides<inType, indxType, offsetType>(
+template <
+    typename inType,
+    typename indxType,
+    typename offsetType,
+    typename outType>
+typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType, outType>::
+    Type
+    GenerateEmbeddingSpMDM(
+        const int64_t block_size,
+        bool has_weight,
+        bool normalize_by_lengths,
+        int prefetch,
+        bool is_weight_positional,
+        bool use_offsets) {
+  return GenerateEmbeddingSpMDMWithStrides<
+      inType,
+      indxType,
+      offsetType,
+      outType>(
       block_size,
       has_weight,
       normalize_by_lengths,
       prefetch,
       is_weight_positional,
-      use_offsets,
-      /*output_stride=*/-1,
-      /*input_stride=*/-1);
+      use_offsets);
 }
 
 template <typename inType, typename indxType, typename offsetType>
@@ -1030,6 +1147,7 @@ GenerateEmbeddingSpMDMRowWiseSparse(
         inType,
         indxType,
         offsetType,
+        /*outType=*/float,
         inst_set_t::avx512,
         /*rowwise_sparse=*/true>
         kernel_generator;
@@ -1041,7 +1159,8 @@ GenerateEmbeddingSpMDMRowWiseSparse(
         prefetch,
         use_offsets,
         /*output_stride=*/block_size,
-        input_stride);
+        input_stride,
+        /*scale_bias_last=*/true);
     return [=](int64_t output_size,
                int64_t index_size,
                int64_t uncompressed_data_size,
@@ -1068,6 +1187,7 @@ GenerateEmbeddingSpMDMRowWiseSparse(
         inType,
         indxType,
         offsetType,
+        /*outType=*/float,
         inst_set_t::avx2,
         /*rowwise_sparse=*/true>
         kernel_generator;
@@ -1079,7 +1199,8 @@ GenerateEmbeddingSpMDMRowWiseSparse(
         prefetch,
         use_offsets,
         /*output_stride=*/block_size,
-        input_stride);
+        input_stride,
+        /*scale_bias_last=*/true);
     return [=](int64_t output_size,
                int64_t index_size,
                int64_t uncompressed_data_size,
@@ -1134,12 +1255,17 @@ GenerateEmbeddingSpMDMRowWiseSparse(
   }
 }
 
-#define INSTANTIATE_SPMDM_BASE(IN_TYPE, INDEX_TYPE, OFFSET_TYPE)           \
+#define INSTANTIATE_SPMDM_BASE(IN_TYPE, INDEX_TYPE, OFFSET_TYPE, OUT_TYPE) \
   template FBGEMM_API typename EmbeddingSpMDMKernelSignature<              \
       IN_TYPE,                                                             \
       INDEX_TYPE,                                                          \
-      OFFSET_TYPE>::Type                                                   \
-  GenerateEmbeddingSpMDMWithStrides<IN_TYPE, INDEX_TYPE, OFFSET_TYPE>(     \
+      OFFSET_TYPE,                                                         \
+      OUT_TYPE>::Type                                                      \
+  GenerateEmbeddingSpMDMWithStrides<                                       \
+      IN_TYPE,                                                             \
+      INDEX_TYPE,                                                          \
+      OFFSET_TYPE,                                                         \
+      OUT_TYPE>(                                                           \
       const int64_t block_size,                                            \
       bool has_weight,                                                     \
       bool normalize_by_lengths,                                           \
@@ -1147,18 +1273,24 @@ GenerateEmbeddingSpMDMRowWiseSparse(
       bool is_weight_positional,                                           \
       bool use_offsets,                                                    \
       int64_t output_stride,                                               \
-      int64_t input_stride);                                               \
+      int64_t input_stride,                                                \
+      bool scale_bias_last);                                               \
   template FBGEMM_API typename EmbeddingSpMDMKernelSignature<              \
       IN_TYPE,                                                             \
       INDEX_TYPE,                                                          \
-      OFFSET_TYPE>::Type                                                   \
-  GenerateEmbeddingSpMDM<IN_TYPE, INDEX_TYPE, OFFSET_TYPE>(                \
+      OFFSET_TYPE,                                                         \
+      OUT_TYPE>::Type                                                      \
+  GenerateEmbeddingSpMDM<IN_TYPE, INDEX_TYPE, OFFSET_TYPE, OUT_TYPE>(      \
       const int64_t block_size,                                            \
       bool has_weight,                                                     \
       bool normalize_by_lengths,                                           \
       int prefetch,                                                        \
       bool is_weight_positional,                                           \
-      bool use_offsets);                                                   \
+      bool use_offsets);
+
+#define INSTANTIATE_SPMDM_OUT_T(IN_TYPE, INDEX_TYPE, OFFSET_TYPE)          \
+  INSTANTIATE_SPMDM_BASE(IN_TYPE, INDEX_TYPE, OFFSET_TYPE, float)          \
+  INSTANTIATE_SPMDM_BASE(IN_TYPE, INDEX_TYPE, OFFSET_TYPE, float16)        \
   template FBGEMM_API typename EmbeddingSpMDMRowWiseSparseKernelSignature< \
       IN_TYPE,                                                             \
       INDEX_TYPE,                                                          \
@@ -1171,12 +1303,9 @@ GenerateEmbeddingSpMDMRowWiseSparse(
       bool is_weight_positional,                                           \
       bool use_offsets);
 
-#define INSTANTIATE_SPMDM_NAME(IN_TYPE, INDEX_TYPE, OFFSET_TYPE) \
-  INSTANTIATE_SPMDM_BASE(IN_TYPE, INDEX_TYPE, OFFSET_TYPE)
-
 #define INSTANTIATE_SPMDM_OFFSET_T(IN_TYPE, INDEX_TYPE) \
-  INSTANTIATE_SPMDM_NAME(IN_TYPE, INDEX_TYPE, int32_t)  \
-  INSTANTIATE_SPMDM_NAME(IN_TYPE, INDEX_TYPE, int64_t)
+  INSTANTIATE_SPMDM_OUT_T(IN_TYPE, INDEX_TYPE, int32_t) \
+  INSTANTIATE_SPMDM_OUT_T(IN_TYPE, INDEX_TYPE, int64_t)
 
 #define INSTANTIATE_SPMDM_INDEX_T(IN_TYPE)     \
   INSTANTIATE_SPMDM_OFFSET_T(IN_TYPE, int32_t) \
@@ -1188,7 +1317,7 @@ INSTANTIATE_SPMDM_INDEX_T(uint8_t)
 
 #undef INSTANTIATE_SPMDM_INDEX_T
 #undef INSTANTIATE_SPMDM_OFFSET_T
-#undef INSTANTIATE_SPMDM_NAME
+#undef INSTANTIATE_SPMDM_OUT_T
 #undef INSTANTIATE_SPMDM_BASE
 
 template <typename IndexType>

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -35,11 +35,15 @@ T ceil_div(T a, T b) {
 
 namespace x86 = asmjit::x86;
 
-template <typename indxType, typename offsetType, bool ROWWISE_SPARSE>
+template <
+    typename indxType,
+    typename offsetType,
+    typename outType,
+    bool ROWWISE_SPARSE>
 class ReturnFunctionSignature {};
 
-template <typename indxType, typename offsetType>
-class ReturnFunctionSignature<indxType, offsetType, false> {
+template <typename indxType, typename offsetType, typename outType>
+class ReturnFunctionSignature<indxType, offsetType, outType, false> {
  public:
   using jit_embedding_kernel = bool (*)(
       int64_t output_size,
@@ -49,12 +53,12 @@ class ReturnFunctionSignature<indxType, offsetType, false> {
       const indxType* indices,
       const offsetType* offsets_or_lengths,
       const float* weights,
-      float* out,
+      outType* out,
       const int* mask);
 };
 
-template <typename indxType, typename offsetType>
-class ReturnFunctionSignature<indxType, offsetType, true> {
+template <typename indxType, typename offsetType, typename outType>
+class ReturnFunctionSignature<indxType, offsetType, outType, true> {
  public:
   using jit_embedding_kernel = bool (*)(
       int64_t output_size,
@@ -65,7 +69,7 @@ class ReturnFunctionSignature<indxType, offsetType, true> {
       const indxType* indices,
       const offsetType* offsets_or_lengths,
       const float* weights,
-      float* out,
+      outType* out,
       const int32_t* compressed_indices_table,
       const int* mask);
 };
@@ -73,21 +77,28 @@ class ReturnFunctionSignature<indxType, offsetType, true> {
 template <
     typename indxType,
     typename offsetType,
+    typename outType,
     inst_set_t instSet,
     bool ROWWISE_SPARSE = false>
 class GenEmbeddingSpMDMNBitLookup {
  public:
   GenEmbeddingSpMDMNBitLookup() {}
-  typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
-      jit_embedding_kernel
-      getOrCreate(
-          int bit_rate,
-          int block_size,
-          bool has_weight,
-          bool is_weight_positional,
-          bool normalize_by_lengths,
-          int prefetch,
-          bool use_offsets);
+  typename ReturnFunctionSignature<
+      indxType,
+      offsetType,
+      outType,
+      ROWWISE_SPARSE>::jit_embedding_kernel
+  getOrCreate(
+      int bit_rate,
+      int block_size,
+      bool has_weight,
+      bool is_weight_positional,
+      bool normalize_by_lengths,
+      int prefetch,
+      bool use_offsets,
+      int output_stride,
+      int input_stride,
+      bool scale_bias_last);
 
  private:
   static asmjit::JitRuntime& runtime() {
@@ -101,66 +112,98 @@ class GenEmbeddingSpMDMNBitLookup {
   static mutex rtMutex_; ///< Controll access to runtime;
 
   // The hash depends on bit_rate, embedding dimension (block size), weighted
-  // sls, positional weights, normalize by lenths, prefetch distance, and
-  // use_offsets.
+  // sls, positional weights, normalize by lenths, prefetch distance,
+  // use_offsets, output_stride, input_stride, and scale_bias_last
   static CodeCache<
-      tuple<int, int, bool, bool, bool, int, bool>,
-      typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
-          jit_embedding_kernel>
+      tuple<int, int, bool, bool, bool, int, bool, int, int, bool>,
+      typename ReturnFunctionSignature<
+          indxType,
+          offsetType,
+          outType,
+          ROWWISE_SPARSE>::jit_embedding_kernel>
       codeCache_; ///< JIT Code Cache for reuse.
 }; // GenEmbeddingSpmDMLookup
 
 template <
     typename indxType,
     typename offsetType,
+    typename outType,
     inst_set_t instSet,
     bool ROWWISE_SPARSE>
-mutex
-    GenEmbeddingSpMDMNBitLookup<indxType, offsetType, instSet, ROWWISE_SPARSE>::
-        rtMutex_;
+mutex GenEmbeddingSpMDMNBitLookup<
+    indxType,
+    offsetType,
+    outType,
+    instSet,
+    ROWWISE_SPARSE>::rtMutex_;
 
 template <
     typename indxType,
     typename offsetType,
+    typename outType,
     inst_set_t instSet,
     bool ROWWISE_SPARSE>
 CodeCache<
-    tuple<int, int, bool, bool, bool, int, bool>,
-    typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
-        jit_embedding_kernel>
-    GenEmbeddingSpMDMNBitLookup<indxType, offsetType, instSet, ROWWISE_SPARSE>::
-        codeCache_;
+    tuple<int, int, bool, bool, bool, int, bool, int, int, bool>,
+    typename ReturnFunctionSignature<
+        indxType,
+        offsetType,
+        outType,
+        ROWWISE_SPARSE>::jit_embedding_kernel>
+    GenEmbeddingSpMDMNBitLookup<
+        indxType,
+        offsetType,
+        outType,
+        instSet,
+        ROWWISE_SPARSE>::codeCache_;
 
 template <
     typename indxType,
     typename offsetType,
+    typename outType,
     inst_set_t instSet,
     bool ROWWISE_SPARSE>
-typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
-    jit_embedding_kernel
-    GenEmbeddingSpMDMNBitLookup<indxType, offsetType, instSet, ROWWISE_SPARSE>::
-        getOrCreate(
-            int bit_rate,
-            int block_size,
-            bool has_weight,
-            bool is_weight_positional,
-            bool normalize_by_lengths,
-            int prefetch,
-            bool use_offsets) {
-  tuple<int, int, bool, bool, bool, int, bool> kernelSig = make_tuple(
-      bit_rate,
-      block_size,
-      has_weight,
-      is_weight_positional,
-      normalize_by_lengths,
-      prefetch,
-      use_offsets);
+typename ReturnFunctionSignature<
+    indxType,
+    offsetType,
+    outType,
+    ROWWISE_SPARSE>::jit_embedding_kernel
+GenEmbeddingSpMDMNBitLookup<
+    indxType,
+    offsetType,
+    outType,
+    instSet,
+    ROWWISE_SPARSE>::
+    getOrCreate(
+        int bit_rate,
+        int block_size,
+        bool has_weight,
+        bool is_weight_positional,
+        bool normalize_by_lengths,
+        int prefetch,
+        bool use_offsets,
+        int output_stride,
+        int input_stride,
+        bool scale_bias_last) {
+  tuple<int, int, bool, bool, bool, int, bool, int, int, bool> kernelSig =
+      make_tuple(
+          bit_rate,
+          block_size,
+          has_weight,
+          is_weight_positional,
+          normalize_by_lengths,
+          prefetch,
+          use_offsets,
+          output_stride,
+          input_stride,
+          scale_bias_last);
 
   return codeCache_.getOrCreate(
       kernelSig,
       [&]() -> typename ReturnFunctionSignature<
                 indxType,
                 offsetType,
+                outType,
                 ROWWISE_SPARSE>::jit_embedding_kernel {
         // TODO: Make this tunable
         int pref_dist = prefetch;
@@ -190,6 +233,9 @@ typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
         if (ROWWISE_SPARSE) {
           filename += "_rowwise_sparse";
         }
+        if (!scale_bias_last) {
+          filename += "_scale_bias_first"
+        }
         filename += ".txt";
         FILE* codeLogFile = fopen(filename.c_str(), "w");
         asmjit::FileLogger* codeLogger = new asmjit::FileLogger(codeLogFile);
@@ -218,7 +264,6 @@ typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
 
         ++reg_id;
         x86::Gp scratchReg1_ = a->gpz(reg_id); // 12 or 13
-        x86::Gp scratchReg1D_ = a->gpz(reg_id).r32();
 
         ++reg_id;
         x86::Gpd lengths_R_ = a->gpz(reg_id).r32(); // 13 or 14
@@ -318,7 +363,7 @@ typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
         typedef typename simd_info<instSet>::vec_reg_t vec_reg_t;
 
         int num_vec_regs_per_block = ceil_div(block_size, vlen);
-        int remainder = block_size % vlen;
+        const int remainder = block_size % vlen;
 
         // Compute a remainder for vector load
         // Since every row is followed by 2 fp16 (scale and bias), luckily
@@ -338,6 +383,7 @@ typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
         vec_reg_t src_vreg; // for holding embedding value temporarily
         x86::Ymm mask_vreg; // mask for avx2
         x86::Xmm mask2_vreg;
+        x86::Xmm mask_fp16_vreg;
 
         // We need 2 vec registers for 1. scale 2. bias
         --unroll_factor;
@@ -379,6 +425,10 @@ typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
           // AVX512 doesn't need to use vector register for masking
           --unroll_factor;
           mask_vreg = x86::ymm(unroll_factor);
+          if (remainder > 1 && std::is_same<outType, float16>::value) {
+            --unroll_factor;
+            mask_fp16_vreg = x86::xmm(unroll_factor);
+          }
         }
 
         // Creating a mask for vector load
@@ -402,6 +452,20 @@ typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
                 mask_vreg,
                 x86::ymmword_ptr(
                     scratchReg1_, (vlen - remainder) % vlen * sizeof(int32_t)));
+            if (std::is_same<outType, float16>::value) {
+              if (remainder > 1) {
+                a->vmovups(
+                    mask_fp16_vreg,
+                    x86::xmmword_ptr(
+                        scratchReg1_,
+                        (vlen - remainder / 2) * sizeof(int32_t)));
+              }
+              // We need to keep using the stack during the main loop
+              a->lea(
+                  x86::rsp,
+                  x86::dword_ptr(
+                      x86::rsp, static_cast<int32_t>(-vlen * sizeof(int32_t))));
+            }
           } else {
             a->mov(scratchReg1_, (1 << remainder) - 1);
             a->kmovw(x86::k(1), scratchReg1_);
@@ -505,6 +569,7 @@ typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
 
           asmjit::Label LoopDataIndexBegin = a->newLabel();
           asmjit::Label LoopDataIndexEnd = a->newLabel();
+          asmjit::Label ValidIndexLabel = a->newLabel();
 
           // dataIndex loop begins (iterate lengths_R_ times)
           a->bind(LoopDataIndexBegin);
@@ -516,6 +581,19 @@ typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
             a->mov(scratchReg1_, x86::qword_ptr(indices));
           } else {
             a->mov(scratchReg1_.r32(), x86::dword_ptr(indices));
+          }
+          if (!scale_bias_last) {
+            // When scale_bias_last == false, assume this is for table batched
+            // embedding (TBE) that can get -1 for pruned rows.
+            if (areIndices64b) {
+              a->cmp(scratchReg1_, static_cast<asmjit::Imm>(-1));
+            } else {
+              a->cmp(scratchReg1_.r32(), static_cast<asmjit::Imm>(-1));
+            }
+            a->jne(ValidIndexLabel);
+            a->add(indices, static_cast<asmjit::Imm>(sizeof(indxType)));
+            a->jmp(LoopDataIndexBegin);
+            a->bind(ValidIndexLabel);
           }
           // A trick to check x >= data_size or x < 0 in one shot by treating
           // scratchReg1_ as if it has unsigned value
@@ -533,8 +611,7 @@ typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
           }
 
           int num_elem_per_byte = 8 / bit_rate;
-          int fused_block_size =
-              ceil_div(block_size, num_elem_per_byte) + 2 * sizeof(float16);
+          int fused_block_size = input_stride;
           if (pref_dist) {
             asmjit::Label pref_dist_reset_start = a->newLabel();
             asmjit::Label pref_dist_reset_end = a->newLabel();
@@ -608,13 +685,11 @@ typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
 
           // broadcast the scale
           x86::Mem scale_src, bias_src;
-          scale_src = x86::word_ptr(
-              input, scratchReg1_, 0, ceil_div(block_size, num_elem_per_byte));
+          int scale_offset =
+              scale_bias_last ? ceil_div(block_size, num_elem_per_byte) : 0;
+          scale_src = x86::word_ptr(input, scratchReg1_, 0, scale_offset);
           bias_src = x86::word_ptr(
-              input,
-              scratchReg1_,
-              0,
-              ceil_div(block_size, num_elem_per_byte) + sizeof(float16));
+              input, scratchReg1_, 0, scale_offset + sizeof(float16));
           a->vpbroadcastw(scale_vreg.half(), scale_src);
           a->vpbroadcastw(bias_vreg.half(), bias_src);
           a->vcvtph2ps(scale_vreg, scale_vreg.half());
@@ -642,10 +717,14 @@ typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
           // 2) when bit_rate == 2, we get zmm from xmm load via vpmovzxbd
           // (epu8->epi32), and then get 4 zmms from each 128-bit portion of
           // zmm via vpmovsxbd (epi8->epi32).
+          int src_addr_offset = scale_bias_last ? 0 : 2 * sizeof(float16);
           for (int v = 0; v < cur_unroll_factor; v += 4) {
             int bytes_per_vload = (vlen / num_elem_per_byte) * sizeof(uint8_t);
             auto src_addr = x86::dword_ptr(
-                input, scratchReg1_, 0, (vec_idx + v) * bytes_per_vload);
+                input,
+                scratchReg1_,
+                0,
+                src_addr_offset + (vec_idx + v) * bytes_per_vload);
 
             if (bit_rate == 4) {
               if (num_vec_regs_per_block - (vec_idx + v) < 4 &&
@@ -754,21 +833,55 @@ typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
           // back to memory
           for (int v = 0; v < cur_unroll_factor; ++v) {
             auto dst_addr =
-                x86::dword_ptr(out, (vec_idx + v) * vlen * sizeof(float));
+                x86::dword_ptr(out, (vec_idx + v) * vlen * sizeof(outType));
             vec_reg_t out_vreg = vec_reg_t(v);
 
             if (normalize_by_lengths) {
               a->vmulps(out_vreg, out_vreg, vlen_inv_vreg);
             }
 
-            if (remainder && vec_idx + v == num_vec_regs_per_block - 1) {
-              if (instSet == inst_set_t::avx512) {
-                a->k(x86::k(1)).vmovups(dst_addr, out_vreg);
+            if (std::is_same<outType, float>::value) {
+              if (remainder && vec_idx + v == num_vec_regs_per_block - 1) {
+                if (instSet == inst_set_t::avx512) {
+                  a->k(x86::k(1)).vmovups(dst_addr, out_vreg);
+                } else {
+                  a->vmaskmovps(dst_addr, mask_vreg, out_vreg.ymm());
+                }
               } else {
-                a->vmaskmovps(dst_addr, mask_vreg, out_vreg.ymm());
+                a->vmovups(dst_addr, out_vreg);
               }
             } else {
-              a->vmovups(dst_addr, out_vreg);
+              // fp16 output
+              if (instSet == inst_set_t::avx2) {
+                // round nearest with no exception
+                a->vcvtps2ph(out_vreg.xmm(), out_vreg, 8);
+                if (remainder && vec_idx + v == num_vec_regs_per_block - 1) {
+                  if (remainder > 1) {
+                    a->vmaskmovps(dst_addr, mask_fp16_vreg, out_vreg.xmm());
+                  }
+                  if (remainder % 2 != 0) {
+                    a->vmovups(x86::xmmword_ptr(x86::rsp), out_vreg.xmm());
+                    a->mov(
+                        scratchReg1_.r16(),
+                        x86::word_ptr(
+                            x86::rsp, (remainder - 1) * sizeof(outType)));
+                    a->mov(
+                        x86::word_ptr(
+                            out,
+                            ((vec_idx + v) * vlen + (remainder - 1)) *
+                                sizeof(outType)),
+                        scratchReg1_.r16());
+                  }
+                } else {
+                  a->vmovups(dst_addr, out_vreg.xmm());
+                }
+              } else {
+                if (remainder && vec_idx + v == num_vec_regs_per_block - 1) {
+                  a->k(x86::k(1)).vcvtps2ph(dst_addr, out_vreg, 8);
+                } else {
+                  a->vcvtps2ph(dst_addr, out_vreg, 8);
+                }
+              }
             }
           }
 
@@ -807,7 +920,7 @@ typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
         }
 
         a->add(lengths, static_cast<asmjit::Imm>(sizeof(offsetType)));
-        a->add(out, static_cast<asmjit::Imm>(block_size * sizeof(float)));
+        a->add(out, static_cast<asmjit::Imm>(output_stride * sizeof(outType)));
 
         a->jmp(LoopRangeIndexBegin);
         a->bind(LoopRangeIndexEnd);
@@ -820,11 +933,19 @@ typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
         a->mov(x86::eax, false);
         a->bind(exit);
 
+        if (remainder && instSet == inst_set_t::avx2 &&
+            std::is_same<outType, float16>::value) {
+          a->lea(x86::rsp, x86::ymmword_ptr(x86::rsp, vlen * sizeof(int32_t)));
+        }
+
         a->emitEpilog(frame);
 
         // jit_fused8bitembedding_kernel fn;
-        typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
-            jit_embedding_kernel fn;
+        typename ReturnFunctionSignature<
+            indxType,
+            offsetType,
+            outType,
+            ROWWISE_SPARSE>::jit_embedding_kernel fn;
         asmjit::Error err;
         {
           unique_lock<mutex> lock(rtMutex_);
@@ -845,23 +966,39 @@ typename ReturnFunctionSignature<indxType, offsetType, ROWWISE_SPARSE>::
 
 } // namespace
 
-template <typename indxType, typename offsetType>
-typename EmbeddingSpMDMKernelSignature<uint8_t, indxType, offsetType>::Type
-GenerateEmbeddingSpMDMNBit(
-    int bit_rate,
-    const int64_t block_size,
-    bool has_weight,
-    bool normalize_by_lengths,
-    int prefetch,
-    bool is_weight_positional,
-    bool use_offsets) {
+template <typename indxType, typename offsetType, typename outType>
+typename EmbeddingSpMDMKernelSignature<uint8_t, indxType, offsetType, outType>::
+    Type
+    GenerateEmbeddingSpMDMNBitWithStrides(
+        int bit_rate,
+        const int64_t block_size,
+        bool has_weight,
+        bool normalize_by_lengths,
+        int prefetch,
+        bool is_weight_positional,
+        bool use_offsets,
+        int64_t output_stride /*=-1*/,
+        int64_t input_stride /*=-1*/,
+        bool scale_bias_last /*=true*/) {
   assert((bit_rate == 2 || bit_rate == 4) && "bit_rate must be 2 or 4");
 
   if (!cpuinfo_initialize()) {
     throw runtime_error("Failed to initialize cpuinfo!");
   }
+  if (output_stride == -1) {
+    output_stride = block_size;
+  }
+  if (input_stride == -1) {
+    int64_t num_elem_per_byte = 8 / bit_rate;
+    input_stride =
+        ceil_div(block_size, num_elem_per_byte) + 2 * sizeof(float16);
+  }
   if (fbgemmHasAvx512Support()) {
-    static GenEmbeddingSpMDMNBitLookup<indxType, offsetType, inst_set_t::avx512>
+    static GenEmbeddingSpMDMNBitLookup<
+        indxType,
+        offsetType,
+        outType,
+        inst_set_t::avx512>
         kernel_generator;
     const auto original_func = kernel_generator.getOrCreate(
         bit_rate,
@@ -870,7 +1007,10 @@ GenerateEmbeddingSpMDMNBit(
         is_weight_positional,
         normalize_by_lengths,
         prefetch,
-        use_offsets);
+        use_offsets,
+        output_stride,
+        input_stride,
+        scale_bias_last);
     return [=](int64_t output_size,
                int64_t index_size,
                int64_t data_size,
@@ -878,7 +1018,7 @@ GenerateEmbeddingSpMDMNBit(
                const indxType* indices,
                const offsetType* offsets_or_lengths,
                const float* weights,
-               float* out) {
+               outType* out) {
       return original_func(
           output_size,
           index_size,
@@ -891,7 +1031,11 @@ GenerateEmbeddingSpMDMNBit(
           nullptr /* mask not used in avx512 */);
     };
   } else if (fbgemmHasAvx2Support()) {
-    static GenEmbeddingSpMDMNBitLookup<indxType, offsetType, inst_set_t::avx2>
+    static GenEmbeddingSpMDMNBitLookup<
+        indxType,
+        offsetType,
+        outType,
+        inst_set_t::avx2>
         kernel_generator;
     const auto original_func = kernel_generator.getOrCreate(
         bit_rate,
@@ -900,7 +1044,10 @@ GenerateEmbeddingSpMDMNBit(
         is_weight_positional,
         normalize_by_lengths,
         prefetch,
-        use_offsets);
+        use_offsets,
+        output_stride,
+        input_stride,
+        scale_bias_last);
     return [=](int64_t output_size,
                int64_t index_size,
                int64_t data_size,
@@ -908,7 +1055,7 @@ GenerateEmbeddingSpMDMNBit(
                const indxType* indices,
                const offsetType* offsets_or_lengths,
                const float* weights,
-               float* out) {
+               outType* out) {
       return original_func(
           output_size,
           index_size,
@@ -931,7 +1078,7 @@ GenerateEmbeddingSpMDMNBit(
                const indxType* indices,
                const offsetType* offsets_or_lengths,
                const float* weights,
-               float* out) {
+               outType* out) {
       return EmbeddingSpMDMNBit_ref(
           bit_rate,
           block_size,
@@ -945,9 +1092,36 @@ GenerateEmbeddingSpMDMNBit(
           normalize_by_lengths,
           out,
           is_weight_positional,
-          use_offsets);
+          use_offsets,
+          output_stride,
+          input_stride,
+          scale_bias_last);
     };
   }
+}
+
+template <typename IndexType, typename OffsetType, typename OutType>
+FBGEMM_API typename EmbeddingSpMDMKernelSignature<
+    std::uint8_t,
+    IndexType,
+    OffsetType,
+    OutType>::Type
+GenerateEmbeddingSpMDMNBit(
+    int bit_rate,
+    const std::int64_t block_size,
+    bool has_weight,
+    bool normalize_by_lengths,
+    int prefetch,
+    bool is_weight_positional,
+    bool use_offsets) {
+  return GenerateEmbeddingSpMDMNBitWithStrides<IndexType, OffsetType, OutType>(
+      bit_rate,
+      block_size,
+      has_weight,
+      normalize_by_lengths,
+      prefetch,
+      is_weight_positional,
+      use_offsets);
 }
 
 template <typename indxType, typename offsetType>
@@ -968,10 +1142,14 @@ GenerateEmbeddingSpMDMNBitRowWiseSparse(
   if (!cpuinfo_initialize()) {
     throw runtime_error("Failed to initialize cpuinfo!");
   }
+  int64_t num_elem_per_byte = 8 / bit_rate;
+  int64_t input_stride =
+      ceil_div(block_size, num_elem_per_byte) + 2 * sizeof(float16);
   if (fbgemmHasAvx512Support()) {
     static GenEmbeddingSpMDMNBitLookup<
         indxType,
         offsetType,
+        /*outType=*/float,
         inst_set_t::avx512,
         /*rowwise_sparse=*/true>
         kernel_generator;
@@ -982,7 +1160,10 @@ GenerateEmbeddingSpMDMNBitRowWiseSparse(
         is_weight_positional,
         normalize_by_lengths,
         prefetch,
-        use_offsets);
+        use_offsets,
+        /*output_stride=*/block_size,
+        input_stride,
+        /*scale_bias_last=*/true);
     return [=](int64_t output_size,
                int64_t index_size,
                int64_t uncompressed_data_size,
@@ -1008,6 +1189,7 @@ GenerateEmbeddingSpMDMNBitRowWiseSparse(
     static GenEmbeddingSpMDMNBitLookup<
         indxType,
         offsetType,
+        /*outType=*/float,
         inst_set_t::avx2,
         /*rowwise_sparse=*/true>
         kernel_generator;
@@ -1018,7 +1200,10 @@ GenerateEmbeddingSpMDMNBitRowWiseSparse(
         is_weight_positional,
         normalize_by_lengths,
         prefetch,
-        use_offsets);
+        use_offsets,
+        /*output_stride=*/block_size,
+        input_stride,
+        /*scale_bias_last=*/true);
     return [=](int64_t output_size,
                int64_t index_size,
                int64_t uncompressed_data_size,
@@ -1073,39 +1258,62 @@ GenerateEmbeddingSpMDMNBitRowWiseSparse(
   }
 }
 
-#define INSTANTIATE_SPMDM_BASE(RET_TYPE, NAME, INDEX_TYPE, OFFSET_TYPE) \
-  template FBGEMM_API                                                   \
-      typename RET_TYPE<uint8_t, INDEX_TYPE, OFFSET_TYPE>::Type         \
-      NAME<INDEX_TYPE, OFFSET_TYPE>(                                    \
-          int bit_rate,                                                 \
-          const int64_t block_size,                                     \
-          bool has_weight,                                              \
-          bool normalize_by_lengths,                                    \
-          int prefetch,                                                 \
-          bool is_weight_positional,                                    \
-          bool use_offsets);
+#define INSTANTIATE_SPMDM_BASE(INDEX_TYPE, OFFSET_TYPE, OUT_TYPE)           \
+  template FBGEMM_API typename EmbeddingSpMDMKernelSignature<               \
+      uint8_t,                                                              \
+      INDEX_TYPE,                                                           \
+      OFFSET_TYPE,                                                          \
+      OUT_TYPE>::Type                                                       \
+  GenerateEmbeddingSpMDMNBit<INDEX_TYPE, OFFSET_TYPE, OUT_TYPE>(            \
+      int bit_rate,                                                         \
+      const int64_t block_size,                                             \
+      bool has_weight,                                                      \
+      bool normalize_by_lengths,                                            \
+      int prefetch,                                                         \
+      bool is_weight_positional,                                            \
+      bool use_offsets);                                                    \
+  template FBGEMM_API typename EmbeddingSpMDMKernelSignature<               \
+      uint8_t,                                                              \
+      INDEX_TYPE,                                                           \
+      OFFSET_TYPE,                                                          \
+      OUT_TYPE>::Type                                                       \
+  GenerateEmbeddingSpMDMNBitWithStrides<INDEX_TYPE, OFFSET_TYPE, OUT_TYPE>( \
+      int bit_rate,                                                         \
+      const int64_t block_size,                                             \
+      bool has_weight,                                                      \
+      bool normalize_by_lengths,                                            \
+      int prefetch,                                                         \
+      bool is_weight_positional,                                            \
+      bool use_offsets,                                                     \
+      int64_t output_stride,                                                \
+      int64_t input_stride,                                                 \
+      bool scale_bias_last);
 
-#define INSTANTIATE_SPMDM_NAME(INDEX_TYPE, OFFSET_TYPE) \
-  INSTANTIATE_SPMDM_BASE(                               \
-      EmbeddingSpMDMKernelSignature,                    \
-      GenerateEmbeddingSpMDMNBit,                       \
-      INDEX_TYPE,                                       \
-      OFFSET_TYPE)                                      \
-  INSTANTIATE_SPMDM_BASE(                               \
-      EmbeddingSpMDMRowWiseSparseKernelSignature,       \
-      GenerateEmbeddingSpMDMNBitRowWiseSparse,          \
-      INDEX_TYPE,                                       \
-      OFFSET_TYPE)
+#define INSTANTIATE_SPMDM_OUT_T(INDEX_TYPE, OFFSET_TYPE)                   \
+  INSTANTIATE_SPMDM_BASE(INDEX_TYPE, OFFSET_TYPE, float)                   \
+  INSTANTIATE_SPMDM_BASE(INDEX_TYPE, OFFSET_TYPE, float16)                 \
+  template FBGEMM_API typename EmbeddingSpMDMRowWiseSparseKernelSignature< \
+      uint8_t,                                                             \
+      INDEX_TYPE,                                                          \
+      OFFSET_TYPE>::Type                                                   \
+  GenerateEmbeddingSpMDMNBitRowWiseSparse<INDEX_TYPE, OFFSET_TYPE>(        \
+      int bit_rate,                                                        \
+      const int64_t block_size,                                            \
+      bool has_weight,                                                     \
+      bool normalize_by_lengths,                                           \
+      int prefetch,                                                        \
+      bool is_weight_positional,                                           \
+      bool use_offsets);
 
 #define INSTANTIATE_SPMDM_OFFSET_T(INDEX_TYPE) \
-  INSTANTIATE_SPMDM_NAME(INDEX_TYPE, int32_t)  \
-  INSTANTIATE_SPMDM_NAME(INDEX_TYPE, int64_t)
+  INSTANTIATE_SPMDM_OUT_T(INDEX_TYPE, int32_t) \
+  INSTANTIATE_SPMDM_OUT_T(INDEX_TYPE, int64_t)
 
 INSTANTIATE_SPMDM_OFFSET_T(int32_t)
 INSTANTIATE_SPMDM_OFFSET_T(int64_t)
 
 #undef INSTANTIATE_SPMDM_OFFSET_T
-#undef INSTANTIATE_SPMDM_NAME
+#undef INSTANTIATE_SPMDM_OUT_T
 #undef INSTANTIATE_SPMDM_BASE
 
 } // namespace fbgemm

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -217,7 +217,8 @@ FBGEMM_API void im2col_ref(
 template <
     typename InType = std::uint8_t,
     typename IndexType = std::int64_t,
-    typename OffsetType = std::int32_t>
+    typename OffsetType = std::int32_t,
+    typename OutType = float>
 FBGEMM_API bool EmbeddingSpMDM_ref(
     const std::int64_t block_size,
     const std::int64_t output_size,
@@ -228,13 +229,17 @@ FBGEMM_API bool EmbeddingSpMDM_ref(
     const OffsetType* offsets_or_lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
-    float* out,
+    OutType* out,
     bool is_weight_positional = false,
     bool use_offsets = true,
     std::int64_t output_stride = -1,
-    std::int64_t input_stride = -1);
+    std::int64_t input_stride = -1,
+    bool scale_bias_last = true);
 
-template <typename IndexType = std::int64_t, typename OffsetType = std::int32_t>
+template <
+    typename IndexType = std::int64_t,
+    typename OffsetType = std::int32_t,
+    typename OutType = float>
 FBGEMM_API bool EmbeddingSpMDMNBit_ref(
     int bit_rate,
     const std::int64_t block_size,
@@ -246,9 +251,12 @@ FBGEMM_API bool EmbeddingSpMDMNBit_ref(
     const OffsetType* offsets_or_lengths,
     const float* weights, // optional, can be null for non-weighted sum
     bool normalize_by_lengths,
-    float* out,
+    OutType* out,
     bool is_weight_positional = false,
-    bool use_offsets = true);
+    bool use_offsets = true,
+    std::int64_t output_stride = -1,
+    std::int64_t input_stride = -1,
+    bool scale_bias_last = true);
 
 template <
     typename InType = std::uint8_t,

--- a/test/EmbeddingSpMDMNBitTest.cc
+++ b/test/EmbeddingSpMDMNBitTest.cc
@@ -59,7 +59,9 @@ class FusedNBitRowwiseEmbeddingLookupTest : public testing::TestWithParam<tuple<
                                                 EmbeddingSpMDMWeightChoice,
                                                 bool,
                                                 bool,
-                                                EmbeddingSpMDMCornerCase>> {};
+                                                EmbeddingSpMDMCornerCase,
+                                                bool,
+                                                bool>> {};
 }; // namespace
 
 INSTANTIATE_TEST_CASE_P(
@@ -80,12 +82,14 @@ INSTANTIATE_TEST_CASE_P(
             NONE,
             EMPTY_INDICES,
             OUT_OF_BOUND_INDICES,
-            UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM)));
+            UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM),
+        ::testing::Bool(), // output float or float16
+        ::testing::Bool())); // scale_bias_last
 
 TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
   vector<vector<int>> inputs(GetInputs_());
   bool isIndex64b, isOffset64b, is_wt_positional, use_weight,
-      normalize_by_lengths, use_offsets;
+      normalize_by_lengths, use_offsets, is_output_float, scale_bias_last;
   int bit_rate, prefetch;
   EmbeddingSpMDMWeightChoice weight_choice;
   EmbeddingSpMDMCornerCase corner_case;
@@ -96,9 +100,22 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
       weight_choice,
       normalize_by_lengths,
       use_offsets,
-      corner_case) = GetParam();
+      corner_case,
+      is_output_float,
+      scale_bias_last) = GetParam();
   is_wt_positional = weight_choice == POSITIONAL_WEIGHTED;
   use_weight = weight_choice != UNWEIGHTED;
+
+  if (corner_case != NONE || weight_choice == POSITIONAL_WEIGHTED) {
+    // Check corner case only for subset of tests.
+    if (normalize_by_lengths || !is_output_float || !scale_bias_last) {
+      return;
+    }
+  }
+  if (is_wt_positional && !use_weight) {
+    // weight positional only makes sense when use_weight is true
+    return;
+  }
 
   int num_elem_per_byte = 8 / bit_rate;
 
@@ -121,12 +138,15 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
       for (int ii = 0;
            ii < (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte;
            ii++) {
-        fused_embedding_table[i * fused_embedding_dim + ii] =
-            entries(generator);
+        fused_embedding_table
+            [i * fused_embedding_dim + ii +
+             (scale_bias_last ? 0 : 2 * sizeof(float16))] = entries(generator);
       }
       float16* scale_bias = reinterpret_cast<float16*>(
           fused_embedding_table.data() + i * fused_embedding_dim +
-          (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte);
+          (scale_bias_last
+               ? (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte
+               : 0));
       float scale = embedding_distribution(generator);
       float bias = embedding_distribution(generator);
       FloatToFloat16_ref(&scale, scale_bias, 1, true /* clip */);
@@ -154,151 +174,108 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
     const int32_t* offsets_or_lengths_32 =
         (use_offsets ? offsets_32 : lengths_32).data();
 
-    vector<float> output_sls_ref(batch_size * embedding_dim);
-    vector<float> output_slws_ref(output_sls_ref.size()),
-        output_sls(output_sls_ref.size()), output_slws(output_sls_ref.size());
+    // Sentries at the end to make sure masking is done correctly not to write
+    // out of bounds.
+    constexpr int num_sentries = 10;
+    const float sentry_value = 1.0f;
+    int output_size_wo_sentries = batch_size * embedding_dim;
+    vector<float> output_ref(output_size_wo_sentries + num_sentries);
+    vector<float> output(output_ref.size());
+    vector<float16> output_ref_fp16(output.size()), output_fp16(output.size());
+    for (int i = output_size_wo_sentries; i < output.size(); ++i) {
+      output_ref[i] = sentry_value;
+      output[i] = sentry_value;
+      output_ref_fp16[i] = cpu_float2half_rn(sentry_value);
+      output_fp16[i] = cpu_float2half_rn(sentry_value);
+    }
 
-    vector<float>& output_ref = use_weight ? output_slws_ref : output_sls_ref;
-    vector<float>& output = use_weight ? output_slws : output_sls;
     bool success, success_ref;
 
-    if (isOffset64b) {
-      if (isIndex64b) {
-        success_ref = EmbeddingSpMDMNBit_ref<int64_t>(
-            bit_rate,
-            embedding_dim,
-            batch_size,
-            lengths_sum,
-            num_rows,
-            fused_embedding_table.data(),
-            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
-            offsets_or_lengths,
-            use_weight ? weights.data() : nullptr,
-            normalize_by_lengths,
-            output_ref.data(),
-            is_wt_positional,
-            use_offsets);
+#define TEST_BASE(                                                           \
+    indices,                                                                 \
+    offsets_or_lengths,                                                      \
+    output_ref,                                                              \
+    output,                                                                  \
+    IndexType,                                                               \
+    OffsetType,                                                              \
+    OutType)                                                                 \
+  success_ref = EmbeddingSpMDMNBit_ref<IndexType, OffsetType, OutType>(      \
+      bit_rate,                                                              \
+      embedding_dim,                                                         \
+      batch_size,                                                            \
+      lengths_sum,                                                           \
+      num_rows,                                                              \
+      fused_embedding_table.data(),                                          \
+      corner_case == EMPTY_INDICES ? nullptr : indices.data(),               \
+      offsets_or_lengths,                                                    \
+      use_weight ? weights.data() : nullptr,                                 \
+      normalize_by_lengths,                                                  \
+      output_ref.data(),                                                     \
+      is_wt_positional,                                                      \
+      use_offsets,                                                           \
+      /*output_stride=*/-1,                                                  \
+      /*input_stride=*/-1,                                                   \
+      scale_bias_last);                                                      \
+                                                                             \
+  auto kernel =                                                              \
+      GenerateEmbeddingSpMDMNBitWithStrides<IndexType, OffsetType, OutType>( \
+          bit_rate,                                                          \
+          embedding_dim,                                                     \
+          use_weight,                                                        \
+          normalize_by_lengths,                                              \
+          prefetch,                                                          \
+          is_wt_positional,                                                  \
+          use_offsets,                                                       \
+          /*output_stride=*/-1,                                              \
+          /*input_stride=*/-1,                                               \
+          scale_bias_last);                                                  \
+  success = kernel(                                                          \
+      batch_size,                                                            \
+      lengths_sum,                                                           \
+      num_rows,                                                              \
+      fused_embedding_table.data(),                                          \
+      corner_case == EMPTY_INDICES ? nullptr : indices.data(),               \
+      offsets_or_lengths,                                                    \
+      use_weight ? weights.data() : nullptr,                                 \
+      output.data());
 
-        auto kernel = GenerateEmbeddingSpMDMNBit<int64_t, int64_t>(
-            bit_rate,
-            embedding_dim,
-            use_weight,
-            normalize_by_lengths,
-            prefetch,
-            is_wt_positional,
-            use_offsets);
-        success = kernel(
-            batch_size,
-            lengths_sum,
-            num_rows,
-            fused_embedding_table.data(),
-            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
-            offsets_or_lengths,
-            use_weight ? weights.data() : nullptr,
-            output.data());
-      } else {
-        success_ref = EmbeddingSpMDMNBit_ref<int32_t>(
-            bit_rate,
-            embedding_dim,
-            batch_size,
-            lengths_sum,
-            num_rows,
-            fused_embedding_table.data(),
-            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
-            offsets_or_lengths,
-            use_weight ? weights.data() : nullptr,
-            normalize_by_lengths,
-            output_ref.data(),
-            is_wt_positional,
-            use_offsets);
+#define TEST_OUT_TYPE(indices, offsets_or_lengths, IndexType, OffsetType) \
+  if (is_output_float) {                                                  \
+    TEST_BASE(                                                            \
+        indices,                                                          \
+        offsets_or_lengths,                                               \
+        output_ref,                                                       \
+        output,                                                           \
+        IndexType,                                                        \
+        OffsetType,                                                       \
+        float);                                                           \
+  } else {                                                                \
+    TEST_BASE(                                                            \
+        indices,                                                          \
+        offsets_or_lengths,                                               \
+        output_ref_fp16,                                                  \
+        output_fp16,                                                      \
+        IndexType,                                                        \
+        OffsetType,                                                       \
+        float16);                                                         \
+  }
 
-        auto kernel = GenerateEmbeddingSpMDMNBit<int32_t, int64_t>(
-            bit_rate,
-            embedding_dim,
-            use_weight,
-            normalize_by_lengths,
-            prefetch,
-            is_wt_positional,
-            use_offsets);
-        success = kernel(
-            batch_size,
-            lengths_sum,
-            num_rows,
-            fused_embedding_table.data(),
-            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
-            offsets_or_lengths,
-            use_weight ? weights.data() : nullptr,
-            output.data());
-      }
+#define TEST_OFFSET_TYPE(indices, IndexType)                           \
+  if (isOffset64b) {                                                   \
+    TEST_OUT_TYPE(indices, offsets_or_lengths, IndexType, int64_t);    \
+  } else {                                                             \
+    TEST_OUT_TYPE(indices, offsets_or_lengths_32, IndexType, int32_t); \
+  }
+
+    if (isIndex64b) {
+      TEST_OFFSET_TYPE(indices, int64_t);
     } else {
-      if (isIndex64b) {
-        success_ref = EmbeddingSpMDMNBit_ref<int64_t>(
-            bit_rate,
-            embedding_dim,
-            batch_size,
-            lengths_sum,
-            num_rows,
-            fused_embedding_table.data(),
-            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
-            offsets_or_lengths,
-            use_weight ? weights.data() : nullptr,
-            normalize_by_lengths,
-            output_ref.data(),
-            is_wt_positional,
-            use_offsets);
-
-        auto kernel = GenerateEmbeddingSpMDMNBit<int64_t>(
-            bit_rate,
-            embedding_dim,
-            use_weight,
-            normalize_by_lengths,
-            prefetch,
-            is_wt_positional,
-            use_offsets);
-        success = kernel(
-            batch_size,
-            lengths_sum,
-            num_rows,
-            fused_embedding_table.data(),
-            corner_case == EMPTY_INDICES ? nullptr : indices.data(),
-            offsets_or_lengths_32,
-            use_weight ? weights.data() : nullptr,
-            output.data());
-      } else {
-        success_ref = EmbeddingSpMDMNBit_ref<int32_t>(
-            bit_rate,
-            embedding_dim,
-            batch_size,
-            lengths_sum,
-            num_rows,
-            fused_embedding_table.data(),
-            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
-            offsets_or_lengths,
-            use_weight ? weights.data() : nullptr,
-            normalize_by_lengths,
-            output_ref.data(),
-            is_wt_positional,
-            use_offsets);
-
-        auto kernel = GenerateEmbeddingSpMDMNBit<int32_t>(
-            bit_rate,
-            embedding_dim,
-            use_weight,
-            normalize_by_lengths,
-            prefetch,
-            is_wt_positional,
-            use_offsets);
-        success = kernel(
-            batch_size,
-            lengths_sum,
-            num_rows,
-            fused_embedding_table.data(),
-            corner_case == EMPTY_INDICES ? nullptr : indices_32.data(),
-            offsets_or_lengths_32,
-            use_weight ? weights.data() : nullptr,
-            output.data());
-      }
+      TEST_OFFSET_TYPE(indices_32, int32_t);
     }
+
+#undef TEST_OFFSET_TYPE
+#undef TEST_OUT_TYPE
+#undef TEST_BASE
 
     // Check correctness
     EXPECT_EQ(success, success_ref)
@@ -309,9 +286,25 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
     }
     if (success) {
       for (int i = 0; i < output.size(); ++i) {
-        EXPECT_EQ(output[i], output_ref[i])
-            << "results differ at (" << i << ") reference: " << output_ref[i]
-            << ", FBGEMM: " << output[i] << " emb dim :" << embedding_dim;
+        float actual =
+            is_output_float ? output[i] : cpu_half2float(output_fp16[i]);
+        float expected = is_output_float ? output_ref[i]
+                                         : cpu_half2float(output_ref_fp16[i]);
+        EXPECT_EQ(actual, expected)
+            << "results differ at (" << i << ") reference: " << expected
+            << ", FBGEMM: " << actual << " emb dim :" << embedding_dim;
+      }
+      for (int offset = output_size_wo_sentries;
+           offset < output_size_wo_sentries + num_sentries;
+           ++offset) {
+        float actual = is_output_float ? output[offset]
+                                       : cpu_half2float(output_fp16[offset]);
+        float expected = is_output_float
+            ? output_ref[offset]
+            : cpu_half2float(output_ref_fp16[offset]);
+        EXPECT_EQ(actual, expected)
+            << "results differ at (" << offset << ") reference: " << expected
+            << ", FBGEMM: " << actual << " emb dim :" << embedding_dim;
       }
     }
   } // end for input
@@ -320,7 +313,7 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
 TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
   vector<vector<int>> inputs(GetInputs_());
   bool isIndex64b, isOffset64b, is_wt_positional, use_weight,
-      normalize_by_lengths, use_offsets;
+      normalize_by_lengths, use_offsets, is_output_float, scale_bias_last;
   int bit_rate, prefetch;
   EmbeddingSpMDMWeightChoice weight_choice;
   EmbeddingSpMDMCornerCase corner_case;
@@ -331,9 +324,15 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
       weight_choice,
       normalize_by_lengths,
       use_offsets,
-      corner_case) = GetParam();
+      corner_case,
+      is_output_float,
+      scale_bias_last) = GetParam();
   is_wt_positional = weight_choice == POSITIONAL_WEIGHTED;
   use_weight = weight_choice != UNWEIGHTED;
+
+  if (!is_output_float || !scale_bias_last) {
+    return;
+  }
 
   int num_elem_per_byte = 8 / bit_rate;
   constexpr float sparsity = 0.7;


### PR DESCRIPTION
Summary:
This diff adds the followings to be used in quantized table batched embedding (TBE)
* scale_bias_last : by default true which is the old fbgemm CPU embedding JIT'ed kernel behavior. If false, scale and bias appear at the beginning of each row and are in fp16 matching with TBE.
* OutType can be fp16
* output_stride and input_stride support for int4/int2 embedding

Differential Revision: D33430251

