### PR TITLE
track states properly

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -41,6 +41,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     CounterWeightDecayMode,
     DEFAULT_ASSOC,
     DenseTableBatchedEmbeddingBagsCodegen,
+    GlobalWeightDecayDefinition,
     GradSumDecay,
     INT8_EMB_ROW_DIM_OFFSET,
     LearningRateMode,


### PR DESCRIPTION
Summary: Global weight decay has additional state `prev_iter` compared to rowwise_adagrad, need to return it in optimizer state to allow proper checkpointing.

Differential Revision: D60155101
