### PR TITLE
allow specify output_dtype for split no_bag embedding forward

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
@@ -113,6 +113,7 @@ Tensor split_embedding_nobag_codegen_forward_unweighted_cuda(
     Tensor indices,
     Tensor offsets,
     Tensor lxu_cache_locations,
+    int64_t output_dtype,
     int64_t unused);
 
 void split_embedding_nobag_backward_codegen_{{ optimizer }}_unweighted_exact_cuda(
@@ -140,9 +141,7 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
   static torch::autograd::variable_list forward(
     torch::autograd::AutogradContext* ctx,
     Tensor placeholder_autograd_tensor,
-    {% if not nobag %}
     int64_t output_dtype,
-    {% endif %}
     Tensor dev_weights,
     Tensor uvm_weights,
     Tensor lxu_cache_weights,
@@ -214,6 +213,7 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
       indices,
       offsets,
       lxu_cache_locations,
+      output_dtype,
       0)};
     {% endif %}
   }
@@ -402,6 +402,7 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
         {{ args.split_function_arg_names | join(", ") }});
     return {
         Tensor(), // placeholder autograd tensor
+        Variable(), // output_dtype
         Tensor(), // dev_weights
         Variable(), // uvm_weights
         Variable(), // lxu_cache_weights
@@ -449,6 +450,7 @@ Tensor split_embedding_codegen_lookup_{{ optimizer }}_function(
   if (static_cast<PoolingMode>(pooling_mode) == PoolingMode::NONE) {
     return SplitNoBagLookupFunction_{{ optimizer }}_Op::apply(
       placeholder_autograd_tensor,
+      output_dtype,
       dev_weights,
       uvm_weights,
       lxu_cache_weights,

--- a/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
@@ -223,10 +223,10 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights
     {% else %}
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
     {% endif %}
-        dev_weights.type(),
+        dev_weights.scalar_type(),
         {% if not dense %}
-        grad_output.type(),
-        lxu_cache_weights.type(),
+        grad_output.scalar_type(),
+        lxu_cache_weights.scalar_type(),
         {% endif %}
         "split_embedding_codegen_grad_indice_weights_kernel",
         [&] {

--- a/fbgemm_gpu/codegen/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_template.cu
@@ -828,12 +828,12 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
 
     {% if not dense %}
     DISPATCH_EMB_GRAD_CACHE_TYPES(
-        dev_weights.type(),
-        grad_output.type(),
-        lxu_cache_weights.type(),
+        dev_weights.scalar_type(),
+        grad_output.scalar_type(),
+        lxu_cache_weights.scalar_type(),
     {% else %}
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-        dev_weights.type(),
+        dev_weights.scalar_type(),
     {% endif %}
         "split_embedding_backward_{{ optimizer }}_exact_kernel",
         [&] {

--- a/fbgemm_gpu/codegen/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_template.cu
@@ -299,7 +299,7 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
     {% if not dense %}
     Tensor lxu_cache_locations,
     {% endif %}
-    {% if not dense and not nobag %}
+    {% if not dense %}
     int64_t output_dtype,
     {% endif %}
     int64_t unused
@@ -345,10 +345,26 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
     TORCH_CHECK(D % 4 == 0);
     {% endif %}
 
-    {% if nobag %}
-    Tensor output = at::empty({total_L, D}, dev_weights.options().dtype(at::kFloat));
-    {% else %}
     Tensor output;
+    {% if nobag %}
+    {% if dense %}
+        output = at::empty({total_L, D}, dev_weights.options().dtype(at::kFloat));
+    {% else %}
+    SparseType o_dtype = static_cast<SparseType>(output_dtype);
+    TORCH_CHECK(o_dtype == SparseType::FP32 || o_dtype == SparseType::FP16 ||
+                o_dtype == SparseType::BF16 || o_dtype == SparseType::INT8);
+    if (o_dtype == SparseType::FP32) {
+        output = at::empty({total_L, D}, dev_weights.options().dtype(at::kFloat));
+    } else if (o_dtype == SparseType::FP16) {
+        output = at::empty({total_L, D}, dev_weights.options().dtype(at::kHalf));
+    } else if (o_dtype == SparseType::BF16) {
+        output = at::empty({total_L, D}, dev_weights.options().dtype(at::kBFloat16));
+    } else if (o_dtype == SparseType::INT8) {
+        output = at::empty({total_L, int64_t(D + T * kINT8QparamsBytes)}, dev_weights.options().dtype(at::kByte));
+    }
+    // Tensor output = at::empty({total_L, D}, dev_weights.options().dtype(at::kFloat));
+    {% endif %}
+    {% else %}
     {% if dense %}
     if (dev_weights.type().scalarType() == at::kHalf || dev_weights.type().scalarType() == at::kByte) {
         output = at::empty({B, total_D}, dev_weights.options().dtype(at::kFloat));
@@ -380,10 +396,10 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
     {% else %}
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
     {% endif %}
-        dev_weights.type(),
+        dev_weights.scalar_type(),
         {% if not dense %}
-        lxu_cache_weights.type(),
-        output.type(),
+        lxu_cache_weights.scalar_type(),
+        output.scalar_type(),
         {% endif %}
         "batched_embedding{{ "_nobag" if nobag else "" }}_forward_kernel_2", [&] {
         {% if not nobag %}

--- a/fbgemm_gpu/include/fbgemm_gpu/dispatch_macros.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/dispatch_macros.h
@@ -149,6 +149,8 @@
     switch (_grad_t) {                                                       \
       PRIVATE_CASE_TYPE_CACHE_EMB(                                           \
           at::ScalarType::Float, _cache_t, _emb_t, float, NAME, __VA_ARGS__) \
+      PRIVATE_CASE_TYPE_CACHE_EMB(                                           \
+          at::ScalarType::Half, _cache_t, _emb_t, at::Half, NAME, __VA_ARGS__) \
       default:                                                               \
         AT_ERROR(                                                            \
             #NAME, " not implemented for grad_t '", toString(_grad_t), "'"); \

--- a/fbgemm_gpu/src/histogram_binning_calibration_ops.cu
+++ b/fbgemm_gpu/src/histogram_binning_calibration_ops.cu
@@ -76,7 +76,7 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_cuda(
   const auto bin_num_examples_packed = bin_num_examples.contiguous();
   const auto bin_num_positives_packed = bin_num_positives.contiguous();
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      logit.type(), "histogram_binning_calibration_cuda", [&] {
+      logit.scalar_type(), "histogram_binning_calibration_cuda", [&] {
         histogram_binning_calibration_kernel<scalar_t>
             <<<fbgemm_gpu::div_round_up(logit.numel(), kMaxThreads),
                kMaxThreads,
@@ -230,7 +230,7 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_by_feature_cuda(
   const auto bin_num_examples_packed = bin_num_examples.contiguous();
   const auto bin_num_positives_packed = bin_num_positives.contiguous();
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      logit.type(),
+      logit.scalar_type(),
       "histogram_binning_calibration_by_feature_cuda_wrapper",
       [&] {
         using logit_t = scalar_t;
@@ -390,7 +390,7 @@ generic_histogram_binning_calibration_by_feature_cuda(
   const auto bin_num_positives_packed = bin_num_positives.contiguous();
   const auto bin_boundaries_packed = bin_boundaries.contiguous();
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      logit.type(),
+      logit.scalar_type(),
       "generic_histogram_binning_calibration_by_feature_cuda_wrapper",
       [&] {
         using logit_t = scalar_t;

--- a/fbgemm_gpu/src/layout_transform_ops.cu
+++ b/fbgemm_gpu/src/layout_transform_ops.cu
@@ -45,7 +45,7 @@ Tensor recat_embedding_grad_output_cuda(
   Tensor sharded_grad_output =
       at::empty({grad_output.numel()}, grad_output.options());
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      grad_output.type(), "recat_embedding_gradients", [&] {
+      grad_output.scalar_type(), "recat_embedding_gradients", [&] {
         const auto go = grad_output.accessor<scalar_t, 3>();
         auto sgo = sharded_grad_output.accessor<scalar_t, 1>();
         int64_t feature_offset = 0;
@@ -85,7 +85,7 @@ Tensor recat_embedding_grad_output_mixed_D_cuda(
       at::empty({grad_output.numel()}, grad_output.options());
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      grad_output.type(), "recat_embedding_gradients", [&] {
+      grad_output.scalar_type(), "recat_embedding_gradients", [&] {
         const auto go = grad_output.accessor<scalar_t, 2>();
         auto sgo = sharded_grad_output.accessor<scalar_t, 1>();
         int64_t sgo_offset = 0;
@@ -134,7 +134,7 @@ Tensor recat_embedding_grad_output_mixed_D_batch_cuda(
       (B_local * dim_num), fbgemm_gpu::kMaxThreads / fbgemm_gpu::kWarpSize));
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      grad_output.type(), "recat_embedding_gradients", [&] {
+      grad_output.scalar_type(), "recat_embedding_gradients", [&] {
         recat_copy_async_kernel<scalar_t>
             <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
                 dim_sum_per_rank.data_ptr<int64_t>(),

--- a/fbgemm_gpu/src/layout_transform_ops_cpu.cpp
+++ b/fbgemm_gpu/src/layout_transform_ops_cpu.cpp
@@ -15,7 +15,7 @@ using Tensor = at::Tensor;
 namespace fbgemm_gpu {
 
 Tensor recat_embedding_grad_output_mixed_D_cpu(
-    const Tensor& grad_output, // [B_local][Sum_T_global(D)]
+    const Tensor& grad_output,  // [B_local][Sum_T_global(D)]
     const std::vector<int64_t>& dim_sum_per_rank) {
   TORCH_CHECK(grad_output.is_contiguous());
   const auto B_local = grad_output.sizes()[0];
@@ -32,7 +32,7 @@ Tensor recat_embedding_grad_output_mixed_D_cpu(
   TORCH_CHECK(B_local * global_dim_sum == grad_output.numel());
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      grad_output.type(), "recat_embedding_gradients", [&] {
+      grad_output.scalar_type(), "recat_embedding_gradients", [&] {
         const auto go = grad_output.accessor<scalar_t, 2>();
         auto sgo = sharded_grad_output.accessor<scalar_t, 1>();
         at::parallel_for(
@@ -46,8 +46,8 @@ Tensor recat_embedding_grad_output_mixed_D_cpu(
                 const scalar_t* src = &go[0][accum_dim_sum[dim]];
                 const auto r_begin = (dim == dim_begin) ? i_begin % B_local : 0;
                 const auto r_end = (dim == dim_end - 1 && i_end % B_local != 0)
-                    ? i_end % B_local
-                    : B_local;
+                                       ? i_end % B_local
+                                       : B_local;
                 for (const auto r : c10::irange(r_begin, r_end)) {
                   memcpy(
                       dst + r * dim_sum,
@@ -61,7 +61,7 @@ Tensor recat_embedding_grad_output_mixed_D_cpu(
   return sharded_grad_output;
 }
 
-} // namespace fbgemm_gpu
+}  // namespace fbgemm_gpu
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops.cu
@@ -63,7 +63,7 @@ Tensor permute_pooled_embs_gpu(
       (B + max_grid_dim_y - 1) / max_grid_dim_y);
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      pooled_embs_contiguous.type(), "permute_pooled_embeddings", [&] {
+      pooled_embs_contiguous.scalar_type(), "permute_pooled_embeddings", [&] {
         permute_pooled_embs_kernel<scalar_t>
             <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
                 pooled_embs_contiguous.data_ptr<scalar_t>(),

--- a/fbgemm_gpu/src/sparse_ops.cu
+++ b/fbgemm_gpu/src/sparse_ops.cu
@@ -170,7 +170,8 @@ Tensor segment_sum_csr_cuda(
   auto output = at::empty(csr_seg.numel() - 1, values.options());
   constexpr uint32_t threads_per_block = 256;
   const uint32_t num_blocks = csr_seg.numel() - 1;
-  AT_DISPATCH_ALL_TYPES(values.type(), "_segment_sum_csr_cuda", [&] {
+  AT_DISPATCH_ALL_TYPES(values.scalar_type(), 
+  "_segment_sum_csr_cuda", [&] {
     _segment_sum_csr_cuda_kernel<scalar_t>
         <<<num_blocks,
            threads_per_block,
@@ -1525,7 +1526,7 @@ Tensor reorder_batched_ad_lengths_gpu(
   const dim3 blocks((B * T + 32 - 1) / 32);
 
   AT_DISPATCH_ALL_TYPES(
-      cat_ad_lengths.type(), "reorder_batched_ad_lengths_gpu_kernel", [&] {
+      cat_ad_lengths.scalar_type(), "reorder_batched_ad_lengths_gpu_kernel", [&] {
         reorder_batched_ad_lengths_kernel<scalar_t>
             <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
                 cat_ad_lengths
@@ -1618,7 +1619,7 @@ Tensor reorder_batched_ad_indices_gpu(
   const dim3 blocks((B * T + 32 - 1) / 32);
 
   AT_DISPATCH_ALL_TYPES(
-      cat_ad_indices.type(), "reorder_batched_ad_indices_gpu_kernel_1", [&] {
+      cat_ad_indices.scalar_type(), "reorder_batched_ad_indices_gpu_kernel_1", [&] {
         AT_DISPATCH_INDEX_TYPES(
             cat_ad_offsets.scalar_type(),
             "reorder_batched_ad_indices_gpu_kernel_2",
@@ -1703,9 +1704,9 @@ Tensor batched_unary_embeddings_forward_cuda(
   dim3 blocks(cuda_calc_xblock_count(B, threads), T, N);
   auto output = at::empty({N, B, T}, weight.options());
   AT_DISPATCH_INDEX_TYPES(
-      indices.type(), "batched_unary_embeddings_forward_kernel", [&] {
+      indices.scalar_type(), "batched_unary_embeddings_forward_kernel", [&] {
         AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-            weight.type(), "batched_unary_embeddings_forward_kernel", [&] {
+            weight.scalar_type(), "batched_unary_embeddings_forward_kernel", [&] {
               batched_unary_embeddings_forward_kernel<scalar_t>
                   <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
                       N,
@@ -1839,9 +1840,9 @@ Tensor batched_unary_embeddings_backward_cuda(
       cuda_calc_xblock_count(sorted_linear_indices_run.numel(), threads), N);
   auto grad_weight = at::zeros_like(weight);
   AT_DISPATCH_INDEX_TYPES(
-      indices.type(), "batched_unary_embeddings_backward_kernel", [&] {
+      indices.scalar_type(), "batched_unary_embeddings_backward_kernel", [&] {
         AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-            grad_output.type(),
+            grad_output.scalar_type(),
             "batched_unary_embeddings_backward_kernel",
             [&] {
               batched_unary_embeddings_backward_kernel<scalar_t>

--- a/fbgemm_gpu/src/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_cpu.cpp
@@ -47,7 +47,7 @@ void _to_dense_representation(
   }
 }
 
-} // namespace
+}  // namespace
 
 using Tensor = at::Tensor;
 
@@ -108,9 +108,9 @@ void _permute_2D_indices_weights_kernel_cpu(
               }
             }
             output_start += permuted_length;
-          } // for each b
-        } // for each t
-      }); // parallel_for T * B
+          }  // for each b
+        }    // for each t
+      });    // parallel_for T * B
 }
 
 // specialization for variable B and T,
@@ -147,7 +147,7 @@ void _permute_1D_indices_weights_kernel_cpu(
             }
           }
         }
-      }); // parallel_for T x B, different B across T
+      });  // parallel_for T x B, different B across T
 }
 
 template <typename index_t>
@@ -373,7 +373,7 @@ void BFloat16QuantizedToFloat_ref(
     for (const auto col : c10::irange(ncols)) {
       uint32_t val_fp32 = static_cast<uint32_t>(
                               reinterpret_cast<const uint16_t*>(input_row)[col])
-          << 16;
+                          << 16;
       reinterpret_cast<uint32_t*>(output_row)[col] = val_fp32;
     }
   }
@@ -390,7 +390,7 @@ at::Tensor _float_to_bfloat16_cpu(const at::Tensor& input) {
   const int32_t output_columns = ncols;
   auto output = at::empty(
       {nrows, output_columns},
-      input.options().dtype(at::kHalf)); // at::kHalf
+      input.options().dtype(at::kHalf));  // at::kHalf
   // input.options().dtype(at::kBFloat16)); // at::kBFloat16
 
   FloatToBFloat16Quantized_ref(
@@ -413,8 +413,8 @@ at::Tensor _bfloat16_to_float_cpu(const at::Tensor& input) {
   const int32_t output_columns = ncols;
 
   auto output = at::empty(
-      {nrows, output_columns}, // 4 = sizeof(float)
-      input.options().dtype(at::kFloat)); //
+      {nrows, output_columns},             // 4 = sizeof(float)
+      input.options().dtype(at::kFloat));  //
 
   BFloat16QuantizedToFloat_ref(
       reinterpret_cast<at::BFloat16*>(input.data_ptr<at::Half>()),
@@ -553,7 +553,7 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_2D_sparse_data_cpu(
             permuted_lengths.data_ptr<index_t>(),
             input_offsets.data_ptr<index_t>(),
             output_offsets_per_thread_cumsum.data());
-      }); // for each scalar_t
+      });  // for each scalar_t
 
   int64_t permuted_indices_size = 0;
   if (permuted_lengths_sum.has_value()) {
@@ -612,9 +612,9 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_2D_sparse_data_cpu(
                           nullptr,
                           permuted_lengths.data_ptr<offsets_t>());
                     }
-                  }); // for each weights_t
-            }); // for each indices_t
-      }); // for each offsets_t
+                  });  // for each weights_t
+            });        // for each indices_t
+      });              // for each offsets_t
   return {permuted_lengths, permuted_indices, permuted_weights};
 }
 
@@ -676,7 +676,7 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_1D_sparse_data_cpu(
             permuted_lengths_size,
             permute.data_ptr<int32_t>(),
             permuted_lengths.data_ptr<index_t>());
-      }); // for each scalar_t
+      });  // for each scalar_t
 
   const auto input_offsets = asynchronous_exclusive_cumsum_cpu(lengths);
   const auto output_offsets =
@@ -738,9 +738,9 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_1D_sparse_data_cpu(
                           permuted_indices.data_ptr<indices_t>(),
                           nullptr);
                     }
-                  }); // for each weights_t
-            }); // for each indices_t
-      }); // for each offsets_t
+                  });  // for each weights_t
+            });        // for each indices_t
+      });              // for each offsets_t
 
   return {permuted_lengths, permuted_indices, permuted_weights};
 }
@@ -762,7 +762,7 @@ void _expand_into_jagged_permute_cpu_kernel(
             output_permute[output_start + i] = input_start + i;
           }
         }
-      }); // parallel_for T
+      });  // parallel_for T
 }
 
 Tensor expand_into_jagged_permute_cpu(
@@ -1043,7 +1043,7 @@ Tensor asynchronous_exclusive_cumsum_cpu(const Tensor& t_in) {
   const auto t_in_contig = t_in.expect_contiguous();
   auto output = native_empty_like(*t_in_contig);
   AT_DISPATCH_ALL_TYPES(
-      t_in_contig->type(), "asynchronous_exclusive_cumsum_cpu_kernel", [&] {
+      t_in_contig->scalar_type(), "asynchronous_exclusive_cumsum_cpu_kernel", [&] {
         exclusive_scan_ptrs_cpu(
             t_in_contig->numel(),
             t_in_contig->data_ptr<scalar_t>(),
@@ -1058,7 +1058,7 @@ Tensor asynchronous_inclusive_cumsum_cpu(const Tensor& t_in) {
   const auto t_in_contig = t_in.expect_contiguous();
   auto output = native_empty_like(*t_in_contig);
   AT_DISPATCH_ALL_TYPES(
-      t_in_contig->type(), "asynchronous_inclusive_cumsum_cpu_kernel", [&] {
+      t_in_contig->scalar_type(), "asynchronous_inclusive_cumsum_cpu_kernel", [&] {
         scalar_t cumsum = 0;
         const auto* input_ptr = t_in_contig->data_ptr<scalar_t>();
         const auto N = t_in_contig->numel();
@@ -1079,7 +1079,7 @@ Tensor asynchronous_complete_cumsum_cpu(const Tensor& t_in) {
   const auto t_in_contig = t_in.expect_contiguous();
   auto output = at::zeros({t_in.numel() + 1}, t_in.options());
   AT_DISPATCH_ALL_TYPES(
-      t_in_contig->type(), "asynchronous_complete_cumsum_cpu_kernel", [&] {
+      t_in_contig->scalar_type(), "asynchronous_complete_cumsum_cpu_kernel", [&] {
         const auto N = t_in_contig->numel();
         const auto last_sum = exclusive_scan_ptrs_cpu(
             N, t_in_contig->data_ptr<scalar_t>(), output.data_ptr<scalar_t>());
@@ -1125,9 +1125,9 @@ Tensor reorder_batched_ad_lengths_cpu(
 
   Tensor reordered_cat_ad_lengths = at::empty_like(cat_ad_lengths);
   AT_DISPATCH_INDEX_TYPES(
-      batch_offsets.type(), "reorder_batched_ad_lengths_cpu_kernel1", [&] {
+      batch_offsets.scalar_type(), "reorder_batched_ad_lengths_cpu_kernel1", [&] {
         AT_DISPATCH_ALL_TYPES(
-            cat_ad_lengths.type(),
+            cat_ad_lengths.scalar_type(),
             "reorder_batched_ad_lengths_cpu_kernel2",
             [&] {
               reorder_batched_ad_lengths_<index_t, scalar_t>(
@@ -1202,7 +1202,7 @@ Tensor reorder_batched_ad_indices_cpu(
       "reorder_batched_ad_indices_cpu_kernel_1",
       [&] {
         AT_DISPATCH_ALL_TYPES(
-            cat_ad_indices.type(),
+            cat_ad_indices.scalar_type(),
             "reorder_batched_ad_indices_cpu_kernel_2",
             [&] {
               reorder_batched_ad_indices_cpu_<index_t, scalar_t>(
@@ -1344,7 +1344,7 @@ void _histogram_binning_calibration_cpu_kernel(
       const auto curr_bin_ctr =
           bin_num_positives_data[bin_ids_data[i]] / curr_bin_num_examples;
       calibrated_prediction_data[i] = curr_bin_ctr * bin_ctr_weight_value +
-          uncalibrated * (1.0 - bin_ctr_weight_value);
+                                      uncalibrated * (1.0 - bin_ctr_weight_value);
     } else {
       calibrated_prediction_data[i] = uncalibrated;
     }
@@ -1369,9 +1369,9 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_cpu(
   Tensor bin_ids = at::empty({logit.numel()}, logit.options().dtype(at::kLong));
   const double recalibrate_value = std::log(positive_weight);
   const double step = (upper_bound - lower_bound) /
-      static_cast<double>(bin_num_examples.numel());
+                      static_cast<double>(bin_num_examples.numel());
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      logit.type(), "histogram_binning_calibration_cpu", [&] {
+      logit.scalar_type(), "histogram_binning_calibration_cpu", [&] {
         _histogram_binning_calibration_cpu_kernel<scalar_t>(
             logit.numel(),
             recalibrate_value,
@@ -1409,8 +1409,8 @@ void _histogram_binning_calibration_by_feature_cpu_kernel(
 
     const int64_t curr_segment_value =
         dense_segment_value_data[i] > num_segments
-        ? 0
-        : std::max(0L, dense_segment_value_data[i] * num_bins);
+            ? 0
+            : std::max(0L, dense_segment_value_data[i] * num_bins);
 
     bin_ids_data[i] = (std::ceil(uncalibrated / step) - 1) + curr_segment_value;
 
@@ -1419,7 +1419,7 @@ void _histogram_binning_calibration_by_feature_cpu_kernel(
       const auto curr_bin_ctr =
           bin_num_positives_data[bin_ids_data[i]] / curr_bin_num_examples;
       calibrated_prediction_data[i] = curr_bin_ctr * bin_ctr_weight_value +
-          uncalibrated * (1.0 - bin_ctr_weight_value);
+                                      uncalibrated * (1.0 - bin_ctr_weight_value);
     } else {
       calibrated_prediction_data[i] = uncalibrated;
     }
@@ -1469,7 +1469,7 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_by_feature_cpu(
   const double step =
       (upper_bound - lower_bound) / static_cast<double>(num_bins);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      logit.type(),
+      logit.scalar_type(),
       "histogram_binning_calibration_by_feature_cpu_wrapper",
       [&] {
         using logit_t = scalar_t;
@@ -1526,8 +1526,8 @@ void _generic_histogram_binning_calibration_by_feature_cpu_kernel(
 
     const int64_t curr_segment_value =
         dense_segment_value_data[i] > num_segments
-        ? 0
-        : std::max(0L, dense_segment_value_data[i] * num_bins);
+            ? 0
+            : std::max(0L, dense_segment_value_data[i] * num_bins);
 
     bin_ids_data[i] = curr_bin_id + curr_segment_value;
 
@@ -1536,7 +1536,7 @@ void _generic_histogram_binning_calibration_by_feature_cpu_kernel(
       const auto curr_bin_ctr =
           bin_num_positives_data[bin_ids_data[i]] / curr_bin_num_examples;
       calibrated_prediction_data[i] = curr_bin_ctr * bin_ctr_weight_value +
-          uncalibrated * (1.0 - bin_ctr_weight_value);
+                                      uncalibrated * (1.0 - bin_ctr_weight_value);
     } else {
       calibrated_prediction_data[i] = uncalibrated;
     }
@@ -1586,7 +1586,7 @@ std::tuple<Tensor, Tensor> generic_histogram_binning_calibration_by_feature_cpu(
   Tensor bin_ids = at::empty({logit.numel()}, logit.options().dtype(at::kLong));
   const double recalibrate_value = std::log(positive_weight);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      logit.type(),
+      logit.scalar_type(),
       "generic_histogram_binning_calibration_by_feature_cpu_wrapper",
       [&] {
         using logit_t = scalar_t;
@@ -1643,14 +1643,15 @@ Tensor segment_sum_csr_cpu(
   TENSOR_ON_CPU(values);
 
   auto output = at::empty(csr_seg.numel() - 1, values.options());
-  AT_DISPATCH_ALL_TYPES(values.type(), "_segment_sum_csr_cpu", [&] {
-    _segment_sum_csr_cpu_kernel<scalar_t>(
-        csr_seg.numel() - 1,
-        batch_size,
-        csr_seg.data_ptr<int>(),
-        values.data_ptr<scalar_t>(),
-        output.data_ptr<scalar_t>());
-  });
+  AT_DISPATCH_ALL_TYPES(values.scalar_type(),
+                        "_segment_sum_csr_cpu", [&] {
+                          _segment_sum_csr_cpu_kernel<scalar_t>(
+                              csr_seg.numel() - 1,
+                              batch_size,
+                              csr_seg.data_ptr<int>(),
+                              values.data_ptr<scalar_t>(),
+                              output.data_ptr<scalar_t>());
+                        });
   return output;
 }
 
@@ -1674,7 +1675,7 @@ bool should_prune(
 
   const int64_t original_size = data_byte_size * weights.numel();
   return (compressed_idx_overhead_size + lut_after_prune_size) <
-      min_save_ratio * original_size;
+         min_save_ratio * original_size;
 }
 
 // This operator introduces sparsity to a weight matrix by applying
@@ -1812,7 +1813,7 @@ Tensor& lengths_range_out(
           std::iota(
               start,
               start + len,
-              0); // make the third argument the arg of this operator
+              0);  // make the third argument the arg of this operator
         }
       });
 
@@ -1859,9 +1860,9 @@ void _permute_data_kernel_cpu(
               }
             }
             output_start += permuted_length;
-          } // for each b
-        } // for each t
-      }); // parallel_for T * B
+          }  // for each b
+        }    // for each t
+      });    // parallel_for T * B
 }
 
 std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_features_cpu(
@@ -1916,7 +1917,7 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_features_cpu(
             permuted_lengths.data_ptr<index_t>(),
             input_offsets.data_ptr<index_t>(),
             output_offsets_per_thread_cumsum.data());
-      })); // for each scalar_t
+      }));  // for each scalar_t
 
   auto permuted_lengths_sum =
       output_offsets_per_thread_cumsum[num_threads * FALSE_SHARING_PAD];
@@ -1957,8 +1958,8 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_features_cpu(
                     nullptr,
                     permuted_lengths.data_ptr<index_t>());
               }
-            })); // for each scalar_t
-      })); // for each index_t
+            }));  // for each scalar_t
+      }));        // for each index_t
   return {permuted_lengths, permuted_indices, permuted_weights};
 }
 
@@ -2106,9 +2107,9 @@ void _permute_embeddings_kernel_cpu(
                   embeddings[input_start + i];
             }
             output_start += permuted_length;
-          } // for each b
-        } // for each t
-      }); // parallel_for T * B
+          }  // for each b
+        }    // for each t
+      });    // parallel_for T * B
 }
 
 std::tuple<Tensor, Tensor> permute_sequence_embeddings_cpu(
@@ -2155,7 +2156,7 @@ std::tuple<Tensor, Tensor> permute_sequence_embeddings_cpu(
             permuted_lengths.data_ptr<index_t>(),
             input_offsets.data_ptr<index_t>(),
             output_offsets_per_thread_cumsum.data());
-      })); // for each scalar_t
+      }));  // for each scalar_t
 
   auto permuted_lengths_sum =
       output_offsets_per_thread_cumsum[num_threads * FALSE_SHARING_PAD];
@@ -2175,12 +2176,12 @@ std::tuple<Tensor, Tensor> permute_sequence_embeddings_cpu(
                   output_offsets_per_thread_cumsum.data(),
                   permuted_embeddings.data_ptr<scalar_t>(),
                   permuted_lengths.data_ptr<index_t>());
-            })); // for each scalar_t
-      })); // for each index_t
+            }));  // for each scalar_t
+      }));        // for each index_t
   return {permuted_lengths, permuted_embeddings};
 }
 
-} // namespace fbgemm_gpu
+}  // namespace fbgemm_gpu
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(


### PR DESCRIPTION
"split_embedding_nobag_forward" did not accept "output_dtype" parameters when "{% if not dense and not nobag %}". 

So when user created "SplitTableBatchedEmbeddingBagsCodegen" with the "output_dtype" to some type needed, it is not passed into split_embedding_nobag_forward, so the real output data type is not aligned with output_dtype user specified. And also there is no warning or error happens as well. 

This PR added the "output_dtype" support for "split_embedding_nobag_forward". 