### PR TITLE
Refactor CUDA callback functor

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -7,18 +7,10 @@
  */
 
 #include "kv_db_table_batched_embeddings.h"
+#include "kv_db_utils.h"
 #include "torch/csrc/autograd/record_function_ops.h"
 
 namespace kv_db {
-
-folly::CPUThreadPoolExecutor* CudaExecutor::get_executor() {
-  static auto executor = std::make_unique<folly::CPUThreadPoolExecutor>(1);
-  return executor.get();
-}
-
-void hostAsynchronousThreadPoolExecutor(void (*f)(void*), void* userData) {
-  CudaExecutor::get_executor()->add([f, userData]() { f(userData); });
-}
 
 void EmbeddingKVDB::get_cuda(
     const at::Tensor& indices,
@@ -30,24 +22,11 @@ void EmbeddingKVDB::get_cuda(
   auto self = shared_from_this();
   std::function<void()>* functor =
       new std::function<void()>([=]() { self->get(indices, weights, count); });
-  auto callFunctor =
-      [](cudaStream_t /*stream*/, cudaError_t status, void* userData) -> void {
-    AT_CUDA_CHECK(status);
-    auto* f = reinterpret_cast<std::function<void()>*>(userData);
-    AT_CUDA_CHECK(cudaGetLastError());
-    (*f)();
-    // delete f; // unfortunately, this invoke destructors that call CUDA
-    // API functions (e.g. caching host allocators issue cudaGetDevice(..),
-    // etc)
-    hostAsynchronousThreadPoolExecutor(
-        [](void* userData) {
-          auto* fn = reinterpret_cast<std::function<void()>*>(userData);
-          delete fn;
-        },
-        userData);
-  };
   AT_CUDA_CHECK(cudaStreamAddCallback(
-      at::cuda::getCurrentCUDAStream(), callFunctor, functor, 0));
+      at::cuda::getCurrentCUDAStream(),
+      kv_db_utils::cuda_callback_func,
+      functor,
+      0));
   rec->record.end();
 }
 
@@ -64,24 +43,11 @@ void EmbeddingKVDB::set_cuda(
     self->set(indices, weights, count);
     self->flush_or_compact(timestep);
   });
-  auto callFunctor =
-      [](cudaStream_t /*stream*/, cudaError_t status, void* userData) -> void {
-    AT_CUDA_CHECK(status);
-    auto* f = reinterpret_cast<std::function<void()>*>(userData);
-    AT_CUDA_CHECK(cudaGetLastError());
-    (*f)();
-    // delete f; // unfortunately, this invoke destructors that call CUDA
-    // API functions (e.g. caching host allocators issue cudaGetDevice(..),
-    // etc)
-    hostAsynchronousThreadPoolExecutor(
-        [](void* userData) {
-          auto* fn = reinterpret_cast<std::function<void()>*>(userData);
-          delete fn;
-        },
-        userData);
-  };
   AT_CUDA_CHECK(cudaStreamAddCallback(
-      at::cuda::getCurrentCUDAStream(), callFunctor, functor, 0));
+      at::cuda::getCurrentCUDAStream(),
+      kv_db_utils::cuda_callback_func,
+      functor,
+      0));
   rec->record.end();
 }
 

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
@@ -22,7 +22,6 @@
 
 #include <folly/Random.h>
 #include <folly/concurrency/UnboundedQueue.h>
-#include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/futures/Future.h>
 #include <folly/hash/Hash.h>
 
@@ -40,11 +39,6 @@
 #include "fbgemm_gpu/utils/dispatch_macros.h"
 
 namespace kv_db {
-
-class CudaExecutor {
- public:
-  static folly::CPUThreadPoolExecutor* get_executor();
-};
 
 class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
  public:

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_utils.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_utils.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "kv_db_utils.h"
+#include <ATen/cuda/CUDAContext.h>
+
+namespace kv_db_utils {
+
+namespace {
+
+class CudaExecutor {
+ public:
+  static folly::CPUThreadPoolExecutor* get_executor() {
+    static auto executor = std::make_unique<folly::CPUThreadPoolExecutor>(1);
+    return executor.get();
+  }
+};
+
+void host_async_threadpool_executor(void (*f)(void*), void* userData) {
+  CudaExecutor::get_executor()->add([f, userData]() { f(userData); });
+}
+
+}; // namespace
+
+void cuda_callback_func(
+    cudaStream_t /*stream*/,
+    cudaError_t status,
+    void* functor) {
+  AT_CUDA_CHECK(status);
+  auto* f = reinterpret_cast<std::function<void()>*>(functor);
+  AT_CUDA_CHECK(cudaGetLastError());
+  (*f)();
+  // delete f; // unfortunately, this invoke destructors that call CUDA
+  // API functions (e.g. caching host allocators issue cudaGetDevice(..),
+  // etc)
+  host_async_threadpool_executor(
+      [](void* functor) {
+        auto* fn = reinterpret_cast<std::function<void()>*>(functor);
+        delete fn;
+      },
+      functor);
+}
+
+}; // namespace kv_db_utils

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_utils.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_utils.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cuda_runtime.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+
+namespace kv_db_utils {
+
+/// @brief A callback function for `cudaStreamAddCallback`
+///
+/// A common callback function for `cudaStreamAddCallback`, i.e.,
+/// `cudaStreamCallback_t callback`. This function casts `functor`
+/// into a void function, invokes it and then delete it (the deletion
+/// occurs in another thread)
+///
+/// @param stream (`cudaStream_t`) CUDA stream that
+///               `cudaStreamAddCallback` operates on
+/// @param status (`cudaError_t`) CUDA status
+/// @param functor (`void*`) A functor that will be called
+///
+/// @return None
+void cuda_callback_func(cudaStream_t stream, cudaError_t status, void* functor);
+
+}; // namespace kv_db_utils

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <folly/executors/CPUThreadPoolExecutor.h>
 #include <torch/nn/init.h>
 #include <iostream>
 #include "kv_db_table_batched_embeddings.h"


### PR DESCRIPTION
Summary:
This diff creates a common CUDA callback function, called
`cuda_callback_func`, in the `kv_db_utils` namespace.  It can be used
as a callback function for `cudaStreamAddCallback`.

`cuda_callback_func` casts the input `functor` into a void function,
invokes it and then delete it.

Differential Revision: D60348604
