### PR TITLE
Remove semicolon(s) from 3 files inc deeplearning/fbgemm/fb/FbgemmFP32.h

### DIFF
--- a/test/EmbeddingSpMDMTest.cc
+++ b/test/EmbeddingSpMDMTest.cc
@@ -62,7 +62,7 @@ class rowwiseSparseEmbeddingSpMDMTest
 
 class IndexRemapTest
     : public testing::TestWithParam<tuple<int, int, int, bool, bool>> {};
-}; // namespace
+} // namespace
 
 vector<int> prefetch_distances = {0, 16, 1000000};
 

--- a/test/EmbeddingSpMDMTestUtils.h
+++ b/test/EmbeddingSpMDMTestUtils.h
@@ -59,4 +59,4 @@ int CreateMappingTableForRowWiseSparsity(
     int num_rows,
     float sparsity);
 
-}; // namespace fbgemm
+} // namespace fbgemm


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt` found an extra semi

If the code compiles, this is safe to land.

Reviewed By: palmje, dmm-fb

Differential Revision: D53776044


