### PR TITLE
use npt.NDArray instead of np.ndarray in type annotations [2/N]

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/utils/requests.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/utils/requests.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
 import numpy as np
+import numpy.typing as npt
 import torch
 
 # pyre-fixme[21]: Could not find name `default_rng` in `numpy.random` (stubbed).
@@ -135,7 +136,7 @@ def generate_int_data_from_stats(
     sigma: int,
     size: int,
     distribution: str,
-) -> np.ndarray:
+) -> npt.NDArray:
     """
     Generate integer data based on stats
     """

--- a/fbgemm_gpu/test/jagged/common.py
+++ b/fbgemm_gpu/test/jagged/common.py
@@ -16,6 +16,7 @@ from typing import Callable, Dict, List, Tuple
 import fbgemm_gpu
 import fbgemm_gpu.sparse_ops
 import numpy as np
+import numpy.typing as npt
 import torch
 from hypothesis import HealthCheck, settings
 
@@ -122,7 +123,7 @@ def generate_jagged_tensor(
     # dynamo to mark the input as dynamic shape to make sure symbolic
     # shape is generated
     mark_dynamic: bool = False,
-) -> Tuple[torch.Tensor, List[torch.LongTensor], np.ndarray]:
+) -> Tuple[torch.Tensor, List[torch.LongTensor], npt.NDArray]:
     max_lengths = np.random.randint(low=1, high=10, size=(num_jagged_dim,))
     x_offsets: List[torch.LongTensor] = []
     num_lengths = outer_dense_size
@@ -167,7 +168,7 @@ def generate_jagged_tensor(
 def to_padded_dense(
     values: torch.Tensor,
     offsets: List[torch.LongTensor],
-    max_lengths: np.ndarray,
+    max_lengths: npt.NDArray,
     padding_value: float = 0,
 ) -> torch.Tensor:
     outer_dense_size = len(offsets[0]) - 1

--- a/fbgemm_gpu/test/sparse/pack_segments_test.py
+++ b/fbgemm_gpu/test/sparse/pack_segments_test.py
@@ -15,6 +15,7 @@ from typing import Callable, Optional
 
 import hypothesis.strategies as st
 import numpy as np
+import numpy.typing as npt
 import torch
 from hypothesis import given, settings
 
@@ -27,7 +28,7 @@ else:
     from fbgemm_gpu.test.test_utils import gpu_available
 
 
-def get_n_rand_num_summing_to_k(n: int, k: int) -> np.ndarray:
+def get_n_rand_num_summing_to_k(n: int, k: int) -> npt.NDArray:
     """Get a list of `n` integers which collectively sum to `k`, drawn
     uniformly from the set of all such lists.
 
@@ -58,7 +59,7 @@ class PackedSegmentsTest(unittest.TestCase):
         lengths: torch.Tensor,
         tensor: torch.Tensor,
         max_length: Optional[int] = None,
-    ) -> np.ndarray:
+    ) -> npt.NDArray:
         lengths = lengths.numpy()
         sections = np.split(tensor, np.cumsum(lengths))
         max_length = np.max(lengths, initial=0) if max_length is None else max_length


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/245

To facilitate PSS-2 upgrade, this uses `ndt.NDArray` instead of `nd.ndarray` in type annotations. In Numpy-1.19 (PSS-1) it's an alias to `nd.ndarray` -- a noop.
In Numpy-1.24, `ndt.NDArray` a proper generic type, and without this change uses of `nd.ndarray` generate this Pyre type error:
```counterexample
 Invalid type parameters [24]: Generic type `np.ndarray` expects 2 type parameters.
```

Reviewed By: florazzz

Differential Revision: D62986280
