### PR TITLE
Change published cuda version to be 11.8.0

### DIFF
--- a/.github/scripts/fbgemm_gpu_build.bash
+++ b/.github/scripts/fbgemm_gpu_build.bash
@@ -300,7 +300,7 @@ build_fbgemm_gpu_package () {
 
   # Distribute Python extensions as wheels on Linux
   echo "[BUILD] Building FBGEMM-GPU wheel (VARIANT=${fbgemm_variant}) ..."
-  print_exec conda run -n "${env_name}" \
+  print_exec VERBOSE=1 conda run -n "${env_name}" \
     python setup.py bdist_wheel \
       --package_name="${package_name}" \
       --python-tag="${python_tag}" \

--- a/.github/workflows/fbgemm_gpu_cuda_nightly.yml
+++ b/.github/workflows/fbgemm_gpu_cuda_nightly.yml
@@ -130,7 +130,7 @@ jobs:
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]
         cuda-version: [ "11.7.1", "11.8.0", "12.1.1" ]
         # Specify exactly ONE CUDA version for artifact publish
-        cuda-version-publish: [ "11.7.1" ]
+        cuda-version-publish: [ "11.8.0" ]
     needs: build_artifact
 
     steps:


### PR DESCRIPTION
Summary:
Published fbgemm-gpu-nightly only works with cuda 11.7.1 environments and is not compatible with cuda 11.8 environment (e.g., torchnightly) and would throw `NotImplementedError: Could not run 'fbgemm::permute_2D_sparse_data'' with arguments from the 'CUDA' backend`.

https://github.com/pytorch/FBGEMM/issues/1847#event-10113251990

Reviewed By: sryap, shintaro-iwasaki

Differential Revision: D48445420

