### PR TITLE
pyre lint fix

### DIFF
--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -2413,7 +2413,7 @@ def hashtable(  # noqa C901
     )
 
     if use_cpu:
-        ht = torch.classes.fbgemm.PrunedMapCPU()
+        ht = torch.classes.fbgemm.PrunedMapCPU()  # pyre-ignore
         ht.insert(chosen_indices, dense_indices, offsets, T)
 
         time_per_iter = benchmark_requests(

--- a/fbgemm_gpu/bench/ssd_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/ssd_table_batched_embeddings_benchmark.py
@@ -108,7 +108,7 @@ def benchmark_read_write(
     elem_size = 4
 
     with tempfile.TemporaryDirectory(prefix=ssd_prefix) as ssd_directory:
-        ssd_db = torch.classes.fbgemm.EmbeddingRocksDBWrapper(
+        ssd_db = torch.classes.fbgemm.EmbeddingRocksDBWrapper(  # pyre-ignore
             ssd_directory,
             num_shards,
             num_threads,


### PR DESCRIPTION
Summary:
Remove some pyre noise from dynamically loaded classes.

```
pyre -l deeplearning/fbgemm/fbgemm_gpu/
ƛ Found 4 type errors!
deeplearning/fbgemm/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py:2414:13 Undefined attribute [16]: Module `torch.classes` has no attribute `fbgemm`.
deeplearning/fbgemm/fbgemm_gpu/bench/ssd_table_batched_embeddings_benchmark.py:111:17 Undefined attribute [16]: Module `torch.classes` has no attribute `fbgemm`.
deeplearning/fbgemm/fbgemm_gpu/fb/test/preproc_oplist_legacy_comparison_test.py:259:15 Undefined attribute [16]: Module `torch.classes` has no attribute `fb`.
deeplearning/fbgemm/fbgemm_gpu/fb/test/preproc_oplist_legacy_comparison_test.py:259:15 Undefined attribute [16]: Module `torch.classes` has no attribute `fb`.
```

Reviewed By: sryap

Differential Revision: D54444971


