### PR TITLE
handle case when value size is bigger than last value of offset

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops.cu
@@ -290,6 +290,7 @@ __launch_bounds__(kMaxThreads) void jagged_dense_dense_elementwise_jagged_output
         output_values,
     StackArray<int64_t> jagged_dims,
     F f) {
+  const int outer_dense_size = y_0.size(0);
   const int inner_dense_size = y_0.size(2);
   const int nnz = x_values.size(0);
 
@@ -328,6 +329,11 @@ __launch_bounds__(kMaxThreads) void jagged_dense_dense_elementwise_jagged_output
       offset_temp = first;
     }
 
+    if (offset_temp >= outer_dense_size) {
+      // This can happen when values have more elements than the last element of
+      // offset
+      truncated = true;
+    }
     if (!truncated) {
       const int oidx = offset_temp;
       int iidx;

--- a/fbgemm_gpu/test/jagged_tensor_ops_test.py
+++ b/fbgemm_gpu/test/jagged_tensor_ops_test.py
@@ -993,6 +993,16 @@ class JaggedTensorOpsTest(unittest.TestCase):
             ),
         )
 
+    def test_zeros(self):
+        xval = torch.zeros(524288, 96, device="cuda")
+        xoff = torch.zeros(1025, dtype=torch.int64, device="cuda")
+        y0 = torch.zeros(1024, 512, 96, device="cuda")
+        y1 = torch.zeros(1024, 512, 96, device="cuda")
+        _, _ = torch.ops.fbgemm.jagged_dense_dense_elementwise_add_jagged_output(
+            xval, [xoff], y0, y1
+        )
+        torch.cuda.synchronize()
+
     # pyre-ignore [56]
     @given(
         num_jagged_dim=st.integers(1, 4),


### PR DESCRIPTION
Summary:
Normally, value size should be same as the last value of offset but we want to allow value can have more elements. For example, in PT2, FakeTensor would call jagged tensor ops with tensors with zero values like
values = [0, 0, 0, 0]
offsets = [0, 0]

Ideally, FakeTensor should generate jagged tensors differently but this can be a complex discussion I guess.

Reviewed By: bertmaher

Differential Revision: D41071879

