### PR TITLE
Lint fix for type equality

### DIFF
--- a/fbgemm_gpu/test/split_embedding_inference_converter_test.py
+++ b/fbgemm_gpu/test/split_embedding_inference_converter_test.py
@@ -221,7 +221,7 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
             quantization_config=quantization_config,
         )
         split_emb_infer_converter.convert_model(sparse_arch)
-        assert type(sparse_arch.emb_module) == IntNBitTableBatchedEmbeddingBagsCodegen
+        assert type(sparse_arch.emb_module) is IntNBitTableBatchedEmbeddingBagsCodegen
         assert sparse_arch.emb_module.use_cpu == use_cpu
         quantized_emb_out = sparse_arch(indices.int(), offsets.int())  # B, T, D
 
@@ -304,7 +304,7 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
             )
             split_emb_infer_converter.convert_model(sparse_arch)
             assert (
-                type(sparse_arch.emb_module) == IntNBitTableBatchedEmbeddingBagsCodegen
+                type(sparse_arch.emb_module) is IntNBitTableBatchedEmbeddingBagsCodegen
             )
             assert sparse_arch.emb_module.use_cpu == use_cpu
             pruned_emb_out = sparse_arch(
@@ -359,7 +359,7 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
         )
         split_emb_infer_converter.convert_model(sparse_arch)
         embedding_weights_after = sparse_arch.emb_module.split_embedding_weights()
-        assert type(sparse_arch.emb_module) == IntNBitTableBatchedEmbeddingBagsCodegen
+        assert type(sparse_arch.emb_module) is IntNBitTableBatchedEmbeddingBagsCodegen
         assert sparse_arch.emb_module.use_cpu == use_cpu
 
         # Collect #rows after pruning.

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -1774,13 +1774,13 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             )
         )
         if optimizer is None:
-            assert type(gos) == list
+            assert type(gos) is list
             if do_pooling:
                 goc = torch.cat([go.view(B, -1) for go in gos], dim=1)
             else:
                 goc = torch.cat(gos, dim=0)
         else:
-            assert type(gos) == Tensor
+            assert type(gos) is Tensor
             goc = gos.clone()
         fc2.backward(goc)
 


### PR DESCRIPTION
Summary:
Ran into the following lint errors in CI

> Error: ./fbgemm_gpu/test/split_embedding_inference_converter_test.py:224:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
Error: ./fbgemm_gpu/test/split_embedding_inference_converter_test.py:306:21: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
Error: ./fbgemm_gpu/test/split_embedding_inference_converter_test.py:362:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
Error: ./fbgemm_gpu/test/split_table_batched_embeddings_test.py:1777:20: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
Error: ./fbgemm_gpu/test/split_table_batched_embeddings_test.py:1783:20: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`

https://github.com/pytorch/FBGEMM/actions/runs/5766331761/job/15634050067

Differential Revision: D48080868

