### PR TITLE
Remove contiguous() in split_embedding_weights_with_scale_bias

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
@@ -1270,16 +1270,14 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
                         splits.append(
                             (
                                 weights_shifts[:, self.scale_bias_size_in_bytes :],
-                                weights_shifts[:, : self.scale_bias_size_in_bytes // 2]
-                                .contiguous()
-                                .view(torch.float16),
+                                weights_shifts[
+                                    :, : self.scale_bias_size_in_bytes // 2
+                                ].view(torch.float16),
                                 weights_shifts[
                                     :,
                                     self.scale_bias_size_in_bytes
                                     // 2 : self.scale_bias_size_in_bytes,
-                                ]
-                                .contiguous()
-                                .view(torch.float16),
+                                ].view(torch.float16),
                             )
                         )
                 elif (


### PR DESCRIPTION
Summary:
Calling `tensor.contiguous()` in case of non-contiguous tensor creates a new tensor.
Changing it will not change the original `tensor`.

To use results of `split_embedding_weights_with_scale_bias(split_scale_bias_mode=2)` as a tensor in state_dict - we should be able via that tensor to change the original tbe weight.

For that we need to remove copy via contiguous().

Differential Revision:
D46483112

Privacy Context Container: L1138451

