### PR TITLE
allow FP16-type grad_t

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
@@ -344,31 +344,35 @@ void split_embedding_backward_exact_cpu_dense_kernel(
 
   grad_output = grad_output.contiguous();
 
+
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      host_weights.scalar_type(), "split_embedding_backward_exact_cpu", [&] {
-        // TODO: respect output_dtype
-        using grad_t = float;
-        split_embedding_backward_exact_cpu_kernel<scalar_t, grad_t>(
-            grad_output,
-            host_weights,
-            weights_offsets_data,
-            D_offsets_data,
-            hash_size_cumsum,
-            indices,
-            offsets,
-            pooling_mode,
-            indice_weights,
-            num_tables,
-            B,
-            table_to_feature_offset,
-            {% if "momentum1_offsets" in args.split_function_arg_names %}
-            momentum1_offsets_data,
-            {% endif %}
-            {% if "momentum2_offsets" in args.split_function_arg_names %}
-            momentum2_offsets_data,
-            {% endif %}
-            {{ args.split_cpu_kernel_arg_constructors | join(", ") }});
-      });
+      grad_output.scalar_type(),
+      "split_embedding_backward_exact_cpu_outer", [&]() {
+        using grad_t = scalar_t;
+      AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+          host_weights.scalar_type(), "split_embedding_backward_exact_cpu", [&] {
+            split_embedding_backward_exact_cpu_kernel<scalar_t, grad_t>(
+                grad_output,
+                host_weights,
+                weights_offsets_data,
+                D_offsets_data,
+                hash_size_cumsum,
+                indices,
+                offsets,
+                pooling_mode,
+                indice_weights,
+                num_tables,
+                B,
+                table_to_feature_offset,
+                {% if "momentum1_offsets" in args.split_function_arg_names %}
+                momentum1_offsets_data,
+                {% endif %}
+                {% if "momentum2_offsets" in args.split_function_arg_names %}
+                momentum2_offsets_data,
+                {% endif %}
+                {{ args.split_cpu_kernel_arg_constructors | join(", ") }});
+          });
+    });
 
   return;
 

--- a/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
@@ -194,8 +194,8 @@ Tensor split_embedding_codegen_forward_cpu(
   // It is assumed that the indice_weights will always be float
   TORCH_CHECK(
       !indice_weights.defined() || indice_weights.scalar_type() != at::kHalf);
-  AT_DISPATCH_FLOATING_TYPES(
-      output.scalar_type(), "split_embedding_cpu_forward", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+      output.scalar_type(), "split_embedding_cpu_forward", [&]() {
         using output_t = scalar_t;
         AT_DISPATCH_FLOATING_TYPES_AND2(
             at::ScalarType::Half,

--- a/fbgemm_gpu/include/fbgemm_gpu/dispatch_macros.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/dispatch_macros.h
@@ -137,20 +137,22 @@
     }                                                                      \
   }
 
-#define DISPATCH_EMB_GRAD_CACHE_TYPES(                                       \
-    EMB_TYPE, GRAD_TYPE, CACHE_TYPE, NAME, ...)                              \
-  [&] {                                                                      \
-    const auto& emb_type = EMB_TYPE;                                         \
-    const auto& grad_type = GRAD_TYPE;                                       \
-    const auto& cache_type = CACHE_TYPE;                                     \
-    at::ScalarType _emb_t = ::detail::scalar_type(emb_type);                 \
-    at::ScalarType _grad_t = ::detail::scalar_type(grad_type);               \
-    at::ScalarType _cache_t = ::detail::scalar_type(cache_type);             \
-    switch (_grad_t) {                                                       \
-      PRIVATE_CASE_TYPE_CACHE_EMB(                                           \
-          at::ScalarType::Float, _cache_t, _emb_t, float, NAME, __VA_ARGS__) \
-      default:                                                               \
-        AT_ERROR(                                                            \
-            #NAME, " not implemented for grad_t '", toString(_grad_t), "'"); \
-    }                                                                        \
+#define DISPATCH_EMB_GRAD_CACHE_TYPES(                                         \
+    EMB_TYPE, GRAD_TYPE, CACHE_TYPE, NAME, ...)                                \
+  [&] {                                                                        \
+    const auto& emb_type = EMB_TYPE;                                           \
+    const auto& grad_type = GRAD_TYPE;                                         \
+    const auto& cache_type = CACHE_TYPE;                                       \
+    at::ScalarType _emb_t = ::detail::scalar_type(emb_type);                   \
+    at::ScalarType _grad_t = ::detail::scalar_type(grad_type);                 \
+    at::ScalarType _cache_t = ::detail::scalar_type(cache_type);               \
+    switch (_grad_t) {                                                         \
+      PRIVATE_CASE_TYPE_CACHE_EMB(                                             \
+          at::ScalarType::Float, _cache_t, _emb_t, float, NAME, __VA_ARGS__)   \
+      PRIVATE_CASE_TYPE_CACHE_EMB(                                             \
+          at::ScalarType::Half, _cache_t, _emb_t, at::Half, NAME, __VA_ARGS__) \
+      default:                                                                 \
+        AT_ERROR(                                                              \
+            #NAME, " not implemented for grad_t '", toString(_grad_t), "'");   \
+    }                                                                          \
   }()

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -238,6 +238,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         cache_algorithm: split_table_batched_embeddings_ops.CacheAlgorithm,
         pooling_mode: split_table_batched_embeddings_ops.PoolingMode,
         use_cpu: bool,
+        output_dtype: SparseType,
     ) -> None:
         # NOTE: cache is not applicable to CPU version.
         assume(not use_cpu or not use_cache)
@@ -388,6 +389,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             learning_rate=0.05,
             cache_algorithm=cache_algorithm,
             pooling_mode=pooling_mode,
+            output_dtype=output_dtype,
         )
         # NOTE: test TorchScript-compatible!
         cc = torch.jit.script(cc)
@@ -408,11 +410,16 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             if not weighted
             else cc(indices, offsets, to_device(xw.contiguous().view(-1), use_cpu))
         )
