### PR TITLE
Back out "Update API interface and reroute backend for exact_rowwise_adagrad FE when using freq based methods"

### DIFF
--- a/fbgemm_gpu/codegen/__init__.template
+++ b/fbgemm_gpu/codegen/__init__.template
@@ -13,9 +13,7 @@ import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_lars_sgd as loo
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_partial_rowwise_adam as lookup_partial_rowwise_adam  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_partial_rowwise_lamb as lookup_partial_rowwise_lamb  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_rowwise_adagrad as lookup_rowwise_adagrad  # noqa: F401
-import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_rowwise_adagrad_with_counter as lookup_rowwise_adagrad_with_counter  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_sgd as lookup_sgd  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_approx_sgd as lookup_approx_sgd  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_approx_rowwise_adagrad as lookup_approx_rowwise_adagrad  # noqa: F401
-import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_approx_rowwise_adagrad_with_counter as lookup_approx_rowwise_adagrad_with_counter  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_rowwise_weighted_adagrad as lookup_rowwise_weighted_adagrad  # noqa: F401

--- a/fbgemm_gpu/codegen/embedding_backward_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_backward_code_generator.py
@@ -646,11 +646,6 @@ def rowwise_adagrad_with_counter() -> None:
     split_precomputation = """
     at::acc_type<cache_t, true> freq = 1.0;
     at::acc_type<cache_t, true> l2_wd = 0.0;
-    at::acc_type<cache_t, true> tail_id_threshold_val = tail_id_threshold;
-    CUDA_KERNEL_ASSERT(max_counter > 0.0); // avoid divide by zero error
-    if (is_tail_id_thresh_ratio == 1){
-        tail_id_threshold_val = floorf(tail_id_threshold * max_counter);
-    }
     if (counter_halflife > 0 && threadIdx.x == 0) {
         // if id occurs multiple times in a batch, iter_delta=1
         const auto iter_delta = prev_iter[idx] == 0 ? 1.0 : iter * 1.0 - prev_iter[idx];
@@ -665,7 +660,6 @@ def rowwise_adagrad_with_counter() -> None:
     }
     freq = SHFL_SYNC(freq, 0);
     l2_wd = SHFL_SYNC(l2_wd, 0);
-    tail_id_threshold_val = SHFL_SYNC(tail_id_threshold_val, 0);
 
     at::acc_type<cache_t, true> g_local_sum_square = 0.0;
 
@@ -688,7 +682,10 @@ def rowwise_adagrad_with_counter() -> None:
     at::acc_type<cache_t, true> multiplier;
     at::acc_type<cache_t, true> adjusted_multiplier;
     at::acc_type<cache_t, true> exp_reg_correction;
-
+    at::acc_type<cache_t, true> tail_id_threshold_val = tail_id_threshold;
+    if (is_tail_id_thresh_ratio == 1){
+        tail_id_threshold_val = floorf(tail_id_threshold * max_counter);
+    }
     if (threadIdx.x == 0) {
         at::acc_type<cache_t, true> new_sum_square_grads = momentum1[idx] + g_avg_square;
         momentum1[idx] = new_sum_square_grads;

--- a/fbgemm_gpu/codegen/lookup_args.py
+++ b/fbgemm_gpu/codegen/lookup_args.py
@@ -44,13 +44,6 @@ class OptimizerArgs(NamedTuple):
     weight_decay_mode: int
     eta: float
     momentum: float
-    counter_halflife: int
-    adjustment_iter: int
-    adjustment_ub: float
-    learning_rate_mode: int
-    grad_sum_decay: int
-    tail_id_threshold: float
-    is_tail_id_thresh_ratio: int
 
 
 class Momentum(NamedTuple):

--- a/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
@@ -36,17 +36,8 @@ def invoke(
     {% if "momentum2_dev" in args.split_function_arg_names %}
     momentum2: Momentum,
     {% endif %}
-    {% if "prev_iter_dev" in args.split_function_arg_names %}
-    prev_iter: Momentum,
-    {% endif %}
-    {% if "row_counter_dev" in args.split_function_arg_names %}
-    row_counter: Momentum,
-    {% endif %}
     {% if "iter" in args.split_function_arg_names %}
     iter: int,
-    {% endif %}
-    {% if "max_counter" in args.split_function_arg_names %}
-    max_counter: float,
     {% endif %}
 ) -> torch.Tensor:
     if (common_args.host_weights.numel() > 0):
@@ -93,27 +84,6 @@ def invoke(
             {% if "momentum" in args.split_function_arg_names %}
             momentum=optimizer_args.momentum,
             {% endif %}
-            {% if "counter_halflife" in args.split_function_arg_names %}
-            counter_halflife=optimizer_args.counter_halflife,
-            {% endif %}
-            {% if "adjustment_iter" in args.split_function_arg_names %}
-            adjustment_iter=optimizer_args.adjustment_iter,
-            {% endif %}
-            {% if "adjustment_ub" in args.split_function_arg_names %}
-            adjustment_ub=optimizer_args.adjustment_ub,
-            {% endif %}
-            {% if "learning_rate_mode" in args.split_function_arg_names %}
-            learning_rate_mode=optimizer_args.learning_rate_mode,
-            {% endif %}
-            {% if "grad_sum_decay" in args.split_function_arg_names %}
-            grad_sum_decay=optimizer_args.grad_sum_decay,
-            {% endif %}
-            {% if "tail_id_threshold" in args.split_function_arg_names %}
-            tail_id_threshold=optimizer_args.tail_id_threshold,
-            {% endif %}
-            {% if "is_tail_id_thresh_ratio" in args.split_function_arg_names %}
-            is_tail_id_thresh_ratio=optimizer_args.is_tail_id_thresh_ratio,
-            {% endif %}
             # momentum1
             {% if "momentum1_dev" in args.split_function_arg_names %}
             momentum1_host=momentum1.host,
@@ -126,25 +96,9 @@ def invoke(
             momentum2_offsets=momentum2.offsets,
             momentum2_placements=momentum2.placements,
             {% endif %}
-            # prev_iter
-            {% if "prev_iter_dev" in args.split_function_arg_names %}
-            prev_iter_host=prev_iter.host,
-            prev_iter_offsets=prev_iter.offsets,
-            prev_iter_placements=prev_iter.placements,
-            {% endif %}
-            # row_counter
-            {% if "row_counter_dev" in args.split_function_arg_names %}
-            row_counter_host=row_counter.host,
-            row_counter_offsets=row_counter.offsets,
-            row_counter_placements=row_counter.placements,
-            {% endif %}
             # iter
             {% if "iter" in args.split_function_arg_names %}
             iter=iter,
-            {% endif %}
-            # max counter
-            {% if "max_counter" in args.split_function_arg_names %}
-            max_counter=max_counter,
             {% endif %}
         )
     else:
@@ -197,27 +151,6 @@ def invoke(
             {% if "momentum" in args.split_function_arg_names %}
             momentum=optimizer_args.momentum,
             {% endif %}
-            {% if "counter_halflife" in args.split_function_arg_names %}
-            counter_halflife=optimizer_args.counter_halflife,
-            {% endif %}
-            {% if "adjustment_iter" in args.split_function_arg_names %}
-            adjustment_iter=optimizer_args.adjustment_iter,
-            {% endif %}
-            {% if "adjustment_ub" in args.split_function_arg_names %}
-            adjustment_ub=optimizer_args.adjustment_ub,
-            {% endif %}
-            {% if "learning_rate_mode" in args.split_function_arg_names %}
-            learning_rate_mode=optimizer_args.learning_rate_mode,
-            {% endif %}
-            {% if "grad_sum_decay" in args.split_function_arg_names %}
-            grad_sum_decay=optimizer_args.grad_sum_decay,
-            {% endif %}
-            {% if "tail_id_threshold" in args.split_function_arg_names %}
-            tail_id_threshold=optimizer_args.tail_id_threshold,
-            {% endif %}
-            {% if "is_tail_id_thresh_ratio" in args.split_function_arg_names %}
-            is_tail_id_thresh_ratio=optimizer_args.is_tail_id_thresh_ratio,
-            {% endif %}
             # momentum1
             {% if "momentum1_dev" in args.split_function_arg_names %}
             momentum1_dev=momentum1.dev,
@@ -232,27 +165,9 @@ def invoke(
             momentum2_offsets=momentum2.offsets,
             momentum2_placements=momentum2.placements,
             {% endif %}
-            # prev_iter
-            {% if "prev_iter_dev" in args.split_function_arg_names %}
-            prev_iter_dev=prev_iter.dev,
-            prev_iter_uvm=prev_iter.uvm,
-            prev_iter_offsets=prev_iter.offsets,
-            prev_iter_placements=prev_iter.placements,
-            {% endif %}
-            # row_counter
-            {% if "row_counter_dev" in args.split_function_arg_names %}
-            row_counter_dev=row_counter.dev,
-            row_counter_uvm=row_counter.uvm,
-            row_counter_offsets=row_counter.offsets,
-            row_counter_placements=row_counter.placements,
-            {% endif %}
             # iter
             {% if "iter" in args.split_function_arg_names %}
             iter=iter,
-            {% endif %}
-            # max counter
-            {% if "max_counter" in args.split_function_arg_names %}
-            max_counter=max_counter,
             {% endif %}
             output_dtype=common_args.output_dtype,
         )

--- a/fbgemm_gpu/fbgemm_gpu/ssd_split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/ssd_split_table_batched_embeddings_ops.py
@@ -18,7 +18,6 @@ from fbgemm_gpu.split_embedding_configs import SparseType
 from fbgemm_gpu.split_table_batched_embeddings_ops import (
     align_to_cacheline,
     CacheAlgorithm,
-    CounterBasedRegularizationDefinition,
     DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
     EmbeddingLocation,
     PoolingMode,
@@ -89,9 +88,6 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         eta: float = 0.001,  # used by LARS-SGD,
         beta1: float = 0.9,  # used by LAMB and ADAM
         beta2: float = 0.999,  # used by LAMB and ADAM
-        counter_based_regularization: Optional[
-            CounterBasedRegularizationDefinition
-        ] = None,  # used by Rowwise Adagrad
         pooling_mode: PoolingMode = PoolingMode.SUM,
     ) -> None:
         super(SSDTableBatchedEmbeddingBags, self).__init__()
@@ -221,12 +217,6 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         self.ssd_set_end = torch.cuda.Event()
         self.timesteps_prefetched: List[int] = []
 
-        if weight_decay_mode == WeightDecayMode.COUNTER or counter_based_regularization:
-            raise AssertionError(
-                "weight_decay_mode = WeightDecayMode.COUNTER is not supported for SSD TBE."
-            )
-        counter_based_regularization = CounterBasedRegularizationDefinition()
-
         self.optimizer_args = invokers.lookup_args.OptimizerArgs(
             stochastic_rounding=stochastic_rounding,
             gradient_clipping=gradient_clipping,
@@ -239,15 +229,6 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             weight_decay_mode=weight_decay_mode.value,
             eta=eta,
             momentum=momentum,
-            counter_halflife=counter_based_regularization.counter_halflife,
-            adjustment_iter=counter_based_regularization.adjustment_iter,
-            adjustment_ub=counter_based_regularization.adjustment_ub,
-            learning_rate_mode=counter_based_regularization.learning_rate_mode.value,
-            grad_sum_decay=counter_based_regularization.grad_sum_decay.value,
-            tail_id_threshold=counter_based_regularization.tail_id_threshold.val,
-            is_tail_id_thresh_ratio=int(
-                counter_based_regularization.tail_id_threshold.is_ratio
-            ),
         )
         self.weights_dev = nn.Parameter(
             torch.empty((0,), device=self.current_device, dtype=torch.float32)

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -9,11 +9,10 @@
 
 import copy
 
-import math
 import pickle
 import random
 import unittest
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import fbgemm_gpu
 import fbgemm_gpu.split_table_batched_embeddings_ops as split_table_batched_embeddings_ops
@@ -32,16 +31,11 @@ from fbgemm_gpu.split_embedding_utils import (
 )
 from fbgemm_gpu.split_table_batched_embeddings_ops import (
     BoundsCheckMode,
-    CounterBasedRegularizationDefinition,
-    CounterWeightDecayMode,
-    GradSumDecay,
     INT8_EMB_ROW_DIM_OFFSET,
-    LearningRateMode,
     OptimType,
     RecordCacheMetrics,
     rounded_row_size_in_bytes,
     SparseType,
-    TailIdThreshold,
     WeightDecayMode,
 )
 from hypothesis import assume, given, HealthCheck, settings, Verbosity
@@ -1633,7 +1627,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         use_cpu: bool,
         exact: bool,
         output_dtype: SparseType,
-        weight_decay_mode: WeightDecayMode = WeightDecayMode.NONE,
     ) -> None:
         # NOTE: cache is not applicable to CPU version.
         assume(not use_cpu or not use_cache)
@@ -1833,39 +1826,31 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             goc = torch.cat(gos, dim=0)
         fc2.backward(goc)
         cc.flush()
-        split_optimizer_states = cc.split_optimizer_states()
-        assert len(split_optimizer_states) == T
+        split_optimizer_states = [s for (s,) in cc.split_optimizer_states()]
         tolerance = (
             1.0e-4
             if weights_precision == SparseType.FP32 and output_dtype == SparseType.FP32
             else 1.0e-2
         )
         for t in range(T):
-            if row_wise and weight_decay_mode == WeightDecayMode.COUNTER:
-                (m1, c1, c2) = split_optimizer_states[t]
-            else:
-                (m1,) = split_optimizer_states[t]
             # pyre-fixme[16]: `Optional` has no attribute `float`.
             ref_optimizer_state = bs[t].weight.grad.float().cpu().to_dense().pow(2)
             torch.testing.assert_close(
-                m1.float().cpu(),
+                split_optimizer_states[t].float().cpu(),
                 ref_optimizer_state.mean(dim=1) if row_wise else ref_optimizer_state,
                 atol=tolerance,
                 rtol=tolerance,
             )
         for t in range(T):
             # optimizer_state = squares (no row-wise) or sum squares (row-wise)
-            if row_wise and weight_decay_mode == WeightDecayMode.COUNTER:
-                (m1, c1, c2) = split_optimizer_states[t]
-            else:
-                (m1,) = split_optimizer_states[t]
             torch.testing.assert_close(
                 cc.split_embedding_weights()[t].float().cpu(),
                 torch.addcdiv(
                     bs[t].weight.float().cpu(),
                     value=-lr,
                     tensor1=bs[t].weight.grad.float().cpu().to_dense(),
-                    tensor2=m1.float()
+                    tensor2=split_optimizer_states[t]
+                    .float()
                     .sqrt_()
                     .add_(eps)
                     .view(Es[t], 1 if row_wise else Ds[t])
@@ -2604,8 +2589,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             0.9,
             0.01,
         )
-        counter_based_regularization: CounterBasedRegularizationDefinition
-
         if optimizer == OptimType.EXACT_ADAGRAD:
             optimizer_kwargs["eps"] = eps
 
@@ -2613,21 +2596,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             optimizer_kwargs["eps"] = eps
             optimizer_kwargs["weight_decay"] = weight_decay
             optimizer_kwargs["weight_decay_mode"] = weight_decay_mode
-            if weight_decay_mode == WeightDecayMode.COUNTER:
-                counter_based_regularization = CounterBasedRegularizationDefinition(
-                    counter_weight_decay_mode=CounterWeightDecayMode.DECOUPLE,
-                    counter_halflife=20000,
-                    adjustment_iter=24000,
-                    adjustment_ub=0.1,
-                    learning_rate_mode=LearningRateMode.TAIL_ID_LR_DECREASE,
-                    grad_sum_decay=GradSumDecay.NO_DECAY,
-                    tail_id_threshold=TailIdThreshold(val=1000, is_ratio=False),
-                )
-
-                optimizer_kwargs[
-                    "counter_based_regularization"
-                    # pyre-fixme[6]: Expected `float` for 2nd param but got `CounterBasedRegularizationDefinition`.
-                ] = counter_based_regularization
 
         if optimizer == OptimType.EXACT_ROWWISE_WEIGHTED_ADAGRAD:
             optimizer_kwargs["eps"] = eps
@@ -2686,39 +2654,15 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         if optimizer in (OptimType.EXACT_ROWWISE_ADAGRAD, OptimType.EXACT_ADAGRAD):
             rowwise = optimizer == OptimType.EXACT_ROWWISE_ADAGRAD
             for t in range(T):
-                row_counter: Optional[torch.Tensor] = None
-                freq: Optional[torch.Tensor] = None
-                iter_: int = -1
-
-                if rowwise and weight_decay_mode == WeightDecayMode.COUNTER:
-                    (m1, prev_iter, row_counter) = split_optimizer_states[t]
-                else:
-                    (m1,) = split_optimizer_states[t]
+                (m1,) = split_optimizer_states[t]
                 # to_dense in GPU is non-deterministic due to atmomics used in
                 # coalescing and floating point non-associativity.
                 # pyre-fixme[16]: `Optional` has no attribute `cpu`.
                 dense_cpu_grad = bs[t].weight.grad.cpu().to_dense()
-                if rowwise and not use_cpu:
+                if rowwise and not use_cpu and weight_decay_mode == WeightDecayMode.L2:
                     # We need to skip when using cpu because use_fbgemm (https://fburl.com/code/12131iub)
                     # is true and the template code (https://fburl.com/code/1kctlup3) is not executed.
-                    if weight_decay_mode == WeightDecayMode.L2:
-                        dense_cpu_grad += weight_decay * bs[t].weight.cpu()
-                    elif weight_decay_mode == WeightDecayMode.COUNTER:
-                        iter_ = int(cc.iter.item())
-                        (
-                            dense_cpu_grad,
-                            row_counter,
-                            freq,
-                        ) = self.get_grad_from_counter_adagrad(
-                            dense_cpu_grad,
-                            bs[t].weight.cpu(),
-                            counter_based_regularization,
-                            row_counter.cpu(),
-                            prev_iter.cpu(),
-                            iter_,
-                            weight_decay,
-                        )
-
+                    dense_cpu_grad += weight_decay * bs[t].weight.cpu()
                 m1_ref = (
                     dense_cpu_grad.pow(2)
                     if not rowwise
@@ -2737,31 +2681,14 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                     )
                     + eps
                 )
-                if rowwise and not use_cpu:
-                    if weight_decay_mode == WeightDecayMode.DECOUPLE:
-                        weights_ref = bs[t].weight.cpu() - lr * (
-                            dense_cpu_grad / denom + weight_decay * bs[t].weight.cpu()
-                        )
-                    elif weight_decay_mode == WeightDecayMode.L2:
-                        # pyre-fixme[58]: `/` is not supported for operand types `float`
-                        #  and `Tensor`.
-                        weights_ref = bs[t].weight.cpu() - lr * dense_cpu_grad / denom
-                    elif weight_decay_mode == WeightDecayMode.COUNTER:
-                        max_counter = cc.max_counter.item()
-                        weights_ref = self.get_wts_from_counter_adagrad(
-                            dense_cpu_grad,
-                            bs[t].weight.cpu(),
-                            denom,
-                            counter_based_regularization,
-                            row_counter,
-                            # pyre-fixme[6]: Expected `Tensor` for 6th param but got `Optional[Tensor]`
-                            freq,
-                            max_counter,
-                            iter_,
-                            eps,
-                            lr,
-                            weight_decay,
-                        )
+                if (
+                    rowwise
+                    and not use_cpu
+                    and weight_decay_mode == WeightDecayMode.DECOUPLE
+                ):
+                    weights_ref = bs[t].weight.cpu() - lr * (
+                        dense_cpu_grad / denom + weight_decay * bs[t].weight.cpu()
+                    )
                 else:
                     # pyre-fixme[58]: `/` is not supported for operand types `float`
                     #  and `Tensor`.
@@ -2906,117 +2833,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                     rtol=1.0e-4,
                 )
 
-    def get_grad_from_counter_adagrad(
-        self,
-        dense_cpu_grad: torch.Tensor,
-        weights: torch.Tensor,
-        counter_based_regularization: CounterBasedRegularizationDefinition,
-        row_counter: torch.Tensor,
-        prev_iter: torch.Tensor,
-        iter_: int,
-        weight_decay: float,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        row_counter = row_counter.view(row_counter.numel(), 1)
-        prev_iter = prev_iter.view(prev_iter.numel(), 1)
-        freq = torch.ones_like(row_counter)
-        counter_weight_decay_mode = (
-            counter_based_regularization.counter_weight_decay_mode
-        )
-        counter_halflife = counter_based_regularization.counter_halflife
-        l2_wd = 1.0 if counter_weight_decay_mode == CounterWeightDecayMode.L2 else 0.0
-
-        if counter_halflife > 0:
-            counter_log_rho = math.log(2.0) / counter_halflife
-            # if id occurs multiple times in a batch, iter_delta=1
-            iter_delta = torch.where(prev_iter == 0.0, 1.0, iter_ * 1.0 - prev_iter)
-            prev_iter = iter_ * torch.ones_like(prev_iter)
-            row_counter = 1.0 + torch.exp(-iter_delta * counter_log_rho) * row_counter
-            freq = torch.tensor([counter_halflife]) / row_counter
-
-        dense_cpu_grad += l2_wd * freq * weight_decay * weights
-        return dense_cpu_grad, row_counter, freq
-
-    def get_wts_from_counter_adagrad(
-        self,
-        dense_cpu_grad: torch.Tensor,
-        weights: torch.Tensor,
-        denom: torch.Tensor,
-        counter_based_regularization: CounterBasedRegularizationDefinition,
-        row_counter: torch.Tensor,
-        freq: torch.Tensor,
-        max_counter: float,
-        iter_: int,
-        eps: float,
-        learning_rate: float,
-        weight_decay: float,
-    ) -> torch.Tensor:
-        counter_weight_decay_mode = (
-            counter_based_regularization.counter_weight_decay_mode
-        )
-        counter_halflife = counter_based_regularization.counter_halflife
-        tail_id_threshold_val = counter_based_regularization.tail_id_threshold.val
-        if counter_based_regularization.tail_id_threshold.is_ratio:
-            tail_id_threshold_val = math.floor(tail_id_threshold_val * max_counter)
-        learning_rate_mode = counter_based_regularization.learning_rate_mode
-        adjustment_iter = counter_based_regularization.adjustment_iter
-        adjustment_ub = counter_based_regularization.adjustment_ub
-
-        multiplier = torch.tensor([learning_rate]) / denom
-        adjusted_multiplier = multiplier
-        exp_reg_correction = torch.ones_like(row_counter)
-
-        if counter_halflife > 0:
-            if adjustment_iter <= 0 or (
-                adjustment_iter > 0 and iter_ > adjustment_iter
-            ):
-                if learning_rate_mode == LearningRateMode.TAIL_ID_LR_INCREASE:
-                    adjusted_multiplier = torch.where(
-                        row_counter > tail_id_threshold_val,
-                        multiplier
-                        * torch.maximum(
-                            torch.minimum(
-                                torch.pow(
-                                    torch.tensor([max_counter]) / (row_counter + 1.0),
-                                    adjustment_ub,
-                                ),
-                                torch.Tensor([10.0]),
-                            ),
-                            torch.Tensor([1.0]),
-                        ),
-                        multiplier,
-                    )
-                elif learning_rate_mode == LearningRateMode.TAIL_ID_LR_DECREASE:
-                    adjusted_multiplier = torch.where(
-                        row_counter > tail_id_threshold_val,
-                        multiplier
-                        * torch.minimum(
-                            torch.maximum(
-                                torch.pow(
-                                    (row_counter + 1.0) / max_counter,
-                                    adjustment_ub,
-                                ),
-                                torch.Tensor([0.1]),
-                            ),
-                            torch.Tensor([1.0]),
-                        ),
-                        multiplier,
-                    )
-                elif learning_rate_mode == LearningRateMode.COUNTER_SGD:
-                    adjusted_multiplier = torch.where(
-                        row_counter > tail_id_threshold_val,
-                        torch.Tensor([learning_rate])
-                        / (torch.sqrt(adjustment_ub * row_counter) + eps),
-                        multiplier,
-                    )
-
-                if counter_weight_decay_mode == CounterWeightDecayMode.DECOUPLE:
-                    exp_reg_correction = 1.0 - freq * weight_decay * learning_rate
-                elif counter_weight_decay_mode == CounterWeightDecayMode.L2:
-                    exp_reg_correction = 1.0 - freq * weight_decay * multiplier
-
-        weights = exp_reg_correction * weights - adjusted_multiplier * dense_cpu_grad
-        return weights
-
     @given(
         T=st.integers(min_value=1, max_value=5),
         D=st.integers(min_value=2, max_value=256),
@@ -3085,7 +2901,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         D=st.integers(min_value=2, max_value=256),
         B=st.integers(min_value=1, max_value=128),
         log_E=st.integers(min_value=3, max_value=5),
-        L=st.integers(min_value=2, max_value=20),
+        L=st.integers(min_value=0, max_value=20),
         weighted=st.booleans(),
         mixed=st.booleans(),
         optimizer=st.sampled_from(
@@ -3112,7 +2928,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             [
                 WeightDecayMode.L2,
                 WeightDecayMode.DECOUPLE,
-                WeightDecayMode.COUNTER,
             ]
         ),
     )


### PR DESCRIPTION
Summary:
Original commit changeset: 8eb5da8a5c8b

Original Phabricator Diff: D36788395

Revert because this diff causes `test_backward_optimizers_adagrad` to
fail occasionally

Differential Revision: D44584192

