### PR TITLE
Add cache update function for delta in-place update

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh
@@ -44,6 +44,15 @@ at::Tensor linearize_cache_indices_cuda(
     at::Tensor offsets);
 
 ///@ingroup table-batched-embed-cuda
+/// Linearize the indices of all tables to make it be unique.
+/// Note the update_table_indices and update_row_indices are
+/// from the row indices format for inplace update.
+at::Tensor linearize_cache_indices_from_row_idx_cuda(
+    at::Tensor cache_hash_size_cumsum,
+    at::Tensor update_table_indices,
+    at::Tensor update_row_indices);
+
+///@ingroup table-batched-embed-cuda
 /// LRU cache: fetch the rows corresponding to `linear_cache_indices` from
 ///`weights`, and insert them into the cache at timestep `time_stamp`.
 void lru_cache_populate_cuda(

--- a/fbgemm_gpu/src/split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/split_table_batched_embeddings.cpp
@@ -18,6 +18,11 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "linearize_cache_indices(Tensor cache_hash_size_cumsum, Tensor indices, Tensor offsets) -> Tensor");
   DISPATCH_TO_CUDA("linearize_cache_indices", linearize_cache_indices_cuda);
   m.def(
+      "linearize_cache_indices_from_row_idx(Tensor cache_hash_size_cumsum, Tensor update_table_indices, Tensor update_row_indices) -> Tensor");
+  DISPATCH_TO_CUDA(
+      "linearize_cache_indices_from_row_idx",
+      linearize_cache_indices_from_row_idx_cuda);
+  m.def(
       "lru_cache_populate(Tensor weights, Tensor hash_size_cumsum, int total_cache_hash_size, Tensor cache_index_table_map, Tensor weights_offsets, Tensor D_offsets, Tensor linear_cache_indices, Tensor(a!) lxu_cache_state, Tensor(b!) lxu_cache_weights, int time_stamp, Tensor(c!) lru_state, bool stochastic_rounding) -> ()");
   DISPATCH_TO_CUDA("lru_cache_populate", lru_cache_populate_cuda);
   m.def(


### PR DESCRIPTION
Summary: With inplace update, we need to update dev_weights, uvm_weights, as well as the cache_weights (note that during inference, cache is read-only; but in the inplace delta update, cache needs to be updated. Since we don't have "write back"/flushing cache (when inference finishes, or cache evicts) during inference, we need to update cache weight **and** the back storage (uvm weight) simultaneously during the inplace delta update.

Differential Revision: D39158010

