### PR TITLE
Run CI on pytorch built with CUDA 11.3

### DIFF
--- a/.github/workflows/fbgemmci.yml
+++ b/.github/workflows/fbgemmci.yml
@@ -224,10 +224,8 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install git pip python3-dev
         sudo pip install cmake scikit-build ninja jinja2 numpy hypothesis --no-input
-        # "11.5" -> "115"
-        cuda_torch_version=$(echo "${{ matrix.cuda_version }}" | sed "s/\.//")
-        # Install PyTorch (nightly) as required by fbgemm_gpu
-        sudo pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu${cuda_torch_version}/torch_nightly.html
+        # Install pytorch built with CUDA 11.3 in all cases
+        sudo pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
 
     - name: Checkout submodules
       shell: bash


### PR DESCRIPTION
Summary:
- pytorch has not updated their CUDA 11.5 .whl files with latest pytorch (1.13), while they have updated their CUDA 11.3 .whl files
- pytorch built with CUDA 11.3 will work with later CUDA versions, as CUDA is backward compatable
- Suggest we set a policy where we support building/installing FBGEMM with pytorch .whl which is built with CUDA 11.3 as this seems to be their preferred build. This guidance in our README and also torchrec README.
- This diff updates CI to install pytorch .whl which was built with CUDA 11.3, even when testing FBGEMM with later CUDA versions

Differential Revision: D38416122

