### PR TITLE
Add variable batch size support to TBE training

### DIFF
--- a/fbgemm_gpu/codegen/lookup_args.py
+++ b/fbgemm_gpu/codegen/lookup_args.py
@@ -10,6 +10,15 @@ from typing import NamedTuple, Optional
 import torch
 
 
+class VBEMetadata(NamedTuple):
+    B_offsets: Optional[torch.Tensor]
+    output_offsets_feature_rank: Optional[torch.Tensor]
+    B_offsets_rank_per_feature: Optional[torch.Tensor]
+    max_B_feature_rank: int = -1
+    max_B: int = -1
+    output_size: int = -1
+
+
 class CommonArgs(NamedTuple):
     placeholder_autograd_tensor: torch.Tensor
     dev_weights: torch.Tensor
@@ -30,6 +39,7 @@ class CommonArgs(NamedTuple):
     feature_requires_grad: Optional[torch.Tensor]
     lxu_cache_locations: torch.Tensor
     output_dtype: int
+    vbe_metadata: VBEMetadata
 
 
 class OptimizerArgs(NamedTuple):

--- a/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
@@ -162,6 +162,7 @@ def invoke(
     {% endif %}
 
     {% if has_gpu_support %}
+    vbe_metadata = common_args.vbe_metadata
     return torch.ops.fbgemm.split_embedding_codegen_lookup_{{ optimizer }}_function(
         # common_args
         {% if not dense %}
@@ -183,6 +184,13 @@ def invoke(
         indice_weights=common_args.indice_weights,
         feature_requires_grad=common_args.feature_requires_grad,
         lxu_cache_locations=common_args.lxu_cache_locations,
+        # VBE metadata
+        B_offsets=vbe_metadata.B_offsets,
+        vbe_output_offsets_feature_rank=vbe_metadata.output_offsets_feature_rank,
+        vbe_B_offsets_rank_per_feature=vbe_metadata.B_offsets_rank_per_feature,
+        max_B=vbe_metadata.max_B,
+        max_B_feature_rank=vbe_metadata.max_B_feature_rank,
+        vbe_output_size=vbe_metadata.output_size,
         # optimizer_args
         gradient_clipping = optimizer_args.gradient_clipping,
         max_gradient=optimizer_args.max_gradient,

--- a/fbgemm_gpu/fbgemm_gpu/ssd_split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/ssd_split_table_batched_embeddings_ops.py
@@ -443,6 +443,14 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             indice_weights=per_sample_weights,
             feature_requires_grad=feature_requires_grad,
             lxu_cache_locations=lxu_cache_locations,
+            vbe_metadata=invokers.lookup_args.VBEMetadata(
+                B_offsets=None,
+                output_offsets_feature_rank=None,
+                B_offsets_rank_per_feature=None,
+                max_B=-1,
+                max_B_feature_rank=-1,
+                output_size=-1,
+            ),
         )
 
         momentum1 = invokers.lookup_args.Momentum(


### PR DESCRIPTION
Summary:
This diff adds the variable batch size (or variable length) support in split TBE training on GPU.

**Usage:**

```
# Initialize TBE as same as previously
emb_op = SplitTableBatchedEmbeddingBagsCodegen(
    embedding_specs=[...],
    ... # other params
)

# batch sizes (one for each FEATURE and each RANK).
# Example: num_features = 2, num_ranks = 4
batch_size_per_feature_per_rank = [
    [1,  2, 8, 3] # batch sizes for [Rank 0, Rank 1, Rank 2, Rank 3] in Feature 0
    [6, 10, 3, 5] # batch sizes for [Rank 0, Rank 1, Rank 2, Rank 3] in Feature 1
]

# Pass a list of batch_size_per_feature_per_rank to forward.
# !! Make sure to pass batch_size_per_feature_per_rank as a keyword arg because there can be other keyword args in forward. !!
output = emb_op(indices, offsets, batch_size_per_feature_per_rank=batch_size_per_feature_per_rank)
```

**Output format**

{F967393126}

**Limitation:**

`T` and `max_B` have to fit in 32 bits.
- We use lower `info_B_num_bits` bits to store `b` (bag ID; `b` < `max_B`).  Supported `max_B` = `2^info_B_num_bits`
- We use upper `32 - info_B_num_bits` bits to store `t` (table ID; `t` < `T`).  Supported `T` = `2^(32 - info_B_num_bits)`

Note that we adjust `info_B_num_bits` automatically at runtime based on `max_B` and `T`.  If they cannot fit into 32 bits, it will abort.

Differential Revision: D42663369

