### PR TITLE
Profile only bwd instead of fwd/bwd in TBE benchmark

### DIFF
--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -286,12 +286,14 @@ def device(  # noqa C901
             offsets.long(),
             per_sample_weights,
             feature_requires_grad=feature_requires_grad,
-        ).backward(grad_output),
+        ),
         flush_gpu_cache_size_mb=flush_gpu_cache_size_mb,
+        bwd_only=True,
+        grad=grad_output,
     )
     logging.info(
-        f"ForwardBackward, B: {B}, E: {E}, T: {T}, D: {D}, L: {L}, "
-        f"BW: {3 * read_write_bytes / time_per_iter / 1.0e9: .2f} GB/s, "
+        f"Backward, B: {B}, E: {E}, T: {T}, D: {D}, L: {L}, "
+        f"BW: {2 * read_write_bytes / time_per_iter / 1.0e9: .2f} GB/s, "
         f"T: {time_per_iter * 1.0e6:.0f}us"
     )
 
@@ -669,12 +671,14 @@ def cache(  # noqa C901
         requests,
         lambda indices, offsets, per_sample_weights: emb_nc(
             indices.long(), offsets.long(), per_sample_weights
-        ).backward(grad_output),
+        ),
         flush_gpu_cache_size_mb=flush_gpu_cache_size_mb,
+        bwd_only=True,
+        grad=grad_output,
     )
     logging.info(
-        f"ForwardBackward (UVM), B: {B}, E: {E}, T: {T}, D: {D}, L: {L}, "
-        f"BW: {3 * param_size_multiplier * B * sum(Ds) * L / time_per_iter / 1.0e9: .2f} GB/s, "
+        f"Backward (UVM), B: {B}, E: {E}, T: {T}, D: {D}, L: {L}, "
+        f"BW: {2 * param_size_multiplier * B * sum(Ds) * L / time_per_iter / 1.0e9: .2f} GB/s, "
         f"T: {time_per_iter * 1.0e6:.0f}us"
     )
 


### PR DESCRIPTION
Summary:
Before this diff, TBE benchmark profile and report both forward and
backward performance together for backward profiling.  This diff
updates TBE benchmark to profile only backward.

Differential Revision: D39491994

