### PR TITLE
Add check on configs and logging

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -458,6 +458,13 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             raise AssertionError(
                 "weight_decay_mode is set to WeightDecayMode.COUNTER but counter_based_regularization is None"
             )
+        if (
+            weight_decay_mode != WeightDecayMode.COUNTER
+            and counter_based_regularization is not None
+        ):
+            raise AssertionError(
+                "Need to set weight_decay_mode to WeightDecayMode.COUNTER together with counter_based_regularization"
+            )
 
         self._used_rowwise_adagrad_with_counter: bool = (
             optimizer in (OptimType.EXACT_ROWWISE_ADAGRAD, OptimType.ROWWISE_ADAGRAD)
@@ -640,7 +647,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         )
 
         logging.info(
-            f"Using fused {optimizer} with optimizer_args={self.optimizer_args}"
+            f"Using fused {optimizer} with optimizer_args={self.optimizer_args}\n"
+            f"Using rowwise_adagrad_with_counter={self._used_rowwise_adagrad_with_counter}"
         )
 
         self.step = 0


### PR DESCRIPTION
Summary:
Freq-SGD requires to set both `weight_decay_mode=WeightDecayMode.COUNTER` and `counter_based_regularization` to kick in. Previously we checked when `weight_decay_mode` is set but no config provided. There's another missing case when the config is provided but users forget to set `weight_decay_mode`. We add the check in this diff.

In addition, added logging to print out whether **internally**  counter is used or not to make debugging easier.

Reviewed By: dvksabin

Differential Revision: D45329516

