### PR TITLE
Add batch_index_select_dim0 (w/ TBE backend)

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -217,9 +217,16 @@ set(gen_gpu_kernel_source_files
     "gen_embedding_forward_split_unweighted_codegen_cuda.cu"
     "gen_embedding_backward_dense_indice_weights_codegen_cuda.cu"
     "gen_embedding_backward_split_indice_weights_codegen_cuda.cu"
-    "gen_embedding_backward_split_grad.cu"
     "gen_embedding_forward_split_weighted_vbe_codegen_cuda.cu"
-    "gen_embedding_forward_split_unweighted_vbe_codegen_cuda.cu")
+    "gen_embedding_forward_split_unweighted_vbe_codegen_cuda.cu"
+    "gen_batch_index_select_dim0_forward_codegen_cuda.cu"
+    "gen_batch_index_select_dim0_forward_kernel.cu"
+    "gen_batch_index_select_dim0_forward_kernel_small.cu"
+    "gen_batch_index_select_dim0_backward_codegen_cuda.cu"
+    "gen_batch_index_select_dim0_backward_kernel_cta.cu"
+    "gen_batch_index_select_dim0_backward_kernel_warp.cu"
+    "gen_embedding_backward_split_grad.cu"
+)
 
 if(NOT USE_ROCM)
   list(APPEND gen_gpu_kernel_source_files
@@ -559,7 +566,8 @@ set(fbgemm_gpu_sources_static_cpu
     src/quantize_ops/quantize_ops_meta.cpp
     src/sparse_ops/sparse_ops_cpu.cpp
     src/sparse_ops/sparse_ops_meta.cpp
-    src/embedding_inplace_update_cpu.cpp)
+    src/embedding_inplace_update_cpu.cpp
+    codegen/batch_index_select_dim0_cpu_host.cpp)
 
 if(NOT FBGEMM_CPU_ONLY)
   list(APPEND fbgemm_gpu_sources_static_cpu
@@ -576,7 +584,8 @@ if(NOT FBGEMM_CPU_ONLY)
     src/split_table_batched_embeddings.cpp
     src/metric_ops_host.cpp
     src/embedding_inplace_update_gpu.cpp
-    src/input_combine_gpu.cpp)
+    src/input_combine_gpu.cpp
+    codegen/batch_index_select_dim0_host.cpp)
 
   if(NVML_LIB_PATH)
     message(STATUS "Found NVML_LIB_PATH: ${NVML_LIB_PATH}")

--- a/fbgemm_gpu/codegen/batch_index_select_dim0_cpu_host.cpp
+++ b/fbgemm_gpu/codegen/batch_index_select_dim0_cpu_host.cpp
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/TypeDefault.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <torch/script.h>
+
+#include "fbgemm_gpu/embedding_common.h"
+#include "fbgemm_gpu/sparse_ops.h"
+#include "fbgemm_gpu/sparse_ops_utils.h"
+
+using Tensor = at::Tensor;
+using namespace fbgemm_gpu;
+
+class BatchIndexSelectDim0CPUOp
+    : public torch::autograd::Function<BatchIndexSelectDim0CPUOp> {
+ public:
+  static torch::autograd::variable_list forward(
+      torch::autograd::AutogradContext* ctx,
+      const Tensor& inputs,
+      const Tensor& indices,
+      const std::vector<int64_t>& input_num_indices,
+      const std::vector<int64_t>& input_rows,
+      const std::vector<int64_t>& input_columns,
+      const bool permute_output_dim_0_1) {
+    const int64_t num_inputs = input_num_indices.size();
+    ctx->save_for_backward({indices});
+
+    ctx->saved_data["input_numel"] = inputs.numel();
+    ctx->saved_data["input_num_indices"] = input_num_indices;
+    ctx->saved_data["input_rows"] = input_rows;
+    ctx->saved_data["input_columns"] = input_columns;
+    ctx->saved_data["permute_output_dim_0_1"] = permute_output_dim_0_1;
+
+    // Early exit
+    if (inputs.numel() == 0) {
+      return {at::empty({0}, inputs.options())};
+    }
+
+    // Compute section sizes for splitting tensors
+    std::vector<int64_t> input_numels;
+    std::vector<int64_t> indices_numels;
+    input_numels.reserve(num_inputs);
+    indices_numels.reserve(num_inputs);
+    for (auto i = 0; i < num_inputs; i++) {
+      input_numels.push_back(input_rows[i] * input_columns[i]);
+      indices_numels.push_back(input_num_indices[i]);
+    }
+
+    ctx->saved_data["indices_numels"] = indices_numels;
+
+    // Split tensors into vectors
+    const auto inputs_ = at::split_with_sizes(inputs, input_numels, 0);
+    const auto indices_ = at::split_with_sizes(indices, indices_numels, 0);
+
+    std::vector<Tensor> outputs;
+    outputs.reserve(num_inputs);
+    for (auto i = 0; i < num_inputs; i++) {
+      const auto input = inputs_[i].view({input_rows[i], input_columns[i]});
+      const auto index = indices_[i];
+      const auto output = at::index_select(input, 0, index);
+      if (permute_output_dim_0_1) {
+        outputs.push_back(output);
+      } else {
+        outputs.push_back(output.flatten());
+      }
+    }
+
+    // permute_output_dim_0_1 = true shape: (batch_size, num_inputs, cols)
+    // permute_output_dim_0_1 = false shape: (num_inputs, batch_size cols)
+    return {at::concat(outputs, permute_output_dim_0_1 ? 1 : 0).flatten()};
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext* ctx,
+      torch::autograd::variable_list grad_outputs) {
+    using torch::autograd::Variable;
+
+    TORCH_CHECK_EQ(grad_outputs.size(), 1);
+
+    const auto grad_output = grad_outputs[0];
+    const auto input_numel = ctx->saved_data["input_numel"].toInt();
+
+    // Early exit
+    if (input_numel == 0) {
+      return {
+          at::empty({0}, grad_output.options()),
+          Variable(), // indices
+          Variable(), // input_num_indices
+          Variable(), // input_rows
+          Variable(), // input_columns
+          Variable() // permute_output_dim_0_1
+      };
+    }
+
+    const auto saved = ctx->get_saved_variables();
+    auto indices = *std::begin(saved);
+
+    const auto input_num_indices =
+        ctx->saved_data["input_num_indices"].toIntVector();
+    const auto input_rows = ctx->saved_data["input_rows"].toIntVector();
+    const auto input_cols = ctx->saved_data["input_columns"].toIntVector();
+    const auto permute_output_dim_0_1 =
+        ctx->saved_data["permute_output_dim_0_1"].toBool();
+    const auto indices_numels = ctx->saved_data["indices_numels"].toIntVector();
+
+    const int64_t num_inputs = input_num_indices.size();
+
+    std::vector<Tensor> grads;
+    if (permute_output_dim_0_1) {
+      grads = at::split_with_sizes(
+          grad_output.view({input_num_indices[0], -1}), input_cols, 1);
+    } else {
+      std::vector<int64_t> grad_numels;
+      grad_numels.reserve(num_inputs);
+      for (auto i = 0; i < num_inputs; i++) {
+        grad_numels.push_back(input_num_indices[i] * input_cols[i]);
+      }
+      grads = at::split_with_sizes(grad_output, grad_numels, 0);
+    }
+
+    const auto indices_ = at::split_with_sizes(indices, indices_numels, 0);
+
+    std::vector<Tensor> grad_inputs;
+    grad_inputs.reserve(num_inputs);
+    for (auto i = 0; i < num_inputs; i++) {
+      const auto num_indices = input_num_indices[i];
+      const auto grad_input =
+          at::zeros({input_rows[i], input_cols[i]}, grad_output.options());
+      const auto grad =
+          permute_output_dim_0_1 ? grads[i] : grads[i].view({num_indices, -1});
+      grad_inputs.push_back(
+          at::index_add(grad_input, 0, indices_[i], grad).flatten());
+    }
+
+    return {
+        at::concat(grad_inputs, 0),
+        Variable(), // indices
+        Variable(), // input_num_indices
+        Variable(), // input_rows
+        Variable(), // input_columns
+        Variable() // permute_output_dim_0_1
+    };
+  }
+};
+
+Tensor batch_index_select_dim0_cpu(
+    Tensor inputs,
+    Tensor indices,
+    std::vector<int64_t> input_num_indices,
+    std::vector<int64_t> input_rows,
+    std::vector<int64_t> input_columns,
+    // Permute dim 0 and 1 of the output tensor
+    const bool permute_output_dim_0_1) {
+  const int64_t num_inputs = input_num_indices.size();
+  TORCH_CHECK(
+      num_inputs == static_cast<int64_t>(input_rows.size()),
+      "[batch_index_select_dim0] input_rows must have the same length as "
+      "input_num_indices.");
+  TORCH_CHECK(
+      num_inputs == static_cast<int64_t>(input_columns.size()),
+      "[batch_index_select_dim0] input_columns must have the same length as "
+      "input_num_indices.");
+
+  TORCH_CHECK(
+      reinterpret_cast<uint64_t>(inputs.data_ptr()) % 16 == 0,
+      "Currently batch_index_select only supports 16-byte align input tensors");
+
+  const auto int_opts = torch::TensorOptions().dtype(torch::kInt64);
+  const auto num_cols =
+      torch::from_blob(input_columns.data(), {num_inputs}, int_opts);
+  const auto input_num_rows =
+      torch::from_blob(input_rows.data(), {num_inputs}, int_opts);
+  const auto output_num_rows =
+      torch::from_blob(input_num_indices.data(), {num_inputs}, int_opts);
+
+  if (num_inputs > 0) {
+    TORCH_CHECK(
+        torch::all(torch::gt(num_cols, 0)).item<bool>(),
+        "[batch_index_select_dim0] All input_columns must be the same.");
+    TORCH_CHECK(
+        torch::all(torch::gt(input_num_rows, 0)).item<bool>(),
+        "[batch_index_select_dim0] All input_rows must be the same.");
+    if (permute_output_dim_0_1) {
+      // All output rows must be the same
+      TORCH_CHECK(input_num_indices[0] > 0);
+      TORCH_CHECK(
+          torch::all(torch::eq(output_num_rows, input_num_indices[0]))
+              .item<bool>(),
+          "[batch_index_select_dim0] All input_num_indices must be the same if "
+          "permute_output_dim_0_1 is true.");
+    } else {
+      TORCH_CHECK(
+          torch::all(torch::gt(output_num_rows, 0)).item<bool>(),
+          "[batch_index_select_dim0] All input_num_indices must be greater than zero.");
+    }
+  }
+
+  return BatchIndexSelectDim0CPUOp::apply(
+      inputs,
+      indices,
+      input_num_indices,
+      input_rows,
+      input_columns,
+      permute_output_dim_0_1)[0];
+}
+
+// Deprecated for fb namespace! Please use fbgemm namespace instead!
+TORCH_LIBRARY_FRAGMENT(fb, m) {
+  m.def(
+      "batch_index_select_dim0("
+      "    Tensor inputs,"
+      "    Tensor indices,"
+      "    int[] input_num_indices,"
+      "    int[] input_rows,"
+      "    int[] input_columns,"
+      "    bool permute_output_dim_0_1=False) -> Tensor");
+  DISPATCH_TO_CPU("batch_index_select_dim0", batch_index_select_dim0_cpu);
+}
+
+TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  m.def(
+      "batch_index_select_dim0("
+      "    Tensor inputs,"
+      "    Tensor indices,"
+      "    int[] input_num_indices,"
+      "    int[] input_rows,"
+      "    int[] input_columns,"
+      "    bool permute_output_dim_0_1=False) -> Tensor");
+  DISPATCH_TO_CPU("batch_index_select_dim0", batch_index_select_dim0_cpu);
+}

