### PR TITLE
Bm/t143666669/remove py37

### DIFF
--- a/.github/scripts/build_wheel.bash
+++ b/.github/scripts/build_wheel.bash
@@ -10,17 +10,17 @@ verbose=0
 package_name=""
 python_version=""
 pytorch_channel_name=""
-pytorch_cuda_version="x"
+cuda_version="x"
 miniconda_prefix="${HOME}/miniconda"
 
 usage () {
-  echo "Usage: bash build_wheel.bash -o PACKAGE_NAME -p PYTHON_VERSION -P PYTORCH_CHANNEL_NAME -c PYTORCH_CUDA_VERSION [-m MINICONDA_PREFIX] [-v] [-h]"
+  echo "Usage: bash build_wheel.bash -o PACKAGE_NAME -p PYTHON_VERSION -P PYTORCH_CHANNEL_NAME -c CUDA_VERSION [-m MINICONDA_PREFIX] [-v] [-h]"
   echo "-v                  : verbose"
   echo "-h                  : help"
   echo "PACKAGE_NAME        : output package name (e.g., fbgemm_gpu_nightly)"
   echo "PYTHON_VERSION      : Python version (e.g., 3.8, 3.9, 3.10)"
   echo "PYTORCH_CHANNEL_NAME: PyTorch's channel name (e.g., pytorch-nightly, pytorch-test (=pre-release), pytorch (=stable release))"
-  echo "PYTORCH_CUDA_VERSION: PyTorch's CUDA version (e.g., 11.6, 11.7)"
+  echo "CUDA_VERSION        : PyTorch's CUDA version (e.g., 11.6, 11.7)"
   echo "MINICONDA_PREFIX    : path to install Miniconda (default: \$HOME/miniconda)"
   echo "Example 1: Python 3.10 + PyTorch nightly (CUDA 11.7), install miniconda at /home/user/tmp/miniconda"
   echo "       bash build_wheel.bash -v -P pytorch-nightly -p 3.10 -c 11.7 -m /home/user/tmp/miniconda"
@@ -35,7 +35,7 @@ do
         o) package_name="${OPTARG}";;
         p) python_version="${OPTARG}";;
         P) pytorch_channel_name="${OPTARG}";;
-        c) pytorch_cuda_version="${OPTARG}";;
+        c) cuda_version="${OPTARG}";;
         m) miniconda_prefix="${OPTARG}";;
         h) usage
            exit 0;;
@@ -44,7 +44,7 @@ do
     esac
 done
 
-if [ "$python_version" == "" ] || [ "$pytorch_cuda_version" == "x" ] || [ "$miniconda_prefix" == "" ] || [ "$pytorch_channel_name" == "" ] || [ "$package_name" == "" ]; then
+if [ "$python_version" == "" ] || [ "$cuda_version" == "x" ] || [ "$miniconda_prefix" == "" ] || [ "$pytorch_channel_name" == "" ] || [ "$package_name" == "" ]; then
   usage
   exit 1
 fi
@@ -77,7 +77,7 @@ setup_miniconda "$miniconda_prefix"
 echo "## 2. Create build_binary environment"
 ################################################################################
 
-create_conda_environment build_binary "$python_version" "$pytorch_channel_name" "$pytorch_cuda_version"
+create_conda_environment build_binary "$python_version" "$pytorch_channel_name" "$cuda_version"
 
 cd fbgemm_gpu
 
@@ -104,7 +104,7 @@ echo "## 3. Build FBGEMM_GPU"
 
 cd fbgemm_gpu
 rm -rf dist _skbuild
-if [ "$pytorch_cuda_version" == "" ]; then
+if [ "$cuda_version" == "" ]; then
   # CPU version
   build_arg="--cpu_only"
   package_name="${package_name}_cpu"

