### PR TITLE
Jagged_dense_dense_elementwise_add_jagged add Meta and Autograd backend

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -290,6 +290,8 @@ set(fbgemm_gpu_sources_cpu
     codegen/embedding_bounds_check_host_cpu.cpp
     src/permute_pooled_embedding_ops_split_cpu.cpp
     src/cpu_utils.cpp
+    src/jagged_tensor_ops_autograd.cpp
+    src/jagged_tensor_ops_meta.cpp
     src/jagged_tensor_ops_cpu.cpp
     src/input_combine_cpu.cpp
     src/layout_transform_ops_cpu.cpp

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -395,6 +395,13 @@ at::Tensor jagged_2d_to_dense_autograd(
     at::Tensor offsets,
     int64_t max_sequence_length);
 
+std::tuple<at::Tensor, std::vector<at::Tensor>>
+jagged_dense_dense_elementwise_add_jagged_output_autograd(
+    const at::Tensor& x_values,
+    const std::vector<at::Tensor>& x_offsets,
+    const at::Tensor& y_0,
+    const at::Tensor& y_1);
+
 ///@ingroup sparse-data-cpu
 at::Tensor jagged_2d_to_dense_forward_cpu(
     at::Tensor values,

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -365,23 +365,6 @@ at::Tensor batched_unary_embeddings_backward_cuda(
     const at::Tensor& offsets,
     const at::Tensor& indices);
 
-///@ingroup sparse-data-cuda
-std::tuple<std::vector<at::Tensor>, std::vector<at::Tensor>>
-stacked_jagged_2d_to_dense_forward_cuda(
-    at::Tensor values,
-    at::Tensor lengths,
-    const std::vector<int64_t>& offset_per_key,
-    const std::vector<int64_t>& max_lengths_per_key);
-
-///@ingroup sparse-data-cuda
-at::Tensor stacked_jagged_2d_to_dense_backward_cuda(
-    int64_t B,
-    int64_t D,
-    int64_t total_L,
-    const std::vector<at::Tensor>& grad_padded_values_per_key,
-    const std::vector<at::Tensor>& offsets_tensor_per_key,
-    const std::vector<int64_t>& offset_per_key);
-
 ///@ingroup sparse-data-cpu
 std::vector<at::Tensor> stacked_jagged_2d_to_dense_cpu(
     at::Tensor values,
@@ -390,31 +373,33 @@ std::vector<at::Tensor> stacked_jagged_2d_to_dense_cpu(
     const std::vector<int64_t>& max_lengths_per_key,
     int64_t padding_value);
 
-///@ingroup sparse-data-cuda
-at::Tensor jagged_1d_to_dense_gpu(
+at::Tensor jagged_to_padded_dense_autograd(
+    const at::Tensor& values,
+    const std::vector<at::Tensor>& offsets,
+    const std::vector<std::int64_t>& max_lengths,
+    const double padding_value);
+
+at::Tensor jagged_dense_elementwise_add_autograd(
+    const at::Tensor& x_values,
+    const std::vector<at::Tensor>& x_offsets,
+    const at::Tensor& y);
+
+at::Tensor jagged_1d_to_dense_autograd(
     at::Tensor values,
     at::Tensor offsets,
     int64_t max_L,
     int64_t padding_value);
 
-///@ingroup sparse-data-cpu
-at::Tensor jagged_1d_to_dense_cpu(
+at::Tensor jagged_2d_to_dense_autograd(
     at::Tensor values,
     at::Tensor offsets,
-    int64_t max_L,
-    int64_t padding_value);
+    int64_t max_sequence_length);
 
 ///@ingroup sparse-data-cpu
 at::Tensor jagged_2d_to_dense_forward_cpu(
     at::Tensor values,
     at::Tensor offsets,
     int64_t max_L);
-
-///@ingroup sparse-data-cuda
-at::Tensor jagged_2d_to_dense_gpu(
-    at::Tensor values,
-    at::Tensor offsets,
-    int64_t max_sequence_length);
 
 ///@ingroup sparse-data-cuda
 at::Tensor jagged_2d_to_dense_gpu_forward(
@@ -428,21 +413,6 @@ at::Tensor jagged_2d_to_dense_gpu_backward(
     at::Tensor offsets,
     int64_t max_lengths);
 
-///@ingroup sparse-data-gpu
-std::vector<at::Tensor> stacked_jagged_1d_to_dense_gpu(
-    at::Tensor values,
-    at::Tensor lengths,
-    const std::vector<int64_t>& offset_per_key,
-    const std::vector<int64_t>& max_lengths_per_key,
-    int64_t padding_value);
-
-///@ingroup sparse-data-cpu
-std::vector<at::Tensor> stacked_jagged_1d_to_dense_cpu(
-    at::Tensor values,
-    at::Tensor lengths,
-    const std::vector<int64_t>& offset_per_key,
-    const std::vector<int64_t>& max_lengths_per_key,
-    int64_t padding_value);
 #endif
 
 ///@ingroup sparse-data-cpu

--- a/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
@@ -67,6 +67,63 @@ class JaggedToPaddedDenseOp
   }
 };
 
+class JaggedDenseDenseAddJaggedOutputOp
+    : public torch::autograd::Function<JaggedDenseDenseAddJaggedOutputOp> {
+ public:
+  static torch::autograd::variable_list forward(
+      torch::autograd::AutogradContext* ctx,
+      const Tensor& x_values,
+      const std::vector<Tensor>& offsets,
+      const Tensor& dense_0,
+      const Tensor& dense_1) {
+    ctx->save_for_backward(offsets);
+    ctx->saved_data["dense_shape"] = dense_0.sizes();
+
+    static auto op =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow(
+                "fbgemm::jagged_dense_dense_elementwise_add_jagged_output_forward",
+                "")
+            .typed<at::Tensor(
+                const at::Tensor& x_values,
+                const std::vector<at::Tensor>& x_offsets,
+                const at::Tensor& y_0,
+                const at::Tensor& y_1)>();
+    Tensor output = op.call(x_values, offsets, dense_0, dense_1);
+
+    return {output};
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext* ctx,
+      torch::autograd::variable_list grad_outputs) {
+    auto offsets = ctx->get_saved_variables();
+    auto dense_shape = ctx->saved_data["dense_shape"].toIntVector();
+    TORCH_CHECK(grad_outputs.size() == 1);
+
+    static auto op =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow("fbgemm::jagged_to_padded_dense_forward", "")
+            .typed<at::Tensor(
+                const Tensor& values,
+                const std::vector<Tensor>& offsets,
+                const std::vector<int64_t>& max_lengths,
+                const double padding_value)>();
+    Tensor dense_values_grad_0 = op.call(
+        grad_outputs[0],
+        offsets,
+        std::vector<int64_t>(dense_shape.begin() + 1, dense_shape.end() - 1),
+        /*padding_value=*/0);
+    Tensor dense_values_grad_1 = dense_values_grad_0;
+
+    return {
+        grad_outputs[0],
+        torch::autograd::Variable(), // offsets
+        dense_values_grad_0,
+        dense_values_grad_1};
+  }
+};
+
 } // namespace
 
 ///@ingroup jagged-tensor-ops-cpu
@@ -101,6 +158,20 @@ Tensor jagged_dense_elementwise_add_autograd(
   return dense_output;
 }
 
+// output = x + y_0 + y_1 where x is jagged, y_0 and y_1 are dense, and output
+// is jagged
+std::tuple<Tensor, std::vector<Tensor>>
+jagged_dense_dense_elementwise_add_jagged_output_autograd(
+    const Tensor& x_values,
+    const std::vector<Tensor>& x_offsets,
+    const Tensor& y_0,
+    const Tensor& y_1) {
+  auto sum_values = JaggedDenseDenseAddJaggedOutputOp::apply(
+      x_values, x_offsets, y_0, y_1)[0];
+
+  return {sum_values, x_offsets};
+}
+
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_IMPL(fbgemm, Autograd, m) {
@@ -111,4 +182,8 @@ TORCH_LIBRARY_IMPL(fbgemm, Autograd, m) {
       "jagged_2d_to_dense", TORCH_FN(fbgemm_gpu::jagged_2d_to_dense_autograd));
   m.impl(
       "jagged_1d_to_dense", TORCH_FN(fbgemm_gpu::jagged_1d_to_dense_autograd));
+  m.impl(
+      "jagged_dense_dense_elementwise_add_jagged_output",
+      TORCH_FN(fbgemm_gpu::
+                   jagged_dense_dense_elementwise_add_jagged_output_autograd));
 }

--- a/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
@@ -1,0 +1,114 @@
+#include <ATen/ATen.h>
+#include <ATen/AccumulateType.h>
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <torch/csrc/autograd/custom_function.h>
+#include <torch/library.h>
+
+#include "fbgemm_gpu/sparse_ops.h"
+#include "fbgemm_gpu/sparse_ops_utils.h"
+
+namespace fbgemm_gpu {
+
+///@defgroup jagged-tensor-ops-cpu Jagged Tensor Operators
+/// The following are Jagged Tensor CPU Operators
+
+using Tensor = at::Tensor;
+
+namespace {
+
+class JaggedToPaddedDenseOp
+    : public torch::autograd::Function<JaggedToPaddedDenseOp> {
+ public:
+  static torch::autograd::variable_list forward(
+      torch::autograd::AutogradContext* ctx,
+      const Tensor& values,
+      const std::vector<Tensor>& offsets,
+      const std::vector<int64_t>& max_lengths,
+      const double padding_value) {
+    ctx->save_for_backward(offsets);
+    ctx->saved_data["total_L"] = values.size(0);
+
+    static auto op =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow("fbgemm::jagged_to_padded_dense_forward", "")
+            .typed<at::Tensor(
+                const Tensor& values,
+                const std::vector<Tensor>& offsets,
+                const std::vector<int64_t>& max_lengths,
+                const double padding_value)>();
+    Tensor padded_values = op.call(values, offsets, max_lengths, padding_value);
+
+    return {padded_values};
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext* ctx,
+      torch::autograd::variable_list grad_outputs) {
+    auto offsets = ctx->get_saved_variables();
+    int32_t total_L = ctx->saved_data["total_L"].toInt();
+    TORCH_CHECK(grad_outputs.size() == 1);
+
+    TORCH_CHECK(total_L >= 0);
+    static auto op =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow("fbgemm::jagged_to_padded_dense_backward", "")
+            .typed<at::Tensor(
+                const Tensor& grad_output,
+                const std::vector<Tensor>& offsets,
+                const int64_t total_L)>();
+    auto grad_values = op.call(grad_outputs[0], {offsets}, total_L);
+
+    return {
+        grad_values,
+        torch::autograd::Variable(), // offsets
+        torch::autograd::Variable(), // max_lengths
+        torch::autograd::Variable(), // padding_value
+    };
+  }
+};
+
+} // namespace
+
+///@ingroup jagged-tensor-ops-cpu
+Tensor jagged_to_padded_dense_autograd(
+    const Tensor& values,
+    const std::vector<Tensor>& offsets,
+    const std::vector<int64_t>& max_lengths,
+    const double padding_value) {
+  return JaggedToPaddedDenseOp::apply(
+      values, offsets, max_lengths, padding_value)[0];
+}
+
+///@ingroup jagged-tensor-ops-cpu
+/// Output = x + y where x is jagged, y and output are dense
+Tensor jagged_dense_elementwise_add_autograd(
+    const Tensor& x_values,
+    const std::vector<Tensor>& x_offsets,
+    const Tensor& y) {
+  // Construct max_lengths from y
+  std::vector<int64_t> max_lengths;
+  max_lengths.reserve(x_offsets.size());
+  for (int d = 1; d < y.dim() - 1; d++) {
+    max_lengths.push_back(y.size(d));
+  }
+  TORCH_CHECK(max_lengths.size() == x_offsets.size());
+
+  // Convert x to dense (assume padding is 0.0)
+  auto xd = JaggedToPaddedDenseOp::apply(
+      x_values, x_offsets, max_lengths, /* padding_value */ 0.0)[0];
+
+  auto dense_output = xd + y;
+  return dense_output;
+}
+
+} // namespace fbgemm_gpu
+
+TORCH_LIBRARY_IMPL(fbgemm, Autograd, m) {
+  m.impl(
+      "jagged_to_padded_dense",
+      TORCH_FN(fbgemm_gpu::jagged_to_padded_dense_autograd));
+  m.impl(
+      "jagged_2d_to_dense", TORCH_FN(fbgemm_gpu::jagged_2d_to_dense_autograd));
+  m.impl(
+      "jagged_1d_to_dense", TORCH_FN(fbgemm_gpu::jagged_1d_to_dense_autograd));
+}

--- a/fbgemm_gpu/src/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_cpu.cpp
@@ -405,8 +405,9 @@ class JaggedToPaddedDenseCPUOp
     Tensor padded_values_view =
         values.dim() == 1 ? padded_values.unsqueeze(-1) : padded_values;
 
-    AT_DISPATCH_ALL_TYPES_AND(
+    AT_DISPATCH_ALL_TYPES_AND2(
         at::ScalarType::Half,
+        at::ScalarType::BFloat16,
         values.scalar_type(),
         "jagged_to_padded_dense",
         [&] {
@@ -437,8 +438,9 @@ class JaggedToPaddedDenseCPUOp
     // in forward.
     auto grad_values = at::zeros({total_L, D}, grad_padded_values.options());
 
-    AT_DISPATCH_ALL_TYPES_AND(
+    AT_DISPATCH_ALL_TYPES_AND2(
         at::ScalarType::Half,
+        at::ScalarType::BFloat16,
         grad_padded_values.scalar_type(),
         "jagged_2d_to_dense_backward_kernel",
         [&] {
@@ -519,9 +521,9 @@ class DenseToJaggedCPUOp
     auto values = at::empty({total_L_computed, D}, dense.options());
     auto output = at::zeros({total_L_computed, D}, dense.options());
 
-    AT_DISPATCH_FLOATING_TYPES_AND2(
+    AT_DISPATCH_ALL_TYPES_AND2(
         at::ScalarType::Half,
-        at::ScalarType::Long,
+        at::ScalarType::BFloat16,
         values.scalar_type(),
         "jagged_scalars",
         [&] {
@@ -886,7 +888,9 @@ class BatchedDenseVecJagged2DMulCPUOp
     if (B > 0 && D > 0) {
       AT_DISPATCH_INDEX_TYPES(
           a_offsets.scalar_type(), "dense_vec_jagged_2d_bmm_kernel_1", [&] {
-            AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+            AT_DISPATCH_FLOATING_TYPES_AND2(
+                at::ScalarType::Half,
+                at::ScalarType::BFloat16,
                 a_values.scalar_type(),
                 "dense_vec_jagged_2d_bmm_kernel_2",
                 [&] {
@@ -925,7 +929,9 @@ class BatchedDenseVecJagged2DMulCPUOp
           a_offsets.scalar_type(),
           "dense_vec_jagged_2d_bmm_baackward_kernel_1",
           [&] {
-            AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+            AT_DISPATCH_FLOATING_TYPES_AND2(
+                at::ScalarType::Half,
+                at::ScalarType::BFloat16,
                 grad_outputs[0].scalar_type(),
                 "dense_vec_jagged_2d_bmm_baackward_kernel_2",
                 [&] {
@@ -974,8 +980,12 @@ Tensor jagged_1d_to_truncated_values_cpu(
   Tensor truncated_values;
   AT_DISPATCH_INDEX_TYPES(
       lengths.scalar_type(), "jagged_1d_to_truncated_values_cpu_kernel", [&] {
-        AT_DISPATCH_ALL_TYPES_AND_HALF(
-            values.scalar_type(), "copy_values_and_truncate_cpu_kernel", [&] {
+        AT_DISPATCH_ALL_TYPES_AND2(
+            at::ScalarType::Half,
+            at::ScalarType::BFloat16,
+            values.scalar_type(),
+            "copy_values_and_truncate_cpu_kernel",
+            [&] {
               const index_t max_length_int =
                   static_cast<index_t>(max_truncated_length);
               const auto lengths_accessor = lengths.accessor<index_t, 1>();
@@ -1021,8 +1031,12 @@ std::tuple<Tensor, Tensor> masked_select_jagged_1d(
 
   AT_DISPATCH_INDEX_TYPES(
       lengths.scalar_type(), "mask_select_jagged_1d_kernel1", [&] {
-        AT_DISPATCH_ALL_TYPES_AND_HALF(
-            values.scalar_type(), "mask_select_jagged_1d_kernel2", [&] {
+        AT_DISPATCH_ALL_TYPES_AND2(
+            at::ScalarType::Half,
+            at::ScalarType::BFloat16,
+            values.scalar_type(),
+            "mask_select_jagged_1d_kernel2",
+            [&] {
               const int32_t num_outputs = mask.sum().item<int32_t>();
               masked_values = at::empty({num_outputs}, values.options());
 

--- a/fbgemm_gpu/src/jagged_tensor_ops_meta.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_meta.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/AccumulateType.h>
+#include <torch/csrc/autograd/custom_function.h>
+#include <torch/library.h>
+
+#include "fbgemm_gpu/sparse_ops.h"
+#include "fbgemm_gpu/sparse_ops_utils.h"
+
+namespace fbgemm_gpu {
+
+using Tensor = at::Tensor;
+
+///@ingroup jagged-tensor-ops-meta
+Tensor jagged_to_padded_dense_forward_meta(
+    const Tensor& values,
+    const std::vector<Tensor>& offsets,
+    const std::vector<int64_t>& max_lengths,
+    const double padding_value = 0) {
+  const size_t num_jagged_dim = offsets.size();
+  TORCH_CHECK(
+      max_lengths.size() == num_jagged_dim,
+      "max_lengths.size(), ",
+      max_lengths.size(),
+      " != num_jagged_dim, ",
+      num_jagged_dim);
+
+  at::DimVector padded_values_shape({offsets[0].size(0) - 1});
+  padded_values_shape.insert(
+      padded_values_shape.end(), max_lengths.begin(), max_lengths.end());
+  if (values.dim() > 1) {
+    padded_values_shape.push_back(values.size(-1));
+  }
+  return at::empty(padded_values_shape, values.options());
+}
+
+Tensor jagged_to_padded_dense_backward_meta(
+    const at::Tensor& grad_output,
+    const std::vector<Tensor>& offsets,
+    const int64_t total_L) {
+  auto grad_padded_values = grad_output;
+
+  int32_t D = grad_padded_values.size(-1);
+  // Initialize with zeros so output will be zero for the portion truncated
+  // in forward.
+  auto grad_values = at::zeros({total_L, D}, grad_padded_values.options());
+
+  TORCH_CHECK(grad_values.is_meta());
+  return grad_values;
+}
+
+} // namespace fbgemm_gpu
+
+TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
+  m.impl(
+      "jagged_to_padded_dense_forward",
+      TORCH_FN(fbgemm_gpu::jagged_to_padded_dense_forward_meta));
+  m.impl(
+      "jagged_to_padded_dense_backward",
+      TORCH_FN(fbgemm_gpu::jagged_to_padded_dense_backward_meta));
+}

--- a/fbgemm_gpu/src/jagged_tensor_ops_meta.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_meta.cpp
@@ -55,6 +55,15 @@ Tensor jagged_to_padded_dense_backward_meta(
   return grad_values;
 }
 
+at::Tensor jagged_dense_dense_elementwise_add_jagged_output_forward_meta(
+    const at::Tensor& x_values,
+    const std::vector<at::Tensor>& x_offsets,
+    const at::Tensor& y_0,
+    const at::Tensor& y_1) {
+  TORCH_CHECK(y_0.sizes() == y_0.sizes());
+  return at::empty_like(x_values);
+}
+
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
@@ -64,4 +73,9 @@ TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
   m.impl(
       "jagged_to_padded_dense_backward",
       TORCH_FN(fbgemm_gpu::jagged_to_padded_dense_backward_meta));
+  m.impl(
+      "jagged_dense_dense_elementwise_add_jagged_output_forward",
+      TORCH_FN(
+          fbgemm_gpu::
+              jagged_dense_dense_elementwise_add_jagged_output_forward_meta));
 }


### PR DESCRIPTION
Summary:
Add Meta and Autograd backend for Jagged_dense_dense_elementwise_add_jagged for dynamo and AOT autograd.

A more proper way of doing Autograd to make inductor working for jagged ops. Also added Meta tensors so we're not mercy of arbitrary zero inputs fed into by default.

Differential Revision: D41368350

