### PR TITLE
Update ROCm version on CI pipeline to 5.6 and 5.7

### DIFF
--- a/.github/workflows/fbgemm_gpu_ci.yml
+++ b/.github/workflows/fbgemm_gpu_ci.yml
@@ -47,7 +47,7 @@ jobs:
         ]
         container-image: [ "ubuntu:20.04" ]
         python-version: [ "3.8", "3.9", "3.10" ]
-        rocm-version: [ "5.5.1", "5.6" ]
+        rocm-version: [ "5.6", "5.7" ]
 
     steps:
     - name: Setup Build Container
@@ -116,7 +116,7 @@ jobs:
         ]
         # ROCm machines are limited, so we only test against Python 3.10
         python-version: [ "3.10" ]
-        rocm-version: [ "5.5.1", "5.6" ]
+        rocm-version: [ "5.6", "5.7" ]
 
     steps:
     - name: Setup Build Container


### PR DESCRIPTION
Summary:
PyTorch no longer releases ROCm 5.5 for nightly. The last nightly release was on 9/21/23. This will cause some tests to fail on CI if the diff relies on
torch's new changes after 9/21 (e.g., https://github.com/pytorch/FBGEMM/actions/runs/6398449444/job/17368614311)

Pytorch dev infra also supports ROCm 5.6 and 5.7 by default. This diff updates the ROCm version on FBGEMM CI to align with PyTorch.

Reviewed By: q10

Differential Revision: D49980627


