### PR TITLE
Add FP8 datatype and stochastic rounding functions in fbgemm_gpu

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_backward_code_generator.py
@@ -911,7 +911,9 @@ def lamb() -> None:
   at::acc_type<cache_t, true> rtw_sum_sq = 0.0;
   auto weight_row = WeightRow<emb_t, cache_t, at::acc_type<cache_t, true>>(weights, cache_weights, D, nullptr);
   float2 qparams;
-  if (std::is_same<emb_t, uint8_t>::value && !cache_weights) {
+  qparams.x = 1.0f;
+  qparams.y = 0.0f;
+  if ((std::is_same<emb_t, uint8_t>::value || std::is_same<emb_t, int8_t>::value) && !cache_weights) {
     qparams = weight_row.load_qparams();
   }
 #pragma unroll 1
@@ -1003,7 +1005,9 @@ def partial_rowwise_lamb() -> None:
     at::acc_type<cache_t, true> rtw_sum_sq = 0.0;
     auto weight_row = WeightRow<emb_t, cache_t, at::acc_type<cache_t, true>>(weights, cache_weights, D, nullptr);
     float2 qparams;
-    if (std::is_same<emb_t, uint8_t>::value && !cache_weights) {
+    qparams.x = 1.0f;
+    qparams.y = 0.0f;
+    if ((std::is_same<emb_t, uint8_t>::value || std::is_same<emb_t, int8_t>::value) && !cache_weights) {
         qparams = weight_row.load_qparams();
     }
     #pragma unroll kMaxVecsPerThread
@@ -1178,7 +1182,9 @@ def lars_sgd() -> None:
 
   auto weight_row = WeightRow<emb_t, cache_t, at::acc_type<cache_t, true>>(weights, cache_weights, D, nullptr);
   float2 qparams;
-  if (std::is_same<emb_t, uint8_t>::value && !cache_weights) {
+  qparams.x = 1.0f;
+  qparams.y = 0.0f;
+  if ((std::is_same<emb_t, uint8_t>::value || std::is_same<emb_t, int8_t>::value) && !cache_weights) {
       qparams = weight_row.load_qparams();
   }
 #pragma unroll kMaxVecsPerThread

--- a/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
@@ -122,7 +122,7 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
                         weight.acc.z * grad_out[i].acc.z + weight.acc.w * grad_out[i].acc.w;
                 } else {
                     int32_t D_emb = D;
-                    if (std::is_same<emb_t, uint8_t>::value) {
+                    if (std::is_same<emb_t, uint8_t>::value || std::is_same<emb_t, int8_t>::value) {
                         D_emb += kINT8QparamsBytes;
                     }
                     auto weight_row = WeightRow<emb_t, cache_t, at::acc_type<cache_t, true>>(
@@ -131,7 +131,9 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
                         D,
                         nullptr);
                     float2 qparams;
-                    if (std::is_same<emb_t, uint8_t>::value) {
+                    qparams.x = 1.0f;
+                    qparams.y = 0.0f;
+                    if (std::is_same<emb_t, uint8_t>::value || std::is_same<emb_t, int8_t>::value) {
                         qparams = weight_row.load_qparams();
                     }
                     Vec4T<at::acc_type<cache_t, true>> weight =
@@ -142,7 +144,7 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
                 }
                 {% else %}
                 int32_t D_emb = D;
-                if (std::is_same<emb_t, uint8_t>::value) {
+                if (std::is_same<emb_t, uint8_t>::value || std::is_same<emb_t, int8_t>::value) {
                     D_emb += kINT8QparamsBytes;
                 }
                 auto weight_row = WeightRow<emb_t, cache_t, at::acc_type<cache_t, true>>(
@@ -151,7 +153,9 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
                     D,
                     nullptr);
                 float2 qparams;
-                if (std::is_same<emb_t, uint8_t>::value) {
+                qparams.x = 1.0f;
+                qparams.y = 0.0f;
+                if (std::is_same<emb_t, uint8_t>::value || std::is_same<emb_t, int8_t>::value) {
                     qparams = weight_row.load_qparams();
                 }
                 Vec4T<at::acc_type<cache_t, true>> weight =

--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
@@ -68,6 +68,7 @@ class SparseType(enum.Enum):
     FP32 = "fp32"
     FP16 = "fp16"
     FP8 = "fp8"
+    FP8_qparams = "fp8_qparams"
     INT8 = "int8"
     INT4 = "int4"
     INT2 = "int2"
@@ -104,6 +105,7 @@ class SparseType(enum.Enum):
             SparseType.INT2.value: 4,
             SparseType.BF16.value: 5,
             SparseType.FP8.value: 6,
+            SparseType.FP8_qparams.value: 7,
         }[self.value]
 
     @staticmethod
@@ -112,8 +114,10 @@ class SparseType(enum.Enum):
             return SparseType("fp32")
         elif dtype == torch.float16:
             return SparseType("fp16")
-        elif dtype == torch.int8 or dtype == torch.uint8:
+        elif dtype == torch.uint8:
             return SparseType("int8")
+        elif dtype == torch.int8:
+            return SparseType("fp8_qparams")
         elif dtype == torch.quint4x2:
             return SparseType("int4")
         elif dtype == torch.quint2x4:
@@ -128,6 +132,7 @@ class SparseType(enum.Enum):
             SparseType.FP32.value: torch.float32,
             SparseType.FP16.value: torch.float16,
             SparseType.INT8.value: torch.uint8,
+            SparseType.FP8_qparams.value: torch.int8,
             SparseType.INT4.value: torch.quint4x2,
             SparseType.INT2.value: torch.quint2x4,
             SparseType.BF16.value: torch.bfloat16,
@@ -138,6 +143,7 @@ class SparseType(enum.Enum):
             SparseType.FP32.value: 32,
             SparseType.FP16.value: 16,
             SparseType.FP8.value: 8,
+            SparseType.FP8_qparams.value: 8,
             SparseType.INT8.value: 8,
             SparseType.INT4.value: 4,
             SparseType.INT2.value: 2,
@@ -149,6 +155,7 @@ class SparseType(enum.Enum):
             SparseType.FP32.value: 1,
             SparseType.FP16.value: 2,
             SparseType.FP8.value: 4,
+            SparseType.FP8_qparams.value: 4,
             SparseType.INT8.value: 4,
             SparseType.INT4.value: 8,
             SparseType.INT2.value: 16,
@@ -160,6 +167,7 @@ class SparseType(enum.Enum):
             self.value == SparseType.FP32.value
             or self.value == SparseType.FP16.value
             or self.value == SparseType.FP8.value
+            or self.value == SparseType.FP8_qparams.value
             or self.value == SparseType.BF16.value
         ):
             return True
@@ -167,8 +175,11 @@ class SparseType(enum.Enum):
             return False
 
     def default_config(self) -> QuantizationConfig:
-        if self.value == SparseType.FP8.value:
-            return FP8QuantizationConfig(4, 7)
+        if (
+            self.value == SparseType.FP8.value
+            or self.value == SparseType.FP8_qparams.value
+        ):
+            return FP8QuantizationConfig(4, 14)
         else:
             return QuantizationConfig()
 
@@ -177,6 +188,7 @@ ELEMENT_SIZE: Dict[SparseType, int] = {
     SparseType.FP32: 4,
     SparseType.FP16: 2,
     SparseType.FP8: 1,
+    SparseType.FP8_qparams: 1,
     SparseType.INT8: 1,
     SparseType.BF16: 2,
     # SparseType.INT4: 0.5,

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -98,7 +98,7 @@ def construct_split_state(
     uvm_size = 0
     for (num_embeddings, embedding_dim, location, _) in embedding_specs:
         assert embedding_dim % 4 == 0, f"{embedding_dim}"
-        if precision == SparseType.INT8:
+        if precision == SparseType.INT8 or precision == SparseType.FP8_qparams:
             embedding_dim += int8_emb_row_dim_offset
         state_size = num_embeddings * embedding_dim if not rowwise else num_embeddings
         if location == EmbeddingLocation.HOST:
@@ -887,6 +887,27 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 tmp_emb.uniform_(min_val, max_val)
                 tmp_emb_i8 = torch.ops.fbgemm.FloatToFused8BitRowwiseQuantized(tmp_emb)
                 emb.data.copy_(tmp_emb_i8)
+        elif self.weights_precision == SparseType.FP8_qparams:
+            for emb in splits:
+                assert (
+                    len(emb.shape) == 2
+                ), "FP8 embedding only supported for 2D weight tensors."
+                shape = [emb.shape[0], emb.shape[1] - self.int8_emb_row_dim_offset]
+                tmp_emb = torch.zeros(shape, device=self.current_device)
+                tmp_emb.uniform_(min_val, max_val)
+                """
+                ebits = 5
+                mbits = 2
+                bias = 30
+                """
+                ebits = 4
+                mbits = 3
+                bias = 14
+                max_pos = (1 << ((1 << ebits) - 2 - bias)) * (2 - 2 ** (-mbits))
+                tmp_emb_fp8 = torch.ops.fbgemm.FloatToHFP8Quantized(
+                    tmp_emb.contiguous(), ebits, bias, max_pos
+                )
+                emb.data.copy_(tmp_emb_fp8)
         else:
             for param in splits:
                 param.uniform_(min_val, max_val)
@@ -898,7 +919,10 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         """
         splits = []
         for t, (rows, dim, _, _) in enumerate(self.embedding_specs):
-            if self.weights_precision == SparseType.INT8:
+            if (
+                self.weights_precision == SparseType.INT8
+                or self.weights_precision == SparseType.FP8_qparams
+            ):
                 dim += self.int8_emb_row_dim_offset
             # pyre-fixme[29]:
             #  `Union[BoundMethod[typing.Callable(Tensor.__getitem__)[[Named(self,
@@ -1104,7 +1128,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 torch.empty(0, device=self.current_device, dtype=dtype),
             )
         if split.host_size > 0:
-            if dtype == torch.uint8:
+            if dtype == torch.uint8 or dtype == torch.int8:
                 self.register_buffer(
                     f"{prefix}_host",
                     torch.zeros(
@@ -1487,6 +1511,7 @@ def unpadded_row_size_in_bytes(dim: int, weight_ty: SparseType) -> int:
         SparseType.FP32.value: dim * 4,
         SparseType.FP16.value: dim * 2,
         SparseType.FP8.value: dim,
+        SparseType.FP8_qparams.value: dim + 4,
         SparseType.INT8.value: dim + 4,
         SparseType.INT4.value: dim // 2 + 4,
         SparseType.INT2.value: dim // 4 + 4,
@@ -2273,6 +2298,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
                     weight_ty == SparseType.INT8
                     or weight_ty == SparseType.INT4
                     or weight_ty == SparseType.INT2
+                    or weight_ty == SparseType.FP8_qparams
                 ):
                     splits.append(
                         (

--- a/fbgemm_gpu/include/fbgemm_gpu/dispatch_macros.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/dispatch_macros.h
@@ -32,6 +32,8 @@
     PRIVATE_CASE_TYPE_EMB(                                                    \
         at::ScalarType::Byte, _cache_t, uint8_t, NAME, __VA_ARGS__)           \
     PRIVATE_CASE_TYPE_EMB(                                                    \
+        at::ScalarType::Char, _cache_t, int8_t, NAME, __VA_ARGS__)            \
+    PRIVATE_CASE_TYPE_EMB(                                                    \
         at::ScalarType::Float, _cache_t, float, NAME, __VA_ARGS__)            \
     PRIVATE_CASE_TYPE_EMB(                                                    \
         at::ScalarType::Half, _cache_t, at::Half, NAME, __VA_ARGS__)          \
@@ -127,6 +129,8 @@
     switch (_emb_t) {                                                      \
       PRIVATE_CASE_TYPE_EMB(                                               \
           at::ScalarType::Byte, _cache_t, uint8_t, NAME, __VA_ARGS__)      \
+      PRIVATE_CASE_TYPE_EMB(                                               \
+          at::ScalarType::Char, _cache_t, int8_t, NAME, __VA_ARGS__)       \
       PRIVATE_CASE_TYPE_EMB(                                               \
           at::ScalarType::Float, _cache_t, float, NAME, __VA_ARGS__)       \
       PRIVATE_CASE_TYPE_EMB(                                               \

--- a/fbgemm_gpu/include/fbgemm_gpu/embedding_common.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/embedding_common.h
@@ -20,7 +20,8 @@ enum class SparseType : uint8_t {
   INT2 = 4,
   BF16 = 5,
   FP8 = 6,
-  INVALID = 7,
+  FP8_qparams = 7,
+  INVALID = 8,
 };
 
 enum class PoolingMode : uint8_t { SUM = 0, MEAN = 1, NONE = 2 };
@@ -47,6 +48,8 @@ inline at::ScalarType getScalarType(SparseType dtype) {
       return at::kHalf;
     case SparseType::INT8:
       return at::kByte;
+    case SparseType::FP8_qparams:
+      return at::kChar;
     case SparseType::BF16:
       return at::kBFloat16;
     case SparseType::INT4:
@@ -66,6 +69,7 @@ inline SparseType getSparseType(at::ScalarType dtype) {
       return SparseType::FP16;
     case at::kByte:
     case at::kChar:
+      return SparseType::FP8_qparams;
     case at::kQUInt8:
     case at::kQInt8:
       return SparseType::INT8;
@@ -103,6 +107,9 @@ unpadded_row_size_in_bytes(int32_t dim, fbgemm_gpu::SparseType weight_ty) {
   }
   if (weight_ty == fbgemm_gpu::SparseType::FP8) {
     return dim;
+  }
+  if (weight_ty == fbgemm_gpu::SparseType::FP8_qparams) {
+    return dim + 4;
   }
   if (weight_ty == fbgemm_gpu::SparseType::INT8) {
     return dim + 4;

--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
@@ -13,6 +13,7 @@
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
+#include "fbgemm_gpu/quantize_ops_utils.h"
 
 namespace {
 using fint32 = union fint32 {
@@ -22,6 +23,25 @@ using fint32 = union fint32 {
 } // namespace
 
 namespace fbgemm_gpu {
+
+__device__ int ebits = 4;
+__device__ int mbits = 3;
+__device__ int bias = 14;
+__device__ float min_pos = 1.52587890625e-05;
+__device__ float max_pos = 1.875;
+
+/*
+__device__ int ebits = 5;
+__device__ int mbits = 2;
+__device__ int bias = 30;
+__device__ float min_pos = 4.656612873077393e-10;
+__device__ float max_pos = 1.75;
+__device__ int ebits = 5;
+__device__ int mbits = 2;
+__device__ int bias = 24;
+__device__ float min_pos = 2.9802322387695312e-08;
+__device__ float max_pos = 112.0;
+*/
 
 enum class PrimitiveType : uint8_t { FP = 0, INT = 1, BF = 2 };
 
@@ -790,6 +810,92 @@ DEVICE_INLINE void stochastic_rounding_vector(
       (value.acc.w - qparams.y) * inv_scale, random_bits.w);
 }
 
+template <>
+DEVICE_INLINE void stochastic_rounding_vector(
+    int8_t* output,
+    Vec4T<float> value,
+    StochasticRoundingRNGState& state,
+    float2 qparams) {
+  uint4 random_bits = stochastic_rounding_rand4(&state);
+  CUDA_KERNEL_ASSERT(!isnan(qparams.x));
+  float inv_scale = 1.0f / (qparams.x + kQParamEps);
+  output[0] = float_to_hfp8_stochastic(
+      value.acc.x * inv_scale,
+      ebits,
+      mbits,
+      bias,
+      min_pos,
+      max_pos,
+      random_bits.x);
+  output[1] = float_to_hfp8_stochastic(
+      value.acc.y * inv_scale,
+      ebits,
+      mbits,
+      bias,
+      min_pos,
+      max_pos,
+      random_bits.y);
+  output[2] = float_to_hfp8_stochastic(
+      value.acc.z * inv_scale,
+      ebits,
+      mbits,
+      bias,
+      min_pos,
+      max_pos,
+      random_bits.z);
+  output[3] = float_to_hfp8_stochastic(
+      value.acc.w * inv_scale,
+      ebits,
+      mbits,
+      bias,
+      min_pos,
+      max_pos,
+      random_bits.w);
+}
+
+template <>
+DEVICE_INLINE void stochastic_rounding_vector(
+    int8_t* output,
+    Vec4T<at::Half> value,
+    StochasticRoundingRNGState& state,
+    float2 qparams) {
+  uint4 random_bits = stochastic_rounding_rand4(&state);
+  CUDA_KERNEL_ASSERT(!isnan(qparams.x));
+  float inv_scale = 1.0f / (qparams.x + kQParamEps);
+  output[0] = float_to_hfp8_stochastic(
+      value.acc.x * inv_scale,
+      ebits,
+      mbits,
+      bias,
+      min_pos,
+      max_pos,
+      random_bits.x);
+  output[1] = float_to_hfp8_stochastic(
+      value.acc.y * inv_scale,
+      ebits,
+      mbits,
+      bias,
+      min_pos,
+      max_pos,
+      random_bits.y);
+  output[2] = float_to_hfp8_stochastic(
+      value.acc.z * inv_scale,
+      ebits,
+      mbits,
+      bias,
+      min_pos,
+      max_pos,
+      random_bits.z);
+  output[3] = float_to_hfp8_stochastic(
+      value.acc.w * inv_scale,
+      ebits,
+      mbits,
+      bias,
+      min_pos,
+      max_pos,
+      random_bits.w);
+}
+
 // begin nearest rounding and store implementations
 template <typename dst_t, typename src_t>
 DEVICE_INLINE void nearest_rounding_vector(
@@ -827,12 +933,40 @@ nearest_rounding_vector(uint8_t* output, Vec4T<double> value, float2 qparams) {
   CUDA_KERNEL_ASSERT(false);
 }
 
+template <>
+DEVICE_INLINE void
+nearest_rounding_vector(int8_t* output, Vec4T<float> value, float2 qparams) {
+  CUDA_KERNEL_ASSERT(!isnan(qparams.x));
+  float inv_scale = 1.0f / (qparams.x + kQParamEps);
+  output[0] = lrintf(value.acc.x * inv_scale);
+  output[1] = lrintf(value.acc.y * inv_scale);
+  output[2] = lrintf(value.acc.z * inv_scale);
+  output[3] = lrintf(value.acc.w * inv_scale);
+}
+template <>
+DEVICE_INLINE void
+nearest_rounding_vector(int8_t* output, Vec4T<at::Half> value, float2 qparams) {
+  CUDA_KERNEL_ASSERT(!isnan(qparams.x));
+  float inv_scale = 1.0f / (qparams.x + kQParamEps);
+  output[0] = lrintf(value.acc.x * inv_scale);
+  output[1] = lrintf(value.acc.y * inv_scale);
+  output[2] = lrintf(value.acc.z * inv_scale);
+  output[3] = lrintf(value.acc.w * inv_scale);
+}
+
+template <>
+DEVICE_INLINE void
+nearest_rounding_vector(int8_t* output, Vec4T<double> value, float2 qparams) {
+  CUDA_KERNEL_ASSERT(false);
+}
+
 template <typename dst_t, typename src_t>
 DEVICE_INLINE void quantize_store(
     dst_t* output,
     Vec4T<src_t> value,
     StochasticRoundingRNGState* state,
     float2 qparams) {
+  CUDA_KERNEL_ASSERT(!isnan(qparams.x));
   if (!state) {
     nearest_rounding_vector<dst_t, src_t>(output, value, qparams);
   } else {
@@ -865,12 +999,39 @@ DEVICE_INLINE Vec4T<at::Half> dequantize_load(uint8_t* value, float2 qparams) {
   return out;
 }
 
+template <>
+DEVICE_INLINE Vec4T<float> dequantize_load(int8_t* value, float2 qparams) {
+  CUDA_KERNEL_ASSERT(!isnan(qparams.x));
+  uint8_t* fp8_value = reinterpret_cast<uint8_t*>(value);
+  Vec4T<float> out;
+  out.acc.x = hfp8_to_float(fp8_value[0], ebits, bias) * qparams.x;
+  out.acc.y = hfp8_to_float(fp8_value[1], ebits, bias) * qparams.x;
+  out.acc.z = hfp8_to_float(fp8_value[2], ebits, bias) * qparams.x;
+  out.acc.w = hfp8_to_float(fp8_value[3], ebits, bias) * qparams.x;
+  CUDA_KERNEL_ASSERT(!isnan(out.acc.x));
+  return out;
+}
+
+template <>
+DEVICE_INLINE Vec4T<at::Half> dequantize_load(int8_t* value, float2 qparams) {
+  CUDA_KERNEL_ASSERT(!isnan(qparams.x));
+  uint8_t* fp8_value = reinterpret_cast<uint8_t*>(value);
+  Vec4T<at::Half> out;
+  out.acc.x = hfp8_to_float(fp8_value[0], ebits, bias) * qparams.x;
+  out.acc.y = hfp8_to_float(fp8_value[1], ebits, bias) * qparams.x;
+  out.acc.z = hfp8_to_float(fp8_value[2], ebits, bias) * qparams.x;
+  out.acc.w = hfp8_to_float(fp8_value[3], ebits, bias) * qparams.x;
+  CUDA_KERNEL_ASSERT(!isnan(out.acc.x));
+  return out;
+}
+
 template <typename emb_t>
 DEVICE_INLINE float2 load_qparams_from_row(emb_t* qparam_ptr) {
   float2 qparams;
   float* qparams_fp_ptr = reinterpret_cast<float*>(qparam_ptr);
   qparams.x = qparams_fp_ptr[0];
   qparams.y = qparams_fp_ptr[1];
+  CUDA_KERNEL_ASSERT(!isnan(qparams.x));
   return qparams;
 }
 
@@ -881,6 +1042,7 @@ DEVICE_INLINE void store_qparams_to_row(emb_t* ptr, float2 qparams) {
 
 template <>
 DEVICE_INLINE void store_qparams_to_row(uint8_t* ptr, float2 qparams) {
+  CUDA_KERNEL_ASSERT(!isnan(qparams.x));
   auto ptr_as_uint = reinterpret_cast<uintptr_t>(ptr);
   if (ptr_as_uint % 8 == 0) {
     *reinterpret_cast<float2*>(ptr) = qparams;
@@ -932,6 +1094,7 @@ struct WeightRow {
 
   // load from cache if resident; else load from embedding
   DEVICE_INLINE Vec4T<dst_t> load(int32_t d, float2 qparams) {
+    CUDA_KERNEL_ASSERT(!isnan(qparams.x));
     if (cache_row_) {
       return dequantize_load<dst_t, cache_t>(cache_row_ + d, qparams);
     } else {
@@ -1069,6 +1232,42 @@ thrust_find_qparams(fbgemm_gpu::Vec4T<scalar_t>* input_row, int D) {
 }
 
 template <typename scalar_t>
+__device__ float2 thrust_find_qparams_fp8(scalar_t* input_row, int D) {
+  float2 qparams;
+
+  scalar_t scalar_minimum = *(input_row++);
+  scalar_t scalar_maximum = scalar_minimum;
+
+  while (--D > 0) {
+    scalar_t next = *(input_row++);
+    scalar_minimum = (scalar_minimum <= next) ? scalar_minimum : next;
+    scalar_maximum = (scalar_maximum >= next) ? scalar_maximum : next;
+  }
+  float minimum_element = scalar_minimum;
+  float maximum_element = scalar_maximum;
+
+  qparams.x = maximum_element;
+  qparams.y = minimum_element;
+  return qparams;
+}
+
+template <typename scalar_t>
+__device__ float2
+thrust_find_qparams_fp8(fbgemm_gpu::Vec4T<scalar_t>* input_row, int D) {
+  // TODO: replace uses in backward kernels with warp find qparams
+  float2 qparams;
+  float min_val = vec4_min(input_row[0]);
+  float max_val = vec4_max(input_row[0]);
+  for (int i = 0; i < D / 4; ++i) {
+    min_val = min(min_val, vec4_min(input_row[i]));
+    max_val = max(max_val, vec4_max(input_row[i]));
+  }
+  qparams.x = max_val;
+  qparams.y = min_val;
+  return qparams;
+}
+
+template <typename scalar_t>
 DEVICE_INLINE scalar_t vec4_min(fbgemm_gpu::Vec4T<scalar_t> vec4) {
   scalar_t min_val = vec4.acc.x;
   min_val = min(vec4.acc.y, min_val);
@@ -1113,6 +1312,21 @@ __device__ float2 warp_find_qparams(scalar_t local_min, scalar_t local_max) {
   local_max = warp_reduce_max<scalar_t>(local_max);
   if (threadIdx.x == 0) {
     qparams.x = (local_max - local_min) / 255.0f;
+    qparams.y = local_min;
+  }
+  qparams.x = shfl_sync(qparams.x, 0);
+  qparams.y = shfl_sync(qparams.y, 0);
+  return qparams;
+}
+
+template <typename scalar_t>
+__device__ float2
+warp_find_qparams_fp8(scalar_t local_min, scalar_t local_max) {
+  float2 qparams;
+  local_min = warp_reduce_min<scalar_t>(local_min);
+  local_max = warp_reduce_max<scalar_t>(local_max);
+  if (threadIdx.x == 0) {
+    qparams.x = local_max;
     qparams.y = local_min;
   }
   qparams.x = shfl_sync(qparams.x, 0);
@@ -1718,6 +1932,14 @@ struct VecNT<1, PrimitiveType::FP> {
   }
 
   DEVICE_INLINE void
+  store(int8_t* output_ptr, float2 qparams, int num_valid_outputs = 1) {
+    CUDA_KERNEL_ASSERT(!isnan(qparams.x));
+    const float inv_scale = 1.0f / (qparams.x + kQParamEps);
+    output_ptr[0] = *reinterpret_cast<int8_t*>(
+        float_to_hfp8(acc * inv_scale, ebits, bias, max_pos));
+  }
+
+  DEVICE_INLINE void
   store(float* output_ptr, float2 qparams, int num_valid_outputs = 1) {
     CUDA_KERNEL_ASSERT(false);
   }
@@ -1795,6 +2017,19 @@ struct VecNT<2, PrimitiveType::FP> {
     for (int i = 0; i < 2; ++i) {
       if (i < num_valid_outputs) {
         output_ptr[i] = lrintf(((&acc.x)[i] - qparams.y) * inv_scale);
+      }
+    }
+  }
+
+  DEVICE_INLINE void
+  store(int8_t* output_ptr, float2 qparams, int num_valid_outputs = 2) {
+    CUDA_KERNEL_ASSERT(!isnan(qparams.x));
+    const float inv_scale = 1.0f / (qparams.x + kQParamEps);
+#pragma unroll
+    for (int i = 0; i < 2; ++i) {
+      if (i < num_valid_outputs) {
+        output_ptr[i] = *reinterpret_cast<int8_t*>(
+            float_to_hfp8((&acc.x)[i] * inv_scale, ebits, bias, max_pos));
       }
     }
   }
@@ -1912,6 +2147,18 @@ struct VecNT<4, PrimitiveType::FP> {
   }
 
   DEVICE_INLINE void
+  store(int8_t* output_ptr, float2 qparams, int num_valid_outputs = 4) {
+    CUDA_KERNEL_ASSERT(!isnan(qparams.x));
+    const float inv_scale = 1.0f / (qparams.x + kQParamEps);
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+      if (i < num_valid_outputs) {
+        output_ptr[i] = *reinterpret_cast<int8_t*>(float_to_hfp8(
+            lrintf((&(acc.x))[i] * inv_scale), ebits, bias, max_pos));
+      }
+    }
+  }
+  DEVICE_INLINE void
   store(float* output_ptr, float2 qparams, int num_valid_outputs = 4) {
     CUDA_KERNEL_ASSERT(false);
   }
@@ -2021,6 +2268,19 @@ struct VecNT<4, PrimitiveType::INT> {
     for (int i = 0; i < 4; ++i) {
       if (i < num_valid_outputs) {
         output_ptr[i] = lrintf(((&(acc.x))[i] - qparams.y) * inv_scale);
+      }
+    }
+  }
+
+  DEVICE_INLINE void
+  store(int8_t* output_ptr, float2 qparams, int num_valid_outputs = 4) {
+    CUDA_KERNEL_ASSERT(!isnan(qparams.x));
+    const float inv_scale = 1.0f / (qparams.x + kQParamEps);
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+      if (i < num_valid_outputs) {
+        output_ptr[i] = *reinterpret_cast<int8_t*>(
+            float_to_hfp8((&(acc.x))[i] * inv_scale, ebits, bias, max_pos));
       }
     }
   }


### PR DESCRIPTION
Summary:
Add FP8 and FP8_qparams datatype in the split_embedding* ops for training
Add kChar (or int8_t) support in fbgemm kernels to interpret the FP8 datatype
Add unit tests for the FP8 and FP8_qparams kernels

Differential Revision: D37101116

