### PR TITLE
Add Stochastic downcasting to MX4 Quantization

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/quantize_utils.py
+++ b/fbgemm_gpu/fbgemm_gpu/quantize_utils.py
@@ -35,6 +35,7 @@ def fp32_to_mx4(
     tensor: torch.Tensor,
     group_size: int = 32,
     rounding_mode: Optional[Union[RoundingMode, int]] = RoundingMode.ceil,
+    stochastic_casting: bool = False,
     use_triton: bool = True,
 ) -> torch.Tensor:
     """Quantize an FP32 tensor to MX4 with triton or native cuda impl.
@@ -44,6 +45,7 @@ def fp32_to_mx4(
         group_size (int): Compute scale in chunks of group_size.
         rounding_mode (RoundingMode or int): Which type of rounding to use when computing exponent.
         Only supported with use_triton=True.
+        stochastic_casting (bool): Whether to use stochastic casting when downcasting.
         use_triton (bool): If set, use triton quantization, otherwise cuda.
 
     Return:
@@ -60,7 +62,12 @@ def fp32_to_mx4(
         return py_quantize_mx4(input, group_size, rounding_mode=rounding_mode)
 
     if use_triton:
-        return quantize_mx4(input, group_size, rounding_mode=rounding_mode)
+        return quantize_mx4(
+            input,
+            group_size,
+            rounding_mode=rounding_mode,
+            stochastic_casting=stochastic_casting,
+        )
     else:
         out = torch.ops.fbgemm.quantize_mx_cuda(
             input,

--- a/fbgemm_gpu/fbgemm_gpu/triton/quantize_ref.py
+++ b/fbgemm_gpu/fbgemm_gpu/triton/quantize_ref.py
@@ -26,25 +26,31 @@ def _compute_exp(
     Returns:
         Tensor: Shared exponent of group.
     """
+    # Helpful constants.
+    MBITS_FP32 = 23
+    MBITS_E2M1 = 1
+    RAND_MASK = (1 << (MBITS_FP32 - MBITS_E2M1)) - 1
+    # Nearest rounding mode.
     if rounding_mode == 0:
-        return torch.round(torch.log2(group_max))
+        return torch.floor(torch.log2(group_max) + 0.5)
     # Floor rounding mode.
     if rounding_mode == 1:
         return torch.floor(torch.log2(group_max))
     # Even pre-rounding mode.
     elif rounding_mode == 2:
         # First round to nearest even integer.
-        group_max = torch.round(group_max)
+        M_ROUND = (1 << (MBITS_FP32 - MBITS_E2M1 - 1)) - 1
+        group_max = group_max.view(dtype=torch.int32) + M_ROUND
         # Then perform floor rounding of log.
-        return torch.floor(torch.log2(group_max))
+        return torch.floor(torch.log2(group_max.view(dtype=torch.float32)))
     # Stochastic rounding mode.
     elif rounding_mode == 3:
         # Create random noise.
-        noise = torch.rand_like(group_max)
+        rand_bits = torch.randint_like(group_max, high=2**31 - 1, dtype=torch.int32)
         # Add noise to group max and round down.
-        group_max = group_max + noise
+        group_max = group_max.view(dtype=torch.int32) + (RAND_MASK & rand_bits)
         # Now compute log and truncate.
-        return torch.floor(torch.log2(group_max))
+        return torch.floor(torch.log2(group_max.view(dtype=torch.float32)))
     else:
         return torch.ceil(torch.log2(group_max))
 
@@ -53,6 +59,7 @@ def py_quantize_mx4(
     a: torch.Tensor,
     group_size: int = 32,
     rounding_mode: Union[RoundingMode, int] = RoundingMode.ceil,
+    stochastic_casting: bool = False,
 ) -> torch.Tensor:
     """
     Quantize a tensor to mx4 format.
@@ -62,6 +69,7 @@ def py_quantize_mx4(
         group_size (int): Size of chunks that will use the same shared exponent.
         rounding_mode (int or RoundingMode): Which type of rounding to use when
         calculating shared exponent.
+        stochastic_casting (bool): Whether to use stochastic rounding when downcasting.
 
     Returns:
         torch.Tensor: [M / 2 + M / group_size] mx4 scaled tensor packed into in8
@@ -72,6 +80,24 @@ def py_quantize_mx4(
         each value contain two elements packed into an int8 and
         there are 32 groups in each row.
     """
