### PR TITLE
fix index overflow for FindMinMax and QuantizeAvx2

### DIFF
--- a/include/fbgemm/QuantUtilsAvx2.h
+++ b/include/fbgemm/QuantUtilsAvx2.h
@@ -44,7 +44,7 @@ template <typename T = std::uint8_t, bool LEGACY = true>
 void QuantizeAvx2(
     const float* src,
     T* dst,
-    int len,
+    int64_t len,
     const TensorQuantizationParams& qparams);
 
 template <typename T = std::uint8_t>
@@ -63,7 +63,7 @@ uint32_t FBGEMM_API Xor128(void);
 /**
  * @brief Find the min and max value in a float matrix.
  */
-void FBGEMM_API FindMinMax(const float* m, float* min, float* max, int len);
+void FBGEMM_API FindMinMax(const float* m, float* min, float* max, int64_t len);
 
 void RequantizeFixedPointAvx2(
     const std::int32_t* src,

--- a/src/QuantUtilsAvx2.cc
+++ b/src/QuantUtilsAvx2.cc
@@ -29,7 +29,7 @@ template <typename T, bool LEGACY>
 void QuantizeAvx2(
     const float* src,
     T* dst,
-    int len,
+    int64_t len,
     const TensorQuantizationParams& qparams) {
 #if defined(__AVX2__) && (defined(__FMA__) || defined(_MSC_VER))
   constexpr int VLEN = 8;
@@ -89,7 +89,7 @@ void QuantizeAvx2(
 
   // Handle remainder using mask instructions so that
   // the main loop and remainder loop have the same behavior
-  int rem = len - i;
+  int64_t rem = len - i;
   if (rem > 0) {
     __m256i mask_v = _mm256_load_si256(reinterpret_cast<const __m256i*>(
         internal::avx2_ps_or_epi32_masks[rem]));
@@ -148,7 +148,7 @@ uint32_t Xor128(void) {
   template void QuantizeAvx2<T, LEGACY>(   \
       const float* src,                    \
       T* dst,                              \
-      int len,                             \
+      int64_t len,                             \
       const TensorQuantizationParams& qparams);
 SPECIALIZE_QUANTIZEAVX2(uint8_t, true)
 SPECIALIZE_QUANTIZEAVX2(int8_t, true)
@@ -277,7 +277,7 @@ SPECIALIZE_FUSEDDQAVX2(int8_t)
 
 #undef SPECIALIZE_FUSEDDQAVX2
 
-void FindMinMax(const float* a, float* min, float* max, int len) {
+void FindMinMax(const float* a, float* min, float* max, int64_t len) {
   if (len <= 0) {
     *min = 0.0f;
     *max = 0.0f;
@@ -285,7 +285,7 @@ void FindMinMax(const float* a, float* min, float* max, int len) {
   }
 
   float temp_min = *a, temp_max = *a;
-  int i = 0;
+  int64_t i = 0;
 
 #ifdef __AVX__
   __m256 min_v = _mm256_set1_ps(*a), max_v = _mm256_set1_ps(*a);


### PR DESCRIPTION
There will have a data overflow for int type when input len > 2,147,483,647, PyTorch side has reported an issue which using FBGEMM Quantize, see https://github.com/pytorch/pytorch/issues/80501, the user example's input len is 5,117,410,688,  but FBGEMM side use **int** to represent the input len, there will get a wrong number for single thread case. 

This PR just fixed those two **Quantize** and **FindMinMax** API which are used in PyTorch side, there may have other functions which need to be updated using high-precison dtype.