### PR TITLE
use parallel radix sorting for weighted csr2csc

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
@@ -95,9 +95,9 @@ void split_embedding_backward_exact_cpu_kernel(
         table_to_feature_offset + t,
         hash_size);
   }
-  // sort based csr2csc handles segment_ids differently
-  bool is_csr2csc_sort = batched_cscs[0].weights == nullptr;
 
+  // sort based csr2csc handles segment_ids differently
+  bool is_csr2csc_sort = true;
   for (int t = 0; t < num_tables; ++t) {
     int feature_begin = table_to_feature_offset[t];
 

--- a/fbgemm_gpu/src/cpu_utils.cpp
+++ b/fbgemm_gpu/src/cpu_utils.cpp
@@ -173,4 +173,19 @@ template std::pair<int64_t*, int*> radix_sort_parallel(
     int64_t elements_count,
     int64_t max_value);
 
+template std::pair<int*, std::pair<int, double>*> radix_sort_parallel(
+    int* inp_key_buf,
+    std::pair<int, double>* inp_value_buf,
+    int* tmp_key_buf,
+    std::pair<int, double>* tmp_value_buf,
+    int64_t elements_count,
+    int64_t max_value);
+
+template std::pair<int*, std::pair<int, float>*> radix_sort_parallel(
+    int* inp_key_buf,
+    std::pair<int, float>* inp_value_buf,
+    int* tmp_key_buf,
+    std::pair<int, float>* tmp_value_buf,
+    int64_t elements_count,
+    int64_t max_value);
 } // namespace fbgemm_gpu


### PR DESCRIPTION
Summary:
OMP_NUM_THREADS=1 ./buck-out/opt/gen/deeplearning/fbgemm/fbgemm_gpu/split_table_batched_embeddings_benchmark.par device --weighted

Single-thread:
INFO:root:Forward, B: 512, E: 100000, T: 32, D: 128, L: 20, W: True, BW:  3.52 GB/s, T: 47693us
INFO:root:ForwardBackward, B: 512, E: 100000, T: 32, D: 128, L: 20, BW:  1.70 GB/s, T: 296752us

Multi-thread:
INFO:root:Forward, B: 512, E: 100000, T: 32, D: 128, L: 20, W: True, BW:  22.30 GB/s, T: 7523us
INFO:root:ForwardBackward, B: 512, E: 100000, T: 32, D: 128, L: 20, BW:  8.25 GB/s, T: 60977us

before this diff:
Multi-thread:
INFO:root:Forward, B: 512, E: 100000, T: 32, D: 128, L: 20, W: True, BW:  13.67 GB/s, T: 12275us
INFO:root:ForwardBackward, B: 512, E: 100000, T: 32, D: 128, L: 20, BW:  5.04 GB/s, T: 99833us

Differential Revision: D36193558

