### PR TITLE
use verbose mode for CMake

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -16,6 +16,7 @@ set(THIRDPARTY ${FBGEMM}/third_party)
 
 include(${CMAKEMODULES}/Utilities.cmake)
 
+set(CMAKE_VERBOSE_MAKEFILE on)
 
 ################################################################################
 # FBGEMM_GPU Build Options


### PR DESCRIPTION
Summary:
When adding `-DTORCH_CUDA_ARCH_LIST="9.0a"`, it doesn't work with `-gencode arch=compute_90a,code=sm_90a`.

Checking https://github.com/pytorch/pytorch/pull/125523/files , we need to further modify CMake related regex to support this.

Differential Revision: D56988506


