### PR TITLE
[T145005253] Re-enable Tests for OSS PR Builds

### DIFF
--- a/.github/scripts/setup_env.bash
+++ b/.github/scripts/setup_env.bash
@@ -93,6 +93,66 @@ test_env_var () {
   fi
 }
 
+install_system_packages () {
+  if [ $# -le 0 ]; then
+    echo "Usage: ${FUNCNAME[0]} PACKAGE_NAME ... "
+    echo "Example(s):"
+    echo "    ${FUNCNAME[0]} miopen-hip miopen-hip-dev"
+    return 1
+  fi
+
+  if which sudo; then
+    update_cmd=("sudo")
+    install_cmd=("sudo")
+  else
+    update_cmd=()
+    install_cmd=()
+  fi
+
+  if which apt-get; then
+    update_cmd+=(apt update -y)
+    install_cmd+=(apt install -y "$@")
+  elif which yum; then
+    update_cmd+=(yum update -y)
+    install_cmd+=(yum install -y "$@")
+  else
+    echo "[INSTALL] Could not find a system package installer to install packages!"
+    return 1
+  fi
+
+  echo "[INSTALL] Updating system repositories ..."
+  # shellcheck disable=SC2068
+  print_exec ${update_cmd[@]}
+
+  # shellcheck disable=SC2145
+  echo "[INSTALL] Installing system package(s): $@ ..."
+  # shellcheck disable=SC2068
+  print_exec ${install_cmd[@]}
+}
+
+run_python_test () {
+  env_name="$1"
+  python_test_file="$2"
+  if [ "$python_test_file" == "" ]; then
+    echo "Usage: ${FUNCNAME[0]} ENV_NAME PYTHON_TEST_FILE"
+    echo "Example(s):"
+    echo "    ${FUNCNAME[0]} build_env quantize_ops_test.py"
+    return 1
+  else
+    echo "################################################################################"
+    echo "# [$(date --utc +%FT%T.%3NZ)] Run Python Test Suite:"
+    echo "#   ${python_test_file}"
+    echo "################################################################################"
+  fi
+
+  if conda run -n "${env_name}" python -m pytest -v -s -W ignore::pytest.PytestCollectionWarning "${python_test_file}"; then
+    echo "[TEST] Python test suite PASSED: ${python_test_file}"
+  else
+    echo "[TEST] Python test suite FAILED: ${python_test_file}"
+    return 1
+  fi
+}
+
 print_system_info () {
   echo "################################################################################"
   echo "# Print System Info"
@@ -114,12 +174,7 @@ print_system_info () {
   print_exec cat /etc/os-release
 
   echo "[INFO] Check GPU info"
-  if which apt-get; then
-    print_exec sudo apt-get install -y lshw
-  else
-    print_exec sudo yum install -y lshw
-  fi
-
+  install_system_packages lshw
   print_exec sudo lshw -C display
 }
 
@@ -412,10 +467,6 @@ install_cuda () {
   # Ensure that the libraries are properly installed
   test_filepath "${env_name}" libnvToolsExt.so || return 1
 
-  # LIBNVTOOLSEXT
-  # CUDA_TOOLKIT_ROOT_DIR
-  # print_exec conda env config vars set -n "${env_name}" CUDNN_INCLUDE_DIR="${install_path}/include" CUDNN_LIBRARY="${install_path}/lib"
-
   # Print nvcc version
   print_exec conda run -n "${env_name}" nvcc --version
   echo "[INSTALL] Successfully installed CUDA ${cuda_version}"
@@ -440,9 +491,8 @@ install_cxx_compiler () {
   fi
 
   if [ "$use_yum" != "" ]; then
-    echo "[INSTALL] Installing C/C++ compilers through Yum ..."
-    print_exec sudo yum update -y
-    print_exec sudo yum install -y gcc gcc-c++
+    echo "[INSTALL] Installing C/C++ compilers through yum ..."
+    install_system_packages gcc gcc-c++
   else
     # Install gxx_linux-64 from main instead of cxx-compiler from conda-forge, as
     # the latter breaks builds:
@@ -797,28 +847,6 @@ install_fbgemm_gpu_package () {
   echo "[BUILD] Wheel installation completed ..."
 }
 
-run_python_test () {
-  env_name="$1"
-  python_test_file="$2"
-  if [ "$python_test_file" == "" ]; then
-    echo "Usage: ${FUNCNAME[0]} ENV_NAME PYTHON_TEST_FILE"
-    echo "Example(s):"
-    echo "    ${FUNCNAME[0]} build_env quantize_ops_test.py"
-    return 1
-  else
-    echo "################################################################################"
-    echo "# [$(date --utc +%FT%T.%3NZ)] Run Python Test Suite:"
-    echo "#   ${python_test_file}"
-    echo "################################################################################"
-  fi
-
-  if conda run -n "${env_name}" python -m pytest -v -s -W ignore::pytest.PytestCollectionWarning "${python_test_file}"; then
-    echo "[TEST] Python test suite PASSED: ${python_test_file}"
-  else
-    echo "[TEST] Python test suite FAILED: ${python_test_file}"
-    return 1
-  fi
-}
 
 ################################################################################
 # Publish Functions
@@ -859,8 +887,11 @@ run_fbgemm_gpu_tests () {
     unstable_tests=()
   fi
 
-  echo "[INSTALL] Installing pytest ..."
+  echo "[TEST] Installing pytest ..."
   print_exec conda install -n "${env_name}" -y pytest
+
+  echo "[BUILD] Checking imports ..."
+  test_python_import "${env_name}" fbgemm_gpu || return 1
 
   # NOTE: These tests running on single CPU core with a less powerful testing
   # GPU in GHA can take up to 5 hours.

--- a/.github/workflows/fbgemm_gpu_ci.yml
+++ b/.github/workflows/fbgemm_gpu_ci.yml
@@ -14,81 +14,6 @@ on:
       - main
 
 jobs:
-  build_nvidia_gpu:
-    if: ${{ false }}  # Disable the job for now
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
-    env:
-      PRELUDE: .github/scripts/setup_env.bash
-      BUILD_ENV: build_binary
-    strategy:
-      # Don't fast-fail all the other builds if one of the them fails
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-20.04 ]
-        python-version: [ "3.8" ]
-        # As of version 2.0, PyTorch has dropped support for CUDA 11.6
-        cuda-version: [ 11.7.1 ]
-
-    steps:
-    - name: Checkout the Repository
-      uses: actions/checkout@v3
-      with:
-        submodules: true
-
-    - name: Display System Info
-      run: . $PRELUDE; print_system_info
-
-    - name: Setup Miniconda
-      run: |
-        . $PRELUDE; setup_miniconda $HOME/miniconda
-        echo "${HOME}/miniconda/bin" >> $GITHUB_PATH
-        echo "CONDA=${HOME}/miniconda" >> $GITHUB_PATH
-
-    - name: Create Conda Environment
-      run: |
-        . $PRELUDE
-        create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
-
-        # This hack is needed to get builds running properly on Ubuntu 20.04
-        echo "[SETUP] Creating symlink \$CONDA_PREFIX/lib64 -> \$CONDA_PREFIX/lib ..."
-        conda_prefix=$(conda run -n "${env_name}" printenv CONDA_PREFIX)
-        ln -s "${conda_prefix}/lib" "${conda_prefix}/lib64"
-
-    # - name: Install C/C++ Compilers
-    #   run: . $PRELUDE; install_cxx_compiler $BUILD_ENV
-
-    - name: Install Build Tools
-      run: . $PRELUDE; install_build_tools $BUILD_ENV
-
-    - name: Install CUDA
-      run: . $PRELUDE; install_cuda $BUILD_ENV "${{ matrix.cuda-version }}"
-
-    - name: Install PyTorch
-      run:  . $PRELUDE; install_pytorch_pip $BUILD_ENV nightly cuda "${{ matrix.cuda-version }}"
-
-    - name: Install cuDNN
-      run: . $PRELUDE; install_cudnn $BUILD_ENV "$(pwd)/build_only/cudnn" "${{ matrix.cuda-version }}"
-
-    - name: Prepare FBGEMM Build
-      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
-
-    - name: Build and Install FBGEMM_GPU
-      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_install $BUILD_ENV
-
-    - name: Test FBGEMM_GPU installation
-      shell: bash
-      run: |
-        . $PRELUDE;
-        cd fbgemm_gpu/test
-        print_exec conda run -n $BUILD_ENV python input_combine_test.py -v
-        print_exec conda run -n $BUILD_ENV python quantize_ops_test.py -v
-        print_exec conda run -n $BUILD_ENV python sparse_ops_test.py -v
-        conda run -n $BUILD_ENV python -c "import fbgemm_gpu"
-        conda run -n $BUILD_ENV python -c "import fbgemm_gpu.split_embedding_codegen_lookup_invokers"
-
   build_amd_gpu:
     if: ${{ false }}  # Disable the job for now
     runs-on: ${{ matrix.os }}
@@ -200,71 +125,48 @@ jobs:
         "
         docker run $DOCKER_OPTIONS $DOCKER_IMAGE $JENKINS_REPO_DIR_DOCKER/.jenkins/rocm/build_and_test.sh $JENKINS_REPO_DIR_DOCKER
 
-  test_nvidia_gpu:
-    if: ${{ false }}  # Disable the job for now
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
-    with:
-      job-name: cuda 11.7, A10
-      runner: linux.g5.4xlarge.nvidia.gpu # A10
-      repository: pytorch/fbgemm
-      gpu-arch-type: cuda
-      gpu-arch-version: 11.7
-      timeout: 150
-      script: |
-        set -x
-        # Checkout FBGEMM_GPU
-        git submodule update --init
-
-        # Build FBGEMM_GPU with pytorch-nightly
-        CUDA_VERSION="11.7.1"
-        PYTHON_VERSION="3.10"
-        bash .github/scripts/build_wheel.bash -v -p "$PYTHON_VERSION" -o fbgemm_gpu_test -P pytorch-nightly -c "$CUDA_VERSION" -m /opt/conda
-
-        # Test FBGEMM_GPU using a generated wheel file
-        WHEEL_PATH="$(ls fbgemm_gpu/dist/*.whl)"
-        bash .github/scripts/test_wheel.bash -v -p "$PYTHON_VERSION" -P pytorch-nightly -c "$CUDA_VERSION" -w "$WHEEL_PATH" -m /opt/conda
-
-  build_cpu_only:
+  build_and_test_cpu:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      PRELUDE: .github/scripts/setup_env.bash
+      BUILD_ENV: build_binary
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ ubuntu-20.04, ubuntu-latest ]
+        python-version: [ "3.8", "3.9", "3.10" ]
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout the Repository
+      uses: actions/checkout@v3
+      with:
+        submodules: true
 
-    - name: Install dependencies
-      shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get -y install git pip python3-dev
-        sudo pip install cmake scikit-build ninja jinja2 numpy hypothesis --no-input
-        # Install PyTorch (nightly) as required by fbgemm_gpu
-        sudo pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+    - name: Display System Info
+      run: . $PRELUDE; print_system_info
 
-    - name: Checkout submodules
-      shell: bash
+    - name: Setup Miniconda
       run: |
-        cd fbgemm_gpu
-        git submodule sync
-        git submodule update --init --recursive
+        . $PRELUDE; setup_miniconda $HOME/miniconda
+        echo "${HOME}/miniconda/bin" >> $GITHUB_PATH
+        echo "CONDA=${HOME}/miniconda" >> $GITHUB_PATH
 
-    - name: Build fbgemm_gpu
-      shell: bash
-      run: |
-        cd fbgemm_gpu
-        # to avoid "Permission denied" error in '/usr/local/lib/python3.8/dist-packages/' folder
-        sudo python setup.py install --cpu_only
+    - name: Create Conda Environment
+      run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
 
-    - name: Test fbgemm_gpu cpu-only installation
-      shell: bash
-      run: |
-        cd fbgemm_gpu
-        cd test
-        python batched_unary_embeddings_test.py -v
-        python input_combine_test.py -v
-        python layout_transform_ops_test.py -v
-        python merge_pooled_embeddings_test.py -v
-        python permute_pooled_embedding_modules_test.py -v
-        python quantize_ops_test.py -v
-        python sparse_ops_test.py -v
+    - name: Install Build Tools
+      run: . $PRELUDE; install_build_tools $BUILD_ENV
+
+    - name: Install PyTorch
+      run:  . $PRELUDE; install_pytorch_pip $BUILD_ENV nightly cpu
+
+    - name: Prepare FBGEMM Build
+      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
+
+    - name: Build and Install FBGEMM_GPU (CPU version)
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_install $BUILD_ENV cpuonly
+
+    - name: Test with PyTest
+      run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV cpuonly

--- a/.github/workflows/fbgemm_gpu_lint.yml
+++ b/.github/workflows/fbgemm_gpu_lint.yml
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 name: FBGEMM_GPU Lint
 
 on:
@@ -8,24 +13,26 @@ on:
   pull_request:
     branches:
       - main
+
 jobs:
-  build:
+  run_pylint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: [ "3.8" ]
     steps:
     - uses: actions/checkout@v3
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+
+    - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ufmt
-        pip install click
-        pip install flake8
+        pip install click flake8 ufmt
+
     - name: Analyzing the code with flake8
       run: |
         echo "::add-matcher::fbgemm_gpu/test/lint/flake8_problem_matcher.json"
@@ -33,11 +40,13 @@ jobs:
         # E501 = line too long
         # W503 = line break before binary operator (deprecated)
         # E203 = whitespace before ":"
+
     - name: Analyzing the code with ufmt
       run: |
         ufmt diff fbgemm_gpu/fbgemm_gpu
         ufmt diff fbgemm_gpu/test
         ufmt diff fbgemm_gpu/bench
+
     - name: Check Meta copyright header
       run: |
         python fbgemm_gpu/test/lint/check_meta_header.py --path=./fbgemm_gpu/fbgemm_gpu --fixit=False

--- a/.github/workflows/fbgemm_nightly_build.yml
+++ b/.github/workflows/fbgemm_nightly_build.yml
@@ -18,21 +18,21 @@ on:
     branches:
       - main
 
-  # Cron Trigger
+  # Cron Trigger (UTC)
   #
   # Based on the Conda page for PyTorch-nightly, the GPU nightly releases appear
-  # around 02:30 every day (roughly 2 hours after the CPU releases)
+  # around 02:30 PST every day (roughly 2 hours after the CPU releases)
   #
   schedule:
-    - cron:  '45 04 * * *'
+    - cron:  '45 12 * * *'
 
-  # Manual trigger
+  # Manual Trigger
   #
   workflow_dispatch:
 
 jobs:
   # Build on CPU hosts and upload to GHA
-  build_on_cpu:
+  build_artifact:
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -95,7 +95,7 @@ jobs:
 
 
   # Download the built artifact from GHA, test on GPU, and push to PyPI
-  test_on_gpu:
+  test_and_publish_artifact:
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -109,7 +109,8 @@ jobs:
         os: [ linux.g5.4xlarge.nvidia.gpu ]
         python-version: [ "3.8", "3.9", "3.10" ]
         cuda-version: [ "11.7.1" ]
-    needs: build_on_cpu
+    needs: build_artifact
+
     steps:
     - name: Checkout the Repository
       uses: actions/checkout@v3
@@ -145,33 +146,18 @@ jobs:
       with:
         name: fbgemm_gpu_nightly_${{ matrix.python-version }}_cuda${{ matrix.cuda-version }}.whl
 
-    - name: Display structure of downloaded files
+    - name: Display Structure of the Downloaded Files
       run: ls -R
 
     - name: Install FBGEMM_GPU Nightly
-      run: |
-        rm -rf dist
-        conda run -n $BUILD_ENV \
-          python -m pip install *.whl
-
-    - name: Test FBGEMM_GPU Installation
-      shell: bash
-      run: |
-        conda run -n $BUILD_ENV \
-          python -c "import fbgemm_gpu"
+      run: . $PRELUDE; install_fbgemm_gpu_package $BUILD_ENV *.whl
 
     - name: Test with PyTest
       # Remove this line when we fixed all the unit tests
       continue-on-error: true
-      run: |
-        conda run -n $BUILD_ENV \
-          python -m pip install pytest
-        # The tests with single CPU core on a less powerful testing GPU in GHA
-        # can take 5 hours.
-        timeout 600s conda run -n $BUILD_ENV \
-          python -m pytest -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors
+      run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV
 
-    - name: Push FBGEMM_GPU Binary to PYPI
+    - name: Push FBGEMM_GPU Nightly Binary to PYPI
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'push' }}
       env:
         PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/fbgemm_nightly_build_cpu.yml
+++ b/.github/workflows/fbgemm_nightly_build_cpu.yml
@@ -6,7 +6,7 @@
 name: FBGEMM_GPU-CPU Nightly Build
 
 on:
-  # PR Trigger (enable only for debugging)
+  # PR Trigger (enabled only for debugging)
   #
   pull_request:
     branches:
@@ -18,21 +18,21 @@ on:
     branches:
       - main
 
-  # Cron Trigger
+  # Cron Trigger (UTC)
   #
   # Based on the Conda page for PyTorch-nightly, the CPU nightly releases appear
-  # around 00:30 every day
+  # around 00:30 PST every day
   #
   schedule:
-    - cron:  '45 04 * * *'
+    - cron:  '45 12 * * *'
 
-  # Manual trigger
+  # Manual Trigger
   #
   workflow_dispatch:
 
 jobs:
   # Build on CPU hosts, run tests, and upload to GHA
-  build_test_upload:
+  build_artifact:
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -46,7 +46,6 @@ jobs:
       matrix:
         os: [ linux.4xlarge ]
         python-version: [ "3.8", "3.9", "3.10" ]
-        cuda-tag: [ "cpu" ]
 
     steps:
     - name: Checkout the Repository
@@ -73,44 +72,80 @@ jobs:
       run: . $PRELUDE; install_build_tools $BUILD_ENV
 
     - name: Install PyTorch-CPU Nightly
-      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV nightly 1
+      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV nightly cpuonly
 
     - name: Prepare FBGEMM Build
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
     - name: Build FBGEMM_GPU Nightly (CPU version)
-      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_package $BUILD_ENV fbgemm_gpu_nightly 1
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_package $BUILD_ENV fbgemm_gpu_nightly cpuonly
 
     - name: Upload Built Wheel as GHA Artifact
       uses: actions/upload-artifact@v3
       with:
-        name: fbgemm_gpu_nightly_cpu_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
+        name: fbgemm_gpu_nightly_cpu_${{ matrix.python-version }}.whl
         path: fbgemm_gpu/dist/fbgemm_gpu_nightly_cpu-*.whl
 
-    - name: Install FBGEMM_GPU Nightly (CPU version)
-      run: |
-        conda run -n build_binary \
-          python -m pip install fbgemm_gpu/dist/fbgemm_gpu_nightly_cpu-*.whl
 
-    - name: Test FBGEMM_GPU installation
-      shell: bash
+  # Download the built artifact from GHA, test on GPU, and push to PyPI
+  test_and_publish_artifact:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      PRELUDE: .github/scripts/setup_env.bash
+      BUILD_ENV: build_binary
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ linux.g5.4xlarge.nvidia.gpu ]
+        python-version: [ "3.8", "3.9", "3.10" ]
+    needs: build_artifact
+
+    steps:
+    - name: Checkout the Repository
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Display System Info
+      run: . $PRELUDE; print_system_info
+
+    - name: Display EC2 Info
+      run: . $PRELUDE; print_ec2_info
+
+    - name: Setup Miniconda
       run: |
