### PR TITLE
move set_cache and set_async to background thread

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/runtime_monitor.py
+++ b/fbgemm_gpu/fbgemm_gpu/runtime_monitor.py
@@ -34,6 +34,13 @@ class TBEStatsReporter(abc.ABC):
         ...
 
     @abc.abstractmethod
+    def register_stats(self, stats_name: str, amplifier: int = 1) -> None:
+        """
+        Register stats_name in the whitelist of the reporter
+        """
+        ...
+
+    @abc.abstractmethod
     def report_duration(
         self,
         iteration_step: int,
@@ -68,6 +75,9 @@ class StdLogStatsReporter(TBEStatsReporter):
         assert report_interval > 0, "Report interval must be positive"
         self.report_interval = report_interval
 
+    def register_stats(self, stats_name: str, amplifier: int = 1) -> None:
+        return
+
     def should_report(self, iteration_step: int) -> bool:
         return iteration_step % self.report_interval == 0
 
@@ -95,6 +105,9 @@ class StdLogStatsReporter(TBEStatsReporter):
         logging.info(
             f"[Batch #{iteration_step}][TBE:{tbe_id}][Table:{embedding_id}] The event {event_name} used {data_bytes} bytes"
         )
+
+    def __repr__(self) -> str:
+        return "StdLogStatsReporter{ " f"report_interval={self.report_interval} " "}"
 
 
 @dataclass(frozen=True)

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -1748,16 +1748,19 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             self.step, stats_reporter.report_interval  # pyre-ignore
         )
 
-        if len(l2_cache_perf_stats) != 6:
-            logging.error("l2 perf stats should have 6 elements")
+        if len(l2_cache_perf_stats) != 9:
+            logging.error("l2 perf stats should have 9 elements")
             return
 
         num_cache_misses = l2_cache_perf_stats[0]
         num_lookups = l2_cache_perf_stats[1]
         get_total_duration = l2_cache_perf_stats[2]
         get_cache_lookup_total_duration = l2_cache_perf_stats[3]
-        get_weights_fillup_total_duration = l2_cache_perf_stats[4]
-        get_cache_update_total_duration = l2_cache_perf_stats[5]
+        get_cache_lookup_wait_filling_thread_duration = l2_cache_perf_stats[4]
+        get_weights_fillup_total_duration = l2_cache_perf_stats[5]
+        get_cache_update_total_duration = l2_cache_perf_stats[6]
+        get_tensor_copy_for_cache_update_duration = l2_cache_perf_stats[7]
+        set_tensor_copy_for_cache_update_duration = l2_cache_perf_stats[8]
 
         stats_reporter.report_data_amount(
             iteration_step=self.step,
@@ -1784,6 +1787,12 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         )
         stats_reporter.report_duration(
             iteration_step=self.step,
+            event_name="l2_cache.perf.get.cache_lookup_wait_filling_thread_duration_us",
+            duration_ms=get_cache_lookup_wait_filling_thread_duration,
+            time_unit="us",
+        )
+        stats_reporter.report_duration(
+            iteration_step=self.step,
             event_name="l2_cache.perf.get.weights_fillup_duration_us",
             duration_ms=get_weights_fillup_total_duration,
             time_unit="us",
@@ -1792,6 +1801,18 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             iteration_step=self.step,
             event_name="l2_cache.perf.get.cache_update_duration_us",
             duration_ms=get_cache_update_total_duration,
+            time_unit="us",
+        )
+        stats_reporter.report_duration(
+            iteration_step=self.step,
+            event_name="l2_cache.perf.get.tensor_copy_for_cache_update_duration_us",
+            duration_ms=get_tensor_copy_for_cache_update_duration,
+            time_unit="us",
+        )
+        stats_reporter.report_duration(
+            iteration_step=self.step,
+            event_name="l2_cache.perf.set.tensor_copy_for_cache_update_duration_us",
+            duration_ms=set_tensor_copy_for_cache_update_duration,
             time_unit="us",
         )
 

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
@@ -168,6 +168,16 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
       const int64_t timestep,
       const bool is_bwd = false);
 
