### PR TITLE
Refactor TBE GPU backward codegen

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -235,6 +235,8 @@ set(gen_gpu_kernel_source_files
     "gen_batch_index_select_dim0_backward_kernel_warp.cu"
     "gen_embedding_backward_split_grad_embedding_ops.cu"
     "gen_embedding_backward_split_grad_index_select.cu"
+    "gen_embedding_backward_common_split_device_kernel.cuh"
+    "gen_embedding_backward_batch_index_select_split_device_kernel.cuh"
 )
 
 if(NOT USE_ROCM)
@@ -254,10 +256,9 @@ foreach(wdesc weighted unweighted_nobag unweighted)
       "gen_embedding_forward_dense_${wdesc}_kernel.cu"
       "gen_embedding_backward_dense_split_${wdesc}_cuda.cu"
       "gen_embedding_backward_dense_split_${wdesc}_kernel_cta.cu"
-      "gen_embedding_backward_dense_split_${wdesc}_kernel_warp.cu")
-
-  list(APPEND gen_gpu_kernel_source_files
-      "gen_embedding_forward_split_${wdesc}_kernel.cu")
+      "gen_embedding_backward_dense_split_${wdesc}_kernel_warp.cu"
+      "gen_embedding_forward_split_${wdesc}_kernel.cu"
+      "gen_embedding_backward_${wdesc}_split_device_kernel.cuh")
 
   foreach(etype fp32 fp16 fp8 int8 int4 int2)
     list(APPEND gen_gpu_kernel_source_files
@@ -265,9 +266,12 @@ foreach(wdesc weighted unweighted_nobag unweighted)
   endforeach()
 endforeach()
 
-list(APPEND gen_gpu_kernel_source_files
-     "gen_embedding_forward_split_weighted_vbe_kernel.cu"
-     "gen_embedding_forward_split_unweighted_vbe_kernel.cu")
+# Generate VBE files
+foreach(wdesc weighted unweighted)
+  list(APPEND gen_gpu_kernel_source_files
+      "gen_embedding_forward_split_${wdesc}_vbe_kernel.cu"
+      "gen_embedding_backward_${wdesc}_vbe_split_device_kernel.cuh")
+endforeach()
 
 set(gen_cpu_source_files
     "gen_embedding_forward_quantized_unweighted_codegen_cpu.cpp"
@@ -379,6 +383,7 @@ set(embedding_codegen_dependencies
     ${CMAKE_CODEGEN_DIR}/lookup_args.py
     ${CMAKE_CODEGEN_DIR}/split_embedding_codegen_lookup_invoker.template
     ${CMAKE_CODEGEN_DIR}/embedding_optimizer_split_device_kernel_template.cuh
+    ${CMAKE_CODEGEN_DIR}/embedding_backward_split_device_kernel_template.cuh
     ${CMAKE_CURRENT_SOURCE_DIR}/include/fbgemm_gpu/cpu_utils.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/fbgemm_gpu/cub_namespace_prefix.cuh
     ${CMAKE_CURRENT_SOURCE_DIR}/include/fbgemm_gpu/cub_namespace_postfix.cuh

--- a/fbgemm_gpu/codegen/embedding_backward_split_device_kernel_template.cuh
+++ b/fbgemm_gpu/codegen/embedding_backward_split_device_kernel_template.cuh
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// clang-format off
+
+#include "fbgemm_gpu/embedding_backward_template_helpers.cuh"
+#include "fbgemm_gpu/fbgemm_tensor_accessor.h"
+#include "fbgemm_gpu/split_embeddings_utils.cuh"
+
+using namespace fbgemm_gpu;
+
+{%- if gen_once %}
+{#- /*
+    The kernels in this section will be generated only once for all TBE configs
+    as they are common across the different configs. The generated file name is
+    `gen_embedding_backward_common_split_device_kernel.cuh`
+     */
+#}
+
+template<
+    typename emb_t,
+    typename cache_t,
+    size_t kMaxVecsPerThread,
+    int32_t kThreadGroupSize,
+    int32_t VEC_WIDTH
+>
+DEVICE_INLINE void store_grad_sum(
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits>& grad_dev_weights,
+    const Vec4T<at::acc_type<cache_t, true>>* grad_sum,
+    const int32_t D,
+    const int64_t weights_offset,
+    const int64_t idx
+) {
+    #pragma unroll kMaxVecsPerThread
+    for (int32_t i = 0;
+        i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
+        ++i) {
+        int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
+        auto& grad = grad_sum[i];
+        grad.store(&grad_dev_weights[weights_offset + idx * D + d]);
+    }
+}
+
+{%- else %}
+
+{#- /*
+    The kernels in this section will be generated multiple times based on the
+    TBE configs (weighted/unweighted, bag/no bag, vbe/no vbe). The generated
+    file name's pattern is
+    `gen_embedding_backward_[weighted|unweighted][_nobag|][_vbe|]_split_device_kernel.cuh`
+     */
+#}
+
+template <
+    typename grad_t,
+    typename cache_t,
+    size_t kMaxVecsPerThread,
+    int32_t kThreadGroupSize = kWarpSize,
+    int32_t VEC_WIDTH
+>
+DEVICE_INLINE void compute_grad_sum_{{ kdesc }}(
+    Vec4T<at::acc_type<cache_t, true>>* grad_sum,
+    const pta::PackedTensorAccessor64<grad_t, {{ "1" if is_index_select else "2" }}, at::RestrictPtrTraits>& grad_output,
+    {%- if not nobag or is_index_select %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>& D_offsets,
+    {%- endif %}
+    const int32_t D,
+    const int32_t T,
+    const pta::PackedTensorAccessor32<{{ "int64_t" if nobag else "int32_t" }}, 1, at::RestrictPtrTraits>& sorted_infos,
+    {%- if weighted %}
+    const pta::PackedTensorAccessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits>& sorted_indice_weights,
+    {%- endif %}
+    {%- if not nobag and vbe %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>& B_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>& row_output_offsets,
+    {%- endif %}
+    {%- if is_index_select %}
+    const int64_t grad_offset,
+    const int32_t grad_stride,
+    {%- endif %}
+    {%- if not nobag %}
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask,
+    {%- endif %}
+    const int32_t segment_start,
+    const int32_t sl_start,
+    const int32_t sl_end,
+    const unsigned int shfl_sync_mask
+) {
+    for (int32_t sl = sl_start; sl < sl_end; sl += kThreadGroupSize) {
+        int32_t sl_j = sl + threadIdx.x;
+        {%- if not nobag %}
+        const auto b_t = sl_j < sl_end ? reinterpret_cast<const uint32_t*>(&sorted_infos[0])[segment_start + sl_j] : 0;
+        const auto b = b_t & info_B_mask;
+        const auto t = b_t >> info_B_num_bits;
+        {%- if vbe %}
+        const auto grad_offset = row_output_offsets[B_offsets[t] + b];
+        {%- else %} // if vbe
+        int32_t D_start = sl_j < sl_end ? D_offsets[t] : 0;
+        {%- endif %} // if vbe
+        {%- else %} // if not nobag
+        int64_t l_t = sl_j < sl_end ? sorted_infos[segment_start + sl_j] : 0;
+        int32_t l = l_t / T;
+        {%- endif %} // if not nobag
+        {%- if weighted %}
+        at::acc_type<cache_t, true> idx_weight = sl_j < sl_end ? sorted_indice_weights[segment_start + sl_j] : 0.0;
+        {%- endif %}
+        for (int32_t j = 0; j < kThreadGroupSize && sl + j < sl_end; ++j) {
+            {%- if nobag %}
+            int32_t l_j = SHFL_SYNC(l, j);
+            {%- elif vbe %}
+            const auto grad_offset_j = SHFL_SYNC(grad_offset, j);
+            {%- else %}
+            int32_t b_j = SHFL_SYNC(b, j);
+            int32_t D_start_j = SHFL_SYNC(D_start, j);
+            {%- endif %}
+
+            {%- if weighted %}
+            at::acc_type<cache_t, true> idx_weight_j = SHFL_SYNC(idx_weight, j);
+            {%- endif %}
+
+            #pragma unroll kMaxVecsPerThread
+            for (int32_t i = 0;
+                i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
+                ++i) {
+                int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
+                Vec4T<at::acc_type<grad_t, true>> grad_out_vec(
+                    {%- if nobag and is_index_select %}
+                    // grad_output is 1d
+                    &grad_output[grad_offset + l_j * grad_stride + d]
+                    {%- elif nobag %}
+                    &grad_output[l_j][d]
+                    {%- elif vbe %}
+                    &grad_output[0][grad_offset_j + d]
+                    {%- else %}
+                    &grad_output[b_j][0] + D_start_j + d
+                    {%- endif %} // if nobag
+                );
+
+                {%- if weighted %}
+                grad_sum[i].fma_(grad_out_vec, idx_weight_j);
+                {%- else %}
+                grad_sum[i].add_(grad_out_vec);
+                {%- endif %}
+            }
+        }
+    }
+}
+
+{%- endif %}
+
+    // clang-format on

--- a/fbgemm_gpu/codegen/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/embedding_backward_split_kernel_warp_template.cu
@@ -17,6 +17,8 @@
 {%- if optimizer != "none" and not dense %}
 #include "gen_embedding_optimizer_{{ optimizer }}_split_device_kernel.cuh"
 {%- endif %}
+#include "gen_embedding_backward_{{ kdesc }}_split_device_kernel.cuh"
+#include "gen_embedding_backward_common_split_device_kernel.cuh"
 
 using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
@@ -154,65 +156,38 @@ split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc 
         const int32_t sl_start = 0;
         const int32_t sl_end = SL;
         Vec4T<at::acc_type<cache_t, true>> grad_sum[kMaxVecsPerThread];
-        for (int32_t sl = sl_start; sl < sl_end; sl += kThreadGroupSize) {
-            int32_t sl_j = sl + threadIdx.x;
-            {%- if not nobag %}
-            const auto b_t = sl_j < sl_end ? reinterpret_cast<const uint32_t*>(&sorted_infos[0])[segment_start + sl_j] : 0;
-            const auto b = b_t & info_B_mask;
-            const auto t = b_t >> info_B_num_bits;
-            {%- if vbe %}
-            const auto grad_offset = row_output_offsets[B_offsets[t] + b];
-            {% else %}
-            int32_t D_start = sl_j < sl_end ? D_offsets[t] : 0;
-            {%- endif %} // if vbe
-            {%- else %} // if not nobag
-            int64_t l_t = sl_j < sl_end ? sorted_infos[segment_start + sl_j] : 0;
-            int32_t l = l_t / T;
-            {%- endif %} // if not nobag
-            {%- if weighted %}
-            at::acc_type<cache_t, true> idx_weight = sl_j < sl_end ? sorted_indice_weights[segment_start + sl_j] : 0.0;
+
+        compute_grad_sum_{{ kdesc }}
+          <grad_t, cache_t, kMaxVecsPerThread, kThreadGroupSize, VEC_WIDTH>(
+            grad_sum,
+            grad_output,
+            {%- if not nobag or is_index_select %}
+            D_offsets,
             {%- endif %}
+            D,
+            T,
+            sorted_infos,
+            {%- if weighted %}
+            sorted_indice_weights,
+            {%- endif %}
+            {%- if not nobag and vbe %}
+            B_offsets,
+            row_output_offsets,
+            {%- endif %}
+            {%- if is_index_select %}
+            grad_offset,
+            grad_stride,
+            {%- endif %}
+            {%- if not nobag %}
+            info_B_num_bits,
+            info_B_mask,
+            {%- endif %}
+            segment_start,
+            sl_start,
+            sl_end,
+            shfl_sync_mask
+        );
 
-            for (int32_t j = 0; j < kThreadGroupSize && sl + j < sl_end; ++j) {
-                {%- if nobag %}
-                int32_t l_j = SHFL_SYNC(l, j);
-                {%- elif vbe %}
-                const auto grad_offset_j = SHFL_SYNC(grad_offset, j);
-                {%- else %}
-                int32_t b_j = SHFL_SYNC(b, j);
-                int32_t D_start_j = SHFL_SYNC(D_start, j);
-                {%- endif %}
-
-                {%- if weighted %}
-                at::acc_type<cache_t, true> idx_weight_j = SHFL_SYNC(idx_weight, j);
-                {%- endif %}
-
-                #pragma unroll kMaxVecsPerThread
-                for (int32_t i = 0;
-                        i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
-                        ++i) {
-                    int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
-                    Vec4T<at::acc_type<grad_t, true>> grad_out_vec(
-                        {%- if nobag and is_index_select %}
-                        // grad_output is 1d
-                        &grad_output[grad_offset + l_j * grad_stride + d]
-                        {%- elif nobag %}
-                        &grad_output[l_j][d]
-                        {%- elif vbe %}
-                        &grad_output[0][grad_offset_j + d]
-                        {%- else %}
-                        &grad_output[b_j][0] + D_start_j + d
-                        {%- endif %}
-                    );
-
-                    {%- if weighted %}
-                    grad_sum[i].fma_(grad_out_vec, idx_weight_j);
-                    {%- else %}
-                    grad_sum[i].add_(grad_out_vec);
-                    {%- endif %}
-                }
-            }
-        }
         {%- if not dense and optimizer != "none" %}
         split_{{ optimizer }}_table_update_kernel
           <emb_t, cache_t, kMaxVecsPerThread, kThreadGroupSize, VEC_WIDTH>(
@@ -243,16 +218,10 @@ split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc 
         const int64_t weights_offset = run_id * max_D;
         idx = 0;
         {%- endif %}
-    	#pragma unroll kMaxVecsPerThread
-        for (int32_t i = 0;
-            i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
-            ++i) {
-            int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
-            auto& grad = grad_sum[i];
-            grad.store(&grad_dev_weights[weights_offset + idx * D + d]);
-        }
+        store_grad_sum
+          <emb_t, cache_t, kMaxVecsPerThread, kThreadGroupSize, VEC_WIDTH>(
+              grad_dev_weights, grad_sum, D, weights_offset, idx);
         {%- endif %} // if not dense and optimizer != "none"
-
     }
 }
 


### PR DESCRIPTION
Summary:
This diff moved the common TBE backward code between `cta_per_row` and
`warp_per_row` into separate functions to improve programmability and
maintainability.

Differential Revision: D54933812


