### PR TITLE
Use const& to avoid unnecessary copy.

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -154,7 +154,7 @@ at::Tensor reorder_batched_ad_indices_cpu(
 
 at::Tensor recat_embedding_grad_output_cuda(
     at::Tensor grad_output, // [B_local][T_global][D]
-    std::vector<int64_t> num_features_per_rank);
+    const std::vector<int64_t>& num_features_per_rank);
 
 at::Tensor recat_embedding_grad_output_mixed_D_cuda(
     const at::Tensor& grad_output, // [B_local][Sum_T_global(D)]

--- a/fbgemm_gpu/src/layout_transform_ops.cu
+++ b/fbgemm_gpu/src/layout_transform_ops.cu
@@ -31,7 +31,7 @@ namespace fbgemm_gpu {
 
 Tensor recat_embedding_grad_output_cuda(
     Tensor grad_output, // [B_local][T_global][D]
-    std::vector<int64_t> num_features_per_rank) {
+    const std::vector<int64_t>& num_features_per_rank) {
   TENSOR_ON_CUDA_GPU(grad_output);
 
   at::cuda::OptionalCUDAGuard device_guard;


### PR DESCRIPTION
Summary: Use const& instead to avoid copy.

Reviewed By: jianyuh

Differential Revision: D34054116

