### PR TITLE
Continue moving fbgemm_gpu operators to the preferred fbgemm namespace.

### DIFF
--- a/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
@@ -38,7 +38,7 @@ def invoke(
     {% endif %}
 ) -> torch.Tensor:
     if (common_args.host_weights.numel() > 0):
-        return torch.ops.fb.split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(
+        return torch.ops.fbgemm.split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(
             # common_args
             host_weights=common_args.host_weights,
             weights_placements=common_args.weights_placements,
@@ -96,7 +96,7 @@ def invoke(
             {% endif %}
         )
     else:
-        return torch.ops.fb.split_embedding_codegen_lookup_{{ optimizer }}_function(
+        return torch.ops.fbgemm.split_embedding_codegen_lookup_{{ optimizer }}_function(
             # common_args
             {% if not dense %}
             placeholder_autograd_tensor=common_args.placeholder_autograd_tensor,

--- a/fbgemm_gpu/src/cumem_utils_host.cpp
+++ b/fbgemm_gpu/src/cumem_utils_host.cpp
@@ -67,6 +67,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "uvm_mem_advice_dont_fork(Tensor t) -> ()",
       TORCH_FN(uvm_mem_advice_dont_fork));
 
+  m.def("uvm_to_cpu_clone(Tensor t) -> Tensor", TORCH_FN(uvm_to_cpu_clone));
+
 #ifndef __HIP_PLATFORM_HCC__
   // FIXME: some advanced "cudaMemAdvise" flags are not supported by HIP.
   m.def(FBGEMM_GPU_ENUM_OP(uvm, fbgemm_gpu_uvm_enum_query));


### PR DESCRIPTION
Reviewed By: jianyuh

Differential Revision: D33480850

