### PR TITLE
Disable @optests.generate_opcheck_tests in TBE unit tests

### DIFF
--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -178,7 +178,6 @@ additional_decorators: Dict[str, List[Callable]] = {
 }
 
 
-@optests.generate_opcheck_tests(fast=True, additional_decorators=additional_decorators)
 class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
     def execute_forward_(  # noqa C901
         self,


### PR DESCRIPTION
Summary:
`optests.generate_opcheck_tests` generates test cases that cause a
lot of failures (see P887745303).  We will investigate this and put
the decorator back once all the failures are resolved.

Differential Revision: D51512895


