### PR TITLE
Add fbgemm CPU only build in GHA (#953)

### DIFF
--- a/.github/workflows/fbgemm_nightly_build_cpu.yml
+++ b/.github/workflows/fbgemm_nightly_build_cpu.yml
@@ -1,0 +1,158 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Push CPU Binary Nightly
+
+on:
+  # # For debugging, enable push/pull_request
+  # [push, pull_request]
+  # run every day at 10:45 AM
+  schedule:
+    - cron:  '45 10 * * *'
+  # or manually trigger it
+  workflow_dispatch:
+
+jobs:
+  # build, test, and upload to GHA on cpu hosts
+  build_test_upload:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+         - os: linux.2xlarge
+           python-version: 3.7
+           python-tag: "py37"
+           cuda-tag: "cpu"
+         - os: linux.2xlarge
+           python-version: 3.8
+           python-tag: "py38"
+           cuda-tag: "cpu"
+         - os: linux.2xlarge
+           python-version: 3.9
+           python-tag: "py39"
+           cuda-tag: "cpu"
+    steps:
+    # Checkout the repository to the GitHub Actions runner
+    - name: Check ldd --version
+      run: ldd --version
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    # Update references
+    - name: Git Sumbodule Update
+      run: |
+        cd fbgemm_gpu/
+        git submodule sync
+        git submodule update --init --recursive
+    - name: Update pip
+      run: |
+        sudo yum update -y
+        sudo yum -y install git python3-pip
+        sudo pip3 install --upgrade pip
+    - name: Setup conda
+      run: |
+        wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+        bash ~/miniconda.sh -b -p $HOME/miniconda
+    - name: Setup PATH with conda
+      run: |
+        echo "/home/ec2-user/miniconda/bin" >> $GITHUB_PATH
+        echo "CONDA=/home/ec2-user/miniconda" >> $GITHUB_PATH
+    - name: Create conda env
+      run: |
+        conda create --name build_binary python=${{ matrix.python-version }}
+        conda info
+    - name: check python version
+      run: |
+        conda run -n build_binary python --version
+    - name: Install gcc
+      shell: bash
+      run: |
+        sudo yum group install -y "Development Tools"
+    - name: setup Path
+      run: |
+        echo /usr/local/bin >> $GITHUB_PATH
+    - name: Install PyTorch
+      shell: bash
+      run: |
+        conda run -n build_binary python -m pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+    - name: Install Dependencies
+      shell: bash
+      run: |
+        cd fbgemm_gpu/
+        conda run -n build_binary python -m pip install -r requirements.txt
+    - name: Test Installation of dependencies
+      run: |
+        cd fbgemm_gpu/
+        conda run -n build_binary python -c "import torch.distributed"
+        echo "torch.distributed succeeded"
+        conda run -n build_binary python -c "import skbuild"
+        echo "skbuild succeeded"
+        conda run -n build_binary python -c "import numpy"
+        echo "numpy succeeded"
+    - name: Build FBGEMM_GPU Nightly
+      run: |
+        cd fbgemm_gpu/
+        rm -r dist || true
+        # buld cuda7.0;8.0 for v100/a100 arch:
+        # Couldn't build more cuda arch due to 100 MB binary size limit from
+        # pypi website.
+        # manylinux1_x86_64 is specified for pypi upload:
+        # distribute python extensions as wheels on Linux
+        conda run -n build_binary \
+          python setup.py bdist_wheel \
+          --package_name=fbgemm_gpu_nightly-cpu \
+          --python-tag=${{ matrix.python-tag }} \
+          --cpu_only \
+          --plat-name=manylinux1_x86_64
+    - name: Upload wheel as GHA artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: fbgemm_gpu_nightly_cpu_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
+        path: fbgemm_gpu/dist/fbgemm_gpu_nightly_cpu-*.whl
+
+    - name: Install Dependencies
+      shell: bash
+      run: |
+        cd fbgemm_gpu/
+        conda run -n build_binary python -m pip install -r requirements.txt
+    - name: Test Installation of dependencies
+      run: |
+        cd fbgemm_gpu/
+        conda run -n build_binary python -c "import torch.distributed"
+        echo "torch.distributed succeeded"
+        conda run -n build_binary python -c "import skbuild"
+        echo "skbuild succeeded"
+        conda run -n build_binary python -c "import numpy"
+        echo "numpy succeeded"
+    - name: Install FBGEMM_GPU Nightly (CPU version)
+      run: |
+        conda run -n build_binary \
+          python -m pip install fbgemm_gpu/dist/fbgemm_gpu_nightly_cpu-*.whl
+    - name: Test fbgemm_gpu installation
+      shell: bash
+      run: |
+        conda run -n build_binary \
+          python -c "import fbgemm_gpu"
+    - name: Test with pytest
+      # remove this line when we fixed all the unit tests
+      continue-on-error: true
+      run: |
+        conda run -n build_binary \
+          python -m pip install pytest
+        # The tests with single CPU core on a less powerful testing GPU in GHA
+        # can take 5 hours.
+        timeout 600s conda run -n build_binary \
+          python -m pytest -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors
+    # Push to Pypi
+    - name: Push FBGEMM_GPU Binary to PYPI
+      env:
+        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        conda run -n build_binary python -m pip install twine
+        # Official PYPI website
+        conda run -n build_binary \
+          python -m twine upload \
+            --username __token__ \
+            --password "$PYPI_TOKEN" \
+            fbgemm_gpu/dist/fbgemm_gpu_nightly_cpu-*.whl

--- a/.github/workflows/fbgemm_release_build.yml
+++ b/.github/workflows/fbgemm_release_build.yml
@@ -1,16 +1,17 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Push Binary Nightly
+name: Push Binary Release
 
 on:
-  # For debugging, enable push/pull_request
+  # # For debugging, enable push/pull_request
+  [push]
   # [push, pull_request]
-  # run every day at 10:45 AM
-  schedule:
-    - cron:  '45 10 * * *'
-  # or manually trigger it
-  workflow_dispatch:
+  # # run every day at 10:45 AM
+  # schedule:
+  #   - cron:  '45 10 * * *'
+  # # or manually trigger it
+  # workflow_dispatch:
 
 jobs:
   # build on cpu hosts and upload to GHA
@@ -85,7 +86,9 @@ jobs:
     - name: Install PyTorch
       shell: bash
       run: |
-        conda run -n build_binary python -m pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
+        conda run -n build_binary \
+          python -m pip install --pre torch -f https://download.pytorch.org/whl/test/cu113/torch_test.html
+
     - name: Install Dependencies
       shell: bash
       run: |
@@ -102,7 +105,7 @@ jobs:
         echo "numpy succeeded"
     # for the conda run with quotes, we have to use "\" and double quotes
     # here is the issue: https://github.com/conda/conda/issues/10972
-    - name: Build FBGEMM_GPU Nightly
+    - name: Build FBGEMM_GPU Release
       run: |
         cd fbgemm_gpu/
         rm -r dist || true
@@ -113,15 +116,15 @@ jobs:
         # distribute python extensions as wheels on Linux
         conda run -n build_binary \
           python setup.py bdist_wheel \
-          --package_name=fbgemm_gpu_nightly \
+          --package_name=fbgemm_gpu \
           --python-tag=${{ matrix.python-tag }} \
           -DTORCH_CUDA_ARCH_LIST="'7.0;8.0'" \
           --plat-name=manylinux1_x86_64
     - name: Upload wheel as GHA artifact
       uses: actions/upload-artifact@v2
       with:
-        name: fbgemm_gpu_nightly_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
-        path: fbgemm_gpu/dist/fbgemm_gpu_nightly-*.whl
+        name: fbgemm_gpu_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
+        path: fbgemm_gpu/dist/fbgemm_gpu-*.whl
 
   # download from GHA, test on gpu and push to pypi
   test_on_gpu:
@@ -217,12 +220,12 @@ jobs:
       shell: bash
       run: |
         conda run -n build_binary \
-          python -m pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
+          python -m pip install --pre torch -f https://download.pytorch.org/whl/test/cu113/torch_test.html
     # download wheel from GHA
     - name: Download wheel
       uses: actions/download-artifact@v2
       with:
-        name: fbgemm_gpu_nightly_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
+        name: fbgemm_gpu_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
     - name: Display structure of downloaded files
       run: ls -R
     - name: Install Dependencies
@@ -239,7 +242,7 @@ jobs:
         echo "skbuild succeeded"
         conda run -n build_binary python -c "import numpy"
         echo "numpy succeeded"
-    - name: Install FBGEMM_GPU Nightly
+    - name: Install FBGEMM_GPU Release
       run: |
         rm -r dist || true
         conda run -n build_binary \
@@ -270,4 +273,4 @@ jobs:
           python -m twine upload \
             --username __token__ \
             --password "$PYPI_TOKEN" \
-            fbgemm_gpu_nightly-*.whl
+            fbgemm_gpu-*.whl

--- a/.github/workflows/fbgemm_release_build_cpu.yml
+++ b/.github/workflows/fbgemm_release_build_cpu.yml
@@ -1,0 +1,161 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Push CPU Binary Release
+
+on:
+  # # For debugging, enable push/pull_request
+  [push]
+  # [push, pull_request]
+  # # run every day at 10:45 AM
+  # schedule:
+  #   - cron:  '45 10 * * *'
+  # # or manually trigger it
+  # workflow_dispatch:
+
+jobs:
+  # build, test, and upload to GHA on cpu hosts
+  build_test_upload:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+         - os: linux.2xlarge
+           python-version: 3.7
+           python-tag: "py37"
+           cuda-tag: "cpu"
+         - os: linux.2xlarge
+           python-version: 3.8
+           python-tag: "py38"
+           cuda-tag: "cpu"
+         - os: linux.2xlarge
+           python-version: 3.9
+           python-tag: "py39"
+           cuda-tag: "cpu"
+    steps:
+    # Checkout the repository to the GitHub Actions runner
+    - name: Check ldd --version
+      run: ldd --version
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    # Update references
+    - name: Git Sumbodule Update
+      run: |
+        cd fbgemm_gpu/
+        git submodule sync
+        git submodule update --init --recursive
+    - name: Update pip
+      run: |
+        sudo yum update -y
+        sudo yum -y install git python3-pip
+        sudo pip3 install --upgrade pip
+    - name: Setup conda
+      run: |
+        wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+        bash ~/miniconda.sh -b -p $HOME/miniconda
+    - name: Setup PATH with conda
+      run: |
+        echo "/home/ec2-user/miniconda/bin" >> $GITHUB_PATH
+        echo "CONDA=/home/ec2-user/miniconda" >> $GITHUB_PATH
+    - name: Create conda env
+      run: |
+        conda create --name build_binary python=${{ matrix.python-version }}
+        conda info
+    - name: check python version
+      run: |
+        conda run -n build_binary python --version
+    - name: Install gcc
+      shell: bash
+      run: |
+        sudo yum group install -y "Development Tools"
+    - name: setup Path
+      run: |
+        echo /usr/local/bin >> $GITHUB_PATH
+    - name: Install PyTorch
+      shell: bash
+      run: |
+        conda run -n build_binary \
+          python -m pip install --pre torch -f https://download.pytorch.org/whl/test/cpu/torch_test.html
+
+    - name: Install Dependencies
+      shell: bash
+      run: |
+        cd fbgemm_gpu/
+        conda run -n build_binary python -m pip install -r requirements.txt
+    - name: Test Installation of dependencies
+      run: |
+        cd fbgemm_gpu/
+        conda run -n build_binary python -c "import torch.distributed"
+        echo "torch.distributed succeeded"
+        conda run -n build_binary python -c "import skbuild"
+        echo "skbuild succeeded"
+        conda run -n build_binary python -c "import numpy"
+        echo "numpy succeeded"
+    - name: Build FBGEMM_GPU Release
+      run: |
+        cd fbgemm_gpu/
+        rm -r dist || true
+        # buld cuda7.0;8.0 for v100/a100 arch:
+        # Couldn't build more cuda arch due to 100 MB binary size limit from
+        # pypi website.
+        # manylinux1_x86_64 is specified for pypi upload:
+        # distribute python extensions as wheels on Linux
+        conda run -n build_binary \
+          python setup.py bdist_wheel \
+          --package_name=fbgemm_gpu-cpu \
+          --python-tag=${{ matrix.python-tag }} \
+          --cpu_only \
+          --plat-name=manylinux1_x86_64
+    - name: Upload wheel as GHA artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: fbgemm_gpu_cpu_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
+        path: fbgemm_gpu/dist/fbgemm_gpu_cpu-*.whl
+
+    - name: Install Dependencies
+      shell: bash
+      run: |
+        cd fbgemm_gpu/
+        conda run -n build_binary python -m pip install -r requirements.txt
+    - name: Test Installation of dependencies
+      run: |
+        cd fbgemm_gpu/
+        conda run -n build_binary python -c "import torch.distributed"
+        echo "torch.distributed succeeded"
+        conda run -n build_binary python -c "import skbuild"
+        echo "skbuild succeeded"
+        conda run -n build_binary python -c "import numpy"
+        echo "numpy succeeded"
+    - name: Install FBGEMM_GPU Release (CPU version)
+      run: |
+        conda run -n build_binary \
+          python -m pip install fbgemm_gpu/dist/fbgemm_gpu_cpu-*.whl
+    - name: Test fbgemm_gpu installation
+      shell: bash
+      run: |
+        conda run -n build_binary \
+          python -c "import fbgemm_gpu"
+    - name: Test with pytest
+      # remove this line when we fixed all the unit tests
+      continue-on-error: true
+      run: |
+        conda run -n build_binary \
+          python -m pip install pytest
+        # The tests with single CPU core on a less powerful testing GPU in GHA
+        # can take 5 hours.
+        timeout 600s conda run -n build_binary \
+          python -m pytest -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors
+    # Push to Pypi
+    - name: Push FBGEMM_GPU Binary to PYPI
+      env:
+        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        conda run -n build_binary python -m pip install twine
+        # Official PYPI website
+        conda run -n build_binary \
+          python -m twine upload \
+            --username __token__ \
+            --password "$PYPI_TOKEN" \
+            fbgemm_gpu/dist/fbgemm_gpu_cpu-*.whl

--- a/fbgemm_gpu/README.md
+++ b/fbgemm_gpu/README.md
@@ -2,6 +2,9 @@
 
 [![FBGEMMCI](https://github.com/pytorch/FBGEMM/actions/workflows/fbgemmci.yml/badge.svg)](https://github.com/pytorch/FBGEMM/actions/workflows/fbgemmci.yml)
 [![Nightly Build](https://github.com/pytorch/FBGEMM/actions/workflows/fbgemm_nightly_build.yml/badge.svg)](https://github.com/pytorch/FBGEMM/actions/workflows/fbgemm_nightly_build.yml)
+[![Nightly Build CPU](https://github.com/pytorch/FBGEMM/actions/workflows/fbgemm_nightly_build_cpu.yml/badge.svg)](https://github.com/pytorch/FBGEMM/actions/workflows/fbgemm_nightly_build_cpu.yml)
+[![Release Build](https://github.com/pytorch/FBGEMM/actions/workflows/fbgemm_release_build.yml/badge.svg)](https://github.com/pytorch/FBGEMM/actions/workflows/fbgemm_release_build.yml)
+[![Release Build CPU](https://github.com/pytorch/FBGEMM/actions/workflows/fbgemm_release_build_cpu.yml/badge.svg)](https://github.com/pytorch/FBGEMM/actions/workflows/fbgemm_release_build_cpu.yml)
 
 FBGEMM_GPU (FBGEMM GPU kernel library) is a collection of
 high-performance CUDA GPU operator library for GPU training and inference.

--- a/fbgemm_gpu/version.py
+++ b/fbgemm_gpu/version.py
@@ -14,4 +14,4 @@
 # 0.1.0bN  # Beta release
 # 0.1.0rcN  # Release Candidate
 # 0.1.0  # Final release
-__version__ = "0.1.0"
+__version__ = "0.0.1"


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/FBGEMM/pull/953

- Add the CPU only build in GHA
- Add the release version of GPU build in GHA
- Add the release version of CPU build in GHA

Reviewed By: colin2328

Differential Revision: D34509897

fbshipit-source-id: 52a0fdd5baa1545c793da981e055b9618426d817