### PR TITLE
Fix incompatable bahavior with old pkgs

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_backward_code_generator.py
@@ -434,6 +434,9 @@ def rowwise_adagrad() -> None:
         } else if (weight_decay_mode == 2) {
             // Decoupled weight decay
             correction = 1.0 - learning_rate * weight_decay;
+        } else {
+            // default value
+            correction = 1.0;
         }
     }
     multiplier = shfl_sync(multiplier, 0);
@@ -461,6 +464,9 @@ def rowwise_adagrad() -> None:
         } else if (weight_decay_mode == 2) {
             // Decoupled weight decay
             correction = 1.0 - learning_rate * weight_decay;
+        } else {
+            // default value
+            correction = 1.0;
         }
         for (int64_t d = 0; d < D; ++d) {
             host_weights_data[embedding_begin + d] = correction * host_weights_data[embedding_begin + d] - grad_buffer[d] * multiplier;
@@ -549,6 +555,9 @@ def rowwise_adagrad_with_weight_decay() -> None:
         } else if (weight_decay_mode == 2) {
             // Decoupled weight decay
             correction = 1.0 - learning_rate * weight_decay;
+        } else {
+            // default value
+            correction = 1.0;
         }
     }
     multiplier = shfl_sync(multiplier, 0);
@@ -576,6 +585,9 @@ def rowwise_adagrad_with_weight_decay() -> None:
         } else if (weight_decay_mode == 2) {
             // Decoupled weight decay
             correction = 1.0 - learning_rate * weight_decay;
+        } else {
+            // default value
+            correction = 1.0;
         }
         for (int64_t d = 0; d < D; ++d) {
             host_weights_data[embedding_begin + d] = correction * host_weights_data[embedding_begin + d] - grad_buffer[d] * multiplier;


### PR DESCRIPTION
Summary: D35763365 (https://github.com/pytorch/FBGEMM/commit/25b029edba41e4e1ea6d344cfc5ba5a5f94021af) changes the definition of `WeightDecayMode`, which caused a mismatch if an old `ads_dper3` pkg passes mode=0 but a new `training_platform` only has mode=1&2. As a result, `correction` is not computed and uses 0. We need to add a default `1.0` value to avoid wrong computation when this cross-pkg passing happens.

Differential Revision: D36247238

