### PR TITLE
Remove INT8 weight/output support from TBE GPU training

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_kernel_cta_template.cu
@@ -505,7 +505,7 @@ split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc 
 
 {%- macro bulk_template_instantiations(kMaxVecsPerThread, kThreadGroupSize) %}
     {%- for grad_type in ['float', 'at::Half'] %}
-    {%- for emb_type in ['uint8_t', 'float', 'at::Half'] %}
+    {%- for emb_type in ['float', 'at::Half'] %}
     {%- for cache_type in ['float', 'at::Half'] %}
         {{ template_instantiation(emb_type, grad_type, cache_type, kMaxVecsPerThread, kThreadGroupSize) }}
     {%- endfor %}

--- a/fbgemm_gpu/codegen/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_kernel_warp_template.cu
@@ -341,7 +341,7 @@ split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc 
 
 {%- macro bulk_template_instantiations(kMaxVecsPerThread, kThreadGroupSize) %}
     {%- for grad_type in ['float', 'at::Half'] %}
-    {%- for emb_type in ['uint8_t', 'float', 'at::Half'] %}
+    {%- for emb_type in ['float', 'at::Half'] %}
     {%- for cache_type in ['float', 'at::Half'] %}
         {{ template_instantiation(emb_type, grad_type, cache_type, kMaxVecsPerThread, kThreadGroupSize) }}
     {%- endfor %}

--- a/fbgemm_gpu/codegen/embedding_forward_split_kernel_nobag_small_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_kernel_nobag_small_template.cu
@@ -193,8 +193,8 @@ batch_index_select_dim0_codegen_forward_small_kernel(
     embedding_forward_split_template.cu
 */
 
-{%- for output_type in ['uint8_t', 'at::Half', 'float'] %}
-{%- for emb_type in ['uint8_t', 'float', 'at::Half'] %}
+{%- for output_type in ['float', 'at::Half'] %}
+{%- for emb_type in ['float', 'at::Half'] %}
 {%- for cache_type in ['float', 'at::Half'] %}
 {%- for kEmbeddingSize in [4, 8, 16, 32] %}
 {%- set index_type = 'int64_t' %}

--- a/fbgemm_gpu/codegen/embedding_forward_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_kernel_template.cu
@@ -548,9 +548,9 @@ batch_index_select_dim0_codegen_forward_kernel
 {%- endmacro %}
 
 {%- macro bulk_template_instantiations(use_cache, kMaxVecsPerThread, kThreadGroupSize) %}
-    {%- for emb_type in ['uint8_t', 'float', 'at::Half'] %}
+    {%- for emb_type in ['float', 'at::Half'] %}
     {%- for cache_type in ['float', 'at::Half'] %}
-    {%- for output_type in ['uint8_t', 'at::Half', 'float'] %}
+    {%- for output_type in ['float', 'at::Half'] %}
         {{ template_instantiation(emb_type, cache_type, output_type, use_cache, kMaxVecsPerThread, kThreadGroupSize) }}
     {%- endfor %}
     {%- endfor %}

--- a/fbgemm_gpu/codegen/embedding_forward_split_kernel_v2_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_kernel_v2_template.cu
@@ -973,8 +973,8 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel(
     embedding_forward_split_template.cu
 */
 
-{%- for output_type in ['uint8_t', 'at::Half', 'float'] %}
-{%- for emb_type in ['uint8_t', 'float', 'at::Half'] %}
+{%- for output_type in ['float', 'at::Half'] %}
+{%- for emb_type in ['float', 'at::Half'] %}
 {%- for cache_type in ['float', 'at::Half'] %}
 {%- for use_cache in ['true', 'false'] %}
 

--- a/fbgemm_gpu/include/fbgemm_gpu/dispatch_macros.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/dispatch_macros.h
@@ -35,8 +35,6 @@
   at::ScalarType _cache_t = ::detail::scalar_type(cache_enum_type);           \
   switch (_emb_t) {                                                           \
     PRIVATE_CASE_TYPE_EMB(                                                    \
-        at::ScalarType::Byte, _cache_t, uint8_t, NAME, __VA_ARGS__)           \
-    PRIVATE_CASE_TYPE_EMB(                                                    \
         at::ScalarType::Float, _cache_t, float, NAME, __VA_ARGS__)            \
     PRIVATE_CASE_TYPE_EMB(                                                    \
         at::ScalarType::Half, _cache_t, at::Half, NAME, __VA_ARGS__)          \
@@ -72,13 +70,6 @@
     const auto& cache_type = CACHE_TYPE;                           \
     at::ScalarType _output_t = ::detail::scalar_type(output_type); \
     switch (_output_t) {                                           \
-      PRIVATE_CASE_TYPE_OUTPUT(                                    \
-          at::ScalarType::Byte,                                    \
-          emb_type,                                                \
-          cache_type,                                              \
-          uint8_t,                                                 \
-          NAME,                                                    \
-          __VA_ARGS__)                                             \
       PRIVATE_CASE_TYPE_OUTPUT(                                    \
           at::ScalarType::Half,                                    \
           emb_type,                                                \
@@ -157,8 +148,6 @@
   case grad_enum_type: {                                                   \
     using grad_t = grad_cxx_type;                                          \
     switch (_emb_t) {                                                      \
-      PRIVATE_CASE_TYPE_EMB(                                               \
-          at::ScalarType::Byte, _cache_t, uint8_t, NAME, __VA_ARGS__)      \
       PRIVATE_CASE_TYPE_EMB(                                               \
           at::ScalarType::Float, _cache_t, float, NAME, __VA_ARGS__)       \
       PRIVATE_CASE_TYPE_EMB(                                               \

--- a/fbgemm_gpu/test/tbe/training/forward_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_test.py
@@ -394,7 +394,7 @@ class ForwardTest(unittest.TestCase):
             False,  # use_experimental_tbe
         )
 
-    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(True, "INT8 support is disabled")
     def test_forward_gpu_no_cache_int8(
         self,
     ) -> None:
@@ -570,7 +570,7 @@ class ForwardTest(unittest.TestCase):
             use_experimental_tbe,
         )
 
-    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(True, "INT8 support is disabled")
     @given(
         cache_algorithm=st.sampled_from(CacheAlgorithm),
     )
@@ -773,7 +773,7 @@ class ForwardTest(unittest.TestCase):
         B=st.integers(min_value=1, max_value=128),
         log_E=st.integers(min_value=3, max_value=5),
         L=st.integers(min_value=0, max_value=20),
-        output_dtype=st.sampled_from([SparseType.FP16, SparseType.INT8]),
+        output_dtype=st.sampled_from([SparseType.FP16]),
     )
     @settings(
         verbosity=VERBOSITY,

--- a/fbgemm_gpu/test/tbe/utils/split_embeddings_test.py
+++ b/fbgemm_gpu/test/tbe/utils/split_embeddings_test.py
@@ -381,9 +381,7 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
         T=st.integers(min_value=1, max_value=5),
         D=st.integers(min_value=2, max_value=128),
         log_E=st.integers(min_value=2, max_value=3),
-        weights_precision=st.sampled_from(
-            [SparseType.FP16, SparseType.FP32, SparseType.INT8]
-        ),
+        weights_precision=st.sampled_from([SparseType.FP16, SparseType.FP32]),
         mixed=st.booleans(),
         use_cache=st.booleans(),
         output_dtype=st.sampled_from([SparseType.FP32, SparseType.FP16]),


### PR DESCRIPTION
Summary:
This diff removes the INT8 dispatcher for weight and output types from
TBE.  We keep the implementation and tests in case we would like to
re-enable it in the future.

Differential Revision: D54400909


