### PR TITLE
[T148369035] Add C++17 Support to FBGEMM and FBGEMM_GPU OSS builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,48 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+################################################################################
+# FBGEMM Bazel configuration file
+#
+# Based on MozoLM build options:
+#   https://github.com/google-research/mozolm/blob/main/.bazelrc
+#
+# Documentation for Bazel configuration options can be found in:
+#   https://bazel.build/reference/command-line-reference
+################################################################################
+
+# Automatically picks up host-OS-specific config lines from bazelrc files
+# Enabling this is equivalent to auto-calling --config=linux on Linux, --config=windows, etc
+build --enable_platform_specific_config
+
+# Print logs for all tests
+test --test_output=all
+
+# Build with verbose logging
+build --verbose_explanations --verbose_failures
+test  --verbose_explanations --verbose_failures
+
+# Build with optimization mode turned on
+build  --compilation_mode opt
+test   --compilation_mode opt
+
+# Build FBGEMM with C17 and C++17
+build:linux --cxxopt=-std=c++17
+build:linux --host_cxxopt=-std=c++17
+build:linux --conlyopt=-std=c17
+build:linux --host_conlyopt=-std=c17
+build:macos --cxxopt=-std=c++17
+build:macos --host_cxxopt=-std=c++17
+build:macos --conlyopt=-std=c17
+build:macos --host_conlyopt=-std=c17
+build:windows --cxxopt=/std:c++17
+build:windows --host_cxxopt=/std:c++17
+build:windows --conlyopt=/std:c17
+build:windows --host_conlyopt=/std:c17
+
+# Generation of `runfiles` directories on Windows has to be explicitly enabled.
+# See https://github.com/bazelbuild/bazel/issues/8843.
+build:windows --enable_runfiles
+test:windows --enable_runfiles

--- a/.github/scripts/setup_env.bash
+++ b/.github/scripts/setup_env.bash
@@ -915,6 +915,15 @@ install_cxx_compiler () {
 
   # Print out the C++ version
   print_exec conda run -n "${env_name}" c++ --version
+
+  # https://stackoverflow.com/questions/2324658/how-to-determine-the-version-of-the-c-standard-used-by-the-compiler
+  echo "[INSTALL] Printing the default version of the C++ standard used by the compiler ..."
+  print_exec conda run -n "${env_name}" c++ -x c++ /dev/null -E -dM | grep __cplusplus
+
+  # https://stackoverflow.com/questions/4991707/how-to-find-my-current-compilers-standard-like-if-it-is-c90-etc
+  echo "[INSTALL] Printing the default version of the C standard used by the compiler ..."
+  print_exec conda run -n "${env_name}" cc -dM -E - < /dev/null | grep __STDC_VERSION__
+
   echo "[INSTALL] Successfully installed C/C++ compilers"
 }
 

