### PR TITLE
Back out "RW Dist change to support uneven sharding"

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
@@ -306,8 +306,7 @@ void _block_bucketize_sparse_features_cpu(
   const index_t* const block_sizes_data = block_sizes.data_ptr<index_t>();
   offset_t* batch_sizes_data = nullptr;
   const auto variable_batch_size = batch_size_per_feature.has_value();
-  const auto variable_bucket_sizes = block_bucketize_pos.has_value() &&
-      block_bucketize_pos.value().size() != 0;
+  const auto variable_bucket_sizes = block_bucketize_pos.has_value();
   using uindex_t = std::make_unsigned_t<index_t>;
   using uoffset_t = std::make_unsigned_t<offset_t>;
   std::vector<int64_t> lower_bounds(indices.numel(), 0);


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/torchrec/pull/1532

Revert this diff due to errors https://fb.workplace.com/groups/1069285536500339/permalink/6853872844708217/

Reviewed By: dstaay-fb, joshuadeng

Differential Revision: D51480773


