### PR TITLE
Add -lrt to asmjit bazel build

### DIFF
--- a/third_party/asmjit.BUILD
+++ b/third_party/asmjit.BUILD
@@ -19,6 +19,9 @@ cc_library(
         "-fmerge-all-constants",
         "-DTH_BLAS_MKL",
     ],
+    linkopts = [
+      "-lrt",
+    ],
     includes = [
         "asmjit/",
         "src/",


### PR DESCRIPTION
Because asmjit uses shm_open.