### PR TITLE
Fix non-contiguous tensor problem in jagged_index_select

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_index_select_2d_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_index_select_2d_forward.cu
@@ -14,14 +14,14 @@ namespace fbgemm_gpu {
 
 template <typename index_t, typename offset_t, typename scalar_t>
 __global__ __launch_bounds__(kMaxThreads) void jagged_index_select_2d_kernel(
-    scalar_t* output,
-    const scalar_t* input,
-    const offset_t* input_offsets,
-    const index_t* indices,
-    const offset_t* output_offsets,
-    const int64_t num_output_rows,
-    const int64_t num_dense_output_rows,
-    const int64_t num_cols) {
+    at::PackedTensorAccessor64<scalar_t, 2, at::RestrictPtrTraits> output,
+    const at::PackedTensorAccessor64<scalar_t, 2, at::RestrictPtrTraits> input,
+    const at::PackedTensorAccessor32<offset_t, 1, at::RestrictPtrTraits>
+        input_offsets,
+    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
+    const at::PackedTensorAccessor32<offset_t, 1, at::RestrictPtrTraits>
+        output_offsets,
+    const int64_t num_dense_output_rows) {
   __shared__ int smem[1];
   for (offset_t dense_output_offset = blockIdx.x;
        dense_output_offset < num_dense_output_rows;
@@ -29,8 +29,9 @@ __global__ __launch_bounds__(kMaxThreads) void jagged_index_select_2d_kernel(
     // Binary search
     // TODO: use multiple threads to do bin search to reduce number of steps
     if (threadIdx.x == 0) {
+      const auto num_output_rows = indices.size(0);
       binary_search_range(
-          smem, output_offsets, dense_output_offset, num_output_rows);
+          smem, &output_offsets[0], dense_output_offset, num_output_rows);
     }
     __syncthreads();
 
@@ -46,12 +47,9 @@ __global__ __launch_bounds__(kMaxThreads) void jagged_index_select_2d_kernel(
     const offset_t input_offset =
         (index == 0 ? 0 : input_offsets[index - 1]) + rel_index;
 
-    // Shift buffers
-    scalar_t* output_ = output + dense_output_offset * num_cols;
-    const scalar_t* input_ = input + input_offset * num_cols;
-
+    const auto num_cols = input.size(1);
     for (int i = threadIdx.x; i < num_cols; i += blockDim.x) {
-      output_[i] = input_[i];
+      output[dense_output_offset][i] = input[input_offset][i];
     }
   }
 }
@@ -81,7 +79,6 @@ Tensor jagged_index_select_2d_forward_cuda(
   device_guard.set_index(values.get_device());
 
   auto num_cols = values.size(1);
-  const int64_t num_output_rows = indices.numel();
 
   const int64_t max_num_blocks = 1024; // Arbitrarily set to this number of now
   const int64_t max_num_threads = kMaxThreads;
@@ -91,6 +88,9 @@ Tensor jagged_index_select_2d_forward_cuda(
       at::empty({num_dense_output_rows, num_cols}, values.options());
 
   if (num_blocks > 0) {
+    // output_offsets has to be contiguous since it is passed to
+    // binary_search_range which accepts raw pointers
+    const auto output_offsets_contig = output_offsets.expect_contiguous();
     AT_DISPATCH_ALL_TYPES_AND2(
         at::ScalarType::Half,
         at::ScalarType::BFloat16,
@@ -106,14 +106,23 @@ Tensor jagged_index_select_2d_forward_cuda(
                     dim3(num_cols),
                     0,
                     at::cuda::getCurrentCUDAStream()>>>(
-                    output.data_ptr<scalar_t>(),
-                    values.data_ptr<scalar_t>(),
-                    input_offsets.data_ptr<int64_t>(),
-                    indices.data_ptr<index_t>(),
-                    output_offsets.data_ptr<int64_t>(),
-                    num_output_rows,
-                    num_dense_output_rows,
-                    num_cols);
+                    output.packed_accessor64<
+                        scalar_t,
+                        2,
+                        at::RestrictPtrTraits>(),
+                    values.packed_accessor64<
+                        scalar_t,
+                        2,
+                        at::RestrictPtrTraits>(),
+                    input_offsets
+                        .packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
+                    indices
+                        .packed_accessor32<index_t, 1, at::RestrictPtrTraits>(),
+                    output_offsets_contig->packed_accessor32<
+                        int64_t,
+                        1,
+                        at::RestrictPtrTraits>(),
+                    num_dense_output_rows);
                 C10_CUDA_KERNEL_LAUNCH_CHECK();
               });
         });


### PR DESCRIPTION
Summary:
Before this diff, `jagged_index_select` kernels take raw pointers as
arguments.  This requires the input tensors to be contiguous.
However, the `jagged_index_select` operator did not make sure that the
tensors are contiguous before extracting and passing the raw pointers
to the kernels causing the correctness issue.  This diff replaces the
raw pointer arguments with PyTorch's `PackedTensorAccessor` which
handles non-contiguous tensor accesses automatically.  For some
tensors that their raw pointers are still being used, the operator
makes sure that the tensors are contiguous before using them.

Differential Revision: D49937274


