### PR TITLE
Mingwcompile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,14 @@ else(MSVC)
   string(APPEND CMAKE_CXX_FLAGS " -Werror")
   string(APPEND CMAKE_CXX_FLAGS " -Wno-deprecated-declarations")
   string(APPEND CMAKE_CXX_FLAGS " -Wimplicit-fallthrough")
+  if(MINGW)
+    if(FBGEMM_LIBRARY_TYPE STREQUAL "static")
+    target_compile_definitions(fbgemm_generic PRIVATE ASMJIT_STATIC)
+    target_compile_definitions(fbgemm_avx2 PRIVATE ASMJIT_STATIC)
+    target_compile_definitions(fbgemm_avx512 PRIVATE ASMJIT_STATIC)
+    endif()
+  endif()
+
   target_compile_options(fbgemm_avx2 PRIVATE
     "-m64" "-mavx2" "-mf16c" "-mfma")
   target_compile_options(fbgemm_avx512 PRIVATE
@@ -236,51 +244,31 @@ message(WARNING "CMAKE_CXX_FLAGS_RELEASE is ${CMAKE_CXX_FLAGS_RELEASE}")
 message(WARNING "==========")
 
 if(NOT TARGET asmjit)
-  # Check if we are using MinGW and the asmjit header exists in the specified include directory
-  if(MINGW AND EXISTS "$ENV{MINGW_PREFIX}/include/asmjit")
-    message(STATUS "Using system-installed asmjit from $ENV{MINGW_PREFIX}")
-    
-    # Add an imported target for asmjit
-    add_library(asmjit SHARED IMPORTED GLOBAL)
-    
-    # Set the properties for the imported target
-    set_target_properties(asmjit PROPERTIES
-      IMPORTED_LOCATION "$ENV{MINGW_PREFIX}/bin/libasmjit.dll"
-      INTERFACE_INCLUDE_DIRECTORIES "$ENV{MINGW_PREFIX}/include"
-      IMPORTED_IMPLIB "$ENV{MINGW_PREFIX}/lib/libasmjit.dll.a"
-    )
-  else()
-    # ASMJIT_SRC_DIR is not defined, download asmjit from GitHub
-    if(NOT DEFINED ASMJIT_SRC_DIR)
-      set(ASMJIT_SRC_DIR "${FBGEMM_SOURCE_DIR}/third_party/asmjit"
-        CACHE STRING "asmjit source directory from submodules")
-    endif()
-
-    # Add the asmjit subdirectory from the specified source directory
-    add_subdirectory("${ASMJIT_SRC_DIR}" "${FBGEMM_BINARY_DIR}/asmjit")
+  #Download asmjit from github if ASMJIT_SRC_DIR is not specified.
+  if(NOT DEFINED ASMJIT_SRC_DIR)
+    set(ASMJIT_SRC_DIR "${FBGEMM_SOURCE_DIR}/third_party/asmjit"
+      CACHE STRING "asmjit source directory from submodules")
   endif()
 
-  # Set the common properties for asmjit
-  if(NOT MINGW)
-    set_property(TARGET asmjit PROPERTY POSITION_INDEPENDENT_CODE ON)
-    # add a flag required for mac build
-    if(NOT MSVC)
-      target_compile_options(asmjit PRIVATE "-Wno-sign-conversion")
-    endif()
-  endif()
-
-  # Set additional compile options for Clang, if applicable
-  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 13.0.0)
-  # See https://github.com/pytorch/pytorch/issues/74352, https://github.com/pytorch/FBGEMM/issues/1173
-    target_compile_options_if_supported(asmjit -Wno-deprecated-copy)
-    target_compile_options_if_supported(asmjit -Wno-unused-but-set-variable)
-  endif()
-
-  # Determine if asmjit should be built statically or dynamically
-  if ((MSVC OR MINGW) AND (FBGEMM_LIBRARY_TYPE STREQUAL "shared"))
+  #build asmjit
+  #For MSVC shared build, asmjit needs to be shared also.
+  if (MSVC AND (FBGEMM_LIBRARY_TYPE STREQUAL "shared"))
     set(ASMJIT_STATIC OFF)
   else()
     set(ASMJIT_STATIC ON)
