### PR TITLE
[CI][Test] Fix uvm_test.py when a machine has only 1 GPU

### DIFF
--- a/fbgemm_gpu/test/uvm_test.py
+++ b/fbgemm_gpu/test/uvm_test.py
@@ -169,7 +169,10 @@ class UvmTest(unittest.TestCase):
         torch.cuda.synchronize(torch.device("cuda:0"))
 
     @skipIfRocm()
-    @unittest.skipIf(*gpu_unavailable or torch.cuda.device_count() < 2)
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        "Skip unless two CUDA devices are detected",
+    )
     @given(
         sizes=st.lists(
             st.integers(min_value=1, max_value=(1024)), min_size=1, max_size=4


### PR DESCRIPTION
The following `skipIf` does not work correctly when a machine has only one GPU.
```py
@unittest.skipIf(*gpu_unavailable or torch.cuda.device_count() < 2)
def test_uvm_to_device(self, sizes: List[int], uvm_op) -> None:
  [...]
```

This patch corrects the condition.

### Details

First, `*gpu_unavailable` is defined as follows.
```py
gpu_unavailable: Tuple[bool, str] = (
    not torch.cuda.is_available() or torch.cuda.device_count() == 0,
    "CUDA is not available or no GPUs detected",
)
```

So the `skipIf` is expanded as follows when there is only one CUDA device.
```py
@unittest.skipIf(*gpu_unavailable or torch.cuda.device_count() < 2)
->
@unittest.skipIf((False, "CUDA is not ...") or True)
```

Because `(False, "abc") or True` is `(False, "abc")` in Python,
```py
@unittest.skipIf((False, "CUDA is not ...") or True)
->
@unittest.skipIf(False, "CUDA is not ...")
```
It is `False`, so this unit test is not skipped.  This UVM test seems failing occasionally because the machine does not have two GPUs, which annoys FBGEMM developers.
