### PR TITLE
Allow `block_bucketize_sparse_features` to return original idx

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -464,6 +464,8 @@ def block_bucketize_sparse_features_meta(
     weights: Optional[torch.Tensor] = None,
     batch_size_per_feature: Optional[torch.Tensor] = None,
     max_B: int = -1,
+    block_bucketize_pos: Optional[torch.Tensor] = None,
+    maybe_keep_orig_idx: bool = False,
 ) -> Tuple[
     torch.Tensor,
     torch.Tensor,

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -176,7 +176,8 @@ block_bucketize_sparse_features_cuda(
     const std::optional<at::Tensor>& weights,
     const std::optional<at::Tensor>& batch_size_per_feature,
     const int64_t max_batch_size,
-    const std::optional<std::vector<at::Tensor>>& block_bucketize_pos);
+    const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
+    const bool maybe_keep_orig_idx);
 
 std::tuple<
     at::Tensor,
@@ -196,7 +197,8 @@ block_bucketize_sparse_features_cpu(
     const std::optional<at::Tensor>& weights,
     const std::optional<at::Tensor>& batch_size_per_feature,
     const int64_t max_batch_size,
-    const std::optional<std::vector<at::Tensor>>& block_bucketize_pos);
+    const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
+    const bool maybe_keep_orig_idx);
 
 std::tuple<
     at::Tensor,
@@ -217,7 +219,8 @@ block_bucketize_sparse_features_inference_cuda(
     const std::optional<at::Tensor>& batch_size_per_feature,
     const int64_t max_batch_size,
     const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
-    const bool return_bucket_mapping);
+    const bool return_bucket_mapping,
+    const bool maybe_keep_orig_idx);
 
 ///@ingroup sparse-data-cuda
 at::Tensor populate_bucketized_permute_cuda(
@@ -245,7 +248,8 @@ block_bucketize_sparse_features_inference_cpu(
     const std::optional<at::Tensor>& batch_size_per_feature,
     const int64_t max_batch_size,
     const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
-    const bool return_bucket_mapping);
+    const bool return_bucket_mapping,
+    const bool maybe_keep_orig_idx);
 
 ///@ingroup sparse-data-cpu
 at::Tensor populate_bucketized_permute_cpu(


### PR DESCRIPTION
Summary: current operator will do `new_idx = orig_idx / world_size` even when we are in 0-collision hashing path. Add the capability of just returning the original idx in this case with a flag to control. default should not change existing logic.

Reviewed By: bixue2010

Differential Revision: D60526038
