### PR TITLE
Fix multi gpu customized all reduce test for AMD

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/test/comm/multi_gpu_car_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/comm/multi_gpu_car_test.py
@@ -134,7 +134,10 @@ def _run_allreduce_inner(path: str) -> None:
         def round_up(a: int, b: int) -> int:
             return int(math.ceil(a / b)) * b
 
-        N = round_up(N, 256)
+        N_even_divisor = 8 * 64 if torch.version.hip else 8 * 32
+        N = round_up(N, N_even_divisor)
+        if rank == 0:
+            logger.info(f"N: {N}")
         y = torch.zeros(size=(N,), dtype=torch.bfloat16, device="cuda")
         y[:] = rank
         y_allreduce = torch.empty_like(y)
@@ -229,9 +232,10 @@ def _run_oneshot_car_stress_inner(path: str) -> None:
         def round_up(a: int, b: int) -> int:
             return int(math.ceil(a / b)) * b
 
-        N = round_up(N, 256)
+        N_even_divisor = 8 * 64 if torch.version.hip else 8 * 32
+        N = round_up(N, N_even_divisor)
         if rank == 0:
-            print(f"N: {N}")
+            logger.info(f"N: {N}")
         for iterId in range(ITER):
             y = torch.zeros(size=(N,), dtype=torch.bfloat16, device="cuda")
             y[:] = rank + idx + iterId


### PR DESCRIPTION
Summary:
Test failure on MI300x only:

```
    File "/mnt/xarfuse/uid-169890/4fb88812-seed-nspid4026531836_cgpid164384869-ns-4026531841/torch/distributed/elastic/multiprocessing/errors/__in
it__.py", line 355, in wrapper
      return f(*args, **kwargs)
    File "/mnt/xarfuse/uid-169890/4fb88812-seed-nspid4026531836_cgpid164384869-ns-4026531841/deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai/te
st/comm/multi_gpu_car_test.py", line 141, in _run_allreduce_inner
      torch.ops.fbgemm.one_shot_car_allreduce(y_allreduce, y)
    File "/mnt/xarfuse/uid-169890/4fb88812-seed-nspid4026531836_cgpid164384869-ns-4026531841/torch/_ops.py", line 1120, in __call__
      return self._op(*args, **(kwargs or {}))
  RuntimeError: Expected N % N_per_warp == 0 to be true, but got false.  (Could this error message be improved?  If so, please report an enhanceme
nt request to PyTorch.)
```

```
  Exception raised from one_shot_car_allreduce at buck-out/v2/gen/fbcode/0b30f0b22247298e/deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai/__com
m_ops_hip_hipify_gen__/out/src/comm/car.hip:542 (most recent call first):
```

-->

https://www.internalfb.com/code/fbsource/[d7412f71f108ef5ae9d44b6d42d8a54aea737c21]/fbcode/deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai/src/comm/car.cu?lines=538-539

kThreadsPerWarp is 32 on NV GPUs, and 64 on AMD GPUs.

Differential Revision: D60097224