+        tolerance = (
+            1.0e-5
+            if weights_precision == SparseType.FP32 and output_dtype == SparseType.FP32
+            else 8.0e-3
+        )
         torch.testing.assert_close(
             fc2.float(),
             f.float(),
-            atol=8.0e-3 if weights_precision == SparseType.FP16 else 1.0e-5,
-            rtol=8.0e-3 if weights_precision == SparseType.FP16 else 1.0e-5,
+            atol=tolerance,
+            rtol=tolerance,
         )
 
     def test_forward_cpu_int8(
@@ -454,6 +461,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             cache_algorithm,
             pooling_mode,
             use_cpu,
+            SparseType.FP32,
         )
 
     def test_forward_cpu_fp32(
@@ -495,6 +503,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             cache_algorithm,
             pooling_mode,
             use_cpu,
+            SparseType.FP32,
         )
 
     @unittest.skipIf(*gpu_unavailable)
@@ -541,6 +550,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             cache_algorithm,
             pooling_mode,
             use_cpu,
+            SparseType.FP32,
         )
 
     @unittest.skipIf(*gpu_unavailable)
@@ -587,6 +597,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             cache_algorithm,
             pooling_mode,
             use_cpu,
+            SparseType.FP32,
         )
 
     @unittest.skipIf(*gpu_unavailable)
@@ -633,6 +644,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             cache_algorithm,
             pooling_mode,
             use_cpu,
+            SparseType.FP32,
         )
 
     @unittest.skipIf(*gpu_unavailable)
@@ -668,6 +680,12 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 split_table_batched_embeddings_ops.PoolingMode.NONE,
             ]
         )
+        output_dtype = random.choice(
+            [
+                SparseType.FP32,
+                SparseType.FP16,
+            ]
+        )
         if pooling_mode == split_table_batched_embeddings_ops.PoolingMode.NONE:
             mixed = False
         else:
@@ -689,6 +707,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             cache_algorithm,
             pooling_mode,
             use_cpu,
+            output_dtype,
         )
 
     @unittest.skipIf(*gpu_unavailable)
@@ -724,6 +743,12 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 split_table_batched_embeddings_ops.PoolingMode.NONE,
             ]
         )
+        output_dtype = random.choice(
+            [
+                SparseType.FP32,
+                SparseType.FP16,
+            ]
+        )
         if pooling_mode == split_table_batched_embeddings_ops.PoolingMode.NONE:
             mixed = False
         else:
@@ -745,6 +770,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             cache_algorithm,
             pooling_mode,
             use_cpu,
+            output_dtype,
         )
 
     @unittest.skipIf(*gpu_unavailable)
@@ -780,6 +806,12 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 split_table_batched_embeddings_ops.PoolingMode.NONE,
             ]
         )
