### PR TITLE
handle EmbeddingBagCollectionsSparseArch in serialization

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/quantize_comm.py
+++ b/fbgemm_gpu/fbgemm_gpu/quantize_comm.py
@@ -193,7 +193,9 @@ class QuantizedCommCodec:
             self._comm_precision == SparseType.FP8 and self._row_dim > 0
         ):
             ctx = none_throws(ctx)
-            assert input_len % ctx.row_dim == 0
+            assert (
+                input_len % ctx.row_dim == 0
+            ), f"input_len {input_len} is not a multiple of row dim {ctx.row_dim}"
             nrows = input_len // ctx.row_dim
             ncols = (ctx.row_dim + 3) // 4 * 4 + 2 * 4
             return nrows * ncols


### PR DESCRIPTION
Summary:
This adds support for the new EBC-based sparse arch along side our existing support for PooledEmbeddingArch.

It's mostly analagous to the work done for PEA. The only complication is the `regroup_as_dict` operation, where we are turning a `List[KeyedTensor]` into a `Dict[str, Tensor]` and optionally casting to bf16. This happens separately from the rest of the sparse arch, but contains KJT code so we can't trace it.

I solved this by pulling out `regroup_as_dict` as making it a method of `EmbeddingBagCollectionsSparseArch`, and doing a similar swap + custom op trick as we do for the sparse arch itself. I think this will be reasonably durable (I don't expect the usage pattern to change very much), but obviously long term we want to avoid special-casing stuff like this (cc ezyang on the need for good KJT tracing :P )

Differential Revision: D47803009

