### PR TITLE
Back out "proper unrolling for 1x2 avx256 kernel"

### DIFF
--- a/src/FbgemmFP16UKernelsAvx2.cc
+++ b/src/FbgemmFP16UKernelsAvx2.cc
@@ -43,14 +43,6 @@ void NOINLINE gemmkernel_1x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "xor ebx, ebx\t\n"
       "loop_outter%=:\t\n"
       "mov r14, r8\t\n"
-
-      "vxorps ymm5, ymm5, ymm5\n\t"
-      "vxorps ymm6, ymm6, ymm6\n\t"
-      "vxorps ymm7, ymm7, ymm7\n\t"
-      "vxorps ymm8, ymm8, ymm8\n\t"
-      "vxorps ymm9, ymm9, ymm9\n\t"
-      "vxorps ymm10, ymm10, ymm10\n\t"
-
       "vbroadcastss ymm15,DWORD PTR [r15]\t\n"
       "vcvtph2ps ymm3,XMMWORD PTR [r10 + 0]\t\n"
       "vcvtph2ps ymm4,XMMWORD PTR [r10 + 16]\t\n"
@@ -69,7 +61,7 @@ void NOINLINE gemmkernel_1x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "vfmadd231ps ymm0,ymm3,ymm2\t\n"
       "vfmadd231ps ymm1,ymm4,ymm2\t\n"
       "test r14,r14\t\n"
-      "jnz loop_inner_start%=\t\n"
+      "jnz next_inner%=\t\n"
       "add r10,32\t\n"
       "jmp dump_C%=\t\n"
 
@@ -83,16 +75,9 @@ void NOINLINE gemmkernel_1x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "vmulps ymm0,ymm3,ymm2\t\n"
       "vmulps ymm1,ymm4,ymm2\t\n"
       "test r14,r14\t\n"
-      "jnz loop_inner_start%=\t\n"
+      "jnz next_inner%=\t\n"
       "add r10,32\t\n"
       "jmp dump_C%=\t\n"
-
-      "loop_inner_start%=:\t\n"
-      "add r9,4\t\n"
-      "add r10,32\t\n"
-      "dec r14\t\n"
-
-      "jz loop_inner_end%=\t\n"
 
       "loop_inner%=:\t\n"
 
@@ -103,35 +88,11 @@ void NOINLINE gemmkernel_1x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "vfmadd231ps ymm0,ymm3,ymm2\t\n"
       "vfmadd231ps ymm1,ymm4,ymm2\t\n"
 
-      "vmovaps ymm3,ymm15\t\n"
-      "vcvtph2ps ymm4,XMMWORD PTR [r10 + 48]\t\n"
-      "vcvtph2ps ymm15,XMMWORD PTR [r10 + 64]\t\n"
-      "vbroadcastss ymm2,DWORD PTR [r9+4]\t\n"
-      "vfmadd231ps ymm5,ymm3,ymm2\t\n"
-      "vfmadd231ps ymm6,ymm4,ymm2\t\n"
-
-      "vmovaps ymm3,ymm15\t\n"
-      "vcvtph2ps ymm4,XMMWORD PTR [r10 + 80]\t\n"
-      "vcvtph2ps ymm15,XMMWORD PTR [r10 + 96]\t\n"
-      "vbroadcastss ymm2,DWORD PTR [r9+8]\t\n"
-      "vfmadd231ps ymm7,ymm3,ymm2\t\n"
-      "vfmadd231ps ymm8,ymm4,ymm2\t\n"
-
-      "vmovaps ymm3,ymm15\t\n"
-      "vcvtph2ps ymm4,XMMWORD PTR [r10 + 112]\t\n"
-      "vcvtph2ps ymm15,XMMWORD PTR [r10 + 128]\t\n"
-      "vbroadcastss ymm2,DWORD PTR [r9+12]\t\n"
-      "vfmadd231ps ymm9,ymm3,ymm2\t\n"
-      "vfmadd231ps ymm10,ymm4,ymm2\t\n"
-
       "next_inner%=:\t\n"
-      "add r9,16\t\n"
-      "add r10,128\t\n"
-      "sub r14,4\t\n"
-
-      "cmp r14, 4\t\n"
-      "jge loop_inner%=\t\n"
-      "loop_inner_end%=:\t\n"
+      "add r9,4\t\n"
+      "add r10,32\t\n"
+      "dec r14\t\n"
+      "jnz loop_inner%=\t\n"
 
       "vmovaps ymm3,ymm15\t\n"
       "vcvtph2ps ymm4,XMMWORD PTR [r10 + 16]\t\n"
