### PR TITLE
Switch back to use Nova main branch in main

### DIFF
--- a/.github/workflows/build_wheels_linux_aarch64.yml
+++ b/.github/workflows/build_wheels_linux_aarch64.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@release/2.3
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: wheel
       os: linux-aarch64
@@ -44,7 +44,7 @@ jobs:
             env-var-script: .github/scripts/nova_dir.bash
             package-name: fbgemm_gpu
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@release/2.3
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
     with:
       repository: ${{ matrix.repository }}
       ref: ""

--- a/.github/workflows/build_wheels_linux_x86.yml
+++ b/.github/workflows/build_wheels_linux_x86.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@release/2.3
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: wheel
       os: linux
@@ -36,7 +36,7 @@ jobs:
   build:
     needs: generate-matrix
     name: pytorch/FBGEMM
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@release/2.3
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
     with:
       repository: pytorch/FBGEMM
       ref: ""


### PR DESCRIPTION
Summary:
[Fallback option](https://github.com/pytorch/test-infra/commit/751efc18b9b1aa1740c83064b13d56b64ab36153) is added and merge for Nova @ main branch. We can safely revert D55947486 to use main branch.

D55947486 was to mainly unblock nightly releases and to be used for OSS release cycle.
Note that the change of [switching to Nova release branch](https://github.com/pytorch/FBGEMM/pull/2489#issuecomment-2046505255) had already been cherrypicked into release branch (v0.7.0-release)

Differential Revision: D55993279


