### PR TITLE
Add NVFP4 fake quant kernel to fbgemm

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -116,6 +116,14 @@ at::Tensor get_fp8_per_tensor_scale(
     std::optional<at::Tensor> bs,
     std::optional<at::Tensor> scale_ub); // scale upperbound
 
+#ifndef USE_ROCM
+std::vector<at::Tensor> quantize_nvfp4_per_tensor(
+    at::Tensor input,
+    std::optional<at::Tensor> static_scales,
+    std::optional<at::Tensor> bs, // batch size
+    std::optional<at::Tensor> scale_ub); // scale upperbound
+#endif
+
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 #ifndef USE_ROCM
   // TODO: on AMD this throws "Undefined symbol" when loading
@@ -140,6 +148,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "i8i8bf16_dynamic(Tensor XQ, Tensor WQ, Tensor scale, int split_k=1) -> Tensor");
   m.impl("i8i8bf16_dynamic", i8i8bf16_dynamic);
+  m.def(
+      "quantize_nvfp4_per_tensor(Tensor input, Tensor? static_scales=None, Tensor? bs=None, Tensor? scale_ub=None) -> Tensor[]");
+  m.impl("quantize_nvfp4_per_tensor", quantize_nvfp4_per_tensor);
 #endif
   m.def(
       "f8f8bf16_blockwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, int block_m=256, int block_n=256, int block_k=256) -> Tensor");

--- a/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
@@ -9,7 +9,7 @@
 
 import unittest
 
-from typing import Tuple
+from typing import Optional, Tuple
 
 import fbgemm_gpu.experimental.gen_ai  # noqa: F401
 
@@ -603,6 +603,53 @@ class FP8Tests(unittest.TestCase):
 
         zq_ref = (x @ w.T).to(torch.bfloat16)
         torch.testing.assert_close(zq, zq_ref, atol=1.0e-3, rtol=1.0e-3)
+
+
+@unittest.skipIf(
+    not torch.cuda.is_available()
+    or torch.cuda.get_device_properties(torch.cuda.current_device()).major < 9
+    or torch.version.hip is not None,
+    "Skip when cuda is not available or HIP is enabled",
+)
+class NVFP4Tests(unittest.TestCase):
+    @unittest.skipIf(
+        (not torch.version.cuda) or torch.version.hip is not None,
+        "Skip if no cuda is present or HIP is enabled",
+    )
+    @settings(deadline=None)
+    @given(
+        B_T=st.sampled_from([2048, 4096]),
+        D=st.sampled_from([128, 256]),
+        HD_L=st.sampled_from([256, 512]),
+        static_scale=st.sampled_from(
+            [None, torch.tensor([1.0], dtype=torch.float, device="cuda")]
+        ),
+        scale_ub=st.sampled_from(
+            [None, torch.tensor([1.0], dtype=torch.float, device="cuda")]
+        ),
+    )
+    def test_fake_quantize_nvfp4_per_tensor(
+        self,
+        B_T: int,
+        D: int,
+        HD_L: int,
+        static_scale: Optional[torch.tensor],
+        scale_ub: Optional[torch.tensor],
+    ) -> None:
+        x = torch.randn(size=(B_T, D), dtype=torch.bfloat16, device="cuda") * 0.1
+        w = torch.randn(size=(HD_L, D), dtype=torch.bfloat16, device="cuda") * 0.01
+
+        xq, _ = torch.ops.fbgemm.quantize_nvfp4_per_tensor(
+            x, static_scales=static_scale, scale_ub=scale_ub
+        )
+        wq, _ = torch.ops.fbgemm.quantize_nvfp4_per_tensor(
+            w, static_scales=static_scale, scale_ub=scale_ub
+        )
+        fake_quant_y = xq @ wq.T
+        fake_quant_y = fake_quant_y.to(torch.bfloat16)
+
+        y_ref = (x @ w.T).to(torch.bfloat16)
+        torch.testing.assert_close(fake_quant_y, y_ref, atol=0.1, rtol=0.1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Add the NVFP4 fake quant kernel to fbgemm (in standalone diff for general uses)
Add unittest for NVFP4 fake quant on input and weight tensors of GEMM operators.

Context: NVFP4 is a custom format on Nvidia Blackwell GPUs, which is a slight variant from MX4. Specifically, it uses: block size = 16; MX4 E2M1 elements + E4M3 (OCP FP8) block scales in each block; per-tensor scaling factor( due to the limited range of E4M3 vs E8M0).

Reviewed By: jiawenliu64

Differential Revision: D59980951
