### PR TITLE
add lock for l2 cache set/get

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -1850,8 +1850,8 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             self.step, stats_reporter.report_interval  # pyre-ignore
         )
 
-        if len(l2_cache_perf_stats) != 13:
-            logging.error("l2 perf stats should have 13 elements")
+        if len(l2_cache_perf_stats) != 15:
+            logging.error("l2 perf stats should have 15 elements")
             return
 
         num_cache_misses = l2_cache_perf_stats[0]
@@ -1868,6 +1868,9 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
 
         l2_cache_free_bytes = l2_cache_perf_stats[11]
         l2_cache_capacity = l2_cache_perf_stats[12]
+
+        set_cache_lock_wait_duration = l2_cache_perf_stats[13]
+        get_cache_lock_wait_duration = l2_cache_perf_stats[14]
 
         stats_reporter.report_data_amount(
             iteration_step=self.step,
@@ -1941,6 +1944,19 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             iteration_step=self.step,
             event_name="l2_cache.perf.set.tensor_copy_for_cache_update_duration_us",
             duration_ms=set_tensor_copy_for_cache_update_duration,
+            time_unit="us",
+        )
+
+        stats_reporter.report_duration(
+            iteration_step=self.step,
+            event_name="l2_cache.perf.get.cache_lock_wait_duration_us",
+            duration_ms=get_cache_lock_wait_duration,
+            time_unit="us",
+        )
+        stats_reporter.report_duration(
+            iteration_step=self.step,
+            event_name="l2_cache.perf.set.cache_lock_wait_duration_us",
+            duration_ms=set_cache_lock_wait_duration,
             time_unit="us",
         )
 

