### PR TITLE
Disable dynamo testing in TBE

### DIFF
--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_test.py
@@ -119,6 +119,9 @@ class BackwardAdagradTest(unittest.TestCase):
             )
         )
 
+        # Disable dynamo tests due to unknown failure
+        assume(not compile)
+
         emb_op = SplitTableBatchedEmbeddingBagsCodegen
 
         if pooling_mode == PoolingMode.SUM:


### PR DESCRIPTION
Summary: This diff disables dynamo testing in TBE unit tests.

Differential Revision: D54455966


