### PR TITLE
Remove PythonExtensions from CMakeLists.txt

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -40,7 +40,6 @@ else()
 endif()
 
 find_package(Torch REQUIRED)
-find_package(PythonExtensions REQUIRED)
 
 set(FBGEMM ${CMAKE_CURRENT_SOURCE_DIR}/..)
 set(THIRDPARTY ${FBGEMM}/third_party)


### PR DESCRIPTION
Summary: PythonExtensions is not needed

Differential Revision: D40197444

