### PR TITLE
Add inverse_permute argument to permute_1D_sparse_data

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -89,6 +89,8 @@ permute_1D_sparse_data_cuda(
     const at::Tensor& indices,
     const c10::optional<at::Tensor>& weights,
     const c10::optional<int64_t>& permuted_lengths_sum);
+
+at::Tensor invert_permute_cuda(const at::Tensor& permute);
 #endif
 
 /// @ingroup sparse-data-cuda

--- a/fbgemm_gpu/src/sparse_ops.cu
+++ b/fbgemm_gpu/src/sparse_ops.cu
@@ -585,7 +585,7 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_1D_sparse_data_cuda(
             <<<blocks_1, threads_1, 0, at::cuda::getCurrentCUDAStream()>>>(
                 lengths_contig.data_ptr<index_t>(),
                 permuted_lengths_size,
-                permute.data_ptr<int32_t>(),
+                permute_contig.data_ptr<int32_t>(),
                 permuted_lengths.data_ptr<index_t>());
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       });
@@ -672,6 +672,37 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_1D_sparse_data_cuda(
       }); // for each offsets_t
 
   return {permuted_lengths, permuted_indices, permuted_weights};
+}
+
+template <typename index_t>
+__global__ __launch_bounds__(kMaxThreads) void invert_permute_kernel(
+    int32_t permute_size,
+    const index_t* __restrict__ permute,
+    index_t* __restrict__ inversed_permute) {
+  CUDA_KERNEL_LOOP(i, permute_size) {
+    inversed_permute[permute[i]] = i;
+  }
+}
+
+Tensor invert_permute_cuda(const Tensor& permute) {
+  TENSOR_ON_CUDA_GPU(permute);
+  at::cuda::OptionalCUDAGuard device_guard;
+  device_guard.set_index(permute.get_device());
+  const auto permute_contig = permute.contiguous();
+  const auto permute_size = permute.numel();
+  Tensor inversed_permute = at::empty_like(permute);
+
+  constexpr int32_t threads_1 = kMaxThreads;
+  const auto blocks_1 = cuda_calc_xblock_count(permute_size, threads_1);
+  AT_DISPATCH_INDEX_TYPES(permute.scalar_type(), "invert_permute_kernel", [&] {
+    invert_permute_kernel<index_t>
+        <<<blocks_1, threads_1, 0, at::cuda::getCurrentCUDAStream()>>>(
+            permute_size,
+            permute_contig.data_ptr<index_t>(),
+            inversed_permute.data_ptr<index_t>());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  });
+  return inversed_permute;
 }
 
 // Kernel for generate 1D data permute from dimension permute index.

--- a/fbgemm_gpu/src/sparse_ops_gpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_gpu.cpp
@@ -217,6 +217,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
       "permute_2D_sparse_data", fbgemm_gpu::permute_2D_sparse_data_cuda);
   DISPATCH_TO_CUDA(
       "permute_1D_sparse_data", fbgemm_gpu::permute_1D_sparse_data_cuda);
+  DISPATCH_TO_CUDA("invert_permute", fbgemm_gpu::invert_permute_cuda);
   DISPATCH_TO_CUDA(
       "expand_into_jagged_permute",
       fbgemm_gpu::expand_into_jagged_permute_cuda);


### PR DESCRIPTION
Summary: Variable batch size EC requires permute_1D backward. Add inverse_permute so we don't need to generate backward recat.

Reviewed By: YazhiGao

Differential Revision:
D40521813

LaMa Project: L1138451

