### PR TITLE
Change from ubuntu latest (22.04) to ubuntu 20.04

### DIFF
--- a/.github/workflows/fbgemmci.yml
+++ b/.github/workflows/fbgemmci.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         config: [[pip, 5.1.1]]
 
     steps:


### PR DESCRIPTION
Summary:
Resolve the OSS test failure like

```
The following packages have unmet dependencies:
 libcufile-11-5 : Depends: liburcu6 but it is not installable
E: Unable to correct problems, you have held broken packages.
Error: Process completed with exit code 100.
```
https://github.com/pytorch/FBGEMM/actions/runs/3611911561/jobs/6086679760
https://github.com/pytorch/FBGEMM/actions/runs/3611911561/jobs/6086679736

According to https://askubuntu.com/a/1416915 , this is Ubuntu 22.04 issue, and from https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/ , very recently the default "ubuntu-latest" has been upgraded from 20.04 to 22.04. Before we figure out what to fix on 22.04, we can roll back to 20.04 to avoid the OSS CI failure.

Other helpful links:
- https://fburl.com/code/eqlvzbj8
- https://askubuntu.com/a/1416915
- https://askubuntu.com/a/1307181

Differential Revision: D41717631

