### PR TITLE
Add launch_bounds constraint for CUDA kernel to avoid register overuse

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_template.cu
@@ -18,7 +18,7 @@ constexpr size_t kBackwardMaxThreads = 512;
 using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
 
-__global__ void
+__global__ __launch_bounds__(kMaxThreads) void
 split_embedding_backward_codegen_{{ optimizer }}_{{ wdesc }}_find_long_segments(
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         sorted_linear_indices_num_runs,
@@ -39,7 +39,7 @@ split_embedding_backward_codegen_{{ optimizer }}_{{ wdesc }}_find_long_segments(
 }
 
 template <typename grad_t>
-__global__ void __launch_bounds__(kMaxThreads) grad_mean_kernel(
+__global__ __launch_bounds__(kMaxThreads) void grad_mean_kernel(
     const at::PackedTensorAccessor32<grad_t, 2, at::RestrictPtrTraits>
         grad_output,
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
@@ -83,8 +83,7 @@ template <
     typename grad_t,
     typename cache_t,
     size_t kMaxVecsPerThread>
-__global__ void
-__launch_bounds__(kMaxThreads)
+__global__ __launch_bounds__(kMaxThreads) void
 split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_kernel_cta_per_row_1(
     const at::PackedTensorAccessor32<grad_t, 2, at::RestrictPtrTraits> grad_output,
     at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,

--- a/fbgemm_gpu/codegen/embedding_bounds_check.cu
+++ b/fbgemm_gpu/codegen/embedding_bounds_check.cu
@@ -10,7 +10,7 @@ using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
 
 template <typename index_t>
-__global__ void bounds_check_indices_kernel(
+__global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel(
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         rows_per_table,
     at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_split_template.cu
@@ -472,7 +472,7 @@ __device__ inline uint32_t pruned_hash_function(uint32_t h) {
     return h;
 }
 
-__global__ void int_nbit_split_embedding_codegen_forward_pruned_hashmap_lookup_{{ wdesc }}_kernel(
+__global__ __launch_bounds__(kMaxThreads) void int_nbit_split_embedding_codegen_forward_pruned_hashmap_lookup_{{ wdesc }}_kernel(
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> indices,
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> offsets,
     const at::PackedTensorAccessor64<int32_t, 2, at::RestrictPtrTraits> hash_table,
@@ -547,7 +547,7 @@ __global__ void int_nbit_split_embedding_codegen_forward_pruned_hashmap_lookup_{
 }
 
 {% if not weighted %}
-__global__ void int_nbit_split_embedding_codegen_forward_pruned_array_lookup_kernel(
+__global__ __launch_bounds__(kMaxThreads) void int_nbit_split_embedding_codegen_forward_pruned_array_lookup_kernel(
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> indices,
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> offsets,
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> index_remappings,

--- a/fbgemm_gpu/include/fbgemm_gpu/bench_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/bench_utils.cuh
@@ -12,7 +12,8 @@
 #include <vector>
 #include "./cuda_utils.cuh"
 
-__global__ void flush_gpu(char* d_flush, char* d_flush2, bool do_write) {
+__global__ __launch_bounds__(
+    kMaxThreads) void flush_gpu(char* d_flush, char* d_flush2, bool do_write) {
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   char val = d_flush[idx];
   if (do_write * val) {

--- a/fbgemm_gpu/src/jagged_tensor_ops.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops.cu
@@ -83,7 +83,8 @@ DEVICE_INLINE bool walk_down_tensor_storage_tree_(
 // warp size.
 // We rely on compiler unrolling the compiler time constant NUM_JAGGED_DIM.
 template <int NUM_JAGGED_DIM, typename index_t, typename scalar_t, typename F>
-__global__ void jagged_dense_elementwise_dense_output_kernel_(
+__global__
+__launch_bounds__(kMaxThreads) void jagged_dense_elementwise_dense_output_kernel_(
     const at::PackedTensorAccessor32<scalar_t, 2, at::RestrictPtrTraits>
         x_values,
     const std::array<index_t*, NUM_JAGGED_DIM> x_offsets,
@@ -238,7 +239,8 @@ Tensor jagged_dense_elementwise_dense_output_(
 }
 
 template <int NUM_JAGGED_DIM, typename index_t, typename scalar_t, typename F>
-__global__ void jagged_dense_elementwise_jagged_output_kernel_(
+__global__
+__launch_bounds__(kMaxThreads) void jagged_dense_elementwise_jagged_output_kernel_(
     const at::PackedTensorAccessor32<scalar_t, 2, at::RestrictPtrTraits>
         x_values,
     const std::array<index_t*, NUM_JAGGED_DIM> x_offsets,
@@ -662,7 +664,8 @@ jagged_dense_elementwise_add_jagged_output(
  * @param padding_value padding_value for the output, not for inputs
  */
 template <int NUM_JAGGED_DIM, typename index_t, typename scalar_t, typename F>
-__global__ void jagged_jagged_elementwise_dense_output_kernel_(
+__global__
+__launch_bounds__(kMaxThreads) void jagged_jagged_elementwise_dense_output_kernel_(
     const at::PackedTensorAccessor32<scalar_t, 2, at::RestrictPtrTraits>
         x_values,
     const std::array<index_t*, NUM_JAGGED_DIM> x_offsets,
@@ -855,7 +858,7 @@ std::tuple<Tensor, std::vector<Tensor>> jagged_dense_elementwise_mul(
 }
 
 template <typename index_t, typename scalar_t>
-__global__ void dense_vec_jagged_2d_bmm(
+__global__ __launch_bounds__(kMaxThreads) void dense_vec_jagged_2d_bmm(
     const at::PackedTensorAccessor32<scalar_t, 2> v,
     const at::PackedTensorAccessor32<scalar_t, 2> a_values,
     const at::PackedTensorAccessor32<index_t, 1> a_offsets,
@@ -893,7 +896,8 @@ __global__ void dense_vec_jagged_2d_bmm(
 }
 
 template <typename index_t, typename scalar_t>
-__global__ void dense_vec_jagged_2d_transposed_bmm(
+__global__
+__launch_bounds__(kMaxThreads) void dense_vec_jagged_2d_transposed_bmm(
     const at::PackedTensorAccessor32<scalar_t, 2> v,
     const at::PackedTensorAccessor32<scalar_t, 2> a_values,
     const at::PackedTensorAccessor32<index_t, 1> a_offsets,
@@ -934,7 +938,7 @@ __global__ void dense_vec_jagged_2d_transposed_bmm(
 }
 
 template <typename index_t, typename scalar_t>
-__global__ void outer_prod_jagged_2d_output(
+__global__ __launch_bounds__(kMaxThreads) void outer_prod_jagged_2d_output(
     const at::PackedTensorAccessor32<scalar_t, 2> x,
     const at::PackedTensorAccessor32<scalar_t, 2> y,
     const at::PackedTensorAccessor32<index_t, 1> offsets,

--- a/fbgemm_gpu/src/sparse_ops.cu
+++ b/fbgemm_gpu/src/sparse_ops.cu
@@ -59,7 +59,7 @@ std::tuple<uint32_t, uint32_t, uint32_t> calc_offsets_range_thread_block(
 
 // Kernel for calculating the offsets ranges
 template <typename scalar_t>
-__global__ void _offsets_range_cuda_kernel(
+__global__ __launch_bounds__(kMaxThreads) void _offsets_range_cuda_kernel(
     int64_t N,
     int64_t range_size,
     const scalar_t* __restrict__ offsets_data,
@@ -127,7 +127,7 @@ Tensor offsets_range_cuda(const Tensor& offsets, int64_t range_size) {
 // Kernel for calculating the segmented sum for sparse matrix with CSR format.
 // See https://moderngpu.github.io/segreduce.html
 template <typename scalar_t>
-__global__ void _segment_sum_csr_cuda_kernel(
+__global__ __launch_bounds__(kMaxThreads) void _segment_sum_csr_cuda_kernel(
     int num_segments,
     int batch_size,
     const int* csr_seg_data,
@@ -306,7 +306,7 @@ template <
     typename offsets_t,
     typename indices_t,
     typename weights_t>
-__global__ void permute_2D_data_kernel(
+__global__ __launch_bounds__(kMaxThreads) void permute_2D_data_kernel(
     int32_t len,
     int32_t T,
     int32_t B,
@@ -341,7 +341,7 @@ __global__ void permute_2D_data_kernel(
 
 // Kernel for permuting the lengths. Used for permutation of sparse features.
 template <typename index_t>
-__global__ void permute_2D_lengths_kernel(
+__global__ __launch_bounds__(kMaxThreads) void permute_2D_lengths_kernel(
     int32_t T,
     int32_t B,
     const index_t* __restrict__ lengths,
@@ -487,7 +487,7 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_2D_sparse_data_cuda(
 
 // Kernel for permuting 1D lengths. Used for permutation of sparse features.
 template <typename index_t>
-__global__ void permute_1D_lengths_kernel(
+__global__ __launch_bounds__(kMaxThreads) void permute_1D_lengths_kernel(
     const index_t* __restrict__ lengths,
     int32_t permuted_lengths_size,
     const int32_t* __restrict__ permute,
@@ -504,7 +504,7 @@ template <
     typename offsets_t,
     typename indices_t,
     typename weights_t>
-__global__ void permute_1D_data_kernel(
+__global__ __launch_bounds__(kMaxThreads) void permute_1D_data_kernel(
     int32_t permuted_indices_size,
     int32_t permuted_lengths_size,
     const indices_t* __restrict__ indices,
@@ -667,7 +667,8 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_1D_sparse_data_cuda(
 // Kernel for generate 1D data permute from dimension permute index.
 // Used for permutation of sparse features.
 template <typename index_t, typename offsets_t>
-__global__ void expand_into_jagged_permute_kernel(
+__global__
+__launch_bounds__(kMaxThreads) void expand_into_jagged_permute_kernel(
     const offsets_t* __restrict__ input_offsets,
     const offsets_t* __restrict__ output_offsets,
     int32_t input_size,
@@ -733,7 +734,8 @@ Tensor expand_into_jagged_permute_cuda(
 // checkpointing with row-wise partition (sparse_feature is partitioned
 // continuously along the sparse dimension into my_size blocks)
 template <typename offset_t, typename index_t>
-__global__ void _block_bucketize_sparse_features_cuda_kernel1(
+__global__
+__launch_bounds__(kMaxThreads) void _block_bucketize_sparse_features_cuda_kernel1(
     int32_t lengths_size,
     int32_t B,
     const index_t* __restrict__ block_sizes_data,
@@ -773,7 +775,8 @@ template <
     typename offset_t,
     typename index_t,
     typename scalar_t>
-__global__ void _block_bucketize_sparse_features_cuda_kernel2(
+__global__
+__launch_bounds__(kMaxThreads) void _block_bucketize_sparse_features_cuda_kernel2(
     int lengths_size,
     int32_t B,
     const index_t* __restrict__ block_sizes_data,
@@ -1230,7 +1233,8 @@ block_bucketize_sparse_features_cuda(
 // partition (sparse_feature is partitioned cyclically along the sparse
 // dimension into my_size blocks)
 template <typename scalar_t>
-__global__ void _bucketize_sparse_features_cuda_kernel1(
+__global__
+__launch_bounds__(kMaxThreads) void _bucketize_sparse_features_cuda_kernel1(
     int lengths_size,
     int my_size,
     const scalar_t* __restrict__ offsets_data,
@@ -1259,7 +1263,8 @@ template <
     bool bucketize_pos,
     typename index_t,
     typename scalar_t>
-__global__ void _bucketize_sparse_features_cuda_kernel2(
+__global__
+__launch_bounds__(kMaxThreads) void _bucketize_sparse_features_cuda_kernel2(
     int lengths_size,
     int my_size,
     const index_t* __restrict__ offsets_data,
@@ -1468,7 +1473,8 @@ bucketize_sparse_features_cuda(
 }
 
 template <typename Dtype>
-__global__ void reorder_batched_ad_lengths_kernel(
+__global__
+__launch_bounds__(kMaxThreads) void reorder_batched_ad_lengths_kernel(
     // reorder lengths from (ragged) [B  x T x #num_ads_b)] to
     // [T][B][#num_ads_b], i.e. [T][sum(#num_ads_b)].
     const at::PackedTensorAccessor32<Dtype, 1, at::RestrictPtrTraits>
@@ -1535,7 +1541,8 @@ Tensor reorder_batched_ad_lengths_gpu(
 }
 
 template <typename Dtype, typename index_t = int32_t>
-__global__ void reorder_batched_ad_indices_kernel(
+__global__
+__launch_bounds__(kMaxThreads) void reorder_batched_ad_indices_kernel(
     // reorder indices from (ragged) [B  x T x #num_ads_b x length_{b, t, a})]
     // to [T][B][#num_ads_b][length_{b, t, a}], i.e. [sum(length_{b, t, a})],
     // laid out as [T][B][A][L] (if all lengths were equal).
@@ -1640,7 +1647,8 @@ Tensor reorder_batched_ad_indices_gpu(
 
 // Forward kernel for batched unary embedding op
 template <typename scalar_t, typename index_t>
-__global__ void batched_unary_embeddings_forward_kernel(
+__global__
+__launch_bounds__(kMaxThreads) void batched_unary_embeddings_forward_kernel(
     const int32_t N,
     const int32_t B,
     const int32_t T,
@@ -1730,7 +1738,8 @@ Tensor batched_unary_embeddings_forward_cuda(
 //    A challenge is there's no available batched GEMM routine with varying K
 //    dimension.
 template <typename scalar_t, typename index_t>
-__global__ void batched_unary_embeddings_backward_kernel(
+__global__
+__launch_bounds__(kMaxThreads) void batched_unary_embeddings_backward_kernel(
     const int32_t N,
     const int32_t B,
     const int32_t T,
@@ -1911,7 +1920,7 @@ Tensor lengths_range_cuda(
 // Kernel for permuting the indices and weights. Used for permutation of
 // sparse features
 template <bool has_weight, typename index_t, typename scalar_t>
-__global__ void permute_indices_weights_kernel(
+__global__ __launch_bounds__(kMaxThreads) void permute_indices_weights_kernel(
     int32_t len,
     int32_t T,
     int32_t B,

--- a/fbgemm_gpu/src/split_embeddings_utils.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils.cu
@@ -60,7 +60,7 @@ using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
 
 template <typename index_t>
-__global__ void linearize_index_kernel(
+__global__ __launch_bounds__(kMaxThreads) void linearize_index_kernel(
     const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         hash_size_cumsum,
     const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
@@ -94,7 +94,7 @@ __global__ void linearize_index_kernel(
 }
 
 template <typename index_t>
-__global__ void nobag_linearize_index_kernel(
+__global__ __launch_bounds__(kMaxThreads) void nobag_linearize_index_kernel(
     const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         hash_size_cumsum,
     const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,


### PR DESCRIPTION
Summary: Address `CUDA error : too many resources requested for launch` error and avoid register overuse.

Differential Revision: D35344926

