### PR TITLE
fixed https://github.com/pytorch/FBGEMM/issues/896 issue

### DIFF
--- a/bench/GEMMsBenchmark.cc
+++ b/bench/GEMMsBenchmark.cc
@@ -133,7 +133,7 @@ void performance_test() {
          << setw(5) << fixed << setw(5) << setprecision(1) << nops / ttot
          << endl;
 
-    for (auto i = 0; i < Cfp32_mkl.size(); ++i) {
+    for (size_t i = 0; i < Cfp32_mkl.size(); ++i) {
       Cint32_mkl[i] = (int32_t)Cfp32_mkl[i];
     }
 #endif


### PR DESCRIPTION
fixed make install failing 

```
/myworkspace/FAMBench/FBGEMM_local/bench/GEMMsBenchmark.cc: In function ‘void performance_test()’:
/myworkspace/FAMBench/FBGEMM_local/bench/GEMMsBenchmark.cc:136:24: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
     for (auto i = 0; i < Cfp32_mkl.size(); ++i) {
                      ~~^~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

https://github.com/pytorch/FBGEMM/issues/896 issue