### PR TITLE
Optimize linearize_cache_indices implementation.

### DIFF
--- a/fbgemm_gpu/src/split_embeddings_cache_cuda.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache_cuda.cu
@@ -241,42 +241,41 @@ void lxu_cache_flush_cuda(
   return;
 }
 
-template <typename index_t>
+template <typename IndexType>
 __global__ __launch_bounds__(kMaxThreads) void linearize_cache_indices_kernel(
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         cache_hash_size_cumsum,
-    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
-    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
-    at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
+    const at::PackedTensorAccessor32<IndexType, 1, at::RestrictPtrTraits>
+        indices,
+    const at::PackedTensorAccessor32<IndexType, 1, at::RestrictPtrTraits>
+        table_offsets,
+    at::PackedTensorAccessor32<IndexType, 1, at::RestrictPtrTraits>
         linear_cache_indices) {
-  int32_t T = cache_hash_size_cumsum.size(0) - 1;
-  int64_t total_cache_hash_size = cache_hash_size_cumsum[T];
-  int32_t B = (offsets.size(0) - 1) / T;
-  int32_t b_t = blockIdx.x * blockDim.x + threadIdx.x;
-  int32_t b = b_t % B;
-  int32_t t = b_t / B;
-  bool valid = t < T;
+  const IndexType index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index >= indices.size(0)) {
+    return;
+  }
 
