### PR TITLE
Pass cache stats to TBE only when using LRU

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -1021,7 +1021,13 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             # Pass the local_uvm_cache_stats bc only that information is
             # relevant for the current iteration
             uvm_cache_stats=(
-                self.local_uvm_cache_stats if self.gather_uvm_cache_stats else None
+                self.local_uvm_cache_stats
+                if (
+                    self.gather_uvm_cache_stats
+                    # Unique conflict misses are only collected when using CacheAlgorithm.LRU
+                    and self.cache_algorithm == CacheAlgorithm.LRU
+                )
+                else None
             ),
             output_dtype=self.output_dtype,
             vbe_metadata=vbe_metadata,


### PR DESCRIPTION
Summary:
This diff introduces a condition to pass `local_uvm_cache_stats` to
TBE only when using the LRU policy.

When `local_uvm_cache_stats` is passed to TBE, it utilizes the cache
unique conflict misses information to determine whether to load data
entirely or partially from cache, UVM, or HBM.  If this information is
inaccurate, TBE may produce an incorrect output.  Since the unique
conflict misses stat is only collected during the cache lookup only
when the LRU cache eviction policy is used, `local_uvm_cache_stats`
should not be passed to TBE when other cache eviction policies are
used.

Differential Revision: D54237731


