### PR TITLE
Increase dynamic shared memory size to support larger bucket sizes in pooled block_bucketize_sparse_features

### DIFF
--- a/fbgemm_gpu/test/sparse/block_bucketize_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_test.py
@@ -604,16 +604,17 @@ class BlockBucketizeTest(unittest.TestCase):
         has_weight=st.booleans(),
         bucketize_pos=st.booleans(),
         sequence=st.booleans(),
+        my_size=st.sampled_from([3, 194, 256]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    @settings(verbosity=Verbosity.verbose, max_examples=32, deadline=None)
     def test_block_bucketize_sparse_features_large(
         self,
         index_type: Type[torch.dtype],
         has_weight: bool,
         bucketize_pos: bool,
         sequence: bool,
+        my_size: int,
     ) -> None:
-        my_size = 3
         bucket_size = 5
         warp_size = 32
         max_num_thread_in_a_block = 1024


### PR DESCRIPTION
Summary:
If shared memory size per thread block required for `_block_bucketize_pooled_sparse_features_cuda_kernel2` exceeds 48KB, this kernel launch will fail as this is the default shared memory size limit.

To support larger bucket sizes (for large world size), we set the dynamic shared memory size as 2/3 of total available shared mem size (V100: 64 KB; A100: 96 KB; H100: 144 KB)

Reviewed By: sryap

Differential Revision: D56127859


