### PR TITLE
Refactor TBE generate requests return type

### DIFF
--- a/fbgemm_gpu/test/tbe/cache/cache_test.py
+++ b/fbgemm_gpu/test/tbe/cache/cache_test.py
@@ -20,6 +20,7 @@ from fbgemm_gpu.split_embedding_configs import SparseType
 from fbgemm_gpu.split_embedding_utils import (
     generate_requests,
     get_table_batched_offsets_from_dense,
+    TBERequest,
     to_device,
 )
 from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
@@ -91,7 +92,8 @@ class CacheTest(unittest.TestCase):
         requests = generate_requests(iters, B, T, L, min_Es, reuse=0.1)
         grad_output = torch.randn(B, sum_Ds).cuda()
 
-        for indices, offsets, _ in requests:
+        for req in requests:
+            indices, offsets = req.unpack_2()
             output = cc(indices, offsets)
             output_ref = cc_ref(indices, offsets)
             assert_cache(output, output_ref, stochastic_rounding)
@@ -167,19 +169,19 @@ class CacheTest(unittest.TestCase):
 
         def _prefetch(
             cc: SplitTableBatchedEmbeddingBagsCodegen,
-            batch: Optional[Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]],
+            batch: Optional[TBERequest],
         ) -> None:
             if not batch:
                 return
             context_stream = prefetch_stream if prefetch_stream else cur_stream
             stream = cur_stream if prefetch_stream else None
-            indices, offsets, _ = batch
+            indices, offsets = batch.unpack_2()
             with torch.cuda.stream(context_stream):
                 cc.prefetch(indices, offsets, stream)
 
         _prefetch(cc, batch_i)
         while batch_i:
-            indices, offsets, _ = batch_i
+            indices, offsets = batch_i.unpack_2()
             batch_ip1 = next(req_iter, None)
             if prefetch_stream:
                 cur_stream.wait_stream(prefetch_stream)
@@ -193,7 +195,8 @@ class CacheTest(unittest.TestCase):
             batch_ip1 = None
         cc.flush()
 
-        for indices, offsets, _ in requests:
+        for req in requests:
+            indices, offsets = req.unpack_2()
             output_ref = cc_ref(indices, offsets)
             output_ref.backward(grad_output)
 

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -234,7 +234,8 @@ class NBitFowardTest(unittest.TestCase):
                 scale_shift.copy_(ref_scale_shift)
 
         requests = generate_requests(1, B, T, L, min(Es), reuse=0.1)
-        for indices, offsets, _ in requests:
+        for req in requests:
+            indices, offsets = req.unpack_2()
             lowp_pooled_output = op(
                 indices=indices.int(),
                 offsets=offsets.int(),
@@ -841,7 +842,8 @@ class NBitFowardTest(unittest.TestCase):
 
         requests = generate_requests(iters, B, T, L, min(Es), reuse=0.1)
 
-        for indices, offsets, _ in requests:
+        for req in requests:
+            indices, offsets = req.unpack_2()
             indices = indices.int()
             offsets = offsets.int()
             output = cc(indices, offsets)

--- a/fbgemm_gpu/test/tbe/inference/nbit_split_embeddings_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_split_embeddings_test.py
@@ -243,7 +243,8 @@ class NBitSplitEmbeddingsTest(unittest.TestCase):
         requests = generate_requests(
             iters, B, T, L, min(Es), reuse=0.1, emulate_pruning=emulate_pruning
         )
-        for indices, offsets, _ in requests:
+        for req in requests:
+            indices, offsets = req.unpack_2()
             indices = indices.int()
             offsets = offsets.int()
             output_ref = cc_ref(indices, offsets)

--- a/fbgemm_gpu/test/tbe/training/forward_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_test.py
@@ -833,7 +833,8 @@ class ForwardTest(unittest.TestCase):
 
         requests = generate_requests(2, B, T, L, min(Es), reuse=0.1)
 
-        for indices, offsets, _ in requests:
+        for req in requests:
+            indices, offsets = req.unpack_2()
             lowp_pooled_output = op(
                 indices=indices,
                 offsets=offsets,


### PR DESCRIPTION
Summary:
This diff refactors the return type of `generate_requests` (TBE random
input generator).  Prior to this diff, `generate_requests` returns
a list of indices, offsets and per sample weights (optional) tuple
(`List[Tuple(Tensor, Tensor, Optional[Tensor])]`).  If we add another
return value to the tuple, we need to update every request tuple
unpacking site and update typing to satisfy Pyre requirements.  Thus,
this diff adds `TBERequest` which is a wrapper of return values of
`generate_requests`.  It allows the user to access each return value
individually or as an arbitrary length tuple.

Differential Revision: D54710610


