### PR TITLE
Revert D50941763: Multisect successfully blamed "D50941763: [fbgemm_gpu] Remove test_aot_dispatch_static* tests from opcheck tests" for test or build failures

### DIFF
--- a/fbgemm_gpu/test/failures_dict.json
+++ b/fbgemm_gpu/test/failures_dict.json
@@ -10,6 +10,10 @@
         "comment": "",
         "status": "xfail"
       },
+      "SparseOpsTest.test_aot_dispatch_static__test_batch_index_select_dim0": {
+        "comment": "",
+        "status": "xfail"
+      },
       "SparseOpsTest.test_autograd_registration__test_batch_index_select_dim0": {
         "comment": "",
         "status": "xfail"
@@ -33,6 +37,18 @@
         "comment": "",
         "status": "xfail"
       },
+      "SparseOpsTest.test_aot_dispatch_static__test_block_bucketize_sparse_features": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "SparseOpsTest.test_aot_dispatch_static__test_block_bucketize_sparse_features_long_indices": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "SparseOpsTest.test_aot_dispatch_static__test_block_bucketize_sparse_features_with_variable_batch_sizes": {
+        "comment": "",
+        "status": "xfail"
+      },
       "SparseOpsTest.test_faketensor__test_block_bucketize_sparse_features": {
         "comment": "",
         "status": "xfail"
@@ -51,6 +67,10 @@
         "comment": "",
         "status": "xfail"
       },
+      "SparseOpsTest.test_aot_dispatch_static__test_bottom_unique_k_per_row": {
+        "comment": "",
+        "status": "xfail"
+      },
       "SparseOpsTest.test_faketensor__test_bottom_unique_k_per_row": {
         "comment": "",
         "status": "xfail"
@@ -61,6 +81,10 @@
         "comment": "",
         "status": "xfail"
       },
+      "SparseOpsTest.test_aot_dispatch_static__test_bucketize_sparse_features": {
+        "comment": "",
+        "status": "xfail"
+      },
       "SparseOpsTest.test_faketensor__test_bucketize_sparse_features": {
         "comment": "",
         "status": "xfail"
@@ -68,6 +92,10 @@
     },
     "fbgemm::cat_reorder_batched_ad_indices": {
       "SparseOpsTest.test_aot_dispatch_dynamic__test_cat_reorder_batched_ad_indices_cpu": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "SparseOpsTest.test_aot_dispatch_static__test_cat_reorder_batched_ad_indices_cpu": {
         "comment": "",
         "status": "xfail"
       },
@@ -90,6 +118,22 @@
         "status": "xfail"
       },
       "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_dense_to_jagged_opt_large_batch": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_dense_to_jagged": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_dense_to_jagged_meta_backend": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_dense_to_jagged_opt": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_dense_to_jagged_opt_large_batch": {
         "comment": "",
         "status": "xfail"
       },
@@ -120,6 +164,14 @@
         "comment": "",
         "status": "xfail"
       },
+      "SparseOpsTest.test_aot_dispatch_static__test_generic_histogram_binning_calibration_by_feature": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "SparseOpsTest.test_aot_dispatch_static__test_generic_histogram_binning_calibration_by_feature_cpu_gpu": {
+        "comment": "",
+        "status": "xfail"
+      },
       "SparseOpsTest.test_faketensor__test_generic_histogram_binning_calibration_by_feature": {
         "comment": "",
         "status": "xfail"
@@ -144,6 +196,10 @@
         "comment": "",
         "status": "xfail"
       },
+      "SparseOpsTest.test_aot_dispatch_static__test_histogram_binning_calibration": {
+        "comment": "",
+        "status": "xfail"
+      },
       "SparseOpsTest.test_faketensor__test_histogram_binning_calibration": {
         "comment": "",
         "status": "xfail"
@@ -151,6 +207,10 @@
     },
     "fbgemm::histogram_binning_calibration_by_feature": {
       "SparseOpsTest.test_aot_dispatch_dynamic__test_histogram_binning_calibration_by_feature": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "SparseOpsTest.test_aot_dispatch_static__test_histogram_binning_calibration_by_feature": {
         "comment": "",
         "status": "xfail"
       },
@@ -164,6 +224,10 @@
         "comment": "",
         "status": "xfail"
       },
