### PR TITLE
Make variable type consistent in CPU code

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_backward_code_generator.py
@@ -454,7 +454,7 @@ def rowwise_adagrad() -> None:
         momentum1_host[momentum1_offsets_data[feature_begin] + idx] = new_sum_square_grads;
         at::acc_type<grad_t, true> multiplier;
         multiplier = learning_rate / (sqrtf(new_sum_square_grads) + eps);
-        at::acc_type<scalar_t, true> correction;
+        at::acc_type<grad_t, true> correction;
         if (weight_decay_mode == 1) {
             // L2 regularization
             correction = 1.0 - multiplier * weight_decay;
@@ -569,7 +569,7 @@ def rowwise_adagrad_with_weight_decay() -> None:
         momentum1_host[momentum1_offsets_data[feature_begin] + idx] = new_sum_square_grads;
         at::acc_type<grad_t, true> multiplier;
         multiplier = learning_rate / (sqrtf(new_sum_square_grads) + eps);
-        at::acc_type<scalar_t, true> correction;
+        at::acc_type<grad_t, true> correction;
         if (weight_decay_mode == 1) {
             // L2 regularization
             correction = 1.0 - multiplier * weight_decay;
@@ -659,15 +659,15 @@ def rowwise_weighted_adagrad() -> None:
     """
     split_weight_update_cpu = """
         // weight_decay not supported for cpu version
-        at::acc_type<scalar_t, true> g_local_sum_square = 0.0;
+        at::acc_type<grad_t, true> g_local_sum_square = 0.0;
         for (int64_t d = 0; d < D; ++d) {
             g_local_sum_square += grad_buffer[d] * grad_buffer[d];
         }
         auto g_avg_square = g_local_sum_square / D;
-        at::acc_type<scalar_t, true> lambda = sqrtf(iter + 1);
-        at::acc_type<scalar_t, true> new_sum_square_grads = momentum1_host[momentum1_offsets_data[feature_begin] + idx] + lambda * g_avg_square;
+        at::acc_type<grad_t, true> lambda = sqrtf(iter + 1);
+        at::acc_type<grad_t, true> new_sum_square_grads = momentum1_host[momentum1_offsets_data[feature_begin] + idx] + lambda * g_avg_square;
         momentum1_host[momentum1_offsets_data[feature_begin] + idx] = new_sum_square_grads;
-        at::acc_type<scalar_t, true> multiplier;
+        at::acc_type<grad_t, true> multiplier;
         multiplier = learning_rate * lambda / (cbrtf(new_sum_square_grads) + eps);
         for (int64_t d = 0; d < D; ++d) {
             host_weights_data[embedding_begin + d] -= grad_buffer[d] * multiplier;


### PR DESCRIPTION
Summary: Variable types got mixed up in code versions for CPU code. Here we clean it up and make variable types consistent.

Reviewed By: shintaro-iwasaki

Differential Revision: D35817968

