### PR TITLE
Add back float support to `asynchronous_complete_cumsum_cpu`

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
@@ -1227,7 +1227,7 @@ Tensor asynchronous_complete_cumsum_cpu(const Tensor& t_in) {
       ? at::empty({t_in.numel() + 1}, t_in.options())
       : at::empty({t_in.size(0), t_in.size(1) + 1}, t_in.options());
 
-  FBGEMM_DISPATCH_INTEGRAL_TYPES(
+  FBGEMM_DISPATCH_ALL_TYPES(
       t_in_contig->scalar_type(),
       "asynchronous_complete_cumsum_cpu_kernel",
       [&] {


### PR DESCRIPTION
Summary: - Add back float support to `asynchronous_complete_cumsum_cpu`

Differential Revision: D54497745