+      "SparseOpsTest.test_aot_dispatch_static__test_invert_permute": {
+        "comment": "",
+        "status": "xfail"
+      },
       "SparseOpsTest.test_faketensor__test_invert_permute": {
         "comment": "",
         "status": "xfail"
@@ -172,6 +236,10 @@
     "fbgemm::jagged_1d_to_dense": {},
     "fbgemm::jagged_1d_to_truncated_values": {
       "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_1d_to_truncated_values": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_1d_to_truncated_values": {
         "comment": "",
         "status": "xfail"
       },
@@ -188,6 +256,10 @@
         "comment": "",
         "status": "xfail"
       },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_elementwise_binary": {
+        "comment": "",
+        "status": "xfail"
+      },
       "JaggedTensorOpsTest.test_autograd_registration__test_jagged_elementwise_binary": {
         "comment": "",
         "status": "xfail"
@@ -199,6 +271,14 @@
         "status": "xfail"
       },
       "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_elementwise_binary_opt": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_elementwise_binary": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_elementwise_binary_opt": {
         "comment": "",
         "status": "xfail"
       },
@@ -221,6 +301,10 @@
         "comment": "",
         "status": "xfail"
       },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_unique_indices": {
+        "comment": "",
+        "status": "xfail"
+      },
       "JaggedTensorOpsTest.test_faketensor__test_jagged_unique_indices": {
         "comment": "",
         "status": "xfail"
@@ -236,6 +320,18 @@
         "status": "xfail"
       },
       "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_keyed_jagged_index_select_dim1": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_index_select_2d": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_index_select_2d_in_inference": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_keyed_jagged_index_select_dim1": {
         "comment": "",
         "status": "xfail"
       },
@@ -258,6 +354,10 @@
         "comment": "",
         "status": "xfail"
       },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_slice": {
+        "comment": "",
+        "status": "xfail"
+      },
       "JaggedTensorOpsTest.test_faketensor__test_jagged_slice": {
         "comment": "",
         "status": "xfail"
@@ -267,6 +367,10 @@
     "fbgemm::jagged_to_padded_dense": {
       "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_to_padded_dense": {
         "comment": "seems nondeterministic, but error is real",
+        "status": "skip"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_to_padded_dense": {
+        "comment": "seems nondeterministic but error is real",
         "status": "skip"
       }
     },
@@ -280,6 +384,18 @@
         "status": "xfail"
       },
       "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_unique_indices_multi_keys": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_unique_indices": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_unique_indices_empty": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_unique_indices_multi_keys": {
         "comment": "",
         "status": "xfail"
       },
@@ -301,6 +417,10 @@
         "comment": "",
         "status": "xfail"
       },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_keyed_jagged_index_select_dim1": {
+        "comment": "",
+        "status": "xfail"
+      },
       "JaggedTensorOpsTest.test_autograd_registration__test_keyed_jagged_index_select_dim1": {
         "comment": "",
         "status": "xfail"
@@ -312,6 +432,10 @@
     },
     "fbgemm::masked_select_jagged_1d": {
       "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_masked_select_jagged_1d": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_masked_select_jagged_1d": {
         "comment": "",
         "status": "xfail"
       },
@@ -336,10 +460,30 @@
       "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_stacked_jagged_2d_to_dense": {
         "comment": "",
         "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_1d_to_dense": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_2d_to_dense": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_jagged_2d_to_dense_truncation": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_stacked_jagged_2d_to_dense": {
+        "comment": "",
+        "status": "xfail"
       }
     },
     "fbgemm::pack_segments": {
       "SparseOpsTest.test_aot_dispatch_dynamic__test_pack_segments": {
+        "comment": "",
+        "status": "xsuccess"
+      },
+      "SparseOpsTest.test_aot_dispatch_static__test_pack_segments": {
         "comment": "",
         "status": "xsuccess"
       }
@@ -349,18 +493,38 @@
         "comment": "",
         "status": "xfail"
       },
