### PR TITLE
Improve `TORCH_CHECK` diagnostics in files including deeplearning/fbgemm/fbgemm_gpu/src/jagged_tensor_ops.cu

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_autograd.cpp
@@ -54,9 +54,9 @@ class JaggedToPaddedDenseOp
       torch::autograd::variable_list grad_outputs) {
     auto offsets = ctx->get_saved_variables();
     int32_t total_L = ctx->saved_data["total_L"].toInt();
-    TORCH_CHECK(grad_outputs.size() == 1);
+    TORCH_CHECK_EQ(grad_outputs.size(), 1);
 
-    TORCH_CHECK(total_L >= 0);
+    TORCH_CHECK_GE(total_L, 0);
     static auto op =
         c10::Dispatcher::singleton()
             .findSchemaOrThrow("fbgemm::jagged_to_padded_dense_backward", "")
@@ -107,7 +107,7 @@ class JaggedDenseDenseAddJaggedOutputOp
       torch::autograd::variable_list grad_outputs) {
     auto offsets = ctx->get_saved_variables();
     auto dense_shape = ctx->saved_data["dense_shape"].toIntVector();
-    TORCH_CHECK(grad_outputs.size() == 1);
+    TORCH_CHECK_EQ(grad_outputs.size(), 1);
 
     static auto op =
         c10::Dispatcher::singleton()
@@ -167,7 +167,7 @@ class JaggedDenseMulOp : public torch::autograd::Function<JaggedDenseMulOp> {
       x_offsets.push_back(ctx->get_saved_variables()[i]);
     }
     Tensor y = ctx->get_saved_variables().back();
-    TORCH_CHECK(grad_outputs.size() == 1);
+    TORCH_CHECK_EQ(grad_outputs.size(), 1);
 
     static auto op =
         c10::Dispatcher::singleton()
@@ -221,7 +221,7 @@ class BatchedDenseVecJagged2DMulOp
     const Tensor v = *savedItr++;
     const Tensor a_values = *savedItr++;
     const Tensor a_offsets = *savedItr++;
-    TORCH_CHECK(grad_outputs.size() == 1);
+    TORCH_CHECK_EQ(grad_outputs.size(), 1);
 
     static auto op =
         c10::Dispatcher::singleton()
@@ -271,7 +271,7 @@ class DenseToJaggedOp : public torch::autograd::Function<DenseToJaggedOp> {
       torch::autograd::variable_list grad_outputs) {
     auto offsets = ctx->get_saved_variables();
     auto dense_shape = ctx->saved_data["dense_shape"].toIntVector();
-    TORCH_CHECK(grad_outputs.size() == 1);
+    TORCH_CHECK_EQ(grad_outputs.size(), 1);
 
     static auto op =
         c10::Dispatcher::singleton()
@@ -287,7 +287,7 @@ class DenseToJaggedOp : public torch::autograd::Function<DenseToJaggedOp> {
         std::vector<int64_t>(dense_shape.begin() + 1, dense_shape.end() - 1),
         /*padding_value=*/0);
 
-    TORCH_CHECK(dense_values_grad.sizes() == dense_shape);
+    TORCH_CHECK_EQ(dense_values_grad.sizes(), dense_shape);
 
     return {
         dense_values_grad,
@@ -326,7 +326,7 @@ class JaggedSoftmaxOp : public torch::autograd::Function<JaggedSoftmaxOp> {
     Tensor output = *savedItr++;
     Tensor offsets = *savedItr++;
     int64_t max_L = ctx->saved_data["max_L"].toInt();
-    TORCH_CHECK(grad_outputs.size() == 1);
+    TORCH_CHECK_EQ(grad_outputs.size(), 1);
 
     static auto op =
         c10::Dispatcher::singleton()
@@ -381,7 +381,7 @@ class JaggedJaggedBmmOp : public torch::autograd::Function<JaggedJaggedBmmOp> {
     Tensor y_values = *savedItr++;
     Tensor offsets = *savedItr++;
     int64_t max_L = ctx->saved_data["max_L"].toInt();
-    TORCH_CHECK(grad_outputs.size() == 1);
+    TORCH_CHECK_EQ(grad_outputs.size(), 1);
 
     static auto op =
         c10::Dispatcher::singleton()
@@ -439,7 +439,7 @@ class JaggedDenseBmmOp : public torch::autograd::Function<JaggedDenseBmmOp> {
     Tensor offsets = *savedItr++;
     Tensor y = *savedItr++;
     int64_t max_L = ctx->saved_data["max_L"].toInt();
-    TORCH_CHECK(grad_outputs.size() == 1);
+    TORCH_CHECK_EQ(grad_outputs.size(), 1);
 
     static auto op =
         c10::Dispatcher::singleton()
@@ -520,7 +520,7 @@ class JaggedIndexSelect2dOp
   static torch::autograd::variable_list backward(
       torch::autograd::AutogradContext* ctx,
       torch::autograd::variable_list grad_outputs) {
-    TORCH_CHECK(grad_outputs.size() == 2);
+    TORCH_CHECK_EQ(grad_outputs.size(), 2);
 
     const auto saved = ctx->get_saved_variables();
     auto savedItr = std::begin(saved);
@@ -681,7 +681,7 @@ Tensor jagged_dense_elementwise_add(
   for (int d = 1; d < y.dim() - 1; d++) {
     max_lengths.push_back(y.size(d));
   }
-  TORCH_CHECK(max_lengths.size() == x_offsets.size());
+  TORCH_CHECK_EQ(max_lengths.size(), x_offsets.size());
 
   // Convert x to dense (assume padding is 0.0)
   auto xd = JaggedToPaddedDenseOp::apply(
@@ -756,9 +756,9 @@ Tensor jagged_1d_to_dense(
     Tensor offsets,
     int64_t max_L,
     int64_t padding_value) {
-  TORCH_CHECK(values.dim() == 1);
-  TORCH_CHECK(offsets.dim() == 1);
-  TORCH_CHECK(max_L > 0);
+  TORCH_CHECK_EQ(values.dim(), 1);
+  TORCH_CHECK_EQ(offsets.dim(), 1);
+  TORCH_CHECK_GT(max_L, 0);
 
   return jagged_to_padded_dense(values, {offsets}, {max_L}, padding_value);
 }

--- a/fbgemm_gpu/src/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_cpu.cpp
@@ -871,8 +871,8 @@ Tensor jagged_1d_to_truncated_values_cpu(
     Tensor values,
     Tensor lengths,
     int64_t max_truncated_length) {
-  TORCH_CHECK(values.dim() == 1);
-  TORCH_CHECK(lengths.dim() == 1);
+  TORCH_CHECK_EQ(values.dim(), 1);
+  TORCH_CHECK_EQ(lengths.dim(), 1);
 
   const int32_t B = lengths.size(0);
   Tensor truncated_values;
@@ -915,8 +915,8 @@ std::tuple<Tensor, Tensor> masked_select_jagged_1d(
     const Tensor& values,
     const Tensor& lengths,
     const Tensor& mask) {
-  TORCH_CHECK(values.dim() == 1);
-  TORCH_CHECK(lengths.dim() == 1);
+  TORCH_CHECK_EQ(values.dim(), 1);
+  TORCH_CHECK_EQ(lengths.dim(), 1);
 
   auto values_contiguous = values.expect_contiguous();
   auto lengths_contiguous = lengths.expect_contiguous();
@@ -969,9 +969,9 @@ std::tuple<Tensor, Tensor> masked_select_jagged_1d(
 
 Tensor
 jagged_2d_to_dense_forward_cpu(Tensor values, Tensor offsets, int64_t max_L) {
-  TORCH_CHECK(values.dim() == 2);
-  TORCH_CHECK(offsets.dim() == 1);
-  TORCH_CHECK(max_L > 0);
+  TORCH_CHECK_EQ(values.dim(), 2);
+  TORCH_CHECK_EQ(offsets.dim(), 1);
+  TORCH_CHECK_GT(max_L, 0);
 
   return jagged_to_padded_dense_forward(
       values, {offsets}, {max_L}, /*padding_value=*/0);
@@ -983,8 +983,8 @@ std::vector<Tensor> stacked_jagged_1d_to_dense_cpu(
     const std::vector<int64_t>& offset_per_key,
     const std::vector<int64_t>& max_lengths_per_key,
     int64_t padding_value) {
-  TORCH_CHECK(values.dim() == 1);
-  TORCH_CHECK(lengths.dim() == 2);
+  TORCH_CHECK_EQ(values.dim(), 1);
+  TORCH_CHECK_EQ(lengths.dim(), 2);
 
   const auto lengths_contig = lengths.contiguous();
   int32_t B = lengths.size(1);
@@ -1021,8 +1021,8 @@ std::vector<Tensor> stacked_jagged_2d_to_dense_cpu(
     const std::vector<int64_t>& offset_per_key,
     const std::vector<int64_t>& max_lengths_per_key,
     int64_t padding_value) {
-  TORCH_CHECK(values.dim() == 2);
-  TORCH_CHECK(lengths.dim() == 2);
+  TORCH_CHECK_EQ(values.dim(), 2);
+  TORCH_CHECK_EQ(lengths.dim(), 2);
 
   const auto lengths_contig = lengths.contiguous();
   int32_t B = lengths.size(1);

--- a/fbgemm_gpu/src/jagged_tensor_ops_meta.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops_meta.cpp
@@ -60,7 +60,7 @@ at::Tensor jagged_dense_dense_elementwise_add_jagged_output_forward_meta(
     const std::vector<at::Tensor>& x_offsets,
     const at::Tensor& y_0,
     const at::Tensor& y_1) {
-  TORCH_CHECK(y_0.sizes() == y_0.sizes());
+  TORCH_CHECK_EQ(y_0.sizes(), y_0.sizes());
   return at::empty_like(x_values);
 }
 

--- a/fbgemm_gpu/src/layout_transform_ops.cu
+++ b/fbgemm_gpu/src/layout_transform_ops.cu
@@ -70,8 +70,8 @@ Tensor recat_embedding_grad_output_cuda(
           feature_offset += num_features;
           sgo_offset += B_local * num_features * D;
         }
-        TORCH_CHECK(sgo_offset == grad_output.numel());
-        TORCH_CHECK(feature_offset == T_global);
+        TORCH_CHECK_EQ(sgo_offset, grad_output.numel());
+        TORCH_CHECK_EQ(feature_offset, T_global);
       });
   return sharded_grad_output;
 }
@@ -114,8 +114,8 @@ Tensor recat_embedding_grad_output_mixed_D_cuda(
           sgo_offset += B_local * dim_sum;
           accum_dim_sum += dim_sum;
         }
-        TORCH_CHECK(sgo_offset == grad_output.numel());
-        TORCH_CHECK(accum_dim_sum == global_dim_sum);
+        TORCH_CHECK_EQ(sgo_offset, grad_output.numel());
+        TORCH_CHECK_EQ(accum_dim_sum, global_dim_sum);
       });
 
   return sharded_grad_output;

--- a/fbgemm_gpu/src/layout_transform_ops_cpu.cpp
+++ b/fbgemm_gpu/src/layout_transform_ops_cpu.cpp
@@ -33,7 +33,7 @@ Tensor recat_embedding_grad_output_mixed_D_cpu(
   std::partial_sum(
       dim_sum_per_rank.begin(), dim_sum_per_rank.end(), &accum_dim_sum[1]);
   const auto global_dim_sum = accum_dim_sum[n];
-  TORCH_CHECK(B_local * global_dim_sum == grad_output.numel());
+  TORCH_CHECK_EQ(B_local * global_dim_sum, grad_output.numel());
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       grad_output.scalar_type(), "recat_embedding_gradients", [&] {

--- a/fbgemm_gpu/src/merge_pooled_embeddings_gpu.cpp
+++ b/fbgemm_gpu/src/merge_pooled_embeddings_gpu.cpp
@@ -493,9 +493,9 @@ Tensor cat_dim_2d(
   std::vector<int64_t> cumulative_dims;
   cumulative_dims.push_back(0);
   for (const auto& t : tensors) {
-    TORCH_CHECK(t.dim() == 2);
+    TORCH_CHECK_EQ(t.dim(), 2);
     // only support two-dimension tensors.
-    TORCH_CHECK(t.size(1 - cat_dim) == uncat_dim_size);
+    TORCH_CHECK_EQ(t.size(1 - cat_dim), uncat_dim_size);
     total_cat_dim += t.size(cat_dim);
     cumulative_dims.push_back(total_cat_dim);
   }


### PR DESCRIPTION
Summary:
`TORCH_CHECK` produces pretty generic error messages. Using, eg, `TORCH_CHECK_GE` produces a message that shows the names of the variables being compared as well as their values at the time of comparison. This makes debugging easier.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

(7 files modified.)

Differential Revision: D45402702

