### PR TITLE
[CI][README] Update the PyTorch installation method

### DIFF
--- a/.github/workflows/fbgemm_nightly_build.yml
+++ b/.github/workflows/fbgemm_nightly_build.yml
@@ -40,24 +40,19 @@ jobs:
       with:
         submodules: true
     # Update references
-    - name: Git Sumbodule Update
+    - name: Git Submodule Update
       run: |
         cd fbgemm_gpu/
         git submodule sync
         git submodule update --init --recursive
-    - name: Update pip
-      run: |
-        sudo yum update -y
-        sudo yum -y install git python3-pip
-        sudo pip3 install --upgrade pip
     - name: Setup conda
       run: |
         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
         bash ~/miniconda.sh -b -p $HOME/miniconda -u
     - name: Setup PATH with conda
       run: |
-        echo "/home/ec2-user/miniconda/bin" >> $GITHUB_PATH
-        echo "CONDA=/home/ec2-user/miniconda" >> $GITHUB_PATH
+        echo "${HOME}/miniconda/bin" >> $GITHUB_PATH
+        echo "CONDA=${HOME}/miniconda" >> $GITHUB_PATH
     - name: Create conda env
       run: |
         conda create --name build_binary python=${{ matrix.python-version }}
@@ -65,33 +60,20 @@ jobs:
     - name: check python version
       run: |
         conda run -n build_binary python --version
-    - name: Install CUDA 11.3
+    - name: Install C/C++ compilers
+      run: |
+        sudo yum install -y gcc gcc-c++
+    - name: Install PyTorch and CUDA
       shell: bash
       run: |
-        sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-        sudo yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
-        sudo yum clean expire-cache
-        sudo yum install -y nvidia-driver-latest-dkms
-        sudo yum install -y cuda-11-3
-        sudo yum install -y cuda-drivers
-        sudo yum install -y libcudnn8-devel
-    - name: setup Path
-      run: |
-        echo /usr/local/cuda-11.3/bin >> $GITHUB_PATH
-        echo /usr/local/bin >> $GITHUB_PATH
-    - name: nvcc check
-      run: |
-        nvcc --version
-    - name: Install PyTorch
-      shell: bash
-      run: |
-        conda run -n build_binary python -m pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
-    - name: Install Dependencies
+        conda install -n build_binary -y pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
+        conda install -n build_binary -y cudnn
+    - name: Install Other Dependencies
       shell: bash
       run: |
         cd fbgemm_gpu/
         conda run -n build_binary python -m pip install -r requirements.txt
-    - name: Test Installation of dependencies
+    - name: Test Installation of Dependencies
       run: |
         cd fbgemm_gpu/
         conda run -n build_binary python -c "import torch.distributed"
@@ -105,8 +87,8 @@ jobs:
     - name: Build FBGEMM_GPU Nightly
       run: |
         cd fbgemm_gpu/
-        rm -r dist || true
-        # buld cuda7.0;8.0 for v100/a100 arch:
+        rm -rf dist
+        # build cuda7.0;8.0 for v100/a100 arch:
         # Couldn't build more cuda arch due to 100 MB binary size limit from
         # pypi website.
         # manylinux1_x86_64 is specified for pypi upload:
@@ -185,16 +167,16 @@ jobs:
         bash ~/miniconda.sh -b -p $HOME/miniconda -u
     - name: setup Path
       run: |
-        echo "/home/ec2-user/miniconda/bin" >> $GITHUB_PATH
-        echo "CONDA=/home/ec2-user/miniconda" >> $GITHUB_PATH
+        echo "$HOME/miniconda/bin" >> $GITHUB_PATH
+        echo "CONDA=$HOME/miniconda" >> $GITHUB_PATH
     - name: create conda env
       run: |
         conda create --name build_binary python=${{ matrix.python-version }}
         conda info
-    - name: check python version no Conda
+    - name: check python version without Conda
       run: |
         python --version
-    - name: check python version
+    - name: check python version with Conda
       run: |
         conda run -n build_binary python --version
     - name: Install CUDA 11.3
@@ -214,11 +196,10 @@ jobs:
     - name: nvcc check
       run: |
         nvcc --version
-    - name: Install PyTorch
+    - name: Install PyTorch using Conda
       shell: bash
       run: |
