### PR TITLE
Improve MX4 perf Pt. 3 (dequantize)

### DIFF
--- a/fbgemm_gpu/src/quantize_ops/mx_common.cuh
+++ b/fbgemm_gpu/src/quantize_ops/mx_common.cuh
@@ -49,3 +49,100 @@ construct_fp4(
   const uint8_t* ptr = reinterpret_cast<const uint8_t*>(&f_4bit);
   return *ptr;
 }
+
+__device__ __forceinline__ uint8_t quantize_elemwise_4bit(
+    const float input,
+    const int bits, // bits = mantissa bits + sign bit
+    const int exp_bits, // exp_bits == 0 indicates integer dtype
+    const float max_norm,
+    const RoundingMode rounding_mode = rd_away,
+    const bool saturate_normals = false,
+    const bool allow_denorm = true) {
+  u_float_int input_;
+  input_.f = input;
+
+  // TODO: Refactor to return unsigned data
+  int biased_exp = get_biased_exponent(input_);
+  int sign = get_sign(input_);
+  int tmant = get_trailing_mantissa(input_);
+
+  // Mantissa bits to quantize to (remove sign)
+  const int mbits = bits - 1;
+  const bool is_int = exp_bits == 0;
+
+  // Integers can be treated has having exp bias of 1
+  const int new_bias = is_int ? 1 : (1 << (exp_bits - 1)) - 1;
+  int new_biased_exp = biased_exp - FLOAT32_EXP_BIAS + new_bias;
+
+  // Skip denorms
+  if ((!is_int) && (!allow_denorm) && (new_biased_exp < 1)) {
+    return 0.0;
+  }
+
+  // Use exp_diff to truncate additional bits for subnorms
+  // mbits includes implicit 1, so when new_biased_exp==0
+  // we want exp_diff = 1 to truncate away 1 bit
+  int exp_diff = (new_biased_exp <= 0) ? 1 - new_biased_exp : 0;
+  exp_diff = (exp_diff > FLOAT32_FULL_MBITS) ? FLOAT32_FULL_MBITS : exp_diff;
+
+  // Shift down and round mantissa, allow overflow except for integers
+  // This converts tmant into a full mantissa
+  shift_right_round_mantissa(
+      tmant, biased_exp == 0, mbits, exp_diff, rounding_mode, !is_int);
+
+  if (tmant == 0) {
+    return 0.0;
+  }
+
+  // Shift back up to restore mantissa
+  // This converts back to a trailing mantissa
+  const bool overflow =
+      shift_left_mantissa(tmant, biased_exp == 0, mbits, exp_diff);
+  if (overflow) {
+    biased_exp = biased_exp + 1;
+    new_biased_exp = new_biased_exp + 1;
+  }
+
+  // Reconstruct float number
+  const float output = construct_float(sign, biased_exp, tmant);
+
+  /* Convert float to MX4 encodings:
+    bits  FP4     [int4 lookup]
+                    +  - (sign)
+    S000 = 0    <=> 0  8
+    S001 = 0.5  <=> 1  9
+    S010 = 1    <=> 2  10
+    S011 = 1.5  <=> 3  11
+    S100 = 2.0  <=> 4  12
+    S101 = 3.0  <=> 5  13
+    S110 = 4.0  <=> 6  14
+    S111 = 6.0  <=> 7  15
+  */
+
+  // construct the 4 bit using 1-bit sign, 2-bit new_exp 1-bit tmant
+  // |0.5f| is the exception since it has tmant of 0 instead of 1
+  // return the lookup value
+  if (output == 0.5f) {
+    return 1; // bits 0001
+  } else if (output == -0.5f) {
+    return 9; // bits 1001
+  }
+
+  // Return Inf if rounded value is out of bounds,
+  // unless target format is integer or saturate_normals==True
+  if (abs(output) > max_norm) {
+    if (is_int || saturate_normals) {
+      // max norm = 6.0f => bias=3, tmant = 1, sign remains the same
+      new_biased_exp = 3;
+      tmant = 4194304; // bit 10000000000000000000000
+    } else {
+      // TODO: set Inf for 4 bit for other patterns
+      new_biased_exp = 0xFF;
+      tmant = 0;
+      // e2m1 has no inf
+      CUDA_KERNEL_ASSERT(false);
+    }
+  }
+  CUDA_KERNEL_ASSERT(new_biased_exp >= 0 && new_biased_exp <= 3);
+  return construct_fp4(sign, new_biased_exp, tmant);
+}

