### PR TITLE
SymIntify torchrec variable batch size path

### DIFF
--- a/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_backward_split_host_template.cpp
@@ -202,8 +202,22 @@ class {{ autograd_func }} :
     const auto uvm_cache_stats_ = uvm_cache_stats
       .value_or(at::empty({0}, uvm_weights.options().dtype(at::kInt)));
 
-    // TODO: don't guard here
-    auto [info_B_num_bits, info_B_mask] = adjust_info_B_num_bits(max_B_.guard_int(__FILE__, __LINE__), T.guard_int(__FILE__, __LINE__));
+    // Default values for Dynamo tracing
+    // SymInt does not support bitshifts operator
+    // Constanting info_B_num_bits, info_B_mask for Dynamo for now.
+    int32_t info_B_num_bits = DEFAULT_INFO_B_NUM_BITS;
+    uint32_t info_B_mask = (1u << info_B_num_bits) - 1;
+    if (max_B_.is_symbolic()) {
+      int32_t info_B_num_bits = 22;
+      uint32_t info_B_mask = (1u << info_B_num_bits) - 1;
+
+      // TODO(ivankobzarev): Guarding Dynamo that T and B fits in constanted number of bits.
+      // TORCH_CHECK(max_B_ < 1u << info_B_num_bits)
+      // TORCH_CHECK(T < 1u << (DEFAULT_INFO_NUM_BITS - info_B_num_bits))
+    } else {
+      // TODO: don't guard here
+      std::tie(info_B_num_bits, info_B_mask) = adjust_info_B_num_bits(max_B_.guard_int(__FILE__, __LINE__), T.guard_int(__FILE__, __LINE__));
+    }
 
     {%- if vbe %}
     static auto generate_vbe_metadata_op =

--- a/fbgemm_gpu/codegen/embedding_forward_split_meta_template.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_split_meta_template.cpp
@@ -78,7 +78,7 @@ Tensor
     {%- if vbe %}
     const Tensor& vbe_row_output_offsets,
     const Tensor& vbe_b_t_map,
-    const int64_t vbe_output_size,
+    const c10::SymInt vbe_output_size,
     const int64_t info_B_num_bits, // int32_t
     const int64_t info_B_mask_int64, // uint32_t
     {%- endif %}

--- a/fbgemm_gpu/codegen/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_split_template.cu
@@ -747,7 +747,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
           {%- if vbe %}
           "    Tensor vbe_row_output_offsets, "
           "    Tensor vbe_b_t_map, "
-          "    int vbe_output_size, "
+          "    SymInt vbe_output_size, "
           "    int info_B_num_bits, "
           "    int info_B_mask_int64, "
           {%- endif %}


### PR DESCRIPTION
Summary:
Variable Batch parameters are SymInt in dynamo tracing.

SymInt does not support bit shifts => Skipping adjust_info_B_num_bits logic for dynamo case (when SymInt arrive into kernel) defaulting the values.

fbcode/deeplearning/fbgemm/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py - changing List comprehension with python sum to torch.sum. 

Removing int() convertions for SymInt.

Adding torch._check() for VB parameters

Differential Revision: D54554735


