### PR TITLE
Fix issue of quantize_fp8_per_row with CPU backend

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -150,6 +150,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.impl("quantize_fp8_per_tensor", quantize_fp8_per_tensor);
   m.def(
       "quantize_fp8_per_row(Tensor input, Tensor? bs=None, Tensor? scale_ub=None, ScalarType? output_dtype=None) -> Tensor[]");
+  m.impl("quantize_fp8_per_row", quantize_fp8_per_row);
 
 #if CUDART_VERSION >= 12000
   m.def(


### PR DESCRIPTION
Summary:
As title, fix the issue (P1394921317) introduced in D57885347

Before this Diff:
```
Exception Found: Could not run 'fbgemm::quantize_fp8_per_row' with arguments from the 'CPU' backend
```

Differential Revision: D58159637


