### PR TITLE
Fix run_tbe_benchmark.py so that it benchmarks all shapes supplied to it

### DIFF
--- a/fbgemm_gpu/bench/run_tbe_benchmark.py
+++ b/fbgemm_gpu/bench/run_tbe_benchmark.py
@@ -15,6 +15,8 @@ def run(args):
         shapes = json.load(f)
 
     num_embeddings_list = ",".join([str(shape[0]) for shape in shapes])
+    bag_sizes = [args.bag_size] * len(shapes)
+    bag_size_list = ",".join([str(bag_size) for bag_size in bag_sizes])
     embedding_dims_list = ",".join([str(shape[1]) for shape in shapes])
 
     cmds = [
@@ -24,7 +26,7 @@ def run(args):
         "--batch-size",
         str(args.batch_size),
         "--bag-size-list",
-        str(args.bag_size),
+        bag_size_list,
         "--embedding-dim-list",
         embedding_dims_list,
         "--num-embeddings-list",


### PR DESCRIPTION
Summary: Previously `run_tbe_benchmark.py` will only supply one bag size to the `--bag-size-list` parameter of split_table_batched_embeddings_benchmark. This will cause the benchmark to only run the first shape supplied to it. This diff fixes this bug by supplying N copies of bag_size to `--bag-size-list` parameter (N = number of shapes).

Reviewed By: jspark1105

Differential Revision: D53276155


