### PR TITLE
Meta registration for custom PT ops: jagged_dense_dense_elementwise_add_jagged_output + batched_dense_vec_jagged_2d_mul

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_meta.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_meta.cpp
@@ -141,6 +141,13 @@ Tensor batched_dense_vec_jagged_2d_mul_forward_meta(
   return at::empty_symint({B * H, D}, v.options());
 }
 
+Tensor batched_dense_vec_jagged_2d_mul_meta(
+    const Tensor& v,
+    const Tensor& a_values,
+    const Tensor& a_offsets) {
+  return batched_dense_vec_jagged_2d_mul_forward_meta(v, a_values, a_offsets);
+}
+
 std::tuple<Tensor, Tensor> batched_dense_vec_jagged_2d_mul_backward_meta(
     const Tensor& grad_output,
     const Tensor& v,
@@ -225,6 +232,10 @@ TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
           fbgemm_gpu::
               jagged_dense_dense_elementwise_add_jagged_output_forward_meta));
   m.impl(
+      "jagged_dense_dense_elementwise_add_jagged_output",
+      TORCH_FN(
+          fbgemm_gpu::jagged_dense_dense_elementwise_add_jagged_output_meta));
+  m.impl(
       "jagged_dense_elementwise_add_jagged_output",
       TORCH_FN(fbgemm_gpu::jagged_dense_elementwise_add_jagged_output_meta));
   m.impl(
@@ -239,6 +250,9 @@ TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
   m.impl(
       "jagged_dense_elementwise_mul_backward",
       TORCH_FN(fbgemm_gpu::jagged_dense_elementwise_mul_backward_meta));
+  m.impl(
+      "batched_dense_vec_jagged_2d_mul",
+      TORCH_FN(fbgemm_gpu::batched_dense_vec_jagged_2d_mul_meta));
   m.impl(
       "batched_dense_vec_jagged_2d_mul_forward",
       TORCH_FN(fbgemm_gpu::batched_dense_vec_jagged_2d_mul_forward_meta));


### PR DESCRIPTION
Summary:
For these two custom PT ops, we have an CUDA dispatch key in the fbgemm namespace.

https://www.internalfb.com/code/fbsource/[99773712d12af930ee3ffa2df7f104d6a9da07c2]/fbcode/deeplearning/fbgemm/fbgemm_gpu/include/fbgemm_gpu/ops_utils.h?lines=41-46

https://www.internalfb.com/code/fbsource/[b02f08eab8226e634c52c9cf485528bb360da15a]/fbcode/deeplearning/fbgemm/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops.cu?lines=20-23%2C28-31


We have an Autograd dispatch key in the fbgemm namespace.
https://www.internalfb.com/code/fbsource/[8bb335b45a79dacd05516eade3136e6af0c52854]/fbcode/deeplearning/fbgemm/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_autograd.cpp?lines=954%2C959-961%2C968-970


However, neither are registered as `CompositeImplicitAutograd`, so it should have a Meta impl.

Differential Revision: D54771077


