### PR TITLE
support dense_to_jagged long cpu

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_cpu.cpp
@@ -519,8 +519,12 @@ class DenseToJaggedCPUOp
     auto values = at::empty({total_L_computed, D}, dense.options());
     auto output = at::zeros({total_L_computed, D}, dense.options());
 
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-        values.scalar_type(), "jagged_scalars", [&] {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        at::ScalarType::Half,
+        at::ScalarType::Long,
+        values.scalar_type(),
+        "jagged_scalars",
+        [&] {
           jagged_dense_elementwise_jagged_output_<scalar_t>(
               values,
               offsets,


### PR DESCRIPTION
Summary: * support long type for dense_to_jagged cpu op, as mirrored in GPU.

Differential Revision: D38290666

