### PR TITLE
Add optimized TBE training forward

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -214,6 +214,12 @@ set(gen_gpu_kernel_source_files
     "gen_embedding_forward_split_weighted_vbe_codegen_cuda.cu"
     "gen_embedding_forward_split_unweighted_vbe_codegen_cuda.cu")
 
+if(NOT USE_ROCM)
+  list(APPEND gen_gpu_kernel_source_files
+    "gen_embedding_forward_split_weighted_v2_kernel.cu"
+    "gen_embedding_forward_split_unweighted_v2_kernel.cu")
+endif()
+
 foreach(wdesc dense split)
   list(APPEND gen_gpu_kernel_source_files
     "gen_embedding_forward_${wdesc}_unweighted_nobag_kernel_small.cu")
@@ -316,6 +322,7 @@ set(codegen_dependencies
     ${CMAKE_CODEGEN_DIR}/embedding_forward_split_cpu.cpp
     ${CMAKE_CODEGEN_DIR}/embedding_forward_split_cpu.h
     ${CMAKE_CODEGEN_DIR}/embedding_forward_split_kernel_template.cu
+    ${CMAKE_CODEGEN_DIR}/embedding_forward_split_kernel_v2_template.cu
     ${CMAKE_CODEGEN_DIR}/embedding_forward_split_kernel_nobag_small_template.cu
     ${CMAKE_CODEGEN_DIR}/embedding_forward_split_template.cu
     ${CMAKE_CODEGEN_DIR}/embedding_forward_template_helpers.cuh

--- a/fbgemm_gpu/codegen/embedding_backward_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_backward_code_generator.py
@@ -1408,17 +1408,26 @@ def lars_sgd() -> None:
 def generate_forward_embedding_cuda(
     template_filepath: str,
     filename_format: str,
+    dense_options: List[bool],
+    nobag_options: List[bool],
+    vbe_options: List[bool],
 ) -> None:
     template = env.get_template(template_filepath)
-    for dense in [True, False]:
+    for dense in dense_options:
         for weighted in [True, False]:
-            for nobag in [True, False]:
-                for vbe in [True, False]:
+            for nobag in nobag_options:
+                for vbe in vbe_options:
                     if (not nobag or (not weighted and not vbe)) and (
                         not dense or not vbe
                     ):
-                        wdesc = f"{ 'dense' if dense else 'split'}_{ 'weighted' if weighted else 'unweighted' }{ '_nobag' if nobag else '' }{ '_vbe' if vbe else '' }"
-                        filename = filename_format.format(wdesc)
+                        dense_desc = f"{ 'dense' if dense else 'split'}"
+                        weight_desc = f"{ 'weighted' if weighted else 'unweighted' }"
+                        nobag_desc = f"{ '_nobag' if nobag else '' }"
+                        vbe_desc = f"{ '_vbe' if vbe else '' }"
+                        desc = (
+                            f"{ dense_desc }_{ weight_desc }{ nobag_desc }{ vbe_desc }"
+                        )
+                        filename = filename_format.format(desc)
                         write(
                             filename,
                             template.render(
@@ -1430,23 +1439,30 @@ def generate_forward_embedding_cuda(
 
 def forward_split() -> None:
     # Generate the forward splits
-    template = env.get_template("embedding_forward_split_template.cu")
-    for dense in [True, False]:
-        for weighted in [True, False]:
-            for vbe in [True, False]:
-                if not dense or not vbe:
-                    wdesc = f"{ 'dense' if dense else 'split' }_{ 'weighted' if weighted else 'unweighted' }{ '_vbe' if vbe else '' }"
-                    filename = f"gen_embedding_forward_{wdesc}_codegen_cuda.cu"
-                    write(
-                        filename,
-                        template.render(weighted=weighted, dense=dense, vbe=vbe),
-                    )
-                    print(f"[Forward Split]: {filename}")
+    generate_forward_embedding_cuda(
+        "embedding_forward_split_template.cu",
+        "gen_embedding_forward_{}_codegen_cuda.cu",
+        dense_options=[True, False],
+        nobag_options=[False],  # nobag is not used
+        vbe_options=[True, False],
+    )
 
     # Generate the kernels for the forward splits
     generate_forward_embedding_cuda(
         "embedding_forward_split_kernel_template.cu",
         "gen_embedding_forward_{}_kernel.cu",
+        dense_options=[True, False],
+        nobag_options=[True, False],
+        vbe_options=[True, False],
+    )
+
+    # Generate the kernels for the forward splits v2
+    generate_forward_embedding_cuda(
+        "embedding_forward_split_kernel_v2_template.cu",
+        "gen_embedding_forward_{}_v2_kernel.cu",
+        dense_options=[False],  # dense is not supported
+        nobag_options=[False],  # nobag is not supported
+        vbe_options=[False],  # vbe is not supported
     )
 
     # Generate the small kernels (for nobag only) for the forward splits

--- a/fbgemm_gpu/codegen/embedding_forward_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_kernel_template.cu
@@ -337,7 +337,7 @@ void {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else "" }
 
 /*
     Explicitly instantiate the kernel function template.  The instantiations are
-    based on the types enumerated by DISPATCH_EMB_GRAD_CACHE_TYPES macro used in
+    based on the types enumerated by DISPATCH_EMB_CACHE_TYPES macro used in
     embedding_forward_split_template.cu
 */
 

--- a/fbgemm_gpu/codegen/embedding_forward_split_kernel_v2_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_kernel_v2_template.cu
@@ -1,0 +1,982 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+{#-
+// @lint-ignore LINTIGNORE
+// @lint-ignore-every CLANGFORMAT
+// clang-format off
+// Note: clang-format off doesn't work with this templaterized code,
+// so we need to keep lint-ignore-every.
+// See https://fburl.com/dw9ljh4h
+#}
+
+{%- set wdesc =  "weighted" if weighted else "unweighted" %}
+#include "codegen/embedding_forward_template_helpers.cuh"
+
+using namespace fbgemm_gpu;
+
+constexpr uint32_t VEC_WIDTH = 4;
+
+enum SAVED_PARAMS {
+  P_indices = 0,
+  P_weights,
+  P_outputs,
+  {%- if weighted %}
+  P_index_weights,
+  {%- endif %}
+  P_offsets,
+  P_num_offsets,
+  P_load_D,
+  P_total_load_D
+};
+{%- if weighted %}
+constexpr uint32_t SAVED_PARAMS_CNT = 8;
+{%- else %}
+constexpr uint32_t SAVED_PARAMS_CNT = 7;
+{%- endif %}
+enum LXU_CACHE_PARAMS {
+  P_lxu_cache_weights = SAVED_PARAMS_CNT,
+  P_lxu_cache_locations = SAVED_PARAMS_CNT + 1};
+constexpr uint32_t LXU_PARAMS_CNT = 2;
+
+#define SMEM_PTR_BASE(TYPE) \
+  (reinterpret_cast<TYPE>(smem + WEIGHT_PTR_OFFSET) + threadIdx.y * kWarpSize)
+
+#define SMEM_GENERIC_PTR SMEM_PTR_BASE(uintptr_t*)
+
+#define SMEM_EMB_WEIGHT_PTR SMEM_PTR_BASE(const emb_vec_t**)
+
+#define SMEM_EMB_WEIGHT_DATA(SMEM_IDX, WEIGHT_IDX) \
+  (SMEM_PTR_BASE(const emb_vec_t**)[SMEM_IDX])[WEIGHT_IDX]
+
+#define SMEM_CACHE_WEIGHT_PTR SMEM_PTR_BASE(const cache_vec_t**)
+
+#define SMEM_CACHE_WEIGHT_DATA(SMEM_IDX, WEIGHT_IDX) \
+  (SMEM_PTR_BASE(const cache_vec_t**)[SMEM_IDX])[WEIGHT_IDX]
+
+// This avoid type conversion of denom in div_round_up
+#define DIV_ROUND_UP(numer, denom) ((numer + denom - 1) / denom)
+
+#define ACC_ADD_OR_FMA(WEIGHT, INDEX_WEIGHT) \
+  {%- if weighted %}
+  accumulator.fma(WEIGHT, INDEX_WEIGHT);
+  {%- else %}
+  accumulator.add(WEIGHT);
+  {%- endif %}
+
+template <typename T>
+struct Vec4Type {};
+
+template <>
+struct Vec4Type<float> {
+  using type = float4;
+};
+
+template <>
+struct Vec4Type<at::Half> {
+  using type = float2;
+};
+
+template <>
+struct Vec4Type<uint8_t> {
+  using type = uint8_t;
+};
+
+template <typename T>
+using vec4_type = typename Vec4Type<T>::type;
+
+template<uint32_t LOWER_BIT_CNT, uint32_t WARP_MASK>
+__inline__ __device__ void get_next_bag_boundary_and_L(
+    const uint32_t bag_boundary,
+    int32_t* const next_boundary,
+    uint32_t* const L) {
+  const int32_t tid = bag_boundary & WARP_MASK;
+  if (tid < kWarpSize) {
+    const auto prev_boundary = *next_boundary;
+    *next_boundary = shfl_sync(bag_boundary, tid) >> LOWER_BIT_CNT;
+    *L = (*next_boundary) - prev_boundary;
+  }
+  else {
+    *next_boundary = -1;
+  }
+}
+
+template <
+  typename index_t,
+  typename emb_t,
+  typename emb_vec_t,
+  typename output_vec_t,
+  uint32_t STEP
+  >
+__inline__ __device__ void process_all_indices_no_pooling(
+    long* const smem,
+    const bool process_d,
+    const uint32_t params_offset) {
+  constexpr uint32_t TOTAL_L = kWarpSize; // caller needs to ensure this
+
+  const auto* __restrict__ indices =
+    *reinterpret_cast<index_t**>(&smem[params_offset + SAVED_PARAMS::P_indices]);
+  const auto* __restrict__ weights =
+    *reinterpret_cast<emb_vec_t**>(&smem[params_offset + SAVED_PARAMS::P_weights]);
+  {%- if weighted %}
+  const auto* index_weights = reinterpret_cast<float*>(smem[params_offset + SAVED_PARAMS::P_index_weights]);
+  {%- endif %}
+  const auto load_D = static_cast<uint32_t>(smem[params_offset + SAVED_PARAMS::P_load_D]);
+  const auto total_load_D = static_cast<uint32_t>(smem[params_offset + SAVED_PARAMS::P_total_load_D]);
+
+  // Each thread loads a separate weight ptr
+  const auto weight_ptrs = reinterpret_cast<const uintptr_t>(&weights[indices[threadIdx.x] * load_D]);
+
+  // Assuming kWarpSize is a multiple of STEP
+  for (uint32_t l_start = 0; l_start < TOTAL_L; l_start += STEP) {
+    Vec4StepT<STEP, emb_t> vecs;
+    #pragma loop unroll
+    for (uint32_t j = 0; j < STEP; ++j) {
+      // Get weight pointer
+      const auto* ptr = reinterpret_cast<const emb_vec_t*>(
+          shfl_sync(weight_ptrs, l_start + j)) + threadIdx.x;
+      // Load row
+      if (process_d) {
+        vecs.load(ptr, j);
+      }
+    }
+
+    auto* const __restrict__ output =
+      *reinterpret_cast<output_vec_t**>(&smem[params_offset + SAVED_PARAMS::P_outputs]) + l_start * total_load_D + threadIdx.x;
+
+    if (process_d) {
+      // Write to output (not pooling)
+      #pragma loop unroll
+      for (uint32_t j = 0; j < STEP; ++j) {
+        {%- if weighted %}
+        const auto index_weight = index_weights[l_start + j];
+        vecs.index_weighted_store(j, &output[j * total_load_D], index_weight);
+        {%- else %}
+        vecs.index_store(j, &output[j * total_load_D]);
+        {%- endif %}
+      }
+    }
+  }
+}
+
+template <
+  typename emb_t,
+  typename output_vec_t,
+  uint32_t STEP,
+  uint32_t BOUNDARY_IDX_BIT_CNT,
+  uint32_t WARP_MASK
+  >
+__inline__ __device__ void write_loop_small_Ls(
+    long* const smem,
+    uint32_t* const write_idx,
+    uint32_t* const bag_boundary,
+    int32_t* const next_boundary,
+    uint32_t* const L,
+    Vec4StepT<STEP, emb_t>* const accumulator,
+    const uint32_t params_offset,
+    const uint32_t l,
+    const bool process_d,
+    const bool mean_pooling) {
+  // The loop writes to accumulated results or zeros to the output buffer.
+  // When threads first enter this loop, they write the accumulated results.
+  // Then, if next_boundary is still equal to l + 1, they write zeros. If all
+  // the outputs (up to 32 outputs) are written, next_boundary will be -1.
+  while (*next_boundary == l + 1) {
+    output_vec_t* __restrict__ const output =
+      *reinterpret_cast<output_vec_t**>(&smem[params_offset + SAVED_PARAMS::P_outputs]) + *write_idx + threadIdx.x;
+
+    const auto total_load_D = static_cast<uint32_t>(smem[params_offset + SAVED_PARAMS::P_total_load_D]);
+    *write_idx += total_load_D;
+
+    // Write the output
+    if (process_d) {
+      if (mean_pooling && *L != 0) {
+        accumulator->div(*L);
+      }
+      accumulator->store(output);
+    }
+
+    // Reset accumulator
+    accumulator->reset();
+
+    // Increment boundary index
+    *bag_boundary += 1; // boundary value in the upper bits is unaffected
+    get_next_bag_boundary_and_L<BOUNDARY_IDX_BIT_CNT, WARP_MASK>(*bag_boundary, next_boundary, L);
+  }
+}
+
+template <
+  typename index_t,
+  typename emb_t,
+  typename emb_vec_t,
+  typename cache_t,
+  typename cache_vec_t,
+  typename output_vec_t,
+  bool USE_CACHE_WEIGHTS,
+  bool USE_MIXED_TYPE_CACHE,
+  uint32_t WEIGHT_PTR_OFFSET,
+  uint32_t STEP,
+  uint32_t STEP_MASK,
+  uint32_t LOAD_GROUP_SIZE // unused
+  >
+__noinline__ __device__ void process_all_indices_small_Ls(
+    long* const smem,
+    const uint32_t total_L,
+    const bool process_d,
+    const bool mean_pooling,
+    const uint32_t params_offset,
+    const uint32_t max_D_cache) {
+  Vec4StepT<STEP, emb_t> accumulator;
+
+  if (total_L <= 0) {
+    if (process_d) {
+      output_vec_t* __restrict__ const output =
+        *reinterpret_cast<output_vec_t**>(&smem[params_offset + SAVED_PARAMS::P_outputs]) + threadIdx.x;
+      const uint32_t num_offsets = smem[params_offset + SAVED_PARAMS::P_num_offsets];
+      const uint32_t total_load_D = smem[params_offset + SAVED_PARAMS::P_total_load_D];
+      // Write zeros to the sample that L = 0
+      for (uint32_t i = 0; i < num_offsets; ++i) {
+        memset(output + i * total_load_D, 0, sizeof(output_vec_t));
+      }
+    }
+    return;
+  }
+
+  // Determine the indices at which we need to write to output, i.e. the bag boundaries
+  const auto* __restrict__ offsets =
+    *reinterpret_cast<index_t**>(&smem[params_offset + SAVED_PARAMS::P_offsets]);
+  const uint32_t num_offsets = smem[params_offset + SAVED_PARAMS::P_num_offsets];
+
+  // The first offset assigned to this warp
+  index_t offset_start = offsets[0];
+  uint32_t bag_boundary = 0;
+  if (threadIdx.x < num_offsets) {
+    bag_boundary = offsets[threadIdx.x + 1] - offset_start;
+  }
+
+  // Check the special case where each thread needs to process exactly one input
+  // If UVM cache is used, fall back to the generic function
+  if (!USE_CACHE_WEIGHTS &&
+      ballot_sync(bag_boundary == threadIdx.x + 1) == kFullWarpMask) {
+    process_all_indices_no_pooling<index_t, emb_t, emb_vec_t, output_vec_t, STEP>(
+        smem, process_d, params_offset);
+    return;
+  }
+
+  // Each thread needs to keep two states:
+  // 1) The index before/after which we need to write outputs. i.e. bag boundaries.
+  //    Note that there are at most kWarpSize such indices because this function can
+  //    handle at most kWarpsize offsets. Each thread will keep one of those values.
+  //
+  // 2) The next bag boundary index to check. In the beginning, the first boundary
+  //    will be checked. Over the iterations, we will be moving to the next boundaries
+  //    as we write outputs. This index will correspond to the threadIdx we need to
+  //    read the #1 data from.
+  //
+  // Optimization:
+  // The max value for #1 is the max number of indices that can be handled by this warp.
+  // The max value for #2 is kWarpSize.
+  // We will use a single variable to keep track of both: The lower 8 bits will store #2,
+  // whereas the upper 24 bits will store #1. Here, we assume that kWarpSize < 256, but this
+  // can be easily changed if needed.
+  constexpr uint32_t BOUNDARY_IDX_BIT_CNT = 8;
+  constexpr uint32_t WARP_MASK = (1u << BOUNDARY_IDX_BIT_CNT) - 1;
+  bag_boundary = bag_boundary << BOUNDARY_IDX_BIT_CNT;
+
+  uint32_t write_idx = 0; // Index for output
+  int32_t next_boundary = 0; // Can be -1 if all outputs are written
+  uint32_t L = 0; // Required for mean pooling
+
+  // Compute the first boundary and L
+  get_next_bag_boundary_and_L<BOUNDARY_IDX_BIT_CNT, WARP_MASK>(bag_boundary, &next_boundary, &L);
+
+  while (next_boundary == 0) {
+    auto * __restrict__ const output = *reinterpret_cast<output_vec_t**>(&smem[params_offset + SAVED_PARAMS::P_outputs]);
+    const auto total_load_D = static_cast<uint32_t>(smem[params_offset + SAVED_PARAMS::P_total_load_D]);
+    if (process_d) {
+      memset(output + write_idx + threadIdx.x, 0, sizeof(output_vec_t));
+    }
+    write_idx += total_load_D;
+
+    // Increment the bag boundary index value
+    bag_boundary += 1; // Note that the boundary value in the upper bits is unaffected
+    get_next_bag_boundary_and_L<BOUNDARY_IDX_BIT_CNT, WARP_MASK>(bag_boundary, &next_boundary, &L);
+  }
+
+  uint32_t l_start = 0;
+  // The ith LSB bit is set to 1 if the ith row needs to be looked up from cache
+  uint32_t cache_look_up_bits = 0;
+  for (; l_start < total_L; l_start += STEP) {
+    if ((l_start % kWarpSize) == 0) {
+      const uint32_t l = l_start + threadIdx.x;
+
+      // We expect the following to be loaded from shared memory instead of consuming registers
+      const auto* __restrict__ indices =
+        *reinterpret_cast<index_t**>(&smem[params_offset + SAVED_PARAMS::P_indices]);
+      const auto* __restrict__ weights =
+        *reinterpret_cast<emb_vec_t**>(&smem[params_offset + SAVED_PARAMS::P_weights]);
+      const auto load_D = static_cast<uint32_t>(smem[params_offset + SAVED_PARAMS::P_load_D]);
+
+      syncwarp(); // Ensure that all warps read the previous value before overwriting it
+      if (USE_CACHE_WEIGHTS) {
+        auto cache_idx = kCacheLocationMissing;
+        if (l < total_L) {
+          cache_idx = reinterpret_cast<int32_t*>(smem[params_offset + LXU_CACHE_PARAMS::P_lxu_cache_locations])[l];
+          const cache_t* lxu_cache_weights =
+            reinterpret_cast<const cache_t*>(smem[params_offset + LXU_CACHE_PARAMS::P_lxu_cache_weights]);
+          SMEM_GENERIC_PTR[threadIdx.x] = cache_idx != kCacheLocationMissing ?
+            reinterpret_cast<const uintptr_t>(&lxu_cache_weights[cache_idx * max_D_cache]) :
+            reinterpret_cast<const uintptr_t>(&weights[indices[l] * load_D]);
+        }
+        if (!std::is_same<emb_t, cache_t>::value) {
+          cache_look_up_bits = ballot_sync(cache_idx != kCacheLocationMissing);
+        }
+      }
+      else {
+        SMEM_EMB_WEIGHT_PTR[threadIdx.x] = (l < total_L) ?
+          reinterpret_cast<const emb_vec_t*>(&weights[indices[l] * load_D]) : nullptr;
+      }
+      syncwarp(); // Ensure that all weight pointers are written
+    }
+
+    // Make sure that all threads execute the same code
+    if (l_start + STEP > total_L) {
+      break;
+    }
+
+    const auto cache_look_up_bits_step = cache_look_up_bits & STEP_MASK;
+    if (USE_MIXED_TYPE_CACHE && cache_look_up_bits_step != 0) {
+      if (cache_look_up_bits_step == STEP_MASK) {
+        #pragma loop unroll
+        for (uint32_t j = 0; j < STEP; ++j) {
+          const auto smem_offset = (l_start % kWarpSize) + j;
+          if (process_d) {
+            {%- if weighted %}
+            const auto index_weight =
+              reinterpret_cast<float*>(smem[params_offset + SAVED_PARAMS::P_index_weights])[l_start + j];
+            {%- endif %}
+            // Load STEP rows from lx_cache_weights
+            const auto* weight = &SMEM_CACHE_WEIGHT_DATA(smem_offset, threadIdx.x);
+            ACC_ADD_OR_FMA(weight, index_weight)
+          }
+
+          // Write to the output buffer at the boundary
+          write_loop_small_Ls<emb_t, output_vec_t, STEP, BOUNDARY_IDX_BIT_CNT, WARP_MASK>(
+              smem,
+              &write_idx,
+              &bag_boundary,
+              &next_boundary,
+              &L,
+              &accumulator,
+              params_offset,
+              l_start + j,
+              process_d,
+              mean_pooling);
+        }
+        cache_look_up_bits >>= STEP;
+      }
+      else {
+        #pragma loop unroll
+        for (uint32_t j = 0; j < STEP; ++j) {
+          const auto smem_offset = (l_start % kWarpSize) + j;
+          if (process_d) {
+            {%- if weighted %}
+            const auto index_weight =
+              reinterpret_cast<float*>(smem[params_offset + SAVED_PARAMS::P_index_weights])[l_start + j];
+            {%- endif %}
+            // Load and accumulate STEP rows for UVM caching that emb_t and cache_t
+            // are not the same and rows within STEPS are read from different
+            // locations. It is unlikely that the compiler will be able to unroll
+            // the loop below because of the runtime conditionals
+            if (cache_look_up_bits & 1u) {
+              const auto* weight = &SMEM_CACHE_WEIGHT_DATA(smem_offset, threadIdx.x);
+              ACC_ADD_OR_FMA(weight, index_weight)
+            }
+            else {
+              const auto* weight = &SMEM_EMB_WEIGHT_DATA(smem_offset, threadIdx.x);
+              ACC_ADD_OR_FMA(weight, index_weight)
+            }
+          }
+
+          // Write to the output buffer at the boundary
+          write_loop_small_Ls<emb_t, output_vec_t, STEP, BOUNDARY_IDX_BIT_CNT, WARP_MASK>(
+              smem,
+              &write_idx,
+              &bag_boundary,
+              &next_boundary,
+              &L,
+              &accumulator,
+              params_offset,
+              l_start + j,
+              process_d,
+              mean_pooling);
+
+          cache_look_up_bits >>= 1;
+        }
+      }
+    }
+    else {
+      if (process_d) {
+        // Load STEP rows
+        #pragma loop unroll
+        for (uint32_t j = 0; j < STEP; ++j) {
+          const auto smem_offset = (l_start % kWarpSize) + j;
+          accumulator.load(&SMEM_EMB_WEIGHT_DATA(smem_offset, threadIdx.x), j);
+        }
+      }
+
+      #pragma loop unroll
+      for (uint32_t j = 0; j < STEP; ++j) {
+        // Accumulate rows
+        if (process_d) {
+          {%- if weighted %}
+          const auto index_weight =
+            reinterpret_cast<float*>(smem[params_offset + SAVED_PARAMS::P_index_weights])[l_start + j];
+          accumulator.index_fma(j, index_weight);
+          {%- else %}
+          accumulator.index_add(j);
+          {%- endif %}
+        }
+
+        // Write to the output buffer at the boundary
+        write_loop_small_Ls<emb_t, output_vec_t, STEP, BOUNDARY_IDX_BIT_CNT, WARP_MASK>(
+            smem,
+            &write_idx,
+            &bag_boundary,
+            &next_boundary,
+            &L,
+            &accumulator,
+            params_offset,
+            l_start + j,
+            process_d,
+            mean_pooling);
+      }
+
+      if (USE_MIXED_TYPE_CACHE) {
+        cache_look_up_bits >>= STEP;
+      }
+    }
+  }
+
+  // Process the remaining indices (less than STEP)
+  for (uint32_t j = 0; j < total_L - l_start; j++) {
+    // Load and accumulate rows
+    if (process_d) {
+      {%- if weighted %}
+      const auto index_weight =
+        reinterpret_cast<float*>(smem[params_offset + SAVED_PARAMS::P_index_weights])[l_start + j];
+      {%- endif %}
+      if (USE_MIXED_TYPE_CACHE && cache_look_up_bits & 1u) {
+        const auto* weight = &SMEM_CACHE_WEIGHT_DATA((l_start % kWarpSize) + j, threadIdx.x);
+        ACC_ADD_OR_FMA(weight, index_weight)
+      }
+      else {
+        const auto* weight = &SMEM_EMB_WEIGHT_DATA((l_start % kWarpSize) + j, threadIdx.x);
+        ACC_ADD_OR_FMA(weight, index_weight)
+      }
+      if (USE_MIXED_TYPE_CACHE) {
+        cache_look_up_bits >>= 1;
+      }
+    }
+
+    // Write to the output buffer at the boundary
+    write_loop_small_Ls<emb_t, output_vec_t, STEP, BOUNDARY_IDX_BIT_CNT, WARP_MASK>(
+        smem,
+        &write_idx,
+        &bag_boundary,
+        &next_boundary,
+        &L,
+        &accumulator,
+        params_offset,
+        l_start + j,
+        process_d,
+        mean_pooling);
+  }
+}
+
+template <
+  typename index_t,
+  typename emb_t,
+  typename emb_vec_t,
+  typename cache_t,
+  typename cache_vec_t,
+  typename output_vec_t,
+  bool USE_CACHE_WEIGHTS,
+  bool USE_MIXED_TYPE_CACHE,
+  uint32_t WEIGHT_PTR_OFFSET,
+  uint32_t STEP,
+  uint32_t STEP_MASK,
+  uint32_t LOAD_GROUP_SIZE
+  >
+__noinline__ __device__ void process_all_indices_large_Ls(
+    long* const smem,
+    const uint32_t L,
+    const bool process_d,
+    const bool mean_pooling,
+    const uint32_t params_offset,
+    const uint32_t max_D_cache) {
+
+#define SMEM_OFFSET \
+    (IS_FULL_WARP ? j : ((threadIdx.x / LOAD_GROUP_SIZE) + (j * NUM_LOAD_GROUPS)))
+
+#define WEIGHT_OFFSET \
+    (IS_FULL_WARP ? threadIdx.x : (threadIdx.x % LOAD_GROUP_SIZE))
+
+  constexpr uint32_t NUM_LOAD_GROUPS = kWarpSize / LOAD_GROUP_SIZE;
+  constexpr bool IS_FULL_WARP = LOAD_GROUP_SIZE == kWarpSize;
+
+  Vec4StepT<STEP, emb_t> accumulator;
+
+  uint32_t l_start = 0;
+  // The ith LSB bit is set to 1 if the ith row needs to be looked up from cache
+  uint32_t cache_look_up_bits = 0;
+  for (;
+      l_start < L;
+      l_start += (IS_FULL_WARP ? STEP : (NUM_LOAD_GROUPS * STEP))) {
+    if ((l_start % kWarpSize) == 0) {
+      const uint32_t l = l_start + threadIdx.x;
+
+      // We expect the following to be loaded from shared memory instead of consuming registers
+      const auto* __restrict__ indices =
+        *reinterpret_cast<index_t**>(&smem[params_offset + SAVED_PARAMS::P_indices]);
+      const auto* __restrict__ weights =
+        *reinterpret_cast<emb_vec_t**>(&smem[params_offset + SAVED_PARAMS::P_weights]);
+      const auto load_D = static_cast<uint32_t>(smem[params_offset + SAVED_PARAMS::P_load_D]);
+
+      syncwarp(); // Ensure that all warps read the previous value before overwriting it
+      if (USE_CACHE_WEIGHTS) {
+        int32_t cache_idx = kCacheLocationMissing;
+        if (l < L) {
+          cache_idx = reinterpret_cast<int32_t*>(smem[params_offset + LXU_CACHE_PARAMS::P_lxu_cache_locations])[l];
+          const auto* lxu_cache_weights =
+            reinterpret_cast<const cache_t*>(smem[params_offset + LXU_CACHE_PARAMS::P_lxu_cache_weights]);
+          SMEM_GENERIC_PTR[threadIdx.x] = cache_idx != kCacheLocationMissing ?
+            reinterpret_cast<const uintptr_t>(&lxu_cache_weights[cache_idx * max_D_cache]) :
+            reinterpret_cast<const uintptr_t>(&weights[indices[l] * load_D]);
+        }
+        if (!std::is_same<emb_t, cache_t>::value) {
+          cache_look_up_bits = ballot_sync(cache_idx != kCacheLocationMissing);
+          // Shift cache_look_up_bits based on group_id
+          cache_look_up_bits >>= static_cast<uint32_t>(threadIdx.x / LOAD_GROUP_SIZE);
+        }
+      }
+      else {
+        SMEM_EMB_WEIGHT_PTR[threadIdx.x] = (l < L) ?
+          reinterpret_cast<const emb_vec_t*>(&weights[indices[l] * load_D]) : nullptr;
+      }
+      syncwarp(); // Ensure that all weight pointers are written
+    }
+
+    // Make sure that all threads execute the same code
+    if (l_start + (IS_FULL_WARP ? STEP : (NUM_LOAD_GROUPS * STEP)) > L) {
+      break;
+    }
+
+    if (process_d) {
+      const auto cache_look_up_bits_step = cache_look_up_bits & STEP_MASK;
+      if (USE_MIXED_TYPE_CACHE && cache_look_up_bits_step != 0) {
+        {%- if weighted %}
+        const auto* index_weights =
+          reinterpret_cast<const float*>(smem[params_offset + SAVED_PARAMS::P_index_weights]) + l_start;
+        {%- endif %}
+        if (cache_look_up_bits_step == STEP_MASK) {
+          // Load STEP rows from lxu_cache_weights
+          #pragma loop unroll
+          for (uint32_t j = 0; j < STEP; ++j) {
+            const auto* weight =
+              &SMEM_CACHE_WEIGHT_DATA((l_start % kWarpSize) + SMEM_OFFSET, WEIGHT_OFFSET);
+            ACC_ADD_OR_FMA(weight, index_weights[SMEM_OFFSET])
+          }
+          cache_look_up_bits >>= STEP * NUM_LOAD_GROUPS;
+        }
+        else {
+          // Load and accumulate STEP rows for UVM caching that emb_t and cache_t
+          // are not the same and rows within STEPS are read from different
+          // locations. It is unlikely that the compiler will be able to unroll
+          // the loop below because of the runtime conditionals
+          #pragma loop unroll
+          for (uint32_t j = 0; j < STEP; ++j) {
+            if (cache_look_up_bits & 1u) {
+              // Look up from lxu_cache_weights
+              const auto* weight =
+                &SMEM_CACHE_WEIGHT_DATA((l_start % kWarpSize) + SMEM_OFFSET, WEIGHT_OFFSET);
+              ACC_ADD_OR_FMA(weight, index_weights[SMEM_OFFSET])
+            }
+            else {
+              // Look up from dev_weights/uvm_weights
+              const auto* weight =
+                &SMEM_EMB_WEIGHT_DATA((l_start % kWarpSize) + SMEM_OFFSET, WEIGHT_OFFSET);
+              ACC_ADD_OR_FMA(weight, index_weights[SMEM_OFFSET])
+            }
+            cache_look_up_bits >>= NUM_LOAD_GROUPS;
+          }
+        }
+      }
+      else {
+        // Load STEP rows from dev_weights
+        #pragma loop unroll
+        for (uint32_t j = 0; j < STEP; ++j) {
+          accumulator.load(
+              &SMEM_EMB_WEIGHT_DATA(
+                (l_start % kWarpSize) + SMEM_OFFSET,
+                WEIGHT_OFFSET),
+              j);
+        }
+
+        // Accumulate rows
+        {%- if weighted %}
+        accumulator.weighted_sum(
+            reinterpret_cast<const float*>(smem[params_offset + SAVED_PARAMS::P_index_weights]) + l_start,
+            IS_FULL_WARP ? 0 : (threadIdx.x / LOAD_GROUP_SIZE),
+            IS_FULL_WARP ? 1 : NUM_LOAD_GROUPS);
+        {%- else %}
+        accumulator.sum();
+        {%- endif %}
+
+        if (USE_MIXED_TYPE_CACHE) {
+          cache_look_up_bits >>= STEP * NUM_LOAD_GROUPS;
+        }
+      }
+    }
+  }
+
+  if (process_d) {
+    // Process the remaining indices (less than STEP)
+    for (uint32_t j = (IS_FULL_WARP ? 0 : (threadIdx.x / LOAD_GROUP_SIZE));
+         j < L - l_start;
+         j += (IS_FULL_WARP ? 1 : NUM_LOAD_GROUPS)) {
+      // Load and accumulate rows
+      const auto weight_offset = WEIGHT_OFFSET;
+      {%- if weighted %}
+      const auto index_weight =
+        reinterpret_cast<float*>(smem[params_offset + SAVED_PARAMS::P_index_weights])[l_start + j];
+      {%- endif %}
+      if (USE_MIXED_TYPE_CACHE && cache_look_up_bits & 1u) {
+        const auto* weight =
+          &SMEM_CACHE_WEIGHT_DATA((l_start % kWarpSize) + j, weight_offset);
+        ACC_ADD_OR_FMA(weight, index_weight)
+      }
+      else {
+        const auto* weight =
+          &SMEM_EMB_WEIGHT_DATA((l_start % kWarpSize) + j, weight_offset);
+        ACC_ADD_OR_FMA(weight, index_weight)
+      }
+      if (USE_MIXED_TYPE_CACHE) {
+        cache_look_up_bits >>= NUM_LOAD_GROUPS;
+      }
+    }
+  }
+
+  // Sync accumulator when subwarp is used
+  if (!IS_FULL_WARP) {
+    for (uint32_t i = NUM_LOAD_GROUPS >> 1; i > 0; i >>= 1) {
+      const auto src = i * LOAD_GROUP_SIZE;
+      accumulator.acc[0] += shfl_down_sync(accumulator.acc[0], src);
+      accumulator.acc[1] += shfl_down_sync(accumulator.acc[1], src);
+      accumulator.acc[2] += shfl_down_sync(accumulator.acc[2], src);
+      accumulator.acc[3] += shfl_down_sync(accumulator.acc[3], src);
+    }
+  }
+
+  // Write results to output
+  if (process_d && (IS_FULL_WARP || threadIdx.x < LOAD_GROUP_SIZE)) {
+    auto* __restrict__ const output =
+      *reinterpret_cast<output_vec_t**>(&smem[params_offset + SAVED_PARAMS::P_outputs]) +
+      (IS_FULL_WARP ? threadIdx.x : (threadIdx.x % LOAD_GROUP_SIZE));
+    if (mean_pooling) {
+      accumulator.div(L);
+    }
+    accumulator.store(output);
+  }
+
+#undef SMEM_OFFSET
+#undef WEIGHT_OFFSET
+
+}
+
+template <
+    typename emb_t,
+    typename cache_t,
+    typename output_t,
+    typename index_t,
+    bool USE_LXU_CACHE
+    >
+__launch_bounds__(kForwardMaxThreads, 2048 / kForwardMaxThreads)
+__global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel(
+    const emb_t* __restrict__ const dev_weights,
+    const emb_t* __restrict__ const uvm_weights,
+    const cache_t* __restrict__ const lxu_cache_weights,
+    const int32_t* __restrict__ const weights_placements,
+    const uint32_t B,
+    const uint32_t T,
+    const bool mean_pooling,
+    const uint32_t max_D_cache,
+    const FixedDivisor fd_num_warps_per_table,
+    const index_t* __restrict__ const indices,
+    {%- if weighted %}
+    const float* __restrict__ const index_weights,
+    {%- endif %}
+    const index_t* __restrict__ const  offsets,
+    const uint32_t* __restrict__ const D_offsets,
+    const int64_t* __restrict__ const weights_offsets,
+    const int32_t* __restrict__ const lxu_cache_locations,
+    output_t* __restrict__ const output) {
+    using emb_vec_t = vec4_type<emb_t>;
+    using cache_vec_t = vec4_type<cache_t>;
+    using output_vec_t = vec4_type<output_t>;
+
+    constexpr uint32_t NUM_WARPS = kForwardMaxThreads / kWarpSize;
+    constexpr uint32_t NUM_OFFSETS_PER_WARP = kWarpSize;
+    constexpr uint32_t NUM_PARAMS = SAVED_PARAMS_CNT + (USE_LXU_CACHE ? LXU_PARAMS_CNT : 0);
+    constexpr uint32_t STEP = 4;
+    __shared__ long smem[NUM_PARAMS * NUM_WARPS + kForwardMaxThreads];
+    const uint32_t params_offset = NUM_PARAMS * threadIdx.y;
+
+    const int32_t global_warp_id = blockIdx.x * blockDim.y + threadIdx.y;
+    int32_t t;
+    int32_t table_warp_id;
+    fd_num_warps_per_table.DivMod(global_warp_id, &t, &table_warp_id);
+
+    if (t >= T) {
+      return;
+    }
+
+    bool is_small_L;
+    if (threadIdx.x == 0) {
+      // Use the small-L optimization if average L <= 8
+      is_small_L = (offsets[(t + 1) * B] - offsets[t * B]) <= (static_cast<index_t>(B) * 8);
+    }
+    is_small_L = shfl_sync(is_small_L, 0);
+
+    const uint32_t num_warps_for_small_L = DIV_ROUND_UP(B, NUM_OFFSETS_PER_WARP);
+
+    // Early exit for small-L to avoid D_offsets reads
+    // if table_warp_id > B * max(num_warps_per_row) / NUM_OFFSETS_PER_WARP
+    // max(num_warps_per_row) = 8 (for D = 1024)
+    // NUM_OFFSETS_PER_WARP = 32
+    // Return if table_warp_id > ceil(B / 32) * 8
+    if (is_small_L && table_warp_id >= num_warps_for_small_L * 8) {
+      return;
+    }
+
+    uint32_t load_D;
+    uint32_t D_start;
+    uint32_t total_load_D;
+
+    if (threadIdx.x == 0) {
+      D_start = D_offsets[t] / VEC_WIDTH;
+      load_D = (D_offsets[t + 1] / VEC_WIDTH) - D_start;
+    }
+    load_D = shfl_sync(load_D, 0);
+
+    const uint32_t num_warps_per_row = DIV_ROUND_UP(load_D, kWarpSize);
+
+    if (table_warp_id >= num_warps_per_row * (is_small_L ? num_warps_for_small_L : B)) {
+      return;
+    }
+
+    // Compute d (same for all Ls)
+    const uint32_t load_d = (table_warp_id % num_warps_per_row) * kWarpSize;
+    // Compute sample ID
+    const uint32_t b = table_warp_id / num_warps_per_row * (is_small_L ? NUM_OFFSETS_PER_WARP : 1);
+    uint32_t L;
+    uint32_t row_start;
+    bool use_lxu_cache = USE_LXU_CACHE;
+
+    if (threadIdx.x == 0) {
+      // If the small-L optimization is used, each warp processes up to 32
+      // rows. Otherwise, each warp processes only 1 row.
+      auto num_offsets = is_small_L ? (B - b < NUM_OFFSETS_PER_WARP ? B - b : NUM_OFFSETS_PER_WARP) : 1;
+      row_start = offsets[t * B + b];
+      L = offsets[t * B + b + num_offsets] - row_start;
+      total_load_D = (D_offsets[T] / VEC_WIDTH);
+      // Manual register spilling (Store state registers in shared memory to
+      // free up some registers for compiler optimizations)
+      if (L > 1 || is_small_L) {
+        *reinterpret_cast<const index_t**>(&smem[params_offset + SAVED_PARAMS::P_indices]) =
+          indices + row_start;
+        const auto placement = static_cast<PlacementType>(weights_placements[t]);
+        const auto weight_offset = weights_offsets[t];
+        const emb_t* weight = placement == PlacementType::DEVICE ?
+          &dev_weights[weight_offset] : &uvm_weights[weight_offset];
+        *reinterpret_cast<const emb_vec_t**>(&smem[params_offset + SAVED_PARAMS::P_weights]) =
+          reinterpret_cast<const emb_vec_t*>(weight) + load_d;
+        *reinterpret_cast<output_vec_t**>(&smem[params_offset + SAVED_PARAMS::P_outputs]) =
+          reinterpret_cast<output_vec_t*>(output) + D_start + b * total_load_D + load_d;
+        {%- if weighted %}
+        *reinterpret_cast<const float**>(&smem[params_offset + SAVED_PARAMS::P_index_weights]) =
+          index_weights + row_start;
+        {%- endif %}
+        if (is_small_L) {
+          *reinterpret_cast<const index_t**>(&smem[params_offset + SAVED_PARAMS::P_offsets]) = &offsets[t * B + b];
+          smem[params_offset + SAVED_PARAMS::P_num_offsets] = num_offsets;
+        }
+        smem[params_offset + SAVED_PARAMS::P_load_D] = load_D;
+        smem[params_offset + SAVED_PARAMS::P_total_load_D] = total_load_D;
+        if (USE_LXU_CACHE) {
+          if (placement == PlacementType::MANAGED_CACHING) {
+            *reinterpret_cast<const cache_t**>(&smem[params_offset + LXU_CACHE_PARAMS::P_lxu_cache_weights]) =
+              lxu_cache_weights + (load_d * VEC_WIDTH);
+            *reinterpret_cast<const int32_t**>(&smem[params_offset + LXU_CACHE_PARAMS::P_lxu_cache_locations]) =
+              lxu_cache_locations + row_start;
+          }
+          else {
+            use_lxu_cache = false;
+          }
+        }
+      }
+    }
+
+    L = shfl_sync(L, 0);
+    use_lxu_cache = shfl_sync(use_lxu_cache, 0);
+
+#define INVOKE_PROCESS_ALL_INDICES_HELPER(USE_CACHE, KERNEL_TYPE, TAIL_WARP_SIZE, STEP_MASK) \
+    process_all_indices_## KERNEL_TYPE< \
+      index_t, \
+      emb_t, \
+      emb_vec_t, \
+      cache_t, \
+      cache_vec_t, \
+      output_vec_t, \
+      USE_CACHE, \
+      USE_CACHE && !std::is_same<emb_t, cache_t>::value, \
+      NUM_PARAMS * NUM_WARPS, \
+      STEP, \
+      STEP_MASK, \
+      TAIL_WARP_SIZE \
+    >( \
+        smem, \
+        L, \
+        load_d + (threadIdx.x % TAIL_WARP_SIZE) < load_D, \
+        mean_pooling, \
+        params_offset, \
+        max_D_cache)
+
+#define INVOKE_PROCESS_ALL_INDICES(...) \
+    if (use_lxu_cache) { \
+      INVOKE_PROCESS_ALL_INDICES_HELPER(true, __VA_ARGS__); \
+    } \
+    else { \
+      INVOKE_PROCESS_ALL_INDICES_HELPER(false, __VA_ARGS__); \
+    }
+
+    if (is_small_L) {
+      INVOKE_PROCESS_ALL_INDICES(small_Ls, 32, 0xf)
+      return;
+    }
+
+    // Special cases
+    if (L <= 1) {
+      total_load_D = shfl_sync(total_load_D, 0);
+      D_start = shfl_sync(D_start, 0);
+      output_vec_t* output_ptr = reinterpret_cast<output_vec_t*>(output) +
+          D_start + b * total_load_D + load_d + threadIdx.x;
+      if (L == 0) {
+        if (load_d + threadIdx.x < load_D) {
+          // Write zeros to output
+          memset(output_ptr, 0, sizeof(output_vec_t));
+        }
+      }
+      else {
+        row_start = shfl_sync(row_start, 0);
+        if (load_d + threadIdx.x < load_D) {
+          const auto placement = static_cast<PlacementType>(weights_placements[t]);
+          const auto weight_offset = weights_offsets[t];
+          Vec4StepT<1, emb_t> accumulator;
+          {%- if weighted %}
+          const auto index_weight = index_weights[row_start];
+          {%- endif %}
+          const int32_t cache_idx = USE_LXU_CACHE && placement == PlacementType::MANAGED_CACHING ?
+            lxu_cache_locations[row_start] : kCacheLocationMissing;
+          if (USE_LXU_CACHE &&
+              placement == PlacementType::MANAGED_CACHING &&
+              cache_idx != kCacheLocationMissing) {
+            const auto* weight =
+              reinterpret_cast<const cache_vec_t*>(&lxu_cache_weights[cache_idx * max_D_cache]);
+            const auto weight_vec_offset = load_d + threadIdx.x;
+            ACC_ADD_OR_FMA(weight + weight_vec_offset, index_weight);
+          }
+          else {
+            const auto* weight = reinterpret_cast<const emb_vec_t*>(placement == PlacementType::DEVICE ?
+                &dev_weights[weight_offset] : &uvm_weights[weight_offset]);
+            const auto weight_vec_offset = load_d + indices[row_start] * load_D + threadIdx.x;
+            // Load and store data
+            ACC_ADD_OR_FMA(weight + weight_vec_offset, index_weight)
+          }
+          accumulator.store(output_ptr);
+        }
+      }
+      return;
+    }
+
+    // Tail warp
+    // STEP_MASK computation assumes STEP = 4
+    if (load_D - load_d < kWarpSize) {
+      const auto tail_warp_size = load_D % kWarpSize;
+      if (tail_warp_size <= 8) {
+        INVOKE_PROCESS_ALL_INDICES(large_Ls, 8, 0x1111)
+      }
+      else if (tail_warp_size <= 16) {
+        INVOKE_PROCESS_ALL_INDICES(large_Ls, 16, 0x55)
+      }
+      else {
+        INVOKE_PROCESS_ALL_INDICES(large_Ls, 32, 0xf)
+      }
+    }
+    else {
+      INVOKE_PROCESS_ALL_INDICES(large_Ls, 32, 0xf)
+    }
+
+#undef INVOKE_PROCESS_ALL_INDICES_HELPER
+#undef INVOKE_PROCESS_ALL_INDICES
+
+}
+
+/*
+    Explicitly instantiate the kernel function template.  The instantiations are
+    based on the types enumerated by DISPATCH_EMB_CACHE_TYPES macro used in
+    embedding_forward_split_template.cu
+*/
+
+{%- for output_type in ['uint8_t', 'at::Half', 'float'] %}
+{%- for emb_type in ['uint8_t', 'float', 'at::Half'] %}
+{%- for cache_type in ['float', 'at::Half'] %}
+{%- for use_cache in ['true', 'false'] %}
+
+template __launch_bounds__(kForwardMaxThreads, 2048 / kForwardMaxThreads)
+__global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel
+<
+    {{ emb_type }},
+    {{ cache_type }},
+    {{ output_type }},
+    int64_t, // index_t
+    {{ use_cache }}
+> (
+    const {{ emb_type }}* __restrict__ const dev_weights,
+    const {{ emb_type }}* __restrict__ const uvm_weights,
+    const {{ cache_type }}* __restrict__ const lxu_cache_weights,
+    const int32_t* __restrict__ const weights_placements,
+    const uint32_t B,
+    const uint32_t T,
+    const bool mean_pooling,
+    const uint32_t max_D_cache,
+    const FixedDivisor fd_num_warps_per_table,
+    const int64_t* __restrict__ const indices,
+    {%- if weighted %}
+    const float* __restrict__ const index_weights,
+    {%- endif %}
+    const int64_t* __restrict__ const  offsets,
+    const uint32_t* __restrict__ const D_offsets,
+    const int64_t* __restrict__ const weights_offsets,
+    const int32_t* __restrict__ const lxu_cache_locations,
+    {{ output_type }}* __restrict__ const output);
+
+{%- endfor %}
+{%- endfor %}
+{%- endfor %}
+{%- endfor %}

--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
@@ -68,6 +68,8 @@ static constexpr int32_t kMaxThreads = 1024;
 static constexpr int32_t kMaxBlockYDim = 65535;
 // Max block size in Z dimension of a grid
 static constexpr int32_t kMaxBlockZDim = 65535;
+// Full warp mask
+static constexpr uint32_t kFullWarpMask = 0xff'ff'ff'ff;
 
 static constexpr float kQParamEps = 1e-8f;
 
@@ -763,7 +765,7 @@ DEVICE_INLINE T shfl_xor(
     const T val,
     int laneMask,
     int width = kWarpSize,
-    unsigned shfl_sync_mask = 0xffffffffu) {
+    unsigned shfl_sync_mask = kFullWarpMask) {
 #if defined(__HIP_PLATFORM_HCC__) || CUDA_VERSION < 9000
   return __shfl_xor(val, laneMask, width);
 #else
@@ -776,7 +778,7 @@ DEVICE_INLINE T shfl_sync(
     const T val,
     int srcLane = 0,
     int width = kWarpSize,
-    unsigned shfl_sync_mask = 0xffffffffu) {
+    unsigned shfl_sync_mask = kFullWarpMask) {
 #if defined(__HIP_PLATFORM_HCC__) || CUDA_VERSION < 9000
   return __shfl(val, srcLane, width);
 #else
@@ -784,9 +786,37 @@ DEVICE_INLINE T shfl_sync(
 #endif
 }
 
+template <typename T>
+DEVICE_INLINE T shfl_down_sync(
+    const T val,
+    unsigned delta,
+    int width = kWarpSize,
+    unsigned shfl_sync_mask = kFullWarpMask) {
+#if defined(__HIP_PLATFORM_HCC__) || CUDA_VERSION < 9000
+  return __shfl_down(val, delta, width);
+#else
+  return __shfl_down_sync(shfl_sync_mask, val, delta, width);
+#endif
+}
+
+#if defined(__HIP_PLATFORM_HCC__) || CUDA_VERSION < 9000
+DEVICE_INLINE uint64_t ballot_sync(
+#else
+DEVICE_INLINE uint32_t ballot_sync(
+#endif
+    int predicate,
+    unsigned shfl_sync_mask = kFullWarpMask) {
+#if defined(__HIP_PLATFORM_HCC__) || CUDA_VERSION < 9000
+  return __ballot(predicate);
+#else
+  return __ballot_sync(shfl_sync_mask, predicate);
+#endif
+}
+
 /// Sums a register value across all warp threads
 template <typename T, int ReduceWidth = kWarpSize>
-DEVICE_INLINE T warpReduceAllSum(T val, unsigned shfl_sync_mask = 0xffffffffu) {
+DEVICE_INLINE T
+warpReduceAllSum(T val, unsigned shfl_sync_mask = kFullWarpMask) {
 #pragma unroll
   for (int mask = ReduceWidth / 2; mask > 0; mask >>= 1) {
     val += shfl_xor(val, mask, ReduceWidth, shfl_sync_mask);
@@ -2931,6 +2961,362 @@ struct VecNT<16, PrimitiveType::INT> {
     acc.vals[1].vals[1].y *= a;
     acc.vals[1].vals[1].z *= a;
     acc.vals[1].vals[1].w *= a;
+  }
+};
+
+// Vec4AccT is a vector data type for representing four floats.
+// Vec4AccT provides many vector arithmetic operators (mainly the
+// operators that CUDA vector primitives do not provide).  Each
+// operator handles operand data type conversion implicitly.
+struct Vec4AccT {
+  float acc[4];
+
+  DEVICE_INLINE Vec4AccT() {
+    reset();
+  }
+
+  DEVICE_INLINE void reset() {
+    memset(acc, 0, sizeof(float) * 4);
+  }
+
+  DEVICE_INLINE void add_(const float* vals) {
+    acc[0] += vals[0];
+    acc[1] += vals[1];
+    acc[2] += vals[2];
+    acc[3] += vals[3];
+  }
+
+  DEVICE_INLINE void add_(const half2* vals_h) {
+    float2 vals_f[2];
+    vals_f[0] = __half22float2(vals_h[0]);
+    vals_f[1] = __half22float2(vals_h[1]);
+    const float* vals = reinterpret_cast<const float*>(&vals_f);
+    this->add_(vals);
+  }
+
+  DEVICE_INLINE void fma_(const float* vals, const float weight) {
+    acc[0] = __fmaf_rn(vals[0], weight, acc[0]);
+    acc[1] = __fmaf_rn(vals[1], weight, acc[1]);
+    acc[2] = __fmaf_rn(vals[2], weight, acc[2]);
+    acc[3] = __fmaf_rn(vals[3], weight, acc[3]);
+  }
+
+  DEVICE_INLINE void fma_(const half* vals, const float weight) {
+    acc[0] = __fmaf_rn(vals[0], weight, acc[0]);
+    acc[1] = __fmaf_rn(vals[1], weight, acc[1]);
+    acc[2] = __fmaf_rn(vals[2], weight, acc[2]);
+    acc[3] = __fmaf_rn(vals[3], weight, acc[3]);
+  }
+
+  DEVICE_INLINE void store_(const float4* src, float4* dst) {
+    *dst = *src;
+  }
+
+  DEVICE_INLINE void store_(const float4* src, float2* dst) {
+    const float2* vals = reinterpret_cast<const float2*>(src);
+    half2 vals_h[2];
+    vals_h[0] = __float22half2_rn(vals[0]);
+    vals_h[1] = __float22half2_rn(vals[1]);
+    *dst = *reinterpret_cast<float2*>(vals_h);
+  }
+
+  DEVICE_INLINE void store(float4* ptr) {
+    this->store_(reinterpret_cast<float4*>(acc), ptr);
+  }
+
+  // Store to half
+  DEVICE_INLINE void store(float2* ptr) {
+    this->store_(reinterpret_cast<const float4*>(acc), ptr);
+  }
+
+  DEVICE_INLINE void store(uint8_t* ptr) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void add(const float4* ptr) {
+    const float4 loaded_vals_ = *ptr;
+    const float* vals = reinterpret_cast<const float*>(&loaded_vals_);
+    this->add_(vals);
+  }
+
+  DEVICE_INLINE void fma(const float4* ptr, const float weight) {
+    const float4 loaded_vals_ = *ptr;
+    const float* vals = reinterpret_cast<const float*>(&loaded_vals_);
+    this->fma_(vals, weight);
+  }
+
+  DEVICE_INLINE void add(const float2* ptr) {
+    const float2 loaded_vals_ = *ptr;
+    const half2* vals_h = reinterpret_cast<const half2*>(&loaded_vals_);
+    this->add_(vals_h);
+  }
+
+  DEVICE_INLINE void fma(const float2* ptr, const float weight) {
+    const float2 loaded_vals_ = *ptr;
+    const half* vals = reinterpret_cast<const half*>(&loaded_vals_);
+    this->fma_(vals, weight);
+  }
+
+  DEVICE_INLINE void add(const uint8_t* ptr) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void fma(const uint8_t* ptr, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void div(uint32_t denom) {
+    acc[0] /= denom;
+    acc[1] /= denom;
+    acc[2] /= denom;
+    acc[3] /= denom;
+  }
+};
+
+template <uint32_t STEP, typename input_t>
+struct Vec4StepT : Vec4AccT {};
+
+template <uint32_t STEP>
+struct Vec4StepT<STEP, float> : Vec4AccT {
+  float4 loaded_vals[STEP];
+
+  DEVICE_INLINE void load(const float4* ptr, const uint32_t idx) {
+    loaded_vals[idx] = *ptr;
+  }
+
+  DEVICE_INLINE void sum() {
+#pragma loop unroll
+    for (uint32_t j = 0; j < STEP; ++j) {
+      const float* vals = reinterpret_cast<const float*>(&loaded_vals[j]);
+      this->add_(vals);
+    }
+  }
+
+  DEVICE_INLINE void weighted_sum(
+      const float* const weights,
+      const uint32_t idx_shift,
+      const uint32_t idx_scale) {
+#pragma loop unroll
+    for (uint32_t j = 0; j < STEP; ++j) {
+      const float weight = weights[j * idx_scale + idx_shift];
+      const float* vals = reinterpret_cast<const float*>(&loaded_vals[j]);
+      this->fma_(vals, weight);
+    }
+  }
+
+  DEVICE_INLINE void index_add(uint32_t idx) {
+    const float* vals = reinterpret_cast<const float*>(&loaded_vals[idx]);
+    this->add_(vals);
+  }
+
+  DEVICE_INLINE void index_fma(uint32_t idx, const float weight) {
+    const float* vals = reinterpret_cast<const float*>(&loaded_vals[idx]);
+    this->fma_(vals, weight);
+  }
+
+  // Convert and store from loaded_vals
+  DEVICE_INLINE void index_store(uint32_t idx, float4* ptr) {
+    this->store_(reinterpret_cast<const float4*>(&loaded_vals[idx]), ptr);
+  }
+
+  DEVICE_INLINE void index_store(uint32_t idx, float2* ptr) {
+    this->store_(&loaded_vals[idx], ptr);
+  }
+
+  DEVICE_INLINE void index_store(uint32_t idx, uint8_t* ptr) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, float4* ptr, const float weight) {
+    const float* vals = reinterpret_cast<const float*>(&loaded_vals[idx]);
+    float* ptr_f = reinterpret_cast<float*>(ptr);
+    ptr_f[0] = __fmul_rn(vals[0], weight);
+    ptr_f[1] = __fmul_rn(vals[1], weight);
+    ptr_f[2] = __fmul_rn(vals[2], weight);
+    ptr_f[3] = __fmul_rn(vals[3], weight);
+  }
+
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, float2* ptr, const float weight) {
+    const float* vals = reinterpret_cast<const float*>(&loaded_vals[idx]);
+    float vals_f[4];
+    vals_f[0] = __fmul_rn(vals[0], weight);
+    vals_f[1] = __fmul_rn(vals[1], weight);
+    vals_f[2] = __fmul_rn(vals[2], weight);
+    vals_f[3] = __fmul_rn(vals[3], weight);
+    this->store_(reinterpret_cast<float4*>(vals_f), ptr);
+  }
+
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, uint8_t* ptr, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+};
+
+template <uint32_t STEP>
+struct Vec4StepT<STEP, at::Half> : Vec4AccT {
+  float2 loaded_vals[STEP];
+
+  DEVICE_INLINE void load(const float2* ptr, const uint32_t idx) {
+    loaded_vals[idx] = *ptr;
+  }
+
+  DEVICE_INLINE void sum() {
+#if defined(OPTIMIZE_INNER_LOOP)
+#pragma loop unroll
+    for (uint32_t j = 0; j < STEP; j += 2) {
+      // If we add an fp16 register to and fp32 accumulator, the following
+      // happens in assembly:
+      // 1. R32 = R16 + 0 , i.e. the fp16 register is converted to fp32 through
+      // an add.
+      // 2. Accum += R32
+      // This prevents the compiler from using vector addition.
+      //
+      // As an optimization, we can sum two fp16 inputs together and add their
+      // sum to the accumulator:
+      const half2* vals_A = reinterpret_cast<const half2*>(&loaded_vals[j]);
+      const half2* vals_B = reinterpret_cast<const half2*>(&loaded_vals[j + 1]);
+      float2 local_sum[2];
+      local_sum[0] = __half22float2(vals_A[0] + vals_B[0]);
+      local_sum[1] = __half22float2(vals_A[1] + vals_B[1]);
+      // Note that there is some potential precision loss here because the
+      // addition above is done in fp16.
+      // TODO: There is a SASS instruction HADD2.F32 that adds 2 fp16s and
+      // outputs fp32. Check if there is a corresponding intrinsics or PTX
+      // instruction to be used here.
+      const float* vals = reinterpret_cast<const float*>(&local_sum);
+      this->add_(vals);
+    }
+#else
+#pragma loop unroll
+    for (uint32_t j = 0; j < STEP; ++j) {
+      const half2* vals_h = reinterpret_cast<const half2*>(&loaded_vals[j]);
+      this->add_(vals_h);
+    }
+#endif
+  }
+
+  DEVICE_INLINE void weighted_sum(
+      const float* const weights,
+      const uint32_t idx_shift,
+      const uint32_t idx_scale) {
+#pragma loop unroll
+    for (uint32_t j = 0; j < STEP; ++j) {
+      const float weight = weights[j * idx_scale + idx_shift];
+      const half* vals = reinterpret_cast<const half*>(&loaded_vals[j]);
+      this->fma_(vals, weight);
+    }
+  }
+
+  DEVICE_INLINE void index_add(uint32_t idx) {
+    const half2* vals_h = reinterpret_cast<const half2*>(&loaded_vals[idx]);
+    this->add_(vals_h);
+  }
+
+  DEVICE_INLINE void index_fma(uint32_t idx, const float weight) {
+    const half* vals = reinterpret_cast<const half*>(&loaded_vals[idx]);
+    this->fma_(vals, weight);
+  }
+
+  // Convert and store from loaded_vals
+  DEVICE_INLINE void index_store(uint32_t idx, float4* ptr) {
+    const half2* vals_h = reinterpret_cast<const half2*>(&loaded_vals[idx]);
+    float2 vals_f[2];
+    vals_f[0] = __half22float2(vals_h[0]);
+    vals_f[1] = __half22float2(vals_h[1]);
+    this->store_(reinterpret_cast<const float4*>(vals_f), ptr);
+  }
+
+  DEVICE_INLINE void index_store(uint32_t idx, float2* ptr) {
+    *ptr = *reinterpret_cast<float2*>(&loaded_vals[idx]);
+  }
+
+  DEVICE_INLINE void index_store(uint32_t idx, uint8_t* ptr) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, float4* ptr, const float weight) {
+    const half* vals = reinterpret_cast<const half*>(&loaded_vals[idx]);
+    float* ptr_f = reinterpret_cast<float*>(ptr);
+    ptr_f[0] = __fmul_rn(vals[0], weight);
+    ptr_f[1] = __fmul_rn(vals[1], weight);
+    ptr_f[2] = __fmul_rn(vals[2], weight);
+    ptr_f[3] = __fmul_rn(vals[3], weight);
+  }
+
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, float2* ptr, const float weight) {
+    const float* vals = reinterpret_cast<const float*>(&loaded_vals[idx]);
+    float vals_f[4];
+    vals_f[0] = __fmul_rn(vals[0], weight);
+    vals_f[1] = __fmul_rn(vals[1], weight);
+    vals_f[2] = __fmul_rn(vals[2], weight);
+    vals_f[3] = __fmul_rn(vals[3], weight);
+    this->store_(reinterpret_cast<float4*>(vals_f), ptr);
+  }
+
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, uint8_t* ptr, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+};
+
+template <uint32_t STEP>
+struct Vec4StepT<STEP, uint8_t> : Vec4AccT {
+  DEVICE_INLINE Vec4StepT() {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void load(const uint8_t* ptr, const uint32_t idx) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void sum() {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void weighted_sum(
+      const float* const weights,
+      const uint32_t idx_shift,
+      const uint32_t idx_scale) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void index_add(uint32_t idx) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void index_fma(uint32_t idx, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void index_store(uint32_t idx, float4* ptr) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void index_store(uint32_t idx, float2* ptr) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void index_store(uint32_t idx, uint8_t* ptr) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, float4* ptr, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, float2* ptr, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, uint8_t* ptr, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
   }
 };
 


### PR DESCRIPTION
Summary:
This diff adds an optimized implementation of TBE training forward,
namely
`split_embedding_codegen_forward_[weighted|unweighted]_v2_kernel`.
The implementation currently supports only a subset of usecases of TBE
including:

- Split TBE (`SplitTableBatchedEmbeddingBagsCodegen`)
- Pooled TBE (`pooling_mode`: `PoolingMode.SUM`, `PoolingMode.MEAN`)
- Weighted and unweighted TBE (`per_sample_weights`: `Tensor`, `None`)
- FP32 and FP16 weight types (`weights_precision`: `SparseType.FP32`,
  `SparseType.FP16`)
- FP32 and FP16 output types (`output_dtype`: `SparseType.FP32`,
  `SparseType.FP16`)
- Device, manged, managed caching embedding locations
  (`EmbeddingLocation`: `EmbeddingLocation.DEVICE`,
  `EmbeddingLocation.MANAGED`,
  `EmbeddingLocation.MANAGED_CACHING`)

Cases that the new implementation does **NOT** support:

- Dense TBE (`DenseTableBatchedEmbeddingBagsCodegen`)
- Sequence TBE (`pooling_mode`: `PoolingMode.NONE`)
- FP8, INT8, INT4, INT2, and BF16 weight types (`weights_precision`:
  `SparseType.FP8`, `SparseType.INT8`, `SparseType.INT4`,
  `SparseType.INT2`, `SparseType.BF16`)
- FP8, INT8, INT4, INT2, and BF16 output types (`weights_precision`:
  `SparseType.FP8`, `SparseType.INT8`, `SparseType.INT4`,
  `SparseType.INT2`, `SparseType.BF16`)
- Host embedding locations (`EmbeddingLocation`:
  `EmbeddingLocation.HOST`)

The `IS_EXPERIMENTAL` environment variable flag is added for
enabling/disabling the new implementation at runtime.  If
`IS_EXPERIMENTAL` is not set, TBE will use the orignal implementation.
If `IS_EXPERIMENTAL=1`, TBE will use the new implementation.  If the
TBE usecases are not supported in the new implementation, TBE will
fall back to the original implementation.  By default,
`IS_EXPERIMENTAL` is not set.

The new implementation contains the following optimizations:

- Use multiple warps per bag for D > 128 to maintain a constant
  number of registers per thread
- Use subwarps to process subsets of input rows in a bag if D < 128
- Cooperatively compute weight pointers and store them in shared
  memory
- Save state variables in shared memory instead of registers to free
  registers for compiler optimizations
- Use the upper bound number of warps for all tables to avoid complex
  warp offset computation
- Process multiple samples (up to kWarpSize samples) in a warp for
  small Ls

Note: D = embedding dimension, L = pooling factor

Differential Revision: D43634651

