### PR TITLE
fbgemm_gpu: dense tensor to jagged tensor conversion

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_cpu.cpp
@@ -512,6 +512,76 @@ Tensor jagged_dense_elementwise_add(
   return JaggedDenseAddCPUOp::apply(x_values, x_offsets, y)[0];
 }
 
+// TODO: Add option to pass in total_L
+class DenseToJaggedCPUOp
+    : public torch::autograd::Function<DenseToJaggedCPUOp> {
+ public:
+  static torch::autograd::variable_list forward(
+      torch::autograd::AutogradContext* ctx,
+      const Tensor& dense,
+      const std::vector<Tensor>& offsets,
+      const c10::optional<int64_t>& total_L) {
+    ctx->save_for_backward(offsets);
+
+    // dims of dense tensor: <batch, [maxlen0, maxlen1, ...], embedding_dim>
+    ctx->saved_data["dense_shape"] = dense.sizes();
+
+    // D is the embedding dimension
+    auto D = dense.size(-1);
+
+    // If total_L is not given then compute it
+    int64_t total_L_computed;
+    if (total_L.has_value()) {
+      total_L_computed = total_L.value();
+    } else {
+      total_L_computed = (int64_t)offsets.back().max().item<int64_t>();
+    }
+    auto values = at::empty({total_L_computed, D}, dense.options());
+    auto output = at::zeros({total_L_computed, D}, dense.options());
+
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+        values.scalar_type(), "jagged_scalars", [&] {
+          jagged_dense_elementwise_jagged_output_<scalar_t>(
+              values,
+              offsets,
+              dense,
+              output,
+              [](scalar_t /*unused*/, scalar_t y) -> scalar_t { return y; });
+        });
+
+    return {output};
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext* ctx,
+      torch::autograd::variable_list grad_outputs) {
+    auto offsets = ctx->get_saved_variables();
+    auto dense_shape = ctx->saved_data["dense_shape"].toIntVector();
+    TORCH_CHECK(grad_outputs.size() == 1);
+
+    Tensor dense_values_grad = jagged_to_padded_dense(
+        grad_outputs[0],
+        offsets,
+        std::vector<int64_t>(dense_shape.begin() + 1, dense_shape.end() - 1),
+        /*padding_value=*/0);
+    TORCH_CHECK(dense_values_grad.sizes() == dense_shape);
+
+    return {
+        dense_values_grad,
+        torch::autograd::Variable(), // offsets
+        torch::autograd::Variable() // total_L
+    };
+  }
+};
+
+// output = x + y where x is jagged, y is dense, and output is jagged
+std::tuple<Tensor, std::vector<Tensor>> dense_to_jagged_cpu(
+    const Tensor& dense,
+    const std::vector<Tensor>& offsets,
+    const c10::optional<int64_t>& total_L) {
+  return {DenseToJaggedCPUOp::apply(dense, offsets, total_L)[0], offsets};
+}
+
 // Unlike JaggedDenseAddGPUOp that treats "zeros" as zeros so adding with
 // a dense tensor results in a dense tensor, this operator treats "zeros" as
 // undefined so resulting a jagged tensor.
@@ -1023,6 +1093,9 @@ Tensor jagged_1d_to_dense_cpu(
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  // (dense, offsets) -> jagged. Offsets output is same as input.
+  m.def(
+      "dense_to_jagged(Tensor dense, Tensor[] x_offsets, int? total_L=None) -> (Tensor, Tensor[])");
   m.def(
       "jagged_2d_to_dense(Tensor values, Tensor offsets, int max_sequence_length) -> Tensor");
   m.def(
@@ -1055,6 +1128,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
   DISPATCH_TO_CPU(
       "jagged_2d_to_dense", fbgemm_gpu::jagged_2d_to_dense_forward_cpu);
   DISPATCH_TO_CPU("jagged_1d_to_dense", fbgemm_gpu::jagged_1d_to_dense_cpu);
+  DISPATCH_TO_CPU("dense_to_jagged", fbgemm_gpu::dense_to_jagged_cpu);
   DISPATCH_TO_CPU("jagged_to_padded_dense", fbgemm_gpu::jagged_to_padded_dense);
   DISPATCH_TO_CPU(
       "jagged_dense_elementwise_add", fbgemm_gpu::jagged_dense_elementwise_add);


### PR DESCRIPTION
Summary:
Add torch.ops.fbgemm.dense_to_jagged which converts a dense tensor and corresponding offsets into a jagged tensor:

```dense_to_jagged(dense, [offsets,...], total_L (optional) ) -> (values, [offsets, ...])```

*dense* is a tensor with dimensions: (batch_size x max_index0 x max_index1 x ... x embedding_dim)

*offsets* is a list of 1D tensors with offsets (the cumulative sum of lengths) for each dimension of the jagged tensor.

*total_L* is an integer with the total number of values. If it's not specified then it's automatically computed from the offsets.

*values* is a tensor with dimension (num_lengths x embedding_dim), where num_lengths is also the max index in the offsets lists.

Reviewed By: jspark1105

Differential Revision: D35205853

