### PR TITLE
Enable global weight decay to TBE (Backend) (#2498)

### DIFF
--- a/fbgemm_gpu/FbgemmGpu.cmake
+++ b/fbgemm_gpu/FbgemmGpu.cmake
@@ -88,6 +88,10 @@ set(VBE_OPTIMIZERS
     rowwise_adagrad_with_counter
     sgd)
 
+# Optimizers with the GWD support
+set(GWD_OPTIMIZERS
+    rowwise_adagrad)
+
 # Individual optimizers (not fused with SplitTBE backward)
 set(DEFUSED_OPTIMIZERS
     rowwise_adagrad)
@@ -155,7 +159,10 @@ set(gen_gpu_kernel_source_files
 if(NOT USE_ROCM)
   list(APPEND gen_gpu_kernel_source_files
     "gen_embedding_forward_split_weighted_v2_kernel.cu"
-    "gen_embedding_forward_split_unweighted_v2_kernel.cu")
+    "gen_embedding_forward_split_unweighted_v2_kernel.cu"
+    "gen_embedding_forward_split_weighted_gwd_codegen_cuda.cu"
+    "gen_embedding_forward_split_unweighted_gwd_codegen_cuda.cu"
+    )
 endif()
 
 foreach(wdesc dense split)
@@ -185,6 +192,14 @@ foreach(wdesc weighted unweighted)
       "gen_embedding_forward_split_${wdesc}_vbe_kernel.cu"
       "gen_embedding_backward_${wdesc}_vbe_split_device_kernel.cuh")
 endforeach()
+
+# Generate GWD files
+if(NOT USE_ROCM)
+foreach(wdesc weighted unweighted)
+  list(APPEND gen_gpu_kernel_source_files
+      "gen_embedding_forward_split_${wdesc}_gwd_kernel.cu")
+endforeach()
+endif()
 
 set(gen_cpu_source_files
     "gen_embedding_forward_quantized_unweighted_codegen_cpu.cpp"
@@ -251,6 +266,18 @@ foreach(optimizer ${VBE_OPTIMIZERS})
       "gen_embedding_backward_${optimizer}_split_${wdesc}_vbe_kernel_warp.cu")
   endforeach()
 endforeach()
+
+if(NOT USE_ROCM)
+foreach(optimizer ${GWD_OPTIMIZERS})
+  # GWD is not supported in nobag
+  foreach(wdesc weighted unweighted)
+    list(APPEND gen_gpu_kernel_source_files
+      "gen_embedding_backward_${optimizer}_split_${wdesc}_gwd_cuda.cu"
+      "gen_embedding_backward_${optimizer}_split_${wdesc}_gwd_kernel_cta.cu"
+      "gen_embedding_backward_${optimizer}_split_${wdesc}_gwd_kernel_warp.cu")
+  endforeach()
+endforeach()
+endif()
 
 foreach(optimizer ${DEFUSED_OPTIMIZERS})
   list(APPEND gen_defused_optim_source_files

--- a/fbgemm_gpu/codegen/genscript/generate_forward_split.py
+++ b/fbgemm_gpu/codegen/genscript/generate_forward_split.py
@@ -8,14 +8,19 @@
 # pyre-strict
 # flake8: noqa F401
 
+import argparse
 import sys
 from typing import List
 
 try:
     from .common import CodeTemplate
+    from .scripts_argsparse import args
 except ImportError:
     # pyre-ignore[21]
     from common import CodeTemplate
+
+    # pyre-ignore[21]
+    from scripts_argsparse import args
 
 
 class ForwardSplitGenerator:
@@ -26,6 +31,7 @@ class ForwardSplitGenerator:
         dense_options: List[bool],
         nobag_options: List[bool],
         vbe_options: List[bool],
+        is_gwd: bool = False,
     ) -> None:
         template = CodeTemplate.load(template_filepath)
         for dense in dense_options:
@@ -51,6 +57,7 @@ class ForwardSplitGenerator:
                                 nobag=nobag,
                                 vbe=vbe,
                                 is_index_select=False,
+                                is_gwd=is_gwd,
                             )
 
     @staticmethod
