### PR TITLE
Add Cutlass Blockwise Kernel to Quantize Benchmark

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_blockwise_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_blockwise_gemm.hip
@@ -76,11 +76,6 @@ at::Tensor f8f8bf16_blockwise_impl(
   int StrideB = K;
   int StrideE = N;
 
-  // For now hardcode block size.
-  TORCH_CHECK(block_m == 256);
-  TORCH_CHECK(block_n == 256);
-  TORCH_CHECK(block_k == 256);
-
   int ScaleStrideAM = K / block_k;
   int ScaleStrideAK = 1;
   int ScaleStrideBN = K / block_k;
@@ -243,9 +238,9 @@ at::Tensor f8f8bf16_blockwise(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    int64_t block_m,
-    int64_t block_n,
-    int64_t block_k) {
+    int64_t block_m = 256,
+    int64_t block_n = 256,
+    int64_t block_k = 256) {
   // Check that input datatypes are valid.
   TORCH_CHECK(
       (XQ.dtype() == at::kFloat8_e4m3fnuz) &&

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions.cu
@@ -1666,9 +1666,9 @@ at::Tensor f8f8bf16_blockwise(
     at::Tensor WQ, // FP8
     at::Tensor x_scale, // FP32
     at::Tensor w_scale, // FP32
-    int64_t block_m,
-    int64_t block_n,
-    int64_t block_k) {
+    int64_t block_m = 256,
+    int64_t block_n = 256,
+    int64_t block_k = 256) {
   // Check datatypes.
   TORCH_CHECK(
       x_scale.dtype() == at::kFloat && w_scale.dtype() == at::kFloat,
@@ -2443,9 +2443,9 @@ at::Tensor f8f8bf16_blockwise(
     at::Tensor WQ, // FP8
     at::Tensor x_scale,
     at::Tensor w_scale,
-    int64_t block_m,
-    int64_t block_n,
-    int64_t block_k) {
+    int64_t block_m = 256,
+    int64_t block_n = 256,
+    int64_t block_k = 256) {
   throw std::runtime_error(
       "CUDA version is older than 12.0"); // requires CUDA>=12
 }

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -56,9 +56,9 @@ at::Tensor f8f8bf16_blockwise(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    int64_t block_m,
-    int64_t block_n,
-    int64_t block_k);
+    int64_t block_m = 256,
+    int64_t block_n = 256,
+    int64_t block_k = 256);
 at::Tensor f8f8bf16_cublas(
     at::Tensor A,
     at::Tensor B,
@@ -138,7 +138,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.impl("i8i8bf16_dynamic", i8i8bf16_dynamic);
 #endif
   m.def(
-      "f8f8bf16_blockwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, int block_m, int block_n, int block_k) -> Tensor");
+      "f8f8bf16_blockwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, int block_m=256, int block_n=256, int block_k=256) -> Tensor");
   m.def(
       "f8f8bf16_rowwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? bias=None, bool use_fast_accum=True, Tensor(a!)? output=None) -> Tensor");
   m.def(
@@ -226,9 +226,9 @@ at::Tensor f8f8bf16_blockwise_meta(
     at::Tensor WQ, // FP8
     at::Tensor /* x_scale */,
     at::Tensor /* w_scale */,
-    int64_t /* block_m */,
-    int64_t /* block_n */,
-    int64_t /* block_k */) {
+    int64_t /* block_m = 256*/,
+    int64_t /* block_n = 256*/,
+    int64_t /* block_k = 256*/) {
   int M = XQ.size(0);
   int N = WQ.size(0);
   auto Y = at::empty({M, N}, XQ.options().dtype(at::kBFloat16));


### PR DESCRIPTION
Summary: This diff adds the new cutlass blockwise kernel added in D57965065 to quantize_bench.py. I also set a default block size to make the API conformant with the triton quantize op that is often paired with it.

Reviewed By: choudharydhruv

Differential Revision: D59249763
