### PR TITLE
Always use hardware casting in AMD triton FP8 cast

### DIFF
--- a/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
@@ -1207,6 +1207,8 @@ def _kernel_quantize_fp8_row(
             A + pid * stride_am + n_offset * stride_an, mask=n_offset < N, other=0.0
         )
         a_fp8 = a * a_scale
+        # Clamp A to fp8 range to make sure there's no overflow.
+        a_fp8 = tl.clamp(a_fp8, -MAX_FP8, MAX_FP8)
         a_fp8.to(TL_FP8_DTYPE)
         tl.store(
             A_fp8 + pid * stride_am + n_offset * stride_an, a_fp8, mask=n_offset < N

--- a/fbgemm_gpu/experimental/gen_ai/bench/ck_fp8_bench.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/ck_fp8_bench.py
@@ -14,6 +14,7 @@ import pandas as pd
 
 import torch
 import triton  # @manual=//triton:triton
+from fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm import quantize_fp8_row
 
 E4M3_MAX_POS: float = torch.finfo(torch.float8_e4m3fnuz).max
 EPS = 1e-12
@@ -116,8 +117,8 @@ def evaluate_impl(
     QA, a_scale = fp8_quantize(A)
     B = torch.randn(N, K).to(dtype=torch.bfloat16, device="cuda")
     QB, b_scale = fp8_quantize(B)
-    QA_row, a_scale_row = fp8_row_quantize(A)
-    QB_row, b_scale_row = fp8_row_quantize(B)
+    QA_row, a_scale_row = quantize_fp8_row(A)
+    QB_row, b_scale_row = quantize_fp8_row(B)
 
     # Check accuracy.
     out_ref = fp_func(A.to(torch.float32), B.t().to(torch.float32))


### PR DESCRIPTION
Summary: There remain issues in the correctness of Triton's software FP8 casting. Specifically, it seems that subnormal values are not properly handled. Since we only use MI300 internally, we can just always use hardware casting instead. This is more correct and probably faster.

Reviewed By: jianyuh, nmacchioni

Differential Revision: D58366123
