### PR TITLE
make _mm_clflush x86 only

### DIFF
--- a/bench/BenchUtils.h
+++ b/bench/BenchUtils.h
@@ -68,7 +68,13 @@ NOINLINE float cache_evict(const T& vec) {
 #ifndef _MSC_VER
     asm volatile("" ::: "memory");
 #endif
+#if defined(__x86_64__) || defined(__i386__) || \
+    (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86)))
     _mm_clflush(&data[i]);
+#else
+    __builtin___clear_cache(
+        (char*)&data[i], (char*)(&data[i] + CACHE_LINE_SIZE));
+#endif
   }
 
   return dummy;


### PR DESCRIPTION
Summary: https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/caches-and-self-modifying-code

Differential Revision: D39420206

