### PR TITLE
[T150838079][WIP] Split the Code Generation for `embedding_backward_split_template.cu` into Smaller Files

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -123,10 +123,9 @@ set(gen_gpu_source_files
     "gen_embedding_forward_dense_unweighted_codegen_cuda.cu"
     "gen_embedding_forward_split_weighted_codegen_cuda.cu"
     "gen_embedding_forward_split_unweighted_codegen_cuda.cu"
-    "gen_embedding_backward_split_indice_weights_codegen_cuda.cu"
     "gen_embedding_backward_dense_indice_weights_codegen_cuda.cu"
-    "gen_embedding_backward_dense_split_unweighted_cuda.cu"
-    "gen_embedding_backward_dense_split_weighted_cuda.cu")
+    "gen_embedding_backward_split_indice_weights_codegen_cuda.cu"
+    "gen_embedding_backward_split_grad.cu")
 
 foreach(wdesc weighted unweighted_nobag unweighted)
   list(APPEND gen_gpu_source_files
@@ -136,6 +135,9 @@ foreach(wdesc weighted unweighted_nobag unweighted)
     list(APPEND gen_gpu_source_files
        "gen_embedding_forward_quantized_split_nbit_kernel_${wdesc}_${etype}_codegen_cuda.cu")
   endforeach()
+
+  list(APPEND gen_gpu_source_files
+    "gen_embedding_backward_dense_split_${wdesc}_cuda.cu")
 endforeach()
 
 set(gen_cpu_source_files
@@ -147,18 +149,20 @@ set(gen_python_files ${CMAKE_BINARY_DIR}/__init__.py)
 
 foreach(optimizer ${OPTIMIZERS})
   list(APPEND gen_gpu_host_source_files
-       "gen_embedding_backward_split_${optimizer}.cpp")
+    "gen_embedding_backward_split_${optimizer}.cpp")
 
   list(APPEND gen_cpu_source_files
-       "gen_embedding_backward_split_${optimizer}_cpu.cpp")
+    "gen_embedding_backward_split_${optimizer}_cpu.cpp")
+
   list(APPEND gen_cpu_source_files
-       "gen_embedding_backward_${optimizer}_split_cpu.cpp")
+    "gen_embedding_backward_${optimizer}_split_cpu.cpp")
 
-  list(APPEND gen_python_files "${CMAKE_BINARY_DIR}/lookup_${optimizer}.py")
+  list(APPEND gen_python_files
+    "${CMAKE_BINARY_DIR}/lookup_${optimizer}.py")
 
-  foreach(weight weighted unweighted)
+  foreach(wdesc weighted unweighted_nobag unweighted)
     list(APPEND gen_gpu_source_files
-         "gen_embedding_backward_${optimizer}_split_${weight}_cuda.cu")
+      "gen_embedding_backward_${optimizer}_split_${wdesc}_cuda.cu")
   endforeach()
 endforeach()
 
