### PR TITLE
Fix torchscript issue

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
@@ -1192,9 +1192,9 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
                     ),
                 ]
                 if (
-                    weight_ty == SparseType.INT8
-                    or weight_ty == SparseType.INT4
-                    or weight_ty == SparseType.INT2
+                    weight_ty.value == SparseType.INT8.value
+                    or weight_ty.value == SparseType.INT4.value
+                    or weight_ty.value == SparseType.INT2.value
                 ):
                     if split_scale_bias_mode == 1:
                         splits.append(
@@ -1220,9 +1220,9 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
                             )
                         )
                 elif (
-                    weight_ty == SparseType.FP8
-                    or weight_ty == SparseType.FP16
-                    or weight_ty == SparseType.FP32
+                    weight_ty.value == SparseType.FP8.value
+                    or weight_ty.value == SparseType.FP16.value
+                    or weight_ty.value == SparseType.FP32.value
                 ):
                     splits.append(
                         (


### PR DESCRIPTION
Summary:
Check https://fb.workplace.com/groups/957614988799577/permalink/995501075010968/

Similar to D29056288 .

Didn't know `split_embedding_weights_with_scale_bias` is used in forward path in torchscript?

Reviewed By: q10, mengyingdu

Differential Revision: D50474951


