### PR TITLE
Add index_select for jagged tensors

### DIFF
--- a/fbgemm_gpu/bench/sparse_ops_benchmark.py
+++ b/fbgemm_gpu/bench/sparse_ops_benchmark.py
@@ -121,5 +121,108 @@ def batch_reuse_index_select_device(
     )
 
 
+@cli.command()
+@click.option("--max-seq-length", default=500)
+@click.option("--batch-size", default=4096)
+@click.option("--num-cols", default=256)
+@click.option("--num-jagged-tensor-rows", default=4096)
+@click.option("--num-zero-padding", default=1024)
+@click.option("--index-dtype", type=click.Choice(["int", "long"]), default="int")
+@click.option(
+    "--jagged-tensor-dtype", type=click.Choice(["float", "half"]), default="float"
+)
+def jagged_index_select_2d_bench(
+    max_seq_length: int,
+    batch_size: int,
+    num_cols: int,
+    num_jagged_tensor_rows: int,
+    num_zero_padding: int,
+    index_dtype: str,
+    jagged_tensor_dtype: str,
+) -> None:
+    def jagged_index_select_2d_ref(
+        values: torch.Tensor, lengths: torch.Tensor, inverse_lookup: torch.Tensor
+    ) -> torch.Tensor:
+        offsets = torch.ops.fbgemm.asynchronous_exclusive_cumsum(lengths)
+        end_offsets = offsets + lengths
+        full_start_offset = torch.index_select(offsets, 0, inverse_lookup)
+        full_end_offset = torch.index_select(end_offsets, 0, inverse_lookup)
+        index_ranges = torch.stack(
+            (full_start_offset, full_end_offset), dim=0
+        ).transpose(0, 1)
+
+        to_be_merged_tensors = []
+        for row in index_ranges:
+            to_be_merged_tensors.append(torch.arange(row[0], row[1], device="cuda"))
+        all_indices = torch.cat(to_be_merged_tensors, dim=0)
+        new_embeddings = torch.index_select(values, 0, all_indices)
+        return new_embeddings
+
+    index_t = {"int": torch.int, "long": torch.long}[index_dtype]
+    scalar_t = {"float": torch.float, "half": torch.half}[jagged_tensor_dtype]
+
+    lengths = torch.randint(
+        low=0,
+        high=max_seq_length,
+        size=(num_jagged_tensor_rows,),
+        dtype=index_t,
+        device="cuda",
+    )
+    indices, _ = torch.sort(
+        torch.randint(
+            low=0,
+            high=num_jagged_tensor_rows,
+            size=(batch_size,),
+            dtype=index_t,
+            device="cuda",
+        )
+    )
+    values = torch.rand(
+        int(lengths.sum().item()), num_cols, dtype=scalar_t, device="cuda"
+    )
+    values.requires_grad = True
+
+    indices[batch_size - num_zero_padding :] = 0
+
+    time, (output, _) = benchmark_torch_function(
+        torch.ops.fbgemm.jagged_index_select,
+        (values, lengths, indices),
+        num_warmups=10,
+        iters=100,
+    )
+    time_ref, output_ref = benchmark_torch_function(
+        jagged_index_select_2d_ref,
+        (values, lengths, indices),
+        num_warmups=10,
+        iters=100,
+    )
+    logging.info(
+        f"jagged_index_select_2d_bench "
+        f"(max_seq_length={max_seq_length}, "
+        f"batch_size={batch_size}, "
+        f"num_cols={num_cols}, "
+        f"num_jagged_tensor_rows={num_jagged_tensor_rows}, "
+        f"num_zero_padding={num_zero_padding}, "
+        f"index_dtype={index_dtype}, "
+        f"jagged_tensor_dtype={jagged_tensor_dtype})"
+    )
+    logging.info(f"forward: fbgemm {time * 1e3:.3f} ms, ref {time_ref * 1e3:.3f} ms")
+
+    grad = torch.rand_like(output)
+    time, _ = benchmark_torch_function(
+        functools.partial(output.backward, retain_graph=True),
+        (grad,),
+        num_warmups=10,
+        iters=100,
+    )
+    time_ref, _ = benchmark_torch_function(
+        functools.partial(output_ref.backward, retain_graph=True),
+        (grad,),
+        num_warmups=10,
+        iters=100,
+    )
+    logging.info(f"backward: fbgemm {time * 1e3:.3f} ms, ref {time_ref * 1e3:.3f} ms")
+
+
 if __name__ == "__main__":
     cli()

--- a/fbgemm_gpu/src/jagged_tensor_ops.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops.cu
@@ -11,6 +11,7 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <torch/csrc/autograd/custom_function.h>
 #include <torch/library.h>