-        conda run -n build_binary \
-          python -c "import fbgemm_gpu"
+        . $PRELUDE; setup_miniconda $HOME/miniconda
+        echo "${HOME}/miniconda/bin" >> $GITHUB_PATH
+        echo "CONDA=${HOME}/miniconda" >> $GITHUB_PATH
+
+    - name: Create Conda Environment
+      run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
+
+    - name: Install PyTorch Nightly
+      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV nightly cpuonly
+
+    - name: Prepare FBGEMM Build
+      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
+
+    - name: Download Wheel Artifact from GHA
+      uses: actions/download-artifact@v3
+      with:
+        name: fbgemm_gpu_nightly_cpu_${{ matrix.python-version }}.whl
+
+    - name: Display Structure of the Downloaded Files
+      run: ls -R
+
+    - name: Install FBGEMM_GPU Nightly (CPU version)
+      run: . $PRELUDE; install_fbgemm_gpu_package $BUILD_ENV *.whl
 
     - name: Test with PyTest
-      # Remove this line when we have fixed all the unit tests
-      continue-on-error: true
-      run: |
-        conda run -n build_binary \
-          python -m pip install pytest
-        # The tests with single CPU core on a less powerful testing GPU in GHA
-        # can take 5 hours.
-        timeout 600s conda run -n build_binary \
-          python -m pytest -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors
+      run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV cpuonly
 
