### PR TITLE
padding for fp8-rowwise quantization for varying length of 1D Tensor

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -203,6 +203,10 @@ permute_1D_sparse_data_cpu(
     const c10::optional<int64_t>& permuted_lengths_sum);
 
 at::Tensor _float_to_fused8bitrowwise_gpu(const at::Tensor& input);
+at::Tensor _float_to_paddedFP8rowwise_gpu(
+    const at::Tensor& input,
+    const bool forward = true,
+    const int64_t row_dim = 256);
 at::Tensor _float_to_FP8rowwise_gpu(
     const at::Tensor& input,
     const bool forward = true);
@@ -212,6 +216,10 @@ at::Tensor _fused8bitrowwise_to_float_gpu(const at::Tensor& input);
 at::Tensor _FP8rowwise_to_float_gpu(
     const at::Tensor& input,
     const bool forward = true);
+at::Tensor _paddedFP8rowwise_to_float_gpu(
+    const at::Tensor& input,
+    const bool forward = true,
+    const int64_t row_dim = 256);
 at::Tensor _fused8bitrowwise_to_half_gpu(const at::Tensor& input);
 at::Tensor _fused8bitrowwise_to_float_or_half_gpu(
     const at::Tensor& input,

--- a/fbgemm_gpu/src/quantize_ops_cpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops_cpu.cpp
@@ -405,6 +405,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def("FloatToFused8BitRowwiseQuantized(Tensor t) -> Tensor");
   m.def("FloatToFP8RowwiseQuantized(Tensor t, bool forward) -> Tensor");
   m.def(
+      "FloatToPaddedFP8RowwiseQuantized(Tensor t, bool forward, int row_dim) -> Tensor");
+  m.def(
       "FloatToFused8BitRowwiseQuantizedOut(Tensor output, Tensor input) -> Tensor");
   m.def("HalfToFused8BitRowwiseQuantized(Tensor t) -> Tensor");
   m.def("FloatOrHalfToFused8BitRowwiseQuantized(Tensor t) -> Tensor");
@@ -437,6 +439,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "FloatToMSFPQuantized(Tensor input, int bounding_box_size, int ebits, int mbits, int bias, float min_pos, float max_pos) -> Tensor");
   m.def(
       "MSFPQuantizedToFloat(Tensor input, int ebits, int mbits, int bias) -> Tensor");
+  m.def(
+      "PaddedFP8RowwiseQuantizedToFloat(Tensor input, bool forward, int row_dim) -> Tensor");
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {

--- a/fbgemm_gpu/src/quantize_ops_gpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops_gpu.cpp
@@ -17,6 +17,9 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   DISPATCH_TO_CUDA(
       "FloatToFP8RowwiseQuantized", fbgemm_gpu::_float_to_FP8rowwise_gpu);
   DISPATCH_TO_CUDA(
+      "FloatToPaddedFP8RowwiseQuantized",
+      fbgemm_gpu::_float_to_paddedFP8rowwise_gpu);
+  DISPATCH_TO_CUDA(
       "HalfToFused8BitRowwiseQuantized",
       fbgemm_gpu::_half_to_fused8bitrowwise_gpu);
   DISPATCH_TO_CUDA(
@@ -58,4 +61,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   DISPATCH_TO_CUDA("HFP8QuantizedToFloat", fbgemm_gpu::_hfp8_to_float_gpu);
   DISPATCH_TO_CUDA("FloatToMSFPQuantized", fbgemm_gpu::_float_to_msfp_gpu);
   DISPATCH_TO_CUDA("MSFPQuantizedToFloat", fbgemm_gpu::_msfp_to_float_gpu);
+  DISPATCH_TO_CUDA(
+      "PaddedFP8RowwiseQuantizedToFloat",
+      fbgemm_gpu::_paddedFP8rowwise_to_float_gpu);
 }


### PR DESCRIPTION
Summary:
As all gather becomes expensive for tensor/sequential parallel training, we create padded rowwise quantization/dequantization kernels for flattened tensor to convert between fp8 (stored as uint8 for gpu <= A100) and fp32 formats.
Since the activations/grads will be concat into 1d tensor for all gather, the scaling to fit into fp8 format's range might be tricky as small elements will be quantized to zero if the scale is chosen to accommodate the largest element in the model.

Thus, we continue to use row-wise quantization used in the previous all2all kernel. Every block with the size of "row_dim" will be quantized with the scale choose to accommodate the largest value in the block.

Since the total length of the flattened tensor will not always be divisible by row_dim, we'll pad the 1D tensor to multiple of row_dim. As such, the padding/unpadding is handled by quantize/dequantize kernels and will be invisible to API calling them.

Differential Revision:
D42721325

Privacy Context Container: L1138451