@@ -173,6 +177,7 @@ set(codegen_dependencies
     ${CMAKE_CODEGEN_DIR}/embedding_backward_split_host_cpu_template.cpp
     ${CMAKE_CODEGEN_DIR}/embedding_backward_split_host_template.cpp
     ${CMAKE_CODEGEN_DIR}/embedding_backward_split_indice_weights_template.cu
+    ${CMAKE_CODEGEN_DIR}/embedding_backward_split_grad_template.cu
     ${CMAKE_CODEGEN_DIR}/embedding_backward_split_template.cu
     ${CMAKE_CODEGEN_DIR}/embedding_forward_quantized_cpu_template.cpp
     ${CMAKE_CODEGEN_DIR}/embedding_forward_quantized_host.cpp

--- a/fbgemm_gpu/codegen/embedding_backward_split_grad_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_grad_template.cu
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// clang-format off
+#include "fbgemm_gpu/embedding_backward_template_helpers.cuh"
+#include "fbgemm_gpu/split_embeddings_utils.cuh"
+
+using Tensor = at::Tensor;
+using namespace fbgemm_gpu;
+
+__global__ __launch_bounds__(kMaxThreads) void
+split_embedding_backward_codegen_find_long_segments(
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        sorted_linear_indices_num_runs,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        sorted_linear_indices_run_lengths,
+    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        long_run_ids,
+    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        num_long_run_ids,
+    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        long_run_id_to_really_long_run_ids,
+    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        num_really_long_run_ids,
+    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        grad_accum_counter,
+    const int32_t max_segment_length_per_warp,
+    const int32_t max_segment_length_per_cta,
+    const bool use_deterministic_algorithms) {
+  const int32_t num_runs = sorted_linear_indices_num_runs[0];
+  for (auto run_id = blockIdx.x * blockDim.x + threadIdx.x; run_id < num_runs; run_id += blockDim.x * gridDim.x) {
+    if (sorted_linear_indices_run_lengths[run_id] >= max_segment_length_per_warp) {
+        // A segment with length > max_segment_length_per_cta is handled by more than 1 thread block.
+        const int num_ctas_for_run =
+            use_deterministic_algorithms ? 1 : div_round_up(sorted_linear_indices_run_lengths[run_id], max_segment_length_per_cta);
+        const auto long_run_idx = gpuAtomicAdd(&num_long_run_ids[0], num_ctas_for_run);
+        // The first thread block in the really long run gets run_id in long_run_ids
+        // and the rest get the negative of its offset.
+        long_run_ids[long_run_idx] = run_id;
+        for (int i = 1; i < num_ctas_for_run; ++i) {
+            long_run_ids[long_run_idx + i] = -i;
+        }
+        if (num_ctas_for_run > 1) {
+            const auto really_long_run_idx = gpuAtomicAdd(&num_really_long_run_ids[0], 1);
+            grad_accum_counter[really_long_run_idx] = num_ctas_for_run;
+            for (int i = 0; i < num_ctas_for_run; ++i) {
+                long_run_id_to_really_long_run_ids[long_run_idx + i] = really_long_run_idx;
+            }
+        }
+    }
+  }
+}
+
+template <typename grad_t>
+__global__ __launch_bounds__(kMaxThreads) void grad_mean_kernel(
+    const at::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits>
+        grad_output,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> offsets,
+    at::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits>
+        grad_output_mean) {
+  int32_t B = grad_output.size(0);
+  int32_t T = D_offsets.size(0) - 1;
+  int32_t b_t = blockIdx.x * blockDim.y + threadIdx.y;
+  int32_t b = b_t % B;
+  int32_t t = b_t / B;
+
+  if (b_t >= B * T) {
+    return;
+  }
+
+  int32_t D_start = D_offsets[t];
+  int32_t D_end = D_offsets[t + 1];
+  int32_t D = D_end - D_start;
+  int64_t indices_start = offsets[t * B + b];
+  int64_t indices_end = offsets[t * B + b + 1];
+  int32_t L = indices_end - indices_start;
+
+  if (L != 0) {
+    for (int32_t d = threadIdx.x; d * 4 < D; d += blockDim.x) {
+      Vec4T<grad_t> grad_out_vec(&grad_output[b][D_start + d * 4]);
+      grad_out_vec.mul_(1.0 / L);
+      grad_out_vec.store(&grad_output_mean[b][D_start + d * 4]);
+    }
+  } else {
+    for (int32_t d = threadIdx.x; d * 4 < D; d += blockDim.x) {
+      Vec4T<grad_t> grad_out_vec(&grad_output[b][D_start + d * 4]);
+      grad_out_vec.store(&grad_output_mean[b][D_start + d * 4]);
+    }
+  }
+}
+
+// Explicitly instantiate the template based on DISPATCH_EMB_GRAD_CACHE_TYPES
+{% for grad_type in ['at::Half', 'float'] %}
+template __global__ __launch_bounds__(kMaxThreads)
+void grad_mean_kernel
+< {{ grad_type }} > (
+    const at::PackedTensorAccessor64<{{ grad_type }}, 2, at::RestrictPtrTraits>
+        grad_output,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> offsets,
+    at::PackedTensorAccessor64<{{ grad_type }}, 2, at::RestrictPtrTraits>
+        grad_output_mean);
+{% endfor %} // for grad_type in ['at::Half', 'float']
+
+// clang-format on

--- a/fbgemm_gpu/include/fbgemm_gpu/embedding_backward_template_helpers.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/embedding_backward_template_helpers.cuh
@@ -4,6 +4,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+#pragma once
 
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>
@@ -25,6 +26,11 @@
 #include "fbgemm_cuda_utils.cuh"
 #include "sparse_ops_utils.h"
 
+#define SHFL_SYNC(val, srcLane) \
+  shfl_sync(val, srcLane, kThreadGroupSize, shfl_sync_mask)
+
+constexpr size_t kBackwardMaxThreads = 512;
+
 DEVICE_INLINE int64_t gpuAtomicIncrement(int64_t* p) {
   static_assert(
       sizeof(int64_t) == sizeof(unsigned long long),
@@ -33,3 +39,48 @@ DEVICE_INLINE int64_t gpuAtomicIncrement(int64_t* p) {
       reinterpret_cast<unsigned long long int*>(p),
       static_cast<unsigned long long int>(1)));
 }
+
+namespace fbgemm_gpu {
+namespace {
+
+// Based on the empirical study, max grid size that is 64x larger than the
+// number of SMs gives good performance across the board
+constexpr int MAX_THREAD_BLOCKS_FACTOR = 64;
+
+int get_max_thread_blocks_() {
+  return MAX_THREAD_BLOCKS_FACTOR *
+      at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+}
+} // namespace
+} // namespace fbgemm_gpu
+
+__global__
+    __launch_bounds__(fbgemm_gpu::kMaxThreads) void split_embedding_backward_codegen_find_long_segments(
+        const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+            sorted_linear_indices_num_runs,
+        const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+            sorted_linear_indices_run_lengths,
+        at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+            long_run_ids,
+        at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+            num_long_run_ids,
+        at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+            long_run_id_to_really_long_run_ids,
+        at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+            num_really_long_run_ids,
+        at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+            grad_accum_counter,
+        const int32_t max_segment_length_per_warp,
+        const int32_t max_segment_length_per_cta,
+        const bool use_deterministic_algorithms);
+
+template <typename grad_t>
+__global__ __launch_bounds__(fbgemm_gpu::kMaxThreads) void grad_mean_kernel(
+    const at::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits>
+        grad_output,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        D_offsets,
+
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> offsets,
+    at::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits>
+        grad_output_mean);


### PR DESCRIPTION
Summary:

`embedding_backward_split_template.cu` contains both jinja-template and non-jinja-template code, and some of the templating is unneccessary.  Furthermore, the template generates both the vanilla and `nobag` variants of unweighted into the same source file.  This PR moves the non-jinja-template code out of the template, de-duplicates code are unneccessarily templated, and splits the generation of the code to three files per optimizer, one for `weighted`, `unweighted nobag`, and `unweighted`.


Details:

- Migrate non-jinja-templated code out of `embedding_backward_split_template.cu` and into `embedding_backward_template_helpers.cuh`
- De-templatize `split_embedding_backward_codegen_{{ optimizer }}_{{ wdesc }}_find_long_segments` into `split_embedding_backward_codegen_find_long_segments` since there is no implementation difference between the optimizers and weighted vs unweighted
- Migrate `grad_mean_kernel` and `split_embedding_backward_codegen_find_long_segments` into a separate non-template source file to de-duplicate code generation and compilation
- Split the code generation of `embedding_backward_split_template.cu` into 3 files per optimizer, according to weighted, unweighted_nobag, and unweighted