### PR TITLE
Fixed illegal memory access in [split|dense]_embedding_nobag_codegen_forward_unweighted_small_kernel

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -167,7 +167,8 @@ set(codegen_dependencies
     ${CMAKE_CURRENT_SOURCE_DIR}/include/fbgemm_gpu/quantize_ops_utils.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/fbgemm_gpu/split_embeddings_utils.cuh
     ${CMAKE_CURRENT_SOURCE_DIR}/include/fbgemm_gpu/sparse_ops_utils.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh)
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/fbgemm_gpu/fbgemm_tensor_accessor.h)
 
 if(USE_ROCM)
 message(STATUS "${PYTHON_EXECUTABLE}" "${CMAKE_CODEGEN_DIR}/embedding_backward_code_generator.py" "--opensource --is_rocm")

--- a/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
@@ -7,6 +7,12 @@
 // clang-format off
 #include "codegen/embedding_forward_template_helpers.cuh"
 
+#define MAKE_PACKED_TENSOR_ACCESSOR(...) \
+  MAKE_PACKED_TENSOR_ACCESSOR_BASE(func_name, __VA_ARGS__)
+
+#define MAKE_PACKED_TENSOR_ACCESSOR_ACC_TYPE(...) \
+  MAKE_PACKED_TENSOR_ACCESSOR_ACC_TYPE_BASE(func_name, __VA_ARGS__)
+
 using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
 
