### PR TITLE
MX4 quantization

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
@@ -76,6 +76,7 @@ class SparseType(enum.Enum):
     INT4 = "int4"
     INT2 = "int2"
     BF16 = "bf16"
+    MX4 = "mx4"
 
     def __str__(self) -> str:
         return self.value
@@ -96,6 +97,8 @@ class SparseType(enum.Enum):
             return SparseType("bf16")
         elif ty == 6:
             return SparseType("fp8")
+        elif ty == 7:
+            return SparseType("mx4")
         else:
             raise ValueError(f"Unsupported sparse type: {ty}")
 
@@ -108,15 +111,16 @@ class SparseType(enum.Enum):
             SparseType.INT2.value: 4,
             SparseType.BF16.value: 5,
             SparseType.FP8.value: 6,
+            SparseType.MX4.value: 7,
         }[self.value]
 
     @staticmethod
-    def from_dtype(dtype: torch.dtype) -> "SparseType":
+    def from_dtype(dtype: torch.dtype, is_mx: bool = False) -> "SparseType":
         if dtype == torch.float32:
             return SparseType("fp32")
         elif dtype == torch.float16:
             return SparseType("fp16")
-        elif dtype == torch.int8 or dtype == torch.uint8:
+        elif (dtype == torch.int8 or dtype == torch.uint8) and not is_mx:
             return SparseType("int8")
         elif dtype == torch.quint4x2:
             return SparseType("int4")
@@ -124,6 +128,8 @@ class SparseType(enum.Enum):
             return SparseType("int2")
         elif dtype == torch.bfloat16:
             return SparseType("bf16")
+        elif dtype == torch.uint8:
+            return SparseType("mx4")
         else:
             raise ValueError(f"Unsupported sparse dtype: {dtype}")
 
@@ -136,6 +142,7 @@ class SparseType(enum.Enum):
             SparseType.INT4.value: torch.quint4x2,
             SparseType.INT2.value: torch.quint2x4,
             SparseType.BF16.value: torch.bfloat16,
+            SparseType.MX4.value: torch.uint8,
         }[self.value]
 
     def bit_rate(self) -> int:
@@ -147,6 +154,7 @@ class SparseType(enum.Enum):
             SparseType.INT4.value: 4,
             SparseType.INT2.value: 2,
             SparseType.BF16.value: 16,
+            SparseType.MX4.value: 4,
         }[self.value]
 
     def align_size(self) -> int:
@@ -158,6 +166,7 @@ class SparseType(enum.Enum):
             SparseType.INT4.value: 8,
             SparseType.INT2.value: 16,
             SparseType.BF16.value: 2,
+            SparseType.MX4.value: 8,
         }[self.value]
 
     def is_float(self) -> bool:

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -400,6 +400,22 @@ at::Tensor fusednbitrowwise_to_float_or_half_cpu(
     const int64_t bit_rate,
     const int64_t output_dtype);
 