--- a/fbgemm_gpu/codegen/batch_index_select_dim0_host.cpp
+++ b/fbgemm_gpu/codegen/batch_index_select_dim0_host.cpp
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/TypeDefault.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <torch/script.h>
+
+#include "fbgemm_gpu/embedding_common.h"
+#include "fbgemm_gpu/sparse_ops.h"
+#include "fbgemm_gpu/sparse_ops_utils.h"
+
+using Tensor = at::Tensor;
+using namespace fbgemm_gpu;
+
+Tensor batch_index_select_dim0_codegen_forward_cuda(
+    Tensor dev_weights,
+    Tensor weights_offsets,
+    Tensor D_offsets,
+    int64_t max_D,
+    Tensor indices,
+    int64_t output_dtype,
+    const Tensor& output_offsets,
+    const Tensor& total_L_offsets,
+    const int64_t output_size,
+    const int32_t fixed_L_per_warp,
+    const int32_t num_warps_per_feature,
+    const bool permute_output_dim_0_1);
+
+Tensor batch_index_select_dim0_codegen_backward_cuda(
+    Tensor grad_output,
+    Tensor dev_weights,
+    Tensor weights_offsets,
+    Tensor D_offsets,
+    int64_t max_D,
+    Tensor hash_size_cumsum,
+    int64_t total_hash_size_bits,
+    Tensor indices,
+    int64_t max_segment_length_per_warp,
+    const Tensor& grad_offsets,
+    const Tensor& total_L_offsets,
+    const int32_t fixed_L_per_warp,
+    const int32_t num_warps_per_feature,
+    const bool permute_output_dim_0_1);
+
+class BatchIndexSelectDim0GPUOp
+    : public torch::autograd::Function<BatchIndexSelectDim0GPUOp> {
+ public:
+  static torch::autograd::variable_list forward(
+      torch::autograd::AutogradContext* ctx,
+      const int64_t output_dtype,
+      const Tensor& dev_weights,
+      const Tensor& weights_offsets,
+      const Tensor& hash_size_cumsum,
+      const int64_t total_hash_size_bits,
+      const Tensor& indices,
+      const Tensor& D_offsets,
+      const int64_t max_D,
+      const Tensor& output_offsets,
+      const Tensor& total_L_offsets,
+      const int64_t output_size,
+      const int64_t fixed_L_per_warp,
+      const int64_t num_warps_per_feature,
+      const bool permute_output_dim_0_1) {
+    ctx->save_for_backward(
+        {dev_weights,
+         weights_offsets,
+         hash_size_cumsum,
+         indices,
+         D_offsets,
+         output_offsets,
+         total_L_offsets});
+
+    ctx->saved_data["max_D"] = max_D;
+    ctx->saved_data["total_hash_size_bits"] = total_hash_size_bits;
+    ctx->saved_data["fixed_L_per_warp"] = fixed_L_per_warp;
+    ctx->saved_data["num_warps_per_feature"] = num_warps_per_feature;
+    ctx->saved_data["permute_output_dim_0_1"] = permute_output_dim_0_1;
+
+    // Early exit
+    if (dev_weights.numel() == 0) {
+      return {at::empty({0}, dev_weights.options())};
+    }
+
+    return {batch_index_select_dim0_codegen_forward_cuda(
+        dev_weights,
+        weights_offsets,
+        D_offsets,
+        max_D,
+        indices,
+        output_dtype,
+        output_offsets,
+        total_L_offsets,
+        output_size,
+        fixed_L_per_warp,
+        num_warps_per_feature,
+        permute_output_dim_0_1)};
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext* ctx,
+      torch::autograd::variable_list grad_outputs) {
+    const auto saved = ctx->get_saved_variables();
+    auto savedItr = std::begin(saved);
+    auto dev_weights = *savedItr++;
+    auto weights_offsets = *savedItr++;
+    auto hash_size_cumsum = *savedItr++;
+    auto indices = *savedItr++;
+    auto D_offsets = *savedItr++;
+    auto grad_offsets = *savedItr++;
+    auto total_L_offsets = *savedItr++;
+
+    const auto max_D = ctx->saved_data["max_D"].toInt();
+    const auto total_hash_size_bits =
+        ctx->saved_data["total_hash_size_bits"].toInt();
+    const auto fixed_L_per_warp = ctx->saved_data["fixed_L_per_warp"].toInt();
+    const auto num_warps_per_feature =
+        ctx->saved_data["num_warps_per_feature"].toInt();
+    const auto permute_output_dim_0_1 =
+        ctx->saved_data["permute_output_dim_0_1"].toBool();
+
+    using torch::autograd::Variable;
+
+    Tensor grad_dev_weights;
+    if (dev_weights.numel() == 0) {
+      grad_dev_weights = at::empty({0}, dev_weights.options());
+    } else {
+      TORCH_CHECK_EQ(grad_outputs.size(), 1);
+
+      constexpr int32_t max_segment_length_per_warp = 32;
+
+      auto grad_output = grad_outputs[0];
+      // FIXME: to support aligned memory access in Vec4T load/store function
+      // 16 for FP32 and 8 for FP16
+      if (reinterpret_cast<uint64_t>(grad_output.data_ptr()) % 16 != 0) {
+        grad_output = at::empty_like(grad_output).copy_(grad_output);
+      }
+
+      grad_dev_weights = batch_index_select_dim0_codegen_backward_cuda(
+          grad_output,
+          dev_weights,
+          weights_offsets,
+          D_offsets,
+          max_D,
+          hash_size_cumsum,
+          total_hash_size_bits,
+          indices,
+          max_segment_length_per_warp,
+          grad_offsets,
+          total_L_offsets,
+          fixed_L_per_warp,
+          num_warps_per_feature,
+          permute_output_dim_0_1);
+    }
+
+    return {
+        Variable(), // output_dtype
+        grad_dev_weights, // grad_dev_weights
+        Variable(), // weights_offsets
+        Variable(), // hash_size_cumsum
+        Variable(), // total_hash_size_bits
+        Variable(), // indices
+        Variable(), // D_offsets
+        Variable(), // max_D
+        Variable(), // output_offsets
+        Variable(), // total_L_offsets
+        Variable(), // output_size
+        Variable(), // fixed_L_per_warp
+        Variable(), // num_warps_per_feature
+        Variable(), // permute_output_dim_0_1
+    };
+  }
+};
+
+Tensor batch_index_select_dim0_gpu(
+    Tensor inputs,
+    Tensor indices,
+    std::vector<int64_t> input_num_indices,
+    std::vector<int64_t> input_rows,
+    std::vector<int64_t> input_columns,
+    // Permute dim 0 and 1 of the output tensor
+    const bool permute_output_dim_0_1) {
+  // From the empirical study, this value provides the best perf
+  constexpr int64_t ROWS_PER_WARP = 1;
+  const int64_t num_inputs = input_num_indices.size();
+  TORCH_CHECK(
+      num_inputs == static_cast<int64_t>(input_rows.size()),
+      "[batch_index_select_dim0] input_rows must have the same length as "
+      "input_num_indices.");
+  TORCH_CHECK(
+      num_inputs == static_cast<int64_t>(input_columns.size()),
+      "[batch_index_select_dim0] input_columns must have the same length as "
+      "input_num_indices.");
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(inputs, indices);
+
+  TORCH_CHECK(
+      reinterpret_cast<uint64_t>(inputs.data_ptr()) % 16 == 0,
+      "Currently batch_index_select only supports 16-byte align input tensors");
+
+  const auto int_opts = torch::TensorOptions().dtype(torch::kInt64);
+  const auto num_cols =
+      torch::from_blob(input_columns.data(), {num_inputs}, int_opts);
+  const auto max_col = num_inputs > 0 ? num_cols.max().item<int64_t>() : 0;
+  const auto input_num_rows =
+      torch::from_blob(input_rows.data(), {num_inputs}, int_opts);
+  const auto output_num_rows =
+      torch::from_blob(input_num_indices.data(), {num_inputs}, int_opts);
+
+  if (num_inputs > 0) {
+    TORCH_CHECK(
+        torch::all(torch::gt(num_cols, 0)).item<bool>(),
+        "[batch_index_select_dim0] All input_columns must be the same.");
+    TORCH_CHECK(
+        torch::all(torch::gt(input_num_rows, 0)).item<bool>(),
+        "[batch_index_select_dim0] All input_rows must be the same.");
+    if (permute_output_dim_0_1) {
+      // All output rows must be the same
+      TORCH_CHECK(input_num_indices[0] > 0);
+      TORCH_CHECK(
+          torch::all(torch::eq(output_num_rows, input_num_indices[0]))
+              .item<bool>(),
+          "[batch_index_select_dim0] All input_num_indices must be the same if "
+          "permute_output_dim_0_1 is true.");
+    } else {
+      TORCH_CHECK(
+          torch::all(torch::gt(output_num_rows, 0)).item<bool>(),
+          "[batch_index_select_dim0] All input_num_indices must be greater than zero.");
+    }
+  }
+
+  const auto max_output_num_rows =
+      num_inputs > 0 ? output_num_rows.max().item<int64_t>() : 0;
+
+  const auto input_numels = input_num_rows * num_cols;
+  const auto output_numels =
+      permute_output_dim_0_1 ? Tensor() : (output_num_rows * num_cols);
+
+  // Takes ~1.2 ms for num_inputs = 1024 on CPU
+  auto D_offsets =
+      fbgemm_gpu::asynchronous_complete_cumsum_cpu(num_cols).to(torch::kInt32);
+  auto input_offsets =
+      fbgemm_gpu::asynchronous_complete_cumsum_cpu(input_numels);
+  auto input_row_offsets =
+      fbgemm_gpu::asynchronous_complete_cumsum_cpu(input_num_rows);
+  auto total_L_offsets =
+      fbgemm_gpu::asynchronous_complete_cumsum_cpu(output_num_rows);
+  int64_t total_hash_size_bits =
+      std::log2(static_cast<float>(input_row_offsets[-1].item<int64_t>())) + 1;
+  input_offsets = torch::narrow(input_offsets, 0, 0, input_offsets.numel() - 1);
+
+  const int64_t num_warps_per_input =
+      (max_output_num_rows + ROWS_PER_WARP - 1) / ROWS_PER_WARP;
+
+  // Transfer helper tensors to GPU
+  const auto device = inputs.device();
+  constexpr bool non_blocking = true;
+  D_offsets = D_offsets.to(device, non_blocking);
+  input_offsets = input_offsets.to(device, non_blocking);
+  input_row_offsets = input_row_offsets.to(device, non_blocking);
+  total_L_offsets = total_L_offsets.to(device, non_blocking);
+
+  int64_t output_size;
+  Tensor output_offsets;
+  if (permute_output_dim_0_1) {
+    // output_offsets is not required because the output tensor is not jagged
+    output_offsets = at::empty({0}, inputs.options().dtype(at::kLong));
+    output_size = num_inputs > 0
+        ? (input_num_indices[0] * D_offsets[-1].item<int64_t>())
+        : 0;
+  } else {
+    output_offsets =
+        fbgemm_gpu::asynchronous_complete_cumsum_cpu(output_numels);
+    output_size = output_offsets[-1].item<int64_t>();
+    output_offsets = output_offsets.to(device, non_blocking);
+  }
+
+  const auto sparse_type = fbgemm_gpu::getSparseType(inputs.scalar_type());
+  TORCH_CHECK(
+      sparse_type == SparseType::FP32 || sparse_type == SparseType::FP16,
+      "batch_index_select_dim0 supports only either float or half")
+
+  // Call TBE
+  return BatchIndexSelectDim0GPUOp::apply(
+      static_cast<int64_t>(fbgemm_gpu::getSparseType(inputs.scalar_type())),
+      inputs,
+      input_offsets,
+      input_row_offsets,
+      total_hash_size_bits,
+      indices,
+      D_offsets,
+      max_col,
+      output_offsets,
+      total_L_offsets,
+      output_size,
+      ROWS_PER_WARP, // fixed_L_per_warp
+      num_warps_per_input,
+      permute_output_dim_0_1)[0];
+}
+
+// Deprecated for fb namespace! Please use fbgemm namespace instead!
+TORCH_LIBRARY_FRAGMENT(fb, m) {
+  DISPATCH_TO_CUDA("batch_index_select_dim0", batch_index_select_dim0_gpu);
+}
+
+TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  DISPATCH_TO_CUDA("batch_index_select_dim0", batch_index_select_dim0_gpu);
+}

