### PR TITLE
Optimize the cache fetch for forward split, pt. 2

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
@@ -23,8 +23,8 @@ using namespace fbgemm_gpu;
 /// @defgroup embedding-cuda Embedding CUDA Operators
 
 {% for vbe in ([True, False] if has_vbe_support else [False]) %}
-{% set vbe_desc = "_vbe" if vbe else "" %}
-Tensor split_embedding_codegen_forward_unweighted{{ vbe_desc }}_cuda(
+{% set vdesc = "_vbe" if vbe else "" %}
+Tensor split_embedding_codegen_forward_unweighted{{ vdesc }}_cuda(
     Tensor dev_weights,
     Tensor uvm_weights,
     Tensor lxu_cache_weights,
@@ -45,7 +45,7 @@ Tensor split_embedding_codegen_forward_unweighted{{ vbe_desc }}_cuda(
     {% endif %}
     bool is_experimental);
 
-Tensor split_embedding_codegen_forward_weighted{{ vbe_desc }}_cuda(
+Tensor split_embedding_codegen_forward_weighted{{ vdesc }}_cuda(
     Tensor dev_weights,
     Tensor uvm_weights,
     Tensor lxu_cache_weights,
@@ -67,7 +67,7 @@ Tensor split_embedding_codegen_forward_weighted{{ vbe_desc }}_cuda(
     {% endif %}
     bool is_experimental);
 
-Tensor split_embedding_codegen_grad_indice_weights{{ vbe_desc }}_cuda(
+Tensor split_embedding_codegen_grad_indice_weights{{ vdesc }}_cuda(
     Tensor grad_output,
     Tensor dev_weights,
     Tensor uvm_weights,
@@ -89,7 +89,7 @@ Tensor split_embedding_codegen_grad_indice_weights{{ vbe_desc }}_cuda(
     {% endif %}
 );
 
-Tensor split_embedding_backward_codegen_{{ optimizer }}_unweighted_exact{{ vbe_desc }}_cuda(
+Tensor split_embedding_backward_codegen_{{ optimizer }}_unweighted_exact{{ vdesc }}_cuda(
     Tensor grad_output,
     Tensor dev_weights,
     Tensor uvm_weights,
@@ -116,7 +116,7 @@ Tensor split_embedding_backward_codegen_{{ optimizer }}_unweighted_exact{{ vbe_d
     {% endif %}
     {{ args.split_function_args | join(", ") }});
 
-Tensor split_embedding_backward_codegen_{{ optimizer }}_weighted_exact{{ vbe_desc }}_cuda(
+Tensor split_embedding_backward_codegen_{{ optimizer }}_weighted_exact{{ vdesc }}_cuda(
     Tensor grad_output,
     Tensor dev_weights,
     Tensor uvm_weights,
@@ -320,7 +320,7 @@ class Split{{ "NoBag" if nobag else "" }}{{ "VBE" if vbe else "" }}LookupFunctio
     {% if not nobag %}
     if (!indice_weights) {
         return {
-          split_embedding_codegen_forward_unweighted{{ vbe_desc }}_cuda(
+          split_embedding_codegen_forward_unweighted{{ vdesc }}_cuda(
             dev_weights,
             uvm_weights,
             lxu_cache_weights,
@@ -344,7 +344,7 @@ class Split{{ "NoBag" if nobag else "" }}{{ "VBE" if vbe else "" }}LookupFunctio
         };
     } else {
         return {
-          split_embedding_codegen_forward_weighted{{ vbe_desc }}_cuda(
+          split_embedding_codegen_forward_weighted{{ vdesc }}_cuda(
             dev_weights,
             uvm_weights,
             lxu_cache_weights,
@@ -478,12 +478,12 @@ class Split{{ "NoBag" if nobag else "" }}{{ "VBE" if vbe else "" }}LookupFunctio
     {% if not nobag %}
     {% if optimizer == "none" %}
     // Flatten (dev_weights is used in
-    // split_embedding_codegen_grad_indice_weights{{ vbe_desc }}_cuda)
+    // split_embedding_codegen_grad_indice_weights{{ vdesc }}_cuda)
     dev_weights = dev_weights.flatten();
     {% endif %}
     const auto grad_indice_weights = !indice_weights.defined() ?
       Variable() :
-      split_embedding_codegen_grad_indice_weights{{ vbe_desc }}_cuda(
+      split_embedding_codegen_grad_indice_weights{{ vdesc }}_cuda(
         grad_output,
         dev_weights,
         uvm_weights,
@@ -506,7 +506,7 @@ class Split{{ "NoBag" if nobag else "" }}{{ "VBE" if vbe else "" }}LookupFunctio
         );
     const auto grad_dev_weights = !indice_weights.defined() ?
       {% for weighted in [False, True] %}
-      split_embedding_backward_codegen_{{ optimizer }}_{{ "weighted" if weighted else "unweighted" }}_exact{{ vbe_desc }}_cuda(
+      split_embedding_backward_codegen_{{ optimizer }}_{{ "weighted" if weighted else "unweighted" }}_exact{{ vdesc }}_cuda(
           grad_output,
           dev_weights,
           uvm_weights,

--- a/fbgemm_gpu/codegen/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_template.cu
@@ -255,6 +255,7 @@ Tensor {{ ddesc }}_embedding{{ ndesc }}_codegen_forward_{{ wdesc }}{{ vdesc }}_c
     {%- endif %}
     {%- if not dense %}
     Tensor lxu_cache_locations,
+    Tensor uvm_cache_stats,
     {%- endif %}
     int64_t output_dtype,
     {%- if vbe %}
@@ -359,9 +360,6 @@ Tensor {{ ddesc }}_embedding{{ ndesc }}_codegen_forward_{{ wdesc }}{{ vdesc }}_c
         {%- endif %}
         return output;
     }
-
-    // TODO: Turn this into a function argument
-    auto uvm_cache_stats = at::empty({0}, dev_weights.options().dtype(at::ScalarType::Int));
 
     DISPATCH_EMB_CACHE_OUTPUT_TYPES(
         dev_weights.scalar_type(),

--- a/fbgemm_gpu/codegen/embedding_forward_template_helpers.cuh
+++ b/fbgemm_gpu/codegen/embedding_forward_template_helpers.cuh
@@ -42,6 +42,21 @@
 constexpr int32_t kCacheLocationMissing = -1;
 constexpr size_t kForwardMaxThreads = 512;
 
+namespace fbgemm_gpu {
+
+enum cache_conflict_miss_rate {
+  // Cache conflict misses will sometimes occur
+  mixed = 0,
+  // Cache conflict misses will always occur, i.e. every weight row to be
+  // accessed is NOT in the cache
+  all = 1,
+  // Cache conflict misses will never occur, i.e. every weight row to be
+  // accessed IS in the cache
+  zero = 2,
+};
+
+} // namespace fbgemm_gpu
+
 namespace nbit {
 // "Effective" number of elements in the row when we include the row-wise
 // quantization parameters.

--- a/fbgemm_gpu/codegen/lookup_args.py
+++ b/fbgemm_gpu/codegen/lookup_args.py
@@ -38,6 +38,7 @@ class CommonArgs(NamedTuple):
     indice_weights: Optional[torch.Tensor]
     feature_requires_grad: Optional[torch.Tensor]
     lxu_cache_locations: torch.Tensor
+    uvm_cache_stats: Optional[torch.Tensor]
     output_dtype: int
     vbe_metadata: VBEMetadata
     is_experimental: bool

--- a/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
@@ -198,6 +198,7 @@ def invoke(
         indice_weights=common_args.indice_weights,
         feature_requires_grad=common_args.feature_requires_grad,
         lxu_cache_locations=common_args.lxu_cache_locations,
+        uvm_cache_stats=common_args.uvm_cache_stats,
         # VBE metadata
         B_offsets=vbe_metadata.B_offsets,
         vbe_output_offsets_feature_rank=vbe_metadata.output_offsets_feature_rank,

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -956,6 +956,11 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             indice_weights=per_sample_weights,
             feature_requires_grad=feature_requires_grad,
             lxu_cache_locations=self.lxu_cache_locations,
+            # Pass the local_uvm_cache_stats bc only that information is
+            # relevant for the current iteration
+            uvm_cache_stats=self.local_uvm_cache_stats
+            if self.gather_uvm_cache_stats
+            else None,
             output_dtype=self.output_dtype,
             vbe_metadata=vbe_metadata,
             is_experimental=self.is_experimental,
@@ -1146,6 +1151,12 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         if not self.lxu_cache_weights.numel():
             return
 
+        # Clear the local_uvm_cache_stats before the prefetch instead of after
+        # the prefetch step, since it will be used in the CommonArgs in the
+        # forward step
+        if self.gather_uvm_cache_stats:
+            self.local_uvm_cache_stats.zero_()
+
         (indices, offsets) = indices.long(), offsets.long()
         linear_cache_indices = torch.ops.fbgemm.linearize_cache_indices(
             self.cache_hash_size_cumsum,
@@ -1230,7 +1241,6 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             self.uvm_cache_stats = torch.add(
                 self.uvm_cache_stats, self.local_uvm_cache_stats
             )
-            self.local_uvm_cache_stats.zero_()
 
     def _prefetch_tensors_record_stream(
         self, forward_stream: torch.cuda.Stream

--- a/fbgemm_gpu/fbgemm_gpu/ssd_split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/ssd_split_table_batched_embeddings_ops.py
@@ -444,6 +444,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             indice_weights=per_sample_weights,
             feature_requires_grad=feature_requires_grad,
             lxu_cache_locations=lxu_cache_locations,
+            uvm_cache_stats=None,
             vbe_metadata=invokers.lookup_args.VBEMetadata(
                 B_offsets=None,
                 output_offsets_feature_rank=None,

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh
@@ -13,6 +13,19 @@
 ///@defgroup table-batched-embed-cuda CUDA Operators
 /// The following are CUDA Operators
 
+namespace fbgemm_gpu {
+
+enum uvm_cache_stats_index {
+  num_calls = 0,
+  num_requested_indices = 1,
+  num_unique_indices = 2,
+  num_unique_misses = 3,
+  num_conflict_unique_misses = 4,
+  num_conflict_misses = 5,
+};
+
+}
+
 ///@ingroup table-batched-embed-cuda
 /// Deduplicate indices.
 std::tuple<at::Tensor, at::Tensor, c10::optional<at::Tensor>>


### PR DESCRIPTION
Summary: This follows up the work on D47778422 by plumbing the `uvm_cache_stats` argument passing up to the Python API level.  `local_uvm_cache_stats` is now zeroed out before the prefetch step as opposed to after, to allow for the data to be passed into the forward step.

Differential Revision: D47809950

