### PR TITLE
Deprecate GPU rowwise_adagrad_with_weight_decay

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -182,14 +182,14 @@ set(GPU_ONLY_OPTIMIZERS
   partial_rowwise_adam
   partial_rowwise_lamb
   lars_sgd
-  rowwise_adagrad_with_weight_decay
   approx_rowwise_adagrad_with_weight_decay
   none)
 
 set(DEPRECATED_OPTIMIZERS
   approx_sgd
   approx_rowwise_adagrad
-  approx_rowwise_adagrad_with_counter)
+  approx_rowwise_adagrad_with_counter
+  rowwise_adagrad_with_weight_decay)
 
 set(ALL_OPTIMIZERS
   ${COMMON_OPTIMIZERS}

--- a/fbgemm_gpu/codegen/embedding_common_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_common_code_generator.py
@@ -607,6 +607,7 @@ def approx_rowwise_adagrad() -> Dict[str, Any]:
     }
 
 
+# Deprecated, to be cleaned up
 def rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
     split_weight_update = """
         weight_new.acc.x = correction * weight_new.acc.x - multiplier * grad.acc.x;
@@ -705,7 +706,7 @@ def rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
         "split_post_update": "",
         "split_weight_update_cpu": split_weight_update_cpu,
         "has_cpu_support": False,
-        "has_gpu_support": True,
+        "has_gpu_support": False,
         "has_vbe_support": False,
     }
 


### PR DESCRIPTION
Summary: Deprecate `rowwise_adagrad_with_weight_decay` GPU kernel

Differential Revision: D52574782


