### PR TITLE
Remove importing GlobalWeightDecayDefinition in split_table_batched_embeddings_ops

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py
@@ -41,7 +41,6 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     CounterWeightDecayMode,
     DEFAULT_ASSOC,
     DenseTableBatchedEmbeddingBagsCodegen,
-    GlobalWeightDecayDefinition,
     GradSumDecay,
     INT8_EMB_ROW_DIM_OFFSET,
     LearningRateMode,


### PR DESCRIPTION
Summary: f585120721 packaged `split_table_batched_embeddings_ops.py` but not `split_table_batched_embeddings_ops_training.py`. Thus it fails to import `GlobalWeightDecayDefinition` from an older version of `split_table_batched_embeddings_ops_training.py`.

Reviewed By: spcyppt

Differential Revision: D60271207


