### PR TITLE
Add reset weight momentum function to FBGemm

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -1338,6 +1338,47 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.lxu_state.fill_(0)
         self.timestep = 1
 
+    def reset_embedding_weight_momentum(
+        self,
+        pruned_indices: Tensor,
+        pruned_indices_offsets: Tensor,
+        logical_table_ids: Tensor,
+        buffer_ids: Tensor,
+    ) -> None:
+        total_cache_hash_size = 0
+        if isinstance(self.total_cache_hash_size, Tensor):
+            total_cache_hash_size = self.total_cache_hash_size.item()
+        else:
+            total_cache_hash_size = self.total_cache_hash_size
+
+        rowwise = self.optimizer in [
+            OptimType.EXACT_ROWWISE_ADAGRAD,
+            OptimType.ROWWISE_ADAGRAD,
+            OptimType.EXACT_ROWWISE_WEIGHTED_ADAGRAD,
+        ]
+        if rowwise:
+            torch.ops.fbgemm.reset_weight_momentum(
+                dev_weights=self.weights_dev,
+                uvm_weights=self.weights_uvm,
+                lxu_cache_weights=self.lxu_cache_weights,
+                weights_placements=self.weights_placements,
+                weights_offsets=self.weights_offsets,
+                momentum1_dev=self.momentum1_dev,
+                momentum1_uvm=self.momentum1_uvm,
+                momentum1_placements=self.momentum1_placements,
+                momentum1_offsets=self.momentum1_offsets,
+                D_offsets=self.D_offsets,
+                pruned_indices=pruned_indices.to(device=self.current_device),
+                pruned_indices_offsets=pruned_indices_offsets.to(
+                    device=self.current_device
+                ),
+                logical_table_ids=logical_table_ids.to(device=self.current_device),
+                buffer_ids=buffer_ids.to(device=self.current_device),
+                cache_hash_size_cumsum=self.cache_hash_size_cumsum,
+                lxu_cache_state=self.lxu_cache_state,
+                total_cache_hash_size=total_cache_hash_size,
+            )
+
 
 class DenseTableBatchedEmbeddingBagsCodegen(nn.Module):
     """

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh
@@ -159,3 +159,25 @@ void lxu_cache_flush_cuda(
     at::Tensor lxu_cache_state,
     at::Tensor lxu_cache_weights,
     bool stochastic_rounding);
+
+///@ingroup table-batched-embed-cuda
+// For in-training embedding pruning
+// Function to reset the weight and momentum of pruned indices
+void reset_weight_momentum_cuda(
+    at::Tensor dev_weights,
+    at::Tensor uvm_weights,
+    at::Tensor lxu_cache_weights,
+    at::Tensor weights_placements,
+    at::Tensor weights_offsets,
+    at::Tensor momentum1_dev,
+    at::Tensor momentum1_uvm,
+    at::Tensor momentum1_placements,
+    at::Tensor momentum1_offsets,
+    at::Tensor D_offsets,
+    at::Tensor pruned_indices,
+    at::Tensor pruned_indices_offsets,
+    at::Tensor logical_table_ids,
+    at::Tensor buffer_ids,
+    at::Tensor cache_hash_size_cumsum,
+    at::Tensor lxu_cache_state,
+    int64_t total_cache_hash_size);

--- a/fbgemm_gpu/src/split_embeddings_cache_cuda.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache_cuda.cu
@@ -2377,3 +2377,306 @@ Tensor direct_mapped_lxu_cache_lookup_cuda(
 
   return lxu_cache_locations;
 }
+
+int get_sm_count_() {
+  cudaDeviceProp* deviceProp =
+      at::cuda::getDeviceProperties(c10::cuda::current_device());
+  return deviceProp->multiProcessorCount;
+}
+
+__global__ __launch_bounds__(kMaxThreads) void get_cache_indices_kernel(
+    int32_t blocks_per_table,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+        cache_hash_size_cumsum,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+        pruned_indices,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+        pruned_indices_offsets,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        logical_table_ids,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        buffer_ids,
+    at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+        linear_cache_indices) {
+  const int64_t index = blockIdx.x * blockDim.x + threadIdx.x;
+
+  const int32_t t_i = blockIdx.x / blocks_per_table;
+  const int32_t threads_per_table = blocks_per_table * blockDim.x;
+  const int32_t idx_table = index % threads_per_table;
+  const int32_t logical_id = logical_table_ids[t_i];
+  const int32_t buffer_id = buffer_ids[t_i];
+
+  const int64_t num_indices =
+      pruned_indices_offsets[buffer_id + 1] - pruned_indices_offsets[buffer_id];
+
+  if (num_indices <= 0) {
+    return;
+  }
+
+  const int64_t indices_per_thread =
+      div_round_up(num_indices, threads_per_table);
+  const int64_t start = idx_table * indices_per_thread;
+  const int64_t end = min(start + indices_per_thread, num_indices);
+
+  if (start >= num_indices) {
+    return;
+  }
+
+  const int64_t pruned_indices_offset = pruned_indices_offsets[buffer_id];
+  const int64_t* pruned_indices_table = &pruned_indices[pruned_indices_offset];
+  int64_t* linear_cache_indices_table =
+      &linear_cache_indices[pruned_indices_offset];
+
+  const auto max_offset =
+      __ldg(&cache_hash_size_cumsum[cache_hash_size_cumsum.size(0) - 1]);
+  const auto curr_offset = __ldg(&cache_hash_size_cumsum[logical_id]);
+
+  for (int64_t i = start; i < end; i++) {
+    if (curr_offset >= 0) {
+      linear_cache_indices_table[i] = curr_offset + pruned_indices_table[i];
+    } else {
+      linear_cache_indices_table[i] = max_offset;
+    }
+  }
+}
+
+template <typename emb_t, typename cache_t>
+__global__ __launch_bounds__(kMaxThreads) void reset_weight_momentum_kernel(
+    int32_t blocks_per_table,
+    at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
+    at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> uvm_weights,
+    at::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits>
+        lxu_cache_weights,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        weights_placements,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+        weights_offsets,
+    at::PackedTensorAccessor64<
+        at::acc_type<cache_t, true>,
+        1,
+        at::RestrictPtrTraits> momentum1_dev,
+    at::PackedTensorAccessor64<
+        at::acc_type<cache_t, true>,
+        1,
+        at::RestrictPtrTraits> momentum1_uvm,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        momentum1_placements,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+        momentum1_offsets,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        D_offsets,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+        pruned_indices,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+        pruned_indices_offsets,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        logical_table_ids,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        buffer_ids,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        lxu_cache_locations) {
+  const int64_t index = blockIdx.x * blockDim.x + threadIdx.x;
+
+  const int32_t t_i = blockIdx.x / blocks_per_table;
+  const int32_t buffer_id = buffer_ids[t_i];
+  const int64_t num_indices =
+      pruned_indices_offsets[buffer_id + 1] - pruned_indices_offsets[buffer_id];
+
+  if (num_indices <= 0) {
+    return;
+  }
+
+  const int32_t logical_id = logical_table_ids[t_i];
+  int32_t D = D_offsets[logical_id + 1] - D_offsets[logical_id];
+  const int32_t chunk4s_per_row = D / 4;
+  const int64_t total_chunk4s_per_table = num_indices * chunk4s_per_row;
+
+  const int32_t threads_per_table = blocks_per_table * blockDim.x;
+  const int64_t chunk4s_per_thread =
+      div_round_up(total_chunk4s_per_table, threads_per_table);
+  const int32_t idx_table = index % threads_per_table;
+  const int64_t start = idx_table * chunk4s_per_thread;
+  const int64_t end = min(start + chunk4s_per_thread, total_chunk4s_per_table);
+
+  if (start >= total_chunk4s_per_table) {
+    return;
+  }
+
+  int32_t D_emb = D;
+  if (std::is_same<emb_t, uint8_t>::value) {
+    D_emb += kINT8QparamsBytes;
+  }
+
+  at::acc_type<cache_t, true>* __restrict__ momentum1;
+  const auto momentum1_placement =
+      static_cast<PlacementType>(momentum1_placements[logical_id]);
+  int64_t momentum1_offset = momentum1_offsets[logical_id];
+  if (momentum1_placement == PlacementType::DEVICE) {
+    momentum1 = &momentum1_dev[momentum1_offset];
+  } else {
+    momentum1 = &momentum1_uvm[momentum1_offset];
+  }
+
+  emb_t* __restrict__ weights{nullptr};
+  cache_t* __restrict__ cache_weights{nullptr};
+  const auto weights_placement =
+      static_cast<PlacementType>(weights_placements[logical_id]);
+  int64_t weights_offset = weights_offsets[logical_id];
+
+  const int64_t pruned_indices_offset = pruned_indices_offsets[buffer_id];
+  const int64_t* pruned_indices_table = &pruned_indices[pruned_indices_offset];
+
+  for (int64_t i = start; i < end; i++) {
+    int64_t idx = i / chunk4s_per_row;
+    int64_t pruned_index = pruned_indices_table[idx];
+
+    if (weights_placement == PlacementType::DEVICE) {
+      weights = &dev_weights[weights_offset + pruned_index * D_emb];
+    } else {
+      weights = &uvm_weights[weights_offset + pruned_index * D_emb];
+    }
+    if (weights_placement == PlacementType::MANAGED_CACHING) {
+      int32_t cache_idx = lxu_cache_locations[pruned_indices_offset + idx];
+      if (cache_idx != kCacheLocationMissing) {
+        cache_weights = &lxu_cache_weights[cache_idx][0];
+      }
+    }
+
+    auto weight_row_template =
+        WeightRow<emb_t, cache_t, at::acc_type<cache_t, true>>(
+            weights, cache_weights, D, nullptr);
+
+    // reset momentum1
+    const int32_t d = (i % chunk4s_per_row) * 4;
+    if (d == 0) {
+      momentum1[pruned_index] = 0;
+    }
+
+    // reset weight
+    float2 qparams_new;
+    Vec4T<at::acc_type<cache_t, true>> weight_new; // 0 weight
+    weight_row_template.store(
+        weight_new,
+        d,
+        qparams_new); // qparams_new not used if type is not int8
+  }
+}
+
+void reset_weight_momentum_cuda(
+    Tensor dev_weights,
+    Tensor uvm_weights,
+    Tensor lxu_cache_weights,
+    Tensor weights_placements,
+    Tensor weights_offsets,
+    Tensor momentum1_dev,
+    Tensor momentum1_uvm,
+    Tensor momentum1_placements,
+    Tensor momentum1_offsets,
+    Tensor D_offsets,
+    Tensor pruned_indices,
+    Tensor pruned_indices_offsets,
+    Tensor logical_table_ids,
+    Tensor buffer_ids,
+    Tensor cache_hash_size_cumsum,
+    Tensor lxu_cache_state,
+    int64_t total_cache_hash_size) {
+  TENSOR_ON_CUDA_GPU(dev_weights);
+  TENSOR_ON_CUDA_GPU(uvm_weights);
+  TENSOR_ON_CUDA_GPU(lxu_cache_weights);
+  TENSOR_ON_CUDA_GPU(weights_placements);
+  TENSOR_ON_CUDA_GPU(weights_offsets);
+  TENSOR_ON_CUDA_GPU(momentum1_dev);
+  TENSOR_ON_CUDA_GPU(momentum1_uvm);
+  TENSOR_ON_CUDA_GPU(momentum1_placements);
+  TENSOR_ON_CUDA_GPU(momentum1_offsets);
+  TENSOR_ON_CUDA_GPU(D_offsets);
+  TENSOR_ON_CUDA_GPU(pruned_indices);
+  TENSOR_ON_CUDA_GPU(pruned_indices_offsets);
+  TENSOR_ON_CUDA_GPU(logical_table_ids);
+  TENSOR_ON_CUDA_GPU(buffer_ids);
+  TENSOR_ON_CUDA_GPU(cache_hash_size_cumsum);
+  TENSOR_ON_CUDA_GPU(lxu_cache_state);
+  at::cuda::OptionalCUDAGuard device_guard;
+  device_guard.set_index(dev_weights.get_device());
+
+  const int64_t num_pruned_indices = pruned_indices.size(0);
+  const int32_t num_pruned_tables = buffer_ids.size(0);
+  const int32_t blocks_per_table = get_sm_count_();
+
+  auto lxu_cache_locations =
+      at::zeros({num_pruned_indices}, pruned_indices.options().dtype(at::kInt));
+  lxu_cache_locations.fill_(kCacheLocationMissing);
+
+  if (total_cache_hash_size > 0) {
+    // Get corresponding cache indices of pruned indices
+    auto linear_cache_indices = at::zeros(
+        {num_pruned_indices}, pruned_indices.options().dtype(at::kLong));
+
+    get_cache_indices_kernel<<<
+        num_pruned_tables * blocks_per_table,
+        kMaxThreads,
+        0,
+        at::cuda::getCurrentCUDAStream()>>>(
+        blocks_per_table,
+        cache_hash_size_cumsum
+            .packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
+        pruned_indices.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
+        pruned_indices_offsets
+            .packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
+        logical_table_ids
+            .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+        buffer_ids.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+        linear_cache_indices
+            .packed_accessor32<int64_t, 1, at::RestrictPtrTraits>());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+    // Look up cache locations
+    lxu_cache_locations = lxu_cache_lookup_cuda(
+        linear_cache_indices, lxu_cache_state, total_cache_hash_size);
+  }
+
+  // Reset weight and momentum of pruned rows
+  DISPATCH_EMB_CACHE_TYPES(
+      dev_weights.scalar_type(),
+      lxu_cache_weights.scalar_type(),
+      "reset_weight_momentum_kernel",
+      ([&] {
+        reset_weight_momentum_kernel<emb_t, cache_t><<<
+            num_pruned_tables * blocks_per_table,
+            kMaxThreads,
+            0,
+            at::cuda::getCurrentCUDAStream()>>>(
+            blocks_per_table,
+            dev_weights.packed_accessor64<emb_t, 1, at::RestrictPtrTraits>(),
+            uvm_weights.packed_accessor64<emb_t, 1, at::RestrictPtrTraits>(),
+            lxu_cache_weights
+                .packed_accessor64<cache_t, 2, at::RestrictPtrTraits>(),
+            weights_placements
+                .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+            weights_offsets
+                .packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
+            momentum1_dev.packed_accessor64<
+                at::acc_type<cache_t, true>,
+                1,
+                at::RestrictPtrTraits>(),
+            momentum1_uvm.packed_accessor64<
+                at::acc_type<cache_t, true>,
+                1,
+                at::RestrictPtrTraits>(),
+            momentum1_placements
+                .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+            momentum1_offsets
+                .packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
+            D_offsets.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+            pruned_indices
+                .packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
+            pruned_indices_offsets
+                .packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
+            logical_table_ids
+                .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+            buffer_ids.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+            lxu_cache_locations
+                .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>());
+      }));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}

--- a/fbgemm_gpu/src/split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/split_table_batched_embeddings.cpp
@@ -76,6 +76,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   DISPATCH_TO_CUDA("lxu_cache_flush", lxu_cache_flush_cuda);
   m.def("lxu_cache_slot(int h_in, int C) -> int");
   DISPATCH_TO_ALL("lxu_cache_slot", host_lxu_cache_slot);
+  m.def(
+      "reset_weight_momentum(Tensor dev_weights, Tensor uvm_weights, Tensor lxu_cache_weights, Tensor weights_placements, Tensor weights_offsets, Tensor momentum1_dev, Tensor momentum1_uvm, Tensor momentum1_placements, Tensor momentum1_offsets, Tensor D_offsets, Tensor pruned_indices, Tensor pruned_indices_offsets, Tensor logical_table_ids, Tensor buffer_ids, Tensor cache_hash_size_cumsum, Tensor lxu_cache_state, int total_cache_hash_size) -> ()");
+  DISPATCH_TO_CUDA("reset_weight_momentum", reset_weight_momentum_cuda);
 }
 
 } // namespace


### PR DESCRIPTION
Summary: Add a reset_embedding_weight_momentum function to reset the momentum and weight of selected rows for selected tables.

Reviewed By: jianyuh

Differential Revision: D39046516

