### PR TITLE
Use larger zipf_oversample_ratio for large L in TBE device_with_spec

### DIFF
--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -2729,6 +2729,7 @@ def device_with_spec(  # noqa C901
             alpha=alpha,
             weighted=weighted,
             sigma_L=sigma_Ls[t] if use_variable_bag_sizes else None,
+            zipf_oversample_ratio=3 if Ls[t] > 5 else 5,
         )
         for i, (indices, offsets, weights) in enumerate(requests):
             all_requests["indices"][i].append(indices)

--- a/fbgemm_gpu/src/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_cpu.cpp
@@ -2400,6 +2400,10 @@ Tensor bottom_k_per_row(
                                : k_offsets_accessor[i + 1] - start_k_offset;
           TORCH_CHECK(k >= 0);
 
+          if (k == 0) {
+            continue;
+          }
+
           if (requires_unique) {
             std::set<int64_t> s;
 


### PR DESCRIPTION
Summary:
This diff uses larger `zipf_oversample_ratio` for large `bag_size` in
the TBE `device_with_spec` benchmark to support zipf data generation
for large `bag_size`.

Differential Revision: D42035880

