### PR TITLE
[T149188477] Fix the ROCm Test Job

### DIFF
--- a/.github/scripts/setup_env.bash
+++ b/.github/scripts/setup_env.bash
@@ -261,13 +261,27 @@ print_gpu_info () {
       echo "[CHECK] NVIDIA driver is required, but does not appear to have been installed.  This will cause FBGEMM_GPU installation to fail!"
       return 1
     fi
-
   else
     if which nvidia-smi; then
       # If nvidia-smi is installed on a machine without GPUs, this will return error
       (print_exec nvidia-smi) || true
     else
       echo "[CHECK] nvidia-smi not found"
+    fi
+  fi
+
+  if [[ "${ENFORCE_AMD_GPU}" ]]; then
+    # Ensure that nvidia-smi is available and returns GPU entries
+    if ! rocm-smi; then
+      echo "[CHECK] AMD driver is required, but does not appear to have been installed.  This will cause FBGEMM_GPU installation to fail!"
+      return 1
+    fi
+  else
+    if which rocm-smi; then
+      # If nvidia-smi is installed on a machine without GPUs, this will return error
+      (print_exec rocm-smi) || true
+    else
+      echo "[CHECK] rocm-smi not found"
     fi
   fi
 }

--- a/.github/workflows/fbgemm_gpu_ci.yml
+++ b/.github/workflows/fbgemm_gpu_ci.yml
@@ -102,52 +102,70 @@ jobs:
   test_amd_gpu:
     if: ${{ false }}  # Disable the job for now
     runs-on: rocm
+    container:
+      image: "rocm/dev-ubuntu-20.04:${{ matrix.rocm-version }}-complete"
+      options: --user root --device=/dev/kfd --device=/dev/dri --ipc=host --shm-size 16G --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
+    defaults:
+      run:
+        shell: bash
+    env:
+      PRELUDE: .github/scripts/setup_env.bash
+      BUILD_ENV: build_binary
+      ENFORCE_AMD_GPU: 1
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        python-version: [ "3.8", "3.9", "3.10" ]
+        rocm-version: [ "5.3", "5.4.2" ]
 
     steps:
-    - name: pre-checkout
-      shell: bash
+    - name: Setup Build Container
       run: |
-        if [ -d ${{ github.workspace }} ]
-        then
-          sudo chown -R $USER:$USER ${{ github.workspace }}
-        fi
-        sudo add-apt-repository ppa:git-core/ppa
-        sudo apt update
-        sudo apt -y install --only-upgrade git
+        apt update -y
+        apt install -y git rocrand-dev wget
+        git config --global --add safe.directory '*'
 
-    - uses: actions/checkout@v3
+    - name: Checkout the Repository
+      uses: actions/checkout@v3
       with:
-        ref: ${{ github.ref }}
-        submodules: 'true'
+        submodules: true
 
-    - name: build fbgemm_gpu and test
-      shell: bash
+    - name: Display System Info
+      run: . $PRELUDE; print_system_info
+
+    - name: Display GPU Info
+      run: . $PRELUDE; print_gpu_info
+
+    - name: Free Disk Space
+      run: . $PRELUDE; free_disk_space
+
+    - name: Setup Miniconda
+      run: . $PRELUDE; setup_miniconda $HOME/miniconda
+
+    - name: Create Conda Environment
+      run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
+
+    - name: Install Build Tools
+      run: . $PRELUDE; install_build_tools $BUILD_ENV
+
+    - name: Install PyTorch-ROCm Nightly
+      run:  . $PRELUDE; install_pytorch_pip $BUILD_ENV nightly rocm ${{ matrix.rocm-version }}
+
+    - name: Prepare FBGEMM_GPU Build
+      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
+
+    - name: Build FBGEMM_GPU-ROCM Nightly
       run: |
-        set -eux
-        env
-        ls -l
-        DOCKER_IMAGE=rocm/pytorch:rocm5.4_ubuntu20.04_py3.8_pytorch_staging_base
-        docker pull $DOCKER_IMAGE
-        JENKINS_REPO_DIR=fbgemm-private-jenkins
-        JENKINS_REPO_DIR_BAREMETAL=$PWD
-        JENKINS_REPO_DIR_DOCKER=/workspace/$JENKINS_REPO_DIR
-        DOCKER_OPTIONS="\
-        --user 0 \
-        --network=host \
-        --ipc=host \
-        --shm-size 16G \
-        --group-add video \
-        --cap-add=SYS_PTRACE \
-        --security-opt seccomp=unconfined \
-        --device=/dev/kfd \
-        --device=/dev/dri \
-        -v $JENKINS_REPO_DIR_BAREMETAL:$JENKINS_REPO_DIR_DOCKER
-        "
-        docker run $DOCKER_OPTIONS $DOCKER_IMAGE $JENKINS_REPO_DIR_DOCKER/.jenkins/rocm/build_and_test.sh $JENKINS_REPO_DIR_DOCKER
+        . $PRELUDE
+        cd fbgemm_gpu
+
+        # Build for MI250 only to save time.
+        print_exec conda env config vars set -n $BUILD_ENV PYTORCH_ROCM_ARCH=gfx90a
+        print_exec conda run -n $BUILD_ENV python setup.py build develop
+
+    - name: Test FBGEMM_GPU-ROCM Nightly Installation
+      timeout-minutes: 10
+      run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV rocm
 
 
   build_and_test_cpu:

