### PR TITLE
Enable sequence TBE CPU via AVX

### DIFF
--- a/fbgemm_gpu/test/failures_dict_fast.json
+++ b/fbgemm_gpu/test/failures_dict_fast.json
@@ -35,10 +35,6 @@
         "comment": "",
         "status": "xfail"
       },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_nbit_forward_cpu_bf16_out": {
-        "comment": "",
-        "status": "xfail"
-      },
       "SplitTableBatchedEmbeddingsTest.test_faketensor__test_nbit_forward_gpu_no_cache": {
         "comment": "",
         "status": "xfail"
@@ -72,10 +68,6 @@
     },
     "fbgemm::HFP8QuantizedToFloat": {
       "SplitTableBatchedEmbeddingsTest.test_faketensor__test_nbit_forward_cpu": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_nbit_forward_cpu_bf16_out": {
         "comment": "",
         "status": "xfail"
       },

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -4526,6 +4526,12 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         nbit_weights_ty=get_nbit_weights_ty(),
         use_array_for_index_remapping=st.booleans(),
         do_pruning=st.booleans(),
+        pooling_mode=st.sampled_from(
+            [PoolingMode.SUM, PoolingMode.NONE, PoolingMode.MEAN]
+        ),
+        output_dtype=st.sampled_from(
+            [SparseType.FP32, SparseType.FP16, SparseType.BF16]
+        ),
     )
     @settings(
         verbosity=VERBOSITY,
@@ -4537,6 +4543,8 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         nbit_weights_ty: Optional[SparseType],
         use_array_for_index_remapping: bool,
         do_pruning: bool,
+        pooling_mode: PoolingMode,
+        output_dtype: SparseType,
     ) -> None:
         use_cpu = True
         T = random.randint(1, 50)
@@ -4549,27 +4557,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         # cache_algorithm is don't care as we don't use cache.
         cache_algorithm = CacheAlgorithm.LRU
 
-        pooling_mode = random.choice(
-            [
-                PoolingMode.SUM,
-                PoolingMode.MEAN,
-                PoolingMode.NONE,
-            ]
-        )
         mixed = random.choice([True, False])
-        if pooling_mode == PoolingMode.NONE:
-            nbit_weights_ty = random.choice(
-                [
-                    SparseType.FP32,
-                    SparseType.FP16,
-                    # CPU sequence embedding does not support FP8/INT4/INT2 yet
-                    # SparseType.FP8,
-                    SparseType.INT8,
-                    # SparseType.INT4,
-                    # SparseType.INT2,
-                ]
-            )
-
         if pooling_mode == PoolingMode.SUM:
             weighted = random.choice([True, False])
         else:
@@ -4582,81 +4570,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         else:
             weights_ty: SparseType = nbit_weights_ty
             mixed_weights_ty = False
-        output_dtype = random.choice(
-            (
-                [SparseType.BF16]
-                if weights_ty in [SparseType.INT4, SparseType.INT2]
-                else []
-            )
-            + [SparseType.FP32, SparseType.FP16]
-        )
-        self.execute_nbit_forward_(
-            T,
-            D,
-            B,
-            log_E,
-            L,
-            weighted,
-            mixed,
-            pooling_mode,
-            weights_ty,
-            use_cache,
-            cache_algorithm,
-            use_cpu,
-            use_array_for_index_remapping,
-            do_pruning,
-            mixed_weights_ty,
-            output_dtype,
-        )
 
-    @given(
-        nbit_weights_ty=get_nbit_weights_ty(),
-        use_array_for_index_remapping=st.booleans(),
-        do_pruning=st.booleans(),
-    )
-    @settings(
-        verbosity=VERBOSITY,
-        max_examples=MAX_EXAMPLES_LONG_RUNNING,
-        deadline=None,
-    )
-    def test_nbit_forward_cpu_bf16_out(
-        self,
-        nbit_weights_ty: Optional[SparseType],
-        use_array_for_index_remapping: bool,
-        do_pruning: bool,
-    ) -> None:
-        use_cpu = True
-        T = random.randint(1, 50)
-        B = random.randint(0, 128)
-        L = random.randint(0, 32)
-        D = random.randint(2, 2048)
-        log_E = random.randint(2, 4)
-
-        use_cache = False
-        # cache_algorithm is don't care as we don't use cache.
-        cache_algorithm = CacheAlgorithm.LRU
-
-        pooling_mode = random.choice(
-            [
-                PoolingMode.SUM,
-                PoolingMode.MEAN,
-            ]
-        )
-        mixed = random.choice([True, False])
-
-        if pooling_mode == PoolingMode.SUM:
-            weighted = random.choice([True, False])
-        else:
-            weighted = False
-
-        if nbit_weights_ty is None:
-            # don't care when mixed type is used.
-            weights_ty: SparseType = SparseType.INT8
-            mixed_weights_ty = True
-        else:
-            weights_ty: SparseType = nbit_weights_ty
-            mixed_weights_ty = False
-        output_dtype = SparseType.BF16
         self.execute_nbit_forward_(
             T,
             D,


### PR DESCRIPTION
Summary:
Instead of using the ref implementation for sequence embedding on CPU,
this diff directs TBE to invoke the AVX implementation by forcing
pooling factors of 1 (i.e., passing `at::arange(index_size)` as
offfsets).  The performance gained from using the AVX implementation
offsets the overhead incurs in creating the new offsets.

Differential Revision: D51918878


