### PR TITLE
fix FBGEMM compilation for AMD GPUs

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_template.cu
@@ -247,9 +247,11 @@ __global__ void {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if noba
     }
 
     constexpr int VEC_WIDTH = 4;
+#ifdef FBGEMM_USE_SUBWARP_SHUFFLE
     const unsigned int shfl_sync_mask =
         ((1L << kThreadGroupSize) - 1) <<
         (threadIdx.y % (kWarpSize / kThreadGroupSize) * kThreadGroupSize);
+#endif
 
     {% if not nobag %}
     Vec4T<cache_t> accumulators[kMaxVecsPerThread];


### PR DESCRIPTION
Summary: This PR fixes FBGEMM compilation for AMD GPUs. This PR fixes FBGEMM compilation for AMD GPUs. Because `kThreadGroupSize` is 64 for AMD GPUs, we cannot compile `shfl_sync_mask` correctly (1 << 64 causes an overflow).


Differential Revision: D39452453