--- a/.github/workflows/fbgemm_gpu_ci.yml
+++ b/.github/workflows/fbgemm_gpu_ci.yml
@@ -86,13 +86,7 @@ jobs:
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
     - name: Build FBGEMM_GPU-ROCM Nightly
-      run: |
-        . $PRELUDE
-        cd fbgemm_gpu
-
-        # Build for MI250 only to save time.
-        print_exec conda env config vars set -n $BUILD_ENV PYTORCH_ROCM_ARCH=gfx90a
-        print_exec conda run -n $BUILD_ENV python setup.py build develop
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_develop $BUILD_ENV rocm gfx90a
 
     - name: Test FBGEMM_GPU-ROCM Nightly Installation
       timeout-minutes: 10
@@ -100,7 +94,6 @@ jobs:
 
 
   test_amd_gpu:
-    if: ${{ false }}  # Disable the job for now
     runs-on: rocm
     container:
       image: "rocm/dev-ubuntu-20.04:${{ matrix.rocm-version }}-complete"
@@ -115,7 +108,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10" ]
+        # ROCm machines are limited, so we only test against Python 3.10
+        python-version: [ "3.10" ]
         rocm-version: [ "5.3", "5.4.2" ]
 
     steps:
@@ -155,13 +149,7 @@ jobs:
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
     - name: Build FBGEMM_GPU-ROCM Nightly
-      run: |
-        . $PRELUDE
-        cd fbgemm_gpu
-
-        # Build for MI250 only to save time.
-        print_exec conda env config vars set -n $BUILD_ENV PYTORCH_ROCM_ARCH=gfx90a
-        print_exec conda run -n $BUILD_ENV python setup.py build develop
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_develop $BUILD_ENV rocm
 
     - name: Test FBGEMM_GPU-ROCM Nightly Installation
       timeout-minutes: 10
@@ -221,6 +209,6 @@ jobs:
     - name: Build + Install FBGEMM_GPU (CPU version)
       run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_install $BUILD_ENV cpu
 
-    - name: Test with PyTest
+    - name: Test FBGEMM_GPU-CPU Nightly Installation
       timeout-minutes: 10
       run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV cpu

--- a/.github/workflows/fbgemm_gpu_ci.yml
+++ b/.github/workflows/fbgemm_gpu_ci.yml
@@ -116,7 +116,7 @@ jobs:
     - name: Setup Build Container
       run: |
         apt update -y
-        apt install -y git rocrand-dev wget
+        apt install -y git wget
         git config --global --add safe.directory '*'
 
     - name: Checkout the Repository
@@ -152,7 +152,7 @@ jobs:
       run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_develop $BUILD_ENV rocm
 
     - name: Test FBGEMM_GPU-ROCM Nightly Installation
-      timeout-minutes: 10
+      timeout-minutes: 15
       run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV rocm
 
 

--- a/.github/workflows/fbgemm_gpu_cuda_nightly.yml
+++ b/.github/workflows/fbgemm_gpu_cuda_nightly.yml
@@ -97,7 +97,7 @@ jobs:
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
     - name: Build FBGEMM_GPU Nightly
-      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_package $BUILD_ENV fbgemm_gpu_nightly
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_package $BUILD_ENV fbgemm_gpu_nightly cuda
 
     - name: Upload Built Wheel as GHA Artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/fbgemm_gpu_cuda_release.yml
+++ b/.github/workflows/fbgemm_gpu_cuda_release.yml
@@ -88,7 +88,7 @@ jobs:
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
     - name: Build FBGEMM_GPU
-      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_package $BUILD_ENV fbgemm_gpu
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_package $BUILD_ENV fbgemm_gpu cuda
 
     - name: Upload Built Wheel as GHA Artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/fbgemm_gpu_lint.yml
+++ b/.github/workflows/fbgemm_gpu_lint.yml
@@ -6,10 +6,14 @@
 name: FBGEMM_GPU Lint
 
 on:
+  # PR Trigger
+  #
   push:
     branches:
       - main
 
+  # Push Trigger (enable to catch errors coming out of multiple merges)
+  #
   pull_request:
     branches:
       - main
@@ -20,11 +24,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run_pylint:
+  run-lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.8" ]
+        python-version: [ "3.10" ]
     steps:
     - uses: actions/checkout@v3
 
@@ -38,7 +42,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install click flake8 ufmt
 
-    - name: Analyzing the code with flake8
+    - name: Analyzing the Code with flake8
       run: |
         echo "::add-matcher::fbgemm_gpu/test/lint/flake8_problem_matcher.json"
         flake8 --ignore=E501,W503,E203 .
@@ -46,13 +50,13 @@ jobs:
         # W503 = line break before binary operator (deprecated)
         # E203 = whitespace before ":"
 
