### PR TITLE
QuantizeAvx2: Manually hoist zero_point loads

### DIFF
--- a/src/QuantUtilsAvx2.cc
+++ b/src/QuantUtilsAvx2.cc
@@ -52,12 +52,14 @@ void QuantizeAvx2(
   // clang-format on
   __m256i permute_mask_v =
       _mm256_set_epi32(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00);
+  const auto zero_point_v_legacy = _mm256_set1_ps(qparams.zero_point);
+  const auto zero_point_v_non_legacy = _mm256_set1_epi32(qparams.zero_point);
   for (; i < len / VLEN * VLEN; i += VLEN) {
     __m256 src_v = _mm256_loadu_ps(src + i);
     __m256 transformed_v;
     if (LEGACY) { // static if
-      transformed_v = _mm256_fmadd_ps(
-          src_v, inverse_scale_v, _mm256_set1_ps(qparams.zero_point));
+      transformed_v =
+          _mm256_fmadd_ps(src_v, inverse_scale_v, zero_point_v_legacy);
     } else {
       transformed_v = _mm256_mul_ps(src_v, inverse_scale_v);
     }
@@ -69,8 +71,7 @@ void QuantizeAvx2(
 
     __m256i rounded_v = _mm256_cvtps_epi32(transformed_v);
     if (!LEGACY) {
-      rounded_v =
-          _mm256_add_epi32(rounded_v, _mm256_set1_epi32(qparams.zero_point));
+      rounded_v = _mm256_add_epi32(rounded_v, zero_point_v_non_legacy);
     }
     __m256i clipped_v = _mm256_min_epi32(
         _mm256_max_epi32(rounded_v, _mm256_set1_epi32(min_val)),
@@ -94,8 +95,8 @@ void QuantizeAvx2(
     __m256 src_v = _mm256_maskload_ps(src + i, mask_v);
     __m256 transformed_v;
     if (LEGACY) {
-      transformed_v = _mm256_fmadd_ps(
-          src_v, inverse_scale_v, _mm256_set1_ps(qparams.zero_point));
+      transformed_v =
+          _mm256_fmadd_ps(src_v, inverse_scale_v, zero_point_v_legacy);
     } else {
       transformed_v = _mm256_mul_ps(src_v, inverse_scale_v);
     }
@@ -104,8 +105,7 @@ void QuantizeAvx2(
 
     __m256i rounded_v = _mm256_cvtps_epi32(transformed_v);
     if (!LEGACY) {
-      rounded_v =
-          _mm256_add_epi32(rounded_v, _mm256_set1_epi32(qparams.zero_point));
+      rounded_v = _mm256_add_epi32(rounded_v, zero_point_v_non_legacy);
     }
     __m256i clipped_v = _mm256_min_epi32(
         _mm256_max_epi32(rounded_v, _mm256_set1_epi32(min_val)),


### PR DESCRIPTION
Summary: When T is unsigned char, the compiler can't prove that the storages in this loop don't alias qparams, so it loads zero_point on each iteration. We manually hoist the loads to get around this.

Differential Revision: D36415089

