### PR TITLE
[CI] Set PYPI_TOKEN in build_wheel.yml

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -129,28 +129,32 @@ jobs:
         WHEEL_PATH="$(ls ${FBGEMM_ARTIFACT_PATH}/*.whl)"
         bash .github/scripts/test_wheel.bash -v -p ${{ matrix.python-version }} -P ${{ needs.setup_wheel_jobs.outputs.pytorch_channel }} -c "${PYTORCH_CUDA_VERSION}" -w "${WHEEL_PATH}" -m "/opt/conda"
 
-  # Upload the created wheels to PYPI
+  # Upload the created wheels to PyPI
   upload_pypi:
     needs: [setup_wheel_jobs, test_wheel_gpu, test_wheel_cpu]
     strategy:
       matrix:
-        os: [linux.4xlarge]
+        os: [ubuntu-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         cuda-tag: ["cu11", "cpu"]
+    runs-on: ${{ matrix.os }}
 
-    if: ${{ inputs.upload_pypi }}
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
-    with:
-      job-name: upload_pypi (py${{ matrix.python-version }}-${{ matrix.cuda-tag }})
-      runner: ${{ matrix.os }}
-      repository: pytorch/fbgemm
-      download-artifact: ${{ needs.setup_wheel_jobs.outputs.fbgemm_package_name }}_${{ matrix.python-version }}_${{ matrix.cuda-tag }}
-      timeout: 60
-      script: |
-        set -x
-        conda create -y -n build_binary
-        conda run -n build_binary python -m pip install twine
-        # Upload it to the official PYPI website
-        FBGEMM_ARTIFACT_PATH="${RUNNER_ARTIFACT_DIR}/${{ needs.setup_wheel_jobs.outputs.fbgemm_package_name }}_${{ matrix.python-version }}_${{ matrix.cuda-tag }}"
+    steps:
+    - name: Download an artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ needs.setup_wheel_jobs.outputs.fbgemm_package_name }}_${{ matrix.python-version }}_${{ matrix.cuda-tag }}
+        path: ${{ runner.temp }}/artifacts/
+    - name: Upload a wheel to PyPI
+      if: ${{ inputs.upload_pypi }}
+      env:
+        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        # Install Twine
+        sudo apt install python3-pip
+        pip3 install twine
+
+        # Upload FBGEMM_GPU binary
+        FBGEMM_ARTIFACT_PATH="${{ runner.temp }}/artifacts/${{ needs.setup_wheel_jobs.outputs.fbgemm_package_name }}_${{ matrix.python-version }}_${{ matrix.cuda-tag }}"
         WHEEL_PATH="$(ls ${FBGEMM_ARTIFACT_PATH}/*.whl)"
-        conda run -n build_binary python -m twine upload --username __token__ --password "$PYPI_TOKEN" --skip-existing --verbose "${WHEEL_PATH}"
+        twine upload --username __token__ --password "$PYPI_TOKEN" --skip-existing --verbose "$WHEEL_PATH"


### PR DESCRIPTION
`PYPI_TOKEN` is not set in the new nightly wheel script (`build_wheel.yml`), so it fails to upload created wheel files to PYPI (https://github.com/pytorch/FBGEMM/actions/runs/3901417835). This PR fixes this issue.

### Details

We need to use a secret `PYPI_TOKEN` to upload wheel files to PyPI. It needs to be accessed via `env` (e.g., https://github.com/pytorch/FBGEMM/blob/v0.3.0/.github/workflows/fbgemm_nightly_build.yml#L264-L265).

`upload_pypi` job in the new nightly script uses a Docker (via `linux_job.yml`). Because I am not 100% sure if we can securely pass this `PYPI_TOKEN` to the Docker container, this PR changes `upload_pypi` to use a default GitHub Action runner (`ubuntu-latest`) and pass `PYPI_TOKEN` as the original nightly script does, which is the standard method and therefore should be more secure.
