### PR TITLE
Add BF16 in FP8 quantize/dequantize ops

### DIFF
--- a/fbgemm_gpu/test/quantize_ops_test.py
+++ b/fbgemm_gpu/test/quantize_ops_test.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
+import os
 import random
 import unittest
 from ctypes import c_float, c_int32, cast, POINTER, pointer
@@ -13,7 +15,7 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from hypothesis import assume, given, HealthCheck, settings
+from hypothesis import assume, given, HealthCheck, settings, Verbosity
 from torch import Tensor
 
 
@@ -967,6 +969,77 @@ class TestBfloat16QuantizationConversion(unittest.TestCase):
             )
             # compare quantized data
             torch.testing.assert_close(dequantized_data_gpu.cpu(), dequantized_data)
+
+
+class TestFP8RowwiseQuantizationConversion(unittest.TestCase):
+    enable_logging: bool = False
+
+    def setUp(self) -> None:
+        self.enable_logging = bool(os.getenv("FBGEMM_GPU_ENABLE_LOGGING", 0))
+        if self.enable_logging:
+            logging.info("Enabled logging for TestFP8RowwiseQuantizationConversion")
+
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-fixme[56]:
+    @given(
+        batched=st.booleans(),
+        bs=st.integers(min_value=1, max_value=100),
+        m=st.integers(min_value=0, max_value=100),
+        n=st.integers(min_value=0, max_value=100),
+        forward=st.booleans(),
+        given_last_dim=st.booleans(),
+        dtype=st.sampled_from(
+            [
+                torch.float,
+                torch.half,
+                torch.bfloat16,
+            ],
+        ),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
+    def test_quantize_and_dequantize_op_fp8_rowwise(
+        self,
+        batched: bool,
+        bs: int,
+        m: int,
+        n: int,
+        forward: bool,
+        given_last_dim: bool,
+        dtype: torch.dtype,
+    ) -> None:
+        n = n * 4  # need (n % 4 == 0)
+        input_data = (
+            torch.rand(bs, m, n, dtype=dtype)
+            if batched
+            else torch.rand(bs * m, n, dtype=dtype)
+        )
+
+        input_data_gpu = input_data.cuda()
+        quantized_data_gpu = torch.ops.fbgemm.FloatToFP8RowwiseQuantized(
+            input_data_gpu, forward=forward
+        )
+        dequantized_data_gpu = torch.ops.fbgemm.FP8RowwiseQuantizedToFloat(
+            quantized_data_gpu, forward=forward
+        )
+
+        if m == 0 or n == 0:
+            assert dequantized_data_gpu.numel() == 0
+            return
+
+        qref = input_data_gpu.float()
+        dq = dequantized_data_gpu
+
+        if self.enable_logging:
+            # Logging quantization errors
+            errors = (input_data_gpu - dequantized_data_gpu) / input_data_gpu
+            logging.info(f"max relative error {errors.abs().max()}")
+            val, idx = torch.topk(errors.flatten().abs(), k=min(10, errors.shape[-1]))
+            logging.info(f"top-10 errors {val}")
+            logging.info(f"qref {qref.flatten()[idx]}")
+            logging.info(f"dqcat {dq.flatten()[idx]}")
+            logging.info(f"max relative error {errors.flatten()[idx]}")
+
+        torch.testing.assert_close(qref.cpu(), dq.cpu(), rtol=0.1, atol=0.05)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
This diff adds BF16 input support for `FloatToFP8RowwiseQuantized` and
BF16 output support for `FP8RowwiseQuantizedToFloat`.

Reviewed By: xiaosun86, jianyuh

Differential Revision: D47419981

