### PR TITLE
Fix auto-vec int8 CPU STBE

### DIFF
--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -1088,7 +1088,6 @@ typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType, outType>::
             no_bag,
             is_bf16_out);
       };
-
     } else {
       return [=](int64_t output_size,
                  int64_t index_size,


### PR DESCRIPTION
Summary: Fix test failure in deeplearning/fbgemm/fbgemm_gpu/test/tbe:nbit_forward - test_nbit_forward_cpu_seq_int8

Differential Revision: D60126202
