### PR TITLE
FP8 kernel development and enablement.

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16.cu
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/DeviceGuard.h>
+#include <ATen/Dispatch.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/Exceptions.h>
+#include <c10/core/ScalarType.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <ATen/cuda/Atomic.cuh>
+
+#include <cutlass/cutlass.h>
+#include <cutlass/library/library.h>
+#include <cutlass/util/host_tensor.h>
+#include <cutlass/util/packed_stride.hpp>
+
+// clang-format off
+// The fixed ordering of the headers is required for CUTLASS 3.2+
+#include <cute/tensor.hpp>
+#include <cutlass/gemm/collective/collective_builder.hpp>     // @manual
+#include <cutlass/gemm/device/gemm_universal_adapter.h>       // @manual
+#include <cutlass/epilogue/collective/collective_builder.hpp> // @manual
+// clang-format on
+
+#include <cutlass_extensions/include/gemm_description.h>
+#include <cutlass_extensions/include/manifest.h>
+#include <cutlass_extensions/include/operation_table.h>
+#include <cutlass_extensions/include/singleton.h>
+#include <cutlass_extensions/include/utils.h>
+#include <iostream>
+
+namespace fbgemm_gpu {
+
+class Fp8GemmTensorWiseHeuristics {
+  //
+  // Data members
+  //
+
+ private:
+  // GemmPerformanceKey -> [operations]
+  cutlass_extensions::GemmOperationPerformanceMap operation_map;
+
+  //
+  // Methods
+  //
+
+ private:
+  /// Returns an operation ptr given a performance key.
+  cutlass::library::Operation const* _find_operation(
+      cutlass_extensions::GemmPerformanceKey const& key) const {
+    auto operation_it = operation_map.find(key);
+    if (operation_it == operation_map.end()) {
+      std::stringstream ss;
+      ss << "cutlass_extensions::GemmPerformanceKey key = ";
+      cutlass_extensions::operator<<(ss, key) << std::endl;
+      ss << "Not found in the GemmOperationPerformanceMap.";
+      throw std::runtime_error(ss.str());
+    }
+    return operation_it->second[0];
+  }
+
+  /// Returns an operation based on a strict problem_shape -> operation mapping.
+  cutlass::library::Operation const* _strict_heuristics(
+      cutlass::gemm::GemmCoord problem_shape) const {
+    /*
+      TODO: For every problem shape we dispatch to the top-performning
+      operation*
+    */
+    return nullptr;
+  }
+
+  /// Returns an operation based on a relaxed generalized heuristcs.
+  cutlass::library::Operation const* _relaxed_heuristics(
+      cutlass::gemm::GemmCoord problem_shape) const {
+    if (problem_shape.n() <= 128) {
+      cutlass_extensions::GemmPerformanceKey perf_key(
+          {64, 128, 32}, // instruction shape
+          {64, 128, 128}, // threadblock shape
+          {2, 1, 1}, // cluster shape
+          cutlass_extensions::MainloopSchedule::kWarpspecialized,
+          cutlass_extensions::EpilogueSchedule::kUnknown);
+      return _find_operation(perf_key);
+    } else {
+      cutlass_extensions::GemmPerformanceKey perf_key(
+          {64, 128, 32}, // instruction shape
+          {128, 128, 128}, // threadblock shape
+          {1, 2, 1}, // cluster shape
+          cutlass_extensions::MainloopSchedule::kWarpspecialized,
+          cutlass_extensions::EpilogueSchedule::kUnknown);
+      return _find_operation(perf_key);
+    }
+  }
+
+ public:
+  /// ctor
+  Fp8GemmTensorWiseHeuristics(
+      cutlass_extensions::GemmOperationPerformanceMap operation_map)
+      : operation_map(operation_map) {}
+
+  /// Returns a operation give a gemm problem shape.
+  cutlass::library::Operation const* operator()(
+      cutlass::gemm::GemmCoord problem_shape) const {
+    if (auto const* operation = _strict_heuristics(problem_shape))
+      return operation;
+    else
+      return _relaxed_heuristics(problem_shape);
+  }
+};
+
+/// FP8 Gemm with tensor wise scaling.
+/// Input A   : MxK matrix in FP8 and RowMajor layout.
+/// Input B   : KxN matrix in FP8 and ColumnMajor layout.
+/// Returns Y  : MxN matrix in FP8 and ColumnMajor layout.
+at::Tensor f8f8bf16_tnn(
+    at::Tensor A, // FP8, RowMajor
+    at::Tensor B, // FP8, ColumnMajor
+    at::Tensor scale,
+    bool use_fast_accum) {
+  // Get the gemm_operation_with_tensorwise operation table.
+  auto& operation_map = cutlass_extensions::Singleton::get()
+                            .operation_table.gemm_operations_with_tensorwise;
+
+  // Select a gemm operation with tensorwise scaling.
+  cutlass_extensions::AccumKind accum_kind = (use_fast_accum)
+      ? (cutlass_extensions::AccumKind::kFastAccum)
+      : (cutlass_extensions::AccumKind::kDefault);
+
+  cutlass_extensions::GemmFunctionalKey functional_key(
+      cutlass::library::Provider::kCUTLASS, // Operator provider
+      cutlass::library::GemmKind::kUniversal, // Gemm kind
+      cutlass::library::NumericTypeID::kF32, // Accumulation type
+      cutlass::library::NumericTypeID::kFE4M3, // ElementA
+      cutlass::library::LayoutTypeID::kRowMajor, // LayoutA
+      cutlass::library::NumericTypeID::kFE4M3, // ElementB
+      cutlass::library::LayoutTypeID::kColumnMajor, // LayoutB
+      cutlass::library::NumericTypeID::kBF16, // ElementC
+      cutlass::library::LayoutTypeID::kColumnMajor, // LayoutC
+      cutlass::library::NumericTypeID::kBF16, // ElementD
+      cutlass::library::LayoutTypeID::kColumnMajor, // LayoutC
+      cutlass_extensions::FusionKind::kTensorwiseScaling, // Scaling type
+      accum_kind);
+
+  auto operation_perf_it = operation_map.find(functional_key);
+
+  if (operation_perf_it == operation_map.end()) {
+    std::stringstream ss;
+    ss << "GemmFunctionaKey key = ";
+    cutlass_extensions::operator<<(ss, functional_key) << std::endl;
+    ss << "Not found in the GemmOperationFunctionalMap.";
+    throw std::runtime_error(ss.str());
+  }
+
+  int M = A.size(0);
+  int N = B.size(0);
+  int K = A.size(1);
+  cutlass::gemm::GemmCoord problem_shape{M, N, K};
+
+  // Query heuristics and select a gemm with tensorwise scaling operation.
+  Fp8GemmTensorWiseHeuristics heur(operation_perf_it->second);
+  auto const* operation = heur(problem_shape);
+  if (!operation) {
+    throw std::runtime_error("Heuristics returned null operation.");
+  }
+
+  // Output tensor
+  auto Y = at::empty(
+      {problem_shape.n(), problem_shape.m()}, A.options().dtype(at::kBFloat16));
+
+  // Initialize configuration
+  cutlass::library::GemmUniversalConfiguration configuration{
+      cutlass::library::GemmUniversalMode::kGemm,
+      problem_shape, // Gemm problem shape
+      1, // Batch size
+      problem_shape.k(), // lda (row-major)
+      problem_shape.k(), // ldb (column-major)
+      problem_shape.m(), // ldc (column-major)
+      problem_shape.m() // ldd (column-major)
+  };
+
+  // Initialize arguments
+  cutlass::library::GemmUniversalArguments arguments;
+  arguments.problem_size = problem_shape;
+  arguments.batch_count = 1;
+  arguments.lda = configuration.lda;
+  arguments.ldb = configuration.ldb;
+  arguments.ldc = configuration.ldc;
+  arguments.ldd = configuration.ldd;
+  arguments.batch_stride_A = problem_shape.mk().product();
+  arguments.batch_stride_B = problem_shape.nk().product();
+  arguments.batch_stride_C = problem_shape.mn().product();
+  arguments.batch_stride_D = problem_shape.mn().product();
+
+  arguments.A = reinterpret_cast<void const*>(A.data_ptr());
+  arguments.B = reinterpret_cast<void const*>(B.data_ptr());
+  arguments.C = reinterpret_cast<void*>(Y.data_ptr());
+  arguments.D = reinterpret_cast<void*>(Y.data_ptr());
+  arguments.alpha = reinterpret_cast<void const*>(scale.data_ptr());
+  arguments.beta = nullptr;
+  arguments.pointer_mode = cutlass::library::ScalarPointerMode::kDevice;
+  arguments.sm_count = 132;
+  arguments.raster_order = cutlass::library::RasterOrder::kHeuristic;
+
+  // Buffer used for the operation's host workspace
+  std::vector<uint8_t> host_workspace;
+  uint64_t host_workspace_size =
+      operation->get_host_workspace_size(&configuration);
+  host_workspace.resize(host_workspace_size, 0);
+
+  // Device workspace size
+  uint64_t device_workspace_size =
+      operation->get_device_workspace_size(&configuration, &arguments);
+
+  // Allocate device workspace memory
+  cutlass::device_memory::allocation<uint8_t> device_workspace(
+      device_workspace_size);
+
+  // Check if we can call this kernel
+  cutlass::Status status = cutlass::Status::kSuccess;
+  status = operation->can_implement(&configuration, &arguments);
+
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass operation can_implement failed.");
+  }
+
+  // Initialize host and device workspaces
+  status = operation->initialize(
+      &configuration,
+      host_workspace.data(),
+      device_workspace.get(),
+      at::cuda::getCurrentCUDAStream());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass operation initialize failed.");
+  }
+
+  // Run the Gemm operator
+  status = operation->run(
+      &arguments,
+      host_workspace.data(),
+      device_workspace.get(),
+      at::cuda::getCurrentCUDAStream());
+
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass operation run failed.");
+  }
+
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  return Y;
+}
+
+/// FP8 Gemm with tensor wise scaling.
+/// Input XQ   : MxK matrix in FP8 and RowMajor layout.
+/// Input WQ   : KxN matrix in FP8 and ColumnMajor layout.
+/// Returns Y  : MxN matrix in FP8 and RowMajor layout.
+at::Tensor f8f8bf16_v2(
+    at::Tensor XQ, // FP8, RowMajor
+    at::Tensor WQ, // FP8, ColumnMajor
+    at::Tensor scale,
+    bool use_fast_accum) {
+  // Swap and run the kernel with ColumnMajor output
+  return f8f8bf16_tnn(WQ, XQ, scale, use_fast_accum);
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/fp8_gemm_with_tensorwise/cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_epi_nosmem.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/fp8_gemm_with_tensorwise/cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_epi_nosmem.cu
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// clang-format off
+
+#include "cutlass/cutlass.h"
+#include "cutlass/library/library.h"
+
+#include "cutlass/arch/wmma.h"
+#include "cutlass/numeric_types.h"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+
+// cutlass_extensions includes
+#include <cutlass_extensions/include/manifest.h>
+#include <cutlass_extensions/include/gemm_operation_wrapper_3x.h>
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_epi_nosmem_epilogue =
+  typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+    cute::Shape<cute::_128, cute::_128, cute::_128>,
+    cute::Shape<cute::_1, cute::_2, cute::_1>,
+    cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float,
+    cutlass::bfloat16_t, cutlass::layout::ColumnMajor, 1,
+    cutlass::bfloat16_t, cutlass::layout::ColumnMajor, 1,
+    cutlass::epilogue::NoSmemWarpSpecialized,
+
+    cutlass::epilogue::fusion::LinearCombination<
+      cutlass::bfloat16_t,
+      float,
+      cutlass::bfloat16_t,
+      float
+    >
+
+  >::CollectiveOp;
+
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_epi_nosmem_mainloop =
+  typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+    cutlass::float_e4m3_t, cutlass::layout::RowMajor, 16,
+    cutlass::float_e4m3_t, cutlass::layout::ColumnMajor, 16,
+    float,
+    cute::Shape<cute::_128, cute::_128, cute::_128>,
+    cute::Shape<cute::_1, cute::_2, cute::_1>,
+    cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(sizeof(typename cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_epi_nosmem_epilogue::SharedStorage))>,
+    cutlass::gemm::KernelTmaWarpSpecialized
+  >::CollectiveOp;
+
+// Gemm operator cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_epi_nosmem
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_epi_nosmem_base = cutlass::gemm::kernel::GemmUniversal<
+    cute::Shape<int,int,int,int>,
+    cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_epi_nosmem_mainloop,
+    cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_epi_nosmem_epilogue,
+    cutlass::gemm::PersistentScheduler>;
+
+// Define named type
+struct cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_epi_nosmem :
+  public cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_epi_nosmem_base { };
+
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass_extensions {
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+void initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_epi_nosmem(Manifest &manifest) {
+
+
+
+  {
+    using GemmKernel = cutlass::gemm::device::GemmUniversalAdapter<cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_epi_nosmem>;
+    manifest.append(
+      new cutlass_extensions::GemmOperationWrapper3x<GemmKernel>("cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_epi_nosmem"));
+  }
+
+
+
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass_extensionss
+
+///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/fp8_gemm_with_tensorwise/cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/fp8_gemm_with_tensorwise/cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem.cu
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// clang-format off
+
+#include "cutlass/cutlass.h"
+#include "cutlass/library/library.h"
+
+#include "cutlass/arch/wmma.h"
+#include "cutlass/numeric_types.h"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+
+// cutlass_extensions includes
+#include <cutlass_extensions/include/manifest.h>
+#include <cutlass_extensions/include/gemm_operation_wrapper_3x.h>
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem_epilogue =
+  typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+    cute::Shape<cute::_128, cute::_128, cute::_128>,
+    cute::Shape<cute::_1, cute::_2, cute::_1>,
+    cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float,
+    cutlass::bfloat16_t, cutlass::layout::ColumnMajor, 1,
+    cutlass::bfloat16_t, cutlass::layout::ColumnMajor, 1,
+    cutlass::epilogue::NoSmemWarpSpecialized,
+
+    cutlass::epilogue::fusion::LinearCombination<
+      cutlass::bfloat16_t,
+      float,
+      cutlass::bfloat16_t,
+      float
+    >
+
+  >::CollectiveOp;
+
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem_mainloop =
+  typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+    cutlass::float_e4m3_t, cutlass::layout::RowMajor, 16,
+    cutlass::float_e4m3_t, cutlass::layout::ColumnMajor, 16,
+    float,
+    cute::Shape<cute::_128, cute::_128, cute::_128>,
+    cute::Shape<cute::_1, cute::_2, cute::_1>,
+    cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(sizeof(typename cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem_epilogue::SharedStorage))>,
+    cutlass::gemm::KernelTmaWarpSpecializedFP8FastAccum
+  >::CollectiveOp;
+
+// Gemm operator cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem_base = cutlass::gemm::kernel::GemmUniversal<
+    cute::Shape<int,int,int,int>,
+    cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem_mainloop,
+    cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem_epilogue,
+    cutlass::gemm::PersistentScheduler>;
+
+// Define named type
+struct cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem :
+  public cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem_base { };
+
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass_extensions {
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+void initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem(Manifest &manifest) {
+
+
+
+  {
+    using GemmKernel = cutlass::gemm::device::GemmUniversalAdapter<cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem>;
+    manifest.append(
+      new cutlass_extensions::GemmOperationWrapper3x<GemmKernel>("cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem"));
+  }
+
+
+
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass_extensions
+
+///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/fp8_gemm_with_tensorwise/cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_epi_nosmem.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/fp8_gemm_with_tensorwise/cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_epi_nosmem.cu
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// clang-format off
+
+#include "cutlass/cutlass.h"
+#include "cutlass/library/library.h"
+
+#include "cutlass/arch/wmma.h"
+#include "cutlass/numeric_types.h"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+
+// cutlass_extensions includes
+#include <cutlass_extensions/include/manifest.h>
+#include <cutlass_extensions/include/gemm_operation_wrapper_3x.h>
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_epi_nosmem_epilogue =
+  typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+    cute::Shape<cute::_128, cute::_128, cute::_128>,
+    cute::Shape<cute::_1, cute::_2, cute::_1>,
+    cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float,
+    cutlass::bfloat16_t, cutlass::layout::RowMajor, 1,
+    cutlass::bfloat16_t, cutlass::layout::RowMajor, 1,
+    cutlass::epilogue::NoSmemWarpSpecialized,
+
+    cutlass::epilogue::fusion::LinearCombination<
+      cutlass::bfloat16_t,
+      float,
+      cutlass::bfloat16_t,
+      float
+    >
+
+  >::CollectiveOp;
+
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_epi_nosmem_mainloop =
+  typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+    cutlass::float_e4m3_t, cutlass::layout::RowMajor, 16,
+    cutlass::float_e4m3_t, cutlass::layout::ColumnMajor, 16,
+    float,
+    cute::Shape<cute::_128, cute::_128, cute::_128>,
+    cute::Shape<cute::_1, cute::_2, cute::_1>,
+    cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(sizeof(typename cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_epi_nosmem_epilogue::SharedStorage))>,
+    cutlass::gemm::KernelTmaWarpSpecialized
+  >::CollectiveOp;
+
+// Gemm operator cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_epi_nosmem
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_epi_nosmem_base = cutlass::gemm::kernel::GemmUniversal<
+    cute::Shape<int,int,int,int>,
+    cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_epi_nosmem_mainloop,
+    cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_epi_nosmem_epilogue,
+    cutlass::gemm::PersistentScheduler>;
+
+// Define named type
+struct cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_epi_nosmem :
+  public cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_epi_nosmem_base { };
+
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass_extensions {
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+void initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_epi_nosmem(Manifest &manifest) {
+
+
+
+  {
+    using GemmKernel = cutlass::gemm::device::GemmUniversalAdapter<cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_epi_nosmem>;
+    manifest.append(
+      new cutlass_extensions::GemmOperationWrapper3x<GemmKernel>("cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_epi_nosmem"));
+  }
+
+
+
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass_extensions
+
+///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/fp8_gemm_with_tensorwise/cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/fp8_gemm_with_tensorwise/cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem.cu
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// clang-format off
+
+#include "cutlass/cutlass.h"
+#include "cutlass/library/library.h"
+
+#include "cutlass/arch/wmma.h"
+#include "cutlass/numeric_types.h"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+
+// cutlass_extensions includes
+#include <cutlass_extensions/include/manifest.h>
+#include <cutlass_extensions/include/gemm_operation_wrapper_3x.h>
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem_epilogue =
+  typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+    cute::Shape<cute::_128, cute::_128, cute::_128>,
+    cute::Shape<cute::_1, cute::_2, cute::_1>,
+    cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float,
+    cutlass::bfloat16_t, cutlass::layout::RowMajor, 1,
+    cutlass::bfloat16_t, cutlass::layout::RowMajor, 1,
+    cutlass::epilogue::NoSmemWarpSpecialized,
+
+    cutlass::epilogue::fusion::LinearCombination<
+      cutlass::bfloat16_t,
+      float,
+      cutlass::bfloat16_t,
+      float
+    >
+
+  >::CollectiveOp;
+
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem_mainloop =
+  typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+    cutlass::float_e4m3_t, cutlass::layout::RowMajor, 16,
+    cutlass::float_e4m3_t, cutlass::layout::ColumnMajor, 16,
+    float,
+    cute::Shape<cute::_128, cute::_128, cute::_128>,
+    cute::Shape<cute::_1, cute::_2, cute::_1>,
+    cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(sizeof(typename cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem_epilogue::SharedStorage))>,
+    cutlass::gemm::KernelTmaWarpSpecializedFP8FastAccum
+  >::CollectiveOp;
+
+// Gemm operator cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem_base = cutlass::gemm::kernel::GemmUniversal<
+    cute::Shape<int,int,int,int>,
+    cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem_mainloop,
+    cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem_epilogue,
+    cutlass::gemm::PersistentScheduler>;
+
+// Define named type
+struct cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem :
+  public cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem_base { };
+
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass_extensions {
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+void initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem(Manifest &manifest) {
+
+
+
+  {
+    using GemmKernel = cutlass::gemm::device::GemmUniversalAdapter<cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem>;
+    manifest.append(
+      new cutlass_extensions::GemmOperationWrapper3x<GemmKernel>("cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem"));
+  }
+
+
+
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass_extensions
+
+///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/fp8_gemm_with_tensorwise/cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_epi_nosmem.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/fp8_gemm_with_tensorwise/cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_epi_nosmem.cu
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// clang-format off
+
+#include "cutlass/cutlass.h"
+#include "cutlass/library/library.h"
+
+#include "cutlass/arch/wmma.h"
+#include "cutlass/numeric_types.h"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+
+// cutlass_extensions includes
+#include <cutlass_extensions/include/manifest.h>
+#include <cutlass_extensions/include/gemm_operation_wrapper_3x.h>
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_epi_nosmem_epilogue =
+  typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+    cute::Shape<cute::_64, cute::_128, cute::_128>,
+    cute::Shape<cute::_2, cute::_1, cute::_1>,
+    cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float,
+    cutlass::bfloat16_t, cutlass::layout::ColumnMajor, 1,
+    cutlass::bfloat16_t, cutlass::layout::ColumnMajor, 1,
+    cutlass::epilogue::NoSmemWarpSpecialized,
+
+    cutlass::epilogue::fusion::LinearCombination<
+      cutlass::bfloat16_t,
+      float,
+      cutlass::bfloat16_t,
+      float
+    >
+
+  >::CollectiveOp;
+
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_epi_nosmem_mainloop =
+  typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+    cutlass::float_e4m3_t, cutlass::layout::RowMajor, 16,
+    cutlass::float_e4m3_t, cutlass::layout::ColumnMajor, 16,
+    float,
+    cute::Shape<cute::_64, cute::_128, cute::_128>,
+    cute::Shape<cute::_2, cute::_1, cute::_1>,
+    cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(sizeof(typename cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_epi_nosmem_epilogue::SharedStorage))>,
+    cutlass::gemm::KernelTmaWarpSpecialized
+  >::CollectiveOp;
+
+// Gemm operator cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_epi_nosmem
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_epi_nosmem_base = cutlass::gemm::kernel::GemmUniversal<
+    cute::Shape<int,int,int,int>,
+    cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_epi_nosmem_mainloop,
+    cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_epi_nosmem_epilogue,
+    cutlass::gemm::PersistentScheduler>;
+
+// Define named type
+struct cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_epi_nosmem :
+  public cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_epi_nosmem_base { };
+
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass_extensions {
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+void initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_epi_nosmem(Manifest &manifest) {
+
+
+
+  {
+    using GemmKernel = cutlass::gemm::device::GemmUniversalAdapter<cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_epi_nosmem>;
+    manifest.append(
+      new cutlass_extensions::GemmOperationWrapper3x<GemmKernel>("cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_epi_nosmem"));
+  }
+
+
+
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass_extensions
+
+///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/fp8_gemm_with_tensorwise/cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/fp8_gemm_with_tensorwise/cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem.cu
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// clang-format off
+
+#include "cutlass/cutlass.h"
+#include "cutlass/library/library.h"
+
+#include "cutlass/arch/wmma.h"
+#include "cutlass/numeric_types.h"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+
+// cutlass_extensions includes
+#include <cutlass_extensions/include/manifest.h>
+#include <cutlass_extensions/include/gemm_operation_wrapper_3x.h>
+
+
+
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem_epilogue =
+  typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+    cute::Shape<cute::_64, cute::_128, cute::_128>,
+    cute::Shape<cute::_2, cute::_1, cute::_1>,
+    cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float,
+    cutlass::bfloat16_t, cutlass::layout::ColumnMajor, 1,
+    cutlass::bfloat16_t, cutlass::layout::ColumnMajor, 1,
+    cutlass::epilogue::NoSmemWarpSpecialized,
+
+    cutlass::epilogue::fusion::LinearCombination<
+      cutlass::bfloat16_t,
+      float,
+      cutlass::bfloat16_t,
+      float
+    >
+
+  >::CollectiveOp;
+
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem_mainloop =
+  typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+    cutlass::float_e4m3_t, cutlass::layout::RowMajor, 16,
+    cutlass::float_e4m3_t, cutlass::layout::ColumnMajor, 16,
+    float,
+    cute::Shape<cute::_64, cute::_128, cute::_128>,
+    cute::Shape<cute::_2, cute::_1, cute::_1>,
+    cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(sizeof(typename cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem_epilogue::SharedStorage))>,
+    cutlass::gemm::KernelTmaWarpSpecializedFP8FastAccum
+  >::CollectiveOp;
+
+// Gemm operator cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem_base = cutlass::gemm::kernel::GemmUniversal<
+    cute::Shape<int,int,int,int>,
+    cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem_mainloop,
+    cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem_epilogue,
+    cutlass::gemm::PersistentScheduler>;
+
+// Define named type
+struct cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem :
+  public cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem_base { };
+
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass_extensions {
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+void initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem(Manifest &manifest) {
+
+
+
+  {
+    using GemmKernel = cutlass::gemm::device::GemmUniversalAdapter<cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem>;
+    manifest.append(
+      new cutlass_extensions::GemmOperationWrapper3x<GemmKernel>("cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem"));
+  }
+
+
+
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass_extensions
+
+///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/fp8_gemm_with_tensorwise/cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_epi_nosmem.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/fp8_gemm_with_tensorwise/cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_epi_nosmem.cu
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// clang-format off
+
+#include "cutlass/cutlass.h"
+#include "cutlass/library/library.h"
+
+#include "cutlass/arch/wmma.h"
+#include "cutlass/numeric_types.h"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+
+// cutlass_extensions includes
+#include <cutlass_extensions/include/manifest.h>
+#include <cutlass_extensions/include/gemm_operation_wrapper_3x.h>
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_epi_nosmem_epilogue =
+  typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+    cute::Shape<cute::_64, cute::_128, cute::_128>,
+    cute::Shape<cute::_2, cute::_1, cute::_1>,
+    cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float,
+    cutlass::bfloat16_t, cutlass::layout::RowMajor, 1,
+    cutlass::bfloat16_t, cutlass::layout::RowMajor, 1,
+    cutlass::epilogue::NoSmemWarpSpecialized,
+
+    cutlass::epilogue::fusion::LinearCombination<
+      cutlass::bfloat16_t,
+      float,
+      cutlass::bfloat16_t,
+      float
+    >
+
+  >::CollectiveOp;
+
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_epi_nosmem_mainloop =
+  typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+    cutlass::float_e4m3_t, cutlass::layout::RowMajor, 16,
+    cutlass::float_e4m3_t, cutlass::layout::ColumnMajor, 16,
+    float,
+    cute::Shape<cute::_64, cute::_128, cute::_128>,
+    cute::Shape<cute::_2, cute::_1, cute::_1>,
+    cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(sizeof(typename cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_epi_nosmem_epilogue::SharedStorage))>,
+    cutlass::gemm::KernelTmaWarpSpecialized
+  >::CollectiveOp;
+
+// Gemm operator cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_epi_nosmem
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_epi_nosmem_base = cutlass::gemm::kernel::GemmUniversal<
+    cute::Shape<int,int,int,int>,
+    cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_epi_nosmem_mainloop,
+    cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_epi_nosmem_epilogue,
+    cutlass::gemm::PersistentScheduler>;
+
+// Define named type
+struct cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_epi_nosmem :
+  public cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_epi_nosmem_base { };
+
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass_extensions {
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+void initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_epi_nosmem(Manifest &manifest) {
+
+
+
+  {
+    using GemmKernel = cutlass::gemm::device::GemmUniversalAdapter<cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_epi_nosmem>;
+    manifest.append(
+      new cutlass_extensions::GemmOperationWrapper3x<GemmKernel>("cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_epi_nosmem"));
+  }
+
+
+
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass_extensions
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/fp8_gemm_with_tensorwise/cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/fp8_gemm_with_tensorwise/cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem.cu
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// clang-format off
+
+#include "cutlass/cutlass.h"
+#include "cutlass/library/library.h"
+
+#include "cutlass/arch/wmma.h"
+#include "cutlass/numeric_types.h"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+
+// cutlass_extensions includes
+#include <cutlass_extensions/include/manifest.h>
+#include <cutlass_extensions/include/gemm_operation_wrapper_3x.h>
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem_epilogue =
+  typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+    cute::Shape<cute::_64, cute::_128, cute::_128>,
+    cute::Shape<cute::_2, cute::_1, cute::_1>,
+    cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float,
+    cutlass::bfloat16_t, cutlass::layout::RowMajor, 1,
+    cutlass::bfloat16_t, cutlass::layout::RowMajor, 1,
+    cutlass::epilogue::NoSmemWarpSpecialized,
+
+    cutlass::epilogue::fusion::LinearCombination<
+      cutlass::bfloat16_t,
+      float,
+      cutlass::bfloat16_t,
+      float
+    >
+
+  >::CollectiveOp;
+
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem_mainloop =
+  typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+    cutlass::float_e4m3_t, cutlass::layout::RowMajor, 16,
+    cutlass::float_e4m3_t, cutlass::layout::ColumnMajor, 16,
+    float,
+    cute::Shape<cute::_64, cute::_128, cute::_128>,
+    cute::Shape<cute::_2, cute::_1, cute::_1>,
+    cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(sizeof(typename cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem_epilogue::SharedStorage))>,
+    cutlass::gemm::KernelTmaWarpSpecializedFP8FastAccum
+  >::CollectiveOp;
+
+// Gemm operator cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem
+using cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem_base = cutlass::gemm::kernel::GemmUniversal<
+    cute::Shape<int,int,int,int>,
+    cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem_mainloop,
+    cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem_epilogue,
+    cutlass::gemm::PersistentScheduler>;
+
+// Define named type
+struct cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem :
+  public cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem_base { };
+
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass_extensions {
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+void initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem(Manifest &manifest) {
+
+
+
+  {
+    using GemmKernel = cutlass::gemm::device::GemmUniversalAdapter<cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem>;
+    manifest.append(
+      new cutlass_extensions::GemmOperationWrapper3x<GemmKernel>("cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem"));
+  }
+
+
+
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass_extensions
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/include/gemm_description.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/include/gemm_description.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// clang-format off
+
+#pragma once
+#include <stdexcept>
+#include <cutlass/cutlass.h>
+#include <cutlass/gemm_coord.h>
+#include <cutlass/library/descriptions.h>
+#include <cutlass/library/library.h>
+#include <cutlass/library/types.h>
+#include <cutlass_extensions/include/utils.h>
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass_extensions {
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Description of all GEMM computations
+struct GemmDescription : public cutlass::library::OperationDescription {
+
+  /// Indicates the kind of GEMM performed
+  cutlass::library::GemmKind gemm_kind;
+  
+  /// Describes the A operand
+  cutlass::library::TensorDescription A;
+
+  /// Describes the B operand
+  cutlass::library::TensorDescription B;
+
+  /// Describes the source matrix
+  cutlass::library::TensorDescription C;
+
+  /// Describes the destination matrix
+  cutlass::library::TensorDescription D;
+
+  /// Describes the data type of the scalars passed to the epilogue
+  cutlass::library::NumericTypeID element_epilogue;
+
+  /// Describes the fusion kind followed by the Gemm
+  cutlass_extensions::FusionKind fusion_kind;
+
+  /// Describes the accumulation kind (none, slow, fast)
+  cutlass_extensions::AccumKind accum_kind;
+
+  /// Describes the mainloop schedule
+  cutlass_extensions::MainloopSchedule mainloop_schedule;
+
+  /// Describes the epilogue schedule
+  cutlass_extensions::EpilogueSchedule epilogue_schedule;
+
+  //
+  // Methods
+  //
+
+  GemmDescription(
+    cutlass::library::GemmKind gemm_kind = cutlass::library::GemmKind::kGemm,
+    cutlass::library::TensorDescription const& A = cutlass::library::TensorDescription(),
+    cutlass::library::TensorDescription const& B = cutlass::library::TensorDescription(),
+    cutlass::library::TensorDescription const& C = cutlass::library::TensorDescription(),
+    cutlass::library::TensorDescription const& D = cutlass::library::TensorDescription(),
+    cutlass::library::NumericTypeID element_epilogue = cutlass::library::NumericTypeID::kInvalid,
+    cutlass_extensions::FusionKind fusion_kind = cutlass_extensions::FusionKind::kNone,
+    cutlass_extensions::AccumKind accum_kind = cutlass_extensions::AccumKind::kDefault,
+    cutlass_extensions::MainloopSchedule mainloop_schedule = cutlass_extensions::MainloopSchedule::kUnknown,
+    cutlass_extensions::EpilogueSchedule epilogue_schedule = cutlass_extensions::EpilogueSchedule::kUnknown
+  ):
+    gemm_kind(gemm_kind),
+    A(A),
+    B(B),
+    C(C),
+    D(D),
+    element_epilogue(element_epilogue),
+    fusion_kind(fusion_kind),
+    accum_kind(accum_kind),
+    mainloop_schedule(mainloop_schedule),
+    epilogue_schedule(epilogue_schedule) {} 
+
+  GemmDescription(
+    cutlass::library::OperationDescription op_desc,
+    cutlass::library::GemmKind gemm_kind,
+    cutlass::library::TensorDescription const& A,
+    cutlass::library::TensorDescription const& B,
+    cutlass::library::TensorDescription const& C,
+    cutlass::library::TensorDescription const& D,
+    cutlass::library::NumericTypeID element_epilogue,
+    cutlass_extensions::FusionKind fusion_kind,
+    cutlass_extensions::AccumKind accum_kind,
+    cutlass_extensions::MainloopSchedule mainloop_schedule,
+    cutlass_extensions::EpilogueSchedule epilogue_schedule
+  ):
+    cutlass::library::OperationDescription(op_desc),
+    gemm_kind(gemm_kind),
+    A(A),
+    B(B),
+    C(C),
+    D(D),
+    element_epilogue(element_epilogue),
+    fusion_kind(fusion_kind),
+    accum_kind(accum_kind),
+    mainloop_schedule(mainloop_schedule),
+    epilogue_schedule(epilogue_schedule)  {}
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass_extensions
+
+/////////////////////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/include/gemm_operation_wrapper_3x.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/include/gemm_operation_wrapper_3x.h
@@ -1,0 +1,366 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights
+ *reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+// @lint-ignore-every LICENSELINT
+
+// clang-format off
+#pragma once
+
+#include "cutlass/cutlass.h"
+#include "cutlass/library/library.h"
+#include "library_internal.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include <unordered_map>
+
+#include <cutlass_extensions/include/gemm_description.h>
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass_extensions {
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename Operator_>
+class GemmOperationWrapper3xBase : public cutlass::library::Operation {
+public:
+  using Operator = Operator_;
+  using OperatorArguments = typename Operator::Arguments;
+  using ElementA = typename Operator::ElementA;
+  using LayoutA = typename Operator::LayoutA;
+  using ElementB = typename Operator::ElementB;
+  using LayoutB = typename Operator::LayoutB;
+  using ElementC = typename Operator::ElementC;
+  using LayoutC = typename Operator::LayoutC;
+  using ElementD = typename Operator::ElementD;
+  using LayoutD = typename Operator::LayoutD;
+  // assuming all tensors use same type for StrideIndex
+  using StrideIndex = typename Operator::LayoutA::Index;
+  using ElementAccumulator = typename Operator::ElementAccumulator;
+  using ElementCompute = typename Operator::EpilogueOutputOp::ElementCompute;
+
+  using KernelSchedule = typename Operator::GemmKernel::DispatchPolicy::Schedule;
+
+private:
+  cutlass_extensions::GemmDescription description_;
+
+public:
+
+  /// Constructor
+  GemmOperationWrapper3xBase(char const *name = "unknown_gemm", 
+                             cutlass::library::GemmKind gemm_kind_ = cutlass::library::GemmKind::kGemm) {
+
+    description_.name = name;
+    description_.provider = cutlass::library::Provider::kCUTLASS;
+    description_.kind = cutlass::library::OperationKind::kGemm;
+    description_.gemm_kind = gemm_kind_;
+
+    description_.tile_description.threadblock_shape = cutlass::make_Coord(
+      Operator::ThreadblockShape::kM,
+      Operator::ThreadblockShape::kN,
+      Operator::ThreadblockShape::kK);
+
+    if constexpr (Operator::ArchTag::kMinComputeCapability >= 90) {
+      description_.tile_description.cluster_shape = cutlass::make_Coord(
+        Operator::ClusterShape::kM,
+        Operator::ClusterShape::kN,
+        Operator::ClusterShape::kK);
+    }
+
+    description_.tile_description.threadblock_stages = Operator::kStages;
+
+    description_.tile_description.warp_count = cutlass::make_Coord(
+      Operator::WarpCount::kM,
+      Operator::WarpCount::kN,
+      Operator::WarpCount::kK);
+
+    description_.tile_description.math_instruction.instruction_shape = cutlass::make_Coord(
+      Operator::InstructionShape::kM,
+      Operator::InstructionShape::kN,
+      Operator::InstructionShape::kK);
+
+    description_.tile_description.math_instruction.element_accumulator =
+      cutlass::library::NumericTypeMap<ElementAccumulator>::kId;
+
+    description_.tile_description.math_instruction.opcode_class =
+      cutlass::library::OpcodeClassMap<typename Operator::OperatorClass>::kId;
+
+    description_.tile_description.math_instruction.math_operation =
+      cutlass::library::MathOperationMap<typename Operator::MathOperator>::kId;
+
+    description_.tile_description.minimum_compute_capability =
+      cutlass::library::ArchMap<typename Operator::ArchTag, typename Operator::OperatorClass>::kMin;
+
+    description_.tile_description.maximum_compute_capability =
+      cutlass::library::ArchMap<typename Operator::ArchTag, typename Operator::OperatorClass>::kMax;
+
+    description_.A = cutlass::library::make_TensorDescription<ElementA, LayoutA>(Operator::kAlignmentA);
+    description_.B = cutlass::library::make_TensorDescription<ElementB, LayoutB>(Operator::kAlignmentB);
+    description_.C = cutlass::library::make_TensorDescription<ElementC, LayoutC>(Operator::kAlignmentC);
+    description_.D = cutlass::library::make_TensorDescription<ElementD, LayoutD>(Operator::kAlignmentD);
+    description_.element_epilogue = cutlass::library::NumericTypeMap<ElementCompute>::kId;
+
+
+    description_.fusion_kind = cutlass_extensions::FusionKind::kNone;
+    description_.accum_kind = cutlass_extensions::KernelScheduleMap<KernelSchedule>::kAccumKind;
+    description_.mainloop_schedule = cutlass_extensions::KernelScheduleMap<KernelSchedule>::kMainloopSchedule;
+    description_.epilogue_schedule = cutlass_extensions::KernelScheduleMap<KernelSchedule>::kEpilogueSchedule;
+
+    if ((description_.A.element == cutlass::library::NumericTypeID::kFE4M3) || 
+        (description_.A.element == cutlass::library::NumericTypeID::kFE5M2) ||
+        (description_.B.element == cutlass::library::NumericTypeID::kFE4M3) || 
+        (description_.B.element == cutlass::library::NumericTypeID::kFE5M2)) {
+      
+      // FP8 by default atleast needs tensor wise scaling factor.
+      // For Rowwise and Blockwise scaling, `fusion_kind` field is set in 
+      // the respective inherited classes.
+      description_.fusion_kind = cutlass_extensions::FusionKind::kTensorwiseScaling;
+    }
+    
+  }
+
+  /// Returns the description of the GEMM operation
+  virtual cutlass::library::OperationDescription const & description() const {
+    return description_;
+  }
+
+  /// Returns the description of the GEMM operation
+  cutlass_extensions::GemmDescription const& get_gemm_description() const {
+    return description_;
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename Operator_>
+class GemmOperationWrapper3x : public GemmOperationWrapper3xBase<Operator_> {
+public:
+
+  using Operator = Operator_;
+  using OperatorArguments = typename Operator::Arguments;
+  using ElementA = typename Operator::ElementA;
+  using LayoutA = typename Operator::LayoutA;
+  using ElementB = typename Operator::ElementB;
+  using LayoutB = typename Operator::LayoutB;
+  using ElementC = typename Operator::ElementC;
+  using LayoutC = typename Operator::LayoutC;
+  using ElementD = typename Operator::ElementD;
+  using LayoutD = typename Operator::LayoutD;
+  using ElementAccumulator = typename Operator::ElementAccumulator;
+  using ElementCompute = typename Operator::EpilogueOutputOp::ElementCompute;
+
+  using CollectiveMainloop = typename Operator::CollectiveMainloop;
+  using CollectiveEpilogue = typename Operator::CollectiveEpilogue;
+  using ThreadEpilogueOp = typename CollectiveEpilogue::ThreadEpilogueOp;
+
+public:
+
+  /// Constructor
+  GemmOperationWrapper3x(char const *name = "unknown_gemm"):
+    GemmOperationWrapper3xBase<Operator_>(name, cutlass::library::GemmKind::kUniversal) {}
+
+protected:
+
+  /// Constructs the arguments structure given the configuration and arguments
+  static cutlass::Status construct_arguments_(
+      OperatorArguments &operator_args, cutlass::library::GemmUniversalConfiguration const *configuration) {
+    // NOTE: GemmUniversalConfiguration does not contain problem shapes or batch strides
+    // Do nothing here and construct kernel arguments in update_arguments_ instead
+    // We also cannot construct TMA descriptors without all the arguments available
+
+    operator_args.mode = configuration->mode;
+    return cutlass::Status::kSuccess;
+  }
+
+  template<class FusionArgs, class = void>
+  struct UpdateFusionArgs {
+    static cutlass::Status update_(FusionArgs const& fusion_args, cutlass::library::GemmUniversalArguments const &arguments) {
+      // If a custom EVT is instantiated then it is the users's responsibility
+      // to ensure alpha and beta are updated appropriately
+      return cutlass::Status::kSuccess;
+    }
+  };
+
+  template<class FusionArgs>
+  struct UpdateFusionArgs<FusionArgs, cute::void_t<decltype(FusionArgs{}.alpha)>> {
+    static cutlass::Status update_(FusionArgs& fusion_args, cutlass::library::GemmUniversalArguments const &arguments) {
+      if (arguments.pointer_mode == cutlass::library::ScalarPointerMode::kHost) {
+        fusion_args.alpha = *static_cast<ElementCompute const *>(arguments.alpha);
+        fusion_args.beta = *static_cast<ElementCompute const *>(arguments.beta);
+        fusion_args.alpha_ptr = nullptr;
+        fusion_args.beta_ptr = nullptr;
+
+        return cutlass::Status::kSuccess;
+      }
+      else if (arguments.pointer_mode == cutlass::library::ScalarPointerMode::kDevice) {
+        fusion_args.alpha = 0;
+        fusion_args.beta = 0;
+        fusion_args.alpha_ptr = static_cast<ElementCompute const *>(arguments.alpha);
+        fusion_args.beta_ptr = static_cast<ElementCompute const *>(arguments.beta);
+
+        return cutlass::Status::kSuccess;
+      }
+      else {
+        return cutlass::Status::kErrorInvalidProblem;
+      }
+    }
+  };
+
+  /// Constructs the arguments structure given the configuration and arguments
+  static cutlass::Status update_arguments_(
+      OperatorArguments &operator_args,
+      cutlass::library::GemmUniversalArguments const *arguments) {
+    cutlass::Status status = cutlass::Status::kSuccess;
+
+    status = UpdateFusionArgs<decltype(operator_args.epilogue.thread)>::update_(
+      operator_args.epilogue.thread, *arguments);
+    if (status != cutlass::Status::kSuccess) {
+      return status;
+    }
+
+    // TODO: type erase Arguments structure in 3.0 GEMM
+    operator_args.problem_shape = cute::make_shape(
+      arguments->problem_size.m(),
+      arguments->problem_size.n(),
+      arguments->problem_size.k(),
+      arguments->batch_count);
+
+    // update arguments
+    operator_args.mainloop.ptr_A = static_cast<ElementA const *>(arguments->A);
+    operator_args.mainloop.ptr_B = static_cast<ElementB const *>(arguments->B);
+    operator_args.epilogue.ptr_C = static_cast<ElementC const *>(arguments->C);
+    operator_args.epilogue.ptr_D = static_cast<ElementD       *>(arguments->D);
+
+    operator_args.mainloop.dA = cute::make_int_tuple_from<typename Operator::GemmKernel::StrideA>(
+        arguments->lda, arguments->batch_stride_A);
+    operator_args.mainloop.dB = cute::make_int_tuple_from<typename Operator::GemmKernel::StrideB>(
+        arguments->ldb, arguments->batch_stride_B);
+    operator_args.epilogue.dC = cute::make_int_tuple_from<typename Operator::GemmKernel::StrideC>(
+        arguments->ldc, arguments->batch_stride_C);
+    operator_args.epilogue.dD = operator_args.epilogue.dC;
+
+    /* Query device SM count to pass onto the kernel as an argument, where needed */
+    operator_args.hw_info.sm_count = arguments->sm_count;
+
+    if constexpr (!std::is_const_v<decltype(operator_args.scheduler.raster_order)>) {
+      using Enum_t = decltype(operator_args.scheduler.raster_order);
+      switch (arguments->raster_order) {
+        case cutlass::library::RasterOrder::kAlongN:
+          operator_args.scheduler.raster_order = Enum_t::AlongN;
+          break;
+        case cutlass::library::RasterOrder::kAlongM:
+          operator_args.scheduler.raster_order = Enum_t::AlongM;
+          break;
+        default:
+          operator_args.scheduler.raster_order = Enum_t::Heuristic;
+      }
+    }
+
+    return status;
+  }
+
+public:
+
+  /// Returns success if the operation can proceed
+  cutlass::Status can_implement(
+      void const *configuration_ptr, void const *arguments_ptr) const override {
+    cutlass::library::GemmUniversalConfiguration const *configuration =
+      static_cast<cutlass::library::GemmUniversalConfiguration const *>(configuration_ptr);
+    cutlass::library::GemmUniversalArguments const *arguments =
+      static_cast<cutlass::library::GemmUniversalArguments const *>(arguments_ptr);
+
+    OperatorArguments args;
+    auto status = update_arguments_(args, arguments);
+    if (status != cutlass::Status::kSuccess) {
+      return status;
+    }
+
+    // can_implement rules may need access to problem shape
+    args.problem_shape = cute::make_shape(
+      configuration->problem_size.m(),
+      configuration->problem_size.n(),
+      configuration->problem_size.k(),
+      configuration->batch_count);
+    return Operator::can_implement(args);
+  }
+
+  /// Gets the host-side workspace
+  uint64_t get_host_workspace_size(void const *configuration) const override {
+    return sizeof(Operator);
+  }
+
+  /// Gets the device-side workspace
+  uint64_t get_device_workspace_size(
+      void const *configuration_ptr,void const *arguments_ptr) const override {
+
+    OperatorArguments args;
+    auto status = update_arguments_(
+      args, static_cast<cutlass::library::GemmUniversalArguments const *>(arguments_ptr));
+    if (status != cutlass::Status::kSuccess) {
+      return 0;
+    }
+
+    uint64_t size = Operator::get_workspace_size(args);
+    return size;
+  }
+
+  /// Initializes the workspace
+  cutlass::Status initialize(
+      void const *configuration_ptr,
+      void *host_workspace,
+      void *device_workspace,
+      cudaStream_t stream = nullptr) const override {
+    Operator *op = new (host_workspace) Operator;
+    return cutlass::Status::kSuccess;
+  }
+
+  /// Runs the kernel
+  cutlass::Status run(
+      void const *arguments_ptr,
+      void *host_workspace,
+      void *device_workspace = nullptr,
+      cudaStream_t stream = nullptr) const override {
+
+    OperatorArguments args;
+    cutlass::Status status = update_arguments_(args, static_cast<cutlass::library::GemmUniversalArguments const *>(arguments_ptr));
+    if (status != cutlass::Status::kSuccess) {
+      return status;
+    }
+
+    Operator *op = static_cast<Operator *>(host_workspace);
+    // We need to call initialize() since we have to rebuild TMA desc for every new set of args
+    status = op->run(args, device_workspace, stream);
+    return status;
+  }
+};
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass_extensions
+
+///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/include/manifest.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/include/manifest.h
@@ -1,0 +1,120 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights
+ *reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+// @lint-ignore-every LICENSELINT
+
+/*
+  Manifest of CUTLASS kernels to be used to generate a library of compiled
+  cutlass extended kernels for pytorch/fbgemm.
+*/
+
+#pragma once
+
+#include <list>
+#include <map>
+#include <memory>
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "cutlass/library/library.h"
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass_extensions {
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Forward declaration
+class Manifest;
+
+// init and insert all cutlass gemm operations in manifest object (present in
+// cutlass_extensions)
+void initialize_all(Manifest& manifest);
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// List of operations
+using OperationVector =
+    std::vector<std::unique_ptr<cutlass::library::Operation>>;
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Manifest of CUTLASS extension Library
+class Manifest {
+ private:
+  /// Operation provider
+  cutlass::library::Provider provider_;
+
+  /// Global list of operations
+  OperationVector operations_;
+
+ public:
+  Manifest(
+      cutlass::library::Provider provider =
+          cutlass::library::Provider::kCUTLASS)
+      : provider_(provider) {}
+
+  /// Top-level initialization
+  cutlass::Status initialize();
+
+  /// Used for initialization
+  void reserve(uint64_t operation_count);
+
+  /// Graceful shutdown
+  cutlass::Status release();
+
+  /// Get provider
+  cutlass::library::Provider get_provider() {
+    return provider_;
+  }
+
+  /// Appends an operation and takes ownership
+  void append(cutlass::library::Operation*
+                  operation_ptr) { // This function is inline s.t. it is
+    // present in generated libraries
+    // without having to compile or link in manifest.cpp
+    operations_.emplace_back(operation_ptr);
+  }
+
+  /// Returns an iterator to the first operation
+  OperationVector const& operations() const;
+
+  /// Returns a const iterator
+  OperationVector::const_iterator begin() const;
+
+  /// Returns a const iterator
+  OperationVector::const_iterator end() const;
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass_extensions
+
+///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/include/operation_table.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/include/operation_table.h
@@ -1,0 +1,316 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights
+ *reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+// @lint-ignore-every LICENSELINT
+
+/*! \file
+    \brief Operation table for CUTLASS kernels
+*/
+
+// clang-format off
+#pragma once
+
+#include <algorithm>
+#include <fstream>
+#include <iosfwd>
+#include <unordered_map>
+
+#include "cutlass/library/library.h"
+#include "cutlass/library/util.h"
+
+#include <cutlass_extensions/include/manifest.h>
+#include <cutlass_extensions/include/utils.h>
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass_extensions {
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//                          Data Structures for Gemm Functional Maps
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Tuple uniquely identifying Gemm functional behavior
+struct GemmFunctionalKey {
+  // Functional key items from cutlass::library
+  cutlass::library::Provider provider;
+  cutlass::library::GemmKind gemm_kind;
+  cutlass::library::NumericTypeID element_accumulator;
+  cutlass::library::NumericTypeID element_A;
+  cutlass::library::LayoutTypeID layout_A;
+  cutlass::library::NumericTypeID element_B;
+  cutlass::library::LayoutTypeID layout_B;
+  cutlass::library::NumericTypeID element_C;
+  cutlass::library::LayoutTypeID layout_C;
+  cutlass::library::NumericTypeID element_D;
+  cutlass::library::LayoutTypeID layout_D;
+
+  // Additional functional key imtes from cutlass_extensions
+  cutlass_extensions::FusionKind fusion_kind;
+  cutlass_extensions::AccumKind accum_kind;
+
+  //
+  // Methods
+  //
+
+  inline GemmFunctionalKey(
+      cutlass::library::Provider provider = cutlass::library::Provider::kCUTLASS,
+      cutlass::library::GemmKind gemm_kind = cutlass::library::GemmKind::kGemm,
+      cutlass::library::NumericTypeID element_accumulator = cutlass::library::NumericTypeID::kF32,
+      cutlass::library::NumericTypeID element_A = cutlass::library::NumericTypeID::kF16,
+      cutlass::library::LayoutTypeID layout_A = cutlass::library::LayoutTypeID::kColumnMajor,
+      cutlass::library::NumericTypeID element_B = cutlass::library::NumericTypeID::kF16,
+      cutlass::library::LayoutTypeID layout_B = cutlass::library::LayoutTypeID::kColumnMajor,
+      cutlass::library::NumericTypeID element_C = cutlass::library::NumericTypeID::kF16,
+      cutlass::library::LayoutTypeID layout_C = cutlass::library::LayoutTypeID::kColumnMajor,
+      cutlass::library::NumericTypeID element_D = cutlass::library::NumericTypeID::kF16,
+      cutlass::library::LayoutTypeID layout_D = cutlass::library::LayoutTypeID::kColumnMajor,
+      cutlass_extensions::FusionKind fusion_kind = cutlass_extensions::FusionKind::kNone,
+      cutlass_extensions::AccumKind accum_kind = cutlass_extensions::AccumKind::kDefault)
+      : provider(provider),
+        gemm_kind(gemm_kind),
+        element_accumulator(element_accumulator),
+        element_A(element_A),
+        layout_A(layout_A),
+        element_B(element_B),
+        layout_B(layout_B),
+        element_C(element_C),
+        layout_C(layout_C),
+        element_D(element_D),
+        layout_D(layout_D),
+        fusion_kind(fusion_kind),
+        accum_kind(accum_kind) {}
+
+  inline bool operator==(GemmFunctionalKey const& rhs) const {
+    return (provider == rhs.provider) && (gemm_kind == rhs.gemm_kind) &&
+        (element_accumulator == rhs.element_accumulator) &&
+        (element_A == rhs.element_A) && (layout_A == rhs.layout_A) &&
+        (element_B == rhs.element_B) && (layout_B == rhs.layout_B) &&
+        (element_C == rhs.element_C) && (layout_C == rhs.layout_C) &&
+        (element_D == rhs.element_D) && (layout_D == rhs.layout_D) &&
+        (fusion_kind == rhs.fusion_kind) && (accum_kind == rhs.accum_kind);
+  }
+
+  inline bool operator!=(GemmFunctionalKey const& rhs) const {
+    return !(*this == rhs);
+  }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+inline std::ostream& operator<<(
+    std::ostream& out,
+    cutlass_extensions::GemmFunctionalKey const& k) {
+  out << "{\n"
+      << "             provider: " << cutlass::library::to_string(k.provider) << "\n"
+      << "            gemm_kind: " << cutlass::library::to_string(k.gemm_kind) << "\n"
+      << "  element_accumulator: " << cutlass::library::to_string(k.element_accumulator) << "\n"
+      << "            element_A: " << cutlass::library::to_string(k.element_A) << "\n"
+      << "             layout_A: " << cutlass::library::to_string(k.layout_A) << "\n"
+      << "            element_B: " << cutlass::library::to_string(k.element_B) << "\n"
+      << "             layout_B: " << cutlass::library::to_string(k.layout_B) << "\n"
+      << "            element_C: " << cutlass::library::to_string(k.element_C) << "\n"
+      << "             layout_C: " << cutlass::library::to_string(k.layout_C) << "\n"
+      << "            element_D: " << cutlass::library::to_string(k.element_D) << "\n"
+      << "             layout_D: " << cutlass::library::to_string(k.layout_D) << "\n"
+      << "           fusion_kind: " << cutlass_extensions::to_string(k.fusion_kind) << "\n"
+      << "            accum_kind: " << cutlass_extensions::to_string(k.accum_kind) << "\n"
+      << "}";
+
+  return out;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Hash function for GemmFunctionalKey
+struct GemmFunctionalKeyHasher {
+  using IntHash = std::hash<int>;
+
+  inline static size_t rotl(size_t key, int shl) {
+    return (key << shl) |
+        (key >> (sizeof(key) * 8u - static_cast<size_t>(shl)));
+  }
+
+  inline size_t operator()(GemmFunctionalKey const& key) const {
+    IntHash hash;
+
+    return rotl(hash(int(key.provider)), 1) ^
+        rotl(hash(int(key.gemm_kind)), 2) ^
+        rotl(hash(int(key.element_accumulator)), 3) ^
+        rotl(hash(int(key.element_A)), 5) ^ rotl(hash(int(key.layout_A)), 6) ^
+        rotl(hash(int(key.element_B)), 8) ^ rotl(hash(int(key.layout_B)), 9) ^
+        rotl(hash(int(key.element_C)), 11) ^ rotl(hash(int(key.layout_C)), 12) ^
+        rotl(hash(int(key.element_D)), 13) ^ rotl(hash(int(key.layout_D)), 14) ^
+        rotl(hash(int(key.fusion_kind)), 15) ^ rotl(hash(int(key.accum_kind)), 16);
+  }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//                          Data Structures for Gemm Performance Maps
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct GemmPerformanceKey {
+
+  /// Describes the shape of tensor core math instruction (in elements)
+  cutlass::gemm::GemmCoord instruction_shape;
+
+  /// Describes the shape of a threadblock (in elements)
+  cutlass::gemm::GemmCoord threadblock_shape;
+
+  /// Describes the shape of a cluster (in blocks)
+  cutlass::gemm::GemmCoord cluster_shape;
+
+  /// Describles mainloop schedule (multistage, warpspecalized, etc)
+  cutlass_extensions::MainloopSchedule mainloop_schedule;
+
+  /// Describles epilogue schedule (nosmem, tma, etc)
+  cutlass_extensions::EpilogueSchedule epilogue_schedule;
+
+  /// ctor
+  inline GemmPerformanceKey(
+      cutlass::gemm::GemmCoord instruction_shape,
+      cutlass::gemm::GemmCoord threadblock_shape,
+      cutlass::gemm::GemmCoord cluster_shape,
+      cutlass_extensions::MainloopSchedule mainloop_schedule,
+      cutlass_extensions::EpilogueSchedule epilogue_schedule)
+      : instruction_shape(instruction_shape),
+        threadblock_shape(threadblock_shape), 
+        cluster_shape(cluster_shape),
+        mainloop_schedule(mainloop_schedule),
+        epilogue_schedule(epilogue_schedule) {}
+
+  inline bool operator==(GemmPerformanceKey const& rhs) const {
+    return (instruction_shape == rhs.instruction_shape) &&
+           (threadblock_shape == rhs.threadblock_shape) &&
+           (cluster_shape == rhs.cluster_shape) &&
+           (mainloop_schedule == rhs.mainloop_schedule) &&
+           (epilogue_schedule == rhs.epilogue_schedule);
+  }
+
+  inline bool operator!=(GemmPerformanceKey const& rhs) const {
+    return !(*this == rhs);
+  }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Hash function for GemmPerformanceKey
+struct GemmPerformanceKeyHasher {
+  using IntHash = std::hash<int>;
+
+  inline static size_t rotl(size_t key, int shl) {
+    return (key << shl) |
+        (key >> (sizeof(key) * 8u - static_cast<size_t>(shl)));
+  }
+
+  inline size_t operator()(GemmPerformanceKey const& key) const {
+    IntHash hash;
+
+    return rotl(hash(int(key.instruction_shape.m())), 1) ^
+           rotl(hash(int(key.instruction_shape.n())), 2) ^
+           rotl(hash(int(key.instruction_shape.k())), 3) ^
+           rotl(hash(int(key.threadblock_shape.m())), 4) ^
+           rotl(hash(int(key.threadblock_shape.n())), 5) ^
+           rotl(hash(int(key.threadblock_shape.k())), 6) ^
+           rotl(hash(int(key.cluster_shape.m())), 7) ^
+           rotl(hash(int(key.cluster_shape.n())), 8) ^
+           rotl(hash(int(key.cluster_shape.k())), 9) ^
+           rotl(hash(int(key.mainloop_schedule)), 10) ^
+           rotl(hash(int(key.epilogue_schedule)), 11);
+  }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+inline std::ostream& operator<<(
+    std::ostream& out,
+    cutlass_extensions::GemmPerformanceKey const& k) {
+  out << "{\n"
+      << "         instruction shape: {" << k.instruction_shape.m() << ", "
+                                         << k.instruction_shape.n() << ", " 
+                                         << k.instruction_shape.k() << "}\n"
+      << "         threadblock shape: {" << k.threadblock_shape.m() << ", "
+                                         << k.threadblock_shape.n() << ", " 
+                                         << k.threadblock_shape.k() << "}\n"
+      << "             cluster shape: {" << k.cluster_shape.m() << ", "
+                                         << k.cluster_shape.n() << ", " 
+                                         << k.cluster_shape.k() << "}\n"
+      << "         mainloop schedule:  " << cutlass_extensions::to_string(k.mainloop_schedule) << "\n"  
+      << "}";
+
+  return out;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//     Data structures for Operation tables
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Maps Gemm Performance Key to a vector Gemm Operation.
+using GemmOperationPerformanceMap = std::unordered_map<
+    GemmPerformanceKey,
+    std::vector<cutlass::library::Operation const*>,
+    GemmPerformanceKeyHasher>;
+
+/// Maps a GemmFunctionalKey onto a vector of Operation
+/// GemmFunctionalKey -> {GemmPerformanceKey -> [Operations*]}
+using GemmOperationFunctionalMap = std::unordered_map<
+    GemmFunctionalKey,
+    GemmOperationPerformanceMap,
+    GemmFunctionalKeyHasher>;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Table of cutlass::library::Operation instances
+class OperationTable {
+ public:
+  /// Gemm operation (D = alpha * (A x B) + beta * C)
+  GemmOperationFunctionalMap gemm_operations;
+  GemmOperationFunctionalMap gemm_operations_with_tensorwise;
+  GemmOperationFunctionalMap gemm_operations_with_rowwise;
+  GemmOperationFunctionalMap gemm_operations_with_blockwise;
+
+ public:
+  void append(Manifest const& manifest);
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass_extensions
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+std::ostream& operator<<(
+    std::ostream& out,
+    cutlass_extensions::GemmFunctionalKey const& k);
+
+std::ostream& operator<<(
+    std::ostream& out,
+    cutlass_extensions::GemmPerformanceKey const& k);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/include/singleton.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/include/singleton.h
@@ -1,0 +1,64 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights
+ *reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+// @lint-ignore-every LICENSELINT
+
+#pragma once
+
+#include <cutlass_extensions/include/manifest.h>
+#include <cutlass_extensions/include/operation_table.h>
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass_extensions {
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Singleton instance stores a Manifest and Operation table and used to avoid
+// repeated initialization of the manifest and operation table during the
+// lifetime of a process. The operation table is generated once at the first
+// call to Singleton::get().
+class Singleton {
+ public:
+  cutlass_extensions::Manifest manifest;
+  cutlass_extensions::OperationTable operation_table;
+
+ public:
+  Singleton();
+
+  static Singleton const& get();
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass_extensions
+
+/////////////////////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/include/utils.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/include/utils.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "cutlass/cutlass.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/library/library.h"
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass_extensions {
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//                                 Enumerations for reflection
+/////////////////////////////////////////////////////////////////////////////////////////////////
+/// Fusion type identifier
+enum class FusionKind {
+  kNone,
+  kTensorwiseScaling,
+  kRowwiseScaling,
+  kBlockwiseScaling,
+  kInvalid,
+};
+
+/// Mainloop schedule identifier
+enum class MainloopSchedule {
+  kUnknown,
+  kMultistage,
+  kWarpspecialized,
+  kWarpspecializedPingpong,
+  kWarpspecializedCooperative,
+  kInvalid,
+};
+
+/// Epilogue schedule identifier
+enum class EpilogueSchedule {
+  kUnknown,
+  kNoSmem,
+  kTma,
+  kInvalid,
+};
+
+/// Accumulation algorithm kind
+enum class AccumKind {
+  kDefault, // For non-fp8 types, Default accumulation is in-place regular
+            // accumulation. For fp8 types, Default accumulation is slow with
+            // staging into f32 registers.
+  kFastAccum, // Fast accumulation is for fp8 is regular accumulation.
+  kInvalid,
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//                                Enumerations to string conversion
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Converts a FusionKind enumerant to a string
+char const* to_string(FusionKind fusion_kind, bool pretty = false);
+
+/// Converts a Mainloop enumerant to a string
+char const* to_string(MainloopSchedule mainloop, bool pretty = false);
+
+/// Converts a Epilogue enumerant to a string
+char const* to_string(EpilogueSchedule epilogue, bool pretty = false);
+
+/// Converts a Accumulation kind enumerant to a string
+char const* to_string(AccumKind fp8acc, bool pretty = false);
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//                           Compile-time tags to runtime enumerants
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+struct KernelScheduleMap;
+
+template <>
+struct KernelScheduleMap<cutlass::gemm::KernelMultistage> {
+  static MainloopSchedule const kMainloopSchedule =
+      MainloopSchedule::kMultistage;
+  static AccumKind const kAccumKind = AccumKind::kDefault;
+  static EpilogueSchedule const kEpilogueSchedule = EpilogueSchedule::kUnknown;
+};
+
+// Default accumulation
+template <>
+struct KernelScheduleMap<cutlass::gemm::KernelTmaWarpSpecialized> {
+  static MainloopSchedule const kMainloopSchedule =
+      MainloopSchedule::kWarpspecialized;
+  static AccumKind const kAccumKind = AccumKind::kDefault;
+  static EpilogueSchedule const kEpilogueSchedule = EpilogueSchedule::kUnknown;
+};
+
+template <>
+struct KernelScheduleMap<cutlass::gemm::KernelTmaWarpSpecializedPingpong> {
+  static MainloopSchedule const kMainloopSchedule =
+      MainloopSchedule::kWarpspecializedPingpong;
+  static AccumKind const kAccumKind = AccumKind::kDefault;
+  static EpilogueSchedule const kEpilogueSchedule = EpilogueSchedule::kUnknown;
+};
+
+template <>
+struct KernelScheduleMap<cutlass::gemm::KernelTmaWarpSpecializedCooperative> {
+  static MainloopSchedule const kMainloopSchedule =
+      MainloopSchedule::kWarpspecializedCooperative;
+  static AccumKind const kAccumKind = AccumKind::kDefault;
+  static EpilogueSchedule const kEpilogueSchedule = EpilogueSchedule::kUnknown;
+};
+
+// Fast accumulation for FP8
+template <>
+struct KernelScheduleMap<cutlass::gemm::KernelTmaWarpSpecializedFP8FastAccum> {
+  static MainloopSchedule const kMainloopSchedule =
+      MainloopSchedule::kWarpspecialized;
+  static AccumKind const kAccumKind = AccumKind::kFastAccum;
+  static EpilogueSchedule const kEpilogueSchedule = EpilogueSchedule::kUnknown;
+};
+
+template <>
+struct KernelScheduleMap<
+    cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum> {
+  static MainloopSchedule const kMainloopSchedule =
+      MainloopSchedule::kWarpspecializedPingpong;
+  static AccumKind const kAccumKind = AccumKind::kFastAccum;
+  static EpilogueSchedule const kEpilogueSchedule = EpilogueSchedule::kUnknown;
+};
+
+template <>
+struct KernelScheduleMap<
+    cutlass::gemm::KernelTmaWarpSpecializedCooperativeFP8FastAccum> {
+  static MainloopSchedule const kMainloopSchedule =
+      MainloopSchedule::kWarpspecializedCooperative;
+  static AccumKind const kAccumKind = AccumKind::kFastAccum;
+  static EpilogueSchedule const kEpilogueSchedule = EpilogueSchedule::kUnknown;
+};
+
+} // namespace cutlass_extensions
+
+/////////////////////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/initialize_all.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/initialize_all.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cutlass_extensions/include/manifest.h>
+
+namespace cutlass_extensions {
+/////////////////////////////////////////////////////////////////////////
+//                     Declarations
+/////////////////////////////////////////////////////////////////////////
+
+// Four f8f8bf16 instances used in legacy cutlass_extensions.cu (Row-Col-Col
+// TensorWise Scaled Gemms)
+void initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem(
+    Manifest& manifest);
+void initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem(
+    Manifest& manifest);
+void initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_epi_nosmem(
+    Manifest& manifest);
+void initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_epi_nosmem(
+    Manifest& manifest);
+
+// Additional f8f8bf16 instances (Row-Col-Row TensorWise Scaled Gemms)
+void initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_epi_nosmem(
+    Manifest& manifest);
+void initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem(
+    Manifest& manifest);
+void initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_epi_nosmem(
+    Manifest& manifest);
+void initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem(
+    Manifest& manifest);
+
+/////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////////////////////////////////////////////////
+//            Initializers for different Gemm variants
+/////////////////////////////////////////////////////////////////////////
+
+/// Add Pure FP8 operations to the manifest
+void initialize_fp8_gemm_operations(Manifest& manifest) {
+  initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem(
+      manifest);
+  initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_fp8_fastaccum_epi_nosmem(
+      manifest);
+  initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnn_align16_warpspecialized_epi_nosmem(
+      manifest);
+  initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnn_align16_warpspecialized_epi_nosmem(
+      manifest);
+
+  initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_epi_nosmem(
+      manifest);
+  initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_64x128x128_2x1x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem(
+      manifest);
+  initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_epi_nosmem(
+      manifest);
+  initialize_cutlass3x_sm90_tensorop_s64x128x32gemm_e4m3_e4m3_f32_bf16_bf16_128x128x128_1x2x1_0_tnt_align16_warpspecialized_fp8_fastaccum_epi_nosmem(
+      manifest);
+}
+/////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////////////////////////////////////////////////
+//            Top-level manifest initializer call
+/////////////////////////////////////////////////////////////////////////
+void initialize_all(Manifest& manifest) {
+  initialize_fp8_gemm_operations(manifest);
+  // initialize_fp8_rowwise_gemm_operations(manifest);
+}
+
+} // namespace cutlass_extensions

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/manifest.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/manifest.cpp
@@ -1,0 +1,87 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights
+ *reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+// @lint-ignore-every LICENSELINT
+
+#include <cutlass_extensions/include/manifest.h>
+#include <memory>
+
+namespace cutlass_extensions {
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void initialize_all(Manifest& manifest);
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Top-level initialization
+cutlass::Status Manifest::initialize() {
+  if (!operations_.empty()) {
+    operations_.clear();
+  }
+
+  // initialize procedurally generated cutlass op in manifest object
+  initialize_all(*this);
+
+  return cutlass::Status::kSuccess;
+}
+
+/// Used for initialization
+void Manifest::reserve(size_t operation_count) {
+  operations_.reserve(operation_count);
+}
+
+/// Graceful shutdown
+cutlass::Status Manifest::release() {
+  operations_.clear();
+  return cutlass::Status::kSuccess;
+}
+
+/// Returns an iterator to the first operation
+OperationVector const& Manifest::operations() const {
+  return operations_;
+}
+
+/// Returns a const iterator
+OperationVector::const_iterator Manifest::begin() const {
+  return operations_.begin();
+}
+
+/// Returns a const iterator
+OperationVector::const_iterator Manifest::end() const {
+  return operations_.end();
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass_extensions
+
+///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/operation_table.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/operation_table.cu
@@ -1,0 +1,110 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights
+ *reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+// @lint-ignore-every LICENSELINT
+
+/*
+  \file
+  \brief Defines a data structure in which a set of functionally equivalent
+  cutlass::library::Operation instances may be queried.
+*/
+
+#include <cutlass_extensions/include/gemm_description.h>
+#include <cutlass_extensions/include/operation_table.h>
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass_extensions {
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+void OperationTable::append(Manifest const& manifest) {
+  for (auto const& operation : manifest) {
+    cutlass::library::OperationDescription const& desc =
+        operation->description();
+
+    if (desc.kind == cutlass::library::OperationKind::kGemm) {
+      cutlass_extensions::GemmDescription const& gemm_desc =
+          static_cast<cutlass_extensions::GemmDescription const&>(desc);
+
+      GemmFunctionalKey functional_key(
+          gemm_desc.provider,
+          gemm_desc.gemm_kind,
+          gemm_desc.tile_description.math_instruction.element_accumulator,
+          gemm_desc.A.element,
+          gemm_desc.A.layout,
+          gemm_desc.B.element,
+          gemm_desc.B.layout,
+          gemm_desc.C.element,
+          gemm_desc.C.layout,
+          gemm_desc.D.element,
+          gemm_desc.D.layout,
+          gemm_desc.fusion_kind,
+          gemm_desc.accum_kind);
+      // std::cout << "Gemm Functional Key: " << functional_key << std::endl;
+
+      GemmPerformanceKey performance_key(
+          gemm_desc.tile_description.math_instruction.instruction_shape,
+          gemm_desc.tile_description.threadblock_shape,
+          gemm_desc.tile_description.cluster_shape,
+          gemm_desc.mainloop_schedule,
+          gemm_desc.epilogue_schedule);
+      // std::cout << "Gemm Performance Key " << performance_key << std::endl;
+
+      // Populate gemm operation tables
+      cutlass::library::Operation const* op_ptr = operation.get();
+      if (gemm_desc.fusion_kind ==
+          cutlass_extensions::FusionKind::kTensorwiseScaling) {
+        gemm_operations_with_tensorwise[functional_key][performance_key]
+            .push_back(op_ptr);
+      } else if (
+          gemm_desc.fusion_kind ==
+          cutlass_extensions::FusionKind::kRowwiseScaling) {
+        gemm_operations_with_rowwise[functional_key][performance_key].push_back(
+            op_ptr);
+      } else if (
+          gemm_desc.fusion_kind ==
+          cutlass_extensions::FusionKind::kBlockwiseScaling) {
+        gemm_operations_with_blockwise[functional_key][performance_key]
+            .push_back(op_ptr);
+      }
+    }
+  }
+}
+
+} // namespace cutlass_extensions
+
+/*
+f8f8bf16 : it takes a scale tensor scale[1]. It is a single element tensor for
+cuda graph to work.
+
+
+ignore it for now: f8f8bf16_tensorwise
+*/

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/singleton.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/singleton.cu
@@ -1,0 +1,57 @@
+/***************************************************************************************************
+ * Copyright (c) 2017 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights
+ *reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+// @lint-ignore-every LICENSELINT
+
+#include <cutlass_extensions/include/singleton.h>
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass_extensions {
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+Singleton::Singleton() {
+  manifest.initialize();
+
+  operation_table.append(manifest);
+}
+
+Singleton const& Singleton::get() {
+  static Singleton instance;
+  return instance;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass_extensions
+
+/////////////////////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/torch_script_ops.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/torch_script_ops.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <torch/library.h>
+
+#include "c10/core/ScalarType.h"
+
+#include <ATen/cuda/CUDAEvent.h>
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <cmath>
+#include <vector>
+#include "c10/util/Exception.h"
+
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200)
+#define torch_fp8_e4m3 at::kFloat8_e4m3fnuz
+#else
+#define torch_fp8_e4m3 at::kFloat8_e4m3fn
+#endif
+
+namespace fbgemm_gpu {
+
+// CUTLASS kernel v2
+at::Tensor f8f8bf16_v2(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor scale,
+    bool use_fast_accum = true);
+
+TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+#ifndef USE_ROCM
+  // CUTLASS kernel v2
+  m.def(
+      "f8f8bf16_v2(Tensor XQ, Tensor WQ, Tensor scale, bool use_fast_accum=True) -> Tensor");
+
+#endif
+}
+
+TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
+#ifndef USE_ROCM
+  // CUTLASS kernel v2
+  m.impl("f8f8bf16_v2", f8f8bf16_v2);
+#endif
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/utils.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/utils.cu
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cutlass_extensions/include/utils.h>
+
+namespace cutlass_extensions {
+
+static struct {
+  char const* text;
+  char const* pretty;
+  FusionKind enumerant;
+} FusionKind_enumerants[] = {
+    {"none", "None", FusionKind::kNone},
+    {"tensorwise scaling", "TensorWiseScaling", FusionKind::kTensorwiseScaling},
+    {"rowwise scaling", "RowWiseScaling", FusionKind::kRowwiseScaling},
+    {"blockwise scaling", "BlockWiseScaling", FusionKind::kBlockwiseScaling},
+    {"invalid", "Invalid", FusionKind::kInvalid}};
+
+/// Converts a FusionKind enumerant to a string
+char const* to_string(FusionKind fusion_kind, bool pretty) {
+  for (auto const& possible : FusionKind_enumerants) {
+    if (fusion_kind == possible.enumerant) {
+      if (pretty) {
+        return possible.pretty;
+      } else {
+        return possible.text;
+      }
+    }
+  }
+
+  return pretty ? "Invalid" : "invalid";
+}
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+static struct {
+  char const* text;
+  char const* pretty;
+  MainloopSchedule enumerant;
+} MainloopSchedule_enumerants[] = {
+    {"unknown", "Unknown", MainloopSchedule::kUnknown},
+    {"multistage", "Multistage", MainloopSchedule::kMultistage},
+    {"warpspecialized", "Warpspecialized", MainloopSchedule::kWarpspecialized},
+    {"warpspecialized pingpong",
+     "WarpspecializedPingpong",
+     MainloopSchedule::kWarpspecializedPingpong},
+    {"warpspecialized cooperative",
+     "WarpspecializedCooperative",
+     MainloopSchedule::kWarpspecializedCooperative},
+    {"invalid", "Invalid", MainloopSchedule::kInvalid},
+};
+
+/// Converts a MainloopSchedule enumerant to a string
+char const* to_string(MainloopSchedule mainloop_schedule, bool pretty) {
+  for (auto const& possible : MainloopSchedule_enumerants) {
+    if (mainloop_schedule == possible.enumerant) {
+      if (pretty) {
+        return possible.pretty;
+      } else {
+        return possible.text;
+      }
+    }
+  }
+
+  return pretty ? "Invalid" : "invalid";
+}
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+static struct {
+  char const* text;
+  char const* pretty;
+  AccumKind enumerant;
+} AccumKind_enumerants[] = {
+    {"default", "Default", AccumKind::kDefault},
+    {"fast accum", "FastAccum", AccumKind::kFastAccum},
+    {"invalid", "Invalid", AccumKind::kInvalid},
+};
+
+/// Converts a MainloopSchedule enumerant to a string
+char const* to_string(AccumKind accum_kind, bool pretty) {
+  for (auto const& possible : AccumKind_enumerants) {
+    if (accum_kind == possible.enumerant) {
+      if (pretty) {
+        return possible.pretty;
+      } else {
+        return possible.text;
+      }
+    }
+  }
+
+  return pretty ? "Invalid" : "invalid";
+}
+/////////////////////////////////////////////////////////////////////////////////////////////////
+} // namespace cutlass_extensions


### PR DESCRIPTION
Summary:
This diff creates a library of cutlass kernels starting fp8 tensorwise scaled gemms as cutlass_extensions to be used within Meta. CUTLASS extensions v2 is being built with an intension to consolidate all of Meta's CUTLASS use-cases within cutlass_extensions.

Differential Revision: D59240214
