### PR TITLE
Add max embedding dim = 2048 support in TBE training

### DIFF
--- a/fbgemm_gpu/codegen/embedding_common_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_common_code_generator.py
@@ -50,6 +50,120 @@ env.globals["max_embedding_dim"] = 1024
 # An optimization for ROCm
 env.globals["items_per_warp"] = 128 if args.is_rocm is False else 256
 env.globals["dense"] = False
+env.globals["fixed_max_vecs_per_thread"] = 2
+
+######################################################################
+## Helper functions in Jinja's env.globals                          ##
+######################################################################
+
+
+def prepare_string_for_formatting(blob: str, format_keywords: List[str]) -> str:
+    """
+    Replace curly brackets ('{' or '}') with escape characters ('{{' or '}}')
+    to prepare the string to be formatted by `str.format()`. `str.format()`
+    searches curly brackets to find keywords to format. It will run into an
+    error if the string contains curly brackets.
+    """
+    blob = blob.replace("{", "{{").replace("}", "}}")
+    for kw in format_keywords:
+        blob = blob.replace("{{" + kw + "}}", "{" + kw + "}")
+    return blob
+
+
+def generate_optimized_grad_sum_loop_access(
+    blob: str, other_formats: Optional[Dict[str, str]] = None
+) -> str:
+    """
+    Generate an optimized code for grad_sum accessing
+    - The indices of `grad_sum` when `kUseVecBlocking` is true and false are
+      different. When `kUseVecBlocking` is true, `d_vec` is the index.
+      Otherwise, `vec` is the index.
+    - When `kUseVecBlocking` is false, the number times that the for-loop is
+      executed is known at compile time. Thus, we can add the `#pragma unroll`
+      hint to tell the compiler to optimize the for-loop.
+    """
+    blob = prepare_string_for_formatting(blob, ["grad_vec"])
+
+    smem_blob = blob.format(grad_vec="smem_grad_sum[d_vec]")
+    reg_blob = blob.format(grad_vec="grad_sum[vec]")
+    gen_blob = """
+    if (kUseVecBlocking) {
+        // max_vecs is not known at compile time
+        for (int32_t vec = 0;
+            vec < max_vecs &&
+            (kThreadGroupSize * vec + threadIdx.x) * VEC_WIDTH < D;
+            ++vec) {
+            const int32_t d_vec = vec * kThreadGroupSize + threadIdx.x;
+            [[maybe_unused]] const int32_t d = d_vec * VEC_WIDTH;
+            {smem_blob}
+        }
+    }
+    else {
+        // kFixedMaxVecsPerThread is known at compile time
+        #pragma unroll kFixedMaxVecsPerThread
+        for (int32_t vec = 0;
+            vec < kFixedMaxVecsPerThread
+                && (kThreadGroupSize * vec + threadIdx.x) * VEC_WIDTH < D;
+            ++vec) {
+            const int32_t d_vec = vec * kThreadGroupSize + threadIdx.x;
+            [[maybe_unused]] const int32_t d = d_vec * VEC_WIDTH;
+            {reg_blob}
+        }
+    }
+    """
+    gen_blob = prepare_string_for_formatting(gen_blob, ["smem_blob", "reg_blob"])
+    gen_blob = gen_blob.format(smem_blob=smem_blob, reg_blob=reg_blob)
+    if other_formats is not None:
+        gen_blob = prepare_string_for_formatting(gen_blob, list(other_formats.keys()))
+        gen_blob = gen_blob.format(**other_formats)
+    return gen_blob
+
+
+def get_max_vecs_template_configs(
+    items_per_warp: int, fixed_max_vecs_per_thread: int, use_subwarp_shuffle: bool
+) -> List[Tuple[int, int, str]]:
+    """
+    Generate the template configs for each kFixedMaxVecsPerThread,
+    kThreadGroupSize, and kUseVecBlocking
+    """
+    warp_size = items_per_warp // 4
+    # Init configs with the common case
+    # kFixedMaxVecsPerThread = fixed_max_vecs_per_thread
+    # kThreadGroupSize = kWarpSize
+    # kUseVecBlocking = true
+    configs: List[Tuple[int, int, str]] = [
+        (fixed_max_vecs_per_thread, warp_size, "true")
+    ]
+
+    # Generate the cases where an entire embedding row can fit in the
+    # thread-local buffer (i.e., shared memory is not need for grad_sum)
+    if use_subwarp_shuffle:
+        # Generate configs for sub-warp templates
+        group_size = 8  # Smallest group size that TBE supports
+        while group_size < warp_size:
+            # kFixedMaxVecsPerThread = 1
+            # kThreadGroupSize = group_size
+            # kUseVecBlocking = false
+            configs.append((1, group_size, "false"))
+            group_size *= 2
+
+    # Generate configs for the full-warp templates
+    for v in range(1, fixed_max_vecs_per_thread + 1):
+        configs.append((v, warp_size, "false"))
+
+    return configs
+
+
+# Make helper functions visible to code gen
+env.globals["generate_optimized_grad_sum_loop_access"] = (
+    generate_optimized_grad_sum_loop_access
+)
+env.globals["get_max_vecs_template_configs"] = get_max_vecs_template_configs
+
+
+######################################################################
+## Helper functions for the code generator script                   ##
+######################################################################
 
 
 def write(filename: str, s: str) -> None:
@@ -400,6 +514,11 @@ def make_args(
     return {"cpu": cpu, "cuda": cuda, "any_device": any_device}
 
 
+######################################################################
+## Optimizer templates                                              ##
+######################################################################
+
+
 def adagrad() -> Dict[str, Any]:
     split_weight_update = """
       Vec4T<cache_t> m_t(&momentum1[idx * D + d]);
@@ -474,13 +593,16 @@ def rowwise_adagrad() -> Dict[str, Any]:
 
         // compute weight norm
         at::acc_type<cache_t, true> weight_sum_square = 0.0;
-        #pragma unroll kMaxVecsPerThread
-        for (int32_t i = 0;
-                i < kMaxVecsPerThread && 4 * kThreadGroupSize * i + threadIdx.x * 4 < D;
-                ++i) {
-            int32_t d = 4 * kThreadGroupSize * i + threadIdx.x * 4;
+        for (int32_t vec = 0;
+             vec < max_vecs && (kThreadGroupSize * vec + threadIdx.x) * VEC_WIDTH < D;
+             ++vec) {
+            const int32_t d = (kThreadGroupSize * vec + threadIdx.x) * VEC_WIDTH;
             Vec4TAcc<cache_t> weight_new = weight_row_template.load(d, qparams_template);
-            weight_sum_square += weight_new.acc.x * weight_new.acc.x + weight_new.acc.y * weight_new.acc.y + weight_new.acc.z * weight_new.acc.z + weight_new.acc.w * weight_new.acc.w;
+            weight_sum_square
+                += weight_new.acc.x * weight_new.acc.x
+                + weight_new.acc.y * weight_new.acc.y
+                + weight_new.acc.z * weight_new.acc.z
+                + weight_new.acc.w * weight_new.acc.w;
         }
         const at::acc_type<cache_t, true> weight_norm =
             sqrtf(warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(weight_sum_square, shfl_sync_mask));
@@ -491,11 +613,10 @@ def rowwise_adagrad() -> Dict[str, Any]:
         }
         multiplier = SHFL_SYNC(multiplier, 0);
         if (weight_norm > max_norm) {
-            #pragma unroll kMaxVecsPerThread
-            for (int32_t i = 0;
-                    i < kMaxVecsPerThread && 4 * kThreadGroupSize * i + threadIdx.x * 4 < D;
-                    ++i) {
-                int32_t d = 4 * kThreadGroupSize * i + threadIdx.x * 4;
+            for (int32_t vec = 0;
+                 vec < max_vecs && (kThreadGroupSize * vec + threadIdx.x) * VEC_WIDTH < D;
+                 ++vec) {
+                const int32_t d = (kThreadGroupSize * vec + threadIdx.x) * VEC_WIDTH;
                 Vec4TAcc<cache_t> weight_new = weight_row_template.load(d, qparams_template);
 
                 weight_new.acc.x *= multiplier;
@@ -509,17 +630,16 @@ def rowwise_adagrad() -> Dict[str, Any]:
     """
     split_precomputation = """
     at::acc_type<cache_t, true> g_local_sum_square = 0.0;
-    #pragma unroll kMaxVecsPerThread
-    for (int32_t i = 0;
-        i < kMaxVecsPerThread && 4 * kThreadGroupSize * i + threadIdx.x * 4 < D;
-        ++i) {
-        auto gx = grad_sum[i].acc.x;
-        auto gy = grad_sum[i].acc.y;
-        auto gz = grad_sum[i].acc.z;
-        auto gw = grad_sum[i].acc.w;
+    """
+    split_precomputation += generate_optimized_grad_sum_loop_access(
+        """
+        const float4* grad = &{grad_vec}.acc;
+        auto gx = grad->x;
+        auto gy = grad->y;
+        auto gz = grad->z;
+        auto gw = grad->w;
         if (weight_decay_mode == 1) {
             // L2 regularization
-            int32_t d = 4 * kThreadGroupSize * i + threadIdx.x * 4;
             Vec4TAcc<cache_t> weight = weight_row_template.load(d, qparams_template);
             gx += weight_decay * weight.acc.x;
             gy += weight_decay * weight.acc.y;
@@ -527,7 +647,9 @@ def rowwise_adagrad() -> Dict[str, Any]:
             gw += weight_decay * weight.acc.w;
         }
         g_local_sum_square += gx * gx + gy * gy + gz * gz + gw * gw;
-    }
+    """
+    )
+    split_precomputation += """
     const at::acc_type<cache_t, true> g_avg_square =
         warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(g_local_sum_square, shfl_sync_mask) / D;
 
@@ -644,17 +766,16 @@ def rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
     """
     split_precomputation = """
     at::acc_type<cache_t, true> g_local_sum_square = 0.0;
-    #pragma unroll kMaxVecsPerThread
-    for (int32_t i = 0;
-        i < kMaxVecsPerThread && 4 * kThreadGroupSize * i + threadIdx.x * 4 < D;
-        ++i) {
-        auto gx = grad_sum[i].acc.x;
-        auto gy = grad_sum[i].acc.y;
-        auto gz = grad_sum[i].acc.z;
-        auto gw = grad_sum[i].acc.w;
+    """
+    split_precomputation += generate_optimized_grad_sum_loop_access(
+        """
+        const float4* grad = &{grad_vec}.acc;
+        auto gx = grad->x;
+        auto gy = grad->y;
+        auto gz = grad->z;
+        auto gw = grad->w;
         if (weight_decay_mode == 1) {
             // L2 regularization
-            int32_t d = 4 * kThreadGroupSize * i + threadIdx.x * 4;
             Vec4TAcc<cache_t> weight = weight_row_template.load(d, qparams_template);
             gx += weight_decay * weight.acc.x;
             gy += weight_decay * weight.acc.y;
@@ -662,7 +783,9 @@ def rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
             gw += weight_decay * weight.acc.w;
         }
         g_local_sum_square += gx * gx + gy * gy + gz * gz + gw * gw;
-    }
+    """
+    )
+    split_precomputation += """
     const at::acc_type<cache_t, true> g_avg_square =
         warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(g_local_sum_square, shfl_sync_mask) / D;
 
@@ -806,17 +929,15 @@ def rowwise_adagrad_with_counter() -> Dict[str, Any]:
 
     at::acc_type<cache_t, true> g_local_sum_square = 0.0;
     at::acc_type<cache_t, true> w_local_sum_square = 0.0;
+    """
+    split_precomputation += generate_optimized_grad_sum_loop_access(
+        """
+        const float4* grad = &{grad_vec}.acc;
+        auto gx = grad->x;
+        auto gy = grad->y;
+        auto gz = grad->z;
+        auto gw = grad->w;
 
-    #pragma unroll kMaxVecsPerThread
-    for (int32_t i = 0;
-        i < kMaxVecsPerThread && 4 * kThreadGroupSize * i + threadIdx.x * 4 < D;
-        ++i) {
-        auto gx = grad_sum[i].acc.x;
-        auto gy = grad_sum[i].acc.y;
-        auto gz = grad_sum[i].acc.z;
-        auto gw = grad_sum[i].acc.w;
-
-        int32_t d = 4 * kThreadGroupSize * i + threadIdx.x * 4;
         Vec4TAcc<cache_t> weight = weight_row_template.load(d, qparams_template);
 
         // for L2 regularization (weight_decay_mode=1)
@@ -833,8 +954,9 @@ def rowwise_adagrad_with_counter() -> Dict[str, Any]:
         if (regularization_mode == 4) {
             w_local_sum_square += weight.acc.x * weight.acc.x + weight.acc.y * weight.acc.y + weight.acc.z * weight.acc.z + weight.acc.w * weight.acc.w;
         }
-    }
-
+    """
+    )
+    split_precomputation += """
     const at::acc_type<cache_t, true> g_sum_square =
         warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(g_local_sum_square, shfl_sync_mask);
     const at::acc_type<cache_t, true> g_avg_square = g_sum_square / D;
@@ -1002,18 +1124,19 @@ def rowwise_weighted_adagrad() -> Dict[str, Any]:
     """
     split_precomputation = """
     at::acc_type<cache_t, true> g_local_sum_square = 0.0;
-    #pragma unroll kMaxVecsPerThread
-    for (int32_t i = 0;
-        i < kMaxVecsPerThread && 4 * kThreadGroupSize * i + threadIdx.x * 4 < D;
-        ++i) {
-        int32_t d = 4 * kThreadGroupSize * i + threadIdx.x * 4;
+    """
+    split_precomputation += generate_optimized_grad_sum_loop_access(
+        """
+        const float4* grad = &{grad_vec}.acc;
         Vec4TAcc<cache_t> weight = weight_row_template.load(d, qparams_template);
-        auto gx = grad_sum[i].acc.x + weight_decay * weight.acc.x;
-        auto gy = grad_sum[i].acc.y + weight_decay * weight.acc.y;
-        auto gz = grad_sum[i].acc.z + weight_decay * weight.acc.z;
-        auto gw = grad_sum[i].acc.w + weight_decay * weight.acc.w;
+        auto gx = grad->x + weight_decay * weight.acc.x;
+        auto gy = grad->y + weight_decay * weight.acc.y;
+        auto gz = grad->z + weight_decay * weight.acc.z;
+        auto gw = grad->w + weight_decay * weight.acc.w;
         g_local_sum_square += gx * gx + gy * gy + gz * gz + gw * gw;
-    }
+    """
+    )
+    split_precomputation += """
     const at::acc_type<cache_t, true> g_avg_square =
         warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(g_local_sum_square, shfl_sync_mask) / D;
 
@@ -1116,49 +1239,51 @@ def approx_sgd() -> Dict[str, Any]:
 
 def lamb() -> Dict[str, Any]:
     split_precomputation = """
-  at::acc_type<cache_t, true> weight_sum_sq = 0.0;
-  at::acc_type<cache_t, true> rtw_sum_sq = 0.0;
-  auto weight_row = WeightRow<emb_t, cache_t, at::acc_type<cache_t, true>>(weights, cache_weights, D);
-  float2 qparams;
-  if (std::is_same<emb_t, uint8_t>::value && !cache_weights) {
-    qparams = weight_row.load_qparams();
-  }
-#pragma unroll 1
-  for (int32_t i = 0;
-      i < kMaxVecsPerThread && 4 * kThreadGroupSize * i + threadIdx.x * 4 < D;
-      ++i) {
-    int32_t d = 4 * kThreadGroupSize * i + threadIdx.x * 4;
-    Vec4TAcc<cache_t> weight = weight_row.load(d, qparams);
-    Vec4TAcc<cache_t> m1(&momentum1[idx * D + d]);
+    at::acc_type<cache_t, true> weight_sum_sq = 0.0;
+    at::acc_type<cache_t, true> rtw_sum_sq = 0.0;
+    auto weight_row = WeightRow<emb_t, cache_t, at::acc_type<cache_t, true>>(weights, cache_weights, D);
+    float2 qparams;
+    if (std::is_same<emb_t, uint8_t>::value && !cache_weights) {
+      qparams = weight_row.load_qparams();
+    }
+    """
+    split_precomputation += generate_optimized_grad_sum_loop_access(
+        """
+      float4* grad = &{grad_vec}.acc;
 
-    m1.acc.x = beta1 * m1.acc.x + (1.0 - beta1) * grad_sum[i].acc.x;
-    m1.acc.y = beta1 * m1.acc.y + (1.0 - beta1) * grad_sum[i].acc.y;
-    m1.acc.z = beta1 * m1.acc.z + (1.0 - beta1) * grad_sum[i].acc.z;
-    m1.acc.w = beta1 * m1.acc.w + (1.0 - beta1) * grad_sum[i].acc.w;
-    m1.store(&momentum1[idx * D + d]);
+      Vec4TAcc<cache_t> weight = weight_row.load(d, qparams);
+      Vec4TAcc<cache_t> m1(&momentum1[idx * D + d]);
 
-    Vec4TAcc<cache_t> m2(&momentum2[idx * D + d]);
-    m2.acc.x = beta2 * m2.acc.x + (1.0 - beta2) * grad_sum[i].acc.x * grad_sum[i].acc.x;
-    m2.acc.y = beta2 * m2.acc.y + (1.0 - beta2) * grad_sum[i].acc.y * grad_sum[i].acc.y;
-    m2.acc.z = beta2 * m2.acc.z + (1.0 - beta2) * grad_sum[i].acc.z * grad_sum[i].acc.z;
-    m2.acc.w = beta2 * m2.acc.w + (1.0 - beta2) * grad_sum[i].acc.w * grad_sum[i].acc.w;
-    m2.store(&momentum2[idx * D + d]);
+      m1.acc.x = beta1 * m1.acc.x + (1.0 - beta1) * grad->x;
+      m1.acc.y = beta1 * m1.acc.y + (1.0 - beta1) * grad->y;
+      m1.acc.z = beta1 * m1.acc.z + (1.0 - beta1) * grad->z;
+      m1.acc.w = beta1 * m1.acc.w + (1.0 - beta1) * grad->w;
+      m1.store(&momentum1[idx * D + d]);
 
-    // now, we are finished with grad_sum. We can *reuse* grad_sum to store r_t + weight_decay * weight;
-    grad_sum[i].acc.x = (m1.acc.x / (1.0 - powf(beta1, iter))) / (sqrtf((m2.acc.x / (1.0 - powf(beta2, iter)))) + eps) + weight_decay * weight.acc.x;
-    grad_sum[i].acc.y = (m1.acc.y / (1.0 - powf(beta1, iter))) / (sqrtf((m2.acc.y / (1.0 - powf(beta2, iter)))) + eps) + weight_decay * weight.acc.y;
-    grad_sum[i].acc.z = (m1.acc.z / (1.0 - powf(beta1, iter))) / (sqrtf((m2.acc.z / (1.0 - powf(beta2, iter)))) + eps) + weight_decay * weight.acc.z;
-    grad_sum[i].acc.w = (m1.acc.w / (1.0 - powf(beta1, iter))) / (sqrtf((m2.acc.w / (1.0 - powf(beta2, iter)))) + eps) + weight_decay * weight.acc.w;
+      Vec4TAcc<cache_t> m2(&momentum2[idx * D + d]);
+      m2.acc.x = beta2 * m2.acc.x + (1.0 - beta2) * grad->x * grad->x;
+      m2.acc.y = beta2 * m2.acc.y + (1.0 - beta2) * grad->y * grad->y;
+      m2.acc.z = beta2 * m2.acc.z + (1.0 - beta2) * grad->z * grad->z;
+      m2.acc.w = beta2 * m2.acc.w + (1.0 - beta2) * grad->w * grad->w;
+      m2.store(&momentum2[idx * D + d]);
 
-    weight_sum_sq += weight.acc.x * weight.acc.x + weight.acc.y * weight.acc.y + weight.acc.z * weight.acc.z + weight.acc.w * weight.acc.w;
-    rtw_sum_sq += grad_sum[i].acc.x * grad_sum[i].acc.x + grad_sum[i].acc.y * grad_sum[i].acc.y + grad_sum[i].acc.z * grad_sum[i].acc.z + grad_sum[i].acc.w * grad_sum[i].acc.w;
-  }
-  const auto weight_norm =
-      sqrtf(warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(weight_sum_sq, shfl_sync_mask));
-  const auto rtw_norm =
-      sqrtf(warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(rtw_sum_sq, shfl_sync_mask));
-   const auto true_ratio = weight_norm / rtw_norm;
-"""
+      // now, we are finished with grad_sum. We can *reuse* grad_sum to store r_t + weight_decay * weight;
+      grad->x = (m1.acc.x / (1.0 - powf(beta1, iter))) / (sqrtf((m2.acc.x / (1.0 - powf(beta2, iter)))) + eps) + weight_decay * weight.acc.x;
+      grad->y = (m1.acc.y / (1.0 - powf(beta1, iter))) / (sqrtf((m2.acc.y / (1.0 - powf(beta2, iter)))) + eps) + weight_decay * weight.acc.y;
+      grad->z = (m1.acc.z / (1.0 - powf(beta1, iter))) / (sqrtf((m2.acc.z / (1.0 - powf(beta2, iter)))) + eps) + weight_decay * weight.acc.z;
+      grad->w = (m1.acc.w / (1.0 - powf(beta1, iter))) / (sqrtf((m2.acc.w / (1.0 - powf(beta2, iter)))) + eps) + weight_decay * weight.acc.w;
+
+      weight_sum_sq += weight.acc.x * weight.acc.x + weight.acc.y * weight.acc.y + weight.acc.z * weight.acc.z + weight.acc.w * weight.acc.w;
+      rtw_sum_sq += grad->x * grad->x + grad->y * grad->y + grad->z * grad->z + grad->w * grad->w;
+    """
+    )
+    split_precomputation += """
+    const auto weight_norm =
+        sqrtf(warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(weight_sum_sq, shfl_sync_mask));
+    const auto rtw_norm =
+        sqrtf(warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(rtw_sum_sq, shfl_sync_mask));
+     const auto true_ratio = weight_norm / rtw_norm;
+  """
     split_weight_update = """
       weight_new.fma_(grad, -learning_rate * true_ratio);
     """
