### PR TITLE
fbgemm dequantize for bf16

### DIFF
--- a/fbgemm_gpu/test/quantize_ops_test.py
+++ b/fbgemm_gpu/test/quantize_ops_test.py
@@ -138,64 +138,80 @@ class TestFused8BitRowwiseQuantizationConversion(unittest.TestCase):
     @given(
         nrows=st.integers(min_value=0, max_value=100),
         ncols=st.integers(min_value=0, max_value=100),
-        is_output_half=st.booleans(),
-        test_float_or_half_op=st.booleans(),
+        output_dtype=st.sampled_from(
+            [SparseType.FP16, SparseType.FP32, SparseType.BF16]
+        ),
+        test_generic_op=st.booleans(),
+        test_cuda=st.booleans(),
     )
     @settings(deadline=10000, suppress_health_check=[HealthCheck.filter_too_much])
     def test_quantize_and_dequantize_op(
         self,
         nrows: int,
         ncols: int,
-        is_output_half: bool,
-        test_float_or_half_op: bool,
+        output_dtype: SparseType,
+        test_generic_op: bool,
+        test_cuda: bool,
     ) -> None:
         num_elem_per_byte = 1
         input_data = torch.rand(nrows, ncols).float()
-        if is_output_half:
+        if output_dtype == SparseType.FP16:
             input_data = input_data.half()
+        elif output_dtype == SparseType.BF16:
+            input_data = input_data.bfloat16()
 
         assume(ncols % (2 * num_elem_per_byte) == 0)
-
-        if test_float_or_half_op:
-            quantized_data = torch.ops.fbgemm.FloatOrHalfToFused8BitRowwiseQuantized(
-                input_data
-            )
-            dequantized_data = torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloatOrHalf(
-                quantized_data,
-                output_dtype=1 if is_output_half else 0,
-            )
-        else:
-            if not is_output_half:
-                quantized_data = torch.ops.fbgemm.FloatToFused8BitRowwiseQuantized(
-                    input_data
+        if not test_cuda:
+            # cpu path does not support bf16
+            if output_dtype == SparseType.BF16:
+                return
+            if test_generic_op:
+                quantized_data = (
+                    torch.ops.fbgemm.FloatOrHalfToFused8BitRowwiseQuantized(input_data)
                 )
-                dequantized_data = torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloat(
-                    quantized_data
+                dequantized_data = (
+                    torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloatOrHalf(
+                        quantized_data,
+                        output_dtype.as_int(),
+                    )
                 )
             else:
-                quantized_data = torch.ops.fbgemm.HalfToFused8BitRowwiseQuantized(
-                    input_data
-                )
-                dequantized_data = torch.ops.fbgemm.Fused8BitRowwiseQuantizedToHalf(
-                    quantized_data
-                )
+                if output_dtype == SparseType.FP32:
+                    quantized_data = torch.ops.fbgemm.FloatToFused8BitRowwiseQuantized(
+                        input_data
+                    )
+                    dequantized_data = (
+                        torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloat(
+                            quantized_data
+                        )
+                    )
+                elif output_dtype == SparseType.FP16:
+                    quantized_data = torch.ops.fbgemm.HalfToFused8BitRowwiseQuantized(
+                        input_data
+                    )
+                    dequantized_data = torch.ops.fbgemm.Fused8BitRowwiseQuantizedToHalf(
+                        quantized_data
+                    )
+                else:
+                    raise NotImplementedError("Unsupported dtype")
 
-        if nrows == 0 or ncols == 0:
-            assert dequantized_data.numel() == 0
-            return
+            if nrows == 0 or ncols == 0:
+                assert dequantized_data.numel() == 0
+                return
 
-        reference = torch.from_numpy(
-            fused_rowwise_8bit_dequantize_reference(quantized_data.numpy())
-        )
-        if not is_output_half:
-            torch.testing.assert_close(dequantized_data.float(), reference.float())
-        else:
-            torch.testing.assert_close(dequantized_data.half(), reference.half())
-
-        if gpu_available:
+            reference = torch.from_numpy(
+                fused_rowwise_8bit_dequantize_reference(quantized_data.numpy())
+            )
+            if output_dtype == SparseType.FP32:
+                torch.testing.assert_close(dequantized_data.float(), reference.float())
+            elif output_dtype == SparseType.FP16:
+                torch.testing.assert_close(dequantized_data.half(), reference.half())
+        if test_cuda and gpu_available:
+            if nrows == 0 or ncols == 0:
+                return
             input_data_gpu = input_data.cuda()
 
-            if test_float_or_half_op:
+            if test_generic_op:
                 quantized_data_gpu = (
                     torch.ops.fbgemm.FloatOrHalfToFused8BitRowwiseQuantized(
                         input_data_gpu
@@ -204,11 +220,14 @@ class TestFused8BitRowwiseQuantizationConversion(unittest.TestCase):
                 dequantized_data_gpu = (
                     torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloatOrHalf(
                         quantized_data_gpu,
-                        output_dtype=1 if is_output_half else 0,
+                        output_dtype.as_int(),
                     )
                 )
             else:
-                if not is_output_half:
+                # legacy path does not support bf16
+                if SparseType.BF16 == output_dtype:
+                    return
+                if output_dtype == SparseType.FP32:
                     quantized_data_gpu = (
                         torch.ops.fbgemm.FloatToFused8BitRowwiseQuantized(
                             input_data_gpu
@@ -219,7 +238,7 @@ class TestFused8BitRowwiseQuantizationConversion(unittest.TestCase):
                             quantized_data_gpu
                         )
                     )
-                else:
+                elif output_dtype == SparseType.FP16:
                     quantized_data_gpu = (
                         torch.ops.fbgemm.HalfToFused8BitRowwiseQuantized(input_data_gpu)
                     )
@@ -229,18 +248,23 @@ class TestFused8BitRowwiseQuantizationConversion(unittest.TestCase):
                         )
                     )
 
-            dequantized_data_numpy = dequantized_data_gpu.cpu().numpy()
-            dequantized_data_trimmed = torch.from_numpy(
-                dequantized_data_numpy[:, :ncols]
+            dequantized_data_trimmed = dequantized_data_gpu[:, :ncols].cpu()
+            quantize_data_numpy = quantized_data_gpu.cpu().numpy()
+            reference = torch.from_numpy(
+                fused_rowwise_8bit_dequantize_reference(quantize_data_numpy)[:, :ncols]
             )
 
-            if not is_output_half:
+            if output_dtype == SparseType.FP32:
                 torch.testing.assert_close(
                     dequantized_data_trimmed.float(), reference.float()
                 )
-            else:
+            elif output_dtype == SparseType.FP16:
                 torch.testing.assert_close(
                     dequantized_data_trimmed.half(), reference.half()
+                )
+            elif output_dtype == SparseType.BF16:
+                torch.testing.assert_close(
+                    dequantized_data_trimmed.bfloat16(), reference.bfloat16()
                 )
 
     @unittest.skipIf(no_long_tests, "Slow test, requires buck build to run.")  # noqa


### PR DESCRIPTION
Summary: * add cuda quantize & dequantize path for bf16 for the generic + cuda path. cpu and legacy ops are omitted.

Reviewed By: sryap

Differential Revision: D50826146


