### PR TITLE
Add docstrings for sparse ops

### DIFF
--- a/fbgemm_gpu/docs/src/fbgemm_gpu-python-api/pooled_embedding_modules.rst
+++ b/fbgemm_gpu/docs/src/fbgemm_gpu-python-api/pooled_embedding_modules.rst
@@ -1,0 +1,7 @@
+Pooled Embedding Modules
+========================
+
+.. automodule:: fbgemm_gpu
+
+.. autoclass:: fbgemm_gpu.permute_pooled_embedding_modules.PermutePooledEmbeddings
+   :members: __call__

--- a/fbgemm_gpu/docs/src/fbgemm_gpu-python-api/pooled_embedding_ops.rst
+++ b/fbgemm_gpu/docs/src/fbgemm_gpu-python-api/pooled_embedding_ops.rst
@@ -4,3 +4,5 @@ Pooled Embedding Operators
 .. automodule:: fbgemm_gpu
 
 .. autofunction:: torch.ops.fbgemm.merge_pooled_embeddings
+
+.. autofunction:: torch.ops.fbgemm.permute_pooled_embs

--- a/fbgemm_gpu/docs/src/fbgemm_gpu-python-api/quantize_ops.rst
+++ b/fbgemm_gpu/docs/src/fbgemm_gpu-python-api/quantize_ops.rst
@@ -1,0 +1,6 @@
+Quantization Operators
+======================
+
+.. automodule:: fbgemm_gpu
+
+.. autofunction:: torch.ops.fbgemm.FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf

--- a/fbgemm_gpu/docs/src/fbgemm_gpu-python-api/sparse_ops.rst
+++ b/fbgemm_gpu/docs/src/fbgemm_gpu-python-api/sparse_ops.rst
@@ -6,3 +6,9 @@ Sparse Operators
 .. autofunction:: torch.ops.fbgemm.permute_2D_sparse_data
 
 .. autofunction:: torch.ops.fbgemm.permute_1D_sparse_data
+
+.. autofunction:: torch.ops.fbgemm.expand_into_jagged_permute
+
+.. autofunction:: torch.ops.fbgemm.asynchronous_complete_cumsum
+
+.. autofunction:: torch.ops.fbgemm.offsets_range

--- a/fbgemm_gpu/docs/src/fbgemm_gpu-python-api/sparse_ops.rst
+++ b/fbgemm_gpu/docs/src/fbgemm_gpu-python-api/sparse_ops.rst
@@ -1,0 +1,8 @@
+Sparse Operators
+================
+
+.. automodule:: fbgemm_gpu
+
+.. autofunction:: torch.ops.fbgemm.permute_2D_sparse_data
+
+.. autofunction:: torch.ops.fbgemm.permute_1D_sparse_data

--- a/fbgemm_gpu/docs/src/index.rst
+++ b/fbgemm_gpu/docs/src/index.rst
@@ -91,6 +91,7 @@ Table of Contents
 
    fbgemm_gpu-python-api/jagged_tensor_ops.rst
    fbgemm_gpu-python-api/pooled_embedding_ops.rst
+   fbgemm_gpu-python-api/quantize_ops.rst
 
 .. _fbgemm-gpu.toc.api.python.modules:
 

--- a/fbgemm_gpu/docs/src/index.rst
+++ b/fbgemm_gpu/docs/src/index.rst
@@ -89,9 +89,10 @@ Table of Contents
    :maxdepth: 1
    :caption: FBGEMM_GPU Python Operators API
 
-   fbgemm_gpu-python-api/jagged_tensor_ops.rst
+   fbgemm_gpu-python-api/sparse_ops.rst
    fbgemm_gpu-python-api/pooled_embedding_ops.rst
    fbgemm_gpu-python-api/quantize_ops.rst
+   fbgemm_gpu-python-api/jagged_tensor_ops.rst
 
 .. _fbgemm-gpu.toc.api.python.modules:
 

--- a/fbgemm_gpu/docs/src/index.rst
+++ b/fbgemm_gpu/docs/src/index.rst
@@ -83,12 +83,20 @@ Table of Contents
    fbgemm_gpu-cpp-api/ssd_embedding_ops.rst
    fbgemm_gpu-cpp-api/experimental_ops.rst
 
-.. _fbgemm-gpu.toc.api.python:
+.. _fbgemm-gpu.toc.api.python.ops:
 
 .. toctree::
    :maxdepth: 1
-   :caption: FBGEMM_GPU Python API
+   :caption: FBGEMM_GPU Python Operators API
 
