### PR TITLE
Compactable with ROCm6.2 

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -201,6 +201,7 @@ if(USE_ROCM)
   list(APPEND HIP_HCC_FLAGS
     " \"-Wno-#pragma-messages\" "
     " \"-Wno-#warnings\" "
+    -fclang-abi-compat=17
     -Wno-cuda-compat
     -Wno-deprecated-declarations
     -Wno-format

--- a/fbgemm_gpu/codegen/embedding_common_code_generator.py
+++ b/fbgemm_gpu/codegen/embedding_common_code_generator.py
@@ -1096,6 +1096,8 @@ def rowwise_adagrad_with_counter() -> Dict[str, Any]:
 
     at::acc_type<cache_t, true> adjusted_multiplier;
     at::acc_type<cache_t, true> exp_reg_correction;
+    adjusted_multiplier = 0.0;
+    exp_reg_correction = 0.0;
 
     if (threadIdx.x == 0) {
         at::acc_type<cache_t, true> new_sum_square_grads = momentum1[idx] + g_avg_square;
@@ -1463,6 +1465,7 @@ def partial_rowwise_lamb() -> Dict[str, Any]:
         warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(g_local_sum_square, shfl_sync_mask) / D;
 
     at::acc_type<cache_t, true> m2;
+    m2 = 0.0;
     if (threadIdx.x == 0) {
         m2 = beta2 * momentum2[idx] + (1.0 - beta2) * g_avg_square;
         momentum2[idx] = m2;
@@ -1609,6 +1612,7 @@ def partial_rowwise_adam() -> Dict[str, Any]:
         warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(g_local_sum_square) / D;
 
     at::acc_type<cache_t, true> v_hat_t;
+    v_hat_t = 0.0;
     if (threadIdx.x == 0) {
         at::acc_type<cache_t, true> v_t = momentum2[idx] * beta2 + g_avg_square * (1.0 - beta2);
         momentum2[idx] = v_t;

--- a/fbgemm_gpu/codegen/genscript/optimizers.py
+++ b/fbgemm_gpu/codegen/genscript/optimizers.py
@@ -175,6 +175,8 @@ def rowwise_adagrad() -> Dict[str, Any]:
 
     at::acc_type<cache_t, true> multiplier;
     at::acc_type<cache_t, true> correction;
+    multiplier = 0.0;
+    correction = 0.0;
     if (threadIdx.x == 0) {
         at::acc_type<cache_t, true> new_sum_square_grads = momentum1[idx] + g_avg_square;
         momentum1[idx] = new_sum_square_grads;
@@ -485,6 +487,8 @@ def rowwise_adagrad_with_counter() -> Dict[str, Any]:
 
     at::acc_type<cache_t, true> adjusted_multiplier;
     at::acc_type<cache_t, true> exp_reg_correction;
+    adjusted_multiplier = 0.0;
+    exp_reg_correction = 0.0;
 
     if (threadIdx.x == 0) {
         at::acc_type<cache_t, true> new_sum_square_grads = momentum1[idx] + g_avg_square;
@@ -852,6 +856,7 @@ def partial_rowwise_lamb() -> Dict[str, Any]:
         warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(g_local_sum_square, shfl_sync_mask) / D;
 
     at::acc_type<cache_t, true> m2;
+    m2  = 0.0;
     if (threadIdx.x == 0) {
         m2 = beta2 * momentum2[idx] + (1.0 - beta2) * g_avg_square;
         momentum2[idx] = m2;
@@ -998,6 +1003,7 @@ def partial_rowwise_adam() -> Dict[str, Any]:
         warpReduceAllSum<at::acc_type<cache_t, true>, kThreadGroupSize>(g_local_sum_square) / D;
 
     at::acc_type<cache_t, true> v_hat_t;
+    v_hat_t = 0.0;
     if (threadIdx.x == 0) {
         at::acc_type<cache_t, true> v_t = momentum2[idx] * beta2 + g_avg_square * (1.0 - beta2);
         momentum2[idx] = v_t;

--- a/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/fbgemm_cuda_utils.cuh
@@ -1102,6 +1102,8 @@ DEVICE_INLINE T warp_reduce_max(T val) {
 template <typename scalar_t>
 DEVICE_INLINE float2 warp_find_qparams(scalar_t local_min, scalar_t local_max) {
   float2 qparams;
+  qparams.x = 0.0f;
+  qparams.y = 0.0f;
   local_min = warp_reduce_min<scalar_t>(local_min);
   local_max = warp_reduce_max<scalar_t>(local_max);
   if (threadIdx.x == 0) {


### PR DESCRIPTION
The credit for this PR belongs to @naromero77amd and @shiltian.
Initializing variables and adding the `-fclang-abi-compat=17` flag to make fbgemm_gpu compatible with ROCm6.2.