### PR TITLE
int8 dequantize kernel for batched mixed dimension pooled embedding output

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -93,6 +93,10 @@ at::Tensor half_to_fused8bitrowwise_cpu(const at::Tensor& input);
 at::Tensor fused8bitrowwise_to_float_cpu(const at::Tensor& input);
 at::Tensor fused8bitrowwise_to_half_cpu(const at::Tensor& input);
 
+at::Tensor _fused8bitrowwise_to_float_mixed_dim_gpu(
+    const at::Tensor& input,
+    const at::Tensor& D_offsets,
+    const int64_t output_dtype);
 at::Tensor _float_to_fusednbitrowwise_gpu(
     const at::Tensor& input,
     const int64_t bit_rate);

--- a/fbgemm_gpu/src/quantize_ops_cpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops_cpu.cpp
@@ -222,6 +222,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "Fused8BitRowwiseQuantizedToFloatOut(Tensor output, Tensor input) -> Tensor");
   m.def(
+      "Fused8BitRowwiseQuantizedToFloatMixedDim(Tensor input, Tensor D_offsets, int output_dtype) -> Tensor");
+  m.def(
       "FloatToFusedNBitRowwiseQuantizedSBHalf(Tensor input, int bit_rate) -> Tensor");
   m.def(
       "HalfToFusedNBitRowwiseQuantizedSBHalf(Tensor input, int bit_rate) -> Tensor");

--- a/fbgemm_gpu/src/quantize_ops_gpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops_gpu.cpp
@@ -21,6 +21,9 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
       "Fused8BitRowwiseQuantizedToFloat",
       fbgemm_gpu::_fused8bitrowwise_to_float_gpu);
   DISPATCH_TO_CUDA(
+      "Fused8BitRowwiseQuantizedToFloatMixedDim",
+      fbgemm_gpu::_fused8bitrowwise_to_float_mixed_dim_gpu);
+  DISPATCH_TO_CUDA(
       "Fused8BitRowwiseQuantizedToHalf",
       fbgemm_gpu::_fused8bitrowwise_to_half_gpu);
   DISPATCH_TO_CUDA(

--- a/fbgemm_gpu/test/quantize_ops_test.py
+++ b/fbgemm_gpu/test/quantize_ops_test.py
@@ -3,11 +3,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import random
 import unittest
 
 import hypothesis.strategies as st
 import numpy as np
 import torch
+from fbgemm_gpu.split_embedding_configs import SparseType
 from hypothesis import HealthCheck, given, assume, settings
 
 
@@ -209,6 +211,132 @@ class TestFused8BitRowwiseQuantizationConversion(unittest.TestCase):
             )
             # compare quantized data
             torch.testing.assert_allclose(dequantized_data_gpu.cpu(), reference)
