### PR TITLE
Use auto-vec kernel in CPU sequential embedding lookup for int8 tables

### DIFF
--- a/src/EmbeddingSpMDMAutovec.cc
+++ b/src/EmbeddingSpMDMAutovec.cc
@@ -102,12 +102,14 @@ bool EmbeddingSpMDM8Bit_autovec(
   IndexType current = 0;
 
   if (no_bag) {
+#pragma unroll 4
     for (int m = 0; m < output_size; ++m) {
       const auto idx = indices[m];
 
       if (idx < 0 || idx >= data_size) {
         return false;
       }
+
       if constexpr (isOutput8bit) {
         const uint8_t* input_row_ptr = input + input_stride * idx;
         memcpy(out, input_row_ptr, sizeof(uint8_t) * input_stride);


### PR DESCRIPTION
Differential Revision: D59940518
