### PR TITLE
[T145005253] Fix the build scripts infrastructure

### DIFF
--- a/.github/scripts/build_wheel.bash
+++ b/.github/scripts/build_wheel.bash
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 # Exit on failure
 set -e
 
@@ -77,14 +82,12 @@ setup_miniconda "$miniconda_prefix"
 echo "## 2. Create build_binary environment"
 ################################################################################
 
-create_conda_environment build_binary "$python_version" "$pytorch_channel_name" "$cuda_version"
+create_conda_pytorch_environment build_binary "$python_version" "$pytorch_channel_name" "$cuda_version" || exit 1
 
 cd fbgemm_gpu
 
 # cuDNN is needed to "build" FBGEMM
-install_cudnn "$miniconda_prefix/build_only/cudnn"
-export CUDNN_INCLUDE_DIR="$miniconda_prefix/build_only/cudnn/include"
-export CUDNN_LIBRARY="$miniconda_prefix/build_only/cudnn/lib"
+install_cudnn build_binary "$miniconda_prefix/build_only/cudnn" "$cuda_version" || exit 1
 
 conda run -n build_binary python -m pip install -r requirements.txt
 

--- a/.github/scripts/build_wheel.bash
+++ b/.github/scripts/build_wheel.bash
@@ -82,12 +82,12 @@ setup_miniconda "$miniconda_prefix"
 echo "## 2. Create build_binary environment"
 ################################################################################
 
-create_conda_pytorch_environment build_binary "$python_version" "$pytorch_channel_name" "$cuda_version" || exit 1
+create_conda_pytorch_environment build_binary "$python_version" "$pytorch_channel_name" "$cuda_version"
 
 cd fbgemm_gpu
 
 # cuDNN is needed to "build" FBGEMM
-install_cudnn build_binary "$miniconda_prefix/build_only/cudnn" "$cuda_version" || exit 1
+install_cudnn build_binary "$miniconda_prefix/build_only/cudnn" "$cuda_version"
 
 conda run -n build_binary python -m pip install -r requirements.txt
 