+#include <ATen/cuda/Atomic.cuh>
 
 // clang-format off
 #include "fbgemm_gpu/cub_namespace_prefix.cuh"
@@ -1444,6 +1445,311 @@ std::vector<Tensor> stacked_jagged_1d_to_dense_gpu(
   return padded_values_per_key;
 }
 
+template <typename scalar_t>
+__device__ __forceinline__ void binary_search_range(
+    int* found,
+    const scalar_t* arr,
+    const scalar_t target,
+    const int num_entries) {
+  const int last_entry = num_entries - 1;
+  int start = 0, end = last_entry;
+  int found_ = -1;
+  while (start <= end) {
+    int mid = start + (end - start) / 2;
+    scalar_t mid_offset = arr[mid];
+    if (target == mid_offset) {
+      if (mid != last_entry && target != arr[last_entry]) {
+        // Do linear scan in case of duplicate data (We assume that the
+        // number of duplicates is small.  This can we very bad if the
+        // number of duplicates is large)
+        for (int i = mid + 1; i < num_entries; i++) {
+          if (target != arr[i]) {
+            found_ = i;
+            break;
+          }
+        }
+      }
+      break;
+    } else if (target < mid_offset) {
+      if (mid == 0) {
+        found_ = 0;
+        break;
+      } else if (mid - 1 >= 0 && target > arr[mid - 1]) {
+        found_ = mid;
+        break;
+      }
+      end = mid - 1;
+    } else {
+      if (mid + 1 <= last_entry && target < arr[mid + 1]) {
+        found_ = mid + 1;
+        break;
+      }
+      start = mid + 1;
+    }
+  }
+  *found = found_;
+}
+
+template <typename index_t, typename offset_t, typename scalar_t>
+__global__ __launch_bounds__(kMaxThreads) void jagged_index_select_2d_kernel(
+    scalar_t* output,
+    const scalar_t* input,
+    const offset_t* input_offsets,
+    const index_t* indices,
+    const offset_t* output_offsets,
+    const int64_t num_output_rows,
+    const int64_t num_dense_output_rows,
+    const int64_t num_cols) {
+  __shared__ int smem[1];
+  for (offset_t dense_output_offset = blockIdx.x;
+       dense_output_offset < num_dense_output_rows;
+       dense_output_offset += gridDim.x) {
+    // Binary search
+    // TODO: use multiple threads to do bin search to reduce number of steps
+    if (threadIdx.x == 0) {
+      binary_search_range(
+          smem, output_offsets, dense_output_offset, num_output_rows);
+    }
+    __syncthreads();
+
+    // All threads load index_pos from shared memory and return if the index_pos
+    // is invalid
+    int index_pos = smem[0];
+
+    // TODO: Can also be obtained during the binary search
+    // Relative index position
+    const offset_t rel_index = dense_output_offset -
+        (index_pos == 0 ? 0 : output_offsets[index_pos - 1]);
+    const index_t index = indices[index_pos];
+    const offset_t input_offset =
+        (index == 0 ? 0 : input_offsets[index - 1]) + rel_index;
+
+    // Shift buffers
+    scalar_t* output_ = output + dense_output_offset * num_cols;
+    const scalar_t* input_ = input + input_offset * num_cols;
+
+    for (int i = threadIdx.x; i < num_cols; i += blockDim.x) {
+      output_[i] = input_[i];
+    }
+  }
+}
+
+Tensor jagged_index_select_2d_cuda(
+    const Tensor& values,
+    const Tensor& indices,
+    const Tensor& input_offsets,
+    const Tensor& output_offsets,
+    const int64_t num_dense_output_rows) {
+  at::cuda::OptionalCUDAGuard device_guard;
+  device_guard.set_index(values.get_device());
+
+  auto num_cols = values.size(1);
+  const int64_t num_output_rows = indices.numel();
+
+  const int64_t max_num_blocks = 1024; // Arbitrarily set to this number of now
+  const int64_t max_num_threads = kMaxThreads;
+  const int64_t num_blocks = std::min(max_num_blocks, num_dense_output_rows);
+  const int64_t num_threads = std::min(max_num_threads, num_cols);
+  Tensor output =
+      at::empty({num_dense_output_rows, num_cols}, values.options());
+
+  if (num_blocks > 0) {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+        values.scalar_type(), "jagged_index_select_2d_kernel_wrapper_1", [&] {
+          AT_DISPATCH_INDEX_TYPES(
+              indices.scalar_type(),
+              "jagged_index_select_2d_kernel_wrapper_2",
+              [&] {
+                jagged_index_select_2d_kernel<<<
+                    dim3(num_blocks),
+                    dim3(num_cols),
+                    0,
+                    at::cuda::getCurrentCUDAStream()>>>(
+                    output.data_ptr<scalar_t>(),
+                    values.data_ptr<scalar_t>(),
+                    input_offsets.data_ptr<int64_t>(),
+                    indices.data_ptr<index_t>(),
+                    output_offsets.data_ptr<int64_t>(),
+                    num_output_rows,
+                    num_dense_output_rows,
+                    num_cols);
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+              });
+        });
+  }
+
+  return output;
+}
+
+template <typename index_t, typename offset_t, typename scalar_t>
+__global__ __launch_bounds__(kMaxThreads) void jagged_index_add_2d_kernel(
+    scalar_t* output,
+    const scalar_t* grad,
+    const offset_t* grad_offsets,
+    const index_t* indices,
+    const offset_t* output_offsets,
+    const int64_t num_grad_rows,
+    const int64_t num_dense_grad_rows,
+    const int64_t num_cols) {
+  __shared__ int smem[1];
+  for (offset_t dense_grad_offset = blockIdx.x;
+       dense_grad_offset < num_dense_grad_rows;
+       dense_grad_offset += gridDim.x) {
+    // Binary search
+    // TODO: use multiple threads to do bin search to reduce number of steps
+    if (threadIdx.x == 0) {
+      binary_search_range(smem, grad_offsets, dense_grad_offset, num_grad_rows);
+    }
+    __syncthreads();
+
+    // All threads load index_pos from shared memory and return if the index_pos
+    // is invalid
+    int index_pos = smem[0];
+
+    // TODO: Can also be obtained during the binary search
+    // Relative index position
+    const offset_t rel_index =
+        dense_grad_offset - (index_pos == 0 ? 0 : grad_offsets[index_pos - 1]);
+    const index_t index = indices[index_pos];
+    const offset_t output_offset =
+        (index == 0 ? 0 : output_offsets[index - 1]) + rel_index;
+
+    // Shift buffers
+    const scalar_t* grad_ = grad + dense_grad_offset * num_cols;
+    scalar_t* output_ = output + output_offset * num_cols;
+
+    // TODO: Avoid using atoimcAdd (because it could lead to the numerical
+    // indeterminism issue)
+    for (int i = threadIdx.x; i < num_cols; i += blockDim.x) {
+      gpuAtomicAdd(&output_[i], grad_[i]);
+    }
+  }
+}
+
+Tensor jagged_index_add_2d_cuda(
+    const Tensor& grad,
+    const Tensor& indices,
+    const Tensor& grad_offsets,
+    const Tensor& output_offsets,
+    const int64_t num_dense_grad_rows,
+    const int64_t num_output_rows) {
+  at::cuda::OptionalCUDAGuard device_guard;
+  device_guard.set_index(grad.get_device());
+
+  auto num_cols = grad.size(1);
+  const int64_t num_grad_rows = indices.numel();
+
+  const int64_t max_num_blocks = 1024; // Arbitrarily set to this number of now
+  const int64_t max_num_threads = kMaxThreads;
+  const int64_t num_blocks = std::min(max_num_blocks, num_dense_grad_rows);
+  const int64_t num_threads = std::min(max_num_threads, num_cols);
+  Tensor output = at::zeros({num_output_rows, num_cols}, grad.options());
+
+  if (num_blocks > 0) {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+        grad.scalar_type(), "jagged_index_add_2d_kernel_wrapper_1", [&] {
+          AT_DISPATCH_INDEX_TYPES(
+              indices.scalar_type(),
+              "jagged_index_add_2d_kernel_wrapper_2",
+              [&] {
+                jagged_index_add_2d_kernel<<<
+                    dim3(num_blocks),
+                    dim3(num_cols),
+                    0,
+                    at::cuda::getCurrentCUDAStream()>>>(
+                    output.data_ptr<scalar_t>(),
+                    grad.data_ptr<scalar_t>(),
+                    grad_offsets.data_ptr<int64_t>(),
+                    indices.data_ptr<index_t>(),
+                    output_offsets.data_ptr<int64_t>(),
+                    num_grad_rows,
+                    num_dense_grad_rows,
+                    num_cols);
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+              });
+        });
+  }
+
+  return output;
+}
+
+class JaggedIndexSelect2dGPUOp
+    : public torch::autograd::Function<JaggedIndexSelect2dGPUOp> {
+ public:
+  static torch::autograd::variable_list forward(
+      torch::autograd::AutogradContext* ctx,
+      const Tensor& values,
+      const Tensor& lengths,
+      const Tensor& indices) {
+    TENSOR_ON_CUDA_GPU(lengths);
+    TENSOR_ON_CUDA_GPU(values);
+    TENSOR_ON_CUDA_GPU(indices);
+    TENSORS_ON_SAME_DEVICE(lengths, indices);
+    TENSORS_ON_SAME_DEVICE(values, indices);
+
+    Tensor output_lengths = at::index_select(lengths, 0, indices);
+    Tensor output_offsets = output_lengths.cumsum(0);
+    Tensor input_offsets = lengths.cumsum(0);
+
+    // TODO: Try to not do D->H transfer
+    // The challenge here is num_dense_output_rows is needed for allocating the
+    // output buffer
+    int64_t num_dense_output_rows =
+        output_offsets[output_offsets.numel() - 1].item<int64_t>();
+
+    ctx->save_for_backward({indices, output_offsets, input_offsets});
+    ctx->saved_data["num_dense_grad_rows"] = num_dense_output_rows;
+    ctx->saved_data["num_input_rows"] = values.size(0);
+
+    return {
+        jagged_index_select_2d_cuda(
+            values,
+            indices,
+            input_offsets,
+            output_offsets,
+            num_dense_output_rows),
+        output_lengths};
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext* ctx,
+      torch::autograd::variable_list grad_outputs) {
+    TORCH_CHECK(grad_outputs.size() == 2);
+    TENSOR_ON_CUDA_GPU(grad_outputs[0]);
+
+    const auto saved = ctx->get_saved_variables();
+    auto savedItr = std::begin(saved);
+    Tensor indices = *savedItr++;
+    Tensor grad_offsets = *savedItr++;
+    Tensor output_offsets = *savedItr++;
+
+    Tensor grad = grad_outputs[0];
+    TENSORS_ON_SAME_DEVICE(grad, indices);
+
+    int64_t num_dense_grad_rows =
+        ctx->saved_data["num_dense_grad_rows"].toInt();
+    int64_t num_output_rows = ctx->saved_data["num_input_rows"].toInt();
+
+    return {
+        jagged_index_add_2d_cuda(
+            grad,
+            indices,
+            grad_offsets,
+            output_offsets,
+            num_dense_grad_rows,
+            num_output_rows),
+        torch::autograd::Variable(), // lengths
+        torch::autograd::Variable() // indices
+    };
+  }
+};
+
+std::vector<Tensor> jagged_index_select_2d_gpu(
+    const Tensor& values,
+    const Tensor& lengths,
+    const Tensor& indices) {
+  return JaggedIndexSelect2dGPUOp::apply(values, lengths, indices);
+}
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
@@ -1463,4 +1769,6 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   DISPATCH_TO_CUDA(
       "batched_dense_vec_jagged_2d_mul",
       fbgemm_gpu::batched_dense_vec_jagged_2d_mul);
