### PR TITLE
Skip tests with bmm due to unstable testing on ARM

### DIFF
--- a/fbgemm_gpu/test/jagged_tensor_ops_test.py
+++ b/fbgemm_gpu/test/jagged_tensor_ops_test.py
@@ -2275,6 +2275,7 @@ class JaggedTensorOpsTest(unittest.TestCase):
         if gpu_available
         else st.just("cpu"),
     )
+    @unittest.skipIf(*on_arm_platform)
     @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
     def test_jagged_jagged_bmm(
         self,
@@ -2402,6 +2403,7 @@ class JaggedTensorOpsTest(unittest.TestCase):
         dtype=st.sampled_from([torch.float, torch.double]),
         device_type=st.just("cpu"),
     )
+    @unittest.skipIf(*on_arm_platform)
     @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
     def test_jagged_dense_bmm_dynamic_shape(
         self,


### PR DESCRIPTION
Summary:
Skip tests that use bmm due to unstable testing on ARM
- test_jagged_jagged_bmm
- test_jagged_dense_bmm_dynamic_shape

Reviewed By: sryap

Differential Revision: D48707683

