### PR TITLE
Refactor index_remapping_array initialization for PT2 export

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
@@ -1453,15 +1453,16 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
             device=self.current_device,
             dtype=torch.int64,
         )
-        if self.index_remappings_array_offsets[-1] == 0:
+
+        index_remappings_filter_nones = []
+        for mapping in index_remapping:
+            if mapping is not None:
+                index_remappings_filter_nones.append(mapping)
+        if len(index_remappings_filter_nones) == 0:
             self.index_remappings_array = torch.empty(
                 0, dtype=torch.int32, device=self.current_device
             )
         else:
-            index_remappings_filter_nones = []
-            for mapping in index_remapping:
-                if mapping is not None:
-                    index_remappings_filter_nones.append(mapping)
             self.index_remappings_array = torch.cat(index_remappings_filter_nones).to(
                 self.current_device
             )


### PR DESCRIPTION
Summary:
We end up getting this error
```
torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode: Could not guard on data-dependent expression Eq(u0, 1) (unhinted: Eq(u0, 1)).  (Size-like symbols: none)
```
w/ tracing `if self.index_remappings_array_offsets[-1] == 0` in FakeTensorMode. Changing it to check len(index_remapping) is logically the same, and seems to fix the error.

Reviewed By: sryap

Differential Revision: D54779307


