### PR TITLE
Integrate fbgemm_gpu build with fbgemm CMake build.

### DIFF
--- a/.github/workflows/fbgemmci.yml
+++ b/.github/workflows/fbgemmci.yml
@@ -192,3 +192,45 @@ jobs:
         set -e
         ./bazel test --compilation_mode opt :*
 
+  build_gpu:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install CUDA 11.3
+      shell: bash
+      run: |
+        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
+        sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
+        sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub
+        sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
+        sudo apt-get update
+        sudo apt-get -y install cuda-minimal-build-11-3 cuda-nvrtc-dev-11-3 cuda-nvtx-11-3 cuda-libraries-dev-11-3
+        sudo apt-get -y install libcudnn8-dev
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install git pip python3-dev
+        sudo pip install cmake scikit-build ninja jinja2 --no-input
+        # Install pytorch 1.11 as required by fbgemm_gpu
+        sudo pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
+
+    - name: Checkout submodules
+      shell: bash
+      run: |
+        cd fbgemm_gpu
+        git submodule sync
+        git submodule update --init --recursive
+
+    - name: Build fbgemm_gpu
+      shell: bash
+      run: |
+        cd fbgemm_gpu
+        export CUDACXX=/usr/local/cuda-11.3/bin/nvcc
+        TORCH_CUDA_ARCH_LIST="6.0" python setup.py build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set_property(CACHE FBGEMM_LIBRARY_TYPE PROPERTY STRINGS default static shared)
 option(FBGEMM_BUILD_TESTS "Build fbgemm unit tests" ON)
 option(FBGEMM_BUILD_BENCHMARKS "Build fbgemm benchmarks" ON)
 option(FBGEMM_BUILD_DOCS "Build fbgemm documentation" OFF)
+option(FBGEMM_BUILD_FBGEMM_GPU "Build fbgemm_gpu library" OFF)
 
 if(FBGEMM_BUILD_TESTS)
   enable_testing()
@@ -277,4 +278,8 @@ endif()
 
 if(FBGEMM_BUILD_DOCS)
   add_subdirectory(docs)
+endif()
+
+if(FBGEMM_BUILD_FBGEMM_GPU)
+  add_subdirectory(fbgemm_gpu)
 endif()

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -13,18 +13,6 @@ if(SKBUILD)
   message("The project is built using scikit-build")
 endif()
 
-set(default_cuda_architectures 60 61 70 75 80)
-set(cuda_architectures_doc
-    "CUDA architectures to build for. Default is ${default_cuda_architectures}")
-set(cuda_architectures
-    "${default_cuda_architectures}"
-    CACHE STRING "${cuda_architectures_doc}")
-
-message("${message_line}")
-message("fbgemm_gpu:")
-message("Building for cuda_architectures = \"${cuda_architectures}\"")
-message("${message_line}")
-
 find_package(Torch REQUIRED)
 find_package(PythonExtensions REQUIRED)
 
@@ -257,8 +245,6 @@ add_library(fbgemm_gpu_py MODULE ${fbgemm_gpu_sources} ${gen_source_files}
 
 target_compile_definitions(fbgemm_gpu_py PRIVATE FBGEMM_CUB_USE_NAMESPACE)
 
-set_property(TARGET fbgemm_gpu_py PROPERTY CUDA_ARCHITECTURES
-                                           "${cuda_architectures}")
 set_target_properties(fbgemm_gpu_py PROPERTIES PREFIX "")
 
 target_link_libraries(fbgemm_gpu_py ${TORCH_LIBRARIES})

--- a/fbgemm_gpu/src/sparse_ops_gpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_gpu.cpp
@@ -10,7 +10,6 @@
 
 #include <ATen/ATen.h>
 #include <ATen/core/op_registration/op_registration.h>
-#include <Python.h>
 #include <torch/csrc/autograd/custom_function.h>
 #include <torch/library.h>
 #include <stdexcept> // for logic_error


### PR DESCRIPTION
Summary:
Include the fbgemm_gpu CMake build with the fbgemm CMake build.  This allows fbgemm_gpu
to use existing github and CircleCI build configurations.

Also integrated (WIP) fbgemm_gpu build into the existing FBGEMM GHA build.

Differential Revision: D33519289

