### PR TITLE
Add `iter` singular value into TBE optimizer state

### DIFF
--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_global_weight_decay_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_global_weight_decay_test.py
@@ -331,8 +331,8 @@ def execute_global_weight_decay(  # noqa C901
                     gwd_lower_bound,
                 )
             if i != 1:
-                tbe.step = i - 1  # step will be incremented when forward is called
-                tbe.iter = torch.Tensor([tbe.step])
+                tbe.iter_int = i - 1  # step will be incremented when forward is called
+                tbe.iter = torch.Tensor([tbe.iter_int])
 
             # Run forward pass
             output = tbe(


### PR DESCRIPTION
Summary:
When the optimizer states for sharded embedding tables are tracked in TorchRec, they are assumed to be either point-wise (same shape as the embedding table, for example, Adam's exp_avg), or row-wise (same length as the embedding hashsize, for example, rowwise_adagrad's momentum/sum). However, there may be other formats, a single value for each table. Specifically, for Adam/Partial_rowwise_adam/Lamb/Partial_rowwise_lamb and GWD, the `iter` number is a single value tensor, which **cannot be tracked and checkpointed properly** (this also means that there is a bug in Adam/Partial_rowwise_adam/Lamb/Partial_rowwise_lamb usages!)

Here we support tracking and checkpointing single-value states, by constructing ShardMetadata with rowwise-sharding and replicating the single-value for each Sharded param (this is similar to how the rowwise state for colume-wise sharded tables are concatenated along row-dim).

By doing so, single-value `iter` can be properly checkpointed just like other states, ensuring correct reloading of states and continuous training.

Differential Revision: D63909559