--- a/fbgemm_gpu/codegen/embedding_backward_split_grad_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_grad_template.cu
@@ -68,7 +68,7 @@ __global__ __launch_bounds__(kMaxThreads) void grad_mean{{ vbe_desc }}_kernel(
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
     const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> offsets,
     {% if vbe %}
-    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> grad_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> row_grad_offsets,
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> b_t_map,
     const int32_t info_B_num_bits,
     const uint32_t info_B_mask
@@ -102,7 +102,7 @@ __global__ __launch_bounds__(kMaxThreads) void grad_mean{{ vbe_desc }}_kernel(
   int32_t L = indices_end - indices_start;
 
   {% if vbe %}
-  const auto grad_offset = grad_offsets[b_t];
+  const auto grad_offset = row_grad_offsets[b_t];
   const auto grad_outer_offset = 0;
   {% else %}
   const auto grad_offset = D_start;
@@ -141,7 +141,7 @@ void grad_mean{{ vbe_desc }}_kernel
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
     const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> offsets,
     {% if vbe %}
-    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> grad_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> row_grad_offsets,
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> b_t_map,
     const int32_t info_B_num_bits,
     const uint32_t info_B_mask

--- a/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
@@ -285,7 +285,7 @@ class Split{{ "NoBag" if nobag else "" }}{{ "VBE" if vbe else "" }}LookupFunctio
         lxu_cache_locations,
         {% if vbe %}
         vbe_metadata.B_offsets,
-        vbe_metadata.output_offsets,
+        vbe_metadata.row_output_offsets,
         vbe_metadata.b_t_map,
         {% endif %}
         {{ args.split_saved_tensors | join(", ") }}
@@ -410,7 +410,7 @@ class Split{{ "NoBag" if nobag else "" }}{{ "VBE" if vbe else "" }}LookupFunctio
     auto lxu_cache_locations = *savedItr++;
     {% if vbe %}
     auto B_offsets = *savedItr++;
-    auto vbe_output_offsets = *savedItr++;
+    auto vbe_row_output_offsets = *savedItr++;
     auto vbe_b_t_map = *savedItr++;
     {% endif %}
 
@@ -470,7 +470,7 @@ class Split{{ "NoBag" if nobag else "" }}{{ "VBE" if vbe else "" }}LookupFunctio
     {% if vbe %}
     struct VBEMetadata vbe_metadata = {
       .B_offsets = B_offsets,
-      .output_offsets = vbe_output_offsets,
+      .row_output_offsets = vbe_row_output_offsets,
       .b_t_map = vbe_b_t_map,
     };
     {% endif %}

--- a/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_indice_weights_template.cu
@@ -43,7 +43,7 @@ __global__ __launch_bounds__(kForwardMaxThreads) void
     pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> feature_requires_grad, // [T],
     pta::PackedTensorAccessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits> grad_indice_weights,
     {%- if vbe %}
-    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> grad_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> row_grad_offsets,
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> b_t_map,
     const int32_t info_B_num_bits,
     const uint32_t info_B_mask
@@ -100,7 +100,7 @@ __global__ __launch_bounds__(kForwardMaxThreads) void
     {%- endif %}
 
     {%- if vbe %}
-    const grad_t* grad_output_ = &grad_output[0][grad_offsets[b_t]];
+    const grad_t* grad_output_ = &grad_output[0][row_grad_offsets[b_t]];
     {%- else %}
     const grad_t* grad_output_ = &grad_output[b][D_start];
     {%- endif %}
@@ -229,7 +229,7 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights
         lxu_cache_locations,
         {%- endif %}
         {%- if vbe %}
-        vbe_metadata.output_offsets,
+        vbe_metadata.row_output_offsets,
         vbe_metadata.b_t_map,
         {%- endif %}
         grad_output
@@ -300,7 +300,7 @@ Tensor {{ "dense" if dense else "split" }}_embedding_codegen_grad_indice_weights
                 MAKE_PTA_WITH_NAME(func_name, feature_requires_grad, int32_t, 1, 32),
                 MAKE_PTA_ACC_WITH_NAME(func_name, grad_indice_weights, grad_t, 1, 32),
                 {%- if vbe %}
-                MAKE_PTA_WITH_NAME(func_name, vbe_metadata.output_offsets, int64_t, 1, 32),
+                MAKE_PTA_WITH_NAME(func_name, vbe_metadata.row_output_offsets, int64_t, 1, 32),
                 MAKE_PTA_WITH_NAME(func_name, vbe_metadata.b_t_map, int32_t, 1, 32),
                 info_B_num_bits,
                 info_B_mask

--- a/fbgemm_gpu/codegen/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_kernel_warp_template.cu
@@ -30,8 +30,12 @@ template <
     size_t kMaxVecsPerThread,
     int32_t kThreadGroupSize >
 __global__ __launch_bounds__(kBackwardMaxThreads) void
+{%- if is_index_select %}
+batch_index_select_dim0_codegen_backward_kernel_warp_per_row(
+{%- else %}
 split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vbe_desc }}_kernel_warp_per_row_1(
-    const pta::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits> grad_output,
+{%- endif %}
+    const pta::PackedTensorAccessor64<grad_t, {{ "1" if is_index_select else "2" }}, at::RestrictPtrTraits> grad_output,
     {%- if optimizer != "none" %}
     pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
     {%- if not dense %}
@@ -41,7 +45,7 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
     {%- endif %}
     {%- endif %}
     const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
-    {%- if not nobag %}
+    {%- if not nobag or is_index_select %}
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
     {%- else %}
     int64_t D,
@@ -73,14 +77,19 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
     {%- endif %} // if not dense and optimizer != "none"
     {%- if not nobag and vbe %}
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> B_offsets,
-    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> output_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> row_output_offsets,
     {%- endif %}
     {%- if not nobag %}
     const int32_t info_B_num_bits,
     const uint32_t info_B_mask,
     {%- endif %}
-    {{ args.split_kernel_args | replace_pta_namespace() | join(",\n    ") }}) {
-
+    {%- if is_index_select %}
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> grad_offsets,
+    const bool permute_output_dim_0_1
+    {%- else %}
+    {{ args.split_kernel_args | replace_pta_namespace() | join(",\n    ") }}
+    {%- endif %}
+) {
     {%- if not nobag %}
     int32_t T = D_offsets.size(0) - 1;
     {%- else %}
@@ -123,8 +132,17 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
         {%- endif %}
 
         int64_t hash_size = hash_size_cumsum[t_0];
-        {%- if not nobag %}
-        int32_t D = D_offsets[t_0 + 1] - D_offsets[t_0];
+        {%- if not nobag or is_index_select %}
+        const auto D_start_t0 = D_offsets[t_0];
+        // D can be hoisted here because D is the same if features share the
+        // same table, but D_start is different
+        const int32_t D = D_offsets[t_0 + 1] - D_start_t0;
+        {%- if is_index_select %}
+        // grad_offset can be hoisted here for batch_index_select because it
+        // does not allow multiple features to share a single embedding table
+        const auto grad_offset = permute_output_dim_0_1 ? D_start_t0 : grad_offsets[t_0];
+        const auto grad_stride = permute_output_dim_0_1 ? D_offsets[T] : D;
+        {%- endif %}
         {%- endif %}
         int64_t idx = linear_index - hash_size;
 
@@ -139,8 +157,8 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
             const auto b = b_t & info_B_mask;
             const auto t = b_t >> info_B_num_bits;
             {%- if vbe %}
-            const auto grad_offset = output_offsets[B_offsets[t] + b];
-            {%- else %} // if vbe
+            const auto grad_offset = row_output_offsets[B_offsets[t] + b];
+            {% else %}
             int32_t D_start = sl_j < sl_end ? D_offsets[t] : 0;
             {%- endif %} // if vbe
             {%- else %} // if not nobag
@@ -171,7 +189,10 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
                         ++i) {
                     int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
                     Vec4T<at::acc_type<grad_t, true>> grad_out_vec(
-                        {%- if nobag %}
+                        {%- if nobag and is_index_select %}
+                        // grad_output is 1d
+                        &grad_output[grad_offset + l_j * grad_stride + d]
+                        {%- elif nobag %}
                         &grad_output[l_j][d]
                         {%- elif vbe %}
                         &grad_output[0][grad_offset_j + d]
@@ -243,15 +264,19 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
 */
 
 {%- macro template_instantiation(emb_type, grad_type, cache_type, kMaxVecsPerThread, kThreadGroupSize) %}
-template __global__ __launch_bounds__(kBackwardMaxThreads)
-void split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vbe_desc }}_kernel_warp_per_row_1
+template __global__ __launch_bounds__(kBackwardMaxThreads) void
+{%- if is_index_select %}
+batch_index_select_dim0_codegen_backward_kernel_warp_per_row
+{%- else %}
+split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vbe_desc }}_kernel_warp_per_row_1
+{%- endif %}
 < {{ emb_type }},
   {{ grad_type }},
   {{ cache_type }},
   {{ kMaxVecsPerThread }},
   {{ kThreadGroupSize }}
 > (
-    const pta::PackedTensorAccessor64<{{ grad_type }}, 2, at::RestrictPtrTraits> grad_output,
+    const pta::PackedTensorAccessor64<{{ grad_type }}, {{ "1" if is_index_select else "2" }}, at::RestrictPtrTraits> grad_output,
     {%- if optimizer != "none" %}
     pta::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> dev_weights,
     {%- if not dense %}
@@ -261,7 +286,7 @@ void split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimize
     {%- endif %}
     {%- endif %}
     const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
-    {%- if not nobag %}
+    {%- if not nobag or is_index_select %}
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
     {%- else %}
     int64_t D,
@@ -293,13 +318,19 @@ void split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimize
     {%- endif %} // if not dense and optimizer != "none"
     {%- if not nobag and vbe %}
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> B_offsets,
-    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> output_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> row_output_offsets,
     {%- endif %}
     {%- if not nobag %}
     const int32_t info_B_num_bits,
     const uint32_t info_B_mask,
     {%- endif %}
-    {{ args.split_kernel_args_no_defaults | replace_pta_namespace() | join(",\n    ") | replace("cache_t", cache_type) }});
+    {%- if is_index_select %}
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> grad_offsets,
+    const bool permute_output_dim_0_1
+    {%- else %}
+    {{ args.split_kernel_args_no_defaults | replace_pta_namespace() | join(",\n    ") | replace("cache_t", cache_type) }}
+    {%- endif %}
+);
 {%- endmacro %}
 
 {%- macro bulk_template_instantiations(kMaxVecsPerThread, kThreadGroupSize) %}

