### PR TITLE
Remove redundant torch.abs in sim check

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/bench/quantize_bench.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/quantize_bench.py
@@ -58,7 +58,7 @@ def benchmark(
             # Compute the output given quantized values.
             output = quantize_op.compute(*quantized_vals)
             # Compare the quantize op output to reference as a sanity check.
-            sim_check = torch.mean(torch.pow(torch.abs(output - out_ref), 2))
+            sim_check = torch.mean(torch.pow(output - out_ref, 2))
 
             # Now perform benchmark.
             if bench_quantize:


### PR DESCRIPTION
Summary:
The absolute value is redundant because
the next step involves squaring the differences,
which makes all values non-negative.