-    - name: Push FBGEMM_GPU (CPU version) Binary to PYPI
+    - name: Push FBGEMM_GPU Nightly (CPU version) Binary to PYPI
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'push' }}
       env:
         PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      run: . $PRELUDE; publish_to_pypi $BUILD_ENV fbgemm_gpu_nightly-*.whl "$PYPI_TOKEN"
+      run: . $PRELUDE; publish_to_pypi $BUILD_ENV fbgemm_gpu_nightly_cpu-*.whl "$PYPI_TOKEN"

--- a/.github/workflows/fbgemm_release_build.yml
+++ b/.github/workflows/fbgemm_release_build.yml
@@ -1,275 +1,155 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
 
-name: Push Binary Release
+name: FBGEMM_GPU Release Build
 
 on:
-  # # For debugging, enable push/pull_request
-  # [push, pull_request]
-  # # run every day at 10:45 AM
-  # schedule:
-  #   - cron:  '45 10 * * *'
-  # # or manually trigger it
-  # workflow_dispatch:
+  # PR Trigger (enabled only for debugging)
+  #
+  pull_request:
+    branches:
+      - main
+
+  # Push Trigger (enable to catch errors coming out of multiple merges)
+  #
+  push:
+    branches:
+      - main
+
+  # Manual Trigger
+  #
+  workflow_dispatch:
 
 jobs:
