### PR TITLE
Move permute_pooled_embedding_ops_split_cpu.cpp to fbgemm_gpu_sources_cpu

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -288,6 +288,7 @@ set(fbgemm_gpu_sources_cpu
     codegen/embedding_forward_quantized_host_cpu.cpp
     codegen/embedding_backward_dense_host_cpu.cpp
     codegen/embedding_bounds_check_host_cpu.cpp
+    src/permute_pooled_embedding_ops_split_cpu.cpp
     src/cpu_utils.cpp
     src/jagged_tensor_ops_cpu.cpp
     src/input_combine_cpu.cpp
@@ -306,7 +307,6 @@ if(NOT FBGEMM_CPU_ONLY)
     src/layout_transform_ops_gpu.cpp
     src/permute_pooled_embedding_ops_gpu.cpp
     src/permute_pooled_embedding_ops_split_gpu.cpp
-    src/permute_pooled_embedding_ops_split_cpu.cpp
     src/quantize_ops_gpu.cpp
     src/sparse_ops_gpu.cpp
     src/split_embeddings_utils.cpp


### PR DESCRIPTION
Summary: Fix issue with nightly CPU build where `torch.ops.fbgemm.permute_pooled_embs_auto_grad_split` is not found

Differential Revision: D41131999