+  DISPATCH_TO_CUDA(
+      "jagged_index_select", fbgemm_gpu::jagged_index_select_2d_gpu);
 }

--- a/fbgemm_gpu/src/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_cpu.cpp
@@ -2391,6 +2391,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   // unique indices computation step in the backward operation.
   m.def(
       "index_select_dim0(Tensor input, Tensor indices, int? consecutive_range_start=0, int? consecutive_range_length=0) -> Tensor");
+  m.def(
+      "jagged_index_select(Tensor values, Tensor lengths, Tensor indices) -> Tensor[]");
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {

--- a/fbgemm_gpu/src/sparse_ops_gpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_gpu.cpp
@@ -243,7 +243,6 @@ Tensor index_select_dim0_gpu(
       consecutive_range_start ? *consecutive_range_start : 0,
       consecutive_range_length ? *consecutive_range_length : 0)[0];
 }
-
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {


### PR DESCRIPTION
Summary:
This diff adds the index_select operation for jagged tensors, i.e.,
``jagged_index_select``.  This op did not exist before this diff.  To
apply index_select to a jagged tensor, we had to compute the expanded
set of indices (which requires memory copy within the device as well
as H<->D memory copy) to access the jagged tensor's data using the
dense index_select operation (i.e., index_select that takes a dense
input tensor).

The implementation of ``jagged_index_select`` aims to minimize memory
copies especially the H<->D ones.  Instead of involving a host in
computing the expanded set of indices and storing them in the global
memory, this op computes the expanded indices inside the CUDA kernel
(using binary search to infer this information from the offsets of
index selected lengths of jagged tensor) and uses shared memory as a
storage (we use shared memory instead of register because the indices
have to be shared to all threads in a thread block).  Once the
expanded set of indices are computed, the subsequent steps are the
same as the dense index_select.

Differential Revision: D36928968

