### PR TITLE
Remove redundant pad_sequence_embeddings ops

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -279,6 +279,32 @@ at::Tensor jagged_1d_to_dense_gpu(
     int64_t max_L,
     int64_t padding_value);
 
+at::Tensor jagged_1d_to_dense_cpu(
+    at::Tensor values,
+    at::Tensor offsets,
+    int64_t max_L,
+    int64_t padding_value);
+
+at::Tensor jagged_2d_to_dense_forward_cpu(
+    at::Tensor values,
+    at::Tensor offsets,
+    int64_t max_L);
+
+at::Tensor jagged_2d_to_dense_gpu(
+    at::Tensor values,
+    at::Tensor offsets,
+    int64_t max_sequence_length);
+
+at::Tensor jagged_2d_to_dense_gpu_forward(
+    at::Tensor values,
+    at::Tensor offsets,
+    int64_t max_sequence_length);
+
+at::Tensor jagged_2d_to_dense_gpu_backward(
+    at::Tensor grad_output,
+    at::Tensor offsets,
+    int64_t max_lengths);
+
 std::vector<at::Tensor> stacked_jagged_1d_to_dense_gpu(
     at::Tensor values,
     at::Tensor lengths,

--- a/fbgemm_gpu/src/sparse_ops_gpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_gpu.cpp
@@ -67,7 +67,7 @@ class StackedJagged2DToDenseGPUOp
       Tensor lengths,
       const std::vector<int64_t>& offset_per_key,
       const std::vector<int64_t>& max_lengths_per_key) {
-    int32_t total_L = values.size(0);
+    int64_t total_L = values.size(0);
     ctx->saved_data["B"] = lengths.size(1);
     ctx->saved_data["D"] = values.size(1);
     ctx->saved_data["total_L"] = total_L;
@@ -152,6 +152,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
       "batched_unary_embeddings",
       fbgemm_gpu::lookup_batched_unary_embedding_function);
   DISPATCH_TO_CUDA("jagged_1d_to_dense", fbgemm_gpu::jagged_1d_to_dense_gpu);
+  DISPATCH_TO_CUDA("jagged_2d_to_dense", fbgemm_gpu::jagged_2d_to_dense_gpu);
   DISPATCH_TO_CUDA(
       "stacked_jagged_1d_to_dense", fbgemm_gpu::stacked_jagged_1d_to_dense_gpu);
   DISPATCH_TO_CUDA(


### PR DESCRIPTION
Summary: Support more jagged_2d_to_dense ops in fbgemm_gpu.

Differential Revision: D34689010

