### PR TITLE
add metrics for ssd logging

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/cachelib_cache.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/cachelib_cache.h
@@ -74,6 +74,14 @@ class CacheLibCache {
   /// deterministic mapping from a embedding index to a specific pool id
   facebook::cachelib::PoolId get_pool_id(int64_t key);
 
+  /// update the LRU queue in cachelib, this is detached from cache->find()
+  /// so that we could boost up the lookup perf without worrying about LRU queue
+  /// contention
+  ///
+  /// @param read_handles the read handles that record what cache item has been
+  /// accessed
+  void batchMarkUseful(const std::vector<Cache::ReadHandle>& read_handles);
+
   /// Add an embedding index and embeddings into cachelib
   ///
   /// @param key embedding index to insert

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/cachelib_cache.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/cachelib_cache.h
@@ -128,8 +128,9 @@ class CacheLibCache {
       const at::Tensor& count);
 
   /// reset slot pointer that points to the next available slot in the eviction
-  /// tensors
-  void reset_eviction_states();
+  /// tensors and returns number of slots filled
+  /// @return number evictions
+  int64_t reset_eviction_states();
 
   /// get the filled indices and weights tensors from L2 eviction, could be all
   /// invalid if no eviction happened

--- a/fbgemm_gpu/src/ps_split_embeddings_cache/ps_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ps_split_embeddings_cache/ps_table_batched_embeddings.h
@@ -48,7 +48,8 @@ class EmbeddingParameterServer : public kv_db::EmbeddingKVDB {
       const at::Tensor& indices,
       const at::Tensor& weights,
       const at::Tensor& count,
-      const bool is_bwd = false) override {
+      const kv_db::RocksdbWriteMode w_mode =
+          kv_db::RocksdbWriteMode::FWD_ROCKSDB_READ) override {
     RECORD_USER_SCOPE("EmbeddingParameterServer::set");
     co_await tps_client_->set(indices, weights, count.item().toLong());
   }

--- a/fbgemm_gpu/src/split_embeddings_cache/cachelib_cache.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/cachelib_cache.cpp
@@ -209,8 +209,10 @@ void CacheLibCache::init_tensor_for_l2_eviction(
       at::TensorOptions().device(weights.device()).dtype(weights.dtype())));
 }
 
