### PR TITLE
Update Utils.h

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -73,6 +73,7 @@ def get_fbgemm_public_headers():
         "include/fbgemm/QuantUtilsAvx512.h",
         "include/fbgemm/spmmUtils.h",
         "include/fbgemm/spmmUtilsAvx2.h",
+        "include/fbgemm/SimdUtils.h",
         "include/fbgemm/Utils.h",
         "include/fbgemm/UtilsAvx2.h",
         "include/fbgemm/Types.h",

--- a/include/fbgemm/FbgemmFPCommon.h
+++ b/include/fbgemm/FbgemmFPCommon.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <fbgemm/FbgemmPackMatrixB.h>
+#include <fbgemm/SimdUtils.h>
 #include <fbgemm/Types.h>
 #include <fbgemm/Utils.h>
 #include <array>

--- a/include/fbgemm/FbgemmPackMatrixB.h
+++ b/include/fbgemm/FbgemmPackMatrixB.h
@@ -14,6 +14,7 @@
 #include <typeinfo>
 #include <vector>
 
+#include "SimdUtils.h"
 #include "Types.h"
 #include "Utils.h"
 

--- a/include/fbgemm/SimdUtils.h
+++ b/include/fbgemm/SimdUtils.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include "./Utils.h"
+
+#include <asmjit/asmjit.h>
+
+namespace fbgemm {
+/**
+ * @brief Some commonly used variables for different instruction sets
+ */
+template <inst_set_t inst_set>
+struct simd_info;
+
+template <>
+struct simd_info<inst_set_t::avx2> {
+  static constexpr int WIDTH_BITS = 256;
+  static constexpr int WIDTH_BYTES = 32;
+  static constexpr int WIDTH_32BIT_ELEMS = 8;
+  static constexpr int NUM_VEC_REGS = 16;
+
+  using vec_reg_t = asmjit::x86::Ymm;
+};
+
+template <>
+struct simd_info<inst_set_t::avx512> {
+  static constexpr int WIDTH_BITS = 512;
+  static constexpr int WIDTH_BYTES = 64;
+  static constexpr int WIDTH_32BIT_ELEMS = 16;
+  static constexpr int NUM_VEC_REGS = 32;
+
+  using vec_reg_t = asmjit::x86::Zmm;
+};
+
+template <>
+struct simd_info<inst_set_t::avx512_vnni>
+    : public simd_info<inst_set_t::avx512> {};
+
+template <>
+struct simd_info<inst_set_t::avx512_ymm> {
+  static constexpr int WIDTH_BITS = 256;
+  static constexpr int WIDTH_BYTES = 32;
+  static constexpr int WIDTH_32BIT_ELEMS = 8;
+  static constexpr int NUM_VEC_REGS = 32;
+
+  using vec_reg_t = asmjit::x86::Ymm;
+};
+
+template <>
+struct simd_info<inst_set_t::avx512_vnni_ymm>
+    : public simd_info<inst_set_t::avx512_ymm> {};
+
+} // namespace fbgemm

--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -15,8 +15,6 @@
 #include <string>
 #include <type_traits>
 
