### PR TITLE
Add warmup_runs to TBE benchmarks and run at least 1 warmup iter

### DIFF
--- a/fbgemm_gpu/bench/bench_utils.py
+++ b/fbgemm_gpu/bench/bench_utils.py
@@ -156,6 +156,10 @@ def benchmark_requests(
 ) -> float:
     times = []
 
+    # Run at least one warmup iteration to avoid the long cudaLaunchKernel time
+    # for the first kernel
+    num_warmups = num_warmups + 1 if num_warmups >= 0 else 1
+
     if num_warmups > 0:
         indices, offsets, weights = requests[0]
         for _ in range(num_warmups):


### PR DESCRIPTION
Summary:
We observe an extremely long `cudaLaunchKernel` time for the first
kernel launch after switching to CUDA 12.  This causes the performance
of TBE to degrade if `warmup_runs=0`.  This diff modifies
`benchmark_requests` which is used extensively in TBE benchmarks to
run at least one warm up iteration even when `warmup_runs=0` to
exclude the first kernel time from the profiling result.  Moreover, we
add `--warmup-runs` to every TBE benchmarks to allow the users to
increase the warmup iterations.

Differential Revision: D51603915


