### PR TITLE
Meta functions for dynamic_shapes for block_bucketize_sparse_features, int_nbit_split_embedding_codegen_lookup_function

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host_cpu.cpp
@@ -244,13 +244,13 @@ Tensor pruned_array_lookup_cpu(
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
-      "int_nbit_split_embedding_codegen_lookup_function(Tensor dev_weights, Tensor uvm_weights, Tensor weights_placements, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, int total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, int max_float32_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, int output_dtype=1, Tensor? lxu_cache_weights=None, Tensor? lxu_cache_locations=None, int? row_alignment = None, int? max_float8_D=0, int? fp8_exponent_bits=-1, int? fp8_exponent_bias=-1) -> Tensor");
+      "int_nbit_split_embedding_codegen_lookup_function(Tensor dev_weights, Tensor uvm_weights, Tensor weights_placements, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, SymInt total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, int max_float32_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, int output_dtype=1, Tensor? lxu_cache_weights=None, Tensor? lxu_cache_locations=None, int? row_alignment = None, int? max_float8_D=0, int? fp8_exponent_bits=-1, int? fp8_exponent_bias=-1) -> Tensor");
   DISPATCH_TO_CPU(
       "int_nbit_split_embedding_codegen_lookup_function",
       int_nbit_split_embedding_codegen_lookup_function_cpu);
 
   m.def(
-      "int_nbit_split_embedding_uvm_caching_codegen_lookup_function(Tensor dev_weights, Tensor uvm_weights, Tensor weights_placements, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, int total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, int max_float32_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights=None, int output_dtype=1, Tensor? lxu_cache_weights=None, Tensor? lxu_cache_locations=None, int? row_alignment=-1, int? max_float8_D=0, int? fp8_exponent_bits=-1, int? fp8_exponent_bias=-1, Tensor? cache_hash_size_cumsum=None, int? total_cache_hash_size=-1, Tensor? cache_index_table_map=None, Tensor? lxu_cache_state=None, Tensor? lxu_state=None) -> Tensor");
+      "int_nbit_split_embedding_uvm_caching_codegen_lookup_function(Tensor dev_weights, Tensor uvm_weights, Tensor weights_placements, Tensor weights_offsets, Tensor weights_tys, Tensor D_offsets, SymInt total_D, int max_int2_D, int max_int4_D, int max_int8_D, int max_float16_D, int max_float32_D, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights=None, int output_dtype=1, Tensor? lxu_cache_weights=None, Tensor? lxu_cache_locations=None, int? row_alignment=-1, int? max_float8_D=0, int? fp8_exponent_bits=-1, int? fp8_exponent_bias=-1, Tensor? cache_hash_size_cumsum=None, int? total_cache_hash_size=-1, Tensor? cache_index_table_map=None, Tensor? lxu_cache_state=None, Tensor? lxu_state=None) -> Tensor");
   DISPATCH_TO_CPU(
       "int_nbit_split_embedding_uvm_caching_codegen_lookup_function",
       int_nbit_split_embedding_uvm_caching_codegen_lookup_function_cpu);

--- a/fbgemm_gpu/fbgemm_gpu/sparse_operators.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_operators.py
@@ -4,9 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Callable, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import torch
+
+from fbgemm_gpu.split_embedding_configs import SparseType
+from fbgemm_gpu.split_table_batched_embeddings_ops_common import PoolingMode
 from torch import Tensor
 
 try:
@@ -15,6 +18,12 @@ try:
 except Exception:
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:merge_pooled_embeddings")
+    torch.ops.load_library(
+        "//deeplearning/fbgemm/fbgemm_gpu:merge_pooled_embeddings_cpu"
+    )
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops")
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops_cpu")
 
 
 if hasattr(torch.library, "impl_abstract"):
@@ -104,3 +113,140 @@ def expand_into_jagged_permute_meta(
     )
     output_permute = input_offsets.new_empty(output_size)
     return output_permute
