### PR TITLE
create cumem_utils_cpu and add to all_deps_cpu

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -601,6 +601,7 @@ if(NOT FBGEMM_CPU_ONLY)
     codegen/embedding_bounds_check_host.cpp
     src/memory_utils/memory_utils.cpp
     src/memory_utils/memory_utils_ops.cpp
+    src/memory_utils/memory_utils_ops_cpu.cpp
     src/layout_transform_ops/layout_transform_ops_gpu.cpp
     src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_gpu.cpp
     src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split_gpu.cpp

--- a/fbgemm_gpu/src/memory_utils/memory_utils_ops.cpp
+++ b/fbgemm_gpu/src/memory_utils/memory_utils_ops.cpp
@@ -23,8 +23,6 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def("uvm_to_cpu(Tensor t) -> Tensor");
   m.def("new_managed_tensor(Tensor self, int[] sizes) -> Tensor");
   m.def("new_host_mapped_tensor(Tensor self, int[] sizes) -> Tensor");
-  m.def(
-      "new_unified_tensor(Tensor self, int[] sizes, bool is_host_mapped) -> Tensor");
   m.def("new_vanilla_managed_tensor(Tensor self, int[] sizes) -> Tensor");
   m.def(
       "cuda_mem_advise(Tensor t, int advice) -> ()",
@@ -41,7 +39,6 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
-  DISPATCH_TO_CPU("new_unified_tensor", new_unified_tensor_cpu);
   DISPATCH_TO_META("new_managed_tensor", new_managed_tensor_meta);
 }
 

--- a/fbgemm_gpu/src/memory_utils/memory_utils_ops_cpu.cpp
+++ b/fbgemm_gpu/src/memory_utils/memory_utils_ops_cpu.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <torch/library.h>
+#include "common.h"
+#include "fbgemm_gpu/sparse_ops_utils.h"
+
+using Tensor = at::Tensor;
+
+namespace fbgemm_gpu {
+
+TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  m.def(
+      "new_unified_tensor(Tensor self, int[] sizes, bool is_host_mapped) -> Tensor");
+}
+
+TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  DISPATCH_TO_CPU("new_unified_tensor", new_unified_tensor_cpu);
+}
+
+} // namespace fbgemm_gpu


### PR DESCRIPTION
Summary:
Fix Could not find any similar ops to fbgemm::new_unified_tensor.: P876042425
At model loading using IntNBitTableBatchedEmbeddingBagsCodegen, we got  Could not find any similar ops to fbgemm::new_unified_tensor.
P876042425
The error line https://fburl.com/code/j41vcjg1 means we lack dependency of new_unified_tensor in full cpu predictor build. This diff adds the dep.

Reviewed By: jiayisuse

Differential Revision: D52176309


