### PR TITLE
Fix jagged_tensor passing of dims to kernels

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
@@ -293,6 +293,16 @@ constexpr uint32_t cuda_calc_block_count(
       cuda_calc_xblock_count(num_items, threads_per_block), max_blocks);
 }
 
+// A wrapper class for passing dynamically sized dimension information (e.g.
+// tensor.dims()) from the host to device.
+constexpr size_t kStackArrayMaxDims = 5;
+
+template <typename T>
+struct StackArray {
+  T vals[kStackArrayMaxDims];
+  size_t ndim;
+};
+
 // Used in jagged_tensor_ops.cu and jagged_tensor_ops_cpu.cpp
 // Passing lambda exp argument by value instead of by reference to avoid
 // "internal compiler error: in maybe_undo_parenthesized_ref" error for specific


### PR DESCRIPTION
Summary:
This is a very costly operation currently in terms of host-side overheads.  We create a pinned memory tensor, then we create a device tensor, then we do a host to device copy, all to copy a few (<50B) bytes of data.

Instead, we can just pass the data directly to the kernel via value - we can pass up to 2KB (at least) per kernel in this fashion.  This significantly reduces the host-side overheads of these jagged tensor operations.

Differential Revision: D36136656

