### PR TITLE
Add BF16 output support for CPU TBE kernel when input is int4/int2 (Copy from D46740232)

### DIFF
--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -166,7 +166,8 @@ GenerateEmbeddingSpMDMNBitWithStrides(
     bool use_offsets = true,
     std::int64_t output_stride = -1,
     std::int64_t input_stride = -1,
-    bool scale_bias_last = true);
+    bool scale_bias_last = true,
+    bool is_bf16_out = false);
 
 /**
  * @param output_stride If -1, output_stride is same as block_size

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -260,7 +260,8 @@ FBGEMM_API bool EmbeddingSpMDMNBit_ref(
     bool use_offsets = true,
     std::int64_t output_stride = -1,
     std::int64_t input_stride = -1,
-    bool scale_bias_last = true);
+    bool scale_bias_last = true,
+    bool is_bf16_out = false);
 
 template <
     typename IndexType = std::int64_t,


### PR DESCRIPTION
Summary:
(Copied from D46740232 to solve signal failures)
Enable BF16 output support in FBGEMM CPU TBE kernel (when the input is of int4 or int2)

Reviewed By: sryap

Differential Revision: D46789900

