### PR TITLE
[D49020046][fbgemm_gpu] Re-enable tests in `permute_pooled_embedding_test.py`

### DIFF
--- a/.github/scripts/fbgemm_gpu_test.bash
+++ b/.github/scripts/fbgemm_gpu_test.bash
@@ -187,14 +187,28 @@ test_setup_conda_environment () {
 test_fbgemm_gpu_build_and_install () {
   local env_name="$1"
   local pytorch_variant_type="$2"
+  if [ "$pytorch_variant_type" == "" ]; then
+    echo "Usage: ${FUNCNAME[0]} ENV_NAME PYTORCH_VARIANT_TYPE"
+    echo "Example(s):"
+    echo "    ${FUNCNAME[0]} build_env cuda   # Build and install FBGEMM_GPU for CUDA (All Steps)"
+    return 1
+  else
+    echo "################################################################################"
+    echo "# Setup FBGEMM-GPU Build Container (All Steps)"
+    echo "#"
+    echo "# [$(date --utc +%FT%T.%3NZ)] + ${FUNCNAME[0]} ${*}"
+    echo "################################################################################"
+    echo ""
+  fi
 
   # Assume we are starting from the repository root directory
   cd fbgemm_gpu                                                               || return 1
   prepare_fbgemm_gpu_build    "${env_name}"                                   || return 1
   build_fbgemm_gpu_package    "${env_name}" release "${pytorch_variant_type}" || return 1
+
   # shellcheck disable=SC2164
   cd -
-  install_fbgemm_gpu_wheel  "${env_name}" fbgemm_gpu/dist/*.whl             || return 1
+  install_fbgemm_gpu_wheel    "${env_name}" fbgemm_gpu/dist/*.whl             || return 1
 
   cd fbgemm_gpu/test                        || return 1
   run_fbgemm_gpu_tests        "${env_name}" || return 1

--- a/.github/scripts/utils_cuda.bash
+++ b/.github/scripts/utils_cuda.bash
@@ -117,11 +117,11 @@ install_cudnn () {
   local cuda_concat_version="${cuda_version_arr[0]}${cuda_version_arr[1]}"
 
   # Get the URL
-  local cudnn_url="${cudnn_packages[cuda_concat_version]}"
+  local cudnn_url="${cudnn_packages[$cuda_concat_version]}"
   if [ "$cudnn_url" == "" ]; then
-    # Default to cuDNN for 11.7 if no CUDA version fits
-    echo "[INSTALL] Defaulting to cuDNN for CUDA 11.7"
-    cudnn_url="${cudnn_packages[117]}"
+    # Default to cuDNN for 11.8 if no CUDA version fits
+    echo "[INSTALL] Defaulting to cuDNN for CUDA 11.8"
+    cudnn_url="${cudnn_packages[118]}"
   fi
 
   # Clear the install path

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -561,6 +561,8 @@ set(fbgemm_gpu_sources_static_cpu
     codegen/embedding_forward_quantized_host_cpu.cpp
     codegen/embedding_backward_dense_host_cpu.cpp
     codegen/embedding_bounds_check_host_cpu.cpp
+    src/permute_pooled_embedding_ops/permute_pooled_embedding_function.cpp
+    src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_cpu.cpp
     src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split_cpu.cpp
     src/jagged_tensor_ops/jagged_tensor_ops_autograd.cpp
     src/jagged_tensor_ops/jagged_tensor_ops_meta.cpp

--- a/fbgemm_gpu/fbgemm_gpu/permute_pooled_embedding_modules.py
+++ b/fbgemm_gpu/fbgemm_gpu/permute_pooled_embedding_modules.py
@@ -17,6 +17,9 @@ try:
     from fbgemm_gpu import open_source  # noqa: F401
 except Exception:
     torch.ops.load_library(
+        "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_cpu"
+    )
+    torch.ops.load_library(
         "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_gpu"
     )
 

--- a/fbgemm_gpu/include/fbgemm_gpu/ops_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/ops_utils.h
@@ -8,7 +8,24 @@
 
 #pragma once
 
+#ifdef FBGEMM_GPU_ENABLE_DUMMY_IA32_SERIALIZE
+// Workaround the missing __builtin_ia32_serialize issue
+#if defined(__NVCC__) && \
+    (__CUDACC_VER_MAJOR__ > 11 || __CUDACC_VER_MINOR__ >= 4)
+#if defined(__i386__) || defined(__i686__) || defined(__x86_64__)
+static __inline void __attribute__((
+    __gnu_inline__,
+    __always_inline__,
+    __artificial__,
+    __target__("serialize"))) __builtin_ia32_serialize(void) {
+  abort();
+}
+#endif
+#endif // __NVCC__
+#endif // FBGEMM_GPU_ENABLE_DUMMY_IA32_SERIALIZE
+
 #include <ATen/ATen.h>
+#include <ATen/core/op_registration/op_registration.h>
 #include <torch/library.h>
 
 /*

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_function.cpp
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_function.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbgemm_gpu/permute_pooled_embedding_ops.h"
+
+using Tensor = at::Tensor;
+
+namespace fbgemm_gpu {
+
+using torch::autograd::AutogradContext;
+using torch::autograd::Variable;
+using torch::autograd::variable_list;
+
+Variable PermutePooledEmbsFunction::forward(
+    AutogradContext* ctx,
+    const Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
+    const Tensor& offset_dim_list,
+    const Tensor& permute_list,
+    const Tensor& inv_offset_dim_list,
+    const Tensor& inv_permute_list,
+    const bool& allow_duplicates) {
+  ctx->saved_data["offset_dim_list"] = offset_dim_list;
+  ctx->saved_data["permute_list"] = permute_list;
+  ctx->saved_data["inv_offset_dim_list"] = inv_offset_dim_list;
+  ctx->saved_data["inv_permute_list"] = inv_permute_list;
+  ctx->saved_data["allow_duplicates"] = allow_duplicates;
+  TORCH_CHECK(
+      offset_dim_list.scalar_type() == at::ScalarType::Long,
+      "offset_dim_list needs to have long/int64 type");
+  TORCH_CHECK(
+      permute_list.scalar_type() == at::ScalarType::Long,
+      "permute_list needs to have long/int64 type");
+
+  const auto schema = allow_duplicates ? "fbgemm::permute_duplicate_pooled_embs"
+                                       : "fbgemm::permute_pooled_embs";
+  const auto permute_pooled_embs_op =
+      torch::Dispatcher::singleton()
+          .findSchemaOrThrow(schema, "")
+          .typed<decltype(permute_pooled_embs_cpu)>();
+  return permute_pooled_embs_op.call(
+      pooled_embs,
+      offset_dim_list,
+      permute_list,
+      inv_offset_dim_list,
+      inv_permute_list);
+}
+
+variable_list PermutePooledEmbsFunction::backward(
+    AutogradContext* ctx,
+    variable_list grad_output) {
+  const auto& offset_dim_list = ctx->saved_data["offset_dim_list"].toTensor();
+  const auto& permute_list = ctx->saved_data["permute_list"].toTensor();
+  const auto& inv_offset_dim_list =
+      ctx->saved_data["inv_offset_dim_list"].toTensor();
+  const auto& inv_permute_list = ctx->saved_data["inv_permute_list"].toTensor();
+  const auto& allow_duplicates = ctx->saved_data["allow_duplicates"].toBool();
+  TORCH_CHECK(
+      allow_duplicates == false,
+      "permute_pooled_embs does not support allow_duplicates in backward!");
+  variable_list grad_inputs(6);
+  static auto permute_pooled_embs_op =
+      torch::Dispatcher::singleton()
+          .findSchemaOrThrow("fbgemm::permute_pooled_embs", "")
+          .typed<decltype(permute_pooled_embs_cpu)>();
+  grad_inputs[0] = permute_pooled_embs_op.call(
+      grad_output[0],
+      inv_offset_dim_list,
+      inv_permute_list,
+      offset_dim_list,
+      permute_list);
+  return grad_inputs;
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops.cu
@@ -12,6 +12,7 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include "fbgemm_gpu/ops_utils.h"
 
 #include "fbgemm_gpu/fbgemm_cuda_utils.cuh"
 #include "fbgemm_gpu/layout_transform_ops.cuh"

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_cpu.cpp
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_cpu.cpp
@@ -5,3 +5,184 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+#include <c10/util/irange.h>
+#include <vector>
+#include "fbgemm_gpu/permute_pooled_embedding_ops.h"
+
+using Tensor = at::Tensor;
+
+namespace fbgemm_gpu {
+
+///@ingroup permute-pooled-embs-cpu-impl
+Tensor permute_pooled_embs_cpu_impl(
+    const Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
+    const Tensor& offset_dim_list,
+    const Tensor& permute_list,
+    const Tensor& inv_offset_dim_list,
+    const Tensor& inv_permute_list,
+    const bool& allow_duplicates) {
+  TORCH_CHECK(
+      offset_dim_list.scalar_type() == at::ScalarType::Long,
+      "offset_dim_list needs to have long/int64 type")
+  TORCH_CHECK(
+      permute_list.scalar_type() == at::ScalarType::Long,
+      "permute_list needs to have long/int64 type")
+  auto permute = permute_list.data_ptr<int64_t>();
+  const auto n = permute_list.numel();
+  const auto dims_size = allow_duplicates ? offset_dim_list.numel() : n;
+  std::vector<int64_t> dims;
+  dims.reserve(dims_size - 1);
+  for (const auto i : c10::irange(1, dims_size)) {
+    dims.push_back(offset_dim_list[i].item<int64_t>());
+  }
+  auto ts = pooled_embs.tensor_split(dims, 1);
+  std::vector<Tensor> permuted_ts;
+  permuted_ts.reserve(n);
+  for (const auto i : c10::irange(n)) {
+    permuted_ts.push_back(ts[permute[i]]);
+  }
+  return at::cat(permuted_ts, 1);
+}
+
+///@ingroup permute-pooled-embs-cpu
+at::Tensor permute_pooled_embs_cpu(
+    const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
+    const at::Tensor& offset_dim_list,
+    const at::Tensor& permute_list,
+    const at::Tensor& inv_offset_dim_list,
+    const at::Tensor& inv_permute_list) {
+  return permute_pooled_embs_cpu_impl(
+      pooled_embs,
+      offset_dim_list,
+      permute_list,
+      inv_offset_dim_list,
+      inv_permute_list,
+      false);
+}
+
+///@ingroup permute-duplicate-pooled-embs-cpu
+at::Tensor permute_duplicate_pooled_embs_cpu(
+    const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
+    const at::Tensor& offset_dim_list,
+    const at::Tensor& permute_list,
+    const at::Tensor& inv_offset_dim_list,
+    const at::Tensor& inv_permute_list) {
+  return permute_pooled_embs_cpu_impl(
+      pooled_embs,
+      offset_dim_list,
+      permute_list,
+      inv_offset_dim_list,
+      inv_permute_list,
+      true);
+}
+
+///@ingroup permute-pooled-embs-cpu
+at::Tensor permute_pooled_embs_auto_grad(
+    const Tensor& pooled_embs,
+    const Tensor& offset_dim_list,
+    const Tensor& permute_list,
+    const Tensor& inv_offset_dim_list,
+    const Tensor& inv_permute_list) {
+  return PermutePooledEmbsFunction::apply(
+      pooled_embs,
+      offset_dim_list,
+      permute_list,
+      inv_offset_dim_list,
+      inv_permute_list,
+      false);
+}
+
+///@ingroup permute-pooled-embs-cpu
+at::Tensor permute_pooled_embs_auto_grad_cpu(
+    const Tensor& pooled_embs,
+    const Tensor& offset_dim_list,
+    const Tensor& permute_list,
+    const Tensor& inv_offset_dim_list,
+    const Tensor& inv_permute_list) {
+  return PermutePooledEmbsFunction::apply(
+      pooled_embs,
+      offset_dim_list,
+      permute_list,
+      inv_offset_dim_list,
+      inv_permute_list,
+      false);
+}
+
+///@ingroup permute-duplicate-pooled-embs-cpu
+at::Tensor permute_duplicate_pooled_embs_auto_grad_cpu(
+    const Tensor& pooled_embs,
+    const Tensor& offset_dim_list,
+    const Tensor& permute_list,
+    const Tensor& inv_offset_dim_list,
+    const Tensor& inv_permute_list) {
+  return PermutePooledEmbsFunction::apply(
+      pooled_embs,
+      offset_dim_list,
+      permute_list,
+      inv_offset_dim_list,
+      inv_permute_list,
+      true);
+}
+
+at::Tensor permute_pooled_embs_meta(
+    const Tensor& pooled_embs,
+    const Tensor& /* offset_dim_list */,
+    const Tensor& /* permute_list */,
+    const Tensor& /* inv_offset_dim_list */,
+    const Tensor& /* inv_permute_list */) {
+  return torch::empty_like(pooled_embs);
+}
+
+at::Tensor permute_pooled_embs_auto_grad_meta(
+    const Tensor& pooled_embs,
+    const Tensor& /* offset_dim_list */,
+    const Tensor& /* permute_list */,
+    const Tensor& /* inv_offset_dim_list */,
+    const Tensor& /* inv_permute_list */) {
+  return torch::empty_like(pooled_embs);
+}
+
+} // namespace fbgemm_gpu
+
+TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  m.def(
+      "permute_pooled_embs(Tensor pooled_embs, Tensor offset_dim_list, Tensor permute_list, Tensor inv_offset_dim_list, Tensor inv_permute_list) -> Tensor");
+  m.def(
+      "permute_pooled_embs_auto_grad(Tensor pooled_embs, Tensor offset_dim_list, Tensor permute_list, Tensor inv_offset_dim_list, Tensor inv_permute_list) -> Tensor");
+  m.def(
+      "permute_duplicate_pooled_embs(Tensor pooled_embs, Tensor offset_dim_list, Tensor permute_list, Tensor inv_offset_dim_list, Tensor inv_permute_list) -> Tensor");
+  m.def(
+      "permute_duplicate_pooled_embs_auto_grad(Tensor pooled_embs, Tensor offset_dim_list, Tensor permute_list, Tensor inv_offset_dim_list, Tensor inv_permute_list) -> Tensor");
+}
+
+FBGEMM_OP_DISPATCH(
+    CPU,
+    "permute_pooled_embs",
+    fbgemm_gpu::permute_pooled_embs_cpu);
+FBGEMM_OP_DISPATCH(
+    CPU,
+    "permute_pooled_embs_auto_grad",
+    fbgemm_gpu::permute_pooled_embs_auto_grad_cpu);
+FBGEMM_OP_DISPATCH(
+    CPU,
+    "permute_duplicate_pooled_embs",
+    fbgemm_gpu::permute_duplicate_pooled_embs_cpu);
+FBGEMM_OP_DISPATCH(
+    CPU,
+    "permute_duplicate_pooled_embs_auto_grad",
+    fbgemm_gpu::permute_duplicate_pooled_embs_auto_grad_cpu);
+
+FBGEMM_OP_DISPATCH(
+    Meta,
+    "permute_pooled_embs",
+    fbgemm_gpu::permute_pooled_embs_meta);
+FBGEMM_OP_DISPATCH(
+    Meta,
+    "permute_pooled_embs_auto_grad",
+    fbgemm_gpu::permute_pooled_embs_auto_grad_meta);
+
+FBGEMM_OP_DISPATCH(
+    Autograd,
+    "permute_pooled_embs_auto_grad",
+    fbgemm_gpu::permute_pooled_embs_auto_grad);

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_gpu.cpp
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_gpu.cpp
@@ -13,146 +13,10 @@
 #include <vector>
 
 #include "fbgemm_gpu/permute_pooled_embedding_ops.h"
