### PR TITLE
bug fix atomics without fence and speedup super long segments

### DIFF
--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -1561,7 +1561,9 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
 
     @given(
         D=st.integers(min_value=2, max_value=10),
-        B=st.sampled_from([1152, 2048]),
+        # 128 * 1024 is to exercise a case num_ctas_for_run needs to be capped at
+        # the number of SMs (H100 has 114 SMs and the default seglen per CTA is 1024)
+        B=st.sampled_from([1152, 128 * 1024]),
         L=st.integers(min_value=1, max_value=4),
         weighted=st.booleans(),
         mixed=st.booleans(),


### PR DESCRIPTION
Summary:
Atomics should be often used together with fence (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#memory-fence-functions).

cta_per_row kernel with atomic was supposed to help really long segments but it introduced pathologically bad performance when the segment is SUPER long.
If one embedding vector is accessed 46266989 times within a batch as shown by Patrick’s notebook, we’ll create 46266989/1024 = 45K long_run_ids that parallelized across thread blocks (https://fburl.com/code/hhh3z33i where max_segment_length_per_cta = 1024).
With so many long_run_ids, the linear search to compute cta_rank_on_current_run and num_ctas_on_current_run takes too long.

Instead, in this diff, we store negative of cta_rank_on_current_run to long_run_ids except for cta_rank_on_current_run == 0. And compute num_ctas_on_current_run by using the same formula used in find_long_segments kernel (but we must be careful they agree! Added a comment on this).

Differential Revision: D42806776