+  /// export internally collected L2 performance metrics out
+  ///
+  /// @param step the training step that caller side wants to report the stats
+  /// @param interval report interval in terms of training step
+  ///
+  /// @return a list of doubles with predefined order for each metrics
+  std::vector<double> get_l2cache_perf(
+      const int64_t step,
+      const int64_t interval);
+
  private:
   /// Find non-negative embedding indices in <indices> and shard them into
   /// #cachelib_pools pieces to be lookedup in parallel
@@ -225,6 +235,18 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
   const int64_t num_shards_;
   const int64_t max_D_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> executor_tp_;
+  // perf stats
+  //   get perf
+  // cache miss rate(cmr) is avged on cmr per iteration
+  // instead of SUM(cache miss per interval) / SUM(lookups per interval)
+  std::atomic<int64_t> num_cache_misses_{0};
+  std::atomic<int64_t> num_lookups_{0};
+  std::atomic<int64_t> get_total_duration_{0};
+  std::atomic<int64_t> get_cache_lookup_total_duration_{0};
+  std::atomic<int64_t> get_weights_fillup_total_duration_{0};
+  std::atomic<int64_t> get_cache_update_total_duration_{0};
+
+  //    set perf
 }; // class EmbeddingKVDB
 
 } // namespace kv_db

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -286,10 +286,16 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
     return impl_->get_mem_usage();
   }
 
-  std::vector<double> get_io_duration(
+  std::vector<double> get_rocksdb_io_duration(
       const int64_t step,
       const int64_t interval) {
-    return impl_->get_io_duration(step, interval);
+    return impl_->get_rocksdb_io_duration(step, interval);
+  }
+
+  std::vector<double> get_l2cache_perf(
+      const int64_t step,
+      const int64_t interval) {
+    return impl_->get_l2cache_perf(step, interval);
   }
 
   void compact() {
@@ -365,7 +371,10 @@ static auto embedding_rocks_db_wrapper =
         .def("compact", &EmbeddingRocksDBWrapper::compact)
         .def("flush", &EmbeddingRocksDBWrapper::flush)
         .def("get_mem_usage", &EmbeddingRocksDBWrapper::get_mem_usage)
-        .def("get_io_duration", &EmbeddingRocksDBWrapper::get_io_duration)
+        .def(
+            "get_rocksdb_io_duration",
+            &EmbeddingRocksDBWrapper::get_rocksdb_io_duration)
+        .def("get_l2cache_perf", &EmbeddingRocksDBWrapper::get_l2cache_perf)
         .def("set", &EmbeddingRocksDBWrapper::set)
         .def("get", &EmbeddingRocksDBWrapper::get);
 

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -556,7 +556,7 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
     return mem_usages;
   }
 
-  std::vector<double> get_io_duration(
+  std::vector<double> get_rocksdb_io_duration(
       const int64_t step,
       const int64_t interval) {
     std::vector<double> ret;
@@ -565,9 +565,9 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
       auto read_dur = read_total_duration_.load();
       auto fwd_write_dur = fwd_write_total_duration_.load();
       auto bwd_write_dur = bwd_write_total_duration_.load();
-      ret.push_back(double(read_dur / interval));
-      ret.push_back(double(fwd_write_dur / interval));
-      ret.push_back(double(bwd_write_dur / interval));
+      ret.push_back(double(read_dur) / interval);
+      ret.push_back(double(fwd_write_dur) / interval);
+      ret.push_back(double(bwd_write_dur) / interval);
       read_total_duration_ = 0;
       fwd_write_total_duration_ = 0;
       bwd_write_total_duration_ = 0;

--- a/fbgemm_gpu/test/tbe/cache/cache_common.py
+++ b/fbgemm_gpu/test/tbe/cache/cache_common.py
@@ -54,6 +54,9 @@ class TestingStatsReporter(TBEStatsReporter):
     def should_report(self, iteration_step: int) -> bool:
         return (iteration_step - 1) % self.reporting_interval == 0
 
+    def register_stats(self, stats_name: str, amplifier: int = 1) -> None:
+        return
+
     def report_duration(
         self,
         iteration_step: int,


### PR DESCRIPTION
Summary:
set cache is inserting values into L2 cache
set_async it inserting values into SSD(rocksdb)

this 2 steps could be done asynchronously in the background thread wihtout blocking the read path.
Actually, it could potentially block the next read if it take close to each train iteration time.

Differential Revision: D61418016
