### PR TITLE
Dynamically determine platform name in FBGEMM scripts

### DIFF
--- a/.github/scripts/fbgemm_gpu_build.bash
+++ b/.github/scripts/fbgemm_gpu_build.bash
@@ -291,7 +291,7 @@ build_fbgemm_gpu_package () {
     python setup.py bdist_wheel \
       --package_name="${package_name}" \
       --python-tag="${python_tag}" \
-      --plat-name=manylinux1_x86_64 \
+      --plat-name="manylinux1_${MACHINE_NAME}" \
       "${build_args[@]}"
 
   # Run checks on the built libraries

--- a/.github/scripts/utils_base.bash
+++ b/.github/scripts/utils_base.bash
@@ -5,6 +5,16 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+################################################################################
+# Platform specific variables 
+################################################################################
+
+KERN_NAME="$(uname -s)"
+MACHINE_NAME="$(uname -m)"
+PLATFORM_NAME="$KERN_NAME-$MACHINE_NAME"
+KERN_NAME_LC="$(echo "$KERN_NAME" | awk '{print tolower($0)}')"
+MACHINE_NAME_LC="$(echo "$MACHINE_NAME" | awk '{print tolower($0)}')"
+PLATFORM_NAME_LC="$KERN_NAME_LC-$MACHINE_NAME_LC"
 
 ################################################################################
 # Command Execution Functions

--- a/cmake/modules/FindAVX.cmake
+++ b/cmake/modules/FindAVX.cmake
@@ -1,0 +1,92 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+################################################################################
+# Finds and sets AVX compilation flags
+# This file is copied over from the PyTorch repo
+################################################################################
+
+INCLUDE(CheckCSourceRuns)
+INCLUDE(CheckCXXSourceRuns)
+
+SET(AVX_CODE "
+  #include <immintrin.h>
+
+  int main()
+  {
+    __m256 a;
+    a = _mm256_set1_ps(0);
+    return 0;
+  }
+")
+
+SET(AVX512_CODE "
+  #include <immintrin.h>
+
+  int main()
+  {
+    __m512i a = _mm512_set_epi8(0, 0, 0, 0, 0, 0, 0, 0,
+                                0, 0, 0, 0, 0, 0, 0, 0,
+                                0, 0, 0, 0, 0, 0, 0, 0,
+                                0, 0, 0, 0, 0, 0, 0, 0,
+                                0, 0, 0, 0, 0, 0, 0, 0,
+                                0, 0, 0, 0, 0, 0, 0, 0,
+                                0, 0, 0, 0, 0, 0, 0, 0,
+                                0, 0, 0, 0, 0, 0, 0, 0);
+    __m512i b = a;
+    __mmask64 equality_mask = _mm512_cmp_epi8_mask(a, b, _MM_CMPINT_EQ);
+    return 0;
+  }
+")
+
+SET(AVX2_CODE "
+  #include <immintrin.h>
+
+  int main()
+  {
+    __m256i a = {0};
+    a = _mm256_abs_epi16(a);
+    __m256i x;
+    _mm256_extract_epi64(x, 0); // we rely on this in our AVX2 code
+    return 0;
+  }
+")
+
+MACRO(CHECK_SSE lang type flags)
+  SET(__FLAG_I 1)
+  SET(CMAKE_REQUIRED_FLAGS_SAVE ${CMAKE_REQUIRED_FLAGS})
+  FOREACH(__FLAG ${flags})
+    IF(NOT ${lang}_${type}_FOUND)
+      SET(CMAKE_REQUIRED_FLAGS ${__FLAG})
+      IF(lang STREQUAL "CXX")
+        CHECK_CXX_SOURCE_RUNS("${${type}_CODE}" ${lang}_HAS_${type}_${__FLAG_I})
+      ELSE()
+        CHECK_C_SOURCE_RUNS("${${type}_CODE}" ${lang}_HAS_${type}_${__FLAG_I})
+      ENDIF()
+      IF(${lang}_HAS_${type}_${__FLAG_I})
+        SET(${lang}_${type}_FOUND TRUE CACHE BOOL "${lang} ${type} support")
+        SET(${lang}_${type}_FLAGS "${__FLAG}" CACHE STRING "${lang} ${type} flags")
+      ENDIF()
+      MATH(EXPR __FLAG_I "${__FLAG_I}+1")
+    ENDIF()
+  ENDFOREACH()
+  SET(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS_SAVE})
+
+  IF(NOT ${lang}_${type}_FOUND)
+    SET(${lang}_${type}_FOUND FALSE CACHE BOOL "${lang} ${type} support")
+    SET(${lang}_${type}_FLAGS "" CACHE STRING "${lang} ${type} flags")
+  ENDIF()
+
+  MARK_AS_ADVANCED(${lang}_${type}_FOUND ${lang}_${type}_FLAGS)
+
+ENDMACRO()
+
+CHECK_SSE(C "AVX" " ;-mavx;/arch:AVX")
+CHECK_SSE(C "AVX2" " ;-mavx2 -mfma -mf16c;/arch:AVX2")
+CHECK_SSE(C "AVX512" " ;-mavx512f -mavx512dq -mavx512vl -mavx512bw -mfma;/arch:AVX512")
+
+CHECK_SSE(CXX "AVX" " ;-mavx;/arch:AVX")
+CHECK_SSE(CXX "AVX2" " ;-mavx2 -mfma -mf16c;/arch:AVX2")
+CHECK_SSE(CXX "AVX512" " ;-mavx512f -mavx512dq -mavx512vl -mavx512bw -mfma;/arch:AVX512")

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -18,6 +18,7 @@ function(BLOCK_PRINT)
   message("")
 endfunction()
 
+set(CMAKEMODULES ${CMAKE_CURRENT_SOURCE_DIR}/../cmake/modules)
 set(FBGEMM ${CMAKE_CURRENT_SOURCE_DIR}/..)
 set(THIRDPARTY ${FBGEMM}/third_party)
 
@@ -82,6 +83,10 @@ BLOCK_PRINT(
 # FBGEMM_GPU Build Kickstart
 ################################################################################
 
+if(SKBUILD)
+  BLOCK_PRINT("The project is built using scikit-build")
+endif()
+
 if(FBGEMM_CPU_ONLY OR USE_ROCM)
   project(
     fbgemm_gpu
@@ -94,9 +99,7 @@ else()
     LANGUAGES CXX C CUDA)
 endif()
 
-if(SKBUILD)
-  BLOCK_PRINT("The project is built using scikit-build")
-endif()
+include(${CMAKEMODULES}/FindAVX.cmake)
 
 
 ################################################################################
@@ -296,9 +299,15 @@ else()
     DEPENDS "${codegen_dependencies}")
 endif()
 
-set_source_files_properties(${gen_cpu_source_files}
-  PROPERTIES COMPILE_OPTIONS
-  "-mavx2;-mf16c;-mfma;-fopenmp")
+if(CXX_AVX2_FOUND)
+  set_source_files_properties(${gen_cpu_source_files}
+    PROPERTIES COMPILE_OPTIONS
+    "-mavx2;-mf16c;-mfma;-fopenmp")
+else()
+  set_source_files_properties(${gen_cpu_source_files}
+    PROPERTIES COMPILE_OPTIONS
+    "-fopenmp")
+endif()
 
 set_source_files_properties(${gen_cpu_source_files}
   PROPERTIES INCLUDE_DIRECTORIES
@@ -349,14 +358,17 @@ set(fbgemm_sources_avx2
 set(fbgemm_sources_avx512
   "${FBGEMM}/src/EmbeddingSpMDMAvx512.cc")
 
-# Add compilation flags
-set_source_files_properties(${fbgemm_sources_avx2}
-  PROPERTIES COMPILE_OPTIONS
-  "-mavx2;-mf16c;-mfma")
+if(CXX_AVX2_FOUND)
+  set_source_files_properties(${fbgemm_sources_avx2}
+    PROPERTIES COMPILE_OPTIONS
+    "-mavx2;-mf16c;-mfma")
+endif()
 
-set_source_files_properties(${fbgemm_sources_avx512}
-  PROPERTIES COMPILE_OPTIONS
-  "-mavx2;-mf16c;-mfma;-mavx512f;-mavx512bw;-mavx512dq;-mavx512vl")
+if(CXX_AVX512_FOUND)
+  set_source_files_properties(${fbgemm_sources_avx512}
+    PROPERTIES COMPILE_OPTIONS
+    "-mavx2;-mf16c;-mfma;-mavx512f;-mavx512bw;-mavx512dq;-mavx512vl")
+endif()
 
 if(USE_ROCM)
   set(fbgemm_sources
@@ -444,9 +456,15 @@ if(NOT FBGEMM_CPU_ONLY)
   endif()
 endif()
 
-set_source_files_properties(${fbgemm_gpu_sources_static_cpu}
-  PROPERTIES COMPILE_OPTIONS
-  "-mavx;-mf16c;-mfma;-mavx2;-fopenmp")
+if(CXX_AVX2_FOUND)
+  set_source_files_properties(${fbgemm_gpu_sources_static_cpu}
+    PROPERTIES COMPILE_OPTIONS
+    "-mavx;-mf16c;-mfma;-mavx2;-fopenmp")
+else()
+  set_source_files_properties(${fbgemm_gpu_sources_static_cpu}
+    PROPERTIES COMPILE_OPTIONS
+    "-fopenmp")
+endif()
 
 if(NOT FBGEMM_CPU_ONLY)
   set(fbgemm_gpu_sources_static_gpu


### PR DESCRIPTION
Summary: Instead of hardcoding x86_64 when installing dependencies, let's now dynamically determine the platform name

Differential Revision: D45246996

