### PR TITLE
Support cudaHostAlloc API inside TBE split op

### DIFF
--- a/fbgemm_gpu/src/cumem_utils.cu
+++ b/fbgemm_gpu/src/cumem_utils.cu
@@ -232,8 +232,10 @@ Tensor new_unified_tensor(
     const std::vector<std::int64_t>& sizes,
     bool is_host_mapped) {
   if (is_host_mapped) {
+    VLOG(2) << "Allocate the ATen Tensor with cudaHostAlloc";
     return new_host_mapped_tensor(self, sizes);
   } else {
+    VLOG(2) << "Allocate the ATen Tensor with cudaMallocManaged";
     return new_managed_tensor(self, sizes);
   }
 }


### PR DESCRIPTION
Summary: For retrieval models, memory allocation happens inside fbgemm. To fix the numa OOM issue, we want to call cudaHostAlloc API inside tbe op

Differential Revision: D42256144

