### PR TITLE
Get fbgemm::pack_segments tests working (#2076)

### DIFF
--- a/fbgemm_gpu/test/failures_dict.json
+++ b/fbgemm_gpu/test/failures_dict.json
@@ -481,11 +481,11 @@
     "fbgemm::pack_segments": {
       "SparseOpsTest.test_aot_dispatch_dynamic__test_pack_segments": {
         "comment": "",
-        "status": "xfail"
+        "status": "xsuccess"
       },
       "SparseOpsTest.test_aot_dispatch_static__test_pack_segments": {
         "comment": "",
-        "status": "xfail"
+        "status": "xsuccess"
       }
     },
     "fbgemm::permute102_baddbmm_permute102": {


### PR DESCRIPTION
Summary:

Follow https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU/edit?usp=sharing to get `fbgemm::pack_segments` tests passing in `failures_dict.json`

Reviewed By: zou3519

Differential Revision: D50513309


