### PR TITLE
Add AMD Rowwise FP8 Matmul

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions.hip
@@ -21,6 +21,7 @@
 #include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
 #include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
+#include "ck/utility/blkgemmpipe_scheduler.hpp"
 #include "ck/utility/data_type.hpp"
 
 #include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
@@ -32,6 +33,7 @@
 #include "ck/library/utility/literals.hpp"
 
 #include "ck/tensor_operation/gpu/device/impl/device_gemm_multiple_d_xdl_cshuffle.hpp"
+#include "ck/tensor_operation/gpu/device/impl/device_gemm_multiple_d_xdl_cshuffle_v3.hpp"
 
 // Define commonly used types.
 template <ck::index_t... Is>
@@ -51,6 +53,24 @@ struct Scale {
   float scale_;
 };
 
+struct RowwiseScale {
+  template <typename E, typename C, typename D0, typename D1>
+  __host__ __device__ constexpr void
+  operator()(E& e, const C& c, const D0& d0, const D1& d1) const;
+
+  template <>
+  __host__ __device__ constexpr void
+  operator()<ck::bhalf_t, float, float, float>(
+      ck::bhalf_t& e,
+      const float& c,
+      const float& d0,
+      const float& d1) const {
+    const float x0_f = c * d0 * d1;
+
+    e = ck::type_convert<ck::bhalf_t>(x0_f);
+  }
+};
+
 namespace fbgemm_gpu {
 
 template <
@@ -61,16 +81,12 @@ template <
     int MPER_WAVE,
     int NPER_WAVE,
     bool PADDING = false>
-at::Tensor f8f8bf16_tensorwise_impl(at::Tensor XQ, at::Tensor WQ, double scale) {
+at::Tensor
+f8f8bf16_tensorwise_impl(at::Tensor XQ, at::Tensor WQ, double scale) {
   // Get input information.
   int M = XQ.size(0);
   int N = WQ.size(0);
   int K = XQ.size(1);
-
-  // Check that sizes are sufficiently large for grid dispatch.
-  TORCH_CHECK(
-      M >= 128 && N >= 128 && K >= 256,
-      "Minimum supported M,N,K is 128,128,256.");
 
   int StrideA = K;
   int StrideB = K;
@@ -211,17 +227,28 @@ std::tuple<KernelMode, bool> get_kernel_mode(at::Tensor XQ, at::Tensor WQ) {
   }
 }
 
-at::Tensor
-f8f8bf16_tensorwise(at::Tensor XQ, at::Tensor WQ, double scale, bool use_fast_accum) {
+at::Tensor f8f8bf16_tensorwise(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    double scale,
+    bool use_fast_accum) {
+  // Check that input types are compatible with AMD FP8.
+  TORCH_CHECK(
+      (XQ.dtype() == at::kFloat8_e4m3fnuz) &&
+          (WQ.dtype() == at::kFloat8_e4m3fnuz),
+      "Inputs must be type float8_e4m3fnuz.");
   TORCH_CHECK(use_fast_accum, "AMD does not support disabling use_fast_accum");
   auto [kernel, pad] = get_kernel_mode(XQ, WQ);
   if (pad) {
     if (kernel == KernelMode::Small) {
-      return f8f8bf16_tensorwise_impl<64, 32, 64, 64, 1, 2, true>(XQ, WQ, scale);
+      return f8f8bf16_tensorwise_impl<64, 32, 64, 64, 1, 2, true>(
+          XQ, WQ, scale);
     } else if (kernel == KernelMode::Large) {
-      return f8f8bf16_tensorwise_impl<256, 256, 128, 64, 4, 2, true>(XQ, WQ, scale);
+      return f8f8bf16_tensorwise_impl<256, 256, 128, 64, 4, 2, true>(
+          XQ, WQ, scale);
     } else {
-      return f8f8bf16_tensorwise_impl<256, 128, 128, 64, 2, 2, true>(XQ, WQ, scale);
+      return f8f8bf16_tensorwise_impl<256, 128, 128, 64, 2, 2, true>(
+          XQ, WQ, scale);
     }
   } else {
     if (kernel == KernelMode::Small) {
@@ -230,6 +257,180 @@ f8f8bf16_tensorwise(at::Tensor XQ, at::Tensor WQ, double scale, bool use_fast_ac
       return f8f8bf16_tensorwise_impl<256, 256, 128, 64, 4, 2>(XQ, WQ, scale);
     } else {
       return f8f8bf16_tensorwise_impl<256, 128, 128, 64, 2, 2>(XQ, WQ, scale);
+    }
+  }
+}
+
+template <
+    int BLOCK_SIZE,
+    int MBLOCK,
+    int NBLOCK,
+    int KBLOCK,
+    int MPER_WAVE,
+    int NPER_WAVE,
+    bool PADDING = false>
+at::Tensor f8f8bf16_rowwise_impl(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale) {
+  // Get input information.
+  int M = XQ.size(0);
+  int N = WQ.size(0);
+  int K = XQ.size(1);
+
+  int StrideA = K;
+  int StrideB = K;
+  int StrideE = N;
+
+  TORCH_CHECK(XQ.is_cuda() && XQ.is_contiguous());
+  TORCH_CHECK(WQ.is_cuda() && WQ.is_contiguous());
+
+  auto Y = at::empty({M, N}, XQ.options().dtype(at::kBFloat16));
+
+  using ADataType = ck::f8_t;
+  using BDataType = ck::f8_t;
+  using D0DataType = float;
+  using D1DataType = float;
+  using DsDataType = ck::Tuple<D0DataType, D1DataType>;
+  using EDataType = ck::bhalf_t;
+  using AccDataType = float;
+  using CShuffleDataType = float;
+
+  using ALayout = Row;
+  using BLayout = Col;
+  using D0Layout = Row;
+  using D1Layout = Col;
+  using DsLayout = ck::Tuple<D0Layout, D1Layout>;
+  using ELayout = Row;
+
+  using AElementOp = PassThrough;
+  using BElementOp = PassThrough;
+  using CDEElementOp = RowwiseScale;
+
+  static constexpr auto GemmDefault =
+      ck::tensor_operation::device::GemmSpecialization::Default;
+  static constexpr auto GemmMNKPadding =
+      ck::tensor_operation::device::GemmSpecialization::MNKPadding;
+  static constexpr auto GemmSpec = PADDING ? GemmMNKPadding : GemmDefault;
+  using ComputeType = ck::f8_t;
+
+  // Define derivative constants based on template parameters.
+  static constexpr int BLOCK_CLUSTER = BLOCK_SIZE / 4;
+  static constexpr int CBLOCK_N = NBLOCK / 16;
+  static constexpr int CBLOCK_M = BLOCK_SIZE / CBLOCK_N;
+
+  using DeviceGemmInstance =
+      ck::tensor_operation::device::DeviceGemmMultiD_Xdl_CShuffle_V3<
+          ALayout,
+          BLayout,
+          DsLayout,
+          ELayout,
+          ADataType,
+          BDataType,
+          DsDataType,
+          EDataType,
+          AccDataType,
+          CShuffleDataType,
+          AElementOp,
+          BElementOp,
+          CDEElementOp,
+          GemmSpec,
+          BLOCK_SIZE, // Block Size
+          MBLOCK, // M per Block
+          NBLOCK, // N per Block
+          KBLOCK, // K per Block
+          16, // AK1
+          16, // BK1
+          32, // M per Xdl
+          32, // N per Xdl
+          MPER_WAVE, // Mxdl per Wave
+          NPER_WAVE, // Nxdl per Wave
+          S<4, 64, 1>,
+          S<1, 0, 2>,
+          S<1, 0, 2>,
+          2,
+          16,
+          16,
+          0,
+          S<4, 64, 1>,
+          S<1, 0, 2>,
+          S<1, 0, 2>,
+          2,
+          16,
+          16,
+          0,
+          1,
+          1,
+          S<1, CBLOCK_M, 1, CBLOCK_N>,
+          S<8, 8, 1>,
+          ck::BlockGemmPipelineScheduler::Interwave,
+          ck::BlockGemmPipelineVersion::v1,
+          ComputeType>;
+
+  // Create gemm launcher and arguments.
+  auto gemm = DeviceGemmInstance{};
+  auto invoker = gemm.MakeInvoker();
+
+  auto a_element_op = AElementOp{};
+  auto b_element_op = BElementOp{};
+  auto cde_element_op = CDEElementOp{};
+
+  constexpr ck::index_t NumDTensor = DsDataType::Size();
+  constexpr auto I0 =
+      ck::Number<0>{}; // Used to indicate 0 stride for row and col broadcast.
+
+  auto argument = gemm.MakeArgument(
+      reinterpret_cast<ADataType*>(XQ.data_ptr()),
+      reinterpret_cast<BDataType*>(WQ.data_ptr()),
+      std::array<const void*, NumDTensor>{
+          reinterpret_cast<D0DataType*>(w_scale.data_ptr()),
+          reinterpret_cast<D1DataType*>(x_scale.data_ptr())},
+      reinterpret_cast<EDataType*>(Y.data_ptr()),
+      M,
+      N,
+      K,
+      StrideA,
+      StrideB,
+      std::array<ck::index_t, NumDTensor>{I0, I0},
+      StrideE,
+      a_element_op,
+      b_element_op,
+      cde_element_op);
+
+  auto stream = at::cuda::getCurrentHIPStream().stream();
+  invoker.Run(argument, StreamConfig{stream, false});
+
+  return Y;
+}
+
+at::Tensor f8f8bf16_rowwise(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    c10::optional<at::Tensor> bias,
+    bool use_fast_accum) {
+  // Check that input datatypes are valid.
+  TORCH_CHECK(
+    (XQ.dtype() == at::kFloat8_e4m3fnuz) &&
+        (WQ.dtype() == at::kFloat8_e4m3fnuz),
+    "Inputs must be type float8_e4m3fnuz.");
+  TORCH_CHECK((x_scale.dtype() == at::kFloat) && (w_scale.dtype() == at::kFloat), "Scales must be float32.");
+  TORCH_CHECK(use_fast_accum, "AMD does not support disabling use_fast_accum.");
+  TORCH_CHECK(!(bias.has_value()), "AMD does not yet support bias.");
+  auto [kernel, pad] = get_kernel_mode(XQ, WQ);
+  if (pad) {
+    if (kernel == KernelMode::Large) {
+      return f8f8bf16_rowwise_impl<256, 256, 128, 64, 4, 2, true>(XQ, WQ, x_scale, w_scale);
+    } else {
+      return f8f8bf16_rowwise_impl<256, 128, 128, 64, 2, 2, true>(XQ, WQ, x_scale, w_scale);
+    }
+  } else {
+    if (kernel == KernelMode::Large) {
+      return f8f8bf16_rowwise_impl<256, 256, 128, 64, 4, 2, false>(XQ, WQ, x_scale, w_scale);
+    } else {
+      return f8f8bf16_rowwise_impl<256, 128, 128, 64, 2, 2, false>(XQ, WQ, x_scale, w_scale);
     }
   }
 }

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions.cu
@@ -1326,11 +1326,6 @@ at::Tensor f8f8bf16_rowwise(
             bias.value().dtype() == at::kBFloat16,
         "Bias type must be bfloat16 or float32 if provided.");
   }
-  // Extract problem size.
-  auto M = XQ.size(0);
-  auto K = XQ.size(1);
-  auto N = WQ.size(0);
-
   bool use_bias = bias.has_value();
   bool bf16_bias = use_bias && bias.value().dtype() == at::kBFloat16;
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -106,9 +106,6 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "f8f8bf16(Tensor XQ, Tensor WQ, Tensor scale, bool use_fast_accum=True) -> Tensor");
 
   m.def(
-      "f8f8bf16_rowwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? bias=None, bool use_fast_accum=True) -> Tensor");
-
-  m.def(
       "f8f8bf16_cublas(Tensor A, Tensor B, Tensor Ainvs, Tensor Binvs, bool use_fast_accum=True, Tensor(a!)? output=None) -> Tensor");
 
   m.def(
@@ -120,6 +117,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.impl("i8i8bf16_dynamic", i8i8bf16_dynamic);
 #endif
 
+  m.def(
+      "f8f8bf16_rowwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? bias=None, bool use_fast_accum=True) -> Tensor");
   m.def(
       "f8f8bf16_tensorwise(Tensor XQ, Tensor WQ, float scale, bool use_fast_accum=True) -> Tensor");
   m.def("per_tensor_quantize_i8(Tensor X, float scale) -> Tensor");
@@ -164,9 +163,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   m.impl("f8f8bf16_tensorwise", f8f8bf16_tensorwise);
+  m.impl("f8f8bf16_rowwise", f8f8bf16_rowwise);
 #ifndef USE_ROCM
   m.impl("i8i8bf16", i8i8bf16);
-  m.impl("f8f8bf16_rowwise", f8f8bf16_rowwise);
   m.impl("quantize_fp8_per_tensor", quantize_fp8_per_tensor);
   m.impl("f8f8bf16", f8f8bf16);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas);
@@ -255,9 +254,9 @@ at::Tensor f8i4bf16_rowwise_meta(
 
 TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
   m.impl("f8f8bf16_tensorwise", f8f8bf16_tensorwise_meta);
+  m.impl("f8f8bf16_rowwise", f8f8bf16_rowwise_meta);
 #ifndef USE_ROCM
   m.impl("i8i8bf16", i8i8bf16_meta);
-  m.impl("f8f8bf16_rowwise", f8f8bf16_rowwise_meta);
   m.impl("quantize_fp8_per_tensor", quantize_fp8_per_tensor_meta);
   m.impl("f8f8bf16", f8f8bf16_meta);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas_meta);


### PR DESCRIPTION
Summary: This diff extends the `fp8fp8bf16_rowwise` gemm operation to AMD through a new CK kernel. The new kernel requires [new stride support](https://github.com/ROCm/composable_kernel/pull/1300) implemented by @zjing14 that is only available in developer branches of CK, so we must rely on the `ai_codesign/gen_ai` CK repo. I also extend the fp8 benchmarking suite to include rowwise measurements. I'll soon add detailed benchmarking results but the quick summary is that performance looks quite good, typically inline with tensorwise quantization and sometimes faster, presumably due to using the latest and greatest CK pipelines.

Differential Revision: D57600068


