### PR TITLE
skip cudaMemcpy2DAsync() if no copy is needed

### DIFF
--- a/fbgemm_gpu/src/layout_transform_ops.cu
+++ b/fbgemm_gpu/src/layout_transform_ops.cu
@@ -51,6 +51,9 @@ Tensor recat_embedding_grad_output_cuda(
         int64_t feature_offset = 0;
         int64_t sgo_offset = 0;
         for (auto num_features : num_features_per_rank) {
+          if (num_features == 0) {
+            continue;
+          }
           AT_CUDA_CHECK(cudaMemcpy2DAsync(
               &sgo[sgo_offset],
               num_features * D * sizeof(scalar_t),
@@ -91,6 +94,9 @@ Tensor recat_embedding_grad_output_mixed_D_cuda(
         int64_t sgo_offset = 0;
         int64_t accum_dim_sum = 0;
         for (auto dim_sum : dim_sum_per_rank) {
+          if (dim_sum == 0) {
+            continue;
+          }
           AT_CUDA_CHECK(cudaMemcpy2DAsync(
               &sgo[sgo_offset],
               dim_sum * sizeof(scalar_t),


### PR DESCRIPTION
Summary: We don't need to call `cudaMemcpy2DAsync()` if we don't need to copy the data. Calling `hipMemcpy2DAsync()` (after hipification) can cause a compilation issue, so this patch applies a small change to skip `cudaMemcpy2DAsync()` when not needed.

Reviewed By: minsii, jianyuh

Differential Revision: D36536644

