### PR TITLE
Enable Global Weight Decay for VBE

### DIFF
--- a/fbgemm_gpu/FbgemmGpu.cmake
+++ b/fbgemm_gpu/FbgemmGpu.cmake
@@ -156,6 +156,8 @@ set(gen_gpu_kernel_source_files
     "gen_embedding_forward_dense_unweighted_vbe_codegen_cuda.cu"
     "gen_embedding_forward_split_weighted_vbe_codegen_cuda.cu"
     "gen_embedding_forward_split_unweighted_vbe_codegen_cuda.cu"
+    "gen_embedding_forward_split_weighted_vbe_gwd_codegen_cuda.cu"
+    "gen_embedding_forward_split_unweighted_vbe_gwd_codegen_cuda.cu"
     "gen_batch_index_select_dim0_forward_codegen_cuda.cu"
     "gen_batch_index_select_dim0_forward_kernel.cu"
     "gen_batch_index_select_dim0_forward_kernel_small.cu"
@@ -214,6 +216,7 @@ endforeach()
 # Generate GWD files
 foreach(wdesc weighted unweighted)
   list(APPEND gen_gpu_kernel_source_files
+      "gen_embedding_forward_split_${wdesc}_vbe_gwd_kernel.cu"
       "gen_embedding_forward_split_${wdesc}_gwd_kernel.cu")
 endforeach()
 
@@ -302,6 +305,12 @@ foreach(optimizer ${GWD_OPTIMIZERS})
       "gen_embedding_backward_${optimizer}_split_${wdesc}_gwd_cuda.cu"
       "gen_embedding_backward_${optimizer}_split_${wdesc}_gwd_kernel_cta.cu"
       "gen_embedding_backward_${optimizer}_split_${wdesc}_gwd_kernel_warp.cu")
+    if(";${VBE_OPTIMIZERS};" MATCHES ";${optimizer};")
+      list(APPEND gen_gpu_kernel_source_files
+        "gen_embedding_backward_${optimizer}_split_${wdesc}_vbe_gwd_cuda.cu"
+        "gen_embedding_backward_${optimizer}_split_${wdesc}_vbe_gwd_kernel_cta.cu"
+        "gen_embedding_backward_${optimizer}_split_${wdesc}_vbe_gwd_kernel_warp.cu")
+    endif()
   endforeach()
 endforeach()
 

--- a/fbgemm_gpu/codegen/genscript/generate_backward_split.py
+++ b/fbgemm_gpu/codegen/genscript/generate_backward_split.py
@@ -44,9 +44,7 @@ class BackwardSplitGenerator:
 
         weighted_options = [True, False]
         nobag_options = [True, False] if (not is_gwd) else [False]
-        vbe_options = (
-            [True, False] if (kwargs.get("has_vbe_support") and not is_gwd) else [False]
-        )
+        vbe_options = [True, False] if (kwargs.get("has_vbe_support")) else [False]
         ssd_options = [True, False] if kwargs.get("has_ssd_support") else [False]
         template = CodeTemplate.load(template_filepath)
 

--- a/fbgemm_gpu/codegen/genscript/generate_forward_split.py
+++ b/fbgemm_gpu/codegen/genscript/generate_forward_split.py
@@ -118,7 +118,7 @@ class ForwardSplitGenerator:
             "gen_embedding_forward_{}_gwd_codegen_cuda.cu",
             dense_options=[False],
             nobag_options=[False],  # nobag is not used
-            vbe_options=[False],
+            vbe_options=[True, False],
             is_gwd=True,
             ssd_options=[False],
         )
@@ -148,7 +148,7 @@ class ForwardSplitGenerator:
             "gen_embedding_forward_{}_gwd_kernel.cu",
             dense_options=[False],
             nobag_options=[False],
-            vbe_options=[False],
+            vbe_options=[True, False],
             ssd_options=[False],
             is_gwd=True,
         )

--- a/fbgemm_gpu/codegen/genscript/jinja_environment.py
+++ b/fbgemm_gpu/codegen/genscript/jinja_environment.py
@@ -323,7 +323,6 @@ def is_valid_gwd_config(
     return (
         not dense
         and not nobag
-        and not vbe
         and not is_index_select
         and has_global_weight_decay_support
         and not ssd

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
@@ -1039,7 +1039,13 @@ Tensor {{ bwd_mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function(
     {%- if has_vbe_support %}
     // has vbe support
     if (B_offsets.has_value()) {
-      // vbe
+      {%- if has_global_weight_decay_support %}
+        // vbe and has gwd support
+        if (apply_global_weight_decay && weight_decay > 0) {
+          {{ call_autograd(nobag=False, vbe=True, is_gwd=True) }}
+        }
+      {%- endif %} {#-/* if has_global_weight_decay_support */ #}
+      // vbe and no gwd support
       {{ call_autograd(nobag=False, vbe=True, is_gwd=False) }}
     }
     {%- endif %} {#-/* if has_vbe_support */ #}


### PR DESCRIPTION
Summary:
Enable Global weight decay for VBE
 ---
**Usage:**
set
```
optimizer = OptimType.EXACT_ROWWISE_ADAGRAD
weight_decay_mode = WeightDecayMode.DECOUPLE_GLOBAL

#  for VBE, pass batch_size_per_feature_per_rank
# Example: num_features = 2, num_ranks = 4
batch_size_per_feature_per_rank = [
    [1,  2, 8, 3] # batch sizes for [Rank 0, Rank 1, Rank 2, Rank 3] in Feature 0
    [6, 10, 3, 5] # batch sizes for [Rank 0, Rank 1, Rank 2, Rank 3] in Feature 1
]
```

e.g.,
```
tbe = SplitTableBatchedEmbeddingBagsCodegen(
            embedding_specs=[
                (E, D, managed_option, ComputeDevice.CUDA) for (E, D) in zip(Es, Ds)
            ],
            optimizer=OptimType.EXACT_ROWWISE_ADAGRAD,
            learning_rate=0.1,
            eps=0.1,
            output_dtype=output_dtype,
            pooling_mode=pooling_mode,
            weight_decay_mode=WeightDecayMode.DECOUPLE_GLOBAL,
        )
output = tbe(indices, offsets, batch_size_per_feature_per_rank=batch_size_per_feature_per_rank)
```
Relevant diffs:
D53866750
D55660277
D55660762

Differential Revision: D56200676