+
+
+@impl_abstract("fbgemm::int_nbit_split_embedding_codegen_lookup_function")
+def int_nbit_split_embedding_codegen_lookup_function_meta(
+    dev_weights: torch.Tensor,
+    uvm_weights: torch.Tensor,
+    weights_placements: torch.Tensor,
+    weights_offsets: torch.Tensor,
+    weights_tys: torch.Tensor,
+    D_offsets: torch.Tensor,
+    total_D: int,
+    max_int2_D: int,
+    max_int4_D: int,
+    max_int8_D: int,
+    max_float16_D: int,
+    max_float32_D: int,
+    indices: torch.Tensor,
+    offsets: torch.Tensor,
+    pooling_mode: int,
+    indice_weights: Optional[torch.Tensor] = None,
+    output_dtype_int: Optional[int] = None,
+    lxu_cache_weights: Optional[torch.Tensor] = None,
+    lxu_cache_locations: Optional[torch.Tensor] = None,
+    row_alignment: Optional[int] = None,
+    max_float8_D: Optional[int] = None,
+    fp8_exponent_bits: Optional[int] = None,
+    fp8_exponent_bias: Optional[int] = None,
+) -> torch.Tensor:
+    T = D_offsets.numel() - 1
+    B = (offsets.size(0) - 1) // T
+    output_dtype = torch.float32
+    torch._check(
+        output_dtype_int in (0, 1, 5),
+        lambda: f"expected output_dtype to be fp32, fp16 or bf16, got {indices.dtype}",
+    )
+    if output_dtype_int == SparseType.FP32.value:
+        output_dtype = torch.float32
+    elif output_dtype_int == SparseType.FP16.value:
+        output_dtype = torch.float16
+    elif output_dtype_int == SparseType.BF16.value:
+        output_dtype = torch.bfloat16
+
+    if pooling_mode == PoolingMode.NONE:
+        # pyre-ignore
+        offsets_last: int = offsets[-1].item()
+        total_D_T: int = total_D // T
+        torch._check_is_size(offsets[-1].item())
+        torch._check_is_size(total_D_T)
+        torch._check_is_size(B)
+        return dev_weights.new_empty(
+            [offsets_last, total_D_T],
+            dtype=output_dtype,
+            device=torch.device("meta"),
+        )
+    torch._check_is_size(B)
+    torch._check_is_size(total_D)
+    return dev_weights.new_empty(
+        (B, total_D),
+        dtype=output_dtype,
+        device=torch.device("meta"),
+    )
+
+
+@impl_abstract("fbgemm::block_bucketize_sparse_features")
+def block_bucketize_sparse_features_meta(
+    lengths: torch.Tensor,
+    indices: torch.Tensor,
+    bucketize_pos: bool,
+    sequence: bool,
+    block_sizes: torch.Tensor,
+    my_size: int,
+    weights: Optional[torch.Tensor] = None,
+    batch_size_per_feature: Optional[torch.Tensor] = None,
+    max_B: int = -1,
+) -> Tuple[
+    torch.Tensor,
+    torch.Tensor,
+    Optional[torch.Tensor],
+    Optional[torch.Tensor],
+    Optional[torch.Tensor],
+]:
+    # Output: lengths, indices, weights", pos?, unbucketize_permute?
+    num_buckets = my_size
+    num_features = lengths.size(0)
+    num_values = indices.size(0)
+    return (
+        lengths.new_empty([num_buckets * num_features]),
+        indices.new_empty([num_values]),
+        weights.new_empty(weights.shape) if weights is not None else None,
+        indices.new_empty([num_values]) if bucketize_pos else None,
+        indices.new_empty([num_values]),
+    )
+
+
+@impl_abstract("fbgemm::merge_pooled_embeddings")
+def merge_pooled_embeddings(
+    pooled_embeddings: List[torch.Tensor],
+    uncat_dim_size: int,
+    target_device: torch.device,
+    cat_dim: int = 1,
+) -> torch.Tensor:
+    if len(pooled_embeddings) == 0:
+        return torch.empty([], device=target_device)
+    torch._check_is_size(cat_dim)
+    torch._check(cat_dim >= 0)
+    torch._check(cat_dim <= 1)
+    total_cat_dim_size = 0
+    for e in pooled_embeddings:
+        torch._check(e.dim() == 2)
+        torch._check(e.size(1 - cat_dim) == uncat_dim_size)
+        total_cat_dim_size += e.size(cat_dim)
+    torch._check_is_size(total_cat_dim_size)
+    e = pooled_embeddings[0]
+    if cat_dim == 0:
+        return e.new_empty(
+            [total_cat_dim_size, e.size(1)],
+            device=torch.device("meta"),
+        )
+
+    return e.new_empty(
+        [e.size(0), total_cat_dim_size],
+        device=torch.device("meta"),
+    )
+
+
+@impl_abstract("fbgemm::bounds_check_indices")
+def bounds_check_indices(
+    rows_per_table: torch.Tensor,
+    indices: torch.Tensor,
+    offsets: torch.Tensor,
+    bounds_check_mode: int,
+    warning: torch.Tensor,
+    weights: Optional[torch.Tensor] = None,
+    B_offsets: Optional[torch.Tensor] = None,
+    max_B: int = -1,
+) -> None:
+    pass

