### PR TITLE
revert changes on __fma_rn, __fmaf_rn, etc.

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
@@ -805,15 +805,10 @@ struct Vec4T<double> {
 
   // this <- this + a * b
   DEVICE_INLINE void fma_(const Vec4T<double>& a, const double b) {
-#ifndef __HIP_PLATFORM_HCC__
     acc.x = __fma_rn(a.acc.x, b, acc.x);
     acc.y = __fma_rn(a.acc.y, b, acc.y);
     acc.z = __fma_rn(a.acc.z, b, acc.z);
     acc.w = __fma_rn(a.acc.w, b, acc.w);
-#else
-    // AMD doesn't support __fma_rn on double precision
-    CUDA_KERNEL_ASSERT(false);
-#endif
   }
 
   // this <- this + a
@@ -3173,27 +3168,17 @@ struct Vec4AccT {
   }
 
   DEVICE_INLINE void fma_(const float* vals, const float weight) {
-#ifndef __HIP_PLATFORM_HCC__
     acc[0] = __fmaf_rn(vals[0], weight, acc[0]);
     acc[1] = __fmaf_rn(vals[1], weight, acc[1]);
     acc[2] = __fmaf_rn(vals[2], weight, acc[2]);
     acc[3] = __fmaf_rn(vals[3], weight, acc[3]);
-#else
-    // AMD doesn't support __fmul_rn
-    CUDA_KERNEL_ASSERT(false);
-#endif
   }
 
   DEVICE_INLINE void fma_(const half* vals, const float weight) {
-#ifndef __HIP_PLATFORM_HCC__
-    acc[0] = __fmaf_rn(vals[0], weight, acc[0]);
-    acc[1] = __fmaf_rn(vals[1], weight, acc[1]);
-    acc[2] = __fmaf_rn(vals[2], weight, acc[2]);
-    acc[3] = __fmaf_rn(vals[3], weight, acc[3]);
-#else
-    // AMD doesn't support __fmaf_rn
-    CUDA_KERNEL_ASSERT(false);
-#endif
+    acc[0] = __fmaf_rn(__half2float(vals[0]), weight, acc[0]);
+    acc[1] = __fmaf_rn(__half2float(vals[1]), weight, acc[1]);
+    acc[2] = __fmaf_rn(__half2float(vals[2]), weight, acc[2]);
+    acc[3] = __fmaf_rn(__half2float(vals[3]), weight, acc[3]);
   }
 
   DEVICE_INLINE void store_(const float4* src, float4* dst) {
@@ -3319,30 +3304,20 @@ struct Vec4StepT<STEP, float> : Vec4AccT {
   index_weighted_store(uint32_t idx, float4* ptr, const float weight) {
     const float* vals = reinterpret_cast<const float*>(&loaded_vals[idx]);
     float* ptr_f = reinterpret_cast<float*>(ptr);
-#ifndef __HIP_PLATFORM_HCC__
     ptr_f[0] = __fmul_rn(vals[0], weight);
     ptr_f[1] = __fmul_rn(vals[1], weight);
     ptr_f[2] = __fmul_rn(vals[2], weight);
     ptr_f[3] = __fmul_rn(vals[3], weight);
-#else
-    // AMD doesn't support __fmul_rn
-    CUDA_KERNEL_ASSERT(false);
-#endif
   }
 
   DEVICE_INLINE void
   index_weighted_store(uint32_t idx, float2* ptr, const float weight) {
     const float* vals = reinterpret_cast<const float*>(&loaded_vals[idx]);
     float vals_f[4];
-#ifndef __HIP_PLATFORM_HCC__
     vals_f[0] = __fmul_rn(vals[0], weight);
     vals_f[1] = __fmul_rn(vals[1], weight);
     vals_f[2] = __fmul_rn(vals[2], weight);
     vals_f[3] = __fmul_rn(vals[3], weight);
-#else
-    // AMD doesn't support __fmul_rn
-    CUDA_KERNEL_ASSERT(false);
-#endif
     this->store_(reinterpret_cast<float4*>(vals_f), ptr);
   }
 
@@ -3438,30 +3413,20 @@ struct Vec4StepT<STEP, at::Half> : Vec4AccT {
   index_weighted_store(uint32_t idx, float4* ptr, const float weight) {
     const half* vals = reinterpret_cast<const half*>(&loaded_vals[idx]);
     float* ptr_f = reinterpret_cast<float*>(ptr);
-#ifndef __HIP_PLATFORM_HCC__
-    ptr_f[0] = __fmul_rn(vals[0], weight);
-    ptr_f[1] = __fmul_rn(vals[1], weight);
-    ptr_f[2] = __fmul_rn(vals[2], weight);
-    ptr_f[3] = __fmul_rn(vals[3], weight);
-#else
-    // AMD doesn't support __fmul_rn
-    CUDA_KERNEL_ASSERT(false);
-#endif
+    ptr_f[0] = __fmul_rn(__half2float(vals[0]), weight);
+    ptr_f[1] = __fmul_rn(__half2float(vals[1]), weight);
+    ptr_f[2] = __fmul_rn(__half2float(vals[2]), weight);
+    ptr_f[3] = __fmul_rn(__half2float(vals[3]), weight);
   }
 
   DEVICE_INLINE void
   index_weighted_store(uint32_t idx, float2* ptr, const float weight) {
     const float* vals = reinterpret_cast<const float*>(&loaded_vals[idx]);
     float vals_f[4];
-#ifndef __HIP_PLATFORM_HCC__
     vals_f[0] = __fmul_rn(vals[0], weight);
     vals_f[1] = __fmul_rn(vals[1], weight);
     vals_f[2] = __fmul_rn(vals[2], weight);
     vals_f[3] = __fmul_rn(vals[3], weight);
-#else
-    // AMD doesn't support __fmul_rn
-    CUDA_KERNEL_ASSERT(false);
-#endif
     this->store_(reinterpret_cast<float4*>(vals_f), ptr);
   }
 


### PR DESCRIPTION
Summary:
AMD supports `__fma_rn` / `__fmaf_rn` etc. in https://clang.llvm.org/doxygen/____clang__hip__math_8h.html#aa8f73b90792a75ca57693316c5107587 (Thanks xw285cornell for pointing this out!)

Previously we cannot pass the AMD build because AMD compiler requires the explicit half <-> float conversions. Now we add this `__half2float` conversion APIs explicitly.

Differential Revision: D48142777

