### PR TITLE
Introduce TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
@@ -220,26 +220,26 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights
     Tensor feature_requires_grad
     {% endif %}
 ) {
-    TENSOR_ON_CUDA_GPU(grad_output);
-    TENSOR_ON_CUDA_GPU(dev_weights);
-    {% if not dense %}
-    TENSOR_ON_CUDA_GPU(uvm_weights);
-    TENSOR_ON_CUDA_GPU(lxu_cache_weights);
-    TENSOR_ON_CUDA_GPU(weights_placements);
-    {% endif %}
-    TENSOR_ON_CUDA_GPU(weights_offsets);
-    TENSOR_ON_CUDA_GPU(D_offsets);
-    TENSOR_ON_CUDA_GPU(indices);
-    TENSOR_ON_CUDA_GPU(offsets);
-    {% if not dense %}
-    TENSOR_ON_CUDA_GPU(lxu_cache_locations);
-    {% endif %}
-    {% if vbe %}
-    TENSOR_ON_CUDA_GPU(vbe_metadata.output_offsets);
-    TENSOR_ON_CUDA_GPU(vbe_metadata.b_t_map);
-    TENSORS_ON_SAME_DEVICE(dev_weights, vbe_metadata.output_offsets);
-    TENSORS_ON_SAME_DEVICE(dev_weights, vbe_metadata.b_t_map);
-    {% endif %}
+   TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+        dev_weights,
+        {% if not dense %}
+        uvm_weights,
+        lxu_cache_weights,
+        weights_placements,
+        {% endif %}
+        weights_offsets,
+        D_offsets,
+        indices,
+        offsets,
+        {% if not dense %}
+        lxu_cache_locations,
+        {% endif %}
+        {% if vbe %}
+        vbe_metadata.output_offsets,
+        vbe_metadata.b_t_map,
+        {% endif %}
+        grad_output
+    );
 
     if (feature_requires_grad.defined()) {
         TENSOR_ON_CUDA_GPU(feature_requires_grad);

--- a/fbgemm_gpu/codegen/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_template.cu
@@ -184,34 +184,32 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
     {% endif %}
     {{ args.split_function_args | join(", ") }}) {
 
-    TENSOR_ON_CUDA_GPU(grad_output);
-    TENSOR_ON_CUDA_GPU(dev_weights);
-    {% if not dense %}
-    TENSOR_ON_CUDA_GPU(uvm_weights);
-    TENSOR_ON_CUDA_GPU(lxu_cache_weights);
-    TENSOR_ON_CUDA_GPU(weights_placements);
-    {% endif %}
-    {% if vbe %}
-    TENSOR_ON_CUDA_GPU(vbe_metadata.B_offsets);
-    TENSOR_ON_CUDA_GPU(vbe_metadata.output_offsets);
-    TENSOR_ON_CUDA_GPU(vbe_metadata.b_t_map);
-    TENSORS_ON_SAME_DEVICE(dev_weights, vbe_metadata.B_offsets);
-    TENSORS_ON_SAME_DEVICE(dev_weights, vbe_metadata.output_offsets);
-    TENSORS_ON_SAME_DEVICE(dev_weights, vbe_metadata.b_t_map);
-    {% endif %}
-    TENSOR_ON_CUDA_GPU(weights_offsets);
-    {% if not nobag %}
-    TENSOR_ON_CUDA_GPU(D_offsets);
-    {% endif %}
-    TENSOR_ON_CUDA_GPU(hash_size_cumsum);
-    TENSOR_ON_CUDA_GPU(indices);
-    TENSOR_ON_CUDA_GPU(offsets);
-    {% if weighted %}
-    TENSOR_ON_CUDA_GPU(indice_weights);
-    {% endif %}
-    {% if not dense %}
-    TENSOR_ON_CUDA_GPU(lxu_cache_locations);
-    {% endif %}
+   TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+        dev_weights,
+        {% if not dense %}
+        uvm_weights,
+        lxu_cache_weights,
+        weights_placements,
+        {% endif %}
+        {% if vbe %}
+        vbe_metadata.B_offsets,
+        vbe_metadata.output_offsets,
+        vbe_metadata.b_t_map,
+        {% endif %}
+        weights_offsets,
+        {% if not nobag %}
+        D_offsets,
+        {% endif %}
+        hash_size_cumsum,
+        indices,
+        offsets,
+        {% if weighted %}
+        indice_weights,
+        {% endif %}
+        {% if not dense %}
+        lxu_cache_locations,
+        {% endif %}
+        grad_output);
 
     at::cuda::OptionalCUDAGuard device_guard;
     device_guard.set_index(dev_weights.get_device());

--- a/fbgemm_gpu/codegen/embedding_bounds_check.cu
+++ b/fbgemm_gpu/codegen/embedding_bounds_check.cu
@@ -182,12 +182,8 @@ void bounds_check_indices_cuda(
     const c10::optional<Tensor>& weights,
     const c10::optional<Tensor>& B_offsets,
     const int64_t max_B) {
-  TENSOR_ON_CUDA_GPU(rows_per_table);
-  TENSOR_ON_CUDA_GPU(indices);
-  TENSOR_ON_CUDA_GPU(offsets);
-  TENSOR_ON_CUDA_GPU(warning);
-  TENSOR_EMPTY_OR_ON_CUDA_GPU(weights);
-  TENSOR_EMPTY_OR_ON_CUDA_GPU(B_offsets);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      rows_per_table, indices, offsets, warning, weights, B_offsets);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(rows_per_table.get_device());

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_split_lookup.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_split_lookup.cu
@@ -132,10 +132,8 @@ Tensor pruned_hashmap_lookup_cuda(
     Tensor offsets,
     Tensor hash_table,
     Tensor hash_table_offsets) {
-  TENSOR_ON_CUDA_GPU(indices);
-  TENSOR_ON_CUDA_GPU(offsets);
-  TENSOR_ON_CUDA_GPU(hash_table);
-  TENSOR_ON_CUDA_GPU(hash_table_offsets);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      indices, offsets, hash_table, hash_table_offsets);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(indices.get_device());
@@ -166,10 +164,8 @@ Tensor pruned_array_lookup_cuda(
     Tensor offsets,
     Tensor index_remappings,
     Tensor index_remappings_offsets) {
-  TENSOR_ON_CUDA_GPU(indices);
-  TENSOR_ON_CUDA_GPU(offsets);
-  TENSOR_ON_CUDA_GPU(index_remappings);
-  TENSOR_ON_CUDA_GPU(index_remappings_offsets);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      indices, offsets, index_remappings, index_remappings_offsets);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(indices.get_device());

--- a/fbgemm_gpu/codegen/embedding_forward_split_kernel_nobag_small_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_kernel_nobag_small_template.cu
@@ -104,7 +104,7 @@ __launch_bounds__(kForwardMaxThreads) __global__ void
                 nullptr,
                 D,
                 nullptr);
-            float2 qparams_emb;
+            [[maybe_unused]] float2 qparams_emb;
             if (std::is_same<emb_t, uint8_t>::value) {
                 qparams_emb = weight_row_emb.load_qparams();
             }

--- a/fbgemm_gpu/codegen/embedding_forward_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_kernel_template.cu
@@ -194,7 +194,7 @@ void {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else "" }
                     nullptr,
                     D,
                     nullptr);
-                float2 qparams_emb;
+                [[maybe_unused]] float2 qparams_emb;
                 if (std::is_same<emb_t, uint8_t>::value) {
                     qparams_emb = weight_row_emb.load_qparams();
                 }

