### PR TITLE
Integrate prototype jagged op from NVIDIA

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops.cu
@@ -28,6 +28,25 @@ namespace fbgemm_gpu {
 
 namespace {
 
+template <typename T>
+struct SharedMemory;
+
+template <>
+struct SharedMemory<int64_t> {
+  __device__ int64_t* getPointer() {
+    extern __shared__ int64_t s_int64_t[];
+    return s_int64_t;
+  }
+};
+
+template <>
+struct SharedMemory<int32_t> {
+  __device__ int32_t* getPointer() {
+    extern __shared__ int32_t s_int32_t[];
+    return s_int32_t;
+  }
+};
+
 /// @defgroup jagged-tensor-ops-cuda Jagged Tensor CUDA Operators
 /// The following are Jagged Tensor CUDA Operators
 ///
@@ -344,44 +363,294 @@ __launch_bounds__(kMaxThreads) void jagged_dense_dense_elementwise_jagged_output
   }
 }
 
-///@addtogroup jagged-tensor-ops-cuda
-template <typename scalar_t, typename F>
-void jagged_dense_elementwise_jagged_output_(
-    const Tensor& x_values,
-    const std::vector<Tensor>& x_offsets,
-    const Tensor& y,
-    const Tensor& output_values,
-    F f) {
-  TENSOR_ON_CUDA_GPU(x_values);
-  for (auto& x_offset : x_offsets) {
-    TENSOR_ON_CUDA_GPU(x_offset);
+template <typename index_t>
+__global__ void jagged_dense_dense_elementwise_jagged_output_opt_search_kernel_(
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
+    at::PackedTensorAccessor32<int, 1, at::RestrictPtrTraits> rows,
+    at::PackedTensorAccessor32<int, 1, at::RestrictPtrTraits> cols,
+    int nnz,
+    int B) {
+  struct SharedMemory<index_t> smem;
+  index_t* offsets_sh = smem.getPointer();
+  for (int i = threadIdx.x; i < B + 1; i += blockDim.x) {
+    offsets_sh[i] = offsets[i];
   }
-
-  const int num_jagged_dim = y.dim() - 2;
-  TORCH_CHECK(
-      x_offsets.size() == static_cast<size_t>(num_jagged_dim),
-      "x_offsets.size(), ",
-      x_offsets.size(),
-      " != num_jagged_dim, ",
-      num_jagged_dim);
-
-  if (y.numel() == 0 || x_values.numel() == 0) {
+  __syncthreads();
+  int row = threadIdx.x + blockIdx.x * blockDim.x;
+  if (row >= nnz)
     return;
+  int first = -1;
+  int count = B - 1;
+  first = 1;
+  while (count > 0) {
+    int idx = first;
+    int step = count / 2;
+    idx += step;
+    if (offsets_sh[idx] <= row) {
+      first = ++idx;
+      count -= step + 1;
+    } else {
+      count = step;
+    }
   }
+  --first;
 
-  dim3 threads, blocks;
-  StackArray<int64_t> jagged_dims_tensor;
-  std::tie(threads, blocks, jagged_dims_tensor) =
-      check_shape_and_partition_(x_values, x_offsets, y);
-  // Patch up blocks.x because we're using different parallelization from other
-  // jagged kernels.
-  blocks.x = div_round_up(x_values.size(0), threads.y);
+  int dense_row = first;
+  int offset = offsets_sh[dense_row];
+  int dense_col = row - offset;
+  rows[row] = dense_row;
+  cols[row] = dense_col;
+}
 
-  // Canonicalize y to 3D, collapsing jagged dimensions.
-  const Tensor y_reshaped = y.view({y.size(0), -1, y.size(-1)});
+struct VecType128 {
+  typedef float4 TType; // Transaction Type
+  typedef struct __align__(16) {
+    __half a, b, c, d, w, x, y, z;
+  }
+  half8;
+
+  union Data {
+    half8 val;
+    TType mask;
+  } data;
+
+  __device__ VecType128() {
+    data.mask = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+  }
+};
+
+struct VecType64 {
+  typedef float2 TType; // Transaction Type
+  typedef struct __align__(8) {
+    __half a, b, c, d;
+  }
+  half4;
+
+  union Data {
+    half4 val;
+    TType mask;
+  } data;
+
+  __device__ VecType64() {
+    data.mask = make_float2(0.0f, 0.0f);
+  }
+};
+
+struct VecType32 {
+  typedef float TType; // Transaction Type
+
+  union Data {
+    __half2 val;
+    TType mask;
+  } data;
+
+  __device__ VecType32() {
+    data.mask = 0.0f;
+  }
+};
+
+template <typename F>
+__device__ void f128(
+    VecType128& v_out,
+    const VecType128& x,
+    const VecType128& y0,
+    const VecType128& y1,
+    F f) {
+  v_out.data.val.a = f(x.data.val.a, y0.data.val.a, y1.data.val.a);
+  v_out.data.val.b = f(x.data.val.b, y0.data.val.b, y1.data.val.b);
+  v_out.data.val.c = f(x.data.val.c, y0.data.val.c, y1.data.val.c);
+  v_out.data.val.d = f(x.data.val.d, y0.data.val.d, y1.data.val.d);
+  v_out.data.val.w = f(x.data.val.w, y0.data.val.w, y1.data.val.w);
+  v_out.data.val.x = f(x.data.val.x, y0.data.val.x, y1.data.val.x);
+  v_out.data.val.y = f(x.data.val.y, y0.data.val.y, y1.data.val.y);
+  v_out.data.val.z = f(x.data.val.z, y0.data.val.z, y1.data.val.z);
+}
+
+template <typename F>
+__device__ void f64(
+    VecType64& v_out,
+    const VecType64& x,
+    const VecType64& y0,
+    const VecType64& y1,
+    F f) {
+  v_out.data.val.a = f(x.data.val.a, y0.data.val.a, y1.data.val.a);
+  v_out.data.val.b = f(x.data.val.b, y0.data.val.b, y1.data.val.b);
+  v_out.data.val.c = f(x.data.val.c, y0.data.val.c, y1.data.val.c);
+  v_out.data.val.d = f(x.data.val.d, y0.data.val.d, y1.data.val.d);
+}
+
+template <typename F>
+__device__ void f32(
+    VecType32& v_out,
+    const VecType32& x,
+    const VecType32& y0,
+    const VecType32& y1,
+    F f) {
+  v_out.data.val = __halves2half2(
+      f(__low2half(x.data.val),
+        __low2half(y0.data.val),
+        __low2half(y1.data.val)),
+      f(__high2half(x.data.val),
+        __high2half(y0.data.val),
+        __high2half(y1.data.val)));
+}
+
+template <typename F>
+__device__ void
+fh(__half& v_out, const __half& x, const __half& y0, const __half& y1, F f) {
+  v_out = f(x, y0, y1);
+}
+
+template <typename index_t, typename F>
+__global__ void jagged_dense_dense_elementwise_jagged_output_opt_gather_kernel_(
+    at::PackedTensorAccessor32<c10::Half, 2, at::RestrictPtrTraits> values,
+    const at::PackedTensorAccessor32<c10::Half, 2, at::RestrictPtrTraits>
+        x_values,
+    const at::PackedTensorAccessor32<c10::Half, 3, at::RestrictPtrTraits> y0,
+    const at::PackedTensorAccessor32<c10::Half, 3, at::RestrictPtrTraits> y1,
+    const at::PackedTensorAccessor32<int, 1, at::RestrictPtrTraits> rows,
+    const at::PackedTensorAccessor32<int, 1, at::RestrictPtrTraits> cols,
+    const int nnz,
+    const int E,
+    F f) {
+  int values_row = threadIdx.y + blockIdx.y * blockDim.y;
+  if (values_row >= nnz)
+    return;
+  for (int real_row = values_row; real_row < nnz;
+       real_row += blockDim.y * gridDim.y) {
+    int dense_row = rows[real_row];
+    int dense_col = cols[real_row];
+    __half* values_ptr = reinterpret_cast<__half*>(&values[real_row][0]);
+    const __half* x_ptr =
+        reinterpret_cast<const __half*>(&x_values[real_row][0]);
+    const __half* y0_ptr =
+        reinterpret_cast<const __half*>(&y0[dense_row][dense_col][0]);
+    const __half* y1_ptr =
+        reinterpret_cast<const __half*>(&y1[dense_row][dense_col][0]);
+    if ((dense_col < y0.size(1)) && (dense_row < y0.size(0)) &&
+        (dense_col < y1.size(1)) && (dense_row < y1.size(0)) &&
+        (dense_col >= 0) && (dense_row >= 0)) {
+      for (int tid = threadIdx.x; tid < E / 8; tid += blockDim.x) {
+        VecType128 v_x, v_out, v_y0, v_y1;
+        v_x.data.mask =
+            (reinterpret_cast<const VecType128::TType*>(x_ptr))[tid];
+        v_y0.data.mask =
+            (reinterpret_cast<const VecType128::TType*>(y0_ptr))[tid];
+        v_y1.data.mask =
+            (reinterpret_cast<const VecType128::TType*>(y1_ptr))[tid];
+        f128(v_out, v_x, v_y0, v_y1, f);
+        (reinterpret_cast<VecType128::TType*>(values_ptr))[tid] =
+            v_out.data.mask;
+      }
+      for (int tid = threadIdx.x + (E / 8) * 8; tid < E / 4;
+           tid += blockDim.x) {
+        VecType64 v_x, v_out, v_y0, v_y1;
+        v_x.data.mask = (reinterpret_cast<const VecType64::TType*>(x_ptr))[tid];
+        v_y0.data.mask =
+            (reinterpret_cast<const VecType64::TType*>(y0_ptr))[tid];
+        v_y1.data.mask =
+            (reinterpret_cast<const VecType64::TType*>(y1_ptr))[tid];
+        f64(v_out, v_x, v_y0, v_y1, f);
+        (reinterpret_cast<VecType64::TType*>(values_ptr))[tid] =
+            v_out.data.mask;
+      }
+      for (int tid = threadIdx.x + (E / 4) * 4; tid < E / 2;
+           tid += blockDim.x) {
+        VecType32 v_x, v_out, v_y0, v_y1;
+        v_x.data.mask = (reinterpret_cast<const VecType32::TType*>(x_ptr))[tid];
+        v_y0.data.mask =
+            (reinterpret_cast<const VecType32::TType*>(y0_ptr))[tid];
+        v_y1.data.mask =
+            (reinterpret_cast<const VecType32::TType*>(y1_ptr))[tid];
+        f32(v_out, v_x, v_y0, v_y1, f);
+        (reinterpret_cast<VecType32::TType*>(values_ptr))[tid] =
+            v_out.data.mask;
+      }
+      for (int tid = threadIdx.x + (E / 2) * 2; tid < E; tid += blockDim.x) {
+        __half v_x, v_out, v_y0, v_y1;
+        v_x = static_cast<__half>(x_ptr[tid]);
+        v_y0 = static_cast<__half>(y0_ptr[tid]);
+        v_y1 = static_cast<__half>(y1_ptr[tid]);
+        fh(v_out, v_x, v_y0, v_y1, f);
+        values_ptr[tid] = v_out;
+      }
+    } else {
+      for (int tid = threadIdx.x; tid < E / 8; tid += blockDim.x) {
+        VecType128 v_x, v_out, v_y0, v_y1;
+        v_x.data.mask =
+            (reinterpret_cast<const VecType128::TType*>(x_ptr))[tid];
+        f128(v_out, v_x, v_y0, v_y1, f);
+        (reinterpret_cast<VecType128::TType*>(values_ptr))[tid] =
+            v_out.data.mask;
+      }
+      for (int tid = threadIdx.x + (E / 8) * 8; tid < E / 4;
+           tid += blockDim.x) {
+        VecType64 v_x, v_out, v_y0, v_y1;
+        v_x.data.mask = (reinterpret_cast<const VecType64::TType*>(x_ptr))[tid];
+        f64(v_out, v_x, v_y0, v_y1, f);
+        (reinterpret_cast<VecType64::TType*>(values_ptr))[tid] =
+            v_out.data.mask;
+      }
+      for (int tid = threadIdx.x + (E / 4) * 4; tid < E / 2;
+           tid += blockDim.x) {
+        VecType32 v_x, v_out, v_y0, v_y1;
+        v_x.data.mask = (reinterpret_cast<const VecType32::TType*>(x_ptr))[tid];
+        f32(v_out, v_x, v_y0, v_y1, f);
+        (reinterpret_cast<VecType32::TType*>(values_ptr))[tid] =
+            v_out.data.mask;
+      }
+      for (int tid = threadIdx.x + (E / 2) * 2; tid < E; tid += blockDim.x) {
+        __half v_x, v_out, v_y0, v_y1;
+        v_x = static_cast<__half>(x_ptr[tid]);
+        fh(v_out, v_x, v_y0, v_y1, f);
+        values_ptr[tid] = v_out;
+      }
+    }
+  }
+}
+
+// Check to see if the inputs to the op are amenable to the fast path
+bool jagged_dense_dense_elementwise_jagged_output_matches_opt(
+    const int& num_jagged_dim,
+    const Tensor& x_values,
+    const Tensor& y_0_reshaped,
+    const Tensor& y_1_reshaped,
+    const Tensor& output_values) {
+  bool matches = true;
+  matches &= (num_jagged_dim == 1);
+
+  // Unit stride embedding dim
+  matches &= (x_values.stride(-1) == 1);
+  matches &= (output_values.stride(-1) == 1);
+  matches &= (y_0_reshaped.stride(-1) == 1);
+  matches &= (y_1_reshaped.stride(-1) == 1);
+
+  // Each row is aligned to 128-bit
+  matches &= (x_values.stride(-2) % 8 == 0);
+  matches &= (output_values.stride(-2) % 8 == 0);
+  matches &= (y_0_reshaped.stride(-2) % 8 == 0);
+  matches &= (y_1_reshaped.stride(-2) % 8 == 0);
+
+  // Base addresses aligned to 128-bit
+  matches &= (reinterpret_cast<uint64_t>(x_values.data_ptr()) % 16 == 0);
+  matches &= (reinterpret_cast<uint64_t>(output_values.data_ptr()) % 16 == 0);
+  matches &= (reinterpret_cast<uint64_t>(y_0_reshaped.data_ptr()) % 16 == 0);
+  matches &= (reinterpret_cast<uint64_t>(y_1_reshaped.data_ptr()) % 16 == 0);
+
+  // Rows and col fit into int32_t
+  matches &= (y_0_reshaped.size(0) < INT_MAX);
+  matches &= (y_0_reshaped.size(1) < INT_MAX);
+
+  return matches;
+}
 
 #define INVOKE_KERNEL_WITH_DIM(NUM_JAGGED_DIM)                                 \
   {                                                                            \
+    dim3 threads, blocks;                                                      \
+    StackArray<int64_t> jagged_dims_tensor;                                    \
+    std::tie(threads, blocks, jagged_dims_tensor) =                            \
+        check_shape_and_partition_(x_values, x_offsets, y);                    \
+    blocks.x = div_round_up(x_values.size(0), threads.y);                      \
     std::vector<Tensor> x_offsets_contig;                                      \
     x_offsets_contig.resize(num_jagged_dim);                                   \
     StackArray<index_t*> x_offset_ptrs;                                        \
@@ -408,10 +677,269 @@ void jagged_dense_elementwise_jagged_output_(
             -> scalar_t { return f_(x, y); });                                 \
   }
 
+///@addtogroup jagged-tensor-ops-cuda
+template <typename scalar_t, typename F>
+void jagged_dense_elementwise_jagged_output_opt_(
+    const Tensor& x_values,
+    const std::vector<Tensor>& x_offsets,
+    const Tensor& y,
+    const Tensor& output_values,
+    F f) {
+  TENSOR_ON_CUDA_GPU(x_values);
+  for (auto& x_offset : x_offsets) {
+    TENSOR_ON_CUDA_GPU(x_offset);
+  }
+
+  const int num_jagged_dim = y.dim() - 2;
+  TORCH_CHECK(
+      x_offsets.size() == static_cast<size_t>(num_jagged_dim),
+      "x_offsets.size(), ",
+      x_offsets.size(),
+      " != num_jagged_dim, ",
+      num_jagged_dim);
+
+  if (y.numel() == 0 || x_values.numel() == 0) {
+    return;
+  }
+
+  // Canonicalize y to 3D, collapsing jagged dimensions.
+  const Tensor y_reshaped = y.view({y.size(0), -1, y.size(-1)});
+  if (jagged_dense_dense_elementwise_jagged_output_matches_opt(
+          num_jagged_dim, x_values, y_reshaped, y_reshaped, output_values)) {
+    AT_DISPATCH_INDEX_TYPES(
+        x_offsets[0].scalar_type(), "jagged_indices_fast_path", [=] {
+          auto nnz = output_values.size(0);
+          auto B = y_reshaped.size(0);
+          auto E = y_reshaped.size(2);
+          Tensor t_rows_after_bs = at::empty(
+              {nnz},
+              at::TensorOptions().dtype(at::kInt).device(
+                  at::kCUDA, at::cuda::current_device()));
+          Tensor t_cols_after_bs = at::empty(
+              {nnz},
+              at::TensorOptions().dtype(at::kInt).device(
+                  at::kCUDA, at::cuda::current_device()));
+
+          // Binary search
+          size_t dynamic_smem_size = (B + 1) * sizeof(index_t);
+          dim3 threads_bs = dim3(1024, 1, 1);
+          dim3 blocks_bs = dim3(div_round_up(nnz, threads_bs.x), 1, 1);
+          jagged_dense_dense_elementwise_jagged_output_opt_search_kernel_<
+              index_t>
+              <<<blocks_bs,
+                 threads_bs,
+                 dynamic_smem_size,
+                 at::cuda::getCurrentCUDAStream()>>>(
+                  x_offsets[0]
+                      .packed_accessor32<index_t, 1, at::RestrictPtrTraits>(),
+                  t_rows_after_bs
+                      .packed_accessor32<int, 1, at::RestrictPtrTraits>(),
+                  t_cols_after_bs
+                      .packed_accessor32<int, 1, at::RestrictPtrTraits>(),
+                  nnz,
+                  B);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+          // Gather kernel
+          dim3 threads = dim3(16, 16, 1);
+          dim3 blocks = dim3(1, div_round_up(nnz, threads.y), 1);
+          if (blocks.y > 65535) {
+            blocks.y = 65535;
+          }
+          jagged_dense_dense_elementwise_jagged_output_opt_gather_kernel_<
+              index_t>
+              <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+                  output_values
+                      .packed_accessor32<c10::Half, 2, at::RestrictPtrTraits>(),
+                  x_values
+                      .packed_accessor32<c10::Half, 2, at::RestrictPtrTraits>(),
+                  y_reshaped
+                      .packed_accessor32<c10::Half, 3, at::RestrictPtrTraits>(),
+                  y_reshaped
+                      .packed_accessor32<c10::Half, 3, at::RestrictPtrTraits>(),
+                  t_rows_after_bs
+                      .packed_accessor32<int, 1, at::RestrictPtrTraits>(),
+                  t_cols_after_bs
+                      .packed_accessor32<int, 1, at::RestrictPtrTraits>(),
+                  nnz,
+                  E,
+                  [_f = f] __device__(__half x, __half y0, __half) -> __half {
+                    return _f(x, y0);
+                  });
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }); // AT_DISPATCH
+  } else {
+    JAGGED_TENSOR_DISPATCH_DIMS();
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+}
+
+///@addtogroup jagged-tensor-ops-cuda
+template <typename scalar_t, typename F>
+void jagged_dense_elementwise_jagged_output_(
+    const Tensor& x_values,
+    const std::vector<Tensor>& x_offsets,
+    const Tensor& y,
+    const Tensor& output_values,
+    F f) {
+  TENSOR_ON_CUDA_GPU(x_values);
+  for (auto& x_offset : x_offsets) {
+    TENSOR_ON_CUDA_GPU(x_offset);
+  }
+
+  const int num_jagged_dim = y.dim() - 2;
+  TORCH_CHECK(
+      x_offsets.size() == static_cast<size_t>(num_jagged_dim),
+      "x_offsets.size(), ",
+      x_offsets.size(),
+      " != num_jagged_dim, ",
+      num_jagged_dim);
+
+  if (y.numel() == 0 || x_values.numel() == 0) {
+    return;
+  }
+
+  // Canonicalize y to 3D, collapsing jagged dimensions.
+  const Tensor y_reshaped = y.view({y.size(0), -1, y.size(-1)});
+
   JAGGED_TENSOR_DISPATCH_DIMS();
   C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
 
 #undef INVOKE_KERNEL_WITH_DIM
+
+#define INVOKE_KERNEL_WITH_DIM(NUM_JAGGED_DIM)                                 \
+  {                                                                            \
+    dim3 threads, blocks;                                                      \
+    StackArray<int64_t> jagged_dims_tensor;                                    \
+    std::tie(threads, blocks, jagged_dims_tensor) =                            \
+        check_shape_and_partition_(x_values, x_offsets, y_0);                  \
+    blocks.x = div_round_up(x_values.size(0), threads.y);                      \
+    std::vector<Tensor> x_offsets_contig;                                      \
+    x_offsets_contig.resize(num_jagged_dim);                                   \
+    StackArray<index_t*> x_offset_ptrs;                                        \
+    x_offset_ptrs.ndim = num_jagged_dim;                                       \
+    StackArray<int64_t> x_offset_sizes;                                        \
+    x_offset_sizes.ndim = num_jagged_dim;                                      \
+    for (int d = 0; d < num_jagged_dim; ++d) {                                 \
+      x_offsets_contig[d] = x_offsets[d].contiguous();                         \
+      x_offset_ptrs.vals[d] =                                                  \
+          x_offsets_contig[d].template data_ptr<index_t>();                    \
+      x_offset_sizes.vals[d] = x_offsets[d].numel();                           \
+    }                                                                          \
+    jagged_dense_dense_elementwise_jagged_output_kernel_<                      \
+        NUM_JAGGED_DIM,                                                        \
+        index_t><<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(    \
+        x_values.packed_accessor32<scalar_t, 2, at::RestrictPtrTraits>(),      \
+        x_offset_ptrs,                                                         \
+        x_offset_sizes,                                                        \
+        y_0_reshaped.packed_accessor32<scalar_t, 3, at::RestrictPtrTraits>(),  \
+        y_1_reshaped.packed_accessor32<scalar_t, 3, at::RestrictPtrTraits>(),  \
+        output_values.packed_accessor32<scalar_t, 2, at::RestrictPtrTraits>(), \
+        jagged_dims_tensor,                                                    \
+        f);                                                                    \
+  }
+
+template <typename scalar_t, typename F>
+void jagged_dense_dense_elementwise_jagged_output_opt_(
+    const Tensor& x_values,
+    const std::vector<Tensor>& x_offsets,
+    const Tensor& y_0,
+    const Tensor& y_1,
+    const Tensor& output_values,
+    F f) {
+  TENSOR_ON_CUDA_GPU(x_values);
+  for (auto& x_offset : x_offsets) {
+    TENSOR_ON_CUDA_GPU(x_offset);
+  }
+
+  const int num_jagged_dim = y_0.dim() - 2;
+  TORCH_CHECK(
+      x_offsets.size() == static_cast<size_t>(num_jagged_dim),
+      "x_offsets.size(), ",
+      x_offsets.size(),
+      " != num_jagged_dim, ",
+      num_jagged_dim);
+
+  if (y_0.numel() == 0 || x_values.numel() == 0) {
+    return;
+  }
+
+  // Canonicalize y to 3D, collapsing jagged dimensions.
+  const Tensor y_0_reshaped = y_0.view({y_0.size(0), -1, y_0.size(-1)});
+  const Tensor y_1_reshaped = y_1.view({y_1.size(0), -1, y_1.size(-1)});
+
+  if (jagged_dense_dense_elementwise_jagged_output_matches_opt(
+          num_jagged_dim,
+          x_values,
+          y_0_reshaped,
+          y_1_reshaped,
+          output_values)) {
+    AT_DISPATCH_INDEX_TYPES(
+        x_offsets[0].scalar_type(),
+        "jagged_dense_dense_indices_fast_path",
+        [=] {
+          auto nnz = output_values.size(0);
+          auto B = y_0_reshaped.size(0);
+          auto E = y_0_reshaped.size(2);
+          Tensor t_rows_after_bs = at::empty(
+              {nnz},
+              at::TensorOptions().dtype(at::kInt).device(
+                  at::kCUDA, at::cuda::current_device()));
+          Tensor t_cols_after_bs = at::empty(
+              {nnz},
+              at::TensorOptions().dtype(at::kInt).device(
+                  at::kCUDA, at::cuda::current_device()));
+
+          // Binary search
+          size_t dynamic_smem_size = (B + 1) * sizeof(index_t);
+          dim3 threads_bs = dim3(1024, 1, 1);
+          dim3 blocks_bs = dim3(div_round_up(nnz, threads_bs.x), 1, 1);
+          jagged_dense_dense_elementwise_jagged_output_opt_search_kernel_<
+              index_t>
+              <<<blocks_bs,
+                 threads_bs,
+                 dynamic_smem_size,
+                 at::cuda::getCurrentCUDAStream()>>>(
+                  x_offsets[0]
+                      .packed_accessor32<index_t, 1, at::RestrictPtrTraits>(),
+                  t_rows_after_bs
+                      .packed_accessor32<int, 1, at::RestrictPtrTraits>(),
+                  t_cols_after_bs
+                      .packed_accessor32<int, 1, at::RestrictPtrTraits>(),
+                  nnz,
+                  B);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+          // Gather kernel
+          dim3 threads = dim3(16, 16, 1);
+          dim3 blocks = dim3(1, div_round_up(nnz, threads.y), 1);
+          if (blocks.y > 65535) {
+            blocks.y = 65535;
+          }
+          jagged_dense_dense_elementwise_jagged_output_opt_gather_kernel_<
+              index_t>
+              <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+                  output_values
+                      .packed_accessor32<c10::Half, 2, at::RestrictPtrTraits>(),
+                  x_values
+                      .packed_accessor32<c10::Half, 2, at::RestrictPtrTraits>(),
+                  y_0_reshaped
+                      .packed_accessor32<c10::Half, 3, at::RestrictPtrTraits>(),
+                  y_1_reshaped
+                      .packed_accessor32<c10::Half, 3, at::RestrictPtrTraits>(),
+                  t_rows_after_bs
+                      .packed_accessor32<int, 1, at::RestrictPtrTraits>(),
+                  t_cols_after_bs
+                      .packed_accessor32<int, 1, at::RestrictPtrTraits>(),
+                  nnz,
+                  E,
+                  [_f = f] __device__(__half x, __half y0, __half y1)
+                      -> __half { return _f(x, y0, y1); });
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }); // AT_DISPATCH
+  } else {
+    JAGGED_TENSOR_DISPATCH_DIMS();
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
 }
 
 template <typename scalar_t, typename F>
@@ -439,50 +967,15 @@ void jagged_dense_dense_elementwise_jagged_output_(
     return;
   }
 
-  dim3 threads, blocks;
-  StackArray<int64_t> jagged_dims_tensor;
-  std::tie(threads, blocks, jagged_dims_tensor) =
-      check_shape_and_partition_(x_values, x_offsets, y_0);
-  // Patch up blocks.x because we're using different parallelization from other
-  // jagged kernels.
-  blocks.x = div_round_up(x_values.size(0), threads.y);
-
   // Canonicalize y to 3D, collapsing jagged dimensions.
   const Tensor y_0_reshaped = y_0.view({y_0.size(0), -1, y_0.size(-1)});
   const Tensor y_1_reshaped = y_1.view({y_1.size(0), -1, y_1.size(-1)});
 
-#define INVOKE_KERNEL_WITH_DIM(NUM_JAGGED_DIM)                                 \
-  {                                                                            \
-    std::vector<Tensor> x_offsets_contig;                                      \
-    x_offsets_contig.resize(num_jagged_dim);                                   \
-    StackArray<index_t*> x_offset_ptrs;                                        \
-    x_offset_ptrs.ndim = num_jagged_dim;                                       \
-    StackArray<int64_t> x_offset_sizes;                                        \
-    x_offset_sizes.ndim = num_jagged_dim;                                      \
-    for (int d = 0; d < num_jagged_dim; ++d) {                                 \
-      x_offsets_contig[d] = x_offsets[d].contiguous();                         \
-      x_offset_ptrs.vals[d] =                                                  \
-          x_offsets_contig[d].template data_ptr<index_t>();                    \
-      x_offset_sizes.vals[d] = x_offsets[d].numel();                           \
-    }                                                                          \
-    jagged_dense_dense_elementwise_jagged_output_kernel_<                      \
-        NUM_JAGGED_DIM,                                                        \
-        index_t><<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(    \
-        x_values.packed_accessor32<scalar_t, 2, at::RestrictPtrTraits>(),      \
-        x_offset_ptrs,                                                         \
-        x_offset_sizes,                                                        \
-        y_0_reshaped.packed_accessor32<scalar_t, 3, at::RestrictPtrTraits>(),  \
-        y_1_reshaped.packed_accessor32<scalar_t, 3, at::RestrictPtrTraits>(),  \
-        output_values.packed_accessor32<scalar_t, 2, at::RestrictPtrTraits>(), \
-        jagged_dims_tensor,                                                    \
-        f);                                                                    \
-  }
-
   JAGGED_TENSOR_DISPATCH_DIMS();
   C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
 
 #undef INVOKE_KERNEL_WITH_DIM
-}
 
 ///@ingroup jagged-tensor-ops-cuda
 at::Tensor jagged_to_padded_dense_forward(
@@ -633,7 +1126,10 @@ Tensor jagged_dense_elementwise_add(
 
   // Convert x to dense (assume padding is 0.0)
   auto xd = JaggedToPaddedDenseGPUOp::apply(
-      x_values, x_offsets, max_lengths, /* padding_value */ 0.0)[0];
+      x_values,
+      x_offsets,
+      max_lengths,
+      /* padding_value */ 0.0)[0];
 
   auto dense_output = xd + y;
   return dense_output;
@@ -667,21 +1163,36 @@ class DenseToJaggedGPUOp
     at::cuda::OptionalCUDAGuard device_guard;
     device_guard.set_index(dense.get_device());
 
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        at::ScalarType::Half,
-        at::ScalarType::Long,
+    AT_DISPATCH_SWITCH(
         values.scalar_type(),
-        "jagged_dense_add_forward",
-        [&] {
-          jagged_dense_elementwise_jagged_output_<scalar_t>(
-              values,
-              offsets,
-              dense,
-              output,
-              [] __device__(scalar_t /*unused*/, scalar_t y) -> scalar_t {
-                return y;
-              });
-        });
+        "dense_to_jagged_gpu_op_forward",
+        AT_DISPATCH_CASE(
+            at::ScalarType::Half,
+            [&] {
+              jagged_dense_elementwise_jagged_output_opt_<scalar_t>(
+                  values,
+                  offsets,
+                  dense,
+                  output,
+                  [] __device__(scalar_t /*unused*/, scalar_t y) -> scalar_t {
+                    return y;
+                  }); // device lambda
+            } // lambda
+            ) // CASE
+        AT_DISPATCH_CASE_FLOATING_TYPES_AND(
+            at::ScalarType::Long,
+            [&] {
+              jagged_dense_elementwise_jagged_output_<scalar_t>(
+                  values,
+                  offsets,
+                  dense,
+                  output,
+                  [] __device__(scalar_t /*unused*/, scalar_t y) -> scalar_t {
+                    return y;
+                  }); // device lambda
+            } // lambda
+            ) // CASE_FLOATING_TYPES_AND
+    ); // SWITCH
 
     return {output};
   }
@@ -728,10 +1239,23 @@ class JaggedDenseDenseAddJaggedOutputGPUOp
     at::cuda::OptionalCUDAGuard device_guard;
     device_guard.set_index(dense_0.get_device());
 
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+    AT_DISPATCH_SWITCH(
         x_values.scalar_type(),
         "jagged_dense_dense_elementwise_jagged_output_forward",
-        [&] {
+        AT_DISPATCH_CASE(
+            at::ScalarType::Half,
+            [&] {
+              jagged_dense_dense_elementwise_jagged_output_opt_<scalar_t>(
+                  x_values,
+                  offsets,
+                  dense_0,
+                  dense_1,
+                  output,
+                  [] __device__(scalar_t x, scalar_t y_0, scalar_t y_1)
+                      -> scalar_t { return x + y_0 + y_1; });
+            } // lambda
+            ) // CASE
+        AT_DISPATCH_CASE_FLOATING_TYPES([&] {
           jagged_dense_dense_elementwise_jagged_output_<scalar_t>(
               x_values,
               offsets,
@@ -740,7 +1264,9 @@ class JaggedDenseDenseAddJaggedOutputGPUOp
               output,
               [] __device__(scalar_t x, scalar_t y_0, scalar_t y_1)
                   -> scalar_t { return x + y_0 + y_1; });
-        });
+        } // lambda
+                                        ) // CASE_FLOATING_TYPES_AND
+    ); // SWITCH
 
     return {output};
   }
