### PR TITLE
add unit test for weighted pruned embedding

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
@@ -256,7 +256,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   // GPU version of pruned_hashmap needs to use CPU version of
   // pruned_hashmap_insert
   m.def(
-      "pruned_hashmap_insert(Tensor indices, Tensor dense_indices, Tensor offsets, Tensor hash_table, Tensor hash_table_offsets) -> ()");
+      "pruned_hashmap_insert(Tensor indices, Tensor dense_indices, Tensor offsets, Tensor(a!) hash_table, Tensor hash_table_offsets) -> ()");
   DISPATCH_TO_CPU(
       "pruned_hashmap_insert", pruned_hashmap_insert_unweighted_cpu);
 

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -2438,8 +2438,13 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
                     indices, dense_indices, offsets, T
                 )
             else:
+                # pruned_hashmap_insert only has cpu implementation: Move dense_indices to CPU
                 torch.ops.fbgemm.pruned_hashmap_insert(
-                    indices, dense_indices, offsets, hash_table, hash_table_offsets
+                    indices,
+                    dense_indices.cpu(),
+                    offsets,
+                    hash_table,
+                    hash_table_offsets,
                 )
                 self.index_remapping_hash_table = hash_table.to(self.current_device)
                 self.index_remapping_hash_table_offsets = hash_table_offsets.to(


### PR DESCRIPTION
Summary: The current test_nbit_forward test does not test pruned embeddingbag case, that is why the issue in T120864673 is not being captured. In this diff, we append the pruning to the cpu test file.

Differential Revision: D36986058

