### PR TITLE
Add int4 to int4 CPU Sequence TBE kernel

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/quantize_ops_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/quantize_ops_utils.h
@@ -111,4 +111,23 @@ hfp8_to_float(uint8_t hfp8_val, int ebits, int exponent_bias) {
   return val_out.F;
 }
 
+// Get the number of bytes of a row in a tensor with quantized nbit integers
+inline int32_t nbit_elems_to_bytes(const at::Tensor& input) {
+  const auto input_sizes = input.sizes();
+  const int32_t ncols = input_sizes[1];
+  // at::kQUInt4x2 is the dtype for quantized int4 tensors and at::kQUInt2x4 is
+  // for quantized int2 tensors. QUIntMxN (M*N=8) means quantized M-bit integer
+  // with each byte holding N such elements.
+  // input_sizes[1] is the number of elements in each row, so we need to divide
+  // it by 2 or 4 for quint4x2 or quint2x4 respectively to get the number of
+  // bytes in each row.
+  if (input.dtype() == at::kQUInt2x4) {
+    return fbgemm_gpu::div_up(ncols, 4);
+  } else if (input.dtype() == at::kQUInt4x2) {
+    return fbgemm_gpu::div_up(ncols, 2);
+  } else {
+    return ncols;
+  }
+}
+
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/ops_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/ops_utils.h
@@ -56,6 +56,11 @@ __builtin_ia32_serialize(void) {
 #define DISPATCH_TO_CPU(name, function) \
   m.impl(name, torch::dispatch(c10::DispatchKey::CPU, TORCH_FN(function)))
 
+#define DISPATCH_TO_QUANTIZED_CPU(name, function) \
+  m.impl(                                         \
+      name,                                       \
+      torch::dispatch(c10::DispatchKey::QuantizedCPU, TORCH_FN(function)))
+
 #define DISPATCH_TO_META(name, function) \
   m.impl(name, torch::dispatch(c10::DispatchKey::Meta, TORCH_FN(function)))
 

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/types.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/types.h
@@ -15,4 +15,8 @@ using fint32 = union fint32 {
   float F;
 };
 
+inline int64_t div_up(int64_t val, int64_t unit) {
+  return (val + unit - 1) / unit;
+}
+
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/quantize_ops/quantize_ops_cpu.cpp
+++ b/fbgemm_gpu/src/quantize_ops/quantize_ops_cpu.cpp
@@ -123,7 +123,8 @@ Tensor _fusednbitrowwise_to_float_cpu(
 
   const auto input_sizes = input.sizes();
   const int64_t nrows = input_sizes[0];
-  const int32_t ncols = input_sizes[1];
+  // Here we want the number of bytes in a row
+  const int32_t ncols = nbit_elems_to_bytes(input);
   const int32_t num_elem_per_byte = 8 / bit_rate;
   const int32_t output_columns =
       (ncols - 2 * sizeof(at::Half)) * num_elem_per_byte;
@@ -145,6 +146,40 @@ Tensor _fusednbitrowwise_to_float_cpu(
 
   fbgemm::FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf<output_t>(
       bit_rate, input.data_ptr<uint8_t>(), nrows, ncols, output_data);
+
+  return output;
+}
+
+Tensor _fusednbitrowwise_sbfront_to_float_cpu(
+    const Tensor& input,
+    const int64_t bit_rate) {
+  TENSOR_ON_CPU(input);
+  TENSOR_NDIM_EQUALS(input, 2);
+
+  const auto input_sizes = input.sizes();
+  const int64_t nrows = input_sizes[0];
+  // Here we want the number of bytes in a row
+  const int32_t ncols = nbit_elems_to_bytes(input);
+  const int32_t num_elem_per_byte = 8 / bit_rate;
+  const int32_t output_columns =
+      (ncols - 2 * sizeof(at::Half)) * num_elem_per_byte;
+
+  Tensor output;
+  output = at::empty(
+      {nrows, output_columns}, // 4 = sizeof(float)
+      input.options().dtype(at::kFloat));
+
+  float* output_data = static_cast<float*>(
+      output.data_ptr()); // output.data_ptr<output_t>(); -> Yields
+                          // unresolved data_ptr symbol.
+
+  fbgemm::FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef<float>(
+      bit_rate,
+      input.data_ptr<uint8_t>(),
+      nrows,
+      ncols,
+      output_data,
+      /*scale_bias_last=*/false);
 
   return output;
 }
@@ -272,6 +307,24 @@ Tensor fusednbitrowwise_to_float_cpu(
     const Tensor& input,
     const int64_t bit_rate) {
   return _fusednbitrowwise_to_float_cpu<float>(input, bit_rate);
+}
+
+/// @ingroup quantize-data-cpu
+/// @brief Dequantize int4/int2 rows with scale and bias stored in the front
+/// into float32.
+/// @param input Tensor of int4/int2 rows with scale and bias stored in the
+/// front.
+/// @param bit_rate Bit rate of each element. Should be 4 or 2.
+/// @return Tensor of float32, holding dequantized numbers.
+///
+/// Dequantize int4/int2 rows with scale and bias stored in the front into
+/// float32. The input tensor should have torch.quint4x2 or torch.quint2x4 dtype
+/// and QuantizedCPU backend. This operator is only recommended for testing
+/// purpose because its kernel is reference implementation and not optimized.
+Tensor fusednbitrowwise_sbfront_to_float_cpu(
+    const Tensor& input,
+    const int64_t bit_rate) {
+  return _fusednbitrowwise_sbfront_to_float_cpu(input, bit_rate);
 }
 
 /// @ingroup quantize-data-cpu
@@ -467,6 +520,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "FusedNBitRowwiseQuantizedSBHalfToFloat(Tensor input, int bit_rate) -> Tensor");
   m.def(
+      "FusedNBitRowwiseQuantizedSBHalfFrontToFloat(Tensor input, int bit_rate) -> Tensor");
+  m.def(
       "FusedNBitRowwiseQuantizedSBHalfToHalf(Tensor input, int bit_rate) -> Tensor");
   m.def(
       "FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf(Tensor input, int bit_rate, int output_dtype=0) -> Tensor");
@@ -483,6 +538,12 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "quantize_mx_cuda(Tensor input, int scale_bits, int elem_ebits, int elem_mbits, float elem_max_norm, int mx_group_size, bool flush_fp32_subnorms=False, int rounding_mode=0) -> Tensor");
   m.def("dequantize_mx_cuda(Tensor input, int mx_group_size) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(fbgemm, QuantizedCPU, m) {
+  DISPATCH_TO_QUANTIZED_CPU(
+      "FusedNBitRowwiseQuantizedSBHalfFrontToFloat",
+      fbgemm_gpu::fusednbitrowwise_sbfront_to_float_cpu);
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {

--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -159,7 +159,7 @@ FBGEMM_API typename EmbeddingSpMDMKernelSignature<
     OffsetType,
     OutType>::Type
 GenerateEmbeddingSpMDMNBitWithStrides(
-    int bit_rate,
+    const int input_bit_rate,
     const std::int64_t block_size,
     bool has_weight,
     bool normalize_by_lengths,
@@ -169,7 +169,9 @@ GenerateEmbeddingSpMDMNBitWithStrides(
     std::int64_t output_stride = -1,
     std::int64_t input_stride = -1,
     bool scale_bias_last = true,
-    bool is_bf16_out = false);
+    const bool is_bf16_out = false,
+    const bool no_bag = false,
+    int output_bit_rate = -1);
 
 /**
  * @param output_stride If -1, output_stride is same as block_size

--- a/include/fbgemm/QuantUtils.h
+++ b/include/fbgemm/QuantUtils.h
@@ -366,7 +366,8 @@ FBGEMM_API void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef(
     const uint8_t* input,
     size_t input_rows,
     int input_columns,
-    OutputType* output);
+    OutputType* output,
+    bool scale_bias_last = true);
 
 /**
  * Same as Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf but unoptimized.

--- a/src/EmbeddingSpMDMAutovec.cc
+++ b/src/EmbeddingSpMDMAutovec.cc
@@ -273,7 +273,7 @@ INSTANTIATE_SPMDM_INDEX_T()
 
 template <typename IndexType, typename OffsetType, typename OutType>
 bool EmbeddingSpMDMNBit_autovec(
-    const int bit_rate,
+    const int input_bit_rate,
     const int64_t block_size,
     const int64_t output_size,
     const int64_t index_size,
@@ -289,9 +289,14 @@ bool EmbeddingSpMDMNBit_autovec(
     int64_t output_stride /*=-1*/,
     int64_t input_stride /*=-1*/,
     const bool scale_bias_last /*=true*/,
-    const bool is_bf16_out /*=false*/) {
-  assert((bit_rate == 2 || bit_rate == 4) && "bit_rate must be 2 or 4");
-  const int num_elem_per_byte = 8 / bit_rate;
+    const bool is_bf16_out /*=false*/,
+    const bool no_bag /*=false*/,
+    int output_bit_rate /*=-1*/) {
+  if (output_bit_rate == -1) {
+    output_bit_rate = 8 * sizeof(OutType);
+  }
+  nbit_embedding_sanity_check<OutType>(input_bit_rate, output_bit_rate, no_bag);
+  const int num_elem_per_byte = 8 / input_bit_rate;
 
   if (output_stride == -1) {
     output_stride = block_size;
@@ -333,6 +338,26 @@ bool EmbeddingSpMDMNBit_autovec(
             0);
       }
     }
+  }
+
+  if (no_bag) {
+    // We currently only support int4 to int4 for sequential TBE in this nbit
+    // kernel. Note that assert() will be ignored in release mode, so we check
+    // here to double check and also avoid "unused variable" warning
+    if (!(input_bit_rate == 4 && output_bit_rate == 4)) {
+      WARN_ONCE("no_bag is only supported for int4 to int4");
+      return false;
+    }
+    for (int64_t i = 0; i < output_size; ++i) {
+      const auto idx = indices[i];
+      if (idx < 0 || idx > data_size) {
+        return false;
+      }
+      const uint8_t* input_row = input + input_stride * idx;
+      memcpy(out, input_row, sizeof(uint8_t) * input_stride);
+      out += input_stride;
+    }
+    return true;
   }
 
   int64_t current = 0;
