### PR TITLE
Fix autograd for permute_pooled_embedding_ops

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops_utils.h
@@ -108,6 +108,19 @@ inline bool torch_tensor_empty_or_on_cpu_check(
 #define DISPATCH_TO_ALL(name, function) \
   m.impl(name, torch::dispatch(c10::DispatchKey::CatchAll, TORCH_FN(function)))
 
+#define DISPATCH_TO_AUTOGRAD(name, function) \
+  m.impl(name, torch::dispatch(c10::DispatchKey::Autograd, TORCH_FN(function)))
+
+#define DISPATCH_TO_AUTOGRAD_CUDA(name, function) \
+  m.impl(                                         \
+      name,                                       \
+      torch::dispatch(c10::DispatchKey::AutogradCUDA, TORCH_FN(function)))
+
+#define DISPATCH_TO_AUTOGRAD_META(name, function) \
+  m.impl(                                         \
+      name,                                       \
+      torch::dispatch(c10::DispatchKey::AutogradMETA, TORCH_FN(function)))
+
 #define TENSOR_ON_CPU(x)                                      \
   TORCH_CHECK(                                                \
       torch_tensor_on_cpu_check(x),                           \


### PR DESCRIPTION
Summary: Make sure the permute_pooled_embedding follow the standard way of implementing autograd function and registering in PyTorch dispatcher.

Differential Revision: D48409758

