### PR TITLE
Fix TorchRec CPU only build

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_dense_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_dense_host.cpp
@@ -393,16 +393,12 @@ Tensor split_embedding_codegen_lookup_dense_function(
 }
 
 TORCH_LIBRARY_FRAGMENT(fb, m) {
-  m.def(
-      "dense_embedding_codegen_lookup_function(Tensor dev_weights, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad) -> Tensor");
   DISPATCH_TO_CUDA(
       "dense_embedding_codegen_lookup_function",
       split_embedding_codegen_lookup_dense_function);
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
-  m.def(
-      "dense_embedding_codegen_lookup_function(Tensor dev_weights, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad) -> Tensor");
   DISPATCH_TO_CUDA(
       "dense_embedding_codegen_lookup_function",
       split_embedding_codegen_lookup_dense_function);

--- a/fbgemm_gpu/codegen/embedding_backward_dense_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_dense_host_cpu.cpp
@@ -174,7 +174,9 @@ Tensor split_embedding_codegen_lookup_dense_function(
       feature_requires_grad)[0];
 }
 
-TORCH_LIBRARY_IMPL(fb, CPU, m) {
+TORCH_LIBRARY_FRAGMENT(fb, m) {
+  m.def(
+      "dense_embedding_codegen_lookup_function(Tensor dev_weights, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad) -> Tensor");
   m.impl(
       "dense_embedding_codegen_lookup_function",
       torch::dispatch(
@@ -182,7 +184,9 @@ TORCH_LIBRARY_IMPL(fb, CPU, m) {
           TORCH_FN(split_embedding_codegen_lookup_dense_function)));
 }
 
-TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
+TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  m.def(
+      "dense_embedding_codegen_lookup_function(Tensor dev_weights, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad) -> Tensor");
   m.impl(
       "dense_embedding_codegen_lookup_function",
       torch::dispatch(

--- a/fbgemm_gpu/codegen/embedding_bounds_check_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host.cpp
@@ -22,17 +22,9 @@ void bounds_check_indices_cuda(
     Tensor warning);
 
 TORCH_LIBRARY_FRAGMENT(fb, m) {
-  // The (a!) tells PyTorch this is an impure operation and so cannot be CSE'd
-  // or DCE'd, etc.
-  m.def(
-      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(a!) offsets, int bounds_check_mode, Tensor(a!) warning) -> ()");
   DISPATCH_TO_CUDA("bounds_check_indices", bounds_check_indices_cuda);
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
-  // The (a!) tells PyTorch this is an impure operation and so cannot be CSE'd
-  // or DCE'd, etc.
-  m.def(
-      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(a!) offsets, int bounds_check_mode, Tensor(a!) warning) -> ()");
   DISPATCH_TO_CUDA("bounds_check_indices", bounds_check_indices_cuda);
 }

--- a/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
@@ -105,6 +105,10 @@ void bounds_check_indices_cpu(
 } // namespace
 
 TORCH_LIBRARY_FRAGMENT(fb, m) {
+  // The (a!) tells PyTorch this is an impure operation and so cannot be CSE'd
+  // or DCE'd, etc.
+  m.def(
+      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(a!) offsets, int bounds_check_mode, Tensor(a!) warning) -> ()");
   m.impl(
       "bounds_check_indices",
       torch::dispatch(
@@ -112,6 +116,10 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  // The (a!) tells PyTorch this is an impure operation and so cannot be CSE'd
+  // or DCE'd, etc.
+  m.def(
+      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(a!) offsets, int bounds_check_mode, Tensor(a!) warning) -> ()");
   m.impl(
       "bounds_check_indices",
       torch::dispatch(


### PR DESCRIPTION
Summary:
When using CPU only build in FBGEMM_GPU, the definitions of some ops are missing. We need to move it from GPU file to CPU file in order to keep these definitions and avoid the error message like
```
>       op = torch._C._jit_get_operation(qualified_op_name)
E       RuntimeError: No such operator fbgemm::bounds_check_indices
```

Differential Revision: D34093077

