### PR TITLE
Add VBE support in UVM caching training

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_host.cpp
@@ -432,7 +432,11 @@ Tensor int_nbit_split_embedding_uvm_caching_codegen_lookup_function(
 
     // Linearize indices.
     auto linear_cache_indices = linearize_cache_indices_cuda(
-        cache_hash_size_cumsum.value(), indices, offsets);
+        cache_hash_size_cumsum.value(),
+        indices,
+        offsets,
+        /*B_offsets=*/c10::optional<Tensor>(),
+        /*max_B=*/-1);
 
     bool gather_uvm_stats = false;
     // populate_uvm_stats indicates whether to calculate cache related ratios,

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -300,6 +300,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
     record_cache_metrics: RecordCacheMetrics
     uvm_cache_stats: torch.Tensor
     local_uvm_cache_stats: torch.Tensor
+    _vbe_B_offsets: Optional[torch.Tensor]
+    _vbe_max_B: int
 
     def __init__(  # noqa C901
         self,
@@ -889,17 +891,19 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
         return self.table_wise_cache_miss
 
-    def forward(  # noqa: C901
-        self,
-        indices: Tensor,
-        offsets: Tensor,
-        per_sample_weights: Optional[Tensor] = None,
-        feature_requires_grad: Optional[Tensor] = None,
-        # 2D tensor of batch size for each rank and feature.
-        # Shape (number of features, number of ranks)
-        batch_size_per_feature_per_rank: Optional[List[List[int]]] = None,
-        total_unique_indices: Optional[int] = None,
-    ) -> Tensor:
+    def generate_vbe_metadata(
+        self, batch_size_per_feature_per_rank: Optional[List[List[int]]] = None
+    ) -> invokers.lookup_args.VBEMetadata:
+        """
+        Generate VBE metadata based on batch_size_per_feature_per_rank.
+        Metadata includes:
+        1) B_offsets - A tensor that contains batch size offsets for each feature
+        2) output_offsets_feature_rank - A tensor that contains output offsets for each feature
+        3) B_offsets_per_rank_per_feature - A tensor that contains batch size offsets for each feature and rank
+        4) max_B - The maximum batch size for all features
+        5) max_B_feature_rank - The maximum batch size for all ranks and features
+        6) output_size - The output size (number of elements)
+        """
         if batch_size_per_feature_per_rank is not None:
             assert (
                 self.optimizer == OptimType.EXACT_ROWWISE_ADAGRAD
@@ -982,6 +986,21 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 max_B_feature_rank=-1,
                 output_size=-1,
             )
+        return vbe_metadata
+
+    def forward(  # noqa: C901
+        self,
+        indices: Tensor,
+        offsets: Tensor,
+        per_sample_weights: Optional[Tensor] = None,
+        feature_requires_grad: Optional[Tensor] = None,
+        # 2D tensor of batch size for each rank and feature.
+        # Shape (number of features, number of ranks)
+        batch_size_per_feature_per_rank: Optional[List[List[int]]] = None,
+        total_unique_indices: Optional[int] = None,
+    ) -> Tensor:
+        # Generate VBE metadata
+        vbe_metadata = self.generate_vbe_metadata(batch_size_per_feature_per_rank)
 
         (indices, offsets) = indices.long(), offsets.long()
         # Force casting per_sample_weights to float
@@ -1000,13 +1019,15 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 max_B=vbe_metadata.max_B,
             )
 
-        # Storing indices and offsets for linear_cache_indices recomputation
+        # Storing tensors for linear_cache_indices recomputation
         self._indices = indices
         self._offsets = offsets
+        self._vbe_B_offsets = vbe_metadata.B_offsets
+        self._vbe_max_B = vbe_metadata.max_B
 
         self.step += 1
         if len(self.timesteps_prefetched) == 0:
-            self._prefetch(indices, offsets)
+            self._prefetch(indices, offsets, vbe_metadata)
 
         if len(self.timesteps_prefetched) > 0:
             self.timesteps_prefetched.pop(0)
@@ -1223,6 +1244,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         indices: Tensor,
         offsets: Tensor,
         forward_stream: Optional[torch.cuda.Stream] = None,
+        vbe_metadata: Optional[invokers.lookup_args.VBEMetadata] = None,
     ) -> None:
         if self.prefetch_stream is None and forward_stream is not None:
             self.prefetch_stream = torch.cuda.current_stream()
@@ -1230,11 +1252,16 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 self.prefetch_stream != forward_stream
             ), "prefetch_stream and forward_stream should not be the same stream"
 
-        self._prefetch(indices, offsets)
+        self._prefetch(indices, offsets, vbe_metadata)
         if forward_stream is not None:
             self._prefetch_tensors_record_stream(forward_stream)
 
-    def _prefetch(self, indices: Tensor, offsets: Tensor) -> None:
+    def _prefetch(
+        self,
+        indices: Tensor,
+        offsets: Tensor,
+        vbe_metadata: Optional[invokers.lookup_args.VBEMetadata] = None,
+    ) -> None:
         self.timestep += 1
         self.timesteps_prefetched.append(self.timestep)
         if not self.lxu_cache_weights.numel():
@@ -1250,6 +1277,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             self.cache_hash_size_cumsum,
             indices,
             offsets,