-   fbgemm_gpu-python-api/table_batched_embedding_ops.rst
    fbgemm_gpu-python-api/jagged_tensor_ops.rst
    fbgemm_gpu-python-api/pooled_embedding_ops.rst
+
+.. _fbgemm-gpu.toc.api.python.modules:
+
+.. toctree::
+   :maxdepth: 1
+   :caption: FBGEMM_GPU Python Modules API
+
+   fbgemm_gpu-python-api/table_batched_embedding_ops.rst
+   fbgemm_gpu-python-api/pooled_embedding_modules.rst

--- a/fbgemm_gpu/fbgemm_gpu/docs/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/docs/__init__.py
@@ -7,6 +7,10 @@
 
 # Trigger the manual addition of docstrings to pybind11-generated operators
 try:
-    from . import jagged_tensor_ops, merge_pooled_embedding_ops  # noqa: F401
+    from . import (  # noqa: F401
+        jagged_tensor_ops,
+        merge_pooled_embedding_ops,
+        permute_pooled_embedding_ops,
+    )
 except Exception:
     pass

--- a/fbgemm_gpu/fbgemm_gpu/docs/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/docs/__init__.py
@@ -11,6 +11,7 @@ try:
         jagged_tensor_ops,
         merge_pooled_embedding_ops,
         permute_pooled_embedding_ops,
+        quantize_ops,
     )
 except Exception:
     pass

--- a/fbgemm_gpu/fbgemm_gpu/docs/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/docs/__init__.py
@@ -12,6 +12,7 @@ try:
         merge_pooled_embedding_ops,
         permute_pooled_embedding_ops,
         quantize_ops,
+        sparse_ops,
     )
 except Exception:
     pass

--- a/fbgemm_gpu/fbgemm_gpu/docs/permute_pooled_embedding_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/docs/permute_pooled_embedding_ops.py
@@ -1,0 +1,108 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+from .common import add_docs
+
+add_docs(
+    torch.ops.fbgemm.permute_pooled_embs,
+    """
+permute_pooled_embs(pooled_embs, offset_dim_list, permute_list, inv_offset_dim_list, inv_permute_list) -> Tensor
+
+Permute embedding outputs along the feature dimension.
+
+The embedding output tensor `pooled_embs` contains the embedding outputs
+for all features in a batch. It is represented in a 2D format, where the
+rows are the batch size dimension and the columns are the feature *
+embedding dimension. Permuting along the feature dimension is
+essentially permuting along the second dimension (dim 1).
+
+Args:
+    pooled_embs (Tensor): The embedding outputs to permute. Shape is
+        `(B_local, total_global_D)`, where `B_local` = a local batch size
+        and `total_global_D` is the total embedding dimension across all
+        features (global)
+
+    offset_dim_list (Tensor): The complete cumulative sum of embedding
+        dimensions of all features. Shape is `T + 1` where `T` is the
+        total number of features
+
+    permute_list (Tensor): A tensor that describes how each feature is
+        permuted.  `permute_list[i]` indicates that the feature
+        `permute_list[i]` is permuted to position `i`
+
+    inv_offset_dim_list (Tensor): The complete cumulative sum of inverse
+        embedding dimensions, which are the permuted embedding dimensions.
+        `inv_offset_dim_list[i]` represents the starting embedding position of
+        feature `permute_list[i]`
+
+    inv_permute_list (Tensor): The inverse permute list, which contains the
+        permuted positions of each feature. `inv_permute_list[i]` represents
+        the permuted position of feature `i`
+
+Returns:
+    Permuted embedding outputs (Tensor). Same shape as `pooled_embs`
+
+**Example:**
+
+    >>> import torch
+    >>> from itertools import accumulate
+    >>>
+    >>> # Suppose batch size = 3 and there are 3 features
+    >>> batch_size = 3
+    >>>
+    >>> # Embedding dimensions for each feature
+    >>> embs_dims = torch.tensor([4, 4, 8], dtype=torch.int64, device="cuda")
+    >>>
+    >>> # Permute list, i.e., move feature 2 to position 0, move feature 0
+    >>> # to position 1, so on
+    >>> permute = torch.tensor([2, 0, 1], dtype=torch.int64, device="cuda")
+    >>>
+    >>> # Compute embedding dim offsets
+    >>> offset_dim_list = torch.tensor([0] + list(accumulate(embs_dims)), dtype=torch.int64, device="cuda")
+    >>> print(offset_dim_list)
+    >>>
+    tensor([ 0,  4,  8, 16], device='cuda:0')
+    >>>
+    >>> # Compute inverse embedding dims
+    >>> inv_embs_dims = [embs_dims[p] for p in permute]
+    >>> # Compute complete cumulative sum of inverse embedding dims
+    >>> inv_offset_dim_list = torch.tensor([0] + list(accumulate(inv_embs_dims)), dtype=torch.int64, device="cuda")
+    >>> print(inv_offset_dim_list)
+    >>>
+    tensor([ 0,  8, 12, 16], device='cuda:0')
+    >>>
+    >>> # Compute inverse permutes
+    >>> inv_permute = [0] * len(permute)
+    >>> for i, p in enumerate(permute):
+    >>>     inv_permute[p] = i
+    >>> inv_permute_list = torch.tensor([inv_permute], dtype=torch.int64, device="cuda")
+    >>> print(inv_permute_list)
+    >>>
+    tensor([[1, 2, 0]], device='cuda:0')
+    >>>
+    >>> # Generate an example input
+    >>> pooled_embs = torch.arange(embs_dims.sum().item() * batch_size, dtype=torch.float32, device="cuda").reshape(batch_size, -1)
+    >>> print(pooled_embs)
+    >>>
+    tensor([[ 0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10., 11., 12., 13.,
+             14., 15.],
+            [16., 17., 18., 19., 20., 21., 22., 23., 24., 25., 26., 27., 28., 29.,
+             30., 31.],
+            [32., 33., 34., 35., 36., 37., 38., 39., 40., 41., 42., 43., 44., 45.,
+             46., 47.]], device='cuda:0')
+    >>>
+    >>> torch.ops.fbgemm.permute_pooled_embs_auto_grad(pooled_embs, offset_dim_list, permute, inv_offset_dim_list, inv_permute_list)
+    >>>
+    tensor([[ 8.,  9., 10., 11., 12., 13., 14., 15.,  0.,  1.,  2.,  3.,  4.,  5.,
+              6.,  7.],
+            [24., 25., 26., 27., 28., 29., 30., 31., 16., 17., 18., 19., 20., 21.,
+             22., 23.],
+            [40., 41., 42., 43., 44., 45., 46., 47., 32., 33., 34., 35., 36., 37.,
+             38., 39.]], device='cuda:0')
+    """,
+)

