### PR TITLE
Add missing `torch.ops.load_library()`

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/gen_ai/__init__.py
+++ b/fbgemm_gpu/experimental/gen_ai/gen_ai/__init__.py
@@ -32,8 +32,11 @@ else:
         "//deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai:attention_ops"
     )
     torch.ops.load_library(
-        "//deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai:quantize_ops"
+        "//deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai:comm_ops"
     )
     torch.ops.load_library(
         "//deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai:gemm_ops"
+    )
+    torch.ops.load_library(
+        "//deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai:quantize_ops"
     )


### PR DESCRIPTION
Summary: - Add missing `torch.ops.load_library()`

Reviewed By: jianyuh

Differential Revision: D58493360
