### PR TITLE
Always avoid CPU blocking D2H in JaggedIndexSelect2dOp backward

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -1161,13 +1161,7 @@ Tensor jagged_index_add_2d_forward_v2_impl(
     const Tensor& input_offsets,
     const Tensor& output_offsets,
     const int64_t num_output_rows,
-    const c10::optional<int64_t> optional_num_dense_input_rows) {
-  // Intentionally not using optional::value_or here to avoid materializing
-  // .item() call when possible.
-  int64_t num_dense_input_rows = optional_num_dense_input_rows.has_value()
-      ? optional_num_dense_input_rows.value()
-      : input_offsets[input_offsets.numel() - 1].item<int64_t>();
-
+    const int64_t num_dense_input_rows) {
   static auto v1_op =
       c10::Dispatcher::singleton()
           .findSchemaOrThrow("fbgemm::jagged_index_add_2d_forward", "")
@@ -1681,7 +1675,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "jagged_index_add_2d_forward(Tensor values, Tensor indices, Tensor input_offsets, Tensor output_offsets, int num_dense_input_rows, int num_output_rows) -> Tensor");
   m.def(
-      "jagged_index_add_2d_forward_v2(Tensor values, Tensor indices, Tensor input_offsets, Tensor output_offsets, SymInt num_output_rows, int? num_dense_input_rows) -> Tensor",
+      "jagged_index_add_2d_forward_v2(Tensor values, Tensor indices, Tensor input_offsets, Tensor output_offsets, SymInt num_output_rows, SymInt num_dense_input_rows) -> Tensor",
       {PT2_COMPLIANT_TAG});
   m.def(
       "jagged_1d_to_truncated_values(Tensor values, Tensor lengths, int max_truncated_length) -> Tensor");


### PR DESCRIPTION
Summary: Since the value of `num_dense_output_rows` has been computed in forward. Directly save this number (not optional) in context and reuse it to avoid D2H syncs in backward.

Differential Revision: D56212536


