### PR TITLE
Fix heap-buffer-overflow in `radix_sort_parallel `

### DIFF
--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -623,7 +623,6 @@ void combine_prefix_sum(
   int64_t offset = 0;
   update_prefsum_and_offset_in_range(
       offset, 0, RDX_HIST_SIZE, nthreads, histogram, histogram_ps);
-  histogram_ps[RDX_HIST_SIZE * nthreads] = offset;
   // TODO(DamianSzwichtenberg): Is assert sufficient? In most cases, it will
   // work only in debug build.
   assert(offset == elements_count);
@@ -641,7 +640,6 @@ void combine_prefix_sum_for_msb(
       offset, 128, RDX_HIST_SIZE, nthreads, histogram, histogram_ps);
   update_prefsum_and_offset_in_range(
       offset, 0, 128, nthreads, histogram, histogram_ps);
-  histogram_ps[RDX_HIST_SIZE * (nthreads - 1) + 127] = offset;
   // TODO(DamianSzwichtenberg): Is assert sufficient? In most cases, it will
   // work only in debug build.
   assert(offset == elements_count);
@@ -760,13 +758,13 @@ std::pair<K*, V*> radix_sort_parallel(
   const size_t array_size = (size_t)RDX_HIST_SIZE * maxthreads;
   // fixes MSVC error C2131
   auto* const histogram = static_cast<int64_t*>(
-      fbgemm::fbgemmAlignedAlloc(64, (array_size) * sizeof(int64_t)));
+      fbgemm::fbgemmAlignedAlloc(64, array_size * sizeof(int64_t)));
   auto* const histogram_ps = static_cast<int64_t*>(
-      fbgemm::fbgemmAlignedAlloc(64, (array_size + 1) * sizeof(int64_t)));
+      fbgemm::fbgemmAlignedAlloc(64, array_size * sizeof(int64_t)));
 
 #else
   alignas(64) int64_t histogram[RDX_HIST_SIZE * maxthreads];
-  alignas(64) int64_t histogram_ps[RDX_HIST_SIZE * maxthreads + 1];
+  alignas(64) int64_t histogram_ps[RDX_HIST_SIZE * maxthreads];
 #endif
   // If negative values are present, we want to perform all passes
   // up to a sign bit


### PR DESCRIPTION
Setting `histogram_ps[RDX_HIST_SIZE * (nthreads - 1) + 127] = offset;` in `combine_prefix_sum_for_msb` is guaranteed to result in `heap-buffer-overflow` if bucket is not empty during the scatter stage (as all values of `histogram_ps` should be strictly less than `element_count` 

Factor out common code from `RadixSortTest.cc` into `test_tempalte` and add regression test for buffer overflow, which before the test will fail as follows:
```
[ RUN      ] cpuKernelTest.raidx_sort_heap_overflow
/home/nshulga/git/pytorch/FBGEMM/test/RadixSortTest.cc:36: Failure
Expected equality of these values:
  expected_keys
    Which is: { 2, 3, 5, -1, -1, 2147483647, 2147483647, 2147483647 }
  keys
    Which is: { -1, -1, -1, -1, -1, -1, -1, -1 }
/home/nshulga/git/pytorch/FBGEMM/test/RadixSortTest.cc:37: Failure
Expected equality of these values:
  expected_values
    Which is: { 1, 4, 6, 7, 8, 2, 3, 5 }
  values
    Which is: { 2147483647, 4, 6, 7, 8, 6, 7, 8 }
[  FAILED  ] cpuKernelTest.raidx_sort_heap_overflow (0 ms)
```

Will fix https://github.com/pytorch/pytorch/issues/111189 once FBGEMM is updated to the correct version