### PR TITLE
Add variable length (batch size) support to TBE training

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -194,6 +194,9 @@ set(CPU_OPTIMIZERS ${COMMON_OPTIMIZERS} ${CPU_ONLY_OPTIMIZERS})
 
 set(GPU_OPTIMIZERS ${COMMON_OPTIMIZERS} ${GPU_ONLY_OPTIMIZERS})
 
+# Optimizers with the VBE support
+set(VBE_OPTIMIZERS rowwise_adagrad)
+
 set(gen_gpu_kernel_source_files
     "gen_embedding_forward_dense_weighted_codegen_cuda.cu"
     "gen_embedding_forward_dense_unweighted_codegen_cuda.cu"
@@ -201,7 +204,9 @@ set(gen_gpu_kernel_source_files
     "gen_embedding_forward_split_unweighted_codegen_cuda.cu"
     "gen_embedding_backward_dense_indice_weights_codegen_cuda.cu"
     "gen_embedding_backward_split_indice_weights_codegen_cuda.cu"
-    "gen_embedding_backward_split_grad.cu")
+    "gen_embedding_backward_split_grad.cu"
+    "gen_embedding_forward_split_weighted_vbe_codegen_cuda.cu"
+    "gen_embedding_forward_split_unweighted_vbe_codegen_cuda.cu")
 
 foreach(wdesc dense split)
   list(APPEND gen_gpu_kernel_source_files
@@ -210,18 +215,24 @@ endforeach()
 
 foreach(wdesc weighted unweighted_nobag unweighted)
   list(APPEND gen_gpu_kernel_source_files
-      "gen_embedding_forward_split_${wdesc}_kernel.cu"
-      "gen_embedding_forward_dense_${wdesc}_kernel.cu"
       "gen_embedding_forward_quantized_split_nbit_host_${wdesc}_codegen_cuda.cu"
+      "gen_embedding_forward_dense_${wdesc}_kernel.cu"
       "gen_embedding_backward_dense_split_${wdesc}_cuda.cu"
       "gen_embedding_backward_dense_split_${wdesc}_kernel_cta.cu"
       "gen_embedding_backward_dense_split_${wdesc}_kernel_warp.cu")
+
+  list(APPEND gen_gpu_kernel_source_files
+      "gen_embedding_forward_split_${wdesc}_kernel.cu")
 
   foreach(etype fp32 fp16 fp8 int8 int4 int2)
     list(APPEND gen_gpu_kernel_source_files
        "gen_embedding_forward_quantized_split_nbit_kernel_${wdesc}_${etype}_codegen_cuda.cu")
   endforeach()
 endforeach()
+
+list(APPEND gen_gpu_kernel_source_files
+     "gen_embedding_forward_split_weighted_vbe_kernel.cu"
+     "gen_embedding_forward_split_unweighted_vbe_kernel.cu")
 
 set(gen_cpu_source_files
     "gen_embedding_forward_quantized_unweighted_codegen_cpu.cpp"
@@ -262,6 +273,17 @@ foreach(optimizer ${GPU_OPTIMIZERS})
       "gen_embedding_backward_${optimizer}_split_${wdesc}_cuda.cu"
       "gen_embedding_backward_${optimizer}_split_${wdesc}_kernel_cta.cu"
       "gen_embedding_backward_${optimizer}_split_${wdesc}_kernel_warp.cu")
+  endforeach()
+
+endforeach()
+
+foreach(optimizer ${VBE_OPTIMIZERS})
+  # vbe is not supported in nobag
+  foreach(wdesc weighted unweighted)
+    list(APPEND gen_gpu_kernel_source_files
+      "gen_embedding_backward_${optimizer}_split_${wdesc}_vbe_cuda.cu"
+      "gen_embedding_backward_${optimizer}_split_${wdesc}_vbe_kernel_cta.cu"
+      "gen_embedding_backward_${optimizer}_split_${wdesc}_vbe_kernel_warp.cu")
   endforeach()
 endforeach()
 

--- a/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
@@ -14,13 +14,17 @@
 
 #include "fbgemm_gpu/embedding_common.h"
 #include "fbgemm_gpu/sparse_ops_utils.h"
+#include "fbgemm_gpu/split_embeddings_utils.cuh"
 
 using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
 
 {% if has_gpu_support %}
 /// @defgroup embedding-cuda Embedding CUDA Operators
-Tensor split_embedding_codegen_forward_unweighted_cuda(
+
+{% for vbe in ([True, False] if has_vbe_support else [False]) %}
+{% set vbe_desc = "_vbe" if vbe else "" %}
+Tensor split_embedding_codegen_forward_unweighted{{ vbe_desc }}_cuda(
     Tensor dev_weights,
     Tensor uvm_weights,
     Tensor lxu_cache_weights,
@@ -34,9 +38,17 @@ Tensor split_embedding_codegen_forward_unweighted_cuda(
     int64_t pooling_mode,
     Tensor lxu_cache_locations,
     int64_t output_dtype,
-    int64_t BT_block_size);
+    {% if vbe %}
+    int64_t BT_block_size,
+    const VBEMetadata& vbe_metadata,
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask
+    {% else %}
+    int64_t BT_block_size
+    {% endif %}
+);
 
-Tensor split_embedding_codegen_forward_weighted_cuda(
+Tensor split_embedding_codegen_forward_weighted{{ vbe_desc }}_cuda(
     Tensor dev_weights,
     Tensor uvm_weights,
     Tensor lxu_cache_weights,
@@ -51,9 +63,17 @@ Tensor split_embedding_codegen_forward_weighted_cuda(
     Tensor indice_weights,
     Tensor lxu_cache_locations,
     int64_t output_dtype,
-    int64_t BT_block_size);
+    {% if vbe %}
+    int64_t BT_block_size,
+    const VBEMetadata& vbe_metadata,
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask
+    {% else %}
+    int64_t BT_block_size
+    {% endif %}
+);
 
-Tensor split_embedding_codegen_grad_indice_weights_cuda(
+Tensor split_embedding_codegen_grad_indice_weights{{ vbe_desc }}_cuda(
     Tensor grad_output,
     Tensor dev_weights,
     Tensor uvm_weights,
@@ -65,9 +85,17 @@ Tensor split_embedding_codegen_grad_indice_weights_cuda(
     Tensor indices,
     Tensor offsets,
     Tensor lxu_cache_locations,
-    Tensor feature_requires_grad);
+    {% if vbe %}
+    Tensor feature_requires_grad,
+    const VBEMetadata& vbe_metadata,
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask
+    {% else %}
+    Tensor feature_requires_grad
+    {% endif %}
+);
 
-void split_embedding_backward_codegen_{{ optimizer }}_unweighted_exact_cuda(
+void split_embedding_backward_codegen_{{ optimizer }}_unweighted_exact{{ vbe_desc }}_cuda(
     Tensor grad_output,
     Tensor dev_weights,
     Tensor uvm_weights,
@@ -85,9 +113,14 @@ void split_embedding_backward_codegen_{{ optimizer }}_unweighted_exact_cuda(
     int64_t BT_block_size,
     int64_t max_segment_length_per_warp,
     bool stochastic_rounding,
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask,
+    {% if vbe %}
+    const VBEMetadata& vbe_metadata,
+    {% endif %}
     {{ args.split_function_args | join(", ") }});
 
-void split_embedding_backward_codegen_{{ optimizer }}_weighted_exact_cuda(
+void split_embedding_backward_codegen_{{ optimizer }}_weighted_exact{{ vbe_desc }}_cuda(
     Tensor grad_output,
     Tensor dev_weights,
     Tensor uvm_weights,
@@ -106,8 +139,14 @@ void split_embedding_backward_codegen_{{ optimizer }}_weighted_exact_cuda(
     int64_t BT_block_size,
     int64_t max_segment_length_per_warp,
     bool stochastic_rounding,
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask,
+    {% if vbe %}
+    const VBEMetadata& vbe_metadata,
+    {% endif %}
     {{ args.split_function_args | join(", ") }});
 
+{% if not vbe %}
 Tensor split_embedding_nobag_codegen_forward_unweighted_cuda(
     Tensor dev_weights,
     Tensor uvm_weights,
@@ -119,7 +158,8 @@ Tensor split_embedding_nobag_codegen_forward_unweighted_cuda(
     Tensor offsets,
     Tensor lxu_cache_locations,
     int64_t output_dtype,
-    int64_t unused);
+    int64_t unused
+);
 
 void split_embedding_nobag_backward_codegen_{{ optimizer }}_unweighted_exact_cuda(
     Tensor grad_output,
@@ -137,11 +177,17 @@ void split_embedding_nobag_backward_codegen_{{ optimizer }}_unweighted_exact_cud
     int64_t BT_block_size,
     int64_t max_segment_length_per_warp,
     bool stochastic_rounding,
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask,
     {{ args.split_function_args | join(", ") }});
+{% endif %} // if not vbe
 
 {% for nobag in [True, False] %}
-class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
-    public torch::autograd::Function<Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op> {
+{% if not nobag or not vbe %} // nobag does not support vbe
+class Split{{ "NoBag" if nobag else "" }}{{ "VBE" if vbe else "" }}LookupFunction_{{ optimizer }}_Op :
+    public torch::autograd::Function<
+        Split{{ "NoBag" if nobag else "" }}{{ "VBE" if vbe else "" }}LookupFunction_{{ optimizer }}_Op
+    > {
  public:
   static torch::autograd::variable_list forward(
     torch::autograd::AutogradContext* ctx,
@@ -172,10 +218,75 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
     bool gradient_clipping,
     double max_gradient,
     bool stochastic_rounding,
+    {% if vbe %}
+    const c10::optional<Tensor>& B_offsets,
+    const c10::optional<Tensor>& vbe_output_offsets_feature_rank,
+    const c10::optional<Tensor>& vbe_B_offsets_rank_per_feature,
+    const int32_t max_B,
+    const int32_t max_B_feature_rank,
+    const int64_t vbe_output_size,
+    {% endif %}
     {{ args.split_function_args | join(", ") }}) {
+
+    const auto T = weights_offsets.numel();
+    {% if vbe %}
+    struct VBEMetadata vbe_metadata = {
+      .B_offsets = B_offsets.value_or(Tensor()),
+      .output_offsets_feature_rank = vbe_output_offsets_feature_rank.value_or(Tensor()),
+      .B_offsets_rank_per_feature = vbe_B_offsets_rank_per_feature.value_or(Tensor()),
+      .max_B_feature_rank = max_B_feature_rank,
+      .output_size = vbe_output_size
+    };
+    const auto max_B_ = max_B;
+    {% else %}
+    const auto max_B_ = offsets.size(0) / T;
+    {% endif %}
+
+    int32_t info_B_num_bits;
+    uint32_t info_B_mask;
+    std::tie(info_B_num_bits, info_B_mask) = adjust_info_B_num_bits(max_B_, T);
+
+    {% if vbe %}
+    populate_vbe_metadata_foreach_sample_inplace(
+        vbe_metadata,
+        {% if not nobag %}
+        D_offsets,
+        /*D=*/-1,
+        /*nobag=*/false,
+        {% else %}
+        // weights_placements has the same options as D_offsets
+        at::empty({0}, weights_placements.options()),
+        D,
+        /*nobag=*/true,
+        {% endif %}
+        info_B_num_bits,
+        /*total_B=*/offsets.size(0) - 1
+        );
+    {% endif %}
+
     ctx->save_for_backward({
-        dev_weights, uvm_weights, lxu_cache_weights, weights_placements, weights_offsets, {% if not nobag %} D_offsets, {% endif %} hash_size_cumsum,
-        indices, offsets, {% if not nobag %} indice_weights.value_or(Tensor()), feature_requires_grad.value_or(Tensor()), {% endif %} lxu_cache_locations, {{ args.split_saved_tensors | join(", ") }} });
+        dev_weights,
+        uvm_weights,
+        lxu_cache_weights,
+        weights_placements,
+        weights_offsets,
+        {% if not nobag %}
+        D_offsets,
+        {% endif %}
+        hash_size_cumsum,
+        indices,
+        offsets,
+        {% if not nobag %}
+        indice_weights.value_or(Tensor()),
+        feature_requires_grad.value_or(Tensor()),
+        {% endif %}
+        lxu_cache_locations,
+        {% if vbe %}
+        vbe_metadata.B_offsets,
+        vbe_metadata.output_offsets,
+        vbe_metadata.b_t_map,
+        {% endif %}
+        {{ args.split_saved_tensors | join(", ") }} });
 
     {% if not nobag %}
     ctx->saved_data["max_D"] = max_D;
@@ -187,6 +298,9 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
     ctx->saved_data["gradient_clipping"] = gradient_clipping;
     ctx->saved_data["max_gradient"] = max_gradient;
     ctx->saved_data["stochastic_rounding"] = stochastic_rounding;
+    ctx->saved_data["info_B_num_bits"] = info_B_num_bits;
+    uint64_t info_B_mask_64 = info_B_mask;
+    ctx->saved_data["info_B_mask"] = *reinterpret_cast<int64_t*>(&info_B_mask_64);
 
     {% for (var, _) in args.saved_data %}
     ctx->saved_data["{{ var }}"] = {{ var }};
@@ -199,27 +313,75 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
     constexpr int32_t BT_block_size = 32;
 #endif
     if (!indice_weights) {
-        return {split_embedding_codegen_forward_unweighted_cuda(
-        dev_weights, uvm_weights, lxu_cache_weights, weights_placements, weights_offsets,
-        D_offsets, total_D, max_D, indices, offsets, pooling_mode, lxu_cache_locations, output_dtype, BT_block_size)};
-    }  else {
-        return {split_embedding_codegen_forward_weighted_cuda(
-        dev_weights, uvm_weights, lxu_cache_weights, weights_placements, weights_offsets,
-        D_offsets, total_D, max_D, indices, offsets, pooling_mode, *indice_weights, lxu_cache_locations, output_dtype, BT_block_size)};
+        return {
+          split_embedding_codegen_forward_unweighted{{ vbe_desc }}_cuda(
+            dev_weights,
+            uvm_weights,
+            lxu_cache_weights,
+            weights_placements,
+            weights_offsets,
+            D_offsets,
+            total_D,
+            max_D,
+            indices,
+            offsets,
+            pooling_mode,
+            lxu_cache_locations,
+            output_dtype,
+            {% if vbe %}
+            BT_block_size,
+            vbe_metadata,
+            info_B_num_bits,
+            info_B_mask
+            {% else %}
+            BT_block_size
+            {% endif %}
+          )
+        };
+    } else {
+        return {
+          split_embedding_codegen_forward_weighted{{ vbe_desc }}_cuda(
+            dev_weights,
+            uvm_weights,
+            lxu_cache_weights,
+            weights_placements,
+            weights_offsets,
+            D_offsets,
+            total_D,
+            max_D,
+            indices,
+            offsets,
+            pooling_mode,
+            *indice_weights,
+            lxu_cache_locations,
+            output_dtype,
+            {% if vbe %}
+            BT_block_size,
+            vbe_metadata,
+            info_B_num_bits,
+            info_B_mask
+            {% else %}
+            BT_block_size
+            {% endif %}
+          )
+        };
     }
     {% else %}
-    return {split_embedding_nobag_codegen_forward_unweighted_cuda(
-      dev_weights,
-      uvm_weights,
-      lxu_cache_weights,
-      weights_placements,
-      weights_offsets,
-      D,
-      indices,
-      offsets,
-      lxu_cache_locations,
-      output_dtype,
-      0)};
+    return {
+      split_embedding_nobag_codegen_forward_unweighted_cuda(
+        dev_weights,
+        uvm_weights,
+        lxu_cache_weights,
+        weights_placements,
+        weights_offsets,
+        D,
+        indices,
+        offsets,
+        lxu_cache_locations,
+        output_dtype,
+        0
+      )
+    };
     {% endif %}
   }
 
@@ -244,6 +406,11 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
     auto feature_requires_grad = *savedItr++;
     {% endif %}
     auto lxu_cache_locations = *savedItr++;
+    {% if vbe %}
+    auto B_offsets = *savedItr++;
+    auto vbe_output_offsets = *savedItr++;
+    auto vbe_b_t_map = *savedItr++;
+    {% endif %}
 
     {% for tensor in args.split_saved_tensors %}
     auto {{ tensor }} = *savedItr++;
@@ -259,6 +426,9 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
     auto gradient_clipping = ctx->saved_data["gradient_clipping"].toBool();
     auto max_gradient = ctx->saved_data["max_gradient"].toDouble();
     auto stochastic_rounding = ctx->saved_data["stochastic_rounding"].toBool();
+    const int32_t info_B_num_bits = ctx->saved_data["info_B_num_bits"].toInt();
+    const int64_t info_B_mask_64 = ctx->saved_data["info_B_mask"].toInt();
+    const uint32_t info_B_mask = *reinterpret_cast<const uint64_t*>(&info_B_mask_64);
 
     {% for (var, ivalue_cast) in args.saved_data %}
     auto {{ var }} = ctx->saved_data["{{ var }}"].{{ ivalue_cast }}();
@@ -278,17 +448,26 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
     auto grad_output = gradient_clipping ? clamp(grad_outputs[0], -max_gradient, max_gradient) : grad_outputs[0];
     // FIXME: to support aligned memory access in Vec4T load/store function
     // 16 for FP32 and 8 for FP16
-    if (reinterpret_cast<uint64_t>(grad_output.data_ptr()) % 16 != 0 ||
-        grad_output.stride(1) != 1 || grad_output.stride(0) % 4 != 0) {
+    if (grad_output.dim() > 1 &&
+        (reinterpret_cast<uint64_t>(grad_output.data_ptr()) % 16 != 0 ||
+        grad_output.stride(1) != 1 || grad_output.stride(0) % 4 != 0)) {
         grad_output = grad_output.contiguous();
     }
     if (reinterpret_cast<uint64_t>(grad_output.data_ptr()) % 16 != 0) {
         grad_output = at::empty_like(grad_output).copy_(grad_output);
     }
 
+    {% if vbe %}
+    struct VBEMetadata vbe_metadata = {
+      .B_offsets = B_offsets,
+      .output_offsets = vbe_output_offsets,
+      .b_t_map = vbe_b_t_map,
+    };
+    {% endif %}
+
     {% if not nobag %}
     if (!indice_weights.defined()) {
-      split_embedding_backward_codegen_{{ optimizer }}_unweighted_exact_cuda(
+      split_embedding_backward_codegen_{{ optimizer }}_unweighted_exact{{ vbe_desc }}_cuda(
           grad_output,
           dev_weights,
           uvm_weights,
@@ -306,6 +485,11 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
           BT_block_size,
           max_segment_length_per_warp,
           stochastic_rounding,
+          info_B_num_bits,
+          info_B_mask,
+          {% if vbe %}
+          vbe_metadata,
+          {% endif %}
           {{ args.split_function_arg_names | join(", ") }});
       return {
           Tensor(), // placeholder autograd tensor
@@ -329,10 +513,18 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
           Variable(), // gradient_clipping
           Variable(), // max_gradient
           Variable(), // stochastic_rounding
+          Variable(), // B_offsets
+          {% if vbe %}
+          Variable(), // vbe_output_offsets_feature_rank
+          Variable(), // vbe_B_offsets_rank_per_feature
+          Variable(), // max_B
+          Variable(), // max_B_feature_rank
+          Variable(), // vbe_output_size
+          {% endif %}
           {{ args.split_variables | join(", ") }}
       };
     } else {
-      auto grad_indice_weights = split_embedding_codegen_grad_indice_weights_cuda(
+      auto grad_indice_weights = split_embedding_codegen_grad_indice_weights{{ vbe_desc }}_cuda(
           grad_output,
           dev_weights,
           uvm_weights,
@@ -344,8 +536,16 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
           indices,
           offsets,
           lxu_cache_locations,
-          feature_requires_grad);
-      split_embedding_backward_codegen_{{ optimizer }}_weighted_exact_cuda(
+          {% if vbe %}
+          feature_requires_grad,
+          vbe_metadata,
+          info_B_num_bits,
+          info_B_mask
+          {% else %}
+          feature_requires_grad
+          {% endif %}
+          );
+      split_embedding_backward_codegen_{{ optimizer }}_weighted_exact{{ vbe_desc }}_cuda(
           grad_output,
           dev_weights,
           uvm_weights,
@@ -364,6 +564,11 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
           BT_block_size,
           max_segment_length_per_warp,
           stochastic_rounding,
+          info_B_num_bits,
+          info_B_mask,
+          {% if vbe %}
+          vbe_metadata,
+          {% endif %}
           {{ args.split_function_arg_names | join(", ") }});
       return {
           Tensor(), // placeholder autograd tensor
@@ -388,6 +593,14 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
           Variable(), // gradient_clipping
           Variable(), // max_gradient
           Variable(), // stochastic_rounding
+          {% if vbe %}
+          Variable(), // B_offsets
+          Variable(), // vbe_output_offsets_feature_rank
+          Variable(), // vbe_B_offsets_rank_per_feature
+          Variable(), // max_B
+          Variable(), // max_B_feature_rank
+          Variable(), // vbe_output_size
+          {% endif %}
           {{ args.split_variables | join(", ") }}
       };
     }
@@ -408,6 +621,11 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
         BT_block_size,
         max_segment_length_per_warp,
         stochastic_rounding,
+        info_B_num_bits,
+        info_B_mask,
+        {% if vbe %}
+        vbe_metadata,
+        {% endif %}
         {{ args.split_function_arg_names | join(", ") }});
     return {
         Tensor(), // placeholder autograd tensor
@@ -426,12 +644,22 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
         Variable(), // gradient_clipping
         Variable(), // max_gradient
         Variable(), // stochastic_rounding
+        {% if vbe %}
+        Variable(), // B_offsets
+        Variable(), // vbe_output_offsets_feature_rank
+        Variable(), // vbe_B_offsets_rank_per_feature
+        Variable(), // max_B
+        Variable(), // max_B_feature_rank
+        Variable(), // vbe_output_size
+        {% endif %}
         {{ args.split_variables | join(", ") }}
     };
     {% endif %}
   }
 };
-{% endfor %}
+{% endif %} // if not nobag or not vbe
+{% endfor %} // for nobag in [True, False]
+{% endfor %} // for vbe in [True, False]
 {% endif %} // if has_gpu_support
 
 ///@ingroup embedding-cuda
@@ -457,52 +685,80 @@ Tensor split_embedding_codegen_lookup_{{ optimizer }}_function(
     double max_gradient,
     bool stochastic_rounding,
     {{ args.split_function_args | join(", ") }},
-    int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)) {
+    const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32),
+    const c10::optional<Tensor>& B_offsets = c10::optional<Tensor>(),
+    const c10::optional<Tensor>& vbe_output_offsets_feature_rank = c10::optional<Tensor>(),
+    const c10::optional<Tensor>& vbe_B_offsets_rank_per_feature = c10::optional<Tensor>(),
+    const int64_t max_B = -1,
+    const int64_t max_B_feature_rank = -1,
+    const int64_t vbe_output_size = -1) {
   {% if has_gpu_support %}
-  if (static_cast<PoolingMode>(pooling_mode) == PoolingMode::NONE) {
-    return SplitNoBagLookupFunction_{{ optimizer }}_Op::apply(
-      placeholder_autograd_tensor,
-      output_dtype,
-      dev_weights,
-      uvm_weights,
-      lxu_cache_weights,
-      weights_placements,
-      weights_offsets,
-      max_D,
-      hash_size_cumsum,
-      total_hash_size_bits,
-      indices,
-      offsets,
-      lxu_cache_locations,
-      gradient_clipping,
-      max_gradient,
-      stochastic_rounding,
-      {{ args.split_function_arg_names | join(", ") }})[0];
-  } else {
-    return SplitLookupFunction_{{ optimizer }}_Op::apply(
-      placeholder_autograd_tensor,
-      output_dtype,
-      dev_weights,
-      uvm_weights,
-      lxu_cache_weights,
-      weights_placements,
-      weights_offsets,
-      D_offsets,
-      total_D,
-      max_D,
-      hash_size_cumsum,
-      total_hash_size_bits,
-      indices,
-      offsets,
-      pooling_mode,
-      indice_weights,
-      feature_requires_grad,
-      lxu_cache_locations,
-      gradient_clipping,
-      max_gradient,
-      stochastic_rounding,
-      {{ args.split_function_arg_names | join(", ") }})[0];
+  {% for vbe in ([True, False] if has_vbe_support else [False]) %}
+  {% set vbe_class_desc = "VBE" if vbe else "" %}
+
+  {% if has_vbe_support %}
+  {% if vbe %}
+  if (B_offsets.has_value()) {
+  {% else %}
+  else { // if (B_offsets.has_value())
+  {% endif %}
+  {% endif %} // if has_vbe_support
+    if (static_cast<PoolingMode>(pooling_mode) == PoolingMode::NONE) {
+      return SplitNoBagLookupFunction_{{ optimizer }}_Op::apply(
+          placeholder_autograd_tensor,
+          output_dtype,
+          dev_weights,
+          uvm_weights,
+          lxu_cache_weights,
+          weights_placements,
+          weights_offsets,
+          max_D,
+          hash_size_cumsum,
+          total_hash_size_bits,
+          indices,
+          offsets,
+          lxu_cache_locations,
+          gradient_clipping,
+          max_gradient,
+          stochastic_rounding,
+          {{ args.split_function_arg_names | join(", ") }})[0];
+    } else {
+      return Split{{ vbe_class_desc }}LookupFunction_{{ optimizer }}_Op::apply(
+          placeholder_autograd_tensor,
+          output_dtype,
+          dev_weights,
+          uvm_weights,
+          lxu_cache_weights,
+          weights_placements,
+          weights_offsets,
+          D_offsets,
+          total_D,
+          max_D,
+          hash_size_cumsum,
+          total_hash_size_bits,
+          indices,
+          offsets,
+          pooling_mode,
+          indice_weights,
+          feature_requires_grad,
+          lxu_cache_locations,
+          gradient_clipping,
+          max_gradient,
+          stochastic_rounding,
+          {% if vbe %}
+          B_offsets,
+          vbe_output_offsets_feature_rank,
+          vbe_B_offsets_rank_per_feature,
+          max_B,
+          max_B_feature_rank,
+          vbe_output_size,
+          {% endif %}
+          {{ args.split_function_arg_names | join(", ") }})[0];
+    }
+  {% if has_vbe_support %}
   }
+  {% endif %}
+  {% endfor %}
   {% else %}
   TORCH_CHECK(false, "split_embedding_codegen_lookup_{{ optimizer }}_function is deprecated. Please see https://github.com/pytorch/FBGEMM/discussions/1727 for more detail.");
   return Tensor();
@@ -511,13 +767,13 @@ Tensor split_embedding_codegen_lookup_{{ optimizer }}_function(
 
 // Deprecated for fb namespace! Please use fbgemm namespace instead!
 TORCH_LIBRARY_FRAGMENT(fb, m) {
-    m.def("split_embedding_codegen_lookup_{{ optimizer }}_function(Tensor placeholder_autograd_tensor, Tensor dev_weights, Tensor uvm_weights, Tensor lxu_cache_weights, Tensor weights_placements, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, Tensor lxu_cache_locations, bool gradient_clipping, float max_gradient, bool stochastic_rounding, {{ args.split_function_schemas | join(", ") }}, int output_dtype=0) -> Tensor");
+    m.def("split_embedding_codegen_lookup_{{ optimizer }}_function(Tensor placeholder_autograd_tensor, Tensor dev_weights, Tensor uvm_weights, Tensor lxu_cache_weights, Tensor weights_placements, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, Tensor lxu_cache_locations, bool gradient_clipping, float max_gradient, bool stochastic_rounding, {{ args.split_function_schemas | join(", ") }}, int output_dtype=0, Tensor? B_offsets=None, Tensor? vbe_output_offsets_feature_rank=None, Tensor? vbe_B_offsets_rank_per_feature=None, int max_B=-1, int max_B_feature_rank=-1, int vbe_output_size=-1) -> Tensor");
     DISPATCH_TO_CUDA("split_embedding_codegen_lookup_{{ optimizer }}_function", split_embedding_codegen_lookup_{{ optimizer }}_function);
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
-    m.def("split_embedding_codegen_lookup_{{ optimizer }}_function(Tensor placeholder_autograd_tensor, Tensor dev_weights, Tensor uvm_weights, Tensor lxu_cache_weights, Tensor weights_placements, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, Tensor lxu_cache_locations, bool gradient_clipping, float max_gradient, bool stochastic_rounding, {{ args.split_function_schemas | join(", ") }}, int output_dtype=0) -> Tensor");
+    m.def("split_embedding_codegen_lookup_{{ optimizer }}_function(Tensor placeholder_autograd_tensor, Tensor dev_weights, Tensor uvm_weights, Tensor lxu_cache_weights, Tensor weights_placements, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, Tensor lxu_cache_locations, bool gradient_clipping, float max_gradient, bool stochastic_rounding, {{ args.split_function_schemas | join(", ") }}, int output_dtype=0, Tensor? B_offsets=None, Tensor? vbe_output_offsets_feature_rank=None, Tensor? vbe_B_offsets_rank_per_feature=None, int max_B=-1, int max_B_feature_rank=-1, int vbe_output_size=-1) -> Tensor");
     DISPATCH_TO_CUDA("split_embedding_codegen_lookup_{{ optimizer }}_function", split_embedding_codegen_lookup_{{ optimizer }}_function);
 }
 
-// clang-format on
+  // clang-format on

--- a/fbgemm_gpu/codegen/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_kernel_cta_template.cu
@@ -8,6 +8,7 @@
 
 // clang-format off
 {%- set wdesc = "weighted" if weighted else "unweighted" %}
+{%- set vbe_desc = "_vbe" if vbe else "" %}
 #include "fbgemm_gpu/embedding_backward_template_helpers.cuh"
 #include "fbgemm_gpu/split_embeddings_utils.cuh"
 
@@ -21,7 +22,7 @@ template <
     size_t kMaxVecsPerThread,
     int32_t kThreadGroupSize >
 __global__ __launch_bounds__(kMaxThreads) void
-split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_kernel_cta_per_row_1(
+split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vbe_desc }}_kernel_cta_per_row_1(
     const at::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits> grad_output,
     at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
     {%- if not dense %}
@@ -64,7 +65,11 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
     {%- else %}
     at::PackedTensorAccessor64<cache_t, 1, at::RestrictPtrTraits> grad_dev_weights,
     {%- endif %}
-    {%- if not nobag %}
+    {%- if not nobag and vbe %}
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> B_offsets,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> output_offsets,
+    {% endif %}
+    {% if not nobag %}
     const int32_t info_B_num_bits,
     const uint32_t info_B_mask,
     {%- endif %}
@@ -140,20 +145,26 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
             const auto b_t = sl_j < sl_end ? reinterpret_cast<const uint32_t*>(&sorted_infos[0])[segment_start + sl_j] : 0;
             const auto b = b_t & info_B_mask;
             const auto t = b_t >> info_B_num_bits;
+            {% if vbe %}
+            const auto grad_offset = output_offsets[B_offsets[t] + b];
+            {% else %} // if vbe
             int32_t D_start = sl_j < sl_end ? D_offsets[t] : 0;
-            {%- else %}
+            {%- endif %} // if vbe
+            {%- else %} // if not nobag
             int64_t l_t = sl_j < sl_end ? sorted_infos[segment_start + sl_j] : 0;
             int32_t l = l_t / T;
-            {%- endif %}
+            {%- endif %} // if not nobag
             {%- if weighted %}
             at::acc_type<cache_t, true> idx_weight = sl_j < sl_end ? sorted_indice_weights[segment_start + sl_j] : 0.0;
             {%- endif %}
             for (int32_t j = 0; j < kThreadGroupSize && sl + j < sl_end; ++j) {
-                {%- if not nobag %}
+                {%- if nobag %}
+                int32_t l_j = SHFL_SYNC(l, j);
+                {%- elif vbe %}
+                const auto grad_offset_j = SHFL_SYNC(grad_offset, j);
+                {%- else %}
                 int32_t b_j = SHFL_SYNC(b, j);
                 int32_t D_start_j = SHFL_SYNC(D_start, j);
-                {%- else %}
-                int32_t l_j = SHFL_SYNC(l, j);
                 {%- endif %}
 
                 {%- if weighted %}
@@ -165,12 +176,16 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
                     i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
                     ++i) {
                     int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
-                    {%- if not nobag %}
                     Vec4T<at::acc_type<grad_t, true>> grad_out_vec(
-                        &grad_output[b_j][0] + D_start_j + d);
-                    {%- else %}
-                    Vec4T<at::acc_type<grad_t, true>> grad_out_vec(&grad_output[l_j][d]);
-                    {%- endif %}
+                        {%- if nobag %}
+                        &grad_output[l_j][d]
+                        {%- elif vbe %}
+                        &grad_output[0][grad_offset_j + d]
+                        {%- else %}
+                        &grad_output[b_j][0] + D_start_j + d
+                        {%- endif %}
+                    );
+
                     {%- if weighted %}
                     grad_sum[i].fma_(grad_out_vec, idx_weight_j);
                     {%- else %}
@@ -459,7 +474,7 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
 {%- for (kMaxVecsPerThread, kThreadGroupSize) in tuples | unique %}
 
 template __global__ __launch_bounds__(kMaxThreads)
-void split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_kernel_cta_per_row_1
+void split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vbe_desc }}_kernel_cta_per_row_1
 < {{ emb_type }},
   {{ grad_type }},
   {{ cache_type }},
@@ -507,6 +522,10 @@ void split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimize
     at::PhiloxCudaState stochastic_rounding_philox_args,
     {%- else %}
     at::PackedTensorAccessor64<{{ cache_type }}, 1, at::RestrictPtrTraits> grad_dev_weights,
+    {%- endif %}
+    {%- if not nobag and vbe %}
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> B_offsets,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> output_offsets,
     {%- endif %}
     {%- if not nobag %}
     const int32_t info_B_num_bits,
@@ -545,7 +564,7 @@ void split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimize
 {%- for (kMaxVecsPerThread, kThreadGroupSize) in tuples | unique %}
 
 template __global__ __launch_bounds__(kMaxThreads)
-void split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_kernel_cta_per_row_1
+void split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vbe_desc }}_kernel_cta_per_row_1
 < {{ emb_type }},
   {{ grad_type }},
   {{ cache_type }},
@@ -593,6 +612,10 @@ void split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimize
     at::PhiloxCudaState stochastic_rounding_philox_args,
     {%- else %}
     at::PackedTensorAccessor64<{{ cache_type }}, 1, at::RestrictPtrTraits> grad_dev_weights,
+    {%- endif %}
+    {%- if not nobag and vbe %}
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> B_offsets,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> output_offsets,
     {%- endif %}
     {%- if not nobag %}
     const int32_t info_B_num_bits,

--- a/fbgemm_gpu/include/fbgemm_gpu/embedding_backward_template_helpers.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/embedding_backward_template_helpers.cuh
@@ -79,11 +79,26 @@ __global__
 
 template <typename grad_t>
 __global__ __launch_bounds__(fbgemm_gpu::kMaxThreads) void grad_mean_kernel(
+    at::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits>
+        grad_output_mean,
     const at::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits>
         grad_output,
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         D_offsets,
-
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> offsets,
+    fbgemm_gpu::FixedDivisor fd_B);
+
+template <typename grad_t>
+__global__ __launch_bounds__(fbgemm_gpu::kMaxThreads) void grad_mean_vbe_kernel(
     at::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits>
-        grad_output_mean);
+        grad_output_mean,
+    const at::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits>
+        grad_output,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        D_offsets,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> offsets,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+        grad_offsets,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> b_t_map,
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask);

--- a/fbgemm_gpu/include/fbgemm_gpu/embedding_common.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/embedding_common.h
@@ -82,6 +82,16 @@ inline SparseType getSparseType(at::ScalarType dtype) {
   }
 };
 
+struct VBEMetadata {
+  at::Tensor B_offsets; // torch.int
+  at::Tensor output_offsets_feature_rank; // torch.long
+  at::Tensor B_offsets_rank_per_feature; // torch.int
+  at::Tensor output_offsets; // torch.long
+  at::Tensor b_t_map; // torch.int
+  int32_t max_B_feature_rank;
+  int64_t output_size;
+};
+
 } // namespace fbgemm_gpu
 
 namespace nbit {

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.cuh
@@ -11,6 +11,7 @@
 #include <ATen/ATen.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include "fbgemm_gpu/embedding_common.h"
 
 // These values are adjusted in backward based on B and T
 constexpr int DEFAULT_INFO_NUM_BITS = 32;
@@ -71,3 +72,11 @@ DECL_RADIX_SORT_PAIRS_FN(int64_t, int64_t);
 DECL_RADIX_SORT_PAIRS_FN(int64_t, int32_t);
 
 #undef DECL_RADIX_SORT_PAIRS_FN
+
+void populate_vbe_metadata_foreach_sample_inplace(
+    fbgemm_gpu::VBEMetadata& vbe_metadata,
+    const at::Tensor& D_offsets,
+    const int32_t D,
+    const bool nobag,
+    const int32_t info_B_num_bits,
+    const int64_t total_B);


### PR DESCRIPTION
Summary:
This diff adds the variable length (or variable batch size) support in split TBE training on GPU.

**Usage:**

```
# Initialize TBE as same as previously
emb_op = SplitTableBatchedEmbeddingBagsCodegen(
    embedding_specs=[...],
    ... # other params
)

# batch sizes (one for each FEATURE).
# If `feature_table_map` is None, `len(Bs)` must be as same as `len(embedding_specs)`
# If `feature_table_map` is not None, `len(Bs)` must be as same as `len(feature_table_map)`
Bs = [2, 3, 4, 5]

# Pass a list of batch_sizes to forward.
# !! Make sure to pass batch_sizes as a keyword arg because there can be other keyword args in forward. !!
output = emb_op(indices, offsets, batch_sizes=Bs)
```

**Output**

{F854479754}

**Limitation:**

`T` and `max_B` have to fit in 32 bits.
- We use lower `info_B_num_bits` bits to store `b` (bag ID; `b` < `max_B`).  Supported `max_B` = `2^info_B_num_bits`
- We use upper `32 - info_B_num_bits` bits to store `t` (table ID; `t` < `T`).  Supported `T` = `2^(32 - info_B_num_bits)`

Note that we adjust `info_B_num_bits` automatically at runtime based on `max_B` and `T`.  If they cannot fit into 32 bits, it will abort.

Differential Revision: D43259020

