### PR TITLE
Enable `LICENSELINT` in FBGEMM, pt. 1

### DIFF
--- a/.github/scripts/fbgemm_gpu_build.bash
+++ b/.github/scripts/fbgemm_gpu_build.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
-
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+#
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/.github/scripts/fbgemm_gpu_docs.bash
+++ b/.github/scripts/fbgemm_gpu_docs.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
-
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+#
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/.github/scripts/fbgemm_gpu_lint.bash
+++ b/.github/scripts/fbgemm_gpu_lint.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
-
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+#
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/.github/scripts/fbgemm_gpu_test.bash
+++ b/.github/scripts/fbgemm_gpu_test.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
-
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+#
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/.github/scripts/setup_env.bash
+++ b/.github/scripts/setup_env.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
-
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+#
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/.github/scripts/test_torchrec.bash
+++ b/.github/scripts/test_torchrec.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
-
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+#
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/.github/scripts/utils_base.bash
+++ b/.github/scripts/utils_base.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
-
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+#
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/.github/scripts/utils_conda.bash
+++ b/.github/scripts/utils_conda.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
-
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+#
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/.github/scripts/utils_cuda.bash
+++ b/.github/scripts/utils_cuda.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
-
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+#
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/.github/scripts/utils_pytorch.bash
+++ b/.github/scripts/utils_pytorch.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
-
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+#
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/.github/scripts/utils_rocm.bash
+++ b/.github/scripts/utils_rocm.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
-
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+#
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/.github/scripts/utils_system.bash
+++ b/.github/scripts/utils_system.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
-
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+#
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+#
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/cmake/modules/FindMKL.cmake
+++ b/cmake/modules/FindMKL.cmake
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 # - Find INTEL MKL library
 # This module finds the Intel Mkl libraries.
 # Note: This file is a modified version of pytorch/cmake/Modules/FindMKL.cmake

--- a/cmake/modules/FindSphinx.cmake
+++ b/cmake/modules/FindSphinx.cmake
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 # Search sphinx-build
 find_program(SPHINX_EXECUTABLE
              NAMES sphinx-build

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 find_package(Doxygen REQUIRED)
 find_package(Sphinx REQUIRED)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,9 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+#
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-#
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full


### PR DESCRIPTION
Summary:
- Enable `LICENSELINT` in FBGEMM

- Run license-lint on GitHub action scripts and build files

Differential Revision: D45793120

