### PR TITLE
Revert D52679387: Multisect successfully blamed "D52679387: [T158416182][fbgemm_gpu][Rebase 3b] Optimize the cache fetch for forward split, pt. 2A" for otest failure

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
@@ -167,7 +167,6 @@ class {{ autograd_func }} :
     const c10::optional<Tensor>& feature_requires_grad,
     {%- endif %}
     const Tensor& lxu_cache_locations,
-    c10::optional<Tensor> uvm_cache_stats,
     {%- if optimizer != "none" %}
     const bool gradient_clipping,
     const double max_gradient,
@@ -196,11 +195,6 @@ class {{ autograd_func }} :
     {%- else %}
     const auto max_B_ = offsets.sym_size(0) / T;
     {%- endif %}
-
-    // NOTE: The `local_uvm_cache_stats` variable held by the nn.Module has dtype int32_t
-    // TODO: Hook up with frontend code
-    const auto uvm_cache_stats_ = uvm_cache_stats
-      .value_or(at::empty({0}, uvm_weights.options().dtype(at::kInt)));
 
     // TODO: don't guard here
     auto [info_B_num_bits, info_B_mask] = adjust_info_B_num_bits(max_B_.guard_int(__FILE__, __LINE__), T.guard_int(__FILE__, __LINE__));
@@ -289,6 +283,13 @@ class {{ autograd_func }} :
     const auto& flatten_dev_weights = dev_weights;
     {%- endif %}
 
+
+
+
+    const auto uvm_cache_stats = at::empty({0}, uvm_weights.options().dtype(at::kInt));
+
+
+
     {%- if not nobag %}
     {%- for weighted in [False, True] %}
     {%- set wdesc = "weighted" if weighted else "unweighted" %}
@@ -323,7 +324,7 @@ class {{ autograd_func }} :
             *indice_weights,
             {%- endif %}
             lxu_cache_locations,
-            uvm_cache_stats_,
+            uvm_cache_stats,
             output_dtype,
             {%- if vbe %}
             vbe_row_output_offsets,
@@ -354,7 +355,7 @@ class {{ autograd_func }} :
         indices,
         offsets,
         lxu_cache_locations,
-        uvm_cache_stats_,
+        uvm_cache_stats,
         output_dtype,
         /*is_experimental=*/false
       )
@@ -554,7 +555,6 @@ class {{ autograd_func }} :
         grad_indice_weights, // indice_weights
         Variable(), // feature_requires_grad
         Variable(), // lxu_cache_locations
-        Variable(), // uvm_cache_stats
         {%- if optimizer != "none" %}
         Variable(), // gradient_clipping
         Variable(), // max_gradient
@@ -628,7 +628,6 @@ class {{ autograd_func }} :
         Variable(), // indices
         Variable(), // offsets
         Variable(), // lxu_cache_locations
-        Variable(), // uvm_cache_stats
         {%- if optimizer != "none" %}
         Variable(), // gradient_clipping
         Variable(), // max_gradient
@@ -689,8 +688,7 @@ Tensor split_embedding_codegen_lookup_{{ optimizer }}_function(
     const int64_t vbe_output_size = -1,
     const bool is_experimental = false,
     const bool use_uniq_cache_locations_bwd = false,
-    const bool use_homogeneous_placements = false,
-    const c10::optional<Tensor>& uvm_cache_stats = c10::optional<Tensor>()
+    const bool use_homogeneous_placements = false
 ) {
   {%- if has_gpu_support %}
   {%- for vbe in ([True, False] if has_vbe_support else [False]) %}
@@ -740,7 +738,6 @@ Tensor split_embedding_codegen_lookup_{{ optimizer }}_function(
           feature_requires_grad,
           {%- endif %}
           lxu_cache_locations,
-          uvm_cache_stats,
           {%- if optimizer != "none" %}
           gradient_clipping,
           max_gradient,
@@ -805,9 +802,7 @@ TORCH_LIBRARY_FRAGMENT({{ lib_name }}, m) {
           "    int vbe_output_size=-1, "
           "    bool is_experimental=False, "
           "    bool use_uniq_cache_locations_bwd=False, "
-          "    bool use_homogeneous_placements=False, "
-          "    Tensor? uvm_cache_stats=None"
-          ") -> Tensor",
+          "    bool use_homogeneous_placements=False) -> Tensor",
           {PT2_COMPLIANT_TAG});
     // We're playing a funny trick here: we're using the autograd
     // implementation of the operator at all the dispatch keys.  This is OK

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -1282,8 +1282,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
         if self.gather_uvm_cache_stats:
             # Accumulate local_uvm_cache_stats (int32) into uvm_cache_stats (int64).
-            # We may want to do this accumulation atomically, but as it's only
-            # for monitoring, slightly inaccurate result may be acceptable.
+            # We may wanna do this accumulation atomically, but as it's only for monitoring,
+            # slightly inaccurate result may be acceptable.
             self.uvm_cache_stats = torch.add(
                 self.uvm_cache_stats, self.local_uvm_cache_stats
             )


### PR DESCRIPTION
Summary:
This diff is reverting D52679387
D52679387: [T158416182][fbgemm_gpu][Rebase 3b] Optimize the cache fetch for forward split, pt. 2A by q10 has been identified to be causing the following test failure:

Tests affected:
- [sigmoid/backend/test_gpu:unsharded_batched_fused_embedding_lookup_test - UnshardedBatchedFusedEmbeddingLookup.Basic](https://www.internalfb.com/intern/test/562950044538314/)

Here's the Multisect link:
https://www.internalfb.com/multisect/4116743
Here are the tasks that are relevant to this breakage:


We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Reviewed By: jspark1105

Differential Revision: D53074630