@@ -98,6 +105,16 @@ class ForwardSplitGenerator:
             nobag_options=[False],  # nobag is not used
             vbe_options=[True, False],
         )
+        # Generate the CUDA host code for global weight decay
+        if not args.is_rocm:
+            ForwardSplitGenerator.render_forward_templates(
+                "training/forward/embedding_forward_split_template.cu",
+                "gen_embedding_forward_{}_gwd_codegen_cuda.cu",
+                dense_options=[False],
+                nobag_options=[False],  # nobag is not used
+                vbe_options=[False],
+                is_gwd=True,
+            )
 
         # Generate the meta kernels
         ForwardSplitGenerator.render_forward_templates(
@@ -116,6 +133,16 @@ class ForwardSplitGenerator:
             nobag_options=[True, False],
             vbe_options=[True, False],
         )
+        # Generate the global weight decay CUDA kernels
+        if not args.is_rocm:
+            ForwardSplitGenerator.render_forward_templates(
+                "training/forward/embedding_forward_split_kernel_template.cu",
+                "gen_embedding_forward_{}_gwd_kernel.cu",
+                dense_options=[False],
+                nobag_options=[False],
+                vbe_options=[False],
+                is_gwd=True,
+            )
 
         # Generate the v2 CUDA kernels
         ForwardSplitGenerator.render_forward_templates(

--- a/fbgemm_gpu/codegen/genscript/optimizers.py
+++ b/fbgemm_gpu/codegen/genscript/optimizers.py
@@ -41,6 +41,7 @@ def dense() -> Dict[str, Any]:
         "has_cpu_support": True,
         "has_gpu_support": True,
         "has_vbe_support": False,
+        "has_global_weight_decay_support": False,
     }
 
 
@@ -84,6 +85,7 @@ def adagrad() -> Dict[str, Any]:
         "has_cpu_support": True,
         "has_gpu_support": True,
         "has_vbe_support": False,
+        "has_global_weight_decay_support": False,
     }
 
 
@@ -191,7 +193,7 @@ def rowwise_adagrad() -> Dict[str, Any]:
         if (weight_decay_mode == 1) {
             // L2 regularization
             correction = 1.0 - multiplier * weight_decay;
-        } else if (weight_decay_mode == 2) {
+        } else if (weight_decay_mode == 2 || weight_decay_mode == 5) {
             // Decoupled weight decay
             correction = 1.0 - learning_rate * weight_decay;
         } else {
@@ -221,7 +223,7 @@ def rowwise_adagrad() -> Dict[str, Any]:
         if (weight_decay_mode == 1) {
             // L2 regularization
             correction = 1.0 - multiplier * weight_decay;
-        } else if (weight_decay_mode == 2) {
+        } else if (weight_decay_mode == 2 || weight_decay_mode == 5) {
             // Decoupled weight decay
             correction = 1.0 - learning_rate * weight_decay;
         } else {
@@ -252,6 +254,7 @@ def rowwise_adagrad() -> Dict[str, Any]:
         "has_cpu_support": True,
         "has_gpu_support": True,
         "has_vbe_support": True,
+        "has_global_weight_decay_support": True,
     }
 
 
@@ -282,6 +285,7 @@ def approx_rowwise_adagrad() -> Dict[str, Any]:
         "has_cpu_support": False,
         "has_gpu_support": False,
         "has_vbe_support": False,
+        "has_global_weight_decay_support": False,
     }
 
 
@@ -387,6 +391,7 @@ def rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
         "has_cpu_support": False,
         "has_gpu_support": False,
         "has_vbe_support": False,
+        "has_global_weight_decay_support": False,
     }
 
 
@@ -422,6 +427,7 @@ def approx_rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
         "has_cpu_support": False,
         "has_gpu_support": False,
         "has_vbe_support": False,
+        "has_global_weight_decay_support": False,
     }
 
 
@@ -592,6 +598,7 @@ def rowwise_adagrad_with_counter() -> Dict[str, Any]:
         "has_cpu_support": False,
         "has_gpu_support": True,
         "has_vbe_support": True,
+        "has_global_weight_decay_support": False,
     }
 
 
@@ -640,6 +647,7 @@ def approx_rowwise_adagrad_with_counter() -> Dict[str, Any]:
         "has_cpu_support": False,
         "has_gpu_support": False,
         "has_vbe_support": False,
