### PR TITLE
Add Cublas FP8 + Rowwise Scaling Kernel

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions.cu
@@ -1991,8 +1991,8 @@ at::Tensor f8i4bf16_rowwise(
 at::Tensor f8f8bf16_cublas(
     at::Tensor A, // FP8
     at::Tensor B, // FP8
-    at::Tensor Ainvs,
-    at::Tensor Binvs,
+    std::optional<at::Tensor> Ainvs = c10::nullopt,
+    std::optional<at::Tensor> Binvs = c10::nullopt,
     bool use_fast_accum = true,
     std::optional<at::Tensor> output = c10::nullopt) {
   auto m = A.size(0);
@@ -2023,11 +2023,6 @@ at::Tensor f8f8bf16_cublas(
     TORCH_CHECK(output_tensor.options().dtype() == at::kBFloat16);
   }
 
-  // Hack to avoid passing the additional A_scale_scale/B_scale_inverse, which
-  // should be a single FP32 element per input tensor for inverse scale.
-
-  const float* Ainvs_pt = Ainvs.data_ptr<float>();
-  const float* Binvs_pt = Binvs.data_ptr<float>();
   const cudaDataType_t A_type = CUDA_R_8F_E4M3;
   const cudaDataType_t B_type = CUDA_R_8F_E4M3;
   const cudaDataType_t D_type = CUDA_R_16BF;
@@ -2068,16 +2063,23 @@ at::Tensor f8f8bf16_cublas(
       &fastAccuMode,
       sizeof(fastAccuMode)));
 
-  checkCublasStatus(cublasLtMatmulDescSetAttribute(
-      operationDesc,
-      CUBLASLT_MATMUL_DESC_A_SCALE_POINTER,
-      &Ainvs_pt,
-      sizeof(Ainvs_pt)));
-  checkCublasStatus(cublasLtMatmulDescSetAttribute(
-      operationDesc,
-      CUBLASLT_MATMUL_DESC_B_SCALE_POINTER,
-      &Binvs_pt,
-      sizeof(Binvs_pt)));
+  if (Ainvs.has_value()) {
+    const float* Ainvs_pt = Ainvs.value().data_ptr<float>();
+    checkCublasStatus(cublasLtMatmulDescSetAttribute(
+        operationDesc,
+        CUBLASLT_MATMUL_DESC_A_SCALE_POINTER,
+        &Ainvs_pt,
+        sizeof(Ainvs_pt)));
+  }
+
+  if (Binvs.has_value()) {
+    const float* Binvs_pt = Binvs.value().data_ptr<float>();
+    checkCublasStatus(cublasLtMatmulDescSetAttribute(
+        operationDesc,
+        CUBLASLT_MATMUL_DESC_B_SCALE_POINTER,
+        &Binvs_pt,
+        sizeof(Binvs_pt)));
+  }
 
   checkCublasStatus(cublasLtMatmulDescSetAttribute(
       operationDesc,
@@ -2134,10 +2136,10 @@ at::Tensor f8f8bf16_cublas(
 at::Tensor f8f8bf16_cublas(
     at::Tensor A, // FP8
     at::Tensor B, // FP8
-    at::Tensor Ainvs,
-    at::Tensor Binvs,
-    bool use_fast_accum,
-    std::optional<at::Tensor> output) {
+    std::optional<at::Tensor> Ainvs = c10::nullopt,
+    std::optional<at::Tensor> Binvs = c10::nullopt,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> output = c10::nullopt) {
   throw std::runtime_error(
       "CUDA version is older than 12.0"); // requires CUDA>=12
 }

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -58,10 +58,10 @@ at::Tensor f8f8bf16_blockwise(
 at::Tensor f8f8bf16_cublas(
     at::Tensor A,
     at::Tensor B,
-    at::Tensor Ainvs,
-    at::Tensor Binvs,
-    bool use_fast_accum,
-    std::optional<at::Tensor> output);
+    std::optional<at::Tensor> Ainvs = c10::nullopt,
+    std::optional<at::Tensor> Binvs = c10::nullopt,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> output = c10::nullopt);
 at::Tensor f8i4bf16_rowwise(
     at::Tensor XQ,
     at::Tensor WQ,
@@ -119,7 +119,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "f8f8bf16(Tensor XQ, Tensor WQ, Tensor scale, bool use_fast_accum=True) -> Tensor");
 
   m.def(
-      "f8f8bf16_cublas(Tensor A, Tensor B, Tensor Ainvs, Tensor Binvs, bool use_fast_accum=True, Tensor(a!)? output=None) -> Tensor");
+      "f8f8bf16_cublas(Tensor A, Tensor B, Tensor? Ainvs=None, Tensor? Binvs=None, bool use_fast_accum=True, Tensor(a!)? output=None) -> Tensor");
 
   m.def(
       "f8i4bf16_rowwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor w_zp) -> Tensor");
@@ -246,10 +246,10 @@ std::vector<at::Tensor> quantize_fp8_per_tensor_meta(
 at::Tensor f8f8bf16_cublas_meta(
     at::Tensor X,
     at::Tensor W,
-    at::Tensor x_scale,
-    at::Tensor w_scale,
-    bool use_fast_accum = true,
-    std::optional<at::Tensor> output = c10::nullopt) {
+    std::optional<at::Tensor> /* x_scale = c10::nullopt */,
+    std::optional<at::Tensor> /* w_scale = c10::nullopt */,
+    bool /* use_fast_accum = true */,
+    std::optional<at::Tensor> /* output = c10::nullopt */) {
   const at::SymInt M = X.sym_size(0);
   const at::SymInt N = W.sym_size(0);
   auto Y = at::empty_symint({M, N}, X.options().dtype(at::kBFloat16));


### PR DESCRIPTION
Summary:
It recently was noted that in some cases using unfused cublas FP8 matmul and a followup rowwise scaling kernel was more efficient than trying to use fused kernels. This Diff makes it easier to use this unfused approach and adds a triton kernel specifically for stand-alone rowwise scaling.

We do see that this unfused cublas + scale approach is better for very large shapes than cutlass. Maybe we can do a multi dispatch just like we did for tensorwise scaling.

[Results Sheet](https://docs.google.com/spreadsheets/d/1zONUBvN-vI2kDQFYVSVBwdbSzRDtbHvvc2kzG6xkZ64/edit?usp=sharing)

 {F1717407393}

Reviewed By: jianyuh, jiawenliu64

Differential Revision: D58960601
