### PR TITLE
introduce populate bucketize offsets kernel

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -194,6 +194,12 @@ block_bucketize_sparse_features_inference_cuda(
     const c10::optional<std::vector<at::Tensor>>& block_bucketize_pos,
     const bool return_bucket_mapping);
 
+///@ingroup sparse-data-cuda
+at::Tensor populate_bucketized_permute_cuda(
+    const at::Tensor& length,
+    const at::Tensor& bucketized_length,
+    const at::Tensor& bucket_mapping);
+
 std::tuple<
     at::Tensor,
     at::Tensor,
@@ -215,6 +221,12 @@ block_bucketize_sparse_features_inference_cpu(
     const int64_t max_batch_size,
     const c10::optional<std::vector<at::Tensor>>& block_bucketize_pos,
     const bool return_bucket_mapping);
+
+///@ingroup sparse-data-cpu
+at::Tensor populate_bucketized_permute_cpu(
+    const at::Tensor& length,
+    const at::Tensor& bucketized_length,
+    const at::Tensor& bucket_mapping);
 
 std::tuple<
     at::Tensor,

--- a/fbgemm_gpu/test/sparse/failures_dict.json
+++ b/fbgemm_gpu/test/sparse/failures_dict.json
@@ -66,7 +66,15 @@
         "comment": "",
         "status": "xfail"
       },
+      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_populate_bucketized_permute": {
+        "comment": "",
+        "status": "xfail"
+      },
       "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_inference": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketizeTest.test_faketensor__test_populate_bucketized_permute": {
         "comment": "",
         "status": "xfail"
       }
@@ -178,6 +186,16 @@
         "status": "xfail"
       },
       "PermuteEmbeddingsTest.test_faketensor__test_permute_embeddings": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
+    "fbgemm::populate_bucketized_permute": {
+      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_populate_bucketized_permute": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketizeTest.test_faketensor__test_populate_bucketized_permute": {
         "comment": "",
         "status": "xfail"
       }


### PR DESCRIPTION
Summary:
* this kernel is a batching runtime used unparametrized kernel version of block_bucketize, which produces the bucketization permute from the permuted data to the source data.
* we do have limited paralleism on T,B, as we grow on L massively these days, an overall optimzaiton for intra-bag parallelism is to be revisited ASAP.

Reviewed By: jiayisuse

Differential Revision: D55511724


