### PR TITLE
fix an OSS build issue

### DIFF
--- a/fbgemm_gpu/src/topology_utils.cpp
+++ b/fbgemm_gpu/src/topology_utils.cpp
@@ -8,6 +8,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/core/Device.h>
 #include <c10/cuda/CUDAException.h>
+#include <c10/util/Logging.h>
 #include <algorithm>
 
 #include "fbgemm_gpu/topology_utils.h"


### PR DESCRIPTION
Summary: To solve a compilation error like `'TORCH_CHECK_EQ' was not declared in this scope; did you mean 'TORCH_CHECK'?` when building from the OSS side.

Differential Revision: D45777319

