### PR TITLE
Add BF16 in FP8 quantize ops

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
@@ -1687,6 +1687,15 @@ DEVICE_INLINE half16 to_half16(float_16 v) {
   return t;
 }
 
+// Override __bfloat162float to accept at::BFloat16
+static DEVICE_INLINE float __bfloat162float(const at::BFloat16 input) {
+#ifdef __HIP_PLATFORM_HCC__
+  return float(*reinterpret_cast<const __nv_bfloat16*>(&input));
+#else
+  return __bfloat162float(*reinterpret_cast<const __nv_bfloat16*>(&input));
+#endif
+}
+
 #ifdef __HIP_PLATFORM_HCC__
 // the descriptions of __float2bfloat16 and __float2bfloat16_rn are identical
 // https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH____BFLOAT16__MISC.html#group__CUDA__MATH____BFLOAT16__MISC

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -220,7 +220,8 @@ at::Tensor _float_or_half_to_fused8bitrowwise_gpu(const at::Tensor& input);
 at::Tensor _fused8bitrowwise_to_float_gpu(const at::Tensor& input);
 at::Tensor _FP8rowwise_to_float_gpu(
     const at::Tensor& input,
-    const bool forward = true);
+    const bool forward = true,
+    const int64_t output_dtype = 0);
 at::Tensor _paddedFP8rowwise_to_float_gpu(
     const at::Tensor& input,
     const bool forward = true,
@@ -239,7 +240,8 @@ at::Tensor float_or_half_to_fused8bitrowwise_cpu(const at::Tensor& input);
 at::Tensor fused8bitrowwise_to_float_cpu(const at::Tensor& input);
 at::Tensor FP8rowwise_to_float_cpu(
     const at::Tensor& input,
-    const bool forward = true);
+    const bool forward = true,
+    const int64_t output_dtype = 0);
 at::Tensor fused8bitrowwise_to_half_cpu(const at::Tensor& input);
 at::Tensor fused8bitrowwise_to_float_or_half_cpu(
     const at::Tensor& input,

--- a/fbgemm_gpu/src/quantize_ops/common.cuh
+++ b/fbgemm_gpu/src/quantize_ops/common.cuh
@@ -30,21 +30,3 @@
 #define QUANTIZE_OPS_MIN(a, b) ((a) < (b) ? (a) : (b))
 
 using Tensor = at::Tensor;
-
-namespace fbgemm_gpu {
-
-namespace {
-
-template <typename T>
-__device__ inline __attribute__((always_inline)) T
-quantize_ops_shfl_xor(const T val, int laneMask, int width) {
-#if defined(__HIP_PLATFORM_HCC__) || CUDA_VERSION < 9000
-  return __shfl_xor(val, laneMask, width);
-#else
-  return __shfl_xor_sync(0xffffffff, val, laneMask, width);
-#endif
-}
-
-} // namespace
-
-} // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/quantize_ops/quantize_fused_8bit_rowwise.cu
+++ b/fbgemm_gpu/src/quantize_ops/quantize_fused_8bit_rowwise.cu
@@ -95,12 +95,10 @@ __global__ inline void _get_8bit_qparam_cuda_kernel(
   // participate, even if they aren't assigned to a row, since we can't assume
   // the existence of the `*_sync` warp primitives with support for masking.
   for (int offset = lane_width >> 1; offset > 0; offset >>= 1) {
-    minimum_element = fminf(
-        minimum_element,
-        quantize_ops_shfl_xor(minimum_element, offset, lane_width));
-    maximum_element = fmaxf(
-        maximum_element,
-        quantize_ops_shfl_xor(maximum_element, offset, lane_width));
+    minimum_element =
+        fminf(minimum_element, shfl_xor(minimum_element, offset, lane_width));
+    maximum_element =
+        fmaxf(maximum_element, shfl_xor(maximum_element, offset, lane_width));
   }
 
   // only the leading thread in the warp is needed to return the final result in

--- a/fbgemm_gpu/src/quantize_ops/quantize_ops_cpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops/quantize_ops_cpu.cpp
@@ -214,7 +214,6 @@ Tensor fused8bitrowwise_to_float_or_half_cpu(
     const Tensor& input,
     const int64_t output_dtype) {
   Tensor output;
-
   SparseType output_sparse_dtype = static_cast<SparseType>(output_dtype);
   switch (output_sparse_dtype) {
     case SparseType::FP32:
@@ -241,7 +240,10 @@ Tensor float_to_FP8rowwise_cpu(const Tensor& input, bool forward) {
 }
 
 ///@ingroup quantize-data-cpu
-Tensor FP8rowwise_to_float_cpu(const Tensor& input, bool forward) {
+Tensor FP8rowwise_to_float_cpu(
+    const Tensor& input,
+    bool forward,
+    const int64_t output_dtype) {
   TORCH_CHECK(false, "fp8 is not supported by CPU");
   return input;
 }
@@ -413,7 +415,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def("HalfToFused8BitRowwiseQuantized(Tensor t) -> Tensor");
   m.def("FloatOrHalfToFused8BitRowwiseQuantized(Tensor t) -> Tensor");
   m.def("Fused8BitRowwiseQuantizedToFloat(Tensor input) -> Tensor");
-  m.def("FP8RowwiseQuantizedToFloat(Tensor input, bool forward) -> Tensor");
+  m.def(
+      "FP8RowwiseQuantizedToFloat(Tensor input, bool forward, int output_dtype=0) -> Tensor");
   m.def("Fused8BitRowwiseQuantizedToHalf(Tensor input) -> Tensor");
   m.def(
       "Fused8BitRowwiseQuantizedToFloatOrHalf(Tensor input, int output_dtype=0) -> Tensor");

--- a/fbgemm_gpu/test/quantize_ops_test.py
+++ b/fbgemm_gpu/test/quantize_ops_test.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
+import os
 import random
 import unittest
 from ctypes import c_float, c_int32, cast, POINTER, pointer
@@ -13,7 +15,7 @@ import hypothesis.strategies as st
 import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from hypothesis import assume, given, HealthCheck, settings
+from hypothesis import assume, given, HealthCheck, settings, Verbosity
 from torch import Tensor
 
 
@@ -967,6 +969,88 @@ class TestBfloat16QuantizationConversion(unittest.TestCase):
             )
             # compare quantized data
             torch.testing.assert_close(dequantized_data_gpu.cpu(), dequantized_data)
+
+
+class TestFP8RowwiseQuantizationConversion(unittest.TestCase):
+    enable_logging: bool = False
+
+    def setUp(self) -> None:
+        self.enable_logging = bool(os.getenv("FBGEMM_GPU_ENABLE_LOGGING", 0))
+        if self.enable_logging:
+            logging.info("Enabled logging for TestFP8RowwiseQuantizationConversion")
+
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-fixme[56]:
+    @given(
+        batched=st.booleans(),
+        bs=st.integers(min_value=1, max_value=100),
+        m=st.integers(min_value=0, max_value=100),
+        n=st.integers(min_value=0, max_value=100),
+        forward=st.booleans(),
+        given_last_dim=st.booleans(),
+        dtype=st.sampled_from(
+            [
+                torch.float,
+                torch.half,
+                torch.bfloat16,
+            ],
+        ),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
+    def test_quantize_and_dequantize_op_fp8_rowwise(
+        self,
+        batched: bool,
+        bs: int,
+        m: int,
+        n: int,
+        forward: bool,
+        given_last_dim: bool,
+        dtype: torch.dtype,
+    ) -> None:
+        n = n * 4  # need (n % 4 == 0)
+        input_data = (
+            torch.rand(bs, m, n, dtype=dtype)
+            if batched
+            else torch.rand(bs * m, n, dtype=dtype)
+        )
+
+        input_data_gpu = input_data.cuda()
+        quantized_data_gpu = torch.ops.fbgemm.FloatToFP8RowwiseQuantized(
+            input_data_gpu, forward=forward
+        )
+        dequantized_data_gpu = torch.ops.fbgemm.FP8RowwiseQuantizedToFloat(
+            quantized_data_gpu,
+            forward=forward,
+            output_dtype=SparseType.FP32.as_int()
+            if dtype == torch.float
+            else (
+                SparseType.FP16.as_int()
+                if dtype == torch.half
+                else SparseType.BF16.as_int()
+            ),
+        )
+
+        if m == 0 or n == 0:
+            assert dequantized_data_gpu.numel() == 0
+            return
+
+        assert (
+            dequantized_data_gpu.dtype == dtype
+        ), "result is {dequantized_data_gpu.dtype} type, but expected {dtype}"
+        qref = input_data_gpu.float()
+        dq = dequantized_data_gpu.float()
+
+        if self.enable_logging:
+            # Logging quantization errors
+            errors = (qref - dq) / (qref + 1e-5)
+            logging.info(f"max relative error {errors.abs().max()}")
+            val, idx = torch.topk(errors.flatten().abs(), k=min(10, errors.shape[-1]))
+            logging.info(f"top-10 errors {val}")
+            logging.info(f"ref data {input_data_gpu.flatten()}")
+            logging.info(f"dequantized data {dequantized_data_gpu.flatten()}")
+            logging.info(f"max relative error {errors.flatten()[idx]}")
+
+        torch.testing.assert_close(qref.cpu(), dq.cpu(), rtol=0.1, atol=0.05)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- Added output_dtype for half, bfloat16 and float as output in
  dequantization functions; currently it's an integer value defined by
  Sparse_dtype (float:0, half:1, bfloat16:5)
- Added type conversion in quant and dequant kernels by using native
  CUDA/HIP functions for half to float conversion and writing
  everything explicitly.

Differential Revision: D47904459