-  # build on cpu hosts and upload to GHA
-  build_on_cpu:
+  # Build on CPU hosts and upload to GHA
+  build_artifact:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      PRELUDE: .github/scripts/setup_env.bash
+      BUILD_ENV: build_binary
     strategy:
+      # Don't fast-fail all the other builds if one of the them fails
+      fail-fast: false
       matrix:
-        include:
-         - os: linux.2xlarge
-           python-version: "3.8"
-           python-tag: "py38"
-           cuda-tag: "cu11"
-         - os: linux.2xlarge
-           python-version: "3.9"
-           python-tag: "py39"
-           cuda-tag: "cu11"
-         - os: linux.2xlarge
-           python-version: "3.10"
-           python-tag: "py310"
-           cuda-tag: "cu11"
+        os: [ linux.12xlarge ]
+        python-version: [ "3.8", "3.9", "3.10" ]
+        cuda-version: [ "11.7.1" ]
+
     steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Check ldd --version
-      run: ldd --version
-    - name: Checkout
+    - name: Checkout the Repository
       uses: actions/checkout@v3
       with:
         submodules: true
-    # Update references
-    - name: Git Submodule Update
+
+    - name: Display System Info
+      run: . $PRELUDE; print_system_info
+
+    - name: Setup Miniconda
       run: |
