### PR TITLE
Use volatile pointer in inclusive_sum_scan_kernel

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
@@ -3120,7 +3120,9 @@ __inline__ __device__ void inclusive_sum_scan_kernel(
     typename cub::BlockScan<scalar_t, NUM_THREADS_PER_BLOCK>::TempStorage&
         temp_storage,
     int* block_flags,
-    scalar_t* block_sums,
+    // Declared as volatile to prevent the compiler from register-allocating
+    // the accesses to block_sums
+    volatile scalar_t* block_sums,
     scalar_t* block_prev,
     const int num_entries_per_block,
     const int block_id,


### PR DESCRIPTION
Summary:
In the multi-block cumsum case, the `inclusive_sum_scan_kernel`
implements the stream-scan technique in which each thread block has to
consume the preceding sum result from the previous block. The sum
result is passed via the `block_sums` buffer (global memory). To ensure
that the sum results are visible for inter-thread-block consumption,
the buffer has to be declared as `volatile` to prevent the compiler from
caching the results in registers. This diff adds the `volatile` keyword
to `block_sums`.

Differential Revision: D45435897

