### PR TITLE
Prune CPU/GPU TBE optimizer codegen

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -105,7 +105,6 @@ set(OPTIMIZERS
     adagrad
     adam
     approx_rowwise_adagrad
-    approx_rowwise_adagrad_with_weight_decay
     approx_rowwise_adagrad_with_counter
     approx_sgd
     lamb
@@ -113,7 +112,6 @@ set(OPTIMIZERS
     partial_rowwise_adam
     partial_rowwise_lamb
     rowwise_adagrad
-    rowwise_adagrad_with_weight_decay
     rowwise_adagrad_with_counter
     rowwise_weighted_adagrad
     sgd)
@@ -146,10 +144,12 @@ foreach(optimizer ${OPTIMIZERS})
   list(APPEND gen_cpu_source_files
        "gen_embedding_backward_${optimizer}_split_cpu.cpp")
 
-  list(APPEND gen_python_files "${CMAKE_BINARY_DIR}/lookup_${optimizer}.py")
+  list(APPEND gen_python_files
+       "${CMAKE_BINARY_DIR}/lookup_${optimizer}.py")
 
   foreach(weight weighted unweighted)
-    list(APPEND gen_gpu_source_files
+    list(APPEND
+         gen_gpu_source_files
          "gen_embedding_backward_${optimizer}_split_${weight}_cuda.cu")
   endforeach()
 endforeach()

--- a/fbgemm_gpu/codegen/embedding_backward_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_backward_code_generator.py
@@ -369,6 +369,8 @@ def adagrad() -> None:
         split_precomputation="",
         split_weight_update=split_weight_update,
         split_weight_update_cpu=split_weight_update_cpu,
+        has_cpu_support=True,
+        has_gpu_support=True,
     )
 
 
@@ -490,6 +492,8 @@ def rowwise_adagrad() -> None:
         split_precomputation=split_precomputation,
         split_weight_update=split_weight_update,
         split_weight_update_cpu=split_weight_update_cpu,
+        has_cpu_support=True,
+        has_gpu_support=True,
     )
 
     approx_split_weight_update = """
@@ -512,127 +516,8 @@ def rowwise_adagrad() -> None:
         split_precomputation=split_precomputation,
         split_weight_update=approx_split_weight_update,
         split_weight_update_cpu=split_weight_update_cpu,
-    )
-
-
-def rowwise_adagrad_with_weight_decay() -> None:
-    split_weight_update = """
-        weight_new.acc.x = correction * weight_new.acc.x - multiplier * grad.acc.x;
-        weight_new.acc.y = correction * weight_new.acc.y - multiplier * grad.acc.y;
-        weight_new.acc.z = correction * weight_new.acc.z - multiplier * grad.acc.z;
-        weight_new.acc.w = correction * weight_new.acc.w - multiplier * grad.acc.w;
-    """
-    split_precomputation = """
-    at::acc_type<cache_t, true> g_local_sum_square = 0.0;
-    #pragma unroll kMaxVecsPerThread
-    for (int32_t i = 0;
-        i < kMaxVecsPerThread && 4 * kThreadGroupSize * i + threadIdx.x * 4 < D;
-        ++i) {
-        auto gx = grad_sum[i].acc.x;
-        auto gy = grad_sum[i].acc.y;
-        auto gz = grad_sum[i].acc.z;
-        auto gw = grad_sum[i].acc.w;
-        if (weight_decay_mode == 1) {
-            // L2 regularization
-            int32_t d = 4 * kThreadGroupSize * i + threadIdx.x * 4;
-            Vec4T<at::acc_type<cache_t, true>> weight = weight_row_template.load(d, qparams_template);
-            gx += weight_decay * weight.acc.x;
-            gy += weight_decay * weight.acc.y;
-            gz += weight_decay * weight.acc.z;
-            gw += weight_decay * weight.acc.w;
-        }
-        g_local_sum_square += gx * gx + gy * gy + gz * gz + gw * gw;
-    }
-    const at::acc_type<cache_t, true> g_avg_square =
-        warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(g_local_sum_square, shfl_sync_mask) / D;
-
-    at::acc_type<cache_t, true> multiplier;
-    at::acc_type<cache_t, true> correction;
-    if (threadIdx.x == 0) {
-        at::acc_type<cache_t, true> new_sum_square_grads = momentum1[idx] + g_avg_square;
-        momentum1[idx] = new_sum_square_grads;
-        multiplier = learning_rate / (sqrtf(new_sum_square_grads) + eps);
-        if (weight_decay_mode == 1) {
-            // L2 regularization
-            correction = 1.0 - multiplier * weight_decay;
-        } else if (weight_decay_mode == 2) {
-            // Decoupled weight decay
-            correction = 1.0 - learning_rate * weight_decay;
-        } else {
-            // default value
-            correction = 1.0;
-        }
-    }
-    multiplier = SHFL_SYNC(multiplier, 0);
-    correction = SHFL_SYNC(correction, 0);
-    """
-    split_weight_update_cpu = """
-        at::acc_type<grad_t, true> g_local_sum_square = 0.0;
-        for (int64_t d = 0; d < D; ++d) {
-            auto grad = grad_buffer[d];
-            if (weight_decay_mode == 1) {
-                // L2 regularization
-                grad += weight_decay * host_weights_data[embedding_begin + d];
-            }
-            g_local_sum_square += grad * grad;
-        }
-        auto g_avg_square = g_local_sum_square / D;
-        at::acc_type<grad_t, true> new_sum_square_grads = momentum1_host[momentum1_offsets_data[feature_begin] + idx] + g_avg_square;
-        momentum1_host[momentum1_offsets_data[feature_begin] + idx] = new_sum_square_grads;
-        at::acc_type<grad_t, true> multiplier;
-        multiplier = learning_rate / (sqrtf(new_sum_square_grads) + eps);
-        at::acc_type<grad_t, true> correction;
-        if (weight_decay_mode == 1) {
-            // L2 regularization
-            correction = 1.0 - multiplier * weight_decay;
-        } else if (weight_decay_mode == 2) {
-            // Decoupled weight decay
-            correction = 1.0 - learning_rate * weight_decay;
-        } else {
-            // default value
-            correction = 1.0;
-        }
-        for (int64_t d = 0; d < D; ++d) {
-            host_weights_data[embedding_begin + d] = correction * host_weights_data[embedding_begin + d] - grad_buffer[d] * multiplier;
-        }
-    """
-
-    generate(
-        optimizer="rowwise_adagrad_with_weight_decay",
-        args=make_args(
-            [
-                (TENSOR, "momentum1"),
-                (FLOAT, "eps"),
-                (FLOAT, "learning_rate"),
-                (FLOAT, "weight_decay", 0.0),
-                (INT, "weight_decay_mode", 0),
-            ]
-        ),
-        split_precomputation=split_precomputation,
-        split_weight_update=split_weight_update,
-        split_weight_update_cpu=split_weight_update_cpu,
-    )
-
-    approx_split_weight_update = """
-      // dummy computation to avoid unused variable warning
-      weight_new.fma_(grad, -multiplier);
-      assert(false); // approx rowwise AdaGrad is not supported on GPU
-    """
-
-    generate(
-        optimizer="approx_rowwise_adagrad_with_weight_decay",
-        args=make_args(
-            [
-                (TENSOR, "momentum1"),
-                (FLOAT, "eps"),
-                (FLOAT, "learning_rate"),
-                (FLOAT, "weight_decay", 0.0),
-                (INT, "weight_decay_mode", 0),
-            ]
-        ),
-        split_precomputation=split_precomputation,
-        split_weight_update=approx_split_weight_update,
-        split_weight_update_cpu=split_weight_update_cpu,
+        has_cpu_support=True,
+        has_gpu_support=False,
     )
 
 
@@ -771,6 +656,8 @@ def rowwise_adagrad_with_counter() -> None:
         split_precomputation=split_precomputation,
         split_weight_update=split_weight_update,
         split_weight_update_cpu=split_weight_update_cpu,
+        has_cpu_support=True,
+        has_gpu_support=True,
     )
 
     approx_split_weight_update = """
