### PR TITLE
[T145005253] Make Tests More Stable

### DIFF
--- a/.github/scripts/setup_env.bash
+++ b/.github/scripts/setup_env.bash
@@ -25,6 +25,7 @@ exec_with_retries () {
     echo "[EXEC] [ATTEMPT ${i}/${max}]    + $*"
 
     if "$@"; then
+      retcode=0
       break
     else
       retcode=$?
@@ -47,8 +48,8 @@ exec_with_retries () {
 ################################################################################
 
 test_python_import () {
-  env_name="$1"
-  python_import="$2"
+  local env_name="$1"
+  local python_import="$2"
   if [ "$python_import" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME PYTHON_IMPORT"
     echo "Example(s):"
@@ -65,8 +66,8 @@ test_python_import () {
 }
 
 test_binpath () {
-  env_name="$1"
-  bin_name="$2"
+  local env_name="$1"
+  local bin_name="$2"
   if [ "$bin_name" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME BIN_NAME"
     echo "Example(s):"
@@ -83,8 +84,8 @@ test_binpath () {
 }
 
 test_filepath () {
-  env_name="$1"
-  file_name="$2"
+  local env_name="$1"
+  local file_name="$2"
   if [ "$file_name" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME FILE_NAME"
     echo "Example(s):"
@@ -92,9 +93,12 @@ test_filepath () {
     return 1
   fi
 
-  conda_prefix=$(conda run -n "${env_name}" printenv CONDA_PREFIX)
-  file_path=$(find "${conda_prefix}" -type f -name "${file_name}")
-  link_path=$(find "${conda_prefix}" -type l -name "${file_name}")
+  # shellcheck disable=SC2155
+  local conda_prefix=$(conda run -n "${env_name}" printenv CONDA_PREFIX)
+  # shellcheck disable=SC2155
+  local file_path=$(find "${conda_prefix}" -type f -name "${file_name}")
+  # shellcheck disable=SC2155
+  local link_path=$(find "${conda_prefix}" -type l -name "${file_name}")
   if [ "${file_path}" != "" ]; then
     echo "[CHECK] ${file_name} found in CONDA_PREFIX PATH (file): ${file_path}"
   elif [ "${link_path}" != "" ]; then
@@ -106,8 +110,8 @@ test_filepath () {
 }
 
 test_env_var () {
-  env_name="$1"
-  env_key="$2"
+  local env_name="$1"
+  local env_key="$2"
   if [ "$env_key" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME ENV_KEY"
     echo "Example(s):"
@@ -137,11 +141,11 @@ install_system_packages () {
   fi
 
   if which sudo; then
-    update_cmd=("sudo")
-    install_cmd=("sudo")
+    local update_cmd=("sudo")
+    local install_cmd=("sudo")
   else
-    update_cmd=()
-    install_cmd=()
+    local update_cmd=()
+    local install_cmd=()
   fi
 
   if which apt-get; then
@@ -166,8 +170,8 @@ install_system_packages () {
 }
 
 run_python_test () {
-  env_name="$1"
-  python_test_file="$2"
+  local env_name="$1"
+  local python_test_file="$2"
   if [ "$python_test_file" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME PYTHON_TEST_FILE"
     echo "Example(s):"
@@ -264,7 +268,7 @@ print_ec2_info () {
   get_ec2_metadata() {
     # Pulled from instance metadata endpoint for EC2
     # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-    category=$1
+    local category=$1
     curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
   }
 
@@ -279,7 +283,7 @@ print_ec2_info () {
 ################################################################################
 
 setup_miniconda () {
-  miniconda_prefix="$1"
+  local miniconda_prefix="$1"
   if [ "$miniconda_prefix" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} MINICONDA_PREFIX_PATH"
     echo "Example:"
@@ -324,8 +328,8 @@ setup_miniconda () {
 }
 
 create_conda_environment () {
-  env_name="$1"
-  python_version="$2"
+  local env_name="$1"
+  local python_version="$2"
   if [ "$python_version" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME PYTHON_VERSION"
     echo "Example:"
@@ -349,9 +353,9 @@ create_conda_environment () {
 }
 
 install_pytorch_conda () {
-  env_name="$1"
-  pytorch_version="$2"
-  pytorch_cpu="$3"
+  local env_name="$1"
+  local pytorch_version="$2"
+  local pytorch_cpu="$3"
   if [ "$pytorch_version" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME PYTORCH_VERSION [CPU]"
     echo "Example(s):"
@@ -372,19 +376,19 @@ install_pytorch_conda () {
   # Install cpuonly if needed
   if [ "$pytorch_cpu" != "" ]; then
     pytorch_cpu=1
-    pytorch_package="cpuonly pytorch"
+    local pytorch_package="cpuonly pytorch"
   else
-    pytorch_package="pytorch"
+    local pytorch_package="pytorch"
   fi
 
   # Set package name and installation channel
   if [ "$pytorch_version" == "nightly" ] || [ "$pytorch_version" == "test" ]; then
-    pytorch_channel="pytorch-${pytorch_version}"
+    local pytorch_channel="pytorch-${pytorch_version}"
   elif [ "$pytorch_version" == "latest" ]; then
-    pytorch_channel="pytorch"
+    local pytorch_channel="pytorch"
   else
     pytorch_package="${pytorch_package}==${pytorch_version}"
-    pytorch_channel="pytorch"
+    local pytorch_channel="pytorch"
   fi
 
   # Install PyTorch packages
@@ -413,7 +417,7 @@ install_pytorch_conda () {
   fi
 
   # Check that PyTorch is importable
-  test_python_import "${env_name}" torch.distributed || return 1
+  (test_python_import "${env_name}" torch.distributed) || return 1
 
   # Print out the actual installed PyTorch version
   installed_pytorch_version=$(conda run -n "${env_name}" python -c "import torch; print(torch.__version__)")
@@ -495,7 +499,7 @@ install_pytorch_pip () {
   fi
 
   # Check that PyTorch is importable
-  test_python_import "${env_name}" torch.distributed || return 1
+  (test_python_import "${env_name}" torch.distributed) || return 1
 
   # Print out the actual installed PyTorch version
   installed_pytorch_version=$(conda run -n "${env_name}" python -c "import torch; print(torch.__version__)")
@@ -504,8 +508,8 @@ install_pytorch_pip () {
 }
 
 install_cuda () {
-  env_name="$1"
-  cuda_version="$2"
+  local env_name="$1"
+  local cuda_version="$2"
   if [ "$cuda_version" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME CUDA_VERSION"
     echo "Example(s):"
@@ -522,7 +526,7 @@ install_cuda () {
 
   # Check CUDA version formatting
   # shellcheck disable=SC2206
-  cuda_version_arr=(${cuda_version//./ })
+  local cuda_version_arr=(${cuda_version//./ })
   if [ ${#cuda_version_arr[@]} -lt 3 ]; then
     echo "[ERROR] CUDA minor version number must be specified (i.e. X.Y.Z)"
     return 1
@@ -547,8 +551,8 @@ install_cuda () {
 }
 
 install_rocm_ubuntu () {
-  env_name="$1"
-  rocm_version="$2"
+  local env_name="$1"
+  local rocm_version="$2"
   if [ "$rocm_version" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME ROC_VERSION"
     echo "Example(s):"
@@ -573,14 +577,15 @@ install_rocm_ubuntu () {
   . /etc/os-release
 
   # Split version string by dot into array, i.e. 5.4.3 => [5, 4, 3]
-  # shellcheck disable=SC2206
-  rocm_version_arr=(${rocm_version//./ })
+  # shellcheck disable=SC2206,SC2155
+  local rocm_version_arr=(${rocm_version//./ })
   # Materialize the long version string, i.e. 5.3 => 50500, 5.4.3 => 50403
-  long_version="${rocm_version_arr[0]}$(printf %02d "${rocm_version_arr[1]}")$(printf %02d "${rocm_version_arr[2]}")"
+  # shellcheck disable=SC2155
+  local long_version="${rocm_version_arr[0]}$(printf %02d "${rocm_version_arr[1]}")$(printf %02d "${rocm_version_arr[2]}")"
   # Materialize the full deb package name
-  package_name="amdgpu-install_${rocm_version_arr[0]}.${rocm_version_arr[1]}.${long_version}-1_all.deb"
+  local package_name="amdgpu-install_${rocm_version_arr[0]}.${rocm_version_arr[1]}.${long_version}-1_all.deb"
   # Materialize the download URL
-  rocm_download_url="https://repo.radeon.com/amdgpu-install/${rocm_version}/ubuntu/${VERSION_CODENAME}/${package_name}"
+  local rocm_download_url="https://repo.radeon.com/amdgpu-install/${rocm_version}/ubuntu/${VERSION_CODENAME}/${package_name}"
 
   echo "[INSTALL] Downloading the ROCm installer script ..."
   print_exec wget -q "${rocm_download_url}" -O "${package_name}"
@@ -603,8 +608,8 @@ install_rocm_ubuntu () {
 }
 
 install_cxx_compiler () {
-  env_name="$1"
-  use_yum="$2"
+  local env_name="$1"
+  local use_yum="$2"
   if [ "$env_name" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME [USE_YUM]"
     echo "Example(s):"
@@ -633,8 +638,10 @@ install_cxx_compiler () {
     # The compilers are visible in the PATH as `x86_64-conda-linux-gnu-cc` and
     # `x86_64-conda-linux-gnu-c++`, so symlinks will need to be created
     echo "[INSTALL] Setting the C/C++ compiler symlinks ..."
-    cc_path=$(conda run -n "${env_name}" printenv CC)
-    cxx_path=$(conda run -n "${env_name}" printenv CXX)
+    # shellcheck disable=SC2155
+    local cc_path=$(conda run -n "${env_name}" printenv CC)
+    # shellcheck disable=SC2155
+    local cxx_path=$(conda run -n "${env_name}" printenv CXX)
 
     print_exec ln -s "${cc_path}" "$(dirname "$cc_path")/cc"
     print_exec ln -s "${cc_path}" "$(dirname "$cc_path")/gcc"
@@ -654,7 +661,7 @@ install_cxx_compiler () {
 }
 
 install_build_tools () {
-  env_name="$1"
+  local env_name="$1"
   if [ "$env_name" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME"
     echo "Example(s):"
@@ -671,6 +678,7 @@ install_build_tools () {
 
   echo "[INSTALL] Installing build tools ..."
   (exec_with_retries conda install -n "${env_name}" -y \
+    click \
     cmake \
     hypothesis \
     jinja2 \
@@ -684,19 +692,18 @@ install_build_tools () {
   test_binpath "${env_name}" ninja || return 1
 
   # Check Python packages are importable
-  test_python_import "${env_name}" hypothesis || return 1
-  test_python_import "${env_name}" jinja2 || return 1
-  test_python_import "${env_name}" numpy || return 1
-  test_python_import "${env_name}" skbuild || return 1
-  test_python_import "${env_name}" wheel || return 1
+  local import_tests=( click hypothesis jinja2 numpy skbuild wheel )
+  for p in "${import_tests[@]}"; do
+    (test_python_import "${env_name}" "${p}") || return 1
+  done
 
   echo "[INSTALL] Successfully installed all the build tools"
 }
 
 install_cudnn () {
-  env_name="$1"
-  install_path="$2"
-  cuda_version="$3"
+  local env_name="$1"
+  local install_path="$2"
+  local cuda_version="$3"
   if [ "$cuda_version" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME INSTALL_PATH CUDA_VERSION"
     echo "Example:"
@@ -713,7 +720,7 @@ install_cudnn () {
 
   # Install cuDNN manually
   # Based on install script in https://github.com/pytorch/builder/blob/main/common/install_cuda.sh
-  cudnn_packages=(
+  local cudnn_packages=(
     ["115"]="https://developer.download.nvidia.com/compute/redist/cudnn/v8.3.2/local_installers/11.5/cudnn-linux-x86_64-8.3.2.44_cuda11.5-archive.tar.xz"
     ["116"]="https://developer.download.nvidia.com/compute/redist/cudnn/v8.3.2/local_installers/11.5/cudnn-linux-x86_64-8.3.2.44_cuda11.5-archive.tar.xz"
     ["117"]="https://ossci-linux.s3.amazonaws.com/cudnn-linux-x86_64-8.5.0.96_cuda11-archive.tar.xz"
@@ -722,12 +729,12 @@ install_cudnn () {
 
   # Split version string by dot into array, i.e. 11.7.1 => [11, 7, 1]
   # shellcheck disable=SC2206
-  cuda_version_arr=(${cuda_version//./ })
+  local cuda_version_arr=(${cuda_version//./ })
   # Fetch the major and minor version to concat
-  cuda_concat_version="${cuda_version_arr[0]}${cuda_version_arr[1]}"
+  local cuda_concat_version="${cuda_version_arr[0]}${cuda_version_arr[1]}"
 
   # Get the URL
-  cudnn_url="${cudnn_packages[cuda_concat_version]}"
+  local cudnn_url="${cudnn_packages[cuda_concat_version]}"
   if [ "$cudnn_url" == "" ]; then
     # Default to cuDNN for 11.7 if no CUDA version fits
     echo "[INSTALL] Defaulting to cuDNN for CUDA 11.7"
@@ -739,7 +746,8 @@ install_cudnn () {
   mkdir -p "$install_path"
 
   # Create temporary directory
-  tmp_dir=$(mktemp -d)
+  # shellcheck disable=SC2155
+  local tmp_dir=$(mktemp -d)
   cd "$tmp_dir" || return 1
 
   # Download cuDNN
@@ -813,7 +821,7 @@ create_conda_pytorch_environment () {
 ################################################################################
 
 prepare_fbgemm_gpu_build () {
-  env_name="$1"
+  local env_name="$1"
   if [ "$env_name" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME"
     echo "Example(s):"
@@ -835,8 +843,8 @@ prepare_fbgemm_gpu_build () {
   echo "[BUILD] Installing other build dependencies ..."
   print_exec conda run -n "${env_name}" python -m pip install -r requirements.txt
 
-  test_python_import "${env_name}" numpy || return 1
-  test_python_import "${env_name}" skbuild || return 1
+  (test_python_import "${env_name}" numpy) || return 1
+  (test_python_import "${env_name}" skbuild) || return 1
 
   echo "[BUILD] Successfully ran git submodules update"
 }
@@ -951,8 +959,8 @@ build_fbgemm_gpu_install () {
 }
 
 install_fbgemm_gpu_package () {
-  env_name="$1"
-  package_name="$2"
+  local env_name="$1"
+  local package_name="$2"
   if [ "$package_name" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME WHEEL_NAME"
     echo "Example(s):"
@@ -971,8 +979,8 @@ install_fbgemm_gpu_package () {
   conda run -n "${env_name}" python -m pip install "${package_name}"
 
   echo "[BUILD] Checking imports ..."
-  test_python_import "${env_name}" fbgemm_gpu || return 1
-  test_python_import "${env_name}" fbgemm_gpu.split_embedding_codegen_lookup_invokers || return 1
+  (test_python_import "${env_name}" fbgemm_gpu) || return 1
+  (test_python_import "${env_name}" fbgemm_gpu.split_embedding_codegen_lookup_invokers) || return 1
 
   echo "[BUILD] Wheel installation completed ..."
 }
@@ -983,13 +991,14 @@ install_fbgemm_gpu_package () {
 ################################################################################
 
 run_fbgemm_gpu_tests () {
-  env_name="$1"
-  cpu_only="$2"
+  local env_name="$1"
+  local fbgemm_variant="$2"
   if [ "$env_name" == "" ]; then
-    echo "Usage: ${FUNCNAME[0]} ENV_NAME [CPU_ONLY]"
+    echo "Usage: ${FUNCNAME[0]} ENV_NAME [FBGEMM_VARIANT]"
     echo "Example(s):"
-    echo "    ${FUNCNAME[0]} build_env    # Run all tests"
-    echo "    ${FUNCNAME[0]} build_env 1  # Skip tests known to be broken in CPU-only mode"
+    echo "    ${FUNCNAME[0]} build_env        # Run all tests applicable to GPU (Nvidia)"
+    echo "    ${FUNCNAME[0]} build_env cpu    # Run all tests applicable to CPU"
+    echo "    ${FUNCNAME[0]} build_env rocm   # Run all tests applicable to ROCm"
     return 1
   else
     echo "################################################################################"
@@ -1000,27 +1009,39 @@ run_fbgemm_gpu_tests () {
     echo ""
   fi
 
+  # Enable ROCM testing if specified
+  if [ "$fbgemm_variant" == "rocm" ]; then
+    echo "[TEST] Set environment variable FBGEMM_TEST_WITH_ROCM to enable ROCm tests ..."
+    print_exec conda env config vars set -n "${env_name}" FBGEMM_TEST_WITH_ROCM=1
+  fi
+
   # These are either non-tests or currently-broken tests in both FBGEMM_GPU and FBGEMM_GPU-CPU
-  files_to_skip=(
-    split_table_batched_embeddings_test.py
+  local files_to_skip=(
     test_utils.py
+    split_table_batched_embeddings_test.py
     ssd_split_table_batched_embeddings_test.py
   )
 
-  if [ "$cpu_only" != "" ]; then
+  if [ "$fbgemm_variant" == "cpu" ]; then
     # These are tests that are currently broken in FBGEMM_GPU-CPU
-    ignored_tests=(
+    local ignored_tests=(
       uvm_test.py
     )
+  elif [ "$fbgemm_variant" == "rocm" ]; then
+    local ignored_tests=()
   else
-    ignored_tests=()
+    local ignored_tests=()
   fi
 
   echo "[TEST] Installing pytest ..."
   print_exec conda install -n "${env_name}" -y pytest
 
-  echo "[BUILD] Checking imports ..."
-  test_python_import "${env_name}" fbgemm_gpu || return 1
+  echo "[TEST] Checking imports ..."
+  (test_python_import "${env_name}" fbgemm_gpu) || return 1
+  (test_python_import "${env_name}" fbgemm_gpu.split_embedding_codegen_lookup_invokers) || return 1
+
+  echo "[TEST] Enumerating test files ..."
+  print_exec ls -lth ./*.py
 
   # NOTE: These tests running on single CPU core with a less powerful testing
   # GPU in GHA can take up to 5 hours.
@@ -1043,9 +1064,9 @@ run_fbgemm_gpu_tests () {
 ################################################################################
 
 publish_to_pypi () {
-  env_name="$1"
-  package_name="$2"
-  pypi_token="$3"
+  local env_name="$1"
+  local package_name="$2"
+  local pypi_token="$3"
   if [ "$pypi_token" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME PACKAGE_NAME PYPI_TOKEN"
     echo "Example(s):"
@@ -1064,7 +1085,7 @@ publish_to_pypi () {
 
   echo "[INSTALL] Installing twine ..."
   print_exec conda install -n "${env_name}" -y twine
-  test_python_import "${env_name}" twine || return 1
+  (test_python_import "${env_name}" twine) || return 1
 
   echo "[PUBLISH] Uploading package(s) to PyPI: ${package_name} ..."
   conda run -n "${env_name}" \

--- a/.github/scripts/setup_env.bash
+++ b/.github/scripts/setup_env.bash
@@ -955,7 +955,7 @@ run_fbgemm_gpu_tests () {
   if [ "$cpu_only" != "" ]; then
     # These are tests that are currently broken in FBGEMM_GPU-CPU
     unstable_tests=(
-      # jagged_tensor_ops_test.py
+      jagged_tensor_ops_test.py
       uvm_test.py
     )
   else

--- a/.github/workflows/fbgemm_docs.yml
+++ b/.github/workflows/fbgemm_docs.yml
@@ -1,5 +1,9 @@
-# This workflow builds the fbgemm_gpu docs and deploys them to gh-pages.
-name: Generate documentation
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+name: FBGEMM Documentation
 on:
   push:
     branches:

--- a/.github/workflows/fbgemm_gpu_ci.yml
+++ b/.github/workflows/fbgemm_gpu_ci.yml
@@ -14,7 +14,7 @@ on:
       - main
 
 jobs:
-  build_amd_gpu:
+  build_and_test_amd:
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -23,6 +23,7 @@ jobs:
       PRELUDE: .github/scripts/setup_env.bash
       BUILD_ENV: build_binary
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-20.04 ]
         python-version: [ "3.10" ]
@@ -71,82 +72,15 @@ jobs:
         print_exec conda run -n $BUILD_ENV python setup.py build develop
 
     - name: Test FBGEMM_GPU-ROCM Nightly installation
-      run: |
-        . $PRELUDE
-        cd fbgemm_gpu/test
+      timeout-minutes: 10
+      run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV rocm
 
-        print_exec conda run -n $BUILD_ENV python -c "import fbgemm_gpu"
-        print_exec conda run -n $BUILD_ENV python -c "import fbgemm_gpu.split_embedding_codegen_lookup_invokers"
-        print_exec conda run -n $BUILD_ENV python input_combine_test.py -v
-        print_exec conda run -n $BUILD_ENV python quantize_ops_test.py -v
-        print_exec conda run -n $BUILD_ENV python sparse_ops_test.py -v
-
-  # build_amd_gpu:
-  #   if: ${{ false }}  # Disable the job for now
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-20.04]
-  #       config: [[pip, 5.3]]
-
-  #   steps:
-  #   - name: Free space
-  #     run: sudo rm -rf /usr/local/android /usr/share/dotnet /usr/local/share/boost /opt/ghc /usr/local/share/chrom* /usr/share/swift /usr/local/julia* /usr/local/lib/android
-
-  #   - uses: actions/checkout@v3
-
-  #   - name: Install ROCm
-  #     shell: bash
-  #     run: |
-  #       sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-  #       wget https://repo.radeon.com/amdgpu-install/5.3/ubuntu/focal/amdgpu-install_5.3.50300-1_all.deb
-  #       export DEBIAN_FRONTEND=noninteractive
-  #       sudo apt install -y ./amdgpu-install_5.3.50300-1_all.deb
-  #       amdgpu-install -y --usecase=hiplibsdk,rocm --no-dkms
-  #       sudo rm amdgpu-install_5.3.50300-1_all.deb
-
-  #   - name: Install dependencies
-  #     shell: bash
-  #     run: |
-  #       sudo apt-get update
-  #       sudo apt-get install -y git pip python3-dev mesa-common-dev clang comgr libopenblas-dev jp intel-mkl-full locales libnuma-dev
-  #       sudo apt-get install -y hipify-clang || true
-  #       sudo apt-get install -y miopen-hip miopen-hip-dev
-  #       sudo pip install cmake scikit-build ninja jinja2 numpy hypothesis --no-input
-  #       sudo apt-get clean
-  #       # Install PyTorch (nightly) as required by fbgemm_gpu
-  #       sudo pip install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.3/
-
-  #   - name: Checkout submodules
-  #     shell: bash
-  #     run: |
-  #       cd fbgemm_gpu
-  #       git submodule sync
-  #       git submodule update --init --recursive
-
-  #   - name: Build fbgemm_gpu
-  #     shell: bash
-  #     run: |
-  #       sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-  #       cd fbgemm_gpu
-  #       # build for MI250 only to save time.
-  #       sudo PYTORCH_ROCM_ARCH=gfx90a python3 setup.py build develop
-
-  #   - name: Test fbgemm_gpu installation
-  #     shell: bash
-  #     run: |
-  #       cd fbgemm_gpu
-  #       cd test
-  #       python3 input_combine_test.py -v
-  #       python3 quantize_ops_test.py -v
-  #       python3 sparse_ops_test.py -v
-  #       python3 -c "import fbgemm_gpu"
-  #       python3 -c "import fbgemm_gpu.split_embedding_codegen_lookup_invokers"
 
   test_amd_gpu:
     if: ${{ false }}  # Disable the job for now
     runs-on: rocm
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
 
@@ -192,6 +126,7 @@ jobs:
         "
         docker run $DOCKER_OPTIONS $DOCKER_IMAGE $JENKINS_REPO_DIR_DOCKER/.jenkins/rocm/build_and_test.sh $JENKINS_REPO_DIR_DOCKER
 
+
   build_and_test_cpu:
     runs-on: ${{ matrix.os }}
     defaults:
@@ -201,6 +136,7 @@ jobs:
       PRELUDE: .github/scripts/setup_env.bash
       BUILD_ENV: build_binary
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-20.04, ubuntu-latest ]
         python-version: [ "3.8", "3.9", "3.10" ]
@@ -237,4 +173,4 @@ jobs:
 
     - name: Test with PyTest
       timeout-minutes: 10
-      run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV cpuonly
+      run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV cpu

--- a/.github/workflows/fbgemm_gpu_ci.yml
+++ b/.github/workflows/fbgemm_gpu_ci.yml
@@ -15,66 +15,134 @@ on:
 
 jobs:
   build_amd_gpu:
-    if: ${{ false }}  # Disable the job for now
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      PRELUDE: .github/scripts/setup_env.bash
+      BUILD_ENV: build_binary
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        config: [[pip, 5.3]]
+        os: [ ubuntu-20.04 ]
+        python-version: [ "3.10" ]
+        rocm-version: [ "5.3" ]
 
     steps:
-    - name: Free space
-      run: sudo rm -rf /usr/local/android /usr/share/dotnet /usr/local/share/boost /opt/ghc /usr/local/share/chrom* /usr/share/swift /usr/local/julia* /usr/local/lib/android
+    - name: Checkout the Repository
+      uses: actions/checkout@v3
+      with:
+        submodules: true
 
-    - uses: actions/checkout@v3
+    - name: Display System Info
+      run: . $PRELUDE; print_system_info
+
+    - name: Free Disk Space
+      run: . $PRELUDE; free_disk_space
+
+    - name: Setup Miniconda
+      run: |
+        . $PRELUDE; setup_miniconda $HOME/miniconda
+        echo "${HOME}/miniconda/bin" >> $GITHUB_PATH
+        echo "CONDA=${HOME}/miniconda" >> $GITHUB_PATH
+
+    - name: Create Conda Environment
+      run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
 
     - name: Install ROCm
-      shell: bash
-      run: |
-        sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-        wget https://repo.radeon.com/amdgpu-install/5.3/ubuntu/focal/amdgpu-install_5.3.50300-1_all.deb
-        export DEBIAN_FRONTEND=noninteractive
-        sudo apt install -y ./amdgpu-install_5.3.50300-1_all.deb
-        amdgpu-install -y --usecase=hiplibsdk,rocm --no-dkms
-        sudo rm amdgpu-install_5.3.50300-1_all.deb
+      run: . $PRELUDE; install_rocm_ubuntu $BUILD_ENV ${{ matrix.rocm-version }}
 
-    - name: Install dependencies
-      shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y git pip python3-dev mesa-common-dev clang comgr libopenblas-dev jp intel-mkl-full locales libnuma-dev
-        sudo apt-get install -y hipify-clang || true
-        sudo apt-get install -y miopen-hip miopen-hip-dev
-        sudo pip install cmake scikit-build ninja jinja2 numpy hypothesis --no-input
-        sudo apt-get clean
-        # Install PyTorch (nightly) as required by fbgemm_gpu
-        sudo pip install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.3/
+    - name: Install Build Tools
+      run: . $PRELUDE; install_build_tools $BUILD_ENV
 
-    - name: Checkout submodules
-      shell: bash
+    - name: Install PyTorch-ROCm Nightly
+      run:  . $PRELUDE; install_pytorch_pip $BUILD_ENV nightly rocm ${{ matrix.rocm-version }}
+
+    - name: Prepare FBGEMM Build
+      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
+
+    - name: Build FBGEMM_GPU-ROCM Nightly
       run: |
+        . $PRELUDE
         cd fbgemm_gpu
-        git submodule sync
-        git submodule update --init --recursive
 
-    - name: Build fbgemm_gpu
+        # Build for MI250 only to save time.
+        print_exec conda env config vars set -n $BUILD_ENV PYTORCH_ROCM_ARCH=gfx90a
+        print_exec conda run -n $BUILD_ENV python setup.py build develop
+
+    - name: Test FBGEMM_GPU-ROCM Nightly installation
       shell: bash
       run: |
-        sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-        cd fbgemm_gpu
-        # build for MI250 only to save time.
-        sudo PYTORCH_ROCM_ARCH=gfx90a python3 setup.py build develop
+        . $PRELUDE
+        cd fbgemm_gpu/test
 
-    - name: Test fbgemm_gpu installation
-      shell: bash
-      run: |
-        cd fbgemm_gpu
-        cd test
-        python3 input_combine_test.py -v
-        python3 quantize_ops_test.py -v
-        python3 sparse_ops_test.py -v
-        python3 -c "import fbgemm_gpu"
-        python3 -c "import fbgemm_gpu.split_embedding_codegen_lookup_invokers"
+        print_exec conda run -n $BUILD_ENV python -c "import fbgemm_gpu"
+        print_exec conda run -n $BUILD_ENV python -c "import fbgemm_gpu.split_embedding_codegen_lookup_invokers"
+        print_exec conda run -n $BUILD_ENV python input_combine_test.py -v
+        print_exec conda run -n $BUILD_ENV python quantize_ops_test.py -v
+        print_exec conda run -n $BUILD_ENV python sparse_ops_test.py -v
+
+  # build_amd_gpu:
+  #   if: ${{ false }}  # Disable the job for now
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-20.04]
+  #       config: [[pip, 5.3]]
+
+  #   steps:
+  #   - name: Free space
+  #     run: sudo rm -rf /usr/local/android /usr/share/dotnet /usr/local/share/boost /opt/ghc /usr/local/share/chrom* /usr/share/swift /usr/local/julia* /usr/local/lib/android
+
+  #   - uses: actions/checkout@v3
+
+  #   - name: Install ROCm
+  #     shell: bash
+  #     run: |
+  #       sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+  #       wget https://repo.radeon.com/amdgpu-install/5.3/ubuntu/focal/amdgpu-install_5.3.50300-1_all.deb
+  #       export DEBIAN_FRONTEND=noninteractive
+  #       sudo apt install -y ./amdgpu-install_5.3.50300-1_all.deb
+  #       amdgpu-install -y --usecase=hiplibsdk,rocm --no-dkms
+  #       sudo rm amdgpu-install_5.3.50300-1_all.deb
+
+  #   - name: Install dependencies
+  #     shell: bash
+  #     run: |
+  #       sudo apt-get update
+  #       sudo apt-get install -y git pip python3-dev mesa-common-dev clang comgr libopenblas-dev jp intel-mkl-full locales libnuma-dev
+  #       sudo apt-get install -y hipify-clang || true
+  #       sudo apt-get install -y miopen-hip miopen-hip-dev
+  #       sudo pip install cmake scikit-build ninja jinja2 numpy hypothesis --no-input
+  #       sudo apt-get clean
+  #       # Install PyTorch (nightly) as required by fbgemm_gpu
+  #       sudo pip install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.3/
+
+  #   - name: Checkout submodules
+  #     shell: bash
+  #     run: |
+  #       cd fbgemm_gpu
+  #       git submodule sync
+  #       git submodule update --init --recursive
+
+  #   - name: Build fbgemm_gpu
+  #     shell: bash
+  #     run: |
+  #       sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+  #       cd fbgemm_gpu
+  #       # build for MI250 only to save time.
+  #       sudo PYTORCH_ROCM_ARCH=gfx90a python3 setup.py build develop
+
+  #   - name: Test fbgemm_gpu installation
+  #     shell: bash
+  #     run: |
+  #       cd fbgemm_gpu
+  #       cd test
+  #       python3 input_combine_test.py -v
+  #       python3 quantize_ops_test.py -v
+  #       python3 sparse_ops_test.py -v
+  #       python3 -c "import fbgemm_gpu"
+  #       python3 -c "import fbgemm_gpu.split_embedding_codegen_lookup_invokers"
 
   test_amd_gpu:
     if: ${{ false }}  # Disable the job for now

--- a/.github/workflows/fbgemm_gpu_ci.yml
+++ b/.github/workflows/fbgemm_gpu_ci.yml
@@ -71,7 +71,6 @@ jobs:
         print_exec conda run -n $BUILD_ENV python setup.py build develop
 
     - name: Test FBGEMM_GPU-ROCM Nightly installation
-      shell: bash
       run: |
         . $PRELUDE
         cd fbgemm_gpu/test
@@ -237,4 +236,5 @@ jobs:
       run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_install $BUILD_ENV cpuonly
 
     - name: Test with PyTest
+      timeout-minutes: 10
       run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV cpuonly

--- a/.github/workflows/fbgemm_nightly_build.yml
+++ b/.github/workflows/fbgemm_nightly_build.yml
@@ -146,11 +146,11 @@ jobs:
       with:
         name: fbgemm_gpu_nightly_${{ matrix.python-version }}_cuda${{ matrix.cuda-version }}.whl
 
-    - name: Display Structure of the Downloaded Files
-      run: ls -R
-
     - name: Install FBGEMM_GPU Nightly
-      run: . $PRELUDE; install_fbgemm_gpu_package $BUILD_ENV *.whl
+      run: |
+        . $PRELUDE
+        ls .
+        install_fbgemm_gpu_package $BUILD_ENV *.whl
 
     - name: Test with PyTest
       timeout-minutes: 10

--- a/.github/workflows/fbgemm_nightly_build.yml
+++ b/.github/workflows/fbgemm_nightly_build.yml
@@ -153,8 +153,7 @@ jobs:
       run: . $PRELUDE; install_fbgemm_gpu_package $BUILD_ENV *.whl
 
     - name: Test with PyTest
-      # Remove this line when we fixed all the unit tests
-      continue-on-error: true
+      timeout-minutes: 10
       run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV
 
     - name: Push FBGEMM_GPU Nightly Binary to PYPI

--- a/.github/workflows/fbgemm_nightly_build_cpu.yml
+++ b/.github/workflows/fbgemm_nightly_build_cpu.yml
@@ -142,6 +142,7 @@ jobs:
       run: . $PRELUDE; install_fbgemm_gpu_package $BUILD_ENV *.whl
 
     - name: Test with PyTest
+      timeout-minutes: 10
       run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV cpuonly
 
     - name: Push FBGEMM_GPU Nightly (CPU version) Binary to PYPI

--- a/.github/workflows/fbgemm_nightly_build_cpu.yml
+++ b/.github/workflows/fbgemm_nightly_build_cpu.yml
@@ -135,15 +135,15 @@ jobs:
       with:
         name: fbgemm_gpu_nightly_cpu_${{ matrix.python-version }}.whl
 
-    - name: Display Structure of the Downloaded Files
-      run: ls -R
-
     - name: Install FBGEMM_GPU Nightly (CPU version)
-      run: . $PRELUDE; install_fbgemm_gpu_package $BUILD_ENV *.whl
+      run: |
+        . $PRELUDE
+        ls .
+        install_fbgemm_gpu_package $BUILD_ENV *.whl
 
     - name: Test with PyTest
       timeout-minutes: 10
-      run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV cpuonly
+      run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV cpu
 
     - name: Push FBGEMM_GPU Nightly (CPU version) Binary to PYPI
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'push' }}

--- a/.github/workflows/fbgemm_release_build.yml
+++ b/.github/workflows/fbgemm_release_build.yml
@@ -144,8 +144,7 @@ jobs:
       run: . $PRELUDE; install_fbgemm_gpu_package $BUILD_ENV *.whl
 
     - name: Test with PyTest
-      # Remove this line when we fixed all the unit tests
-      continue-on-error: true
+      timeout-minutes: 10
       run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV
 
     - name: Push FBGEMM_GPU Binary to PYPI

--- a/.github/workflows/fbgemm_release_build.yml
+++ b/.github/workflows/fbgemm_release_build.yml
@@ -137,11 +137,11 @@ jobs:
       with:
         name: fbgemm_gpu_${{ matrix.python-version }}_cuda${{ matrix.cuda-version }}.whl
 
-    - name: Display Structure of the Downloaded Files
-      run: ls -R
-
     - name: Install FBGEMM_GPU
-      run: . $PRELUDE; install_fbgemm_gpu_package $BUILD_ENV *.whl
+      run: |
+        . $PRELUDE
+        ls .
+        install_fbgemm_gpu_package $BUILD_ENV *.whl
 
     - name: Test with PyTest
       timeout-minutes: 10

--- a/.github/workflows/fbgemm_release_build_cpu.yml
+++ b/.github/workflows/fbgemm_release_build_cpu.yml
@@ -127,15 +127,15 @@ jobs:
       with:
         name: fbgemm_gpu_cpu_${{ matrix.python-version }}.whl
 
-    - name: Display Structure of the Downloaded Files
-      run: ls -R
-
     - name: Install FBGEMM_GPU (CPU version)
-      run: . $PRELUDE; install_fbgemm_gpu_package $BUILD_ENV *.whl
+      run: |
+        . $PRELUDE
+        ls .
+        install_fbgemm_gpu_package $BUILD_ENV *.whl
 
     - name: Test with PyTest
       timeout-minutes: 10
-      run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV cpuonly
+      run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV cpu
 
     - name: Push FBGEMM_GPU (CPU version) Binary to PYPI
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'push' }}

--- a/.github/workflows/fbgemm_release_build_cpu.yml
+++ b/.github/workflows/fbgemm_release_build_cpu.yml
@@ -134,6 +134,7 @@ jobs:
       run: . $PRELUDE; install_fbgemm_gpu_package $BUILD_ENV *.whl
 
     - name: Test with PyTest
+      timeout-minutes: 10
       run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV cpuonly
 
     - name: Push FBGEMM_GPU (CPU version) Binary to PYPI

--- a/fbgemm_gpu/test/jagged_tensor_ops_test.py
+++ b/fbgemm_gpu/test/jagged_tensor_ops_test.py
@@ -624,7 +624,9 @@ class JaggedTensorOpsTest(unittest.TestCase):
         outer_dense_size=st.integers(0, 5),
         inner_dense_size=st.integers(0, 5),
         dtype=st.sampled_from([torch.float, torch.half, torch.bfloat16]),
-        device_type=st.sampled_from(["cpu", "cuda"]),
+        device_type=st.sampled_from(["cpu", "cuda"])
+        if gpu_available
+        else st.just("cpu"),
         precompute_total_L=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
@@ -646,13 +648,16 @@ class JaggedTensorOpsTest(unittest.TestCase):
             precompute_total_L,
         )
 
+    @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore [56]
     @given(
         num_jagged_dim=st.just(1),
         outer_dense_size=st.integers(0, 6000),
         inner_dense_size=st.sampled_from([8, 16, 23, 24, 48, 50, 64, 72, 96, 192]),
         dtype=st.just(torch.half),
-        device_type=st.just("cuda"),
+        device_type=st.sampled_from(["cpu", "cuda"])
+        if gpu_available
+        else st.just("cpu"),
         precompute_total_L=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
@@ -676,13 +681,16 @@ class JaggedTensorOpsTest(unittest.TestCase):
 
     # (8000+1) * 8 (size of the element of LongTensor/int64_t offsets)
     # = ~62.5KB > 48KB default shared memory on V100/A100.
+    @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore [56]
     @given(
         num_jagged_dim=st.just(1),
         outer_dense_size=st.just(8000),
         inner_dense_size=st.just(16),
         dtype=st.just(torch.half),
-        device_type=st.just("cuda"),
+        device_type=st.sampled_from(["cpu", "cuda"])
+        if gpu_available
+        else st.just("cpu"),
         precompute_total_L=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
@@ -969,7 +977,9 @@ class JaggedTensorOpsTest(unittest.TestCase):
         inner_dense_size=st.integers(0, 4),
         operation=st.sampled_from(["add", "add_jagged_output", "mul"]),
         dtype=st.sampled_from([torch.float, torch.half, torch.double, torch.bfloat16]),
-        device_type=st.sampled_from(["cpu", "cuda"]),
+        device_type=st.sampled_from(["cpu", "cuda"])
+        if gpu_available
+        else st.just("cpu"),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
     def test_jagged_elementwise_binary(
@@ -990,6 +1000,7 @@ class JaggedTensorOpsTest(unittest.TestCase):
             device_type,
         )
 
+    @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore [56]
     @given(
         num_jagged_dim=st.just(1),
@@ -997,7 +1008,9 @@ class JaggedTensorOpsTest(unittest.TestCase):
         inner_dense_size=st.sampled_from([16, 64, 96, 192]),
         operation=st.sampled_from(["add_jagged_output", "mul"]),
         dtype=st.just(torch.half),
-        device_type=st.just("cuda"),
+        device_type=st.sampled_from(["cpu", "cuda"])
+        if gpu_available
+        else st.just("cpu"),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
     def test_jagged_elementwise_binary_opt(
@@ -1170,7 +1183,9 @@ class JaggedTensorOpsTest(unittest.TestCase):
         outer_dense_size=st.integers(0, 4),
         inner_dense_size=st.integers(0, 4),
         dtype=st.sampled_from([torch.float, torch.half, torch.double, torch.bfloat16]),
-        device_type=st.sampled_from(["cpu", "cuda"]),
+        device_type=st.sampled_from(["cpu", "cuda"])
+        if gpu_available
+        else st.just("cpu"),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
     def test_jagged_dense_dense_elementwise_add_jagged_output(
@@ -1185,13 +1200,16 @@ class JaggedTensorOpsTest(unittest.TestCase):
             num_jagged_dim, outer_dense_size, inner_dense_size, dtype, device_type
         )
 
+    @unittest.skipIf(*gpu_unavailable)
     # pyre-ignore [56]
     @given(
         num_jagged_dim=st.just(1),
         outer_dense_size=st.integers(0, 8),
         inner_dense_size=st.sampled_from([16, 64, 96, 192]),
         dtype=st.just(torch.half),
-        device_type=st.just("cuda"),
+        device_type=st.sampled_from(["cpu", "cuda"])
+        if gpu_available
+        else st.just("cpu"),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
     def test_jagged_dense_dense_elementwise_add_jagged_output_opt(
@@ -1282,7 +1300,7 @@ class JaggedTensorOpsTest(unittest.TestCase):
         dtype=st.sampled_from([torch.float, torch.half, torch.bfloat16, torch.double]),
         device_type=st.sampled_from(["cpu", "cuda"])
         if gpu_available
-        else st.just("cuda"),
+        else st.just("cpu"),
     )
     def test_batched_dense_vec_jagged_2d_mul(
         self,

--- a/fbgemm_gpu/test/jagged_tensor_ops_test.py
+++ b/fbgemm_gpu/test/jagged_tensor_ops_test.py
@@ -20,11 +20,15 @@ try:
     from fbgemm_gpu import open_source  # noqa: F401
 
     # pyre-ignore[21]
-    from test_utils import gpu_available, gpu_unavailable
+    from test_utils import gpu_available, gpu_unavailable, running_on_github
 except Exception:
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
-    from fbgemm_gpu.test.test_utils import gpu_available, gpu_unavailable
+    from fbgemm_gpu.test.test_utils import (
+        gpu_available,
+        gpu_unavailable,
+        running_on_github,
+    )
 
 
 def lengths_to_segment_ids(lengths: torch.Tensor) -> torch.Tensor:
@@ -1446,6 +1450,7 @@ class JaggedTensorOpsTest(unittest.TestCase):
         new_embeddings = torch.index_select(values, 0, all_indices)
         return new_embeddings
 
+    @unittest.skipIf(*running_on_github)
     # pyre-ignore [56]
     @given(
         max_seq_length=st.integers(5, 10),

--- a/fbgemm_gpu/test/test_utils.py
+++ b/fbgemm_gpu/test/test_utils.py
@@ -173,7 +173,7 @@ gpu_unavailable: Tuple[bool, str] = (
 gpu_available: bool = not gpu_unavailable[0]
 
 # Used for `@unittest.skipIf` for tests that pass in internal CI, but fail on the GitHub runners
-running_on_github: bool = (
+running_on_github: Tuple[bool, str] = (
     os.getenv("GITHUB_ENV") is not None,
     "Test is currently known to fail or hang when run in the GitHub runners",
 )

--- a/fbgemm_gpu/test/test_utils.py
+++ b/fbgemm_gpu/test/test_utils.py
@@ -172,6 +172,12 @@ gpu_unavailable: Tuple[bool, str] = (
 # Used for `if` statements inside tests
 gpu_available: bool = not gpu_unavailable[0]
 
+# Used for `@unittest.skipIf` for tests that pass in internal CI, but fail on the GitHub runners
+running_on_github: bool = (
+    os.getenv("GITHUB_ENV") is not None,
+    "Test is currently known to fail or hang when run in the GitHub runners",
+)
+
 
 def cpu_and_maybe_gpu() -> st.SearchStrategy[List[torch.device]]:
     gpu_available = torch.cuda.is_available() and torch.cuda.device_count() > 0


### PR DESCRIPTION
Summary:

- Add support for retries in build steps that are known to fail due to the occasional network connection failures
- Add support for installing ROCm tooling and testing ROCm builds in the build scripts framework
- Update the existing FBGEMM_GPU CI / build_amd_gpu job to use the build scripts framework
- Fix the annotations to tests in `jagged_tensor_ops_test.py` to run correctly on CPU-only mode
- Impose timeouts of 10 minutes for running the test suites (in practice, they generally complete within 3 minutes)
- Add ability to conditionally disable tests depending on whether or not they are running inside the GitHub runner
- Disable the `test_jagged_index_select_2d` test on GitHub until we figure out the root cause of it hanging whenever it is run on GitHub (regardless of GPU or CPU variant)
