### PR TITLE
general jagged tensor element wise op

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -225,6 +225,7 @@ set(fbgemm_gpu_sources_cpu
     codegen/embedding_backward_dense_host_cpu.cpp
     codegen/embedding_bounds_check_host_cpu.cpp
     src/cpu_utils.cpp
+    src/jagged_tensor_ops_cpu.cpp
     src/input_combine_cpu.cpp
     src/layout_transform_ops_cpu.cpp
     src/quantize_ops_cpu.cpp

--- a/fbgemm_gpu/src/jagged_tensor_ops.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops.cu
@@ -9,6 +9,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <torch/library.h>
 
 // clang-format off
 #include "fbgemm_gpu/cub_namespace_prefix.cuh"
@@ -23,72 +24,261 @@ using Tensor = at::Tensor;
 
 namespace fbgemm_gpu {
 
-template <typename index_t, typename scalar_t>
-__global__ void jagged_2d_to_dense_forward_kernel(
-    int32_t B,
-    int32_t max_L,
-    int32_t D,
-    index_t* offsets,
-    scalar_t* values,
-    scalar_t* padded_values) {
-  int32_t b_l = blockIdx.x * blockDim.y + threadIdx.y;
-  int32_t l = b_l / B;
-  int32_t b = b_l % B;
-  if (b_l >= B * max_L) {
-    return;
+namespace {
+
+/**
+ * Ref. http://tensor-compiler.org/kjolstad-oopsla17-tensor-compiler.pdf
+ * @param offset the input value points to the offset in the first jagged dim
+ *               and output is the final offset to access the value tensor.
+ *               It would've been better if we return a pair including this
+ *               offset but CUDA doesn't seem to have comprehensive support
+ *               on std::pair like std::tie.
+ * @returns true if the flattend jagged idx points to zero'ed (masked out)
+ *               portion of the jagged tensor
+ */
+template <int NUM_JAGGED_DIM, typename index_t>
+DEVICE_INLINE bool walk_down_tensor_storage_tree_(
+    int& offset,
+    const int flattened_jagged_idx,
+    const int64_t* jagged_dims,
+    const std::array<index_t*, NUM_JAGGED_DIM>& x_offsets) {
+  // compute coorindates
+  int jagged_coords[NUM_JAGGED_DIM];
+  int j_temp = flattened_jagged_idx;
+#pragma unroll
+  for (int d = NUM_JAGGED_DIM - 1; d >= 0; --d) {
+    const int jagged_size = jagged_dims[d];
+    jagged_coords[d] = j_temp % jagged_size;
+    j_temp /= jagged_size;
   }
-  int32_t row_start = offsets[b];
-  int32_t row_end = offsets[b + 1];
-  int32_t length = row_end - row_start;
-  if (l < length) {
-    for (int32_t d = threadIdx.x; d < D; d += kWarpSize) {
-      padded_values[b * max_L * D + l * D + d] =
-          values[(row_start + l) * D + d];
+
+  // walk down the tree
+  bool is_zero = false;
+#pragma unroll
+  for (int d = 0; d < NUM_JAGGED_DIM; ++d) {
+    const int begin = x_offsets[d][offset];
+    const int end = x_offsets[d][offset + 1];
+    if (jagged_coords[d] >= end - begin) {
+      is_zero = true;
+      break;
     }
-  } else {
-    for (int32_t d = threadIdx.x; d < D; d += kWarpSize) {
-      padded_values[b * max_L * D + l * D + d] = 0.0;
+    offset = begin + jagged_coords[d];
+  }
+  return is_zero;
+}
+
+// output = f(x, y) where x is jagged, y is dense, and output is dense.
+// A generic elementwise operation between a jagged tensor and a dense tensor
+// This kernel assumes jagged dims are clustered together, preceded by outer
+// dense dimensions and followed by inner dense dimensions.
+// The outer/inner dense dimensions, and jagged dimensions in between are
+// assumed to be folded so physically the dense tensor is 3D and the value of
+// jagged tensor is 2D.
+// To support arbitrary number of jagged dimensions, we pass a vector of
+// pointers to offset tensors (this is ugly and probably we can use nested
+// tensor here).
+// This kernel parallelizes the (folded) inner dense dimension across
+// blockDim.x so the inner dense dimension should be similar to or bigger than
+// warp size.
+// We rely on compiler unrolling the compiler time constant NUM_JAGGED_DIM.
+template <int NUM_JAGGED_DIM, typename index_t, typename scalar_t, typename F>
+__global__ void jagged_dense_elementwise_dense_output_kernel_(
+    const at::PackedTensorAccessor32<scalar_t, 2, at::RestrictPtrTraits>
+        x_values,
+    const std::array<index_t*, NUM_JAGGED_DIM> x_offsets,
+    const at::PackedTensorAccessor32<scalar_t, 3, at::RestrictPtrTraits> y,
+    at::PackedTensorAccessor32<scalar_t, 3, at::RestrictPtrTraits> output,
+    const int64_t* jagged_dims,
+    F f,
+    const scalar_t padding_value) {
+  const int outer_dense_size = y.size(0);
+  const int jagged_folded_size = y.size(1);
+  const int inner_dense_size = y.size(2);
+
+  const int outer_begin = blockIdx.x * blockDim.y + threadIdx.y;
+  const int outer_stride = gridDim.x * blockDim.y;
+  for (int outer = outer_begin; outer < outer_dense_size * jagged_folded_size;
+       outer += outer_stride) {
+    const int oidx = outer / jagged_folded_size;
+    const int jidx = outer % jagged_folded_size;
+
+    int offset = oidx;
+    const bool is_zero = walk_down_tensor_storage_tree_<NUM_JAGGED_DIM>(
+        offset, jidx, jagged_dims, x_offsets);
+
+    if (is_zero) {
+      for (int iidx = threadIdx.x; iidx < inner_dense_size;
+           iidx += blockDim.x) {
+        output[oidx][jidx][iidx] = f(padding_value, y[oidx][jidx][iidx]);
+      }
+    } else {
+      for (int iidx = threadIdx.x; iidx < inner_dense_size;
+           iidx += blockDim.x) {
+        output[oidx][jidx][iidx] =
+            f(x_values[offset][iidx], y[oidx][jidx][iidx]);
+      }
     }
   }
 }
 
-Tensor
-jagged_2d_to_dense_forward_cuda(Tensor values, Tensor offsets, int32_t max_L) {
-  TENSOR_ON_CUDA_GPU(values);
-  TENSOR_ON_CUDA_GPU(offsets);
+std::tuple<dim3, dim3, Tensor> check_shape_and_partition_(
+    const Tensor& values,
+    const std::vector<Tensor>& offsets,
+    const Tensor& dense_tensor) {
+  const int outer_dense_size = dense_tensor.size(0);
+  TORCH_CHECK(outer_dense_size == offsets[0].numel() - 1);
+  const int inner_dense_size = dense_tensor.size(-1);
+  TORCH_CHECK(inner_dense_size == values.size(-1));
+  const int jagged_folded_size =
+      dense_tensor.numel() / (outer_dense_size * inner_dense_size);
+  const int jagged_innermost_size = dense_tensor.size(-2);
 
-  TORCH_CHECK(values.dim() == 2);
-  TORCH_CHECK(offsets.dim() == 1);
-  TORCH_CHECK(max_L > 0);
+  const int threads_x = jagged_innermost_size >= kWarpSize / 2
+      ? kWarpSize
+      : jagged_innermost_size;
+  const int threads_y = kMaxThreads / kWarpSize;
+  const dim3 blocks(
+      div_round_up(outer_dense_size * jagged_folded_size, threads_y));
+
+  const int num_jagged_dim = dense_tensor.dim() - 2;
+  const Tensor jagged_dims_tensor =
+      at::from_blob(
+          const_cast<int64_t*>(dense_tensor.sizes().data() + 1),
+          {num_jagged_dim},
+          at::kLong)
+          .to(offsets[0].device());
+
+  return {dim3(threads_x, threads_y), blocks, jagged_dims_tensor};
+}
+
+template <typename scalar_t, typename F>
+void jagged_dense_elementwise_dense_output_(
+    const Tensor& x_values,
+    const std::vector<Tensor>& x_offsets,
+    const Tensor& y,
+    const Tensor& output,
+    F f,
+    const scalar_t padding_value = static_cast<scalar_t>(0)) {
+  TENSOR_ON_CUDA_GPU(x_values);
+  for (auto& x_offset : x_offsets) {
+    TENSOR_ON_CUDA_GPU(x_offset);
+  }
+
+  const int num_jagged_dim = y.dim() - 2;
+  TORCH_CHECK(x_offsets.size() == static_cast<size_t>(num_jagged_dim));
+
+  dim3 threads, blocks;
+  Tensor jagged_dims_tensor;
+  std::tie(threads, blocks, jagged_dims_tensor) =
+      check_shape_and_partition_(x_values, x_offsets, y);
+
+  // Canonicalize y and output to 3D, collapsing jagged dimensions.
+  const Tensor y_reshaped = y.view({y.size(0), -1, y.size(-1)});
+  Tensor output_reshaped = output.view(y_reshaped.sizes());
+
+#define INVOKE_KERNEL_WITH_DIM(NUM_JAGGED_DIM)                                \
+  {                                                                           \
+    Tensor x_offsets_contig[num_jagged_dim];                                  \
+    std::array<index_t*, NUM_JAGGED_DIM> x_offset_ptrs;                       \
+    for (int d = 0; d < num_jagged_dim; ++d) {                                \
+      x_offsets_contig[d] = x_offsets[d].contiguous();                        \
+      x_offset_ptrs[d] = x_offsets_contig[d].template data_ptr<index_t>();    \
+    }                                                                         \
+    jagged_dense_elementwise_dense_output_kernel_<NUM_JAGGED_DIM, index_t>    \
+        <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(           \
+            x_values.packed_accessor32<scalar_t, 2, at::RestrictPtrTraits>(), \
+            x_offset_ptrs,                                                    \
+            y_reshaped                                                        \
+                .packed_accessor32<scalar_t, 3, at::RestrictPtrTraits>(),     \
+            output_reshaped                                                   \
+                .packed_accessor32<scalar_t, 3, at::RestrictPtrTraits>(),     \
+            jagged_dims_tensor.data_ptr<int64_t>(),                           \
+            f,                                                                \
+            padding_value);                                                   \
+  }
+
+  AT_DISPATCH_INDEX_TYPES(x_offsets[0].scalar_type(), "jagged_indices", [&] {
+    switch (num_jagged_dim) {
+      case 1:
+        INVOKE_KERNEL_WITH_DIM(1);
+        break;
+      case 2:
+        INVOKE_KERNEL_WITH_DIM(2);
+        break;
+      case 3:
+        INVOKE_KERNEL_WITH_DIM(3);
+        break;
+      case 4:
+        INVOKE_KERNEL_WITH_DIM(4);
+        break;
+      case 5:
+        INVOKE_KERNEL_WITH_DIM(5);
+        break;
+      default:
+        TORCH_CHECK(false, "unsupported number of jagged dim ", num_jagged_dim);
+    }
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  });
+
+#undef INVOKE_KERNEL_WITH_DIM
+}
+
+// Almost identical copy of jagged_to_padded_dense in jagged_tensor_ops_cpu.cpp
+Tensor jagged_to_padded_dense(
+    const Tensor& values,
+    const std::vector<Tensor>& offsets,
+    const std::vector<int64_t>& max_lengths,
+    const int64_t padding_value) {
+  const size_t num_jagged_dim = offsets.size();
+  TORCH_CHECK(max_lengths.size() == num_jagged_dim);
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(values.get_device());
 
-  int32_t D = values.size(1);
-  int32_t B = offsets.numel() - 1;
-  auto padded_values = at::empty({B, max_L, D}, values.options());
-  const auto values_contig = values.contiguous();
-  const auto offsets_contig = offsets.contiguous();
+  const Tensor values_canonicalized = values.view(
+      {values.size(0),
+       std::accumulate(
+           values.sizes().begin() + 1,
+           values.sizes().end(),
+           1,
+           std::multiplies<size_t>())});
+  at::DimVector padded_values_shape({offsets[0].size(0) - 1});
+  padded_values_shape.insert(
+      padded_values_shape.end(), max_lengths.begin(), max_lengths.end());
+  if (values.dim() > 1) {
+    padded_values_shape.push_back(values.size(-1));
+  }
+  Tensor padded_values = at::empty(padded_values_shape, values.options());
+  Tensor padded_values_view =
+      values.dim() == 1 ? padded_values.unsqueeze(-1) : padded_values;
 
-  AT_DISPATCH_INDEX_TYPES(
-      offsets.scalar_type(), "jagged_2d_to_dense_forward_kernel_1", [&] {
-        AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-            values.scalar_type(), "jagged_2d_to_dense_forward_kernel_2", [&] {
-              jagged_2d_to_dense_forward_kernel<index_t, scalar_t>
-                  <<<div_round_up((B * max_L), kMaxThreads / kWarpSize),
-                     dim3(kWarpSize, kMaxThreads / kWarpSize),
-                     0,
-                     at::cuda::getCurrentCUDAStream()>>>(
-                      B,
-                      max_L,
-                      D,
-                      offsets_contig.data_ptr<index_t>(),
-                      values_contig.data_ptr<scalar_t>(),
-                      padded_values.data_ptr<scalar_t>());
-              C10_CUDA_KERNEL_LAUNCH_CHECK();
-            });
+  AT_DISPATCH_ALL_TYPES_AND(
+      at::ScalarType::Half,
+      values.scalar_type(),
+      "jagged_to_padded_dense",
+      [&] {
+        jagged_dense_elementwise_dense_output_<scalar_t>(
+            values_canonicalized,
+            offsets,
+            padded_values_view, // dummy not used in the lambda function
+            padded_values_view,
+            [] __device__(scalar_t x, scalar_t /*unused*/) -> scalar_t {
+              return x;
+            },
+            static_cast<scalar_t>(padding_value));
       });
 
   return padded_values;
+}
+
+} // namespace
+
+Tensor
+jagged_2d_to_dense_forward_cuda(Tensor values, Tensor offsets, int32_t max_L) {
+  TORCH_CHECK(values.dim() == 2);
+  TORCH_CHECK(offsets.dim() == 1);
+  TORCH_CHECK(max_L > 0);
+
+  return jagged_to_padded_dense(values, {offsets}, {max_L}, 0);
 }
 
 template <typename index_t, typename scalar_t>
@@ -161,69 +351,16 @@ Tensor jagged_2d_to_dense_backward_cuda(
   return grad_values;
 }
 
-template <typename index_t, typename scalar_t>
-__global__ void jagged_1d_to_dense_kernel(
-    int32_t B,
-    int32_t max_L,
-    scalar_t padding_value,
-    index_t* offsets,
-    scalar_t* values,
-    scalar_t* padded_values) {
-  const int32_t b_l = blockIdx.x * blockDim.x + threadIdx.x;
-  if (b_l >= B * max_L) {
-    return;
-  }
-  int32_t b = b_l / max_L;
-  int32_t l = b_l % max_L;
-  int32_t row_start = offsets[b];
-  int32_t row_end = offsets[b + 1];
-  int32_t length = row_end - row_start;
-  if (l < length) {
-    padded_values[b * max_L + l] = values[row_start + l];
-  } else {
-    padded_values[b * max_L + l] = padding_value;
-  }
-}
-
 Tensor jagged_1d_to_dense_gpu(
     Tensor values,
     Tensor offsets,
     int64_t max_L,
     int64_t padding_value) {
-  TENSOR_ON_CUDA_GPU(values);
-  TENSOR_ON_CUDA_GPU(offsets);
-
   TORCH_CHECK(values.dim() == 1);
   TORCH_CHECK(offsets.dim() == 1);
   TORCH_CHECK(max_L > 0);
-  at::cuda::OptionalCUDAGuard device_guard;
-  device_guard.set_index(values.get_device());
 
-  int32_t B = offsets.numel() - 1;
-  auto padded_values = at::empty({B, max_L}, values.options());
-  const auto values_contig = values.contiguous();
-  const auto offsets_contig = offsets.contiguous();
-  const int32_t num_threads = 512; // 256~1024 per xingl
-  AT_DISPATCH_INDEX_TYPES(
-      offsets.scalar_type(), "jagged_1d_to_dense_kernel_1", [&] {
-        AT_DISPATCH_ALL_TYPES(
-            values.scalar_type(), "jagged_1d_to_dense_kernel_2", [&] {
-              jagged_1d_to_dense_kernel<index_t, scalar_t>
-                  <<<div_round_up(B * max_L, num_threads),
-                     num_threads,
-                     0,
-                     at::cuda::getCurrentCUDAStream()>>>(
-                      B,
-                      max_L,
-                      static_cast<scalar_t>(padding_value),
-                      offsets_contig.data_ptr<index_t>(),
-                      values_contig.data_ptr<scalar_t>(),
-                      padded_values.data_ptr<scalar_t>());
-              C10_CUDA_KERNEL_LAUNCH_CHECK();
-            });
-      });
-
-  return padded_values;
+  return jagged_to_padded_dense(values, {offsets}, {max_L}, padding_value);
 }
 
 // stacked ops
@@ -238,7 +375,6 @@ stacked_jagged_2d_to_dense_forward_cuda(
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(values.get_device());
 
-  const auto values_contig = values.contiguous();
   const auto lengths_contig = lengths.contiguous();
   int32_t D = values.size(1);
   int32_t B = lengths.size(1);
@@ -274,31 +410,11 @@ stacked_jagged_2d_to_dense_forward_cuda(
               at::cuda::getCurrentCUDAStream()));
         });
     offsets_tensor_per_key.push_back(offsets);
-    auto padded_values = at::empty({B, max_L, D}, values.options());
-    padded_values_per_key.push_back(padded_values);
-    int64_t start = offset_per_key[t] * D;
-    AT_DISPATCH_INDEX_TYPES(
-        offsets.scalar_type(), "jagged_2d_to_dense_forward_kernel_1", [&] {
-          AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-              values.scalar_type(), "jagged_2d_to_dense_forward_kernel_2", [&] {
-                jagged_2d_to_dense_forward_kernel<index_t, scalar_t>
-                    <<<fbgemm_gpu::div_round_up(
-                           (B * max_L),
-                           fbgemm_gpu::kMaxThreads / fbgemm_gpu::kWarpSize),
-                       dim3(
-                           fbgemm_gpu::kWarpSize,
-                           fbgemm_gpu::kMaxThreads / fbgemm_gpu::kWarpSize),
-                       0,
-                       at::cuda::getCurrentCUDAStream()>>>(
-                        B,
-                        max_L,
-                        D,
-                        offsets.data_ptr<index_t>(),
-                        &(values_contig.data_ptr<scalar_t>()[start]),
-                        padded_values.data_ptr<scalar_t>());
-                C10_CUDA_KERNEL_LAUNCH_CHECK();
-              });
-        });
+
+    padded_values_per_key.push_back(jagged_2d_to_dense_forward_cuda(
+        values.slice(0, offset_per_key[t], offset_per_key[t + 1]),
+        offsets,
+        max_L));
   }
 
   return std::make_tuple(padded_values_per_key, offsets_tensor_per_key);
@@ -368,7 +484,6 @@ std::vector<Tensor> stacked_jagged_1d_to_dense_gpu(
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(values.get_device());
 
-  const auto values_contig = values.contiguous();
   const auto lengths_contig = lengths.contiguous();
   int32_t B = lengths.size(1);
   int32_t T = lengths.size(0);
@@ -401,31 +516,20 @@ std::vector<Tensor> stacked_jagged_1d_to_dense_gpu(
               B,
               at::cuda::getCurrentCUDAStream()));
         });
-    auto padded_values = at::empty({B, max_L}, values.options());
-    padded_values_per_key.push_back(padded_values);
-    int64_t start = offset_per_key[t];
-    const int32_t num_threads = 512; // 256~1024 per xingl
-    AT_DISPATCH_INDEX_TYPES(
-        offsets.scalar_type(), "jagged_1d_to_dense_kernel_1", [&] {
-          AT_DISPATCH_ALL_TYPES(
-              values.scalar_type(), "jagged_1d_to_dense_kernel_2", [&] {
-                jagged_1d_to_dense_kernel<index_t, scalar_t>
-                    <<<div_round_up(B * max_L, num_threads),
-                       num_threads,
-                       0,
-                       at::cuda::getCurrentCUDAStream()>>>(
-                        B,
-                        max_L,
-                        static_cast<scalar_t>(padding_value),
-                        offsets.data_ptr<index_t>(),
-                        &(values_contig.data_ptr<scalar_t>()[start]),
-                        padded_values.data_ptr<scalar_t>());
-                C10_CUDA_KERNEL_LAUNCH_CHECK();
-              });
-        });
+
+    padded_values_per_key.push_back(jagged_1d_to_dense_gpu(
+        values.slice(0, offset_per_key[t], offset_per_key[t + 1]),
+        offsets,
+        max_L,
+        padding_value));
   }
 
   return padded_values_per_key;
 }
 
 } // namespace fbgemm_gpu
