### PR TITLE
Add a new config for row-wise quant fp8 gemm perf bench with fp8_fast_accum=false

### DIFF
--- a/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
@@ -332,7 +332,14 @@ def _kernel_matmul_fp8_row(
 
 
 @triton.autotune(
-    configs=MATMUL_CONFIGS,
+    configs=MATMUL_CONFIGS
+    + [
+        Config(
+            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+    ],
     key=[
         "m_key",
         "n_key",


### PR DESCRIPTION
Summary: Adding a new config learned from cuBLAS.

Differential Revision: D57746696


