### PR TITLE
Refactor jagged_index_select and add impl for CPU

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -739,5 +739,26 @@ std::vector<at::Tensor> group_index_add_cuda(
     const int num_output_rows,
     const int num_cols,
     const int num_groups);
+
+std::vector<at::Tensor> jagged_index_select_2d(
+    const at::Tensor& values,
+    const at::Tensor& lengths,
+    const at::Tensor& indices);
+
+at::Tensor jagged_index_select_2d_forward_cpu(
+    const at::Tensor& values,
+    const at::Tensor& indices,
+    const at::Tensor& input_offsets,
+    const at::Tensor& output_offsets,
+    const int64_t num_dense_output_rows);
+
+at::Tensor jagged_index_add_2d_forward_cpu(
+    const at::Tensor& grad,
+    const at::Tensor& indices,
+    const at::Tensor& grad_offsets,
+    const at::Tensor& output_offsets,
+    const int64_t num_dense_grad_rows,
+    const int64_t num_output_rows);
+
 #endif
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
@@ -330,3 +330,49 @@ struct StackArray {
             false, "unsupported number of jagged dim ", num_jagged_dim);      \
     }                                                                         \
   });
+
+// TODO: Merge this with the device code
+template <typename scalar_t>
+void binary_search_range_cpu(
+    int* found,
+    const scalar_t* arr,
+    const scalar_t target,
+    const int num_entries) {
+  const int last_entry = num_entries - 1;
+  int start = 0, end = last_entry;
+  int found_ = -1;
+  while (start <= end) {
+    int mid = start + (end - start) / 2;
+    scalar_t mid_offset = arr[mid];
+    if (target == mid_offset) {
+      if (mid != last_entry && target != arr[last_entry]) {
+        // Do linear scan in case of duplicate data (We assume that the
+        // number of duplicates is small.  This can we very bad if the
+        // number of duplicates is large)
+        for (int i = mid + 1; i < num_entries; i++) {
+          if (target != arr[i]) {
+            found_ = i;
+            break;
+          }
+        }
+      }
+      break;
+    } else if (target < mid_offset) {
+      if (mid == 0) {
+        found_ = 0;
+        break;
+      } else if (mid - 1 >= 0 && target > arr[mid - 1]) {
+        found_ = mid;
+        break;
+      }
+      end = mid - 1;
+    } else {
+      if (mid + 1 <= last_entry && target < arr[mid + 1]) {
+        found_ = mid + 1;
+        break;
+      }
+      start = mid + 1;
+    }
+  }
+  *found = found_;
+}

--- a/fbgemm_gpu/src/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_cpu.cpp
@@ -2520,8 +2520,6 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "index_select_dim0(Tensor input, Tensor indices, int? consecutive_range_start=0, int? consecutive_range_length=0, bool? skip_indices_sorting_fwd=None) -> Tensor");
   m.def(
       "group_index_select_dim0(Tensor[] input_group, Tensor[] indices_group) -> Tensor[]");
-  m.def(
-      "jagged_index_select(Tensor values, Tensor lengths, Tensor indices) -> Tensor[]");
   // This is an one-off op to be used in split_embedding_utils.py for zipf
   // generation w/o replacement along dim=-1. If requires_unique=True, find
   // smallest unique k.  If the number of unique elements is less than k,


### PR DESCRIPTION
Summary:
Changes are as follows:

- Update variable names of jagged_index_add_2d for GPU
- Use a single autograd function to dispatch the op on CPU and GPU
- Add an implementation on CPU using `at::parallel_for` to parallelize
  work on multiple threads.  For jagged_index_add_2d (backward), locks
  are used instead of atomic add (one lock per row) to manage add
  conflict between threads.

Differential Revision: D43111264

