### PR TITLE
add EmbeddingLocation.MTIA to tbe module

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -26,6 +26,7 @@ class EmbeddingLocation(enum.IntEnum):
     MANAGED = 1
     MANAGED_CACHING = 2
     HOST = 3
+    MTIA = 4
 
 
 class CacheAlgorithm(enum.Enum):


### PR DESCRIPTION
Summary:
For MTIA, tbe weights have the following characteristics
1. fp32 as qparam instead of fp16,
2. row alignment 1,
3. no cacheline alignment.

Differential Revision: D52860637