-        cd fbgemm_gpu/
-        git submodule sync
-        git submodule update --init --recursive
-    - name: Setup conda
-      run: |
-        wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-        bash ~/miniconda.sh -b -p $HOME/miniconda -u
-    - name: Setup PATH with conda
-      run: |
+        . $PRELUDE; setup_miniconda $HOME/miniconda
         echo "${HOME}/miniconda/bin" >> $GITHUB_PATH
         echo "CONDA=${HOME}/miniconda" >> $GITHUB_PATH
-    - name: Create conda env
-      run: |
-        conda create --name build_binary python=${{ matrix.python-version }}
-        conda info
-    - name: check python version
-      run: |
-        conda run -n build_binary python --version
-    - name: Install C/C++ compilers
-      run: |
-        sudo yum install -y gcc gcc-c++
-    - name: Install PyTorch and CUDA
-      shell: bash
-      run: |
-        conda install -n build_binary -y pytorch cuda -c pytorch-test -c "nvidia/label/cuda-11.7.1"
-        #conda run -n build_binary \
-        #  python -m pip install --pre torch -f https://download.pytorch.org/whl/test/cu117/torch_test.html
-    - name: Install Other Dependencies
-      shell: bash
-      run: |
-        cd fbgemm_gpu/
-        conda run -n build_binary python -m pip install -r requirements.txt
-    - name: Test Installation of Dependencies
-      run: |
-        cd fbgemm_gpu/
-        conda run -n build_binary python -c "import torch.distributed"
-        echo "torch.distributed succeeded"
-        conda run -n build_binary python -c "import skbuild"
-        echo "skbuild succeeded"
-        conda run -n build_binary python -c "import numpy"
-        echo "numpy succeeded"
-    # for the conda run with quotes, we have to use "\" and double quotes
-    # here is the issue: https://github.com/conda/conda/issues/10972
-    - name: Build FBGEMM_GPU Release
-      run: |
-        # Install cuDNN. This is needed to build FBGEMM but not for execution.
-        # See https://github.com/pytorch/builder/blob/main/common/install_cuda.sh
-        tmp_cudnn_path="$(pwd)/build_only/cudnn"
-        mkdir -p tmp_cudnn
-        cd tmp_cudnn
-        wget -q https://ossci-linux.s3.amazonaws.com/cudnn-linux-x86_64-8.5.0.96_cuda11-archive.tar.xz -O cudnn-linux-x86_64-8.5.0.96_cuda11-archive.tar.xz
-        tar xf cudnn-linux-x86_64-8.5.0.96_cuda11-archive.tar.xz
-        mkdir -p "${tmp_cudnn_path}"
-        mv cudnn-linux-x86_64-8.5.0.96_cuda11-archive/include "${tmp_cudnn_path}"
-        mv cudnn-linux-x86_64-8.5.0.96_cuda11-archive/lib "${tmp_cudnn_path}"
-        cd ../
-        rm -rf tmp_cudnn
 
