### PR TITLE
Disable clang inline asm workaround for clang-14 and later

### DIFF
--- a/src/FbgemmFP16UKernelsAvx2.cc
+++ b/src/FbgemmFP16UKernelsAvx2.cc
@@ -10,7 +10,7 @@ namespace fbgemm {
 
 void NOINLINE gemmkernel_1x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -132,7 +132,7 @@ void NOINLINE gemmkernel_1x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_2x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -275,7 +275,7 @@ void NOINLINE gemmkernel_2x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_3x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -437,7 +437,7 @@ void NOINLINE gemmkernel_3x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_4x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -618,7 +618,7 @@ void NOINLINE gemmkernel_4x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_5x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -818,7 +818,7 @@ void NOINLINE gemmkernel_5x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_6x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"

--- a/src/FbgemmFP16UKernelsAvx512.cc
+++ b/src/FbgemmFP16UKernelsAvx512.cc
@@ -10,7 +10,7 @@ namespace fbgemm {
 
 void NOINLINE gemmkernel_1x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -132,7 +132,7 @@ void NOINLINE gemmkernel_1x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_2x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -275,7 +275,7 @@ void NOINLINE gemmkernel_2x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_3x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -437,7 +437,7 @@ void NOINLINE gemmkernel_3x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_4x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -618,7 +618,7 @@ void NOINLINE gemmkernel_4x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_5x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -818,7 +818,7 @@ void NOINLINE gemmkernel_5x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_6x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -1037,7 +1037,7 @@ void NOINLINE gemmkernel_6x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_7x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -1275,7 +1275,7 @@ void NOINLINE gemmkernel_7x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_8x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -1532,7 +1532,7 @@ void NOINLINE gemmkernel_8x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_9x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -1808,7 +1808,7 @@ void NOINLINE gemmkernel_9x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_10x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -2103,7 +2103,7 @@ void NOINLINE gemmkernel_10x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_11x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -2417,7 +2417,7 @@ void NOINLINE gemmkernel_11x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_12x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -2750,7 +2750,7 @@ void NOINLINE gemmkernel_12x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_13x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -3102,7 +3102,7 @@ void NOINLINE gemmkernel_13x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_14x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"

--- a/src/FbgemmFP16UKernelsAvx512_256.cc
+++ b/src/FbgemmFP16UKernelsAvx512_256.cc
@@ -10,7 +10,7 @@ namespace fbgemm {
 
 void NOINLINE gemmkernel_7x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -248,7 +248,7 @@ void NOINLINE gemmkernel_7x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_8x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -505,7 +505,7 @@ void NOINLINE gemmkernel_8x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_9x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -781,7 +781,7 @@ void NOINLINE gemmkernel_9x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_10x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -1076,7 +1076,7 @@ void NOINLINE gemmkernel_10x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_11x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -1390,7 +1390,7 @@ void NOINLINE gemmkernel_11x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_12x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -1723,7 +1723,7 @@ void NOINLINE gemmkernel_12x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_13x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"
@@ -2075,7 +2075,7 @@ void NOINLINE gemmkernel_13x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_14x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 14
       "mov r14, %[gp]\t\n"
 #else
       "mov %[gp], %%r14\t\n"

--- a/src/codegen_fp16fp32.cc
+++ b/src/codegen_fp16fp32.cc
@@ -393,7 +393,7 @@ int main(int argc, const char* argv[]) {
 
         srcfile << "  asm volatile(\n";
 
-        srcfile << "#if !defined(__clang__)"
+        srcfile << "#if !defined(__clang__) || __clang_major__ >= 14"
                 << "\n";
         addi(srcfile, "mov r14, %[gp]");
         srcfile << "#else\n";


### PR DESCRIPTION
Summary:
clang-14 will improve handling of inline assembly when `-masm=intel` is used (https://reviews.llvm.org/D113707)

The workaround used so far used for clang will no longer be necessary for clang-14 and triggers a syntax error.

Reviewed By: efiks

Differential Revision: D33553604

