### PR TITLE
Remove unused variables in deeplearning/fbgemm/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
+++ b/fbgemm_gpu/codegen/embedding_forward_split_cpu.cpp
@@ -384,7 +384,7 @@ void csr2csc_template_(
         fbgemm::fbgemmAlignedAlloc(64, nnz * sizeof(float)));
   }
 
-  int column_ptr_curr = 0;
+  [[maybe_unused]] int column_ptr_curr = 0;
   bool is_shared_table =
       table_to_feature_offset[1] > table_to_feature_offset[0] + 1;
   auto NS = csr_offsets[table_to_feature_offset[1] * B] -


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: sryap

Differential Revision: D54378367


