### PR TITLE
deprecate the inplace update op in fbgemm_gpu/fb

### DIFF
--- a/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
@@ -18,13 +18,8 @@ torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
 torch.ops.load_library(
     "//deeplearning/fbgemm/fbgemm_gpu:split_table_batched_embeddings"
 )
-# try:
-#     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:embedding_inplace_update")
-#     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:embedding_inplace_update_cpu")
-# except OSError:
-#     # Keep for BC: will be deprecated soon.
-#     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/fb:embedding_inplace_update")
-#     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/fb:embedding_inplace_update_cpu")
+# torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:embedding_inplace_update")
+# torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:embedding_inplace_update_cpu")
 
 {% else %}
 #import os


### PR DESCRIPTION
Summary:
Original commit changeset: e26887e89608

Original Phabricator Diff: D42082115 (https://github.com/pytorch/FBGEMM/commit/eb163a09e2fd7408fc6dbbbd1674990483df3b73)

Re-apply D42056919 (https://github.com/pytorch/FBGEMM/commit/aab63de930473669db358ea207d4f80330296fda)

Differential Revision: D42223033

