### PR TITLE
Back out "Set negative index (due to pruning) to max_offset in linearize kernel"

### DIFF
--- a/fbgemm_gpu/src/split_embeddings_cache_cuda.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache_cuda.cu
@@ -260,11 +260,9 @@ __global__ __launch_bounds__(kMaxThreads) void linearize_cache_indices_kernel(
   const auto max_offset =
       ::__ldg(&cache_hash_size_cumsum[cache_hash_size_cumsum.size(0) - 1]);
   const auto curr_offset = ::__ldg(&cache_hash_size_cumsum[table_index]);
-  if (curr_offset >= 0 && indices[index] >= 0) {
+  if (curr_offset >= 0) {
     linear_cache_indices[index] = indices[index] + curr_offset;
   } else {
-    // Either table index is wrong, or index value is negative (due to pruning):
-    // set it to invalid value.
     linear_cache_indices[index] = max_offset;
   }
 }

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -4618,11 +4618,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             dtype=torch.int,
             device="cuda",
         )
-        pruned_indices = torch.tensor(
-            [10, -1, 3, 7, 1, 4, -1, 9, 2, -1, 6, 8, 5, 1, -1, 4],
-            dtype=torch.int,
-            device="cuda",
-        )
         equal_offsets = torch.tensor([0, 4, 8, 12, 16], dtype=torch.int, device="cuda")
         varying_offsets = torch.tensor(
             [0, 1, 3, 6, 8, 10, 14, 15, 16], dtype=torch.int, device="cuda"
@@ -4683,36 +4678,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 linear_cache_indices_3.cpu(),
                 torch.tensor(
                     [10, 2, 3, 7, 1, 4, 5, 9, 14, 19, 18, 20, 17, 13, 12, 16],
-                    dtype=torch.int,
-                ),
-            )
-        )
-
-        # Testing equal sized tables + pruned indices
-        cache_hash_size_cumsum_4 = torch.tensor([0, 12, 24, 36, 48]).cuda()
-        linear_cache_indices_4 = torch.ops.fbgemm.linearize_cache_indices(
-            cache_hash_size_cumsum_4, pruned_indices, equal_offsets
-        )
-        self.assertTrue(
-            torch.equal(
-                linear_cache_indices_4.cpu(),
-                torch.tensor(
-                    [10, 48, 3, 7, 13, 16, 48, 21, 26, 48, 30, 32, 41, 37, 48, 40],
-                    dtype=torch.int,
-                ),
-            )
-        )
-
-        # Testing batched with varying pooling factor + pruned indices
-        cache_hash_size_cumsum_5 = torch.tensor([0, 12, -1, 24, 36]).cuda()
-        linear_cache_indices_5 = torch.ops.fbgemm.linearize_cache_indices(
-            cache_hash_size_cumsum_5, pruned_indices, varying_offsets
-        )
-        self.assertTrue(
-            torch.equal(
-                linear_cache_indices_5.cpu(),
-                torch.tensor(
-                    [10, 36, 3, 19, 13, 16, 36, 21, 36, 36, 36, 36, 36, 36, 36, 28],
                     dtype=torch.int,
                 ),
             )


### PR DESCRIPTION
Summary:
Original commit changeset: 72019f445ac8

Original Phabricator Diff: D40788589 (https://github.com/pytorch/FBGEMM/commit/bcc69edc3f24ef8bd607b9bf86d60bb80dac6647)

Differential Revision: D40834080

