### PR TITLE
add bag reverse mapping for block_bucketize kernel

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -177,6 +177,49 @@ std::tuple<
     at::Tensor,
     at::Tensor,
     c10::optional<at::Tensor>,
+    c10::optional<at::Tensor>,
+    c10::optional<at::Tensor>,
+    c10::optional<at::Tensor>>
+///@ingroup sparse-data-cuda
+block_bucketize_sparse_features_inference_cuda(
+    const at::Tensor& lengths,
+    const at::Tensor& indices,
+    const bool bucketize_pos,
+    const bool sequence,
+    const at::Tensor& block_sizes,
+    const int64_t my_size,
+    const c10::optional<at::Tensor>& weights,
+    const c10::optional<at::Tensor>& batch_size_per_feature,
+    const int64_t max_batch_size,
+    const c10::optional<std::vector<at::Tensor>>& block_bucketize_pos,
+    const bool return_bucket_mapping);
+
+std::tuple<
+    at::Tensor,
+    at::Tensor,
+    c10::optional<at::Tensor>,
+    c10::optional<at::Tensor>,
+    c10::optional<at::Tensor>,
+    c10::optional<at::Tensor>>
+
+///@ingroup sparse-data-cpu
+block_bucketize_sparse_features_inference_cpu(
+    const at::Tensor& lengths,
+    const at::Tensor& indices,
+    const bool bucketize_pos,
+    const bool sequence,
+    const at::Tensor& block_sizes,
+    const int64_t my_size,
+    const c10::optional<at::Tensor>& weights,
+    const c10::optional<at::Tensor>& batch_size_per_feature,
+    const int64_t max_batch_size,
+    const c10::optional<std::vector<at::Tensor>>& block_bucketize_pos,
+    const bool return_bucket_mapping);
+
+std::tuple<
+    at::Tensor,
+    at::Tensor,
+    c10::optional<at::Tensor>,
     c10::optional<at::Tensor>>
 
 ///@ingroup sparse-data-cuda

--- a/fbgemm_gpu/test/sparse/block_bucketize_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_test.py
@@ -351,6 +351,87 @@ class BlockBucketizeTest(unittest.TestCase):
     @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    def test_block_bucketize_sparse_features_inference(
+        self,
+        index_type: Type[torch.dtype],
+    ) -> None:
+        B = 2
+        # pyre-ignore [6]
+        lengths = torch.tensor([0, 2, 1, 3, 2, 3, 3, 1], dtype=index_type)
+        indices = torch.tensor(
+            [3, 4, 15, 11, 28, 29, 1, 10, 11, 12, 13, 11, 22, 20, 20],
+            # pyre-ignore [6]
+            dtype=index_type,
+        )
+        # pyre-ignore [6]
+        block_sizes = torch.tensor([5, 15, 10, 20], dtype=index_type)
+        my_size = 2
+
+        new_lengths_ref = torch.tensor(
+            [0, 2, 0, 1, 1, 0, 1, 0, 0, 0, 1, 2, 1, 3, 2, 1],
+            # pyre-ignore [6]
+            dtype=index_type,
+        )
+        new_indices_ref = torch.tensor(
+            [3, 4, 11, 1, 11, 0, 13, 14, 0, 1, 2, 3, 2, 0, 0],
+            # pyre-ignore [6]
+            dtype=index_type,
+        )
+        (
+            new_lengths_cpu,
+            new_indices_cpu,
+            _,
+            _,
+            _,
+            bucket_mapping,
+        ) = torch.ops.fbgemm.block_bucketize_sparse_features_inference(
+            lengths,
+            indices,
+            False,
+            True,
+            block_sizes,
+            my_size,
+            None,
+            return_bucket_mapping=True,
+        )
+
+        torch.testing.assert_close(new_lengths_cpu, new_lengths_ref, rtol=0, atol=0)
+        torch.testing.assert_close(new_indices_cpu, new_indices_ref, rtol=0, atol=0)
+
+        if gpu_available:
+            (
+                new_lengths_gpu,
+                new_indices_gpu,
+                _,
+                _,
+                _,
+                bucket_mapping_gpu,
+            ) = torch.ops.fbgemm.block_bucketize_sparse_features_inference(
+                lengths.cuda(),
+                indices.cuda(),
+                False,
+                True,
+                block_sizes.cuda(),
+                my_size,
+                None,
+                return_bucket_mapping=True,
+            )
+            torch.testing.assert_close(
+                new_lengths_gpu.cpu(), new_lengths_ref, rtol=0, atol=0
+            )
+            torch.testing.assert_close(
+                new_lengths_gpu.cpu(), new_lengths_ref, rtol=0, atol=0
+            )
+            torch.testing.assert_allclose(
+                bucket_mapping_gpu.cpu(),
+                bucket_mapping,
+            )
+
+    @skipIfRocm(ROCM_FAILURE_MESSAGE)
+    @given(
+        index_type=st.sampled_from([torch.int, torch.long]),
         has_weight=st.booleans(),
         bucketize_pos=st.booleans(),
         sequence=st.booleans(),

--- a/fbgemm_gpu/test/sparse/failures_dict.json
+++ b/fbgemm_gpu/test/sparse/failures_dict.json
@@ -61,6 +61,16 @@
         "status": "xfail"
       }
     },
+    "fbgemm::block_bucketize_sparse_features_inference": {
+      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_inference": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_inference": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
     "fbgemm::bottom_k_per_row": {
       "MiscOpsTest.test_aot_dispatch_dynamic__test_bottom_unique_k_per_row": {
         "comment": "",


### PR DESCRIPTION
Summary: * we add the per indices bucketize bag reverse index return for inference batching needs.

Differential Revision: D55492793


