### PR TITLE
fbgemm_gpu: Use original storage ptr and correct offsets for all UVM Tensors

### DIFF
--- a/fbgemm_gpu/test/uvm_test.py
+++ b/fbgemm_gpu/test/uvm_test.py
@@ -171,11 +171,16 @@ class UvmTest(unittest.TestCase):
         assert torch.ops.fbgemm.is_uvm_tensor(uvm_t)
         assert torch.ops.fbgemm.uvm_storage(uvm_t)
 
-        # Reference uvm tensor from second cuda device
-        second_t = uvm_t[0]
+        for i in range(sizes[0]):
+            uvm_slice = uvm_t[i]
+            cpu_slice = torch.ops.fbgemm.uvm_to_cpu(uvm_slice)
 
-        assert torch.ops.fbgemm.is_uvm_tensor(second_t)
-        assert torch.ops.fbgemm.uvm_storage(second_t)
+            assert uvm_slice.storage_offset() == cpu_slice.storage_offset()
+            assert uvm_slice.storage().data_ptr() == uvm_t.storage().data_ptr()
+            assert cpu_slice.storage().data_ptr() == uvm_t.storage().data_ptr()
+
+            assert torch.ops.fbgemm.is_uvm_tensor(uvm_slice)
+            assert torch.ops.fbgemm.uvm_storage(cpu_slice)
 
     @unittest.skipIf(*gpu_unavailable)
     @given(


### PR DESCRIPTION
Summary:
Change uvm_to_cpu() to create a new storage object with the same data_ptr as the original storage object and copy the data_offset from the original tensor.

Previously the data_ptr from the original Tensor was used as the data pointer for the storage object and the data offset of the Tensor was set to zero.

This also fixes an issue where the new storage object had an incorrect length as this had just been copied from the original Tensor's storage object. The incorrect length caused issues when the storage object and not the associated Tensor was used to determine valid data.

Differential Revision: D35479829

