### PR TITLE
Fix block_bucketize_features with variable bucket size when using torch.int64 for block_bucketize_pos

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
@@ -355,7 +355,7 @@ void _block_bucketize_sparse_features_cpu(
         if (variable_bucket_sizes) {
           int64_t lb = std::upper_bound(
                            bucketize_offset,
-                           bucketize_offset + bucket_size,
+                           bucketize_offset + static_cast<index_t>(bucket_size),
                            indices_data[i]) -
               bucketize_offset - 1;
           lower_bounds[i] = lb;


### PR DESCRIPTION
Summary: When block_bucketize_pos using torch.int64, it would fail TorchRec uneven sharing test. This is fix resolving this issue

Reviewed By: sryap

Differential Revision: D51713675


