### PR TITLE
Allow N-D inputs to triton fp8 row quantize

### DIFF
--- a/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
@@ -2128,9 +2128,10 @@ def quantize_fp8_row_meta(
     """Shape function for torch compile."""
     if output_device is None:
         output_device = a.device
-    M, K = a.shape
+    # Flatten to 2D since each row of each potential batch gets a scale.
+    M = a.view(-1, a.shape[-1]).shape[0]
     dtype = get_fp8_constants()[0]
-    fake_out = torch.empty((M, K), device=output_device, dtype=dtype)
+    fake_out = torch.empty(a.shape, device=output_device, dtype=dtype)
     fake_scale = torch.empty((M), device=output_device, dtype=torch.float32)
     return fake_out, fake_scale
 


### PR DESCRIPTION
Summary: We previously assumed inputs to fp8 quantize would be 2D, however we now are working with higher dimension workloads that would benefit from FP8. This small diff adds more general shape checking to fp8 quantization.

Differential Revision: D63921964


