### PR TITLE
Increase test time out for test workflow OSS CI

### DIFF
--- a/.github/workflows/fbgemm_gpu_pip.yml
+++ b/.github/workflows/fbgemm_gpu_pip.yml
@@ -160,7 +160,7 @@ jobs:
       run: . $PRELUDE; install_fbgemm_gpu_pip $BUILD_ENV ${{ github.event.inputs.fbgemm_gpu_channel_version || 'nightly' }} cuda/${{ matrix.cuda-version }}
 
     - name: Test with PyTest
-      timeout-minutes: 20
+      timeout-minutes: 40
       run: . $PRELUDE; test_all_fbgemm_gpu_modules $BUILD_ENV
 
 


### PR DESCRIPTION
Summary:
Failures on OSS CI test workflow are due to time-out during unit testing.
https://github.com/pytorch/FBGEMM/actions/runs/10851972782

This diff increases time-out so all tests can be run.

Reviewed By: sryap

Differential Revision: D62649448
