### PR TITLE
Minor fix to benchmark_torch_function, when num_threads > 2

### DIFF
--- a/fbgemm_gpu/bench/bench_utils.py
+++ b/fbgemm_gpu/bench/bench_utils.py
@@ -118,7 +118,7 @@ def benchmark_torch_function(
         torch.cuda.synchronize(device)
         if copy_f_for_multi_thread_test:
             # clean the copies of f and clean the HBM cache
-            for idx in range(num_threads - 1):
+            for idx in reversed(range(num_threads - 1)):
                 del f_list[idx + 1]
         torch.cuda.empty_cache()
 


### PR DESCRIPTION
Summary:
It failed when running feed_lower_benchmark with num_thread > 2.
If we delete k-th element in a list, the list shrunk, so delete (k+1)-th element isn't what it used to be (k+1)-th element, and it could be out of bound index.

This diff makes delete in reverse order.

Differential Revision: D41721711