--- a/fbgemm_gpu/test/quantize/mx/LICENSE
+++ b/fbgemm_gpu/test/quantize/mx/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/fbgemm_gpu/test/quantize/mx/common.py
+++ b/fbgemm_gpu/test/quantize/mx/common.py
@@ -1,0 +1,572 @@
+# @lint-ignore-every LICENSELINT
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Copyright (c) Microsoft Corporation.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import struct
+from enum import Enum, IntEnum
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+
+
+# -------------------------------------------------------------------------
+# Helper funcs
+# -------------------------------------------------------------------------
+
+FP32_EXPONENT_BIAS: int = 127
+FP32_MIN_NORMAL: float = 2 ** (-FP32_EXPONENT_BIAS + 1)
+
+
+# Enum for rounding modes
+class RoundingMode(IntEnum):
+    nearest = 0
+    floor = 1
+    even = 2
+
+    @staticmethod
+    def string_enums() -> List[str]:
+        return [s.name for s in list(RoundingMode)]
+
+
+# Enum for scalar data formats
+class ElemFormat(Enum):
+    int8 = 1
+    int4 = 2
+    int2 = 3
+    fp8_e5m2 = 4
+    fp8_e4m3 = 5
+    fp6_e3m2 = 6
+    fp6_e2m3 = 7
+    fp4 = 8
+    fp4_e2m1 = 8
+    float16 = 9
+    fp16 = 9
+    bfloat16 = 10
+    bf16 = 10
+
+    @staticmethod
+    def from_str(s: str) -> int:
+        assert s is not None, "String elem_format == None"
+        s = s.lower()
+        if hasattr(ElemFormat, s):
+            return getattr(ElemFormat, s)
+        else:
+            raise Exception("Undefined elem format", s)
+
+
+def _get_min_norm(ebits: int) -> int:
+    """Valid for all float formats"""
+    emin = 2 - (2 ** (ebits - 1))
+    return 0 if ebits == 0 else 2**emin
+
+
+def _get_max_norm(ebits: int, mbits: int) -> float:
+    """Valid only for floats that define NaN"""
+    assert ebits >= 5, "invalid for floats that don't define NaN"
+    emax = 0 if ebits == 0 else 2 ** (ebits - 1) - 1
+    return 2**emax * float(2 ** (mbits - 1) - 1) / 2 ** (mbits - 2)
+
+
+_FORMAT_CACHE: Dict[ElemFormat, Tuple[int, int, int, float, float]] = {}
+
+
+def _get_format_params(  # noqa
+    fmt: ElemFormat | str | None,
+) -> Tuple[int, int, int, float, float]:
+    """Allowed formats:
+    - intX:         2 <= X <= 32, assume sign-magnitude, 1.xxx representation
+    - floatX/fpX:   16 <= X <= 28, assume top exp is used for NaN/Inf
+    - bfloatX/bfX:  9 <= X <= 32
+    - fp4,                  no NaN/Inf
+    - fp6_e3m2/e2m3,        no NaN/Inf
+    - fp8_e4m3/e5m2,        e5m2 normal NaN/Inf, e4m3 special behavior
+
+    Returns:
+      ebits: exponent bits
+      mbits: mantissa bits: includes sign and implicit bits
+      emax: max normal exponent
+      max_norm: max normal number
+      min_norm: min normal number
+    """
+
+    if type(fmt) is str:
+        fmt = ElemFormat.from_str(fmt)
+
+    if fmt in _FORMAT_CACHE:
+        return _FORMAT_CACHE[fmt]
+
+    if fmt == ElemFormat.int8:
+        ebits, mbits = 0, 8
+        emax = 0
+    elif fmt == ElemFormat.int4:
+        ebits, mbits = 0, 4
+        emax = 0
+    elif fmt == ElemFormat.int2:
+        ebits, mbits = 0, 2
+        emax = 0
+    elif fmt == ElemFormat.fp8_e5m2:
+        ebits, mbits = 5, 4
+        emax = 2 ** (ebits - 1) - 1
+    elif fmt == ElemFormat.fp8_e4m3:
+        ebits, mbits = 4, 5
+        emax = 2 ** (ebits - 1)
+    elif fmt == ElemFormat.fp6_e3m2:
+        ebits, mbits = 3, 4
+        emax = 2 ** (ebits - 1)
+    elif fmt == ElemFormat.fp6_e2m3:
+        ebits, mbits = 2, 5
+        emax = 2 ** (ebits - 1)
+    elif fmt == ElemFormat.fp4:
+        ebits, mbits = 2, 3
+        emax = 2 ** (ebits - 1)
+    elif fmt == ElemFormat.float16:
+        ebits, mbits = 5, 12
+        emax = 2 ** (ebits - 1) - 1
+    elif fmt == ElemFormat.bfloat16:
+        ebits, mbits = 8, 9
+        emax = 2 ** (ebits - 1) - 1
+    else:
+        raise Exception("Unknown element format %s" % fmt)
+
+    if fmt != ElemFormat.fp8_e4m3:
+        max_norm = 2**emax * float(2 ** (mbits - 1) - 1) / 2 ** (mbits - 2)
+    else:
+        max_norm = 2**emax * 1.75  # FP8 has custom max_norm
+
+    min_norm = _get_min_norm(ebits)
+
+    _FORMAT_CACHE[fmt] = (ebits, mbits, emax, max_norm, min_norm)
+
+    return ebits, mbits, emax, max_norm, min_norm
+
+
+def _reshape_to_blocks(
+    A: torch.Tensor, axes: List[int], block_size: int
+) -> Tuple[torch.Tensor, List[int], torch.Size, torch.Size]:
+    if axes is None:
+        raise Exception(
+            "axes required in order to determine which "
+            "dimension toapply block size to"
+        )
+    if block_size == 0:
+        raise Exception("block_size == 0 in _reshape_to_blocks")
+
+    # Fix axes to be positive and sort them
+    axes = [(x + len(A.shape) if x < 0 else x) for x in axes]
+    assert all(x >= 0 for x in axes)
+    axes = sorted(axes)
+
+    # Add extra dimension for tiles
+    for i in range(len(axes)):
+        axes[i] += i  # Shift axes due to added dimensions
+        A = torch.unsqueeze(A, dim=axes[i] + 1)
+
+    # Pad to block_size
+    orig_shape = A.size()
+    pad = []
+    for _ in range(len(orig_shape)):
+        pad += [0, 0]
+
+    do_padding = False
+    for axis in axes:
+        pre_pad_size = orig_shape[axis]
+        if isinstance(pre_pad_size, torch.Tensor):
+            pre_pad_size = int(pre_pad_size.value)
+        # Don't pad if the axis is short enough to fit inside one tile
+        if pre_pad_size % block_size == 0:
+            pad[2 * axis] = 0
+        else:
+            pad[2 * axis] = block_size - pre_pad_size % block_size
+            do_padding = True
+
+    if do_padding:
+        pad = list(reversed(pad))
+        A = torch.nn.functional.pad(A, pad, mode="constant")
+
+    def _reshape(shape: List[int], reshape_block_size: int) -> List[int]:
+        for axis in axes:
+            # Reshape to tiles if axis length > reshape_block_size
+            if shape[axis] >= reshape_block_size:
+                assert shape[axis] % reshape_block_size == 0
+                shape[axis + 1] = reshape_block_size
+                shape[axis] = shape[axis] // reshape_block_size
+            # Otherwise preserve length and insert a 1 into the shape
+            else:
+                shape[axis + 1] = shape[axis]
+                shape[axis] = 1
+        return shape
+
+    # Reshape to tiles
+    padded_shape = A.size()
+    reshape = _reshape(list(padded_shape), block_size)
+
+    A = A.view(reshape)
+    return A, axes, orig_shape, padded_shape
+
+
+def _undo_reshape_to_blocks(
+    A: torch.Tensor, padded_shape: torch.Size, orig_shape: torch.Size, axes: List[int]
+) -> torch.Tensor:
+    # Undo tile reshaping
+    A = A.view(padded_shape)
+    # Undo padding
+    if not list(padded_shape) == list(orig_shape):
+        slices = [slice(0, x) for x in orig_shape]
+        A = A[slices]
+    for axis in reversed(axes):
+        # Remove extra dimension
+        A = torch.squeeze(A, dim=axis + 1)
+    return A
+
+
+def get_s_e_m(value_in_float: float) -> Tuple[int, int, int]:
+    def float_to_bits(value_in_float: float) -> int:
+        s = struct.pack("@f", value_in_float)
+        return struct.unpack("@I", s)[0]
+
+    bits = float_to_bits(value_in_float)  # bits in form of uint32
+    sign = (bits & 0x80000000) >> 31  # sign bit
+    exp = ((bits & 0x7F800000) >> 23) - 127  # exponent
+    mant = bits & 0x007FFFFF
+    return sign, exp, mant
+
+
+def all_encodings(
+    _e: int,
+    _m: int,
+    device: torch.device,
+    encodes_infs: bool = True,
+) -> torch.Tensor:
+    _CACHE = {}
+    if (_e, _m, encodes_infs) in _CACHE:
+        x = _CACHE[(_e, _m, encodes_infs)]
+        return torch.as_tensor(x, dtype=torch.float32, device=device)
+
+    # Holds all positive and negative
+    x = np.zeros((2 ** (_e + _m + 1)), dtype=np.float32)
+    for _i in range(2 ** (_e + _m)):
+        if _e > 0:
+            _exp = _i >> _m
+            # Skip exp == all ones
+            if encodes_infs and _exp == 2**_e - 1:
+                continue
+            # Normal or subnormal encoding
+            if _exp == 0:
+                _exp = 1 - (2 ** (_e - 1) - 1)
+                _explicit = 0.0
+            else:
+                _exp -= 2 ** (_e - 1) - 1
+                _explicit = 1.0
+            # Obtain mantissa value
+            _mant = _i & ((2**_m) - 1)
+            _mmant = _mant / (2**_m)
+
+            # FP8 e4m3 hack
+            if _e == 4 and _m == 3 and _exp == 8 and _mmant == 0.875:
+                _value = 0
+            else:
+                _value = 2 ** (_exp) * (_explicit + _mmant)
+        else:
+            _value = _i / (2 ** (_m - 1))
+
+        x[_i] = _value
+        x[_i + 2 ** (_e + _m)] = -_value
+
+    _CACHE[(_e, _m, encodes_infs)] = x
+
+    return torch.as_tensor(x, dtype=torch.float32, device=device)
+
+
+# -------------------------------------------------------------------------
+# Helper funcs for test
+# -------------------------------------------------------------------------
+
+
+def check_diff_quantize(
+    x: torch.Tensor,
+    y1: torch.Tensor,
+    y2: torch.Tensor,
+    tol: int = 0,
+    ntol: int = 0,
+    handle_infs: bool = False,
+) -> bool:
+    """In floating-point x==y with inf on both sides returns NaN.
+    If handle_infs is True, then we allow inf==inf to pass.
+    """
+    __tracebackhide__ = True
+
+    # Check shapes
+    if y1.size() != y2.size():
+        print("Size mismatch: ", list(y1.size()), "!=", list(y2.size()))
+        raise IndexError
+
+    # Convert to numpy
+    x = np.array(x) if type(x) is list else x
+    x = x.cpu().numpy() if type(x) is torch.Tensor else x
+    y1 = y1.detach().cpu().numpy()
+    y2 = y2.detach().cpu().numpy()
+
+    torch_infs = np.isinf(y1) | np.isnan(y1)
+    cuda_infs = np.isinf(y2) | np.isnan(y2)
+    y1_ = np.where(torch_infs, 0.0, y1)
+    y2_ = np.where(cuda_infs, 0.0, y2)
+    diff = abs(y1_ - y2_)
+
+    # Don't compare infs if requested
+    if not handle_infs:
+        torch_infs = None
+        cuda_infs = None
+
+    # Check for differences
+    max_diff = np.max(diff)
+    ndiff = np.sum(diff > tol)  # num of violations
+    if (max_diff > tol and ndiff > ntol) or np.any(torch_infs != cuda_infs):
+        where_diff = (diff != 0) | (torch_infs != cuda_infs)
+        print("%d/%d mismatches" % (np.count_nonzero(where_diff), where_diff.size))
+        print("First and last mismatch:")
+        print("Orig:", x[where_diff][0], get_s_e_m(x[where_diff][0]))
+        print("y1:  ", y1[where_diff][0], get_s_e_m(y1[where_diff][0]))
+        print("y2:  ", y2[where_diff][0], get_s_e_m(y2[where_diff][0]))
+        if np.count_nonzero(where_diff) > 1:
+            print("--------------------")
+            print("Orig:", x[where_diff][-1], get_s_e_m(x[where_diff][-1]))
+            print("y1:  ", y1[where_diff][-1], get_s_e_m(y1[where_diff][-1]))
+            print("y2:  ", y2[where_diff][-1], get_s_e_m(y2[where_diff][-1]))
+        # raise ValueError
+        return False
+    return True
+
+
+# -------------------------------------------------------------------------
+# Helper funcs for quantization
+# -------------------------------------------------------------------------
+
+
+# Never explicitly compute 2**(-exp) since subnorm numbers have
+# exponents smaller than -126
+def _safe_lshift(x: torch.Tensor, bits: int, exp: Optional[int]) -> torch.Tensor:
+    if exp is None:
+        return x * (2**bits)
+    else:
+        return x / (2**exp) * (2**bits)
+
+
+def _safe_rshift(x: torch.Tensor, bits: int, exp: Optional[int]) -> torch.Tensor:
+    if exp is None:
+        return x / (2**bits)
+    else:
+        return x / (2**bits) * (2**exp)
+
+
+def _round_mantissa(
+    A: torch.Tensor, bits: int, round: RoundingMode, clamp: bool = False
+) -> torch.Tensor:
+    """
+    Rounds mantissa to nearest bits depending on the rounding method 'round'
+    Args:
+      A     {PyTorch tensor} -- Input tensor
+      round {str}            --  Rounding method
+                                 "floor" rounds to the floor
+                                 "nearest" rounds to ceil or floor, whichever is nearest
+    Returns:
+      A {PyTorch tensor} -- Tensor with mantissas rounded
+    """
+
+    if round == "dither":
+        rand_A = torch.rand_like(A, requires_grad=False)
+        A = torch.sign(A) * torch.floor(torch.abs(A) + rand_A)
+    elif round == "floor":
+        A = torch.sign(A) * torch.floor(torch.abs(A))
+    elif round == "nearest":
+        A = torch.sign(A) * torch.floor(torch.abs(A) + 0.5)
+    elif round == "even":
+        absA = torch.abs(A)
+        # find 0.5, 2.5, 4.5 ...
+        maskA = ((absA - 0.5) % 2 == torch.zeros_like(A)).type(A.dtype)
+        A = torch.sign(A) * (torch.floor(absA + 0.5) - maskA)
+    else:
+        raise Exception("Unrecognized round method %s" % (round))
+
+    # Clip values that cannot be expressed by the specified number of bits
+    if clamp:
+        max_mantissa = 2 ** (bits - 1) - 1
+        A = torch.clamp(A, -max_mantissa, max_mantissa)
+    return A
+
+
+def _shared_exponents(
+    A: torch.Tensor,
+    method: str = "max",
+    axes: Optional[List[int]] = None,
+    ebits: int = 0,
+) -> torch.Tensor:
+    """
+    Get shared exponents for the passed matrix A.
+    Args:
+      A      {PyTorch tensor} -- Input tensor
+      method {str}            -- Exponent selection method.
+                                 "max" uses the max absolute value
+                                 "none" uses an exponent for each value (i.e., no sharing)
+      axes   {list(int)}      -- List of integers which specifies the axes across which
+                                 shared exponents are calculated.
+    Returns:
+      shared_exp {PyTorch tensor} -- Tensor of shared exponents
+    """
+
+    if method == "max":
+        if axes is None:
+            shared_exp = torch.max(torch.abs(A))
+        else:
+            shared_exp = A
+            for axis in axes:
+                shared_exp, _ = torch.max(torch.abs(shared_exp), dim=axis, keepdim=True)
+    elif method == "none":
+        shared_exp = torch.abs(A)
+    else:
+        raise Exception("Unrecognized shared exponent selection method %s" % (method))
+
+    # log2(shared_exp) and truncate to integer
+    shared_exp = torch.floor(
+        torch.log2(
+            shared_exp + FP32_MIN_NORMAL * (shared_exp == 0).type(shared_exp.dtype)
+        )
+    )
+
+    # Restrict to [-emax, emax] range
+    if ebits > 0:
+        emax = 2 ** (ebits - 1) - 1
+        # shared_exp = torch.clamp(shared_exp, -emax, emax)
+        # Overflow to Inf
+        shared_exp[shared_exp > emax] = float("NaN")
+        # Underflows are set to -127 which causes them to be
+        # flushed to 0 later
+        shared_exp[shared_exp < -emax] = -emax
+
+    return shared_exp
+
+
+# -------------------------------------------------------------------------
+# Main funcs
+# -------------------------------------------------------------------------
+def _quantize_elemwise_core(
+    A: torch.Tensor,
+    bits: int,
+    exp_bits: int,
+    max_norm: float,
+    round: str = "nearest",
+    saturate_normals: bool = False,
+    allow_denorm: bool = True,
+    custom_cuda: bool = False,
+) -> torch.Tensor:
+    """
+    Core function used for element-wise quantization
+    Arguments:
+      A         {PyTorch tensor} -- A tensor to be quantized
+      bits      {int}            -- Number of mantissa bits. Includes
+                                    sign bit and implicit one for floats
+      exp_bits  {int}            -- Number of exponent bits, 0 for ints
+      max_norm  {float}          -- Largest representable normal number
+      round     {str}            -- Rounding mode: (floor, nearest, even)
+      saturate_normals {bool}    -- If True, normal numbers (i.e., not NaN/Inf)
+                                    that exceed max norm are clamped.
+                                    Must be True for correct MX conversion.
+      allow_denorm     {bool}    -- If False, flush denorm numbers in the
+                                    elem_format to zero.
+      custom_cuda      {str}     -- If True, use custom CUDA kernels
+    Returns:
+      quantized tensor {PyTorch tensor} -- A tensor that has been quantized
+    """
+    A_is_sparse = A.is_sparse
+    if A_is_sparse:
+        if A.layout != torch.sparse_coo:
+            raise NotImplementedError(
+                "Only COO layout sparse tensors are currently supported."
+            )
+
+        sparse_A = A.coalesce()
+        A = sparse_A.values().clone()
+
+    # Flush values < min_norm to zero if denorms are not allowed
+    if not allow_denorm and exp_bits > 0:
+        min_norm = _get_min_norm(exp_bits)
+        out = (torch.abs(A) >= min_norm).type(A.dtype) * A
+    else:
+        out = A
+
+    if exp_bits != 0:
+        private_exp = torch.floor(torch.log2(torch.abs(A) + (A == 0).type(A.dtype)))
+
+        # The minimum representable exponent for 8 exp bits is -126
+        min_exp = -(2 ** (exp_bits - 1)) + 2
+        private_exp = private_exp.clip(min=min_exp)
+    else:
+        private_exp = None
+
+    # Scale up so appropriate number of bits are in the integer portion of the number
+    out = _safe_lshift(out, bits - 2, private_exp)
+
+    out = _round_mantissa(out, bits, round, clamp=False)
+
+    # Undo scaling
+    out = _safe_rshift(out, bits - 2, private_exp)
+
+    # Set values > max_norm to Inf if desired, else clamp them
+    if saturate_normals or exp_bits == 0:
+        out = torch.clamp(out, min=-max_norm, max=max_norm)
+    else:
+        out = torch.where(
+            (torch.abs(out) > max_norm), torch.sign(out) * float("Inf"), out
+        )
+
+    # handle Inf/NaN
+    if not custom_cuda:
+        out[A == float("Inf")] = float("Inf")
+        out[A == -float("Inf")] = -float("Inf")
+        out[A == float("NaN")] = float("NaN")
+
+    if A_is_sparse:
+        out = torch.sparse_coo_tensor(
+            sparse_A.indices(),
+            out,
+            sparse_A.size(),
+            dtype=sparse_A.dtype,
+            device=sparse_A.device,
+            requires_grad=sparse_A.requires_grad,
+        )
+
+    return out
+
+
+def _quantize_elemwise(
+    A: torch.Tensor,
+    elem_format: ElemFormat | None,
+    round: str = "nearest",
+    custom_cuda: bool = False,
+    saturate_normals: bool = False,
+    allow_denorm: bool = True,
+) -> torch.Tensor:
+    """Quantize values to a defined format. See _quantize_elemwise_core()"""
+    if elem_format is None:
+        return A
+
+    ebits, mbits, _, max_norm, _ = _get_format_params(elem_format)
+
+    output = _quantize_elemwise_core(
+        A,
+        mbits,
+        ebits,
+        max_norm,
+        round=round,
+        allow_denorm=allow_denorm,
+        saturate_normals=saturate_normals,
+        custom_cuda=custom_cuda,
+    )
+
+    return output

