### PR TITLE
Global weight decay - add num_warmups and lower bound

### DIFF
--- a/fbgemm_gpu/codegen/genscript/jinja_environment.py
+++ b/fbgemm_gpu/codegen/genscript/jinja_environment.py
@@ -338,7 +338,8 @@ def compute_global_weight_decay(is_global_weight_decay_kernel: bool) -> str:
     """
     if is_global_weight_decay_kernel:
         return """
-        const auto global_weight_decay = std::pow(weight_decay_base, iter - prev_iter_dev[linear_index] - 1);
+        const auto prev_iter = prev_iter_dev[linear_index];
+        const auto global_weight_decay = prev_iter == 0 ? 1 : max(gwd_lower_bound, std::pow(weight_decay_base, iter - prev_iter - 1));
         if (threadIdx.x == 0) {
             prev_iter_dev[linear_index] = iter;
         }

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
@@ -152,6 +152,7 @@ batch_index_select_dim0_codegen_backward_kernel_cta_per_row(
     {%- if "iter" not in args.split_function_arg_names %}
     const int64_t iter,
     {%- endif %}
+    const float gwd_lower_bound,
     {%- endif %}
     {%- if is_index_select %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> grad_offsets,
@@ -517,6 +518,7 @@ batch_index_select_dim0_codegen_backward_kernel_cta_per_row
     {%- if "iter" not in args.split_function_arg_names %}
     const int64_t iter,
     {%- endif %}
+    const float gwd_lower_bound,
     {%- endif %}
     {%- if is_index_select %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> grad_offsets,

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -130,6 +130,7 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row(
     {%- if "iter" not in args.split_function_arg_names %}
     const int64_t iter,
     {%- endif %}
+    const float gwd_lower_bound,
     {%- endif %}
     {%- if is_index_select %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> grad_offsets,
@@ -420,6 +421,7 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row
     {%- if "iter" not in args.split_function_arg_names %}
     const int64_t iter,
     {%- endif %}
+    const float gwd_lower_bound,
     {%- endif %}
     {%- if is_index_select %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> grad_offsets,

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_meta_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_meta_template.cpp
@@ -130,6 +130,7 @@ Tensor {{ mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ desc
     {%- if "iter" not in args.split_function_arg_names %}
     const int64_t iter,
     {%- endif %}
+    const double gwd_lower_bound,
     {%- endif -%}
     {{ args.split_function_args_no_defaults | join(", ") }}
     {%- else %}

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -126,6 +126,7 @@ batch_index_select_dim0_codegen_backward_kernel_cta_per_row(
     {%- if "iter" not in args.split_function_arg_names %}
     const int64_t iter,
     {%- endif %}
+    const float gwd_lower_bound,
     {%- endif %}
     {%- if is_index_select %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> grad_offsets,
@@ -207,6 +208,7 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row(
     {%- if "iter" not in args.split_function_arg_names %}
     const int64_t iter,
     {%- endif %}
+    const float gwd_lower_bound,
     {%- endif %}
     {%- if is_index_select %}
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> grad_offsets,
@@ -505,6 +507,7 @@ Tensor {{ embedding_cuda_op }}(
     {%- if "iter" not in args.split_function_arg_names %}
     const int64_t iter,
     {%- endif %}
+    const double gwd_lower_bound,
     {%- endif %}
     {{ args.split_function_args_no_defaults | join(", ") }}
     {%- else %}
@@ -1047,6 +1050,7 @@ Tensor {{ embedding_cuda_op }}(
                             {%- if "iter" not in args.split_function_arg_names %}
                             iter,
                             {%- endif %}
+                            gwd_lower_bound,
                             {%- endif %}
                             {%- if is_index_select %}
                             grad_offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
@@ -1163,6 +1167,7 @@ Tensor {{ embedding_cuda_op }}(
                             {%- if "iter" not in args.split_function_arg_names %}
                             iter,
                             {%- endif %}
+                            gwd_lower_bound,
                             {%- endif %}
                             {%- if is_index_select %}
                             grad_offsets.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
@@ -1260,6 +1265,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
           {%- if "iter" not in args.split_function_arg_names %}
           "    int iter, "
           {%- endif %}
+          "    float gwd_lower_bound, "
           {%- endif %}
           "    {{ args.split_function_schemas | join(", ") }}"
           ") -> Tensor");

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_meta_template.cpp
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_meta_template.cpp
@@ -101,6 +101,7 @@ Tensor
     const double learning_rate,
     const double weight_decay,
     const int64_t iter,
+    const double gwd_lower_bound,
     {%- endif %}
     const bool is_experimental
 ) {

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
@@ -201,6 +201,7 @@ batch_index_select_dim0_codegen_forward_kernel(
     const float learning_rate,
     const float weight_decay,
     const int64_t iter,
+    const float gwd_lower_bound,
     {%- endif %}
     pta::PackedTensorAccessor64<output_t, {{ "1" if is_index_select else "2" }}, at::RestrictPtrTraits> output
     );
@@ -387,6 +388,7 @@ batch_index_select_dim0_codegen_forward_cuda(
     const double learning_rate,
     const double weight_decay,
     const int64_t iter,
+    const double gwd_lower_bound,
     {%- endif %}
     const bool is_experimental
     {%- endif %} {#- /*if is_index_select*/ #}
@@ -488,10 +490,6 @@ batch_index_select_dim0_codegen_forward_cuda(
 
     // Cast info_B_mask from int64_t to uint32_t
     const uint32_t info_B_mask = info_B_mask_int64;
-    {%- endif %}
-
-    {%- if is_gwd_kernel %}
-    TORCH_CHECK(learning_rate > 0, "Expect to apply weight decay but learning rate is < 0")
     {%- endif %}
 
     Tensor output;
@@ -763,6 +761,7 @@ batch_index_select_dim0_codegen_forward_cuda(
                 learning_rate,
                 weight_decay,
                 iter,
+                gwd_lower_bound,
                 {%- endif %} // if not dense
                 MAKE_PTA_WITH_NAME(func_name, output, output_t, 2, 64)
               );
@@ -882,6 +881,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
           "    float learning_rate, "
           "    float weight_decay, "
           "    int iter, "
+          "    float gwd_lower_bound, "
           {%- endif %}
           "    bool is_experimental"
           ") -> Tensor"


### PR DESCRIPTION
Summary:

This diff adds two parameters `num_warmups` and `global_weight_decay_bound`.
- In warmup iterations, global weight decay will not be applied. `num_warmups` is added such that global weight decay would be applied only if current iteration is larger than this `num_warmups` value.
- `global_weight_decay_bound` is used specify the lowest possible value of global weight decay. In other words, `global_weight_decay` will not be smaller than `global_weight_decay_bound`.
 ---
**Usage:**

set
```
optimizer = OptimType.EXACT_ROWWISE_ADAGRAD
weight_decay_mode = WeightDecayMode.DECOUPLE_GLOBAL
num_warmups = 100
global_weight_decay_bound = 0.01
```

e.g.,
```
tbe = SplitTableBatchedEmbeddingBagsCodegen(
            embedding_specs=[
                (E, D, managed_option, ComputeDevice.CUDA) for (E, D) in zip(Es, Ds)
            ],
            optimizer=OptimType.EXACT_ROWWISE_ADAGRAD,
            learning_rate=0.1,
            eps=0.1,
            output_dtype=output_dtype,
            pooling_mode=pooling_mode,
            weight_decay_mode=WeightDecayMode.DECOUPLE_GLOBAL,
            num_warmups = 100
            global_weight_decay_bound = 0.01
      )
```