### PR TITLE
Remove unused args in linearize cache indices CPU ops

### DIFF
--- a/fbgemm_gpu/src/split_embeddings_cache/linearize_cache_indices.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/linearize_cache_indices.cpp
@@ -13,17 +13,17 @@ using Tensor = at::Tensor;
 namespace fbgemm_gpu {
 
 DLL_PUBLIC Tensor linearize_cache_indices_cpu(
-    const Tensor& cache_hash_size_cumsum,
+    const Tensor& /*cache_hash_size_cumsum*/,
     const Tensor& indices,
-    const Tensor& offsets,
-    const c10::optional<Tensor>& B_offsets,
-    const int64_t max_B) {
+    const Tensor& /*offsets*/,
+    const c10::optional<Tensor>& /*B_offsets*/,
+    const int64_t /*max_B*/) {
   return at::empty_like(indices);
 }
 
 DLL_PUBLIC Tensor linearize_cache_indices_from_row_idx_cpu(
-    Tensor cache_hash_size_cumsum,
-    Tensor update_table_indices,
+    Tensor /*cache_hash_size_cumsum*/,
+    Tensor /*update_table_indices*/,
     Tensor update_row_indices) {
   return at::empty_like(update_row_indices);
 }


### PR DESCRIPTION
Summary: This is a follow up diff that fixes linter complaints in D54512865

Reviewed By: q10

Differential Revision: D54608225
