### PR TITLE
Use torch.testing.assert_close() instead of torch.testing.assert_allclose()

### DIFF
--- a/fbgemm_gpu/test/batched_unary_embeddings_test.py
+++ b/fbgemm_gpu/test/batched_unary_embeddings_test.py
@@ -119,7 +119,7 @@ class TableBatchedEmbeddingsTest(unittest.TestCase):
             param.detach().copy_(ref_emb.emb_modules[i].weight)
         output_ref = ref_emb(offsets, indices)
         output = unary_emb(offsets_tensor, indices_tensor)
-        torch.testing.assert_allclose(output_ref, output)
+        torch.testing.assert_close(output_ref, output)
 
         # forward with int_64
         ref_emb = self.RefEmb(num_tasks, hash_sizes).to(device)
@@ -130,7 +130,7 @@ class TableBatchedEmbeddingsTest(unittest.TestCase):
             param.detach().copy_(ref_emb.emb_modules[i].weight)
         output_ref = ref_emb(offsets, indices)
         output = unary_emb(offsets_tensor.long(), indices_tensor.long())
-        torch.testing.assert_allclose(output_ref, output)
+        torch.testing.assert_close(output_ref, output)
 
         # No implementation for CPU backprop yet
         if not gpu_infer:
@@ -146,7 +146,7 @@ class TableBatchedEmbeddingsTest(unittest.TestCase):
             d_weight_ref.append(emb.weight.grad)
         d_weight_ref = torch.cat(d_weight_ref).view(num_tasks, sum(hash_sizes), -1)
         d_weight = unary_emb.weight.grad
-        torch.testing.assert_allclose(d_weight_ref, d_weight)
+        torch.testing.assert_close(d_weight_ref, d_weight)
 
     @unittest.skipIf(*gpu_unavailable)
     def test_gpu(self) -> None:

--- a/fbgemm_gpu/test/input_combine_test.py
+++ b/fbgemm_gpu/test/input_combine_test.py
@@ -144,7 +144,7 @@ class InputCombineTest(unittest.TestCase):
         )
         ref_outputs = ref_mod(indices_list, offsets_list, per_sample_weights)
         for i, j in zip(outputs, ref_outputs):
-            torch.testing.assert_allclose(i, j)
+            torch.testing.assert_close(i, j)
         self.assertTrue(outputs[0].dtype == torch.int32)
         self.assertTrue(outputs[1].dtype == torch.int32)
 
@@ -156,7 +156,7 @@ class InputCombineTest(unittest.TestCase):
         )
         ref_outputs = ref_mod(indices_list, offsets_list, empty_per_sample_weights)
         for i, j in zip(outputs[:-1], ref_outputs[:-1]):
-            torch.testing.assert_allclose(i, j)
+            torch.testing.assert_close(i, j)
             self.assertTrue(j.dtype == torch.int32)
 
         self.assertTrue(outputs[0].dtype == torch.int32)

--- a/fbgemm_gpu/test/layout_transform_ops_test.py
+++ b/fbgemm_gpu/test/layout_transform_ops_test.py
@@ -52,7 +52,7 @@ class LayoutTransformOpsTest(unittest.TestCase):
         sharded_grad_output_impl = torch.ops.fbgemm.recat_embedding_grad_output(
             grad_output, num_features_per_rank
         )
-        torch.testing.assert_allclose(
+        torch.testing.assert_close(
             sharded_grad_output_impl.cpu(), sharded_grad_output.cpu()
         )
 
@@ -95,7 +95,7 @@ class LayoutTransformOpsTest(unittest.TestCase):
         sharded_grad_output_impl = torch.ops.fbgemm.recat_embedding_grad_output_mixed_D(
             grad_output, dim_sum_per_rank
         )
-        torch.testing.assert_allclose(
+        torch.testing.assert_close(
             sharded_grad_output_impl.cpu(), sharded_grad_output.cpu()
         )
 
@@ -142,7 +142,7 @@ class LayoutTransformOpsTest(unittest.TestCase):
                 cumsum_dim_sum_per_rank_tensor.cuda(),
             )
         )
-        torch.testing.assert_allclose(
+        torch.testing.assert_close(
             sharded_grad_output_impl.cpu(), sharded_grad_output.cpu()
         )
         num_features_per_rank = np.random.randint(low=1, high=20, size=(W,)).tolist()
@@ -178,7 +178,7 @@ class LayoutTransformOpsTest(unittest.TestCase):
                 grad_output, dim_sum_per_rank_tensor, cumsum_dim_sum_per_rank_tensor
             )
         )
