### PR TITLE
Hide cub symbols for static link CUDA runtime lib

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
@@ -36,7 +36,8 @@ try:
     torch.ops.load_library(
         "//deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops_cpu_inference"
     )
-except Exception:
+except Exception as e:
+    logging.error(f"Cannot open cpu ops due to {str(e)}.")
     pass
 
 

--- a/fbgemm_gpu/src/split_embeddings_cache_cuda.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache_cuda.cu
@@ -36,6 +36,16 @@
 #include "fbgemm_gpu/sparse_ops_utils.h"
 #include "fbgemm_gpu/split_embeddings_utils.cuh"
 
+/*
+ * We annotate the public fbgemm functions and hide the rest. Those
+ * public symbols can be called via fbgemm_gpu::func() or pytorch
+ * operator dispatcher. We'll hide other symbols, especially cub APIs,
+ * because different .so may include the same cub CUDA kernels, which
+ * results in confusion and libA may end up calling libB's cub kernel,
+ * causing failures when we static link libcudart_static.a
+ */
+#define DLL_PUBLIC __attribute__((visibility("default")))
+
 constexpr size_t kCacheMaxThreads = 512;
 
 using Tensor = at::Tensor;
@@ -94,7 +104,7 @@ int get_max_thread_blocks_for_cache_kernels_() {
 
 } // namespace
 
