### PR TITLE
torch._dynamo.is_compiling -> torch.compiler.is_compiling in fbgemm_gpu

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -60,7 +60,7 @@ except Exception:
 
 
 try:
-    from torch._dynamo import is_compiling as is_torchdynamo_compiling
+    from torch.compiler import is_compiling as is_torchdynamo_compiling
 except Exception:
 
     def is_torchdynamo_compiling() -> bool:  # type: ignore[misc]


### PR DESCRIPTION
Summary: Function got a deprecated decorator, but I don't know why its failing since the function still exists...

Differential Revision: D58372856
