### PR TITLE
Use guard_size_oblivious in tbe_input_combine_abstract fake kernel

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -254,7 +254,7 @@ def tbe_input_combine_abstract(
         torch._check(index.is_contiguous())
         torch._check(offset.is_contiguous())
         total_indices = total_indices + index.numel()
-        if weight.numel() > 0:
+        if guard_size_oblivious(weight.numel() > 0):
             torch._check(weight.dim() == 1)
             torch._check(weight.numel() == index.numel())
             torch._check(weight.is_contiguous())
@@ -291,7 +291,7 @@ def tbe_input_combine_with_length_abstract(
         torch._check(offset.is_contiguous())
         total_indices = total_indices + index.numel()
         total_offsets = total_offsets + offset.numel()
-        if weight.numel() > 0:
+        if guard_size_oblivious(weight.numel() > 0):
             torch._check(weight.dim() == 1)
             torch._check(weight.numel() == index.numel())
             torch._check(weight.is_contiguous())


### PR DESCRIPTION
Summary:
Encountered this error during export
```
torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode: Could not guard on data-dependent expression u5 > 0 (unhinted: u5 > 0).  (Size-like symbols: u5)

ATTENTION: guard_size_oblivious would fix the error, evaluating expression to True.
Maybe you need to add guard_size_oblivious to framework code, see doc below for more guidance.
```

Reviewed By: SherlockNoMad

Differential Revision:
D60260290

Privacy Context Container: L1125031