@@ -796,10 +1322,23 @@ class JaggedDenseAddJaggedOutputGPUOp
     at::cuda::OptionalCUDAGuard device_guard;
     device_guard.set_index(dense.get_device());
 
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+    AT_DISPATCH_SWITCH(
         x_values.scalar_type(),
         "jagged_dense_elementwise_jagged_output_forward",
-        [&] {
+        AT_DISPATCH_CASE(
+            at::ScalarType::Half,
+            [&] {
+              jagged_dense_elementwise_jagged_output_opt_<scalar_t>(
+                  x_values,
+                  offsets,
+                  dense,
+                  output,
+                  [] __device__(scalar_t x, scalar_t y) -> scalar_t {
+                    return x + y;
+                  }); // device lambda
+            } // lambda
+            ) // CASE
+        AT_DISPATCH_CASE_FLOATING_TYPES([&] {
           jagged_dense_elementwise_jagged_output_<scalar_t>(
               x_values,
               offsets,
@@ -807,8 +1346,10 @@ class JaggedDenseAddJaggedOutputGPUOp
               output,
               [] __device__(scalar_t x, scalar_t y) -> scalar_t {
                 return x + y;
-              });
-        });
+              }); // device lambda
+        } // lambda
+                                        ) // CASE_FLOATING_TYPES_AND
+    ); // SWITCH
 
     return {output};
   }
