### PR TITLE
TBEs fused optim in backward capability with aot_autograd

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_cpu_template.cpp
@@ -103,6 +103,9 @@ class SplitLookupFunction_{{ optimizer }}_Op : public torch::autograd::Function<
   static torch::autograd::variable_list backward(
       torch::autograd::AutogradContext* ctx,
       torch::autograd::variable_list grad_outputs) {
+    // backward does weights mutation, allowed in aot_autograd only with no_grad
+    at::AutoGradMode m(false);
+
     const auto saved = ctx->get_saved_variables();
     auto savedItr = std::begin(saved);
     auto host_weights = *savedItr++;

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
@@ -784,6 +784,9 @@ class {{ autograd_func }} :
   static torch::autograd::variable_list backward(
       torch::autograd::AutogradContext* ctx,
       torch::autograd::variable_list grad_outputs) {
+    // backward impl does mutation of weights, which are allowed in aot autograd only in no_grad mode
+    at::AutoGradMode m(false);
+
     const auto saved = ctx->get_saved_variables();
     auto savedItr = std::begin(saved);
     auto dev_weights = *savedItr++;

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
@@ -365,6 +365,9 @@ class {{ autograd_func }} :
 static torch::autograd::variable_list backward(
     torch::autograd::AutogradContext* ctx,
     torch::autograd::variable_list grad_outputs) {
+    // backward does weights mutation, allowed in aot_autograd only with no_grad
+    at::AutoGradMode m(false);
+
     const auto saved = ctx->get_saved_variables();
     auto savedItr = std::begin(saved);
     auto host_weights = *savedItr++;

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
@@ -556,9 +556,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
     %}
     m.def("{{ embedding_codegen_backward_op }}_wrapper("
         "    Tensor grad_output, "
-        "    Tensor host_weights, "
-        "    Tensor dev_weights, "
-        "    Tensor uvm_weights, "
+        "    Tensor(a!) host_weights, "
+        "    Tensor(b!) dev_weights, "
+        "    Tensor(c!) uvm_weights, "
         "    Tensor lxu_cache_weights, "
         "    Tensor weights_placements, "
         "    Tensor weights_offsets, "


### PR DESCRIPTION
Summary:
1. Backward with fused optimizer does mutations of the weights => correcting schemas to register mutations. (Needed for PT2 to run functionalization)

2. aot_autograd allows mutations in backward only if they are in within.no_grad() mode.

Adding `at::AutoGradMode m(false);` in backwards that does mutations

Differential Revision: D58014269


