### PR TITLE
Adding C/C++ Compilers

### DIFF
--- a/.github/workflows/fbgemm_gpu_cpu_nightly.yml
+++ b/.github/workflows/fbgemm_gpu_cpu_nightly.yml
@@ -151,6 +151,10 @@ jobs:
     - name: Create Conda Environment
       run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
 
+    - name: Install C/C++ Compilers
+      # CXX compiler is needed for inductor used by torchrec.
+      run: . $PRELUDE; install_cxx_compiler $BUILD_ENV
+
     - name: Install PyTorch-CPU Nightly
       run: . $PRELUDE; install_pytorch_pip $BUILD_ENV nightly cpu
 


### PR DESCRIPTION
Summary:
CXX compiler is needed for inductor used by torchrec.

Raised error:
`InvalidCxxCompiler: No working C++ compiler found in torch._inductor.config.cpp.cxx: `
 https://github.com/pytorch/FBGEMM/actions/runs/5762408012

Reviewed By: sryap

Differential Revision: D48085285

