### PR TITLE
support jagged tensor with no inner dense dim

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_cpu.cpp
@@ -388,7 +388,11 @@ at::Tensor jagged_to_padded_dense_forward(
   at::DimVector padded_values_shape({offsets[0].size(0) - 1});
   padded_values_shape.insert(
       padded_values_shape.end(), max_lengths.begin(), max_lengths.end());
-  if (values.dim() > 1) {
+
+  // Canonicalize padded_values by unsqueeze the last dim if the inner dense
+  // dimension is 1 and folded.
+  const bool D_folded = values.dim() == 1;
+  if (!D_folded) {
     padded_values_shape.push_back(values.size(-1));
   }
   Tensor padded_values = at::empty(padded_values_shape, values.options());
@@ -398,7 +402,7 @@ at::Tensor jagged_to_padded_dense_forward(
     return {padded_values};
   }
   Tensor padded_values_view =
-      values.dim() == 1 ? padded_values.unsqueeze(-1) : padded_values;
+      D_folded ? padded_values.unsqueeze(-1) : padded_values;
 
   AT_DISPATCH_ALL_TYPES_AND2(
       at::ScalarType::Half,
@@ -424,7 +428,13 @@ at::Tensor jagged_to_padded_dense_backward(
     const int64_t total_L) {
   auto grad_padded_values = grad_output;
 
-  int32_t D = grad_padded_values.size(-1);
+  // Canonicalize padded_values by unsqueeze the last dim if the inner dense
+  // dimension is 1 and folded.
+  const bool D_folded =
+      static_cast<size_t>(grad_padded_values.dim()) == offsets.size() + 1;
+  Tensor grad_padded_values_view =
+      D_folded ? grad_padded_values.unsqueeze(-1) : grad_padded_values;
+  int32_t D = grad_padded_values_view.size(-1);
   // Initialize with zeros so output will be zero for the portion truncated
   // in forward.
   auto grad_values = at::zeros({total_L, D}, grad_padded_values.options());
@@ -438,12 +448,12 @@ at::Tensor jagged_to_padded_dense_backward(
         jagged_dense_elementwise_jagged_output_<scalar_t>(
             grad_values, // dummy not used in the lambda function
             {offsets},
-            grad_padded_values,
+            grad_padded_values_view,
             grad_values,
             [](scalar_t /*unused*/, scalar_t y) -> scalar_t { return y; });
       });
 
-  return grad_values;
+  return D_folded ? grad_values.squeeze(-1) : grad_values;
 }
 
 Tensor dense_to_jagged_forward(


### PR DESCRIPTION
Summary:
jagged_to_padded_dense supports jagged tensor with inner dense dim is 1 and folded like the following example, but producing the error ``x_offsets.size(), 1 != num_jagged_dim, 0`` in backward.

x_values = [5, 3, 7, 1]
x_offsets = [0, 1, 4]
max_length = 3
->
x_padded = [[5, 0, 0], [3, 7, 1]]

Differential Revision: D39121072

