### PR TITLE
Back out "deprecate the inplace update op in fbgemm_gpu/fb"

### DIFF
--- a/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
@@ -18,8 +18,13 @@ torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
 torch.ops.load_library(
     "//deeplearning/fbgemm/fbgemm_gpu:split_table_batched_embeddings"
 )
-# torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:embedding_inplace_update")
-# torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:embedding_inplace_update_cpu")
+# try:
+#     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:embedding_inplace_update")
+#     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:embedding_inplace_update_cpu")
+# except OSError:
+#     # Keep for BC: will be deprecated soon.
+#     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/fb:embedding_inplace_update")
+#     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/fb:embedding_inplace_update_cpu")
 
 {% else %}
 #import os


### PR DESCRIPTION
Summary:
Original commit changeset: 1d9ec15772e4

Original Phabricator Diff: D42056919 (https://github.com/pytorch/FBGEMM/commit/aab63de930473669db358ea207d4f80330296fda)

Backward compatibility.

Reviewed By: pengtxiafb

Differential Revision: D42082115

