### PR TITLE
Low-overhead hit/miss counter for UVM_CACHING

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh
@@ -28,7 +28,9 @@ std::pair<at::Tensor, at::Tensor> lru_cache_find_uncached_cuda(
     int64_t max_indices,
     at::Tensor lxu_cache_state,
     int64_t time_stamp,
-    at::Tensor lru_state);
+    at::Tensor lru_state,
+    bool gather_cache_stats,
+    at::Tensor uvm_cache_stats);
 
 ///@ingroup table-batched-embed-cuda
 /// Map index to cache_set. h_in: linear_indices; C: #cache_sets.
@@ -75,7 +77,9 @@ void lru_cache_populate_byte_cuda(
     at::Tensor lxu_cache_weights,
     int64_t time_stamp,
     at::Tensor lru_state,
-    int64_t row_alignment);
+    int64_t row_alignment,
+    bool gather_cache_stats,
+    c10::optional<at::Tensor> uvm_cache_stats);
 
 ///@ingroup table-batched-embed-cuda
 /// Direct-mapped (assoc=1) variant of lru_cache_populate_byte_cuda
@@ -136,7 +140,9 @@ void lfu_cache_populate_byte_cuda(
 at::Tensor lxu_cache_lookup_cuda(
     at::Tensor linear_cache_indices,
     at::Tensor lxu_cache_state,
-    int64_t invalid_index);
+    int64_t invalid_index,
+    bool gather_cache_stats,
+    c10::optional<at::Tensor> uvm_cache_stats);
 
 ///@ingroup table-batched-embed-cuda
 /// Lookup the LRU/LFU cache: find the cache weights location for all indices.

--- a/fbgemm_gpu/src/split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/split_table_batched_embeddings.cpp
@@ -21,7 +21,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "lru_cache_populate(Tensor weights, Tensor hash_size_cumsum, int total_cache_hash_size, Tensor cache_index_table_map, Tensor weights_offsets, Tensor D_offsets, Tensor linear_cache_indices, Tensor(a!) lxu_cache_state, Tensor(b!) lxu_cache_weights, int time_stamp, Tensor(c!) lru_state, bool stochastic_rounding) -> ()");
   DISPATCH_TO_CUDA("lru_cache_populate", lru_cache_populate_cuda);
   m.def(
-      "lru_cache_populate_byte(Tensor weights, Tensor hash_size_cumsum, int total_cache_hash_size, Tensor cache_index_table_map, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, Tensor linear_cache_indices, Tensor(a!) lxu_cache_state, Tensor(b!) lxu_cache_weights, int time_stamp, Tensor(c!) lru_state, int row_alignment=16) -> ()");
+      "lru_cache_populate_byte(Tensor weights, Tensor hash_size_cumsum, int total_cache_hash_size, Tensor cache_index_table_map, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, Tensor linear_cache_indices, Tensor(a!) lxu_cache_state, Tensor(b!) lxu_cache_weights, int time_stamp, Tensor(c!) lru_state, int row_alignment=16, bool gather_cache_stats=False, Tensor(d!)? uvm_cache_stats=None) -> ()");
   DISPATCH_TO_CUDA("lru_cache_populate_byte", lru_cache_populate_byte_cuda);
   m.def(
       "direct_mapped_lru_cache_populate_byte(Tensor weights, Tensor hash_size_cumsum, int total_cache_hash_size, Tensor cache_index_table_map, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, Tensor linear_cache_indices, Tensor(a!) lxu_cache_state, Tensor(b!) lxu_cache_weights, int time_stamp, Tensor(c!) lru_state, Tensor(d!) lxu_cache_miss_timestamp, int row_alignment=16) -> ()");
@@ -35,7 +35,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "lfu_cache_populate_byte(Tensor weights, Tensor cache_hash_size_cumsum, int total_cache_hash_size, Tensor cache_index_table_map, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, Tensor linear_cache_indices, Tensor(a!) lxu_cache_state, Tensor(b!) lxu_cache_weights, Tensor(c!) lfu_state, int row_alignment=16) -> ()");
   DISPATCH_TO_CUDA("lfu_cache_populate_byte", lfu_cache_populate_byte_cuda);
   m.def(
-      "lxu_cache_lookup(Tensor linear_cache_indices, Tensor lxu_cache_state, int invalid_index = -1) -> Tensor");
+      "lxu_cache_lookup(Tensor linear_cache_indices, Tensor lxu_cache_state, int invalid_index = -1, bool gather_cache_stats=False, Tensor(a!)? uvm_cache_stats=None) -> Tensor");
   DISPATCH_TO_CUDA("lxu_cache_lookup", lxu_cache_lookup_cuda);
   m.def(
       "direct_mapped_lxu_cache_lookup(Tensor linear_cache_indices, Tensor lxu_cache_state, int invalid_index = -1) -> Tensor");


### PR DESCRIPTION
Summary:
Add low-overhead hit / miss counter to UVM_CACHING (currently, only for inference). The plan is to turn this on when UVM_CACHING is being used.

Stats are gathered from the GPU kernels (thus, we can get more info, like conflict miss); gathered stats stay in GPU memory -- no device to host traffic -- until we read it, which may be done only once it a while (every 60 sec?)

Using int32_t for counters -- atomicAdd seems to be pretty slow with int64_t?
int32_t stats for a batch is accumulated to int64_t stats at the end of cache prefetch related kernels.

Function signatures of lru_cache_populate_byte and lxu_cache_lookup are changed, but the additional args are at the end and with default value or optional, so the existing calls wouldn't be impacted (in general).

Differential Revision: D40518654

