### PR TITLE
Add the missing op registration for metric ops in OSS

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -308,7 +308,8 @@ if(NOT FBGEMM_CPU_ONLY)
     src/permute_pooled_embedding_ops_split_cpu.cpp
     src/quantize_ops_gpu.cpp
     src/sparse_ops_gpu.cpp
-    src/split_table_batched_embeddings.cpp)
+    src/split_table_batched_embeddings.cpp
+    src/metric_ops_host.cpp)
 
   if(NVML_LIB_PATH)
     list(APPEND fbgemm_gpu_sources_cpu src/merge_pooled_embeddings_cpu.cpp

--- a/fbgemm_gpu/cmake/Hip.cmake
+++ b/fbgemm_gpu/cmake/Hip.cmake
@@ -178,7 +178,7 @@ IF(HIP_FOUND)
   message("\n***** Library versions from cmake find_package *****\n")
 
   # As of ROCm 5.1.x, all *.cmake files are under /opt/rocm/lib/cmake/<package>
-  if(ROCM_VERSION_DEV VERSION_GREATER_EQUAL "5.1.1")
+  if(ROCM_VERSION_DEV VERSION_GREATER_EQUAL "5.1.0")
     set(hip_DIR ${HIP_PATH}/lib/cmake/hip)
     set(hsa-runtime64_DIR ${ROCM_PATH}/lib/cmake/hsa-runtime64)
     set(AMDDeviceLibs_DIR ${ROCM_PATH}/lib/cmake/AMDDeviceLibs)
@@ -198,7 +198,7 @@ IF(HIP_FOUND)
     set(ROCRAND_INCLUDE ${ROCM_PATH}/include)
     set(ROCM_SMI_INCLUDE ${ROCM_PATH}/rocm_smi/include)
   else()
-    message(FATAL_ERROR "\n***** The minimal ROCm version is 5.1.1 but have ${ROCM_VERSION_DEV} installed *****\n")
+    message(FATAL_ERROR "\n***** The minimal ROCm version is 5.1.0 but have ${ROCM_VERSION_DEV} installed *****\n")
   endif()
 
   find_package(hip REQUIRED)


### PR DESCRIPTION
Summary:
`src/metric_ops_host.cpp` which contains op registration was missing
in CMakeLists.txt causing the metric ops to not be registered
properly in OSS.

This diff adds `src/metric_ops_host.cpp` in CMakeLists to fix the
problem.

Differential Revision: D37571128

