### PR TITLE
Add option to skip indices sorting in index_select_dim0 fwd

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -670,12 +670,11 @@ at::Tensor pack_segments_backward_cuda(
     int64_t max_length);
 
 ///@ingroup sparse-data-cuda
-at::Tensor index_select_with_sorted_indices_cuda(
+at::Tensor index_select_cuda(
     const at::Tensor& input,
     const at::Tensor& sorted_indices,
     const at::Tensor& orig_indices,
-    const int consecutive_range_start,
-    const int consecutive_range_length);
+    const bool indices_sorted);
 
 at::Tensor index_add_with_unique_indices_cuda(
     const at::Tensor& grad_output,

--- a/fbgemm_gpu/src/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_cpu.cpp
@@ -2322,7 +2322,8 @@ Tensor index_select_dim0(
     const Tensor& input,
     const Tensor& indices,
     c10::optional<int64_t> /*consecutive_range_start*/,
-    c10::optional<int64_t> /*consecutive_range_length*/) {
+    c10::optional<int64_t> /*consecutive_range_length*/,
+    c10::optional<bool> /*skip_indices_sorting_fwd*/) {
   return at::index_select(input, 0, indices);
 }
 
@@ -2422,8 +2423,10 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   //
   // If indices are not selected from a consecutive range, we perform the
   // unique indices computation step in the backward operation.
+  //
+  // skip_indices_sorting_fwd is for skipping indices sorting in forward
   m.def(
-      "index_select_dim0(Tensor input, Tensor indices, int? consecutive_range_start=0, int? consecutive_range_length=0) -> Tensor");
+      "index_select_dim0(Tensor input, Tensor indices, int? consecutive_range_start=0, int? consecutive_range_length=0, bool? skip_indices_sorting_fwd=None) -> Tensor");
   m.def(
       "jagged_index_select(Tensor values, Tensor lengths, Tensor indices) -> Tensor[]");
   // This is an one-off op to be used in bench_utils.py for zipf generation w/o


### PR DESCRIPTION
Summary:
Indices sorting is mainly meant for backward of index_select_dim0.
This diff adds an option to skip indices sorting in forward.  This is
useful in the case that indices are already sorted.  Note that the op
still performs sorting in backward.

Reviewed By: jspark1105

Differential Revision: D39991371

