### PR TITLE
Parallelize bottom_unique_k_per_row for faster zipf gen

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -697,5 +697,32 @@ at::Tensor index_add_with_unique_indices_cuda(
     std::vector<int64_t>& input_shape,
     const int consecutive_range_start,
     const int consecutive_range_length);
+
+///@ingroup sparse-data-cuda
+std::vector<at::Tensor> group_index_select_cuda(
+    const int64_t* input_ptrs,
+    const int64_t* indices_ptrs,
+    const c10::TensorOptions& input_tensor_options,
+    const c10::ScalarType& input_scalar_type,
+    const c10::ScalarType& indices_scalar_type,
+    const c10::DeviceIndex& device,
+    const std::vector<int64_t>& output_shape,
+    const int num_input_rows,
+    const int num_output_rows,
+    const int num_cols,
+    const int num_groups);
+
+std::vector<at::Tensor> group_index_add_cuda(
+    const int64_t* input_ptrs,
+    const int64_t* indices_ptrs,
+    const c10::TensorOptions& input_tensor_options,
+    const c10::ScalarType& input_scalar_type,
+    const c10::ScalarType& indices_scalar_type,
+    const c10::DeviceIndex& device,
+    const std::vector<int64_t>& output_shape,
+    const int num_input_rows,
+    const int num_output_rows,
+    const int num_cols,
+    const int num_groups);
 #endif
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/jagged_tensor_ops.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops.cu
@@ -2556,6 +2556,414 @@ std::vector<Tensor> stacked_jagged_2d_to_dense_gpu(
       values, lengths, offset_per_key, max_lengths_per_key, padding_value);
 }
 
