### PR TITLE
add PT2 support for permute_multi_embedding

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/permute_multi_embedding_function.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/permute_multi_embedding_function.h
@@ -36,7 +36,7 @@ class PermuteMultiEmbeddingOp
       const Tensor& permutes,
       const Tensor& in_shapes,
       const Tensor& out_shapes,
-      const std::vector<int64_t>& out_lengths);
+      const c10::SymIntArrayRef out_lengths);
 
   static variable_list backward(
       AutogradContext* ctx,
@@ -48,7 +48,7 @@ std::vector<Tensor> permute_multi_embedding_function_cpu(
     const Tensor& permutes,
     const Tensor& in_shapes,
     const Tensor& out_shapes,
-    const std::vector<int64_t>& out_lengths,
+    const c10::SymIntArrayRef out_lengths,
     const bool& reverse_permute);
 
 std::vector<Tensor> permute_multi_embedding_function_meta(
@@ -56,7 +56,7 @@ std::vector<Tensor> permute_multi_embedding_function_meta(
     const Tensor& permutes,
     const Tensor& in_shapes,
     const Tensor& out_shapes,
-    const std::vector<int64_t>& out_lengths,
+    const c10::SymIntArrayRef out_lengths,
     const bool& reverse_permute);
 
 std::vector<Tensor> permute_multi_embedding_function_gpu(
@@ -64,7 +64,7 @@ std::vector<Tensor> permute_multi_embedding_function_gpu(
     const Tensor& permutes,
     const Tensor& in_shapes,
     const Tensor& out_shapes,
-    const std::vector<int64_t>& out_lengths,
+    const c10::SymIntArrayRef out_lengths,
     const bool& reverse_permute);
 
 std::tuple<std::vector<int32_t>, std::vector<int32_t>, std::vector<int32_t>>

--- a/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_function.cpp
+++ b/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_function.cpp
@@ -22,15 +22,15 @@ variable_list PermuteMultiEmbeddingOp::forward(
     const Tensor& permutes,
     const Tensor& in_shapes,
     const Tensor& out_shapes,
-    const std::vector<int64_t>& out_lengths) {
+    const c10::SymIntArrayRef out_lengths) {
   ctx->saved_data["permutes"] = permutes;
   ctx->saved_data["in_shapes"] = in_shapes;
   ctx->saved_data["out_shapes"] = out_shapes;
 
-  std::vector<int64_t> in_lengths;
+  std::vector<at::SymInt> in_lengths;
   in_lengths.reserve(pooled_embs.size());
   for (auto i : c10::irange(pooled_embs.size())) {
-    in_lengths.push_back(pooled_embs[i].size(1));
+    in_lengths.push_back(pooled_embs[i].sym_size(1));
   }
   ctx->saved_data["in_lengths"] = in_lengths;
 
@@ -54,7 +54,7 @@ variable_list PermuteMultiEmbeddingOp::backward(
   const auto permutes = ctx->saved_data["permutes"].toTensor();
   const auto in_shapes = ctx->saved_data["in_shapes"].toTensor();
   const auto out_shapes = ctx->saved_data["out_shapes"].toTensor();
-  const auto in_lengths = ctx->saved_data["in_lengths"].toIntVector();
+  const auto in_lengths = ctx->saved_data["in_lengths"].toSymIntVector();
 
   /*
     select the correct dispatched (cpu/gpu) backward function

--- a/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
@@ -222,7 +222,7 @@ std::vector<Tensor> permute_multi_embedding_function_gpu(
     const Tensor& permutes,
     const Tensor& in_shapes,
     const Tensor& out_shapes,
-    const std::vector<int64_t>& out_lengths,
+    const c10::SymIntArrayRef out_lengths,
     const bool& reverse_permute) {
   // we assume that there's at least one input tensor in the list
   // it should be enforced from the caller side who has the knowledge.
@@ -251,9 +251,10 @@ std::vector<Tensor> permute_multi_embedding_function_gpu(
   // initiate output tensors
   std::vector<Tensor> outputs;
   outputs.reserve(num_of_output_tensors);
+  const auto lengths = reinterpret_cast<const int64_t*>(out_lengths.data());
   for (int32_t i = 0; i < num_of_output_tensors; i++) {
     Tensor output =
-        at::empty({batch_size, out_lengths[i]}, pooled_embs[0].options());
+        at::empty({batch_size, lengths[i]}, pooled_embs[0].options());
     outputs.push_back(output);
   }
   auto device = pooled_embs[0].device();
@@ -301,7 +302,7 @@ std::vector<Tensor> permute_multi_embedding_gpu(
     const Tensor& permutes,
     const Tensor& in_shapes,
     const Tensor& out_shapes,
-    const std::vector<int64_t>& out_lengths) {
+    const c10::SymIntArrayRef out_lengths) {
   return permute_multi_embedding_function_gpu(
       pooled_embs, permutes, in_shapes, out_shapes, out_lengths, false);
 }
@@ -313,8 +314,14 @@ std::vector<Tensor> regroup_keyed_tensor_gpu(
     const std::vector<std::vector<std::string>>& groups) {
   auto [permutes, in_shapes, out_shapes, out_lengths] =
       kt_regroup_arguments_gpu(pooled_embs[0], keys, lengths, groups);
+  std::vector<at::SymInt> out;
+  std::transform(
+      out_lengths.begin(),
+      out_lengths.end(),
+      std::back_inserter(out),
+      [](const int32_t v) { return c10::SymInt(v); });
   return permute_multi_embedding_function_gpu(
-      pooled_embs, permutes, in_shapes, out_shapes, out_lengths, false);
+      pooled_embs, permutes, in_shapes, out_shapes, out, false);
 }
 
 } // namespace fbgemm_gpu


### PR DESCRIPTION
Summary:
It looks like test_pt2 already passed. not sure why the test can't capture the PT2 incompatibility in the op.

graph breaks: P1557581728
https://interncache-all.fbcdn.net/manifold/tlparse_reports/tree/logs/.tmphgx6wM/rank_0/failures_and_restarts.html

Differential Revision: D62226292
