### PR TITLE
Fix FBGEMM_GPU PIP Install + Test

### DIFF
--- a/.github/workflows/fbgemm_gpu_pip.yml
+++ b/.github/workflows/fbgemm_gpu_pip.yml
@@ -88,14 +88,14 @@ jobs:
       run: . $PRELUDE; install_build_tools $BUILD_ENV
 
     - name: Install PyTorch-CPU
-      run: . $PRELUDE; install_pytorch_pip $BUILD_ENV ${{ github.event.inputs.pytorch_version }} cpu
+      run: . $PRELUDE; install_pytorch_pip $BUILD_ENV ${{ github.event.inputs.pytorch_version || 'nightly' }} cpu
 
     - name: Collect PyTorch Environment Info
       if: ${{ success() || failure() }}
       run:  . $PRELUDE; collect_pytorch_env_info $BUILD_ENV
 
     - name: Install FBGEMM_GPU-CPU
-      run: . $PRELUDE; install_fbgemm_gpu_pip $BUILD_ENV ${{ github.event.inputs.fbgemm_gpu_channel_version }} cpu
+      run: . $PRELUDE; install_fbgemm_gpu_pip $BUILD_ENV ${{ github.event.inputs.fbgemm_gpu_channel_version || 'nightly' }} cpu
 
     - name: Test with PyTest
       timeout-minutes: 10
@@ -148,14 +148,14 @@ jobs:
       run: . $PRELUDE; install_cuda $BUILD_ENV ${{ matrix.cuda-version }}
 
     - name: Install PyTorch-CUDA
-      run: . $PRELUDE; install_pytorch_pip $BUILD_ENV ${{ github.event.inputs.pytorch_version }} cuda/${{ matrix.cuda-version }}
+      run: . $PRELUDE; install_pytorch_pip $BUILD_ENV ${{ github.event.inputs.pytorch_version || 'nightly' }} cuda/${{ matrix.cuda-version }}
 
     - name: Collect PyTorch Environment Info
       if: ${{ success() || failure() }}
       run:  . $PRELUDE; collect_pytorch_env_info $BUILD_ENV
 
     - name: Install FBGEMM_GPU-CUDA
-      run: . $PRELUDE; install_fbgemm_gpu_pip $BUILD_ENV ${{ github.event.inputs.fbgemm_gpu_channel_version }} cuda/${{ matrix.cuda-version }}
+      run: . $PRELUDE; install_fbgemm_gpu_pip $BUILD_ENV ${{ github.event.inputs.fbgemm_gpu_channel_version || 'nightly' }} cuda/${{ matrix.cuda-version }}
 
     - name: Test with PyTest
       timeout-minutes: 15
@@ -214,14 +214,14 @@ jobs:
       run: . $PRELUDE; install_build_tools $BUILD_ENV
 
     - name: Install PyTorch-ROCm
-      run:  . $PRELUDE; install_pytorch_pip $BUILD_ENV ${{ github.event.inputs.pytorch_version }} rocm/${{ matrix.rocm-version }}
+      run:  . $PRELUDE; install_pytorch_pip $BUILD_ENV ${{ github.event.inputs.pytorch_version || 'nightly' }} rocm/${{ matrix.rocm-version }}
 
     - name: Collect PyTorch Environment Info
       if: ${{ success() || failure() }}
       run:  . $PRELUDE; collect_pytorch_env_info $BUILD_ENV
 
     - name: Install FBGEMM_GPU-ROCm
-      run: . $PRELUDE; install_fbgemm_gpu_pip $BUILD_ENV ${{ github.event.inputs.fbgemm_gpu_channel_version }} rocm/${{ matrix.rocm-version }}
+      run: . $PRELUDE; install_fbgemm_gpu_pip $BUILD_ENV ${{ github.event.inputs.fbgemm_gpu_channel_version || 'nightly' }} rocm/${{ matrix.rocm-version }}
 
     - name: Test FBGEMM_GPU-ROCm
       timeout-minutes: 15


### PR DESCRIPTION
Summary:
Default values are not set for scheduled case, causing error https://github.com/pytorch/FBGEMM/actions/runs/723279023. 

`github.event.inputs` are available to workflows triggered by the `workflow_dispatch` event only 
(https://stackoverflow.com/questions/72539900/schedule-trigger-github-action-workflow-with-input-parameters).

Reviewed By: q10

Differential Revision: D52279882


