### PR TITLE
Revert D58147817: Multisect successfully blamed "D58147817: [FBGEMM][PR] [fbgemm_gpu] Enable NCCL code" for one test failure

### DIFF
--- a/.github/scripts/fbgemm_gpu_build.bash
+++ b/.github/scripts/fbgemm_gpu_build.bash
@@ -85,6 +85,14 @@ __configure_fbgemm_gpu_build_nvcc () {
   # shellcheck disable=SC2206
   local cuda_version_arr=(${cuda_version//./ })
 
+  echo "[BUILD] Looking up NCCL path ..."
+  # shellcheck disable=SC2155,SC2086
+  local conda_prefix=$(conda run ${env_prefix} printenv CONDA_PREFIX)
+  # shellcheck disable=SC2155,SC2086
+  local nccl_lib=$(conda run ${env_prefix} find ${conda_prefix} -name "libnccl.so*")
+  # shellcheck disable=SC2155,SC2086
+  local nccl_path=$(dirname "$(dirname ${nccl_lib})")
+
   # Only NVCC 12+ supports C++20
   if [[ ${cuda_version_arr[0]} -lt 12 ]]; then
     local cppstd_ver=17
@@ -115,6 +123,8 @@ __configure_fbgemm_gpu_build_nvcc () {
   build_args+=(
     # Override CMake configuration
     -DCMAKE_CXX_STANDARD="${cppstd_ver}"
+    -DNCCL_INCLUDE_DIR=${nccl_path}/include
+    -DNCCL_LIB_DIR=${nccl_path}/lib
   )
 }
 
@@ -193,7 +203,6 @@ __configure_fbgemm_gpu_build_cuda () {
     local arch_list="${TORCH_CUDA_ARCH_LIST}"
 
   else
-    # Build only CUDA 7.0, 8.0, and 9.0 (i.e. V100, A100, H100) because of 100 MB binary size limits from PyPI.
     echo "[BUILD] Using the default CUDA targets ..."
     # For cuda version 12.1, enable sm 9.0
     cuda_version_nvcc=$(conda run -n "${env_name}" nvcc --version)
@@ -204,44 +213,26 @@ __configure_fbgemm_gpu_build_cuda () {
       local arch_list="7.0;8.0"
     fi
   fi
-  echo "[BUILD] Setting the following CUDA targets: ${arch_list}"
 
   # Unset the environment-supplied TORCH_CUDA_ARCH_LIST because it will take
   # precedence over cmake -DTORCH_CUDA_ARCH_LIST
   unset TORCH_CUDA_ARCH_LIST
 
-  echo "[BUILD] Looking up NVML filepath ..."
+  echo "[BUILD] Setting the following CUDA targets: ${arch_list}"
+
+  # Build only CUDA 7.0 and 8.0 (i.e. V100 and A100) because of 100 MB binary size limits from PyPI.
+  echo "[BUILD] Setting CUDA build args ..."
   # shellcheck disable=SC2155,SC2086
   local nvml_lib_path=$(conda run --no-capture-output ${env_prefix} printenv NVML_LIB_PATH)
-
-  echo "[BUILD] Looking up NCCL filepath ..."
-  # shellcheck disable=SC2155,SC2086
-  local conda_prefix=$(conda run ${env_prefix} printenv CONDA_PREFIX)
-  # shellcheck disable=SC2155,SC2086
-  local nccl_lib_path=$(conda run ${env_prefix} find ${conda_prefix} -name "libnccl.so*")
-
-  echo "[BUILD] Setting CUDA build args ..."
   build_args=(
     --package_variant=cuda
     --nvml_lib_path="${nvml_lib_path}"
-    --nccl_lib_path="${nccl_lib_path}"
     # Pass to PyTorch CMake
     -DTORCH_CUDA_ARCH_LIST="'${arch_list}'"
   )
 
   # Set NVCC flags
   __configure_fbgemm_gpu_build_nvcc
-}
-
-__configure_fbgemm_gpu_build_genai () {
-  local fbgemm_variant_targets="$1"
-
-  __configure_fbgemm_gpu_build_cuda "$fbgemm_variant_targets" || return 1
-
-  # Replace the package_variant flag, since GenAI is also a CUDA-type build
-  for i in "${!build_args[@]}"; do
-    build_args[i]="${build_args[i]/--package_variant=cuda/--package_variant=genai}"
-  done
 }
 
 __configure_fbgemm_gpu_build () {
@@ -275,10 +266,6 @@ __configure_fbgemm_gpu_build () {
   elif [ "$fbgemm_variant" == "rocm" ]; then
     echo "[BUILD] Configuring build as ROCm variant ..."
     __configure_fbgemm_gpu_build_rocm "${fbgemm_variant_targets}"
-
-  elif [ "$fbgemm_variant" == "genai" ]; then
-    echo "[BUILD] Configuring build as GenAI variant ..."
-    __configure_fbgemm_gpu_build_genai "${fbgemm_variant_targets}"
 
   else
     echo "[BUILD] Configuring build as CUDA variant (this is the default behavior) ..."
@@ -360,13 +347,7 @@ __build_fbgemm_gpu_common_pre_steps () {
   (test_binpath "${env_name}" g++) || return 1
 
   # Set the default the FBGEMM_GPU variant to be CUDA
-  if [ "$fbgemm_variant" != "cpu" ] &&
-     [ "$fbgemm_variant" != "rocm" ] &&
-     [ "$fbgemm_variant" != "genai" ]; then
-    echo "################################################################################"
-    echo "[BUILD] Unknown FBGEMM_GPU variant: $fbgemm_variant"
-    echo "[BUILD] Defaulting to CUDA"
-    echo "################################################################################"
+  if [ "$fbgemm_variant" != "cpu" ] && [ "$fbgemm_variant" != "rocm" ]; then
     export fbgemm_variant="cuda"
   fi
 
@@ -390,113 +371,66 @@ __build_fbgemm_gpu_common_pre_steps () {
   print_exec git diff
 }
 
-__print_library_infos () {
-  # shellcheck disable=SC2035,SC2061,SC2062,SC2155,SC2178
-  local fbgemm_gpu_so_files=$(find . -name *.so | grep .*cmake-build/.*)
-  readarray -t fbgemm_gpu_so_files <<<"$fbgemm_gpu_so_files"
-
-  for library in "${fbgemm_gpu_so_files[@]}"; do
-    echo "################################################################################"
-    echo "[CHECK] BUILT LIBRARY: ${library}"
-
-    echo "[CHECK] Listing out library size:"
-    print_exec "du -h --block-size=1M ${library}"
-
-    echo "[CHECK] Listing out the GLIBCXX versions referenced:"
-    print_glibc_info "${library}"
-
-    echo "[CHECK] Listing out undefined symbols:"
-    print_exec "nm -gDCu ${library} | sort"
-
-    echo "[CHECK] Listing out external shared libraries linked:"
-    print_exec ldd "${library}"
-    echo "################################################################################"
-    echo ""
-    echo ""
-  done
-}
-
-__verify_library_symbols () {
-  __test_one_symbol () {
-    local symbol="$1"
-    if [ "$symbol" == "" ]; then
-      echo "Usage: ${FUNCNAME[0]} SYMBOL"
-      echo "Example(s):"
-      echo "    ${FUNCNAME[0]} fbgemm_gpu::asynchronous_inclusive_cumsum_cpu"
-      return 1
-    fi
-
-    # shellcheck disable=SC2035,SC2061,SC2062,SC2155,SC2178
-    local fbgemm_gpu_so_files=$(find . -name *.so | grep .*cmake-build/.*)
-    readarray -t fbgemm_gpu_so_files <<<"$fbgemm_gpu_so_files"
-
-    # Iterate through the built .SO files to check for the symbol's existence
-    for library in "${fbgemm_gpu_so_files[@]}"; do
-      if test_library_symbol "${library}" "${symbol}"; then
-        return 0
-      fi
-    done
-
-    return 1
-  }
-
-  # Prepare a sample set of symbols whose existence in the built library should be checked
-  # This is by no means an exhaustive set, and should be updated accordingly
-  if [ "${fbgemm_variant}" == "cpu" ]; then
-    local lib_symbols_to_check=(
-      fbgemm_gpu::asynchronous_inclusive_cumsum_cpu
-      fbgemm_gpu::jagged_2d_to_dense
-    )
-  elif [ "${fbgemm_variant}" == "cuda" ]; then
-    local lib_symbols_to_check=(
-      fbgemm_gpu::asynchronous_inclusive_cumsum_cpu
-      fbgemm_gpu::jagged_2d_to_dense
-      fbgemm_gpu::asynchronous_inclusive_cumsum_gpu
-      fbgemm_gpu::merge_pooled_embeddings
-    )
-  elif [ "${fbgemm_variant}" == "rocm" ]; then
-    local lib_symbols_to_check=(
-      fbgemm_gpu::asynchronous_inclusive_cumsum_cpu
-      fbgemm_gpu::jagged_2d_to_dense
-      fbgemm_gpu::asynchronous_inclusive_cumsum_gpu
-      fbgemm_gpu::merge_pooled_embeddings
-    )
-  elif [ "${fbgemm_variant}" == "genai" ]; then
-    local lib_symbols_to_check=(
-      fbgemm_gpu::car_init
-      fbgemm_gpu::per_tensor_quantize_i8
-    )
-  fi
-
-  echo "[CHECK] Verifying sample subset of symbols in the built libraries ..."
-  for symbol in "${lib_symbols_to_check[@]}"; do
-    (__test_one_symbol "${symbol}") || return 1
-  done
-}
-
 run_fbgemm_gpu_postbuild_checks () {
-  fbgemm_variant="$1"
+  local fbgemm_variant="$1"
   if [ "$fbgemm_variant" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} FBGEMM_VARIANT"
     echo "Example(s):"
     echo "    ${FUNCNAME[0]} cpu"
     echo "    ${FUNCNAME[0]} cuda"
     echo "    ${FUNCNAME[0]} rocm"
-    echo "    ${FUNCNAME[0]} genai"
     return 1
   fi
 
   # Find the .SO file
-  # shellcheck disable=SC2035,SC2061,SC2062,SC2155,SC2178
-  local fbgemm_gpu_so_files=$(find . -name *.so | grep .*cmake-build/.*)
+  # shellcheck disable=SC2155
+  local fbgemm_gpu_so_files=$(find . -name fbgemm_gpu_py.so)
   readarray -t fbgemm_gpu_so_files <<<"$fbgemm_gpu_so_files"
   if [ "${#fbgemm_gpu_so_files[@]}" -le 0 ]; then
-    echo "[CHECK] .SO library is missing from the build path!"
+    echo "[CHECK] .SO library fbgemm_gpu_py.so is missing from the build path!"
     return 1
   fi
 
-  __print_library_infos
-  __verify_library_symbols
+  # Prepare a sample set of symbols whose existence in the built library should be checked
+  # This is by no means an exhaustive set, and should be updated accordingly
+  local lib_symbols_to_check=(
+    fbgemm_gpu::asynchronous_inclusive_cumsum_cpu
+    fbgemm_gpu::jagged_2d_to_dense
+  )
+
+  # Add more symbols to check for if it's a non-CPU variant
+  if [ "${fbgemm_variant}" == "cuda" ]; then
+    lib_symbols_to_check+=(
+      fbgemm_gpu::asynchronous_inclusive_cumsum_gpu
+      fbgemm_gpu::merge_pooled_embeddings
+    )
+  elif [ "${fbgemm_variant}" == "rocm" ]; then
+    # merge_pooled_embeddings is missing in ROCm builds bc it requires NVML
+    lib_symbols_to_check+=(
+      fbgemm_gpu::asynchronous_inclusive_cumsum_gpu
+      fbgemm_gpu::merge_pooled_embeddings
+    )
+  fi
+
+  # Print info for only the first instance of the .SO file, since the build makes multiple copies
+  local library="${fbgemm_gpu_so_files[0]}"
+
+  echo "[CHECK] Listing out library size: ${library}"
+  print_exec "du -h --block-size=1M ${library}"
+
+  echo "[CHECK] Listing out the GLIBCXX versions referenced by the library: ${library}"
+  print_glibc_info "${library}"
+
+  echo "[CHECK] Listing out undefined symbols in the library: ${library}"
+  print_exec "nm -gDCu ${library} | sort"
+
+  echo "[CHECK] Listing out external shared libraries required by the library: ${library}"
+  print_exec ldd "${library}"
+
+  echo "[CHECK] Verifying sample subset of symbols in the library ..."
+  for symbol in "${lib_symbols_to_check[@]}"; do
+    (test_library_symbol "${library}" "${symbol}") || return 1
+  done
 }
 
 ################################################################################

--- a/.github/scripts/fbgemm_gpu_install.bash
+++ b/.github/scripts/fbgemm_gpu_install.bash
@@ -115,7 +115,7 @@ install_fbgemm_gpu_pip () {
     echo "Example(s):"
     echo "    ${FUNCNAME[0]} build_env 0.5.0 cpu                  # Install the CPU variant, specific version from release channel"
     echo "    ${FUNCNAME[0]} build_env release cuda 12.4.1        # Install the CUDA variant, latest version from release channel"
-    echo "    ${FUNCNAME[0]} build_env test/0.7.0rc0 cuda 12.4.1  # Install the CUDA 12.4 variant, specific version from test channel"
+    echo "    ${FUNCNAME[0]} build_env test/0.6.0rc0 cuda 12.4.1  # Install the CUDA 12.4 variant, specific version from test channel"
     echo "    ${FUNCNAME[0]} build_env nightly rocm 5.3           # Install the ROCM 5.3 variant, latest version from nightly channel"
     return 1
   else

--- a/.github/scripts/fbgemm_gpu_test.bash
+++ b/.github/scripts/fbgemm_gpu_test.bash
@@ -70,12 +70,16 @@ __configure_fbgemm_gpu_test_cpu () {
     # These tests have non-CPU operators referenced in @given
     ./uvm/copy_test.py
     ./uvm/uvm_test.py
+    # require multiple GPUs
+    ./comm/multi_gpu_car_test.py
   )
 }
 
 __configure_fbgemm_gpu_test_cuda () {
   ignored_tests=(
     ./tbe/ssd/ssd_split_table_batched_embeddings_test.py
+    # require multiple GPUs
+    ./comm/multi_gpu_car_test.py
   )
 }
 
@@ -101,6 +105,8 @@ __configure_fbgemm_gpu_test_rocm () {
     ./tbe/ssd/ssd_split_table_batched_embeddings_test.py
     # https://github.com/pytorch/FBGEMM/issues/1559
     ./batched_unary_embeddings_test.py
+    # require multiple GPUs
+    ./comm/multi_gpu_car_test.py
   )
 }
 
@@ -244,7 +250,7 @@ test_setup_conda_environment () {
   if [ "$pytorch_variant_type" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME COMPILER PYTHON_VERSION PYTORCH_INSTALLER PYTORCH_CHANNEL[/VERSION] PYTORCH_VARIANT_TYPE [PYTORCH_VARIANT_VERSION]"
     echo "Example(s):"
-    echo "    ${FUNCNAME[0]} build_env clang 3.12 pip test/0.7.0 cuda 12.1.0       # Setup environment with pytorch-test 0.7.0 for Clang + Python 3.12 + CUDA 12.1.0"
+    echo "    ${FUNCNAME[0]} build_env clang 3.12 pip test/0.6.0 cuda 12.1.0       # Setup environment with pytorch-test 0.6.0 for Clang + Python 3.12 + CUDA 12.1.0"
     return 1
   else
     echo "################################################################################"
@@ -314,13 +320,6 @@ test_fbgemm_gpu_build_and_install () {
 
   cd ~/FBGEMM/                                                                || return 1
   install_fbgemm_gpu_wheel    "${env_name}" fbgemm_gpu/dist/*.whl             || return 1
-}
-
-test_fbgemm_gpu_build_and_install_and_run () {
-  local env_name="$1"
-  local pytorch_variant_type="$2"
-
-  test_fbgemm_gpu_build_and_install "${env_name}" "${pytorch_variant_type}"   || return 1
 
   cd ~/FBGEMM/                                                                || return 1
   test_all_fbgemm_gpu_modules "${env_name}" "${pytorch_variant_type}"         || return 1
@@ -333,7 +332,7 @@ test_fbgemm_gpu_setup_and_pip_install () {
   if [ "$fbgemm_gpu_channel_version" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME PYTORCH_CHANNEL[/VERSION] FBGEMM_GPU_CHANNEL[/VERSION]"
     echo "Example(s):"
-    echo "    ${FUNCNAME[0]} test_env cpu test/2.2.0 test/0.7.0     # Run tests against all Python versions with PyTorch test/2.2.0 and FBGEMM_GPU test/0.7.0 (CPU-only)"
+    echo "    ${FUNCNAME[0]} test_env cpu test/2.2.0 test/0.6.0     # Run tests against all Python versions with PyTorch test/2.2.0 and FBGEMM_GPU test/0.6.0 (CPU-only)"
     echo "    ${FUNCNAME[0]} test_env cuda test/2.3.0 test/0.7.0    # Run tests against all Python versions with PyTorch test/2.3.0 and FBGEMM_GPU test/0.7.0 (all CUDA versions)"
     return 1
   else

--- a/.github/scripts/utils_conda.bash
+++ b/.github/scripts/utils_conda.bash
@@ -62,11 +62,11 @@ setup_miniconda () {
   # https://medium.com/data-tyro/resolving-the-conda-libmamba-issue-and-environment-activation-trouble-9f911a6106a4
   # https://www.reddit.com/r/learnpython/comments/160kjz9/how_do_i_get_anaconda_to_work_the_way_i_want_it_to/
   echo "[SETUP] Installing libmamba-solver (required since Anaconda 2024.02-1) ..."
-  (exec_with_retries 3 conda install -n base  -y conda-libmamba-solver --solver classic) || return 1
+  (exec_with_retries 3 conda install -n base conda-libmamba-solver --solver classic) || return 1
 
   # https://stackoverflow.com/questions/77617946/solve-conda-libmamba-solver-libarchive-so-19-error-after-updating-conda-to-23
   echo "[SETUP] Installing libarchive ..."
-  (exec_with_retries 3 conda install -n base -c main -y libarchive --force-reinstall) || return 1
+  (exec_with_retries 3 conda install -n base -c main libarchive --force-reinstall) || return 1
 
   # Clean up packages
   conda_cleanup

--- a/.github/scripts/utils_pip.bash
+++ b/.github/scripts/utils_pip.bash
@@ -176,11 +176,11 @@ install_from_pytorch_pip () {
     echo "Example(s):"
     echo "    ${FUNCNAME[0]} build_env torch 1.11.0 cpu                       # Install the CPU variant, specific version from release channel"
     echo "    ${FUNCNAME[0]} build_env torch release cpu                      # Install the CPU variant, latest version from release channel"
-    echo "    ${FUNCNAME[0]} build_env fbgemm_gpu test/0.7.0rc0 cuda/12.1.0   # Install the CUDA 12.1 variant, specific version from test channel"
+    echo "    ${FUNCNAME[0]} build_env fbgemm_gpu test/0.6.0rc0 cuda/12.1.0   # Install the CUDA 12.1 variant, specific version from test channel"
     echo "    ${FUNCNAME[0]} build_env fbgemm_gpu nightly rocm/5.3            # Install the ROCM 5.3 variant, latest version from nightly channel"
     echo "    ${FUNCNAME[0]} build_env pytorch_triton 1.11.0                  # Install specific version from release channel"
     echo "    ${FUNCNAME[0]} build_env pytorch_triton release                 # Install latest version from release channel"
-    echo "    ${FUNCNAME[0]} build_env pytorch_triton test/0.7.0rc0           # Install specific version from test channel"
+    echo "    ${FUNCNAME[0]} build_env pytorch_triton test/0.6.0rc0           # Install specific version from test channel"
     echo "    ${FUNCNAME[0]} build_env pytorch_triton_rocm nightly            # Install latest version from nightly channel"
     return 1
   else
@@ -233,7 +233,7 @@ download_from_pytorch_pip () {
     echo "Example(s):"
     echo "    ${FUNCNAME[0]} build_env torch 1.11.0 cpu                       # Download the CPU variant, specific version from release channel"
     echo "    ${FUNCNAME[0]} build_env torch release cpu                      # Download the CPU variant, latest version from release channel"
-    echo "    ${FUNCNAME[0]} build_env fbgemm_gpu test/0.7.0rc0 cuda/12.1.0   # Download the CUDA 12.1 variant, specific version from test channel"
+    echo "    ${FUNCNAME[0]} build_env fbgemm_gpu test/0.6.0rc0 cuda/12.1.0   # Download the CUDA 12.1 variant, specific version from test channel"
     echo "    ${FUNCNAME[0]} build_env fbgemm_gpu nightly rocm/5.3            # Download the ROCM 5.3 variant, latest version from nightly channel"
     return 1
   else

--- a/.github/workflows/fbgemm_gpu_pip.yml
+++ b/.github/workflows/fbgemm_gpu_pip.yml
@@ -31,7 +31,7 @@ on:
         required: true
         default: "nightly"
       fbgemm_gpu_channel_version:
-        description: FBGEMM-GPU Channel + Version (e.g. '0.5.0', 'nightly', 'test/0.7.0r0')
+        description: FBGEMM-GPU Channel + Version (e.g. '0.5.0', 'nightly', 'test/0.6.0r0')
         type: string
         required: true
         default: "nightly"

--- a/cmake/modules/CudaSetup.cmake
+++ b/cmake/modules/CudaSetup.cmake
@@ -12,10 +12,10 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/modules/Utilities.cmake)
 ################################################################################
 
 BLOCK_PRINT(
-  "NCCL Flags"
+  "NCCL flags"
   ""
-  "NCCL_INCLUDE_DIRS=${NCCL_INCLUDE_DIRS}"
-  "NCCL_LIBRARIES=${NCCL_LIBRARIES}"
+  "NCCL_INCLUDE_DIR=${NCCL_INCLUDE_DIR}"
+  "NCCL_LIB_DIR=${NCCL_LIB_DIR}"
 )
 
 # Set NVML_LIB_PATH if provided, or detect the default lib path

--- a/cmake/modules/PyTorchSetup.cmake
+++ b/cmake/modules/PyTorchSetup.cmake
@@ -13,14 +13,6 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/modules/Utilities.cmake)
 
 find_package(Torch REQUIRED)
 
-BLOCK_PRINT(
-  "PyTorch Flags"
-  ""
-  "TORCH_INCLUDE_DIRS=${TORCH_INCLUDE_DIRS}"
-  ""
-  "TORCH_LIBRARIES=${TORCH_LIBRARIES}"
-)
-
 #
 # PyTorch CUDA Extensions are normally compiled with the flags below. However we
 # disabled -D__CUDA_NO_HALF_CONVERSIONS__ here as it caused "error: no suitable

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -94,20 +94,18 @@ endif()
 # Build Experimental Modules
 ################################################################################
 
-if(NOT FBGEMM_CPU_ONLY AND NOT USE_ROCM)
-  # TODO: Figure out NCCL/RCCL integration with ROCm
-  add_subdirectory(experimental/example)
-endif()
-
 if(NOT FBGEMM_CPU_ONLY)
   add_subdirectory(experimental/gemm)
-endif()
 
-if(NOT FBGEMM_CPU_ONLY AND NOT USE_ROCM)
-  # CUTLASS currently doesn't build on ROCm and CK hasnt yet been added:
-  #
-  # 2024-05-06T23:09:35.5730483Z /__w/FBGEMM/FBGEMM/fbgemm_gpu/../third_party/cutlass/include/cutlass/half.h:73:10: fatal error: 'cuda_fp16.h' file not found
-  # #include <cuda_fp16.h>
-  #
-  add_subdirectory(experimental/gen_ai)
+  if(NOT USE_ROCM)
+    # TODO: Figure out NCCL/RCCL integration with ROCm
+    add_subdirectory(experimental/example)
+
+    # CUTLASS currently doesn't build on ROCm and CK hasnt yet been added:
+    #
+    # 2024-05-06T23:09:35.5730483Z /__w/FBGEMM/FBGEMM/fbgemm_gpu/../third_party/cutlass/include/cutlass/half.h:73:10: fatal error: 'cuda_fp16.h' file not found
+    # #include <cuda_fp16.h>
+    #
+    add_subdirectory(experimental/gen_ai)
+  endif()
 endif()

--- a/fbgemm_gpu/FbgemmGpu.cmake
+++ b/fbgemm_gpu/FbgemmGpu.cmake
@@ -31,7 +31,7 @@ set(fbgemm_sources_include_directories
   ${THIRDPARTY}/cpuinfo/include
   ${THIRDPARTY}/cutlass/include
   ${THIRDPARTY}/cutlass/tools/util/include
-  ${NCCL_INCLUDE_DIRS})
+  ${NCCL_INCLUDE_DIR})
 
 
 ################################################################################
@@ -675,7 +675,7 @@ endif()
 # Add PyTorch include/
 target_include_directories(fbgemm_gpu_py PRIVATE
   ${TORCH_INCLUDE_DIRS}
-  ${NCCL_INCLUDE_DIRS})
+  ${NCCL_INCLUDE_DIR})
 
 # Remove `lib` from the output artifact name `libfbgemm_gpu_py.so`
 set_target_properties(fbgemm_gpu_py PROPERTIES PREFIX "")
@@ -683,7 +683,7 @@ set_target_properties(fbgemm_gpu_py PROPERTIES PREFIX "")
 # Link to PyTorch
 target_link_libraries(fbgemm_gpu_py
   ${TORCH_LIBRARIES}
-  ${NCCL_LIBRARIES})
+  ${NCCL_LIB_DIR})
 
 # Link to NVML
 if(NVML_LIB_PATH)

--- a/fbgemm_gpu/docs/src/conf.py
+++ b/fbgemm_gpu/docs/src/conf.py
@@ -28,10 +28,10 @@ copyright = f"2020 - {datetime.date.today().year}, FBGEMM Team"
 author = "FBGEMM Team"
 
 # The short X.Y version.
-version = "0.7"
+version = "0.6"
 
 # The full version, including alpha/beta/rc tags
-release = "0.7.0"
+release = "0.6.0"
 
 
 # -- Path setup --------------------------------------------------------------

--- a/fbgemm_gpu/docs/src/fbgemm_gpu-development/BuildInstructions.rst
+++ b/fbgemm_gpu/docs/src/fbgemm_gpu-development/BuildInstructions.rst
@@ -115,8 +115,7 @@ Install the full CUDA package through Conda, which includes
   # Install the full CUDA package
   conda install -n ${env_name} -y cuda -c "nvidia/label/cuda-${cuda_version}"
 
-Verify that ``cuda_runtime.h``, ``libnvidia-ml.so``, and ``libnccl.so*`` are
-found:
+Verify that ``cuda_runtime.h`` and ``libnvidia-ml.so`` are found:
 
 .. code:: sh
 
@@ -124,7 +123,6 @@ found:
 
   find "${conda_prefix}" -name cuda_runtime.h
   find "${conda_prefix}" -name libnvidia-ml.so
-  find "${conda_prefix}" -name libnccl.so*
 
 Install cuDNN
 ~~~~~~~~~~~~~
@@ -142,14 +140,6 @@ cuDNN package for the given CUDA version:
   # Download and unpack cuDNN
   wget -q "${cudnn_url}" -O cudnn.tar.xz
   tar -xvf cudnn.tar.xz
-
-Install CUTLASS
-~~~~~~~~~~~~~~~
-
-This section is only applicable to building the experimental FBGEMM_GPU GenAI
-module.  CUTLASS should be already be available in the repository as a git
-submodule (see :ref:`fbgemm-gpu.build.prepare`).  The following include paths
-are already added to the CMake configuration:
 
 
 Set Up for ROCm Build
@@ -417,8 +407,6 @@ For the CUDA variant of PyTorch, verify that at the minimum ``cuda_cmake_macros.
 Build the FBGEMM_GPU Package
 ----------------------------
 
-.. _fbgemm-gpu.build.prepare:
-
 Preparing the Build
 ~~~~~~~~~~~~~~~~~~~
 
@@ -430,7 +418,7 @@ Clone the repo along with its submodules, and install the
   # !! Run inside the Conda environment !!
 
   # Select a version tag
-  FBGEMM_VERSION=v0.7.0
+  FBGEMM_VERSION=v0.6.0
 
   # Clone the repo along with its submodules
   git clone --recursive -b ${FBGEMM_VERSION} https://github.com/pytorch/FBGEMM.git fbgemm_${FBGEMM_VERSION}
@@ -556,11 +544,8 @@ toolchains have been properly installed.
   export CUDNN_INCLUDE_DIR=/path/to/cudnn/include
   export CUDNN_LIBRARY=/path/to/cudnn/lib
 
-  # Specify NVML filepath
+  # Specify NVML path
   export NVML_LIB_PATH=/path/to/libnvidia-ml.so
-
-  # Specify NCCL filepath
-  export NCCL_LIB_PATH=/path/to/libnccl.so.2
 
   # Build for SM70/80 (V100/A100 GPU); update as needed
   # If not specified, only the CUDA architecture supported by current system will be targeted
@@ -578,14 +563,12 @@ toolchains have been properly installed.
       --python-tag="${python_tag}" \
       --plat-name="${python_plat_name}" \
       --nvml_lib_path=${NVML_LIB_PATH} \
-      --nccl_lib_path=${NCCL_LIB_PATH} \
       -DTORCH_CUDA_ARCH_LIST="${cuda_arch_list}"
 
   # Build and install the library into the Conda environment
   python setup.py install \
       --package_variant=cuda \
       --nvml_lib_path=${NVML_LIB_PATH} \
-      --nccl_lib_path=${NCCL_LIB_PATH} \
       -DTORCH_CUDA_ARCH_LIST="${cuda_arch_list}"
 
 .. _fbgemm-gpu.build.process.rocm:

--- a/fbgemm_gpu/docs/src/fbgemm_gpu-development/InstallationInstructions.rst
+++ b/fbgemm_gpu/docs/src/fbgemm_gpu-development/InstallationInstructions.rst
@@ -163,32 +163,6 @@ Follow the instructions in :ref:`fbgemm-gpu.build.setup.pytorch.install`
 for installing PyTorch inside a Conda environment.
 
 
-Install Triton
---------------
-
-This section is only applicable to working the experimental FBGEMM_GPU GenAI
-module.  Triton should already come packaged with the PyTOrch installation.
-This can be verified with:
-
-.. code:: sh
-
-  conda run -n ${env_name} python -c "import triton"
-
-If Triton is not available, it can be installed through PyTorch PIP:
-
-.. code:: sh
-
-  # Most recent version used can be found in the build scripts
-  TRITON_VERSION=3.0.0+45fff310c8
-
-  conda run -n ${env_name} pip install \
-    --pre pytorch-triton==${TRITON_VERSION} \
-    --index-url https://download.pytorch.org/whl/nightly/
-
-Information about PyTorch-Triton release can be found
-`here <https://github.com/pytorch/pytorch/blob/main/RELEASE.md>`__.
-
-
 Install the FBGEMM_GPU Package
 ------------------------------
 

--- a/fbgemm_gpu/docs/src/general/documentation/Cpp.rst
+++ b/fbgemm_gpu/docs/src/general/documentation/Cpp.rst
@@ -4,7 +4,7 @@ Adding Documentation to C++ Code
 --------------------------------
 
 Documentation for C++ is provided through
-`Javadoc-style comments <https://www.oracle.com/java/technologies/javase/javadoc-tool.html>`__
+`Javadoc-style comments <https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html>`__
 and generated using Sphinx, `Doxygen <https://www.doxygen.nl/>`__, and
 `Breathe <https://www.breathe-doc.org/>`__.
 

--- a/fbgemm_gpu/experimental/example/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/example/CMakeLists.txt
@@ -10,21 +10,28 @@ include(${CMAKEMODULES}/Utilities.cmake)
 # Target Sources
 ################################################################################
 
-set(fbgemm_sources_include_directories
-  # FBGEMM
-  ${FBGEMM}/include
-  # FBGEMM_GPU
-  ${CMAKE_CURRENT_SOURCE_DIR}../..
-  ${CMAKE_CURRENT_SOURCE_DIR}../../include
-  ${CMAKE_CURRENT_SOURCE_DIR}../../../include
-  # PyTorch
-  ${TORCH_INCLUDE_DIRS}
-  # Third-party
-  ${THIRDPARTY}/asmjit/src
-  ${THIRDPARTY}/cpuinfo/include
-  ${THIRDPARTY}/cutlass/include
-  ${THIRDPARTY}/cutlass/tools/util/include
-  ${NCCL_INCLUDE_DIRS})
+if(FBGEMM_GENAI_ONLY)
+  set(fbgemm_sources_include_directories
+    # FBGEMM
+    ${FBGEMM}/include
+    # FBGEMM_GPU
+    ${CMAKE_CURRENT_SOURCE_DIR}../..
+    ${CMAKE_CURRENT_SOURCE_DIR}../../include
+    ${CMAKE_CURRENT_SOURCE_DIR}../../../include
+    # PyTorch
+    ${TORCH_INCLUDE_DIRS}
+    # Third-party
+    ${THIRDPARTY}/asmjit/src
+    ${THIRDPARTY}/cpuinfo/include
+    ${THIRDPARTY}/cutlass/include
+    ${THIRDPARTY}/cutlass/tools/util/include
+    ${NCCL_INCLUDE_DIR})
+
+  set(third_party_include_directories
+    ${THIRDPARTY}/asmjit/src
+    ${THIRDPARTY}/cpuinfo/include
+    ${THIRDPARTY}/cutlass/include)
+endif()
 
 set(experimental_example_cpp_source_files
     src/cutlass_sgemm_nn.cu
@@ -49,11 +56,11 @@ add_library(fbgemm_gpu_experimental_example_py MODULE
 
 target_include_directories(fbgemm_gpu_experimental_example_py PRIVATE
     ${TORCH_INCLUDE_DIRS}
-    ${NCCL_INCLUDE_DIRS})
+    ${NCCL_INCLUDE_DIR})
 
 target_link_libraries(fbgemm_gpu_experimental_example_py
     ${TORCH_LIBRARIES}
-    ${NCCL_LIBRARIES})
+    ${NCCL_LIB_DIR})
 
 # Remove `lib` from the output artifact name
 set_target_properties(fbgemm_gpu_experimental_example_py PROPERTIES PREFIX "")

--- a/fbgemm_gpu/experimental/example/test/triton_example_test.py
+++ b/fbgemm_gpu/experimental/example/test/triton_example_test.py
@@ -14,8 +14,7 @@ import triton.language as tl
 @triton.jit
 # fmt: off
 def triton_add_kernel(x_ptr, y_ptr, z_ptr, n_elements, BLOCK_SIZE: tl.constexpr) -> None:
-# fmt: on  # noqa E115
-
+    # fmt: on
     # We use a 1D launch grid so axis is 0.
     pid = tl.program_id(axis=0)
 

--- a/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
@@ -8,21 +8,23 @@
 # Target Sources
 ################################################################################
 
-set(fbgemm_sources_include_directories
-  # FBGEMM
-  ${FBGEMM}/include
-  # FBGEMM_GPU
-  ${CMAKE_CURRENT_SOURCE_DIR}/../..
-  ${CMAKE_CURRENT_SOURCE_DIR}/../../include
-  ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
-  # PyTorch
-  ${TORCH_INCLUDE_DIRS}
-  # Third-party
-  ${THIRDPARTY}/asmjit/src
-  ${THIRDPARTY}/cpuinfo/include
-  ${THIRDPARTY}/cutlass/include
-  ${THIRDPARTY}/cutlass/tools/util/include
-  ${NCCL_INCLUDE_DIRS})
+if(FBGEMM_GENAI_ONLY)
+  set(fbgemm_sources_include_directories
+    # FBGEMM
+    ${FBGEMM}/include
+    # FBGEMM_GPU
+    ${CMAKE_CURRENT_SOURCE_DIR}/../..
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
+    # PyTorch
+    ${TORCH_INCLUDE_DIRS}
+    # Third-party
+    ${THIRDPARTY}/asmjit/src
+    ${THIRDPARTY}/cpuinfo/include
+    ${THIRDPARTY}/cutlass/include
+    ${THIRDPARTY}/cutlass/tools/util/include
+    ${NCCL_INCLUDE_DIR})
+endif()
 
 set(attention_ops_sources
     src/attention/attention.cpp
@@ -33,14 +35,14 @@ set(quantize_ops_sources
     src/quantize/quantize.cu
     src/quantize/quantize.cpp)
 
-set(comm_ops_sources
-    src/comm/car.cu
-    src/comm/car.cpp)
+# set(comm_ops_sources
+#     src/comm/car.cu
+#     src/comm/car.cpp)
 
 set(experimental_gen_ai_cpp_source_files
     ${attention_ops_sources}
-    ${quantize_ops_sources}
-    ${comm_ops_sources})
+    ${quantize_ops_sources})
+#     ${comm_ops_sources})
 
 set_source_files_properties(${experimental_gen_ai_cpp_source_files}
     PROPERTIES INCLUDE_DIRECTORIES
@@ -102,11 +104,11 @@ endif()
 
 target_include_directories(fbgemm_gpu_experimental_gen_ai_py PRIVATE
   ${TORCH_INCLUDE_DIRS}
-  ${NCCL_INCLUDE_DIRS})
+  ${NCCL_INCLUDE_DIR})
 
 target_link_libraries(fbgemm_gpu_experimental_gen_ai_py
   ${TORCH_LIBRARIES}
-  ${NCCL_LIBRARIES})
+  ${NCCL_LIB_DIR})
 
 # Remove `lib` from the output artifact name
 set_target_properties(fbgemm_gpu_experimental_gen_ai_py PROPERTIES PREFIX "")

--- a/fbgemm_gpu/experimental/gen_ai/src/comm/car.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/comm/car.cpp
@@ -16,11 +16,13 @@
 #include "c10/cuda/CUDAFunctions.h"
 #include "c10/cuda/CUDAStream.h"
 #include "c10/util/Optional.h"
+#include "folly/futures/Future.h"
 
 #include <ATen/cuda/CUDAEvent.h>
+#include <folly/experimental/symbolizer/SignalHandler.h>
+
 #include <sys/stat.h>
 #include <torch/csrc/cuda/nccl.h>
-#include <unistd.h>
 #include <algorithm>
 #include <atomic>
 #include <cassert>
@@ -40,8 +42,8 @@ constexpr size_t kMaxNumNcclComms = 3;
 static ncclComm_t* get_nccl_comm(int64_t comm_idx) {
   static ncclComm_t comms[kMaxNumNcclComms];
 
-  TORCH_CHECK_GE(comm_idx, 0);
-  TORCH_CHECK_LT(comm_idx, kMaxNumNcclComms);
+  CHECK_GE(comm_idx, 0);
+  CHECK_LT(comm_idx, kMaxNumNcclComms);
   return &comms[comm_idx];
 }
 
@@ -231,50 +233,46 @@ at::Tensor car_tensor();
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "nccl_init(int rank, int world_size, str rendevouz, int comm_idx=0) -> ()");
+  m.impl("nccl_init", nccl_init);
 
   m.def("nccl_get_unique_id() -> Tensor");
+  m.impl("nccl_get_unique_id", nccl_get_unique_id);
 
   m.def(
       "nccl_comm_init_rank(int world_size, int rank, Tensor id_, int comm_idx=0) -> ()");
+  m.impl("nccl_comm_init_rank", nccl_comm_init_rank);
 
-  m.def("nccl_allgather(Tensor y_allgather, Tensor y, int comm_idx=0) -> ()");
-
-  m.def(
-      "nccl_alltoall(Tensor y_all2all, Tensor y, int world_size, int comm_idx=0) -> ()");
-
-  m.def(
-      "nccl_reducescatter(Tensor y_reducescatter, Tensor y, int comm_idx=0) -> ()");
+  m.def("nccl_allgather(Tensor dst, Tensor src, int comm_idx=0) -> ()");
+  m.impl("nccl_allgather", nccl_allgather);
 
   m.def(
-      "nccl_allreduce(Tensor y_allreduce, Tensor y, Tensor? z=None, int comm_idx=0) -> ()");
+      "nccl_alltoall(Tensor dst, Tensor src, int world_size, int comm_idx=0) -> ()");
+  m.impl("nccl_alltoall", nccl_alltoall);
+
+  m.def("nccl_reducescatter(Tensor dst, Tensor src, int comm_idx=0) -> ()");
+  m.impl("nccl_reducescatter", nccl_reducescatter);
+
+  m.def(
+      "nccl_allreduce(Tensor dst, Tensor src, Tensor? bias=None, int comm_idx=0) -> ()");
+  m.impl("nccl_allreduce", nccl_allreduce);
 
   // car: customized all reduce
   m.def("car_tensor() -> Tensor");
+  m.impl("car_tensor", car_tensor);
 
   m.def("car_ipc_handle(Tensor buffer) -> Tensor");
+  m.impl("car_ipc_handle", car_ipc_handle);
 
   m.def(
       "car_init(int rank, int world_size, Tensor local_barrier, Tensor[] all_barrier_handles, Tensor local_buffer, Tensor[] all_buffer_handles) -> ()");
-
-  m.def(
-      "one_shot_car_allreduce(Tensor y_allreduce, Tensor y, Tensor? z=None, int comm_idx=0) -> ()");
-
-  m.def(
-      "two_shot_car_allreduce(Tensor y_allreduce, Tensor y, Tensor? z=None, int comm_idx=0) -> ()");
-}
-
-TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
-  m.impl("nccl_init", nccl_init);
-  m.impl("nccl_get_unique_id", nccl_get_unique_id);
-  m.impl("nccl_comm_init_rank", nccl_comm_init_rank);
-  m.impl("nccl_allgather", nccl_allgather);
-  m.impl("nccl_alltoall", nccl_alltoall);
-  m.impl("nccl_reducescatter", nccl_reducescatter);
-  m.impl("nccl_allreduce", nccl_allreduce);
-  m.impl("car_tensor", car_tensor);
-  m.impl("car_ipc_handle", car_ipc_handle);
   m.impl("car_init", car_init);
+
+  m.def(
+      "one_shot_car_allreduce(Tensor dst, Tensor src, Tensor? bias=None, int comm_idx=0) -> ()");
   m.impl("one_shot_car_allreduce", one_shot_car_allreduce);
+
+  m.def(
+      "two_shot_car_allreduce(Tensor dst, Tensor src, Tensor? bias=None, int comm_idx=0) -> ()");
   m.impl("two_shot_car_allreduce", two_shot_car_allreduce);
 }
 

--- a/fbgemm_gpu/experimental/gen_ai/test/comm/multi_gpu_car_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/comm/multi_gpu_car_test.py
@@ -250,10 +250,14 @@ def _run_oneshot_car_stress_inner(path: str) -> None:
 
 
 @unittest.skipIf(
-    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
-    "Skip when CUDA is not available or when there are not enough GPUs; these tests require at least two GPUs",
+    not torch.cuda.is_available(),
+    "Skip when CUDA is not available",
 )
 class LLamaMultiGpuTests(unittest.TestCase):
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
     def test_allgather(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir, tempfile.TemporaryDirectory() as path:
             lc = LaunchConfig(
@@ -272,6 +276,10 @@ class LLamaMultiGpuTests(unittest.TestCase):
                 os.path.join(path, "rdvz")
             )
 
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
     def test_allreduce(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir, tempfile.TemporaryDirectory() as path:
             lc = LaunchConfig(

--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -47,7 +47,7 @@ class FbgemmGpuBuild:
         parser.add_argument(
             "--package_variant",
             type=str,
-            choices=["cpu", "cuda", "rocm", "genai"],
+            choices=["cpu", "cuda", "rocm"],
             default="cuda",
             help="The FBGEMM_GPU variant to build.",
         )
@@ -62,14 +62,8 @@ class FbgemmGpuBuild:
             "--nvml_lib_path",
             type=str,
             default=None,
-            help="Certain build targets require NVML (libnvidia-ml.so). If you installed"
+            help="Certain operations require the nvml lib (libnvidia-ml.so). If you installed"
             " this in a custom location (through cudatoolkit-dev), provide the path here.",
-        )
-        parser.add_argument(
-            "--nccl_lib_path",
-            type=str,
-            default=None,
-            help="NCCL (libnccl.so.2) filepath. This is required for building certain targets.",
         )
         parser.add_argument(
             "--cxxprefix",
@@ -237,8 +231,6 @@ class FbgemmGpuBuild:
             _get_cxx11_abi(),
         ]
 
-        cxx_args = []
-
         if self.args.verbose:
             print("[SETUP.PY] Building in VERBOSE mode ...")
             cmake_args.extend(
@@ -256,40 +248,17 @@ class FbgemmGpuBuild:
         if self.args.nvml_lib_path:
             cmake_args.append(f"-DNVML_LIB_PATH={self.args.nvml_lib_path}")
 
-        if self.args.nccl_lib_path:
-            nccl_root = os.path.dirname(os.path.dirname(self.args.nccl_lib_path))
-            cxx_args.extend([f"-L{nccl_root}/lib"])
-            cmake_args.extend(
-                [
-                    f"-DNCCL_INCLUDE_DIRS={nccl_root}/include",
-                    f"-DNCCL_LIBRARIES={self.args.nccl_lib_path}",
-                ]
-            )
-
         if self.args.cxxprefix:
             print("[SETUP.PY] Setting CMake flags ...")
             path = self.args.cxxprefix
-
-            cxx_args.extend(
-                [
-                    "-fopenmp=libgomp",
-                    "-stdlib=libstdc++",
-                    f"-I{path}/include",
-                ]
-            )
             cmake_args.extend(
                 [
                     f"-DCMAKE_C_COMPILER={path}/bin/cc",
                     f"-DCMAKE_CXX_COMPILER={path}/bin/c++",
+                    f"-DCMAKE_C_FLAGS='-fopenmp=libgomp -stdlib=libstdc++ -I{path}/include'",
+                    f"-DCMAKE_CXX_FLAGS='-fopenmp=libgomp -stdlib=libstdc++ -I{path}/include'",
                 ]
             )
-
-        cmake_args.extend(
-            [
-                f"-DCMAKE_C_FLAGS='{' '.join(cxx_args)}'",
-                f"-DCMAKE_CXX_FLAGS='{' '.join(cxx_args)}'",
-            ]
-        )
 
         # Pass CMake args attached to the setup.py call over to the CMake invocation
         for arg in self.other_args:


### PR DESCRIPTION
Summary:
This diff reverts D58147817
D58147817: [FBGEMM][PR] [fbgemm_gpu] Enable NCCL code by q10 causes the following test failure:

Tests affected:
- [cogwheel:cogwheel_llm_py_gpu_accu_eval_ipnext#main](https://www.internalfb.com/intern/test/844425037388229/)

Here's the Multisect link:
https://www.internalfb.com/multisect/5354281
Here are the tasks that are relevant to this breakage:
T186335849: 10+ tests failing for llm_inference_infra

The backout may land if someone accepts it.

If this diff has been generated in error, you can Commandeer and Abandon it.

Reviewed By: feikou, xw285cornell, lacora2017

Differential Revision: D58320078