--- a/fbgemm_gpu/src/merge_pooled_embeddings_gpu.cpp
+++ b/fbgemm_gpu/src/merge_pooled_embeddings_gpu.cpp
@@ -642,25 +642,11 @@ Tensor sum_reduce_to_one_device(
   return sum_reduce_to_one(input_tensors, target_device);
 }
 
-Tensor merge_pooled_embeddings_meta(
-    std::vector<Tensor> pooled_embeddings,
-    int64_t uncat_dim_size,
-    at::Device /*target_device*/,
-    int64_t cat_dim) {
-  if (pooled_embeddings.size() == 0) {
-    return at::empty({0}, at::TensorOptions().device("meta"));
-  }
-
-  auto [output_shape, cumulative_dims, total_cat_dim] =
-      cat_dim_2d_output_shape(pooled_embeddings, uncat_dim_size, cat_dim);
-
-  return at::empty(output_shape, pooled_embeddings.front().options());
-}
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
-      "merge_pooled_embeddings(Tensor[] pooled_embeddings, int uncat_dim_size, Device target_device, int cat_dim=1) -> Tensor");
+      "merge_pooled_embeddings(Tensor[] pooled_embeddings, SymInt uncat_dim_size, Device target_device, SymInt cat_dim=1) -> Tensor");
   DISPATCH_TO_CUDA(
       "merge_pooled_embeddings", fbgemm_gpu::merge_pooled_embeddings);
   m.def(
@@ -669,6 +655,4 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "sum_reduce_to_one(Tensor[] input_tensors, Device target_device) -> Tensor");
   DISPATCH_TO_CUDA("sum_reduce_to_one", fbgemm_gpu::sum_reduce_to_one_device);
-  DISPATCH_TO_META(
-      "merge_pooled_embeddings", fbgemm_gpu::merge_pooled_embeddings_meta);
 }

--- a/fbgemm_gpu/test/failures_dict.json
+++ b/fbgemm_gpu/test/failures_dict.json
@@ -37,18 +37,6 @@
         "comment": "",
         "status": "xfail"
       },
-      "SparseOpsTest.test_aot_dispatch_static__test_block_bucketize_sparse_features": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "SparseOpsTest.test_aot_dispatch_static__test_block_bucketize_sparse_features_long_indices": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "SparseOpsTest.test_aot_dispatch_static__test_block_bucketize_sparse_features_with_variable_batch_sizes": {
-        "comment": "",
-        "status": "xfail"
-      },
       "SparseOpsTest.test_faketensor__test_block_bucketize_sparse_features": {
         "comment": "",
         "status": "xfail"

--- a/fbgemm_gpu/test/merge_pooled_embeddings_test.py
+++ b/fbgemm_gpu/test/merge_pooled_embeddings_test.py
@@ -26,6 +26,7 @@ except Exception:
     torch.ops.load_library(
         "//deeplearning/fbgemm/fbgemm_gpu:merge_pooled_embeddings_cpu"
     )
+    import fbgemm_gpu.sparse_operators  # noqa: F401, E402
     from fbgemm_gpu.test.test_utils import gpu_unavailable
 
     open_source = False


### PR DESCRIPTION
Summary:
Main goal is to make torchrec inference modules dynamo traceable with dynamic shapes.
Adding meta function for `int_nbit_split_embedding_codegen_lookup_function`, changing `int` to `SymInt` in schema.
Adding meta function for `block_bucketize_sparse_features`  (RW sharding)

Differential Revision:
D50741802

Privacy Context Container: L1138451


