### PR TITLE
support VBE -- reland

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -204,6 +204,7 @@ set(GPU_OPTIMIZERS ${COMMON_OPTIMIZERS} ${GPU_ONLY_OPTIMIZERS})
 # Optimizers with the VBE support
 set(VBE_OPTIMIZERS
     rowwise_adagrad
+    rowwise_adagrad_with_counter
     sgd)
 
 # Individual optimizers (not fused with SplitTBE backward)

--- a/fbgemm_gpu/codegen/embedding_common_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_common_code_generator.py
@@ -911,7 +911,7 @@ def rowwise_adagrad_with_counter() -> Dict[str, Any]:
         "split_weight_update_cpu": split_weight_update_cpu,
         "has_cpu_support": True,
         "has_gpu_support": True,
-        "has_vbe_support": False,
+        "has_vbe_support": True,
     }
 
 


### PR DESCRIPTION
Summary: Reland D52517415 after deprecating a few unused FBGEMM kernels to reduce the binary size

Differential Revision: D52590085


