### PR TITLE
reduced grid size for insert kernel (training)

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
@@ -45,6 +45,13 @@ using fint32 = union fint32 {
   uint32_t I;
   float F;
 };
+
+int get_device_sm_cnt_() {
+  cudaDeviceProp* deviceProp =
+      at::cuda::getDeviceProperties(c10::cuda::current_device());
+  return deviceProp->multiProcessorCount;
+}
+
 } // namespace
 
 namespace fbgemm_gpu {


### PR DESCRIPTION
Summary:
`lru_cache_insert` kernel is not sensitive to #SMs (latency bound). Using less SMs avoids structural hazard on the main training stream. https://docs.google.com/document/d/1p3Id8HfVMfyFn4ZcL4e79Rl0ktTSevnW3jXm9PTy0ys/edit#bookmark=id.lyjw9rtmebv0

Given the performance optimized config is with pipelining, this diff changes the number of SMs (through limiting grid size) regardless of pipelined schema.

Reviewed By: jspark1105, q10

Differential Revision: D47781958

