### PR TITLE
Add early exit in permute ops when B and T == 0

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_permute_1d.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute_1d.cu
@@ -82,6 +82,12 @@ permute_1D_sparse_data_cuda(
   const auto lengths_size = lengths.numel();
 
   const auto permuted_lengths_size = permute.numel();
+
+  if (permuted_lengths_size == 0 || lengths_size == 0) {
+    // Permutation will not be performed.  Return the input tensors
+    return {lengths.view({-1}), indices, weights};
+  }
+
   Tensor permuted_lengths;
   Tensor permuted_indices;
   Tensor permuted_weights;

--- a/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
@@ -88,6 +88,16 @@ permute_2D_sparse_data_cuda(
   const auto T = permute.numel();
   const auto B = lengths.size(1);
 
+  if (T == 0 || B == 0) {
+    // When T = 0 or B = 0, permutation will not be performed.  Return the
+    // input tensors.
+    return {
+        lengths,
+        indices,
+        weights,
+    };
+  }
+
   Tensor permuted_lengths;
   Tensor permuted_indices;
   Tensor permuted_weights;


### PR DESCRIPTION
Summary:
This diff adds an early exit in `permute_[1|2]D_sparse_data` when the
sizes of input tensors are zeors.  In such cases, the ops return the
input tensors as outputs because permutation will not be performed.

Reviewed By: jianyuh

Differential Revision: D47452714

