### PR TITLE
Back out "support VBE"

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -204,7 +204,6 @@ set(GPU_OPTIMIZERS ${COMMON_OPTIMIZERS} ${GPU_ONLY_OPTIMIZERS})
 # Optimizers with the VBE support
 set(VBE_OPTIMIZERS
     rowwise_adagrad
-    rowwise_adagrad_with_counter
     sgd)
 
 # Individual optimizers (not fused with SplitTBE backward)

--- a/fbgemm_gpu/codegen/embedding_common_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_common_code_generator.py
@@ -911,7 +911,7 @@ def rowwise_adagrad_with_counter() -> Dict[str, Any]:
         "split_weight_update_cpu": split_weight_update_cpu,
         "has_cpu_support": True,
         "has_gpu_support": True,
-        "has_vbe_support": True,
+        "has_vbe_support": False,
     }
 
 


### PR DESCRIPTION
Summary:
original diff: D52517415

in conveyor, gti fbpkg build started failing since yesterday with relocation overflow errors: https://www.internalfb.com/sandcastle/workflow/4494592428117555335/artifact/actionlog.4494592428153522650.stdout.1

During bisect, we found that, this is causing the sigrid.predictor.cuda.gti fbpkg build failures

```
[ankursingla@devgpu005.cco1 ~/fbsource/fbcode (5ab44661f)]$ hg bisect --good cce6f8fb266acaa471303f55abaeda5f035ad89c                                                                                                                                                                             [0/88]
pulling 'cce6f8fb266acaa471303f55abaeda5f035ad89c' from 'fb:fbsource'
[ankursingla@devgpu005.cco1 ~/fbsource/fbcode (5ab44661f|BISECT)]$ hg bisect --bad b79ebdb25ce741210152f594733e8eb9df5d9aa5
Testing commit 91e1ed4b0a43 (1156 commits remaining, ~10 tests)
update complete
[ankursingla@devgpu005.cco1 ~/fbsource/fbcode (91e1ed4b0|BISECT)]$ hg bisect --command "buck run //sigrid/predictor:sigrid.predictor.cuda.gti"
```

output:
```
The first bad revision is:
changeset:   75daf25ec85f9eff96030d9ef4f955ff91b84e9c  D52517415  (@)
user:        Wang Zhou <wangzhou@meta.com>
date:        Wed, 03 Jan 2024 21:44:17 -0800
[CowClip] support VBE
```

Reviewed By: sryap

Differential Revision: D52565062


