### PR TITLE
Prepare bounds_check_indices API for variable batch size TBE

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
@@ -32,7 +32,10 @@ Tensor split_embedding_codegen_forward_unweighted_cuda(
     int64_t pooling_mode,
     Tensor lxu_cache_locations,
     int64_t output_dtype,
-    int64_t BT_block_size);
+    int64_t BT_block_size,
+    const c10::optional<std::vector<int64_t>>& D_offsets_vec,
+    const c10::optional<Tensor>& var_B_metadata, // Variable batch size is optional
+    const c10::optional<std::vector<int64_t>>& var_B_metadata_vec);
 
 Tensor split_embedding_codegen_forward_weighted_cuda(
     Tensor dev_weights,
@@ -49,7 +52,10 @@ Tensor split_embedding_codegen_forward_weighted_cuda(
     Tensor indice_weights,
     Tensor lxu_cache_locations,
     int64_t output_dtype,
-    int64_t BT_block_size);
+    int64_t BT_block_size,
+    const c10::optional<std::vector<int64_t>>& D_offsets_vec,
+    const c10::optional<Tensor>& var_B_metadata, // Variable batch size is optional
+    const c10::optional<std::vector<int64_t>>& var_B_metadata_vec);
 
 Tensor split_embedding_codegen_grad_indice_weights_cuda(
     Tensor grad_output,
@@ -63,7 +69,8 @@ Tensor split_embedding_codegen_grad_indice_weights_cuda(
     Tensor indices,
     Tensor offsets,
     Tensor lxu_cache_locations,
-    Tensor feature_requires_grad);
+    Tensor feature_requires_grad,
+    const c10::optional<Tensor>& var_B_metadata);
 
 void split_embedding_backward_codegen_{{ optimizer }}_unweighted_exact_cuda(
     Tensor grad_output,
@@ -83,6 +90,8 @@ void split_embedding_backward_codegen_{{ optimizer }}_unweighted_exact_cuda(
     int64_t BT_block_size,
     int64_t max_segment_length_per_warp,
     bool stochastic_rounding,
+    const c10::optional<Tensor>& var_B_metadata,
+    const c10::optional<std::vector<int64_t>>& var_B_metadata_vec,
     {{ args.split_function_args | join(", ") }});
 
 void split_embedding_backward_codegen_{{ optimizer }}_weighted_exact_cuda(
@@ -104,6 +113,8 @@ void split_embedding_backward_codegen_{{ optimizer }}_weighted_exact_cuda(
     int64_t BT_block_size,
     int64_t max_segment_length_per_warp,
     bool stochastic_rounding,
+    const c10::optional<Tensor>& var_B_metadata,
+    const c10::optional<std::vector<int64_t>>& var_B_metadata_vec,
     {{ args.split_function_args | join(", ") }});
 
 Tensor split_embedding_nobag_codegen_forward_unweighted_cuda(
@@ -117,7 +128,9 @@ Tensor split_embedding_nobag_codegen_forward_unweighted_cuda(
     Tensor offsets,
     Tensor lxu_cache_locations,
     int64_t output_dtype,
-    int64_t unused);
+    int64_t unused,
+    const c10::optional<Tensor>& var_B_metadata, // Variable batch size is optional
+    const c10::optional<std::vector<int64_t>>& var_B_metadata_vec);
 
 void split_embedding_nobag_backward_codegen_{{ optimizer }}_unweighted_exact_cuda(
     Tensor grad_output,
@@ -135,6 +148,7 @@ void split_embedding_nobag_backward_codegen_{{ optimizer }}_unweighted_exact_cud
     int64_t BT_block_size,
     int64_t max_segment_length_per_warp,
     bool stochastic_rounding,
+    const c10::optional<Tensor>& var_B_metadata,
     {{ args.split_function_args | join(", ") }});
 
 {% for nobag in [True, False] %}
@@ -170,10 +184,16 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
     bool gradient_clipping,
     double max_gradient,
     bool stochastic_rounding,
+    {% if not nobag %}
+    const c10::optional<std::vector<int64_t>>& D_offsets_vec,
+    {% endif %}
+    const c10::optional<Tensor>& var_B_metadata,
+    const c10::optional<std::vector<int64_t>>& var_B_metadata_vec,
     {{ args.split_function_args | join(", ") }}) {
     ctx->save_for_backward({
         dev_weights, uvm_weights, lxu_cache_weights, weights_placements, weights_offsets, {% if not nobag %} D_offsets, {% endif %} hash_size_cumsum,
-        indices, offsets, {% if not nobag %} indice_weights.value_or(Tensor()), feature_requires_grad.value_or(Tensor()), {% endif %} lxu_cache_locations, {{ args.split_saved_tensors | join(", ") }} });
+        indices, offsets, {% if not nobag %} indice_weights.value_or(Tensor()), feature_requires_grad.value_or(Tensor()), {% endif %} lxu_cache_locations,
+        var_B_metadata.value_or(Tensor()), {{ args.split_saved_tensors | join(", ") }} });
 
     {% if not nobag %}
     ctx->saved_data["max_D"] = max_D;
@@ -185,6 +205,10 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
     ctx->saved_data["gradient_clipping"] = gradient_clipping;
     ctx->saved_data["max_gradient"] = max_gradient;
     ctx->saved_data["stochastic_rounding"] = stochastic_rounding;
+    ctx->saved_data["var_batch_size"] = var_B_metadata.has_value();
+    if (var_B_metadata_vec.has_value()) {
+        ctx->saved_data["var_B_metadata_vec"] = var_B_metadata_vec.value();
+    }
 
     {% for (var, _) in args.saved_data %}
     ctx->saved_data["{{ var }}"] = {{ var }};
@@ -199,11 +223,13 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
     if (!indice_weights) {
         return {split_embedding_codegen_forward_unweighted_cuda(
         dev_weights, uvm_weights, lxu_cache_weights, weights_placements, weights_offsets,
-        D_offsets, total_D, max_D, indices, offsets, pooling_mode, lxu_cache_locations, output_dtype, BT_block_size)};
+        D_offsets, total_D, max_D, indices, offsets, pooling_mode, lxu_cache_locations,
+        output_dtype, BT_block_size, D_offsets_vec, var_B_metadata, var_B_metadata_vec)};
     }  else {
         return {split_embedding_codegen_forward_weighted_cuda(
         dev_weights, uvm_weights, lxu_cache_weights, weights_placements, weights_offsets,
-        D_offsets, total_D, max_D, indices, offsets, pooling_mode, *indice_weights, lxu_cache_locations, output_dtype, BT_block_size)};
+        D_offsets, total_D, max_D, indices, offsets, pooling_mode, *indice_weights,
+        lxu_cache_locations, output_dtype, BT_block_size, D_offsets_vec, var_B_metadata, var_B_metadata_vec)};
     }
     {% else %}
     return {split_embedding_nobag_codegen_forward_unweighted_cuda(
@@ -217,7 +243,9 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
       offsets,
       lxu_cache_locations,
       output_dtype,
-      0)};
+      0,
+      var_B_metadata,
+      var_B_metadata_vec)};
     {% endif %}
   }
 
@@ -242,6 +270,7 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
     auto feature_requires_grad = *savedItr++;
     {% endif %}
     auto lxu_cache_locations = *savedItr++;
+    auto var_B_metadata_tensor = *savedItr++;
 
     {% for tensor in args.split_saved_tensors %}
     auto {{ tensor }} = *savedItr++;
@@ -257,6 +286,11 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
     auto gradient_clipping = ctx->saved_data["gradient_clipping"].toBool();
     auto max_gradient = ctx->saved_data["max_gradient"].toDouble();
     auto stochastic_rounding = ctx->saved_data["stochastic_rounding"].toBool();
+    auto var_batch_size = ctx->saved_data["var_batch_size"].toBool();
+    std::vector<int64_t> var_B_metadata_ivec;
+    if (var_batch_size) {
+        var_B_metadata_ivec = ctx->saved_data["var_B_metadata_vec"].toIntVector();
+    }
 
     {% for (var, ivalue_cast) in args.saved_data %}
     auto {{ var }} = ctx->saved_data["{{ var }}"].{{ ivalue_cast }}();
@@ -276,13 +310,23 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
     auto grad_output = gradient_clipping ? clamp(grad_outputs[0], -max_gradient, max_gradient) : grad_outputs[0];
     // FIXME: to support aligned memory access in Vec4T load/store function
     // 16 for FP32 and 8 for FP16
