### PR TITLE
Enable bf16 output in TBE CPU kernel for other input types

### DIFF
--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -4357,7 +4357,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         )
 
     @given(
-        nbit_weights_ty=st.sampled_from([SparseType.INT4, SparseType.INT2]),
+        nbit_weights_ty=get_nbit_weights_ty(),
         use_array_for_index_remapping=st.booleans(),
         do_pruning=st.booleans(),
     )

--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -80,7 +80,8 @@ GenerateEmbeddingSpMDM(
     int prefetch = 16,
     bool is_weight_positional = false,
     bool use_offsets = true,
-    bool isbf16 = false);
+    bool is_bf16_out = false,
+    bool is_bf16_in = false);
 
 /**
  * @param output_stride If -1, output_stride is same as block_size
@@ -112,7 +113,8 @@ GenerateEmbeddingSpMDMWithStrides(
     std::int64_t input_stride = -1,
     bool scale_bias_last = true,
     bool no_bag = false,
-    bool isbf16 = false);
+    bool is_bf16_out = false,
+    bool is_bf16_in = false);
 
 /**
  * @tparam IndexType can be int32_t or int64_t
@@ -195,7 +197,8 @@ GenerateEmbeddingSpMDMFP8WithStrides(
     std::int64_t output_stride = -1,
     std::int64_t input_stride = -1,
     int exponent_bits = 4,
-    int exponent_bias = 7);
+    int exponent_bias = 7,
+    bool is_bf16_out = false);
 
 template <
     typename InType,

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -238,7 +238,8 @@ FBGEMM_API bool EmbeddingSpMDM_ref(
     std::int64_t input_stride = -1,
     bool scale_bias_last = true,
     bool no_bag = false,
-    bool is_bf16_out = false);
+    bool is_bf16_out = false,
+    bool is_bf16_in = false);
 
 template <
     typename IndexType = std::int64_t,
@@ -283,7 +284,8 @@ bool EmbeddingSpMDMFP8_ref(
     int64_t output_stride = -1,
     int64_t input_stride = -1,
     int exponent_bits = 4,
-    int exponent_bias = 7);
+    int exponent_bias = 7,
+    bool is_bf16_out = false);
 
 template <
     typename InType = std::uint8_t,

--- a/test/EmbeddingSpMDMTestUtils.h
+++ b/test/EmbeddingSpMDMTestUtils.h
@@ -32,6 +32,9 @@ enum EmbeddingSpMDMDtypeChoice {
   BFLOAT16,
 };
 
+using EmbeddingSpMDMInputDtypeChoice = EmbeddingSpMDMDtypeChoice;
+using EmbeddingSpMDMOutputDtypeChoice = EmbeddingSpMDMDtypeChoice;
+
 /**
  * @return lengths_sum
  */


### PR DESCRIPTION
Summary: Enable bf16 output support in TBE CPU kernel when the input weight type is int8/fp8/fp16/fp32

Differential Revision: D47028021

