### PR TITLE
Create separate targets for training and inference

### DIFF
--- a/fbgemm_gpu/codegen/embedding_ops_placeholder.cpp
+++ b/fbgemm_gpu/codegen/embedding_ops_placeholder.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+    This is placeholder code to force compilation and generation of an
+    `libdeeplearning_fbgemm_fbgemm_gpu_codegen_embedding_ops.so` file, which
+    allows downstream PyTorch code to contlinue loading the `embedding_ops“
+    and `embedding_ops_cpu` (now-)shim targets correctly.
+*/
+namespace fbgemm_gpu {}

--- a/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
@@ -10,8 +10,15 @@ from .lookup_args import *
 
 
 {% if is_fbcode %}
-torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops")
-torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops_cpu")
+
+# Provide compatibility to downstream packages for eventual migration to the split training / inference packages
+try:
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops_cuda_training")
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops_cpu_training")
+except Exception:
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops")
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops_cpu")
+
 torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:cumem_utils")
 torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
 torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -19,6 +19,12 @@ import torch  # usort:skip
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
 from torch import nn, Tensor  # usort:skip
 
+try:
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops")
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops_cpu")
+except Exception:
+    pass
+
 DEFAULT_ASSOC = 32 if torch.version.hip is None else 64
 # Maximum number of times prefetch() can be called without
 # a corresponding forward() call


### PR DESCRIPTION
Summary:
- Create separate targets for training and inference

- Redefine the old `embedding_ops` and `embedding_ops` as an empty
target with `exported_defs` pointing to the new split targets

Differential Revision: D45687293