@@ -1192,16 +1317,17 @@ def lamb() -> Dict[str, Any]:
 def partial_rowwise_lamb() -> Dict[str, Any]:
     split_precomputation = """
     at::acc_type<cache_t, true> g_local_sum_square = 0.0;
-
-    #pragma unroll kMaxVecsPerThread
-    for (int32_t i = 0;
-        i < kMaxVecsPerThread && 4 * kThreadGroupSize * i + threadIdx.x * 4 < D;
-        ++i) {
-    g_local_sum_square += grad_sum[i].acc.x * grad_sum[i].acc.x +
-        grad_sum[i].acc.y * grad_sum[i].acc.y +
-        grad_sum[i].acc.z * grad_sum[i].acc.z +
-        grad_sum[i].acc.w * grad_sum[i].acc.w;
-    }
+    """
+    split_precomputation += generate_optimized_grad_sum_loop_access(
+        """
+        const float4* grad = &{grad_vec}.acc;
+        g_local_sum_square += grad->x * grad->x +
+            grad->y * grad->y +
+            grad->z * grad->z +
+            grad->w * grad->w;
+    """
+    )
+    split_precomputation += """
     const at::acc_type<cache_t, true> g_avg_square =
         warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(g_local_sum_square, shfl_sync_mask) / D;
 
@@ -1220,29 +1346,29 @@ def partial_rowwise_lamb() -> Dict[str, Any]:
     if (std::is_same<emb_t, uint8_t>::value && !cache_weights) {
         qparams = weight_row.load_qparams();
     }
-    #pragma unroll kMaxVecsPerThread
-    for (int32_t i = 0;
-        i < kMaxVecsPerThread && 4 * kThreadGroupSize * i + threadIdx.x * 4 < D;
-        ++i) {
-        int32_t d = 4 * kThreadGroupSize * i + threadIdx.x * 4;
-
+    """
+    split_precomputation += generate_optimized_grad_sum_loop_access(
+        """
+        float4* grad = &{grad_vec}.acc;
         Vec4TAcc<cache_t> m1(&momentum1[idx * D + d]);
-        m1.acc.x = beta1 * m1.acc.x + (1.0 - beta1) * grad_sum[i].acc.x;
-        m1.acc.y = beta1 * m1.acc.y + (1.0 - beta1) * grad_sum[i].acc.y;
-        m1.acc.z = beta1 * m1.acc.z + (1.0 - beta1) * grad_sum[i].acc.z;
-        m1.acc.w = beta1 * m1.acc.w + (1.0 - beta1) * grad_sum[i].acc.w;
+        m1.acc.x = beta1 * m1.acc.x + (1.0 - beta1) * grad->x;
+        m1.acc.y = beta1 * m1.acc.y + (1.0 - beta1) * grad->y;
+        m1.acc.z = beta1 * m1.acc.z + (1.0 - beta1) * grad->z;
+        m1.acc.w = beta1 * m1.acc.w + (1.0 - beta1) * grad->w;
         m1.store(&momentum1[idx * D + d]);
 
         // now, we are finished with grad_sum. We can *reuse* grad_sum to store r_t + weight_decay * weight;
         Vec4TAcc<cache_t> weight = weight_row.load(d, qparams);
-        grad_sum[i].acc.x = (m1.acc.x / (1.0 - powf(beta1, iter))) * m2_hat + weight_decay * weight.acc.x;
-        grad_sum[i].acc.y = (m1.acc.y / (1.0 - powf(beta1, iter))) * m2_hat + weight_decay * weight.acc.y;
-        grad_sum[i].acc.z = (m1.acc.z / (1.0 - powf(beta1, iter))) * m2_hat + weight_decay * weight.acc.z;
-        grad_sum[i].acc.w = (m1.acc.w / (1.0 - powf(beta1, iter))) * m2_hat + weight_decay * weight.acc.w;
+        grad->x = (m1.acc.x / (1.0 - powf(beta1, iter))) * m2_hat + weight_decay * weight.acc.x;
+        grad->y = (m1.acc.y / (1.0 - powf(beta1, iter))) * m2_hat + weight_decay * weight.acc.y;
+        grad->z = (m1.acc.z / (1.0 - powf(beta1, iter))) * m2_hat + weight_decay * weight.acc.z;
+        grad->w = (m1.acc.w / (1.0 - powf(beta1, iter))) * m2_hat + weight_decay * weight.acc.w;
 
         weight_sum_sq += weight.acc.x * weight.acc.x + weight.acc.y * weight.acc.y + weight.acc.z * weight.acc.z + weight.acc.w * weight.acc.w;
-        rtw_sum_sq += grad_sum[i].acc.x * grad_sum[i].acc.x + grad_sum[i].acc.y * grad_sum[i].acc.y + grad_sum[i].acc.z * grad_sum[i].acc.z + grad_sum[i].acc.w * grad_sum[i].acc.w;
-    }
+        rtw_sum_sq += grad->x * grad->x + grad->y * grad->y + grad->z * grad->z + grad->w * grad->w;
+    """
+    )
+    split_precomputation += """
     const auto weight_norm =
       sqrtf(warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(weight_sum_sq));
     const auto rtw_norm =
@@ -1337,15 +1463,17 @@ def adam() -> Dict[str, Any]:
 def partial_rowwise_adam() -> Dict[str, Any]:
     split_precomputation = """
     at::acc_type<cache_t, true> g_local_sum_square = 0.0;
