### PR TITLE
Register meta dispatcher for permute_pooled_embedding

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
@@ -102,6 +102,9 @@ inline bool torch_tensor_empty_or_on_cpu_check(
 #define DISPATCH_TO_CPU(name, function) \
   m.impl(name, torch::dispatch(c10::DispatchKey::CPU, TORCH_FN(function)))
 
+#define DISPATCH_TO_META(name, function) \
+  m.impl(name, torch::dispatch(c10::DispatchKey::Meta, TORCH_FN(function)))
+
 #define DISPATCH_TO_ALL(name, function) \
   m.impl(name, torch::dispatch(c10::DispatchKey::CatchAll, TORCH_FN(function)))
 

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops_gpu.cpp
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops_gpu.cpp
@@ -138,6 +138,15 @@ Tensor permute_pooled_embs_auto_grad_cpu(
       inv_offset_dim_list,
       inv_permute_list);
 }
+
+Tensor permute_pooled_embs_auto_grad_meta(
+    const Tensor& pooled_embs,
+    const Tensor& /* offset_dim_list */,
+    const Tensor& /* permute_list */,
+    const Tensor& /* inv_offset_dim_list */,
+    const Tensor& /* inv_permute_list */) {
+  return torch::empty_like(pooled_embs);
+}
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
@@ -152,4 +161,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   DISPATCH_TO_CUDA(
       "permute_pooled_embs_auto_grad",
       fbgemm_gpu::permute_pooled_embs_auto_grad_gpu);
+  DISPATCH_TO_META(
+      "permute_pooled_embs_auto_grad",
+      fbgemm_gpu::permute_pooled_embs_auto_grad_meta);
 }


### PR DESCRIPTION
Summary: Torch dynamo needs the meta dispatcher for graph capturing.

Differential Revision: D47064694

