### PR TITLE
Simplify cmake build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,8 @@ cd FBGEMM
 # if you are updating an existing checkout
 git submodule sync
 git submodule update --init --recursive
-mkdir build && cd build
-cmake ..
-make
+cmake -B build
+make -C build
 ```
 
 To run the tests after building FBGEMM (if tests are built), use the following


### PR DESCRIPTION
Just a very tiny documentation tweak, not that it matters much just that it is a little time saving to start development of one project at least for me.

As a counter argument to have this (!) `-B` https://cgold.readthedocs.io/en/latest/glossary/-B.html is officially supported since CMake 3.13 but the project's CMake minimum requirement is 3.5 which is way old... but `-B` also existed way back in time, probably much before 3.5 but well not officially supported so feel free to just close this if you didn't like it. Thanks :)