### PR TITLE
Add support for Bias in CK BF16 Gemm and improve small shape tuning

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/gemm/ck_extensions.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/gemm/ck_extensions.hip
@@ -12,6 +12,7 @@
 #include <numeric>
 
 #include <ATen/ATen.h>
+#include <c10/cuda/CUDAStream.h>
 #include <torch/torch.h>
 
 #if defined(USE_ROCM)
@@ -30,7 +31,7 @@
 #include "ck/library/utility/host_tensor_generator.hpp"
 #include "ck/library/utility/literals.hpp"
 
-#include "ck/tensor_operation/gpu/device/impl/device_gemm_xdl_cshuffle_v3.hpp"
+#include "ck/tensor_operation/gpu/device/impl/device_gemm_multiple_d_xdl_cshuffle_v3.hpp"
 
 // Define commonly used types.
 template <ck::index_t... Is>
@@ -39,6 +40,7 @@ using S = ck::Sequence<Is...>;
 using Row = ck::tensor_layout::gemm::RowMajor;
 using Col = ck::tensor_layout::gemm::ColumnMajor;
 using PassThrough = ck::tensor_operation::element_wise::PassThrough;
+using Add = ck::tensor_operation::element_wise::Add;
 
 namespace fbgemm_gpu {
 
@@ -52,37 +54,37 @@ template <
     int MPER_WAVE,
     int NPER_WAVE,
     int CNPER_WAVE = 1,
-    bool PADDING = false>
-at::Tensor bf16_gemm_impl(at::Tensor A, at::Tensor B) {
+    bool PADDING = false,
+    bool BIAS = false>
+at::Tensor bf16_gemm_impl(at::Tensor A, at::Tensor B, std::optional<at::Tensor> bias) {
   // Get input information.
   int M = A.size(0);
   int N = B.size(0);
   int K = A.size(1);
-  // Check that sizes are sufficiently large for grid dispatch.
-  TORCH_CHECK(
-      M >= 128 && N >= 128 && K >= 256,
-      "Minimum supported M,N,K is 128,128,256.")
 
   int StrideA = K;
   int StrideB = K;
   int StrideC = N;
-  int KBatch = 1;
 
   auto C = at::empty({M, N}, A.options().dtype(at::kBFloat16));
 
   using ADataType = ck::bhalf_t;
   using BDataType = ck::bhalf_t;
+  using DDataType = ck::bhalf_t;
+  using DsDataType = std::conditional_t<BIAS, ck::Tuple<DDataType>, ck::Tuple<>>;
   using AccDataType = float;
   using CShuffleDataType = ck::bhalf_t;
   using CDataType = ck::bhalf_t;
 
   using ALayout = Row;
   using BLayout = Col;
+  using DLayout = Row;
+  using DsLayout = std::conditional_t<BIAS, ck::Tuple<DLayout>, ck::Tuple<>>;
   using CLayout = Row;
 
   using AElementOp = PassThrough;
   using BElementOp = PassThrough;
-  using CElementOp = PassThrough;
+  using CElementOp = std::conditional_t<BIAS, Add, PassThrough>;
 
   static constexpr auto GemmDefault =
       ck::tensor_operation::device::GemmSpecialization::Default;
@@ -96,18 +98,20 @@ at::Tensor bf16_gemm_impl(at::Tensor A, at::Tensor B) {
   static constexpr int CBLOCK_M = BLOCK_SIZE / CBLOCK_N;
 
   using DeviceGemmV2Instance =
-      ck::tensor_operation::device::DeviceGemm_Xdl_CShuffleV3<
+      ck::tensor_operation::device::DeviceGemmMultiD_Xdl_CShuffle_V3<
           ALayout,
           BLayout,
+          DsLayout,
           CLayout,
           ADataType,
           BDataType,
+          DsDataType,
           CDataType,
           AccDataType,
           CShuffleDataType,
-          PassThrough,
-          PassThrough,
-          PassThrough,
+          AElementOp,
+          BElementOp,
+          CElementOp,
           GemmSpec,
           BLOCK_SIZE,
           MBLOCK,
@@ -136,7 +140,7 @@ at::Tensor bf16_gemm_impl(at::Tensor A, at::Tensor B) {
           1, // CShuffleMXdlPerWavePerShuffle
           CNPER_WAVE, // CShuffleNXdlPerWavePerShuffle
           S<1, CBLOCK_M, 1, CBLOCK_N>, // CShuffleBlockTransferClusterLengths
-          8, // CShuffleBlockTransferScalarPerVector
+          S<8, 8, 1>, // CShuffleBlockTransferScalarPerVector
           ck::BlockGemmPipelineScheduler::Intrawave, // Pipeline Schedule
           ck::BlockGemmPipelineVersion::v3>; // Pipeline Version
 
@@ -148,48 +152,73 @@ at::Tensor bf16_gemm_impl(at::Tensor A, at::Tensor B) {
   auto b_element_op = BElementOp{};
   auto c_element_op = CElementOp{};
 
+  using DDataArrayType = std::conditional_t<BIAS, std::array<const void*, 1>, std::array<const void*, 0>>;
+  using DStrideArrayType = std::conditional_t<BIAS, std::array<ck::index_t, 1>, std::array<ck::index_t, 0>>;
+
+  DDataArrayType DDataArray;
+  DStrideArrayType DStrideArray;
+
+  if constexpr (BIAS) {
+    DDataArray = {reinterpret_cast<DDataType*>(bias.value().data_ptr())};
+    DStrideArray = {0};
+  }
+
   auto arguments = gemm.MakeArgument(
       reinterpret_cast<ADataType*>(A.data_ptr()),
       reinterpret_cast<BDataType*>(B.data_ptr()),
+      DDataArray,
       reinterpret_cast<CDataType*>(C.data_ptr()),
       M,
       N,
       K,
       StrideA,
       StrideB,
+      DStrideArray,
       StrideC,
-      KBatch,
       a_element_op,
       b_element_op,
       c_element_op);
 
-  invoker.Run(arguments);
+  auto stream = at::cuda::getCurrentHIPStream().stream();
+  invoker.Run(arguments, StreamConfig{stream, false});
 
   return C;
 }
 
-at::Tensor bf16_gemm(at::Tensor A, at::Tensor B) {
-  TORCH_CHECK(
-      A.dtype() == at::kBFloat16 && B.dtype() == at::kBFloat16,
-      "Inputs must be bfloat16.");
+template<bool USE_BIAS=false>
+at::Tensor dispatch_bf16_gemm(at::Tensor A, at::Tensor B, std::optional<at::Tensor> bias) {
   int M = A.size(0);
   int N = B.size(0);
   int K = A.size(1);
   // If any of the shapes cant be tiled, we must use padding.
-  bool use_padding = ((M % 256 != 0) || (N % 256 != 0) || (K % 256 != 0));
+  bool use_padding = ((M % 256 != 0) || (N % 128 != 0) || (K % 64 != 0));
   // Dispatch to best implementation. TODO add more configurations.
   if (use_padding) {
-    if ((M >= 8192 && N >= 4096) || (N >= 8192 && M >= 4096)) {
-      return bf16_gemm_impl<256, 256, 128, 64, 16, 16, 8, 4, 2, true>(A, B);
+    if (M <= 128) {
+      return bf16_gemm_impl<256, 128, 64, 32, 32, 32, 2, 1, 1, true, USE_BIAS>(A, B, bias);
+    } else if ((M >= 8192 && N >= 4096) || (N >= 8192 && M >= 4096)) {
+      return bf16_gemm_impl<256, 256, 128, 64, 16, 16, 8, 4, 2, true, USE_BIAS>(A, B, bias);
     } else {
-      return bf16_gemm_impl<256, 128, 128, 64, 16, 16, 4, 4, 2, true>(A, B);
+      return bf16_gemm_impl<256, 128, 128, 64, 16, 16, 4, 4, 2, true, USE_BIAS>(A, B, bias);
     }
   } else {
     if ((M >= 8192 && N >= 4096) || (N >= 8192 && M >= 4096)) {
-      return bf16_gemm_impl<256, 256, 128, 64, 16, 16, 8, 4, 2, false>(A, B);
+      return bf16_gemm_impl<256, 256, 128, 64, 16, 16, 8, 4, 2, false, USE_BIAS>(A, B, bias);
     } else {
-      return bf16_gemm_impl<256, 128, 128, 64, 16, 16, 4, 4, 2, false>(A, B);
+      return bf16_gemm_impl<256, 128, 128, 64, 16, 16, 4, 4, 2, false, USE_BIAS>(A, B, bias);
     }
+  }
+}
+
+at::Tensor bf16_gemm(at::Tensor A, at::Tensor B, std::optional<at::Tensor> bias = c10::nullopt) {
+  TORCH_CHECK(
+      A.dtype() == at::kBFloat16 && B.dtype() == at::kBFloat16,
+      "Inputs must be bfloat16.");
+  if (bias.has_value()) {
+    TORCH_CHECK(bias.value().dtype() == at::kBFloat16, "Only bfloat16 currently supported for bias.");
+    return dispatch_bf16_gemm<true>(A, B, bias);
+  } else {
+    return dispatch_bf16_gemm<false>(A, B, bias);
   }
 }
 

--- a/fbgemm_gpu/experimental/gen_ai/src/gemm/gemm.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/gemm/gemm.cpp
@@ -11,11 +11,14 @@
 
 namespace fbgemm_gpu {
 
-at::Tensor bf16_gemm(at::Tensor A, at::Tensor B);
+at::Tensor bf16_gemm(
+    at::Tensor A,
+    at::Tensor B,
+    std::optional<at::Tensor> bias = c10::nullopt);
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 #ifdef USE_ROCM
-  m.def("bf16_gemm(Tensor A, Tensor B) -> Tensor");
+  m.def("bf16_gemm(Tensor A, Tensor B, Tensor? bias=None) -> Tensor");
 #endif // USE_ROCM
 }
 
@@ -25,7 +28,10 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
 #endif // USE_ROCM
 }
 
-at::Tensor bf16_gemm_meta(at::Tensor A, at::Tensor B) {
+at::Tensor bf16_gemm_meta(
+    at::Tensor A,
+    at::Tensor B,
+    std::optional<at::Tensor> /* bias */ = c10::nullopt) {
   const at::SymInt M = A.sym_size(0);
   const at::SymInt N = B.sym_size(0);
   auto C = at::empty_symint({M, N}, A.options().dtype(at::kBFloat16));


### PR DESCRIPTION
Summary:
This diff adds support for bias addition to the CK BF16 Gemm by updating to the V3 epilogue enabled kernel. I also add a schedule that does better for small M and expand the benchmark script to more shapes and allow bias benchmarking.

Interestingly it seems like there is currently a bug with `enable_amd_env_vars` that causes the reference to produce very incorrect results, while CK of course still produces proper outputs (which can be confirmed by comparing to the output of a cpu matmul). This may be an issue on the current head that we should fix asap.

Differential Revision: D58641141
