### PR TITLE
Limit TBE defused optimizer's max emb dim support to 1024

### DIFF
--- a/fbgemm_gpu/codegen/embedding_optimizer_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/embedding_optimizer_split_kernel_template.cu
@@ -94,7 +94,7 @@ void split_{{ optimizer }}_update_kernel(
 {%- for cache_type in ['float', 'at::Half'] %}
 
 {%- set tuples = [] %}
-{%- for kMaxElemPerThread in range(1, max_embedding_dim // (items_per_warp // 4) + 1) %}
+{%- for kMaxElemPerThread in range(1, legacy_max_embedding_dim // (items_per_warp // 4) + 1) %}
 {%- if kMaxElemPerThread in [1, 2] or kMaxElemPerThread % 4 == 0 %}
     {%- set t0 = [ (kMaxElemPerThread // 4), 1 ] | max if not nobag else "NULL" %}
     {%- set t1 = [ 4 // kMaxElemPerThread, 1] | max %}

--- a/fbgemm_gpu/codegen/embedding_optimizer_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_optimizer_split_template.cu
@@ -78,6 +78,8 @@ void split_embedding_{{ optimizer }}_update(
     TENSORS_ON_SAME_DEVICE(dev_weights, {{ tensor }}_offsets);
     {%- endfor %}
 
+    TORCH_CHECK_LE(max_D, {{ legacy_max_embedding_dim }});
+
     if (grad_dev_indices.numel() == 0) {
         return;
     }
@@ -104,7 +106,7 @@ void split_embedding_{{ optimizer }}_update(
                     at::check_generator<at::CUDAGeneratorImpl>(gen)
                         ->philox_cuda_state(4);
             }
-            {%- for kMaxElemPerThread in range(1, max_embedding_dim // (items_per_warp // 4) + 1) %}
+            {%- for kMaxElemPerThread in range(1, legacy_max_embedding_dim // (items_per_warp // 4) + 1) %}
             {%- if kMaxElemPerThread in [1, 2] or kMaxElemPerThread % 4 == 0 %}
             if (max_D <= {{ items_per_warp // 4 * kMaxElemPerThread }}) {
                 // hipcc can't use max in constexpr


### PR DESCRIPTION
Summary:
This diff temporarily caps the maximum embedding dimension support for
table batched embeddings (TBE) defused optimizers at 1024. This is to
limit the binary size growth when increasing the maximum embedding
dimension support in other components of TBE.

Differential Revision: D55406654