-    #pragma unroll kMaxVecsPerThread
-    for (int32_t i = 0;
-        i < kMaxVecsPerThread && 4 * kThreadGroupSize * i + threadIdx.x * 4 < D;
-        ++i) {
-    g_local_sum_square += grad_sum[i].acc.x * grad_sum[i].acc.x +
-        grad_sum[i].acc.y * grad_sum[i].acc.y +
-        grad_sum[i].acc.z * grad_sum[i].acc.z +
-        grad_sum[i].acc.w * grad_sum[i].acc.w;
-    }
+    """
+    split_precomputation += generate_optimized_grad_sum_loop_access(
+        """
+        const float4* grad = &{grad_vec}.acc;
+        g_local_sum_square += grad->x * grad->x +
+            grad->y * grad->y +
+            grad->z * grad->z +
+            grad->w * grad->w;
+    """
+    )
+    split_precomputation += """
     const at::acc_type<cache_t, true> g_avg_square =
         warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(g_local_sum_square) / D;
 
@@ -1400,29 +1528,30 @@ def partial_rowwise_adam() -> Dict[str, Any]:
 
 def lars_sgd() -> Dict[str, Any]:
     split_precomputation = """
-  at::acc_type<cache_t, true> weight_sum_sq = 0.0;
-  at::acc_type<cache_t, true> grad_sum_sq = 0.0;
+    at::acc_type<cache_t, true> weight_sum_sq = 0.0;
+    at::acc_type<cache_t, true> grad_sum_sq = 0.0;
 
-  auto weight_row = WeightRow<emb_t, cache_t, at::acc_type<cache_t, true>>(weights, cache_weights, D);
-  float2 qparams;
-  if (std::is_same<emb_t, uint8_t>::value && !cache_weights) {
-      qparams = weight_row.load_qparams();
-  }
-#pragma unroll kMaxVecsPerThread
-  for (int32_t i = 0;
-      i < kMaxVecsPerThread && 4 * kThreadGroupSize * i + threadIdx.x * 4 < D;
-      ++i) {
-    int32_t d = 4 * kThreadGroupSize * i + threadIdx.x * 4;
-    Vec4TAcc<cache_t> weight = weight_row.load(d, qparams);
-    weight_sum_sq += weight.acc.x * weight.acc.x + weight.acc.y * weight.acc.y + weight.acc.z * weight.acc.z + weight.acc.w * weight.acc.w;
-    grad_sum_sq += grad_sum[i].acc.x * grad_sum[i].acc.x + grad_sum[i].acc.y * grad_sum[i].acc.y + grad_sum[i].acc.z * grad_sum[i].acc.z + grad_sum[i].acc.w * grad_sum[i].acc.w;
-  }
-  const auto weight_norm =
-      sqrtf(warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(weight_sum_sq));
-  const auto grad_norm =
-      sqrtf(warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(grad_sum_sq));
-   const at::acc_type<cache_t, true> adjusted_lr = learning_rate * eta * weight_norm / (grad_norm + weight_decay * weight_norm);
-"""
+    auto weight_row = WeightRow<emb_t, cache_t, at::acc_type<cache_t, true>>(weights, cache_weights, D);
+    float2 qparams;
+    if (std::is_same<emb_t, uint8_t>::value && !cache_weights) {
+        qparams = weight_row.load_qparams();
+    }
+    """
+    split_precomputation += generate_optimized_grad_sum_loop_access(
+        """
+      const float4* grad = &{grad_vec}.acc;
+      Vec4TAcc<cache_t> weight = weight_row.load(d, qparams);
+      weight_sum_sq += weight.acc.x * weight.acc.x + weight.acc.y * weight.acc.y + weight.acc.z * weight.acc.z + weight.acc.w * weight.acc.w;
+      grad_sum_sq += grad->x * grad->x + grad->y * grad->y + grad->z * grad->z + grad->w * grad->w;
+    """
+    )
+    split_precomputation += """
+    const auto weight_norm =
+        sqrtf(warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(weight_sum_sq));
+    const auto grad_norm =
+        sqrtf(warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(grad_sum_sq));
+     const at::acc_type<cache_t, true> adjusted_lr = learning_rate * eta * weight_norm / (grad_norm + weight_decay * weight_norm);
+    """
 
     split_weight_update = """
       Vec4T<cache_t> m1(&momentum1[idx * D + d]);

