### PR TITLE
Change rocm version and update documentation

### DIFF
--- a/.github/scripts/fbgemm_gpu_install.bash
+++ b/.github/scripts/fbgemm_gpu_install.bash
@@ -179,10 +179,10 @@ install_fbgemm_gpu_pip () {
   if [ "$fbgemm_gpu_variant_type_version" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME FBGEMM_GPU_CHANNEL[/VERSION] FBGEMM_GPU_VARIANT_TYPE[/VARIANT_VERSION]"
     echo "Example(s):"
-    echo "    ${FUNCNAME[0]} build_env 0.5.0 cpu                  # Install the CPU variant, specific version from release channel"
+    echo "    ${FUNCNAME[0]} build_env 0.8.0 cpu                  # Install the CPU variant, specific version from release channel"
     echo "    ${FUNCNAME[0]} build_env release cuda/12.4.1        # Install the CUDA variant, latest version from release channel"
-    echo "    ${FUNCNAME[0]} build_env test/0.8.0rc0 cuda/12.4.1  # Install the CUDA 12.4 variant, specific version from test channel"
-    echo "    ${FUNCNAME[0]} build_env nightly rocm/5.3           # Install the ROCM 5.3 variant, latest version from nightly channel"
+    echo "    ${FUNCNAME[0]} build_env test/0.8.0 cuda/12.4.1     # Install the CUDA 12.4 variant, specific version from test channel"
+    echo "    ${FUNCNAME[0]} build_env nightly rocm/6.1           # Install the ROCM 6.1 variant, latest version from nightly channel"
     return 1
   else
     echo "################################################################################"

--- a/.github/scripts/utils_pip.bash
+++ b/.github/scripts/utils_pip.bash
@@ -204,11 +204,11 @@ install_from_pytorch_pip () {
     echo "Example(s):"
     echo "    ${FUNCNAME[0]} build_env torch 1.11.0 cpu                       # Install the CPU variant, specific version from release channel"
     echo "    ${FUNCNAME[0]} build_env torch release cpu                      # Install the CPU variant, latest version from release channel"
-    echo "    ${FUNCNAME[0]} build_env fbgemm_gpu test/0.8.0rc0 cuda/12.1.0   # Install the CUDA 12.1 variant, specific version from test channel"
-    echo "    ${FUNCNAME[0]} build_env fbgemm_gpu nightly rocm/5.3            # Install the ROCM 5.3 variant, latest version from nightly channel"
+    echo "    ${FUNCNAME[0]} build_env fbgemm_gpu test/0.8.0 cuda/12.1.0      # Install the CUDA 12.1 variant, specific version from test channel"
+    echo "    ${FUNCNAME[0]} build_env fbgemm_gpu nightly rocm/6.1            # Install the ROCM 6.1 variant, latest version from nightly channel"
     echo "    ${FUNCNAME[0]} build_env pytorch_triton 1.11.0                  # Install specific version from release channel"
     echo "    ${FUNCNAME[0]} build_env pytorch_triton release                 # Install latest version from release channel"
-    echo "    ${FUNCNAME[0]} build_env pytorch_triton test/0.8.0rc0           # Install specific version from test channel"
+    echo "    ${FUNCNAME[0]} build_env pytorch_triton test/0.8.0              # Install specific version from test channel"
     echo "    ${FUNCNAME[0]} build_env pytorch_triton_rocm nightly            # Install latest version from nightly channel"
     return 1
   else
@@ -249,8 +249,8 @@ download_from_pytorch_pip () {
     echo "Example(s):"
     echo "    ${FUNCNAME[0]} build_env torch 1.11.0 cpu                       # Download the CPU variant, specific version from release channel"
     echo "    ${FUNCNAME[0]} build_env torch release cpu                      # Download the CPU variant, latest version from release channel"
-    echo "    ${FUNCNAME[0]} build_env fbgemm_gpu test/0.8.0rc0 cuda/12.1.0   # Download the CUDA 12.1 variant, specific version from test channel"
-    echo "    ${FUNCNAME[0]} build_env fbgemm_gpu nightly rocm/5.3            # Download the ROCM 5.3 variant, latest version from nightly channel"
+    echo "    ${FUNCNAME[0]} build_env fbgemm_gpu test/0.8.0 cuda/12.1.0      # Download the CUDA 12.1 variant, specific version from test channel"
+    echo "    ${FUNCNAME[0]} build_env fbgemm_gpu nightly rocm/6.1            # Download the ROCM 6.1 variant, latest version from nightly channel"
     return 1
   else
     echo "################################################################################"

--- a/.github/scripts/utils_pytorch.bash
+++ b/.github/scripts/utils_pytorch.bash
@@ -110,10 +110,10 @@ install_pytorch_pip () {
   if [ "$pytorch_variant_type_version" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME PYTORCH_CHANNEL[/VERSION] PYTORCH_VARIANT_TYPE[/VARIANT_VERSION]"
     echo "Example(s):"
-    echo "    ${FUNCNAME[0]} build_env test/2.1.0rc0 cpu  # Install the CPU variant for a specific version"
+    echo "    ${FUNCNAME[0]} build_env test/2.1.0 cpu     # Install the CPU variant for a specific version"
     echo "    ${FUNCNAME[0]} build_env release cpu        # Install the CPU variant, latest release version"
     echo "    ${FUNCNAME[0]} build_env test cuda/12.1.0   # Install the CUDA 12.1 variant, latest test version"
-    echo "    ${FUNCNAME[0]} build_env nightly rocm/5.3   # Install the ROCM 5.3 variant, latest nightly version"
+    echo "    ${FUNCNAME[0]} build_env nightly rocm/6.1   # Install the ROCM 6.1 variant, latest nightly version"
     return 1
   else
     echo "################################################################################"

--- a/.github/workflows/fbgemm_gpu_ci_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_ci_rocm.yml
@@ -65,7 +65,7 @@ jobs:
         ]
         container-image: [ "ubuntu:20.04" ]
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]
-        rocm-version: [ "6.0.2" ]
+        rocm-version: [ "6.1" ]
         compiler: [ "gcc", "clang" ]
 
     steps:
@@ -145,7 +145,7 @@ jobs:
         ]
         # ROCm machines are limited, so we only test a subset of Python versions
         python-version: [ "3.12" ]
-        rocm-version: [ "6.0.2" ]
+        rocm-version: [ "6.1" ]
         compiler: [ "gcc", "clang" ]
     needs: build_artifact
 

--- a/.github/workflows/fbgemm_gpu_pip.yml
+++ b/.github/workflows/fbgemm_gpu_pip.yml
@@ -186,7 +186,7 @@ jobs:
         ]
         # ROCm machines are limited, so we only test a subset of Python versions
         python-version: [ "3.11", "3.12" ]
-        rocm-version: [ "6.0.2" ]
+        rocm-version: [ "6.1" ]
 
     steps:
     - name: Setup Build Container

--- a/fbgemm_gpu/docs/src/fbgemm_gpu-development/BuildInstructions.rst
+++ b/fbgemm_gpu/docs/src/fbgemm_gpu-development/BuildInstructions.rst
@@ -177,8 +177,8 @@ desired ROCm version:
 
 .. code:: sh
 
-  # Run for ROCm 5.6.1
-  docker run -it --entrypoint "/bin/bash" rocm/rocm-terminal:5.6.1
+  # Run for ROCm 6.1.2
+  docker run -it --entrypoint "/bin/bash" rocm/rocm-terminal:6.1.2
 
 While the `full ROCm Docker image <https://hub.docker.com/r/rocm/dev-ubuntu-20.04>`__
 comes with all ROCm packages pre-installed, it results in a very large Docker


### PR DESCRIPTION
Summary:
Pytorch nightly no longer releases rocm 6.0.  {F1816076162}
The test workflow tests the old torch nightly version (since Aug 2) against latest fbgemm nightly, likely this is why the tests failed only on this workflow.

This diff updates rocm version on ROCm CI and test workflows to be 6.1 as well as documentation.

Differential Revision: D61576587
