### PR TITLE
Fix meta function for merge_pooled_embeddings

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -228,12 +228,12 @@ def merge_pooled_embeddings(
     if cat_dim == 0:
         return e.new_empty(
             [total_cat_dim_size, e.size(1)],
-            device=torch.device("meta"),
+            device=target_device,
         )
 
     return e.new_empty(
         [e.size(0), total_cat_dim_size],
-        device=torch.device("meta"),
+        device=target_device,
     )
 
 


### PR DESCRIPTION
Summary:
Meta fn should contain device information (FakeTensor) for merge_pooled_embeddings.

BEFORE dynamo export fails with
```
 File "/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/5408a275d581d7c2/scripts/ads_pt2_inference/__pt2_cli__/pt2_cli#link-tree/torch/_subclasses/fake_tensor.py", line 1264, in merge_devices
    raise RuntimeError(
torch._dynamo.exc.TorchRuntimeError: Failed running call_function fbgemm.permute_pooled_embs_auto_grad(*(FakeTensor(..., device='meta', size=(10, 5124)), FakeTensor(..., device='cuda:0', size=(40,), dtype=torch.int64), FakeTensor(..., device='cuda:0', size=(39,), dtype=torch.int64), FakeTensor(..., device='cuda:0', size=(40,), dtype=torch.int64), FakeTensor(..., device='cuda:0', size=(39,), dtype=torch.int64)), **{}):
Unhandled FakeTensor Device Propagation for fbgemm.permute_pooled_embs.default, found two different devices meta, cuda:0
```

Reviewed By: ezyang

Differential Revision:
D51121648

Privacy Context Container: L1138451