-    if (reinterpret_cast<uint64_t>(grad_output.data_ptr()) % 16 != 0 ||
-        grad_output.stride(1) != 1 || grad_output.stride(0) % 4 != 0) {
+    if (grad_output.dim() > 1 &&
+        (reinterpret_cast<uint64_t>(grad_output.data_ptr()) % 16 != 0 ||
+        grad_output.stride(1) != 1 || grad_output.stride(0) % 4 != 0)) {
         grad_output = grad_output.contiguous();
     }
     if (reinterpret_cast<uint64_t>(grad_output.data_ptr()) % 16 != 0) {
         grad_output = at::empty_like(grad_output).copy_(grad_output);
     }
+
+    const c10::optional<Tensor>& var_B_metadata =
+      var_batch_size ?
+      c10::optional<Tensor>(var_B_metadata_tensor) :
+      c10::optional<Tensor>();
+    const c10::optional<std::vector<int64_t>>& var_B_metadata_vec =
+      var_batch_size ?
+      c10::optional<std::vector<int64_t>>(var_B_metadata_ivec) :
+      c10::optional<std::vector<int64_t>>();
 
     {% if not nobag %}
     if (!indice_weights.defined()) {
@@ -304,6 +348,8 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
           BT_block_size,
           max_segment_length_per_warp,
           stochastic_rounding,
+          var_B_metadata,
+          var_B_metadata_vec,
           {{ args.split_function_arg_names | join(", ") }});
       return {
           Tensor(), // placeholder autograd tensor
@@ -327,6 +373,9 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
           Variable(), // gradient_clipping
           Variable(), // max_gradient
           Variable(), // stochastic_rounding
+          Variable(), // D_offsets_vec
+          Variable(), // var_B_metadata
+          Variable(), // var_B_metadata_vec
           {{ args.split_variables | join(", ") }}
       };
     } else {
@@ -342,7 +391,8 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
           indices,
           offsets,
           lxu_cache_locations,
-          feature_requires_grad);
+          feature_requires_grad,
+          var_B_metadata);
       split_embedding_backward_codegen_{{ optimizer }}_weighted_exact_cuda(
           grad_output,
           dev_weights,
@@ -362,6 +412,8 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
           BT_block_size,
           max_segment_length_per_warp,
           stochastic_rounding,
+          var_B_metadata,
+          var_B_metadata_vec,
           {{ args.split_function_arg_names | join(", ") }});
       return {
           Tensor(), // placeholder autograd tensor
@@ -386,6 +438,9 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
           Variable(), // gradient_clipping
           Variable(), // max_gradient
           Variable(), // stochastic_rounding
+          Variable(), // D_offsets_vec
+          Variable(), // var_B_metadata
+          Variable(), // var_B_metadata_vec
           {{ args.split_variables | join(", ") }}
       };
     }
@@ -406,6 +461,7 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
         BT_block_size,
         max_segment_length_per_warp,
         stochastic_rounding,
+        var_B_metadata,
         {{ args.split_function_arg_names | join(", ") }});
     return {
         Tensor(), // placeholder autograd tensor
@@ -424,6 +480,8 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
         Variable(), // gradient_clipping
         Variable(), // max_gradient
         Variable(), // stochastic_rounding
+        Variable(), // var_B_metadata
+        Variable(), // var_B_metadata_vec
         {{ args.split_variables | join(", ") }}
     };
     {% endif %}