-    - name: Analyzing the code with ufmt
+    - name: Analyzing the Code with ufmt
       run: |
         ufmt diff fbgemm_gpu/fbgemm_gpu
         ufmt diff fbgemm_gpu/test
         ufmt diff fbgemm_gpu/bench
 
-    - name: Check Meta copyright header
+    - name: Check Meta Copyright Header
       run: |
         python fbgemm_gpu/test/lint/check_meta_header.py --path=./fbgemm_gpu/fbgemm_gpu --fixit=False
         python fbgemm_gpu/test/lint/check_meta_header.py --path=./fbgemm_gpu/test --fixit=False

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -344,6 +344,10 @@ if(NOT FBGEMM_CPU_ONLY)
 
   if(NVML_LIB_PATH)
     message(STATUS "Found NVML_LIB_PATH: ${NVML_LIB_PATH}")
+  endif()
+
+  if(NVML_LIB_PATH OR USE_ROCM)
+    message(STATUS "Adding merge_pooled_embeddings sources")
     list(
       APPEND
       fbgemm_gpu_sources_cpu
@@ -351,8 +355,7 @@ if(NOT FBGEMM_CPU_ONLY)
       src/merge_pooled_embeddings_gpu.cpp
       src/topology_utils.cpp)
   else()
-    message(STATUS
-    "Could not find NVML_LIB_PATH; skipping certain sources into the build")
+    message(STATUS "Skipping merge_pooled_embeddings sources")
   endif()
 endif()
 

--- a/fbgemm_gpu/src/jagged_tensor_ops.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops.cu
@@ -1844,7 +1844,7 @@ __global__ __launch_bounds__(kMaxThreads) void jagged_softmax_kernel(
   __shared__ scalar_t exp_sum;
 
   const auto tid = threadIdx.x;
-  for (auto b = blockIdx.y; b < B; b += gridDim.y) {
+  for (uint32_t b = blockIdx.y; b < B; b += gridDim.y) {
     const index_t row_start = offsets[b];
     const index_t row_end = offsets[b + 1];
     const auto length = min(row_end - row_start, (index_t)max_L);
@@ -1853,7 +1853,7 @@ __global__ __launch_bounds__(kMaxThreads) void jagged_softmax_kernel(
       const auto num_l_blocks =
           (length + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
 
-      for (auto d = blockIdx.x; d < D; d += gridDim.x) {
+      for (uint32_t d = blockIdx.x; d < D; d += gridDim.x) {
         if (tid == 0) {
           max_value = values[row_start][d];
           exp_sum = 0;
@@ -1987,7 +1987,7 @@ __global__ __launch_bounds__(kMaxThreads) void jagged_softmax_backward_kernel(
   __shared__ scalar_t sum_value;
 
   const auto tid = threadIdx.x;
-  for (auto b = blockIdx.y; b < B; b += gridDim.y) {
+  for (uint32_t b = blockIdx.y; b < B; b += gridDim.y) {
     const index_t row_start = offsets[b];
     const index_t row_end = offsets[b + 1];
     const auto length = min(row_end - row_start, (index_t)max_L);
@@ -1996,7 +1996,7 @@ __global__ __launch_bounds__(kMaxThreads) void jagged_softmax_backward_kernel(
       const auto num_l_blocks =
           (length + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
 
-      for (auto d = blockIdx.x; d < D; d += gridDim.x) {
+      for (uint32_t d = blockIdx.x; d < D; d += gridDim.x) {
         if (tid == 0) {
           sum_value = 0;
         }

--- a/fbgemm_gpu/src/merge_pooled_embeddings_gpu.cpp
+++ b/fbgemm_gpu/src/merge_pooled_embeddings_gpu.cpp
@@ -20,6 +20,14 @@
 #include "fbgemm_gpu/sparse_ops_utils.h"
 #include "fbgemm_gpu/topology_utils.h"
 
+// For some reason, hipify fails to replace the macro names when compiling for
+// ROCm, so we manually replace it here.  Name mapping based on:
+// https://github.com/pytorch/pytorch/blob/master/torch/utils/hipify/cuda_to_hip_mappings.py
+#ifdef __HIP_PLATFORM_HCC__
+#define C10_CUDA_CLEAR_ERROR C10_HIP_CLEAR_ERROR
+#define C10_CUDA_ERROR_HANDLED C10_HIP_ERROR_HANDLED
+#endif
+
 using Tensor = at::Tensor;
 
 namespace {


### PR DESCRIPTION
Summary:

- Clean up the ROCm test job and re-enable ROCm testing on the rocm instances.  
- Update the build scripts framework to build FBGEMM_GPU against the correct hardware target that it is intended to be tested on.  One thing that was discovered was that if FBGEMM_GPU was built with `PYTORCH_ROCM_ARCH=gfx90a` but run on `gfx908` target, the tests will fail with a segfault.  While the failure is expected, the segfault can be unfriendly and confusing for users.
- Enable correct compilation of `merge_pooled_embeddings` operator under ROCm
- Fix existing code in `jagged_tensor_ops` from PR #1661 and #1662 that break its compilation under ROCm 5.3

CCing @liligwu to this PR since it involves ROCm-related changes