### PR TITLE
add sequence embedding reference implementation

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
@@ -102,14 +102,20 @@ void pruned_hashmap_insert_{{ wdesc }}_cpu(
     return;
 }
 
-Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
+{% for nobag in [True, False] %}
+{% if not nobag or not weighted %}
+Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{{ wdesc }}_cpu(
     Tensor dev_weights,
     Tensor uvm_weights,
     Tensor weights_placements,
     Tensor weights_offsets,
     Tensor weights_tys,
+    {% if not nobag %}
     Tensor D_offsets,
     int64_t total_D,
+    {% else %}
+    const int64_t D,
+    {% endif %}
     Tensor indices,
     Tensor offsets,
     int64_t pooling_mode,
@@ -126,19 +132,30 @@ Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
     TENSOR_ON_CPU(weights_placements);
     TENSOR_ON_CPU(weights_offsets);
     TENSOR_ON_CPU(weights_tys);
+    {% if not nobag %}
     TENSOR_ON_CPU(D_offsets);
+    {% endif %}
     TENSOR_ON_CPU(indices);
     TENSOR_ON_CPU(offsets);
     {% if weighted %}
     TENSOR_EMPTY_OR_ON_CPU(indice_weights);
     {% endif %}
 
-    int32_t T = D_offsets.numel() - 1;
+    {% if not nobag %}
+    const int32_t T = D_offsets.numel() - 1;
+    {% else %}
+    const int32_t total_L = indices.numel();
+    const int32_t T = weights_offsets.numel();
+    {% endif %}
     TORCH_CHECK(T > 0);
     // offsets = [B x T  + 1]
     int32_t B = (offsets.size(0) - 1) / T;
     TORCH_CHECK(B >= 0);
+    {% if not nobag %}
     TORCH_CHECK(total_D > 0);
+    {% else %}
+    TORCH_CHECK(D > 0);
+    {% endif %}
     bool pinned_memory = false;
     if (at::Context::hasCUDA() && at::getNumGPUs() > 0) {
       pinned_memory = true;
@@ -148,11 +165,21 @@ Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
     const int kINT8QparamsBytes = 8;
     SparseType o_dtype = static_cast<SparseType>(output_dtype);
     TORCH_CHECK(o_dtype == SparseType::FP32 || o_dtype == SparseType::FP16 || o_dtype == SparseType::INT8);
+    {% if not nobag %}
     int64_t total_adjusted_D = total_D;
     if (o_dtype == SparseType::INT8) {
-        total_adjusted_D += T * kINT8QparamsBytes;
+      total_adjusted_D += T * kINT8QparamsBytes;
     }
     output = at::empty({B, total_adjusted_D}, dev_weights.options().dtype(getScalarType(o_dtype)).pinned_memory(pinned_memory));
+    {% else %}
+    int64_t adjusted_D = D;
+    if (o_dtype == SparseType::INT8) {
+      adjusted_D += T * kINT8QparamsBytes;
+    }
+    output = at::empty({total_L, adjusted_D}, dev_weights.options().dtype(getScalarType(o_dtype)).pinned_memory(pinned_memory));
+
+    {% endif %}
+
 
     if (B == 0) {
         return output;
@@ -163,23 +190,32 @@ Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
 
     const auto* weights_tys_acc = weights_tys.data_ptr<uint8_t>();
 
-    DISPATCH_OUTPUT_TYPES(output.scalar_type(), "intn_split_embedding_codegen_forward_kernel", [&] {
-        auto* output_acc = output.data_ptr<output_t>();
+    DISPATCH_OUTPUT_TYPES(output.scalar_type(), "intn_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", [&] {
         {% if weighted %}
         const float* indice_weights_acc = indice_weights.data_ptr<float>();
         {% endif %}
 
-        AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "int_nbit_split_embedding_codegen_forward_", [&] {
+        AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_", [&] {
             const auto* indices_acc = indices.data_ptr<index_t>();
             const auto* offsets_acc = offsets.data_ptr<index_t>();
-            const auto* D_offsets_acc = D_offsets.data_ptr<int32_t>();
             const auto* weights_offsets_acc = weights_offsets.data_ptr<int64_t>();
+            int32_t total_output_size = 0;
 
+            auto* output_acc = output.data_ptr<output_t>();
             int32_t num_indices_m_1 = indices.numel() - 1;
 
+            int32_t D_start_ = 0;
             for (int32_t t = 0; t < T; ++t) {
+
+                {% if not nobag %}
+                const auto* D_offsets_acc = D_offsets.data_ptr<int32_t>();
                 const int32_t D_start = D_offsets_acc[t];
-                const int32_t D = D_offsets_acc[t+1] - D_offsets_acc[t];
+                const int32_t D_end = D_offsets_acc[t + 1];
+                const int32_t D = D_end - D_start;
+                {% else %}
+                const int32_t D_start = offsets_acc[t * B] * D;
+                {% endif %}
+
                 const auto placement = static_cast<PlacementType>(weights_placements_ptr[t]);
                 TORCH_CHECK(placement != PlacementType::DEVICE);
                 Tensor weight_tensor = (placement == PlacementType::HOST) ? dev_weights : uvm_weights;
@@ -217,11 +253,24 @@ Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
                         /*prefetch=*/16,
                         /*is_weight_positional=*/false,
                         /*use_offsets=*/true,
+                        {% if not nobag %}
                         /*output_stride=*/total_D,
+                        {% else %}
+                        /*output_stride=*/D,
+                        {% endif %}
                         /*input_stride=*/D_bytes / sizeof(float),
+                        {% if not nobag %}
                         /*scale_bias_last=*/false);
+                        {% else %}
+                        /*scale_bias_last=*/false,
+                        /*no_bag=*/true);
+                        {% endif %}
                     success = kernel(
+                        {% if not nobag %}
                         B,
+                        {% else %}
+                        index_size,
+                        {% endif %}
                         index_size,
                         num_rows,
                         reinterpret_cast<const float*>(weights),
@@ -237,11 +286,24 @@ Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
                         /*prefetch=*/16,
                         /*is_weight_positional=*/false,
                         /*use_offsets=*/true,
+                        {% if not nobag %}
                         /*output_stride=*/total_D,
+                        {% else %}
+                        /*output_stride=*/D,
+                        {% endif %}
                         /*input_stride=*/D_bytes / sizeof(float16),
+                        {% if not nobag %}
                         /*scale_bias_last=*/false);
+                        {% else %}
+                        /*scale_bias_last=*/false,
+                        /*no_bag=*/true);
+                        {% endif %}
                     success = kernel(
+                        {% if not nobag %}
                         B,
+                        {% else %}
+                        index_size,
+                        {% endif %}
                         index_size,
                         num_rows,
                         reinterpret_cast<const float16*>(weights),
@@ -256,7 +318,11 @@ Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
                         normalize_by_lengths,
                         /*is_weight_positional=*/false,
                         /*use_offsets=*/true,
+                        {% if not nobag %}
                         /*output_stride=*/total_D,
+                        {% else %}
+                        /*output_stride=*/D,
+                        {% endif %}
                         /*input_stride=*/D_bytes / sizeof(uint8_t),
                         /*exponent_bits=*/fp8_exponent_bits,
                         /*exponent_bias=*/fp8_exponent_bias);
@@ -277,11 +343,24 @@ Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
                         /*prefetch=*/16,
                         /*is_weight_positional=*/false,
                         /*use_offsets=*/true,
+                        {% if not nobag %}
                         /*output_stride=*/total_D,
+                        {% else %}
+                        /*output_stride=*/D,
+                        {% endif %}
                         /*input_stride=*/D_bytes / sizeof(uint8_t),
+                        {% if not nobag %}
                         /*scale_bias_last=*/false);
+                        {% else %}
+                        /*scale_bias_last=*/false,
+                        /*no_bag=*/true);
+                        {% endif %}
                     success = kernel(
+                        {% if not nobag %}
                         B,
+                        {% else %}
+                        index_size,
+                        {% endif %}
                         index_size,
                         num_rows,
                         weights,
@@ -309,7 +388,11 @@ Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
                         /*prefetch=*/16,
                         /*is_weight_positional=*/false,
                         /*use_offsets=*/true,
+                        {% if not nobag %}
                         /*output_stride=*/total_D,
+                        {% else %}
+                        /*output_stride=*/D,
+                        {% endif %}
                         /*input_stride=*/D_bytes / sizeof(uint8_t),
                         /*scale_bias_last=*/false);
                     success = kernel(
@@ -341,6 +424,8 @@ Tensor int_nbit_split_embedding_codegen_forward_{{ wdesc }}_cpu(
     });
     return output;
 }
+{% endif %} // if not nobag or not weighted
+{% endfor %} // for nobag in [True, False]
 
 Tensor pruned_hashmap_lookup_{{ wdesc }}_cpu(
     Tensor indices,

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -3105,11 +3105,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             pooling_mode == split_table_batched_embeddings_ops.PoolingMode.SUM
             or not weighted
         )
-        # NOTE: No bag ops only work on GPUs, no mixed
-        assume(
-            not use_cpu
-            or pooling_mode != split_table_batched_embeddings_ops.PoolingMode.NONE
-        )
         assume(
             not mixed
             or pooling_mode != split_table_batched_embeddings_ops.PoolingMode.NONE
@@ -3436,9 +3431,23 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             [
                 split_table_batched_embeddings_ops.PoolingMode.SUM,
                 split_table_batched_embeddings_ops.PoolingMode.MEAN,
+                split_table_batched_embeddings_ops.PoolingMode.NONE,
             ]
         )
         mixed = random.choice([True, False])
+        if pooling_mode == split_table_batched_embeddings_ops.PoolingMode.NONE:
+            nbit_weights_ty = random.choice(
+                [
+                    SparseType.FP32,
+                    SparseType.FP16,
+                    # CPU sequence embedding does not support FP8/INT4/INT2 yet
+                    # SparseType.FP8,
+                    SparseType.INT8,
+                    # SparseType.INT4,
+                    # SparseType.INT2,
+                ]
+            )
+
         if pooling_mode == split_table_batched_embeddings_ops.PoolingMode.SUM:
             weighted = random.choice([True, False])
         else:

--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -107,7 +107,8 @@ GenerateEmbeddingSpMDMWithStrides(
     bool use_offsets = true,
     std::int64_t output_stride = -1,
     std::int64_t input_stride = -1,
-    bool scale_bias_last = true);
+    bool scale_bias_last = true,
+    bool no_bag = false);
 
 /**
  * @tparam IndexType can be int32_t or int64_t

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -234,7 +234,8 @@ FBGEMM_API bool EmbeddingSpMDM_ref(
     bool use_offsets = true,
     std::int64_t output_stride = -1,
     std::int64_t input_stride = -1,
-    bool scale_bias_last = true);
+    bool scale_bias_last = true,
+    bool no_bag = false);
 
 template <
     typename IndexType = std::int64_t,


### PR DESCRIPTION
Summary:
Sequence Embedding on CPU
- Enabled FP32/FP16/INT8 versions
- Scalar embedding implementation ( performance may be slow)

Differential Revision: D36049936

