### PR TITLE
Use current_device as rank can be different.

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/comm/car.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/comm/car.cu
@@ -287,7 +287,7 @@ void car_init(
       ptr = local_buffer.data_ptr();
     }
 #ifndef __HIP_PLATFORM_AMD__
-    auto target_rank = rank;
+    auto target_rank = at::cuda::current_device();
 #else
     /*
      * This is to mitigate an issue for ROCm where the
@@ -306,7 +306,7 @@ void car_init(
   for (auto ii = 0; ii < world_size; ++ii) {
     void* ptr = nullptr;
 #ifndef __HIP_PLATFORM_AMD__
-    auto target_rank = rank;
+    auto target_rank = at::cuda::current_device();
 #else
     auto target_rank = (ii == rank ? rank : 0);
 #endif


### PR DESCRIPTION
Summary: Use current_device as rank is not guaranteed to be matching device in complicated scenarios.

Differential Revision: D58763992
