### PR TITLE
Fixing type comparing errors from Lint

### DIFF
--- a/.github/workflows/fbgemm_gpu_cpu_nightly.yml
+++ b/.github/workflows/fbgemm_gpu_cpu_nightly.yml
@@ -151,6 +151,10 @@ jobs:
     - name: Create Conda Environment
       run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
 
+    - name: Install C/C++ Compilers
+      # CXX compiler is needed for inductor used by torchrec.
+      run: . $PRELUDE; install_cxx_compiler $BUILD_ENV
+
     - name: Install PyTorch-CPU Nightly
       run: . $PRELUDE; install_pytorch_pip $BUILD_ENV nightly cpu
 

--- a/fbgemm_gpu/test/split_embedding_inference_converter_test.py
+++ b/fbgemm_gpu/test/split_embedding_inference_converter_test.py
@@ -221,7 +221,9 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
             quantization_config=quantization_config,
         )
         split_emb_infer_converter.convert_model(sparse_arch)
-        assert type(sparse_arch.emb_module) == IntNBitTableBatchedEmbeddingBagsCodegen
+        assert isinstance(
+            sparse_arch.emb_module, IntNBitTableBatchedEmbeddingBagsCodegen
+        )
         assert sparse_arch.emb_module.use_cpu == use_cpu
         quantized_emb_out = sparse_arch(indices.int(), offsets.int())  # B, T, D
 
@@ -303,8 +305,8 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
                 use_array_for_index_remapping=use_array_for_index_remapping,
             )
             split_emb_infer_converter.convert_model(sparse_arch)
-            assert (
-                type(sparse_arch.emb_module) == IntNBitTableBatchedEmbeddingBagsCodegen
+            assert isinstance(
+                sparse_arch.emb_module, IntNBitTableBatchedEmbeddingBagsCodegen
             )
             assert sparse_arch.emb_module.use_cpu == use_cpu
             pruned_emb_out = sparse_arch(
@@ -359,7 +361,9 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
         )
         split_emb_infer_converter.convert_model(sparse_arch)
         embedding_weights_after = sparse_arch.emb_module.split_embedding_weights()
-        assert type(sparse_arch.emb_module) == IntNBitTableBatchedEmbeddingBagsCodegen
+        assert isinstance(
+            sparse_arch.emb_module, IntNBitTableBatchedEmbeddingBagsCodegen
+        )
         assert sparse_arch.emb_module.use_cpu == use_cpu
 
         # Collect #rows after pruning.

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -1774,13 +1774,13 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             )
         )
         if optimizer is None:
-            assert type(gos) == list
+            assert isinstance(gos, list)
             if do_pooling:
                 goc = torch.cat([go.view(B, -1) for go in gos], dim=1)
             else:
                 goc = torch.cat(gos, dim=0)
         else:
-            assert type(gos) == Tensor
+            assert isinstance(gos, Tensor)
             goc = gos.clone()
         fc2.backward(goc)
 


### PR DESCRIPTION
Summary:
This diff is to fix error E721 from lint
Error: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`

https://github.com/pytorch/FBGEMM/actions/runs/5767549179/job/15637392972

Reviewed By: sryap

Differential Revision: D48086663

