### PR TITLE
Add DISPATCH_TO_CPU macro and refactor

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_dense_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_dense_host_cpu.cpp
@@ -10,6 +10,7 @@
 
 #include "codegen/embedding_forward_split_cpu.h"
 #include "fbgemm_gpu/embedding_common.h"
+#include "fbgemm_gpu/sparse_ops_utils.h"
 
 using Tensor = at::Tensor;
 
@@ -177,21 +178,17 @@ Tensor split_embedding_codegen_lookup_dense_function(
 TORCH_LIBRARY_FRAGMENT(fb, m) {
   m.def(
       "dense_embedding_codegen_lookup_function(Tensor dev_weights, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad) -> Tensor");
-  m.impl(
+  DISPATCH_TO_CPU(
       "dense_embedding_codegen_lookup_function",
-      torch::dispatch(
-          c10::DispatchKey::CPU,
-          TORCH_FN(split_embedding_codegen_lookup_dense_function)));
+      split_embedding_codegen_lookup_dense_function);
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "dense_embedding_codegen_lookup_function(Tensor dev_weights, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad) -> Tensor");
-  m.impl(
+  DISPATCH_TO_CPU(
       "dense_embedding_codegen_lookup_function",
-      torch::dispatch(
-          c10::DispatchKey::CPU,
-          TORCH_FN(split_embedding_codegen_lookup_dense_function)));
+      split_embedding_codegen_lookup_dense_function);
 }
 
 } // namespace

--- a/fbgemm_gpu/codegen/embedding_backward_split_host_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_cpu_template.cpp
@@ -11,6 +11,7 @@
 
 #include "codegen/embedding_forward_split_cpu.h"
 #include "fbgemm_gpu/embedding_common.h"
+#include "fbgemm_gpu/sparse_ops_utils.h"
 
 using Tensor = at::Tensor;
 
@@ -217,12 +218,16 @@ Tensor split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(
 
 TORCH_LIBRARY_FRAGMENT(fb, m) {
     m.def("split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(Tensor host_weights, Tensor weights_placements, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, bool gradient_clipping, float max_gradient, bool stochastic_rounding, {{ args.split_function_schemas | join(", ") }}, int output_dtype=0) -> Tensor");
-    m.impl("split_embedding_codegen_lookup_{{ optimizer }}_function_cpu", torch::dispatch(c10::DispatchKey::CPU, TORCH_FN(split_embedding_codegen_lookup_{{ optimizer }}_function_cpu)));
+    DISPATCH_TO_CPU(
+        "split_embedding_codegen_lookup_{{ optimizer }}_function_cpu",
+        split_embedding_codegen_lookup_{{ optimizer }}_function_cpu);
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
     m.def("split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(Tensor host_weights, Tensor weights_placements, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, bool gradient_clipping, float max_gradient, bool stochastic_rounding, {{ args.split_function_schemas | join(", ") }}, int output_dtype=0) -> Tensor");
-    m.impl("split_embedding_codegen_lookup_{{ optimizer }}_function_cpu", torch::dispatch(c10::DispatchKey::CPU, TORCH_FN(split_embedding_codegen_lookup_{{ optimizer }}_function_cpu)));
+    DISPATCH_TO_CPU(
+        "split_embedding_codegen_lookup_{{ optimizer }}_function_cpu",
+        split_embedding_codegen_lookup_{{ optimizer }}_function_cpu);
 }
 
 } // namespace

--- a/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
@@ -9,6 +9,7 @@
 #include <ATen/core/op_registration/op_registration.h>
 #include <torch/script.h>
 #include "fbgemm_gpu/embedding_common.h"
+#include "fbgemm_gpu/sparse_ops_utils.h"
 
 using Tensor = at::Tensor;
 
@@ -109,10 +110,7 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
   // or DCE'd, etc.
   m.def(
       "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(a!) offsets, int bounds_check_mode, Tensor(a!) warning) -> ()");
