### PR TITLE
Const safety for fbgemm

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_dense_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_dense_host_cpu.cpp
@@ -48,8 +48,8 @@ class SplitLookupFunction_Dense_Op
       int64_t pooling_mode,
       c10::optional<Tensor> indice_weights,
       c10::optional<Tensor> feature_requires_grad) {
-    Tensor indice_weights_value = indice_weights.value_or(Tensor());
-    Tensor feature_requires_grad_value =
+    const Tensor indice_weights_value = indice_weights.value_or(Tensor());
+    const Tensor feature_requires_grad_value =
         feature_requires_grad.value_or(Tensor());
     ctx->save_for_backward({
         host_weights,
@@ -180,7 +180,11 @@ Tensor split_embedding_codegen_lookup_dense_function(
 // Deprecated for fb namespace! Please use fbgemm namespace instead!
 TORCH_LIBRARY_FRAGMENT(fb, m) {
   m.def(
-      "dense_embedding_codegen_lookup_function(Tensor dev_weights, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, int output_dtype=0) -> Tensor");
+      "dense_embedding_codegen_lookup_function(Tensor dev_weights, Tensor "
+      "weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor "
+      "hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor "
+      "offsets, int pooling_mode, Tensor? indice_weights, Tensor? "
+      "feature_requires_grad, int output_dtype=0) -> Tensor");
   DISPATCH_TO_CPU(
       "dense_embedding_codegen_lookup_function",
       split_embedding_codegen_lookup_dense_function);
@@ -188,7 +192,11 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
-      "dense_embedding_codegen_lookup_function(Tensor dev_weights, Tensor weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, int output_dtype=0) -> Tensor");
+      "dense_embedding_codegen_lookup_function(Tensor dev_weights, Tensor "
+      "weights_offsets, Tensor D_offsets, int total_D, int max_D, Tensor "
+      "hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor "
+      "offsets, int pooling_mode, Tensor? indice_weights, Tensor? "
+      "feature_requires_grad, int output_dtype=0) -> Tensor");
   DISPATCH_TO_CPU(
       "dense_embedding_codegen_lookup_function",
       split_embedding_codegen_lookup_dense_function);

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
@@ -66,20 +66,24 @@ DEFINE_quantile_stat(
 DEFINE_int32(
     tbe_uvm_cache_stat_report,
     -1,
-    "If set to a positive number, it enables UVMCacheStats reporting, and this FLAG value is "
+    "If set to a positive number, it enables UVMCacheStats reporting, "
+    "and this FLAG value is "
     "stats collecting period");
 
 DEFINE_int32(
     tbe_uvm_cache_stats_print_out_period,
     -1,
-    "If tbe_uvm_cache_stat_report is enabled, more detailed raw stats will be printed with this "
+    "If tbe_uvm_cache_stat_report is enabled, more detailed raw stats will be "
+    "printed with this "
     "period. This should be an integer multiple of tbe_uvm_cache_stat_report.");
 
 DEFINE_int32(
     tbe_uvm_cache_enforced_misses,
     0,
-    "If set to non-zero, some cache lookups (tbe_uvm_cache_enforced_misses / 256) are enforced to be misses; "
-    "this is performance evaluation purposes only; and should be zero otherwise.");
+    "If set to non-zero, some cache lookups "
+    "(tbe_uvm_cache_enforced_misses / 256) are enforced to be misses; "
+    "this is performance evaluation purposes only; and should be zero "
+    "otherwise.");
 
 // TODO: align this with uvm_cache_stats_index in
 // split_embeddings_cache_cuda.cu.
@@ -120,7 +124,7 @@ void process_uvm_cache_stats(
       // Report cache stats in per-mille.
       {
         // Add cache stats values into the culmulated variables.
-        std::lock_guard<std::mutex> guard(cache_mutex);
+        const std::lock_guard<std::mutex> guard(cache_mutex);
         std::transform(
             uvm_cache_stats_counters.begin(),
             uvm_cache_stats_counters.end(),
@@ -290,7 +294,8 @@ Tensor int_nbit_split_embedding_codegen_lookup_function(
         max_float8_D ? *max_float8_D : 0,
         max_float16_D,
         max_float32_D};
-    int64_t max_D = *std::max_element(max_D_list.begin(), max_D_list.end());
+    const int64_t max_D =
+        *std::max_element(max_D_list.begin(), max_D_list.end());
     return int_nbit_split_embedding_nobag_codegen_forward_unweighted_cuda(
         dev_weights,
         uvm_weights,
@@ -440,10 +445,10 @@ Tensor int_nbit_split_embedding_uvm_caching_codegen_lookup_function(
     Tensor uvm_cache_stats =
         at::empty({0}, lxu_cache_weights.value().options().dtype(at::kInt));
 #ifdef FBCODE_CAFFE2
-    size_t signature = reinterpret_cast<size_t>(uvm_weights.data_ptr());
+    const size_t signature = reinterpret_cast<size_t>(uvm_weights.data_ptr());
     int64_t call_count = 0;
     {
-      std::lock_guard<std::mutex> guard(uvm_cache_stats_mutex);
+      const std::lock_guard<std::mutex> guard(uvm_cache_stats_mutex);
       if (tbe_call_count.count(signature) == 0) {
         tbe_call_count[signature] = 0;
       }

--- a/fbgemm_gpu/src/cpu_utils.cpp
+++ b/fbgemm_gpu/src/cpu_utils.cpp
@@ -28,9 +28,9 @@ void radix_sort_kernel(
     int* histogram,
     int* histogram_ps,
     int pass) {
-  int tid = omp_get_thread_num();
-  int nthreads = omp_get_num_threads();
-  int elements_count_4 = elements_count / 4 * 4;
+  const int tid = omp_get_thread_num();
+  const int nthreads = omp_get_num_threads();
+  const int elements_count_4 = elements_count / 4 * 4;
 
   int* local_histogram = &histogram[RDX_HIST_SIZE * tid];
   int* local_histogram_ps = &histogram_ps[RDX_HIST_SIZE * tid];
@@ -82,10 +82,10 @@ void radix_sort_kernel(
     K key_3 = input_keys[i + 2];
     K key_4 = input_keys[i + 3];
 
-    int bin_1 = (key_1 >> (pass * 8)) & 0xFF;
-    int bin_2 = (key_2 >> (pass * 8)) & 0xFF;
-    int bin_3 = (key_3 >> (pass * 8)) & 0xFF;
-    int bin_4 = (key_4 >> (pass * 8)) & 0xFF;
+    const int bin_1 = (key_1 >> (pass * 8)) & 0xFF;
+    const int bin_2 = (key_2 >> (pass * 8)) & 0xFF;
+    const int bin_3 = (key_3 >> (pass * 8)) & 0xFF;
+    const int bin_4 = (key_4 >> (pass * 8)) & 0xFF;
 
     int pos;
     pos = local_histogram_ps[bin_1]++;
@@ -104,7 +104,7 @@ void radix_sort_kernel(
   if (tid == (nthreads - 1)) {
     for (int64_t i = elements_count_4; i < elements_count; ++i) {
       K key = input_keys[i];
-      int pos = local_histogram_ps[(key >> (pass * 8)) & 0xFF]++;
+      const int pos = local_histogram_ps[(key >> (pass * 8)) & 0xFF]++;
       output_keys[pos] = key;
       output_values[pos] = input_values[i];
     }
@@ -120,14 +120,14 @@ std::pair<K*, V*> radix_sort_parallel(
     V* tmp_value_buf,
     int64_t elements_count,
     int64_t max_value) {
-  int maxthreads = omp_get_max_threads();
+  const int maxthreads = omp_get_max_threads();
   alignas(64) int histogram[RDX_HIST_SIZE * maxthreads];
   alignas(64) int histogram_ps[RDX_HIST_SIZE * maxthreads + 1];
   if (max_value == 0) {
     return std::make_pair(inp_key_buf, inp_value_buf);
   }
-  int num_bits = sizeof(K) * 8 - __builtin_clz(max_value);
-  unsigned int num_passes = (num_bits + 7) / 8;
+  const int num_bits = sizeof(K) * 8 - __builtin_clz(max_value);
+  const unsigned int num_passes = (num_bits + 7) / 8;
 
 #pragma omp parallel
   {

--- a/fbgemm_gpu/src/embedding_inplace_update_cpu.cpp
+++ b/fbgemm_gpu/src/embedding_inplace_update_cpu.cpp
@@ -32,16 +32,16 @@ void embedding_inplace_update_cpu_kernel(
     const at::TensorAccessor<int64_t, 1>& update_offsets,
     int64_t row_alignment) {
   for (int64_t n = 0; n < update_row_idx.size(0); n++) {
-    int32_t t = update_table_idx[n];
+    const int32_t t = update_table_idx[n];
     auto row_idx = update_row_idx[n];
 
-    SparseType weight_ty = static_cast<SparseType>(weights_tys[t]);
+    const SparseType weight_ty = static_cast<SparseType>(weights_tys[t]);
     const int32_t D_start = D_offsets[t];
     const int32_t D_end = D_offsets[t + 1];
     const int32_t D = D_end - D_start;
     const int32_t D_bytes =
         nbit::padded_row_size_in_bytes(D, weight_ty, row_alignment);
-    int64_t weight_offset = weights_offsets[t];
+    const int64_t weight_offset = weights_offsets[t];
 
     uint8_t* __restrict__ weight_row;
     const auto placement = static_cast<PlacementType>(weights_placements[t]);
@@ -57,7 +57,7 @@ void embedding_inplace_update_cpu_kernel(
                static_cast<int64_t>(D_bytes) * static_cast<int64_t>(row_idx)];
     }
 
-    int64_t update_weight_offset = update_offsets[n];
+    const int64_t update_weight_offset = update_offsets[n];
 
     const uint8_t* __restrict__ update_weight_row =
         &update_weights[update_weight_offset];
@@ -94,7 +94,7 @@ void embedding_inplace_update_cpu(
   TENSOR_ON_CPU(update_offsets);
   TENSOR_ON_CPU(update_weights);
 
-  int64_t N = update_row_idx.numel();
+  const int64_t N = update_row_idx.numel();
   if (N == 0) {
     return;
   }
@@ -120,7 +120,12 @@ void embedding_inplace_update_cpu(
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
-      "emb_inplace_update(Tensor(a!) dev_weights, Tensor(b!) uvm_weights, Tensor weights_placements, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, Tensor update_weights, Tensor update_table_indices, Tensor update_row_indices, Tensor update_offsets, int row_alignment=1, Tensor(c!)? lxu_cache_weights=None, Tensor? lxu_cache_locations=None) -> ()");
+      "emb_inplace_update(Tensor(a!) dev_weights, Tensor(b!) uvm_weights, "
+      "Tensor weights_placements, Tensor weights_offsets, Tensor "
+      "weights_tys, Tensor D_offsets, Tensor update_weights, Tensor "
+      "update_table_indices, Tensor update_row_indices, Tensor "
+      "update_offsets, int row_alignment=1, Tensor(c!)? "
+      "lxu_cache_weights=None, Tensor? lxu_cache_locations=None) -> ()");
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {

--- a/fbgemm_gpu/src/input_combine_cpu.cpp
+++ b/fbgemm_gpu/src/input_combine_cpu.cpp
@@ -116,7 +116,7 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_cpu(
   int64_t total_indices = 0;
   int64_t total_offsets = 1;
   bool need_weights = false;
-  bool pin_memory = false;
+  const bool pin_memory = false;
 
   for (size_t i = 0; i < indices_list.size(); i++) {
     TORCH_CHECK(
@@ -195,7 +195,7 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_with_length_cpu(
   int64_t total_indices = 0;
   int64_t total_lengths = 0;
   bool need_weights = false;
-  bool pin_memory = false;
+  const bool pin_memory = false;
 
   for (size_t i = 0; i < indices_list.size(); i++) {
     TORCH_CHECK(
@@ -252,9 +252,9 @@ std::tuple<Tensor, Tensor, Tensor> padding_fused_tbe_input_combine_cpu(
       indices_list.size());
   auto include_last_offsets_acc = include_last_offsets.accessor<bool, 1>();
   int64_t total_indices = 0;
-  int64_t total_offsets = 1 + batch_size * indices_list.size();
+  const int64_t total_offsets = 1 + batch_size * indices_list.size();
   bool need_weights = false;
-  bool pin_memory = false;
+  const bool pin_memory = false;
 
   for (size_t i = 0; i < indices_list.size(); i++) {
     TORCH_CHECK(
@@ -337,9 +337,9 @@ padding_fused_tbe_input_combine_with_length_cpu(
   TORCH_CHECK(lengths_list.size() == indices_list.size());
   TORCH_CHECK(per_sample_weights.size() == indices_list.size());
   int64_t total_indices = 0;
-  int64_t total_lengths = batch_size * indices_list.size();
+  const int64_t total_lengths = batch_size * indices_list.size();
   bool need_weights = false;
-  bool pin_memory = false;
+  const bool pin_memory = false;
 
   for (size_t i = 0; i < indices_list.size(); i++) {
     TORCH_CHECK(
@@ -382,13 +382,20 @@ padding_fused_tbe_input_combine_with_length_cpu(
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
-      "tbe_input_combine(Tensor[] indices_list, Tensor[] offsets_list, Tensor[] per_sample_weights, Tensor include_last_offsets) -> (Tensor, Tensor, Tensor)");
+      "tbe_input_combine(Tensor[] indices_list, Tensor[] offsets_list, "
+      "Tensor[] per_sample_weights, Tensor include_last_offsets) -> (Tensor, "
+      "Tensor, Tensor)");
   m.def(
-      "tbe_input_combine_with_length(Tensor[] indices_list, Tensor[] lengths_list, Tensor[] per_sample_weights) -> (Tensor, Tensor, Tensor)");
+      "tbe_input_combine_with_length(Tensor[] indices_list, Tensor[] "
+      "lengths_list, Tensor[] per_sample_weights) -> (Tensor, Tensor, Tensor)");
   m.def(
-      "padding_fused_tbe_input_combine(Tensor[] indices_list, Tensor[] offsets_list, Tensor[] per_sample_weights, Tensor include_last_offsets, int batch_size) -> (Tensor, Tensor, Tensor)");
+      "padding_fused_tbe_input_combine(Tensor[] indices_list, Tensor[] "
+      "offsets_list, Tensor[] per_sample_weights, Tensor "
+      "include_last_offsets, int batch_size) -> (Tensor, Tensor, Tensor)");
   m.def(
-      "padding_fused_tbe_input_combine_with_length(Tensor[] indices_list, Tensor[] lengths_list, Tensor[] per_sample_weights, int batch_size) -> (Tensor, Tensor, Tensor)");
+      "padding_fused_tbe_input_combine_with_length(Tensor[] indices_list, "
+      "Tensor[] lengths_list, Tensor[] per_sample_weights, int batch_size) "
+      "-> (Tensor, Tensor, Tensor)");
   DISPATCH_TO_CPU("tbe_input_combine", fbgemm_gpu::tbe_input_combine_cpu);
   DISPATCH_TO_CPU(
       "tbe_input_combine_with_length",

--- a/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
@@ -43,7 +43,8 @@ class JaggedToPaddedDenseOp
                 const std::vector<Tensor>& offsets,
                 const std::vector<int64_t>& max_lengths,
                 const double padding_value)>();
-    Tensor padded_values = op.call(values, offsets, max_lengths, padding_value);
+    const Tensor padded_values =
+        op.call(values, offsets, max_lengths, padding_value);
 
     return {padded_values};
   }
@@ -52,7 +53,7 @@ class JaggedToPaddedDenseOp
       torch::autograd::AutogradContext* ctx,
       torch::autograd::variable_list grad_outputs) {
     auto offsets = ctx->get_saved_variables();
-    int32_t total_L = ctx->saved_data["total_L"].toInt();
+    const int32_t total_L = ctx->saved_data["total_L"].toInt();
     TORCH_CHECK(grad_outputs.size() == 1);
 
     TORCH_CHECK(total_L >= 0);
@@ -86,17 +87,17 @@ class JaggedDenseDenseAddJaggedOutputOp
     ctx->save_for_backward(offsets);
     ctx->saved_data["dense_shape"] = dense_0.sizes();
 
-    static auto op =
-        c10::Dispatcher::singleton()
-            .findSchemaOrThrow(
-                "fbgemm::jagged_dense_dense_elementwise_add_jagged_output_forward",
-                "")
-            .typed<at::Tensor(
-                const at::Tensor& x_values,
-                const std::vector<at::Tensor>& x_offsets,
-                const at::Tensor& y_0,
-                const at::Tensor& y_1)>();
-    Tensor output = op.call(x_values, offsets, dense_0, dense_1);
+    static auto op = c10::Dispatcher::singleton()
+                         .findSchemaOrThrow(
+                             "fbgemm::jagged_dense_dense_elementwise_add_"
+                             "jagged_output_forward",
+                             "")
+                         .typed<at::Tensor(
+                             const at::Tensor& x_values,
+                             const std::vector<at::Tensor>& x_offsets,
+                             const at::Tensor& y_0,
+                             const at::Tensor& y_1)>();
+    const Tensor output = op.call(x_values, offsets, dense_0, dense_1);
 
     return {output};
   }
@@ -116,12 +117,12 @@ class JaggedDenseDenseAddJaggedOutputOp
                 const std::vector<Tensor>& offsets,
                 const std::vector<int64_t>& max_lengths,
                 const double padding_value)>();
-    Tensor dense_values_grad_0 = op.call(
+    const Tensor dense_values_grad_0 = op.call(
         grad_outputs[0],
         offsets,
         std::vector<int64_t>(dense_shape.begin() + 1, dense_shape.end() - 1),
         /*padding_value=*/0);
-    Tensor dense_values_grad_1 = dense_values_grad_0;
+    const Tensor dense_values_grad_1 = dense_values_grad_0;
 
     return {
         grad_outputs[0],
@@ -152,7 +153,7 @@ class JaggedDenseMulOp : public torch::autograd::Function<JaggedDenseMulOp> {
                              const Tensor& x_values,
                              const std::vector<Tensor>& x_offsets,
                              const Tensor& y)>();
-    Tensor output = op.call(x_values, x_offsets, y);
+    const Tensor output = op.call(x_values, x_offsets, y);
 
     return {output};
   }
@@ -165,7 +166,7 @@ class JaggedDenseMulOp : public torch::autograd::Function<JaggedDenseMulOp> {
     for (size_t i = 1; i < ctx->get_saved_variables().size() - 1; ++i) {
       x_offsets.push_back(ctx->get_saved_variables()[i]);
     }
-    Tensor y = ctx->get_saved_variables().back();
+    const Tensor y = ctx->get_saved_variables().back();
     TORCH_CHECK(grad_outputs.size() == 1);
 
     static auto op =
@@ -207,7 +208,7 @@ class BatchedDenseVecJagged2DMulOp
                 const Tensor& v,
                 const Tensor& a_values,
                 const Tensor& a_offsets)>();
-    Tensor output = op.call(v, a_values, a_offsets);
+    const Tensor output = op.call(v, a_values, a_offsets);
 
     return {output};
   }
@@ -322,9 +323,9 @@ class JaggedSoftmaxOp : public torch::autograd::Function<JaggedSoftmaxOp> {
       torch::autograd::variable_list grad_outputs) {
     const auto saved = ctx->get_saved_variables();
     auto savedItr = std::begin(saved);
-    Tensor output = *savedItr++;
-    Tensor offsets = *savedItr++;
-    int64_t max_L = ctx->saved_data["max_L"].toInt();
+    const Tensor output = *savedItr++;
+    const Tensor offsets = *savedItr++;
+    const int64_t max_L = ctx->saved_data["max_L"].toInt();
     TORCH_CHECK(grad_outputs.size() == 1);
 
     static auto op =
@@ -376,10 +377,10 @@ class JaggedJaggedBmmOp : public torch::autograd::Function<JaggedJaggedBmmOp> {
       torch::autograd::variable_list grad_outputs) {
     const auto saved = ctx->get_saved_variables();
     auto savedItr = std::begin(saved);
-    Tensor x_values = *savedItr++;
-    Tensor y_values = *savedItr++;
-    Tensor offsets = *savedItr++;
-    int64_t max_L = ctx->saved_data["max_L"].toInt();
+    const Tensor x_values = *savedItr++;
+    const Tensor y_values = *savedItr++;
+    const Tensor offsets = *savedItr++;
+    const int64_t max_L = ctx->saved_data["max_L"].toInt();
     TORCH_CHECK(grad_outputs.size() == 1);
 
     static auto op =
@@ -434,10 +435,10 @@ class JaggedDenseBmmOp : public torch::autograd::Function<JaggedDenseBmmOp> {
       torch::autograd::variable_list grad_outputs) {
     const auto saved = ctx->get_saved_variables();
     auto savedItr = std::begin(saved);
-    Tensor x_values = *savedItr++;
-    Tensor offsets = *savedItr++;
-    Tensor y = *savedItr++;
-    int64_t max_L = ctx->saved_data["max_L"].toInt();
+    const Tensor x_values = *savedItr++;
+    const Tensor offsets = *savedItr++;
+    const Tensor y = *savedItr++;
+    const int64_t max_L = ctx->saved_data["max_L"].toInt();
     TORCH_CHECK(grad_outputs.size() == 1);
 
     static auto op =
@@ -485,11 +486,11 @@ class JaggedIndexSelect2dOp
     TENSORS_ON_SAME_DEVICE(lengths, indices);
     TENSORS_ON_SAME_DEVICE(values, indices);
 
-    Tensor output_lengths = at::index_select(lengths, 0, indices);
-    Tensor output_offsets = output_lengths.cumsum(0);
-    Tensor input_offsets = lengths.cumsum(0);
+    const Tensor output_lengths = at::index_select(lengths, 0, indices);
+    const Tensor output_offsets = output_lengths.cumsum(0);
+    const Tensor input_offsets = lengths.cumsum(0);
 
-    int64_t num_dense_output_rows =
+    const int64_t num_dense_output_rows =
         output_offsets[output_offsets.numel() - 1].item<int64_t>();
 
     ctx->save_for_backward({indices, output_offsets, input_offsets});
@@ -523,16 +524,16 @@ class JaggedIndexSelect2dOp
 
     const auto saved = ctx->get_saved_variables();
     auto savedItr = std::begin(saved);
-    Tensor indices = *savedItr++;
-    Tensor grad_offsets = *savedItr++;
-    Tensor output_offsets = *savedItr++;
-    Tensor grad = grad_outputs[0];
+    const Tensor indices = *savedItr++;
+    const Tensor grad_offsets = *savedItr++;
+    const Tensor output_offsets = *savedItr++;
+    const Tensor grad = grad_outputs[0];
 
     TENSORS_ON_SAME_DEVICE(grad, indices);
 
-    int64_t num_dense_grad_rows =
+    const int64_t num_dense_grad_rows =
         ctx->saved_data["num_dense_grad_rows"].toInt();
-    int64_t num_output_rows = ctx->saved_data["num_input_rows"].toInt();
+    const int64_t num_output_rows = ctx->saved_data["num_input_rows"].toInt();
 
     static auto op =
         c10::Dispatcher::singleton()
@@ -587,7 +588,10 @@ Tensor jagged_dense_elementwise_add(
 
   // Convert x to dense (assume padding is 0.0)
   auto xd = JaggedToPaddedDenseOp::apply(
-      x_values, x_offsets, max_lengths, /* padding_value */ 0.0)[0];
+      x_values,
+      x_offsets,
+      max_lengths,
+      /* padding_value */ 0.0)[0];
 
   auto dense_output = xd + y;
   return dense_output;

--- a/fbgemm_gpu/src/jagged_tensor_ops_meta.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_meta.cpp
@@ -46,7 +46,7 @@ Tensor jagged_to_padded_dense_backward_meta(
     const int64_t total_L) {
   auto grad_padded_values = grad_output;
 
-  int32_t D = grad_padded_values.size(-1);
+  const int32_t D = grad_padded_values.size(-1);
   // Initialize with zeros so output will be zero for the portion truncated
   // in forward.
   auto grad_values = at::zeros({total_L, D}, grad_padded_values.options());
@@ -76,8 +76,8 @@ std::tuple<Tensor, Tensor> jagged_dense_elementwise_add_backward_meta(
     const std::vector<Tensor>& x_offsets,
     const Tensor& y,
     const Tensor& x_values) {
-  Tensor x_values_grad = at::empty_like(grad_output);
-  Tensor y_grad = at::empty_like(y);
+  const Tensor x_values_grad = at::empty_like(grad_output);
+  const Tensor y_grad = at::empty_like(y);
 
   return {x_values_grad, y_grad};
 }
@@ -87,9 +87,9 @@ Tensor dense_to_jagged_forward_meta(
     const std::vector<Tensor>& offsets,
     const c10::optional<int64_t>& total_L) {
   auto dense_values = dense;
-  int32_t D = dense_values.size(-1);
+  const int32_t D = dense_values.size(-1);
   TORCH_CHECK(total_L.has_value(), "total_L is required for meta backend");
-  int64_t total_L_computed = total_L.value();
+  const int64_t total_L_computed = total_L.value();
   auto values = at::zeros({total_L_computed, D}, dense_values.options());
 
   TORCH_CHECK(values.is_meta());
@@ -108,8 +108,8 @@ std::tuple<Tensor, Tensor> jagged_dense_elementwise_mul_backward_meta(
     const std::vector<Tensor>& x_offsets,
     const Tensor& y,
     const Tensor& x_values) {
-  Tensor x_values_grad = at::empty_like(grad_output);
-  Tensor y_grad = at::empty_like(y);
+  const Tensor x_values_grad = at::empty_like(grad_output);
+  const Tensor y_grad = at::empty_like(y);
 
   return {x_values_grad, y_grad};
 }
@@ -143,8 +143,8 @@ std::tuple<Tensor, Tensor> batched_dense_vec_jagged_2d_mul_backward_meta(
     const Tensor& v,
     const Tensor& a_values,
     const Tensor& a_offsets) {
-  Tensor a_values_grad = at::zeros_like(a_values);
-  Tensor v_grad = at::empty_like(v);
+  const Tensor a_values_grad = at::zeros_like(a_values);
+  const Tensor v_grad = at::empty_like(v);
   return {v_grad, a_values_grad};
 }
 

--- a/fbgemm_gpu/src/quantize_ops_cpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops_cpu.cpp
@@ -93,7 +93,8 @@ Tensor _float_to_fusednbitrowwise_cpu(
   const int32_t num_elem_per_byte = 8 / bit_rate;
   TORCH_CHECK(
       ncols % (2 * num_elem_per_byte) == 0,
-      "ncols needs to be multiple of 2 Bytes (half type size) to make the address aligned");
+      "ncols needs to be multiple of 2 Bytes (half type size) to make "
+      "the address aligned");
   const int64_t output_columns =
       (ncols + num_elem_per_byte - 1) / num_elem_per_byte +
       2 * sizeof(at::Half);
@@ -213,7 +214,7 @@ Tensor fused8bitrowwise_to_float_or_half_cpu(
     const int64_t output_dtype) {
   Tensor output;
 
-  SparseType output_sparse_dtype = static_cast<SparseType>(output_dtype);
+  const SparseType output_sparse_dtype = static_cast<SparseType>(output_dtype);
   switch (output_sparse_dtype) {
     case SparseType::FP32:
       output = at::empty({0}, input.options().dtype(at::kFloat));
@@ -265,7 +266,7 @@ Tensor fusednbitrowwise_to_float_or_half_cpu(
     const int64_t output_dtype) {
   Tensor output;
 
-  SparseType output_sparse_dtype = static_cast<SparseType>(output_dtype);
+  const SparseType output_sparse_dtype = static_cast<SparseType>(output_dtype);
   switch (output_sparse_dtype) {
     case SparseType::FP32:
       output = _fusednbitrowwise_to_float_cpu<float>(input, bit_rate);
@@ -405,38 +406,52 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def("FloatToFused8BitRowwiseQuantized(Tensor t) -> Tensor");
   m.def("FloatToFP8RowwiseQuantized(Tensor t, bool forward) -> Tensor");
   m.def(
-      "FloatToFused8BitRowwiseQuantizedOut(Tensor output, Tensor input) -> Tensor");
+      "FloatToFused8BitRowwiseQuantizedOut(Tensor output, Tensor input) -> "
+      "Tensor");
   m.def("HalfToFused8BitRowwiseQuantized(Tensor t) -> Tensor");
   m.def("FloatOrHalfToFused8BitRowwiseQuantized(Tensor t) -> Tensor");
   m.def("Fused8BitRowwiseQuantizedToFloat(Tensor input) -> Tensor");
   m.def("FP8RowwiseQuantizedToFloat(Tensor input, bool forward) -> Tensor");
   m.def("Fused8BitRowwiseQuantizedToHalf(Tensor input) -> Tensor");
   m.def(
-      "Fused8BitRowwiseQuantizedToFloatOrHalf(Tensor input, int output_dtype=0) -> Tensor");
+      "Fused8BitRowwiseQuantizedToFloatOrHalf(Tensor input, int "
+      "output_dtype=0) -> Tensor");
   m.def(
-      "Fused8BitRowwiseQuantizedToFloatOut(Tensor output, Tensor input) -> Tensor");
+      "Fused8BitRowwiseQuantizedToFloatOut(Tensor output, Tensor input) -> "
+      "Tensor");
   m.def(
-      "Fused8BitRowwiseQuantizedToFloatMixedDim(Tensor input, Tensor D_offsets, int output_dtype) -> Tensor");
+      "Fused8BitRowwiseQuantizedToFloatMixedDim(Tensor input, Tensor "
+      "D_offsets, int output_dtype) -> Tensor");
   m.def(
-      "FloatToFusedNBitRowwiseQuantizedSBHalf(Tensor input, int bit_rate) -> Tensor");
+      "FloatToFusedNBitRowwiseQuantizedSBHalf(Tensor input, int bit_rate) -> "
+      "Tensor");
   m.def(
-      "HalfToFusedNBitRowwiseQuantizedSBHalf(Tensor input, int bit_rate) -> Tensor");
+      "HalfToFusedNBitRowwiseQuantizedSBHalf(Tensor input, int bit_rate) -> "
+      "Tensor");
   m.def(
-      "FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf(Tensor input, int bit_rate) -> Tensor");
+      "FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf(Tensor input, int "
+      "bit_rate) -> Tensor");
   m.def(
-      "FusedNBitRowwiseQuantizedSBHalfToFloat(Tensor input, int bit_rate) -> Tensor");
+      "FusedNBitRowwiseQuantizedSBHalfToFloat(Tensor input, int bit_rate) -> "
+      "Tensor");
   m.def(
-      "FusedNBitRowwiseQuantizedSBHalfToHalf(Tensor input, int bit_rate) -> Tensor");
+      "FusedNBitRowwiseQuantizedSBHalfToHalf(Tensor input, int bit_rate) -> "
+      "Tensor");
   m.def(
-      "FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf(Tensor input, int bit_rate, int output_dtype=0) -> Tensor");
+      "FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf(Tensor input, int "
+      "bit_rate, int output_dtype=0) -> Tensor");
   m.def(
-      "FloatToHFP8Quantized(Tensor input, int ebits, int exponent_bias, float max_pos) -> Tensor");
+      "FloatToHFP8Quantized(Tensor input, int ebits, int exponent_bias, "
+      "float max_pos) -> Tensor");
   m.def(
-      "HFP8QuantizedToFloat(Tensor input, int ebits, int exponent_bias) -> Tensor");
+      "HFP8QuantizedToFloat(Tensor input, int ebits, int exponent_bias) -> "
+      "Tensor");
   m.def(
-      "FloatToMSFPQuantized(Tensor input, int bounding_box_size, int ebits, int mbits, int bias, float min_pos, float max_pos) -> Tensor");
+      "FloatToMSFPQuantized(Tensor input, int bounding_box_size, int ebits, "
+      "int mbits, int bias, float min_pos, float max_pos) -> Tensor");
   m.def(
-      "MSFPQuantizedToFloat(Tensor input, int ebits, int mbits, int bias) -> Tensor");
+      "MSFPQuantizedToFloat(Tensor input, int ebits, int mbits, int bias) -> "
+      "Tensor");
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {

--- a/fbgemm_gpu/src/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_cpu.cpp
@@ -94,11 +94,12 @@ void _permute_2D_indices_weights_kernel_cpu(
       0, T * B, FALSE_SHARING_PAD, [&](int64_t tb_begin, int64_t tb_end) {
         offsets_t output_start = output_offsets_per_thread_cumsum
             [at::get_thread_num() * FALSE_SHARING_PAD];
-        int64_t t_begin = tb_begin / B;
-        int64_t t_end = (tb_end + B - 1) / B;
+        int64_t const t_begin = tb_begin / B;
+        int64_t const t_end = (tb_end + B - 1) / B;
         for (const auto t : c10::irange(t_begin, t_end)) {
-          int64_t b_begin = (t == t_begin) ? tb_begin % B : 0;
-          int64_t b_end = (t == t_end - 1 && tb_end % B != 0) ? tb_end % B : B;
+          int64_t const b_begin = (t == t_begin) ? tb_begin % B : 0;
+          int64_t const b_end =
+              (t == t_end - 1 && tb_end % B != 0) ? tb_end % B : B;
           for (const auto b : c10::irange(b_begin, b_end)) {
             offsets_t permuted_length = permuted_lengths[t * B + b];
             const offsets_t input_start = input_offsets[permute[t] * B + b];
@@ -124,7 +125,7 @@ void _permute_2D_lengths_cpu_kernel(
     index_t* const __restrict__ permuted_lengths,
     index_t* const __restrict__ input_offsets,
     int64_t* const __restrict__ output_offsets_per_thread_cumsum) {
-  int num_threads = at::get_num_threads();
+  const int num_threads = at::get_num_threads();
   std::vector<int> input_offsets_per_thread_cumsum(
       (num_threads + 1) * FALSE_SHARING_PAD, 0);
 
@@ -141,11 +142,12 @@ void _permute_2D_lengths_cpu_kernel(
         }
 
         index_t current_output_offset = 0;
-        int64_t t_begin = tb_begin / B;
-        int64_t t_end = (tb_end + B - 1) / B;
+        int64_t const t_begin = tb_begin / B;
+        int64_t const t_end = (tb_end + B - 1) / B;
         for (const auto t : c10::irange(t_begin, t_end)) {
-          int64_t b_begin = (t == t_begin) ? tb_begin % B : 0;
-          int64_t b_end = (t == t_end - 1 && tb_end % B != 0) ? tb_end % B : B;
+          int64_t const b_begin = (t == t_begin) ? tb_begin % B : 0;
+          int64_t const b_end =
+              (t == t_end - 1 && tb_end % B != 0) ? tb_end % B : B;
           for (const auto b : c10::irange(b_begin, b_end)) {
             auto permuted_length = lengths[permute[t] * B + b];
             permuted_lengths[t * B + b] = permuted_length;
@@ -261,8 +263,8 @@ void _block_bucketize_sparse_features_cpu(
         // bucketization can distribute them into different ranks and within
         // range of blk_size, we expect the later embedding module to take care
         // of hashing indices calculation.
-        uindex_t idx = static_cast<uindex_t>(indices_data[i]);
-        uindex_t p = idx < static_cast<uindex_t>(blk_size * my_size)
+        const uindex_t idx = static_cast<uindex_t>(indices_data[i]);
+        const uindex_t p = idx < static_cast<uindex_t>(blk_size * my_size)
             ? idx / blk_size
             : idx % my_size;
         new_lengths_data[p * lengths_size + b_t]++;
@@ -330,7 +332,7 @@ void BFloat16QuantizedToFloat_ref(
     const at::BFloat16* input_elem = input + idx;
     float* output_elem = output + idx;
 
-    uint32_t val_fp32 =
+    const uint32_t val_fp32 =
         static_cast<uint32_t>(*reinterpret_cast<const uint16_t*>(input_elem))
         << 16;
     *reinterpret_cast<uint32_t*>(output_elem) = val_fp32;
@@ -483,7 +485,7 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_2D_sparse_data_cpu(
   const auto lengths_size = lengths.numel();
   auto input_offsets = at::empty({lengths_size + 1}, lengths.options());
 
-  int num_threads = at::get_num_threads();
+  const int num_threads = at::get_num_threads();
   std::vector<int64_t> output_offsets_per_thread_cumsum(
       (num_threads + 1) * FALSE_SHARING_PAD, 0);
 
@@ -647,8 +649,8 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_1D_sparse_data_cpu(
   const auto permuted_lengths_size = permute.numel();
   permuted_lengths = at::empty({permuted_lengths_size}, lengths.options());
 
-  int num_threads = at::get_num_threads();
-  std::vector<int64_t> output_offsets_per_thread_cumsum(
+  const int num_threads = at::get_num_threads();
+  const std::vector<int64_t> output_offsets_per_thread_cumsum(
       (num_threads + 1) * FALSE_SHARING_PAD, 0);
 
   AT_DISPATCH_INDEX_TYPES(
@@ -1881,11 +1883,12 @@ void _permute_data_kernel_cpu(
       0, T * B, FALSE_SHARING_PAD, [&](int64_t tb_begin, int64_t tb_end) {
         index_t output_start = output_offsets_per_thread_cumsum
             [at::get_thread_num() * FALSE_SHARING_PAD];
-        int64_t t_begin = tb_begin / B;
-        int64_t t_end = (tb_end + B - 1) / B;
+        int64_t const t_begin = tb_begin / B;
+        int64_t const t_end = (tb_end + B - 1) / B;
         for (const auto t : c10::irange(t_begin, t_end)) {
-          int64_t b_begin = (t == t_begin) ? tb_begin % B : 0;
-          int64_t b_end = (t == t_end - 1 && tb_end % B != 0) ? tb_end % B : B;
+          int64_t const b_begin = (t == t_begin) ? tb_begin % B : 0;
+          int64_t const b_end =
+              (t == t_end - 1 && tb_end % B != 0) ? tb_end % B : B;
           for (const auto b : c10::irange(b_begin, b_end)) {
             index_t permuted_length = permuted_lengths[t * B + b];
             const index_t input_start = input_offsets[permute[t] * B + b];
@@ -1919,7 +1922,8 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_features_cpu(
 
   TORCH_CHECK(
       lengths.dim() == 2,
-      "The dimension of lengths tensor should be equal to 2 to correctly infer number of features and batch size.");
+      "The dimension of lengths tensor should be equal to 2 to "
+      "correctly infer number of features and batch size.");
 
   const auto permute_contig = permute.expect_contiguous();
   const auto lengths_contig = lengths.expect_contiguous();
@@ -1938,7 +1942,7 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_features_cpu(
   const auto lengths_size = lengths.numel();
   auto input_offsets = at::empty({lengths_size + 1}, lengths.options());
 
-  int num_threads = at::get_num_threads();
+  const int num_threads = at::get_num_threads();
   std::vector<int64_t> output_offsets_per_thread_cumsum(
       (num_threads + 1) * FALSE_SHARING_PAD, 0);
 
@@ -2044,7 +2048,7 @@ void _permute_lengths_cpu_kernel(
     index_t* const __restrict__ permuted_lengths,
     index_t* const __restrict__ input_offsets,
     int64_t* const __restrict__ output_offsets_per_thread_cumsum) {
-  int num_threads = at::get_num_threads();
+  const int num_threads = at::get_num_threads();
   std::vector<int> input_offsets_per_thread_cumsum(
       (num_threads + 1) * FALSE_SHARING_PAD, 0);
 
@@ -2062,11 +2066,12 @@ void _permute_lengths_cpu_kernel(
         }
 
         index_t current_output_offset = 0;
-        int64_t t_begin = tb_begin / B;
-        int64_t t_end = (tb_end + B - 1) / B;
+        int64_t const t_begin = tb_begin / B;
+        int64_t const t_end = (tb_end + B - 1) / B;
         for (const auto t : c10::irange(t_begin, t_end)) {
-          int64_t b_begin = (t == t_begin) ? tb_begin % B : 0;
-          int64_t b_end = (t == t_end - 1 && tb_end % B != 0) ? tb_end % B : B;
+          int64_t const b_begin = (t == t_begin) ? tb_begin % B : 0;
+          int64_t const b_end =
+              (t == t_end - 1 && tb_end % B != 0) ? tb_end % B : B;
           for (const auto b : c10::irange(b_begin, b_end)) {
             auto permuted_length = lengths[permute[t] * B + b];
             permuted_lengths[t * B + b] = permuted_length;
@@ -2130,11 +2135,12 @@ void _permute_embeddings_kernel_cpu(
       0, T * B, FALSE_SHARING_PAD, [&](int64_t tb_begin, int64_t tb_end) {
         index_t output_start = output_offsets_per_thread_cumsum
             [at::get_thread_num() * FALSE_SHARING_PAD];
-        int64_t t_begin = tb_begin / B;
-        int64_t t_end = (tb_end + B - 1) / B;
+        int64_t const t_begin = tb_begin / B;
+        int64_t const t_end = (tb_end + B - 1) / B;
         for (const auto t : c10::irange(t_begin, t_end)) {
-          int64_t b_begin = (t == t_begin) ? tb_begin % B : 0;
-          int64_t b_end = (t == t_end - 1 && tb_end % B != 0) ? tb_end % B : B;
+          int64_t const b_begin = (t == t_begin) ? tb_begin % B : 0;
+          int64_t const b_end =
+              (t == t_end - 1 && tb_end % B != 0) ? tb_end % B : B;
           for (const auto b : c10::irange(b_begin, b_end)) {
             index_t permuted_length = permuted_lengths[t * B + b];
             const index_t input_start = input_offsets[permute[t] * B + b];
@@ -2164,8 +2170,8 @@ std::tuple<Tensor, Tensor> permute_sequence_embeddings_cpu(
 
   Tensor permuted_lengths;
   Tensor permuted_embeddings;
-  c10::optional<Tensor> weights_dummy;
-  c10::optional<int64_t> permuted_lengths_sum_dummy;
+  const c10::optional<Tensor> weights_dummy;
+  const c10::optional<int64_t> permuted_lengths_sum_dummy;
 
   const auto T = permute.numel();
   const auto B = lengths.size(1);
@@ -2217,7 +2223,8 @@ Tensor pack_segments_forward_cpu(
         auto shape = t_in_cont->sizes().vec(); // Get copy of current shape
         shape[0] = max_length; // Set first element to max_len
         shape.insert(
-            shape.begin(), lengths.numel()); // Insert batch size at beginning
+            shape.begin(),
+            lengths.numel()); // Insert batch size at beginning
         packed_tensor = at::zeros(shape, t_in_cont->options());
 
         if (t_in_cont->sizes()[0] == 0) {
@@ -2273,7 +2280,8 @@ Tensor pack_segments_backward_cpu(
       "data must be of type float or double");
   TORCH_CHECK(
       max_length == data.sizes()[1],
-      "max_length should be equal to the second dimension of the packed segments");
+      "max_length should be equal to the second dimension of the "
+      "packed segments");
 
   Tensor unpacked_tensor; // The output tensor
 
@@ -2325,7 +2333,7 @@ class PackSegmentsFunction
       const Tensor& t_in,
       const Tensor& lengths,
       const int64_t max_length) {
-    int64_t total_length = t_in.expect_contiguous()->sizes()[0];
+    const int64_t total_length = t_in.expect_contiguous()->sizes()[0];
     ctx->saved_data["max_length"] = max_length;
     ctx->saved_data["total_length"] = total_length;
     ctx->save_for_backward({lengths});
@@ -2377,7 +2385,7 @@ Tensor index_select_dim0(
 std::vector<Tensor> group_index_select_dim0(
     const std::vector<Tensor>& input_group,
     const std::vector<Tensor>& indices_group) {
-  int num_groups = input_group.size();
+  const int num_groups = input_group.size();
   TORCH_CHECK(num_groups == (int)indices_group.size())
   std::vector<Tensor> output_group;
   for (int i = 0; i < num_groups; i++) {
@@ -2392,7 +2400,7 @@ Tensor bottom_k_per_row(
     const Tensor& k_offsets,
     const bool requires_unique) {
   auto num_cols = input.size(-1);
-  Tensor input_reshaped = input.reshape({-1, num_cols});
+  const Tensor input_reshaped = input.reshape({-1, num_cols});
   auto input_accessor = input_reshaped.accessor<int64_t, 2>();
   auto k_offsets_accessor = k_offsets.accessor<int64_t, 1>();
 
@@ -2402,7 +2410,7 @@ Tensor bottom_k_per_row(
       use_fixed_k ? k_offsets_accessor[1] - k_offsets_accessor[0] : 0;
 
   // Create output tensor
-  Tensor output = at::empty(
+  const Tensor output = at::empty(
       {use_fixed_k ? input_reshaped.size(0) * fixed_k
                    : k_offsets_accessor[k_offsets.numel() - 1]},
       input.options());
@@ -2434,7 +2442,7 @@ Tensor bottom_k_per_row(
                 s.size() == static_cast<size_t>(k),
                 "too skewed distribution (alpha too big)")
             int j = 0;
-            for (int64_t x : s) {
+            for (int64_t const x : s) {
               output_accessor[start_k_offset + j] = x;
               ++j;
             }
@@ -2455,49 +2463,82 @@ Tensor bottom_k_per_row(
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
-      "permute_sparse_data(Tensor permute, Tensor lengths, Tensor values, Tensor? weights=None, int? permuted_lengths_sum=None) -> (Tensor, Tensor, Tensor?)");
+      "permute_sparse_data(Tensor permute, Tensor lengths, Tensor values, "
+      "Tensor? weights=None, int? permuted_lengths_sum=None) -> (Tensor, "
+      "Tensor, Tensor?)");
   m.def(
-      "permute_2D_sparse_data(Tensor permute, Tensor lengths, Tensor values, Tensor? weights=None, int? permuted_lengths_sum=None) -> (Tensor, Tensor, Tensor?)");
+      "permute_2D_sparse_data(Tensor permute, Tensor lengths, Tensor values, "
+      "Tensor? weights=None, int? permuted_lengths_sum=None) -> (Tensor, "
+      "Tensor, Tensor?)");
   m.def(
-      "permute_1D_sparse_data(Tensor permute, Tensor lengths, Tensor values, Tensor? weights=None, int? permuted_lengths_sum=None) -> (Tensor, Tensor, Tensor?)");
+      "permute_1D_sparse_data(Tensor permute, Tensor lengths, Tensor values, "
+      "Tensor? weights=None, int? permuted_lengths_sum=None) -> (Tensor, "
+      "Tensor, Tensor?)");
   m.def("invert_permute(Tensor permute) -> Tensor");
   m.def(
-      "expand_into_jagged_permute(Tensor permute, Tensor input_offset, Tensor output_offset, int output_size) -> Tensor");
+      "expand_into_jagged_permute(Tensor permute, Tensor input_offset, "
+      "Tensor output_offset, int output_size) -> Tensor");
   m.def(
-      "block_bucketize_sparse_features(Tensor lengths, Tensor indices, bool bucketize_pos, bool sequence, Tensor block_sizes, int my_size, Tensor? weights=None) -> (Tensor, Tensor, Tensor?, Tensor?, Tensor?)");
+      "block_bucketize_sparse_features(Tensor lengths, Tensor indices, bool "
+      "bucketize_pos, bool sequence, Tensor block_sizes, int my_size, "
+      "Tensor? weights=None) -> (Tensor, Tensor, Tensor?, Tensor?, Tensor?)");
   m.def(
-      "bucketize_sparse_features(Tensor lengths, Tensor indices, bool bucketize_pos, int my_size, Tensor? weights=None) -> (Tensor, Tensor, Tensor?, Tensor?)");
+      "bucketize_sparse_features(Tensor lengths, Tensor indices, bool "
+      "bucketize_pos, int my_size, Tensor? weights=None) -> (Tensor, Tensor, "
+      "Tensor?, Tensor?)");
   m.def("asynchronous_exclusive_cumsum(Tensor t_in) -> Tensor");
   m.def("asynchronous_inclusive_cumsum(Tensor t_in) -> Tensor");
   m.def("asynchronous_complete_cumsum(Tensor t_in) -> Tensor");
   m.def(
-      "reorder_batched_ad_lengths(Tensor cat_ad_lengths, Tensor batch_offsets, int num_ads_in_batch) -> Tensor");
+      "reorder_batched_ad_lengths(Tensor cat_ad_lengths, Tensor "
+      "batch_offsets, int num_ads_in_batch) -> Tensor");
   m.def(
-      "reorder_batched_ad_indices(Tensor cat_ad_offsets, Tensor cat_ad_indices, Tensor reordered_cat_ad_offsets, Tensor batch_offsets, int num_ads_in_batch) -> Tensor");
+      "reorder_batched_ad_indices(Tensor cat_ad_offsets, Tensor "
+      "cat_ad_indices, Tensor reordered_cat_ad_offsets, Tensor "
+      "batch_offsets, int num_ads_in_batch) -> Tensor");
   m.def("offsets_range(Tensor offsets, int range_size) -> Tensor");
   m.def(
-      "batched_unary_embeddings(Tensor weight, Tensor table_offsets, Tensor offsets, Tensor indices) -> Tensor");
+      "batched_unary_embeddings(Tensor weight, Tensor table_offsets, Tensor "
+      "offsets, Tensor indices) -> Tensor");
   m.def(
-      "histogram_binning_calibration(Tensor logit, Tensor bin_num_examples, Tensor bin_num_positives, float positive_weight, float lower_bound, float upper_bound, int bin_ctr_in_use_after, float bin_ctr_weight_value) -> (Tensor, Tensor)");
+      "histogram_binning_calibration(Tensor logit, Tensor bin_num_examples, "
+      "Tensor bin_num_positives, float positive_weight, float lower_bound, "
+      "float upper_bound, int bin_ctr_in_use_after, float "
+      "bin_ctr_weight_value) -> (Tensor, Tensor)");
   m.def(
-      "histogram_binning_calibration_by_feature(Tensor logit, Tensor segment_value, Tensor segment_lengths, int num_segments, Tensor bin_num_examples, Tensor bin_num_positives, int num_bins, float positive_weight, float lower_bound, float upper_bound, int bin_ctr_in_use_after, float bin_ctr_weight_value) -> (Tensor, Tensor)");
+      "histogram_binning_calibration_by_feature(Tensor logit, Tensor "
+      "segment_value, Tensor segment_lengths, int num_segments, Tensor "
+      "bin_num_examples, Tensor bin_num_positives, int num_bins, float "
+      "positive_weight, float lower_bound, float upper_bound, int "
+      "bin_ctr_in_use_after, float bin_ctr_weight_value) -> (Tensor, Tensor)");
   m.def(
-      "generic_histogram_binning_calibration_by_feature(Tensor logit, Tensor segment_value, Tensor segment_lengths, int num_segments, Tensor bin_num_examples, Tensor bin_num_positives, Tensor bin_boundaries, float positive_weight, int bin_ctr_in_use_after, float bin_ctr_weight_value) -> (Tensor, Tensor)");
+      "generic_histogram_binning_calibration_by_feature(Tensor logit, Tensor "
+      "segment_value, Tensor segment_lengths, int num_segments, Tensor "
+      "bin_num_examples, Tensor bin_num_positives, Tensor bin_boundaries, "
+      "float positive_weight, int bin_ctr_in_use_after, float "
+      "bin_ctr_weight_value) -> (Tensor, Tensor)");
   m.def(
-      "segment_sum_csr(int batch_size, Tensor csr_seg, Tensor values) -> Tensor");
+      "segment_sum_csr(int batch_size, Tensor csr_seg, Tensor values) -> "
+      "Tensor");
   m.def(
-      "embedding_bag_rowwise_prune(Tensor weight, Tensor indicator, float threshold, ScalarType compressed_indices_dtype, bool abs=True, int min_num_rows=0, float? min_save_ratio=1.0) -> (Tensor, Tensor)");
+      "embedding_bag_rowwise_prune(Tensor weight, Tensor indicator, float "
+      "threshold, ScalarType compressed_indices_dtype, bool abs=True, int "
+      "min_num_rows=0, float? min_save_ratio=1.0) -> (Tensor, Tensor)");
   m.def("lengths_range(Tensor t_in, int[]? shape=None) -> Tensor");
   m.def(
-      "lengths_range_out(Tensor output, Tensor t_in, int[]? shape=None) -> Tensor");
+      "lengths_range_out(Tensor output, Tensor t_in, int[]? shape=None) -> "
+      "Tensor");
   m.def(
-      "permute_sparse_features(Tensor permute, Tensor lengths, Tensor indices, Tensor? weights=None) -> (Tensor, Tensor, Tensor?)");
+      "permute_sparse_features(Tensor permute, Tensor lengths, Tensor "
+      "indices, Tensor? weights=None) -> (Tensor, Tensor, Tensor?)");
   m.def("Bfloat16QuantizedToFloat(Tensor input) -> Tensor");
   m.def("FloatToBfloat16Quantized(Tensor input) -> Tensor");
   m.def(
-      "permute102_baddbmm_permute102(Tensor bias, Tensor A, Tensor B) -> Tensor");
+      "permute102_baddbmm_permute102(Tensor bias, Tensor A, Tensor B) -> "
+      "Tensor");
   m.def(
-      "permute_sequence_embeddings(Tensor permute, Tensor lengths, Tensor embeddings) -> (Tensor, Tensor)");
+      "permute_sequence_embeddings(Tensor permute, Tensor lengths, Tensor "
+      "embeddings) -> (Tensor, Tensor)");
   m.def("pack_segments(Tensor t_in, Tensor lengths, int max_length) -> Tensor");
   // A specialization of at::index_select for selecting dim 0
   //
@@ -2517,9 +2558,12 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   //
   // skip_indices_sorting_fwd is for skipping indices sorting in forward
   m.def(
-      "index_select_dim0(Tensor input, Tensor indices, int? consecutive_range_start=0, int? consecutive_range_length=0, bool? skip_indices_sorting_fwd=None) -> Tensor");
+      "index_select_dim0(Tensor input, Tensor indices, int? "
+      "consecutive_range_start=0, int? consecutive_range_length=0, bool? "
+      "skip_indices_sorting_fwd=None) -> Tensor");
   m.def(
-      "group_index_select_dim0(Tensor[] input_group, Tensor[] indices_group) -> Tensor[]");
+      "group_index_select_dim0(Tensor[] input_group, Tensor[] indices_group) "
+      "-> Tensor[]");
   // This is an one-off op to be used in split_embedding_utils.py for zipf
   // generation w/o replacement along dim=-1. If requires_unique=True, find
   // smallest unique k.  If the number of unique elements is less than k,
@@ -2528,9 +2572,12 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   // 2 instead of 1 to trigger the fixed-k assumption to keep the k_offsets
   // semantic).
   m.def(
-      "bottom_k_per_row(Tensor input, Tensor k_offsets, bool requires_unique) -> Tensor");
+      "bottom_k_per_row(Tensor input, Tensor k_offsets, bool "
+      "requires_unique) -> Tensor");
   m.def(
-      "keyed_jagged_index_select_dim1(Tensor values, Tensor lengths, Tensor offsets, Tensor indices, int batch_size, Tensor? weights=None) -> Tensor[]");
+      "keyed_jagged_index_select_dim1(Tensor values, Tensor lengths, Tensor "
+      "offsets, Tensor indices, int batch_size, Tensor? weights=None) -> "
+      "Tensor[]");
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {

--- a/fbgemm_gpu/test/cpu_kernel_test.cpp
+++ b/fbgemm_gpu/test/cpu_kernel_test.cpp
@@ -33,8 +33,8 @@ TEST(cpu_kernel_test, radix_sort_parallel_test) {
       keys.size(),
       10);
 
-  std::array<int, 8> expect_keys_tmp = {1, 2, 2, 3, 4, 4, 5, 9};
-  std::array<int, 8> expect_values_tmp = {0, 0, 1, 1, 0, 1, 0, 1};
+  const std::array<int, 8> expect_keys_tmp = {1, 2, 2, 3, 4, 4, 5, 9};
+  const std::array<int, 8> expect_values_tmp = {0, 0, 1, 1, 0, 1, 0, 1};
   EXPECT_EQ(sorted_keys, keys_tmp.data());
   EXPECT_EQ(sorted_values, values_tmp.data());
   EXPECT_EQ(keys_tmp, expect_keys_tmp);
@@ -43,12 +43,12 @@ TEST(cpu_kernel_test, radix_sort_parallel_test) {
 
 TEST(cpu_kernel_test, csr2csc_test) {
   internal::HyperCompressedSparseColumn csc;
-  int B = 2;
-  at::Tensor offsets = torch::tensor({0, 4, 8});
-  at::Tensor indices = torch::tensor({1, 2, 4, 5, 4, 3, 2, 9});
-  int64_t pooling_mode = (int64_t)fbgemm_gpu::PoolingMode::SUM;
+  const int B = 2;
+  at::Tensor const offsets = torch::tensor({0, 4, 8});
+  at::Tensor const indices = torch::tensor({1, 2, 4, 5, 4, 3, 2, 9});
+  const int64_t pooling_mode = (int64_t)fbgemm_gpu::PoolingMode::SUM;
   int table_to_feature_offset[2] = {0, 1};
-  int num_embeddings = 10;
+  const int num_embeddings = 10;
 
   ::internal::csr2csc(
       csc,
@@ -82,7 +82,7 @@ TEST(cpu_kernel_test, csr2csc_test) {
   }
 
   internal::HyperCompressedSparseColumn csc_weighted;
-  at::Tensor indice_weights = torch::tensor(
+  at::Tensor const indice_weights = torch::tensor(
       {1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f}, torch::kFloat32);
   ::internal::csr2csc(
       csc_weighted,

--- a/fbgemm_gpu/test/embedding_inplace_update_test.cpp
+++ b/fbgemm_gpu/test/embedding_inplace_update_test.cpp
@@ -19,14 +19,14 @@ int32_t get_D_bytes(
   const int32_t D_start = D_offsets[table_idx].item<int32_t>();
   const int32_t D_end = D_offsets[table_idx + 1].item<int32_t>();
   const int32_t D = D_end - D_start;
-  SparseType weight_ty =
+  const SparseType weight_ty =
       static_cast<SparseType>(weights_tys[table_idx].item<uint8_t>());
   return nbit::padded_row_size_in_bytes(D, weight_ty, row_alignment);
 }
 
 template <typename index_t>
 void test_embedding_inplace_update() {
-  int T = folly::Random::rand32() % 3 + 2; // total number of tables
+  const int T = folly::Random::rand32() % 3 + 2; // total number of tables
   std::vector<SparseType> weight_ty_list = {
       SparseType::FP32,
       SparseType::FP16,
@@ -46,12 +46,12 @@ void test_embedding_inplace_update() {
     SparseType weight_ty =
         weight_ty_list[folly::Random::rand32() % weight_ty_list.size()];
     weights_tys.push_back(uint8_t(weight_ty));
-    int D = 1 << (1 + folly::Random::rand32() % 5); // table dimension
-    int32_t D_bytes = nbit::padded_row_size_in_bytes(D, weight_ty, 16);
-    int total_rows = 10 + folly::Random::rand32() % 50;
+    const int D = 1 << (1 + folly::Random::rand32() % 5); // table dimension
+    const int32_t D_bytes = nbit::padded_row_size_in_bytes(D, weight_ty, 16);
+    const int total_rows = 10 + folly::Random::rand32() % 50;
     D_offsets.push_back(D_offsets.back() + D);
 
-    int32_t weights_placement = folly::Random::rand32() % 2;
+    const int32_t weights_placement = folly::Random::rand32() % 2;
     weights_placements.push_back(weights_placement);
     if (weights_placement == 0) {
       weights_offsets.push_back(dev_weights_offset);
@@ -60,13 +60,13 @@ void test_embedding_inplace_update() {
       weights_offsets.push_back(uvm_weights_offset);
       uvm_weights_offset += D_bytes * total_rows;
     }
-    int n = folly::Random::rand32() % 10 + 5;
+    const int n = folly::Random::rand32() % 10 + 5;
     std::set<int32_t> rows;
     for (int j = 0; j < n; j++) {
       rows.insert(folly::Random::rand32() % total_rows);
     }
     std::string update_row_idx_str = "";
-    for (int32_t r : rows) {
+    for (const int32_t r : rows) {
       update_table_idx.push_back(i);
       update_row_idx.push_back(r);
       update_size += D_bytes;
@@ -80,9 +80,9 @@ void test_embedding_inplace_update() {
               << ", update rows: " << update_row_idx_str;
   }
 
-  bool use_cpu = folly::Random::rand32() % 2;
+  const bool use_cpu = folly::Random::rand32() % 2;
   auto device = use_cpu ? at::kCPU : at::kCUDA;
-  int64_t row_alignment = use_cpu ? 1L : 16L;
+  const int64_t row_alignment = use_cpu ? 1L : 16L;
 
   auto dev_weight = at::randint(
       0, 255, {dev_weights_offset}, at::device(device).dtype(at::kByte));
@@ -100,7 +100,7 @@ void test_embedding_inplace_update() {
   int64_t update_offset = 0;
   update_offsets.push_back(0);
   for (int i = 0; i < update_table_idx.size(); ++i) {
-    int32_t idx = update_table_idx[i];
+    const int32_t idx = update_table_idx[i];
     update_offset +=
         get_D_bytes(D_offsets_tensor, weights_tys_tensor, idx, row_alignment);
     update_offsets.push_back(update_offset);
@@ -153,8 +153,8 @@ void test_embedding_inplace_update() {
     auto weight_offset = weights_offsets[table_idx];
     auto weight_placement = weights_placements[table_idx];
     auto D = D_offsets[table_idx + 1] - D_offsets[table_idx];
-    SparseType ty = static_cast<SparseType>(weights_tys[table_idx]);
-    int32_t D_bytes = nbit::padded_row_size_in_bytes(D, ty, 16);
+    const SparseType ty = static_cast<SparseType>(weights_tys[table_idx]);
+    const int32_t D_bytes = nbit::padded_row_size_in_bytes(D, ty, 16);
     auto dev_weight_acc = dev_weight_cpu.data_ptr<uint8_t>();
     auto uvm_weight_acc = uvm_weight_cpu.data_ptr<uint8_t>();
     auto update_weight_acc = update_weight_cpu.data_ptr<uint8_t>();

--- a/fbgemm_gpu/test/tensor_assert_test.cpp
+++ b/fbgemm_gpu/test/tensor_assert_test.cpp
@@ -11,7 +11,7 @@
 #include "fbgemm_gpu/sparse_ops_utils.h"
 
 TEST(tensor_assert_test, gpu_asserts) {
-  at::Tensor on_cpu_empty;
+  at::Tensor const on_cpu_empty;
 
   ASSERT_EQ(on_cpu_empty.numel(), 0);
   EXPECT_NO_THROW(TENSOR_EMPTY_OR_ON_CPU(on_cpu_empty));

--- a/fbgemm_gpu/test/uvm_cache_miss_emulate_test.cpp
+++ b/fbgemm_gpu/test/uvm_cache_miss_emulate_test.cpp
@@ -29,7 +29,7 @@ std::pair<at::Tensor, at::Tensor> run_emulate_cache_miss(
     at::Tensor lxu_cache_locations,
     const int64_t enforced_misses_per_256,
     const bool gather_uvm_stats = false) {
-  at::Tensor lxu_cache_locations_copy = at::_to_copy(lxu_cache_locations);
+  at::Tensor const lxu_cache_locations_copy = at::_to_copy(lxu_cache_locations);
   const auto options =
       lxu_cache_locations.options().device(at::kCUDA).dtype(at::kInt);
   const auto uvm_cache_stats =
@@ -96,7 +96,7 @@ TEST(uvm_cache_miss_emulate_test, enforced_cache_miss) {
             enforced_misses++;
           }
         }
-        int64_t num_requests_over_256 =
+        const int64_t num_requests_over_256 =
             static_cast<int64_t>(num_requests / 256);
         int64_t expected_misses = num_requests_over_256 *
                 enforced_misses_per_256 +


### PR DESCRIPTION
Summary: Uses LLVM-15's `misc-const-correctness` linter to add `const`. I've tried to make these left-const, but haven't been successful in all cases.

Differential Revision: D44394692