+        output_dtype = random.choice(
+            [
+                SparseType.FP32,
+                SparseType.FP16,
+            ]
+        )
         if pooling_mode == split_table_batched_embeddings_ops.PoolingMode.NONE:
             mixed = False
         else:
@@ -801,6 +833,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             cache_algorithm,
             pooling_mode,
             use_cpu,
+            output_dtype,
         )
 
     @unittest.skipIf(*gpu_unavailable)
@@ -1318,6 +1351,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         ),
         use_cpu=st.booleans() if gpu_available else st.just(True),
         exact=st.booleans(),
+        output_dtype=st.just(SparseType.FP32),
     )
     @settings(
         verbosity=Verbosity.verbose,
@@ -1341,6 +1375,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         pooling_mode: split_table_batched_embeddings_ops.PoolingMode,
         use_cpu: bool,
         exact: bool,
+        output_dtype: SparseType,
     ) -> None:
         # NOTE: cache is not applicable to CPU version.
         assume(not use_cpu or not use_cache)
@@ -1506,6 +1541,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             weights_precision=weights_precision,
             cache_algorithm=cache_algorithm,
             pooling_mode=pooling_mode,
+            output_dtype=output_dtype,
         )
 
         for t in range(T):
@@ -1558,6 +1594,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         pooling_mode: split_table_batched_embeddings_ops.PoolingMode,
         use_cpu: bool,
         exact: bool,
+        output_dtype: SparseType,
     ) -> None:
         # NOTE: cache is not applicable to CPU version.
         assume(not use_cpu or not use_cache)
@@ -1730,6 +1767,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             weights_precision=weights_precision,
             stochastic_rounding=stochastic_rounding,
             pooling_mode=pooling_mode,
+            output_dtype=output_dtype,
         )
 
         if exact:
@@ -1754,13 +1792,18 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         fc2.backward(goc)
         cc.flush()
         split_optimizer_states = [s for (s,) in cc.split_optimizer_states()]
+        tolerance = (
+            1.0e-4
+            if weights_precision == SparseType.FP32 and output_dtype == SparseType.FP32
+            else 1.0e-2
+        )
         for t in range(T):
             ref_optimizer_state = bs[t].weight.grad.float().cpu().to_dense().pow(2)
             torch.testing.assert_close(
                 split_optimizer_states[t].float().cpu(),
                 ref_optimizer_state.mean(dim=1) if row_wise else ref_optimizer_state,
-                atol=1.0e-2 if weights_precision == SparseType.FP16 else 1.0e-4,
-                rtol=1.0e-2 if weights_precision == SparseType.FP16 else 1.0e-4,
+                atol=tolerance,
+                rtol=tolerance,
             )
         for t in range(T):
             # optimizer_state = squares (no row-wise) or sum squares (row-wise)
@@ -1777,8 +1820,8 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                     .view(Es[t], 1 if row_wise else Ds[t])
                     .cpu(),
                 ),
-                atol=1.0e-2 if weights_precision == SparseType.FP16 else 1.0e-4,
-                rtol=1.0e-2 if weights_precision == SparseType.FP16 else 1.0e-4,
+                atol=tolerance,
+                rtol=tolerance,
             )
         if use_cpu:
             D_gradcheck = (D_gradcheck + 15) // 16 * 4
@@ -1796,6 +1839,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             stochastic_rounding=stochastic_rounding,
             # NOTE: only SUM pooling can work with per_sample_weights!
             pooling_mode=split_table_batched_embeddings_ops.PoolingMode.SUM,
+            output_dtype=output_dtype,
         )
         if use_cpu:
             # NOTE: GPU version of SplitTableBatchedEmbeddingBagsCodegen doesn't support double.
@@ -1867,6 +1911,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         ),
         use_cpu=st.booleans() if gpu_available else st.just(True),
         exact=st.booleans(),
+        output_dtype=st.sampled_from([SparseType.FP32, SparseType.FP16]),
     )
     @settings(
         verbosity=Verbosity.verbose,
@@ -1891,6 +1936,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         cache_algorithm: split_table_batched_embeddings_ops.CacheAlgorithm,
         use_cpu: bool,
         exact: bool,
+        output_dtype: SparseType,
     ) -> None:
         self.execute_backward_adagrad_(
             T,
@@ -1909,6 +1955,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             split_table_batched_embeddings_ops.PoolingMode.SUM,
             use_cpu,
             exact,
+            output_dtype,
         )
 
     @given(
@@ -1929,6 +1976,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         ),
         use_cpu=st.booleans() if gpu_available else st.just(True),
         exact=st.booleans(),
