### PR TITLE
remove _autograd, these functions are common interfaces for CPU/CUDA/Autograd backend

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -373,53 +373,52 @@ std::vector<at::Tensor> stacked_jagged_2d_to_dense_cpu(
     const std::vector<int64_t>& max_lengths_per_key,
     int64_t padding_value);
 
-at::Tensor jagged_to_padded_dense_autograd(
+at::Tensor jagged_to_padded_dense(
     const at::Tensor& values,
     const std::vector<at::Tensor>& offsets,
     const std::vector<std::int64_t>& max_lengths,
     const double padding_value);
 
-at::Tensor jagged_dense_elementwise_add_autograd(
+at::Tensor jagged_dense_elementwise_add(
     const at::Tensor& x_values,
     const std::vector<at::Tensor>& x_offsets,
     const at::Tensor& y);
 
-at::Tensor jagged_1d_to_dense_autograd(
+at::Tensor jagged_1d_to_dense(
     at::Tensor values,
     at::Tensor offsets,
     int64_t max_L,
     int64_t padding_value);
 
-at::Tensor jagged_2d_to_dense_autograd(
+at::Tensor jagged_2d_to_dense(
     at::Tensor values,
     at::Tensor offsets,
     int64_t max_sequence_length);
 
 std::tuple<at::Tensor, std::vector<at::Tensor>>
-jagged_dense_dense_elementwise_add_jagged_output_autograd(
+jagged_dense_dense_elementwise_add_jagged_output(
     const at::Tensor& x_values,
     const std::vector<at::Tensor>& x_offsets,
     const at::Tensor& y_0,
     const at::Tensor& y_1);
 
-at::Tensor batched_dense_vec_jagged_2d_mul_autograd(
+at::Tensor batched_dense_vec_jagged_2d_mul(
     const at::Tensor& v,
     const at::Tensor& a_values,
     const at::Tensor& a_offsets);
 
-std::tuple<at::Tensor, std::vector<at::Tensor>>
-jagged_dense_elementwise_mul_autograd(
+std::tuple<at::Tensor, std::vector<at::Tensor>> jagged_dense_elementwise_mul(
     const at::Tensor& x_values,
     const std::vector<at::Tensor>& x_offsets,
     const at::Tensor& y);
 
-std::tuple<at::Tensor, std::vector<at::Tensor>> dense_to_jagged_autograd(
+std::tuple<at::Tensor, std::vector<at::Tensor>> dense_to_jagged(
     const at::Tensor& dense,
     const std::vector<at::Tensor>& offsets,
     const c10::optional<int64_t>& total_L);
 
 std::tuple<at::Tensor, std::vector<at::Tensor>>
-jagged_dense_elementwise_add_jagged_output_autograd(
+jagged_dense_elementwise_add_jagged_output(
     const at::Tensor& x_values,
     const std::vector<at::Tensor>& x_offsets,
     const at::Tensor& y);

--- a/fbgemm_gpu/src/jagged_tensor_ops.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops.cu
@@ -2785,11 +2785,11 @@ std::vector<Tensor> keyed_jagged_index_select_dim_1_gpu(
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
-  DISPATCH_TO_CUDA("dense_to_jagged", fbgemm_gpu::dense_to_jagged_autograd);
+  DISPATCH_TO_CUDA("dense_to_jagged", fbgemm_gpu::dense_to_jagged);
   DISPATCH_TO_CUDA(
       "dense_to_jagged_forward", fbgemm_gpu::dense_to_jagged_forward);
   DISPATCH_TO_CUDA(
-      "jagged_to_padded_dense", fbgemm_gpu::jagged_to_padded_dense_autograd);
+      "jagged_to_padded_dense", fbgemm_gpu::jagged_to_padded_dense);
   DISPATCH_TO_CUDA(
       "jagged_to_padded_dense_forward",
       fbgemm_gpu::jagged_to_padded_dense_forward);
@@ -2797,17 +2797,18 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
       "jagged_to_padded_dense_backward",
       fbgemm_gpu::jagged_to_padded_dense_backward);
   DISPATCH_TO_CUDA(
-      "jagged_dense_elementwise_add",
-      fbgemm_gpu::jagged_dense_elementwise_add_autograd);
+      "jagged_dense_elementwise_add", fbgemm_gpu::jagged_dense_elementwise_add);
   DISPATCH_TO_CUDA(
       "jagged_dense_elementwise_add_jagged_output",
-      fbgemm_gpu::jagged_dense_elementwise_add_jagged_output_autograd);
+      fbgemm_gpu::jagged_dense_elementwise_add_jagged_output);
   DISPATCH_TO_CUDA(
       "jagged_dense_dense_elementwise_add_jagged_output_forward",
       fbgemm_gpu::jagged_dense_dense_elementwise_add_jagged_output_forward);
   DISPATCH_TO_CUDA(
       "jagged_dense_dense_elementwise_add_jagged_output",
-      fbgemm_gpu::jagged_dense_dense_elementwise_add_jagged_output_autograd);
+      fbgemm_gpu::jagged_dense_dense_elementwise_add_jagged_output);
+  DISPATCH_TO_CUDA(
+      "jagged_dense_elementwise_mul", fbgemm_gpu::jagged_dense_elementwise_mul);
   DISPATCH_TO_CUDA(
       "jagged_dense_elementwise_mul_forward",
       fbgemm_gpu::jagged_dense_elementwise_mul_forward);
@@ -2815,8 +2816,8 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
       "jagged_dense_elementwise_mul_backward",
       fbgemm_gpu::jagged_dense_elementwise_mul_backward);
   DISPATCH_TO_CUDA(
-      "jagged_dense_elementwise_mul",
-      fbgemm_gpu::jagged_dense_elementwise_mul_autograd);
+      "batched_dense_vec_jagged_2d_mul",
+      fbgemm_gpu::batched_dense_vec_jagged_2d_mul);
   DISPATCH_TO_CUDA(
       "batched_dense_vec_jagged_2d_mul_forward",
       fbgemm_gpu::batched_dense_vec_jagged_2d_mul_forward);
@@ -2824,14 +2825,9 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
       "batched_dense_vec_jagged_2d_mul_backward",
       fbgemm_gpu::batched_dense_vec_jagged_2d_mul_backward);
   DISPATCH_TO_CUDA(
-      "batched_dense_vec_jagged_2d_mul",
-      fbgemm_gpu::batched_dense_vec_jagged_2d_mul_autograd);
-  DISPATCH_TO_CUDA(
       "jagged_index_select", fbgemm_gpu::jagged_index_select_2d_gpu);
-  DISPATCH_TO_CUDA(
-      "jagged_1d_to_dense", fbgemm_gpu::jagged_1d_to_dense_autograd);
-  DISPATCH_TO_CUDA(
-      "jagged_2d_to_dense", fbgemm_gpu::jagged_2d_to_dense_autograd);
+  DISPATCH_TO_CUDA("jagged_1d_to_dense", fbgemm_gpu::jagged_1d_to_dense);
+  DISPATCH_TO_CUDA("jagged_2d_to_dense", fbgemm_gpu::jagged_2d_to_dense);
   DISPATCH_TO_CUDA(
       "stacked_jagged_1d_to_dense", fbgemm_gpu::stacked_jagged_1d_to_dense_gpu);
   DISPATCH_TO_CUDA(

--- a/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
@@ -299,7 +299,7 @@ class DenseToJaggedOp : public torch::autograd::Function<DenseToJaggedOp> {
 } // namespace
 
 ///@ingroup jagged-tensor-ops-cpu
-Tensor jagged_to_padded_dense_autograd(
+Tensor jagged_to_padded_dense(
     const Tensor& values,
     const std::vector<Tensor>& offsets,
     const std::vector<int64_t>& max_lengths,
@@ -310,7 +310,7 @@ Tensor jagged_to_padded_dense_autograd(
 
 ///@ingroup jagged-tensor-ops-cpu
 /// Output = x + y where x is jagged, y and output are dense
-Tensor jagged_dense_elementwise_add_autograd(
+Tensor jagged_dense_elementwise_add(
     const Tensor& x_values,
     const std::vector<Tensor>& x_offsets,
     const Tensor& y) {
@@ -333,7 +333,7 @@ Tensor jagged_dense_elementwise_add_autograd(
 // output = x + y_0 + y_1 where x is jagged, y_0 and y_1 are dense, and output
 // is jagged
 std::tuple<Tensor, std::vector<Tensor>>
-jagged_dense_dense_elementwise_add_jagged_output_autograd(
+jagged_dense_dense_elementwise_add_jagged_output(
     const Tensor& x_values,
     const std::vector<Tensor>& x_offsets,
     const Tensor& y_0,
@@ -345,7 +345,7 @@ jagged_dense_dense_elementwise_add_jagged_output_autograd(
 }
 
 ///@ingroup jagged-tensor-ops-cpu
-std::tuple<Tensor, std::vector<Tensor>> jagged_dense_elementwise_mul_autograd(
+std::tuple<Tensor, std::vector<Tensor>> jagged_dense_elementwise_mul(
     const Tensor& x_values,
     const std::vector<Tensor>& x_offsets,
     const Tensor& y) {
@@ -356,7 +356,7 @@ std::tuple<Tensor, std::vector<Tensor>> jagged_dense_elementwise_mul_autograd(
 }
 
 ///@ingroup jagged-tensor-ops-cpu
-Tensor batched_dense_vec_jagged_2d_mul_autograd(
+Tensor batched_dense_vec_jagged_2d_mul(
     const Tensor& v,
     const Tensor& a_values,
     const Tensor& a_offsets) {
@@ -365,7 +365,7 @@ Tensor batched_dense_vec_jagged_2d_mul_autograd(
 
 ///@ingroup jagged-tensor-ops-cpu
 // output = x + y where x is jagged, y is dense, and output is jagged
-std::tuple<Tensor, std::vector<Tensor>> dense_to_jagged_autograd(
+std::tuple<Tensor, std::vector<Tensor>> dense_to_jagged(
     const Tensor& dense,
     const std::vector<Tensor>& offsets,
     const c10::optional<int64_t>& total_L) {
@@ -375,7 +375,7 @@ std::tuple<Tensor, std::vector<Tensor>> dense_to_jagged_autograd(
 ///@ingroup jagged-tensor-ops-cpu
 /// Output = x + y where x is jagged, y is dense, and output is jagged
 std::tuple<Tensor, std::vector<Tensor>>
-jagged_dense_elementwise_add_jagged_output_autograd(
+jagged_dense_elementwise_add_jagged_output(
     const Tensor& x_values,
     const std::vector<Tensor>& x_offsets,
     const Tensor& y) {
@@ -389,25 +389,44 @@ jagged_dense_elementwise_add_jagged_output_autograd(
   return {sum_values, x_offsets};
 }
 
+///@ingroup jagged-tensor-ops-cpu
+Tensor jagged_1d_to_dense(
+    Tensor values,
+    Tensor offsets,
+    int64_t max_L,
+    int64_t padding_value) {
+  TORCH_CHECK(values.dim() == 1);
+  TORCH_CHECK(offsets.dim() == 1);
+  TORCH_CHECK(max_L > 0);
+
+  return jagged_to_padded_dense(values, {offsets}, {max_L}, padding_value);
+}
+
+///@ingroup jagged-tensor-ops-cpu
+Tensor
+jagged_2d_to_dense(Tensor values, Tensor offsets, int64_t max_sequence_length) {
+  return jagged_to_padded_dense(
+      values,
+      {offsets},
+      {max_sequence_length},
+      /*padding_value=*/0);
+}
+
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_IMPL(fbgemm, Autograd, m) {
   m.impl(
-      "jagged_to_padded_dense",
-      TORCH_FN(fbgemm_gpu::jagged_to_padded_dense_autograd));
-  m.impl(
-      "jagged_2d_to_dense", TORCH_FN(fbgemm_gpu::jagged_2d_to_dense_autograd));
-  m.impl(
-      "jagged_1d_to_dense", TORCH_FN(fbgemm_gpu::jagged_1d_to_dense_autograd));
+      "jagged_to_padded_dense", TORCH_FN(fbgemm_gpu::jagged_to_padded_dense));
+  m.impl("jagged_2d_to_dense", TORCH_FN(fbgemm_gpu::jagged_2d_to_dense));
+  m.impl("jagged_1d_to_dense", TORCH_FN(fbgemm_gpu::jagged_1d_to_dense));
   m.impl(
       "jagged_dense_dense_elementwise_add_jagged_output",
-      TORCH_FN(fbgemm_gpu::
-                   jagged_dense_dense_elementwise_add_jagged_output_autograd));
+      TORCH_FN(fbgemm_gpu::jagged_dense_dense_elementwise_add_jagged_output));
   m.impl(
       "jagged_dense_elementwise_mul",
-      TORCH_FN(fbgemm_gpu::jagged_dense_elementwise_mul_autograd));
+      TORCH_FN(fbgemm_gpu::jagged_dense_elementwise_mul));
   m.impl(
       "batched_dense_vec_jagged_2d_mul",
-      TORCH_FN(fbgemm_gpu::batched_dense_vec_jagged_2d_mul_autograd));
-  m.impl("dense_to_jagged", TORCH_FN(fbgemm_gpu::dense_to_jagged_autograd));
+      TORCH_FN(fbgemm_gpu::batched_dense_vec_jagged_2d_mul));
+  m.impl("dense_to_jagged", TORCH_FN(fbgemm_gpu::dense_to_jagged));
 }

--- a/fbgemm_gpu/src/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_cpu.cpp
@@ -335,7 +335,6 @@ void jagged_dense_elementwise_jagged_output_kernel_(
   } // for each oidx
 }
 
-/// @ingroup jagged-tensor-ops-cpu
 template <typename scalar_t, typename F>
 void jagged_dense_elementwise_jagged_output_(
     const Tensor& x_values,
@@ -364,7 +363,6 @@ void jagged_dense_elementwise_jagged_output_(
 #undef INVOKE_KERNEL_WITH_DIM
 }
 
-///@ingroup jagged-tensor-ops-cpu
 at::Tensor jagged_to_padded_dense_forward(
     const Tensor& values,
     const std::vector<Tensor>& offsets,
@@ -868,7 +866,6 @@ std::tuple<Tensor, Tensor> batched_dense_vec_jagged_2d_mul_backward(
   return {v_grad, a_values_grad};
 }
 
-///@ingroup jagged-tensor-ops-cpu
 Tensor jagged_1d_to_truncated_values_cpu(
     Tensor values,
     Tensor lengths,
@@ -913,7 +910,6 @@ Tensor jagged_1d_to_truncated_values_cpu(
   return truncated_values;
 }
 
-///@ingroup jagged-tensor-ops-cpu
 std::tuple<Tensor, Tensor> masked_select_jagged_1d(
     const Tensor& values,
     const Tensor& lengths,
@@ -970,7 +966,6 @@ std::tuple<Tensor, Tensor> masked_select_jagged_1d(
 
 } // namespace
 
-///@ingroup jagged-tensor-ops-cpu
 Tensor
 jagged_2d_to_dense_forward_cpu(Tensor values, Tensor offsets, int64_t max_L) {
   TORCH_CHECK(values.dim() == 2);
@@ -979,31 +974,6 @@ jagged_2d_to_dense_forward_cpu(Tensor values, Tensor offsets, int64_t max_L) {
 
   return jagged_to_padded_dense_forward(
       values, {offsets}, {max_L}, /*padding_value=*/0);
-}
-
-///@ingroup jagged-tensor-ops-cpu
-Tensor jagged_1d_to_dense_autograd(
-    Tensor values,
-    Tensor offsets,
-    int64_t max_L,
-    int64_t padding_value) {
-  TORCH_CHECK(values.dim() == 1);
-  TORCH_CHECK(offsets.dim() == 1);
-  TORCH_CHECK(max_L > 0);
-
-  return jagged_to_padded_dense_autograd(
-      values, {offsets}, {max_L}, padding_value);
-}
-
-Tensor jagged_2d_to_dense_autograd(
-    Tensor values,
-    Tensor offsets,
-    int64_t max_sequence_length) {
-  return jagged_to_padded_dense_autograd(
-      values,
-      {offsets},
-      {max_sequence_length},
-      /*padding_value=*/0);
 }
 
 std::vector<Tensor> stacked_jagged_1d_to_dense_cpu(
@@ -1033,7 +1003,7 @@ std::vector<Tensor> stacked_jagged_1d_to_dense_cpu(
             output_ptr[i] = cumsum;
           }
         });
-    padded_values_per_key.push_back(jagged_to_padded_dense_autograd(
+    padded_values_per_key.push_back(jagged_to_padded_dense(
         values.slice(0, offset_per_key[t], offset_per_key[t + 1]),
         {offsets},
         {max_L},
@@ -1074,7 +1044,7 @@ std::vector<Tensor> stacked_jagged_2d_to_dense_cpu(
         });
     offsets_tensor_per_key.push_back(offsets);
 
-    padded_values_per_key.push_back(jagged_to_padded_dense_autograd(
+    padded_values_per_key.push_back(jagged_to_padded_dense(
         values.slice(0, offset_per_key[t], offset_per_key[t + 1]),
         {offsets},
         {max_L},
@@ -1141,15 +1111,12 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
-  DISPATCH_TO_CPU(
-      "jagged_2d_to_dense", fbgemm_gpu::jagged_2d_to_dense_autograd);
-  DISPATCH_TO_CPU(
-      "jagged_1d_to_dense", fbgemm_gpu::jagged_1d_to_dense_autograd);
-  DISPATCH_TO_CPU("dense_to_jagged", fbgemm_gpu::dense_to_jagged_autograd);
+  DISPATCH_TO_CPU("jagged_2d_to_dense", fbgemm_gpu::jagged_2d_to_dense);
+  DISPATCH_TO_CPU("jagged_1d_to_dense", fbgemm_gpu::jagged_1d_to_dense);
+  DISPATCH_TO_CPU("dense_to_jagged", fbgemm_gpu::dense_to_jagged);
   DISPATCH_TO_CPU(
       "dense_to_jagged_forward", fbgemm_gpu::dense_to_jagged_forward);
-  DISPATCH_TO_CPU(
-      "jagged_to_padded_dense", fbgemm_gpu::jagged_to_padded_dense_autograd);
+  DISPATCH_TO_CPU("jagged_to_padded_dense", fbgemm_gpu::jagged_to_padded_dense);
   DISPATCH_TO_CPU(
       "jagged_to_padded_dense_forward",
       fbgemm_gpu::jagged_to_padded_dense_forward);
@@ -1157,20 +1124,18 @@ TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
       "jagged_to_padded_dense_backward",
       fbgemm_gpu::jagged_to_padded_dense_backward);
   DISPATCH_TO_CPU(
-      "jagged_dense_elementwise_add",
-      fbgemm_gpu::jagged_dense_elementwise_add_autograd);
+      "jagged_dense_elementwise_add", fbgemm_gpu::jagged_dense_elementwise_add);
   DISPATCH_TO_CPU(
       "jagged_dense_elementwise_add_jagged_output",
-      fbgemm_gpu::jagged_dense_elementwise_add_jagged_output_autograd);
+      fbgemm_gpu::jagged_dense_elementwise_add_jagged_output);
   DISPATCH_TO_CPU(
       "jagged_dense_dense_elementwise_add_jagged_output_forward",
       fbgemm_gpu::jagged_dense_dense_elementwise_add_jagged_output_forward);
   DISPATCH_TO_CPU(
       "jagged_dense_dense_elementwise_add_jagged_output",
-      fbgemm_gpu::jagged_dense_dense_elementwise_add_jagged_output_autograd);
+      fbgemm_gpu::jagged_dense_dense_elementwise_add_jagged_output);
   DISPATCH_TO_CPU(
-      "jagged_dense_elementwise_mul",
-      fbgemm_gpu::jagged_dense_elementwise_mul_autograd);
+      "jagged_dense_elementwise_mul", fbgemm_gpu::jagged_dense_elementwise_mul);
   DISPATCH_TO_CPU(
       "jagged_dense_elementwise_mul_forward",
       fbgemm_gpu::jagged_dense_elementwise_mul_forward);
@@ -1179,7 +1144,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
       fbgemm_gpu::jagged_dense_elementwise_mul_backward);
   DISPATCH_TO_CPU(
       "batched_dense_vec_jagged_2d_mul",
-      fbgemm_gpu::batched_dense_vec_jagged_2d_mul_autograd);
+      fbgemm_gpu::batched_dense_vec_jagged_2d_mul);
   DISPATCH_TO_CPU(
       "batched_dense_vec_jagged_2d_mul_forward",
       fbgemm_gpu::batched_dense_vec_jagged_2d_mul_forward);


### PR DESCRIPTION
Summary: To avoid _autograd captured by FBGEMM document: https://pytorch.org/FBGEMM/cpp-api/jagged_tensor_ops.html.

Differential Revision: D42669538

