### PR TITLE
Move pruning/index_remapping support to embedding inplace update files

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
@@ -534,44 +534,5 @@ Tensor pruned_array_lookup_cpu(
     return dense_indices;
 }
 
-Tensor pruned_array_lookup_from_row_idx_cpu(
-    Tensor update_row_indices,
-    Tensor update_table_indices,
-    Tensor index_remappings,
-    Tensor index_remappings_offsets) {
-    TENSOR_ON_CPU(update_row_indices);
-    TENSOR_ON_CPU(update_table_indices);
-    TENSOR_ON_CPU(index_remappings);
-    TENSOR_ON_CPU(index_remappings_offsets);
-
-    int32_t T = index_remappings_offsets.size(0) - 1;
-    auto dense_indices = empty_like(update_row_indices);
-    const auto num_indices = update_row_indices.numel();
-
-    AT_DISPATCH_INDEX_TYPES(
-      update_row_indices.scalar_type(), "pruned_array_lookup_from_row_idx_cpu_kernel", [&] {
-        const auto update_row_indices_acc = update_row_indices.accessor<index_t, 1>();
-        auto dense_indices_acc = dense_indices.accessor<index_t, 1>();
-        const auto update_table_indices_acc = update_table_indices.accessor<int32_t, 1>();
-
-        const auto index_remappings_acc = index_remappings.accessor<int32_t, 1>();
-        const auto index_remappings_offsets_acc = index_remappings_offsets.accessor<int64_t, 1>();
-
-        for (int64_t idx = 0; idx < num_indices; idx++) {
-            const int table_idx = update_table_indices_acc[idx];
-            const auto row_idx = update_row_indices_acc[idx];
-            int64_t index_remappings_start = index_remappings_offsets_acc[table_idx];
-            int64_t index_remappings_end = index_remappings_offsets_acc[table_idx + 1];
-            int64_t capacity = index_remappings_end - index_remappings_start;
-            if (capacity > 0) {
-                dense_indices_acc[idx] = index_remappings_acc[index_remappings_start + row_idx];
-            } else {
-                dense_indices_acc[idx] = row_idx;
-            }
-        }
-      });
-    return dense_indices;
-}
-
 {% endif %}
 // clang-format on

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
@@ -558,13 +558,6 @@ Tensor pruned_array_lookup_cuda(
     Tensor index_remappings,
     Tensor index_remappings_offsets);
 
-///@ingroup embedding-cuda
-Tensor pruned_array_lookup_from_row_idx_cuda(
-    Tensor update_row_indices,
-    Tensor update_table_indices,
-    Tensor index_remappings,
-    Tensor index_remappings_offsets);
-
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   DISPATCH_TO_CUDA(
       "int_nbit_split_embedding_codegen_lookup_function",
@@ -576,7 +569,4 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "pruned_hashmap_lookup", pruned_hashmap_lookup_unweighted_cuda);
 
   DISPATCH_TO_CUDA("pruned_array_lookup", pruned_array_lookup_cuda);
-  DISPATCH_TO_CUDA(
-      "pruned_array_lookup_from_row_idx",
-      pruned_array_lookup_from_row_idx_cuda);
 }

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
@@ -240,13 +240,6 @@ Tensor pruned_array_lookup_cpu(
     Tensor index_remappings,
     Tensor index_remappings_offsets);
 
-///@ingroup embedding-cpu
-Tensor pruned_array_lookup_from_row_idx_cpu(
-    Tensor update_row_indices,
-    Tensor update_table_indices,
-    Tensor index_remappings,
-    Tensor index_remappings_offsets);
-
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "int_nbit_split_embedding_codegen_lookup_function(Tensor dev_weights, Tensor uvm_weights, Tensor weights_placements, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, int total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, int max_float32_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, int output_dtype=1, Tensor? lxu_cache_weights=None, Tensor? lxu_cache_locations=None, int? row_alignment = None, int? max_float8_D=0, int? fp8_exponent_bits=-1, int? fp8_exponent_bias=-1) -> Tensor");
@@ -278,12 +271,6 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "pruned_array_lookup(Tensor indices, Tensor offsets, Tensor index_remappings, Tensor index_remappings_offsets) -> Tensor");
   DISPATCH_TO_CPU("pruned_array_lookup", pruned_array_lookup_cpu);