@@ -387,7 +412,7 @@ bool EmbeddingSpMDMNBit_autovec(
       const int64_t offset =
           input_stride * idx + (scale_bias_last ? 0 : scale_bias_offset);
       const uint8_t* input_row = input + offset;
-      if (bit_rate == 4) {
+      if (input_bit_rate == 4) {
         const size_t halfbufsz = (block_size + 1) / 2;
         for (size_t j = 0; j < halfbufsz; ++j) {
           float quantized1 = float(input_row[j] & 0xf);
@@ -395,7 +420,7 @@ bool EmbeddingSpMDMNBit_autovec(
           buf[j * 2] = std::fma(scale, quantized1, buf[j * 2] + bias);
           buf[j * 2 + 1] = std::fma(scale, quantized2, buf[j * 2 + 1] + bias);
         }
-      } else if (bit_rate == 2) {
+      } else if (input_bit_rate == 2) {
         size_t qbufsz = (block_size + 3) / 4;
         const uint8_t mask1 = 0x3;
         const uint8_t mask2 = 0xC;
@@ -445,7 +470,7 @@ bool EmbeddingSpMDMNBit_autovec(
 
 #define INSTANTIATE_SPMDM_BASE(INDEX_TYPE, OFFSET_TYPE, OUT_TYPE) \
   template FBGEMM_API bool EmbeddingSpMDMNBit_autovec(            \
-      const int bit_rate,                                         \
+      const int input_bit_rate,                                   \
       const int64_t block_size,                                   \
       const int64_t output_size,                                  \
       const int64_t index_size,                                   \
@@ -461,11 +486,14 @@ bool EmbeddingSpMDMNBit_autovec(
       int64_t output_stride,                                      \
       int64_t input_stride,                                       \
       const bool scale_bias_last,                                 \
-      const bool is_bf16_out);
+      const bool is_bf16_out,                                     \
+      const bool no_bag,                                          \
+      int output_bit_rate);
 
-#define INSTANTIATE_SPMDM_OUT_T(INDEX_TYPE, OFFSET_TYPE) \
-  INSTANTIATE_SPMDM_BASE(INDEX_TYPE, OFFSET_TYPE, float) \
-  INSTANTIATE_SPMDM_BASE(INDEX_TYPE, OFFSET_TYPE, float16)
+#define INSTANTIATE_SPMDM_OUT_T(INDEX_TYPE, OFFSET_TYPE)   \
+  INSTANTIATE_SPMDM_BASE(INDEX_TYPE, OFFSET_TYPE, float)   \
+  INSTANTIATE_SPMDM_BASE(INDEX_TYPE, OFFSET_TYPE, float16) \
+  INSTANTIATE_SPMDM_BASE(INDEX_TYPE, OFFSET_TYPE, uint8_t)
 
 #define INSTANTIATE_SPMDM_OFFSET_T(INDEX_TYPE) \
   INSTANTIATE_SPMDM_OUT_T(INDEX_TYPE, int32_t) \

--- a/src/EmbeddingSpMDMAutovec.h
+++ b/src/EmbeddingSpMDMAutovec.h
@@ -51,7 +51,7 @@ template <
     typename OffsetType = std::int32_t,
     typename OutType = float>
 FBGEMM_API bool EmbeddingSpMDMNBit_autovec(
-    const int bit_rate,
+    const int input_bit_rate,
     const std::int64_t block_size,
     const std::int64_t output_size,
     const std::int64_t index_size,
@@ -67,7 +67,9 @@ FBGEMM_API bool EmbeddingSpMDMNBit_autovec(
     std::int64_t output_stride = -1,
     std::int64_t input_stride = -1,
     const bool scale_bias_last = true,
-    const bool is_bf16_out = false);
+    const bool is_bf16_out = false,
+    const bool no_bag = false,
+    int output_bit_rate = -1);
 
 } // namespace fbgemm
 

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -1413,7 +1413,7 @@ bool EmbeddingSpMDM_ref(
 
 template <typename IndexType, typename OffsetType, typename OutType>
 bool EmbeddingSpMDMNBit_ref(
-    int bit_rate,
+    int input_bit_rate,
     const int64_t block_size,
     const int64_t output_size,
     const int64_t index_size,
@@ -1428,10 +1428,15 @@ bool EmbeddingSpMDMNBit_ref(
     bool use_offsets /*=true*/,
     int64_t output_stride /*=-1*/,
     int64_t input_stride /*=-1*/,
-    bool scale_bias_last /*=true*/,
-    bool is_bf16_out /*=false*/) {
-  assert((bit_rate == 2 || bit_rate == 4) && "bit_rate must be 2 or 4");
-  int num_elem_per_byte = 8 / bit_rate;
+    const bool scale_bias_last /*=true*/,
+    const bool is_bf16_out /*=false*/,
+    const bool no_bag /*=false*/,
+    int output_bit_rate /*=-1*/) {
+  if (output_bit_rate == -1) {
+    output_bit_rate = 8 * sizeof(OutType);
+  }
+  nbit_embedding_sanity_check<OutType>(input_bit_rate, output_bit_rate, no_bag);
+  int num_elem_per_byte = 8 / input_bit_rate;
 
   if (output_stride == -1) {
     output_stride = block_size;
@@ -1444,6 +1449,27 @@ bool EmbeddingSpMDMNBit_ref(
     input_stride = (block_size + num_elem_per_byte - 1) / num_elem_per_byte +
         scale_bias_offset;
   }
+
+  if (no_bag) {
+    // We currently only support int4 to int4 for sequential TBE in this nbit
+    // kernel. Note that assert() will be ignored in release mode, so we check
+    // here to double check and also avoid "unused variable" warning
+    if (!(input_bit_rate == 4 && output_bit_rate == 4)) {
+      WARN_ONCE("no_bag is only supported for int4 to int4");
+      return false;
+    }
+    for (int64_t i = 0; i < output_size; ++i) {
+      const auto idx = indices[i];
+      if (idx < 0 || idx > data_size) {
+        return false;
+      }
+      const uint8_t* input_row = input + input_stride * idx;
+      memcpy(out, input_row, sizeof(uint8_t) * input_stride);
+      out += input_stride;
+    }
+    return true;
+  }
+
   int64_t current = 0;
   vector<float> buf(block_size);
   for (int m = 0; m < output_size; ++m) {
@@ -1481,8 +1507,8 @@ bool EmbeddingSpMDMNBit_ref(
         uint8_t quantized = input
             [input_stride * idx + j / num_elem_per_byte +
              (scale_bias_last ? 0 : scale_bias_offset)];
-        quantized >>= (j % num_elem_per_byte) * bit_rate;
-        quantized &= (1 << bit_rate) - 1;
+        quantized >>= (j % num_elem_per_byte) * input_bit_rate;
+        quantized &= (1 << input_bit_rate) - 1;
 
         buf[j] = std::fma(scale, quantized, buf[j] + bias);
       }
@@ -2105,47 +2131,53 @@ INSTANTIATE_SPMDM_INDEX_T(std::uint8_t)
 #undef INSTANTIATE_SPMDM_OUT_T
 #undef INSTANTIATE_SPMDM_BASE
 
-#define INSTANTIATE_SPMDM_BASE(INDEX_TYPE, OFFSET_TYPE, OUT_TYPE) \
-  template FBGEMM_API bool EmbeddingSpMDMNBit_ref(                \
-      int bit_rate,                                               \
-      const int64_t block_size,                                   \
-      const int64_t output_size,                                  \
-      const int64_t index_size,                                   \
-      const int64_t data_size,                                    \
-      const uint8_t* input,                                       \
-      const INDEX_TYPE* indices,                                  \
-      const OFFSET_TYPE* offsets_or_lengths,                      \
-      const float* weights,                                       \
-      bool normalize_by_lengths,                                  \
-      OUT_TYPE* out,                                              \
-      bool is_weight_positional,                                  \
-      bool use_offsets,                                           \
-      int64_t output_stride,                                      \
-      int64_t input_stride,                                       \
-      bool scale_bias_last,                                       \
-      bool is_bf16_out);                                          \
-  template FBGEMM_API bool EmbeddingSpMDMFP8_ref(                 \
-      const int64_t block_size,                                   \
-      const int64_t output_size,                                  \
-      const int64_t index_size,                                   \
-      const int64_t data_size,                                    \
-      const uint8_t* input,                                       \
-      const INDEX_TYPE* indices,                                  \
-      const OFFSET_TYPE* offsets_or_lengths,                      \
-      const float* weights,                                       \
-      bool normalize_by_lengths,                                  \
-      OUT_TYPE* out,                                              \
-      bool is_weight_positional,                                  \
-      bool use_offsets,                                           \
-      int64_t output_stride,                                      \
-      int64_t input_stride,                                       \
-      int exponent_bits,                                          \
-      int exponent_bias,                                          \
+#define INSTANTIATE_SPMDM_NBIT_BASE(INDEX_TYPE, OFFSET_TYPE, OUT_TYPE) \
+  template FBGEMM_API bool EmbeddingSpMDMNBit_ref(                     \
+      const int input_bit_rate,                                        \
+      const int64_t block_size,                                        \
+      const int64_t output_size,                                       \
+      const int64_t index_size,                                        \
+      const int64_t data_size,                                         \
+      const uint8_t* input,                                            \
+      const INDEX_TYPE* indices,                                       \
+      const OFFSET_TYPE* offsets_or_lengths,                           \
+      const float* weights,                                            \
+      bool normalize_by_lengths,                                       \
+      OUT_TYPE* out,                                                   \
+      bool is_weight_positional,                                       \
+      bool use_offsets,                                                \
+      int64_t output_stride,                                           \
+      int64_t input_stride,                                            \
+      const bool scale_bias_last,                                      \
+      const bool is_bf16_out,                                          \
+      const bool no_bag,                                               \
+      int output_bit_rate);
+#define INSTANTIATE_SPMDM_FP8_BASE(INDEX_TYPE, OFFSET_TYPE, OUT_TYPE) \
+  template FBGEMM_API bool EmbeddingSpMDMFP8_ref(                     \
+      const int64_t block_size,                                       \
+      const int64_t output_size,                                      \
+      const int64_t index_size,                                       \
+      const int64_t data_size,                                        \
+      const uint8_t* input,                                           \
+      const INDEX_TYPE* indices,                                      \
+      const OFFSET_TYPE* offsets_or_lengths,                          \
+      const float* weights,                                           \
+      bool normalize_by_lengths,                                      \
+      OUT_TYPE* out,                                                  \
+      bool is_weight_positional,                                      \
+      bool use_offsets,                                               \
+      int64_t output_stride,                                          \
+      int64_t input_stride,                                           \
+      int exponent_bits,                                              \
+      int exponent_bias,                                              \
       bool is_bf16_out);
 
 #define INSTANTIATE_SPMDM_OUT_T(INDEX_TYPE, OFFSET_TYPE)        \
-  INSTANTIATE_SPMDM_BASE(INDEX_TYPE, OFFSET_TYPE, float)        \
-  INSTANTIATE_SPMDM_BASE(INDEX_TYPE, OFFSET_TYPE, float16)      \
+  INSTANTIATE_SPMDM_NBIT_BASE(INDEX_TYPE, OFFSET_TYPE, float)   \
+  INSTANTIATE_SPMDM_FP8_BASE(INDEX_TYPE, OFFSET_TYPE, float)    \
+  INSTANTIATE_SPMDM_NBIT_BASE(INDEX_TYPE, OFFSET_TYPE, float16) \
+  INSTANTIATE_SPMDM_FP8_BASE(INDEX_TYPE, OFFSET_TYPE, float16)  \
+  INSTANTIATE_SPMDM_NBIT_BASE(INDEX_TYPE, OFFSET_TYPE, uint8_t) \
   template FBGEMM_API bool EmbeddingSpMDMNBitRowWiseSparse_ref( \
       int bit_rate,                                             \
       const int64_t block_size,                                 \

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -246,7 +246,7 @@ template <
     typename OffsetType = std::int32_t,
     typename OutType = float>
 FBGEMM_API bool EmbeddingSpMDMNBit_ref(
-    int bit_rate,
+    const int input_bit_rate,
     const std::int64_t block_size,
     const std::int64_t output_size,
     const std::int64_t index_size,
@@ -261,8 +261,10 @@ FBGEMM_API bool EmbeddingSpMDMNBit_ref(
     bool use_offsets = true,
     std::int64_t output_stride = -1,
     std::int64_t input_stride = -1,
-    bool scale_bias_last = true,
-    bool is_bf16_out = false);
+    const bool scale_bias_last = true,
+    const bool is_bf16_out = false,
+    const bool no_bag = false,
+    int output_bit_rate = -1);
 
 template <
     typename IndexType = std::int64_t,


### PR DESCRIPTION
Summary: Add int4 to int4 sequence CPU TBE kernel. The core code only comprises a few lines (basically just `memcpy`, most of other lines of code are change of function declarations and template instantiations.

Differential Revision: D61305980
