### PR TITLE
rename fbgemm.permute_sparse_data to fbgemm.permute_2D_sparse_data

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -39,7 +39,7 @@ at::Tensor segment_sum_csr_cpu(
     const at::Tensor& values);
 
 std::tuple<at::Tensor, at::Tensor, c10::optional<at::Tensor>>
-permute_sparse_data_cuda(
+permute_2D_sparse_data_cuda(
     const at::Tensor& permute,
     const at::Tensor& lengths,
     const at::Tensor& indices,
@@ -77,7 +77,7 @@ block_bucketize_sparse_features_cpu(
     c10::optional<at::Tensor> weights);
 
 std::tuple<at::Tensor, at::Tensor, c10::optional<at::Tensor>>
-permute_sparse_data_cpu(
+permute_2D_sparse_data_cpu(
     const at::Tensor& permute,
     const at::Tensor& lengths,
     const at::Tensor& indices,

--- a/fbgemm_gpu/src/sparse_ops.cu
+++ b/fbgemm_gpu/src/sparse_ops.cu
@@ -237,7 +237,7 @@ Tensor asynchronous_complete_cumsum_gpu(const Tensor& t_in) {
   return t_out;
 }
 
-std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_data_cuda(
+std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_2D_sparse_data_cuda(
     const Tensor& permute,
     const Tensor& lengths,
     const Tensor& indices,
@@ -247,6 +247,7 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_data_cuda(
   TENSOR_ON_CUDA_GPU(lengths);
   TENSOR_ON_CUDA_GPU(indices);
   TENSOR_ON_CUDA_GPU(weights);
+  TORCH_CHECK(lengths.dim() == 2);
 
   TENSORS_ON_SAME_DEVICE(permute, lengths);
   TENSORS_ON_SAME_DEVICE(permute, indices);
@@ -261,8 +262,7 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_data_cuda(
   // the data to permute over can be less or more with or without
   // repetitions
   const auto T = permute.numel();
-  const auto T_ = lengths.size(0);
-  const auto B = lengths.view({lengths.sizes()[0], -1}).sizes()[1];
+  const auto B = lengths.size(1);
 
   Tensor permuted_lengths;
   Tensor permuted_indices;

--- a/fbgemm_gpu/src/sparse_ops_gpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_gpu.cpp
@@ -164,7 +164,8 @@ std::vector<Tensor> stacked_jagged_2d_to_dense_gpu(
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
-  DISPATCH_TO_CUDA("permute_sparse_data", fbgemm_gpu::permute_sparse_data_cuda);
+  DISPATCH_TO_CUDA(
+      "permute_2D_sparse_data", fbgemm_gpu::permute_2D_sparse_data_cuda);
   DISPATCH_TO_CUDA(
       "block_bucketize_sparse_features",
       fbgemm_gpu::block_bucketize_sparse_features_cuda);

--- a/fbgemm_gpu/test/sparse_ops_test.py
+++ b/fbgemm_gpu/test/sparse_ops_test.py
@@ -142,7 +142,7 @@ class SparseOpsTest(unittest.TestCase):
             permuted_lengths_cpu,
             permuted_indices_cpu,
             permuted_weights_cpu,
-        ) = torch.ops.fbgemm.permute_sparse_data(permute, lengths, indices, weights)
+        ) = torch.ops.fbgemm.permute_2D_sparse_data(permute, lengths, indices, weights)
         (
             permuted_lengths_ref,
             permuted_indices_ref,
@@ -160,7 +160,7 @@ class SparseOpsTest(unittest.TestCase):
                 permuted_lengths_gpu,
                 permuted_indices_gpu,
                 permuted_weights_gpu,
-            ) = torch.ops.fbgemm.permute_sparse_data(
+            ) = torch.ops.fbgemm.permute_2D_sparse_data(
                 permute.cuda(),
                 lengths.cuda(),
                 indices.cuda(),
@@ -214,7 +214,7 @@ class SparseOpsTest(unittest.TestCase):
             permuted_lengths_cpu,
             permuted_indices_cpu,
             permuted_weights_cpu,
-        ) = torch.ops.fbgemm.permute_sparse_data(permute, lengths, indices, weights)
+        ) = torch.ops.fbgemm.permute_2D_sparse_data(permute, lengths, indices, weights)
         (
             permuted_lengths_ref,
             permuted_indices_ref,
@@ -232,75 +232,7 @@ class SparseOpsTest(unittest.TestCase):
                 permuted_lengths_gpu,
                 permuted_indices_gpu,
                 permuted_weights_gpu,
-            ) = torch.ops.fbgemm.permute_sparse_data(
-                permute.cuda(),
-                lengths.cuda(),
-                indices.cuda(),
-                weights.cuda() if has_weight else None,
-            )
-            torch.testing.assert_allclose(
-                permuted_indices_gpu.cpu(), permuted_indices_cpu
-            )
-            torch.testing.assert_allclose(
-                permuted_lengths_gpu.cpu(), permuted_lengths_cpu
-            )
-            if has_weight:
-                torch.testing.assert_allclose(
-                    permuted_weights_gpu.cpu(), permuted_weights_cpu
-                )
-            else:
-                assert permuted_weights_cpu is None
-
-    # pyre-ignore [56]: Invalid decoration, was not able to infer the type of argument
-    @given(
-        D=st.integers(min_value=5, max_value=20),
-        B=st.integers(min_value=1, max_value=20),
-        T=st.integers(min_value=1, max_value=20),
-        L=st.integers(min_value=2, max_value=20),
-        long_index=st.booleans(),
-        has_weight=st.booleans(),
-    )
-    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
-    def test_permute_indices_multi_dimension(
-        self, D: int, B: int, T: int, L: int, long_index: bool, has_weight: bool
-    ) -> None:
-        index_dtype = torch.int64 if long_index else torch.int32
-        lengths = torch.randint(low=1, high=L, size=(T, B, D)).type(index_dtype)
-        weights = torch.rand(lengths.sum().item()).float() if has_weight else None
-        indices = torch.randint(
-            low=1,
-            high=int(1e5),
-            # pyre-fixme[6]: Expected `Union[int, typing.Tuple[int, ...]]` for 3rd
-            #  param but got `Tuple[typing.Union[float, int]]`.
-            size=(lengths.sum().item(),),
-        ).type(index_dtype)
-        permute_list = list(range(T))
-        random.shuffle(permute_list)
-        permute = torch.IntTensor(permute_list)
-
-        (
-            permuted_lengths_cpu,
-            permuted_indices_cpu,
-            permuted_weights_cpu,
-        ) = torch.ops.fbgemm.permute_sparse_data(permute, lengths, indices, weights)
-        (
-            permuted_lengths_ref,
-            permuted_indices_ref,
-            permuted_weights_ref,
-        ) = self.permute_indices_ref_(lengths, indices, weights, permute.long())
-        torch.testing.assert_allclose(permuted_indices_cpu, permuted_indices_ref)
-        torch.testing.assert_allclose(permuted_lengths_cpu, permuted_lengths_ref)
-        if has_weight:
-            torch.testing.assert_allclose(permuted_weights_cpu, permuted_weights_ref)
-        else:
-            assert permuted_weights_cpu is None and permuted_weights_ref is None
-
-        if gpu_available:
-            (
-                permuted_lengths_gpu,
-                permuted_indices_gpu,
-                permuted_weights_gpu,
-            ) = torch.ops.fbgemm.permute_sparse_data(
+            ) = torch.ops.fbgemm.permute_2D_sparse_data(
                 permute.cuda(),
                 lengths.cuda(),
                 indices.cuda(),
@@ -339,7 +271,7 @@ class SparseOpsTest(unittest.TestCase):
             permuted_lengths_cpu,
             permuted_embeddings_cpu,
             _,
-        ) = torch.ops.fbgemm.permute_sparse_data(permute, lengths, embeddings, None)
+        ) = torch.ops.fbgemm.permute_2D_sparse_data(permute, lengths, embeddings, None)
         (
             permuted_lengths_ref,
             permuted_embeddings_ref,
@@ -353,7 +285,7 @@ class SparseOpsTest(unittest.TestCase):
                 permuted_lengths_gpu,
                 permuted_embeddings_gpu,
                 _,
-            ) = torch.ops.fbgemm.permute_sparse_data(
+            ) = torch.ops.fbgemm.permute_2D_sparse_data(
                 permute.cuda(),
                 lengths.cuda(),
                 embeddings.cuda(),


### PR DESCRIPTION
Summary: rename permute_sparse_data to permute_2D_sparse_data as it requires 'lengths' is a 2D tensor. Will add permute_1D_sparse_data in the follow-up diff.

Reviewed By: YazhiGao

Differential Revision: D34333459

