### PR TITLE
use int64_t in fbgemmPartition1D

### DIFF
--- a/include/fbgemm/FbgemmFPCommon.h
+++ b/include/fbgemm/FbgemmFPCommon.h
@@ -157,7 +157,7 @@ void cblas_gemm_compute(
           gp.b_block_size = gp.k * Bp.blockColSize() * sizeof(gp.B[0]);
 
           if ((n % Bp.blockColSize()) == 0) {
-            int jb_begin, jb_end;
+            int64_t jb_begin, jb_end;
             fbgemmPartition1D(
                 thread_id, num_threads, gp.b_block_cols, jb_begin, jb_end);
             gp.B += gp.k * Bp.blockColSize() * jb_begin;
@@ -173,7 +173,7 @@ void cblas_gemm_compute(
           } else {
             int last_blk_col = nbcol * Bp.blockColSize();
             if (nbcol) {
-              int jb_begin, jb_end;
+              int64_t jb_begin, jb_end;
               fbgemmPartition1D(
                   thread_id, num_threads, gp.b_block_cols, jb_begin, jb_end);
               gp.B += gp.k * Bp.blockColSize() * jb_begin;

--- a/include/fbgemm/QuantUtils.h
+++ b/include/fbgemm/QuantUtils.h
@@ -96,7 +96,7 @@ template <typename T, bool LEGACY = true>
 FBGEMM_API void Quantize(
     const float* src,
     T* dst,
-    int len,
+    std::int64_t len,
     const TensorQuantizationParams& qparams,
     int thread_id = 0,
     int num_threads = 1);
@@ -144,13 +144,13 @@ template <typename T>
 void Dequantize(
     const T* src,
     float* dst,
-    int len,
+    std::int64_t len,
     const TensorQuantizationParams& qparams,
     int thread_id = 0,
     int num_threads = 1) {
-  int i_begin, i_end;
+  int64_t i_begin, i_end;
   fbgemmPartition1D(thread_id, num_threads, len, i_begin, i_end);
-  for (auto i = i_begin; i < i_end; i++) {
+  for (int64_t i = i_begin; i < i_end; i++) {
     dst[i] = Dequantize(src[i], qparams);
   }
 }
@@ -173,7 +173,7 @@ template <typename T>
 FBGEMM_API void FusedQuantizeDequantize(
     const float* src,
     float* dst,
-    int len,
+    std::int64_t len,
     const TensorQuantizationParams& qparams,
     int thread_id = 0,
     int num_threads = 1,
@@ -215,7 +215,7 @@ template <typename T>
 FBGEMM_API void RequantizeFixedPoint(
     const std::int32_t* src,
     T* dst,
-    int len,
+    std::int64_t len,
     const RequantizationParams& params,
     int thread_id = 0,
     int num_threads = 1);
@@ -249,7 +249,7 @@ template <typename T>
 FBGEMM_API void Requantize(
     const std::int32_t* src,
     T* dst,
-    int len,
+    std::int64_t len,
     const RequantizationParams& params,
     int thread_id = 0,
     int num_threads = 1);

--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -349,9 +349,9 @@ bool isValidBlockingFactor(BlockingFactors* param) {
 FBGEMM_API void fbgemmPartition1D(
     int thread_id,
     int num_threads,
-    int total_work,
-    int& start,
-    int& end);
+    std::int64_t total_work,
+    std::int64_t& start,
+    std::int64_t& end);
 
 /**
  * @brief Partition work across given number of threads in blocks
@@ -392,8 +392,8 @@ FBGEMM_API void fbgemmPartition1D(
 FBGEMM_API void fbgemmPartition1DBlocked(
     int thread_id,
     int num_threads,
-    int total_work,
+    std::int64_t total_work,
     int block_size,
-    int& start,
-    int& end);
+    std::int64_t& start,
+    std::int64_t& end);
 } // namespace fbgemm

--- a/src/ExecuteKernelU8S8.cc
+++ b/src/ExecuteKernelU8S8.cc
@@ -126,7 +126,7 @@ void ExecuteKernel<
   bool lastKBlock = packedB_.isThisLastKBlock(kBlock % packedB_.blockRows());
   bool accum = (kBlock % packedB_.blockRows()) > 0;
 
-  int jb_begin, jb_end;
+  int64_t jb_begin, jb_end;
   fbgemmPartition1D(
       th_info_.n_thread_id,
       th_info_.n_num_threads,
@@ -329,7 +329,7 @@ void ExecuteKernel<
               C_buffer_row_start + jb_begin * nbSize_,
               {row_start_A,
                packed_rows_A,
-               NDim * group + jb_begin * nbSize_,
+               static_cast<int>(NDim * group + jb_begin * nbSize_),
                nSize},
               ldc_,
               ldc_);

--- a/src/Fbgemm.cc
+++ b/src/Fbgemm.cc
@@ -56,7 +56,7 @@ void fbgemmPacked(
     throw std::runtime_error("unknown architecure");
   }
 
-  int MCB;
+  int64_t MCB;
   int KCB;
   int MR;
 
@@ -144,7 +144,7 @@ void fbgemmPacked(
   // if (thread_id == 0)
   //   std::cout << ", " << th_info.toString();
 
-  int g_begin, g_end, i_begin, i_end;
+  int64_t g_begin, g_end, i_begin, i_end;
 
   // Calculate the begin and end index along the group dimension
   fbgemmPartition1D(

--- a/src/FbgemmI8Depthwise2DAvx2-inl.h
+++ b/src/FbgemmI8Depthwise2DAvx2-inl.h
@@ -144,8 +144,8 @@ static ALWAYS_INLINE void depthwise_2d_(
     int num_threads) {
   assert(IC % 8 == 0);
   constexpr int R = S;
-  constexpr int PAD_T = (R - 1) / 2, PAD_B = PAD_T, PAD_L = (S - 1) / 2,
-                PAD_R = PAD_L;
+  constexpr int64_t PAD_T = (R - 1) / 2, PAD_B = PAD_T, PAD_L = (S - 1) / 2,
+                    PAD_R = PAD_L;
   int H_OUT = (H + PAD_T + PAD_B - R) / stride_h + 1;
   int W_OUT = (W + PAD_L + PAD_R - S) / stride_w + 1;
   const std::int8_t* Bp = B.PackedMat();
@@ -153,7 +153,7 @@ static ALWAYS_INLINE void depthwise_2d_(
   int32_t* row_offsets = static_cast<int32_t*>(
       fbgemmAlignedAlloc(64, (IC + 31) / 32 * 32 * sizeof(int32_t)));
 
-  int n_begin, n_end, h_begin, h_end, w_begin, w_end;
+  int64_t n_begin, n_end, h_begin, h_end, w_begin, w_end;
   // Reuse the 3-dim partition scheme for parallelization in matrix
   // multiplication.
   thread_type_t th_info =

--- a/src/FbgemmI8Depthwise3DAvx2.cc
+++ b/src/FbgemmI8Depthwise3DAvx2.cc
@@ -160,15 +160,15 @@ static ALWAYS_INLINE void depthwise_3d_same_pad_(
   int K_T = F[0], K_H = F[1], K_W = F[2];
   int PAD_P = (F[0] - 1) / 2, PAD_N = PAD_P, PAD_T = (F[1] - 1) / 2,
       PAD_B = PAD_T, PAD_L = (F[2] - 1) / 2, PAD_R = PAD_L;
-  int T_OUT = (T + PAD_P + PAD_N - K_T) / stride_t + 1;
-  int H_OUT = (H + PAD_T + PAD_B - K_H) / stride_h + 1;
+  int64_t T_OUT = (T + PAD_P + PAD_N - K_T) / stride_t + 1;
+  int64_t H_OUT = (H + PAD_T + PAD_B - K_H) / stride_h + 1;
   int W_OUT = (W + PAD_L + PAD_R - K_W) / stride_w + 1;
   const int8_t* Bp = B.PackedMat();
 
   int32_t* row_offsets = static_cast<int32_t*>(
       fbgemmAlignedAlloc(64, (IC + 31) / 32 * 32 * sizeof(int32_t)));
 
-  int n_begin, n_end, t_begin, t_end, h_begin, h_end;
+  int64_t n_begin, n_end, t_begin, t_end, h_begin, h_end;
   // Reuse the 3-dim partition scheme for parallelization in matrix
   // multiplication.
   thread_type_t th_info =

--- a/src/GroupwiseConv.cc
+++ b/src/GroupwiseConv.cc
@@ -1022,10 +1022,10 @@ void fbgemmGroupwiseConv(
   }
   if (SPATIAL_DIM == 2) {
     // Parallelization:
-    int batch_start = 0;
-    int batch_end = MB;
-    int oh_start = 0;
-    int oh_end = OH;
+    int64_t batch_start = 0;
+    int64_t batch_end = MB;
+    int64_t oh_start = 0;
+    int64_t oh_end = OH;
     if (MB >= num_threads) {
       fbgemmPartition1D(thread_id, num_threads, MB, batch_start, batch_end);
     } else {
@@ -1100,8 +1100,8 @@ void fbgemmGroupwiseConv(
 
         const int32_t* inp = out_start_group;
         block_type_t block{
-            i * OT_OH_OW + oh_start * OW,
-            (oh_end - oh_start) * OW,
+            static_cast<int>(i * OT_OH_OW + oh_start * OW),
+            static_cast<int>((oh_end - oh_start) * OW),
             g * K_per_G,
             G_together * K_per_G};
         int ld_out = G * K_per_G;
@@ -1139,10 +1139,10 @@ void fbgemmGroupwiseConv(
          conv_param.pad[5]});
 
     // Parallelization:
-    int batch_start = 0;
-    int batch_end = MB;
-    int oh_start = 0;
-    int oh_end = OH;
+    int64_t batch_start = 0;
+    int64_t batch_end = MB;
+    int64_t oh_start = 0;
+    int64_t oh_end = OH;
     if (MB >= num_threads) {
       fbgemmPartition1D(thread_id, num_threads, MB, batch_start, batch_end);
     } else {
@@ -1243,8 +1243,8 @@ void fbgemmGroupwiseConv(
 
           const int32_t* inp = out_start_t;
           block_type_t block{
-              i * OT_OH_OW + oh_start * OW,
-              (oh_end - oh_start) * OW,
+              static_cast<int>(i * OT_OH_OW + oh_start * OW),
+              static_cast<int>((oh_end - oh_start) * OW),
               g * K_per_G,
               G_together * K_per_G};
           int ld_out = G * K_per_G;

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -351,16 +351,16 @@ bool fbgemmHasAvx512VnniSupport() {
 void fbgemmPartition1D(
     int thread_id,
     int num_threads,
-    int total_work,
-    int& start,
-    int& end) {
+    int64_t total_work,
+    int64_t& start,
+    int64_t& end) {
   // if num_threads == 0,
   // this threads should not perform any work
   if (num_threads == 0) {
     start = end = 0;
     return;
   }
-  int work_per_thread = (total_work + num_threads - 1) / num_threads;
+  int64_t work_per_thread = (total_work + num_threads - 1) / num_threads;
   start = std::min(thread_id * work_per_thread, total_work);
   end = std::min((thread_id + 1) * work_per_thread, total_work);
 }
@@ -368,15 +368,15 @@ void fbgemmPartition1D(
 void fbgemmPartition1DBlocked(
     int thread_id,
     int num_threads,
-    int total_work,
+    int64_t total_work,
     int block_size,
-    int& start,
-    int& end) {
+    int64_t& start,
+    int64_t& end) {
   if (block_size == 1) {
     return fbgemmPartition1D(thread_id, num_threads, total_work, start, end);
   }
-  int total_work_in_blocks = total_work / block_size;
-  int start_block, end_block;
+  int64_t total_work_in_blocks = total_work / block_size;
+  int64_t start_block, end_block;
   fbgemmPartition1D(
       thread_id, num_threads, total_work_in_blocks, start_block, end_block);
   start = std::min(start_block * block_size, total_work);


### PR DESCRIPTION
Summary: To handle large tensors.

Differential Revision: D34234352

