### PR TITLE
c10::irange for fbgemm

### DIFF
--- a/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
@@ -94,10 +94,9 @@ void bounds_check_indices_cpu(
         offsets_acc[B * T] = num_indices;
       }
     }
-
-    for (auto t = 0; t < T; ++t) {
+    for (const auto t : c10::irange(T)) {
       auto num_rows = rows_per_table_acc[t];
-      for (auto b = 0; b < B; ++b) {
+      for (const auto b : c10::irange(B)) {
         auto indices_start = offsets_acc[t * B + b];
         auto indices_end = offsets_acc[t * B + b + 1];
         if (bounds_check_mode == BoundsCheckMode::FATAL) {
@@ -132,7 +131,7 @@ void bounds_check_indices_cpu(
         }
 
         auto L = indices_end - indices_start;
-        for (auto l = 0; l < L; ++l) {
+        for (const auto l : c10::irange(L)) {
           auto idx = indices_acc[indices_start + l];
           if (idx == -1) {
             // -1 indicates pruned rows.

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_cpu_template.cpp
@@ -61,19 +61,18 @@ void pruned_hashmap_insert_{{ wdesc }}_cpu(
     const auto* offsets_acc = offsets.data_ptr<int32_t>();
     auto hash_table_acc = hash_table.accessor<int32_t, 2>();
     const auto hash_table_offsets_acc = hash_table_offsets.accessor<int64_t, 1>();
-
-    for (int32_t t = 0; t < T; ++t) {
+for (const auto t : c10::irange(T)) {
         int64_t table_start = hash_table_offsets_acc[t];
         int64_t table_end = hash_table_offsets_acc[t + 1];
         if (table_start == table_end) {
             continue;
         }
         int64_t capacity = table_end - table_start;
-        for (int32_t b = 0; b < B; ++b) {
+for (const auto b : c10::irange(B)) {
             int32_t indices_start = offsets_acc[t * B + b];
             int32_t indices_end = offsets_acc[t * B + b + 1];
             int32_t L = indices_end - indices_start;
-            for (int32_t l = 0; l < L; ++l) {
+for (const auto l : c10::irange(L)) {
                 int32_t idx = indices_acc[indices_start + l];
                 int32_t dense_idx = dense_indices_acc[indices_start + l];
                 if (dense_idx == -1) {
@@ -207,7 +206,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
             int32_t num_indices_m_1 = indices.numel() - 1;
 
             int32_t D_start_ = 0;
-            for (int32_t t = 0; t < T; ++t) {
+for (const auto t : c10::irange(T)) {
 
                 {% if not nobag %}
                 const auto* D_offsets_acc = D_offsets.data_ptr<int32_t>();
@@ -449,23 +448,21 @@ Tensor pruned_hashmap_lookup_{{ wdesc }}_cpu(
     const auto* offsets_acc = offsets.data_ptr<int32_t>();
     const auto hash_table_acc = hash_table.accessor<int32_t, 2>();
     const auto hash_table_offsets_acc = hash_table_offsets.accessor<int64_t, 1>();
-
-    for (int32_t t = 0; t < T; ++t) {
+for (const auto t : c10::irange(T)) {
         int64_t table_start = hash_table_offsets_acc[t];
         int64_t table_end = hash_table_offsets_acc[t + 1];
         int64_t capacity = table_end - table_start;
-
-        for (int32_t b = 0; b < B; ++b) {
+for (const auto b : c10::irange(B)) {
             int32_t indices_start = offsets_acc[t * B + b];
             int32_t indices_end = offsets_acc[t * B + b + 1];
             int32_t L = indices_end - indices_start;
 
             if (table_start == table_end) {
-                for (int32_t l = 0; l < L; ++l) {
+for (const auto l : c10::irange(L)) {
                     dense_indices_acc[indices_start + l] = indices_acc[indices_start + l];
                 }
             } else {
-                for (int32_t l = 0; l < L; ++l) {
+for (const auto l : c10::irange(L)) {
                     int32_t idx = indices_acc[indices_start + l];
                     uint32_t slot = pruned_hash_function(static_cast<uint32_t>(idx)) % capacity;
                     while (true) {
@@ -512,15 +509,14 @@ Tensor pruned_array_lookup_cpu(
 
     const auto index_remappings_acc = index_remappings.data_ptr<int32_t>();
     const auto index_remappings_offsets_acc = index_remappings_offsets.data_ptr<int64_t>();
-
-    for (int32_t t = 0; t < T; ++t) {
+for (const auto t : c10::irange(T)) {
         int64_t index_remappings_start = index_remappings_offsets_acc[t];
         int64_t index_remappings_end = index_remappings_offsets_acc[t + 1];
         int64_t capacity = index_remappings_end - index_remappings_start;
         int32_t indices_start = offsets_acc[t * B];
         int32_t indices_end = offsets_acc[(t + 1) * B];
         if (capacity > 0) {
-            for (int32_t i = indices_start; i < indices_end; ++i) {
+for (const auto i : c10::irange(indices_start,indices_end)) {
                 int32_t idx = indices_acc[i];
                 dense_indices_acc[i] = index_remappings_acc[index_remappings_start + idx];
             }

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
@@ -290,7 +290,7 @@ class PrunedMapCPU : public torch::jit::CustomClassHolder {
     auto table_offsets_acc = table_offsets.accessor<int64_t, 1>();
 
     maps_.resize(T);
-    for (auto t = 0; t < T; ++t) {
+    for (const auto t : c10::irange(T)) {
       auto& map = maps_[t];
       const auto table_start = table_offsets_acc[t];
       for (auto i = 0; i < values.size(0); ++i) {
@@ -309,7 +309,7 @@ class PrunedMapCPU : public torch::jit::CustomClassHolder {
     auto table_offsets_acc = table_offsets.accessor<int64_t, 1>();
     table_offsets_acc[0] = 0;
     int64_t N = 0;
-    for (auto t = 0; t < T; ++t) {
+    for (const auto t : c10::irange(T)) {
       N += maps_[t].size();
       table_offsets_acc[t + 1] = N;
     }
@@ -342,13 +342,13 @@ class PrunedMapCPU : public torch::jit::CustomClassHolder {
     auto* dense_indices_acc = dense_indices.data_ptr<int32_t>();
     const auto* offsets_acc = offsets.data_ptr<int32_t>();
     maps_.resize(T);
-    for (int32_t t = 0; t < T; ++t) {
+    for (const auto t : c10::irange(T)) {
       auto& map = maps_[t];
-      for (int32_t b = 0; b < B; ++b) {
+      for (const auto b : c10::irange(B)) {
         int32_t indices_start = offsets_acc[t * B + b];
         int32_t indices_end = offsets_acc[t * B + b + 1];
         int32_t L = indices_end - indices_start;
-        for (int32_t l = 0; l < L; ++l) {
+        for (const auto l : c10::irange(L)) {
           int32_t slot_sparse_index = indices_acc[indices_start + l];
           int32_t slot_dense_index = dense_indices_acc[indices_start + l];
           if (slot_dense_index == -1) {
@@ -371,13 +371,13 @@ class PrunedMapCPU : public torch::jit::CustomClassHolder {
     const auto* indices_acc = indices.data_ptr<int32_t>();
     auto* dense_indices_acc = dense_indices.data_ptr<int32_t>();
     const auto* offsets_acc = offsets.data_ptr<int32_t>();
-    for (int32_t t = 0; t < T; ++t) {
+    for (const auto t : c10::irange(T)) {
       auto& map = maps_[t];
-      for (int32_t b = 0; b < B; ++b) {
+      for (const auto b : c10::irange(B)) {
         int32_t indices_start = offsets_acc[t * B + b];
         int32_t indices_end = offsets_acc[t * B + b + 1];
         int32_t L = indices_end - indices_start;
-        for (int32_t l = 0; l < L; ++l) {
+        for (const auto l : c10::irange(L)) {
           int32_t slot_sparse_index = indices_acc[indices_start + l];
           auto it = map.find(slot_sparse_index);
           dense_indices_acc[indices_start + l] =

--- a/fbgemm_gpu/src/embedding_inplace_update_cpu.cpp
+++ b/fbgemm_gpu/src/embedding_inplace_update_cpu.cpp
@@ -61,8 +61,7 @@ void embedding_inplace_update_cpu_kernel(
 
     const uint8_t* __restrict__ update_weight_row =
         &update_weights[update_weight_offset];
-
-    for (int32_t d = 0; d < D_bytes; d++) {
+    for (const auto d : c10::irange(D_bytes)) {
       weight_row[d] = update_weight_row[d];
     }
   }
@@ -143,8 +142,7 @@ Tensor pruned_array_lookup_from_row_idx_cpu(
             index_remappings.accessor<int32_t, 1>();
         const auto index_remappings_offsets_acc =
             index_remappings_offsets.accessor<int64_t, 1>();
-
-        for (int64_t idx = 0; idx < num_indices; idx++) {
+        for (const auto idx : c10::irange(num_indices)) {
           const int table_idx = update_table_indices_acc[idx];
           const auto row_idx = update_row_indices_acc[idx];
           int64_t index_remappings_start =

--- a/fbgemm_gpu/src/input_combine_cpu.cpp
+++ b/fbgemm_gpu/src/input_combine_cpu.cpp
@@ -298,7 +298,7 @@ std::tuple<Tensor, Tensor, Tensor> padding_fused_tbe_input_combine_cpu(
           auto offsets_acc = offsets_list[i].accessor<index_t, 1>();
           int64_t offsets_size =
               offsets_list[i].numel() - (include_last_offsets_acc[i] ? 1 : 0);
-          for (int64_t j = 1; j < offsets_size; j++) {
+          for (const auto j : c10::irange(1, offsets_size)) {
             combined_offsets_acc[offsets_acc_idx++] =
                 offset + static_cast<int32_t>(offsets_acc[j]);
           }

--- a/fbgemm_gpu/src/input_combine_gpu.cpp
+++ b/fbgemm_gpu/src/input_combine_gpu.cpp
@@ -96,7 +96,7 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_with_length_gpu(
   // Compute offsets
   uint64_t offset = 0;
   auto next = args_offsets[0];
-  for (uint32_t i = 0; i < NUM_ARGS; i++) {
+  for (const auto i : c10::irange(NUM_ARGS)) {
     args_offsets[i] = offset;
     offset += next;
     next = args_offsets[i + 1];
@@ -132,7 +132,7 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_with_length_gpu(
   uint64_t total_indices = 0;
   uint64_t total_lengths = 0;
   uint64_t max_list_size = 0;
-  for (uint64_t i = 0; i < num_lists; i++) {
+  for (const auto i : c10::irange(num_lists)) {
     const uint64_t is_long_idx = i / IS_LONG_NUM_BITS;
     auto& indices_is_long_ = indices_is_long[is_long_idx];
     auto& lengths_is_long_ = lengths_is_long[is_long_idx];

--- a/fbgemm_gpu/src/sparse_ops_gpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_gpu.cpp
@@ -297,7 +297,7 @@ class GroupIndexSelectDim0GPUOp
     outputs.reserve(group_size);
     std::vector<int64_t> input_shape_group;
     input_shape_group.reserve(group_size * input_dim);
-    for (int i = 0; i < group_size; i++) {
+    for (const auto i : c10::irange(group_size)) {
       auto& input = input_group[i];
       auto& indices = indices_group[i];
 
@@ -434,7 +434,7 @@ class GroupIndexSelectDim0GPUOp
         at::TensorOptions().dtype(at::kLong).pinned_memory(true));
     int64_t* grad_output_ptrs = args_tensor.data_ptr<int64_t>();
     int64_t* grad_input_ptrs = args_tensor.data_ptr<int64_t>() + group_size;
-    for (int i = 0; i < group_size; i++) {
+    for (const auto i : c10::irange(group_size)) {
       Tensor& grad = grad_output_group[i];
       TENSOR_ON_CUDA_GPU(grad);
       TENSORS_ON_SAME_DEVICE(grad, first_indices);

--- a/fbgemm_gpu/test/embedding_inplace_update_test.cpp
+++ b/fbgemm_gpu/test/embedding_inplace_update_test.cpp
@@ -42,7 +42,7 @@ void test_embedding_inplace_update() {
   std::vector<index_t> update_row_idx;
   int64_t dev_weights_offset = 0;
   int64_t uvm_weights_offset = 0;
-  for (int i = 0; i < T; i++) {
+  for (const auto i : c10::irange(T)) {
     SparseType weight_ty =
         weight_ty_list[folly::Random::rand32() % weight_ty_list.size()];
     weights_tys.push_back(uint8_t(weight_ty));
@@ -62,7 +62,7 @@ void test_embedding_inplace_update() {
     }
     int n = folly::Random::rand32() % 10 + 5;
     std::set<int32_t> rows;
-    for (int j = 0; j < n; j++) {
+    for (const auto j : c10::irange(n)) {
       rows.insert(folly::Random::rand32() % total_rows);
     }
     std::string update_row_idx_str = "";
@@ -159,13 +159,13 @@ void test_embedding_inplace_update() {
     auto uvm_weight_acc = uvm_weight_cpu.data_ptr<uint8_t>();
     auto update_weight_acc = update_weight_cpu.data_ptr<uint8_t>();
     if (weight_placement == 0) {
-      for (int j = 0; j < D_bytes; j++) {
+      for (const auto j : c10::irange(D_bytes)) {
         ASSERT_EQ(
             dev_weight_acc[weight_offset + D_bytes * row_idx + j],
             update_weight_acc[offset + j]);
       }
     } else {
-      for (int j = 0; j < D_bytes; j++) {
+      for (const auto j : c10::irange(D_bytes)) {
         ASSERT_EQ(
             uvm_weight_acc[weight_offset + D_bytes * row_idx + j],
             update_weight_acc[offset + j]);


### PR DESCRIPTION
Summary:
Generated with
```
buck2 run //scripts/rbarnes/regex_multiline_replacer:regex_multiline_replacer -- --find '(\s*)for\s*\(\w+ (\w+)\s*=\s*0\s*;\s*\2\s*<\s*(\w+);\s*(?:\+\+\2|\2\+\+)\)(.*)' --replace 'for (const auto \2 : c10::irange(\3))\4' `find deeplearning/fbgemm -iname "*.cpp" -type f`

buck2 run //scripts/rbarnes/regex_multiline_replacer:regex_multiline_replacer -- --find '(\s*)for\s*\(\w+ (\w+)\s*=\s*(\w+)\s*;\s*\2\s*<\s*(\w+);\s*(?:\+\+\2|\2\+\+)\)(.*)' --replace 'for (const auto \2 : c10::irange(\3,\4))\5' `find deeplearning/fbgemm -iname "*.cpp" -type f`
```

Reviewed By: q10

Differential Revision: D44563544

