### PR TITLE
Add weights mutations declaration in TBE backward ops schemas

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
@@ -1068,8 +1068,8 @@ TORCH_LIBRARY_FRAGMENT({{ lib_name }}, m) {
     {%- if not dense %}
     m.def("{{ op_name }}("
           "    Tensor placeholder_autograd_tensor, "
-          "    Tensor dev_weights, "
-          "    Tensor uvm_weights, "
+          "    Tensor(a!) dev_weights, "
+          "    Tensor(b!) uvm_weights, "
           "    Tensor lxu_cache_weights, "
           "    Tensor weights_placements, "
           "    Tensor weights_offsets, "

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -1205,9 +1205,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
     %}
     m.def("{{ embedding_codegen_backward_op }}("
           "    Tensor grad_output, "
-          "    Tensor dev_weights, "
+          "    Tensor(a!) dev_weights, "
           {%- if not dense %}
-          "    Tensor uvm_weights, "
+          "    Tensor(b!) uvm_weights, "
           "    Tensor lxu_cache_weights, "
           "    Tensor weights_placements, "
           {%- endif %}


### PR DESCRIPTION
Summary:
Continuation of D58014269 / https://github.com/pytorch/FBGEMM/pull/2651

Backward with fused optimizer does mutations of the weights => correcting schemas to register mutations. (Needed for PT2 to run functionalization)

Differential Revision: D58291332
