### PR TITLE
Prepare transpose_embedding_input for VBE

### DIFF
--- a/fbgemm_gpu/codegen/embedding_bounds_check_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host.cpp
@@ -24,7 +24,7 @@ void bounds_check_indices_cuda(
     int64_t bounds_check_mode,
     Tensor& warning,
     const c10::optional<Tensor>& weights,
-    const c10::optional<Tensor>& vbe_metadata,
+    const c10::optional<Tensor>& B_ofsets,
     const int64_t max_B);
 
 // Deprecated for fb namespace! Please use fbgemm namespace instead!

--- a/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
@@ -43,10 +43,10 @@ void bounds_check_indices_cpu(
     int64_t bounds_check_mode_,
     Tensor& warning,
     const c10::optional<Tensor>& weights,
-    const c10::optional<Tensor>& vbe_metadata,
+    const c10::optional<Tensor>& B_offsets,
     const int64_t /*max_B*/) {
   TORCH_CHECK(
-      !vbe_metadata.has_value(),
+      !B_offsets.has_value(),
       "bounds_check_indices on CPU does not support variable length (batch size)");
   auto bounds_check_mode = static_cast<BoundsCheckMode>(bounds_check_mode_);
   if (bounds_check_mode == BoundsCheckMode::WARNING) {
@@ -168,7 +168,7 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
   // The (a!) tells PyTorch this is an impure operation and so cannot be CSE'd
   // or DCE'd, etc.
   m.def(
-      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(b!) offsets, int bounds_check_mode, Tensor(c!) warning, Tensor(d!)? weights=None, Tensor? vbe_metadata=None, int max_B=-1) -> ()");
+      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(b!) offsets, int bounds_check_mode, Tensor(c!) warning, Tensor(d!)? weights=None, Tensor? B_offsets=None, int max_B=-1) -> ()");
   DISPATCH_TO_CPU("bounds_check_indices", bounds_check_indices_cpu);
 }
 
@@ -176,6 +176,6 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   // The (a!) tells PyTorch this is an impure operation and so cannot be CSE'd
   // or DCE'd, etc.
   m.def(
-      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(b!) offsets, int bounds_check_mode, Tensor(c!) warning, Tensor(d!)? weights=None, Tensor? vbe_metadata=None, int max_B=-1) -> ()");
+      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(b!) offsets, int bounds_check_mode, Tensor(c!) warning, Tensor(d!)? weights=None, Tensor? B_offsets=None, int max_B=-1) -> ()");
   DISPATCH_TO_CPU("bounds_check_indices", bounds_check_indices_cpu);
 }

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.cuh
@@ -28,7 +28,10 @@ transpose_embedding_input(
     int64_t total_hash_size_bits,
     at::Tensor indices,
     at::Tensor offsets,
-    bool nobag = false);
+    bool nobag = false,
+    const c10::optional<at::Tensor>& vbe_b_t_map = c10::optional<at::Tensor>(),
+    const int64_t info_B_num_bits = 26,
+    const int64_t info_B_mask = 0x2FFFFFF);
 
 // Use these functions instead of directly calling cub functions
 // to reduce code size and compilation time.

--- a/fbgemm_gpu/src/split_embeddings_utils.cpp
+++ b/fbgemm_gpu/src/split_embeddings_utils.cpp
@@ -13,6 +13,6 @@
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
-      "transpose_embedding_input(Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, bool nobag=False) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)");
+      "transpose_embedding_input(Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, bool nobag=False, Tensor? vbe_b_t_map=None, int info_B_num_bits=26, int info_B_mask=0x2FFFFFF) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)");
   DISPATCH_TO_CUDA("transpose_embedding_input", transpose_embedding_input);
 }

--- a/fbgemm_gpu/src/split_embeddings_utils.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils.cu
@@ -141,7 +141,10 @@ transpose_embedding_input(
     int64_t total_hash_size_bits,
     Tensor indices,
     Tensor offsets,
-    bool nobag) {
+    bool nobag,
+    const c10::optional<Tensor>& vbe_b_t_map,
+    const int64_t info_B_num_bits,
+    const int64_t info_B_mask) {
   const int32_t T = hash_size_cumsum.size(0) - 1;
   const int32_t B = (offsets.size(0) - 1) / T;
 


### PR DESCRIPTION
Summary:
Prepare `transpose_embedding_input` for variable batch size TBE (VBE).

- Update the frontend API with new args

Differential Revision: D45212897