-
-  // GPU version of array lookup.
-  m.def(
-      "pruned_array_lookup_from_row_idx(Tensor update_row_indices, Tensor update_table_indices, Tensor index_remappings, Tensor index_remappings_offsets) -> Tensor");
-  DISPATCH_TO_CPU(
-      "pruned_array_lookup_from_row_idx", pruned_array_lookup_from_row_idx_cpu);
 }
 
 class PrunedMapCPU : public torch::jit::CustomClassHolder {

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_split_template.cu
@@ -552,36 +552,6 @@ __global__ __launch_bounds__(kMaxThreads) void int_nbit_split_embedding_codegen_
 }
 {% endif %}
 
-{% if not weighted %}
-template <typename index_t>
-__global__ __launch_bounds__(kMaxThreads) void int_nbit_split_embedding_codegen_forward_pruned_array_lookup_from_row_idx_kernel(
-    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> update_row_indices,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> update_table_indices,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> index_remappings,
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> index_remappings_offsets,
-    at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> dense_indices) {
-
-  const int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
-  if (idx >= update_row_indices.size(0)) {
-    return;
-  }
-  const int table_idx = update_table_indices[idx];
-  const auto row_idx = update_row_indices[idx];
-
-  const int64_t index_remappings_start = index_remappings_offsets[table_idx];
-  const int64_t index_remappings_end = index_remappings_offsets[table_idx + 1];
-  const int64_t capacity = index_remappings_end - index_remappings_start;
-
-  if (capacity > 0) {
-    dense_indices[idx] = index_remappings[index_remappings_start + row_idx];
-  } else {
-    dense_indices[idx] = row_idx;
-  }
-}
-{% endif %}
-
-
-
 }
 
 {% for nobag in [True, False] %}
@@ -1105,53 +1075,6 @@ Tensor pruned_array_lookup_cuda(
           dense_indices.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>()
   );
   C10_CUDA_KERNEL_LAUNCH_CHECK();
-  return dense_indices;
-}
-
-Tensor pruned_array_lookup_from_row_idx_cuda(
-    Tensor update_row_indices,
-    Tensor update_table_indices,
-    Tensor index_remappings,
-    Tensor index_remappings_offsets) {
-
-  TENSOR_ON_CUDA_GPU(update_row_indices);
-  TENSOR_ON_CUDA_GPU(update_table_indices);
-  TENSOR_ON_CUDA_GPU(index_remappings);
-  TENSOR_ON_CUDA_GPU(index_remappings_offsets);
-
-  at::cuda::OptionalCUDAGuard device_guard;
-  device_guard.set_index(update_table_indices.get_device());
-  auto dense_indices = at::empty_like(update_row_indices);
-  const int32_t T = index_remappings_offsets.size(0) - 1;
-
-  const auto num_indices = update_row_indices.numel();
-  if (num_indices == 0) {
-    return dense_indices;
-  }
-
-  TORCH_CHECK(index_remappings.size(0) < std::numeric_limits<int64_t>::max());
-  TORCH_CHECK(update_row_indices.dim() == 1, "Tensor dim: ", update_row_indices.dim());
-  TORCH_CHECK(update_table_indices.dim() == 1, "Tensor dim: ", update_table_indices.dim());
-  TORCH_CHECK(index_remappings.dim() == 1, "Tensor dim: ", index_remappings.dim());
-  TORCH_CHECK(index_remappings_offsets.dim() == 1, "Tensor dim: ", index_remappings_offsets.dim());
-  TORCH_CHECK(dense_indices.dim() == 1, "Tensor dim: ", dense_indices.dim());
-  constexpr size_t kForwardMaxThreads = 256;
-
-  AT_DISPATCH_INDEX_TYPES(
-      update_row_indices.scalar_type(), "embedding_inplace_update_kernel", [&] {
-        nbit::int_nbit_split_embedding_codegen_forward_pruned_array_lookup_from_row_idx_kernel<<<
-            nbit::div_round_up(num_indices, kForwardMaxThreads),
-            kForwardMaxThreads,
-            0,
-            at::cuda::getCurrentCUDAStream()>>>(
-                update_row_indices.packed_accessor32<index_t, 1, at::RestrictPtrTraits>(),
-                update_table_indices.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
-                index_remappings.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
-                index_remappings_offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
-                dense_indices.packed_accessor32<index_t, 1, at::RestrictPtrTraits>()
-        );
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
-      });
   return dense_indices;
 }
 {% endif %}

