### PR TITLE
Low-overhead hit/miss counter for UVM_CACHING

### DIFF
--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -1918,6 +1918,7 @@ def nbit_uvm_compare_direct_mapped(
 @click.option("--enforce-hbm", is_flag=True, default=False)
 @click.option("--record-cache-miss-counter", is_flag=True, default=False)
 @click.option("--record-tablewise-cache-miss", is_flag=True, default=False)
+@click.option("--gather-uvm-cache-stats", is_flag=True, default=False)
 @click.option("--fp8-exponent-bits", type=int, default=None)
 @click.option("--fp8-exponent-bias", type=int, default=None)
 def nbit_cache(  # noqa C901
@@ -1939,6 +1940,7 @@ def nbit_cache(  # noqa C901
     enforce_hbm: bool,
     record_cache_miss_counter: bool,
     record_tablewise_cache_miss: bool,
+    gather_uvm_cache_stats: bool,
     fp8_exponent_bits: Optional[int],
     fp8_exponent_bias: Optional[int],
 ) -> None:
@@ -1991,6 +1993,7 @@ def nbit_cache(  # noqa C901
         record_cache_metrics=RecordCacheMetrics(
             record_cache_miss_counter, record_tablewise_cache_miss
         ),
+        gather_uvm_cache_stats=gather_uvm_cache_stats,
         cache_load_factor=cache_load_factor,
         cache_algorithm=cache_alg,
         output_dtype=output_dtype,
@@ -2049,6 +2052,8 @@ def nbit_cache(  # noqa C901
     # reset the cache miss counters after warmup
     if record_cache_miss_counter or record_tablewise_cache_miss:
         emb.reset_cache_miss_counter()
+    if gather_uvm_cache_stats:
+        emb.reset_uvm_cache_stats()
 
     for indices, offsets, _ in requests:
         # pyre-fixme[29]:
@@ -2098,9 +2103,15 @@ def nbit_cache(  # noqa C901
     )
     if record_cache_miss_counter or record_tablewise_cache_miss:
         emb.print_cache_miss_counter()
+    if gather_uvm_cache_stats:
+        emb.print_uvm_cache_stats()
+
     # benchmark prefetch
     if record_cache_miss_counter or record_tablewise_cache_miss:
         emb.reset_cache_states()
+    if gather_uvm_cache_stats:
+        emb.reset_uvm_cache_stats()
+
     for indices, offsets, _ in warmup_requests:
         emb.forward(indices, offsets)
 

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -4208,6 +4208,123 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 for i in range(len(tablewise_cache_miss)):
                     self.assertEqual(tablewise_cache_miss[i], t_tablewise_cache_miss[i])
 
+    @unittest.skipIf(*gpu_unavailable)
+    @given(
+        N=st.integers(min_value=1, max_value=8),
+        dtype=st.sampled_from([SparseType.INT8, SparseType.INT4, SparseType.INT2]),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    def test_nbit_uvm_cache_stats(self, N: int, dtype: SparseType) -> None:
+        # Create an abstract split table
+        D = 8
+        T = 2
+        E = 10**3
+        Ds = [D] * T
+        Es = [E] * T
+        cc = split_table_batched_embeddings_ops.IntNBitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (
+                    "",
+                    E,
+                    D,
+                    dtype,
+                    split_table_batched_embeddings_ops.EmbeddingLocation.MANAGED_CACHING,
+                )
+                for (E, D) in zip(Es, Ds)
+            ],
+            device=torch.cuda.current_device(),
+            gather_uvm_cache_stats=True,
+        )
+        cc.fill_random_weights()
+
+        # Create fake input data and the target output
+        x1 = torch.Tensor([[[1], [1]], [[3], [4]]]).cuda()
+        x2 = torch.Tensor([[[2], [1]], [[3], [4]]]).cuda()
+        x3 = torch.Tensor([[[5], [6]], [[7], [8]]]).cuda()
+
+        xs = [x1, x2, x3]
+        # num_unique_indices, num_unique_misses
+        # note that these are cumulative over calls; and also "unique" is per batch.
+        target_counter_list = [[3, 3], [4, 4], [4, 8]]
+        num_calls_expected = 0
+        num_indices_expcted = 0
+        num_unique_indices_expected = 0
+        for x, t_counter in zip(xs, target_counter_list):
+            (indices, offsets) = get_table_batched_offsets_from_dense(x, use_cpu=False)
+            for _ in range(N):
+                num_calls_expected = num_calls_expected + 1
+                num_indices_expcted = num_indices_expcted + len(indices)
+                cc(indices.int(), offsets.int())
+                (
+                    num_calls,
+                    num_indices,
+                    num_unique_indices,
+                    num_unique_misses,
+                    num_conflict_unique_miss,
+                    num_conflict_miss,
+                ) = cc.get_uvm_cache_stats().cpu()
+                # Note num_unique_indices is cumulative stats.
+                num_unique_indices_expected = num_unique_indices_expected + t_counter[0]
+                self.assertEqual(num_calls, num_calls_expected)
+                self.assertEqual(num_indices, num_indices_expcted)
+                self.assertEqual(num_unique_indices, num_unique_indices_expected)
+                self.assertEqual(num_unique_misses, t_counter[1])
+                self.assertEqual(num_conflict_unique_miss, 0)
+                self.assertEqual(num_conflict_miss, 0)
+
+        T = 1  # for simplicity
+        Ds = [D] * T
+        Es = [E] * T
+        cc1 = split_table_batched_embeddings_ops.IntNBitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (
+                    "",
+                    E,
+                    D,
+                    SparseType.INT8,
+                    split_table_batched_embeddings_ops.EmbeddingLocation.MANAGED_CACHING,
+                )
+                for (E, D) in zip(Es, Ds)
+            ],
+            device=torch.cuda.current_device(),
+            gather_uvm_cache_stats=True,
+            cache_sets=1,  # Only one set.
+        )
+        cc1.fill_random_weights()
+
+        associativty = (
+            split_table_batched_embeddings_ops.DEFAULT_ASSOC
+        )  # 32 for NVidia / 64 for AMD.
+        repetition = 17
+        indices1 = torch.Tensor(
+            [[list(range(0, associativty))] * repetition]
+        ).cuda()  # 0, 1, ..., 31.
+        indices2 = torch.Tensor(
+            [[list(range(0, associativty + 1))] * repetition]
+        ).cuda()  # 0, 1, ..., 31, 32.
+        indices3 = torch.Tensor(
+            [[list(range(0, associativty + 10))] * repetition]
+        ).cuda()  # 0, 1, ..., 31, 32, ..., 41.
+
+        # num_conflict_unique_miss, num_conflict_miss
+        expected = [[0, 0], [1, 17], [10, 170]]
+
+        for x, e in zip((indices1, indices2, indices3), expected):
+            (indices, offsets) = get_table_batched_offsets_from_dense(x, use_cpu=False)
+            for _ in range(N):
+                cc1(indices.int(), offsets.int())
+                (
+                    _,
+                    _,
+                    _,
+                    _,
+                    num_conflict_unique_miss,
+                    num_conflict_miss,
+                ) = cc1.get_uvm_cache_stats().cpu()
+                self.assertEqual(num_conflict_unique_miss, e[0])
+                self.assertEqual(num_conflict_miss, e[1])
+                cc1.reset_uvm_cache_stats()
+
     @given(
         T=st.integers(min_value=1, max_value=64),
         B=st.integers(min_value=1, max_value=64),


### PR DESCRIPTION
Summary:
This diff implements frontend (python) changes as well as unit testing.

Add low-overhead hit / miss counter to UVM_CACHING (currently, only for inference). The plan is to turn this on when UVM_CACHING is being used.
Stats are gathered from the GPU kernels (thus, we can get more info, like conflict miss); gathered stats stay in GPU memory -- no GPU to CPU traffic -- until we read it, which may be done only once in a while (every 60 sec?)
Using int32_t for counters -- atomicAdd seems to be pretty slow with int64_t?
int32_t stats for a batch is accumulated to int64_t stats at the end of cache prefetch related kernels.
Function signatures of lru_cache_populate_byte and lxu_cache_lookup are changed, but the additional args are at the end and with default value or optional, so the existing calls wouldn't be impacted (in general).

Differential Revision: D40569821

