### PR TITLE
Use gpu_library_selector for permute_pooled_embedding_ops_gpu

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/permute_pooled_embedding_modules.py
+++ b/fbgemm_gpu/fbgemm_gpu/permute_pooled_embedding_modules.py
@@ -20,20 +20,9 @@ except Exception:
     torch.ops.load_library(
         "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_cpu"
     )
-    try:
-        if torch.version.hip:
-            torch.ops.load_library(
-                "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_gpu_hip"
-            )
-        else:
-            torch.ops.load_library(
-                "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_gpu_cuda"
-            )
-    except OSError:
-        # For backward compatibility
-        torch.ops.load_library(
-            "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_gpu"
-        )
+    torch.ops.load_library(
+        "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_gpu"
+    )
 except OSError:
     pass
 

--- a/fbgemm_gpu/include/fbgemm_gpu/permute_pooled_embedding_function.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/permute_pooled_embedding_function.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ATen/ATen.h>
+#include <torch/csrc/api/include/torch/types.h>
+#include <torch/csrc/autograd/custom_function.h>
+
+namespace fbgemm_gpu {
+
+using torch::autograd::AutogradContext;
+using torch::autograd::Variable;
+using torch::autograd::variable_list;
+
+class PermutePooledEmbsFunction
+    : public torch::autograd::Function<PermutePooledEmbsFunction> {
+ public:
+  static Variable forward(
+      AutogradContext* ctx,
+      const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
+      const at::Tensor& offset_dim_list,
+      const at::Tensor& permute_list,
+      const at::Tensor& inv_offset_dim_list,
+      const at::Tensor& inv_permute_list,
+      const bool& allow_duplicates = false);
+
+  static variable_list backward(
+      AutogradContext* ctx,
+      variable_list grad_output);
+};
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/include/fbgemm_gpu/permute_pooled_embedding_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/permute_pooled_embedding_ops.h
@@ -12,6 +12,7 @@
 #include <torch/csrc/api/include/torch/types.h>
 #include <torch/csrc/autograd/custom_function.h>
 #include "fbgemm_gpu/ops_utils.h"
+#include "fbgemm_gpu/permute_pooled_embedding_function.h"
 #include "fbgemm_gpu/sparse_ops_utils.h"
 
 /// @defgroup permute-pooled-embs-gpu Permute Pooled Embeddings Operators (CUDA)
@@ -63,26 +64,5 @@ at::Tensor permute_pooled_embs_gpu(
     const at::Tensor& permute_list,
     const at::Tensor& inv_offset_dim_list,
     const at::Tensor& inv_permute_list);
-
-using torch::autograd::AutogradContext;
-using torch::autograd::Variable;
-using torch::autograd::variable_list;
-
-class PermutePooledEmbsFunction
-    : public torch::autograd::Function<PermutePooledEmbsFunction> {
- public:
-  static Variable forward(
-      AutogradContext* ctx,
-      const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
-      const at::Tensor& offset_dim_list,
-      const at::Tensor& permute_list,
-      const at::Tensor& inv_offset_dim_list,
-      const at::Tensor& inv_permute_list,
-      const bool& allow_duplicates = false);
-
-  static variable_list backward(
-      AutogradContext* ctx,
-      variable_list grad_output);
-};
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_function.cpp
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_function.cpp
@@ -6,11 +6,20 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "fbgemm_gpu/permute_pooled_embedding_ops.h"
+#include "include/fbgemm_gpu/permute_pooled_embedding_function.h"
 
 using Tensor = at::Tensor;
 
 namespace fbgemm_gpu {
+
+namespace {
+at::Tensor permute_pooled_embs_cpu(
+    const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]
+    const at::Tensor& offset_dim_list,
+    const at::Tensor& permute_list,
+    const at::Tensor& inv_offset_dim_list,
+    const at::Tensor& inv_permute_list);
+}
 
 using torch::autograd::AutogradContext;
 using torch::autograd::Variable;


### PR DESCRIPTION
Summary: Using gpu_library_selector can avoid divergence in the usercode

Differential Revision: D54986292