+template <
+    typename scalar_t,
+    typename index_t,
+    typename offset_t,
+    typename weight_t,
+    bool has_weights>
+__global__ void keyed_jagged_index_select_dim1_kernel(
+    scalar_t* output,
+    weight_t* output_weights,
+    const scalar_t* input,
+    const weight_t* weights,
+    const offset_t* input_offsets,
+    const index_t* indices,
+    const offset_t* output_offsets,
+    const int num_batches,
+    const int input_batch_size,
+    const int output_batch_size,
+    const int64_t num_outputs) {
+  const int64_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (tid < num_outputs) {
+    // Each thread searches index position
+    int index_pos;
+    binary_search_range(
+        &index_pos,
+        output_offsets,
+        (offset_t)tid,
+        num_batches * output_batch_size);
+
+    const offset_t rel_index =
+        tid - (index_pos == 0 ? 0 : output_offsets[index_pos - 1]);
+
+    // indices are the same for all batches
+    const index_t index = indices[index_pos % output_batch_size];
+    const int bid = index_pos / output_batch_size;
+    const offset_t input_offset =
+        (index == 0 && bid == 0
+             ? 0
+             : input_offsets[bid * input_batch_size + index - 1]) +
+        rel_index;
+
+    // Store data
+    output[tid] = input[input_offset];
+    if (has_weights) {
+      output_weights[tid] = weights[input_offset];
+    }
+  }
+}
+
+template <typename scalar_t, typename index_t, typename offset_t>
+__global__ void keyed_jagged_index_add_dim1_kernel(
+    scalar_t* output,
+    const scalar_t* input,
+    const offset_t* input_offsets,
+    const index_t* indices,
+    const offset_t* output_offsets,
+    const int num_batches,
+    const int input_batch_size,
+    const int output_batch_size,
+    const int64_t num_inputs) {
+  const int64_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (tid < num_inputs) {
+    // Each thread searches index position
+    int index_pos;
+    binary_search_range(
+        &index_pos,
+        input_offsets,
+        (offset_t)tid,
+        num_batches * input_batch_size);
+
+    const offset_t rel_index =
+        tid - (index_pos == 0 ? 0 : input_offsets[index_pos - 1]);
+
+    // indices are the same for all batches
+    const index_t index = indices[index_pos % input_batch_size];
+    const int bid = index_pos / input_batch_size;
+    const offset_t output_offset =
+        (index == 0 && bid == 0
+             ? 0
+             : output_offsets[bid * output_batch_size + index - 1]) +
+        rel_index;
+
+    // Store data
+    gpuAtomicAdd(&output[output_offset], input[tid]);
+  }
+}
+
+template <
+    typename scalar_t,
+    typename index_t,
+    typename acc_t,
+    int NUM_THREADS_PER_BLOCK,
+    int MAX_ENTRIES_PER_BLOCK>
+__global__ void index_select_scalar_cumsum_kernel(
+    scalar_t* output,
+    acc_t* output_cumsum,
+    const scalar_t* __restrict__ input,
+    const index_t* __restrict__ indices,
+    const int num_batches,
+    const int input_batch_size,
+    const int output_batch_size,
+    const int last_block_num_entries,
+    int* block_flags,
+    acc_t* block_sums) {
+  typedef cub::BlockScan<acc_t, NUM_THREADS_PER_BLOCK> BlockScan;
+  __shared__ typename BlockScan::TempStorage bs_temp_storage;
+  __shared__ acc_t smem[MAX_ENTRIES_PER_BLOCK];
+  const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const int bid = tid / output_batch_size;
+  const int num_entries_per_block = blockIdx.x == gridDim.x - 1
+      ? last_block_num_entries
+      : MAX_ENTRIES_PER_BLOCK;
+
+  // Load data
+  acc_t local_data[1];
+  if (tid < num_batches * output_batch_size) {
+    *local_data =
+        input[bid * input_batch_size + indices[tid % output_batch_size]];
+    output[tid] = *local_data;
+  } else {
+    *local_data = 0;
+  }
+
+  // Cumsum
+  inclusive_sum_scan_kernel<acc_t, 1, NUM_THREADS_PER_BLOCK>(
+      local_data,
+      bs_temp_storage,
+      block_flags,
+      block_sums,
+      &smem[0],
+      num_entries_per_block,
+      blockIdx.x,
+      gridDim.x > 1,
+      1);
+
+  // Store data
+  if (tid < num_batches * output_batch_size) {
+    output_cumsum[tid] = *local_data;
+  }
+}
+
+class KeyedJaggedIndexSelectDim1GPUOp
+    : public torch::autograd::Function<KeyedJaggedIndexSelectDim1GPUOp> {
+ public:
+  static torch::autograd::variable_list forward(
+      torch::autograd::AutogradContext* ctx,
+      const Tensor& values,
+      const Tensor& lengths,
+      const Tensor& offsets,
+      const Tensor& indices, // select same indices for all batches
+      const int batch_size,
+      const c10::optional<Tensor>& weights) {
+    // TODO: Add weights support
+    TENSOR_ON_CUDA_GPU(lengths);
+    TENSOR_ON_CUDA_GPU(offsets);
+    TENSOR_ON_CUDA_GPU(values);
+    TENSOR_ON_CUDA_GPU(indices);
+    TENSORS_ON_SAME_DEVICE(lengths, indices);
+    TENSORS_ON_SAME_DEVICE(offsets, indices);
+    TENSORS_ON_SAME_DEVICE(values, indices);
+    TORCH_CHECK(values.dim() == 1, "values must be a 1D tensor");
+    TORCH_CHECK(lengths.dim() == 1, "lengths must be a 1D tensor");
+    TORCH_CHECK(offsets.dim() == 1, "offsets must be a 1D tensor");
+    TORCH_CHECK(indices.dim() == 1, "indices must be a 1D tensor");
+    TORCH_CHECK(
+        lengths.numel() + 1 == offsets.numel(),
+        "offsets size must be lengths size + 1");
+    TORCH_CHECK(lengths.numel() % batch_size == 0, "lengths");
+
+    if (weights.has_value()) {
+      const Tensor& pos_weights = weights.value();
+      TENSOR_ON_CUDA_GPU(pos_weights);
+      TENSORS_ON_SAME_DEVICE(pos_weights, indices);
+      TORCH_CHECK(pos_weights.dim() == 1, "weights must be a 1D tensor");
+      TORCH_CHECK(
+          pos_weights.numel() == values.numel(),
+          "weights size and values size must be the same");
+    }
+
+    at::cuda::OptionalCUDAGuard device_guard;
+    device_guard.set_index(values.get_device());
+
+    const int num_batches = lengths.numel() / batch_size;
+    const int num_output_lengths = num_batches * indices.numel();
+    const int MAX_CUMSUM_ENTRIES_PER_BLOCK = 256;
+    auto grid_size = cuda_calc_xblock_count(
+        num_output_lengths, MAX_CUMSUM_ENTRIES_PER_BLOCK);
+
+    Tensor output_offsets =
+        at::empty({num_batches * indices.numel()}, offsets.options());
+    Tensor output_lengths =
+        at::empty({num_batches * indices.numel()}, lengths.options());
+
+    Tensor block_flags, block_sums;
+    if (grid_size > 1) {
+      block_flags = at::zeros({grid_size}, lengths.options().dtype(at::kInt));
+      block_sums = at::empty({grid_size}, output_offsets.options());
+    }
+    // Do index select and cumsum
+    AT_DISPATCH_INDEX_TYPES(
+        lengths.scalar_type(), "index_select_scalar_cumsum_wrapper_1", [&] {
+          using length_t = index_t;
+          AT_DISPATCH_INDEX_TYPES(
+              offsets.scalar_type(),
+              "index_select_scalar_cumsum_wrapper_2",
+              [&] {
+                using offset_t = index_t;
+                AT_DISPATCH_INDEX_TYPES(
+                    indices.scalar_type(),
+                    "index_select_scalar_cumsum_wrapper_3",
+                    [&] {
+                      index_select_scalar_cumsum_kernel<
+                          length_t,
+                          index_t,
+                          offset_t,
+                          MAX_CUMSUM_ENTRIES_PER_BLOCK,
+                          MAX_CUMSUM_ENTRIES_PER_BLOCK>
+                          <<<grid_size,
+                             MAX_CUMSUM_ENTRIES_PER_BLOCK,
+                             0,
+                             at::cuda::getCurrentCUDAStream()>>>(
+                              output_lengths.data_ptr<length_t>(),
+                              output_offsets.data_ptr<offset_t>(),
+                              lengths.data_ptr<length_t>(),
+                              indices.data_ptr<index_t>(),
+                              num_batches,
+                              batch_size,
+                              indices.numel(),
+                              num_output_lengths -
+                                  MAX_CUMSUM_ENTRIES_PER_BLOCK *
+                                      (grid_size - 1),
+                              grid_size > 1 ? block_flags.data_ptr<int>()
+                                            : nullptr,
+                              grid_size > 1 ? block_sums.data_ptr<offset_t>()
+                                            : nullptr);
+                      C10_CUDA_KERNEL_LAUNCH_CHECK();
+                    });
+              });
+        });
+
+    // TODO: Try to not do D->H transfer
+    const int64_t num_outputs =
+        output_offsets[output_offsets.numel() - 1].item<int64_t>();
+    Tensor output = at::empty({num_outputs}, values.options());
+    Tensor output_weights;
+    if (weights.has_value()) {
+      output_weights = at::empty({num_outputs}, weights.value().options());
+    }
+    grid_size = cuda_calc_xblock_count(num_outputs, kMaxThreads);
+
+#define LAUNCH_KERNEL(WEIGHTED, WEIGHT_TYPE, OUTPUT_WEIGHTS, WEIGHTS)      \
+  {                                                                        \
+    keyed_jagged_index_select_dim1_kernel<                                 \
+        value_t,                                                           \
+        index_t,                                                           \
+        offset_t,                                                          \
+        WEIGHT_TYPE,                                                       \
+        WEIGHTED>                                                          \
+        <<<grid_size, kMaxThreads, 0, at::cuda::getCurrentCUDAStream()>>>( \
+            output.data_ptr<value_t>(),                                    \
+            OUTPUT_WEIGHTS,                                                \
+            values.data_ptr<value_t>(),                                    \
+            WEIGHTS,                                                       \
+            offsets.data_ptr<offset_t>() + 1,                              \
+            indices.data_ptr<index_t>(),                                   \
+            output_offsets.data_ptr<offset_t>(),                           \
+            num_batches,                                                   \
+            batch_size,                                                    \
+            indices.numel(),                                               \
+            num_outputs);                                                  \
+  }
+
+    AT_DISPATCH_ALL_TYPES_AND(
+        at::ScalarType::Half,
+        values.scalar_type(),
+        "keyed_jagged_index_select_dim1_warpper_1",
+        [&] {
+          using value_t = scalar_t;
+          AT_DISPATCH_INDEX_TYPES(
+              offsets.scalar_type(),
+              "keyed_jagged_index_select_dim1_warpper_2",
+              [&] {
+                using offset_t = index_t;
+                AT_DISPATCH_INDEX_TYPES(
+                    indices.scalar_type(),
+                    "keyed_jagged_index_select_dim1_warpper_3",
+                    [&] {
+                      if (weights.has_value()) {
+                        AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+                            weights.value().scalar_type(),
+                            "keyed_jagged_index_select_dim1_warpper_4",
+                            [&] {
+                              using weight_t = scalar_t;
+                              LAUNCH_KERNEL(
+                                  true,
+                                  weight_t,
+                                  output_weights.data_ptr<weight_t>(),
+                                  weights.value().data_ptr<weight_t>())
+                            });
+                      } else {
+                        LAUNCH_KERNEL(false, scalar_t, nullptr, nullptr)
+                      }
+                      C10_CUDA_KERNEL_LAUNCH_CHECK();
+                    });
+              });
+        });
+
+#undef LAUNCH_KERNEL
+
+    ctx->save_for_backward({indices, output_offsets, offsets});
+    ctx->saved_data["num_outputs"] = num_outputs;
+    ctx->saved_data["num_inputs"] = values.numel();
+    ctx->saved_data["batch_size"] = batch_size;
+    ctx->saved_data["num_batches"] = num_batches;
+    ctx->saved_data["has_weights"] = weights.has_value();
+
+    if (weights.has_value()) {
+      return {output, output_lengths, output_weights};
+    }
+    return {output, output_lengths};
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext* ctx,
+      torch::autograd::variable_list grad_outputs) {
+    bool has_weights = ctx->saved_data["has_weights"].toBool();
+    TORCH_CHECK(
+        (has_weights && grad_outputs.size() == 3) || grad_outputs.size() == 2);
+
+    const Tensor& grad = grad_outputs[0];
+    TENSOR_ON_CUDA_GPU(grad_outputs[0]);
+
+    const auto saved = ctx->get_saved_variables();
+    auto savedItr = std::begin(saved);
+    const Tensor& indices = *savedItr++;
+    const Tensor& grad_offsets = *savedItr++;
+    const Tensor& output_offsets = *savedItr++;
+
+    TENSORS_ON_SAME_DEVICE(grad, indices);
+
+    int64_t num_grads = ctx->saved_data["num_outputs"].toInt();
+    int64_t num_outputs = ctx->saved_data["num_inputs"].toInt();
+    int64_t output_batch_size = ctx->saved_data["batch_size"].toInt();
+    int64_t num_batches = ctx->saved_data["num_batches"].toInt();
+
+    at::cuda::OptionalCUDAGuard device_guard;
+    device_guard.set_index(grad.get_device());
+
+    Tensor grad_input = at::zeros({num_outputs}, grad.options());
+    auto grid_size = cuda_calc_xblock_count(grad.numel(), kMaxThreads);
+
+    AT_DISPATCH_ALL_TYPES_AND(
+        at::ScalarType::Half,
+        grad.scalar_type(),
+        "keyed_jagged_index_add_dim1_wrapper_1",
+        [&] {
+          AT_DISPATCH_INDEX_TYPES(
+              grad_offsets.scalar_type(),
+              "keyed_jagged_index_add_dim1_wrapper_2",
+              [&] {
+                using offset_t = index_t;
+                AT_DISPATCH_INDEX_TYPES(
+                    indices.scalar_type(),
+                    "keyed_jagged_index_add_dim1_wrapper_3",
+                    [&] {
+                      keyed_jagged_index_add_dim1_kernel<<<
+                          grid_size,
+                          kMaxThreads,
+                          0,
+                          at::cuda::getCurrentCUDAStream()>>>(
+                          grad_input.data_ptr<scalar_t>(),
+                          grad.data_ptr<scalar_t>(),
+                          grad_offsets.data_ptr<offset_t>(),
+                          indices.data_ptr<index_t>(),
+                          output_offsets.data_ptr<offset_t>() +
+                              1, // shift it to make it inclusive cumsum
+                          num_batches,
+                          indices.numel(),
+                          output_batch_size,
+                          grad.numel());
+                      C10_CUDA_KERNEL_LAUNCH_CHECK();
+                    });
+              });
+        });
+
+    return {
+        grad_input,
+        torch::autograd::Variable(), // lengths
+        torch::autograd::Variable(), // offsets
+        torch::autograd::Variable(), // indices
+        torch::autograd::Variable(), // batch_size
+        torch::autograd::Variable() // weights
+    };
+  }
+};
+
+std::vector<Tensor> keyed_jagged_index_select_dim_1_gpu(
+    const Tensor& values,
+    const Tensor& lengths,
+    const Tensor& offsets,
+    const Tensor& indices,
+    const int64_t batch_size,
+    const c10::optional<Tensor>& weights) {
+  return KeyedJaggedIndexSelectDim1GPUOp::apply(
+      values, lengths, offsets, indices, batch_size, weights);
+}
+
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
@@ -2577,7 +2985,6 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
       fbgemm_gpu::batched_dense_vec_jagged_2d_mul);
   DISPATCH_TO_CUDA(
       "jagged_index_select", fbgemm_gpu::jagged_index_select_2d_gpu);
