### PR TITLE
Deprecate CPU|GPU rowwise_weighted_adagrad

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -182,14 +182,14 @@ set(GPU_ONLY_OPTIMIZERS
   partial_rowwise_adam
   partial_rowwise_lamb
   lars_sgd
-  rowwise_adagrad_with_weight_decay
   approx_rowwise_adagrad_with_weight_decay
   none)
 
 set(DEPRECATED_OPTIMIZERS
   approx_sgd
   approx_rowwise_adagrad
-  approx_rowwise_adagrad_with_counter)
+  approx_rowwise_adagrad_with_counter
+  rowwise_adagrad_with_weight_decay)
 
 set(ALL_OPTIMIZERS
   ${COMMON_OPTIMIZERS}

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -182,13 +182,13 @@ set(GPU_ONLY_OPTIMIZERS
   partial_rowwise_adam
   partial_rowwise_lamb
   lars_sgd
-  approx_rowwise_adagrad_with_weight_decay
   none)
 
 set(DEPRECATED_OPTIMIZERS
   approx_sgd
   approx_rowwise_adagrad
   approx_rowwise_adagrad_with_counter
+  approx_rowwise_adagrad_with_weight_decay
   rowwise_adagrad_with_weight_decay)
 
 set(ALL_OPTIMIZERS

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -169,7 +169,6 @@ file(GLOB_RECURSE asmjit_sources
 set(COMMON_OPTIMIZERS
     adagrad
     rowwise_adagrad
-    rowwise_weighted_adagrad
     sgd)
 
 # To be populated in the subsequent diffs
@@ -189,7 +188,8 @@ set(DEPRECATED_OPTIMIZERS
   approx_rowwise_adagrad
   approx_rowwise_adagrad_with_counter
   approx_rowwise_adagrad_with_weight_decay
-  rowwise_adagrad_with_weight_decay)
+  rowwise_adagrad_with_weight_decay
+  rowwise_weighted_adagrad)
 
 set(ALL_OPTIMIZERS
   ${COMMON_OPTIMIZERS}

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -169,7 +169,6 @@ file(GLOB_RECURSE asmjit_sources
 set(COMMON_OPTIMIZERS
     adagrad
     rowwise_adagrad
-    rowwise_adagrad_with_counter
     rowwise_weighted_adagrad
     sgd)
 
@@ -182,7 +181,8 @@ set(GPU_ONLY_OPTIMIZERS
   partial_rowwise_adam
   partial_rowwise_lamb
   lars_sgd
-  none)
+  none
+  rowwise_adagrad_with_counter)
 
 set(DEPRECATED_OPTIMIZERS
   approx_sgd

--- a/fbgemm_gpu/codegen/__init__.template
+++ b/fbgemm_gpu/codegen/__init__.template
@@ -15,5 +15,4 @@ import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_partial_rowwise
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_rowwise_adagrad as lookup_rowwise_adagrad  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_rowwise_adagrad_with_counter as lookup_rowwise_adagrad_with_counter  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_sgd as lookup_sgd  # noqa: F401
-import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_rowwise_weighted_adagrad as lookup_rowwise_weighted_adagrad  # noqa: F401
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers.lookup_none as lookup_none # noqa: F401

--- a/fbgemm_gpu/codegen/embedding_common_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_common_code_generator.py
@@ -607,6 +607,7 @@ def approx_rowwise_adagrad() -> Dict[str, Any]:
     }
 
 
+# Deprecated, to be cleaned up
 def rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
     split_weight_update = """
         weight_new.acc.x = correction * weight_new.acc.x - multiplier * grad.acc.x;
@@ -705,7 +706,7 @@ def rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
         "split_post_update": "",
         "split_weight_update_cpu": split_weight_update_cpu,
         "has_cpu_support": False,
-        "has_gpu_support": True,
+        "has_gpu_support": False,
         "has_vbe_support": False,
     }
 

--- a/fbgemm_gpu/codegen/embedding_common_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_common_code_generator.py
@@ -965,6 +965,7 @@ def approx_rowwise_adagrad_with_counter() -> Dict[str, Any]:
     }
 
 
+# Deprecated, to be cleaned up
 def rowwise_weighted_adagrad() -> Dict[str, Any]:
     split_weight_update = """
       weight_new.acc.x = correction * weight_new.acc.x - multiplier * grad.acc.x;
@@ -1034,8 +1035,8 @@ def rowwise_weighted_adagrad() -> Dict[str, Any]:
         "split_weight_update": split_weight_update,
         "split_post_update": "",
         "split_weight_update_cpu": split_weight_update_cpu,
-        "has_cpu_support": True,
-        "has_gpu_support": True,
+        "has_cpu_support": False,
+        "has_gpu_support": False,
         "has_vbe_support": False,
     }
 

--- a/fbgemm_gpu/codegen/embedding_common_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_common_code_generator.py
@@ -711,6 +711,7 @@ def rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
     }
 
 
+# Deprecated, to be cleaned up
 def approx_rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
     rowwise_adagrad_with_weight_decay_args = rowwise_adagrad_with_weight_decay()
 
@@ -740,7 +741,7 @@ def approx_rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
             "split_weight_update_cpu"
         ],
         "has_cpu_support": False,