@@ -454,7 +512,10 @@ Tensor split_embedding_codegen_lookup_{{ optimizer }}_function(
     double max_gradient,
     bool stochastic_rounding,
     {{ args.split_function_args | join(", ") }},
-    int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)) {
+    int64_t output_dtype = static_cast<int64_t>(SparseType::FP32),
+    const c10::optional<std::vector<int64_t>>& D_offsets_vec = std::vector<int64_t>(),
+    const c10::optional<Tensor>& var_B_metadata = c10::optional<Tensor>(),
+    const c10::optional<std::vector<int64_t>>& var_B_metadata_vec = std::vector<int64_t>()) {
   if (static_cast<PoolingMode>(pooling_mode) == PoolingMode::NONE) {
     return SplitNoBagLookupFunction_{{ optimizer }}_Op::apply(
       placeholder_autograd_tensor,
@@ -473,6 +534,8 @@ Tensor split_embedding_codegen_lookup_{{ optimizer }}_function(
       gradient_clipping,
       max_gradient,
       stochastic_rounding,
+      var_B_metadata,
+      var_B_metadata_vec,
       {{ args.split_function_arg_names | join(", ") }})[0];
   } else {
     return SplitLookupFunction_{{ optimizer }}_Op::apply(
@@ -497,18 +560,21 @@ Tensor split_embedding_codegen_lookup_{{ optimizer }}_function(
       gradient_clipping,
       max_gradient,
       stochastic_rounding,
+      D_offsets_vec,
+      var_B_metadata,
+      var_B_metadata_vec,
       {{ args.split_function_arg_names | join(", ") }})[0];
   }
 }
 
 // Deprecated for fb namespace! Please use fbgemm namespace instead!
 TORCH_LIBRARY_FRAGMENT(fb, m) {
-    m.def("split_embedding_codegen_lookup_{{ optimizer }}_function(Tensor placeholder_autograd_tensor, Tensor dev_weights, Tensor uvm_weights, Tensor lxu_cache_weights, Tensor weights_placements, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, Tensor lxu_cache_locations, bool gradient_clipping, float max_gradient, bool stochastic_rounding, {{ args.split_function_schemas | join(", ") }}, int output_dtype=0) -> Tensor");
+    m.def("split_embedding_codegen_lookup_{{ optimizer }}_function(Tensor placeholder_autograd_tensor, Tensor dev_weights, Tensor uvm_weights, Tensor lxu_cache_weights, Tensor weights_placements, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, Tensor lxu_cache_locations, bool gradient_clipping, float max_gradient, bool stochastic_rounding, {{ args.split_function_schemas | join(", ") }}, int output_dtype=0, int[]? D_offsets_vec=None, Tensor? var_B_metadata=None, int[]? var_B_metadata_vec=None) -> Tensor");
     DISPATCH_TO_CUDA("split_embedding_codegen_lookup_{{ optimizer }}_function", split_embedding_codegen_lookup_{{ optimizer }}_function);
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
-    m.def("split_embedding_codegen_lookup_{{ optimizer }}_function(Tensor placeholder_autograd_tensor, Tensor dev_weights, Tensor uvm_weights, Tensor lxu_cache_weights, Tensor weights_placements, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, Tensor lxu_cache_locations, bool gradient_clipping, float max_gradient, bool stochastic_rounding, {{ args.split_function_schemas | join(", ") }}, int output_dtype=0) -> Tensor");
+    m.def("split_embedding_codegen_lookup_{{ optimizer }}_function(Tensor placeholder_autograd_tensor, Tensor dev_weights, Tensor uvm_weights, Tensor lxu_cache_weights, Tensor weights_placements, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, Tensor lxu_cache_locations, bool gradient_clipping, float max_gradient, bool stochastic_rounding, {{ args.split_function_schemas | join(", ") }}, int output_dtype=0, int[]? D_offsets_vec=None, Tensor? var_B_metadata=None, int[]? var_B_metadata_vec=None) -> Tensor");
     DISPATCH_TO_CUDA("split_embedding_codegen_lookup_{{ optimizer }}_function", split_embedding_codegen_lookup_{{ optimizer }}_function);
 }
 

--- a/fbgemm_gpu/codegen/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_template.cu
@@ -81,34 +81,76 @@ __global__ __launch_bounds__(kMaxThreads) void grad_mean_kernel(
         grad_output,
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> offsets,
+    {% if not dense %}
+    const int32_t* __restrict__ var_B_metadata,
+    {% endif %}
     at::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits>
         grad_output_mean) {
-  int32_t B = grad_output.size(0);
   int32_t T = D_offsets.size(0) - 1;
   int32_t b_t = blockIdx.x * blockDim.y + threadIdx.y;
-  int32_t b = b_t % B;
-  int32_t t = b_t / B;
+  int32_t b, t;
+  const auto total_B = offsets.size(0) - 1;
 
-  if (b_t >= B * T) {
+  if (b_t >= total_B) {
     return;
   }
+
+  {% if not dense %}
+  // Use variable batch size
+  if (var_B_metadata != nullptr) {
+    if (threadIdx.x == 0) {
+      binary_search_range(&t, var_B_metadata + 1, b_t, T);
+      b = b_t - var_B_metadata[t];
+    }
+    t = shfl_sync(t, 0);
+    b = shfl_sync(b, 0);
+  }
+  else {
+  {% endif %}
+    const int32_t B = grad_output.size(0);
+    b = b_t % B;
+    t = b_t / B;
+  {% if not dense %}
+  } // if (var_B_metadata != nullptr)
+  {% endif %}
+
   int32_t D_start = D_offsets[t];
   int32_t D_end = D_offsets[t + 1];
   int32_t D = D_end - D_start;
-  int64_t indices_start = offsets[t * B + b];
-  int64_t indices_end = offsets[t * B + b + 1];
+  int64_t indices_start = offsets[b_t];
+  int64_t indices_end = offsets[b_t + 1];
   int32_t L = indices_end - indices_start;
+
+  {% if not dense %}
+  int32_t grad_offset;
+  if (var_B_metadata != nullptr) {
+    if (threadIdx.x == 0) {
+      grad_offset = var_B_metadata[T + 1 + t] + b * D;
+    }
+    grad_offset = shfl_sync(grad_offset, 0);
+  }
+  else {
+    grad_offset = D_start;
+  }
+  const int32_t grad_outer_offset = var_B_metadata != nullptr ? 0 : b;
+  {% else %}
+  const int32_t grad_offset = D_start;
+  const int32_t grad_outer_offset = b;
+  {% endif %}
+
+  const grad_t* shifted_grad_output = &grad_output[grad_outer_offset][grad_offset];
+  grad_t* shifted_grad_output_mean = &grad_output_mean[grad_outer_offset][grad_offset];
 
   if (L != 0) {
     for (int32_t d = threadIdx.x; d * 4 < D; d += blockDim.x) {
-      Vec4T<grad_t> grad_out_vec(&grad_output[b][D_start + d * 4]);
+      Vec4T<grad_t> grad_out_vec(&shifted_grad_output[d * 4]);
       grad_out_vec.mul_(1.0 / L);
-      grad_out_vec.store(&grad_output_mean[b][D_start + d * 4]);
+      grad_out_vec.store(&shifted_grad_output_mean[d * 4]);
     }
   } else {
     for (int32_t d = threadIdx.x; d * 4 < D; d += blockDim.x) {
-      Vec4T<grad_t> grad_out_vec(&grad_output[b][D_start + d * 4]);
-      grad_out_vec.store(&grad_output_mean[b][D_start + d * 4]);
+      Vec4T<grad_t> grad_out_vec(&shifted_grad_output[d * 4]);
+      grad_out_vec.store(&shifted_grad_output_mean[d * 4]);
     }
   }
 }
@@ -119,6 +161,7 @@ template <
     typename emb_t,
     typename grad_t,
     typename cache_t,
+    bool var_batch_size,
     size_t kMaxVecsPerThread,
     int32_t kThreadGroupSize = kWarpSize>
 __global__ __launch_bounds__(kMaxThreads) void
@@ -135,7 +178,6 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
     {% if not nobag %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
     {% else %}
-    int32_t B,
     int64_t D,
     {% endif %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
@@ -166,8 +208,12 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
     {% else %}
     at::PackedTensorAccessor64<cache_t, 1, at::RestrictPtrTraits> grad_dev_weights,
     {% endif %}
+    {% if not nobag and not dense %}
+    const int32_t* var_B_metadata,
+    {% endif %}
     {% if not nobag %}
-    FixedDivisor fd,
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask,
     {% endif %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> long_run_id_to_really_long_run_ids,
     at::PackedTensorAccessor32<at::acc_type<cache_t, true>, 2, at::RestrictPtrTraits> temp_grad_accum,
@@ -184,9 +230,6 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
 #endif
   constexpr int VEC_WIDTH = 4;
   int32_t T = weights_offsets.size(0);
-  {% if not nobag %}
-  const int32_t B = grad_output.size(0);
-  {% endif %}
   const int32_t num_long_runs = num_long_run_ids[0];
   for (int32_t long_run_id = blockIdx.x; long_run_id < num_long_runs; long_run_id += gridDim.x) {
         // The first thread block in the really long run has run_id in long_run_ids
@@ -220,11 +263,11 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
         // Note that with shared embedding tables we can have multiple tables
         // (i.e. different values of `t` sharing the same segment).
         //
-        const auto info_0 = sorted_infos[segment_start];
-
         {% if not nobag %}
-        int32_t t_0 = fd.Div(info_0); //info_0 / B;
+        const uint32_t info_0 = reinterpret_cast<const uint32_t*>(&sorted_infos[0])[segment_start];
+        int32_t t_0 = info_0 >> info_B_num_bits;
         {% else %}
+        const auto info_0 = sorted_infos[segment_start];
         int32_t t_0 = info_0 % T;
         {% endif %}
 
@@ -241,11 +284,13 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
         for (int32_t sl = sl_start; sl < sl_end; sl += kThreadGroupSize) {
             int32_t sl_j = sl + threadIdx.x;
             {% if not nobag %}
-            int32_t b_t = sl_j < sl_end ? sorted_infos[segment_start + sl_j] : 0;
-            int32_t b; //= b_t % B;
-            int32_t t; //= b_t / B;
-            fd.DivMod(b_t, &t, &b);
+            uint32_t b_t = sl_j < sl_end ? reinterpret_cast<const uint32_t*>(&sorted_infos[0])[segment_start + sl_j] : 0;
+            int32_t b = b_t & info_B_mask;
+            int32_t t = b_t >> info_B_num_bits;
             int32_t D_start = sl_j < sl_end ? D_offsets[t] : 0;
+            {% if not dense %}
+            int32_t grad_offset = var_batch_size ? var_B_metadata[T + 1 + t] : 0;
+            {% endif %}
             {% else %}
             int64_t l_t = sl_j < sl_end ? sorted_infos[segment_start + sl_j] : 0;
             int32_t l = l_t / T;
@@ -257,6 +302,9 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
                 {% if not nobag %}
                 int32_t b_j = SHFL_SYNC(b, j);
                 int32_t D_start_j = SHFL_SYNC(D_start, j);
+                {% if not dense %}
+                int32_t grad_offset_j = var_batch_size ? SHFL_SYNC(grad_offset, j) : 0;
+                {% endif %}
                 {% else %}
                 int32_t l_j = SHFL_SYNC(l, j);
                 {% endif %}
@@ -272,7 +320,12 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
                     int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
                     {% if not nobag %}
                     Vec4T<at::acc_type<grad_t, true>> grad_out_vec(
-                        &grad_output[b_j][0] + D_start_j + d);
+                        {% if not dense %}
+                        var_batch_size ?
+                        &grad_output[0][grad_offset_j + b_j * D + d] :
+                        {% endif %}
+                        &grad_output[b_j][0] + D_start_j + d
+                    );
                     {% else %}
                     Vec4T<at::acc_type<grad_t, true>> grad_out_vec(&grad_output[l_j][d]);
                     {% endif %}
@@ -532,6 +585,7 @@ template <
     typename emb_t,
     typename grad_t,
     typename cache_t,
+    bool var_batch_size,
     size_t kMaxVecsPerThread,
     int32_t kThreadGroupSize = kWarpSize>
 __global__
@@ -551,7 +605,6 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
     {% if not nobag %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
     {% else %}
-    int32_t B,
     int64_t D,
     {% endif %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
@@ -581,14 +634,17 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
     {% else %}
     at::PackedTensorAccessor64<cache_t, 1, at::RestrictPtrTraits> grad_dev_weights,
     {% endif %}
+    {% if not nobag and not dense %}
+    const int32_t* var_B_metadata,
+    {% endif %}
     {% if not nobag %}
-    FixedDivisor fd,
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask,
     {% endif %}
     {{ args.split_kernel_args | join(", ") }}) {
 
     {% if not nobag %}
     int32_t T = D_offsets.size(0) - 1;
-    const int32_t B = grad_output.size(0);
     {% else %}
     int32_t T = weights_offsets.size(0);
     {% endif %}
@@ -620,11 +676,11 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
 
     // now, each segment corresponds to exactly one table `t` and row in
     // that table (`idx`). Thus, we can hoist out some of the book-keeping.
-    const auto info_0 = sorted_infos[segment_start];
-
     {% if not nobag %}
-    int32_t t_0 = fd.Div(info_0); // info_0 / B;
+    const uint32_t info_0 = reinterpret_cast<const uint32_t*>(&sorted_infos[0])[segment_start];
+    int32_t t_0 = info_0 >> info_B_num_bits;
     {% else %}
+    const auto info_0 = sorted_infos[segment_start];
     int32_t t_0 = info_0 % T;
     {% endif %}
 
@@ -641,11 +697,13 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
     for (int32_t sl = sl_start; sl < sl_end; sl += kThreadGroupSize) {
         int32_t sl_j = sl + threadIdx.x;
         {% if not nobag %}
-        int32_t b_t = sl_j < sl_end ? sorted_infos[segment_start + sl_j] : 0;
-        int32_t b; //= b_t % B;
-        int32_t t; //= b_t / B;
-        fd.DivMod(b_t, &t, &b);
+        uint32_t b_t = sl_j < sl_end ? reinterpret_cast<const uint32_t*>(&sorted_infos[0])[segment_start + sl_j] : 0;
+        int32_t b = b_t & info_B_mask;
+        int32_t t = b_t >> info_B_num_bits;
         int32_t D_start = D_offsets[t];
+        {% if not dense %}
+        int32_t grad_offset = var_batch_size ? var_B_metadata[T + 1 + t] : 0;
+        {% endif %}
         {% else %}
         int64_t l_t = sl_j < sl_end ? sorted_infos[segment_start + sl_j] : 0;
         int32_t l = l_t / T;
@@ -658,6 +716,9 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
             {% if not nobag %}
             int32_t b_j = SHFL_SYNC(b, j);
             int32_t D_start_j = SHFL_SYNC(D_start, j);
+            {% if not dense %}
+            int32_t grad_offset_j = var_batch_size ? SHFL_SYNC(grad_offset, j) : 0;
+            {% endif %}
             {% else %}
             int32_t l_j = SHFL_SYNC(l, j);
             {% endif %}
@@ -672,6 +733,10 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
                 int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
                 {% if not nobag %}
                 Vec4T<at::acc_type<grad_t, true>> grad_out_vec(
+                    {% if not dense %}
+                    var_batch_size ?
+                    &grad_output[0][grad_offset_j + b_j * D + d] :
+                    {% endif %}
                     &grad_output[b_j][0] + D_start_j + d);
                 {% else %}
                 Vec4T<at::acc_type<grad_t, true>> grad_out_vec(&grad_output[l_j][d]);
@@ -813,6 +878,10 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
     int64_t max_segment_length_per_warp,
     {% if not dense %}
     bool stochastic_rounding,
+    const c10::optional<Tensor>& var_B_metadata,
+    {% if not nobag %}
+    const c10::optional<std::vector<int64_t>>& var_B_metadata_vec,
+    {% endif %}
     {% endif %}
     {{ args.split_function_args | join(", ") }}) {
 
@@ -822,6 +891,9 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
     TENSOR_ON_CUDA_GPU(uvm_weights);
     TENSOR_ON_CUDA_GPU(lxu_cache_weights);
     TENSOR_ON_CUDA_GPU(weights_placements);
+    if (var_B_metadata.has_value()) {
+        TENSOR_ON_CUDA_GPU(var_B_metadata.value());
+    }
     {% endif %}
     TENSOR_ON_CUDA_GPU(weights_offsets);
     {% if not nobag %}
@@ -857,14 +929,45 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
 
     TORCH_CHECK(T > 0);
     // offsets = [B x T  + 1]
-    const auto B = (offsets.size(0) - 1) / T;
-    TORCH_CHECK(B > 0);
+    const auto total_B = offsets.size(0) - 1;
+    TORCH_CHECK(total_B > 0);
     auto BT_block_size = kMaxThreads / kWarpSize;
     TORCH_CHECK(BT_block_size * kWarpSize <= kMaxThreads);
     {% if nobag %}
     auto max_D = D;
     {% endif %}
     TORCH_CHECK(max_D <= {{ max_embedding_dim }});
+
+    {% if not nobag %}
+    int32_t max_B = 0;
+    {% if not dense %}
+    if (var_B_metadata.has_value()) {
+      TORCH_CHECK(
+          var_B_metadata_vec.has_value(),
+          "Variable batch size TBE requires var_B_metadata_vec"
+      );
+      TORCH_CHECK(var_B_metadata.value().numel() == 2 * (T + 1));
+      TORCH_CHECK(var_B_metadata_vec.value().size() == var_B_metadata.value().numel());
+
+      const std::vector<int64_t>& var_B_metadata_v = var_B_metadata_vec.value();
+      for (int32_t i = 0; i < T; i++) {
+        int32_t B_t = var_B_metadata_v[i + 1] - var_B_metadata_v[i];
+        if (max_B < B_t) {
+          max_B = B_t;
+        }
+      }
+    }
+    else {
+    {% endif %}
+      max_B = total_B / T;
+    {% if not dense %}
+    } // if (var_B_metadata.has_value())
+    {% endif %}
+
+    int32_t info_B_num_bits;
+    uint32_t info_B_mask;
+    std::tie(info_B_num_bits, info_B_mask) = adjust_info_B_num_bits(max_B, T);
+    {% endif %}
 
     // V100: 96 KB; A100: 160 KB.
     int max_shared_bytes = 0;
@@ -905,7 +1008,9 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
             total_hash_size_bits,
             indices,
             offsets,
-            {{"true" if nobag else "false"}});
+            {{"var_B_metadata" if not dense else "c10::optional<Tensor>()"}},
+            {{"true" if nobag else "false"}},
+            {{"0" if nobag else "info_B_num_bits"}});
 
     {% if not dense %}
     auto lxu_cache_locations_sorted = at::empty_like(lxu_cache_locations);
@@ -989,13 +1094,16 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
             linear_indices.reset();
             linear_indices_sorted.reset();
 
+            {% if not dense and not nobag %}
+            grad_output = var_B_metadata.has_value() ? grad_output.reshape({1, -1}) : grad_output;
+            {% endif %}
             auto grad_output_accessor = grad_output.packed_accessor64<grad_t, 2, at::RestrictPtrTraits>();
             {% if not nobag %}
             Tensor grad_output_mean;
             if (static_cast<PoolingMode>(pooling_mode) == PoolingMode::MEAN) {
               grad_output_mean = at::empty_like(grad_output);
               grad_mean_kernel<grad_t>
-                  <<<div_round_up((B * T), kMaxThreads / kWarpSize),
+                  <<<div_round_up(total_B, kMaxThreads / kWarpSize),
                      dim3(kWarpSize, kMaxThreads / kWarpSize),
                      0,
                      at::cuda::getCurrentCUDAStream()>>>(
@@ -1004,6 +1112,9 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
                           .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
                       offsets
                           .packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
+                      {% if not dense %}
+                      var_B_metadata.has_value() ? var_B_metadata.value().data_ptr<int32_t>() : nullptr,
+                      {% endif %}
                       grad_output_mean.packed_accessor64<
                           grad_t, 2, at::RestrictPtrTraits>());
               C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -1098,12 +1209,18 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
             // must use dynamic shared memory (rather than statically sized
             // arrays) and require an explicit opt-in using cudaFuncSetAttribute()".
 
+            {% for var_batch_size in ["true", "false"] %}
+            {% if not dense or var_batch_size == "true" %}
+            {% if not dense %}
+            if (var_B_metadata.has_value() == {{ var_batch_size }}) {
+            {% endif %}
 #ifndef __HIP_PLATFORM_HCC__
             cudaFuncSetAttribute(
                 split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_kernel_cta_per_row_1<
                 emb_t,
                 grad_t,
                 cache_t,
+                {{ var_batch_size }},
                 kMaxVecsPerThread,
                 kThreadGroupSize>,
                 cudaFuncAttributeMaxDynamicSharedMemorySize,
@@ -1115,6 +1232,7 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
                 emb_t,
                 grad_t,
                 cache_t,
+                {{ var_batch_size }},
                 kMaxVecsPerThread,
                 kThreadGroupSize>
                 <<<grid_size,
@@ -1135,7 +1253,6 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
                     {% if not nobag %}
                     D_offsets.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
                     {% else %}
-                    B,
                     D,
                     {% endif %}
                     hash_size_cumsum.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
@@ -1162,8 +1279,12 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
                     {% else %}
                     grad_dev_weights.packed_accessor64<cache_t, 1, at::RestrictPtrTraits>(),
                     {% endif %}
+                    {% if not nobag and not dense %}
+                    var_B_metadata.has_value() ? var_B_metadata.value().data_ptr<int32_t>() : nullptr,
+                    {% endif %}
                     {% if not nobag %}
-                    FixedDivisor(B),
+                    info_B_num_bits,
+                    info_B_mask,
                     {% endif %}
                     long_run_id_to_really_long_run_ids.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
                     temp_grad_accum.packed_accessor32<at::acc_type<cache_t, true>, 2, at::RestrictPtrTraits>(),
@@ -1171,6 +1292,7 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
                     max_segment_length_per_cta,
                     use_deterministic_algorithms,
                     {{ args.split_kernel_arg_constructors | join(", ") }});
+
             C10_CUDA_KERNEL_LAUNCH_CHECK();
             grid_size = std::min(
                 div_round_up(sorted_linear_indices_run.numel(), kBackwardMaxThreads / kThreadGroupSize),
@@ -1187,6 +1309,7 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
                     emb_t,
                     grad_t,
                     cache_t,
+                    {{ var_batch_size }},
                     kMaxVecsPerThread,
                     kThreadGroupSize>,
                     cudaFuncAttributeMaxDynamicSharedMemorySize,
@@ -1199,6 +1322,7 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
                 emb_t,
                 grad_t,
                 cache_t,
+                {{ var_batch_size }},
                 kMaxVecsPerThread,
                 kThreadGroupSize>
                 <<<grid_size,
@@ -1218,7 +1342,6 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
                     {% if not nobag %}
                     D_offsets.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
                     {% else %}
-                    B,
                     D,
                     {% endif %}
                     hash_size_cumsum.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
@@ -1246,12 +1369,23 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
                     {% else %}
                     grad_dev_weights.packed_accessor64<cache_t, 1, at::RestrictPtrTraits>(),
                     {% endif %}
+                    {% if not nobag and not dense %}
+                    var_B_metadata.has_value() ? var_B_metadata.value().data_ptr<int32_t>() : nullptr,
+                    {% endif %}
                     {% if not nobag %}
-                    FixedDivisor(B),
+                    info_B_num_bits,
+                    info_B_mask,
                     {% endif %}
                     {{ args.split_kernel_arg_constructors | join(", ") }});
             C10_CUDA_KERNEL_LAUNCH_CHECK();
             return;
+
+            {% if not dense %}
+            } // if (var_B_metadata.has_value() == {{ var_batch_size }})
+            {% endif %}
+
+            {% endif %} // if not dense or var_batch_size == "true"
+            {% endfor %} // for var_batch_size in ["true", "false"]
         }
         {% endif %}
         {% endfor %}

--- a/fbgemm_gpu/codegen/embedding_bounds_check.cu
+++ b/fbgemm_gpu/codegen/embedding_bounds_check.cu
@@ -23,30 +23,42 @@ __device__ void adjust_offset_kernel(
   *offset_acc_end = indices_end;
 }
 
-template <typename index_t>
+template <typename index_t, bool var_batch_size>
 __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel(
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         rows_per_table,
     at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
     at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
+    const int32_t* var_B_metadata,
     const int64_t bounds_check_mode_,
     at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> warning,
     FixedDivisor fd) {
   int32_t T = rows_per_table.size(0);
-  int32_t B = (offsets.size(0) - 1) / T;
-
   int32_t b_t = blockIdx.x * blockDim.y + threadIdx.y;
-  int32_t b; // = b_t % B;
-  int32_t t; // = b_t / B;
-  fd.DivMod(b_t, &t, &b);
-  if (t >= T) {
+  int32_t b, t, B = 0;
+  int32_t total_B = offsets.size(0) - 1;
+
+  if (b_t >= total_B) {
     return;
   }
-  auto bounds_check_mode = static_cast<BoundsCheckMode>(bounds_check_mode_);
 
+  if (var_batch_size) {
+    if (threadIdx.x == 0) {
+      // binary_search_range takes inclusive sumscan array
+      binary_search_range(&t, var_B_metadata + 1, b_t, T);
+      b = b_t - var_B_metadata[t];
+    }
+    t = shfl_sync(t, 0);
+    b = shfl_sync(b, 0);
+  } else {
+    B = total_B / T;
+    fd.DivMod(b_t, &t, &b);
+  }
+
+  auto bounds_check_mode = static_cast<BoundsCheckMode>(bounds_check_mode_);
   auto num_rows = rows_per_table[t];
-  auto indices_start = offsets[t * B + b];
-  auto indices_end = offsets[t * B + b + 1];
+  auto indices_start = offsets[b_t];
+  auto indices_end = offsets[b_t + 1];
   index_t num_indices = indices.size(0);
 
   if (bounds_check_mode == BoundsCheckMode::FATAL) {
@@ -58,10 +70,11 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel(
         indices_end > num_indices) {
       if (gpuAtomicIncrement(&warning[0]) == 0) {
         printf(
-            "EmbeddingBoundsCheck: (at least one) Out of bounds access for "
+            "EmbeddingBoundsCheck (var_batch_size %s): (at least one) Out of bounds access for "
             "batch: %lld, table: %lld, indices_start: %lld, indices_end: %lld,"
             " num_indices: %lld. Setting indices_start and indices_end within "
             "the range.\n",
+            var_batch_size ? "true" : "false",
             static_cast<int64_t>(b),
             static_cast<int64_t>(t),
             static_cast<int64_t>(indices_start),
@@ -72,16 +85,16 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel(
           indices_start,
           indices_end,
           num_indices,
-          &offsets[t * B + b],
-          &offsets[t * B + b + 1]);
+          &offsets[b_t],
+          &offsets[b_t + 1]);
     }
   } else if (bounds_check_mode == BoundsCheckMode::IGNORE) {
     adjust_offset_kernel(
         indices_start,
         indices_end,
         num_indices,
-        &offsets[t * B + b],
-        &offsets[t * B + b + 1]);
+        &offsets[b_t],
+        &offsets[b_t + 1]);
   }
 
   const auto L = indices_end - indices_start;
@@ -100,7 +113,8 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel(
       if (idx < 0 || idx >= num_rows) {
         if (gpuAtomicIncrement(&warning[0]) == 0) {
           printf(
-              "EmbeddingBoundsCheck: (at least one) Out of bounds access for batch: %lld, table: %lld, bag element: %lld, idx: %lld, num_rows: %lld, indices_start: %lld, indices_end: %lld, T: %d, B: %d, b_t: %d. Setting idx to zero.\n",
+              "EmbeddingBoundsCheck (var_batch_size %s): (at least one) Out of bounds access for batch: %lld, table: %lld, bag element: %lld, idx: %lld, num_rows: %lld, indices_start: %lld, indices_end: %lld, T: %d, B: %d, b_t: %d. Setting idx to zero.\n",
+              var_batch_size ? "true" : "false",
               static_cast<int64_t>(b),
               static_cast<int64_t>(t),
               static_cast<int64_t>(i),
@@ -122,25 +136,27 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel(
   }
 
   if (bounds_check_mode == BoundsCheckMode::FATAL) {
-    CUDA_KERNEL_ASSERT(num_indices == offsets[B * T]);
+    CUDA_KERNEL_ASSERT(num_indices == offsets[total_B]);
   } else if (bounds_check_mode == BoundsCheckMode::WARNING) {
-    if (num_indices != offsets[B * T]) {
+    if (num_indices != offsets[total_B]) {
       if (gpuAtomicIncrement(&warning[0]) == 0) {
         printf(
-            "EmbeddingBoundsCheck: the last element in offsets is incorrect for "
-            "total batch size B: %lld, total table num T: %lld, "
+            "EmbeddingBoundsCheck (var_batch_size %s): the last element in offsets is incorrect for "
+            "total batch size %s: %lld, total table num T: %lld, "
             " last element in offsets: %lld, indices size: %lld. "
             " Setting the last element in offsets to be indices size.\n",
-            static_cast<int64_t>(B),
+            var_batch_size ? "true" : "false",
+            var_batch_size ? "total_B" : "B",
+            static_cast<int64_t>(var_batch_size ? total_B : B),
             static_cast<int64_t>(T),
-            static_cast<int64_t>(offsets[B * T]),
+            static_cast<int64_t>(offsets[total_B]),
             static_cast<int64_t>(num_indices));
       }
-      offsets[B * T] = num_indices;
+      offsets[total_B] = num_indices;
     }
   } else if (bounds_check_mode == BoundsCheckMode::IGNORE) {
-    if (num_indices != offsets[B * T]) {
-      offsets[B * T] = num_indices;
+    if (num_indices != offsets[total_B]) {
+      offsets[total_B] = num_indices;
     }
   }
 }
@@ -151,19 +167,24 @@ void bounds_check_indices_cuda(
     Tensor& offsets,
     int64_t bounds_check_mode_,
     Tensor& warning,
-    c10::optional<Tensor> weights) {
+    c10::optional<Tensor> weights,
+    c10::optional<Tensor> var_B_metadata) {
   TENSOR_ON_CUDA_GPU(rows_per_table);
   TENSOR_ON_CUDA_GPU(indices);
   TENSOR_ON_CUDA_GPU(offsets);
   TENSOR_ON_CUDA_GPU(warning);
   TENSOR_EMPTY_OR_ON_CUDA_GPU(weights);
+  if (var_B_metadata.has_value()) {
+    TENSOR_ON_CUDA_GPU(var_B_metadata.value());
+  }
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(rows_per_table.get_device());
 
   const int32_t T = rows_per_table.size(0);
-  const int32_t B = (offsets.size(0) - 1) / T;
-  if (B == 0 || T == 0) {
+  const int32_t total_B = offsets.size(0) - 1;
+  const int32_t B = (total_B) / T;
+  if (total_B == 0 || T == 0) {
     return;
   }
   const auto bounds_check_mode =
@@ -173,11 +194,13 @@ void bounds_check_indices_cuda(
   }
   const int64_t num_indices = indices.size(0);
 
-  TORCH_CHECK(
-      offsets.size(0) == B * T + 1,
-      "offsets size " + std::to_string(offsets.size(0)) +
-          " is not equal to B (" + std::to_string(B) + ") * T (" +
-          std::to_string(T) + ") + 1");
+  if (!var_B_metadata.has_value()) {
+    TORCH_CHECK(
+        offsets.size(0) == B * T + 1,
+        "offsets size " + std::to_string(offsets.size(0)) +
+            " is not equal to B (" + std::to_string(B) + ") * T (" +
+            std::to_string(T) + ") + 1");
+  }
   if (weights.has_value()) {
     TORCH_CHECK(
         weights.value().size(0) == num_indices,
@@ -187,19 +210,30 @@ void bounds_check_indices_cuda(
 
   constexpr size_t kNumThreads = 256;
 
+#define INVOKE_BOUNDS_CHECK_INDICES_KERNEL(VAR_BATCH_SIZE, VAR_B_METADATA) \
+  bounds_check_indices_kernel<index_t, VAR_BATCH_SIZE>                     \
+      <<<div_round_up(total_B, kNumThreads / fbgemm_gpu::kWarpSize),       \
+         dim3(fbgemm_gpu::kWarpSize, kNumThreads / fbgemm_gpu::kWarpSize), \
+         0,                                                                \
+         at::cuda::getCurrentCUDAStream()>>>(                              \
+          rows_per_table                                                   \
+              .packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),     \
+          indices.packed_accessor32<index_t, 1, at::RestrictPtrTraits>(),  \
+          offsets.packed_accessor32<index_t, 1, at::RestrictPtrTraits>(),  \
+          VAR_B_METADATA,                                                  \
+          bounds_check_mode_,                                              \
+          warning.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),  \
+          FixedDivisor(B))
+
   AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "bounds_check_indices", [&] {
-    bounds_check_indices_kernel<index_t>
-        <<<div_round_up(B * T, kNumThreads / fbgemm_gpu::kWarpSize),
-           dim3(fbgemm_gpu::kWarpSize, kNumThreads / fbgemm_gpu::kWarpSize),
-           0,
-           at::cuda::getCurrentCUDAStream()>>>(
-            rows_per_table
-                .packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
-            indices.packed_accessor32<index_t, 1, at::RestrictPtrTraits>(),
-            offsets.packed_accessor32<index_t, 1, at::RestrictPtrTraits>(),
-            bounds_check_mode_,
-            warning.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
-            FixedDivisor(B));
+    if (var_B_metadata.has_value()) {
+      INVOKE_BOUNDS_CHECK_INDICES_KERNEL(
+          true, var_B_metadata.value().data_ptr<int32_t>());
+    } else {
+      INVOKE_BOUNDS_CHECK_INDICES_KERNEL(false, nullptr);
+    }
   });
   C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+#undef INVOKE_BOUNDS_CHECK_INDICES_KERNEL
 }

--- a/fbgemm_gpu/codegen/embedding_bounds_check_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host.cpp
@@ -23,7 +23,8 @@ void bounds_check_indices_cuda(
     Tensor& offsets,
     int64_t bounds_check_mode,
     Tensor& warning,
-    c10::optional<Tensor> weights);
+    c10::optional<Tensor> weights,
+    c10::optional<Tensor> var_B_metadata);
 
 // Deprecated for fb namespace! Please use fbgemm namespace instead!
 TORCH_LIBRARY_FRAGMENT(fb, m) {

--- a/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
@@ -42,7 +42,11 @@ void bounds_check_indices_cpu(
     Tensor& offsets,
     int64_t bounds_check_mode_,
     Tensor& warning,
-    c10::optional<Tensor> weights) {
+    c10::optional<Tensor> weights,
+    c10::optional<Tensor> var_B_metadata) {
+  TORCH_CHECK(
+      !var_B_metadata.has_value(),
+      "bounds_check_indices on CPU does not support variable batch_size");
   auto bounds_check_mode = static_cast<BoundsCheckMode>(bounds_check_mode_);
   if (bounds_check_mode == BoundsCheckMode::WARNING) {
     warning.zero_();
@@ -163,7 +167,7 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
   // The (a!) tells PyTorch this is an impure operation and so cannot be CSE'd
   // or DCE'd, etc.
   m.def(
-      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(b!) offsets, int bounds_check_mode, Tensor(c!) warning, Tensor(d!)? weights=None) -> ()");
+      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(b!) offsets, int bounds_check_mode, Tensor(c!) warning, Tensor(d!)? weights=None, Tensor? var_B_metadata=None) -> ()");
   DISPATCH_TO_CPU("bounds_check_indices", bounds_check_indices_cpu);
 }
 
@@ -171,6 +175,6 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   // The (a!) tells PyTorch this is an impure operation and so cannot be CSE'd
   // or DCE'd, etc.
   m.def(
-      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(b!) offsets, int bounds_check_mode, Tensor(c!) warning, Tensor(d!)? weights=None) -> ()");
+      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(b!) offsets, int bounds_check_mode, Tensor(c!) warning, Tensor(d!)? weights=None, Tensor? var_B_metadata=None) -> ()");
   DISPATCH_TO_CPU("bounds_check_indices", bounds_check_indices_cpu);
 }

--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
@@ -3133,4 +3133,49 @@ __inline__ __device__ void inclusive_sum_scan_kernel(
   }
 }
 
+template <typename scalar_t>
+__device__ __forceinline__ void binary_search_range(
+    int* found,
+    const scalar_t* arr,
+    const scalar_t target,
+    const int num_entries) {
+  const int last_entry = num_entries - 1;
+  int start = 0, end = last_entry;
+  int found_ = -1;
+  while (start <= end) {
+    int mid = start + (end - start) / 2;
+    scalar_t mid_offset = arr[mid];
+    if (target == mid_offset) {
+      if (mid != last_entry && target != arr[last_entry]) {
+        // Do linear scan in case of duplicate data (We assume that the
+        // number of duplicates is small.  This can we very bad if the
+        // number of duplicates is large)
+        for (int i = mid + 1; i < num_entries; i++) {
+          if (target != arr[i]) {
+            found_ = i;
+            break;
+          }
+        }
+      }
+      break;
+    } else if (target < mid_offset) {
+      if (mid == 0) {
+        found_ = 0;
+        break;
+      } else if (mid - 1 >= 0 && target > arr[mid - 1]) {
+        found_ = mid;
+        break;
+      }
+      end = mid - 1;
+    } else {
+      if (mid + 1 <= last_entry && target < arr[mid + 1]) {
+        found_ = mid + 1;
+        break;
+      }
+      start = mid + 1;
+    }
+  }
+  *found = found_;
+}
+
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.cuh
@@ -10,6 +10,14 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
+// These values are adjusted in backward based on B and T
+constexpr int DEFAULT_INFO_NUM_BITS = 32;
+constexpr int DEFAULT_INFO_B_NUM_BITS = 26;
+constexpr uint32_t DEFAULT_INFO_B_MASK = (1u << DEFAULT_INFO_B_NUM_BITS) - 1;
+constexpr int32_t MAX_T =
+    (1u << (DEFAULT_INFO_NUM_BITS - DEFAULT_INFO_B_NUM_BITS)) - 1;
+constexpr int32_t MAX_B = (1u << DEFAULT_INFO_B_NUM_BITS) - 1;
+
 /**
  * "Transpose" embedding inputs by sorting indices by their values.
  * Logically this transpose compressed sparse row (CSR) representation
@@ -28,7 +36,14 @@ transpose_embedding_input(
     int64_t total_hash_size_bits,
     at::Tensor indices,
     at::Tensor offsets,
-    bool nobag = false);
+    c10::optional<at::Tensor> var_B_metadata,
+    bool nobag = false,
+    int64_t info_B_num_bits = 0);
+
+std::tuple<int64_t, int64_t>
+get_infos_metadata(at::Tensor unused, int64_t B, int64_t T);
+
+std::tuple<int32_t, uint32_t> adjust_info_B_num_bits(int32_t B, int32_t T);
 
 // Use these functions instead of directly calling cub functions
 // to reduce code size and compilation time.

--- a/fbgemm_gpu/src/jagged_tensor_ops.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops.cu
@@ -1989,51 +1989,6 @@ std::vector<Tensor> stacked_jagged_1d_to_dense_gpu(
   return padded_values_per_key;
 }
 
-template <typename scalar_t>
-__device__ __forceinline__ void binary_search_range(
-    int* found,
-    const scalar_t* arr,
-    const scalar_t target,
-    const int num_entries) {
-  const int last_entry = num_entries - 1;
-  int start = 0, end = last_entry;
-  int found_ = -1;
-  while (start <= end) {
-    int mid = start + (end - start) / 2;
-    scalar_t mid_offset = arr[mid];
-    if (target == mid_offset) {
-      if (mid != last_entry && target != arr[last_entry]) {
-        // Do linear scan in case of duplicate data (We assume that the
-        // number of duplicates is small.  This can we very bad if the
-        // number of duplicates is large)
-        for (int i = mid + 1; i < num_entries; i++) {
-          if (target != arr[i]) {
-            found_ = i;
-            break;
-          }
-        }
-      }
-      break;
-    } else if (target < mid_offset) {
-      if (mid == 0) {
-        found_ = 0;
-        break;
-      } else if (mid - 1 >= 0 && target > arr[mid - 1]) {
-        found_ = mid;
-        break;
-      }
-      end = mid - 1;
-    } else {
-      if (mid + 1 <= last_entry && target < arr[mid + 1]) {
-        found_ = mid + 1;
-        break;
-      }
-      start = mid + 1;
-    }
-  }
-  *found = found_;
-}
-
 template <typename index_t, typename offset_t, typename scalar_t>
 __global__ __launch_bounds__(kMaxThreads) void jagged_index_select_2d_kernel(
     scalar_t* output,

--- a/fbgemm_gpu/src/sparse_ops.cu
+++ b/fbgemm_gpu/src/sparse_ops.cu
@@ -1943,7 +1943,8 @@ __launch_bounds__(kMaxThreads) void batched_unary_embeddings_backward_kernel(
     const int32_t* __restrict__ sorted_linear_indices_cumulative_run_lengths,
     const int32_t* __restrict__ sorted_infos,
     const int32_t* __restrict__ sorted_linear_indices_num_runs,
-    FixedDivisor fd) {
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask) {
   int32_t run_id = blockIdx.x * blockDim.x + threadIdx.x;
   int32_t n = blockIdx.y;
   if (n >= N) {
@@ -1967,12 +1968,15 @@ __launch_bounds__(kMaxThreads) void batched_unary_embeddings_backward_kernel(
 
   // now, each segment corresponds to exactly one table `t` and row in
   // that table (`idx`). Thus, we can hoist out some of the book-keeping.
-  auto info = sorted_infos[segment_start];
-  int t = fd.Div(info);
+  uint32_t info =
+      reinterpret_cast<const uint32_t*>(sorted_infos)[segment_start];
+  int t = info >> info_B_num_bits;
 
   at::acc_type<scalar_t, true> grad_sum = 0.0;
   for (int32_t sl = 0; sl < SL; ++sl) {
-    int32_t b = fd.Mod(sorted_infos[segment_start + sl]);
+    int32_t b =
+        reinterpret_cast<const uint32_t*>(sorted_infos)[segment_start + sl] &
+        info_B_mask;
     grad_sum += grad_output[(n * B + b) * T + t];
   }
 
@@ -2005,6 +2009,10 @@ Tensor batched_unary_embeddings_backward_cuda(
   TORCH_CHECK(B > 0);
   TORCH_CHECK(T > 0);
 
+  int32_t info_B_num_bits;
+  uint32_t info_B_mask;
+  std::tie(info_B_num_bits, info_B_mask) = adjust_info_B_num_bits(B, T);
+
   // weight: [N, sum_E]
   // total_hash_size_bits = log2(sum_E)
   int64_t total_hash_size_bits = log2(weight.numel() / N) + 1;
@@ -2023,7 +2031,13 @@ Tensor batched_unary_embeddings_backward_cuda(
       sorted_linear_indices_num_runs,
       sorted_linear_indices_cumulative_run_lengths) =
       transpose_embedding_input(
-          table_offsets, total_hash_size_bits, indices, offsets);
+          table_offsets,
+          total_hash_size_bits,
+          indices,
+          offsets,
+          c10::optional<Tensor>(),
+          false, // nobag
+          info_B_num_bits);
 
   int threads = std::min<int32_t>(sorted_linear_indices_run.numel(), 512);
   dim3 blocks(
@@ -2051,7 +2065,8 @@ Tensor batched_unary_embeddings_backward_cuda(
                           .data_ptr<int32_t>(),
                       infos_sorted.data_ptr<int32_t>(),
                       sorted_linear_indices_num_runs.data_ptr<int32_t>(),
-                      FixedDivisor(B));
+                      info_B_num_bits,
+                      info_B_mask);
               C10_CUDA_KERNEL_LAUNCH_CHECK();
             });
       });

--- a/fbgemm_gpu/src/split_embeddings_utils.cpp
+++ b/fbgemm_gpu/src/split_embeddings_utils.cpp
@@ -13,6 +13,8 @@
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
-      "transpose_embedding_input(Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, bool nobag=False) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)");
+      "transpose_embedding_input(Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, Tensor? var_B_metadata=None, bool nobag=False, int info_B_num_bits=26) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)");
+  m.def("get_infos_metadata(Tensor unused, int B, int T) -> (int, int)");
   DISPATCH_TO_CUDA("transpose_embedding_input", transpose_embedding_input);
+  DISPATCH_TO_CUDA("get_infos_metadata", get_infos_metadata);
 }

--- a/fbgemm_gpu/src/split_embeddings_utils.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils.cu
@@ -59,71 +59,79 @@ using Tensor = at::Tensor;
 
 using namespace fbgemm_gpu;
 
-template <typename index_t>
+template <typename index_t, typename info_acc_t, bool nobag>
 __global__ __launch_bounds__(kMaxThreads) void linearize_index_kernel(
     const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         hash_size_cumsum,
     const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
     const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
-    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> infos,
+    const int32_t* __restrict__ var_B_metadata,
+    const int32_t info_B_num_bits,
+    const int32_t max_T,
+    const int32_t max_B,
+    at::PackedTensorAccessor32<info_acc_t, 1, at::RestrictPtrTraits> infos,
     at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         linear_indices) {
   const int32_t T = hash_size_cumsum.size(0) - 1;
-  const int32_t B = (offsets.size(0) - 1) / T;
   const int32_t b_t = blockIdx.x * blockDim.x + threadIdx.x;
-  const int32_t b = b_t % B;
-  const int32_t t = b_t / B;
-  const bool valid = t < T;
+  int32_t b, t;
+  const auto total_B = offsets.size(0) - 1;
+  const bool valid = b_t < total_B;
 
-  const index_t hash_offset = valid ? hash_size_cumsum[t] : -1;
-  const index_t indices_start = valid ? offsets[t * B + b] : -1;
-  const int32_t L = valid ? offsets[t * B + b + 1] - indices_start : 0;
-  const int32_t lane_id = threadIdx.x % fbgemm_gpu::kWarpSize;
-
-  for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
-    const index_t indices_start_warp = fbgemm_gpu::shfl_sync(indices_start, j);
-    const int32_t b_t_warp = fbgemm_gpu::shfl_sync(b_t, j);
-    const int32_t L_warp = fbgemm_gpu::shfl_sync(L, j);
-    const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
-    for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
-      const index_t idx = __ldg(&indices[indices_start_warp + i]);
-      infos[indices_start_warp + i] = b_t_warp;
-      linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
-    }
+  // Use variable batch size
+  if (var_B_metadata != nullptr && valid) {
+    // TODO: Check if this is expensive because every thread executes this
+    // Complexity is log(T).
+    binary_search_range(&t, var_B_metadata + 1, b_t, T);
+    b = b_t - var_B_metadata[t];
+  } else {
+    const int32_t B = total_B / T;
+    b = b_t % B;
+    t = b_t / B;
   }
-}
-
-template <typename index_t>
-__global__ __launch_bounds__(kMaxThreads) void nobag_linearize_index_kernel(
-    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
-        hash_size_cumsum,
-    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
-    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
-    at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> infos,
-    at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
-        linear_indices) {
-  const int32_t T = hash_size_cumsum.size(0) - 1;
-  const int32_t B = (offsets.size(0) - 1) / T;
-  const int32_t b_t = blockIdx.x * blockDim.x + threadIdx.x;
-  const int32_t b = b_t % B;
-  const int32_t t = b_t / B;
-  const bool valid = t < T;
 
   const index_t hash_offset = valid ? hash_size_cumsum[t] : -1;
-  const index_t indices_start = valid ? offsets[t * B + b] : -1;
-  const int32_t L = valid ? offsets[t * B + b + 1] - indices_start : 0;
+  const index_t indices_start = valid ? offsets[b_t] : -1;
+  const int32_t L = valid ? offsets[b_t + 1] - indices_start : 0;
   const int32_t lane_id = threadIdx.x % fbgemm_gpu::kWarpSize;
 
-  for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
-    const index_t indices_start_warp = fbgemm_gpu::shfl_sync(indices_start, j);
-    const int32_t t_warp = fbgemm_gpu::shfl_sync(t, j);
-    const int32_t L_warp = fbgemm_gpu::shfl_sync(L, j);
-    const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
-    for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
-      const index_t idx = __ldg(&indices[indices_start_warp + i]);
-      const int64_t l_t = (indices_start_warp + i) * T + t_warp;
-      infos[indices_start_warp + i] = l_t;
-      linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
+  // Compile-time conditional
+  if (nobag) {
+    for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
+      const index_t indices_start_warp =
+          fbgemm_gpu::shfl_sync(indices_start, j);
+      const int32_t t_warp = fbgemm_gpu::shfl_sync(t, j);
+      const int32_t L_warp = fbgemm_gpu::shfl_sync(L, j);
+      const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
+      for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
+        const index_t idx = __ldg(&indices[indices_start_warp + i]);
+        const int64_t l_t = (indices_start_warp + i) * T + t_warp;
+        infos[indices_start_warp + i] = l_t;
+        linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
+      }
+    }
+  } else {
+    // Store t in upper (32 - DEFAULT_INFO_B_NUM_BITS).
+    // Store b in lower (DEFAULT_INFO_B_NUM_BITS).
+    uint32_t info = 0;
+    if (valid) {
+      CUDA_KERNEL_ASSERT(t < max_T)
+      CUDA_KERNEL_ASSERT(b < max_B)
+      info = (reinterpret_cast<uint32_t*>(&t)[0] << info_B_num_bits) |
+          reinterpret_cast<uint32_t*>(&b)[0];
+    }
+    for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
+      const index_t indices_start_warp =
+          fbgemm_gpu::shfl_sync(indices_start, j);
+      const uint32_t info_warp = fbgemm_gpu::shfl_sync(info, j);
+      const int32_t L_warp = fbgemm_gpu::shfl_sync(L, j);
+      const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
+      for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
+        const index_t idx = __ldg(&indices[indices_start_warp + i]);
+        reinterpret_cast<uint32_t*>(&infos[0])[indices_start_warp + i] =
+            info_warp;
+        linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
+      }
     }
   }
 }
@@ -141,9 +149,12 @@ transpose_embedding_input(
     int64_t total_hash_size_bits,
     Tensor indices,
     Tensor offsets,
-    bool nobag) {
-  const int32_t T = hash_size_cumsum.size(0) - 1;
-  const int32_t B = (offsets.size(0) - 1) / T;
+    c10::optional<Tensor> var_B_metadata,
+    bool nobag,
+    int64_t info_B_num_bits) {
+  TORCH_CHECK(nobag || info_B_num_bits > 0);
+
+  const int32_t total_B = offsets.size(0) - 1;
 
   auto infos = at::empty_like(
       indices, indices.options().dtype(nobag ? at::kLong : at::kInt));
@@ -157,37 +168,33 @@ transpose_embedding_input(
 
   using at::RestrictPtrTraits;
 
+#define INVOKE_LINEARIZE_INDEX_KERNEL(INFO_ACC_T, NOBAG)                       \
+  linearize_index_kernel<index_t, INFO_ACC_T, NOBAG>                           \
+      <<<div_round_up(total_B, kMaxThreads),                                   \
+         kMaxThreads,                                                          \
+         0,                                                                    \
+         at::cuda::getCurrentCUDAStream()>>>(                                  \
+          hash_size_cumsum.packed_accessor32<index_t, 1, RestrictPtrTraits>(), \
+          indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),          \
+          offsets.packed_accessor32<index_t, 1, RestrictPtrTraits>(),          \
+          var_B_metadata.has_value()                                           \
+              ? var_B_metadata.value().data_ptr<int32_t>()                     \
+              : nullptr,                                                       \
+          info_B_num_bits,                                                     \
+          (1 << (DEFAULT_INFO_NUM_BITS - info_B_num_bits)) - 1,                \
+          (1 << info_B_num_bits) - 1,                                          \
+          infos.packed_accessor32<INFO_ACC_T, 1, RestrictPtrTraits>(),         \
+          linear_indices.packed_accessor32<index_t, 1, RestrictPtrTraits>())
+
   AT_DISPATCH_INDEX_TYPES(
       infos.scalar_type(), "transpose_embedding_input1", [&] {
         using info_t = index_t;
         AT_DISPATCH_INDEX_TYPES(
             indices.scalar_type(), "transpose_embedding_input2", [&] {
               if (!nobag) {
-                linearize_index_kernel<<<
-                    div_round_up(B * T, kMaxThreads),
-                    kMaxThreads,
-                    0,
-                    at::cuda::getCurrentCUDAStream()>>>(
-                    hash_size_cumsum
-                        .packed_accessor32<index_t, 1, RestrictPtrTraits>(),
-                    indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
-                    offsets.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
-                    infos.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
-                    linear_indices
-                        .packed_accessor32<index_t, 1, RestrictPtrTraits>());
+                INVOKE_LINEARIZE_INDEX_KERNEL(int32_t, false);
               } else {
-                nobag_linearize_index_kernel<<<
-                    div_round_up(B * T, kMaxThreads),
-                    kMaxThreads,
-                    0,
-                    at::cuda::getCurrentCUDAStream()>>>(
-                    hash_size_cumsum
-                        .packed_accessor32<index_t, 1, RestrictPtrTraits>(),
-                    indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
-                    offsets.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
-                    infos.packed_accessor32<int64_t, 1, RestrictPtrTraits>(),
-                    linear_indices
-                        .packed_accessor32<index_t, 1, RestrictPtrTraits>());
+                INVOKE_LINEARIZE_INDEX_KERNEL(int64_t, true);
               }
               C10_CUDA_KERNEL_LAUNCH_CHECK();
               {
@@ -263,6 +270,8 @@ transpose_embedding_input(
   auto sorted_linear_indices_cumulative_run_lengths =
       asynchronous_complete_cumsum(sorted_linear_indices_run_lengths);
 
+#undef INVOKE_LINEARIZE_INDEX_KERNEL
+
   return {
       linear_indices,
       linear_indices_sorted,
@@ -271,6 +280,55 @@ transpose_embedding_input(
       sorted_linear_indices_run_lengths,
       sorted_linear_indices_num_runs,
       sorted_linear_indices_cumulative_run_lengths};
+}
+
+std::tuple<int64_t, int64_t>
+get_infos_metadata(Tensor unused, int64_t B, int64_t T) {
+  return adjust_info_B_num_bits(B, T);
+}
+
+std::tuple<int32_t, uint32_t> adjust_info_B_num_bits(int32_t B, int32_t T) {
+  int32_t info_B_num_bits = DEFAULT_INFO_B_NUM_BITS;
+  uint32_t info_B_mask = DEFAULT_INFO_B_MASK;
+  uint32_t max_T = MAX_T;
+  uint32_t max_B = MAX_B;
+  bool invalid_T = T > max_T;
+  bool invalid_B = B > max_B;
+
+  TORCH_CHECK(
+      !(invalid_T && invalid_B),
+      "Not enough infos bits to accommodate T and B in linearize_index_kernel. Default num bits = ",
+      DEFAULT_INFO_NUM_BITS);
+
+  if (invalid_T) {
+    // Reduce info_B_num_bits
+    while (invalid_T && !invalid_B && info_B_num_bits > 0) {
+      info_B_num_bits--;
+      max_T = ((max_T + 1) << 1) - 1;
+      max_B = ((max_B + 1) >> 1) - 1;
+      invalid_T = T > max_T;
+      invalid_B = B > max_B;
+    }
+  } else if (invalid_B) {
+    // Increase info_B_num_bits
+    while (!invalid_T && invalid_B && info_B_num_bits < DEFAULT_INFO_NUM_BITS) {
+      info_B_num_bits++;
+      max_T = ((max_T + 1) >> 1) - 1;
+      max_B = ((max_B + 1) << 1) - 1;
+      invalid_T = T > max_T;
+      invalid_B = B > max_B;
+    }
+  }
+
+  TORCH_CHECK(
+      !invalid_T && !invalid_B,
+      "Not enough infos bits to accommodate T and B in linearize_index_kernel. Default num bits = ",
+      DEFAULT_INFO_NUM_BITS);
+
+  // Recompute info_B_mask using new info_B_num_bits
+  info_B_mask = (1u << info_B_num_bits) - 1;
+
+  return {info_B_num_bits, info_B_mask};
 }
 
 #define DEF_RADIX_SORT_PAIRS_FN(KeyT, ValueT)                        \

--- a/fbgemm_gpu/test/split_embeddings_utils_test.py
+++ b/fbgemm_gpu/test/split_embeddings_utils_test.py
@@ -59,6 +59,7 @@ def transpose_embedding_input_ref(
     hash_size_cumsum: torch.Tensor,
     indices: torch.Tensor,
     offsets: torch.Tensor,
+    info_B_num_bits: int,
 ) -> Tuple[
     torch.Tensor,
     torch.Tensor,
@@ -78,11 +79,12 @@ def transpose_embedding_input_ref(
     infos = torch.zeros_like(indices)
     for b_t in range(B * T):
         t = b_t // B
+        b = b_t % B
         start = int(offsets[b_t].item())
         end = int(offsets[b_t + 1].item())
         for i in range(start, end):
             linear_indices[i] = indices[i] + hash_size_cumsum[t]
-            infos[i] = b_t
+            infos[i] = (t << info_B_num_bits) | b
 
     linear_indices_sorted, sorted_idx = torch.sort(linear_indices, stable=True)
     infos_sorted = infos[sorted_idx]
@@ -131,6 +133,11 @@ class SplitEmbeddingsUtilsTest(unittest.TestCase):
         )
 
         indices, offsets = gen_inputs(hash_sizes, batch_size, max_len)
+        hash_size_cumsum_cuda = hash_size_cumsum.cuda()
+
+        info_B_num_bits, _ = torch.ops.fbgemm.get_infos_metadata(
+            hash_size_cumsum_cuda, B, T
+        )
 
         (
             linear_indices,
@@ -141,10 +148,11 @@ class SplitEmbeddingsUtilsTest(unittest.TestCase):
             sorted_linear_indices_num_runs,
             sorted_linear_indices_cumulative_run_lengths,
         ) = torch.ops.fbgemm.transpose_embedding_input(
-            hash_size_cumsum.cuda(),
+            hash_size_cumsum_cuda,
             total_hash_size_bits,
             indices.cuda(),
             offsets.cuda(),
+            info_B_num_bits=info_B_num_bits,
         )
 
         (
@@ -156,9 +164,7 @@ class SplitEmbeddingsUtilsTest(unittest.TestCase):
             sorted_linear_indices_num_runs_ref,
             sorted_linear_indices_cumulative_run_lengths_ref,
         ) = transpose_embedding_input_ref(
-            hash_size_cumsum,
-            indices,
-            offsets,
+            hash_size_cumsum, indices, offsets, info_B_num_bits
         )
 
         self.assertTrue(torch.equal(linear_indices.cpu(), linear_indices_ref))


### PR DESCRIPTION
Summary:
This diff appends the argument list of `bounds_check_indices` with
`var_B_metadata` which is needed by the variable batch size TBE
implementation.  We need to update the API before using it to address
the forward compatibility issue.

Differential Revision: D42979993

