### PR TITLE
Upgrade CUTLASS (Re-attempt of D55155839)

### DIFF
--- a/fbgemm_gpu/test/test_utils.py
+++ b/fbgemm_gpu/test/test_utils.py
@@ -32,6 +32,11 @@ gpu_unavailable: Tuple[bool, str] = (
 # Used for `if` statements inside tests
 gpu_available: bool = not gpu_unavailable[0]
 
+running_on_sm70: Tuple[bool, str] = (
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 8,
+    "Skip test if SM70, since the code is hardcoded to sm80+ support",
+)
+
 # Used for `@unittest.skipIf` for tests that pass in internal CI, but fail on the GitHub runners
 running_on_github: Tuple[bool, str] = (
     os.getenv("GITHUB_ENV") is not None,


### PR DESCRIPTION
Summary:
- Upgrade `deeplearning/fbgemm/fbgemm_gpu/fb` targets to use CUTLASS v3.  

- Skip `int8_matmul` tests if we are running on SM80, because the existing CUDA implementation appears to be hardcoded to run only on SM80 - https://www.internalfb.com/code/fbsource/[fbc0044928b04927da0051ae31739acc83229107]/fbcode/deeplearning/fbgemm/fbgemm_gpu/fb/src/int8_ops/int8_ops.cu?lines=24

Reviewed By: spcyppt

Differential Revision: D55169265


