### PR TITLE
Print TMA benchmark info to stderr

### DIFF
--- a/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
@@ -6,6 +6,7 @@
 
 # pyre-unsafe
 import logging
+import sys
 from typing import List, Optional, Tuple, Union
 
 import torch
@@ -874,10 +875,14 @@ HAS_TMA_DESC = "nv_tma_desc_type" in dir(tl)
 
 if HAS_TMA_DESC:
     print(
-        "TMA benchmarks will be running with experimental grid constant TMA descriptor."
+        "TMA benchmarks will be running with experimental grid constant TMA descriptor.",
+        file=sys.stderr,
     )
 else:
-    print("TMA benchmarks will be running without grid constant TMA descriptor.")
+    print(
+        "TMA benchmarks will be running without grid constant TMA descriptor.",
+        file=sys.stderr,
+    )
 
 
 class TmaAutoTuneHelper:


### PR DESCRIPTION
Summary: Printing warnings to stdout mucks up the output of various tools/benchmarks

Reviewed By: xuzhao9, htyu

Differential Revision: D63643615
