### PR TITLE
Remove CPU and GPU support for approx_sgd (#1769)

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -168,7 +168,6 @@ set(COMMON_OPTIMIZERS
     adam
     approx_rowwise_adagrad
     approx_rowwise_adagrad_with_counter
-    approx_sgd
     lamb
     lars_sgd
     partial_rowwise_adam
@@ -185,7 +184,8 @@ set(GPU_ONLY_OPTIMIZERS
   rowwise_adagrad_with_weight_decay
   approx_rowwise_adagrad_with_weight_decay)
 
-set(DEPRECATED_OPTIMIZERS "")
+set(DEPRECATED_OPTIMIZERS
+  approx_sgd)
 
 set(ALL_OPTIMIZERS
   ${COMMON_OPTIMIZERS}

--- a/fbgemm_gpu/codegen/__init__.template
+++ b/fbgemm_gpu/codegen/__init__.template
@@ -15,7 +15,6 @@ import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_partial_rowwise
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_rowwise_adagrad as lookup_rowwise_adagrad  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_rowwise_adagrad_with_counter as lookup_rowwise_adagrad_with_counter  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_sgd as lookup_sgd  # noqa: F401
-import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_approx_sgd as lookup_approx_sgd  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_approx_rowwise_adagrad as lookup_approx_rowwise_adagrad  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_approx_rowwise_adagrad_with_counter as lookup_approx_rowwise_adagrad_with_counter  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_rowwise_weighted_adagrad as lookup_rowwise_weighted_adagrad  # noqa: F401

--- a/fbgemm_gpu/codegen/embedding_backward_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_backward_code_generator.py
@@ -1055,8 +1055,8 @@ def sgd() -> None:
         split_weight_update=approx_split_weight_update,
         split_post_update="",
         split_weight_update_cpu=split_weight_update_cpu,
-        has_cpu_support=True,
-        has_gpu_support=True,
+        has_cpu_support=False,
+        has_gpu_support=False,
         has_vbe_support=False,
     )
 

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -1263,7 +1263,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         long_segments: bool,
         pooling_mode: PoolingMode,
         use_cpu: bool,
-        exact: bool,
         output_dtype: SparseType,
     ) -> None:
         # NOTE: cache is not applicable to CPU version.
@@ -1271,8 +1270,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         # NOTE: limit (T * B * L * D) to avoid timeout for CPU version!
         assume(not use_cpu or T * B * L * D <= 2048)
         assume(not (use_cpu and weights_precision == SparseType.FP16))
-        # GPU only does exact sgd
-        assume((use_cpu and not long_segments) or exact)
         # No bag ops only work on GPUs, no mixed, no weighted
         assume(not use_cpu or pooling_mode != PoolingMode.NONE)
         assume(not mixed or pooling_mode != PoolingMode.NONE)
@@ -1350,17 +1347,16 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             bs = [b.half() for b in bs]
 
         feature_table_map = list(range(T))
-        if exact:
-            table_to_replicate = T // 2
-            # pyre-fixme[6]: For 2nd param expected `Embedding` but got
-            #  `Union[Embedding, EmbeddingBag]`.
-            bs.insert(table_to_replicate, bs[table_to_replicate])
-            feature_table_map.insert(table_to_replicate, table_to_replicate)
+        table_to_replicate = T // 2
+        # pyre-fixme[6]: For 2nd param expected `Embedding` but got
+        #  `Union[Embedding, EmbeddingBag]`.
+        bs.insert(table_to_replicate, bs[table_to_replicate])
+        feature_table_map.insert(table_to_replicate, table_to_replicate)
 
         xs = [
             to_device(
                 torch.from_numpy(
-                    np.random.choice(range(Es[t]), size=(B, L), replace=exact).astype(
+                    np.random.choice(range(Es[t]), size=(B, L), replace=True).astype(
                         np.int64
                     )
                 ),
@@ -1400,9 +1396,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         [f.backward(go) for (f, go) in zip(fs, gos)]
         # do SGD update
         lr = 0.05
-        if exact:
-            # pyre-fixme[61]: `table_to_replicate` may not be initialized here.
-            del bs[table_to_replicate]
+        del bs[table_to_replicate]
         # pyre-fixme[58]: `*` is not supported for operand types
         #  `Optional[torch._tensor.Tensor]` and `float`.
         new_weights = [(b.weight - b.weight.grad * lr) for b in bs]
@@ -1411,7 +1405,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             embedding_specs=[
                 (E, D, M, compute_device) for (E, D, M) in zip(Es, Ds, managed)
             ],
-            optimizer=OptimType.EXACT_SGD if exact else OptimType.SGD,
+            optimizer=OptimType.EXACT_SGD,
             feature_table_map=feature_table_map,
             learning_rate=lr,
             weights_precision=weights_precision,
@@ -1477,7 +1471,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         else st.just(False)
         if (gpu_available and TEST_WITH_ROCM)
         else st.just(True),
-        exact=st.booleans(),
     )
     @settings(
         verbosity=Verbosity.verbose,
@@ -1500,7 +1493,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         long_segments: bool,
         pooling_mode: PoolingMode,
         use_cpu: bool,
-        exact: bool,
     ) -> None:
         self.execute_backward_sgd_(
             T,
@@ -1516,7 +1508,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             long_segments,
             pooling_mode,
             use_cpu,
-            exact,
             SparseType.FP32,  # output_dtype
         )
 
@@ -1563,7 +1554,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             True,  # long_segments
             PoolingMode.SUM,  # pooling_mode
             False,  # use_cpu
-            True,  # exact
             SparseType.FP32,  # output_dtype
         )
 
@@ -2403,7 +2393,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 OptimType.EXACT_ADAGRAD,
                 OptimType.EXACT_ROWWISE_ADAGRAD,
                 OptimType.EXACT_SGD,
-                OptimType.SGD,
             ]
         )
 
@@ -2611,7 +2600,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 OptimType.PARTIAL_ROWWISE_ADAM,
                 OptimType.LAMB,
                 OptimType.PARTIAL_ROWWISE_LAMB,
-                OptimType.SGD,
                 OptimType.EXACT_SGD,
                 OptimType.EXACT_ROWWISE_ADAGRAD,
                 OptimType.ROWWISE_ADAGRAD,


### PR DESCRIPTION
Summary:

This diff is a part of FBGEMM TBE optimizer deprecation plan (see
https://github.com/pytorch/FBGEMM/discussions/1727)

Changes include:
- Setting `has_cpu_support` and `has_gpu_support` of `approx_sgd` to
  `False` in the code gen script
- Updating `codegen/TARGETS` and `CMakeLists.txt`

See D45835048 for how the changes affect the code generation

Reviewed By: csmiler

Differential Revision: D45844197

