### PR TITLE
[build] Fix the nightly build

### DIFF
--- a/.github/workflows/fbgemm_nightly_build.yml
+++ b/.github/workflows/fbgemm_nightly_build.yml
@@ -70,8 +70,9 @@ jobs:
     - name: Install PyTorch and CUDA
       shell: bash
       run: |
-        conda install -n build_binary -y -c "nvidia/label/cuda-11.7.1" cuda-nvcc cuda-runtime
+        conda install -n build_binary -y -c "nvidia/label/cuda-11.7.1" cuda-nvcc
         ls ~/miniconda/envs/build_binary
+        find / -name cuda_runtime.h 2> /dev/null
         conda run -n build_binary pip3 install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu117
     - name: Install Other Dependencies
       shell: bash

--- a/.github/workflows/fbgemm_nightly_build.yml
+++ b/.github/workflows/fbgemm_nightly_build.yml
@@ -71,6 +71,8 @@ jobs:
       shell: bash
       run: |
         conda install -n build_binary -y -c "nvidia/label/cuda-11.7.1" cuda-nvcc
+        conda install -n build_binary -y -c anaconda cudatoolkit
+        ls ~/miniconda/envs/build_binary
         conda run -n build_binary pip3 install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu117
     - name: Install Other Dependencies
       shell: bash

--- a/.github/workflows/fbgemm_nightly_build.yml
+++ b/.github/workflows/fbgemm_nightly_build.yml
@@ -70,8 +70,7 @@ jobs:
     - name: Install PyTorch and CUDA
       shell: bash
       run: |
-        conda install -n build_binary -y -c "nvidia/label/cuda-11.7.1" cuda-nvcc
-        conda install -n build_binary -y -c anaconda cudatoolkit
+        conda install -n build_binary -y -c "nvidia/label/cuda-11.7.1" cuda-nvcc cuda-runtime
         ls ~/miniconda/envs/build_binary
         conda run -n build_binary pip3 install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu117
     - name: Install Other Dependencies

--- a/.github/workflows/fbgemm_nightly_build.yml
+++ b/.github/workflows/fbgemm_nightly_build.yml
@@ -5,12 +5,12 @@ name: Push Binary Nightly
 
 on:
   # For debugging, enable push/pull_request
-  # [push, pull_request]
+  [push, pull_request]
   # run every day at 10:45 AM
   # schedule:
   #   - cron:  '45 10 * * *'
   # or manually trigger it
-  workflow_dispatch:
+  # workflow_dispatch:
 
 jobs:
   # build on cpu hosts and upload to GHA
@@ -70,7 +70,8 @@ jobs:
     - name: Install PyTorch and CUDA
       shell: bash
       run: |
-        conda install -n build_binary -y pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
+        conda install -n build_binary -y -c "nvidia/label/cuda-11.7.1" cuda-nvcc
+        conda run -n build_binary pip3 install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu117
     - name: Install Other Dependencies
       shell: bash
       run: |
@@ -217,7 +218,8 @@ jobs:
     - name: Install PyTorch using Conda
       shell: bash
       run: |
-        conda install -n build_binary -y pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
+        conda install -n build_binary -y -c "nvidia/label/cuda-11.7.1" cuda-nvcc
+        conda run -n build_binary pip3 install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu117
     # download wheel from GHA
     - name: Download wheel
       uses: actions/download-artifact@v2


### PR DESCRIPTION
- Update the PyTorch installation to use `pip` instead of `conda` to work around the recent PyTorch nightlies missing the generated `torch/include/c10/cuda/impl/cuda_cmake_macros.h`