### PR TITLE
Open-source and benchmark FP8 conversion kernels

### DIFF
--- a/fbgemm_gpu/bench/benchmark_torch_function.py
+++ b/fbgemm_gpu/bench/benchmark_torch_function.py
@@ -1,0 +1,57 @@
+import time
+from typing import Callable, Tuple, Any
+
+import torch
+from torch import Tensor
+
+
+def benchmark_torch_function_with_output(
+    flush_gpu_cache_size_mb: int,
+    func: Callable,
+    *args: Any,
+) -> Tuple[float, Tensor]:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        # Flush the cache
+        if flush_gpu_cache_size_mb:
+            _ = torch.rand(
+                flush_gpu_cache_size_mb * 1024 * 1024 // 4, dtype=torch.float
+            )
+            torch.cuda.synchronize()
+        start_event.record()
+        # Benchmark code
+        output = func(*args)
+        # Accumulate the time for iters iteration
+        end_event.record()
+        torch.cuda.synchronize()
+        elapsed_time = start_event.elapsed_time(end_event) * 1.0e-3
+    else:
+        start_time = time.time()
+        output = func(*args)
+        elapsed_time = time.time() - start_time
+    return float(elapsed_time), output
+
+
+def benchmark_torch_function(
+    flush_gpu_cache_size_mb: int,
+    iters: int,
+    warmup_runs: int,
+    func: Callable,
+    *args: Any,
+) -> float:
+    torch.cuda.synchronize()
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    # Flush the cache
+    if flush_gpu_cache_size_mb:
+        _ = torch.rand(flush_gpu_cache_size_mb * 1024 * 1024 // 4, dtype=torch.float)
+        torch.cuda.synchronize()
+    for i in range(iters):
+        if i == warmup_runs:
+            start_event.record()
+        func(*args)
+    end_event.record()
+    torch.cuda.synchronize()
+    return (start_event.elapsed_time(end_event) * 1.0e-3) / iters

--- a/fbgemm_gpu/bench/quantize_ops_benchmark.py
+++ b/fbgemm_gpu/bench/quantize_ops_benchmark.py
@@ -5,12 +5,14 @@
 
 import logging
 import random
-import time
-from typing import Callable, Tuple
 
 import click
+import hypothesis.strategies as st
 import torch
-from torch import Tensor
+from bench.benchmark_torch_function import (
+    benchmark_torch_function,
+)
+from hypothesis import given, settings
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -22,66 +24,6 @@ except Exception:
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
 
 
-def benchmark_torch_function(
-    func: Callable[[Tensor], Tensor],
-    input: Tensor,
-    flush_gpu_cache_size_mb: int,
-) -> Tuple[float, Tensor]:
-    if torch.cuda.is_available():
-        torch.cuda.synchronize()
-        start_event = torch.cuda.Event(enable_timing=True)
-        end_event = torch.cuda.Event(enable_timing=True)
-        # Flush the cache
-        if flush_gpu_cache_size_mb:
-            _ = torch.rand(
-                flush_gpu_cache_size_mb * 1024 * 1024 // 4, dtype=torch.float
-            )
-            torch.cuda.synchronize()
-        start_event.record()
-        # Benchmark code
-        output = func(input)
-        # Accumulate the time for iters iteration
-        end_event.record()
-        torch.cuda.synchronize()
-        elapsed_time = start_event.elapsed_time(end_event) * 1.0e-3
-    else:
-        start_time = time.time()
-        output = func(input)
-        elapsed_time = time.time() - start_time
-    return float(elapsed_time), output
-
-
-def benchmark_torch_mixdim_function(
-    func: Callable[[Tensor, Tensor, int], Tensor],
-    input: Tensor,
-    D_offsets: Tensor,
-    output_dtype: int,
-    flush_gpu_cache_size_mb: int,
-) -> Tuple[float, Tensor]:
-    if torch.cuda.is_available():
-        torch.cuda.synchronize()
-        start_event = torch.cuda.Event(enable_timing=True)
-        end_event = torch.cuda.Event(enable_timing=True)
-        # Flush the cache
-        if flush_gpu_cache_size_mb:
-            _ = torch.rand(
-                flush_gpu_cache_size_mb * 1024 * 1024 // 4, dtype=torch.float
-            )
-            torch.cuda.synchronize()
-        start_event.record()
-        # Benchmark code
-        output = func(input, D_offsets, output_dtype)
-        # Accumulate the time for iters iteration
-        end_event.record()
-        torch.cuda.synchronize()
-        elapsed_time = start_event.elapsed_time(end_event) * 1.0e-3
-    else:
-        start_time = time.time()
-        output = func(input, D_offsets, output_dtype)
-        elapsed_time = time.time() - start_time
-    return float(elapsed_time), output
-
-
 @click.group()
 def cli() -> None:
     pass
@@ -90,9 +32,13 @@ def cli() -> None:
 @cli.command()
 @click.option("--flush-gpu-cache-size-mb", default=0)
 @click.option("--iters", default=100)
-@click.option("--num-columns", default=512)
-@click.option("--num-rows", default=512)
 @click.option("--warmup-runs", default=2)
+@settings(max_examples=10, deadline=None)
+# pyre-ignore
+@given(
+    num_columns=st.sampled_from([2 ** n for n in range(4, 10)]),
+    num_rows=st.sampled_from([2 ** n for n in range(4, 10)]),
+)
 def bench(
     flush_gpu_cache_size_mb: int,
     iters: int,
@@ -101,78 +47,118 @@ def bench(
     warmup_runs: int,
 ) -> None:
 
-    total_time = {
-        "8bit_quant": 0.0,
-        "4bit_quant": 0.0,
-        "2bit_quant": 0.0,
-        "8bit_dequant": 0.0,
-        "4bit_dequant": 0.0,
-        "2bit_dequant": 0.0,
+    average_time = {
+        "int8_quant": 0.0,
+        "int4_quant": 0.0,
+        "int2_quant": 0.0,
+        "fp8_143_quant": 0.0,
+        "fp8_152_quant": 0.0,
+        "int8_dequant": 0.0,
+        "int4_dequant": 0.0,
+        "int2_dequant": 0.0,
+        "fp8_143_dequant": 0.0,
+        "fp8_152_dequant": 0.0,
     }
 
     input_data = torch.rand(num_rows, num_columns).float()
+    quant_data_8bit = torch.ops.fbgemm.FloatToFused8BitRowwiseQuantized(input_data)
+    quant_data_4bit = torch.ops.fbgemm.FloatToFusedNBitRowwiseQuantizedSBHalf(
+        input_data, 4
+    )
+    quant_data_2bit = torch.ops.fbgemm.FloatToFusedNBitRowwiseQuantizedSBHalf(
+        input_data, 2
+    )
+    quant_data_fp8_143 = torch.ops.fbgemm.FloatToHFP8Quantized(
+        input_data.contiguous(), 4, 3, 14, 2 ** (1 - 14 - 3), (2 - 2 ** (-3))
+    )
+    quant_data_fp8_152 = torch.ops.fbgemm.FloatToHFP8Quantized(
+        input_data, 5, 2, 30, 2 ** (1 - 30 - 2), (2 - 2 ** (-2))
+    )
+
     if torch.cuda.is_available():
         input_data = input_data.cuda()
-    for step in range(iters + warmup_runs):
-        time, quant_data_8bit = benchmark_torch_function(
-            torch.ops.fbgemm.FloatToFused8BitRowwiseQuantized,
-            input_data,
-            flush_gpu_cache_size_mb,
-        )
-        if step >= warmup_runs:
-            total_time["8bit_quant"] += time
 
-        time, quant_data_4bit = benchmark_torch_function(
-            lambda input: torch.ops.fbgemm.FloatToFusedNBitRowwiseQuantizedSBHalf(
-                input, 4
-            ),
-            input_data,
-            flush_gpu_cache_size_mb,
-        )
-        if step >= warmup_runs:
-            total_time["4bit_quant"] += time
+    average_time["int8_quant"] = benchmark_torch_function(
+        flush_gpu_cache_size_mb,
+        iters + warmup_runs,
+        warmup_runs,
+        torch.ops.fbgemm.FloatToFused8BitRowwiseQuantized,
+        input_data,
+    )
+    average_time["int4_quant"] = benchmark_torch_function(
+        flush_gpu_cache_size_mb,
+        iters + warmup_runs,
+        warmup_runs,
+        lambda input: torch.ops.fbgemm.FloatToFusedNBitRowwiseQuantizedSBHalf(input, 4),
+        input_data,
+    )
 
-        time, quant_data_2bit = benchmark_torch_function(
-            lambda input: torch.ops.fbgemm.FloatToFusedNBitRowwiseQuantizedSBHalf(
-                input, 2
-            ),
-            input_data,
-            flush_gpu_cache_size_mb,
-        )
-        if step >= warmup_runs:
-            total_time["2bit_quant"] += time
+    average_time["int2_quant"] = benchmark_torch_function(
+        flush_gpu_cache_size_mb,
+        iters + warmup_runs,
+        warmup_runs,
+        lambda input: torch.ops.fbgemm.FloatToFusedNBitRowwiseQuantizedSBHalf(input, 2),
+        input_data,
+    )
+    average_time["fp8_143_quant"] = benchmark_torch_function(
+        flush_gpu_cache_size_mb,
+        iters + warmup_runs,
+        warmup_runs,
+        lambda input: torch.ops.fbgemm.FloatToHFP8Quantized(
+            input.contiguous(), 4, 3, 14, 2 ** (1 - 14 - 3), (2 - 2 ** (-3))
+        ),
+        input_data,
+    )
+    average_time["fp8_152_quant"] = benchmark_torch_function(
+        flush_gpu_cache_size_mb,
+        iters + warmup_runs,
+        warmup_runs,
+        lambda input: torch.ops.fbgemm.FloatToHFP8Quantized(
+            input.contiguous(), 5, 2, 30, 2 ** (1 - 30 - 2), (2 - 2 ** (-2))
+        ),
+        input_data,
+    )
 
-        time, _ = benchmark_torch_function(
-            torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloat,
-            quant_data_8bit,
-            flush_gpu_cache_size_mb,
-        )
-        if step >= warmup_runs:
-            total_time["8bit_dequant"] += time
+    average_time["int8_dequant"] = benchmark_torch_function(
+        flush_gpu_cache_size_mb,
+        iters + warmup_runs,
+        warmup_runs,
+        torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloat,
+        quant_data_8bit,
+    )
 
-        time, _ = benchmark_torch_function(
-            lambda input: torch.ops.fbgemm.FusedNBitRowwiseQuantizedSBHalfToFloat(
-                input, 4
-            ),
-            quant_data_4bit,
-            flush_gpu_cache_size_mb,
-        )
-        if step >= warmup_runs:
-            total_time["4bit_dequant"] += time
-
-        time, _ = benchmark_torch_function(
-            lambda input: torch.ops.fbgemm.FusedNBitRowwiseQuantizedSBHalfToFloat(
-                input, 2
-            ),
-            quant_data_2bit,
-            flush_gpu_cache_size_mb,
-        )
-        if step >= warmup_runs:
-            total_time["2bit_dequant"] += time
+    average_time["int4_dequant"] = benchmark_torch_function(
+        flush_gpu_cache_size_mb,
+        iters + warmup_runs,
+        warmup_runs,
+        lambda input: torch.ops.fbgemm.FusedNBitRowwiseQuantizedSBHalfToFloat(input, 4),
+        quant_data_4bit,
+    )
+    average_time["int2_dequant"] = benchmark_torch_function(
+        flush_gpu_cache_size_mb,
+        iters + warmup_runs,
+        warmup_runs,
+        lambda input: torch.ops.fbgemm.FusedNBitRowwiseQuantizedSBHalfToFloat(input, 2),
+        quant_data_2bit,
+    )
+    average_time["fp8_143_dequant"] = benchmark_torch_function(
+        flush_gpu_cache_size_mb,
+        iters + warmup_runs,
+        warmup_runs,
+        lambda input: torch.ops.fbgemm.HFP8QuantizedToFloat(input, 4, 3, 14),
+        quant_data_fp8_143,
+    )
+    average_time["fp8_152_dequant"] = benchmark_torch_function(
+        flush_gpu_cache_size_mb,
+        iters + warmup_runs,
+        warmup_runs,
+        lambda input: torch.ops.fbgemm.HFP8QuantizedToFloat(input, 5, 2, 30),
+        quant_data_fp8_152,
+    )
 
     logging.info(f"-------------- ncols={num_columns}, nrows={num_rows}-------------")
-    for k, t_time in total_time.items():
-        logging.info(f"{k} time per iter: {t_time / iters * 1.0e6:.0f}us")
+    for k, t_time in average_time.items():
+        logging.info(f"{k} time per iter: {t_time * 1.0e6:.0f}us")
 
 
 @cli.command()
@@ -210,42 +196,34 @@ def mixdim(
         torch.ops.fbgemm.FloatToFused8BitRowwiseQuantized(t) for t in input_refs
     ]
     input_data = torch.concat(input_refs_int8, dim=1).contiguous()
-    total_time_mixed_dim_fp32 = 0.0
-    total_time_mixed_dim_fp16 = 0.0
-    total_time_single_dim = 0.0
 
-    for step in range(iters + warmup_runs):
-        time, _ = benchmark_torch_mixdim_function(
-            torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloatMixedDim,
-            input_data,
-            D_offsets,
-            0,
-            0,
-        )  # output is FP32
-        if step >= warmup_runs:
-            total_time_mixed_dim_fp32 += time
+    average_time_mixed_dim_fp32 = benchmark_torch_function(
+        flush_gpu_cache_size_mb,
+        iters + warmup_runs,
+        warmup_runs,
+        torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloatMixedDim,
+        input_data,
+        D_offsets,
+        0,
+    )  # output is FP32
 
-        time, _ = benchmark_torch_mixdim_function(
-            torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloatMixedDim,
-            input_data,
-            D_offsets,
-            1,
-            0,
-        )  # output is FP16
-        if step >= warmup_runs:
-            total_time_mixed_dim_fp16 += time
+    average_time_mixed_dim_fp16 = benchmark_torch_function(
+        flush_gpu_cache_size_mb,
+        iters + warmup_runs,
+        warmup_runs,
+        torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloatMixedDim,
+        input_data,
+        D_offsets,
+        1,
+    )  # output is FP16
 
-        time, _ = benchmark_torch_function(
-            torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloat,
-            input_data,
-            0,
-        )  # output is FP32
-        if step >= warmup_runs:
-            total_time_single_dim += time
-
-    average_time_mixed_dim_fp32 = total_time_mixed_dim_fp32 / iters
-    average_time_mixed_dim_fp16 = total_time_mixed_dim_fp16 / iters
-    average_time_single_dim = total_time_single_dim / iters
+    average_time_single_dim = benchmark_torch_function(
+        flush_gpu_cache_size_mb,
+        iters + warmup_runs,
+        warmup_runs,
+        torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloat,
+        input_data,
+    )  # output is FP32
 
     print(
         f"Input tensor batch_size: {batch_size}, num_tables: {num_tables}, tensor_size: {input_data.numel() / (1 << 30)} GB, average table dimension: {sum(table_dims) * 1.0/num_tables}."

--- a/fbgemm_gpu/include/fbgemm_gpu/quantize_ops_gpu.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/quantize_ops_gpu.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ATen/ATen.h>
+#include <ATen/native/TensorIterator.h>
+
+namespace fbgemm_gpu {
+at::Tensor _float_to_hfp8_gpu(
+    const at::Tensor& input,
+    const int64_t ebits,
+    const int64_t mbits,
+    const int64_t bias,
+    const double min_pos,
+    const double max_pos);
+
+at::Tensor _hfp8_to_float_gpu(
+    const at::Tensor& input,
+    const int64_t ebits,
+    const int64_t mbits,
+    const int64_t bias);
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/include/fbgemm_gpu/quantize_ops_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/quantize_ops_utils.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ATen/ATen.h>
+namespace fbgemm_gpu {
+typedef union {
+  uint32_t I;
+  float F;
+} fint32;
+
+// TODO: add a flag later to control whether underflow
+// flushes to 0 or clips to smallest denorm number.
+inline C10_HOST_DEVICE uint8_t
+float_to_hfp8(float val_fp, int ebits, int mbits, int bias, float max_pos) {
+  fint32 val_out, bouncer, smallest_normal;
+
+  val_out.F = val_fp;
+  uint32_t sign_bit = val_out.I & 0x80000000;
+  val_out.I = val_out.I & 0x7FFFFFFF;
+  val_out.F = fminf(val_out.F, max_pos);
+
+  smallest_normal.I = (127 - bias + 1)
+      << 23; // smallest hfp8 normal number in FP32
+  // I don't know if the input "min_pos" is the smallest denormalized number
+  // or the smallest normalized number. The test below needs to be done with
+  // the smallest normal number, which is the numerical value 2^(1-bias)
+
+  // The conversion for denormalized values are slightly different. HFP8 is so
+  // low precision that gradual underflow is probably crucial
+  if (val_out.F >= smallest_normal.F) {
+    // Use round to nearest even. We make use of the standard rounding mechanism
+    // in FP32 rather than rounding the mantissa and handling tie-to-even and
+    // incrementing exponent We want to round of 23-mbits of the FP32 value
+    // val_in This can be done by adding a power of 2 exactly 23-mbits larger
+    // than the exponent of val_in This forces val_in to be moved to the right
+    // and rounding exact at the location corresponding to having mbits of
+    // explicit mantissa left
+    bouncer.I = (val_out.I & 0xFF800000) + ((23 - mbits) << 23);
+    val_out.F = (bouncer.F + val_out.F) - bouncer.F;
+    // adding the bouncer rounds off bits, and subtracting bouncer
+    // leaves the desired value, albeit in FP32 encoding
+    // All we need is to change the exponent encoding to using "bias"
+    val_out.I = uint32_t(val_out.I - ((127 - bias) << 23)) << (8 - ebits);
+    val_out.I =
+        ((val_out.I | sign_bit) >>
+         24); // the 8 lsbs is the desired HFP8 encoding
+
+  } else {
+    // When the value is in the denormal range, IEEE numbers essentially becomes
+    // a fixed point number. The lsb is the smallest non-zero number
+    // 2^(1-bias-mbits) Hence, we define the bouncer so that its lsb is this
+    // smallest non-zero number Adding the input to this bouncer forces rounding
+    // to occur appropriately Also, in this situation, after adding the bouncer,
+    // the 8 least significant bits of the sum is already the HFP8 encoding of
+    // the desired result. Just need to restore the sign bit
+    bouncer.I = (127 + (23 + (1 - bias - mbits))) << 23;
+    val_out.F = bouncer.F + val_out.F;
+    val_out.I = val_out.I | (sign_bit >> 24);
+    ;
+  }
+
+  uint8_t bfp8_val = val_out.I; // get the 8 lsbs
+  return bfp8_val;
+}
+
+inline C10_HOST_DEVICE float
+hfp8_to_float(uint8_t hfp8_val, int ebits, int bias) {
+  fint32 val_out, sign, multiplier;
+
+  sign.I = (hfp8_val & 0x80) << 24;
+  val_out.I = (hfp8_val & 0x7F) << (24 - (8 - ebits));
+  // so that the mantissa bits start at the mantissa bit positions of FP32
+  // encoding
+
+  // Let the hfp8 mantissa bits correspond to the value frac, 0 <= frac < 1
+  // So if the hfp8 value is a normal number, it's value is 2^e x (1+frac)
+  // where e is its (true, unbiased) exponent
+  // If the hfp8 value is denormal, the value is 2^(1-bias) x frac
+
+  // However, the bit pattern in the 8-bit exponent field of val_out.F
+  // is bias+e when hfp8 is normal, and 0 when hfp8 is subnormal.
+  // So, as an FP32 value, when hfp8 is normal, val_out.F represents the value
+  // of 2^(bias+e-127) * (1+frac)
+  // And when hfp8 is subnormal, val_out.F is also subnormal, and represents the
+  // value of 2^(-126) * frac In either case, val_out.F corresponds to
+  // 2^(bias-127) * (value of hfp8 input) Thus, if we multiply val_out.F by
+  // 2^(127-bias), we obtain the hfp8 value as an FP32 number
+
+  multiplier.I = (127 + (127 - bias)) << 23; // multiplier.F is 2^(127-bias)
+  val_out.F *= multiplier.F;
+  val_out.I |= sign.I;
+  return val_out.F;
+}
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/quantize_ops_cpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops_cpu.cpp
@@ -7,9 +7,10 @@
 #include <ATen/ATen.h>
 #include <ATen/core/op_registration/op_registration.h>
 #include <fbgemm_gpu/sparse_ops.h>
+#include <fbgemm_gpu/sparse_ops_utils.h>
 #include <torch/library.h>
 #include "fbgemm/QuantUtils.h"
-#include "fbgemm_gpu/sparse_ops_utils.h"
+#include "fbgemm_gpu/quantize_ops_utils.h"
 
 using Tensor = at::Tensor;
 
@@ -210,6 +211,105 @@ Tensor half_to_fusednbitrowwise_cpu(
   return _float_to_fusednbitrowwise_cpu<fbgemm::float16>(input, bit_rate);
 }
 
+void FloatToFP8Quantized_ref(
+    const float* const input,
+    const size_t nrows,
+    const size_t ncols,
+    uint8_t* const output,
+    const int ebits,
+    const int mbits,
+    const int bias) {
+  for (const auto row : c10::irange(nrows)) {
+    const float* input_row = input + row * ncols;
+    uint8_t* output_row = output + row * ncols;
+
+    for (const auto col : c10::irange(ncols)) {
+      output_row[col] = float_to_hfp8(
+          input_row[col],
+          ebits,
+          mbits,
+          bias,
+          static_cast<float>(
+              (1 << ((1 << ebits) - 2 - bias)) * (2 - std::pow(2, -mbits))));
+    }
+  }
+}
+
+void FP8QuantizedToFloat_ref(
+    const uint8_t* const input,
+    const size_t nrows,
+    const size_t ncols,
+    float* const output,
+    const int ebits,
+    const int /*mbits*/,
+    const int bias) {
+  const int32_t output_columns = ncols;
+
+  for (const auto row : c10::irange(nrows)) {
+    const uint8_t* input_row = input + row * ncols;
+    float* output_row = output + row * output_columns;
+
+    for (const auto col : c10::irange(ncols)) {
+      output_row[col] = hfp8_to_float(input_row[col], ebits, bias);
+    }
+  }
+}
+
+at::Tensor _float_to_hfp8_cpu(
+    const at::Tensor& input,
+    const int64_t ebits,
+    const int64_t mbits,
+    const int64_t bias,
+    const double min_pos,
+    const double max_pos) {
+  TENSOR_ON_CPU(input);
+  TENSOR_NDIM_EQUALS(input, 2);
+  TORCH_CHECK(min_pos > 0 && max_pos > 0 && max_pos > min_pos);
+
+  const auto input_sizes = input.sizes();
+  const int32_t nrows = input_sizes[0];
+  const int32_t ncols = input_sizes[1];
+  auto output = at::empty({nrows, ncols}, input.options().dtype(at::kByte));
+
+  FloatToFP8Quantized_ref(
+      input.data_ptr<float>(),
+      nrows,
+      ncols,
+      output.data_ptr<uint8_t>(),
+      ebits,
+      mbits,
+      bias);
+
+  return output;
+}
+
+at::Tensor _hfp8_to_float_cpu(
+    const at::Tensor& input,
+    const int64_t ebits,
+    const int64_t mbits,
+    const int64_t bias) {
+  TENSOR_ON_CPU(input);
+  TENSOR_NDIM_EQUALS(input, 2);
+
+  const auto input_sizes = input.sizes();
+  const int32_t nrows = input_sizes[0];
+  const int32_t ncols = input_sizes[1];
+  const int32_t output_columns = ncols;
+  auto output = at::empty(
+      {nrows, output_columns}, // 4 = sizeof(float)
+      input.options().dtype(at::kFloat)); //
+
+  FP8QuantizedToFloat_ref(
+      input.data_ptr<uint8_t>(),
+      nrows,
+      ncols,
+      output.data_ptr<float>(),
+      ebits,
+      mbits,
+      bias);
+
+  return output;
+}
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
@@ -231,6 +331,10 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "FusedNBitRowwiseQuantizedSBHalfToFloat(Tensor input, int bit_rate) -> Tensor");
   m.def(
       "FusedNBitRowwiseQuantizedSBHalfToHalf(Tensor input, int bit_rate) -> Tensor");
+  m.def(
+      "FloatToHFP8Quantized(Tensor input, int ebits, int mbits, int bias, float min_pos, float max_pos) -> Tensor");
+  m.def(
+      "HFP8QuantizedToFloat(Tensor input, int ebits, int mbits, int bias) -> Tensor");
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
@@ -264,4 +368,6 @@ TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
   DISPATCH_TO_CPU(
       "HalfToFusedNBitRowwiseQuantizedSBHalf",
       fbgemm_gpu::half_to_fusednbitrowwise_cpu);
+  DISPATCH_TO_CPU("FloatToHFP8Quantized", fbgemm_gpu::_float_to_hfp8_cpu);
+  DISPATCH_TO_CPU("HFP8QuantizedToFloat", fbgemm_gpu::_hfp8_to_float_cpu);
 }

--- a/fbgemm_gpu/src/quantize_ops_gpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops_gpu.cpp
@@ -7,6 +7,7 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 #include <torch/library.h>
 
+#include "fbgemm_gpu/quantize_ops_gpu.h"
 #include "fbgemm_gpu/sparse_ops.h"
 #include "fbgemm_gpu/sparse_ops_utils.h"
 
@@ -38,4 +39,6 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   DISPATCH_TO_CUDA(
       "HalfToFusedNBitRowwiseQuantizedSBHalf",
       fbgemm_gpu::_half_to_fusednbitrowwise_gpu);
+  DISPATCH_TO_CUDA("FloatToHFP8Quantized", fbgemm_gpu::_float_to_hfp8_gpu);
+  DISPATCH_TO_CUDA("HFP8QuantizedToFloat", fbgemm_gpu::_hfp8_to_float_gpu);
 }


### PR DESCRIPTION
Summary:
Open-source the FP8 conversion kernels in fbgemm_gpu;
Benchmark the low-precision conversion kernels in fbgemm such as INT8/INT4/INT2/FP8;
Refactor the benchmarking script and merge the benchmark_torch_function;
Fix related operator tests;

Differential Revision: D34586688

