### PR TITLE
Avoid unnecessary copy if possible.

### DIFF
--- a/fbgemm_gpu/src/cumem_utils.cu
+++ b/fbgemm_gpu/src/cumem_utils.cu
@@ -75,7 +75,7 @@ std::vector<int64_t> defaultStrides(IntArrayRef sizes) {
 // Allocate the ATen Tensor with unified managed memory (UVM)
 Tensor new_managed_tensor_internal(
     Tensor self,
-    std::vector<std::int64_t>& sizes) {
+    const std::vector<std::int64_t>& sizes) {
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(self.get_device());
 
@@ -138,7 +138,7 @@ std::tuple<void*, size_t> adjust_to_page_boundaries(void* ptr, size_t size) {
 // Allocate a cuda Tensor with unified managed memory (UVM)
 // Then set the preferred data location to CPU (host memory)
 // And establish mappings on the cuda device to the host memory
-Tensor new_managed_tensor(Tensor self, std::vector<std::int64_t> sizes) {
+Tensor new_managed_tensor(Tensor self, const std::vector<std::int64_t>& sizes) {
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(self.get_device());
 
@@ -169,7 +169,7 @@ Tensor new_managed_tensor(Tensor self, std::vector<std::int64_t> sizes) {
 // additional steps taked by new_managed_tensor above
 Tensor new_vanilla_managed_tensor(
     Tensor self,
-    std::vector<std::int64_t> sizes) {
+    const std::vector<std::int64_t>& sizes) {
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(self.get_device());
 

--- a/fbgemm_gpu/src/cumem_utils.h
+++ b/fbgemm_gpu/src/cumem_utils.h
@@ -14,10 +14,12 @@ using namespace at;
 
 // Allocate the ATen Tensor with unified managed memory (UVM)
 // and set both UVM storage preference to CPU and access from self.device
-Tensor new_managed_tensor(Tensor self, std::vector<std::int64_t> sizes);
+Tensor new_managed_tensor(Tensor self, const std::vector<std::int64_t>& sizes);
 
 // Allocate the ATen Tensor with unified managed memory (UVM)
-Tensor new_vanilla_managed_tensor(Tensor self, std::vector<std::int64_t> sizes);
+Tensor new_vanilla_managed_tensor(
+    Tensor self,
+    const std::vector<std::int64_t>& sizes);
 
 // Check if a tensor is allocated with UVM
 bool uvm_storage(Tensor t);


### PR DESCRIPTION
Summary:
When allocating UVM, avoid unnecessary copy on vector.
Add const keyword to indicate that vector does not change.

Differential Revision: D33990382

