### PR TITLE
working version of fbgemm gpu documentation

### DIFF
--- a/fbgemm_gpu/docs/requirements.txt
+++ b/fbgemm_gpu/docs/requirements.txt
@@ -10,3 +10,4 @@ docutils==0.16
 bs4
 lxml
 six
+fbgemm-gpu-cpu

--- a/fbgemm_gpu/docs/source/conf.py
+++ b/fbgemm_gpu/docs/source/conf.py
@@ -19,7 +19,16 @@ import sys
 
 import pytorch_sphinx_theme
 
-sys.path.insert(0, os.path.abspath("../.."))
+for dir_i in os.listdir("../.."):
+    if dir_i == "fbgemm_gpu":
+        continue
+    possible_dir = os.path.join("../..", dir_i)
+    if os.path.isdir(possible_dir):
+        sys.path.insert(0, possible_dir)
+
+sys.path.insert(0, "../../fbgemm_gpu/docs")
+import _fbgemm_gpu_docs
+
 # Doxygen
 subprocess.call("doxygen Doxyfile.in", shell=True)
 

--- a/fbgemm_gpu/docs/source/python-api/index.rst
+++ b/fbgemm_gpu/docs/source/python-api/index.rst
@@ -3,9 +3,35 @@ fbgemm_gpu
 
 .. automodule:: fbgemm_gpu
 
-fbgemm_gpu.batched_unary_embeddings_ops
-=======================================
 
-.. automodule:: fbgemm_gpu.batched_unary_embeddings_ops
-   :members:
-   :show-inheritance:
+.. autofunction:: torch.ops.fbgemm.jagged_2d_to_dense
+
+
+.. autofunction:: torch.ops.fbgemm.jagged_1d_to_dense
+
+
+.. autofunction:: torch.ops.fbgemm.dense_to_jagged
+
+
+.. autofunction:: torch.ops.fbgemm.jagged_to_padded_dense
+
+
+.. autofunction:: torch.ops.fbgemm.jagged_dense_elementwise_add
+
+
+.. autofunction:: torch.ops.fbgemm.jagged_dense_elementwise_add_jagged_output
+
+
+.. autofunction:: torch.ops.fbgemm.jagged_dense_dense_elementwise_add_jagged_output
+
+
+.. autofunction:: torch.ops.fbgemm.jagged_dense_elementwise_mul
+
+
+.. autofunction:: torch.ops.fbgemm.batched_dense_vec_jagged_2d_mul
+
+
+.. autofunction:: torch.ops.fbgemm.stacked_jagged_1d_to_dense
+
+
+.. autofunction:: torch.ops.fbgemm.stacked_jagged_2d_to_dense

--- a/fbgemm_gpu/fbgemm_gpu/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/__init__.py
@@ -17,3 +17,5 @@ except Exception as e:
 # __init__.py is only used in OSS
 # Use existence to check if fbgemm_gpu_py.so has already been loaded
 open_source: bool = True
+
+from .docs import _fbgemm_gpu_docs

--- a/fbgemm_gpu/fbgemm_gpu/docs/_fbgemm_gpu_docs.py
+++ b/fbgemm_gpu/fbgemm_gpu/docs/_fbgemm_gpu_docs.py
@@ -1,0 +1,106 @@
+import fbgemm_gpu
+import torch
+
+
+def add_docs(method, docstr):
+    method.__doc__ = docstr
+
+
+add_docs(
+    torch.ops.fbgemm.jagged_2d_to_dense,
+    """Sample doc string example.
+
+    Args:
+        Obj
+    """,
+)
+
+
+add_docs(
+    torch.ops.fbgemm.jagged_1d_to_dense,
+    """Args:
+                {input}
+            Keyword args:
+                {out}""",
+)
+
+
+add_docs(
+    torch.ops.fbgemm.dense_to_jagged,
+    """Args:
+                {input}
+            Keyword args:
+                {out}""",
+)
+
+
+add_docs(
+    torch.ops.fbgemm.jagged_to_padded_dense,
+    """Args:
+                {input}
+            Keyword args:
+                {out}""",
+)
+
+
+add_docs(
+    torch.ops.fbgemm.jagged_dense_elementwise_add,
+    """Args:
+                {input}
+            Keyword args:
+                {out}""",
+)
+
+
+add_docs(
+    torch.ops.fbgemm.jagged_dense_elementwise_add_jagged_output,
+    """Args:
+                {input}
+            Keyword args:
+                {out}""",
+)
+
+
+add_docs(
+    torch.ops.fbgemm.jagged_dense_dense_elementwise_add_jagged_output,
+    """Args:
+                {input}
+            Keyword args:
+                {out}""",
+)
+
+
+add_docs(
+    torch.ops.fbgemm.jagged_dense_elementwise_mul,
+    """Args:
+                {input}
+            Keyword args:
+                {out}""",
+)
+
+
+add_docs(
+    torch.ops.fbgemm.batched_dense_vec_jagged_2d_mul,
+    """Args:
+                {input}
+            Keyword args:
+                {out}""",
+)
+
+
+add_docs(
+    torch.ops.fbgemm.stacked_jagged_1d_to_dense,
+    """Args:
+                {input}
+            Keyword args:
+                {out}""",
+)
+
+
+add_docs(
+    torch.ops.fbgemm.stacked_jagged_2d_to_dense,
+    """Args:
+                {input}
+            Keyword args:
+                {out}""",
+)


### PR DESCRIPTION
In the pull request, I am committing changes to add documentation to fbgemm_gpu module. 

-         modified:   fbgemm_gpu/docs/source/python-api/index.rst
-         modified:   fbgemm_gpu/fbgemm_gpu/__init__.py
-         added: fbgemm_gpu/fbgemm_gpu/_fbgemm_gpu_docs.py