-int64_t host_lxu_cache_slot(int64_t h_in, int64_t C) {
+DLL_PUBLIC int64_t host_lxu_cache_slot(int64_t h_in, int64_t C) {
   return static_cast<int64_t>(cache_slot(h_in, static_cast<int32_t>(C)));
 }
 
@@ -178,7 +188,7 @@ __global__ __launch_bounds__(kMaxThreads) void lxu_cache_flush_kernel(
 
 } // namespace
 
-void lxu_cache_flush_cuda(
+DLL_PUBLIC void lxu_cache_flush_cuda(
     Tensor uvm_weights,
     Tensor cache_hash_size_cumsum,
     Tensor cache_index_table_map,
@@ -285,7 +295,7 @@ __global__ __launch_bounds__(kMaxThreads) void linearize_cache_indices_kernel(
 
 } // namespace
 
-Tensor linearize_cache_indices_cuda(
+DLL_PUBLIC Tensor linearize_cache_indices_cuda(
     Tensor cache_hash_size_cumsum,
     Tensor indices,
     Tensor offsets) {
@@ -360,7 +370,7 @@ __launch_bounds__(kMaxThreads) void linearize_cache_indices_from_row_idx_kernel(
 
 } // namespace
 
-Tensor linearize_cache_indices_from_row_idx_cuda(
+DLL_PUBLIC Tensor linearize_cache_indices_from_row_idx_cuda(
     Tensor cache_hash_size_cumsum,
     Tensor update_table_indices,
     Tensor update_row_indices) {
@@ -401,7 +411,8 @@ Tensor linearize_cache_indices_from_row_idx_cuda(
   return linear_cache_indices;
 }
 
-std::tuple<Tensor, Tensor, c10::optional<Tensor>> get_unique_indices_cuda(
+DLL_PUBLIC std::tuple<Tensor, Tensor, c10::optional<Tensor>>
+get_unique_indices_cuda(
     Tensor linear_indices,
     int64_t max_indices,
     bool compute_count) {
@@ -532,7 +543,7 @@ __global__ __launch_bounds__(kMaxThreads) void emulate_cache_miss_kernel(
 }
 } // namespace
 
-Tensor emulate_cache_miss(
+DLL_PUBLIC Tensor emulate_cache_miss(
     Tensor lxu_cache_locations,
     const int64_t enforced_misses_per_256,
     const bool gather_cache_stats,
@@ -697,7 +708,7 @@ __launch_bounds__(kMaxThreads) void direct_mapped_lru_cache_find_uncached_kernel
 }
 } // namespace
 
-std::pair<Tensor, Tensor> lru_cache_find_uncached_cuda(
+DLL_PUBLIC std::pair<Tensor, Tensor> lru_cache_find_uncached_cuda(
     Tensor unique_indices,
     Tensor unique_indices_length,
     int64_t max_indices,
@@ -1097,7 +1108,7 @@ void lru_cache_insert_cuda(
 
 } // namespace
 
-void lru_cache_populate_cuda(
+DLL_PUBLIC void lru_cache_populate_cuda(
     Tensor weights,
     Tensor cache_hash_size_cumsum,
     const int64_t total_cache_hash_size,
@@ -1523,7 +1534,7 @@ void direct_mapped_lru_cache_insert_byte_cuda(
 
 } // namespace
 
-void lru_cache_populate_byte_cuda(
+DLL_PUBLIC void lru_cache_populate_byte_cuda(
     Tensor weights,
     Tensor cache_hash_size_cumsum,
     int64_t total_cache_hash_size,
@@ -1609,7 +1620,7 @@ void lru_cache_populate_byte_cuda(
       row_alignment);
 }
 
-void direct_mapped_lru_cache_populate_byte_cuda(
+DLL_PUBLIC void direct_mapped_lru_cache_populate_byte_cuda(
     Tensor weights,
     Tensor cache_hash_size_cumsum,
     int64_t total_cache_hash_size,
@@ -2122,7 +2133,7 @@ void lfu_cache_insert_cuda(
 
 } // namespace
 
-void lfu_cache_populate_cuda(
+DLL_PUBLIC void lfu_cache_populate_cuda(
     Tensor weights,
     Tensor cache_hash_size_cumsum,
     int64_t total_cache_hash_size,
@@ -2390,7 +2401,7 @@ void lfu_cache_insert_byte_cuda(
 
 } // namespace
 
-void lfu_cache_populate_byte_cuda(
+DLL_PUBLIC void lfu_cache_populate_byte_cuda(
     Tensor weights,
     Tensor cache_hash_size_cumsum,
     int64_t total_cache_hash_size,
@@ -2567,7 +2578,7 @@ __launch_bounds__(kMaxThreads) void direct_mapped_lxu_cache_lookup_kernel(
 
 } // namespace
 
-Tensor lxu_cache_lookup_cuda(
+DLL_PUBLIC Tensor lxu_cache_lookup_cuda(
     Tensor linear_cache_indices,
     Tensor lxu_cache_state,
     int64_t invalid_index,
@@ -2619,7 +2630,7 @@ Tensor lxu_cache_lookup_cuda(
   return lxu_cache_locations;
 }
 
-Tensor direct_mapped_lxu_cache_lookup_cuda(
+DLL_PUBLIC Tensor direct_mapped_lxu_cache_lookup_cuda(
     Tensor linear_cache_indices,
     Tensor lxu_cache_state,
     int64_t invalid_index) {
@@ -2845,7 +2856,7 @@ __global__ __launch_bounds__(kMaxThreads) void reset_weight_momentum_kernel(
   }
 }
 
-void reset_weight_momentum_cuda(
+DLL_PUBLIC void reset_weight_momentum_cuda(
     Tensor dev_weights,
     Tensor uvm_weights,
     Tensor lxu_cache_weights,

--- a/fbgemm_gpu/src/split_embeddings_utils.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils.cu
@@ -20,6 +20,16 @@
 #include "fbgemm_gpu/cub_namespace_postfix.cuh"
 // clang-format on
 
+/*
+ * We annotate the public fbgemm functions and hide the rest. Those
+ * public symbols can be called via fbgemm_gpu::func() or pytorch
+ * operator dispatcher. We'll hide other symbols, especially cub APIs,
+ * because different .so may include the same cub CUDA kernels, which
+ * results in confusion and libA may end up calling libB's cub kernel,
+ * causing failures when we static link libcudart_static.a
+ */
+#define DLL_PUBLIC __attribute__((visibility("default")))
+
 inline at::Tensor asynchronous_complete_cumsum(at::Tensor t_in) {
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(t_in.get_device());
@@ -136,7 +146,7 @@ __global__ __launch_bounds__(kMaxThreads) void linearize_index_kernel(
   }
 }
 
-std::tuple<
+DLL_PUBLIC std::tuple<
     Tensor /*linear_indices*/,
     Tensor /*linear_indices_sorted*/,
     Tensor /*infos_sorted*/,
@@ -304,7 +314,9 @@ get_infos_metadata(Tensor unused, int64_t B, int64_t T) {
   return adjust_info_B_num_bits(B, T);
 }
 
-std::tuple<int32_t, uint32_t> adjust_info_B_num_bits(int32_t B, int32_t T) {
+DLL_PUBLIC std::tuple<int32_t, uint32_t> adjust_info_B_num_bits(
+    int32_t B,
+    int32_t T) {
   int32_t info_B_num_bits = DEFAULT_INFO_B_NUM_BITS;
   uint32_t info_B_mask = DEFAULT_INFO_B_MASK;
   uint32_t max_T = MAX_T;
@@ -349,7 +361,7 @@ std::tuple<int32_t, uint32_t> adjust_info_B_num_bits(int32_t B, int32_t T) {
 }
 
 #define DEF_RADIX_SORT_PAIRS_FN(KeyT, ValueT)                        \
-  cudaError_t radix_sort_pairs(                                      \
+  DLL_PUBLIC cudaError_t radix_sort_pairs(                           \
       void* d_temp_storage,                                          \
       size_t& temp_storage_bytes,                                    \
       const KeyT* d_keys_in,                                         \
@@ -459,7 +471,7 @@ __launch_bounds__(kMaxThreads) void populate_vbe_metadata_foreach_sample_inplace
 ///                         (Used for populating b_t_map).
 /// @param total_B          The total number of samples (i.e., the total number
 ///                         of b and t pairs).
-void populate_vbe_metadata_foreach_sample_inplace(
+DLL_PUBLIC void populate_vbe_metadata_foreach_sample_inplace(
     VBEMetadata& vbe_metadata,
     const Tensor& D_offsets,
     const int32_t D,


### PR DESCRIPTION
Summary:
This is pretty tricky. After we static link CUDA runtime lib (libcudart_static.a), we start to see illegal memory access or incorrect numerics. The good thing is that cuda compute-sanitizer sheds some lights on what's going on:

```
 /usr/local/cuda-12.0/bin/compute-sanitizer --target-processes all --launch-timeout 1000000 split_table_batched_embeddings_test.par  -r test_backward_optimizers_adam

========= Program hit cudaErrorMissingConfiguration (error 52) due to "__global__ function call is not configured" on CUDA API call to cudaGetLastError.
=========     Saved host backtrace up to driver entry point at error
=========     Host Frame: [0x4416b6]
=========                in /usr/local/fbcode/platform010/lib/libcuda.so.1
=========     Host Frame:cudaGetLastError [0x748d17]
=========                in /split_table_batched_embeddings_test#link-tree/runtime/lib/libdeeplearning_fbgemm_fbgemm_gpu_sparse_ops.so
=========     Host Frame:cudaError cub::DeviceRadixSort::SortPairs<long, int, long>(void*, unsigned long&, long const*, long*, int const*, int*, long, int, int, CUstream_st*) [0x5688d6]
=========                in /split_table_batched_embeddings_test#link-tree/runtime/lib/libdeeplearning_fbgemm_fbgemm_gpu_sparse_ops.so
=========     Host Frame:transpose_embedding_input(at::Tensor, long, at::Tensor, at::Tensor, bool, c10::optional<at::Tensor> const&, long, long)::{lambda()#1}::operator()() const::{lambda()#1}::operator()() const::{lambda()#1}::operator()() const::{lambda()#2}::operator()() const [0x56be94]
=========                in /data/users/xdwang/fbsource/buck-out/v2/gen/fbcode/c03d83c7f083d977/deeplearning/fbgemm/fbgemm_gpu/__split_table_batched_embeddings_test__/split_table_batched_embeddings_test#link-tree/runtime/lib/libdeeplearning_fbgemm_fbgemm_gpu_sparse_ops.so
=========     Host Frame:transpose_embedding_input(at::Tensor, long, at::Tensor, at::Tensor, bool, c10::optional<at::Tensor> const&, long, long) [0x58a855]
=========                in //split_table_batched_embeddings_test#link-tree/runtime/lib/libdeeplearning_fbgemm_fbgemm_gpu_sparse_ops.so
=========     Host Frame:split_embedding_backward_codegen_partial_rowwise_adam_weighted_exact_cuda(at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, long, at::Tensor, long, at::Tensor, at::Tensor, long, at::Tensor, at::Tensor, long, long, bool, int, unsigned int, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, double, double, double, double, double, long) [0x22efcb5]
=========                in /split_table_batched_embeddings_test#link-tree/runtime/lib/libdeeplearning_fbgemm_fbgemm_gpu_codegen_embedding_ops_cuda_training.so
```

So what this means is that the kernel cub::DeviceRadixSort::SortPairs is wrong - missing arguments or something. After consulting Nvidia, this is what likely happens:

lib A and lib B both contains this SortPairs symbol. When libA is trying to execute the kernel, it referenced libB's kernel. The sequence is that:

```
__cudaPushCallConfiguration(...); // this comes from static cudart in the current libA
your_kernel_wrapper(); // exported by both libA and libB and it's resolved to libB's kernel
```

And then in your case your_kernel_wrapper gets linked to libB. And then cudart state in libB is missing the info configured by __cudaPushCallConfiguration.

So our strategy is to hide unnecessary symbols with the compiler flag -fvisibility=hidden. We'll mark a few symbols as public because they're actually public API.

Differential Revision:
D46586773

Privacy Context Container: L1156430