-        torch.testing.assert_allclose(
+        torch.testing.assert_close(
             sharded_grad_output_impl.cpu(), sharded_grad_output.cpu()
         )
 

--- a/fbgemm_gpu/test/merge_pooled_embeddings_test.py
+++ b/fbgemm_gpu/test/merge_pooled_embeddings_test.py
@@ -90,8 +90,8 @@ class MergePooledEmbeddingsTest(unittest.TestCase):
             dim,
         )
         self.assertEqual(output.device, torch.device(f"cuda:{dst_device}"))
-        torch.testing.assert_allclose(output_ref, output.cpu())
-        torch.testing.assert_allclose(output_ref, output_cpu)
+        torch.testing.assert_close(output_ref, output.cpu())
+        torch.testing.assert_close(output_ref, output_cpu)
 
     @given(
         num_inputs=st.integers(min_value=1, max_value=10),
@@ -117,7 +117,7 @@ class MergePooledEmbeddingsTest(unittest.TestCase):
             cuda_outputs = torch.ops.fbgemm.all_to_one_device(cuda_inputs, dst_device)
             for i, o in zip(inputs, cuda_outputs):
                 self.assertEqual(o.device, dst_device)
-                torch.testing.assert_allclose(o.cpu(), i)
+                torch.testing.assert_close(o.cpu(), i)
 
 
 if __name__ == "__main__":

--- a/fbgemm_gpu/test/permute_pooled_embedding_modules_test.py
+++ b/fbgemm_gpu/test/permute_pooled_embedding_modules_test.py
@@ -92,9 +92,8 @@ class PooledEmbeddingModulesTest(unittest.TestCase):
 
         # check grads for fc1 when permuted, equals to fc2 weights times input_sum
         permute_res = net.permute_pooled_embeddings(net.fc1.weight.grad.view(1, 10))
-        self.assertTrue(
-            permute_res.isclose(input_sum * net.fc2.weight, rtol=1e-03).all().item()
-        )
+        permute_ref = input_sum * net.fc2.weight
+        torch.testing.assert_close(permute_res, permute_ref, rtol=1e-03, atol=1e-03)
 
     def test_compatibility(self) -> None:
         members = inspect.getmembers(sys.modules[INTERN_MODULE])

--- a/fbgemm_gpu/test/quantize_ops_test.py
+++ b/fbgemm_gpu/test/quantize_ops_test.py
@@ -150,9 +150,9 @@ class TestFused8BitRowwiseQuantizationConversion(unittest.TestCase):
             fused_rowwise_8bit_dequantize_reference(quantized_data.numpy())
         )
         if not is_output_half:
-            torch.testing.assert_allclose(dequantized_data.float(), reference.float())
+            torch.testing.assert_close(dequantized_data.float(), reference.float())
         else:
-            torch.testing.assert_allclose(dequantized_data.half(), reference.half())
+            torch.testing.assert_close(dequantized_data.half(), reference.half())
 
         if gpu_available:
             input_data_gpu = input_data.cuda()
@@ -180,11 +180,11 @@ class TestFused8BitRowwiseQuantizationConversion(unittest.TestCase):
             )
 
             if not is_output_half:
-                torch.testing.assert_allclose(
+                torch.testing.assert_close(
                     dequantized_data_trimmed.float(), reference.float()
                 )
             else:
-                torch.testing.assert_allclose(
+                torch.testing.assert_close(
                     dequantized_data_trimmed.half(), reference.half()
                 )
 
@@ -215,7 +215,7 @@ class TestFused8BitRowwiseQuantizationConversion(unittest.TestCase):
                 )
             )
             # compare quantized data
-            torch.testing.assert_allclose(dequantized_data_gpu.cpu(), reference)
+            torch.testing.assert_close(dequantized_data_gpu.cpu(), reference)
 
 
 class TestMixedDimInt8DequantizationConversion(unittest.TestCase):
@@ -341,7 +341,7 @@ class TestMixedDimInt8DequantizationConversion(unittest.TestCase):
         if output_dtype == SparseType.FP16:
             output_ref_concat = output_ref_concat.half()
 
-        torch.testing.assert_allclose(output_ref_concat, mixed_dim_dequant_output)
+        torch.testing.assert_close(output_ref_concat, mixed_dim_dequant_output)
 
 
 class TestFusedNBitRowwiseQuantizationConversion(unittest.TestCase):
@@ -463,12 +463,19 @@ class TestFusedNBitRowwiseQuantizationConversion(unittest.TestCase):
         if nrows == 0 or ncols == 0:
             assert dequantized_data.numel() == 0
             return
