### PR TITLE
[fbgemm_gpu] Remove Python 3.8

### DIFF
--- a/.github/scripts/fbgemm_gpu_build.bash
+++ b/.github/scripts/fbgemm_gpu_build.bash
@@ -301,7 +301,7 @@ __build_fbgemm_gpu_set_python_tag () {
   # shellcheck disable=SC2206
   local python_version_arr=(${python_version[1]//./ })
 
-  # Set the python tag (e.g. Python 3.12 -> py312)
+  # Set the python tag (e.g. Python 3.12 --> py312)
   export python_tag="py${python_version_arr[0]}${python_version_arr[1]}"
   echo "[BUILD] Extracted and set Python tag: ${python_tag}"
 }

--- a/.github/scripts/fbgemm_gpu_install.bash
+++ b/.github/scripts/fbgemm_gpu_install.bash
@@ -68,7 +68,9 @@ __install_check_subpackages () {
 
   echo "[INSTALL] Check for installation of Python sources ..."
   local subpackages=(
+    "fbgemm_gpu.config"
     "fbgemm_gpu.docs"
+    "fbgemm_gpu.quantize"
     "fbgemm_gpu.tbe.cache"
   )
 

--- a/.github/scripts/fbgemm_gpu_test.bash
+++ b/.github/scripts/fbgemm_gpu_test.bash
@@ -460,7 +460,6 @@ test_fbgemm_gpu_setup_and_pip_install () {
   }
 
   local python_versions=(
-    3.8
     3.9
     3.10
     3.11

--- a/.github/workflows/fbgemm_gpu_ci_cpu.yml
+++ b/.github/workflows/fbgemm_gpu_ci_cpu.yml
@@ -67,7 +67,7 @@ jobs:
           { arch: x86, instance: "linux.4xlarge" },
           { arch: arm, instance: "linux.arm64.2xlarge" },
         ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         compiler: [ "gcc", "clang" ]
 
     steps:
@@ -136,7 +136,7 @@ jobs:
           { arch: x86, instance: "linux.4xlarge", timeout: 20 },
           { arch: arm, instance: "linux.arm64.2xlarge", timeout: 30 },
         ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         compiler: [ "gcc", "clang" ]
     needs: build_artifact
 

--- a/.github/workflows/fbgemm_gpu_ci_cuda.yml
+++ b/.github/workflows/fbgemm_gpu_ci_cuda.yml
@@ -65,7 +65,7 @@ jobs:
         host-machine: [
           { arch: x86, instance: "linux.24xlarge" },
         ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         cuda-version: [ "11.8.0", "12.1.1", "12.4.1" ]
         compiler: [ "gcc", "clang" ]
 
@@ -147,7 +147,7 @@ jobs:
           # https://hud.pytorch.org/metrics
           # { arch: x86, instance: "linux.gcp.a100" },
         ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         cuda-version: [ "11.8.0", "12.1.1", "12.4.1" ]
         # Specify exactly ONE CUDA version for artifact publish
         cuda-version-publish: [ "12.1.1" ]

--- a/.github/workflows/fbgemm_gpu_ci_genai.yml
+++ b/.github/workflows/fbgemm_gpu_ci_genai.yml
@@ -65,7 +65,7 @@ jobs:
         host-machine: [
           { arch: x86, instance: "linux.24xlarge" },
         ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         cuda-version: [ "11.8.0", "12.1.1", "12.4.1" ]
         compiler: [ "gcc", "clang" ]
 
@@ -147,7 +147,7 @@ jobs:
           # https://hud.pytorch.org/metrics
           # { arch: x86, instance: "linux.gcp.a100" },
         ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         cuda-version: [ "11.8.0", "12.1.1", "12.4.1" ]
         # Specify exactly ONE CUDA version for artifact publish
         cuda-version-publish: [ "12.1.1" ]

--- a/.github/workflows/fbgemm_gpu_ci_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_ci_rocm.yml
@@ -64,7 +64,7 @@ jobs:
           { arch: x86, instance: "linux.24xlarge" },
         ]
         container-image: [ "ubuntu:20.04" ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         rocm-version: [ "6.0.2" ]
         compiler: [ "gcc", "clang" ]
 

--- a/.github/workflows/fbgemm_gpu_pip.yml
+++ b/.github/workflows/fbgemm_gpu_pip.yml
@@ -64,7 +64,7 @@ jobs:
           { arch: x86, instance: "linux.4xlarge", timeout: 20 },
           { arch: arm, instance: "linux.arm64.2xlarge", timeout: 30 },
         ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
     - name: Setup Build Container
@@ -120,7 +120,7 @@ jobs:
         host-machine: [
           { instance: "linux.g5.4xlarge.nvidia.gpu" },
         ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         cuda-version: [ "11.8.0", "12.1.1", "12.4.1" ]
 
     steps:

--- a/.github/workflows/fbgemm_gpu_release_cpu.yml
+++ b/.github/workflows/fbgemm_gpu_release_cpu.yml
@@ -64,7 +64,7 @@ jobs:
           { arch: x86, instance: "linux.4xlarge" },
           { arch: arm, instance: "linux.arm64.2xlarge" },
         ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
     - name: Setup Build Container
@@ -132,7 +132,7 @@ jobs:
           { arch: x86, instance: "linux.4xlarge", timeout: 20 },
           { arch: arm, instance: "linux.arm64.2xlarge", timeout: 30 },
         ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
     needs: build_artifact
 
     steps:

--- a/.github/workflows/fbgemm_gpu_release_cuda.yml
+++ b/.github/workflows/fbgemm_gpu_release_cuda.yml
@@ -69,7 +69,7 @@ jobs:
         host-machine: [
           { arch: x86, instance: "linux.24xlarge" },
         ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         cuda-version: [ "11.8.0", "12.1.1", "12.4.1" ]
 
     steps:
@@ -141,7 +141,7 @@ jobs:
         host-machine: [
           { arch: x86, instance: "linux.g5.4xlarge.nvidia.gpu" },
         ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         cuda-version: [ "11.8.0", "12.1.1", "12.4.1" ]
     needs: build_artifact
 

--- a/.github/workflows/fbgemm_gpu_release_genai.yml
+++ b/.github/workflows/fbgemm_gpu_release_genai.yml
@@ -69,7 +69,7 @@ jobs:
         host-machine: [
           { arch: x86, instance: "linux.24xlarge" },
         ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         cuda-version: [ "11.8.0", "12.1.1", "12.4.1" ]
 
     steps:
@@ -141,7 +141,7 @@ jobs:
         host-machine: [
           { arch: x86, instance: "linux.g5.4xlarge.nvidia.gpu" },
         ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         cuda-version: [ "11.8.0", "12.1.1", "12.4.1" ]
     needs: build_artifact
 

--- a/fbgemm_gpu/docs/src/fbgemm_gpu-development/BuildInstructions.rst
+++ b/fbgemm_gpu/docs/src/fbgemm_gpu-development/BuildInstructions.rst
@@ -499,7 +499,7 @@ Python platform name must first be properly set:
   export package_name=fbgemm_gpu_{cpu, cuda, rocm}
 
   # Set the Python version tag.  It should follow the convention `py<major><minor>`,
-  # e.g. Python 3.12 -> py312
+  # e.g. Python 3.12 --> py312
   export python_tag=py312
 
   # Determine the processor architecture

--- a/fbgemm_gpu/fbgemm_gpu/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/__init__.py
@@ -5,24 +5,27 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
 import os
 
 import torch
 
-try:
-    torch.ops.load_library(os.path.join(os.path.dirname(__file__), "fbgemm_gpu_py.so"))
-except Exception as error_ranking:
+
+def _load_library(filename: str) -> None:
+    """Load a shared library from the given filename."""
     try:
-        torch.ops.load_library(
-            os.path.join(
-                os.path.dirname(__file__),
-                "experimental/gen_ai/fbgemm_gpu_experimental_gen_ai_py.so",
-            )
+        torch.ops.load_library(os.path.join(os.path.dirname(__file__), filename))
+    except Exception as error:
+        logging.warning(
+            f"Could not the library '{filename}': {error}.  This may be expected depending on the FBGEMM_GPU variant."
         )
-    except Exception as error_gen_ai:
-        # When both ranking/gen_ai so files are not available, print the error logs
-        print(error_ranking)
-        print(error_gen_ai)
+
+
+for filename in [
+    "fbgemm_gpu_py.so",
+    "experimental/gen_ai/fbgemm_gpu_experimental_gen_ai_py.so",
+]:
+    _load_library(filename)
 
 # Since __init__.py is only used in OSS context, we define `open_source` here
 # and use its existence to determine whether or not we are in OSS context

--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -547,7 +547,7 @@ def main(argv: List[str]) -> None:
         ]
         + [
             f"Programming Language :: Python :: {x}"
-            for x in ["3", "3.8", "3.9", "3.10", "3.11", "3.12"]
+            for x in ["3", "3.9", "3.10", "3.11", "3.12"]
         ],
     )
 


### PR DESCRIPTION
- Deprecate Python 3.8 builds as Python 3.8 has been deprecated from PyTorch builds since 2024-07-31 (see https://github.com/pytorch/pytorch/issues/120718)

- Clarify module load errors in OSS