### PR TITLE
[fbgemm] Fix clang builds of FBGEMM

### DIFF
--- a/.github/scripts/fbgemm_build.bash
+++ b/.github/scripts/fbgemm_build.bash
@@ -41,8 +41,8 @@ __configure_fbgemm_build_cmake () {
     build_args+=(
       -DCMAKE_C_COMPILER="${cc_path}"
       -DCMAKE_CXX_COMPILER="${cxx_path}"
-      -DCMAKE_C_FLAGS=\"-fopenmp=libomp -stdlib=libc++ -I ${conda_prefix}/include\"
-      -DCMAKE_CXX_FLAGS=\"-fopenmp=libomp -stdlib=libc++ -I ${conda_prefix}/include\"
+      -DCMAKE_C_FLAGS=\"-fopenmp=libomp -I ${conda_prefix}/include\"
+      -DCMAKE_CXX_FLAGS=\"-fopenmp=libomp -I ${conda_prefix}/include\"
     )
   fi
 


### PR DESCRIPTION
- Set to use libstdc++ instead of libc++ when building FBGEMM