### PR TITLE
corner case handling of empty values in jagged_to_padded_dense CPU op

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_cpu.cpp
@@ -389,6 +389,11 @@ class JaggedToPaddedDenseCPUOp
       padded_values_shape.push_back(values.size(-1));
     }
     Tensor padded_values = at::empty(padded_values_shape, values.options());
+    if (values.numel() == 0) {
+      // To avoid an error due to values_canonicalized.data_ptr is nullptr.
+      padded_values.fill_(padding_value);
+      return {padded_values};
+    }
     Tensor padded_values_view =
         values.dim() == 1 ? padded_values.unsqueeze(-1) : padded_values;
 


### PR DESCRIPTION
Summary: If jagged tensor is completely empty (e.g., all lengths are 0), we get ASAN error

Differential Revision: D37591589

