### PR TITLE
Add sequence parallel non overlap impl for x-attn layer in mmllm

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/comm/car.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/comm/car.cpp
@@ -35,7 +35,7 @@ namespace {
 
 static_assert(sizeof(cudaIpcMemHandle_t) == 64, "");
 
-constexpr size_t kMaxNumNcclComms = 3;
+constexpr size_t kMaxNumNcclComms = 4;
 
 static ncclComm_t* get_nccl_comm(int64_t comm_idx) {
   static ncclComm_t comms[kMaxNumNcclComms];


### PR DESCRIPTION
Summary:
**We enable sequence parallel (non overlap version) in this diff for the cross attention layer in mm model**

Context: https://fb.workplace.com/notes/1084477789174669?fbclid=IwAR0TikgLSmFcJA8v-mO0Rh8GU9CWoQ3mQxKF3UqfdDKnNA0CNthXjhmZzWU

**w/o SP:**
input=>Rms_norm => cross_attention [AR] => Add with gated => RMS_NORM => FFN [AR] => MASK => Add with Gated

**w/ SP:**
input=> Pad => select by rank  => rms_norm[AG] => cross_attention [RS] => Add with gated => RMS_NORM[AG] => FFN  => MASK [RS]=> Add with Gated

## Benchmarks  :
Benchmark Before/After on LLAMA MM 70b with 20k image token lengths:

On 2K, BS=1, reduced TTFT by 4.27% => 190.54ms
On larger batch sizes/sequence, reduced up to 7% with BS=6, and up to 8% with 8K sequence.

 {F1682006211}

Differential Revision: D57886311
