### PR TITLE
Support k=0 in bottom_k_per_row

### DIFF
--- a/fbgemm_gpu/src/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_cpu.cpp
@@ -2400,6 +2400,10 @@ Tensor bottom_k_per_row(
                                : k_offsets_accessor[i + 1] - start_k_offset;
           TORCH_CHECK(k >= 0);
 
+          if (k == 0) {
+            continue;
+          }
+
           if (requires_unique) {
             std::set<int64_t> s;
 


### PR DESCRIPTION
Summary:
Before this diff, `bottom_k_per_row` would assert with the "too skewed
distribution (alpha too big)" error when k=0.  This diff fixes that
error.

Differential Revision: D42034694

