### PR TITLE
Support original indices for FBGEMM block bucketization flag

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -465,7 +465,7 @@ def block_bucketize_sparse_features_meta(
     batch_size_per_feature: Optional[torch.Tensor] = None,
     max_B: int = -1,
     block_bucketize_pos: Optional[torch.Tensor] = None,
-    maybe_keep_orig_idx: bool = False,
+    keep_orig_idx: bool = False,
 ) -> Tuple[
     torch.Tensor,
     torch.Tensor,

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -177,7 +177,7 @@ block_bucketize_sparse_features_cuda(
     const std::optional<at::Tensor>& batch_size_per_feature,
     const int64_t max_batch_size,
     const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
-    const bool maybe_keep_orig_idx);
+    const bool keep_orig_idx);
 
 std::tuple<
     at::Tensor,
@@ -198,7 +198,7 @@ block_bucketize_sparse_features_cpu(
     const std::optional<at::Tensor>& batch_size_per_feature,
     const int64_t max_batch_size,
     const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
-    const bool maybe_keep_orig_idx);
+    const bool keep_orig_idx);
 
 std::tuple<
     at::Tensor,
@@ -220,7 +220,7 @@ block_bucketize_sparse_features_inference_cuda(
     const int64_t max_batch_size,
     const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
     const bool return_bucket_mapping,
-    const bool maybe_keep_orig_idx);
+    const bool keep_orig_idx);
 
 ///@ingroup sparse-data-cuda
 at::Tensor populate_bucketized_permute_cuda(
@@ -249,7 +249,7 @@ block_bucketize_sparse_features_inference_cpu(
     const int64_t max_batch_size,
     const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
     const bool return_bucket_mapping,
-    const bool maybe_keep_orig_idx);
+    const bool keep_orig_idx);
 
 ///@ingroup sparse-data-cpu
 at::Tensor populate_bucketized_permute_cpu(

--- a/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
@@ -290,7 +290,7 @@ void _block_bucketize_sparse_features_cpu_kernel(
     const std::optional<Tensor>& batch_size_per_feature,
     const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
     const std::optional<Tensor>& bucket_mapping,
-    const bool maybe_keep_orig_idx) {
+    const bool keep_orig_idx) {
   // allocate tensors and buffers
   const auto lengths_size = lengths.numel();
   const auto new_lengths_size = lengths_size * my_size;
@@ -408,15 +408,24 @@ void _block_bucketize_sparse_features_cpu_kernel(
         if (variable_bucket_sizes) {
           int64_t lb = lower_bounds[i];
           p = lb < my_size ? lb : idx % my_size;
-          new_idx = lb < my_size ? idx - bucketize_offset[lb]
-                                 : (maybe_keep_orig_idx ? idx : idx / my_size);
+          if (keep_orig_idx) {
+            new_idx = idx;
+          } else if (lb < my_size) {
+            new_idx = idx - bucketize_offset[lb];
+          } else {
+            new_idx = idx / my_size;
+          }
+        } else { // uniform bucket size
 
-        } else {
-          p = idx < static_cast<uindex_t>(blk_size * my_size) ? idx / blk_size
-                                                              : idx % my_size;
-          new_idx = idx < static_cast<uindex_t>(blk_size * my_size)
-              ? idx % blk_size
-              : (maybe_keep_orig_idx ? idx : idx / my_size);
+          const uindex_t ub = static_cast<uindex_t>(blk_size * my_size);
+          p = idx < ub ? idx / blk_size : idx % my_size;
+          if (keep_orig_idx) {
+            new_idx = idx;
+          } else if (idx < ub) {
+            new_idx = idx % blk_size;
+          } else {
+            new_idx = idx / my_size;
+          }
         }
         const uoffset_t pos = new_offsets_data[p * lengths_size + b_t];
         new_indices_data[pos] = new_idx;
@@ -1026,7 +1035,7 @@ _block_bucketize_sparse_features_cpu(
     const int64_t /* max_batch_size */, // Only used in GPU variant
     const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
     const bool return_bucket_mapping,
-    const bool maybe_keep_orig_idx) {
+    const bool keep_orig_idx) {
   const auto lengths_size = lengths.numel();
   const auto new_lengths_size = lengths_size * my_size;
   auto new_lengths = at::zeros({new_lengths_size}, lengths.options());
@@ -1074,7 +1083,7 @@ _block_bucketize_sparse_features_cpu(
                         batch_size_per_feature,                  \
                         block_bucketize_pos,                     \
                         bucket_mapping,                          \
-                        maybe_keep_orig_idx);                    \
+                        keep_orig_idx);                          \
                   });                                            \
             });                                                  \
       });
