### PR TITLE
support lengths broadcast for reorder_batched_ad_lengths

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -310,7 +310,8 @@ at::Tensor fusednbitrowwise_to_float_or_half_cpu(
 at::Tensor reorder_batched_ad_lengths_gpu(
     const at::Tensor& cat_ad_lengths,
     const at::Tensor& batch_offsets,
-    const int64_t num_ads_in_batch);
+    const int64_t num_ads_in_batch,
+    const c10::optional<bool>& broadcast_lengths = false);
 
 ///@ingroup sparse-data-cuda
 at::Tensor reorder_batched_ad_indices_gpu(
@@ -326,7 +327,8 @@ at::Tensor reorder_batched_ad_indices_gpu(
 at::Tensor reorder_batched_ad_lengths_cpu(
     const at::Tensor& cat_ad_lengths,
     const at::Tensor& batch_offsets,
-    const int64_t num_ads_in_batch);
+    const int64_t num_ads_in_batch,
+    const c10::optional<bool>& broadcast_lengths = false);
 ///@ingroup sparse-data-cpu
 at::Tensor reorder_batched_ad_indices_cpu(
     const at::Tensor& cat_ad_offsets,


### PR DESCRIPTION
Summary:
similar to D45155887

when `broadcast_lengths` is enabled, the lengths are copied from the only instance of each batch, this is also to facilitate request-only broadcast

Differential Revision: D45208736

