### PR TITLE
- Required changes for kernels

### DIFF
--- a/fbgemm_gpu/codegen/training/index_select/batch_index_select_dim0_host.cpp
+++ b/fbgemm_gpu/codegen/training/index_select/batch_index_select_dim0_host.cpp
@@ -53,6 +53,7 @@ Tensor batch_index_select_dim0_codegen_backward_cuda(
 class BatchIndexSelectDim0GPUOp
     : public torch::autograd::Function<BatchIndexSelectDim0GPUOp> {
  public:
+  static constexpr bool is_traceable = true;
   static torch::autograd::variable_list forward_impl(
       Tensor inputs,
       Tensor indices,

--- a/fbgemm_gpu/include/fbgemm_gpu/permute_multi_embedding_function.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/permute_multi_embedding_function.h
@@ -30,6 +30,7 @@ using torch::autograd::variable_list;
 class PermuteMultiEmbeddingOp
     : public torch::autograd::Function<PermuteMultiEmbeddingOp> {
  public:
+  static constexpr bool is_traceable = true;
   static variable_list forward(
       AutogradContext* ctx,
       const at::TensorList& pooled_embs,

--- a/fbgemm_gpu/include/fbgemm_gpu/permute_pooled_embs_function_split.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/permute_pooled_embs_function_split.h
@@ -27,6 +27,7 @@ class PermutePooledEmbsFunctionSplit
     : public torch::autograd::Function<
           PermutePooledEmbsFunctionSplit<permute_pooled_embs_op>> {
  public:
+  static constexpr bool is_traceable = true;
   static Variable forward(
       AutogradContext* ctx,
       const at::Tensor& pooled_embs, // [B_local][Sum_T_global(D)]

--- a/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
@@ -66,6 +66,7 @@ namespace fbgemm_gpu {
 // Needed this to support backward pass.
 class PackSegments : public torch::autograd::Function<PackSegments> {
  public:
+  static constexpr bool is_traceable = true;
   static torch::autograd::variable_list forward(
       torch::autograd::AutogradContext* ctx,
       const Tensor& t_in,


### PR DESCRIPTION
Summary:
Adding small changes to kernels for CompiledAutograd support.

Adding `static constexpr bool is_traceable = true;` on kernels, making some kernels to use tensors instead of double and unrolling input shapes on GroupIndexSelectDim0GPUOp from vector into the ctx dict to help enablement of CompiledAutograd.

Differential Revision: D63151913
