### PR TITLE
enable merge_pooled_embeddings in oss

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -221,6 +221,22 @@ set_source_files_properties(
 # Actual static SOURCES
 #
 
+# Ensure NVML_LIB_PATH is empty if it wasn't set and if the
+# default lib path doesn't exist.
+if(NOT NVML_LIB_PATH)
+  set(DEFAULT_NVML_LIB_PATH
+    "${CUDA_TOOLKIT_ROOT_DIR}/lib64/stubs/libnvidia-ml.so")
+
+  if(EXISTS ${DEFAULT_NVML_LIB_PATH})
+    message(
+      STATUS
+      "Setting NVML_LIB_PATH: \
+      ${CUDA_TOOLKIT_ROOT_DIR}/lib64/stubs/libnvidia-ml.so"
+    )
+    set(NVML_LIB_PATH "${CUDA_TOOLKIT_ROOT_DIR}/lib64/stubs/libnvidia-ml.so")
+  endif()
+endif()
+
 set(fbgemm_gpu_sources_cpu
     codegen/embedding_forward_split_cpu.cpp
     codegen/embedding_forward_quantized_host_cpu.cpp
@@ -240,11 +256,16 @@ if(NOT FBGEMM_CPU_ONLY)
     codegen/embedding_bounds_check_host.cpp
     src/cumem_utils_host.cpp
     src/layout_transform_ops_gpu.cpp
-    # src/merge_pooled_embeddings_cpu.cpp src/merge_pooled_embeddings_gpu.cpp
     src/permute_pooled_embedding_ops_gpu.cpp
     src/quantize_ops_gpu.cpp
     src/sparse_ops_gpu.cpp
     src/split_table_batched_embeddings.cpp)
+
+    if(NVML_LIB_PATH)
+      list(APPEND fbgemm_gpu_sources_cpu
+        src/merge_pooled_embeddings_cpu.cpp
+        src/merge_pooled_embeddings_gpu.cpp)
+    endif()
 endif()
 
 set_source_files_properties(
@@ -292,6 +313,9 @@ endif()
 set_target_properties(fbgemm_gpu_py PROPERTIES PREFIX "")
 
 target_link_libraries(fbgemm_gpu_py ${TORCH_LIBRARIES})
+if(NVML_LIB_PATH)
+  target_link_libraries(fbgemm_gpu_py ${NVML_LIB_PATH})
+endif()
 target_include_directories(fbgemm_gpu_py PRIVATE ${TORCH_INCLUDE_DIRS})
 set_property(TARGET fbgemm_gpu_py PROPERTY CXX_STANDARD 17)
 

--- a/fbgemm_gpu/README.md
+++ b/fbgemm_gpu/README.md
@@ -27,6 +27,15 @@ conda install pytorch cudatoolkit=11.3 -c pytorch-nightly
 conda install scikit-build jinja2 ninja cmake hypothesis
 ```
 
+**If you're planning to build from source** and **don't** have `nvml.h` in your system, you can install it via the command
+below.
+```
+conda install -c conda-forge cudatoolkit-dev
+```
+ Certain operations require this library to be present. Be sure to provide the path to `libnvidia-ml.so` to
+`--nvml_lib_path` if installing from source (e.g. `python setup.py install --nvml_lib_path path_to_libnvidia-ml.so`).
+
+
 ## PIP install
 
 Currently only built with sm70/80 (V100/A100 GPU) wheel supports:

--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -46,6 +46,13 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         default="fbgemm_gpu",
         help="the name of this output wheel",
     )
+    parser.add_argument(
+        "--nvml_lib_path",
+        type=str,
+        default=None,
+        help="Certain operations require the nvml lib (libnvidia-ml.so). If you installed"
+        " this in a custom location (through cudatoolkit-dev), provide the path here.",
+    )
     return parser.parse_known_args(argv)
 
 
@@ -148,6 +155,8 @@ def main(argv: List[str]) -> None:
     cmake_args = [f"-DCMAKE_PREFIX_PATH={torch_root}"]
     if args.cpu_only:
         cmake_args.append("-DFBGEMM_CPU_ONLY=ON")
+    if args.nvml_lib_path:
+        cmake_args.append(f"-DNVML_LIB_PATH={args.nvml_lib_path}")
 
     name = args.package_name
     print("name: ", name)


### PR DESCRIPTION
Summary:
In inference OSS we need to build fbgemm from source and we need the `merge_pooled_embeddings` operator.

This is not available in fbgemm oss because of this: https://www.internalfb.com/diff/D30037992 (https://github.com/pytorch/FBGEMM/commit/41ab9713cb1c083414bd9759ebb95d47609101b7)?dst_version_fbid=1066324687448445&transaction_fbid=198310519085547, a dependency on nvml.h.

However, generally nvml.h is present on systems and can be located at: `${CUDA_TOOLKIT_ROOT_DIR}/lib64/stubs/libnvidia-ml.so`, as detailed here: https://tianyuliukingcrimson.wordpress.com/2018/07/23/findnvml-cmake-done-correctly-how-to-have-cmake-find-nvidia-management-library-nvml-on-windows-and-linux/.

**However**, sometimes systems don't have it preinstalled with cuda for whatever reason, in which case you can get it by installing cudatoolkit-dev:

`conda install -c conda-forge cudatoolkit-dev` (as i had to for my system)

This changes the path that `libnvidia-ml.so` exists on, so we can give the option for people to specify where this library lives: `nvml_lib_path`

post: https://fb.workplace.com/groups/2126278550786248/posts/5357069087707162

Differential Revision: D35785768

