### PR TITLE
Fix incorrect SymInt signature on dense_to_jagged

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -453,7 +453,7 @@ std::tuple<at::Tensor, std::vector<at::Tensor>> jagged_dense_elementwise_mul(
 std::tuple<at::Tensor, std::vector<at::Tensor>> dense_to_jagged(
     const at::Tensor& dense,
     const std::vector<at::Tensor>& offsets,
-    const c10::optional<at::SymInt>& total_L);
+    c10::optional<at::SymInt> total_L);
 
 std::tuple<at::Tensor, std::vector<at::Tensor>>
 jagged_dense_elementwise_add_jagged_output(

--- a/fbgemm_gpu/src/jagged_tensor_ops/dense_to_jagged_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/dense_to_jagged_forward.cu
@@ -15,7 +15,7 @@ namespace fbgemm_gpu {
 Tensor dense_to_jagged_forward(
     const Tensor& dense,
     const std::vector<Tensor>& offsets,
-    const c10::optional<at::SymInt>& total_L) {
+    c10::optional<at::SymInt> total_L) {
   // D is the embedding dimension
   auto D = dense.size(-1);
 

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_autograd.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_autograd.cpp
@@ -284,7 +284,7 @@ class DenseToJaggedOp : public torch::autograd::Function<DenseToJaggedOp> {
             .typed<Tensor(
                 const Tensor& dense,
                 const std::vector<Tensor>& offsets,
-                const c10::optional<at::SymInt>& total_L)>();
+                c10::optional<at::SymInt> total_L)>();
     auto output = op.call(dense, offsets, total_L);
 
     return {output};
@@ -763,7 +763,7 @@ Tensor batched_dense_vec_jagged_2d_mul(
 std::tuple<Tensor, std::vector<Tensor>> dense_to_jagged(
     const Tensor& dense,
     const std::vector<Tensor>& offsets,
-    const c10::optional<at::SymInt>& total_L) {
+    c10::optional<at::SymInt> total_L) {
   return {DenseToJaggedOp::apply(dense, offsets, total_L)[0], offsets};
 }
 

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -464,7 +464,7 @@ at::Tensor jagged_to_padded_dense_backward(
 Tensor dense_to_jagged_forward(
     const Tensor& dense,
     const std::vector<Tensor>& offsets,
-    const c10::optional<at::SymInt>& total_L) {
+    c10::optional<at::SymInt> total_L) {
   // D is the embedding dimension
   auto D = dense.size(-1);
 

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_meta.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_meta.cpp
@@ -95,7 +95,7 @@ Tensor jagged_dense_elementwise_add_meta(
 Tensor dense_to_jagged_forward_meta(
     const Tensor& dense,
     const std::vector<Tensor>& offsets,
-    const c10::optional<at::SymInt>& total_L) {
+    c10::optional<at::SymInt> total_L) {
   auto dense_values = dense;
   at::SymInt D = dense_values.sym_size(-1);
   TORCH_CHECK_NOT_IMPLEMENTED(
@@ -110,7 +110,7 @@ Tensor dense_to_jagged_forward_meta(
 std::tuple<Tensor, std::vector<Tensor>> dense_to_jagged_meta(
     const Tensor& dense,
     const std::vector<Tensor>& offsets,
-    const c10::optional<at::SymInt>& total_L) {
+    c10::optional<at::SymInt> total_L) {
   return {dense_to_jagged_forward_meta(dense, offsets, total_L), offsets};
 }
 


### PR DESCRIPTION
Summary:
Caught this when I was tightening up the error checking at
https://github.com/pytorch/pytorch/pull/109727  Need to fix
the problem before I land the improved error checking.

Differential Revision: D49572882


