### PR TITLE
Support other integral types for segment values in HBC by feature

### DIFF
--- a/fbgemm_gpu/src/histogram_binning_calibration_ops.cu
+++ b/fbgemm_gpu/src/histogram_binning_calibration_ops.cu
@@ -99,12 +99,12 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_cuda(
   return std::make_tuple(calibrated_prediction, bin_ids);
 }
 
-template <typename T>
+template <typename OffsetType, typename ValueType>
 __global__ void to_dense_segment_value_kernel(
     const int64_t num_lengths,
-    const int64_t* const segment_value_data,
-    const T* const segment_offsets_data,
-    int64_t* const dense_segment_value_data) {
+    const ValueType* const segment_value_data,
+    const OffsetType* const segment_offsets_data,
+    ValueType* const dense_segment_value_data) {
   const int32_t index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index >= num_lengths - 1) {
     return;
@@ -119,7 +119,7 @@ __global__ void to_dense_segment_value_kernel(
   }
 }
 
-template <typename T>
+template <typename LogitType, typename SegmentValueType>
 __global__ void histogram_binning_calibration_by_feature_kernel(
     const int64_t num_logits,
     const int64_t num_bins,
@@ -128,18 +128,18 @@ __global__ void histogram_binning_calibration_by_feature_kernel(
     const double step,
     const int64_t bin_ctr_in_use_after,
     const double bin_ctr_weight_value,
-    const T* const logit_data,
-    const int64_t* const dense_segment_value_data,
+    const LogitType* const logit_data,
+    const SegmentValueType* const dense_segment_value_data,
     const double* const bin_num_examples_data,
     const double* const bin_num_positives_data,
-    T* const calibrated_prediction_data,
+    LogitType* const calibrated_prediction_data,
     int64_t* const bin_ids_data) {
   const int32_t index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index >= num_logits) {
     return;
   }
 
-  const T pre_sigmoid = logit_data[index] + recalibrate_value;
+  const LogitType pre_sigmoid = logit_data[index] + recalibrate_value;
   const double uncalibrated = 1.0 / (1.0 + exp(-pre_sigmoid));
 
   const int64_t curr_segment_value =
@@ -197,17 +197,23 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_by_feature_cuda(
   const auto segment_offsets_packed = segment_offsets.contiguous();
   auto dense_segment_value_packed = dense_segment_value.contiguous();
   AT_DISPATCH_INDEX_TYPES(
-      segment_offsets.scalar_type(), "to_dense_segment_value_cuda", [&]() {
-        to_dense_segment_value_kernel<index_t>
-            <<<fbgemm_gpu::div_round_up(segment_offsets.numel(), num_threads),
-               num_threads,
-               0,
-               at::cuda::getCurrentCUDAStream()>>>(
-                segment_offsets.numel(),
-                segment_value_packed.data_ptr<int64_t>(),
-                segment_offsets_packed.data_ptr<index_t>(),
-                dense_segment_value_packed.data_ptr<int64_t>());
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      segment_offsets.scalar_type(),
+      "to_dense_segment_value_cuda_wrapper",
+      [&]() {
+        AT_DISPATCH_INTEGRAL_TYPES(
+            segment_value.scalar_type(), "to_dense_segment_value_cuda", [&]() {
+              to_dense_segment_value_kernel<index_t, scalar_t>
+                  <<<fbgemm_gpu::div_round_up(
+                         segment_offsets.numel(), num_threads),
+                     num_threads,
+                     0,
+                     at::cuda::getCurrentCUDAStream()>>>(
+                      segment_offsets.numel(),
+                      segment_value_packed.data_ptr<scalar_t>(),
+                      segment_offsets_packed.data_ptr<index_t>(),
+                      dense_segment_value_packed.data_ptr<scalar_t>());
+              C10_CUDA_KERNEL_LAUNCH_CHECK();
+            });
       });
 
   Tensor calibrated_prediction = at::empty_like(logit);
@@ -220,32 +226,43 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_by_feature_cuda(
   const auto bin_num_examples_packed = bin_num_examples.contiguous();
   const auto bin_num_positives_packed = bin_num_positives.contiguous();
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      logit.type(), "histogram_binning_calibration_by_feature_cuda", [&]() {
-        histogram_binning_calibration_by_feature_kernel<scalar_t>
-            <<<fbgemm_gpu::div_round_up(logit.numel(), num_threads),
-               num_threads,
-               0,
-               at::cuda::getCurrentCUDAStream()>>>(
-                logit.numel(),
-                num_bins,
-                num_segments,
-                recalibrate_value,
-                step,
-                bin_ctr_in_use_after,
-                bin_ctr_weight_value,
-                logit_packed.data_ptr<scalar_t>(),
-                dense_segment_value_packed.data_ptr<int64_t>(),
-                bin_num_examples_packed.data_ptr<double>(),
-                bin_num_positives_packed.data_ptr<double>(),
-                calibrated_prediction.data_ptr<scalar_t>(),
-                bin_ids.data_ptr<int64_t>());
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      logit.type(),
+      "histogram_binning_calibration_by_feature_cuda_wrapper",
+      [&]() {
+        using logit_t = scalar_t;
+        AT_DISPATCH_INTEGRAL_TYPES(
+            dense_segment_value_packed.scalar_type(),
+            "histogram_binning_calibration_by_feature_cuda",
+            [&]() {
+              using segment_value_t = scalar_t;
+              histogram_binning_calibration_by_feature_kernel<
+                  logit_t,
+                  segment_value_t>
+                  <<<fbgemm_gpu::div_round_up(logit.numel(), num_threads),
+                     num_threads,
+                     0,
+                     at::cuda::getCurrentCUDAStream()>>>(
+                      logit.numel(),
+                      num_bins,
+                      num_segments,
+                      recalibrate_value,
+                      step,
+                      bin_ctr_in_use_after,
+                      bin_ctr_weight_value,
+                      logit_packed.data_ptr<logit_t>(),
+                      dense_segment_value_packed.data_ptr<segment_value_t>(),
+                      bin_num_examples_packed.data_ptr<double>(),
+                      bin_num_positives_packed.data_ptr<double>(),
+                      calibrated_prediction.data_ptr<logit_t>(),
+                      bin_ids.data_ptr<int64_t>());
+              C10_CUDA_KERNEL_LAUNCH_CHECK();
+            });
       });
 
   return std::make_tuple(calibrated_prediction, bin_ids);
 }
 
-template <typename T>
+template <typename LogitType, typename SegmentValueType>
 __global__ void generic_histogram_binning_calibration_by_feature_kernel(
     const int64_t num_logits,
     const int64_t num_bins,
@@ -253,19 +270,19 @@ __global__ void generic_histogram_binning_calibration_by_feature_kernel(
     const double recalibrate_value,
     const int64_t bin_ctr_in_use_after,
     const double bin_ctr_weight_value,
-    const T* const logit_data,
-    const int64_t* const dense_segment_value_data,
+    const LogitType* const logit_data,
+    const SegmentValueType* const dense_segment_value_data,
     const double* const bin_num_examples_data,
     const double* const bin_num_positives_data,
     const double* const bin_boundaries,
-    T* const calibrated_prediction_data,
+    LogitType* const calibrated_prediction_data,
     int64_t* const bin_ids_data) {
   const int32_t index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index >= num_logits) {
     return;
   }
 
-  const T pre_sigmoid = logit_data[index] + recalibrate_value;
+  const LogitType pre_sigmoid = logit_data[index] + recalibrate_value;
   const double uncalibrated = 1.0 / (1.0 + exp(-pre_sigmoid));
 
   // Perform binary search.
@@ -339,17 +356,23 @@ generic_histogram_binning_calibration_by_feature_cuda(
   const auto segment_offsets_packed = segment_offsets.contiguous();
   auto dense_segment_value_packed = dense_segment_value.contiguous();
   AT_DISPATCH_INDEX_TYPES(
-      segment_offsets.scalar_type(), "to_dense_segment_value_cuda", [&]() {
-        to_dense_segment_value_kernel<index_t>
-            <<<fbgemm_gpu::div_round_up(segment_offsets.numel(), num_threads),
-               num_threads,
-               0,
-               at::cuda::getCurrentCUDAStream()>>>(
-                segment_offsets.numel(),
-                segment_value_packed.data_ptr<int64_t>(),
-                segment_offsets_packed.data_ptr<index_t>(),
-                dense_segment_value_packed.data_ptr<int64_t>());
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      segment_offsets.scalar_type(),
+      "to_dense_segment_value_cuda_wrapper",
+      [&]() {
+        AT_DISPATCH_INTEGRAL_TYPES(
+            segment_value.scalar_type(), "to_dense_segment_value_cuda", [&]() {
+              to_dense_segment_value_kernel<index_t>
+                  <<<fbgemm_gpu::div_round_up(
+                         segment_offsets.numel(), num_threads),
+                     num_threads,
+                     0,
+                     at::cuda::getCurrentCUDAStream()>>>(
+                      segment_offsets.numel(),
+                      segment_value_packed.data_ptr<scalar_t>(),
+                      segment_offsets_packed.data_ptr<index_t>(),
+                      dense_segment_value_packed.data_ptr<scalar_t>());
+              C10_CUDA_KERNEL_LAUNCH_CHECK();
+            });
       });
 
   Tensor calibrated_prediction = at::empty_like(logit);
@@ -361,26 +384,37 @@ generic_histogram_binning_calibration_by_feature_cuda(
   const auto bin_num_positives_packed = bin_num_positives.contiguous();
   const auto bin_boundaries_packed = bin_boundaries.contiguous();
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      logit.type(), "histogram_binning_calibration_by_feature_cuda", [&]() {
-        generic_histogram_binning_calibration_by_feature_kernel<scalar_t>
-            <<<fbgemm_gpu::div_round_up(logit.numel(), num_threads),
-               num_threads,
-               0,
-               at::cuda::getCurrentCUDAStream()>>>(
-                logit.numel(),
-                bin_boundaries.numel() + 1,
-                num_segments,
-                recalibrate_value,
-                bin_ctr_in_use_after,
-                bin_ctr_weight_value,
-                logit_packed.data_ptr<scalar_t>(),
-                dense_segment_value_packed.data_ptr<int64_t>(),
-                bin_num_examples_packed.data_ptr<double>(),
-                bin_num_positives_packed.data_ptr<double>(),
-                bin_boundaries_packed.data_ptr<double>(),
-                calibrated_prediction.data_ptr<scalar_t>(),
-                bin_ids.data_ptr<int64_t>());
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      logit.type(),
+      "generic_histogram_binning_calibration_by_feature_cuda_wrapper",
+      [&]() {
+        using logit_t = scalar_t;
+        AT_DISPATCH_INTEGRAL_TYPES(
+            dense_segment_value_packed.scalar_type(),
+            "generic_histogram_binning_calibration_by_feature_cuda",
+            [&]() {
+              using segment_value_t = scalar_t;
+              generic_histogram_binning_calibration_by_feature_kernel<
+                  logit_t,
+                  segment_value_t>
+                  <<<fbgemm_gpu::div_round_up(logit.numel(), num_threads),
+                     num_threads,
+                     0,
+                     at::cuda::getCurrentCUDAStream()>>>(
+                      logit.numel(),
+                      bin_boundaries.numel() + 1,
+                      num_segments,
+                      recalibrate_value,
+                      bin_ctr_in_use_after,
+                      bin_ctr_weight_value,
+                      logit_packed.data_ptr<logit_t>(),
+                      dense_segment_value_packed.data_ptr<segment_value_t>(),
+                      bin_num_examples_packed.data_ptr<double>(),
+                      bin_num_positives_packed.data_ptr<double>(),
+                      bin_boundaries_packed.data_ptr<double>(),
+                      calibrated_prediction.data_ptr<logit_t>(),
+                      bin_ids.data_ptr<int64_t>());
+              C10_CUDA_KERNEL_LAUNCH_CHECK();
+            });
       });
 
   return std::make_tuple(calibrated_prediction, bin_ids);

--- a/fbgemm_gpu/src/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_cpu.cpp
@@ -1033,7 +1033,7 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_cpu(
   return std::make_tuple(calibrated_prediction, bin_ids);
 }
 
-template <typename T>
+template <typename LogitType, typename SegmentValueType>
 void _histogram_binning_calibration_by_feature_cpu_kernel(
     const int64_t num_logits,
     const int64_t num_bins,
@@ -1043,13 +1043,13 @@ void _histogram_binning_calibration_by_feature_cpu_kernel(
     const double step,
     const int64_t bin_ctr_in_use_after,
     const double bin_ctr_weight_value,
-    const T* const logit_data,
-    const int64_t* const segment_value_data,
+    const LogitType* const logit_data,
+    const SegmentValueType* const segment_value_data,
     const int64_t* const segment_lengths_data,
     const double* const bin_num_examples_data,
     const double* const bin_num_positives_data,
-    int64_t* const dense_segment_value_data,
-    T* const calibrated_prediction_data,
+    SegmentValueType* const dense_segment_value_data,
+    LogitType* const calibrated_prediction_data,
     int64_t* const bin_ids_data) {
   int k = 0;
   for (const auto i : c10::irange(num_lengths)) {
@@ -1062,7 +1062,7 @@ void _histogram_binning_calibration_by_feature_cpu_kernel(
   }
 
   for (const auto i : c10::irange(num_logits)) {
-    const T pre_sigmoid = logit_data[i] + recalibrate_value;
+    const LogitType pre_sigmoid = logit_data[i] + recalibrate_value;
     const double uncalibrated = 1.0 / (1.0 + std::exp(-pre_sigmoid));
 
     const int64_t curr_segment_value =
@@ -1113,30 +1113,39 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_by_feature_cpu(
   const double step =
       (upper_bound - lower_bound) / static_cast<double>(num_bins);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      logit.type(), "histogram_binning_calibration_by_feature_cpu", [&]() {
-        _histogram_binning_calibration_by_feature_cpu_kernel<scalar_t>(
-            logit.numel(),
-            num_bins,
-            num_segments,
-            segment_lengths.numel(),
-            recalibrate_value,
-            step,
-            bin_ctr_in_use_after,
-            bin_ctr_weight_value,
-            logit.data_ptr<scalar_t>(),
-            segment_value.data_ptr<int64_t>(),
-            segment_lengths.data_ptr<int64_t>(),
-            bin_num_examples.data_ptr<double>(),
-            bin_num_positives.data_ptr<double>(),
-            dense_segment_value.data_ptr<int64_t>(),
-            calibrated_prediction.data_ptr<scalar_t>(),
-            bin_ids.data_ptr<int64_t>());
+      logit.type(),
+      "histogram_binning_calibration_by_feature_cpu_wrapper",
+      [&]() {
+        using logit_t = scalar_t;
+        AT_DISPATCH_INTEGRAL_TYPES(
+            segment_value.scalar_type(),
+            "histogram_binning_calibration_by_feature_cpu",
+            [&]() {
+              using segment_value_t = scalar_t;
+              _histogram_binning_calibration_by_feature_cpu_kernel<logit_t>(
+                  logit.numel(),
+                  num_bins,
+                  num_segments,
+                  segment_lengths.numel(),
+                  recalibrate_value,
+                  step,
+                  bin_ctr_in_use_after,
+                  bin_ctr_weight_value,
+                  logit.data_ptr<logit_t>(),
+                  segment_value.data_ptr<segment_value_t>(),
+                  segment_lengths.data_ptr<int64_t>(),
+                  bin_num_examples.data_ptr<double>(),
+                  bin_num_positives.data_ptr<double>(),
+                  dense_segment_value.data_ptr<segment_value_t>(),
+                  calibrated_prediction.data_ptr<logit_t>(),
+                  bin_ids.data_ptr<int64_t>());
+            });
       });
 
   return std::make_tuple(calibrated_prediction, bin_ids);
 }
 
-template <typename T>
+template <typename LogitType, typename SegmentValueType>
 void _generic_histogram_binning_calibration_by_feature_cpu_kernel(
     const int64_t num_logits,
     const int64_t num_bins,
@@ -1145,14 +1154,14 @@ void _generic_histogram_binning_calibration_by_feature_cpu_kernel(
     const double recalibrate_value,
     const int64_t bin_ctr_in_use_after,
     const double bin_ctr_weight_value,
-    const T* const logit_data,
-    const int64_t* const segment_value_data,
+    const LogitType* const logit_data,
+    const SegmentValueType* const segment_value_data,
     const int64_t* const segment_lengths_data,
     const double* const bin_num_examples_data,
     const double* const bin_num_positives_data,
     const double* const bin_boundaries,
-    int64_t* const dense_segment_value_data,
-    T* const calibrated_prediction_data,
+    SegmentValueType* const dense_segment_value_data,
+    LogitType* const calibrated_prediction_data,
     int64_t* const bin_ids_data) {
   int k = 0;
   for (const auto i : c10::irange(num_lengths)) {
@@ -1165,7 +1174,7 @@ void _generic_histogram_binning_calibration_by_feature_cpu_kernel(
   }
 
   for (const auto i : c10::irange(num_logits)) {
-    const T pre_sigmoid = logit_data[i] + recalibrate_value;
+    const LogitType pre_sigmoid = logit_data[i] + recalibrate_value;
     const double uncalibrated = 1.0 / (1.0 + std::exp(-pre_sigmoid));
 
     const int curr_bin_id =
@@ -1222,25 +1231,34 @@ std::tuple<Tensor, Tensor> generic_histogram_binning_calibration_by_feature_cpu(
   const double recalibrate_value = std::log(positive_weight);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       logit.type(),
-      "generic_histogram_binning_calibration_by_feature_cpu",
+      "generic_histogram_binning_calibration_by_feature_cpu_wrapper",
       [&]() {
-        _generic_histogram_binning_calibration_by_feature_cpu_kernel<scalar_t>(
-            logit.numel(),
-            bin_boundaries.numel() + 1,
-            num_segments,
-            segment_lengths.numel(),
-            recalibrate_value,
-            bin_ctr_in_use_after,
-            bin_ctr_weight_value,
-            logit.data_ptr<scalar_t>(),
-            segment_value.data_ptr<int64_t>(),
-            segment_lengths.data_ptr<int64_t>(),
-            bin_num_examples.data_ptr<double>(),
-            bin_num_positives.data_ptr<double>(),
-            bin_boundaries.data_ptr<double>(),
-            dense_segment_value.data_ptr<int64_t>(),
-            calibrated_prediction.data_ptr<scalar_t>(),
-            bin_ids.data_ptr<int64_t>());
+        using logit_t = scalar_t;
+        AT_DISPATCH_INTEGRAL_TYPES(
+            segment_value.scalar_type(),
+            "generic_histogram_binning_calibration_by_feature_cpu",
+            [&]() {
+              using segment_value_t = scalar_t;
+              _generic_histogram_binning_calibration_by_feature_cpu_kernel<
+                  logit_t,
+                  segment_value_t>(
+                  logit.numel(),
+                  bin_boundaries.numel() + 1,
+                  num_segments,
+                  segment_lengths.numel(),
+                  recalibrate_value,
+                  bin_ctr_in_use_after,
+                  bin_ctr_weight_value,
+                  logit.data_ptr<logit_t>(),
+                  segment_value.data_ptr<segment_value_t>(),
+                  segment_lengths.data_ptr<int64_t>(),
+                  bin_num_examples.data_ptr<double>(),
+                  bin_num_positives.data_ptr<double>(),
+                  bin_boundaries.data_ptr<double>(),
+                  dense_segment_value.data_ptr<segment_value_t>(),
+                  calibrated_prediction.data_ptr<logit_t>(),
+                  bin_ids.data_ptr<int64_t>());
+            });
       });
 
   return std::make_tuple(calibrated_prediction, bin_ids);

--- a/fbgemm_gpu/test/sparse_ops_test.py
+++ b/fbgemm_gpu/test/sparse_ops_test.py
@@ -1229,17 +1229,20 @@ class SparseOpsTest(unittest.TestCase):
             )
 
     # pyre-ignore [56]: Invalid decoration, was not able to infer the type of argument
-    @given(data_type=st.sampled_from([torch.half, torch.float32]))
+    @given(
+        data_type=st.sampled_from([torch.half, torch.float32]),
+        segment_value_type=st.sampled_from([torch.int, torch.long]),
+    )
     @settings(verbosity=Verbosity.verbose, deadline=None)
     def test_histogram_binning_calibration_by_feature(
-        self, data_type: torch.dtype
+        self, data_type: torch.dtype, segment_value_type: torch.dtype
     ) -> None:
         num_bins = 5000
         num_segments = 42
 
         logit = torch.tensor([-0.0018, 0.0085, 0.0090, 0.0003, 0.0029]).type(data_type)
 
-        segment_value = torch.tensor([40, 31, 32, 13, 31])
+        segment_value = torch.tensor([40, 31, 32, 13, 31]).type(segment_value_type)
         lengths = torch.tensor([[1], [1], [1], [1], [1]])
 
         num_interval = num_bins * (num_segments + 1)
@@ -1319,17 +1322,20 @@ class SparseOpsTest(unittest.TestCase):
             )
 
     # pyre-ignore [56]: Invalid decoration, was not able to infer the type of argument
-    @given(data_type=st.sampled_from([torch.half, torch.float32]))
+    @given(
+        data_type=st.sampled_from([torch.half, torch.float32]),
+        segment_value_type=st.sampled_from([torch.int, torch.long]),
+    )
     @settings(verbosity=Verbosity.verbose, deadline=None)
     def test_generic_histogram_binning_calibration_by_feature(
-        self, data_type: torch.dtype
+        self, data_type: torch.dtype, segment_value_type: torch.dtype
     ) -> None:
         num_bins = 5000
         num_segments = 42
 
         logit = torch.tensor([-0.0018, 0.0085, 0.0090, 0.0003, 0.0029]).type(data_type)
 
-        segment_value = torch.tensor([40, 31, 32, 13, 31])
+        segment_value = torch.tensor([40, 31, 32, 13, 31]).type(segment_value_type)
         lengths = torch.tensor([[1], [1], [1], [1], [1]])
 
         num_interval = num_bins * (num_segments + 1)


### PR DESCRIPTION
Summary:
Current code assumes int64 type, but there are cases, where it is int (32-bit) type.

Fix to support such cases.

Differential Revision: D33643675

