### PR TITLE
Fix shadowed variable in deeplearning/fbgemm/src/GroupwiseConv.cc

### DIFF
--- a/src/GroupwiseConv.cc
+++ b/src/GroupwiseConv.cc
@@ -181,7 +181,7 @@ jit_conv_kernel_fp GenConvKernel<SPATIAL_DIM, INST_SET>::getOrCreate() {
   x86::Assembler assembler(&code);
   x86::Emitter* a = assembler.as<x86::Emitter>();
 
-  typedef typename simd_info<INST_SET>::vec_reg_t vec_reg_t;
+  using vec_reg_t_2 = typename simd_info<INST_SET>::vec_reg_t;
 #if defined(FBGEMM_LOG_CODE)
   auto kernelSig = make_tuple(
       this->isAZeroPointZero_,
@@ -261,13 +261,13 @@ jit_conv_kernel_fp GenConvKernel<SPATIAL_DIM, INST_SET>::getOrCreate() {
   // this in a register. It's generated again at
   // each use. Only used for the case of C_per_G == 2 or 4
   // gen8BitVectorOne(a, oneReg8Bit_V_);
-  gen16BitVectorOne<INST_SET, vec_reg_t>(a, oneReg16Bit_V_);
+  gen16BitVectorOne<INST_SET, vec_reg_t_2>(a, oneReg16Bit_V_);
 
   loopR1_ = a->gpz(14);
   loopR2_ = a->gpz(15);
 
   if (!this->isAZeroPointZero_) {
-    broadcast8Bit<vec_reg_t>(a, a_zero_pt_R_, zeroPTReg_V_);
+    broadcast8Bit<vec_reg_t_2>(a, a_zero_pt_R_, zeroPTReg_V_);
   }
 
   genConstForPermutations(a);


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D52582820


