### PR TITLE
Fix the leftover test case for output_dtype

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
@@ -1477,10 +1477,10 @@ DEVICE_INLINE __nv_bfloat162 to_bfloat16_2(float2 v) {
     __nv_bfloat162 raw;
     __nv_bfloat16 x;
     __nv_bfloat16 y;
-  } tmp;
-  tmp.x = __float2bfloat16_rn(v.x);
-  tmp.y = __float2bfloat16_rn(v.y);
-  return tmp.raw;
+  } t;
+  t.x = __float2bfloat16_rn(v.x);
+  t.y = __float2bfloat16_rn(v.y);
+  return t.raw;
 #endif
 }
 

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -703,10 +703,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         B=st.integers(min_value=1, max_value=128),
         log_E=st.integers(min_value=3, max_value=5),
         L=st.integers(min_value=0, max_value=20),
-        # FIXME: switch to
-        # output_dtype=st.sampled_from([SparseType.FP16, SparseType.INT8]),
-        # after v0/v2 is landed.
-        output_dtype=st.sampled_from([SparseType.FP32]),
+        output_dtype=st.sampled_from([SparseType.FP16, SparseType.INT8]),
     )
     @settings(
         verbosity=Verbosity.verbose,

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -831,6 +831,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         output_dtype=st.sampled_from(
             [
                 SparseType.FP16,
+                SparseType.BF16,
                 SparseType.INT8,
                 # SparseType.INT4,
             ]
@@ -855,6 +856,11 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         D_alignment = max(weights_ty.align_size() for t in range(T))
         D_alignment = max(D_alignment, output_dtype.align_size())
         D = round_up(D, D_alignment)
+
+        if (
+            not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 0)
+        ) and output_dtype == SparseType.BF16:
+            output_dtype = SparseType.FP16
 
         Ds = [
             round_up(


### PR DESCRIPTION
Summary: We have fixed v0/v2 BC issue so should be good to test the INT8 output_dtype support in the unit test.

Differential Revision: D42017879

