### PR TITLE
Set TORCH_CUDA_ARCH_LIST as command line arg rather than env var.

### DIFF
--- a/.github/workflows/fbgemmci.yml
+++ b/.github/workflows/fbgemmci.yml
@@ -232,7 +232,7 @@ jobs:
       shell: bash
       run: |
         cd fbgemm_gpu
-        sudo CUDACXX=/usr/local/cuda-11.3/bin/nvcc TORCH_CUDA_ARCH_LIST="6.0" python setup.py install
+        sudo CUDACXX=/usr/local/cuda-11.3/bin/nvcc python setup.py install -DTORCH_CUDA_ARCH_LIST="6.0"
 
     - name: Test fbgemm_gpu installation
       shell: bash

--- a/fbgemm_gpu/README.md
+++ b/fbgemm_gpu/README.md
@@ -43,7 +43,7 @@ export CUB_DIR=${CUB_DIR}
 # build for the CUDA architecture supported by current system (or all architectures if no CUDA device present)
 python setup.py install
 # or build it for specific CUDA architectures (see PyTorch documentation for usage of TORCH_CUDA_ARCH_LIST)
-TORCH_CUDA_ARCH_LIST="7.0;8.0" python setup.py install
+python setup.py install -DTORCH_CUDA_ARCH_LIST="7.0;8.0"
 
 ```
 


### PR DESCRIPTION
Summary: Use preferred means to pass CUDA architecture list.

Differential Revision: D33845626

