### PR TITLE
Add 3D+ input support for fp8 rowwise GEMM

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
@@ -166,6 +166,7 @@ class FP8Tests(unittest.TestCase):
         Bias=st.sampled_from([True, False]),
         CudaGraph=st.sampled_from([True, False]),
         UseTriton=st.sampled_from([True, False]),
+        InputMultiDim=st.booleans(),
     )
     def test_quantize_fp8_matmul(
         self,
@@ -177,8 +178,12 @@ class FP8Tests(unittest.TestCase):
         Bias: bool,
         CudaGraph: bool,
         UseTriton: bool,
+        InputMultiDim: bool,
     ) -> None:
-        x = torch.randn(size=(B_T, D), dtype=torch.bfloat16, device="cuda") * 0.1
+        if InputMultiDim:
+            x = torch.randn(size=(3, B_T, D), dtype=torch.bfloat16, device="cuda") * 0.1
+        else:
+            x = torch.randn(size=(B_T, D), dtype=torch.bfloat16, device="cuda") * 0.1
         w = torch.randn(size=(HD_L, D), dtype=torch.bfloat16, device="cuda") * 0.01
         bias = (
             torch.randn(size=(HD_L,), dtype=torch.bfloat16, device="cuda")
@@ -362,8 +367,8 @@ class FP8Tests(unittest.TestCase):
             atol = 1.0e-1
             rtol = 1.0e-1
         else:
-            atol = 8.0e-2
-            rtol = 8.0e-2
+            atol = 9.0e-2
+            rtol = 9.0e-2
         torch.testing.assert_close(zq, zq_ref, atol=atol, rtol=rtol)
 
     @unittest.skipIf(


### PR DESCRIPTION
Summary:
The input activation can be 3D+, with first dimension as batch dimension.

- 1. If the input tensor is {M, K}, the output tensor is {M, N}.
- 2. If the input tensor is {b, M, K}, the output tensor is {b, M, N}.

This Diff adds the support, to match nn.Linear function / matmul supports.

Differential Revision: D59671644
