### PR TITLE
Fix building under Xcode 14

### DIFF
--- a/src/FbgemmFP16UKernelsAvx2.cc
+++ b/src/FbgemmFP16UKernelsAvx2.cc
@@ -5,16 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include "./FbgemmFP16UKernelsAvx2.h"
+#include "./InlineAsmDefines.h"
 
 namespace fbgemm {
 
 void NOINLINE gemmkernel_1x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -132,11 +133,11 @@ void NOINLINE gemmkernel_1x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_2x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -275,11 +276,11 @@ void NOINLINE gemmkernel_2x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_3x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -437,11 +438,11 @@ void NOINLINE gemmkernel_3x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_4x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -618,11 +619,11 @@ void NOINLINE gemmkernel_4x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_5x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -818,11 +819,11 @@ void NOINLINE gemmkernel_5x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_6x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters

--- a/src/FbgemmFP16UKernelsAvx512.cc
+++ b/src/FbgemmFP16UKernelsAvx512.cc
@@ -5,16 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include "./FbgemmFP16UKernelsAvx512.h"
+#include "./InlineAsmDefines.h"
 
 namespace fbgemm {
 
 void NOINLINE gemmkernel_1x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -132,11 +133,11 @@ void NOINLINE gemmkernel_1x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_2x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -275,11 +276,11 @@ void NOINLINE gemmkernel_2x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_3x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -437,11 +438,11 @@ void NOINLINE gemmkernel_3x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_4x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -618,11 +619,11 @@ void NOINLINE gemmkernel_4x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_5x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -818,11 +819,11 @@ void NOINLINE gemmkernel_5x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_6x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -1037,11 +1038,11 @@ void NOINLINE gemmkernel_6x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_7x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -1275,11 +1276,11 @@ void NOINLINE gemmkernel_7x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_8x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -1532,11 +1533,11 @@ void NOINLINE gemmkernel_8x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_9x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -1808,11 +1809,11 @@ void NOINLINE gemmkernel_9x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_10x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -2103,11 +2104,11 @@ void NOINLINE gemmkernel_10x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_11x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -2417,11 +2418,11 @@ void NOINLINE gemmkernel_11x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_12x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -2750,11 +2751,11 @@ void NOINLINE gemmkernel_12x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_13x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -3102,11 +3103,11 @@ void NOINLINE gemmkernel_13x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_14x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters

--- a/src/FbgemmFP16UKernelsAvx512_256.cc
+++ b/src/FbgemmFP16UKernelsAvx512_256.cc
@@ -5,16 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include "./FbgemmFP16UKernelsAvx512_256.h"
+#include "./InlineAsmDefines.h"
 
 namespace fbgemm {
 
 void NOINLINE gemmkernel_7x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -248,11 +249,11 @@ void NOINLINE gemmkernel_7x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_8x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -505,11 +506,11 @@ void NOINLINE gemmkernel_8x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_9x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -781,11 +782,11 @@ void NOINLINE gemmkernel_9x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_10x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -1076,11 +1077,11 @@ void NOINLINE gemmkernel_10x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_11x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -1390,11 +1391,11 @@ void NOINLINE gemmkernel_11x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_12x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -1723,11 +1724,11 @@ void NOINLINE gemmkernel_12x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_13x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters
@@ -2075,11 +2076,11 @@ void NOINLINE gemmkernel_13x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 void NOINLINE gemmkernel_14x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
   asm volatile(
-#if !defined(__clang__) || __clang_major__ >= 14
-      "mov r14, %[gp]\t\n"
-#else
+#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
       "mov %[gp], %%r14\t\n"
       ".intel_syntax noprefix\t\n"
+#else
+      "mov r14, %[gp]\t\n"
 #endif
 
       // Copy parameters

--- a/src/InlineAsmDefines.h
+++ b/src/InlineAsmDefines.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// We need to do a hack in inline assembly in some clang versions where we have
+// to do `.intel_syntax noprefix`. This was fixed in clang in
+// https://reviews.llvm.org/D113707, which made it into clang-14, but not in
+// Apple's clang-14 that ships with Xcode 14.
+#if defined(__clang__)
+
+#if (                                                                      \
+    defined(__apple_build_version__) ||                                    \
+    (defined(__has_builtin) && __has_builtin(__builtin_pika_xxhash64))) && \
+    (__clang_major__ < 15)
+#define FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK 1
+#elif (__clang_major__ < 14)
+#define FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK 1
+#endif
+
+#endif // defined(__clang__)
+
+#ifndef FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK
+#define FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK 0
+#endif

--- a/src/codegen_fp16fp32.cc
+++ b/src/codegen_fp16fp32.cc
@@ -223,7 +223,8 @@ int main(int argc, const char* argv[]) {
       ofstream srcfile;
       srcfile.open(isa_file_name + ".cc");
       srcfile << license;
-      srcfile << "#include \"./" + isa_file_name + ".h\"\n\n";
+      srcfile << "#include \"./" + isa_file_name + ".h\"\n";
+      srcfile << "#include \"./InlineAsmDefines.h\"\n\n";
       srcfile << "namespace fbgemm {\n\n";
       if (iaca) {
         srcfile << "#include \"iacaMarks.h\"\n";
@@ -393,12 +394,11 @@ int main(int argc, const char* argv[]) {
 
         srcfile << "  asm volatile(\n";
 
-        srcfile << "#if !defined(__clang__) || __clang_major__ >= 14"
-                << "\n";
-        addi(srcfile, "mov r14, %[gp]");
-        srcfile << "#else\n";
+        srcfile << "#if FBGEMM_USE_CLANG_INTEL_SYNTAX_ASM_HACK\n";
         addi(srcfile, "mov %[gp], %%r14");
         addi(srcfile, ".intel_syntax noprefix");
+        srcfile << "#else\n";
+        addi(srcfile, "mov r14, %[gp]");
         srcfile << "#endif\n";
 
         srcfile << "\n";


### PR DESCRIPTION
Summary:
There was a change made to remove the workaround for clang inline assembly for clang-14, but unfortunately the fix upstream in clang-14 didn't make it to the clang-14 that ships with Xcode 14. So we need to not apply that change for Apple clang builds. We'll also preempt here that the fix does make it to Apple's clang-15.

At the same time this diff moves out the preprocessor macro to a separate include file to avoid pasting this same code everywhere.

Differential Revision: D38947852