+  endif()
+
+  add_subdirectory("${ASMJIT_SRC_DIR}" "${FBGEMM_BINARY_DIR}/asmjit")
+  set_property(TARGET asmjit PROPERTY POSITION_INDEPENDENT_CODE ON)
+  # add a flag required for mac build
+  if(NOT MSVC)
+    target_compile_options(asmjit PRIVATE "-Wno-sign-conversion")
+  endif()
+
+  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 13.0.0)
+    # See https://github.com/pytorch/pytorch/issues/74352, https://github.com/pytorch/FBGEMM/issues/1173
+    target_compile_options_if_supported(asmjit -Wno-deprecated-copy)
+    target_compile_options_if_supported(asmjit -Wno-unused-but-set-variable)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,31 +236,51 @@ message(WARNING "CMAKE_CXX_FLAGS_RELEASE is ${CMAKE_CXX_FLAGS_RELEASE}")
 message(WARNING "==========")
 
 if(NOT TARGET asmjit)
-  #Download asmjit from github if ASMJIT_SRC_DIR is not specified.
-  if(NOT DEFINED ASMJIT_SRC_DIR)
-    set(ASMJIT_SRC_DIR "${FBGEMM_SOURCE_DIR}/third_party/asmjit"
-      CACHE STRING "asmjit source directory from submodules")
+  # Check if we are using MinGW and the asmjit header exists in the specified include directory
+  if(MINGW AND EXISTS "$ENV{MINGW_PREFIX}/include/asmjit")
+    message(STATUS "Using system-installed asmjit from $ENV{MINGW_PREFIX}")
+    
+    # Add an imported target for asmjit
+    add_library(asmjit SHARED IMPORTED GLOBAL)
+    
+    # Set the properties for the imported target
+    set_target_properties(asmjit PROPERTIES
+      IMPORTED_LOCATION "$ENV{MINGW_PREFIX}/bin/libasmjit.dll"
+      INTERFACE_INCLUDE_DIRECTORIES "$ENV{MINGW_PREFIX}/include"
+      IMPORTED_IMPLIB "$ENV{MINGW_PREFIX}/lib/libasmjit.dll.a"
+    )
+  else()
+    # ASMJIT_SRC_DIR is not defined, download asmjit from GitHub
+    if(NOT DEFINED ASMJIT_SRC_DIR)
+      set(ASMJIT_SRC_DIR "${FBGEMM_SOURCE_DIR}/third_party/asmjit"
+        CACHE STRING "asmjit source directory from submodules")
+    endif()
+
+    # Add the asmjit subdirectory from the specified source directory
+    add_subdirectory("${ASMJIT_SRC_DIR}" "${FBGEMM_BINARY_DIR}/asmjit")
   endif()
 
-  #build asmjit
-  #For MSVC shared build, asmjit needs to be shared also.
-  if (MSVC AND (FBGEMM_LIBRARY_TYPE STREQUAL "shared"))
+  # Set the common properties for asmjit
+  if(NOT MINGW)
+    set_property(TARGET asmjit PROPERTY POSITION_INDEPENDENT_CODE ON)
+    # add a flag required for mac build
+    if(NOT MSVC)
+      target_compile_options(asmjit PRIVATE "-Wno-sign-conversion")
+    endif()
+  endif()
+
+  # Set additional compile options for Clang, if applicable
+  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 13.0.0)
+  # See https://github.com/pytorch/pytorch/issues/74352, https://github.com/pytorch/FBGEMM/issues/1173
+    target_compile_options_if_supported(asmjit -Wno-deprecated-copy)
+    target_compile_options_if_supported(asmjit -Wno-unused-but-set-variable)
+  endif()
+
+  # Determine if asmjit should be built statically or dynamically
+  if ((MSVC OR MINGW) AND (FBGEMM_LIBRARY_TYPE STREQUAL "shared"))
     set(ASMJIT_STATIC OFF)
   else()
     set(ASMJIT_STATIC ON)
