### PR TITLE
cachelib optimization

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/cachelib_cache.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/cachelib_cache.h
@@ -74,6 +74,14 @@ class CacheLibCache {
   /// deterministic mapping from a embedding index to a specific pool id
   facebook::cachelib::PoolId get_pool_id(int64_t key);
 
+  /// update the LRU queue in cachelib, this is detached from cache->find()
+  /// so that we could boost up the lookup perf without worrying about LRU queue
+  /// contention
+  ///
+  /// @param read_handles the read handles that record what cache item has been
+  /// accessed
+  void batchMarkUseful(const std::vector<Cache::ReadHandle>& read_handles);
+
   /// Add an embedding index and embeddings into cachelib
   ///
   /// @param key embedding index to insert


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/211

1. formulate bucket power and lock power in setAccessConfig to reduce hashtable contention
2. modify cache put logic to do find first, this will avoid always kicking out an existing item on cach hit cases when cache is full.

Reviewed By: q10

Differential Revision: D62041988
