### PR TITLE
Update sparse_ops.py to use generic gpu target fbgemm_gpu:input_combine to support both nvidia and AMD

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -26,7 +26,6 @@ except Exception:
         torch.ops.load_library(
             "//deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops_hip"
         )
-        torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:input_combine_hip")
         torch.ops.load_library(
             "//deeplearning/fbgemm/fbgemm_gpu/codegen:index_select_ops_hip"
         )
@@ -36,7 +35,8 @@ except Exception:
             "//deeplearning/fbgemm/fbgemm_gpu:merge_pooled_embeddings"
         )
         torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu/codegen:embedding_ops")
-        torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:input_combine")
+
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:input_combine")
 
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
     torch.ops.load_library(


### PR DESCRIPTION
Summary: Update sparse_ops.py to use generic gpu target fbgemm_gpu:input_combine to support both nvidia and AMD

Differential Revision: D60271751