@@ -1109,7 +1118,7 @@ _block_bucketize_sparse_features_cpu(
                   batch_size_per_feature,                                   \
                   block_bucketize_pos,                                      \
                   bucket_mapping,                                           \
-                  maybe_keep_orig_idx);                                     \
+                  keep_orig_idx);                                           \
             });                                                             \
       });
   const auto lengths_sum = indices.numel();
@@ -1178,7 +1187,7 @@ block_bucketize_sparse_features_cpu(
     const std::optional<Tensor>& batch_size_per_feature,
     const int64_t /* max_batch_size */, // Only used in GPU variant
     const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
-    const bool maybe_keep_orig_idx) {
+    const bool keep_orig_idx) {
   Tensor new_lengths;
   Tensor new_indices;
   std::optional<Tensor> new_weights;
@@ -1203,7 +1212,7 @@ block_bucketize_sparse_features_cpu(
           -1, /* placeholder for max_batch_size */
           block_bucketize_pos,
           false,
-          maybe_keep_orig_idx);
+          keep_orig_idx);
   return {new_lengths, new_indices, new_weights, new_pos, unbucketize_permute};
 }
 
@@ -1226,7 +1235,7 @@ block_bucketize_sparse_features_inference_cpu(
     const int64_t /* max_batch_size */, // Only used in GPU variant
     const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
     const bool return_bucket_mapping,
-    const bool maybe_keep_orig_idx) {
+    const bool keep_orig_idx) {
   return _block_bucketize_sparse_features_cpu(
       lengths,
       indices,
@@ -1239,7 +1248,7 @@ block_bucketize_sparse_features_inference_cpu(
       -1, /* placeholder for max_batch_size */
       block_bucketize_pos,
       return_bucket_mapping,
-      maybe_keep_orig_idx);
+      keep_orig_idx);
 }
 
 // This function partitions sparse features
