### PR TITLE
Increase Nova timeout to 180 mins

### DIFF
--- a/.github/workflows/build_wheels_linux_x86.yml
+++ b/.github/workflows/build_wheels_linux_x86.yml
@@ -49,3 +49,4 @@ jobs:
       test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       trigger-event: ${{ github.event_name }}
+      timeout: 180


### PR DESCRIPTION
Summary:
FBGEMM build for cuda 12.1 on Nova has been facing time-out error and unable to release 12.1 binaries since it takes longer than 120 minutes. For example, https://github.com/pytorch/FBGEMM/actions/runs/10772363019/job/29869849673.

Huy from Dev infra has helped make time-out as a configurable parameter https://github.com/pytorch/test-infra/pull/5631.

This diff extends time out to 180 mins until we find a good solution to reduce build time.

Differential Revision: D62415584
