### PR TITLE
Remove conda cudnn installation from the nightly build

### DIFF
--- a/.github/workflows/fbgemm_nightly_build.yml
+++ b/.github/workflows/fbgemm_nightly_build.yml
@@ -71,7 +71,6 @@ jobs:
       shell: bash
       run: |
         conda install -n build_binary -y pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
-        conda install -n build_binary -y cudnn
     - name: Install Other Dependencies
       shell: bash
       run: |

--- a/.github/workflows/fbgemmci.yml
+++ b/.github/workflows/fbgemmci.yml
@@ -237,7 +237,8 @@ jobs:
           eval "$($HOME/miniconda/bin/conda shell.bash hook)"
           cuda_version="${{ matrix.config[1] }}"
           conda install -y pytorch pytorch-cuda="$cuda_version" -c pytorch-nightly -c nvidia
-          conda install -y cudnn numpy scikit-build jinja2 ninja cmake hypothesis
+          conda install -y -c conda-forge cudnn
+          conda install -y numpy scikit-build jinja2 ninja cmake hypothesis
         fi
     - name: Checkout submodules
       shell: bash


### PR DESCRIPTION
Summary: conda's cudnn version is too old causing torch nightly import failure

Differential Revision: D40389408