-        export CUDNN_INCLUDE_DIR="${tmp_cudnn_path}/include"
-        export CUDNN_LIBRARY="${tmp_cudnn_path}/lib"
-        cd fbgemm_gpu/
-        rm -rf dist
-        # build cuda7.0;8.0 for v100/a100 arch:
-        # Couldn't build more cuda arch due to 300 MB binary size limit from
-        # pypi website.
-        # manylinux1_x86_64 is specified for pypi upload:
-        # distribute python extensions as wheels on Linux
-        conda run -n build_binary \
-          python setup.py bdist_wheel \
-          --package_name=fbgemm_gpu \
-          --python-tag=${{ matrix.python-tag }} \
-          -DTORCH_CUDA_ARCH_LIST="'7.0;8.0'" \
-          --plat-name=manylinux1_x86_64
-        ls -lt dist/*.whl
-    - name: Upload wheel as GHA artifact
+    - name: Create Conda Environment
+      run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
+
+    - name: Install C/C++ Compilers
+      run: . $PRELUDE; install_cxx_compiler $BUILD_ENV
+
+    - name: Install Build Tools
+      run: . $PRELUDE; install_build_tools $BUILD_ENV
+
+    - name: Install CUDA
+      run: . $PRELUDE; install_cuda $BUILD_ENV ${{ matrix.cuda-version }}
+
+    - name: Install PyTorch Test
+      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV test
+
+    - name: Install cuDNN
+      run: . $PRELUDE; install_cudnn $BUILD_ENV "$(pwd)/build_only/cudnn" ${{ matrix.cuda-version }}
+
+    - name: Prepare FBGEMM Build
+      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
+
+    - name: Build FBGEMM_GPU
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_package $BUILD_ENV fbgemm_gpu
+
+    - name: Upload Built Wheel as GHA Artifact
       uses: actions/upload-artifact@v3
       with:
-        name: fbgemm_gpu_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
+        name: fbgemm_gpu_${{ matrix.python-version }}_cuda${{ matrix.cuda-version }}.whl
         path: fbgemm_gpu/dist/fbgemm_gpu-*.whl
 
-  # download from GHA, test on gpu and push to pypi
-  test_on_gpu:
+
+  # Download the built artifact from GHA, test on GPU, and push to PyPI
+  test_and_publish_artifact:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      PRELUDE: .github/scripts/setup_env.bash
+      BUILD_ENV: build_binary
     strategy:
+      fail-fast: false
       matrix:
-        os: [linux.g5.4xlarge.nvidia.gpu]
-        python-version: ["3.8", "3.9", "3.10"]
-        cuda-tag: ["cu11"]
-    needs: build_on_cpu
+        os: [ linux.g5.4xlarge.nvidia.gpu ]
+        python-version: [ "3.8", "3.9", "3.10" ]
+        cuda-version: [ "11.7.1" ]
+    needs: build_artifact
     steps:
-    - name: Check ldd --version
-      run: ldd --version
-    - name: check cpu info
-      shell: bash
-      run: |
-        cat /proc/cpuinfo
-    - name: check distribution info
-      shell: bash
-      run: |
-        cat /proc/version
-    - name: Display EC2 information
-      shell: bash
-      run: |
-        set -euo pipefail
-        function get_ec2_metadata() {
-          # Pulled from instance metadata endpoint for EC2
-          # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-          category=$1
-          curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-        }
-        echo "ami-id: $(get_ec2_metadata ami-id)"
-        echo "instance-id: $(get_ec2_metadata instance-id)"
-        echo "instance-type: $(get_ec2_metadata instance-type)"
-    - name: check gpu info
-      shell: bash
-      run: |
-        sudo yum install lshw -y
-        sudo lshw -C display
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
+    - name: Checkout the Repository
       uses: actions/checkout@v3
       with:
         submodules: true
-    # Update references
-    - name: Git Sumbodule Update
+
+    - name: Display System Info
+      run: . $PRELUDE; print_system_info
+
+    - name: Display EC2 Info
+      run: . $PRELUDE; print_ec2_info
+
+    - name: Setup Miniconda
       run: |
-        cd fbgemm_gpu/
-        git submodule sync
-        git submodule update --init --recursive
-        git log
-    - name: Update pip
-      run: |
-        sudo yum update -y
-        sudo yum -y install git python3-pip
-        sudo pip3 install --upgrade pip
-    - name: Setup conda
-      run: |
-        wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-        bash ~/miniconda.sh -b -p $HOME/miniconda -u
-    - name: setup Path
-      run: |
-        echo "$HOME/miniconda/bin" >> $GITHUB_PATH
-        echo "CONDA=$HOME/miniconda" >> $GITHUB_PATH
-    - name: create conda env
-      run: |
-        conda create --name build_binary python=${{ matrix.python-version }}
-        conda info
-    - name: check python version without Conda
-      run: |
-        python --version
-    - name: check python version with Conda
-      run: |
-        conda run -n build_binary python --version
-    - name: Install CUDA 11.3
-      shell: bash
-      run: |
-        sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-        sudo yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
-        sudo yum clean expire-cache
-        sudo yum install -y nvidia-driver-latest-dkms
-        sudo yum install -y cuda-11-3
-        sudo yum install -y cuda-drivers
-        sudo yum install -y libcudnn8-devel
-    - name: setup Path
-      run: |
-        echo /usr/local/cuda-11.3/bin >> $GITHUB_PATH
-        echo /usr/local/bin >> $GITHUB_PATH
-    - name: nvcc check
-      run: |
-        nvcc --version
-    - name: Install PyTorch using Conda
-      shell: bash
-      run: |
-        conda install -n build_binary -y pytorch cuda -c pytorch-test -c "nvidia/label/cuda-11.7.1"
-        #conda run -n build_binary \
-        #  python -m pip install --pre torch -f https://download.pytorch.org/whl/test/cu117/torch_test.html
-    # download wheel from GHA
-    - name: Download wheel
+        . $PRELUDE; setup_miniconda $HOME/miniconda
+        echo "${HOME}/miniconda/bin" >> $GITHUB_PATH
+        echo "CONDA=${HOME}/miniconda" >> $GITHUB_PATH
+
+    - name: Create Conda Environment
+      run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
+
+    - name: Install CUDA
+      run: . $PRELUDE; install_cuda $BUILD_ENV ${{ matrix.cuda-version }}
+
+    - name: Install PyTorch Test
+      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV test
+
+    - name: Prepare FBGEMM Build
+      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
+
+    - name: Download Wheel Artifact from GHA
       uses: actions/download-artifact@v3
       with:
-        name: fbgemm_gpu_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
-    - name: Display structure of downloaded files
+        name: fbgemm_gpu_${{ matrix.python-version }}_cuda${{ matrix.cuda-version }}.whl
+
+    - name: Display Structure of the Downloaded Files
       run: ls -R
-    - name: Install Dependencies
-      shell: bash
-      run: |
-        cd fbgemm_gpu/
-        conda run -n build_binary python -m pip install -r requirements.txt
-    - name: Test Installation of dependencies
-      run: |
-        cd fbgemm_gpu/
-        conda run -n build_binary python -c "import torch.distributed"
-        echo "torch.distributed succeeded"
-        conda run -n build_binary python -c "import skbuild"
-        echo "skbuild succeeded"
-        conda run -n build_binary python -c "import numpy"
-        echo "numpy succeeded"
-    - name: Install FBGEMM_GPU Release
-      run: |
-        rm -rf dist
-        conda run -n build_binary \
-          python -m pip install *.whl
-    - name: Test fbgemm_gpu installation
-      shell: bash
-      run: |
-        conda run -n build_binary \
-          python -c "import fbgemm_gpu"
-    - name: Test with pytest
-      # remove this line when we fixed all the unit tests
+
+    - name: Install FBGEMM_GPU
+      run: . $PRELUDE; install_fbgemm_gpu_package $BUILD_ENV *.whl
+
+    - name: Test with PyTest
+      # Remove this line when we fixed all the unit tests
       continue-on-error: true
-      run: |
-        conda run -n build_binary \
-          python -m pip install pytest
-        # The tests with single CPU core on a less powerful testing GPU in GHA
-        # can take 5 hours.
-        timeout 600s conda run -n build_binary \
-          python -m pytest -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors
-    # Push to Pypi
+      run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV
+
     - name: Push FBGEMM_GPU Binary to PYPI
+      if: ${{ github.event_name != 'pull_request' && github.event_name != 'push' }}
       env:
         PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      run: |
-        conda run -n build_binary python -m pip install twine
-        # Official PYPI website
-        conda run -n build_binary \
-          python -m twine upload \
-            --username __token__ \
-            --password "$PYPI_TOKEN" \
-            --skip-existing \
-            --verbose \
-            fbgemm_gpu-*.whl
+      run: . $PRELUDE; publish_to_pypi $BUILD_ENV fbgemm_gpu-*.whl "$PYPI_TOKEN"

--- a/.github/workflows/fbgemm_release_build_cpu.yml
+++ b/.github/workflows/fbgemm_release_build_cpu.yml
@@ -1,163 +1,143 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
 
-name: Push CPU Binary Release
+name: FBGEMM_GPU-CPU Release Build
 
 on:
-  # # For debugging, enable push/pull_request
-  # [push, pull_request]
-  # # run every day at 10:45 AM
-  # schedule:
-  #   - cron:  '45 10 * * *'
-  # # or manually trigger it
-  # workflow_dispatch:
+  # PR Trigger (enabled only for debugging)
+  #
+  pull_request:
+    branches:
+      - main
+
+  # Push Trigger (enable to catch errors coming out of multiple merges)
+  #
+  push:
+    branches:
+      - main
+
+  # Manual Trigger
+  #
+  workflow_dispatch:
 
 jobs:
-  # build, test, and upload to GHA on cpu hosts
-  build_test_upload:
+  # Build on CPU hosts, run tests, and upload to GHA
+  build_artifact:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      PRELUDE: .github/scripts/setup_env.bash
+      BUILD_ENV: build_binary
     strategy:
+      # Don't fast-fail all the other builds if one of the them fails
+      fail-fast: false
       matrix:
-        include:
-         - os: linux.2xlarge
-           python-version: "3.8"
-           python-tag: "py38"
-           cuda-tag: "cpu"
-         - os: linux.2xlarge
-           python-version: "3.9"
-           python-tag: "py39"
-           cuda-tag: "cpu"
-         - os: linux.2xlarge
-           python-version: "3.10"
-           python-tag: "py310"
-           cuda-tag: "cpu"
+        os: [ linux.4xlarge ]
+        python-version: [ "3.8", "3.9", "3.10" ]
+
     steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Check ldd --version
-      run: ldd --version
-    - name: Checkout
+    - name: Checkout the Repository
       uses: actions/checkout@v3
       with:
         submodules: true
-    # Update references
-    - name: Git Sumbodule Update
-      run: |
-        cd fbgemm_gpu/
-        git submodule sync
-        git submodule update --init --recursive
-    - name: Update pip
-      run: |
-        sudo yum update -y
-        sudo yum -y install git python3-pip
-        sudo pip3 install --upgrade pip
-    - name: Setup conda
-      run: |
-        wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-        bash ~/miniconda.sh -b -p $HOME/miniconda -u
-    - name: Setup PATH with conda
-      run: |
-        echo "/home/ec2-user/miniconda/bin" >> $GITHUB_PATH
-        echo "CONDA=/home/ec2-user/miniconda" >> $GITHUB_PATH
-    - name: Create conda env
-      run: |
-        conda create --name build_binary python=${{ matrix.python-version }}
-        conda info
-    - name: check python version
-      run: |
-        conda run -n build_binary python --version
-    - name: Install gcc
-      shell: bash
-      run: |
-        sudo yum group install -y "Development Tools"
-    - name: setup Path
-      run: |
-        echo /usr/local/bin >> $GITHUB_PATH
-    - name: Install PyTorch
-      shell: bash
-      run: |
-        conda run -n build_binary \
-          python -m pip install --pre torch -f https://download.pytorch.org/whl/test/cpu/torch_test.html
 
-    - name: Install Dependencies
-      shell: bash
+    - name: Display System Info
+      run: . $PRELUDE; print_system_info
+
+    - name: Setup Miniconda
       run: |
-        cd fbgemm_gpu/
-        conda run -n build_binary python -m pip install -r requirements.txt
-    - name: Test Installation of dependencies
-      run: |
-        cd fbgemm_gpu/
-        conda run -n build_binary python -c "import torch.distributed"
-        echo "torch.distributed succeeded"
-        conda run -n build_binary python -c "import skbuild"
-        echo "skbuild succeeded"
-        conda run -n build_binary python -c "import numpy"
-        echo "numpy succeeded"
-    - name: Build FBGEMM_GPU Release
-      run: |
-        cd fbgemm_gpu/
-        rm -rf dist
-        # buld cuda7.0;8.0 for v100/a100 arch:
-        # Couldn't build more cuda arch due to 100 MB binary size limit from
-        # pypi website.
-        # manylinux1_x86_64 is specified for pypi upload:
-        # distribute python extensions as wheels on Linux
-        conda run -n build_binary \
-          python setup.py bdist_wheel \
-          --package_name=fbgemm_gpu-cpu \
-          --python-tag=${{ matrix.python-tag }} \
-          --cpu_only \
-          --plat-name=manylinux1_x86_64
-        ls -lt dist/*.whl
-    - name: Upload wheel as GHA artifact
+        . $PRELUDE; setup_miniconda $HOME/miniconda
+        echo "${HOME}/miniconda/bin" >> $GITHUB_PATH
+        echo "CONDA=${HOME}/miniconda" >> $GITHUB_PATH
+
+    - name: Create Conda Environment
+      run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
+
+    - name: Install C/C++ Compilers
+      run: . $PRELUDE; install_cxx_compiler $BUILD_ENV
+
+    - name: Install Build Tools
+      run: . $PRELUDE; install_build_tools $BUILD_ENV
+
+    - name: Install PyTorch-CPU Test
+      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV test cpuonly
+
+    - name: Prepare FBGEMM Build
+      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
+
+    - name: Build FBGEMM_GPU (CPU version)
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_package $BUILD_ENV fbgemm_gpu cpuonly
+
+    - name: Upload Built Wheel as GHA Artifact
       uses: actions/upload-artifact@v3
       with:
-        name: fbgemm_gpu_cpu_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
+        name: fbgemm_gpu_cpu_${{ matrix.python-version }}.whl
         path: fbgemm_gpu/dist/fbgemm_gpu_cpu-*.whl
 
-    - name: Install Dependencies
-      shell: bash
+
+  # Download the built artifact from GHA, test on GPU, and push to PyPI
+  test_and_publish_artifact:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      PRELUDE: .github/scripts/setup_env.bash
+      BUILD_ENV: build_binary
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ linux.g5.4xlarge.nvidia.gpu ]
+        python-version: [ "3.8", "3.9", "3.10" ]
+    needs: build_artifact
+
+    steps:
+    - name: Checkout the Repository
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Display System Info
+      run: . $PRELUDE; print_system_info
+
+    - name: Display EC2 Info
+      run: . $PRELUDE; print_ec2_info
+
+    - name: Setup Miniconda
       run: |
-        cd fbgemm_gpu/
-        conda run -n build_binary python -m pip install -r requirements.txt
-    - name: Test Installation of dependencies
-      run: |
-        cd fbgemm_gpu/
-        conda run -n build_binary python -c "import torch.distributed"
-        echo "torch.distributed succeeded"
-        conda run -n build_binary python -c "import skbuild"
-        echo "skbuild succeeded"
-        conda run -n build_binary python -c "import numpy"
-        echo "numpy succeeded"
-    - name: Install FBGEMM_GPU Release (CPU version)
-      run: |
-        conda run -n build_binary \
-          python -m pip install fbgemm_gpu/dist/fbgemm_gpu_cpu-*.whl
-    - name: Test fbgemm_gpu installation
-      shell: bash
-      run: |
-        conda run -n build_binary \
-          python -c "import fbgemm_gpu"
-    - name: Test with pytest
-      # remove this line when we fixed all the unit tests
-      continue-on-error: true
-      run: |
-        conda run -n build_binary \
-          python -m pip install pytest
-        # The tests with single CPU core on a less powerful testing GPU in GHA
-        # can take 5 hours.
-        timeout 600s conda run -n build_binary \
-          python -m pytest -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors
-    # Push to Pypi
-    - name: Push FBGEMM_GPU Binary to PYPI
+        . $PRELUDE; setup_miniconda $HOME/miniconda
+        echo "${HOME}/miniconda/bin" >> $GITHUB_PATH
+        echo "CONDA=${HOME}/miniconda" >> $GITHUB_PATH
+
+    - name: Create Conda Environment
+      run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
+
+    - name: Install PyTorch Test
+      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV test cpuonly
+
+    - name: Prepare FBGEMM Build
+      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
+
+    - name: Download Wheel Artifact from GHA
+      uses: actions/download-artifact@v3
+      with:
+        name: fbgemm_gpu_cpu_${{ matrix.python-version }}.whl
+
+    - name: Display Structure of the Downloaded Files
+      run: ls -R
+
+    - name: Install FBGEMM_GPU (CPU version)
+      run: . $PRELUDE; install_fbgemm_gpu_package $BUILD_ENV *.whl
+
+    - name: Test with PyTest
+      run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV cpuonly
+
+    - name: Push FBGEMM_GPU (CPU version) Binary to PYPI
+      if: ${{ github.event_name != 'pull_request' && github.event_name != 'push' }}
       env:
         PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      run: |
-        conda run -n build_binary python -m pip install twine
-        # Official PYPI website
-        conda run -n build_binary \
-          python -m twine upload \
-            --username __token__ \
-            --password "$PYPI_TOKEN" \
-            --skip-existing \
-            --verbose \
-            fbgemm_gpu/dist/fbgemm_gpu_cpu-*.whl
+      run: . $PRELUDE; publish_to_pypi $BUILD_ENV fbgemm_gpu_cpu-*.whl "$PYPI_TOKEN"


### PR DESCRIPTION
Summary:

- Upgrade the FBGEMM_GPU release workflows to use the same build scripts framework for running the builds
- Update the build scripts framework to properly support running PyTests
- Disable certain tests from running in the **CPU-only build** as they are known to be failing at the moment (`jagged_tensor_ops_test`, `uvm_test`)
- Update both the nightly and release jobs to actually run tests prior to publishing to PyPI
- Fix bug with PyPI publishing for the FBGEMM_GPU-CPU nightly job
- Update the nightly build cron schedules to follow PST
- Remove some jobs from FBGEMM_GPU CI as they are now redundant with the FBGEMM_GPU nightly / release builds
- Update the FBGEMM_GPU-CPU CI job (Ubuntu) to use the build scripts framework for building and running tests