### PR TITLE
FP8 AMD Kernels

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -98,7 +98,7 @@ if(NOT FBGEMM_CPU_ONLY)
   add_subdirectory(experimental/example)
 
   if(NOT USE_ROCM)
-    # CUTLASS currently doesn't build on ROCm:
+    # CUTLASS currently doesn't build on ROCm and CK hasnt yet been added:
     #
     # 2024-05-06T23:09:35.5730483Z /__w/FBGEMM/FBGEMM/fbgemm_gpu/../third_party/cutlass/include/cutlass/half.h:73:10: fatal error: 'cuda_fp16.h' file not found
     # #include <cuda_fp16.h>

--- a/fbgemm_gpu/experimental/gen_ai/bench/ck_fp8_bench.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/ck_fp8_bench.py
@@ -1,0 +1,198 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import os
+from typing import Any, Callable, Tuple
+
+import fbgemm_gpu.experimental.gen_ai  # noqa: F401
+
+import pandas as pd
+
+import torch
+import triton  # @manual=//triton:triton
+
+E4M3_MAX_POS: float = torch.finfo(torch.float8_e4m3fnuz).max
+EPS = 1e-12
+
+
+def set_amd_env_vars() -> None:
+    print("Setting environment variables for AMD GPU performance")
+    os.environ["DISABLE_ADDMM_HIP_LT"] = "0"
+    os.environ["HIP_FORCE_DEV_KERNARG"] = "1"
+    os.environ["PYTORCH_TUNABLEOP_VERBOSE"] = "0"
+    os.environ["PYTORCH_TUNABLEOP_ENABLED"] = "1"
+    os.environ["PYTORCH_TUNABLEOP_TUNING"] = "1"
+    os.environ["PYTORCH_TUNABLEOP_FILENAME"] = "hipblas_tuning_pt_llama.csv"
+    os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_DURATION_MS"] = "30"
+    os.environ["PYTORCH_TUNABLEOP_MAX_WARMUP_DURATION_MS"] = "30"
+
+
+def fp8_quantize(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    f8_max = torch.tensor(E4M3_MAX_POS, device=x.device)
+    x_amax = torch.max(torch.abs(x))
+    scale = f8_max / torch.clamp(x_amax, min=EPS)
+    scaled_x = torch.clamp(x * scale, min=-1 * f8_max, max=f8_max)
+    return scaled_x.to(torch.float8_e4m3fnuz), scale.reciprocal().to(torch.float32)
+
+
+class FPMatMul(torch.nn.Module):
+    def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return torch.matmul(a, b)
+
+
+class BaselineMatmul(torch.nn.Module):
+    def forward(
+        self,
+        qa: torch.Tensor,
+        qb: torch.Tensor,
+        a_scale: torch.Tensor,
+        b_scale: torch.Tensor,
+    ) -> torch.Tensor:
+        output, _ = torch._scaled_mm(
+            qa,
+            qb,
+            bias=None,
+            out_dtype=torch.bfloat16,
+            scale_a=a_scale,
+            scale_b=b_scale,
+            scale_result=None,
+            use_fast_accum=True,
+        )
+        return output
+
+
+class CKMatmul(torch.nn.Module):
+    def forward(
+        self, a: torch.Tensor, b: torch.Tensor, scale: torch.Tensor
+    ) -> torch.Tensor:
+        out = torch.ops.fbgemm.f8f8bf16(a, b, scale)
+        return out
+
+
+@torch.no_grad()
+def evaluate_impl(
+    M: int,
+    N: int,
+    K: int,
+    fp_func: Callable[[torch.Tensor, torch.Tensor], torch.Tensor],
+    baseline_func: Callable[
+        [torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor], torch.Tensor
+    ],
+    ck_func: Callable[[torch.Tensor, torch.Tensor, torch.Tensor], torch.Tensor],
+) -> Tuple[float, float, float, float, float]:
+    print(f"Evaluating {M=}, {N=}, {K=}")
+    A = torch.randn(M, K).to(dtype=torch.bfloat16, device="cuda")
+    QA, a_scale = fp8_quantize(A)
+    B = torch.randn(N, K).to(dtype=torch.bfloat16, device="cuda")
+    QB, b_scale = fp8_quantize(B)
+
+    # Check accuracy.
+    out_ref = fp_func(A.to(torch.float32), B.t().to(torch.float32))
+
+    baseline_out = baseline_func(QA, QB.t(), a_scale, b_scale)
+    baseline_sim = torch.mean(torch.pow(torch.abs(baseline_out - out_ref), 2))
+    print(f"Baseline accuracy: {baseline_sim}")
+
+    ck_out = ck_func(QA, QB, a_scale * b_scale)
+    ck_sim = torch.mean(torch.pow(torch.abs(ck_out - out_ref), 2))
+    print(f"CK accuracy: {ck_sim}")
+
+    # Benchmark runtimes.
+    ms_ref: float = triton.testing.do_bench(lambda: fp_func(A, B.t()))
+    print(f"BF16 runtime: {ms_ref} ms")
+
+    ms_baseline: float = triton.testing.do_bench(
+        lambda: baseline_func(QA, QB.t(), a_scale, b_scale)
+    )
+    print(f"Baseline runtime: {ms_baseline} ms")
+
+    ms_ck: float = triton.testing.do_bench(lambda: ck_func(QA, QB, a_scale * b_scale))
+    print(f"CK runtime: {ms_ck} ms")
+
+    return float(baseline_sim.item()), float(ck_sim.item()), ms_baseline, ms_ck, ms_ref
+
+
+def main(args: Any) -> None:
+    if args.enable_amd_env_vars:
+        set_amd_env_vars()
+
+    with torch.no_grad():
+        ck_mod = CKMatmul()
+        baseline_mod = BaselineMatmul()
+        bf16_mod = FPMatMul()
+        if args.torch_compile_mode:
+            ck_mod = torch.compile(
+                ck_mod,
+                dynamic=False,
+                backend="inductor",
+                mode=args.torch_compile_mode,
+            )
+            baseline_mod = torch.compile(
+                baseline_mod,
+                dynamic=False,
+                backend="inductor",
+                mode=args.torch_compile_mode,
+            )
+            bf16_mod = torch.compile(
+                bf16_mod,
+                dynamic=False,
+                backend="inductor",
+                mode=args.torch_compile_mode,
+            )
+        # Create a list of results.
+        benchmark_results = []
+
+        # Test over a bunch of shapes.
+        M = [13312, 16384, 16032, 2304, 2048]
+        N = [4096, 2304, 13312, 8192]
+        K = [16384, 6656, 2304, 2048, 13312]
+
+        for m in M:
+            for n in N:
+                for k in K:
+                    baseline_sim, ck_sim, ms_baseline, ms_ck, ms_bf16 = evaluate_impl(
+                        m, n, k, bf16_mod, baseline_mod, ck_mod
+                    )
+                    benchmark_results.append(
+                        {
+                            "M": m,
+                            "N": n,
+                            "K": k,
+                            "baseline_sim": baseline_sim,
+                            "ck_sim": ck_sim,
+                            "ms_baseline": ms_baseline,
+                            "ms_ck": ms_ck,
+                            "ms_bf16": ms_bf16,
+                        }
+                    )
+        if args.export_csv:
+            benchmark_results_df = pd.DataFrame(benchmark_results)
+            benchmark_results_df.to_csv("ck_bench.csv", index=False)
+
+
+def invoke_main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--export_csv",
+        action="store_true",
+        help="Export results to a CSV file.",
+    )
+    parser.add_argument(
+        "--torch_compile_mode",
+        type=str,
+        default="",
+        help="Torch compile mode to use.",
+    )
+    parser.add_argument(
+        "--enable_amd_env_vars",
+        default=False,
+        action="store_true",
+        help="Enable a set of environment variables for AMD GPU performance",
+    )
+
+    args = parser.parse_args()
+    main(args)

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions.hip
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cstdlib>
+#include <initializer_list>
+#include <iostream>
+#include <numeric>
+
+#include <ATen/ATen.h>
+#include <c10/cuda/CUDAStream.h>
+#include <torch/torch.h>
+
+#if defined(USE_ROCM)
+
+#include "ck/ck.hpp"
+#include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
+#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
+#include "ck/utility/data_type.hpp"
+
+#include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
+#include "ck/library/utility/check_err.hpp"
+#include "ck/library/utility/device_memory.hpp"
+#include "ck/library/utility/fill.hpp"
+#include "ck/library/utility/host_tensor.hpp"
+#include "ck/library/utility/host_tensor_generator.hpp"
+#include "ck/library/utility/literals.hpp"
+
+#include "ck/tensor_operation/gpu/device/impl/device_gemm_multiple_d_xdl_cshuffle.hpp"
+
+// Define commonly used types.
+template <ck::index_t... Is>
+using S = ck::Sequence<Is...>;
+
+using Row = ck::tensor_layout::gemm::RowMajor;
+using Col = ck::tensor_layout::gemm::ColumnMajor;
+using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+
+struct Scale {
+  Scale(float scale) : scale_(scale){};
+
+  __host__ __device__ void operator()(ck::bhalf_t& e, const float& c) const {
+    e = ck::type_convert<ck::bhalf_t>(scale_ * c);
+  }
+
+  float scale_;
+};
+
+namespace fbgemm_gpu {
+
+template <
+    int BLOCK_SIZE,
+    int MBLOCK,
+    int NBLOCK,
+    int KBLOCK,
+    int MPER_WAVE,
+    int NPER_WAVE,
+    bool PADDING = false>
+at::Tensor f8f8bf16_impl(at::Tensor XQ, at::Tensor WQ, double scale) {
+  // Get input information.
+  int M = XQ.size(0);
+  int N = WQ.size(0);
+  int K = XQ.size(1);
+
+  // Check that sizes are sufficiently large for grid dispatch.
+  TORCH_CHECK(
+      M >= 128 && N >= 128 && K >= 256,
+      "Minimum supported M,N,K is 128,128,256.");
+
+  int StrideA = K;
+  int StrideB = K;
+  int StrideC = N;
+
+  TORCH_CHECK(XQ.is_cuda() && XQ.is_contiguous());
+  TORCH_CHECK(WQ.is_cuda() && WQ.is_contiguous());
+
+  auto Y = at::empty({M, N}, XQ.options().dtype(at::kBFloat16));
+
+  using ADataType = ck::f8_t;
+  using BDataType = ck::f8_t;
+  using CDataType = ck::bhalf_t;
+  using AccDataType = float;
+  using CShuffleDataType = float;
+
+  using ALayout = Row;
+  using BLayout = Col;
+  using CLayout = Row;
+
+  using AElementOp = PassThrough;
+  using BElementOp = PassThrough;
+  using CElementOp = Scale;
+
+  static constexpr auto GemmDefault =
+      ck::tensor_operation::device::GemmSpecialization::Default;
+  static constexpr auto GemmMNKPadding =
+      ck::tensor_operation::device::GemmSpecialization::MNKPadding;
+  static constexpr auto GemmSpec = PADDING ? GemmMNKPadding : GemmDefault;
+  static constexpr auto LoopSched = ck::make_default_loop_scheduler();
+  static constexpr auto PipelineVer = ck::PipelineVersion::v1;
+  using ComputeType = ck::f8_t;
+
+  // Define derivative constants based on template parameters.
+  static constexpr int BLOCK_CLUSTER = BLOCK_SIZE / 4;
+  static constexpr int CBLOCK_N = NBLOCK / 16;
+  static constexpr int CBLOCK_M = BLOCK_SIZE / CBLOCK_N;
+  // Create the GEMM Operator.
+  using DeviceGemmInstance =
+      ck::tensor_operation::device::DeviceGemmMultipleD_Xdl_CShuffle<
+          ALayout,
+          BLayout,
+          ck::Tuple<>, // D Layouts
+          CLayout, // Output Layouts
+          ADataType,
+          BDataType,
+          AccDataType,
+          CShuffleDataType,
+          ck::Tuple<>, // D Datatypes
+          CDataType, // Output datatype
+          AElementOp,
+          BElementOp,
+          CElementOp,
+          GemmSpec, // Kernel Schedule.
+          1, // Prefetch stage
+          BLOCK_SIZE, // Block size
+          MBLOCK, // M per block
+          NBLOCK, // N per block
+          KBLOCK, // K per block
+          16, // AK1
+          16, // BK1
+          32, // M Per Xdl
+          32, // N Per Xdl
+          MPER_WAVE, // Mxdl per wave
+          NPER_WAVE, // Nxdl per wave
+          S<4, BLOCK_CLUSTER, 1>, // ABlockTransfer Threadcluster K0_M_K1
+          S<1, 0, 2>, // ABlockTransfer ThreadCluster ArrangeOrder
+          S<1, 0, 2>, // ABlockTransfer SrcAccessOrder
+          2, // ABlockTransfer SrcVectorDim
+          16, // ABlockTransfer SrcScalar PerVector
+          16, // ABlockTransfer DstScalar PerVector_K1
+          1, // ABlockLds AddExtraM
+          S<4, BLOCK_CLUSTER, 1>, // BBlockTransfer ThreadCluster K0_N_K1
+          S<1, 0, 2>, // BBlockTransfer ThreadCluster ArrangeOrder
+          S<1, 0, 2>, // BBlockTransfer SrcAccess Order
+          2, // BBlockTransfer SrcVectorDim
+          8, // BBlockTransfer SrcScalarPerVector
+          8, // BBlockTransfer DstScalar PerVector_K1
+          1, // BBlockLds AddExtraN
+          1, // CShuffle MXdlPerWave PerShuffle
+          1, // CShuffle NXdlPerWave PerShuffle
+          S<1, CBLOCK_M, 1, CBLOCK_N>, // CBlockTransferClusterLengths
+          8, // CBlockTransfer ScalarPerVector
+          LoopSched, // Loop Scheduler
+          PipelineVer, // Pipeline version
+          ComputeType>; // Compute datatype
+
+  // Create gemm launcher and arguments.
+  auto gemm = DeviceGemmInstance{};
+  auto invoker = gemm.MakeInvoker();
+
+  auto a_element_op = AElementOp{};
+  auto b_element_op = BElementOp{};
+  auto c_element_op = CElementOp{float(scale)};
+
+  auto argument = gemm.MakeArgument(
+      reinterpret_cast<ADataType*>(XQ.data_ptr()),
+      reinterpret_cast<BDataType*>(WQ.data_ptr()),
+      std::array<const void*, 0>{},
+      reinterpret_cast<CDataType*>(Y.data_ptr()),
+      M,
+      N,
+      K,
+      StrideA,
+      StrideB,
+      std::array<ck::index_t, 0>{},
+      StrideC,
+      a_element_op,
+      b_element_op,
+      c_element_op);
+
+  auto stream = at::cuda::getCurrentHIPStream().stream();
+  invoker.Run(argument, StreamConfig{stream, false});
+
+  return Y;
+}
+
+enum class KernelMode { Small, Large, Default };
+
+std::tuple<KernelMode, bool> get_kernel_mode(at::Tensor XQ, at::Tensor WQ) {
+  auto M = XQ.size(0);
+  auto K = XQ.size(1);
+  auto N = WQ.size(0);
+  // Use small kernel when input matrices are small.
+  bool use_small_kernel = (M <= 512 && N <= 512);
+  // For larger workloads, specialize to large gemm.
+  bool use_large_kernel =
+      ((M >= 4096 && N >= 4096) || (M >= 8192 && N >= 2048) ||
+       (N >= 8192 && M >= 2048) || (K >= 8192 && M >= 2048 && N >= 2048));
+  // Must use specialized padding kernel for shapes that cant be tiled.
+  bool use_pad = ((M % 256 != 0) || (N % 256 != 0) || (K % 256 != 0));
+  if (use_small_kernel) {
+    return {KernelMode::Small, use_pad};
+  } else if (use_large_kernel) {
+    return {KernelMode::Large, use_pad};
+  } else {
+    return {KernelMode::Default, use_pad};
+  }
+}
+
+at::Tensor
+f8f8bf16(at::Tensor XQ, at::Tensor WQ, double scale, bool use_fast_accum) {
+  TORCH_CHECK(use_fast_accum, "AMD does not support disabling use_fast_accum");
+  auto [kernel, pad] = get_kernel_mode(XQ, WQ);
+  if (pad) {
+    if (kernel == KernelMode::Small) {
+      return f8f8bf16_impl<64, 32, 64, 64, 1, 2, true>(XQ, WQ, scale);
+    } else if (kernel == KernelMode::Large) {
+      return f8f8bf16_impl<256, 256, 128, 64, 4, 2, true>(XQ, WQ, scale);
+    } else {
+      return f8f8bf16_impl<256, 128, 128, 64, 2, 2, true>(XQ, WQ, scale);
+    }
+  } else {
+    if (kernel == KernelMode::Small) {
+      return f8f8bf16_impl<64, 32, 64, 64, 1, 2>(XQ, WQ, scale);
+    } else if (kernel == KernelMode::Large) {
+      return f8f8bf16_impl<256, 256, 128, 64, 4, 2>(XQ, WQ, scale);
+    } else {
+      return f8f8bf16_impl<256, 128, 128, 64, 2, 2>(XQ, WQ, scale);
+    }
+  }
+}
+
+} // namespace fbgemm_gpu
+
+#endif // defined(USE_ROCM)

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -103,9 +103,6 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def("i8i8bf16(Tensor XQ, Tensor WQ, float scale, int split_k=1) -> Tensor");
 
   m.def(
-      "f8f8bf16(Tensor XQ, Tensor WQ, float scale, bool use_fast_accum=True) -> Tensor");
-
-  m.def(
       "f8f8bf16_rowwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? bias=None, bool use_fast_accum=True) -> Tensor");
 
   m.def(
@@ -120,6 +117,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.impl("i8i8bf16_dynamic", i8i8bf16_dynamic);
 #endif
 
+  m.def(
+      "f8f8bf16(Tensor XQ, Tensor WQ, float scale, bool use_fast_accum=True) -> Tensor");
   m.def("per_tensor_quantize_i8(Tensor X, float scale) -> Tensor");
   m.impl("per_tensor_quantize_i8", per_tensor_quantize_i8);
   m.def("per_tensor_dynamic_quantize_i8(Tensor X) -> (Tensor, Tensor)");
@@ -165,16 +164,17 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 #endif
 }
 