-#include "fbgemm_gpu/sparse_ops_utils.h"
 
 using Tensor = at::Tensor;
 
-///@defgroup permute-pooled-embs-gpu
-///@defgroup permute-pooled-embs-cpu
-
 namespace fbgemm_gpu {
-
-///@ingroup permute-pooled-embs-cpu-impl
-Tensor permute_pooled_embs_cpu_impl(
-    const Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
-    const Tensor& offset_dim_list,
-    const Tensor& permute_list,
-    const Tensor& inv_offset_dim_list,
-    const Tensor& inv_permute_list,
-    const bool& allow_duplicates) {
-  TORCH_CHECK(
-      offset_dim_list.scalar_type() == at::ScalarType::Long,
-      "offset_dim_list needs to have long/int64 type")
-  TORCH_CHECK(
-      permute_list.scalar_type() == at::ScalarType::Long,
-      "permute_list needs to have long/int64 type")
-  auto permute = permute_list.data_ptr<int64_t>();
-  const auto n = permute_list.numel();
-  const auto dims_size = allow_duplicates ? offset_dim_list.numel() : n;
-  std::vector<int64_t> dims;
-  dims.reserve(dims_size - 1);
-  for (const auto i : c10::irange(1, dims_size)) {
-    dims.push_back(offset_dim_list[i].item<int64_t>());
-  }
-  auto ts = pooled_embs.tensor_split(dims, 1);
-  std::vector<Tensor> permuted_ts;
-  permuted_ts.reserve(n);
-  for (const auto i : c10::irange(n)) {
-    permuted_ts.push_back(ts[permute[i]]);
-  }
-  return at::cat(permuted_ts, 1);
-}
-
-///@ingroup permute-pooled-embs-cpu
-at::Tensor permute_pooled_embs_cpu(
-    const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
-    const at::Tensor& offset_dim_list,
-    const at::Tensor& permute_list,
-    const at::Tensor& inv_offset_dim_list,
-    const at::Tensor& inv_permute_list) {
-  return permute_pooled_embs_cpu_impl(
-      pooled_embs,
-      offset_dim_list,
-      permute_list,
-      inv_offset_dim_list,
-      inv_permute_list,
-      false);
-}
-
-///@ingroup permute-duplicate-pooled-embs-cpu
-at::Tensor permute_duplicate_pooled_embs_cpu(
-    const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
-    const at::Tensor& offset_dim_list,
-    const at::Tensor& permute_list,
-    const at::Tensor& inv_offset_dim_list,
-    const at::Tensor& inv_permute_list) {
-  return permute_pooled_embs_cpu_impl(
-      pooled_embs,
-      offset_dim_list,
-      permute_list,
-      inv_offset_dim_list,
-      inv_permute_list,
-      true);
-}
-
-using torch::autograd::AutogradContext;
-using torch::autograd::Variable;
-using torch::autograd::variable_list;
-
-class PermutePooledEmbsFunction
-    : public torch::autograd::Function<PermutePooledEmbsFunction> {
- public:
-  static Variable forward(
-      AutogradContext* ctx,
-      const Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
-      const Tensor& offset_dim_list,
-      const Tensor& permute_list,
-      const Tensor& inv_offset_dim_list,
-      const Tensor& inv_permute_list,
-      const bool& allow_duplicates = false) {
-    ctx->saved_data["offset_dim_list"] = offset_dim_list;
-    ctx->saved_data["permute_list"] = permute_list;
-    ctx->saved_data["inv_offset_dim_list"] = inv_offset_dim_list;
-    ctx->saved_data["inv_permute_list"] = inv_permute_list;
-    ctx->saved_data["allow_duplicates"] = allow_duplicates;
-    TORCH_CHECK(
-        offset_dim_list.scalar_type() == at::ScalarType::Long,
-        "offset_dim_list needs to have long/int64 type");
-    TORCH_CHECK(
-        permute_list.scalar_type() == at::ScalarType::Long,
-        "permute_list needs to have long/int64 type");
-
-    const auto schema = allow_duplicates
-        ? "fbgemm::permute_duplicate_pooled_embs"
-        : "fbgemm::permute_pooled_embs";
-    const auto permute_pooled_embs_op =
-        torch::Dispatcher::singleton()
-            .findSchemaOrThrow(schema, "")
-            .typed<decltype(permute_pooled_embs_cpu)>();
-    return permute_pooled_embs_op.call(
-        pooled_embs,
-        offset_dim_list,
-        permute_list,
-        inv_offset_dim_list,
-        inv_permute_list);
-  }
-  static variable_list backward(
-      AutogradContext* ctx,
-      variable_list grad_output) {
-    const auto& offset_dim_list = ctx->saved_data["offset_dim_list"].toTensor();
-    const auto& permute_list = ctx->saved_data["permute_list"].toTensor();
-    const auto& inv_offset_dim_list =
-        ctx->saved_data["inv_offset_dim_list"].toTensor();
-    const auto& inv_permute_list =
-        ctx->saved_data["inv_permute_list"].toTensor();
-    const auto& allow_duplicates = ctx->saved_data["allow_duplicates"].toBool();
-    TORCH_CHECK(
-        allow_duplicates == false,
-        "permute_pooled_embs does not support allow_duplicates in backward!");
-    variable_list grad_inputs(6);
-    static auto permute_pooled_embs_op =
-        torch::Dispatcher::singleton()
-            .findSchemaOrThrow("fbgemm::permute_pooled_embs", "")
-            .typed<decltype(permute_pooled_embs_cpu)>();
-    grad_inputs[0] = permute_pooled_embs_op.call(
-        grad_output[0],
-        inv_offset_dim_list,
-        inv_permute_list,
-        offset_dim_list,
-        permute_list);
-    return grad_inputs;
-  }
-};
 
 ///@ingroup permute-pooled-embs-gpu
 Tensor permute_pooled_embs_auto_grad_gpu(
@@ -168,56 +32,6 @@ Tensor permute_pooled_embs_auto_grad_gpu(
       inv_offset_dim_list,
       inv_permute_list,
       false);
-}
-
-///@ingroup permute-pooled-embs-cpu
-Tensor permute_pooled_embs_auto_grad_cpu(
-    const Tensor& pooled_embs,
-    const Tensor& offset_dim_list,
-    const Tensor& permute_list,
-    const Tensor& inv_offset_dim_list,
-    const Tensor& inv_permute_list) {
-  return PermutePooledEmbsFunction::apply(
-      pooled_embs,
-      offset_dim_list,
-      permute_list,
-      inv_offset_dim_list,
-      inv_permute_list,
-      false);
-}
-
-///@ingroup permute-pooled-embs-cpu
-Tensor permute_pooled_embs_auto_grad(
-    const Tensor& pooled_embs,
-    const Tensor& offset_dim_list,
-    const Tensor& permute_list,
-    const Tensor& inv_offset_dim_list,
-    const Tensor& inv_permute_list) {
-  return PermutePooledEmbsFunction::apply(
-      pooled_embs,
-      offset_dim_list,
-      permute_list,
-      inv_offset_dim_list,
-      inv_permute_list,
-      false);
-}
-
-Tensor permute_pooled_embs_meta(
-    const Tensor& pooled_embs,
-    const Tensor& /* offset_dim_list */,
-    const Tensor& /* permute_list */,
-    const Tensor& /* inv_offset_dim_list */,
-    const Tensor& /* inv_permute_list */) {
-  return torch::empty_like(pooled_embs);
-}
-
-Tensor permute_pooled_embs_auto_grad_meta(
-    const Tensor& pooled_embs,
-    const Tensor& /* offset_dim_list */,
-    const Tensor& /* permute_list */,
-    const Tensor& /* inv_offset_dim_list */,
-    const Tensor& /* inv_permute_list */) {
-  return torch::empty_like(pooled_embs);
 }
 
 ///@ingroup permute-duplicate-pooled-embs-gpu
@@ -236,57 +50,17 @@ Tensor permute_duplicate_pooled_embs_auto_grad_gpu(
       true);
 }
 
