### PR TITLE
Add backend for supporting many optim state types

### DIFF
--- a/fbgemm_gpu/codegen/genscript/generate_index_select.py
+++ b/fbgemm_gpu/codegen/genscript/generate_index_select.py
@@ -14,27 +14,23 @@ from typing import Optional
 
 try:
     from .common import CodeTemplate
-    from .optimizer_args import (
-        FLOAT,
-        OptimizerArgsSet,
-        OptimizerArgsSetItem as OptimItem,
-    )
+    from .optimizer_args import OptimizerArgsSet, OptimizerArgsSetItem as OptimItem
+    from .torch_type_utils import ArgType
 except ImportError:
     # pyre-ignore[21]
     from common import CodeTemplate
 
     # pyre-ignore[21]
-    from optimizer_args import (
-        FLOAT,
-        OptimizerArgsSet,
-        OptimizerArgsSetItem as OptimItem,
-    )
+    from optimizer_args import OptimizerArgsSet, OptimizerArgsSetItem as OptimItem
+
+    # pyre-ignore[21]
+    from torch_type_utils import ArgType
 
 
 class IndexSelectGenerator:
     @staticmethod
     def generate() -> None:
-        optargs = OptimizerArgsSet.create([OptimItem(FLOAT, "unused")])
+        optargs = OptimizerArgsSet.create([OptimItem(ArgType.FLOAT, "unused")])
         for template_file, generated_file in [
             (
                 "training/forward/embedding_forward_split_template.cu",

--- a/fbgemm_gpu/codegen/genscript/generate_index_select.py
+++ b/fbgemm_gpu/codegen/genscript/generate_index_select.py
@@ -14,19 +14,27 @@ from typing import Optional
 
 try:
     from .common import CodeTemplate
-    from .optimizer_args import FLOAT, OptimizerArgsSet
+    from .optimizer_args import (
+        FLOAT,
+        OptimizerArgsSet,
+        OptimizerArgsSetItem as OptimItem,
+    )
 except ImportError:
     # pyre-ignore[21]
     from common import CodeTemplate
 
     # pyre-ignore[21]
-    from optimizer_args import FLOAT, OptimizerArgsSet
+    from optimizer_args import (
+        FLOAT,
+        OptimizerArgsSet,
+        OptimizerArgsSetItem as OptimItem,
+    )
 
 
 class IndexSelectGenerator:
     @staticmethod
     def generate() -> None:
-        optargs = OptimizerArgsSet.create([(FLOAT, "unused")])
+        optargs = OptimizerArgsSet.create([OptimItem(FLOAT, "unused")])
         for template_file, generated_file in [
             (
                 "training/forward/embedding_forward_split_template.cu",

--- a/fbgemm_gpu/codegen/genscript/optimizer_args.py
+++ b/fbgemm_gpu/codegen/genscript/optimizer_args.py
@@ -11,6 +11,7 @@
 
 
 import argparse
+import itertools
 import os
 import re
 from dataclasses import dataclass
@@ -18,8 +19,11 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import jinja2
 
-# pyre-ignore[5]
-TENSOR, INT_TENSOR, LONG_TENSOR, INT, FLOAT = range(5)
+try:
+    from .torch_type_utils import arg_type_to_tensor_type, ArgType, TensorType
+except ImportError:
+    # pyre-ignore[21]
+    from torch_type_utils import arg_type_to_tensor_type, ArgType, TensorType
 
 
 ######################################################################
@@ -52,6 +56,10 @@ def _arg(
     )
 
 
+def demangle_name(name: str) -> str:
+    return name.replace("_dev", "").replace("_uvm", "")
+
+
 def acc_cache_tensor_arg_constructor(name: str, gpu: bool = True) -> str:
     return _arg_constructor(
         "at::acc_type<" + ("cache_t" if gpu else "scalar_t") + ", true>",
@@ -61,9 +69,30 @@ def acc_cache_tensor_arg_constructor(name: str, gpu: bool = True) -> str:
     )
 
 
+def acc_placeholder_tensor_arg_constructor(name: str, gpu: bool = True) -> str:
+    return _arg_constructor(
+        demangle_name(name) + "_ph_t",
+        name,
+        gpu=gpu,
+        precision=64,
+    )
+
+
 def acc_cache_tensor_arg(name: str, gpu: bool = True, pass_by_ref: bool = False) -> str:
     return _arg(
         "at::acc_type<" + ("cache_t" if gpu else "scalar_t") + ", true>",
+        name,
+        gpu=gpu,
+        precision=64,
+        pass_by_ref=pass_by_ref,
+    )
+
+
+def acc_placeholder_tensor_arg(
+    name: str, gpu: bool = True, pass_by_ref: bool = False
+) -> str:
+    return _arg(
+        demangle_name(name) + "_ph_t",
         name,
         gpu=gpu,
         precision=64,
@@ -120,18 +149,21 @@ def int_arg(name: str, default: int = 0) -> str:
 
 
 def make_kernel_arg(
-    ty: int, name: str, default: Union[int, float, None], pass_by_ref: bool = False
+    ty: ArgType, name: str, default: Union[int, float, None], pass_by_ref: bool = False
 ) -> str:
     return {
-        TENSOR: lambda x: acc_cache_tensor_arg(x, pass_by_ref=pass_by_ref),
-        INT_TENSOR: lambda x: int_tensor_arg(x, pass_by_ref=pass_by_ref),
-        LONG_TENSOR: lambda x: long_tensor_arg(x, pass_by_ref=pass_by_ref),
-        INT: (
+        ArgType.TENSOR: lambda x: acc_cache_tensor_arg(x, pass_by_ref=pass_by_ref),
+        ArgType.INT_TENSOR: lambda x: int_tensor_arg(x, pass_by_ref=pass_by_ref),
+        ArgType.LONG_TENSOR: lambda x: long_tensor_arg(x, pass_by_ref=pass_by_ref),
+        ArgType.PLACEHOLDER_TENSOR: lambda x: acc_placeholder_tensor_arg(
+            x, pass_by_ref=pass_by_ref
+        ),
+        ArgType.INT: (
             (lambda x: int64_arg(x, default=int(default)))
             if default is not None
             else int64_arg_no_default
         ),
-        FLOAT: (
+        ArgType.FLOAT: (
             (lambda x: float_arg(x, default=default))
             if default is not None
             else float_arg_no_default
@@ -139,47 +171,55 @@ def make_kernel_arg(
     }[ty](name)
 
 
-def make_kernel_arg_constructor(ty: int, name: str) -> str:
+def make_kernel_arg_constructor(ty: ArgType, name: str) -> str:
     return {
-        TENSOR: acc_cache_tensor_arg_constructor,
-        INT_TENSOR: int_tensor_arg_constructor,
-        LONG_TENSOR: long_tensor_arg_constructor,
-        INT: lambda x: x,
-        FLOAT: lambda x: x,
+        ArgType.TENSOR: acc_cache_tensor_arg_constructor,
+        ArgType.INT_TENSOR: int_tensor_arg_constructor,
+        ArgType.LONG_TENSOR: long_tensor_arg_constructor,
+        ArgType.PLACEHOLDER_TENSOR: acc_placeholder_tensor_arg_constructor,
+        ArgType.INT: lambda x: x,
+        ArgType.FLOAT: lambda x: x,
     }[ty](name)
 
 
-def make_cpu_kernel_arg(ty: int, name: str, default: Union[int, float]) -> str:
+def make_cpu_kernel_arg(ty: ArgType, name: str, default: Union[int, float]) -> str:
     return {
-        TENSOR: lambda x: acc_cache_tensor_arg(x, gpu=False),
-        INT_TENSOR: lambda x: int_tensor_arg(x, gpu=False),
-        LONG_TENSOR: lambda x: long_tensor_arg(x, gpu=False),
-        INT: lambda x: int64_arg(x, default=int(default)),
-        FLOAT: lambda x: float_arg(x, default=default),
+        ArgType.TENSOR: lambda x: acc_cache_tensor_arg(x, gpu=False),
+        ArgType.INT_TENSOR: lambda x: int_tensor_arg(x, gpu=False),
+        ArgType.LONG_TENSOR: lambda x: long_tensor_arg(x, gpu=False),
+        ArgType.PLACEHOLDER_TENSOR: acc_cache_tensor_arg_constructor,
+        ArgType.INT: lambda x: int64_arg(x, default=int(default)),
+        ArgType.FLOAT: lambda x: float_arg(x, default=default),
     }[ty](name)
 
 
-def make_cpu_kernel_arg_constructor(ty: int, name: str) -> str:
+def make_cpu_kernel_arg_constructor(ty: ArgType, name: str) -> str:
     return {
-        TENSOR: lambda x: acc_cache_tensor_arg_constructor(x, gpu=False),
-        INT_TENSOR: lambda x: int_tensor_arg_constructor(x, gpu=False),
-        LONG_TENSOR: lambda x: long_tensor_arg_constructor(x, gpu=False),
-        INT: lambda x: x,
-        FLOAT: lambda x: x,
+        ArgType.TENSOR: lambda x: acc_cache_tensor_arg_constructor(x, gpu=False),
+        ArgType.INT_TENSOR: lambda x: int_tensor_arg_constructor(x, gpu=False),
+        ArgType.LONG_TENSOR: lambda x: long_tensor_arg_constructor(x, gpu=False),
+        ArgType.PLACEHOLDER_TENSOR: lambda x: acc_cache_tensor_arg_constructor(
+            x, gpu=False
+        ),
+        ArgType.INT: lambda x: x,
+        ArgType.FLOAT: lambda x: x,
     }[ty](name)
 
 
-def make_function_arg(ty: int, name: str, default: Optional[Union[int, float]]) -> str:
+def make_function_arg(
+    ty: ArgType, name: str, default: Optional[Union[int, float]]
+) -> str:
     return {
-        TENSOR: tensor_arg,
-        INT_TENSOR: tensor_arg,
-        LONG_TENSOR: tensor_arg,
-        INT: (
+        ArgType.TENSOR: tensor_arg,
+        ArgType.INT_TENSOR: tensor_arg,
+        ArgType.LONG_TENSOR: tensor_arg,
+        ArgType.PLACEHOLDER_TENSOR: tensor_arg,
+        ArgType.INT: (
             (lambda x: int64_arg(x, default=int(default)))
             if default is not None
             else int64_arg_no_default
         ),
-        FLOAT: (
+        ArgType.FLOAT: (
             (lambda x: double_arg(x, default=default))
             if default is not None
             else double_arg_no_default
@@ -187,18 +227,19 @@ def make_function_arg(ty: int, name: str, default: Optional[Union[int, float]]) 
     }[ty](name)
 
 
-def make_function_schema_arg(ty: int, name: str, default: Union[int, float]) -> str:
+def make_function_schema_arg(ty: ArgType, name: str, default: Union[int, float]) -> str:
     return {
-        TENSOR: tensor_arg,
-        INT_TENSOR: tensor_arg,
-        LONG_TENSOR: tensor_arg,
-        INT: lambda x: int_arg(x, default=int(default)),
-        FLOAT: lambda x: float_arg(x, default=default),
+        ArgType.TENSOR: tensor_arg,
+        ArgType.INT_TENSOR: tensor_arg,
+        ArgType.LONG_TENSOR: tensor_arg,
+        ArgType.PLACEHOLDER_TENSOR: tensor_arg,
+        ArgType.INT: lambda x: int_arg(x, default=int(default)),
+        ArgType.FLOAT: lambda x: float_arg(x, default=default),
     }[ty](name)
 
 
-def make_ivalue_cast(ty: int) -> str:
-    return {INT: "toInt", FLOAT: "toDouble"}[ty]
+def make_ivalue_cast(ty: ArgType) -> str:
+    return {ArgType.INT: "toInt", ArgType.FLOAT: "toDouble"}[ty]
 
 
 ######################################################################
@@ -208,10 +249,10 @@ def make_ivalue_cast(ty: int) -> str:
 
 @dataclass
 class OptimizerArgsSetItem:
-    ty: int  # type
+    ty: ArgType  # type
     name: str
-    default: Union[float, int] = 0  # DEFAULT_ARG_VAL
-    ph_tys: Optional[List[int]] = None  # placeholder types
+    default: Union[float, ArgType] = 0  # DEFAULT_ARG_VAL
+    ph_tys: Optional[List[ArgType]] = None  # placeholder types
 
 
 # Alias b/c the name is too long
@@ -234,11 +275,14 @@ class OptimizerArgs:
     split_function_args_no_defaults: List[str]
     split_saved_tensors: List[str]
     split_tensors: List[str]
+    split_tensor_types: Dict[str, str]
     saved_data: List[Tuple[str, str]]
     split_function_arg_names: List[str]
     split_function_schemas: List[str]
     split_variables: List[str]
     split_ref_kernel_args: List[str]
+    placeholder_tensor_names: List[str]
+    placeholder_type_combos: Union[List[Dict[str, TensorType]], List[None]]
 
     @staticmethod
     # pyre-ignore[3]
@@ -246,7 +290,27 @@ class OptimizerArgs:
         split_arg_spec: List[OptimItem],
         arg_spec: List[OptimItem],
     ):
+        # Compute placeholder tensor combinations
+        ph_tensor_names = [
+            s.name for s in arg_spec if s.ty == ArgType.PLACEHOLDER_TENSOR
+        ]
+        ph_tensor_types = [
+            # pyre-ignore[16]
+            [arg_type_to_tensor_type[t] for t in s.ph_tys]
+            for s in arg_spec
+            if s.ty == ArgType.PLACEHOLDER_TENSOR
+        ]
+        if len(ph_tensor_names) > 0:
+            ph_combos_list = itertools.product(*ph_tensor_types)
+            ph_combos = [
+                {k: ph for k, ph in zip(ph_tensor_names, combo)}
+                for combo in ph_combos_list
+            ]
+        else:
+            ph_combos = [None]
+
         return OptimizerArgs(
+            # GPU kernel args
             split_kernel_args=[
                 make_kernel_arg(s.ty, s.name, s.default) for s in split_arg_spec
             ],
@@ -256,26 +320,50 @@ class OptimizerArgs:
             split_kernel_arg_constructors=[
                 make_kernel_arg_constructor(s.ty, s.name) for s in split_arg_spec
             ],
+            # CPU kernel args
             split_cpu_kernel_args=[
                 make_cpu_kernel_arg(s.ty, s.name, s.default) for s in split_arg_spec
             ],
             split_cpu_kernel_arg_constructors=[
                 make_cpu_kernel_arg_constructor(s.ty, s.name) for s in split_arg_spec
             ],
+            # Function args
             split_function_args=[
                 make_function_arg(s.ty, s.name, s.default) for s in split_arg_spec
             ],
             split_function_args_no_defaults=[
                 make_function_arg(s.ty, s.name, None) for s in split_arg_spec
             ],
-            split_tensors=[s.name for s in arg_spec if s.ty == TENSOR],
+            # Helper values
+            split_tensors=[
+                s.name
+                for s in arg_spec
+                if s.ty in (ArgType.TENSOR, ArgType.PLACEHOLDER_TENSOR)
+            ],
+            split_tensor_types={
+                s.name: (
+                    "at::acc_type<cache_t, true>"
+                    if s.ty == ArgType.TENSOR
+                    else (s.name + "_ph_t")
+                )
+                for s in arg_spec
+                if s.ty in (ArgType.TENSOR, ArgType.PLACEHOLDER_TENSOR)
+            },
             split_saved_tensors=[
                 s.name
                 for s in split_arg_spec
-                if s.ty in (TENSOR, INT_TENSOR, LONG_TENSOR)
+                if s.ty
+                in (
+                    ArgType.TENSOR,
+                    ArgType.INT_TENSOR,
+                    ArgType.LONG_TENSOR,
+                    ArgType.PLACEHOLDER_TENSOR,
+                )
             ],
             saved_data=[
-                (s.name, make_ivalue_cast(s.ty)) for s in arg_spec if s.ty != TENSOR
+                (s.name, make_ivalue_cast(s.ty))
+                for s in arg_spec
+                if s.ty not in (ArgType.TENSOR, ArgType.PLACEHOLDER_TENSOR)
             ],
             split_function_arg_names=[s.name for s in split_arg_spec],
             split_function_schemas=[
@@ -287,6 +375,8 @@ class OptimizerArgs:
                 make_kernel_arg(s.ty, s.name, s.default, pass_by_ref=True)
                 for s in split_arg_spec
             ],
+            placeholder_tensor_names=ph_tensor_names,
+            placeholder_type_combos=ph_combos,
         )
 
 
@@ -307,10 +397,11 @@ class OptimizerArgsSet:
     ) -> OptimizerArgs:
         split_arg_spec = []
         for s in arg_spec:
-            if s.ty in (FLOAT, INT):
+            if s.ty in (ArgType.FLOAT, ArgType.INT):
                 split_arg_spec.append(OptimItem(s.ty, s.name, s.default))
             else:
-                assert s.ty == TENSOR
+                assert s.ty in (ArgType.TENSOR, ArgType.PLACEHOLDER_TENSOR)
+                # Treat PLACEHOLDER_TENSOR as TENSOR for CPU
                 split_arg_spec.extend(ext_fn(s))
         return OptimizerArgs.create(split_arg_spec, arg_spec)
 
@@ -319,32 +410,36 @@ class OptimizerArgsSet:
         name = spec.name
         default = spec.default
         return [
-            OptimItem(TENSOR, f"{name}_host", default),
-            OptimItem(INT_TENSOR, f"{name}_placements", default),
-            OptimItem(LONG_TENSOR, f"{name}_offsets", default),
+            OptimItem(ArgType.TENSOR, f"{name}_host", default),
+            OptimItem(ArgType.INT_TENSOR, f"{name}_placements", default),
+            OptimItem(ArgType.LONG_TENSOR, f"{name}_offsets", default),
         ]
 
     @staticmethod
     def extend_for_cuda(spec: OptimItem) -> List[OptimItem]:
         name = spec.name
         default = spec.default
+        ty = spec.ty
+        ph_tys = spec.ph_tys
         return [
-            OptimItem(TENSOR, f"{name}_dev", default),
-            OptimItem(TENSOR, f"{name}_uvm", default),
-            OptimItem(INT_TENSOR, f"{name}_placements", default),
-            OptimItem(LONG_TENSOR, f"{name}_offsets", default),
+            OptimItem(ty, f"{name}_dev", default, ph_tys),
+            OptimItem(ty, f"{name}_uvm", default, ph_tys),
+            OptimItem(ArgType.INT_TENSOR, f"{name}_placements", default),
+            OptimItem(ArgType.LONG_TENSOR, f"{name}_offsets", default),
         ]
 
     @staticmethod
     def extend_for_any(spec: OptimItem) -> List[OptimItem]:
         name = spec.name
         default = spec.default
+        ty = spec.ty
+        ph_tys = spec.ph_tys
         return [
-            OptimItem(TENSOR, f"{name}_host", default),
-            OptimItem(TENSOR, f"{name}_dev", default),
-            OptimItem(TENSOR, f"{name}_uvm", default),
-            OptimItem(INT_TENSOR, f"{name}_placements", default),
-            OptimItem(LONG_TENSOR, f"{name}_offsets", default),
+            OptimItem(ArgType.TENSOR, f"{name}_host", default),
+            OptimItem(ty, f"{name}_dev", default, ph_tys),
+            OptimItem(ty, f"{name}_uvm", default, ph_tys),
+            OptimItem(ArgType.INT_TENSOR, f"{name}_placements", default),
+            OptimItem(ArgType.LONG_TENSOR, f"{name}_offsets", default),
         ]
 
     @staticmethod

--- a/fbgemm_gpu/codegen/genscript/optimizers.py
+++ b/fbgemm_gpu/codegen/genscript/optimizers.py
@@ -18,6 +18,7 @@ try:
         INT_TENSOR,
         LONG_TENSOR,
         OptimizerArgsSet,
+        OptimizerArgsSetItem as OptimItem,
         TENSOR,
     )
 except:
@@ -31,6 +32,7 @@ except:
         INT_TENSOR,
         LONG_TENSOR,
         OptimizerArgsSet,
+        OptimizerArgsSetItem as OptimItem,
         TENSOR,
     )
 
@@ -45,7 +47,7 @@ def dense() -> Dict[str, Any]:
         "dense": True,
         "args": OptimizerArgsSet.create(
             [
-                (FLOAT, "unused"),
+                OptimItem(FLOAT, "unused"),
             ]
         ),
         "has_cpu_support": True,
@@ -81,7 +83,11 @@ def adagrad() -> Dict[str, Any]:
     return {
         "optimizer": "adagrad",
         "args": OptimizerArgsSet.create(
-            [(TENSOR, "momentum1"), (FLOAT, "eps"), (FLOAT, "learning_rate")]
+            [
+                OptimItem(TENSOR, "momentum1"),
+                OptimItem(FLOAT, "eps"),
+                OptimItem(FLOAT, "learning_rate"),
+            ]
         ),
         "split_precomputation": "",
         "split_weight_update": split_weight_update,
@@ -243,12 +249,12 @@ def rowwise_adagrad() -> Dict[str, Any]:
         "optimizer": "rowwise_adagrad",
         "args": OptimizerArgsSet.create(
             [
-                (TENSOR, "momentum1"),
-                (FLOAT, "eps"),
-                (FLOAT, "learning_rate"),
-                (FLOAT, "weight_decay", 0.0),
-                (INT, "weight_decay_mode", 0),
-                (FLOAT, "max_norm", 0.0),
+                OptimItem(TENSOR, "momentum1"),
+                OptimItem(FLOAT, "eps"),
+                OptimItem(FLOAT, "learning_rate"),
+                OptimItem(FLOAT, "weight_decay", 0.0),
+                OptimItem(INT, "weight_decay_mode", 0),
+                OptimItem(FLOAT, "max_norm", 0.0),
             ]
         ),
         "split_precomputation": split_precomputation,
@@ -274,11 +280,11 @@ def approx_rowwise_adagrad() -> Dict[str, Any]:
         "optimizer": "approx_rowwise_adagrad",
         "args": OptimizerArgsSet.create(
             [
-                (TENSOR, "momentum1"),
-                (FLOAT, "eps"),
-                (FLOAT, "learning_rate"),
-                (FLOAT, "weight_decay", 0.0),
-                (INT, "weight_decay_mode", 0),
+                OptimItem(TENSOR, "momentum1"),
+                OptimItem(FLOAT, "eps"),
+                OptimItem(FLOAT, "learning_rate"),
+                OptimItem(FLOAT, "weight_decay", 0.0),
+                OptimItem(INT, "weight_decay_mode", 0),
             ]
         ),
         "split_precomputation": rowwise_adagrad_args["split_precomputation"],
@@ -379,11 +385,11 @@ def rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
         "optimizer": "rowwise_adagrad_with_weight_decay",
         "args": OptimizerArgsSet.create(
             [
-                (TENSOR, "momentum1"),
-                (FLOAT, "eps"),
-                (FLOAT, "learning_rate"),
-                (FLOAT, "weight_decay", 0.0),
-                (INT, "weight_decay_mode", 0),
+                OptimItem(TENSOR, "momentum1"),
+                OptimItem(FLOAT, "eps"),
+                OptimItem(FLOAT, "learning_rate"),
+                OptimItem(FLOAT, "weight_decay", 0.0),
+                OptimItem(INT, "weight_decay_mode", 0),
             ]
         ),
         "split_precomputation": split_precomputation,
@@ -410,11 +416,11 @@ def approx_rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
         "optimizer": "approx_rowwise_adagrad_with_weight_decay",
         "args": OptimizerArgsSet.create(
             [
-                (TENSOR, "momentum1"),
-                (FLOAT, "eps"),
-                (FLOAT, "learning_rate"),
-                (FLOAT, "weight_decay", 0.0),
-                (INT, "weight_decay_mode", 0),
+                OptimItem(TENSOR, "momentum1"),
+                OptimItem(FLOAT, "eps"),
+                OptimItem(FLOAT, "learning_rate"),
+                OptimItem(FLOAT, "weight_decay", 0.0),
+                OptimItem(INT, "weight_decay_mode", 0),
             ]
         ),
         "split_precomputation": rowwise_adagrad_with_weight_decay_args[
@@ -570,25 +576,25 @@ def rowwise_adagrad_with_counter() -> Dict[str, Any]:
         "optimizer": "rowwise_adagrad_with_counter",
         "args": OptimizerArgsSet.create(
             [
-                (TENSOR, "momentum1"),
-                (TENSOR, "prev_iter"),
-                (TENSOR, "row_counter"),
-                (FLOAT, "eps"),
-                (FLOAT, "learning_rate"),
-                (FLOAT, "weight_decay", 0.0),
-                (INT, "iter"),
-                (INT, "counter_halflife", -1),
-                (INT, "adjustment_iter", -1),
-                (FLOAT, "adjustment_ub", 1.0),
-                (INT, "learning_rate_mode", -1),
-                (INT, "weight_decay_mode", 1),
-                (INT, "grad_sum_decay", -1),
-                (FLOAT, "max_counter"),
-                (FLOAT, "tail_id_threshold", 0.0),
-                (INT, "is_tail_id_thresh_ratio", 0),
-                (INT, "regularization_mode", 0),
-                (FLOAT, "weight_norm_coefficient", 0.0),
-                (FLOAT, "lower_bound", 0.0),
+                OptimItem(TENSOR, "momentum1"),
+                OptimItem(TENSOR, "prev_iter"),
+                OptimItem(TENSOR, "row_counter"),
+                OptimItem(FLOAT, "eps"),
+                OptimItem(FLOAT, "learning_rate"),
+                OptimItem(FLOAT, "weight_decay", 0.0),
+                OptimItem(INT, "iter"),
+                OptimItem(INT, "counter_halflife", -1),
+                OptimItem(INT, "adjustment_iter", -1),
+                OptimItem(FLOAT, "adjustment_ub", 1.0),
+                OptimItem(INT, "learning_rate_mode", -1),
+                OptimItem(INT, "weight_decay_mode", 1),
+                OptimItem(INT, "grad_sum_decay", -1),
+                OptimItem(FLOAT, "max_counter"),
+                OptimItem(FLOAT, "tail_id_threshold", 0.0),
+                OptimItem(INT, "is_tail_id_thresh_ratio", 0),
+                OptimItem(INT, "regularization_mode", 0),
+                OptimItem(FLOAT, "weight_norm_coefficient", 0.0),
+                OptimItem(FLOAT, "lower_bound", 0.0),
             ]
         ),
         "split_precomputation": split_precomputation,
@@ -614,25 +620,25 @@ def approx_rowwise_adagrad_with_counter() -> Dict[str, Any]:
         "optimizer": "approx_rowwise_adagrad_with_counter",
         "args": OptimizerArgsSet.create(
             [
-                (TENSOR, "momentum1"),
-                (TENSOR, "prev_iter"),
-                (TENSOR, "row_counter"),
-                (FLOAT, "eps"),
-                (FLOAT, "learning_rate"),
-                (FLOAT, "weight_decay", 0.0),
-                (INT, "iter"),
-                (INT, "counter_halflife", -1),
-                (INT, "adjustment_iter", -1),
-                (FLOAT, "adjustment_ub", 1.0),
-                (INT, "learning_rate_mode", -1),
-                (INT, "weight_decay_mode", 1),
-                (INT, "grad_sum_decay", -1),
-                (FLOAT, "max_counter"),
-                (FLOAT, "tail_id_threshold", 0.0),
-                (INT, "is_tail_id_thresh_ratio", 0),
-                (INT, "regularization_mode", 0),
-                (FLOAT, "weight_norm_coefficient", 0.0),
-                (FLOAT, "lower_bound", 0.0),
+                OptimItem(TENSOR, "momentum1"),
+                OptimItem(TENSOR, "prev_iter"),
+                OptimItem(TENSOR, "row_counter"),
+                OptimItem(FLOAT, "eps"),
+                OptimItem(FLOAT, "learning_rate"),
+                OptimItem(FLOAT, "weight_decay", 0.0),
+                OptimItem(INT, "iter"),
+                OptimItem(INT, "counter_halflife", -1),
+                OptimItem(INT, "adjustment_iter", -1),
+                OptimItem(FLOAT, "adjustment_ub", 1.0),
+                OptimItem(INT, "learning_rate_mode", -1),
+                OptimItem(INT, "weight_decay_mode", 1),
+                OptimItem(INT, "grad_sum_decay", -1),
+                OptimItem(FLOAT, "max_counter"),
+                OptimItem(FLOAT, "tail_id_threshold", 0.0),
+                OptimItem(INT, "is_tail_id_thresh_ratio", 0),
+                OptimItem(INT, "regularization_mode", 0),
+                OptimItem(FLOAT, "weight_norm_coefficient", 0.0),
+                OptimItem(FLOAT, "lower_bound", 0.0),
             ]
         ),
         "split_precomputation": rowwise_adagrad_with_counter_args[
@@ -709,11 +715,11 @@ def rowwise_weighted_adagrad() -> Dict[str, Any]:
         "is_experimental_optimizer": True,
         "args": OptimizerArgsSet.create(
             [
-                (TENSOR, "momentum1"),
-                (FLOAT, "eps"),
-                (FLOAT, "learning_rate"),
-                (FLOAT, "weight_decay"),
-                (INT, "iter"),
+                OptimItem(TENSOR, "momentum1"),
+                OptimItem(FLOAT, "eps"),
+                OptimItem(FLOAT, "learning_rate"),
+                OptimItem(FLOAT, "weight_decay"),
+                OptimItem(INT, "iter"),
             ]
         ),
         "split_precomputation": split_precomputation,
@@ -738,7 +744,7 @@ def sgd() -> Dict[str, Any]:
 
     return {
         "optimizer": "sgd",
-        "args": OptimizerArgsSet.create([(FLOAT, "learning_rate")]),
+        "args": OptimizerArgsSet.create([OptimItem(FLOAT, "learning_rate")]),
         "split_precomputation": "",
         "split_weight_update": split_weight_update,
         "split_post_update": "",
@@ -761,7 +767,7 @@ def approx_sgd() -> Dict[str, Any]:
 
     return {
         "optimizer": "approx_sgd",
-        "args": OptimizerArgsSet.create([(FLOAT, "learning_rate")]),
+        "args": OptimizerArgsSet.create([OptimItem(FLOAT, "learning_rate")]),
         "split_precomputation": "",
         "split_weight_update": approx_split_weight_update,
         "split_post_update": "",
@@ -829,14 +835,14 @@ def lamb() -> Dict[str, Any]:
         "is_experimental_optimizer": True,
         "args": OptimizerArgsSet.create(
             [
-                (TENSOR, "momentum1"),
-                (TENSOR, "momentum2"),
-                (FLOAT, "learning_rate"),
-                (FLOAT, "eps"),
-                (FLOAT, "beta1"),
-                (FLOAT, "beta2"),
-                (FLOAT, "weight_decay"),
-                (INT, "iter"),
+                OptimItem(TENSOR, "momentum1"),
+                OptimItem(TENSOR, "momentum2"),
+                OptimItem(FLOAT, "learning_rate"),
+                OptimItem(FLOAT, "eps"),
+                OptimItem(FLOAT, "beta1"),
+                OptimItem(FLOAT, "beta2"),
+                OptimItem(FLOAT, "weight_decay"),
+                OptimItem(INT, "iter"),
             ]
         ),
         "split_precomputation": split_precomputation,
@@ -920,14 +926,14 @@ def partial_rowwise_lamb() -> Dict[str, Any]:
         "optimizer": "partial_rowwise_lamb",
         "args": OptimizerArgsSet.create(
             [
-                (TENSOR, "momentum1"),
-                (TENSOR, "momentum2"),
-                (FLOAT, "learning_rate"),
-                (FLOAT, "eps"),
-                (FLOAT, "beta1"),
-                (FLOAT, "beta2"),
-                (FLOAT, "weight_decay"),
-                (INT, "iter"),
+                OptimItem(TENSOR, "momentum1"),
+                OptimItem(TENSOR, "momentum2"),
+                OptimItem(FLOAT, "learning_rate"),
+                OptimItem(FLOAT, "eps"),
+                OptimItem(FLOAT, "beta1"),
+                OptimItem(FLOAT, "beta2"),
+                OptimItem(FLOAT, "weight_decay"),
+                OptimItem(INT, "iter"),
             ]
         ),
         "split_precomputation": split_precomputation,
@@ -975,14 +981,14 @@ def adam() -> Dict[str, Any]:
         "is_experimental_optimizer": True,
         "args": OptimizerArgsSet.create(
             [
-                (TENSOR, "momentum1"),
-                (TENSOR, "momentum2"),
-                (FLOAT, "learning_rate"),
-                (FLOAT, "eps"),
-                (FLOAT, "beta1"),
-                (FLOAT, "beta2"),
-                (FLOAT, "weight_decay"),
-                (INT, "iter"),
+                OptimItem(TENSOR, "momentum1"),
+                OptimItem(TENSOR, "momentum2"),
+                OptimItem(FLOAT, "learning_rate"),
+                OptimItem(FLOAT, "eps"),
+                OptimItem(FLOAT, "beta1"),
+                OptimItem(FLOAT, "beta2"),
+                OptimItem(FLOAT, "weight_decay"),
+                OptimItem(INT, "iter"),
             ]
         ),
         "split_precomputation": "",
@@ -1041,14 +1047,14 @@ def partial_rowwise_adam() -> Dict[str, Any]:
         "optimizer": "partial_rowwise_adam",
         "args": OptimizerArgsSet.create(
             [
-                (TENSOR, "momentum1"),
-                (TENSOR, "momentum2"),
-                (FLOAT, "learning_rate"),
-                (FLOAT, "eps"),
-                (FLOAT, "beta1"),
-                (FLOAT, "beta2"),
-                (FLOAT, "weight_decay"),
-                (INT, "iter"),
+                OptimItem(TENSOR, "momentum1"),
+                OptimItem(TENSOR, "momentum2"),
+                OptimItem(FLOAT, "learning_rate"),
+                OptimItem(FLOAT, "eps"),
+                OptimItem(FLOAT, "beta1"),
+                OptimItem(FLOAT, "beta2"),
+                OptimItem(FLOAT, "weight_decay"),
+                OptimItem(INT, "iter"),
             ]
         ),
         "split_precomputation": split_precomputation,
@@ -1108,11 +1114,11 @@ def lars_sgd() -> Dict[str, Any]:
         "is_experimental_optimizer": True,
         "args": OptimizerArgsSet.create(
             [
-                (TENSOR, "momentum1"),
-                (FLOAT, "learning_rate"),
-                (FLOAT, "eta"),
-                (FLOAT, "momentum"),
-                (FLOAT, "weight_decay"),
+                OptimItem(TENSOR, "momentum1"),
+                OptimItem(FLOAT, "learning_rate"),
+                OptimItem(FLOAT, "eta"),
+                OptimItem(FLOAT, "momentum"),
+                OptimItem(FLOAT, "weight_decay"),
             ]
         ),
         "split_precomputation": split_precomputation,
@@ -1131,8 +1137,8 @@ def none_optimizer() -> Dict[str, Any]:
         "dense": False,
         "args": OptimizerArgsSet.create(
             [
-                (INT, "total_hash_size"),
-                (INT, "total_unique_indices"),
+                OptimItem(INT, "total_hash_size"),
+                OptimItem(INT, "total_unique_indices"),
             ]
         ),
         # Generate only GPU code

--- a/fbgemm_gpu/codegen/genscript/optimizers.py
+++ b/fbgemm_gpu/codegen/genscript/optimizers.py
@@ -12,29 +12,17 @@ from typing import Any, Dict
 
 try:
     from .jinja_environment import generate_optimized_grad_sum_loop_access
-    from .optimizer_args import (
-        FLOAT,
-        INT,
-        INT_TENSOR,
-        LONG_TENSOR,
-        OptimizerArgsSet,
-        OptimizerArgsSetItem as OptimItem,
-        TENSOR,
-    )
+    from .optimizer_args import OptimizerArgsSet, OptimizerArgsSetItem as OptimItem
+    from .torch_type_utils import ArgType
 except:
     # pyre-ignore[21]
     from jinja_environment import generate_optimized_grad_sum_loop_access
 
     # pyre-ignore[21]
-    from optimizer_args import (
-        FLOAT,
-        INT,
-        INT_TENSOR,
-        LONG_TENSOR,
-        OptimizerArgsSet,
-        OptimizerArgsSetItem as OptimItem,
-        TENSOR,
-    )
+    from optimizer_args import OptimizerArgsSet, OptimizerArgsSetItem as OptimItem
+
+    # pyre-ignore[21]
+    from torch_type_utils import ArgType
 
 ######################################################################
 ## Optimizer templates                                              ##
@@ -47,7 +35,7 @@ def dense() -> Dict[str, Any]:
         "dense": True,
         "args": OptimizerArgsSet.create(
             [
-                OptimItem(FLOAT, "unused"),
+                OptimItem(ArgType.FLOAT, "unused"),
             ]
         ),
         "has_cpu_support": True,
@@ -84,9 +72,9 @@ def adagrad() -> Dict[str, Any]:
         "optimizer": "adagrad",
         "args": OptimizerArgsSet.create(
             [
-                OptimItem(TENSOR, "momentum1"),
-                OptimItem(FLOAT, "eps"),
-                OptimItem(FLOAT, "learning_rate"),
+                OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
             ]
         ),
         "split_precomputation": "",
@@ -249,12 +237,12 @@ def rowwise_adagrad() -> Dict[str, Any]:
         "optimizer": "rowwise_adagrad",
         "args": OptimizerArgsSet.create(
             [
-                OptimItem(TENSOR, "momentum1"),
-                OptimItem(FLOAT, "eps"),
-                OptimItem(FLOAT, "learning_rate"),
-                OptimItem(FLOAT, "weight_decay", 0.0),
-                OptimItem(INT, "weight_decay_mode", 0),
-                OptimItem(FLOAT, "max_norm", 0.0),
+                OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
+                OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
+                OptimItem(ArgType.INT, "weight_decay_mode", 0),
+                OptimItem(ArgType.FLOAT, "max_norm", 0.0),
             ]
         ),
         "split_precomputation": split_precomputation,
@@ -280,11 +268,11 @@ def approx_rowwise_adagrad() -> Dict[str, Any]:
         "optimizer": "approx_rowwise_adagrad",
         "args": OptimizerArgsSet.create(
             [
-                OptimItem(TENSOR, "momentum1"),
-                OptimItem(FLOAT, "eps"),
-                OptimItem(FLOAT, "learning_rate"),
-                OptimItem(FLOAT, "weight_decay", 0.0),
-                OptimItem(INT, "weight_decay_mode", 0),
+                OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
+                OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
+                OptimItem(ArgType.INT, "weight_decay_mode", 0),
             ]
         ),
         "split_precomputation": rowwise_adagrad_args["split_precomputation"],
@@ -385,11 +373,11 @@ def rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
         "optimizer": "rowwise_adagrad_with_weight_decay",
         "args": OptimizerArgsSet.create(
             [
-                OptimItem(TENSOR, "momentum1"),
-                OptimItem(FLOAT, "eps"),
-                OptimItem(FLOAT, "learning_rate"),
-                OptimItem(FLOAT, "weight_decay", 0.0),
-                OptimItem(INT, "weight_decay_mode", 0),
+                OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
+                OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
+                OptimItem(ArgType.INT, "weight_decay_mode", 0),
             ]
         ),
         "split_precomputation": split_precomputation,
@@ -416,11 +404,11 @@ def approx_rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
         "optimizer": "approx_rowwise_adagrad_with_weight_decay",
         "args": OptimizerArgsSet.create(
             [
-                OptimItem(TENSOR, "momentum1"),
-                OptimItem(FLOAT, "eps"),
-                OptimItem(FLOAT, "learning_rate"),
-                OptimItem(FLOAT, "weight_decay", 0.0),
-                OptimItem(INT, "weight_decay_mode", 0),
+                OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
+                OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
+                OptimItem(ArgType.INT, "weight_decay_mode", 0),
             ]
         ),
         "split_precomputation": rowwise_adagrad_with_weight_decay_args[
@@ -576,25 +564,25 @@ def rowwise_adagrad_with_counter() -> Dict[str, Any]:
         "optimizer": "rowwise_adagrad_with_counter",
         "args": OptimizerArgsSet.create(
             [
-                OptimItem(TENSOR, "momentum1"),
-                OptimItem(TENSOR, "prev_iter"),
-                OptimItem(TENSOR, "row_counter"),
-                OptimItem(FLOAT, "eps"),
-                OptimItem(FLOAT, "learning_rate"),
-                OptimItem(FLOAT, "weight_decay", 0.0),
-                OptimItem(INT, "iter"),
-                OptimItem(INT, "counter_halflife", -1),
-                OptimItem(INT, "adjustment_iter", -1),
-                OptimItem(FLOAT, "adjustment_ub", 1.0),
-                OptimItem(INT, "learning_rate_mode", -1),
-                OptimItem(INT, "weight_decay_mode", 1),
-                OptimItem(INT, "grad_sum_decay", -1),
-                OptimItem(FLOAT, "max_counter"),
-                OptimItem(FLOAT, "tail_id_threshold", 0.0),
-                OptimItem(INT, "is_tail_id_thresh_ratio", 0),
-                OptimItem(INT, "regularization_mode", 0),
-                OptimItem(FLOAT, "weight_norm_coefficient", 0.0),
-                OptimItem(FLOAT, "lower_bound", 0.0),
+                OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.TENSOR, "prev_iter"),
+                OptimItem(ArgType.TENSOR, "row_counter"),
+                OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
+                OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
+                OptimItem(ArgType.INT, "iter"),
+                OptimItem(ArgType.INT, "counter_halflife", -1),
+                OptimItem(ArgType.INT, "adjustment_iter", -1),
+                OptimItem(ArgType.FLOAT, "adjustment_ub", 1.0),
+                OptimItem(ArgType.INT, "learning_rate_mode", -1),
+                OptimItem(ArgType.INT, "weight_decay_mode", 1),
+                OptimItem(ArgType.INT, "grad_sum_decay", -1),
+                OptimItem(ArgType.FLOAT, "max_counter"),
+                OptimItem(ArgType.FLOAT, "tail_id_threshold", 0.0),
+                OptimItem(ArgType.INT, "is_tail_id_thresh_ratio", 0),
+                OptimItem(ArgType.INT, "regularization_mode", 0),
+                OptimItem(ArgType.FLOAT, "weight_norm_coefficient", 0.0),
+                OptimItem(ArgType.FLOAT, "lower_bound", 0.0),
             ]
         ),
         "split_precomputation": split_precomputation,
@@ -620,25 +608,25 @@ def approx_rowwise_adagrad_with_counter() -> Dict[str, Any]:
         "optimizer": "approx_rowwise_adagrad_with_counter",
         "args": OptimizerArgsSet.create(
             [
-                OptimItem(TENSOR, "momentum1"),
-                OptimItem(TENSOR, "prev_iter"),
-                OptimItem(TENSOR, "row_counter"),
-                OptimItem(FLOAT, "eps"),
-                OptimItem(FLOAT, "learning_rate"),
-                OptimItem(FLOAT, "weight_decay", 0.0),
-                OptimItem(INT, "iter"),
-                OptimItem(INT, "counter_halflife", -1),
-                OptimItem(INT, "adjustment_iter", -1),
-                OptimItem(FLOAT, "adjustment_ub", 1.0),
-                OptimItem(INT, "learning_rate_mode", -1),
-                OptimItem(INT, "weight_decay_mode", 1),
-                OptimItem(INT, "grad_sum_decay", -1),
-                OptimItem(FLOAT, "max_counter"),
-                OptimItem(FLOAT, "tail_id_threshold", 0.0),
-                OptimItem(INT, "is_tail_id_thresh_ratio", 0),
-                OptimItem(INT, "regularization_mode", 0),
-                OptimItem(FLOAT, "weight_norm_coefficient", 0.0),
-                OptimItem(FLOAT, "lower_bound", 0.0),
+                OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.TENSOR, "prev_iter"),
+                OptimItem(ArgType.TENSOR, "row_counter"),
+                OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
+                OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
+                OptimItem(ArgType.INT, "iter"),
+                OptimItem(ArgType.INT, "counter_halflife", -1),
+                OptimItem(ArgType.INT, "adjustment_iter", -1),
+                OptimItem(ArgType.FLOAT, "adjustment_ub", 1.0),
+                OptimItem(ArgType.INT, "learning_rate_mode", -1),
+                OptimItem(ArgType.INT, "weight_decay_mode", 1),
+                OptimItem(ArgType.INT, "grad_sum_decay", -1),
+                OptimItem(ArgType.FLOAT, "max_counter"),
+                OptimItem(ArgType.FLOAT, "tail_id_threshold", 0.0),
+                OptimItem(ArgType.INT, "is_tail_id_thresh_ratio", 0),
+                OptimItem(ArgType.INT, "regularization_mode", 0),
+                OptimItem(ArgType.FLOAT, "weight_norm_coefficient", 0.0),
+                OptimItem(ArgType.FLOAT, "lower_bound", 0.0),
             ]
         ),
         "split_precomputation": rowwise_adagrad_with_counter_args[
@@ -715,11 +703,11 @@ def rowwise_weighted_adagrad() -> Dict[str, Any]:
         "is_experimental_optimizer": True,
         "args": OptimizerArgsSet.create(
             [
-                OptimItem(TENSOR, "momentum1"),
-                OptimItem(FLOAT, "eps"),
-                OptimItem(FLOAT, "learning_rate"),
-                OptimItem(FLOAT, "weight_decay"),
-                OptimItem(INT, "iter"),
+                OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
+                OptimItem(ArgType.FLOAT, "weight_decay"),
+                OptimItem(ArgType.INT, "iter"),
             ]
         ),
         "split_precomputation": split_precomputation,
@@ -744,7 +732,7 @@ def sgd() -> Dict[str, Any]:
 
     return {
         "optimizer": "sgd",
-        "args": OptimizerArgsSet.create([OptimItem(FLOAT, "learning_rate")]),
+        "args": OptimizerArgsSet.create([OptimItem(ArgType.FLOAT, "learning_rate")]),
         "split_precomputation": "",
         "split_weight_update": split_weight_update,
         "split_post_update": "",
@@ -767,7 +755,7 @@ def approx_sgd() -> Dict[str, Any]:
 
     return {
         "optimizer": "approx_sgd",
-        "args": OptimizerArgsSet.create([OptimItem(FLOAT, "learning_rate")]),
+        "args": OptimizerArgsSet.create([OptimItem(ArgType.FLOAT, "learning_rate")]),
         "split_precomputation": "",
         "split_weight_update": approx_split_weight_update,
         "split_post_update": "",
@@ -835,14 +823,14 @@ def lamb() -> Dict[str, Any]:
         "is_experimental_optimizer": True,
         "args": OptimizerArgsSet.create(
             [
-                OptimItem(TENSOR, "momentum1"),
-                OptimItem(TENSOR, "momentum2"),
-                OptimItem(FLOAT, "learning_rate"),
-                OptimItem(FLOAT, "eps"),
-                OptimItem(FLOAT, "beta1"),
-                OptimItem(FLOAT, "beta2"),
-                OptimItem(FLOAT, "weight_decay"),
-                OptimItem(INT, "iter"),
+                OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.TENSOR, "momentum2"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
+                OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "beta1"),
+                OptimItem(ArgType.FLOAT, "beta2"),
+                OptimItem(ArgType.FLOAT, "weight_decay"),
+                OptimItem(ArgType.INT, "iter"),
             ]
         ),
         "split_precomputation": split_precomputation,
@@ -926,14 +914,14 @@ def partial_rowwise_lamb() -> Dict[str, Any]:
         "optimizer": "partial_rowwise_lamb",
         "args": OptimizerArgsSet.create(
             [
-                OptimItem(TENSOR, "momentum1"),
-                OptimItem(TENSOR, "momentum2"),
-                OptimItem(FLOAT, "learning_rate"),
-                OptimItem(FLOAT, "eps"),
-                OptimItem(FLOAT, "beta1"),
-                OptimItem(FLOAT, "beta2"),
-                OptimItem(FLOAT, "weight_decay"),
-                OptimItem(INT, "iter"),
+                OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.TENSOR, "momentum2"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
+                OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "beta1"),
+                OptimItem(ArgType.FLOAT, "beta2"),
+                OptimItem(ArgType.FLOAT, "weight_decay"),
+                OptimItem(ArgType.INT, "iter"),
             ]
         ),
         "split_precomputation": split_precomputation,
@@ -981,14 +969,14 @@ def adam() -> Dict[str, Any]:
         "is_experimental_optimizer": True,
         "args": OptimizerArgsSet.create(
             [
-                OptimItem(TENSOR, "momentum1"),
-                OptimItem(TENSOR, "momentum2"),
-                OptimItem(FLOAT, "learning_rate"),
-                OptimItem(FLOAT, "eps"),
-                OptimItem(FLOAT, "beta1"),
-                OptimItem(FLOAT, "beta2"),
-                OptimItem(FLOAT, "weight_decay"),
-                OptimItem(INT, "iter"),
+                OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.TENSOR, "momentum2"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
+                OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "beta1"),
+                OptimItem(ArgType.FLOAT, "beta2"),
+                OptimItem(ArgType.FLOAT, "weight_decay"),
+                OptimItem(ArgType.INT, "iter"),
             ]
         ),
         "split_precomputation": "",
@@ -1047,14 +1035,14 @@ def partial_rowwise_adam() -> Dict[str, Any]:
         "optimizer": "partial_rowwise_adam",
         "args": OptimizerArgsSet.create(
             [
-                OptimItem(TENSOR, "momentum1"),
-                OptimItem(TENSOR, "momentum2"),
-                OptimItem(FLOAT, "learning_rate"),
-                OptimItem(FLOAT, "eps"),
-                OptimItem(FLOAT, "beta1"),
-                OptimItem(FLOAT, "beta2"),
-                OptimItem(FLOAT, "weight_decay"),
-                OptimItem(INT, "iter"),
+                OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.TENSOR, "momentum2"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
+                OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "beta1"),
+                OptimItem(ArgType.FLOAT, "beta2"),
+                OptimItem(ArgType.FLOAT, "weight_decay"),
+                OptimItem(ArgType.INT, "iter"),
             ]
         ),
         "split_precomputation": split_precomputation,
@@ -1114,11 +1102,11 @@ def lars_sgd() -> Dict[str, Any]:
         "is_experimental_optimizer": True,
         "args": OptimizerArgsSet.create(
             [
-                OptimItem(TENSOR, "momentum1"),
-                OptimItem(FLOAT, "learning_rate"),
-                OptimItem(FLOAT, "eta"),
-                OptimItem(FLOAT, "momentum"),
-                OptimItem(FLOAT, "weight_decay"),
+                OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
+                OptimItem(ArgType.FLOAT, "eta"),
+                OptimItem(ArgType.FLOAT, "momentum"),
+                OptimItem(ArgType.FLOAT, "weight_decay"),
             ]
         ),
         "split_precomputation": split_precomputation,
@@ -1137,8 +1125,8 @@ def none_optimizer() -> Dict[str, Any]:
         "dense": False,
         "args": OptimizerArgsSet.create(
             [
-                OptimItem(INT, "total_hash_size"),
-                OptimItem(INT, "total_unique_indices"),
+                OptimItem(ArgType.INT, "total_hash_size"),
+                OptimItem(ArgType.INT, "total_unique_indices"),
             ]
         ),
         # Generate only GPU code

--- a/fbgemm_gpu/codegen/genscript/torch_type_utils.py
+++ b/fbgemm_gpu/codegen/genscript/torch_type_utils.py
@@ -1,0 +1,40 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+######################################################################
+## PyTorch type utils
+######################################################################
+
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Dict
+
+
+class ArgType(IntEnum):
+    TENSOR = 0
+    INT_TENSOR = 1
+    LONG_TENSOR = 2
+    FLOAT_TENSOR = 3
+    HALF_TENSOR = 4
+    BFLOAT16_TENSOR = 5
+    PLACEHOLDER_TENSOR = 6
+    INT = 7
+    FLOAT = 8
+
+
+@dataclass
+class TensorType:
+    # Primitive type
+    primitive_type: str
+    # PyTorch Scalar type
+    scalar_type: str
+
+
+arg_type_to_tensor_type: Dict[ArgType, TensorType] = {
+    ArgType.FLOAT_TENSOR: TensorType("float", "at::ScalarType::Float"),
+    ArgType.HALF_TENSOR: TensorType("at::Half", "at::ScalarType::Half"),
+    ArgType.BFLOAT16_TENSOR: TensorType("at::BFloat16", "at::ScalarType::BFloat16"),
+}

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
@@ -48,6 +48,9 @@ template <
     typename emb_t,
     typename grad_t,
     typename cache_t,
+    {%- for ph_name in args.placeholder_tensor_names %}
+    typename {{ ph_name + "_ph_t" }},
+    {%- endfor %}
     int32_t kFixedMaxVecsPerThread,
     int32_t kThreadGroupSize,
     bool kUseVecBlocking>
@@ -306,6 +309,9 @@ split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc 
         split_{{ optimizer }}_table_update_kernel<
           emb_t,
           cache_t,
+          {%- for ph_name in args.placeholder_tensor_names %}
+          {{ ph_name + "_ph_t" }},
+          {%- endfor %}
           kFixedMaxVecsPerThread,
           kThreadGroupSize,
           VEC_WIDTH,
@@ -375,6 +381,7 @@ split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc 
       emb_type,
       grad_type,
       cache_type,
+      ph_type_combo,
       kFixedMaxVecsPerThread,
       kThreadGroupSize,
       kUseVecBlocking
@@ -389,6 +396,9 @@ split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc 
 < {{ emb_type }},
   {{ grad_type }},
   {{ cache_type }},
+  {%- for ph_name in args.placeholder_tensor_names %}
+  {{ ph_type_combo[ph_name].primitive_type }},
+  {%- endfor %}
   {{ kFixedMaxVecsPerThread }},
   {{ kThreadGroupSize }},
   {{ kUseVecBlocking }}
@@ -455,7 +465,12 @@ split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc 
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> grad_offsets,
     const bool permute_output_dim_0_1
     {%- else %}
-    {{ args.split_kernel_args_no_defaults | replace_pta_namespace() | join(",\n    ") | replace("cache_t", cache_type) }}
+    {{ args.split_kernel_args_no_defaults |
+         replace_pta_namespace() |
+         replace_placeholder_types(ph_type_combo) |
+         join(",\n    ") |
+         replace("cache_t", cache_type)
+    }}
     {%- endif %}
 );
 {%- endmacro %}
@@ -464,14 +479,17 @@ split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc 
     {%- for grad_type in ['float', 'at::Half', 'at::BFloat16'] %}
     {%- for emb_type in ['float', 'at::Half'] %}
     {%- for cache_type in ['float', 'at::Half'] %}
+    {%- for ph_type_combo in args.placeholder_type_combos %}
         {{ template_instantiation(
             emb_type,
             grad_type,
             cache_type,
+            ph_type_combo,
             kFixedMaxVecsPerThread,
             kThreadGroupSize,
             kUseVecBlocking)
          }}
+    {%- endfor %}
     {%- endfor %}
     {%- endfor %}
     {%- endfor %}

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_device_kernel_template.cuh
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_device_kernel_template.cuh
@@ -19,6 +19,10 @@ using namespace fbgemm_gpu;
 template <
     typename emb_t,
     typename cache_t,
+    {%- for ph_name in args.placeholder_tensor_names %}
+    {%- set ph_type = "{}_ph_t".format(ph_name) %}
+    typename {{ ph_type }},
+    {%- endfor %}
     int32_t kFixedMaxVecsPerThread,
     int32_t kThreadGroupSize = kWarpSize,
     int32_t VEC_WIDTH,
@@ -70,7 +74,7 @@ DEVICE_INLINE void split_{{ optimizer }}_table_update_kernel(
         }
     }
     {%- for tensor in args.split_tensors %}
-    at::acc_type<cache_t, true>* __restrict__ {{ tensor }};
+    {{ args.split_tensor_types[tensor] }}* __restrict__ {{ tensor }};
     const auto {{ tensor }}_placement = static_cast<PlacementType>({{ tensor }}_placements[t]);
     const int64_t {{ tensor }}_offset = {{ tensor }}_offsets[t];
     if ({{ tensor }}_placement == PlacementType::DEVICE) {


### PR DESCRIPTION
Summary:
This diff adds the backend to support multiple optimizer state types
in TBE GPU training. Previously, TBE only supported FP32 optimizer
states.

The key changes for supporting multiple optimizer state types include:
- Adding the `ArgType.PLACEHOLDER_TENSOR` tensor type in the
  code generation script to indicate that a tensor can have multiple
  types.
- Updating code generation scripts to generate appropriate template
  types for both GPU kernels and hosts.
- Modifying the TBE GPU kernel code templates to instantiate kernels
  for all supported types.
- Updating the TBE host code template to dispatch kernels based on the
  types of the optimizer states.

Note that this diff still supports only FP32 optimizer states.  The
additional optimizer state type support will be added in the
subsequent diffs.

Differential Revision: D56192738