@@ -3071,9 +3080,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "populate_bucketized_permute(Tensor lengths, Tensor bucketized_lengths, Tensor bucket_mapping) -> Tensor");
   m.def(
-      "block_bucketize_sparse_features(Tensor lengths, Tensor indices, bool bucketize_pos, bool sequence, Tensor block_sizes, SymInt my_size, Tensor? weights=None, Tensor? batch_size_per_feature=None, SymInt max_B= -1, Tensor[]? block_bucketize_pos=None, bool maybe_keep_orig_idx=False) -> (Tensor, Tensor, Tensor?, Tensor?, Tensor?)");
+      "block_bucketize_sparse_features(Tensor lengths, Tensor indices, bool bucketize_pos, bool sequence, Tensor block_sizes, SymInt my_size, Tensor? weights=None, Tensor? batch_size_per_feature=None, SymInt max_B= -1, Tensor[]? block_bucketize_pos=None, bool keep_orig_idx=False) -> (Tensor, Tensor, Tensor?, Tensor?, Tensor?)");
   m.def(
-      "block_bucketize_sparse_features_inference(Tensor lengths, Tensor indices, bool bucketize_pos, bool sequence, Tensor block_sizes, SymInt my_size, Tensor? weights=None, Tensor? batch_size_per_feature=None, SymInt max_B= -1, Tensor[]? block_bucketize_pos=None, bool return_bucket_mapping=False, bool maybe_keep_orig_idx=False) -> (Tensor, Tensor, Tensor?, Tensor?, Tensor?, Tensor?)");
+      "block_bucketize_sparse_features_inference(Tensor lengths, Tensor indices, bool bucketize_pos, bool sequence, Tensor block_sizes, SymInt my_size, Tensor? weights=None, Tensor? batch_size_per_feature=None, SymInt max_B= -1, Tensor[]? block_bucketize_pos=None, bool return_bucket_mapping=False, bool keep_orig_idx=False) -> (Tensor, Tensor, Tensor?, Tensor?, Tensor?, Tensor?)");
   m.def(
       "bucketize_sparse_features(Tensor lengths, Tensor indices, bool bucketize_pos, SymInt my_size, Tensor? weights=None) -> (Tensor, Tensor, Tensor?, Tensor?)");
   m.def(

--- a/fbgemm_gpu/test/sparse/block_bucketize_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_test.py
@@ -79,60 +79,140 @@ class BlockBucketizeTest(unittest.TestCase):
         long_indices=st.booleans(),
         use_cpu=st.booleans() if gpu_available else st.just(True),
         keep_orig_idx=st.booleans(),
+        sequence=st.booleans(),
+        bucketize_pos=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_long_indices(
-        self, long_indices: bool, use_cpu: bool, keep_orig_idx: bool
+        self,
+        long_indices: bool,
+        use_cpu: bool,
+        keep_orig_idx: bool,
+        sequence: bool,
+        bucketize_pos: bool,
     ) -> None:
-        bucketize_pos = False
-        sequence = False
         index_type = torch.long if long_indices else torch.int
-
         # 3 GPUs
         my_size = 3
         block_sizes = torch.tensor([3, 4, 5], dtype=index_type)
 
         if not long_indices:
-            lengths = torch.tensor([0, 3, 2, 0, 1, 4], dtype=index_type)
-            indices = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=index_type)
-            new_lengths_ref = torch.tensor(
-                [0, 2, 0, 0, 0, 0, 0, 1, 2, 0, 1, 3, 0, 0, 0, 0, 0, 1], dtype=index_type
-            )
-            new_indices_ref = torch.tensor(
-                [1, 2, 0, 0, 1, 1, 2, 3, 4, 0], dtype=index_type
-            )
-        else:
-            lengths = torch.tensor([0, 3, 2, 0, 1, 4], dtype=index_type)
-            # Test long and negative indices: -8 will be casted to 18446644015555759292
-            indices = torch.tensor(
-                [1, 2, 3, 100061827127359, 5, 6, 7, -8, 100058153792324, 10],
-                dtype=index_type,
-            )
-            new_lengths_ref = torch.tensor(
-                [0, 2, 0, 0, 0, 0, 0, 1, 2, 0, 1, 1, 0, 0, 0, 0, 0, 3], dtype=index_type
-            )
+            # batch size 2, 3 features to 3 gpus
+            lengths = torch.tensor([0, 3, 2, 0, 1, 5], dtype=index_type)
+            indices = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0], dtype=index_type)
 
