### PR TITLE
[fbgemm_gpu] Disable CXX11 ABI by default

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -64,12 +64,13 @@ set(CMAKE_C_STANDARD 17)
 set(CMAKE_C_EXTENSIONS OFF)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
-if(DEFINED GLIBCXX_USE_CXX11_ABI)
-  if(${GLIBCXX_USE_CXX11_ABI} EQUAL 1)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=1")
-  else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
-  endif()
+if(DEFINED GLIBCXX_USE_CXX11_ABI AND ${GLIBCXX_USE_CXX11_ABI} EQUAL 1)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=1")
+else()
+  # Disable compilation to CXX11 ABI by default because the built version of
+  # PyTorch library that is available on PIP is compiled without CXX11 ABI
+  # See: https://github.com/pyg-team/pytorch_geometric/issues/7220
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
 endif()
 
 BLOCK_PRINT(


### PR DESCRIPTION
- Disable compilation to CXX11 ABI by default because the built version of PyTorch library that is available on PIP is compiled without CXX11 ABI