### PR TITLE
UVM tensor generating without preferred location

### DIFF
--- a/fbgemm_gpu/bench/reproduce.sh
+++ b/fbgemm_gpu/bench/reproduce.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#You need to change the TARGET_BIN
+TARGET_BIN="buck run @mode/opt -c python.package_style=inplace -j 40 //deeplearning/fbgemm/fbgemm_gpu:split_table_batched_embeddings_benchmark"
+
+NUMA_CMD="numactl --cpunodebind=0 --membind=0"
+CUDA_CMD="CUDA_VISIBLE_DEVICES=1"
+
+COMMON_PART="${CUDA_CMD} ${NUMA_CMD} ${TARGET_BIN} -- nbit-uvm --alpha 1.0 --reuse 0.1 --weights-precision int4 --uvm-num-embeddings 5000000 --num-embeddings 5000000 --batch-size 2048 --bag-size 256 --uvm-bag-size 256 --num-tables 10 --uvm-tables 10 --embedding-dim 248 "
+
+for f in 0.305 0.405 0.505
+do
+    CMD1="${COMMON_PART} --memory-fraction ${f}"
+    CMD2="${COMMON_PART} --memory-fraction ${f} --set-preferred-location False"
+    echo ${CMD1}
+    eval ${CMD1}
+    echo ${CMD2}
+    eval ${CMD2}
+done

--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -1128,10 +1128,12 @@ def nbit_device(  # noqa C901
 @click.option("--output-dtype", type=SparseType, default=SparseType.FP16)
 @click.option("--use-cache", is_flag=True, default=False)
 @click.option("--cache-algorithm", default="lru")
+@click.option("--memory-fraction", default=1.0)
 @click.option("--cache-load-factor", default=0.2)
 @click.option("--enforce-hbm", is_flag=True, default=False)
 @click.option("--fp8-exponent-bits", type=int, default=None)
 @click.option("--fp8-exponent-bias", type=int, default=None)
+@click.option("--set-preferred-location", default=True)
 def nbit_uvm(
     alpha: bool,
     bag_size: int,
@@ -1152,9 +1154,11 @@ def nbit_uvm(
     use_cache: bool,
     cache_algorithm: str,
     cache_load_factor: float,
+    memory_fraction: float,
     enforce_hbm: bool,
     fp8_exponent_bits: Optional[int],
     fp8_exponent_bias: Optional[int],
+    set_preferred_location: bool,
 ) -> None:
     np.random.seed(42)
     torch.manual_seed(42)
@@ -1177,6 +1181,27 @@ def nbit_uvm(
     )
 
     logging.info(f"T: {T}, T_uvm: {T_uvm}, T_gpu: {T_gpu}")
+    total_memory = torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).total_memory
+    if memory_fraction < 1:
+        tmp_tensor = torch.empty(
+            int(total_memory * (1 - memory_fraction)),
+            dtype=torch.int8,
+            device=torch.cuda.current_device(),
+        )
+    else:
+        tmp_tensor = torch.empty(
+            int(1),
+            dtype=torch.int8,
+            device=torch.cuda.current_device(),
+        )
+    print("total memory (GB): ", total_memory / (1024 * 1024 * 1024))
+    print("Tmp tensor size (GB): ", len(tmp_tensor) / (1024 * 1024 * 1024))
+    print(
+        "Available memory size (GB): ",
+        (total_memory - len(tmp_tensor)) / (1024 * 1024 * 1024),
+    )
 
     if mixed:
         Ds = [
@@ -1203,6 +1228,7 @@ def nbit_uvm(
         enforce_hbm=enforce_hbm,
         fp8_exponent_bits=fp8_exponent_bits,
         fp8_exponent_bias=fp8_exponent_bias,
+        set_preferred_location=set_preferred_location,
     ).cuda()
     emb_uvm.fill_random_weights()
 
@@ -1245,6 +1271,7 @@ def nbit_uvm(
             enforce_hbm=enforce_hbm,
             fp8_exponent_bits=fp8_exponent_bits,
             fp8_exponent_bias=fp8_exponent_bias,
+            set_preferred_location=set_preferred_location,
         ).cuda()
         emb_mixed.fill_random_weights()
 

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -1570,6 +1570,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         row_alignment: Optional[int] = None,
         fp8_exponent_bits: Optional[int] = None,
         fp8_exponent_bias: Optional[int] = None,
+        set_preferred_location: bool = True,
     ) -> None:  # noqa C901  # tuple of (rows, dims,)
         super(IntNBitTableBatchedEmbeddingBagsCodegen, self).__init__()
 
@@ -1716,6 +1717,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.dev_size: int = weight_split.dev_size
         self.uvm_size: int = weight_split.uvm_size
         self.enforce_hbm: bool = enforce_hbm
+        self.set_preferred_location: bool = set_preferred_location
 
         # Assign weights after weights and weights_offsets are initialized.
         if weight_lists:
@@ -1726,6 +1728,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 self.weights_physical_placements,
                 self.weights_physical_offsets,
                 self.enforce_hbm,
+                self.set_preferred_location,
             )
             self.assign_embedding_weights(weight_lists)  # type: ignore
 