--- a/fbgemm_gpu/include/fbgemm_gpu/embedding_inplace_update.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/embedding_inplace_update.h
@@ -75,4 +75,28 @@ void embedding_inplace_update_cpu(
         c10::nullopt // Not used, to match cache interface for CUDA op
 );
 
+/**
+ * Index remapping function that returns the remapped indices.
+ *
+ * Args:
+ *    update_row_indices: row indices for every new row
+ *    update_table_indices: table indices for every new row
+ *    index_remappings: concated index remapping for every embedding table
+ *    index_remappings_offsets: offset for each embedding table
+ *
+ * Returns:
+ *    remapped indices for each new row.
+ */
+Tensor pruned_array_lookup_from_row_idx_cuda(
+    const Tensor& update_row_indices,
+    const Tensor& update_table_indices,
+    const Tensor& index_remappings,
+    const Tensor& index_remappings_offsets);
+
+Tensor pruned_array_lookup_from_row_idx_cpu(
+    const Tensor& update_row_indices,
+    const Tensor& update_table_indices,
+    const Tensor& index_remappings,
+    const Tensor& index_remappings_offsets);
+
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/embedding_inplace_update.cu
+++ b/fbgemm_gpu/src/embedding_inplace_update.cu
@@ -186,4 +186,98 @@ void embedding_inplace_update_cuda(
       });
 }
 
+template <typename index_t>
+__global__
+__launch_bounds__(kMaxThreads) void pruned_array_lookup_from_row_idx_kernel(
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
+        update_row_indices,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        update_table_indices,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        index_remappings,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+        index_remappings_offsets,
+    at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
+        dense_indices) {
+  const int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= update_row_indices.size(0)) {
+    return;
+  }
+  const auto row_idx = update_row_indices[idx];
+  if (idx >= update_table_indices.size(0)) {
+    return;
+  }
+  const int table_idx = update_table_indices[idx];
+
+  const int64_t index_remappings_start = index_remappings_offsets[table_idx];
+  const int64_t index_remappings_end = index_remappings_offsets[table_idx + 1];
+  const int64_t capacity = index_remappings_end - index_remappings_start;
+
+  if (capacity > 0) {
+    dense_indices[idx] = index_remappings[index_remappings_start + row_idx];
+  } else {
+    dense_indices[idx] = row_idx;
+  }
+}
+
+Tensor pruned_array_lookup_from_row_idx_cuda(
+    const Tensor& update_row_indices,
+    const Tensor& update_table_indices,
+    const Tensor& index_remappings,
+    const Tensor& index_remappings_offsets) {
+  TENSOR_ON_CUDA_GPU(update_row_indices);
+  TENSOR_ON_CUDA_GPU(update_table_indices);
+  TENSOR_ON_CUDA_GPU(index_remappings);
+  TENSOR_ON_CUDA_GPU(index_remappings_offsets);
+
+  at::cuda::OptionalCUDAGuard device_guard;
+  device_guard.set_index(update_table_indices.get_device());
+  auto dense_indices = at::empty_like(update_row_indices);
+  const int32_t T = index_remappings_offsets.size(0) - 1;
+
+  const auto num_indices = update_row_indices.numel();
+  if (num_indices == 0) {
+    return dense_indices;
+  }
+
+  TORCH_CHECK(index_remappings.size(0) < std::numeric_limits<int64_t>::max());
+  TORCH_CHECK(
+      update_row_indices.dim() == 1, "Tensor dim: ", update_row_indices.dim());
+  TORCH_CHECK(
+      update_table_indices.dim() == 1,
+      "Tensor dim: ",
+      update_table_indices.dim());
+  TORCH_CHECK(
+      index_remappings.dim() == 1, "Tensor dim: ", index_remappings.dim());
+  TORCH_CHECK(
+      index_remappings_offsets.dim() == 1,
+      "Tensor dim: ",
+      index_remappings_offsets.dim());
+  TORCH_CHECK(dense_indices.dim() == 1, "Tensor dim: ", dense_indices.dim());
+  constexpr size_t kForwardMaxThreads = 256;
+
+  AT_DISPATCH_INDEX_TYPES(
+      update_row_indices.scalar_type(),
+      "pruned_array_lookup_from_row_idx_kernel",
+      [&] {
+        pruned_array_lookup_from_row_idx_kernel<<<
+            nbit::div_round_up(num_indices, kForwardMaxThreads),
+            kForwardMaxThreads,
+            0,
+            at::cuda::getCurrentCUDAStream()>>>(
+            update_row_indices
+                .packed_accessor32<index_t, 1, at::RestrictPtrTraits>(),
+            update_table_indices
+                .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+            index_remappings
+                .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+            index_remappings_offsets
+                .packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
+            dense_indices
+                .packed_accessor32<index_t, 1, at::RestrictPtrTraits>());
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      });
+  return dense_indices;
+}
+
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/embedding_inplace_update_cpu.cpp
+++ b/fbgemm_gpu/src/embedding_inplace_update_cpu.cpp
@@ -116,6 +116,53 @@ void embedding_inplace_update_cpu(
       });
 }
 