+        "has_global_weight_decay_support": False,
     }
 
 
@@ -717,6 +725,7 @@ def rowwise_weighted_adagrad() -> Dict[str, Any]:
         "has_cpu_support": False,
         "has_gpu_support": False,
         "has_vbe_support": False,
+        "has_global_weight_decay_support": False,
     }
 
 
@@ -740,6 +749,7 @@ def sgd() -> Dict[str, Any]:
         "has_cpu_support": True,
         "has_gpu_support": True,
         "has_vbe_support": True,
+        "has_global_weight_decay_support": False,
     }
 
 
@@ -763,6 +773,7 @@ def approx_sgd() -> Dict[str, Any]:
         "has_cpu_support": False,
         "has_gpu_support": False,
         "has_vbe_support": False,
+        "has_global_weight_decay_support": False,
     }
 
 
@@ -840,6 +851,7 @@ def lamb() -> Dict[str, Any]:
         "has_cpu_support": False,
         "has_gpu_support": True,
         "has_vbe_support": False,
+        "has_global_weight_decay_support": False,
     }
 
 
@@ -931,6 +943,7 @@ def partial_rowwise_lamb() -> Dict[str, Any]:
         "has_cpu_support": False,
         "has_gpu_support": True,
         "has_vbe_support": False,
+        "has_global_weight_decay_support": False,
     }
 
 
@@ -986,6 +999,7 @@ def adam() -> Dict[str, Any]:
         "has_cpu_support": False,
         "has_gpu_support": True,
         "has_vbe_support": False,
+        "has_global_weight_decay_support": False,
     }
 
 
@@ -1060,6 +1074,7 @@ def partial_rowwise_adam() -> Dict[str, Any]:
         "has_cpu_support": False,
         "has_gpu_support": True,
         "has_vbe_support": False,
+        "has_global_weight_decay_support": False,
     }
 
 
@@ -1124,6 +1139,7 @@ def lars_sgd() -> Dict[str, Any]:
         "has_cpu_support": False,
         "has_gpu_support": True,
         "has_vbe_support": False,
+        "has_global_weight_decay_support": False,
     }
 
 
@@ -1141,4 +1157,5 @@ def none_optimizer() -> Dict[str, Any]:
         "has_cpu_support": False,
         "has_gpu_support": True,
         "has_vbe_support": False,
