### PR TITLE
actually clamp denorm in RoundToFloat16 when clamp_denorms is set (#457)

### DIFF
--- a/src/FbgemmFloat16Convert.cc
+++ b/src/FbgemmFloat16Convert.cc
@@ -73,10 +73,23 @@ void RoundToFloat16(
     bool clamp,
     bool clamp_denorms) {
   std::vector<fbgemm::float16> data_fp16(size);
-  // clamp_denorms is always true, since we use FloatToFloat16_simd function
-  // with _mm256_cvtps_ph.
   FloatToFloat16_simd(input, &(data_fp16[0]), size, /*do_clip=*/clamp);
   Float16ToFloat_simd(&(data_fp16[0]), output, size);
+  if (clamp_denorms) {
+    // FloatToFloat16_simd always preserve fp16 denorm, so we need to manually
+    // clamp.
+    union epsilon_t {
+      float f;
+      uint32_t i;
+    };
+    union epsilon_t epsilon;
+    epsilon.i = 0x38800000u; // 1 / 16384
+    for (size_t i = 0; i < size; ++i) {
+      if (std::abs(output[i]) < epsilon.f) {
+        output[i] = 0.0;
+      }
+    }
+  }
 }
 
 } // namespace fbgemm

--- a/test/Float16ConvertTest.cc
+++ b/test/Float16ConvertTest.cc
@@ -138,7 +138,7 @@ TEST_P(FBGemmFloat16Test, Conversion_fake_rounding) {
   vector<vector<int>> shapes;
   random_device r;
   default_random_engine generator(r());
-  uniform_int_distribution<int> dm(2, 1024 * 256);
+  uniform_int_distribution<int> dm(32, 1024 * 256);
 
   for (int i = 0; i < 10; i++) {
     int m = dm(generator);
@@ -159,6 +159,7 @@ TEST_P(FBGemmFloat16Test, Conversion_fake_rounding) {
     if (do_clip) {
       A_fp32_ref[0] += 1024 * FP16_MAX;
       A_fp32_ref[1] = 1e-10;
+      A_fp32_ref[2] = 5.5e-8;
     }
 
     RoundToFloat16(A_fp32_ref.data(), A_fp32_final.data(), m, do_clip, do_clip);
@@ -186,6 +187,7 @@ TEST_P(FBGemmFloat16Test, Conversion_fake_rounding) {
     }
     if (do_clip) {
       EXPECT_EQ(A_fp32_final[1], 0.0);
+      EXPECT_EQ(A_fp32_final[2], 0.0);
     }
   }
 }


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/FBGEMM/pull/457

As title. This is the follow-ups for the discussion in D24801098 (https://github.com/pytorch/FBGEMM/commit/c438e6ebad4ce09c1b257fc39d626092a3aa67a1).

Differential Revision: D24842171