-            new_indices_ref = torch.tensor(
+            new_lengths_ref = torch.tensor(
                 [
+                    0,
+                    2,
+                    0,
+                    0,
+                    0,
+                    1,  # GPU 0, F0 = [0-3), F1 = [0-4), F2 = [0-5)
+                    0,
                     1,
                     2,
                     0,
-                    (
-                        100061827127359 if keep_orig_idx else 33353942375786
-                    ),  # 100061827127359/3 = 33353942375786
                     1,
-                    1,
-                    2,
-                    (
-                        -8 if keep_orig_idx else 6148914691236517202
-                    ),  # -8 cast to 18446644015555759292, 18446644015555759292 /3 = 6148914691236517202
-                    (
-                        100058153792324 if keep_orig_idx else 33352717930774
-                    ),  # 100058153792324/3 = 33352717930774
+                    3,  # GPU 1, F0 = [3-6), F1 = [4-8), F2 = [5-10)
                     0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    1,  # GPU 2, F0 = [6-9), F1 = [8-12), F2 = [10-15)
                 ],
                 dtype=index_type,
             )
+            if keep_orig_idx:
+                new_indices_ref = torch.tensor(
+                    [
+                        1,
+                        2,
+                        0,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        8,
+                        9,
+                        10,
+                    ],
+                    dtype=index_type,
+                )
+            else:
+                new_indices_ref = torch.tensor(
+                    [
+                        1,
+                        2,
+                        0,
+                        0,
+                        0,
+                        1,
+                        1,
+                        2,
+                        3,
+                        4,
+                        0,
+                    ],
+                    dtype=index_type,
+                )
+
+        else:
+            lengths = torch.tensor([0, 3, 2, 0, 1, 5], dtype=index_type)
+            # Test long and negative indices: -8 will be casted to 18446644015555759292
+            indices = torch.tensor(
+                [1, 2, 3, 100061827127359, 5, 6, 7, -8, 100058153792324, 10, 0],
+                dtype=index_type,
+            )
+            new_lengths_ref = torch.tensor(
+                [
+                    0,
+                    2,
+                    0,
+                    0,
+                    0,
+                    1,  # GPU 0, F0 = [0-3), F1 = [0-4), F2 = [0-5) + relevant outliers
+                    0,
+                    1,
+                    2,
+                    0,
+                    1,
+                    1,  # GPU 1, F0 = [3-6), F1 = [4-8), F2 = [5-10) + relevant outliers
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    3,  # GPU 2, F0 = [6-9), F1 = [8-12), F2 = [10-15) + relevant outliers
+                ],
+                dtype=index_type,
+            )
+
+            if keep_orig_idx:
+                new_indices_ref = torch.tensor(
+                    [1, 2, 0, 3, 100061827127359, 5, 6, 7, -8, 100058153792324, 10],
+                    dtype=index_type,
+                )
+
+            else:
+                new_indices_ref = torch.tensor(
+                    [
+                        1,
+                        2,
+                        0,
+                        0,
+                        33353942375786,  # 100061827127359/3 = 33353942375786
+                        1,
+                        1,
+                        2,
+                        6148914691236517202,  # -8 cast to 18446644015555759292, 18446644015555759292 /3 = 6148914691236517202
+                        33352717930774,  # 100058153792324/3 = 33352717930774
+                        0,
+                    ],
+                    dtype=index_type,
+                )
 
         (
             new_lengths_cpu,
@@ -148,7 +228,7 @@ class BlockBucketizeTest(unittest.TestCase):
             block_sizes,
             my_size,
             None,
-            maybe_keep_orig_idx=keep_orig_idx,
+            keep_orig_idx=keep_orig_idx,
         )
         torch.testing.assert_close(new_lengths_cpu, new_lengths_ref)
         torch.testing.assert_close(
@@ -172,11 +252,10 @@ class BlockBucketizeTest(unittest.TestCase):
                 block_sizes.cuda(),
                 my_size,
                 None,
-                maybe_keep_orig_idx=keep_orig_idx,
+                keep_orig_idx=keep_orig_idx,
             )
 
             torch.testing.assert_close(new_lengths_gpu.cpu(), new_lengths_ref)
-
             torch.testing.assert_close(new_lengths_gpu.cpu(), new_lengths_cpu)
 
             if not sequence:


### PR DESCRIPTION
Summary: For ZCH we want to operate in global id space; which requires expanding fbgemm block bucketization kernels to operate on global ids, not local.  Purposed 'maybe_keep_orig_idx' -> 'keep_orig_idx'

Differential Revision: D61102970
