### PR TITLE
fbgemm::batch_index_select and fbgemm:: keyed_jagged_index_select

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -26,6 +26,9 @@ except Exception:
             "//deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops_hip"
         )
         torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:input_combine_hip")
+        torch.ops.load_library(
+            "//deeplearning/fbgemm/fbgemm_gpu/codegen:index_select_ops_hip"
+        )
     else:
         torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
         torch.ops.load_library(
@@ -40,6 +43,7 @@ except Exception:
     )
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops_cpu")
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:input_combine_cpu")
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/codegen:index_select_ops")
 
 import torch.utils._pytree as pytree
 from torch import Tensor
@@ -474,3 +478,81 @@ def dense_to_jagged(
     if not total_L:
         total_L = torch.library.get_ctx().new_dynamic_size()
     return (dense_to_jagged_forward(dense, offsets, total_L), offsets)
+
+
+@impl_abstract("fbgemm::batch_index_select_dim0")
+def batch_index_select_dim0_abstract(
+    inputs: torch.Tensor,
+    indices: torch.Tensor,
+    input_num_indices: List[int],
+    input_rows: List[int],
+    input_columns: List[int],
+    permute_output_dim_0_1: bool,
+) -> torch.Tensor:
+    """
+    This meta function is used to calculate the shape of output tensor
+    from the original function `fbgemm::batch_index_select_dim0` without the actual data.
+    """
+    # input lists must have the same length
+    torch._check(len(input_num_indices) == len(input_rows))
+    torch._check(len(input_num_indices) == len(input_columns))
+
+    if permute_output_dim_0_1 and len(input_num_indices) > 0:
+        # All num_indices must be the same if permute_output_dim_0_1 is True
+        for x in input_num_indices:
+            torch._check(x == input_num_indices[0])
+
+    size = sum([row * col for row, col in zip(input_rows, input_columns)])
+    torch._check(inputs.size(0) == size)
+
+    output_numel = 0
+    for i, cols in enumerate(input_columns):
+        output_numel += input_num_indices[i] * cols
+    return inputs.new_empty([output_numel])
+
+
+@impl_abstract("fbgemm::keyed_jagged_index_select_dim1")
+def keyed_jagged_index_select_dim1_abstract(
+    values: torch.Tensor,
+    lengths: torch.Tensor,
+    offsets: torch.Tensor,
+    indices: torch.Tensor,
+    batch_size: torch.SymInt,
+    weights: Optional[torch.Tensor] = None,
+    selected_lengths_sum: Optional[torch.SymInt] = None,
+) -> List[torch.Tensor]:
+    """
+    This meta function is used to calculate the shape of output tensors
+    from the original function `fbgemm::keyed_jagged_index_select_dim1` without the actual data.
+    """
+    # pyre-ignore
+    num_batches = len(lengths) // batch_size
+    # offsets = [0] + lengths.cumsum(0)
+    torch._check(len(lengths) + 1 == len(offsets))
+    # len(lengths) == batch_size * num_batches
+    # pyre-ignore
+    torch._check(len(lengths) % batch_size == 0)
+    if weights is not None:
+        # weights must have the same shape as values
+        torch._check(values.shape == weights.shape)
+
+    if selected_lengths_sum is None:
+        length_indices = torch.cat(
+            # pyre-ignore
+            [indices + i * batch_size for i in range(num_batches)]
+        )
+        selected_lengths_sum = (
+            torch.index_select(lengths, 0, length_indices).sum().item()
+        )
+
+    ret: List[torch.Tensor] = [
+        # pyre-ignore
+        values.new_empty([selected_lengths_sum]),
+        lengths.new_empty([indices.shape[0] * num_batches]),
+    ]
+
+    if weights is not None:
+        # pyre-ignore
+        ret.append(weights.new_empty([selected_lengths_sum]))
+
+    return ret

--- a/fbgemm_gpu/test/jagged/jagged_tensor_ops_test.py
+++ b/fbgemm_gpu/test/jagged/jagged_tensor_ops_test.py
@@ -618,7 +618,7 @@ class JaggedTensorOpsTest(unittest.TestCase):
         )
         indices = torch.randint(
             low=0,
-            high=1,
+            high=input_batch_size,
             size=(output_batch_size,),
             dtype=index_dtype,
             device="cuda",


### PR DESCRIPTION
Summary:
# batch_index_select_dim0
* source of truth forthe function in [GPU CPP](https://fburl.com/code/8nhxisy1)
```
Tensor batch_index_select_dim0_gpu(
    Tensor inputs,
    Tensor indices,
    std::vector<int64_t> input_num_indices,
    std::vector<int64_t> input_rows,
    std::vector<int64_t> input_columns,
    // Permute dim 0 and 1 of the output tensor
    const bool permute_output_dim_0_1)
```

* test data generation example in [test_batch_index_select_dim0](https://fburl.com/code/df4s0ml9)
```
output_ref = [
    input.index_select(dim=0, index=index).flatten()
    for input, index in zip(inputs, indices)
]

output_test = torch.ops.fbgemm.batch_index_select_dim0(
    concat_inputs,
    concat_indices,
    input_num_indices,
    input_rows,
    input_columns,
    permute_output_dim_0_1,
)
```

# keyed_jagged_index_select_dim1
* input argument registration in [sparse_ops_cpu.cpp](https://fburl.com/code/a11zx1nv)
```
  m.def(
      "keyed_jagged_index_select_dim1(Tensor values, Tensor lengths, Tensor offsets, Tensor indices, SymInt batch_size, Tensor? weights=None, SymInt? selected_lengths_sum=None) -> Tensor[]");
```

* source of truth for the function in [GPU CUDA](https://fburl.com/code/h536wn8y)
```
__global__ void keyed_jagged_index_select_dim1_kernel(
    at::PackedTensorAccessor64<scalar_t, 1, at::RestrictPtrTraits> output,
    at::PackedTensorAccessor64<weight_t, 1, at::RestrictPtrTraits>
        output_weights,
    const at::PackedTensorAccessor64<scalar_t, 1, at::RestrictPtrTraits> input,
    const at::PackedTensorAccessor64<weight_t, 1, at::RestrictPtrTraits>
        weights,
    const at::PackedTensorAccessor32<offset_t, 1, at::RestrictPtrTraits>
        input_offsets,
    const at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> indices,
    const at::PackedTensorAccessor32<offset_t, 1, at::RestrictPtrTraits>
        output_offsets,
    const int num_batches,
    const int input_batch_size)
```

* [test_keyed_jagged_index_select_dim1](https://fburl.com/code/rrxp6osc)
```
output_ref = []
output_weight_ref = []
for k in range(num_batches):
    key_lengths = lengths[k * input_batch_size : (k + 1) * input_batch_size]
    start_offset = offsets[k * input_batch_size]
    end_offset = offsets[(k + 1) * input_batch_size]
    key_values = values_ref[start_offset:end_offset].view(-1, 1)
    output_ref.append(
        torch.ops.fbgemm.jagged_index_select(key_values, key_lengths, indices)[
            0
        ].view(-1)
    )
    if has_weights:
        # pyre-ignore[16]
        key_weights = weights[start_offset:end_offset].view(-1, 1)
        output_weight_ref.append(
            torch.ops.fbgemm.jagged_index_select(
                key_weights, key_lengths, indices
            )[0].view(-1)
        )

output_ref = torch.concat(output_ref)
```

# Notes
* compile works for `batch_index_select_dim0` (please see the test plan), but failed for `test_keyed_jagged_index_select_dim1`. It's unlikely a bento setup issue. The error message complains "data dependent operator"
```
data dependent operator: aten._local_scalar_dense.default; to enable, set torch._dynamo.config.capture_scalar_outputs = True

from user code:
   File "/tmp/ipykernel_1445682/1191350425.py", line 2, in <lambda>
    fn = lambda: torch.ops.fbgemm.keyed_jagged_index_select_dim1(

Set TORCH_LOGS="+dynamo" and TORCHDYNAMO_VERBOSE=1 for more information
```
* after going through the stack trace, it could be due to the output Tensor size = `selected_lengths_sum`, which is an optional argument, and it will be calculated based on the input tensor `lengths` when not provided.

* The diff test also failed: 1) github-export-checks, 2) operator does not exist. Not sure if these failures are expected or not.
```
if you fixed the below errors and this error is still here, please rerun this job (github-export-checks) manually.

No GitHub pull request(s) for pytorch/FBGEMM were found linked for your diff. Please export your diff here: https://our.intern.facebook.com/.../preview/D54669445/.
```

```
RuntimeError: operator fbgemm::batch_index_select_dim0 does not exist
2024-03-09T19:45:33.412907Z  INFO re_gpu_analyzer: Command exited with exit code cmd_status=ExitStatus(unix_wait_status(256))
2024-03-09T19:45:33.412954Z  WARN re_gpu_analyzer: detected_problem="The command is running on a worker with dedicated GPUs but hasn't used any during its execution."
```
* it really took some time and efforts to figure out the definition/expectation of these two functions, especially the KeyedJaggedTensor, most of my understandings are from reading the two test_functions (really appreciate it!). Curious if there is any design doc for these functions.

# Readings
* [KeyedJaggedTensor](https://pytorch.org/torchrec/torchrec.sparse.html) for [minibatch](https://pytorch.org/tutorials/intermediate/torchrec_tutorial.html#representing-minibatches-with-keyedjaggedtensor)
> We need an efficient representation of multiple examples of an arbitrary number of entity IDs per feature per example. In order to enable this “jagged” representation, we use the TorchRec datastructure KeyedJaggedTensor (KJT).

> Let’s take a look at how to lookup a collection of two embedding bags, “product” and “user”. Assume the minibatch is made up of three examples for three users. The first of which has two product IDs, the second with none, and the third with one product ID.
|------------|------------|
| product ID | user ID    |
|------------|------------|
| [101, 202] | [404]      |
| []         | [505]      |
| [303]      | [606]      |
|------------|------------|
```
mb = torchrec.KeyedJaggedTensor(
    keys = ["product", "user"],
    values = torch.tensor([101, 202, 303, 404, 505, 606]).cuda(),
    lengths = torch.tensor([2, 0, 1, 1, 1, 1], dtype=torch.int64).cuda(),
)

print(mb.to(torch.device("cpu")))
```

* [impl_abstract](https://pytorch.org/docs/stable/library.html#torch.library.impl_abstract)
> An “abstract implementation” specifies the behavior of this operator on Tensors that carry no data. Given some input Tensors with certain properties (sizes/strides/storage_offset/device), it specifies what the properties of the output Tensors are.

> The abstract implementation has the same signature as the operator. It is run for both **FakeTensors** and **meta tensors**. To write an abstract implementation, assume that all Tensor inputs to the operator are regular CPU/CUDA/Meta tensors, but they do not have storage, and you are trying to return regular CPU/CUDA/Meta tensor(s) as output. The abstract implementation must consist of only PyTorch operations (and may not directly access the storage or data of any input or intermediate Tensors).

* [fake tensor](https://pytorch.org/docs/stable/torch.compiler_fake_tensor.html)
> When doing Dynamo symbolic evaluation and compiler passes, we often want to be able to run tensor operations to understand what output sizes/dtypes/devices are, without actually running those operations (or trashing preexisting tensors)...
A fake tensor is like a real tensor in all respects, except that it doesn’t actually have any data. For example, when we do Dynamo tracing, we need to trace through user Tensor code and answer questions about intermediates.

> A meta tensor is a tensor with device=’meta’. This is actually a lot of what you want for fake tensor, but meta tensors don’t model devices, and sometimes stride behavior varies depending on your device, so fake tensors really can get a lot more accurate info this way. Also, meta tensors are “global” (they exist on their own, similar to how a CPU/CUDA tensor exist on their own), whereas fake tensors are scoped to a FakeTensorMode.

Reviewed By: ezyang

Differential Revision: D54669445


