### PR TITLE
fix reorder indices op gpu

### DIFF
--- a/fbgemm_gpu/bench/sparse_ops_benchmark.py
+++ b/fbgemm_gpu/bench/sparse_ops_benchmark.py
@@ -31,10 +31,7 @@ if open_source:
 else:
     from fbgemm_gpu.bench.bench_utils import benchmark_torch_function
 
-    if torch.version.hip:
-        torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_hip")
-    else:
-        torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/codegen:index_select_ops")
 

--- a/fbgemm_gpu/src/sparse_ops/sparse_reorder_batched_ad.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_reorder_batched_ad.cu
@@ -351,9 +351,10 @@ DLL_PUBLIC Tensor reorder_batched_ad_indices_gpu(
     }
   }
   constexpr auto NUM_WARPS = 32;
-  const dim3 threads(NUM_WARPS, kWarpSize); // 32 x 32
+  auto maxWarpSize = kMaxThreads / NUM_WARPS;
+  const dim3 threads(
+      NUM_WARPS, maxWarpSize < kWarpSize ? maxWarpSize : kWarpSize); // 32 x 32
   const dim3 blocks(cuda_calc_xblock_count(B * T, NUM_WARPS));
-
   DISPATCH_SINGLE_HALF_FP_INT32_64_TYPES(
       cat_ad_indices.scalar_type(),
       "reorder_batched_ad_indices_gpu_kernel_1",


### PR DESCRIPTION
Summary:
It throws invalid argument error because num of threads per block would be 32 * 64 for hip which exceeds the limit (1024). We need to either make it 32 * 32 or 16 * 64

# Why choose 32 * 32 over 16 * 16
I didn't run many different inputs setup though but only the following command
```
buck2 run mode/{opt,amd-gpu} -c fbcode.use_link_groups=True -c fbcode.enable_gpu_sections=true deeplearning/fbgemm/fbgemm_gpu:sparse_ops_benchmark --  reorder-batched-ad-indices-bench --device="cuda"
```

The above command shows that
num warp = 32 (32 * 32): fbgemm_gpu time: 1.85434 ms (3569.53566 GB/s)
num warp = 16 (16 * 64): fbgemm_gpu time: 2.10100 ms (3150.46812 GB/s)

And I picked num warp 32 (we probably can tune it a bit more by testing on different input setups).

Differential Revision: D56362651