--- a/.github/scripts/setup_env.bash
+++ b/.github/scripts/setup_env.bash
@@ -23,21 +23,21 @@ create_conda_environment () {
   env_name="$1"
   python_version="$2"
   pytorch_channel_name="$3"
-  pytorch_cuda_version="$4"
+  cuda_version="$4"
   if [ "$python_version" == "" ]; then
-    echo "Usage: create_conda_environment ENV_NAME PYTHON_VERSION PYTORCH_CHANNEL_NAME PYTORCH_CUDA_VERSION"
+    echo "Usage: create_conda_environment ENV_NAME PYTHON_VERSION PYTORCH_CHANNEL_NAME CUDA_VERSION"
     echo "Example:"
-    echo "    create_conda_environment build_binary 3.10 pytorch-nightly 11.7"
+    echo "    create_conda_environment build_binary 3.10 pytorch-nightly 11.7.1"
     exit 1
   fi
   # -y removes existing environment
   conda create -y --name "$env_name" python="$python_version"
-  if [ "$pytorch_cuda_version" == "" ]; then
+  if [ "$cuda_version" == "" ]; then
     # CPU version
     conda install -n "$env_name" -y pytorch cpuonly -c "$pytorch_channel_name"
   else
     # GPU version
-    conda install -n "$env_name" -y pytorch pytorch-cuda="$pytorch_cuda_version" -c "$pytorch_channel_name" -c nvidia
+    conda install -n "$env_name" -y pytorch cuda -c "$pytorch_channel_name" -c "nvidia/label/cuda-${cuda_version}"
   fi
 }
 

--- a/.github/scripts/test_torchrec.bash
+++ b/.github/scripts/test_torchrec.bash
@@ -9,12 +9,12 @@ set -e
 verbose=0
 torchrec_package_name=""
 python_version=""
-pytorch_cuda_version="x"
+cuda_version="x"
 fbgemm_wheel_path="x"
 miniconda_prefix="${HOME}/miniconda"
 
 usage () {
-  echo "Usage: bash test_torchrec.bash -o PACKAGE_NAME -p PYTHON_VERSION -P PYTORCH_CHANNEL_NAME -c PYTORCH_CUDA_VERSION -w FBGEMM_WHEEL_PATH [-m MINICONDA_PREFIX] [-v] [-h]"
+  echo "Usage: bash test_torchrec.bash -o PACKAGE_NAME -p PYTHON_VERSION -P PYTORCH_CHANNEL_NAME -c CUDA_VERSION -w FBGEMM_WHEEL_PATH [-m MINICONDA_PREFIX] [-v] [-h]"
   echo "-v                  : verbose"
   echo "-h                  : help"
   echo "PACKAGE_NAME        : output package name of TorchRec (e.g., torchrec_nightly)"
@@ -22,7 +22,7 @@ usage () {
   echo "                      e.g., torchrec needs fbgemm-gpu while torchrec_nightly needs fbgemm-gpu-nightly"
   echo "PYTHON_VERSION      : Python version (e.g., 3.8, 3.9, 3.10)"
   echo "PYTORCH_CHANNEL_NAME: PyTorch's channel name (e.g., pytorch-nightly, pytorch-test (=pre-release), pytorch (=stable release))"
-  echo "PYTORCH_CUDA_VERSION: PyTorch's CUDA version (e.g., 11.6, 11.7)"
+  echo "CUDA_VERSION        : PyTorch's CUDA version (e.g., 11.6, 11.7)"
   echo "FBGEMM_WHEEL_PATH   : path to FBGEMM_GPU's wheel file"
   echo "MINICONDA_PREFIX    : path to install Miniconda (default: \$HOME/miniconda)"
   echo "Example: Python 3.10 + PyTorch nightly (CUDA 11.7), install miniconda at \$HOME/miniconda, using dist/fbgemm_gpu_nightly.whl"
@@ -36,7 +36,7 @@ do
         o) torchrec_package_name="${OPTARG}";;
         p) python_version="${OPTARG}";;
         P) pytorch_channel_name="${OPTARG}";;
-        c) pytorch_cuda_version="${OPTARG}";;
+        c) cuda_version="${OPTARG}";;
         m) miniconda_prefix="${OPTARG}";;
         w) fbgemm_wheel_path="${OPTARG}";;
         h) usage
@@ -46,7 +46,7 @@ do
     esac
 done
 
-if [ "$torchrec_package_name" == "" ] || [ "$python_version" == "" ] || [ "$pytorch_cuda_version" == "x" ] || [ "$miniconda_prefix" == "" ] || [ "$pytorch_channel_name" == "" ] || [ "$fbgemm_wheel_path" == "" ]; then
+if [ "$torchrec_package_name" == "" ] || [ "$python_version" == "" ] || [ "$cuda_version" == "x" ] || [ "$miniconda_prefix" == "" ] || [ "$pytorch_channel_name" == "" ] || [ "$fbgemm_wheel_path" == "" ]; then
   usage
   exit 1
 fi
