### PR TITLE
Implement PS KV DB for FBGEMM TBE operator

### DIFF
--- a/fbgemm_gpu/src/ps_split_embeddings_cache/ps_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ps_split_embeddings_cache/ps_split_table_batched_embeddings.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "./ps_table_batched_embeddings.h"
+
+#include <torch/custom_class.h>
+#include "fbgemm_gpu/sparse_ops_utils.h"
+
+using namespace at;
+using namespace ps;
+
+namespace {
+class EmbeddingParameterServerWrapper : public torch::jit::CustomClassHolder {
+ public:
+  EmbeddingParameterServerWrapper(
+      const std::vector<std::string>& tps_ips,
+      const std::vector<int64_t>& tps_ports,
+      int64_t tbe_id,
+      int64_t maxLocalIndexLength = 54,
+      int64_t num_threads = 32) {
+    TORCH_CHECK(
+        tps_ips.size() == tps_ports.size(),
+        "tps_ips and tps_ports must have the same size");
+    std::vector<std::pair<std::string, int>> tpsHosts = {};
+    for (int i = 0; i < tps_ips.size(); i++) {
+      tpsHosts.push_back(std::make_pair(tps_ips[i], tps_ports[i]));
+    }
+
+    impl_ = std::make_shared<ps::EmbeddingParameterServer>(
+        std::move(tpsHosts), tbe_id, maxLocalIndexLength, num_threads);
+  }
+
+  void
+  set_cuda(Tensor indices, Tensor weights, Tensor count, int64_t timestep) {
+    return impl_->set_cuda(indices, weights, count, timestep);
+  }
+
+  void get_cuda(Tensor indices, Tensor weights, Tensor count) {
+    return impl_->get_cuda(indices, weights, count);
+  }
+
+  void set(Tensor indices, Tensor weights, Tensor count) {
+    return impl_->set(indices, weights, count);
+  }
+
+  void get(Tensor indices, Tensor weights, Tensor count) {
+    return impl_->get(indices, weights, count);
+  }
+
+  void compact() {
+    return impl_->compact();
+  }
+
+  void flush() {
+    return impl_->flush();
+  }
+
+  void cleanup() {
+    return impl_->cleanup();
+  }
+
+ private:
+  // shared pointer since we use shared_from_this() in callbacks.
+  std::shared_ptr<EmbeddingParameterServer> impl_;
+};
+
+static auto embedding_parameter_server_wrapper =
+    torch::class_<EmbeddingParameterServerWrapper>(
+        "fbgemm",
+        "EmbeddingParameterServerWrapper")
+        .def(torch::init<
+             const std::vector<std::string>,
+             const std::vector<int64_t>,
+             int64_t,
+             int64_t,
+             int64_t>())
+        .def("set_cuda", &EmbeddingParameterServerWrapper::set_cuda)
+        .def("get_cuda", &EmbeddingParameterServerWrapper::get_cuda)
+        .def("compact", &EmbeddingParameterServerWrapper::compact)
+        .def("flush", &EmbeddingParameterServerWrapper::flush)
+        .def("set", &EmbeddingParameterServerWrapper::set)
+        .def("get", &EmbeddingParameterServerWrapper::get)
+        .def("cleanup", &EmbeddingParameterServerWrapper::cleanup);
+} // namespace

--- a/fbgemm_gpu/src/ps_split_embeddings_cache/ps_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ps_split_embeddings_cache/ps_table_batched_embeddings.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include "../ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h"
+
+#include <folly/experimental/coro/BlockingWait.h>
+#include "mvai_infra/experimental/ps_training/tps_client/TrainingParameterServiceClient.h"
+
+namespace ps {
+
+class EmbeddingParameterServer : public kv_db::EmbeddingKVDB {
+ public:
+  explicit EmbeddingParameterServer(
+      std::vector<std::pair<std::string, int>>&& tps_hosts,
+      int64_t tbe_id,
+      int64_t maxLocalIndexLength = 54,
+      int64_t num_threads = 32)
+      : tps_client_(
+            std::make_shared<mvai_infra::experimental::ps_training::tps_client::
+                                 TrainingParameterServiceClient>(
+                std::move(tps_hosts),
+                tbe_id,
+                maxLocalIndexLength,
+                num_threads)) {}
+
+  void set(
+      const at::Tensor& indices,
+      const at::Tensor& weights,
+      const at::Tensor& count) override {
+    RECORD_USER_SCOPE("EmbeddingParameterServer::set");
+    folly::coro::blockingWait(
+        tps_client_->set(indices, weights, count.item().toLong()));
+  }
+  void get(
+      const at::Tensor& indices,
+      const at::Tensor& weights,
+      const at::Tensor& count) override {
+    RECORD_USER_SCOPE("EmbeddingParameterServer::get");
+    folly::coro::blockingWait(
+        tps_client_->get(indices, weights, count.item().toLong()));
+  }
+  void flush() override {}
+  void compact() override {}
+  // cleanup cached results in server side
+  // This is a test helper, please do not use it in production
+  void cleanup() {
+    folly::coro::blockingWait(tps_client_->cleanup());
+  }
+
+ private:
+  void flush_or_compact(const int64_t /*timestep*/) override {}
+
+  std::shared_ptr<mvai_infra::experimental::ps_training::tps_client::
+                      TrainingParameterServiceClient>
+      tps_client_;
+}; // class EmbeddingKVDB
+
+} // namespace ps


### PR DESCRIPTION
Summary:
Implemented kv_db::EmbeddingKVDB interface to connect remote PS service instead of using local SSD based rocksDB embedding.
Initialize PS KV DB when ps_hosts is not None.

Differential Revision: D56715840


