### PR TITLE
[fbgemm] Annotate unused params

### DIFF
--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -73,19 +73,13 @@ open_source: bool = getattr(fbgemm_gpu, "open_source", False)
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import (
-        gpu_available,
-        gpu_unavailable,
-        gradcheck,
-        optests,
-        TEST_WITH_ROCM,
-    )
+    from test_utils import gpu_available, gpu_unavailable, gradcheck, TEST_WITH_ROCM
+
 else:
     from fbgemm_gpu.test.test_utils import (
         gpu_available,
         gpu_unavailable,
         gradcheck,
-        optests,
         TEST_WITH_ROCM,
     )
 

--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -1018,9 +1018,9 @@ typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType, outType>::
     Type
     GenerateEmbeddingSpMDMWithStrides(
         const int64_t block_size,
-        bool has_weight,
+        [[maybe_unused]] bool has_weight,
         bool normalize_by_lengths,
-        int prefetch,
+        [[maybe_unused]] int prefetch,
         bool is_weight_positional,
         bool use_offsets,
         int64_t output_stride /*=-1*/,

--- a/src/QuantUtils.cc
+++ b/src/QuantUtils.cc
@@ -268,7 +268,7 @@ FBGEMM_SPECIALIZED_QUANTIZE(uint8_t, false)
       const TensorQuantizationParams& qparams,                      \
       int thread_id,                                                \
       int num_threads,                                              \
-      float noise_ratio) {                                          \
+      [[maybe_unused]] float noise_ratio) {                         \
     int64_t i_begin, i_end;                                         \
     fbgemmPartition1D(thread_id, num_threads, len, i_begin, i_end); \
     for (int64_t i = i_begin; i < i_end; ++i) {                     \


### PR DESCRIPTION
- Annotate unused params to unblock compilation in strict mode (see https://github.com/pytorch/FBGEMM/issues/2157)