### PR TITLE
[T151287074] Split the Rendering of `embedding_forward_split_template.cu` into Smaller Files

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -185,8 +185,15 @@ set(gen_gpu_kernel_source_files
     "gen_embedding_backward_split_indice_weights_codegen_cuda.cu"
     "gen_embedding_backward_split_grad.cu")
 
+foreach(wdesc dense split)
+  list(APPEND gen_gpu_kernel_source_files
+    "gen_embedding_forward_${wdesc}_unweighted_nobag_kernel_small.cu")
+endforeach()
+
 foreach(wdesc weighted unweighted_nobag unweighted)
   list(APPEND gen_gpu_kernel_source_files
+      "gen_embedding_forward_split_${wdesc}_kernel.cu"
+      "gen_embedding_forward_dense_${wdesc}_kernel.cu"
       "gen_embedding_forward_quantized_split_nbit_host_${wdesc}_codegen_cuda.cu"
       "gen_embedding_backward_dense_split_${wdesc}_cuda.cu"
       "gen_embedding_backward_dense_split_${wdesc}_kernel_cta.cu"
@@ -249,6 +256,8 @@ set(codegen_dependencies
     ${CMAKE_CODEGEN_DIR}/embedding_forward_quantized_split_nbit_kernel_template.cu
     ${CMAKE_CODEGEN_DIR}/embedding_forward_split_cpu.cpp
     ${CMAKE_CODEGEN_DIR}/embedding_forward_split_cpu.h
+    ${CMAKE_CODEGEN_DIR}/embedding_forward_split_kernel_template.cu
+    ${CMAKE_CODEGEN_DIR}/embedding_forward_split_kernel_nobag_small_template.cu
     ${CMAKE_CODEGEN_DIR}/embedding_forward_split_template.cu
     ${CMAKE_CODEGEN_DIR}/embedding_forward_template_helpers.cuh
     ${CMAKE_CODEGEN_DIR}/__init__.template

--- a/fbgemm_gpu/codegen/embedding_backward_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_backward_code_generator.py
@@ -132,7 +132,7 @@ def int_arg(name: str, default: int = 0) -> str:
     return f"int {name} = {default}"
 
 
-def generate_backwards_embedding_cuda(
+def generate_backward_embedding_cuda(
     template_filepath: str,
     optimizer: str,
     filename_format: str,
@@ -161,7 +161,7 @@ def generate(**kwargs: Any) -> None:
     kwargs["args"] = gen_args["cuda"]
 
     # Generate the backward splits
-    generate_backwards_embedding_cuda(
+    generate_backward_embedding_cuda(
         "embedding_backward_split_template.cu",
         optimizer,
         "gen_embedding_backward_{}_split_{}_cuda.cu",
@@ -169,7 +169,7 @@ def generate(**kwargs: Any) -> None:
     )
 
     # Generate the cta_per_row kernels for the backward splits
-    generate_backwards_embedding_cuda(
+    generate_backward_embedding_cuda(
         "embedding_backward_split_kernel_cta_template.cu",
         optimizer,
         "gen_embedding_backward_{}_split_{}_kernel_cta.cu",
@@ -177,7 +177,7 @@ def generate(**kwargs: Any) -> None:
     )
 
     # Generate the warp_per_row kernels for the backward splits
-    generate_backwards_embedding_cuda(
+    generate_backward_embedding_cuda(
         "embedding_backward_split_kernel_warp_template.cu",
         optimizer,
         "gen_embedding_backward_{}_split_{}_kernel_warp.cu",
@@ -1291,18 +1291,49 @@ def lars_sgd() -> None:
     )
 
 
+def generate_forward_embedding_cuda(
+    template_filepath: str,
+    filename_format: str,
+) -> None:
+    template = env.get_template(template_filepath)
+    for dense in [True, False]:
+        for weighted in [True, False]:
+            for nobag in [True, False]:
+                if not nobag or not weighted:
+                    wdesc = f"{ 'dense' if dense else 'split'}_{ 'weighted' if weighted else 'unweighted' }{ '_nobag' if nobag else '' }"
+                    filename = filename_format.format(wdesc)
+                    write(
+                        filename,
+                        template.render(dense=dense, weighted=weighted, nobag=nobag),
+                    )
+                    print(f"[Forward Split]: {filename}")
+
+
 def forward_split() -> None:
+    # Generate the forward splits
     template = env.get_template("embedding_forward_split_template.cu")
+    for dense in [True, False]:
+        for weighted in [True, False]:
+            wdesc = f"{ 'dense' if dense else 'split' }_{ 'weighted' if weighted else 'unweighted' }"
+            filename = f"gen_embedding_forward_{wdesc}_codegen_cuda.cu"
+            write(filename, template.render(weighted=weighted, dense=dense))
+            print(f"[Forward Split]: {filename}")
 
-    src_cu = template.render(weighted=False)
-    write("gen_embedding_forward_split_unweighted_codegen_cuda.cu", src_cu)
-    src_cu = template.render(weighted=True)
-    write("gen_embedding_forward_split_weighted_codegen_cuda.cu", src_cu)
+    # Generate the kernels for the forward splits
+    generate_forward_embedding_cuda(
+        "embedding_forward_split_kernel_template.cu",
+        "gen_embedding_forward_{}_kernel.cu",
+    )
 
-    src_cu = template.render(weighted=False, dense=True)
-    write("gen_embedding_forward_dense_unweighted_codegen_cuda.cu", src_cu)
-    src_cu = template.render(weighted=True, dense=True)
-    write("gen_embedding_forward_dense_weighted_codegen_cuda.cu", src_cu)
+    # Generate the small kernels (for nobag only) for the forward splits
+    template = env.get_template(
+        "embedding_forward_split_kernel_nobag_small_template.cu"
+    )
+    for dense in [True, False]:
+        wdesc = f"{ 'dense' if dense else 'split' }"
+        filename = f"gen_embedding_forward_{wdesc}_unweighted_nobag_kernel_small.cu"
+        write(filename, template.render(dense=dense))
+        print(f"[Forward Split]: {filename}")
 
 
 def forward_quantized() -> None:

--- a/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
@@ -10,12 +10,6 @@
 using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
 
-{% if not dense %}
-constexpr int32_t kCacheLocationMissing = -1;
-{% endif %}
-
-constexpr size_t kForwardMaxThreads = 512;
-
 // TODO: optimization to use multiple warps per row.
 template <typename emb_t, typename grad_t, typename cache_t, size_t kMaxVecsPerThread>
 __global__

--- a/fbgemm_gpu/codegen/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_kernel_cta_template.cu
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 // clang-format off
-{% set wdesc = "weighted" if weighted else "unweighted" %}
+{%- set wdesc = "weighted" if weighted else "unweighted" %}
 #include "fbgemm_gpu/embedding_backward_template_helpers.cuh"
 #include "fbgemm_gpu/split_embeddings_utils.cuh"
 
@@ -22,19 +22,19 @@ __global__ __launch_bounds__(kMaxThreads) void
 split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_kernel_cta_per_row_1(
     const at::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits> grad_output,
     at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
-    {% if not dense %}
+    {%- if not dense %}
     at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> uvm_weights,
     at::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         weights_placements,
-    {% endif %}
+    {%- endif %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
-    {% if not nobag %}
+    {%- if not nobag %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
-    {% else %}
+    {%- else %}
     int32_t B,
     int64_t D,
-    {% endif %}
+    {%- endif %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         hash_size_cumsum,
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
@@ -45,27 +45,27 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
         long_run_ids,
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         num_long_run_ids,
-    {% if not nobag %}
+    {%- if not nobag %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_infos,
-    {% else %}
+    {%- else %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_infos,
-    {% endif %}
-    {% if not dense %}
+    {%- endif %}
+    {%- if not dense %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         sorted_lxu_cache_locations,
-    {% endif %}
-    {% if weighted %}
+    {%- endif %}
+    {%- if weighted %}
     const at::PackedTensorAccessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits> sorted_indice_weights,
-    {% endif %}
-    {% if not dense %}
+    {%- endif %}
+    {%- if not dense %}
     bool stochastic_rounding,
     at::PhiloxCudaState stochastic_rounding_philox_args,
-    {% else %}
+    {%- else %}
     at::PackedTensorAccessor64<cache_t, 1, at::RestrictPtrTraits> grad_dev_weights,
-    {% endif %}
-    {% if not nobag %}
+    {%- endif %}
+    {%- if not nobag %}
     FixedDivisor fd,
-    {% endif %}
+    {%- endif %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> long_run_id_to_really_long_run_ids,
     at::PackedTensorAccessor32<at::acc_type<cache_t, true>, 2, at::RestrictPtrTraits> temp_grad_accum,
     at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> grad_accum_counter,
@@ -81,9 +81,9 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
 #endif
   constexpr int VEC_WIDTH = 4;
   int32_t T = weights_offsets.size(0);
-  {% if not nobag %}
+  {%- if not nobag %}
   const int32_t B = grad_output.size(0);
-  {% endif %}
+  {%- endif %}
   const int32_t num_long_runs = num_long_run_ids[0];
   for (int32_t long_run_id = blockIdx.x; long_run_id < num_long_runs; long_run_id += gridDim.x) {
         // The first thread block in the really long run has run_id in long_run_ids
@@ -119,16 +119,16 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
         //
         const auto info_0 = sorted_infos[segment_start];
 
-        {% if not nobag %}
+        {%- if not nobag %}
         int32_t t_0 = fd.Div(info_0); //info_0 / B;
-        {% else %}
+        {%- else %}
         int32_t t_0 = info_0 % T;
-        {% endif %}
+        {%- endif %}
 
         int64_t hash_size = hash_size_cumsum[t_0];
-        {% if not nobag %}
+        {%- if not nobag %}
         int32_t D = D_offsets[t_0 + 1] - D_offsets[t_0];
-        {% endif %}
+        {%- endif %}
         int64_t idx = linear_index - hash_size;
 
         const int32_t SL_per_warp = div_round_up(SL, blockDim.y);
@@ -137,47 +137,47 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
         Vec4T<at::acc_type<cache_t, true>> grad_sum[kMaxVecsPerThread];
         for (int32_t sl = sl_start; sl < sl_end; sl += kThreadGroupSize) {
             int32_t sl_j = sl + threadIdx.x;
-            {% if not nobag %}
+            {%- if not nobag %}
             int32_t b_t = sl_j < sl_end ? sorted_infos[segment_start + sl_j] : 0;
             int32_t b; //= b_t % B;
             int32_t t; //= b_t / B;
             fd.DivMod(b_t, &t, &b);
             int32_t D_start = sl_j < sl_end ? D_offsets[t] : 0;
-            {% else %}
+            {%- else %}
             int64_t l_t = sl_j < sl_end ? sorted_infos[segment_start + sl_j] : 0;
             int32_t l = l_t / T;
-            {% endif %}
-            {% if weighted %}
+            {%- endif %}
+            {%- if weighted %}
             at::acc_type<cache_t, true> idx_weight = sl_j < sl_end ? sorted_indice_weights[segment_start + sl_j] : 0.0;
-            {% endif %}
+            {%- endif %}
             for (int32_t j = 0; j < kThreadGroupSize && sl + j < sl_end; ++j) {
-                {% if not nobag %}
+                {%- if not nobag %}
                 int32_t b_j = SHFL_SYNC(b, j);
                 int32_t D_start_j = SHFL_SYNC(D_start, j);
-                {% else %}
+                {%- else %}
                 int32_t l_j = SHFL_SYNC(l, j);
-                {% endif %}
+                {%- endif %}
 
-                {% if weighted %}
+                {%- if weighted %}
                 at::acc_type<cache_t, true> idx_weight_j = SHFL_SYNC(idx_weight, j);
-                {% endif %}
+                {%- endif %}
 
         #pragma unroll kMaxVecsPerThread
                 for (int32_t i = 0;
                     i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
                     ++i) {
                     int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
-                    {% if not nobag %}
+                    {%- if not nobag %}
                     Vec4T<at::acc_type<grad_t, true>> grad_out_vec(
                         &grad_output[b_j][0] + D_start_j + d);
-                    {% else %}
+                    {%- else %}
                     Vec4T<at::acc_type<grad_t, true>> grad_out_vec(&grad_output[l_j][d]);
-                    {% endif %}
-                    {% if weighted %}
+                    {%- endif %}
+                    {%- if weighted %}
                     grad_sum[i].fma_(grad_out_vec, idx_weight_j);
-                    {% else %}
+                    {%- else %}
                     grad_sum[i].add_(grad_out_vec);
-                    {% endif %}
+                    {%- endif %}
                 }
             }
         }
@@ -328,7 +328,7 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
         }
 
         int64_t weights_offset = weights_offsets[t_0];
-        {% if not dense %}
+        {%- if not dense %}
         emb_t* __restrict__ weights{nullptr};
         cache_t* __restrict__ cache_weights{nullptr};
         int32_t D_emb = D;
@@ -347,7 +347,7 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
                 cache_weights = &lxu_cache_weights[cache_idx][0];
             }
         }
-        {% for tensor in args.split_tensors %}
+        {%- for tensor in args.split_tensors %}
         at::acc_type<cache_t, true>* __restrict__ {{ tensor }};
         const auto {{ tensor }}_placement = static_cast<PlacementType>({{ tensor }}_placements[t_0]);
         int64_t {{ tensor }}_offset = {{ tensor }}_offsets[t_0];
@@ -356,7 +356,7 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
         } else {
             {{ tensor }} = &{{ tensor }}_uvm[{{ tensor }}_offset];
         }
-        {% endfor %}
+        {%- endfor %}
 
 
         struct SharedMemory<Vec4T<at::acc_type<cache_t, true>>> weight_update_buffer;
@@ -411,7 +411,7 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
                 weight_row_template.store(shared_weight_update_row[lane_id + i * kThreadGroupSize], d, qparams_new);
             }
         }
-        {% else %}
+        {%- else %}
 #pragma unroll kMaxVecsPerThread
         for (int32_t i = 0;
             i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
@@ -420,160 +420,179 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
             auto& grad = grad_sum[i];
             grad.store(&grad_dev_weights[weights_offset + idx * D + d]);
         }
-        {% endif %}
+        {%- endif %}
     } // for each run
 }
 
 /*
     Explicitly instantiate the kernel function template.  The instantiations are
-    based on the DISPATCH_EMB_GRAD_CACHE_TYPES macro in
+    based on the types enumerated by DISPATCH_EMB_GRAD_CACHE_TYPES macro used in
     embedding_backward_split_template.cu
-
-    Because duplicate instantiations can exist for the case where
-    FBGEMM_USE_SUBWARP_SHUFFLE is undefined, we split separate the template
-    instantiations for the FBGEMM_USE_SUBWARP_SHUFFLE defined and undefined
-    cases.
-
-    kMaxElemPerThread is # of elements handled by thread if we use a full warp
-    for a row.
-    We consider kMaxElemPerThread 1 and 2, and then a multiple of 4.
 */
 
-{% for grad_type in ['float', 'at::Half'] -%}
-{% for emb_type in ['uint8_t', 'float', 'at::Half'] -%}
-{% for cache_type in ['float', 'at::Half'] -%}
+{%- for grad_type in ['float', 'at::Half'] %}
+{%- for emb_type in ['uint8_t', 'float', 'at::Half'] %}
+{%- for cache_type in ['float', 'at::Half'] %}
 
 ////////////////////////////////////////////////////////////////////////////////
 #ifdef FBGEMM_USE_SUBWARP_SHUFFLE
 ////////////////////////////////////////////////////////////////////////////////
 
-{% for kMaxElemPerThread in range(1, max_embedding_dim // (items_per_warp // 4) + 1) -%}
-{% if kMaxElemPerThread in [1, 2] or kMaxElemPerThread % 4 == 0 %}
+{#- /*
+    Compute the Cartesian product of (kMaxVecsPerThread, kThreadGroupSize)
+    in the FBGEMM_USE_SUBWARP_SHUFFLE case
 
-// kMaxElemPerThread = {{ kMaxElemPerThread }};
-// kMaxVecsPerThread = std::max({{ kMaxElemPerThread }} / 4,  1);
-// kThreadGroupSize = FBGEMM_USE_SUBWARP_SHUFFLE ? kWarpSize / std::max(4 / {{ kMaxElemPerThread }}, 1) : kWarpSize;
-{%- set kMaxVecsPerThread = [ (kMaxElemPerThread // 4), 1 ] | max %}
+    constexpr int kMaxVecsPerThread = std::max({{ kMaxElemPerThread }} / 4, 1);
+    constexpr int kThreadGroupSize = kWarpSize / std::max(4 / {{ kMaxElemPerThread }}, 1);
+
+    This is needed to compute the unique tuples to use for explicit instantiation,
+    so that we can avoid duplicate template instantiations.
+*/ #}
+{%- set tuples = [] %}
+{%- for kMaxElemPerThread in range(1, max_embedding_dim // (items_per_warp // 4) + 1) %}
+{%- if kMaxElemPerThread in [1, 2] or kMaxElemPerThread % 4 == 0 %}
+    {%- set t0 = [ (kMaxElemPerThread // 4), 1 ] | max %}
+    {%- set t1 = [ 4 // kMaxElemPerThread, 1] | max %}
+    {%- set temp = tuples.append((t0, "(kWarpSize / " ~ t1 ~ ")")) %}
+{%- endif %}
+{%- endfor %}
+
+{#- /* Enumerate over the unique tuples */ #}
+{%- for (kMaxVecsPerThread, kThreadGroupSize) in tuples | unique %}
+
 template __global__ __launch_bounds__(kMaxThreads)
 void split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_kernel_cta_per_row_1
 < {{ emb_type }},
   {{ grad_type }},
   {{ cache_type }},
-  {{ kMaxVecsPerThread }},                                // kMaxVecsPerThread
-  (kWarpSize / {{ [ 4 // kMaxElemPerThread, 1] | max }})  // kThreadGroupSize
+  {{ kMaxVecsPerThread }},
+  {{ kThreadGroupSize }}
 > (
     const at::PackedTensorAccessor64<{{ grad_type  }}, 2, at::RestrictPtrTraits> grad_output,
     at::PackedTensorAccessor64<{{ emb_type  }}, 1, at::RestrictPtrTraits> dev_weights,
-    {% if not dense %}
+    {%- if not dense %}
     at::PackedTensorAccessor64<{{ emb_type  }}, 1, at::RestrictPtrTraits> uvm_weights,
     at::PackedTensorAccessor64<{{ cache_type  }}, 2, at::RestrictPtrTraits> lxu_cache_weights,
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
-    {% endif %}
+    {%- endif %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
-    {% if not nobag %}
+    {%- if not nobag %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
-    {% else %}
+    {%- else %}
     int32_t B,
     int64_t D,
-    {% endif %}
+    {%- endif %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> hash_size_cumsum,
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_linear_indices_run,
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_cumulative_run_lengths,
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> long_run_ids,
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> num_long_run_ids,
-    {% if not nobag %}
+    {%- if not nobag %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_infos,
-    {% else %}
+    {%- else %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_infos,
-    {% endif %}
-    {% if not dense %}
+    {%- endif %}
+    {%- if not dense %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_lxu_cache_locations,
-    {% endif %}
-    {% if weighted %}
+    {%- endif %}
+    {%- if weighted %}
     const at::PackedTensorAccessor32<at::acc_type<{{ cache_type  }}, true>, 1, at::RestrictPtrTraits> sorted_indice_weights,
-    {% endif %}
-    {% if not dense %}
+    {%- endif %}
+    {%- if not dense %}
     bool stochastic_rounding,
     at::PhiloxCudaState stochastic_rounding_philox_args,
-    {% else %}
+    {%- else %}
     at::PackedTensorAccessor64<{{ cache_type  }}, 1, at::RestrictPtrTraits> grad_dev_weights,
-    {% endif %}
-    {% if not nobag %}
+    {%- endif %}
+    {%- if not nobag %}
     FixedDivisor fd,
-    {% endif %}
+    {%- endif %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> long_run_id_to_really_long_run_ids,
     at::PackedTensorAccessor32<at::acc_type<{{ cache_type  }}, true>, 2, at::RestrictPtrTraits> temp_grad_accum,
     at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> grad_accum_counter,
     const int32_t max_segment_length_per_cta,
     const bool use_deterministic_algorithms,
     {{ args.split_kernel_args_no_defaults | join(",\n    ") | replace("cache_t", cache_type) }});
-{%- endif %}
+
 {%- endfor %}
 
 ////////////////////////////////////////////////////////////////////////////////
 #else
 ////////////////////////////////////////////////////////////////////////////////
 
-{%- set kMaxVecsPerThreadValues = [] %}
+{#- /*
+    Compute the Cartesian product of (kMaxVecsPerThread, kThreadGroupSize)
+    in the non-FBGEMM_USE_SUBWARP_SHUFFLE case
+
+    constexpr int kMaxVecsPerThread = std::max({{ kMaxElemPerThread }} / 4, 1);
+    constexpr int kThreadGroupSize = kWarpSize;
+*/ #}
+{%- set tuples = [] %}
 {%- for kMaxElemPerThread in range(1, max_embedding_dim // (items_per_warp // 4) + 1) %}
 {%- if kMaxElemPerThread in [1, 2] or kMaxElemPerThread % 4 == 0 %}
-{%- set temp = kMaxVecsPerThreadValues.append([ (kMaxElemPerThread // 4), 1 ] | max) %}
+    {%- set t0 = [ (kMaxElemPerThread // 4), 1 ] | max %}
+    {%- set t1 = [ 4 // kMaxElemPerThread, 1] | max %}
+    {%- set temp = tuples.append((t0, "kWarpSize")) %}
 {%- endif %}
 {%- endfor %}
-{%- for kMaxVecsPerThread in kMaxVecsPerThreadValues | unique %}
+
+{#- /* Enumerate over the unique tuples */ #}
+{%- for (kMaxVecsPerThread, kThreadGroupSize) in tuples | unique %}
+
 template __global__ __launch_bounds__(kMaxThreads)
 void split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_kernel_cta_per_row_1
 < {{ emb_type }},
   {{ grad_type }},
   {{ cache_type }},
-  {{ kMaxVecsPerThread }},  // kMaxVecsPerThread
-  kWarpSize                 // kThreadGroupSize
+  {{ kMaxVecsPerThread }},
+  {{ kThreadGroupSize }}
 > (
     const at::PackedTensorAccessor64<{{ grad_type  }}, 2, at::RestrictPtrTraits> grad_output,
     at::PackedTensorAccessor64<{{ emb_type  }}, 1, at::RestrictPtrTraits> dev_weights,
-    {% if not dense %}
+    {%- if not dense %}
     at::PackedTensorAccessor64<{{ emb_type  }}, 1, at::RestrictPtrTraits> uvm_weights,
     at::PackedTensorAccessor64<{{ cache_type  }}, 2, at::RestrictPtrTraits> lxu_cache_weights,
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
-    {% endif %}
+    {%- endif %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
-    {% if not nobag %}
+    {%- if not nobag %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
-    {% else %}
+    {%- else %}
     int32_t B,
     int64_t D,
-    {% endif %}
+    {%- endif %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> hash_size_cumsum,
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_linear_indices_run,
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_cumulative_run_lengths,
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> long_run_ids,
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> num_long_run_ids,
-    {% if not nobag %}
+    {%- if not nobag %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_infos,
-    {% else %}
+    {%- else %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_infos,
-    {% endif %}
-    {% if not dense %}
+    {%- endif %}
+    {%- if not dense %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_lxu_cache_locations,
-    {% endif %}
-    {% if weighted %}
+    {%- endif %}
+    {%- if weighted %}
     const at::PackedTensorAccessor32<at::acc_type<{{ cache_type  }}, true>, 1, at::RestrictPtrTraits> sorted_indice_weights,
-    {% endif %}
-    {% if not dense %}
+    {%- endif %}
+    {%- if not dense %}
     bool stochastic_rounding,
     at::PhiloxCudaState stochastic_rounding_philox_args,
-    {% else %}
+    {%- else %}
     at::PackedTensorAccessor64<{{ cache_type  }}, 1, at::RestrictPtrTraits> grad_dev_weights,
-    {% endif %}
-    {% if not nobag %}
+    {%- endif %}
+    {%- if not nobag %}
     FixedDivisor fd,
-    {% endif %}
+    {%- endif %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> long_run_id_to_really_long_run_ids,
     at::PackedTensorAccessor32<at::acc_type<{{ cache_type  }}, true>, 2, at::RestrictPtrTraits> temp_grad_accum,
     at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> grad_accum_counter,
     const int32_t max_segment_length_per_cta,
     const bool use_deterministic_algorithms,
     {{ args.split_kernel_args_no_defaults | join(",\n    ") | replace("cache_t", cache_type) }});
+
 {%- endfor %}
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/codegen/embedding_forward_split_kernel_nobag_small_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_kernel_nobag_small_template.cu
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+{#
+// @lint-ignore LINTIGNORE
+// @lint-ignore-every CLANGFORMAT
+// clang-format off
+// Note: clang-format off doesn't work with this templaterized code,
+// so we need to keep lint-ignore-every.
+// See https://fburl.com/dw9ljh4h
+#}
+
+{%- set wdesc =  "weighted" if weighted else "unweighted" %}
+#include "codegen/embedding_forward_template_helpers.cuh"
+
+using Tensor = at::Tensor;
+using namespace fbgemm_gpu;
+
+template <
+    typename emb_t,
+    typename cache_t,
+    typename output_t,
+    typename index_t,
+    size_t kThreadGroupSize
+    >
+__launch_bounds__(kForwardMaxThreads) __global__ void
+{{ "dense" if dense else "split" }}_embedding_nobag_codegen_forward_unweighted_small_kernel(
+    const at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
+    {%- if not dense %}
+    const at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> uvm_weights,
+    const at::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
+    {%- endif %}
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
+    int64_t D,
+    FixedDivisor fd_B,
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
+    {%- if not dense %}
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> lxu_cache_locations,
+    {%- endif %}
+    at::PackedTensorAccessor64<output_t, 2, at::RestrictPtrTraits> output // [B][total_D],
+    ) {
+    int32_t T = weights_offsets.size(0);
+    int32_t B = (offsets.size(0) - 1) / T;
+    int32_t b_t = blockIdx.x * blockDim.y + threadIdx.y;
+    if (b_t >= B * T) {
+        return;
+    }
+    int32_t t;
+    int32_t b;
+    fd_B.DivMod(b_t, &t, &b);
+    int64_t weights_offset = weights_offsets[t];
+    index_t indices_start = offsets[t * B + b];
+    index_t indices_end = offsets[t * B + b + 1];
+    int32_t L = indices_end - indices_start;
+    const emb_t* __restrict__ weights;
+    {%- if not dense %}
+    const auto placement = static_cast<PlacementType>(weights_placements[t]);
+    if (placement == PlacementType::DEVICE) {
+        weights = &dev_weights[weights_offset];
+    } else {
+        weights = &uvm_weights[weights_offset];
+    }
+    {%- else %}
+    weights = &dev_weights[weights_offset];
+    {%- endif %}
+
+    int32_t D_emb = D;
+    if (std::is_same<emb_t, uint8_t>::value) {
+        D_emb += kINT8QparamsBytes;
+    }
+
+    const int32_t group_start = threadIdx.x / kThreadGroupSize * kThreadGroupSize;
+    const int32_t group_end = group_start + kThreadGroupSize;
+    const int32_t d = threadIdx.x % kThreadGroupSize * 4;
+
+    for (int32_t l_start = 0; l_start < L; l_start += kWarpSize) {
+        int32_t l = l_start + threadIdx.x;
+        int64_t idx = l < L ? indices[indices_start + l] : 0;
+        {%- if not dense %}
+        int32_t cache_idx = (placement == PlacementType::MANAGED_CACHING && l < L) ? lxu_cache_locations[indices_start + l] : 0;
+        {%- endif %}
+        for (auto j = group_start; j < group_end && l_start + j < L; ++j) {
+            int64_t idx_j = shfl_sync(idx, j);
+            int64_t output_j = indices_start + l_start + j;
+            {%- if not dense %}
+            int32_t cache_idx_j = shfl_sync(cache_idx, j);
+            {%- endif %}
+
+            {%- if not dense %}
+
+            // assume cache is fp16/fp32 which doesn't require qparams
+            float2 qparams_cache = make_float2(0.0f, 0.0f);
+
+            {%- endif %}
+            auto weight_row_emb = WeightRow<emb_t, cache_t, cache_t>(
+                const_cast<emb_t*>(&weights[idx_j * D_emb]),
+                nullptr,
+                D,
+                nullptr);
+            float2 qparams_emb;
+            if (std::is_same<emb_t, uint8_t>::value) {
+                qparams_emb = weight_row_emb.load_qparams();
+            }
+
+            if (d < D) {
+                {%- if not dense %}
+                if (placement == PlacementType::MANAGED_CACHING && cache_idx_j != kCacheLocationMissing) {
+                    auto weight_row_cache = WeightRow<emb_t, cache_t, cache_t>(
+                        const_cast<emb_t*>(&weights[idx_j * D_emb]),
+                        const_cast<cache_t*>(&lxu_cache_weights[cache_idx_j][0]),
+                        D,
+                        nullptr);
+                    Vec4T<cache_t> weight = weight_row_cache.load(d, qparams_cache);
+                    weight.store(&output[output_j][d]);
+                } else {
+                    Vec4T<cache_t> weight = weight_row_emb.load(d, qparams_emb);
+                    weight.store(&output[output_j][d]);
+                }
+                {%- else %}
+                    Vec4T<cache_t> weight = weight_row_emb.load(d, qparams_emb);
+                    weight.store(&output[output_j][d]);
+                {%- endif %}
+            }
+        }
+    }
+}
+
+/*
+    Explicitly instantiate the kernel function template.  The instantiations are
+    based on the types enumerated by DISPATCH_EMB_GRAD_CACHE_TYPES macro used in
+    embedding_forward_split_template.cu
+*/
+
+{%- for output_type in ['uint8_t', 'at::Half', 'float'] %}
+{%- for emb_type in ['uint8_t', 'float', 'at::Half'] %}
+{%- for cache_type in ['float', 'at::Half'] %}
+{%- for kEmbeddingSize in [4, 8, 16, 32] %}
+{%- set index_type = 'int64_t' %}
+
+template __launch_bounds__(kForwardMaxThreads) __global__
+void {{ "dense" if dense else "split" }}_embedding_nobag_codegen_forward_unweighted_small_kernel
+<
+  {{ emb_type }},
+  {{ cache_type }},
+  {{ output_type }},
+  {{ index_type }},
+  {{ kEmbeddingSize // 4 }}
+> (
+    const at::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> dev_weights,
+    {%- if not dense %}
+    const at::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> uvm_weights,
+    const at::PackedTensorAccessor64<{{ cache_type }}, 2, at::RestrictPtrTraits> lxu_cache_weights,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
+    {%- endif %}
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
+    int64_t D,
+    FixedDivisor fd_B,
+    const at::PackedTensorAccessor32<{{ index_type }}, 1, at::RestrictPtrTraits> indices,
+    const at::PackedTensorAccessor32<{{ index_type }}, 1, at::RestrictPtrTraits> offsets,
+    {%- if not dense %}
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> lxu_cache_locations,
+    {%- endif %}
+    at::PackedTensorAccessor64<{{ output_type }}, 2, at::RestrictPtrTraits> output);
+
+{%- endfor %}
+{%- endfor %}
+{%- endfor %}
+{%- endfor %}

--- a/fbgemm_gpu/codegen/embedding_forward_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_kernel_template.cu
@@ -1,0 +1,491 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+{#-
+// @lint-ignore LINTIGNORE
+// @lint-ignore-every CLANGFORMAT
+// clang-format off
+// Note: clang-format off doesn't work with this templaterized code,
+// so we need to keep lint-ignore-every.
+// See https://fburl.com/dw9ljh4h
+#}
+
+{%- set wdesc =  "weighted" if weighted else "unweighted" %}
+#include "codegen/embedding_forward_template_helpers.cuh"
+
+using Tensor = at::Tensor;
+using namespace fbgemm_gpu;
+
+template <
+    typename emb_t,
+    typename cache_t,
+    typename output_t,
+    {%- if not dense %}
+    bool use_lxu_cache,
+    {%- endif %}
+    typename index_t,
+    {%- if not nobag %}
+    size_t kMaxVecsPerThread,
+    {%- endif %}
+    size_t kThreadGroupSize >
+__launch_bounds__(kForwardMaxThreads) __global__
+void {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{{ wdesc }}_kernel(
+    const at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
+    {%- if not dense %}
+    const at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> uvm_weights,
+    const at::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
+    {%- endif %}
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
+    {%- if not nobag %}
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
+    {%- else %}
+    int64_t D,
+    {%- endif %}
+    FixedDivisor fd_B,
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
+    {%- if not nobag %}
+    int64_t pooling_mode,
+    {%- endif %}
+    {%- if weighted %}
+    at::PackedTensorAccessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits> indice_weights,
+    {%- endif %}
+    {%- if not dense %}
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> lxu_cache_locations,
+    {%- endif %}
+    at::PackedTensorAccessor64<output_t, 2, at::RestrictPtrTraits> output // [B][total_D],
+    ) {
+    int32_t T = weights_offsets.size(0);
+    {%- if not nobag %}
+    const bool mean_pooling = static_cast<PoolingMode>(pooling_mode) == PoolingMode::MEAN;
+    int32_t B = output.size(0);
+    {%- else %}
+    int32_t B = (offsets.size(0) - 1) / T;
+    {%- endif %}
+    int32_t b_t = blockIdx.x * blockDim.y + threadIdx.y;
+    if (b_t >= B * T) {
+        return;
+    }
+    int32_t t;
+    int32_t b;
+    fd_B.DivMod(b_t, &t, &b);
+    int64_t weights_offset = weights_offsets[t];
+    {%- if not nobag %}
+    int32_t D_start = D_offsets[t];
+    int32_t D_end = D_offsets[t + 1];
+    int32_t D = D_end - D_start;
+    {%- endif %}
+    index_t indices_start = offsets[t * B + b];
+    index_t indices_end = offsets[t * B + b + 1];
+    int32_t L = indices_end - indices_start;
+    const emb_t* __restrict__ weights;
+    {%- if not dense %}
+    const auto placement = static_cast<PlacementType>(weights_placements[t]);
+    if (placement == PlacementType::DEVICE) {
+        weights = &dev_weights[weights_offset];
+    } else {
+        weights = &uvm_weights[weights_offset];
+    }
+    {%- else %}
+    weights = &dev_weights[weights_offset];
+    {%- endif %}
+
+    int32_t D_emb = D;
+    if (std::is_same<emb_t, uint8_t>::value) {
+        D_emb += kINT8QparamsBytes;
+    }
+
+    constexpr int VEC_WIDTH = 4;
+#ifdef FBGEMM_USE_SUBWARP_SHUFFLE
+    const unsigned int shfl_sync_mask =
+        ((1L << kThreadGroupSize) - 1) <<
+        (threadIdx.y % (kWarpSize / kThreadGroupSize) * kThreadGroupSize);
+#else
+    const unsigned int shfl_sync_mask = 0xffffffffu;
+#endif
+
+    {%- if not nobag %}
+    const float inv_L = (mean_pooling && L != 0) ? static_cast<float>(1.0) / L: static_cast<float>(1.0);
+    Vec4T<cache_t> accumulators[kMaxVecsPerThread];
+    {%- endif %}
+    for (int32_t l_start = 0; l_start < L; l_start += kThreadGroupSize) {
+        int32_t l = l_start + threadIdx.x;
+        int64_t idx = l < L ? indices[indices_start + l] : 0;
+        {%- if not dense %}
+        int32_t cache_idx = (use_lxu_cache && placement == PlacementType::MANAGED_CACHING && l < L) ? lxu_cache_locations[indices_start + l] : 0;
+        {%- endif %}
+        {%- if weighted %}
+        at::acc_type<cache_t, true> idx_weight = l < L ? indice_weights[indices_start + l] : 0;
+        {%- endif %}
+        for (auto j = 0; j < kThreadGroupSize && l_start + j < L; ++j) {
+            int64_t idx_j = SHFL_SYNC(idx, j);
+            {%- if nobag %}
+            int64_t output_j = indices_start + l_start + j;
+            {%- endif %}
+            {%- if not dense %}
+            int32_t cache_idx_j = use_lxu_cache ? SHFL_SYNC(cache_idx, j) : 0;
+            {%- endif %}
+
+            {%- if weighted %}
+            at::acc_type<cache_t, true> idx_weight_j = SHFL_SYNC(idx_weight, j);
+            {%- endif %}
+
+            {%- if not dense %}
+            // use_lxu_cache is a compile time condition
+            if (use_lxu_cache && placement == PlacementType::MANAGED_CACHING && cache_idx_j != kCacheLocationMissing) {
+                auto weight_row_cache = WeightRow<emb_t, cache_t, cache_t>(
+                    const_cast<emb_t*>(&weights[idx_j * D_emb]),
+                    const_cast<cache_t*>(&lxu_cache_weights[cache_idx_j][0]),
+                    D,
+                    nullptr);
+                // assume cache is fp16/fp32 which doesn't require qparams
+                float2 qparams_cache = make_float2(0.0f, 0.0f);
+
+                {%- if not nobag %}
+                #pragma unroll kMaxVecsPerThread
+                for (int32_t i = 0;
+                    i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
+                    ++i) {
+                    int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
+                    Vec4T<cache_t> weight = weight_row_cache.load(d, qparams_cache);
+                    {%- if weighted %}
+                    accumulators[i].fma_(weight, idx_weight_j);
+                    {%- else %}
+                    accumulators[i].add_(weight);
+                    {%- endif %}
+                }
+                {%- else %}
+                for (int32_t i = 0; i < D; i += kThreadGroupSize * VEC_WIDTH) {
+                    int32_t d = i + threadIdx.x * VEC_WIDTH;
+                    if (d < D) {
+                        Vec4T<cache_t> weight = weight_row_cache.load(d, qparams_cache);
+                        weight.store(&output[output_j][d]);
+                    }
+                }
+                {%- endif %}
+            }
+            else { // else row is not in cache
+            {%- endif %}
+                auto weight_row_emb = WeightRow<emb_t, cache_t, cache_t>(
+                    const_cast<emb_t*>(&weights[idx_j * D_emb]),
+                    nullptr,
+                    D,
+                    nullptr);
+                float2 qparams_emb;
+                if (std::is_same<emb_t, uint8_t>::value) {
+                    qparams_emb = weight_row_emb.load_qparams();
+                }
+                {%- if not nobag %}
+                #pragma unroll kMaxVecsPerThread
+                for (int32_t i = 0;
+                    i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
+                    ++i) {
+                    int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
+                    Vec4T<cache_t> weight = weight_row_emb.load(d, qparams_emb);
+                    {%- if weighted %}
+                    accumulators[i].fma_(weight, idx_weight_j);
+                    {%- else %}
+                    accumulators[i].add_(weight);
+                    {%- endif %}
+                }
+                {%- else %}
+                for (int32_t i = 0; i < D; i += kThreadGroupSize * VEC_WIDTH) {
+                    int32_t d = i + threadIdx.x * VEC_WIDTH;
+                    if (d < D) {
+                        Vec4T<cache_t> weight = weight_row_emb.load(d, qparams_emb);
+                        weight.store(&output[output_j][d]);
+                    }
+                }
+                {%- endif %}
+            {%- if not dense %}
+            } // else row is not in cache
+            {%- endif %}
+        }
+    }
+
+    {%- if not nobag %}
+    if (!std::is_same<output_t, uint8_t>::value) {
+        #pragma unroll kMaxVecsPerThread
+        for (int32_t i = 0;
+        i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
+        ++i) {
+            accumulators[i].mul_(inv_L);
+            int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
+            accumulators[i].store(&output[b][D_start + d]);
+        }
+    } else {
+        // apply per feature row-wise int8
+        float thread_local_min = std::numeric_limits<float>::max();
+        float thread_local_max = std::numeric_limits<float>::lowest();
+        float2 qparams;
+
+        #pragma unroll kMaxVecsPerThread
+        for (int32_t i = 0;
+            i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
+            ++i) {
+            accumulators[i].mul_(inv_L);
+            thread_local_max = max(thread_local_max, vec4_max(accumulators[i]));
+            thread_local_min = min(thread_local_max, vec4_min(accumulators[i]));
+        }
+
+        qparams = warp_find_qparams(thread_local_min, thread_local_max);
+        int output_D_start = D_start + t * 8;
+        int output_D_end = output_D_start + D;
+
+        #pragma unroll kMaxVecsPerThread
+        for (int32_t i = 0;
+            i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
+            ++i) {
+            int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
+            nearest_rounding_vector<output_t, cache_t>(&output[b][output_D_start + d], accumulators[i], qparams);
+        }
+        if (threadIdx.x == 0) {
+            store_qparams_to_row(&output[b][output_D_end], qparams);
+        }
+
+    }
+    {%- endif %}
+}
+
+/*
+    Explicitly instantiate the kernel function template.  The instantiations are
+    based on the types enumerated by DISPATCH_EMB_GRAD_CACHE_TYPES macro used in
+    embedding_forward_split_template.cu
+*/
+
+{%- for output_type in ['uint8_t', 'at::Half', 'float'] %}
+{%- for emb_type in ['uint8_t', 'float', 'at::Half'] %}
+{%- for cache_type in ['float', 'at::Half'] %}
+
+////////////////////////////////////////////////////////////////////////////////
+#ifdef FBGEMM_USE_SUBWARP_SHUFFLE
+////////////////////////////////////////////////////////////////////////////////
+
+{#- /*
+    Compute the Cartesian product of (use_cache, kMaxVecsPerThread, kThreadGroupSize)
+    in the FBGEMM_USE_SUBWARP_SHUFFLE case
+
+    constexpr int kMaxVecsPerThread = std::max({{ kMaxElemPerThread }} / 4, 1);
+    constexpr int kThreadGroupSize = kWarpSize / std::max(4 / {{ kMaxElemPerThread }}, 1);
+
+    This is needed to compute the unique tuples to use for explicit instantiation,
+    so that we can avoid duplicate template instantiations.
+*/ #}
+{%- set tuples = [] %}
+{%- for use_cache in ['true', 'false'] %}
+{%- for kMaxElemPerThread in range(1, max_embedding_dim // (items_per_warp // 4) + 1) %}
+{%- if kMaxElemPerThread in [1, 2] or kMaxElemPerThread % 4 == 0 %}
+    {%- set t0 = use_cache if not dense else "NULL" %}
+    {%- set t1 = [ (kMaxElemPerThread // 4), 1 ] | max if not nobag else "NULL" %}
+    {%- set t2 = [ 4 // kMaxElemPerThread, 1] | max %}
+    {%- set temp = tuples.append((t0, t1, "(kWarpSize / " ~ t2 ~ ")")) %}
+{%- endif %}
+{%- endfor %}
+{%- endfor %}
+
+{#- /*
+    Enumerate over the unique tuples (NULL means the field is not materialized
+    for the template context, e.g. where nobag = true):
+
+    (true,·1,·(kWarpSize·/·4))
+    (true,·1,·(kWarpSize·/·2))
+    (true,·1,·(kWarpSize·/·1))
+    (true,·2,·(kWarpSize·/·1))
+    (true,·3,·(kWarpSize·/·1))
+    (true,·4,·(kWarpSize·/·1))
+    (true,·5,·(kWarpSize·/·1))
+    (true,·6,·(kWarpSize·/·1))
+    (true,·7,·(kWarpSize·/·1))
+    (true,·8,·(kWarpSize·/·1))
+    (false,·1,·(kWarpSize·/·4))
+    (false,·1,·(kWarpSize·/·2))
+    (false,·1,·(kWarpSize·/·1))
+    (false,·2,·(kWarpSize·/·1))
+    (false,·3,·(kWarpSize·/·1))
+    (false,·4,·(kWarpSize·/·1))
+    (false,·5,·(kWarpSize·/·1))
+    (false,·6,·(kWarpSize·/·1))
+    (false,·7,·(kWarpSize·/·1))
+    (false,·8,·(kWarpSize·/·1))
+
+    (NULL,·1,·(kWarpSize·/·4))
+    (NULL,·1,·(kWarpSize·/·2))
+    (NULL,·1,·(kWarpSize·/·1))
+    (NULL,·2,·(kWarpSize·/·1))
+    (NULL,·3,·(kWarpSize·/·1))
+    (NULL,·4,·(kWarpSize·/·1))
+    (NULL,·5,·(kWarpSize·/·1))
+    (NULL,·6,·(kWarpSize·/·1))
+    (NULL,·7,·(kWarpSize·/·1))
+    (NULL,·8,·(kWarpSize·/·1))
+
+    (true,·NULL,·(kWarpSize·/·4))
+    (true,·NULL,·(kWarpSize·/·2))
+    (true,·NULL,·(kWarpSize·/·1))
+    (false,·NULL,·(kWarpSize·/·4))
+    (false,·NULL,·(kWarpSize·/·2))
+    (false,·NULL,·(kWarpSize·/·1))
+
+    (NULL,·NULL,·(kWarpSize·/·4))
+    (NULL,·NULL,·(kWarpSize·/·2))
+    (NULL,·NULL,·(kWarpSize·/·1))
+*/ #}
+{%- for (use_cache, kMaxVecsPerThread, kThreadGroupSize) in tuples | unique %}
+
+template __launch_bounds__(kForwardMaxThreads) __global__
+void {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{{ wdesc }}_kernel
+<
+    {{ emb_type }},
+    {{ cache_type }},
+    {{ output_type }},
+    {%- if not dense %}
+    {{ use_cache }},
+    {%- endif %}
+    int64_t,
+    {%- if not nobag %}
+    {{- kMaxVecsPerThread }},
+    {%- endif %}
+    {{ kThreadGroupSize }}
+> (
+    const at::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> dev_weights,
+    {%- if not dense %}
+    const at::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> uvm_weights,
+    const at::PackedTensorAccessor64<{{ cache_type }}, 2, at::RestrictPtrTraits> lxu_cache_weights,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
+    {%- endif %}
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
+    {%- if not nobag %}
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
+    {%- else %}
+    int64_t D,
+    {%- endif %}
+    FixedDivisor fd_B,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> indices,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> offsets,
+    {%- if not nobag %}
+    int64_t pooling_mode,
+    {%- endif %}
+    {%- if weighted %}
+    at::PackedTensorAccessor32<at::acc_type<{{ cache_type }}, true>, 1, at::RestrictPtrTraits> indice_weights,
+    {%- endif %}
+    {%- if not dense %}
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> lxu_cache_locations,
+    {%- endif %}
+    at::PackedTensorAccessor64<{{ output_type }}, 2, at::RestrictPtrTraits> output);
+
+{%- endfor %}
+
+////////////////////////////////////////////////////////////////////////////////
+#else
+////////////////////////////////////////////////////////////////////////////////
+
+{#- /*
+    Compute the Cartesian product of (use_cache, kMaxVecsPerThread, kThreadGroupSize)
+    in the non-FBGEMM_USE_SUBWARP_SHUFFLE case
+
+    constexpr int kMaxVecsPerThread = std::max({{ kMaxElemPerThread }} / 4, 1);
+    constexpr int kThreadGroupSize = kWarpSize;
+*/ #}
+{%- set tuples = [] %}
+{%- for use_cache in ['true', 'false'] %}
+{%- for kMaxElemPerThread in range(1, max_embedding_dim // (items_per_warp // 4) + 1) %}
+{%- if kMaxElemPerThread in [1, 2] or kMaxElemPerThread % 4 == 0 %}
+    {%- set t0 = use_cache if not dense else "NULL" %}
+    {%- set t1 = [ (kMaxElemPerThread // 4), 1 ] | max if not nobag else "NULL" %}
+    {%- set temp = tuples.append((t0, t1, "kWarpSize")) %}
+{%- endif %}
+{%- endfor %}
+{%- endfor %}
+
+{#- /*
+    Enumerate over the unique tuples (NULL means the field is not materialized
+    for the template context, e.g. where nobag = true):
+
+    (true,·1,·kWarpSize)
+    (true,·2,·kWarpSize)
+    (true,·3,·kWarpSize)
+    (true,·4,·kWarpSize)
+    (true,·5,·kWarpSize)
+    (true,·6,·kWarpSize)
+    (true,·7,·kWarpSize)
+    (true,·8,·kWarpSize)
+    (false,·1,·kWarpSize)
+    (false,·2,·kWarpSize)
+    (false,·3,·kWarpSize)
+    (false,·4,·kWarpSize)
+    (false,·5,·kWarpSize)
+    (false,·6,·kWarpSize)
+    (false,·7,·kWarpSize)
+    (false,·8,·kWarpSize)
+
+    (NULL,·1,·kWarpSize)
+    (NULL,·2,·kWarpSize)
+    (NULL,·3,·kWarpSize)
+    (NULL,·4,·kWarpSize)
+    (NULL,·5,·kWarpSize)
+    (NULL,·6,·kWarpSize)
+    (NULL,·7,·kWarpSize)
+    (NULL,·8,·kWarpSize)
+
+    (true,·NULL,·kWarpSize)
+    (false,·NULL,·kWarpSize)
+
+    (NULL,·NULL,·kWarpSize)
+*/ #}
+{%- for (use_cache, kMaxVecsPerThread, kThreadGroupSize) in tuples | unique %}
+
+template __launch_bounds__(kForwardMaxThreads) __global__
+void {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{{ wdesc }}_kernel
+<
+    {{ emb_type }},
+    {{ cache_type }},
+    {{ output_type }},
+    {%- if not dense %}
+    {{ use_cache }},
+    {%- endif %}
+    int64_t,
+    {%- if not nobag %}
+    {{- kMaxVecsPerThread }},
+    {%- endif %}
+    {{ kThreadGroupSize }}
+> (
+    const at::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> dev_weights,
+    {%- if not dense %}
+    const at::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> uvm_weights,
+    const at::PackedTensorAccessor64<{{ cache_type }}, 2, at::RestrictPtrTraits> lxu_cache_weights,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
+    {%- endif %}
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
+    {%- if not nobag %}
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
+    {%- else %}
+    int64_t D,
+    {%- endif %}
+    FixedDivisor fd_B,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> indices,
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> offsets,
+    {%- if not nobag %}
+    int64_t pooling_mode,
+    {%- endif %}
+    {%- if weighted %}
+    at::PackedTensorAccessor32<at::acc_type<{{ cache_type }}, true>, 1, at::RestrictPtrTraits> indice_weights,
+    {%- endif %}
+    {%- if not dense %}
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> lxu_cache_locations,
+    {%- endif %}
+    at::PackedTensorAccessor64<{{ output_type }}, 2, at::RestrictPtrTraits> output);
+
+{%- endfor %}
+
+////////////////////////////////////////////////////////////////////////////////
+#endif
+////////////////////////////////////////////////////////////////////////////////
+
+{%- endfor %}
+{%- endfor %}
+{%- endfor %}

--- a/fbgemm_gpu/codegen/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_template.cu
@@ -14,21 +14,13 @@
 // See https://fburl.com/dw9ljh4h
 #}
 
-{% set wdesc =  "weighted" if weighted else "unweighted" %}
+{%- set wdesc =  "weighted" if weighted else "unweighted" %}
 #include "codegen/embedding_forward_template_helpers.cuh"
-
-#define SHFL_SYNC(val, srcLane) shfl_sync(val, srcLane, kThreadGroupSize, shfl_sync_mask)
-
-{% if not dense %}
-constexpr int32_t kCacheLocationMissing = -1;
-{% endif %}
-
-constexpr size_t kForwardMaxThreads = 512;
 
 using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
 
-{% if not weighted %}
+{%- if not weighted %}
 template <
     typename emb_t,
     typename cache_t,
@@ -39,424 +31,139 @@ template <
 __launch_bounds__(kForwardMaxThreads)
 __global__ void {{ "dense" if dense else "split" }}_embedding_nobag_codegen_forward_unweighted_small_kernel(
     const at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
-    {% if not dense %}
+    {%- if not dense %}
     const at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> uvm_weights,
-    const at::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits>
-        lxu_cache_weights,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        weights_placements,
-    {% endif %}
+    const at::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
+    {%- endif %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
     int64_t D,
     FixedDivisor fd_B,
     const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
     const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
-    {% if not dense %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        lxu_cache_locations,
-    {% endif %}
-    at::PackedTensorAccessor64<output_t, 2, at::RestrictPtrTraits>
-        output // [B][total_D],
-    ) {
-    int32_t T = weights_offsets.size(0);
-    int32_t B = (offsets.size(0) - 1) / T;
-    int32_t b_t = blockIdx.x * blockDim.y + threadIdx.y;
-    if (b_t >= B * T) {
-        return;
-    }
-    int32_t t;
-    int32_t b;
-    fd_B.DivMod(b_t, &t, &b);
-    int64_t weights_offset = weights_offsets[t];
-    index_t indices_start = offsets[t * B + b];
-    index_t indices_end = offsets[t * B + b + 1];
-    int32_t L = indices_end - indices_start;
-    const emb_t* __restrict__ weights;
-    {% if not dense %}
-    const auto placement = static_cast<PlacementType>(weights_placements[t]);
-    if (placement == PlacementType::DEVICE) {
-        weights = &dev_weights[weights_offset];
-    } else {
-        weights = &uvm_weights[weights_offset];
-    }
-    {% else %}
-    weights = &dev_weights[weights_offset];
-    {% endif %}
+    {%- if not dense %}
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> lxu_cache_locations,
+    {%- endif %}
+    at::PackedTensorAccessor64<output_t, 2, at::RestrictPtrTraits> output // [B][total_D],
+    );
+{%- endif %}
 
-    int32_t D_emb = D;
-    if (std::is_same<emb_t, uint8_t>::value) {
-        D_emb += kINT8QparamsBytes;
-    }
-
-    const int32_t group_start = threadIdx.x / kThreadGroupSize * kThreadGroupSize;
-    const int32_t group_end = group_start + kThreadGroupSize;
-    const int32_t d = threadIdx.x % kThreadGroupSize * 4;
-
-    for (int32_t l_start = 0; l_start < L; l_start += kWarpSize) {
-        int32_t l = l_start + threadIdx.x;
-        int64_t idx = l < L ? indices[indices_start + l] : 0;
-        {% if not dense %}
-        int32_t cache_idx = (placement == PlacementType::MANAGED_CACHING && l < L) ? lxu_cache_locations[indices_start + l] : 0;
-        {% endif %}
-        for (auto j = group_start; j < group_end && l_start + j < L; ++j) {
-            int64_t idx_j = shfl_sync(idx, j);
-            int64_t output_j = indices_start + l_start + j;
-            {% if not dense %}
-            int32_t cache_idx_j = shfl_sync(cache_idx, j);
-            {% endif %}
-
-            {% if not dense %}
-
-            // assume cache is fp16/fp32 which doesn't require qparams
-            float2 qparams_cache = make_float2(0.0f, 0.0f);
-
-            {% endif %}
-            auto weight_row_emb = WeightRow<emb_t, cache_t, cache_t>(
-                const_cast<emb_t*>(&weights[idx_j * D_emb]),
-                nullptr,
-                D,
-                nullptr);
-            float2 qparams_emb;
-            if (std::is_same<emb_t, uint8_t>::value) {
-                qparams_emb = weight_row_emb.load_qparams();
-            }
-
-            if (d < D) {
-                {% if not dense %}
-                if (placement == PlacementType::MANAGED_CACHING && cache_idx_j != kCacheLocationMissing) {
-                    auto weight_row_cache = WeightRow<emb_t, cache_t, cache_t>(
-                        const_cast<emb_t*>(&weights[idx_j * D_emb]),
-                        const_cast<cache_t*>(&lxu_cache_weights[cache_idx_j][0]),
-                        D,
-                        nullptr);
-                    Vec4T<cache_t> weight = weight_row_cache.load(d, qparams_cache);
-                    weight.store(&output[output_j][d]);
-                } else {
-                    Vec4T<cache_t> weight = weight_row_emb.load(d, qparams_emb);
-                    weight.store(&output[output_j][d]);
-                }
-                {% else %}
-                    Vec4T<cache_t> weight = weight_row_emb.load(d, qparams_emb);
-                    weight.store(&output[output_j][d]);
-                {% endif %}
-            }
-        }
-    }
-}
-{% endif %}
-
-{% for nobag in [True, False] %}
-{% if not nobag or not weighted %}
+{%- for nobag in [True, False] %}
+{%- if not nobag or not weighted %}
 template <
     typename emb_t,
     typename cache_t,
     typename output_t,
-    {% if not dense %}
+    {%- if not dense %}
     bool use_lxu_cache,
-    {% endif %}
+    {%- endif %}
     typename index_t,
-    {% if not nobag %}
+    {%- if not nobag %}
     size_t kMaxVecsPerThread,
-    {% endif %}
+    {%- endif %}
     size_t kThreadGroupSize = kWarpSize
     >
 __launch_bounds__(kForwardMaxThreads)
 __global__ void {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{{ wdesc }}_kernel(
     const at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
-    {% if not dense %}
+    {%- if not dense %}
     const at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> uvm_weights,
-    const at::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits>
-        lxu_cache_weights,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        weights_placements,
-    {% endif %}
+    const at::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
+    {%- endif %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
-    {% if not nobag %}
+    {%- if not nobag %}
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
-    {% else %}
+    {%- else %}
     int64_t D,
-    {% endif %}
+    {%- endif %}
     FixedDivisor fd_B,
     const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
     const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
-    {% if not nobag %}
+    {%- if not nobag %}
     int64_t pooling_mode,
-    {% endif %}
-    {% if weighted %}
-    at::PackedTensorAccessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits>
-        indice_weights,
-    {% endif %}
-    {% if not dense %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        lxu_cache_locations,
-    {% endif %}
-    at::PackedTensorAccessor64<output_t, 2, at::RestrictPtrTraits>
-        output // [B][total_D],
-    ) {
-    int32_t T = weights_offsets.size(0);
-    {% if not nobag %}
-    const bool mean_pooling = static_cast<PoolingMode>(pooling_mode) == PoolingMode::MEAN;
-    int32_t B = output.size(0);
-    {% else %}
-    int32_t B = (offsets.size(0) - 1) / T;
-    {% endif %}
-    int32_t b_t = blockIdx.x * blockDim.y + threadIdx.y;
-    if (b_t >= B * T) {
-        return;
-    }
-    int32_t t;
-    int32_t b;
-    fd_B.DivMod(b_t, &t, &b);
-    int64_t weights_offset = weights_offsets[t];
-    {% if not nobag %}
-    int32_t D_start = D_offsets[t];
-    int32_t D_end = D_offsets[t + 1];
-    int32_t D = D_end - D_start;
-    {% endif %}
-    index_t indices_start = offsets[t * B + b];
-    index_t indices_end = offsets[t * B + b + 1];
-    int32_t L = indices_end - indices_start;
-    const emb_t* __restrict__ weights;
-    {% if not dense %}
-    const auto placement = static_cast<PlacementType>(weights_placements[t]);
-    if (placement == PlacementType::DEVICE) {
-        weights = &dev_weights[weights_offset];
-    } else {
-        weights = &uvm_weights[weights_offset];
-    }
-    {% else %}
-    weights = &dev_weights[weights_offset];
-    {% endif %}
-
-    int32_t D_emb = D;
-    if (std::is_same<emb_t, uint8_t>::value) {
-        D_emb += kINT8QparamsBytes;
-    }
-
-    constexpr int VEC_WIDTH = 4;
-#ifdef FBGEMM_USE_SUBWARP_SHUFFLE
-    const unsigned int shfl_sync_mask =
-        ((1L << kThreadGroupSize) - 1) <<
-        (threadIdx.y % (kWarpSize / kThreadGroupSize) * kThreadGroupSize);
-#else
-    const unsigned int shfl_sync_mask = 0xffffffffu;
-#endif
-
-    {% if not nobag %}
-    const float inv_L = (mean_pooling && L != 0) ? static_cast<float>(1.0) / L: static_cast<float>(1.0);
-    Vec4T<cache_t> accumulators[kMaxVecsPerThread];
-    {% endif %}
-    for (int32_t l_start = 0; l_start < L; l_start += kThreadGroupSize) {
-        int32_t l = l_start + threadIdx.x;
-        int64_t idx = l < L ? indices[indices_start + l] : 0;
-        {% if not dense %}
-        int32_t cache_idx = (use_lxu_cache && placement == PlacementType::MANAGED_CACHING && l < L) ? lxu_cache_locations[indices_start + l] : 0;
-        {% endif %}
-        {% if weighted %}
-        at::acc_type<cache_t, true> idx_weight = l < L ? indice_weights[indices_start + l] : 0;
-        {% endif %}
-        for (auto j = 0; j < kThreadGroupSize && l_start + j < L; ++j) {
-            int64_t idx_j = SHFL_SYNC(idx, j);
-            {% if nobag %}
-            int64_t output_j = indices_start + l_start + j;
-            {% endif %}
-            {% if not dense %}
-            int32_t cache_idx_j = use_lxu_cache ? SHFL_SYNC(cache_idx, j) : 0;
-            {% endif %}
-
-            {% if weighted %}
-            at::acc_type<cache_t, true> idx_weight_j = SHFL_SYNC(idx_weight, j);
-            {% endif %}
-
-            {% if not dense %}
-            // use_lxu_cache is a compile time condition
-            if (use_lxu_cache && placement == PlacementType::MANAGED_CACHING && cache_idx_j != kCacheLocationMissing) {
-                auto weight_row_cache = WeightRow<emb_t, cache_t, cache_t>(
-                    const_cast<emb_t*>(&weights[idx_j * D_emb]),
-                    const_cast<cache_t*>(&lxu_cache_weights[cache_idx_j][0]),
-                    D,
-                    nullptr);
-                // assume cache is fp16/fp32 which doesn't require qparams
-                float2 qparams_cache = make_float2(0.0f, 0.0f);
-
-                {% if not nobag %}
-                #pragma unroll kMaxVecsPerThread
-                for (int32_t i = 0;
-                    i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
-                    ++i) {
-                    int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
-                    Vec4T<cache_t> weight = weight_row_cache.load(d, qparams_cache);
-                    {% if weighted %}
-                    accumulators[i].fma_(weight, idx_weight_j);
-                    {% else %}
-                    accumulators[i].add_(weight);
-                    {% endif %}
-                }
-                {% else %}
-                for (int32_t i = 0; i < D; i += kThreadGroupSize * VEC_WIDTH) {
-                    int32_t d = i + threadIdx.x * VEC_WIDTH;
-                    if (d < D) {
-                        Vec4T<cache_t> weight = weight_row_cache.load(d, qparams_cache);
-                        weight.store(&output[output_j][d]);
-                    }
-                }
-                {% endif %}
-            }
-            else { // else row is not in cache
-            {% endif %}
-                auto weight_row_emb = WeightRow<emb_t, cache_t, cache_t>(
-                    const_cast<emb_t*>(&weights[idx_j * D_emb]),
-                    nullptr,
-                    D,
-                    nullptr);
-                float2 qparams_emb;
-                if (std::is_same<emb_t, uint8_t>::value) {
-                    qparams_emb = weight_row_emb.load_qparams();
-                }
-                {% if not nobag %}
-                #pragma unroll kMaxVecsPerThread
-                for (int32_t i = 0;
-                    i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
-                    ++i) {
-                    int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
-                    Vec4T<cache_t> weight = weight_row_emb.load(d, qparams_emb);
-                    {% if weighted %}
-                    accumulators[i].fma_(weight, idx_weight_j);
-                    {% else %}
-                    accumulators[i].add_(weight);
-                    {% endif %}
-                }
-                {% else %}
-                for (int32_t i = 0; i < D; i += kThreadGroupSize * VEC_WIDTH) {
-                    int32_t d = i + threadIdx.x * VEC_WIDTH;
-                    if (d < D) {
-                        Vec4T<cache_t> weight = weight_row_emb.load(d, qparams_emb);
-                        weight.store(&output[output_j][d]);
-                    }
-                }
-                {% endif %}
-            {% if not dense %}
-            } // else row is not in cache
-            {% endif %}
-        }
-    }
-
-    {% if not nobag %}
-    if (!std::is_same<output_t, uint8_t>::value) {
-        #pragma unroll kMaxVecsPerThread
-        for (int32_t i = 0;
-        i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
-        ++i) {
-            accumulators[i].mul_(inv_L);
-            int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
-            accumulators[i].store(&output[b][D_start + d]);
-        }
-    } else {
-        // apply per feature row-wise int8
-        float thread_local_min = std::numeric_limits<float>::max();
-        float thread_local_max = std::numeric_limits<float>::lowest();
-        float2 qparams;
-
-        #pragma unroll kMaxVecsPerThread
-        for (int32_t i = 0;
-            i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
-            ++i) {
-            accumulators[i].mul_(inv_L);
-            thread_local_max = max(thread_local_max, vec4_max(accumulators[i]));
-            thread_local_min = min(thread_local_max, vec4_min(accumulators[i]));
-        }
-
-        qparams = warp_find_qparams(thread_local_min, thread_local_max);
-        int output_D_start = D_start + t * 8;
-        int output_D_end = output_D_start + D;
-
-        #pragma unroll kMaxVecsPerThread
-        for (int32_t i = 0;
-            i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
-            ++i) {
-            int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
-            nearest_rounding_vector<output_t, cache_t>(&output[b][output_D_start + d], accumulators[i], qparams);
-        }
-        if (threadIdx.x == 0) {
-            store_qparams_to_row(&output[b][output_D_end], qparams);
-        }
-
-    }
-    {% endif %}
-}
+    {%- endif %}
+    {%- if weighted %}
+    at::PackedTensorAccessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits> indice_weights,
+    {%- endif %}
+    {%- if not dense %}
+    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> lxu_cache_locations,
+    {%- endif %}
+    at::PackedTensorAccessor64<output_t, 2, at::RestrictPtrTraits> output // [B][total_D],
+    );
 
 Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{{ wdesc }}_cuda(
     Tensor dev_weights,
-    {% if not dense %}
+    {%- if not dense %}
     Tensor uvm_weights,
     Tensor lxu_cache_weights,
     Tensor weights_placements,
-    {% endif %}
+    {%- endif %}
     Tensor weights_offsets,
-    {% if not nobag %}
+    {%- if not nobag %}
     Tensor D_offsets,
     int64_t total_D,
     int64_t max_D,
-    {% else %}
+    {%- else %}
     int64_t D,
-    {% endif %}
+    {%- endif %}
     Tensor indices,
     Tensor offsets,
-    {% if not nobag %}
+    {%- if not nobag %}
     int64_t pooling_mode,
-    {% endif %}
-    {% if weighted %}
+    {%- endif %}
+    {%- if weighted %}
     Tensor indice_weights,
-    {% endif %}
-    {% if not dense %}
+    {%- endif %}
+    {%- if not dense %}
     Tensor lxu_cache_locations,
-    {% endif %}
+    {%- endif %}
     int64_t output_dtype,
     int64_t unused
 ) {
     TENSOR_ON_CUDA_GPU(dev_weights);
-    {% if not dense %}
+    {%- if not dense %}
     TENSOR_ON_CUDA_GPU(uvm_weights);
     TENSOR_ON_CUDA_GPU(lxu_cache_weights);
     TENSOR_ON_CUDA_GPU(weights_placements);
-    {% endif %}
+    {%- endif %}
     TENSOR_ON_CUDA_GPU(weights_offsets);
-    {% if not nobag %}
+    {%- if not nobag %}
     TENSOR_ON_CUDA_GPU(D_offsets);
-    {% endif %}
+    {%- endif %}
     TENSOR_ON_CUDA_GPU(indices);
     TENSOR_ON_CUDA_GPU(offsets);
-    {% if weighted %}
+    {%- if weighted %}
     TENSOR_ON_CUDA_GPU(indice_weights);
-    {% endif %}
-    {% if not dense %}
+    {%- endif %}
+    {%- if not dense %}
     TENSOR_ON_CUDA_GPU(lxu_cache_locations);
-    {% endif %}
+    {%- endif %}
 
     at::cuda::OptionalCUDAGuard device_guard;
     device_guard.set_index(dev_weights.get_device());
 
-    {% if not nobag %}
+    {%- if not nobag %}
     int32_t T = D_offsets.numel() - 1;
-    {% else %}
+    {%- else %}
     int32_t total_L = indices.numel();
     int32_t T = weights_offsets.numel();
-    {% endif %}
+    {%- endif %}
     TORCH_CHECK_GT(T, 0);
     // offsets = [B x T  + 1]
     int32_t B = (offsets.size(0) - 1) / T;
     TORCH_CHECK_GE(B, 0);
-    {% if not nobag %}
+    {%- if not nobag %}
     TORCH_CHECK_GT(total_D, 0);
     TORCH_CHECK_EQ(total_D % 4, 0);
     TORCH_CHECK_LE(max_D, {{ max_embedding_dim }});
-    {% else %}
+    {%- else %}
     TORCH_CHECK_GT(D, 0);
     TORCH_CHECK_EQ(D % 4, 0);
-    {% endif %}
+    {%- endif %}
 
     Tensor output;
-    {% if nobag %}
+    {%- if nobag %}
     SparseType o_dtype = static_cast<SparseType>(output_dtype);
     TORCH_CHECK(o_dtype == SparseType::FP32 || o_dtype == SparseType::FP16 ||
                 o_dtype == SparseType::BF16 || o_dtype == SparseType::INT8);
@@ -465,7 +172,7 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
         adjusted_D += T * kINT8QparamsBytes;
     }
     output = at::empty({total_L, adjusted_D}, dev_weights.options().dtype(getScalarType(o_dtype)));
-    {% else %}
+    {%- else %}
     SparseType o_dtype = static_cast<SparseType>(output_dtype);
     TORCH_CHECK(o_dtype == SparseType::FP32 || o_dtype == SparseType::FP16 ||
                 o_dtype == SparseType::BF16 || o_dtype == SparseType::INT8);
@@ -475,7 +182,7 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
     }
     output = at::empty({B, total_adjusted_D}, dev_weights.options().dtype(getScalarType(o_dtype)));
 
-    {% endif %}
+    {%- endif %}
 
     if (B == 0) {
         return output;
@@ -483,29 +190,29 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
 
     DISPATCH_EMB_CACHE_OUTPUT_TYPES(
         dev_weights.scalar_type(),
-        {% if not dense %}
+        {%- if not dense %}
         lxu_cache_weights.scalar_type(),
-        {% else %}
+        {%- else %}
         dev_weights.scalar_type(),
-        {% endif %}
+        {%- endif %}
         output.scalar_type(),
         "batched_embedding{{ "_nobag" if nobag else "" }}_forward_kernel_2", [&] {
-        {% if not dense %}
+        {%- if not dense %}
         // Check if LXU cache is used
         bool use_lxu_cache = lxu_cache_weights.numel() > 0;
-        {% endif %}
-        {% if not nobag %}
-        {% for use_cache in ["false", "true"] %}
+        {%- endif %}
+        {%- if not nobag %}
+        {%- for use_cache in ["false", "true"] %}
         // The dense case does not have cache so we have to generate code for
         // only one case (value of use_cache does not matter)
-        {% if (not dense) or (use_cache == "true") %}
-        {% if not dense %}
+        {%- if (not dense) or (use_cache == "true") %}
+        {%- if not dense %}
         if (use_lxu_cache == {{ use_cache }}) {
-        {% endif %}
+        {%- endif %}
             // kMaxElemPerThread is # of elements handled by thread if we use a full warp for a row
             // We consider kMaxElemPerThread 1 and 2, and then a multiple of 4.
-            {% for kMaxElemPerThread in range(1, max_embedding_dim // (items_per_warp // 4) + 1) %}
-            {% if kMaxElemPerThread in [1, 2] or kMaxElemPerThread % 4 == 0 %}
+            {%- for kMaxElemPerThread in range(1, max_embedding_dim // (items_per_warp // 4) + 1) %}
+            {%- if kMaxElemPerThread in [1, 2] or kMaxElemPerThread % 4 == 0 %}
             if (max_D <= {{ items_per_warp // 4 * kMaxElemPerThread }}) {
                 // hipcc can't use max in constexpr
                 constexpr int kMaxVecsPerThread = {{ kMaxElemPerThread }} / 4 >= 1 ? {{ kMaxElemPerThread }} / 4 : 1;
@@ -515,33 +222,33 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
 #else
                 constexpr int kThreadGroupSize = kWarpSize;
 #endif
-                {% if not dense %}
+                {%- if not dense %}
                 split_embedding_codegen_forward_{{ wdesc }}_kernel<emb_t, cache_t, output_t, {{ use_cache }}, int64_t, kMaxVecsPerThread, kThreadGroupSize><<<
-                {% else %}
+                {%- else %}
                 dense_embedding_codegen_forward_{{ wdesc }}_kernel<emb_t, cache_t, output_t, int64_t, kMaxVecsPerThread, kThreadGroupSize><<<
-                {% endif %}
+                {%- endif %}
                     div_round_up((B * T), kForwardMaxThreads / kThreadGroupSize),
                     dim3(kThreadGroupSize, kForwardMaxThreads / kThreadGroupSize),
                     0,
                     at::cuda::getCurrentCUDAStream()>>>(
                     dev_weights.packed_accessor64<emb_t, 1, at::RestrictPtrTraits>(),
-                    {% if not dense %}
+                    {%- if not dense %}
                     uvm_weights.packed_accessor64<emb_t, 1, at::RestrictPtrTraits>(),
                     lxu_cache_weights.packed_accessor64<cache_t, 2, at::RestrictPtrTraits>(),
                     weights_placements.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
-                    {% endif %}
+                    {%- endif %}
                     weights_offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
                     D_offsets.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
                     FixedDivisor(B),
                     indices.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
                     offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
                     pooling_mode,
-                    {% if weighted %}
+                    {%- if weighted %}
                     indice_weights.packed_accessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits>(),
-                    {% endif %}
-                    {% if not dense %}
+                    {%- endif %}
+                    {%- if not dense %}
                     lxu_cache_locations.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
-                    {% endif %}
+                    {%- endif %}
                     output.packed_accessor64<
                         output_t,
                         2,
@@ -550,39 +257,39 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
 
                 return;
             }
-            {% endif %}
-            {% endfor %}
-        {% if not dense %}
+            {%- endif %}
+            {%- endfor %}
+        {%- if not dense %}
         } // if (use_lxu_cache == {{ use_cache }})
-        {% endif %}
-        {% endif %} // if (not dense) or (use_cache == "true")
-        {% endfor %} // for use_cache in ["false", "true"]
-        {% else %}
-        {% for kEmbeddingSize in [4, 8, 16, 32] %}
+        {%- endif %}
+        {%- endif %} // if (not dense) or (use_cache == "true")
+        {%- endfor %} // for use_cache in ["false", "true"]
+        {%- else %}
+        {%- for kEmbeddingSize in [4, 8, 16, 32] %}
         if (D <= {{ kEmbeddingSize }}) {
-        {% if not dense %}
+        {%- if not dense %}
         split_embedding_nobag_codegen_forward_unweighted_small_kernel<emb_t, cache_t, output_t, int64_t, {{ kEmbeddingSize // 4 }}><<<
-        {% else %}
+        {%- else %}
         dense_embedding_nobag_codegen_forward_unweighted_small_kernel<emb_t, cache_t, output_t, int64_t, {{ kEmbeddingSize // 4 }}><<<
-        {% endif %}
+        {%- endif %}
             div_round_up((B * T), kForwardMaxThreads / kWarpSize),
             dim3(kWarpSize, kForwardMaxThreads / kWarpSize),
             0,
             at::cuda::getCurrentCUDAStream()>>>(
             dev_weights.packed_accessor64<emb_t, 1, at::RestrictPtrTraits>(),
-            {% if not dense %}
+            {%- if not dense %}
             uvm_weights.packed_accessor64<emb_t, 1, at::RestrictPtrTraits>(),
             lxu_cache_weights.packed_accessor64<cache_t, 2, at::RestrictPtrTraits>(),
             weights_placements.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
-            {% endif %}
+            {%- endif %}
             weights_offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
             D,
             FixedDivisor(B),
             indices.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
             offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
-            {% if not dense %}
+            {%- if not dense %}
             lxu_cache_locations.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
-            {% endif %}
+            {%- endif %}
             output.packed_accessor64<
                 output_t,
                 2,
@@ -590,52 +297,52 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
             );
             return;
         }
-        {% endfor %}
-        {% for use_cache in ["false", "true"] %}
+        {%- endfor %}
+        {%- for use_cache in ["false", "true"] %}
         // The dense case does not have cache so we have to generate code for
         // only one case (value of use_cache does not matter)
-        {% if (not dense) or (use_cache == "true") %}
-        {% if not dense %}
+        {%- if (not dense) or (use_cache == "true") %}
+        {%- if not dense %}
         if (use_lxu_cache == {{ use_cache }}) {
             split_embedding_nobag_codegen_forward_unweighted_kernel<emb_t, cache_t, output_t, {{ use_cache }}, int64_t><<<
-        {% else %}
+        {%- else %}
             dense_embedding_nobag_codegen_forward_unweighted_kernel<emb_t, cache_t, output_t, int64_t><<<
-        {% endif %}
+        {%- endif %}
                 div_round_up((B * T), kForwardMaxThreads / kWarpSize),
                 dim3(kWarpSize, kForwardMaxThreads / kWarpSize),
                 0,
                 at::cuda::getCurrentCUDAStream()>>>(
                 dev_weights.packed_accessor64<emb_t, 1, at::RestrictPtrTraits>(),
-                {% if not dense %}
+                {%- if not dense %}
                 uvm_weights.packed_accessor64<emb_t, 1, at::RestrictPtrTraits>(),
                 lxu_cache_weights.packed_accessor64<cache_t, 2, at::RestrictPtrTraits>(),
                 weights_placements.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
-                {% endif %}
+                {%- endif %}
                 weights_offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
                 D,
                 FixedDivisor(B),
                 indices.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
                 offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
-                {% if not dense %}
+                {%- if not dense %}
                 lxu_cache_locations.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
-                {% endif %}
+                {%- endif %}
                 output.packed_accessor64<
                     output_t,
                     2,
                     at::RestrictPtrTraits>()
                 );
                 return;
-        {% if not dense %}
+        {%- if not dense %}
         } // if (use_lxu_cache == {{ use_cache }})
-        {% endif %}
-        {% endif %} // if (not dense) or (use_cache == "true")
-        {% endfor %} // for use_cache in ["false", "true"]
-        {% endif %}
+        {%- endif %}
+        {%- endif %} // if (not dense) or (use_cache == "true")
+        {%- endfor %} // for use_cache in ["false", "true"]
+        {%- endif %}
         });
 
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return output;
 }
-{% endif %}
-{% endfor %}
+{%- endif %}
+{%- endfor %}
     // clang-format on

--- a/fbgemm_gpu/codegen/embedding_forward_template_helpers.cuh
+++ b/fbgemm_gpu/codegen/embedding_forward_template_helpers.cuh
@@ -33,10 +33,13 @@
 #include "fbgemm_gpu/fbgemm_cuda_utils.cuh"
 #include "fbgemm_gpu/sparse_ops_utils.h"
 
-namespace nbit {
+#define SHFL_SYNC(val, srcLane) \
+  shfl_sync(val, srcLane, kThreadGroupSize, shfl_sync_mask)
 
 constexpr int32_t kCacheLocationMissing = -1;
+constexpr size_t kForwardMaxThreads = 512;
 
+namespace nbit {
 // "Effective" number of elements in the row when we include the row-wise
 // quantization parameters.
 __device__ inline int32_t padded_D(

--- a/fbgemm_gpu/docs/BuildInstructions.md
+++ b/fbgemm_gpu/docs/BuildInstructions.md
@@ -246,7 +246,7 @@ conda install -n "${env_name}" -y pytorch -c pytorch-nightly
 # Install the latest test (RC)
 conda install -n "${env_name}" -y pytorch -c pytorch-test
 # Install a specific version
-conda install -n "${env_name}" -y pytorch==1.13.1 -c pytorch
+conda install -n "${env_name}" -y pytorch==2.0.0 -c pytorch
 ```
 
 Note that installing PyTorch through Conda without specifying a version (as in
@@ -270,7 +270,7 @@ conda run -n "${env_name}" pip install --pre torch --extra-index-url https://dow
 # Install the latest test (RC)
 conda run -n "${env_name}" pip install --pre torch --extra-index-url https://download.pytorch.org/whl/test/cu117/
 # Install a specific version
-conda run -n "${env_name}" pip install torch==1.13.1+cu117 --extra-index-url https://download.pytorch.org/whl/cu117/
+conda run -n "${env_name}" pip install torch==2.0.0+cu117 --extra-index-url https://download.pytorch.org/whl/cu117/
 # Install the latest nightly (ROCm 5.3)
 conda run -n "${env_name}" pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/rocm5.3/
 ```


### PR DESCRIPTION
Summary:

- Migrate `*_embedding_*_codegen_forward_*_kernel` out of `embedding_forward_split_template.cu` and into `embedding_forward_split_kernel_template.cu`
- Migrate `*_embedding_nobag_codegen_forward_unweighted_small_kernel` out of `embedding_forward_split_template.cu` and into `embedding_forward_split_kernel_small_template.cu`