### PR TITLE
Sync optimizers list to FBGEMM_GPU OSS build

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -55,12 +55,14 @@ set(OPTIMIZERS
     adagrad
     adam
     approx_rowwise_adagrad
+    approx_rowwise_adagrad_with_weight_decay
     approx_sgd
     lamb
     lars_sgd
     partial_rowwise_adam
     partial_rowwise_lamb
     rowwise_adagrad
+    rowwise_adagrad_with_weight_decay
     rowwise_weighted_adagrad
     sgd)
 


### PR DESCRIPTION
Summary: New optimizers added to FBGEMM were not included in OSS build list.

Reviewed By: YLGH

Differential Revision: D35613125

