### PR TITLE
Revert usage of TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL in histogram_binning_calibration_ops.cu

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
@@ -36,9 +36,7 @@ inline std::optional<int64_t> get_device_index_from_tensor(
 }
 
 inline std::string torch_tensor_device_name(const at::Tensor& ten) {
-  const auto index = get_device_index_from_tensor(ten);
-  return c10::DeviceTypeName(ten.device().type()) +
-      (index ? ":" + std::to_string(index.value()) : "");
+  return c10::DeviceTypeName(ten.device().type());
 }
 
 inline std::string torch_tensor_device_name(
@@ -259,7 +257,12 @@ std::string tensor_on_same_gpu_if_not_optional_check(
         }
         msg.append(
             var_names.at(current_idx++) + "(" +
-            torch_tensor_device_name(tensor) + ")");
+            torch_tensor_device_name(tensor));
+        const auto gpu_device_index = get_device_index_from_tensor(tensor);
+        if (gpu_device_index) {
+          msg.append(":" + std::to_string(*gpu_device_index));
+        }
+        msg.append(")");
       }(tensors),
       ...);
 

--- a/fbgemm_gpu/src/histogram_binning_calibration_ops.cu
+++ b/fbgemm_gpu/src/histogram_binning_calibration_ops.cu
@@ -60,8 +60,9 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_cuda(
     double upper_bound,
     int64_t bin_ctr_in_use_after,
     double bin_ctr_weight_value) {
-  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
-      logit, bin_num_examples, bin_num_positives);
+  TENSOR_ON_CUDA_GPU(logit);
+  TENSOR_ON_CUDA_GPU(bin_num_examples);
+  TENSOR_ON_CUDA_GPU(bin_num_positives);
   TORCH_CHECK_EQ(bin_num_examples.numel(), bin_num_positives.numel());
 
   at::cuda::OptionalCUDAGuard device_guard;
@@ -181,12 +182,11 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_by_feature_cuda(
     double upper_bound,
     int64_t bin_ctr_in_use_after,
     double bin_ctr_weight_value) {
-  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
-      logit,
-      segment_value,
-      segment_lengths,
-      bin_num_examples,
-      bin_num_positives);
+  TENSOR_ON_CUDA_GPU(logit);
+  TENSOR_ON_CUDA_GPU(segment_value);
+  TENSOR_ON_CUDA_GPU(segment_lengths);
+  TENSOR_ON_CUDA_GPU(bin_num_examples);
+  TENSOR_ON_CUDA_GPU(bin_num_positives);
   TORCH_CHECK_EQ(bin_num_examples.numel(), bin_num_positives.numel());
 
   at::cuda::OptionalCUDAGuard device_guard;
@@ -341,13 +341,12 @@ generic_histogram_binning_calibration_by_feature_cuda(
     double positive_weight,
     int64_t bin_ctr_in_use_after,
     double bin_ctr_weight_value) {
-  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
-      logit,
-      segment_value,
-      segment_lengths,
-      bin_num_examples,
-      bin_num_positives,
-      bin_boundaries);
+  TENSOR_ON_CUDA_GPU(logit);
+  TENSOR_ON_CUDA_GPU(segment_value);
+  TENSOR_ON_CUDA_GPU(segment_lengths);
+  TENSOR_ON_CUDA_GPU(bin_num_examples);
+  TENSOR_ON_CUDA_GPU(bin_num_positives);
+  TENSOR_ON_CUDA_GPU(bin_boundaries);
   TORCH_CHECK_EQ(bin_num_examples.numel(), bin_num_positives.numel());
   TORCH_CHECK(
       bin_num_examples.numel() ==


### PR DESCRIPTION
Summary:
This was introduced as part of the diff: D46366500

Earlier in this file, the only condition was being checked was around all the tensors being on CUDA but not being on the same device index. Introducing the cuda and device index checks is breaking model loading for some of the gpu models: S347396 .

Although it could point towards an issue with the model generation but since it is breaking production use cases, reverting changes to this file to mitigate the sev.

We may need to revisit other files changed in the diff D46366500 as well where earlier there was only cuda check and no device index check or fix the issues around model generation to have all the tensors on the same gpu device index.

Differential Revision: D46923168

