### PR TITLE
audit icvr custom ops and mark as traceable

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_cpu_template.cpp
@@ -44,6 +44,8 @@ namespace {
 {% if has_cpu_support %}
 class SplitLookupFunction_{{ optimizer }}_Op : public torch::autograd::Function<SplitLookupFunction_{{ optimizer }}_Op> {
  public:
+  static constexpr bool is_traceable = true;
+
   static torch::autograd::variable_list forward(
     torch::autograd::AutogradContext* ctx,
     Tensor host_weights,

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
@@ -529,6 +529,8 @@ Tensor
 class {{ autograd_func }} :
     public torch::autograd::Function<{{ autograd_func }}> {
  public:
+  static constexpr bool is_traceable = true;
+
   static torch::autograd::variable_list forward(
     torch::autograd::AutogradContext* ctx,
     {%- if not dense %}

--- a/fbgemm_gpu/include/fbgemm_gpu/permute_pooled_embedding_function.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/permute_pooled_embedding_function.h
@@ -21,6 +21,8 @@ using torch::autograd::variable_list;
 class PermutePooledEmbsFunction
     : public torch::autograd::Function<PermutePooledEmbsFunction> {
  public:
+  static constexpr bool is_traceable = true;
+
   static Variable forward(
       AutogradContext* ctx,
       const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]


### PR DESCRIPTION
Summary:
only aten ops in scale_gradient and permute_pooled_embedding_function. only custom op redispatch in embedding_backward_split_host_*_template outputs.

flag is used to indicate to torch.compile that this custom autograd function's backward can be traced

Differential Revision: D58438979
