### PR TITLE
Add VBE support in UVM caching training

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
@@ -432,7 +432,11 @@ Tensor int_nbit_split_embedding_uvm_caching_codegen_lookup_function(
 
     // Linearize indices.
     auto linear_cache_indices = linearize_cache_indices_cuda(
-        cache_hash_size_cumsum.value(), indices, offsets);
+        cache_hash_size_cumsum.value(),
+        indices,
+        offsets,
+        /*B_offsets=*/c10::optional<Tensor>(),
+        /*max_B=*/-1);
 
     bool gather_uvm_stats = false;
     // populate_uvm_stats indicates whether to calculate cache related ratios,

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh
@@ -56,9 +56,11 @@ int64_t host_lxu_cache_slot(int64_t h_in, int64_t C);
 ///@ingroup table-batched-embed-cuda
 /// Linearize the indices of all tables to make it be unique
 at::Tensor linearize_cache_indices_cuda(
-    at::Tensor cache_hash_size_cumsum,
-    at::Tensor indices,
-    at::Tensor offsets);
+    const at::Tensor& cache_hash_size_cumsum,
+    const at::Tensor& indices,
+    const at::Tensor& offsets,
+    const c10::optional<at::Tensor>& B_offsets,
+    const int64_t max_B);
 
 ///@ingroup table-batched-embed-cuda
 /// Linearize the indices of all tables to make it be unique.

--- a/fbgemm_gpu/src/split_embeddings_cache/common.h
+++ b/fbgemm_gpu/src/split_embeddings_cache/common.h
@@ -26,9 +26,11 @@ using Tensor = at::Tensor;
 namespace fbgemm_gpu {
 
 Tensor linearize_cache_indices_cpu(
-    Tensor cache_hash_size_cumsum,
-    Tensor indices,
-    Tensor offsets);
+    const Tensor& cache_hash_size_cumsum,
+    const Tensor& indices,
+    const Tensor& offsets,
+    const c10::optional<Tensor>& B_offsets,
+    const int64_t max_B);
 
 Tensor linearize_cache_indices_from_row_idx_cpu(
     Tensor cache_hash_size_cumsum,

--- a/fbgemm_gpu/src/split_embeddings_cache/linearize_cache_indices.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/linearize_cache_indices.cpp
@@ -13,9 +13,11 @@ using Tensor = at::Tensor;
 namespace fbgemm_gpu {
 
 DLL_PUBLIC Tensor linearize_cache_indices_cpu(
-    Tensor cache_hash_size_cumsum,
-    Tensor indices,
-    Tensor offsets) {
+    const Tensor& cache_hash_size_cumsum,
+    const Tensor& indices,
+    const Tensor& offsets,
+    const c10::optional<Tensor>& B_offsets,
+    const int64_t max_B) {
   return at::empty_like(indices);
 }
 

--- a/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
@@ -12,7 +12,7 @@ namespace {
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
-      "linearize_cache_indices(Tensor cache_hash_size_cumsum, Tensor indices, Tensor offsets) -> Tensor");
+      "linearize_cache_indices(Tensor cache_hash_size_cumsum, Tensor indices, Tensor offsets, Tensor? B_offsets=None, int max_B=-1) -> Tensor");
   m.def(
       "linearize_cache_indices_from_row_idx(Tensor cache_hash_size_cumsum, Tensor update_table_indices, Tensor update_row_indices) -> Tensor");
   m.def(


### PR DESCRIPTION
Summary:
This diff adds VBE (variable batch size embedding) support to TBE with
UVM caching, specifically adding the VBE support in
`linearize_cache_indices`.

Differential Revision: D54512865


