### PR TITLE
Fix the hang issue in some TBE GPU optimizers

### DIFF
--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_device_kernel_template.cuh
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_device_kernel_template.cuh
@@ -11,6 +11,9 @@
 #include "fbgemm_gpu/fbgemm_tensor_accessor.h"
 #include "fbgemm_gpu/split_embeddings_utils.cuh"
 
+#define GROUP_REDUCE_ALL_SUM(val, ...) \
+  warpReduceAllSum<__VA_ARGS__, kThreadGroupSize>(val, shfl_sync_mask)
+
 using namespace fbgemm_gpu;
 
 template <

--- a/fbgemm_gpu/test/tbe/training/backward_optimizers_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_optimizers_test.py
@@ -760,9 +760,6 @@ class BackwardOptimizersTest(unittest.TestCase):
         suppress_health_check=[HealthCheck.filter_too_much, HealthCheck.data_too_large],
     )
     @unittest.skipIf(*gpu_unavailable)
-    @unittest.skip(
-        "is flaky, see https://www.internalfb.com/intern/test/281475047227145?ref_report_id=0"
-    )
     def test_backward_optimizers_adam(  # noqa C901
         self,
         T: int,


### PR DESCRIPTION
Summary:
Previously, some TBE optimizer unit tests hung indefinitely causing
the unit tests to timeout.  We were able to reproduce this problem
consistently by using the config in D50612178 (composed by ezyang).
The main characteristics of this config are (1) the optimizer is
PARTIAL_ROWWISE_ADAM, (2) the embedding dimension is less than 32, and
(3) it contains long segments (i.e., some indices are repeated with
extremely high counts).

Upon our investigation, we identified that the value reduction in
PARTIAL_ROWWISE_ADAM was implemented incorrectly.  The optimizer
intended to perform a value reduction within a sub-warp (i.e., a group
of threads in a warp) instead of an entire warp.  (Note that sub-warp
reduction is done when the embedding dimension is smaller than the
warp size).  However, it did not pass a correct `shfl_sync` mask.  The
wrong mask expected an entire warp to perform the reduction.  When the
segment length is long (> 32), only one sub-warp would perform the
reduction.  Such the warp divergence caused the kernel execution to
freeze.  (Note that the reduction is a collective operation).

This diff fixes the issue by passing a correct mask when invoking the
reduction function.

Reviewed By: shintaro-iwasaki

Differential Revision: D56223375


