### PR TITLE
fbgemm workaround for MSVC compiler bug

### DIFF
--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -802,6 +802,8 @@ std::pair<K*, V*> radix_sort_parallel(
       std::swap(input_keys, output_keys);
       std::swap(input_values, output_values);
 #pragma omp barrier
+      {} // The empty brackets are to get around a MSVC VS2022 C++20
+         // compiler bug
     }
   }
 #ifdef _MSC_VER


### PR DESCRIPTION
Summary:
There's a compiler bug in VS2022 when using /std:c++20 and `#pragma omp barrier` before a `}`. See https://developercommunity.visualstudio.com/t/pragma-omp-barrier-ignored-for-std:c/10339559?q=known+issues+in+16.11&stateGroup=active&ftype=problem&sort=votes

This has now been fixed in more recent versions of the MSVC toolchain, but updating the toolchain is a lot more involved then this workaround for now.

Differential Revision: D54707715


