### PR TITLE
Fix the inference TBE loading on the GPU with specific target device

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
@@ -396,7 +396,7 @@ struct TensorQueue : torch::CustomClassHolder {
     init_tensor_ = dict.at(std::string("init_tensor"));
     const std::string key = "queue";
     Tensor size_tensor;
-    size_tensor = dict.at(std::string(key + "/size"));
+    size_tensor = dict.at(std::string(key + "/size")).cpu();
     const auto* size_tensor_acc = size_tensor.data_ptr<int64_t>();
     int64_t queue_size = size_tensor_acc[0];
 


### PR DESCRIPTION
Summary: If we specify the target device, the tensors will be loaded to GPU, and directly calling data_ptr will cause issue. So we need to move it back to CPU first.

Differential Revision: D34292970

