### PR TITLE
TBE UVM cache line locking - backend

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh
@@ -32,7 +32,9 @@ std::pair<at::Tensor, at::Tensor> lru_cache_find_uncached_cuda(
     int64_t time_stamp,
     at::Tensor lru_state,
     bool gather_cache_stats,
-    at::Tensor uvm_cache_stats);
+    at::Tensor uvm_cache_stats,
+    bool lock_cache_line,
+    at::Tensor lxu_cache_locking_counter);
 
 ///@ingroup table-batched-embed-cuda
 /// Map index to cache_set. h_in: linear_indices; C: #cache_sets.
@@ -71,7 +73,9 @@ void lru_cache_populate_cuda(
     at::Tensor lru_state,
     bool stochastic_rounding,
     bool gather_cache_stats,
-    c10::optional<at::Tensor> uvm_cache_stats);
+    c10::optional<at::Tensor> uvm_cache_stats,
+    bool lock_cache_line,
+    c10::optional<at::Tensor> lxu_cache_locking_counter);
 
 ///@ingroup table-batched-embed-cuda
 /// LRU cache: fetch the rows corresponding to `linear_cache_indices` from
@@ -206,3 +210,17 @@ void reset_weight_momentum_cuda(
     at::Tensor cache_hash_size_cumsum,
     at::Tensor lxu_cache_state,
     int64_t total_cache_hash_size);
+
+///@ingroup table-batched-embed-cuda
+/// Decrement the LRU/LFU cache counter based on lxu_cache_locations.
+void lxu_cache_locking_counter_decrement_cuda(
+    at::Tensor lxu_cache_locking_counter,
+    at::Tensor lxu_cache_locations);
+
+///@ingroup table-batched-embed-cuda
+/// Inplace update lxu_cache_locations to the new one
+/// should only update if lxu_cache_locations[i] == -1
+/// and lxu_cache_locations_new[i] >= 0
+void lxu_cache_locations_update_cuda(
+    at::Tensor lxu_cache_locations,
+    at::Tensor lxu_cache_locations_new);

--- a/fbgemm_gpu/src/split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/split_table_batched_embeddings.cpp
@@ -25,7 +25,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "linearize_cache_indices_from_row_idx",
       linearize_cache_indices_from_row_idx_cuda);
   m.def(
-      "lru_cache_populate(Tensor weights, Tensor hash_size_cumsum, int total_cache_hash_size, Tensor cache_index_table_map, Tensor weights_offsets, Tensor D_offsets, Tensor linear_cache_indices, Tensor(a!) lxu_cache_state, Tensor(b!) lxu_cache_weights, int time_stamp, Tensor(c!) lru_state, bool stochastic_rounding, bool gather_cache_stats=False, Tensor(d!)? uvm_cache_stats=None) -> ()");
+      "lru_cache_populate(Tensor weights, Tensor hash_size_cumsum, int total_cache_hash_size, Tensor cache_index_table_map, Tensor weights_offsets, Tensor D_offsets, Tensor linear_cache_indices, Tensor(a!) lxu_cache_state, Tensor(b!) lxu_cache_weights, int time_stamp, Tensor(c!) lru_state, bool stochastic_rounding, bool gather_cache_stats=False, Tensor(d!)? uvm_cache_stats=None, bool lock_cache_line=False, Tensor(e!)? lxu_cache_locking_counter=None) -> ()");
   DISPATCH_TO_CUDA("lru_cache_populate", lru_cache_populate_cuda);
   m.def(
       "lru_cache_populate_byte(Tensor weights, Tensor hash_size_cumsum, int total_cache_hash_size, Tensor cache_index_table_map, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, Tensor linear_cache_indices, Tensor(a!) lxu_cache_state, Tensor(b!) lxu_cache_weights, int time_stamp, Tensor(c!) lru_state, int row_alignment=16, bool gather_cache_stats=False, Tensor(d!)? uvm_cache_stats=None) -> ()");
@@ -56,6 +56,15 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "reset_weight_momentum(Tensor dev_weights, Tensor uvm_weights, Tensor lxu_cache_weights, Tensor weights_placements, Tensor weights_offsets, Tensor momentum1_dev, Tensor momentum1_uvm, Tensor momentum1_placements, Tensor momentum1_offsets, Tensor D_offsets, Tensor pruned_indices, Tensor pruned_indices_offsets, Tensor logical_table_ids, Tensor buffer_ids, Tensor cache_hash_size_cumsum, Tensor lxu_cache_state, int total_cache_hash_size) -> ()");
   DISPATCH_TO_CUDA("reset_weight_momentum", reset_weight_momentum_cuda);
