### PR TITLE
Switch to Triton FP8 Quantization in EMU1.6

### DIFF
--- a/fbgemm_gpu/experimental/gemm/test/fp8_gemm_benchmark.py
+++ b/fbgemm_gpu/experimental/gemm/test/fp8_gemm_benchmark.py
@@ -18,7 +18,6 @@ from fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm import (
     quantize_fp8_row,
 )
 from torch._tensor import Tensor
-from triton.runtime.jit import TensorWrapper
 
 
 def bench() -> None:
@@ -95,8 +94,8 @@ def bf16_bench(x: Tensor, w: Tensor) -> Callable[[], Tensor]:
 def scale_row_bench(x: Tensor, w: Tensor) -> Callable[[], Tensor]:
     # Benchmark quantize(x) + gemm for inference.
     def run_gemm() -> Tensor:
-        x_fp8: TensorWrapper
-        w_fp8: TensorWrapper
+        x_fp8: Tensor
+        w_fp8: Tensor
         x_scale: Tensor
         w_scale: Tensor
         x_fp8, x_scale = quantize_fp8_row(x)
@@ -116,8 +115,8 @@ def scale_row_bench(x: Tensor, w: Tensor) -> Callable[[], Tensor]:
 
 def row_gemm_bench(x: Tensor, w: Tensor) -> Callable[[], Tensor]:
     # Benchmark only row-wise gemm, caching scaling.
-    x_fp8: TensorWrapper
-    w_fp8: TensorWrapper
+    x_fp8: Tensor
+    w_fp8: Tensor
     x_scale: Tensor
     w_scale: Tensor
     x_fp8, x_scale = quantize_fp8_row(x)
@@ -139,8 +138,8 @@ def row_gemm_bench(x: Tensor, w: Tensor) -> Callable[[], Tensor]:
 
 def row_gemm_bench_no_fast_acc(x: Tensor, w: Tensor) -> Callable[[], Tensor]:
     # Benchmark only row-wise gemm, caching scaling.
-    x_fp8: TensorWrapper
-    w_fp8: TensorWrapper
+    x_fp8: Tensor
+    w_fp8: Tensor
     x_scale: Tensor
     w_scale: Tensor
     x_fp8, x_scale = quantize_fp8_row(x)
@@ -162,8 +161,8 @@ def row_gemm_bench_no_fast_acc(x: Tensor, w: Tensor) -> Callable[[], Tensor]:
 
 def row_gemm_bench_imprecise_acc(x: Tensor, w: Tensor) -> Callable[[], Tensor]:
     # Benchmark only row-wise gemm, caching scaling.
-    x_fp8: TensorWrapper
-    w_fp8: TensorWrapper
+    x_fp8: Tensor
+    w_fp8: Tensor
     x_scale: Tensor
     w_scale: Tensor
     x_fp8, x_scale = quantize_fp8_row(x)
@@ -186,8 +185,8 @@ def row_gemm_bench_imprecise_acc(x: Tensor, w: Tensor) -> Callable[[], Tensor]:
 
 def scale_block_bench(x: Tensor, w: Tensor) -> Callable[[], Tensor]:
     def run_gemm() -> Tensor:
-        x_fp8: TensorWrapper
-        w_fp8: TensorWrapper
+        x_fp8: Tensor
+        w_fp8: Tensor
         x_scale: Tensor
         w_scale: Tensor
         x_fp8, x_scale = quantize_fp8_block(x)
@@ -207,8 +206,8 @@ def scale_block_bench(x: Tensor, w: Tensor) -> Callable[[], Tensor]:
 
 def block_gemm_bench(x: Tensor, w: Tensor) -> Callable[[], Tensor]:
     # Benchmark only block-wise gemm, caching scaling.
-    x_fp8: TensorWrapper
-    w_fp8: TensorWrapper
+    x_fp8: Tensor
+    w_fp8: Tensor
     x_scale: Tensor
     w_scale: Tensor
     x_fp8, x_scale = quantize_fp8_block(x)

--- a/fbgemm_gpu/experimental/gemm/test/fp8_gemm_test.py
+++ b/fbgemm_gpu/experimental/gemm/test/fp8_gemm_test.py
@@ -50,7 +50,7 @@ class TestFp8Matmul(unittest.TestCase):
             )
 
             # Undo scaling.
-            a_torch = a_fp8.base.to(torch.bfloat16)
+            a_torch = a_fp8.to(torch.bfloat16)
             a_torch *= a_scale[:, None]
 
             self.assertTrue(
@@ -110,7 +110,7 @@ class TestFp8Matmul(unittest.TestCase):
 
             a_fp8, a_scale = quantize_fp8_block(a, BLOCK_M, BLOCK_K, scale_ub=scale_ub)
 
-            a_torch = a_fp8.base.to(torch.bfloat16)
+            a_torch = a_fp8.to(torch.bfloat16)
 
             # Undo scaling.
             for i in range(0, M, BLOCK_M):


### PR DESCRIPTION
Summary:
For some reason, the cuda `quantize_fp8_per_row` kernel is very slow in EMU. Switching it to the functionally equivalent triton kernel yields excellent speedups from FP8. For eager mode, I'm seeing a 20% e2e speedup and still getting proper outputs.

Eager:
BF16: 19702.10ms
FP8 Triton Quant: 16466.97ms

Compiled:
FP8 Native Quant: 14605.18ms
FP8 Triton Quant: 16043.92ms
BF16: 18030.98ms

We see that quantizing in native pytorch helps quite a bit when torch.compile is used. I added the option to choose which quantization function is used and default to triton when torch.compile is off and native torch when torch.compile is on. This gives us the best performance in either case.

Reviewed By: jiawenliu64

Differential Revision: D58167756


