### PR TITLE
remove grad_t to reduce binary size + compilation time

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_approx_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_approx_template.cpp
@@ -191,11 +191,8 @@ split_embedding_backward_codegen_{{ optimizer }}_cpu(
 
   {% endif %}
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      at::ScalarType::Half,
-      at::ScalarType::BFloat16,
-      grad_output.scalar_type(),
-      "split_embedding_backward_cpu", [&]() {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+      grad_output.scalar_type(), "split_embedding_backward_cpu", [&]() {
         using grad_t = scalar_t;
         AT_DISPATCH_FLOATING_TYPES_AND_HALF(
             host_weights.scalar_type(),

--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
@@ -329,35 +329,30 @@ void split_embedding_backward_exact_cpu_dense_kernel(
 
   grad_output = grad_output.contiguous();
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      at::ScalarType::Half,
-      at::ScalarType::BFloat16,
-      grad_output.scalar_type(),
-      "split_embedding_backward_exact_cpu_outer", [&]() {
-        using grad_t = scalar_t;
-        AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-            host_weights.scalar_type(), "split_embedding_backward_exact_cpu", [&]() {
-              split_embedding_backward_exact_cpu_kernel<scalar_t, grad_t>(
-                  grad_output,
-                  host_weights,
-                  weights_offsets_data,
-                  D_offsets_data,
-                  hash_size_cumsum,
-                  indices,
-                  offsets,
-                  pooling_mode,
-                  indice_weights,
-                  num_tables,
-                  B,
-                  table_to_feature_offset,
-                  {% if "momentum1_offsets" in args.split_function_arg_names %}
-                  momentum1_offsets_data,
-                  {% endif %}
-                  {% if "momentum2_offsets" in args.split_function_arg_names %}
-                  momentum2_offsets_data,
-                  {% endif %}
-                  {{ args.split_cpu_kernel_arg_constructors | join(", ") }});
-            });
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+      host_weights.scalar_type(), "split_embedding_backward_exact_cpu", [&]() {
+        // TODO: respect output_dtype
+        using grad_t = float;
+        split_embedding_backward_exact_cpu_kernel<scalar_t, grad_t>(
+            grad_output,
+            host_weights,
+            weights_offsets_data,
+            D_offsets_data,
+            hash_size_cumsum,
+            indices,
+            offsets,
+            pooling_mode,
+            indice_weights,
+            num_tables,
+            B,
+            table_to_feature_offset,
+            {% if "momentum1_offsets" in args.split_function_arg_names %}
+            momentum1_offsets_data,
+            {% endif %}
+            {% if "momentum2_offsets" in args.split_function_arg_names %}
+            momentum2_offsets_data,
+            {% endif %}
+            {{ args.split_cpu_kernel_arg_constructors | join(", ") }});
       });
 
   return;

--- a/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
@@ -194,12 +194,8 @@ Tensor split_embedding_codegen_forward_cpu(
   // It is assumed that the indice_weights will always be float
   TORCH_CHECK(
       !indice_weights.defined() || indice_weights.scalar_type() != at::kHalf);
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      at::ScalarType::Half,
-      at::ScalarType::BFloat16,
-      output.scalar_type(),
-      "split_embedding_cpu_forward",
-      [&]() {
+  AT_DISPATCH_FLOATING_TYPES(
+      output.scalar_type(), "split_embedding_cpu_forward", [&]() {
         using output_t = scalar_t;
         AT_DISPATCH_FLOATING_TYPES_AND2(
             at::ScalarType::Half,
@@ -295,9 +291,7 @@ Tensor split_embedding_codegen_grad_indice_weights_cpu(
       indices,
       indices.options().dtype(
           at::toAccumulateType(grad_output.scalar_type(), true)));
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-      at::ScalarType::Half,
-      at::ScalarType::BFloat16,
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       grad_output.scalar_type(),
       "split_embedding_grad_indice_weights_cpu_outer",
       [&]() {

--- a/fbgemm_gpu/include/fbgemm_gpu/dispatch_macros.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/dispatch_macros.h
@@ -82,13 +82,6 @@
           NAME,                                                    \
           __VA_ARGS__)                                             \
       PRIVATE_CASE_TYPE_OUTPUT(                                    \
-          at::ScalarType::BFloat16,                                \
-          emb_type,                                                \
-          cache_type,                                              \
-          at::BFloat16,                                            \
-          NAME,                                                    \
-          __VA_ARGS__)                                             \
-      PRIVATE_CASE_TYPE_OUTPUT(                                    \
           at::ScalarType::Float,                                   \
           emb_type,                                                \
           cache_type,                                              \
@@ -144,29 +137,20 @@
     }                                                                      \
   }
 
-#define DISPATCH_EMB_GRAD_CACHE_TYPES(                                         \
-    EMB_TYPE, GRAD_TYPE, CACHE_TYPE, NAME, ...)                                \
-  [&] {                                                                        \
-    const auto& emb_type = EMB_TYPE;                                           \
-    const auto& grad_type = GRAD_TYPE;                                         \
-    const auto& cache_type = CACHE_TYPE;                                       \
-    at::ScalarType _emb_t = ::detail::scalar_type(emb_type);                   \
-    at::ScalarType _grad_t = ::detail::scalar_type(grad_type);                 \
-    at::ScalarType _cache_t = ::detail::scalar_type(cache_type);               \
-    switch (_grad_t) {                                                         \
-      PRIVATE_CASE_TYPE_CACHE_EMB(                                             \
-          at::ScalarType::Float, _cache_t, _emb_t, float, NAME, __VA_ARGS__)   \
-      PRIVATE_CASE_TYPE_CACHE_EMB(                                             \
-          at::ScalarType::Half, _cache_t, _emb_t, at::Half, NAME, __VA_ARGS__) \
-      PRIVATE_CASE_TYPE_CACHE_EMB(                                             \
-          at::ScalarType::BFloat16,                                            \
-          _cache_t,                                                            \
-          _emb_t,                                                              \
-          at::BFloat16,                                                        \
-          NAME,                                                                \
-          __VA_ARGS__)                                                         \
-      default:                                                                 \
-        AT_ERROR(                                                              \
-            #NAME, " not implemented for grad_t '", toString(_grad_t), "'");   \
-    }                                                                          \
+#define DISPATCH_EMB_GRAD_CACHE_TYPES(                                       \
+    EMB_TYPE, GRAD_TYPE, CACHE_TYPE, NAME, ...)                              \
+  [&] {                                                                      \
+    const auto& emb_type = EMB_TYPE;                                         \
+    const auto& grad_type = GRAD_TYPE;                                       \
+    const auto& cache_type = CACHE_TYPE;                                     \
+    at::ScalarType _emb_t = ::detail::scalar_type(emb_type);                 \
+    at::ScalarType _grad_t = ::detail::scalar_type(grad_type);               \
+    at::ScalarType _cache_t = ::detail::scalar_type(cache_type);             \
+    switch (_grad_t) {                                                       \
+      PRIVATE_CASE_TYPE_CACHE_EMB(                                           \
+          at::ScalarType::Float, _cache_t, _emb_t, float, NAME, __VA_ARGS__) \
+      default:                                                               \
+        AT_ERROR(                                                            \
+            #NAME, " not implemented for grad_t '", toString(_grad_t), "'"); \
+    }                                                                        \
   }()


### PR DESCRIPTION
Summary:
As pointed out by haocizhang, D31432199 (https://github.com/pytorch/FBGEMM/commit/127f813152666ca5d451e93375c40b2742bb245f) increased the binary size as well as compilation time, which causes timeout on several things. This is because of an increase of the number of template instantiation layers (i.e., new `grad_t` instantiation)

Because at this point, always `grad_t = float` suffices, this patch removes `grad_t != float` paths to address this issue.
(This patch does not revert D31432199 (https://github.com/pytorch/FBGEMM/commit/127f813152666ca5d451e93375c40b2742bb245f) since the original Diff changes many places and reverting all can cause troubles in different places.)

Differential Revision: D33735445

