### PR TITLE
jagged_dense_bmm forward only

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -441,6 +441,11 @@ at::Tensor jagged_2d_to_dense_gpu_backward(
     at::Tensor offsets,
     int64_t max_lengths);
 
+std::tuple<at::Tensor, at::Tensor> jagged_softmax(
+    const at::Tensor& values,
+    const at::Tensor& offsets,
+    const int64_t max_L);
+
 #endif
 
 ///@ingroup sparse-data-cpu

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -446,6 +446,12 @@ std::tuple<at::Tensor, at::Tensor> jagged_softmax(
     const at::Tensor& offsets,
     const int64_t max_L);
 
+at::Tensor jagged_jagged_bmm(
+    const at::Tensor& x_values,
+    const at::Tensor& y_values,
+    const at::Tensor& offsets,
+    const int64_t max_L);
+
 #endif
 
 ///@ingroup sparse-data-cpu

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -452,6 +452,12 @@ at::Tensor jagged_jagged_bmm(
     const at::Tensor& offsets,
     const int64_t max_L);
 
+std::tuple<at::Tensor, at::Tensor> jagged_dense_bmm(
+    const at::Tensor& x_values,
+    const at::Tensor& x_offsets,
+    const at::Tensor& y,
+    const int64_t max_L);
+
 #endif
 
 ///@ingroup sparse-data-cpu

--- a/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
@@ -446,6 +446,25 @@ Tensor jagged_jagged_bmm(
   return output;
 }
 
+std::tuple<Tensor, Tensor> jagged_dense_bmm(
+    const Tensor& x_values,
+    const Tensor& x_offsets,
+    const Tensor& y,
+    const int64_t max_L) {
+  static auto op =
+      c10::Dispatcher::singleton()
+          .findSchemaOrThrow("fbgemm::jagged_dense_bmm_forward", "")
+          .typed<Tensor(
+              const Tensor& x_values,
+              const Tensor& x_offsets,
+              const Tensor& y,
+              int64_t max_L)>();
+
+  auto output = op.call(x_values, x_offsets, y, max_L);
+
+  return {output, x_offsets};
+}
+
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_IMPL(fbgemm, Autograd, m) {
@@ -465,4 +484,5 @@ TORCH_LIBRARY_IMPL(fbgemm, Autograd, m) {
   m.impl("dense_to_jagged", TORCH_FN(fbgemm_gpu::dense_to_jagged));
   m.impl("jagged_softmax", TORCH_FN(fbgemm_gpu::jagged_softmax));
   m.impl("jagged_jagged_bmm", TORCH_FN(fbgemm_gpu::jagged_jagged_bmm));
+  m.impl("jagged_dense_bmm", TORCH_FN(fbgemm_gpu::jagged_dense_bmm));
 }

--- a/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
@@ -427,6 +427,25 @@ std::tuple<Tensor, Tensor> jagged_softmax(
   return {output, offsets};
 }
 
+Tensor jagged_jagged_bmm(
+    const Tensor& x_values,
+    const Tensor& y_values,
+    const Tensor& offsets,
+    const int64_t max_L) {
+  static auto op =
+      c10::Dispatcher::singleton()
+          .findSchemaOrThrow("fbgemm::jagged_jagged_bmm_forward", "")
+          .typed<Tensor(
+              const Tensor& x_values,
+              const Tensor& y_values,
+              const Tensor& offsets,
+              int64_t max_L)>();
+
+  auto output = op.call(x_values, y_values, offsets, max_L);
+
+  return output;
+}
+
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_IMPL(fbgemm, Autograd, m) {
@@ -445,4 +464,5 @@ TORCH_LIBRARY_IMPL(fbgemm, Autograd, m) {
       TORCH_FN(fbgemm_gpu::batched_dense_vec_jagged_2d_mul));
   m.impl("dense_to_jagged", TORCH_FN(fbgemm_gpu::dense_to_jagged));
   m.impl("jagged_softmax", TORCH_FN(fbgemm_gpu::jagged_softmax));
+  m.impl("jagged_jagged_bmm", TORCH_FN(fbgemm_gpu::jagged_jagged_bmm));
 }

--- a/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
@@ -412,6 +412,21 @@ jagged_2d_to_dense(Tensor values, Tensor offsets, int64_t max_sequence_length) {
       /*padding_value=*/0);
 }
 
+std::tuple<Tensor, Tensor> jagged_softmax(
+    const Tensor& values,
+    const Tensor& offsets,
+    const int64_t max_L) {
+  static auto op =
+      c10::Dispatcher::singleton()
+          .findSchemaOrThrow("fbgemm::jagged_softmax_forward", "")
+          .typed<Tensor(
+              const Tensor& values, const Tensor& offsets, int64_t max_L)>();
+
+  auto output = op.call(values, offsets, max_L);
+
+  return {output, offsets};
+}
+
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_IMPL(fbgemm, Autograd, m) {
@@ -429,4 +444,5 @@ TORCH_LIBRARY_IMPL(fbgemm, Autograd, m) {
       "batched_dense_vec_jagged_2d_mul",
       TORCH_FN(fbgemm_gpu::batched_dense_vec_jagged_2d_mul));
   m.impl("dense_to_jagged", TORCH_FN(fbgemm_gpu::dense_to_jagged));
+  m.impl("jagged_softmax", TORCH_FN(fbgemm_gpu::jagged_softmax));
 }

--- a/fbgemm_gpu/test/jagged_tensor_ops_test.py
+++ b/fbgemm_gpu/test/jagged_tensor_ops_test.py
@@ -1804,6 +1804,54 @@ class JaggedTensorOpsTest(unittest.TestCase):
 
         torch.testing.assert_close(output, output_ref)
 
+    # pyre-ignore [56]
+    @given(
+        B=st.integers(10, 512),
+        M=st.integers(1, 32),
+        N=st.integers(1, 32),
+        max_L=st.integers(1, 32),
+        dtype=st.sampled_from([torch.float, torch.double]),
+        device_type=st.sampled_from(["cpu", "cuda"])
+        if gpu_available
+        else st.just("cpu"),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    def test_jagged_jagged_bmm(
+        self,
+        B: int,
+        M: int,
+        N: int,
+        max_L: int,
+        dtype: torch.dtype,
+        device_type: str,
+    ) -> None:
+        assume(B != 0)
+        device = torch.device(device_type)
+        torch.backends.cuda.matmul.allow_tf32 = False
+        lengths = torch.randint(max_L + 1, size=(B,), device=device)
+        offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(lengths)
+        x_values = torch.rand((offsets[-1], M), dtype=dtype, device=device)
+        y_values = torch.rand((offsets[-1], N), dtype=dtype, device=device)
+        output = torch.ops.fbgemm.jagged_jagged_bmm(
+            x_values,
+            y_values,
+            offsets,
+            max_L,
+        )
+        x_dense = torch.ops.fbgemm.jagged_to_padded_dense(
+            x_values,
+            [offsets],
+            max_lengths=[max_L],
+        )
+        y_dense = torch.ops.fbgemm.jagged_to_padded_dense(
+            y_values,
+            [offsets],
+            max_lengths=[max_L],
+        )
+        output_ref = torch.bmm(x_dense.transpose(2, 1), y_dense)
+
+        torch.testing.assert_close(output, output_ref)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary: Naive implementation for jagged dense bmm w/o any optimization, will optimize more later.

Differential Revision: D43012766

