### PR TITLE
Fix UVM Cache Stats Report

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
@@ -372,7 +372,8 @@ Tensor int_nbit_split_embedding_uvm_caching_codegen_lookup_function(
       call_count = tbe_call_count[signature];
     }
 
-    if (call_count % FLAGS_tbe_uvm_cache_stat_report == 0) {
+    if (FLAGS_tbe_uvm_cache_stat_report > 0 &&
+        call_count % FLAGS_tbe_uvm_cache_stat_report == 0) {
       gather_uvm_stats = true;
       uvm_cache_stats = at::zeros(
           {kUvmCacheStatsSize},


### PR DESCRIPTION
Summary: Previously, we want to disable cache stats report when gflag ```FLAGS_tbe_uvm_cache_stat_report``` is non-positive but we can still see observe cache stats (cache miss when UVM cache is enabled) when ```FLAGS_tbe_uvm_cache_stat_report``` is negative. This diff fixes this error so that cache stats report can be disabled.

Differential Revision: D43630535

