### PR TITLE
Fix failure in AMD GPU test in test_reset_embedding_weight_momentum

### DIFF
--- a/fbgemm_gpu/src/split_embeddings_cache_cuda.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache_cuda.cu
@@ -2553,7 +2553,7 @@ __global__ __launch_bounds__(kMaxThreads) void reset_weight_momentum_kernel(
     }
 
     // reset weight
-    float2 qparams_new;
+    float2 qparams_new = {1.0, 0.0}; // scaler=1.0, and offset=0.0, for int8.
     Vec4T<at::acc_type<cache_t, true>> weight_new; // 0 weight
     weight_row_template.store(
         weight_new,


### PR DESCRIPTION
Summary:
test_reset_embedding_weight_momentum fails only in AMD test (was ok in NVidia GPU).
It's added in D39046516 (https://github.com/pytorch/FBGEMM/commit/da2065d2e5a3032b38332c9747c5e4d8381a2453), but somehowe qparam_new is used without init, and
that shows different behavior between AMD and NVidia.

This diff initializes it to {1.0, and 0.0}, and that fixes AMD test failure.

Differential Revision: D40602633

