### PR TITLE
Add meta implementation for asynchronous_exclusive_cumsum

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -46,6 +46,9 @@ at::Tensor asynchronous_inclusive_cumsum_cpu(const at::Tensor& t_in);
 at::Tensor asynchronous_complete_cumsum_meta(const at::Tensor& t_in);
 
 ///@ingroup sparse-data-cuda
+at::Tensor asynchronous_exclusive_cumsum_meta(const at::Tensor& t_in);
+
+///@ingroup sparse-data-cuda
 at::Tensor offsets_range_cuda(const at::Tensor& offsets, int64_t range_size);
 
 ///@ingroup sparse-data-cpu

--- a/fbgemm_gpu/src/sparse_ops/sparse_ops_meta.cpp
+++ b/fbgemm_gpu/src/sparse_ops/sparse_ops_meta.cpp
@@ -31,6 +31,10 @@ Tensor asynchronous_complete_cumsum_meta(const Tensor& t_in) {
   return output;
 }
 
+Tensor asynchronous_exclusive_cumsum_meta(const Tensor& t_in) {
+  return at::zeros_symint(t_in.sym_sizes(), t_in.options());
+}
+
 namespace {
 
 Tensor pack_segments_forward_meta(
@@ -74,10 +78,6 @@ Tensor batched_unary_embeddings_forward_meta(
 }
 
 Tensor asynchronous_inclusive_cumsum_meta(const Tensor& t_in) {
-  return at::empty_symint(t_in.sym_sizes(), t_in.options());
-}
-
-Tensor asynchronous_exclusive_cumsum_meta(const Tensor& t_in) {
   return at::empty_symint(t_in.sym_sizes(), t_in.options());
 }
 

--- a/fbgemm_gpu/test/sparse_ops_test.py
+++ b/fbgemm_gpu/test/sparse_ops_test.py
@@ -610,11 +610,11 @@ class SparseOpsTest(unittest.TestCase):
 
         # meta tests
         mx = torch.randint(low=0, high=100, size=(n,)).type(index_dtype).to("meta")
-        # mze = torch.ops.fbgemm.asynchronous_exclusive_cumsum(mx)
+        mze = torch.ops.fbgemm.asynchronous_exclusive_cumsum(mx)
+        self.assertEqual(ze.size(), mze.size())
         # mzi = torch.ops.fbgemm.asynchronous_inclusive_cumsum(mx)
-        mzc = torch.ops.fbgemm.asynchronous_complete_cumsum(mx)
-        # self.assertEqual(ze.size(), mze.size())
         # self.assertEqual(zi.size(), mzi.size())
+        mzc = torch.ops.fbgemm.asynchronous_complete_cumsum(mx)
         self.assertEqual(zc.size(), mzc.size())
 
         if gpu_available:


### PR DESCRIPTION
Summary:
same as title.

Follow the same pattern with ``asynchronous_complete_cumsum``  in https://www.internalfb.com/diff/D47834850.

Differential Revision: D50195064


