### PR TITLE
Add masked_index_select and refactor masked_index_put

### DIFF
--- a/fbgemm_gpu/docs/src/fbgemm_gpu-cpp-api/ssd_embedding_ops.rst
+++ b/fbgemm_gpu/docs/src/fbgemm_gpu-cpp-api/ssd_embedding_ops.rst
@@ -1,0 +1,7 @@
+SSD Embedding Operators
+=======================
+
+CUDA Operators
+--------------
+.. doxygengroup:: embedding-ssd
+   :content-only:

--- a/fbgemm_gpu/docs/src/index.rst
+++ b/fbgemm_gpu/docs/src/index.rst
@@ -79,6 +79,7 @@ Table of Contents
    fbgemm_gpu-cpp-api/input_combine.rst
    fbgemm_gpu-cpp-api/layout_transform_ops.rst
    fbgemm_gpu-cpp-api/embedding_ops.rst
+   fbgemm_gpu-cpp-api/ssd_embedding_ops.rst
    fbgemm_gpu-cpp-api/experimental_ops.rst
 
 .. _fbgemm-gpu.toc.api.python:

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -7,18 +7,10 @@
  */
 
 #include "kv_db_table_batched_embeddings.h"
+#include "kv_db_utils.h"
 #include "torch/csrc/autograd/record_function_ops.h"
 
 namespace kv_db {
-
-folly::CPUThreadPoolExecutor* CudaExecutor::get_executor() {
-  static auto executor = std::make_unique<folly::CPUThreadPoolExecutor>(1);
-  return executor.get();
-}
-
-void hostAsynchronousThreadPoolExecutor(void (*f)(void*), void* userData) {
-  CudaExecutor::get_executor()->add([f, userData]() { f(userData); });
-}
 
 void EmbeddingKVDB::get_cuda(
     const at::Tensor& indices,
@@ -30,24 +22,11 @@ void EmbeddingKVDB::get_cuda(
   auto self = shared_from_this();
   std::function<void()>* functor =
       new std::function<void()>([=]() { self->get(indices, weights, count); });
-  auto callFunctor =
-      [](cudaStream_t /*stream*/, cudaError_t status, void* userData) -> void {
-    AT_CUDA_CHECK(status);
-    auto* f = reinterpret_cast<std::function<void()>*>(userData);
-    AT_CUDA_CHECK(cudaGetLastError());
-    (*f)();
-    // delete f; // unfortunately, this invoke destructors that call CUDA
-    // API functions (e.g. caching host allocators issue cudaGetDevice(..),
-    // etc)
-    hostAsynchronousThreadPoolExecutor(
-        [](void* userData) {
-          auto* fn = reinterpret_cast<std::function<void()>*>(userData);
-          delete fn;
-        },
-        userData);
-  };
   AT_CUDA_CHECK(cudaStreamAddCallback(
-      at::cuda::getCurrentCUDAStream(), callFunctor, functor, 0));
+      at::cuda::getCurrentCUDAStream(),
+      kv_db_utils::cuda_callback_func,
+      functor,
+      0));
   rec->record.end();
 }
 
@@ -64,24 +43,11 @@ void EmbeddingKVDB::set_cuda(
     self->set(indices, weights, count);
     self->flush_or_compact(timestep);
   });
-  auto callFunctor =
-      [](cudaStream_t /*stream*/, cudaError_t status, void* userData) -> void {
-    AT_CUDA_CHECK(status);
-    auto* f = reinterpret_cast<std::function<void()>*>(userData);
-    AT_CUDA_CHECK(cudaGetLastError());
-    (*f)();
-    // delete f; // unfortunately, this invoke destructors that call CUDA
-    // API functions (e.g. caching host allocators issue cudaGetDevice(..),
-    // etc)
-    hostAsynchronousThreadPoolExecutor(
-        [](void* userData) {
-          auto* fn = reinterpret_cast<std::function<void()>*>(userData);
-          delete fn;
-        },
-        userData);
-  };
   AT_CUDA_CHECK(cudaStreamAddCallback(
-      at::cuda::getCurrentCUDAStream(), callFunctor, functor, 0));
+      at::cuda::getCurrentCUDAStream(),
+      kv_db_utils::cuda_callback_func,
+      functor,
+      0));
   rec->record.end();
 }
 

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
@@ -22,7 +22,6 @@
 
 #include <folly/Random.h>
 #include <folly/concurrency/UnboundedQueue.h>
-#include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/futures/Future.h>
 #include <folly/hash/Hash.h>
 
