### PR TITLE
[Fix] Fix compilation error under ROCm 5.3

### DIFF
--- a/fbgemm_gpu/src/sparse_ops.cu
+++ b/fbgemm_gpu/src/sparse_ops.cu
@@ -1668,7 +1668,8 @@ __launch_bounds__(kMaxThreads) void reorder_batched_ad_indices_kernel(
   const auto num_elements = input_segment_end - input_segment_start;
 
   if (broadcast_indices) {
-    for (auto i = threadIdx.x; i < num_ads_b * num_elements; i += blockDim.x) {
+    for (int32_t i = threadIdx.x; i < num_ads_b * num_elements;
+         i += blockDim.x) {
       reordered_cat_ad_indices[output_segment_start + i] =
           cat_ad_indices[input_segment_start + i % num_elements];
     }


### PR DESCRIPTION
Summary:

- Fix bug introduced by PR 1711 (D45155887), which broke compilation of FBGEMM_GPU under ROCm 5.3