### PR TITLE
Add WeightDecayMode.NONE as default

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_backward_code_generator.py
@@ -481,7 +481,7 @@ def rowwise_adagrad() -> None:
                 (FLOAT, "eps"),
                 (FLOAT, "learning_rate"),
                 (FLOAT, "weight_decay", 0.0),
-                (INT, "weight_decay_mode", 1),
+                (INT, "weight_decay_mode", 0),
             ]
         ),
         split_precomputation=split_precomputation,
@@ -503,7 +503,7 @@ def rowwise_adagrad() -> None:
                 (FLOAT, "eps"),
                 (FLOAT, "learning_rate"),
                 (FLOAT, "weight_decay", 0.0),
-                (INT, "weight_decay_mode", 1),
+                (INT, "weight_decay_mode", 0),
             ]
         ),
         split_precomputation=split_precomputation,
@@ -602,7 +602,7 @@ def rowwise_adagrad_with_weight_decay() -> None:
                 (FLOAT, "eps"),
                 (FLOAT, "learning_rate"),
                 (FLOAT, "weight_decay", 0.0),
-                (INT, "weight_decay_mode", 1),
+                (INT, "weight_decay_mode", 0),
             ]
         ),
         split_precomputation=split_precomputation,
@@ -624,7 +624,7 @@ def rowwise_adagrad_with_weight_decay() -> None:
                 (FLOAT, "eps"),
                 (FLOAT, "learning_rate"),
                 (FLOAT, "weight_decay", 0.0),
-                (INT, "weight_decay_mode", 1),
+                (INT, "weight_decay_mode", 0),
             ]
         ),
         split_precomputation=split_precomputation,

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -65,6 +65,7 @@ class BoundsCheckMode(enum.IntEnum):
 
 
 class WeightDecayMode(enum.IntEnum):
+    NONE = 0
     L2 = 1
     DECOUPLE = 2
 


### PR DESCRIPTION
Summary: Add WeightDecayMode.NONE = 0 to `enum` definitions, and use `WeightDecayMode.NONE` as default.

Differential Revision: D38847625

