### PR TITLE
Specify fbgemm_gpu version as a dynamic field in pyproject.toml

### DIFF
--- a/fbgemm_gpu/pyproject.toml
+++ b/fbgemm_gpu/pyproject.toml
@@ -14,6 +14,7 @@ requires = [
 
 [project]
 name = "fbgemm_gpu"
+dynamic = ["version"]
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
Setuptools start to support `pyproject.toml` to specify project metadata from v61.0.0.
When I use setuptools v61.2.0 or later, building fbgemm_gpu become to be failed. Because [pyproject validation was updated](https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6120) and `project.verson` became required field.

fbgemm_gpu specify the version dynamically in `setup.py`, so we have to also specify version as a dynamic field in pyproject.toml.
I referenced [PEP621](https://peps.python.org/pep-0621/#dynamic) and [setuptools documentation](https://setuptools.pypa.io/en/stable/userguide/pyproject_config.html).

Building error message is like this.

```sh
$ python setup.py bdist_wheel --package_name=fbgemm_gpu_nightly-cpu --cpu_only

['setup.py', 'bdist_wheel', '--package_name=fbgemm_gpu_nightly-cpu', '--cpu_only']
...
configuration error: `project` must contain ['version'] properties
...
ValueError: invalid pyproject.toml config: `project`
```