### PR TITLE
Do not set no_grad for TBE backward

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_cpu_template.cpp
@@ -105,9 +105,6 @@ class SplitLookupFunction_{{ optimizer }}_Op : public torch::autograd::Function<
   static torch::autograd::variable_list backward(
       torch::autograd::AutogradContext* ctx,
       torch::autograd::variable_list grad_outputs) {
-    // backward does weights mutation, allowed in aot_autograd only with no_grad
-    at::AutoGradMode m(false);
-
     const auto saved = ctx->get_saved_variables();
     auto savedItr = std::begin(saved);
     auto host_weights = *savedItr++;

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
@@ -798,9 +798,6 @@ class {{ autograd_func }} :
   static torch::autograd::variable_list backward(
       torch::autograd::AutogradContext* ctx,
       torch::autograd::variable_list grad_outputs) {
-    // backward impl does mutation of weights, which are allowed in aot autograd only in no_grad mode
-    at::AutoGradMode m(false);
-
     const auto saved = ctx->get_saved_variables();
     auto savedItr = std::begin(saved);
     auto dev_weights = *savedItr++;

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
@@ -365,9 +365,6 @@ class {{ autograd_func }} :
 static torch::autograd::variable_list backward(
     torch::autograd::AutogradContext* ctx,
     torch::autograd::variable_list grad_outputs) {
-    // backward does weights mutation, allowed in aot_autograd only with no_grad
-    at::AutoGradMode m(false);
-
     const auto saved = ctx->get_saved_variables();
     auto savedItr = std::begin(saved);
     auto host_weights = *savedItr++;


### PR DESCRIPTION
Summary: TBE weights are Tensor without requires_grad => Mutations in Backward work without turning off GradMode, to not break double-grad.

Differential Revision: D60225378