-        reference = torch.from_numpy(
-            fused_rowwise_nbit_quantize_dequantize_reference(
-                input_data.float().numpy(), bit_rate
+        if not is_output_half:
+            reference = torch.from_numpy(
+                fused_rowwise_nbit_quantize_dequantize_reference(
+                    input_data.float().numpy(), bit_rate
+                )
             )
-        )
-        torch.testing.assert_allclose(dequantized_data, reference)
+        else:
+            reference = torch.from_numpy(
+                fused_rowwise_nbit_quantize_dequantize_reference(
+                    input_data.float().numpy(), bit_rate
+                )
+            ).half()
+        torch.testing.assert_close(dequantized_data, reference)
 
         if gpu_available:
             input_data_gpu = input_data.cuda()
@@ -495,7 +502,7 @@ class TestFusedNBitRowwiseQuantizationConversion(unittest.TestCase):
                     )
                 )
             # compare quantized data
-            torch.testing.assert_allclose(
+            torch.testing.assert_close(
                 dequantized_data_gpu.cpu().float(), dequantized_data.float()
             )
 
@@ -529,7 +536,7 @@ class TestFusedNBitRowwiseQuantizationConversion(unittest.TestCase):
                 )
             )
             # compare quantized data
-            torch.testing.assert_allclose(dequantized_data_gpu.cpu(), reference)
+            torch.testing.assert_close(dequantized_data_gpu.cpu(), reference)
 
 
 class TestDenseMLPQuantizationConversion(unittest.TestCase):
@@ -561,9 +568,7 @@ class TestDenseMLPQuantizationConversion(unittest.TestCase):
         dequantized_data = torch.ops.fb.MSFPQuantizedToFloat(
             quantized_data.cuda(), ebits, mbits, bias
         )
-        torch.testing.assert_allclose(
-            dequantized_data.cpu(), input_data, rtol=1, atol=0
-        )
+        torch.testing.assert_close(dequantized_data.cpu(), input_data, rtol=1, atol=0)
 
 
 if __name__ == "__main__":

--- a/fbgemm_gpu/test/sparse_ops_test.py
+++ b/fbgemm_gpu/test/sparse_ops_test.py
@@ -211,10 +211,10 @@ class SparseOpsTest(unittest.TestCase):
             permuted_indices_ref,
             permuted_weights_ref,
         ) = self.permute_indices_ref_(lengths, indices, weights, permute.long(), is_1D)
-        torch.testing.assert_allclose(permuted_indices_cpu, permuted_indices_ref)
-        torch.testing.assert_allclose(permuted_lengths_cpu, permuted_lengths_ref)
+        torch.testing.assert_close(permuted_indices_cpu, permuted_indices_ref)
+        torch.testing.assert_close(permuted_lengths_cpu, permuted_lengths_ref)
         if has_weight:
-            torch.testing.assert_allclose(permuted_weights_cpu, permuted_weights_ref)
+            torch.testing.assert_close(permuted_weights_cpu, permuted_weights_ref)
         else:
             assert permuted_weights_cpu is None and permuted_weights_ref is None
 
@@ -243,14 +243,10 @@ class SparseOpsTest(unittest.TestCase):
                     weights.cuda() if has_weight else None,
                     None,
                 )
-            torch.testing.assert_allclose(
-                permuted_indices_gpu.cpu(), permuted_indices_cpu
-            )
-            torch.testing.assert_allclose(
-                permuted_lengths_gpu.cpu(), permuted_lengths_cpu
-            )
+            torch.testing.assert_close(permuted_indices_gpu.cpu(), permuted_indices_cpu)
+            torch.testing.assert_close(permuted_lengths_gpu.cpu(), permuted_lengths_cpu)
             if has_weight:
-                torch.testing.assert_allclose(
+                torch.testing.assert_close(
                     permuted_weights_gpu.cpu(), permuted_weights_cpu
                 )
             else:
@@ -297,10 +293,10 @@ class SparseOpsTest(unittest.TestCase):
             permuted_indices_ref,
             permuted_weights_ref,
         ) = self.permute_indices_ref_(lengths, indices, weights, permute.long())
-        torch.testing.assert_allclose(permuted_indices_cpu, permuted_indices_ref)
-        torch.testing.assert_allclose(permuted_lengths_cpu, permuted_lengths_ref)
+        torch.testing.assert_close(permuted_indices_cpu, permuted_indices_ref)
+        torch.testing.assert_close(permuted_lengths_cpu, permuted_lengths_ref)
         if has_weight:
-            torch.testing.assert_allclose(permuted_weights_cpu, permuted_weights_ref)
+            torch.testing.assert_close(permuted_weights_cpu, permuted_weights_ref)
         else:
             assert permuted_weights_cpu is None and permuted_weights_ref is None
 