+            vbe_metadata.B_offsets if vbe_metadata is not None else None,
+            vbe_metadata.max_B if vbe_metadata is not None else -1,
         )
 
         if (
@@ -1664,6 +1693,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.lxu_cache_locations = self.lxu_cache_locations_empty
         self._indices = self.lxu_cache_locations_empty
         self._offsets = self.lxu_cache_locations_empty
+        self._vbe_B_offsets = self.lxu_cache_locations_empty
+        self._vbe_max_B = -1
         self.prefetch_stream: Optional[torch.cuda.Stream] = None
 
         self._init_uvm_cache_stats()
@@ -1886,6 +1917,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             self.cache_hash_size_cumsum,
             self._indices,
             self._offsets,
+            self._vbe_B_offsets,
+            self._vbe_max_B,
         )
         (
             linear_unique_indices,

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh
@@ -56,9 +56,11 @@ int64_t host_lxu_cache_slot(int64_t h_in, int64_t C);
 ///@ingroup table-batched-embed-cuda
 /// Linearize the indices of all tables to make it be unique
 at::Tensor linearize_cache_indices_cuda(
-    at::Tensor cache_hash_size_cumsum,
-    at::Tensor indices,
-    at::Tensor offsets);
+    const at::Tensor& cache_hash_size_cumsum,
+    const at::Tensor& indices,
+    const at::Tensor& offsets,
+    const c10::optional<at::Tensor>& B_offsets,
+    const int64_t max_B);
 
 ///@ingroup table-batched-embed-cuda
 /// Linearize the indices of all tables to make it be unique.

--- a/fbgemm_gpu/src/split_embeddings_cache/common.h
+++ b/fbgemm_gpu/src/split_embeddings_cache/common.h
@@ -26,9 +26,11 @@ using Tensor = at::Tensor;
 namespace fbgemm_gpu {
 
 Tensor linearize_cache_indices_cpu(
-    Tensor cache_hash_size_cumsum,
-    Tensor indices,
-    Tensor offsets);
+    const Tensor& cache_hash_size_cumsum,
+    const Tensor& indices,
+    const Tensor& offsets,
+    const c10::optional<Tensor>& B_offsets,
+    const int64_t max_B);
 
 Tensor linearize_cache_indices_from_row_idx_cpu(
     Tensor cache_hash_size_cumsum,

--- a/fbgemm_gpu/src/split_embeddings_cache/linearize_cache_indices.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/linearize_cache_indices.cpp
@@ -13,9 +13,11 @@ using Tensor = at::Tensor;
 namespace fbgemm_gpu {
 
 DLL_PUBLIC Tensor linearize_cache_indices_cpu(
-    Tensor cache_hash_size_cumsum,
-    Tensor indices,
-    Tensor offsets) {
+    const Tensor& cache_hash_size_cumsum,
+    const Tensor& indices,
+    const Tensor& offsets,
+    const c10::optional<Tensor>& B_offsets,
+    const int64_t max_B) {
   return at::empty_like(indices);
 }
 

--- a/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
@@ -12,7 +12,7 @@ namespace {
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
-      "linearize_cache_indices(Tensor cache_hash_size_cumsum, Tensor indices, Tensor offsets) -> Tensor");
+      "linearize_cache_indices(Tensor cache_hash_size_cumsum, Tensor indices, Tensor offsets, Tensor? B_offsets=None, int max_B=-1) -> Tensor");
   m.def(
       "linearize_cache_indices_from_row_idx(Tensor cache_hash_size_cumsum, Tensor update_table_indices, Tensor update_row_indices) -> Tensor");
   m.def(

--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_test.py
@@ -114,7 +114,6 @@ class BackwardAdagradTest(unittest.TestCase):
                 weights_precision != SparseType.INT8
                 and output_dtype != SparseType.INT8
                 and not use_cpu
-                and not use_cache
                 and pooling_mode != PoolingMode.NONE
             )
         )

--- a/fbgemm_gpu/test/tbe/training/backward_sgd_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_sgd_test.py
@@ -94,7 +94,6 @@ class BackwardSGDTest(unittest.TestCase):
                 weights_precision != SparseType.INT8
                 and output_dtype != SparseType.INT8
                 and not use_cpu
-                and not use_cache
                 and pooling_mode != PoolingMode.NONE
             )
         )

--- a/fbgemm_gpu/test/tbe/training/forward_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_test.py
@@ -108,7 +108,6 @@ class ForwardTest(unittest.TestCase):
                 weights_precision != SparseType.INT8
                 and output_dtype != SparseType.INT8
                 and not use_cpu
-                and not use_cache
                 and pooling_mode != PoolingMode.NONE
             )
         )
@@ -676,9 +675,12 @@ class ForwardTest(unittest.TestCase):
         )
         if pooling_mode == PoolingMode.NONE:
             mixed = False
+            mixed_B = False
         else:
             mixed = random.choice([True, False])
-        mixed_B = False
+            mixed_B = (
+                random.choice([True, False]) if not use_experimental_tbe else False
+            )
         if pooling_mode == PoolingMode.SUM:
             weighted = random.choice([True, False])
         else:
@@ -743,9 +745,12 @@ class ForwardTest(unittest.TestCase):
         )
         if pooling_mode == PoolingMode.NONE:
             mixed = False
+            mixed_B = False
         else:
             mixed = random.choice([True, False])
-        mixed_B = False
+            mixed_B = (
+                random.choice([True, False]) if not use_experimental_tbe else False
+            )
         if pooling_mode == PoolingMode.SUM:
             weighted = random.choice([True, False])
         else:


### PR DESCRIPTION
Summary:
This diff adds VBE (variable batch size embedding) support to TBE with
UVM caching, specifically adding the VBE support in
`linearize_cache_indices`.

Backend: D54512865
Frontend: D54546141 (this diff)

Differential Revision: D54546141


