### PR TITLE
Add an auto-vectorization implementation for int4 CPU TBE kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,18 +152,21 @@ get_filelist("get_fbgemm_inline_avx2_srcs(msvc=${MSVC_BOOL})"
 get_filelist("get_fbgemm_avx512_srcs(msvc=${MSVC_BOOL})" FBGEMM_AVX512_SRCS)
 get_filelist("get_fbgemm_inline_avx512_srcs(msvc=${MSVC_BOOL})"
   FBGEMM_AVX512_INLINE_SRCS)
+get_filelist("get_fbgemm_autovec_srcs()" FBGEMM_AUTOVEC_SRCS)
 get_filelist("get_fbgemm_public_headers()" FBGEMM_PUBLIC_HEADERS)
 
 add_library(fbgemm_generic OBJECT ${FBGEMM_GENERIC_SRCS})
 add_library(fbgemm_avx2 OBJECT ${FBGEMM_AVX2_SRCS} ${FBGEMM_AVX2_INLINE_SRCS})
 add_library(fbgemm_avx512 OBJECT
   ${FBGEMM_AVX512_SRCS} ${FBGEMM_AVX512_INLINE_SRCS})
+add_library(fbgemm_autovec OBJECT ${FBGEMM_AUTOVEC_SRCS})
 
 # Make libraries depend on defs.bzl
 add_custom_target(defs.bzl DEPENDS defs.bzl)
 add_dependencies(fbgemm_generic defs.bzl)
 add_dependencies(fbgemm_avx2 defs.bzl)
 add_dependencies(fbgemm_avx512 defs.bzl)
+add_dependencies(fbgemm_autovec defs.bzl)
 
 # On Windows:
 # 1)  Adding definition of ASMJIT_STATIC to avoid generating asmjit function
@@ -186,6 +189,9 @@ if(MSVC)
   endif()
   target_compile_options(fbgemm_avx2 PRIVATE "/arch:AVX2")
   target_compile_options(fbgemm_avx512 PRIVATE "/arch:AVX512")
+  if(OpenMP_FOUND)
+    target_compile_options(fbgemm_autovec PRIVATE "/openmp:experimental")
+  endif()
 else(MSVC)
   string(APPEND CMAKE_CXX_FLAGS " -Wall")
   string(APPEND CMAKE_CXX_FLAGS " -Wextra")
@@ -300,29 +306,40 @@ target_include_directories(fbgemm_avx512 BEFORE
       PRIVATE "${ASMJIT_SRC_DIR}/src"
       PRIVATE "${CPUINFO_SOURCE_DIR}/include")
 
+target_include_directories(fbgemm_autovec BEFORE
+      PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}>
+      PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}/include>
+      PRIVATE "${ASMJIT_SRC_DIR}/src"
+      PRIVATE "${CPUINFO_SOURCE_DIR}/include")
+
 if(FBGEMM_LIBRARY_TYPE STREQUAL "default")
   add_library(fbgemm
     $<TARGET_OBJECTS:fbgemm_generic>
     $<TARGET_OBJECTS:fbgemm_avx2>
-    $<TARGET_OBJECTS:fbgemm_avx512>)
+    $<TARGET_OBJECTS:fbgemm_avx512>
+    $<TARGET_OBJECTS:fbgemm_autovec>)
 elseif(FBGEMM_LIBRARY_TYPE STREQUAL "shared")
   add_library(fbgemm SHARED
     $<TARGET_OBJECTS:fbgemm_generic>
     $<TARGET_OBJECTS:fbgemm_avx2>
-    $<TARGET_OBJECTS:fbgemm_avx512>)
+    $<TARGET_OBJECTS:fbgemm_avx512>
+    $<TARGET_OBJECTS:fbgemm_autovec>)
   set_property(TARGET fbgemm_generic PROPERTY POSITION_INDEPENDENT_CODE ON)
   set_property(TARGET fbgemm_avx2 PROPERTY POSITION_INDEPENDENT_CODE ON)
   set_property(TARGET fbgemm_avx512 PROPERTY POSITION_INDEPENDENT_CODE ON)
