### PR TITLE
Add optimized TBE training forward

### DIFF
--- a/fbgemm_gpu/codegen/lookup_args.py
+++ b/fbgemm_gpu/codegen/lookup_args.py
@@ -40,6 +40,7 @@ class CommonArgs(NamedTuple):
     lxu_cache_locations: torch.Tensor
     output_dtype: int
     vbe_metadata: VBEMetadata
+    is_experimental: bool
 
 
 class OptimizerArgs(NamedTuple):

--- a/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
@@ -277,5 +277,6 @@ def invoke(
         max_counter=max_counter,
         {% endif %}
         output_dtype=common_args.output_dtype,
+        is_experimental=common_args.is_experimental,
     )
     {% endif %}

--- a/fbgemm_gpu/fbgemm_gpu/ssd_split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/ssd_split_table_batched_embeddings_ops.py
@@ -451,6 +451,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 max_B_feature_rank=-1,
                 output_size=-1,
             ),
+            is_experimental=False,
         )
 
         momentum1 = invokers.lookup_args.Momentum(


### PR DESCRIPTION
Summary:
This diff adds the frontend changes and tests for TBE v2 (D43634651)

The `FBGEMM_EXPERIMENTAL_TBE` environment variable flag is added for
enabling/disabling the new implementation at runtime.  If
`FBGEMM_EXPERIMENTAL_TBE` is not set, TBE will use the orignal
implementation.  If `FBGEMM_EXPERIMENTAL_TBE=1`, TBE will use the new
implementation.  If the TBE usecases are not supported in the new
implementation, TBE will fall back to the original implementation.  By
default, `FBGEMM_EXPERIMENTAL_TBE` is not set.

This can also be enabled by passing `use_experimental_tbe=True` when
instantiating the TBE operator.

```
emb_op = SplitTableBatchedEmbeddingBagsCodegen(
    embedding_specs=...,
    ...,
    use_experimental_tbe=True,
)
```

Differential Revision: D44479772