--- a/.github/scripts/setup_env.bash
+++ b/.github/scripts/setup_env.bash
@@ -1,68 +1,595 @@
 #!/bin/bash
 
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+################################################################################
+# Utility Functions
+################################################################################
+
+print_exec () {
+    echo "+ $@"
+    echo ""
+    $@
+}
+
+test_python_import () {
+  env_name="$1"
+  python_import="$2"
+  if [ "$python_import" == "" ]; then
+    echo "Usage: ${FUNCNAME[0]} ENV_NAME PYTHON_IMPORT"
+    echo "Example(s):"
+    echo "    ${FUNCNAME[0]} build_binary numpy"
+    return 1
+  fi
+
+  conda run -n "${env_name}" python -c "import ${python_import}"
+  if [ $? -eq 0 ]; then
+    echo "[CHECK] Python package ${python_import} found"
+  else
+    echo "[CHECK] Python package ${python_import} not found!"
+    return 1
+  fi
+}
+
+test_binpath () {
+  env_name="$1"
+  bin_name="$2"
+  if [ "$bin_name" == "" ]; then
+    echo "Usage: ${FUNCNAME[0]} ENV_NAME BIN_NAME"
+    echo "Example(s):"
+    echo "    ${FUNCNAME[0]} build_binary nvcc"
+    return 1
+  fi
+
+  conda run -n "${env_name}" which $bin_name
+  if [ $? -eq 0 ]; then
+    echo "[CHECK] Binary ${bin_name} found in PATH"
+  else
+    echo "[CHECK] Binary ${bin_name} not found in PATH!"
+    return 1
+  fi
+}
+
+test_env_var () {
+  env_name="$1"
+  env_key="$2"
+  if [ "$env_key" == "" ]; then
+    echo "Usage: ${FUNCNAME[0]} ENV_NAME ENV_KEY"
+    echo "Example(s):"
+    echo "    ${FUNCNAME[0]} build_binary CUDNN_INCLUDE_DIR"
+    return 1
+  fi
+
+  conda run -n "${env_name}" printenv "${env_key}"
+  if [ $? -eq 0 ]; then
+    echo "[CHECK] Environment variable ${env_key} is defined in the Conda environment"
+  else
+    echo "[CHECK] Environment variable ${env_key} is not defined in the Conda environment!"
+    return 1
+  fi
+}
+
+print_system_info () {
+  echo "################################################################################"
+  echo "# Print System Info"
+  echo "################################################################################"
+  echo ""
+
+  echo "Check ldd version"
+  print_exec ldd --version
+
+  echo "Check CPU info"
+  print_exec cat /proc/cpuinfo
+
+  echo "Check Linux distribution info"
+  print_exec cat /proc/version
+
+  echo "Check GPU info"
+  print_exec sudo yum install -y lshw
+  print_exec sudo lshw -C display
+}
+
+print_ec2_info () {
+  echo "################################################################################"
+  echo "# Print EC2 Instance Info"
+  echo "################################################################################"
+  echo ""
+
+  get_ec2_metadata() {
+    # Pulled from instance metadata endpoint for EC2
+    # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+    category=$1
+    curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
+  }
+
+  set -euo pipefail
+  echo "ami-id: $(get_ec2_metadata ami-id)"
+  echo "instance-id: $(get_ec2_metadata instance-id)"
+  echo "instance-type: $(get_ec2_metadata instance-type)"
+}
+
+
+################################################################################
+# Environment Setup and Install Functions
+################################################################################
+
 setup_miniconda () {
   miniconda_prefix="$1"
   if [ "$miniconda_prefix" == "" ]; then
-    echo "Usage: setup_miniconda MINICONDA_PREFIX_PATH"
+    echo "Usage: ${FUNCNAME[0]} MINICONDA_PREFIX_PATH"
     echo "Example:"
     echo "    setup_miniconda /home/user/tmp/miniconda"
-    exit 1
+    return 1
+  else
+    echo "################################################################################"
+    echo "# Setup Miniconda"
+    echo "################################################################################"
+    echo ""
   fi
+
+  # Download and install Miniconda if doesn't exist
   if [ ! -f "${miniconda_prefix}/bin/conda" ]; then
-    # Download miniconda if not exists
-    mkdir -p "$miniconda_prefix"
-    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-    bash miniconda.sh -b -p "$miniconda_prefix" -u
+    print_exec mkdir -p "$miniconda_prefix"
+
+    echo "[SETUP] Downloading the Miniconda installer ..."
+    print_exec wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+
+    echo "[SETUP] Installing Miniconda ..."
+    print_exec bash miniconda.sh -b -p "$miniconda_prefix" -u
+    print_exec rm -f miniconda.sh
+
+    echo "[SETUP] Reloading the bash configuration ..."
+    print_exec ${miniconda_prefix}/bin/conda init bash
+    print_exec . ~/.bashrc
   fi
+
+  echo "[SETUP] Updating Miniconda base packages ..."
+  print_exec conda update -n base -c defaults -y conda
+
+  # Print conda info
+  conda info
+
   # These variables will be exported outside
   export PATH="${miniconda_prefix}/bin:${PATH}"
   export CONDA="${miniconda_prefix}"
+
+  echo "[SETUP] Successfully set up Miniconda at ${miniconda_prefix}"
 }
 
 create_conda_environment () {
   env_name="$1"
   python_version="$2"
-  pytorch_channel_name="$3"
-  cuda_version="$4"
   if [ "$python_version" == "" ]; then
-    echo "Usage: create_conda_environment ENV_NAME PYTHON_VERSION PYTORCH_CHANNEL_NAME CUDA_VERSION"
+    echo "Usage: ${FUNCNAME[0]} ENV_NAME PYTHON_VERSION"
     echo "Example:"
-    echo "    create_conda_environment build_binary 3.10 pytorch-nightly 11.7.1"
-    exit 1
-  fi
-  # -y removes existing environment
-  conda create -y --name "$env_name" python="$python_version"
-  if [ "$cuda_version" == "" ]; then
-    # CPU version
-    conda install -n "$env_name" -y pytorch cpuonly -c "$pytorch_channel_name"
+    echo "    ${FUNCNAME[0]} build_binary 3.10"
+    return 1
   else
-    # GPU version
-    conda install -n "$env_name" -y pytorch cuda -c "$pytorch_channel_name" -c "nvidia/label/cuda-${cuda_version}"
+    echo "################################################################################"
+    echo "# Create Conda Environment"
+    echo "################################################################################"
+    echo ""
   fi
+
+  # -y removes any existing conda environment with the same name
+  echo "[SETUP] Creating new Conda environment (Python ${python_version}) ..."
+  print_exec conda create -y --name "${env_name}" python="${python_version}"
+
+  echo "[SETUP] Installed Python version: " `conda run -n "${env_name}" python --version`
+  echo "[SETUP] Successfully created Conda environment: ${env_name}"
+}
+
+install_pytorch_conda () {
+  env_name="$1"
+  pytorch_version="$2"
+  pytorch_cpu="$3"
+  if [ "$pytorch_version" == "" ]; then
+    echo "Usage: ${FUNCNAME[0]} ENV_NAME PYTORCH_VERSION [CPU]"
+    echo "Example(s):"
+    echo "    ${FUNCNAME[0]} build_binary 1.11.0      # Install a specific version"
+    echo "    ${FUNCNAME[0]} build_binary latest      # Install the latest stable release"
+    echo "    ${FUNCNAME[0]} build_binary test        # Install the pre-release"
+    echo "    ${FUNCNAME[0]} build_binary nightly 1   # Install the CPU variant of the nightly"
+    return 1
+  else
+    echo "################################################################################"
+    echo "# Install PyTorch (Conda)"
+    echo "################################################################################"
+    echo ""
+  fi
+
+  # Set package name and installation channel
+  if [ "$pytorch_version" == "nightly" ] || [ "$pytorch_version" == "test" ]; then
+    pytorch_package="pytorch"
+    pytorch_channel="pytorch-${pytorch_version}"
+  elif [ "$pytorch_version" == "latest" ]; then
+    pytorch_package="pytorch"
+    pytorch_channel="pytorch"
+  else
+    pytorch_package="pytorch==${pytorch_version}"
+    pytorch_channel="pytorch"
+  fi
+
+  # Install cpuonly if needed
+  if [ "$pytorch_cpu" != "" ]; then
+    pytorch_cpu=1
+    pytorch_package="${pytorch_package} cpuonly"
+  fi
+
+  # Install PyTorch packages
+  echo "[INSTALL] Installing ${pytorch_package} (${pytorch_version}, CPU=${pytorch_cpu}) through Conda using channel ${pytorch_channel} ..."
+  print_exec conda install -n "${env_name}" -y ${pytorch_package} -c "${pytorch_channel}"
+
+  # Run check for GPU variant
+  if [ "$pytorch_cpu" == "" ]; then
+    # Ensure that the PyTorch build is the GPU variant (i.e. contains cuDNN reference)
+    # This test usually applies to the PyTorch nightly builds
+    conda list -n "${env_name}" pytorch | grep cudnn
+    if [ $? -eq 0 ]; then
+      echo "[CHECK] The installed PyTorch ${pytorch_version} contains references to cuDNN"
+    else
+      echo "[CHECK] The installed PyTorch ${pytorch_version} appears to be the CPU-only version as it is missing references to cuDNN!"
+      return 1
+    fi
+  fi
+
+  # Check that PyTorch is importable
+  test_python_import $env_name torch.distributed || return 1
+
+  echo "[INSTALL] Successfully installed PyTorch ${pytorch_version} through Conda"
+}
+
+install_pytorch_pip () {
+  env_name="$1"
+  pytorch_version="$2"
+  pytorch_variant="$3"
+  if [ "$pytorch_variant" == "" ]; then
+    echo "Usage: ${FUNCNAME[0]} ENV_NAME PYTORCH_VERSION PYTORCH_VARIANT"
+    echo "Example(s):"
+    echo "    ${FUNCNAME[0]} build_binary 1.11.0 cpu        # Install the CPU variant a specific version"
+    echo "    ${FUNCNAME[0]} build_binary latest cpu        # Install the CPU variant of the latest stable version"
+    echo "    ${FUNCNAME[0]} build_binary test cu117        # Install the variant for CUDA 11.7"
+    echo "    ${FUNCNAME[0]} build_binary nightly rocm5.3   # Install the variant for ROCM 5.3"
+    return 1
+  else
+    echo "################################################################################"
+    echo "# Install PyTorch (PIP)"
+    echo "################################################################################"
+    echo ""
+  fi
+
+  # Set package name and installation channel
+  if [ "$pytorch_version" == "nightly" ] || [ "$pytorch_version" == "test" ]; then
+    pytorch_package="--pre torch"
+    pytorch_channel="https://download.pytorch.org/whl/${pytorch_version}/${pytorch_variant}/"
+  elif [ "$pytorch_version" == "latest" ]; then
+    pytorch_package="torch"
+    pytorch_channel="https://download.pytorch.org/whl/${pytorch_variant}/"
+  else
+    pytorch_package="torch==${pytorch_version}+${pytorch_variant}"
+    pytorch_channel="https://download.pytorch.org/whl/${pytorch_variant}/"
+  fi
+
+  echo "[INSTALL] Installing PyTorch ${pytorch_version}+${pytorch_variant} through PIP using channel ${pytorch_channel} ..."
+  print_exec conda run -n "${env_name}" pip install ${pytorch_package} --extra-index-url ${pytorch_channel}
+
+  # Check that PyTorch is importable
+  test_python_import $env_name torch.distributed || return 1
+
+  echo "[INSTALL] Successfully installed PyTorch ${pytorch_version} through PIP"
+}
+
+install_cuda () {
+  env_name="$1"
+  cuda_version="$2"
+
+  if [ "$cuda_version" == "" ]; then
+    echo "Usage: ${FUNCNAME[0]} ENV_NAME CUDA_VERSION"
+    echo "Example(s):"
+    echo "    ${FUNCNAME[0]} build_binary 11.7.1"
+    return 1
+  else
+    echo "################################################################################"
+    echo "# Install CUDA"
+    echo "################################################################################"
+    echo ""
+  fi
+
+  # Check CUDA version formatting
+  cuda_version_arr=(${cuda_version//./ })
+  if [ ${#cuda_version_arr[@]} -lt 3 ]; then
+    echo "[ERROR] CUDA minor version number must be specified (i.e. x.y.z)"
+    return 1
+  fi
+
+  # Install CUDA packages
+  echo "[INSTALL] Installing CUDA ${cuda_version} ..."
+  print_exec conda install -n "${env_name}" -y cuda -c "nvidia/label/cuda-${cuda_version}"
+
+  # Ensure that nvcc is properly installed
+  test_binpath $env_name nvcc || return 1
+
+  # Ensure that the CUDA headers are properly installed
+  conda run -n "${env_name}" test -n "$(find ${CONDA_PREFIX} -name cuda_runtime.h)"
+  if [ $? -eq 0 ]; then
+    echo "[CHECK] cuda_runtime.h found in path"
+  else
+    echo "[CHECK] cuda_runtime.h not found in path!"
+    return 1
+  fi
+
+  echo "[INSTALL] Successfully installed CUDA ${cuda_version}"
+}
+
+install_build_tools () {
+  env_name="$1"
+  if [ "$env_name" == "" ]; then
+    echo "Usage: ${FUNCNAME[0]} ENV_NAME"
+    echo "Example(s):"
+    echo "    ${FUNCNAME[0]} build_binary"
+    return 1
+  else
+    echo "################################################################################"
+    echo "# Install Build Tools"
+    echo "################################################################################"
+    echo ""
+  fi
+
+  echo "[INSTALL] Installing build tools ..."
+  print_exec conda install -n "${env_name}" -y cmake hypothesis jinja2 ninja numpy scikit-build wheel
+
+  # https://root-forum.cern.ch/t/error-timespec-get-has-not-been-declared-with-conda-root-package/45712/6
+  # binutils_linux-64 gxx_linux-64 make
+
+  # Check binaries are visible in the PAATH
+  test_binpath $env_name cmake || return 1
+  test_binpath $env_name ninja || return 1
+
+  # Check Python packages are importable
+  test_python_import $env_name hypothesis || return 1
+  test_python_import $env_name jinja2 || return 1
+  test_python_import $env_name numpy || return 1
+  test_python_import $env_name skbuild || return 1
+  test_python_import $env_name wheel || return 1
+
+  echo "[INSTALL] Successfully installed all the build tools"
 }
 
 install_cudnn () {
-  install_path="$1"
-  if [ "$install_path" == "" ]; then
-    echo "Usage: install_cudnn INSTALL_PATH"
+  env_name="$1"
+  install_path="$2"
+  cuda_version="$3"
+  if [ "$cuda_version" == "" ]; then
+    echo "Usage: ${FUNCNAME[0]} ENV_NAME INSTALL_PATH CUDA_VERSION"
     echo "Example:"
-    echo "    install_cudnn \$(pwd)/cudnn_install"
-    exit 1
+    echo "    ${FUNCNAME[0]} build_binary \$(pwd)/cudnn_install 11.7"
+    return 1
+  else
+    echo "################################################################################"
+    echo "# Install cuDNN"
+    echo "################################################################################"
+    echo ""
   fi
 
+  # Install cuDNN manually
+  # Based on install script in https://github.com/pytorch/builder/blob/main/common/install_cuda.sh
+  cudnn_packages=(
+    ["115"]="https://developer.download.nvidia.com/compute/redist/cudnn/v8.3.2/local_installers/11.5/cudnn-linux-x86_64-8.3.2.44_cuda11.5-archive.tar.xz"
+    ["116"]="https://developer.download.nvidia.com/compute/redist/cudnn/v8.3.2/local_installers/11.5/cudnn-linux-x86_64-8.3.2.44_cuda11.5-archive.tar.xz"
+    ["117"]="https://ossci-linux.s3.amazonaws.com/cudnn-linux-x86_64-8.5.0.96_cuda11-archive.tar.xz"
+    ["118"]="https://developer.download.nvidia.com/compute/redist/cudnn/v8.7.0/local_installers/11.8/cudnn-linux-x86_64-8.7.0.84_cuda11-archive.tar.xz"
+  )
+
+  # Remove the dot, e.g. 11.7 => 117
+  # Split version string by dot into array
+  cuda_version_arr=(${cuda_version//./ })
+  # Fetch the major and minor version to concat
+  cuda_concat_version="${cuda_version_arr[0]}${cuda_version_arr[1]}"
+
+  # Get the URL
+  cudnn_url="${cudnn_packages[cuda_concat_version]}"
+  if [ "$cudnn_url" == "" ]; then
+    cudnn_url="${cudnn_packages[117]}"
+  fi
+
+  # Clear the install path
   rm -rf "$install_path"
   mkdir -p "$install_path"
 
-  # Install cuDNN manually
-  # See https://github.com/pytorch/builder/blob/main/common/install_cuda.sh
-  mkdir -p tmp_cudnn
-  cd tmp_cudnn || exit
-  wget -q https://ossci-linux.s3.amazonaws.com/cudnn-linux-x86_64-8.5.0.96_cuda11-archive.tar.xz -O cudnn-linux-x86_64-8.5.0.96_cuda11-archive.tar.xz
-  tar xf cudnn-linux-x86_64-8.5.0.96_cuda11-archive.tar.xz
+  # Create temporary directory
+  tmp_dir=`mktemp -d`
+  cd "$tmp_dir" || return 1
+
+  # Download cuDNN
+  echo "[INSTALL] Downloading cuDNN to ${tmp_dir} ..."
+  print_exec wget "$cudnn_url" -O cudnn.tar.xz
+
+  # Unpack the tarball
+  echo "[INSTALL] Unpacking cuDNN ..."
+  tar -xvf cudnn.tar.xz
+
+  # Copy the includes and libs over to the install path
+  echo "[INSTALL] Moving cuDNN files to ${install_path} ..."
   rm -rf "${install_path:?}/include"
   rm -rf "${install_path:?}/lib"
-  mv cudnn-linux-x86_64-8.5.0.96_cuda11-archive/include "$install_path"
-  mv cudnn-linux-x86_64-8.5.0.96_cuda11-archive/lib "$install_path"
-  cd ../
-  rm -rf tmp_cudnn
+  mv cudnn-linux-*/include "$install_path"
+  mv cudnn-linux-*/lib "$install_path"
+
+  # Delete the temporary directory
+  cd -
+  rm -rf "$tmp_dir"
+
+  # Export the environment variables to the Conda environment
+  echo "[INSTALL] Set environment variables CUDNN_INCLUDE_DIR and CUDNN_LIBRARY ..."
+  print_exec conda env config vars set -n "${env_name}" CUDNN_INCLUDE_DIR="${install_path}/include" CUDNN_LIBRARY="${install_path}/lib"
+
+  echo "[INSTALL] Successfully installed cuDNN (for CUDA ${cuda_version})"
+}
+
+
+################################################################################
+# Combination Functions
+################################################################################
+
+create_conda_pytorch_environment () {
+  env_name="$1"
+  python_version="$2"
+  pytorch_channel_name="$3"
+  cuda_version="$4"
+  if [ "$python_version" == "" ]; then
+    echo "Usage: ${FUNCNAME[0]} ENV_NAME PYTHON_VERSION PYTORCH_CHANNEL_NAME CUDA_VERSION"
+    echo "Example:"
+    echo "    ${FUNCNAME[0]} build_binary 3.10 pytorch-nightly 11.7.1"
+    return 1
+  fi
+
+  # Create the Conda environment
+  create_conda_environment "${env_name}" "${python_version}"
+
+  # Convert the channels to versions
+  if [ "${pytorch_channel_name}" == "pytorch-nightly" ]; then
+    pytorch_version="nightly"
+  elif [ "${pytorch_channel_name}" == "pytorch-test" ]; then
+    pytorch_version="test"
+  else
+    pytorch_version="latest"
+  fi
+
+  if [ "${cuda_version}" == "" ]; then
+    # Install the CPU variant of PyTorch
+    install_pytorch_conda "${env_name}" "${pytorch_version}" 1
+  else
+    # Install CUDA and the GPU variant of PyTorch
+    install_cuda "${env_name}" "${cuda_version}"
+    install_pytorch_conda "${env_name}" "${pytorch_version}"
+  fi
+}
+
+
+################################################################################
+# Build Functions
+################################################################################
+
+prepare_fbgemm_build () {
+  env_name="$1"
+  if [ "$env_name" == "" ]; then
+    echo "Usage: ${FUNCNAME[0]} ENV_NAME"
+    echo "Example(s):"
+    echo "    ${FUNCNAME[0]} build_binary"
+    return 1
+  else
+    echo "################################################################################"
+    echo "# Prepare FBGEMM Build"
+    echo "################################################################################"
+    echo ""
+  fi
+
+  echo "[BUILD] Running git submodules update ..."
+  git submodule sync
+  git submodule update --init --recursive
+
+  echo "[BUILD] Installing other build dependencies ..."
+  print_exec conda run -n "${env_name}" python -m pip install -r requirements.txt
+
+  echo "[BUILD] Successfully ran git submodules update"
+}
+
+build_fbgemm_package () {
+  env_name="$1"
+  package_name="$2"
+  cpu_only="$3"
+  if [ "$package_name" == "" ]; then
+    echo "Usage: ${FUNCNAME[0]} PACKAGE_NAME [CPU_ONLY]"
+    echo "Example(s):"
+    echo "    ${FUNCNAME[0]} build_binary fbgemm_gpu_nightly    # Build the full package"
+    echo "    ${FUNCNAME[0]} build_binary fbgemm_gpu 1          # Build the CPU-only variant of the package"
+    return 1
+  else
+    echo "################################################################################"
+    echo "# Build FBGEMM Package"
+    echo "################################################################################"
+    echo ""
+  fi
+
+  # Check that cuDNN environment variables are available
+  test_env_var "${env_name}" CUDNN_INCLUDE_DIR || return 1
+  test_env_var "${env_name}" CUDNN_LIBRARY || return 1
+
+  # Extract the Python tag
+  python_version=(`conda run -n "${env_name}" python --version`)
+  python_version_arr=(${python_version[1]//./ })
+  python_tag="py${python_version_arr[0]}${python_version_arr[1]}"
+  echo "[BUILD] Extracted Python tag: ${python_tag}"
+
+  # Update the package name and build args depending on if CUDA is specified
+  if [ "$cpu_only" != "" ]; then
+    echo "[BUILD] Applying CPU-only build args ..."
+    # CPU version
+    build_args="--cpu_only"
+    package_name="${package_name}-cpu"
+  else
+    echo "[BUILD] Applying GPU build args ..."
+    # GPU version
+    # Build only CUDA 7.0 and 8.0 (i.e. V100 and A100) because of 100 MB binary size limits from PyPI.
+    build_args="-DTORCH_CUDA_ARCH_LIST=7.0;8.0"
+  fi
+
+  echo "[BUILD] Running pre-build cleanups ..."
+  print_exec rm -rf dist
+  print_exec conda run -n "${env_name}" python setup.py clean
+
+  # manylinux1_x86_64 is specified for PyPI upload
+  # Distribute Python extensions as wheels on Linux
+  echo "[BUILD] Building FBGEMM ..."
+  print_exec conda run -n "${env_name}" \
+    python setup.py bdist_wheel \
+      --package_name="${package_name}" \
+      --python-tag="${python_tag}" \
+      ${build_args} \
+      --plat-name=manylinux1_x86_64
+
+  echo "[BUILD] Enumerating the built wheels ..."
+  print_exec ls -lth dist/*.whl
+
+  echo "[BUILD] FBGEMM build completed"
+}
+
+################################################################################
+# Publish Functions
+################################################################################
+
+publish_to_pypi () {
+  env_name="$1"
+  package_name="$2"
+  pypi_token="$3"
+  if [ "$pypi_token" == "" ]; then
+    echo "Usage: ${FUNCNAME[0]} ENV_NAME PACKAGE_NAME"
+    echo "Example(s):"
+    echo "    ${FUNCNAME[0]} build_binary 11.7.1"
+    return 1
+  else
+    echo "################################################################################"
+    echo "# Publish to PyPI"
+    echo "################################################################################"
+    echo ""
+  fi
+
+  echo "[INSTALL] Installing twine ..."
+  print_exec conda install -n "${env_name}" -y twine
+  test_python_import $env_name twine || return 1
+
+  echo "[PUBLISH] Uploading package(s) to PyPI: ${package_name} ..."
+  conda run -n "${env_name}" \
+    python -m twine upload \
+      --username __token__ \
+      --password "${pypi_token}" \
+      --skip-existing \
+      --verbose \
+      ${package_name}
+
+  echo "[PUBLISH] Successfully published package(s) to PyPI: ${package_name}"
 }

--- a/.github/scripts/setup_env.bash
+++ b/.github/scripts/setup_env.bash
@@ -102,9 +102,11 @@ print_system_info () {
   print_exec ldd --version
 
   echo "[INFO] Check CPU info"
+  print_exec nproc
   print_exec cat /proc/cpuinfo
 
   echo "[INFO] Check Linux distribution info"
+  print_exec uname -a
   print_exec cat /proc/version
   print_exec cat /etc/os-release
 

--- a/.github/scripts/test_torchrec.bash
+++ b/.github/scripts/test_torchrec.bash
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 # Exit on failure
 set -e
 
@@ -70,13 +75,13 @@ fi
 echo "## 1. Set up Miniconda"
 ################################################################################
 
-setup_miniconda "$miniconda_prefix"
+setup_miniconda "$miniconda_prefix" || exit 1
 
 ################################################################################
 echo "## 2. Create test_binary environment"
 ################################################################################
 
-create_conda_environment test_binary "$python_version" "$pytorch_channel_name" "$cuda_version"
+create_conda_pytorch_environment test_binary "$python_version" "$pytorch_channel_name" "$cuda_version" || exit 1
 
 # Comment out FBGEMM_GPU since we will install it from "$fbgemm_wheel_path"
 sed -i 's/fbgemm-gpu/#fbgemm-gpu/g' requirements.txt

--- a/.github/scripts/test_torchrec.bash
+++ b/.github/scripts/test_torchrec.bash
@@ -75,13 +75,13 @@ fi
 echo "## 1. Set up Miniconda"
 ################################################################################
 
-setup_miniconda "$miniconda_prefix" || exit 1
+setup_miniconda "$miniconda_prefix"
 
 ################################################################################
 echo "## 2. Create test_binary environment"
 ################################################################################
 
-create_conda_pytorch_environment test_binary "$python_version" "$pytorch_channel_name" "$cuda_version" || exit 1
+create_conda_pytorch_environment test_binary "$python_version" "$pytorch_channel_name" "$cuda_version"
 
 # Comment out FBGEMM_GPU since we will install it from "$fbgemm_wheel_path"
 sed -i 's/fbgemm-gpu/#fbgemm-gpu/g' requirements.txt

--- a/.github/scripts/test_wheel.bash
+++ b/.github/scripts/test_wheel.bash
@@ -72,13 +72,13 @@ fi
 echo "## 1. Set up Miniconda"
 ################################################################################
 
-setup_miniconda "$miniconda_prefix" || exit 1
+setup_miniconda "$miniconda_prefix"
 
 ################################################################################
 echo "## 2. Create test_binary environment"
 ################################################################################
 
-create_conda_pytorch_environment test_binary "$python_version" "$pytorch_channel_name" "$cuda_version" || exit 1
+create_conda_pytorch_environment test_binary "$python_version" "$pytorch_channel_name" "$cuda_version"
 conda install -n test_binary -y pytest
 
 cd fbgemm_gpu

--- a/.github/scripts/test_wheel.bash
+++ b/.github/scripts/test_wheel.bash
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 # Exit on failure
 set -e
 
@@ -67,13 +72,13 @@ fi
 echo "## 1. Set up Miniconda"
 ################################################################################
 
-setup_miniconda "$miniconda_prefix"
+setup_miniconda "$miniconda_prefix" || exit 1
 
 ################################################################################
 echo "## 2. Create test_binary environment"
 ################################################################################
 
-create_conda_environment test_binary "$python_version" "$pytorch_channel_name" "$cuda_version"
+create_conda_pytorch_environment test_binary "$python_version" "$pytorch_channel_name" "$cuda_version" || exit 1
 conda install -n test_binary -y pytest
 
 cd fbgemm_gpu

--- a/.github/workflows/fbgemm_ci.yml
+++ b/.github/workflows/fbgemm_ci.yml
@@ -1,0 +1,198 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+name: FBGEMM CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-posix:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Checkout submodules
+      shell: bash
+      run: |
+        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+        git submodule sync --recursive
+        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+
+    - name: Get CPU info on Ubuntu
+      if: contains(runner.os, 'linux')
+      run: |
+        cat /proc/cpuinfo
+
+    - name: Get CPU info on macOS
+      if: contains(runner.os, 'macOs')
+      run: |
+        sysctl -a | grep machdep.cpu
+
+    - name: Get env vars
+      run: |
+        echo GITHUB_WORKFLOW   = $GITHUB_WORKFLOW
+        echo HOME              = $HOME
+        echo GITHUB_ACTION     = $GITHUB_ACTION
+        echo GITHUB_ACTIONS    = $GITHUB_ACTIONS
+        echo GITHUB_REPOSITORY = $GITHUB_REPOSITORY
+        echo GITHUB_EVENT_NAME = $GITHUB_EVENT_NAME
+        echo GITHUB_EVENT_PATH = $GITHUB_EVENT_PATH
+        echo GITHUB_WORKSPACE  = $GITHUB_WORKSPACE
+        echo GITHUB_SHA        = $GITHUB_SHA
+        echo GITHUB_REF        = $GITHUB_REF
+        c++ --verbose
+
+    - name: Build static FBGEMM lib
+      run: |
+        set -e
+        mkdir build_static
+        cd build_static
+        cmake -DUSE_SANITIZER=address -DFBGEMM_LIBRARY_TYPE=static ..
+        make
+
+    - name: Test static FBGEMM lib
+      if: contains(runner.os, 'linux')   # not run on macos-latest now due to supporting AVX2
+      run: |
+        set -e
+        cd build_static
+        ctest --rerun-failed --output-on-failure
+
+    - name: Build shared FBGEMM lib
+      run: |
+        set -e
+        mkdir build_shared
+        cd build_shared
+        cmake -DUSE_SANITIZER=address -DFBGEMM_LIBRARY_TYPE=shared ..
+        make
+
+    - name: Test shared FBGEMM lib
+      if: contains(runner.os, 'linux')   # not run on macos-latest now due to supporting AVX2
+      run: |
+        set -e
+        cd build_shared
+        ctest --rerun-failed --output-on-failure
+
+  build-windows:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-2019]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Checkout submodules
+      shell: bash
+      run: |
+        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+        git submodule sync --recursive
+        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+
+    - name: Get CPU info on Windows
+      shell: cmd
+      run: |
+        wmic cpu list full
+
+    - name: Build static FBGEMM lib
+      shell: cmd
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+        echo "INSTALL NINJA:"
+        pip install ninja
+        which ninja
+        mkdir build_static
+        cd build_static
+        echo "STARTING CMAKE"
+        cmake -G Ninja -DFBGEMM_BUILD_BENCHMARKS=OFF -DFBGEMM_LIBRARY_TYPE=static -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" ..
+        ninja all
+        echo "Build Success"
+
+    - name: Test static FBGEMM lib
+      shell: cmd
+      run: |
+        echo %cd%
+        cd build_static
+        ctest --rerun-failed --output-on-failure
+        if errorlevel 1 exit /b 1
+
+    - name: Build shared FBGEMM lib
+      shell: cmd
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+        echo "INSTALL NINJA:"
+        pip install ninja
+        which ninja
+        mkdir build_shared
+        cd build_shared
+        echo "STARTING CMAKE"
+        cmake -G Ninja -DFBGEMM_BUILD_BENCHMARKS=OFF -DFBGEMM_LIBRARY_TYPE=shared -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" ..
+        ninja all
+        if errorlevel 1 exit /b 1
+
+    - name: Test shared FBGEMM lib
+      shell: cmd
+      run: |
+        echo %cd%
+        cd build_shared
+        set PATH=%PATH%;%cd%;%cd%\asmjit
+        echo %PATH%
+        ctest --rerun-failed --output-on-failure
+        if errorlevel 1 exit /b 1
+
+  build-bazel:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Checkout submodules
+      shell: bash
+      run: |
+        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+        git submodule sync --recursive
+        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+
+    - name: Get env vars
+      run: |
+        echo GITHUB_WORKFLOW   = $GITHUB_WORKFLOW
+        echo HOME              = $HOME
+        echo GITHUB_ACTION     = $GITHUB_ACTION
+        echo GITHUB_ACTIONS    = $GITHUB_ACTIONS
+        echo GITHUB_REPOSITORY = $GITHUB_REPOSITORY
+        echo GITHUB_EVENT_NAME = $GITHUB_EVENT_NAME
+        echo GITHUB_EVENT_PATH = $GITHUB_EVENT_PATH
+        echo GITHUB_WORKSPACE  = $GITHUB_WORKSPACE
+        echo GITHUB_SHA        = $GITHUB_SHA
+        echo GITHUB_REF        = $GITHUB_REF
+        c++ --verbose
+
+    - name: Download bazel
+      run: |
+        set -e
+        wget https://github.com/bazelbuild/bazel/releases/download/2.2.0/bazel-2.2.0-linux-x86_64 -O bazel
+        # verify content
+        echo 'b2f002ea0e6194a181af6ac84cd94bd8dc797722eb2354690bebac92dda233ff bazel' | sha256sum --quiet -c
+        chmod +x bazel
+
+
+    - name: Build FBGEMM with bazel
+      run: |
+        set -e
+        ./bazel build --verbose_explanations --verbose_failures --compilation_mode opt :*
+
+    - name: Test FBGEMM bazel build
+      run: |
+        set -e
+        ./bazel test --test_output=all --verbose_explanations --verbose_failures --compilation_mode opt :*

--- a/.github/workflows/fbgemm_docs.yml
+++ b/.github/workflows/fbgemm_docs.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
     # Update references

--- a/.github/workflows/fbgemm_gpu_ci.yml
+++ b/.github/workflows/fbgemm_gpu_ci.yml
@@ -28,7 +28,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04 ]
-        # PyTorch has dropped support for CUDA 11.6
+        python-version: [ "3.8" ]
+        # As of version 2.0, PyTorch has dropped support for CUDA 11.6
         cuda-version: [ 11.7.1 ]
 
     steps:
@@ -47,7 +48,14 @@ jobs:
         echo "CONDA=${HOME}/miniconda" >> $GITHUB_PATH
 
     - name: Create Conda Environment
-      run: . $PRELUDE; create_conda_environment $BUILD_ENV 3.8
+      run: |
+        . $PRELUDE
+        create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
+
+        # This hack is needed to get builds running properly on Ubuntu 20.04
+        echo "[SETUP] Creating symlink \$CONDA_PREFIX/lib64 -> \$CONDA_PREFIX/lib ..."
+        conda_prefix=$(conda run -n "${env_name}" printenv CONDA_PREFIX)
+        ln -s "${conda_prefix}/lib" "${conda_prefix}/lib64"
 
     # - name: Install C/C++ Compilers
     #   run: . $PRELUDE; install_cxx_compiler $BUILD_ENV
@@ -80,86 +88,6 @@ jobs:
         print_exec conda run -n $BUILD_ENV python sparse_ops_test.py -v
         conda run -n $BUILD_ENV python -c "import fbgemm_gpu"
         conda run -n $BUILD_ENV python -c "import fbgemm_gpu.split_embedding_codegen_lookup_invokers"
-
-  # build_nvidia_gpu:
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-20.04]
-  #       config: [[pip, 11.3], [pip, 11.5], [pip, 11.6], [pip, 11.7], [conda, 11.7.1]]
-
-  #   steps:
-  #   - uses: actions/checkout@v3
-
-  #   - name: Install CUDA
-  #     shell: bash
-  #     if: matrix.config[0] == 'pip'
-  #     run: |
-  #       wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
-  #       sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
-  #       # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772
-  #       wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
-  #       sudo dpkg -i cuda-keyring_1.0-1_all.deb
-  #       # sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
-  #       sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
-  #       sudo apt-get update
-  #       # "11.5 -> 11-5"
-  #       cuda_apt_version=$(echo "${{ matrix.config[1] }}" | sed "s/\./-/")
-  #       sudo apt-get -y install cuda-minimal-build-${cuda_apt_version} cuda-nvrtc-dev-${cuda_apt_version} cuda-nvtx-${cuda_apt_version} cuda-libraries-dev-${cuda_apt_version}
-  #       sudo apt-get -y install libcudnn8-dev
-
-  #   - name: Install dependencies
-  #     shell: bash
-  #     run: |
-  #       if [ x"${{ matrix.config[0] }}" == x"pip" ]; then
-  #         # pip-based installation
-  #         sudo apt-get update
-  #         sudo apt-get -y install git pip python3-dev
-  #         sudo pip install cmake scikit-build ninja jinja2 numpy hypothesis --no-input
-  #         # Install pytorch built with CUDA 11.3 in all cases
-  #         sudo pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
-  #       else
-  #         # conda-based installation
-  #         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-  #         bash ~/miniconda.sh -b -p $HOME/miniconda -u
-  #         eval "$($HOME/miniconda/bin/conda shell.bash hook)"
-  #         cuda_version="${{ matrix.config[1] }}"
-  #         conda install -y pytorch cuda -c pytorch-nightly -c "nvidia/label/cuda-${cuda_version}"
-  #         conda install -y -c conda-forge cudnn
-  #         conda install -y numpy scikit-build jinja2 ninja cmake hypothesis
-  #       fi
-  #   - name: Checkout submodules
-  #     shell: bash
-  #     run: |
-  #       cd fbgemm_gpu
-  #       git submodule sync
-  #       git submodule update --init --recursive
-
-  #   - name: Build fbgemm_gpu
-  #     shell: bash
-  #     run: |
-  #       cd fbgemm_gpu
-  #       if [ x"${{ matrix.config[0] }}" == x"pip" ]; then
-  #         CUDA_PATH="/usr/local/cuda-${{ matrix.config[1] }}"
-  #         sudo CUDACXX="${CUDA_PATH}/bin/nvcc" python setup.py install -DTORCH_CUDA_ARCH_LIST="6.0"
-  #       else
-  #         eval "$($HOME/miniconda/bin/conda shell.bash hook)"
-  #         python setup.py install -DTORCH_CUDA_ARCH_LIST="6.0"
-  #       fi
-
-  #   - name: Test fbgemm_gpu installation
-  #     shell: bash
-  #     run: |
-  #       if [ x"${{ matrix.config[0] }}" == x"conda" ]; then
-  #         eval "$($HOME/miniconda/bin/conda shell.bash hook)"
-  #       fi
-  #       cd fbgemm_gpu
-  #       cd test
-  #       python input_combine_test.py -v
-  #       python quantize_ops_test.py -v
-  #       python sparse_ops_test.py -v
-  #       python -c "import fbgemm_gpu"
-  #       python -c "import fbgemm_gpu.split_embedding_codegen_lookup_invokers"
 
   build_amd_gpu:
     if: ${{ false }}  # Disable the job for now

--- a/.github/workflows/fbgemm_gpu_ci.yml
+++ b/.github/workflows/fbgemm_gpu_ci.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build_nvidia_gpu:
+    if: ${{ false }}  # Disable the job for now
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -27,7 +28,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04 ]
-        cuda-version: [ 11.5.2, 11.6.2, 11.7.1 ]
+        # PyTorch has dropped support for CUDA 11.6
+        cuda-version: [ 11.7.1 ]
 
     steps:
     - name: Checkout the Repository
@@ -47,8 +49,8 @@ jobs:
     - name: Create Conda Environment
       run: . $PRELUDE; create_conda_environment $BUILD_ENV 3.8
 
-    - name: Install C/C++ Compilers
-      run: . $PRELUDE; install_cxx_compiler $BUILD_ENV
+    # - name: Install C/C++ Compilers
+    #   run: . $PRELUDE; install_cxx_compiler $BUILD_ENV
 
     - name: Install Build Tools
       run: . $PRELUDE; install_build_tools $BUILD_ENV
@@ -76,8 +78,8 @@ jobs:
         print_exec conda run -n $BUILD_ENV python input_combine_test.py -v
         print_exec conda run -n $BUILD_ENV python quantize_ops_test.py -v
         print_exec conda run -n $BUILD_ENV python sparse_ops_test.py -v
-        print_exec conda run -n $BUILD_ENV python -c "import fbgemm_gpu"
-        print_exec conda run -n $BUILD_ENV python -c "import fbgemm_gpu.split_embedding_codegen_lookup_invokers"
+        conda run -n $BUILD_ENV python -c "import fbgemm_gpu"
+        conda run -n $BUILD_ENV python -c "import fbgemm_gpu.split_embedding_codegen_lookup_invokers"
 
   # build_nvidia_gpu:
   #   runs-on: ${{ matrix.os }}
@@ -160,6 +162,7 @@ jobs:
   #       python -c "import fbgemm_gpu.split_embedding_codegen_lookup_invokers"
 
   build_amd_gpu:
+    if: ${{ false }}  # Disable the job for now
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -221,6 +224,7 @@ jobs:
         python3 -c "import fbgemm_gpu.split_embedding_codegen_lookup_invokers"
 
   test_amd_gpu:
+    if: ${{ false }}  # Disable the job for now
     runs-on: rocm
     strategy:
       matrix:

--- a/.github/workflows/fbgemm_gpu_ci.yml
+++ b/.github/workflows/fbgemm_gpu_ci.yml
@@ -1,4 +1,9 @@
-name: FBGEMMCI
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+name: FBGEMM_GPU CI
 
 on:
   push:
@@ -9,190 +14,6 @@ on:
       - main
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Checkout submodules
-      shell: bash
-      run: |
-        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-        git submodule sync --recursive
-        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-
-    - name: Get CPU info on Ubuntu
-      if: contains(runner.os, 'linux')
-      run: |
-        cat /proc/cpuinfo
-
-    - name: Get CPU info on macOS
-      if: contains(runner.os, 'macOs')
-      run: |
-        sysctl -a | grep machdep.cpu
-
-    - name: Get env vars
-      run: |
-        echo GITHUB_WORKFLOW   = $GITHUB_WORKFLOW
-        echo HOME              = $HOME
-        echo GITHUB_ACTION     = $GITHUB_ACTION
-        echo GITHUB_ACTIONS    = $GITHUB_ACTIONS
-        echo GITHUB_REPOSITORY = $GITHUB_REPOSITORY
-        echo GITHUB_EVENT_NAME = $GITHUB_EVENT_NAME
-        echo GITHUB_EVENT_PATH = $GITHUB_EVENT_PATH
-        echo GITHUB_WORKSPACE  = $GITHUB_WORKSPACE
-        echo GITHUB_SHA        = $GITHUB_SHA
-        echo GITHUB_REF        = $GITHUB_REF
-        c++ --verbose
-
-    - name: Build static FBGEMM lib
-      run: |
-        set -e
-        mkdir build_static
-        cd build_static
-        cmake -DUSE_SANITIZER=address -DFBGEMM_LIBRARY_TYPE=static ..
-        make
-
-    - name: Test static FBGEMM lib
-      if: contains(runner.os, 'linux')   # not run on macos-latest now due to supporting AVX2
-      run: |
-        set -e
-        cd build_static
-        ctest --rerun-failed --output-on-failure
-
-    - name: Build shared FBGEMM lib
-      run: |
-        set -e
-        mkdir build_shared
-        cd build_shared
-        cmake -DUSE_SANITIZER=address -DFBGEMM_LIBRARY_TYPE=shared ..
-        make
-
-    - name: Test shared FBGEMM lib
-      if: contains(runner.os, 'linux')   # not run on macos-latest now due to supporting AVX2
-      run: |
-        set -e
-        cd build_shared
-        ctest --rerun-failed --output-on-failure
-
-  build-windows:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-2019]
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Checkout submodules
-      shell: bash
-      run: |
-        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-        git submodule sync --recursive
-        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-
-    - name: Get CPU info on Windows
-      shell: cmd
-      run: |
-        wmic cpu list full
-
-    - name: Build static FBGEMM lib
-      shell: cmd
-      run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-        echo "INSTALL NINJA:"
-        pip install ninja
-        which ninja
-        mkdir build_static
-        cd build_static
-        echo "STARTING CMAKE"
-        cmake -G Ninja -DFBGEMM_BUILD_BENCHMARKS=OFF -DFBGEMM_LIBRARY_TYPE=static -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" ..
-        ninja all
-        echo "Build Success"
-
-    - name: Test static FBGEMM lib
-      shell: cmd
-      run: |
-        echo %cd%
-        cd build_static
-        ctest --rerun-failed --output-on-failure
-        if errorlevel 1 exit /b 1
-
-    - name: Build shared FBGEMM lib
-      shell: cmd
-      run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-        echo "INSTALL NINJA:"
-        pip install ninja
-        which ninja
-        mkdir build_shared
-        cd build_shared
-        echo "STARTING CMAKE"
-        cmake -G Ninja -DFBGEMM_BUILD_BENCHMARKS=OFF -DFBGEMM_LIBRARY_TYPE=shared -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" ..
-        ninja all
-        if errorlevel 1 exit /b 1
-
-    - name: Test shared FBGEMM lib
-      shell: cmd
-      run: |
-        echo %cd%
-        cd build_shared
-        set PATH=%PATH%;%cd%;%cd%\asmjit
-        echo %PATH%
-        ctest --rerun-failed --output-on-failure
-        if errorlevel 1 exit /b 1
-
-  build-bazel:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Checkout submodules
-      shell: bash
-      run: |
-        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-        git submodule sync --recursive
-        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-
-    - name: Get env vars
-      run: |
-        echo GITHUB_WORKFLOW   = $GITHUB_WORKFLOW
-        echo HOME              = $HOME
-        echo GITHUB_ACTION     = $GITHUB_ACTION
-        echo GITHUB_ACTIONS    = $GITHUB_ACTIONS
-        echo GITHUB_REPOSITORY = $GITHUB_REPOSITORY
-        echo GITHUB_EVENT_NAME = $GITHUB_EVENT_NAME
-        echo GITHUB_EVENT_PATH = $GITHUB_EVENT_PATH
-        echo GITHUB_WORKSPACE  = $GITHUB_WORKSPACE
-        echo GITHUB_SHA        = $GITHUB_SHA
-        echo GITHUB_REF        = $GITHUB_REF
-        c++ --verbose
-
-    - name: Download bazel
-      run: |
-        set -e
-        wget https://github.com/bazelbuild/bazel/releases/download/2.2.0/bazel-2.2.0-linux-x86_64 -O bazel
-        # verify content
-        echo 'b2f002ea0e6194a181af6ac84cd94bd8dc797722eb2354690bebac92dda233ff bazel' | sha256sum --quiet -c
-        chmod +x bazel
-
-
-    - name: Build FBGEMM with bazel
-      run: |
-        set -e
-        ./bazel build --verbose_explanations --verbose_failures --compilation_mode opt :*
-
-    - name: Test FBGEMM bazel build
-      run: |
-        set -e
-        ./bazel test --test_output=all --verbose_explanations --verbose_failures --compilation_mode opt :*
-
-
   build_nvidia_gpu:
     runs-on: ${{ matrix.os }}
     defaults:
@@ -207,6 +28,7 @@ jobs:
       matrix:
         os: [ ubuntu-20.04 ]
         cuda-version: [ 11.5.2, 11.6.2, 11.7.1 ]
+
     steps:
     - name: Checkout the Repository
       uses: actions/checkout@v3

--- a/.github/workflows/fbgemm_nightly_build.yml
+++ b/.github/workflows/fbgemm_nightly_build.yml
@@ -3,20 +3,23 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-name: Push Binary Nightly
+name: Push FBGEMM_GPU Nightly
 
 on:
   # PR Trigger (enable only for debugging)
-  [ push, pull_request ]
+  #
+   [ push, pull_request ]
 
   # Cron Trigger
   #
   # Based on the Conda page for PyTorch-nightly, the GPU nightly releases appear
   # around 02:30 every day (roughly 2 hours after the CPU releases)
+  #
   # schedule:
   #   - cron:  '45 03 * * *'
 
   # Manual trigger
+  #
   # workflow_dispatch:
 
 jobs:
@@ -36,6 +39,7 @@ jobs:
         os: [ linux.2xlarge ]
         python-version: [ "3.8", "3.9", "3.10" ]
         cuda-version: [ "11.7.1" ]
+
     steps:
     - name: Checkout the Repository
       uses: actions/checkout@v3
@@ -122,24 +126,6 @@ jobs:
     - name: Install CUDA
       run: . $PRELUDE; install_cuda $BUILD_ENV ${{ matrix.cuda-version }}
 
-    # - name: Install CUDA 11.3
-    #   shell: bash
-    #   run: |
-    #     sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-    #     sudo yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
-    #     sudo yum clean expire-cache
-    #     sudo yum install -y nvidia-driver-latest-dkms
-    #     sudo yum install -y cuda-11-3
-    #     sudo yum install -y cuda-drivers
-    #     sudo yum install -y libcudnn8-devel
-    # - name: setup Path
-    #   run: |
-    #     echo /usr/local/cuda-11.3/bin >> $GITHUB_PATH
-    #     echo /usr/local/bin >> $GITHUB_PATH
-    # - name: nvcc check
-    #   run: |
-    #     nvcc --version
-
     - name: Install PyTorch Nightly
       run: . $PRELUDE; install_pytorch_conda $BUILD_ENV nightly
 
@@ -166,7 +152,7 @@ jobs:
         conda run -n $BUILD_ENV \
           python -c "import fbgemm_gpu"
 
-    - name: Test with pytest
+    - name: Test with PyTest
       # Remove this line when we fixed all the unit tests
       continue-on-error: true
       run: |

--- a/.github/workflows/fbgemm_nightly_build.yml
+++ b/.github/workflows/fbgemm_nightly_build.yml
@@ -1,258 +1,151 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
 
 name: Push Binary Nightly
 
 on:
-  # For debugging, enable push/pull_request
-  # [push, pull_request]
-  # run every day at 10:45 AM
+  # PR Trigger (enable only for debugging)
+  [ push, pull_request ]
+  # Cron Trigger
   # schedule:
-  #   - cron:  '45 10 * * *'
-  # or manually trigger it
-  workflow_dispatch:
+  #   - cron:  '45 03 * * *'
+  # Manual trigger
+  # workflow_dispatch:
 
 jobs:
   # build on cpu hosts and upload to GHA
   build_on_cpu:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      PRELUDE: .github/scripts/setup_env.bash
+      BUILD_ENV: build_binary
     strategy:
       matrix:
-        include:
-         - os: linux.2xlarge
-           python-version: "3.8"
-           python-tag: "py38"
-           cuda-tag: "cu11"
-         - os: linux.2xlarge
-           python-version: "3.9"
-           python-tag: "py39"
-           cuda-tag: "cu11"
-         - os: linux.2xlarge
-           python-version: "3.10"
-           python-tag: "py310"
-           cuda-tag: "cu11"
+        os: [ linux.2xlarge ]
+        python-version: [ "3.8", "3.9", "3.10" ]
+        cuda-tag: [ "cu11" ]
     steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Check ldd --version
-      run: ldd --version
-    - name: Checkout
+    - name: Checkout the Repository
       uses: actions/checkout@v2
       with:
         submodules: true
-    # Update references
-    - name: Git Submodule Update
+
+    - name: Display System Info
+      run: . $PRELUDE; print_system_info
+
+    - name: Setup Miniconda
       run: |
-        cd fbgemm_gpu/
-        git submodule sync
-        git submodule update --init --recursive
-    - name: Setup conda
-      run: |
-        wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-        bash ~/miniconda.sh -b -p $HOME/miniconda -u
-    - name: Setup PATH with conda
-      run: |
+        . $PRELUDE; setup_miniconda $HOME/miniconda
         echo "${HOME}/miniconda/bin" >> $GITHUB_PATH
         echo "CONDA=${HOME}/miniconda" >> $GITHUB_PATH
-    - name: Create conda env
-      run: |
-        conda create --name build_binary python=${{ matrix.python-version }}
-        conda info
-    - name: check python version
-      run: |
-        conda run -n build_binary python --version
-    - name: Install C/C++ compilers
-      run: |
-        sudo yum install -y gcc gcc-c++
-    - name: Install PyTorch and CUDA
-      shell: bash
-      run: |
-        conda install -n build_binary -y pytorch cuda -c pytorch-nightly -c "nvidia/label/cuda-11.7.1"
 
-        # Ensure that CUDA is properly installed
-        conda run -n build_binary which nvcc
-        conda run -n build_binary test -n "$(find $HOME/miniconda -name cuda_runtime.h)"
-        echo "Successfully installed CUDA"
+    - name: Create Conda Environment
+      run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
 
-        # Ensure that the PyTorch nightly build is the GPU variant (i.e. contains cuDNN)
-        conda list -n build_binary pytorch | grep cudnn
-        echo "Successfully installed pytorch-nightly"
-    - name: Install Other Dependencies
-      shell: bash
-      run: |
-        cd fbgemm_gpu/
-        conda run -n build_binary python -m pip install -r requirements.txt
-    - name: Test Installation of Dependencies
-      run: |
-        cd fbgemm_gpu/
-        conda run -n build_binary python -c "import torch.distributed"
-        echo "torch.distributed succeeded"
-        conda run -n build_binary python -c "import skbuild"
-        echo "skbuild succeeded"
-        conda run -n build_binary python -c "import numpy"
-        echo "numpy succeeded"
-    # for the conda run with quotes, we have to use "\" and double quotes
-    # here is the issue: https://github.com/conda/conda/issues/10972
+    - name: Install C/C++ Compilers
+      run: . $PRELUDE; install_cxx_compiler $BUILD_ENV
+
+    - name: Install Build Tools
+      run: . $PRELUDE; install_build_tools $BUILD_ENV
+
+    - name: Install CUDA
+      run: . $PRELUDE; install_cuda $BUILD_ENV 11.7.1
+
+    - name: Install PyTorch Nightly
+      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV nightly
+
+    - name: Install cuDNN
+      run: . $PRELUDE; install_cudnn $BUILD_ENV "$(pwd)/build_only/cudnn" 11.7.1
+
+    - name: Prepare FBGEMM Build
+      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_build $BUILD_ENV
+
     - name: Build FBGEMM_GPU Nightly
-      run: |
-        # Install cuDNN. This is needed to build FBGEMM but not for execution.
-        # See https://github.com/pytorch/builder/blob/main/common/install_cuda.sh
-        tmp_cudnn_path="$(pwd)/build_only/cudnn"
-        mkdir -p tmp_cudnn
-        cd tmp_cudnn
-        wget -q https://ossci-linux.s3.amazonaws.com/cudnn-linux-x86_64-8.5.0.96_cuda11-archive.tar.xz -O cudnn-linux-x86_64-8.5.0.96_cuda11-archive.tar.xz
-        tar xf cudnn-linux-x86_64-8.5.0.96_cuda11-archive.tar.xz
-        mkdir -p "${tmp_cudnn_path}"
-        mv cudnn-linux-x86_64-8.5.0.96_cuda11-archive/include "${tmp_cudnn_path}"
-        mv cudnn-linux-x86_64-8.5.0.96_cuda11-archive/lib "${tmp_cudnn_path}"
-        cd ../
-        rm -rf tmp_cudnn
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_package $BUILD_ENV fbgemm_gpu_nightly
 
-        export CUDNN_INCLUDE_DIR="${tmp_cudnn_path}/include"
-        export CUDNN_LIBRARY="${tmp_cudnn_path}/lib"
-        cd fbgemm_gpu/
-        rm -rf dist
-        # build cuda7.0;8.0 for v100/a100 arch:
-        # Couldn't build more cuda arch due to 300 MB binary size limit from
-        # pypi website.
-        # manylinux1_x86_64 is specified for pypi upload:
-        # distribute python extensions as wheels on Linux
-        conda run -n build_binary \
-          python setup.py bdist_wheel \
-          --package_name=fbgemm_gpu_nightly \
-          --python-tag=${{ matrix.python-tag }} \
-          -DTORCH_CUDA_ARCH_LIST="'7.0;8.0'" \
-          --plat-name=manylinux1_x86_64
-        ls -lt dist/*.whl
-    - name: Upload wheel as GHA artifact
+    - name: Upload Built Wheel as GHA Artifact
       uses: actions/upload-artifact@v2
       with:
         name: fbgemm_gpu_nightly_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
         path: fbgemm_gpu/dist/fbgemm_gpu_nightly-*.whl
 
+
   # download from GHA, test on gpu and push to pypi
   test_on_gpu:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      PRELUDE: .github/scripts/setup_env.bash
+      BUILD_ENV: build_binary
     strategy:
       matrix:
-        os: [linux.g5.4xlarge.nvidia.gpu]
-        python-version: ["3.8", "3.9", "3.10"]
-        cuda-tag: ["cu11"]
+        os: [ linux.g5.4xlarge.nvidia.gpu ]
+        python-version: [ "3.8", "3.9", "3.10" ]
+        cuda-tag: [ "cu11" ]
     needs: build_on_cpu
     steps:
-    - name: Check ldd --version
-      run: ldd --version
-    - name: check cpu info
-      shell: bash
-      run: |
-        cat /proc/cpuinfo
-    - name: check distribution info
-      shell: bash
-      run: |
-        cat /proc/version
-    - name: Display EC2 information
-      shell: bash
-      run: |
-        set -euo pipefail
-        function get_ec2_metadata() {
-          # Pulled from instance metadata endpoint for EC2
-          # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-          category=$1
-          curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-        }
-        echo "ami-id: $(get_ec2_metadata ami-id)"
-        echo "instance-id: $(get_ec2_metadata instance-id)"
-        echo "instance-type: $(get_ec2_metadata instance-type)"
-    - name: check gpu info
-      shell: bash
-      run: |
-        sudo yum install lshw -y
-        sudo lshw -C display
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
+    - name: Checkout the Repository
       uses: actions/checkout@v2
       with:
         submodules: true
-    # Update references
-    - name: Git Sumbodule Update
-      run: |
-        cd fbgemm_gpu/
-        git submodule sync
-        git submodule update --init --recursive
-        git log
-    - name: Update pip
-      run: |
-        sudo yum update -y
-        sudo yum -y install git python3-pip
-        sudo pip3 install --upgrade pip
-    - name: Setup conda
-      run: |
-        wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-        bash ~/miniconda.sh -b -p $HOME/miniconda -u
-    - name: setup Path
-      run: |
-        echo "$HOME/miniconda/bin" >> $GITHUB_PATH
-        echo "CONDA=$HOME/miniconda" >> $GITHUB_PATH
-    - name: create conda env
-      run: |
-        conda create --name build_binary python=${{ matrix.python-version }}
-        conda info
-    - name: check python version without Conda
-      run: |
-        python --version
-    - name: check python version with Conda
-      run: |
-        conda run -n build_binary python --version
-    - name: Install CUDA 11.3
-      shell: bash
-      run: |
-        sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-        sudo yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
-        sudo yum clean expire-cache
-        sudo yum install -y nvidia-driver-latest-dkms
-        sudo yum install -y cuda-11-3
-        sudo yum install -y cuda-drivers
-        sudo yum install -y libcudnn8-devel
-    - name: setup Path
-      run: |
-        echo /usr/local/cuda-11.3/bin >> $GITHUB_PATH
-        echo /usr/local/bin >> $GITHUB_PATH
-    - name: nvcc check
-      run: |
-        nvcc --version
-    - name: Install PyTorch using Conda
-      shell: bash
-      run: |
-        conda install -n build_binary -y pytorch cuda -c pytorch-nightly -c "nvidia/label/cuda-11.7.1"
 
-        # Ensure that CUDA is properly installed
-        conda run -n build_binary which nvcc
-        conda run -n build_binary test -n "$(find $HOME/miniconda -name cuda_runtime.h)"
-        echo "Successfully installed CUDA"
+    - name: Display System Info
+      run: . $PRELUDE; print_system_info
 
-        # Ensure that the PyTorch nightly build is the GPU variant (i.e. contains cuDNN)
-        conda list -n build_binary pytorch | grep cudnn
-        echo "Successfully installed pytorch-nightly"
-    # download wheel from GHA
-    - name: Download wheel
+    - name: Display EC2 Info
+      run: . $PRELUDE; print_ec2_info
+
+    - name: Setup Miniconda
+      run: |
+        . $PRELUDE; setup_miniconda $HOME/miniconda
+        echo "${HOME}/miniconda/bin" >> $GITHUB_PATH
+        echo "CONDA=${HOME}/miniconda" >> $GITHUB_PATH
+
+    - name: Create Conda Environment
+      run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
+
+    - name: Install CUDA
+      run: . $PRELUDE; install_cuda $BUILD_ENV 11.7.1
+
+    # - name: Install CUDA 11.3
+    #   shell: bash
+    #   run: |
+    #     sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    #     sudo yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
+    #     sudo yum clean expire-cache
+    #     sudo yum install -y nvidia-driver-latest-dkms
+    #     sudo yum install -y cuda-11-3
+    #     sudo yum install -y cuda-drivers
+    #     sudo yum install -y libcudnn8-devel
+    # - name: setup Path
+    #   run: |
+    #     echo /usr/local/cuda-11.3/bin >> $GITHUB_PATH
+    #     echo /usr/local/bin >> $GITHUB_PATH
+    # - name: nvcc check
+    #   run: |
+    #     nvcc --version
+
+    - name: Install PyTorch Nightly
+      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV nightly
+
+    - name: Prepare FBGEMM Build
+      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_build $BUILD_ENV
+
+    - name: Download Wheel Artifact from GHA
       uses: actions/download-artifact@v2
       with:
         name: fbgemm_gpu_nightly_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
+
     - name: Display structure of downloaded files
       run: ls -R
-    - name: Install Dependencies
-      shell: bash
-      run: |
-        cd fbgemm_gpu/
-        conda run -n build_binary python -m pip install -r requirements.txt
-    - name: Test Installation of dependencies
-      run: |
-        cd fbgemm_gpu/
-        conda run -n build_binary python -c "import torch.distributed"
-        echo "torch.distributed succeeded"
-        conda run -n build_binary python -c "import skbuild"
-        echo "skbuild succeeded"
-        conda run -n build_binary python -c "import numpy"
-        echo "numpy succeeded"
+
     - name: Install FBGEMM_GPU Nightly
       run: |
         rm -rf dist
@@ -264,7 +157,7 @@ jobs:
         conda run -n build_binary \
           python -c "import fbgemm_gpu"
     - name: Test with pytest
-      # remove this line when we fixed all the unit tests
+      # Remove this line when we fixed all the unit tests
       continue-on-error: true
       run: |
         conda run -n build_binary \
@@ -273,7 +166,7 @@ jobs:
         # can take 5 hours.
         timeout 600s conda run -n build_binary \
           python -m pytest -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors
-    # Push to Pypi
+
     - name: Push FBGEMM_GPU Binary to PYPI
       env:
         PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/fbgemm_nightly_build.yml
+++ b/.github/workflows/fbgemm_nightly_build.yml
@@ -8,9 +8,14 @@ name: Push Binary Nightly
 on:
   # PR Trigger (enable only for debugging)
   [ push, pull_request ]
+
   # Cron Trigger
+  #
+  # Based on the Conda page for PyTorch-nightly, the GPU nightly releases appear
+  # around 02:30 every day (roughly 2 hours after the CPU releases)
   # schedule:
   #   - cron:  '45 03 * * *'
+
   # Manual trigger
   # workflow_dispatch:
 
@@ -25,13 +30,15 @@ jobs:
       PRELUDE: .github/scripts/setup_env.bash
       BUILD_ENV: build_binary
     strategy:
+      # Don't fast-fail all the other builds if one of the them fails
+      fail-fast: false
       matrix:
         os: [ linux.2xlarge ]
         python-version: [ "3.8", "3.9", "3.10" ]
-        cuda-tag: [ "cu11" ]
+        cuda-version: [ "11.7.1" ]
     steps:
     - name: Checkout the Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -54,28 +61,28 @@ jobs:
       run: . $PRELUDE; install_build_tools $BUILD_ENV
 
     - name: Install CUDA
-      run: . $PRELUDE; install_cuda $BUILD_ENV 11.7.1
+      run: . $PRELUDE; install_cuda $BUILD_ENV ${{ matrix.cuda-version }}
 
     - name: Install PyTorch Nightly
       run: . $PRELUDE; install_pytorch_conda $BUILD_ENV nightly
 
     - name: Install cuDNN
-      run: . $PRELUDE; install_cudnn $BUILD_ENV "$(pwd)/build_only/cudnn" 11.7.1
+      run: . $PRELUDE; install_cudnn $BUILD_ENV "$(pwd)/build_only/cudnn" ${{ matrix.cuda-version }}
 
     - name: Prepare FBGEMM Build
-      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_build $BUILD_ENV
+      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
     - name: Build FBGEMM_GPU Nightly
-      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_package $BUILD_ENV fbgemm_gpu_nightly
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_package $BUILD_ENV fbgemm_gpu_nightly
 
     - name: Upload Built Wheel as GHA Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
-        name: fbgemm_gpu_nightly_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
+        name: fbgemm_gpu_nightly_${{ matrix.python-version }}_cuda${{ matrix.cuda-version }}.whl
         path: fbgemm_gpu/dist/fbgemm_gpu_nightly-*.whl
 
 
-  # download from GHA, test on gpu and push to pypi
+  # Download the built artifact from GHA, test on GPU and push to PyPI
   test_on_gpu:
     runs-on: ${{ matrix.os }}
     defaults:
@@ -85,14 +92,15 @@ jobs:
       PRELUDE: .github/scripts/setup_env.bash
       BUILD_ENV: build_binary
     strategy:
+      fail-fast: false
       matrix:
         os: [ linux.g5.4xlarge.nvidia.gpu ]
         python-version: [ "3.8", "3.9", "3.10" ]
-        cuda-tag: [ "cu11" ]
+        cuda-version: [ "11.7.1" ]
     needs: build_on_cpu
     steps:
     - name: Checkout the Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -112,7 +120,7 @@ jobs:
       run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
 
     - name: Install CUDA
-      run: . $PRELUDE; install_cuda $BUILD_ENV 11.7.1
+      run: . $PRELUDE; install_cuda $BUILD_ENV ${{ matrix.cuda-version }}
 
     # - name: Install CUDA 11.3
     #   shell: bash
@@ -136,12 +144,12 @@ jobs:
       run: . $PRELUDE; install_pytorch_conda $BUILD_ENV nightly
 
     - name: Prepare FBGEMM Build
-      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_build $BUILD_ENV
+      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
     - name: Download Wheel Artifact from GHA
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
-        name: fbgemm_gpu_nightly_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
+        name: fbgemm_gpu_nightly_${{ matrix.python-version }}_cuda${{ matrix.cuda-version }}.whl
 
     - name: Display structure of downloaded files
       run: ls -R
@@ -149,34 +157,27 @@ jobs:
     - name: Install FBGEMM_GPU Nightly
       run: |
         rm -rf dist
-        conda run -n build_binary \
+        conda run -n $BUILD_ENV \
           python -m pip install *.whl
-    - name: Test fbgemm_gpu installation
+
+    - name: Test FBGEMM_GPU Installation
       shell: bash
       run: |
-        conda run -n build_binary \
+        conda run -n $BUILD_ENV \
           python -c "import fbgemm_gpu"
+
     - name: Test with pytest
       # Remove this line when we fixed all the unit tests
       continue-on-error: true
       run: |
-        conda run -n build_binary \
+        conda run -n $BUILD_ENV \
           python -m pip install pytest
         # The tests with single CPU core on a less powerful testing GPU in GHA
         # can take 5 hours.
-        timeout 600s conda run -n build_binary \
+        timeout 600s conda run -n $BUILD_ENV \
           python -m pytest -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors
 
     - name: Push FBGEMM_GPU Binary to PYPI
       env:
         PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      run: |
-        conda run -n build_binary python -m pip install twine
-        # Official PYPI website
-        conda run -n build_binary \
-          python -m twine upload \
-            --username __token__ \
-            --password "$PYPI_TOKEN" \
-            --skip-existing \
-            --verbose \
-            fbgemm_gpu_nightly-*.whl
+      run: . $PRELUDE; publish_to_pypi $BUILD_ENV fbgemm_gpu_nightly-*.whl "$PYPI_TOKEN"

--- a/.github/workflows/fbgemm_nightly_build.yml
+++ b/.github/workflows/fbgemm_nightly_build.yml
@@ -3,27 +3,35 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-name: Push FBGEMM_GPU Nightly
+name: FBGEMM_GPU Nightly Build
 
 on:
-  # PR Trigger (enable only for debugging)
+  # PR Trigger (enabled only for debugging)
   #
-   [ push, pull_request ]
+  pull_request:
+    branches:
+      - main
+
+  # Push Trigger (enable to catch errors coming out of multiple merges)
+  #
+  push:
+    branches:
+      - main
 
   # Cron Trigger
   #
   # Based on the Conda page for PyTorch-nightly, the GPU nightly releases appear
   # around 02:30 every day (roughly 2 hours after the CPU releases)
   #
-  # schedule:
-  #   - cron:  '45 03 * * *'
+  schedule:
+    - cron:  '45 04 * * *'
 
   # Manual trigger
   #
-  # workflow_dispatch:
+  workflow_dispatch:
 
 jobs:
-  # build on cpu hosts and upload to GHA
+  # Build on CPU hosts and upload to GHA
   build_on_cpu:
     runs-on: ${{ matrix.os }}
     defaults:
@@ -36,7 +44,7 @@ jobs:
       # Don't fast-fail all the other builds if one of the them fails
       fail-fast: false
       matrix:
-        os: [ linux.2xlarge ]
+        os: [ linux.12xlarge ]
         python-version: [ "3.8", "3.9", "3.10" ]
         cuda-version: [ "11.7.1" ]
 
@@ -86,7 +94,7 @@ jobs:
         path: fbgemm_gpu/dist/fbgemm_gpu_nightly-*.whl
 
 
-  # Download the built artifact from GHA, test on GPU and push to PyPI
+  # Download the built artifact from GHA, test on GPU, and push to PyPI
   test_on_gpu:
     runs-on: ${{ matrix.os }}
     defaults:
@@ -164,6 +172,7 @@ jobs:
           python -m pytest -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors
 
     - name: Push FBGEMM_GPU Binary to PYPI
+      if: ${{ github.event_name != 'pull_request' && github.event_name != 'push' }}
       env:
         PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
       run: . $PRELUDE; publish_to_pypi $BUILD_ENV fbgemm_gpu_nightly-*.whl "$PYPI_TOKEN"

--- a/.github/workflows/fbgemm_nightly_build_cpu.yml
+++ b/.github/workflows/fbgemm_nightly_build_cpu.yml
@@ -8,9 +8,14 @@ name: Push CPU Binary Nightly
 on:
   # PR Trigger (enable only for debugging)
   [ push, pull_request ]
+
   # Cron Trigger
+  #
+  # Based on the Conda page for PyTorch-nightly, the CPU nightly releases appear
+  # around 00:30 every day
   # schedule:
   #   - cron:  '45 03 * * *'
+
   # Manual trigger
   # workflow_dispatch:
 
@@ -25,6 +30,8 @@ jobs:
       PRELUDE: .github/scripts/setup_env.bash
       BUILD_ENV: build_binary
     strategy:
+      # Don't fast-fail all the other builds if one of the them fails
+      fail-fast: false
       matrix:
         os: [ linux.2xlarge ]
         python-version: [ "3.8", "3.9", "3.10" ]
@@ -32,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout the Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -58,108 +65,28 @@ jobs:
       run: . $PRELUDE; install_pytorch_conda $BUILD_ENV nightly 1
 
     - name: Prepare FBGEMM Build
-      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_build $BUILD_ENV
+      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
     - name: Build FBGEMM_GPU Nightly (CPU version)
-      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_package $BUILD_ENV fbgemm_gpu_nightly 1
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_package $BUILD_ENV fbgemm_gpu_nightly 1
 
-    # # Update references
-    # - name: Git Sumbodule Update
-    #   run: |
-    #     cd fbgemm_gpu/
-    #     git submodule sync
-    #     git submodule update --init --recursive
-    # - name: Update pip
-    #   run: |
-    #     sudo yum update -y
-    #     sudo yum -y install git python3-pip
-    #     sudo pip3 install --upgrade pip
-    # - name: Setup conda
-    #   run: |
-    #     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-    #     bash ~/miniconda.sh -b -p $HOME/miniconda -u
-    # - name: Setup PATH with conda
-    #   run: |
-    #     echo "/home/ec2-user/miniconda/bin" >> $GITHUB_PATH
-    #     echo "CONDA=/home/ec2-user/miniconda" >> $GITHUB_PATH
-    # - name: Create conda env
-    #   run: |
-    #     conda create --name build_binary python=${{ matrix.python-version }}
-    #     conda info
-    # - name: check python version
-    #   run: |
-    #     conda run -n build_binary python --version
-    # - name: Install gcc
-    #   shell: bash
-    #   run: |
-    #     sudo yum group install -y "Development Tools"
-    # - name: setup Path
-    #   run: |
-    #     echo /usr/local/bin >> $GITHUB_PATH
-    # - name: Install PyTorch
-    #   shell: bash
-    #   run: |
-    #     conda run -n build_binary python -m pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-    # - name: Install Dependencies
-    #   shell: bash
-    #   run: |
-    #     cd fbgemm_gpu/
-    #     conda run -n build_binary python -m pip install -r requirements.txt
-    # - name: Test Installation of dependencies
-    #   run: |
-    #     cd fbgemm_gpu/
-    #     conda run -n build_binary python -c "import torch.distributed"
-    #     echo "torch.distributed succeeded"
-    #     conda run -n build_binary python -c "import skbuild"
-    #     echo "skbuild succeeded"
-    #     conda run -n build_binary python -c "import numpy"
-    #     echo "numpy succeeded"
-    # - name: Build FBGEMM_GPU Nightly
-    #   run: |
-    #     cd fbgemm_gpu/
-    #     rm -r dist || true
-    #     # buld cuda7.0;8.0 for v100/a100 arch:
-    #     # Couldn't build more cuda arch due to 100 MB binary size limit from
-    #     # pypi website.
-    #     # manylinux1_x86_64 is specified for pypi upload:
-    #     # distribute python extensions as wheels on Linux
-    #     conda run -n build_binary \
-    #       python setup.py bdist_wheel \
-    #       --package_name=fbgemm_gpu_nightly-cpu \
-    #       --python-tag=${{ matrix.python-tag }} \
-    #       --cpu_only \
-    #       --plat-name=manylinux1_x86_64
-    #     ls -lt dist/*.whl
     - name: Upload Built Wheel as GHA Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: fbgemm_gpu_nightly_cpu_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
         path: fbgemm_gpu/dist/fbgemm_gpu_nightly_cpu-*.whl
-
-    # - name: Install Dependencies
-    #   shell: bash
-    #   run: |
-    #     cd fbgemm_gpu/
-    #     conda run -n build_binary python -m pip install -r requirements.txt
-    # - name: Test Installation of dependencies
-    #   run: |
-    #     cd fbgemm_gpu/
-    #     conda run -n build_binary python -c "import torch.distributed"
-    #     echo "torch.distributed succeeded"
-    #     conda run -n build_binary python -c "import skbuild"
-    #     echo "skbuild succeeded"
-    #     conda run -n build_binary python -c "import numpy"
-    #     echo "numpy succeeded"
 
     - name: Install FBGEMM_GPU Nightly (CPU version)
       run: |
         conda run -n build_binary \
           python -m pip install fbgemm_gpu/dist/fbgemm_gpu_nightly_cpu-*.whl
-    - name: Test fbgemm_gpu installation
+
+    - name: Test FBGEMM_GPU installation
       shell: bash
       run: |
         conda run -n build_binary \
           python -c "import fbgemm_gpu"
+
     - name: Test with pytest
       # remove this line when we fixed all the unit tests
       continue-on-error: true
@@ -170,17 +97,8 @@ jobs:
         # can take 5 hours.
         timeout 600s conda run -n build_binary \
           python -m pytest -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors
-    # Push to Pypi
-    - name: Push FBGEMM_GPU Binary to PYPI
+
+    - name: Push FBGEMM_GPU (CPU version) Binary to PYPI
       env:
         PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      run: |
-        conda run -n build_binary python -m pip install twine
-        # Official PYPI website
-        conda run -n build_binary \
-          python -m twine upload \
-            --username __token__ \
-            --password "$PYPI_TOKEN" \
-            --skip-existing \
-            --verbose \
-            fbgemm_gpu/dist/fbgemm_gpu_nightly_cpu-*.whl
+      run: . $PRELUDE; publish_to_pypi $BUILD_ENV fbgemm_gpu_nightly-*.whl "$PYPI_TOKEN"

--- a/.github/workflows/fbgemm_nightly_build_cpu.yml
+++ b/.github/workflows/fbgemm_nightly_build_cpu.yml
@@ -3,20 +3,23 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-name: Push CPU Binary Nightly
+name: Push FBGEMM_GPU-CPU Nightly
 
 on:
   # PR Trigger (enable only for debugging)
+  #
   [ push, pull_request ]
 
   # Cron Trigger
   #
   # Based on the Conda page for PyTorch-nightly, the CPU nightly releases appear
   # around 00:30 every day
+  #
   # schedule:
   #   - cron:  '45 03 * * *'
 
   # Manual trigger
+  #
   # workflow_dispatch:
 
 jobs:

--- a/.github/workflows/fbgemm_nightly_build_cpu.yml
+++ b/.github/workflows/fbgemm_nightly_build_cpu.yml
@@ -1,131 +1,156 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
 
 name: Push CPU Binary Nightly
 
 on:
-  # # For debugging, enable push/pull_request
-  # [push, pull_request]
-  # run every day at 10:45 AM
-  schedule:
-    - cron:  '45 10 * * *'
-  # or manually trigger it
-  workflow_dispatch:
+  # PR Trigger (enable only for debugging)
+  [ push, pull_request ]
+  # Cron Trigger
+  # schedule:
+  #   - cron:  '45 03 * * *'
+  # Manual trigger
+  # workflow_dispatch:
 
 jobs:
   # build, test, and upload to GHA on cpu hosts
   build_test_upload:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      PRELUDE: .github/scripts/setup_env.bash
+      BUILD_ENV: build_binary
     strategy:
       matrix:
-        include:
-         - os: linux.2xlarge
-           python-version: "3.8"
-           python-tag: "py38"
-           cuda-tag: "cpu"
-         - os: linux.2xlarge
-           python-version: "3.9"
-           python-tag: "py39"
-           cuda-tag: "cpu"
-         - os: linux.2xlarge
-           python-version: "3.10"
-           python-tag: "py310"
-           cuda-tag: "cpu"
+        os: [ linux.2xlarge ]
+        python-version: [ "3.8", "3.9", "3.10" ]
+        cuda-tag: [ "cpu" ]
+
     steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Check ldd --version
-      run: ldd --version
-    - name: Checkout
+    - name: Checkout the Repository
       uses: actions/checkout@v2
       with:
         submodules: true
-    # Update references
-    - name: Git Sumbodule Update
+
+    - name: Display System Info
+      run: . $PRELUDE; print_system_info
+
+    - name: Setup Miniconda
       run: |
-        cd fbgemm_gpu/
-        git submodule sync
-        git submodule update --init --recursive
-    - name: Update pip
-      run: |
-        sudo yum update -y
-        sudo yum -y install git python3-pip
-        sudo pip3 install --upgrade pip
-    - name: Setup conda
-      run: |
-        wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-        bash ~/miniconda.sh -b -p $HOME/miniconda -u
-    - name: Setup PATH with conda
-      run: |
-        echo "/home/ec2-user/miniconda/bin" >> $GITHUB_PATH
-        echo "CONDA=/home/ec2-user/miniconda" >> $GITHUB_PATH
-    - name: Create conda env
-      run: |
-        conda create --name build_binary python=${{ matrix.python-version }}
-        conda info
-    - name: check python version
-      run: |
-        conda run -n build_binary python --version
-    - name: Install gcc
-      shell: bash
-      run: |
-        sudo yum group install -y "Development Tools"
-    - name: setup Path
-      run: |
-        echo /usr/local/bin >> $GITHUB_PATH
-    - name: Install PyTorch
-      shell: bash
-      run: |
-        conda run -n build_binary python -m pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-    - name: Install Dependencies
-      shell: bash
-      run: |
-        cd fbgemm_gpu/
-        conda run -n build_binary python -m pip install -r requirements.txt
-    - name: Test Installation of dependencies
-      run: |
-        cd fbgemm_gpu/
-        conda run -n build_binary python -c "import torch.distributed"
-        echo "torch.distributed succeeded"
-        conda run -n build_binary python -c "import skbuild"
-        echo "skbuild succeeded"
-        conda run -n build_binary python -c "import numpy"
-        echo "numpy succeeded"
-    - name: Build FBGEMM_GPU Nightly
-      run: |
-        cd fbgemm_gpu/
-        rm -r dist || true
-        # buld cuda7.0;8.0 for v100/a100 arch:
-        # Couldn't build more cuda arch due to 100 MB binary size limit from
-        # pypi website.
-        # manylinux1_x86_64 is specified for pypi upload:
-        # distribute python extensions as wheels on Linux
-        conda run -n build_binary \
-          python setup.py bdist_wheel \
-          --package_name=fbgemm_gpu_nightly-cpu \
-          --python-tag=${{ matrix.python-tag }} \
-          --cpu_only \
-          --plat-name=manylinux1_x86_64
-        ls -lt dist/*.whl
-    - name: Upload wheel as GHA artifact
+        . $PRELUDE; setup_miniconda $HOME/miniconda
+        echo "${HOME}/miniconda/bin" >> $GITHUB_PATH
+        echo "CONDA=${HOME}/miniconda" >> $GITHUB_PATH
+
+    - name: Create Conda Environment
+      run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
+
+    - name: Install C/C++ Compilers
+      run: . $PRELUDE; install_cxx_compiler $BUILD_ENV
+
+    - name: Install Build Tools
+      run: . $PRELUDE; install_build_tools $BUILD_ENV
+
+    - name: Install PyTorch-CPU Nightly
+      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV nightly 1
+
+    - name: Prepare FBGEMM Build
+      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_build $BUILD_ENV
+
+    - name: Build FBGEMM_GPU Nightly (CPU version)
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_package $BUILD_ENV fbgemm_gpu_nightly 1
+
+    # # Update references
+    # - name: Git Sumbodule Update
+    #   run: |
+    #     cd fbgemm_gpu/
+    #     git submodule sync
+    #     git submodule update --init --recursive
+    # - name: Update pip
+    #   run: |
+    #     sudo yum update -y
+    #     sudo yum -y install git python3-pip
+    #     sudo pip3 install --upgrade pip
+    # - name: Setup conda
+    #   run: |
+    #     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+    #     bash ~/miniconda.sh -b -p $HOME/miniconda -u
+    # - name: Setup PATH with conda
+    #   run: |
+    #     echo "/home/ec2-user/miniconda/bin" >> $GITHUB_PATH
+    #     echo "CONDA=/home/ec2-user/miniconda" >> $GITHUB_PATH
+    # - name: Create conda env
+    #   run: |
+    #     conda create --name build_binary python=${{ matrix.python-version }}
+    #     conda info
+    # - name: check python version
+    #   run: |
+    #     conda run -n build_binary python --version
+    # - name: Install gcc
+    #   shell: bash
+    #   run: |
+    #     sudo yum group install -y "Development Tools"
+    # - name: setup Path
+    #   run: |
+    #     echo /usr/local/bin >> $GITHUB_PATH
+    # - name: Install PyTorch
+    #   shell: bash
+    #   run: |
+    #     conda run -n build_binary python -m pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+    # - name: Install Dependencies
+    #   shell: bash
+    #   run: |
+    #     cd fbgemm_gpu/
+    #     conda run -n build_binary python -m pip install -r requirements.txt
+    # - name: Test Installation of dependencies
+    #   run: |
+    #     cd fbgemm_gpu/
+    #     conda run -n build_binary python -c "import torch.distributed"
+    #     echo "torch.distributed succeeded"
+    #     conda run -n build_binary python -c "import skbuild"
+    #     echo "skbuild succeeded"
+    #     conda run -n build_binary python -c "import numpy"
+    #     echo "numpy succeeded"
+    # - name: Build FBGEMM_GPU Nightly
+    #   run: |
+    #     cd fbgemm_gpu/
+    #     rm -r dist || true
+    #     # buld cuda7.0;8.0 for v100/a100 arch:
+    #     # Couldn't build more cuda arch due to 100 MB binary size limit from
+    #     # pypi website.
+    #     # manylinux1_x86_64 is specified for pypi upload:
+    #     # distribute python extensions as wheels on Linux
+    #     conda run -n build_binary \
+    #       python setup.py bdist_wheel \
+    #       --package_name=fbgemm_gpu_nightly-cpu \
+    #       --python-tag=${{ matrix.python-tag }} \
+    #       --cpu_only \
+    #       --plat-name=manylinux1_x86_64
+    #     ls -lt dist/*.whl
+    - name: Upload Built Wheel as GHA Artifact
       uses: actions/upload-artifact@v2
       with:
         name: fbgemm_gpu_nightly_cpu_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
         path: fbgemm_gpu/dist/fbgemm_gpu_nightly_cpu-*.whl
 
-    - name: Install Dependencies
-      shell: bash
-      run: |
-        cd fbgemm_gpu/
-        conda run -n build_binary python -m pip install -r requirements.txt
-    - name: Test Installation of dependencies
-      run: |
-        cd fbgemm_gpu/
-        conda run -n build_binary python -c "import torch.distributed"
-        echo "torch.distributed succeeded"
-        conda run -n build_binary python -c "import skbuild"
-        echo "skbuild succeeded"
-        conda run -n build_binary python -c "import numpy"
-        echo "numpy succeeded"
+    # - name: Install Dependencies
+    #   shell: bash
+    #   run: |
+    #     cd fbgemm_gpu/
+    #     conda run -n build_binary python -m pip install -r requirements.txt
+    # - name: Test Installation of dependencies
+    #   run: |
+    #     cd fbgemm_gpu/
+    #     conda run -n build_binary python -c "import torch.distributed"
+    #     echo "torch.distributed succeeded"
+    #     conda run -n build_binary python -c "import skbuild"
+    #     echo "skbuild succeeded"
+    #     conda run -n build_binary python -c "import numpy"
+    #     echo "numpy succeeded"
+
     - name: Install FBGEMM_GPU Nightly (CPU version)
       run: |
         conda run -n build_binary \

--- a/.github/workflows/fbgemm_nightly_build_cpu.yml
+++ b/.github/workflows/fbgemm_nightly_build_cpu.yml
@@ -3,27 +3,35 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-name: Push FBGEMM_GPU-CPU Nightly
+name: FBGEMM_GPU-CPU Nightly Build
 
 on:
   # PR Trigger (enable only for debugging)
   #
-  [ push, pull_request ]
+  pull_request:
+    branches:
+      - main
+
+  # Push Trigger (enable to catch errors coming out of multiple merges)
+  #
+  push:
+    branches:
+      - main
 
   # Cron Trigger
   #
   # Based on the Conda page for PyTorch-nightly, the CPU nightly releases appear
   # around 00:30 every day
   #
-  # schedule:
-  #   - cron:  '45 03 * * *'
+  schedule:
+    - cron:  '45 04 * * *'
 
   # Manual trigger
   #
-  # workflow_dispatch:
+  workflow_dispatch:
 
 jobs:
-  # build, test, and upload to GHA on cpu hosts
+  # Build on CPU hosts, run tests, and upload to GHA
   build_test_upload:
     runs-on: ${{ matrix.os }}
     defaults:
@@ -36,7 +44,7 @@ jobs:
       # Don't fast-fail all the other builds if one of the them fails
       fail-fast: false
       matrix:
-        os: [ linux.2xlarge ]
+        os: [ linux.4xlarge ]
         python-version: [ "3.8", "3.9", "3.10" ]
         cuda-tag: [ "cpu" ]
 
@@ -90,8 +98,8 @@ jobs:
         conda run -n build_binary \
           python -c "import fbgemm_gpu"
 
-    - name: Test with pytest
-      # remove this line when we fixed all the unit tests
+    - name: Test with PyTest
+      # Remove this line when we have fixed all the unit tests
       continue-on-error: true
       run: |
         conda run -n build_binary \
@@ -102,6 +110,7 @@ jobs:
           python -m pytest -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors
 
     - name: Push FBGEMM_GPU (CPU version) Binary to PYPI
+      if: ${{ github.event_name != 'pull_request' && github.event_name != 'push' }}
       env:
         PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
       run: . $PRELUDE; publish_to_pypi $BUILD_ENV fbgemm_gpu_nightly-*.whl "$PYPI_TOKEN"

--- a/.github/workflows/fbgemm_release_build.yml
+++ b/.github/workflows/fbgemm_release_build.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Check ldd --version
       run: ldd --version
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
     # Update references
@@ -117,7 +117,7 @@ jobs:
           --plat-name=manylinux1_x86_64
         ls -lt dist/*.whl
     - name: Upload wheel as GHA artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: fbgemm_gpu_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
         path: fbgemm_gpu/dist/fbgemm_gpu-*.whl
@@ -162,7 +162,7 @@ jobs:
         sudo lshw -C display
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
     # Update references
@@ -220,7 +220,7 @@ jobs:
         #  python -m pip install --pre torch -f https://download.pytorch.org/whl/test/cu117/torch_test.html
     # download wheel from GHA
     - name: Download wheel
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: fbgemm_gpu_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
     - name: Display structure of downloaded files

--- a/.github/workflows/fbgemm_release_build_cpu.yml
+++ b/.github/workflows/fbgemm_release_build_cpu.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Check ldd --version
       run: ldd --version
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
     # Update references
@@ -109,7 +109,7 @@ jobs:
           --plat-name=manylinux1_x86_64
         ls -lt dist/*.whl
     - name: Upload wheel as GHA artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: fbgemm_gpu_cpu_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
         path: fbgemm_gpu/dist/fbgemm_gpu_cpu-*.whl

--- a/.github/workflows/fbgemmci.yml
+++ b/.github/workflows/fbgemmci.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Checkout submodules
       shell: bash
       run: |
@@ -85,7 +85,7 @@ jobs:
         os: [windows-2019]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Checkout submodules
       shell: bash
       run: |
@@ -151,7 +151,7 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Checkout submodules
       shell: bash
       run: |
@@ -195,83 +195,147 @@ jobs:
 
   build_nvidia_gpu:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      PRELUDE: .github/scripts/setup_env.bash
+      BUILD_ENV: build_binary
     strategy:
+      # Don't fast-fail all the other builds if one of the them fails
+      fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
-        config: [[pip, 11.3], [pip, 11.5], [pip, 11.6], [pip, 11.7], [conda, 11.7.1]]
-
+        os: [ ubuntu-20.04 ]
+        cuda-version: [ 11.5.2, 11.6.2, 11.7.1 ]
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout the Repository
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Display System Info
+      run: . $PRELUDE; print_system_info
+
+    - name: Setup Miniconda
+      run: |
+        . $PRELUDE; setup_miniconda $HOME/miniconda
+        echo "${HOME}/miniconda/bin" >> $GITHUB_PATH
+        echo "CONDA=${HOME}/miniconda" >> $GITHUB_PATH
+
+    - name: Create Conda Environment
+      run: . $PRELUDE; create_conda_environment $BUILD_ENV 3.8
+
+    - name: Install C/C++ Compilers
+      run: . $PRELUDE; install_cxx_compiler $BUILD_ENV
+
+    - name: Install Build Tools
+      run: . $PRELUDE; install_build_tools $BUILD_ENV
 
     - name: Install CUDA
-      shell: bash
-      if: matrix.config[0] == 'pip'
-      run: |
-        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
-        sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
-        # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772
-        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
-        sudo dpkg -i cuda-keyring_1.0-1_all.deb
-        # sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
-        sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
-        sudo apt-get update
-        # "11.5 -> 11-5"
-        cuda_apt_version=$(echo "${{ matrix.config[1] }}" | sed "s/\./-/")
-        sudo apt-get -y install cuda-minimal-build-${cuda_apt_version} cuda-nvrtc-dev-${cuda_apt_version} cuda-nvtx-${cuda_apt_version} cuda-libraries-dev-${cuda_apt_version}
-        sudo apt-get -y install libcudnn8-dev
+      run: . $PRELUDE; install_cuda $BUILD_ENV "${{ matrix.cuda-version }}"
 
-    - name: Install dependencies
-      shell: bash
-      run: |
-        if [ x"${{ matrix.config[0] }}" == x"pip" ]; then
-          # pip-based installation
-          sudo apt-get update
-          sudo apt-get -y install git pip python3-dev
-          sudo pip install cmake scikit-build ninja jinja2 numpy hypothesis --no-input
-          # Install pytorch built with CUDA 11.3 in all cases
-          sudo pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
-        else
-          # conda-based installation
-          wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-          bash ~/miniconda.sh -b -p $HOME/miniconda -u
-          eval "$($HOME/miniconda/bin/conda shell.bash hook)"
-          cuda_version="${{ matrix.config[1] }}"
-          conda install -y pytorch cuda -c pytorch-nightly -c "nvidia/label/cuda-${cuda_version}"
-          conda install -y -c conda-forge cudnn
-          conda install -y numpy scikit-build jinja2 ninja cmake hypothesis
-        fi
-    - name: Checkout submodules
-      shell: bash
-      run: |
-        cd fbgemm_gpu
-        git submodule sync
-        git submodule update --init --recursive
+    - name: Install PyTorch
+      run:  . $PRELUDE; install_pytorch_pip $BUILD_ENV nightly cuda "${{ matrix.cuda-version }}"
 
-    - name: Build fbgemm_gpu
-      shell: bash
-      run: |
-        cd fbgemm_gpu
-        if [ x"${{ matrix.config[0] }}" == x"pip" ]; then
-          CUDA_PATH="/usr/local/cuda-${{ matrix.config[1] }}"
-          sudo CUDACXX="${CUDA_PATH}/bin/nvcc" python setup.py install -DTORCH_CUDA_ARCH_LIST="6.0"
-        else
-          eval "$($HOME/miniconda/bin/conda shell.bash hook)"
-          python setup.py install -DTORCH_CUDA_ARCH_LIST="6.0"
-        fi
+    - name: Install cuDNN
+      run: . $PRELUDE; install_cudnn $BUILD_ENV "$(pwd)/build_only/cudnn" "${{ matrix.cuda-version }}"
 
-    - name: Test fbgemm_gpu installation
+    - name: Prepare FBGEMM Build
+      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
+
+    - name: Build and Install FBGEMM_GPU
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_install $BUILD_ENV
+
+    - name: Test FBGEMM_GPU installation
       shell: bash
       run: |
-        if [ x"${{ matrix.config[0] }}" == x"conda" ]; then
-          eval "$($HOME/miniconda/bin/conda shell.bash hook)"
-        fi
-        cd fbgemm_gpu
-        cd test
-        python input_combine_test.py -v
-        python quantize_ops_test.py -v
-        python sparse_ops_test.py -v
-        python -c "import fbgemm_gpu"
-        python -c "import fbgemm_gpu.split_embedding_codegen_lookup_invokers"
+        . $PRELUDE;
+        cd fbgemm_gpu/test
+        print_exec conda run -n $BUILD_ENV python input_combine_test.py -v
+        print_exec conda run -n $BUILD_ENV python quantize_ops_test.py -v
+        print_exec conda run -n $BUILD_ENV python sparse_ops_test.py -v
+        print_exec conda run -n $BUILD_ENV python -c "import fbgemm_gpu"
+        print_exec conda run -n $BUILD_ENV python -c "import fbgemm_gpu.split_embedding_codegen_lookup_invokers"
+
+  # build_nvidia_gpu:
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-20.04]
+  #       config: [[pip, 11.3], [pip, 11.5], [pip, 11.6], [pip, 11.7], [conda, 11.7.1]]
+
+  #   steps:
+  #   - uses: actions/checkout@v3
+
+  #   - name: Install CUDA
+  #     shell: bash
+  #     if: matrix.config[0] == 'pip'
+  #     run: |
+  #       wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
+  #       sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
+  #       # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772
+  #       wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
+  #       sudo dpkg -i cuda-keyring_1.0-1_all.deb
+  #       # sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+  #       sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
+  #       sudo apt-get update
+  #       # "11.5 -> 11-5"
+  #       cuda_apt_version=$(echo "${{ matrix.config[1] }}" | sed "s/\./-/")
+  #       sudo apt-get -y install cuda-minimal-build-${cuda_apt_version} cuda-nvrtc-dev-${cuda_apt_version} cuda-nvtx-${cuda_apt_version} cuda-libraries-dev-${cuda_apt_version}
+  #       sudo apt-get -y install libcudnn8-dev
+
+  #   - name: Install dependencies
+  #     shell: bash
+  #     run: |
+  #       if [ x"${{ matrix.config[0] }}" == x"pip" ]; then
+  #         # pip-based installation
+  #         sudo apt-get update
+  #         sudo apt-get -y install git pip python3-dev
+  #         sudo pip install cmake scikit-build ninja jinja2 numpy hypothesis --no-input
+  #         # Install pytorch built with CUDA 11.3 in all cases
+  #         sudo pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
+  #       else
+  #         # conda-based installation
+  #         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+  #         bash ~/miniconda.sh -b -p $HOME/miniconda -u
+  #         eval "$($HOME/miniconda/bin/conda shell.bash hook)"
+  #         cuda_version="${{ matrix.config[1] }}"
+  #         conda install -y pytorch cuda -c pytorch-nightly -c "nvidia/label/cuda-${cuda_version}"
+  #         conda install -y -c conda-forge cudnn
+  #         conda install -y numpy scikit-build jinja2 ninja cmake hypothesis
+  #       fi
+  #   - name: Checkout submodules
+  #     shell: bash
+  #     run: |
+  #       cd fbgemm_gpu
+  #       git submodule sync
+  #       git submodule update --init --recursive
+
+  #   - name: Build fbgemm_gpu
+  #     shell: bash
+  #     run: |
+  #       cd fbgemm_gpu
+  #       if [ x"${{ matrix.config[0] }}" == x"pip" ]; then
+  #         CUDA_PATH="/usr/local/cuda-${{ matrix.config[1] }}"
+  #         sudo CUDACXX="${CUDA_PATH}/bin/nvcc" python setup.py install -DTORCH_CUDA_ARCH_LIST="6.0"
+  #       else
+  #         eval "$($HOME/miniconda/bin/conda shell.bash hook)"
+  #         python setup.py install -DTORCH_CUDA_ARCH_LIST="6.0"
+  #       fi
+
+  #   - name: Test fbgemm_gpu installation
+  #     shell: bash
+  #     run: |
+  #       if [ x"${{ matrix.config[0] }}" == x"conda" ]; then
+  #         eval "$($HOME/miniconda/bin/conda shell.bash hook)"
+  #       fi
+  #       cd fbgemm_gpu
+  #       cd test
+  #       python input_combine_test.py -v
+  #       python quantize_ops_test.py -v
+  #       python sparse_ops_test.py -v
+  #       python -c "import fbgemm_gpu"
+  #       python -c "import fbgemm_gpu.split_embedding_codegen_lookup_invokers"
 
   build_amd_gpu:
     runs-on: ${{ matrix.os }}
@@ -284,7 +348,7 @@ jobs:
     - name: Free space
       run: sudo rm -rf /usr/local/android /usr/share/dotnet /usr/local/share/boost /opt/ghc /usr/local/share/chrom* /usr/share/swift /usr/local/julia* /usr/local/lib/android
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install ROCm
       shell: bash
@@ -352,7 +416,7 @@ jobs:
         sudo apt update
         sudo apt -y install --only-upgrade git
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.ref }}
         submodules: 'true'
@@ -383,6 +447,7 @@ jobs:
         docker run $DOCKER_OPTIONS $DOCKER_IMAGE $JENKINS_REPO_DIR_DOCKER/.jenkins/rocm/build_and_test.sh $JENKINS_REPO_DIR_DOCKER
 
   test_nvidia_gpu:
+    if: ${{ false }}  # Disable the job for now
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       job-name: cuda 11.7, A10
@@ -412,7 +477,7 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/push_wheel_trigger.yml
+++ b/.github/workflows/push_wheel_trigger.yml
@@ -3,8 +3,8 @@ name: Push Wheel
 on:
   # For debugging, please use test_wheel_*.yml
   # run every day at 10:30 AM
-  schedule:
-    - cron:  '30 10 * * *'
+  # schedule:
+  #   - cron:  '30 10 * * *'
   # or manually trigger it
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -1,4 +1,4 @@
-name: Lint
+name: FBGEMM_GPU Lint
 
 on:
   push:

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         python-version: ["3.8"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/fbgemm_gpu/requirements.txt
+++ b/fbgemm_gpu/requirements.txt
@@ -1,6 +1,6 @@
 cmake
 hypothesis
-Jinja2
+jinja2
 ninja
 numpy
 scikit-build


### PR DESCRIPTION
Summary of the changes:

- Add well-defined functions that perform steps of the installation well, with verbose logging
- Redefine the nightly builds using the functions defined in `setup_env.bash`
- Split up the FBGEMM CI jobs into FBGEMM CI and FBGEMM_GPU CI
- Enable the nightly builds jobs to run in PR and push mode, BUT with the publish to PyPI step disabled
- Remove support for building against older CUDA versions
- Upgrade the build machines for the nightly GPU builds to linux.x12large, thus reducing the build time from over 3.5 hours to 11 minutes
- Disable the FBGEMM_GPU CIs for now, until we figure out what is broken