### PR TITLE
Support EXACT_ADAGRAD in `get_optimizer_state`

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -1199,6 +1199,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             self.optimizer == OptimType.EXACT_ROWWISE_ADAGRAD
             or self.optimizer == OptimType.ROWWISE_ADAGRAD
             or self.optimizer == OptimType.EXACT_ROWWISE_WEIGHTED_ADAGRAD
+            or self.optimizer == OptimType.EXACT_ADAGRAD
         ):
             list_of_state_dict = [
                 {"sum": states[0], "prev_iter": states[1], "row_counter": states[2]}

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -2718,6 +2718,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 OptimType.EXACT_ROWWISE_ADAGRAD,
                 OptimType.ROWWISE_ADAGRAD,
                 OptimType.EXACT_ROWWISE_WEIGHTED_ADAGRAD,
+                OptimType.EXACT_ADAGRAD,
             )
 
         if optimizer in (OptimType.EXACT_ROWWISE_ADAGRAD, OptimType.EXACT_ADAGRAD):
@@ -2811,12 +2812,11 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                     rtol=1.0e-2,
                 )
 
-                if get_optimizer_states is not None:
-                    optimizer_states_dict = get_optimizer_states[t]
-                    expected_keys = {"sum"}
-                    if rowwise and weight_decay_mode == WeightDecayMode.COUNTER:
-                        expected_keys.update(["prev_iter", "row_counter"])
-                    assert set(optimizer_states_dict.keys()) == expected_keys
+                optimizer_states_dict = get_optimizer_states[t]
+                expected_keys = {"sum"}
+                if rowwise and weight_decay_mode == WeightDecayMode.COUNTER:
+                    expected_keys.update(["prev_iter", "row_counter"])
+                assert set(optimizer_states_dict.keys()) == expected_keys
 
         if optimizer == OptimType.EXACT_ROWWISE_WEIGHTED_ADAGRAD:
             for t in range(T):


### PR DESCRIPTION
Summary:
This diff support `get_optimizer_state` for exact_adagrad.
Exact_adagrad is not supported in `get_optimizer_state`. However, this is needed for creating fused optimizer in torchrec.

Differential Revision: D44963975

