### PR TITLE
fix grid-stride for permute_1d_sparse_data

### DIFF
--- a/fbgemm_gpu/src/sparse_ops.cu
+++ b/fbgemm_gpu/src/sparse_ops.cu
@@ -469,7 +469,7 @@ __global__ void permute_1D_data_kernel(
     indices_t* __restrict__ permuted_indices,
     weights_t* __restrict__ permuted_weights) {
   int32_t b_t_start = blockIdx.x * blockDim.y + threadIdx.y;
-  const int stride = blockDim.y;
+  const int stride = gridDim.x * blockDim.y;
   for (int b_t = b_t_start; b_t < permuted_lengths_size; b_t += stride) {
     offsets_t output_start = output_offsets[b_t];
     offsets_t segment_length;


### PR DESCRIPTION
Summary: the current grid-stride for permute_1D_sparse_data is wrong, the loop is doing more than once permute and introduce race condition. fix the grid stride to decrease runtime.

Differential Revision: D34712719

