### PR TITLE
[T162270879][fbgemm_gpu] Deprecate CUDA 11.7 from OSS build jobs

### DIFF
--- a/.github/scripts/utils_pytorch.bash
+++ b/.github/scripts/utils_pytorch.bash
@@ -127,7 +127,10 @@ install_pytorch_pip () {
   elif [ "$pytorch_variant_type" == "rocm" ]; then
     # Extract the ROCM version or default to 5.3
     local rocm_version="${pytorch_variant_version:-5.3}"
-    local pytorch_variant="rocm${rocm_version}"
+    # shellcheck disable=SC2206
+    local rocm_version_arr=(${rocm_version//./ })
+    # Convert, i.e. rocm 5.5.1 => rocm5.5
+    local pytorch_variant="rocm${rocm_version_arr[0]}.${rocm_version_arr[1]}"
   else
     local pytorch_variant_type="cpu"
     local pytorch_variant="cpu"

--- a/.github/workflows/fbgemm_gpu_ci.yml
+++ b/.github/workflows/fbgemm_gpu_ci.yml
@@ -47,7 +47,7 @@ jobs:
         ]
         container-image: [ "ubuntu:20.04" ]
         python-version: [ "3.8", "3.9", "3.10" ]
-        rocm-version: [ "5.3", "5.4.2" ]
+        rocm-version: [ "5.5.1", "5.6" ]
 
     steps:
     - name: Setup Build Container
@@ -116,7 +116,7 @@ jobs:
         ]
         # ROCm machines are limited, so we only test against Python 3.10
         python-version: [ "3.10" ]
-        rocm-version: [ "5.3", "5.4.2" ]
+        rocm-version: [ "5.5.1", "5.6" ]
 
     steps:
     - name: Setup Build Container

--- a/.github/workflows/fbgemm_gpu_cuda_nightly.yml
+++ b/.github/workflows/fbgemm_gpu_cuda_nightly.yml
@@ -57,7 +57,7 @@ jobs:
           { arch: x86, instance: "linux.24xlarge" },
         ]
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]
-        cuda-version: [ "11.7.1", "11.8.0", "12.1.1" ]
+        cuda-version: [ "11.8.0", "12.1.1" ]
 
     steps:
     - name: Setup Build Container
@@ -128,9 +128,9 @@ jobs:
           { arch: x86, instance: "linux.g5.4xlarge.nvidia.gpu" },
         ]
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]
-        cuda-version: [ "11.7.1", "11.8.0", "12.1.1" ]
+        cuda-version: [ "11.8.0", "12.1.1" ]
         # Specify exactly ONE CUDA version for artifact publish
-        cuda-version-publish: [ "11.7.1" ]
+        cuda-version-publish: [ "11.8.0" ]
     needs: build_artifact
 
     steps:

--- a/.github/workflows/fbgemm_gpu_cuda_release.yml
+++ b/.github/workflows/fbgemm_gpu_cuda_release.yml
@@ -49,7 +49,7 @@ jobs:
           { arch: x86, instance: "linux.24xlarge" },
         ]
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]
-        cuda-version: [ "11.7.1", "11.8.0" ]
+        cuda-version: [ "11.8.0", "12.1.1" ]
 
     steps:
     - name: Setup Build Container
@@ -82,7 +82,7 @@ jobs:
       run: . $PRELUDE; install_cuda $BUILD_ENV ${{ matrix.cuda-version }}
 
     - name: Install PyTorch Test
-      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV test
+      run: . $PRELUDE; install_pytorch_pip $BUILD_ENV test cuda ${{ matrix.cuda-version }}
 
     - name: Install cuDNN
       run: . $PRELUDE; install_cudnn $BUILD_ENV "$(pwd)/build_only/cudnn" ${{ matrix.cuda-version }}
@@ -117,9 +117,9 @@ jobs:
           { arch: x86, instance: "linux.g5.4xlarge.nvidia.gpu" },
         ]
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]
-        cuda-version: [ "11.7.1", "11.8.0" ]
+        cuda-version: [ "11.8.0", "12.1.1" ]
         # Specify exactly ONE CUDA version for artifact publish
-        cuda-version-publish: [ "11.7.1" ]
+        cuda-version-publish: [ "11.8.0" ]
     needs: build_artifact
 
     steps:
@@ -152,7 +152,7 @@ jobs:
       run: . $PRELUDE; install_cuda $BUILD_ENV ${{ matrix.cuda-version }}
 
     - name: Install PyTorch Test
-      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV test
+      run: . $PRELUDE; install_pytorch_pip $BUILD_ENV test cuda ${{ matrix.cuda-version }}
 
     - name: Prepare FBGEMM_GPU Build
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV

--- a/fbgemm_gpu/src/sparse_ops/sparse_permute102.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute102.cu
@@ -8,6 +8,11 @@
 
 #include "common.cuh"
 
+#ifdef __HIP_PLATFORM_HCC__
+#define rocblas_set_stream hipblasSetStream
+#define rocblas_status_success HIPBLAS_STATUS_SUCCESS
+#endif
+
 using Tensor = at::Tensor;
 
 namespace fbgemm_gpu {


### PR DESCRIPTION
- Remove CUDA 11.7 support from OSS build jobs, since it is no longer supported in PyTorch.

- Upgrade the published version of FBGEMM to use CUDA 11.8