@@ -76,7 +76,7 @@ setup_miniconda "$miniconda_prefix"
 echo "## 2. Create test_binary environment"
 ################################################################################
 
-create_conda_environment test_binary "$python_version" "$pytorch_channel_name" "$pytorch_cuda_version"
+create_conda_environment test_binary "$python_version" "$pytorch_channel_name" "$cuda_version"
 
 # Comment out FBGEMM_GPU since we will install it from "$fbgemm_wheel_path"
 sed -i 's/fbgemm-gpu/#fbgemm-gpu/g' requirements.txt

--- a/.github/scripts/test_wheel.bash
+++ b/.github/scripts/test_wheel.bash
@@ -9,17 +9,17 @@ set -e
 
 verbose=0
 python_version=""
-pytorch_cuda_version="x"
+cuda_version="x"
 fbgemm_wheel_path="x"
 miniconda_prefix="${HOME}/miniconda"
 
 usage () {
-  echo "Usage: bash test_wheel.bash -p PYTHON_VERSION -P PYTORCH_CHANNEL_NAME -c PYTORCH_CUDA_VERSION -w FBGEMM_WHEEL_PATH [-m MINICONDA_PREFIX] [-v] [-h]"
+  echo "Usage: bash test_wheel.bash -p PYTHON_VERSION -P PYTORCH_CHANNEL_NAME -c CUDA_VERSION -w FBGEMM_WHEEL_PATH [-m MINICONDA_PREFIX] [-v] [-h]"
   echo "-v                  : verbose"
   echo "-h                  : help"
   echo "PYTHON_VERSION      : Python version (e.g., 3.8, 3.9, 3.10)"
   echo "PYTORCH_CHANNEL_NAME: PyTorch's channel name (e.g., pytorch-nightly, pytorch-test (=pre-release), pytorch (=stable release))"
-  echo "PYTORCH_CUDA_VERSION: PyTorch's CUDA version (e.g., 11.6, 11.7)"
+  echo "CUDA_VERSION        : PyTorch's CUDA version (e.g., 11.6, 11.7)"
   echo "FBGEMM_WHEEL_PATH   : path to FBGEMM_GPU's wheel file"
   echo "MINICONDA_PREFIX    : path to install Miniconda (default: \$HOME/miniconda)"
   echo "Example 1: Python 3.10 + PyTorch nightly (CUDA 11.7), install miniconda at /home/user/tmp/miniconda, using dist/fbgemm_gpu.whl"
@@ -34,7 +34,7 @@ do
         v) verbose="1";;
         p) python_version="${OPTARG}";;
         P) pytorch_channel_name="${OPTARG}";;
-        c) pytorch_cuda_version="${OPTARG}";;
+        c) cuda_version="${OPTARG}";;
         m) miniconda_prefix="${OPTARG}";;
         w) fbgemm_wheel_path="${OPTARG}";;
         h) usage
@@ -44,7 +44,7 @@ do
     esac
 done
 
-if [ "$python_version" == "" ] || [ "$pytorch_cuda_version" == "x" ] || [ "$miniconda_prefix" == "" ] || [ "$pytorch_channel_name" == "" ] || [ "$fbgemm_wheel_path" == "" ]; then
+if [ "$python_version" == "" ] || [ "$cuda_version" == "x" ] || [ "$miniconda_prefix" == "" ] || [ "$pytorch_channel_name" == "" ] || [ "$fbgemm_wheel_path" == "" ]; then
   usage
   exit 1
 fi
@@ -73,7 +73,7 @@ setup_miniconda "$miniconda_prefix"
 echo "## 2. Create test_binary environment"
 ################################################################################
 
-create_conda_environment test_binary "$python_version" "$pytorch_channel_name" "$pytorch_cuda_version"
+create_conda_environment test_binary "$python_version" "$pytorch_channel_name" "$cuda_version"
 conda install -n test_binary -y pytest
 
 cd fbgemm_gpu
@@ -87,7 +87,7 @@ echo "## 3. Install and test FBGEMM_GPU"
 conda run -n test_binary python -m pip install "$fbgemm_wheel_path"
 conda run -n test_binary python -c "import fbgemm_gpu"
 
