### PR TITLE
Get some fbgemm::split_embedding_codegen_lookup_{} functions pt2_compliant

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_split_meta_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_split_meta_template.cpp
@@ -179,6 +179,10 @@ Tensor
         return output;
     }
 
+    {%- if not nobag and vbe %}
+    output = output.reshape({-1});
+    {%- endif %}
+
     return output;
 }
 

--- a/fbgemm_gpu/codegen/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_template.cu
@@ -15,6 +15,8 @@
 // See https://fburl.com/dw9ljh4h
 #}
 
+#include "fbgemm_gpu/dispatch_macros.h"
+
 {%- set ddesc =  "dense" if dense else "split" %}
 {%- set wdesc =  "weighted" if weighted else "unweighted" %}
 {%- set vdesc = "_vbe" if vbe else "" %}
@@ -739,7 +741,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
           "    int info_B_mask_int64, "
           {%- endif %}
           "    bool is_experimental"
-          ") -> Tensor");
+          ") -> Tensor",
+          {PT2_COMPLIANT_TAG});
     DISPATCH_TO_CUDA(
         "{{ embedding_codegen_forward_op }}",
         {{ embedding_codegen_forward_op }}

--- a/fbgemm_gpu/include/fbgemm_gpu/dispatch_macros.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/dispatch_macros.h
@@ -203,8 +203,10 @@
       TYPE, NAME, FBGEMM_DISPATCH_FLOAT_HALF_AND_BFLOAT16_CASE(__VA_ARGS__))
 
 // We can cleanup the following once fbgemm uses PyTorch 2.2 in January 2024.
+#ifndef PT2_COMPLIANT_TAG
 #ifdef HAS_PT2_COMPLIANT_TAG
 #define PT2_COMPLIANT_TAG at::Tag::pt2_compliant_tag
 #else
 #define PT2_COMPLIANT_TAG
+#endif
 #endif

--- a/fbgemm_gpu/test/failures_dict_fast.json
+++ b/fbgemm_gpu/test/failures_dict_fast.json
@@ -495,115 +495,17 @@
       }
     },
     "fbgemm::split_embedding_codegen_lookup_adagrad_function": {},
-    "fbgemm::split_embedding_codegen_lookup_adagrad_function_cpu": {
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_optimizers_adagrad": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
-    "fbgemm::split_embedding_codegen_lookup_adam_function": {
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_optimizers_adam": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
+    "fbgemm::split_embedding_codegen_lookup_adagrad_function_cpu": {},
+    "fbgemm::split_embedding_codegen_lookup_adam_function": {},
     "fbgemm::split_embedding_codegen_lookup_lamb_function": {},
     "fbgemm::split_embedding_codegen_lookup_lars_sgd_function": {},
     "fbgemm::split_embedding_codegen_lookup_none_function": {},
     "fbgemm::split_embedding_codegen_lookup_partial_rowwise_adam_function": {},
     "fbgemm::split_embedding_codegen_lookup_partial_rowwise_lamb_function": {},
-    "fbgemm::split_embedding_codegen_lookup_rowwise_adagrad_function": {
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_adagrad_fp16_pmMEAN": {
-        "comment": "",
-        "status": "skip"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_adagrad_fp16_pmNONE": {
-        "comment": "",
-        "status": "skip"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_adagrad_fp16_pmSUM": {
-        "comment": "",
-        "status": "skip"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_adagrad_fp32_pmMEAN": {
-        "comment": "",
-        "status": "skip"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_adagrad_fp32_pmNONE": {
-        "comment": "",
-        "status": "skip"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_adagrad_fp32_pmSUM": {
-        "comment": "",
-        "status": "skip"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_optimizers_adagrad": {
-        "comment": "",
-        "status": "skip"
-      }
-    },
-    "fbgemm::split_embedding_codegen_lookup_rowwise_adagrad_function_cpu": {
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_adagrad_fp16_pmMEAN": {
-        "comment": "",
-        "status": "skip"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_adagrad_fp16_pmNONE": {
-        "comment": "",
-        "status": "skip"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_adagrad_fp16_pmSUM": {
-        "comment": "",
-        "status": "skip"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_adagrad_fp32_pmMEAN": {
-        "comment": "",
-        "status": "skip"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_adagrad_fp32_pmNONE": {
-        "comment": "",
-        "status": "skip"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_adagrad_fp32_pmSUM": {
-        "comment": "",
-        "status": "skip"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_optimizers_adagrad": {
-        "comment": "",
-        "status": "skip"
-      }
-    },
+    "fbgemm::split_embedding_codegen_lookup_rowwise_adagrad_function": {},
+    "fbgemm::split_embedding_codegen_lookup_rowwise_adagrad_function_cpu": {},
     "fbgemm::split_embedding_codegen_lookup_rowwise_weighted_adagrad_function": {},
-    "fbgemm::split_embedding_codegen_lookup_sgd_function": {
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_sgd": {
-        "comment": "",
-        "status": "skip"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_sgd_really_long_segments": {
-        "comment": "",
-        "status": "skip"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_cache_pipeline": {
-        "comment": "",
-        "status": "skip"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_cache_prefetch_pipeline": {
-        "comment": "",
-        "status": "skip"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_cache_prefetch_pipeline_stream_1": {
-        "comment": "",
-        "status": "skip"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_cache_prefetch_pipeline_stream_2": {
-        "comment": "",
-        "status": "skip"
-      }
-    },
-    "fbgemm::split_embedding_codegen_lookup_sgd_function_cpu": {
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_backward_sgd": {
-        "comment": "",
-        "status": "xfail"
-      }
-    }
+    "fbgemm::split_embedding_codegen_lookup_sgd_function": {},
+    "fbgemm::split_embedding_codegen_lookup_sgd_function_cpu": {}
   }
 }


### PR DESCRIPTION
Summary: In particular `split_embedding_codegen_lookup_rowwise_adagrad_function`. But a bunch of similar ops can be marked as pt2_compliant by fixing some templates and bugs.

Differential Revision: D51960321


