### PR TITLE
Correct device for cache_miss_counter

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
@@ -1090,7 +1090,9 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
             )
             self.register_buffer(
                 "cache_miss_counter",
-                torch.tensor([0, 0, 0, 0], dtype=torch.int64),
+                torch.tensor(
+                    [0, 0, 0, 0], dtype=torch.int64, device=self.current_device
+                ),
                 persistent=False,
             )
             self.register_buffer(


### PR DESCRIPTION
Summary: IntNBitTableBatchedEmbeddingBagsCodegen's cache_miss_counter should be on current_device

Reviewed By: zimin2000

Differential Revision: D57190075


