### PR TITLE
Support FP8 scale calculation with scalar and cleanup

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions.cu
@@ -601,200 +601,9 @@ template <
     int TBS_M,
     int TBS_N,
     int TBS_K,
-    bool FAST_ACCUM>
-at::Tensor f8f8bf16_impl(
-    at::Tensor XQ, // FP8
-    at::Tensor WQ, // FP8
-    at::Tensor scale) {
-  int M = XQ.size(0);
-  int N = WQ.size(0);
-  int K = XQ.size(1);
-
-  TORCH_CHECK(XQ.is_cuda() && XQ.is_contiguous());
-  TORCH_CHECK(WQ.is_cuda() && WQ.is_contiguous());
-
-  auto Y = at::empty({M, N}, XQ.options().dtype(at::kBFloat16));
-
-  using ElementInputA = cutlass::float_e4m3_t;
-  using LayoutInputA = cutlass::layout::RowMajor;
-  constexpr int AlignmentInputA =
-      128 /
-      cutlass::sizeof_bits<
-          ElementInputA>::value; // Memory access granularity/alignment of A
-                                 // matrix in units of elements (up to 16 bytes)
-
-  using ElementInputB = cutlass::float_e4m3_t;
-  using LayoutInputB = cutlass::layout::ColumnMajor;
-  constexpr int AlignmentInputB =
-      128 /
-      cutlass::sizeof_bits<
-          ElementInputB>::value; // Memory access granularity/alignment of B
-                                 // matrix in units of elements (up to 16 bytes)
-
-  using ElementOutput = cutlass::bfloat16_t;
-  using LayoutOutput = cutlass::layout::ColumnMajor;
-  constexpr int AlignmentOutput =
-      128 /
-      cutlass::sizeof_bits<
-          ElementOutput>::value; // Memory access granularity/alignment of C
-                                 // matrix in units of elements (up to 16 bytes)
-
-  using ElementAccumulator = float;
-  using ElementComputeEpilogue = float;
-  using ArchTag = cutlass::arch::Sm90; // Tag indicating the minimum SM that
-                                       // supports the intended feature
-  using OperatorClass = cutlass::arch::OpClassTensorOp;
-  using TileShape = cute::Shape<
-      cute::Int<TB_M>,
-      cute::Int<TB_N>,
-      cute::Int<TB_K>>; // Threadblock-level
-                        // tile size
-  using ClusterShape = cute::Shape<
-      cute::Int<TBS_M>,
-      cute::Int<TBS_N>,
-      cute::Int<TBS_K>>; // Shape of the
-                         // threadblocks in a
-                         // cluster
-  using StageCountType =
-      cutlass::gemm::collective::StageCountAuto; // Stage count maximized
-                                                 // based on the tile size
-  using KernelSchedule = cutlass::gemm::collective::
-      KernelScheduleAuto; // Kernel to launch based on the default setting in
-                          // the Collective Builder
-
-  using MainLoopSchedule = cute::conditional_t<
-      FAST_ACCUM,
-      cutlass::gemm::KernelTmaWarpSpecializedFP8FastAccum,
-      cutlass::gemm::KernelTmaWarpSpecialized>;
-
-  using CollectiveMainloop =
-      typename cutlass::gemm::collective::CollectiveBuilder<
-          ArchTag,
-          OperatorClass,
-          ElementInputA,
-          LayoutInputA,
-          AlignmentInputA,
-          ElementInputB,
-          LayoutInputB,
-          AlignmentInputB,
-          ElementAccumulator,
-          TileShape,
-          ClusterShape,
-          cutlass::gemm::collective::StageCountAuto,
-          MainLoopSchedule>::CollectiveOp;
-
-  using CollectiveEpilogue =
-      typename cutlass::epilogue::collective::CollectiveBuilder<
-          cutlass::arch::Sm90,
-          cutlass::arch::OpClassTensorOp,
-          TileShape,
-          ClusterShape,
-          cutlass::epilogue::collective::EpilogueTileAuto,
-          ElementAccumulator,
-          ElementComputeEpilogue,
-          ElementOutput,
-          LayoutOutput,
-          AlignmentOutput,
-          ElementOutput,
-          LayoutOutput,
-          AlignmentOutput,
-          cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int, int, int>,
-      CollectiveMainloop,
-      CollectiveEpilogue>;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
-
-  using StrideInputA = typename Gemm::GemmKernel::StrideA;
-  using StrideInputB = typename Gemm::GemmKernel::StrideB;
-  using StrideOutput = typename Gemm::GemmKernel::StrideC;
-
-  StrideInputA stride_a = cutlass::make_cute_packed_stride(
-      StrideInputA{}, cute::make_shape(M, K, cute::Int<1>{}));
-  StrideInputB stride_b = cutlass::make_cute_packed_stride(
-      StrideInputB{}, cute::make_shape(N, K, cute::Int<1>{}));
-  StrideOutput stride_output = cutlass::make_cute_packed_stride(
-      StrideOutput{}, cute::make_shape(N, M, cute::Int<1>{}));
-
-  typename Gemm::Arguments arguments{
-      cutlass::gemm::GemmUniversalMode::kGemm,
-      {N, M, K},
-      {reinterpret_cast<ElementInputB*>(WQ.data_ptr()),
-       stride_b,
-       reinterpret_cast<ElementInputA*>(XQ.data_ptr()),
-       stride_a},
-      {{scale.data_ptr<float>(), 0},
-       (ElementOutput*)Y.data_ptr<at::BFloat16>(),
-       stride_output,
-       (ElementOutput*)Y.data_ptr<at::BFloat16>(),
-       stride_output}};
-  Gemm gemm;
-
-  // Using the arguments, query for extra workspace required for matrix
-  // multiplication computation
-  size_t workspace_size = Gemm::get_workspace_size(arguments);
-
-  // Allocate workspace memory
-  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
-
-  // Check the problem size is supported or not
-  cutlass::Status status = gemm.can_implement(arguments);
-  if (status != cutlass::Status::kSuccess) {
-    throw std::runtime_error("cutlass cannot implement");
-  }
-
-  // Initialize CUTLASS kernel with arguments and workspace pointer
-  status = gemm.initialize(arguments, workspace.get());
-  if (status != cutlass::Status::kSuccess) {
-    throw std::runtime_error("cutlass cannot initialize");
-  }
-
-  status = gemm(at::cuda::getCurrentCUDAStream());
-  if (status != cutlass::Status::kSuccess) {
-    throw std::runtime_error(
-        std::string("cutlass cannot run") +
-        cutlass::cutlassGetStatusString(status));
-  }
-  C10_CUDA_KERNEL_LAUNCH_CHECK();
-
-  return Y;
-}
-
-at::Tensor f8f8bf16(
-    at::Tensor XQ, // FP8
-    at::Tensor WQ, // FP8
-    at::Tensor scale,
-    bool use_fast_accum) {
-  auto M = XQ.size(0);
-  // auto K = XQ.size(1);
-  // auto N = WQ.size(0);
-  if (use_fast_accum) {
-    if (M <= 128) {
-      return f8f8bf16_impl<64, 128, 128, 2, 1, 1, true>(XQ, WQ, scale);
-    } else {
-      return f8f8bf16_impl<128, 128, 128, 1, 2, 1, true>(XQ, WQ, scale);
-    }
-  } else {
-    if (M <= 128) {
-      return f8f8bf16_impl<64, 128, 128, 2, 1, 1, false>(XQ, WQ, scale);
-    } else {
-      return f8f8bf16_impl<128, 128, 128, 1, 2, 1, false>(XQ, WQ, scale);
-    }
-  }
-}
-
-template <
-    int TB_M,
-    int TB_N,
-    int TB_K,
-    int TBS_M,
-    int TBS_N,
-    int TBS_K,
     bool PONG,
     bool FAST_ACCUM>