@@ -21,29 +27,29 @@ template <typename emb_t, typename grad_t, typename cache_t, size_t kMaxVecsPerT
 __global__
 __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights_kernel(
     // [\sum_t E_t x D_t]
-    const at::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits>
         grad_output,
-    at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
     {% if not dense %}
-    at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> uvm_weights,
-    at::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> uvm_weights,
+    pta::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         weights_placements,
     {% endif %}
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         indices, // [N = \sum_{b,t} L_{b,t} total indices, i.e. flattened
                  // [B][T][L]
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         offsets, // [B x T + 1]
     {% if not dense %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         lxu_cache_locations,
     {% endif %}
-    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         feature_requires_grad, // [T],
-    at::PackedTensorAccessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits>
         grad_indice_weights
     ) {
     int32_t B = grad_output.size(0);
@@ -230,6 +236,15 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights
         [&] {
             {% for kMaxVecsPerThread in range(1, max_embedding_dim // items_per_warp + 1) %}
             if (max_D <= {{ items_per_warp * kMaxVecsPerThread }}) {
+
+#ifdef FBGEMM_GPU_MEMCHECK
+            {% if dense %}
+            const char* func_name = "dense_embedding_codegen_grad_indice_weights_kernel";
+            {% else %}
+            const char* func_name = "split_embedding_codegen_grad_indice_weights_kernel";
+            {% endif %}
+#endif
+
             {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights_kernel<
                 emb_t,
                 grad_t,
@@ -239,22 +254,22 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights
                 dim3(kWarpSize, kForwardMaxThreads / kWarpSize),
                 0,
                 at::cuda::getCurrentCUDAStream()>>>(
-                grad_output.packed_accessor64<grad_t, 2, at::RestrictPtrTraits>(),
-                dev_weights.packed_accessor64<emb_t, 1, at::RestrictPtrTraits>(),
+                MAKE_PACKED_TENSOR_ACCESSOR(grad_output, grad_t, 2, at::RestrictPtrTraits, 64),
+                MAKE_PACKED_TENSOR_ACCESSOR(dev_weights, emb_t, 1, at::RestrictPtrTraits, 64),
                 {% if not dense %}
-                uvm_weights.packed_accessor64<emb_t, 1, at::RestrictPtrTraits>(),
-                lxu_cache_weights.packed_accessor64<cache_t, 2, at::RestrictPtrTraits>(),
-                weights_placements.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+                MAKE_PACKED_TENSOR_ACCESSOR(uvm_weights, emb_t, 1, at::RestrictPtrTraits, 64),
+                MAKE_PACKED_TENSOR_ACCESSOR(lxu_cache_weights, cache_t, 2, at::RestrictPtrTraits, 64),
+                MAKE_PACKED_TENSOR_ACCESSOR(weights_placements, int32_t, 1, at::RestrictPtrTraits, 32),
                 {% endif %}
-                weights_offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
-                D_offsets.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
-                indices.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
-                offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
+                MAKE_PACKED_TENSOR_ACCESSOR(weights_offsets, int64_t, 1, at::RestrictPtrTraits, 32),
+                MAKE_PACKED_TENSOR_ACCESSOR(D_offsets, int32_t, 1, at::RestrictPtrTraits, 32),
+                MAKE_PACKED_TENSOR_ACCESSOR(indices, int64_t, 1, at::RestrictPtrTraits, 32),
+                MAKE_PACKED_TENSOR_ACCESSOR(offsets, int64_t, 1, at::RestrictPtrTraits, 32),
                 {% if not dense %}
-                lxu_cache_locations.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+                MAKE_PACKED_TENSOR_ACCESSOR(lxu_cache_locations, int32_t, 1, at::RestrictPtrTraits, 32),
                 {% endif %}
-                feature_requires_grad.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
-                grad_indice_weights.packed_accessor32<at::acc_type<grad_t, true>, 1, at::RestrictPtrTraits>()
+                MAKE_PACKED_TENSOR_ACCESSOR(feature_requires_grad, int32_t, 1, at::RestrictPtrTraits, 32),
+                MAKE_PACKED_TENSOR_ACCESSOR_ACC_TYPE(grad_indice_weights, grad_t, 1, at::RestrictPtrTraits, 32)
             );
             return;
             }

--- a/fbgemm_gpu/codegen/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_template.cu
@@ -112,11 +112,7 @@ __global__ void {{ "dense" if dense else "split" }}_embedding_nobag_codegen_forw
             {% endif %}
 
             {% if not dense %}
-            auto weight_row_cache = WeightRow<emb_t, cache_t, cache_t>(
-                const_cast<emb_t*>(&weights[idx_j * D_emb]),
-                const_cast<cache_t*>(&lxu_cache_weights[cache_idx_j][0]),
-                D,
-                nullptr);
+
             // assume cache is fp16/fp32 which doesn't require qparams
             float2 qparams_cache = make_float2(0.0f, 0.0f);
 
@@ -134,6 +130,11 @@ __global__ void {{ "dense" if dense else "split" }}_embedding_nobag_codegen_forw
             if (d < D) {
                 {% if not dense %}
                 if (placement == PlacementType::MANAGED_CACHING && cache_idx_j != kCacheLocationMissing) {
+                    auto weight_row_cache = WeightRow<emb_t, cache_t, cache_t>(
+                        const_cast<emb_t*>(&weights[idx_j * D_emb]),
+                        const_cast<cache_t*>(&lxu_cache_weights[cache_idx_j][0]),
+                        D,
+                        nullptr);
                     Vec4T<cache_t> weight = weight_row_cache.load(d, qparams_cache);
                     weight.store(&output[output_j][d]);
                 } else {

--- a/fbgemm_gpu/codegen/embedding_forward_template_helpers.cuh
+++ b/fbgemm_gpu/codegen/embedding_forward_template_helpers.cuh
@@ -29,4 +29,5 @@
 #include "fbgemm_gpu/dispatch_macros.h"
 #include "fbgemm_gpu/embedding_common.h"
 #include "fbgemm_gpu/fbgemm_cuda_utils.cuh"
+#include "fbgemm_gpu/fbgemm_tensor_accessor.h"
 #include "fbgemm_gpu/sparse_ops_utils.h"

--- a/fbgemm_gpu/include/fbgemm_gpu/embedding_backward_template_helpers.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/embedding_backward_template_helpers.cuh
@@ -23,6 +23,7 @@
 #include "dispatch_macros.h"
 #include "embedding_common.h"
 #include "fbgemm_cuda_utils.cuh"
+#include "fbgemm_gpu/fbgemm_tensor_accessor.h"
 #include "sparse_ops_utils.h"
 
 DEVICE_INLINE int64_t gpuAtomicIncrement(int64_t* p) {

--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_tensor_accessor.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_tensor_accessor.h
@@ -1,0 +1,573 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include <c10/macros/Macros.h>
+#include <c10/util/ArrayRef.h>
+#include <c10/util/Deprecated.h>
+#include <c10/util/Exception.h>
+#include <c10/util/irange.h>
+#include <stdint.h>
+#include <cstddef>
+
+namespace fbgemm_gpu {
+
+// The PtrTraits argument to the TensorAccessor/GenericPackedTensorAccessor
+// is used to enable the __restrict__ keyword/modifier for the data
+// passed to cuda.
+template <typename T>
+struct DefaultPtrTraits {
+  typedef T* PtrType;
+};
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+template <typename T>
+struct RestrictPtrTraits {
+  typedef T* __restrict__ PtrType;
+};
+#endif
+
+// TensorAccessorBase and TensorAccessor are used for both CPU and CUDA tensors.
+// For CUDA tensors it is used in device code (only). This means that we
+// restrict ourselves to functions and types available there (e.g.
+// at::IntArrayRef isn't).
+
+// The PtrTraits argument is only relevant to cuda to support `__restrict__`
+// pointers.
+template <
+    typename T,
+    size_t N,
+    template <typename U> class PtrTraits = DefaultPtrTraits,
+    typename index_t = int64_t>
+class TensorAccessorBase {
+ public:
+  typedef typename PtrTraits<T>::PtrType PtrType;
+
+  C10_HOST_DEVICE TensorAccessorBase(
+      PtrType data_,
+      const index_t* sizes_,
+      const index_t* strides_,
+      const char* ptr_name_,
+      const char* func_name_)
+      : data_(data_),
+        sizes_(sizes_),
+        strides_(strides_),
+        ptr_name_(ptr_name_),
+        func_name_(func_name_) {
+    this->numel_ = 0;
+    for (size_t d = 0; d < N; d++) {
+      this->numel_ += sizes_[d];
+    }
+  }
+  C10_HOST at::IntArrayRef sizes() const {
+    return at::IntArrayRef(sizes_, N);
+  }
+  C10_HOST at::IntArrayRef strides() const {
+    return at::IntArrayRef(strides_, N);
+  }
+  C10_HOST_DEVICE index_t stride(index_t i) const {
+    return strides_[i];
+  }
+  C10_HOST_DEVICE index_t size(index_t i) const {
+    return sizes_[i];
+  }
+  C10_HOST_DEVICE PtrType data() {
+    return data_;
+  }
+  C10_HOST_DEVICE const PtrType data() const {
+    return data_;
+  }
+  C10_HOST_DEVICE void check_access(index_t idx) const {
+    if (idx < 0) {
+      printf(
+          "ERROR: idx < 0, tensor %s in %s, idx %lld\n",
+          this->ptr_name_,
+          this->func_name_,
+          static_cast<int64_t>(idx));
+    } else if (idx >= this->numel_) {
+      printf(
+          "ERROR: idx >= numel, tensor %s in %s, idx %lld, numel %lld\n",
+          this->ptr_name_,
+          this->func_name_,
+          static_cast<int64_t>(idx),
+          this->numel_);
+    }
+    CUDA_KERNEL_ASSERT(idx >= 0)
+    CUDA_KERNEL_ASSERT(idx < this->numel_);
+  }
+
+ protected:
+  PtrType data_;
+  const index_t* sizes_;
+  const index_t* strides_;
+  index_t numel_;
+  const char* ptr_name_;
+  const char* func_name_;
+};
+
+// The `TensorAccessor` is typically instantiated for CPU `Tensor`s using
+// `Tensor.accessor<T, N>()`.
+// For CUDA `Tensor`s, `GenericPackedTensorAccessor` is used on the host and
+// only indexing on the device uses `TensorAccessor`s.
+template <
+    typename T,
+    size_t N,
+    template <typename U> class PtrTraits = DefaultPtrTraits,
+    typename index_t = int64_t>
+class TensorAccessor : public TensorAccessorBase<T, N, PtrTraits, index_t> {
+ public:
+  typedef typename PtrTraits<T>::PtrType PtrType;
+
+  C10_HOST_DEVICE TensorAccessor(
+      PtrType data_,
+      const index_t* sizes_,
+      const index_t* strides_,
+      const char* ptr_name_,
+      const char* func_name_)
+      : TensorAccessorBase<T, N, PtrTraits, index_t>(
+            data_,
+            sizes_,
+            strides_,
+            ptr_name_,
+            func_name_) {}
+
+  C10_HOST_DEVICE TensorAccessor<T, N - 1, PtrTraits, index_t> operator[](
+      index_t i) {
+    return TensorAccessor<T, N - 1, PtrTraits, index_t>(
+        this->data_ + this->strides_[0] * i,
+        this->sizes_ + 1,
+        this->strides_ + 1,
+        this->ptr_name_,
+        this->func_name);
+  }
+
+  C10_HOST_DEVICE const TensorAccessor<T, N - 1, PtrTraits, index_t> operator[](
+      index_t i) const {
+    return TensorAccessor<T, N - 1, PtrTraits, index_t>(
+        this->data_ + this->strides_[0] * i,
+        this->sizes_ + 1,
+        this->strides_ + 1,
+        this->ptr_name_,
+        this->func_name);
+  }
+};
+
+template <typename T, template <typename U> class PtrTraits, typename index_t>
+class TensorAccessor<T, 1, PtrTraits, index_t>
+    : public TensorAccessorBase<T, 1, PtrTraits, index_t> {
+ public:
+  typedef typename PtrTraits<T>::PtrType PtrType;
+
+  C10_HOST_DEVICE TensorAccessor(
+      PtrType data_,
+      const index_t* sizes_,
+      const index_t* strides_,
+      const char* ptr_name_,
+      const char* func_name_)
+      : TensorAccessorBase<T, 1, PtrTraits, index_t>(
+            data_,
+            sizes_,
+            strides_,
+            ptr_name_,
+            func_name_) {}
+  C10_HOST_DEVICE T& operator[](index_t i) {
+    this->check_access(this->strides_[0] * i);
+    // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
+    return this->data_[this->strides_[0] * i];
+  }
+  C10_HOST_DEVICE const T& operator[](index_t i) const {
+    this->check_access(this->strides_[0] * i);
+    // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
+    return this->data_[this->strides_[0] * i];
+  }
+};
+
+// GenericPackedTensorAccessorBase and GenericPackedTensorAccessor are used on
+// for CUDA `Tensor`s on the host and as In contrast to `TensorAccessor`s, they
+// copy the strides and sizes on instantiation (on the host) in order to
+// transfer them on the device when calling kernels. On the device, indexing of
+// multidimensional tensors gives to `TensorAccessor`s. Use RestrictPtrTraits as
+// PtrTraits if you want the tensor's data pointer to be marked as __restrict__.
+// Instantiation from data, sizes, strides is only needed on the host and
+// std::copy isn't available on the device, so those functions are host only.
+template <
+    typename T,
+    size_t N,
+    template <typename U> class PtrTraits = DefaultPtrTraits,
+    typename index_t = int64_t>
+class GenericPackedTensorAccessorBase {
+ public:
+  typedef typename PtrTraits<T>::PtrType PtrType;
+  C10_HOST GenericPackedTensorAccessorBase(
+      PtrType data_,
+      const index_t* sizes_,
+      const index_t* strides_,
+      const char* ptr_name_,
+      const char* func_name_)
+      : data_(data_) {
+    std::copy(sizes_, sizes_ + N, std::begin(this->sizes_));
+    std::copy(strides_, strides_ + N, std::begin(this->strides_));
+    // Compute numel_
+    this->numel_ = 0;
+    for (size_t d = 0; d < N; d++) {
+      this->numel_ += sizes_[d];
+    }
+    auto ptr_name_len = std::min(strlen(ptr_name_), static_cast<size_t>(16));
+    std::memcpy(this->ptr_name_, ptr_name_, sizeof(const char) * ptr_name_len);
+    auto func_name_len = std::min(strlen(func_name_), static_cast<size_t>(64));
+    std::memcpy(
+        this->func_name_, func_name_, sizeof(const char) * func_name_len);
+  }
+
+  // if index_t is not int64_t, we want to have an int64_t constructor
+  template <
+      typename source_index_t,
+      class = typename std::enable_if<
+          std::is_same<source_index_t, int64_t>::value>::type>
+  C10_HOST GenericPackedTensorAccessorBase(
+      PtrType data_,
+      const source_index_t* sizes_,
+      const source_index_t* strides_,
+      const char* ptr_name_,
+      const char* func_name_)
+      : data_(data_) {
+    for (const auto i : c10::irange(N)) {
+      this->sizes_[i] = sizes_[i];
+      this->strides_[i] = strides_[i];
+    }
+    // Compute numel_
+    this->numel_ = 0;
+    for (size_t d = 0; d < N; d++) {
+      this->numel_ += sizes_[d];
+    }
+    auto ptr_name_len = std::min(strlen(ptr_name_), static_cast<size_t>(16));
+    std::memcpy(this->ptr_name_, ptr_name_, sizeof(const char) * ptr_name_len);
+    auto func_name_len = std::min(strlen(func_name_), static_cast<size_t>(64));
+    std::memcpy(
+        this->func_name_, func_name_, sizeof(const char) * func_name_len);
+  }
+
+  C10_HOST_DEVICE void check_access(index_t idx) const {
+    if (idx < 0) {
+      printf(
+          "ERROR: idx < 0, tensor %s in %s, idx %lld\n",
+          this->ptr_name_,
+          this->func_name_,
+          static_cast<int64_t>(idx));
+    } else if (idx >= this->numel_) {
+      printf(
+          "ERROR: idx >= numel, tensor %s in %s, idx %lld, numel %lld\n",
+          this->ptr_name_,
+          this->func_name_,
+          static_cast<int64_t>(idx),
+          this->numel_);
+    }
+    CUDA_KERNEL_ASSERT(idx >= 0)
+    CUDA_KERNEL_ASSERT(idx < this->numel_)
+  }
+
+  C10_HOST_DEVICE index_t stride(index_t i) const {
+    return strides_[i];
+  }
+  C10_HOST_DEVICE index_t size(index_t i) const {
+    return sizes_[i];
+  }
+  C10_HOST_DEVICE PtrType data() {
+    return data_;
+  }
+  C10_HOST_DEVICE const PtrType data() const {
+    return data_;
+  }
+
+ protected:
+  PtrType data_;
+  index_t sizes_[N];
+  index_t strides_[N];
+  index_t numel_;
+  char ptr_name_[16];
+  char func_name_[64];
+  C10_HOST void bounds_check_(index_t i) const {
+    TORCH_CHECK_INDEX(
+        0 <= i && i < index_t{N},
+        "Index ",
+        i,
+        " is not within bounds of a tensor of dimension ",
+        N);
+  }
+};
+
+template <
+    typename T,
+    size_t N,
+    template <typename U> class PtrTraits = DefaultPtrTraits,
+    typename index_t = int64_t>
+class GenericPackedTensorAccessor
+    : public GenericPackedTensorAccessorBase<T, N, PtrTraits, index_t> {
+ public:
+  typedef typename PtrTraits<T>::PtrType PtrType;
+
+  C10_HOST GenericPackedTensorAccessor(
+      PtrType data_,
+      const index_t* sizes_,
+      const index_t* strides_,
+      const char* ptr_name_,
+      const char* func_name_)
+      : GenericPackedTensorAccessorBase<T, N, PtrTraits, index_t>(
+            data_,
+            sizes_,
+            strides_,
+            ptr_name_,
+            func_name_) {}
+
+  // if index_t is not int64_t, we want to have an int64_t constructor
+  template <
+      typename source_index_t,
+      class = typename std::enable_if<
+          std::is_same<source_index_t, int64_t>::value>::type>
+  C10_HOST GenericPackedTensorAccessor(
+      PtrType data_,
+      const source_index_t* sizes_,
+      const source_index_t* strides_,
+      const char* ptr_name_,
+      const char* func_name_)
+      : GenericPackedTensorAccessorBase<T, N, PtrTraits, index_t>(
+            data_,
+            sizes_,
+            strides_,
+            ptr_name_,
+            func_name_) {}
+
+  C10_DEVICE TensorAccessor<T, N - 1, PtrTraits, index_t> operator[](
+      index_t i) {
+    index_t* new_sizes = this->sizes_ + 1;
+    index_t* new_strides = this->strides_ + 1;
+    return TensorAccessor<T, N - 1, PtrTraits, index_t>(
+        this->data_ + this->strides_[0] * i,
+        new_sizes,
+        new_strides,
+        this->ptr_name_,
+        this->func_name_);
+  }
+
+  C10_DEVICE const TensorAccessor<T, N - 1, PtrTraits, index_t> operator[](
+      index_t i) const {
+    const index_t* new_sizes = this->sizes_ + 1;
+    const index_t* new_strides = this->strides_ + 1;
+    return TensorAccessor<T, N - 1, PtrTraits, index_t>(
+        this->data_ + this->strides_[0] * i,
+        new_sizes,
+        new_strides,
+        this->ptr_name_,
+        this->func_name_);
+  }
+
+  /// Returns a PackedTensorAccessor of the same dimension after transposing the
+  /// two dimensions given. Does not actually move elements; transposition is
+  /// made by permuting the size/stride arrays. If the dimensions are not valid,
+  /// asserts.
+  C10_HOST GenericPackedTensorAccessor<T, N, PtrTraits, index_t> transpose(
+      index_t dim1,
+      index_t dim2) const {
+    this->bounds_check_(dim1);
+    this->bounds_check_(dim2);
+    GenericPackedTensorAccessor<T, N, PtrTraits, index_t> result(
+        this->data_, this->sizes_, this->strides_);
+    std::swap(result.strides_[dim1], result.strides_[dim2]);
+    std::swap(result.sizes_[dim1], result.sizes_[dim2]);
+    return result;
+  }
+};
+
+template <typename T, template <typename U> class PtrTraits, typename index_t>
+class GenericPackedTensorAccessor<T, 1, PtrTraits, index_t>
+    : public GenericPackedTensorAccessorBase<T, 1, PtrTraits, index_t> {
+ public:
+  typedef typename PtrTraits<T>::PtrType PtrType;
+  C10_HOST GenericPackedTensorAccessor(
+      PtrType data_,
+      const index_t* sizes_,
+      const index_t* strides_,
+      const char* ptr_name_,
+      const char* func_name_)
+      : GenericPackedTensorAccessorBase<T, 1, PtrTraits, index_t>(
+            data_,
+            sizes_,
+            strides_,
+            ptr_name_,
+            func_name_) {}
+
+  // if index_t is not int64_t, we want to have an int64_t constructor
+  template <
+      typename source_index_t,
+      class = typename std::enable_if<
+          std::is_same<source_index_t, int64_t>::value>::type>
+  C10_HOST GenericPackedTensorAccessor(
+      PtrType data_,
+      const source_index_t* sizes_,
+      const source_index_t* strides_,
+      const char* ptr_name_,
+      const char* func_name_)
+      : GenericPackedTensorAccessorBase<T, 1, PtrTraits, index_t>(
+            data_,
+            sizes_,
+            strides_,
+            ptr_name_,
+            func_name_) {}
+
+  C10_DEVICE T& operator[](index_t i) {
+    this->check_access(this->strides_[0] * i);
+    return this->data_[this->strides_[0] * i];
+  }
+  C10_DEVICE const T& operator[](index_t i) const {
+    this->check_access(this->strides_[0] * i);
+    return this->data_[this->strides_[0] * i];
+  }
+
+  // Same as in the general N-dimensional case, but note that in the
+  // 1-dimensional case the returned PackedTensorAccessor will always be an
+  // identical copy of the original
+  C10_HOST GenericPackedTensorAccessor<T, 1, PtrTraits, index_t> transpose(
+      index_t dim1,
+      index_t dim2) const {
+    this->bounds_check_(dim1);
+    this->bounds_check_(dim2);
+    return GenericPackedTensorAccessor<T, 1, PtrTraits, index_t>(
+        this->data_, this->sizes_, this->strides_);
+  }
+};
+
+// Can't put this directly into the macro function args because of commas
+#define AT_X GenericPackedTensorAccessor<T, N, PtrTraits, index_t>
+
+// Old name for `GenericPackedTensorAccessor`
+template <
+    typename T,
+    size_t N,
+    template <typename U> class PtrTraits = DefaultPtrTraits,
+    typename index_t = int64_t>
+C10_DEFINE_DEPRECATED_USING(PackedTensorAccessor, AT_X)
+
+#undef AT_X
+
+template <
+    typename T,
+    size_t N,
+    template <typename U> class PtrTraits = DefaultPtrTraits>
+using PackedTensorAccessor32 =
+    GenericPackedTensorAccessor<T, N, PtrTraits, int32_t>;
+
+template <
+    typename T,
+    size_t N,
+    template <typename U> class PtrTraits = DefaultPtrTraits>
+using PackedTensorAccessor64 =
+    GenericPackedTensorAccessor<T, N, PtrTraits, int64_t>;
+
+} // namespace fbgemm_gpu
+
+#ifdef FBGEMM_GPU_MEMCHECK
+namespace pta = fbgemm_gpu;
+#else
+namespace pta = at;
+#endif
+
+#ifdef FBGEMM_GPU_MEMCHECK
+template <
+    typename T,
+    size_t N,
+    template <typename U> class PtrTraits = at::DefaultPtrTraits,
+    typename index_t = int64_t>
+const fbgemm_gpu::GenericPackedTensorAccessor<T, N, PtrTraits, index_t>
+make_generic_packed_tensor_accessor(
+    at::Tensor& tensor,
+    const char* ptr_name,
+    const char* func_name) {
+  static_assert(
+      N > 0,
+      "accessor is used for indexing tensor, for scalars use *data_ptr<T>()");
+  TORCH_CHECK(
+      tensor.dim() == N,
+      "TensorAccessor expected ",
+      N,
+      " dims but tensor has ",
+      tensor.dim());
+  return fbgemm_gpu::GenericPackedTensorAccessor<T, N, PtrTraits, index_t>(
+      static_cast<typename PtrTraits<T>::PtrType>(tensor.data_ptr<T>()),
+      tensor.sizes().data(),
+      tensor.strides().data(),
+      ptr_name,
+      func_name);
+}
+#endif
+
+template <
+    typename T,
+    size_t N,
+    template <typename U> class PtrTraits = at::DefaultPtrTraits>
+const pta::PackedTensorAccessor32<T, N, PtrTraits>
+make_packed_tensor_accessor32(
+#ifdef FBGEMM_GPU_MEMCHECK
+    at::Tensor& tensor,
+    const char* ptr_name,
+    const char* func_name) {
+#else
+    at::Tensor& tensor) {
+#endif
+  TORCH_CHECK(
+      tensor.numel() <=
+          static_cast<int64_t>(std::numeric_limits<int32_t>::max()),
+      "numel needs to be smaller than int32_t max; otherwise, please use packed_accessor64");
+#ifdef FBGEMM_GPU_MEMCHECK
+  return make_generic_packed_tensor_accessor<T, N, PtrTraits, int32_t>(
+      tensor, ptr_name, func_name);
+#else
+  return tensor.packed_accessor32<T, N, PtrTraits>();
+#endif
+}
+
+template <
+    typename T,
+    size_t N,
+    template <typename U> class PtrTraits = at::DefaultPtrTraits>
+const pta::PackedTensorAccessor64<T, N, PtrTraits>
+make_packed_tensor_accessor64(
+#ifdef FBGEMM_GPU_MEMCHECK
+    at::Tensor& tensor,
+    const char* ptr_name,
+    const char* func_name) {
+  return make_generic_packed_tensor_accessor<T, N, PtrTraits, int64_t>(
+      tensor, ptr_name, func_name);
+#else
+    at::Tensor& tensor) {
+  return tensor.packed_accessor64<T, N, PtrTraits>();
+#endif
+}
+
+#ifdef FBGEMM_GPU_MEMCHECK
+#define MAKE_PACKED_TENSOR_ACCESSOR_BASE(                     \
+    FUNC_NAME, TENSOR, T, N, PTR_TRAITS, INDEX_NBITS)         \
+  make_packed_tensor_accessor##INDEX_NBITS<T, N, PTR_TRAITS>( \
+      TENSOR, #TENSOR, FUNC_NAME)
+
+#define MAKE_PACKED_TENSOR_ACCESSOR_ACC_TYPE_BASE(    \
+    FUNC_NAME, TENSOR, T, N, PTR_TRAITS, INDEX_NBITS) \
+  make_packed_tensor_accessor##INDEX_NBITS<           \
+      at::acc_type<T, true>,                          \
+      N,                                              \
+      PTR_TRAITS>(TENSOR, #TENSOR, FUNC_NAME)
+#else
+#define MAKE_PACKED_TENSOR_ACCESSOR_BASE(             \
+    FUNC_NAME, TENSOR, T, N, PTR_TRAITS, INDEX_NBITS) \
+  make_packed_tensor_accessor##INDEX_NBITS<T, N, PTR_TRAITS>(TENSOR)
+
+#define MAKE_PACKED_TENSOR_ACCESSOR_ACC_TYPE_BASE(    \
+    FUNC_NAME, TENSOR, T, N, PTR_TRAITS, INDEX_NBITS) \
+  make_packed_tensor_accessor##INDEX_NBITS<           \
+      at::acc_type<T, true>,                          \
+      N,                                              \
+      PTR_TRAITS>(TENSOR)
+#endif


### PR DESCRIPTION
Summary:
`[split|dense]_embedding_nobag_codegen_forward_unweighted_small_kernel`
always accesses the LXU cache even when the cache is not available.
This diff adds a runtime conditional to check if the kernel needs to
read data from cache.  (We can potentially use compile time
conditional here if this conditional adds too much overhead but it
will increase the binary size.  We can revisit this if it is needed.)

Differential Revision: D43581917

