### PR TITLE
[CI] Fix test_amd_gpu

### DIFF
--- a/.jenkins/rocm/build_and_test.sh
+++ b/.jenkins/rocm/build_and_test.sh
@@ -26,6 +26,8 @@ locale-gen en_US.UTF-8
 pip3 install click
 pip3 install jinja2
 pip3 install ninja
+# scikit-build >=0.16.5 needs a newer CMake
+pip3 install --upgrade cmake
 pip3 install scikit-build
 pip3 install --upgrade hypothesis
 pip3 install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.2/


### PR DESCRIPTION
Recently (within 1-2 days), the version of pip3's `scikit-build` was upgraded from `0.16.4` to `0.16.5`.  After that a newer CMake version becomes necessary perhaps because of the first issue in https://scikit-build.readthedocs.io/en/latest/changes.html#scikit-build-0-16-5

This is causing a compilation issue on a ROCm docker, which uses a relatively old CMake (e.g., https://github.com/pytorch/FBGEMM/actions/runs/3962257477/jobs/6788688786).  This PR upgrades the CMake version in the Docker container.
