### PR TITLE
jagged_softmax forward only

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -441,6 +441,11 @@ at::Tensor jagged_2d_to_dense_gpu_backward(
     at::Tensor offsets,
     int64_t max_lengths);
 
+std::tuple<at::Tensor, at::Tensor> jagged_softmax(
+    const at::Tensor& values,
+    const at::Tensor& offsets,
+    const int64_t max_L);
+
 #endif
 
 ///@ingroup sparse-data-cpu

--- a/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
@@ -412,6 +412,21 @@ jagged_2d_to_dense(Tensor values, Tensor offsets, int64_t max_sequence_length) {
       /*padding_value=*/0);
 }
 
+std::tuple<Tensor, Tensor> jagged_softmax(
+    const Tensor& values,
+    const Tensor& offsets,
+    const int64_t max_L) {
+  static auto op =
+      c10::Dispatcher::singleton()
+          .findSchemaOrThrow("fbgemm::jagged_softmax_forward", "")
+          .typed<Tensor(
+              const Tensor& values, const Tensor& offsets, int64_t max_L)>();
+
+  auto output = op.call(values, offsets, max_L);
+
+  return {output, offsets};
+}
+
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_IMPL(fbgemm, Autograd, m) {
@@ -429,4 +444,5 @@ TORCH_LIBRARY_IMPL(fbgemm, Autograd, m) {
       "batched_dense_vec_jagged_2d_mul",
       TORCH_FN(fbgemm_gpu::batched_dense_vec_jagged_2d_mul));
   m.impl("dense_to_jagged", TORCH_FN(fbgemm_gpu::dense_to_jagged));
+  m.impl("jagged_softmax", TORCH_FN(fbgemm_gpu::jagged_softmax));
 }


### PR DESCRIPTION
Summary: Naive implementation for jagged tensor softmax on jagged dimension w/o any optimization, will optimize more later.

Differential Revision: D43011937

