### PR TITLE
Derandomize Hypothesis tests in split_table_batched_embeddings_test

### DIFF
--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -88,6 +88,10 @@ MAX_EXAMPLES = 40
 MAX_EXAMPLES_LONG_RUNNING = 15
 
 
+settings.register_profile("derandomize", derandomize=True)
+settings.load_profile("derandomize")
+
+
 @composite
 # pyre-ignore
 def get_nbit_weights_ty(draw) -> Optional[SparseType]:


### PR DESCRIPTION
Summary: This probably needs to be applied globally, but starting small.  Hopefully this will make some tests that were previously flaky e.g. https://www.internalfb.com/intern/test/281475047227145?ref_report_id=0 deterministically fail

Reviewed By: zou3519

Differential Revision: D50612859