+        "has_global_weight_decay_support": False,
     }

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
@@ -116,10 +116,18 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel(
 {% endif %} {#-/* if not dense */#}
 
 
-{%- for nobag in [True, False] %}
+{%- for nobag in ([True, False] if (not is_gwd) else [False]) %}
 {%- set ndesc = "_nobag" if nobag else "" %}
 {%- if is_valid_forward_config(nobag, weighted, vbe, is_index_select) %}
 {%- set has_experimental = has_experimental_support(dense, nobag, vbe, is_index_select, is_rocm) %}
+
+{%- set is_gwd_kernel = is_gwd and is_valid_gwd_config(
+    dense,
+    nobag,
+    vbe,
+    is_index_select,
+    is_rocm) %}
+{%- set gwddesc = "_gwd" if is_gwd_kernel else "" %}
 template <
     typename emb_t,
     typename cache_t,
@@ -137,7 +145,7 @@ __launch_bounds__(kForwardMaxThreads) __global__ void
 {%- if is_index_select %}
 batch_index_select_dim0_codegen_forward_kernel(
 {%- else %}
-{{ ddesc }}_embedding{{ ndesc }}_codegen_forward_{{ wdesc }}{{ vdesc }}_kernel(
+{{ ddesc }}_embedding{{ ndesc }}_codegen_forward_{{ wdesc }}{{ vdesc }}{{ gwddesc }}_kernel(
 {%- endif %}
     const pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
     {%- if not dense %}
@@ -179,9 +187,15 @@ batch_index_select_dim0_codegen_forward_kernel(
     const int32_t fixed_L_per_warp,
     const bool permute_output_dim_0_1,
     {%- endif %} // if dense
+    {%- if is_gwd_kernel %}
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> hash_size_cumsum,
+    const pta::PackedTensorAccessor64<float, 1, at::RestrictPtrTraits> prev_iter_dev,
+    const float learning_rate,
+    const float weight_decay,
+    const int64_t iter,
+    {%- endif %}
     pta::PackedTensorAccessor64<output_t, {{ "1" if is_index_select else "2" }}, at::RestrictPtrTraits> output
     );
-
 {%- endif %} {#-/* if is_valid_forward_config(...) */#}
 {%- endfor %} {#-/* for nobag in [True, False] */#}
 
@@ -291,16 +305,24 @@ batch_index_select_dim0_codegen_forward_kernel(
 // Kernel Definitions
 ////////////////////////////////////////////////////////////////////////////////
 
-{%- for nobag in [True, False] %}
+{%- for nobag in ([True, False] if (not is_gwd) else [False]) %}
 {%- set ndesc = "_nobag" if nobag else "" %}
 {%- if is_valid_forward_config(nobag, weighted, vbe, is_index_select) %}
 {%- set has_experimental = has_experimental_support(dense, nobag, vbe, is_index_select, is_rocm) %}
 
+{#- /* Generate a separate cuda host to enable global weight decay using Jinja */ #}
+{%- set is_gwd_kernel = is_gwd and is_valid_gwd_config(
+    dense,
+    nobag,
+    vbe,
+    is_index_select,
+    is_rocm) %}
+{%- set gwddesc = "_gwd" if is_gwd_kernel else "" %}
 Tensor
 {%- if is_index_select %}
 batch_index_select_dim0_codegen_forward_cuda(
 {%- else %}
-{{ ddesc }}_embedding{{ ndesc }}_codegen_forward_{{ wdesc }}{{ vdesc }}_cuda(
+{{ ddesc }}_embedding{{ ndesc }}_codegen_forward_{{ wdesc }}{{ vdesc }}{{ gwddesc }}_cuda(
 {%- endif %}
     const Tensor& dev_weights,
     {%- if not dense %}
@@ -350,7 +372,16 @@ batch_index_select_dim0_codegen_forward_cuda(
     const int64_t info_B_num_bits, // int32_t
     const int64_t info_B_mask_int64, // uint32_t
     {%- endif %}
+    {%- if is_gwd_kernel %}
+    const bool is_experimental,
+    const Tensor& hash_size_cumsum,
+    const Tensor& prev_iter_dev,
+    const double learning_rate,
+    const double weight_decay,
+    const int64_t iter
+    {%- else %}
     const bool is_experimental
+    {%- endif %}
     {%- endif %}
 ) {
     {%- if not nobag or is_index_select %}
@@ -396,6 +427,9 @@ batch_index_select_dim0_codegen_forward_cuda(
         {%- endif %}
         {%- if is_index_select %}
         total_L_offsets,
+        {%- endif %}
+        {%- if is_gwd_kernel %}
+        prev_iter_dev,
         {%- endif %}
         dev_weights
     );
@@ -444,6 +478,10 @@ batch_index_select_dim0_codegen_forward_cuda(
 
     // Cast info_B_mask from int64_t to uint32_t
     const uint32_t info_B_mask = info_B_mask_int64;
+    {%- endif %}
+
+    {%- if is_gwd_kernel %}
+    TORCH_CHECK(learning_rate > 0, "Expect to apply weight decay but learning rate is < 0")
     {%- endif %}
 
     Tensor output;
@@ -650,8 +688,9 @@ batch_index_select_dim0_codegen_forward_cuda(
                 else "DISPATCH_OPTIMAL_FORWARD_KERNEL"
           %}
           {{ dispatcher }}(max_D, [&] {
+
 #ifdef FBGEMM_GPU_MEMCHECK
-            const auto func_name = "{{ ddesc }}_embedding_codegen_forward_{{ wdesc }}{{ vdesc }}_kernel";
+            const auto func_name = "{{ ddesc }}_embedding_codegen_forward_{{ wdesc }}{{ vdesc }}{{ gwddesc }}_kernel";
 #endif
             // Other components in TBE (backward, backward_indice_weights) use
             // kFixedMaxVecsPerThread. Thus, the codegen generates
@@ -659,7 +698,7 @@ batch_index_select_dim0_codegen_forward_cuda(
             // kMaxVecsPerThread and kFixedMaxVecsPerThread are the same
             // forward
             constexpr auto kMaxVecsPerThread = kFixedMaxVecsPerThread;
-            {{ ddesc }}_embedding_codegen_forward_{{ wdesc }}{{ vdesc }}_kernel
+            {{ ddesc }}_embedding_codegen_forward_{{ wdesc }}{{ vdesc }}{{ gwddesc }}_kernel
                 <emb_t,
                 cache_t,
                 output_t,
@@ -702,6 +741,13 @@ batch_index_select_dim0_codegen_forward_cuda(
                 uvm_cache_stats.size(0) == 0
                     ? nullptr
                     : (uvm_cache_stats.data_ptr<int32_t>() + uvm_cache_stats_index::num_conflict_unique_misses),
+                {%- endif %} // if not dense
+                {%- if is_gwd_kernel %}
+                MAKE_PTA_WITH_NAME(func_name, hash_size_cumsum, int64_t, 1, 32),
+                MAKE_PTA_WITH_NAME(func_name, prev_iter_dev, float, 1, 64),
+                learning_rate,
+                weight_decay,
+                iter,
                 {%- endif %} // if not dense
                 MAKE_PTA_WITH_NAME(func_name, output, output_t, 2, 64)
               );
@@ -768,14 +814,15 @@ batch_index_select_dim0_codegen_forward_cuda(
   return output;
 }
 
+
 ////////////////////////////////////////////////////////////////////////////////
 // Op registrations
 ////////////////////////////////////////////////////////////////////////////////
 {%- if not is_index_select %}
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
     {%- set embedding_codegen_forward_op =
-        "{}_embedding{}_codegen_forward_{}{}_cuda".format(
-            ddesc, ndesc, wdesc, vdesc
+        "{}_embedding{}_codegen_forward_{}{}{}_cuda".format(
+            ddesc, ndesc, wdesc, vdesc, gwddesc
         )
     %}
     m.def("{{ embedding_codegen_forward_op }}("
@@ -813,7 +860,16 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
           "    int info_B_num_bits, "
           "    int info_B_mask_int64, "
           {%- endif %}
+          {%- if is_gwd_kernel %}
+          "    bool is_experimental,"
+          "    Tensor hash_size_cumsum, "
+          "    Tensor prev_iter_dev, "
+          "    float learning_rate, "
+          "    float weight_decay, "
+          "    int iter "
+          {%- else %}
           "    bool is_experimental"
+          {%- endif %}
           ") -> Tensor"
           {%- if not dense and not nobag and not vbe %}
           // only split_embedding_codegen_forward_[un]weighted_cuda

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_kernel_template.cu
@@ -92,6 +92,10 @@ void split_{{ optimizer }}_update_kernel(
           D,
           0, // t
           grad_dev_indices[run_id], // idx
+          // global weight decay is not supported in split optimizer
+          {%- if has_global_weight_decay_support %}
+          1.0, // global_weight_decay
+          {%- endif %}
           shfl_sync_mask,
           kMaxVecsPerThread,
           {{ args.split_function_arg_names | join(", ") }});


### PR DESCRIPTION
Summary:

With existing implementation for sparse embedding tables with rowwise adagrad, weight decay is performed to update the weights only when an ID and its corresponding embedding row appears within a training batch. This means that rows that do not show up won't be updated nor decayed, and hence the embedding table only gets *local* but not *global* weight decay.

---
**Usage:**
set 
```
optimizer = OptimType.EXACT_ROWWISE_ADAGRAD
weight_decay_mode = WeightDecayMode.DECOUPLE_GLOBAL
```

e.g.,
```
tbe = SplitTableBatchedEmbeddingBagsCodegen(
            embedding_specs=[
                (E, D, managed_option, ComputeDevice.CUDA) for (E, D) in zip(Es, Ds)
            ],
            optimizer=OptimType.EXACT_ROWWISE_ADAGRAD,
            learning_rate=0.1,
            eps=0.1,
            output_dtype=output_dtype,
            pooling_mode=pooling_mode,
            weight_decay_mode=WeightDecayMode.DECOUPLE_GLOBAL,
        )
```
