### PR TITLE
Remove unused-but-set variables in deeplearning/fbgemm/fbgemm_gpu/codegen/training/forward/embedding_forward_split_cpu.cpp +1

### DIFF
--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_cpu.cpp
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_cpu.cpp
@@ -385,7 +385,7 @@ void csr2csc_template_(
         fbgemm::fbgemmAlignedAlloc(64, nnz * sizeof(float)));
   }
 
-  int column_ptr_curr = 0;
+  [[maybe_unused]] int column_ptr_curr = 0;
   bool is_shared_table =
       table_to_feature_offset[1] > table_to_feature_offset[0] + 1;
   auto NS = csr_offsets[table_to_feature_offset[1] * B] -


### PR DESCRIPTION
Summary:
This diff removes a variable that was set, but which was not used.

LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused but set variables often indicate a programming mistake, but can also just be unnecessary cruft that harms readability and performance.

Removing this variable will not change how your code works, but the unused variable may indicate your code isn't working the way you thought it was. I've gone through each of these by hand, but mistakes may have slipped through. If you feel the diff needs changes before landing, **please commandeer** and make appropriate changes: there are hundreds of these and responding to them individually is challenging.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje, dmm-fb

Differential Revision: D56887160


