### PR TITLE
minor refactoring

### DIFF
--- a/fbgemm_gpu/src/cumem_utils.cu
+++ b/fbgemm_gpu/src/cumem_utils.cu
@@ -265,7 +265,7 @@ int64_t uvm_get_guard_index(Tensor& t) {
 }
 } // namespace
 
-void uvm_cuda_mem_advise(Tensor t, int64_t cudaMemoryAdvise) {
+void uvm_cuda_mem_advise(Tensor t, int64_t cuda_memory_advise) {
   // Call cudaMemAdvise on vm tensor
   // See cudaMemoryAdvise enum (automatically exported to python fbgemm_gpu.uvm
   // namespace) for valid values and interface stub.
@@ -289,7 +289,7 @@ void uvm_cuda_mem_advise(Tensor t, int64_t cudaMemoryAdvise) {
   AT_CUDA_CHECK(cudaMemAdvise(
       ptr,
       size_bytes,
-      static_cast<enum cudaMemoryAdvise>(cudaMemoryAdvise),
+      static_cast<enum cudaMemoryAdvise>(cuda_memory_advise),
       hint_device));
   return;
 }

--- a/fbgemm_gpu/src/cumem_utils.h
+++ b/fbgemm_gpu/src/cumem_utils.h
@@ -36,7 +36,7 @@ Tensor uvm_to_device(Tensor t, Tensor prototype);
 
 // Call cudaMemAdvise on UVM Storage. The hint enum is generated in Python
 // (fbgemm,uvm) using data returned from C++ op.
-void uvm_cuda_mem_advise(Tensor t, int64_t cudaMemoryAdvise);
+void uvm_cuda_mem_advise(Tensor t, int64_t cuda_memory_advise);
 
 // Call cudaMemPrefetchAsync on UVM Storage
 void uvm_cuda_mem_prefetch_async(Tensor t, c10::optional<Tensor> device_t);

--- a/fbgemm_gpu/src/merge_pooled_embeddings_gpu.cpp
+++ b/fbgemm_gpu/src/merge_pooled_embeddings_gpu.cpp
@@ -19,6 +19,7 @@
 #include "hip/hip_runtime.h"
 #include "rocm_smi/rocm_smi.h"
 
+#include <inttypes.h>
 #include <algorithm>
 
 #include "fbgemm_gpu/merge_pooled_embeddings.h"
@@ -64,7 +65,12 @@ AdjacencyMatrix<Links> get_nvlink_matrix() {
     // to reconstruct it.
     char pci_bus_id_str[RSMI_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
     sprintf(
-        pci_bus_id_str, "%04X:%02X:%02X.%0X", domain, bus, device, function);
+        pci_bus_id_str,
+        "%04" PRIu64 ":%02" PRIu64 ":%02" PRIu64 ".%0" PRIu64,
+        domain,
+        bus,
+        device,
+        function);
 
     std::array<char, RSMI_DEVICE_PCI_BUS_ID_BUFFER_SIZE> pci_bus_id;
     std::copy(


### PR DESCRIPTION
Summary:
This patch applies refactoring.
1. Rename a local variable `cudaMemoryAdvise` to `cuda_memory_advise`. `cudaMemoryAdvise` is used by CUDA, so it is confusing to have a local variable that has the same name.
2. Uses `PRIu64` for `sprintf` in AMD's `get_nvlink_matrix()` implementation to deal with `uint64_t`. Otherwise the compiler warns.

Differential Revision: D36523866

