### PR TITLE
[T146787123] Re-enable compilation of `merge_pooled_embeddings` operator in OSS

### DIFF
--- a/.github/workflows/fbgemm_gpu_ci.yml
+++ b/.github/workflows/fbgemm_gpu_ci.yml
@@ -169,7 +169,7 @@ jobs:
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
     - name: Build and Install FBGEMM_GPU (CPU version)
-      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_install $BUILD_ENV cpuonly
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_install $BUILD_ENV cpu
 
     - name: Test with PyTest
       timeout-minutes: 10

--- a/.github/workflows/fbgemm_nightly_build_cpu.yml
+++ b/.github/workflows/fbgemm_nightly_build_cpu.yml
@@ -78,7 +78,7 @@ jobs:
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
     - name: Build FBGEMM_GPU Nightly (CPU version)
-      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_package $BUILD_ENV fbgemm_gpu_nightly cpuonly
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_package $BUILD_ENV fbgemm_gpu_nightly cpu
 
     - name: Upload Built Wheel as GHA Artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/fbgemm_release_build_cpu.yml
+++ b/.github/workflows/fbgemm_release_build_cpu.yml
@@ -70,7 +70,7 @@ jobs:
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
     - name: Build FBGEMM_GPU (CPU version)
-      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_package $BUILD_ENV fbgemm_gpu cpuonly
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_package $BUILD_ENV fbgemm_gpu cpu
 
     - name: Upload Built Wheel as GHA Artifact
       uses: actions/upload-artifact@v3

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -320,12 +320,15 @@ if(NOT FBGEMM_CPU_ONLY)
     src/embedding_inplace_update_gpu.cpp)
 
   if(NVML_LIB_PATH)
+    message(STATUS "Found NVML_LIB_PATH: ${NVML_LIB_PATH}")
     list(
       APPEND
       fbgemm_gpu_sources_cpu
       src/merge_pooled_embeddings_cpu.cpp
       src/merge_pooled_embeddings_gpu.cpp
       src/topology_utils.cpp)
+  else()
+    message(STATUS "Could not find NVML_LIB_PATH; will NOT include certain sources into the build!")
   endif()
 endif()
 


### PR DESCRIPTION
Summary:

- Re-enable building of `merge_pooled_embeddings` operators in OSS
- Add `nm` checks for a few operators after OSS compilation to ensure that they are actually compiled into the shared library
- Downgrade the GCC version used for OSS builds to 9.3, since later versions of GCC will build libraries that have a dependency on `GLIBCXX_3.4.29`, which is not available on systems with older versions of `libstdc++.so.6`, such as CentOS Stream 8 and Ubuntu 20.04
- Print SHA of the built wheels after build and before installation to verify that the packages are correctly uploaded to and downloaded from GHA