+
+TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
+  DISPATCH_TO_CUDA(
+      "jagged_to_padded_dense", fbgemm_gpu::jagged_to_padded_dense);
+}

--- a/fbgemm_gpu/src/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_cpu.cpp
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <torch/library.h>
+
+#include "fbgemm_gpu/sparse_ops_utils.h"
+
+namespace fbgemm_gpu {
+
+using Tensor = at::Tensor;
+
+namespace {
+
+// Ref. http://tensor-compiler.org/kjolstad-oopsla17-tensor-compiler.pdf
+template <int NUM_JAGGED_DIM, typename index_t>
+inline bool walk_down_tensor_storage_tree_except_last_(
+    int& offset,
+    const int flattened_jagged_idx,
+    const int64_t* jagged_dims,
+    const std::vector<at::TensorAccessor<index_t, 1>>& x_offsets) {
+  // compute coorindates
+  int jagged_coords[NUM_JAGGED_DIM];
+  int j_temp = flattened_jagged_idx;
+#pragma unroll
+  for (int d = NUM_JAGGED_DIM - 2; d >= 0; --d) {
+    const int jagged_size = jagged_dims[d + 1];
+    jagged_coords[d] = j_temp % jagged_size;
+    j_temp /= jagged_size;
+  }
+
+  bool is_zero = false;
+#pragma unroll
+  for (int d = 0; d < NUM_JAGGED_DIM - 1; ++d) {
+    const int begin = x_offsets[d][offset];
+    const int end = x_offsets[d][offset + 1];
+    if (jagged_coords[d] >= end - begin) {
+      is_zero = true;
+      break;
+    }
+    offset = begin + jagged_coords[d];
+  }
+  return is_zero;
+}
+
+template <typename index_t>
+std::vector<at::TensorAccessor<index_t, 1>> collect_offsets_accessors(
+    const std::vector<Tensor>& x_offsets,
+    const int outer_dense_size,
+    const int num_jagged_dim) {
+  // Also check x_offsets are consistent
+  int num_lengths_expected = outer_dense_size;
+  std::vector<at::TensorAccessor<index_t, 1>> x_offsets_accessors;
+  for (int d = 0; d < num_jagged_dim; ++d) {
+    TENSOR_ON_CPU(x_offsets[d]);
+    x_offsets_accessors.emplace_back(x_offsets[d].accessor<index_t, 1>());
+    TORCH_CHECK(x_offsets[d].numel() == num_lengths_expected + 1);
+    auto num_lengths = x_offsets_accessors[d][x_offsets[d].numel() - 1];
+    num_lengths_expected = num_lengths;
+  }
+
+  return x_offsets_accessors;
+}
+
+/**
+ * @tparam F element wise compute functor
+ * @param padding_value instead of zero, can configure the padding
+ *                      value for x_values
+ *
+ * See more details comments at jagged_elementwise_dense_output_kernel in
+ * jagged_tensor_ops.cu
+ */
+template <
+    int NUM_JAGGED_DIM,
+    bool NO_INNER_DENSE,
+    typename scalar_t,
+    typename F>
+void jagged_dense_elementwise_dense_output_kernel_(
+    const Tensor& x_values,
+    const std::vector<Tensor>& x_offsets,
+    const Tensor& y,
+    const Tensor& output,
+    F f,
+    const scalar_t& padding_value) {
+  TENSOR_ON_CPU(x_values);
+  TENSOR_ON_CPU(y);
+  TENSOR_ON_CPU(output);
+
+  TORCH_CHECK(x_offsets.size() == static_cast<size_t>(NUM_JAGGED_DIM));
+
+  const int outer_dense_size = y.size(0);
+  TORCH_CHECK(outer_dense_size == x_offsets[0].numel() - 1);
+  TORCH_CHECK(!NO_INNER_DENSE || y.size(-1) == 1);
+  const int inner_dense_size = NO_INNER_DENSE ? 1 : y.size(-1);
+  TORCH_CHECK(inner_dense_size == x_values.size(-1));
+  const int jagged_folded_size =
+      y.numel() / (outer_dense_size * inner_dense_size);
+  const int jagged_innermost_size = y.size(-2);
+
+  // Canonicalize y and output to 3D, collapsing jagged dimensions.
+  const Tensor y_reshaped = y.view({y.size(0), -1, y.size(-1)});
+  Tensor output_reshaped = output.view(y_reshaped.sizes());
+
+  AT_DISPATCH_INDEX_TYPES(x_offsets[0].scalar_type(), "jagged_indices", [&] {
+    const std::vector<at::TensorAccessor<index_t, 1>> x_offsets_accessors =
+        collect_offsets_accessors<index_t>(
+            x_offsets, outer_dense_size, NUM_JAGGED_DIM);
+
+    const at::TensorAccessor<scalar_t, 2> x_accessor =
+        x_values.accessor<scalar_t, 2>();
+    const at::TensorAccessor<scalar_t, 3> y_accessor =
+        y_reshaped.accessor<scalar_t, 3>();
+    at::TensorAccessor<scalar_t, 3> output_accessor =
+        output_reshaped.accessor<scalar_t, 3>();
+
+    for (int oidx = 0; oidx < outer_dense_size; ++oidx) {
+      for (int joidx = 0; joidx < jagged_folded_size / jagged_innermost_size;
+           ++joidx) {
+        int offset_base = oidx;
+        const bool is_zero =
+            walk_down_tensor_storage_tree_except_last_<NUM_JAGGED_DIM>(
+                offset_base, joidx, y.sizes().data(), x_offsets_accessors);
+
+        // As a perf optimization, a separate loop level for the inner-most
+        // jagged dimension.
+        int jiidx = 0;
+        if (!is_zero) {
+          const int begin =
+              x_offsets_accessors[NUM_JAGGED_DIM - 1][offset_base];
+          const int end =
+              x_offsets_accessors[NUM_JAGGED_DIM - 1][offset_base + 1];
+          for (; jiidx < end - begin; ++jiidx) {
+            int jidx = joidx * jagged_innermost_size + jiidx;
+            if (NO_INNER_DENSE) {
+              output_accessor[oidx][jidx][0] =
+                  f(x_accessor[begin + jiidx][0], y_accessor[oidx][jidx][0]);
+            } else {
+              for (int iidx = 0; iidx < inner_dense_size; ++iidx) {
+                output_accessor[oidx][jidx][iidx] =
+                    f(x_accessor[begin + jiidx][iidx],
+                      y_accessor[oidx][jidx][iidx]);
+              }
+            }
+          }
+        }
+        for (; jiidx < jagged_innermost_size; ++jiidx) {
+          int jidx = joidx * jagged_innermost_size + jiidx;
+          if (NO_INNER_DENSE) {
+            output_accessor[oidx][jidx][0] =
+                f(padding_value, y_accessor[oidx][jidx][0]);
+          } else {
+            for (int iidx = 0; iidx < inner_dense_size; ++iidx) {
+              output_accessor[oidx][jidx][iidx] =
+                  f(padding_value, y_accessor[oidx][jidx][iidx]);
+            }
+          }
+        }
+      } // for each joidx
+    } // for each oidx
+  });
+}
+
+template <typename scalar_t, typename F>
+void jagged_dense_elementwise_dense_output_(
+    const Tensor& x_values,
+    const std::vector<Tensor>& x_offsets,
+    const Tensor& y,
+    const Tensor& output,
+    F f,
+    const scalar_t& padding_value = static_cast<scalar_t>(0)) {
+#define INVOKE_KERNEL_WITH_DIM(NUM_JAGGED_DIM)                            \
+  if (y.size(-1) == 1) {                                                  \
+    jagged_dense_elementwise_dense_output_kernel_<NUM_JAGGED_DIM, true>(  \
+        x_values, x_offsets, y, output, f, padding_value);                \
+  } else {                                                                \
+    jagged_dense_elementwise_dense_output_kernel_<NUM_JAGGED_DIM, false>( \
+        x_values, x_offsets, y, output, f, padding_value);                \
+  }
+
+  const int num_jagged_dim = y.dim() - 2;
+  switch (num_jagged_dim) {
+    case 1:
+      INVOKE_KERNEL_WITH_DIM(1);
+      break;
+    case 2:
+      INVOKE_KERNEL_WITH_DIM(2);
+      break;
+    case 3:
+      INVOKE_KERNEL_WITH_DIM(3);
+      break;
+    case 4:
+      INVOKE_KERNEL_WITH_DIM(4);
+      break;
+    case 5:
+      INVOKE_KERNEL_WITH_DIM(5);
+      break;
+    default:
+      TORCH_CHECK(false, "unsupported number of jagged dim ", num_jagged_dim);
+  }
+
+#undef INVOKE_KERNEL_WITH_DIM
+}
+
+Tensor jagged_to_padded_dense(
+    const Tensor& values,
+    const std::vector<Tensor>& offsets,
+    const std::vector<int64_t>& max_lengths,
+    const int64_t padding_value = 0) {
+  const size_t num_jagged_dim = offsets.size();
+  TORCH_CHECK(max_lengths.size() == num_jagged_dim);
+
+  const Tensor values_canonicalized = values.view(
+      {values.size(0),
+       std::accumulate(
+           values.sizes().begin() + 1,
+           values.sizes().end(),
+           1,
+           std::multiplies<size_t>())});
+  at::DimVector padded_values_shape({offsets[0].size(0) - 1});
+  padded_values_shape.insert(
+      padded_values_shape.end(), max_lengths.begin(), max_lengths.end());
+  if (values.dim() > 1) {
+    padded_values_shape.push_back(values.size(-1));
+  }
+  Tensor padded_values = at::empty(padded_values_shape, values.options());
+  Tensor padded_values_view =
+      values.dim() == 1 ? padded_values.unsqueeze(-1) : padded_values;
+
+  AT_DISPATCH_ALL_TYPES_AND(
+      at::ScalarType::Half,
+      values.scalar_type(),
+      "jagged_to_padded_dense",
+      [&] {
+        jagged_dense_elementwise_dense_output_<scalar_t>(
+            values_canonicalized,
+            offsets,
+            padded_values_view, // dummy not used in the lambda function
+            padded_values_view,
+            [](scalar_t x, scalar_t /*unused*/) -> scalar_t { return x; },
+            static_cast<scalar_t>(padding_value));
+      });
+
+  return padded_values;
+}
+
+} // namespace
+
+Tensor
+jagged_2d_to_dense_forward_cpu(Tensor values, Tensor offsets, int64_t max_L) {
+  TORCH_CHECK(values.dim() == 2);
+  TORCH_CHECK(offsets.dim() == 1);
+  TORCH_CHECK(max_L > 0);
+
+  return jagged_to_padded_dense(values, {offsets}, {max_L});
+}
+
+Tensor jagged_1d_to_dense_cpu(
+    Tensor values,
+    Tensor offsets,
+    int64_t max_L,
+    int64_t padding_value) {
+  TORCH_CHECK(values.dim() == 1);
+  TORCH_CHECK(offsets.dim() == 1);
+  TORCH_CHECK(max_L > 0);
+
+  return jagged_to_padded_dense(values, {offsets}, {max_L}, padding_value);
+}
+} // namespace fbgemm_gpu
+
+TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  m.def(
+      "jagged_2d_to_dense(Tensor values, Tensor offsets, int max_sequence_length) -> Tensor");
+  m.def(
+      "jagged_1d_to_dense(Tensor values, Tensor offsets, int max_sequence_length, int padding_value) -> Tensor");
+  m.def(
+      "stacked_jagged_2d_to_dense_forward(Tensor values, Tensor lengths, int[] offset_per_key, int[] max_lengths_per_key) -> (Tensor[], Tensor[])");
+  m.def(
+      "stacked_jagged_2d_to_dense_backward(int B, int D, int total_L, Tensor[] grad_padded_values_per_key, Tensor[] offsets_tensor_per_key, int[] offset_per_key) -> Tensor");
+  m.def(
+      "stacked_jagged_1d_to_dense(Tensor values, Tensor lengths, int[] offset_per_key, int[] max_lengths_per_key, int padding_value) -> Tensor[]");
+  m.def(
+      "stacked_jagged_2d_to_dense(Tensor values, Tensor lengths, int[] offset_per_key, int[] max_lengths_per_key) -> Tensor[]");
+  m.def(
+      "jagged_to_padded_dense(Tensor values, Tensor[] offsets, int[] max_lengths, int padding_value = 0) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
+  DISPATCH_TO_CPU(
+      "jagged_2d_to_dense", fbgemm_gpu::jagged_2d_to_dense_forward_cpu);
+  DISPATCH_TO_CPU("jagged_1d_to_dense", fbgemm_gpu::jagged_1d_to_dense_cpu);
+  DISPATCH_TO_CPU("jagged_to_padded_dense", fbgemm_gpu::jagged_to_padded_dense);
+}


### PR DESCRIPTION
Summary:
Kernels that support arbitrary number of jagged dimensions and parameterized with an element-wise operation functor.
We first use the kernels for jagged_1/2d_to_dense.

Reviewed By: jasonjk-park

Differential Revision: D34804180

