### PR TITLE
Improve `TORCH_CHECK` diagnostics in files including deeplearning/fbgemm/fbgemm_gpu/codegen/embedding_backward_split_template.cu

### DIFF
--- a/fbgemm_gpu/codegen/embedding_bounds_check.cu
+++ b/fbgemm_gpu/codegen/embedding_bounds_check.cu
@@ -205,7 +205,7 @@ void bounds_check_indices_cuda(
   const auto vbe = B_offsets.has_value();
 
   if (vbe) {
-    TORCH_CHECK(max_B >= 0);
+    TORCH_CHECK_GE(max_B, 0);
   } else {
     TORCH_CHECK(
         offsets.size(0) == B * T + 1,

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
@@ -54,7 +54,7 @@ void pruned_hashmap_insert_{{ wdesc }}_cpu(
 
     int32_t T = hash_table_offsets.size(0) - 1;
     int32_t B = (offsets.size(0) - 1) / T;
-    TORCH_CHECK(B > 0);
+    TORCH_CHECK_GT(B, 0);
     const auto* indices_acc = indices.data_ptr<int32_t>();
     const auto* dense_indices_acc = dense_indices.data_ptr<int32_t>();
 
@@ -149,14 +149,14 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
     const int32_t total_L = indices.numel();
     const int32_t T = weights_offsets.numel();
     {% endif %}
-    TORCH_CHECK(T > 0);
+    TORCH_CHECK_GT(T, 0);
     // offsets = [B x T  + 1]
     int32_t B = (offsets.size(0) - 1) / T;
-    TORCH_CHECK(B >= 0);
+    TORCH_CHECK_GE(B, 0);
     {% if not nobag %}
-    TORCH_CHECK(total_D > 0);
+    TORCH_CHECK_GT(total_D, 0);
     {% else %}
-    TORCH_CHECK(D > 0);
+    TORCH_CHECK_GT(D, 0);
     {% endif %}
     bool pinned_memory = false;
     if (at::Context::hasCUDA() && at::getNumGPUs() > 0) {
@@ -441,7 +441,7 @@ Tensor pruned_hashmap_lookup_{{ wdesc }}_cpu(
 
     int32_t T = hash_table_offsets.size(0) - 1;
     int32_t B = (offsets.size(0) - 1) / T;
-    TORCH_CHECK(B > 0);
+    TORCH_CHECK_GT(B, 0);
     auto dense_indices = empty_like(indices);
     const auto* indices_acc = indices.data_ptr<int32_t>();
     auto* dense_indices_acc = dense_indices.data_ptr<int32_t>();
@@ -504,7 +504,7 @@ Tensor pruned_array_lookup_cpu(
 
     int32_t T = index_remappings_offsets.size(0) - 1;
     int32_t B = (offsets.size(0) - 1) / T;
-    TORCH_CHECK(B > 0);
+    TORCH_CHECK_GT(B, 0);
     auto dense_indices = empty_like(indices);
     const auto* indices_acc = indices.data_ptr<int32_t>();
     auto* dense_indices_acc = dense_indices.data_ptr<int32_t>();

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
@@ -337,7 +337,7 @@ class PrunedMapCPU : public torch::jit::CustomClassHolder {
 
   void insert(Tensor indices, Tensor dense_indices, Tensor offsets, int64_t T) {
     int32_t B = (offsets.size(0) - 1) / T;
-    TORCH_CHECK(B > 0);
+    TORCH_CHECK_GT(B, 0);
     const auto* indices_acc = indices.data_ptr<int32_t>();
     auto* dense_indices_acc = dense_indices.data_ptr<int32_t>();
     const auto* offsets_acc = offsets.data_ptr<int32_t>();
@@ -363,10 +363,10 @@ class PrunedMapCPU : public torch::jit::CustomClassHolder {
 
   Tensor lookup(Tensor indices, Tensor offsets) const {
     int32_t T = maps_.size();
-    TORCH_CHECK(T > 0);
+    TORCH_CHECK_GT(T, 0);
     int32_t B = (offsets.size(0) - 1) / T;
-    TORCH_CHECK(B > 0);
-    TORCH_CHECK(maps_.size() == T);
+    TORCH_CHECK_GT(B, 0);
+    TORCH_CHECK_EQ(maps_.size(), T);
     auto dense_indices = empty_like(indices);
     const auto* indices_acc = indices.data_ptr<int32_t>();
     auto* dense_indices_acc = dense_indices.data_ptr<int32_t>();

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_split_lookup.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_split_lookup.cu
@@ -141,8 +141,8 @@ Tensor pruned_hashmap_lookup_cuda(
   auto dense_indices = at::empty_like(indices);
   const int32_t T = hash_table_offsets.size(0) - 1;
   const int32_t B = (offsets.size(0) - 1) / T;
-  TORCH_CHECK(B > 0);
-  TORCH_CHECK(hash_table.size(0) < std::numeric_limits<int32_t>::max());
+  TORCH_CHECK_GT(B, 0);
+  TORCH_CHECK_LT(hash_table.size(0), std::numeric_limits<int32_t>::max());
   constexpr size_t kForwardMaxThreads = 256;
   nbit::int_nbit_split_embedding_codegen_forward_pruned_hashmap_lookup_kernel<<<
       nbit::div_round_up(B * T + 1, kForwardMaxThreads / kWarpSize),
@@ -183,7 +183,7 @@ Tensor pruned_array_lookup_cuda(
   const int32_t B = (offsets.size(0) - 1) / T;
   TORCH_CHECK(
       B > 0, "offsets.size(): ", offsets.size(0), ", T: ", T, ", B: ", B);
-  TORCH_CHECK(index_remappings.size(0) < std::numeric_limits<int64_t>::max());
+  TORCH_CHECK_LT(index_remappings.size(0), std::numeric_limits<int64_t>::max());
   TORCH_CHECK(indices.dim() == 1, "Tensor dim: ", indices.dim());
   TORCH_CHECK(offsets.dim() == 1, "Tensor dim: ", offsets.dim());
   TORCH_CHECK(

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_split_nbit_host_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_split_nbit_host_template.cu
@@ -118,15 +118,15 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
     const int32_t total_L = indices.numel();
     const int32_t T = weights_offsets.numel();
     {% endif %}
-    TORCH_CHECK(T > 0);
+    TORCH_CHECK_GT(T, 0);
     // offsets = [B x T  + 1]
     const int32_t B = (offsets.size(0) - 1) / T;
-    TORCH_CHECK(B >= 0);
+    TORCH_CHECK_GE(B, 0);
 
     {% if not nobag %}
-    TORCH_CHECK(total_D > 0);
+    TORCH_CHECK_GT(total_D, 0);
     {% else %}
-    TORCH_CHECK(D > 0);
+    TORCH_CHECK_GT(D, 0);
     {% endif %}
 
     Tensor output;
@@ -208,7 +208,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
     DISPATCH_OUTPUT_TYPES(output.scalar_type(), "int2_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", ([&] {
       if (max_int2_D > 0) {
         auto max_int2_128b_rows = nbit::div_round_up(nbit::padded_row_size_in_bytes(max_int2_D, SparseType::INT2, row_alignment), 128);
-        TORCH_CHECK(max_int2_128b_rows <= 4);
+        TORCH_CHECK_LE(max_int2_128b_rows, 4);
         if (max_int2_128b_rows > 0) {
           Y(2, 16, 0, 1);
         }
@@ -257,7 +257,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
     DISPATCH_OUTPUT_TYPES(output.scalar_type(), "int4_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", ([&] {
       if (max_int4_D > 0) {
         auto max_int4_128b_rows = nbit::div_round_up(nbit::padded_row_size_in_bytes(max_int4_D, SparseType::INT4, row_alignment), 128);
-        TORCH_CHECK(max_int4_128b_rows <= 8);
+        TORCH_CHECK_LE(max_int4_128b_rows, 8);
         if (max_int4_128b_rows > 0) {
           Y(4, 8, 0, 1);
         }
@@ -308,7 +308,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
     DISPATCH_OUTPUT_TYPES(output.scalar_type(), "int8_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", ([&] {
       if (max_int8_D > 0) {
         auto max_int8_128b_rows = nbit::div_round_up(nbit::padded_row_size_in_bytes(max_int8_D, SparseType::INT8, row_alignment), 128);
-        TORCH_CHECK(max_int8_128b_rows <= 16);
+        TORCH_CHECK_LE(max_int8_128b_rows, 16);
         if (max_int8_128b_rows > 0) {
           Y(2, 8, 0, 1);
         }
@@ -364,7 +364,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
     DISPATCH_OUTPUT_TYPES(output.scalar_type(), "fp8_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", ([&] {
       if (max_float8_D > 0) {
         auto max_fp8_128b_rows = nbit::div_round_up(nbit::padded_row_size_in_bytes(max_float8_D, SparseType::FP8, row_alignment), 128);
-        TORCH_CHECK(max_fp8_128b_rows <= 16);
+        TORCH_CHECK_LE(max_fp8_128b_rows, 16);
         if (max_fp8_128b_rows > 0) {
           Y(2, 8, 0, 1);
         }
@@ -418,7 +418,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
     DISPATCH_OUTPUT_TYPES(output.scalar_type(), "fp16_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", ([&] {
       if (max_float16_D > 0) {
         auto max_fp16_128b_rows = nbit::div_round_up(nbit::padded_row_size_in_bytes(max_float16_D, SparseType::FP16, row_alignment), 128);
-        TORCH_CHECK(max_fp16_128b_rows <= 32);
+        TORCH_CHECK_LE(max_fp16_128b_rows, 32);
         if (max_fp16_128b_rows > 0) {
           Y(2, 8, 0, 2);
         }
@@ -472,7 +472,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
     DISPATCH_OUTPUT_TYPES(output.scalar_type(), "fp32_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_kernel", ([&] {
       if (max_float32_D > 0) {
         auto max_fp32_128b_rows = nbit::div_round_up(nbit::padded_row_size_in_bytes(max_float32_D, SparseType::FP32, row_alignment), 128);
-        TORCH_CHECK(max_fp32_128b_rows <= 64);
+        TORCH_CHECK_LE(max_fp32_128b_rows, 64);
         if (max_fp32_128b_rows > 0) {
           Y(2, 4, 0, 4);
         }


### PR DESCRIPTION
Summary:
`TORCH_CHECK` produces pretty generic error messages. Using, eg, `TORCH_CHECK_GE` produces a message that shows the names of the variables being compared as well as their values at the time of comparison. This makes debugging easier.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

(7 files modified.)

Differential Revision: D45402699

