### PR TITLE
Add memchecks to TBE training (forward, pt. 2)

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
@@ -12,9 +12,10 @@
 using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
 
-{% for vbe in [True, False] %}
-{% set vbe_desc = "_vbe" if vbe else "" %}
-{% if not dense or not vbe %}
+{%- for vbe in [True, False] %}
+{%- set vbe_desc = "_vbe" if vbe else "" %}
+{%- if not dense or not vbe %}
+
 // TODO: optimization to use multiple warps per row.
 template <
   typename emb_t,
@@ -22,42 +23,35 @@ template <
   typename cache_t,
   size_t kMaxVecsPerThread
 >
-__global__
-__launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights{{ vbe_desc }}_kernel(
+__global__ __launch_bounds__(kForwardMaxThreads) void
+{{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights{{ vbe_desc }}_kernel(
     // [\sum_t E_t x D_t]
-    const pta::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits>
-        grad_output,
+    const pta::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits> grad_output,
     pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
-    {% if not dense %}
+    {%- if not dense %}
     pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> uvm_weights,
     pta::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
-    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        weights_placements,
-    {% endif %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
+    {%- endif %}
     const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
-    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
-        indices, // [N = \sum_{b,t} L_{b,t} total indices, i.e. flattened
-                 // [B][T][L]
-    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
-        offsets, // [B x T + 1]
-    {% if not dense %}
-    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        lxu_cache_locations,
-    {% endif %}
-    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
-        feature_requires_grad, // [T],
-    pta::PackedTensorAccessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits>
-        grad_indice_weights,
-    {% if vbe %}
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> indices, // [N = \sum_{b,t} L_{b,t} total indices, i.e. flattened [B][T][L]
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> offsets, // [B x T + 1]
+    {%- if not dense %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> lxu_cache_locations,
+    {%- endif %}
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> feature_requires_grad, // [T],
+    pta::PackedTensorAccessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits> grad_indice_weights,
+    {%- if vbe %}
     const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> grad_offsets,
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> b_t_map,
     const int32_t info_B_num_bits,
     const uint32_t info_B_mask
-    {% else %}
+    {%- else %}
     FixedDivisor fd_B
-    {% endif %}
+    {%- endif %}
     ) {
+
     int32_t T = D_offsets.size(0) - 1;
     int32_t b_t = blockIdx.x * blockDim.y + threadIdx.y;
     if (b_t >= offsets.size(0) - 1) {
@@ -67,13 +61,13 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
     int32_t t;
     int32_t b;
 
-    {% if vbe %}
+    {%- if vbe %}
     const auto info = reinterpret_cast<const uint32_t*>(&b_t_map[b_t])[0];
     reinterpret_cast<uint32_t*>(&t)[0] = info >> info_B_num_bits;
     reinterpret_cast<uint32_t*>(&b)[0] = info & info_B_mask;
-    {% else %}
+    {%- else %}
     fd_B.DivMod(b_t, &t, &b);
-    {% endif %}
+    {%- endif %}
 
     int64_t weights_offset = weights_offsets[t];
     int32_t D_start = D_offsets[t];
@@ -94,22 +88,22 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
     }
 
     const emb_t* __restrict__ weights;
-    {% if not dense %}
+    {%- if not dense %}
     const auto placement = static_cast<PlacementType>(weights_placements[t]);
     if (placement == PlacementType::DEVICE) {
         weights = &dev_weights[weights_offset];
     } else {
         weights = &uvm_weights[weights_offset];
     }
-    {% else %}
+    {%- else %}
     weights = &dev_weights[weights_offset];
-    {% endif %}
+    {%- endif %}
 
-    {% if vbe %}
+    {%- if vbe %}
     const grad_t* grad_output_ = &grad_output[0][grad_offsets[b_t]];
-    {% else %}
+    {%- else %}
     const grad_t* grad_output_ = &grad_output[b][D_start];
-    {% endif %}
+    {%- endif %}
 
     Vec4T<at::acc_type<cache_t, true>> grad_out[kMaxVecsPerThread];
     #pragma unroll kMaxVecsPerThread
@@ -124,14 +118,14 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
     for (int32_t l_start = 0; l_start < L; l_start += kWarpSize) {
         int32_t l = l_start + threadIdx.x;
         int64_t idx = l < L ? indices[indices_start + l] : 0;
-        {% if not dense %}
+        {%- if not dense %}
         int32_t cache_idx = (placement == PlacementType::MANAGED_CACHING && l < L) ? lxu_cache_locations[indices_start + l] : 0;
-        {% endif %}
+        {%- endif %}
         for (auto j = 0; j < kWarpSize && l_start + j < L; ++j) {
             int64_t idx_j = shfl_sync(idx, j);
-            {% if not dense %}
+            {%- if not dense %}
             int32_t cache_idx_j = shfl_sync(cache_idx, j);
-            {% endif %}
+            {%- endif %}
             at::acc_type<cache_t, true> grad_indice_weight = 0.0;
 
         #pragma unroll kMaxVecsPerThread
@@ -139,7 +133,7 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
                 i < kMaxVecsPerThread && 4 * kWarpSize * i + threadIdx.x * 4 < D;
                 ++i) {
                 int32_t d = 4 * kWarpSize * i + threadIdx.x * 4;
-                {% if not dense %}
+                {%- if not dense %}
                 if (placement == PlacementType::MANAGED_CACHING && cache_idx_j != kCacheLocationMissing) {
                     Vec4T<cache_t> weight(&lxu_cache_weights[cache_idx_j][d]);
                     grad_indice_weight += weight.acc.x * grad_out[i].acc.x +
@@ -165,7 +159,7 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
                         weight.acc.y * grad_out[i].acc.y +
                         weight.acc.z * grad_out[i].acc.z + weight.acc.w * grad_out[i].acc.w;
                 }
-                {% else %}
+                {%- else %}
                 int32_t D_emb = D;
                 if (std::is_same<emb_t, uint8_t>::value) {
                     D_emb += kINT8QparamsBytes;
@@ -184,7 +178,7 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
                 grad_indice_weight += weight.acc.x * grad_out[i].acc.x +
                     weight.acc.y * grad_out[i].acc.y +
                     weight.acc.z * grad_out[i].acc.z + weight.acc.w * grad_out[i].acc.w;
-                {% endif %}
+                {%- endif %}
             }
             grad_indice_weight =
                 warpReduceAllSum<at::acc_type<cache_t, true>>(grad_indice_weight);
@@ -198,46 +192,46 @@ __launch_bounds__(kForwardMaxThreads) void {{ "dense" if dense else "split" }}_e
 Tensor {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights{{ vbe_desc }}_cuda(
     Tensor grad_output,
     Tensor dev_weights,
-    {% if not dense %}
+    {%- if not dense %}
     Tensor uvm_weights,
     Tensor lxu_cache_weights,
     Tensor weights_placements,
-    {% endif %}
+    {%- endif %}
     Tensor weights_offsets,
     Tensor D_offsets,
     int64_t max_D,
     Tensor indices,
     Tensor offsets,
-    {% if not dense %}
+    {%- if not dense %}
     Tensor lxu_cache_locations,
-    {% endif %}
-    {% if vbe %}
+    {%- endif %}
+    {%- if vbe %}
     Tensor feature_requires_grad,
     const VBEMetadata& vbe_metadata,
     const int32_t info_B_num_bits,
     const uint32_t info_B_mask
-    {% else %}
+    {%- else %}
     Tensor feature_requires_grad
-    {% endif %}
+    {%- endif %}
 ) {
    TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
         dev_weights,
-        {% if not dense %}
+        {%- if not dense %}
         uvm_weights,
         lxu_cache_weights,
         weights_placements,
-        {% endif %}
+        {%- endif %}
         weights_offsets,
         D_offsets,
         indices,
         offsets,
-        {% if not dense %}
+        {%- if not dense %}
         lxu_cache_locations,
-        {% endif %}
-        {% if vbe %}
+        {%- endif %}
+        {%- if vbe %}
         vbe_metadata.output_offsets,
         vbe_metadata.b_t_map,
-        {% endif %}
+        {%- endif %}
         grad_output
     );
 
@@ -262,18 +256,18 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights
     DISPATCH_EMB_GRAD_CACHE_TYPES(
         dev_weights.scalar_type(),
         grad_output.scalar_type(),
-        {% if not dense %}
+        {%- if not dense %}
         lxu_cache_weights.scalar_type(),
-        {% else %}
+        {%- else %}
         dev_weights.scalar_type(),
-        {% endif %}
+        {%- endif %}
         "split_embedding_codegen_grad_indice_weights_kernel",
         [&] {
-            {% if vbe %}
+            {%- if vbe %}
             grad_output = grad_output.reshape({1, -1});
-            {% endif %}
+            {%- endif %}
 
-            {% for kMaxVecsPerThread in range(1, max_embedding_dim // items_per_warp + 1) %}
+            {%- for kMaxVecsPerThread in range(1, max_embedding_dim // items_per_warp + 1) %}
             if (max_D <= {{ items_per_warp * kMaxVecsPerThread }}) {
 
 #ifdef FBGEMM_GPU_MEMCHECK
@@ -289,40 +283,40 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights
                 dim3(kWarpSize, kForwardMaxThreads / kWarpSize),
                 0,
                 at::cuda::getCurrentCUDAStream()>>>(
-                MAKE_PTA(grad_output, grad_t, 2, 64),
-                MAKE_PTA(dev_weights, emb_t, 1, 64),
-                {% if not dense %}
-                MAKE_PTA(uvm_weights, emb_t, 1, 64),
-                MAKE_PTA(lxu_cache_weights, cache_t, 2, 64),
-                MAKE_PTA(weights_placements, int32_t, 1, 32),
-                {% endif %}
-                MAKE_PTA(weights_offsets, int64_t, 1, 32),
-                MAKE_PTA(D_offsets, int32_t, 1, 32),
-                MAKE_PTA(indices, int64_t, 1, 32),
-                MAKE_PTA(offsets, int64_t, 1, 32),
-                {% if not dense %}
-                MAKE_PTA(lxu_cache_locations, int32_t, 1, 32),
-                {% endif %}
-                MAKE_PTA(feature_requires_grad, int32_t, 1, 32),
-                MAKE_PTA_ACC(grad_indice_weights, grad_t, 1, 32),
-                {% if vbe %}
-                MAKE_PTA(vbe_metadata.output_offsets, int64_t, 1, 32),
-                MAKE_PTA(vbe_metadata.b_t_map, int32_t, 1, 32),
+                MAKE_PTA_WITH_NAME(func_name, grad_output, grad_t, 2, 64),
+                MAKE_PTA_WITH_NAME(func_name, dev_weights, emb_t, 1, 64),
+                {%- if not dense %}
+                MAKE_PTA_WITH_NAME(func_name, uvm_weights, emb_t, 1, 64),
+                MAKE_PTA_WITH_NAME(func_name, lxu_cache_weights, cache_t, 2, 64),
+                MAKE_PTA_WITH_NAME(func_name, weights_placements, int32_t, 1, 32),
+                {%- endif %}
+                MAKE_PTA_WITH_NAME(func_name, weights_offsets, int64_t, 1, 32),
+                MAKE_PTA_WITH_NAME(func_name, D_offsets, int32_t, 1, 32),
+                MAKE_PTA_WITH_NAME(func_name, indices, int64_t, 1, 32),
+                MAKE_PTA_WITH_NAME(func_name, offsets, int64_t, 1, 32),
+                {%- if not dense %}
+                MAKE_PTA_WITH_NAME(func_name, lxu_cache_locations, int32_t, 1, 32),
+                {%- endif %}
+                MAKE_PTA_WITH_NAME(func_name, feature_requires_grad, int32_t, 1, 32),
+                MAKE_PTA_ACC_WITH_NAME(func_name, grad_indice_weights, grad_t, 1, 32),
+                {%- if vbe %}
+                MAKE_PTA_WITH_NAME(func_name, vbe_metadata.output_offsets, int64_t, 1, 32),
+                MAKE_PTA_WITH_NAME(func_name, vbe_metadata.b_t_map, int32_t, 1, 32),
                 info_B_num_bits,
                 info_B_mask
-                {% else %}
+                {%- else %}
                 FixedDivisor(total_B / T)
-                {% endif %}
+                {%- endif %}
             );
             C10_CUDA_KERNEL_LAUNCH_CHECK();
             return;
             }
-            {% endfor %}
+            {%- endfor %}
         });
 
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return grad_indice_weights;
 }
-{% endif %}
-{% endfor %}
+{%- endif %}
+{%- endfor %}
     // clang-format on

--- a/fbgemm_gpu/codegen/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_kernel_cta_template.cu
@@ -12,9 +12,9 @@
 #include "fbgemm_gpu/embedding_backward_template_helpers.cuh"
 #include "fbgemm_gpu/fbgemm_tensor_accessor.h"
 #include "fbgemm_gpu/split_embeddings_utils.cuh"
-{% if optimizer != "none" and not dense %}
+{%- if optimizer != "none" and not dense %}
 #include "gen_embedding_optimizer_{{ optimizer }}_split_device_kernel.cuh"
-{% endif %}
+{%- endif %}
 
 using Tensor = at::Tensor;
 using namespace fbgemm_gpu;

--- a/fbgemm_gpu/codegen/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_kernel_warp_template.cu
@@ -12,9 +12,9 @@
 #include "fbgemm_gpu/embedding_backward_template_helpers.cuh"
 #include "fbgemm_gpu/fbgemm_tensor_accessor.h"
 #include "fbgemm_gpu/split_embeddings_utils.cuh"
-{% if optimizer != "none" and not dense %}
+{%- if optimizer != "none" and not dense %}
 #include "gen_embedding_optimizer_{{ optimizer }}_split_device_kernel.cuh"
-{% endif %}
+{%- endif %}
 
 using Tensor = at::Tensor;
 using namespace fbgemm_gpu;

--- a/fbgemm_gpu/codegen/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_template.cu
@@ -322,32 +322,32 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
                     dim3(kThreadGroupSize, kForwardMaxThreads / kThreadGroupSize),
                     0,
                     at::cuda::getCurrentCUDAStream()>>>(
-                    MAKE_PTA(dev_weights, emb_t, 1, 64),
+                    MAKE_PTA_WITH_NAME(func_name, dev_weights, emb_t, 1, 64),
                     {%- if not dense %}
-                    MAKE_PTA(uvm_weights, emb_t, 1, 64),
-                    MAKE_PTA(lxu_cache_weights, cache_t, 2, 64),
-                    MAKE_PTA(weights_placements, int32_t, 1, 32),
+                    MAKE_PTA_WITH_NAME(func_name, uvm_weights, emb_t, 1, 64),
+                    MAKE_PTA_WITH_NAME(func_name, lxu_cache_weights, cache_t, 2, 64),
+                    MAKE_PTA_WITH_NAME(func_name, weights_placements, int32_t, 1, 32),
                     {%- endif %}
-                    MAKE_PTA(weights_offsets, int64_t, 1, 32),
-                    MAKE_PTA(D_offsets, int32_t, 1, 32),
+                    MAKE_PTA_WITH_NAME(func_name, weights_offsets, int64_t, 1, 32),
+                    MAKE_PTA_WITH_NAME(func_name, D_offsets, int32_t, 1, 32),
                     {%- if vbe %}
-                    MAKE_PTA(vbe_metadata.output_offsets, int64_t, 1, 32),
-                    MAKE_PTA(vbe_metadata.b_t_map, int32_t, 1, 32),
+                    MAKE_PTA_WITH_NAME(func_name, vbe_metadata.output_offsets, int64_t, 1, 32),
+                    MAKE_PTA_WITH_NAME(func_name, vbe_metadata.b_t_map, int32_t, 1, 32),
                     info_B_num_bits,
                     info_B_mask,
                     {%- else %}
                     FixedDivisor(B),
                     {%- endif %}
-                    MAKE_PTA(indices, int64_t, 1, 32),
-                    MAKE_PTA(offsets, int64_t, 1, 32),
+                    MAKE_PTA_WITH_NAME(func_name, indices, int64_t, 1, 32),
+                    MAKE_PTA_WITH_NAME(func_name, offsets, int64_t, 1, 32),
                     pooling_mode,
                     {%- if weighted %}
-                    MAKE_PTA_ACC(indice_weights, cache_t, 1, 32),
+                    MAKE_PTA_ACC_WITH_NAME(func_name, indice_weights, cache_t, 1, 32),
                     {%- endif %}
                     {%- if not dense %}
-                    MAKE_PTA(lxu_cache_locations, int32_t, 1, 32),
+                    MAKE_PTA_WITH_NAME(func_name, lxu_cache_locations, int32_t, 1, 32),
                     {%- endif %} // if not dense
-                    MAKE_PTA(output, output_t, 2, 64)
+                    MAKE_PTA_WITH_NAME(func_name, output, output_t, 2, 64)
                     );
                 C10_CUDA_KERNEL_LAUNCH_CHECK();
                 {%- if vbe %}
@@ -380,21 +380,21 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
             dim3(kWarpSize, kForwardMaxThreads / kWarpSize),
             0,
             at::cuda::getCurrentCUDAStream()>>>(
-            MAKE_PTA(dev_weights, emb_t, 1, 64),
+            MAKE_PTA_WITH_NAME(func_name, dev_weights, emb_t, 1, 64),
             {%- if not dense %}
-            MAKE_PTA(uvm_weights, emb_t, 1, 64),
-            MAKE_PTA(lxu_cache_weights, cache_t, 2, 64),
-            MAKE_PTA(weights_placements, int32_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, uvm_weights, emb_t, 1, 64),
+            MAKE_PTA_WITH_NAME(func_name, lxu_cache_weights, cache_t, 2, 64),
+            MAKE_PTA_WITH_NAME(func_name, weights_placements, int32_t, 1, 32),
             {%- endif %}
-            MAKE_PTA(weights_offsets, int64_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, weights_offsets, int64_t, 1, 32),
             D,
             FixedDivisor(B),
-            MAKE_PTA(indices, int64_t, 1, 32),
-            MAKE_PTA(offsets, int64_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, indices, int64_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, offsets, int64_t, 1, 32),
             {%- if not dense %}
-            MAKE_PTA(lxu_cache_locations, int32_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, lxu_cache_locations, int32_t, 1, 32),
             {%- endif %}
-            MAKE_PTA(output, output_t, 2, 64)
+            MAKE_PTA_WITH_NAME(func_name, output, output_t, 2, 64)
             );
             C10_CUDA_KERNEL_LAUNCH_CHECK();
             return;
@@ -420,21 +420,21 @@ Tensor {{ "dense" if dense else "split" }}_embedding{{ "_nobag" if nobag else ""
                 dim3(kWarpSize, kForwardMaxThreads / kWarpSize),
                 0,
                 at::cuda::getCurrentCUDAStream()>>>(
-                MAKE_PTA(dev_weights, emb_t, 1, 64),
+                MAKE_PTA_WITH_NAME(func_name, dev_weights, emb_t, 1, 64),
                 {%- if not dense %}
-                MAKE_PTA(uvm_weights, emb_t, 1, 64),
-                MAKE_PTA(lxu_cache_weights, cache_t, 2, 64),
-                MAKE_PTA(weights_placements, int32_t, 1, 32),
+                MAKE_PTA_WITH_NAME(func_name, uvm_weights, emb_t, 1, 64),
+                MAKE_PTA_WITH_NAME(func_name, lxu_cache_weights, cache_t, 2, 64),
+                MAKE_PTA_WITH_NAME(func_name, weights_placements, int32_t, 1, 32),
                 {%- endif %}
-                MAKE_PTA(weights_offsets, int64_t, 1, 32),
+                MAKE_PTA_WITH_NAME(func_name, weights_offsets, int64_t, 1, 32),
                 D,
                 FixedDivisor(B),
-                MAKE_PTA(indices, int64_t, 1, 32),
-                MAKE_PTA(offsets, int64_t, 1, 32),
+                MAKE_PTA_WITH_NAME(func_name, indices, int64_t, 1, 32),
+                MAKE_PTA_WITH_NAME(func_name, offsets, int64_t, 1, 32),
                 {%- if not dense %}
-                MAKE_PTA(lxu_cache_locations, int32_t, 1, 32),
+                MAKE_PTA_WITH_NAME(func_name, lxu_cache_locations, int32_t, 1, 32),
                 {%- endif %}
-                MAKE_PTA(output, output_t, 2, 64)
+                MAKE_PTA_WITH_NAME(func_name, output, output_t, 2, 64)
                 );
                 C10_CUDA_KERNEL_LAUNCH_CHECK();
                 return;

--- a/fbgemm_gpu/codegen/embedding_forward_template_helpers.cuh
+++ b/fbgemm_gpu/codegen/embedding_forward_template_helpers.cuh
@@ -39,14 +39,6 @@
 #define SHFL_SYNC(val, srcLane) \
   shfl_sync(val, srcLane, kThreadGroupSize, shfl_sync_mask)
 
-#define MAKE_PTA(TENSOR, T, N, INDEX_NBITS) \
-  MAKE_PACKED_TENSOR_ACCESSOR_BASE(         \
-      func_name, TENSOR, T, N, at::RestrictPtrTraits, INDEX_NBITS)
-
-#define MAKE_PTA_ACC(TENSOR, T, N, INDEX_NBITS) \
-  MAKE_PACKED_TENSOR_ACCESSOR_ACC_TYPE_BASE(    \
-      func_name, TENSOR, T, N, at::RestrictPtrTraits, INDEX_NBITS)
-
 constexpr int32_t kCacheLocationMissing = -1;
 constexpr size_t kForwardMaxThreads = 512;
 

--- a/fbgemm_gpu/codegen/embedding_optimizer_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_optimizer_split_template.cu
@@ -19,8 +19,8 @@ template <
     int32_t kThreadGroupSize = kWarpSize,
     int32_t VEC_WIDTH
 >
-__global__ __launch_bounds__(kMaxThreads)
-void split_{{ optimizer }}_update_kernel(
+__global__ __launch_bounds__(kMaxThreads) void
+split_{{ optimizer }}_update_kernel(
     at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
     at::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> uvm_weights,
     at::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
@@ -58,12 +58,12 @@ void split_embedding_{{ optimizer }}_update(
     TENSOR_ON_CUDA_GPU(grad_dev_indices);
     TENSOR_ON_CUDA_GPU(weights_placements);
     TENSOR_ON_CUDA_GPU(weights_offsets);
-    {% for tensor in args.split_tensors %}
+    {%- for tensor in args.split_tensors %}
     TENSOR_ON_CUDA_GPU({{ tensor }}_dev);
     TENSOR_ON_CUDA_GPU({{ tensor }}_uvm);
     TENSOR_ON_CUDA_GPU({{ tensor }}_placements);
     TENSOR_ON_CUDA_GPU({{ tensor }}_offsets);
-    {% endfor %}
+    {%- endfor %}
 
     TENSORS_ON_SAME_DEVICE(dev_weights, uvm_weights);
     TENSORS_ON_SAME_DEVICE(dev_weights, lxu_cache_weights);
@@ -71,12 +71,12 @@ void split_embedding_{{ optimizer }}_update(
     TENSORS_ON_SAME_DEVICE(dev_weights, grad_dev_indices);
     TENSORS_ON_SAME_DEVICE(dev_weights, weights_placements);
     TENSORS_ON_SAME_DEVICE(dev_weights, weights_offsets);
-    {% for tensor in args.split_tensors %}
+    {%- for tensor in args.split_tensors %}
     TENSORS_ON_SAME_DEVICE(dev_weights, {{ tensor }}_dev);
     TENSORS_ON_SAME_DEVICE(dev_weights, {{ tensor }}_uvm);
     TENSORS_ON_SAME_DEVICE(dev_weights, {{ tensor }}_placements);
     TENSORS_ON_SAME_DEVICE(dev_weights, {{ tensor }}_offsets);
-    {% endfor %}
+    {%- endfor %}
 
     if (grad_dev_indices.numel() == 0) {
         return;
@@ -105,8 +105,8 @@ void split_embedding_{{ optimizer }}_update(
                     at::check_generator<at::CUDAGeneratorImpl>(gen)
                         ->philox_cuda_state(4);
             }
-            {% for kMaxElemPerThread in range(1, max_embedding_dim // (items_per_warp // 4) + 1) %}
-            {% if kMaxElemPerThread in [1, 2] or kMaxElemPerThread % 4 == 0 %}
+            {%- for kMaxElemPerThread in range(1, max_embedding_dim // (items_per_warp // 4) + 1) %}
+            {%- if kMaxElemPerThread in [1, 2] or kMaxElemPerThread % 4 == 0 %}
             if (max_D <= {{ items_per_warp // 4 * kMaxElemPerThread }}) {
                 // hipcc can't use max in constexpr
                 constexpr int kMaxVecsPerThread = {{ kMaxElemPerThread }} / 4 >= 1 ? {{ kMaxElemPerThread }} / 4 : 1;
@@ -142,8 +142,8 @@ void split_embedding_{{ optimizer }}_update(
                 C10_CUDA_KERNEL_LAUNCH_CHECK();
                 return;
             }
-            {% endif %}
-            {% endfor %}
+            {%- endif %}
+            {%- endfor %}
         }
     );
 }


### PR DESCRIPTION
Summary: - Clean up memchecks for TBE training (forward) to use the same macros as for all the other memchecks

Reviewed By: sryap

Differential Revision: D46815006

