### PR TITLE
Add fused bias to Triton FP8 Rowwise Kernels

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
@@ -353,10 +353,11 @@ class TritonFP8RowwiseGemm(QuantizeOpBase):
         # Quantize both input tensors.
         xq, x_scale = quantize_fp8_row(x)
         wq, w_scale = quantize_fp8_row(w)
-        return xq, wq, x_scale, w_scale
+        bias = torch.randn(w.shape[0], device=x.device, dtype=torch.float32)
+        return xq, wq, x_scale, w_scale, bias
 
-    def compute(self, xq, wq, x_scale, w_scale):
-        return matmul_fp8_row(xq, wq, x_scale, w_scale)
+    def compute(self, xq, wq, x_scale, w_scale, bias):
+        return matmul_fp8_row(xq, wq, x_scale, w_scale, bias=bias)
 
     def quantize_and_compute(self, x, w):
         xq, wq, x_scale, w_scale = self.quantize(x, w)


### PR DESCRIPTION
Summary: This diff adds an optional `bias` input to matmul_fp8_row, which is needed for some ads use cases. I havent yet added support for the TMA persistent kernel since its a little confusing and not currently used. I'll try to add it as a follow-up.

Differential Revision: D59784977