@@ -40,11 +39,6 @@
 #include "fbgemm_gpu/utils/dispatch_macros.h"
 
 namespace kv_db {
-
-class CudaExecutor {
- public:
-  static folly::CPUThreadPoolExecutor* get_executor();
-};
 
 class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
  public:

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_utils.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_utils.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "kv_db_utils.h"
+#include <ATen/cuda/CUDAContext.h>
+
+namespace kv_db_utils {
+
+namespace {
+
+class CudaExecutor {
+ public:
+  static folly::CPUThreadPoolExecutor* get_executor() {
+    static auto executor = std::make_unique<folly::CPUThreadPoolExecutor>(1);
+    return executor.get();
+  }
+};
+
+void host_async_threadpool_executor(void (*f)(void*), void* userData) {
+  CudaExecutor::get_executor()->add([f, userData]() { f(userData); });
+}
+
+}; // namespace
+
+void cuda_callback_func(
+    cudaStream_t /*stream*/,
+    cudaError_t status,
+    void* functor) {
+  AT_CUDA_CHECK(status);
+  auto* f = reinterpret_cast<std::function<void()>*>(functor);
+  AT_CUDA_CHECK(cudaGetLastError());
+  (*f)();
+  // delete f; // unfortunately, this invoke destructors that call CUDA
+  // API functions (e.g. caching host allocators issue cudaGetDevice(..),
+  // etc)
+  host_async_threadpool_executor(
+      [](void* functor) {
+        auto* fn = reinterpret_cast<std::function<void()>*>(functor);
+        delete fn;
+      },
+      functor);
+}
+
+}; // namespace kv_db_utils

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_utils.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_utils.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cuda_runtime.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+
+namespace kv_db_utils {
+
+/// @brief A callback function for `cudaStreamAddCallback`
+///
+/// A common callback function for `cudaStreamAddCallback`, i.e.,
+/// `cudaStreamCallback_t callback`. This function casts `functor`
+/// into a void function, invokes it and then delete it (the deletion
+/// occurs in another thread)
+///
+/// @param stream (`cudaStream_t`) CUDA stream that
+///               `cudaStreamAddCallback` operates on
+/// @param status (`cudaError_t`) CUDA status
+/// @param functor (`void*`) A functor that will be called
+///
+/// @return None
+void cuda_callback_func(cudaStream_t stream, cudaError_t status, void* functor);
+
+}; // namespace kv_db_utils

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -28,8 +28,60 @@ ssd_cache_populate_actions_cuda(
     int64_t prefetch_dist,
     Tensor lru_state);
 
+/// @ingroup embedding-ssd
+///
+/// @brief Similar to `torch.Tensor.index_put` but ignore `indices < 0`
+///
+/// `masked_index_put_cuda` only supports 2D input `values`. It puts
+/// `count` rows in `values` into `self` using the row indices that
+/// are >= 0 in `indices`.
+///
+/// ```python
+/// # Equivalent PyTorch Python code
+/// indices = indices[:count]
+/// filter_ = indices >= 0
+/// indices_ = indices[filter_]
+/// self[indices_] = values[filter_.nonzero().flatten()]
+/// ```
+///
+/// @param self The 2D output tensor (the tensor that is indexed)
+/// @param indices The 1D index tensor
+/// @param values The 2D input tensor
+/// @param count The tensor that contains the length of `indices` to
+/// process
+///
+/// @return The `self` tensor
 Tensor
 masked_index_put_cuda(Tensor self, Tensor indices, Tensor values, Tensor count);
+
+/// @ingroup embedding-ssd
+///
+/// @brief Similar to `torch.index_select` but ignore `indices < 0`
+///
+/// `masked_index_select_cuda` only supports 2D input `values`. It
+/// puts `count` rows that are specified in `indices` (where `indices`
+/// >= 0) from `values` into `self`
+///
+/// ```python
+/// # Equivalent PyTorch Python code
+/// indices = indices[:count]
+/// filter_ = indices >= 0
+/// indices_ = indices[filter_]
+/// self[filter_.nonzero().flatten()] = values[indices_]
+/// ```
+///
+/// @param self The 2D output tensor
+/// @param indices The 1D index tensor
+/// @param values The 2D input tensor (the tensor that is indexed)
+/// @param count The tensor that contains the length of `indices` to
+/// process
+///
+/// @return The `self` tensor
+Tensor masked_index_select_cuda(
+    Tensor self,
+    Tensor indices,
+    Tensor values,
+    Tensor count);
 
 Tensor masked_index_put_byte_cuda(
     Tensor self,
@@ -197,6 +249,14 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "    Tensor count"
       ") -> Tensor");
   DISPATCH_TO_CUDA("masked_index_put", masked_index_put_cuda);
+  m.def(
+      "masked_index_select("
+      "    Tensor self, "
+      "    Tensor indices, "
+      "    Tensor values, "
+      "    Tensor count"
+      ") -> Tensor");
+  DISPATCH_TO_CUDA("masked_index_select", masked_index_select_cuda);
   m.def(
       "ssd_cache_populate_actions("
       "    Tensor linear_indices, "

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <folly/executors/CPUThreadPoolExecutor.h>
 #include <torch/nn/init.h>
 #include <iostream>
 #include "kv_db_table_batched_embeddings.h"

--- a/fbgemm_gpu/test/tbe/ssd/ssd_utils_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_utils_test.py
@@ -1,0 +1,156 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+from typing import Callable
+
+import fbgemm_gpu.tbe.ssd  # noqa F401
+import hypothesis.strategies as st
+import torch
+from hypothesis import given, settings, Verbosity
+
+from .. import common  # noqa E402
+from ..common import open_source
+
+if open_source:
+    # pyre-ignore[21]
+    from test_utils import gpu_unavailable, running_on_github
+else:
+    from fbgemm_gpu.test.test_utils import gpu_unavailable, running_on_github
+
+
+MAX_EXAMPLES = 20
+
+
+@unittest.skipIf(*running_on_github)
+@unittest.skipIf(*gpu_unavailable)
+class SSDUtilsTest(unittest.TestCase):
+    def execute_masked_index_test(
+        self,
+        D: int,
+        max_index: int,
+        num_indices: int,
+        num_value_rows: int,
+        num_output_rows: int,
+        dtype: torch.dtype,
+        test_fn: Callable[
+            [torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor], torch.Tensor
+        ],
+        is_index_put: bool,
+    ) -> None:
+        """
+        A helper function that generates inputs/outputs, runs
+        torch.ops.fbgemm.masked_index_* against the PyTorch counterpart, and
+        compares the output results"""
+        device = "cuda"
+
+        # Number of columns must be multiple of 4 (embedding requirement)
+        D = D * 4
+
+        # Generate indices
+        indices = torch.randint(
+            low=0, high=max_index, size=(num_indices,), dtype=torch.long, device=device
+        )
+
+        # Compute/set unique indices (indices have to be unique to avoid race
+        # condition)
+        indices_unique = indices.unique()
+        count_val = indices_unique.numel()
+        indices[:count_val] = indices_unique
+
+        # Permute unique indices
+        rand_pos = torch.randperm(indices_unique.numel(), device=device)
+        indices[:count_val] = indices[rand_pos]
+
+        # Set some indices to -1
+        indices[rand_pos[: max(count_val // 2, 1)]] = -1
+
+        # Generate count tensor
+        count = torch.as_tensor([count_val], dtype=torch.int, device=device)
+
+        # Generate values
+        values = torch.rand(num_value_rows, D, dtype=dtype, device=device)
+
+        # Allocate output and output_ref
+        output = torch.zeros(num_output_rows, D, dtype=dtype, device=device)
+        output_ref = torch.zeros(num_output_rows, D, dtype=dtype, device=device)
+
+        # Run test
+        output = test_fn(output, indices, values, count)
+
+        # Run reference
+        indices = indices[:count_val]
+        filter_ = indices >= 0
+        indices_ = indices[filter_]
+        filter_locs = filter_.nonzero().flatten()
+        if is_index_put:
+            output_ref[indices_] = values[filter_locs]
+        else:
+            output_ref[filter_locs] = values[indices_]
+
+        # Compare results
+        assert torch.equal(output_ref, output)
+
+    # pyre-ignore [56]
+    @given(
+        num_indices=st.integers(min_value=10, max_value=100),
+        D=st.integers(min_value=2, max_value=256),
+        num_output_rows=st.integers(min_value=10, max_value=100),
+        dtype=st.sampled_from([torch.float, torch.half]),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    def test_masked_index_put(
+        self,
+        num_indices: int,
+        D: int,
+        num_output_rows: int,
+        dtype: torch.dtype,
+    ) -> None:
+        """
+        Test correctness of torch.ops.fbgemm.masked_index_put against PyTorch's
+        index_put
+        """
+        self.execute_masked_index_test(
+            D=D,
+            max_index=num_output_rows,
+            num_indices=num_indices,
+            num_value_rows=num_indices,
+            num_output_rows=num_output_rows,
+            dtype=dtype,
+            test_fn=torch.ops.fbgemm.masked_index_put,
+            is_index_put=True,
+        )
+
+    # pyre-ignore [56]
+    @given(
+        num_indices=st.integers(min_value=10, max_value=100),
+        D=st.integers(min_value=2, max_value=256),
+        num_value_rows=st.integers(min_value=10, max_value=100),
+        dtype=st.sampled_from([torch.float, torch.half]),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    def test_masked_index_select(
+        self,
+        num_indices: int,
+        D: int,
+        num_value_rows: int,
+        dtype: torch.dtype,
+    ) -> None:
+        """
+        Test correctness of torch.ops.fbgemm.masked_index_select aginst
+        PyTorch's index_select
+        """
+        self.execute_masked_index_test(
+            D=D,
+            max_index=num_value_rows,
+            num_indices=num_indices,
+            num_value_rows=num_value_rows,
+            num_output_rows=num_indices,
+            dtype=dtype,
+            test_fn=torch.ops.fbgemm.masked_index_select,
+            is_index_put=False,
+        )


### PR DESCRIPTION
Summary:
This diff adds `torch.ops.fbgemm.masked_index_select` (will be used in
subsequent diffs) and refactors `torch.ops.fbgemm.masked_index_put`.

- Add unit tests
- Add docstrings
- Add contiguous tensor checks

Differential Revision: D60362812