-if [ "$pytorch_cuda_version" == "" ]; then
+if [ "$cuda_version" == "" ]; then
   # CPU version: unfortunately, not all tests are properly excluded,
   # so we cherry-pick what we can run.
   conda run -n test_binary python fbgemm_gpu/test/batched_unary_embeddings_test.py -v

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [linux.4xlarge]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         cuda-tag: ["cpu", "cu11"]
 
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
@@ -79,7 +79,7 @@ jobs:
     strategy:
       matrix:
         os: [linux.g5.4xlarge.nvidia.gpu]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         cuda-tag: ["cu11"]
 
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
@@ -108,7 +108,7 @@ jobs:
     strategy:
       matrix:
         os: [linux.4xlarge]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         cuda-tag: ["cpu"]
 
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
@@ -135,7 +135,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         cuda-tag: ["cu11", "cpu"]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -62,11 +62,11 @@ jobs:
         # Build wheel
         if [ x"${{ matrix.cuda-tag }}" == x"cpu" ]; then
           # Empty string
-          PYTORCH_CUDA_VERSION=""
+          CUDA_VERSION=""
         else
-          PYTORCH_CUDA_VERSION="11.7"
+          CUDA_VERSION="11.7.1"
         fi
-        bash .github/scripts/build_wheel.bash -v -p ${{ matrix.python-version }} -o ${{ needs.setup_wheel_jobs.outputs.fbgemm_package_name }} -P ${{ needs.setup_wheel_jobs.outputs.pytorch_channel }} -c "${PYTORCH_CUDA_VERSION}" -m "/opt/conda"
+        bash .github/scripts/build_wheel.bash -v -p ${{ matrix.python-version }} -o ${{ needs.setup_wheel_jobs.outputs.fbgemm_package_name }} -P ${{ needs.setup_wheel_jobs.outputs.pytorch_channel }} -c "${CUDA_VERSION}" -m "/opt/conda"
 
         # Put a wheel file in RUNNER_ARTIFACT_DIR
         FBGEMM_ARTIFACT_PATH="${RUNNER_ARTIFACT_DIR}/${{ needs.setup_wheel_jobs.outputs.fbgemm_package_name }}_${{ matrix.python-version }}_${{ matrix.cuda-tag }}"
@@ -97,10 +97,10 @@ jobs:
         git submodule update --init
 
         # Test Wheel
-        PYTORCH_CUDA_VERSION="11.7"
+        CUDA_VERSION="11.7.1"
         FBGEMM_ARTIFACT_PATH="${RUNNER_ARTIFACT_DIR}/${{ needs.setup_wheel_jobs.outputs.fbgemm_package_name }}_${{ matrix.python-version }}_${{ matrix.cuda-tag }}"
         WHEEL_PATH="$(ls ${FBGEMM_ARTIFACT_PATH}/*.whl)"
-        bash .github/scripts/test_wheel.bash -v -p ${{ matrix.python-version }} -P ${{ needs.setup_wheel_jobs.outputs.pytorch_channel }} -c "${PYTORCH_CUDA_VERSION}" -w "${WHEEL_PATH}" -m "/opt/conda"
+        bash .github/scripts/test_wheel.bash -v -p ${{ matrix.python-version }} -P ${{ needs.setup_wheel_jobs.outputs.pytorch_channel }} -c "${CUDA_VERSION}" -w "${WHEEL_PATH}" -m "/opt/conda"
 
   # Download the GitHub Action artifact and test the artifact on a GPU machine
   test_wheel_cpu:
@@ -124,10 +124,10 @@ jobs:
         git submodule update --init
 
         # Test Wheel
-        PYTORCH_CUDA_VERSION=""
+        CUDA_VERSION=""
         FBGEMM_ARTIFACT_PATH="${RUNNER_ARTIFACT_DIR}/${{ needs.setup_wheel_jobs.outputs.fbgemm_package_name }}_${{ matrix.python-version }}_${{ matrix.cuda-tag }}"
         WHEEL_PATH="$(ls ${FBGEMM_ARTIFACT_PATH}/*.whl)"
-        bash .github/scripts/test_wheel.bash -v -p ${{ matrix.python-version }} -P ${{ needs.setup_wheel_jobs.outputs.pytorch_channel }} -c "${PYTORCH_CUDA_VERSION}" -w "${WHEEL_PATH}" -m "/opt/conda"
+        bash .github/scripts/test_wheel.bash -v -p ${{ matrix.python-version }} -P ${{ needs.setup_wheel_jobs.outputs.pytorch_channel }} -c "${CUDA_VERSION}" -w "${WHEEL_PATH}" -m "/opt/conda"
 
   # Upload the created wheels to PyPI
   upload_pypi:

