### PR TITLE
[fbgemm_gpu] Add Doxygen predefines

### DIFF
--- a/fbgemm_gpu/docs/Doxyfile.in
+++ b/fbgemm_gpu/docs/Doxyfile.in
@@ -2360,9 +2360,15 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
+# Define platform preprocessor flags to enable docs generation for code sections
+# that are `#ifdef`-guarded by platform flags
+
 PREDEFINED             = DOXYGEN_THIS_WILL_BE_SKIPPED \
-                         "FBGEMM_API=" \
-                         "DLL_PUBLIC="
+                         FBGEMM_API \
+                         DLL_PUBLIC \
+                         __linux__ \
+                         _WIN32 \
+                         __APPLE__
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
- Add platform preprocessor flags to Doxygen to enable docs generation for code sections that are `#ifdef`-guarded by platform flags