### PR TITLE
Remove extra semi colon from dbproxy/StatValue.h

### DIFF
--- a/src/DirectConv.h
+++ b/src/DirectConv.h
@@ -224,4 +224,4 @@ CodeCache<
     typename DirectConvCodeGenBase<TA, TB, TC, accT>::jit_micro_kernel_fp_convT>
     DirectConvCodeGenBase<TA, TB, TC, accT>::codeCacheT_;
 
-}; // namespace fbgemm
+} // namespace fbgemm


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D51995043