@@ -804,6 +691,8 @@ def rowwise_adagrad_with_counter() -> None:
         split_precomputation=split_precomputation,
         split_weight_update=approx_split_weight_update,
         split_weight_update_cpu=split_weight_update_cpu,
+        has_cpu_support=True,
+        has_gpu_support=False,
     )
 
 
@@ -874,6 +763,8 @@ def rowwise_weighted_adagrad() -> None:
         split_precomputation=split_precomputation,
         split_weight_update=split_weight_update,
         split_weight_update_cpu=split_weight_update_cpu,
+        has_cpu_support=True,
+        has_gpu_support=True,
     )
 
 
@@ -893,6 +784,8 @@ def sgd() -> None:
         split_precomputation="",
         split_weight_update=split_weight_update,
         split_weight_update_cpu=split_weight_update_cpu,
+        has_cpu_support=True,
+        has_gpu_support=True,
     )
 
     approx_split_weight_update = """
@@ -908,6 +801,8 @@ def sgd() -> None:
         split_precomputation="",
         split_weight_update=approx_split_weight_update,
         split_weight_update_cpu=split_weight_update_cpu,
+        has_cpu_support=True,
+        has_gpu_support=True,
     )
 
 
@@ -978,6 +873,8 @@ def lamb() -> None:
         split_precomputation=split_precomputation,
         split_weight_update=split_weight_update,
         split_weight_update_cpu=split_weight_update_cpu,
+        has_cpu_support=False,
+        has_gpu_support=True,
     )
 
 
@@ -1064,6 +961,8 @@ def partial_rowwise_lamb() -> None:
         split_precomputation=split_precomputation,
         split_weight_update=split_weight_update,
         split_weight_update_cpu=split_weight_update_cpu,
+        has_cpu_support=False,
+        has_gpu_support=True,
     )
 
 
@@ -1114,6 +1013,8 @@ def adam() -> None:
         split_precomputation="",
         split_weight_update=split_weight_update,
         split_weight_update_cpu=split_weight_update_cpu,
+        has_cpu_support=False,
+        has_gpu_support=True,
     )
 
 
@@ -1174,6 +1075,8 @@ def partial_rowwise_adam() -> None:
         split_precomputation=split_precomputation,
         split_weight_update=split_weight_update,
         split_weight_update_cpu=split_weight_update_cpu,
+        has_cpu_support=False,
+        has_gpu_support=True,
     )
 
 
@@ -1232,6 +1135,8 @@ def lars_sgd() -> None:
         split_precomputation=split_precomputation,
         split_weight_update=split_weight_update,
         split_weight_update_cpu=split_weight_update_cpu,
+        has_cpu_support=False,
+        has_gpu_support=True,
     )
 
 
@@ -1296,6 +1201,8 @@ def backward_dense() -> None:
                 (FLOAT, "unused"),
             ]
         ),
+        has_cpu_support=True,
+        has_gpu_support=True,
     )
 
 
@@ -1323,7 +1230,6 @@ def emb_codegen(
     partial_rowwise_adam()
     partial_rowwise_lamb()
     rowwise_adagrad()
-    rowwise_adagrad_with_weight_decay()
     rowwise_adagrad_with_counter()
     rowwise_weighted_adagrad()
     sgd()

--- a/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
@@ -49,6 +49,7 @@ def invoke(
     max_counter: float,
     {% endif %}
 ) -> torch.Tensor:
+    {% if has_cpu_support %}
     if (common_args.host_weights.numel() > 0):
         return torch.ops.fbgemm.split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(
             # common_args
@@ -147,112 +148,119 @@ def invoke(
             max_counter=max_counter,
             {% endif %}
         )
+    {% if not has_gpu_support %}
     else:
-        return torch.ops.fbgemm.split_embedding_codegen_lookup_{{ optimizer }}_function(
-            # common_args
-            {% if not dense %}
-            placeholder_autograd_tensor=common_args.placeholder_autograd_tensor,
-            {% endif %}
-            dev_weights=common_args.dev_weights,
-            uvm_weights=common_args.uvm_weights,
-            lxu_cache_weights=common_args.lxu_cache_weights,
-            weights_placements=common_args.weights_placements,
-            weights_offsets=common_args.weights_offsets,
-            D_offsets=common_args.D_offsets,
-            total_D=common_args.total_D,
-            max_D=common_args.max_D,
-            hash_size_cumsum=common_args.hash_size_cumsum,
-            total_hash_size_bits=common_args.total_hash_size_bits,
-            indices=common_args.indices,
-            offsets=common_args.offsets,
-            pooling_mode=common_args.pooling_mode,
-            indice_weights=common_args.indice_weights,
-            feature_requires_grad=common_args.feature_requires_grad,
-            lxu_cache_locations=common_args.lxu_cache_locations,
-            # optimizer_args
-            gradient_clipping = optimizer_args.gradient_clipping,
-            max_gradient=optimizer_args.max_gradient,
-            stochastic_rounding=optimizer_args.stochastic_rounding,
-            {% if "learning_rate" in args.split_function_arg_names %}
-            learning_rate=optimizer_args.learning_rate,
-            {% endif %}
-            {% if "eps" in args.split_function_arg_names %}
-            eps=optimizer_args.eps,
-            {% endif %}
-            {% if "beta1" in args.split_function_arg_names %}
-            beta1=optimizer_args.beta1,
-            {% endif %}
-            {% if "beta2" in args.split_function_arg_names %}
-            beta2=optimizer_args.beta2,
-            {% endif %}
-            {% if "weight_decay" in args.split_function_arg_names %}
-            weight_decay=optimizer_args.weight_decay,
-            {% endif %}
-            {% if "weight_decay_mode" in args.split_function_arg_names %}
-            weight_decay_mode=optimizer_args.weight_decay_mode,
-            {% endif %}
-            {% if "eta" in args.split_function_arg_names %}
-            eta=optimizer_args.eta,
-            {% endif %}
-            {% if "momentum" in args.split_function_arg_names %}
-            momentum=optimizer_args.momentum,
-            {% endif %}
-            {% if "counter_halflife" in args.split_function_arg_names %}
-            counter_halflife=optimizer_args.counter_halflife,
-            {% endif %}
-            {% if "adjustment_iter" in args.split_function_arg_names %}
-            adjustment_iter=optimizer_args.adjustment_iter,
-            {% endif %}
-            {% if "adjustment_ub" in args.split_function_arg_names %}
-            adjustment_ub=optimizer_args.adjustment_ub,
-            {% endif %}
-            {% if "learning_rate_mode" in args.split_function_arg_names %}
-            learning_rate_mode=optimizer_args.learning_rate_mode,
-            {% endif %}
-            {% if "grad_sum_decay" in args.split_function_arg_names %}
-            grad_sum_decay=optimizer_args.grad_sum_decay,
-            {% endif %}
-            {% if "tail_id_threshold" in args.split_function_arg_names %}
-            tail_id_threshold=optimizer_args.tail_id_threshold,
-            {% endif %}
-            {% if "is_tail_id_thresh_ratio" in args.split_function_arg_names %}
-            is_tail_id_thresh_ratio=optimizer_args.is_tail_id_thresh_ratio,
-            {% endif %}
-            # momentum1
-            {% if "momentum1_dev" in args.split_function_arg_names %}
-            momentum1_dev=momentum1.dev,
-            momentum1_uvm=momentum1.uvm,
-            momentum1_offsets=momentum1.offsets,
-            momentum1_placements=momentum1.placements,
-            {% endif %}
-            # momentum2
-            {% if "momentum2_dev" in args.split_function_arg_names %}
-            momentum2_dev=momentum2.dev,
-            momentum2_uvm=momentum2.uvm,
-            momentum2_offsets=momentum2.offsets,
-            momentum2_placements=momentum2.placements,
-            {% endif %}
-            # prev_iter
-            {% if "prev_iter_dev" in args.split_function_arg_names %}
-            prev_iter_dev=prev_iter.dev,
-            prev_iter_uvm=prev_iter.uvm,
-            prev_iter_offsets=prev_iter.offsets,
-            prev_iter_placements=prev_iter.placements,
-            {% endif %}
-            # row_counter
-            {% if "row_counter_dev" in args.split_function_arg_names %}
-            row_counter_dev=row_counter.dev,
-            row_counter_uvm=row_counter.uvm,
-            row_counter_offsets=row_counter.offsets,
-            row_counter_placements=row_counter.placements,
-            {% endif %}
-            # iter
-            {% if "iter" in args.split_function_arg_names %}
-            iter=iter,
-            {% endif %}
-            # max counter
-            {% if "max_counter" in args.split_function_arg_names %}
-            max_counter=max_counter,
-            {% endif %}
-            output_dtype=common_args.output_dtype,
-        )
+        assert False, "{{ optimizer }} has only CPU support. host_weights.numel() must be greater than 0."
+    {% endif %}
+    {% endif %}
+
+    {% if has_gpu_support %}
+    return torch.ops.fbgemm.split_embedding_codegen_lookup_{{ optimizer }}_function(
+        # common_args
+        {% if not dense %}
+        placeholder_autograd_tensor=common_args.placeholder_autograd_tensor,
+        {% endif %}
+        dev_weights=common_args.dev_weights,
+        uvm_weights=common_args.uvm_weights,
+        lxu_cache_weights=common_args.lxu_cache_weights,
+        weights_placements=common_args.weights_placements,
+        weights_offsets=common_args.weights_offsets,
+        D_offsets=common_args.D_offsets,
+        total_D=common_args.total_D,
+        max_D=common_args.max_D,
+        hash_size_cumsum=common_args.hash_size_cumsum,
+        total_hash_size_bits=common_args.total_hash_size_bits,
+        indices=common_args.indices,
+        offsets=common_args.offsets,
+        pooling_mode=common_args.pooling_mode,
+        indice_weights=common_args.indice_weights,
+        feature_requires_grad=common_args.feature_requires_grad,
+        lxu_cache_locations=common_args.lxu_cache_locations,
+        # optimizer_args
+        gradient_clipping = optimizer_args.gradient_clipping,
+        max_gradient=optimizer_args.max_gradient,
+        stochastic_rounding=optimizer_args.stochastic_rounding,
+        {% if "learning_rate" in args.split_function_arg_names %}
+        learning_rate=optimizer_args.learning_rate,
+        {% endif %}
+        {% if "eps" in args.split_function_arg_names %}
+        eps=optimizer_args.eps,
+        {% endif %}
+        {% if "beta1" in args.split_function_arg_names %}
+        beta1=optimizer_args.beta1,
+        {% endif %}
+        {% if "beta2" in args.split_function_arg_names %}
+        beta2=optimizer_args.beta2,
+        {% endif %}
+        {% if "weight_decay" in args.split_function_arg_names %}
+        weight_decay=optimizer_args.weight_decay,
+        {% endif %}
+        {% if "weight_decay_mode" in args.split_function_arg_names %}
+        weight_decay_mode=optimizer_args.weight_decay_mode,
+        {% endif %}
+        {% if "eta" in args.split_function_arg_names %}
+        eta=optimizer_args.eta,
+        {% endif %}
+        {% if "momentum" in args.split_function_arg_names %}
+        momentum=optimizer_args.momentum,
+        {% endif %}
+        {% if "counter_halflife" in args.split_function_arg_names %}
+        counter_halflife=optimizer_args.counter_halflife,
+        {% endif %}
+        {% if "adjustment_iter" in args.split_function_arg_names %}
+        adjustment_iter=optimizer_args.adjustment_iter,
+        {% endif %}
+        {% if "adjustment_ub" in args.split_function_arg_names %}
+        adjustment_ub=optimizer_args.adjustment_ub,
+        {% endif %}
+        {% if "learning_rate_mode" in args.split_function_arg_names %}
+        learning_rate_mode=optimizer_args.learning_rate_mode,
+        {% endif %}
+        {% if "grad_sum_decay" in args.split_function_arg_names %}
+        grad_sum_decay=optimizer_args.grad_sum_decay,
+        {% endif %}
+        {% if "tail_id_threshold" in args.split_function_arg_names %}
+        tail_id_threshold=optimizer_args.tail_id_threshold,
+        {% endif %}
+        {% if "is_tail_id_thresh_ratio" in args.split_function_arg_names %}
+        is_tail_id_thresh_ratio=optimizer_args.is_tail_id_thresh_ratio,
+        {% endif %}
+        # momentum1
+        {% if "momentum1_dev" in args.split_function_arg_names %}
+        momentum1_dev=momentum1.dev,
+        momentum1_uvm=momentum1.uvm,
+        momentum1_offsets=momentum1.offsets,
+        momentum1_placements=momentum1.placements,
+        {% endif %}
+        # momentum2
+        {% if "momentum2_dev" in args.split_function_arg_names %}
+        momentum2_dev=momentum2.dev,
+        momentum2_uvm=momentum2.uvm,
+        momentum2_offsets=momentum2.offsets,
+        momentum2_placements=momentum2.placements,
+        {% endif %}
+        # prev_iter
+        {% if "prev_iter_dev" in args.split_function_arg_names %}
+        prev_iter_dev=prev_iter.dev,
+        prev_iter_uvm=prev_iter.uvm,
+        prev_iter_offsets=prev_iter.offsets,
+        prev_iter_placements=prev_iter.placements,
+        {% endif %}
+        # row_counter
+        {% if "row_counter_dev" in args.split_function_arg_names %}
+        row_counter_dev=row_counter.dev,
+        row_counter_uvm=row_counter.uvm,
+        row_counter_offsets=row_counter.offsets,
+        row_counter_placements=row_counter.placements,
+        {% endif %}
+        # iter
+        {% if "iter" in args.split_function_arg_names %}
+        iter=iter,
+        {% endif %}
+        # max counter
+        {% if "max_counter" in args.split_function_arg_names %}
+        max_counter=max_counter,
+        {% endif %}
+        output_dtype=common_args.output_dtype,
+    )
+    {% endif %}


### PR DESCRIPTION
Summary:
This diff aims to reduce the build time and libary size of
`//deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops`.

[1/2] Update `lookup_invoker` to enable the function invoker based on
`has_cpu_support` and `has_gpu_support`
[2/2] Update the code generation part

The diff modifies the build target to generate and compile only the
necessary files. This is based on the fact that CPU and GPU do not
support all optimizers in `SplitTBE`.  (Before this diff, all optimizers
were generated and compiled for both CPU and GPU.)

The following is the list of supported optimizers

|OptimType|Generated optimizer|Supported on CPU|Supported on GPU|
|EXACT_ADAGRAD|adagrad|x|x|
|EXACT_ROWWISE_ADAGRAD|rowwise_adagrad_with_counter|x|x|
||rowwise_adagrad|x|x|
|EXACT_ROWWISE_WEIGHTED_ADAGRAD|rowwise_weighted_adagrad|x|x|
|EXACT_SGD|sgd|x|x|
|SGD|approx_sgd|x|x|
|ROWWISE_ADAGRAD|approx_rowwise_adagrad_with_counter|x||
||approx_rowwise_adagrad|x||
|ADAM|adam||x|
|LAMB|lamb||x|
|LARS_SGD|lars_sgd||x|
|PARTIAL_ROWWISE_ADAM|partial_rowwise_adam||x|
|PARTIAL_ROWWISE_LAMB|partial_rowwise_lamb||x|
|-|rowwise_adagrad_with_weight_decay|||
|-|approx_rowwise_adagrad_with_weight_decay|||

Differential Revision: D44484764

