### PR TITLE
Improve `TORCH_CHECK` diagnostics in files including deeplearning/fbgemm/fbgemm_gpu/fb/src/split_embeddings_utils.cu

### DIFF
--- a/fbgemm_gpu/src/cumem_utils.cu
+++ b/fbgemm_gpu/src/cumem_utils.cu
@@ -423,7 +423,7 @@ void uvm_mem_advice_dont_fork(const Tensor& t) {
   int result =
       madvise(std::get<0>(adjusted), std::get<1>(adjusted), MADV_DONTFORK);
 
-  TORCH_CHECK(result == 0);
+  TORCH_CHECK_EQ(result, 0);
 
   return;
 }

--- a/fbgemm_gpu/src/embedding_inplace_update.cu
+++ b/fbgemm_gpu/src/embedding_inplace_update.cu
@@ -144,7 +144,7 @@ void embedding_inplace_update_cuda(
   if (N == 0) {
     return;
   }
-  TORCH_CHECK(N == update_table_idx.numel());
+  TORCH_CHECK_EQ(N, update_table_idx.numel());
 
   const int32_t warpsPerBlock = kMaxThreads / kWarpSize;
 
@@ -240,7 +240,7 @@ Tensor pruned_array_lookup_from_row_idx_cuda(
     return dense_indices;
   }
 
-  TORCH_CHECK(index_remappings.size(0) < std::numeric_limits<int64_t>::max());
+  TORCH_CHECK_LT(index_remappings.size(0), std::numeric_limits<int64_t>::max());
   TORCH_CHECK(
       update_row_indices.dim() == 1, "Tensor dim: ", update_row_indices.dim());
   TORCH_CHECK(

--- a/fbgemm_gpu/src/histogram_binning_calibration_ops.cu
+++ b/fbgemm_gpu/src/histogram_binning_calibration_ops.cu
@@ -61,7 +61,7 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_cuda(
   TENSOR_ON_CUDA_GPU(logit);
   TENSOR_ON_CUDA_GPU(bin_num_examples);
   TENSOR_ON_CUDA_GPU(bin_num_positives);
-  TORCH_CHECK(bin_num_examples.numel() == bin_num_positives.numel());
+  TORCH_CHECK_EQ(bin_num_examples.numel(), bin_num_positives.numel());
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(logit.get_device());
@@ -181,7 +181,7 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_by_feature_cuda(
   TENSOR_ON_CUDA_GPU(segment_lengths);
   TENSOR_ON_CUDA_GPU(bin_num_examples);
   TENSOR_ON_CUDA_GPU(bin_num_positives);
-  TORCH_CHECK(bin_num_examples.numel() == bin_num_positives.numel());
+  TORCH_CHECK_EQ(bin_num_examples.numel(), bin_num_positives.numel());
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(logit.get_device());
@@ -339,7 +339,7 @@ generic_histogram_binning_calibration_by_feature_cuda(
   TENSOR_ON_CUDA_GPU(bin_num_examples);
   TENSOR_ON_CUDA_GPU(bin_num_positives);
   TENSOR_ON_CUDA_GPU(bin_boundaries);
-  TORCH_CHECK(bin_num_examples.numel() == bin_num_positives.numel());
+  TORCH_CHECK_EQ(bin_num_examples.numel(), bin_num_positives.numel());
   TORCH_CHECK(
       bin_num_examples.numel() ==
       (num_segments + 1) * (bin_boundaries.numel() + 1));

--- a/fbgemm_gpu/src/input_combine_cpu.cpp
+++ b/fbgemm_gpu/src/input_combine_cpu.cpp
@@ -106,9 +106,9 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_cpu(
     const std::vector<Tensor>& offsets_list,
     const std::vector<Tensor>& per_sample_weights,
     const Tensor& include_last_offsets) {
-  TORCH_CHECK(indices_list.size() > 0);
-  TORCH_CHECK(offsets_list.size() == indices_list.size());
-  TORCH_CHECK(per_sample_weights.size() == indices_list.size());
+  TORCH_CHECK_GT(indices_list.size(), 0);
+  TORCH_CHECK_EQ(offsets_list.size(), indices_list.size());
+  TORCH_CHECK_EQ(per_sample_weights.size(), indices_list.size());
   TORCH_CHECK(
       static_cast<uint64_t>(include_last_offsets.numel()) ==
       indices_list.size());
@@ -125,8 +125,8 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_cpu(
     TORCH_CHECK(
         offsets_list[i].dtype() == c10::kInt ||
         offsets_list[i].dtype() == c10::kLong);
-    TORCH_CHECK(indices_list[i].ndimension() == 1);
-    TORCH_CHECK(offsets_list[i].ndimension() == 1);
+    TORCH_CHECK_EQ(indices_list[i].ndimension(), 1);
+    TORCH_CHECK_EQ(offsets_list[i].ndimension(), 1);
     TORCH_CHECK(indices_list[i].is_contiguous());
     TORCH_CHECK(offsets_list[i].is_contiguous());
     total_indices += indices_list[i].numel();
@@ -135,8 +135,8 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_cpu(
     total_offsets += num_offset == 0 ? 1 : num_offset;
 
     if (per_sample_weights[i].numel() > 0) {
-      TORCH_CHECK(per_sample_weights[i].ndimension() == 1);
-      TORCH_CHECK(per_sample_weights[i].numel() == indices_list[i].numel());
+      TORCH_CHECK_EQ(per_sample_weights[i].ndimension(), 1);
+      TORCH_CHECK_EQ(per_sample_weights[i].numel(), indices_list[i].numel());
       TORCH_CHECK(per_sample_weights[i].is_contiguous());
       need_weights = true;
     }
@@ -189,9 +189,9 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_with_length_cpu(
     const std::vector<Tensor>& indices_list,
     const std::vector<Tensor>& lengths_list,
     const std::vector<Tensor>& per_sample_weights) {
-  TORCH_CHECK(indices_list.size() > 0);
-  TORCH_CHECK(lengths_list.size() == indices_list.size());
-  TORCH_CHECK(per_sample_weights.size() == indices_list.size());
+  TORCH_CHECK_GT(indices_list.size(), 0);
+  TORCH_CHECK_EQ(lengths_list.size(), indices_list.size());
+  TORCH_CHECK_EQ(per_sample_weights.size(), indices_list.size());
   int64_t total_indices = 0;
   int64_t total_lengths = 0;
   bool need_weights = false;
@@ -204,16 +204,16 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_with_length_cpu(
     TORCH_CHECK(
         lengths_list[i].dtype() == c10::kInt ||
         lengths_list[i].dtype() == c10::kLong);
-    TORCH_CHECK(indices_list[i].ndimension() == 1);
-    TORCH_CHECK(lengths_list[i].ndimension() == 1);
+    TORCH_CHECK_EQ(indices_list[i].ndimension(), 1);
+    TORCH_CHECK_EQ(lengths_list[i].ndimension(), 1);
     TORCH_CHECK(indices_list[i].is_contiguous());
     TORCH_CHECK(lengths_list[i].is_contiguous());
     total_indices += indices_list[i].numel();
     total_lengths += lengths_list[i].numel();
 
     if (per_sample_weights[i].numel() > 0) {
-      TORCH_CHECK(per_sample_weights[i].ndimension() == 1);
-      TORCH_CHECK(per_sample_weights[i].numel() == indices_list[i].numel());
+      TORCH_CHECK_EQ(per_sample_weights[i].ndimension(), 1);
+      TORCH_CHECK_EQ(per_sample_weights[i].numel(), indices_list[i].numel());
       TORCH_CHECK(per_sample_weights[i].is_contiguous());
       need_weights = true;
     }
@@ -244,9 +244,9 @@ std::tuple<Tensor, Tensor, Tensor> padding_fused_tbe_input_combine_cpu(
     const std::vector<Tensor>& per_sample_weights,
     const Tensor& include_last_offsets,
     int64_t batch_size) {
-  TORCH_CHECK(indices_list.size() > 0);
-  TORCH_CHECK(offsets_list.size() == indices_list.size());
-  TORCH_CHECK(per_sample_weights.size() == indices_list.size());
+  TORCH_CHECK_GT(indices_list.size(), 0);
+  TORCH_CHECK_EQ(offsets_list.size(), indices_list.size());
+  TORCH_CHECK_EQ(per_sample_weights.size(), indices_list.size());
   TORCH_CHECK(
       static_cast<uint64_t>(include_last_offsets.numel()) ==
       indices_list.size());
@@ -263,15 +263,15 @@ std::tuple<Tensor, Tensor, Tensor> padding_fused_tbe_input_combine_cpu(
     TORCH_CHECK(
         offsets_list[i].dtype() == c10::kInt ||
         offsets_list[i].dtype() == c10::kLong);
-    TORCH_CHECK(indices_list[i].ndimension() == 1);
-    TORCH_CHECK(offsets_list[i].ndimension() == 1);
+    TORCH_CHECK_EQ(indices_list[i].ndimension(), 1);
+    TORCH_CHECK_EQ(offsets_list[i].ndimension(), 1);
     TORCH_CHECK(indices_list[i].is_contiguous());
     TORCH_CHECK(offsets_list[i].is_contiguous());
     total_indices += indices_list[i].numel();
 
     if (per_sample_weights[i].numel() > 0) {
-      TORCH_CHECK(per_sample_weights[i].ndimension() == 1);
-      TORCH_CHECK(per_sample_weights[i].numel() == indices_list[i].numel());
+      TORCH_CHECK_EQ(per_sample_weights[i].ndimension(), 1);
+      TORCH_CHECK_EQ(per_sample_weights[i].numel(), indices_list[i].numel());
       TORCH_CHECK(per_sample_weights[i].is_contiguous());
       need_weights = true;
     }
@@ -333,9 +333,9 @@ padding_fused_tbe_input_combine_with_length_cpu(
     const std::vector<Tensor>& lengths_list,
     const std::vector<Tensor>& per_sample_weights,
     int64_t batch_size) {
-  TORCH_CHECK(indices_list.size() > 0);
-  TORCH_CHECK(lengths_list.size() == indices_list.size());
-  TORCH_CHECK(per_sample_weights.size() == indices_list.size());
+  TORCH_CHECK_GT(indices_list.size(), 0);
+  TORCH_CHECK_EQ(lengths_list.size(), indices_list.size());
+  TORCH_CHECK_EQ(per_sample_weights.size(), indices_list.size());
   int64_t total_indices = 0;
   int64_t total_lengths = batch_size * indices_list.size();
   bool need_weights = false;
@@ -348,15 +348,15 @@ padding_fused_tbe_input_combine_with_length_cpu(
     TORCH_CHECK(
         lengths_list[i].dtype() == c10::kInt ||
         lengths_list[i].dtype() == c10::kLong);
-    TORCH_CHECK(indices_list[i].ndimension() == 1);
-    TORCH_CHECK(lengths_list[i].ndimension() == 1);
+    TORCH_CHECK_EQ(indices_list[i].ndimension(), 1);
+    TORCH_CHECK_EQ(lengths_list[i].ndimension(), 1);
     TORCH_CHECK(indices_list[i].is_contiguous());
     TORCH_CHECK(lengths_list[i].is_contiguous());
     total_indices += indices_list[i].numel();
 
     if (per_sample_weights[i].numel() > 0) {
-      TORCH_CHECK(per_sample_weights[i].ndimension() == 1);
-      TORCH_CHECK(per_sample_weights[i].numel() == indices_list[i].numel());
+      TORCH_CHECK_EQ(per_sample_weights[i].ndimension(), 1);
+      TORCH_CHECK_EQ(per_sample_weights[i].numel(), indices_list[i].numel());
       TORCH_CHECK(per_sample_weights[i].is_contiguous());
       need_weights = true;
     }

--- a/fbgemm_gpu/src/input_combine_gpu.cpp
+++ b/fbgemm_gpu/src/input_combine_gpu.cpp
@@ -62,9 +62,9 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_with_length_gpu(
     const std::vector<Tensor>& lengths_list,
     const std::vector<Tensor>& per_sample_weights) {
   const auto num_lists = indices_list.size();
-  TORCH_CHECK(num_lists > 0);
-  TORCH_CHECK(lengths_list.size() == num_lists);
-  TORCH_CHECK(per_sample_weights.size() == num_lists);
+  TORCH_CHECK_GT(num_lists, 0);
+  TORCH_CHECK_EQ(lengths_list.size(), num_lists);
+  TORCH_CHECK_EQ(per_sample_weights.size(), num_lists);
   const bool need_weights = std::any_of(
       per_sample_weights.begin(), per_sample_weights.end(), [](const auto& x) {
         return x.numel() > 0;


### PR DESCRIPTION
Summary:
`TORCH_CHECK` produces pretty generic error messages. Using, eg, `TORCH_CHECK_GE` produces a message that shows the names of the variables being compared as well as their values at the time of comparison. This makes debugging easier.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

(7 files modified.)

Differential Revision: D45402704

