### PR TITLE
Remove anonymous namespace for SparseType

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_dense_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_dense_host.cpp
@@ -13,6 +13,7 @@
 #include "fbgemm_gpu/sparse_ops_utils.h"
 
 using Tensor = at::Tensor;
+using namespace fbgemm_gpu;
 
 Tensor dense_embedding_codegen_forward_unweighted_cuda(
     Tensor dev_weights,

--- a/fbgemm_gpu/codegen/embedding_backward_dense_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_dense_host_cpu.cpp
@@ -13,6 +13,7 @@
 #include "fbgemm_gpu/sparse_ops_utils.h"
 
 using Tensor = at::Tensor;
+using namespace fbgemm_gpu;
 
 Tensor split_embedding_backward_codegen_dense_cpu(
     Tensor grad_output,

--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_approx_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_approx_template.cpp
@@ -17,6 +17,7 @@
 #include "fbgemm_gpu/embedding_common.h"
 
 using Tensor = at::Tensor;
+using namespace fbgemm_gpu;
 
 namespace {
 template <typename scalar_t, typename grad_t>

--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
@@ -19,6 +19,7 @@
 #include "fbgemm_gpu/cpu_utils.h"
 
 using Tensor = at::Tensor;
+using namespace fbgemm_gpu;
 
 namespace internal {
 template <typename T>

--- a/fbgemm_gpu/codegen/embedding_backward_split_host_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_cpu_template.cpp
@@ -14,6 +14,7 @@
 #include "fbgemm_gpu/sparse_ops_utils.h"
 
 using Tensor = at::Tensor;
+using namespace fbgemm_gpu;
 
 void split_embedding_backward_codegen_{{ optimizer }}_cpu(
     Tensor grad_output,

--- a/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
@@ -14,6 +14,7 @@
 #include "fbgemm_gpu/sparse_ops_utils.h"
 
 using Tensor = at::Tensor;
+using namespace fbgemm_gpu;
 
 Tensor split_embedding_codegen_forward_unweighted_cuda(
     Tensor dev_weights,

--- a/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
@@ -12,6 +12,7 @@
 #include "fbgemm_gpu/sparse_ops_utils.h"
 
 using Tensor = at::Tensor;
+using namespace fbgemm_gpu;
 
 namespace {
 

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
@@ -19,6 +19,8 @@
 #include <immintrin.h>
 #include <emmintrin.h>
 
+using namespace fbgemm_gpu;
+
 namespace {
 
 using Tensor = at::Tensor;

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
@@ -14,6 +14,7 @@
 #include "fbgemm_gpu/sparse_ops_utils.h"
 
 using Tensor = at::Tensor;
+using namespace fbgemm_gpu;
 
 Tensor int_nbit_split_embedding_codegen_forward_unweighted_cuda(
     Tensor dev_weights,

--- a/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
@@ -20,6 +20,7 @@
 #include <ATen/AccumulateType.h>
 
 using Tensor = at::Tensor;
+using namespace fbgemm_gpu;
 
 template <typename weights_t, typename ind_weights_t, typename output_t>
 void split_embedding_forward_cpu_kernel(

--- a/fbgemm_gpu/include/fbgemm_gpu/embedding_common.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/embedding_common.h
@@ -9,7 +9,7 @@
 #include <c10/macros/Macros.h>
 #include <cstdint>
 
-namespace {
+namespace fbgemm_gpu {
 
 // Keep in sync with split_embedding_configs.py:SparseType
 enum class SparseType : uint8_t {
@@ -39,7 +39,7 @@ enum class BoundsCheckMode : uint8_t {
   IGNORE = 2,
 };
 
-at::ScalarType getScalarType(SparseType dtype) {
+inline at::ScalarType getScalarType(SparseType dtype) {
   switch (dtype) {
     case SparseType::FP32:
       return at::kFloat;
@@ -58,7 +58,7 @@ at::ScalarType getScalarType(SparseType dtype) {
   }
 };
 
-SparseType getSparseType(at::ScalarType dtype) {
+inline SparseType getSparseType(at::ScalarType dtype) {
   switch (dtype) {
     case at::kFloat:
       return SparseType::FP32;
@@ -80,7 +80,7 @@ SparseType getSparseType(at::ScalarType dtype) {
   }
 };
 
-} // namespace
+} // namespace fbgemm_gpu
 
 namespace nbit {
 
@@ -94,23 +94,23 @@ div_round_up(uint32_t a, uint32_t b) {
 }
 
 C10_HOST_DEVICE C10_ALWAYS_INLINE int32_t
-unpadded_row_size_in_bytes(int32_t dim, SparseType weight_ty) {
-  if (weight_ty == SparseType::FP32) {
+unpadded_row_size_in_bytes(int32_t dim, fbgemm_gpu::SparseType weight_ty) {
+  if (weight_ty == fbgemm_gpu::SparseType::FP32) {
     return dim * 4;
   }
-  if (weight_ty == SparseType::FP16) {
+  if (weight_ty == fbgemm_gpu::SparseType::FP16) {
     return dim * 2;
   }
-  if (weight_ty == SparseType::FP8) {
+  if (weight_ty == fbgemm_gpu::SparseType::FP8) {
     return dim;
   }
-  if (weight_ty == SparseType::INT8) {
+  if (weight_ty == fbgemm_gpu::SparseType::INT8) {
     return dim + 4;
   }
-  if (weight_ty == SparseType::INT4) {
+  if (weight_ty == fbgemm_gpu::SparseType::INT4) {
     return dim / 2 + 4;
   }
-  if (weight_ty == SparseType::INT2) {
+  if (weight_ty == fbgemm_gpu::SparseType::INT2) {
     return dim / 4 + 4;
   }
   return 0;
@@ -118,7 +118,7 @@ unpadded_row_size_in_bytes(int32_t dim, SparseType weight_ty) {
 
 C10_HOST_DEVICE C10_ALWAYS_INLINE int32_t padded_row_size_in_bytes(
     int32_t dim,
-    SparseType weight_ty,
+    fbgemm_gpu::SparseType weight_ty,
     int32_t row_alignment) {
   auto r = unpadded_row_size_in_bytes(dim, weight_ty);
   return round_up(r, row_alignment);


### PR DESCRIPTION
Summary:
If two different C++ include this header, we will have two different anonymous namespace, and cause the linking issue.

So we should not have anonymous namespace unless we don't want others refer to this class.

Differential Revision: D36884591

