### PR TITLE
Revert D51999938: Multisect successfully blamed "D51999938: Add early exit in sparse_async_cumsum ops" for otest failure

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_async_cumsum.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_async_cumsum.cu
@@ -13,9 +13,6 @@ using Tensor = at::Tensor;
 namespace fbgemm_gpu {
 
 DLL_PUBLIC Tensor asynchronous_inclusive_cumsum_gpu(const Tensor& t_in) {
-  if (t_in.numel() == 0) {
-    return at::zeros_like(t_in);
-  }
   TENSOR_ON_CUDA_GPU(t_in);
 
   at::cuda::OptionalCUDAGuard device_guard;
@@ -57,9 +54,6 @@ DLL_PUBLIC Tensor asynchronous_inclusive_cumsum_gpu(const Tensor& t_in) {
 }
 
 DLL_PUBLIC Tensor asynchronous_exclusive_cumsum_gpu(const Tensor& t_in) {
-  if (t_in.numel() == 0) {
-    return at::zeros_like(t_in);
-  }
   TENSOR_ON_CUDA_GPU(t_in);
 
   at::cuda::OptionalCUDAGuard device_guard;
@@ -101,9 +95,6 @@ DLL_PUBLIC Tensor asynchronous_exclusive_cumsum_gpu(const Tensor& t_in) {
 }
 
 DLL_PUBLIC Tensor asynchronous_complete_cumsum_gpu(const Tensor& t_in) {
-  if (t_in.numel() == 0) {
-    return at::zeros({t_in.numel() + 1}, t_in.options());
-  }
   TENSOR_ON_CUDA_GPU(t_in);
 
   at::cuda::OptionalCUDAGuard device_guard;

--- a/fbgemm_gpu/test/sparse_ops_test.py
+++ b/fbgemm_gpu/test/sparse_ops_test.py
@@ -591,7 +591,7 @@ class SparseOpsTest(unittest.TestCase):
             torch.testing.assert_close(new_indices_gpu.cpu(), new_indices_cpu)
 
     @given(
-        n=st.integers(min_value=0, max_value=100),
+        n=st.integers(min_value=1, max_value=100),
         long_index=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
@@ -655,8 +655,8 @@ class SparseOpsTest(unittest.TestCase):
             )
 
     @given(
-        n=st.integers(min_value=0, max_value=600),
-        b=st.integers(min_value=0, max_value=10),
+        n=st.integers(min_value=1, max_value=600),
+        b=st.integers(min_value=1, max_value=10),
         long_index=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)


### PR DESCRIPTION
Summary:
This diff is reverting D51999938
D51999938: Add early exit in sparse_async_cumsum ops by meremeev has been identified to be causing the following test failure:

Tests affected:
- [deeplearning/fbgemm/fbgemm_gpu:sparse_ops_test - test_schema__test_asynchronous_complete_cumsum_2d (deeplearning.fbgemm.fbgemm_gpu.test.sparse_ops_test.SparseOpsTest)](https://www.internalfb.com/intern/test/562950068047718/)

Here's the Multisect link:
https://www.internalfb.com/multisect/3757962
Here are the tasks that are relevant to this breakage:


We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Reviewed By: jasonjk-park

Differential Revision: D52099677


