### PR TITLE
Add early exit to sparse_segment_sum_csr_cuda op

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_segment_sum_csr.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_segment_sum_csr.cu
@@ -57,7 +57,14 @@ DLL_PUBLIC Tensor segment_sum_csr_cuda(
 
   CUDA_DEVICE_GUARD(values);
 
+  TORCH_CHECK(csr_seg.numel() >= 1, "The csr_seg tensor should not be empty")
+
   auto output = at::empty(csr_seg.numel() - 1, values.options());
+
+  if (csr_seg.numel() == 1) {
+    return output;
+  }
+
   constexpr uint32_t threads_per_block = 256;
   const uint32_t num_blocks = csr_seg.numel() - 1;
 


### PR DESCRIPTION
Summary: Add early exit to sparse_segment_sum_csr_cuda op in case of empty input. Add check for invalid input size.

Differential Revision: D52963209


