### PR TITLE
Implement offseted mode for linearize_cache_indices CUDA kernel

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_host.cpp
@@ -436,7 +436,8 @@ Tensor int_nbit_split_embedding_uvm_caching_codegen_lookup_function(
         indices,
         offsets,
         /*B_offsets=*/c10::optional<Tensor>(),
-        /*max_B=*/-1);
+        /*max_B=*/-1,
+        /*indices_base_offset=*/0);
 
     bool gather_uvm_stats = false;
     // populate_uvm_stats indicates whether to calculate cache related ratios,

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh
@@ -60,7 +60,8 @@ at::Tensor linearize_cache_indices_cuda(
     const at::Tensor& indices,
     const at::Tensor& offsets,
     const c10::optional<at::Tensor>& B_offsets,
-    const int64_t max_B);
+    const int64_t max_B,
+    const int64_t indices_base_offset);
 
 ///@ingroup table-batched-embed-cuda
 /// Linearize the indices of all tables to make it be unique.

--- a/fbgemm_gpu/src/split_embeddings_cache/common.h
+++ b/fbgemm_gpu/src/split_embeddings_cache/common.h
@@ -30,7 +30,8 @@ Tensor linearize_cache_indices_cpu(
     const Tensor& indices,
     const Tensor& offsets,
     const c10::optional<Tensor>& B_offsets,
-    const int64_t max_B);
+    const int64_t max_B,
+    const int64_t indices_base_offset);
 
 Tensor linearize_cache_indices_from_row_idx_cpu(
     Tensor cache_hash_size_cumsum,

--- a/fbgemm_gpu/src/split_embeddings_cache/linearize_cache_indices.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/linearize_cache_indices.cpp
@@ -17,7 +17,8 @@ DLL_PUBLIC Tensor linearize_cache_indices_cpu(
     const Tensor& indices,
     const Tensor& /*offsets*/,
     const c10::optional<Tensor>& /*B_offsets*/,
-    const int64_t /*max_B*/) {
+    const int64_t /*max_B*/,
+    const int64_t /*indices_base_offset*/) {
   return at::empty_like(indices);
 }
 

--- a/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
@@ -12,7 +12,7 @@ namespace {
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
-      "linearize_cache_indices(Tensor cache_hash_size_cumsum, Tensor indices, Tensor offsets, Tensor? B_offsets=None, int max_B=-1) -> Tensor");
+      "linearize_cache_indices(Tensor cache_hash_size_cumsum, Tensor indices, Tensor offsets, Tensor? B_offsets=None, int max_B=-1, int indices_base_offset=0) -> Tensor");
   m.def(
       "linearize_cache_indices_from_row_idx(Tensor cache_hash_size_cumsum, Tensor update_table_indices, Tensor update_row_indices) -> Tensor");
   m.def(

--- a/fbgemm_gpu/test/tbe/cache/linearize_cache_indices_test.py
+++ b/fbgemm_gpu/test/tbe/cache/linearize_cache_indices_test.py
@@ -84,6 +84,7 @@ class LinearizeCacheIndicesTest(unittest.TestCase):
             dtype=torch.int,
             device="cuda",
         )
+        N = indices.numel()
         pruned_indices = torch.tensor(
             [10, -1, 3, 7, 1, 4, -1, 9, 2, -1, 6, 8, 5, 1, -1, 4],
             dtype=torch.int,
@@ -140,6 +141,28 @@ class LinearizeCacheIndicesTest(unittest.TestCase):
                 output_test = torch.ops.fbgemm.linearize_cache_indices(*args)
                 output_ref = self.execute_linearize_cache_indices_ref(*args)
                 self.assertTrue(torch.equal(output_test, output_ref))
+
+                for partial_start, partial_end in [
+                    (0, N),
+                    (2, 2),
+                    (3, N),
+                    (N - 2, N),
+                    (1, N - 1),
+                ]:
+                    args = (
+                        hash_size_cumsum,
+                        indices[partial_start:partial_end],
+                        offsets,
+                        B_offsets,
+                        max_B,
+                        partial_start,
+                    )
+                    partial_output = torch.ops.fbgemm.linearize_cache_indices(*args)
+                    self.assertTrue(
+                        torch.equal(
+                            partial_output, output_ref[partial_start:partial_end]
+                        )
+                    )
 
     @unittest.skipIf(*gpu_unavailable)
     def test_linearize_cache_indices_from_row_idx(self) -> None:


### PR DESCRIPTION
Summary:
This patch will allow base_offset as a parameter so all values in `offset` will be decresed by that amount. This is done in a way that no copy of `offset`.

The ultimate goal for this is to achieve multipass prefetch, which require calling this kernel on a segment of `indices` (rather than the whole). See unittest for its usage.

Differential Revision: D56863774