-  int64_t hash_offset = valid ? cache_hash_size_cumsum[t] : -1;
-  auto indices_start = valid ? offsets[t * B + b] : -1;
-  int32_t L = valid ? offsets[t * B + b + 1] - indices_start : 0;
-  int32_t lane_id = threadIdx.x % kWarpSize;
-
-  // hash_offset < 0 for non-caching tables
-  for (int32_t j = 0; j < kWarpSize; ++j) {
-    auto indices_start_warp = shfl_sync(indices_start, j);
-    int32_t L_warp = shfl_sync(L, j);
-    int64_t hash_offset_warp = shfl_sync(hash_offset, j);
-    if (hash_offset_warp >= 0) {
-      for (int32_t i = lane_id; i < L_warp; i += kWarpSize) {
-        auto idx = __ldg(&indices[indices_start_warp + i]);
-        linear_cache_indices[indices_start_warp + i] = hash_offset_warp + idx;
-      }
+  // Perform binary search.
+  int left = 0;
+  int right = table_offsets.size(0);
+  while (left != right) {
+    const int middle = (left + right) >> 1;
+    if (table_offsets[middle] <= index) {
+      left = middle + 1;
     } else {
-      for (int32_t i = lane_id; i < L_warp; i += kWarpSize) {
-        linear_cache_indices[indices_start_warp + i] = total_cache_hash_size;
-      }
+      right = middle;
     }
+  }
+  const int table_index = left;
+
+  const auto max_offset =
+      __ldg(&cache_hash_size_cumsum[cache_hash_size_cumsum.size(0) - 1]);
+  const auto curr_offset = __ldg(&cache_hash_size_cumsum[table_index]);
+  if (curr_offset >= 0) {
+    linear_cache_indices[index] = indices[index] + curr_offset;
+  } else {
+    linear_cache_indices[index] = max_offset;
   }
 }
 
@@ -291,27 +290,34 @@ Tensor linearize_cache_indices_cuda(
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(cache_hash_size_cumsum.get_device());
 
-  auto T = cache_hash_size_cumsum.size(0) - 1;
+  const auto T = cache_hash_size_cumsum.size(0) - 1;
   TORCH_CHECK(T > 0);
   // offsets = [B x T  + 1]
-  auto B = (offsets.size(0) - 1) / T;
+  const auto B = (offsets.size(0) - 1) / T;
   TORCH_CHECK(B >= 0);
 
   auto linear_cache_indices = at::empty_like(indices);
-  if (B == 0) {
+  const auto num_indices = indices.numel();
+  if (B == 0 || num_indices == 0) {
     return linear_cache_indices;
   }
+
+  auto table_offsets = offsets.narrow(0, B, B * (T - 1))
+                           .view({T - 1, B})
+                           .narrow(1, 0, 1)
+                           .view({-1});
   AT_DISPATCH_INDEX_TYPES(
       indices.scalar_type(), "linearize_cache_indices_kernel", [&]() {
         linearize_cache_indices_kernel<<<
-            div_round_up(B * T, kMaxThreads),
+            div_round_up(num_indices, kMaxThreads),
             kMaxThreads,
             0,
             at::cuda::getCurrentCUDAStream()>>>(
             cache_hash_size_cumsum
                 .packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
             indices.packed_accessor32<index_t, 1, at::RestrictPtrTraits>(),
-            offsets.packed_accessor32<index_t, 1, at::RestrictPtrTraits>(),
+            table_offsets
+                .packed_accessor32<index_t, 1, at::RestrictPtrTraits>(),
             linear_cache_indices
                 .packed_accessor32<index_t, 1, at::RestrictPtrTraits>());
         C10_CUDA_KERNEL_LAUNCH_CHECK();

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -3529,6 +3529,78 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         pickled = pickle.dumps(tensor_queue)
         unpickled = pickle.loads(pickled)
 
+    @unittest.skipIf(*gpu_unavailable)
+    def test_linearize_cache_indices(self) -> None:
+        indices = torch.tensor(
+            [10, 2, 3, 7, 1, 4, 5, 9, 2, 7, 6, 8, 5, 1, 0, 4],
+            dtype=torch.int,
+            device="cuda",
+        )
+        equal_offsets = torch.tensor([0, 4, 8, 12, 16], dtype=torch.int, device="cuda")
+        varying_offsets = torch.tensor(
+            [0, 1, 3, 6, 8, 10, 14, 15, 16], dtype=torch.int, device="cuda"
+        )
+
+        # Testing equal sized tables.
+        cache_hash_size_cumsum_0 = torch.tensor([0, 12, 24, 36, 48]).cuda()
+        linear_cache_indices_0 = torch.ops.fbgemm.linearize_cache_indices(
+            cache_hash_size_cumsum_0, indices, equal_offsets
+        )
+        self.assertTrue(
+            torch.equal(
+                linear_cache_indices_0.cpu(),
+                torch.tensor(
+                    [10, 2, 3, 7, 13, 16, 17, 21, 26, 31, 30, 32, 41, 37, 36, 40],
+                    dtype=torch.int,
+                ),
+            )
+        )
+
+        # Testing partially cached tables.
+        cache_hash_size_cumsum_1 = torch.tensor([0, 12, -1, 24, 36]).cuda()
+        linear_cache_indices_1 = torch.ops.fbgemm.linearize_cache_indices(
+            cache_hash_size_cumsum_1, indices, equal_offsets
+        )
+        self.assertTrue(
+            torch.equal(
+                linear_cache_indices_1.cpu(),
+                torch.tensor(
+                    [10, 2, 3, 7, 13, 16, 17, 21, 36, 36, 36, 36, 29, 25, 24, 28],
+                    dtype=torch.int,
+                ),
+            )
+        )
+
+        # Testing batched with varying pooling factor.
+        cache_hash_size_cumsum_2 = torch.tensor([0, 12, -1, 24, 36]).cuda()
+        linear_cache_indices_2 = torch.ops.fbgemm.linearize_cache_indices(
+            cache_hash_size_cumsum_2, indices, varying_offsets
+        )
+        self.assertTrue(
+            torch.equal(
+                linear_cache_indices_2.cpu(),
+                torch.tensor(
+                    [10, 2, 3, 19, 13, 16, 17, 21, 36, 36, 36, 36, 36, 36, 24, 28],
+                    dtype=torch.int,
+                ),
+            )
+        )
+
+        # Testing when multiple features share the same table.
+        cache_hash_size_cumsum_3 = torch.tensor([0, 0, 12, 12, 24]).cuda()
+        linear_cache_indices_3 = torch.ops.fbgemm.linearize_cache_indices(
+            cache_hash_size_cumsum_3, indices, varying_offsets
+        )
+        self.assertTrue(
+            torch.equal(
+                linear_cache_indices_3.cpu(),
+                torch.tensor(
+                    [10, 2, 3, 7, 1, 4, 5, 9, 14, 19, 18, 20, 17, 13, 12, 16],
+                    dtype=torch.int,
+                ),
+            )
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
Parallelize across threads even more to obtain better performance.

Microbenchmark at following diff shows that:
batch = 1024, T = 50, avg pooling factor = 400
2514us -> 220us (11.4x improvement)

batch = 1024, T = 1000, avg pooling factor = 10
1855us -> 237us (7.8x improvement)

New implementation always wins regardless of whether pooling factor / # of tables are large.

Differential Revision: D34123799

