### PR TITLE
fix PT2_COMPLIANT_TAG macro

### DIFF
--- a/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_bounds_check_host_cpu.cpp
@@ -179,6 +179,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   // The (a!) tells PyTorch this is an impure operation and so cannot be CSE'd
   // or DCE'd, etc.
   m.def(
-      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(b!) offsets, int bounds_check_mode, Tensor(c!) warning, Tensor(d!)? weights=None, Tensor? B_offsets=None, int max_B=-1) -> ()");
+      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(b!) offsets, int bounds_check_mode, Tensor(c!) warning, Tensor(d!)? weights=None, Tensor? B_offsets=None, int max_B=-1) -> ()",
+      {PT2_COMPLIANT_TAG});
   DISPATCH_TO_CPU("bounds_check_indices", bounds_check_indices_cpu);
 }

--- a/fbgemm_gpu/include/fbgemm_gpu/dispatch_macros.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/dispatch_macros.h
@@ -6,6 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// This is NECESSARY for the PT2_COMPLIANT_TAG macro to work.
+#include <torch/library.h>
+
 #define PRIVATE_CASE_TYPE_CACHE(enum_type, type, ...) \
   case enum_type: {                                   \
     using cache_t = type;                             \

--- a/fbgemm_gpu/src/input_combine_ops/input_combine_cpu.cpp
+++ b/fbgemm_gpu/src/input_combine_ops/input_combine_cpu.cpp
@@ -393,7 +393,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "tbe_input_combine(Tensor[] indices_list, Tensor[] offsets_list, Tensor[] per_sample_weights, Tensor include_last_offsets) -> (Tensor, Tensor, Tensor)",
       {PT2_COMPLIANT_TAG});
   m.def(
-      "tbe_input_combine_with_length(Tensor[] indices_list, Tensor[] lengths_list, Tensor[] per_sample_weights) -> (Tensor, Tensor, Tensor)");
+      "tbe_input_combine_with_length(Tensor[] indices_list, Tensor[] lengths_list, Tensor[] per_sample_weights) -> (Tensor, Tensor, Tensor)",
+      {PT2_COMPLIANT_TAG});
   m.def(
       "padding_fused_tbe_input_combine(Tensor[] indices_list, Tensor[] offsets_list, Tensor[] per_sample_weights, Tensor include_last_offsets, int batch_size) -> (Tensor, Tensor, Tensor)");
   m.def(

--- a/fbgemm_gpu/test/failures_dict.json
+++ b/fbgemm_gpu/test/failures_dict.json
@@ -525,27 +525,27 @@
     "fbgemm::tbe_input_combine_with_length": {
       "InputCombineTest.test_aot_dispatch_dynamic__test_input_combine_int32_with_length": {
         "comment": "",
-        "status": "xfail"
+        "status": "xsuccess"
       },
       "InputCombineTest.test_aot_dispatch_dynamic__test_input_combine_int64_with_length": {
         "comment": "",
-        "status": "xfail"
+        "status": "xsuccess"
       },
       "InputCombineTest.test_aot_dispatch_dynamic__test_input_combine_mix_with_length": {
         "comment": "",
-        "status": "xfail"
+        "status": "xsuccess"
       },
       "InputCombineTest.test_faketensor__test_input_combine_int32_with_length": {
         "comment": "",
-        "status": "xfail"
+        "status": "xsuccess"
       },
       "InputCombineTest.test_faketensor__test_input_combine_int64_with_length": {
         "comment": "",
-        "status": "xfail"
+        "status": "xsuccess"
       },
       "InputCombineTest.test_faketensor__test_input_combine_mix_with_length": {
         "comment": "",
-        "status": "xfail"
+        "status": "xsuccess"
       }
     }
   }


### PR DESCRIPTION
Summary:
This macro checks a macro in torch/library.h.
We need to import torch.library.h first, otherwise we erroneously set the macro
to nothing.

Reviewed By: williamwen42

Differential Revision: D52256752