-  endif()
-
-  add_subdirectory("${ASMJIT_SRC_DIR}" "${FBGEMM_BINARY_DIR}/asmjit")
-  set_property(TARGET asmjit PROPERTY POSITION_INDEPENDENT_CODE ON)
-  # add a flag required for mac build
-  if(NOT MSVC)
-    target_compile_options(asmjit PRIVATE "-Wno-sign-conversion")
-  endif()
-
-  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 13.0.0)
-    # See https://github.com/pytorch/pytorch/issues/74352, https://github.com/pytorch/FBGEMM/issues/1173
-    target_compile_options_if_supported(asmjit -Wno-deprecated-copy)
-    target_compile_options_if_supported(asmjit -Wno-unused-but-set-variable)
   endif()
 endif()
 

--- a/bench/AlignedVec.h
+++ b/bench/AlignedVec.h
@@ -108,7 +108,7 @@ class aligned_allocator {
     // Mallocator wraps malloc().
     void* pv = nullptr;
     int ret;
-#ifdef _MSC_VER
+#ifdef _WIN32
     pv = _aligned_malloc(n * sizeof(T), Alignment);
     ret = 0;
 #else
@@ -126,7 +126,7 @@ class aligned_allocator {
   }
 
   void deallocate(T* const p, const std::size_t /*n*/) const {
-#ifdef _MSC_VER
+#ifdef _WIN32
     _aligned_free(p);
 #else
     free(p);

--- a/bench/BenchUtils.h
+++ b/bench/BenchUtils.h
@@ -367,19 +367,22 @@ void performance_test(
       }
 
 #if defined(USE_MKL) || defined(USE_BLAS)
-      // Compare results
-      for (size_t i = 0; i < C_ref[0].size(); i++) {
-        if (std::abs(C_ref[0][i] - C_fb[0][i]) > 1e-3) {
-          fprintf(
-              stderr,
-              "Error: too high diff between fp32 ref %f and fp16 %f at %ld\n",
-              C_ref[0][i],
-              C_fb[0][i],
-              i);
-          return;
-        }
-      }
+  // Compare results
+  for (size_t i = 0; i < C_ref[0].size(); i++) {
+    if (std::abs(C_ref[0][i] - C_fb[0][i]) > 1e-3) {
+      // Use different format specifiers for MinGW and others
+      #ifdef __MINGW32__
+        fprintf(stderr, "Error: too high diff between fp32 ref %f and fp16 %f at %llu\n",
+                C_ref[0][i], C_fb[0][i], static_cast<unsigned long long>(i));
+      #else
+        fprintf(stderr, "Error: too high diff between fp32 ref %f and fp16 %f at %zu\n",
+                C_ref[0][i], C_fb[0][i], i);
+      #endif
+      return;
+    }
+  }
 #endif
+
     }
 
 #ifdef USE_MKL

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -65,6 +65,10 @@ macro(add_benchmark BENCHNAME)
   if (${BLAS_FOUND})
     target_compile_options(${BENCHNAME} PRIVATE "-DUSE_BLAS")
     target_link_libraries(${BENCHNAME} "${BLAS_LIBRARIES}")
+    if (DEFINED ENV{MINGW_PREFIX})
+    # Include the directory using the value of the environment variable
+    include_directories("$ENV{MINGW_PREFIX}/include/openblas")
+  endif()
   endif()
 
   set_target_properties(${BENCHNAME} PROPERTIES FOLDER test)

--- a/bench/RowwiseAdagradBenchmark.cc
+++ b/bench/RowwiseAdagradBenchmark.cc
@@ -167,19 +167,27 @@ void run_benchmark(
     }
   }
 
