### PR TITLE
[T154122142] Strip out all debug symbols from built library

### DIFF
--- a/.github/scripts/fbgemm_gpu_build.bash
+++ b/.github/scripts/fbgemm_gpu_build.bash
@@ -244,6 +244,10 @@ run_fbgemm_gpu_postbuild_checks () {
 
   # Print info for only the first instance of the .SO file, since the build makes multiple copies
   local library="${fbgemm_gpu_so_files[0]}"
+
+  echo "[CHECK] Listing out library size: ${library}"
+  print_exec "du -h --block-size=1M ${library}"
+
   echo "[CHECK] Listing out the GLIBCXX versions referenced by the library: ${library}"
   print_glibc_info "${library}"
 

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -78,6 +78,9 @@ BLOCK_PRINT(
   "${CMAKE_CXX_FLAGS}"
 )
 
+# Strip all symbols from the .SO file after building
+add_link_options($<$<CONFIG:RELEASE>:-s>)
+
 
 ################################################################################
 # FBGEMM_GPU Build Kickstart

--- a/fbgemm_gpu/test/sparse_ops_test.py
+++ b/fbgemm_gpu/test/sparse_ops_test.py
@@ -24,11 +24,11 @@ try:
     from fbgemm_gpu import open_source  # noqa: F401
 
     # pyre-ignore[21]
-    from test_utils import gpu_available, gpu_unavailable
+    from test_utils import gpu_available, gpu_unavailable, skipIfRocm
 except Exception:
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
-    from fbgemm_gpu.test.test_utils import gpu_available, gpu_unavailable
+    from fbgemm_gpu.test.test_utils import gpu_available, gpu_unavailable, skipIfRocm
 
 
 def unbucketize_indices_value(
@@ -1666,6 +1666,7 @@ class SparseOpsTest(unittest.TestCase):
             )
             self.assertTrue(torch.equal(packed_tensor, packed_cuda.cpu()))
 
+    @skipIfRocm()
     @given(
         n=st.integers(2, 10),
         k=st.integers(2, 10),

--- a/fbgemm_gpu/test/test_utils.py
+++ b/fbgemm_gpu/test/test_utils.py
@@ -197,7 +197,7 @@ def cpu_only() -> st.SearchStrategy[List[torch.device]]:
 
 
 # pyre-fixme[3]: Return annotation cannot be `Any`.
-def skipIfRocm(reason: str = "test doesn't currently work on the ROCm stack") -> Any:
+def skipIfRocm(reason: str = "Test currently doesn't work on the ROCm stack") -> Any:
     # pyre-fixme[3]: Return annotation cannot be `Any`.
     # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
     def skipIfRocmDecorator(fn: Callable) -> Any:


### PR DESCRIPTION
Summary:

- Strip out all debug symbols from built library.  This currently saves around 16MB of storage space (from 1278 to 1262 MB)
- Disable a test known for failing when run under ROCm (GitHub Issue https://github.com/pytorch/FBGEMM/issues/1789)