+  m.def(
+      "lxu_cache_locking_counter_decrement(Tensor(a!) lxu_cache_locking_counter, Tensor lxu_cache_locations) -> ()");
+  DISPATCH_TO_CUDA(
+      "lxu_cache_locking_counter_decrement",
+      lxu_cache_locking_counter_decrement_cuda);
+  m.def(
+      "lxu_cache_locations_update(Tensor(a!) lxu_cache_locations, Tensor lxu_cache_locations_new) -> ()");
+  DISPATCH_TO_CUDA(
+      "lxu_cache_locations_update", lxu_cache_locations_update_cuda);
 }
 
 } // namespace

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache_cuda.cu
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache_cuda.cu
@@ -253,6 +253,8 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> ssd_cache_populate_actions_cuda(
   // Find uncached indices
   Tensor uvm_cache_stats =
       at::empty({0}, linear_indices.options().dtype(at::kInt));
+  Tensor lxu_cache_locking_counter =
+      at::empty({0, 0}, lxu_cache_state.options().dtype(at::kInt));
   auto cache_sets_and_unique_indices = lru_cache_find_uncached_cuda(
       unique_indices,
       unique_indices_length,
@@ -261,7 +263,9 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> ssd_cache_populate_actions_cuda(
       time_stamp,
       lru_state,
       false, // gather_cache_stats
-      uvm_cache_stats);
+      uvm_cache_stats,
+      false, // lock_cache_line
+      lxu_cache_locking_counter);
   auto sorted_cache_sets = cache_sets_and_unique_indices.first;
   auto cache_set_sorted_unique_indices = cache_sets_and_unique_indices.second;
   TORCH_DSA_KERNEL_LAUNCH(


### PR DESCRIPTION
Summary:
This diff is to support cache prefetch pipeline, where cache insert can execute in parallel with embedding table forward/backward. As cache prefetch may evict cache lines, we must make sure that cache lines that are used by forward/backward won't be evicted.

The implementation here targets at training kernel and LRU cache policy. We create a `lxu_cache_locking_counter` of size `(cache_sets, warp_size)` to indicate whether a cache slot is in use (`counter > 0`) or not (`counter = 0`).

Operations on `lxu_cache_locking_counter`:

In `lru_cache_find_uncached_cuda`, if an index is already in cache, the `lxu_cache_locking_counter` of the corresponding cache_slot is incremented.

In `lru_cache_insert_cuda`, we first sort the cache slots based on timestamp within a cache set as the original LRU implementation. When inserting, we check whether the `lxu_cache_locking_counter` of each cache slot to insert is positive of not. If the counter of a cache slot is positive, we skip inserting and move on to next cache slot. If a cache slot is inserted, the `lxu_cache_locking_counter` of that slot is incremented.

After the backward pass is done, we call `lxu_cache_locking_counter_decrement` through a backward hook. For any cache_slot in lxu_cache_locations, the counter of that cache_slot is decremented by 1. Duplicate cache_slots only get decrement once.

With pipeline,  in the case that the same index is not inserted into cache in batch_i, but it is inserted in batch_{i+1}, the cache can be invalid in the sense that the cached weight for this index does not have the backward update of batch_i.

Example of the issue is as follows:

```
        idx is in batch_i, batch_{i+1}
        prefetch(batch_i)
          - failed to insert idx into cache, cache_locations_batch_i of idx is -1 (cache miss)
        forward(batch_i)
        prefetch(batch_{i+1})
          - insert idx into cache, cache is loaded from host memory
        backward(batch_i)
          - cache_locations_batch_i of idx is -1, the host memory is updated
        forward(batch_{i+1})
          - OUTPUT IS WRONG. the weight for idx is fetched from cache, but the cache is outdated.
```

The fix to this cache invalidation is to update the cache_locations_batch_i before backward of batch_i,so that the cache gets updated correctly by the backward pass of TBE.

Reviewed By: sryap

Differential Revision: D46172802

