### PR TITLE
Allow bounds_check_mode to be set by environment variable

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -623,7 +623,10 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.uuid = str(uuid.uuid4())
         self.logging_table_name: str = self.get_table_name_for_logging(table_names)
         self.pooling_mode = pooling_mode
-        self.bounds_check_mode_int: int = bounds_check_mode.value
+        # If environment variable is set, it overwrites the default bounds check mode.
+        self.bounds_check_mode_int: int = int(
+            os.environ.get("FBGEMM_TBE_BOUNDS_CHECK_MODE", bounds_check_mode.value)
+        )
         self.weights_precision = weights_precision
         self.output_dtype: int = output_dtype.as_int()
         assert (


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/282

This very simple diff allows TBE's bounds_check_mode to be overwritten by the environment variable `FBGEMM_TBE_BOUNDS_CHECK_MODE`. When set to `3`, this will disable bounds checking.

Reviewed By: qchip

Differential Revision: D63549883
