### PR TITLE
Make the address of grad_output aligned to 16b for batched unary embeddings

### DIFF
--- a/fbgemm_gpu/src/sparse_ops_gpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_gpu.cpp
@@ -141,8 +141,16 @@ class LookupFunctionBatchedUnaryEmbeddingOp
     // .contiguous() is called on the gradient inputs because
     // the batched_unary_embeddings_backward_cuda assumes contiguous inputs.
     // may cause illegal memory access when it is not
+    auto grad_output = grad_outputs[0];
+    if (reinterpret_cast<uint64_t>(grad_output.data_ptr()) % 16 != 0 ||
+        grad_output.stride(1) != 1 || grad_output.stride(0) % 4 != 0) {
+      grad_output = grad_output.contiguous();
+    }
+    if (reinterpret_cast<uint64_t>(grad_output.data_ptr()) % 16 != 0) {
+      grad_output = at::empty_like(grad_output).copy_(grad_output);
+    }
     auto grad_weight = batched_unary_embeddings_backward_cuda(
-        grad_outputs[0].contiguous(), weight, table_offsets, offsets, indices);
+        grad_output, weight, table_offsets, offsets, indices);
     return {grad_weight, Tensor(), Tensor(), Tensor()};
   }
 };

--- a/fbgemm_gpu/test/batched_unary_embeddings_test.py
+++ b/fbgemm_gpu/test/batched_unary_embeddings_test.py
@@ -151,18 +151,15 @@ class TableBatchedEmbeddingsTest(unittest.TestCase):
         # Testing the case where we add permute operation, which produces
         # in contiguous grad tensor, this should also work
         unary_embedding_module = batched_unary_embeddings_ops.BatchedUnaryEmbeddingBag(
-            num_tasks=2,
-            hash_sizes=[100, 100],
+            num_tasks=3,
+            hash_sizes=[71, 107],
             long_index=True,
         ).to(device)
         offsets = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.long).to(device)
         values = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8], dtype=torch.long).to(device)
         for _ in range(10):
             output = unary_embedding_module(offsets, values).transpose(1, 0)
-            # this magical statement is needed to create the illegal memory access
-            # that would be triggered if non-contiguous grad input is not
-            # well handled. I don't understand why
-            output.__repr__()
+            output = output[1:]
             output.sum().backward()
 
     @unittest.skipIf(*gpu_unavailable)


### PR DESCRIPTION
Summary: Follow up on D42596622 (https://github.com/pytorch/FBGEMM/commit/948a0731e3ba992065bb7202859ded994eb5fde6)

Differential Revision: D43292553

