### PR TITLE
Add group_index_select_dim0

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -685,5 +685,32 @@ at::Tensor index_add_with_unique_indices_cuda(
     std::vector<int64_t>& input_shape,
     const int consecutive_range_start,
     const int consecutive_range_length);
+
+///@ingroup sparse-data-cuda
+std::vector<at::Tensor> group_index_select_cuda(
+    const int64_t* input_ptrs,
+    const int64_t* indices_ptrs,
+    const c10::TensorOptions& input_tensor_options,
+    const c10::ScalarType& input_scalar_type,
+    const c10::ScalarType& indices_scalar_type,
+    const c10::DeviceIndex& device,
+    const std::vector<int64_t>& output_shape,
+    const int num_input_rows,
+    const int num_output_rows,
+    const int num_cols,
+    const int num_groups);
+
+std::vector<at::Tensor> group_index_add_cuda(
+    const int64_t* input_ptrs,
+    const int64_t* indices_ptrs,
+    const c10::TensorOptions& input_tensor_options,
+    const c10::ScalarType& input_scalar_type,
+    const c10::ScalarType& indices_scalar_type,
+    const c10::DeviceIndex& device,
+    const std::vector<int64_t>& output_shape,
+    const int num_input_rows,
+    const int num_output_rows,
+    const int num_cols,
+    const int num_groups);
 #endif
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/sparse_ops_gpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_gpu.cpp
@@ -17,6 +17,60 @@
 using Tensor = at::Tensor;
 
 namespace fbgemm_gpu {
+
+namespace {
+// From https://stackoverflow.com/a/28411055
+template <typename T, std::size_t... Indices, typename... Args>
+auto vec_to_tup_helper(
+    const std::vector<T>& v,
+    std::index_sequence<Indices...>) {
+  return std::make_tuple(v[Indices]...);
+}
+
+template <std::size_t N, typename T>
+auto vec_to_tup(const std::vector<T>& v) {
+  assert(v.size() >= N);
+  return vec_to_tup_helper(v, std::make_index_sequence<N>());
+}
+
+template <typename T, typename F>
+void apply_(F fn, const std::vector<T>& v) {
+  auto size = v.size();
+#define APPLY_AUTOGRAD_FN_N(N)          \
+  {                                     \
+    case N:                             \
+      std::apply(fn, vec_to_tup<N>(v)); \
+      break;                            \
+  }
+
+#define APPLY_AUTOGRAD_FN_2N(N) \
+  APPLY_AUTOGRAD_FN_N(N)        \
+  APPLY_AUTOGRAD_FN_N(N + 1)
+
+#define APPLY_AUTOGRAD_FN_6N(N) \
+  APPLY_AUTOGRAD_FN_2N(N)       \
+  APPLY_AUTOGRAD_FN_2N(N + 2)   \
+  APPLY_AUTOGRAD_FN_2N(N + 4)
+
+#define APPLY_AUTOGRAD_FN_18N(N) \
+  APPLY_AUTOGRAD_FN_6N(N)        \
+  APPLY_AUTOGRAD_FN_6N(N + 6)    \
+  APPLY_AUTOGRAD_FN_6N(N + 12)
+
+#define APPLY_AUTOGRAD_FN_54N(N) \
+  APPLY_AUTOGRAD_FN_18N(N)       \
+  APPLY_AUTOGRAD_FN_18N(N + 18)  \
+  APPLY_AUTOGRAD_FN_18N(N + 36)
+
+  switch (size) {
+    APPLY_AUTOGRAD_FN_54N(1)
+    default:
+      TORCH_CHECK(false, "size is not supported ", size)
+  }
+#undef APPLY_AUTOGRAD_FN
+}
+} // namespace
+
 // Custom PackSegments operator that is based on the Caffe2 PackSegments and
 // UnpackSegments.
 // Needed this to support backward pass.
@@ -184,6 +238,158 @@ class IndexSelectDim0GPUOp
   }
 };
 
