### PR TITLE
add --no-dkms to install ROCm on CI

### DIFF
--- a/.github/workflows/fbgemmci.yml
+++ b/.github/workflows/fbgemmci.yml
@@ -267,7 +267,7 @@ jobs:
         wget https://repo.radeon.com/amdgpu-install/22.10.1/ubuntu/focal/amdgpu-install_22.10.1.50101-1_all.deb
         export DEBIAN_FRONTEND=noninteractive
         sudo apt install -y ./amdgpu-install_22.10.1.50101-1_all.deb
-        amdgpu-install -y --usecase=hiplibsdk,rocm
+        amdgpu-install -y --usecase=hiplibsdk,rocm --no-dkms
         sudo rm amdgpu-install_22.10.1.50101-1_all.deb
 
     - name: Install dependencies


### PR DESCRIPTION
Summary:
This patch fixes a failure of `build_amd_gpu` on GitHub CI.

## Background

We start to encounter the following error on `build_amd_gpu` recently (around July 11th).
```
Building initial module for 5.15.0-1014-azure
Error! Bad return status for module build on kernel: 5.15.0-1014-azure (x86_64)
Consult /var/lib/dkms/amdgpu/5.13.20.22.10-1401700/build/make.log for more information.
dpkg: error processing package amdgpu-dkms (--configure):
 installed amdgpu-dkms package post-installation script subprocess returned error exit status 10
```

## Solution

I did not perform any deep investigation, but basically, we don't need dkms for this test. This patch disables it.

Differential Revision: D38133302

