### PR TITLE
Add memchecks to TBE training (backward, pt. 2)

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_backward_code_generator.py
@@ -7,6 +7,9 @@
 
 # flake8: noqa F401
 
+import re
+from typing import Optional
+
 try:
     # Internal
     from .embedding_common_code_generator import *

--- a/fbgemm_gpu/codegen/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_kernel_cta_template.cu
@@ -10,6 +10,7 @@
 {%- set wdesc = "weighted" if weighted else "unweighted" %}
 {%- set vbe_desc = "_vbe" if vbe else "" %}
 #include "fbgemm_gpu/embedding_backward_template_helpers.cuh"
+#include "fbgemm_gpu/fbgemm_tensor_accessor.h"
 #include "fbgemm_gpu/split_embeddings_utils.cuh"
 {% if optimizer != "none" and not dense %}
 #include "gen_embedding_optimizer_{{ optimizer }}_split_device_kernel.cuh"
@@ -26,67 +27,60 @@ template <
     int32_t kThreadGroupSize >
 __global__ __launch_bounds__(kMaxThreads) void
 split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vbe_desc }}_kernel_cta_per_row_1(
-    const at::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits> grad_output,
+    const pta::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits> grad_output,
     {%- if optimizer != "none" %}
-    at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
     {%- if not dense %}
-    at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> uvm_weights,
-    at::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        weights_placements,
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> uvm_weights,
+    pta::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
     {%- endif %}
     {%- endif %} // if optimizer != "none"
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
     {%- if not nobag %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
     {%- else %}
     int64_t D,
     {%- endif %}
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
-        hash_size_cumsum,
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
-        sorted_linear_indices_run,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        sorted_linear_indices_cumulative_run_lengths,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        long_run_ids,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        num_long_run_ids,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> hash_size_cumsum,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_linear_indices_run,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_cumulative_run_lengths,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> long_run_ids,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> num_long_run_ids,
     {%- if not nobag %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_infos,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_infos,
     {%- else %}
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_infos,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_infos,
     {%- endif %}
     {%- if not dense %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        sorted_lxu_cache_locations,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_lxu_cache_locations,
     {%- endif %}
     {%- if weighted %}
-    const at::PackedTensorAccessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits> sorted_indice_weights,
+    const pta::PackedTensorAccessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits> sorted_indice_weights,
     {%- endif %}
     {%- if not dense and optimizer != "none" %}
     bool stochastic_rounding,
     at::PhiloxCudaState stochastic_rounding_philox_args,
     {%- else %}
-    at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> grad_dev_weights,
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> grad_dev_weights,
     {%- if optimizer == "none" %}
     const int32_t max_D,
     {%- endif %}
     {%- endif %} // if not dense and optimizer != "none"
     {%- if not nobag and vbe %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> B_offsets,
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> output_offsets,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> B_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> output_offsets,
     {%- endif %}
     {%- if not nobag %}
     const int32_t info_B_num_bits,
     const uint32_t info_B_mask,
     {%- endif %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> long_run_id_to_really_long_run_ids,
-    at::PackedTensorAccessor32<at::acc_type<cache_t, true>, 2, at::RestrictPtrTraits> temp_grad_accum,
-    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> grad_accum_counter,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> long_run_id_to_really_long_run_ids,
+    pta::PackedTensorAccessor32<at::acc_type<cache_t, true>, 2, at::RestrictPtrTraits> temp_grad_accum,
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> grad_accum_counter,
     const int32_t max_segment_length_per_cta,
     const bool use_deterministic_algorithms,
-    {{ args.split_kernel_args | join(",\n    ") }}) {
+    {{ args.split_kernel_args | replace_pta_namespace() | join(",\n    ") }}) {
 #ifdef FBGEMM_USE_SUBWARP_SHUFFLE
   const unsigned int shfl_sync_mask =
         ((1L << kThreadGroupSize) - 1) <<
@@ -434,67 +428,62 @@ void split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimize
   {{ kMaxVecsPerThread }},
   {{ kThreadGroupSize }}
 > (
-    const at::PackedTensorAccessor64<{{ grad_type }}, 2, at::RestrictPtrTraits> grad_output,
+    const pta::PackedTensorAccessor64<{{ grad_type }}, 2, at::RestrictPtrTraits> grad_output,
     {%- if optimizer != "none" %}
-    at::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> dev_weights,
+    pta::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> dev_weights,
     {%- if not dense %}
-    at::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> uvm_weights,
-    at::PackedTensorAccessor64<{{ cache_type }}, 2, at::RestrictPtrTraits> lxu_cache_weights,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> uvm_weights,
+    pta::PackedTensorAccessor64<{{ cache_type }}, 2, at::RestrictPtrTraits> lxu_cache_weights,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         weights_placements,
     {%- endif %}
     {%- endif %} // if optimizer != "none"
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
     {%- if not nobag %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
     {%- else %}
     int64_t D,
     {%- endif %}
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
-        hash_size_cumsum,
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
-        sorted_linear_indices_run,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        sorted_linear_indices_cumulative_run_lengths,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        long_run_ids,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        num_long_run_ids,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> hash_size_cumsum,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_linear_indices_run,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_cumulative_run_lengths,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> long_run_ids,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> num_long_run_ids,
     {%- if not nobag %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_infos,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_infos,
     {%- else %}
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_infos,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_infos,
     {%- endif %}
     {%- if not dense %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         sorted_lxu_cache_locations,
     {%- endif %}
     {%- if weighted %}
-    const at::PackedTensorAccessor32<at::acc_type<{{ cache_type }}, true>, 1, at::RestrictPtrTraits> sorted_indice_weights,
+    const pta::PackedTensorAccessor32<at::acc_type<{{ cache_type }}, true>, 1, at::RestrictPtrTraits> sorted_indice_weights,
     {%- endif %}
     {%- if not dense and optimizer != "none" %}
     bool stochastic_rounding,
     at::PhiloxCudaState stochastic_rounding_philox_args,
     {%- else %}
-    at::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> grad_dev_weights,
+    pta::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> grad_dev_weights,
     {%- if optimizer == "none" %}
     const int32_t max_D,
     {%- endif %}
     {%- endif %} // if not dense and optimizer != "none"
     {%- if not nobag and vbe %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> B_offsets,
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> output_offsets,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> B_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> output_offsets,
     {%- endif %}
     {%- if not nobag %}
     const int32_t info_B_num_bits,
     const uint32_t info_B_mask,
     {%- endif %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> long_run_id_to_really_long_run_ids,
-    at::PackedTensorAccessor32<at::acc_type<{{ cache_type }}, true>, 2, at::RestrictPtrTraits> temp_grad_accum,
-    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> grad_accum_counter,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> long_run_id_to_really_long_run_ids,
+    pta::PackedTensorAccessor32<at::acc_type<{{ cache_type }}, true>, 2, at::RestrictPtrTraits> temp_grad_accum,
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> grad_accum_counter,
     const int32_t max_segment_length_per_cta,
     const bool use_deterministic_algorithms,
-    {{ args.split_kernel_args_no_defaults | join(",\n    ") | replace("cache_t", cache_type) }});
+    {{ args.split_kernel_args_no_defaults | replace_pta_namespace() | join(",\n    ") | replace("cache_t", cache_type) }});
 
 {%- endfor %}
 
@@ -529,67 +518,62 @@ void split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimize
   {{ kMaxVecsPerThread }},
   {{ kThreadGroupSize }}
 > (
-    const at::PackedTensorAccessor64<{{ grad_type }}, 2, at::RestrictPtrTraits> grad_output,
+    const pta::PackedTensorAccessor64<{{ grad_type }}, 2, at::RestrictPtrTraits> grad_output,
     {%- if optimizer != "none" %}
-    at::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> dev_weights,
+    pta::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> dev_weights,
     {%- if not dense %}
-    at::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> uvm_weights,
-    at::PackedTensorAccessor64<{{ cache_type }}, 2, at::RestrictPtrTraits> lxu_cache_weights,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> uvm_weights,
+    pta::PackedTensorAccessor64<{{ cache_type }}, 2, at::RestrictPtrTraits> lxu_cache_weights,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         weights_placements,
     {%- endif %}
     {%- endif %} // if optimizer != "none"
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
     {%- if not nobag %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
     {%- else %}
     int64_t D,
     {%- endif %}
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
-        hash_size_cumsum,
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
-        sorted_linear_indices_run,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        sorted_linear_indices_cumulative_run_lengths,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        long_run_ids,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        num_long_run_ids,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> hash_size_cumsum,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_linear_indices_run,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_cumulative_run_lengths,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> long_run_ids,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> num_long_run_ids,
     {%- if not nobag %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_infos,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_infos,
     {%- else %}
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_infos,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_infos,
     {%- endif %}
     {%- if not dense %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         sorted_lxu_cache_locations,
     {%- endif %}
     {%- if weighted %}
-    const at::PackedTensorAccessor32<at::acc_type<{{ cache_type }}, true>, 1, at::RestrictPtrTraits> sorted_indice_weights,
+    const pta::PackedTensorAccessor32<at::acc_type<{{ cache_type }}, true>, 1, at::RestrictPtrTraits> sorted_indice_weights,
     {%- endif %}
     {%- if not dense and optimizer != "none" %}
     bool stochastic_rounding,
     at::PhiloxCudaState stochastic_rounding_philox_args,
     {%- else %}
-    at::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> grad_dev_weights,
+    pta::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> grad_dev_weights,
     {%- if optimizer == "none" %}
     const int32_t max_D,
     {%- endif %}
     {%- endif %} // if not dense and optimizer != "none"
     {%- if not nobag and vbe %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> B_offsets,
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> output_offsets,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> B_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> output_offsets,
     {%- endif %}
     {%- if not nobag %}
     const int32_t info_B_num_bits,
     const uint32_t info_B_mask,
     {%- endif %}
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> long_run_id_to_really_long_run_ids,
-    at::PackedTensorAccessor32<at::acc_type<{{ cache_type }}, true>, 2, at::RestrictPtrTraits> temp_grad_accum,
-    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> grad_accum_counter,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> long_run_id_to_really_long_run_ids,
+    pta::PackedTensorAccessor32<at::acc_type<{{ cache_type }}, true>, 2, at::RestrictPtrTraits> temp_grad_accum,
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> grad_accum_counter,
     const int32_t max_segment_length_per_cta,
     const bool use_deterministic_algorithms,
-    {{ args.split_kernel_args_no_defaults | join(",\n    ") | replace("cache_t", cache_type) }});
+    {{ args.split_kernel_args_no_defaults | replace_pta_namespace() | join(",\n    ") | replace("cache_t", cache_type) }});
 
 {%- endfor %}
 

--- a/fbgemm_gpu/codegen/embedding_common_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_common_code_generator.py
@@ -9,6 +9,7 @@
 
 import argparse
 import os
+import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -140,6 +141,44 @@ def int64_arg_no_default(name: str) -> str:
 
 def int_arg(name: str, default: int = 0) -> str:
     return f"int {name} = {default}"
+
+
+# Format the macro call to generate pta::PackedTensorAccessors
+def make_pta_acc_format(pta_str_list: List[str], func_name: str) -> List[str]:
+    new_str_list = []
+    for pta_str in pta_str_list:
+        if "packed_accessor" in pta_str:
+            match = re.search(
+                r"([a-zA-z0-9_]*)[.]packed_accessor([3|6][2|4])<(.*)>\(\)", pta_str
+            )
+            assert match is not None and len(match.groups()) == 3
+            tensor, acc_nbits, args = match.groups()
+            if "acc_type" in args:
+                match = re.search("at::acc_type<([a-zA-Z_]*), true>", args)
+                assert match is not None and len(match.groups()) == 1
+                new_type = match.group(1)
+                args = re.sub("at::acc_type<[a-zA-Z_]*, true>", new_type, args)
+                macro_name = "MAKE_PTA_ACC_WITH_NAME"
+            else:
+                macro_name = "MAKE_PTA_WITH_NAME"
+            args = args.replace(", at::RestrictPtrTraits", "")
+            new_str_list.append(
+                f"{macro_name}({func_name}, {tensor}, {args}, {acc_nbits})"
+            )
+        else:
+            new_str_list.append(pta_str)
+    return new_str_list
+
+
+def replace_pta_namespace(pta_str_list: List[str]) -> List[str]:
+    return [
+        pta_str.replace("at::PackedTensorAccessor", "pta::PackedTensorAccessor")
+        for pta_str in pta_str_list
+    ]
+
+
+env.filters["make_pta_acc_format"] = make_pta_acc_format
+env.filters["replace_pta_namespace"] = replace_pta_namespace
 
 
 @dataclass

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_split_nbit_host_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_split_nbit_host_template.cu
@@ -43,15 +43,13 @@ __global__ void {{ type_map[emb_weight_type].enum_name }}_split_embedding{{ "_no
   {% endif %}
   const int64_t row_alignment,
   {% if weighted %}
-  at::PackedTensorAccessor32<float, 1, at::RestrictPtrTraits>
-      indice_weights,
+  at::PackedTensorAccessor32<float, 1, at::RestrictPtrTraits> indice_weights,
   {% endif %}
   {% if type_map[emb_weight_type].enum_name == "FP8" %}
   const int exponent_bits,
   const int exponent_bias,
   {% endif %}
-  at::PackedTensorAccessor32<output_t, 2, at::RestrictPtrTraits>
-      output, // [B][total_D],
+  at::PackedTensorAccessor32<output_t, 2, at::RestrictPtrTraits> output, // [B][total_D],
   const at::PackedTensorAccessor64<uint8_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
   const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> lxu_cache_locations
   );

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_split_nbit_kernel_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_split_nbit_kernel_template.cu
@@ -37,15 +37,13 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
   {% endif %}
   const int64_t row_alignment,
   {% if weighted %}
-  at::PackedTensorAccessor32<float, 1, at::RestrictPtrTraits>
-      indice_weights,
+  at::PackedTensorAccessor32<float, 1, at::RestrictPtrTraits> indice_weights,
   {% endif %}
   {% if emb_weight_type.enum_name == "FP8" %}
   const int exponent_bits,
   const int exponent_bias,
   {% endif %}
-  at::PackedTensorAccessor32<output_t, 2, at::RestrictPtrTraits>
-      output, // [B][total_D],
+  at::PackedTensorAccessor32<output_t, 2, at::RestrictPtrTraits> output, // [B][total_D],
   const at::PackedTensorAccessor64<uint8_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
   const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> lxu_cache_locations
   ) {
@@ -343,15 +341,13 @@ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if nobag else ""
   {% endif %}
   const int64_t row_alignment,
   {% if weighted %}
-  at::PackedTensorAccessor32<float, 1, at::RestrictPtrTraits>
-      indice_weights,
+  at::PackedTensorAccessor32<float, 1, at::RestrictPtrTraits> indice_weights,
   {% endif %}
   {% if emb_weight_type.enum_name == "FP8" %}
   const int exponent_bits,
   const int exponent_bias,
   {% endif %}
-  at::PackedTensorAccessor32<{{ output_type }}, 2, at::RestrictPtrTraits>
-      output, // [B][total_D],
+  at::PackedTensorAccessor32<{{ output_type }}, 2, at::RestrictPtrTraits> output, // [B][total_D],
   const at::PackedTensorAccessor64<uint8_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
   const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> lxu_cache_locations
   );

--- a/fbgemm_gpu/codegen/embedding_optimizer_split_device_kernel_template.cuh
+++ b/fbgemm_gpu/codegen/embedding_optimizer_split_device_kernel_template.cuh
@@ -8,6 +8,7 @@
 
 // clang-format off
 #include "fbgemm_gpu/embedding_backward_template_helpers.cuh"
+#include "fbgemm_gpu/fbgemm_tensor_accessor.h"
 #include "fbgemm_gpu/split_embeddings_utils.cuh"
 
 using namespace fbgemm_gpu;
@@ -20,15 +21,12 @@ template <
     int32_t VEC_WIDTH
 >
 DEVICE_INLINE void split_{{ optimizer }}_table_update_kernel(
-    at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits>& dev_weights,
-    at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits>& uvm_weights,
-    at::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits>& lxu_cache_weights,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>&
-        weights_placements,
-    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>&
-        weights_offsets,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>&
-        sorted_lxu_cache_locations,
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits>& dev_weights,
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits>& uvm_weights,
+    pta::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits>& lxu_cache_weights,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>& weights_placements,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>& weights_offsets,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>& sorted_lxu_cache_locations,
     Vec4T<at::acc_type<cache_t, true>>* grad_sum,
     const bool stochastic_rounding,
     const at::PhiloxCudaState& stochastic_rounding_philox_args,
@@ -39,7 +37,7 @@ DEVICE_INLINE void split_{{ optimizer }}_table_update_kernel(
     const int32_t segment_start,
     const uint32_t shfl_sync_mask,
     const int32_t shared_weight_offset,
-    {{ args.split_ref_kernel_args | join(", ") }}
+    {{ args.split_ref_kernel_args | replace_pta_namespace() | join(",\n    ") }}
 ) {
     constexpr auto is_int8 = std::is_same<emb_t, uint8_t>::value;
     const int64_t weights_offset = weights_offsets[t];

--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_tensor_accessor.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_tensor_accessor.h
@@ -485,7 +485,7 @@ template <
     size_t N,
     template <typename U> class PtrTraits = at::DefaultPtrTraits,
     typename index_t = int64_t>
-const fbgemm_gpu::GenericPackedTensorAccessor<T, N, PtrTraits, index_t>
+fbgemm_gpu::GenericPackedTensorAccessor<T, N, PtrTraits, index_t>
 make_generic_packed_tensor_accessor(
     const at::Tensor& tensor,
     const char* const ptr_name,
@@ -512,8 +512,7 @@ template <
     typename T,
     size_t N,
     template <typename U> class PtrTraits = at::DefaultPtrTraits>
-const pta::PackedTensorAccessor32<T, N, PtrTraits>
-make_packed_tensor_accessor32(
+pta::PackedTensorAccessor32<T, N, PtrTraits> make_packed_tensor_accessor32(
 #ifdef FBGEMM_GPU_MEMCHECK
     const at::Tensor& tensor,
     const char* const ptr_name,
@@ -537,8 +536,7 @@ template <
     typename T,
     size_t N,
     template <typename U> class PtrTraits = at::DefaultPtrTraits>
-const pta::PackedTensorAccessor64<T, N, PtrTraits>
-make_packed_tensor_accessor64(
+pta::PackedTensorAccessor64<T, N, PtrTraits> make_packed_tensor_accessor64(
 #ifdef FBGEMM_GPU_MEMCHECK
     const at::Tensor& tensor,
     const char* const ptr_name,
@@ -578,4 +576,8 @@ make_packed_tensor_accessor64(
 
 #define MAKE_PTA_WITH_NAME(FUNC_NAME, TENSOR, T, N, INDEX_NBITS) \
   MAKE_PACKED_TENSOR_ACCESSOR_BASE(                              \
+      FUNC_NAME, TENSOR, T, N, at::RestrictPtrTraits, INDEX_NBITS)
+
+#define MAKE_PTA_ACC_WITH_NAME(FUNC_NAME, TENSOR, T, N, INDEX_NBITS) \
+  MAKE_PACKED_TENSOR_ACCESSOR_ACC_TYPE_BASE(                         \
       FUNC_NAME, TENSOR, T, N, at::RestrictPtrTraits, INDEX_NBITS)


### PR DESCRIPTION
Summary: - Add memchecks to TBE training (backward) kernels, pt. 2

Differential Revision: D46711608

