### PR TITLE
Remove inplace update in Python level to avoid BC issue

### DIFF
--- a/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
@@ -18,8 +18,6 @@ torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
 torch.ops.load_library(
     "//deeplearning/fbgemm/fbgemm_gpu:split_table_batched_embeddings"
 )
-torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/fb:embedding_inplace_update")
-torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/fb:embedding_inplace_update_cpu")
 {% else %}
 #import os
 #torch.ops.load_library(os.path.join(os.path.join(os.path.dirname(os.path.dirname(__file__)), "fbgemm_gpu_py.so")))

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -4764,8 +4764,9 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         )
 
         weights_ty_list = [weights_ty] * T
-        if open_source:
-            test_internal = False
+        # if open_source:
+        #     test_internal = False
+        test_internal = False
 
         # create two embedding bag op with random weights
         locations = [location] * T


### PR DESCRIPTION
Summary: Before we open source the inplace-update operators, we need to make sure training_platform fbpkg will not load `//deeplearning/fbgemm/fbgemm_gpu/fb:embedding_inplace_update` when we make the move from fbgemm_gpu/fb to fbgemm_gpu.

Differential Revision: D41545735

