### PR TITLE
Fix the OSS build error for fbgemm/torchrec

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
@@ -273,15 +273,6 @@ constexpr uint32_t cuda_calc_block_count(
       case 2:                                                                 \
         INVOKE_KERNEL_WITH_DIM(2);                                            \
         break;                                                                \
-      case 3:                                                                 \
-        INVOKE_KERNEL_WITH_DIM(3);                                            \
-        break;                                                                \
-      case 4:                                                                 \
-        INVOKE_KERNEL_WITH_DIM(4);                                            \
-        break;                                                                \
-      case 5:                                                                 \
-        INVOKE_KERNEL_WITH_DIM(5);                                            \
-        break;                                                                \
       default:                                                                \
         TORCH_CHECK(                                                          \
             false, "unsupported number of jagged dim ", num_jagged_dim);      \

--- a/fbgemm_gpu/test/sparse_ops_test.py
+++ b/fbgemm_gpu/test/sparse_ops_test.py
@@ -1610,7 +1610,7 @@ class SparseOpsTest(unittest.TestCase):
 
     # pyre-ignore [56]
     @given(
-        num_jagged_dim=st.integers(1, 5),
+        num_jagged_dim=st.integers(1, 2),
         outer_dense_size=st.integers(0, 5),
         inner_dense_size=st.integers(0, 5),
         use_cpu=st.booleans() if gpu_available else st.just(True),
@@ -1660,7 +1660,7 @@ class SparseOpsTest(unittest.TestCase):
 
     # pyre-ignore [56]
     @given(
-        num_jagged_dim=st.integers(1, 4),
+        num_jagged_dim=st.integers(1, 2),
         outer_dense_size=st.integers(0, 4),
         inner_dense_size=st.integers(0, 4),
         operation=st.sampled_from(["add", "mul"]),


### PR DESCRIPTION
Summary:
OSS failure from D34840551 (https://github.com/pytorch/FBGEMM/commit/43c0f12abda5e1e4c7b424968bddfabf23de9ed5):

- fbgemm_gpu: https://github.com/pytorch/FBGEMM/runs/5616872090?check_suite_focus=true
- TorchRec:  https://github.com/pytorch/torchrec/runs/5604628984?check_suite_focus=true

```
/home/ec2-user/actions-runner/_work/FBGEMM/FBGEMM/fbgemm_gpu/src/jagged_tensor_ops.cu:200:6: internal compiler error: in maybe_undo_parenthesized_ref, at cp/semantics.c:1739
   JAGGED_TENSOR_DISPATCH_DIMS();
```

Make num_jagged_dim to be only 1 / 2 before we can figuring out a way to bypass such compiler issue.

Differential Revision: D35028747

