### PR TITLE
Add int32 overflow unit test for TBE UVM caching

### DIFF
--- a/fbgemm_gpu/test/tbe/cache_common.py
+++ b/fbgemm_gpu/test/tbe/cache_common.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-ignore-all-errors[56]
+
+from typing import Tuple
+
+import numpy as np
+import torch
+from fbgemm_gpu.split_embedding_configs import SparseType
+
+from fbgemm_gpu.split_embedding_utils import round_up
+from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+    CacheAlgorithm,
+    EmbeddingLocation,
+)
+from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
+    ComputeDevice,
+    SplitTableBatchedEmbeddingBagsCodegen,
+)
+
+from hypothesis import Verbosity
+
+from .common import open_source
+
+if open_source:
+    # pyre-ignore[21]
+    from test_utils import gpu_unavailable, optests
+else:
+    from fbgemm_gpu.test.test_utils import gpu_unavailable, optests  # noqa: F401
+
+
+VERBOSITY: Verbosity = Verbosity.verbose
+
+
+def generate_cache_tbes(
+    T: int,
+    D: int,
+    B: int,
+    log_E: int,
+    L: int,
+    mixed: bool,
+    cache_algorithm: CacheAlgorithm = CacheAlgorithm.LRU,
+    prefetch_pipeline: bool = False,
+    use_int_weight: bool = False,
+    cache_sets: int = 0,
+    weights_precision: SparseType = SparseType.FP32,
+) -> Tuple[
+    SplitTableBatchedEmbeddingBagsCodegen,
+    SplitTableBatchedEmbeddingBagsCodegen,
+    int,
+    int,
+]:
+    lr = 1.0 if use_int_weight else 0.02
+    E = int(10**log_E)
+    D = D * 4
+    if not mixed:
+        Ds = [D] * T
+        Es = [E] * T
+    else:
+        Ds = [
+            round_up(np.random.randint(low=int(0.25 * D), high=int(1.0 * D)), 4)
+            for _ in range(T)
+        ]
+        Es = [np.random.randint(low=int(0.5 * E), high=int(2.0 * E)) for _ in range(T)]
+    managed = [EmbeddingLocation.MANAGED_CACHING] * T
+    if mixed:
+        average_D = sum(Ds) // T
+        for t, d in enumerate(Ds):
+            managed[t] = EmbeddingLocation.DEVICE if d < average_D else managed[t]
+    cc_ref = SplitTableBatchedEmbeddingBagsCodegen(
+        [
+            (
+                E,
+                D,
+                EmbeddingLocation.DEVICE,
+                ComputeDevice.CUDA,
+            )
+            for (E, D) in zip(Es, Ds)
+        ],
+        stochastic_rounding=False,
+        prefetch_pipeline=False,
+        learning_rate=lr,
+        weights_precision=weights_precision,
+    )
+    # Init the embedding weights
+    cc_ref.init_embedding_weights_uniform(-10.0, 10.0)
+
+    cc = SplitTableBatchedEmbeddingBagsCodegen(
+        [(E, D, M, ComputeDevice.CUDA) for (E, D, M) in zip(Es, Ds, managed)],
+        cache_algorithm=cache_algorithm,
+        stochastic_rounding=False,
+        prefetch_pipeline=prefetch_pipeline,
+        learning_rate=lr,
+        cache_sets=cache_sets,
+        weights_precision=weights_precision,
+        cache_precision=weights_precision,
+    )
+
+    if use_int_weight:
+        min_val = -20
+        max_val = +20
+        for param in cc_ref.split_embedding_weights():
+            p = torch.randint(
+                int(min_val),
+                int(max_val) + 1,
+                size=param.shape,
+                device=param.device,
+            )
+            param.data.copy_(p)
+
+    for t in range(T):
+        assert (
+            cc.split_embedding_weights()[t].size()
+            == cc_ref.split_embedding_weights()[t].size()
+        )
+        cc.split_embedding_weights()[t].data.copy_(cc_ref.split_embedding_weights()[t])
+
+    return (cc, cc_ref, min(Es), sum(Ds))

