### PR TITLE
Add support for duplicate in permutations for permute_pooled_embs_split

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/permute_pooled_embedding_ops_split.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/permute_pooled_embedding_ops_split.h
@@ -22,6 +22,28 @@ at::Tensor permute_pooled_embs_split_cpu(
     const at::Tensor& inv_offset_dim_list,
     const at::Tensor& inv_permute_list);
 
+// Implementation of permute_pooled_embs_split for GPU. This supports both the
+// duplicate and non-duplicate cases with the allow_duplicates flag.
+///@ingroup permute-pooled-embs-gpu-impl
+at::Tensor permute_pooled_embs_split_gpu_impl(
+    const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
+    const at::Tensor& offset_dim_list,
+    const at::Tensor& permute_list,
+    const at::Tensor& inv_offset_dim_list,
+    const at::Tensor& inv_permute_list,
+    const bool& allow_duplicates);
+
+// Implementation of permute_pooled_embs_split for GPU for the duplicate
+// permutations use case. This calls the permute_pooled_embs_split_gpu_impl
+// function.
+///@ingroup permute-duplicate-pooled-embs-gpu
+at::Tensor permute_duplicate_pooled_embs_split_gpu(
+    const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
+    const at::Tensor& offset_dim_list,
+    const at::Tensor& permute_list,
+    const at::Tensor& inv_offset_dim_list,
+    const at::Tensor& inv_permute_list);
+
 ///@ingroup permute-pooled-embs-gpu
 at::Tensor permute_pooled_embs_split_gpu(
     const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
@@ -32,6 +54,16 @@ at::Tensor permute_pooled_embs_split_gpu(
 
 ///@ingroup permute-pooled-embs-cpu
 at::Tensor permute_pooled_embs_auto_grad_split_cpu(
+    const at::Tensor& pooled_embs,
+    const at::Tensor& offset_dim_list,
+    const at::Tensor& permute_list,
+    const at::Tensor& inv_offset_dim_list,
+    const at::Tensor& inv_permute_list);
+
+// Implementation of permute_pooled_embs_auto_grad_split for GPU for the
+// duplicate permutations use case.
+///@ingroup permute-duplicate-pooled-embs-gpu
+at::Tensor permute_duplicate_pooled_embs_auto_grad_split_gpu(
     const at::Tensor& pooled_embs,
     const at::Tensor& offset_dim_list,
     const at::Tensor& permute_list,

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops.cu
@@ -57,6 +57,7 @@ Tensor permute_pooled_embs_gpu(
       inv_permute_list,
       false);
 }
+
 Tensor permute_pooled_embs_gpu_impl(
     const Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
     const Tensor& offset_dim_list,

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split_gpu.cpp
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split_gpu.cpp
@@ -34,12 +34,33 @@ Tensor permute_pooled_embs_auto_grad_split_gpu(
       inv_permute_list);
 }
 
+Tensor permute_duplicate_pooled_embs_auto_grad_split_gpu(
+    const Tensor& pooled_embs,
+    const Tensor& offset_dim_list,
+    const Tensor& permute_list,
+    const Tensor& inv_offset_dim_list,
+    const Tensor& inv_permute_list) {
+  return PermutePooledEmbsFunctionSplit<
+      permute_duplicate_pooled_embs_split_gpu>::
+      apply(
+          pooled_embs,
+          offset_dim_list,
+          permute_list,
+          inv_offset_dim_list,
+          inv_permute_list);
+}
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   DISPATCH_TO_CUDA(
       "permute_pooled_embs_split", fbgemm_gpu::permute_pooled_embs_split_gpu);
   DISPATCH_TO_CUDA(
+      "permute_duplicate_pooled_embs_split",
+      fbgemm_gpu::permute_duplicate_pooled_embs_split_gpu);
+  DISPATCH_TO_CUDA(
       "permute_pooled_embs_auto_grad_split",
       fbgemm_gpu::permute_pooled_embs_auto_grad_split_gpu);
+  DISPATCH_TO_CUDA(
+      "permute_duplicate_pooled_embs_auto_grad_split",
+      fbgemm_gpu::permute_duplicate_pooled_embs_auto_grad_split_gpu);
 }

--- a/fbgemm_gpu/test/permute_pooled_embedding_split_test.py
+++ b/fbgemm_gpu/test/permute_pooled_embedding_split_test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from itertools import accumulate
+from typing import List, Tuple
+
+import torch
+import torch._dynamo
+
+try:
+    # pyre-ignore[21]
+    from fbgemm_gpu import open_source  # noqa: F401
+
+    # pyre-ignore[21]
+    from test_utils import gpu_unavailable
+except Exception:
+    torch.ops.load_library(
+        "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_split_gpu"
+    )
+    torch.ops.load_library(
+        "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_split_cpu"
+    )
+    from fbgemm_gpu.test.test_utils import gpu_unavailable
+
+typed_gpu_unavailable: Tuple[bool, str] = gpu_unavailable
+
+
+class PermutePooledEmbeddingSplitTest(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.device = "cuda"
+
+    @unittest.skipIf(*typed_gpu_unavailable)
+    def test_duplicate_permutations(self) -> None:
+        # self.device = "cuda"
+        embs_dims = [2, 3, 1, 4]
+        permute = [3, 0, 2, 0, 1, 3]
+        expected_result = [6, 7, 8, 9, 0, 1, 5, 0, 1, 2, 3, 4, 6, 7, 8, 9]
+        input = torch.Tensor([range(10)]).to(device="cuda")
+
+        _permute = torch.tensor(permute, device=self.device, dtype=torch.int64)
+        _offset_dim_list = torch.tensor(
+            [0] + list(accumulate(embs_dims)), device=self.device, dtype=torch.int64
+        )
+        inv_permute: List[int] = [0] * len(permute)
+        for i, p in enumerate(permute):
+            inv_permute[p] = i
+        _inv_permute = torch.tensor(inv_permute, device=self.device, dtype=torch.int64)
+        inv_embs_dims = [embs_dims[i] for i in permute]
+        _inv_offset_dim_list = torch.tensor(
+            [0] + list(accumulate(inv_embs_dims)),
+            device=self.device,
+            dtype=torch.int64,
+        )
+
+        result = torch.ops.fbgemm.permute_duplicate_pooled_embs_auto_grad_split(
+            input,
+            _offset_dim_list.to(device=input.device),
+            _permute.to(device=input.device),
+            _inv_offset_dim_list.to(device=input.device),
+            _inv_permute.to(device=input.device),
+        )
+        self.assertEqual(
+            result.view(16).tolist(),
+            expected_result,
+        )
+
+        input = input.to(device="cpu")
+        result = torch.ops.fbgemm.permute_duplicate_pooled_embs_auto_grad_split(
+            input,
+            _offset_dim_list.to(device=input.device),
+            _permute.to(device=input.device),
+            _inv_offset_dim_list.to(device=input.device),
+            _inv_permute.to(device=input.device),
+        )
+        self.assertEqual(
+            result.view(16).tolist(),
+            expected_result,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
This diff builds ontop of the pervious diffs and adds support for duplicates to the permute_pooled_embs_split op.

Background
Currently permute_pooled_embs_split does not support duplicates in a permutation, this poses a problem with passing the same embeddings to multiple modules. This doc proposes a solution to allow duplicate subsets in the resultant permutation.
Details
The required implementation of permute_pooled_embs_split should support a subset being repeated. This is represented by having duplicates in the permute list. This also results in the output list size being greater than the input list.
Input: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
Offset_dims: [0,  2,  5,  6, 10]
Permute: [3, 0, 2, 1, 3]
Output:  [6, 7, 8, 9, 0, 1, 5, 2, 3, 4, 6, 7, 8, 9]

Differential Revision: D48305847

