### PR TITLE
Use unique cache locations in backward for pipeline prefetching

### DIFF
--- a/fbgemm_gpu/codegen/lookup_args.py
+++ b/fbgemm_gpu/codegen/lookup_args.py
@@ -41,6 +41,8 @@ class CommonArgs(NamedTuple):
     output_dtype: int
     vbe_metadata: VBEMetadata
     is_experimental: bool
+    use_uniq_cache_locations_bwd: bool
+    use_homogeneous_placements: bool
 
 
 class OptimizerArgs(NamedTuple):

--- a/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/split_embedding_codegen_lookup_invoker.template
@@ -329,5 +329,7 @@ def invoke(
         {%- endif %}
         output_dtype=common_args.output_dtype,
         is_experimental=common_args.is_experimental,
+        use_uniq_cache_locations_bwd=common_args.use_uniq_cache_locations_bwd,
+        use_homogeneous_placements=common_args.use_homogeneous_placements,
     )
     {%- endif %}

--- a/fbgemm_gpu/fbgemm_gpu/ssd_split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/ssd_split_table_batched_embeddings_ops.py
@@ -469,7 +469,10 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 max_B_feature_rank=-1,
                 output_size=-1,
             ),
+            # Unused arguments
             is_experimental=False,
+            use_uniq_cache_locations_bwd=False,
+            use_homogeneous_placements=True,
         )
 
         momentum1 = invokers.lookup_args.Momentum(


### PR DESCRIPTION
Summary:
When pipeline prefetching is enabled (`prefetch_pipeline=True`) for
`EmbeddingLocation.MANAGED_CACHING`, TBE has to update
`lxu_cache_locations` to ensure cache consistency.  Prior to this
diff, TBE performs the full cache lookup when updating
`lxu_cache_locations` (i.e., looking up all indices although they are
duplicated).  The time complexity of such the lookup grows with
the number of indices.  Thus, the lookup can be expensive when the
number of indices is large.  This diff addresses this problem by
looking up only the unique indices (which is normally much smaller
than the full indices).  The number of unique indices tends to stay
more or less the same even when the total number of indices grows.
Thus, looking up only unique indices can reduce cost of cache lookup
effectively.  The unique `lxu_cache_locations` are fed directly to TBE
backward to consume.  Thus, there is no decompression cost.

Reviewed By: ehsanardestani, r-barnes

Differential Revision: D51488959


