### PR TITLE
Add BF16 output support for inference TBE

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
@@ -1477,10 +1477,10 @@ DEVICE_INLINE __nv_bfloat162 to_bfloat16_2(float2 v) {
     __nv_bfloat162 raw;
     __nv_bfloat16 x;
     __nv_bfloat16 y;
-  } tmp;
-  tmp.x = __float2bfloat16_rn(v.x);
-  tmp.y = __float2bfloat16_rn(v.y);
-  return tmp.raw;
+  } t;
+  t.x = __float2bfloat16_rn(v.x);
+  t.y = __float2bfloat16_rn(v.y);
+  return t.raw;
 #endif
 }
 


### PR DESCRIPTION
Summary:
Follow up from D41835847 (https://github.com/pytorch/FBGEMM/commit/39a423e4ad1a04b77fea81c7d09c3e6f8984fae9)

BF16 will work on sm80+ (A100+) device capacity.

Differential Revision: D41865889

