### PR TITLE
Update API interface and reroute backend for exact_rowwise_adagrad FE when using freq based methods

### DIFF
--- a/fbgemm_gpu/codegen/__init__.template
+++ b/fbgemm_gpu/codegen/__init__.template
@@ -13,7 +13,9 @@ import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_lars_sgd as loo
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_partial_rowwise_adam as lookup_partial_rowwise_adam  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_partial_rowwise_lamb as lookup_partial_rowwise_lamb  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_rowwise_adagrad as lookup_rowwise_adagrad  # noqa: F401
+import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_rowwise_adagrad_with_counter as lookup_rowwise_adagrad_with_counter  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_sgd as lookup_sgd  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_approx_sgd as lookup_approx_sgd  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_approx_rowwise_adagrad as lookup_approx_rowwise_adagrad  # noqa: F401
+import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_approx_rowwise_adagrad_with_counter as lookup_approx_rowwise_adagrad_with_counter  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_rowwise_weighted_adagrad as lookup_rowwise_weighted_adagrad  # noqa: F401

--- a/fbgemm_gpu/codegen/lookup_args.py
+++ b/fbgemm_gpu/codegen/lookup_args.py
@@ -44,6 +44,13 @@ class OptimizerArgs(NamedTuple):
     weight_decay_mode: int
     eta: float
     momentum: float
+    counter_halflife: int
+    adjustment_iter: int
+    adjustment_ub: float
+    learning_rate_mode: int
+    grad_sum_decay: int
+    tail_id_threshold: float
+    is_tail_id_thresh_ratio: int
 
 
 class Momentum(NamedTuple):

--- a/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
@@ -36,8 +36,17 @@ def invoke(
     {% if "momentum2_dev" in args.split_function_arg_names %}
     momentum2: Momentum,
     {% endif %}
+    {% if "prev_iter_dev" in args.split_function_arg_names %}
+    prev_iter: Momentum,
+    {% endif %}
+    {% if "row_counter_dev" in args.split_function_arg_names %}
+    row_counter: Momentum,
+    {% endif %}
     {% if "iter" in args.split_function_arg_names %}
     iter: int,
+    {% endif %}
+    {% if "max_counter" in args.split_function_arg_names %}
+    max_counter: float,
     {% endif %}
 ) -> torch.Tensor:
     if (common_args.host_weights.numel() > 0):
