### PR TITLE
Use better exponent rounding in Triton MX4 quantize kernel

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/quantize/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/quantize/__init__.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 import torch
+
 from fbgemm_gpu.quantize.quantize_ops import dequantize_mx, quantize_mx  # noqa F401
 
 

--- a/fbgemm_gpu/fbgemm_gpu/triton/quantize_ref.py
+++ b/fbgemm_gpu/fbgemm_gpu/triton/quantize_ref.py
@@ -46,11 +46,11 @@ def py_quantize_mx4(a: torch.Tensor, group_size: int = 32) -> torch.Tensor:
     # Convert max into an intger exponent.
     # Note this can be more efficient by just shifting and masking exp bits.
     # We can even use those directly.
-    shared_exp = torch.floor(torch.log2(shared_exp))
+    shared_exp = torch.ceil(torch.log2(shared_exp))
     # Offset exponent by largest exponent in target datatype.
     shared_exp = shared_exp - 2
     # Restrict to range expressible as int8.
-    shared_exp = torch.clamp(shared_exp, min=-127, max=127)
+    shared_exp = torch.clamp(shared_exp, min=-127, max=125)
     # Convert exponent to scale and apply to input.
     # Need to do this calculation on cpu for accuracy.
     _shared_exp = shared_exp.cpu()


### PR DESCRIPTION
Summary:
As noted in [this doc](https://docs.google.com/document/d/156Du0hBRH6umG_i-OrYC574XhpQMUU5SJYG0RTS2tTg/edit#heading=h.akfcp7xpg8cr), using a ceiling round for scale calculation does a better job of not truncating some mantissa bits. This diff switches triton's floor rounding to ceil rounding.

Note that currently mx4_test doesnt pass as the cuda kernel now has different behavior than triton. Once we rebase this diff onto a similar change to the cuda kernel, we should see exact matching outputs again.

Reviewed By: jianyuh

Differential Revision: D59527463
