### PR TITLE
Allow 1 manitissa bit diff in TestFused8BitRowwiseQuantizationConversion

### DIFF
--- a/fbgemm_gpu/test/quantize_ops_test.py
+++ b/fbgemm_gpu/test/quantize_ops_test.py
@@ -118,7 +118,10 @@ class TestFused8BitRowwiseQuantizationConversion(unittest.TestCase):
             ncols_aligned = (ncols + 4 - 1) // 4 * 4
             # compare quantized data
             np.testing.assert_allclose(
-                quantized_data_numpy[:, :ncols], reference[:, :ncols]
+                quantized_data_numpy[:, :ncols],
+                reference[:, :ncols],
+                # Allow 1 mantissa bit difference (LSB)
+                atol=1,
             )
             # compare scales
             np.testing.assert_array_almost_equal(


### PR DESCRIPTION
Summary:
The reference implementation of FP8 quantization is in Python, but the
actual implementation is in C++/CUDA.  Upon summerdengfb's investigation,
Python has a known floating point representation issue
(https://www.geeksforgeeks.org/floating-point-error-in-python/). This
could cause quantization result discrepancy.  To workaround this
issue, we allow 1 bit difference in the FP8 quantization result (LSB
of mantissa) in `TestFused8BitRowwiseQuantizationConversion`.

Differential Revision: D49255499


