### PR TITLE
Fix clang vla warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,9 @@ else(MSVC)
   string(APPEND CMAKE_CXX_FLAGS " -Wunknown-pragmas")
   string(APPEND CMAKE_CXX_FLAGS " -Wimplicit-fallthrough")
   string(APPEND CMAKE_CXX_FLAGS " -Wno-strict-aliasing")
+  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 17.0.0)
+    string(APPEND CMAKE_CXX_FLAGS " -Wno-vla-cxx-extension")
+  endif()
   target_compile_options(fbgemm_avx2 PRIVATE
     "-m64" "-mavx2" "-mf16c" "-mfma")
   target_compile_options(fbgemm_avx512 PRIVATE


### PR DESCRIPTION
Fix the error
```
/var/lib/jenkins/workspace/third_party/fbgemm/src/FbgemmI8Spmdm.cc:188:41: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
```