--- a/fbgemm_gpu/codegen/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_template.cu
@@ -136,30 +136,30 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
     const uint32_t info_B_mask
     {% endif %}
 ) {
-    TENSOR_ON_CUDA_GPU(dev_weights);
-    {%- if not dense %}
-    TENSOR_ON_CUDA_GPU(uvm_weights);
-    TENSOR_ON_CUDA_GPU(lxu_cache_weights);
-    TENSOR_ON_CUDA_GPU(weights_placements);
-    {%- endif %}
-    TENSOR_ON_CUDA_GPU(weights_offsets);
-    {%- if not nobag %}
-    TENSOR_ON_CUDA_GPU(D_offsets);
-    {%- endif %}
-    TENSOR_ON_CUDA_GPU(indices);
-    TENSOR_ON_CUDA_GPU(offsets);
-    {%- if weighted %}
-    TENSOR_ON_CUDA_GPU(indice_weights);
-    {%- endif %}
-    {%- if not dense %}
-    TENSOR_ON_CUDA_GPU(lxu_cache_locations);
-    {%- endif %}
-    {%- if vbe %}
-    TENSOR_ON_CUDA_GPU(vbe_metadata.output_offsets);
-    TENSOR_ON_CUDA_GPU(vbe_metadata.b_t_map);
-    TENSORS_ON_SAME_DEVICE(dev_weights, vbe_metadata.output_offsets);
-    TENSORS_ON_SAME_DEVICE(dev_weights, vbe_metadata.b_t_map);
-    {%- endif %}
+    TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+        {%- if not dense %}
+        uvm_weights,
+        lxu_cache_weights,
+        weights_placements,
+        {%- endif %}
+        weights_offsets,
+        {%- if not nobag %}
+        D_offsets,
+        {%- endif %}
+        indices,
+        offsets,
+        {%- if weighted %}
+        indice_weights,
+        {%- endif %}
+        {%- if not dense %}
+        lxu_cache_locations,
+        {%- endif %}
+        {%- if vbe %}
+        vbe_metadata.output_offsets,
+        vbe_metadata.b_t_map,
+        {%- endif %}
+        dev_weights
+    );
 
     at::cuda::OptionalCUDAGuard device_guard;
     device_guard.set_index(dev_weights.get_device());

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
@@ -9,6 +9,9 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <cstdint>
+#include <optional>
+#include <string>
 
 inline bool torch_tensor_on_cpu_check(const at::Tensor& ten) {
   return ten.is_cpu();
@@ -18,8 +21,24 @@ inline bool torch_tensor_on_cpu_check(const c10::optional<at::Tensor>& ten) {
   return !ten.has_value() || torch_tensor_on_cpu_check(ten.value());
 }
 
+inline std::optional<int64_t> get_device_index_from_tensor(
+    const at::Tensor& ten) {
+  return {ten.device().index()};
+}
+
+inline std::optional<int64_t> get_device_index_from_tensor(
+    const c10::optional<at::Tensor>& ten) {
+  if (ten) {
+    return {ten->device().index()};
+  } else {
+    return {};
+  }
+}
+
 inline std::string torch_tensor_device_name(const at::Tensor& ten) {
-  return c10::DeviceTypeName(ten.device().type());
+  const auto index = get_device_index_from_tensor(ten);
+  return c10::DeviceTypeName(ten.device().type()) +
+      (index ? ":" + std::to_string(index.value()) : "");
 }
 
 inline std::string torch_tensor_device_name(
@@ -27,7 +46,7 @@ inline std::string torch_tensor_device_name(
   if (ten.has_value()) {
     return torch_tensor_device_name(ten.value());
   } else {
-    return "No device: optional tensor unused.";
+    return "N/A";
   }
 }
 
@@ -174,6 +193,89 @@ inline bool torch_tensor_empty_or_on_cpu_check(
       (x).numel(),                                                     \
       " and ",                                                         \
       (y).numel())
+
+// clang-format off
+// Count the number of __VA_ARGS__, up to 60
+#define TORCH_PP_NARG(...) \
+         TORCH_PP_NARG_(__VA_ARGS__,TORCH_PP_RSEQ_N())
+#define TORCH_PP_NARG_(...) \
+         TORCH_PP_ARG_N(__VA_ARGS__)
+#define TORCH_PP_ARG_N( \
+          _1, _2, _3, _4, _5, _6, _7, _8, _9,_10, \
+         _11,_12,_13,_14,_15,_16,_17,_18,_19,_20, \
+         _21,_22,_23,_24,_25,_26,_27,_28,_29,_30, \
+         _31,_32,_33,_34,_35,_36,_37,_38,_39,_40, \
+         _41,_42,_43,_44,_45,_46,_47,_48,_49,_50, \
+         _51,_52,_53,_54,_55,_56,_57,_58,_59,_60, \
+         _61,_62,_63,N,...) N
+#define TORCH_PP_RSEQ_N() \
+         63,62,61,60,                   \
+         59,58,57,56,55,54,53,52,51,50, \
+         49,48,47,46,45,44,43,42,41,40, \
+         39,38,37,36,35,34,33,32,31,30, \
+         29,28,27,26,25,24,23,22,21,20, \
+         19,18,17,16,15,14,13,12,11,10, \
+         9,8,7,6,5,4,3,2,1,0
+// clang-format on
+
+template <size_t N, typename... Tensors>
+std::string tensor_on_same_gpu_if_not_optional_check(
+    const std::array<const char*, N>& var_names,
+    const Tensors&... tensors) {
+  std::optional<int64_t> gpu_index;
+  bool on_same_gpu = true;
+
+  // Collect the GPU index of the first non-empty optional tensor and make sure
+  // that all tensors are on this same index.
+  (
+      [&](const auto& tensor) {
+        if (!torch_tensor_on_cuda_gpu_check(tensor)) {
+          on_same_gpu = false;
+          return;
+        }
+        const auto my_gpu_index = get_device_index_from_tensor(tensor);
+        if (my_gpu_index) {
+          if (!gpu_index) {
+            gpu_index = my_gpu_index;
+          } else if (*gpu_index != my_gpu_index) {
+            on_same_gpu = false;
+          }
+        }
+      }(tensors),
+      ...);
+
+  if (!gpu_index || on_same_gpu) {
+    return "";
+  }
+
+  // Not all the tensors on a GPU or on the same GPU, generate a message.
+  std::string msg = "Not all tensors were on the same GPU: ";
+  size_t current_idx = 0;
+  (
+      [&](const auto& tensor) {
+        if (current_idx > 0) {
+          msg.append(", ");
+        }
+        msg.append(
+            std::string(var_names[current_idx++]) + "(" +
+            torch_tensor_device_name(tensor) + ")");
+      }(tensors),
+      ...);
+
+  return msg;
+}
+
+// Generate constexpr array of variable names to improve diagnostic output and
+// raise a message if any non-empty tensor is not on a GPU or not on the same
+// GPU as all the other non-empty tensors.
+#define TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(...)                         \
+  do {                                                                        \
+    constexpr std::array<const char*, TORCH_PP_NARG(__VA_ARGS__)>             \
+        variableNames = {#__VA_ARGS__};                                       \
+    const auto tensors_on_same_gpu =                                          \
+        tensor_on_same_gpu_if_not_optional_check(variableNames, __VA_ARGS__); \
+    TORCH_CHECK(tensors_on_same_gpu.empty(), tensors_on_same_gpu);            \
+  } while (false)
 
 /// Determine an appropriate CUDA block count along the x axis
 ///

--- a/fbgemm_gpu/src/embedding_inplace_update.cu
+++ b/fbgemm_gpu/src/embedding_inplace_update.cu
@@ -119,24 +119,19 @@ void embedding_inplace_update_cuda(
     const int64_t row_alignment,
     c10::optional<Tensor> lxu_cache_weights,
     c10::optional<Tensor> lxu_cache_locations) {
-  TENSOR_ON_CUDA_GPU(dev_weights);
-  TENSOR_ON_CUDA_GPU(uvm_weights);
-  TENSOR_ON_CUDA_GPU(weights_placements);
-  TENSOR_ON_CUDA_GPU(weights_offsets);
-  TENSOR_ON_CUDA_GPU(weights_tys);
-  TENSOR_ON_CUDA_GPU(D_offsets);
-
-  TENSOR_ON_CUDA_GPU(update_weights);
-  TENSOR_ON_CUDA_GPU(update_offsets);
-  TENSOR_ON_CUDA_GPU(update_table_idx);
-  TENSOR_ON_CUDA_GPU(update_row_idx);
-
-  if (lxu_cache_weights.has_value()) {
-    TENSOR_ON_CUDA_GPU(lxu_cache_weights);
-  }
-  if (lxu_cache_locations.has_value()) {
-    TENSOR_ON_CUDA_GPU(lxu_cache_locations);
-  }
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      dev_weights,
+      uvm_weights,
+      weights_placements,
+      weights_offsets,
+      weights_tys,
+      D_offsets,
+      update_weights,
+      update_offsets,
+      update_table_idx,
+      update_row_idx,
+      lxu_cache_weights,
+      lxu_cache_locations);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(dev_weights.get_device());
@@ -226,10 +221,11 @@ Tensor pruned_array_lookup_from_row_idx_cuda(
     const Tensor& update_table_indices,
     const Tensor& index_remappings,
     const Tensor& index_remappings_offsets) {
-  TENSOR_ON_CUDA_GPU(update_row_indices);
-  TENSOR_ON_CUDA_GPU(update_table_indices);
-  TENSOR_ON_CUDA_GPU(index_remappings);
-  TENSOR_ON_CUDA_GPU(index_remappings_offsets);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      update_row_indices,
+      update_table_indices,
+      index_remappings,
+      index_remappings_offsets);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(update_table_indices.get_device());

--- a/fbgemm_gpu/src/histogram_binning_calibration_ops.cu
+++ b/fbgemm_gpu/src/histogram_binning_calibration_ops.cu
@@ -60,9 +60,8 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_cuda(
     double upper_bound,
     int64_t bin_ctr_in_use_after,
     double bin_ctr_weight_value) {
-  TENSOR_ON_CUDA_GPU(logit);
-  TENSOR_ON_CUDA_GPU(bin_num_examples);
-  TENSOR_ON_CUDA_GPU(bin_num_positives);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      logit, bin_num_examples, bin_num_positives);
   TORCH_CHECK_EQ(bin_num_examples.numel(), bin_num_positives.numel());
 
   at::cuda::OptionalCUDAGuard device_guard;
@@ -182,11 +181,12 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_by_feature_cuda(
     double upper_bound,
     int64_t bin_ctr_in_use_after,
     double bin_ctr_weight_value) {
-  TENSOR_ON_CUDA_GPU(logit);
-  TENSOR_ON_CUDA_GPU(segment_value);
-  TENSOR_ON_CUDA_GPU(segment_lengths);
-  TENSOR_ON_CUDA_GPU(bin_num_examples);
-  TENSOR_ON_CUDA_GPU(bin_num_positives);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      logit,
+      segment_value,
+      segment_lengths,
+      bin_num_examples,
+      bin_num_positives);
   TORCH_CHECK_EQ(bin_num_examples.numel(), bin_num_positives.numel());
 
   at::cuda::OptionalCUDAGuard device_guard;
@@ -341,12 +341,13 @@ generic_histogram_binning_calibration_by_feature_cuda(
     double positive_weight,
     int64_t bin_ctr_in_use_after,
     double bin_ctr_weight_value) {
-  TENSOR_ON_CUDA_GPU(logit);
-  TENSOR_ON_CUDA_GPU(segment_value);
-  TENSOR_ON_CUDA_GPU(segment_lengths);
-  TENSOR_ON_CUDA_GPU(bin_num_examples);
-  TENSOR_ON_CUDA_GPU(bin_num_positives);
-  TENSOR_ON_CUDA_GPU(bin_boundaries);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      logit,
+      segment_value,
+      segment_lengths,
+      bin_num_examples,
+      bin_num_positives,
+      bin_boundaries);
   TORCH_CHECK_EQ(bin_num_examples.numel(), bin_num_positives.numel());
   TORCH_CHECK(
       bin_num_examples.numel() ==

--- a/fbgemm_gpu/src/jagged_tensor_ops/batched_dense_vec_jagged_2d_mul_backward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/batched_dense_vec_jagged_2d_mul_backward.cu
@@ -89,10 +89,7 @@ std::tuple<Tensor, Tensor> batched_dense_vec_jagged_2d_mul_backward(
     const Tensor& v,
     const Tensor& a_values,
     const Tensor& a_offsets) {
-  TENSOR_ON_CUDA_GPU(grad_output);
-  TENSOR_ON_CUDA_GPU(a_values);
-  TENSOR_ON_CUDA_GPU(a_offsets);
-  TENSOR_ON_CUDA_GPU(v);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(grad_output, a_values, a_offsets, v);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(grad_output.get_device());

--- a/fbgemm_gpu/src/jagged_tensor_ops/batched_dense_vec_jagged_2d_mul_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/batched_dense_vec_jagged_2d_mul_forward.cu
@@ -54,9 +54,7 @@ Tensor batched_dense_vec_jagged_2d_mul_forward(
     const Tensor& v,
     const Tensor& a_values,
     const Tensor& a_offsets) {
-  TENSOR_ON_CUDA_GPU(v);
-  TENSOR_ON_CUDA_GPU(a_values);
-  TENSOR_ON_CUDA_GPU(a_offsets);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(v, a_values, a_offsets);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(v.get_device());

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_bmm_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_bmm_forward.cu
@@ -153,9 +153,7 @@ Tensor jagged_dense_bmm_forward_cuda(
     const Tensor& x_offsets,
     const Tensor& y,
     const int64_t max_L) {
-  TENSOR_ON_CUDA_GPU(x_values);
-  TENSOR_ON_CUDA_GPU(x_offsets);
-  TENSOR_ON_CUDA_GPU(y);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(x_values, x_offsets, y);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(x_values.get_device());

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_index_add_2d_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_index_add_2d_forward.cu
@@ -78,10 +78,8 @@ Tensor jagged_index_add_2d_forward_cuda(
     const Tensor& output_offsets,
     const int64_t num_dense_input_rows,
     const int64_t num_output_rows) {
-  TENSOR_ON_CUDA_GPU(values);
-  TENSOR_ON_CUDA_GPU(indices);
-  TENSOR_ON_CUDA_GPU(input_offsets);
-  TENSOR_ON_CUDA_GPU(output_offsets);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      values, indices, input_offsets, output_offsets);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(values.get_device());

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_index_select_2d_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_index_select_2d_forward.cu
@@ -74,10 +74,8 @@ Tensor jagged_index_select_2d_forward_cuda(
     const Tensor& input_offsets,
     const Tensor& output_offsets,
     const int64_t num_dense_output_rows) {
-  TENSOR_ON_CUDA_GPU(values);
-  TENSOR_ON_CUDA_GPU(indices);
-  TENSOR_ON_CUDA_GPU(input_offsets);
-  TENSOR_ON_CUDA_GPU(output_offsets);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      values, indices, input_offsets, output_offsets);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(values.get_device());

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_jagged_bmm_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_jagged_bmm_forward.cu
@@ -158,9 +158,7 @@ Tensor jagged_jagged_bmm_forward_cuda(
     const Tensor& y_values,
     const Tensor& offsets,
     const int64_t max_L) {
-  TENSOR_ON_CUDA_GPU(x_values);
-  TENSOR_ON_CUDA_GPU(y_values);
-  TENSOR_ON_CUDA_GPU(offsets);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(x_values, y_values, offsets);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(x_values.get_device());

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_backward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_backward.cu
@@ -92,9 +92,7 @@ Tensor jagged_softmax_backward_cuda(
     const Tensor& output,
     const Tensor& offsets,
     const int64_t max_L) {
-  TENSOR_ON_CUDA_GPU(grad_output);
-  TENSOR_ON_CUDA_GPU(output);
-  TENSOR_ON_CUDA_GPU(offsets);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(grad_output, output, offsets);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(grad_output.get_device());

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_softmax_forward.cu
@@ -116,8 +116,7 @@ Tensor jagged_softmax_forward_cuda(
     const Tensor& values,
     const Tensor& offsets,
     const int64_t max_L) {
-  TENSOR_ON_CUDA_GPU(values);
-  TENSOR_ON_CUDA_GPU(offsets);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(values, offsets);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(values.get_device());

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_to_padded_dense_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_to_padded_dense_forward.cu
@@ -288,9 +288,7 @@ std::vector<Tensor> stacked_jagged_2d_to_dense_gpu(
     const std::vector<int64_t>& offset_per_key,
     const std::vector<int64_t>& max_lengths_per_key,
     int64_t padding_value) {
-  TENSOR_ON_CUDA_GPU(values);
-  TENSOR_ON_CUDA_GPU(lengths);
-  TENSORS_ON_SAME_DEVICE(values, lengths);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(values, lengths);
   TORCH_CHECK(values.dim() == 2);
   TORCH_CHECK(lengths.dim() == 2);
   return StackedJagged2DToDenseGPUOp::apply(

--- a/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
@@ -168,13 +168,7 @@ class KeyedJaggedIndexSelectDim1GPUOp
       const int batch_size,
       const c10::optional<Tensor>& weights) {
     // TODO: Add weights support
-    TENSOR_ON_CUDA_GPU(lengths);
-    TENSOR_ON_CUDA_GPU(offsets);
-    TENSOR_ON_CUDA_GPU(values);
-    TENSOR_ON_CUDA_GPU(indices);
-    TENSORS_ON_SAME_DEVICE(lengths, indices);
-    TENSORS_ON_SAME_DEVICE(offsets, indices);
-    TENSORS_ON_SAME_DEVICE(values, indices);
+    TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(lengths, offsets, values, indices);
     TORCH_CHECK(values.dim() == 1, "values must be a 1D tensor");
     TORCH_CHECK(lengths.dim() == 1, "lengths must be a 1D tensor");
     TORCH_CHECK(offsets.dim() == 1, "offsets must be a 1D tensor");

--- a/fbgemm_gpu/src/layout_transform_ops.cu
+++ b/fbgemm_gpu/src/layout_transform_ops.cu
@@ -127,9 +127,8 @@ Tensor recat_embedding_grad_output_mixed_D_batch_cuda(
     const Tensor& grad_output, // [B_local][Sum_T_global(D)]
     const Tensor& dim_sum_per_rank,
     const Tensor& cumsum_dim_sum_per_rank) {
-  TENSOR_ON_CUDA_GPU(grad_output);
-  TENSOR_ON_CUDA_GPU(dim_sum_per_rank);
-  TENSOR_ON_CUDA_GPU(cumsum_dim_sum_per_rank);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      grad_output, dim_sum_per_rank, cumsum_dim_sum_per_rank);
   TORCH_CHECK(grad_output.is_contiguous());
 
   at::cuda::OptionalCUDAGuard device_guard;

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops.cu
@@ -29,10 +29,8 @@ Tensor permute_pooled_embs_gpu(
     const Tensor& inv_offset_dim_list,
     const Tensor& inv_permute_list) {
   // inv_permute_list is not being used so it's not checked here.
-  TENSOR_ON_CUDA_GPU(pooled_embs);
-  TENSOR_ON_CUDA_GPU(offset_dim_list);
-  TENSOR_ON_CUDA_GPU(permute_list);
-  TENSOR_ON_CUDA_GPU(inv_offset_dim_list);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      pooled_embs, offset_dim_list, permute_list, inv_offset_dim_list);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(pooled_embs.get_device());

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops_split.cu
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops_split.cu
@@ -29,10 +29,8 @@ Tensor permute_pooled_embs_split_gpu(
     const Tensor& inv_offset_dim_list,
     const Tensor& inv_permute_list) {
   // inv_permute_list is not being used so it's not checked here.
-  TENSOR_ON_CUDA_GPU(pooled_embs);
-  TENSOR_ON_CUDA_GPU(offset_dim_list);
-  TENSOR_ON_CUDA_GPU(permute_list);
-  TENSOR_ON_CUDA_GPU(inv_offset_dim_list);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      pooled_embs, offset_dim_list, permute_list, inv_offset_dim_list);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(pooled_embs.get_device());

--- a/fbgemm_gpu/src/sparse_ops.cu
+++ b/fbgemm_gpu/src/sparse_ops.cu
@@ -171,10 +171,7 @@ Tensor segment_sum_csr_cuda(
     const int64_t batch_size,
     const Tensor& csr_seg,
     const Tensor& values) {
-  TENSOR_ON_CUDA_GPU(csr_seg);
-  TENSOR_ON_CUDA_GPU(values);
-
-  TENSORS_ON_SAME_DEVICE(csr_seg, values);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(csr_seg, values);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(values.get_device());
@@ -410,15 +407,8 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_2D_sparse_data_cuda(
     const Tensor& indices,
     const c10::optional<Tensor>& weights,
     const c10::optional<int64_t>& permuted_lengths_sum) {
-  TENSOR_ON_CUDA_GPU(permute);
-  TENSOR_ON_CUDA_GPU(lengths);
-  TENSOR_ON_CUDA_GPU(indices);
-  TENSOR_ON_CUDA_GPU(weights);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(permute, lengths, indices, weights);
   TORCH_CHECK(lengths.dim() == 2);
-
-  TENSORS_ON_SAME_DEVICE(permute, lengths);
-  TENSORS_ON_SAME_DEVICE(permute, indices);
-  TENSORS_ON_SAME_DEVICE(permute, weights);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(indices.get_device());
@@ -590,14 +580,7 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_1D_sparse_data_cuda(
     const Tensor& indices,
     const c10::optional<Tensor>& weights,
     const c10::optional<int64_t>& permuted_lengths_sum) {
-  TENSOR_ON_CUDA_GPU(permute);
-  TENSOR_ON_CUDA_GPU(lengths);
-  TENSOR_ON_CUDA_GPU(indices);
-  TENSOR_ON_CUDA_GPU(weights);
-
-  TENSORS_ON_SAME_DEVICE(permute, lengths);
-  TENSORS_ON_SAME_DEVICE(permute, indices);
-  TENSORS_ON_SAME_DEVICE(permute, weights);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(permute, lengths, indices, weights);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(indices.get_device());
@@ -772,12 +755,9 @@ Tensor expand_into_jagged_permute_cuda(
     const Tensor& input_offsets,
     const Tensor& output_offsets,
     int64_t output_size) {
-  TENSOR_ON_CUDA_GPU(permute);
-  TENSOR_ON_CUDA_GPU(input_offsets);
-  TENSOR_ON_CUDA_GPU(output_offsets);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      permute, input_offsets, output_offsets);
 
-  TENSORS_ON_SAME_DEVICE(permute, input_offsets);
-  TENSORS_ON_SAME_DEVICE(permute, output_offsets);
   TORCH_CHECK(permute.numel() > 0);
   TORCH_CHECK(permute.numel() == input_offsets.numel() - 1);
   TORCH_CHECK(permute.numel() == output_offsets.numel() - 1);
@@ -920,11 +900,7 @@ block_bucketize_sparse_features_cuda(
     Tensor block_sizes,
     int64_t my_size,
     c10::optional<Tensor> weights) {
-  TENSOR_ON_CUDA_GPU(lengths);
-  TENSOR_ON_CUDA_GPU(indices);
-  TENSORS_ON_SAME_DEVICE(lengths, indices);
-  TENSOR_ON_CUDA_GPU(weights);
-  TENSORS_ON_SAME_DEVICE(lengths, weights);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(lengths, indices);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(lengths.get_device());
@@ -1387,11 +1363,7 @@ bucketize_sparse_features_cuda(
     const bool bucketize_pos,
     const int64_t my_size,
     const c10::optional<Tensor>& weights) {
-  TENSOR_ON_CUDA_GPU(lengths);
-  TENSOR_ON_CUDA_GPU(indices);
-  TENSORS_ON_SAME_DEVICE(lengths, indices);
-  TENSOR_ON_CUDA_GPU(weights);
-  TENSORS_ON_SAME_DEVICE(lengths, weights);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(lengths, indices);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(lengths.get_device());
@@ -1594,9 +1566,7 @@ Tensor reorder_batched_ad_lengths_gpu(
     const Tensor& batch_offsets,
     const int64_t num_ads_in_batch,
     const bool broadcast_lengths) {
-  TENSOR_ON_CUDA_GPU(cat_ad_lengths);
-  TENSOR_ON_CUDA_GPU(batch_offsets);
-  TENSORS_ON_SAME_DEVICE(cat_ad_lengths, batch_offsets);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(cat_ad_lengths, batch_offsets);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(cat_ad_lengths.get_device());
@@ -1704,13 +1674,8 @@ Tensor reorder_batched_ad_indices_gpu(
     const int64_t num_ads_in_batch,
     const bool broadcast_indices,
     const int64_t num_indices_after_broadcast) {
-  TENSOR_ON_CUDA_GPU(cat_ad_offsets);
-  TENSOR_ON_CUDA_GPU(cat_ad_indices);
-  TENSOR_ON_CUDA_GPU(reordered_cat_ad_offsets);
-  TENSOR_ON_CUDA_GPU(batch_offsets);
-  TENSORS_ON_SAME_DEVICE(cat_ad_offsets, cat_ad_indices);
-  TENSORS_ON_SAME_DEVICE(cat_ad_offsets, reordered_cat_ad_offsets);
-  TENSORS_ON_SAME_DEVICE(cat_ad_offsets, batch_offsets);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      cat_ad_offsets, cat_ad_indices, reordered_cat_ad_offsets, batch_offsets);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(cat_ad_offsets.get_device());
@@ -1920,11 +1885,8 @@ Tensor batched_unary_embeddings_backward_cuda(
     const Tensor& table_offsets,
     const Tensor& offsets,
     const Tensor& indices) {
-  TENSOR_ON_CUDA_GPU(grad_output);
-  TENSOR_ON_CUDA_GPU(weight);
-  TENSOR_ON_CUDA_GPU(table_offsets);
-  TENSOR_ON_CUDA_GPU(offsets);
-  TENSOR_ON_CUDA_GPU(indices);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      grad_output, weight, table_offsets, offsets, indices);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(grad_output.get_device());
@@ -2087,14 +2049,7 @@ std::tuple<Tensor, Tensor, c10::optional<Tensor>> permute_sparse_features_cuda(
     const Tensor& lengths,
     const Tensor& indices,
     const c10::optional<Tensor>& weights) {
-  TENSOR_ON_CUDA_GPU(permute);
-  TENSOR_ON_CUDA_GPU(lengths);
-  TENSOR_ON_CUDA_GPU(indices);
-  TENSOR_ON_CUDA_GPU(weights);
-
-  TENSORS_ON_SAME_DEVICE(permute, lengths);
-  TENSORS_ON_SAME_DEVICE(permute, indices);
-  TENSORS_ON_SAME_DEVICE(permute, weights);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(permute, lengths, indices, weights);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(indices.get_device());
@@ -2379,12 +2334,7 @@ std::tuple<Tensor, Tensor> permute_sequence_embeddings_cuda(
     const Tensor& lengths,
     const Tensor& embeddings) {
   // wrapper for permute_2D_sparse_data_cuda, kept for BC
-  TENSOR_ON_CUDA_GPU(permute);
-  TENSOR_ON_CUDA_GPU(lengths);
-  TENSOR_ON_CUDA_GPU(embeddings);
-
-  TENSORS_ON_SAME_DEVICE(permute, lengths);
-  TENSORS_ON_SAME_DEVICE(permute, embeddings);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(permute, lengths, embeddings);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(embeddings.get_device());
@@ -2459,8 +2409,7 @@ Tensor pack_segments_forward_cuda(
     const Tensor& t_in,
     const Tensor& lengths,
     const int64_t max_length) {
-  TENSOR_ON_CUDA_GPU(t_in);
-  TENSOR_ON_CUDA_GPU(lengths);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(t_in, lengths);
   TENSOR_NDIM_IS_GE(t_in, 1);
   TENSOR_NDIM_EQUALS(lengths, 1);
   TORCH_CHECK(
@@ -2561,8 +2510,7 @@ Tensor pack_segments_backward_cuda(
     const Tensor& lengths,
     int64_t total_length,
     int64_t max_length) {
-  TENSOR_ON_CUDA_GPU(data);
-  TENSOR_ON_CUDA_GPU(lengths);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(data, lengths);
   TENSOR_NDIM_IS_GE(data, 2);
   TENSOR_NDIM_EQUALS(lengths, 1);
   TORCH_CHECK_EQ(data.size(0), lengths.size(0));

--- a/fbgemm_gpu/src/sparse_ops_gpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops_gpu.cpp
@@ -175,9 +175,7 @@ class IndexSelectDim0GPUOp
       const int consecutive_range_start,
       const int consecutive_range_length,
       const bool skip_indices_sorting_fwd) {
-    TENSOR_ON_CUDA_GPU(input);
-    TENSOR_ON_CUDA_GPU(indices);
-    TENSORS_ON_SAME_DEVICE(input, indices);
+    TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(input, indices);
     // Expect a 1D index tensor
     TORCH_CHECK(indices.dim() == 1, "Index tensor must be 1D")
 
@@ -223,8 +221,7 @@ class IndexSelectDim0GPUOp
       sorted_indices = *savedItr++;
       orig_indices = *savedItr++;
     }
-    TENSOR_ON_CUDA_GPU(sorted_indices);
-    TENSOR_ON_CUDA_GPU(orig_indices);
+    TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(sorted_indices, orig_indices);
     Tensor grad_output = grad_outputs[0];
     TENSORS_ON_SAME_DEVICE(grad_output, sorted_indices);
     auto input_shape = ctx->saved_data["input_shape"].toIntVector();
@@ -308,9 +305,7 @@ class GroupIndexSelectDim0GPUOp
           "All inputs in group_index_select must have the same number of dimensions");
 
       // Verify that all tensors are on the same GPU
-      TENSOR_ON_CUDA_GPU(input);
-      TENSOR_ON_CUDA_GPU(indices);
-      TENSORS_ON_SAME_DEVICE(input, indices);
+      TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(input, indices);
 
       auto num_output_rows_ = indices.size(0);
 

--- a/fbgemm_gpu/src/split_embeddings_cache_cuda.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache_cuda.cu
@@ -188,13 +188,14 @@ void lxu_cache_flush_cuda(
     Tensor lxu_cache_state,
     Tensor lxu_cache_weights,
     bool stochastic_rounding) {
-  TENSOR_ON_CUDA_GPU(uvm_weights);
-  TENSOR_ON_CUDA_GPU(cache_hash_size_cumsum);
-  TENSOR_ON_CUDA_GPU(cache_index_table_map);
-  TENSOR_ON_CUDA_GPU(weights_offsets);
-  TENSOR_ON_CUDA_GPU(D_offsets);
-  TENSOR_ON_CUDA_GPU(lxu_cache_state);
-  TENSOR_ON_CUDA_GPU(lxu_cache_weights);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      uvm_weights,
+      cache_hash_size_cumsum,
+      cache_index_table_map,
+      weights_offsets,
+      D_offsets,
+      lxu_cache_state,
+      lxu_cache_weights);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(lxu_cache_weights.get_device());
@@ -288,9 +289,8 @@ Tensor linearize_cache_indices_cuda(
     Tensor cache_hash_size_cumsum,
     Tensor indices,
     Tensor offsets) {
-  TENSOR_ON_CUDA_GPU(cache_hash_size_cumsum);
-  TENSOR_ON_CUDA_GPU(indices);
-  TENSOR_ON_CUDA_GPU(offsets);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      cache_hash_size_cumsum, indices, offsets);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(cache_hash_size_cumsum.get_device());
@@ -364,9 +364,8 @@ Tensor linearize_cache_indices_from_row_idx_cuda(
     Tensor cache_hash_size_cumsum,
     Tensor update_table_indices,
     Tensor update_row_indices) {
-  TENSOR_ON_CUDA_GPU(cache_hash_size_cumsum);
-  TENSOR_ON_CUDA_GPU(update_table_indices);
-  TENSOR_ON_CUDA_GPU(update_row_indices);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      cache_hash_size_cumsum, update_table_indices, update_row_indices);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(cache_hash_size_cumsum.get_device());
@@ -538,8 +537,8 @@ Tensor emulate_cache_miss(
     const int64_t enforced_misses_per_256,
     const bool gather_cache_stats,
     Tensor uvm_cache_stats) {
-  TENSOR_ON_CUDA_GPU(lxu_cache_locations);
-  TENSOR_ON_CUDA_GPU(uvm_cache_stats);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      lxu_cache_locations, uvm_cache_stats);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(lxu_cache_locations.get_device());
@@ -707,11 +706,12 @@ std::pair<Tensor, Tensor> lru_cache_find_uncached_cuda(
     Tensor lru_state,
     bool gather_cache_stats,
     Tensor uvm_cache_stats) {
-  TENSOR_ON_CUDA_GPU(unique_indices);
-  TENSOR_ON_CUDA_GPU(unique_indices_length);
-  TENSOR_ON_CUDA_GPU(lxu_cache_state);
-  TENSOR_ON_CUDA_GPU(lru_state);
-  TENSOR_ON_CUDA_GPU(uvm_cache_stats);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      unique_indices,
+      unique_indices_length,
+      lxu_cache_state,
+      lru_state,
+      uvm_cache_stats);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(unique_indices.get_device());
@@ -790,10 +790,11 @@ Tensor direct_mapped_lru_cache_find_uncached_cuda(
     int64_t time_stamp,
     Tensor lru_state,
     Tensor lxu_cache_miss_timestamp) {
-  TENSOR_ON_CUDA_GPU(linear_cache_indices);
-  TENSOR_ON_CUDA_GPU(lxu_cache_state);
-  TENSOR_ON_CUDA_GPU(lru_state);
-  TENSOR_ON_CUDA_GPU(lxu_cache_miss_timestamp);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      linear_cache_indices,
+      lxu_cache_state,
+      lru_state,
+      lxu_cache_miss_timestamp);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(linear_cache_indices.get_device());
@@ -1027,18 +1028,19 @@ void lru_cache_insert_cuda(
     const bool stochastic_rounding,
     bool gather_cache_stats,
     Tensor uvm_cache_stats) {
-  TENSOR_ON_CUDA_GPU(weights);
-  TENSOR_ON_CUDA_GPU(cache_hash_size_cumsum);
-  TENSOR_ON_CUDA_GPU(cache_index_table_map);
-  TENSOR_ON_CUDA_GPU(weights_offsets);
-  TENSOR_ON_CUDA_GPU(D_offsets);
-  TENSOR_ON_CUDA_GPU(sorted_cache_sets);
-  TENSOR_ON_CUDA_GPU(cache_set_sorted_unique_indices);
-  TENSOR_ON_CUDA_GPU(unique_indices_length);
-  TENSOR_ON_CUDA_GPU(lxu_cache_state);
-  TENSOR_ON_CUDA_GPU(lxu_cache_weights);
-  TENSOR_ON_CUDA_GPU(lru_state);
-  TENSOR_ON_CUDA_GPU(uvm_cache_stats);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      weights,
+      cache_hash_size_cumsum,
+      cache_index_table_map,
+      weights_offsets,
+      D_offsets,
+      sorted_cache_sets,
+      cache_set_sorted_unique_indices,
+      unique_indices_length,
+      lxu_cache_state,
+      lxu_cache_weights,
+      lru_state,
+      uvm_cache_stats);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(weights.get_device());
@@ -1110,15 +1112,16 @@ void lru_cache_populate_cuda(
     const bool stochastic_rounding,
     bool gather_cache_stats,
     c10::optional<Tensor> uvm_cache_stats) {
-  TENSOR_ON_CUDA_GPU(weights);
-  TENSOR_ON_CUDA_GPU(cache_hash_size_cumsum);
-  TENSOR_ON_CUDA_GPU(cache_index_table_map);
-  TENSOR_ON_CUDA_GPU(weights_offsets);
-  TENSOR_ON_CUDA_GPU(D_offsets);
-  TENSOR_ON_CUDA_GPU(linear_cache_indices);
-  TENSOR_ON_CUDA_GPU(lxu_cache_state);
-  TENSOR_ON_CUDA_GPU(lxu_cache_weights);
-  TENSOR_ON_CUDA_GPU(lru_state);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      weights,
+      cache_hash_size_cumsum,
+      cache_index_table_map,
+      weights_offsets,
+      D_offsets,
+      linear_cache_indices,
+      lxu_cache_state,
+      lxu_cache_weights,
+      lru_state);
 
   Tensor uvm_cache_stats_ = at::empty({0}, weights.options().dtype(at::kInt));
   if (gather_cache_stats) {
@@ -1390,19 +1393,20 @@ void lru_cache_insert_byte_cuda(
     bool gather_cache_stats,
     Tensor uvm_cache_stats,
     int64_t row_alignment) {
-  TENSOR_ON_CUDA_GPU(weights);
-  TENSOR_ON_CUDA_GPU(cache_hash_size_cumsum);
-  TENSOR_ON_CUDA_GPU(cache_index_table_map);
-  TENSOR_ON_CUDA_GPU(weights_offsets);
-  TENSOR_ON_CUDA_GPU(weights_tys);
-  TENSOR_ON_CUDA_GPU(D_offsets);
-  TENSOR_ON_CUDA_GPU(sorted_cache_sets);
-  TENSOR_ON_CUDA_GPU(cache_set_sorted_unique_indices);
-  TENSOR_ON_CUDA_GPU(unique_indices_length);
-  TENSOR_ON_CUDA_GPU(lxu_cache_state);
-  TENSOR_ON_CUDA_GPU(lxu_cache_weights);
-  TENSOR_ON_CUDA_GPU(lru_state);
-  TENSOR_ON_CUDA_GPU(uvm_cache_stats);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      weights,
+      cache_hash_size_cumsum,
+      cache_index_table_map,
+      weights_offsets,
+      weights_tys,
+      D_offsets,
+      sorted_cache_sets,
+      cache_set_sorted_unique_indices,
+      unique_indices_length,
+      lxu_cache_state,
+      lxu_cache_weights,
+      lru_state,
+      uvm_cache_stats);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(weights.get_device());
@@ -1463,17 +1467,18 @@ void direct_mapped_lru_cache_insert_byte_cuda(
     Tensor lxu_cache_miss_timestamp,
     Tensor cache_sets,
     int64_t row_alignment) {
-  TENSOR_ON_CUDA_GPU(weights);
-  TENSOR_ON_CUDA_GPU(cache_hash_size_cumsum);
-  TENSOR_ON_CUDA_GPU(cache_index_table_map);
-  TENSOR_ON_CUDA_GPU(weights_offsets);
-  TENSOR_ON_CUDA_GPU(weights_tys);
-  TENSOR_ON_CUDA_GPU(D_offsets);
-  TENSOR_ON_CUDA_GPU(lxu_cache_state);
-  TENSOR_ON_CUDA_GPU(lxu_cache_weights);
-  TENSOR_ON_CUDA_GPU(lru_state);
-  TENSOR_ON_CUDA_GPU(linear_cache_indices);
-  TENSOR_ON_CUDA_GPU(lxu_cache_miss_timestamp);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      weights,
+      cache_hash_size_cumsum,
+      cache_index_table_map,
+      weights_offsets,
+      weights_tys,
+      D_offsets,
+      lxu_cache_state,
+      lxu_cache_weights,
+      lru_state,
+      linear_cache_indices,
+      lxu_cache_miss_timestamp);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(weights.get_device());
@@ -1534,16 +1539,17 @@ void lru_cache_populate_byte_cuda(
     int64_t row_alignment,
     bool gather_cache_stats,
     c10::optional<Tensor> uvm_cache_stats) {
-  TENSOR_ON_CUDA_GPU(weights);
-  TENSOR_ON_CUDA_GPU(cache_hash_size_cumsum);
-  TENSOR_ON_CUDA_GPU(cache_index_table_map);
-  TENSOR_ON_CUDA_GPU(weights_offsets);
-  TENSOR_ON_CUDA_GPU(weights_tys);
-  TENSOR_ON_CUDA_GPU(D_offsets);
-  TENSOR_ON_CUDA_GPU(linear_cache_indices);
-  TENSOR_ON_CUDA_GPU(lxu_cache_state);
-  TENSOR_ON_CUDA_GPU(lxu_cache_weights);
-  TENSOR_ON_CUDA_GPU(lru_state);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      weights,
+      cache_hash_size_cumsum,
+      cache_index_table_map,
+      weights_offsets,
+      weights_tys,
+      D_offsets,
+      linear_cache_indices,
+      lxu_cache_state,
+      lxu_cache_weights,
+      lru_state);
 
   Tensor uvm_cache_stats_ = at::empty({0}, weights.options().dtype(at::kInt));
   if (gather_cache_stats) {
@@ -1618,17 +1624,18 @@ void direct_mapped_lru_cache_populate_byte_cuda(
     Tensor lru_state,
     Tensor lxu_cache_miss_timestamp,
     int64_t row_alignment) {
-  TENSOR_ON_CUDA_GPU(weights);
-  TENSOR_ON_CUDA_GPU(cache_hash_size_cumsum);
-  TENSOR_ON_CUDA_GPU(cache_index_table_map);
-  TENSOR_ON_CUDA_GPU(weights_offsets);
-  TENSOR_ON_CUDA_GPU(weights_tys);
-  TENSOR_ON_CUDA_GPU(D_offsets);
-  TENSOR_ON_CUDA_GPU(linear_cache_indices);
-  TENSOR_ON_CUDA_GPU(lxu_cache_state);
-  TENSOR_ON_CUDA_GPU(lxu_cache_weights);
-  TENSOR_ON_CUDA_GPU(lru_state);
-  TENSOR_ON_CUDA_GPU(lxu_cache_miss_timestamp);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      weights,
+      cache_hash_size_cumsum,
+      cache_index_table_map,
+      weights_offsets,
+      weights_tys,
+      D_offsets,
+      linear_cache_indices,
+      lxu_cache_state,
+      lxu_cache_weights,
+      lru_state,
+      lxu_cache_miss_timestamp);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(weights.get_device());
@@ -1713,10 +1720,8 @@ void lfu_update_counts_cuda(
     Tensor unique_indices_length,
     Tensor unique_indices_count,
     Tensor lfu_state) {
-  TENSOR_ON_CUDA_GPU(unique_indices);
-  TENSOR_ON_CUDA_GPU(unique_indices_length);
-  TENSOR_ON_CUDA_GPU(unique_indices_count);
-  TENSOR_ON_CUDA_GPU(lfu_state);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      unique_indices, unique_indices_length, unique_indices_count, lfu_state);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(unique_indices.get_device());
@@ -1794,10 +1799,8 @@ std::pair<Tensor, Tensor> lfu_cache_find_uncached_cuda(
     int64_t max_indices,
     Tensor lxu_cache_state,
     Tensor lfu_state) {
-  TENSOR_ON_CUDA_GPU(unique_indices);
-  TENSOR_ON_CUDA_GPU(unique_indices_length);
-  TENSOR_ON_CUDA_GPU(lxu_cache_state);
-  TENSOR_ON_CUDA_GPU(lfu_state);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      unique_indices, unique_indices_length, lxu_cache_state, lfu_state);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(unique_indices.get_device());
@@ -2054,17 +2057,18 @@ void lfu_cache_insert_cuda(
     Tensor lxu_cache_weights,
     Tensor lfu_state,
     bool stochastic_rounding) {
-  TENSOR_ON_CUDA_GPU(weights);
-  TENSOR_ON_CUDA_GPU(cache_hash_size_cumsum);
-  TENSOR_ON_CUDA_GPU(cache_index_table_map);
-  TENSOR_ON_CUDA_GPU(weights_offsets);
-  TENSOR_ON_CUDA_GPU(D_offsets);
-  TENSOR_ON_CUDA_GPU(sorted_cache_sets);
-  TENSOR_ON_CUDA_GPU(cache_set_sorted_unique_indices);
-  TENSOR_ON_CUDA_GPU(unique_indices_length);
-  TENSOR_ON_CUDA_GPU(lxu_cache_state);
-  TENSOR_ON_CUDA_GPU(lxu_cache_weights);
-  TENSOR_ON_CUDA_GPU(lfu_state);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      weights,
+      cache_hash_size_cumsum,
+      cache_index_table_map,
+      weights_offsets,
+      D_offsets,
+      sorted_cache_sets,
+      cache_set_sorted_unique_indices,
+      unique_indices_length,
+      lxu_cache_state,
+      lxu_cache_weights,
+      lfu_state);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(weights.get_device());
@@ -2130,15 +2134,16 @@ void lfu_cache_populate_cuda(
     Tensor lxu_cache_weights,
     Tensor lfu_state,
     bool stochastic_rounding) {
-  TENSOR_ON_CUDA_GPU(weights);
-  TENSOR_ON_CUDA_GPU(cache_hash_size_cumsum);
-  TENSOR_ON_CUDA_GPU(cache_index_table_map);
-  TENSOR_ON_CUDA_GPU(weights_offsets);
-  TENSOR_ON_CUDA_GPU(D_offsets);
-  TENSOR_ON_CUDA_GPU(linear_cache_indices);
-  TENSOR_ON_CUDA_GPU(lxu_cache_state);
-  TENSOR_ON_CUDA_GPU(lxu_cache_weights);
-  TENSOR_ON_CUDA_GPU(lfu_state);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      weights,
+      cache_hash_size_cumsum,
+      cache_index_table_map,
+      weights_offsets,
+      D_offsets,
+      linear_cache_indices,
+      lxu_cache_state,
+      lxu_cache_weights,
+      lfu_state);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(weights.get_device());
@@ -2329,18 +2334,19 @@ void lfu_cache_insert_byte_cuda(
     Tensor lxu_cache_weights,
     Tensor lfu_state,
     int64_t row_alignment) {
-  TENSOR_ON_CUDA_GPU(weights);
-  TENSOR_ON_CUDA_GPU(cache_hash_size_cumsum);
-  TENSOR_ON_CUDA_GPU(cache_index_table_map);
-  TENSOR_ON_CUDA_GPU(weights_offsets);
-  TENSOR_ON_CUDA_GPU(weights_tys)
-  TENSOR_ON_CUDA_GPU(D_offsets);
-  TENSOR_ON_CUDA_GPU(sorted_cache_sets);
-  TENSOR_ON_CUDA_GPU(cache_set_sorted_unique_indices);
-  TENSOR_ON_CUDA_GPU(unique_indices_length);
-  TENSOR_ON_CUDA_GPU(lxu_cache_state);
-  TENSOR_ON_CUDA_GPU(lxu_cache_weights);
-  TENSOR_ON_CUDA_GPU(lfu_state);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      weights,
+      cache_hash_size_cumsum,
+      cache_index_table_map,
+      weights_offsets,
+      weights_tys,
+      D_offsets,
+      sorted_cache_sets,
+      cache_set_sorted_unique_indices,
+      unique_indices_length,
+      lxu_cache_state,
+      lxu_cache_weights,
+      lfu_state);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(weights.get_device());
@@ -2397,16 +2403,17 @@ void lfu_cache_populate_byte_cuda(
     Tensor lxu_cache_weights,
     Tensor lfu_state,
     int64_t row_alignment) {
-  TENSOR_ON_CUDA_GPU(weights);
-  TENSOR_ON_CUDA_GPU(cache_hash_size_cumsum);
-  TENSOR_ON_CUDA_GPU(cache_index_table_map);
-  TENSOR_ON_CUDA_GPU(weights_offsets);
-  TENSOR_ON_CUDA_GPU(weights_tys)
-  TENSOR_ON_CUDA_GPU(D_offsets);
-  TENSOR_ON_CUDA_GPU(linear_cache_indices);
-  TENSOR_ON_CUDA_GPU(lxu_cache_state);
-  TENSOR_ON_CUDA_GPU(lxu_cache_weights);
-  TENSOR_ON_CUDA_GPU(lfu_state);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      weights,
+      cache_hash_size_cumsum,
+      cache_index_table_map,
+      weights_offsets,
+      weights_tys,
+      D_offsets,
+      linear_cache_indices,
+      lxu_cache_state,
+      lxu_cache_weights,
+      lfu_state);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(weights.get_device());
@@ -2566,8 +2573,8 @@ Tensor lxu_cache_lookup_cuda(
     int64_t invalid_index,
     bool gather_cache_stats,
     c10::optional<Tensor> uvm_cache_stats) {
-  TENSOR_ON_CUDA_GPU(linear_cache_indices);
-  TENSOR_ON_CUDA_GPU(lxu_cache_state);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      linear_cache_indices, lxu_cache_state);
   Tensor uvm_cache_stats_ =
       at::empty({0}, linear_cache_indices.options().dtype(at::kInt));
   if (gather_cache_stats) {
@@ -2616,8 +2623,8 @@ Tensor direct_mapped_lxu_cache_lookup_cuda(
     Tensor linear_cache_indices,
     Tensor lxu_cache_state,
     int64_t invalid_index) {
-  TENSOR_ON_CUDA_GPU(linear_cache_indices);
-  TENSOR_ON_CUDA_GPU(lxu_cache_state);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      linear_cache_indices, lxu_cache_state);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(linear_cache_indices.get_device());
@@ -2856,22 +2863,23 @@ void reset_weight_momentum_cuda(
     Tensor cache_hash_size_cumsum,
     Tensor lxu_cache_state,
     int64_t total_cache_hash_size) {
-  TENSOR_ON_CUDA_GPU(dev_weights);
-  TENSOR_ON_CUDA_GPU(uvm_weights);
-  TENSOR_ON_CUDA_GPU(lxu_cache_weights);
-  TENSOR_ON_CUDA_GPU(weights_placements);
-  TENSOR_ON_CUDA_GPU(weights_offsets);
-  TENSOR_ON_CUDA_GPU(momentum1_dev);
-  TENSOR_ON_CUDA_GPU(momentum1_uvm);
-  TENSOR_ON_CUDA_GPU(momentum1_placements);
-  TENSOR_ON_CUDA_GPU(momentum1_offsets);
-  TENSOR_ON_CUDA_GPU(D_offsets);
-  TENSOR_ON_CUDA_GPU(pruned_indices);
-  TENSOR_ON_CUDA_GPU(pruned_indices_offsets);
-  TENSOR_ON_CUDA_GPU(logical_table_ids);
-  TENSOR_ON_CUDA_GPU(buffer_ids);
-  TENSOR_ON_CUDA_GPU(cache_hash_size_cumsum);
-  TENSOR_ON_CUDA_GPU(lxu_cache_state);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      dev_weights,
+      uvm_weights,
+      lxu_cache_weights,
+      weights_placements,
+      weights_offsets,
+      momentum1_dev,
+      momentum1_uvm,
+      momentum1_placements,
+      momentum1_offsets,
+      D_offsets,
+      pruned_indices,
+      pruned_indices_offsets,
+      logical_table_ids,
+      buffer_ids,
+      cache_hash_size_cumsum,
+      lxu_cache_state);
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(dev_weights.get_device());
 

--- a/fbgemm_gpu/src/split_embeddings_utils.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils.cu
@@ -458,14 +458,10 @@ void populate_vbe_metadata_foreach_sample_inplace(
     const bool nobag,
     const int32_t info_B_num_bits,
     const int64_t total_B) {
-  TENSOR_ON_CUDA_GPU(vbe_metadata.B_offsets);
-  TENSOR_ON_CUDA_GPU(vbe_metadata.B_offsets_rank_per_feature);
-  TENSOR_ON_CUDA_GPU(vbe_metadata.output_offsets_feature_rank);
-
-  TENSORS_ON_SAME_DEVICE(
-      vbe_metadata.B_offsets, vbe_metadata.B_offsets_rank_per_feature);
-  TENSORS_ON_SAME_DEVICE(
-      vbe_metadata.B_offsets, vbe_metadata.output_offsets_feature_rank);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      vbe_metadata.B_offsets,
+      vbe_metadata.B_offsets_rank_per_feature,
+      vbe_metadata.output_offsets_feature_rank);
 
   TENSOR_NDIM_EQUALS(vbe_metadata.B_offsets, 1);
   TENSOR_NDIM_EQUALS(vbe_metadata.B_offsets_rank_per_feature, 2);

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache_cuda.cu
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache_cuda.cu
@@ -75,10 +75,7 @@ Tensor masked_index_put_cuda(
     Tensor indices,
     Tensor values,
     Tensor count) {
-  TENSOR_ON_CUDA_GPU(self);
-  TENSOR_ON_CUDA_GPU(indices);
-  TENSOR_ON_CUDA_GPU(values);
-  TENSOR_ON_CUDA_GPU(count);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(self, indices, values, count);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(self.get_device());
@@ -220,9 +217,8 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> ssd_cache_populate_actions_cuda(
     int64_t time_stamp,
     int64_t prefetch_dist,
     Tensor lru_state) {
-  TENSOR_ON_CUDA_GPU(linear_indices);
-  TENSOR_ON_CUDA_GPU(lxu_cache_state);
-  TENSOR_ON_CUDA_GPU(lru_state);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      linear_indices, lxu_cache_state, lru_state);
 
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(linear_indices.get_device());


### PR DESCRIPTION
Summary:
Our current strategy for checking to see if a set of potentially optional tensors is on a CUDA GPU is to do the following:
```
TENSOR_ON_CUDA_GPU(encodedWork);
TENSOR_ON_CUDA_GPU(workOffsets);
TENSOR_ON_CUDA_GPU(inputFloatFeatures);
TENSORS_ON_SAME_DEVICE(encodedWork, workOffsets);
TENSORS_ON_SAME_DEVICE(encodedWork, inputFloatFeatures);
```
But this is verbose and a lot of typing and error prone and sad.

What if there was a better way? Now there is!

Just type:
```
TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
  encodedWork, workOffsets, inputFloatFeatures);
```

This will check that all non-optional tensors are on the same CUDA GPU.

If they're not then a message such as:
```
Not all tensors were on the same GPU:
  encodedWork(cuda:0),
  workOffsets(N/A),
  inputFLoatFeatures(cuda:1)
```
will be generated to provide handy diagnostic output.

Used the following script to automated the upgrade:
```
import os
import sys
import re

def replace_in_file(file_path: str):
    with open(file_path, 'r') as file:
        lines = file.readlines()

    modified_lines = []
    held = []

    for line in lines:
        line = line.rstrip()
        if "TENSOR_ON_CUDA_GPU" in line:
            held.append(line)
            continue
        if held:
            if len(held) == 1:
                modified_lines.append(held[0] + "\n")
                held = []
            else:
                tensors = ', '.join([x.replace("TENSOR_ON_CUDA_GPU(", "").replace(");", "") for x in held])
                spaces = held[0].find('T') - 1
                modified_lines.append(" "*spaces + f"TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL({tensors});\n")
                held = []
        modified_lines.append(line + '\n')

    with open(file_path, 'w') as file:
        file.writelines(modified_lines)

def process_files(directory: str):
    for root, dirs, files in os.walk(directory):
        for file_name in files:
            if file_name.endswith('.cpp') or file_name.endswith('.h') or file_name.endswith('.cu'):
                file_path = os.path.join(root, file_name)
                replace_in_file(file_path)

if __name__ == '__main__':
    if len(sys.argv) < 2:
        print('Usage: python script.py <directory>')
        sys.exit(1)

    directory = sys.argv[1]
    process_files(directory)

```

Differential Revision: D46366500