-void CacheLibCache::reset_eviction_states() {
-  eviction_row_id = 0;
+int64_t CacheLibCache::reset_eviction_states() {
+  int64_t reset_val = 0;
+  auto num_eviction = eviction_row_id.exchange(reset_val);
+  return num_eviction;
 }
 
 folly::Optional<std::pair<at::Tensor, at::Tensor>>

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -32,7 +32,8 @@ inline int64_t get_maybe_uvm_scalar(const at::Tensor& tensor) {
 QueueItem tensor_copy(
     const at::Tensor& indices,
     const at::Tensor& weights,
-    const at::Tensor& count) {
+    const at::Tensor& count,
+    kv_db::RocksdbWriteMode mode) {
   auto num_sets = get_maybe_uvm_scalar(count);
   auto new_indices = at::empty(
       num_sets, at::TensorOptions().device(at::kCPU).dtype(indices.dtype()));
@@ -58,7 +59,7 @@ QueueItem tensor_copy(
             new_weightss_addr); // dst_start
       });
   *new_count.data_ptr<int64_t>() = num_sets;
-  return QueueItem{new_indices, new_weights, new_count};
+  return QueueItem{new_indices, new_weights, new_count, mode};
 }
 
 EmbeddingKVDB::EmbeddingKVDB(
@@ -97,6 +98,7 @@ EmbeddingKVDB::EmbeddingKVDB(
       auto& indices = filling_item_ptr->indices;
       auto& weights = filling_item_ptr->weights;
       auto& count = filling_item_ptr->count;
+      auto& rocksdb_wmode = filling_item_ptr->mode;
 
       if (l2_cache_) {
         auto evicted_pairs_opt = set_cache(indices, weights, count);
@@ -104,11 +106,12 @@ EmbeddingKVDB::EmbeddingKVDB(
           auto& evicted_indices = evicted_pairs_opt->first;
           auto& evicted_weights = evicted_pairs_opt->second;
 
-          folly::coro::blockingWait(
-              set_kv_db_async(evicted_indices, evicted_weights, count));
+          folly::coro::blockingWait(set_kv_db_async(
+              evicted_indices, evicted_weights, count, rocksdb_wmode));
         }
       } else {
-        folly::coro::blockingWait(set_kv_db_async(indices, weights, count));
+        folly::coro::blockingWait(
+            set_kv_db_async(indices, weights, count, rocksdb_wmode));
       }
 
       weights_to_fill_queue_.dequeue();
@@ -128,7 +131,8 @@ void EmbeddingKVDB::flush() {
     auto& indices = std::get<0>(tensor_tuple);
     auto& weights = std::get<1>(tensor_tuple);
     auto& count = std::get<2>(tensor_tuple);
-    folly::coro::blockingWait(set_kv_db_async(indices, weights, count));
+    folly::coro::blockingWait(set_kv_db_async(
+        indices, weights, count, kv_db::RocksdbWriteMode::FLUSH));
   }
 }
 
@@ -175,11 +179,12 @@ void EmbeddingKVDB::set_cuda(
 std::vector<double> EmbeddingKVDB::get_l2cache_perf(
     const int64_t step,
     const int64_t interval) {
-  std::vector<double> ret(11, 0); // num metrics
+  std::vector<double> ret(13, 0); // num metrics
   if (step > 0 && step % interval == 0) {
     int reset_val = 0;
     auto num_cache_misses = num_cache_misses_.exchange(reset_val);
     auto num_lookups = num_lookups_.exchange(reset_val);
+    auto num_evictions = num_evictions_.exchange(reset_val);
     auto get_total_duration = get_total_duration_.exchange(reset_val);
     auto get_cache_lookup_total_duration =
         get_cache_lookup_total_duration_.exchange(reset_val);
@@ -187,6 +192,9 @@ std::vector<double> EmbeddingKVDB::get_l2cache_perf(
         get_cache_lookup_wait_filling_thread_duration_.exchange(reset_val);
     auto get_weights_fillup_total_duration =
         get_weights_fillup_total_duration_.exchange(reset_val);
+    auto get_cache_memcpy_duration =
+        get_cache_memcpy_duration_.exchange(reset_val);
+
     auto total_cache_update_duration =
         total_cache_update_duration_.exchange(reset_val);
     auto get_tensor_copy_for_cache_update_dur =
@@ -199,13 +207,15 @@ std::vector<double> EmbeddingKVDB::get_l2cache_perf(
     ret[3] = (double(get_cache_lookup_total_duration) / interval);
     ret[4] = (double(get_cache_lookup_wait_filling_thread_duration) / interval);
     ret[5] = (double(get_weights_fillup_total_duration) / interval);
-    ret[6] = (double(total_cache_update_duration) / interval);
-    ret[7] = (double(get_tensor_copy_for_cache_update_dur) / interval);
-    ret[8] = (double(set_tensor_copy_for_cache_update_dur) / interval);
+    ret[6] = (double(get_cache_memcpy_duration) / interval);
+    ret[7] = (double(total_cache_update_duration) / interval);
+    ret[8] = (double(get_tensor_copy_for_cache_update_dur) / interval);
+    ret[9] = (double(set_tensor_copy_for_cache_update_dur) / interval);
+    ret[10] = (double(num_evictions) / interval);
     if (l2_cache_) {
       auto cache_mem_stats = l2_cache_->get_cache_usage();
-      ret[9] = (cache_mem_stats[0]); // free cache in bytes
-      ret[10] = (cache_mem_stats[1]); // total cache capacity in bytes
+      ret[11] = (cache_mem_stats[0]); // free cache in bytes
+      ret[12] = (cache_mem_stats[1]); // total cache capacity in bytes
     }
   }
   return ret;
@@ -228,7 +238,10 @@ void EmbeddingKVDB::set(
   // parallelized with other cuda kernels, as long as all updates are finished
   // before the next L2 cache lookup
   auto tensor_copy_start_ts = facebook::WallClockUtil::NowInUsecFast();
-  auto new_item = tensor_copy(indices, weights, count);
+  kv_db::RocksdbWriteMode write_mode = is_bwd
+      ? kv_db::RocksdbWriteMode::BWD_L1_CNFLCT_MISS_WRITE_BACK
+      : kv_db::RocksdbWriteMode::FWD_L1_EVICTION;
+  auto new_item = tensor_copy(indices, weights, count, write_mode);
   weights_to_fill_queue_.enqueue(new_item);
   set_tensor_copy_for_cache_update_ +=
       facebook::WallClockUtil::NowInUsecFast() - tensor_copy_start_ts;
@@ -264,7 +277,8 @@ void EmbeddingKVDB::get(
       // be parallelized with other cuda kernels, as long as all updates are
       // finished before the next L2 cache lookup
       auto tensor_copy_start_ts = facebook::WallClockUtil::NowInUsecFast();
-      auto new_item = tensor_copy(indices, weights, count);
+      auto new_item = tensor_copy(
+          indices, weights, count, kv_db::RocksdbWriteMode::FWD_ROCKSDB_READ);
       weights_to_fill_queue_.enqueue(new_item);
       get_tensor_copy_for_cache_update_ +=
           facebook::WallClockUtil::NowInUsecFast() - tensor_copy_start_ts;
@@ -420,7 +434,8 @@ folly::Optional<std::pair<at::Tensor, at::Tensor>> EmbeddingKVDB::set_cache(
             .scheduleOn(executor_tp_.get()));
   }
   folly::coro::blockingWait(folly::coro::collectAllRange(std::move(tasks)));
-  l2_cache_->reset_eviction_states();
+  auto num_evictions = l2_cache_->reset_eviction_states();
+  num_evictions_ += num_evictions;
   total_cache_update_duration_ +=
       facebook::WallClockUtil::NowInUsecFast() - cache_update_start_ts;
   return l2_cache_->get_evicted_indices_and_weights();
@@ -429,6 +444,7 @@ folly::Optional<std::pair<at::Tensor, at::Tensor>> EmbeddingKVDB::set_cache(
 folly::coro::Task<void> EmbeddingKVDB::cache_memcpy(
     const at::Tensor& weights,
     const std::vector<void*>& cached_addr_list) {
+  auto cache_memcpy_start_ts = facebook::WallClockUtil::NowInUsecFast();
   FBGEMM_DISPATCH_FLOAT_HALF_AND_BYTE(
       weights.scalar_type(), "cache_memcpy", [&] {
         auto weights_data_ptr = weights.data_ptr<scalar_t>();
@@ -443,6 +459,8 @@ folly::coro::Task<void> EmbeddingKVDB::cache_memcpy(
               &weights_data_ptr[row_id * max_D_]); // dst_start
         }
       });
+  get_cache_memcpy_duration_ +=
+      facebook::WallClockUtil::NowInUsecFast() - cache_memcpy_start_ts;
   co_return;
 }
 

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -345,7 +345,8 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
       const at::Tensor& indices,
       const at::Tensor& weights,
       const at::Tensor& count,
-      const bool is_bwd = false) override {
+      const kv_db::RocksdbWriteMode w_mode =
+          kv_db::RocksdbWriteMode::FWD_ROCKSDB_READ) override {
     RECORD_USER_SCOPE("EmbeddingRocksDB::set");
 #ifdef FBGEMM_FBCODE
     auto start_ts = facebook::WallClockUtil::NowInUsecFast();
@@ -398,10 +399,19 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
     co_await folly::coro::collectAllRange(std::move(tasks));
 #ifdef FBGEMM_FBCODE
     auto duration = facebook::WallClockUtil::NowInUsecFast() - start_ts;
-    if (is_bwd) {
-      bwd_write_total_duration_ += duration;
-    } else {
-      fwd_write_total_duration_ += duration;
+    switch (w_mode) {
+      case kv_db::RocksdbWriteMode::BWD_L1_CNFLCT_MISS_WRITE_BACK:
+        bwd_l1_cnflct_miss_write_back_dur_ += duration;
+        break;
+      case kv_db::RocksdbWriteMode::FWD_L1_EVICTION:
+        fwd_l1_eviction_dur_ += duration;
+        break;
+      case kv_db::RocksdbWriteMode::FWD_ROCKSDB_READ:
+        fwd_rocksdb_read_dur_ += duration;
+        break;
+      case kv_db::RocksdbWriteMode::FLUSH:
+        flush_write_dur_ += duration;
+        break;
     }
 #endif
   }
@@ -560,17 +570,22 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
       const int64_t step,
       const int64_t interval) {
     std::vector<double> ret;
-    ret.reserve(3);
+    ret.reserve(5);
     if (step > 0 && step % interval == 0) {
-      auto read_dur = read_total_duration_.load();
-      auto fwd_write_dur = fwd_write_total_duration_.load();
-      auto bwd_write_dur = bwd_write_total_duration_.load();
+      int64_t reset_val = 0;
+      auto read_dur = read_total_duration_.exchange(reset_val);
+
+      auto fwd_rocksdb_read_dur = fwd_rocksdb_read_dur_.exchange(reset_val);
+      auto fwd_l1_eviction_dur = fwd_l1_eviction_dur_.exchange(reset_val);
+      auto bwd_l1_cnflct_miss_write_back_dur =
+          bwd_l1_cnflct_miss_write_back_dur_.exchange(reset_val);
+      auto flush_write_dur = flush_write_dur_.exchange(reset_val);
+
       ret.push_back(double(read_dur) / interval);
-      ret.push_back(double(fwd_write_dur) / interval);
-      ret.push_back(double(bwd_write_dur) / interval);
-      read_total_duration_ = 0;
-      fwd_write_total_duration_ = 0;
-      bwd_write_total_duration_ = 0;
+      ret.push_back(double(fwd_rocksdb_read_dur) / interval);
+      ret.push_back(double(fwd_l1_eviction_dur) / interval);
+      ret.push_back(double(bwd_l1_cnflct_miss_write_back_dur) / interval);
+      ret.push_back(double(flush_write_dur) / interval);
     }
     return ret;
   }
@@ -650,9 +665,13 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
   int64_t memtable_flush_period_;
   int64_t compaction_period_;
   int64_t l0_files_per_compact_;
+
+  // break down on rocksdb write duration for details checkout RocksdbWriteMode
   std::atomic<int64_t> read_total_duration_{0};
-  std::atomic<int64_t> fwd_write_total_duration_{0};
-  std::atomic<int64_t> bwd_write_total_duration_{0};
+  std::atomic<int64_t> fwd_rocksdb_read_dur_{0};
+  std::atomic<int64_t> fwd_l1_eviction_dur_{0};
+  std::atomic<int64_t> bwd_l1_cnflct_miss_write_back_dur_{0};
+  std::atomic<int64_t> flush_write_dur_{0};
 }; // class EmbeddingKVDB
 
 } // namespace ssd


### PR DESCRIPTION
Summary:
1. number evictions from L2 cache
2. cache memcpy duration(in parallel with rocksdb io read)
3. break down rocksdb write io for 2 calls for fwd path and 1 call for bwd path

Reviewed By: q10

Differential Revision: D62208506
