### PR TITLE
Revert D51647391: Multisect successfully blamed "D51647391: Mark some more ops as pt2_compliant_tag" for otest failure

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
@@ -2730,15 +2730,12 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "permute_sparse_data(Tensor permute, Tensor lengths, Tensor values, Tensor? weights=None, SymInt? permuted_lengths_sum=None) -> (Tensor, Tensor, Tensor?)");
   m.def(
-      "permute_2D_sparse_data(Tensor permute, Tensor lengths, Tensor values, Tensor? weights=None, SymInt? permuted_lengths_sum=None) -> (Tensor, Tensor, Tensor?)",
-      {PT2_COMPLIANT_TAG});
+      "permute_2D_sparse_data(Tensor permute, Tensor lengths, Tensor values, Tensor? weights=None, SymInt? permuted_lengths_sum=None) -> (Tensor, Tensor, Tensor?)");
   m.def(
-      "permute_1D_sparse_data(Tensor permute, Tensor lengths, Tensor values, Tensor? weights=None, SymInt? permuted_lengths_sum=None) -> (Tensor, Tensor, Tensor?)",
-      {PT2_COMPLIANT_TAG});
+      "permute_1D_sparse_data(Tensor permute, Tensor lengths, Tensor values, Tensor? weights=None, SymInt? permuted_lengths_sum=None) -> (Tensor, Tensor, Tensor?)");
   m.def("invert_permute(Tensor permute) -> Tensor");
   m.def(
-      "expand_into_jagged_permute(Tensor permute, Tensor input_offset, Tensor output_offset, SymInt output_size) -> Tensor",
-      {PT2_COMPLIANT_TAG});
+      "expand_into_jagged_permute(Tensor permute, Tensor input_offset, Tensor output_offset, SymInt output_size) -> Tensor");
   m.def(
       "block_bucketize_sparse_features(Tensor lengths, Tensor indices, bool bucketize_pos, bool sequence, Tensor block_sizes, SymInt my_size, Tensor? weights=None, Tensor? batch_size_per_feature=None, SymInt max_B= -1, Tensor[]? block_bucketize_pos=None) -> (Tensor, Tensor, Tensor?, Tensor?, Tensor?)");
   m.def(

--- a/fbgemm_gpu/test/failures_dict.json
+++ b/fbgemm_gpu/test/failures_dict.json
@@ -436,8 +436,18 @@
         "status": "xfail"
       }
     },
-    "fbgemm::permute_1D_sparse_data": {},
-    "fbgemm::permute_2D_sparse_data": {},
+    "fbgemm::permute_1D_sparse_data": {
+      "SparseOpsTest.test_schema__test_permute_indices": {
+        "comment": "flaky",
+        "status": "skip"
+      }
+    },
+    "fbgemm::permute_2D_sparse_data": {
+      "SparseOpsTest.test_schema__test_permute_indices": {
+        "comment": "flaky",
+        "status": "skip"
+      }
+    },
     "fbgemm::permute_sequence_embeddings": {
       "SparseOpsTest.test_aot_dispatch_dynamic__test_permute_embeddings": {
         "comment": "",


### PR DESCRIPTION
Summary:
This diff is reverting D51647391
D51647391: Mark some more ops as pt2_compliant_tag by zou3519 has been identified to be causing the following test failure:

Tests affected:
- [deeplearning/fbgemm/fbgemm_gpu:sparse_ops_test - test_schema__test_permute_indices (deeplearning.fbgemm.fbgemm_gpu.test.sparse_ops_test.SparseOpsTest)](https://www.internalfb.com/intern/test/562950068029445/)

Here's the Multisect link:
https://www.internalfb.com/multisect/3631441
Here are the tasks that are relevant to this breakage:


We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Reviewed By: zou3519

Differential Revision: D51687883


