### PR TITLE
Remove IS_MSVC bool and build_host_info().compiler usage

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -105,7 +105,8 @@ def get_fbgemm_inline_avx2_srcs(msvc = False, buck = False):
     asm_srcs = ["src/FbgemmFP16UKernelsAvx2.cc"]
     if buck:
         return select({
-            "DEFAULT": asm_srcs if not msvc else intrinsics_srcs,
+            "DEFAULT": asm_srcs,
+            "ovr_config//compiler:cl": intrinsics_srcs,
             "ovr_config//cpu:arm64": intrinsics_srcs,
         })
     return asm_srcs if not msvc else intrinsics_srcs
@@ -135,7 +136,8 @@ def get_fbgemm_inline_avx512_srcs(msvc = False, buck = False):
     ]
     if buck:
         return select({
-            "DEFAULT": asm_srcs if not msvc else intrinsics_srcs,
+            "DEFAULT": asm_srcs,
+            "ovr_config//compiler:cl": intrinsics_srcs,
             "ovr_config//cpu:arm64": intrinsics_srcs,
         })
     return asm_srcs if not msvc else intrinsics_srcs


### PR DESCRIPTION
Summary:
`build_host_info()` checks come from buck1, as in buck1 we didn't have a concept of a 'host select()', whereas on buck2 it is preferred to use `select()` after doing a proper configuration transition to the execution platform.

Replace the call to `build_host_info().compiler` here with a select(). Note we still retain function arguments like `msvc` and `buck` as these are apparently used in the CMake build flow.

Differential Revision: D63710016
