### PR TITLE
Update scaled_mm signature in quantize benchmark.

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
@@ -165,7 +165,7 @@ class ScaledMMBaseline(QuantizeOpBase):
         return xq, wq, x_scale, w_scale
 
     def compute(self, xq, wq, x_scale, w_scale):
-        output, _ = torch._scaled_mm(
+        output = torch._scaled_mm(
             xq,
             wq,
             bias=None,


### PR DESCRIPTION
Summary: D58699985 changed the return type of `torch._scaled_mm`. We need to update our implementation to match to avoid errors on main. We should consider adding a test to prevent future API breakages.

Differential Revision: D58981269
