### PR TITLE
Improve `TORCH_CHECK` diagnostics in files including deeplearning/fbgemm/fbgemm_gpu/src/split_embeddings_utils.cu

### DIFF
--- a/fbgemm_gpu/src/split_embeddings_utils.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils.cu
@@ -25,8 +25,8 @@ inline at::Tensor asynchronous_complete_cumsum(at::Tensor t_in) {
   TORCH_CHECK(t_in.is_contiguous());
   TORCH_CHECK(t_in.dtype() == at::kInt || t_in.dtype() == at::kLong);
   // CUB only handles up to INT_MAX elements.
-  TORCH_CHECK(t_in.numel() < std::numeric_limits<int32_t>::max());
-  TORCH_CHECK(t_in.dim() == 1);
+  TORCH_CHECK_LT(t_in.numel(), std::numeric_limits<int32_t>::max());
+  TORCH_CHECK_EQ(t_in.dim(), 1);
   auto t_out = at::empty({t_in.numel() + 1}, t_in.options());
   t_out[0].zero_();
   AT_DISPATCH_INDEX_TYPES(

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache_cuda.cu
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache_cuda.cu
@@ -85,7 +85,7 @@ Tensor masked_index_put_cuda(
     return self;
   }
   const auto D = self.size(1);
-  TORCH_CHECK(self.size(1) == values.size(1));
+  TORCH_CHECK_EQ(self.size(1), values.size(1));
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half,
@@ -232,7 +232,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> ssd_cache_populate_actions_cuda(
   std::tie(unique_indices, unique_indices_length, unique_indices_count) =
       get_unique_indices_cuda(linear_indices, total_hash_size, false);
 
-  TORCH_CHECK(unique_indices.numel() < std::numeric_limits<int32_t>::max());
+  TORCH_CHECK_LT(unique_indices.numel(), std::numeric_limits<int32_t>::max());
   const int32_t N = unique_indices.numel();
 
   auto evicted_indices = empty_like(unique_indices);

--- a/fbgemm_gpu/src/topology_utils.cpp
+++ b/fbgemm_gpu/src/topology_utils.cpp
@@ -16,10 +16,10 @@
 #include "hip/hip_runtime.h"
 #include "rocm_smi/rocm_smi.h"
 
-#define RSMI_CHECK(fn)                         \
-  do {                                         \
-    rsmi_status_t ret = (fn);                  \
-    TORCH_CHECK((ret) == RSMI_STATUS_SUCCESS); \
+#define RSMI_CHECK(fn)                          \
+  do {                                          \
+    rsmi_status_t ret = (fn);                   \
+    TORCH_CHECK_EQ((ret), RSMI_STATUS_SUCCESS); \
   } while (0)
 
 #define RSMI_DEVICE_PCI_BUS_ID_BUFFER_SIZE 16
@@ -90,8 +90,8 @@ AdjacencyMatrix<Links> get_nvlink_matrix() {
   }
   RSMI_CHECK(rsmi_shut_down());
   return [=](Node i, Node j) {
-    TORCH_CHECK(i < world_size);
-    TORCH_CHECK(j < world_size);
+    TORCH_CHECK_LT(i, world_size);
+    TORCH_CHECK_LT(j, world_size);
     return links[i * world_size + j];
   };
 }
@@ -101,10 +101,10 @@ AdjacencyMatrix<Links> get_nvlink_matrix() {
 
 #include <nvml.h>
 
-#define NVML_CHECK(fn)                  \
-  do {                                  \
-    nvmlReturn_t ret = (fn);            \
-    TORCH_CHECK((ret) == NVML_SUCCESS); \
+#define NVML_CHECK(fn)                   \
+  do {                                   \
+    nvmlReturn_t ret = (fn);             \
+    TORCH_CHECK_EQ((ret), NVML_SUCCESS); \
   } while (0)
 
 namespace fbgemm_gpu {
@@ -175,8 +175,8 @@ AdjacencyMatrix<Links> get_nvlink_matrix() {
   }
 
   return [=](Node i, Node j) {
-    TORCH_CHECK(i < world_size);
-    TORCH_CHECK(j < world_size);
+    TORCH_CHECK_LT(i, world_size);
+    TORCH_CHECK_LT(j, world_size);
     return links[i * world_size + j];
   };
 }


### PR DESCRIPTION
Summary:
`TORCH_CHECK` produces pretty generic error messages. Using, eg, `TORCH_CHECK_GE` produces a message that shows the names of the variables being compared as well as their values at the time of comparison. This makes debugging easier.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

(3 files modified.)

Differential Revision: D45402697

