### PR TITLE
Fix OSS macos CI error on the trunk

### DIFF
--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -238,7 +238,7 @@ FBGEMM_API bool EmbeddingSpMDM_ref(
     std::int64_t input_stride = -1,
     bool scale_bias_last = true,
     bool no_bag = false,
-    bool is_bf16 = false);
+    bool is_bf16_out = false);
 
 template <
     typename IndexType = std::int64_t,


### PR DESCRIPTION
Summary:
Fix some trunk issues on OSS FBGEMM macos tests:

https://github.com/pytorch/FBGEMM/actions/runs/5306099684/jobs/9604231400

```
/Users/runner/work/FBGEMM/FBGEMM/src/RefImplementations.cc:1421:10: error: unused parameter 'is_bf16_out' [-Werror,-Wunused-parameter]
    bool is_bf16_out) {
         ^
1 error generated.
```

It should come from D46789900. cc excelle08 sryap

Differential Revision: D46832373