-  for (size_t i = 0; i < w.size(); ++i) {
-    assert(fabs(w[i] - w_ref[i]) < 1e-5);
-    if (fabs(w[i] - w_ref[i]) >= 1e-5) {
-      fprintf(stderr, "%ld %f %f\n", i, w[i], w_ref[i]);
-    }
+for (size_t i = 0; i < w.size(); ++i) {
+  assert(fabs(w[i] - w_ref[i]) < 1e-5);
+  if (fabs(w[i] - w_ref[i]) >= 1e-5) {
+    #ifdef __MINGW32__
+      fprintf(stderr, "%llu %f %f\n", static_cast<unsigned long long>(i), w[i], w_ref[i]);
+    #else
+      fprintf(stderr, "%zu %f %f\n", i, w[i], w_ref[i]);
+    #endif
   }
+}
 
-  for (size_t i = 0; i < h.size(); ++i) {
-    assert(fabs(h[i] - h_ref[i]) < 1e-5);
-    if (fabs(h[i] - h_ref[i]) >= 1e-5) {
-      fprintf(stderr, "%ld %f %f\n", i, h[i], h_ref[i]);
-    }
+for (size_t i = 0; i < h.size(); ++i) {
+  assert(fabs(h[i] - h_ref[i]) < 1e-5);
+  if (fabs(h[i] - h_ref[i]) >= 1e-5) {
+    #ifdef __MINGW32__
+      fprintf(stderr, "%llu %f %f\n", static_cast<unsigned long long>(i), h[i], h_ref[i]);
+    #else
+      fprintf(stderr, "%zu %f %f\n", i, h[i], h_ref[i]);
+    #endif
   }
+}
 
   cout << "indices: " << (isIndex64b ? " 64bits " : " 32bits ") << " | ";
   cout << "weight_decay: " << setw(1) << adjust_weight_decay << " | ";

--- a/bench/SparseAdagradBenchmark.cc
+++ b/bench/SparseAdagradBenchmark.cc
@@ -174,19 +174,28 @@ void run_benchmark(
     }
   }
 
-  for (size_t i = 0; i < w.size(); ++i) {
-    assert(fabs(w[i] - w_ref[i]) < 1e-5);
-    if (fabs(w[i] - w_ref[i]) >= 1e-5) {
-      fprintf(stderr, "%ld %f %f\n", i, w[i], w_ref[i]);
-    }
+for (size_t i = 0; i < w.size(); ++i) {
+  assert(fabs(w[i] - w_ref[i]) < 1e-5);
+  if (fabs(w[i] - w_ref[i]) >= 1e-5) {
+    #ifdef __MINGW32__
+      fprintf(stderr, "%llu %f %f\n", static_cast<unsigned long long>(i), w[i], w_ref[i]);
+    #else
+      fprintf(stderr, "%zu %f %f\n", i, w[i], w_ref[i]);
+    #endif
   }
+}
 
-  for (size_t i = 0; i < h.size(); ++i) {
-    assert(fabs(h[i] - h_ref[i]) < 1e-5);
-    if (fabs(h[i] - h_ref[i]) >= 1e-5) {
-      fprintf(stderr, "%ld %f %f\n", i, h[i], h_ref[i]);
-    }
+for (size_t i = 0; i < h.size(); ++i) {
+  assert(fabs(h[i] - h_ref[i]) < 1e-5);
+  if (fabs(h[i] - h_ref[i]) >= 1e-5) {
+    #ifdef __MINGW32__
+      fprintf(stderr, "%llu %f %f\n", static_cast<unsigned long long>(i), h[i], h_ref[i]);
+    #else
+      fprintf(stderr, "%zu %f %f\n", i, h[i], h_ref[i]);
+    #endif
   }
+}
+
 
   cout << "indices: " << (isIndex64b ? " 64bits " : " 32bits ") << " | ";
   cout << "weight_decay: " << setw(1) << adjust_weight_decay << " | ";

--- a/bench/SparseDenseMMFP32Benchmark.cc
+++ b/bench/SparseDenseMMFP32Benchmark.cc
@@ -112,15 +112,17 @@ int main(int, char**) {
       // Compare results
       for (size_t i = 0; i < ctDataRef.size(); i++) {
         if (std::abs(ctDataRef[i] - ctDataIntrin[i]) > 1e-3) {
-          fprintf(
-              stderr,
-              "Error: Results differ ref %f and test %f at %ld\n",
-              ctDataRef[i],
-              ctDataIntrin[i],
-              i);
+          #ifdef __MINGW32__
+            fprintf(stderr, "Error: Results differ ref %f and test %f at %llu\n",
+                    ctDataRef[i], ctDataIntrin[i], static_cast<unsigned long long>(i));
+          #else
+            fprintf(stderr, "Error: Results differ ref %f and test %f at %zu\n",
+                    ctDataRef[i], ctDataIntrin[i], i);
+          #endif
           return 1;
         }
       }
+
 
       double effective_gflops_intrin = effective_flop / secs_intrin / 1e9;
       cout << "[" << setw(5) << index << "]" << setw(7) << m << setw(7) << n

--- a/bench/SparseDenseMMInt8Benchmark.cc
+++ b/bench/SparseDenseMMInt8Benchmark.cc
@@ -162,17 +162,19 @@ int main(int, char**) {
       // "ctDataIntrin_u8");
       //
       // Compare results
-      for (size_t i = 0; i < ctDataRef.size(); i++) {
+     for (size_t i = 0; i < ctDataRef.size(); i++) {
         if (std::abs(ctDataRef_u8[i] - ctDataIntrin_u8[i]) > 0) {
-          fprintf(
-              stderr,
-              "Error: Results differ ref %d and test %d at %ld\n",
-              ctDataRef_u8[i],
-              ctDataIntrin_u8[i],
-              i);
+          #ifdef __MINGW32__
+            fprintf(stderr, "Error: Results differ ref %hhu and test %hhu at %llu\n",
+                    ctDataRef_u8[i], ctDataIntrin_u8[i], static_cast<unsigned long long>(i));
+          #else
+            fprintf(stderr, "Error: Results differ ref %hhu and test %hhu at %zu\n",
+                    ctDataRef_u8[i], ctDataIntrin_u8[i], i);
+          #endif
           return 1;
         }
       }
+
 
       double effective_gflops_intrin = effective_flop / secs_intrin / 1e9;
       cout << "[" << setw(5) << index << "]" << setw(7) << m << setw(7) << n

--- a/include/fbgemm/FbgemmBuild.h
+++ b/include/fbgemm/FbgemmBuild.h
@@ -10,6 +10,11 @@
 
 // For details about dllexport/dllimport, checkout the following SO question
 // https://stackoverflow.com/questions/57999/what-is-the-difference-between-dllexport-and-dllimport
+#if defined(__MINGW32__)
+#ifndef FBGEMM_STATIC
+#define FBGEMM_STATIC//I failed with cmake, please help me
+#endif
+#endif
 #if !defined(FBGEMM_API)
 #if defined(FBGEMM_STATIC)
 #define FBGEMM_API

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -429,7 +429,7 @@ void* fbgemmAlignedAlloc(
     bool raiseException /*=false*/) {
   void* aligned_mem = nullptr;
   int ret;
-#ifdef _MSC_VER
+#ifdef _WIN32
   aligned_mem = _aligned_malloc(size, align);
   ret = 0;
 #else
@@ -443,7 +443,7 @@ void* fbgemmAlignedAlloc(
 }
 
 void fbgemmAlignedFree(void* p) {
-#ifdef _MSC_VER
+#ifdef _WIN32
   _aligned_free(p);
 #else
   free(p);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,7 @@ if(${OpenMP_FOUND})
 endif()
 
 macro(add_gtest TESTNAME)
+
   add_executable(${TESTNAME} ${ARGN}
     ../bench/BenchUtils.cc
     EmbeddingSpMDMTestUtils.cc
@@ -62,6 +63,11 @@ macro(add_gtest TESTNAME)
       target_compile_definitions(${TESTNAME} PRIVATE FBGEMM_STATIC)
     endif()
   else(MSVC)
+    if(MINGW)
+    #if (FBGEMM_LIBRARY_TYPE STREQUAL "static")
+      target_compile_definitions(${TESTNAME} PRIVATE FBGEMM_STATIC)
+    #endif()
+    endif()
     target_compile_options(${TESTNAME} PRIVATE
      "-m64" "-mavx2" "-mfma" "-masm=intel")
   endif(MSVC)


### PR DESCRIPTION
In this pull request I have done some code changes to allow mingw to build FBGEMM, everything builds and links, tests and benchmarks too. fix #2113

This is the build procedure
```
#run on a msys2 enviroment
mkdir -p build
cd build
cmake .. -G"MSYS Makefiles"
make
make test
```

I had trouble setting some flags for the tests, so I hardcoded `FBGEMM_STATIC` under mingw builds, I only did this to prove the point that mingw supports this compilation, and runs tests, however I lack the skills to edit the cmake so that the compilation `just works`, linkage error only happens when building the tests.

These are the result of the tests
```
$ make test
Running tests...
Test project C:/path/pytorch-help/FBGEMM/build
      Start  1: Bfloat16ConvertTest
 1/25 Test  #1: Bfloat16ConvertTest ..............   Passed    0.09 sec
      Start  2: EmbeddingSpMDM8BitTest
 2/25 Test  #2: EmbeddingSpMDM8BitTest ...........   Passed    0.54 sec
      Start  3: EmbeddingSpMDMNBitTest
 3/25 Test  #3: EmbeddingSpMDMNBitTest ...........   Passed    0.95 sec
      Start  4: EmbeddingSpMDMTest
 4/25 Test  #4: EmbeddingSpMDMTest ...............***Failed    4.57 sec
      Start  5: FP16Test
 5/25 Test  #5: FP16Test .........................***Exception: SegFault  0.05 sec
      Start  6: Float16ConvertTest
 6/25 Test  #6: Float16ConvertTest ...............   Passed    0.06 sec
      Start  7: GConvTest
 7/25 Test  #7: GConvTest ........................Exit code 0xc0000374
***Exception:   4.72 sec
      Start  8: I64Test
 8/25 Test  #8: I64Test ..........................   Passed    1.20 sec
      Start  9: I8DepthwiseTest
 9/25 Test  #9: I8DepthwiseTest ..................   Passed   45.08 sec
      Start 10: I8DirectconvTest
10/25 Test #10: I8DirectconvTest .................   Passed    5.64 sec
      Start 11: I8SpmdmTest
11/25 Test #11: I8SpmdmTest ......................   Passed   14.93 sec
      Start 12: Im2ColFusedRequantizeTest
12/25 Test #12: Im2ColFusedRequantizeTest ........   Passed   18.40 sec
      Start 13: PackedRequantizeAcc16Test
13/25 Test #13: PackedRequantizeAcc16Test ........   Passed    1.61 sec
      Start 14: PackedRequantizeTest
14/25 Test #14: PackedRequantizeTest .............   Passed   31.11 sec
      Start 15: QuantUtilsTest
15/25 Test #15: QuantUtilsTest ...................   Passed    0.16 sec
      Start 16: RadixSortTest
16/25 Test #16: RadixSortTest ....................   Passed    0.05 sec
      Start 17: RequantizeOnlyTest
17/25 Test #17: RequantizeOnlyTest ...............   Passed    0.04 sec
      Start 18: RowWiseSparseAdagradFusedTest
18/25 Test #18: RowWiseSparseAdagradFusedTest ....   Passed   27.23 sec
      Start 19: SparseAdagradTest
19/25 Test #19: SparseAdagradTest ................   Passed    0.53 sec
      Start 20: SparseDenseMMFP32Test
20/25 Test #20: SparseDenseMMFP32Test ............   Passed    3.37 sec
      Start 21: SparseDenseMMInt8Test
21/25 Test #21: SparseDenseMMInt8Test ............   Passed    5.57 sec
      Start 22: SparsePackUnpackTest
22/25 Test #22: SparsePackUnpackTest .............   Passed    0.08 sec
      Start 23: TransposeTest
23/25 Test #23: TransposeTest ....................   Passed    0.07 sec
      Start 24: TransposedRequantizeTest
24/25 Test #24: TransposedRequantizeTest .........   Passed    0.06 sec
      Start 25: UniConvTest
25/25 Test #25: UniConvTest ......................   Passed   26.91 sec

88% tests passed, 3 tests failed out of 25

Total Test time (real) = 193.31 sec

The following tests FAILED:
          4 - EmbeddingSpMDMTest (Failed)
          5 - FP16Test (SEGFAULT)
          7 - GConvTest (Exit code 0xc0000374
)
Errors while running CTest
Output from these tests are in: C:/path/pytorch-help/FBGEMM/build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
make: *** [Makefile:71: test] Error 8
```

I am open for feedback and suggestions.

In case you're curious in the previous commit, you can also build using the shared library of asmjit that you can get with your msys distribution, but this probably polutes the project, so I took it out.