+class GroupIndexSelectDim0GPUOp
+    : public torch::autograd::Function<GroupIndexSelectDim0GPUOp> {
+ public:
+  template <class... Tensors>
+  static torch::autograd::variable_list forward(
+      torch::autograd::AutogradContext* ctx,
+      const std::vector<Tensor>& indices_group,
+      Tensors&&... input_tensors) {
+    std::vector<Tensor> input_group = {input_tensors...};
+    const int32_t num_groups = input_group.size();
+    if (num_groups == 0) {
+      return {torch::autograd::Variable()};
+    }
+
+    TORCH_CHECK(num_groups == (int32_t)indices_group.size())
+
+    Tensor all_ptrs = at::empty(
+        {(int64_t)num_groups * 2},
+        at::TensorOptions().dtype(at::kLong).pinned_memory(true));
+    int64_t* all_ptrs_buf = all_ptrs.data_ptr<int64_t>();
+
+    auto& first_input = input_group[0];
+    auto& first_indices = indices_group[0];
+
+    const int num_output_rows = first_indices.size(0);
+    const int num_input_rows = first_input.size(0);
+    Tensor input_reshaped = first_input.reshape({num_input_rows, -1});
+    const int num_cols = input_reshaped.size(1);
+
+    std::vector<Tensor> saved_list;
+    saved_list.reserve(num_groups + 1);
+    for (int i = 0; i < num_groups; i++) {
+      auto& input = input_group[i];
+      auto& indices = indices_group[i];
+
+      // Verify that all tensors are on the same GPU
+      TENSOR_ON_CUDA_GPU(input);
+      TENSOR_ON_CUDA_GPU(indices);
+      TENSORS_ON_SAME_DEVICE(input, indices);
+
+      // Verify that all input tensors have the same shape
+      TORCH_CHECK(num_output_rows == indices.size(0))
+      TORCH_CHECK(num_input_rows == input.size(0))
+      Tensor input_reshaped_ = input.reshape({num_input_rows, -1});
+      TORCH_CHECK(num_cols == input_reshaped_.size(1))
+
+      // Put all pointers in an array
+      all_ptrs_buf[i] = reinterpret_cast<int64_t>(input.data_ptr());
+      all_ptrs_buf[i + num_groups] =
+          reinterpret_cast<int64_t>(indices.data_ptr());
+
+      // Save indices for backward
+      saved_list.push_back(indices);
+    }
+    // Store one input tensor to get input tensor property in backward
+    saved_list.push_back(input_group[0]);
+    // Transfer input pointers to GPU
+    all_ptrs = all_ptrs.to(first_input.device(), /*non_blocking=*/true);
+    // Save pointers for backward
+    saved_list.push_back(all_ptrs);
+
+    ctx->save_for_backward(saved_list);
+    ctx->saved_data["input_shape"] = first_input.sizes().vec();
+    ctx->saved_data["num_groups"] = num_groups;
+    ctx->saved_data["num_cols"] = num_cols;
+
+    auto output_shape = first_input.sizes().vec();
+    output_shape[0] = num_groups * num_output_rows;
+
+    return group_index_select_cuda(
+        all_ptrs.data_ptr<int64_t>(),
+        all_ptrs.data_ptr<int64_t>() + num_groups,
+        first_input.options(),
+        first_input.scalar_type(),
+        first_indices.scalar_type(),
+        first_input.device().index(),
+        output_shape,
+        num_input_rows,
+        num_output_rows,
+        num_cols,
+        num_groups);
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext* ctx,
+      torch::autograd::variable_list grad_output_group) {
+    const int num_groups = ctx->saved_data["num_groups"].toInt();
+    const int num_cols = ctx->saved_data["num_cols"].toInt();
+    auto output_shape = ctx->saved_data["input_shape"].toIntVector();
+    const int num_output_rows = output_shape[0];
+    output_shape[0] *= num_groups;
+
+    TORCH_CHECK((int32_t)grad_output_group.size() == num_groups);
+
+    if (num_groups == 0) {
+      return torch::autograd::variable_list();
+    }
+
+    const int num_input_rows = grad_output_group[0].size(0);
+
+    const auto saved = ctx->get_saved_variables();
+    const auto saved_itr = std::begin(saved);
+    Tensor first_indices = *saved_itr;
+    Tensor fwd_input = *(saved_itr + num_groups);
+    // Get indices pointers from all_ptrs saved in forward
+    int64_t* indices_ptrs =
+        (saved_itr + num_groups + 1)->data_ptr<int64_t>() + num_groups;
+
+    Tensor grad_output_ptrs = at::empty(
+        {num_groups}, at::TensorOptions().dtype(at::kLong).pinned_memory(true));
+    int64_t* grad_output_ptrs_buf = grad_output_ptrs.data_ptr<int64_t>();
+    for (int i = 0; i < num_groups; i++) {
+      Tensor& grad = grad_output_group[i];
+      TENSOR_ON_CUDA_GPU(grad);
+      TENSORS_ON_SAME_DEVICE(grad, first_indices);
+
+      // Put all grad output pointers in an array
+      grad_output_ptrs_buf[i] = reinterpret_cast<int64_t>(grad.data_ptr());
+    }
+    // Transfer grad output pointers to GPU
+    grad_output_ptrs =
+        grad_output_ptrs.to(first_indices.device(), /*non_blocking=*/true);
+
+    std::vector<Tensor> output_group;
+    output_group.reserve(num_groups + 1);
+    output_group.push_back(torch::autograd::Variable());
+
+    auto output_index_add_group = group_index_add_cuda(
+        grad_output_ptrs.data_ptr<int64_t>(),
+        indices_ptrs,
+        fwd_input.options(),
+        fwd_input.scalar_type(),
+        first_indices.scalar_type(),
+        fwd_input.device().index(),
+        output_shape,
+        num_input_rows,
+        num_output_rows,
+        num_cols,
+        num_groups);
+
+    // This can be slow because the complexity is O(num_groups)
+    output_group.insert(
+        output_group.end(),
+        output_index_add_group.begin(),
+        output_index_add_group.end());
+
+    TORCH_CHECK((int)output_group.size() == num_groups + 1)
+
+    return output_group;
+  }
+};
+
 Tensor pack_segments_cuda(
     const Tensor& t_in,
     const Tensor& lengths,
@@ -208,6 +414,19 @@ Tensor index_select_dim0_gpu(
       // Always skip indices sorting if doing forward only
       user_skip_indices_sorting_fwd && !c10::InferenceMode::is_enabled())[0];
 }
