### PR TITLE
[CI] Update the nightly-release mechanism

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -148,10 +148,9 @@ jobs:
       timeout: 60
       script: |
         set -x
+        conda create -y -n build_binary
         conda run -n build_binary python -m pip install twine
         # Upload it to the official PYPI website
         FBGEMM_ARTIFACT_PATH="${RUNNER_ARTIFACT_DIR}/${{ needs.setup_wheel_jobs.outputs.fbgemm_package_name }}_${{ matrix.python-version }}_${{ matrix.cuda-tag }}"
         WHEEL_PATH="$(ls ${FBGEMM_ARTIFACT_PATH}/*.whl)"
-        conda run -n build_binary python -m twine upload --username __token__ --password "invalid_password" --skip-existing --verbose "${WHEEL_PATH}"
-        # Still under testing.  Let's comment it out for now.
-        # conda run -n build_binary python -m twine upload --username __token__ --password "$PYPI_TOKEN" --skip-existing --verbose "${WHEEL_PATH}"
+        conda run -n build_binary python -m twine upload --username __token__ --password "$PYPI_TOKEN" --skip-existing --verbose "${WHEEL_PATH}"

--- a/.github/workflows/fbgemm_nightly_build.yml
+++ b/.github/workflows/fbgemm_nightly_build.yml
@@ -7,8 +7,8 @@ on:
   # For debugging, enable push/pull_request
   # [push, pull_request]
   # run every day at 10:45 AM
-  schedule:
-    - cron:  '45 10 * * *'
+  # schedule:
+  #   - cron:  '45 10 * * *'
   # or manually trigger it
   workflow_dispatch:
 


### PR DESCRIPTION
## What does this PR do?

We are updating the release mechanism of the FBGEMM nightly build. The new mechanism (#1407) is cleaner and its tests are more comprehensive.

However, changing such a mechanism needs extra caution because it can break workloads that use FBGEMM nightly binaries. Actually, #1407 did not disable the existing mechanism.  After #1407 was merged, we need to check the following:
- [x] The new nightly job is triggered every day.
- [x] The new nightly job passes tests on GPUs stably.
- [ ] The new nightly job uploads wheel files to PyPI successfully.

The new nightly job seems working correctly (https://github.com/pytorch/FBGEMM/actions/runs/3882482573), so this PR checks the last point by disabling the trigger to the original mechanism and enabling the new one.

## What if the new nightly mechanism is not functional?

Nevertheless, the new mechanism might not work for some reason.  If the new nightly mechanism does not work for some reason, we must revert this PR, but even without doing so, we can trigger the existing `Push Binary Nightly` manually so that we can fall back to the current method.
...
I will carefully check it for a few days :)