+    # Define helpful constants.
+    FP32_MIN_NORMAL = 2 ** (-126)
+    FP32_SIGN_OFFSET = 31
+    SIGN_MASK = 0x1
+    FP32_EXP_MASK = 0x7F800000
+    FP32_EXP_OFFSET = 23
+    FP32_MANTISSA_MASK = 0x007FFFFF
+    # Fp4 has 2 mantissa bits, one explicit, one implicit.
+    MBITS = 2
+    # FP32 and and FP4 have very different exponent biases, adjust to fp4.
+    FP32_EXP_BIAS = 127
+    FP4_EXP_BIAS = 1
+    MAX_FP32_MANTISSA_BITS = 24
+    RAND_MASK = (1 << (FP32_EXP_OFFSET - FP4_EXP_BIAS)) - 1
+    OVERFLOW_THRESHOLD = 4
+    IMPLICIT_1_MASK = 0x1
+
+    # Make sure input has a supported shape.
     # If given an empty shape, return an empty tensor.
     if a.numel() == 0:
         return torch.empty(a.shape, device=a.device, dtype=torch.uint8)
@@ -87,7 +113,6 @@ def py_quantize_mx4(
     # Now we can easily compute the shared exponents for each group.
     shared_exp, _ = torch.max(torch.abs(a), dim=1, keepdim=True)
     # Replace zero values with the minimum expressible normal value.
-    FP32_MIN_NORMAL = 2 ** (-126)
     shared_exp = torch.where(shared_exp == 0, FP32_MIN_NORMAL, shared_exp)
     # Convert max into an integer exponent.
     shared_exp = _compute_exp(shared_exp, rounding_mode)
@@ -103,36 +128,29 @@ def py_quantize_mx4(
     # View as integer for bitwise ops.
     a = a.view(torch.int32)
 
+    # When doing ceiling rounding, we apply stochastic downcasting.
+    if stochastic_casting:
+        rand_bits = torch.randint_like(a, high=2**31 - 1, dtype=torch.int32)
+        a = a + (rand_bits & RAND_MASK)
+
     # Quantization step: convert fp32 values to fp4.
     # Start by extracting float components.
-    FP32_SIGN_OFFSET = 31
     sign_bit = torch.bitwise_right_shift(a, FP32_SIGN_OFFSET).to(torch.int8)
     # Torch does arithmetic shifts so we need to isolate sign bit.
-    SIGN_MASK = 0x1
     sign_bit = torch.bitwise_and(sign_bit, SIGN_MASK)
 
     # Next extract exponent.
-    FP32_EXP_MASK = 0x7F800000
     biased_exp = torch.bitwise_and(a, FP32_EXP_MASK)
     # Shift exponent over to least significant bits.
-    FP32_EXP_OFFSET = 23
     biased_exp = torch.bitwise_right_shift(biased_exp, FP32_EXP_OFFSET).to(torch.int8)
 
     # Finally extract the mantissa.
-    FP32_MANTISSA_MASK = 0x007FFFFF
     trailing_mantissa = torch.bitwise_and(a, FP32_MANTISSA_MASK)
-
-    # Fp4 has 2 mantissa bits, one explicit, one implicit.
-    MBITS = 2
-    # FP32 and and FP4 have very different exponent biases, adjust to fp4.
-    FP32_EXP_BIAS = 127
-    FP4_EXP_BIAS = 1
     new_biased_exp = biased_exp - FP32_EXP_BIAS + FP4_EXP_BIAS
 
     # Compute difference between ideal exponent and what can be represented.
     exp_diff = torch.where(new_biased_exp <= 0, 1 - new_biased_exp, 0)
     # Clip this difference to the maximum number of fp32 mantissa bits (23 + implicit).
-    MAX_FP32_MANTISSA_BITS = 24
     exp_diff = torch.clamp(exp_diff, max=MAX_FP32_MANTISSA_BITS)
 
     # Now perform mantissa rounding down to fp4.
@@ -151,7 +169,6 @@ def py_quantize_mx4(
     mantissa = torch.bitwise_right_shift(mantissa, 1)
 
     # Check for overflow and adjust exponent accordingly.
-    OVERFLOW_THRESHOLD = 4
     overflow = mantissa >= OVERFLOW_THRESHOLD
     # Allow subnorms to overflow into normals, otherwise shift off overflow.
     mantissa = torch.where(
@@ -164,7 +181,6 @@ def py_quantize_mx4(
         torch.bitwise_and(new_biased_exp <= 0, mantissa == 2), 1, new_biased_exp
     )
     # Remove implicit 1.
-    IMPLICIT_1_MASK = 0x1
     mantissa = torch.bitwise_and(mantissa, IMPLICIT_1_MASK)
     # Add overflow to exponent.
     new_biased_exp = torch.where(overflow, new_biased_exp + 1, new_biased_exp)


### PR DESCRIPTION
Summary:
This diff adds stochastic noise injection when using the new`stochastic_casting` argument during mx4 quantization. This is an experimental feature that defaults to being off. Experimentally, it may worsen results and increase runtime.

I did my best to optimize the random noise generation with optimal philox generation but it still is fairly costly. It brings the runtime from ~3000ms to ~3500ms.

Differential Revision: D59835478
