### PR TITLE
[CI] support multiple CUDA versions

### DIFF
--- a/.github/workflows/fbgemmci.yml
+++ b/.github/workflows/fbgemmci.yml
@@ -192,16 +192,17 @@ jobs:
         set -e
         ./bazel test --compilation_mode opt :*
 
-  build_gpu:
+  build_nvidia_gpu:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
+        cuda_version: [11.3, 11.5, 11.6] # 11.7
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install CUDA 11.3
+    - name: Install CUDA
       shell: bash
       run: |
         wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
@@ -212,7 +213,9 @@ jobs:
         # sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
         sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
         sudo apt-get update
-        sudo apt-get -y install cuda-minimal-build-11-3 cuda-nvrtc-dev-11-3 cuda-nvtx-11-3 cuda-libraries-dev-11-3
+        # "11.5 -> 11-5"
+        cuda_apt_version=$(echo "${{ matrix.cuda_version }}" | sed "s/\./-/")
+        sudo apt-get -y install cuda-minimal-build-${cuda_apt_version} cuda-nvrtc-dev-${cuda_apt_version} cuda-nvtx-${cuda_apt_version} cuda-libraries-dev-${cuda_apt_version}
         sudo apt-get -y install libcudnn8-dev
 
     - name: Install dependencies
@@ -221,8 +224,10 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install git pip python3-dev
         sudo pip install cmake scikit-build ninja jinja2 numpy hypothesis --no-input
-        # Install pytorch 1.11 as required by fbgemm_gpu
-        sudo pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
+        # "11.5" -> "115"
+        cuda_torch_version=$(echo "${{ matrix.cuda_version }}" | sed "s/\.//")
+        # Install PyTorch (nightly) as required by fbgemm_gpu
+        sudo pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu${cuda_torch_version}/torch_nightly.html
 
     - name: Checkout submodules
       shell: bash
@@ -235,7 +240,8 @@ jobs:
       shell: bash
       run: |
         cd fbgemm_gpu
-        sudo CUDACXX=/usr/local/cuda-11.3/bin/nvcc python setup.py install -DTORCH_CUDA_ARCH_LIST="6.0"
+        CUDA_PATH="/usr/local/cuda-${{ matrix.cuda_version }}"
+        sudo CUDACXX="${CUDA_PATH}/bin/nvcc" python setup.py install -DTORCH_CUDA_ARCH_LIST="6.0"
 
     - name: Test fbgemm_gpu installation
       shell: bash
@@ -253,6 +259,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        rocm_version: [5.1.1]
 
     steps:
     - name: Free space
@@ -260,7 +267,7 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Install ROCm 5.1.1
+    - name: Install ROCm
       shell: bash
       run: |
         sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
@@ -278,7 +285,7 @@ jobs:
         sudo apt-get install -y hipify-clang || true
         sudo pip install cmake scikit-build ninja jinja2 numpy hypothesis --no-input
         sudo apt-get clean
-        # Install pytorch 1.11 as required by fbgemm_gpu
+        # Install PyTorch (nightly) as required by fbgemm_gpu
         sudo pip install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.1.1/
 
     - name: Checkout submodules
@@ -370,7 +377,7 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install git pip python3-dev
         sudo pip install cmake scikit-build ninja jinja2 numpy hypothesis --no-input
-        # Install pytorch 1.11 as required by fbgemm_gpu
+        # Install PyTorch (nightly) as required by fbgemm_gpu
         sudo pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
     - name: Checkout submodules

--- a/fbgemm_gpu/include/fbgemm_gpu/cub_namespace_postfix.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/cub_namespace_postfix.cuh
@@ -22,7 +22,7 @@
 // PR https://github.com/NVIDIA/cub/pull/350 introduced breaking change.
 // When the CUB_NS_[PRE|POST]FIX macros are set,
 // CUB_NS_QUALIFIER must also be defined to the fully qualified CUB namespace
-#if CUB_VERSION >= 101400
+#if CUB_VERSION >= 101301
 #undef CUB_NS_QUALIFIER
 #endif
 

--- a/fbgemm_gpu/include/fbgemm_gpu/cub_namespace_prefix.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/cub_namespace_prefix.cuh
@@ -20,7 +20,7 @@
 // PR https://github.com/NVIDIA/cub/pull/350 introduced breaking change.
 // When the CUB_NS_[PRE|POST]FIX macros are set,
 // CUB_NS_QUALIFIER must also be defined to the fully qualified CUB namespace
-#if CUB_VERSION >= 101400
+#if CUB_VERSION >= 101301
 #undef CUB_NS_QUALIFIER
 #endif
 
@@ -30,7 +30,7 @@
 // PR https://github.com/NVIDIA/cub/pull/350 introduced breaking change.
 // When the CUB_NS_[PRE|POST]FIX macros are set,
 // CUB_NS_QUALIFIER must also be defined to the fully qualified CUB namespace
-#if CUB_VERSION >= 101400
+#if CUB_VERSION >= 101301
 #define CUB_NS_QUALIFIER ::fbgemm_gpu::cub
 #endif
 


### PR DESCRIPTION
Summary:
This patch adds multiple CUDA versions for OSS CI (build only). Previously on the OSS side, we tested only 11.3, but this patch expands it to 11.3, 11.5, and 11.6.

This CI is useful. For example, it revealed an issue in `cub_namespace_postfix.cuh`: this change was cherry-picked  for CUB 1.13.1 (https://github.com/NVIDIA/cub/blob/1.13.X/cub/util_namespace.cuh), so the `CUB_VERSION` condition should be `CUB_VERSION >= 101301`.

Q&A
 - Why don't we test multiple ROCm versions?
    - PyTorch provides two versions for ROCm at this point: 5.0 and 5.1.1, but FBGEMM does not support ROCm 5.0.
 - Why don't we test CUDA 11.2 or older?
   - I am not sure if FBGEMM supports CUDA <= 11.2. If needed, we can add it.
 - Why don't we test CUDA 11.4?
   - PyTorch does not have nightly CUDA 11.4 build for some reasons at present.
 - Why don't we test CUDA 11.7?
   - It has some compilation issues.

Differential Revision: D38359867

