### PR TITLE
Add default values for func args in FBGEMM codegen

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_approx_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_approx_template.cpp
@@ -101,7 +101,7 @@ split_embedding_backward_codegen_{{ optimizer }}_cpu(
     bool stochastic_rounding,
     {% endif %}
     {{args.split_function_args | join(", ")}},
-    int64_t output_dtype
+    int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)
 ) {
   int64_t T = D_offsets.numel() - 1;
   TORCH_CHECK(T > 0);

--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
@@ -303,7 +303,7 @@ void split_embedding_backward_exact_cpu_dense_kernel(
     {% if not dense %}
     bool stochastic_rounding,
     {{ args.split_function_args | join(", ") }},
-    int64_t output_dtype
+    int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)
     {% else %}
     {{ args.split_function_args | join(", ") }}
     {% endif %}

--- a/fbgemm_gpu/codegen/embedding_backward_split_host_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_cpu_template.cpp
@@ -30,7 +30,7 @@ void split_embedding_backward_codegen_{{ optimizer }}_cpu(
     Tensor indice_weights,
     bool stochastic_rounding,
     {{ args.split_function_args | join(", ") }},
-    int64_t output_dtype);
+    int64_t output_dtype = static_cast<int64_t>(SparseType::FP32));
 
 namespace {
 
@@ -55,7 +55,7 @@ class SplitLookupFunction_{{ optimizer }}_Op : public torch::autograd::Function<
     double max_gradient,
     bool stochastic_rounding,
     {{ args.split_function_args | join(", ") }},
-    int64_t output_dtype) {
+    int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)) {
     Tensor indice_weights_value = indice_weights.value_or(Tensor());
     Tensor feature_requires_grad_value =
         feature_requires_grad.value_or(Tensor());
@@ -194,7 +194,7 @@ Tensor split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(
     double max_gradient,
     bool stochastic_rounding,
     {{ args.split_function_args | join(", ") }},
-    int64_t output_dtype) {
+    int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)) {
   return SplitLookupFunction_{{ optimizer }}_Op::apply(
       host_weights,
       weights_placements,

--- a/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
@@ -445,7 +445,7 @@ Tensor split_embedding_codegen_lookup_{{ optimizer }}_function(
     double max_gradient,
     bool stochastic_rounding,
     {{ args.split_function_args | join(", ") }},
-    int64_t output_dtype) {
+    int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)) {
   if (static_cast<PoolingMode>(pooling_mode) == PoolingMode::NONE) {
     return SplitNoBagLookupFunction_{{ optimizer }}_Op::apply(
       placeholder_autograd_tensor,


### PR DESCRIPTION
Summary:
We enforce mandate default values for float/int function args (usually hyper-parameters for optimizers) when generating FBGEMM code using codegen. This makes backward compatibility easier as we can add more parameters without breaking compatibility.

Note: developers need to be cautious when adding new args with default values. The behavior should remain the same with default values. If no default values are provided for float/int parameters, they'll be set to 0.0/0 by default.

Reviewed By: jianyuh

Differential Revision: D35795294

