### PR TITLE
Add support for int64_t indices and offsets in TBE inference [7C/N]

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_lookup.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_lookup.cu
@@ -14,14 +14,14 @@ using Tensor = at::Tensor;
 
 namespace nbit {
 
-template <typename index_t>
+template <typename index_t, typename hash_t>
 __global__
 __launch_bounds__(kMaxThreads) void int_nbit_split_embedding_codegen_forward_pruned_hashmap_lookup_kernel(
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         indices,
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         offsets,
-    const pta::PackedTensorAccessor64<index_t, 2, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor64<hash_t, 2, at::RestrictPtrTraits>
         hash_table,
     const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         hash_table_offsets,
@@ -52,8 +52,12 @@ __launch_bounds__(kMaxThreads) void int_nbit_split_embedding_codegen_forward_pru
     return;
   }
 
-  using hash_t =
+  using uidx_t =
       std::conditional_t<std::is_same_v<index_t, int64_t>, uint64_t, uint32_t>;
+
+  // Use nv type of size (hash_t x 2)
+  using nv_hash_t =
+      std::conditional_t<std::is_same_v<hash_t, int64_t>, longlong2, int2>;
 
   const uint32_t subwarp_id = threadIdx.x / 4;
   const uint32_t subwarp_tid = threadIdx.x % 4;
@@ -66,15 +70,15 @@ __launch_bounds__(kMaxThreads) void int_nbit_split_embedding_codegen_forward_pru
   for (int32_t l_start = 0; l_start + subwarp_id < L;
        l_start += kWarpSize / 4) {
     const index_t idx = indices[indices_start + l_start + subwarp_id];
-    hash_t slot_start =
-        pruned_hash_function(static_cast<hash_t>(idx)) % capacity;
+    auto slot_start = pruned_hash_function(static_cast<uidx_t>(idx)) % capacity;
 
     while (true) {
-      const hash_t slot = (slot_start + subwarp_tid) % capacity;
-      const int2 val = *reinterpret_cast<const int2*>(
+      const auto slot = (slot_start + subwarp_tid) % capacity;
+
+      const nv_hash_t val = *reinterpret_cast<const nv_hash_t*>(
           &hash_table[table_start + static_cast<int64_t>(slot)][0]);
-      const int32_t slot_sparse_idx = val.x;
-      const int32_t slot_dense_idx = val.y;
+      const auto slot_sparse_idx = val.x;
+      const auto slot_dense_idx = val.y;
 
       bool found = false;
       bool empty = false;
@@ -96,14 +100,14 @@ __launch_bounds__(kMaxThreads) void int_nbit_split_embedding_codegen_forward_pru
   }
 }
 
-template <typename index_t>
+template <typename index_t, typename hash_t>
 __global__
 __launch_bounds__(kMaxThreads) void int_nbit_split_embedding_codegen_forward_pruned_array_lookup_kernel(
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         indices,
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         offsets,
-    const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor32<hash_t, 1, at::RestrictPtrTraits>
         index_remappings,
     const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         index_remappings_offsets,
@@ -129,7 +133,7 @@ __launch_bounds__(kMaxThreads) void int_nbit_split_embedding_codegen_forward_pru
     for (index_t l = threadIdx.x; l < L; l += blockDim.x) {
       index_t idx = indices[indices_start + l];
       dense_indices[indices_start + l] =
-          index_remappings[index_remappings_start + idx];
+          static_cast<index_t>(index_remappings[index_remappings_start + idx]);
     }
   } else {
     for (index_t l = threadIdx.x; l < L; l += blockDim.x) {
@@ -149,7 +153,7 @@ Tensor pruned_hashmap_lookup_cuda(
     Tensor hash_table_offsets) {
   TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
       indices, offsets, hash_table, hash_table_offsets);
-  TENSORS_HAVE_SAME_SCALAR_TYPE(indices, offsets, hash_table);
+  TENSORS_HAVE_SAME_SCALAR_TYPE(indices, offsets);
 
   CUDA_DEVICE_GUARD(indices);
 
@@ -160,25 +164,32 @@ Tensor pruned_hashmap_lookup_cuda(
   TORCH_CHECK(hash_table.size(0) < std::numeric_limits<int32_t>::max());
   constexpr size_t kForwardMaxThreads = 256;
 
-  AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "pruned_hashmap_lookup_cuda", [&] {
+  AT_DISPATCH_INDEX_TYPES(
+      hash_table.scalar_type(), "pruned_hashmap_lookup_cuda_0", [&] {
+        using hash_t = index_t;
+
+        AT_DISPATCH_INDEX_TYPES(
+            indices.scalar_type(), "pruned_hashmap_lookup_cuda_1", [&] {
 #ifdef FBGEMM_GPU_MEMCHECK
-    const auto func_name =
-        "int_nbit_split_embedding_codegen_forward_pruned_hashmap_lookup_kernel";
+              const auto func_name =
+                  "int_nbit_split_embedding_codegen_forward_pruned_hashmap_lookup_kernel";
 #endif
 
-    int_nbit_split_embedding_codegen_forward_pruned_hashmap_lookup_kernel<<<
-        nbit::div_round_up(B * T + 1, kForwardMaxThreads / kWarpSize),
-        dim3(kWarpSize, kForwardMaxThreads / kWarpSize),
-        0,
-        at::cuda::getCurrentCUDAStream()>>>(
-        MAKE_PTA_WITH_NAME(func_name, indices, index_t, 1, 32),
-        MAKE_PTA_WITH_NAME(func_name, offsets, index_t, 1, 32),
-        MAKE_PTA_WITH_NAME(func_name, hash_table, index_t, 2, 64),
-        MAKE_PTA_WITH_NAME(func_name, hash_table_offsets, int64_t, 1, 32),
-        B,
-        T,
-        MAKE_PTA_WITH_NAME(func_name, dense_indices, index_t, 1, 32));
-  });
+              int_nbit_split_embedding_codegen_forward_pruned_hashmap_lookup_kernel<<<
+                  nbit::div_round_up(B * T + 1, kForwardMaxThreads / kWarpSize),
+                  dim3(kWarpSize, kForwardMaxThreads / kWarpSize),
+                  0,
+                  at::cuda::getCurrentCUDAStream()>>>(
+                  MAKE_PTA_WITH_NAME(func_name, indices, index_t, 1, 32),
+                  MAKE_PTA_WITH_NAME(func_name, offsets, index_t, 1, 32),
+                  MAKE_PTA_WITH_NAME(func_name, hash_table, hash_t, 2, 64),
+                  MAKE_PTA_WITH_NAME(
+                      func_name, hash_table_offsets, int64_t, 1, 32),
+                  B,
+                  T,
+                  MAKE_PTA_WITH_NAME(func_name, dense_indices, index_t, 1, 32));
+            });
+      });
 
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return dense_indices;
@@ -191,7 +202,7 @@ Tensor pruned_array_lookup_cuda(
     Tensor index_remappings_offsets) {
   TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
       indices, offsets, index_remappings, index_remappings_offsets);
-  TENSORS_HAVE_SAME_SCALAR_TYPE(indices, offsets, index_remappings);
+  TENSORS_HAVE_SAME_SCALAR_TYPE(indices, offsets);
 
   CUDA_DEVICE_GUARD(indices);
 
@@ -218,25 +229,34 @@ Tensor pruned_array_lookup_cuda(
   TORCH_CHECK(dense_indices.dim() == 1, "Tensor dim: ", dense_indices.dim());
   constexpr size_t kForwardMaxThreads = 256;
 
-  AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "pruned_array_lookup_cuda", [&] {
+  AT_DISPATCH_INDEX_TYPES(
+      index_remappings.scalar_type(), "pruned_array_lookup_cuda_0", [&] {
+        using hash_t = index_t;
+
+        AT_DISPATCH_INDEX_TYPES(
+            indices.scalar_type(), "pruned_array_lookup_cuda_1", [&] {
 #ifdef FBGEMM_GPU_MEMCHECK
-    const auto func_name =
-        "int_nbit_split_embedding_codegen_forward_pruned_array_lookup_kernel";
+              const auto func_name =
+                  "int_nbit_split_embedding_codegen_forward_pruned_array_lookup_kernel";
 #endif
 
-    int_nbit_split_embedding_codegen_forward_pruned_array_lookup_kernel<<<
-        nbit::div_round_up(offsets.size(0), kForwardMaxThreads / kWarpSize),
-        dim3(kWarpSize, kForwardMaxThreads / kWarpSize),
-        0,
-        at::cuda::getCurrentCUDAStream()>>>(
-        MAKE_PTA_WITH_NAME(func_name, indices, index_t, 1, 32),
-        MAKE_PTA_WITH_NAME(func_name, offsets, index_t, 1, 32),
-        MAKE_PTA_WITH_NAME(func_name, index_remappings, index_t, 1, 32),
-        MAKE_PTA_WITH_NAME(func_name, index_remappings_offsets, int64_t, 1, 32),
-        B,
-        T,
-        MAKE_PTA_WITH_NAME(func_name, dense_indices, index_t, 1, 32));
-  });
+              int_nbit_split_embedding_codegen_forward_pruned_array_lookup_kernel<<<
+                  nbit::div_round_up(
+                      offsets.size(0), kForwardMaxThreads / kWarpSize),
+                  dim3(kWarpSize, kForwardMaxThreads / kWarpSize),
+                  0,
+                  at::cuda::getCurrentCUDAStream()>>>(
+                  MAKE_PTA_WITH_NAME(func_name, indices, index_t, 1, 32),
+                  MAKE_PTA_WITH_NAME(func_name, offsets, index_t, 1, 32),
+                  MAKE_PTA_WITH_NAME(
+                      func_name, index_remappings, hash_t, 1, 32),
+                  MAKE_PTA_WITH_NAME(
+                      func_name, index_remappings_offsets, int64_t, 1, 32),
+                  B,
+                  T,
+                  MAKE_PTA_WITH_NAME(func_name, dense_indices, index_t, 1, 32));
+            });
+      });
 
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return dense_indices;

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_autovec_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_autovec_test.py
@@ -87,7 +87,7 @@ additional_decorators: Dict[str, List[Callable]] = {
 
 
 # @optests.generate_opcheck_tests(fast=True, additional_decorators=additional_decorators)
-class NBitFowardTest(unittest.TestCase):
+class NBitFowardAutovecTest(unittest.TestCase):
     def execute_nbit_forward_(  # noqa C901
         self,
         T: int,

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -122,6 +122,11 @@ additional_decorators: Dict[str, List[Callable]] = {
             "Operator outputs int4 tensors which do not support opcheck tests"
         ),
     },
+    "test_pt2_compliant_tag_fbgemm_int_nbit_split_embedding_codegen_lookup_function": [
+        unittest.skip(
+            "Operator outputs int4 tensors which do not support opcheck tests"
+        ),
+    ],
 }
 
 

--- a/fbgemm_gpu/test/tbe/inference/nbit_split_embeddings_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_split_embeddings_test.py
@@ -11,6 +11,7 @@
 
 import random
 import unittest
+from typing import Callable, Dict, List
 
 import hypothesis.strategies as st
 import numpy as np
@@ -38,8 +39,22 @@ else:
 
 VERBOSITY: Verbosity = Verbosity.verbose
 
+# pyre-ignore
+additional_decorators: Dict[str, List[Callable]] = {
+    "test_faketensor__test_nbit_forward_cpu_seq_int4": {
+        unittest.skip(
+            "Operator outputs int4 tensors which do not support opcheck tests"
+        ),
+    },
+    "test_pt2_compliant_tag_fbgemm_int_nbit_split_embedding_codegen_lookup_function": {
+        unittest.skip(
+            "Operator outputs int4 tensors which do not support opcheck tests"
+        ),
+    },
+}
 
-@optests.generate_opcheck_tests(fast=True)
+
+@optests.generate_opcheck_tests(fast=True, additional_decorators=additional_decorators)
 class NBitSplitEmbeddingsTest(unittest.TestCase):
     @unittest.skipIf(*gpu_unavailable)
     @given(

--- a/fbgemm_gpu/test/tbe/utils/split_embeddings_utils_test.py
+++ b/fbgemm_gpu/test/tbe/utils/split_embeddings_utils_test.py
@@ -469,7 +469,7 @@ class SplitEmbeddingsUtilsTest(unittest.TestCase):
         # Initialize and insert Hashmap index remapping based data structure
         hash_table = torch.empty(
             (sum(capacities), 2),
-            dtype=torch.int32,
+            dtype=torch.int64,
         )
         hash_table[:, :] = -1
         hash_table_offsets = torch.tensor([0] + np.cumsum(capacities).tolist()).long()
@@ -486,7 +486,7 @@ class SplitEmbeddingsUtilsTest(unittest.TestCase):
         # Initialize and insert Array index remapping based data structure
         index_remappings_array = torch.tensor(
             [-1] * original_E * T,
-            dtype=torch.int32,
+            dtype=torch.int64,
             device=current_device,
         )
         index_remappings_array_offsets = torch.empty(
@@ -498,7 +498,7 @@ class SplitEmbeddingsUtilsTest(unittest.TestCase):
         for t in range(T):
             indice_t = (indices.view(T, B, L))[t].long().view(-1).to(current_device)
             dense_indice_t = (
-                (dense_indices.view(T, B, L))[t].view(-1).to(current_device)
+                (dense_indices.view(T, B, L))[t].long().view(-1).to(current_device)
             )
             selected_indices = torch.add(indice_t, t * original_E)[:E]
             index_remappings_array[selected_indices] = dense_indice_t


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/312

- Default `index_remapping` in `pruned_array_lookup` to be `int64_t`, since they are set up before `indices` and `offsets` are passed in

Differential Revision: D63778645


