### PR TITLE
Save OSS build time by multi-threading; Fix OSS build failure

### DIFF
--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -38,4 +38,5 @@ setup(
     long_description=long_description,
     packages=["fbgemm_gpu"],
     cmake_args=[f"-DCMAKE_PREFIX_PATH={torch_root}"],
+    build_args=[f"-j{os.cpu_count() // 2}"],
 )

--- a/fbgemm_gpu/src/sparse_ops_gpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_gpu.cpp
@@ -10,7 +10,6 @@
 
 #include <ATen/ATen.h>
 #include <ATen/core/op_registration/op_registration.h>
-#include <Python.h>
 #include <torch/csrc/autograd/custom_function.h>
 #include <torch/library.h>
 #include <stdexcept> // for logic_error


### PR DESCRIPTION
Summary:
Currently the OSS build is broken due to `#include <Python.h>` introduced in D33421488 (https://github.com/pytorch/FBGEMM/commit/5b945acec664753a26b486acd687266c591a87b8).

Additionally, we explicitly specify multi-thread build to decrease the building time.

Differential Revision: D33616784