--- a/fbgemm_gpu/fbgemm_gpu/docs/quantize_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/docs/quantize_ops.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+from .common import add_docs
+
+add_docs(
+    torch.ops.fbgemm.FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf,
+    """
+FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf(input, bit_rate) -> Tensor
+
+Convert FP32/16 to INT8/4/2 using rowwise quantization.
+
+Args:
+    input (Tensor): An input tensor. Must be either FP32 (`torch.float`)
+        or FP16 (`torch.half`) and must be 2 dimensions.
+
+    bit_rate (int): Quantized bit rate (2 for INT2, 4 for INT4, or 8 for
+        INT8)
+
+Returns:
+    Quantized output (Tensor). Data type is `torch.uint8` (byte type)
+
+**Example:**
+
+    >>> # Randomize input
+    >>> input = torch.randn(2, 4, dtype=torch.float32, device="cuda")
+    >>> print(input)
+    tensor([[ 0.8247,  0.0031, -1.0068, -1.2081],
+            [ 0.5427,  1.5772,  1.0291, -0.7626]], device='cuda:0')
+    >>> # Quantize
+    >>> output = torch.ops.fbgemm.FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf(input, bit_rate=4)
+    >>> print(output)
+    tensor([[159,   1,  86,  48, 213, 188],
+            [248,  11, 254,  48,  26, 186]], device='cuda:0', dtype=torch.uint8)
+    """,
+)

