### PR TITLE
Fix error with empty row_counter_dev

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -924,8 +924,11 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         )
         if self._used_rowwise_adagrad_with_counter:
             if self.iter.item() % self._max_counter_update_freq == 0:
-                max_counter = torch.max(self.row_counter_dev.detach())
-                self.max_counter = max_counter.cpu() + 1
+                row_counter_dev = self.row_counter_dev.detach()
+                if row_counter_dev.numel() > 0:
+                    self.max_counter[0] = torch.max(row_counter_dev).cpu().item() + 1
+                else:
+                    self.max_counter[0] = 1
 
         if self.optimizer == OptimType.EXACT_ROWWISE_ADAGRAD:
             if self._used_rowwise_adagrad_with_counter:


### PR DESCRIPTION
Summary:
In some cases, `torch.max(row_counter_dev)` causes failure because `row_counter_dev` is an empty tensor, example flow (f431977946).

Here we guard the op by first checking if `row_counter_dev` is empty.

Differential Revision: D45342010

