### PR TITLE
Use shmem for indices loading in TBE bwd warp_per_row

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_quantized_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_split_template.cu
@@ -297,15 +297,7 @@ __global__ void {{ type_map[emb_weight_type].enum_name }}_split_embedding{{ "_no
     }
     // equivalent to fence + wait.
     cp_async_wait<0>();
-#ifdef __HIP_PLATFORM_HCC__
-    // Performance - replace a block level __syncthreads with per CU __threadfence_block
-    // __threadfence_block is fine replacement for __syncwarp on AMD GPUs, it is because
-    // a. memory fencing: __threadfence_block ops. at CU level, same as __syncwarp at SM
-    // b. threads re-converge: wavefront run in lockstep, no need __syncwarp re-converge
-    __threadfence_block();
-#else
-    __syncwarp();
-#endif
+    syncwarp();
     for (uint32_t input_row_idx = 0; input_row_idx < input_rows_in_flight; ++input_row_idx) {
       #pragma unroll OutputRowsPerThread
       for (uint32_t i = 0; i < OutputRowsPerThread; ++i) {

--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
@@ -764,6 +764,19 @@ DEVICE_INLINE T warpReduceAllSum(T val, unsigned shfl_sync_mask = 0xffffffffu) {
   return val;
 }
 
+DEVICE_INLINE void syncwarp() {
+#ifdef __HIP_PLATFORM_HCC__
+  // Performance - replace a block level __syncthreads with per CU
+  // __threadfence_block. It is a fine replacement for __syncwarp on AMD GPUs,
+  // it is because a. memory fencing: __threadfence_block ops. at CU level,
+  // same as __syncwarp at SM b. threads re-converge: wavefront run in
+  // lockstep, no need __syncwarp re-converge
+  __threadfence_block();
+#else
+  __syncwarp();
+#endif
+}
+
 /// Warp bitonic K/V sorting code from @jhj
 template <typename T>
 struct Comparator {


### PR DESCRIPTION
Summary:
This diff uses shared memory for storing indices instead of registers
to reduce the number of registers per thread.  This increases
theoretical/achieved occupancy in some cases resulting in higher
achieved active warps per SM.

Differential Revision: D40149693

