### PR TITLE
FBGEMM rowwise_adagrad kernel

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_kernel_cta_template.cu
@@ -424,6 +424,9 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
                 weight_row_template.store(shared_weight_update_row[lane_id + i * kThreadGroupSize], d, qparams_new);
             }
         }
+
+        {{ split_post_update }}
+
         {%- else %}
         #pragma unroll kMaxVecsPerThread
         for (int32_t i = 0;

--- a/fbgemm_gpu/codegen/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_kernel_warp_template.cu
@@ -265,6 +265,9 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
                 weight_row_template.store(shared_weight_update_row[threadIdx.x + (i + threadIdx.y * kMaxVecsPerThread) * kThreadGroupSize], d, qparams_new);
             }
         }
+
+        {{ split_post_update }}
+
         {%- else %}
     	#pragma unroll kMaxVecsPerThread
         for (int32_t i = 0;


### PR DESCRIPTION
Summary: Add support to clip embedding vector norm for exact_rowwise_adagrad by `max_norm`. If `max_norm==0` (default), no clip is applied.

Differential Revision: D45993313