@@ -994,8 +1535,23 @@ class JaggedDenseMulGPUOp
 
     Tensor output = at::empty_like(x_values);
 
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-        x_values.scalar_type(), "jagged_scalars", [&] {
+    AT_DISPATCH_SWITCH(
+        x_values.scalar_type(),
+        "jagged_dense_elementwise_mul_jagged_output_forward",
+        AT_DISPATCH_CASE(
+            at::ScalarType::Half,
+            [&] {
+              jagged_dense_elementwise_jagged_output_opt_<scalar_t>(
+                  x_values,
+                  x_offsets,
+                  y,
+                  output,
+                  [] __device__(scalar_t x, scalar_t y) -> scalar_t {
+                    return x * y;
+                  });
+            } // lambda
+            ) // CASE
+        AT_DISPATCH_CASE_FLOATING_TYPES([&] {
           jagged_dense_elementwise_jagged_output_<scalar_t>(
               x_values,
               x_offsets,
@@ -1004,7 +1560,9 @@ class JaggedDenseMulGPUOp
               [] __device__(scalar_t x, scalar_t y) -> scalar_t {
                 return x * y;
               });
-        });
+        } // lambda
+                                        ) // CASE_FLOATING_TYPES_AND
+    ); // SWITCH
 
     return {output};
   }
@@ -1347,7 +1905,10 @@ Tensor jagged_2d_to_dense_gpu(
     Tensor offsets,
     int64_t max_sequence_length) {
   return jagged_to_padded_dense(
-      values, {offsets}, {max_sequence_length}, /*padding_value=*/0);
+      values,
+      {offsets},
+      {max_sequence_length},
+      /*padding_value=*/0);
 }
 
 Tensor jagged_2d_to_dense_gpu_forward(


### PR DESCRIPTION
Summary:
- Integrating prototype from https://github.com/pytorch/FBGEMM/pull/1221
- Added elementwise functionality
- Restricted use to half precision, aligned case
- Added tests for optimized case
- Added elementwise ops to benchmark

Differential Revision: D38365864