@@ -84,6 +93,27 @@ def invoke(
             {% if "momentum" in args.split_function_arg_names %}
             momentum=optimizer_args.momentum,
             {% endif %}
+            {% if "counter_halflife" in args.split_function_arg_names %}
+            counter_halflife=optimizer_args.counter_halflife,
+            {% endif %}
+            {% if "adjustment_iter" in args.split_function_arg_names %}
+            adjustment_iter=optimizer_args.adjustment_iter,
+            {% endif %}
+            {% if "adjustment_ub" in args.split_function_arg_names %}
+            adjustment_ub=optimizer_args.adjustment_ub,
+            {% endif %}
+            {% if "learning_rate_mode" in args.split_function_arg_names %}
+            learning_rate_mode=optimizer_args.learning_rate_mode,
+            {% endif %}
+            {% if "grad_sum_decay" in args.split_function_arg_names %}
+            grad_sum_decay=optimizer_args.grad_sum_decay,
+            {% endif %}
+            {% if "tail_id_threshold" in args.split_function_arg_names %}
+            tail_id_threshold=optimizer_args.tail_id_threshold,
+            {% endif %}
+            {% if "is_tail_id_thresh_ratio" in args.split_function_arg_names %}
+            is_tail_id_thresh_ratio=optimizer_args.is_tail_id_thresh_ratio,
+            {% endif %}
             # momentum1
             {% if "momentum1_dev" in args.split_function_arg_names %}
             momentum1_host=momentum1.host,
@@ -96,9 +126,25 @@ def invoke(
             momentum2_offsets=momentum2.offsets,
             momentum2_placements=momentum2.placements,
             {% endif %}
+            # prev_iter
+            {% if "prev_iter_dev" in args.split_function_arg_names %}
+            prev_iter_host=prev_iter.host,
+            prev_iter_offsets=prev_iter.offsets,
+            prev_iter_placements=prev_iter.placements,
+            {% endif %}
+            # row_counter
+            {% if "row_counter_dev" in args.split_function_arg_names %}
+            row_counter_host=row_counter.host,
+            row_counter_offsets=row_counter.offsets,
+            row_counter_placements=row_counter.placements,
+            {% endif %}
             # iter
             {% if "iter" in args.split_function_arg_names %}
             iter=iter,
+            {% endif %}
+            # max counter
+            {% if "max_counter" in args.split_function_arg_names %}
+            max_counter=max_counter,
             {% endif %}
         )
     else:
@@ -151,6 +197,27 @@ def invoke(
             {% if "momentum" in args.split_function_arg_names %}
             momentum=optimizer_args.momentum,
             {% endif %}
+            {% if "counter_halflife" in args.split_function_arg_names %}
+            counter_halflife=optimizer_args.counter_halflife,
+            {% endif %}
+            {% if "adjustment_iter" in args.split_function_arg_names %}
+            adjustment_iter=optimizer_args.adjustment_iter,
+            {% endif %}
+            {% if "adjustment_ub" in args.split_function_arg_names %}
+            adjustment_ub=optimizer_args.adjustment_ub,
+            {% endif %}
+            {% if "learning_rate_mode" in args.split_function_arg_names %}
+            learning_rate_mode=optimizer_args.learning_rate_mode,
+            {% endif %}
+            {% if "grad_sum_decay" in args.split_function_arg_names %}
+            grad_sum_decay=optimizer_args.grad_sum_decay,
+            {% endif %}
+            {% if "tail_id_threshold" in args.split_function_arg_names %}
+            tail_id_threshold=optimizer_args.tail_id_threshold,
+            {% endif %}
+            {% if "is_tail_id_thresh_ratio" in args.split_function_arg_names %}
+            is_tail_id_thresh_ratio=optimizer_args.is_tail_id_thresh_ratio,
+            {% endif %}
             # momentum1
             {% if "momentum1_dev" in args.split_function_arg_names %}
             momentum1_dev=momentum1.dev,
@@ -165,9 +232,27 @@ def invoke(
             momentum2_offsets=momentum2.offsets,
             momentum2_placements=momentum2.placements,
             {% endif %}
+            # prev_iter
+            {% if "prev_iter_dev" in args.split_function_arg_names %}
+            prev_iter_dev=prev_iter.dev,
+            prev_iter_uvm=prev_iter.uvm,
+            prev_iter_offsets=prev_iter.offsets,
+            prev_iter_placements=prev_iter.placements,
+            {% endif %}
+            # row_counter
+            {% if "row_counter_dev" in args.split_function_arg_names %}
+            row_counter_dev=row_counter.dev,
+            row_counter_uvm=row_counter.uvm,
+            row_counter_offsets=row_counter.offsets,
+            row_counter_placements=row_counter.placements,
+            {% endif %}
             # iter
             {% if "iter" in args.split_function_arg_names %}
             iter=iter,
+            {% endif %}
+            # max counter
+            {% if "max_counter" in args.split_function_arg_names %}
+            max_counter=max_counter,
             {% endif %}
             output_dtype=common_args.output_dtype,
         )

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -71,6 +71,43 @@ class WeightDecayMode(enum.IntEnum):
     NONE = 0
     L2 = 1
     DECOUPLE = 2
+    COUNTER = 3
+
+
+class CounterWeightDecayMode(enum.IntEnum):
+    NONE = 0
+    L2 = 1
+    DECOUPLE = 2
+
+
+class LearningRateMode(enum.IntEnum):
+    EQUAL = -1
+    TAIL_ID_LR_INCREASE = 0
+    TAIL_ID_LR_DECREASE = 1
+    COUNTER_SGD = 2
+
+
+class GradSumDecay(enum.IntEnum):
+    NO_DECAY = -1
+    CTR_DECAY = 0
+
+
+@dataclass
+class TailIdThreshold:
+    val: float = 0
+    is_ratio: bool = False
+
+
+@dataclass
+class CounterBasedRegularizationDefinition:
+    counter_weight_decay_mode: CounterWeightDecayMode = CounterWeightDecayMode.NONE
+    counter_halflife: int = -1
+    adjustment_iter: int = -1
+    adjustment_ub: float = 1.0
+    learning_rate_mode: LearningRateMode = LearningRateMode.EQUAL
+    grad_sum_decay: GradSumDecay = GradSumDecay.NO_DECAY
+    tail_id_threshold: TailIdThreshold = TailIdThreshold(val=0, is_ratio=False)
+    max_counter_update_freq: int = 1000
 
 
 RecordCacheMetrics: NamedTuple = NamedTuple(
@@ -235,6 +272,9 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         eta: float = 0.001,  # used by LARS-SGD,
         beta1: float = 0.9,  # used by LAMB and ADAM
         beta2: float = 0.999,  # used by LAMB and ADAM
+        counter_based_regularization: Optional[
+            CounterBasedRegularizationDefinition
+        ] = None,  # used by Rowwise Adagrad
         pooling_mode: PoolingMode = PoolingMode.SUM,
         device: Optional[Union[str, int, torch.device]] = None,
         bounds_check_mode: BoundsCheckMode = BoundsCheckMode.WARNING,
@@ -408,6 +448,34 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.stochastic_rounding = stochastic_rounding
         self.optimizer = optimizer
 
+        self.weight_decay_mode = weight_decay_mode
+        if (
+            weight_decay_mode == WeightDecayMode.COUNTER
+            and counter_based_regularization is None
+        ):
+            raise AssertionError(
+                "weight_decay_mode is set to WeightDecayMode.COUNTER but counter_based_regularization is None"
+            )
+
+        self._used_rowwise_adagrad_with_counter: bool = (
+            optimizer in (OptimType.EXACT_ROWWISE_ADAGRAD, OptimType.ROWWISE_ADAGRAD)
+            and weight_decay_mode == WeightDecayMode.COUNTER
+            and counter_based_regularization is not None
+        )
+
+        if counter_based_regularization is None:
+            counter_based_regularization = CounterBasedRegularizationDefinition()
+        self._max_counter_update_freq: int = -1
+        if self._used_rowwise_adagrad_with_counter:
+            self._max_counter_update_freq = (
+                counter_based_regularization.max_counter_update_freq
+            )
+            opt_arg_weight_decay_mode = (
+                counter_based_regularization.counter_weight_decay_mode
+            )
+        else:
+            opt_arg_weight_decay_mode = weight_decay_mode
+
         self.optimizer_args = invokers.lookup_args.OptimizerArgs(
             stochastic_rounding=stochastic_rounding,
             gradient_clipping=gradient_clipping,
@@ -417,9 +485,18 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             beta1=beta1,
             beta2=beta2,
             weight_decay=weight_decay,
-            weight_decay_mode=weight_decay_mode.value,
+            weight_decay_mode=opt_arg_weight_decay_mode.value,
             eta=eta,
             momentum=momentum,
+            counter_halflife=counter_based_regularization.counter_halflife,
+            adjustment_iter=counter_based_regularization.adjustment_iter,
+            adjustment_ub=counter_based_regularization.adjustment_ub,
+            learning_rate_mode=counter_based_regularization.learning_rate_mode.value,
+            grad_sum_decay=counter_based_regularization.grad_sum_decay.value,
+            tail_id_threshold=counter_based_regularization.tail_id_threshold.val,
+            is_tail_id_thresh_ratio=int(
+                counter_based_regularization.tail_id_threshold.is_ratio
+            ),
         )
 
         if optimizer in (
@@ -427,25 +504,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             OptimType.EXACT_SGD,
         ):
             # NOTE: make TorchScript work!
-            self.register_buffer(
-                "momentum1_dev", torch.tensor([0], dtype=torch.int64), persistent=False
-            )
-            self.register_buffer(
-                "momentum1_host", torch.tensor([0], dtype=torch.int64), persistent=False
-            )
-            self.register_buffer(
-                "momentum1_uvm", torch.tensor([0], dtype=torch.int64), persistent=False
-            )
-            self.register_buffer(
-                "momentum1_placements",
-                torch.tensor([0], dtype=torch.int64),
-                persistent=False,
-            )
-            self.register_buffer(
-                "momentum1_offsets",
-                torch.tensor([0], dtype=torch.int64),
-                persistent=False,
-            )
+            self._register_nonpersistent_buffers("momentum1")
         else:
             self._apply_split(
                 construct_split_state(
@@ -484,29 +543,40 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             )
         else:
             # NOTE: make TorchScript work!
-            self.register_buffer(
-                "momentum2_dev",
-                torch.zeros(1, dtype=torch.int64, device=self.current_device),
-                persistent=False,
+            self._register_nonpersistent_buffers("momentum2")
+        if self._used_rowwise_adagrad_with_counter:
+            self._apply_split(
+                construct_split_state(
+                    embedding_specs,
+                    rowwise=True,
+                    cacheable=False,
+                ),
+                prefix="prev_iter",
+                # TODO: ideally we should use int64 to track iter but it failed to compile.
+                # It may be related to low precision training code. Currently using float32
+                # as a workaround while investigating the issue.
+                # pyre-fixme[6]: Expected `Type[Type[torch._dtype]]` for 3rd param
+                #  but got `Type[torch.float32]`.
+                dtype=torch.float32,
             )
-            self.register_buffer(
-                "momentum2_host",
-                torch.zeros(1, dtype=torch.int64, device=self.current_device),
-                persistent=False,
+            self._apply_split(
+                construct_split_state(
+                    embedding_specs,
+                    rowwise=True,
+                    cacheable=False,
+                ),
+                prefix="row_counter",
+                # pyre-fixme[6]: Expected `Type[Type[torch._dtype]]` for 3rd param
+                #  but got `Type[torch.float32]`.
+                dtype=torch.float32,
             )
+            self.register_buffer("max_counter", torch.tensor([1], dtype=torch.float32))
+        else:
+            self._register_nonpersistent_buffers("prev_iter")
+            self._register_nonpersistent_buffers("row_counter")
             self.register_buffer(
-                "momentum2_uvm",
-                torch.zeros(1, dtype=torch.int64, device=self.current_device),
-                persistent=False,
-            )
-            self.register_buffer(
-                "momentum2_placements",
-                torch.zeros(1, dtype=torch.int64, device=self.current_device),
-                persistent=False,
-            )
-            self.register_buffer(
-                "momentum2_offsets",
-                torch.zeros(1, dtype=torch.int64, device=self.current_device),
+                "max_counter",
+                torch.ones(1, dtype=torch.float32, device=self.current_device),
                 persistent=False,
             )
         if optimizer in (
@@ -519,6 +589,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             self.register_buffer(
                 "iter", torch.zeros(1, dtype=torch.int64, device=self.current_device)
             )
+
         else:
             self.register_buffer(
                 "iter",
@@ -572,6 +643,34 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
         self.step = 0
 
+    def _register_nonpersistent_buffers(self, prefix: str) -> None:
+        # NOTE: make TorchScript work!
+        self.register_buffer(
+            f"{prefix}_dev",
+            torch.zeros(1, dtype=torch.int64, device=self.current_device),
+            persistent=False,
+        )
+        self.register_buffer(
+            f"{prefix}_host",
+            torch.zeros(1, dtype=torch.int64, device=self.current_device),
+            persistent=False,
+        )
+        self.register_buffer(
+            f"{prefix}_uvm",
+            torch.zeros(1, dtype=torch.int64, device=self.current_device),
+            persistent=False,
+        )
+        self.register_buffer(
+            f"{prefix}_placements",
+            torch.zeros(1, dtype=torch.int64, device=self.current_device),
+            persistent=False,
+        )
+        self.register_buffer(
+            f"{prefix}_offsets",
+            torch.zeros(1, dtype=torch.int64, device=self.current_device),
+            persistent=False,
+        )
+
     def get_states(self, prefix: str) -> Tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
         if not hasattr(self, f"{prefix}_physical_placements"):
             raise DoesNotHavePrefix()
@@ -590,7 +689,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
     def get_all_states(self) -> List[Tuple[Tensor, Tensor, Tensor, Tensor, Tensor]]:
         all_states = []
-        for prefix in ["weights", "momentum1", "momentum2"]:
+        for prefix in ["weights", "momentum1", "momentum2", "prev_iter", "row_counter"]:
             try:
                 all_states.append(self.get_states(prefix))
             except DoesNotHavePrefix:
@@ -681,10 +780,20 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             return invokers.lookup_approx_sgd.invoke(common_args, self.optimizer_args)
 
         momentum1 = invokers.lookup_args.Momentum(
+            # pyre-fixme[6]: Expected `Tensor` for 1st param but got `Union[Tensor,
+            #  nn.Module]`.
             dev=self.momentum1_dev,
+            # pyre-fixme[6]: Expected `Tensor` for 2nd param but got `Union[Tensor,
+            #  nn.Module]`.
             host=self.momentum1_host,
+            # pyre-fixme[6]: Expected `Tensor` for 3rd param but got `Union[Tensor,
+            #  nn.Module]`.
             uvm=self.momentum1_uvm,
+            # pyre-fixme[6]: Expected `Tensor` for 4th param but got `Union[Tensor,
+            #  nn.Module]`.
             offsets=self.momentum1_offsets,
+            # pyre-fixme[6]: Expected `Tensor` for 5th param but got `Union[Tensor,
+            #  nn.Module]`.
             placements=self.momentum1_placements,
         )
 
@@ -696,21 +805,22 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             return invokers.lookup_adagrad.invoke(
                 common_args, self.optimizer_args, momentum1
             )
-        if self.optimizer == OptimType.EXACT_ROWWISE_ADAGRAD:
-            return invokers.lookup_rowwise_adagrad.invoke(
-                common_args, self.optimizer_args, momentum1
-            )
-        if self.optimizer == OptimType.ROWWISE_ADAGRAD:
-            assert self.use_cpu, "Approx rowwise AdaGrad is only supported in CPU mode"
-            return invokers.lookup_approx_rowwise_adagrad.invoke(
-                common_args, self.optimizer_args, momentum1
-            )
 
         momentum2 = invokers.lookup_args.Momentum(
+            # pyre-fixme[6]: Expected `Tensor` for 1st param but got `Union[Tensor,
+            #  nn.Module]`.
             dev=self.momentum2_dev,
+            # pyre-fixme[6]: Expected `Tensor` for 2nd param but got `Union[Tensor,
+            #  nn.Module]`.
             host=self.momentum2_host,
+            # pyre-fixme[6]: Expected `Tensor` for 3rd param but got `Union[Tensor,
+            #  nn.Module]`.
             uvm=self.momentum2_uvm,
+            # pyre-fixme[6]: Expected `Tensor` for 4th param but got `Union[Tensor,
+            #  nn.Module]`.
             offsets=self.momentum2_offsets,
+            # pyre-fixme[6]: Expected `Tensor` for 5th param but got `Union[Tensor,
+            #  nn.Module]`.
             placements=self.momentum2_placements,
         )
         # Ensure iter is always on CPU so the increment doesn't synchronize.
@@ -767,6 +877,79 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 #  int]`.
                 self.iter.item(),
             )
+
+        prev_iter = invokers.lookup_args.Momentum(
+            # pyre-fixme[6]: Expected `Tensor` for 1st param but got `Union[Tensor,
+            #  nn.Module]`.
+            dev=self.prev_iter_dev,
+            # pyre-fixme[6]: Expected `Tensor` for 2nd param but got `Union[Tensor,
+            #  nn.Module]`.
+            host=self.prev_iter_host,
+            # pyre-fixme[6]: Expected `Tensor` for 3rd param but got `Union[Tensor,
+            #  nn.Module]`.
+            uvm=self.prev_iter_uvm,
+            # pyre-fixme[6]: Expected `Tensor` for 4th param but got `Union[Tensor,
+            #  nn.Module]`.
+            offsets=self.prev_iter_offsets,
+            # pyre-fixme[6]: Expected `Tensor` for 5th param but got `Union[Tensor,
+            #  nn.Module]`.
+            placements=self.prev_iter_placements,
+        )
+        row_counter = invokers.lookup_args.Momentum(
+            # pyre-fixme[6]: Expected `Tensor` for 1st param but got `Union[Tensor,
+            #  nn.Module]`.
+            dev=self.row_counter_dev,
+            # pyre-fixme[6]: Expected `Tensor` for 2nd param but got `Union[Tensor,
+            #  nn.Module]`.
+            host=self.row_counter_host,
+            # pyre-fixme[6]: Expected `Tensor` for 3rd param but got `Union[Tensor,
+            #  nn.Module]`.
+            uvm=self.row_counter_uvm,
+            # pyre-fixme[6]: Expected `Tensor` for 4th param but got `Union[Tensor,
+            #  nn.Module]`.
+            offsets=self.row_counter_offsets,
+            # pyre-fixme[6]: Expected `Tensor` for 5th param but got `Union[Tensor,
+            #  nn.Module]`.
+            placements=self.row_counter_placements,
+        )
+        if self._used_rowwise_adagrad_with_counter:
+            if self.iter.item() % self._max_counter_update_freq == 0:
+                max_counter = torch.max(self.row_counter_dev.detach())
+                self.max_counter = max_counter.cpu() + 1
+
+        if self.optimizer == OptimType.EXACT_ROWWISE_ADAGRAD:
+            if self._used_rowwise_adagrad_with_counter:
+                return invokers.lookup_rowwise_adagrad_with_counter.invoke(
+                    common_args,
+                    self.optimizer_args,
+                    momentum1,
+                    prev_iter,
+                    row_counter,
+                    # pyre-fixme[6]: Expected `int` for 6th param but got `Union[float, int]`.
+                    self.iter.item(),
+                    self.max_counter.item(),
+                )
+            else:
+                return invokers.lookup_rowwise_adagrad.invoke(
+                    common_args, self.optimizer_args, momentum1
+                )
+        if self.optimizer == OptimType.ROWWISE_ADAGRAD:
+            assert self.use_cpu, "Approx rowwise AdaGrad is only supported in CPU mode"
+            if self._used_rowwise_adagrad_with_counter:
+                return invokers.lookup_approx_rowwise_adagrad_with_counter.invoke(
+                    common_args,
+                    self.optimizer_args,
+                    momentum1,
+                    prev_iter,
+                    row_counter,
+                    # pyre-fixme[6]: Expected `int` for 6th param but got `Union[float, int]`.
+                    self.iter.item(),
+                    self.max_counter.item(),
+                )
+            else:
+                return invokers.lookup_approx_rowwise_adagrad.invoke(
+                    common_args, self.optimizer_args, momentum1
+                )
 
         raise ValueError(f"Invalid OptimType: {self.optimizer}")
 
@@ -1013,8 +1196,12 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             or self.optimizer == OptimType.ROWWISE_ADAGRAD
             or self.optimizer == OptimType.EXACT_ROWWISE_WEIGHTED_ADAGRAD
         ):
+            split_optimizer_states = self.split_optimizer_states()
             list_of_state_dict = [
-                {"sum": _sum[0]} for _sum in self.split_optimizer_states()
+                {"sum": states[0], "prev_iter": states[1], "row_counter": states[2]}
+                if self._used_rowwise_adagrad_with_counter
+                else {"sum": states[0]}
+                for states in split_optimizer_states
             ]
         else:
             raise NotImplementedError(
@@ -1024,7 +1211,9 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         return list_of_state_dict
 
     @torch.jit.ignore
-    def split_optimizer_states(self) -> List[Tuple[torch.Tensor]]:
+    def split_optimizer_states(
+        self,
+    ) -> List[List[torch.Tensor]]:
         """
         Returns a list of states, split by table
         """
@@ -1062,8 +1251,14 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         ):
             states.append(
                 get_optimizer_states(
+                    # pyre-fixme[6]: Expected `Tensor` for 1st param but got
+                    #  `Union[Tensor, nn.Module]`.
                     self.momentum1_dev,
+                    # pyre-fixme[6]: Expected `Tensor` for 2nd param but got
+                    #  `Union[Tensor, nn.Module]`.
                     self.momentum1_host,
+                    # pyre-fixme[6]: Expected `Tensor` for 3rd param but got
+                    #  `Union[Tensor, nn.Module]`.
                     self.momentum1_uvm,
                     # pyre-fixme[6]: Expected `Tensor` for 4th param but got
                     #  `Union[Tensor, nn.Module]`.
@@ -1087,8 +1282,14 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         ):
             states.append(
                 get_optimizer_states(
+                    # pyre-fixme[6]: Expected `Tensor` for 1st param but got
+                    #  `Union[Tensor, nn.Module]`.
                     self.momentum2_dev,
+                    # pyre-fixme[6]: Expected `Tensor` for 2nd param but got
+                    #  `Union[Tensor, nn.Module]`.
                     self.momentum2_host,
+                    # pyre-fixme[6]: Expected `Tensor` for 3rd param but got
+                    #  `Union[Tensor, nn.Module]`.
                     self.momentum2_uvm,
                     # pyre-fixme[6]: Expected `Tensor` for 4th param but got
                     #  `Union[Tensor, nn.Module]`.
@@ -1100,7 +1301,49 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                     in (OptimType.PARTIAL_ROWWISE_ADAM, OptimType.PARTIAL_ROWWISE_LAMB),
                 )
             )
-        return list(zip(*states))
+        if self._used_rowwise_adagrad_with_counter:
+            states.append(
+                get_optimizer_states(
+                    # pyre-fixme[6]: Expected `Tensor` for 1st param but got
+                    #  `Union[Tensor, nn.Module]`.
+                    self.prev_iter_dev,
+                    # pyre-fixme[6]: Expected `Tensor` for 2nd param but got
+                    #  `Union[Tensor, nn.Module]`.
+                    self.prev_iter_host,
+                    # pyre-fixme[6]: Expected `Tensor` for 3rd param but got
+                    #  `Union[Tensor, nn.Module]`.
+                    self.prev_iter_uvm,
+                    # pyre-fixme[6]: Expected `Tensor` for 4th param but got
+                    #  `Union[Tensor, nn.Module]`.
+                    self.prev_iter_physical_offsets,
+                    # pyre-fixme[6]: Expected `Tensor` for 5th param but got
+                    #  `Union[Tensor, nn.Module]`.
+                    self.prev_iter_physical_placements,
+                    rowwise=True,
+                )
+            )
+            states.append(
+                get_optimizer_states(
+                    # pyre-fixme[6]: Expected `Tensor` for 1st param but got
+                    #  `Union[Tensor, nn.Module]`.
+                    self.row_counter_dev,
+                    # pyre-fixme[6]: Expected `Tensor` for 2nd param but got
+                    #  `Union[Tensor, nn.Module]`.
+                    self.row_counter_host,
+                    # pyre-fixme[6]: Expected `Tensor` for 3rd param but got
+                    #  `Union[Tensor, nn.Module]`.
+                    self.row_counter_uvm,
+                    # pyre-fixme[6]: Expected `Tensor` for 4th param but got
+                    #  `Union[Tensor, nn.Module]`.
+                    self.row_counter_physical_offsets,
+                    # pyre-fixme[6]: Expected `Tensor` for 5th param but got
+                    #  `Union[Tensor, nn.Module]`.
+                    self.row_counter_physical_placements,
+                    rowwise=True,
+                )
+            )
+        return_states = [list(s) for s in zip(*states)]
+        return return_states
 
     @torch.jit.export
     def set_learning_rate(self, lr: float) -> None:


### PR DESCRIPTION
Summary:
1. Update interface to accomadate rowwise_adagrad_with_counter.
2. Route backend for rowwise_adagrad to the new rowwise_adagrad_with_counter when freq based methods (e.g. freq sgd, counter adjusted regularization) are used.

Differential Revision: D36788395