--- a/fbgemm_gpu/fbgemm_gpu/docs/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/docs/sparse_ops.py
@@ -1,0 +1,121 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+from .common import add_docs
+
+add_docs(
+    torch.ops.fbgemm.permute_2D_sparse_data,
+    """
+permute_2D_sparse_data(permute, lengths, values, weights=None, permuted_lengths_sum=None) -> Tuple[Tensor, Tensor, Optional[Tensor]]
+
+Permute 2D sparse data along the first dimension (dim 0). Note that 2D
+refers to the number of dense dimensions. The input data is actually 3D
+where the first two dimensions are dense and the last dimension is
+jagged (sparse). The data to permute over can be less or more and with or
+without repetitions.
+
+Args:
+    permute (Tensor): A 1D-tensor that describes how data is permuted along dim
+        0. `permute[i]` indicates that data at position `permute[i]` is moved
+        to position `i`. The length of this tensor is the total amount of data
+        in dim 0 to be permuted. The values in `permute` must be >= 0 and <
+        `lengths.shape[0]`
+
+    lengths (Tensor): A 2D-tensor that contains jagged shapes corresponding to
+        the other two dense dimensions. For example, in the case of the
+        embedding input, the 3D shape is (num features, batch size, bag size).
+        `lengths[t][b]` represents the bag size of feature `t` and sample `b`.
+
+    values (Tensor): A 1D-input-tensor to be permuted. The length of this
+        tensor must be equal to `lengths.sum()`. This tensor can be of any data
+        type.
+
+    weights (Optional[Tensor] = None): An optional 1D-float-tensor. It must
+        have the same length as `values`. It will be permuted the same way as
+        values
+
+    permuted_lengths_sum (Optional[int] = None): An optional value that
+        represents the total number of elements in the permuted data (output
+        shape). If not provided, the operator will compute this data which may
+        cause a device-host synchronization (if using GPU). Thus, it is
+        recommended to supply this value to avoid such the synchronization.
+
+Returns:
+    A tuple of permuted lengths, permuted indices and permuted weights
+
+**Example:**
+
+    >>> permute = torch.tensor([1, 0, 2], dtype=torch.int32, device="cuda")
+    >>> lengths = torch.tensor([[2, 3, 4, 5], [1, 2, 4, 8], [0, 3, 2, 3]], dtype=torch.int64, device="cuda")
+    >>> values = torch.randint(low=0, high=100, size=(lengths.sum().item(),), dtype=torch.int64, device="cuda")
+    >>> print(values)
+    tensor([29, 12, 61, 98, 56, 94,  5, 89, 65, 48, 71, 54, 40, 33, 78, 68, 42, 21,
+            60, 51, 15, 47, 48, 68, 52, 19, 38, 30, 38, 97, 97, 98, 18, 40, 42, 89,
+            66], device='cuda:0')
+    >>> torch.ops.fbgemm.permute_2D_sparse_data(permute, lengths, values)
+    (tensor([[1, 2, 4, 8],
+             [2, 3, 4, 5],
+             [0, 3, 2, 3]], device='cuda:0'),
+     tensor([78, 68, 42, 21, 60, 51, 15, 47, 48, 68, 52, 19, 38, 30, 38, 29, 12, 61,
+             98, 56, 94,  5, 89, 65, 48, 71, 54, 40, 33, 97, 97, 98, 18, 40, 42, 89,
+             66], device='cuda:0'),
+     None)
+    """,
+)
+
+add_docs(
+    torch.ops.fbgemm.permute_1D_sparse_data,
+    """
+permute_1D_sparse_data(permute, lengths, values, weights=None, permuted_lengths_sum=None) -> Tuple[Tensor, Tensor, Optional[Tensor]]
+
+Permute 1D sparse data. Note that 1D referrs to the number of dense dimensions.
+The input data is actually 2D where the first dimension is dense and the second
+dimension is jagged (sparse).  The data to permute over can be less or more and
+withh or without repetitions.
+
+Args:
+    permute (Tensor): A 1D-tensor that describes how data is permuted along dim
+        0. `permute[i]` indicates that data at position `permute[i]` is moved
+        to position `i`. The length of this tensor is the total amount of data
+        in dim 0 to be permuted. The values in `permute` must be >= 0 and <
+        `lengths.numel()`
+
+    lengths (Tensor): A 1D-tensor that contains jagged shapes corresponding to
+        the other dense dimension. `lengths[i]` represents the jagged shape of
+        data at position `i` in dim 0
+
+    values (Tensor): A 1D-input-tensor to be permuted. The length of this
+        tensor must be equal to `lengths.sum()`. This tensor can be of any data
+        type.
+
+    weights (Optional[Tensor] = None): An optional 1D-float-tensor. It must
+        have the same length as `values`. It will be permuted the same way as
+        values
+
+    permuted_lengths_sum (Optional[int] = None): An optional value that
+        represents the total number of elements in the permuted data (output
+        shape). If not provided, the operator will compute this data which may
+        cause a device-host synchronization (if using GPU). Thus, it is
+        recommended to supply this value to avoid such the synchronization.
+
+Returns:
+    A tuple of permuted lengths, permuted indices and permuted weights
+
+**Example:**
+    >>> permute = torch.tensor([1, 0, 3, 0], dtype=torch.int32, device="cuda")
+    >>> lengths = torch.tensor([2, 3, 4, 5], dtype=torch.int64, device="cuda")
+    >>> values = torch.randint(low=0, high=100, size=(lengths.sum().item(),), dtype=torch.int64, device="cuda")
+    >>> print(values)
+    tensor([ 1, 76, 24, 84, 94, 25, 15, 23, 31, 46,  9, 23, 34,  3],
+           device='cuda:0')
+    >>> torch.ops.fbgemm.permute_1D_sparse_data(permute, lengths, values)
+    (tensor([3, 2, 5, 2], device='cuda:0'),
+     tensor([24, 84, 94,  1, 76, 46,  9, 23, 34,  3,  1, 76], device='cuda:0'),
+     None)
+    """,
+)

