### PR TITLE
Back out "Revert usage of TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL in histogram_binning_calibration_ops.cu"

### DIFF
--- a/fbgemm_gpu/src/histogram_binning_calibration_ops.cu
+++ b/fbgemm_gpu/src/histogram_binning_calibration_ops.cu
@@ -60,9 +60,8 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_cuda(
     double upper_bound,
     int64_t bin_ctr_in_use_after,
     double bin_ctr_weight_value) {
-  TENSOR_ON_CUDA_GPU(logit);
-  TENSOR_ON_CUDA_GPU(bin_num_examples);
-  TENSOR_ON_CUDA_GPU(bin_num_positives);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      logit, bin_num_examples, bin_num_positives);
   TORCH_CHECK_EQ(bin_num_examples.numel(), bin_num_positives.numel());
 
   at::cuda::OptionalCUDAGuard device_guard;
@@ -182,11 +181,12 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_by_feature_cuda(
     double upper_bound,
     int64_t bin_ctr_in_use_after,
     double bin_ctr_weight_value) {
-  TENSOR_ON_CUDA_GPU(logit);
-  TENSOR_ON_CUDA_GPU(segment_value);
-  TENSOR_ON_CUDA_GPU(segment_lengths);
-  TENSOR_ON_CUDA_GPU(bin_num_examples);
-  TENSOR_ON_CUDA_GPU(bin_num_positives);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      logit,
+      segment_value,
+      segment_lengths,
+      bin_num_examples,
+      bin_num_positives);
   TORCH_CHECK_EQ(bin_num_examples.numel(), bin_num_positives.numel());
 
   at::cuda::OptionalCUDAGuard device_guard;
@@ -341,11 +341,13 @@ generic_histogram_binning_calibration_by_feature_cuda(
     double positive_weight,
     int64_t bin_ctr_in_use_after,
     double bin_ctr_weight_value) {
-  TENSOR_ON_CUDA_GPU(logit);
-  TENSOR_ON_CUDA_GPU(segment_value);
-  TENSOR_ON_CUDA_GPU(segment_lengths);
-  TENSOR_ON_CUDA_GPU(bin_num_examples);
-  TENSOR_ON_CUDA_GPU(bin_num_positives);
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+      logit,
+      segment_value,
+      segment_lengths,
+      bin_num_examples,
+      bin_num_positives);
+  // TODO: This is broken internally
   TENSOR_ON_CUDA_GPU(bin_boundaries);
   TORCH_CHECK_EQ(bin_num_examples.numel(), bin_num_positives.numel());
   TORCH_CHECK(


### PR DESCRIPTION
Summary:
Original commit changeset: 787bd0f7e8d8

Original Phabricator Diff: D46923168

Reviewed By: singlaiiit

Differential Revision: D47158153

