### PR TITLE
Add support for different types for segment value vs. length.

### DIFF
--- a/fbgemm_gpu/test/sparse_ops_test.py
+++ b/fbgemm_gpu/test/sparse_ops_test.py
@@ -1232,10 +1232,14 @@ class SparseOpsTest(unittest.TestCase):
     @given(
         data_type=st.sampled_from([torch.half, torch.float32]),
         segment_value_type=st.sampled_from([torch.int, torch.long]),
+        segment_length_type=st.sampled_from([torch.int, torch.long]),
     )
     @settings(verbosity=Verbosity.verbose, deadline=None)
     def test_histogram_binning_calibration_by_feature(
-        self, data_type: torch.dtype, segment_value_type: torch.dtype
+        self,
+        data_type: torch.dtype,
+        segment_value_type: torch.dtype,
+        segment_length_type: torch.dtype,
     ) -> None:
         num_bins = 5000
         num_segments = 42
@@ -1243,7 +1247,7 @@ class SparseOpsTest(unittest.TestCase):
         logit = torch.tensor([-0.0018, 0.0085, 0.0090, 0.0003, 0.0029]).type(data_type)
 
         segment_value = torch.tensor([40, 31, 32, 13, 31]).type(segment_value_type)
-        lengths = torch.tensor([[1], [1], [1], [1], [1]])
+        lengths = torch.tensor([[1], [1], [1], [1], [1]]).type(segment_length_type)
 
         num_interval = num_bins * (num_segments + 1)
         bin_num_examples = torch.empty([num_interval], dtype=torch.float64).fill_(0.0)
@@ -1325,10 +1329,14 @@ class SparseOpsTest(unittest.TestCase):
     @given(
         data_type=st.sampled_from([torch.half, torch.float32]),
         segment_value_type=st.sampled_from([torch.int, torch.long]),
+        segment_length_type=st.sampled_from([torch.int, torch.long]),
     )
     @settings(verbosity=Verbosity.verbose, deadline=None)
     def test_generic_histogram_binning_calibration_by_feature(
-        self, data_type: torch.dtype, segment_value_type: torch.dtype
+        self,
+        data_type: torch.dtype,
+        segment_value_type: torch.dtype,
+        segment_length_type: torch.dtype,
     ) -> None:
         num_bins = 5000
         num_segments = 42
@@ -1336,7 +1344,7 @@ class SparseOpsTest(unittest.TestCase):
         logit = torch.tensor([-0.0018, 0.0085, 0.0090, 0.0003, 0.0029]).type(data_type)
 
         segment_value = torch.tensor([40, 31, 32, 13, 31]).type(segment_value_type)
-        lengths = torch.tensor([[1], [1], [1], [1], [1]])
+        lengths = torch.tensor([[1], [1], [1], [1], [1]]).type(segment_length_type)
 
         num_interval = num_bins * (num_segments + 1)
         bin_num_examples = torch.empty([num_interval], dtype=torch.float64).fill_(0.0)


### PR DESCRIPTION
Summary: Segment value and length can be different types, which was not supported in CPU version. Fix and update test.

Differential Revision: D33696164

