### PR TITLE
Turn on generate_opcheck_tests for jagged_tensor_ops_test.py

### DIFF
--- a/fbgemm_gpu/test/failures_dict.json
+++ b/fbgemm_gpu/test/failures_dict.json
@@ -23,6 +23,7 @@
         "status": "xfail"
       }
     },
+    "fbgemm::batched_dense_vec_jagged_2d_mul": {},
     "fbgemm::block_bucketize_sparse_features": {
       "SparseOpsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features": {
         "comment": "",
@@ -99,6 +100,70 @@
         "status": "xfail"
       },
       "SparseOpsTest.test_faketensor__test_cat_reorder_batched_ad_indices_cpu": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
+    "fbgemm::dense_to_jagged": {
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_dense_to_jagged": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_dense_to_jagged_meta_backend": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_dense_to_jagged_opt": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_dense_to_jagged_opt_large_batch": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_dense_to_jagged": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_dense_to_jagged_meta_backend": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_dense_to_jagged_opt": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_dense_to_jagged_opt_large_batch": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_dense_to_jagged": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_dense_to_jagged_meta_backend": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_dense_to_jagged_opt": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_dense_to_jagged_opt_large_batch": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
+    "fbgemm::expand_into_jagged_permute": {
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_expand_into_jagged_permute": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_expand_into_jagged_permute": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_expand_into_jagged_permute": {
         "comment": "",
         "status": "xfail"
       }
@@ -181,7 +246,242 @@
         "status": "xfail"
       }
     },
