### PR TITLE
KJT custom op for 1d lengths input

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -91,6 +91,15 @@ at::Tensor segment_sum_csr_cpu(
 /// href="https://www.doxygen.nl/manual/commands.html#cmdlink">here</a>
 
 std::tuple<at::Tensor, at::Tensor, std::optional<at::Tensor>>
+permute_2D_sparse_data_input1D(
+    const at::Tensor& permute,
+    const at::Tensor& lengths,
+    const at::Tensor& indices,
+    const int64_t& stride,
+    const std::optional<at::Tensor>& weights,
+    const std::optional<int64_t>& permuted_lengths_sum);
+
+std::tuple<at::Tensor, at::Tensor, std::optional<at::Tensor>>
 permute_2D_sparse_data_cuda(
     const at::Tensor& permute,
     const at::Tensor& lengths,


### PR DESCRIPTION
Summary:
# context
* move the `tensor.view(-1, stride)` from python into the operator (c++)
* make the PT2 complier happy
* reference: D58948987

# notes
* not sure if we should directly change the op call in the jagged_tensor
* tested in CPU
* backward and GPU haven't tested

Differential Revision: D58956327


