### PR TITLE
[CI] Add secret inheritance setting to pass PYPI_TOKEN

### DIFF
--- a/.github/workflows/push_wheel_trigger.yml
+++ b/.github/workflows/push_wheel_trigger.yml
@@ -31,3 +31,4 @@ jobs:
       # if it's triggered by "schedule", nightly + true will be chosen
       release_version: ${{ inputs.release_version || 'nightly' }}
       upload_pypi: ${{ (inputs.upload_pypi || 'true') == 'true' }}
+    secrets: inherit


### PR DESCRIPTION
This PR follows up #1542; `github.secrets` is not passed to a reusable workflow by default, so #1542 does not fix the issue. This PR solves the issue by setting `secrets: inherit` in the caller workflow script.

### [Details]

The main PyPI upload mechanism is defined in `build_wheel.yml`. This is a "reusable workflow" and is triggered by `push_wheel_trigger.yml` every night. GitHub Actions, by default, does not pass `github.secrets` to a reusable workflow even if both belong to the same repository (https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow). The setting above fixes the issue (as far as I tried locally).

Note 1: This problem does not exist in the original scripts (e.g., `fbgemm_nightly_build.yml`) because they do not use a reusable workflow mechanism (i.e., both cron trigger and `pypi-upload` logics exist in the same file).

Note 2: The new mechanism cannot define a trigger and `pypi-upload` in the same file as the original script does because I could not find a way to put all the following triggers in a single file:
1. cron-based job trigger (now in `push_wheel_trigger.yml`)
2. manual job trigger (=`workflow_dispatch`, now in `push_wheel_trigger.yml`)
3. per-PR job trigger to test wheel creation (enabled when a special label is added, now in `test_wheel_trigger.yml`)