--- a/fbgemm_gpu/codegen/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_template.cu
@@ -8,7 +8,8 @@
 
 // clang-format off
 {%- set wdesc = "weighted" if weighted else "unweighted" %}
-{%- set vbe_desc = "_vbe" if vbe else "" %}
+{%- set vdesc = "_vbe" if vbe else "" %}
+{%- set ndesc = "_nobag" if nobag else "" %}
 #include "fbgemm_gpu/embedding_backward_template_helpers.cuh"
 #include "fbgemm_gpu/fbgemm_tensor_accessor.h"
 #include "fbgemm_gpu/split_embeddings_utils.cuh"
@@ -27,8 +28,12 @@ template <
     size_t kMaxVecsPerThread,
     int32_t kThreadGroupSize>
 __global__ __launch_bounds__(kMaxThreads) void
-split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vbe_desc }}_kernel_cta_per_row_1(
-    const pta::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits> grad_output,
+{% if is_index_select %}
+batch_index_select_dim0_codegen_backward_kernel_cta_per_row(
+{% else %}
+split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc }}_kernel_cta_per_row_1(
+{% endif %}
+    const pta::PackedTensorAccessor64<grad_t, {{ "1" if is_index_select else "2" }}, at::RestrictPtrTraits> grad_output,
     {%- if optimizer != "none" %}
     pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
     {%- if not dense %}
@@ -38,7 +43,7 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
     {%- endif %}
     {%- endif %} // if optimizer != "none"
     const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
-    {%- if not nobag %}
+    {%- if not nobag or is_index_select %}
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
     {%- else %}
     int64_t D,
@@ -70,7 +75,7 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
     {%- endif %} // if not dense and optimizer != "none"
     {%- if vbe %}
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> B_offsets,
-    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> output_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> row_output_offsets,
     {%- endif %}
     {%- if not nobag %}
     const int32_t info_B_num_bits,
@@ -81,7 +86,14 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
     pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> grad_accum_counter,
     const int32_t max_segment_length_per_cta,
     const bool use_deterministic_algorithms,
-    {{ args.split_kernel_args | replace_pta_namespace() | join(",\n    ") }});
+    {%- if is_index_select %}
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> grad_offsets,
+    const bool permute_output_dim_0_1
+    {%- else %}
+    {{ args.split_kernel_args | replace_pta_namespace() | join(",\n    ") }}
+    {%- endif %}
+);
+
 
 template <
     typename emb_t,