@@ -2031,6 +2034,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         placements: List[int],
         offsets: List[int],
         enforce_hbm: bool,
+        set_preferred_location: bool = True,
     ) -> None:
         assert not self.weight_initialized, "Weights have already been initialized."
         self.weight_initialized = True
@@ -2072,13 +2076,26 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
                     dtype=torch.uint8,
                 )
             else:
-                self.weights_uvm = torch.zeros(
-                    uvm_size,
-                    out=torch.ops.fbgemm.new_managed_tensor(
-                        torch.zeros(1, device=self.D_offsets.device, dtype=torch.uint8),
-                        [uvm_size],
-                    ),
-                )
+                if set_preferred_location:
+                    self.weights_uvm = torch.zeros(
+                        uvm_size,
+                        out=torch.ops.fbgemm.new_managed_tensor(
+                            torch.zeros(
+                                1, device=self.D_offsets.device, dtype=torch.uint8
+                            ),
+                            [uvm_size],
+                        ),
+                    )
+                else:
+                    self.weights_uvm = torch.zeros(
+                        uvm_size,
+                        out=torch.ops.fbgemm.new_managed_tensor_experimental(
+                            torch.zeros(
+                                1, device=self.D_offsets.device, dtype=torch.uint8
+                            ),
+                            [uvm_size],
+                        ),
+                    )
 
     def _apply_cache_state(
         self,
@@ -2307,6 +2324,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 self.weights_physical_placements,
                 self.weights_physical_offsets,
                 self.enforce_hbm,
+                self.set_preferred_location,
             )
             self.weight_initialized: bool = True
 

--- a/fbgemm_gpu/src/cumem_utils.h
+++ b/fbgemm_gpu/src/cumem_utils.h
@@ -16,6 +16,10 @@ using namespace at;
 // and set both UVM storage preference to CPU and access from self.device
 Tensor new_managed_tensor(Tensor self, const std::vector<std::int64_t>& sizes);
 
+Tensor new_managed_tensor_experimental(
+    Tensor self,
+    const std::vector<std::int64_t>& sizes);
+
 // Allocate the ATen Tensor with unified managed memory (UVM)
 Tensor new_vanilla_managed_tensor(
     Tensor self,

--- a/fbgemm_gpu/src/cumem_utils_host.cpp
+++ b/fbgemm_gpu/src/cumem_utils_host.cpp
@@ -26,6 +26,9 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
   DISPATCH_TO_CUDA("uvm_to_cpu", uvm_to_cpu);
   m.def("new_managed_tensor(Tensor self, int[] sizes) -> Tensor");
   DISPATCH_TO_CUDA("new_managed_tensor", new_managed_tensor);
+  m.def("new_managed_tensor_experimental(Tensor self, int[] sizes) -> Tensor");
+  DISPATCH_TO_CUDA(
+      "new_managed_tensor_experimental", new_managed_tensor_experimental);
   m.def("new_vanilla_managed_tensor(Tensor self, int[] sizes) -> Tensor");
   DISPATCH_TO_CUDA("new_vanilla_managed_tensor", new_vanilla_managed_tensor);
   m.def(
@@ -52,6 +55,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   DISPATCH_TO_CUDA("uvm_to_cpu", uvm_to_cpu);
   m.def("new_managed_tensor(Tensor self, int[] sizes) -> Tensor");
   DISPATCH_TO_CUDA("new_managed_tensor", new_managed_tensor);
+  m.def("new_managed_tensor_experimental(Tensor self, int[] sizes) -> Tensor");
+  DISPATCH_TO_CUDA(
+      "new_managed_tensor_experimental", new_managed_tensor_experimental);
   m.def("new_vanilla_managed_tensor(Tensor self, int[] sizes) -> Tensor");
   DISPATCH_TO_CUDA("new_vanilla_managed_tensor", new_vanilla_managed_tensor);
   m.def(


### PR DESCRIPTION
Summary: Add the "unset_preferred_location" flag to the new_managed_tensor function, which will turn off the preferred location to the CPU if the flag is turned on.

Differential Revision: D36848522