-        conda run -n build_binary \
-          python -m pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
+        conda install -n build_binary -y pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
     # download wheel from GHA
     - name: Download wheel
       uses: actions/download-artifact@v2

--- a/.github/workflows/fbgemmci.yml
+++ b/.github/workflows/fbgemmci.yml
@@ -78,7 +78,7 @@ jobs:
         cd build_shared
         ctest
 
-  build1:
+  build-windows:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -192,18 +192,20 @@ jobs:
         set -e
         ./bazel test --compilation_mode opt :*
 
+
   build_nvidia_gpu:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-        cuda_version: [11.3, 11.5, 11.6, 11.7]
+        config: [[pip, 11.3], [pip, 11.5], [pip, 11.6], [pip, 11.7], [conda, 11.7]]
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Install CUDA
       shell: bash
+      if: matrix.config[0] == 'pip'
       run: |
         wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
         sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
@@ -214,19 +216,29 @@ jobs:
         sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
         sudo apt-get update
         # "11.5 -> 11-5"
-        cuda_apt_version=$(echo "${{ matrix.cuda_version }}" | sed "s/\./-/")
+        cuda_apt_version=$(echo "${{ matrix.config[1] }}" | sed "s/\./-/")
         sudo apt-get -y install cuda-minimal-build-${cuda_apt_version} cuda-nvrtc-dev-${cuda_apt_version} cuda-nvtx-${cuda_apt_version} cuda-libraries-dev-${cuda_apt_version}
         sudo apt-get -y install libcudnn8-dev
 
     - name: Install dependencies
       shell: bash
       run: |
-        sudo apt-get update
-        sudo apt-get -y install git pip python3-dev
-        sudo pip install cmake scikit-build ninja jinja2 numpy hypothesis --no-input
-        # Install pytorch built with CUDA 11.3 in all cases
-        sudo pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
-
+        if [ x"${{ matrix.config[0] }}" == x"pip" ]; then
+          # pip-based installation
+          sudo apt-get update
+          sudo apt-get -y install git pip python3-dev
+          sudo pip install cmake scikit-build ninja jinja2 numpy hypothesis --no-input
+          # Install pytorch built with CUDA 11.3 in all cases
+          sudo pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
+        else
+          # conda-based installation
+          wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+          bash ~/miniconda.sh -b -p $HOME/miniconda -u
+          eval "$($HOME/miniconda/bin/conda shell.bash hook)"
+          cuda_version="${{ matrix.config[1] }}"
+          conda install -y pytorch pytorch-cuda="$cuda_version" -c pytorch-nightly -c nvidia
+          conda install -y cudnn numpy scikit-build jinja2 ninja cmake hypothesis
+        fi
     - name: Checkout submodules
       shell: bash
       run: |
@@ -238,12 +250,20 @@ jobs:
       shell: bash
       run: |
         cd fbgemm_gpu
-        CUDA_PATH="/usr/local/cuda-${{ matrix.cuda_version }}"
-        sudo CUDACXX="${CUDA_PATH}/bin/nvcc" python setup.py install -DTORCH_CUDA_ARCH_LIST="6.0"
+        if [ x"${{ matrix.config[0] }}" == x"pip" ]; then
+          CUDA_PATH="/usr/local/cuda-${{ matrix.config[1] }}"
+          sudo CUDACXX="${CUDA_PATH}/bin/nvcc" python setup.py install -DTORCH_CUDA_ARCH_LIST="6.0"
+        else
+          eval "$($HOME/miniconda/bin/conda shell.bash hook)"
+          python setup.py install -DTORCH_CUDA_ARCH_LIST="6.0"
+        fi
 
     - name: Test fbgemm_gpu installation
       shell: bash
       run: |
+        if [ x"${{ matrix.config[0] }}" == x"conda" ]; then
+          eval "$($HOME/miniconda/bin/conda shell.bash hook)"
+        fi
         cd fbgemm_gpu
         cd test
         python input_combine_test.py -v
@@ -257,7 +277,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rocm_version: [5.1.1]
+        config: [[pip, 5.1.1]]
 
     steps:
     - name: Free space

