### PR TITLE
add FP8RowwiseQuantizedToFloat meta

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -556,6 +556,7 @@ set(fbgemm_gpu_sources_static_cpu
     src/input_combine_cpu.cpp
     src/layout_transform_ops_cpu.cpp
     src/quantize_ops/quantize_ops_cpu.cpp
+    src/quantize_ops/quantize_ops_meta.cpp
     src/sparse_ops/sparse_ops_cpu.cpp
     src/sparse_ops/sparse_ops_meta.cpp
     src/embedding_inplace_update_cpu.cpp)

--- a/fbgemm_gpu/src/quantize_ops/quantize_ops_meta.cpp
+++ b/fbgemm_gpu/src/quantize_ops/quantize_ops_meta.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <torch/library.h>
+
+#include "fbgemm_gpu/sparse_ops.h"
+#include "fbgemm_gpu/sparse_ops_utils.h"
+
+using Tensor = at::Tensor;
+
+namespace fbgemm_gpu {
+
+///@ingroup quantize-data-meta
+Tensor FP8rowwise_to_float_meta(
+    const Tensor& input,
+    [[maybe_unused]] bool forward) {
+  TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
+
+  const auto input_sizes = input.sizes();
+  const auto last_dim = input_sizes.size() - 1;
+  const int ncols = input_sizes[last_dim];
+  const int ncols_aligned = (ncols + 4 - 1) / 4 * 4;
+  const int output_columns = ncols_aligned - 2 * sizeof(float);
+
+  auto output_dims = input_sizes.vec();
+  output_dims[last_dim] = output_columns;
+  return at::empty(output_dims, input.options().dtype(at::kFloat));
+}
+
+} // namespace fbgemm_gpu
+
+TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
+  m.impl(
+      "FP8RowwiseQuantizedToFloat",
+      TORCH_FN(fbgemm_gpu::FP8rowwise_to_float_meta));
+}


### PR DESCRIPTION
Summary:
needed by PT2 adoption in IG-CTR FIRST where dynamo graph breaks happened at unsupported op fbgemm.FP8RowwiseQuantizedToFloat.default
https://www.internalfb.com/manifold/explorer/pyper_traces/tree/torchinductor_traces/f460142279-TrainingApplication/3953

add meta function according to
https://www.internalfb.com/code/fbsource/[6a410f90e6be]/fbcode/deeplearning/fbgemm/fbgemm_gpu/src/quantize_ops/quantize_fp8_rowwise.cu?lines=336-340

Differential Revision: D47741164