-#ifndef USE_ROCM
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
-  m.impl("i8i8bf16", i8i8bf16);
   m.impl("f8f8bf16", f8f8bf16);
+#ifndef USE_ROCM
+  m.impl("i8i8bf16", i8i8bf16);
   m.impl("f8f8bf16_rowwise", f8f8bf16_rowwise);
   m.impl("quantize_fp8_per_tensor", quantize_fp8_per_tensor);
   m.impl(
       "quantize_fp8_per_tensor_tensor_scale",
       quantize_fp8_per_tensor_tensor_scale);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas);
+#endif
 }
 
 at::Tensor i8i8bf16_meta(
@@ -256,8 +256,9 @@ at::Tensor f8i4bf16_rowwise_meta(
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
-  m.impl("i8i8bf16", i8i8bf16_meta);
   m.impl("f8f8bf16", f8f8bf16_meta);
+#ifndef USE_ROCM
+  m.impl("i8i8bf16", i8i8bf16_meta);
   m.impl("f8f8bf16_rowwise", f8f8bf16_rowwise_meta);
   m.impl("quantize_fp8_per_tensor", quantize_fp8_per_tensor_meta);
   m.impl(
@@ -265,8 +266,7 @@ TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
       quantize_fp8_per_tensor_tensor_scale_meta);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas_meta);
   m.impl("f8i4bf16_rowwise", f8i4bf16_rowwise_meta);
-}
-
 #endif
+}
 
 } // namespace fbgemm_gpu


### PR DESCRIPTION
Summary:
AMD support for the `f8f8bf16` fbgemm kernel. This implementation uses the Composable Kernel library to construct a performant FP8 Gemm on AMD. It runs up to 10X faster than `scaled_mm`.

Benchmarking data is available [here](https://docs.google.com/spreadsheets/d/1hK62EJIt9mZQJdZBxf5rGZ3u0hjMng7AkpwKnIjyn3k/edit#gid=500854639). Note that I primarily focused on larger workloads. On small workloads, there doesnt seem to be much benefit to using fp8 over bf16.

Differential Revision: D56963018