-        "has_gpu_support": True,
+        "has_gpu_support": False,
         "has_vbe_support": False,
     }
 

--- a/fbgemm_gpu/codegen/embedding_common_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_common_code_generator.py
@@ -1057,7 +1057,7 @@ def sgd() -> Dict[str, Any]:
         "split_weight_update": split_weight_update,
         "split_post_update": "",
         "split_weight_update_cpu": split_weight_update_cpu,
-        "has_cpu_support": True,
+        "has_cpu_support": False,
         "has_gpu_support": True,
         "has_vbe_support": True,
     }

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -317,13 +317,12 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         gradient_clipping: bool = False,
         max_gradient: float = 1.0,
         learning_rate: float = 0.01,
-        # used by EXACT_ADAGRAD, EXACT_ROWWISE_ADAGRAD, EXACT_ROWWISE_WEIGHTED_ADAGRAD, LAMB, and ADAM only
+        # used by EXACT_ADAGRAD, EXACT_ROWWISE_ADAGRAD, LAMB, and ADAM only
         # NOTE that default is different from nn.optim.Adagrad default of 1e-10
         eps: float = 1.0e-8,
         momentum: float = 0.9,  # used by LARS-SGD
         # EXACT_ADAGRAD, SGD, EXACT_SGD do not support weight decay
         # LAMB, ADAM, PARTIAL_ROWWISE_ADAM, PARTIAL_ROWWISE_LAMB, LARS_SGD support decoupled weight decay
-        # EXACT_ROWWISE_WEIGHTED_ADAGRAD supports L2 weight decay
         # EXACT_ROWWISE_ADAGRAD support both L2 and decoupled weight decay (via weight_decay_mode)
         weight_decay: float = 0.0,
         weight_decay_mode: WeightDecayMode = WeightDecayMode.NONE,
@@ -536,7 +535,6 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             assert optimizer in (
                 OptimType.EXACT_ADAGRAD,
                 OptimType.EXACT_ROWWISE_ADAGRAD,
-                OptimType.EXACT_ROWWISE_WEIGHTED_ADAGRAD,
                 OptimType.EXACT_SGD,
             ), f"Optimizer {optimizer} is not supported in CPU mode."
         else:
@@ -544,7 +542,6 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 OptimType.ADAM,
                 OptimType.EXACT_ADAGRAD,
                 OptimType.EXACT_ROWWISE_ADAGRAD,
-                OptimType.EXACT_ROWWISE_WEIGHTED_ADAGRAD,
                 OptimType.EXACT_SGD,
                 OptimType.LAMB,
                 OptimType.LARS_SGD,