-
   DISPATCH_TO_CUDA("jagged_1d_to_dense", fbgemm_gpu::jagged_1d_to_dense_gpu);
   DISPATCH_TO_CUDA("jagged_2d_to_dense", fbgemm_gpu::jagged_2d_to_dense_gpu);
   DISPATCH_TO_CUDA(
@@ -2590,4 +2997,8 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   DISPATCH_TO_CUDA(
       "stacked_jagged_2d_to_dense_backward",
       fbgemm_gpu::stacked_jagged_2d_to_dense_backward_cuda);
+  // TODO: combine the API with permute_2D_sparse_data and implement a CPU op
+  DISPATCH_TO_CUDA(
+      "keyed_jagged_index_select_dim1",
+      fbgemm_gpu::keyed_jagged_index_select_dim_1_gpu);
 }

--- a/fbgemm_gpu/src/metric_ops.cu
+++ b/fbgemm_gpu/src/metric_ops.cu
@@ -12,17 +12,6 @@
 #include <ATen/cuda/Atomic.cuh>
 #include <algorithm>
 
-// clang-format off
-#ifdef __HIP_PLATFORM_HCC__
-#define HIPCUB_ARCH 1
-#include <hipcub/backend/rocprim/block/block_scan.hpp>
-#else
-#include "fbgemm_gpu/cub_namespace_prefix.cuh"
-#include <cub/block/block_scan.cuh>
-#include "fbgemm_gpu/cub_namespace_postfix.cuh"
-#endif
-// clang-format on
-
 #include "fbgemm_gpu/fbgemm_cuda_utils.cuh"
 #include "metric_ops.h"
 
