### PR TITLE
Print error msg when loading fbgemm_gpu_py.so

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/__init__.py
@@ -11,8 +11,8 @@ import torch
 
 try:
     torch.ops.load_library(os.path.join(os.path.dirname(__file__), "fbgemm_gpu_py.so"))
-except Exception:
-    print("File fbgemm_gpu_py.so not found")
+except Exception as e:
+    print(e)
 
 # __init__.py is only used in OSS
 # Use existence to check if fbgemm_gpu_py.so has already been loaded


### PR DESCRIPTION
The old error message may be confusing when the error is not that `fbgemm_gpu_py.so` cannot be found, e.g. CPU version of pytorch is installed and `libc10_cuda.so` cannot be found. User could still be able to find out that `fbgemm_gpu_py.so` is not there, as the error message now is:
```
/path/to/fbgemm_gpu/fbgemm_gpu_py.so: cannot open shared object file: No such file or directory
```

Thank you for your time on this PR:)