### PR TITLE
Deprecate CUDA 11.7 from OSS build jobs

### DIFF
--- a/.github/workflows/fbgemm_gpu_cuda_nightly.yml
+++ b/.github/workflows/fbgemm_gpu_cuda_nightly.yml
@@ -57,7 +57,7 @@ jobs:
           { arch: x86, instance: "linux.24xlarge" },
         ]
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]
-        cuda-version: [ "11.7.1", "11.8.0", "12.1.1" ]
+        cuda-version: [ "11.8.0", "12.1.1" ]
 
     steps:
     - name: Setup Build Container
@@ -128,7 +128,7 @@ jobs:
           { arch: x86, instance: "linux.g5.4xlarge.nvidia.gpu" },
         ]
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]
-        cuda-version: [ "11.7.1", "11.8.0", "12.1.1" ]
+        cuda-version: [ "11.8.0", "12.1.1" ]
         # Specify exactly ONE CUDA version for artifact publish
         cuda-version-publish: [ "11.8.0" ]
     needs: build_artifact

--- a/.github/workflows/fbgemm_gpu_cuda_release.yml
+++ b/.github/workflows/fbgemm_gpu_cuda_release.yml
@@ -49,7 +49,7 @@ jobs:
           { arch: x86, instance: "linux.24xlarge" },
         ]
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]
-        cuda-version: [ "11.7.1", "11.8.0" ]
+        cuda-version: [ "11.8.0", "12.1.1" ]
 
     steps:
     - name: Setup Build Container
@@ -82,7 +82,7 @@ jobs:
       run: . $PRELUDE; install_cuda $BUILD_ENV ${{ matrix.cuda-version }}
 
     - name: Install PyTorch Test
-      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV test
+      run: . $PRELUDE; install_pytorch_pip $BUILD_ENV test cuda ${{ matrix.cuda-version }}
 
     - name: Install cuDNN
       run: . $PRELUDE; install_cudnn $BUILD_ENV "$(pwd)/build_only/cudnn" ${{ matrix.cuda-version }}
@@ -117,9 +117,9 @@ jobs:
           { arch: x86, instance: "linux.g5.4xlarge.nvidia.gpu" },
         ]
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]
-        cuda-version: [ "11.7.1", "11.8.0" ]
+        cuda-version: [ "11.8.0", "12.1.1" ]
         # Specify exactly ONE CUDA version for artifact publish
-        cuda-version-publish: [ "11.7.1" ]
+        cuda-version-publish: [ "11.8.0" ]
     needs: build_artifact
 
     steps:
@@ -152,7 +152,7 @@ jobs:
       run: . $PRELUDE; install_cuda $BUILD_ENV ${{ matrix.cuda-version }}
 
     - name: Install PyTorch Test
-      run: . $PRELUDE; install_pytorch_conda $BUILD_ENV test
+      run: . $PRELUDE; install_pytorch_pip $BUILD_ENV test cuda ${{ matrix.cuda-version }}
 
     - name: Prepare FBGEMM_GPU Build
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV


### PR DESCRIPTION
Summary:
- Remove CUDA 11.7 support from OSS build jobs, since it is no longer supported in PyTorch.
- Upgrade the published version of FBGEMM to use CUDA 11.8

Differential Revision: D48764127