@@ -30,59 +19,6 @@ constexpr int MAX_ENTRIES_PER_BLOCK = 512;
 constexpr int NUM_THREADS_PER_BLOCK = 256;
 
 namespace fbgemm_gpu {
-
-#ifdef __HIP_PLATFORM_HCC__
-namespace cub = hipcub;
-#endif
-
-template <typename scalar_t, int ITEMS_PER_THREAD>
-__inline__ __device__ void inclusive_sum_scan_kernel(
-    scalar_t (&arr)[ITEMS_PER_THREAD],
-    typename cub::BlockScan<scalar_t, NUM_THREADS_PER_BLOCK>::TempStorage&
-        temp_storage,
-    int* block_flags, // global flags for inter-block sync
-    scalar_t* block_sums, // global sums for inter-block sync
-    scalar_t* block_prev, // shared memory for previous sum sync within a block
-    const int num_entries_per_block,
-    const int block_id,
-    const bool is_multi_block,
-    const int signal) {
-  // Perform scan within a block
-  cub::BlockScan<scalar_t, NUM_THREADS_PER_BLOCK>(temp_storage)
-      .InclusiveSum(arr, arr);
-
-  // Perform stream scan across blocks
-  if (is_multi_block) {
-    // The thread that holds the last entry in the block does synchronization
-    if (threadIdx.x == (num_entries_per_block - 1) / ITEMS_PER_THREAD) {
-      scalar_t block_prev_local = 0;
-      if (block_id != 0) {
-        // Spin wait for the previous block to write the sum value
-        while (atomicAdd(&block_flags[block_id - 1], 0) < signal)
-          ;
-
-        // Get sum from the previous block
-        *block_prev = block_prev_local = block_sums[block_id - 1];
-      }
-
-      // Write sum to global memory for the next block to consume
-      const int scope = (num_entries_per_block - 1) % ITEMS_PER_THREAD;
-      block_sums[block_id] = block_prev_local + arr[scope];
-      __threadfence();
-      // Set a flag to notify the next block
-      atomicAdd(&block_flags[block_id], 1);
-    }
-
-    __syncthreads();
-
-    if (block_id != 0) {
-      scalar_t block_prev_local = *block_prev;
-      for (int i = 0; i < ITEMS_PER_THREAD; i++) {
-        arr[i] += block_prev_local;
-      }
-    }
-  }
-}
 
 template <typename scalar_t>
 __inline__ __device__ void trapz_kernel(
@@ -178,7 +114,7 @@ __global__ void auc_kernel(
 
   __syncthreads();
 
-  inclusive_sum_scan_kernel(
+  inclusive_sum_scan_kernel<acc_t, PADDED_SECTION_SIZE, NUM_THREADS_PER_BLOCK>(
       local_fp,
       bs_temp_storage,
       block_flags,
@@ -189,7 +125,7 @@ __global__ void auc_kernel(
       is_multi_block,
       /*signal=*/1);
 
-  inclusive_sum_scan_kernel(
+  inclusive_sum_scan_kernel<acc_t, PADDED_SECTION_SIZE, NUM_THREADS_PER_BLOCK>(
       local_tp,
       bs_temp_storage,
       block_flags,

--- a/fbgemm_gpu/src/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_cpu.cpp
@@ -2357,6 +2357,19 @@ Tensor index_select_dim0(
   return at::index_select(input, 0, indices);
 }
 
+std::vector<Tensor> group_index_select_dim0(
+    const std::vector<Tensor>& input_group,
+    const std::vector<Tensor>& indices_group) {
+  int num_groups = input_group.size();
+  TORCH_CHECK(num_groups == (int)indices_group.size())
+  std::vector<Tensor> output_group;
+  for (int i = 0; i < num_groups; i++) {
+    output_group.push_back(
+        at::index_select(input_group[i], 0, indices_group[i]));
+  }
+  return output_group;
+}
+
 Tensor bottom_unique_k_per_row(const Tensor& input, const int64_t k) {
   auto num_cols = input.size(-1);
   Tensor input_reshaped = input.reshape({-1, num_cols});
@@ -2389,6 +2402,7 @@ Tensor bottom_unique_k_per_row(const Tensor& input, const int64_t k) {
   output_shape[output_shape.size() - 1] = k;
   return output.reshape(output_shape);
 }
+
 } // namespace
 
 } // namespace fbgemm_gpu
@@ -2459,6 +2473,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "index_select_dim0(Tensor input, Tensor indices, int? consecutive_range_start=0, int? consecutive_range_length=0, bool? skip_indices_sorting_fwd=None) -> Tensor");
   m.def(
+      "group_index_select_dim0(Tensor[] input_group, Tensor[] indices_group) -> Tensor[]");
+  m.def(
       "jagged_index_select(Tensor values, Tensor lengths, Tensor indices) -> Tensor[]");
   // This is an one-off op to be used in bench_utils.py for zipf generation w/o
   // replacement Along dim=-1, find smallest unique k. If the number of unique
@@ -2528,6 +2544,8 @@ TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
       fbgemm_gpu::permute_sequence_embeddings_cpu);
   DISPATCH_TO_CPU("pack_segments", fbgemm_gpu::pack_segments_cpu);
   DISPATCH_TO_CPU("index_select_dim0", fbgemm_gpu::index_select_dim0);
+  DISPATCH_TO_CPU(
+      "group_index_select_dim0", fbgemm_gpu::group_index_select_dim0);
   DISPATCH_TO_CPU(
       "bottom_unique_k_per_row", fbgemm_gpu::bottom_unique_k_per_row);
 }

--- a/fbgemm_gpu/src/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_cpu.cpp
@@ -2464,6 +2464,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   // replacement Along dim=-1, find smallest unique k. If the number of unique
   // elements is less than k, errors out.
   m.def("bottom_unique_k_per_row(Tensor input, int k) -> Tensor");
+  m.def(
+      "keyed_jagged_index_select_dim1(Tensor values, Tensor lengths, Tensor offsets, Tensor indices, int batch_size, Tensor? weights=None) -> Tensor[]");
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {

--- a/fbgemm_gpu/src/sparse_ops_gpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_gpu.cpp
@@ -17,6 +17,60 @@
 using Tensor = at::Tensor;
 
 namespace fbgemm_gpu {
+
+namespace {
+// From https://stackoverflow.com/a/28411055
+template <typename T, std::size_t... Indices, typename... Args>
+auto vec_to_tup_helper(
+    const std::vector<T>& v,
+    std::index_sequence<Indices...>) {
+  return std::make_tuple(v[Indices]...);
+}
+
+template <std::size_t N, typename T>
+auto vec_to_tup(const std::vector<T>& v) {
+  assert(v.size() >= N);
+  return vec_to_tup_helper(v, std::make_index_sequence<N>());
+}
+
+template <typename T, typename F>
+void apply_(F fn, const std::vector<T>& v) {
+  auto size = v.size();
+#define APPLY_AUTOGRAD_FN_N(N)          \
+  {                                     \
+    case N:                             \
+      std::apply(fn, vec_to_tup<N>(v)); \
+      break;                            \
+  }
+
+#define APPLY_AUTOGRAD_FN_2N(N) \
+  APPLY_AUTOGRAD_FN_N(N)        \
+  APPLY_AUTOGRAD_FN_N(N + 1)
+
+#define APPLY_AUTOGRAD_FN_6N(N) \
+  APPLY_AUTOGRAD_FN_2N(N)       \
+  APPLY_AUTOGRAD_FN_2N(N + 2)   \
+  APPLY_AUTOGRAD_FN_2N(N + 4)
+
+#define APPLY_AUTOGRAD_FN_18N(N) \
+  APPLY_AUTOGRAD_FN_6N(N)        \
+  APPLY_AUTOGRAD_FN_6N(N + 6)    \
+  APPLY_AUTOGRAD_FN_6N(N + 12)
+
+#define APPLY_AUTOGRAD_FN_54N(N) \
+  APPLY_AUTOGRAD_FN_18N(N)       \
+  APPLY_AUTOGRAD_FN_18N(N + 18)  \
+  APPLY_AUTOGRAD_FN_18N(N + 36)
+
+  switch (size) {
+    APPLY_AUTOGRAD_FN_54N(1)
+    default:
+      TORCH_CHECK(false, "size is not supported ", size)
+  }
+#undef APPLY_AUTOGRAD_FN
+}
+} // namespace
+
 // Custom PackSegments operator that is based on the Caffe2 PackSegments and
 // UnpackSegments.
 // Needed this to support backward pass.
@@ -184,6 +238,158 @@ class IndexSelectDim0GPUOp
   }
 };
 
+class GroupIndexSelectDim0GPUOp
+    : public torch::autograd::Function<GroupIndexSelectDim0GPUOp> {
+ public:
+  template <class... Tensors>
+  static torch::autograd::variable_list forward(
+      torch::autograd::AutogradContext* ctx,
+      const std::vector<Tensor>& indices_group,
+      Tensors&&... input_tensors) {
+    std::vector<Tensor> input_group = {input_tensors...};
+    const int32_t num_groups = input_group.size();
+    if (num_groups == 0) {
+      return {torch::autograd::Variable()};
+    }
+
+    TORCH_CHECK(num_groups == (int32_t)indices_group.size())
+
+    Tensor all_ptrs = at::empty(
+        {(int64_t)num_groups * 2},
+        at::TensorOptions().dtype(at::kLong).pinned_memory(true));
+    int64_t* all_ptrs_buf = all_ptrs.data_ptr<int64_t>();
+
+    auto& first_input = input_group[0];
+    auto& first_indices = indices_group[0];
+
+    const int num_output_rows = first_indices.size(0);
+    const int num_input_rows = first_input.size(0);
+    Tensor input_reshaped = first_input.reshape({num_input_rows, -1});
+    const int num_cols = input_reshaped.size(1);
+
+    std::vector<Tensor> saved_list;
+    saved_list.reserve(num_groups + 1);
+    for (int i = 0; i < num_groups; i++) {
+      auto& input = input_group[i];
+      auto& indices = indices_group[i];
+
+      // Verify that all tensors are on the same GPU
+      TENSOR_ON_CUDA_GPU(input);
+      TENSOR_ON_CUDA_GPU(indices);
+      TENSORS_ON_SAME_DEVICE(input, indices);
+
+      // Verify that all input tensors have the same shape
+      TORCH_CHECK(num_output_rows == indices.size(0))
+      TORCH_CHECK(num_input_rows == input.size(0))
+      Tensor input_reshaped_ = input.reshape({num_input_rows, -1});
+      TORCH_CHECK(num_cols == input_reshaped_.size(1))
+
+      // Put all pointers in an array
+      all_ptrs_buf[i] = reinterpret_cast<int64_t>(input.data_ptr());
+      all_ptrs_buf[i + num_groups] =
+          reinterpret_cast<int64_t>(indices.data_ptr());
+
+      // Save indices for backward
+      saved_list.push_back(indices);
+    }
+    // Store one input tensor to get input tensor property in backward
+    saved_list.push_back(input_group[0]);
+    // Transfer input pointers to GPU
+    all_ptrs = all_ptrs.to(first_input.device(), /*non_blocking=*/true);
+    // Save pointers for backward
+    saved_list.push_back(all_ptrs);
+
+    ctx->save_for_backward(saved_list);
+    ctx->saved_data["input_shape"] = first_input.sizes().vec();
+    ctx->saved_data["num_groups"] = num_groups;
+    ctx->saved_data["num_cols"] = num_cols;
+
+    auto output_shape = first_input.sizes().vec();
+    output_shape[0] = num_groups * num_output_rows;
+
+    return group_index_select_cuda(
+        all_ptrs.data_ptr<int64_t>(),
+        all_ptrs.data_ptr<int64_t>() + num_groups,
+        first_input.options(),
+        first_input.scalar_type(),
+        first_indices.scalar_type(),
+        first_input.device().index(),
+        output_shape,
+        num_input_rows,
+        num_output_rows,
+        num_cols,
+        num_groups);
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext* ctx,
+      torch::autograd::variable_list grad_output_group) {
+    const int num_groups = ctx->saved_data["num_groups"].toInt();
+    const int num_cols = ctx->saved_data["num_cols"].toInt();
+    auto output_shape = ctx->saved_data["input_shape"].toIntVector();
+    const int num_output_rows = output_shape[0];
+    output_shape[0] *= num_groups;
+
+    TORCH_CHECK((int32_t)grad_output_group.size() == num_groups);
+
+    if (num_groups == 0) {
+      return torch::autograd::variable_list();
+    }
+
+    const int num_input_rows = grad_output_group[0].size(0);
+
+    const auto saved = ctx->get_saved_variables();
+    const auto saved_itr = std::begin(saved);
+    Tensor first_indices = *saved_itr;
+    Tensor fwd_input = *(saved_itr + num_groups);
+    // Get indices pointers from all_ptrs saved in forward
+    int64_t* indices_ptrs =
+        (saved_itr + num_groups + 1)->data_ptr<int64_t>() + num_groups;
+
+    Tensor grad_output_ptrs = at::empty(
+        {num_groups}, at::TensorOptions().dtype(at::kLong).pinned_memory(true));
+    int64_t* grad_output_ptrs_buf = grad_output_ptrs.data_ptr<int64_t>();
+    for (int i = 0; i < num_groups; i++) {
+      Tensor& grad = grad_output_group[i];
+      TENSOR_ON_CUDA_GPU(grad);
+      TENSORS_ON_SAME_DEVICE(grad, first_indices);
+
+      // Put all grad output pointers in an array
+      grad_output_ptrs_buf[i] = reinterpret_cast<int64_t>(grad.data_ptr());
+    }
+    // Transfer grad output pointers to GPU
+    grad_output_ptrs =
+        grad_output_ptrs.to(first_indices.device(), /*non_blocking=*/true);
+
+    std::vector<Tensor> output_group;
+    output_group.reserve(num_groups + 1);
+    output_group.push_back(torch::autograd::Variable());
+
+    auto output_index_add_group = group_index_add_cuda(
+        grad_output_ptrs.data_ptr<int64_t>(),
+        indices_ptrs,
+        fwd_input.options(),
+        fwd_input.scalar_type(),
+        first_indices.scalar_type(),
+        fwd_input.device().index(),
+        output_shape,
+        num_input_rows,
+        num_output_rows,
+        num_cols,
+        num_groups);
+
+    // This can be slow because the complexity is O(num_groups)
+    output_group.insert(
+        output_group.end(),
+        output_index_add_group.begin(),
+        output_index_add_group.end());
+
+    TORCH_CHECK((int)output_group.size() == num_groups + 1)
+
+    return output_group;
+  }
+};
+
 Tensor pack_segments_cuda(
     const Tensor& t_in,
     const Tensor& lengths,
@@ -208,6 +414,19 @@ Tensor index_select_dim0_gpu(
       // Always skip indices sorting if doing forward only
       user_skip_indices_sorting_fwd && !c10::InferenceMode::is_enabled())[0];
 }
+
+std::vector<Tensor> group_index_select_dim0_gpu(
+    const std::vector<Tensor>& input_group,
+    const std::vector<Tensor>& indices_group) {
+  std::vector<Tensor> output_group;
+  apply_(
+      [&](auto&&... args) {
+        output_group = GroupIndexSelectDim0GPUOp::apply(indices_group, args...);
+      },
+      input_group);
+  return output_group;
+}
+
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
@@ -268,4 +487,6 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
       fbgemm_gpu::permute_sequence_embeddings_cuda);
   DISPATCH_TO_CUDA("pack_segments", fbgemm_gpu::pack_segments_cuda);
   DISPATCH_TO_CUDA("index_select_dim0", fbgemm_gpu::index_select_dim0_gpu);
+  DISPATCH_TO_CUDA(
+      "group_index_select_dim0", fbgemm_gpu::group_index_select_dim0_gpu);
 }


### PR DESCRIPTION
Summary:
Use at::parallel_for in bottom_unique_k_per_row for faster zipf
generation

Differential Revision: D40993903

