### PR TITLE
Prefer torch.compiler.is_compiling to torch._dynamo.is_compiling

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -60,7 +60,16 @@ except Exception:
 
 
 try:
-    from torch._dynamo import is_compiling as is_torchdynamo_compiling
+    try:
+        from torch.compiler import is_compiling
+
+        def is_torchdynamo_compiling() -> bool:  # type: ignore[misc]
+            # at least one test fails if we import is_compiling as a different name
+            return is_compiling()
+
+    except Exception:
+        # torch.compiler.is_compiling is not available in torch 1.10
+        from torch._dynamo import is_compiling as is_torchdynamo_compiling
 except Exception:
 
     def is_torchdynamo_compiling() -> bool:  # type: ignore[misc]


### PR DESCRIPTION
Summary:
`torch._dynamo.is_compiling` is deprecated and it just forwards to `torch.compiler.is_compiling`: https://www.internalfb.com/code/fbsource/[99ea324119d7]/fbcode/caffe2/torch/_dynamo/external_utils.py?lines=28

What's the urgency? two `pytorch` PR's had to be reverted in the past week because using `torch._dynamic.is_comiling` indirectly internal (to Meta) failures.

The failure scenario involves using `jit.script.compile` which is not decorator friendly and deprecating  `torch._dynamo.is_compiling` involves decorating the function with `dprecated`.

There are viable alternatives that involve more effort and risk:

* "fix" `jit.script.compile`
* don't use `jit.script.compile`
* don't decorate `torch._dynamic.is_compiling`

Review question:
* should this be done on the OSS side?

Differential Revision: D58415423
