### PR TITLE
Core mx4 quantize optimization

### DIFF
--- a/fbgemm_gpu/src/quantize_ops/mx_common.cuh
+++ b/fbgemm_gpu/src/quantize_ops/mx_common.cuh
@@ -47,7 +47,7 @@ construct_fp4(
     const uint32_t new_biased_exp,
     const uint32_t trailing_mantissa) {
   const uint32_t f_4bit =
-      (trailing_mantissa >> 22) | (new_biased_exp << 1) | (sign << 3);
+      (trailing_mantissa) | (new_biased_exp << 1) | (sign << 3);
   const uint8_t* ptr = reinterpret_cast<const uint8_t*>(&f_4bit);
   return *ptr;
 }


### PR DESCRIPTION
Summary:
Directly constructing the output MX4 value is more efficient than casting back to float32. This yields about a 10% speedup. All tests still pass.

Before: INFO:root:input_size=1073741824 MX4 quantized time per iter: 8566us

After: INFO:root:input_size=1073741824 MX4 quantized time per iter: 7866us

Differential Revision: D58676620
