### PR TITLE
Fix GlobalWeightDecayDefinition frozen class

### DIFF
--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_global_weight_decay_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_global_weight_decay_test.py
@@ -244,9 +244,9 @@ def execute_global_weight_decay(  # noqa C901
     else:
         Bs = [B] * num_features
         Bs_rank_feature = None
-    global_weight_decay = GlobalWeightDecayDefinition()
-    global_weight_decay.start_iter = start_iter
-    global_weight_decay.lower_bound = gwd_lower_bound
+    global_weight_decay = GlobalWeightDecayDefinition(
+        start_iter=start_iter, lower_bound=gwd_lower_bound
+    )
     tbe = SplitTableBatchedEmbeddingBagsCodegen(
         embedding_specs=[
             (E, D, managed_option, ComputeDevice.CUDA) for (E, D) in zip(Es, Ds)


### PR DESCRIPTION
Summary:
Fixed class initialization to align with changes  in D60155101.

Basically, `GlobalWeightDecayDefinition` has been set as `frozen_class`, but existing code assign values to the class after the initialization, causing error:
 ```
dataclasses.FrozenInstanceError: cannot assign to field 'start_iter'
```

Differential Revision: D60206881