+
+std::vector<Tensor> group_index_select_dim0_gpu(
+    const std::vector<Tensor>& input_group,
+    const std::vector<Tensor>& indices_group) {
+  std::vector<Tensor> output_group;
+  apply_(
+      [&](auto&&... args) {
+        output_group = GroupIndexSelectDim0GPUOp::apply(indices_group, args...);
+      },
+      input_group);
+  return output_group;
+}
+
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
@@ -268,4 +487,6 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
       fbgemm_gpu::permute_sequence_embeddings_cuda);
   DISPATCH_TO_CUDA("pack_segments", fbgemm_gpu::pack_segments_cuda);
   DISPATCH_TO_CUDA("index_select_dim0", fbgemm_gpu::index_select_dim0_gpu);
+  DISPATCH_TO_CUDA(
+      "group_index_select_dim0", fbgemm_gpu::group_index_select_dim0_gpu);
 }


### PR DESCRIPTION
Summary:
`group_index_select_dim0` does `index_select_dim0` for each group of
inputs in a single kernel.  The operator takes a list of inputs and a
list of indices and returns a list of outputs.

There are some limitations to group_index_select_dim0:
- All inputs must have the same shape.
- All indices must have the same shape.
- Because we use variadic template for the autograd function, it
supports up to 55 groups.

Differential Revision: D40683435