@@ -90,8 +102,12 @@ template <
     size_t kMaxVecsPerThread,
     int32_t kThreadGroupSize = kWarpSize>
 __global__ __launch_bounds__(kBackwardMaxThreads) void
-split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vbe_desc }}_kernel_warp_per_row_1(
-    const pta::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits> grad_output,
+{% if is_index_select %}
+batch_index_select_dim0_codegen_backward_kernel_warp_per_row(
+{% else %}
+split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc }}_kernel_warp_per_row_1(
+{% endif %}
+    const pta::PackedTensorAccessor64<grad_t, {{ "1" if is_index_select else "2" }}, at::RestrictPtrTraits> grad_output,
     {%- if optimizer != "none" %}
     pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
     {%- if not dense %}
@@ -101,7 +117,7 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
     {%- endif %}
     {%- endif %}
     const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
-    {%- if not nobag %}
+    {%- if not nobag or is_index_select %}
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
     {%- else %}
     int64_t D,
@@ -133,13 +149,19 @@ split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_
     {%- endif %} // if not dense and optimizer != "none"
     {%- if vbe %}
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> B_offsets,
-    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> output_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> row_output_offsets,
     {%- endif %}
     {%- if not nobag %}
     const int32_t info_B_num_bits,
     const uint32_t info_B_mask,
-    {%- endif %}
-    {{ args.split_kernel_args | replace_pta_namespace() | join(",\n    ") }});
+    {% endif %}
+    {% if is_index_select %}
+    const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> grad_offsets,
+    const bool permute_output_dim_0_1
+    {% else %}
+    {{ args.split_kernel_args | replace_pta_namespace() | join(",\n    ") }}
+    {% endif %}
+);
 
 __global__ __launch_bounds__(kMaxThreads) void
 split_embedding_backward_codegen_find_long_segments(
@@ -157,7 +179,7 @@ split_embedding_backward_codegen_find_long_segments(
 
 template <typename grad_t>
 __global__ __launch_bounds__(kMaxThreads) void
-grad_mean{{ vbe_desc }}_kernel(
+grad_mean{{ vdesc }}_kernel(
     pta::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits> grad_output_mean,
     const pta::PackedTensorAccessor64<grad_t, 2, at::RestrictPtrTraits> grad_output,
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
@@ -247,13 +269,17 @@ grad_mean{{ vbe_desc }}_kernel(
 ////////////////////////////////////////////////////////////////////////////////
 
 {%- set func_name0 = "split_embedding{}_backward_codegen_{}_{}_exact{}_cuda".format(
-    "_nobag" if nobag else "",
+    ndesc,
     optimizer,
     wdesc,
-    vbe_desc)
+    vdesc)
 %}
 
-Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_exact{{ vbe_desc }}_cuda(
+{% if is_index_select %}
+Tensor batch_index_select_dim0_codegen_backward_cuda(
+{% else %}
+Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_exact{{ vdesc }}_cuda(
+{% endif %}
     Tensor grad_output,
     Tensor dev_weights,
     {%- if not dense %}
@@ -262,7 +288,7 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
     Tensor weights_placements,
     {%- endif %}
     Tensor weights_offsets,
-    {%- if not nobag %}
+    {%- if not nobag or is_index_select %}
     Tensor D_offsets,
     int64_t max_D,
     {%- else %}
@@ -271,7 +297,9 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
     Tensor hash_size_cumsum,
     int64_t total_hash_size_bits,
     Tensor indices,
+    {% if not is_index_select %}
     Tensor offsets,
+    {%- endif %}
     {%- if not nobag %}
     int64_t pooling_mode,
     {%- endif %}
@@ -281,7 +309,9 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
     {%- if not dense %}
     Tensor lxu_cache_locations,
     {%- endif %}
+    {%- if not is_index_select %}
     int64_t unused_,
+    {% endif %}
     int64_t max_segment_length_per_warp,
     {%- if not dense %}
     {%- if optimizer != "none" %}
@@ -293,7 +323,13 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
     {%- if vbe %}
     const VBEMetadata& vbe_metadata,
     {%- endif %}
-    {%- if optimizer != "none" %}
+    {% if is_index_select %}
+    const Tensor& grad_offsets,
+    const Tensor& total_L_offsets,
+    const int32_t fixed_L_per_warp,
+    const int32_t num_warps_per_feature,
+    const bool permute_output_dim_0_1
+    {%- elif optimizer != "none" %}
     {{ args.split_function_args | join(", ") }}
     {%- else %}
     // This is acutally passed via args.split_function_args but explicitly list
@@ -301,7 +337,7 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
     int64_t total_hash_size,
     int64_t total_unique_indices
     {%- endif %}
-    ) {
+) {
 
     TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
         {%- if optimizer != "none" %}
@@ -314,16 +350,18 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
         {%- endif %}
         {%- if vbe %}
         vbe_metadata.B_offsets,
-        vbe_metadata.output_offsets,
+        vbe_metadata.row_output_offsets,
         vbe_metadata.b_t_map,
         {%- endif %}
         weights_offsets,
-        {%- if not nobag %}
+        {%- if not nobag or is_index_select %}
         D_offsets,
         {%- endif %}
         hash_size_cumsum,
         indices,
+        {%- if not is_index_select %}
         offsets,
+        {%- endif %}
         {%- if weighted %}
         indice_weights,
         {%- endif %}
@@ -332,13 +370,24 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
         {%- endif %}
         grad_output);
 
+    {%- if is_index_select %}
+    if (!permute_output_dim_0_1) {
+        TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
+            grad_offsets,
+            dev_weights
+        );
+    }
+    {%- endif %}
+
     at::cuda::OptionalCUDAGuard device_guard;
     device_guard.set_index(dev_weights.get_device());
 
-    {%- if nobag %}
+    {%- if nobag and not is_index_select %}
     auto max_D = D;
     {%- endif %}
+    {% if not is_index_select %}
     TORCH_CHECK(max_D <= {{ max_embedding_dim }});
+    {%- endif %}
 
     {%- if optimizer == "none" %}
     // grad_dev_weights has emb_t type
@@ -375,14 +424,18 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
 
     TORCH_CHECK(T > 0);
     // offsets = [B x T  + 1]
+    {% if is_index_select %}
+    const auto total_B = num_warps_per_feature * T;
+    {% else %}
     const auto total_B = offsets.size(0) - 1;
+    {% endif %}
     TORCH_CHECK(total_B > 0);
     auto BT_block_size = kMaxThreads / kWarpSize;
     TORCH_CHECK(BT_block_size * kWarpSize <= kMaxThreads);
 
     {%- if vbe %}
     TORCH_CHECK(vbe_metadata.B_offsets.numel() == T + 1);
-    TORCH_CHECK(vbe_metadata.output_offsets.numel() == total_B);
+    TORCH_CHECK(vbe_metadata.row_output_offsets.numel() == total_B);
     TORCH_CHECK(vbe_metadata.b_t_map.numel() == total_B);
     {%- endif %}
 
@@ -429,12 +482,21 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
             hash_size_cumsum,
             total_hash_size_bits,
             indices,
-            offsets,
+            {{ "offsets" if not is_index_select else "Tensor()" }},
             {{ "true" if nobag else "false" }},
             {{ "c10::optional<Tensor>(vbe_metadata.b_t_map)" if vbe else "c10::optional<Tensor>()" }},
             info_B_num_bits,
             info_B_mask,
-            total_unique_indices);
+            total_unique_indices,
+            {% if is_index_select %}
+            true, // is_index_select
+            c10::optional<Tensor>(total_L_offsets),
+            fixed_L_per_warp,
+            num_warps_per_feature
+            {% else %}
+            false // is_index_select
+            {% endif %}
+        );
 
     {%- if not dense %}
     auto lxu_cache_locations_sorted = at::empty_like(lxu_cache_locations);
@@ -522,7 +584,7 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
             grad_output = grad_output.reshape({1, -1});
             {%- endif %}
 
-            auto grad_output_accessor = MAKE_PTA_WITH_NAME("{{ func_name0 }}.1", grad_output, grad_t, 2, 64);
+            auto grad_output_accessor = MAKE_PTA_WITH_NAME("{{ func_name0 }}.1", grad_output, grad_t, {{ "1" if is_index_select else "2" }}, 64);
 
             {%- if not nobag %}
             Tensor grad_output_mean;
@@ -531,10 +593,10 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
                 {%- if not dense or not vbe %}
 
 #ifdef FBGEMM_GPU_MEMCHECK
-                const auto func_name1 = "grad_mean{{ vbe_desc }}_kernel";
+                const auto func_name1 = "grad_mean{{ vdesc }}_kernel";
 #endif
 
-                grad_mean{{ vbe_desc }}_kernel<<<
+                grad_mean{{ vdesc }}_kernel<<<
                     div_round_up(total_B, kMaxThreads / kWarpSize),
                     dim3(kWarpSize, kMaxThreads / kWarpSize),
                     0,
@@ -545,7 +607,7 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
                         MAKE_PTA_WITH_NAME(func_name1, D_offsets, int32_t, 1, 32),
                         MAKE_PTA_WITH_NAME(func_name1, offsets, int64_t, 1, 32),
                         {%- if vbe %}
-                        MAKE_PTA_WITH_NAME(func_name1, vbe_metadata.output_offsets, int64_t, 1, 32),
+                        MAKE_PTA_WITH_NAME(func_name1, vbe_metadata.row_output_offsets, int64_t, 1, 32),
                         MAKE_PTA_WITH_NAME(func_name1, vbe_metadata.b_t_map, int32_t, 1, 32),
                         info_B_num_bits,
                         info_B_mask
@@ -644,30 +706,39 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
                 // must use dynamic shared memory (rather than statically sized
                 // arrays) and require an explicit opt-in using cudaFuncSetAttribute()".
 
+                {%- set cta_kernel =
+                    "batch_index_select_dim0_codegen_backward_kernel_cta_per_row"
+                    if is_index_select else
+                    "split_embedding{}_backward_codegen_{}_{}{}_kernel_cta_per_row_1".format(
+                        ndesc,
+                        optimizer,
+                        wdesc,
+                        vdesc,
+                    )
+                %}
+
+                const auto backward_cta_per_row_kernel =
+                    {{ cta_kernel }}
+                        <emb_t,
+                         grad_t,
+                         cache_t,
+                         kMaxVecsPerThread,
+                         kThreadGroupSize>;
+
 #ifndef __HIP_PLATFORM_HCC__
                 cudaFuncSetAttribute(
-                    split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vbe_desc }}_kernel_cta_per_row_1<
-                    emb_t,
-                    grad_t,
-                    cache_t,
-                    kMaxVecsPerThread,
-                    kThreadGroupSize>,
+                    backward_cta_per_row_kernel,
                     cudaFuncAttributeMaxDynamicSharedMemorySize,
                     used_shared_bytes); // V100: 64 KB; A100: 96 KB; H100: 144 KB
-#endif
                 C10_CUDA_KERNEL_LAUNCH_CHECK();
+#endif
 
 #ifdef FBGEMM_GPU_MEMCHECK
-                const auto func_name3 = "split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vbe_desc }}_kernel_cta_per_row_1";
+                const auto func_name3 = "{{ cta_kernel }}";
 #endif
 
                 // dividing by kMaxThreads is a heuristic to avoid num of blocks far exceeding num_long_run_ids[0]
-                split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vbe_desc }}_kernel_cta_per_row_1<
-                    emb_t,
-                    grad_t,
-                    cache_t,
-                    kMaxVecsPerThread,
-                    kThreadGroupSize>
+                backward_cta_per_row_kernel
                     <<<grid_size,
                         dim3(kThreadGroupSize, BT_block_size),
                         BT_block_size * sizeof(at::acc_type<cache_t, true>) * 4 * kWarpSize *
