### PR TITLE
Remove CPU support for lamb (#1772)

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -165,7 +165,6 @@ file(GLOB_RECURSE asmjit_sources
 
 set(COMMON_OPTIMIZERS
     adagrad
-    lamb
     lars_sgd
     partial_rowwise_adam
     partial_rowwise_lamb
@@ -179,6 +178,7 @@ set(CPU_ONLY_OPTIMIZERS "")
 
 set(GPU_ONLY_OPTIMIZERS
   adam
+  lamb
   rowwise_adagrad_with_weight_decay
   approx_rowwise_adagrad_with_weight_decay)
 

--- a/fbgemm_gpu/codegen/embedding_backward_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_backward_code_generator.py
@@ -1129,7 +1129,7 @@ def lamb() -> None:
         split_weight_update=split_weight_update,
         split_post_update="",
         split_weight_update_cpu=split_weight_update_cpu,
-        has_cpu_support=True,
+        has_cpu_support=False,
         has_gpu_support=True,
         has_vbe_support=False,
     )


### PR DESCRIPTION
Summary:

This diff is a part of FBGEMM TBE optimizer deprecation plan (see
https://github.com/pytorch/FBGEMM/discussions/1727)

Changes include:
- Setting `has_cpu_support` of `lamb` to
  `False` in the code gen script
- Updating `codegen/TARGETS` and `CMakeLists.txt`

See D45835048 for how the changes affect the code generation

Reviewed By: csmiler

Differential Revision: D45845113

