### PR TITLE
Fix fbgemm::permute_1D_sparse_data's aliasing behavior

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
@@ -2730,9 +2730,11 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "permute_sparse_data(Tensor permute, Tensor lengths, Tensor values, Tensor? weights=None, SymInt? permuted_lengths_sum=None) -> (Tensor, Tensor, Tensor?)");
   m.def(
-      "permute_2D_sparse_data(Tensor permute, Tensor lengths, Tensor values, Tensor? weights=None, SymInt? permuted_lengths_sum=None) -> (Tensor, Tensor, Tensor?)");
+      "permute_2D_sparse_data(Tensor permute, Tensor lengths, Tensor values, Tensor? weights=None, SymInt? permuted_lengths_sum=None) -> (Tensor, Tensor, Tensor?)",
+      {PT2_COMPLIANT_TAG});
   m.def(
-      "permute_1D_sparse_data(Tensor permute, Tensor lengths, Tensor values, Tensor? weights=None, SymInt? permuted_lengths_sum=None) -> (Tensor, Tensor, Tensor?)");
+      "permute_1D_sparse_data(Tensor permute, Tensor lengths, Tensor values, Tensor? weights=None, SymInt? permuted_lengths_sum=None) -> (Tensor, Tensor, Tensor?)",
+      {PT2_COMPLIANT_TAG});
   m.def("invert_permute(Tensor permute) -> Tensor");
   m.def(
       "expand_into_jagged_permute(Tensor permute, Tensor input_offset, Tensor output_offset, SymInt output_size) -> Tensor");

--- a/fbgemm_gpu/src/sparse_ops/sparse_permute_1d.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute_1d.cu
@@ -85,7 +85,11 @@ permute_1D_sparse_data_cuda(
 
   if (permuted_lengths_size == 0 || lengths_size == 0) {
     // Permutation will not be performed.  Return the input tensors
-    return {lengths.view({-1}), indices, weights};
+    return {
+        lengths.view({-1}).clone(),
+        indices.clone(),
+        weights.has_value() ? c10::make_optional(weights->clone())
+                            : c10::nullopt};
   }
 
   Tensor permuted_lengths;

--- a/fbgemm_gpu/test/failures_dict.json
+++ b/fbgemm_gpu/test/failures_dict.json
@@ -436,18 +436,8 @@
         "status": "xfail"
       }
     },
-    "fbgemm::permute_1D_sparse_data": {
-      "SparseOpsTest.test_schema__test_permute_indices": {
-        "comment": "flaky",
-        "status": "skip"
-      }
-    },
-    "fbgemm::permute_2D_sparse_data": {
-      "SparseOpsTest.test_schema__test_permute_indices": {
-        "comment": "flaky",
-        "status": "skip"
-      }
-    },
+    "fbgemm::permute_1D_sparse_data": {},
+    "fbgemm::permute_2D_sparse_data": {},
     "fbgemm::permute_sequence_embeddings": {
       "SparseOpsTest.test_aot_dispatch_dynamic__test_permute_embeddings": {
         "comment": "",


### PR DESCRIPTION
Summary:
The schema for this operator promises that it is functional (that is, it does
not return output Tensors that are views on the inputs). There is a fast-path
that does return views on the input. We change it to return clones instead of
views. fbgemm::permute_2d_sparse_data already has this fix; looks like we just
didn't apply it to fbgemm::permute_1d_sparse_data

Differential Revision: D51711257