--- a/fbgemm_gpu/test/tbe/cache_overflow_test.py
+++ b/fbgemm_gpu/test/tbe/cache_overflow_test.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-ignore-all-errors[56]
+
+import logging
+import unittest
+
+import torch
+from fbgemm_gpu.split_embedding_configs import SparseType
+from fbgemm_gpu.split_embedding_utils import to_device
+from fbgemm_gpu.split_table_batched_embeddings_ops_training import DEFAULT_ASSOC
+
+from .cache_common import generate_cache_tbes, gpu_unavailable
+
+from .common import assert_torch_equal
+
+
+class CacheOverflowTest(unittest.TestCase):
+    @unittest.skipIf(*gpu_unavailable)
+    def test_cache_int32_overflow(self) -> None:
+        """
+        The unit test verifies that TBE with UVM caching can handle the cache
+        access correctly when the cache access offset is larger than max int32
+        """
+        D_fac = 1024 // 4
+        D = D_fac * 4
+        cache_sets = 10**6
+
+        current_device = torch.device(torch.cuda.current_device())
+        total_memory = torch.cuda.get_device_properties(current_device).total_memory
+        free_memory = total_memory - torch.cuda.memory_reserved(current_device)
+
+        # Weight and cache precisions are fixed to FP16
+        element_size = 2
+        # Adjust cache_sets based on free memory
+        while cache_sets * DEFAULT_ASSOC * D * element_size > free_memory:
+            cache_sets = cache_sets // 10
+
+        # Generate TBEs
+        cc, cc_ref, _, _ = generate_cache_tbes(
+            T=1,
+            D=D_fac,
+            B=128,
+            log_E=1,
+            L=1,
+            mixed=False,
+            prefetch_pipeline=True,
+            cache_sets=cache_sets,
+            weights_precision=SparseType.FP16,
+        )
+
+        # Accessing the last cache slot
+        last_cache_set = cache_sets - 1
+        cache_idx = last_cache_set * DEFAULT_ASSOC + (DEFAULT_ASSOC - 1)
+        if cache_idx * D < (2**31) - 1:
+            logging.warning("test_cache_int32_overflow does not test int32 overflowing")
+        else:
+            logging.info(f"Testing overflow cache offsets: {cache_idx * D}")
+
+        # Simply access index 0
+        indices = torch.tensor([0], dtype=torch.long)
+        offsets = torch.tensor([0, 1], dtype=torch.long)
+        indices = to_device(indices, use_cpu=False)
+        offsets = to_device(offsets, use_cpu=False)
+
+        # Force the cache locations to be the last row in the cache
+        assert cache_idx < cc.lxu_cache_weights.shape[0]
+        lxu_cache_locations = torch.tensor([cache_idx], dtype=torch.int)
+        lxu_cache_locations = to_device(lxu_cache_locations, use_cpu=False)
+
+        # Does prefetch into the cache
+        cc.lxu_cache_weights[cache_idx] = cc_ref.weights_dev.view(-1, D)[0]
+
+        # Mimic cache prefetching behavior
+        cc.timesteps_prefetched.append(0)
+        cc.lxu_cache_locations_list.append(lxu_cache_locations)
+
+        # Perform forward
+        output = cc(indices, offsets)
+        output_ref = cc_ref(indices, offsets)
+        assert_torch_equal(output, output_ref)
+
+        # Perform backward
+        grad_output = to_device(torch.randn(1, D), use_cpu=False)
+        output.backward(grad_output)
+        output_ref.backward(grad_output)
+        cc.flush()
+        assert_torch_equal(
+            cc.split_embedding_weights()[0], cc_ref.split_embedding_weights()[0]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/fbgemm_gpu/test/tbe/common.py
+++ b/fbgemm_gpu/test/tbe/common.py
@@ -62,3 +62,7 @@ def format_ref_tensors_in_mixed_B_layout(
     for r in range(num_ranks):
         concat_list += split_tensors[r]
     return torch.cat(concat_list, dim=0)
+
+
+def assert_torch_equal(tensor_a: torch.Tensor, tensor_b: torch.Tensor) -> None:
+    assert torch.equal(tensor_a, tensor_b)


### PR DESCRIPTION
Summary:
This diff introduces a unit test to verify that TBE with UVM caching
can handle the cache access correctly when the cache access offset is
larger than max int32

Differential Revision: D53300526


