### PR TITLE
[fbgemm_gpu] Fix setuptools version

### DIFF
--- a/fbgemm_gpu/requirements.txt
+++ b/fbgemm_gpu/requirements.txt
@@ -10,6 +10,7 @@
 #   * https://github.com/nod-ai/SHARK/issues/2095
 #   * https://github.com/jianyicheng/mase-docker/pull/9
 
+backports.tarfile
 build
 cmake
 hypothesis


### PR DESCRIPTION
- Fix setuptools version to be >= 71.0.3 to get the fix for https://github.com/pypa/setuptools/issues/4476 (affects Nova CI)