@@ -140,22 +101,6 @@ void NOINLINE gemmkernel_1x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "vfmadd231ps ymm1,ymm4,ymm2\t\n"
       "add r9,4\t\n"
       "add r10,32\t\n"
-
-      "cmp r14, 0\t\n"
-      "jz loop_tail%=\t\n"
-
-      "dec r14\t\n"
-      "vcvtph2ps ymm15,XMMWORD PTR [r10]\t\n"
-      "jmp loop_inner_end%=\t\n"
-
-      "loop_tail%=:\t\n"
-      "vaddps ymm0, ymm0, ymm5\n\t"
-      "vaddps ymm0, ymm0, ymm7\n\t"
-      "vaddps ymm0, ymm0, ymm9\n\t"
-      "vaddps ymm1, ymm1, ymm6\n\t"
-      "vaddps ymm1, ymm1, ymm8\n\t"
-      "vaddps ymm1, ymm1, ymm10\n\t"
-
       // Dump C
       "dump_C%=:\t\n"
       "vmovups ymmword PTR [r12 + 0], ymm0\t\n"
@@ -280,40 +225,10 @@ void NOINLINE gemmkernel_2x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
       "vfmadd231ps ymm2,ymm5,ymm4\t\n"
       "vfmadd231ps ymm3,ymm6,ymm4\t\n"
 
-      "vmovaps ymm5,ymm15\t\n"
-      "vcvtph2ps ymm6,XMMWORD PTR [r10 + 48]\t\n"
-      "vcvtph2ps ymm15,XMMWORD PTR [r10 + 64]\t\n"
-      "vbroadcastss ymm4,DWORD PTR [r9+8]\t\n"
-      "vfmadd231ps ymm0,ymm5,ymm4\t\n"
-      "vfmadd231ps ymm1,ymm6,ymm4\t\n"
-      "vbroadcastss ymm4,DWORD PTR [r9+12]\t\n"
-      "vfmadd231ps ymm2,ymm5,ymm4\t\n"
-      "vfmadd231ps ymm3,ymm6,ymm4\t\n"
-
-      "vmovaps ymm5,ymm15\t\n"
-      "vcvtph2ps ymm6,XMMWORD PTR [r10 + 80]\t\n"
-      "vcvtph2ps ymm15,XMMWORD PTR [r10 + 96]\t\n"
-      "vbroadcastss ymm4,DWORD PTR [r9+16]\t\n"
-      "vfmadd231ps ymm0,ymm5,ymm4\t\n"
-      "vfmadd231ps ymm1,ymm6,ymm4\t\n"
-      "vbroadcastss ymm4,DWORD PTR [r9+20]\t\n"
-      "vfmadd231ps ymm2,ymm5,ymm4\t\n"
-      "vfmadd231ps ymm3,ymm6,ymm4\t\n"
-
-      "vmovaps ymm5,ymm15\t\n"
-      "vcvtph2ps ymm6,XMMWORD PTR [r10 + 112]\t\n"
-      "vcvtph2ps ymm15,XMMWORD PTR [r10 + 128]\t\n"
-      "vbroadcastss ymm4,DWORD PTR [r9+24]\t\n"
-      "vfmadd231ps ymm0,ymm5,ymm4\t\n"
-      "vfmadd231ps ymm1,ymm6,ymm4\t\n"
-      "vbroadcastss ymm4,DWORD PTR [r9+28]\t\n"
-      "vfmadd231ps ymm2,ymm5,ymm4\t\n"
-      "vfmadd231ps ymm3,ymm6,ymm4\t\n"
-
       "next_inner%=:\t\n"
-      "add r9,32\t\n"
-      "add r10,128\t\n"
-      "sub r14,4\t\n"
+      "add r9,8\t\n"
+      "add r10,32\t\n"
+      "dec r14\t\n"
       "jnz loop_inner%=\t\n"
 
       "vmovaps ymm5,ymm15\t\n"


### PR DESCRIPTION
Summary:
Original commit changeset: 54d9421ae68d

Original Phabricator Diff: D38933136 (https://github.com/pytorch/FBGEMM/commit/6d950a21813e498b39faab5df593a4e7d60f32ec)

Reviewed By: jiyuanzFB

Differential Revision: D38968429

