### PR TITLE
Use floatCloseAll for SparseAdagradTest

### DIFF
--- a/test/SparseAdagradTest.cc
+++ b/test/SparseAdagradTest.cc
@@ -13,6 +13,7 @@
 
 #include <gtest/gtest.h>
 
+#include "TestUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "src/RefImplementations.h"
 
@@ -48,7 +49,7 @@ class SparseAdagradTest
     : public testing::TestWithParam<tuple<bool, int, bool, bool, bool>> {};
 }; // namespace
 
-constexpr float ABS_TOL = 1e-6;
+constexpr float DEFAULT_TOL = 1.0e-6;
 
 // Test:
 INSTANTIATE_TEST_CASE_P(
@@ -186,19 +187,11 @@ TEST_P(SparseAdagradTest, basicTest_two_stages) {
           counter_halflife);
     }
 
-    EXPECT_NEAR(ret_fbgemm, ret_ref, ABS_TOL)
+    EXPECT_EQ(ret_fbgemm, ret_ref)
         << "return vals differ, reference is: " << ret_ref
         << " ,fbgemm is: " << ret_fbgemm;
-    for (size_t i = 0; i < h.size(); ++i) {
-      EXPECT_NEAR(h[i], h_ref[i], ABS_TOL)
-          << "results for h differ at (" << i << ") reference: " << h_ref[i]
-          << ", FBGEMM: " << h[i] << " emb dim :" << block_size;
-    }
-    for (size_t i = 0; i < w.size(); ++i) {
-      EXPECT_NEAR(w[i], w_ref[i], ABS_TOL)
-          << "results for h differ at (" << i << ") reference: " << w_ref[i]
-          << ", FBGEMM: " << w[i] << " emb dim :" << block_size;
-    }
+    EXPECT_TRUE(floatCloseAll(h, h_ref, DEFAULT_TOL, DEFAULT_TOL));
+    EXPECT_TRUE(floatCloseAll(w, w_ref, DEFAULT_TOL, DEFAULT_TOL));
   }
 }
 
@@ -324,20 +317,12 @@ TEST_P(SparseAdagradTest, rowwiseTest_two_stages) {
           counter_halflife);
     }
 
-    EXPECT_NEAR(ret_fbgemm, ret_ref, ABS_TOL)
+    EXPECT_EQ(ret_fbgemm, ret_ref)
         << "return vals differ, reference is: " << ret_ref
         << " ,fbgemm is: " << ret_fbgemm;
-    for (size_t i = 0; i < h.size(); ++i) {
-      // Set the absolute tolerance of rowwise momentum to 1e-3 because it a
-      // product of square, add, div which the rounding error can be very high
-      EXPECT_NEAR(h[i], h_ref[i], 1e-3)
-          << "results for h differ at (" << i << ") reference: " << h_ref[i]
-          << ", FBGEMM: " << h[i] << " emb dim :" << block_size;
-    }
-    for (size_t i = 0; i < w.size(); ++i) {
-      EXPECT_NEAR(w[i], w_ref[i], ABS_TOL)
-          << "results for w differ at (" << i << ") reference: " << w_ref[i]
-          << ", FBGEMM: " << w[i] << " emb dim :" << block_size;
-    }
+    // Set the absolute tolerance of rowwise momentum to 1e-3 because it a
+    // product of square, add, div which the rounding error can be very high
+    EXPECT_TRUE(floatCloseAll(h, h_ref, 1.0e-3, 1.0e-3));
+    EXPECT_TRUE(floatCloseAll(w, w_ref, DEFAULT_TOL, DEFAULT_TOL));
   }
 }

--- a/test/TestUtils.cc
+++ b/test/TestUtils.cc
@@ -87,4 +87,79 @@ check_all_zero_entries<int32_t>(const int32_t* test, int m, int n);
 template bool
 check_all_zero_entries<uint8_t>(const uint8_t* test, int m, int n);
 
