### PR TITLE
bugfix for big tensors quantize to 0

### DIFF
--- a/include/fbgemm/FbgemmFPCommon.h
+++ b/include/fbgemm/FbgemmFPCommon.h
@@ -158,7 +158,7 @@ void cblas_gemm_compute(
 
           if ((n % Bp.blockColSize()) == 0) {
             int jb_begin, jb_end;
-            fbgemmPartition1D(
+            fbgemmPartition1D<int>(
                 thread_id, num_threads, gp.b_block_cols, jb_begin, jb_end);
             gp.B += gp.k * Bp.blockColSize() * jb_begin;
             gp.C += Bp.blockColSize() * jb_begin;
@@ -174,7 +174,7 @@ void cblas_gemm_compute(
             int last_blk_col = nbcol * Bp.blockColSize();
             if (nbcol) {
               int jb_begin, jb_end;
-              fbgemmPartition1D(
+              fbgemmPartition1D<int>(
                   thread_id, num_threads, gp.b_block_cols, jb_begin, jb_end);
               gp.B += gp.k * Bp.blockColSize() * jb_begin;
               gp.C += Bp.blockColSize() * jb_begin;

--- a/include/fbgemm/QuantUtils.h
+++ b/include/fbgemm/QuantUtils.h
@@ -96,7 +96,7 @@ template <typename T, bool LEGACY = true>
 FBGEMM_API void Quantize(
     const float* src,
     T* dst,
-    int len,
+    int64_t len,
     const TensorQuantizationParams& qparams,
     int thread_id = 0,
     int num_threads = 1);

--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -346,12 +346,13 @@ bool isValidBlockingFactor(BlockingFactors* param) {
  *
  * i.e., the loop should be equivalent to for(int i = start; i < end; ++i)
  */
+template <typename T>
 FBGEMM_API void fbgemmPartition1D(
     int thread_id,
     int num_threads,
-    int total_work,
-    int& start,
-    int& end);
+    T total_work,
+    T& start,
+    T& end);
 
 /**
  * @brief Partition work across given number of threads in blocks

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -348,22 +348,37 @@ bool fbgemmHasAvx512VnniSupport() {
   return (cpuinfo_has_x86_avx512vnni());
 }
 
+template <typename T>
 void fbgemmPartition1D(
     int thread_id,
     int num_threads,
-    int total_work,
-    int& start,
-    int& end) {
+    T total_work,
+    T& start,
+    T& end) {
   // if num_threads == 0,
   // this threads should not perform any work
   if (num_threads == 0) {
     start = end = 0;
     return;
   }
-  int work_per_thread = (total_work + num_threads - 1) / num_threads;
+  auto work_per_thread = (total_work + num_threads - 1) / num_threads;
   start = std::min(thread_id * work_per_thread, total_work);
   end = std::min((thread_id + 1) * work_per_thread, total_work);
 }
+
+template void fbgemmPartition1D<int>(
+    int thread_id,
+    int num_threads,
+    int total_work,
+    int& start,
+    int& end);
+
+template void fbgemmPartition1D<int64_t>(
+    int thread_id,
+    int num_threads,
+    int64_t total_work,
+    int64_t& start,
+    int64_t& end);
 
 void fbgemmPartition1DBlocked(
     int thread_id,


### PR DESCRIPTION
Summary: previously the test case would quantize the entire tensor to 0's when the number of tensor elements was greater than int32 max, this PR fixes that by changing the element indexer to use int64 rather than int32.

Differential Revision: D34164235