+        output_dtype=st.sampled_from([SparseType.FP32, SparseType.FP16]),
     )
     @settings(
         verbosity=Verbosity.verbose,
@@ -1953,6 +2001,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         cache_algorithm: split_table_batched_embeddings_ops.CacheAlgorithm,
         use_cpu: bool,
         exact: bool,
+        output_dtype: SparseType,
     ) -> None:
         self.execute_backward_adagrad_(
             T,
@@ -1971,6 +2020,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             split_table_batched_embeddings_ops.PoolingMode.MEAN,
             use_cpu,
             exact,
+            output_dtype,
         )
 
     @given(
@@ -1991,6 +2041,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         ),
         use_cpu=st.booleans() if gpu_available else st.just(True),
         exact=st.booleans(),
+        output_dtype=st.sampled_from([SparseType.FP32, SparseType.FP16]),
     )
     @settings(
         verbosity=Verbosity.verbose,
@@ -2015,6 +2066,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         cache_algorithm: split_table_batched_embeddings_ops.CacheAlgorithm,
         use_cpu: bool,
         exact: bool,
+        output_dtype: SparseType,
     ) -> None:
         self.execute_backward_adagrad_(
             T,
@@ -2033,6 +2085,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             split_table_batched_embeddings_ops.PoolingMode.NONE,
             use_cpu,
             exact,
+            output_dtype,
         )
 
     @given(
@@ -2053,6 +2106,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         ),
         use_cpu=st.booleans() if gpu_available else st.just(True),
         exact=st.booleans(),
+        output_dtype=st.sampled_from([SparseType.FP32, SparseType.FP16]),
     )
     @settings(
         verbosity=Verbosity.verbose,
@@ -2077,6 +2131,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         cache_algorithm: split_table_batched_embeddings_ops.CacheAlgorithm,
         use_cpu: bool,
         exact: bool,
+        output_dtype: SparseType,
     ) -> None:
         self.execute_backward_adagrad_(
             T,
@@ -2095,6 +2150,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             split_table_batched_embeddings_ops.PoolingMode.SUM,
             use_cpu,
             exact,
+            output_dtype,
         )
 
     @given(
@@ -2115,6 +2171,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         ),
         use_cpu=st.booleans() if gpu_available else st.just(True),
         exact=st.booleans(),
+        output_dtype=st.sampled_from([SparseType.FP32, SparseType.FP16]),
     )
     @settings(
         verbosity=Verbosity.verbose,
@@ -2139,6 +2196,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         cache_algorithm: split_table_batched_embeddings_ops.CacheAlgorithm,
         use_cpu: bool,
         exact: bool,
+        output_dtype: SparseType,
     ) -> None:
         self.execute_backward_adagrad_(
             T,
@@ -2157,6 +2215,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             split_table_batched_embeddings_ops.PoolingMode.MEAN,
             use_cpu,
             exact,
+            output_dtype,
         )
 
     @given(
@@ -2177,6 +2236,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         ),
         use_cpu=st.booleans() if gpu_available else st.just(True),
         exact=st.booleans(),
+        output_dtype=st.sampled_from([SparseType.FP32, SparseType.FP16]),
     )
     @settings(
         verbosity=Verbosity.verbose,
@@ -2201,6 +2261,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         cache_algorithm: split_table_batched_embeddings_ops.CacheAlgorithm,
         use_cpu: bool,
         exact: bool,
+        output_dtype: SparseType,
     ) -> None:
         self.execute_backward_adagrad_(
             T,
@@ -2219,6 +2280,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             split_table_batched_embeddings_ops.PoolingMode.NONE,
             use_cpu,
             exact,
+            output_dtype,
         )
 
     @unittest.skipIf(*gpu_unavailable)


### PR DESCRIPTION
Summary:
This Diff partially revives D31432199 (https://github.com/pytorch/FBGEMM/commit/127f813152666ca5d451e93375c40b2742bb245f), but only enables `grad_t = FP16` (no `BF16` support) to reduce the adverse side effect (e.g., the increase of binary size and compilation time).

Specifically, D31432199 (https://github.com/pytorch/FBGEMM/commit/127f813152666ca5d451e93375c40b2742bb245f) provides FP32, FP16, and BF16 for `grad_t`.
This Diff removes BF16 options for `grad_t` (so only FP32 and FP16 for `grad_t`).

Reviewed By: jianyuh

Differential Revision: D35120293

