### PR TITLE
Support CPU for split_table_batched_embeddings_benchmark with device

### DIFF
--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -258,6 +258,7 @@ def device(  # noqa C901
         weighted=weighted,
         requests_data_file=requests_data_file,
         tables=tables,
+        use_cpu=not torch.cuda.is_available(),
     )
 
     # forward


### PR DESCRIPTION
Summary:
This diff adds support for CPU for the `split_table_batched_embeddings_benchmark` benchmark in the `fbgemm_gpu` library. The code change in the `split_table_batched_embeddings_benchmark.py` file sets the `use_cpu` parameter to `True` if the GPU is not available, allowing the benchmark to run on the CPU instead. This will enable users to run the benchmark on CPU-only machines or machines without GPUs.

... according to our GenAI.

`use_cpu` has already been partially supported for `device()` (e.g., `use_cpu=not torch.cuda.is_available()` is passed to `DenseTableBatchedEmbeddingBagsCodegen()` in this `device()` benchmark, so it makes sense to extend `device()` a little bit.

It won't affect any existing functionality.

Differential Revision: D54401117


