### PR TITLE
[T145005253] Containerize the remaining FBGEMM_GPU CI jobs

### DIFF
--- a/.github/workflows/fbgemm_gpu_ci.yml
+++ b/.github/workflows/fbgemm_gpu_ci.yml
@@ -6,12 +6,21 @@
 name: FBGEMM_GPU CI
 
 on:
-  push:
-    branches:
-      - main
+  # PR Trigger
+  #
   pull_request:
     branches:
       - main
+
+  # Push Trigger (enable to catch errors coming out of multiple merges)
+  #
+  push:
+    branches:
+      - main
+
+  # Manual Trigger (for testing only)
+  #
+  workflow_dispatch:
 
 concurrency:
   # Cancel previous runs in the PR if a new commit is pushed
@@ -35,7 +44,7 @@ jobs:
       matrix:
         container-image: [ "ubuntu:20.04" ]
         python-version: [ "3.8", "3.9", "3.10" ]
-        rocm-version: [ "5.3" ]
+        rocm-version: [ "5.3", "5.4.2" ]
 
     steps:
     - name: Setup Build Container

--- a/.github/workflows/fbgemm_nightly_build.yml
+++ b/.github/workflows/fbgemm_nightly_build.yml
@@ -48,6 +48,7 @@ jobs:
     env:
       PRELUDE: .github/scripts/setup_env.bash
       BUILD_ENV: build_binary
+    continue-on-error: true
     strategy:
       # Don't fast-fail all the other builds if one of the them fails
       fail-fast: false
@@ -85,8 +86,9 @@ jobs:
     - name: Install CUDA
       run: . $PRELUDE; install_cuda $BUILD_ENV ${{ matrix.cuda-version }}
 
+    # Install via PIP to avoid defaulting to the CPU variant if the GPU variant of the day is not ready
     - name: Install PyTorch Nightly
-      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV nightly
+      run: . $PRELUDE; install_pytorch_pip $BUILD_ENV nightly cuda ${{ matrix.cuda-version }}
 
     - name: Install cuDNN
       run: . $PRELUDE; install_cudnn $BUILD_ENV "$(pwd)/build_only/cudnn" ${{ matrix.cuda-version }}
@@ -106,7 +108,10 @@ jobs:
 
   # Download the built artifact from GHA, test on GPU, and push to PyPI
   test_and_publish_artifact:
-    runs-on: ${{ matrix.os }}
+    runs-on: linux.g5.4xlarge.nvidia.gpu
+    container:
+      image: ${{ matrix.container-image }}
+      options: --user root --gpus all
     defaults:
       run:
         shell: bash
@@ -117,7 +122,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ linux.g5.4xlarge.nvidia.gpu ]
+        container-image: [ "nvidia/cuda:11.8.0-base-ubuntu20.04" ]
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]
         cuda-version: [ "11.7.1", "11.8.0" ]
         # Specify exactly ONE CUDA version for artifact publish
@@ -125,10 +130,21 @@ jobs:
     needs: build_artifact
 
     steps:
+    - name: Setup Build Container
+      run: |
+        apt update -y
+        apt install -y binutils curl git sudo wget
+        git config --global --add safe.directory '*'
+
     - name: Checkout the Repository
       uses: actions/checkout@v3
       with:
         submodules: true
+
+    - name: Download Wheel Artifact from GHA
+      uses: actions/download-artifact@v3
+      with:
+        name: fbgemm_gpu_nightly_${{ matrix.python-version }}_cuda${{ matrix.cuda-version }}.whl
 
     - name: Display System Info
       run: . $PRELUDE; print_system_info; print_ec2_info
@@ -145,21 +161,17 @@ jobs:
     - name: Install CUDA
       run: . $PRELUDE; install_cuda $BUILD_ENV ${{ matrix.cuda-version }}
 
+    # Install via PIP to avoid defaulting to the CPU variant if the GPU variant of the day is not ready
     - name: Install PyTorch Nightly
