### PR TITLE
remove optional for two ops

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -310,7 +310,8 @@ at::Tensor fusednbitrowwise_to_float_or_half_cpu(
 at::Tensor reorder_batched_ad_lengths_gpu(
     const at::Tensor& cat_ad_lengths,
     const at::Tensor& batch_offsets,
-    const int64_t num_ads_in_batch);
+    const int64_t num_ads_in_batch,
+    const c10::optional<bool>& broadcast_lengths = false);
 
 ///@ingroup sparse-data-cuda
 at::Tensor reorder_batched_ad_indices_gpu(
@@ -326,7 +327,8 @@ at::Tensor reorder_batched_ad_indices_gpu(
 at::Tensor reorder_batched_ad_lengths_cpu(
     const at::Tensor& cat_ad_lengths,
     const at::Tensor& batch_offsets,
-    const int64_t num_ads_in_batch);
+    const int64_t num_ads_in_batch,
+    const c10::optional<bool>& broadcast_lengths = false);
 ///@ingroup sparse-data-cpu
 at::Tensor reorder_batched_ad_indices_cpu(
     const at::Tensor& cat_ad_offsets,

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -311,7 +311,7 @@ at::Tensor reorder_batched_ad_lengths_gpu(
     const at::Tensor& cat_ad_lengths,
     const at::Tensor& batch_offsets,
     const int64_t num_ads_in_batch,
-    const c10::optional<bool>& broadcast_lengths = false);
+    const bool broadcast_lengths = false);
 
 ///@ingroup sparse-data-cuda
 at::Tensor reorder_batched_ad_indices_gpu(
@@ -320,15 +320,15 @@ at::Tensor reorder_batched_ad_indices_gpu(
     const at::Tensor& reordered_cat_ad_offsets,
     const at::Tensor& batch_offsets,
     const int64_t num_ads_in_batch,
-    const c10::optional<bool>& broadcast_indices = false,
-    const c10::optional<int64_t>& num_indices_after_broadcast = 0);
+    const bool broadcast_indices = false,
+    const int64_t num_indices_after_broadcast = -1);
 
 ///@ingroup sparse-data-cpu
 at::Tensor reorder_batched_ad_lengths_cpu(
     const at::Tensor& cat_ad_lengths,
     const at::Tensor& batch_offsets,
     const int64_t num_ads_in_batch,
-    const c10::optional<bool>& broadcast_lengths = false);
+    const bool broadcast_lengths = false);
 ///@ingroup sparse-data-cpu
 at::Tensor reorder_batched_ad_indices_cpu(
     const at::Tensor& cat_ad_offsets,
@@ -336,8 +336,8 @@ at::Tensor reorder_batched_ad_indices_cpu(
     const at::Tensor& reordered_cat_ad_offsets,
     const at::Tensor& batch_offsets,
     const int64_t num_ads_in_batch,
-    const c10::optional<bool>& broadcast_indices = false,
-    const c10::optional<int64_t>& num_indices_after_broadcast = 0);
+    const bool broadcast_indices = false,
+    const int64_t num_indices_after_broadcast = -1);
 
 at::Tensor recat_embedding_grad_output_cuda(
     at::Tensor grad_output, // [B_local][T_global][D]


### PR DESCRIPTION
Summary: remove unnecessary optional decorators for the two newly added sparse ops

Differential Revision: D45286152