@@ -685,7 +756,7 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
                         {%- endif %}
                         {%- endif %} // if optimizer != "none"
                         MAKE_PTA_WITH_NAME(func_name3, weights_offsets, int64_t, 1, 32),
-                        {%- if not nobag %}
+                        {%- if not nobag or is_index_select %}
                         MAKE_PTA_WITH_NAME(func_name3, D_offsets, int32_t, 1, 32),
                         {%- else %}
                         D,
@@ -717,7 +788,7 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
                         {%- endif %} // if not dense and optimizer != "none"
                         {%- if vbe %}
                         MAKE_PTA_WITH_NAME(func_name3, vbe_metadata.B_offsets, int32_t, 1, 32),
-                        MAKE_PTA_WITH_NAME(func_name3, vbe_metadata.output_offsets, int64_t, 1, 32),
+                        MAKE_PTA_WITH_NAME(func_name3, vbe_metadata.row_output_offsets, int64_t, 1, 32),
                         {%- endif %}
                         {%- if not nobag %}
                         info_B_num_bits,
@@ -728,12 +799,37 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
                         MAKE_PTA_WITH_NAME(func_name3, grad_accum_counter, int32_t, 1, 32),
                         max_segment_length_per_cta,
                         use_deterministic_algorithms,
-                        {{ args.split_kernel_arg_constructors | make_pta_acc_format("func_name3") | join(",\n                        ") }});
+                        {%- if is_index_select %}
+                        grad_offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
+                        permute_output_dim_0_1
+                        {%- else %}
+                        {{ args.split_kernel_arg_constructors | make_pta_acc_format("func_name3") | join(",\n                        ") }}
+                        {%- endif %}
+                );
 
                 C10_CUDA_KERNEL_LAUNCH_CHECK();
                 grid_size = std::min(
                     div_round_up(total_unique_indices, kBackwardMaxThreads / kThreadGroupSize),
                     get_max_thread_blocks_());