+Tensor pruned_array_lookup_from_row_idx_cpu(
+    const Tensor& update_row_indices,
+    const Tensor& update_table_indices,
+    const Tensor& index_remappings,
+    const Tensor& index_remappings_offsets) {
+  TENSOR_ON_CPU(update_row_indices);
+  TENSOR_ON_CPU(update_table_indices);
+  TENSOR_ON_CPU(index_remappings);
+  TENSOR_ON_CPU(index_remappings_offsets);
+
+  auto dense_indices = empty_like(update_row_indices);
+  const auto num_indices = update_row_indices.numel();
+
+  AT_DISPATCH_INDEX_TYPES(
+      update_row_indices.scalar_type(),
+      "pruned_array_lookup_from_row_idx_cpu_kernel",
+      [&] {
+        const auto update_row_indices_acc =
+            update_row_indices.accessor<index_t, 1>();
+        auto dense_indices_acc = dense_indices.accessor<index_t, 1>();
+        const auto update_table_indices_acc =
+            update_table_indices.accessor<int32_t, 1>();
+
+        const auto index_remappings_acc =
+            index_remappings.accessor<int32_t, 1>();
+        const auto index_remappings_offsets_acc =
+            index_remappings_offsets.accessor<int64_t, 1>();
+
+        for (int64_t idx = 0; idx < num_indices; idx++) {
+          const int table_idx = update_table_indices_acc[idx];
+          const auto row_idx = update_row_indices_acc[idx];
+          int64_t index_remappings_start =
+              index_remappings_offsets_acc[table_idx];
+          int64_t index_remappings_end =
+              index_remappings_offsets_acc[table_idx + 1];
+          int64_t capacity = index_remappings_end - index_remappings_start;
+          if (capacity > 0) {
+            dense_indices_acc[idx] =
+                index_remappings_acc[index_remappings_start + row_idx];
+          } else {
+            dense_indices_acc[idx] = row_idx;
+          }
+        }
+      });
+  return dense_indices;
+}
+
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
@@ -126,4 +173,15 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
   DISPATCH_TO_CPU(
       "emb_inplace_update", fbgemm_gpu::embedding_inplace_update_cpu);
+}
+
+TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  m.def(
+      "pruned_array_lookup_from_row_idx(Tensor update_row_indices, Tensor update_table_indices, Tensor index_remappings, Tensor index_remappings_offsets) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
+  DISPATCH_TO_CPU(
+      "pruned_array_lookup_from_row_idx",
+      fbgemm_gpu::pruned_array_lookup_from_row_idx_cpu);
 }

--- a/fbgemm_gpu/src/embedding_inplace_update_gpu.cpp
+++ b/fbgemm_gpu/src/embedding_inplace_update_gpu.cpp
@@ -14,3 +14,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   DISPATCH_TO_CUDA(
       "emb_inplace_update", fbgemm_gpu::embedding_inplace_update_cuda);
 }
+
+TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  DISPATCH_TO_CUDA(
+      "pruned_array_lookup_from_row_idx",
+      fbgemm_gpu::pruned_array_lookup_from_row_idx_cuda);
+}


### PR DESCRIPTION
Summary: As title. This diff moves pruning/index_remapping support to embedding inplace update files.

Reviewed By: jianyuh

Differential Revision: D44409419

