### PR TITLE
Preparatory fixes & lint suppressions for c10::optional->std::optional

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
@@ -128,7 +128,7 @@ Tensor pack_segments_autograd(
 Tensor native_empty_like(const Tensor& self) {
   return at::native::empty_like(
       self,
-      optTypeMetaToScalarType(self.options().dtype_opt()),
+      c10::optTypeMetaToScalarType(self.options().dtype_opt()),
       self.options().layout_opt(),
       self.options().device_opt(),
       self.options().pinned_memory_opt(),


### PR DESCRIPTION
Summary: Landing non-PyTorch portions first; then the PyTorch portions of  https://github.com/pytorch/pytorch/pull/101995 will land to Github.

Reviewed By: malfet

Differential Revision: D51355841