+
+                {%- set warp_kernel =
+                    "batch_index_select_dim0_codegen_backward_kernel_warp_per_row"
+                    if is_index_select else
+                    "split_embedding{}_backward_codegen_{}_{}{}_kernel_warp_per_row_1".format(
+                        ndesc,
+                        optimizer,
+                        wdesc,
+                        vdesc,
+                    )
+                %}
+
+                const auto backward_warp_per_row_kernel =
+                    {{ warp_kernel }}
+                        <emb_t,
+                         grad_t,
+                         cache_t,
+                         kMaxVecsPerThread,
+                         kThreadGroupSize>;
 
                 // Shared memory is not needed for non uint8_t weights
                 size_t shmem_bytes = 0;
@@ -742,28 +838,18 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
                         at::acc_type<cache_t, true>) * 4 * kWarpSize * kMaxVecsPerThread;
 #ifndef __HIP_PLATFORM_HCC__
                     cudaFuncSetAttribute(
-                        split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vbe_desc }}_kernel_warp_per_row_1<
-                        emb_t,
-                        grad_t,
-                        cache_t,
-                        kMaxVecsPerThread,
-                        kThreadGroupSize>,
+                        backward_warp_per_row_kernel,
                         cudaFuncAttributeMaxDynamicSharedMemorySize,
                         used_shared_bytes); // V100: 64 KB; A100: 96 KB; H100: 144 KB
+                    C10_CUDA_KERNEL_LAUNCH_CHECK();
 #endif
                 }
 
 #ifdef FBGEMM_GPU_MEMCHECK
-                const auto func_name4 = "split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vbe_desc }}_kernel_warp_per_row_1";
+                const auto func_name4 = "{{ warp_kernel }}";
 #endif
 
-                C10_CUDA_KERNEL_LAUNCH_CHECK();
-                split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vbe_desc }}_kernel_warp_per_row_1<
-                    emb_t,
-                    grad_t,
-                    cache_t,
-                    kMaxVecsPerThread,
-                    kThreadGroupSize>
+                backward_warp_per_row_kernel
                     <<<grid_size,
                         dim3(kThreadGroupSize, kBackwardMaxThreads / kThreadGroupSize),
                         shmem_bytes,
@@ -780,7 +866,7 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
                         {%- endif %}
                         {%- endif %}
                         MAKE_PTA_WITH_NAME(func_name4, weights_offsets, int64_t, 1, 32),
-                        {%- if not nobag %}
+                        {%- if not nobag or is_index_select %}
                         MAKE_PTA_WITH_NAME(func_name4, D_offsets, int32_t, 1, 32),
                         {%- else %}
                         D,
@@ -812,13 +898,19 @@ Tensor split_embedding{{ "_nobag" if nobag else "" }}_backward_codegen_{{ optimi
                         {%- endif %} // if not dense and optimizer != "none"
                         {%- if vbe %}
                         MAKE_PTA_WITH_NAME(func_name4, vbe_metadata.B_offsets, int32_t, 1, 32),
-                        MAKE_PTA_WITH_NAME(func_name4, vbe_metadata.output_offsets, int64_t, 1, 32),
+                        MAKE_PTA_WITH_NAME(func_name4, vbe_metadata.row_output_offsets, int64_t, 1, 32),
                         {%- endif %}
                         {%- if not nobag %}
                         info_B_num_bits,
                         info_B_mask,
                         {%- endif %}
-                        {{ args.split_kernel_arg_constructors | make_pta_acc_format("func_name4") | join(",\n                        ") }});
+                        {% if is_index_select %}
+                        grad_offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
+                        permute_output_dim_0_1
+                        {% else %}
+                        {{ args.split_kernel_arg_constructors | make_pta_acc_format("func_name4") | join(",\n                        ") }}
+                        {% endif %}
+                );
                 C10_CUDA_KERNEL_LAUNCH_CHECK();
                 return;
             });

--- a/fbgemm_gpu/include/fbgemm_gpu/embedding_common.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/embedding_common.h
@@ -86,7 +86,7 @@ struct VBEMetadata {
   at::Tensor B_offsets; // torch.int
   at::Tensor output_offsets_feature_rank; // torch.long
   at::Tensor B_offsets_rank_per_feature; // torch.int
-  at::Tensor output_offsets; // torch.long
+  at::Tensor row_output_offsets; // torch.long
   at::Tensor b_t_map; // torch.int
   int32_t max_B_feature_rank;
   int64_t output_size;

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.cuh
@@ -43,7 +43,12 @@ transpose_embedding_input(
     const c10::optional<at::Tensor>& vbe_b_t_map = c10::optional<at::Tensor>(),
     const int64_t info_B_num_bits = 26,
     const int64_t info_B_mask = 0x2FFFFFF,
-    const int64_t total_unique_indices = -1);
+    const int64_t total_unique_indices = -1,
+    const bool is_index_select = false,
+    const c10::optional<at::Tensor>& total_L_offsets =
+        c10::optional<at::Tensor>(),
+    const int64_t fixed_L_per_warp = 0,
+    const int64_t num_warps_per_feature = 0);
 
 std::tuple<int64_t, int64_t>
 get_infos_metadata(at::Tensor unused, int64_t B, int64_t T);

--- a/fbgemm_gpu/src/split_embeddings_utils.cpp
+++ b/fbgemm_gpu/src/split_embeddings_utils.cpp
@@ -22,8 +22,12 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "bool nobag=False, "
       "Tensor? vbe_b_t_map=None, "
       "int info_B_num_bits=26, "
-      "int info_B_mask=0x2FFFFFF,"
-      "int total_unique_indices=-1) "
+      "int info_B_mask=0x2FFFFFF, "
+      "int total_unique_indices=-1, "
+      "bool is_index_select=False, "
+      "Tensor? total_L_offsets=None, "
+      "int fixed_L_per_warp=0, "
+      "int num_warps_per_feature=0) "
       "-> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)");
   m.def("get_infos_metadata(Tensor unused, int B, int T) -> (int, int)");
   DISPATCH_TO_CUDA("transpose_embedding_input", transpose_embedding_input);