@@ -315,14 +311,10 @@ class SparseOpsTest(unittest.TestCase):
                 indices.cuda(),
                 weights.cuda() if has_weight else None,
             )
-            torch.testing.assert_allclose(
-                permuted_indices_gpu.cpu(), permuted_indices_cpu
-            )
-            torch.testing.assert_allclose(
-                permuted_lengths_gpu.cpu(), permuted_lengths_cpu
-            )
+            torch.testing.assert_close(permuted_indices_gpu.cpu(), permuted_indices_cpu)
+            torch.testing.assert_close(permuted_lengths_gpu.cpu(), permuted_lengths_cpu)
             if has_weight:
-                torch.testing.assert_allclose(
+                torch.testing.assert_close(
                     permuted_weights_gpu.cpu(), permuted_weights_cpu
                 )
             else:
@@ -354,8 +346,8 @@ class SparseOpsTest(unittest.TestCase):
             permuted_embeddings_ref,
             _,
         ) = self.permute_indices_ref_(lengths, embeddings, None, permute.long())
-        torch.testing.assert_allclose(permuted_embeddings_cpu, permuted_embeddings_ref)
-        torch.testing.assert_allclose(permuted_lengths_cpu, permuted_lengths_ref)
+        torch.testing.assert_close(permuted_embeddings_cpu, permuted_embeddings_ref)
+        torch.testing.assert_close(permuted_lengths_cpu, permuted_lengths_ref)
 
         if gpu_available:
             (
@@ -368,12 +360,10 @@ class SparseOpsTest(unittest.TestCase):
                 embeddings.cuda(),
                 None,
             )
-            torch.testing.assert_allclose(
+            torch.testing.assert_close(
                 permuted_embeddings_gpu.cpu(), permuted_embeddings_cpu
             )
-            torch.testing.assert_allclose(
-                permuted_lengths_gpu.cpu(), permuted_lengths_cpu
-            )
+            torch.testing.assert_close(permuted_lengths_gpu.cpu(), permuted_lengths_cpu)
 
     @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore [56]: Invalid decoration, was not able to infer the type of argument
@@ -444,8 +434,8 @@ class SparseOpsTest(unittest.TestCase):
             None,
         )
 
