### PR TITLE
mask_conversion_sparse call `masked_select_jagged_1d` directly

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -478,20 +478,26 @@ std::tuple<at::Tensor, at::Tensor> jagged_dense_bmm(
     const at::Tensor& y,
     const int64_t max_L);
 
+std::tuple<at::Tensor, at::Tensor> masked_select_jagged_1d(
+    const at::Tensor& values,
+    const at::Tensor& lengths,
+    const at::Tensor& mask);
+
 #endif
 
 ///@ingroup sparse-data-cpu
 /// Divide the prediction range (e.g., [0, 1]) into B bins. In each bin, use
-/// two parameters to store the number of positive examples and the number of
-/// examples that fall into this bucket. So we basically have a histogram for
-/// the model prediction. As a result, for each bin, we have a statistical
-/// value for the real CTR (`num_pos / num_example`). We use this statistical
-/// value as the final calibrated prediction if the pre-cali prediction falls
-/// into the corresponding bin. In this way, the predictions within each bin
-/// should be well-calibrated if we have sufficient examples. That is, we have
-/// a fine-grained calibrated model by this calibration module. Theoretically,
-/// this calibration layer can fix any uncalibrated model or prediction if we
-/// have sufficient bins and examples.
+/// two parameters to store the number of positive examples and the number
+/// of examples that fall into this bucket. So we basically have a histogram
+/// for the model prediction. As a result, for each bin, we have a
+/// statistical value for the real CTR (`num_pos / num_example`). We use
+/// this statistical value as the final calibrated prediction if the
+/// pre-cali prediction falls into the corresponding bin. In this way, the
+/// predictions within each bin should be well-calibrated if we have
+/// sufficient examples. That is, we have a fine-grained calibrated model by
+/// this calibration module. Theoretically, this calibration layer can fix
+/// any uncalibrated model or prediction if we have sufficient bins and
+/// examples.
 ///@return `[calibrated_prediction, bin_ids]`
 ///@param logit is input tensor before applying Sigmoid.
 /// Assumes positive weight calibration is used for calibartion target, and
@@ -501,8 +507,8 @@ std::tuple<at::Tensor, at::Tensor> jagged_dense_bmm(
 ///@param lower/upper_bound Bounds of the bins.
 ///@param bin_ctr_in_use_after We will use the calibration_target for the
 /// final calibrated prediction if we don't have sufficient examples. Only
-/// use the statistical value of bin CTR after we observe `bin_ctr_in_use_after`
-/// examples that fall in this bin. Default value: 0.
+/// use the statistical value of bin CTR after we observe
+/// `bin_ctr_in_use_after` examples that fall in this bin. Default value: 0.
 ///@param bin_ctr_weight_value Weight for statistical value of bin CTR.
 /// When this is specified, we perform a weighted sum for the statisctical
 /// bin CTR and the calibration_target:

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -912,6 +912,8 @@ Tensor jagged_1d_to_truncated_values_cpu(
   return truncated_values;
 }
 
+} // namespace
+
 std::tuple<Tensor, Tensor> masked_select_jagged_1d(
     const Tensor& values,
     const Tensor& lengths,
@@ -965,8 +967,6 @@ std::tuple<Tensor, Tensor> masked_select_jagged_1d(
 
   return {masked_values, masked_lengths};
 }
-
-} // namespace
 
 Tensor
 jagged_2d_to_dense_forward_cpu(Tensor values, Tensor offsets, int64_t max_L) {


### PR DESCRIPTION
Summary: perf optimization. while a further step should be having a fused version of it.

Reviewed By: bearzx

Differential Revision: D48288997

