### PR TITLE
Disable embedding_ops training dependency using new buck mode

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -79,6 +79,7 @@ def get_fbgemm_public_headers():
         "include/fbgemm/Types.h",
     ]
 
+# buildifier: disable=unused-variable
 def get_fbgemm_avx2_srcs(msvc = False):
     return [
         #All the source files that either use avx2 instructions statically
@@ -109,6 +110,7 @@ def get_fbgemm_inline_avx2_srcs(msvc = False, buck = False):
         })
     return asm_srcs if not msvc else intrinsics_srcs
 
+# buildifier: disable=unused-variable
 def get_fbgemm_avx512_srcs(msvc = False):
     return [
         #All the source files that use avx512 instructions statically
@@ -140,3 +142,6 @@ def get_fbgemm_inline_avx512_srcs(msvc = False, buck = False):
 
 def get_fbgemm_tests(skip_tests = []):
     return native.glob(["test/*Test.cc"], exclude = skip_tests)
+
+def get_fbgemm_inference_mode():
+    return native.read_config("fbcode", "fbgemm_inference_mode", False)


### PR DESCRIPTION
Summary:
We need a new buck mode for fbgemm to specify fbgemm inference mode and then include dependency based on this and not include training related dependcies.

To enable fbgemm inference *only* mode, we can pass this in buck command line:
   -c fbcode.fbgemm_inference_mode=True

Differential Revision: D52231398