--- a/fbgemm_gpu/fbgemm_gpu/permute_pooled_embedding_modules.py
+++ b/fbgemm_gpu/fbgemm_gpu/permute_pooled_embedding_modules.py
@@ -27,6 +27,70 @@ except Exception:
 
 
 class PermutePooledEmbeddings:
+    """
+    A module for permuting embedding outputs along the feature dimension
+
+    An embedding output tensor contains the embedding outputs for all features
+    in a batch. It is represented in a 2D format, where the rows are the batch
+    size dimension and the columns are the feature * embedding dimension.
+    Permuting along the feature dimension is essentially permuting along the
+    second dimension (dim 1).
+
+    **Example:**
+
+        >>> import torch
+        >>> import fbgemm_gpu
+        >>> from fbgemm_gpu.permute_pooled_embedding_modules import PermutePooledEmbeddings
+        >>>
+        >>> # Suppose batch size = 3 and there are 3 features
+        >>> batch_size = 3
+        >>>
+        >>> # Embedding dimensions for each feature
+        >>> embs_dims = torch.tensor([4, 4, 8], dtype=torch.int64, device="cuda")
+        >>>
+        >>> # Permute list, i.e., move feature 2 to position 0, move feature 0
+        >>> # to position 1, so on
+        >>> permute = [2, 0, 1]
+        >>>
+        >>> # Instantiate the module
+        >>> perm = PermutePooledEmbeddings(embs_dims, permute)
+        >>>
+        >>> # Generate an example input
+        >>> pooled_embs = torch.arange(
+        >>>     embs_dims.sum().item() * batch_size,
+        >>>     dtype=torch.float32, device="cuda"
+        >>> ).reshape(batch_size, -1)
+        >>> print(pooled_embs)
+        >>>
+        tensor([[ 0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10., 11., 12., 13.,
+                 14., 15.],
+                [16., 17., 18., 19., 20., 21., 22., 23., 24., 25., 26., 27., 28., 29.,
+                 30., 31.],
+                [32., 33., 34., 35., 36., 37., 38., 39., 40., 41., 42., 43., 44., 45.,
+                 46., 47.]], device='cuda:0')
+        >>>
+        >>> # Invoke
+        >>> perm(pooled_embs)
+        >>>
+        tensor([[ 8.,  9., 10., 11., 12., 13., 14., 15.,  0.,  1.,  2.,  3.,  4.,  5.,
+                  6.,  7.],
+                [24., 25., 26., 27., 28., 29., 30., 31., 16., 17., 18., 19., 20., 21.,
+                 22., 23.],
+                [40., 41., 42., 43., 44., 45., 46., 47., 32., 33., 34., 35., 36., 37.,
+                 38., 39.]], device='cuda:0')
+
+    Args:
+        embs_dims (List[int]): A list of embedding dimensions for all features.
+            Length = the number of features
+
+        permute (List[int]): A list that describes how each feature is
+            permuted. `permute[i]` is to permute feature `permute[i]` to
+            position `i`.
+
+        device (Optional[torch.device] = None): The device to run this module
+            on
+    """
+
     def __init__(
         self,
         embs_dims: List[int],
@@ -56,6 +120,18 @@ class PermutePooledEmbeddings:
         )
 
     def __call__(self, pooled_embs: torch.Tensor) -> torch.Tensor:
+        """
+        Performs pooled embedding output permutation along the feature dimension
+
+        Args:
+            pooled_embs (Tensor): The embedding outputs to permute. Shape is
+                `(B_local, total_global_D)`, where `B_local` = a local batch
+                size and `total_global_D` is the total embedding dimension
+                across all features (global)
+
+        Returns:
+            Permuted embedding outputs (Tensor). Same shape as `pooled_embs`
+        """
         result = torch.ops.fbgemm.permute_pooled_embs_auto_grad(
             pooled_embs,
             self._offset_dim_list.to(device=pooled_embs.device),


### PR DESCRIPTION
Add a docstring for

- torch.ops.fbgemm.expand_into_jagged_permute
- torch.ops.fbgemm.asynchronous_complete_cumsum
- torch.ops.fbgemm.offsets_range