### PR TITLE
Add cache sets > 0 assertion

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/ssd_split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/ssd_split_table_batched_embeddings_ops.py
@@ -847,6 +847,7 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
                 hash_size_cumsum, device=self.current_device, dtype=torch.int64
             ),
         )
+        assert cache_sets > 0
         element_size = 1
         cache_size = cache_sets * ASSOC * element_size * self.max_D_cache
         logging.info(


### PR DESCRIPTION
Summary: Add assertion. If cache sets is 0, we will run into some cuda illegal memory access error in prefetch.

Differential Revision: D58115776


