### PR TITLE
Bug fix when segment lengths are larger than 1.

### DIFF
--- a/fbgemm_gpu/src/histogram_binning_calibration_ops.cu
+++ b/fbgemm_gpu/src/histogram_binning_calibration_ops.cu
@@ -112,7 +112,7 @@ __global__ void to_dense_segment_value_kernel(
 
   const auto curr_offset = segment_offsets_data[index];
   const auto next_offset = segment_offsets_data[index + 1];
-  if (next_offset > curr_offset) {
+  if (next_offset == curr_offset + 1) {
     // Add 1 to distinguish between 0 inserted by densification vs. original
     // value.
     dense_segment_value_data[index] = segment_value_data[curr_offset] + 1;

--- a/fbgemm_gpu/test/sparse_ops_test.py
+++ b/fbgemm_gpu/test/sparse_ops_test.py
@@ -1444,12 +1444,8 @@ class SparseOpsTest(unittest.TestCase):
 
         logit = torch.randn(num_logits).type(data_type)
 
-        segment_value = torch.randint(
-            0, num_segments, (random.randint(0, num_logits - 1),)
-        )
-        lengths = torch.tensor(
-            [1] * segment_value.numel() + [0] * (num_logits - segment_value.numel())
-        )
+        lengths = torch.randint(0, 2, (num_logits,))
+        segment_value = torch.randint(-3, num_segments + 3, (sum(lengths),))
 
         num_interval = num_bins * (num_segments + 1)
         bin_num_positives = torch.randint(0, 10, (num_interval,)).double()


### PR DESCRIPTION
Summary:
When converting to dense representation for HBC by feature, dense_last_dim == 1, hence assumption was made that length == 0 or 1.

However, in real execution, length can be any value, and simply ignored when >1.

Bug fix to address this issue with update in unit test to test such out of range values in randomized tests.

Reviewed By: jspark1105

Differential Revision: D33756121

