### PR TITLE
Implement some custom fb op out variant kernels

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/input_combine.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/input_combine.h
@@ -46,4 +46,11 @@ tbe_input_combine_with_length_cuda(
     const uint64_t max_list_size,
     const c10::DeviceIndex& device);
 
+void tbe_input_combine_with_length_cpu_out(
+    at::Tensor& combined_indices,
+    at::Tensor& combined_lengths,
+    at::Tensor& combined_per_sample_weights,
+    const std::vector<at::Tensor>& indices_list,
+    const std::vector<at::Tensor>& lengths_list,
+    const std::vector<at::Tensor>& per_sample_weights);
 } // namespace fbgemm_gpu


### PR DESCRIPTION
Summary:
Implement an out variant version of tbe_input_combine_with_length, offsets_to_lengths, and lenghts_to_offsets, and add a skeleton for custom fb op static kernel dispatch in sigmoid.

Also start adding native kernels (ie. kernels with no out variant but for which we can directly go to the native implementation rather than first going torch torch dispatcher)

Reviewed By: henryoier

Differential Revision: D57453462
