### PR TITLE
Revert release install instructions change in README

### DIFF
--- a/fbgemm_gpu/README.md
+++ b/fbgemm_gpu/README.md
@@ -39,7 +39,7 @@ Currently only built with sm70/80 (V100/A100 GPU) wheel supports:
 
 ```
 # Release
-conda install pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
+conda install pytorch cudatoolkit=11.3 -c pytorch
 pip install fbgemm-gpu (release version)
 OR
 pip install fbgemm-gpu-cpu (release version with CPU only)


### PR DESCRIPTION
Summary: Switch back to the old instructions for installing release version, prior to D39784164 (https://github.com/pytorch/FBGEMM/commit/aefa24c624eec175500f58548d13a90e356cee75)

Reviewed By: shintaro-iwasaki

Differential Revision: D40074206

