### PR TITLE
use correct operator signature - SymIntArrayRef and IntArrayRef

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/permute_multi_embedding_function.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/permute_multi_embedding_function.h
@@ -48,7 +48,7 @@ std::vector<Tensor> permute_multi_embedding_function_cpu(
     const Tensor& permutes,
     const Tensor& in_shapes,
     const Tensor& out_shapes,
-    const c10::SymIntArrayRef out_lengths,
+    const c10::IntArrayRef out_lengths,
     const bool& reverse_permute);
 
 std::vector<Tensor> permute_multi_embedding_function_meta(
@@ -64,7 +64,7 @@ std::vector<Tensor> permute_multi_embedding_function_gpu(
     const Tensor& permutes,
     const Tensor& in_shapes,
     const Tensor& out_shapes,
-    const c10::SymIntArrayRef out_lengths,
+    const c10::IntArrayRef out_lengths,
     const bool& reverse_permute);
 
 std::tuple<std::vector<int32_t>, std::vector<int32_t>, std::vector<int32_t>>

--- a/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_function.cpp
+++ b/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_function.cpp
@@ -42,7 +42,7 @@ variable_list PermuteMultiEmbeddingOp::forward(
   const auto permute_op =
       torch::Dispatcher::singleton()
           .findSchemaOrThrow("fbgemm::permute_multi_embedding_function", "")
-          .typed<decltype(permute_multi_embedding_function_cpu)>();
+          .typed<decltype(permute_multi_embedding_function_meta)>();
 
   return permute_op.call(
       pooled_embs, permutes, in_shapes, out_shapes, out_lengths, false);
@@ -64,7 +64,7 @@ variable_list PermuteMultiEmbeddingOp::backward(
   const auto permute_op =
       torch::Dispatcher::singleton()
           .findSchemaOrThrow("fbgemm::permute_multi_embedding_function", "")
-          .typed<decltype(permute_multi_embedding_function_cpu)>();
+          .typed<decltype(permute_multi_embedding_function_meta)>();
   auto grad_input = permute_op.call(
       grad_output, permutes, out_shapes, in_shapes, in_lengths, true);
   grad_input.push_back(torch::autograd::Variable()); // permutes

--- a/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
@@ -222,7 +222,7 @@ std::vector<Tensor> permute_multi_embedding_function_gpu(
     const Tensor& permutes,
     const Tensor& in_shapes,
     const Tensor& out_shapes,
-    const c10::SymIntArrayRef out_lengths,
+    const c10::IntArrayRef out_lengths,
     const bool& reverse_permute) {
   // we assume that there's at least one input tensor in the list
   // it should be enforced from the caller side who has the knowledge.
@@ -302,7 +302,7 @@ std::vector<Tensor> permute_multi_embedding_gpu(
     const Tensor& permutes,
     const Tensor& in_shapes,
     const Tensor& out_shapes,
-    const c10::SymIntArrayRef out_lengths) {
+    const c10::IntArrayRef out_lengths) {
   return permute_multi_embedding_function_gpu(
       pooled_embs, permutes, in_shapes, out_shapes, out_lengths, false);
 }
@@ -314,14 +314,8 @@ std::vector<Tensor> regroup_keyed_tensor_gpu(
     const std::vector<std::vector<std::string>>& groups) {
   auto [permutes, in_shapes, out_shapes, out_lengths] =
       kt_regroup_arguments_gpu(pooled_embs[0], keys, lengths, groups);
-  std::vector<at::SymInt> out;
-  std::transform(
-      out_lengths.begin(),
-      out_lengths.end(),
-      std::back_inserter(out),
-      [](const int32_t v) { return c10::SymInt(v); });
   return permute_multi_embedding_function_gpu(
-      pooled_embs, permutes, in_shapes, out_shapes, out, false);
+      pooled_embs, permutes, in_shapes, out_shapes, out_lengths, false);
 }
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops_cpu.cpp
+++ b/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops_cpu.cpp
@@ -19,7 +19,7 @@ std::vector<Tensor> permute_multi_embedding_function_cpu(
     const Tensor& permutes,
     const Tensor& /* in_shapes */,
     const Tensor& /* out_shapes */,
-    const c10::SymIntArrayRef out_lengths,
+    const c10::IntArrayRef out_lengths,
     const bool& reverse_permute) {
   std::vector<Tensor> inputs;
   inputs.reserve(pooled_embs.size());
@@ -171,7 +171,7 @@ std::vector<Tensor> permute_multi_embedding_cpu(
     const Tensor& permutes,
     const Tensor& in_shapes,
     const Tensor& out_shapes,
-    const c10::SymIntArrayRef out_lengths) {
+    const c10::IntArrayRef out_lengths) {
   return permute_multi_embedding_function_cpu(
       pooled_embs, permutes, in_shapes, out_shapes, out_lengths, false);
 }
@@ -321,14 +321,8 @@ std::vector<Tensor> regroup_keyed_tensor_cpu(
     const std::vector<std::vector<std::string>>& groups) {
   auto [permutes, in_shapes, out_shapes, out_lengths] =
       kt_regroup_arguments_cpu(pooled_embs[0], keys, lengths, groups);
-  std::vector<at::SymInt> out;
-  std::transform(
-      out_lengths.begin(),
-      out_lengths.end(),
-      std::back_inserter(out),
-      [](const int32_t v) { return c10::SymInt(v); });
   return permute_multi_embedding_function_cpu(
-      pooled_embs, permutes, in_shapes, out_shapes, out, false);
+      pooled_embs, permutes, in_shapes, out_shapes, out_lengths, false);
 }
 
 std::vector<Tensor> regroup_keyed_tensor_meta(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/223

# context
* make fbgemm operator `permute_multi_embedding` PT2 compatible.
* `out_lengths` is the list of sizes for all the output KT, which should be dynamic dims.
* change the `out_lengths` from `std::vector<int64_t>` to `c10::SymIntArrayRef`, and other type compatibility fixes.
* actually should use `c10::IntArrayRef` for the cpu and gpu impl, **only use SymInt in meta function**

Differential Revision: D62622020