@@ -639,7 +636,6 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             else:
                 rowwise = optimizer in [
                     OptimType.EXACT_ROWWISE_ADAGRAD,
-                    OptimType.EXACT_ROWWISE_WEIGHTED_ADAGRAD,
                 ]
                 self._apply_split(
                     construct_split_state(
@@ -722,7 +718,6 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 )
             if optimizer in (
                 OptimType.ADAM,
-                OptimType.EXACT_ROWWISE_WEIGHTED_ADAGRAD,
                 OptimType.LAMB,
                 OptimType.PARTIAL_ROWWISE_ADAM,
                 OptimType.PARTIAL_ROWWISE_LAMB,
@@ -1058,15 +1053,6 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             self.iter = self.iter.cpu()
         self.iter[0] += 1
 
-        if self.optimizer == OptimType.EXACT_ROWWISE_WEIGHTED_ADAGRAD:
-            return invokers.lookup_rowwise_weighted_adagrad.invoke(
-                common_args,
-                self.optimizer_args,
-                momentum1,
-                # pyre-fixme[6]: Expected `int` for 4th param but got `Union[float,
-                #  int]`.
-                self.iter.item(),
-            )
         if self.optimizer == OptimType.ADAM:
             return invokers.lookup_adam.invoke(
                 common_args,
@@ -1407,7 +1393,6 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         split_optimizer_states = self.split_optimizer_states()
         if (
             self.optimizer == OptimType.EXACT_ROWWISE_ADAGRAD
-            or self.optimizer == OptimType.EXACT_ROWWISE_WEIGHTED_ADAGRAD
             or self.optimizer == OptimType.EXACT_ADAGRAD
         ):
             list_of_state_dict = [
@@ -1487,7 +1472,6 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                     rowwise=self.optimizer
                     in [
                         OptimType.EXACT_ROWWISE_ADAGRAD,
-                        OptimType.EXACT_ROWWISE_WEIGHTED_ADAGRAD,
                     ],
                 )
             )
@@ -1946,7 +1930,6 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
         rowwise = self.optimizer in [
             OptimType.EXACT_ROWWISE_ADAGRAD,
-            OptimType.EXACT_ROWWISE_WEIGHTED_ADAGRAD,
         ]
         if rowwise:
             torch.ops.fbgemm.reset_weight_momentum(

--- a/fbgemm_gpu/test/split_table_batched_embeddings_test.py
+++ b/fbgemm_gpu/test/split_table_batched_embeddings_test.py
@@ -3535,10 +3535,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 )
                 optimizer_kwargs["cowclip_regularization"] = cowclip_regularization
 
-        if optimizer == OptimType.EXACT_ROWWISE_WEIGHTED_ADAGRAD:
-            optimizer_kwargs["eps"] = eps
-            optimizer_kwargs["weight_decay"] = weight_decay
-
         if optimizer in (OptimType.PARTIAL_ROWWISE_ADAM, OptimType.ADAM):
             optimizer_kwargs["eps"] = eps
             optimizer_kwargs["beta1"] = beta1
@@ -3619,7 +3615,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 OptimType.PARTIAL_ROWWISE_LAMB,
                 OptimType.EXACT_SGD,
                 OptimType.EXACT_ROWWISE_ADAGRAD,
-                OptimType.EXACT_ROWWISE_WEIGHTED_ADAGRAD,
                 OptimType.EXACT_ADAGRAD,
             )
 
@@ -3740,41 +3735,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 ):
                     expected_keys.update(["prev_iter", "row_counter"])
                 assert set(optimizer_states_dict.keys()) == expected_keys
-
-        if optimizer == OptimType.EXACT_ROWWISE_WEIGHTED_ADAGRAD:
-            for t in range(T):
-                (m1,) = split_optimizer_states[t]
-                # to_dense in GPU is non-deterministic due to atmomics used in
-                # coalescing and floating point non-associativity.
-                dense_cpu_grad = bs[t].weight.grad.cpu().to_dense()
-                dense_cpu_grad += weight_decay * bs[t].weight.cpu()
-                iter_ = cc.iter.item()
-                lambda_ = (iter_ + 1) ** 0.5
-                m1_ref = dense_cpu_grad.pow(2).mean(dim=1)
-                m1_ref *= lambda_
-                torch.testing.assert_close(
-                    m1.float().index_select(dim=0, index=xs[t].view(-1)).cpu(),
-                    m1_ref.float().index_select(dim=0, index=xs[t].view(-1).cpu()),
-                    atol=1.0e-4,
-                    rtol=1.0e-4,
-                )
-                weights_new = split_weights[t]
-                weights_ref = bs[t].weight.cpu() - lr * lambda_ * dense_cpu_grad / (
-                    # pyre-fixme[58]: `/` is not supported for operand types `float`
-                    #  and `Tensor`.
-                    torch.pow(m1_ref.view(m1_ref.numel(), 1), 1.0 / 3)
-                    + eps
-                )
-                torch.testing.assert_close(
-                    weights_new.index_select(dim=0, index=xs[t].view(-1)).cpu(),
-                    weights_ref.index_select(dim=0, index=xs[t].view(-1).cpu()),
-                    atol=1.0e-4,
-                    rtol=1.0e-4,
-                )
-
-                if get_optimizer_states is not None:
-                    optimizer_states_dict = get_optimizer_states[t]
-                    assert set(optimizer_states_dict.keys()) == {"sum"}
 
         if optimizer in (OptimType.PARTIAL_ROWWISE_ADAM, OptimType.ADAM):
             rowwise = optimizer == OptimType.PARTIAL_ROWWISE_ADAM
@@ -4113,7 +4073,6 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
             [
                 OptimType.EXACT_ADAGRAD,
                 OptimType.EXACT_ROWWISE_ADAGRAD,
-                OptimType.EXACT_ROWWISE_WEIGHTED_ADAGRAD,
             ]
         ),
         long_segments=st.booleans(),


### PR DESCRIPTION
Summary: Deprecate CPU|GPU `rowwise_weighted_adagrad` kernels

Differential Revision: D52575349


