### PR TITLE
mark autograd function traceable

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/permute_multi_embedding_function.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/permute_multi_embedding_function.h
@@ -30,6 +30,7 @@ using torch::autograd::variable_list;
 class PermuteMultiEmbeddingOp
     : public torch::autograd::Function<PermuteMultiEmbeddingOp> {
  public:
+  static constexpr bool is_traceable = true;
   static variable_list forward(
       AutogradContext* ctx,
       const at::TensorList& pooled_embs,


### PR DESCRIPTION
Summary:
# context
* encountered the following error:
```
Failures:

  1) torchrec.distributed.train_pipeline.tests.test_train_pipelines.TrainPipelineSparseDistCompAutogradTest: test_equal_to_non_pipelined
    1) RuntimeError: Attempting to trace a potentially unsafe C++ autograd function: torch::autograd::CppNode<fbgemm_gpu::PermuteMultiEmbeddingOp>. It may be possible to trace it safely, please refer to the instructions in: https://docs.google.com/document/d/11VucFBEewzqgkABIjebZIzMvrXr3BtcY1aGKpX61pJY/.
      File "torchrec/distributed/train_pipeline/tests/test_train_pipelines.py", line 461, in test_equal_to_non_pipelined
        not torch.cuda.is_available(),
      File "hypothesis/core.py", line 1602, in wrapped_test
        raise the_error_hypothesis_found
      File "torchrec/distributed/train_pipeline/tests/test_train_pipelines.py", line 531, in test_equal_to_non_pipelined
        pred_pipeline = pipeline.progress(dataloader)
      File "torchrec/distributed/train_pipeline/train_pipelines.py", line 1603, in progress
        return super().progress(dataloader_iter)
      File "torchrec/distributed/train_pipeline/train_pipelines.py", line 499, in progress
        torch.sum(losses, dim=0).backward()
      File "torch/_tensor.py", line 581, in backward
        torch.autograd.backward(
      File "torch/autograd/__init__.py", line 347, in backward
        _engine_run_backward(
      File "torch/autograd/graph.py", line 825, in _engine_run_backward
        return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
```
* it turned out that the autograd function is not marked as traceable: [doc](https://fburl.com/gdoc/vh88gnk8)
* the test passed after the diff

Differential Revision: D62889399
