### PR TITLE
use torch_check_not_implemented to force a graph break instead of crashing

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_autograd.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_autograd.cpp
@@ -697,7 +697,7 @@ class JaggedSliceOp : public torch::autograd::Function<JaggedSliceOp> {
 Tensor jagged_to_padded_dense(
     const Tensor& values,
     const std::vector<Tensor>& offsets,
-    c10::SymIntArrayRef max_lengths,
+    const c10::SymIntArrayRef max_lengths,
     const double padding_value) {
   return JaggedToPaddedDenseOp::apply(
       values, offsets, max_lengths, padding_value)[0];

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_meta.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_meta.cpp
@@ -98,7 +98,8 @@ Tensor dense_to_jagged_forward_meta(
     const c10::optional<at::SymInt>& total_L) {
   auto dense_values = dense;
   at::SymInt D = dense_values.sym_size(-1);
-  TORCH_CHECK(total_L.has_value(), "total_L is required for meta backend");
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      total_L.has_value(), "total_L is required for meta backend");
   auto& total_L_computed = total_L.value();
   auto values = at::zeros_symint({total_L_computed, D}, dense_values.options());
 


### PR DESCRIPTION
Summary: Change TORCH_CHECK to TORCH_CHECK_NOT_IMPLEMENTED to force a graph break. This op needs a unbacked symint because it's data dependent. Not sure if there is a better way

Reviewed By: anijain2305

Differential Revision: D48489405