--- a/fbgemm_gpu/test/quantize/mx4_test.py
+++ b/fbgemm_gpu/test/quantize/mx4_test.py
@@ -1,0 +1,187 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import List
+
+import hypothesis.strategies as st
+
+import torch
+from deeplearning.fbgemm.fbgemm_gpu.test.quantize.mx.common import check_diff_quantize
+
+from hypothesis import given, settings, Verbosity
+
+from . import common  # noqa E402
+from .common import open_source
+from .mx.common import (
+    _get_format_params,
+    _quantize_elemwise_core,
+    _reshape_to_blocks,
+    _shared_exponents,
+    _undo_reshape_to_blocks,
+    all_encodings,
+)
+
+if open_source:
+    # pyre-ignore[21]
+    from test_utils import gpu_unavailable
+else:
+    from fbgemm_gpu.test.test_utils import gpu_unavailable
+
+
+FP32_EXPONENT_BIAS: int = 127
+FP32_MIN_NORMAL: float = 2 ** (-FP32_EXPONENT_BIAS + 1)
+
+
+def fake_quantize_mx_cuda(
+    A: torch.Tensor,
+    scale_bits: int = 8,
+    ebits: int = 2,
+    mbits: int = 3,
+    emax: int = 2,
+    max_norm: float = 6.0,
+    group_size: int = 32,
+) -> torch.Tensor:
+    """Call MX* quantization CUDA implementation"""
+
+    mx_quantized = torch.ops.fbgemm.quantize_mx_cuda(
+        A,
+        scale_bits,
+        ebits,
+        mbits,
+        max_norm,
+        group_size,
+    )
+
+    return torch.ops.fbgemm.dequantize_mx_cuda(
+        mx_quantized,
+        group_size,
+    )
+
+
+def fake_quantize_mx(
+    A: torch.Tensor,
+    scale_bits: int,
+    ebits: int = 2,
+    mbits: int = 3,
+    emax: int = 2,
+    max_norm: float = 6.0,
+    group_size: int = 32,
+    shared_exp_method: str = "max",
+    axes: List[int] = [-1],  # noqa
+    round: str = "nearest",
+    flush_fp32_subnorms: bool = False,
+) -> torch.Tensor:
+    """Function used for MX* fake quantization"""
+
+    ####################
+    # Python Quantize
+    ####################
+
+    # Make sure axes is a list of non-negative numbers
+    axes = [x + A.ndim if x < 0 else x for x in axes]
+
+    # Perform tiling to the hardware vector size
+    if group_size > 0:
+        A, axes, orig_shape, padded_shape = _reshape_to_blocks(A, axes, group_size)
+
+    shared_exp_axes = [x + 1 for x in axes] if group_size > 0 else axes
+
+    # Get shared exponents
+    shared_exp = _shared_exponents(
+        A,
+        method=shared_exp_method,
+        axes=shared_exp_axes,
+        ebits=0,
+    )
+
+    # Flush subnormal FP32 inputs to zero
+    if flush_fp32_subnorms:
+        A = A * (shared_exp > -FP32_EXPONENT_BIAS).type(A.dtype)
+
+    # Offset the max exponent by the largest representable exponent
+    # in the element data format
+    shared_exp = shared_exp - emax
+
+    scale_emax = 2 ** (scale_bits - 1) - 1
+    shared_exp[shared_exp > scale_emax] = float("NaN")
+    shared_exp[shared_exp < -scale_emax] = -scale_emax
+
+    _shared_exp: torch.Tensor = shared_exp.cpu()
+    scale = (2**_shared_exp).to(A.device)
+
+    A = A / (scale)
+
+    A = _quantize_elemwise_core(
+        A,
+        mbits,
+        ebits,
+        max_norm,
+        round=round,
+        allow_denorm=True,
+        saturate_normals=True,
+        custom_cuda=False,
+    )
+
+    A = A * scale
+
+    # Undo tile reshaping
+    if group_size:
+        A = _undo_reshape_to_blocks(A, padded_shape, orig_shape, axes)
+
+    return A
+
+
+# @optests.generate_opcheck_tests()
+class TestMXQuantizationConversion(unittest.TestCase):
+
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-fixme[56]:
+    @given(
+        power=st.integers(min_value=5, max_value=7),
+        sizes=st.integers(min_value=4, max_value=12),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    def test_mx4(self, power: int, sizes: int) -> None:
+        group_size = 2**power
+        device = torch.device("cuda")
+
+        input = all_encodings(8, sizes, device=device)
+        assert input.numel() % group_size == 0
+
+        axes = [-1]
+        element_format_str = "fp4_e2m1"
+        ebits, mbits, emax, max_norm, _ = _get_format_params(element_format_str)
+        scale_bits = 8
+
+        output_ref = fake_quantize_mx(
+            input,
+            scale_bits,
+            ebits,
+            mbits,
+            emax,
+            max_norm,
+            axes=axes,
+            group_size=group_size,
+        )
+
+        output = fake_quantize_mx_cuda(
+            input,
+            scale_bits,
+            ebits,
+            mbits,
+            emax,
+            max_norm,
+            group_size=group_size,
+        )
+
+        check_diff_quantize(input, output_ref, output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
This kernel is compute bound when the input tensor is very large. This diff improves dequantization ops by making each thread work on 4 quantized and write 4 float output using `float4`. 

Performance improvement:
quant: n/a
dequant: 10M -> 5.7M

Note:
1 thread work on 1 uint8 and write 2 output
10M -> 7.8 M

For 2**30 input
MX4: 5.8 ms
FP8: 7.29 ms

Reviewed By: sryap

Differential Revision: D58443942


