### PR TITLE
Fix fbgemm CI for segment_sum_csr

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -277,7 +277,7 @@ def permute_sparse_features_abstract(
     return (permuted_lengths, permuted_indices, permuted_weights)
 
 
-@torch.library.impl_abstract("fbgemm::segment_sum_csr")
+@impl_abstract("fbgemm::segment_sum_csr")
 def segment_sum_csr_abstract(
     batch_size: int, csr_seg: Tensor, values: Tensor
 ) -> Tensor:


### PR DESCRIPTION
Summary:
D51296192 breaks OSS CI e.g. https://github.com/pytorch/FBGEMM/actions/runs/6873908944/job/18695145904?pr=2107

We have to support PyTorch 2.1, which doesn't have this attribute defined.  Fortunately, there is a workaround available, where we can replace torch.library.impl_abstract with the locally-defined impl_abstract

Reviewed By: q10

Differential Revision: D51362600


