### PR TITLE
Remove sync point in jagged_dense_elementwise_add_jagged_output backward

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
@@ -644,7 +644,7 @@ jagged_dense_elementwise_add_jagged_output(
     const Tensor& y) {
   // Convert to jagged
   auto jagged_values =
-      DenseToJaggedOp::apply(y, x_offsets, c10::optional<int64_t>())[0];
+      DenseToJaggedOp::apply(y, x_offsets, x_values.size(0))[0];
 
   // Add jagged_values + x_values -> sum_values
   auto sum_values = x_values + jagged_values;


### PR DESCRIPTION
Summary: Remove sync point in jagged_dense_elementwise_add_jagged_output backward

Reviewed By: brad-mengchi

Differential Revision: D44039901