+  set_property(TARGET fbgemm_autovec PROPERTY POSITION_INDEPENDENT_CODE ON)
 elseif(FBGEMM_LIBRARY_TYPE STREQUAL "static")
   add_library(fbgemm STATIC
     $<TARGET_OBJECTS:fbgemm_generic>
     $<TARGET_OBJECTS:fbgemm_avx2>
-    $<TARGET_OBJECTS:fbgemm_avx512>)
+    $<TARGET_OBJECTS:fbgemm_avx512>
+    $<TARGET_OBJECTS:fbgemm_autovec>)
   #MSVC need to define FBGEMM_STATIC for fbgemm_generic also to
   #avoid generating _dllimport functions.
   target_compile_definitions(fbgemm_generic PRIVATE FBGEMM_STATIC)
   target_compile_definitions(fbgemm_avx2 PRIVATE FBGEMM_STATIC)
   target_compile_definitions(fbgemm_avx512 PRIVATE FBGEMM_STATIC)
+  target_compile_definitions(fbgemm_autovec PRIVATE FBGEMM_STATIC)
   target_compile_definitions(fbgemm PRIVATE FBGEMM_STATIC)
 else()
   message(FATAL_ERROR "Unsupported library type ${FBGEMM_LIBRARY_TYPE}")

--- a/bench/EmbeddingSpMDMNBitBenchmark.cc
+++ b/bench/EmbeddingSpMDMNBitBenchmark.cc
@@ -26,6 +26,7 @@
 #include "./BenchUtils.h"
 #include "fbgemm/Fbgemm.h"
 #include "fbgemm/FbgemmConvert.h"
+#include "src/EmbeddingSpMDMAutovec.h"
 #include "src/RefImplementations.h"
 
 using namespace std;
@@ -133,11 +134,13 @@ int run_benchmark(
   }
 
   vector<float> output_sls_ref(batch_size * embedding_dim);
+  vector<float> output_sls_autovec(output_sls_ref.size()),
+      output_slws_autovec(output_sls_ref.size());
   vector<float> output_slws_ref(output_sls_ref.size()),
       output_sls(output_sls_ref.size()), output_slws(output_sls_ref.size());
 
-  constexpr int NUM_WARMUP = 4;
-  constexpr int NUM_ITER = 10;
+  constexpr int NUM_WARMUP = 10;
+  constexpr int NUM_ITER = 100;
   // Only counts the number of bytes for reading embedding table and ignore
   // others. Should be good enough as long as embdding_dim is big enough.
   double bytes = lengths_sum * fused_embedding_dim;