-///@ingroup permute-duplicate-pooled-embs-cpu
-Tensor permute_duplicate_pooled_embs_auto_grad_cpu(
-    const Tensor& pooled_embs,
-    const Tensor& offset_dim_list,
-    const Tensor& permute_list,
-    const Tensor& inv_offset_dim_list,
-    const Tensor& inv_permute_list) {
-  return PermutePooledEmbsFunction::apply(
-      pooled_embs,
-      offset_dim_list,
-      permute_list,
-      inv_offset_dim_list,
-      inv_permute_list,
-      true);
-}
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
-  m.def(
-      "permute_pooled_embs(Tensor pooled_embs, Tensor offset_dim_list, Tensor permute_list, Tensor inv_offset_dim_list, Tensor inv_permute_list) -> Tensor");
   DISPATCH_TO_CUDA("permute_pooled_embs", fbgemm_gpu::permute_pooled_embs_gpu);
-  DISPATCH_TO_CPU("permute_pooled_embs", fbgemm_gpu::permute_pooled_embs_cpu);
-  DISPATCH_TO_META("permute_pooled_embs", fbgemm_gpu::permute_pooled_embs_meta);
-  m.def(
-      "permute_pooled_embs_auto_grad(Tensor pooled_embs, Tensor offset_dim_list, Tensor permute_list, Tensor inv_offset_dim_list, Tensor inv_permute_list) -> Tensor");
-  DISPATCH_TO_AUTOGRAD(
-      "permute_pooled_embs_auto_grad",
-      fbgemm_gpu::permute_pooled_embs_auto_grad);
-  DISPATCH_TO_CPU(
-      "permute_pooled_embs_auto_grad",
-      fbgemm_gpu::permute_pooled_embs_auto_grad_cpu);
   DISPATCH_TO_CUDA(
       "permute_pooled_embs_auto_grad",
       fbgemm_gpu::permute_pooled_embs_auto_grad_gpu);
