### PR TITLE
[detailed][ops] add dispatch_to_cpu for the operators

### DIFF
--- a/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops_cpu.cpp
+++ b/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops_cpu.cpp
@@ -316,6 +316,10 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   DISPATCH_TO_AUTOGRAD(
       "permute_multi_embedding", fbgemm_gpu::permute_multi_embedding);
 
+  // dispath the main function to CPU for external usage
+  DISPATCH_TO_CPU(
+      "permute_multi_embedding", fbgemm_gpu::permute_multi_embedding);
+
   // dispath the main function to Autograd for external usage
   DISPATCH_TO_CUDA(
       "permute_multi_embedding", fbgemm_gpu::permute_multi_embedding);
@@ -323,6 +327,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   // dispath the main function to Autograd for external usage
   DISPATCH_TO_AUTOGRAD(
       "regroup_keyed_tensor", fbgemm_gpu::regroup_keyed_tensor);
+
+  // dispath the main function to CPU for external usage
+  DISPATCH_TO_CPU("regroup_keyed_tensor", fbgemm_gpu::regroup_keyed_tensor);
 
   // dispath the main function to Autograd for external usage
   DISPATCH_TO_CUDA("regroup_keyed_tensor", fbgemm_gpu::regroup_keyed_tensor);


### PR DESCRIPTION
# FBGEMM Operator Design

## Operator Schema ([API](https://docs.pytorch.org/cppdocs/library.html#torch-library-api)) - Why Better Start with CUDA

Despite various backend implementations, an operator should have just one schema to define the input and output, which can be accessed from the pytorch domain. As an example, we actually defined 4 operators for the “KT regroup function” ([codepointer](https://github.com/pytorch/FBGEMM/blob/main/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops_cpu.cpp#L353-L368)) with their functionality shown in the diagram below. 
<img width="1600" height="581" alt="image" src="https://github.com/user-attachments/assets/7a8e3fef-c559-450b-a0e2-d131e8d3f9ab" />

The operator schema uses typical (python/pytorch) data types: Tensor, int, SymInt, bool, float, str, and compounds like List[Tensor], List[List[int]], etc. 

> Notes: The old permute operator flattens (concatenates) the input tensors so there is no need for nested arguments like  List[List[int]] or List[List[str]], which can’t be traced in PT2 (compile nor export). On the other hand, we have to develop a TorchRec IR serializer for the KTRegroupAsDict module to work around the PT2 limitation. 

There are some design considerations regarding the operator schema
* Basic [CUDA programming](https://docs.nvidia.com/cuda/cuda-c-programming-guide/) knowledge, e.g., what data can be accessed from a kernel, how to pass the data/arguments to a kernel.
* Where the data is allocated before calling the operator, and possible optimization (pre-fetch, caching, async comm, etc.).
* When launching CUDA kernels, they often require metadata that may not be directly available. In such cases, it is necessary to compute these parameters before kernel launch. It could be done in python (simpler) or C++ (faster).
* Python/Pytorch data type to C++/CUDA data type mapping: int ⇒ int64_t, List[type] ⇒ std::vector<type> , List[Tensor] ⇒ at::TensorList

Let’s look at the arguments in these regroup operators:
1. pooled_embs: List[Tensor] are the main data pre-allocated on GPU
2. permutes, in_shapes, out_shapes are Tensor that are needed by CUDA kernels, and should be on GPU. 
3. out_lengths is List[SymInt] and should be on the CPU so it can allocate the GPU memory for the output, on the other hand, the out_shapes tensor has effectively the same value but on GPU, which is available to the CUDA kernels. 
4. arguments other than the pooled_embs are all static parameters, they are computed from static parameters like keys: List[List[str]], groups, and lengths: List[List[int]]. 

## Tensor List as Argument - Why Need Extra Host-to-Device Comm
Considering a single Tensor that is on the GPU, its metadata (e.g., tensor shape and memory address) are actually on the CPU such that the CUDA kernels can be launched from the host (CPU). Now let’s take a closer look at the pooled_embs: List[Tensor]. The tensors’ data are on GPU but their memory addresses are actually on CPU. 

In the CUDA operator implementation, there is [an extra step](https://github.com/pytorch/FBGEMM/blob/main/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu#L210-L226) of sending the input&output tensors’ address from CPU to GPU (host-to-device communication), so that the kernels can know which tensor to operate on.
```
template <typename scalar_t>
Tensor tensors_ptr(const at::TensorList& tensors) {
  auto size = tensors.size();
  Tensor ptr_tensor = at::empty(
      {static_cast<long>(size * sizeof(scalar_t*))},
      at::TensorOptions().dtype(tensors[0].scalar_type()).pinned_memory(true));

  // Ensure that ptr_tensor is contiguous
  TORCH_CHECK(ptr_tensor.is_contiguous());
  auto tp = reinterpret_cast<scalar_t**>(ptr_tensor.data_ptr());
  for (int32_t i = 0; i < tensors.size(); i++) {
    tp[i] = tensors[i].data_ptr<scalar_t>();
  }
  // Ensure that ptr_tensor is contiguous
  TORCH_CHECK(ptr_tensor.is_contiguous());
  return ptr_tensor;
}
```

Similarly, this reasoning also applies to the lengths: List[List[int]] argument. The kernels cannot directly access the length vector on the CPU, and host-to-device communication is required.


## this PR
* in the tests with `dispatch_to_autograd` can cover all cases including cpu, cuda, meta
* however, in an inference workflow, it complains that can't find the CPU version: P1490223505
```
Exception Found: Could not run 'fbgemm::permute_multi_embedding' with arguments from the 'CPU' backend
```
* it looks like `AutogradCPU` and `CPU` are treated differently.
 {F1768093961}

Differential Revision: D48720379
