### PR TITLE
Move the GPU kernel from cuh file into fbgemm_gpu/src folder

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.cuh
@@ -20,36 +20,15 @@
 #include "./cub_namespace_postfix.cuh"
 // clang-format on
 
+namespace fbgemm_gpu {
+
 // Kernel for calculating the offsets ranges
 template <typename scalar_t>
 __global__ void _offsets_range_cuda_kernel(
     int64_t N,
     int64_t range_size,
     const scalar_t* __restrict__ offsets_data,
-    scalar_t* __restrict__ range_data) {
-  int start_row_idx = blockIdx.x * blockDim.y + threadIdx.y;
-  const int stride = gridDim.x * blockDim.y;
-  for (int row_idx = start_row_idx; row_idx < N; row_idx += stride) {
-    scalar_t row_start = offsets_data[row_idx];
-    scalar_t row_end =
-        (row_idx < N - 1 ? offsets_data[row_idx + 1] : range_size);
-    if (blockDim.x == 32) {
-      scalar_t i = row_start - (row_start & 31) + threadIdx.x;
-      // unaligned part
-      if (i >= row_start && i < row_end) {
-        range_data[i] = i - row_start;
-      }
-      // aligned part
-      for (i += 32; i < row_end; i += 32) {
-        range_data[i] = i - row_start;
-      }
-    } else {
-      for (scalar_t i = row_start + threadIdx.x; i < row_end; i += blockDim.x) {
-        range_data[i] = i - row_start;
-      }
-    }
-  }
-}
+    scalar_t* __restrict__ range_data);
 
 // Kernel for permuting the lengths. Used for permutation of sparse features.
 template <typename index_t>
@@ -58,10 +37,6 @@ __global__ void permute_2D_lengths_kernel(
     int32_t B,
     const index_t* __restrict__ lengths,
     const int32_t* __restrict__ permute,
-    index_t* __restrict__ permuted_lengths) {
-  CUDA_KERNEL_LOOP(b_t, B * T) {
-    int32_t b = b_t % B;
-    int32_t t = b_t / B;
-    permuted_lengths[b_t] = lengths[permute[t] * B + b];
-  }
-}
+    index_t* __restrict__ permuted_lengths);
+
+} // namespace fbgemm_gpu


### PR DESCRIPTION
Summary: Move https://www.internalfb.com/code/fbsource/fbcode/deeplearning/fbgemm/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.cuh kernels definition into fbgemm_gpu/src folder.

Differential Revision: D34935526

