### PR TITLE
Add opcheck tests for fbgemm::split_embedding_codegen_forward_[un]weighted_cuda

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
@@ -12,6 +12,7 @@
 #include <ATen/core/op_registration/op_registration.h>
 #include <torch/script.h>
 
+#include "fbgemm_gpu/dispatch_macros.h"
 #include "fbgemm_gpu/sparse_ops_utils.h"
 #include "fbgemm_gpu/split_embeddings_utils.cuh"
 
@@ -791,7 +792,8 @@ TORCH_LIBRARY_FRAGMENT({{ lib_name }}, m) {
           "    int vbe_output_size=-1, "
           "    bool is_experimental=False, "
           "    bool use_uniq_cache_locations_bwd=False, "
-          "    bool use_homogeneous_placements=False) -> Tensor");
+          "    bool use_homogeneous_placements=False) -> Tensor",
+          {PT2_COMPLIANT_TAG});
     // We're playing a funny trick here: we're using the autograd
     // implementation of the operator at all the dispatch keys.  This is OK
     // because autograd.Function works even in a context where there is

--- a/fbgemm_gpu/codegen/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_template.cu
@@ -19,6 +19,10 @@
 {%- set wdesc =  "weighted" if weighted else "unweighted" %}
 {%- set vdesc = "_vbe" if vbe else "" %}
 
+{%- if not dense and not nobag and not vbe %}
+#include "fbgemm_gpu/dispatch_macros.h"
+{%- endif %}
+
 {%- if not is_index_select %}
 ////////////////////////////////////////////////////////////////////////////////
 // Required for op registrations
@@ -739,7 +743,13 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
           "    int info_B_mask_int64, "
           {%- endif %}
           "    bool is_experimental"
-          ") -> Tensor");
+          ") -> Tensor"
+          {%- if not dense and not nobag and not vbe %}
+          // only split_embedding_codegen_forward_[un]weighted_cuda
+          // are tested to be PT2 compliant
+          , {PT2_COMPLIANT_TAG}
+          {%- endif %}
+    );
     DISPATCH_TO_CUDA(
         "{{ embedding_codegen_forward_op }}",
         {{ embedding_codegen_forward_op }}

--- a/fbgemm_gpu/test/failures_dict_fast.json
+++ b/fbgemm_gpu/test/failures_dict_fast.json
@@ -80,6 +80,7 @@
         "status": "xfail"
       }
     },
+    "fbgemm::asynchronous_complete_cumsum": {},
     "fbgemm::bounds_check_indices": {},
     "fbgemm::dense_embedding_codegen_lookup_function": {
       "SplitTableBatchedEmbeddingsTest.test_autograd_registration__test_backward_dense": {
@@ -486,6 +487,8 @@
         "status": "skip"
       }
     },
+    "fbgemm::split_embedding_codegen_forward_unweighted_cuda": {},
+    "fbgemm::split_embedding_codegen_forward_weighted_cuda": {},
     "fbgemm::split_embedding_codegen_lookup_adagrad_function": {},
     "fbgemm::split_embedding_codegen_lookup_adagrad_function_cpu": {},
     "fbgemm::split_embedding_codegen_lookup_adam_function": {},


### PR DESCRIPTION
Summary: Title. Also the split_embedding_codegen_forward_[un]weighted_cuda ops as PT2 compliant (and mark split_embedding_codegen_lookup_{} functions I may have missed).

Differential Revision: D52067413


