### PR TITLE
Enable cache line locking support in SSD kernel

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -26,7 +26,9 @@ ssd_cache_populate_actions_cuda(
     int64_t prefetch_dist,
     Tensor lru_state,
     bool gather_cache_stats,
-    std::optional<Tensor> ssd_cache_stats);
+    std::optional<Tensor> ssd_cache_stats,
+    const bool lock_cache_line,
+    const c10::optional<Tensor>& lxu_cache_locking_counter);
 
 /// @ingroup embedding-ssd
 ///
@@ -298,7 +300,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "    int prefetch_dist, "
       "    Tensor lru_state, "
       "    bool gather_cache_stats=False, "
-      "    Tensor? ssd_cache_stats=None"
+      "    Tensor? ssd_cache_stats=None, "
+      "    bool lock_cache_line=False, "
+      "    Tensor? lxu_cache_locking_counter=None"
       ") -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)");
   DISPATCH_TO_CUDA(
       "ssd_cache_populate_actions", ssd_cache_populate_actions_cuda);


### PR DESCRIPTION
Summary:
This diff enables cache line locking in
`ssd_cache_actions_insert_kernel`.

We updated the cache slot cost computation (within a cache set) to
facilitate the cache line locking logic.  Before this diff, the cache
slots are ranked based on the their costs (i.e., their timestamps
which can be retrieved from the cache state).  The cache slots that
contain the lowest costs (lowest timestamps) will be evicted first.

However, when cache line locking is enabled, the cache slot that has
the lowest timestamp cannot be used if it is locked.  Therefore, we
assign unavailable cache slots (i.e., being locked or being occupied
by another index in the same batch) with the highest cost (that is the
current timestamp). The slot will not be evicted if its cost is the
same as the current timestamp.

Differential Revision: D60812956
