### PR TITLE
allow empty indices_weights/per_sample_weights tensor to count as unweighted in C++ op

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
@@ -241,7 +241,7 @@ Tensor int_nbit_split_embedding_codegen_lookup_function(
         fp8_exponent_bits ? *fp8_exponent_bits : -1,
         fp8_exponent_bias ? *fp8_exponent_bias : -1);
   }
-  if (!indice_weights) {
+  if (!indice_weights || indice_weights->numel() == 0) {
     return int_nbit_split_embedding_codegen_forward_unweighted_cuda(
         dev_weights,
         uvm_weights,

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
@@ -124,7 +124,7 @@ Tensor int_nbit_split_embedding_codegen_lookup_function_cpu(
         fp8_exponent_bits ? *fp8_exponent_bits : -1,
         fp8_exponent_bias ? *fp8_exponent_bias : -1);
   }
-  if (!indice_weights) {
+  if (!indice_weights || indice_weights->numel() == 0) {
     return int_nbit_split_embedding_codegen_forward_unweighted_cpu(
         dev_weights,
         uvm_weights,


### PR DESCRIPTION
Summary: tbe_input_combine returns at::empty for per_sample_weights in the unweighted case, but if this output is passed directly to ops like `int_nbit_split_embedding_codegen_lookup_function_cpu`, the bool check fails because the optional has a tensor, it's just that the tensor is empty. This ultimately ends up with a SEGV as the weighted branch tries to read the empty tensor for per_sample_weights.

Differential Revision: D43373836

