### PR TITLE
include fb only ops in private fbgemm build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # General
 .DS_Store
 *~
+.hypothesis/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -25,6 +25,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 option(FBGEMM_CPU_ONLY  "Build FBGEMM_GPU without GPU support" OFF)
 option(USE_ROCM         "Build FBGEMM_GPU for ROCm" OFF)
 option(FBGEMM_GENAI_ONLY  "Build FBGEMM_GPU with GEN AI only support" OFF)
+option(USE_FB_ONLY       "Build FBGEMM_GPU FB only operators" OFF)
 
 if((NOT FBGEMM_CPU_ONLY) AND
    ((EXISTS "/opt/rocm/") OR (EXISTS $ENV{ROCM_PATH})) AND

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -22,9 +22,9 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 # FBGEMM_GPU Build Options
 ################################################################################
 
-option(FBGEMM_CPU_ONLY  "Build FBGEMM_GPU without GPU support" OFF)
-option(USE_ROCM         "Build FBGEMM_GPU for ROCm" OFF)
-option(FBGEMM_GENAI_ONLY  "Build FBGEMM_GPU with GEN AI only support" OFF)
+option(FBGEMM_CPU_ONLY   "Build FBGEMM_GPU without GPU support" OFF)
+option(USE_ROCM          "Build FBGEMM_GPU for ROCm" OFF)
+option(FBGEMM_GENAI_ONLY "Build FBGEMM_GPU with GEN AI only support" OFF)
 option(USE_FB_ONLY       "Build FBGEMM_GPU FB only operators" OFF)
 
 if((NOT FBGEMM_CPU_ONLY) AND

--- a/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
@@ -58,6 +58,14 @@ set(experimental_gen_ai_cpp_source_files
     ${quantize_ops_sources}
     ${comm_ops_sources})
 
+# Set the source file for FB only CPP
+if(USE_FB_ONLY)
+  file(GLOB fb_only_ops_sources
+      fb/src/*/*.cu
+      fb/src/*/*.cpp)
+  list(APPEND experimental_gen_ai_cpp_source_files ${fb_only_ops_sources})
+endif()
+
 set_source_files_properties(${experimental_gen_ai_cpp_source_files}
     PROPERTIES INCLUDE_DIRECTORIES
     "${fbgemm_sources_include_directories}")

--- a/fbgemm_gpu/experimental/gen_ai/gen_ai/__init__.py
+++ b/fbgemm_gpu/experimental/gen_ai/gen_ai/__init__.py
@@ -27,6 +27,9 @@ if open_source:
     torch.ops.load_library(
         os.path.join(os.path.dirname(__file__), "fbgemm_gpu_experimental_gen_ai_py.so")
     )
+    torch.classes.load_library(
+        os.path.join(os.path.dirname(__file__), "fbgemm_gpu_experimental_gen_ai_py.so")
+    )
 else:
     torch.ops.load_library(
         "//deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai:attention_ops"

--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -77,6 +77,11 @@ class FbgemmGpuBuild:
             help="NCCL (libnccl.so.2) filepath. This is required for building certain targets.",
         )
         parser.add_argument(
+            "--use_fb_only",
+            action="store_true",
+            help="Build FB only operators.",
+        )
+        parser.add_argument(
             "--cxxprefix",
             type=str,
             default=None,
@@ -275,6 +280,10 @@ class FbgemmGpuBuild:
                     f"-DNCCL_LIBRARIES={self.args.nccl_lib_path}",
                 ]
             )
+
+        if self.args.use_fb_only:
+            print("[SETUP.PY] Building the FB ONLY operators of FBGEMM_GPU ...")
+            cmake_args.append("-DUSE_FB_ONLY=ON")
 
         if self.args.cxxprefix:
             print("[SETUP.PY] Setting CMake flags ...")


### PR DESCRIPTION
Summary:
On fb only source files, we have CMake files based on USE_FB_ONLY compiler flag:

```
# Set the source file for FB only CPP
if(USE_FB_ONLY)
  file(GLOB fb_only_ops_sources
      fb/src/*/*.cu
      fb/src/*/*.cpp)
  list(APPEND experimental_gen_ai_cpp_source_files ${fb_only_ops_sources})
endif()
```

Reviewed By: GD06

Differential Revision: D61100617
