### PR TITLE
Fix f8f8bf16 function signature when cuda disabled

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions.cu
@@ -1898,6 +1898,14 @@ at::Tensor f8f8bf16_cublas(
 at::Tensor f8f8bf16(
     at::Tensor XQ, // FP8
     at::Tensor WQ, // FP8
+    at::Tensor scale,
+    bool use_fast_accum) {
+  throw std::runtime_error(
+      "CUDA version is older than 12.0"); // requires CUDA>=12
+}
+at::Tensor f8f8bf16_tensorwise(
+    at::Tensor XQ, // FP8
+    at::Tensor WQ, // FP8
     double scale,
     bool use_fast_accum) {
   throw std::runtime_error(


### PR DESCRIPTION
Summary: Since D57442310 changed f8f8bf16 function signature, changing the function signature back fixes the issue

Differential Revision: D57529592


