### PR TITLE
Make batch_index_select_dim0 cuda pt2 autograd compatible

### DIFF
--- a/fbgemm_gpu/codegen/training/index_select/batch_index_select_dim0_cpu_host.cpp
+++ b/fbgemm_gpu/codegen/training/index_select/batch_index_select_dim0_cpu_host.cpp
@@ -11,58 +11,358 @@
 #include <ATen/core/op_registration/op_registration.h>
 #include <torch/script.h>
 
+#include <c10/util/ArrayRef.h>
+#include "fbgemm_gpu/dispatch_macros.h"
 #include "fbgemm_gpu/embedding_common.h"
 #include "fbgemm_gpu/sparse_ops.h"
 #include "fbgemm_gpu/sparse_ops_utils.h"
 
+#include <memory>
+#include <string>
+
 using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
+
+namespace {
+Tensor tensor_from_vec(const std::vector<int64_t>& vec) {
+  auto tensor = at::empty(
+      {static_cast<int64_t>(vec.size())},
+      at::TensorOptions().dtype(torch::kInt64));
+  TORCH_CHECK(tensor.is_contiguous());
+  std::memcpy(
+      tensor.data_ptr<int64_t>(), vec.data(), sizeof(int64_t) * vec.size());
+  return tensor;
+};
+
+std::vector<int64_t> vecref_from_tensor(const Tensor& t) {
+  TORCH_CHECK(t.is_contiguous());
+  const auto numel = static_cast<size_t>(t.numel());
+  const auto* ptr = t.data_ptr<int64_t>();
+  return std::vector(ptr, ptr + numel);
+};
+
+} // namespace
 
 class BatchIndexSelectDim0CPUOp
     : public torch::autograd::Function<BatchIndexSelectDim0CPUOp> {
  public:
+  static torch::autograd::variable_list forward_impl(
+      const Tensor& inputs,
+      const Tensor& indices,
+      const c10::SymIntArrayRef _input_num_indices,
+      const c10::SymIntArrayRef _input_rows,
+      const c10::SymIntArrayRef _input_columns,
+      const bool permute_output_dim_0_1) {
+    const int64_t num_inputs = _input_num_indices.size();
+    TORCH_CHECK(
+        num_inputs == static_cast<int64_t>(_input_rows.size()),
+        "[batch_index_select_dim0] input_rows must have the same length as "
+        "input_num_indices.");
+    TORCH_CHECK(
+        num_inputs == static_cast<int64_t>(_input_columns.size()),
+        "[batch_index_select_dim0] input_columns must have the same length as "
+        "input_num_indices.");
+    TORCH_CHECK(
+        reinterpret_cast<uint64_t>(inputs.data_ptr()) % 16 == 0,
+        "Currently batch_index_select only supports 16-byte align input tensors");
+
+    static auto to_vec_int64 =
+        [](const c10::SymIntArrayRef& sym_vec) -> std::vector<int64_t> {
+      std::vector<int64_t> vec;
+      std::transform(
+          sym_vec.begin(),
+          sym_vec.end(),
+          std::back_inserter(vec),
+          [](const auto& symint) {
+            return symint.guard_int(__FILE__, __LINE__);
+          });
+      return vec;
+    };
+
+    Tensor ret;
+    Tensor indices_numels_tensor;
+    std::vector<int64_t> input_num_indices;
+    std::vector<int64_t> input_rows;
+    std::vector<int64_t> input_columns;
+
+    Tensor input_num_indices_tensor;
+    Tensor input_columns_tensor;
+    Tensor input_rows_tensor;
+
+    // Early exit
+    if (inputs.numel() == 0) {
+      ret = at::empty({0}, inputs.options());
+    } else {
+      input_num_indices = to_vec_int64(_input_num_indices);
+      input_num_indices_tensor = tensor_from_vec(input_num_indices);
+      input_rows = to_vec_int64(_input_rows);
+      input_columns = to_vec_int64(_input_columns);
+      input_columns_tensor = tensor_from_vec(input_columns);
+      input_rows_tensor = tensor_from_vec(input_rows);
+
+      TORCH_CHECK(
+          torch::all(torch::gt(input_columns_tensor, 0)).item<bool>(),
+          "[batch_index_select_dim0] All input_columns must be the same.");
+      TORCH_CHECK(
+          torch::all(torch::gt(input_rows_tensor, 0)).item<bool>(),
+          "[batch_index_select_dim0] All input_rows must be the same.");
+
+      if (permute_output_dim_0_1) {
+        // All output rows must be the same
+        TORCH_CHECK(input_num_indices[0] > 0);
+        TORCH_CHECK(
+            torch::all(
+                torch::eq(input_num_indices_tensor, input_num_indices[0]))
+                .item<bool>(),
+            "[batch_index_select_dim0] All input_num_indices must be the same if "
+            "permute_output_dim_0_1 is true.");
+      } else {
+        TORCH_CHECK(
+            torch::all(torch::gt(input_num_indices_tensor, 0)).item<bool>(),
+            "[batch_index_select_dim0] All input_num_indices must be greater than zero.");
+      }
+
+      // Compute section sizes for splitting tensors
+      std::vector<int64_t> input_numels;
+      std::vector<int64_t> indices_numels;
+      input_numels.reserve(num_inputs);
+      indices_numels.reserve(num_inputs);
+      for (auto i = 0; i < num_inputs; i++) {
+        input_numels.push_back(input_rows[i] * input_columns[i]);
+        indices_numels.push_back(input_num_indices[i]);
+      }
+      indices_numels_tensor = tensor_from_vec(indices_numels);
+
+      // Split tensors into vectors
+      const auto inputs_ = at::split_with_sizes(inputs, input_numels, 0);
+      const auto indices_ = at::split_with_sizes(indices, indices_numels, 0);
+
+      std::vector<Tensor> outputs;
+      outputs.reserve(num_inputs);
+      for (auto i = 0; i < num_inputs; i++) {
+        const auto input = inputs_[i].view({input_rows[i], input_columns[i]});
+        const auto index = indices_[i];
+        const auto output = at::index_select(input, 0, index);
+        if (permute_output_dim_0_1) {
+          outputs.push_back(output);
+        } else {
+          outputs.push_back(output.flatten());
+        }
+      }
+
+      // permute_output_dim_0_1 = true shape: (batch_size, num_inputs, cols)
+      // permute_output_dim_0_1 = false shape: (num_inputs, batch_size cols)
+      ret = at::concat(outputs, permute_output_dim_0_1 ? 1 : 0).flatten();
+    }
+
+    auto saved_data_tensor = tensor_from_vec({inputs.numel()});
+
+    return {
+        ret,
+
+        input_num_indices_tensor,
+        input_rows_tensor,
+        input_columns_tensor,
+
+        indices_numels_tensor,
+        saved_data_tensor};
+  }
+
   static torch::autograd::variable_list forward(
       torch::autograd::AutogradContext* ctx,
       const Tensor& inputs,
       const Tensor& indices,
-      const std::vector<int64_t>& input_num_indices,
-      const std::vector<int64_t>& input_rows,
-      const std::vector<int64_t>& input_columns,
+      const c10::SymIntArrayRef input_num_indices,
+      const c10::SymIntArrayRef input_rows,
+      const c10::SymIntArrayRef input_columns,
       const bool permute_output_dim_0_1) {
-    const int64_t num_inputs = input_num_indices.size();
-    ctx->save_for_backward({indices});
+    at::AutoDispatchBelowADInplaceOrView guard;
+    static auto forward_op_impl =
+        torch::Dispatcher::singleton()
+            .findSchemaOrThrow(
+                "fbgemm::batch_index_select_dim0_forward_cpu_impl", "")
+            .typed<decltype(forward_impl)>();
 
-    ctx->saved_data["input_numel"] = inputs.numel();
-    ctx->saved_data["input_num_indices"] = input_num_indices;
-    ctx->saved_data["input_rows"] = input_rows;
-    ctx->saved_data["input_columns"] = input_columns;
+    auto res = forward_op_impl.call(
+        inputs,
+        indices,
+        input_num_indices,
+        input_rows,
+        input_columns,
+        permute_output_dim_0_1);
     ctx->saved_data["permute_output_dim_0_1"] = permute_output_dim_0_1;
+    ctx->save_for_backward(
+        std::vector<Tensor>{indices, res[1], res[2], res[3], res[4], res[5]});
+    res.resize(1);
+    return res;
+  }
+
+  static Tensor backward_impl(
+      const Tensor& grad_output,
+      const Tensor& indices,
+      const Tensor& indices_numels,
+      const Tensor& input_num_indices,
+      const Tensor& input_rows,
+      const Tensor& input_columns,
+      const bool permute_output_dim_0_1,
+      const Tensor& saved_tensor) {
+    const int64_t input_numel = saved_tensor[0].item<int64_t>();
+
+    // Early exit
+    if (input_numel == 0) {
+      return at::empty({0}, grad_output.options());
+    }
+    const int64_t num_inputs = input_num_indices.size(0);
+
+    auto input_num_indices_vec = vecref_from_tensor(input_num_indices);
+    auto input_rows_vec = vecref_from_tensor(input_rows);
+    auto input_columns_vec = vecref_from_tensor(input_columns);
+
+    std::vector<Tensor> grads;
+    if (permute_output_dim_0_1) {
+      grads = at::split_with_sizes(
+          grad_output.view({input_num_indices_vec[0], -1}),
+          input_columns_vec,
+          1);
+    } else {
+      std::vector<int64_t> grad_numels;
+      grad_numels.reserve(num_inputs);
+      for (auto i = 0; i < num_inputs; i++) {
+        grad_numels.push_back(input_num_indices_vec[i] * input_columns_vec[i]);
+      }
+      grads = at::split_with_sizes(grad_output, grad_numels, 0);
+    }
+
+    const auto indices_ =
+        at::split_with_sizes(indices, vecref_from_tensor(indices_numels), 0);
+
+    std::vector<Tensor> grad_inputs;
+    grad_inputs.reserve(num_inputs);
+    for (auto i = 0; i < num_inputs; i++) {
+      const auto num_indices = input_num_indices_vec[i];
+      const auto grad_input = at::zeros(
+          {input_rows_vec[i], input_columns_vec[i]}, grad_output.options());
+      const auto grad =
+          permute_output_dim_0_1 ? grads[i] : grads[i].view({num_indices, -1});
+      grad_inputs.push_back(
+          at::index_add(grad_input, 0, indices_[i], grad).flatten());
+    }
+
+    return at::concat(grad_inputs, 0);
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext* ctx,
+      torch::autograd::variable_list grad_outputs) {
+    using torch::autograd::Variable;
+    TORCH_CHECK_EQ(grad_outputs.size(), 1);
+
+    const auto grad_output = grad_outputs[0];
+    const auto permute_output_dim_0_1 =
+        ctx->saved_data["permute_output_dim_0_1"].toBool();
+    const auto saved = ctx->get_saved_variables();
+
+    auto savedItr = std::begin(saved);
+    auto indices = *savedItr++;
+
+    auto input_num_indices = *savedItr++;
+    auto input_rows = *savedItr++;
+    auto input_columns = *savedItr++;
+
+    auto indices_numels = *savedItr++;
+    auto saved_tensor = *savedItr++;
+    static auto backward_op =
+        torch::Dispatcher::singleton()
+            .findSchemaOrThrow(
+                "fbgemm::batch_index_select_dim0_backward_cpu_impl", "")
+            .typed<decltype(backward_impl)>();
+    auto ret = backward_op.call(
+        grad_output,
+        indices,
+        indices_numels,
+        input_num_indices,
+        input_rows,
+        input_columns,
+        permute_output_dim_0_1,
+        saved_tensor);
+    return {
+        ret,
+        Variable(), // indices
+        Variable(), // input_num_indices
+        Variable(), // input_rows
+        Variable(), // input_columns
+        Variable() // permute_output_dim_0_1
+    };
+  }
+};
+
+class BatchIndexSelectDim0TensorCPUOp
+    : public torch::autograd::Function<BatchIndexSelectDim0TensorCPUOp> {
+ public:
+  static torch::autograd::variable_list forward_impl(
+      const Tensor& inputs,
+      const Tensor& indices,
+      const Tensor& input_num_indices,
+      const Tensor& input_rows,
+      const Tensor& input_columns,
+      const bool permute_output_dim_0_1) {
+    const int64_t num_inputs = input_num_indices.size(0);
+    TORCH_CHECK(
+        num_inputs == input_rows.size(0),
+        "[batch_index_select_dim0] input_rows must have the same length as "
+        "input_num_indices.");
+    TORCH_CHECK(
+        num_inputs == input_columns.size(0),
+        "[batch_index_select_dim0] input_columns must have the same length as "
+        "input_num_indices.");
+    TORCH_CHECK(
+        reinterpret_cast<uint64_t>(inputs.data_ptr()) % 16 == 0,
+        "Currently batch_index_select only supports 16-byte align input tensors");
+
+    auto saved_data_tensor = tensor_from_vec({inputs.numel()});
 
     // Early exit
     if (inputs.numel() == 0) {
-      return {at::empty({0}, inputs.options())};
+      return {at::empty({0}, inputs.options()), saved_data_tensor};
     }
 
-    // Compute section sizes for splitting tensors
-    std::vector<int64_t> input_numels;
-    std::vector<int64_t> indices_numels;
-    input_numels.reserve(num_inputs);
-    indices_numels.reserve(num_inputs);
-    for (auto i = 0; i < num_inputs; i++) {
-      input_numels.push_back(input_rows[i] * input_columns[i]);
-      indices_numels.push_back(input_num_indices[i]);
+    TORCH_CHECK(
+        torch::all(torch::gt(input_columns, 0)).item<bool>(),
+        "[batch_index_select_dim0] All input_columns must be the same.");
+    TORCH_CHECK(
+        torch::all(torch::gt(input_rows, 0)).item<bool>(),
+        "[batch_index_select_dim0] All input_rows must be the same.");
+
+    if (permute_output_dim_0_1) {
+      // All output rows must be the same
+      const auto item0 = input_num_indices[0].item<int64_t>();
+      TORCH_CHECK(item0 > 0);
+      TORCH_CHECK(
+          torch::all(torch::eq(input_num_indices, item0)).item<bool>(),
+          "[batch_index_select_dim0] All input_num_indices must be the same if "
+          "permute_output_dim_0_1 is true.");
+    } else {
+      TORCH_CHECK(
+          torch::all(torch::gt(input_num_indices, 0)).item<bool>(),
+          "[batch_index_select_dim0] All input_num_indices must be greater than zero.");
     }
 
-    ctx->saved_data["indices_numels"] = indices_numels;
+    const auto input_numels = at::mul(input_rows, input_columns);
 
     // Split tensors into vectors
-    const auto inputs_ = at::split_with_sizes(inputs, input_numels, 0);
-    const auto indices_ = at::split_with_sizes(indices, indices_numels, 0);
+    const auto inputs_ =
+        at::split_with_sizes(inputs, vecref_from_tensor(input_numels), 0);
+    const auto indices_ =
+        at::split_with_sizes(indices, vecref_from_tensor(input_num_indices), 0);
+
+    const auto input_rows_vec = vecref_from_tensor(input_rows);
+    const auto input_columns_vec = vecref_from_tensor(input_columns);
 
     std::vector<Tensor> outputs;
     outputs.reserve(num_inputs);
     for (auto i = 0; i < num_inputs; i++) {
-      const auto input = inputs_[i].view({input_rows[i], input_columns[i]});
+      const auto input =
+          inputs_[i].view({input_rows_vec[i], input_columns_vec[i]});
       const auto index = indices_[i];
       const auto output = at::index_select(input, 0, index);
       if (permute_output_dim_0_1) {
@@ -74,73 +374,76 @@ class BatchIndexSelectDim0CPUOp
 
     // permute_output_dim_0_1 = true shape: (batch_size, num_inputs, cols)
     // permute_output_dim_0_1 = false shape: (num_inputs, batch_size cols)
-    return {at::concat(outputs, permute_output_dim_0_1 ? 1 : 0).flatten()};
+
+    return {
+        at::concat(outputs, permute_output_dim_0_1 ? 1 : 0).flatten(),
+        saved_data_tensor};
+  }
+
+  static torch::autograd::variable_list forward(
+      torch::autograd::AutogradContext* ctx,
+      const Tensor& inputs,
+      const Tensor& indices,
+      const Tensor& input_num_indices,
+      const Tensor& input_rows,
+      const Tensor& input_columns,
+      const bool permute_output_dim_0_1) {
+    at::AutoDispatchBelowADInplaceOrView guard;
+    static auto forward_op_impl =
+        torch::Dispatcher::singleton()
+            .findSchemaOrThrow(
+                "fbgemm::batch_index_select_dim0_tensor_forward_cpu_impl", "")
+            .typed<decltype(forward_impl)>();
+
+    auto res = forward_op_impl.call(
+        inputs,
+        indices,
+        input_num_indices,
+        input_rows,
+        input_columns,
+        permute_output_dim_0_1);
+    ctx->saved_data["permute_output_dim_0_1"] = permute_output_dim_0_1;
+    ctx->save_for_backward(std::vector<Tensor>{
+        indices, input_num_indices, input_rows, input_columns, res[1]});
+    res.resize(1);
+    return res;
   }
 
   static torch::autograd::variable_list backward(
       torch::autograd::AutogradContext* ctx,
       torch::autograd::variable_list grad_outputs) {
     using torch::autograd::Variable;
-
     TORCH_CHECK_EQ(grad_outputs.size(), 1);
 
     const auto grad_output = grad_outputs[0];
-    const auto input_numel = ctx->saved_data["input_numel"].toInt();
-
-    // Early exit
-    if (input_numel == 0) {
-      return {
-          at::empty({0}, grad_output.options()),
-          Variable(), // indices
-          Variable(), // input_num_indices
-          Variable(), // input_rows
-          Variable(), // input_columns
-          Variable() // permute_output_dim_0_1
-      };
-    }
-
-    const auto saved = ctx->get_saved_variables();
-    auto indices = *std::begin(saved);
-
-    const auto input_num_indices =
-        ctx->saved_data["input_num_indices"].toIntVector();
-    const auto input_rows = ctx->saved_data["input_rows"].toIntVector();
-    const auto input_cols = ctx->saved_data["input_columns"].toIntVector();
     const auto permute_output_dim_0_1 =
         ctx->saved_data["permute_output_dim_0_1"].toBool();
-    const auto indices_numels = ctx->saved_data["indices_numels"].toIntVector();
+    const auto saved = ctx->get_saved_variables();
 
-    const int64_t num_inputs = input_num_indices.size();
+    auto savedItr = std::begin(saved);
 
-    std::vector<Tensor> grads;
-    if (permute_output_dim_0_1) {
-      grads = at::split_with_sizes(
-          grad_output.view({input_num_indices[0], -1}), input_cols, 1);
-    } else {
-      std::vector<int64_t> grad_numels;
-      grad_numels.reserve(num_inputs);
-      for (auto i = 0; i < num_inputs; i++) {
-        grad_numels.push_back(input_num_indices[i] * input_cols[i]);
-      }
-      grads = at::split_with_sizes(grad_output, grad_numels, 0);
-    }
+    auto indices = *savedItr++;
+    auto input_num_indices = *savedItr++;
+    auto input_rows = *savedItr++;
+    auto input_columns = *savedItr++;
+    auto saved_tensor = *savedItr++;
 
-    const auto indices_ = at::split_with_sizes(indices, indices_numels, 0);
-
-    std::vector<Tensor> grad_inputs;
-    grad_inputs.reserve(num_inputs);
-    for (auto i = 0; i < num_inputs; i++) {
-      const auto num_indices = input_num_indices[i];
-      const auto grad_input =
-          at::zeros({input_rows[i], input_cols[i]}, grad_output.options());
-      const auto grad =
-          permute_output_dim_0_1 ? grads[i] : grads[i].view({num_indices, -1});
-      grad_inputs.push_back(
-          at::index_add(grad_input, 0, indices_[i], grad).flatten());
-    }
-
+    static auto backward_op =
+        torch::Dispatcher::singleton()
+            .findSchemaOrThrow(
+                "fbgemm::batch_index_select_dim0_backward_cpu_impl", "")
+            .typed<decltype(BatchIndexSelectDim0CPUOp::backward_impl)>();
+    auto ret = backward_op.call(
+        grad_output,
+        indices,
+        input_num_indices,
+        input_num_indices,
+        input_rows,
+        input_columns,
+        permute_output_dim_0_1,
+        saved_tensor);
     return {
-        at::concat(grad_inputs, 0),
+        ret,
         Variable(), // indices
         Variable(), // input_num_indices
         Variable(), // input_rows
@@ -150,59 +453,32 @@ class BatchIndexSelectDim0CPUOp
   }
 };
 
-Tensor batch_index_select_dim0_cpu(
+Tensor batch_index_select_dim0_cpu_autograd(
     Tensor inputs,
     Tensor indices,
-    std::vector<int64_t> input_num_indices,
-    std::vector<int64_t> input_rows,
-    std::vector<int64_t> input_columns,
+    const c10::SymIntArrayRef input_num_indices,
+    const c10::SymIntArrayRef input_rows,
+    const c10::SymIntArrayRef input_columns,
     // Permute dim 0 and 1 of the output tensor
     const bool permute_output_dim_0_1) {
-  const int64_t num_inputs = input_num_indices.size();
-  TORCH_CHECK(
-      num_inputs == static_cast<int64_t>(input_rows.size()),
-      "[batch_index_select_dim0] input_rows must have the same length as "
-      "input_num_indices.");
-  TORCH_CHECK(
-      num_inputs == static_cast<int64_t>(input_columns.size()),
-      "[batch_index_select_dim0] input_columns must have the same length as "
-      "input_num_indices.");
-
-  TORCH_CHECK(
-      reinterpret_cast<uint64_t>(inputs.data_ptr()) % 16 == 0,
-      "Currently batch_index_select only supports 16-byte align input tensors");
-
-  const auto int_opts = torch::TensorOptions().dtype(torch::kInt64);
-  const auto num_cols =
-      torch::from_blob(input_columns.data(), {num_inputs}, int_opts);
-  const auto input_num_rows =
-      torch::from_blob(input_rows.data(), {num_inputs}, int_opts);
-  const auto output_num_rows =
-      torch::from_blob(input_num_indices.data(), {num_inputs}, int_opts);
-
-  if (num_inputs > 0) {
-    TORCH_CHECK(
-        torch::all(torch::gt(num_cols, 0)).item<bool>(),
-        "[batch_index_select_dim0] All input_columns must be the same.");
-    TORCH_CHECK(
-        torch::all(torch::gt(input_num_rows, 0)).item<bool>(),
-        "[batch_index_select_dim0] All input_rows must be the same.");
-    if (permute_output_dim_0_1) {
-      // All output rows must be the same
-      TORCH_CHECK(input_num_indices[0] > 0);
-      TORCH_CHECK(
-          torch::all(torch::eq(output_num_rows, input_num_indices[0]))
-              .item<bool>(),
-          "[batch_index_select_dim0] All input_num_indices must be the same if "
-          "permute_output_dim_0_1 is true.");
-    } else {
-      TORCH_CHECK(
-          torch::all(torch::gt(output_num_rows, 0)).item<bool>(),
-          "[batch_index_select_dim0] All input_num_indices must be greater than zero.");
-    }
-  }
-
   return BatchIndexSelectDim0CPUOp::apply(
+      inputs,
+      indices,
+      input_num_indices,
+      input_rows,
+      input_columns,
+      permute_output_dim_0_1)[0];
+}
+
+Tensor batch_index_select_dim0_tensor_cpu_autograd(
+    const Tensor& inputs,
+    const Tensor& indices,
+    const Tensor& input_num_indices,
+    const Tensor& input_rows,
+    const Tensor& input_columns,
+    // Permute dim 0 and 1 of the output tensor
+    const bool permute_output_dim_0_1) {
+  return BatchIndexSelectDim0TensorCPUOp::apply(
       inputs,
       indices,
       input_num_indices,
@@ -221,13 +497,15 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
       "    SymInt[] input_rows,"
       "    SymInt[] input_columns,"
       "    bool permute_output_dim_0_1=False) -> Tensor");
-  DISPATCH_TO_CPU("batch_index_select_dim0", batch_index_select_dim0_cpu);
+  DISPATCH_TO_CPU(
+      "batch_index_select_dim0", batch_index_select_dim0_cpu_autograd);
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.impl_abstract_pystub(
       "fbgemm_gpu.sparse_ops",
       "//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_py");
+
   m.def(
       "batch_index_select_dim0("
       "    Tensor inputs,"
@@ -235,6 +513,66 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "    SymInt[] input_num_indices,"
       "    SymInt[] input_rows,"
       "    SymInt[] input_columns,"
+      "    bool permute_output_dim_0_1=False) -> Tensor",
+      {PT2_COMPLIANT_TAG});
+
+  m.def(
+      "batch_index_select_dim0_forward_cpu_impl("
+      "Tensor inputs,"
+      "Tensor indices,"
+      "SymInt[] input_num_indices,"
+      "SymInt[] input_rows,"
+      "SymInt[] input_columns,"
+      "bool permute_output_dim_0_1) -> Tensor[]");
+
+  m.def(
+      "batch_index_select_dim0_backward_cpu_impl("
+      "Tensor grad_output,"
+      "Tensor indices,"
+      "Tensor indices_numels,"
+      "Tensor input_num_indices,"
+      "Tensor input_rows,"
+      "Tensor input_columns,"
+      "bool permute_output_dim_0_1,"
+      "Tensor saved_tensor) -> Tensor");
+
+  m.def(
+      "batch_index_select_dim0_tensor("
+      "    Tensor inputs,"
+      "    Tensor indices,"
+      "    Tensor input_num_indices,"
+      "    Tensor input_rows,"
+      "    Tensor input_columns,"
       "    bool permute_output_dim_0_1=False) -> Tensor");
-  DISPATCH_TO_CPU("batch_index_select_dim0", batch_index_select_dim0_cpu);
+
+  m.def(
+      "batch_index_select_dim0_tensor_forward_cpu_impl("
+      "Tensor inputs,"
+      "Tensor indices,"
+      "Tensor input_num_indices,"
+      "Tensor input_rows,"
+      "Tensor input_columns,"
+      "bool permute_output_dim_0_1) -> Tensor[]");
+
+  DISPATCH_TO_CPU(
+      "batch_index_select_dim0_forward_cpu_impl",
+      BatchIndexSelectDim0CPUOp::forward_impl);
+  DISPATCH_TO_CPU(
+      "batch_index_select_dim0_tensor_forward_cpu_impl",
+      BatchIndexSelectDim0TensorCPUOp::forward_impl);
+
+  DISPATCH_TO_CPU(
+      "batch_index_select_dim0_backward_cpu_impl",
+      BatchIndexSelectDim0CPUOp::backward_impl);
+
+  m.impl(
+      "batch_index_select_dim0",
+      torch::dispatch(
+          c10::DispatchKey::AutogradCPU,
+          TORCH_FN(batch_index_select_dim0_cpu_autograd)));
+  m.impl(
+      "batch_index_select_dim0_tensor",
+      torch::dispatch(
+          c10::DispatchKey::AutogradCPU,
+          TORCH_FN(batch_index_select_dim0_tensor_cpu_autograd)));
 }

--- a/fbgemm_gpu/codegen/training/index_select/batch_index_select_dim0_host.cpp
+++ b/fbgemm_gpu/codegen/training/index_select/batch_index_select_dim0_host.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <ATen/ATen.h>
+#include <ATen/MemoryOverlap.h>
 #include <ATen/TypeDefault.h>
 #include <ATen/core/op_registration/op_registration.h>
 #include <torch/script.h>
@@ -51,55 +52,267 @@ Tensor batch_index_select_dim0_codegen_backward_cuda(
 class BatchIndexSelectDim0GPUOp
     : public torch::autograd::Function<BatchIndexSelectDim0GPUOp> {
  public:
-  static torch::autograd::variable_list forward(
-      torch::autograd::AutogradContext* ctx,
-      const int64_t output_dtype,
-      const Tensor& dev_weights,
-      const Tensor& weights_offsets,
-      const Tensor& hash_size_cumsum,
-      const int64_t total_hash_size_bits,
-      const Tensor& indices,
-      const Tensor& D_offsets,
-      const c10::SymInt max_D,
-      const Tensor& output_offsets,
-      const Tensor& total_L_offsets,
-      const int64_t output_size,
-      const int64_t fixed_L_per_warp,
-      const int64_t num_warps_per_feature,
+  static torch::autograd::variable_list forward_impl(
+      Tensor inputs,
+      Tensor indices,
+      c10::SymIntArrayRef _input_num_indices,
+      c10::SymIntArrayRef _input_rows,
+      c10::SymIntArrayRef _input_columns,
+      // Permute dim 0 and 1 of the output tensor
       const bool permute_output_dim_0_1) {
-    ctx->save_for_backward(
-        {dev_weights,
-         weights_offsets,
-         hash_size_cumsum,
-         indices,
-         D_offsets,
-         output_offsets,
-         total_L_offsets});
+    auto to_vec_int64 =
+        [](const c10::SymIntArrayRef& sym_vec) -> std::vector<int64_t> {
+      std::vector<int64_t> vec;
+      std::transform(
+          sym_vec.begin(),
+          sym_vec.end(),
+          std::back_inserter(vec),
+          [](const auto& symint) {
+            return symint.guard_int(__FILE__, __LINE__);
+          });
+      return vec;
+    };
+    auto input_num_indices = to_vec_int64(_input_num_indices);
+    auto input_rows = to_vec_int64(_input_rows);
+    auto input_columns = to_vec_int64(_input_columns);
+    TORCH_CHECK(input_num_indices.size() == _input_num_indices.size());
 
-    ctx->saved_data["max_D"] = max_D;
-    ctx->saved_data["total_hash_size_bits"] = total_hash_size_bits;
-    ctx->saved_data["fixed_L_per_warp"] = fixed_L_per_warp;
-    ctx->saved_data["num_warps_per_feature"] = num_warps_per_feature;
-    ctx->saved_data["permute_output_dim_0_1"] = permute_output_dim_0_1;
+    // From the empirical study, this value provides the best perf
+    constexpr int64_t ROWS_PER_WARP = 1;
+    const int64_t num_inputs = input_num_indices.size();
 
-    // Early exit
-    if (dev_weights.numel() == 0) {
-      return {at::empty({0}, dev_weights.options())};
+    TORCH_CHECK(
+        num_inputs == static_cast<int64_t>(input_rows.size()),
+        "[batch_index_select_dim0] input_rows must have the same length as "
+        "input_num_indices.");
+    TORCH_CHECK(
+        num_inputs == static_cast<int64_t>(input_columns.size()),
+        "[batch_index_select_dim0] input_columns must have the same length as "
+        "input_num_indices.");
+    TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(inputs, indices);
+
+    TORCH_CHECK(
+        reinterpret_cast<uint64_t>(inputs.data_ptr()) % 16 == 0,
+        "Currently batch_index_select only supports 16-byte align input tensors");
+
+    const auto int_opts = torch::TensorOptions().dtype(torch::kInt64);
+    const auto num_cols =
+        torch::from_blob(input_columns.data(), {num_inputs}, int_opts);
+    const auto max_col = num_inputs > 0 ? num_cols.max().item<int64_t>() : 0;
+    const auto input_num_rows =
+        torch::from_blob(input_rows.data(), {num_inputs}, int_opts);
+    const auto output_num_rows =
+        torch::from_blob(input_num_indices.data(), {num_inputs}, int_opts);
+
+    if (num_inputs > 0) {
+      TORCH_CHECK(
+          torch::all(torch::gt(num_cols, 0)).item<bool>(),
+          "[batch_index_select_dim0] All input_columns must be the same.");
+      TORCH_CHECK(
+          torch::all(torch::gt(input_num_rows, 0)).item<bool>(),
+          "[batch_index_select_dim0] All input_rows must be the same.");
+      if (permute_output_dim_0_1) {
+        // All output rows must be the same
+        TORCH_CHECK(input_num_indices[0] > 0);
+        TORCH_CHECK(
+            torch::all(torch::eq(output_num_rows, input_num_indices[0]))
+                .item<bool>(),
+            "[batch_index_select_dim0] All input_num_indices must be the same if "
+            "permute_output_dim_0_1 is true.");
+      } else {
+        TORCH_CHECK(
+            torch::all(torch::gt(output_num_rows, 0)).item<bool>(),
+            "[batch_index_select_dim0] All input_num_indices must be greater than zero.");
+      }
     }
 
-    return {batch_index_select_dim0_codegen_forward_cuda(
+    const auto max_output_num_rows =
+        num_inputs > 0 ? output_num_rows.max().item<int64_t>() : 0;
+
+    const auto input_numels = input_num_rows * num_cols;
+    const auto output_numels =
+        permute_output_dim_0_1 ? Tensor() : (output_num_rows * num_cols);
+
+    // Takes ~1.2 ms for num_inputs = 1024 on CPU
+    auto D_offsets = fbgemm_gpu::asynchronous_complete_cumsum_cpu(num_cols).to(
+        torch::kInt32);
+    auto input_offsets =
+        fbgemm_gpu::asynchronous_complete_cumsum_cpu(input_numels);
+    auto input_row_offsets =
+        fbgemm_gpu::asynchronous_complete_cumsum_cpu(input_num_rows);
+    auto total_L_offsets =
+        fbgemm_gpu::asynchronous_complete_cumsum_cpu(output_num_rows);
+    int64_t total_hash_size_bits =
+        std::log2(static_cast<float>(input_row_offsets[-1].item<int64_t>())) +
+        1;
+    input_offsets =
+        torch::narrow(input_offsets, 0, 0, input_offsets.numel() - 1);
+    const int64_t num_warps_per_input =
+        (max_output_num_rows + ROWS_PER_WARP - 1) / ROWS_PER_WARP;
+
+    // Transfer helper tensors to GPU
+    const auto device = inputs.device();
+    constexpr bool non_blocking = true;
+
+    int64_t output_size;
+    Tensor output_offsets;
+    if (permute_output_dim_0_1) {
+      // output_offsets is not required because the output tensor is not jagged
+      output_offsets = at::empty({0}, inputs.options().dtype(at::kLong));
+      output_size = num_inputs > 0
+          ? (input_num_indices[0] * D_offsets[-1].item<int64_t>())
+          : 0;
+    } else {
+      output_offsets =
+          fbgemm_gpu::asynchronous_complete_cumsum_cpu(output_numels);
+      output_size = output_offsets[-1].item<int64_t>();
+      output_offsets = output_offsets.to(device, non_blocking);
+    }
+
+    D_offsets = D_offsets.to(device, non_blocking);
+    input_offsets = input_offsets.to(device, non_blocking);
+    input_row_offsets = input_row_offsets.to(device, non_blocking);
+    total_L_offsets = total_L_offsets.to(device, non_blocking);
+
+    const auto sparse_type = fbgemm_gpu::getSparseType(inputs.scalar_type());
+    TORCH_CHECK(
+        sparse_type == SparseType::FP32 || sparse_type == SparseType::FP16,
+        "batch_index_select_dim0 supports only either float or half")
+
+    const auto output_dtype =
+        static_cast<int64_t>(fbgemm_gpu::getSparseType(inputs.scalar_type()));
+
+    const auto max_D = max_col;
+    const auto fixed_L_per_warp = ROWS_PER_WARP;
+
+    auto output = inputs.numel() > 0
+        ? batch_index_select_dim0_codegen_forward_cuda(
+              inputs, // dev_weights
+              input_offsets, // weights_offsets
+              D_offsets,
+              max_D,
+              indices,
+              output_dtype,
+              output_offsets,
+              total_L_offsets,
+              output_size,
+              fixed_L_per_warp,
+              num_warps_per_input, // num_warps_per_feature
+              permute_output_dim_0_1)
+        : at::empty({0}, inputs.options());
+
+    int64_t saved_data[] = {
+        max_D,
+        total_hash_size_bits,
+        fixed_L_per_warp,
+        num_warps_per_input,
+    };
+
+    auto saved_data_tensor = at::empty(
+        {sizeof(saved_data) / sizeof(int64_t)},
+        at::TensorOptions().dtype(at::kLong));
+    TORCH_CHECK(saved_data_tensor.is_contiguous());
+    memcpy(
+        saved_data_tensor.data_ptr<int64_t>(), saved_data, sizeof(saved_data));
+
+    return {
+        output, // 0:op_output
+        input_offsets, // 1:weights_offsets
+        input_row_offsets, // 2:hash_size_cumsum,
+        D_offsets, // 3:D_offsets,
+        output_offsets, // 4:output_offsets,
+        total_L_offsets, // 5:total_L_offsets
+        saved_data_tensor, // 6:saved_data_tensor
+    };
+  }
+
+  // make scheme the same as main op
+  static torch::autograd::variable_list forward(
+      torch::autograd::AutogradContext* ctx,
+      Tensor inputs,
+      Tensor indices,
+      c10::SymIntArrayRef input_num_indices,
+      c10::SymIntArrayRef input_rows,
+      c10::SymIntArrayRef input_columns,
+      // Permute dim 0 and 1 of the output tensor
+      const bool permute_output_dim_0_1) {
+    at::AutoDispatchBelowADInplaceOrView guard;
+    static auto forward_op_impl =
+        torch::Dispatcher::singleton()
+            .findSchemaOrThrow(
+                "fbgemm::batch_index_select_dim0_forward_cuda_impl", "")
+            .typed<decltype(forward_impl)>();
+
+    auto res = forward_op_impl.call(
+        inputs,
+        indices,
+        input_num_indices,
+        input_rows,
+        input_columns,
+        permute_output_dim_0_1);
+
+    // 0:op_output
+    // 1:weights_offsets,
+    // 2:hash_size_cumsum,
+    // 3:D_offsets,
+    // 4:output_offsets,
+    // 5:total_L_offsets
+    // 6:saved_data_tensor = [max_D, total_hash_size_bits, fixed_L_per_warp,
+    // num_warps_per_input]
+
+    ctx->saved_data["permute_output_dim_0_1"] = permute_output_dim_0_1;
+
+    ctx->save_for_backward(std::vector<Tensor>{
+        inputs, indices, res[1], res[2], res[3], res[4], res[5], res[6]});
+
+    res.resize(1);
+    return res;
+  }
+
+  static Tensor backward_impl(
+      const Tensor& grad_output,
+      const Tensor& dev_weights,
+      const Tensor& weights_offsets,
+      const Tensor& D_offsets,
+      const Tensor& hash_size_cumsum,
+      const Tensor& indices,
+      const int64_t max_segment_length_per_warp,
+      const Tensor& grad_offsets,
+      const Tensor& total_L_offsets,
+      const bool permute_output_dim_0_1,
+      const Tensor& saved_tensor) {
+    if (dev_weights.numel() == 0) {
+      return at::empty({0}, dev_weights.options());
+    }
+
+    auto _grad_output = grad_output;
+    // FIXME: to support aligned memory access in Vec4T load/store function
+    // 16 for FP32 and 8 for FP16
+    if (reinterpret_cast<uint64_t>(grad_output.data_ptr()) % 16 != 0 ||
+        at::has_internal_overlap(grad_output) != at::MemOverlap::No) {
+      _grad_output = at::empty_like(grad_output).copy_(grad_output);
+    }
+
+    const auto max_D = saved_tensor[0].item<int64_t>();
+    const auto total_hash_size_bits = saved_tensor[1].item<int64_t>();
+    const auto fixed_L_per_warp = saved_tensor[2].item<int64_t>();
+    const auto num_warps_per_feature = saved_tensor[3].item<int64_t>();
+
+    return batch_index_select_dim0_codegen_backward_cuda(
+        _grad_output,
         dev_weights,
         weights_offsets,
         D_offsets,
         max_D,
+        hash_size_cumsum,
+        total_hash_size_bits,
         indices,
-        output_dtype,
-        output_offsets,
+        max_segment_length_per_warp,
+        grad_offsets,
         total_L_offsets,
-        output_size,
         fixed_L_per_warp,
         num_warps_per_feature,
-        permute_output_dim_0_1)};
+        permute_output_dim_0_1);
   }
 
   static torch::autograd::variable_list backward(
@@ -107,71 +320,54 @@ class BatchIndexSelectDim0GPUOp
       torch::autograd::variable_list grad_outputs) {
     const auto saved = ctx->get_saved_variables();
     auto savedItr = std::begin(saved);
-    auto dev_weights = *savedItr++;
+    auto dev_weights = *savedItr++; // inputs
+    auto indices = *savedItr++; // indices
+
     auto weights_offsets = *savedItr++;
     auto hash_size_cumsum = *savedItr++;
-    auto indices = *savedItr++;
     auto D_offsets = *savedItr++;
     auto grad_offsets = *savedItr++;
     auto total_L_offsets = *savedItr++;
 
-    const auto max_D = ctx->saved_data["max_D"].toSymInt();
-    const auto total_hash_size_bits =
-        ctx->saved_data["total_hash_size_bits"].toInt();
-    const auto fixed_L_per_warp = ctx->saved_data["fixed_L_per_warp"].toInt();
-    const auto num_warps_per_feature =
-        ctx->saved_data["num_warps_per_feature"].toInt();
+    auto saved_tensor = *savedItr++;
+
     const auto permute_output_dim_0_1 =
         ctx->saved_data["permute_output_dim_0_1"].toBool();
 
     using torch::autograd::Variable;
 
     Tensor grad_dev_weights;
-    if (dev_weights.numel() == 0) {
-      grad_dev_weights = at::empty({0}, dev_weights.options());
-    } else {
-      TORCH_CHECK_EQ(grad_outputs.size(), 1);
+    TORCH_CHECK_EQ(grad_outputs.size(), 1);
 
-      constexpr int32_t max_segment_length_per_warp = 32;
+    constexpr int32_t max_segment_length_per_warp = 32;
 
-      auto grad_output = grad_outputs[0];
-      // FIXME: to support aligned memory access in Vec4T load/store function
-      // 16 for FP32 and 8 for FP16
-      if (reinterpret_cast<uint64_t>(grad_output.data_ptr()) % 16 != 0) {
-        grad_output = at::empty_like(grad_output).copy_(grad_output);
-      }
+    auto grad_output = grad_outputs[0];
 
-      grad_dev_weights = batch_index_select_dim0_codegen_backward_cuda(
-          grad_output,
-          dev_weights,
-          weights_offsets,
-          D_offsets,
-          max_D,
-          hash_size_cumsum,
-          total_hash_size_bits,
-          indices,
-          max_segment_length_per_warp,
-          grad_offsets,
-          total_L_offsets,
-          fixed_L_per_warp,
-          num_warps_per_feature,
-          permute_output_dim_0_1);
-    }
+    static auto backward_op =
+        torch::Dispatcher::singleton()
+            .findSchemaOrThrow(
+                "fbgemm::batch_index_select_dim0_backward_cuda_impl", "")
+            .typed<decltype(backward_impl)>();
+
+    auto res = backward_op.call(
+        grad_output,
+        dev_weights,
+        weights_offsets,
+        D_offsets,
+        hash_size_cumsum,
+        indices,
+        max_segment_length_per_warp,
+        grad_offsets,
+        total_L_offsets,
+        permute_output_dim_0_1,
+        saved_tensor);
 
     return {
-        Variable(), // output_dtype
-        grad_dev_weights, // grad_dev_weights
-        Variable(), // weights_offsets
-        Variable(), // hash_size_cumsum
-        Variable(), // total_hash_size_bits
+        res, // inputs
         Variable(), // indices
-        Variable(), // D_offsets
-        Variable(), // max_D
-        Variable(), // output_offsets
-        Variable(), // total_L_offsets
-        Variable(), // output_size
-        Variable(), // fixed_L_per_warp
-        Variable(), // num_warps_per_feature
+        Variable(), // input_num_indices
+        Variable(), // input_rows
+        Variable(), // input_columns
         Variable(), // permute_output_dim_0_1
     };
   }
@@ -180,126 +376,333 @@ class BatchIndexSelectDim0GPUOp
 Tensor batch_index_select_dim0_gpu(
     Tensor inputs,
     Tensor indices,
-    std::vector<int64_t> input_num_indices,
-    std::vector<int64_t> input_rows,
-    std::vector<int64_t> input_columns,
+    c10::SymIntArrayRef input_num_indices,
+    c10::SymIntArrayRef input_rows,
+    c10::SymIntArrayRef input_columns,
     // Permute dim 0 and 1 of the output tensor
     const bool permute_output_dim_0_1) {
-  // From the empirical study, this value provides the best perf
-  constexpr int64_t ROWS_PER_WARP = 1;
-  const int64_t num_inputs = input_num_indices.size();
-  TORCH_CHECK(
-      num_inputs == static_cast<int64_t>(input_rows.size()),
-      "[batch_index_select_dim0] input_rows must have the same length as "
-      "input_num_indices.");
-  TORCH_CHECK(
-      num_inputs == static_cast<int64_t>(input_columns.size()),
-      "[batch_index_select_dim0] input_columns must have the same length as "
-      "input_num_indices.");
-  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(inputs, indices);
-
-  TORCH_CHECK(
-      reinterpret_cast<uint64_t>(inputs.data_ptr()) % 16 == 0,
-      "Currently batch_index_select only supports 16-byte align input tensors");
-
-  const auto int_opts = torch::TensorOptions().dtype(torch::kInt64);
-  const auto num_cols =
-      torch::from_blob(input_columns.data(), {num_inputs}, int_opts);
-  const auto max_col = num_inputs > 0 ? num_cols.max().item<int64_t>() : 0;
-  const auto input_num_rows =
-      torch::from_blob(input_rows.data(), {num_inputs}, int_opts);
-  const auto output_num_rows =
-      torch::from_blob(input_num_indices.data(), {num_inputs}, int_opts);
-
-  if (num_inputs > 0) {
-    TORCH_CHECK(
-        torch::all(torch::gt(num_cols, 0)).item<bool>(),
-        "[batch_index_select_dim0] All input_columns must be the same.");
-    TORCH_CHECK(
-        torch::all(torch::gt(input_num_rows, 0)).item<bool>(),
-        "[batch_index_select_dim0] All input_rows must be the same.");
-    if (permute_output_dim_0_1) {
-      // All output rows must be the same
-      TORCH_CHECK(input_num_indices[0] > 0);
-      TORCH_CHECK(
-          torch::all(torch::eq(output_num_rows, input_num_indices[0]))
-              .item<bool>(),
-          "[batch_index_select_dim0] All input_num_indices must be the same if "
-          "permute_output_dim_0_1 is true.");
-    } else {
-      TORCH_CHECK(
-          torch::all(torch::gt(output_num_rows, 0)).item<bool>(),
-          "[batch_index_select_dim0] All input_num_indices must be greater than zero.");
-    }
-  }
-
-  const auto max_output_num_rows =
-      num_inputs > 0 ? output_num_rows.max().item<int64_t>() : 0;
-
-  const auto input_numels = input_num_rows * num_cols;
-  const auto output_numels =
-      permute_output_dim_0_1 ? Tensor() : (output_num_rows * num_cols);
-
-  // Takes ~1.2 ms for num_inputs = 1024 on CPU
-  auto D_offsets =
-      fbgemm_gpu::asynchronous_complete_cumsum_cpu(num_cols).to(torch::kInt32);
-  auto input_offsets =
-      fbgemm_gpu::asynchronous_complete_cumsum_cpu(input_numels);
-  auto input_row_offsets =
-      fbgemm_gpu::asynchronous_complete_cumsum_cpu(input_num_rows);
-  auto total_L_offsets =
-      fbgemm_gpu::asynchronous_complete_cumsum_cpu(output_num_rows);
-  int64_t total_hash_size_bits =
-      std::log2(static_cast<float>(input_row_offsets[-1].item<int64_t>())) + 1;
-  input_offsets = torch::narrow(input_offsets, 0, 0, input_offsets.numel() - 1);
-
-  const int64_t num_warps_per_input =
-      (max_output_num_rows + ROWS_PER_WARP - 1) / ROWS_PER_WARP;
-
-  // Transfer helper tensors to GPU
-  const auto device = inputs.device();
-  constexpr bool non_blocking = true;
-
-  int64_t output_size;
-  Tensor output_offsets;
-  if (permute_output_dim_0_1) {
-    // output_offsets is not required because the output tensor is not jagged
-    output_offsets = at::empty({0}, inputs.options().dtype(at::kLong));
-    output_size = num_inputs > 0
-        ? (input_num_indices[0] * D_offsets[-1].item<int64_t>())
-        : 0;
-  } else {
-    output_offsets =
-        fbgemm_gpu::asynchronous_complete_cumsum_cpu(output_numels);
-    output_size = output_offsets[-1].item<int64_t>();
-    output_offsets = output_offsets.to(device, non_blocking);
-  }
-
-  D_offsets = D_offsets.to(device, non_blocking);
-  input_offsets = input_offsets.to(device, non_blocking);
-  input_row_offsets = input_row_offsets.to(device, non_blocking);
-  total_L_offsets = total_L_offsets.to(device, non_blocking);
-
-  const auto sparse_type = fbgemm_gpu::getSparseType(inputs.scalar_type());
-  TORCH_CHECK(
-      sparse_type == SparseType::FP32 || sparse_type == SparseType::FP16,
-      "batch_index_select_dim0 supports only either float or half")
-
-  // Call TBE
   return BatchIndexSelectDim0GPUOp::apply(
-      static_cast<int64_t>(fbgemm_gpu::getSparseType(inputs.scalar_type())),
       inputs,
-      input_offsets,
-      input_row_offsets,
-      total_hash_size_bits,
       indices,
-      D_offsets,
-      max_col,
-      output_offsets,
-      total_L_offsets,
-      output_size,
-      ROWS_PER_WARP, // fixed_L_per_warp
-      num_warps_per_input,
+      input_num_indices,
+      input_rows,
+      input_columns,
+      permute_output_dim_0_1)[0];
+}
+
+class BatchIndexSelectDim0TensorGPUOp
+    : public torch::autograd::Function<BatchIndexSelectDim0TensorGPUOp> {
+ public:
+  static torch::autograd::variable_list forward_impl(
+      const Tensor& inputs,
+      const Tensor& indices,
+      const Tensor& input_num_indices,
+      const Tensor& input_rows,
+      const Tensor& input_columns,
+      // Permute dim 0 and 1 of the output tensor
+      const bool permute_output_dim_0_1) {
+    // From the empirical study, this value provides the best perf
+    constexpr int64_t ROWS_PER_WARP = 1;
+    const int64_t num_inputs = input_num_indices.size(0);
+
+    TORCH_CHECK(
+        num_inputs == input_rows.size(0),
+        "[batch_index_select_dim0] input_rows must have the same length as "
+        "input_num_indices.");
+    TORCH_CHECK(
+        num_inputs == input_columns.size(0),
+        "[batch_index_select_dim0] input_columns must have the same length as "
+        "input_num_indices.");
+    TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(inputs, indices);
+
+    TORCH_CHECK(
+        reinterpret_cast<uint64_t>(inputs.data_ptr()) % 16 == 0,
+        "Currently batch_index_select only supports 16-byte align input tensors");
+
+    const auto num_cols = input_columns;
+    const auto max_col =
+        num_inputs > 0 ? input_columns.max().item<int64_t>() : 0;
+    const auto input_num_rows = input_rows;
+    const auto output_num_rows = input_num_indices;
+
+    if (num_inputs > 0) {
+      TORCH_CHECK(
+          torch::all(torch::gt(input_columns, 0)).item<bool>(),
+          "[batch_index_select_dim0] All input_columns must be the same.");
+      TORCH_CHECK(
+          torch::all(torch::gt(input_num_rows, 0)).item<bool>(),
+          "[batch_index_select_dim0] All input_rows must be the same.");
+      if (permute_output_dim_0_1) {
+        // All output rows must be the same
+        TORCH_CHECK(input_num_indices[0].item<int64_t>() > 0);
+        TORCH_CHECK(
+            torch::all(torch::eq(output_num_rows, input_num_indices[0]))
+                .item<bool>(),
+            "[batch_index_select_dim0] All input_num_indices must be the same if "
+            "permute_output_dim_0_1 is true.");
+      } else {
+        TORCH_CHECK(
+            torch::all(torch::gt(output_num_rows, 0)).item<bool>(),
+            "[batch_index_select_dim0] All input_num_indices must be greater than zero.");
+      }
+    }
+
+    const auto max_output_num_rows =
+        num_inputs > 0 ? output_num_rows.max().item<int64_t>() : 0;
+
+    const auto input_numels = input_num_rows * num_cols;
+    const auto output_numels =
+        permute_output_dim_0_1 ? Tensor() : (output_num_rows * num_cols);
+
+    // Takes ~1.2 ms for num_inputs = 1024 on CPU
+    auto D_offsets = fbgemm_gpu::asynchronous_complete_cumsum_cpu(num_cols).to(
+        torch::kInt32);
+    auto input_offsets =
+        fbgemm_gpu::asynchronous_complete_cumsum_cpu(input_numels);
+    auto input_row_offsets =
+        fbgemm_gpu::asynchronous_complete_cumsum_cpu(input_num_rows);
+    auto total_L_offsets =
+        fbgemm_gpu::asynchronous_complete_cumsum_cpu(output_num_rows);
+    int64_t total_hash_size_bits =
+        std::log2(static_cast<float>(input_row_offsets[-1].item<int64_t>())) +
+        1;
+    input_offsets =
+        torch::narrow(input_offsets, 0, 0, input_offsets.numel() - 1);
+    const int64_t num_warps_per_input =
+        (max_output_num_rows + ROWS_PER_WARP - 1) / ROWS_PER_WARP;
+
+    // Transfer helper tensors to GPU
+    const auto device = inputs.device();
+    constexpr bool non_blocking = true;
+
+    int64_t output_size;
+    Tensor output_offsets;
+    if (permute_output_dim_0_1) {
+      // output_offsets is not required because the output tensor is not jagged
+      output_offsets = at::empty({0}, inputs.options().dtype(at::kLong));
+      output_size = num_inputs > 0 ? (input_num_indices[0].item<int64_t>() *
+                                      D_offsets[-1].item<int64_t>())
+                                   : 0;
+    } else {
+      output_offsets =
+          fbgemm_gpu::asynchronous_complete_cumsum_cpu(output_numels);
+      output_size = output_offsets[-1].item<int64_t>();
+      output_offsets = output_offsets.to(device, non_blocking);
+    }
+
+    D_offsets = D_offsets.to(device, non_blocking);
+    input_offsets = input_offsets.to(device, non_blocking);
+    input_row_offsets = input_row_offsets.to(device, non_blocking);
+    total_L_offsets = total_L_offsets.to(device, non_blocking);
+
+    const auto sparse_type = fbgemm_gpu::getSparseType(inputs.scalar_type());
+    TORCH_CHECK(
+        sparse_type == SparseType::FP32 || sparse_type == SparseType::FP16,
+        "batch_index_select_dim0 supports only either float or half")
+
+    const auto output_dtype =
+        static_cast<int64_t>(fbgemm_gpu::getSparseType(inputs.scalar_type()));
+    const auto max_D = max_col;
+    const auto fixed_L_per_warp = ROWS_PER_WARP;
+
+    auto output = inputs.numel() > 0
+        ? batch_index_select_dim0_codegen_forward_cuda(
+              inputs, // dev_weights
+              input_offsets, // weights_offsets
+              D_offsets,
+              max_D,
+              indices,
+              output_dtype,
+              output_offsets,
+              total_L_offsets,
+              output_size,
+              fixed_L_per_warp,
+              num_warps_per_input, // num_warps_per_feature
+              permute_output_dim_0_1)
+        : at::empty({0}, inputs.options());
+
+    int64_t saved_data[] = {
+        max_D,
+        total_hash_size_bits,
+        fixed_L_per_warp,
+        num_warps_per_input,
+    };
+
+    auto saved_data_tensor = at::empty(
+        {sizeof(saved_data) / sizeof(int64_t)},
+        at::TensorOptions().dtype(at::kLong));
+    TORCH_CHECK(saved_data_tensor.is_contiguous());
+    memcpy(
+        saved_data_tensor.data_ptr<int64_t>(), saved_data, sizeof(saved_data));
+
+    return {
+        output, // 0:op_output
+        input_offsets, // 1:weights_offsets
+        input_row_offsets, // 2:hash_size_cumsum,
+        D_offsets, // 3:D_offsets,
+        output_offsets, // 4:output_offsets,
+        total_L_offsets, // 5:total_L_offsets
+        saved_data_tensor, // 6:saved_data_tensor
+    };
+  }
+
+  // make scheme the same as main op
+  static torch::autograd::variable_list forward(
+      torch::autograd::AutogradContext* ctx,
+      const Tensor& inputs,
+      const Tensor& indices,
+      const Tensor& input_num_indices,
+      const Tensor& input_rows,
+      const Tensor& input_columns,
+      // Permute dim 0 and 1 of the output tensor
+      const bool permute_output_dim_0_1) {
+    at::AutoDispatchBelowADInplaceOrView guard;
+    static auto forward_op_impl =
+        torch::Dispatcher::singleton()
+            .findSchemaOrThrow(
+                "fbgemm::batch_index_select_dim0_tensor_forward_cuda_impl", "")
+            .typed<decltype(forward_impl)>();
+
+    auto res = forward_op_impl.call(
+        inputs,
+        indices,
+        input_num_indices,
+        input_rows,
+        input_columns,
+        permute_output_dim_0_1);
+
+    // 0:op_output
+    // 1:weights_offsets,
+    // 2:hash_size_cumsum,
+    // 3:D_offsets,
+    // 4:output_offsets,
+    // 5:total_L_offsets
+    // 6:saved_data_tensor = [max_D, total_hash_size_bits, fixed_L_per_warp,
+    // num_warps_per_input]
+
+    ctx->saved_data["permute_output_dim_0_1"] = permute_output_dim_0_1;
+
+    ctx->save_for_backward(std::vector<Tensor>{
+        inputs, indices, res[1], res[2], res[3], res[4], res[5], res[6]});
+
+    // res.resize(1);
+    return res;
+  }
+
+  static Tensor backward_impl(
+      const Tensor& grad_output,
+      const Tensor& dev_weights,
+      const Tensor& weights_offsets,
+      const Tensor& D_offsets,
+      const Tensor& hash_size_cumsum,
+      const Tensor& indices,
+      const int64_t max_segment_length_per_warp,
+      const Tensor& grad_offsets,
+      const Tensor& total_L_offsets,
+      const bool permute_output_dim_0_1,
+      const Tensor& saved_tensor) {
+    if (dev_weights.numel() == 0) {
+      return at::empty({0}, dev_weights.options());
+    }
+
+    auto _grad_output = grad_output;
+    // FIXME: to support aligned memory access in Vec4T load/store function
+    // 16 for FP32 and 8 for FP16
+    if (reinterpret_cast<uint64_t>(grad_output.data_ptr()) % 16 != 0 ||
+        at::has_internal_overlap(grad_output) != at::MemOverlap::No) {
+      _grad_output = at::empty_like(grad_output).copy_(grad_output);
+    }
+
+    const auto max_D = saved_tensor[0].item<int64_t>();
+    const auto total_hash_size_bits = saved_tensor[1].item<int64_t>();
+    const auto fixed_L_per_warp = saved_tensor[2].item<int64_t>();
+    const auto num_warps_per_feature = saved_tensor[3].item<int64_t>();
+
+    return batch_index_select_dim0_codegen_backward_cuda(
+        _grad_output,
+        dev_weights,
+        weights_offsets,
+        D_offsets,
+        max_D,
+        hash_size_cumsum,
+        total_hash_size_bits,
+        indices,
+        max_segment_length_per_warp,
+        grad_offsets,
+        total_L_offsets,
+        fixed_L_per_warp,
+        num_warps_per_feature,
+        permute_output_dim_0_1);
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext* ctx,
+      torch::autograd::variable_list grad_outputs) {
+    const auto saved = ctx->get_saved_variables();
+    auto savedItr = std::begin(saved);
+    auto dev_weights = *savedItr++; // inputs
+    auto indices = *savedItr++; // indices
+
+    auto weights_offsets = *savedItr++;
+    auto hash_size_cumsum = *savedItr++;
+    auto D_offsets = *savedItr++;
+    auto grad_offsets = *savedItr++;
+    auto total_L_offsets = *savedItr++;
+
+    auto saved_tensor = *savedItr++;
+
+    const auto permute_output_dim_0_1 =
+        ctx->saved_data["permute_output_dim_0_1"].toBool();
+
+    constexpr int32_t max_segment_length_per_warp = 32;
+
+    auto grad_output = grad_outputs[0];
+
+    static auto backward_op =
+        torch::Dispatcher::singleton()
+            .findSchemaOrThrow(
+                "fbgemm::batch_index_select_dim0_tensor_backward_cuda_impl", "")
+            .typed<decltype(backward_impl)>();
+
+    auto res = backward_op.call(
+        grad_output,
+        dev_weights,
+        weights_offsets,
+        D_offsets,
+        hash_size_cumsum,
+        indices,
+        max_segment_length_per_warp,
+        grad_offsets,
+        total_L_offsets,
+        permute_output_dim_0_1,
+        saved_tensor);
+
+    using torch::autograd::Variable;
+    return {
+        std::move(res), // inputs
+        Variable(), // indices
+        Variable(), // input_num_indices
+        Variable(), // input_rows
+        Variable(), // input_columns
+        Variable(), // permute_output_dim_0_1
+    };
+  }
+};
+
+Tensor batch_index_select_dim0_tensor_gpu(
+    const Tensor& inputs,
+    const Tensor& indices,
+    const Tensor& input_num_indices,
+    const Tensor& input_rows,
+    const Tensor& input_columns,
+    // Permute dim 0 and 1 of the output tensor
+    const bool permute_output_dim_0_1) {
+  return BatchIndexSelectDim0TensorGPUOp::apply(
+      inputs,
+      indices,
+      input_num_indices,
+      input_rows,
+      input_columns,
       permute_output_dim_0_1)[0];
 }
 
@@ -309,5 +712,66 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
-  DISPATCH_TO_CUDA("batch_index_select_dim0", batch_index_select_dim0_gpu);
+  m.set_python_module("fbgemm_gpu.sparse_ops");
+  m.def(
+      "batch_index_select_dim0_forward_cuda_impl("
+      "Tensor inputs,"
+      "Tensor indices,"
+      "SymInt[] input_num_indices,"
+      "SymInt[] input_rows,"
+      "SymInt[] input_columns,"
+      "bool permute_output_dim_0_1) -> Tensor[]");
+  m.def(
+      "batch_index_select_dim0_backward_cuda_impl("
+      "Tensor grad_output,"
+      "Tensor dev_weights,"
+      "Tensor weights_offsets,"
+      "Tensor D_offsets,"
+      "Tensor hash_size_cumsum,"
+      "Tensor indices,"
+      "int max_segment_length_per_warp,"
+      "Tensor grad_offsets,"
+      "Tensor total_L_offsets,"
+      "bool permute_output_dim_0_1,"
+      "Tensor saved_tensor) ->Tensor");
+  DISPATCH_TO_CUDA(
+      "batch_index_select_dim0_forward_cuda_impl",
+      BatchIndexSelectDim0GPUOp::forward_impl);
+  DISPATCH_TO_CUDA(
+      "batch_index_select_dim0_backward_cuda_impl",
+      BatchIndexSelectDim0GPUOp::backward_impl);
+  DISPATCH_TO_AUTOGRAD_CUDA(
+      "batch_index_select_dim0", batch_index_select_dim0_gpu);
+
+  // Tensor alternative
+  m.def(
+      "batch_index_select_dim0_tensor_forward_cuda_impl("
+      "Tensor inputs,"
+      "Tensor indices,"
+      "Tensor input_num_indices,"
+      "Tensor input_rows,"
+      "Tensor input_columns,"
+      "bool permute_output_dim_0_1) -> Tensor[]");
+
+  m.def(
+      "batch_index_select_dim0_tensor_backward_cuda_impl("
+      "Tensor grad_output,"
+      "Tensor dev_weights,"
+      "Tensor weights_offsets,"
+      "Tensor D_offsets,"
+      "Tensor hash_size_cumsum,"
+      "Tensor indices,"
+      "int max_segment_length_per_warp,"
+      "Tensor grad_offsets,"
+      "Tensor total_L_offsets,"
+      "bool permute_output_dim_0_1,"
+      "Tensor saved_tensor) -> Tensor");
+  DISPATCH_TO_CUDA(
+      "batch_index_select_dim0_tensor_forward_cuda_impl",
+      BatchIndexSelectDim0TensorGPUOp::forward_impl);
+  DISPATCH_TO_CUDA(
+      "batch_index_select_dim0_tensor_backward_cuda_impl",
+      BatchIndexSelectDim0TensorGPUOp::backward_impl);
+  DISPATCH_TO_AUTOGRAD_CUDA(
+      "batch_index_select_dim0_tensor", batch_index_select_dim0_tensor_gpu);
 }

--- a/fbgemm_gpu/test/sparse/failures_dict.json
+++ b/fbgemm_gpu/test/sparse/failures_dict.json
@@ -5,20 +5,7 @@
     "fbgemm::asynchronous_complete_cumsum": {},
     "fbgemm::asynchronous_exclusive_cumsum": {},
     "fbgemm::asynchronous_inclusive_cumsum": {},
-    "fbgemm::batch_index_select_dim0": {
-      "IndexSelectTest.test_aot_dispatch_dynamic__test_batch_index_select_dim0": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "IndexSelectTest.test_autograd_registration__test_batch_index_select_dim0": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "IndexSelectTest.test_faketensor__test_batch_index_select_dim0": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
+    "fbgemm::batch_index_select_dim0": {},
     "fbgemm::block_bucketize_sparse_features": {
       "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features": {
         "comment": "",


### PR DESCRIPTION
Summary:
Making batch_index_select_dim0 with custom autograd functions PT2 traceable.

The main flow is described https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU/edit#heading=h.ptttacy8y1u9

Introducing batch_index_select_dim0_tensor operator that accepts Tensor instead of List[int].

Differential Revision: D57232975


