### PR TITLE
Add device index to error message for TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
@@ -36,9 +36,7 @@ inline std::optional<int64_t> get_device_index_from_tensor(
 }
 
 inline std::string torch_tensor_device_name(const at::Tensor& ten) {
-  const auto index = get_device_index_from_tensor(ten);
-  return c10::DeviceTypeName(ten.device().type()) +
-      (index ? ":" + std::to_string(index.value()) : "");
+  return c10::DeviceTypeName(ten.device().type());
 }
 
 inline std::string torch_tensor_device_name(
@@ -259,7 +257,12 @@ std::string tensor_on_same_gpu_if_not_optional_check(
         }
         msg.append(
             var_names.at(current_idx++) + "(" +
-            torch_tensor_device_name(tensor) + ")");
+            torch_tensor_device_name(tensor));
+        const auto gpu_device_index = get_device_index_from_tensor(tensor);
+        if (gpu_device_index) {
+          msg.append(":" + std::to_string(*gpu_device_index));
+        }
+        msg.append(")");
       }(tensors),
       ...);
 


### PR DESCRIPTION
Summary: Otherwise it is not clear on which tensor was on the wrong device when all the tensors are on cuda but on different devices

Reviewed By: jspark1105, q10

Differential Revision: D46922771

