### PR TITLE
Improve `TORCH_CHECK` diagnostics in files including deeplearning/fbgemm/fbgemm_gpu/codegen/embedding_backward_dense_host.cpp

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_dense_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_dense_host.cpp
@@ -167,7 +167,7 @@ class SplitLookupFunction_Dense_Op
     auto total_hash_size_bits = ctx->saved_data["total_hash_size_bits"].toInt();
     auto pooling_mode = ctx->saved_data["pooling_mode"].toInt();
 
-    TORCH_CHECK(grad_outputs.size() == 1);
+    TORCH_CHECK_EQ(grad_outputs.size(), 1);
 
 #ifdef __HIP_PLATFORM_HCC__
     constexpr int32_t BT_block_size = 64;
@@ -331,7 +331,7 @@ class SplitNoBagLookupFunction_Dense_Op
     auto D = ctx->saved_data["D"].toInt();
     auto total_hash_size_bits = ctx->saved_data["total_hash_size_bits"].toInt();
 
-    TORCH_CHECK(grad_outputs.size() == 1);
+    TORCH_CHECK_EQ(grad_outputs.size(), 1);
 
     constexpr int32_t BT_block_size = 32;
     constexpr int32_t max_segment_length_per_warp = 32;

--- a/fbgemm_gpu/codegen/embedding_backward_dense_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_dense_host_cpu.cpp
@@ -103,7 +103,7 @@ class SplitLookupFunction_Dense_Op
     auto total_hash_size_bits = ctx->saved_data["total_hash_size_bits"].toInt();
     auto pooling_mode = ctx->saved_data["pooling_mode"].toInt();
 
-    TORCH_CHECK(grad_outputs.size() == 1);
+    TORCH_CHECK_EQ(grad_outputs.size(), 1);
 
     using torch::autograd::Variable;
 

--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_approx_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_approx_template.cpp
@@ -105,10 +105,10 @@ split_embedding_backward_codegen_{{ optimizer }}_cpu(
     int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)
 ) {
   int64_t T = D_offsets.numel() - 1;
-  TORCH_CHECK(T > 0);
+  TORCH_CHECK_GT(T, 0);
   // offsets = [T x B  + 1]
   int64_t B = (offsets.size(0) - 1) / T;
-  TORCH_CHECK(B >= 0);
+  TORCH_CHECK_GE(B, 0);
 
   const auto weights_offsets_data = weights_offsets.accessor<int64_t, 1>();
   const auto D_offsets_data = D_offsets.accessor<int, 1>();
@@ -119,7 +119,7 @@ split_embedding_backward_codegen_{{ optimizer }}_cpu(
   const auto momentum2_offsets_data = momentum2_offsets.accessor<int64_t, 1>();
   {% endif %}
 
-  TORCH_CHECK(host_weights.dim() == 1);
+  TORCH_CHECK_EQ(host_weights.dim(), 1);
 
   {% if optimizer == "approx_rowwise_adagrad" %}
 

--- a/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_cpu_template.cpp
@@ -306,10 +306,10 @@ void split_embedding_backward_exact_cpu_dense_kernel(
 ) {
 
   int64_t T = D_offsets.numel() - 1;
-  TORCH_CHECK(T > 0);
+  TORCH_CHECK_GT(T, 0);
   // offsets = [T x B  + 1]
   int64_t B = (offsets.size(0) - 1) / T;
-  TORCH_CHECK(B >= 0);
+  TORCH_CHECK_GE(B, 0);
 
   const auto weights_offsets_data = weights_offsets.accessor<int64_t, 1>();
   const auto D_offsets_data = D_offsets.accessor<int, 1>();
@@ -328,7 +328,7 @@ void split_embedding_backward_exact_cpu_dense_kernel(
   ++num_tables;
   table_to_feature_offset[num_tables] = T;
 
-  TORCH_CHECK(host_weights.dim() == 1);
+  TORCH_CHECK_EQ(host_weights.dim(), 1);
 
   {% if not dense %}
   {% if "momentum1_offsets" in args.split_function_arg_names %}

--- a/fbgemm_gpu/codegen/embedding_backward_split_host_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_cpu_template.cpp
@@ -124,7 +124,7 @@ class SplitLookupFunction_{{ optimizer }}_Op : public torch::autograd::Function<
     auto {{ var }} = ctx->saved_data["{{ var }}"].{{ ivalue_cast }}();
     {% endfor %}
 
-    TORCH_CHECK(grad_outputs.size() == 1);
+    TORCH_CHECK_EQ(grad_outputs.size(), 1);
 
     using torch::autograd::Variable;
 

--- a/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
@@ -262,7 +262,7 @@ class Split{{ "NoBag" if nobag else "" }}LookupFunction_{{ optimizer }}_Op :
     auto {{ var }} = ctx->saved_data["{{ var }}"].{{ ivalue_cast }}();
     {% endfor %}
 
-    TORCH_CHECK(grad_outputs.size() == 1);
+    TORCH_CHECK_EQ(grad_outputs.size(), 1);
 
 #ifdef __HIP_PLATFORM_HCC__
     constexpr int32_t BT_block_size = 64;

--- a/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
@@ -208,11 +208,11 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights
     at::cuda::OptionalCUDAGuard device_guard;
     device_guard.set_index(dev_weights.get_device());
     const auto T = D_offsets.size(0) - 1;
-    TORCH_CHECK(T > 0);
+    TORCH_CHECK_GT(T, 0);
     // offsets = [B x T  + 1]
     const auto B = (offsets.size(0) - 1) / T;
-    TORCH_CHECK(B >= 0);
-    TORCH_CHECK(max_D <= {{ max_embedding_dim }});
+    TORCH_CHECK_GE(B, 0);
+    TORCH_CHECK_LE(max_D, {{ max_embedding_dim }});
     auto grad_indice_weights = empty_like(indices, indices.options().dtype(at::toAccumulateType(grad_output.scalar_type(), true)));
     if (B == 0) {
       return grad_indice_weights;


### PR DESCRIPTION
Summary:
`TORCH_CHECK` produces pretty generic error messages. Using, eg, `TORCH_CHECK_GE` produces a message that shows the names of the variables being compared as well as their values at the time of comparison. This makes debugging easier.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

(7 files modified.)

Differential Revision: D45402700

