### PR TITLE
Fix TorchRec cpu only unit tests

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_dense_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_dense_host.cpp
@@ -393,16 +393,12 @@ Tensor split_embedding_codegen_lookup_dense_function(
 }
 
 TORCH_LIBRARY_FRAGMENT(fb, m) {
-  m.def(
-      "dense_embedding_codegen_lookup_function(Tensor dev_weights, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad) -> Tensor");
   DISPATCH_TO_CUDA(
       "dense_embedding_codegen_lookup_function",
       split_embedding_codegen_lookup_dense_function);
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
-  m.def(
-      "dense_embedding_codegen_lookup_function(Tensor dev_weights, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad) -> Tensor");
   DISPATCH_TO_CUDA(
       "dense_embedding_codegen_lookup_function",
       split_embedding_codegen_lookup_dense_function);

--- a/fbgemm_gpu/codegen/embedding_backward_dense_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_dense_host_cpu.cpp
@@ -174,7 +174,9 @@ Tensor split_embedding_codegen_lookup_dense_function(
       feature_requires_grad)[0];
 }
 
-TORCH_LIBRARY_IMPL(fb, CPU, m) {
+TORCH_LIBRARY_FRAGMENT(fb, m) {
+  m.def(
+      "dense_embedding_codegen_lookup_function(Tensor dev_weights, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad) -> Tensor");
   m.impl(
       "dense_embedding_codegen_lookup_function",
       torch::dispatch(
@@ -182,7 +184,9 @@ TORCH_LIBRARY_IMPL(fb, CPU, m) {
           TORCH_FN(split_embedding_codegen_lookup_dense_function)));
 }
 
-TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
+TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  m.def(
+      "dense_embedding_codegen_lookup_function(Tensor dev_weights, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad) -> Tensor");
   m.impl(
       "dense_embedding_codegen_lookup_function",
       torch::dispatch(

--- a/fbgemm_gpu/codegen/embedding_bounds_check_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host.cpp
@@ -22,17 +22,9 @@ void bounds_check_indices_cuda(
     Tensor warning);
 
 TORCH_LIBRARY_FRAGMENT(fb, m) {
-  // The (a!) tells PyTorch this is an impure operation and so cannot be CSE'd
-  // or DCE'd, etc.
-  m.def(
-      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(a!) offsets, int bounds_check_mode, Tensor(a!) warning) -> ()");
   DISPATCH_TO_CUDA("bounds_check_indices", bounds_check_indices_cuda);
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
-  // The (a!) tells PyTorch this is an impure operation and so cannot be CSE'd
-  // or DCE'd, etc.
-  m.def(
-      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(a!) offsets, int bounds_check_mode, Tensor(a!) warning) -> ()");
   DISPATCH_TO_CUDA("bounds_check_indices", bounds_check_indices_cuda);
 }

--- a/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
@@ -105,6 +105,10 @@ void bounds_check_indices_cpu(
 } // namespace
 
 TORCH_LIBRARY_FRAGMENT(fb, m) {
+  // The (a!) tells PyTorch this is an impure operation and so cannot be CSE'd
+  // or DCE'd, etc.
+  m.def(
+      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(a!) offsets, int bounds_check_mode, Tensor(a!) warning) -> ()");
   m.impl(
       "bounds_check_indices",
       torch::dispatch(
@@ -112,6 +116,10 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  // The (a!) tells PyTorch this is an impure operation and so cannot be CSE'd
+  // or DCE'd, etc.
+  m.def(
+      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(a!) offsets, int bounds_check_mode, Tensor(a!) warning) -> ()");
   m.impl(
       "bounds_check_indices",
       torch::dispatch(

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
@@ -195,18 +195,11 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
-  m.def(
-      "int_nbit_split_embedding_codegen_lookup_function(Tensor dev_weights, Tensor uvm_weights, Tensor weights_placements, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, int total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, int max_float32_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, int output_dtype=1, Tensor? lxu_cache_weights=None, Tensor? lxu_cache_locations=None) -> Tensor");
   DISPATCH_TO_CUDA(
       "int_nbit_split_embedding_codegen_lookup_function",
       int_nbit_split_embedding_codegen_lookup_function);
-
-  m.def(
-      "pruned_hashmap_lookup(Tensor indices, Tensor offsets, Tensor hash_table, Tensor hash_table_offsets) -> Tensor");
   DISPATCH_TO_CUDA(
       "pruned_hashmap_lookup", pruned_hashmap_lookup_unweighted_cuda);
 
-  m.def(
-      "pruned_array_lookup(Tensor indices, Tensor offsets, Tensor index_remappings, Tensor index_remappings_offsets) -> Tensor");
   DISPATCH_TO_CUDA("pruned_array_lookup", pruned_array_lookup_cuda);
 }

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
@@ -152,6 +152,8 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  m.def(
+      "int_nbit_split_embedding_codegen_lookup_function(Tensor dev_weights, Tensor uvm_weights, Tensor weights_placements, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, int total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, int max_float32_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, int output_dtype=1, Tensor? lxu_cache_weights=None, Tensor? lxu_cache_locations=None) -> Tensor");
   m.impl(
       "int_nbit_split_embedding_codegen_lookup_function",
       torch::dispatch(
@@ -170,6 +172,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 
   // CPU version of hashmap Lookup isn't used. For CPUs, we should use
   // PrunedMapCPU below.
+  m.def(
+      "pruned_hashmap_lookup(Tensor indices, Tensor offsets, Tensor hash_table, Tensor hash_table_offsets) -> Tensor");
   m.impl(
       "pruned_hashmap_lookup",
       torch::dispatch(
@@ -177,6 +181,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
           TORCH_FN(pruned_hashmap_lookup_unweighted_cpu)));
 
   // CPU version of array lookup.
+  m.def(
+      "pruned_array_lookup(Tensor indices, Tensor offsets, Tensor index_remappings, Tensor index_remappings_offsets) -> Tensor");
   m.impl(
       "pruned_array_lookup",
       torch::dispatch(


### PR DESCRIPTION
Summary: Continue the fix for int_nbit_split_embedding_codegen_lookup_function op.

Differential Revision: D34099495

