### PR TITLE
Extract the quantized comm into fbgemm

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/quantize_comm.py
+++ b/fbgemm_gpu/fbgemm_gpu/quantize_comm.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+
+import logging
+from typing import Optional, Type
+
+import torch
+from fbgemm_gpu.quantize_utils import (
+    bf16_to_fp32,
+    fp16_to_fp32,
+    fp32_to_bf16_with_clamp,
+    fp32_to_fp16_with_clamp,
+    fp32_to_hfp8_with_clamp,
+    hfp8_to_fp32,
+)
+from fbgemm_gpu.split_embedding_configs import SparseType
+
+logger: logging.Logger = logging.getLogger()
+from abc import ABC, abstractproperty
+
+
+# The code in this file is refactored from https://fburl.com/code/p2gy2gxb
+
+# FP8 configurations
+ebits, mbits, bias = 4, 3, 15
+max_pos: float = (2 ** ((1 << ebits) - 2 - bias)) * (2 - 2 ** (-mbits))
+
+
+class QuantizeCommCodecIf(ABC):
+    @abstractproperty
+    def encoder(self) -> Type[torch.autograd.Function]:
+        ...
+
+    @abstractproperty
+    def decoder(self) -> Type[torch.autograd.Function]:
+        ...
+
+
+class QuantizeWork:
+    def __init__(
+        self,
+        comm_precision: SparseType,
+    ) -> None:
+        self.comm_precision = comm_precision
+        logger.info(f"Creating QuantizeWork comm_precision:{comm_precision}")
+
+    def quantize_tensor(
+        self,
+        input_tensor: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.comm_precision == SparseType.FP32:
+            return input_tensor
+        elif self.comm_precision == SparseType.FP16:
+            return fp32_to_fp16_with_clamp(input_tensor)
+        elif self.comm_precision == SparseType.BF16:
+            # View BF16 tensor as half tensor to bypass autograd restriction
+            return fp32_to_bf16_with_clamp(input_tensor).view(torch.float16)
+        elif self.comm_precision == SparseType.FP8:
+            # View FP8 tensor as half tensor to bypass autograd restriction
+            return fp32_to_hfp8_with_clamp(input_tensor, ebits, mbits, bias).view(
+                torch.float16
+            )
+        else:
+            raise ValueError(f"comm_precision={self.comm_precision} is not supported")
+
+    def dequantize_tensor(
+        self,
+        quantized_tensor: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.comm_precision == SparseType.FP32:
+            return quantized_tensor
+        elif self.comm_precision == SparseType.FP16:
+            return fp16_to_fp32(quantized_tensor)
+        elif self.comm_precision == SparseType.BF16:
+            return bf16_to_fp32(quantized_tensor)
+        elif self.comm_precision == SparseType.FP8:
+            return hfp8_to_fp32(quantized_tensor, ebits, bias)
+        else:
+            raise ValueError(f"comm_precision={self.comm_precision} is not supported")
+
+
+class QuantizeCommCodec(QuantizeCommCodecIf):
+    def __init__(
+        self,
+        fwd_comm_precision: SparseType,
+        bwd_comm_precision: SparseType,
+        loss_scale: Optional[float] = None,
+    ) -> None:
+
+        logger.info(
+            f"Creating QuantizeCommCodec fwd_comm_precision:{fwd_comm_precision} bwd_comm_precision:{bwd_comm_precision} "
+        )
+        if loss_scale is not None:
+            if bwd_comm_precision not in [SparseType.FP16]:
+                logger.warning(
+                    f"Setting loss scale for bwd_comm_precision={bwd_comm_precision} is not supported. Overriding to None"
+                )
+                loss_scale = None
+
+        fwd_work = QuantizeWork(
+            comm_precision=fwd_comm_precision,
+        )
+        bwd_work = QuantizeWork(
+            comm_precision=bwd_comm_precision,
+        )
+
+        class Encoder(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, input_tensor):
+                return fwd_work.quantize_tensor(input_tensor)
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                if loss_scale is not None:
+                    grad_output = grad_output / loss_scale
+                return bwd_work.dequantize_tensor(grad_output)
+
+        class Decoder(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, input_tensor):
+                return fwd_work.dequantize_tensor(input_tensor)
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                if loss_scale is not None:
+                    grad_output = grad_output * loss_scale
+                return bwd_work.quantize_tensor(grad_output)
+
+        self._encoder = Encoder
+        self._decoder = Decoder
+
+    @property
+    def encoder(self) -> Type[torch.autograd.Function]:
+        return self._encoder
+
+    @property
+    def decoder(self) -> Type[torch.autograd.Function]:
+        return self._decoder

--- a/fbgemm_gpu/fbgemm_gpu/quantize_utils.py
+++ b/fbgemm_gpu/fbgemm_gpu/quantize_utils.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+
+try:
+    # pyre-ignore[21]
+    from fbgemm_gpu import open_source  # noqa: F401
+except Exception:
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
+
+TORCH_HALF_MIN: float = torch.finfo(torch.float16).min
+TORCH_HALF_MAX: float = torch.finfo(torch.float16).max
+
+TORCH_BFLOAT16_MIN: float = torch.finfo(torch.bfloat16).min
+TORCH_BFLOAT16_MAX: float = torch.finfo(torch.bfloat16).max
+
+
+def fp32_to_fp16_with_clamp(tensor: torch.Tensor) -> torch.Tensor:
+    return torch.clamp(tensor, TORCH_HALF_MIN, TORCH_HALF_MAX).half()
+
+
+def fp32_to_bf16_with_clamp(tensor: torch.Tensor) -> torch.Tensor:
+    return torch.clamp(tensor, TORCH_BFLOAT16_MIN, TORCH_BFLOAT16_MAX).bfloat16()
+
+
+def fp32_to_hfp8_with_clamp(
+    tensor: torch.Tensor, ebits: int = 4, mbits: int = 3, bias: int = 15
+) -> torch.Tensor:
+    max_pos: float = (2 ** ((1 << ebits) - 2 - bias)) * (2 - 2 ** (-mbits))
+    return torch.ops.fbgemm.FloatToHFP8Quantized(
+        tensor.contiguous(),
+        ebits,
+        bias,
+        max_pos,
+    )
+
+
+def fp16_to_fp32(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor.float()
+
+
+def bf16_to_fp32(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor.view(torch.bfloat16).float()
+
+
+def hfp8_to_fp32(tensor: torch.Tensor, ebits: int = 4, bias: int = 15) -> torch.Tensor:
+    return torch.ops.fbgemm.HFP8QuantizedToFloat(
+        tensor.contiguous().view(torch.uint8),
+        ebits,
+        bias,
+    )

--- a/fbgemm_gpu/test/quantize_comm_test.py
+++ b/fbgemm_gpu/test/quantize_comm_test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import Optional
+
+import hypothesis.strategies as st
+import torch
+from fbgemm_gpu.quantize_comm import QuantizeCommCodec
+from fbgemm_gpu.split_embedding_configs import SparseType
+from hypothesis import assume, given, settings
+
+
+class QuantizeCommCodecTest(unittest.TestCase):
+    @settings(deadline=2000)
+    # pyre-ignore
+    @given(
+        fwd_comm_precision=st.sampled_from(
+            [SparseType.FP32, SparseType.FP16, SparseType.FP8]
+        ),
+        bwd_comm_precision=st.sampled_from(
+            [SparseType.FP32, SparseType.FP16, SparseType.BF16, SparseType.FP8]
+        ),
+        loss_scale=st.sampled_from([None, 4.0]),
+        row_size=st.integers(4, 256),
+        col_size=st.integers(4, 256),
+        rand_seed=st.integers(0, 65534),
+    )
+    def test_quantize_comm_codec(
+        self,
+        fwd_comm_precision: SparseType,
+        bwd_comm_precision: SparseType,
+        loss_scale: Optional[float],
+        row_size: int,
+        col_size: int,
+        rand_seed: int,
+    ) -> None:
+        assume(fwd_comm_precision.bit_rate() == bwd_comm_precision.bit_rate())
+        if fwd_comm_precision == SparseType.FP8 or bwd_comm_precision == SparseType.FP8:
+            assume(col_size % 4 == 0)
+        rtol = 0.005
+        atol = 0.003
+        if fwd_comm_precision == SparseType.FP8:
+            rtol = 0.1
+            atol = 0.1
+        torch.manual_seed(rand_seed)
+
+        shape = (row_size, col_size)
+
+        quant_codec = QuantizeCommCodec(
+            fwd_comm_precision,
+            bwd_comm_precision,
+            loss_scale=loss_scale,
+        )
+
+        input_tensor = torch.rand(shape, requires_grad=True)
+        # pyre-ignore
+        quant_tensor = quant_codec.encoder.apply(input_tensor)
+        output_tensor = quant_codec.decoder.apply(quant_tensor)
+
+        torch.testing.assert_close(
+            input_tensor.detach(), output_tensor.detach(), atol=atol, rtol=rtol
+        )
+
+        expected_grad = torch.rand(shape)
+        output_tensor.backward(expected_grad)
+        actual_grad = input_tensor.grad
+
+        self.assertIsNotNone(actual_grad)
+        torch.testing.assert_close(
+            expected_grad.detach(), actual_grad.detach(), atol=atol, rtol=rtol
+        )


### PR DESCRIPTION
Summary:
This will be better shared between Trec and HPC.
- We will refactor https://www.internalfb.com/code/fbsource/[history]/fbcode/caffe2/torch/fb/hpc/quantized_comms_lib.py to extract the common components in FBGEMM
- It's open source so TorchRec can call it from FBGEMM.

Differential Revision: D37745301

