### PR TITLE
Improve `TORCH_CHECK` diagnostics in files including deeplearning/fbgemm/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
@@ -35,10 +35,10 @@ void split_embedding_forward_cpu_kernel(
     Tensor indice_weights,
     Tensor output) {
   int64_t T = D_offsets.numel() - 1;
-  TORCH_CHECK(T > 0);
+  TORCH_CHECK_GT(T, 0);
   // offsets = [T x B  + 1]
   int64_t B = (offsets.size(0) - 1) / T;
-  TORCH_CHECK(B >= 0);
+  TORCH_CHECK_GE(B, 0);
 
   TORCH_CHECK(weights.is_contiguous());
   indices = indices.contiguous();
@@ -176,10 +176,10 @@ Tensor split_embedding_codegen_forward_cpu(
     Tensor indice_weights,
     int64_t output_dtype) {
   int64_t T = D_offsets.numel() - 1;
-  TORCH_CHECK(T > 0);
+  TORCH_CHECK_GT(T, 0);
   // offsets = [T x B  + 1]
   int64_t B = (offsets.size(0) - 1) / T;
-  TORCH_CHECK(B >= 0);
+  TORCH_CHECK_GE(B, 0);
 
   Tensor output;
   if (output_dtype == static_cast<int64_t>(SparseType::FP32)) {
@@ -238,10 +238,10 @@ void split_embedding_grad_indice_weights_cpu_kernel(
     Tensor feature_requires_grad,
     Tensor grad_indice_weights) {
   int64_t T = D_offsets.numel() - 1;
-  TORCH_CHECK(T > 0);
+  TORCH_CHECK_GT(T, 0);
   // offsets = [T x B  + 1]
   int64_t B = (offsets.size(0) - 1) / T;
-  TORCH_CHECK(B >= 0);
+  TORCH_CHECK_GE(B, 0);
 
   const auto D_offsets_data = D_offsets.accessor<int, 1>();
   const auto weights_offsets_data = weights_offsets.accessor<int64_t, 1>();

--- a/fbgemm_gpu/codegen/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_template.cu
@@ -442,17 +442,17 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
     int32_t total_L = indices.numel();
     int32_t T = weights_offsets.numel();
     {% endif %}
-    TORCH_CHECK(T > 0);
+    TORCH_CHECK_GT(T, 0);
     // offsets = [B x T  + 1]
     int32_t B = (offsets.size(0) - 1) / T;
-    TORCH_CHECK(B >= 0);
+    TORCH_CHECK_GE(B, 0);
     {% if not nobag %}
-    TORCH_CHECK(total_D > 0);
-    TORCH_CHECK(total_D % 4 == 0);
-    TORCH_CHECK(max_D <= {{ max_embedding_dim }});
+    TORCH_CHECK_GT(total_D, 0);
+    TORCH_CHECK_EQ(total_D % 4, 0);
+    TORCH_CHECK_LE(max_D, {{ max_embedding_dim }});
     {% else %}
-    TORCH_CHECK(D > 0);
-    TORCH_CHECK(D % 4 == 0);
+    TORCH_CHECK_GT(D, 0);
+    TORCH_CHECK_EQ(D % 4, 0);
     {% endif %}
 
     Tensor output;


### PR DESCRIPTION
Summary:
`TORCH_CHECK` produces pretty generic error messages. Using, eg, `TORCH_CHECK_GE` produces a message that shows the names of the variables being compared as well as their values at the time of comparison. This makes debugging easier.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

(7 files modified.)

Differential Revision: D45402701