-#include <asmjit/asmjit.h>
-
 namespace fbgemm {
 
 /**
@@ -70,50 +68,6 @@ enum class impl_type_t { ref, opt };
  * KXC can be KRSC format or KTRSC format (e.g., for 3-D convolutions)
  */
 enum class FBGEMM_ENUM_CLASS_API layout_t { KCX, KXC };
-
-/**
- * @brief Some commonly used variables for different instruction sets
- */
-template <inst_set_t inst_set>
-struct simd_info;
-
-template <>
-struct simd_info<inst_set_t::avx2> {
-  static constexpr int WIDTH_BITS = 256;
-  static constexpr int WIDTH_BYTES = 32;
-  static constexpr int WIDTH_32BIT_ELEMS = 8;
-  static constexpr int NUM_VEC_REGS = 16;
-
-  using vec_reg_t = asmjit::x86::Ymm;
-};
-
-template <>
-struct simd_info<inst_set_t::avx512> {
-  static constexpr int WIDTH_BITS = 512;
-  static constexpr int WIDTH_BYTES = 64;
-  static constexpr int WIDTH_32BIT_ELEMS = 16;
-  static constexpr int NUM_VEC_REGS = 32;
-
-  using vec_reg_t = asmjit::x86::Zmm;
-};
-
-template <>
-struct simd_info<inst_set_t::avx512_vnni>
-    : public simd_info<inst_set_t::avx512> {};
-
-template <>
-struct simd_info<inst_set_t::avx512_ymm> {
-  static constexpr int WIDTH_BITS = 256;
-  static constexpr int WIDTH_BYTES = 32;
-  static constexpr int WIDTH_32BIT_ELEMS = 8;
-  static constexpr int NUM_VEC_REGS = 32;
-
-  using vec_reg_t = asmjit::x86::Ymm;
-};
-
-template <>
-struct simd_info<inst_set_t::avx512_vnni_ymm>
-    : public simd_info<inst_set_t::avx512_ymm> {};
 
 /**
  * @brief A function to compare data in two buffers for closeness/equality.

--- a/src/CodeGenHelpers.h
+++ b/src/CodeGenHelpers.h
@@ -6,6 +6,7 @@
  */
 #pragma once
 #include <asmjit/asmjit.h>
+#include "fbgemm/SimdUtils.h"
 #include "fbgemm/Utils.h"
 
 namespace fbgemm {

--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -20,6 +20,7 @@
 #include "./CodeCache.h"
 #include "./MaskAvx2.h"
 #include "./RefImplementations.h"
+#include "fbgemm/SimdUtils.h"
 #include "fbgemm/Types.h"
 
 namespace fbgemm {

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -20,6 +20,7 @@
 #include "./CodeCache.h"
 #include "./MaskAvx2.h"
 #include "./RefImplementations.h"
+#include "fbgemm/SimdUtils.h"
 #include "fbgemm/Types.h"
 
 using namespace std;

--- a/src/GenerateKernel.h
+++ b/src/GenerateKernel.h
@@ -14,6 +14,7 @@
 #include <tuple>
 #include "./CodeCache.h"
 #include "fbgemm/Fbgemm.h"
+#include "fbgemm/SimdUtils.h"
 //#define FBGEMM_LOG_CODE 1
 
 namespace fbgemm {

--- a/src/GroupwiseConv.cc
+++ b/src/GroupwiseConv.cc
@@ -19,6 +19,7 @@
 #include "./TransposeUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "fbgemm/QuantUtilsAvx512.h"
+#include "fbgemm/SimdUtils.h"
 
 namespace fbgemm {
 

--- a/src/GroupwiseConv.h
+++ b/src/GroupwiseConv.h
@@ -18,6 +18,7 @@
 #include "./CodeCache.h"
 #include "fbgemm/ConvUtils.h"
 #include "fbgemm/Fbgemm.h"
+#include "fbgemm/SimdUtils.h"
 #include "fbgemm/Utils.h"
 /*#define FBGEMM_LOG_CODE 1*/
 

--- a/src/PackWeightMatrixForGConv.cc
+++ b/src/PackWeightMatrixForGConv.cc
@@ -11,6 +11,7 @@
 #include <numeric>
 #include "./RefImplementations.h"
 #include "fbgemm/Fbgemm.h"
+#include "fbgemm/SimdUtils.h"
 
 namespace fbgemm {
 

--- a/src/RowWiseSparseAdagradFused.cc
+++ b/src/RowWiseSparseAdagradFused.cc
@@ -15,6 +15,7 @@
 #include "./CodeCache.h"
 #include "./MaskAvx2.h"
 #include "./RefImplementations.h"
+#include "fbgemm/SimdUtils.h"
 #include "fbgemm/Utils.h"
 
 using namespace std;

--- a/src/SparseAdagrad.cc
+++ b/src/SparseAdagrad.cc
@@ -17,6 +17,7 @@
 #include "./CodeCache.h"
 #include "./MaskAvx2.h"
 #include "./RefImplementations.h"
+#include "fbgemm/SimdUtils.h"
 #include "fbgemm/Utils.h"
 
 namespace fbgemm {

--- a/test/RowWiseSparseAdagradFusedTest.cc
+++ b/test/RowWiseSparseAdagradFusedTest.cc
@@ -15,6 +15,7 @@
 
 #include "./EmbeddingSpMDMTestUtils.h"
 #include "fbgemm/Fbgemm.h"
+#include "fbgemm/SimdUtils.h"
 #include "fbgemm/Utils.h"
 #include "src/RefImplementations.h"
 


### PR DESCRIPTION
Differential Revision: D38341763

Extract asmjit/asmjit.h usages into a separate header file and make sure it is not called from PyTorch directly.

This Diff/PR is to unblock the FBGEMM third party upgrade in PyTorch (e.g.,  https://github.com/pytorch/pytorch/pull/82396), where it consistantly reports the <asmjit/asmjit.h> imports error (https://github.com/pytorch/FBGEMM/issues/1227):

```
[ 40%] Building C object confu-deps/XNNPACK/CMakeFiles/all_microkernels.dir/src/qs8-gemm/gen/4x4-minmax-fp32-scalar-imagic.c.o
In file included from /var/lib/jenkins/workspace/caffe2/quantization/server/group_norm_dnnlowp_op_avx2.cc:10:
In file included from /var/lib/jenkins/workspace/third_party/fbgemm/include/fbgemm/QuantUtils.h:6:
/var/lib/jenkins/workspace/third_party/fbgemm/include/fbgemm/./Utils.h:18:10: fatal error: 'asmjit/asmjit.h' file not found
#include <asmjit/asmjit.h>
         ^~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [caffe2/quantization/server/CMakeFiles/caffe2_dnnlowp_avx2_ops.dir/build.make:104: caffe2/quantization/server/CMakeFiles/caffe2_dnnlowp_avx2_ops.dir/group_norm_dnnlowp_op_avx2.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
[ 40%] Building C object confu-deps/XNNPACK/CMakeFiles/XNNPACK.dir/src/qc8-igemm/gen/4x16c8-minmax-fp32-avx512skx.c.o

```

This is because we don't have the direct asmjit dependency in PyTorch. The workaround is to spin off Utils.h to SimdUtils.h where the original Utils.h included in PyTorch files doesn't have asmjit.h dependency any longer.