### PR TITLE
Add BF16 in padded FP8 quantize ops

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
@@ -1696,6 +1696,19 @@ static DEVICE_INLINE float __bfloat162float(const at::BFloat16 input) {
 #endif
 }
 
+// Helper functions for converting data to float
+static DEVICE_INLINE float to_float(const float input) {
+  return input;
+}
+
+static DEVICE_INLINE float to_float(const at::Half input) {
+  return __half2float(input);
+}
+
+static DEVICE_INLINE float to_float(const at::BFloat16 input) {
+  return __bfloat162float(input);
+}
+
 #ifdef __HIP_PLATFORM_HCC__
 // the descriptions of __float2bfloat16 and __float2bfloat16_rn are identical
 // https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH____BFLOAT16__MISC.html#group__CUDA__MATH____BFLOAT16__MISC
@@ -1709,6 +1722,25 @@ static __host__ __device__ __nv_bfloat16 __float2bfloat16_rn(float f) {
   return output.round_to_bfloat16(f);
 }
 #endif
+
+// Helper functions for storing float in quantized storage
+static DEVICE_INLINE void quantize_float_store(
+    at::BFloat16* output,
+    const float input) {
+  *reinterpret_cast<__nv_bfloat16*>(output) = __float2bfloat16(input);
+}
+
+static DEVICE_INLINE void quantize_float_store(
+    at::Half* output,
+    const float input) {
+  *output = __float2half(input);
+}
+
+static DEVICE_INLINE void quantize_float_store(
+    float* output,
+    const float input) {
+  *output = input;
+}
 
 #if !(                                                  \
     ((defined(CUDA_VERSION) && CUDA_VERSION < 11000) || \

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -226,7 +226,8 @@ at::Tensor _paddedFP8rowwise_to_float_gpu(
     const at::Tensor& input,
     const bool forward = true,
     const int64_t row_dim = 256,
-    const int64_t output_last_dim = -1);
+    const int64_t output_last_dim = -1,
+    const int64_t output_dtype = 0);
 at::Tensor _fused8bitrowwise_to_half_gpu(const at::Tensor& input);
 at::Tensor _fused8bitrowwise_to_float_or_half_gpu(
     const at::Tensor& input,

--- a/fbgemm_gpu/src/quantize_ops/quantize_ops_cpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops/quantize_ops_cpu.cpp
@@ -446,7 +446,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "MSFPQuantizedToFloat(Tensor input, int ebits, int mbits, int bias) -> Tensor");
   m.def(
-      "PaddedFP8RowwiseQuantizedToFloat(Tensor input, bool forward, int row_dim, int output_last_dim=-1) -> Tensor");
+      "PaddedFP8RowwiseQuantizedToFloat(Tensor input, bool forward, int row_dim, int output_last_dim=-1, int output_dtype=0) -> Tensor");
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {

--- a/fbgemm_gpu/test/quantize_ops_test.py
+++ b/fbgemm_gpu/test/quantize_ops_test.py
@@ -977,11 +977,17 @@ class TestBfloat16QuantizationConversion(unittest.TestCase):
 
 class TestFP8RowwiseQuantizationConversion(unittest.TestCase):
     enable_logging: bool = False
+    max_examples: int = 40
 
     def setUp(self) -> None:
         self.enable_logging = bool(os.getenv("FBGEMM_GPU_ENABLE_LOGGING", 0))
         if self.enable_logging:
             logging.info("Enabled logging for TestFP8RowwiseQuantizationConversion")
+
+        torch._dynamo.config.cache_size_limit = self.max_examples
+        logging.info(
+            f"Setting torch._dynamo.config.cache_size_limit = {self.max_examples}"
+        )
 
     @unittest.skipIf(*gpu_unavailable)
     # pyre-fixme[56]:
@@ -1002,7 +1008,7 @@ class TestFP8RowwiseQuantizationConversion(unittest.TestCase):
         # if before PT 2.1, we don't support symint_vector, so turn it off
         test_compile=st.booleans() if symint_vector_unsupported() else st.just(False),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
+    @settings(verbosity=Verbosity.verbose, max_examples=max_examples, deadline=None)
     def test_quantize_and_dequantize_op_fp8_rowwise(
         self,
         batched: bool,
@@ -1039,16 +1045,16 @@ class TestFP8RowwiseQuantizationConversion(unittest.TestCase):
             torch._dynamo.mark_dynamic(quantized_data_gpu, 0)
             torch._dynamo.mark_dynamic(quantized_data_gpu, 1)
 
+        output_dtype = {
+            torch.float: SparseType.FP32,
+            torch.half: SparseType.FP16,
+            torch.bfloat16: SparseType.BF16,
+        }[dtype].as_int()
+
         dequantized_data_gpu = quantize_func(
             quantized_data_gpu,
             forward=forward,
-            output_dtype=SparseType.FP32.as_int()
-            if dtype == torch.float
-            else (
-                SparseType.FP16.as_int()
-                if dtype == torch.half
-                else SparseType.BF16.as_int()
-            ),
+            output_dtype=output_dtype,
         )
 
         if m == 0 or n == 0:
@@ -1057,9 +1063,12 @@ class TestFP8RowwiseQuantizationConversion(unittest.TestCase):
 
         assert (
             dequantized_data_gpu.dtype == dtype
-        ), "result is {dequantized_data_gpu.dtype} type, but expected {dtype}"
+        ), "Result is {dequantized_data_gpu.dtype} type, but expected {dtype}"
+
         qref = input_data_gpu.float()
         dq = dequantized_data_gpu.float()
+
+        assert not torch.isnan(dq).any(), "Results contain nan"
 
         if self.enable_logging:
             # Logging quantization errors
@@ -1072,6 +1081,97 @@ class TestFP8RowwiseQuantizationConversion(unittest.TestCase):
             logging.info(f"max relative error {errors.flatten()[idx]}")
 
         torch.testing.assert_close(qref.cpu(), dq.cpu(), rtol=0.1, atol=0.05)
+
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-fixme[56]:
+    @given(
+        m=st.integers(min_value=1, max_value=1000),
+        n1=st.integers(min_value=1, max_value=1000),
+        n2=st.integers(min_value=1, max_value=1000),
+        n3=st.integers(min_value=1, max_value=1000),
+        row_dim=st.integers(min_value=1, max_value=2048),
+        forward=st.booleans(),
+        given_last_dim=st.booleans(),
+        dtype=st.sampled_from(
+            [
+                torch.float,
+                torch.half,
+                torch.bfloat16,
+            ],
+        ),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=max_examples, deadline=None)
+    def test_quantize_and_dequantize_op_padded_fp8_rowwise(
+        self,
+        m: int,
+        n1: int,
+        n2: int,
+        n3: int,
+        row_dim: int,
+        forward: bool,
+        given_last_dim: bool,
+        dtype: torch.dtype,
+    ) -> None:
+        row_dim = row_dim * 4
+        device = "cuda"
+        input1 = torch.rand(m, n1, device=device, dtype=dtype)
+        input2 = torch.rand(m, n2, device=device, dtype=dtype)
+        input3 = torch.rand(m, n3, device=device, dtype=dtype)
+        output_dtype = {
+            torch.float: SparseType.FP32,
+            torch.half: SparseType.FP16,
+            torch.bfloat16: SparseType.BF16,
+        }[dtype].as_int()
+
+        q1 = torch.ops.fbgemm.FloatToPaddedFP8RowwiseQuantized(
+            input1, forward=forward, row_dim=row_dim
+        )
+        q2 = torch.ops.fbgemm.FloatToPaddedFP8RowwiseQuantized(
+            input2, forward=forward, row_dim=row_dim
+        )
+        q3 = torch.ops.fbgemm.FloatToPaddedFP8RowwiseQuantized(
+            input3, forward=forward, row_dim=row_dim
+        )
+        qcat = torch.cat([q1, q3, q2], dim=-1)
+        if given_last_dim:
+            d_qcat = torch.ops.fbgemm.PaddedFP8RowwiseQuantizedToFloat(
+                qcat,
+                forward=forward,
+                row_dim=row_dim,
+                output_last_dim=n1 + n2 + n3,
+                output_dtype=output_dtype,
+            )
+        else:
+            d_qcat = torch.ops.fbgemm.PaddedFP8RowwiseQuantizedToFloat(
+                qcat,
+                forward=forward,
+                row_dim=row_dim,
+                output_dtype=output_dtype,
+            )
+
+        assert (
+            d_qcat.dtype == dtype
+        ), "Result is {d_qcat.dtype} type, but expected {dtype}"
+        qref = torch.cat([input1, input3, input2], dim=-1).cpu().float()
+        dqcat = d_qcat.cpu().float()
+
+        assert not torch.isnan(dqcat).any(), "Results contain nan"
+
+        if self.enable_logging:
+            # Logging quantization errors
+            errors = (dqcat - qref) / (qref + 1e-5)
+            assert not torch.isnan(errors).any()
+            val, idx = torch.topk(errors.abs(), k=min(10, errors.shape[-1]))
+            logging.info(f"top-10 errors {val}")
+            logging.info(f"qref {torch.gather(qref, dim=1, index=idx)}")
+            logging.info(f"dqcat {torch.gather(dqcat, dim=1, index=idx)}")
+            logging.info(
+                f"relative error: max: {errors.abs().max()*100:.1f}%, "
+                f"median: {errors.abs().median()*100:.1f}%, "
+                f"mean: {errors.abs().mean()*100:.1f}%"
+            )
+
+        torch.testing.assert_allclose(dqcat, qref, rtol=0.1, atol=0.05)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- Add BF16 support in `FloatToPaddedFP8RowwiseQuantized` and
  `PaddedFP8RowwiseQuantizedToFloat`.
- Refactor `src/quantize_ops/quantize_fp8_rowwise.cu`
- Move unit test from `hpc` to `fbgemm_gpu`

Differential Revision: D49166595


