### PR TITLE
Remove D->H sync when calling lxu_cache_lookup

### DIFF
--- a/fbgemm_gpu/bench/ssd_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/ssd_table_batched_embeddings_benchmark.py
@@ -8,8 +8,10 @@
 # pyre-strict
 
 import logging
+import os
 import tempfile
 import time
+from contextlib import nullcontext
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import click
@@ -39,6 +41,7 @@ from fbgemm_gpu.ssd_split_table_batched_embeddings_ops import (
     # Training
     SSDTableBatchedEmbeddingBags,
 )
+from torch.profiler import profile
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -233,6 +236,12 @@ def ssd_read_write(
 @click.option("--tables", type=str, default=None)
 @click.option("--ssd-prefix", type=str, default="/tmp/ssd_benchmark")
 @click.option("--block-cache-size-mb", default=0)
+@click.option("--export-trace", is_flag=True, default=False)
+@click.option(
+    "--trace-url",
+    type=str,
+    default="manifold://gpu_traces/tree/fbgemm_gpu/ssd_tbe/trace_{ospid}.json",
+)
 def ssd_training(  # noqa C901
     alpha: float,
     bag_size: int,
@@ -257,6 +266,8 @@ def ssd_training(  # noqa C901
     tables: Optional[str],
     ssd_prefix: Optional[str],
     block_cache_size_mb: int,
+    export_trace: bool,
+    trace_url: str,
 ) -> None:
     np.random.seed(42)
     torch.manual_seed(42)
@@ -417,59 +428,67 @@ def ssd_training(  # noqa C901
             feature_requires_grad=feature_requires_grad,
         )
 
-    # Execute tests
-    report = []
-    nparams = 0
-    for prefix, generator in tbe_generators.items():
-        # Instantiate TBE
-        emb = generator().to(get_device())
+    def _kineto_trace_handler(p: profile) -> None:
+        p.export_chrome_trace(trace_url.format(ospid=os.getpid()))
 
-        # Forward
-        test_name = f"{prefix} Forward"
-        logging.info(f"Running benchmark: {test_name}")
+    prof_ctx = (
+        profile(on_trace_ready=_kineto_trace_handler) if export_trace else nullcontext()
+    )
 
-        time_per_iter = benchmark_requests(
-            requests,
-            gen_forward_func(emb, feature_requires_grad),
-            flush_gpu_cache_size_mb=flush_gpu_cache_size_mb,
-            num_warmups=warmup_runs,
-            periodic_logs=True,
-        )
+    with prof_ctx:
+        # Execute tests
+        report = []
+        nparams = 0
+        for prefix, generator in tbe_generators.items():
+            # Instantiate TBE
+            emb = generator().to(get_device())
 
-        bw = f"{read_write_bytes / time_per_iter / 1.0e9: .2f}"
-        report.append(
-            f"{test_name: <{name_width}} B: {B}, "
-            f"E: {E}, T: {T}, D: {D}, L: {L}, W: {weighted}, "
-            f"BW: {bw: <{bw_width}} GB/s, "  # noqa: B950
-            f"T: {time_per_iter * 1.0e6:.0f}us"
-        )
+            # Forward
+            test_name = f"{prefix} Forward"
+            logging.info(f"Running benchmark: {test_name}")
 
-        # Backward
-        test_name = f"{prefix} Backward,"
-        logging.info(f"Running benchmark: {test_name}")
-        time_per_iter = benchmark_requests(
-            requests,
-            gen_forward_func(emb, feature_requires_grad),
-            flush_gpu_cache_size_mb=flush_gpu_cache_size_mb,
-            bwd_only=True,
-            grad=grad_output,
-            num_warmups=warmup_runs,
-            periodic_logs=True,
-        )
+            time_per_iter = benchmark_requests(
+                requests,
+                gen_forward_func(emb, feature_requires_grad),
+                flush_gpu_cache_size_mb=flush_gpu_cache_size_mb,
+                num_warmups=warmup_runs,
+                periodic_logs=True,
+            )
 
-        bw = f"{2 * read_write_bytes / time_per_iter / 1.0e9: .2f}"
-        report.append(
-            f"{test_name: <{name_width}} B: {B}, E: {E}, T: {T}, D: {D}, L: {L}, W: {weighted}, "
-            f"BW: {bw: <{bw_width}} GB/s, "
-            f"T: {time_per_iter * 1.0e6:.0f}us"
-        )
+            bw = f"{read_write_bytes / time_per_iter / 1.0e9: .2f}"
+            report.append(
+                f"{test_name: <{name_width}} B: {B}, "
+                f"E: {E}, T: {T}, D: {D}, L: {L}, W: {weighted}, "
+                f"BW: {bw: <{bw_width}} GB/s, "  # noqa: B950
+                f"T: {time_per_iter * 1.0e6:.0f}us"
+            )
 
-        # Compute nparams once
-        if prefix == "HBM":
-            nparams = sum(w.numel() for w in emb.split_embedding_weights())
+            # Backward
+            test_name = f"{prefix} Backward,"
+            logging.info(f"Running benchmark: {test_name}")
+            time_per_iter = benchmark_requests(
+                requests,
+                gen_forward_func(emb, feature_requires_grad),
+                flush_gpu_cache_size_mb=flush_gpu_cache_size_mb,
+                bwd_only=True,
+                grad=grad_output,
+                num_warmups=warmup_runs,
+                periodic_logs=True,
+            )
 
-        # Delete module to make room for other modules
-        del emb
+            bw = f"{2 * read_write_bytes / time_per_iter / 1.0e9: .2f}"
+            report.append(
+                f"{test_name: <{name_width}} B: {B}, E: {E}, T: {T}, D: {D}, L: {L}, W: {weighted}, "
+                f"BW: {bw: <{bw_width}} GB/s, "
+                f"T: {time_per_iter * 1.0e6:.0f}us"
+            )
+
+            # Compute nparams once
+            if prefix == "HBM":
+                nparams = sum(w.numel() for w in emb.split_embedding_weights())
+
+            # Delete module to make room for other modules
+            del emb
 
     # Print report
     logging.info(

--- a/fbgemm_gpu/fbgemm_gpu/ssd_split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/ssd_split_table_batched_embeddings_ops.py
@@ -415,29 +415,33 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         inserted_indices: torch.Tensor,
         actions_count_cpu: torch.Tensor,
     ) -> torch.Tensor:
-        lxu_cache_locations = torch.ops.fbgemm.lxu_cache_lookup(
-            linear_cache_indices,
-            self.lxu_cache_state,
-            self.hash_size_cumsum[-1].item(),
-        )
-        lxu_cache_ptrs, post_bwd_evicted_indices = (
-            torch.ops.fbgemm.ssd_generate_row_addrs(
-                lxu_cache_locations,
-                assigned_cache_slots,
-                linear_index_inverse_indices,
-                unique_indices_count_cumsum,
-                cache_set_inverse_indices,
-                self.lxu_cache_weights,
-                inserted_rows_gpu,
-                unique_indices_length,
-                inserted_indices,
+        with record_function("## ssd_tbe_lxu_cache_lookup ##"):
+            lxu_cache_locations = torch.ops.fbgemm.lxu_cache_lookup(
+                linear_cache_indices,
+                self.lxu_cache_state,
+                self.hash_size_cumsum[-1].item(),
             )
-        )
-        # Store scratch pad info for post backward eviction
-        self.ssd_scratch_pads.append(
-            (inserted_rows_gpu, post_bwd_evicted_indices, actions_count_cpu)
-        )
-        assert lxu_cache_ptrs[lxu_cache_ptrs == 0].numel() == 0
+
+        with record_function("## ssd_generate_row_addrs ##"):
+            lxu_cache_ptrs, post_bwd_evicted_indices = (
+                torch.ops.fbgemm.ssd_generate_row_addrs(
+                    lxu_cache_locations,
+                    assigned_cache_slots,
+                    linear_index_inverse_indices,
+                    unique_indices_count_cumsum,
+                    cache_set_inverse_indices,
+                    self.lxu_cache_weights,
+                    inserted_rows_gpu,
+                    unique_indices_length,
+                    inserted_indices,
+                )
+            )
+        with record_function("## ssd_scratch_pads ##"):
+            # Store scratch pad info for post backward eviction
+            self.ssd_scratch_pads.append(
+                (inserted_rows_gpu, post_bwd_evicted_indices, actions_count_cpu)
+            )
+            assert lxu_cache_ptrs[lxu_cache_ptrs == 0].numel() == 0
         return (
             lxu_cache_ptrs,
             inserted_rows_gpu,

--- a/fbgemm_gpu/fbgemm_gpu/ssd_split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/ssd_split_table_batched_embeddings_ops.py
@@ -419,7 +419,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             lxu_cache_locations = torch.ops.fbgemm.lxu_cache_lookup(
                 linear_cache_indices,
                 self.lxu_cache_state,
-                self.hash_size_cumsum[-1].item(),
+                self.total_hash_size,
             )
 
         with record_function("## ssd_generate_row_addrs ##"):
@@ -441,7 +441,6 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             self.ssd_scratch_pads.append(
                 (inserted_rows_gpu, post_bwd_evicted_indices, actions_count_cpu)
             )
-            assert lxu_cache_ptrs[lxu_cache_ptrs == 0].numel() == 0
         return (
             lxu_cache_ptrs,
             inserted_rows_gpu,
@@ -1092,7 +1091,7 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
         lxu_cache_locations = torch.ops.fbgemm.lxu_cache_lookup(
             linear_cache_indices,
             self.lxu_cache_state,
-            self.hash_size_cumsum[-1].item(),
+            self.total_hash_size,
         )
 
         self.timestep_prefetch_size.decrement()


### PR DESCRIPTION
Summary:
Prior to this diff, SSD-TBE called `.item()` to obtain the total hash
size when calling `lxu_cache_lookup`.  It was used as a sentinel value
for identifying invalid indices in the cache.  `.item()` is expensive
since it transfers data from device to host which causes the device and
host synchronization.  Since this information is already available on
this, this diff replaces `.item()` with `self.total_hash_size` which
contains the total hash size information on host.

Differential Revision: D58112318