--- a/fbgemm_gpu/README.md
+++ b/fbgemm_gpu/README.md
@@ -10,14 +10,14 @@ high-performance CUDA GPU operator library for GPU training and inference.
 The library provides efficient table batched embedding bag,
 data layout transformation, and quantization supports.
 
-Currently tested with CUDA 11.3, 11.5, and 11.6 in CI. In all cases, we test with PyTorch packages which are built with CUDA 11.3.
+Currently tested with CUDA 11.3, 11.5, 11.6, and 11.7 in CI. In all cases, we test with PyTorch packages which are built with CUDA 11.7.
 
-Only Intel/AMD with AVX2 extensions are currently supported.
+Only Intel/AMD CPUs with AVX2 extensions are currently supported.
 
 General build and install instructions are as follows:
 
-Build dependencies: "scikit-build","cmake","ninja","jinja2","torch>0.9","cudatoolkit",
-and for testing: "hypothesis".
+Build dependencies: `scikit-build`, `cmake`, `ninja`, `jinja2`, `torch`, `cudatoolkit`,
+and for testing: `hypothesis`.
 
 ```
 conda install scikit-build jinja2 ninja cmake hypothesis
@@ -28,7 +28,8 @@ below.
 ```
 conda install -c conda-forge cudatoolkit-dev
 ```
- Certain operations require this library to be present. Be sure to provide the path to `libnvidia-ml.so` to
+
+Certain operations require this library to be present. Be sure to provide the path to `libnvidia-ml.so` to
 `--nvml_lib_path` if installing from source (e.g. `python setup.py install --nvml_lib_path path_to_libnvidia-ml.so`).
 
 
@@ -38,13 +39,13 @@ Currently only built with sm70/80 (V100/A100 GPU) wheel supports:
 
 ```
 # Release
-conda install pytorch cudatoolkit=11.3 -c pytorch
+conda install pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
 pip install fbgemm-gpu (release version)
 OR
 pip install fbgemm-gpu-cpu (release version with CPU only)
 
 # Nightly
-conda install pytorch cudatoolkit=11.3 -c pytorch-nightly
+conda install pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
 pip install fbgemm-gpu-nightly (nightly build version)
 OR
 pip install fbgemm-gpu-nightly-cpu (nightly build with CPU only)
@@ -57,7 +58,7 @@ Additional dependencies: currently cuDNN is required to be installed.
 
 ```
 # Requires PyTorch 1.13 or later
-conda install pytorch cudatoolkit=11.3 -c pytorch-nightly
+conda install pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
 git clone --recursive https://github.com/pytorch/FBGEMM.git
 cd FBGEMM/fbgemm_gpu
 # if you are updating an existing checkout
@@ -84,6 +85,7 @@ python setup.py install -DTORCH_CUDA_ARCH_LIST="7.0;8.0"
 cd bench
 python split_table_batched_embeddings_benchmark.py uvm
 ```
+
 ## Issues
 
 Building is CMAKE based and keeps state across install runs.
@@ -94,7 +96,6 @@ and using
 python setup.py clean
 ```
 to remove stale cached state can be helpfull.
-
 
 ## Examples
 
@@ -125,7 +126,7 @@ export CUB_DIR=$PWD/cub-1.10.0
 ```
 
 + ###### PyTorch, Jinja2, scikit-build
-[PyTorch][2], [Jinja2][3] and are scikit-build **required** to build and run the table
+[PyTorch][2], [Jinja2][3] and scikit-build are **required** to build and run the table
 batched embedding bag operator. One thing to note is that the implementation
 of this op relies on the version of PyTorch 1.9 or later.
 
@@ -133,7 +134,7 @@ of this op relies on the version of PyTorch 1.9 or later.
 conda install scikit-build jinja2 ninja cmake
 ```
 
-## Running  FBGEMM_GPU
+## Running FBGEMM_GPU
 
 To run the tests or benchmarks after building FBGEMM_GPU (if tests or benchmarks
 are built), use the following command:


### PR DESCRIPTION
This PR fixes an error in https://github.com/pytorch/FBGEMM/actions/runs/3097186212/jobs/5013587244 by updating the PyTorch installation method.

Particularly, we use `pytorch-cuda` as recommended in the PyTorch page (https://pytorch.org/).
```sh
# Old
conda install pytorch cudatoolkit=11.3 -c pytorch
# New
conda install pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
```