-  DISPATCH_TO_META(
-      "permute_pooled_embs_auto_grad",
-      fbgemm_gpu::permute_pooled_embs_auto_grad_meta);
-  m.def(
-      "permute_duplicate_pooled_embs(Tensor pooled_embs, Tensor offset_dim_list, Tensor permute_list, Tensor inv_offset_dim_list, Tensor inv_permute_list) -> Tensor");
   DISPATCH_TO_CUDA(
       "permute_duplicate_pooled_embs",
       fbgemm_gpu::permute_duplicate_pooled_embs_gpu);
-  DISPATCH_TO_CPU(
-      "permute_duplicate_pooled_embs",
-      fbgemm_gpu::permute_duplicate_pooled_embs_cpu);
-  m.def(
-      "permute_duplicate_pooled_embs_auto_grad(Tensor pooled_embs, Tensor offset_dim_list, Tensor permute_list, Tensor inv_offset_dim_list, Tensor inv_permute_list) -> Tensor");
   DISPATCH_TO_CUDA(
       "permute_duplicate_pooled_embs_auto_grad",
       fbgemm_gpu::permute_duplicate_pooled_embs_auto_grad_gpu);
-  DISPATCH_TO_CPU(
-      "permute_duplicate_pooled_embs_auto_grad",
-      fbgemm_gpu::permute_duplicate_pooled_embs_auto_grad_cpu);
 }


### PR DESCRIPTION
- Re-enable tests in `permute_pooled_embedding_test.py` by silencing the hypothesis warnings about multiple executors