### PR TITLE
Don't call avx512 implementation if we didn't build it

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -521,6 +521,8 @@ if(NOT USE_ROCM AND CXX_AVX512_FOUND)
     ${fbgemm_sources}
     ${fbgemm_sources_avx2}
     ${fbgemm_sources_avx512})
+else()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNO_AVX512=1")
 endif()
 
 set(fbgemm_sources_include_directories


### PR DESCRIPTION
You can't use `__AVX512F__` because EmbeddingSpMDM isn't actually
built with -mavx512f.  Carefully selected the macro to be NO_AVX512
so that I don't have to modify the fbcode build (where we assume
we have AVX512 compiler support).

Signed-off-by: Edward Z. Yang <ezyang@meta.com>
