### PR TITLE
Pass eval() down through ShardedPooledEmbeddingArch

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -41,6 +41,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     CounterWeightDecayMode,
     DEFAULT_ASSOC,
     DenseTableBatchedEmbeddingBagsCodegen,
+    GlobalWeightDecayDefinition,
     GradSumDecay,
     INT8_EMB_ROW_DIM_OFFSET,
     LearningRateMode,


### PR DESCRIPTION
Summary: When running for evaluation, the model needs to be set to eval mode by setting `self.training=False`. This flag should be propagated to all sub-modules. However,  in `ShardedPooledEmbeddingArch`, only the weights of TBE are registered (https://fburl.com/code/9g0uykxu) but the TBE module is not taken care of. This causes a problem when running eval: the TBE is not put into eval mode, especially when GWD is enabled which requires different behavior for training vs eval (eval shouldn't be doing weight decay).

Differential Revision: D59817443
