### PR TITLE
Replace torch.classes.fb.PrunedMapCPU with torch.classes.fbgemm.PrunedMapCPU

### DIFF
--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -2001,7 +2001,7 @@ def hashtable(  # noqa C901
     )
 
     if use_cpu:
-        ht = torch.classes.fb.PrunedMapCPU()
+        ht = torch.classes.fbgemm.PrunedMapCPU()
         ht.insert(chosen_indices, dense_indices, offsets, T)
 
         time_per_iter = benchmark_requests(

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
@@ -397,7 +397,7 @@ class PrunedMapCPU : public torch::jit::CustomClassHolder {
 };
 
 static auto PrunedMapCPURegistry =
-    torch::class_<PrunedMapCPU>("fb", "PrunedMapCPU")
+    torch::class_<PrunedMapCPU>("fbgemm", "PrunedMapCPU")
         .def(torch::init<>())
         .def("insert", &PrunedMapCPU::insert)
         .def("lookup", &PrunedMapCPU::lookup)

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -2636,7 +2636,9 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
             offsets = torch.tensor([0] + list(accumulate(original_feature_rows))).int()
 
             if self.use_cpu:
-                self.index_remapping_hash_table_cpu = torch.classes.fb.PrunedMapCPU()
+                self.index_remapping_hash_table_cpu = (
+                    torch.classes.fbgemm.PrunedMapCPU()
+                )
                 self.index_remapping_hash_table_cpu.insert(
                     indices, dense_indices, offsets, T
                 )

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -4104,7 +4104,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         )
 
         if use_cpu_hashtable:
-            ht = torch.classes.fb.PrunedMapCPU()
+            ht = torch.classes.fbgemm.PrunedMapCPU()
             ht.insert(indices, dense_indices, offsets, T)
 
         # Initialize and insert Array index remapping based data structure


### PR DESCRIPTION
Summary:
Instead of torch::class_<PrunedMapCPU>("fb", "PrunedMapCPU") we now register torch::class_<PrunedMapCPU>("fbgemm", "PrunedMapCPU").
Accordingly, renamed all instances of torch.classes.fb.PrunedMapCPU with torch.classes.fbgemm.PrunedMapCPU

Differential Revision: D40953342

