### PR TITLE
MX4 Row-Based Padding

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/quantize_comm.py
+++ b/fbgemm_gpu/fbgemm_gpu/quantize_comm.py
@@ -222,8 +222,12 @@ class QuantizedCommCodec:
             ncols = (ctx.row_dim + 3) // 4 * 4 + 2 * 4
             return nrows * ncols
         elif self._comm_precision == SparseType.MX4:
+            if ctx:
+                group_size = ctx.mx_group_size
+            else:
+                group_size = MX_GROUP_SIZE_DEFAULT
             assert (
-                input_len % 32 == 0
+                input_len % group_size == 0
             ), f"input_len {input_len} needs to be multiple of group_size 32"
             # quantized output size = half input size + number of groups (shared exp)
             ctx = none_throws(ctx)

--- a/fbgemm_gpu/fbgemm_gpu/quantize_utils.py
+++ b/fbgemm_gpu/fbgemm_gpu/quantize_utils.py
@@ -57,14 +57,12 @@ def fp32_to_mx4(
     """
     # Accelerated MX4 is only available on cuda, if input is on cpu, use python.
     # Operate on flattened input.
-    input = tensor.flatten()
-
     if rounding_mode is None:
         rounding_mode = RoundingMode.ceil
 
     if not tensor.is_cuda:
         return py_quantize_mx4(
-            input,
+            tensor,
             group_size,
             ebits=ebits,
             mbits=mbits,
@@ -74,7 +72,7 @@ def fp32_to_mx4(
 
     if use_triton:
         return quantize_mx4(
-            input,
+            tensor,
             group_size,
             ebits=ebits,
             mbits=mbits,
@@ -83,7 +81,7 @@ def fp32_to_mx4(
         )
     else:
         out = torch.ops.fbgemm.quantize_mx_cuda(
-            input,
+            tensor.flatten(),
             scale_bits=8,
             elem_ebits=2,
             elem_mbits=3,
@@ -114,14 +112,13 @@ def mx4_to_fp32(
     Return:
         output: FP32 tensor with total elements (M).
     """
-    flatten_tensor = tensor.view(-1)
     # Accelerated MX4 dequantize is only available on cuda, if input is on cpu, use python.
     if not tensor.is_cuda:
-        return py_dequantize_mx4(flatten_tensor, group_size, ebits=ebits, mbits=mbits)
+        return py_dequantize_mx4(tensor, group_size, ebits=ebits, mbits=mbits)
     if use_triton:
-        return dequantize_mx4(flatten_tensor, group_size, ebits=ebits, mbits=mbits)
+        return dequantize_mx4(tensor, group_size, ebits=ebits, mbits=mbits)
     else:
-        return torch.ops.fbgemm.dequantize_mx_cuda(flatten_tensor, group_size)
+        return torch.ops.fbgemm.dequantize_mx_cuda(tensor.flatten(), group_size)
 
 
 def fp32_to_fp16_with_clamp(tensor: torch.Tensor) -> torch.Tensor:

--- a/fbgemm_gpu/fbgemm_gpu/triton/quantize_ref.py
+++ b/fbgemm_gpu/fbgemm_gpu/triton/quantize_ref.py
@@ -108,11 +108,11 @@ def py_quantize_mx4(
     # If given an empty shape, return an empty tensor.
     if a.numel() == 0:
         return torch.empty(a.shape, device=a.device, dtype=torch.uint8)
-    # Make sure input has a supported shape.
-    if a.numel() % 32 != 0:
-        raise RuntimeError(
-            f"Input must have total elements that are a multiple of 32, but got {a.numel()} elements."
-        )
+    # Make sure input has a supported shape, if not pad each row.
+    if a.shape[-1] % group_size != 0:
+        pad = group_size - (a.shape[-1] % group_size)
+        a = torch.nn.functional.pad(a, (0, pad))
+
     # Keep track of original shape.
     orig_shape = a.shape
     # Prepare for grouping by subdiving the last axis.

--- a/fbgemm_gpu/test/quantize/comm_codec_test.py
+++ b/fbgemm_gpu/test/quantize/comm_codec_test.py
@@ -54,9 +54,9 @@ class QuantizedCommCodecTest(unittest.TestCase):
                 assume((col_size * row_size) % row_dim == 0)
             assume(col_size % 4 == 0)
 
-        # MX4 requires tensors with a multiple of 32 elements.
+        # For these tests assume that rows dont need padding.
         if comm_precision == SparseType.MX4:
-            assume((row_size * col_size) % 32 == 0)
+            assume((col_size) % 32 == 0)
 
         torch.manual_seed(rand_seed)
         shape = (row_size, col_size)

--- a/fbgemm_gpu/test/quantize/mx/common.py
+++ b/fbgemm_gpu/test/quantize/mx/common.py
@@ -437,18 +437,11 @@ def _shared_exponents(
         raise Exception("Unrecognized shared exponent selection method %s" % (method))
 
     if rounding_mode == "even":
-        SBITS, EBITS_F32, MBITS_F32 = 1, 8, 23
-        shared_exp = shared_exp.to(torch.float32).view(torch.int32)
-        val_to_add = 1 << (MBITS_F32 - 1)
-        mask = ((1 << (EBITS_F32 + SBITS)) - 1) << MBITS_F32
-        shared_exp = (shared_exp + val_to_add) & mask
-        shared_exp = shared_exp.view(torch.float32)
-
-        shared_exp = torch.floor(
-            torch.log2(
-                shared_exp + FP32_MIN_NORMAL * (shared_exp == 0).type(shared_exp.dtype)
-            )
-        )
+        MBITS_FP32 = 23
+        SBITS = 1
+        M_ROUND = (1 << (MBITS_FP32 - SBITS - 1)) - 1
+        shared_exp = shared_exp.view(dtype=torch.int32) + M_ROUND
+        return torch.floor(torch.log2(shared_exp.view(dtype=torch.float32)))
         """
         roundup_idx = (shared_exp_old != shared_exp).nonzero()
         if roundup_idx.numel() > 0:


### PR DESCRIPTION
Summary: Refactor MX4 quantization to support per row padding as efficiently as possible. We do this in a cool way where we now support loading 2D blocks to make sure each thread has enough to work on. Using this approach, we should be able to apply padding to each row for effectively no cost.

Differential Revision: D61447274
