### PR TITLE
Use int32_t for kThreadGroupSize in cta_per_row

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_template.cu
@@ -105,7 +105,7 @@ template <
     typename grad_t,
     typename cache_t,
     size_t kMaxVecsPerThread,
-    size_t kThreadGroupSize = kWarpSize>
+    int32_t kThreadGroupSize = kWarpSize>
 __global__ __launch_bounds__(kMaxThreads) void
 split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_kernel_cta_per_row_1(
     const at::PackedTensorAccessor32<grad_t, 2, at::RestrictPtrTraits> grad_output,


### PR DESCRIPTION
Summary:
Use int32_t for kThreadGroupSize instead of size_t in TBE bwd
warp_per_row.  Using size_t causes a slowdown in some cases.

Differential Revision: D39637900