-  m.impl(
-      "bounds_check_indices",
-      torch::dispatch(
-          c10::DispatchKey::CPU, TORCH_FN(bounds_check_indices_cpu)));
+  DISPATCH_TO_CPU("bounds_check_indices", bounds_check_indices_cpu);
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
@@ -120,8 +118,5 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   // or DCE'd, etc.
   m.def(
       "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(a!) offsets, int bounds_check_mode, Tensor(a!) warning) -> ()");
-  m.impl(
-      "bounds_check_indices",
-      torch::dispatch(
-          c10::DispatchKey::CPU, TORCH_FN(bounds_check_indices_cpu)));
+  DISPATCH_TO_CPU("bounds_check_indices", bounds_check_indices_cpu);
 }

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
@@ -16,6 +16,7 @@
 #endif
 #include <torch/serialize/input-archive.h>
 #include <torch/serialize/output-archive.h>
+#include "fbgemm_gpu/sparse_ops_utils.h"
 
 using Tensor = at::Tensor;
 
@@ -122,77 +123,55 @@ Tensor pruned_array_lookup_cpu(
 TORCH_LIBRARY_FRAGMENT(fb, m) {
   m.def(
       "int_nbit_split_embedding_codegen_lookup_function(Tensor dev_weights, Tensor uvm_weights, Tensor weights_placements, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, int total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, int max_float32_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, int output_dtype=1, Tensor? lxu_cache_weights=None, Tensor? lxu_cache_locations=None) -> Tensor");
-  m.impl(
+  DISPATCH_TO_CPU(
       "int_nbit_split_embedding_codegen_lookup_function",
-      torch::dispatch(
-          c10::DispatchKey::CPU,
-          TORCH_FN(int_nbit_split_embedding_codegen_lookup_function_cpu)));
+      int_nbit_split_embedding_codegen_lookup_function_cpu);
 
   // GPU version of pruned_hashmap needs to use CPU version of
   // pruned_hashmap_insert
   m.def(
       "pruned_hashmap_insert(Tensor indices, Tensor dense_indices, Tensor offsets, Tensor hash_table, Tensor hash_table_offsets) -> ()");
-  m.impl(
-      "pruned_hashmap_insert",
-      torch::dispatch(
-          c10::DispatchKey::CPU,
-          TORCH_FN(pruned_hashmap_insert_unweighted_cpu)));
+  DISPATCH_TO_CPU(
+      "pruned_hashmap_insert", pruned_hashmap_insert_unweighted_cpu);
 
   // CPU version of hashmap Lookup isn't used. For CPUs, we should use
   // PrunedMapCPU below.
   m.def(
       "pruned_hashmap_lookup(Tensor indices, Tensor offsets, Tensor hash_table, Tensor hash_table_offsets) -> Tensor");
-  m.impl(
-      "pruned_hashmap_lookup",
-      torch::dispatch(
-          c10::DispatchKey::CPU,
-          TORCH_FN(pruned_hashmap_lookup_unweighted_cpu)));
+  DISPATCH_TO_CPU(
+      "pruned_hashmap_lookup", pruned_hashmap_lookup_unweighted_cpu);
 
   // CPU version of array lookup.
   m.def(
       "pruned_array_lookup(Tensor indices, Tensor offsets, Tensor index_remappings, Tensor index_remappings_offsets) -> Tensor");
-  m.impl(
-      "pruned_array_lookup",
-      torch::dispatch(
-          c10::DispatchKey::CPU, TORCH_FN(pruned_array_lookup_cpu)));
+  DISPATCH_TO_CPU("pruned_array_lookup", pruned_array_lookup_cpu);
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "int_nbit_split_embedding_codegen_lookup_function(Tensor dev_weights, Tensor uvm_weights, Tensor weights_placements, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, int total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, int max_float32_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, int output_dtype=1, Tensor? lxu_cache_weights=None, Tensor? lxu_cache_locations=None) -> Tensor");
-  m.impl(
+  DISPATCH_TO_CPU(
       "int_nbit_split_embedding_codegen_lookup_function",
-      torch::dispatch(
-          c10::DispatchKey::CPU,
-          TORCH_FN(int_nbit_split_embedding_codegen_lookup_function_cpu)));
+      int_nbit_split_embedding_codegen_lookup_function_cpu);
 
   // GPU version of pruned_hashmap needs to use CPU version of
   // pruned_hashmap_insert
   m.def(
       "pruned_hashmap_insert(Tensor indices, Tensor dense_indices, Tensor offsets, Tensor hash_table, Tensor hash_table_offsets) -> ()");
-  m.impl(
-      "pruned_hashmap_insert",
-      torch::dispatch(
-          c10::DispatchKey::CPU,
-          TORCH_FN(pruned_hashmap_insert_unweighted_cpu)));
+  DISPATCH_TO_CPU(
+      "pruned_hashmap_insert", pruned_hashmap_insert_unweighted_cpu);
 
   // CPU version of hashmap Lookup isn't used. For CPUs, we should use
   // PrunedMapCPU below.
   m.def(
       "pruned_hashmap_lookup(Tensor indices, Tensor offsets, Tensor hash_table, Tensor hash_table_offsets) -> Tensor");
-  m.impl(
-      "pruned_hashmap_lookup",
-      torch::dispatch(
-          c10::DispatchKey::CPU,
-          TORCH_FN(pruned_hashmap_lookup_unweighted_cpu)));
+  DISPATCH_TO_CPU(
+      "pruned_hashmap_lookup", pruned_hashmap_lookup_unweighted_cpu);
 
   // CPU version of array lookup.
   m.def(
       "pruned_array_lookup(Tensor indices, Tensor offsets, Tensor index_remappings, Tensor index_remappings_offsets) -> Tensor");
-  m.impl(
-      "pruned_array_lookup",
-      torch::dispatch(
-          c10::DispatchKey::CPU, TORCH_FN(pruned_array_lookup_cpu)));
+  DISPATCH_TO_CPU("pruned_array_lookup", pruned_array_lookup_cpu);
 }
 
 class PrunedMapCPU : public torch::jit::CustomClassHolder {

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
@@ -60,6 +60,9 @@ inline bool torch_tensor_empty_or_on_cuda_gpu_check(
 #define DISPATCH_TO_CUDA(name, function) \
   m.impl(name, torch::dispatch(c10::DispatchKey::CUDA, TORCH_FN(function)))
 
+#define DISPATCH_TO_CPU(name, function) \
+  m.impl(name, torch::dispatch(c10::DispatchKey::CPU, TORCH_FN(function)))
+
 #define TENSOR_ON_CPU(x)                                      \
   TORCH_CHECK(                                                \
       torch_tensor_on_cpu_check(x),                           \

--- a/fbgemm_gpu/src/input_combine_cpu.cpp
+++ b/fbgemm_gpu/src/input_combine_cpu.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include "fbgemm_gpu/input_combine.h"
+#include "fbgemm_gpu/sparse_ops_utils.h"
 
 #include <ATen/ATen.h>
 #include <ATen/Context.h>
@@ -220,13 +221,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "tbe_input_combine(Tensor[] indices_list, Tensor[] offsets_list, Tensor[] per_sample_weights, Tensor include_last_offsets) -> (Tensor, Tensor, Tensor)");
   m.def(
       "tbe_input_combine_with_length(Tensor[] indices_list, Tensor[] lengths_list, Tensor[] per_sample_weights) -> (Tensor, Tensor, Tensor)");
-  m.impl(
-      "tbe_input_combine",
-      torch::dispatch(
-          c10::DispatchKey::CPU, TORCH_FN(fbgemm_gpu::tbe_input_combine_cpu)));
-  m.impl(
+  DISPATCH_TO_CPU("tbe_input_combine", fbgemm_gpu::tbe_input_combine_cpu);
+  DISPATCH_TO_CPU(
       "tbe_input_combine_with_length",
-      torch::dispatch(
-          c10::DispatchKey::CPU,
-          TORCH_FN(fbgemm_gpu::tbe_input_combine_with_length_cpu)));
+      fbgemm_gpu::tbe_input_combine_with_length_cpu);
 }

--- a/fbgemm_gpu/src/layout_transform_ops_cpu.cpp
+++ b/fbgemm_gpu/src/layout_transform_ops_cpu.cpp
@@ -73,7 +73,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
-  m.impl(
+  DISPATCH_TO_CPU(
       "recat_embedding_grad_output_mixed_D",
       fbgemm_gpu::recat_embedding_grad_output_mixed_D_cpu);
 }

--- a/fbgemm_gpu/src/merge_pooled_embeddings_cpu.cpp
+++ b/fbgemm_gpu/src/merge_pooled_embeddings_cpu.cpp
@@ -8,6 +8,7 @@
 #include <ATen/core/op_registration/op_registration.h>
 #include <c10/core/TensorOptions.h>
 #include <torch/library.h>
+#include "fbgemm_gpu/sparse_ops_utils.h"
 
 using Tensor = at::Tensor;
 
@@ -38,5 +39,6 @@ Tensor merge_pooled_embeddings_cpu(
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
-  m.impl("merge_pooled_embeddings", fbgemm_gpu::merge_pooled_embeddings_cpu);
+  DISPATCH_TO_CPU(
+      "merge_pooled_embeddings", fbgemm_gpu::merge_pooled_embeddings_cpu);
 }

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops_gpu.cpp
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops_gpu.cpp
@@ -138,11 +138,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   DISPATCH_TO_CUDA("permute_pooled_embs", fbgemm_gpu::permute_pooled_embs_gpu);
   m.def(
       "permute_pooled_embs_auto_grad(Tensor pooled_embs, Tensor offset_dim_list, Tensor permute_list, Tensor inv_offset_dim_list, Tensor inv_permute_list) -> Tensor");
-  m.impl(
+  DISPATCH_TO_CPU(
       "permute_pooled_embs_auto_grad",
-      torch::dispatch(
-          c10::DispatchKey::CPU,
-          TORCH_FN(fbgemm_gpu::permute_pooled_embs_auto_grad_cpu)));
+      fbgemm_gpu::permute_pooled_embs_auto_grad_cpu);
   DISPATCH_TO_CUDA(
       "permute_pooled_embs_auto_grad",
       fbgemm_gpu::permute_pooled_embs_auto_grad_gpu);

--- a/fbgemm_gpu/src/quantize_ops_cpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops_cpu.cpp
@@ -234,34 +234,34 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
-  m.impl(
+  DISPATCH_TO_CPU(
       "FloatToFused8BitRowwiseQuantized",
       fbgemm_gpu::float_to_fused8bitrowwise_cpu);
-  m.impl(
+  DISPATCH_TO_CPU(
       "HalfToFused8BitRowwiseQuantized",
       fbgemm_gpu::half_to_fused8bitrowwise_cpu);
-  m.impl(
+  DISPATCH_TO_CPU(
       "FloatToFused8BitRowwiseQuantizedOut",
       fbgemm_gpu::_float_to_fused8bitrowwise_cpu_out);
-  m.impl(
+  DISPATCH_TO_CPU(
       "Fused8BitRowwiseQuantizedToFloat",
       fbgemm_gpu::fused8bitrowwise_to_float_cpu);
-  m.impl(
+  DISPATCH_TO_CPU(
       "Fused8BitRowwiseQuantizedToFloatOut",
       fbgemm_gpu::_fused8bitrowwise_to_float_cpu_out);
-  m.impl(
+  DISPATCH_TO_CPU(
       "Fused8BitRowwiseQuantizedToHalf",
       fbgemm_gpu::fused8bitrowwise_to_half_cpu);
-  m.impl(
+  DISPATCH_TO_CPU(
       "FloatToFusedNBitRowwiseQuantizedSBHalf",
       fbgemm_gpu::float_to_fusednbitrowwise_cpu);
-  m.impl(
+  DISPATCH_TO_CPU(
       "FusedNBitRowwiseQuantizedSBHalfToFloat",
       fbgemm_gpu::fusednbitrowwise_to_float_cpu);
-  m.impl(
+  DISPATCH_TO_CPU(
       "FusedNBitRowwiseQuantizedSBHalfToHalf",
       fbgemm_gpu::fusednbitrowwise_to_half_cpu);
-  m.impl(
+  DISPATCH_TO_CPU(
       "HalfToFusedNBitRowwiseQuantizedSBHalf",
       fbgemm_gpu::half_to_fusednbitrowwise_cpu);
 }

--- a/fbgemm_gpu/src/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_cpu.cpp
@@ -1658,40 +1658,44 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
-  m.impl("permute_2D_sparse_data", fbgemm_gpu::permute_2D_sparse_data_cpu);
-  m.impl("permute_1D_sparse_data", fbgemm_gpu::permute_1D_sparse_data_cpu);
-  m.impl(
+  DISPATCH_TO_CPU(
+      "permute_2D_sparse_data", fbgemm_gpu::permute_2D_sparse_data_cpu);
+  DISPATCH_TO_CPU(
+      "permute_1D_sparse_data", fbgemm_gpu::permute_1D_sparse_data_cpu);
+
+  DISPATCH_TO_CPU(
       "block_bucketize_sparse_features",
       fbgemm_gpu::block_bucketize_sparse_features_cpu);
-  m.impl(
+  DISPATCH_TO_CPU(
       "asynchronous_exclusive_cumsum",
       fbgemm_gpu::asynchronous_exclusive_cumsum_cpu);
-  m.impl(
+  DISPATCH_TO_CPU(
       "asynchronous_inclusive_cumsum",
       fbgemm_gpu::asynchronous_inclusive_cumsum_cpu);
-  m.impl(
+  DISPATCH_TO_CPU(
       "asynchronous_complete_cumsum",
       fbgemm_gpu::asynchronous_complete_cumsum_cpu);
-  m.impl(
+  DISPATCH_TO_CPU(
       "reorder_batched_ad_lengths", fbgemm_gpu::reorder_batched_ad_lengths_cpu);
-  m.impl(
+  DISPATCH_TO_CPU(
       "reorder_batched_ad_indices", fbgemm_gpu::reorder_batched_ad_indices_cpu);
-  m.impl("offsets_range", fbgemm_gpu::offsets_range_cpu);
-  m.impl(
+  DISPATCH_TO_CPU("offsets_range", fbgemm_gpu::offsets_range_cpu);
+  DISPATCH_TO_CPU(
       "batched_unary_embeddings",
       fbgemm_gpu::batched_unary_embeddings_forward_cpu);
-  m.impl("jagged_2d_to_dense", fbgemm_gpu::jagged_2d_to_dense_forward_cpu);
-  m.impl("jagged_1d_to_dense", fbgemm_gpu::jagged_1d_to_dense_cpu);
-  m.impl(
+  DISPATCH_TO_CPU(
+      "jagged_2d_to_dense", fbgemm_gpu::jagged_2d_to_dense_forward_cpu);
+  DISPATCH_TO_CPU("jagged_1d_to_dense", fbgemm_gpu::jagged_1d_to_dense_cpu);
+  DISPATCH_TO_CPU(
       "histogram_binning_calibration",
       fbgemm_gpu::histogram_binning_calibration_cpu);
-  m.impl(
+  DISPATCH_TO_CPU(
       "histogram_binning_calibration_by_feature",
       fbgemm_gpu::histogram_binning_calibration_by_feature_cpu);
-  m.impl(
+  DISPATCH_TO_CPU(
       "generic_histogram_binning_calibration_by_feature",
       fbgemm_gpu::generic_histogram_binning_calibration_by_feature_cpu);
-  m.impl("segment_sum_csr", fbgemm_gpu::segment_sum_csr_cpu);
-  m.impl(
+  DISPATCH_TO_CPU("segment_sum_csr", fbgemm_gpu::segment_sum_csr_cpu);
+  DISPATCH_TO_CPU(
       "embedding_bag_rowwise_prune", fbgemm_gpu::embedding_bag_rowwise_prune);
 }


### PR DESCRIPTION
Summary: Add a DISPATCH_TO_CPU and refactor instead of m.impl dispatching to CPU

Reviewed By: jianyuh

Differential Revision: D34189518

