### PR TITLE
add jagged + dense add with jagged output

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops.cu
@@ -406,7 +406,6 @@ class JaggedDenseAddGPUOp
       const Tensor& y) {
     ctx->save_for_backward(x_offsets);
     ctx->saved_data["x_values_shape"] = x_values.sizes();
-    ctx->saved_data["y_shape"] = y.sizes();
 
     at::cuda::OptionalCUDAGuard device_guard;
     device_guard.set_index(x_values.get_device());
@@ -431,7 +430,6 @@ class JaggedDenseAddGPUOp
       torch::autograd::variable_list grad_outputs) {
     auto offsets = ctx->get_saved_variables();
     auto x_values_shape = ctx->saved_data["x_values_shape"].toIntVector();
-    auto y_shape = ctx->saved_data["y_shape"].toIntVector();
     TORCH_CHECK(grad_outputs.size() == 1);
 
     at::cuda::OptionalCUDAGuard device_guard;

--- a/fbgemm_gpu/src/jagged_tensor_ops.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops.cu
@@ -464,6 +464,73 @@ Tensor jagged_dense_elementwise_add(
   return JaggedDenseAddGPUOp::apply(x_values, x_offsets, y)[0];
 }
 
+// Unlike JaggedDenseAddGPUOp that treats "zeros" as zeros so adding with
+// a dense tensor results in a dense tensor, this operator treats "zeros" as
+// undefined so resulting a jagged tensor.
+class JaggedDenseAddJaggedOutputGPUOp
+    : public torch::autograd::Function<JaggedDenseAddJaggedOutputGPUOp> {
+ public:
+  static torch::autograd::variable_list forward(
+      torch::autograd::AutogradContext* ctx,
+      const Tensor& x_values,
+      const std::vector<Tensor>& x_offsets,
+      const Tensor& y) {
+    ctx->save_for_backward(x_offsets);
+    ctx->saved_data["y_shape"] = y.sizes();
+
+    at::cuda::OptionalCUDAGuard device_guard;
+    device_guard.set_index(x_values.get_device());
+
+    Tensor output;
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+        x_values.scalar_type(), "jagged_dense_add_forward", [&] {
+          output = jagged_dense_elementwise_jagged_output_<scalar_t>(
+              x_values,
+              x_offsets,
+              y,
+              [] __device__(scalar_t x, scalar_t y) -> scalar_t {
+                return x + y;
+              });
+        });
+
+    return {output};
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext* ctx,
+      torch::autograd::variable_list grad_outputs) {
+    auto offsets = ctx->get_saved_variables();
+    auto y_shape = ctx->saved_data["y_shape"].toIntVector();
+    TORCH_CHECK(grad_outputs.size() == 1);
+
+    at::cuda::OptionalCUDAGuard device_guard;
+    device_guard.set_index(grad_outputs[0].get_device());
+
+    Tensor y_values_grad = jagged_to_padded_dense(
+        grad_outputs[0],
+        offsets,
+        std::vector<int64_t>(y_shape.begin() + 1, y_shape.end() - 1),
+        /*padding_value=*/0);
+    TORCH_CHECK(y_values_grad.sizes() == y_shape);
+
+    return {
+        grad_outputs[0],
+        torch::autograd::Variable(), // x_offsets
+        y_values_grad};
+  }
+};
+
+// output = x + y where x is jagged, y and output are dense
+std::tuple<Tensor, std::vector<Tensor>>
+jagged_dense_elementwise_add_jagged_output(
+    const Tensor& x_values,
+    const std::vector<Tensor>& x_offsets,
+    const Tensor& y) {
+  return {
+      JaggedDenseAddJaggedOutputGPUOp::apply(x_values, x_offsets, y)[0],
+      x_offsets};
+}
+
 /**
  * output = f(x, y) where x and y are jagged (and share x_offsets), and output
  * is dense.
@@ -1128,6 +1195,9 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
       "jagged_to_padded_dense", fbgemm_gpu::jagged_to_padded_dense);
   DISPATCH_TO_CUDA(
       "jagged_dense_elementwise_add", fbgemm_gpu::jagged_dense_elementwise_add);
+  DISPATCH_TO_CUDA(
+      "jagged_dense_elementwise_add_jagged_output",
+      fbgemm_gpu::jagged_dense_elementwise_add_jagged_output);
   DISPATCH_TO_CUDA(
       "jagged_dense_elementwise_mul", fbgemm_gpu::jagged_dense_elementwise_mul);
   DISPATCH_TO_CUDA(

--- a/fbgemm_gpu/src/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_cpu.cpp
@@ -423,7 +423,6 @@ class JaggedDenseAddCPUOp
       const Tensor& y) {
     ctx->save_for_backward(x_offsets);
     ctx->saved_data["x_values_shape"] = x_values.sizes();
-    ctx->saved_data["y_shape"] = y.sizes();
 
     Tensor output;
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
@@ -442,7 +441,6 @@ class JaggedDenseAddCPUOp
       torch::autograd::variable_list grad_outputs) {
     auto offsets = ctx->get_saved_variables();
     auto x_values_shape = ctx->saved_data["x_values_shape"].toIntVector();
-    auto y_shape = ctx->saved_data["y_shape"].toIntVector();
     TORCH_CHECK(grad_outputs.size() == 1);
 
     Tensor x_values_grad = at::empty(x_values_shape, grad_outputs[0].options());
@@ -868,6 +866,8 @@ class BatchedDenseVecJagged2DMulCPUOp
                       a_values_grad.accessor<scalar_t, 2>());
                 });
           });
+    } else {
+      v_grad.zero_();
     }
 
     return {


### PR DESCRIPTION
Summary: Add elementwise add of a jagged tensor with a dense tensor version that outputs jagged tensor, treating "zeros" in the input jagged tensor as undefined.

Differential Revision: D35086082