@@ -148,36 +151,10 @@ int run_benchmark(
 
   for (bool has_weight : {false, true}) {
     vector<float>& output_ref = has_weight ? output_slws_ref : output_sls_ref;
+    vector<float>& output_autovec =
+        has_weight ? output_slws_autovec : output_sls_autovec;
 
-    bool success = false, success_ref = false;
-
-    if (use_32_bit_indices) {
-      success_ref = EmbeddingSpMDMNBit_ref(
-          bit_rate,
-          embedding_dim,
-          batch_size,
-          lengths_sum,
-          num_rows,
-          fused_embedding_table.data(),
-          indices_32.data(),
-          offsets.data(),
-          has_weight ? weights.data() : nullptr,
-          normalize_by_lengths,
-          output_ref.data());
-    } else {
-      success = EmbeddingSpMDMNBit_ref(
-          bit_rate,
-          embedding_dim,
-          batch_size,
-          lengths_sum,
-          num_rows,
-          fused_embedding_table.data(),
-          indices.data(),
-          offsets.data(),
-          has_weight ? weights.data() : nullptr,
-          normalize_by_lengths,
-          output_ref.data());
-    }
+    bool success = false, success_ref = false, success_autovec = false;
 
     auto kernel_32 = GenerateEmbeddingSpMDMNBit<int32_t>(
         bit_rate,
@@ -194,6 +171,95 @@ int run_benchmark(
 
     vector<float>& output = has_weight ? output_slws : output_sls;
     for (bool flush_cache : {false, true}) {
+      // Reference implementation
+      double t_ref = measureWithWarmup(
+          [&]() {
+            if (use_32_bit_indices) {
+              success_ref = EmbeddingSpMDMNBit_ref(
+                  bit_rate,
+                  embedding_dim,
+                  batch_size,
+                  lengths_sum,
+                  num_rows,
+                  fused_embedding_table.data(),
+                  indices_32.data(),
+                  offsets.data(),
+                  has_weight ? weights.data() : nullptr,
+                  normalize_by_lengths,
+                  output_ref.data());
+            } else {
+              success_ref = EmbeddingSpMDMNBit_ref(
+                  bit_rate,
+                  embedding_dim,
+                  batch_size,
+                  lengths_sum,
+                  num_rows,
+                  fused_embedding_table.data(),
+                  indices.data(),
+                  offsets.data(),
+                  has_weight ? weights.data() : nullptr,
+                  normalize_by_lengths,
+                  output_ref.data());
+            }
+          },
+          NUM_WARMUP,
+          NUM_ITER,
+          [&]() {
+            if (flush_cache) {
+              cache_evict(fused_embedding_table);
+              cache_evict(indices);
+              cache_evict(indices_32);
+              cache_evict(offsets);
+              cache_evict(weights);
+              cache_evict(output);
+            }
+          });
+
+      // Auto-vectorization implementation
+      double t_autovec = measureWithWarmup(
+          [&]() {
+            if (use_32_bit_indices) {
+              success_autovec = EmbeddingSpMDMNBit_autovec(
+                  bit_rate,
+                  embedding_dim,
+                  batch_size,
+                  lengths_sum,
+                  num_rows,
+                  fused_embedding_table.data(),
+                  indices_32.data(),
+                  offsets.data(),
+                  has_weight ? weights.data() : nullptr,
+                  normalize_by_lengths,
+                  output_autovec.data());
+            } else {
+              success_autovec = EmbeddingSpMDMNBit_autovec(
+                  bit_rate,
+                  embedding_dim,
+                  batch_size,
+                  lengths_sum,
+                  num_rows,
+                  fused_embedding_table.data(),
+                  indices.data(),
+                  offsets.data(),
+                  has_weight ? weights.data() : nullptr,
+                  normalize_by_lengths,
+                  output_autovec.data());
+            }
+          },
+          NUM_WARMUP,
+          NUM_ITER,
+          [&]() {
+            if (flush_cache) {
+              cache_evict(fused_embedding_table);
+              cache_evict(indices);
+              cache_evict(indices_32);
+              cache_evict(offsets);
+              cache_evict(weights);
+              cache_evict(output);
+            }
+          });
+
+      // Hand-written AVX2/AVX512 implementation
       double t = measureWithWarmup(
           [&]() {
             if (use_32_bit_indices) {
@@ -251,37 +317,55 @@ int run_benchmark(
         //     has_weight ? output_slws_ref : output_sls_ref;
         if (success != success_ref) {
           assert(
-              false && "ERROR: refernce impl and JIT imp did not both succeed");
+              false &&
+              "ERROR: reference impl and JIT imp did not both succeed");
+        } else if (success != success_autovec) {
+          assert(
+              false &&
+              "ERROR: reference impl and auto-vec impl did not both succeed");
         } else if (success) {
           for (size_t i = 0; i < output.size(); ++i) {
             assert(fabs(output[i] - output_ref[i]) < 1e-3);
+            assert(fabs(output_autovec[i] - output_ref[i]) < 1e-3);
             if (fabs(output[i] - output_ref[i]) >= 1e-3) {
-              cout << i << " " << output[i] << " " << output_ref[i] << endl;
+              cout << "asmjit vs ref  : " << i << " " << output[i] << " "
+                   << output_ref[i] << endl;
+            }
+            if (fabs(output_autovec[i] - output_ref[i]) >= 1e-3) {
+              cout << "autovec vec ref: " << i << " " << output_autovec[i]
+                   << " " << output_ref[i] << endl;
             }
           }
         }
       }
 
       if (has_weight) {
-        cout << setw(16) << "SLW(WEIGHTED) ";
+        cout << "SLW(WEIGHTED), ";
       } else {
-        cout << setw(16) << "SLS ";
+        cout << "SLS, ";
       }
       if (flush_cache) {
-        cout << setw(20) << "cache flushed";
+        cout << "cache flushed, ";
       } else {
-        cout << setw(20) << "cache not flushed";
+        cout << "cache not flushed, ";
       }
       if (prefetch) {
-        cout << setw(16) << "prefetch on";
+        cout << "prefetch on, ";
       } else {
-        cout << setw(16) << "prefetch off";
+        cout << "prefetch off, ";
       }
 
-      cout << setw(8) << "b/w" << setw(10) << bytes / 1e9 / t << " GB/s"
-           << setw(20) << "effective b/w: " << setw(16)
-           << bytes_padded / 1e9 / t << "GB/s" << setw(8) << " time "
-           << setw(16) << t << endl;
+      cout << "b/w, " << bytes / 1e9 / t << ", GB/s, "
+           << "effective b/w, " << bytes_padded / 1e9 / t << ", GB/s, "
+           << "time, " << t << ", autovec b/w, " << bytes / 1e9 / t_autovec
+           << ", GB/s, "
+           << "autovec eff. b/w, " << bytes_padded / 1e9 / t_autovec
+           << ", GB/s, "
+           << "autovec time, " << t_autovec << ", ref b/w, "
+           << bytes / 1e9 / t_ref << ", GB/s, "
+           << "ref eff. b/w, " << bytes_padded / 1e9 / t_ref << ", GB/s, "
+           << "ref time, " << t_ref << ", autovec speedup, "
+           << t_ref / t_autovec << ", asmjit speedup, " << t_ref / t << endl;
     } // flush_cache
   } // has_weight
   return 0;
@@ -295,7 +379,7 @@ int main() {
 
   vector<vector<int>> inputs(GetInputs_());
 
-  for (int bit_rate : {2, 4}) {
+  for (int bit_rate : {4, 2}) {
     for (auto& input : inputs) {
       assert(input.size() > 3);
       batch_size = input[0];
@@ -303,10 +387,9 @@ int main() {
       embedding_dim = input[2];
       average_len = input[3];
 
-      cout << "bit_rate" << setw(6) << bit_rate << "batch size" << setw(6)
-           << batch_size << setw(10) << "num rows" << setw(16) << num_rows
-           << setw(10) << "emb dim" << setw(6) << embedding_dim << setw(16)
-           << "avg length" << setw(6) << average_len << endl;
+      cout << "bit_rate, " << bit_rate << ", batch size, " << batch_size
+           << ", num rows, " << num_rows << ", emb dim, " << embedding_dim
+           << ", avg length, " << average_len << endl;
       // args: batch sz, num rows, emb dim, avg len, normalize, use 32b,
       // prefetch
       cout << "64 bit indices, ";

--- a/defs.bzl
+++ b/defs.bzl
@@ -138,5 +138,10 @@ def get_fbgemm_inline_avx512_srcs(msvc = False, buck = False):
         })
     return asm_srcs if not msvc else intrinsics_srcs
 
+def get_fbgemm_autovec_srcs():
+    return [
+        "src/EmbeddingSpMDMAutovec.cc",
+    ]
+
 def get_fbgemm_tests(skip_tests = []):
     return native.glob(["test/*Test.cc"], exclude = skip_tests)

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -487,6 +487,7 @@ endif()
 
 set(fbgemm_sources_normal
   "${FBGEMM}/src/EmbeddingSpMDM.cc"
+  "${FBGEMM}/src/EmbeddingSpMDMAutovec.cc"
   "${FBGEMM}/src/EmbeddingSpMDMNBit.cc"
   "${FBGEMM}/src/QuantUtils.cc"
   "${FBGEMM}/src/RefImplementations.cc"

--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -147,6 +147,11 @@ FBGEMM_API bool fbgemmHasAvx512VnniSupport();
 FBGEMM_API bool fbgemmHasArmNeonSupport();
 
 /**
+ * @brief Are we running on a ARM SVE2 supported cpu?
+ */
+FBGEMM_API bool fbgemmHasArmSve2Support();
+
+/**
  * @brief Retrieve current CPU instruction set
  */
 FBGEMM_API inst_set_t fbgemmInstructionSet();

--- a/src/EmbeddingSpMDMAutovec.cc
+++ b/src/EmbeddingSpMDMAutovec.cc
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#define FBGEMM_EXPORTS
+#include "./EmbeddingSpMDMAutovec.h"
+
+#include "fbgemm/FbgemmBuild.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <numeric>
+#include <thread>
+
+using std::vector;
+
+namespace fbgemm {
+
+template <typename IndexType, typename OffsetType, typename OutType>
+bool EmbeddingSpMDMNBit_autovec(
+    const int bit_rate,
+    const int64_t block_size,
+    const int64_t output_size,
+    const int64_t index_size,
+    const int64_t data_size,
+    const uint8_t* input,
+    const IndexType* indices,
+    const OffsetType* offsets_or_lengths,
+    const float* weights, // optional, can be null for non-weighted sum
+    const bool normalize_by_lengths,
+    OutType* out,
+    const bool is_weight_positional /*=false*/,
+    const bool use_offsets /*=true*/,
+    int64_t output_stride /*=-1*/,
+    int64_t input_stride /*=-1*/,
+    const bool scale_bias_last /*=true*/,
+    const bool is_bf16_out /*=false*/) {
+  assert((bit_rate == 2 || bit_rate == 4) && "bit_rate must be 2 or 4");
+  const int num_elem_per_byte = 8 / bit_rate;
+
+  if (output_stride == -1) {
+    output_stride = block_size;
+  }
+
+  // block_size is the number of elements and fused_block_size is the size of
+  // an entire row, including scale and bias.
+  const auto scale_bias_offset = 2 * sizeof(float16);
+  if (input_stride == -1) {
+    input_stride = div_up(block_size, num_elem_per_byte) + scale_bias_offset;
+  }
+  int64_t current = 0;
+  const int64_t rounded_bs = round_up(block_size, num_elem_per_byte);
+  vector<float> buf(rounded_bs);
+  for (int m = 0; m < output_size; ++m) {
+    memset(buf.data(), 0, sizeof(float) * rounded_bs);
+    int len = use_offsets ? offsets_or_lengths[m + 1] - offsets_or_lengths[m]
+                          : offsets_or_lengths[m];
+    if (current + len > index_size) {
+      return false;
+    }
+    constexpr int tile_size = 4;
+#if _OPENMP >= 202011
+#pragma omp tile sizes(tile_size)
+#endif
+    for (int i = 0; i < len; ++i) {
+      int64_t idx = indices[current];
+      int64_t prefetch_idx =
+          indices[std::min(current + tile_size, index_size - 1)];
+      do_prefetch(
+          reinterpret_cast<const char*>(input + input_stride * prefetch_idx),
+          1);
+      if (idx < 0 || idx >= data_size) {
+        return false;
+      }
+
+      const float16* scale_bias = reinterpret_cast<const float16*>(
+          input + input_stride * idx +
+          (scale_bias_last ? div_up(block_size, num_elem_per_byte) : 0));
+
+      float weight = 1.0f;
+      if (weights) {
+        weight = weights[is_weight_positional ? i : current];
+      }
+      const float scale = weight * cpu_half2float(scale_bias[0]);
+      const float bias = weight * cpu_half2float(scale_bias[1]);
+
+      const int64_t offset =
+          input_stride * idx + (scale_bias_last ? 0 : scale_bias_offset);
+      if (bit_rate == 4) {
+        const size_t halfbufsz = (block_size + 1) / 2;
+        assert(halfbufsz > 0);
+        thread_local vector<float> buf1;
+        thread_local vector<float> buf2;
+        buf1.resize(halfbufsz);
+        buf2.resize(halfbufsz);
+#pragma omp simd
+        for (size_t j = 0; j < halfbufsz; ++j) {
+          uint8_t quantized1 = input[offset + j] & 0xf;
+          uint8_t quantized2 = input[offset + j] & 0xf0;
+          quantized2 = quantized2 >> 4;
+          buf1[j] = quantized1;
+          buf2[j] = quantized2;
+        }
+#pragma omp simd
+        for (size_t j = 0; j < halfbufsz; ++j) {
+          buf[j * 2] = std::fma(scale, buf1[j], buf[j * 2] + bias);
+          buf[j * 2 + 1] = std::fma(scale, buf2[j], buf[j * 2 + 1] + bias);
+        }
+      } else if (bit_rate == 2) {
+        size_t qbufsz = (block_size + 3) / 4;
+        vector<vector<float>> qbufs(4);
+        for (int k = 0; k < 4; ++k) {
+          qbufs[k].resize(qbufsz);
+        }
+        vector<uint8_t> masks{0x3, 0xC, 0x30, 0xC0};
+#pragma omp simd collapse(2)
+        for (size_t j = 0; j < qbufsz; ++j) {
+          for (size_t k = 0; k < 4; ++k) {
+            uint8_t quantized = input[offset + j] & masks[k];
+            quantized = quantized >> (k * 2);
+            qbufs[k][j] = quantized;
+          }
+        }
+#pragma omp simd collapse(2)
+        for (size_t j = 0; j < qbufsz; ++j) {
+          for (size_t k = 0; k < 4; ++k) {
+            buf[j * 4 + k] =
+                std::fma(scale, qbufs[k][j], buf[j * 4 + k] + bias);
+          }
+        }
+      }
+      ++current;
+    }
+
+    if (normalize_by_lengths && len) {
+      float scale = 1.f / len;
+#pragma omp simd
+      for (int j = 0; j < block_size; ++j) {
+        buf[j] *= scale;
+      }
+    }
+    if (std::is_same<OutType, float>::value) {
+#pragma omp simd
+      for (int j = 0; j < block_size; ++j) {
+        out[j] = buf[j];
+      }
+    } else if (std::is_same<OutType, uint16_t>::value && is_bf16_out) {
+#pragma omp simd
+      for (int j = 0; j < block_size; ++j) {
+        out[j] = cpu_bf162float(buf[j]);
+      }
+    } else {
+#pragma omp simd
+      for (int j = 0; j < block_size; ++j) {
+        out[j] = cpu_half2float(buf[j]);
+      }
+    }
+    out += output_stride;
+  }
+  return current == index_size;
+}
+
+#define INSTANTIATE_SPMDM_BASE(INDEX_TYPE, OFFSET_TYPE, OUT_TYPE) \
+  template FBGEMM_API bool EmbeddingSpMDMNBit_autovec(            \
+      const int bit_rate,                                         \
+      const int64_t block_size,                                   \
+      const int64_t output_size,                                  \
+      const int64_t index_size,                                   \
+      const int64_t data_size,                                    \
+      const uint8_t* input,                                       \
+      const INDEX_TYPE* indices,                                  \
+      const OFFSET_TYPE* offsets_or_lengths,                      \
+      const float* weights,                                       \
+      const bool normalize_by_lengths,                            \
+      OUT_TYPE* out,                                              \
+      const bool is_weight_positional,                            \
+      const bool use_offsets,                                     \
+      int64_t output_stride,                                      \
+      int64_t input_stride,                                       \
+      const bool scale_bias_last,                                 \
+      const bool is_bf16_out);
+
+#define INSTANTIATE_SPMDM_OUT_T(INDEX_TYPE, OFFSET_TYPE) \
+  INSTANTIATE_SPMDM_BASE(INDEX_TYPE, OFFSET_TYPE, float) \
+  INSTANTIATE_SPMDM_BASE(INDEX_TYPE, OFFSET_TYPE, float16)
+
+#define INSTANTIATE_SPMDM_OFFSET_T(INDEX_TYPE) \
+  INSTANTIATE_SPMDM_OUT_T(INDEX_TYPE, int32_t) \
+  INSTANTIATE_SPMDM_OUT_T(INDEX_TYPE, int64_t)
+
+INSTANTIATE_SPMDM_OFFSET_T(int32_t)
+INSTANTIATE_SPMDM_OFFSET_T(int64_t)
+
+#undef INSTANTIATE_SPMDM_OFFSET_T
+#undef INSTANTIATE_SPMDM_OUT_T
+#undef INSTANTIATE_SPMDM_BASE
+
+} // namespace fbgemm

--- a/src/EmbeddingSpMDMAutovec.h
+++ b/src/EmbeddingSpMDMAutovec.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+#include "fbgemm/ConvUtils.h"
+#include "fbgemm/FbgemmI8Spmdm.h"
+#include "fbgemm/Types.h"
+
+#ifdef _WIN32
+#define do_prefetch(...)
+#else
+#define do_prefetch(...) __builtin_prefetch(__VA_ARGS__)
+#endif
+
+namespace fbgemm {
+
+template <
+    typename IndexType = std::int64_t,
+    typename OffsetType = std::int32_t,
+    typename OutType = float>
+FBGEMM_API bool EmbeddingSpMDMNBit_autovec(
+    const int bit_rate,
+    const std::int64_t block_size,
+    const std::int64_t output_size,
+    const std::int64_t index_size,
+    const std::int64_t data_size,
+    const std::uint8_t* input,
+    const IndexType* indices,
+    const OffsetType* offsets_or_lengths,
+    const float* weights, // optional, can be null for non-weighted sum
+    const bool normalize_by_lengths,
+    OutType* out,
+    const bool is_weight_positional = false,
+    const bool use_offsets = true,
+    std::int64_t output_stride = -1,
+    std::int64_t input_stride = -1,
+    const bool scale_bias_last = true,
+    const bool is_bf16_out = false);
+
+} // namespace fbgemm

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -20,6 +20,7 @@
 #include <string>
 #include <tuple>
 #include "./CodeCache.h"
+#include "./EmbeddingSpMDMAutovec.h"
 #include "./MaskAvx2.h"
 #include "./RefImplementations.h"
 #include "fbgemm/SimdUtils.h"
@@ -1124,6 +1125,34 @@ typename EmbeddingSpMDMKernelSignature<uint8_t, indxType, offsetType, outType>::
           weights,
           out,
           internal::avx2_ps_or_epi32_combined_mask);
+    };
+  } else if (fbgemmHasArmSve2Support()) {
+    return [=](int64_t output_size,
+               int64_t index_size,
+               int64_t data_size,
+               const uint8_t* input,
+               const indxType* indices,
+               const offsetType* offsets_or_lengths,
+               const float* weights,
+               outType* out) {
+      return EmbeddingSpMDMNBit_autovec(
+          bit_rate,
+          block_size,
+          output_size,
+          index_size,
+          data_size,
+          input,
+          indices,
+          offsets_or_lengths,
+          weights,
+          normalize_by_lengths,
+          out,
+          is_weight_positional,
+          use_offsets,
+          output_stride,
+          input_stride,
+          scale_bias_last,
+          is_bf16_out);
     };
   } else {
 #ifdef VLOG

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -386,6 +386,10 @@ bool fbgemmHasArmNeonSupport() {
   return (cpuinfo_has_arm_neon());
 }
 
+bool fbgemmHasArmSve2Support() {
+  return (cpuinfo_has_arm_sve2());
+}
+
 void fbgemmPartition1D(
     int thread_id,
     int num_threads,


### PR DESCRIPTION
Summary:
Add an auto-vectorization implementation for int4 CPU-TBE kernel to accelerate ARM platform. Also adds relevant unit tests and benchmarks.

This is based on my auto-vec tries D50142928 and bangshengtang's further optimizations including D50212552, D50213049, D50243725 and D50303751

Differential Revision: D50289383


