### PR TITLE
Add fbgemm::permute_pooled_embs[_auto_grad] opcheck tests

### DIFF
--- a/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_cpu.cpp
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_cpu.cpp
@@ -148,7 +148,8 @@ at::Tensor permute_pooled_embs_auto_grad_meta(
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
-      "permute_pooled_embs(Tensor pooled_embs, Tensor offset_dim_list, Tensor permute_list, Tensor inv_offset_dim_list, Tensor inv_permute_list) -> Tensor");
+      "permute_pooled_embs(Tensor pooled_embs, Tensor offset_dim_list, Tensor permute_list, Tensor inv_offset_dim_list, Tensor inv_permute_list) -> Tensor",
+      {PT2_COMPLIANT_TAG});
   m.def(
       "permute_pooled_embs_auto_grad(Tensor pooled_embs, Tensor offset_dim_list, Tensor permute_list, Tensor inv_offset_dim_list, Tensor inv_permute_list) -> Tensor",
       {PT2_COMPLIANT_TAG});

--- a/fbgemm_gpu/test/failures_dict.json
+++ b/fbgemm_gpu/test/failures_dict.json
@@ -438,6 +438,18 @@
     },
     "fbgemm::permute_1D_sparse_data": {},
     "fbgemm::permute_2D_sparse_data": {},
+    "fbgemm::permute_duplicate_pooled_embs_auto_grad": {
+      "PooledEmbeddingModulesTest.test_aot_dispatch_dynamic__test_duplicate_permutations": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "PooledEmbeddingModulesTest.test_faketensor__test_duplicate_permutations": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
+    "fbgemm::permute_pooled_embs": {},
+    "fbgemm::permute_pooled_embs_auto_grad": {},
     "fbgemm::permute_sequence_embeddings": {
       "SparseOpsTest.test_aot_dispatch_dynamic__test_permute_embeddings": {
         "comment": "",

--- a/fbgemm_gpu/test/permute_pooled_embedding_test.py
+++ b/fbgemm_gpu/test/permute_pooled_embedding_test.py
@@ -8,9 +8,10 @@ import inspect
 import sys
 import unittest
 from itertools import accumulate
-from typing import List, Tuple
+from typing import Any, Callable, Dict, List, Tuple
 
 import fbgemm_gpu
+import hypothesis.strategies as st
 import torch
 import torch._dynamo
 from fbgemm_gpu.permute_pooled_embedding_modules import PermutePooledEmbeddings
@@ -20,12 +21,13 @@ from torch import nn, Tensor
 # pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
 if getattr(fbgemm_gpu, "open_source", False):
     # pyre-ignore[21]
-    from test_utils import cpu_and_maybe_gpu, gpu_unavailable, on_arm_platform
+    from test_utils import cpu_and_maybe_gpu, gpu_unavailable, on_arm_platform, optests
 else:
     from fbgemm_gpu.test.test_utils import (
         cpu_and_maybe_gpu,
         gpu_unavailable,
         on_arm_platform,
+        optests,
     )
 
 typed_gpu_unavailable: Tuple[bool, str] = gpu_unavailable
@@ -66,12 +68,29 @@ FWD_COMPAT_MSG = (
 )
 
 
+class PermutePooledEmbeddingsFwdOnly(PermutePooledEmbeddings):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+    def __call__(self, pooled_embs: torch.Tensor) -> torch.Tensor:
+        result = torch.ops.fbgemm.permute_pooled_embs(
+            pooled_embs,
+            self._offset_dim_list.to(device=pooled_embs.device),
+            self._permute.to(device=pooled_embs.device),
+            self._inv_offset_dim_list.to(device=pooled_embs.device),
+            self._inv_permute.to(device=pooled_embs.device),
+        )
+        return result
+
+
 class Net(torch.nn.Module):
-    def __init__(self) -> None:
+    def __init__(self, fwd_only: bool = False) -> None:
         super(Net, self).__init__()
         self.fc1 = torch.nn.Linear(1, 10, bias=False)
-        self.permute_pooled_embeddings = PermutePooledEmbeddings(
-            [2, 3, 1, 4], [3, 0, 2, 1]
+        op_cls = PermutePooledEmbeddingsFwdOnly if fwd_only else PermutePooledEmbeddings
+        self.permute_pooled_embeddings: PermutePooledEmbeddings = op_cls(
+            [2, 3, 1, 4],
+            [3, 0, 2, 1],
         )
         self.fc2 = torch.nn.Linear(10, 1, bias=False)
 
@@ -82,7 +101,27 @@ class Net(torch.nn.Module):
         return x
 
 
+# e.g. "test_faketensor__test_cumsum": [unittest.expectedFailure]
+# Please avoid putting tests here, you should put operator-specific
+# skips and failures in deeplearning/fbgemm/fbgemm_gpu/test/failures_dict.json
+# pyre-ignore[24]: Generic type `Callable` expects 2 type parameters.
+additional_decorators: Dict[str, List[Callable]] = {
+    "test_pt2_compliant_tag_fbgemm_dense_to_jagged": [
+        # This operator has been grandfathered in. We need to fix this test failure.
+        unittest.expectedFailure,
+    ],
+    "test_pt2_compliant_tag_fbgemm_jagged_dense_elementwise_add": [
+        # This operator has been grandfathered in. We need to fix this test failure.
+        unittest.expectedFailure,
+    ],
+    "test_pt2_compliant_tag_fbgemm_jagged_dense_elementwise_add_jagged_output": [
+        # This operator has been grandfathered in. We need to fix this test failure.
+        unittest.expectedFailure,
+    ],
+}
+
 # @parameterized_class([{"device_type": "cpu"}, {"device_type": "cuda"}])
+@optests.generate_opcheck_tests(additional_decorators=additional_decorators)
 class PooledEmbeddingModulesTest(unittest.TestCase):
     @settings(deadline=10000, suppress_health_check=suppressed_list)
     # pyre-fixme[56]: Pyre was not able to infer the type of argument
@@ -90,8 +129,10 @@ class PooledEmbeddingModulesTest(unittest.TestCase):
     def setUp(self, device_type: torch.device) -> None:
         self.device = device_type
 
-    def test_permutation(self) -> None:
-        net = Net().to(self.device)
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @given(fwd_only=st.booleans())
+    def test_permutation(self, fwd_only: bool) -> None:
+        net = Net(fwd_only=fwd_only).to(self.device)
 
         input = torch.Tensor([range(10)]).to(self.device)
         self.assertEqual(


### PR DESCRIPTION
Summary:
Add autogenerated opcheck tests to `permute_pooled_embedding_test.py`.
Add a test for `fbgemm::permute_pooled_embs`.
Add PT2 compliant tag to `fbgemm::permute_pooled_embs[_auto_grad]` since they pass the opcheck tests.

Differential Revision: D51875123


