### PR TITLE
PT2 compliant - fbgemm::jagged_dense_elementwise_add_jagged_output

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -681,6 +681,20 @@ std::tuple<Tensor, Tensor> jagged_dense_elementwise_mul_backward(
   return {x_values_grad, y_grad};
 }
 
+std::tuple<Tensor, std::vector<Tensor>>
+jagged_dense_elementwise_add_jagged_output_cpu(
+    const Tensor& x_values,
+    const std::vector<Tensor>& x_offsets,
+    const Tensor& y) {
+  // Convert to jagged
+  auto jagged_values =
+      dense_to_jagged_forward(y, x_offsets, c10::optional<at::SymInt>());
+
+  auto sum_values = x_values + jagged_values;
+
+  return {sum_values, x_offsets};
+}
+
 template <typename index_t, typename scalar_t>
 void dense_vec_jagged_2d_bmm(
     const at::TensorAccessor<scalar_t, 2>& v,
@@ -1764,7 +1778,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
       "jagged_dense_elementwise_add", fbgemm_gpu::jagged_dense_elementwise_add);
   DISPATCH_TO_CPU(
       "jagged_dense_elementwise_add_jagged_output",
-      fbgemm_gpu::jagged_dense_elementwise_add_jagged_output);
+      fbgemm_gpu::jagged_dense_elementwise_add_jagged_output_cpu);
   DISPATCH_TO_CPU(
       "jagged_dense_dense_elementwise_add_jagged_output_forward",
       fbgemm_gpu::jagged_dense_dense_elementwise_add_jagged_output_forward);

--- a/fbgemm_gpu/test/failures_dict.json
+++ b/fbgemm_gpu/test/failures_dict.json
@@ -168,28 +168,7 @@
         "status": "xfail"
       }
     },
-    "fbgemm::jagged_dense_elementwise_add_jagged_output": {
-      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_elementwise_binary": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_elementwise_binary_opt": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "JaggedTensorOpsTest.test_autograd_registration__test_jagged_elementwise_binary": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "JaggedTensorOpsTest.test_autograd_registration__test_jagged_elementwise_binary_opt": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "JaggedTensorOpsTest.test_faketensor__test_jagged_elementwise_binary": {
-        "comment": "This is a real failure, it just doesn't fail under all situations",
-        "status": "skip"
-      }
-    },
+    "fbgemm::jagged_dense_elementwise_add_jagged_output": {},
     "fbgemm::jagged_dense_elementwise_mul": {},
     "fbgemm::jagged_hash_size_cumsum": {
       "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_unique_indices": {


### PR DESCRIPTION
Summary:
This op previously didn't have an autograd registration.

a) We would see this warning:
```
/data/users/dberard/fbsource/buck-out/v2/gen/fbcode/6f27a84d3075b0d5/scripts/dberard/jplusd/__jagged_plus_dense__/jagged_plus_dense#link-tree/torch/autograd/graph.py:744: UserWarning: fbgemm::jagged_dense_elementwise_add_jagged_output: an autograd kernel was not registered to the Autograd key(s) but we are trying to backprop through it. This may lead to silently incorrect behavior. This behavior is deprecated and will be removed in a future version of PyTorch. If your operator is differentiable, please ensure you have registered an autograd kernel to the correct Autograd key (e.g. DispatchKey::Autograd, DispatchKey::CompositeImplicitAutograd). If your operator is not differentiable, or to squash this warning and use the previous behavior, please register torch::CppFunction::makeFallthrough() to DispatchKey::Autograd. (Triggered internally at fbcode/caffe2/torch/csrc/autograd/autograd_not_implemented_fallback.cpp:72.)
```
(b) Sometimes we would get aot_autograd partitioner issues because this op would not show up as an op returning a tensor

Previous issue: a single implementation for both CPU and Autograd was registered, which would call DenseToJaggedOp::apply(); a separate CUDA implementation was registered which did not have a backward registration.

Updated implementation:
- added a CPU implementation which does `jagged + dense_to_jagged(dense, offsets)`
- added an AutogradFunction implementation, which: in forward, redispatches to jagged_dense_elementwise_add_jagged_output; and in backward, redispatches to jagged_to_dense.

Differential Revision: D53650907