+      "SparseOpsTest.test_aot_dispatch_static__test_permute102_baddbmm_permute102": {
+        "comment": "",
+        "status": "xfail"
+      },
       "SparseOpsTest.test_faketensor__test_permute102_baddbmm_permute102": {
         "comment": "",
         "status": "xfail"
       }
     },
     "fbgemm::permute_1D_sparse_data": {
+      "SparseOpsTest.test_aot_dispatch_static__test_permute_indices": {
+        "comment": "",
+        "status": "xfail"
+      },
       "SparseOpsTest.test_schema__test_permute_indices": {
         "comment": "flaky",
         "status": "skip"
       }
     },
     "fbgemm::permute_2D_sparse_data": {
+      "SparseOpsTest.test_aot_dispatch_static__test_permute_embeddings": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "SparseOpsTest.test_aot_dispatch_static__test_permute_indices": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "SparseOpsTest.test_aot_dispatch_static__test_permute_indices_with_repeats": {
+        "comment": "",
+        "status": "xfail"
+      },
       "SparseOpsTest.test_schema__test_permute_indices": {
         "comment": "flaky",
         "status": "skip"
@@ -368,6 +532,10 @@
     },
     "fbgemm::permute_sequence_embeddings": {
       "SparseOpsTest.test_aot_dispatch_dynamic__test_permute_embeddings": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "SparseOpsTest.test_aot_dispatch_static__test_permute_embeddings": {
         "comment": "",
         "status": "xfail"
       },
@@ -382,6 +550,14 @@
         "status": "xfail"
       },
       "SparseOpsTest.test_aot_dispatch_dynamic__test_reorder_batched_ad_indices_cpu": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "SparseOpsTest.test_aot_dispatch_static__test_reorder_batched_ad_indices": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "SparseOpsTest.test_aot_dispatch_static__test_reorder_batched_ad_indices_cpu": {
         "comment": "",
         "status": "xfail"
       },
@@ -415,6 +591,26 @@
         "comment": "",
         "status": "xfail"
       },
+      "SparseOpsTest.test_aot_dispatch_static__test_cat_reorder_batched_ad_indices_cpu": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "SparseOpsTest.test_aot_dispatch_static__test_reorder_batched_ad_indices": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "SparseOpsTest.test_aot_dispatch_static__test_reorder_batched_ad_indices_cpu": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "SparseOpsTest.test_aot_dispatch_static__test_reorder_batched_ad_lengths": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "SparseOpsTest.test_aot_dispatch_static__test_reorder_batched_ad_lengths_cpu": {
+        "comment": "",
+        "status": "xfail"
+      },
       "SparseOpsTest.test_faketensor__test_cat_reorder_batched_ad_indices_cpu": {
         "comment": "",
         "status": "xfail"
@@ -441,6 +637,10 @@
         "comment": "",
         "status": "xfail"
       },
+      "SparseOpsTest.test_aot_dispatch_static__test_segment_sum_csr": {
+        "comment": "",
+        "status": "xfail"
+      },
       "SparseOpsTest.test_faketensor__test_segment_sum_csr": {
         "comment": "",
         "status": "xfail"
@@ -451,6 +651,10 @@
         "comment": "",
         "status": "xfail"
       },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_stacked_jagged_1d_to_dense": {
+        "comment": "",
+        "status": "xfail"
+      },
       "JaggedTensorOpsTest.test_faketensor__test_stacked_jagged_1d_to_dense": {
         "comment": "",
         "status": "xfail"
@@ -458,6 +662,10 @@
     },
     "fbgemm::stacked_jagged_2d_to_dense": {
       "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_stacked_jagged_2d_to_dense": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "JaggedTensorOpsTest.test_aot_dispatch_static__test_stacked_jagged_2d_to_dense": {
         "comment": "",
         "status": "xfail"
       },

--- a/fbgemm_gpu/test/test_utils.py
+++ b/fbgemm_gpu/test/test_utils.py
@@ -257,6 +257,7 @@ class optests:
             if not fast:
                 tests_to_run.extend(
                     [
+                        "test_aot_dispatch_static",
                         "test_aot_dispatch_dynamic",
                     ]
                 )


### PR DESCRIPTION
Summary:
This diff is reverting D50941763
D50941763: [fbgemm_gpu] Remove test_aot_dispatch_static* tests from opcheck tests by zou3519 has been identified to be causing the following test or build failures:

Tests affected:
- [deeplearning/fbgemm/fbgemm_gpu:sparse_ops_test - test_aot_dispatch_static__test_permute_indices (deeplearning.fbgemm.fbgemm_gpu.test.sparse_ops_test.SparseOpsTest)](https://www.internalfb.com/intern/test/844425044733284/)

Here's the Multisect link:
https://www.internalfb.com/multisect/3468682
Here are the tasks that are relevant to this breakage:

We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Differential Revision: D51011831