--- a/.github/workflows/fbgemm_nightly_build_cpu.yml
+++ b/.github/workflows/fbgemm_nightly_build_cpu.yml
@@ -20,10 +20,6 @@ jobs:
       matrix:
         include:
          - os: linux.2xlarge
-           python-version: "3.7"
-           python-tag: "py37"
-           cuda-tag: "cpu"
-         - os: linux.2xlarge
            python-version: "3.8"
            python-tag: "py38"
            cuda-tag: "cpu"

--- a/.github/workflows/fbgemm_release_build.yml
+++ b/.github/workflows/fbgemm_release_build.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Install PyTorch and CUDA
       shell: bash
       run: |
-        conda install -n build_binary -y pytorch pytorch-cuda=11.7 -c pytorch-test -c nvidia
+        conda install -n build_binary -y pytorch cuda -c pytorch-test -c "nvidia/label/cuda-11.7.1"
         #conda run -n build_binary \
         #  python -m pip install --pre torch -f https://download.pytorch.org/whl/test/cu117/torch_test.html
     - name: Install Other Dependencies
@@ -215,7 +215,7 @@ jobs:
     - name: Install PyTorch using Conda
       shell: bash
       run: |
-        conda install -n build_binary -y pytorch pytorch-cuda=11.7 -c pytorch-test -c nvidia
+        conda install -n build_binary -y pytorch cuda -c pytorch-test -c "nvidia/label/cuda-11.7.1"
         #conda run -n build_binary \
         #  python -m pip install --pre torch -f https://download.pytorch.org/whl/test/cu117/torch_test.html
     # download wheel from GHA

--- a/.github/workflows/fbgemm_release_build.yml
+++ b/.github/workflows/fbgemm_release_build.yml
@@ -20,10 +20,6 @@ jobs:
       matrix:
         include:
          - os: linux.2xlarge
-           python-version: "3.7"
-           python-tag: "py37"
-           cuda-tag: "cu11"
-         - os: linux.2xlarge
            python-version: "3.8"
            python-tag: "py38"
            cuda-tag: "cu11"
@@ -132,7 +128,7 @@ jobs:
     strategy:
       matrix:
         os: [linux.g5.4xlarge.nvidia.gpu]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         cuda-tag: ["cu11"]
     needs: build_on_cpu
     steps:

--- a/.github/workflows/fbgemm_release_build_cpu.yml
+++ b/.github/workflows/fbgemm_release_build_cpu.yml
@@ -20,10 +20,6 @@ jobs:
       matrix:
         include:
          - os: linux.2xlarge
-           python-version: "3.7"
-           python-tag: "py37"
-           cuda-tag: "cpu"
-         - os: linux.2xlarge
            python-version: "3.8"
            python-tag: "py38"
            cuda-tag: "cpu"

--- a/.github/workflows/fbgemmci.yml
+++ b/.github/workflows/fbgemmci.yml
@@ -198,7 +198,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        config: [[pip, 11.3], [pip, 11.5], [pip, 11.6], [pip, 11.7], [conda, 11.7]]
+        config: [[pip, 11.3], [pip, 11.5], [pip, 11.6], [pip, 11.7], [conda, 11.7.1]]
 
     steps:
     - uses: actions/checkout@v2
@@ -236,7 +236,7 @@ jobs:
           bash ~/miniconda.sh -b -p $HOME/miniconda -u
           eval "$($HOME/miniconda/bin/conda shell.bash hook)"
           cuda_version="${{ matrix.config[1] }}"
-          conda install -y pytorch pytorch-cuda="$cuda_version" -c pytorch-nightly -c nvidia
+          conda install -y pytorch cuda -c pytorch-nightly -c "nvidia/label/cuda-${cuda_version}"
           conda install -y -c conda-forge cudnn
           conda install -y numpy scikit-build jinja2 ninja cmake hypothesis
         fi
@@ -397,13 +397,13 @@ jobs:
         git submodule update --init
 
         # Build FBGEMM_GPU with pytorch-nightly
-        PYTORCH_CUDA_VERSION="11.7"
+        CUDA_VERSION="11.7.1"
         PYTHON_VERSION="3.10"
