### PR TITLE
Revert D42979993: Multisect successfully blamed D42979993 for test or build failures

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
@@ -17,15 +17,7 @@ constexpr int32_t kCacheLocationMissing = -1;
 constexpr size_t kForwardMaxThreads = 512;
 
 // TODO: optimization to use multiple warps per row.
-template <
-  typename emb_t,
-  typename grad_t,
-  typename cache_t,
-  {% if not dense %}
-  bool var_batch_size,
-  {% endif %}
-  size_t kMaxVecsPerThread
->
+template <typename emb_t, typename grad_t, typename cache_t, size_t kMaxVecsPerThread>
 __global__
 __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights_kernel(
     // [\sum_t E_t x D_t]
@@ -39,9 +31,6 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
         weights_placements,
     {% endif %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
-    {% if not dense %}
-    const int32_t* __restrict__ var_B_metadata,
-    {% endif %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         indices, // [N = \sum_{b,t} L_{b,t} total indices, i.e. flattened
@@ -57,44 +46,21 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
     at::PackedTensorAccessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits>
         grad_indice_weights
     ) {
+    int32_t B = grad_output.size(0);
     int32_t T = D_offsets.size(0) - 1;
     int32_t b_t = blockIdx.x * blockDim.y + threadIdx.y;
-    if (b_t >= offsets.size(0) - 1) {
+    int32_t t = b_t / B;
+    int32_t b = b_t % B;
+
+    if (b_t >= B * T) {
         return;
     }
-
-    int32_t t, b, grad_offset;
-    {% if not dense %}
-    if (var_batch_size) {
-        // Compute t and b from var_B_metadata
-        if (threadIdx.x == 0) {
-            // binary_search_range takes inclusive sumscan array
-            binary_search_range(&t, var_B_metadata + 1, b_t, T);
-            b = b_t - var_B_metadata[t];
-            // TODO: check output offset for INT8 and nobag
-            grad_offset = var_B_metadata[T + 1 + t];
-        }
-        t = shfl_sync(t, 0);
-        b = shfl_sync(b, 0);
-        {% if not nobag %}
-        grad_offset = shfl_sync(grad_offset, 0);
-        {% endif %}
-    }
-    else {
-    {% endif %}
-      int32_t B = grad_output.size(0);
-      t = b_t / B;
-      b = b_t % B;
-    {% if not dense %}
-    } // if (var_batch_size)
-    {% endif %}
-
     int64_t weights_offset = weights_offsets[t];
     int32_t D_start = D_offsets[t];
     int32_t D_end = D_offsets[t + 1];
     int32_t D = D_end - D_start;
-    int64_t indices_start = offsets[b_t];
-    int64_t indices_end = offsets[b_t + 1];
+    int64_t indices_start = offsets[t * B + b];
+    int64_t indices_end = offsets[t * B + b + 1];
     int32_t L = indices_end - indices_start;
     if (feature_requires_grad.size(0) > 0 && !feature_requires_grad[t]) {
         // If the table does not require gradient computation, we set the gradient to zero.
@@ -119,8 +85,6 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
     weights = &dev_weights[weights_offset];
     {% endif %}
 
-    const grad_t* grad_output_ptr = {% if not dense %} var_batch_size ? &grad_output[0][grad_offset] : {% endif %}
-        &grad_output[b][D_start];
 
     Vec4T<at::acc_type<cache_t, true>> grad_out[kMaxVecsPerThread];
     #pragma unroll kMaxVecsPerThread
@@ -128,7 +92,7 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
         i < kMaxVecsPerThread && 4 * kWarpSize * i + threadIdx.x * 4 < D;
         ++i) {
         int32_t d = 4 * kWarpSize * i + threadIdx.x * 4;
-        Vec4T<at::acc_type<grad_t, true>> go(grad_output_ptr + d);
+        Vec4T<at::acc_type<grad_t, true>> go((&grad_output[b][0]) + D_start + d);
         grad_out[i] = go;
     }
 
@@ -222,18 +186,13 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights
     {% if not dense %}
     Tensor lxu_cache_locations,
     {% endif %}
-    Tensor feature_requires_grad{% if not dense %},
-    const c10::optional<Tensor>& var_B_metadata
-    {% endif %}) {
+    Tensor feature_requires_grad) {
     TENSOR_ON_CUDA_GPU(grad_output);
     TENSOR_ON_CUDA_GPU(dev_weights);
     {% if not dense %}
     TENSOR_ON_CUDA_GPU(uvm_weights);
     TENSOR_ON_CUDA_GPU(lxu_cache_weights);
     TENSOR_ON_CUDA_GPU(weights_placements);
-    if (var_B_metadata.has_value()) {
-        TENSOR_ON_CUDA_GPU(var_B_metadata.value());
-    }
     {% endif %}
     TENSOR_ON_CUDA_GPU(weights_offsets);
     TENSOR_ON_CUDA_GPU(D_offsets);
@@ -251,11 +210,11 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights
     const auto T = D_offsets.size(0) - 1;
     TORCH_CHECK(T > 0);
     // offsets = [B x T  + 1]
-    const auto total_B = offsets.size(0) - 1;
-    TORCH_CHECK(total_B >= 0);
+    const auto B = (offsets.size(0) - 1) / T;
+    TORCH_CHECK(B >= 0);
     TORCH_CHECK(max_D <= {{ max_embedding_dim }});
     auto grad_indice_weights = empty_like(indices, indices.options().dtype(at::toAccumulateType(grad_output.scalar_type(), true)));
-    if (total_B == 0) {
+    if (B == 0) {
       return grad_indice_weights;
     }
     feature_requires_grad = feature_requires_grad.defined() ? feature_requires_grad : at::empty({0}, indices.options().dtype(at::kInt));
@@ -269,26 +228,14 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights
         {% endif %}
         "split_embedding_codegen_grad_indice_weights_kernel",
         [&] {
-            {% for var_batch_size in ["true", "false"] %}
-            {% if not dense or var_batch_size == "true" %}
-            {% if not dense %}
-            if (var_B_metadata.has_value() == {{ var_batch_size }}) {
-            {% if var_batch_size == "true" %}
-            grad_output = grad_output.reshape({1, -1});
-            {% endif %}
-            {% endif %}
-
             {% for kMaxVecsPerThread in range(1, max_embedding_dim // items_per_warp + 1) %}
             if (max_D <= {{ items_per_warp * kMaxVecsPerThread }}) {
             {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights_kernel<
                 emb_t,
                 grad_t,
                 cache_t,
-                {% if not dense %}
-                {{ var_batch_size }},
-                {% endif %}
                 {{ kMaxVecsPerThread }}><<<
-                div_round_up(total_B, kForwardMaxThreads / kWarpSize),
+                div_round_up((B * T), kForwardMaxThreads / kWarpSize),
                 dim3(kWarpSize, kForwardMaxThreads / kWarpSize),
                 0,
                 at::cuda::getCurrentCUDAStream()>>>(
@@ -300,13 +247,6 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights
                 weights_placements.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
                 {% endif %}
                 weights_offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
-                {% if not dense %}
-                {% if var_batch_size == "true" %}
-                var_B_metadata.value().data_ptr<int32_t>(),
-                {% else %}
-                nullptr,
-                {% endif %}
-                {% endif %}
                 D_offsets.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
                 indices.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
                 offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
@@ -319,12 +259,6 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights
             return;
             }
             {% endfor %}
-
-            {% if not dense %}
-            } // if (var_B_metadata.has_value() == {{ var_batch_size }})
-            {% endif %}
-            {% endif %} // if not dense or var_batch_size == "true"
-            {% endfor %} // for var_batch_size in ["true", "false"]
         });
 
   C10_CUDA_KERNEL_LAUNCH_CHECK();

--- a/fbgemm_gpu/codegen/embedding_bounds_check_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host.cpp
@@ -23,8 +23,7 @@ void bounds_check_indices_cuda(
     Tensor& offsets,
     int64_t bounds_check_mode,
     Tensor& warning,
-    c10::optional<Tensor> weights,
-    c10::optional<Tensor> var_B_metadata);
+    c10::optional<Tensor> weights);
 
 // Deprecated for fb namespace! Please use fbgemm namespace instead!
 TORCH_LIBRARY_FRAGMENT(fb, m) {

--- a/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
@@ -42,11 +42,7 @@ void bounds_check_indices_cpu(
     Tensor& offsets,
     int64_t bounds_check_mode_,
     Tensor& warning,
-    c10::optional<Tensor> weights,
-    c10::optional<Tensor> var_B_metadata) {
-  TORCH_CHECK(
-      !var_B_metadata.has_value(),
-      "bounds_check_indices on CPU does not support variable batch_size");
+    c10::optional<Tensor> weights) {
   auto bounds_check_mode = static_cast<BoundsCheckMode>(bounds_check_mode_);
   if (bounds_check_mode == BoundsCheckMode::WARNING) {
     warning.zero_();
@@ -167,7 +163,7 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
   // The (a!) tells PyTorch this is an impure operation and so cannot be CSE'd
   // or DCE'd, etc.
   m.def(
-      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(b!) offsets, int bounds_check_mode, Tensor(c!) warning, Tensor(d!)? weights=None, Tensor? var_B_metadata=None) -> ()");
+      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(b!) offsets, int bounds_check_mode, Tensor(c!) warning, Tensor(d!)? weights=None) -> ()");
   DISPATCH_TO_CPU("bounds_check_indices", bounds_check_indices_cpu);
 }
 
@@ -175,6 +171,6 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   // The (a!) tells PyTorch this is an impure operation and so cannot be CSE'd
   // or DCE'd, etc.
   m.def(
-      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(b!) offsets, int bounds_check_mode, Tensor(c!) warning, Tensor(d!)? weights=None, Tensor? var_B_metadata=None) -> ()");
+      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(b!) offsets, int bounds_check_mode, Tensor(c!) warning, Tensor(d!)? weights=None) -> ()");
   DISPATCH_TO_CPU("bounds_check_indices", bounds_check_indices_cpu);
 }

--- a/fbgemm_gpu/codegen/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_template.cu
@@ -152,7 +152,6 @@ template <
     typename output_t,
     {% if not dense %}
     bool use_lxu_cache,
-    bool var_batch_size,
     {% endif %}
     typename index_t,
     {% if not nobag %}
@@ -189,7 +188,6 @@ __global__ void {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if noba
     {% if not dense %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         lxu_cache_locations,
-    const int32_t* var_B_metadata,
     {% endif %}
     at::PackedTensorAccessor64<output_t, 2, at::RestrictPtrTraits>
         output // [B][total_D],
@@ -197,59 +195,25 @@ __global__ void {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if noba
     int32_t T = weights_offsets.size(0);
     {% if not nobag %}
     const bool mean_pooling = static_cast<PoolingMode>(pooling_mode) == PoolingMode::MEAN;
+    int32_t B = output.size(0);
+    {% else %}
+    int32_t B = (offsets.size(0) - 1) / T;
     {% endif %}
-
     int32_t b_t = blockIdx.x * blockDim.y + threadIdx.y;
-    if (b_t >= offsets.size(0) - 1) {
+    if (b_t >= B * T) {
         return;
     }
-
-    constexpr int VEC_WIDTH = 4;
-
-#ifdef FBGEMM_USE_SUBWARP_SHUFFLE
-    const unsigned int shfl_sync_mask =
-        ((1L << kThreadGroupSize) - 1) <<
-        (threadIdx.y % (kWarpSize / kThreadGroupSize) * kThreadGroupSize);
-#else
-    const unsigned int shfl_sync_mask = 0xffffffffu;
-#endif
-
-    int32_t t, b, output_offset;
-    {% if not dense %}
-    if (var_batch_size) {
-        // Compute t and b from var_B_metadata
-        if (threadIdx.x == 0) {
-            // binary_search_range takes inclusive sumscan array
-            binary_search_range(&t, var_B_metadata + 1, b_t, T);
-            b = b_t - var_B_metadata[t];
-            {% if not nobag %}
-            // TODO: check output offset for INT8 and nobag
-            output_offset = var_B_metadata[T + 1 + t];
-            {% endif %}
-        }
-        t = SHFL_SYNC(t, 0);
-        b = SHFL_SYNC(b, 0);
-        {% if not nobag %}
-        output_offset = SHFL_SYNC(output_offset, 0);
-        {% endif %}
-    }
-    else {
-    {% endif %}
-        fd_B.DivMod(b_t, &t, &b);
-    {% if not dense %}
-    } // if (var_batch_size)
-    {% endif %}
+    int32_t t;
+    int32_t b;
+    fd_B.DivMod(b_t, &t, &b);
     int64_t weights_offset = weights_offsets[t];
     {% if not nobag %}
     int32_t D_start = D_offsets[t];
     int32_t D_end = D_offsets[t + 1];
     int32_t D = D_end - D_start;
-    {% if not dense and not nobag %}
-    output_t* shifted_output = var_batch_size ? &output[0][output_offset + b * D] : nullptr;
     {% endif %}
-    {% endif %}
-    index_t indices_start = offsets[b_t];
-    index_t indices_end = offsets[b_t + 1];
+    index_t indices_start = offsets[t * B + b];
+    index_t indices_end = offsets[t * B + b + 1];
     int32_t L = indices_end - indices_start;
     const emb_t* __restrict__ weights;
     {% if not dense %}
@@ -267,6 +231,15 @@ __global__ void {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if noba
     if (std::is_same<emb_t, uint8_t>::value) {
         D_emb += kINT8QparamsBytes;
     }
+
+    constexpr int VEC_WIDTH = 4;
+#ifdef FBGEMM_USE_SUBWARP_SHUFFLE
+    const unsigned int shfl_sync_mask =
+        ((1L << kThreadGroupSize) - 1) <<
+        (threadIdx.y % (kWarpSize / kThreadGroupSize) * kThreadGroupSize);
+#else
+    const unsigned int shfl_sync_mask = 0xffffffffu;
+#endif
 
     {% if not nobag %}
     const float inv_L = (mean_pooling && L != 0) ? static_cast<float>(1.0) / L: static_cast<float>(1.0);
@@ -369,30 +342,14 @@ __global__ void {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if noba
 
     {% if not nobag %}
     if (!std::is_same<output_t, uint8_t>::value) {
-        {% if not dense %}
-        if (var_batch_size) {
-            #pragma unroll kMaxVecsPerThread
-            for (int32_t i = 0;
-            i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
-            ++i) {
-                accumulators[i].mul_(inv_L);
-                int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
-                accumulators[i].store(shifted_output + d);
-            }
+        #pragma unroll kMaxVecsPerThread
+        for (int32_t i = 0;
+        i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
+        ++i) {
+            accumulators[i].mul_(inv_L);
+            int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
+            accumulators[i].store(&output[b][D_start + d]);
         }
-        else {
-        {% endif %}
-            #pragma unroll kMaxVecsPerThread
-            for (int32_t i = 0;
-            i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
-            ++i) {
-                accumulators[i].mul_(inv_L);
-                int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
-                accumulators[i].store(&output[b][D_start + d]);
-            }
-        {% if not dense %}
-        } // if (var_batch_size)
-        {% endif %}
     } else {
         // apply per feature row-wise int8
         float thread_local_min = std::numeric_limits<float>::max();
@@ -454,22 +411,13 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
     Tensor lxu_cache_locations,
     {% endif %}
     int64_t output_dtype,
-    int64_t unused{% if not dense %},
-    {% if not nobag %}
-    const c10::optional<std::vector<int64_t>>& D_offsets_vec,
-    {% endif %}
-    const c10::optional<Tensor>& var_B_metadata,
-    const c10::optional<std::vector<int64_t>>& var_B_metadata_vec
-    {% endif %}
+    int64_t unused
 ) {
     TENSOR_ON_CUDA_GPU(dev_weights);
     {% if not dense %}
     TENSOR_ON_CUDA_GPU(uvm_weights);
     TENSOR_ON_CUDA_GPU(lxu_cache_weights);
     TENSOR_ON_CUDA_GPU(weights_placements);
-    if (var_B_metadata.has_value()) {
-        TENSOR_ON_CUDA_GPU(var_B_metadata.value());
-    }
     {% endif %}
     TENSOR_ON_CUDA_GPU(weights_offsets);
     {% if not nobag %}
@@ -495,8 +443,7 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
     {% endif %}
     TORCH_CHECK(T > 0);
     // offsets = [B x T  + 1]
-    const auto total_B = offsets.size(0) - 1;
-    int32_t B = (total_B) / T;
+    int32_t B = (offsets.size(0) - 1) / T;
     TORCH_CHECK(B >= 0);
     {% if not nobag %}
     TORCH_CHECK(total_D > 0);
@@ -525,48 +472,11 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
     if (o_dtype == SparseType::INT8) {
         total_adjusted_D += T * kINT8QparamsBytes;
     }
-    {% if not dense %}
-    if (var_B_metadata.has_value()) {
-        TORCH_CHECK(
-            var_B_metadata_vec.has_value(),
-            "Variable batch size TBE requires var_B_metadata_vec"
-        );
-        TORCH_CHECK(
-            D_offsets_vec.has_value(),
-            "Variable batch size TBE requires D_offsets_vec"
-        );
-        TORCH_CHECK(D_offsets_vec.value().size() == T + 1);
-        TORCH_CHECK(var_B_metadata.value().numel() == 2 * (T + 1));
-        TORCH_CHECK(var_B_metadata_vec.value().size() == var_B_metadata.value().numel());
-
-        const std::vector<int64_t>& var_B_metadata_v = var_B_metadata_vec.value();
-        const std::vector<int64_t>& D_offsets_v = D_offsets_vec.value();
-
-        int64_t output_size = 0;
-        for (int t = 0; t < T; t++) {
-          auto B_t = var_B_metadata_v[t + 1] - var_B_metadata_v[t];
-          auto D_t = (D_offsets_v[t + 1] - D_offsets_v[t]) + (o_dtype == SparseType::INT8 ? kINT8QparamsBytes : 0);
-          output_size += B_t * D_t;
-        }
-
-        // Use a 2D tensor to make it compatible with 2D PackedTensorsAccessor of other output
-        output = at::empty({1, output_size}, dev_weights.options().dtype(getScalarType(o_dtype)));
-    }
-    else {
-    {% endif %}
-        output = at::empty({B, total_adjusted_D}, dev_weights.options().dtype(getScalarType(o_dtype)));
-    {% if not dense %}
-    } // if (var_B_metadata.has_value())
-    {% endif %}
+    output = at::empty({B, total_adjusted_D}, dev_weights.options().dtype(getScalarType(o_dtype)));
 
     {% endif %}
 
     if (B == 0) {
-        {% if not dense and not nobag %}
-        if (var_B_metadata.has_value()) {
-            output = output.reshape({-1});
-        }
-        {% endif %}
         return output;
     }
 
@@ -584,13 +494,12 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
         bool use_lxu_cache = lxu_cache_weights.numel() > 0;
         {% endif %}
         {% if not nobag %}
-        {% for var_batch_size in ["false", "true"] %}
         {% for use_cache in ["false", "true"] %}
         // The dense case does not have cache so we have to generate code for
-        // only one case (value of use_cache/var_batch_size does not matter)
-        {% if (not dense) or (use_cache == "true" and var_batch_size == "true") %}
+        // only one case (value of use_cache does not matter)
+        {% if (not dense) or (use_cache == "true") %}
         {% if not dense %}
-        if (use_lxu_cache == {{ use_cache }} && var_B_metadata.has_value() == {{ var_batch_size }}) {
+        if (use_lxu_cache == {{ use_cache }}) {
         {% endif %}
             // kMaxElemPerThread is # of elements handled by thread if we use a full warp for a row
             // We consider kMaxElemPerThread 1 and 2, and then a multiple of 4.
@@ -606,11 +515,11 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
                 constexpr int kThreadGroupSize = kWarpSize;
 #endif
                 {% if not dense %}
-                split_embedding_codegen_forward_{{ wdesc }}_kernel<emb_t, cache_t, output_t, {{ use_cache }}, {{ var_batch_size }}, int64_t, kMaxVecsPerThread, kThreadGroupSize><<<
+                split_embedding_codegen_forward_{{ wdesc }}_kernel<emb_t, cache_t, output_t, {{ use_cache }}, int64_t, kMaxVecsPerThread, kThreadGroupSize><<<
                 {% else %}
                 dense_embedding_codegen_forward_{{ wdesc }}_kernel<emb_t, cache_t, output_t, int64_t, kMaxVecsPerThread, kThreadGroupSize><<<
                 {% endif %}
-                    div_round_up(total_B, kForwardMaxThreads / kThreadGroupSize),
+                    div_round_up((B * T), kForwardMaxThreads / kThreadGroupSize),
                     dim3(kThreadGroupSize, kForwardMaxThreads / kThreadGroupSize),
                     0,
                     at::cuda::getCurrentCUDAStream()>>>(
@@ -621,7 +530,7 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
                     weights_placements.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
                     {% endif %}
                     weights_offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
-                            D_offsets.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+                    D_offsets.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
                     FixedDivisor(B),
                     indices.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
                     offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
@@ -631,26 +540,22 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
                     {% endif %}
                     {% if not dense %}
                     lxu_cache_locations.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
-                    {% if var_batch_size == "true" %} var_B_metadata.value().data_ptr<int32_t>(), {% else %} nullptr, {% endif %}
                     {% endif %}
                     output.packed_accessor64<
                         output_t,
                         2,
                         at::RestrictPtrTraits>()
                     );
-                {% if not dense and not nobag and var_batch_size == "true" %}
-                output = output.reshape({-1});
-                {% endif %}
+
                 return;
             }
             {% endif %}
             {% endfor %}
         {% if not dense %}
-        } // if (use_lxu_cache == {{ use_cache }} && var_B_metadata.has_value() == {{ var_batch_size }})
+        } // if (use_lxu_cache == {{ use_cache }})
         {% endif %}
-        {% endif %} // if (not dense) or (use_cache == "true" and var_batch_size == "true")
+        {% endif %} // if (not dense) or (use_cache == "true")
         {% endfor %} // for use_cache in ["false", "true"]
-        {% endfor %} // for var_batch_size in ["false", "true"]
         {% else %}
         {% for kEmbeddingSize in [4, 8, 16, 32] %}
         if (D <= {{ kEmbeddingSize }}) {
@@ -685,18 +590,17 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
             return;
         }
         {% endfor %}
-        {% for var_batch_size in ["false", "true"] %}
         {% for use_cache in ["false", "true"] %}
         // The dense case does not have cache so we have to generate code for
-        // only one case (value of use_cache/var_batch_size does not matter)
-        {% if (not dense) or (use_cache == "true" and var_batch_size == "true") %}
+        // only one case (value of use_cache does not matter)
+        {% if (not dense) or (use_cache == "true") %}
         {% if not dense %}
-        if (use_lxu_cache == {{ use_cache }} && var_B_metadata.has_value() == {{ var_batch_size }}) {
-            split_embedding_nobag_codegen_forward_unweighted_kernel<emb_t, cache_t, output_t, {{ use_cache }}, {{ var_batch_size }}, int64_t><<<
+        if (use_lxu_cache == {{ use_cache }}) {
+            split_embedding_nobag_codegen_forward_unweighted_kernel<emb_t, cache_t, output_t, {{ use_cache }}, int64_t><<<
         {% else %}
             dense_embedding_nobag_codegen_forward_unweighted_kernel<emb_t, cache_t, output_t, int64_t><<<
         {% endif %}
-                div_round_up(total_B, kForwardMaxThreads / kWarpSize),
+                div_round_up((B * T), kForwardMaxThreads / kWarpSize),
                 dim3(kWarpSize, kForwardMaxThreads / kWarpSize),
                 0,
                 at::cuda::getCurrentCUDAStream()>>>(
@@ -713,23 +617,18 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
                 offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
                 {% if not dense %}
                 lxu_cache_locations.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
-                {% if var_batch_size == "true" %} var_B_metadata.value().data_ptr<int32_t>(), {% else %} nullptr, {% endif %}
                 {% endif %}
                 output.packed_accessor64<
                     output_t,
                     2,
                     at::RestrictPtrTraits>()
                 );
-                {% if not dense and not nobag and var_batch_size == "true" %}
-                output = output.reshape({-1});
-                {% endif %}
                 return;
         {% if not dense %}
-        } // if (use_lxu_cache == {{ use_cache }} && var_B_metadata.has_value() == {{ var_batch_size }})
+        } // if (use_lxu_cache == {{ use_cache }})
         {% endif %}
-        {% endif %} // if (not dense) or (use_cache == "true" and var_batch_size == "true")
+        {% endif %} // if (not dense) or (use_cache == "true")
         {% endfor %} // for use_cache in ["false", "true"]
-        {% endfor %} // for var_batch_size in ["false", "true"]
         {% endif %}
         });
 

--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
@@ -3158,49 +3158,4 @@ __inline__ __device__ void inclusive_sum_scan_kernel(
   }
 }
 
-template <typename scalar_t>
-__device__ __forceinline__ void binary_search_range(
-    int* found,
-    const scalar_t* arr,
-    const scalar_t target,
-    const int num_entries) {
-  const int last_entry = num_entries - 1;
-  int start = 0, end = last_entry;
-  int found_ = -1;
-  while (start <= end) {
-    int mid = start + (end - start) / 2;
-    scalar_t mid_offset = arr[mid];
-    if (target == mid_offset) {
-      if (mid != last_entry && target != arr[last_entry]) {
-        // Do linear scan in case of duplicate data (We assume that the
-        // number of duplicates is small.  This can we very bad if the
-        // number of duplicates is large)
-        for (int i = mid + 1; i < num_entries; i++) {
-          if (target != arr[i]) {
-            found_ = i;
-            break;
-          }
-        }
-      }
-      break;
-    } else if (target < mid_offset) {
-      if (mid == 0) {
-        found_ = 0;
-        break;
-      } else if (mid - 1 >= 0 && target > arr[mid - 1]) {
-        found_ = mid;
-        break;
-      }
-      end = mid - 1;
-    } else {
-      if (mid + 1 <= last_entry && target < arr[mid + 1]) {
-        found_ = mid + 1;
-        break;
-      }
-      start = mid + 1;
-    }
-  }
-  *found = found_;
-}
-
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.cuh
@@ -10,14 +10,6 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
-// These values are adjusted in backward based on B and T
-constexpr int DEFAULT_INFO_NUM_BITS = 32;
-constexpr int DEFAULT_INFO_B_NUM_BITS = 26;
-constexpr uint32_t DEFAULT_INFO_B_MASK = (1u << DEFAULT_INFO_B_NUM_BITS) - 1;
-constexpr int32_t MAX_T =
-    (1u << (DEFAULT_INFO_NUM_BITS - DEFAULT_INFO_B_NUM_BITS)) - 1;
-constexpr int32_t MAX_B = (1u << DEFAULT_INFO_B_NUM_BITS) - 1;
-
 /**
  * "Transpose" embedding inputs by sorting indices by their values.
  * Logically this transpose compressed sparse row (CSR) representation
@@ -36,14 +28,7 @@ transpose_embedding_input(
     int64_t total_hash_size_bits,
     at::Tensor indices,
     at::Tensor offsets,
-    c10::optional<at::Tensor> var_B_metadata,
-    bool nobag = false,
-    int64_t info_B_num_bits = 0);
-
-std::tuple<int64_t, int64_t>
-get_infos_metadata(at::Tensor unused, int64_t B, int64_t T);
-
-std::tuple<int32_t, uint32_t> adjust_info_B_num_bits(int32_t B, int32_t T);
+    bool nobag = false);
 
 // Use these functions instead of directly calling cub functions
 // to reduce code size and compilation time.

--- a/fbgemm_gpu/src/jagged_tensor_ops.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops.cu
@@ -2243,6 +2243,51 @@ std::vector<Tensor> stacked_jagged_1d_to_dense_gpu(
   return padded_values_per_key;
 }
 
+template <typename scalar_t>
+__device__ __forceinline__ void binary_search_range(
+    int* found,
+    const scalar_t* arr,
+    const scalar_t target,
+    const int num_entries) {
+  const int last_entry = num_entries - 1;
+  int start = 0, end = last_entry;
+  int found_ = -1;
+  while (start <= end) {
+    int mid = start + (end - start) / 2;
+    scalar_t mid_offset = arr[mid];
+    if (target == mid_offset) {
+      if (mid != last_entry && target != arr[last_entry]) {
+        // Do linear scan in case of duplicate data (We assume that the
+        // number of duplicates is small.  This can we very bad if the
+        // number of duplicates is large)
+        for (int i = mid + 1; i < num_entries; i++) {
+          if (target != arr[i]) {
+            found_ = i;
+            break;
+          }
+        }
+      }
+      break;
+    } else if (target < mid_offset) {
+      if (mid == 0) {
+        found_ = 0;
+        break;
+      } else if (mid - 1 >= 0 && target > arr[mid - 1]) {
+        found_ = mid;
+        break;
+      }
+      end = mid - 1;
+    } else {
+      if (mid + 1 <= last_entry && target < arr[mid + 1]) {
+        found_ = mid + 1;
+        break;
+      }
+      start = mid + 1;
+    }
+  }
+  *found = found_;
+}
+
 template <typename index_t, typename offset_t, typename scalar_t>
 __global__ __launch_bounds__(kMaxThreads) void jagged_index_select_2d_kernel(
     scalar_t* output,

--- a/fbgemm_gpu/src/split_embeddings_utils.cpp
+++ b/fbgemm_gpu/src/split_embeddings_utils.cpp
@@ -13,8 +13,6 @@
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
-      "transpose_embedding_input(Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, Tensor? var_B_metadata=None, bool nobag=False, int info_B_num_bits=26) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)");
-  m.def("get_infos_metadata(Tensor unused, int B, int T) -> (int, int)");
+      "transpose_embedding_input(Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, bool nobag=False) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)");
   DISPATCH_TO_CUDA("transpose_embedding_input", transpose_embedding_input);
-  DISPATCH_TO_CUDA("get_infos_metadata", get_infos_metadata);
 }

--- a/fbgemm_gpu/src/split_embeddings_utils.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils.cu
@@ -59,79 +59,71 @@ using Tensor = at::Tensor;
 
 using namespace fbgemm_gpu;
 
-template <typename index_t, typename info_acc_t, bool nobag>
+template <typename index_t>
 __global__ __launch_bounds__(kMaxThreads) void linearize_index_kernel(
     const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         hash_size_cumsum,
     const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
     const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
-    const int32_t* __restrict__ var_B_metadata,
-    const int32_t info_B_num_bits,
-    const int32_t max_T,
-    const int32_t max_B,
-    at::PackedTensorAccessor32<info_acc_t, 1, at::RestrictPtrTraits> infos,
+    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> infos,
     at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         linear_indices) {
   const int32_t T = hash_size_cumsum.size(0) - 1;
+  const int32_t B = (offsets.size(0) - 1) / T;
   const int32_t b_t = blockIdx.x * blockDim.x + threadIdx.x;
-  int32_t b, t;
-  const auto total_B = offsets.size(0) - 1;
-  const bool valid = b_t < total_B;
-
-  // Use variable batch size
-  if (var_B_metadata != nullptr && valid) {
-    // TODO: Check if this is expensive because every thread executes this
-    // Complexity is log(T).
-    binary_search_range(&t, var_B_metadata + 1, b_t, T);
-    b = b_t - var_B_metadata[t];
-  } else {
-    const int32_t B = total_B / T;
-    b = b_t % B;
-    t = b_t / B;
-  }
+  const int32_t b = b_t % B;
+  const int32_t t = b_t / B;
+  const bool valid = t < T;
 
   const index_t hash_offset = valid ? hash_size_cumsum[t] : -1;
-  const index_t indices_start = valid ? offsets[b_t] : -1;
-  const int32_t L = valid ? offsets[b_t + 1] - indices_start : 0;
+  const index_t indices_start = valid ? offsets[t * B + b] : -1;
+  const int32_t L = valid ? offsets[t * B + b + 1] - indices_start : 0;
   const int32_t lane_id = threadIdx.x % fbgemm_gpu::kWarpSize;
 
-  // Compile-time conditional
-  if (nobag) {
-    for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
-      const index_t indices_start_warp =
-          fbgemm_gpu::shfl_sync(indices_start, j);
-      const int32_t t_warp = fbgemm_gpu::shfl_sync(t, j);
-      const int32_t L_warp = fbgemm_gpu::shfl_sync(L, j);
-      const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
-      for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
-        const index_t idx = __ldg(&indices[indices_start_warp + i]);
-        const int64_t l_t = (indices_start_warp + i) * T + t_warp;
-        infos[indices_start_warp + i] = l_t;
-        linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
-      }
+  for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
+    const index_t indices_start_warp = fbgemm_gpu::shfl_sync(indices_start, j);
+    const int32_t b_t_warp = fbgemm_gpu::shfl_sync(b_t, j);
+    const int32_t L_warp = fbgemm_gpu::shfl_sync(L, j);
+    const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
+    for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
+      const index_t idx = __ldg(&indices[indices_start_warp + i]);
+      infos[indices_start_warp + i] = b_t_warp;
+      linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
     }
-  } else {
-    // Store t in upper (32 - DEFAULT_INFO_B_NUM_BITS).
-    // Store b in lower (DEFAULT_INFO_B_NUM_BITS).
-    uint32_t info = 0;
-    if (valid) {
-      CUDA_KERNEL_ASSERT(t < max_T)
-      CUDA_KERNEL_ASSERT(b < max_B)
-      info = (reinterpret_cast<uint32_t*>(&t)[0] << info_B_num_bits) |
-          reinterpret_cast<uint32_t*>(&b)[0];
-    }
-    for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
-      const index_t indices_start_warp =
-          fbgemm_gpu::shfl_sync(indices_start, j);
-      const uint32_t info_warp = fbgemm_gpu::shfl_sync(info, j);
-      const int32_t L_warp = fbgemm_gpu::shfl_sync(L, j);
-      const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
-      for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
-        const index_t idx = __ldg(&indices[indices_start_warp + i]);
-        reinterpret_cast<uint32_t*>(&infos[0])[indices_start_warp + i] =
-            info_warp;
-        linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
-      }
+  }
+}
+
+template <typename index_t>
+__global__ __launch_bounds__(kMaxThreads) void nobag_linearize_index_kernel(
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
+        hash_size_cumsum,
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
+    at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> infos,
+    at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
+        linear_indices) {
+  const int32_t T = hash_size_cumsum.size(0) - 1;
+  const int32_t B = (offsets.size(0) - 1) / T;
+  const int32_t b_t = blockIdx.x * blockDim.x + threadIdx.x;
+  const int32_t b = b_t % B;
+  const int32_t t = b_t / B;
+  const bool valid = t < T;
+
+  const index_t hash_offset = valid ? hash_size_cumsum[t] : -1;
+  const index_t indices_start = valid ? offsets[t * B + b] : -1;
+  const int32_t L = valid ? offsets[t * B + b + 1] - indices_start : 0;
+  const int32_t lane_id = threadIdx.x % fbgemm_gpu::kWarpSize;
+
+  for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
+    const index_t indices_start_warp = fbgemm_gpu::shfl_sync(indices_start, j);
+    const int32_t t_warp = fbgemm_gpu::shfl_sync(t, j);
+    const int32_t L_warp = fbgemm_gpu::shfl_sync(L, j);
+    const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
+    for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
+      const index_t idx = __ldg(&indices[indices_start_warp + i]);
+      const int64_t l_t = (indices_start_warp + i) * T + t_warp;
+      infos[indices_start_warp + i] = l_t;
+      linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
     }
   }
 }
@@ -149,12 +141,9 @@ transpose_embedding_input(
     int64_t total_hash_size_bits,
     Tensor indices,
     Tensor offsets,
-    c10::optional<Tensor> var_B_metadata,
-    bool nobag,
-    int64_t info_B_num_bits) {
-  TORCH_CHECK(nobag || info_B_num_bits > 0);
-
-  const int32_t total_B = offsets.size(0) - 1;
+    bool nobag) {
+  const int32_t T = hash_size_cumsum.size(0) - 1;
+  const int32_t B = (offsets.size(0) - 1) / T;
 
   auto infos = at::empty_like(
       indices, indices.options().dtype(nobag ? at::kLong : at::kInt));
@@ -168,33 +157,37 @@ transpose_embedding_input(
 
   using at::RestrictPtrTraits;
 
-#define INVOKE_LINEARIZE_INDEX_KERNEL(INFO_ACC_T, NOBAG)                       \
-  linearize_index_kernel<index_t, INFO_ACC_T, NOBAG>                           \
-      <<<div_round_up(total_B, kMaxThreads),                                   \
-         kMaxThreads,                                                          \
-         0,                                                                    \
-         at::cuda::getCurrentCUDAStream()>>>(                                  \
-          hash_size_cumsum.packed_accessor32<index_t, 1, RestrictPtrTraits>(), \
-          indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),          \
-          offsets.packed_accessor32<index_t, 1, RestrictPtrTraits>(),          \
-          var_B_metadata.has_value()                                           \
-              ? var_B_metadata.value().data_ptr<int32_t>()                     \
-              : nullptr,                                                       \
-          info_B_num_bits,                                                     \
-          (1 << (DEFAULT_INFO_NUM_BITS - info_B_num_bits)) - 1,                \
-          (1 << info_B_num_bits) - 1,                                          \
-          infos.packed_accessor32<INFO_ACC_T, 1, RestrictPtrTraits>(),         \
-          linear_indices.packed_accessor32<index_t, 1, RestrictPtrTraits>())
-
   AT_DISPATCH_INDEX_TYPES(
       infos.scalar_type(), "transpose_embedding_input1", [&] {
         using info_t = index_t;
         AT_DISPATCH_INDEX_TYPES(
             indices.scalar_type(), "transpose_embedding_input2", [&] {
               if (!nobag) {
-                INVOKE_LINEARIZE_INDEX_KERNEL(int32_t, false);
+                linearize_index_kernel<<<
+                    div_round_up(B * T, kMaxThreads),
+                    kMaxThreads,
+                    0,
+                    at::cuda::getCurrentCUDAStream()>>>(
+                    hash_size_cumsum
+                        .packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+                    indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+                    offsets.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+                    infos.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
+                    linear_indices
+                        .packed_accessor32<index_t, 1, RestrictPtrTraits>());
               } else {
-                INVOKE_LINEARIZE_INDEX_KERNEL(int64_t, true);
+                nobag_linearize_index_kernel<<<
+                    div_round_up(B * T, kMaxThreads),
+                    kMaxThreads,
+                    0,
+                    at::cuda::getCurrentCUDAStream()>>>(
+                    hash_size_cumsum
+                        .packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+                    indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+                    offsets.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+                    infos.packed_accessor32<int64_t, 1, RestrictPtrTraits>(),
+                    linear_indices
+                        .packed_accessor32<index_t, 1, RestrictPtrTraits>());
               }
               C10_CUDA_KERNEL_LAUNCH_CHECK();
               {
@@ -270,8 +263,6 @@ transpose_embedding_input(
   auto sorted_linear_indices_cumulative_run_lengths =
       asynchronous_complete_cumsum(sorted_linear_indices_run_lengths);
 
-#undef INVOKE_LINEARIZE_INDEX_KERNEL
-
   return {
       linear_indices,
       linear_indices_sorted,
@@ -280,55 +271,6 @@ transpose_embedding_input(
       sorted_linear_indices_run_lengths,
       sorted_linear_indices_num_runs,
       sorted_linear_indices_cumulative_run_lengths};
-}
-
-std::tuple<int64_t, int64_t>
-get_infos_metadata(Tensor unused, int64_t B, int64_t T) {
-  return adjust_info_B_num_bits(B, T);
-}
-
-std::tuple<int32_t, uint32_t> adjust_info_B_num_bits(int32_t B, int32_t T) {
-  int32_t info_B_num_bits = DEFAULT_INFO_B_NUM_BITS;
-  uint32_t info_B_mask = DEFAULT_INFO_B_MASK;
-  uint32_t max_T = MAX_T;
-  uint32_t max_B = MAX_B;
-  bool invalid_T = T > max_T;
-  bool invalid_B = B > max_B;
-
-  TORCH_CHECK(
-      !(invalid_T && invalid_B),
-      "Not enough infos bits to accommodate T and B in linearize_index_kernel. Default num bits = ",
-      DEFAULT_INFO_NUM_BITS);
-
-  if (invalid_T) {
-    // Reduce info_B_num_bits
-    while (invalid_T && !invalid_B && info_B_num_bits > 0) {
-      info_B_num_bits--;
-      max_T = ((max_T + 1) << 1) - 1;
-      max_B = ((max_B + 1) >> 1) - 1;
-      invalid_T = T > max_T;
-      invalid_B = B > max_B;
-    }
-  } else if (invalid_B) {
-    // Increase info_B_num_bits
-    while (!invalid_T && invalid_B && info_B_num_bits < DEFAULT_INFO_NUM_BITS) {
-      info_B_num_bits++;
-      max_T = ((max_T + 1) >> 1) - 1;
-      max_B = ((max_B + 1) << 1) - 1;
-      invalid_T = T > max_T;
-      invalid_B = B > max_B;
-    }
-  }
-
-  TORCH_CHECK(
-      !invalid_T && !invalid_B,
-      "Not enough infos bits to accommodate T and B in linearize_index_kernel. Default num bits = ",
-      DEFAULT_INFO_NUM_BITS);
-
-  // Recompute info_B_mask using new info_B_num_bits
-  info_B_mask = (1u << info_B_num_bits) - 1;
-
-  return {info_B_num_bits, info_B_mask};
 }
 
 #define DEF_RADIX_SORT_PAIRS_FN(KeyT, ValueT)                        \


### PR DESCRIPTION
Summary:
This diff is reverting D42979993 (https://github.com/pytorch/FBGEMM/commit/930861b938f6993f08a7e8cec740168f3f363ecd)
D42979993 (https://github.com/pytorch/FBGEMM/commit/930861b938f6993f08a7e8cec740168f3f363ecd): [fbgemm_gpu] Add variable batch sizes to TBE training for GPU (backend) by sryap has been identified to be causing the following test or build failures:

Tests affected:
- [torchrec/distributed/tests:test_dist_data - torchrec.distributed.tests.test_dist_data.PooledEmbeddingsReduceScatterTest: test_pooled_embedding_reduce_scatter](https://www.internalfb.com/intern/test/844425002162920/)

Here's the Multisect link:
https://www.internalfb.com/intern/testinfra/multisect/1558914
Here are the tasks that are relevant to this breakage:
T139270782: 7 tests started failing for oncall torchrec in the last 2 weeks
We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

Reviewed By: sryap

Differential Revision: D43073425

