### PR TITLE
Fix python module import error of rowwise_adagrad_with_weight_decay

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -55,12 +55,14 @@ set(OPTIMIZERS
     adagrad
     adam
     approx_rowwise_adagrad
+    approx_rowwise_adagrad_with_weight_decay
     approx_sgd
     lamb
     lars_sgd
     partial_rowwise_adam
     partial_rowwise_lamb
     rowwise_adagrad
+    rowwise_adagrad_with_weight_decay
     rowwise_weighted_adagrad
     sgd)
 


### PR DESCRIPTION
Fix python `ModuleNotFoundError` when import new modules introduced by https://github.com/pytorch/FBGEMM/commit/1ececf6b249aed6b8d8af9f550df0120666cf67f.

Is it better to add step checking generated code to CI workflows?

```sh
python -c "import fbgemm_gpu.split_embedding_codegen_lookup_invokers"
```