-      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV nightly
+      run: . $PRELUDE; install_pytorch_pip $BUILD_ENV nightly cuda ${{ matrix.cuda-version }}
 
     - name: Prepare FBGEMM_GPU Build
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
-    - name: Download Wheel Artifact from GHA
-      uses: actions/download-artifact@v3
-      with:
-        name: fbgemm_gpu_nightly_${{ matrix.python-version }}_cuda${{ matrix.cuda-version }}.whl
-
     - name: Install FBGEMM_GPU Nightly
       run: |
         . $PRELUDE
-        ls .
+        pwd; ls -la .
         install_fbgemm_gpu_package $BUILD_ENV *.whl
 
     - name: Test with PyTest

--- a/.github/workflows/fbgemm_nightly_build_cpu.yml
+++ b/.github/workflows/fbgemm_nightly_build_cpu.yml
@@ -49,6 +49,7 @@ jobs:
     env:
       PRELUDE: .github/scripts/setup_env.bash
       BUILD_ENV: build_binary
+    continue-on-error: true
     strategy:
       # Don't fast-fail all the other builds if one of the them fails
       fail-fast: false
@@ -83,7 +84,7 @@ jobs:
       run: . $PRELUDE; install_build_tools $BUILD_ENV
 
     - name: Install PyTorch-CPU Nightly
-      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV nightly cpuonly
+      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV nightly cpu
 
     - name: Prepare FBGEMM_GPU Build
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
@@ -125,6 +126,11 @@ jobs:
       with:
         submodules: true
 
+    - name: Download Wheel Artifact from GHA
+      uses: actions/download-artifact@v3
+      with:
+        name: fbgemm_gpu_nightly_cpu_${{ matrix.python-version }}.whl
+
     - name: Display System Info
       run: . $PRELUDE; print_system_info; print_ec2_info
 
@@ -138,20 +144,15 @@ jobs:
       run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
 
     - name: Install PyTorch Nightly
-      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV nightly cpuonly
+      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV nightly cpu
 
     - name: Prepare FBGEMM_GPU Build
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
-    - name: Download Wheel Artifact from GHA
-      uses: actions/download-artifact@v3
-      with:
-        name: fbgemm_gpu_nightly_cpu_${{ matrix.python-version }}.whl
-
     - name: Install FBGEMM_GPU Nightly (CPU version)
       run: |
         . $PRELUDE
-        ls .
+        pwd; ls -la .
         install_fbgemm_gpu_package $BUILD_ENV *.whl
 
     - name: Test with PyTest

--- a/.github/workflows/fbgemm_release_build.yml
+++ b/.github/workflows/fbgemm_release_build.yml
@@ -40,6 +40,7 @@ jobs:
     env:
       PRELUDE: .github/scripts/setup_env.bash
       BUILD_ENV: build_binary
+    continue-on-error: true
     strategy:
       # Don't fast-fail all the other builds if one of the them fails
       fail-fast: false
@@ -98,7 +99,10 @@ jobs:
 
   # Download the built artifact from GHA, test on GPU, and push to PyPI
   test_and_publish_artifact:
-    runs-on: ${{ matrix.os }}
+    runs-on: linux.g5.4xlarge.nvidia.gpu
+    container:
+      image: ${{ matrix.container-image }}
+      options: --user root --gpus all
     defaults:
       run:
         shell: bash
@@ -109,17 +113,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ linux.g5.4xlarge.nvidia.gpu ]
+        container-image: [ "nvidia/cuda:11.8.0-base-ubuntu20.04" ]
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]
         cuda-version: [ "11.7.1", "11.8.0" ]
         # Specify exactly ONE CUDA version for artifact publish
         cuda-version-publish: [ "11.7.1" ]
     needs: build_artifact
+
     steps:
+    - name: Setup Build Container
+      run: |
+        apt update -y
+        apt install -y binutils curl git sudo wget
+        git config --global --add safe.directory '*'
+
     - name: Checkout the Repository
       uses: actions/checkout@v3
       with:
         submodules: true
