### PR TITLE
fix keyed jagged index select selected_lengths_sum parameter to match forward impl

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
@@ -356,7 +356,7 @@ class KeyedJaggedIndexSelectDim1GPUOp
       const Tensor& indices, // select same indices for all batches
       const c10::SymInt batch_size,
       const std::optional<Tensor>& weights,
-      const std::optional<c10::SymInt>& selected_lengths_sum) {
+      const std::optional<c10::SymInt> selected_lengths_sum) {
     at::AutoDispatchBelowADInplaceOrView guard;
     // TODO: Add weights support
     TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(lengths, offsets, values, indices);


### PR DESCRIPTION
Summary:
match selected_lengths_sum parameter type with type in forward impl

matching changes in https://github.com/pytorch/FBGEMM/pull/2663

Differential Revision: D58144998


