### PR TITLE
Compute hash size cumsum and enable dedup across multiple keys

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -1679,7 +1679,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "jagged_slice_forward(Tensor x_values, Tensor x_lengths, Tensor src_start, Tensor output_lengths, Tensor tgt_start, int num_output_rows, int slice_length, bool fill_zeros) -> Tensor");
   m.def(
-      "jagged_unique_indices(Tensor hash_size_cumsum, Tensor offsets, Tensor indices) -> (Tensor, Tensor, Tensor)");
+      "jagged_unique_indices(Tensor hash_size_cumsum, Tensor hash_size_offsets, Tensor offsets, Tensor indices) -> (Tensor, Tensor, Tensor, Tensor)");
+  m.def(
+      "jagged_hash_size_cumsum(Tensor offsets, Tensor indices, int batch_size) -> (Tensor, Tensor)");
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {


### PR DESCRIPTION
Summary:
Two additional functionalities:

- Compute hash size cum sum: When dedup happens within a key, the hash size cum sum can be computed  from only offsets and indices for the usage of jagged_unique_indices.

- Multiple keys share the same hash size cum sum: In EmbeddingCollection, some keys could share the same embedding table, thus indices across these keys can also be deduplicated.

Differential Revision: D47725785

