### PR TITLE
Optimize MX4 padding to minimize need for tuning

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/triton/common.py
+++ b/fbgemm_gpu/fbgemm_gpu/triton/common.py
@@ -8,6 +8,19 @@
 # pyre-unsafe
 from enum import IntEnum
 
+import torch
+
+
+# We keep LUTs persistent to minimize the number of device copies required.
+E2M1_LUT = torch.tensor(
+    [0, 0.5, 1, 1.5, 2, 3, 4, 6, -0, -0.5, -1, -1.5, -2, -3, -4, -6],
+    dtype=torch.float32,
+)
+E3M0_LUT = torch.tensor(
+    [0, 0.25, 0.5, 1, 2, 4, 8, 16, -0, -0.25, -0.5, -1, -2, -4, -8, -16],
+    dtype=torch.float32,
+)
+
 
 class RoundingMode(IntEnum):
     """Rounding options for quantization."""
@@ -36,37 +49,28 @@ def get_mx4_exp_bias(ebits):
         raise NotImplementedError(f"MX4 with ebits={ebits} not supported.")
 
 
-def get_mx4_lookup_table(ebits, mbits):
+def get_mx4_lookup_table(ebits, mbits, device):
     """Helper function to get the proper lookup table for specified mx4 format.
 
     Args:
         ebits: The number of exponent bits in quantized format.
         mbits: The number of mantissa bits in quantized format.
+        device: The device that the LUT should be copied to.
 
     Returns:
         The lookup table for the specified mx4 format.
     """
+    global E2M1_LUT, E3M0_LUT
     if ebits == 2 and mbits == 1:
-        return [0, 0.5, 1, 1.5, 2, 3, 4, 6, -0, -0.5, -1, -1.5, -2, -3, -4, -6]
+        # Update state of LUT to minimize copies.
+        if E2M1_LUT.device != device:
+            E2M1_LUT = E2M1_LUT.to(device)
+        return E2M1_LUT
     elif ebits == 3 and mbits == 0:
-        return [
-            0,
-            0.25,
-            0.5,
-            1,
-            2,
-            4,
-            8,
-            16,
-            -0,
-            -0.25,
-            -0.5,
-            -1,
-            -2,
-            -4,
-            -8,
-            -16,
-        ]
+        # Update state of LUT to minimize copies.
+        if E3M0_LUT.device != device:
+            E3M0_LUT = E3M0_LUT.to(device)
+        return E3M0_LUT
     else:
         raise NotImplementedError(
             f"MX4 with ebits={ebits} and mbits={mbits} not supported."

--- a/fbgemm_gpu/fbgemm_gpu/triton/quantize_ref.py
+++ b/fbgemm_gpu/fbgemm_gpu/triton/quantize_ref.py
@@ -271,11 +271,7 @@ def py_dequantize_mx4(
     a = torch.stack([low_mx4, high_mx4], dim=0).view(2, -1).t().contiguous()
 
     # Use a lookup table to convert
-    mx4_to_fp_values = torch.tensor(
-        get_mx4_lookup_table(ebits, mbits),
-        device=device,
-        dtype=torch.float,
-    )
+    mx4_to_fp_values = get_mx4_lookup_table(ebits, mbits, device)
     # Convert values into float32 equivalent via lookup.
     out = torch.index_select(mx4_to_fp_values, 0, a.to(torch.int32).view(-1))
 


### PR DESCRIPTION
Summary:
D61447274 introduced a very cool way of doing 2D indexing over input tensors during MX4 quantization, however, it is fairly reliant on tuning configurations to get good performance. It turns out the use case for MX4 has highly dynamic shapes, so we spend a huge amount of time tuning those shapes.

After deep meditation I realized there's a much simpler indexing scheme we can use, which is similar to the 1D accesses we used previously but adds shifts for padding.

With this approach we should get the best of both worlds; support for padding rows not divisible by group size and minimizing tuning while maintaining good performance.

Differential Revision: D61816830
