### PR TITLE
Block the combination of bf16 input and float output in EmbeddingSpMDM when running on Mac and Windows

### DIFF
--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -1032,11 +1032,11 @@ typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType, outType>::
   if (!cpuinfo_initialize()) {
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(_WIN32)
   if (std::is_same<inType, uint16_t>::value && is_bf16_in &&
       std::is_same<outType, float>::value) {
     throw std::runtime_error(
-        "Bfloat16 input with float32 output is not yet supported on Apple");
+        "Bfloat16 input with float32 output is not yet supported on Apple or Windows");
   }
 #endif
   if (output_stride == -1) {

--- a/test/EmbeddingSpMDMTest.cc
+++ b/test/EmbeddingSpMDMTest.cc
@@ -145,7 +145,7 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
     return;
   }
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(_WIN32)
   if (in_type == BFLOAT16 && out_type == FLOAT) {
     return;
   }


### PR DESCRIPTION
Summary: Block the combination of bfloat16 input and float32 output in EmbeddingSpMDM API when running on Mac and Windows. This is to prevent a random test failure.

Reviewed By: q10

Differential Revision: D47306447

