### PR TITLE
Update Nova workflow triggers and wheel version

### DIFF
--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches:
       - nightly
+      - main
+      # Release candidate branch look like: v1.11.0-rc1
+      - v[0-9]+.[0-9]+.[0-9]+-release+
+    tags:
+      # Release candidate tag look like: v1.11.0-rc1
+      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Summary: Update nova workflow to be triggered on pushes to main and releases branches and tags. Update wheel version name to match pytorch convention (e.g., +cpu, +cu118)

Reviewed By: q10

Differential Revision: D49296399


