### PR TITLE
Fix get_unique_indices_v2 registration

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/cache/split_embeddings_cache_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/cache/split_embeddings_cache_ops.py
@@ -10,20 +10,7 @@ from typing import Optional, Tuple, Union
 
 import torch
 
-lib = torch.library.Library("fbgemm", "FRAGMENT")
-lib.define(
-    """
-    get_unique_indices_v2(
-        Tensor linear_indices,
-        int max_indices,
-        bool compute_count=False,
-        bool compute_inverse_indices=False
-    ) -> (Tensor, Tensor, Tensor?, Tensor?)
-    """
-)
 
-
-@torch.library.impl(lib, "get_unique_indices_v2", "CUDA")
 def get_unique_indices_v2(
     linear_indices: torch.Tensor,
     max_indices: int,

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -15,7 +15,6 @@ import os
 import tempfile
 from math import log2
 from typing import Any, Callable, List, Optional, Tuple, Type
-
 import torch  # usort:skip
 
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers as invokers

--- a/fbgemm_gpu/test/tbe/common.py
+++ b/fbgemm_gpu/test/tbe/common.py
@@ -10,7 +10,6 @@
 from typing import List, Tuple
 
 import fbgemm_gpu
-import fbgemm_gpu.tbe.cache  # noqa: F401
 import numpy as np
 import torch
 from hypothesis import settings, Verbosity


### PR DESCRIPTION
Summary:
Properly register `get_unique_indices_v2` in `torch.ops.fbgemm` and
import it in SSD-TBE.
- Use `init` to define and register each op only once
- Check if an op is defined before defining and registering it to
  avoid duplicate declaration

Differential Revision: D61294287
