### PR TITLE
Triton MX4 Quantize Rounding Mode Support.

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/quantize/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/quantize/__init__.py
@@ -49,7 +49,8 @@ if "fbgemm::quantize_mx" not in torch.library._defs:
             int elem_ebits,
             int elem_mbits,
             float elem_max_norm,
-            int mx_group_size
+            int mx_group_size,
+            int? rounding_mode = None
         ) -> Tensor
         """
     )

--- a/fbgemm_gpu/fbgemm_gpu/quantize/quantize_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/quantize/quantize_ops.py
@@ -4,11 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# # pyre-unsafe
+# pyre-unsafe
+from typing import Union
 
 import torch
 
-from fbgemm_gpu.quantize_utils import fp32_to_mx4, mx4_to_fp32
+from fbgemm_gpu.quantize_utils import fp32_to_mx4, mx4_to_fp32, RoundingMode
 
 
 def quantize_mx(
@@ -18,6 +19,7 @@ def quantize_mx(
     elem_mbits: int = 3,
     elem_max_norm: float = 6.0,
     mx_group_size: int = 32,
+    rounding_mode: Union[RoundingMode, int] = RoundingMode.ceil,
 ) -> torch.Tensor:
     """
     Registered quantize_mx ops for E2E comm.
@@ -31,6 +33,7 @@ def quantize_mx(
                     i.e., 3 for MX4 e2m1)
         elem_max_norm: max value of the float (i.e., 6.0 for MX4 e2m1)
         mx_group_size: num elements that share the max shared_exponent
+        rounding_mode: Which type of rounding to use when calculating shared exponent.
 
     Return:
         output: MX4 tensor packed into int8 values with size
@@ -38,7 +41,9 @@ def quantize_mx(
                 the shared exponent of each group is stored at the last byte
                 of output of each group
     """
-    return fp32_to_mx4(input, mx_group_size, use_triton=True)
+    return fp32_to_mx4(
+        input, mx_group_size, rounding_mode=rounding_mode, use_triton=True
+    )
 
 
 def dequantize_mx(

--- a/fbgemm_gpu/fbgemm_gpu/quantize_utils.py
+++ b/fbgemm_gpu/fbgemm_gpu/quantize_utils.py
@@ -8,7 +8,6 @@
 # pyre-strict
 
 import logging
-import math
 
 import torch
 
@@ -45,15 +44,9 @@ def fp32_to_mx4(
         output: MX4 tensor packed into int8 values with total elements (M / 2 + M / groupsize)
     """
     # Accelerated MX4 is only available on cuda, if input is on cpu, use python.
-    # For CPU and triton, set the second dim to 2048 or the nearest power of 2.
-    dim = (
-        2048 if tensor.numel() >= 2048 else 2 ** (math.floor(math.log2(tensor.numel())))
-    )
-    input = (
-        tensor.view(-1)
-        if (tensor.is_cuda and not use_triton) or tensor.numel() % dim != 0
-        else tensor.view(-1, dim)
-    )
+    # Operate on flattened input.
+    input = tensor.flatten()
+
     if not tensor.is_cuda:
         return py_quantize_mx4(input, group_size)
 

--- a/fbgemm_gpu/fbgemm_gpu/triton/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/triton/__init__.py
@@ -8,6 +8,8 @@
 # pyre-unsafe
 
 # Attempt to import triton kernels, fallback to reference if we cannot.
+from .common import RoundingMode  # noqa
+
 try:
     from .quantize import (
         triton_dequantize_mx4 as dequantize_mx4,

--- a/fbgemm_gpu/fbgemm_gpu/triton/common.py
+++ b/fbgemm_gpu/fbgemm_gpu/triton/common.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+from enum import IntEnum
+
+
+class RoundingMode(IntEnum):
+    """Rounding options for quantization."""
+
+    nearest = 0
+    floor = 1
+    even = 2
+    stochastic = 3
+    ceil = 4

--- a/fbgemm_gpu/test/quantize/mx4_test.py
+++ b/fbgemm_gpu/test/quantize/mx4_test.py
@@ -217,6 +217,7 @@ class TestMXQuantizationConversion(unittest.TestCase):
         )
 
         check_diff_quantize(input, output_ref, output_cuda)
+        check_diff_quantize(input, output_cuda, output_triton)
         check_diff_quantize(input, output_cuda, output_cuda_from_quantized_triton)
         check_diff_quantize(input, output_cuda_from_quantized_triton, output_triton)
         check_diff_quantize(input, output_triton, output_cpu)


### PR DESCRIPTION
Summary: This diff adds the `rounding_mode` argument to triton quantize. We support (almost) all the rounding described in the [best practices doc](https://docs.google.com/document/d/156Du0hBRH6umG_i-OrYC574XhpQMUU5SJYG0RTS2tTg/edit#heading=h.akfcp7xpg8cr). Stochastic coming soon.

Differential Revision: D59562029
