### PR TITLE
Eliminate unnecessary padding in allocation for FbgemmPackMatrixB

### DIFF
--- a/include/fbgemm/FbgemmPackMatrixB.h
+++ b/include/fbgemm/FbgemmPackMatrixB.h
@@ -121,10 +121,8 @@ class PackedGemmMatrixB {
 
   void initializeMemory() {
     // allocate and initialize packed memory
-    const int padding = 1024; // required by sw pipelined kernels
     size_ = (blockRowSize() * nbrow_) * (blockColSize() * nbcol_);
-    pmat_ = static_cast<T*>(
-        fbgemmAlignedAlloc(64, matSize() * sizeof(T) + padding));
+    pmat_ = static_cast<T*>(fbgemmAlignedAlloc(64, matSize() * sizeof(T)));
     memset(pmat_, 0, matSize() * sizeof(T));
   }
 


### PR DESCRIPTION
Summary: `initializeMemory()` adds an extra 1 KiB to every allocation, but it appears that this is vestigial, an artifact of the previous implementation of 16-bit floating point support. This commit removes the unnecessary padding, thus reducing memory usage.

Differential Revision: D39897109

