### PR TITLE
Call finish_checkpoint_resume to flush optimizer step

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -41,6 +41,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     CounterWeightDecayMode,
     DEFAULT_ASSOC,
     DenseTableBatchedEmbeddingBagsCodegen,
+    GlobalWeightDecayDefinition,
     GradSumDecay,
     INT8_EMB_ROW_DIM_OFFSET,
     LearningRateMode,

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -2127,11 +2127,12 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.optimizer_args = self.optimizer_args._replace(learning_rate=lr)
         return 0.0
 
-    @torch.jit.export
+    @torch.jit.ignore
     def set_optimizer_step(self, step: int) -> None:
         """
         Sets the optimizer step.
         """
+        self.log(f"set_optimizer_step from {self.iter[0]} to {step}")
         if self.optimizer == OptimType.NONE:
             raise NotImplementedError(
                 f"Setting optimizer step is not supported for {self.optimizer}"


### PR DESCRIPTION
Summary: `iter` number is a critical counter in computing how much decay is needed together with `prev_iter`. However, `iter` is not checkpointed since it is not in `split_optimizer_state`. Instead, it relies on external calls of `set_optimizer_step` to flush the counter, which relies on explict calls of `finish_checkpoint_resume` to trigger `flush_state` in `FullSyncOptimizer`. This chain of actions is not properly set up in existing code, which causes the issue that after a preemption, `iter` gets reset to zero.

Differential Revision: D60155781
