### PR TITLE
Fix bug in fp8_split_embedding_codegen_forward_kernel dispatch

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_backward_code_generator.py
@@ -366,7 +366,7 @@ def forward_quantized() -> None:
                 template_instance_params(*map(str, (2, 4, 1, 2))),
                 template_instance_params(*map(str, (2, 4, 2, 4))),
                 template_instance_params(*map(str, (2, 4, 4, 8))),
-                template_instance_params(*map(str, (2, 2, 4, 8))),
+                template_instance_params(*map(str, (2, 2, 8, 16))),
             ],
         ),
         "INT8": elem_type(

--- a/fbgemm_gpu/codegen/embedding_forward_quantized_split_nbit_host_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_split_nbit_host_template.cu
@@ -410,7 +410,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
           Y(2, 4, 4, 8);
         }
         if (max_fp8_128b_rows > 8) {
-          Y(2, 2, 4, 8);
+          Y(2, 2, 8, 16);
         }
       }
     }));

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -4644,6 +4644,28 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         )
 
     @unittest.skipIf(*gpu_unavailable)
+    def test_nbit_forward_gpu_no_cache_fp8_2048(self) -> None:
+        # Test the case of FB8 table with 128B*8 < D <= 128B*16
+        self.execute_nbit_forward_(
+            T=1,
+            D=2048,  # 128B*8 < D <= 128B*16
+            B=128,
+            log_E=2,
+            L=4,
+            weighted=False,
+            mixed=False,
+            pooling_mode=PoolingMode.SUM,
+            weights_ty=SparseType.FP8,  # FP8 table
+            use_cache=False,
+            cache_algorithm=CacheAlgorithm.LRU,
+            use_cpu=False,
+            use_array_for_index_remapping=True,
+            do_pruning=False,
+            mixed_weights_ty=False,
+            output_dtype=SparseType.FP16,
+        )
+
+    @unittest.skipIf(*gpu_unavailable)
     @given(
         nbit_weights_ty=get_nbit_weights_ty(),
         use_array_for_index_remapping=st.booleans(),


### PR DESCRIPTION
Summary:

For the case of loading FP8 tables with 128B * 8 < dimension <= 128B * 16, the numbers for (MinNum128BRows, MaxNum128BRows) should be (8, 16) and not (4, 8 ). Because of this bug, FP8 tables with dimension in that range don't get properly loaded upon codegen_forward. I wrote a little test to show this deterministically. I will remove the test before land if it is too specific.

Differential Revision: D49139649