--- a/fbgemm_gpu/src/split_embeddings_utils.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils.cu
@@ -138,6 +138,62 @@ __global__ __launch_bounds__(kMaxThreads) void linearize_index_kernel(
   }
 }
 
+template <typename index_t, typename info_acc_t>
+__global__
+__launch_bounds__(kMaxThreads) void linearize_index_index_select_kernel(
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
+        hash_size_cumsum,
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
+        total_L_offsets,
+    at::PackedTensorAccessor32<info_acc_t, 1, at::RestrictPtrTraits> infos,
+    at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
+        linear_indices,
+    FixedDivisor fd,
+    int32_t fixed_L_per_warp) {
+  const int32_t T = hash_size_cumsum.size(0) - 1;
+  auto b_t = blockIdx.x * blockDim.x + threadIdx.x;
+  int32_t b;
+  int32_t t;
+
+  fd.DivMod(b_t, &t, &b);
+
+  const int32_t lane_id = threadIdx.x % fbgemm_gpu::kWarpSize;
+
+  index_t hash_offset = -1;
+  index_t indices_start = -1;
+  int32_t L = 0;
+  int32_t L_start = 0;
+  if (t < T) {
+    const auto total_L_start = total_L_offsets[t];
+    const auto total_L = total_L_offsets[t + 1] - total_L_start;
+    L_start = b * fixed_L_per_warp;
+    if (L_start < total_L) {
+      hash_offset = hash_size_cumsum[t];
+      indices_start = total_L_start + L_start;
+      L = (total_L - L_start >= fixed_L_per_warp) ? fixed_L_per_warp
+                                                  : (total_L - L_start);
+    }
+  }
+
+  // Compile-time conditional
+  for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
+    const index_t indices_start_warp = fbgemm_gpu::shfl_sync(indices_start, j);
+    const auto t_warp = fbgemm_gpu::shfl_sync(t, j);
+    const auto L_warp = fbgemm_gpu::shfl_sync(L, j);
+    const auto L_start_warp = fbgemm_gpu::shfl_sync(L_start, j);
+    const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
+    for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
+      const index_t idx = __ldg(&indices[indices_start_warp + i]);
+      // l is the relative l in the feature (i.e., the first l in the feature
+      // is 0)
+      const int64_t l_t = (L_start_warp + i) * T + t_warp;
+      infos[indices_start_warp + i] = l_t;
+      linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
+    }
+  }
+}
+
 DLL_PUBLIC std::tuple<
     Tensor /*linear_indices*/,
     Tensor /*linear_indices_sorted*/,
@@ -155,16 +211,30 @@ transpose_embedding_input(
     const c10::optional<Tensor>& vbe_b_t_map,
     const int64_t info_B_num_bits,
     const int64_t info_B_mask,
-    const int64_t total_unique_indices) {
+    const int64_t total_unique_indices,
+    const bool is_index_select,
+    const c10::optional<Tensor>& total_L_offsets,
+    const int64_t fixed_L_per_warp,
+    const int64_t num_warps_per_feature) {
   const bool vbe = vbe_b_t_map.has_value();
   TORCH_CHECK(nobag || !vbe || info_B_num_bits > 0);
   TORCH_CHECK(!vbe || info_B_mask > 0);
+  TORCH_CHECK(
+      !is_index_select || (fixed_L_per_warp > 0 && num_warps_per_feature > 0));
 
-  const auto total_B = offsets.size(0) - 1;
   const auto T = hash_size_cumsum.size(0) - 1;
+  const auto total_B =
+      !is_index_select ? (offsets.size(0) - 1) : (num_warps_per_feature * T);
+
+  TORCH_CHECK(
+      !is_index_select ||
+      (total_L_offsets.has_value() &&
+       total_L_offsets.value().numel() == T + 1));
 
   auto infos = at::empty_like(
-      indices, indices.options().dtype(nobag ? at::kLong : at::kInt));
+      indices,
+      indices.options().dtype(
+          (nobag || is_index_select) ? at::kLong : at::kInt));
   auto infos_sorted = at::empty_like(infos);
   auto linear_indices = at::empty_like(indices);
   auto linear_indices_sorted = at::empty_like(indices);
@@ -203,10 +273,31 @@ transpose_embedding_input(
         using info_t = index_t;
         AT_DISPATCH_INDEX_TYPES(
             indices.scalar_type(), "transpose_embedding_input2", [&] {
-              if (!nobag) {
-                INVOKE_LINEARIZE_INDEX_KERNEL(int32_t, false);
+              if (!is_index_select) {
+                if (!nobag) {
+                  INVOKE_LINEARIZE_INDEX_KERNEL(int32_t, false);
+                } else {
+                  INVOKE_LINEARIZE_INDEX_KERNEL(int64_t, true);
+                }
               } else {
-                INVOKE_LINEARIZE_INDEX_KERNEL(int64_t, true);
+                // index_select is a special case of TBE (dense, nobag, with
+                // fixed_L_per_warp)
+                linearize_index_index_select_kernel<<<
+                    div_round_up(total_B, kMaxThreads),
+                    kMaxThreads,
+                    0,
+                    at::cuda::getCurrentCUDAStream()>>>(
+                    hash_size_cumsum
+                        .packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+                    indices.packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+                    total_L_offsets.value()
+                        .packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+                    infos.packed_accessor32<int64_t, 1, RestrictPtrTraits>(),
+                    linear_indices
+                        .packed_accessor32<index_t, 1, RestrictPtrTraits>(),
+                    FixedDivisor(total_B / T),
+                    fixed_L_per_warp);
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
               }
               {
                 size_t temp_storage_bytes = 0;
@@ -386,7 +477,7 @@ DEF_RADIX_SORT_PAIRS_FN(int64_t, int32_t);
 __global__
 __launch_bounds__(kMaxThreads) void populate_vbe_metadata_foreach_sample_inplace_kernel(
     at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
-        output_offsets,
+        row_output_offsets,
     at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> b_t_map,
     const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         B_offsets,
@@ -430,7 +521,7 @@ __launch_bounds__(kMaxThreads) void populate_vbe_metadata_foreach_sample_inplace
   // Update b_t
   b_t = B_start_t + B_start_r_t + b;
   const auto D_ = nobag ? D : D_offsets[t + 1] - D_offsets[t];
-  output_offsets[b_t] = output_offsets_feature_rank[r * T + t] + b * D_;
+  row_output_offsets[b_t] = output_offsets_feature_rank[r * T + t] + b * D_;
 
   // Relative sample ID in the table
   const auto b_ = B_start_r_t + b;
@@ -492,7 +583,7 @@ DLL_PUBLIC void populate_vbe_metadata_foreach_sample_inplace(
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(vbe_metadata.B_offsets.get_device());
 
-  Tensor output_offsets =
+  Tensor row_output_offsets =
       at::empty({total_B}, vbe_metadata.output_offsets_feature_rank.options());
   Tensor b_t_map = at::empty({total_B}, vbe_metadata.B_offsets.options());
 
@@ -504,7 +595,7 @@ DLL_PUBLIC void populate_vbe_metadata_foreach_sample_inplace(
       kMaxThreads,
       0,
       at::cuda::getCurrentCUDAStream()>>>(
-      output_offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
+      row_output_offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
       b_t_map.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
       vbe_metadata.B_offsets
           .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
@@ -520,6 +611,6 @@ DLL_PUBLIC void populate_vbe_metadata_foreach_sample_inplace(
       info_B_num_bits);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
-  vbe_metadata.output_offsets = std::move(output_offsets);
+  vbe_metadata.row_output_offsets = std::move(row_output_offsets);
   vbe_metadata.b_t_map = std::move(b_t_map);
 }


### PR DESCRIPTION
Summary:
Usage:

```
# This target might change in the future
torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/codegen:index_select_ops")

...

output = torch.ops.fbgemm.batch_index_select_dim0(
            inputs, # Tensor - 1D tensor (concatenated flatten inputs)
            indices, # Tensor - 1D tensor (concatenated indices)
            input_num_indices, # List[int]
            input_rows, # List[int]
            input_columns, # List[int]
         )
```

Differential Revision: D46084590

