### PR TITLE
[Tests] Skip test_reset_embedding_weight_momentum on AMD GPUs

### DIFF
--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -35,11 +35,12 @@ open_source: bool = getattr(fbgemm_gpu, "open_source", False)
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import gpu_available, gpu_unavailable, TEST_WITH_ROCM
+    from test_utils import gpu_available, gpu_unavailable, skipIfRocm, TEST_WITH_ROCM
 else:
     from fbgemm_gpu.test.test_utils import (
         gpu_available,
         gpu_unavailable,
+        skipIfRocm,
         TEST_WITH_ROCM,
     )
 
@@ -4932,6 +4933,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                     equal_nan=True,
                 )
 
+    @skipIfRocm()
     @given(
         T=st.integers(min_value=1, max_value=5),
         D=st.integers(min_value=2, max_value=128),


### PR DESCRIPTION
https://github.com/pytorch/FBGEMM/pull/1406 broke `test_amd_gpu`. This PR disables `test_reset_embedding_weight_momentum` on AMD GPUs for now.