### PR TITLE
Make keyed_jagged_index_select_dim1 pt2 compatible

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
@@ -168,38 +168,18 @@ namespace {
 class KeyedJaggedIndexSelectDim1GPUOp
     : public torch::autograd::Function<KeyedJaggedIndexSelectDim1GPUOp> {
  public:
-  static torch::autograd::variable_list forward(
-      torch::autograd::AutogradContext* ctx,
+  static torch::autograd::variable_list forward_impl(
       const Tensor& values,
       const Tensor& lengths,
       const Tensor& offsets,
-      const Tensor& indices, // select same indices for all batches
-      const int batch_size,
+      const Tensor& indices,
+      const c10::SymInt _batch_size,
       const c10::optional<Tensor>& weights,
-      const c10::optional<int64_t> selected_lengths_sum) {
-    // TODO: Add weights support
-    TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(lengths, offsets, values, indices);
-    TORCH_CHECK(values.dim() == 1, "values must be a 1D tensor");
-    TORCH_CHECK(lengths.dim() == 1, "lengths must be a 1D tensor");
-    TORCH_CHECK(offsets.dim() == 1, "offsets must be a 1D tensor");
-    TORCH_CHECK(indices.dim() == 1, "indices must be a 1D tensor");
-    TORCH_CHECK(
-        lengths.numel() + 1 == offsets.numel(),
-        "offsets size must be lengths size + 1");
-    TORCH_CHECK(lengths.numel() % batch_size == 0, "lengths");
+      const c10::optional<c10::SymInt>& selected_lengths_sum) {
+    at::cuda::OptionalCUDAGuard device_guard;
+    device_guard.set_index(values.get_device());
 
-    if (weights.has_value()) {
-      const Tensor& pos_weights = weights.value();
-      TENSOR_ON_CUDA_GPU(pos_weights);
-      TENSORS_ON_SAME_DEVICE(pos_weights, indices);
-      TORCH_CHECK(pos_weights.dim() == 1, "weights must be a 1D tensor");
-      TORCH_CHECK(
-          pos_weights.numel() == values.numel(),
-          "weights size and values size must be the same");
-    }
-
-    CUDA_DEVICE_GUARD(values);
-
+    const auto batch_size = _batch_size.guard_int(__FILE__, __LINE__);
     const int num_batches = lengths.numel() / batch_size;
     const int num_output_lengths = num_batches * indices.numel();
     const int MAX_CUMSUM_ENTRIES_PER_BLOCK = 256;
@@ -229,10 +209,6 @@ class KeyedJaggedIndexSelectDim1GPUOp
                     indices.scalar_type(),
                     "index_select_scalar_cumsum_wrapper_3",
                     [&] {
-#ifdef FBGEMM_GPU_MEMCHECK
-                      const auto func_name =
-                          "index_select_scalar_cumsum_kernel";
-#endif
                       index_select_scalar_cumsum_kernel<
                           length_t,
                           index_t,
@@ -243,14 +219,22 @@ class KeyedJaggedIndexSelectDim1GPUOp
                              MAX_CUMSUM_ENTRIES_PER_BLOCK,
                              0,
                              at::cuda::getCurrentCUDAStream()>>>(
-                              MAKE_PTA_WITH_NAME(
-                                  func_name, output_lengths, length_t, 1, 32),
-                              MAKE_PTA_WITH_NAME(
-                                  func_name, output_offsets, offset_t, 1, 32),
-                              MAKE_PTA_WITH_NAME(
-                                  func_name, lengths, length_t, 1, 32),
-                              MAKE_PTA_WITH_NAME(
-                                  func_name, indices, index_t, 1, 32),
+                              output_lengths.packed_accessor32<
+                                  length_t,
+                                  1,
+                                  at::RestrictPtrTraits>(),
+                              output_offsets.packed_accessor32<
+                                  offset_t,
+                                  1,
+                                  at::RestrictPtrTraits>(),
+                              lengths.packed_accessor32<
+                                  length_t,
+                                  1,
+                                  at::RestrictPtrTraits>(),
+                              indices.packed_accessor32<
+                                  index_t,
+                                  1,
+                                  at::RestrictPtrTraits>(),
                               num_batches,
                               batch_size,
                               num_output_lengths -
@@ -265,10 +249,9 @@ class KeyedJaggedIndexSelectDim1GPUOp
               });
         });
 
-    // D->H transfer if selected_lengths_sum not provided
-    const int64_t num_outputs = (selected_lengths_sum.has_value())
-        ? *selected_lengths_sum
-        : output_offsets[output_offsets.numel() - 1].item<int64_t>();
+    // TODO: Try to not do D->H transfer
+    const int64_t num_outputs =
+        output_offsets[output_offsets.numel() - 1].item<int64_t>();
     Tensor output = at::empty({num_outputs}, values.options());
     Tensor output_weights;
     if (weights.has_value()) {
@@ -281,29 +264,31 @@ class KeyedJaggedIndexSelectDim1GPUOp
     const auto output_offsets_contig = output_offsets.expect_contiguous();
 
     if (grid_size != 0) {
-#define LAUNCH_KERNEL(WEIGHTED, WEIGHT_TYPE, OUTPUT_WEIGHTS, WEIGHTS)          \
-  {                                                                            \
-    [[maybe_unused]] const auto func_name =                                    \
-        "keyed_jagged_index_select_dim1_kernel";                               \
-    keyed_jagged_index_select_dim1_kernel<                                     \
-        value_t,                                                               \
-        index_t,                                                               \
-        offset_t,                                                              \
-        WEIGHT_TYPE,                                                           \
-        WEIGHTED>                                                              \
-        <<<grid_size, kMaxThreads, 0, at::cuda::getCurrentCUDAStream()>>>(     \
-            MAKE_PTA_WITH_NAME(func_name, output, value_t, 1, 64),             \
-            MAKE_PTA_WITH_NAME(func_name, OUTPUT_WEIGHTS, WEIGHT_TYPE, 1, 64), \
-            MAKE_PTA_WITH_NAME(func_name, values, value_t, 1, 64),             \
-            MAKE_PTA_WITH_NAME(func_name, WEIGHTS, WEIGHT_TYPE, 1, 64),        \
-            MAKE_PTA_WITH_NAME(func_name, offsets, offset_t, 1, 32),           \
-            MAKE_PTA_WITH_NAME(func_name, indices, index_t, 1, 32),            \
-            MAKE_PTA_WITH_NAME(                                                \
-                func_name, (*output_offsets_contig), offset_t, 1, 32),         \
-            num_batches,                                                       \
-            batch_size);                                                       \
+#define LAUNCH_KERNEL(WEIGHTED, WEIGHT_TYPE, OUTPUT_WEIGHTS, WEIGHTS)        \
+  {                                                                          \
+    keyed_jagged_index_select_dim1_kernel<                                   \
+        value_t,                                                             \
+        index_t,                                                             \
+        offset_t,                                                            \
+        WEIGHT_TYPE,                                                         \
+        WEIGHTED>                                                            \
+        <<<grid_size, kMaxThreads, 0, at::cuda::getCurrentCUDAStream()>>>(   \
+            output.packed_accessor64<value_t, 1, at::RestrictPtrTraits>(),   \
+            OUTPUT_WEIGHTS                                                   \
+                .packed_accessor64<WEIGHT_TYPE, 1, at::RestrictPtrTraits>(), \
+            values.packed_accessor64<value_t, 1, at::RestrictPtrTraits>(),   \
+            WEIGHTS                                                          \
+                .packed_accessor64<WEIGHT_TYPE, 1, at::RestrictPtrTraits>(), \
+            offsets.packed_accessor32<offset_t, 1, at::RestrictPtrTraits>(), \
+            indices.packed_accessor32<index_t, 1, at::RestrictPtrTraits>(),  \
+            output_offsets_contig                                            \
+                ->packed_accessor32<offset_t, 1, at::RestrictPtrTraits>(),   \
+            num_batches,                                                     \
+            batch_size);                                                     \
   }
-      FBGEMM_DISPATCH_ALL_TYPES(
+      AT_DISPATCH_ALL_TYPES_AND2(
+          at::ScalarType::Half,
+          at::ScalarType::BFloat16,
           values.scalar_type(),
           "keyed_jagged_index_select_dim1_warpper_1",
           [&] {
@@ -343,17 +328,153 @@ class KeyedJaggedIndexSelectDim1GPUOp
 
 #undef LAUNCH_KERNEL
 
-    ctx->save_for_backward({indices, output_offsets, offsets});
-    ctx->saved_data["num_outputs"] = num_outputs;
-    ctx->saved_data["num_inputs"] = values.numel();
-    ctx->saved_data["batch_size"] = batch_size;
-    ctx->saved_data["num_batches"] = num_batches;
-    ctx->saved_data["has_weights"] = weights.has_value();
+    int64_t saved_data[] = {
+        num_outputs,
+        values.numel(),
+        batch_size,
+        num_batches,
+    };
+
+    auto saved_data_t = at::empty(
+        {sizeof(saved_data) / sizeof(int64_t)},
+        at::TensorOptions().dtype(at::kLong));
+    TORCH_CHECK(saved_data_t.is_contiguous());
+    memcpy(saved_data_t.data_ptr<int64_t>(), saved_data, sizeof(saved_data));
 
     if (weights.has_value()) {
-      return {output, output_lengths, output_weights};
+      return {
+          output, output_lengths, output_weights, output_offsets, saved_data_t};
     }
-    return {output, output_lengths};
+    return {output, output_lengths, output_offsets, saved_data_t};
+  }
+
+  static torch::autograd::variable_list forward(
+      torch::autograd::AutogradContext* ctx,
+      const Tensor& values,
+      const Tensor& lengths,
+      const Tensor& offsets,
+      const Tensor& indices, // select same indices for all batches
+      const c10::SymInt batch_size,
+      const c10::optional<Tensor>& weights,
+      const c10::optional<c10::SymInt>& selected_lengths_sum) {
+    at::AutoDispatchBelowADInplaceOrView guard;
+    // TODO: Add weights support
+    TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(lengths, offsets, values, indices);
+    TORCH_CHECK(values.dim() == 1, "values must be a 1D tensor");
+    TORCH_CHECK(lengths.dim() == 1, "lengths must be a 1D tensor");
+    TORCH_CHECK(offsets.dim() == 1, "offsets must be a 1D tensor");
+    TORCH_CHECK(indices.dim() == 1, "indices must be a 1D tensor");
+    TORCH_SYM_CHECK(
+        offsets.sym_size(0).sym_eq(lengths.sym_size(0) + 1),
+        "offsets size must be lengths size + 1");
+    // TORCH_SYM_CHECK(lengths.sym_numel() % batch_size == 0, "lengths");
+
+    if (weights.has_value()) {
+      const Tensor& pos_weights = weights.value();
+      TENSOR_ON_CUDA_GPU(pos_weights);
+      TENSORS_ON_SAME_DEVICE(pos_weights, indices);
+      TORCH_CHECK(pos_weights.dim() == 1, "weights must be a 1D tensor");
+      TENSORS_HAVE_SAME_SYM_NUMEL(pos_weights, values);
+    }
+
+    static auto forward_op_impl =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow(
+                "fbgemm::keyed_jagged_index_select_dim1_forward_cuda_impl", "")
+            .typed<decltype(forward_impl)>();
+
+    auto res = forward_op_impl.call(
+        values,
+        lengths,
+        offsets,
+        indices,
+        batch_size,
+        weights,
+        selected_lengths_sum);
+
+    const bool has_weights = weights.has_value();
+    const size_t res_size = has_weights ? 3u : 2u;
+    ctx->saved_data["has_weights"] = has_weights;
+    ctx->save_for_backward(std::vector<Tensor>{
+        offsets,
+        indices,
+        res[res_size + 0], // output_offsets
+        res[res_size + 1], // saved_data_tensor
+    });
+
+    res.resize(res_size);
+    return res;
+  }
+
+  static Tensor backward_impl(
+      const Tensor& grad,
+      const Tensor& indices,
+      const Tensor& grad_offsets,
+      const Tensor& output_offsets,
+      const Tensor& saved_tensor) {
+    const auto num_outputs =
+        saved_tensor[1].item<int64_t>(); // saved forward num_inputs
+    const auto output_batch_size = saved_tensor[2].item<int64_t>();
+    const auto num_batches = saved_tensor[3].item<int64_t>();
+
+    at::cuda::OptionalCUDAGuard device_guard;
+    device_guard.set_index(grad.get_device());
+
+    Tensor grad_input = at::zeros({num_outputs}, grad.options());
+    auto grid_size = cuda_calc_xblock_count(grad.numel(), kMaxThreads);
+    // grad_offsetshas to be contiguous because it is passed to
+    // binary_search_range which takes raw pointers as arguments
+    const auto grad_offsets_contig = grad_offsets.expect_contiguous();
+
+    if (grid_size != 0) {
+      AT_DISPATCH_ALL_TYPES_AND2(
+          at::ScalarType::Half,
+          at::ScalarType::BFloat16,
+          grad.scalar_type(),
+          "keyed_jagged_index_add_dim1_wrapper_1",
+          [&] {
+            AT_DISPATCH_INDEX_TYPES(
+                grad_offsets.scalar_type(),
+                "keyed_jagged_index_add_dim1_wrapper_2",
+                [&] {
+                  using offset_t = index_t;
+                  AT_DISPATCH_INDEX_TYPES(
+                      indices.scalar_type(),
+                      "keyed_jagged_index_add_dim1_wrapper_3",
+                      [&] {
+                        keyed_jagged_index_add_dim1_kernel<<<
+                            grid_size,
+                            kMaxThreads,
+                            0,
+                            at::cuda::getCurrentCUDAStream()>>>(
+                            grad_input.packed_accessor64<
+                                scalar_t,
+                                1,
+                                at::RestrictPtrTraits>(),
+                            grad.packed_accessor64<
+                                scalar_t,
+                                1,
+                                at::RestrictPtrTraits>(),
+                            grad_offsets_contig->packed_accessor32<
+                                offset_t,
+                                1,
+                                at::RestrictPtrTraits>(),
+                            indices.packed_accessor32<
+                                index_t,
+                                1,
+                                at::RestrictPtrTraits>(),
+                            output_offsets.packed_accessor32<
+                                offset_t,
+                                1,
+                                at::RestrictPtrTraits>(),
+                            num_batches,
+                            output_batch_size);
+                        C10_CUDA_KERNEL_LAUNCH_CHECK();
+                      });
+                });
+          });
+    }
+    return grad_input;
   }
 
   static torch::autograd::variable_list backward(
@@ -368,65 +489,23 @@ class KeyedJaggedIndexSelectDim1GPUOp
 
     const auto saved = ctx->get_saved_variables();
     auto savedItr = std::begin(saved);
-    const Tensor& indices = *savedItr++;
-    const Tensor& grad_offsets = *savedItr++;
-    const Tensor& output_offsets = *savedItr++;
+
+    const Tensor& output_offsets = *savedItr++; // saved forward offsets
+    const Tensor& indices = *savedItr++; // saved forward indices
+
+    const Tensor& grad_offsets = *savedItr++; // saved forward output_offsets
+    const Tensor& saved_tensor = *savedItr++;
 
     TENSORS_ON_SAME_DEVICE(grad, indices);
 
-    int64_t num_outputs = ctx->saved_data["num_inputs"].toInt();
-    int64_t output_batch_size = ctx->saved_data["batch_size"].toInt();
-    int64_t num_batches = ctx->saved_data["num_batches"].toInt();
+    static auto backward_op =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow(
+                "fbgemm::keyed_jagged_index_select_dim1_backward_cuda_impl", "")
+            .typed<decltype(backward_impl)>();
 
-    CUDA_DEVICE_GUARD(grad);
-
-    Tensor grad_input = at::zeros({num_outputs}, grad.options());
-    auto grid_size = cuda_calc_xblock_count(grad.numel(), kMaxThreads);
-    // grad_offsetshas to be contiguous because it is passed to
-    // binary_search_range which takes raw pointers as arguments
-    const auto grad_offsets_contig = grad_offsets.expect_contiguous();
-
-    if (grid_size != 0) {
-      FBGEMM_DISPATCH_ALL_TYPES(
-          grad.scalar_type(), "keyed_jagged_index_add_dim1_wrapper_1", [&] {
-            AT_DISPATCH_INDEX_TYPES(
-                grad_offsets.scalar_type(),
-                "keyed_jagged_index_add_dim1_wrapper_2",
-                [&] {
-                  using offset_t = index_t;
-#ifdef FBGEMM_GPU_MEMCHECK
-                  const auto func_name = "keyed_jagged_index_add_dim1_kernel";
-#endif
-                  AT_DISPATCH_INDEX_TYPES(
-                      indices.scalar_type(),
-                      "keyed_jagged_index_add_dim1_wrapper_3",
-                      [&] {
-                        keyed_jagged_index_add_dim1_kernel<<<
-                            grid_size,
-                            kMaxThreads,
-                            0,
-                            at::cuda::getCurrentCUDAStream()>>>(
-                            MAKE_PTA_WITH_NAME(
-                                func_name, grad_input, scalar_t, 1, 64),
-                            MAKE_PTA_WITH_NAME(
-                                func_name, grad, scalar_t, 1, 64),
-                            MAKE_PTA_WITH_NAME(
-                                func_name,
-                                (*grad_offsets_contig),
-                                offset_t,
-                                1,
-                                32),
-                            MAKE_PTA_WITH_NAME(
-                                func_name, indices, index_t, 1, 32),
-                            MAKE_PTA_WITH_NAME(
-                                func_name, output_offsets, offset_t, 1, 32),
-                            num_batches,
-                            output_batch_size);
-                        C10_CUDA_KERNEL_LAUNCH_CHECK();
-                      });
-                });
-          });
-    }
+    auto grad_input = backward_op.call(
+        grad, indices, grad_offsets, output_offsets, saved_tensor);
 
     return {
         grad_input,
@@ -435,7 +514,7 @@ class KeyedJaggedIndexSelectDim1GPUOp
         torch::autograd::Variable(), // indices
         torch::autograd::Variable(), // batch_size
         torch::autograd::Variable(), // weights
-        torch::autograd::Variable() // selected_lengths_sum
+        torch::autograd::Variable(), // selected_lengths_sum
     };
   }
 };
@@ -446,9 +525,9 @@ std::vector<Tensor> keyed_jagged_index_select_dim_1_gpu(
     const Tensor& lengths,
     const Tensor& offsets,
     const Tensor& indices,
-    const int64_t batch_size,
+    const c10::SymInt batch_size,
     const c10::optional<Tensor>& weights,
-    const c10::optional<int64_t> selected_lengths_sum) {
+    const c10::optional<c10::SymInt> selected_lengths_sum) {
   return KeyedJaggedIndexSelectDim1GPUOp::apply(
       values,
       lengths,
@@ -461,7 +540,34 @@ std::vector<Tensor> keyed_jagged_index_select_dim_1_gpu(
 
 } // namespace fbgemm_gpu
 
-FBGEMM_OP_DISPATCH(
-    CUDA,
-    "keyed_jagged_index_select_dim1",
-    fbgemm_gpu::keyed_jagged_index_select_dim_1_gpu);
+TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  m.set_python_module("fbgemm_gpu.sparse_ops");
+  m.def(
+      "keyed_jagged_index_select_dim1_forward_cuda_impl("
+      "Tensor values,"
+      "Tensor lengths,"
+      "Tensor offsets,"
+      "Tensor indices,"
+      "SymInt batch_size,"
+      "Tensor? weights,"
+      "SymInt? selected_lengths_sum) -> Tensor[]");
+
+  m.def(
+      "keyed_jagged_index_select_dim1_backward_cuda_impl("
+      "Tensor grad,"
+      "Tensor indices,"
+      "Tensor grad_offsets,"
+      "Tensor output_offsets,"
+      "Tensor saved_tensor) -> Tensor");
+
+  DISPATCH_TO_CUDA(
+      "keyed_jagged_index_select_dim1_forward_cuda_impl",
+      fbgemm_gpu::KeyedJaggedIndexSelectDim1GPUOp::forward_impl);
+  DISPATCH_TO_CUDA(
+      "keyed_jagged_index_select_dim1_backward_cuda_impl",
+      fbgemm_gpu::KeyedJaggedIndexSelectDim1GPUOp::backward_impl);
+
+  DISPATCH_TO_AUTOGRAD_CUDA(
+      "keyed_jagged_index_select_dim1",
+      fbgemm_gpu::keyed_jagged_index_select_dim_1_gpu);
+}

--- a/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
@@ -3133,7 +3133,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "bottom_k_per_row(Tensor input, Tensor k_offsets, bool requires_unique) -> Tensor");
   m.def(
-      "keyed_jagged_index_select_dim1(Tensor values, Tensor lengths, Tensor offsets, Tensor indices, SymInt batch_size, Tensor? weights=None, SymInt? selected_lengths_sum=None) -> Tensor[]");
+      "keyed_jagged_index_select_dim1(Tensor values, Tensor lengths, Tensor offsets, Tensor indices, SymInt batch_size, Tensor? weights=None, SymInt? selected_lengths_sum=None) -> Tensor[]",
+      {PT2_COMPLIANT_TAG});
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {

--- a/fbgemm_gpu/test/jagged/failures_dict.json
+++ b/fbgemm_gpu/test/jagged/failures_dict.json
@@ -89,20 +89,7 @@
         "status": "xfail"
       }
     },
-    "fbgemm::keyed_jagged_index_select_dim1": {
-      "KeyedJaggedIndexSelectTest.test_aot_dispatch_dynamic__test_keyed_jagged_index_select_dim1": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "KeyedJaggedIndexSelectTest.test_autograd_registration__test_keyed_jagged_index_select_dim1": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "KeyedJaggedIndexSelectTest.test_faketensor__test_keyed_jagged_index_select_dim1": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
+    "fbgemm::keyed_jagged_index_select_dim1": {},
     "fbgemm::masked_select_jagged_1d": {},
     "fbgemm::offsets_range": {
       "Jagged1DToDenseTest.test_aot_dispatch_dynamic__test_jagged_1d_to_dense": {


### PR DESCRIPTION
Summary:
Following C++ Autograd PT2 compat: 
https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU/edit#heading=h.ptttacy8y1u9

Extracting forward_impl and backward_impl to make forward/backward traceable.

Adding meta functions for forward_impl and backward_impl.

Differential Revision: D57334955