-        torch.testing.assert_allclose(new_lengths_gpu.cpu(), new_lengths_ref)
-        torch.testing.assert_allclose(new_indices_gpu.cpu(), new_indices_ref)
+        torch.testing.assert_close(new_lengths_gpu.cpu(), new_lengths_ref)
+        torch.testing.assert_close(new_indices_gpu.cpu(), new_indices_ref)
 
     # pyre-ignore [56]
     @given(
@@ -462,15 +452,21 @@ class SparseOpsTest(unittest.TestCase):
         ze = torch.ops.fbgemm.asynchronous_exclusive_cumsum(x)
         zi = torch.ops.fbgemm.asynchronous_inclusive_cumsum(x)
         zc = torch.ops.fbgemm.asynchronous_complete_cumsum(x)
-        torch.testing.assert_allclose(
-            np.cumsum(x.cpu().numpy()).astype(np_index_dtype), zi.cpu()
+        torch.testing.assert_close(
+            torch.from_numpy(np.cumsum(x.cpu().numpy()).astype(np_index_dtype)),
+            zi.cpu(),
         )
-        torch.testing.assert_allclose(
-            (np.cumsum([0] + x.cpu().numpy().tolist())[:-1]).astype(np_index_dtype),
+        torch.testing.assert_close(
+            torch.from_numpy(
+                (np.cumsum([0] + x.cpu().numpy().tolist())[:-1]).astype(np_index_dtype)
+            ),
             ze.cpu(),
         )
-        torch.testing.assert_allclose(
-            (np.cumsum([0] + x.cpu().numpy().tolist())).astype(np_index_dtype), zc.cpu()
+        torch.testing.assert_close(
+            torch.from_numpy(
+                (np.cumsum([0] + x.cpu().numpy().tolist())).astype(np_index_dtype)
+            ),
+            zc.cpu(),
         )
 
         if gpu_available:
@@ -478,15 +474,22 @@ class SparseOpsTest(unittest.TestCase):
             ze = torch.ops.fbgemm.asynchronous_exclusive_cumsum(x)
             zi = torch.ops.fbgemm.asynchronous_inclusive_cumsum(x)
             zc = torch.ops.fbgemm.asynchronous_complete_cumsum(x)
-            torch.testing.assert_allclose(
-                np.cumsum(x.cpu().numpy()).astype(np_index_dtype), zi.cpu()
+            torch.testing.assert_close(
+                torch.from_numpy(np.cumsum(x.cpu().numpy()).astype(np_index_dtype)),
+                zi.cpu(),
             )
-            torch.testing.assert_allclose(
-                (np.cumsum([0] + x.cpu().numpy().tolist())[:-1]).astype(np_index_dtype),
+            torch.testing.assert_close(
+                torch.from_numpy(
+                    (np.cumsum([0] + x.cpu().numpy().tolist())[:-1]).astype(
+                        np_index_dtype
+                    )
+                ),
                 ze.cpu(),
             )
-            torch.testing.assert_allclose(
-                (np.cumsum([0] + x.cpu().numpy().tolist())).astype(np_index_dtype),
+            torch.testing.assert_close(
+                torch.from_numpy(
+                    (np.cumsum([0] + x.cpu().numpy().tolist())).astype(np_index_dtype)
+                ),
                 zc.cpu(),
             )
 
@@ -501,16 +504,20 @@ class SparseOpsTest(unittest.TestCase):
     ) -> None:
         lengths = np.array([np.random.randint(low=0, high=20) for _ in range(N)])
         offsets = np.cumsum(np.concatenate(([0], lengths)))[:-1]
-        range_ref = np.concatenate([np.arange(size) for size in lengths])
+        range_ref = torch.from_numpy(
+            np.concatenate([np.arange(size) for size in lengths])
+        )
         output_size = np.sum(lengths)
 
         offsets_cpu = torch.tensor(offsets, dtype=offsets_type)
         range_cpu = torch.ops.fbgemm.offsets_range(offsets_cpu, output_size)
-        torch.testing.assert_allclose(range_cpu, range_ref, 0, 0)
+        range_ref = torch.tensor(range_ref, dtype=range_cpu.dtype)
+        torch.testing.assert_close(range_cpu, range_ref, rtol=0, atol=0)
 
         if gpu_available:
             range_gpu = torch.ops.fbgemm.offsets_range(offsets_cpu.cuda(), output_size)
-            torch.testing.assert_allclose(range_gpu.cpu(), range_ref, 0, 0)
+            range_ref = torch.tensor(range_ref, dtype=range_gpu.dtype)
+            torch.testing.assert_close(range_gpu.cpu(), range_ref, rtol=0, atol=0)
 
     # pyre-ignore [56]: Invalid decoration, was not able to infer the type of argument
     @given(
@@ -607,12 +614,12 @@ class SparseOpsTest(unittest.TestCase):
         ) = torch.ops.fbgemm.block_bucketize_sparse_features(
             lengths, indices, bucketize_pos, sequence, block_sizes, my_size, weights
         )
-        torch.testing.assert_allclose(new_lengths_cpu, new_lengths_ref, 0, 0)
-        torch.testing.assert_allclose(new_indices_cpu, new_indices_ref, 0, 0)
+        torch.testing.assert_close(new_lengths_cpu, new_lengths_ref, rtol=0, atol=0)
+        torch.testing.assert_close(new_indices_cpu, new_indices_ref, rtol=0, atol=0)
         if has_weight:
-            torch.testing.assert_allclose(new_weights_cpu, new_weights_ref)
+            torch.testing.assert_close(new_weights_cpu, new_weights_ref)
         if bucketize_pos:
-            torch.testing.assert_allclose(new_pos_cpu, new_pos_ref)
+            torch.testing.assert_close(new_pos_cpu, new_pos_ref)
         if sequence:
             value_unbucketized_indices = unbucketize_indices_value(
                 new_indices_cpu, new_lengths_cpu, block_sizes, my_size, B
@@ -620,7 +627,7 @@ class SparseOpsTest(unittest.TestCase):
             unbucketized_indices = torch.index_select(
                 value_unbucketized_indices, 0, unbucketize_permute
             )
-            torch.testing.assert_allclose(unbucketized_indices, indices, 0, 0)
+            torch.testing.assert_close(unbucketized_indices, indices, rtol=0, atol=0)
 
         if gpu_available:
             (
@@ -638,12 +645,16 @@ class SparseOpsTest(unittest.TestCase):
                 my_size,
                 weights.cuda() if has_weight else None,
             )
-            torch.testing.assert_allclose(new_lengths_gpu.cpu(), new_lengths_ref, 0, 0)
-            torch.testing.assert_allclose(new_indices_gpu.cpu(), new_indices_ref, 0, 0)
+            torch.testing.assert_close(
+                new_lengths_gpu.cpu(), new_lengths_ref, rtol=0, atol=0
+            )
+            torch.testing.assert_close(
+                new_indices_gpu.cpu(), new_indices_ref, rtol=0, atol=0
+            )
             if has_weight:
-                torch.testing.assert_allclose(new_weights_gpu.cpu(), new_weights_cpu)
+                torch.testing.assert_close(new_weights_gpu.cpu(), new_weights_cpu)
             if bucketize_pos:
-                torch.testing.assert_allclose(new_pos_gpu.cpu(), new_pos_cpu)
+                torch.testing.assert_close(new_pos_gpu.cpu(), new_pos_cpu)
             if sequence:
                 value_unbucketized_indices = unbucketize_indices_value(
                     new_indices_gpu.cpu(),
@@ -655,7 +666,9 @@ class SparseOpsTest(unittest.TestCase):
                 unbucketized_indices = torch.index_select(
                     value_unbucketized_indices, 0, unbucketize_permute_gpu.cpu()
                 )
-                torch.testing.assert_allclose(unbucketized_indices, indices, 0, 0)
+                torch.testing.assert_close(
+                    unbucketized_indices, indices, rtol=0, atol=0
+                )
 
     @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore [56]: Invalid decoration, was not able to infer the type of argument
@@ -680,14 +693,14 @@ class SparseOpsTest(unittest.TestCase):
         reordered_batched_ad_lengths = torch.ops.fbgemm.reorder_batched_ad_lengths(
             cat_ad_lengths, batch_offsets, num_ads_in_batch
         )
-        torch.testing.assert_allclose(cat_ad_lengths, reordered_batched_ad_lengths)
+        torch.testing.assert_close(cat_ad_lengths, reordered_batched_ad_lengths)
 
         cat_ad_lengths_cpu = cat_ad_lengths.cpu()
         batch_offsets_cpu = batch_offsets.cpu()
         reordered_batched_ad_lengths_cpu = torch.ops.fbgemm.reorder_batched_ad_lengths(
             cat_ad_lengths_cpu, batch_offsets_cpu, num_ads_in_batch
         )
-        torch.testing.assert_allclose(
+        torch.testing.assert_close(
             reordered_batched_ad_lengths_cpu, reordered_batched_ad_lengths.cpu()
         )
 
@@ -713,7 +726,7 @@ class SparseOpsTest(unittest.TestCase):
         reordered_batched_ad_lengths = torch.ops.fbgemm.reorder_batched_ad_lengths(
             cat_ad_lengths, batch_offsets, num_ads_in_batch
         )
-        torch.testing.assert_allclose(cat_ad_lengths, reordered_batched_ad_lengths)
+        torch.testing.assert_close(cat_ad_lengths, reordered_batched_ad_lengths)
 
     @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore [56]: Invalid decoration, was not able to infer the type of argument
@@ -741,7 +754,7 @@ class SparseOpsTest(unittest.TestCase):
         reordered_cat_ad_lengths = torch.ops.fbgemm.reorder_batched_ad_lengths(
             cat_ad_lengths, batch_offsets, num_ads_in_batch
         )
-        torch.testing.assert_allclose(cat_ad_lengths, reordered_cat_ad_lengths)
+        torch.testing.assert_close(cat_ad_lengths, reordered_cat_ad_lengths)
 
         cat_ad_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(cat_ad_lengths)
         reordered_cat_ad_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
@@ -754,7 +767,7 @@ class SparseOpsTest(unittest.TestCase):
             batch_offsets,
             num_ads_in_batch,
         )
-        torch.testing.assert_allclose(
+        torch.testing.assert_close(
             reordered_cat_ad_indices.view(T, B, A, L).permute(1, 0, 2, 3),
             cat_ad_indices.view(B, T, A, L),
         )
@@ -782,7 +795,7 @@ class SparseOpsTest(unittest.TestCase):
         reordered_cat_ad_lengths = torch.ops.fbgemm.reorder_batched_ad_lengths(
             cat_ad_lengths, batch_offsets, num_ads_in_batch
         )
-        torch.testing.assert_allclose(cat_ad_lengths, reordered_cat_ad_lengths)
+        torch.testing.assert_close(cat_ad_lengths, reordered_cat_ad_lengths)
         cat_ad_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(cat_ad_lengths)
         reordered_cat_ad_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
             reordered_cat_ad_lengths
@@ -794,7 +807,7 @@ class SparseOpsTest(unittest.TestCase):
             batch_offsets,
             num_ads_in_batch,
         )
-        torch.testing.assert_allclose(
+        torch.testing.assert_close(
             reordered_cat_ad_indices.view(T, B, A, L).permute(1, 0, 2, 3),
             cat_ad_indices.view(B, T, A, L),
         )
@@ -831,6 +844,8 @@ class SparseOpsTest(unittest.TestCase):
             max_sequence_length,
             D,
         ).to_dense()
+        if is_half:
+            ref_output_values = ref_output_values.half()
 
         # test cpu forward
         if is_half:
@@ -842,7 +857,7 @@ class SparseOpsTest(unittest.TestCase):
             offsets=offsets,
             max_sequence_length=max_sequence_length,
         )
-        torch.testing.assert_allclose(ref_output_values, output_values)
+        torch.testing.assert_close(ref_output_values, output_values)
 
         if torch.cuda.is_available():
             # test gpu forward
@@ -858,11 +873,13 @@ class SparseOpsTest(unittest.TestCase):
                 offsets=offsets,
                 max_sequence_length=max_sequence_length,
             )
-            torch.testing.assert_allclose(ref_output_values, output_values)
+            torch.testing.assert_close(ref_output_values, output_values)
 
             # test gpu backward
             output_values.backward(ref_output_values)
-            torch.testing.assert_allclose(ref_values, values.grad)
+            if is_half:
+                ref_values = ref_values.half()
+            torch.testing.assert_close(ref_values, values.grad)
 
     def test_jagged_2d_to_dense_truncation(self) -> None:
         # Test the case where max_sequence_length < max(lengths[i])
@@ -888,7 +905,7 @@ class SparseOpsTest(unittest.TestCase):
             offsets=offsets,
             max_sequence_length=max_sequence_length,
         )
-        torch.testing.assert_allclose(ref_output_values, output_values)
+        torch.testing.assert_close(ref_output_values, output_values)
 
         if torch.cuda.is_available():
             # test gpu forward
@@ -901,14 +918,14 @@ class SparseOpsTest(unittest.TestCase):
                 offsets=offsets,
                 max_sequence_length=max_sequence_length,
             )
-            torch.testing.assert_allclose(ref_output_values, output_values)
+            torch.testing.assert_close(ref_output_values, output_values)
 
             # test gpu backward
             expected_grad = ref_values
             expected_grad[4, :] = 0  # due to truncation
             expected_grad = expected_grad.cuda()
             output_values.backward(ref_output_values)
-            torch.testing.assert_allclose(expected_grad, values.grad)
+            torch.testing.assert_close(expected_grad, values.grad)
 
     @unittest.skipIf(*gpu_unavailable)
     @settings(
@@ -957,14 +974,14 @@ class SparseOpsTest(unittest.TestCase):
             offsets=offsets,
             max_sequence_length=max_sequence_length,
         )
-        torch.testing.assert_allclose(
+        torch.testing.assert_close(
             ref_output_values, torch.cat(output_values_per_table)
         )
 
         # test backward
         output_values = torch.cat(output_values_per_table)
         output_values.backward(ref_output_values)
-        torch.testing.assert_allclose(ref_values, values.grad)
+        torch.testing.assert_close(ref_values, values.grad)
 
     @settings(
         verbosity=Verbosity.verbose,
@@ -1039,7 +1056,7 @@ class SparseOpsTest(unittest.TestCase):
             max_sequence_length=max_sequence_length,
             padding_value=padding_value,
         )
-        torch.testing.assert_allclose(ref_output_values, output_values)
+        torch.testing.assert_close(ref_output_values, output_values)
 
         if torch.cuda.is_available():
             # test gpu forward
@@ -1053,7 +1070,7 @@ class SparseOpsTest(unittest.TestCase):
                 max_sequence_length=max_sequence_length,
                 padding_value=padding_value,
             )
-            torch.testing.assert_allclose(ref_output_values, output_values)
+            torch.testing.assert_close(ref_output_values, output_values)
 
     def test_jagged_1d_to_dense_truncation(self) -> None:
         lengths_ = np.array([1, 3, 0, 1])
@@ -1071,7 +1088,7 @@ class SparseOpsTest(unittest.TestCase):
             max_sequence_length=1,
             padding_value=-1,
         )
-        torch.testing.assert_allclose(ref_output, output)
+        torch.testing.assert_close(ref_output, output)
 
         if torch.cuda.is_available():
             # test gpu forward
@@ -1085,7 +1102,7 @@ class SparseOpsTest(unittest.TestCase):
                 max_sequence_length=1,
                 padding_value=-1,
             )
-            torch.testing.assert_allclose(ref_output, output)
+            torch.testing.assert_close(ref_output, output)
 
     @unittest.skipIf(*gpu_unavailable)
     @settings(
@@ -1159,7 +1176,7 @@ class SparseOpsTest(unittest.TestCase):
             max_sequence_length=max_sequence_length,
             padding_value=padding_value,
         )
-        torch.testing.assert_allclose(
+        torch.testing.assert_close(
             ref_output_values, torch.cat(output_values_per_table)
         )
 
@@ -1194,7 +1211,7 @@ class SparseOpsTest(unittest.TestCase):
             [1426, 1437, 1437, 1428, 1431], dtype=torch.long
         )
 
-        torch.testing.assert_allclose(
+        torch.testing.assert_close(
             calibrated_prediction,
             expected_calibrated_prediction,
             rtol=1e-03,
@@ -1223,7 +1240,7 @@ class SparseOpsTest(unittest.TestCase):
                 bin_ctr_weight_value=0.9995,
             )
 
-            torch.testing.assert_allclose(
+            torch.testing.assert_close(
                 calibrated_prediction_gpu,
                 expected_calibrated_prediction.cuda(),
                 rtol=1e-03,
@@ -1287,7 +1304,7 @@ class SparseOpsTest(unittest.TestCase):
             [206426, 161437, 166437, 71428, 161431], dtype=torch.long
         )
 
-        torch.testing.assert_allclose(
+        torch.testing.assert_close(
             calibrated_prediction,
             expected_calibrated_prediction,
             rtol=1e-03,
@@ -1320,7 +1337,7 @@ class SparseOpsTest(unittest.TestCase):
                 bin_ctr_weight_value=0.9995,
             )
 
-            torch.testing.assert_allclose(
+            torch.testing.assert_close(
                 calibrated_prediction_gpu,
                 expected_calibrated_prediction.cuda(),
                 rtol=1e-03,
@@ -1389,7 +1406,7 @@ class SparseOpsTest(unittest.TestCase):
             [206426, 161437, 166437, 71428, 161431], dtype=torch.long
         )
 
-        torch.testing.assert_allclose(
+        torch.testing.assert_close(
             calibrated_prediction,
             expected_calibrated_prediction,
             rtol=1e-03,
@@ -1420,7 +1437,7 @@ class SparseOpsTest(unittest.TestCase):
                 bin_ctr_weight_value=0.9995,
             )
 
-            torch.testing.assert_allclose(
+            torch.testing.assert_close(
                 calibrated_prediction_gpu,
                 expected_calibrated_prediction.cuda(),
                 rtol=1e-03,
@@ -1501,7 +1518,7 @@ class SparseOpsTest(unittest.TestCase):
             bin_ctr_weight_value=bin_ctr_weight_value,
         )
 
-        torch.testing.assert_allclose(
+        torch.testing.assert_close(
             calibrated_prediction_cpu,
             calibrated_prediction_gpu.cpu(),
             rtol=1e-03,
@@ -1522,8 +1539,8 @@ class SparseOpsTest(unittest.TestCase):
             torch.IntTensor([0, 2, 3, 5]),
             torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]),
         )
-        torch.testing.assert_allclose(
-            segment_sum_cpu, torch.Tensor([10.0, 11.0, 34.0]), 0, 0
+        torch.testing.assert_close(
+            segment_sum_cpu, torch.Tensor([10.0, 11.0, 34.0]), rtol=0, atol=0
         )
         if torch.cuda.is_available():
             segment_sum_cuda = torch.ops.fbgemm.segment_sum_csr(
@@ -1533,8 +1550,8 @@ class SparseOpsTest(unittest.TestCase):
                     [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
                 ).cuda(),
             )
-            torch.testing.assert_allclose(
-                segment_sum_cuda.cpu(), torch.Tensor([10.0, 11.0, 34.0]), 0, 0
+            torch.testing.assert_close(
+                segment_sum_cuda.cpu(), torch.Tensor([10.0, 11.0, 34.0]), rtol=0, atol=0
             )
 
 

--- a/fbgemm_gpu/test/split_embedding_inference_converter_test.py
+++ b/fbgemm_gpu/test/split_embedding_inference_converter_test.py
@@ -200,7 +200,7 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
         quantized_emb_out = sparse_arch(indices.int(), offsets.int())  # B, T, D
 
         # Compare FP32 emb module vs. quantize_type (FP16, INT8, INT4, INT2) emb module
-        torch.testing.assert_allclose(
+        torch.testing.assert_close(
             emb_out.float().cpu(),
             quantized_emb_out.float().cpu(),
             atol=1.0e-1,
@@ -280,7 +280,7 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
             )  # B, T, D
 
             # Compare FP32 emb module with remapped index vs. FP16 emb module with pruning
-            torch.testing.assert_allclose(
+            torch.testing.assert_close(
                 emb_out.float().cpu(),
                 pruned_emb_out.float().cpu(),
                 atol=1.0e-1,


### PR DESCRIPTION
Summary: BigGrep in action `torch.testing.assert_allclose` -> `torch.testing.assert_close`

Differential Revision: D34793450

