### PR TITLE
Prepare transpose_embedding_input for VLE

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_kernel_warp_template.cu
@@ -33,7 +33,6 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
     {%- if not nobag %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
     {%- else %}
-    int32_t B,
     int64_t D,
     {%- endif %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
@@ -64,13 +63,13 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
     at::PackedTensorAccessor64<cache_t, 1, at::RestrictPtrTraits> grad_dev_weights,
     {%- endif %}
     {%- if not nobag %}
-    FixedDivisor fd,
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask,
     {%- endif %}
     {{ args.split_kernel_args | join(",\n    ") }}) {
 
     {%- if not nobag %}
     int32_t T = D_offsets.size(0) - 1;
-    const int32_t B = grad_output.size(0);
     {%- else %}
     int32_t T = weights_offsets.size(0);
     {%- endif %}
@@ -87,178 +86,177 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
 
     for (uint32_t run_id = start_run_id;
          run_id < sorted_linear_indices_run.size(0) && run_id < sorted_linear_indices_num_runs[0];
-         run_id += gridDim.x * blockDim.y) {
+             run_id += gridDim.x * blockDim.y) {
 
-    const int64_t linear_index = sorted_linear_indices_run[run_id];
-    const int32_t segment_start =
-        sorted_linear_indices_cumulative_run_lengths[run_id];
-    const int32_t segment_end =
-        sorted_linear_indices_cumulative_run_lengths[run_id + 1];
-    const int32_t SL = segment_end - segment_start;
+        const int64_t linear_index = sorted_linear_indices_run[run_id];
+        const int32_t segment_start =
+            sorted_linear_indices_cumulative_run_lengths[run_id];
+        const int32_t segment_end =
+            sorted_linear_indices_cumulative_run_lengths[run_id + 1];
+        const int32_t SL = segment_end - segment_start;
 
-    if (SL >= max_segment_length_per_warp) {
-        continue;
-    }
+        if (SL >= max_segment_length_per_warp) {
+            continue;
+        }
 
-    // now, each segment corresponds to exactly one table `t` and row in
-    // that table (`idx`). Thus, we can hoist out some of the book-keeping.
-    const auto info_0 = sorted_infos[segment_start];
-
-    {%- if not nobag %}
-    int32_t t_0 = fd.Div(info_0); // info_0 / B;
-    {%- else %}
-    int32_t t_0 = info_0 % T;
-    {%- endif %}
-
-    int64_t hash_size = hash_size_cumsum[t_0];
-    {%- if not nobag %}
-    int32_t D = D_offsets[t_0 + 1] - D_offsets[t_0];
-    {%- endif %}
-    int64_t idx = linear_index - hash_size;
-
-    const int32_t SL_per_warp = div_round_up(SL, blockDim.y);
-    const int32_t sl_start = 0;
-    const int32_t sl_end = SL;
-    Vec4T<at::acc_type<cache_t, true>> grad_sum[kMaxVecsPerThread];
-    for (int32_t sl = sl_start; sl < sl_end; sl += kThreadGroupSize) {
-        int32_t sl_j = sl + threadIdx.x;
+        // now, each segment corresponds to exactly one table `t` and row in
+        // that table (`idx`). Thus, we can hoist out some of the book-keeping.
         {%- if not nobag %}
-        int32_t b_t = sl_j < sl_end ? sorted_infos[segment_start + sl_j] : 0;
-        int32_t b; //= b_t % B;
-        int32_t t; //= b_t / B;
-        fd.DivMod(b_t, &t, &b);
-        int32_t D_start = D_offsets[t];
+        const auto info_0 = reinterpret_cast<const uint32_t*>(&sorted_infos[0])[segment_start];
+        const auto t_0 = info_0 >> info_B_num_bits;
         {%- else %}
-        int64_t l_t = sl_j < sl_end ? sorted_infos[segment_start + sl_j] : 0;
-        int32_t l = l_t / T;
-        {%- endif %}
-        {%- if weighted %}
-        at::acc_type<cache_t, true> idx_weight = sl_j < sl_end ? sorted_indice_weights[segment_start + sl_j] : 0.0;
+        const auto info_0 = sorted_infos[segment_start];
+        int32_t t_0 = info_0 % T;
         {%- endif %}
 
-        for (int32_t j = 0; j < kThreadGroupSize && sl + j < sl_end; ++j) {
+        int64_t hash_size = hash_size_cumsum[t_0];
+        {%- if not nobag %}
+        int32_t D = D_offsets[t_0 + 1] - D_offsets[t_0];
+        {%- endif %}
+        int64_t idx = linear_index - hash_size;
+
+        const int32_t SL_per_warp = div_round_up(SL, blockDim.y);
+        const int32_t sl_start = 0;
+        const int32_t sl_end = SL;
+        Vec4T<at::acc_type<cache_t, true>> grad_sum[kMaxVecsPerThread];
+        for (int32_t sl = sl_start; sl < sl_end; sl += kThreadGroupSize) {
+            int32_t sl_j = sl + threadIdx.x;
             {%- if not nobag %}
-            int32_t b_j = SHFL_SYNC(b, j);
-            int32_t D_start_j = SHFL_SYNC(D_start, j);
+            const auto b_t = sl_j < sl_end ? reinterpret_cast<const uint32_t*>(&sorted_infos[0])[segment_start + sl_j] : 0;
+            const auto b = b_t & info_B_mask;
+            const auto t = b_t >> info_B_num_bits;
+            int32_t D_start = D_offsets[t];
             {%- else %}
-            int32_t l_j = SHFL_SYNC(l, j);
+            int64_t l_t = sl_j < sl_end ? sorted_infos[segment_start + sl_j] : 0;
+            int32_t l = l_t / T;
             {%- endif %}
             {%- if weighted %}
-            at::acc_type<cache_t, true> idx_weight_j = SHFL_SYNC(idx_weight, j);
+            at::acc_type<cache_t, true> idx_weight = sl_j < sl_end ? sorted_indice_weights[segment_start + sl_j] : 0.0;
             {%- endif %}
 
-            #pragma unroll kMaxVecsPerThread
-            for (int32_t i = 0;
-                    i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
-                    ++i) {
-                int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
+            for (int32_t j = 0; j < kThreadGroupSize && sl + j < sl_end; ++j) {
                 {%- if not nobag %}
-                Vec4T<at::acc_type<grad_t, true>> grad_out_vec(
-                    &grad_output[b_j][0] + D_start_j + d);
+                int32_t b_j = SHFL_SYNC(b, j);
+                int32_t D_start_j = SHFL_SYNC(D_start, j);
                 {%- else %}
-                Vec4T<at::acc_type<grad_t, true>> grad_out_vec(&grad_output[l_j][d]);
+                int32_t l_j = SHFL_SYNC(l, j);
                 {%- endif %}
                 {%- if weighted %}
-                grad_sum[i].fma_(grad_out_vec, idx_weight_j);
-                {%- else %}
-                grad_sum[i].add_(grad_out_vec);
+                at::acc_type<cache_t, true> idx_weight_j = SHFL_SYNC(idx_weight, j);
                 {%- endif %}
+
+                #pragma unroll kMaxVecsPerThread
+                for (int32_t i = 0;
+                        i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
+                        ++i) {
+                    int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
+                    {%- if not nobag %}
+                    Vec4T<at::acc_type<grad_t, true>> grad_out_vec(
+                        &grad_output[b_j][0] + D_start_j + d);
+                    {%- else %}
+                    Vec4T<at::acc_type<grad_t, true>> grad_out_vec(&grad_output[l_j][d]);
+                    {%- endif %}
+                    {%- if weighted %}
+                    grad_sum[i].fma_(grad_out_vec, idx_weight_j);
+                    {%- else %}
+                    grad_sum[i].add_(grad_out_vec);
+                    {%- endif %}
+                }
             }
         }
-    }
-    int64_t weights_offset = weights_offsets[t_0];
-    {%- if not dense %}
-    emb_t* __restrict__ weights{nullptr};
-    cache_t* __restrict__ cache_weights{nullptr};
-    int32_t D_emb = D;
-    if (std::is_same<emb_t, uint8_t>::value) {
-        D_emb += kINT8QparamsBytes;
-    }
-    const auto weights_placement = static_cast<PlacementType>(weights_placements[t_0]);
-    if (weights_placement == PlacementType::DEVICE) {
-        weights = &dev_weights[weights_offset + idx * D_emb];
-    } else {
-        weights = &uvm_weights[weights_offset + idx * D_emb];
-    }
-    if (weights_placement == PlacementType::MANAGED_CACHING) {
-        int32_t cache_idx = sorted_lxu_cache_locations[segment_start];
-        if (cache_idx != kCacheLocationMissing) {
-            cache_weights = &lxu_cache_weights[cache_idx][0];
+        int64_t weights_offset = weights_offsets[t_0];
+        {%- if not dense %}
+        emb_t* __restrict__ weights{nullptr};
+        cache_t* __restrict__ cache_weights{nullptr};
+        int32_t D_emb = D;
+        if (std::is_same<emb_t, uint8_t>::value) {
+            D_emb += kINT8QparamsBytes;
         }
-    }
-    {%- for tensor in args.split_tensors %}
-    at::acc_type<cache_t, true>* __restrict__ {{ tensor }};
-    const auto {{ tensor }}_placement = static_cast<PlacementType>({{ tensor }}_placements[t_0]);
-    int64_t {{ tensor }}_offset = {{ tensor }}_offsets[t_0];
-    if ({{ tensor }}_placement == PlacementType::DEVICE) {
-        {{ tensor }} = &{{ tensor }}_dev[{{ tensor }}_offset];
-    } else {
-        {{ tensor }} = &{{ tensor }}_uvm[{{ tensor }}_offset];
-    }
-    {%- endfor %}
-
-    struct SharedMemory<Vec4T<at::acc_type<cache_t, true>>> weight_update_buffer;
-    Vec4T<at::acc_type<cache_t, true>>* shared_weight_update_row = weight_update_buffer.getPointer();
-    auto weight_row_template = WeightRow<emb_t, cache_t, at::acc_type<cache_t, true>>(weights, cache_weights, D, nullptr);
-    if (!std::is_same<emb_t, float>::value && stochastic_rounding) {
-        StochasticRoundingRNGState state;
-        // different for every *run* and every *thread*.
-        auto stochastic_rounding_seeds =
-            at::cuda::philox::unpack(stochastic_rounding_philox_args);
-        stochastic_rounding_init(
-            std::get<0>(stochastic_rounding_seeds) ^
-                std::get<1>(stochastic_rounding_seeds),
-            threadIdx.x + run_id * blockDim.x,
-            &state);
-        weight_row_template.set_stoc_state(&state);
-    }
-    float2 qparams_template;
-    if (std::is_same<emb_t, uint8_t>::value && !cache_weights){
-        qparams_template = weight_row_template.load_qparams();
-    }
-
-    {{ split_precomputation }}
-
-    float2 qparams_new;
-    #pragma unroll kMaxVecsPerThread
-    for (int32_t i = 0;
-            i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
-            ++i) {
-        int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
-        Vec4T<at::acc_type<cache_t, true>> weight_new = weight_row_template.load(d, qparams_template);
-        auto& grad = grad_sum[i];
-        {{ split_weight_update }}
-        if (std::is_same<emb_t, uint8_t>::value && !cache_weights) {
-            shared_weight_update_row[threadIdx.x + (i + threadIdx.y * kMaxVecsPerThread) * kThreadGroupSize] = weight_new;
+        const auto weights_placement = static_cast<PlacementType>(weights_placements[t_0]);
+        if (weights_placement == PlacementType::DEVICE) {
+            weights = &dev_weights[weights_offset + idx * D_emb];
         } else {
-            weight_row_template.store(weight_new, d, qparams_new); // qparams_new not used if type is not int8
+            weights = &uvm_weights[weights_offset + idx * D_emb];
         }
-    }
+        if (weights_placement == PlacementType::MANAGED_CACHING) {
+            int32_t cache_idx = sorted_lxu_cache_locations[segment_start];
+            if (cache_idx != kCacheLocationMissing) {
+                cache_weights = &lxu_cache_weights[cache_idx][0];
+            }
+        }
+        {% for tensor in args.split_tensors %}
+        at::acc_type<cache_t, true>* __restrict__ {{ tensor }};
+        const auto {{ tensor }}_placement = static_cast<PlacementType>({{ tensor }}_placements[t_0]);
+        int64_t {{ tensor }}_offset = {{ tensor }}_offsets[t_0];
+        if ({{ tensor }}_placement == PlacementType::DEVICE) {
+            {{ tensor }} = &{{ tensor }}_dev[{{ tensor }}_offset];
+        } else {
+            {{ tensor }} = &{{ tensor }}_uvm[{{ tensor }}_offset];
+        }
+        {% endfor %}
 
-    if (std::is_same<emb_t, uint8_t>::value && !cache_weights) {
-        // calculate new qparams after row update
-        qparams_new = thrust_find_qparams<at::acc_type<cache_t, true>>(&shared_weight_update_row[threadIdx.y * kMaxVecsPerThread * kThreadGroupSize], D);
-        weight_row_template.store_qparams(qparams_new);
+        struct SharedMemory<Vec4T<at::acc_type<cache_t, true>>> weight_update_buffer;
+        Vec4T<at::acc_type<cache_t, true>>* shared_weight_update_row = weight_update_buffer.getPointer();
+        auto weight_row_template = WeightRow<emb_t, cache_t, at::acc_type<cache_t, true>>(weights, cache_weights, D, nullptr);
+        if (!std::is_same<emb_t, float>::value && stochastic_rounding) {
+            StochasticRoundingRNGState state;
+            // different for every *run* and every *thread*.
+            auto stochastic_rounding_seeds =
+                at::cuda::philox::unpack(stochastic_rounding_philox_args);
+            stochastic_rounding_init(
+                std::get<0>(stochastic_rounding_seeds) ^
+                    std::get<1>(stochastic_rounding_seeds),
+                threadIdx.x + run_id * blockDim.x,
+                &state);
+            weight_row_template.set_stoc_state(&state);
+        }
+        float2 qparams_template;
+        if (std::is_same<emb_t, uint8_t>::value && !cache_weights){
+            qparams_template = weight_row_template.load_qparams();
+        }
 
-        // fetch cached updated row from shared mem and quantize on-the-fly when saving to lowp embedding
+        {{ split_precomputation }}
+
+        float2 qparams_new;
         #pragma unroll kMaxVecsPerThread
         for (int32_t i = 0;
                 i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
                 ++i) {
             int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
-            weight_row_template.store(shared_weight_update_row[threadIdx.x + (i + threadIdx.y * kMaxVecsPerThread) * kThreadGroupSize], d, qparams_new);
+            Vec4T<at::acc_type<cache_t, true>> weight_new = weight_row_template.load(d, qparams_template);
+            auto& grad = grad_sum[i];
+            {{ split_weight_update }}
+            if (std::is_same<emb_t, uint8_t>::value && !cache_weights) {
+                shared_weight_update_row[threadIdx.x + (i + threadIdx.y * kMaxVecsPerThread) * kThreadGroupSize] = weight_new;
+            } else {
+                weight_row_template.store(weight_new, d, qparams_new); // qparams_new not used if type is not int8
+            }
         }
-    }
-    {%- else %}
-#pragma unroll kMaxVecsPerThread
-    for (int32_t i = 0;
-        i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
-        ++i) {
-        int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
-        auto& grad = grad_sum[i];
-        grad.store(&grad_dev_weights[weights_offset + idx * D + d]);
-    }
-    {%- endif %}
+
+        if (std::is_same<emb_t, uint8_t>::value && !cache_weights) {
+            // calculate new qparams after row update
+            qparams_new = thrust_find_qparams<at::acc_type<cache_t, true>>(&shared_weight_update_row[threadIdx.y * kMaxVecsPerThread * kThreadGroupSize], D);
+            weight_row_template.store_qparams(qparams_new);
+
+            // fetch cached updated row from shared mem and quantize on-the-fly when saving to lowp embedding
+            #pragma unroll kMaxVecsPerThread
+            for (int32_t i = 0;
+                    i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
+                    ++i) {
+                int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
+                weight_row_template.store(shared_weight_update_row[threadIdx.x + (i + threadIdx.y * kMaxVecsPerThread) * kThreadGroupSize], d, qparams_new);
+            }
+        }
+        {%- else %}
+    	#pragma unroll kMaxVecsPerThread
+        for (int32_t i = 0;
+            i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
+            ++i) {
+            int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
+            auto& grad = grad_sum[i];
+            grad.store(&grad_dev_weights[weights_offset + idx * D + d]);
+        }
+        {%- endif %}
 
     }
 }
@@ -307,35 +305,41 @@ void split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimize
   {{ kMaxVecsPerThread }},
   {{ kThreadGroupSize }}
 > (
-    const at::PackedTensorAccessor64<{{ grad_type }}, 2, at::RestrictPtrTraits> grad_output,
+    const at::PackedTensorAccessor64<{{ grad_type }}, 2, at::RestrictPtrTraits>
+        grad_output,
     at::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> dev_weights,
     {%- if not dense %}
     at::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> uvm_weights,
     at::PackedTensorAccessor64<{{ cache_type }}, 2, at::RestrictPtrTraits> lxu_cache_weights,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        weights_placements,
     {%- endif %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
     {%- if not nobag %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
     {%- else %}
-    int32_t B,
     int64_t D,
     {%- endif %}
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> hash_size_cumsum,
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_linear_indices_run,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_cumulative_run_lengths,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+        hash_size_cumsum,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+        sorted_linear_indices_run,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        sorted_linear_indices_cumulative_run_lengths,
     {%- if not nobag %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_infos,
     {%- else %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_infos,
     {%- endif %}
     {%- if not dense %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_lxu_cache_locations,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        sorted_lxu_cache_locations,
     {%- endif %}
     {%- if weighted %}
     const at::PackedTensorAccessor32<at::acc_type<{{ cache_type }}, true>, 1, at::RestrictPtrTraits> sorted_indice_weights,
     {%- endif %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_num_runs,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        sorted_linear_indices_num_runs,
     int32_t max_segment_length_per_warp,
     {%- if not dense %}
     bool stochastic_rounding,
@@ -344,7 +348,8 @@ void split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimize
     at::PackedTensorAccessor64<{{ cache_type }}, 1, at::RestrictPtrTraits> grad_dev_weights,
     {%- endif %}
     {%- if not nobag %}
-    FixedDivisor fd,
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask,
     {%- endif %}
     {{ args.split_kernel_args_no_defaults | join(",\n    ") | replace("cache_t", cache_type) }});
 
@@ -381,35 +386,41 @@ void split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimize
   {{ kMaxVecsPerThread }},
   {{ kThreadGroupSize }}
 > (
-    const at::PackedTensorAccessor64<{{ grad_type }}, 2, at::RestrictPtrTraits> grad_output,
+    const at::PackedTensorAccessor64<{{ grad_type }}, 2, at::RestrictPtrTraits>
+        grad_output,
     at::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> dev_weights,
     {%- if not dense %}
     at::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> uvm_weights,
     at::PackedTensorAccessor64<{{ cache_type }}, 2, at::RestrictPtrTraits> lxu_cache_weights,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        weights_placements,
     {%- endif %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
     {%- if not nobag %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
     {%- else %}
-    int32_t B,
     int64_t D,
     {%- endif %}
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> hash_size_cumsum,
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_linear_indices_run,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_cumulative_run_lengths,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+        hash_size_cumsum,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+        sorted_linear_indices_run,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        sorted_linear_indices_cumulative_run_lengths,
     {%- if not nobag %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_infos,
     {%- else %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_infos,
     {%- endif %}
     {%- if not dense %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_lxu_cache_locations,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        sorted_lxu_cache_locations,
     {%- endif %}
     {%- if weighted %}
     const at::PackedTensorAccessor32<at::acc_type<{{ cache_type }}, true>, 1, at::RestrictPtrTraits> sorted_indice_weights,
     {%- endif %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_num_runs,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        sorted_linear_indices_num_runs,
     int32_t max_segment_length_per_warp,
     {%- if not dense %}
     bool stochastic_rounding,
@@ -418,7 +429,8 @@ void split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimize
     at::PackedTensorAccessor64<{{ cache_type }}, 1, at::RestrictPtrTraits> grad_dev_weights,
     {%- endif %}
     {%- if not nobag %}
-    FixedDivisor fd,
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask,
     {%- endif %}
     {{ args.split_kernel_args_no_defaults | join(",\n    ") | replace("cache_t", cache_type) }});
 

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.cuh
@@ -10,6 +10,14 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
+// These values are adjusted in backward based on B and T
+constexpr int DEFAULT_INFO_NUM_BITS = 32;
+constexpr int DEFAULT_INFO_B_NUM_BITS = 26;
+constexpr uint32_t DEFAULT_INFO_B_MASK = (1u << DEFAULT_INFO_B_NUM_BITS) - 1;
+constexpr uint32_t MAX_T =
+    (1u << (DEFAULT_INFO_NUM_BITS - DEFAULT_INFO_B_NUM_BITS)) - 1;
+constexpr uint32_t MAX_B = (1u << DEFAULT_INFO_B_NUM_BITS) - 1;
+
 /**
  * "Transpose" embedding inputs by sorting indices by their values.
  * Logically this transpose compressed sparse row (CSR) representation
@@ -32,6 +40,11 @@ transpose_embedding_input(
     const c10::optional<at::Tensor>& vbe_b_t_map = c10::optional<at::Tensor>(),
     const int64_t info_B_num_bits = 26,
     const int64_t info_B_mask = 0x2FFFFFF);
+
+std::tuple<int64_t, int64_t>
+get_infos_metadata(at::Tensor unused, int64_t B, int64_t T);
+
+std::tuple<int32_t, uint32_t> adjust_info_B_num_bits(int32_t B, int32_t T);
 
 // Use these functions instead of directly calling cub functions
 // to reduce code size and compilation time.

--- a/fbgemm_gpu/src/split_embeddings_utils.cpp
+++ b/fbgemm_gpu/src/split_embeddings_utils.cpp
@@ -14,5 +14,7 @@
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "transpose_embedding_input(Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, bool nobag=False, Tensor? vbe_b_t_map=None, int info_B_num_bits=26, int info_B_mask=0x2FFFFFF) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)");
+  m.def("get_infos_metadata(Tensor unused, int B, int T) -> (int, int)");
   DISPATCH_TO_CUDA("transpose_embedding_input", transpose_embedding_input);
+  DISPATCH_TO_CUDA("get_infos_metadata", get_infos_metadata);
 }

--- a/fbgemm_gpu/src/split_embeddings_utils.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils.cu
@@ -59,71 +59,77 @@ using Tensor = at::Tensor;
 
 using namespace fbgemm_gpu;
 
-template <typename index_t>
+template <typename index_t, typename info_acc_t, bool nobag, bool vbe>
 __global__ __launch_bounds__(kMaxThreads) void linearize_index_kernel(
     const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         hash_size_cumsum,
     const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
     const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
-    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> infos,
+    at::PackedTensorAccessor32<info_acc_t, 1, at::RestrictPtrTraits> infos,
     at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
-        linear_indices) {
+        linear_indices,
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask,
+    const uint32_t max_T,
+    const uint32_t max_B,
+    // Use a raw pointer to avoid creating dummy PackedTensorAccessor
+    const uint32_t* const __restrict__ vbe_b_t_map,
+    FixedDivisor fd) {
   const int32_t T = hash_size_cumsum.size(0) - 1;
-  const int32_t B = (offsets.size(0) - 1) / T;
-  const int32_t b_t = blockIdx.x * blockDim.x + threadIdx.x;
-  const int32_t b = b_t % B;
-  const int32_t t = b_t / B;
-  const bool valid = t < T;
+  auto b_t = blockIdx.x * blockDim.x + threadIdx.x;
+  int32_t b;
+  int32_t t;
+  const auto total_B = offsets.size(0) - 1;
+  bool valid = b_t < total_B;
+  auto info = 0;
 
-  const index_t hash_offset = valid ? hash_size_cumsum[t] : -1;
-  const index_t indices_start = valid ? offsets[t * B + b] : -1;
-  const int32_t L = valid ? offsets[t * B + b + 1] - indices_start : 0;
-  const int32_t lane_id = threadIdx.x % fbgemm_gpu::kWarpSize;
-
-  for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
-    const index_t indices_start_warp = fbgemm_gpu::shfl_sync(indices_start, j);
-    const int32_t b_t_warp = fbgemm_gpu::shfl_sync(b_t, j);
-    const int32_t L_warp = fbgemm_gpu::shfl_sync(L, j);
-    const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
-    for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
-      const index_t idx = __ldg(&indices[indices_start_warp + i]);
-      infos[indices_start_warp + i] = b_t_warp;
-      linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
-    }
+  if (vbe && valid) {
+    info = vbe_b_t_map[b_t];
+    reinterpret_cast<uint32_t*>(&t)[0] = info >> info_B_num_bits;
+    reinterpret_cast<uint32_t*>(&b)[0] = info | info_B_mask;
+  } else {
+    fd.DivMod(b_t, &t, &b);
   }
-}
-
-template <typename index_t>
-__global__ __launch_bounds__(kMaxThreads) void nobag_linearize_index_kernel(
-    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
-        hash_size_cumsum,
-    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
-    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
-    at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> infos,
-    at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
-        linear_indices) {
-  const int32_t T = hash_size_cumsum.size(0) - 1;
-  const int32_t B = (offsets.size(0) - 1) / T;
-  const int32_t b_t = blockIdx.x * blockDim.x + threadIdx.x;
-  const int32_t b = b_t % B;
-  const int32_t t = b_t / B;
-  const bool valid = t < T;
 
   const index_t hash_offset = valid ? hash_size_cumsum[t] : -1;
-  const index_t indices_start = valid ? offsets[t * B + b] : -1;
-  const int32_t L = valid ? offsets[t * B + b + 1] - indices_start : 0;
+  const index_t indices_start = valid ? offsets[b_t] : -1;
+  const int32_t L = valid ? offsets[b_t + 1] - indices_start : 0;
   const int32_t lane_id = threadIdx.x % fbgemm_gpu::kWarpSize;
 
-  for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
-    const index_t indices_start_warp = fbgemm_gpu::shfl_sync(indices_start, j);
-    const int32_t t_warp = fbgemm_gpu::shfl_sync(t, j);
-    const int32_t L_warp = fbgemm_gpu::shfl_sync(L, j);
-    const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
-    for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
-      const index_t idx = __ldg(&indices[indices_start_warp + i]);
-      const int64_t l_t = (indices_start_warp + i) * T + t_warp;
-      infos[indices_start_warp + i] = l_t;
-      linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
+  // Compile-time conditional
+  if (nobag) {
+    for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
+      const index_t indices_start_warp =
+          fbgemm_gpu::shfl_sync(indices_start, j);
+      const int32_t t_warp = fbgemm_gpu::shfl_sync(t, j);
+      const int32_t L_warp = fbgemm_gpu::shfl_sync(L, j);
+      const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
+      for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
+        const index_t idx = __ldg(&indices[indices_start_warp + i]);
+        const int64_t l_t = (indices_start_warp + i) * T + t_warp;
+        infos[indices_start_warp + i] = l_t;
+        linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
+      }
+    }
+  } else {
+    // Store t in upper (32 - DEFAULT_INFO_B_NUM_BITS).
+    // Store b in lower (DEFAULT_INFO_B_NUM_BITS).
+    if (!vbe && valid) {
+      info = (reinterpret_cast<uint32_t*>(&t)[0] << info_B_num_bits) |
+          reinterpret_cast<uint32_t*>(&b)[0];
+    }
+    for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
+      const index_t indices_start_warp =
+          fbgemm_gpu::shfl_sync(indices_start, j);
+      const uint32_t info_warp = fbgemm_gpu::shfl_sync(info, j);
+      const int32_t L_warp = fbgemm_gpu::shfl_sync(L, j);
+      const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
+      for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
+        const index_t idx = __ldg(&indices[indices_start_warp + i]);
+        reinterpret_cast<uint32_t*>(&infos[0])[indices_start_warp + i] =
+            info_warp;
+        linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
+      }
     }
   }
 }
@@ -145,8 +151,12 @@ transpose_embedding_input(
     const c10::optional<Tensor>& vbe_b_t_map,
     const int64_t info_B_num_bits,
     const int64_t info_B_mask) {
-  const int32_t T = hash_size_cumsum.size(0) - 1;
-  const int32_t B = (offsets.size(0) - 1) / T;
+  const bool vbe = vbe_b_t_map.has_value();
+  TORCH_CHECK(nobag || !vbe || info_B_num_bits > 0);
+  TORCH_CHECK(!vbe || info_B_mask > 0);
+
+  const auto total_B = offsets.size(0) - 1;
+  const auto T = hash_size_cumsum.size(0) - 1;
 
   auto infos = at::empty_like(
       indices, indices.options().dtype(nobag ? at::kLong : at::kInt));
@@ -160,39 +170,40 @@ transpose_embedding_input(
 
   using at::RestrictPtrTraits;
 
+#define INVOKE_LINEARIZE_INDEX_KERNEL(INFO_ACC_T, NOBAG)                   \
+  const auto linearize_index_kernel_ =                                     \
+      (vbe ? linearize_index_kernel<index_t, INFO_ACC_T, NOBAG, true>      \
+           : linearize_index_kernel<index_t, INFO_ACC_T, NOBAG, false>);   \
+  linearize_index_kernel_<<<                                               \
+      div_round_up(total_B, kMaxThreads),                                  \
+      kMaxThreads,                                                         \
+      0,                                                                   \
+      at::cuda::getCurrentCUDAStream()>>>(                                 \
+      hash_size_cumsum.packed_accessor32<index_t, 1, RestrictPtrTraits>(), \
+      indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),          \
+      offsets.packed_accessor32<index_t, 1, RestrictPtrTraits>(),          \
+      infos.packed_accessor32<INFO_ACC_T, 1, RestrictPtrTraits>(),         \
+      linear_indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),   \
+      info_B_num_bits,                                                     \
+      info_B_mask,                                                         \
+      (1u << (DEFAULT_INFO_NUM_BITS - info_B_num_bits)) - 1,               \
+      (1u << info_B_num_bits) - 1,                                         \
+      vbe ? reinterpret_cast<uint32_t*>(vbe_b_t_map.value().data_ptr())    \
+          : nullptr,                                                       \
+      FixedDivisor(total_B / T));                                          \
+  C10_CUDA_KERNEL_LAUNCH_CHECK()
+
   AT_DISPATCH_INDEX_TYPES(
       infos.scalar_type(), "transpose_embedding_input1", [&] {
         using info_t = index_t;
         AT_DISPATCH_INDEX_TYPES(
             indices.scalar_type(), "transpose_embedding_input2", [&] {
               if (!nobag) {
-                linearize_index_kernel<<<
-                    div_round_up(B * T, kMaxThreads),
-                    kMaxThreads,
-                    0,
-                    at::cuda::getCurrentCUDAStream()>>>(
-                    hash_size_cumsum
-                        .packed_accessor32<index_t, 1, RestrictPtrTraits>(),
-                    indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
-                    offsets.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
-                    infos.packed_accessor32<int32_t, 1, RestrictPtrTraits>(),
-                    linear_indices
-                        .packed_accessor32<index_t, 1, RestrictPtrTraits>());
+                INVOKE_LINEARIZE_INDEX_KERNEL(int32_t, false);
               } else {
-                nobag_linearize_index_kernel<<<
-                    div_round_up(B * T, kMaxThreads),
-                    kMaxThreads,
-                    0,
-                    at::cuda::getCurrentCUDAStream()>>>(
-                    hash_size_cumsum
-                        .packed_accessor32<index_t, 1, RestrictPtrTraits>(),
-                    indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
-                    offsets.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
-                    infos.packed_accessor32<int64_t, 1, RestrictPtrTraits>(),
-                    linear_indices
-                        .packed_accessor32<index_t, 1, RestrictPtrTraits>());
+                INVOKE_LINEARIZE_INDEX_KERNEL(int64_t, true);
               }
-              C10_CUDA_KERNEL_LAUNCH_CHECK();
+
               {
                 size_t temp_storage_bytes = 0;
                 AT_CUDA_CHECK(
@@ -266,6 +277,8 @@ transpose_embedding_input(
   auto sorted_linear_indices_cumulative_run_lengths =
       asynchronous_complete_cumsum(sorted_linear_indices_run_lengths);
 
+#undef INVOKE_LINEARIZE_INDEX_KERNEL
+
   return {
       linear_indices,
       linear_indices_sorted,
@@ -274,6 +287,55 @@ transpose_embedding_input(
       sorted_linear_indices_run_lengths,
       sorted_linear_indices_num_runs,
       sorted_linear_indices_cumulative_run_lengths};
+}
+
+std::tuple<int64_t, int64_t>
+get_infos_metadata(Tensor unused, int64_t B, int64_t T) {
+  return adjust_info_B_num_bits(B, T);
+}
+
+std::tuple<int32_t, uint32_t> adjust_info_B_num_bits(int32_t B, int32_t T) {
+  int32_t info_B_num_bits = DEFAULT_INFO_B_NUM_BITS;
+  uint32_t info_B_mask = DEFAULT_INFO_B_MASK;
+  uint32_t max_T = MAX_T;
+  uint32_t max_B = MAX_B;
+  bool invalid_T = T > max_T;
+  bool invalid_B = B > max_B;
+
+  TORCH_CHECK(
+      !(invalid_T && invalid_B),
+      "Not enough infos bits to accommodate T and B. Default num bits = ",
+      DEFAULT_INFO_NUM_BITS);
+
+  if (invalid_T) {
+    // Reduce info_B_num_bits
+    while (invalid_T && !invalid_B && info_B_num_bits > 0) {
+      info_B_num_bits--;
+      max_T = ((max_T + 1) << 1) - 1;
+      max_B = ((max_B + 1) >> 1) - 1;
+      invalid_T = T > max_T;
+      invalid_B = B > max_B;
+    }
+  } else if (invalid_B) {
+    // Increase info_B_num_bits
+    while (!invalid_T && invalid_B && info_B_num_bits < DEFAULT_INFO_NUM_BITS) {
+      info_B_num_bits++;
+      max_T = ((max_T + 1) >> 1) - 1;
+      max_B = ((max_B + 1) << 1) - 1;
+      invalid_T = T > max_T;
+      invalid_B = B > max_B;
+    }
+  }
+
+  TORCH_CHECK(
+      !invalid_T && !invalid_B,
+      "Not enough infos bits to accommodate T and B. Default num bits = ",
+      DEFAULT_INFO_NUM_BITS);
+
+  // Recompute info_B_mask using new info_B_num_bits
+  info_B_mask = (1u << info_B_num_bits) - 1;
+
+  return {info_B_num_bits, info_B_mask};
 }
 
 #define DEF_RADIX_SORT_PAIRS_FN(KeyT, ValueT)                        \

--- a/fbgemm_gpu/test/split_embeddings_utils_test.py
+++ b/fbgemm_gpu/test/split_embeddings_utils_test.py
@@ -59,6 +59,7 @@ def transpose_embedding_input_ref(
     hash_size_cumsum: torch.Tensor,
     indices: torch.Tensor,
     offsets: torch.Tensor,
+    info_B_num_bits: int,
 ) -> Tuple[
     torch.Tensor,
     torch.Tensor,
@@ -78,11 +79,12 @@ def transpose_embedding_input_ref(
     infos = torch.zeros_like(indices)
     for b_t in range(B * T):
         t = b_t // B
+        b = b_t % B
         start = int(offsets[b_t].item())
         end = int(offsets[b_t + 1].item())
         for i in range(start, end):
             linear_indices[i] = indices[i] + hash_size_cumsum[t]
-            infos[i] = b_t
+            infos[i] = (t << info_B_num_bits) | b
 
     linear_indices_sorted, sorted_idx = torch.sort(linear_indices, stable=True)
     infos_sorted = infos[sorted_idx]
@@ -131,6 +133,11 @@ class SplitEmbeddingsUtilsTest(unittest.TestCase):
         )
 
         indices, offsets = gen_inputs(hash_sizes, batch_size, max_len)
+        hash_size_cumsum_cuda = hash_size_cumsum.cuda()
+
+        info_B_num_bits, _ = torch.ops.fbgemm.get_infos_metadata(
+            hash_size_cumsum_cuda, B, T
+        )
 
         (
             linear_indices,
@@ -141,10 +148,11 @@ class SplitEmbeddingsUtilsTest(unittest.TestCase):
             sorted_linear_indices_num_runs,
             sorted_linear_indices_cumulative_run_lengths,
         ) = torch.ops.fbgemm.transpose_embedding_input(
-            hash_size_cumsum.cuda(),
+            hash_size_cumsum_cuda,
             total_hash_size_bits,
             indices.cuda(),
             offsets.cuda(),
+            info_B_num_bits=info_B_num_bits,
         )
 
         (
@@ -156,9 +164,7 @@ class SplitEmbeddingsUtilsTest(unittest.TestCase):
             sorted_linear_indices_num_runs_ref,
             sorted_linear_indices_cumulative_run_lengths_ref,
         ) = transpose_embedding_input_ref(
-            hash_size_cumsum,
-            indices,
-            offsets,
+            hash_size_cumsum, indices, offsets, info_B_num_bits
         )
 
         self.assertTrue(torch.equal(linear_indices.cpu(), linear_indices_ref))


### PR DESCRIPTION
Summary:
Prepare `transpose_embedding_input` for variable length TBE (VLE).

- Update the frontend API to accept VLE args
- Change `linearize_index_kernel` to generate new `info` for pooled
  TBE backward. Bag ID (`b`) and table ID (`t`) are stored in a 32-bit
  `info` variable.
  - We use lower `info_B_num_bits` bits to store `b` (`b` < `max_B`).
    Supported `max_B` = `2^info_B_num_bits`
  - We use upper `32 - info_B_num_bits` bits to store `t` (`t` <
    `T`).  Supported `T` = `2^(32 - info_B_num_bits)`
  - Although this change is mainly for avoiding binary search in the
  backward pass, the change is applied to the non-VLE cases too for
  easy code maintenace.
- Update all backward kernels (including Triton's) to process the new
  `info`

Differential Revision: D43256880

