### PR TITLE
Symbolic shape tracing on jagged op

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -431,7 +431,7 @@ std::tuple<at::Tensor, std::vector<at::Tensor>> jagged_dense_elementwise_mul(
 std::tuple<at::Tensor, std::vector<at::Tensor>> dense_to_jagged(
     const at::Tensor& dense,
     const std::vector<at::Tensor>& offsets,
-    const c10::optional<int64_t>& total_L);
+    const c10::optional<at::SymInt>& total_L);
 
 std::tuple<at::Tensor, std::vector<at::Tensor>>
 jagged_dense_elementwise_add_jagged_output(

--- a/fbgemm_gpu/src/jagged_tensor_ops/dense_to_jagged_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/dense_to_jagged_forward.cu
@@ -15,18 +15,18 @@ namespace fbgemm_gpu {
 Tensor dense_to_jagged_forward(
     const Tensor& dense,
     const std::vector<Tensor>& offsets,
-    const c10::optional<int64_t>& total_L) {
+    const c10::optional<at::SymInt>& total_L) {
   // D is the embedding dimension
   auto D = dense.size(-1);
 
   // If total_L is not given then compute it
-  int64_t total_L_computed;
+  at::SymInt total_L_computed;
   if (total_L.has_value()) {
     total_L_computed = total_L.value();
   } else {
     total_L_computed = (int64_t)offsets.back().max().item<int64_t>();
   }
-  auto values = at::empty({total_L_computed, D}, dense.options());
+  auto values = at::empty_symint({total_L_computed, D}, dense.options());
   auto output = at::empty_like(values);
 
   at::cuda::OptionalCUDAGuard device_guard;

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_to_padded_dense_backward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_to_padded_dense_backward.cu
@@ -15,7 +15,7 @@ namespace fbgemm_gpu {
 at::Tensor jagged_to_padded_dense_backward(
     const Tensor& grad_output,
     const std::vector<Tensor>& offsets,
-    const int64_t total_L) {
+    const at::SymInt& total_L) {
   auto grad_padded_values = grad_output;
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(grad_padded_values.get_device());
@@ -29,7 +29,8 @@ at::Tensor jagged_to_padded_dense_backward(
 
   // Initialize with zeros so output will be zero for the portion truncated
   // in forward.
-  auto grad_values = at::zeros({total_L, D}, grad_padded_values.options());
+  auto grad_values =
+      at::zeros_symint({total_L, D}, grad_padded_values.options());
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half,


### PR DESCRIPTION
Summary: fbgemm's jagged op doesn't have symint support in the meta function, resulting in all the shapes specialized (materialized int baked in the model instead of symbolic shape). Fixing them.

Differential Revision:
D44736488

Privacy Context Container: L1156430

