### PR TITLE
Remove type template from Vec4T

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_device_kernel_template.cuh
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_device_kernel_template.cuh
@@ -24,7 +24,6 @@ using namespace fbgemm_gpu;
 
 template<
     typename emb_t,
-    typename cache_t,
     int32_t kFixedMaxVecsPerThread,
     int32_t kThreadGroupSize,
     int32_t VEC_WIDTH,
@@ -32,8 +31,8 @@ template<
 >
 DEVICE_INLINE void store_grad_sum(
     pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits>& grad_dev_weights,
-    const Vec4TAcc<cache_t>* grad_sum,
-    const Vec4TAcc<cache_t>* smem_grad_sum,
+    const Vec4T* grad_sum,
+    const Vec4T* smem_grad_sum,
     const int32_t D,
     const int64_t weights_offset,
     const int64_t idx,
@@ -72,8 +71,8 @@ template <
     bool kUseVecBlocking
 >
 DEVICE_INLINE void compute_grad_sum_{{ kdesc }}(
-    Vec4TAcc<cache_t>* grad_sum,
-    Vec4TAcc<cache_t>* smem_grad_sum,
+    Vec4T* grad_sum,
+    Vec4T* smem_grad_sum,
     const pta::PackedTensorAccessor64<grad_t, {{ "1" if is_index_select else "2" }}, at::RestrictPtrTraits>& grad_output,
     {%- if not nobag or is_index_select %}
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>& D_offsets,
@@ -160,7 +159,7 @@ DEVICE_INLINE void compute_grad_sum_{{ kdesc }}(
                 #pragma unroll kFixedMaxVecsPerThread
                 for (int32_t vec = 0; vec < kFixedMaxVecsPerThread && {{ d }} < D; ++vec) {
                     const int32_t d = {{ d }};
-                    Vec4TAcc<grad_t> grad_out_vec(
+                    Vec4T grad_out_vec(
                         {%- if nobag and is_index_select %}
                         // grad_output is 1d
                         &grad_output[grad_offset + l_j * grad_stride + d]

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_grad_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_grad_template.cu
@@ -195,13 +195,13 @@ __global__ __launch_bounds__(kMaxThreads) void grad_mean{{ vdesc }}_kernel(
 
   if (L != 0) {
     for (int32_t d = threadIdx.x; d * 4 < D; d += blockDim.x) {
-      Vec4T<grad_t> grad_out_vec(&shifted_grad_output[d * 4]);
+      Vec4T grad_out_vec(&shifted_grad_output[d * 4]);
       grad_out_vec.mul_(1.0 / L);
       grad_out_vec.store(&shifted_grad_output_mean[d * 4]);
     }
   } else {
     for (int32_t d = threadIdx.x; d * 4 < D; d += blockDim.x) {
-      Vec4T<grad_t> grad_out_vec(&shifted_grad_output[d * 4]);
+      Vec4T grad_out_vec(&shifted_grad_output[d * 4]);
       grad_out_vec.store(&shifted_grad_output_mean[d * 4]);
     }
   }

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_indice_weights_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_indice_weights_template.cu
@@ -146,7 +146,7 @@ __global__ __launch_bounds__(kForwardMaxThreads) void
     const grad_t* grad_output_ = &grad_output[b][D_start];
     {%- endif %}
 
-    Vec4TAcc<cache_t> grad_out[kFixedMaxVecsPerThread];
+    Vec4T grad_out[kFixedMaxVecsPerThread];
 
     {%- if use_vec_blocking %}
     const int32_t num_vecs = div_round_up(D, kWarpSize * kVecWidth);
@@ -164,7 +164,7 @@ __global__ __launch_bounds__(kForwardMaxThreads) void
         #pragma unroll kFixedMaxVecsPerThread
         for (int32_t vec = 0; vec < kFixedMaxVecsPerThread && {{ d }} < D; ++vec) {
             const int32_t d = {{ d }};
-            Vec4TAcc<grad_t> go(grad_output_ + d);
+            Vec4T go(grad_output_ + d);
             grad_out[vec] = go;
         }
 
@@ -190,7 +190,7 @@ __global__ __launch_bounds__(kForwardMaxThreads) void
                     const int32_t d = {{ d }};
                     {%- if not dense %}
                     if (placement == PlacementType::MANAGED_CACHING && cache_idx_j != kCacheLocationMissing) {
-                        Vec4T<cache_t> weight(&lxu_cache_weights[cache_idx_j][d]);
+                        Vec4T weight(&lxu_cache_weights[cache_idx_j][d]);
                         grad_indice_weight += weight.acc.x * grad_out[vec].acc.x +
                             weight.acc.y * grad_out[vec].acc.y +
                             weight.acc.z * grad_out[vec].acc.z +
@@ -208,7 +208,7 @@ __global__ __launch_bounds__(kForwardMaxThreads) void
                         if (std::is_same<emb_t, uint8_t>::value) {
                             qparams = weight_row.load_qparams();
                         }
-                        Vec4TAcc<cache_t> weight =
+                        Vec4T weight =
                         weight_row.load(d, qparams);
                         grad_indice_weight += weight.acc.x * grad_out[vec].acc.x +
                             weight.acc.y * grad_out[vec].acc.y +
@@ -228,7 +228,7 @@ __global__ __launch_bounds__(kForwardMaxThreads) void
                     if (std::is_same<emb_t, uint8_t>::value) {
                         qparams = weight_row.load_qparams();
                     }
-                    Vec4TAcc<cache_t> weight =
+                    Vec4T weight =
                     weight_row.load(d, qparams);
                     grad_indice_weight += weight.acc.x * grad_out[vec].acc.x +
                         weight.acc.y * grad_out[vec].acc.y +

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
@@ -141,7 +141,7 @@ split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc 
   // when kUseVecBlocking == false
   const int32_t max_vecs =
       kUseVecBlocking ? max_vecs_per_thread : kFixedMaxVecsPerThread;
-  struct SharedMemory<Vec4TAcc<cache_t>> smem;
+  struct SharedMemory<Vec4T> smem;
   auto* smem_grad_sum =
       smem.getPointer() + warp_id * max_vecs * kThreadGroupSize;
 
@@ -202,7 +202,7 @@ split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc 
         const int32_t sl_end = min(SL_per_warp * (warp_id + 1), SL);
 
         // Accumulate gradients (compute grad_sum)
-        Vec4TAcc<cache_t> grad_sum[kFixedMaxVecsPerThread];
+        Vec4T grad_sum[kFixedMaxVecsPerThread];
         constexpr int32_t kGroupVecWidth = kThreadGroupSize * VEC_WIDTH;
         const int32_t num_vecs = (D + kGroupVecWidth - 1) / kGroupVecWidth;
 
@@ -272,8 +272,8 @@ split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc 
 
         if (num_ctas_on_current_run > 1) {
             int really_long_run_id = long_run_id_to_really_long_run_ids[long_run_id];
-            Vec4TAcc<cache_t> *temp_grad_accum_ptr =
-                reinterpret_cast<Vec4TAcc<cache_t>*>(&temp_grad_accum[really_long_run_id][0]);
+            Vec4T *temp_grad_accum_ptr =
+                reinterpret_cast<Vec4T*>(&temp_grad_accum[really_long_run_id][0]);
             {{
                 generate_optimized_grad_sum_loop_access(
                     """
@@ -350,7 +350,6 @@ split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc 
         {%- endif %}
         store_grad_sum<
           emb_t,
-          cache_t,
           kFixedMaxVecsPerThread,
           kThreadGroupSize,
           VEC_WIDTH,

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -116,7 +116,7 @@ split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc 
     constexpr int VEC_WIDTH = 4;
     constexpr auto kIsInt8 = std::is_same<emb_t, uint8_t>::value;
 
-    struct SharedMemory<Vec4TAcc<cache_t>> smem;
+    struct SharedMemory<Vec4T> smem;
     const int32_t grad_sum_stride = max_D / VEC_WIDTH;
     auto* smem_grad_sum = (kUseVecBlocking || kIsInt8)
       ? smem.getPointer() + threadIdx.y * grad_sum_stride
@@ -166,7 +166,7 @@ split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc 
         const int32_t SL_per_warp = div_round_up(SL, blockDim.y);
         const int32_t sl_start = 0;
         const int32_t sl_end = SL;
-        Vec4TAcc<cache_t> grad_sum[kFixedMaxVecsPerThread];
+        Vec4T grad_sum[kFixedMaxVecsPerThread];
         constexpr int32_t kGroupVecWidth = kThreadGroupSize * VEC_WIDTH;
         const int32_t num_vecs = (D + kGroupVecWidth - 1) / kGroupVecWidth;
 
@@ -258,7 +258,6 @@ split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc 
         {%- endif %}
         store_grad_sum<
             emb_t,
-            cache_t,
             kFixedMaxVecsPerThread,
             kThreadGroupSize,
             VEC_WIDTH,

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_nobag_small_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_nobag_small_template.cu
@@ -166,14 +166,14 @@ batch_index_select_dim0_codegen_forward_small_kernel(
                         const_cast<emb_t*>(&weights[idx_j * D_emb]),
                         const_cast<cache_t*>(&lxu_cache_weights[cache_idx_j][0]),
                         D);
-                    Vec4T<cache_t> weight = weight_row_cache.load(d, qparams_cache);
+                    Vec4T weight = weight_row_cache.load(d, qparams_cache);
                     weight.store(&output[output_j][d]);
                 } else {
-                    Vec4T<cache_t> weight = weight_row_emb.load(d, qparams_emb);
+                    Vec4T weight = weight_row_emb.load(d, qparams_emb);
                     weight.store(&output[output_j][d]);
                 }
                 {%- else %}
-                    Vec4T<cache_t> weight = weight_row_emb.load(d, qparams_emb);
+                    Vec4T weight = weight_row_emb.load(d, qparams_emb);
                     {%- if is_index_select %}
                     // output is 1D (because the stride can be irregular)
                     weight.store(&output[output_offset + output_j * output_stride + d]);

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_template.cu
@@ -385,7 +385,7 @@ batch_index_select_dim0_codegen_forward_kernel(
     const float inv_L = (mean_pooling && L != 0) ? static_cast<float>(1.0) / L: static_cast<float>(1.0);
 
     // Set up the accumulator buffer
-    Vec4T<cache_t> accumulators[kMaxVecsPerThread];
+    Vec4T accumulators[kMaxVecsPerThread];
     {%- endif %}
 
     {%- if dense %}

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_kernel_template.cu
@@ -50,7 +50,7 @@ void split_{{ optimizer }}_update_kernel(
     const unsigned int shfl_sync_mask = 0xffffffffu;
 #endif
 
-    Vec4TAcc<cache_t> grad_sum[kMaxVecsPerThread];
+    Vec4T grad_sum[kMaxVecsPerThread];
     const auto D = max_D;
 
     // Load grad_dev_weights into grad_sum

--- a/fbgemm_gpu/src/split_embeddings_cache/reset_weight_momentum.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/reset_weight_momentum.cu
@@ -189,7 +189,7 @@ __global__ __launch_bounds__(kMaxThreads) void reset_weight_momentum_kernel(
 
     // reset weight
     float2 qparams_new = {1.0, 0.0}; // scaler=1.0, and offset=0.0, for int8.
-    Vec4TAcc<cache_t> weight_new; // 0 weight
+    Vec4T weight_new; // 0 weight
     weight_row_template.store(
         weight_new,
         d,

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_embeddings_cache_cuda.cu
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_embeddings_cache_cuda.cu
@@ -42,7 +42,7 @@ __global__ __launch_bounds__(kMaxThreads) void masked_index_put_kernel(
   const auto idx = indices[n];
   const auto D = self.size(1);
   for (int32_t d = threadIdx.x; d * 4 < D; d += blockDim.x) {
-    Vec4T<scalar_t>::copy((&values[n][0]) + d * 4, (&self[idx][0]) + d * 4);
+    copy4((&values[n][0]) + d * 4, (&self[idx][0]) + d * 4);
   }
 }
 


### PR DESCRIPTION
Summary:
The `Vec4T` struct does not use the type template that is passed to
it.  This diff removes the type template to avoid confusion and reduce
duplicate code.

Differential Revision: D56386175