-        bash .github/scripts/build_wheel.bash -v -p "$PYTHON_VERSION" -o fbgemm_gpu_test -P pytorch-nightly -c "$PYTORCH_CUDA_VERSION" -m /opt/conda
+        bash .github/scripts/build_wheel.bash -v -p "$PYTHON_VERSION" -o fbgemm_gpu_test -P pytorch-nightly -c "$CUDA_VERSION" -m /opt/conda
 
         # Test FBGEMM_GPU using a generated wheel file
         WHEEL_PATH="$(ls fbgemm_gpu/dist/*.whl)"
-        bash .github/scripts/test_wheel.bash -v -p "$PYTHON_VERSION" -P pytorch-nightly -c "$PYTORCH_CUDA_VERSION" -w "$WHEEL_PATH" -m /opt/conda
+        bash .github/scripts/test_wheel.bash -v -p "$PYTHON_VERSION" -P pytorch-nightly -c "$CUDA_VERSION" -w "$WHEEL_PATH" -m /opt/conda
 
   build_cpu_only:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/fbgemmci.yml
+++ b/.github/workflows/fbgemmci.yml
@@ -363,7 +363,7 @@ jobs:
         set -eux
         env
         ls -l
-        DOCKER_IMAGE=rocm/pytorch:rocm5.3_ubuntu20.04_py3.7_pytorch_staging_base
+        DOCKER_IMAGE=rocm/pytorch:rocm5.4_ubuntu20.04_py3.8_pytorch_staging_base
         docker pull $DOCKER_IMAGE
         JENKINS_REPO_DIR=fbgemm-private-jenkins
         JENKINS_REPO_DIR_BAREMETAL=$PWD

--- a/fbgemm_gpu/README.md
+++ b/fbgemm_gpu/README.md
@@ -100,11 +100,11 @@ FBGEMM_GPU supports running on AMD (ROCm) devices. A Docker container is recomme
 ##### Build in a Docker container
 Pull Docker container and run
 ```
-docker pull rocm/pytorch:rocm5.3_ubuntu20.04_py3.7_pytorch_staging_base
+docker pull rocm/pytorch:rocm5.4_ubuntu20.04_py3.8_pytorch_staging_base
 sudo docker run -it --network=host --shm-size 16G --device=/dev/kfd --device=/dev/dri \
                 --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
                 --ipc=host --env PYTORCH_ROCM_ARCH="gfx906;gfx908;gfx90a" -u 0 \
-                rocm/pytorch:rocm5.3_ubuntu20.04_py3.7_pytorch_staging_base
+                rocm/pytorch:rocm5.4_ubuntu20.04_py3.8_pytorch_staging_base
 ```
 In the container
 ```

--- a/fbgemm_gpu/README.md
+++ b/fbgemm_gpu/README.md
@@ -39,15 +39,15 @@ Currently only built with sm70/80 (V100/A100 GPU) wheel supports:
 
 ```
 # Release GPU
-conda install pytorch pytorch-cuda=11.7 -c pytorch -c nvidia
+conda install pytorch cuda -c pytorch -c "nvidia/label/cuda-11.7.1"
 pip install fbgemm-gpu
 
 # Release CPU-only
-conda install pytorch pytorch-cuda=11.7 -c pytorch -c nvidia
+conda install pytorch cuda -c pytorch -c "nvidia/label/cuda-11.7.1"
 pip install fbgemm-gpu-cpu
 
 # Nightly GPU
-conda install pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
+conda install pytorch cuda -c pytorch-nightly -c "nvidia/label/cuda-11.7.1"
 pip install fbgemm-gpu-nightly
 
 # Nightly CPU-only
@@ -63,7 +63,7 @@ Please [download][4] and follow instructions [here][5] to install cuDNN.
 
 ```
 # Requires PyTorch 1.13 or later
-conda install pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
+conda install pytorch cuda -c pytorch-nightly -c "nvidia/label/cuda-11.7.1"
 git clone --recursive https://github.com/pytorch/FBGEMM.git
 cd FBGEMM/fbgemm_gpu
 # if you are updating an existing checkout

--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -209,7 +209,7 @@ def main(argv: List[str]) -> None:
             "Intended Audience :: Science/Research",
             "License :: OSI Approved :: BSD License",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
             "Topic :: Scientific/Engineering :: Artificial Intelligence",
         ],
     )


### PR DESCRIPTION
Summary:

- Remove Python 3.7 from list of supported builds
- Replace installation of `pytorch-cuda` package with `cuda` since the former has been slimmed down