### PR TITLE
SymInt-ify Optimizer NONE: total_unique_indices arg

### DIFF
--- a/fbgemm_gpu/codegen/genscript/optimizer_args.py
+++ b/fbgemm_gpu/codegen/genscript/optimizer_args.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import jinja2
+from deeplearning.fbgemm.fbgemm_gpu.codegen.genscript.torch_type_utils import ArgType
 
 try:
     from .torch_type_utils import arg_type_to_tensor_type, ArgType, TensorType
@@ -148,6 +149,22 @@ def int_arg(name: str, default: int = 0) -> str:
     return f"int {name} = {default}"
 
 
+def sym_int_arg(name: str, default: int = 0) -> str:
+    return f"c10::SymInt {name} = {default}"
+
+
+def sym_int_arg_no_default(name: str) -> str:
+    return f"c10::SymInt {name}"
+
+
+def schema_sym_int_arg(name: str, default: int = 0) -> str:
+    return f"SymInt {name} = {default}"
+
+
+def schema_sym_int_arg_no_default(name: str) -> str:
+    return f"SymInt {name}"
+
+
 def make_kernel_arg(
     ty: ArgType, name: str, default: Union[int, float, None], pass_by_ref: bool = False
 ) -> str:
@@ -162,6 +179,11 @@ def make_kernel_arg(
             (lambda x: int64_arg(x, default=int(default)))
             if default is not None
             else int64_arg_no_default
+        ),
+        ArgType.SYM_INT: (
+            (lambda x: sym_int_arg(x, default=int(default)))
+            if default is not None
+            else sym_int_arg_no_default
         ),
         ArgType.FLOAT: (
             (lambda x: float_arg(x, default=default))
@@ -179,6 +201,7 @@ def make_kernel_arg_constructor(ty: ArgType, name: str) -> str:
         ArgType.PLACEHOLDER_TENSOR: acc_placeholder_tensor_arg_constructor,
         ArgType.INT: lambda x: x,
         ArgType.FLOAT: lambda x: x,
+        ArgType.SYM_INT: lambda x: x,
     }[ty](name)
 
 
@@ -190,6 +213,7 @@ def make_cpu_kernel_arg(ty: ArgType, name: str, default: Union[int, float]) -> s
         ArgType.PLACEHOLDER_TENSOR: acc_cache_tensor_arg_constructor,
         ArgType.INT: lambda x: int64_arg(x, default=int(default)),
         ArgType.FLOAT: lambda x: float_arg(x, default=default),
+        ArgType.SYM_INT: lambda x: sym_int_arg(x, default=int(default)),
     }[ty](name)
 
 
@@ -203,6 +227,7 @@ def make_cpu_kernel_arg_constructor(ty: ArgType, name: str) -> str:
         ),
         ArgType.INT: lambda x: x,
         ArgType.FLOAT: lambda x: x,
+        ArgType.SYM_INT: lambda x: x,
     }[ty](name)
 
 
@@ -224,6 +249,11 @@ def make_function_arg(
             if default is not None
             else double_arg_no_default
         ),
+        ArgType.SYM_INT: (
+            (lambda x: sym_int_arg(x, default=int(default)))
+            if default is not None
+            else sym_int_arg_no_default
+        ),
     }[ty](name)
 
 
@@ -235,11 +265,16 @@ def make_function_schema_arg(ty: ArgType, name: str, default: Union[int, float])
         ArgType.PLACEHOLDER_TENSOR: tensor_arg,
         ArgType.INT: lambda x: int_arg(x, default=int(default)),
         ArgType.FLOAT: lambda x: float_arg(x, default=default),
+        ArgType.SYM_INT: lambda x: schema_sym_int_arg(x, default=default),
     }[ty](name)
 
 
 def make_ivalue_cast(ty: ArgType) -> str:
-    return {ArgType.INT: "toInt", ArgType.FLOAT: "toDouble"}[ty]
+    return {
+        ArgType.INT: "toInt",
+        ArgType.FLOAT: "toDouble",
+        ArgType.SYM_INT: "toSymInt",
+    }[ty]
 
 
 ######################################################################
@@ -397,7 +432,7 @@ class OptimizerArgsSet:
     ) -> OptimizerArgs:
         split_arg_spec = []
         for s in arg_spec:
-            if s.ty in (ArgType.FLOAT, ArgType.INT):
+            if s.ty in (ArgType.FLOAT, ArgType.INT, ArgType.SYM_INT):
                 split_arg_spec.append(OptimItem(s.ty, s.name, s.default))
             else:
                 assert s.ty in (ArgType.TENSOR, ArgType.PLACEHOLDER_TENSOR)

--- a/fbgemm_gpu/codegen/genscript/optimizers.py
+++ b/fbgemm_gpu/codegen/genscript/optimizers.py
@@ -1166,7 +1166,7 @@ def none_optimizer() -> Dict[str, Any]:
         "args": OptimizerArgsSet.create(
             [
                 OptimItem(ArgType.INT, "total_hash_size"),
-                OptimItem(ArgType.INT, "total_unique_indices"),
+                OptimItem(ArgType.SYM_INT, "total_unique_indices"),
             ]
         ),
         # Generate only GPU code

--- a/fbgemm_gpu/codegen/genscript/torch_type_utils.py
+++ b/fbgemm_gpu/codegen/genscript/torch_type_utils.py
@@ -25,6 +25,7 @@ class ArgType(IntEnum):
     PLACEHOLDER_TENSOR = 6
     INT = 7
     FLOAT = 8
+    SYM_INT = 9
 
 
 @dataclass

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_meta_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_meta_template.cpp
@@ -122,7 +122,7 @@ Tensor {{ mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdes
     // This is actually passed via args.split_function_args_no_defaults but explicitly list
     // it here for code readability
     int64_t total_hash_size,
-    int64_t total_unique_indices
+    c10::SymInt total_unique_indices
     {%- endif %}
 ) {
 
@@ -206,7 +206,7 @@ Tensor {{ mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdes
 
     // Took allocation from https://www.internalfb.com/code/fbsource/fbcode/deeplearning/fbgemm/fbgemm_gpu/src/split_embeddings_utils.cu?lines=339-347
     Tensor sorted_linear_indices_run;
-    if (total_unique_indices > 0) {
+    if (TORCH_GUARD_SIZE_OBLIVIOUS(total_unique_indices.sym_gt(0))) {
         sorted_linear_indices_run = at::empty_symint({total_unique_indices}, indices.options());
     } else {
         sorted_linear_indices_run = at::empty_like(indices);

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -511,7 +511,7 @@ Tensor {{ embedding_cuda_op }}(
     // This is actually passed via args.split_function_args_no_defaults but explicitly list
     // it here for code readability
     int64_t total_hash_size,
-    int64_t total_unique_indices
+    c10::SymInt total_unique_indices_
     {%- endif %}
 ) {
     {%- if not nobag or is_index_select %}
@@ -576,6 +576,7 @@ Tensor {{ embedding_cuda_op }}(
 
     {%- if optimizer == "none" %}
     // grad_dev_weights has emb_t type
+    const auto total_unique_indices = total_unique_indices_.guard_int(__FILE__, __LINE__);
     auto grad_dev_weights = at::empty({total_unique_indices * max_D}, dev_weights.options());
     {%- else %}
     // Set total_unique_indices to total num indices by default


### PR DESCRIPTION
Summary:
1/ To be able to PT2 compile OptimType.NONE - we need to make total_unique_indices SymInt.

It's generated via python generator - introducing SymInt arg type

2/ adding TORCH_GUARD_SIZE_OBLIVIOUS to pass through data dependent conditions

Differential Revision: D57861244