+
+
+class TestMixedDimInt8DequantizationConversion(unittest.TestCase):
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    # Pyre was not able to infer the type of argument `not torch.cuda.is_available()`
+    # to decorator factory `unittest.skipIf`.
+    @unittest.skipIf(not torch.cuda.is_available(), "Skip when CUDA is not available")
+    def test_mixed_dim_8bit_dequantize_op_empty(self) -> None:
+        # assert that kernel return empty tensor and not failing with cuda error
+        input_refs = torch.empty((0, 0), dtype=torch.uint8).cuda()
+        D_offsets = torch.tensor([0]).cuda()
+        mixed_dim_dequant_output = (
+            torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloatMixedDim(
+                input_refs, D_offsets, SparseType.FP32.as_int()
+            )
+        )
+        assert mixed_dim_dequant_output.numel() == 0
+
+    @unittest.skipIf(not torch.cuda.is_available(), "Skip when CUDA is not available")
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    #  `hypothesis.strategies.integers($parameter$min_value = 0, $parameter$max_value =
+    #  100)` to decorator factory `hypothesis.given`.
+    @given(
+        B=st.integers(min_value=1, max_value=100),
+        T=st.integers(min_value=1, max_value=100),
+        output_dtype=st.sampled_from([SparseType.FP32, SparseType.FP16]),
+        min_dim=st.just(1),
+        max_dim=st.just(100),
+    )
+    @settings(deadline=10000, suppress_health_check=[HealthCheck.filter_too_much])
+    def test_mixed_dim_8bit_dequantize_op(
+        self,
+        B: int,
+        T: int,
+        output_dtype: SparseType,
+        min_dim: int,
+        max_dim: int,
+    ) -> None:
+        self.run_mixed_dim_8bit_dequantize_op_test(B, T, output_dtype, min_dim, max_dim)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "Skip when CUDA is not available")
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    #  `hypothesis.strategies.integers($parameter$min_value = 0, $parameter$max_value =
+    #  100)` to decorator factory `hypothesis.given`.
+    @given(
+        B=st.integers(min_value=1, max_value=100),
+        T=st.integers(min_value=1, max_value=100),
+        output_dtype=st.sampled_from([SparseType.FP32, SparseType.FP16]),
+        min_dim=st.just(100),
+        max_dim=st.just(1000),
+    )
+    @settings(deadline=10000, suppress_health_check=[HealthCheck.filter_too_much])
+    def test_mixed_dim_8bit_dequantize_op_large_dims(
+        self,
+        B: int,
+        T: int,
+        output_dtype: SparseType,
+        min_dim: int,
+        max_dim: int,
+    ) -> None:
+        self.run_mixed_dim_8bit_dequantize_op_test(B, T, output_dtype, min_dim, max_dim)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "Skip when CUDA is not available")
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    #  `hypothesis.strategies.integers($parameter$min_value = 0, $parameter$max_value =
+    #  100)` to decorator factory `hypothesis.given`.
+    @given(
+        B=st.just(65540),
+        T=st.just(5),
+        output_dtype=st.just(SparseType.FP32),
+        min_dim=st.just(1),
+        max_dim=st.just(100),
+    )
+    @settings(deadline=10000, suppress_health_check=[HealthCheck.filter_too_much])
+    def test_mixed_dim_8bit_dequantize_op_large_rows(
+        self,
+        B: int,
+        T: int,
+        output_dtype: SparseType,
+        min_dim: int,
+        max_dim: int,
+    ) -> None:
+        self.run_mixed_dim_8bit_dequantize_op_test(B, T, output_dtype, min_dim, max_dim)
+
+    def run_mixed_dim_8bit_dequantize_op_test(
+        self,
+        B: int,
+        T: int,
+        output_dtype: SparseType,
+        min_dim: int,
+        max_dim: int,
+    ) -> None:
+        table_dims = [
+            random.randint(min_dim, max_dim) * 8 for _ in range(T)
+        ]  # assume table dimensions are multiples of 8
+        table_dims_with_qparams = [d + 8 for d in table_dims]
+        D_offsets = (
+            torch.cumsum(torch.tensor([0] + table_dims_with_qparams), dim=0)
+            .to(torch.int)
+            .cuda()
+        )
+        input_refs = [torch.randn((B, d)).cuda() for d in table_dims]
+        input_refs_int8 = [
+            torch.ops.fbgemm.FloatToFused8BitRowwiseQuantized(t) for t in input_refs
+        ]
+        input_data = torch.concat(input_refs_int8, dim=1).contiguous()
+        mixed_dim_dequant_output = (
+            torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloatMixedDim(
+                input_data, D_offsets, output_dtype.as_int()
+            )
+        )
+
+        table_output_split = [t + 8 for t in table_dims]
+        output_ref = []
+
+        for output_i8 in torch.split(input_data, table_output_split, dim=1):
+            output_ref.append(
+                torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloat(
+                    output_i8.contiguous()
+                )
+            )
+        output_ref_concat = torch.cat(output_ref, dim=1)
+        if output_dtype == SparseType.FP16:
+            output_ref_concat = output_ref_concat.half()
+
+        torch.testing.assert_allclose(output_ref_concat, mixed_dim_dequant_output)
 
 
 class TestFusedNBitRowwiseQuantizationConversion(unittest.TestCase):


### PR DESCRIPTION
Summary:
Add Fused8BitRowwiseQuantizedToFloatMixedDim function that dequantizes batched mixed dimension pooled embedding output, with FP32/FP16 output type.

Fused split table batched embedding forward pass + rowwise int8 quantization of pooled embedding output has the following format:

[B x concat(T1,...,Tn)] where each T1 is a quantized row with format T1 = [x1, x2, ..., xn, qparam1, qparam2]

Differential Revision: D31467683

