### PR TITLE
Change update_row_idx data type from int32_t to int64_t

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -2804,7 +2804,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         update_row_indices = torch.tensor(
             update_row_indices,
             device=self.current_device,
-            dtype=torch.int32,
+            dtype=torch.int64,
         )
         update_offsets = torch.tensor(
             update_offsets,

--- a/fbgemm_gpu/include/fbgemm_gpu/embedding_inplace_update.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/embedding_inplace_update.h
@@ -51,7 +51,7 @@ void embedding_inplace_update_host_weight_cuda(
     Tensor D_offsets,
     Tensor update_weights,
     const std::vector<int32_t>& update_table_idx,
-    const std::vector<int32_t>& update_row_idx,
+    const std::vector<int64_t>& update_row_idx,
     const int64_t row_alignment,
     c10::optional<Tensor> lxu_cache_weights = c10::nullopt,
     c10::optional<Tensor> lxu_cache_locations = c10::nullopt);

--- a/fbgemm_gpu/test/embedding_inplace_update_test.cpp
+++ b/fbgemm_gpu/test/embedding_inplace_update_test.cpp
@@ -25,7 +25,7 @@ TEST(embedding_inplace_update_test, random_update) {
   std::vector<uint8_t> weights_tys;
   int64_t update_size = 0;
   std::vector<int32_t> update_tables;
-  std::vector<int32_t> update_rows;
+  std::vector<int64_t> update_rows;
   int64_t dev_weights_offset = 0;
   int64_t uvm_weights_offset = 0;
   for (int i = 0; i < T; i++) {


### PR DESCRIPTION
Summary:
Following the debugging experience of D42080352 (https://github.com/pytorch/FBGEMM/commit/c47f9aa67baa3c2a5fac8a0540060ed2121b44d9) , we make update_row_idx tensor more general to support int32_t / int64_t.

Follow up:

- boundary checker to make sure early error detection (ignore, warning, and fatal mode) for such issue in the future.

Differential Revision: D42080055

