### PR TITLE
tiny fix for quantized comm on BF16

### DIFF
--- a/fbgemm_gpu/test/quantize_ops_test.py
+++ b/fbgemm_gpu/test/quantize_ops_test.py
@@ -857,9 +857,7 @@ class SparseNNOperatorsGPUTest(unittest.TestCase):
         self, precision: str, batch_size: int, k: int, n: int
     ) -> None:
         if precision == "BF16":
-            input_data = torch.tensor(
-                np.random.rand(n, k).astype(np.float32), dtype=torch.float32
-            )
+            input_data = torch.rand((n, k), dtype=torch.float32)
             quantized_data = torch.ops.fbgemm.FloatToBfloat16Quantized(input_data)
             dequantized_data = torch.ops.fbgemm.Bfloat16QuantizedToFloat(quantized_data)
             torch.testing.assert_allclose(


### PR DESCRIPTION
Summary:
- Fix some view(-1,1) issues for Reduce Scatter quantization op.
- Remove the 2D input limit for FP32 <-> BF16 conversion op.
- Migrate torch.ops.fb to torch.ops.fbgemm

Differential Revision: D36364759

