### PR TITLE
Add embedding weights FP16 supports in dense TBE

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -1350,12 +1350,16 @@ class DenseTableBatchedEmbeddingBagsCodegen(nn.Module):
         self,
         embedding_specs: List[Tuple[int, int]],  # tuple of (rows, dims)
         feature_table_map: Optional[List[int]] = None,  # [T]
+        weights_precision: SparseType = SparseType.FP32,
         pooling_mode: PoolingMode = PoolingMode.SUM,
         use_cpu: bool = False,
     ) -> None:  # noqa C901  # tuple of (rows, dims,)
         super(DenseTableBatchedEmbeddingBagsCodegen, self).__init__()
 
+        self.weights_precision = weights_precision
         self.pooling_mode = pooling_mode
+
+        table_embedding_dtype = weights_precision.as_dtype()
 
         self.use_cpu = use_cpu
         # pyre-fixme[8]: Attribute has type `device`; used as `Union[int, device]`.
@@ -1406,6 +1410,7 @@ class DenseTableBatchedEmbeddingBagsCodegen(nn.Module):
             torch.randn(
                 weights_offsets[-1],
                 device=self.current_device,
+                dtype=table_embedding_dtype,
             )
         )
         for feature in range(T):

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -1292,9 +1292,8 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             embedding_specs=[(E, D) for (E, D) in zip(Es, Ds)],
             pooling_mode=pooling_mode,
             use_cpu=use_cpu,
+            weights_precision=weights_precision,
         )
-        if weights_precision == SparseType.FP16 and not use_cpu:
-            cc = cc.half()
         if do_pooling:
             # NOTE: test TorchScript-compatible!
             cc = torch.jit.script(cc)


### PR DESCRIPTION
Summary: For data parallelism dense TBE evaluation. Reduce memory pressure and avoid OOM.

Differential Revision: D39712548

