### PR TITLE
Remove all target dependencies on `fbgemm_gpu:split_table_batched_embeddings_ops` inside `fbgemm_gpu`

### DIFF
--- a/fbgemm_gpu/bench/bench_utils.py
+++ b/fbgemm_gpu/bench/bench_utils.py
@@ -22,7 +22,7 @@ from fbgemm_gpu.split_embedding_utils import (  # noqa: F401
 logging.basicConfig(level=logging.DEBUG)
 
 
-def benchmark_torch_function(
+def benchmark_torch_function(  # noqa: C901
     # pyre-fixme[2]: Parameter must be annotated.
     f,
     # pyre-fixme[2]: Parameter must be annotated.

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -25,12 +25,12 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
     EmbeddingLocation,
     PoolingMode,
     RecordCacheMetrics,
+    round_up,
     SplitState,
 )
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     align_to_cacheline,
     IntNBitTableBatchedEmbeddingBagsCodegen,
-    round_up,
     rounded_row_size_in_bytes,
     unpadded_row_size_in_bytes,
 )


### PR DESCRIPTION
Summary: - Remove all target dependencies on `fbgemm_gpu:split_table_batched_embeddings_ops` inside `fbgemm_gpu`

Differential Revision: D46161657

