### PR TITLE
Fix binary size limit issue to upload to pypi website

### DIFF
--- a/.github/workflows/fbgemm_nightly_build.yml
+++ b/.github/workflows/fbgemm_nightly_build.yml
@@ -99,14 +99,16 @@ jobs:
       run: |
         cd fbgemm_gpu/
         rm -r dist || true
-        # buld cuda6.0;7.0;8.0 for p100/v100/a100 arch
+        # buld cuda7.0;8.0 for v100/a100 arch:
+        # Couldn't build more cuda arch due to 100 MB binary size limit from
+        # pypi website.
         # manylinux1_x86_64 is specified for pypi upload:
         # distribute python extensions as wheels on Linux
         conda run -n build_binary \
           python setup.py bdist_wheel \
           --package_name=fbgemm_gpu_nightly \
           --python-tag=${{ matrix.python-tag }} \
-          -DTORCH_CUDA_ARCH_LIST="'6.0;7.0;8.0'" \
+          -DTORCH_CUDA_ARCH_LIST="'7.0;8.0'" \
           --plat-name=manylinux1_x86_64
     - name: Upload wheel as GHA artifact
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
Summary:
With 6.0 CUDA build included in pip wheel binary file, the total binary size exceeds 100 MB:
```
HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
File too large. Limit for project 'fbgemm-gpu-nightly' is 100 MB. See https://pypi.org/help/#file-size-limit for more information.

Uploading distributions to https://upload.pypi.org/legacy/
Uploading fbgemm_gpu_nightly-2022.2.8-cp39-cp39-manylinux1_x86_64.whl
```
in https://github.com/pytorch/FBGEMM/runs/5103817412?check_suite_focus=true

In order to reduce the binary size, by default we only build CUDA 7.0 and 8.0 arch.

Reviewed By: jspark1105

Differential Revision: D34064392

