### PR TITLE
Revise split table batched embedding benchmark

### DIFF
--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -1292,7 +1292,7 @@ def nbit_uvm(
             f"{nparams_byte / 1.0e9: .2f} GB"  # IntN TBE use byte for storage
         )
         logging.info(
-            f"Accessed weights per batch: {B * (T * L + T_uvm * L_uvm)} rows, "
+            f"Accessed weights per batch: {B * (T_gpu * L + T_uvm * L_uvm)} rows, "
             f"{B * (L * sum(Ds[T_uvm:]) + L_uvm * sum(Ds[:T_uvm])) * param_size_multiplier / 1.0e9: .2f} GB"
         )
 


### PR DESCRIPTION
Summary:
1. Bug fix at log in nbit-uvm benchmark.
2. Enables check-median option for bench_utils.py:benchmark_pipelined_requests.

Differential Revision: D36741070

