### PR TITLE
[CI] fix a 137 error in sparse_ops_test.py

### DIFF
--- a/.github/workflows/fbgemmci.yml
+++ b/.github/workflows/fbgemmci.yml
@@ -246,9 +246,9 @@ jobs:
       run: |
         cd fbgemm_gpu
         cd test
-        python input_combine_test.py
-        python quantize_ops_test.py
-        python sparse_ops_test.py
+        python input_combine_test.py -v
+        python quantize_ops_test.py -v
+        python sparse_ops_test.py -v
         python -c "import fbgemm_gpu"
         python -c "import fbgemm_gpu.split_embedding_codegen_lookup_invokers"
 
@@ -306,9 +306,9 @@ jobs:
       run: |
         cd fbgemm_gpu
         cd test
-        python3 input_combine_test.py
-        python3 quantize_ops_test.py
-        python3 sparse_ops_test.py
+        python3 input_combine_test.py -v
+        python3 quantize_ops_test.py -v
+        python3 sparse_ops_test.py -v
         python3 -c "import fbgemm_gpu"
         python3 -c "import fbgemm_gpu.split_embedding_codegen_lookup_invokers"
 
@@ -397,10 +397,10 @@ jobs:
       run: |
         cd fbgemm_gpu
         cd test
-        python batched_unary_embeddings_test.py
-        python input_combine_test.py
-        python layout_transform_ops_test.py
-        python merge_pooled_embeddings_test.py
-        python permute_pooled_embedding_modules_test.py
-        python quantize_ops_test.py
-        python sparse_ops_test.py
+        python batched_unary_embeddings_test.py -v
+        python input_combine_test.py -v
+        python layout_transform_ops_test.py -v
+        python merge_pooled_embeddings_test.py -v
+        python permute_pooled_embedding_modules_test.py -v
+        python quantize_ops_test.py -v
+        python sparse_ops_test.py -v

--- a/fbgemm_gpu/test/sparse_ops_test.py
+++ b/fbgemm_gpu/test/sparse_ops_test.py
@@ -1468,7 +1468,10 @@ class SparseOpsTest(unittest.TestCase):
     # pyre-ignore [56]
     @given(
         N=st.integers(1, 32),
-        shape=st.lists(st.integers(1, 32), min_size=1, max_size=2),
+        shape=st.one_of(
+            st.lists(st.integers(1, 128), max_size=1),
+            st.lists(st.integers(1, 16), min_size=2, max_size=2),
+        ),
         dtype=st.sampled_from([torch.float, torch.half, torch.double]),
         use_cpu=st.booleans() if gpu_available else st.just(True),
         consecutive_indices=st.booleans(),


### PR DESCRIPTION

This PR fixes a sporadic 137 (out-of-memory) error during `sparse_ops_test.py` in the GitHub Actions CI environment, such as https://github.com/pytorch/FBGEMM/runs/7743267476?check_suite_focus=true.

### Problem

It seems that `test_index_select_dim0` uses lots of memory in `torch.autograd.gradcheck` if `shape` is large (e.g., `[32, 32]`), which kills `sparse_ops_test.py`.  Consequently that CI job is marked as failure.

### Solution

This patch fixes it by reducing its size to `[1~128] or [1~16, 1~16]}`.

### Check

Without this fix, `sparse_ops_test.py` fails almost 100% if you repeat it 500 times.
With this fix, `sparse_ops_test.py` succeeds even if you repeat it 500 times.

See the following for details: https://github.com/shintaro-iwasaki/FBGEMM/pull/6

### Prevention

You cannot completely avoid this kind of issue, but `-v` should be helpful to understand which test causes this issue. `-v` does not hurt our CI, so this patch enables this for all the tests.


```sh
# This PR.  You can easily pinpoint a problem (in this case, test_index_select_dim0).
$ python3 sparse_ops_test.py -v
...
test_generic_histogram_binning_calibration_by_feature_cpu_gpu (__main__.SparseOpsTest) ... skipped 'CUDA is not available or no GPUs detected'
test_histogram_binning_calibration (__main__.SparseOpsTest) ... ok
test_histogram_binning_calibration_by_feature (__main__.SparseOpsTest) ... ok
test_index_select_dim0 (__main__.SparseOpsTest) ... /home/runner/work/_temp/6cff0d6d-54b0-48fb-a56e-c21f922649f6.sh: line 3:  3384 Killed                  python sparse_ops_test.py -v
```

Without `-v`, it's not easy to find which test causes an issue.

```sh
# The main branch (no "-v")
$ python3 sparse_ops_test.py
Trying example: test_generic_histogram_binning_calibration_by_feature(
    data_type=torch.float32,
    segment_value_type=torch.int64,
    segment_length_type=torch.int32,
    self=<__main__.SparseOpsTest testMethod=test_generic_histogram_binning_calibration_by_feature>,
)
Trying example: test_generic_histogram_binning_calibration_by_feature(
    data_type=torch.float32,
    segment_value_type=torch.int32,
    segment_length_type=torch.int64,
    self=<__main__.SparseOpsTest testMethod=test_generic_histogram_binning_calibration_by_feature>,
)
......s../home/runner/work/_temp/8080a768-5aa1-4c7f-84c0-4136bc60c460.sh: line 5: 16155 Killed                  python3 sparse_ops_test.py
```


