### PR TITLE
Fix exception in QuantUtilsTest

### DIFF
--- a/test/QuantUtilsTest.cc
+++ b/test/QuantUtilsTest.cc
@@ -640,7 +640,7 @@ class EmbeddingQuantizeFixedNumberTest : public testing::TestWithParam<int> {
     };
     assert(float_test_input.size() == row * col);
 
-    float16_test_input.reserve(float_test_input.size());
+    float16_test_input.resize(float_test_input.size());
     std::transform(
         float_test_input.begin(),
         float_test_input.end(),


### PR DESCRIPTION
This test mistakenly calls reserve() to set a vector's length instead of resize(). reserve() allocates memory for the specified number of elements, but does not actually increase the number of elements that can legally be stored in the vector. This test runs with ASAN enabled which is catching this illegal access and causing the test to fail.

This change fixes the code to instead call resize(); the test now passes.