--- a/fbgemm_gpu/codegen/embedding_optimizer_split_device_kernel_template.cuh
+++ b/fbgemm_gpu/codegen/embedding_optimizer_split_device_kernel_template.cuh
@@ -16,9 +16,10 @@ using namespace fbgemm_gpu;
 template <
     typename emb_t,
     typename cache_t,
-    size_t kMaxVecsPerThread,
+    int32_t kFixedMaxVecsPerThread,
     int32_t kThreadGroupSize = kWarpSize,
-    int32_t VEC_WIDTH
+    int32_t VEC_WIDTH,
+    bool kUseVecBlocking
 >
 DEVICE_INLINE void split_{{ optimizer }}_table_update_kernel(
     pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits>& dev_weights,
@@ -28,6 +29,8 @@ DEVICE_INLINE void split_{{ optimizer }}_table_update_kernel(
     const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>& weights_offsets,
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>& sorted_lxu_cache_locations,
     Vec4TAcc<cache_t>* grad_sum,
+    Vec4TAcc<cache_t>* smem_grad_sum,
+    Vec4TAcc<cache_t>* shared_weight_update_row,
     const bool stochastic_rounding,
     const at::PhiloxCudaState& stochastic_rounding_philox_args,
     const uint32_t run_id,
@@ -36,15 +39,19 @@ DEVICE_INLINE void split_{{ optimizer }}_table_update_kernel(
     const int32_t t,
     const int64_t idx,
     const uint32_t shfl_sync_mask,
-    const int32_t shared_weight_offset,
+    const int32_t max_vecs_per_thread,
     {{ args.split_ref_kernel_args | replace_pta_namespace() | join(",\n    ") }}
 ) {
-    constexpr auto is_int8 = std::is_same<emb_t, uint8_t>::value;
+    constexpr auto kIsInt8 = std::is_same<emb_t, uint8_t>::value;
+    // Copy value to max_vecs to make max_vecs_per_thread known at compile time
+    // when kUseVecBlocking == false
+    const int32_t max_vecs =
+        kUseVecBlocking ? max_vecs_per_thread : kFixedMaxVecsPerThread;
     const int64_t weights_offset = weights_offsets[t];
     emb_t* __restrict__ weights {nullptr};
     cache_t* __restrict__ cache_weights {nullptr};
     int32_t D_emb = D;
-    if (is_int8) {
+    if (kIsInt8) {
         D_emb += kINT8QparamsBytes;
     }
     const auto weights_placement = static_cast<PlacementType>(weights_placements[t]);
@@ -70,10 +77,6 @@ DEVICE_INLINE void split_{{ optimizer }}_table_update_kernel(
     }
     {%- endfor %}
 
-    struct SharedMemory<Vec4TAcc<cache_t>> weight_update_buffer;
-    Vec4TAcc<cache_t>* shared_weight_update_row =
-        is_int8 ? weight_update_buffer.getPointer() : nullptr;
-
     StochasticRoundingRNGState state;
     auto weight_row_template =
         WeightRow<emb_t, cache_t, at::acc_type<cache_t, true>>(
@@ -85,45 +88,45 @@ DEVICE_INLINE void split_{{ optimizer }}_table_update_kernel(
             threadIdx.x + run_id * blockDim.x);
 
     float2 qparams_template;
-    if (is_int8 && !cache_weights) {
+    if (kIsInt8 && !cache_weights) {
         qparams_template = weight_row_template.load_qparams();
     }
 
     {{ split_precomputation }}
 
     float2 qparams_new;
-#pragma unroll kMaxVecsPerThread
-    for (int32_t i = 0;
-        i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
-        ++i) {
-        int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
-        Vec4TAcc<cache_t> weight_new = weight_row_template.load(d, qparams_template);
-        auto& grad = grad_sum[i];
-        {{ split_weight_update }}
-        if (is_int8 && !cache_weights) {
-            shared_weight_update_row[
-                threadIdx.x + (i * kThreadGroupSize) + shared_weight_offset] = weight_new;
-        } else {
-            // qparams_new not used if type is not int8
-            weight_row_template.store(weight_new, d, qparams_new);
-        }
-    }
+    {{
+       generate_optimized_grad_sum_loop_access(
+           """
+           Vec4TAcc<cache_t> weight_new = weight_row_template.load(d, qparams_template);
+           Vec4TAcc<cache_t>& grad = {grad_vec};
+           {split_weight_update}
+           if (kIsInt8 && !cache_weights) {
+               shared_weight_update_row[d_vec] = weight_new;
+           } else {
+               // qparams_new not used if type is not int8
+               weight_row_template.store(weight_new, d, qparams_new);
+           }
+           """,
+           other_formats={"split_weight_update": split_weight_update},
+       )
+    }}
 
-    if (is_int8 && !cache_weights) {
+    if (kIsInt8 && !cache_weights) {
         // Calculate new qparams after row update
         qparams_new = thrust_find_qparams<at::acc_type<cache_t, true>>(
-            &shared_weight_update_row[shared_weight_offset], D);
+            shared_weight_update_row, D);
         weight_row_template.store_qparams(qparams_new);
 
         // Fetch cached updated row from shared mem and quantize on-the-fly
         // when saving to lowp embedding
-#pragma unroll kMaxVecsPerThread
-        for (int32_t i = 0;
-            i < kMaxVecsPerThread && (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
-            ++i) {
-            const int32_t d = (i * kThreadGroupSize + threadIdx.x) * VEC_WIDTH;
+        for (int32_t vec = 0;
+            (vec * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
+            ++vec) {
+            const int32_t d_vec = vec * kThreadGroupSize + threadIdx.x;
+            const int32_t d = d_vec * VEC_WIDTH;
             weight_row_template.store(
-                shared_weight_update_row[threadIdx.x + (i * kThreadGroupSize) + shared_weight_offset],
+                shared_weight_update_row[d_vec],
                 d,
                 qparams_new);
         }


### PR DESCRIPTION
Summary:
Prior to this diff, TBE GPU training only supported a max embedding
dimension of 1024.  This diff increases this limitation to 2048.

Previously, the binary size of TBE training grew with the embedding
dimension size.  This was because the TBE kernel stores the
accumulation results (bag sum/mean in forward or grad sum in backward)
in a thread-local buffer.  The size of the thread-local buffer depends
on the embedding dimension.  For example, if 32 threads operate on a
single bag in forward and the embedding dimension is 1024, each thread
needs a buffer of size 1024 / 32 = 32 float numbers.  In order to
allocate this buffer, the size of the buffer has to be known at
compile time.  Thus, TBE templatizes the size of the buffer.  There
are 10 templates for different buffer sizes, supporting the embedding
dimension up to 1024.  To increase the max embedding dimension support
to 2048, the number of templates will be doubled. Note that the total
number of templates is the combination of the buffer size templates,
the data type templates (weight types, output types, and cache types),
and other configuration templates (weighted/unweighted,
pooled/sequence).  The buffer size template is one of the biggest
contributors to the overall templates in TBE.

To address the binary size growth problem, this diff makes the number
of templates for the buffer sizes constant by limiting the max buffer
size (in backward only).  If the embedding dimension is larger than
the buffer size, TBE uses shared memory to store data instead.  This
can significantly reduces the number of templates due to the buffer
sizes.

Moreover, from our experimental results, we found that using shared
memory instead of registers as a buffer can significantly improve the
kernel performance for TBE with large embedding dimensions.  We
suspect that this is due to the increase in occupancy.

Differential Revision: D54976743


