### PR TITLE
Use int32_t for kThreadGroupSize in warp_per_row

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_template.cu
@@ -518,7 +518,7 @@ template <
     typename grad_t,
     typename cache_t,
     size_t kMaxVecsPerThread,
-    size_t kThreadGroupSize = kWarpSize>
+    int32_t kThreadGroupSize = kWarpSize>
 __global__
 __launch_bounds__(kBackwardMaxThreads)
 void


### PR DESCRIPTION
Summary:
Use int32_t for kThreadGroupSize instead of size_t.  Using size_t
causes a slowdown in some cases.

Differential Revision: D39568569