-at::Tensor f8f8bf16_tensorwise_impl(
+at::Tensor f8f8bf16_impl(
     at::Tensor XQ, // FP8
     at::Tensor WQ, // FP8
     double scale) {
@@ -978,21 +787,18 @@ at::Tensor f8f8bf16_tensorwise_impl(
   return Y;
 }
 
-at::Tensor f8f8bf16_tensorwise(
+at::Tensor f8f8bf16(
     at::Tensor XQ, // FP8
     at::Tensor WQ, // FP8
     double scale,
     bool use_fast_accum) {
   KernelMode kernel = get_kernel_mode(XQ, WQ);
   if (kernel == KernelMode::Small) {
-    return f8f8bf16_tensorwise_impl<64, 128, 128, 2, 1, 1, true, true>(
-        XQ, WQ, scale);
+    return f8f8bf16_impl<64, 128, 128, 2, 1, 1, true, true>(XQ, WQ, scale);
   } else if (kernel == KernelMode::Large) {
-    return f8f8bf16_tensorwise_impl<128, 128, 128, 2, 1, 1, true, true>(
-        XQ, WQ, scale);
+    return f8f8bf16_impl<128, 128, 128, 2, 1, 1, true, true>(XQ, WQ, scale);
   } else {
-    return f8f8bf16_tensorwise_impl<128, 128, 128, 1, 2, 1, false, true>(
-        XQ, WQ, scale);
+    return f8f8bf16_impl<128, 128, 128, 1, 2, 1, false, true>(XQ, WQ, scale);
   }
 }
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cu
@@ -680,7 +680,7 @@ at::Tensor quantize_fp8_per_tensor_fixed_scale(
 
 // TODO: Extend to support other data types for other
 // usecases/models when needed
-std::vector<at::Tensor> quantize_fp8_per_tensor(
+std::tuple<at::Tensor, double> quantize_fp8_per_tensor(
     at::Tensor input,
     c10::optional<at::Tensor> bs, // batch size
     c10::optional<at::Tensor> scale_ub) // scale upperbound)
@@ -756,7 +756,89 @@ std::vector<at::Tensor> quantize_fp8_per_tensor(
         input.size(-1),
         stream);
   }
-  return std::vector<at::Tensor>{quantized_input, scales};
+  float scales_host;
+  C10_CUDA_CHECK(cudaMemcpyAsync(
+      &scales_host, scales.data_ptr(), sizeof(float), cudaMemcpyDeviceToHost));
+  return std::tuple<at::Tensor, double>{quantized_input, scales_host};
+}
+
+std::tuple<at::Tensor, at::Tensor> quantize_fp8_per_tensor_tensor_scale(
+    at::Tensor input,
+    c10::optional<at::Tensor> bs, // batch size
+    c10::optional<at::Tensor> scale_ub) // scale upperbound)
+{
+  CUDA_DEVICE_GUARD(input);
+  TORCH_CHECK(input.numel() != 0, "input should not be empty tensor");
+  TORCH_CHECK(
+      input.dim() >= 2,
+      "Invalid dim. The dim of input should be greater than or equal to 2");
+  auto _st = input.scalar_type();
+  TORCH_CHECK(_st == torch::kBFloat16, "Invalid datatype. input must be BF16");
+  std::vector<long int> quantized_input_shape;
+  quantized_input_shape.reserve(input.dim());
+  for (int i = 0; i < input.dim(); i++) {
+    quantized_input_shape.push_back(input.size(i));
+  }
+  std::vector<long int> scale_shape = {1};
+  input = input.cuda();
+  at::Tensor quantized_input = torch::empty(
+      quantized_input_shape,
+      torch::dtype(torch::kFloat8_e4m3fn)
+          .device(torch::kCUDA, at::cuda::current_device())
+          .requires_grad(false));
+  at::Tensor scales = torch::empty(
+      scale_shape,
+      torch::dtype(torch::kFloat32)
+          .device(torch::kCUDA, at::cuda::current_device())
+          .requires_grad(false));
+  auto* const quantized_input_ptr =
+      reinterpret_cast<__nv_fp8_e4m3*>(quantized_input.data_ptr());
+  const auto stream = at::cuda::getCurrentCUDAStream();
+  if (bs.has_value()) {
+    int64_t total_elements_per_slice = quantized_input_shape[0];
+    for (int i = 1; i < input.dim() - 1; i++) {
+      total_elements_per_slice =
+          total_elements_per_slice * quantized_input_shape[i];
+    }
+    invokeComputeScale(
+        reinterpret_cast<float*>(scales.data_ptr()),
+        reinterpret_cast<const __nv_bfloat16*>(input.data_ptr()),
+        input.numel(),
+        input.size(-1),
+        total_elements_per_slice,
+        reinterpret_cast<int64_t*>(bs.value().data_ptr()),
+        scale_ub.has_value()
+            ? reinterpret_cast<float*>(scale_ub.value().data_ptr())
+            : nullptr,
+        stream);
+    invokeQuantizeMatrix(
+        quantized_input_ptr,
+        reinterpret_cast<float*>(scales.data_ptr()),
+        reinterpret_cast<const __nv_bfloat16*>(input.data_ptr()),
+        input.numel(),
+        input.size(-1),
+        stream);
+  } else {
+    invokeComputeScale(
+        reinterpret_cast<float*>(scales.data_ptr()),
+        reinterpret_cast<const __nv_bfloat16*>(input.data_ptr()),
+        input.numel(),
+        input.size(-1),
+        -1,
+        nullptr,
+        scale_ub.has_value()
+            ? reinterpret_cast<float*>(scale_ub.value().data_ptr())
+            : nullptr,
+        stream);
+    invokeQuantizeMatrix(
+        quantized_input_ptr,
+        reinterpret_cast<float*>(scales.data_ptr()),
+        reinterpret_cast<const __nv_bfloat16*>(input.data_ptr()),
+        input.numel(),
+        input.size(-1),
+        stream);
+  }
+  return std::tuple<at::Tensor, at::Tensor>{quantized_input, scales};
 }
 
 template <typename T>
@@ -1012,7 +1094,15 @@ std::vector<at::Tensor> quantize_fp8_per_col(
 }
 
 #else
-std::vector<at::Tensor> quantize_fp8_per_tensor(
+std::tuple<at::Tensor, double> quantize_fp8_per_tensor(
+    at::Tensor input,
+    c10::optional<at::Tensor> bs, // batch size
+    c10::optional<at::Tensor> scale_ub) { // scale upperbound
+  throw std::runtime_error(
+      "CUDA version is older than 12.0"); // requires CUDA>=12
+}
+
+std::tuple<at::Tensor, at::Tensor> quantize_fp8_per_tensor_tensor_scale(
     at::Tensor input,
     c10::optional<at::Tensor> bs, // batch size
     c10::optional<at::Tensor> scale_ub) { // scale upperbound


### PR DESCRIPTION
Summary:
Follow up on D57263833 to support FP8 scale calculation with scalar and merge two FP8 tensorwise GEMMs into one

Note that besides `Sm90ScalarBroadcast` in CUTLASS, AMD CK f8f8bf16 GEMM also requires passing scales as scalar instead of tensor scalar. This support is required in both NV and AMD sides

Differential Revision: D57367680


