### PR TITLE
Add bag size generation from mean and std in TBE benchmark

### DIFF
--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -2573,7 +2573,19 @@ def emb_inplace_update(  # noqa C901
 
 @cli.command()
 @click.option("--alpha", default=1.0)
-@click.option("--bag-size-list", type=str, default="20")
+@click.option(
+    "--bag-size-list",
+    type=str,
+    default="20",
+)
+@click.option(
+    "--bag-size-sigma-list",
+    type=str,
+    default="None",
+    help="A list of bag size standard deviations for generating bag sizes "
+    "(one std per table). If set, the benchmark will treat --bag-size-list as a "
+    "list of bag size means.",
+)
 @click.option("--batch-size", default=512)
 @click.option("--embedding-dim-list", type=str, default="128")
 @click.option("--weights-precision", type=SparseType, default=SparseType.FP32)
@@ -2592,6 +2604,7 @@ def emb_inplace_update(  # noqa C901
 def device_with_spec(  # noqa C901
     alpha: float,
     bag_size_list: str,
+    bag_size_sigma_list: str,
     batch_size: int,
     embedding_dim_list: str,
     weights_precision: SparseType,
@@ -2612,13 +2625,33 @@ def device_with_spec(  # noqa C901
     torch.manual_seed(42)
     B = batch_size
     Ds = [int(D) for D in embedding_dim_list.split(",")]
-    Ls = [int(L) for L in bag_size_list.split(",")]
     Es = [int(E) for E in num_embeddings_list.split(",")]
     T = len(Ds)
-    assert T == len(Ls) and T == len(
-        Es
-    ), f"Ds, Ls, Es must have the same length ({len(Ds)}, {len(Ls)}, {len(Es)})"
+
+    use_variable_bag_sizes = bag_size_sigma_list != "None"
+
+    if use_variable_bag_sizes:
+        Ls = [int(mu) for mu in bag_size_list.split(",")]
+        sigma_Ls = [int(sigma) for sigma in bag_size_sigma_list.split(",")]
+        assert T == len(Ls) and T == len(sigma_Ls), (
+            f"bag-size-list (length: {len(Ls)}) and bag-size-sigma-list "
+            f"(length: {len(sigma_Ls)}) must have the same length as "
+            f"embedding-dim-list (length: {T})"
+        )
+    else:
+        Ls = [int(L) for L in bag_size_list.split(",")]
+        assert T == len(Ls), (
+            f"bag-size-list (length: {len(Ls)}) must have the same length as "
+            f"embedding-dim-list (length: {T})"
+        )
+
+    assert T == len(Es), (
+        f"num-embeddings-list (length: {len(Es)}) must have the same length as "
+        f"embedding-dim-list (length: {T})"
+    )
+
     assert T >= 1, "There must be at least one table"
+
     feature_requires_grad = None
     optimizer = OptimType.EXACT_ROWWISE_ADAGRAD if row_wise else OptimType.EXACT_ADAGRAD
 
@@ -2677,24 +2710,6 @@ def device_with_spec(  # noqa C901
     param_size_multiplier = weights_precision.bit_rate() / 8.0
     output_size_multiplier = output_dtype.bit_rate() / 8.0
 
-    sum_DLs = sum([d * l for d, l in zip(Ds, Ls)])
-    if do_pooling:
-        read_write_bytes = (
-            output_size_multiplier * B * sum(Ds) + param_size_multiplier * B * sum_DLs
-        )
-    else:
-        read_write_bytes = (
-            output_size_multiplier * B * sum(Ds) + param_size_multiplier * B * sum_DLs
-        )
-
-    logging.info(
-        f"Embedding parameters: {nparams / 1.0e9: .2f} GParam, "
-        f"{nparams * param_size_multiplier / 1.0e9: .2f} GB"
-    )
-    logging.info(
-        f"Accessed weights per batch: {B * sum_DLs * param_size_multiplier / 1.0e9: .2f} GB"
-    )
-
     # Generate a request for each table then combine
     all_requests = {
         "indices": [[] for _ in range(iters)],
@@ -2702,17 +2717,18 @@ def device_with_spec(  # noqa C901
         "weights": [[] for _ in range(iters)],
     }
     # row = iter, column = tensor
-    for t, (l, e) in enumerate(zip(Ls, Es)):
+    for t, e in enumerate(Es):
         # (indices, offsets, weights)
         requests = generate_requests(
             iters,
             B,
             1,
-            l,
+            Ls[t],
             e,
             reuse=reuse,
             alpha=alpha,
             weighted=weighted,
+            sigma_L=sigma_Ls[t] if use_variable_bag_sizes else None,
         )
         for i, (indices, offsets, weights) in enumerate(requests):
             all_requests["indices"][i].append(indices)
@@ -2722,9 +2738,15 @@ def device_with_spec(  # noqa C901
             all_requests["offsets"][i].append(offsets)
             all_requests["weights"][i].append(weights)
 
+    prev_indices_len = -1
     requests = []
     for i in range(iters):
         indices = torch.concat(all_requests["indices"][i])
+        if prev_indices_len == -1:
+            prev_indices_len = indices.numel()
+        assert (
+            prev_indices_len == indices.numel()
+        ), "Number of indices for every iteration must be the same"
         offsets = torch.concat(all_requests["offsets"][i])
         if weighted:
             weights = torch.concat(all_requests["weights"][i])
@@ -2735,6 +2757,30 @@ def device_with_spec(  # noqa C901
     del all_requests
 
     assert len(requests) == iters
+
+    sum_DLs = sum([d * l for d, l in zip(Ds, Ls)])
+    if do_pooling:
+        read_write_bytes = (
+            output_size_multiplier * B * sum(Ds) + param_size_multiplier * B * sum_DLs
+        )
+    else:
+        read_write_bytes = (
+            output_size_multiplier * B * sum(Ds) + param_size_multiplier * B * sum_DLs
+        )
+
+    if use_variable_bag_sizes:
+        # pyre-ignore [61]
+        Ls_str = f"mu {Ls} sigma {sigma_Ls}"
+    else:
+        Ls_str = f"{Ls}"
+
+    logging.info(
+        f"Embedding parameters: {nparams / 1.0e9: .2f} GParam, "
+        f"{nparams * param_size_multiplier / 1.0e9: .2f} GB"
+    )
+    logging.info(
+        f"Accessed weights per batch: {B * sum_DLs * param_size_multiplier / 1.0e9: .2f} GB"
+    )
 
     # forward
     time_per_iter = benchmark_requests(
@@ -2750,7 +2796,7 @@ def device_with_spec(  # noqa C901
     )
     logging.info(
         f"Forward, B: {B}, "
-        f"Es: {Es}, T: {T}, Ds: {Ds}, Ls: {Ls}, W: {weighted}, "
+        f"Es: {Es}, T: {T}, Ds: {Ds}, Ls: {Ls_str}, W: {weighted}, "
         f"BW: {read_write_bytes / time_per_iter / 1.0e9: .2f} GB/s, "  # noqa: B950
         f"T: {time_per_iter * 1.0e6:.0f}us"
     )
@@ -2762,8 +2808,9 @@ def device_with_spec(  # noqa C901
     if do_pooling:
         grad_output = torch.randn(B, sum(Ds)).to(get_device())
     else:
+        # Obtain B * L from indices len
         # pyre-ignore[19]
-        grad_output = torch.randn(B * sum(Ls), D).to(get_device())
+        grad_output = torch.randn(requests[0][0].numel(), D).to(get_device())
     # backward
     time_per_iter = benchmark_requests(
         requests,
@@ -2778,7 +2825,7 @@ def device_with_spec(  # noqa C901
         grad=grad_output,
     )
     logging.info(
-        f"Backward, B: {B}, Es: {Es}, T: {T}, Ds: {Ds}, Ls: {Ls}, "
+        f"Backward, B: {B}, Es: {Es}, T: {T}, Ds: {Ds}, Ls: {Ls_str}, "
         f"BW: {2 * read_write_bytes / time_per_iter / 1.0e9: .2f} GB/s, "
         f"T: {time_per_iter * 1.0e6:.0f}us"
     )

--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_utils.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_utils.py
@@ -102,6 +102,9 @@ def generate_requests(
     requests_data_file: Optional[str] = None,
     # Comma-separated list of table numbers
     tables: Optional[str] = None,
+    # If sigma_L is not None, treat L as mu_L and generate Ls from sigma_L
+    # and mu_L
+    sigma_L: Optional[int] = None,
 ) -> List[Tuple[torch.IntTensor, torch.IntTensor, Optional[torch.Tensor]]]:
     if requests_data_file is not None:
         indices_tensor, offsets_tensor, lengths_tensor = torch.load(requests_data_file)
@@ -168,17 +171,39 @@ def generate_requests(
             )
         return rs
 
+    # Generate L from stats
+    if sigma_L is not None:
+        use_variable_L = True
+        Ls = np.random.normal(loc=L, scale=sigma_L, size=T * B).astype(int)
+        # Make sure that Ls are positive
+        Ls[Ls < 0] = 0
+        # Use the same L distribution across iters
+        Ls = np.tile(Ls, iters)
+        L = Ls.max()
+        # Make it exclusive cumsum
+        L_offsets = torch.from_numpy(np.insert(Ls.cumsum(), 0, 0)).to(torch.long)
+    else:
+        use_variable_L = False
+        # Init to suppress the pyre error
+        L_offsets = torch.empty(1)
+
     if alpha <= 1.0:
         all_indices = torch.randint(
             low=0,
             high=E,
             size=(iters, T, B, L),
-            device=get_device(),
+            device="cpu" if use_variable_L else get_device(),
             dtype=torch.int32,
         )
         # each bag is usually sorted
         (all_indices, _) = torch.sort(all_indices)
-        all_indices = all_indices.reshape(iters, T, B * L)
+        if use_variable_L:
+            all_indices = torch.ops.fbgemm.bottom_k_per_row(
+                all_indices.to(torch.long), L_offsets, False
+            )
+            all_indices = all_indices.to(get_device()).int()
+        else:
+            all_indices = all_indices.reshape(iters, T, B * L)
     else:
         assert E >= L, "num-embeddings must be greater than equal to bag-size"
         # oversample and then remove duplicates to obtain sampling without
@@ -200,33 +225,73 @@ def generate_requests(
         else:
             all_indices = torch.as_tensor(np.random.zipf(a=alpha, size=zipf_shape))
         all_indices = (all_indices - 1) % E
-        all_indices = torch.ops.fbgemm.bottom_unique_k_per_row(all_indices, L)
+        if use_variable_L:
+            all_indices = torch.ops.fbgemm.bottom_k_per_row(
+                all_indices, L_offsets, True
+            )
+        else:
+            all_indices = torch.ops.fbgemm.bottom_k_per_row(
+                all_indices, torch.tensor([0, L], dtype=torch.long), True
+            )
         rng = default_rng()
         permutation = torch.as_tensor(
             rng.choice(E, size=all_indices.max().item() + 1, replace=False)
         )
         all_indices = permutation.gather(0, all_indices.flatten())
-        all_indices = all_indices.to(get_device()).int().reshape(iters, T, B * L)
-    for it in range(iters - 1):
-        for t in range(T):
-            reused_indices = torch.randperm(B * L, device=get_device())[
-                : int(B * L * reuse)
-            ]
-            all_indices[it + 1, t, reused_indices] = all_indices[it, t, reused_indices]
+        all_indices = all_indices.to(get_device()).int()
+        if not use_variable_L:
+            all_indices = all_indices.reshape(iters, T, B * L)
+
+    if reuse > 0.0:
+        assert (
+            not use_variable_L
+        ), "Does not support generating Ls from stats for reuse > 0.0"
+
+        for it in range(iters - 1):
+            for t in range(T):
+                reused_indices = torch.randperm(B * L, device=get_device())[
+                    : int(B * L * reuse)
+                ]
+                all_indices[it + 1, t, reused_indices] = all_indices[
+                    it, t, reused_indices
+                ]
 
     rs = []
     for it in range(iters):
-        weights_tensor = (
-            None
-            if not weighted
-            else torch.randn(
-                T * B * L, device=get_device()
-            )  # per sample weights will always be FP32
-        )
-        rs.append(
-            get_table_batched_offsets_from_dense(all_indices[it].view(T, B, L))
-            + (weights_tensor,)
-        )
+        if use_variable_L:
+            start_offset = L_offsets[it * T * B]
+            it_L_offsets = torch.concat(
+                [
+                    torch.zeros(1),
+                    L_offsets[it * T * B + 1 : (it + 1) * T * B + 1] - start_offset,
+                ]
+            )
+            weights_tensor = (
+                None
+                if not weighted
+                else torch.randn(
+                    int(it_L_offsets[-1].item()), device=get_device()
+                )  # per sample weights will always be FP32
+            )
+            rs.append(
+                (
+                    all_indices[start_offset : L_offsets[(it + 1) * T * B]],
+                    it_L_offsets.to(get_device()),
+                    weights_tensor,
+                )
+            )
+        else:
+            weights_tensor = (
+                None
+                if not weighted
+                else torch.randn(
+                    T * B * L, device=get_device()
+                )  # per sample weights will always be FP32
+            )
+            rs.append(
+                get_table_batched_offsets_from_dense(all_indices[it].view(T, B, L))
+                + (weights_tensor,)
+            )
     return rs
 
 

--- a/fbgemm_gpu/test/sparse_ops_test.py
+++ b/fbgemm_gpu/test/sparse_ops_test.py
@@ -1665,8 +1665,8 @@ class SparseOpsTest(unittest.TestCase):
     ) -> None:
         E = 1000000
         all_indices = (np.random.zipf(a=1.15, size=(T, B, 3 * L)) - 1) % E
-        all_indices_deduped = torch.ops.fbgemm.bottom_unique_k_per_row(
-            torch.as_tensor(all_indices), L
+        all_indices_deduped = torch.ops.fbgemm.bottom_k_per_row(
+            torch.as_tensor(all_indices), torch.tensor([0, L], dtype=torch.long), True
         )
         for index_tuple in itertools.product(range(T), range(B)):
             # sample without replacement from


### PR DESCRIPTION
Summary:
Before this diff, the TEB benchmark generates indices using a constant
bag size for each embedding table.  Doing so does not reflect the real
usecase.  This diff adds the option to generate bag sizes based on
statistics (i.e., mean and standard deviation for normal
distribution), which allows varying bag sizes for each table.

`jagged_bottom_k_per_row` (a CPU op) is added for selecting indices
based on the varying bag sizes from the dense indices.

The option to generate varying bag sizes is added to the
`generate_requests` util, however, it can be called from the
`device_with_spec` benchmark in this diff.  (We may extend this
support to other TBE benchmarks in the future.)

Differential Revision: D41017677