-    "fbgemm::offsets_range": {},
+    "fbgemm::jagged_1d_to_dense": {},
+    "fbgemm::jagged_1d_to_truncated_values": {
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_1d_to_truncated_values": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_1d_to_truncated_values": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_jagged_1d_to_truncated_values": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
+    "fbgemm::jagged_2d_to_dense": {},
+    "fbgemm::jagged_dense_bmm": {},
+    "fbgemm::jagged_dense_dense_elementwise_add_jagged_output": {},
+    "fbgemm::jagged_dense_elementwise_add": {
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_elementwise_binary": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_elementwise_binary": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_autograd_registration__test_jagged_elementwise_binary": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
+    "fbgemm::jagged_dense_elementwise_add_jagged_output": {
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_elementwise_binary": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_elementwise_binary_opt": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_elementwise_binary": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_elementwise_binary_opt": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_autograd_registration__test_jagged_elementwise_binary": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_autograd_registration__test_jagged_elementwise_binary_opt": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_jagged_elementwise_binary": {
+        "comment": "This is a real failure, it just doesn't fail under all situations",
+        "status": "skip"
+      }
+    },
+    "fbgemm::jagged_dense_elementwise_mul": {},
+    "fbgemm::jagged_hash_size_cumsum": {
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_unique_indices": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_unique_indices": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_jagged_unique_indices": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
+    "fbgemm::jagged_index_select": {
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_index_select_2d": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_index_select_2d_in_inference": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_keyed_jagged_index_select_dim1": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_index_select_2d": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_index_select_2d_in_inference": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_keyed_jagged_index_select_dim1": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_jagged_index_select_2d": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_jagged_index_select_2d_in_inference": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_keyed_jagged_index_select_dim1": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
+    "fbgemm::jagged_jagged_bmm": {},
+    "fbgemm::jagged_slice": {
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_slice": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_slice": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_jagged_slice": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
+    "fbgemm::jagged_softmax": {},
+    "fbgemm::jagged_to_padded_dense": {},
+    "fbgemm::jagged_unique_indices": {
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_unique_indices": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_unique_indices_empty": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_unique_indices_multi_keys": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_unique_indices": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_unique_indices_empty": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_unique_indices_multi_keys": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_jagged_unique_indices": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_jagged_unique_indices_empty": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_jagged_unique_indices_multi_keys": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
+    "fbgemm::keyed_jagged_index_select_dim1": {
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_keyed_jagged_index_select_dim1": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_keyed_jagged_index_select_dim1": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_autograd_registration__test_keyed_jagged_index_select_dim1": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_keyed_jagged_index_select_dim1": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
+    "fbgemm::masked_select_jagged_1d": {
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_masked_select_jagged_1d": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_masked_select_jagged_1d": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_masked_select_jagged_1d": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
+    "fbgemm::offsets_range": {
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_1d_to_dense": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_2d_to_dense": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_2d_to_dense_truncation": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_stacked_jagged_2d_to_dense": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_1d_to_dense": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_2d_to_dense": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_2d_to_dense_truncation": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_stacked_jagged_2d_to_dense": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
     "fbgemm::pack_segments": {},
     "fbgemm::permute102_baddbmm_permute102": {
       "SparseOpsTest.test_aot_dispatch_dynamic__test_permute102_baddbmm_permute102": {
@@ -369,6 +669,38 @@
         "status": "xfail"
       },
       "SparseOpsTest.test_faketensor__test_segment_sum_csr": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
+    "fbgemm::stacked_jagged_1d_to_dense": {
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_stacked_jagged_1d_to_dense": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_stacked_jagged_1d_to_dense": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_stacked_jagged_1d_to_dense": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
+    "fbgemm::stacked_jagged_2d_to_dense": {
+      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_stacked_jagged_2d_to_dense": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_stacked_jagged_2d_to_dense": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_autograd_registration__test_stacked_jagged_2d_to_dense": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_faketensor__test_stacked_jagged_2d_to_dense": {
         "comment": "",
         "status": "xfail"
       }

--- a/fbgemm_gpu/test/test_utils.py
+++ b/fbgemm_gpu/test/test_utils.py
@@ -4,13 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import inspect
 import math
 import os
 import struct
 import subprocess
 import unittest
 from functools import wraps
-from typing import Any, Callable, List, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import hypothesis.strategies as st
 import numpy as np
@@ -200,6 +201,58 @@ def cpu_and_maybe_gpu() -> st.SearchStrategy[List[torch.device]]:
     return st.sampled_from(
         [torch.device("cpu")] + ([torch.device("cuda")] if gpu_available else [])
     )
+
+
+# Usage examples:
+#
+# @generate_opcheck_tests
+# class MyOpTest(unittest.TestCase):
+#     ...
+#
+# @generate_opcheck_tests(additional_decorators={})
+# class MyOpTest(unittest.TestCase):
+#     ...
+#
+# pyre-ignore[3]
+def generate_opcheck_tests(
+    test_class: Optional[unittest.TestCase] = None,
+    *,
+    # pyre-ignore[24]: Generic type `Callable` expects 2 type parameters.
+    additional_decorators: Optional[Dict[str, Callable]] = None,
+):
+    if additional_decorators is None:
+        additional_decorators = {}
+
+    def decorator(test_class: unittest.TestCase) -> unittest.TestCase:
+        if not torch.__version__ >= "2.2.*":
+            return test_class
+        import torch.testing._internal.optests as optests
+        from torch._utils_internal import get_file_path_2
+
+        filename = inspect.getfile(test_class)
+        failures_dict_path = get_file_path_2(
+            "", os.path.dirname(filename), "failures_dict.json"
+        )
+        optests.generate_opcheck_tests(
+            test_class,
+            ["fb", "fbgemm"],
+            failures_dict_path,
+            # pyre-ignore[6]
+            additional_decorators,
+            [
+                "test_schema",
+                "test_autograd_registration",
+                "test_faketensor",
+                "test_aot_dispatch_static",
+                "test_aot_dispatch_dynamic",
+            ],
+        )
+        return test_class
+
+    if test_class is None:
+        return decorator
+    else:
+        return decorator(test_class)
 
 
 def cpu_only() -> st.SearchStrategy[List[torch.device]]:


### PR DESCRIPTION
Summary:
This diff adds autogenerated opcheck tests to the jagged tensor operator tests.
We skip some torch.compile and gradcheck tests because those take an
unreasonable amount of time to run.

Differential Revision: D50129561