+// atol: absolute tolerance. <=0 means do not consider atol.
+// rtol: relative tolerance. <=0 means do not consider rtol.
+template <>
+::testing::AssertionResult floatCloseAll<float, float>(
+    const std::vector<float>& a,
+    const std::vector<float>& b,
+    const float atol,
+    const float rtol) {
+  std::stringstream ss;
+  bool match = true;
+  if (a.size() != b.size()) {
+    ss << " size mismatch ";
+    match = false;
+  }
+  if (!match) {
+    return ::testing::AssertionFailure()
+        << " results do not match. " << ss.str();
+  }
+  for (size_t i = 0; i < a.size(); i++) {
+    const bool consider_absDiff = atol > 0;
+    const bool consider_relDiff = rtol > 0 &&
+        std::fabs(a[i]) > std::numeric_limits<float>::epsilon() &&
+        std::fabs(b[i]) > std::numeric_limits<float>::epsilon();
+
+    const float absDiff = std::fabs(a[i] - b[i]);
+    const float relDiff = absDiff / std::fabs(a[i]);
+
+    if (consider_absDiff && consider_relDiff) {
+      match = absDiff <= atol || relDiff <= rtol;
+    } else if (consider_absDiff) {
+      match = absDiff <= atol;
+    } else if (consider_relDiff) {
+      match = relDiff <= rtol;
+    }
+    if (!match) {
+      ss << " mismatch at (" << i << ") " << std::endl;
+      ss << "\t  ref: " << a[i] << " test: " << b[i] << std::endl;
+      if (consider_absDiff) {
+        ss << "\t absolute diff: " << absDiff << " > " << atol << std::endl;
+      }
+      if (consider_relDiff) {
+        ss << "\t relative diff: " << relDiff << " > " << rtol << std::endl;
+      }
+      return ::testing::AssertionFailure()
+          << " results do not match. " << ss.str();
+    }
+  }
+  return ::testing::AssertionSuccess();
+}
+
+template <>
+::testing::AssertionResult floatCloseAll<float, float16>(
+    const std::vector<float>& a,
+    const std::vector<float16>& b,
+    const float atol,
+    const float rtol) {
+  std::vector<float> b_float(b.size());
+  const auto transform = [](float16 input) { return cpu_half2float(input); };
+  std::transform(b.begin(), b.end(), b_float.begin(), transform);
+  return floatCloseAll(a, b_float, atol, rtol);
+}
+
+template <>
+::testing::AssertionResult floatCloseAll<float16, float16>(
+    const std::vector<float16>& a,
+    const std::vector<float16>& b,
+    const float atol,
+    const float rtol) {
+  std::vector<float> a_float(a.size());
+  std::vector<float> b_float(b.size());
+  const auto transform = [](float16 input) { return cpu_half2float(input); };
+  std::transform(a.begin(), a.end(), a_float.begin(), transform);
+  std::transform(b.begin(), b.end(), b_float.begin(), transform);
+  return floatCloseAll(a_float, b_float, atol, rtol);
+}
 } // namespace fbgemm

--- a/test/TestUtils.h
+++ b/test/TestUtils.h
@@ -7,6 +7,7 @@
  */
 
 #pragma once
+#include <gtest/gtest.h>
 #include <cmath>
 #include <vector>
 
@@ -31,5 +32,14 @@ int compare_validate_buffers(
  */
 template <typename T>
 bool check_all_zero_entries(const T* test, int m, int n);
+
+// atol: absolute tolerance. <=0 means do not consider atol.
+// rtol: relative tolerance. <=0 means do not consider rtol.
+template <typename a_T, typename b_T>
+::testing::AssertionResult floatCloseAll(
+    const std::vector<a_T>& a,
+    const std::vector<b_T>& b,
+    const float atol = std::numeric_limits<float>::epsilon(),
+    const float rtol = 0);
 
 } // namespace fbgemm


### PR DESCRIPTION
Summary:
Replace `EXPECT_NEAR` with `floatCloseAll` to compare results with
both absolute and relative tolerances

Reviewed By: brad-mengchi, jianyuh, r-barnes, shintaro-iwasaki

Differential Revision: D47382447