+at::Tensor quantize_mx_cuda(
+    const at::Tensor& input,
+    const std::vector<int64_t>& split_sizes,
+    const int64_t scale_bits,
+    const int64_t elem_ebits,
+    const int64_t elem_mbits,
+    const double elem_max_norm,
+    const int64_t mx_group_size,
+    const bool flush_fp32_subnorms = false,
+    const int64_t rounding_mode = 0);
+
+at::Tensor dequantize_mx_cuda(
+    const at::Tensor& input,
+    const std::vector<int64_t>& split_sizes,
+    const int64_t mx_group_size);
+
 ///@ingroup sparse-data-cuda
 at::Tensor reorder_batched_ad_lengths_gpu(
     const at::Tensor& cat_ad_lengths,

--- a/fbgemm_gpu/src/quantize_ops/mx/LICENSE
+++ b/fbgemm_gpu/src/quantize_ops/mx/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/fbgemm_gpu/src/quantize_ops/mx/common.cuh
+++ b/fbgemm_gpu/src/quantize_ops/mx/common.cuh
@@ -1,0 +1,212 @@
+// @lint-ignore-every LICENSELINT
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Copyright (c) Microsoft Corporation.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef PYT_MX_COMMON_CUH
+#define PYT_MX_COMMON_CUH
+
+#include <cooperative_groups.h>
+#include <cuda.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <stdio.h>
+#include <algorithm>
+
+// Max threads per block for CUDA compute capability 2.x - 7.5 is 1024
+// Max threads for some CUDA random number generators is 256
+#define MAX_THREADS 1024
+#define WARP_SIZE 32
+
+#define FLOAT32_EXP_BIAS 127
+#define FLOAT32_EXP_MAX 255
+#define FLOAT32_TRAILING_MBITS 23
+#define FLOAT32_IMPLIED1 (1 << FLOAT32_TRAILING_MBITS)
+#define FLOAT32_FULL_MBITS (FLOAT32_TRAILING_MBITS + 1)
+#define FLOAT32_INF 0x7fe00000
+#define FLOAT32_EXP_OFFSET 23
+#define FLOAT32_SIGN_OFFSET 31
+#define FLOAT32_EXP_MASK 0x7f800000
+#define FLOAT32_MANTISSA_MASK 0x007fffff
+
+#define FLOAT16_MIN_NORMAL_EXP -14
+#define FLOAT16_MAX_EXP 15
+#define FLOAT16_EXP_BIAS 15
+
+//---------------------------------------------------------
+// Helper types/structs
+//---------------------------------------------------------
+typedef union {
+  unsigned int i;
+  float f;
+} u_float_int;
+
+typedef enum _RoundingMode {
+  rd_away = 0, // round nearest, ties to away
+  rd_floor = 1, // floor
+  rd_even = 2 // round nearest, ties to even
+} RoundingMode;
+
+//-----------------------------------------------------------------------
+// Bound the shared_exp based on ebits
+//-----------------------------------------------------------------------
+__host__ __device__ __forceinline__ int clamp_shared_exp(
+    int shared_exp,
+    const int ebits) {
+  // Set overflowing shared exps to NaN and
+  // bound underflowing shared exps to -emax
+  // Note that (for 8 bits) the min scale is -127, not -126
+  int emax = ebits != 0 ? (1 << (ebits - 1)) - 1 : FLOAT32_EXP_MAX;
+  int shared_ub = shared_exp - FLOAT32_EXP_BIAS;
+  shared_exp = shared_ub > emax ? FLOAT32_EXP_MAX : shared_exp;
+  shared_exp = shared_ub < -emax ? FLOAT32_EXP_BIAS - emax : shared_exp;
+  return shared_exp;
+}
+
+//---------------------------------------------------------
+// Helper functions for quantization
+//---------------------------------------------------------
+__host__ __device__ __forceinline__ int get_sign(const u_float_int input) {
+  int sign = input.i >> FLOAT32_SIGN_OFFSET;
+  return sign;
+}
+
+__host__ __device__ __forceinline__ int get_biased_exponent(
+    const u_float_int input) {
+  // Mask only exponent bits
+  int exp = input.i & FLOAT32_EXP_MASK;
+  // Shift down to lowest bits
+  exp = exp >> FLOAT32_EXP_OFFSET;
+  return exp;
+}
+
+__host__ __device__ __forceinline__ int get_biased_exponent(const float input) {
+  u_float_int u;
+  u.f = input;
+  return get_biased_exponent(u);
+}
+
+// get_unbiased_exponent supports denorms
+__host__ __device__ __forceinline__ int get_unbiased_exponent(
+    const float input) {
+  u_float_int u;
+  u.f = input;
+  int exp = get_biased_exponent(u);
+  if (exp == 0) {
+    // Denorm
+    return 1 - FLOAT32_EXP_BIAS;
+  } else {
+    return exp - FLOAT32_EXP_BIAS;
+  }
+}
+
+__host__ __device__ __forceinline__ int get_biased_exponent(
+    const __half input) {
+  u_float_int u;
+  u.f = __half2float(input);
+  return get_biased_exponent(u);
+}
+
+__host__ __device__ __forceinline__ int get_trailing_mantissa(
+    const u_float_int input) {
+  return input.i & FLOAT32_MANTISSA_MASK;
+}
+
+// Construct float from sign, biased exponent, and mantissa
+__host__ __device__ __forceinline__ float
+construct_float(int sign, int biased_exp, int trailing_mantissa) {
+  u_float_int x;
+  x.i = trailing_mantissa | (biased_exp << FLOAT32_EXP_OFFSET) |
+      (sign << FLOAT32_SIGN_OFFSET);
+  return x.f;
+}
+
+//---------------------------------------------------------
+// Shift right and round a float32 mantissa
+// Example of "allow_overflow". Say we are rounding 11111 to 4 bits
+// If allow_overflow is False, it will floor the result to 1111
+// If allow_overflow is True,  it will round up to 10000, overflowing 4 bits
+//---------------------------------------------------------
+__host__ __device__ __forceinline__ void shift_right_round_mantissa(
+    int& mantissa, // 23-bit float32 trailing mantissa
+    const bool is_subnorm, // is the input a subnorm?
+    const int mbits, // number to bits to round to
+    const int exp_diff, // extra right shifts
+    const RoundingMode rounding_mode,
+    const bool allow_overflow = false) {
+  // Implied 1
+  mantissa = is_subnorm ? mantissa : mantissa + FLOAT32_IMPLIED1;
+  int fp32_sig_bits = is_subnorm ? 23 : 24;
+
+  // RNE logic
+  bool tie = false;
+  bool even = false;
+  if (rounding_mode == rd_even) {
+    // tbits is the no. of bits that will be removed
+    int tbits = exp_diff + (fp32_sig_bits - mbits);
+    // 1 at all truncation locations except the first truncation location
+    int mask = (1 << (tbits - 1)) - 1;
+    // We have a tie only if all the truncation bits except the first
+    // one are zero. If the first truncation bit is 1, we have an
+    // actual tie. For rounding, we don't care if the first bits
+    // is 1 or 0. If it is 0, no rounding happens.
+    tie = !(mantissa & mask);
+    mask = (1 << tbits); // 1 at the first non-truncated location
+    even =
+        !(mantissa &
+          mask); // True if the last bit before truncation location is 0
+  }
+
+  // Adjust for shared exponent
+  mantissa = mantissa >> exp_diff;
+  // Shift down to target bit width + 1
+  mantissa = mantissa >> (fp32_sig_bits - mbits - 1);
+  // Rounding using floor(x+1), with overflow check
+  if ((rounding_mode == rd_away || rounding_mode == rd_even) &&
+      (allow_overflow || mantissa != ((1 << (mbits + 1)) - 1))) {
+    if (!(tie && even))
+      mantissa = mantissa + 1;
+  }
+  // Shift last bit away
+  mantissa = mantissa >> 1;
+}
+
+//---------------------------------------------------------
+// Shift back up to restore a float32 mantissa
+// Use in pair with shift_right_round_mantissa to check for
+// overflows caused by rounding
+//---------------------------------------------------------
+__host__ __device__ __forceinline__ bool shift_left_mantissa(
+    int& mantissa, // From shift_right_round_mantissa
+    const bool is_subnorm, // is the input a subnorm?
+    const int mbits,
+    const int exp_diff) {
+  int fp32_sig_bits = is_subnorm ? 23 : 24;
+  mantissa = mantissa << (fp32_sig_bits - mbits + exp_diff);
+  // Handle overflow.
+  // When a subnorm overflows (into a normal) we don't rshift
+  const bool overflow = (mantissa >= (1 << fp32_sig_bits));
+  mantissa = (overflow && !is_subnorm) ? mantissa >> 1 : mantissa;
+  // Remove implied 1
+  mantissa = mantissa & (FLOAT32_IMPLIED1 - 1);
+  return overflow;
+}
+
+#define gpuErrchk(ans) \
+  { gpuAssert((ans), __FILE__, __LINE__); }
+inline void
+gpuAssert(cudaError_t code, const char* file, int line, bool abort = true) {
+  if (code != cudaSuccess) {
+    fprintf(
+        stderr, "GPUassert: %s %s %d\n", cudaGetErrorString(code), file, line);
+    if (abort)
+      exit(code);
+  }
+}
+
+#endif

--- a/fbgemm_gpu/src/quantize_ops/mx_common.cuh
+++ b/fbgemm_gpu/src/quantize_ops/mx_common.cuh
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "mx/common.cuh"
+
+//-----------------------------------------------------------------------
+// MX4-Float mapping
+//-----------------------------------------------------------------------
+
+__device__ const float MX4_values[16] = {
+    0.0f,
+    0.5f,
+    1.0f,
+    1.5f,
+    2.0f,
+    3.0f,
+    4.0f,
+    6.0f,
+    -0.0f,
+    -0.5f,
+    -1.0f,
+    -1.5f,
+    -2.0f,
+    -3.0f,
+    -4.0f,
+    -6.0f};
+
+//-----------------------------------------------------------------------
+// Misc. helper functions
+//-----------------------------------------------------------------------
+
+inline uint32_t align(int a, int b) {
+  return (a + b - 1) / b * b;
+}
+
+// Refactor to use FBGEMM's
+__host__ __device__ __forceinline__ uint32_t round_up(uint32_t a, uint32_t b) {
+  return ((a + b - 1) / b);
+}
+
+//---------------------------------------------------------
+// Helper functions for quantization
+//---------------------------------------------------------
+
+__host__ __device__ __forceinline__ uint8_t
+// construct fp4 and store the 4 bit at the end
+construct_fp4(
+    const uint32_t sign,
+    const uint32_t new_biased_exp,
+    const uint32_t trailing_mantissa) {
+  const uint32_t f_4bit =
+      (trailing_mantissa >> 22) | (new_biased_exp << 1) | (sign << 3);
+  const uint8_t* ptr = reinterpret_cast<const uint8_t*>(&f_4bit);
+  return *ptr;
+}

--- a/fbgemm_gpu/src/quantize_ops/quantize_mx.cu
+++ b/fbgemm_gpu/src/quantize_ops/quantize_mx.cu
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAUtils.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <torch/types.h>
+
+#include "c10/core/ScalarType.h"
+#include "fbgemm_gpu/ops_utils.h"
+#include "fbgemm_gpu/sparse_ops_utils.h"
+
+#include "quantize_mx.cuh"
+
+namespace fbgemm_gpu {
+
+//-----------------------------------------------------------------------
+// quantize_mx_cuda
+//-----------------------------------------------------------------------
+DLL_PUBLIC at::Tensor quantize_mx_cuda(
+    const at::Tensor& input,
+    const std::vector<int64_t>& split_sizes,
+    const int64_t scale_bits,
+    const int64_t elem_ebits,
+    const int64_t elem_mbits,
+    const double elem_max_norm,
+    const int64_t mx_group_size,
+    const bool flush_fp32_subnorms = false,
+    const int64_t rounding_mode = 0) {
+  TORCH_CHECK((split_sizes.size() > 0), "Input split sizes cannot be empty");
+  TORCH_CHECK((mx_group_size % 32 == 0), "Group size needs to be power of 2");
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(input);
+
+  at::Device device = input.device();
+  const at::cuda::CUDAGuard device_guard{device};
+  const uint32_t total_elems = input.numel();
+  const uint32_t total_num_groups = input.numel() / mx_group_size;
+
+  // Compute offsets to be passed to kernel
+  auto start_output_cumsum =
+      at::empty(split_sizes.size() + 1, at::TensorOptions().dtype(at::kUInt32));
+  auto group_ids =
+      at::empty(total_num_groups, at::TensorOptions().dtype(at::kUInt32));
+  auto num_groups_cumsum =
+      at::empty(split_sizes.size() + 1, at::TensorOptions().dtype(at::kUInt32));
+  uint32_t offset = 0;
+  start_output_cumsum[0] = 0;
+  num_groups_cumsum[0] = 0;
+  uint32_t num_groups_cumsum_ = 0;
+  int64_t start_idx = 0;
+  int64_t end_idx = 0;
+  for (int i = 0; i < split_sizes.size(); i++) {
+    const uint32_t split_size = split_sizes[i];
+
+    TORCH_CHECK(
+        split_size % mx_group_size == 0,
+        " Number of inputs needs to be a multiple of group size");
+    const uint32_t num_groups = split_size / mx_group_size;
+    end_idx += num_groups;
+    offset += align((split_size / 2) + num_groups, 16);
+    start_output_cumsum[i + 1] = offset;
+    num_groups_cumsum_ += num_groups;
+    num_groups_cumsum[i + 1] = num_groups_cumsum_;
+    group_ids.index_put_({at::indexing::Slice(start_idx, end_idx)}, i);
+    start_idx = end_idx;
+  }
+
+  // TODO: Search in the kernel
+  start_output_cumsum = start_output_cumsum.to(device, /*non_blocking=*/true);
+  group_ids = group_ids.to(device, /*non_blocking=*/true);
+  num_groups_cumsum = num_groups_cumsum.to(device, /*non_blocking=*/true);
+
+  RoundingMode rd = static_cast<RoundingMode>(rounding_mode);
+
+  const int num_groups_per_block = MAX_THREADS / mx_group_size;
+  const auto gridDim_x = round_up(total_num_groups, num_groups_per_block);
+
+  const dim3 gridDim(gridDim_x);
+  const dim3 blockDim(mx_group_size, num_groups_per_block);
+
+  // Use shmem to find max exponent (int) and temporarily store output (unint8)
+  // max(num_elem_in_block * sizeof(int), num_elem_in_block /2 * sizeof(uint8))
+  const int smem_size = num_groups_per_block * mx_group_size * (sizeof(int));
+  auto output = at::empty(
+      offset, // 4 = sizeof(float)
+      input.options().dtype(at::kByte));
+  // Call CUDA kernel
+  if (input.dtype() == torch::ScalarType::Half) {
+    AT_ASSERTM(0, " fp16 not supported for MX");
+  } else {
+    quantize_float_to_mx4_kernel<<<gridDim, blockDim, smem_size>>>(
+        input.data_ptr<float>(),
+        mx_group_size,
+        group_ids.data_ptr<uint32_t>(),
+        start_output_cumsum.data_ptr<uint32_t>(),
+        num_groups_cumsum.data_ptr<uint32_t>(),
+        total_elems,
+        flush_fp32_subnorms,
+        rd,
+        output.data_ptr<uint8_t>());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+
+  gpuErrchk(cudaPeekAtLastError());
+  return output;
+}
+
+DLL_PUBLIC at::Tensor dequantize_mx_cuda(
+    const at::Tensor& input,
+    const std::vector<int64_t>& split_sizes,
+    const int64_t mx_group_size) {
+  TORCH_CHECK((split_sizes.size() > 0), "Input sizes cannot be empty");
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(input);
+  at::Device device = input.device();
+  const at::cuda::CUDAGuard device_guard{device};
+  const int64_t total_elems =
+      std::accumulate(split_sizes.begin(), split_sizes.end(), 0);
+  const uint32_t total_num_groups = total_elems / mx_group_size;
+
+  auto start_output_cumsum =
+      at::empty(split_sizes.size() + 1, at::TensorOptions().dtype(at::kUInt32));
+  auto group_ids =
+      at::empty(total_num_groups, at::TensorOptions().dtype(at::kUInt32));
+  auto num_groups_cumsum =
+      at::empty(split_sizes.size() + 1, at::TensorOptions().dtype(at::kUInt32));
+  uint32_t offset = 0;
+  start_output_cumsum[0] = 0;
+  num_groups_cumsum[0] = 0;
+  uint32_t num_groups_cumsum_ = 0;
+  int64_t start_idx = 0;
+  int64_t end_idx = 0;
+
+  for (int i = 0; i < split_sizes.size(); i++) {
+    const uint32_t split_size = split_sizes[i];
+
+    TORCH_CHECK(
+        split_size % mx_group_size == 0,
+        " Number of inputs needs to be a multiple of group size");
+    const uint32_t num_groups = split_size / mx_group_size;
+    end_idx += num_groups;
+    offset += align((split_size / 2) + num_groups, 16);
+    start_output_cumsum[i + 1] = offset;
+    num_groups_cumsum_ += num_groups;
+    num_groups_cumsum[i + 1] = num_groups_cumsum_;
+    group_ids.index_put_({at::indexing::Slice(start_idx, end_idx)}, i);
+    start_idx = end_idx;
+  }
+  start_output_cumsum = start_output_cumsum.to(device, /*non_blocking=*/true);
+  group_ids = group_ids.to(device, /*non_blocking=*/true);
+  num_groups_cumsum = num_groups_cumsum.to(device, /*non_blocking=*/true);
+
+  auto output = at::empty(
+      total_elems, // 4 = sizeof(float)
+      input.options().dtype(at::kFloat));
+  const int num_groups_per_block = MAX_THREADS / mx_group_size;
+  const auto gridDim_x = round_up(total_num_groups, num_groups_per_block);
+
+  const dim3 gridDim(gridDim_x);
+  const dim3 blockDim(mx_group_size, num_groups_per_block);
+
+  // Call CUDA kernel
+  if (input.dtype() == torch::ScalarType::Half) {
+    AT_ASSERTM(0, " fp16 not supported for MX");
+  } else {
+    dequantize_mx4_to_float_kernel<<<gridDim, blockDim>>>(
+        input.data_ptr<uint8_t>(),
+        mx_group_size,
+        total_elems,
+        group_ids.data_ptr<uint32_t>(),
+        start_output_cumsum.data_ptr<uint32_t>(),
+        num_groups_cumsum.data_ptr<uint32_t>(),
+        output.data_ptr<float>());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+
+  gpuErrchk(cudaPeekAtLastError());
+  return output;
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/quantize_ops/quantize_mx.cuh
+++ b/fbgemm_gpu/src/quantize_ops/quantize_mx.cuh
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * Microsoft Confidential
+ */
+
+#ifndef PYT_MX_MX_CUH
+#define PYT_MX_MX_CUH
+
+#include "mx_common.cuh"
+
+//-----------------------------------------------------------------------
+// quantize implementation float to fp4
+// For MX4, input float to the function must have already been scaled by
+// the shared exponent. Output will be 4-bit stored in 8-bit data type
+// The 4-bit output is mapped to 16 values for dequantization
+//-----------------------------------------------------------------------
+
+__device__ __forceinline__ uint8_t quantize_elemwise_4bit(
+    const float input,
+    const int bits, // bits = mantissa bits + sign bit
+    const int exp_bits, // exp_bits == 0 indicates integer dtype
+    const float max_norm,
+    const RoundingMode rounding_mode = rd_away,
+    const bool saturate_normals = false,
+    const bool allow_denorm = true) {
+  u_float_int input_;
+  input_.f = input;
+
+  // TODO: Refactor to return unsigned data
+  int biased_exp = get_biased_exponent(input_);
+  int sign = get_sign(input_);
+  int tmant = get_trailing_mantissa(input_);
+
+  // Mantissa bits to quantize to (remove sign)
+  const int mbits = bits - 1;
+  const bool is_int = exp_bits == 0;
+
+  // Integers can be treated has having exp bias of 1
+  const int new_bias = is_int ? 1 : (1 << (exp_bits - 1)) - 1;
+  int new_biased_exp = biased_exp - FLOAT32_EXP_BIAS + new_bias;
+
+  // Skip denorms
+  if ((!is_int) && (!allow_denorm) && (new_biased_exp < 1)) {
+    return 0.0;
+  }
+
+  // Use exp_diff to truncate additional bits for subnorms
+  // mbits includes implicit 1, so when new_biased_exp==0
+  // we want exp_diff = 1 to truncate away 1 bit
+  int exp_diff = (new_biased_exp <= 0) ? 1 - new_biased_exp : 0;
+  exp_diff = (exp_diff > FLOAT32_FULL_MBITS) ? FLOAT32_FULL_MBITS : exp_diff;
+
+  // Shift down and round mantissa, allow overflow except for integers
+  // This converts tmant into a full mantissa
+  shift_right_round_mantissa(
+      tmant, biased_exp == 0, mbits, exp_diff, rounding_mode, !is_int);
+
+  if (tmant == 0) {
+    return 0.0;
+  }
+
+  // Shift back up to restore mantissa
+  // This converts back to a trailing mantissa
+  const bool overflow =
+      shift_left_mantissa(tmant, biased_exp == 0, mbits, exp_diff);
+  if (overflow) {
+    biased_exp = biased_exp + 1;
+    new_biased_exp = new_biased_exp + 1;
+  }
+
+  // Reconstruct float number
+  const float output = construct_float(sign, biased_exp, tmant);
+
+  /* Convert float to MX4 encodings:
+    bits  FP4     [int4 lookup]
+                    +  - (sign)
+    S000 = 0    <=> 0  8
+    S001 = 0.5  <=> 1  9
+    S010 = 1    <=> 2  10
+    S011 = 1.5  <=> 3  11
+    S100 = 2.0  <=> 4  12
+    S101 = 3.0  <=> 5  13
+    S110 = 4.0  <=> 6  14
+    S111 = 6.0  <=> 7  15
+  */
+
+  // construct the 4 bit using 1-bit sign, 2-bit new_exp 1-bit tmant
+  // |0.5f| is the exception since it has tmant of 0 instead of 1
+  // return the lookup value
+  if (output == 0.5f) {
+    return 1; // bits 0001
+  } else if (output == -0.5f) {
+    return 9; // bits 1001
+  }
+
+  // Return Inf if rounded value is out of bounds,
+  // unless target format is integer or saturate_normals==True
+  if (abs(output) > max_norm) {
+    if (is_int || saturate_normals) {
+      // max norm = 6.0f => bias=3, tmant = 1, sign remains the same
+      new_biased_exp = 3;
+      tmant = 4194304; // bit 10000000000000000000000
+    } else {
+      // TODO: set Inf for 4 bit for other patterns
+      new_biased_exp = 0xFF;
+      tmant = 0;
+      // e2m1 has no inf
+      CUDA_KERNEL_ASSERT(false);
+    }
+  }
+  CUDA_KERNEL_ASSERT(new_biased_exp >= 0 && new_biased_exp <= 3);
+  return construct_fp4(sign, new_biased_exp, tmant);
+}
+
+//-----------------------------------------------------------------------
+// quantize float to mx4 kernel
+//-----------------------------------------------------------------------
+
+template <typename T>
+__global__ void quantize_float_to_mx4_kernel(
+    const T* __restrict__ input,
+    const int group_size, // can change to Blockdim.x
+    const uint32_t* __restrict__ group_ids,
+    const uint32_t* __restrict__ start_output_cumsum,
+    const uint32_t* __restrict__ num_groups_cumsum,
+    const uint32_t total_elems,
+    const bool flush_fp32_subnorms,
+    const RoundingMode rounding_mode,
+    uint8_t* __restrict__ output) {
+  const auto linear_group_id = (blockIdx.x * blockDim.y) + threadIdx.y;
+  const auto linear_tid = linear_group_id * group_size + threadIdx.x;
+  if (linear_tid >= total_elems)
+    return;
+
+  const uint32_t rank_id = group_ids[linear_group_id];
+  const uint32_t accum_num_groups = num_groups_cumsum[rank_id];
+  const uint32_t num_elems_per_rank =
+      (num_groups_cumsum[rank_id + 1] - accum_num_groups) * group_size;
+  const uint32_t start_output_idx = start_output_cumsum[rank_id];
+
+  // offsets for within rank to write quantized data and shared_exponent
+  const uint32_t group_id_in_rank = linear_group_id - accum_num_groups;
+
+  // MX4 values
+  constexpr int scale_bits = 8;
+  constexpr int elem_ebits = 2;
+  constexpr int elem_mbits = 3;
+  constexpr float elem_max_norm = 6.0;
+  constexpr int elem_emax = 2;
+
+  const T elem = input[linear_tid];
+
+  extern __shared__ __align__(16) float smem[];
+  const uint32_t group_offset_in_block = threadIdx.y * group_size;
+  // set smem base address for each group
+  int* smem_base = reinterpret_cast<int*>(smem + group_offset_in_block);
+
+  // // allreduce to get the max value in each group size
+  int shared_exp = get_biased_exponent(elem);
+  smem_base[threadIdx.x] = shared_exp;
+  __syncthreads();
+
+  const uint32_t half_group_size = group_size / 2;
+
+  for (uint32_t s = half_group_size; s > 0; s >>= 1) {
+    if (threadIdx.x < s) {
+      smem_base[threadIdx.x] =
+          max(smem_base[threadIdx.x], smem_base[threadIdx.x + s]);
+    }
+    __syncthreads();
+  }
+  // get shared_exponent stored at tid = 0
+  shared_exp = smem_base[0];
+
+  // Offset shared exponent by elem_emax, preserve NaNs
+  shared_exp =
+      (shared_exp != FLOAT32_EXP_MAX) ? shared_exp - elem_emax : shared_exp;
+
+  // Clamp to scale_bits range
+  const uint8_t clamped_shared_exp = clamp_shared_exp(shared_exp, scale_bits);
+
+  const bool flush_tile = (shared_exp == 0 && flush_fp32_subnorms);
+
+  // Divided by 2^shared_exp
+  const T scaled_in =
+      flush_tile ? 0 : elem / pow(2.0f, clamped_shared_exp - FLOAT32_EXP_BIAS);
+
+  // convert to FP4 -> there is 16 possible values
+  // bit pattern of the uint8 result is `0000 xxxx`
+  const uint8_t quantized_val = quantize_elemwise_4bit(
+      scaled_in,
+      elem_mbits,
+      elem_ebits,
+      elem_max_norm,
+      rounding_mode,
+      true,
+      true);
+
+  // Store 2 `quantized_val` in one uint8
+  // let even threads store their 4-bit quantized_val on the left (position 4-7)
+  // and odd threads store on right (position 0-3)
+  uint8_t* stored_8bit =
+      reinterpret_cast<uint8_t*>(smem_base) + (threadIdx.x / 2);
+  const auto is_even_tid = threadIdx.x % 2 == 0;
+
+  // even thread work on the left side
+  if (is_even_tid) {
+    // the 4 bits are on the rightmost, need to shift 4 bit
+    // this becomes `xxxx 0000`
+    *stored_8bit = (quantized_val << 4);
+  }
+  __syncthreads();
+
+  // odd threads work on the right side (position 0-3)
+  if (!is_even_tid) {
+    // 4 bits are already on the rightmost, so just `bitwise OR` to combine
+    *stored_8bit |= quantized_val;
+  }
+  __syncthreads();
+
+  // Let only thread0 write output data and shared exponent
+  if (threadIdx.x == 0) {
+    // write data output using float4 (16 bytes)
+    // 1 output is 1 byte, we write 16 outputs in 1 float4
+    // group_size needs to be multiple of 32 so that the output
+    // will be multiple of 16 bytes
+    const int num_vecs = group_size / 32;
+    // smem is float, move every 4 bytes
+    // need to move half_group_size / 4
+    float4* smem_ptr = reinterpret_cast<float4*>(smem_base);
+    uint8_t* output_base = &output[start_output_idx];
+    float4* output_ptr = reinterpret_cast<float4*>(
+        output_base + group_id_in_rank * half_group_size);
+    for (int i = 0; i < num_vecs; i++) {
+      output_ptr[i] = smem_ptr[i];
+    }
+    // shared_exp_idx is stored after data
+    // need to offset with start_output + output data
+    const uint32_t shared_exp_offset =
+        (num_elems_per_rank / 2) + group_id_in_rank;
+    output_base[shared_exp_offset] = clamped_shared_exp;
+  }
+}
+
+//-----------------------------------------------------------------------
+// quantize mx4 to float kernel
+//-----------------------------------------------------------------------
+
+template <typename T>
+__global__ void dequantize_mx4_to_float_kernel(
+    const uint8_t* __restrict__ input,
+    const int group_size,
+    const int64_t total_elems,
+    const uint32_t* __restrict__ group_ids,
+    const uint32_t* __restrict__ start_output_cumsum,
+    const uint32_t* __restrict__ num_groups_cumsum,
+    T* __restrict__ output) {
+  const auto linear_group_id = (blockIdx.x * blockDim.y) + threadIdx.y;
+  const auto linear_tid = linear_group_id * group_size + threadIdx.x;
+  if (linear_tid >= total_elems)
+    return;
+
+  const uint32_t rank_id = group_ids[linear_group_id];
+  const uint32_t accum_num_groups = num_groups_cumsum[rank_id];
+  const uint32_t num_groups_per_rank =
+      num_groups_cumsum[rank_id + 1] - accum_num_groups;
+  const uint32_t num_elems_per_rank = num_groups_per_rank * group_size;
+  const uint32_t start_output_idx = start_output_cumsum[rank_id];
+
+  const uint32_t tid_in_rank = linear_tid - (accum_num_groups * group_size);
+  const uint32_t group_id_in_rank = linear_group_id - accum_num_groups;
+
+  const uint32_t shared_exp_idx =
+      start_output_idx + (num_elems_per_rank / 2) + group_id_in_rank;
+  const uint32_t output_idx = start_output_idx + round_up(tid_in_rank - 1, 2);
+
+  uint8_t elem = input[output_idx];
+
+  constexpr uint8_t upper_4bit_mask = 0xF0;
+  constexpr uint8_t lower_4bit_mask = 0x0F;
+  // even threads take care of 4 bit on the left
+  // odd threads, the right
+  if (uint32_t(threadIdx.x % 2) == 0) {
+    // shift the 4-bit to the end for even threads
+    elem = (elem & upper_4bit_mask);
+    elem = (elem >> 4);
+  } else {
+    elem = (elem & lower_4bit_mask);
+  }
+  CUDA_KERNEL_ASSERT(elem < 16);
+
+  const uint8_t shared_exp = input[shared_exp_idx];
+  output[linear_tid] = MX4_values[elem] * pow(2, shared_exp - FLOAT32_EXP_BIAS);
+}
+
+#endif

--- a/fbgemm_gpu/src/quantize_ops/quantize_ops_cpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops/quantize_ops_cpu.cpp
@@ -471,6 +471,10 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "MSFPQuantizedToFloat(Tensor input, int ebits, int mbits, int bias) -> Tensor");
   m.def(
       "PaddedFP8RowwiseQuantizedToFloat(Tensor input, bool forward, int row_dim, int output_last_dim=-1, int output_dtype=0) -> Tensor");
+  m.def(
+      "quantize_mx_cuda(Tensor input, int[] split_sizes, int scale_bits, int elem_ebits, int elem_mbits, float elem_max_norm, int mx_group_size, bool flush_fp32_subnorms=False, int rounding_mode=0) -> Tensor");
+  m.def(
+      "dequantize_mx_cuda(Tensor input, int[] split_sizes, int mx_group_size) -> Tensor");
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {

--- a/fbgemm_gpu/src/quantize_ops/quantize_ops_gpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops/quantize_ops_gpu.cpp
@@ -33,3 +33,5 @@ FBGEMM_OP_DISPATCH(
     CUDA,
     "PaddedFP8RowwiseQuantizedToFloat",
     fbgemm_gpu::_paddedFP8rowwise_to_float_gpu);
+FBGEMM_OP_DISPATCH(CUDA, "quantize_mx_cuda", fbgemm_gpu::quantize_mx_cuda);
+FBGEMM_OP_DISPATCH(CUDA, "dequantize_mx_cuda", fbgemm_gpu::dequantize_mx_cuda);


### PR DESCRIPTION
Summary:
Implement MX4 quantization-dequantization ops

Usage:
**Quantization:**
```
quantized_output = torch.ops.fbgemm.quantize_mx_cuda(
            A,
            split_sizes,
            scale_bits=8,
            ebits=2,
            mbits=3,
            max_norm=6.0f,
            mx_group_size=32,
        )
```
where 
`A` is 1-D input tensor and
`split_sizes` is list of int containing number of elements in each rank e.g., `split_sizes = [1024, 2048]` for 2 ranks. Note that each value needs to be a multiple of `group size`.
The output is ensured to be 16-byte aligned. Anything less than 16 bytes is padded to make 16 bytes.
Given that the `group_size` is 32, for the best performance, the value should be a multiple of 32 x 16 = 512. 

**Dequantization:**
```
dequanted_output = torch.ops.fbgemm.dequantize_mx_cuda(
            quantized_output,
            split_sizes,
            mx_group_size=32,
        )
```

Reviewed By: sryap

Differential Revision: D57145102


