### PR TITLE
Fix the hash_size_cumsum cond in TBE's init

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -432,7 +432,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         )
         hash_size_cumsum = [0] + list(accumulate(rows))
         self.total_hash_size: int = int(hash_size_cumsum[-1])
-        if hash_size_cumsum == 0:
+        if self.total_hash_size == 0:
             self.total_hash_size_bits: int = 0
         else:
             self.total_hash_size_bits: int = int(log2(float(self.total_hash_size)) + 1)


### PR DESCRIPTION
Summary:
This diff fixes `ValueError: math domain error` introduced by
D46618714

Reviewed By: q10

Differential Revision: D47236684

