### PR TITLE
use total_L is None for dense_to_jagged

### DIFF
--- a/fbgemm_gpu/experimental/example/test/triton_example_test.py
+++ b/fbgemm_gpu/experimental/example/test/triton_example_test.py
@@ -14,7 +14,7 @@ import triton.language as tl
 @triton.jit
 # fmt: off
 def triton_add_kernel(x_ptr, y_ptr, z_ptr, n_elements, BLOCK_SIZE: tl.constexpr) -> None:
-# fmt: on
+    # fmt: on
     # We use a 1D launch grid so axis is 0.
     pid = tl.program_id(axis=0)
 

--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -14,7 +14,6 @@ import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
 from fbgemm_gpu.split_table_batched_embeddings_ops_common import PoolingMode
 
-
 try:
     # pyre-ignore
     from fbgemm_gpu import open_source  # noqa: F401
@@ -508,7 +507,7 @@ def dense_to_jagged_forward(
     offsets: List[torch.Tensor],
     total_L: Optional[torch.SymInt] = None,
 ) -> torch.Tensor:
-    if not total_L:
+    if total_L is None:
         total_L = torch.library.get_ctx().new_dynamic_size()
     return dense.new_zeros(
         [total_L, dense.size()[-1]],
@@ -524,7 +523,7 @@ def dense_to_jagged(
     offsets: List[torch.Tensor],
     total_L: Optional[torch.SymInt] = None,
 ) -> Tuple[torch.Tensor, List[torch.Tensor]]:
-    if not total_L:
+    if total_L is None:
         total_L = torch.library.get_ctx().new_dynamic_size()
     return (dense_to_jagged_forward(dense, offsets, total_L), offsets)
 


### PR DESCRIPTION
Summary:
# Could not guard on data-dependent expression Ne(u0, 0)

```
RuntimeError: Failed running call_function fbgemm.dense_to_jagged(*(FakeTensor(..., device='cuda:0', size=(s1, 2540, 512), dtype=torch.bfloat16), [FakeTensor(..., device='cuda:0', size=(s1 + 1,), dtype=torch.int64)]), **{'total_L': None}):
Could not guard on data-dependent expression Ne(u0, 0) (unhinted: Ne(u0, 0)).  (Size-like symbols: u0)
ATTENTION: guard_size_oblivious would fix the error, evaluating expression to True.
Maybe you need to add guard_size_oblivious to framework code, see doc below for more guidance.
Potential framework code culprit (scroll up for full backtrace):
  File "/mnt/xarfuse/uid-119376/a7f0c177-seed-nspid4026531836_cgpid3083025-ns-4026531841/fbgemm_gpu/sparse_ops.py", line 467, in dense_to_jagged_forward
    if not total_L:


User Stack (most recent call last):
  (snipped, see stack below for prefix)
  File "<eval_with_key>.82", line 424, in forward
    dense_to_jagged = torch.ops.fbgemm.dense_to_jagged(matmul_22, [asynchronous_complete_cumsum_9], total_L = None);  matmul_22 = None
```

using `total_L is None` instead will avoid this guard.

Differential Revision: D57465638


