### PR TITLE
Don't store on each iteration in EmbeddingSpMDMBlockSize1

### DIFF
--- a/src/EmbeddingSpMDMAvx2.cc
+++ b/src/EmbeddingSpMDMAvx2.cc
@@ -99,9 +99,11 @@ bool EmbeddingSpMDMBlockSize1_(
     }
 #endif
 
+    float temp = out[m];
     for (; i < len; ++i) {
       int64_t idx = indices[current];
       if (idx < 0 || idx >= data_size) {
+        out[m] = temp;
         return false;
       }
 
@@ -111,18 +113,19 @@ bool EmbeddingSpMDMBlockSize1_(
       }
 
       const InType* inptr = input + indices[current];
-      out[m] = std::fma(
+      temp = std::fma(
           w,
           std::is_same<InType, float16>::value ? cpu_half2float(*inptr)
                                                : *inptr,
-          out[m]);
+          temp);
 
       ++current;
     }
     if (normalize_by_lengths && len) {
       float scale = 1.f / len;
-      out[m] *= scale;
+      temp *= scale;
     }
+    out[m] = temp;
   }
   return current == index_size;
 }


### PR DESCRIPTION
Summary: This does not seem to improve latency, but it eliminates a store on each loop iteration, which has to be worth a little something power/efficiency-wise, right?

Differential Revision: D36489429

