### PR TITLE
Add TBE annotation in Kineto trace

### DIFF
--- a/fbgemm_gpu/codegen/training/python/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/training/python/split_embedding_codegen_lookup_invoker.template
@@ -42,6 +42,18 @@ torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
 
 {%- endif %}
 
+{# This macro generates a code blob for to pack Tensor arguments into a TensorList 
+    as number of arguments for some optimizers exceed 64 #}
+{%- macro pack_tensors(arg) %}
+    {{ arg }}_list = [
+        {{ arg }}.host,
+        {{ arg }}.dev,
+        {{ arg }}.uvm,
+        {{ arg }}.placements,
+        {{ arg }}.offsets,
+    ]
+{%- endmacro %}
+
 {%- if is_prototype_optimizer %}
 # Decorate the prototype optimizers which may be deprecated in the future with jit.ignore to avoid
 # possible errors from torch.jit.script. 
@@ -51,28 +63,28 @@ torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
 def invoke(
     common_args: CommonArgs,
     optimizer_args: OptimizerArgs,
-    {%- if "momentum1_dev" in args.split_function_arg_names %}
+    {%- if "momentum1" in args_pt2.unified_pt2.split_function_arg_names %}
     momentum1: Momentum,
     {%- endif %}
-    {%- if "momentum2_dev" in args.split_function_arg_names %}
+    {%- if "momentum2" in args_pt2.unified_pt2.split_function_arg_names %}
     momentum2: Momentum,
     {%- endif %}
-    {%- if "prev_iter_dev" in args.split_function_arg_names %}
+    {%- if "prev_iter" in args_pt2.unified_pt2.split_function_arg_names %}
     prev_iter: Momentum,
     {%- endif %}
-    {%- if "row_counter_dev" in args.split_function_arg_names %}
+    {%- if "row_counter" in args_pt2.unified_pt2.split_function_arg_names %}
     row_counter: Momentum,
     {%- endif %}
-    {%- if "iter" in args.split_function_arg_names %}
+    {%- if "iter" in args_pt2.unified_pt2.split_function_arg_names %}
     iter: int,
     {%- endif %}
-    {%- if "max_counter" in args.split_function_arg_names %}
+    {%- if "max_counter" in args_pt2.unified_pt2.split_function_arg_names %}
     max_counter: float,
     {%- endif %}
-    {%- if "total_unique_indices" in args.split_function_arg_names %}
+    {%- if "total_unique_indices" in args_pt2.unified_pt2.split_function_arg_names %}
     total_unique_indices: int,
     {%- endif %}
-    {%- if "iter" not in args.split_function_arg_names %}
+    {%- if "iter" not in args_pt2.unified_pt2.split_function_arg_names %}
     iter: int = 0,
     {%- endif %}
     apply_global_weight_decay: bool = False,
@@ -92,166 +104,31 @@ def invoke(
         \033[0m"""
     )
     {%- endif %}
-
+    # host_weights is only used for CPU training
+    use_cpu = common_args.host_weights.numel() > 0
     vbe_metadata = common_args.vbe_metadata
-
+    {%- if has_cpu_support and not has_gpu_support %}
+    assert (use_cpu), "{{ optimizer }} has only CPU support. host_weights.numel() must be greater than 0."
+    {%- endif %}
+    offsets = common_args.offsets
     {%- if has_cpu_support and not ssd %}
-    if (common_args.host_weights.numel() > 0):
-        T = common_args.D_offsets.numel() - 1
-        vbe: bool = vbe_metadata.B_offsets is not None
-        if vbe:
-            # create offsets with fixed batch size max_B
-            # not efficient but for now we just need a functional implementation for CPU
-            max_B = vbe_metadata.max_B
-            offsets = torch.empty([T * max_B + 1], dtype=common_args.offsets.dtype, device=common_args.offsets.device)
-            for t in range(T):
-                B_offsets = vbe_metadata.B_offsets
-                assert isinstance(B_offsets, torch.Tensor)
-                begin = B_offsets[t]
-                end = B_offsets[t + 1]
-                offsets[t * max_B : t * max_B + end - begin] = common_args.offsets[begin : end]
-                offsets[t * max_B + end - begin : (t + 1) * max_B] = common_args.offsets[end]
-            offsets[-1] = common_args.offsets[-1]
-        else:
-            offsets = common_args.offsets
-        output = torch.ops.fbgemm.split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(
-            # common_args
-            host_weights=common_args.host_weights,
-            weights_placements=common_args.weights_placements,
-            weights_offsets=common_args.weights_offsets,
-            D_offsets=common_args.D_offsets,
-            total_D=common_args.total_D,
-            max_D=common_args.max_D,
-            hash_size_cumsum=common_args.hash_size_cumsum,
-            total_hash_size_bits=common_args.total_hash_size_bits,
-            indices=common_args.indices,
-            offsets=offsets,
-            pooling_mode=common_args.pooling_mode,
-            indice_weights=common_args.indice_weights,
-            feature_requires_grad=common_args.feature_requires_grad,
-            # optimizer_args
-            gradient_clipping = optimizer_args.gradient_clipping,
-            max_gradient=optimizer_args.max_gradient,
-            stochastic_rounding=optimizer_args.stochastic_rounding,
-            {%- if "learning_rate" in args.split_function_arg_names %}
-            learning_rate=optimizer_args.learning_rate,
-            {%- endif %}
-            {%- if "eps" in args.split_function_arg_names %}
-            eps=optimizer_args.eps,
-            {%- endif %}
-            {%- if "beta1" in args.split_function_arg_names %}
-            beta1=optimizer_args.beta1,
-            {%- endif %}
-            {%- if "beta2" in args.split_function_arg_names %}
-            beta2=optimizer_args.beta2,
-            {%- endif %}
-            {%- if "weight_decay" in args.split_function_arg_names %}
-            weight_decay=optimizer_args.weight_decay,
-            {%- endif %}
-            {%- if "weight_decay_mode" in args.split_function_arg_names %}
-            weight_decay_mode=optimizer_args.weight_decay_mode,
-            {%- endif %}
-            {%- if "eta" in args.split_function_arg_names %}
-            eta=optimizer_args.eta,
-            {%- endif %}
-            {%- if "momentum" in args.split_function_arg_names %}
-            momentum=optimizer_args.momentum,
-            {%- endif %}
-            {%- if "counter_halflife" in args.split_function_arg_names %}
-            counter_halflife=optimizer_args.counter_halflife,
-            {%- endif %}
-            {%- if "adjustment_iter" in args.split_function_arg_names %}
-            adjustment_iter=optimizer_args.adjustment_iter,
-            {%- endif %}
-            {%- if "adjustment_ub" in args.split_function_arg_names %}
-            adjustment_ub=optimizer_args.adjustment_ub,
-            {%- endif %}
-            {%- if "learning_rate_mode" in args.split_function_arg_names %}
-            learning_rate_mode=optimizer_args.learning_rate_mode,
-            {%- endif %}
-            {%- if "grad_sum_decay" in args.split_function_arg_names %}
-            grad_sum_decay=optimizer_args.grad_sum_decay,
-            {%- endif %}
-            {%- if "tail_id_threshold" in args.split_function_arg_names %}
-            tail_id_threshold=optimizer_args.tail_id_threshold,
-            {%- endif %}
-            {%- if "is_tail_id_thresh_ratio" in args.split_function_arg_names %}
-            is_tail_id_thresh_ratio=optimizer_args.is_tail_id_thresh_ratio,
-            {%- endif %}
-            {%- if "weight_norm_coefficient" in args.split_function_arg_names %}
-            weight_norm_coefficient=optimizer_args.weight_norm_coefficient,
-            {%- endif %}
-            {%- if "lower_bound" in args.split_function_arg_names %}
-            lower_bound=optimizer_args.lower_bound,
-            {%- endif %}
-            {%- if "regularization_mode" in args.split_function_arg_names %}
-            regularization_mode=optimizer_args.regularization_mode,
-            {%- endif %}
-            {%- if "max_norm" in args.split_function_arg_names %}
-            max_norm=optimizer_args.max_norm,
-            {%- endif %}
-            # momentum1
-            {%- if "momentum1_dev" in args.split_function_arg_names %}
-            momentum1_host=momentum1.host,
-            momentum1_offsets=momentum1.offsets,
-            momentum1_placements=momentum1.placements,
-            {%- endif %}
-            # momentum2
-            {%- if "momentum2_dev" in args.split_function_arg_names %}
-            momentum2_host=momentum2.host,
-            momentum2_offsets=momentum2.offsets,
-            momentum2_placements=momentum2.placements,
-            {%- endif %}
-            # prev_iter
-            {%- if "prev_iter_dev" in args.split_function_arg_names %}
-            prev_iter_host=prev_iter.host,
-            prev_iter_offsets=prev_iter.offsets,
-            prev_iter_placements=prev_iter.placements,
-            {%- endif %}
-            # row_counter
-            {%- if "row_counter_dev" in args.split_function_arg_names %}
-            row_counter_host=row_counter.host,
-            row_counter_offsets=row_counter.offsets,
-            row_counter_placements=row_counter.placements,
-            {%- endif %}
-            # iter
-            {%- if "iter" in args.split_function_arg_names %}
-            iter=iter,
-            {%- endif %}
-            # max counter
-            {%- if "max_counter" in args.split_function_arg_names %}
-            max_counter=max_counter,
-            {%- endif %}
-        )
-        if vbe:
-            output_new = torch.empty([vbe_metadata.output_size], dtype=output.dtype, device=output.device)
-            B_offsets_rank_per_feature = vbe_metadata.B_offsets_rank_per_feature
-            assert isinstance(B_offsets_rank_per_feature, torch.Tensor)
-            output_offsets_feature_rank = vbe_metadata.output_offsets_feature_rank
-            assert isinstance(output_offsets_feature_rank, torch.Tensor)
-            R = B_offsets_rank_per_feature.size(1) - 1
-            for r in range(R):
-                D_offset = 0
-                for t in range(T):
-                    o_begin = output_offsets_feature_rank[r * T + t].item()
-                    o_end = output_offsets_feature_rank[r * T + t + 1].item()
-                    D = common_args.D_offsets[t + 1].item() - common_args.D_offsets[t].item()
-                    b_begin = B_offsets_rank_per_feature[t][r].item()
-                    b_end = B_offsets_rank_per_feature[t][r + 1].item()
-                    assert o_end - o_begin == (b_end - b_begin) * D
-                    output_new[o_begin : o_end] = output[b_begin : b_end, D_offset : D_offset + D].flatten()
-                    D_offset += D
-            return output_new
-        else:
-            return output
-    {%- if not has_gpu_support %}
-    else:
-        assert False, "{{ optimizer }} has only CPU support. host_weights.numel() must be greater than 0."
+    # vbe for CPU training
+    T = common_args.D_offsets.numel() - 1
+    vbe: bool = vbe_metadata.B_offsets is not None
+    if use_cpu and vbe:
+        # create offsets with fixed batch size max_B
+        # not efficient but for now we just need a functional implementation for CPU
+        max_B = vbe_metadata.max_B
+        offsets = torch.empty([T * max_B + 1], dtype=common_args.offsets.dtype, device=common_args.offsets.device)
+        for t in range(T):
+            B_offsets = vbe_metadata.B_offsets
+            assert isinstance(B_offsets, torch.Tensor)
+            begin = B_offsets[t]
+            end = B_offsets[t + 1]
+            offsets[t * max_B : t * max_B + end - begin] = common_args.offsets[begin : end]
+            offsets[t * max_B + end - begin : (t + 1) * max_B] = common_args.offsets[end]
+        offsets[-1] = common_args.offsets[-1]
     {%- endif %}
-    {%- endif %}
-
-    {%- if has_gpu_support %}
-
     {%- if ssd %}
     ssd_tensors = []
     {%- for tensor in ssd_tensors %}
@@ -262,24 +139,41 @@ def invoke(
     ssd_tensors.append(common_args.ssd_tensors["{{ tensor }}"])
     {%- endfor %}
     {%- endif %}
-
-    return torch.ops.fbgemm.{{ mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function(
+    # pack weights
+    weights = [
+        common_args.host_weights,
+        common_args.dev_weights,
+        common_args.uvm_weights,
+        common_args.weights_placements,
+        common_args.weights_offsets,
+    ]
+    {%- if "momentum1" in args_pt2.unified_pt2.split_function_arg_names %}
+    {{ pack_tensors("momentum1") }}
+    {%- endif %}
+    {%- if "momentum2" in args_pt2.unified_pt2.split_function_arg_names %}
+    {{ pack_tensors("momentum2") }}
+    {%- endif %}
+    {%- if "prev_iter" in args_pt2.unified_pt2.split_function_arg_names %}
+    {{ pack_tensors("prev_iter") }}
+    {%- endif %}
+    {%- if "row_counter" in args_pt2.unified_pt2.split_function_arg_names %}
+    {{ pack_tensors("row_counter") }}
+    {%- endif %}
+    return torch.ops.fbgemm.{{ mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function_pt2(
         # common_args
         {%- if not dense %}
         placeholder_autograd_tensor=common_args.placeholder_autograd_tensor,
         {%- endif %}
-        dev_weights=common_args.dev_weights,
-        uvm_weights=common_args.uvm_weights,
+        # weights
+        weights=weights,
         lxu_cache_weights=common_args.lxu_cache_weights,
-        weights_placements=common_args.weights_placements,
-        weights_offsets=common_args.weights_offsets,
         D_offsets=common_args.D_offsets,
         total_D=common_args.total_D,
         max_D=common_args.max_D,
         hash_size_cumsum=common_args.hash_size_cumsum,
         total_hash_size_bits=common_args.total_hash_size_bits,
         indices=common_args.indices,
-        offsets=common_args.offsets,
+        offsets=offsets,
         pooling_mode=common_args.pooling_mode,
         indice_weights=common_args.indice_weights,
         feature_requires_grad=common_args.feature_requires_grad,
@@ -303,109 +197,97 @@ def invoke(
         max_gradient=optimizer_args.max_gradient,
         stochastic_rounding=optimizer_args.stochastic_rounding,
         {%- endif %} # if optimizer == none
-        {%- if "learning_rate" in args.split_function_arg_names %}
+        {%- if "learning_rate" in args_pt2.unified_pt2.split_function_arg_names %}
         learning_rate=optimizer_args.learning_rate,
         {%- endif %}
-        {%- if "eps" in args.split_function_arg_names %}
+        {%- if "eps" in args_pt2.unified_pt2.split_function_arg_names %}
         eps=optimizer_args.eps,
         {%- endif %}
-        {%- if "beta1" in args.split_function_arg_names %}
+        {%- if "beta1" in args_pt2.unified_pt2.split_function_arg_names %}
         beta1=optimizer_args.beta1,
         {%- endif %}
-        {%- if "beta2" in args.split_function_arg_names %}
+        {%- if "beta2" in args_pt2.unified_pt2.split_function_arg_names %}
         beta2=optimizer_args.beta2,
         {%- endif %}
-        {%- if "weight_decay" in args.split_function_arg_names %}
+        {%- if "weight_decay" in args_pt2.unified_pt2.split_function_arg_names %}
         weight_decay=optimizer_args.weight_decay,
         {%- endif %}
-        {%- if "weight_decay_mode" in args.split_function_arg_names %}
+        {%- if "weight_decay_mode" in args_pt2.unified_pt2.split_function_arg_names %}
         weight_decay_mode=optimizer_args.weight_decay_mode,
         {%- endif %}
-        {%- if "eta" in args.split_function_arg_names %}
+        {%- if "eta" in args_pt2.unified_pt2.split_function_arg_names %}
         eta=optimizer_args.eta,
         {%- endif %}
-        {%- if "momentum" in args.split_function_arg_names %}
+        {%- if "momentum" in args_pt2.unified_pt2.split_function_arg_names %}
         momentum=optimizer_args.momentum,
         {%- endif %}
-        {%- if "counter_halflife" in args.split_function_arg_names %}
+        {%- if "counter_halflife" in args_pt2.unified_pt2.split_function_arg_names %}
         counter_halflife=optimizer_args.counter_halflife,
         {%- endif %}
-        {%- if "adjustment_iter" in args.split_function_arg_names %}
+        {%- if "adjustment_iter" in args_pt2.unified_pt2.split_function_arg_names %}
         adjustment_iter=optimizer_args.adjustment_iter,
         {%- endif %}
-        {%- if "adjustment_ub" in args.split_function_arg_names %}
+        {%- if "adjustment_ub" in args_pt2.unified_pt2.split_function_arg_names %}
         adjustment_ub=optimizer_args.adjustment_ub,
         {%- endif %}
-        {%- if "learning_rate_mode" in args.split_function_arg_names %}
+        {%- if "learning_rate_mode" in args_pt2.unified_pt2.split_function_arg_names %}
         learning_rate_mode=optimizer_args.learning_rate_mode,
         {%- endif %}
-        {%- if "grad_sum_decay" in args.split_function_arg_names %}
+        {%- if "grad_sum_decay" in args_pt2.unified_pt2.split_function_arg_names %}
         grad_sum_decay=optimizer_args.grad_sum_decay,
         {%- endif %}
-        {%- if "tail_id_threshold" in args.split_function_arg_names %}
+        {%- if "tail_id_threshold" in args_pt2.unified_pt2.split_function_arg_names %}
         tail_id_threshold=optimizer_args.tail_id_threshold,
         {%- endif %}
-        {%- if "is_tail_id_thresh_ratio" in args.split_function_arg_names %}
+        {%- if "is_tail_id_thresh_ratio" in args_pt2.unified_pt2.split_function_arg_names %}
         is_tail_id_thresh_ratio=optimizer_args.is_tail_id_thresh_ratio,
         {%- endif %}
-        {%- if "weight_norm_coefficient" in args.split_function_arg_names %}
+        {%- if "weight_norm_coefficient" in args_pt2.unified_pt2.split_function_arg_names %}
         weight_norm_coefficient=optimizer_args.weight_norm_coefficient,
         {%- endif %}
-        {%- if "lower_bound" in args.split_function_arg_names %}
+        {%- if "lower_bound" in args_pt2.unified_pt2.split_function_arg_names %}
         lower_bound=optimizer_args.lower_bound,
         {%- endif %}
-        {%- if "regularization_mode" in args.split_function_arg_names %}
+        {%- if "regularization_mode" in args_pt2.unified_pt2.split_function_arg_names %}
         regularization_mode=optimizer_args.regularization_mode,
         {%- endif %}
-        {%- if "max_norm" in args.split_function_arg_names %}
+        {%- if "max_norm" in args_pt2.unified_pt2.split_function_arg_names %}
         max_norm=optimizer_args.max_norm,
         {%- endif %}
         # momentum1
-        {%- if "momentum1_dev" in args.split_function_arg_names %}
-        momentum1_dev=momentum1.dev,
-        momentum1_uvm=momentum1.uvm,
-        momentum1_offsets=momentum1.offsets,
-        momentum1_placements=momentum1.placements,
+        {%- if "momentum1" in args_pt2.unified_pt2.split_function_arg_names %}
+        momentum1 = momentum1_list,
         {%- endif %}
         # momentum2
-        {%- if "momentum2_dev" in args.split_function_arg_names %}
-        momentum2_dev=momentum2.dev,
-        momentum2_uvm=momentum2.uvm,
-        momentum2_offsets=momentum2.offsets,
-        momentum2_placements=momentum2.placements,
+        {%- if "momentum2" in args_pt2.unified_pt2.split_function_arg_names %}
+        momentum2=momentum2_list,
         {%- endif %}
         # prev_iter
-        {%- if "prev_iter_dev" in args.split_function_arg_names %}
-        prev_iter_dev=prev_iter.dev,
-        prev_iter_uvm=prev_iter.uvm,
-        prev_iter_offsets=prev_iter.offsets,
-        prev_iter_placements=prev_iter.placements,
+        {%- if "prev_iter" in args_pt2.unified_pt2.split_function_arg_names %}
+        prev_iter=prev_iter_list,
         {%- else %}
         {# // explicitly pass only prev_iter_dev for global weight decay #}
         prev_iter_dev=prev_iter_dev,
         {%- endif %}
         # row_counter
-        {%- if "row_counter_dev" in args.split_function_arg_names %}
-        row_counter_dev=row_counter.dev,
-        row_counter_uvm=row_counter.uvm,
-        row_counter_offsets=row_counter.offsets,
-        row_counter_placements=row_counter.placements,
+        {%- if "row_counter" in args_pt2.unified_pt2.split_function_arg_names %}
+        row_counter=row_counter_list,
         {%- endif %}
         # iter
         iter=iter,
         # max counter
-        {%- if "max_counter" in args.split_function_arg_names %}
+        {%- if "max_counter" in args_pt2.unified_pt2.split_function_arg_names %}
         max_counter=max_counter,
         {%- endif %}
         # total_unique_indices
-        {%- if "total_unique_indices" in args.split_function_arg_names %}
+        {%- if "total_unique_indices" in args_pt2.unified_pt2.split_function_arg_names %}
         total_unique_indices = total_unique_indices,
         {%- endif %}
         output_dtype=common_args.output_dtype,
-        is_experimental=common_args.is_experimental,
+        is_experimental_tbe=common_args.is_experimental,
         use_uniq_cache_locations_bwd=common_args.use_uniq_cache_locations_bwd,
         use_homogeneous_placements=common_args.use_homogeneous_placements,
         apply_global_weight_decay=apply_global_weight_decay,
         gwd_lower_bound=gwd_lower_bound,
     )
-    {%- endif %}
+

--- a/fbgemm_gpu/include/fbgemm_gpu/config/feature_gates.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/config/feature_gates.h
@@ -57,7 +57,8 @@ namespace fbgemm_gpu::config {
 /// For OSS: The environment variable will be evaluated as f"FBGEMM_{ENUM}"
 #define ENUMERATE_ALL_FEATURE_FLAGS \
   X(TBE_V2)                         \
-  X(TBE_ENSEMBLE_ROWWISE_ADAGRAD)
+  X(TBE_ENSEMBLE_ROWWISE_ADAGRAD)   \
+  X(TBE_ANNOTATE_KINETO_TRACE)
 // X(EXAMPLE_FEATURE_FLAG)
 
 /// @ingroup fbgemm-gpu-config

--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
@@ -82,8 +82,10 @@ common_strategy: Dict[str, Any] = {
     "use_cache": st.booleans(),
     "cache_algorithm": st.sampled_from(CacheAlgorithm),
     "use_cpu": use_cpu_strategy(),
-    "output_dtype": st.sampled_from(
-        [SparseType.FP32, SparseType.FP16, SparseType.BF16]
+    "output_dtype": (
+        st.sampled_from([SparseType.FP32, SparseType.FP16, SparseType.BF16])
+        if gpu_available
+        else st.sampled_from([SparseType.FP32])
     ),
 }
 
@@ -124,6 +126,7 @@ def execute_backward_adagrad(  # noqa C901
     #       so we have to limit (T * B * L * D)!
     assume(not use_cpu or T * B * L * D <= 1024)
     assume(not (use_cpu and weights_precision == SparseType.FP16))
+    assume(not (use_cpu and weights_precision == SparseType.BF16))
     # max_norm is only applicable to EXACT_ROWWISE_ADAGRAD GPU version
     assume(max_norm == 0.0 or (not use_cpu and row_wise))
 

--- a/fbgemm_gpu/test/tbe/training/failures_dict_fast.json
+++ b/fbgemm_gpu/test/tbe/training/failures_dict_fast.json
@@ -372,6 +372,14 @@
     "fbgemm::split_embedding_codegen_lookup_rowwise_adagrad_function": {},
     "fbgemm::split_embedding_codegen_lookup_rowwise_adagrad_function_cpu": {},
     "fbgemm::split_embedding_codegen_lookup_rowwise_adagrad_function_pt2": {
+      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmMEAN": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BackwardAdagradTest.test_schema__test_backward_adagrad_fp32_pmMEAN": {
+        "comment": "",
+        "status": "xfail"
+      },
       "ForwardTest.test_faketensor__test_forward_cpu_fp32": {
         "comment": "",
         "status": "xfail"


### PR DESCRIPTION
Summary:
This diff adds TBE annotation in a Kineto trace.  It can be enabled
using the `TBE_ANNOTATE_KINETO_TRACE` knob in JustKnob or setting
an environment variable `FBGEMM_TBE_ANNOTATE_KINETO_TRACE=1`.

Reviewed By: q10

Differential Revision: D61999485