--- a/.github/scripts/setup_env.bash
+++ b/.github/scripts/setup_env.bash
@@ -365,6 +365,38 @@ print_glibc_info () {
 
 
 ################################################################################
+# Bazel Setup Functions
+################################################################################
+
+setup_bazel () {
+  echo "################################################################################"
+  echo "# Setup Bazel"
+  echo "#"
+  echo "# [TIMESTAMP] $(date --utc +%FT%T.%3NZ)"
+  echo "################################################################################"
+  echo ""
+
+  local bazel_version="6.1.1"
+
+  if [[ $OSTYPE == 'darwin'* ]]; then
+    local bazel_variant="darwin-$(uname -m)"
+  else
+    local bazel_variant="linux-x86_64"
+  fi
+
+  echo "[SETUP] Downloading installer Bazel ${bazel_version} (${bazel_variant}) ..."
+  print_exec wget -q "https://github.com/bazelbuild/bazel/releases/download/${bazel_version}/bazel-${bazel_version}-installer-${bazel_variant}.sh" -O install-bazel.sh
+
+  echo "[SETUP] Installing Bazel ..."
+  print_exec bash install-bazel.sh
+  print_exec rm -f install-bazel.sh
+
+  print_exec bazel --version
+  echo "[SETUP] Successfully set up Bazel"
+}
+
+
+################################################################################
 # Miniconda Setup Functions
 ################################################################################
 

--- a/.github/workflows/fbgemm_ci.yml
+++ b/.github/workflows/fbgemm_ci.yml
@@ -101,18 +101,28 @@ jobs:
 
 
   build-bazel:
-    runs-on: ${{ matrix.os }}
+    runs-on: linux.12xlarge
+    container:
+      image: ${{ matrix.container-image }}
+      options: --user root
     defaults:
       run:
         shell: bash
     env:
       PRELUDE: .github/scripts/setup_env.bash
+      DEBIAN_FRONTEND: noninteractive
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        container-image: [ "ubuntu:20.04" ]
 
     steps:
+    - name: Setup Build Container
+      run: |
+        apt update -y
+        apt install -y binutils build-essential cmake git libblas-dev python3 sudo unzip wget
+        git config --global --add safe.directory '*'
+
     - name: Checkout the Repository
       uses: actions/checkout@v3
       with:
@@ -122,18 +132,13 @@ jobs:
       run: . $PRELUDE; print_system_info
 
     - name: Download bazel
-      run: |
-        set -e
-        wget https://github.com/bazelbuild/bazel/releases/download/2.2.0/bazel-2.2.0-linux-x86_64 -O bazel
-        # verify content
-        echo 'b2f002ea0e6194a181af6ac84cd94bd8dc797722eb2354690bebac92dda233ff bazel' | sha256sum --quiet -c
-        chmod +x bazel
+      run: . $PRELUDE; setup_bazel
 
-    - name: Build FBGEMM with bazel
-      run: ./bazel build --cxxopt='-std=c++17' --verbose_explanations --verbose_failures --compilation_mode opt :*
+    - name: Build FBGEMM Library
+      run: bazel build -s :*
 
-    - name: Test FBGEMM bazel build
-      run: ./bazel test --cxxopt='-std=c++17' --test_output=all --verbose_explanations --verbose_failures --compilation_mode opt :*
+    - name: Test FBGEMM Library
+      run: bazel test -s :*
 
 
   build-windows:

--- a/.github/workflows/fbgemm_ci.yml
+++ b/.github/workflows/fbgemm_ci.yml
@@ -56,8 +56,9 @@ jobs:
       run: |
         set -e
         mkdir $BUILD_DIR; cd $BUILD_DIR
+        cmake --version
         cmake -DUSE_SANITIZER=address -DFBGEMM_LIBRARY_TYPE=${{ matrix.library-type }} -DPYTHON_EXECUTABLE=/usr/bin/python3 ..
-        make -j
+        make -j VERBOSE=1
 
     - name: Test FBGEMM Library (${{ matrix.library-type }})
       run: |
@@ -94,8 +95,9 @@ jobs:
       run: |
         set -e
         mkdir $BUILD_DIR; cd $BUILD_DIR
+        cmake --version
         cmake -DUSE_SANITIZER=address -DFBGEMM_LIBRARY_TYPE=${{ matrix.library-type }} ..
-        make -j
+        make -j VERBOSE=1
 
 
   build-bazel:
@@ -128,10 +130,10 @@ jobs:
         chmod +x bazel
 
     - name: Build FBGEMM with bazel
-      run: ./bazel build --verbose_explanations --verbose_failures --compilation_mode opt :*
+      run: ./bazel build --cxxopt='-std=c++17' --verbose_explanations --verbose_failures --compilation_mode opt :*
 
     - name: Test FBGEMM bazel build
-      run: ./bazel test --test_output=all --verbose_explanations --verbose_failures --compilation_mode opt :*
+      run: ./bazel test --cxxopt='-std=c++17' --test_output=all --verbose_explanations --verbose_failures --compilation_mode opt :*
 
 
   build-windows:
@@ -168,8 +170,9 @@ jobs:
         mkdir %BUILD_DIR%
         cd %BUILD_DIR%
         echo "STARTING CMAKE"
+        cmake --version
         cmake -G Ninja -DFBGEMM_BUILD_BENCHMARKS=OFF -DFBGEMM_LIBRARY_TYPE=${{ matrix.library-type }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" ..
-        ninja all
+        ninja -v all
         echo "Build Success"
 
     - name: Test FBGEMM Library (${{ matrix.library-type }})

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -159,14 +159,14 @@ cc_library(
 )
 
 [
-  cc_test(
-      name = paths.split_extension(paths.basename(filename))[0],
-      size = "medium",
-      srcs = [
-          filename,
-      ],
-      deps = [
-          ":test_utils",
-      ],
-  ) for filename in get_fbgemm_tests()
+    cc_test(
+        name = paths.split_extension(paths.basename(filename))[0],
+        size = "medium",
+        srcs = [
+            filename,
+        ],
+        deps = [
+            ":test_utils",
+        ],
+    ) for filename in get_fbgemm_tests()
 ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,19 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+
+# Set the default C++ standard to C++17
+# Individual targets can have this value overriden; see
+# https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+
+# Set the default C standard to C11
+# Individual targets can have this value overriden; see
+# https://cmake.org/cmake/help/latest/prop_tgt/C_STANDARD.html
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_C_STANDARD_REQUIRED ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
@@ -114,17 +129,11 @@ add_dependencies(fbgemm_generic defs.bzl)
 add_dependencies(fbgemm_avx2 defs.bzl)
 add_dependencies(fbgemm_avx512 defs.bzl)
 
-set_target_properties(fbgemm_generic fbgemm_avx2 fbgemm_avx512 PROPERTIES
-      CXX_STANDARD 14
-      CXX_STANDARD_REQUIRED YES
-      CXX_EXTENSIONS NO
-      CXX_VISIBILITY_PRESET hidden)
-
-#On Windows:
-#1) Adding definition of ASMJIT_STATIC to avoid generating asmjit function
-#calls with _dllimport attribute
-#2) MSVC uses /MD in default cxx compiling flags,
-#need to change it to /MT in static case
+# On Windows:
+# 1)  Adding definition of ASMJIT_STATIC to avoid generating asmjit function
+#     calls with _dllimport attribute
+# 2)  MSVC uses /MD in default cxx compiling flags,
+# Need to change it to /MT in static case
 if(MSVC)
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244 /wd4267 /wd4305 /wd4309")
   if(FBGEMM_LIBRARY_TYPE STREQUAL "static")
@@ -267,8 +276,6 @@ elseif(FBGEMM_LIBRARY_TYPE STREQUAL "shared")
   set_property(TARGET fbgemm_generic PROPERTY POSITION_INDEPENDENT_CODE ON)
   set_property(TARGET fbgemm_avx2 PROPERTY POSITION_INDEPENDENT_CODE ON)
   set_property(TARGET fbgemm_avx512 PROPERTY POSITION_INDEPENDENT_CODE ON)
-  set_target_properties(fbgemm PROPERTIES
-    CXX_VISIBILITY_PRESET hidden)
 elseif(FBGEMM_LIBRARY_TYPE STREQUAL "static")
   add_library(fbgemm STATIC
     $<TARGET_OBJECTS:fbgemm_generic>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
 # Set the default C++ standard to C++17
-# Individual targets can have this value overriden; see
+# Individual targets can have this value overridden; see
 # https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -9,7 +9,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
 # Set the default C standard to C11
-# Individual targets can have this value overriden; see
+# Individual targets can have this value overridden; see
 # https://cmake.org/cmake/help/latest/prop_tgt/C_STANDARD.html
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_EXTENSIONS OFF)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -16,9 +16,9 @@ http_archive(
 
 http_archive(
     name = "com_google_googletest",
-    strip_prefix = "googletest-cd6b9ae3243985d4dc725abd513a874ab4161f3e",
+    strip_prefix = "googletest-1.13.0",
     urls = [
-        "https://github.com/google/googletest/archive/cd6b9ae3243985d4dc725abd513a874ab4161f3e.tar.gz",
+        "https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz",
     ],
 )
 

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,4 +1,12 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_C_STANDARD_REQUIRED ON)
 
 find_package(MKL)
 if (NOT ${MKL_FOUND})
@@ -21,15 +29,12 @@ if (${BLAS_FOUND})
   message(STATUS "BLAS_LIBRARIES= ${BLAS_LIBRARIES}")
 endif()
 
-#benchmarks
+# Benchmarks
 macro(add_benchmark BENCHNAME)
   add_executable(${BENCHNAME} ${ARGN}
     BenchUtils.cc
     ../test/QuantizationHelpers.cc
     ../test/EmbeddingSpMDMTestUtils.cc)
-  set_target_properties(${BENCHNAME} PROPERTIES
-          CXX_STANDARD 11
-          CXX_EXTENSIONS NO)
   target_compile_options(${BENCHNAME} PRIVATE
     "-m64" "-mavx2" "-mfma" "-masm=intel")
   target_link_libraries(${BENCHNAME} fbgemm)

--- a/bench/EmbeddingSpMDM8BitBenchmark.cc
+++ b/bench/EmbeddingSpMDM8BitBenchmark.cc
@@ -111,7 +111,7 @@ int run_benchmark(
   // please note we generate unique indices
   for (int i = 0; i < batch_size; ++i) {
     iota(container.begin(), container.end(), 0);
-    random_shuffle(container.begin(), container.end());
+    shuffle(container.begin(), container.end(), generator);
     copy(
         container.begin(),
         container.begin() + (offsets[i + 1] - offsets[i]),

--- a/bench/EmbeddingSpMDMBenchmark.cc
+++ b/bench/EmbeddingSpMDMBenchmark.cc
@@ -104,7 +104,7 @@ void run_benchmark(
   // please note we generate unique indices
   for (int i = 0; i < batch_size; ++i) {
     iota(container.begin(), container.end(), 0);
-    random_shuffle(container.begin(), container.end());
+    shuffle(container.begin(), container.end(), generator);
     copy(
         container.begin(),
         container.begin() + (offsets[i + 1] - offsets[i]),

--- a/bench/EmbeddingSpMDMNBitBenchmark.cc
+++ b/bench/EmbeddingSpMDMNBitBenchmark.cc
@@ -116,7 +116,7 @@ int run_benchmark(
   // please note we generate unique indices
   for (int i = 0; i < batch_size; ++i) {
     iota(container.begin(), container.end(), 0);
-    random_shuffle(container.begin(), container.end());
+    shuffle(container.begin(), container.end(), generator);
     copy(
         container.begin(),
         container.begin() + (offsets[i + 1] - offsets[i]),

--- a/bench/EmbeddingSpMDMNBitRowWiseSparseBenchmark.cc
+++ b/bench/EmbeddingSpMDMNBitRowWiseSparseBenchmark.cc
@@ -131,7 +131,7 @@ int run_benchmark(
   // please note we generate unique indices
   for (int i = 0; i < batch_size; ++i) {
     iota(container.begin(), container.end(), 0);
-    random_shuffle(container.begin(), container.end());
+    shuffle(container.begin(), container.end(), generator);
     copy(
         container.begin(),
         container.begin() + (offsets[i + 1] - offsets[i]),

--- a/bench/RowwiseAdagradFusedBenchmark.cc
+++ b/bench/RowwiseAdagradFusedBenchmark.cc
@@ -90,7 +90,7 @@ void run_benchmark(
   // please note we generate unique indices
   for (int i = 0; i < batch_size; ++i) {
     iota(container.begin(), container.end(), 0);
-    random_shuffle(container.begin(), container.end());
+    shuffle(container.begin(), container.end(), generator);
     copy(
         container.begin(),
         container.begin() + (offsets[i + 1] - offsets[i]),

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -1,15 +1,34 @@
-cmake_minimum_required(VERSION 3.11.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
 
-option(FBGEMM_CPU_ONLY "Build fbgemm_gpu without GPU support" OFF)
+# Set the default C++ standard to C++17
+# Individual targets can have this value overriden; see
+# https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(message_line
-    "-------------------------------------------------------------")
-message("${message_line}")
+# Set the default C standard to C17
+# Individual targets can have this value overriden; see
+# https://cmake.org/cmake/help/latest/prop_tgt/C_STANDARD.html
+set(CMAKE_C_STANDARD 17)
+set(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+function(BLOCK_PRINT)
+  message("================================================================================")
+  foreach(ARG IN LISTS ARGN)
+     message("${ARG}")
+  endforeach()
+  message("================================================================================")
+  message("")
+endfunction()
 
 if(SKBUILD)
-  message("The project is built using scikit-build")
+  BLOCK_PRINT("The project is built using scikit-build")
 endif()
 
+# Build options
+option(FBGEMM_CPU_ONLY "Build FBGEMM_GPU without GPU support" OFF)
 option(USE_CUDA "Use CUDA" ON)
 option(USE_ROCM "Use ROCm" OFF)
 
@@ -21,11 +40,10 @@ if(((EXISTS "/opt/rocm/") OR (EXISTS $ENV{ROCM_PATH}))
 endif()
 
 if(FBGEMM_CPU_ONLY)
-  message("Building for CPU-only")
+  BLOCK_PRINT("Building the CPU-only variant of FBGEMM-GPU")
 endif()
 
-message("${message_line}")
-message(STATUS "USE_ROCM ${USE_ROCM}")
+BLOCK_PRINT("USE_ROCM: ${USE_ROCM}")
 
 if(FBGEMM_CPU_ONLY OR USE_ROCM)
   project(
@@ -46,12 +64,14 @@ set(THIRDPARTY ${FBGEMM}/third_party)
 
 if(DEFINED GLIBCXX_USE_CXX11_ABI)
   if(${GLIBCXX_USE_CXX11_ABI} EQUAL 1)
-    set(CXX_STANDARD_REQUIRED ON)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=1")
   else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
   endif()
-  message("${CMAKE_CXX_FLAGS}")
+  BLOCK_PRINT(
+    "Default C++ compiler flags (values may be overriden by CMAKE_CXX_STANDARD and CXX_STANDARD):"
+    "${CMAKE_CXX_FLAGS}"
+  )
 endif()
 
 #
@@ -72,8 +92,7 @@ if(USE_ROCM)
   include(Hip)
   include(Hipify)
 
-  message("${message_line}")
-  message(STATUS "hip found ${HIP_FOUND}")
+  BLOCK_PRINT("HIP found: ${HIP_FOUND}")
 endif()
 
 #
@@ -414,13 +433,6 @@ if(USE_ROCM)
 else()
   add_library(fbgemm_gpu_py MODULE ${fbgemm_gpu_sources} ${gen_source_files}
                                    ${cpp_asmjit_files} ${cpp_fbgemm_files})
-  set_property(TARGET fbgemm_gpu_py PROPERTY CUDA_ARCHITECTURES
-                                             "${cuda_architectures}")
-
-  # FBGEMM_CUB_USE_NAMESPACE will cause compilation errors on CUB for CUDA 12+
-  # if(NOT FBGEMM_CPU_ONLY)
-  #   target_compile_definitions(fbgemm_gpu_py PRIVATE FBGEMM_CUB_USE_NAMESPACE)
-  # endif()
 endif()
 
 set_target_properties(fbgemm_gpu_py PROPERTIES PREFIX "")
@@ -430,7 +442,6 @@ if(NVML_LIB_PATH)
   target_link_libraries(fbgemm_gpu_py ${NVML_LIB_PATH})
 endif()
 target_include_directories(fbgemm_gpu_py PRIVATE ${TORCH_INCLUDE_DIRS})
-set_property(TARGET fbgemm_gpu_py PROPERTY CXX_STANDARD 17)
 
 install(TARGETS fbgemm_gpu_py DESTINATION fbgemm_gpu)
 

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -1,14 +1,14 @@
 cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
 
 # Set the default C++ standard to C++17
-# Individual targets can have this value overriden; see
+# Individual targets can have this value overridden; see
 # https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Set the default C standard to C17
-# Individual targets can have this value overriden; see
+# Individual targets can have this value overridden; see
 # https://cmake.org/cmake/help/latest/prop_tgt/C_STANDARD.html
 set(CMAKE_C_STANDARD 17)
 set(CMAKE_C_EXTENSIONS OFF)
@@ -69,7 +69,9 @@ if(DEFINED GLIBCXX_USE_CXX11_ABI)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
   endif()
   BLOCK_PRINT(
-    "Default C++ compiler flags (values may be overriden by CMAKE_CXX_STANDARD and CXX_STANDARD):"
+    "Default C++ compiler flags"
+    "(values may be overridden by CMAKE_CXX_STANDARD and CXX_STANDARD):"
+    ""
     "${CMAKE_CXX_FLAGS}"
   )
 endif()

--- a/fbgemm_gpu/docs/BuildInstructions.md
+++ b/fbgemm_gpu/docs/BuildInstructions.md
@@ -66,18 +66,23 @@ will also need to be installed to avoid issues with missing versioned symbols
 when compiling FBGEMM_CPU:
 
 ```sh
-conda install -n "${env_name}" -y gxx_linux-64=9.3.0
+conda install -n "${env_name}" -y gxx_linux-64=10.4.0 sysroot_linux-64=2.17 -c conda-forge
 ```
 
-Note that while newer versions of GCC can be used, binaries compiled under newer
-versions of GCC will not be compatible with older systems such as Ubuntu 20.04
-or CentOS Stream 8, because the compiled library will reference symbols from
-versions of `GLIBCXX` that the system's `libstdc++.so.6` will not support.  To
-see what versions of GLIBCXX the available `libstdc++.so.6` supports:
+While newer versions of GCC can be used, binaries compiled under newer versions
+of GCC will not be compatible with older systems such as Ubuntu 20.04 or CentOS
+Stream 8, because the compiled library will reference symbols from versions of
+`GLIBCXX` that the system's `libstdc++.so.6` will not support.  To see what
+versions of GLIBC and GLIBCXX the available `libstdc++.so.6` supports:
 
 ```sh
 libcxx_path=/path/to/libstdc++.so.6
-objdump -TC "${libcxx_path}" | grep GLIBCXX | sed 's/.*GLIBCXX_\([.0-9]*\).*/GLIBCXX_\1/g' | sort -Vu | cat
+
+# Print supported for GLIBC versions
+objdump -TC "${libcxx_path}" | grep GLIBC_ | sed 's/.*GLIBC_\([.0-9]*\).*/GLIBC_\1/g' | sort -Vu | cat
+
+# Print supported for GLIBCXX versions
+objdump -TC "${libcxx_path}" | grep GLIBCXX_ | sed 's/.*GLIBCXX_\([.0-9]*\).*/GLIBCXX_\1/g' | sort -Vu | cat
 ```
 
 ### Other Build Tools

--- a/include/fbgemm/Types.h
+++ b/include/fbgemm/Types.h
@@ -27,14 +27,14 @@ constexpr uint32_t f16_num_exponent_bits = 5;
 constexpr uint32_t f16_num_mantissa_bits = 10;
 constexpr uint32_t f16_num_non_sign_bits =
     f16_num_exponent_bits + f16_num_mantissa_bits;
-constexpr uint32_t f16_exponent_mask = 0x1F; // 5 bits
+constexpr uint32_t f16_exponent_mask = 0b1'1111; // 5 bits
 constexpr uint32_t f16_sign_bit = 1u
     << (f16_num_exponent_bits + f16_num_mantissa_bits);
 constexpr uint32_t f16_exponent_bits = f16_exponent_mask
     << f16_num_mantissa_bits;
-constexpr uint32_t f16_mantissa_mask = 0x3FF; // 10 bits
+constexpr uint32_t f16_mantissa_mask = 0b11'1111'1111; // 10 bits
 constexpr uint32_t f16_exponent_bias = 15;
-constexpr uint32_t f16_nan = 0x7FFF;
+constexpr uint32_t f16_nan = 0x7F'FF;
 
 // The IEEE754 standard specifies a binary32 as having:
 // SEEEEEEEEMMMMMMMMMMMMMMMMMMMMMMM
@@ -44,10 +44,10 @@ constexpr uint32_t f16_nan = 0x7FFF;
 //  * 23 mantissa/significand bits (a 24th bit is implicit)
 constexpr uint32_t f32_num_exponent_bits = 8;
 constexpr uint32_t f32_num_mantissa_bits = 23;
-constexpr uint32_t f32_exponent_mask = 0xFF; // 8 bits
-constexpr uint32_t f32_mantissa_mask = 0x7FFFFF; // 23 bits
+constexpr uint32_t f32_exponent_mask = 0b1111'1111; // 8 bits
+constexpr uint32_t f32_mantissa_mask = 0x7F'FF'FF; // 23 bits
 constexpr uint32_t f32_exponent_bias = 127;
-constexpr uint32_t f32_all_non_sign_mask = 0x7FFFFFFF; // 31 bits
+constexpr uint32_t f32_all_non_sign_mask = 0x7F'FF'FF'FF; // 31 bits
 constexpr uint32_t f32_most_significant_bit = 1u << 22; // Turn on 23rd bit
 constexpr uint32_t f32_num_non_sign_bits =
     f32_num_exponent_bits + f32_num_mantissa_bits;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,12 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_C_STANDARD_REQUIRED ON)
 
 if(FBGEMM_BUILD_TESTS AND NOT TARGET gtest)
   #Download Googletest framework from github if
@@ -38,12 +46,9 @@ macro(add_gtest TESTNAME)
     EmbeddingSpMDMTestUtils.cc
     QuantizationHelpers.cc
     TestUtils.cc)
-  set_target_properties(${TESTNAME} PROPERTIES
-          CXX_STANDARD 11
-          CXX_EXTENSIONS NO)
-  #To compile test files with AVX2 turned on
-  #For static build, defining FBGEMM_STATIC to avoid generating
-  #functions with _dllimport attributes.
+  # To compile test files with AVX2 turned on
+  # For static build, defining FBGEMM_STATIC to avoid generating
+  # functions with _dllimport attributes.
   if(MSVC)
     target_compile_options(${TESTNAME} PRIVATE
       "/arch:AVX2" "/wd4244" "/wd4267" "/wd4305" "/wd4309")

--- a/third_party/asmjit.BUILD
+++ b/third_party/asmjit.BUILD
@@ -16,9 +16,7 @@ cc_library(
     copts = [
         "-DASMJIT_STATIC",
         "-fno-tree-vectorize",
-        "-std=c++17",
         "-fmerge-all-constants",
-        "-std=gnu++11",
         "-DTH_BLAS_MKL",
     ],
     includes = [

--- a/third_party/cpuinfo.BUILD
+++ b/third_party/cpuinfo.BUILD
@@ -8,9 +8,6 @@ cc_library(
     hdrs = glob([
         "deps/clog/include/*.h",
     ]),
-    copts = [
-        "-std=c++17",
-    ],
     includes = [
         "deps/clog/include/",
     ],
@@ -46,7 +43,6 @@ cc_library(
         "-DCPUINFO_LOG_LEVEL=2",
         "-DTH_BLAS_MKL",
         "-D_GNU_SOURCE=1",
-        "-std=c++17",
     ],
     includes = [
         "include",

--- a/third_party/cpuinfo.BUILD
+++ b/third_party/cpuinfo.BUILD
@@ -8,6 +8,9 @@ cc_library(
     hdrs = glob([
         "deps/clog/include/*.h",
     ]),
+    copts = [
+        "-std=c++17",
+    ],
     includes = [
         "deps/clog/include/",
     ],
@@ -43,6 +46,7 @@ cc_library(
         "-DCPUINFO_LOG_LEVEL=2",
         "-DTH_BLAS_MKL",
         "-D_GNU_SOURCE=1",
+        "-std=c++17",
     ],
     includes = [
         "include",


### PR DESCRIPTION
Summary:

- Add C++17 support for the entire FBGEMM_GPU build
- Add C++17 support for the entire FBGEMM build
- Update FBGEMM tests and benchmarks to be C++17-compatible
- Make FBGEMM builds output more logging
- Cherry-pick code changes from D43776442 v4 now that C++17 is fully supported