+
+    - name: Download Wheel Artifact from GHA
+      uses: actions/download-artifact@v3
+      with:
+        name: fbgemm_gpu_${{ matrix.python-version }}_cuda${{ matrix.cuda-version }}.whl
 
     - name: Display System Info
       run: . $PRELUDE; print_system_info; print_ec2_info
@@ -142,15 +158,10 @@ jobs:
     - name: Prepare FBGEMM_GPU Build
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
-    - name: Download Wheel Artifact from GHA
-      uses: actions/download-artifact@v3
-      with:
-        name: fbgemm_gpu_${{ matrix.python-version }}_cuda${{ matrix.cuda-version }}.whl
-
     - name: Install FBGEMM_GPU
       run: |
         . $PRELUDE
-        ls .
+        pwd; ls -la .
         install_fbgemm_gpu_package $BUILD_ENV *.whl
 
     - name: Test with PyTest

--- a/.github/workflows/fbgemm_release_build_cpu.yml
+++ b/.github/workflows/fbgemm_release_build_cpu.yml
@@ -40,6 +40,7 @@ jobs:
     env:
       PRELUDE: .github/scripts/setup_env.bash
       BUILD_ENV: build_binary
+    continue-on-error: true
     strategy:
       # Don't fast-fail all the other builds if one of the them fails
       fail-fast: false
@@ -74,7 +75,7 @@ jobs:
       run: . $PRELUDE; install_build_tools $BUILD_ENV
 
     - name: Install PyTorch-CPU Test
-      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV test cpuonly
+      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV test cpu
 
     - name: Prepare FBGEMM_GPU Build
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
@@ -116,6 +117,11 @@ jobs:
       with:
         submodules: true
 
+    - name: Download Wheel Artifact from GHA
+      uses: actions/download-artifact@v3
+      with:
+        name: fbgemm_gpu_cpu_${{ matrix.python-version }}.whl
+
     - name: Display System Info
       run: . $PRELUDE; print_system_info; print_ec2_info
 
@@ -129,20 +135,15 @@ jobs:
       run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
 
     - name: Install PyTorch Test
-      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV test cpuonly
+      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV test cpu
 
     - name: Prepare FBGEMM_GPU Build
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
-    - name: Download Wheel Artifact from GHA
-      uses: actions/download-artifact@v3
-      with:
-        name: fbgemm_gpu_cpu_${{ matrix.python-version }}.whl
-
     - name: Install FBGEMM_GPU (CPU version)
       run: |
         . $PRELUDE
-        ls .
+        pwd; ls -la .
         install_fbgemm_gpu_package $BUILD_ENV *.whl
 
     - name: Test with PyTest

--- a/fbgemm_gpu/docs/BuildInstructions.md
+++ b/fbgemm_gpu/docs/BuildInstructions.md
@@ -59,9 +59,11 @@ conda run -n "${env_name}" python -m pip install pyOpenSSL>22.1.0
 
 ### C/C++ Compiler
 
-Install the GCC toolchain.  Note that GCC (as opposed to Clang for example) is
-required for GPU (CUDA) builds because NVIDIA's `nvcc` relies on `gcc` and `g++`
-in the path.
+Install a version of the GCC toolchain that supports **C++17**.  Note that GCC
+(as opposed to Clang for example) is required for GPU (CUDA) builds because
+NVIDIA's `nvcc` relies on `gcc` and `g++` in the path.  The `sysroot` package
+will also need to be installed to avoid issues with missing versioned symbols
+when compiling FBGEMM_CPU:
 
 ```sh
 conda install -n "${env_name}" -y gxx_linux-64=9.3.0


### PR DESCRIPTION
Summary:

- Containerize the remaining FBGEMM_GPU CI jobs
- Add Conda cleanups to make PyTorch and CUDA installs more reliable
- Update post-install checks for PyTorch to work with ROCm
- Update the CI to continue running on jobs that fail on just a few variants
- Use PIP to install PyTorch GPU nightly as the nightly packages show up in PIP more reliably than in Conda