### PR TITLE
migrate to FBGEMM version of Permute Pooled Embs module

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/permute_pooled_embedding_modules.py
+++ b/fbgemm_gpu/fbgemm_gpu/permute_pooled_embedding_modules.py
@@ -7,7 +7,6 @@
 
 # pyre-strict
 
-import logging
 from itertools import accumulate
 from typing import List, Optional
 
@@ -34,7 +33,6 @@ class PermutePooledEmbeddings:
         permute: List[int],
         device: Optional[torch.device] = None,
     ) -> None:
-        logging.info("Using Permute Pooled Embeddings")
         self._offset_dim_list: torch.Tensor = torch.tensor(
             [0] + list(accumulate(embs_dims)), device=device, dtype=torch.int64
         )


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/torchrec/pull/1819

migrate to use fbgemm directory version, as it is in pkg already
removes logging for traceability purposes later

Reviewed By: zainhuda

Differential Revision: D55154971