--- a/fbgemm_gpu/src/split_embeddings_cache/cachelib_cache.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/cachelib_cache.cpp
@@ -15,25 +15,11 @@ namespace l2_cache {
 
 using Cache = facebook::cachelib::LruAllocator;
 
-// this is a general predictor for weights data type, might not be general
-// enough for all the cases
-at::ScalarType bytes_to_dtype(int num_bytes) {
-  switch (num_bytes) {
-    case 1:
-      return at::kByte;
-    case 2:
-      return at::kHalf;
-    case 4:
-      return at::kFloat;
-    case 8:
-      return at::kDouble;
-    default:
-      throw std::runtime_error("Unsupported dtype");
-  }
-}
-
-CacheLibCache::CacheLibCache(const CacheConfig& cache_config)
+CacheLibCache::CacheLibCache(
+    const CacheConfig& cache_config,
+    int64_t unique_tbe_id)
     : cache_config_(cache_config),
+      unique_tbe_id_(unique_tbe_id),
       cache_(initializeCacheLib(cache_config_)),
       admin_(createCacheAdmin(*cache_)) {
   for (size_t i = 0; i < cache_config_.num_shards; i++) {
@@ -50,30 +36,41 @@ CacheLibCache::CacheLibCache(const CacheConfig& cache_config)
 
 std::unique_ptr<Cache> CacheLibCache::initializeCacheLib(
     const CacheConfig& config) {
-  auto eviction_cb =
-      [this](const facebook::cachelib::LruAllocator::RemoveCbData& data) {
-        FBGEMM_DISPATCH_FLOAT_HALF_AND_BYTE(
-            evicted_weights_opt_->scalar_type(), "l2_eviction_handling", [&] {
-              if (data.context ==
-                  facebook::cachelib::RemoveContext::kEviction) {
-                auto indices_data_ptr =
-                    evicted_indices_opt_->data_ptr<int64_t>();
-                auto weights_data_ptr =
-                    evicted_weights_opt_->data_ptr<scalar_t>();
-                auto row_id = eviction_row_id++;
-                auto weight_dim = evicted_weights_opt_->size(1);
-                const auto key_ptr =
-                    reinterpret_cast<const int64_t*>(data.item.getKey().data());
-                indices_data_ptr[row_id] = *key_ptr;
+  auto eviction_cb = [this](
+                         const facebook::cachelib::LruAllocator::RemoveCbData&
+                             data) {
+    if (evicted_weights_opt_.has_value()) {
+      FBGEMM_DISPATCH_FLOAT_HALF_AND_BYTE(
+          evicted_weights_opt_->scalar_type(), "l2_eviction_handling", [&] {
+            using value_t = scalar_t;
+            FBGEMM_DISPATCH_INTEGRAL_TYPES(
+                evicted_indices_opt_->scalar_type(),
+                "l2_eviction_handling",
+                [&] {
+                  using index_t = scalar_t;
+                  if (data.context ==
+                      facebook::cachelib::RemoveContext::kEviction) {
+                    auto indices_data_ptr =
+                        evicted_indices_opt_->data_ptr<index_t>();
+                    auto weights_data_ptr =
+                        evicted_weights_opt_->data_ptr<value_t>();
+                    auto row_id = eviction_row_id++;
+                    auto weight_dim = evicted_weights_opt_->size(1);
+                    const auto key_ptr = reinterpret_cast<const index_t*>(
+                        data.item.getKey().data());
+                    indices_data_ptr[row_id] = *key_ptr;
 
-                std::copy(
-                    reinterpret_cast<const scalar_t*>(data.item.getMemory()),
-                    reinterpret_cast<const scalar_t*>(data.item.getMemory()) +
-                        weight_dim,
-                    &weights_data_ptr[row_id * weight_dim]); // dst_start
-              }
-            });
-      };
+                    std::copy(
+                        reinterpret_cast<const value_t*>(data.item.getMemory()),
+                        reinterpret_cast<const value_t*>(
+                            data.item.getMemory()) +
+                            weight_dim,
+                        &weights_data_ptr[row_id * weight_dim]); // dst_start
+                  }
+                });
+          });
+    }
+  };
   Cache::Config cacheLibConfig;
   int64_t rough_num_items =
       cache_config_.cache_size_bytes / cache_config_.item_size_bytes;
@@ -82,8 +79,9 @@ std::unique_ptr<Cache> CacheLibCache::initializeCacheLib(
   unsigned int lock_power =
       std::log(cache_config_.num_shards * 15) / std::log(2) + 1;
   XLOG(INFO) << fmt::format(
-      "Setting up Cachelib for L2 cache, capacity: {}GB, "
+      "[TBE_ID{}] Setting up Cachelib for L2 cache, capacity: {}GB, "
       "item_size: {}B, max_num_items: {}, bucket_power: {}, lock_power: {}",
+      unique_tbe_id_,
       config.cache_size_bytes / 1024 / 1024 / 1024,
       cache_config_.item_size_bytes,
       rough_num_items,
@@ -106,14 +104,21 @@ std::unique_ptr<facebook::cachelib::CacheAdmin> CacheLibCache::createCacheAdmin(
       cache, std::move(adminConfig));
 }
 
-std::optional<void*> CacheLibCache::get(int64_t key) {
-  auto key_str =
-      folly::StringPiece(reinterpret_cast<const char*>(&key), sizeof(int64_t));
-  auto item = cache_->find(key_str);
-  if (!item) {
-    return std::nullopt;
-  }
-  return const_cast<void*>(item->getMemory());
+folly::Optional<void*> CacheLibCache::get(const at::Tensor& key_tensor) {
+  folly::Optional<void*> res;
+  FBGEMM_DISPATCH_INTEGRAL_TYPES(key_tensor.scalar_type(), "get", [&] {
+    using index_t = scalar_t;
+    auto key = *(key_tensor.data_ptr<index_t>());
+    auto key_str = folly::StringPiece(
+        reinterpret_cast<const char*>(&key), sizeof(index_t));
+    auto item = cache_->find(key_str);
+    if (!item) {
+      res = folly::none;
+      return;
+    }
+    res = const_cast<void*>(item->getMemory());
+  });
+  return res;
 }
 
 size_t CacheLibCache::get_shard_id(int64_t key) {
@@ -136,55 +141,79 @@ void CacheLibCache::batchMarkUseful(
   }
 }
 
-bool CacheLibCache::put(int64_t key, const at::Tensor& data) {
-  auto key_str =
-      folly::StringPiece(reinterpret_cast<const char*>(&key), sizeof(int64_t));
-  auto item = cache_->findToWrite(key_str);
-  if (!item) {
-    auto alloc_item =
-        cache_->allocate(get_pool_id(key), key_str, data.nbytes());
-    if (!alloc_item) {
-      XLOG(ERR) << fmt::format(
-          "Failed to allocate item {} in cache, skip", key);
-      return false;
-    }
-    std::memcpy(alloc_item->getMemory(), data.data_ptr(), data.nbytes());
-    cache_->insertOrReplace(std::move(alloc_item));
-  } else {
-    std::memcpy(item->getMemory(), data.data_ptr(), data.nbytes());
+bool CacheLibCache::put(const at::Tensor& key_tensor, const at::Tensor& data) {
+  if (!index_dtype_.has_value()) {
+    index_dtype_ = key_tensor.scalar_type();
   }
-  return true;
+  if (!weights_dtype_.has_value()) {
+    weights_dtype_ = data.scalar_type();
+  }
+  bool res;
+  FBGEMM_DISPATCH_INTEGRAL_TYPES(key_tensor.scalar_type(), "put", [&] {
+    using index_t = scalar_t;
+    auto key = *(key_tensor.data_ptr<index_t>());
+    auto key_str = folly::StringPiece(
+        reinterpret_cast<const char*>(&key), sizeof(index_t));
+    auto item = cache_->findToWrite(key_str);
+    if (!item) {
+      auto alloc_item =
+          cache_->allocate(get_pool_id(key), key_str, data.nbytes());
+      if (!alloc_item) {
+        XLOG(ERR) << fmt::format(
+            "[TBE_ID{}]Failed to allocate item {} in cache, skip",
+            unique_tbe_id_,
+            key);
+        res = false;
+        return;
+      }
+      std::memcpy(alloc_item->getMemory(), data.data_ptr(), data.nbytes());
+      cache_->insertOrReplace(std::move(alloc_item));
+    } else {
+      std::memcpy(item->getMemory(), data.data_ptr(), data.nbytes());
+    }
+    res = true;
+  });
+  return res;
 }
 
-std::tuple<at::Tensor, at::Tensor, at::Tensor> CacheLibCache::get_all_items() {
+folly::Optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>>
+CacheLibCache::get_all_items() {
+  if (!index_dtype_.has_value() || !weights_dtype_.has_value()) {
+    return folly::none;
+  }
   int total_num_items = 0;
   for (auto& pool_id : pool_ids_) {
     total_num_items += cache_->getPoolStats(pool_id).numItems();
   }
   auto weight_dim = cache_config_.max_D_;
-  auto weights_dtype =
-      bytes_to_dtype(cache_config_.item_size_bytes / weight_dim);
   auto indices = at::empty(
-      total_num_items, at::TensorOptions().dtype(at::kLong).device(at::kCPU));
+      total_num_items,
+      at::TensorOptions().dtype(index_dtype_.value()).device(at::kCPU));
   auto weights = at::empty(
       {total_num_items, weight_dim},
-      at::TensorOptions().dtype(weights_dtype).device(at::kCPU));
+      at::TensorOptions().dtype(weights_dtype_.value()).device(at::kCPU));
   FBGEMM_DISPATCH_FLOAT_HALF_AND_BYTE(
       weights.scalar_type(), "get_all_items", [&] {
-        auto indices_data_ptr = indices.data_ptr<int64_t>();
-        auto weights_data_ptr = weights.data_ptr<scalar_t>();
-        int64_t item_idx = 0;
-        for (auto itr = cache_->begin(); itr != cache_->end(); ++itr) {
-          const auto key_ptr =
-              reinterpret_cast<const int64_t*>(itr->getKey().data());
-          indices_data_ptr[item_idx] = *key_ptr;
-          std::copy(
-              reinterpret_cast<const scalar_t*>(itr->getMemory()),
-              reinterpret_cast<const scalar_t*>(itr->getMemory()) + weight_dim,
-              &weights_data_ptr[item_idx * weight_dim]); // dst_start
-          item_idx++;
-        }
-        CHECK_EQ(total_num_items, item_idx);
+        using value_t = scalar_t;
+        FBGEMM_DISPATCH_INTEGRAL_TYPES(
+            indices.scalar_type(), "get_all_items", [&] {
+              using index_t = scalar_t;
+              auto indices_data_ptr = indices.data_ptr<index_t>();
+              auto weights_data_ptr = weights.data_ptr<value_t>();
+              int64_t item_idx = 0;
+              for (auto itr = cache_->begin(); itr != cache_->end(); ++itr) {
+                const auto key_ptr =
+                    reinterpret_cast<const index_t*>(itr->getKey().data());
+                indices_data_ptr[item_idx] = *key_ptr;
+                std::copy(
+                    reinterpret_cast<const value_t*>(itr->getMemory()),
+                    reinterpret_cast<const value_t*>(itr->getMemory()) +
+                        weight_dim,
+                    &weights_data_ptr[item_idx * weight_dim]); // dst_start
+                item_idx++;
+              }
+              CHECK_EQ(total_num_items, item_idx);
+            });
       });
   return std::make_tuple(
       indices,

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
@@ -279,6 +279,10 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
 
   virtual void flush_or_compact(const int64_t timestep) = 0;
 
+  void check_tensor_type_consistency(
+      const at::Tensor& indices,
+      const at::Tensor& weights);
+
   // waiting for working item queue to be empty, this is called by get_cache()
   // as embedding read should wait until previous write to be finished
   void wait_util_filling_work_done();
@@ -287,6 +291,8 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
   const int64_t unique_id_;
   const int64_t num_shards_;
   const int64_t max_D_;
+  folly::Optional<at::ScalarType> index_dtype_{folly::none};
+  folly::Optional<at::ScalarType> weights_dtype_{folly::none};
   std::unique_ptr<folly::CPUThreadPoolExecutor> executor_tp_;
   std::unique_ptr<std::thread> cache_filling_thread_;
   std::atomic<bool> stop_{false};

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -315,8 +315,8 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
     return impl_->set(indices, weights, count);
   }
 
-  void get(Tensor indices, Tensor weights, Tensor count) {
-    return impl_->get(indices, weights, count);
+  void get(Tensor indices, Tensor weights, Tensor count, int64_t sleep_ms) {
+    return impl_->get(indices, weights, count, sleep_ms);
   }
 
   std::vector<int64_t> get_mem_usage() {
@@ -341,6 +341,14 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
 
   void flush() {
     return impl_->flush();
+  }
+
+  void reset_l2_cache() {
+    return impl_->reset_l2_cache();
+  }
+
+  void wait_util_filling_work_done() {
+    return impl_->wait_util_filling_work_done();
   }
 
  private:
@@ -413,7 +421,20 @@ static auto embedding_rocks_db_wrapper =
             &EmbeddingRocksDBWrapper::get_rocksdb_io_duration)
         .def("get_l2cache_perf", &EmbeddingRocksDBWrapper::get_l2cache_perf)
         .def("set", &EmbeddingRocksDBWrapper::set)
-        .def("get", &EmbeddingRocksDBWrapper::get);
+        .def(
+            "get",
+            &EmbeddingRocksDBWrapper::get,
+            "",
+            {
+                torch::arg("indices"),
+                torch::arg("weights"),
+                torch::arg("count"),
+                torch::arg("sleep_ms") = 0,
+            })
+        .def("reset_l2_cache", &EmbeddingRocksDBWrapper::reset_l2_cache)
+        .def(
+            "wait_util_filling_work_done",
+            &EmbeddingRocksDBWrapper::wait_util_filling_work_done);
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(

--- a/fbgemm_gpu/test/tbe/common.py
+++ b/fbgemm_gpu/test/tbe/common.py
@@ -17,8 +17,16 @@ from hypothesis import settings, Verbosity
 # pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
 open_source: bool = getattr(fbgemm_gpu, "open_source", False)
 
-if not open_source:
+if open_source:
+    # pyre-ignore[21]
+    from test_utils import gpu_unavailable, running_on_github
+else:
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:cumem_utils")
+    from fbgemm_gpu.test.test_utils import (  # noqa F401
+        gpu_unavailable,
+        running_on_github,
+    )
+
 
 torch.ops.import_module("fbgemm_gpu.sparse_ops")
 settings.register_profile("derandomize", derandomize=True)

--- a/fbgemm_gpu/test/tbe/ssd/ssd_l2_cache_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_l2_cache_test.py
@@ -1,0 +1,231 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+# pyre-ignore-all-errors[3,6,56]
+
+import tempfile
+
+import threading
+import time
+import unittest
+
+from typing import Any, Dict, List, Tuple
+
+import hypothesis.strategies as st
+import numpy as np
+import torch
+from fbgemm_gpu.split_embedding_configs import SparseType
+from fbgemm_gpu.tbe.ssd import SSDTableBatchedEmbeddingBags
+from fbgemm_gpu.tbe.utils import round_up
+from hypothesis import given, settings, Verbosity
+
+from .. import common  # noqa E402
+from ..common import gpu_unavailable, running_on_github
+
+MAX_EXAMPLES = 20
+default_st: Dict[str, Any] = {
+    "T": st.integers(min_value=1, max_value=10),
+    "D": st.integers(min_value=2, max_value=128),
+    "log_E": st.integers(min_value=2, max_value=3),
+    "mixed": st.booleans(),
+    "weights_precision": st.sampled_from([SparseType.FP32, SparseType.FP16]),
+}
+
+default_settings: Dict[str, Any] = {
+    "verbosity": Verbosity.verbose,
+    "max_examples": MAX_EXAMPLES,
+    "deadline": None,
+}
+
+
+@unittest.skipIf(*running_on_github)
+@unittest.skipIf(*gpu_unavailable)
+class SSDCheckpointTest(unittest.TestCase):
+    def generate_fbgemm_ssd_tbe(
+        self,
+        T: int,
+        D: int,
+        log_E: int,
+        weights_precision: SparseType,
+        mixed: bool,
+        enable_l2: bool = True,
+    ) -> Tuple[SSDTableBatchedEmbeddingBags, List[int], List[int], int]:
+        E = int(10**log_E)
+        D = D * 4
+        if not mixed:
+            Ds = [D] * T
+            Es = [E] * T
+        else:
+            Ds = [
+                round_up(np.random.randint(low=int(0.25 * D), high=int(1.0 * D)), 4)
+                for _ in range(T)
+            ]
+            Es = [
+                np.random.randint(low=int(0.5 * E), high=int(2.0 * E)) for _ in range(T)
+            ]
+
+        feature_table_map = list(range(T))
+        emb = SSDTableBatchedEmbeddingBags(
+            embedding_specs=[(E, D) for (E, D) in zip(Es, Ds)],
+            feature_table_map=feature_table_map,
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=1,
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            weights_precision=weights_precision,
+            l2_cache_size=1 if enable_l2 else 0,
+        )
+        return emb, Es, Ds, max(Ds)
+
+    # @given(**default_st, do_flush=st.sampled_from([True, False]))
+    # @settings(**default_settings)
+    # def test_l2_flush(
+    #     self,
+    #     T: int,
+    #     D: int,
+    #     log_E: int,
+    #     mixed: bool,
+    #     weights_precision: SparseType,
+    #     do_flush: bool,
+    # ) -> None:
+    #     emb, Es, Ds, max_D = self.generate_fbgemm_ssd_tbe(
+    #         T, D, log_E, weights_precision, mixed
+    #     )
+    #     indices = torch.arange(start=0, end=sum(Es))
+    #     weights = torch.randn(
+    #         indices.numel(), max_D, dtype=weights_precision.as_dtype()
+    #     )
+    #     weights_from_l2 = torch.empty_like(weights)
+    #     count = torch.as_tensor([indices.numel()])
+    #     emb.ssd_db.set_cuda(indices, weights, count, 1)
+    #     emb.ssd_db.get_cuda(indices.clone(), weights_from_l2, count)
+
+    #     torch.cuda.synchronize()
+    #     assert torch.equal(weights, weights_from_l2)
+    #     import logging
+
+    #     logging.info(f"wgqtest {do_flush=}")
+    #     weights_from_ssd = torch.empty_like(weights)
+    #     if do_flush:
+    #         emb.ssd_db.flush()
+    #     emb.ssd_db.reset_l2_cache()
+    #     emb.ssd_db.get_cuda(indices, weights_from_ssd, count)
+    #     torch.cuda.synchronize()
+    #     if do_flush:
+    #         assert torch.equal(weights, weights_from_ssd)
+    #     else:
+    #         assert not torch.equal(weights, weights_from_ssd)
+
+    # @given(**default_st, enable_l2=st.sampled_from([True, False]))
+    # @settings(**default_settings)
+    # def test_l2_io(
+    #     self,
+    #     T: int,
+    #     D: int,
+    #     log_E: int,
+    #     mixed: bool,
+    #     weights_precision: SparseType,
+    #     enable_l2: bool,
+    # ) -> None:
+    #     emb, Es, Ds, max_D = self.generate_fbgemm_ssd_tbe(
+    #         T, D, log_E, weights_precision, mixed, enable_l2
+    #     )
+    #     E = int(10**log_E)
+    #     num_rounds = 10
+    #     N = E
+    #     total_indices = torch.tensor([])
+
+    #     indices = torch.as_tensor(
+    #         np.random.choice(E, replace=False, size=(N,)), dtype=torch.int64
+    #     )
+    #     weights = torch.randn(
+    #         indices.numel(), max_D, dtype=weights_precision.as_dtype()
+    #     )
+    #     sub_N = N // num_rounds
+
+    #     for _ in range(num_rounds):
+    #         sub_indices = torch.as_tensor(
+    #             np.random.choice(E, replace=False, size=(sub_N,)), dtype=torch.int64
+    #         )
+    #         sub_weights = weights[sub_indices, :]
+    #         sub_weights_out = torch.empty_like(sub_weights)
+    #         count = torch.as_tensor([sub_indices.numel()])
+    #         emb.ssd_db.set_cuda(sub_indices, sub_weights, count, 1)
+    #         emb.ssd_db.get_cuda(sub_indices.clone(), sub_weights_out, count)
+    #         torch.cuda.synchronize()
+    #         assert torch.equal(sub_weights, sub_weights_out)
+    #         total_indices = torch.cat((total_indices, sub_indices))
+    #     # dedup
+    #     used_unique_indices = torch.tensor(
+    #         list(set(total_indices.tolist())), dtype=torch.int64
+    #     )
+    #     stored_weights = weights[used_unique_indices, :]
+    #     weights_out = torch.empty_like(stored_weights)
+    #     count = torch.as_tensor([used_unique_indices.numel()])
+    #     emb.ssd_db.get_cuda(used_unique_indices.clone(), weights_out, count)
+    #     torch.cuda.synchronize()
+    #     assert torch.equal(stored_weights, weights_out)
+
+    #     emb.ssd_db.flush()
+    #     emb.ssd_db.reset_l2_cache()
+    #     weights_out = torch.empty_like(stored_weights)
+    #     count = torch.as_tensor([used_unique_indices.numel()])
+    #     emb.ssd_db.get_cuda(used_unique_indices.clone(), weights_out, count)
+    #     torch.cuda.synchronize()
+    #     assert torch.equal(stored_weights, weights_out)
+
+    @given(**default_st)
+    @settings(**default_settings)
+    def test_l2_prefetch_compatibility(
+        self,
+        T: int,
+        D: int,
+        log_E: int,
+        mixed: bool,
+        weights_precision: SparseType,
+    ) -> None:
+        weights_precision: SparseType = SparseType.FP32
+        emb, Es, Ds, max_D = self.generate_fbgemm_ssd_tbe(
+            T, D, log_E, weights_precision, mixed
+        )
+        E = int(10**log_E)
+        N = E
+        indices = torch.as_tensor(
+            np.random.choice(E, replace=False, size=(N,)), dtype=torch.int64
+        )
+        weights = torch.randn(N, max_D, dtype=weights_precision.as_dtype())
+        new_weights = weights + 1
+        weights_out = torch.empty_like(weights)
+        count = torch.as_tensor([E])
+        emb.ssd_db.set(indices, weights, count)
+        emb.ssd_db.wait_util_filling_work_done()
+
+        event = threading.Event()
+        get_sleep_ms = 50
+
+        # pyre-ignore
+        def trigger_get() -> None:
+            event.set()
+            emb.ssd_db.get(indices.clone(), weights_out, count, get_sleep_ms)
+
+        # pyre-ignore
+        def trigger_set() -> None:
+            event.wait()
+            time.sleep(
+                get_sleep_ms / 1000.0 / 2
+            )  # sleep half of the sleep time in get, making sure set is trigger after get but before get is done
+            emb.ssd_db.set(indices, new_weights, count)
+
+        thread1 = threading.Thread(target=trigger_get)
+        thread2 = threading.Thread(target=trigger_set)
+        thread1.start()
+        thread2.start()
+        thread1.join()
+        thread2.join()
+        assert torch.equal(weights, weights_out)
+        emb.ssd_db.get(indices.clone(), weights_out, count)
+        assert torch.equal(new_weights, weights_out)

--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
@@ -94,15 +94,23 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
 
     @given(
         weights_precision=st.sampled_from([SparseType.FP32, SparseType.FP16]),
+        indice_int64_t=st.sampled_from([True, False]),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
-    def test_ssd(self, weights_precision: SparseType) -> None:
+    def test_ssd(self, indice_int64_t: bool, weights_precision: SparseType) -> None:
         import tempfile
 
         E = int(1e4)
         D = 128
         N = 100
-        indices = torch.as_tensor(np.random.choice(E, replace=False, size=(N,)))
+        if indice_int64_t:
+            indices = torch.as_tensor(
+                np.random.choice(E, replace=False, size=(N,)), dtype=torch.int64
+            )
+        else:
+            indices = torch.as_tensor(
+                np.random.choice(E, replace=False, size=(N,)), dtype=torch.int32
+            )
         weights = torch.randn(N, D, dtype=weights_precision.as_dtype())
         output_weights = torch.empty_like(weights)
         count = torch.tensor([N])


### PR DESCRIPTION
Summary:
In non pipelining mode, the sequence is
- get_cuda(): L2 read and insert L2 cache misses into queue for bg L2 write
- L1 cache eviction: insert into bg queue for L2 write
- ScratchPad update: insert into bg queue for L2 write
in non-prefetch pipeline, cuda synchronization guarantee get_cuda() happen after SP update

in prefetch pipeline, cuda sync only guarantee get_cuda() happen after L1 cache eviction pipeline case, SP bwd update could happen in parallel with L2 read
lock is used for l2 cache to do read / write exclusively

add unittest to capture L2 cache functionality and the cases discussed above

Differential Revision: D63010906
