### PR TITLE
Add support for int64_t indices and offsets in TBE inference [8/N]

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_lookup.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_lookup.cu
@@ -100,14 +100,14 @@ __launch_bounds__(kMaxThreads) void int_nbit_split_embedding_codegen_forward_pru
   }
 }
 
-template <typename index_t, typename hash_t>
+template <typename index_t, typename remap_t>
 __global__
 __launch_bounds__(kMaxThreads) void int_nbit_split_embedding_codegen_forward_pruned_array_lookup_kernel(
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         indices,
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         offsets,
-    const pta::PackedTensorAccessor32<hash_t, 1, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor32<remap_t, 1, at::RestrictPtrTraits>
         index_remappings,
     const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         index_remappings_offsets,
@@ -231,7 +231,7 @@ Tensor pruned_array_lookup_cuda(
 
   AT_DISPATCH_INDEX_TYPES(
       index_remappings.scalar_type(), "pruned_array_lookup_cuda_0", [&] {
-        using hash_t = index_t;
+        using remap_t = index_t;
 
         AT_DISPATCH_INDEX_TYPES(
             indices.scalar_type(), "pruned_array_lookup_cuda_1", [&] {
@@ -249,7 +249,7 @@ Tensor pruned_array_lookup_cuda(
                   MAKE_PTA_WITH_NAME(func_name, indices, index_t, 1, 32),
                   MAKE_PTA_WITH_NAME(func_name, offsets, index_t, 1, 32),
                   MAKE_PTA_WITH_NAME(
-                      func_name, index_remappings, hash_t, 1, 32),
+                      func_name, index_remappings, remap_t, 1, 32),
                   MAKE_PTA_WITH_NAME(
                       func_name, index_remappings_offsets, int64_t, 1, 32),
                   B,

--- a/fbgemm_gpu/test/tbe/inference/nbit_cache_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_cache_test.py
@@ -118,9 +118,12 @@ class NBitCacheTest(unittest.TestCase):
         self.assertEqual(total_access_count, expected_total_access)
 
     @unittest.skipIf(*gpu_unavailable)
-    @given(N=st.integers(min_value=1, max_value=8))
+    @given(
+        N=st.integers(min_value=1, max_value=8),
+        indices_dtype=st.sampled_from([torch.int, torch.long]),
+    )
     @settings(verbosity=VERBOSITY, max_examples=MAX_EXAMPLES, deadline=None)
-    def test_nbit_cache_miss_counter(self, N: int) -> None:
+    def test_nbit_cache_miss_counter(self, N: int, indices_dtype: torch.dtype) -> None:
         # Create an abstract split table
         D = 8
         T = 2
@@ -156,7 +159,7 @@ class NBitCacheTest(unittest.TestCase):
         ):
             (indices, offsets) = get_table_batched_offsets_from_dense(x, use_cpu=False)
             for _ in range(N):
-                cc(indices.int(), offsets.int())
+                cc(indices.to(dtype=indices_dtype), offsets.to(dtype=indices_dtype))
                 (
                     cache_miss_forward_count,
                     unique_cache_miss_count,
@@ -173,9 +176,12 @@ class NBitCacheTest(unittest.TestCase):
     @given(
         N=st.integers(min_value=1, max_value=8),
         dtype=st.sampled_from([SparseType.INT8, SparseType.INT4, SparseType.INT2]),
+        indices_dtype=st.sampled_from([torch.int, torch.long]),
     )
     @settings(verbosity=VERBOSITY, max_examples=MAX_EXAMPLES, deadline=None)
-    def test_nbit_uvm_cache_stats(self, N: int, dtype: SparseType) -> None:
+    def test_nbit_uvm_cache_stats(
+        self, N: int, dtype: SparseType, indices_dtype: torch.dtype
+    ) -> None:
         # Create an abstract split table
         D = 8
         T = 2
@@ -215,7 +221,7 @@ class NBitCacheTest(unittest.TestCase):
             for _ in range(N):
                 num_calls_expected = num_calls_expected + 1
                 num_indices_expcted = num_indices_expcted + len(indices)
-                cc(indices.int(), offsets.int())
+                cc(indices.to(dtype=indices_dtype), offsets.to(dtype=indices_dtype))
                 (
                     num_calls,
                     num_indices,
@@ -271,7 +277,7 @@ class NBitCacheTest(unittest.TestCase):
         for x, e in zip((indices1, indices2, indices3), expected):
             (indices, offsets) = get_table_batched_offsets_from_dense(x, use_cpu=False)
             for _ in range(N):
-                cc1(indices.int(), offsets.int())
+                cc1(indices.to(dtype=indices_dtype), offsets.to(dtype=indices_dtype))
                 (
                     _,
                     _,
@@ -288,10 +294,11 @@ class NBitCacheTest(unittest.TestCase):
     @given(
         N=st.integers(min_value=1, max_value=8),
         dtype=st.sampled_from([SparseType.INT8, SparseType.INT4, SparseType.INT2]),
+        indices_dtype=st.sampled_from([torch.int, torch.long]),
     )
     @settings(verbosity=VERBOSITY, max_examples=MAX_EXAMPLES, deadline=None)
     def test_nbit_direct_mapped_uvm_cache_stats(
-        self, N: int, dtype: SparseType
+        self, N: int, dtype: SparseType, indices_dtype: torch.dtype
     ) -> None:
         # Create an abstract split table
         D = 8
@@ -333,7 +340,7 @@ class NBitCacheTest(unittest.TestCase):
             for _ in range(N):
                 num_calls_expected = num_calls_expected + 1
                 num_indices_expcted = num_indices_expcted + len(indices)
-                cc(indices.int(), offsets.int())
+                cc(indices.to(dtype=indices_dtype), offsets.to(dtype=indices_dtype))
                 (
                     num_calls,
                     num_indices,
@@ -393,7 +400,7 @@ class NBitCacheTest(unittest.TestCase):
         for x, e in zip((indices1, indices2, indices3), expected):
             (indices, offsets) = get_table_batched_offsets_from_dense(x, use_cpu=False)
             for _ in range(N):
-                cc1(indices.int(), offsets.int())
+                cc1(indices.to(dtype=indices_dtype), offsets.to(dtype=indices_dtype))
                 (
                     _,
                     _,

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_autovec_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_autovec_test.py
@@ -105,6 +105,7 @@ class NBitFowardAutovecTest(unittest.TestCase):
         use_array_for_index_remapping: bool,
         do_pruning: bool,
         mixed_weights_ty: bool,
+        indices_dtype: torch.dtype,
         output_dtype: SparseType,
     ) -> None:
         # NOTE: weighted operation can be done only for SUM.
@@ -311,19 +312,22 @@ class NBitFowardAutovecTest(unittest.TestCase):
                 fp8_config=fp8_config if has_fp8_weight else None,
             )
 
+        indices = indices.to(dtype=indices_dtype)
+        offsets = offsets.to(dtype=indices_dtype)
+
         if not use_cpu:
             fc2 = (
-                cc(indices.int(), offsets.int())
+                cc(indices, offsets)
                 if not weighted
-                else cc(indices.int(), offsets.int(), xw.contiguous().view(-1))
+                else cc(indices, offsets, xw.contiguous().view(-1))
             )
         else:
             cc = cc.cpu()
             indices, offsets = indices.cpu(), offsets.cpu()
             fc2 = (
-                cc(indices.int(), offsets.int())
+                cc(indices, offsets)
                 if not weighted
-                else cc(indices.int(), offsets.int(), xw.contiguous().view(-1).cpu())
+                else cc(indices, offsets, xw.contiguous().view(-1).cpu())
             )
 
         if do_pooling and B == 0:
@@ -373,6 +377,7 @@ class NBitFowardAutovecTest(unittest.TestCase):
         pooling_mode=st.sampled_from(
             [PoolingMode.SUM, PoolingMode.MEAN, PoolingMode.NONE]
         ),
+        indices_dtype=st.sampled_from([torch.int32, torch.int64]),
         output_dtype=st.sampled_from(
             [SparseType.FP32, SparseType.FP16, SparseType.BF16]
         ),
@@ -386,6 +391,7 @@ class NBitFowardAutovecTest(unittest.TestCase):
         self,
         nbit_weights_ty: Optional[SparseType],
         pooling_mode: PoolingMode,
+        indices_dtype: torch.dtype,
         output_dtype: SparseType,
     ) -> None:
         use_cpu = True
@@ -432,6 +438,7 @@ class NBitFowardAutovecTest(unittest.TestCase):
             False,
             False,
             mixed_weights_ty,
+            indices_dtype,
             output_dtype,
         )
 

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -332,6 +332,7 @@ class NBitFowardTest(unittest.TestCase):
         use_array_for_index_remapping: bool,
         do_pruning: bool,
         mixed_weights_ty: bool,
+        indices_dtype: torch.dtype,
         output_dtype: SparseType,
     ) -> None:
         # NOTE: weighted operation can be done only for SUM.
@@ -360,8 +361,14 @@ class NBitFowardTest(unittest.TestCase):
                         SparseType.FP8,
                         SparseType.INT8,
                         SparseType.INT4,
-                        SparseType.INT2,
                     ]
+                    + (
+                        [
+                            SparseType.INT2,
+                        ]
+                        if output_dtype != SparseType.FP32
+                        else []
+                    )
                 )
                 for _ in range(T)
             ]
@@ -538,19 +545,22 @@ class NBitFowardTest(unittest.TestCase):
                 fp8_config=fp8_config if has_fp8_weight else None,
             )
 
+        indices = indices.to(dtype=indices_dtype)
+        offsets = offsets.to(dtype=indices_dtype)
+
         if not use_cpu:
             fc2 = (
-                cc(indices.int(), offsets.int())
+                cc(indices, offsets)
                 if not weighted
-                else cc(indices.int(), offsets.int(), xw.contiguous().view(-1))
+                else cc(indices, offsets, xw.contiguous().view(-1))
             )
         else:
             cc = cc.cpu()
             indices, offsets = indices.cpu(), offsets.cpu()
             fc2 = (
-                cc(indices.int(), offsets.int())
+                cc(indices, offsets)
                 if not weighted
-                else cc(indices.int(), offsets.int(), xw.contiguous().view(-1).cpu())
+                else cc(indices, offsets, xw.contiguous().view(-1).cpu())
             )
 
         if do_pooling and B == 0:
@@ -594,6 +604,7 @@ class NBitFowardTest(unittest.TestCase):
             )
         else:
             fc2_float = fc2.float()
+
         torch.testing.assert_close(
             fc2_float.cpu(),
             f.float().cpu(),
@@ -608,6 +619,7 @@ class NBitFowardTest(unittest.TestCase):
         pooling_mode=st.sampled_from(
             [PoolingMode.SUM, PoolingMode.NONE, PoolingMode.MEAN]
         ),
+        indices_dtype=st.sampled_from([torch.int32, torch.int64]),
         output_dtype=st.sampled_from(
             [SparseType.FP32, SparseType.FP16, SparseType.BF16]
         ),
@@ -623,6 +635,7 @@ class NBitFowardTest(unittest.TestCase):
         use_array_for_index_remapping: bool,
         do_pruning: bool,
         pooling_mode: PoolingMode,
+        indices_dtype: torch.dtype,
         output_dtype: SparseType,
     ) -> None:
         use_cpu = True
@@ -666,11 +679,18 @@ class NBitFowardTest(unittest.TestCase):
             use_array_for_index_remapping,
             do_pruning,
             mixed_weights_ty,
+            indices_dtype,
             output_dtype,
         )
 
+    @given(
+        indices_dtype=st.sampled_from([torch.int32, torch.int64]),
+    )
+    @settings(deadline=None)
     @unittest.skipIf(*gpu_unavailable)
-    def test_nbit_forward_gpu_no_cache_fp8_2048(self) -> None:
+    def test_nbit_forward_gpu_no_cache_fp8_2048(
+        self, indices_dtype: torch.dtype
+    ) -> None:
         # Test the case of FB8 table with 128B*8 < D <= 128B*16
         self.execute_nbit_forward_(
             T=1,
@@ -688,6 +708,7 @@ class NBitFowardTest(unittest.TestCase):
             use_array_for_index_remapping=True,
             do_pruning=False,
             mixed_weights_ty=False,
+            indices_dtype=indices_dtype,
             output_dtype=SparseType.FP16,
         )
 
@@ -696,6 +717,8 @@ class NBitFowardTest(unittest.TestCase):
         nbit_weights_ty=get_nbit_weights_ty(),
         use_array_for_index_remapping=st.booleans(),
         do_pruning=st.booleans(),
+        indices_dtype=st.sampled_from([torch.int32, torch.int64]),
+        output_dtype=st.sampled_from([SparseType.FP32, SparseType.FP16]),
     )
     @settings(
         verbosity=VERBOSITY,
@@ -706,8 +729,25 @@ class NBitFowardTest(unittest.TestCase):
         self,
         nbit_weights_ty: Optional[SparseType],
         use_array_for_index_remapping: bool,
+        indices_dtype: torch.dtype,
         do_pruning: bool,
+        output_dtype: SparseType,
     ) -> None:
+        # NOTE: The combination of INT2 and FP32 as weight and output types, respectively, is
+        # currently not supported.
+        if nbit_weights_ty == SparseType.INT2 and output_dtype == SparseType.FP32:
+            self.skipTest(
+                "The combination of INT2 and FP32 as weight and output types, respectively, is not supported"
+            )
+
+        # NOTE: Hash-based index remapping in general is an experimental feature
+        if indices_dtype != torch.int32 and not use_array_for_index_remapping:
+            self.skipTest(
+                "Hash-based index_remapping is an experimental feature and is "
+                "currently not supported for indices.dtype == torch.int64 and "
+                "indices.device != cpu"
+            )
+
         use_cpu = False
         T = random.randint(1, 50)
         B = random.randint(0, 128)
@@ -742,9 +782,7 @@ class NBitFowardTest(unittest.TestCase):
         else:
             weights_ty: SparseType = nbit_weights_ty
             mixed_weights_ty = False
-        output_dtype = random.choice(
-            [SparseType.FP32, SparseType.FP16, SparseType.BF16]
-        )
+
         self.execute_nbit_forward_(
             T,
             D,
@@ -761,6 +799,7 @@ class NBitFowardTest(unittest.TestCase):
             use_array_for_index_remapping,
             do_pruning,
             mixed_weights_ty,
+            indices_dtype,
             output_dtype,
         )
 
@@ -983,6 +1022,7 @@ class NBitFowardTest(unittest.TestCase):
         T=st.integers(min_value=10, max_value=20),
         L=st.integers(min_value=10, max_value=100),
         MAXH=st.integers(min_value=50, max_value=100),
+        indices_dtype=st.sampled_from([torch.int32, torch.int64]),
     )
     @settings(
         verbosity=VERBOSITY,
@@ -996,6 +1036,7 @@ class NBitFowardTest(unittest.TestCase):
         T: int,
         L: int,
         MAXH: int,
+        indices_dtype: torch.dtype,
     ) -> None:
         """
         we init a quant table split embedding bag with int4 weights and scale of 1 and 0 bias
@@ -1017,6 +1058,7 @@ class NBitFowardTest(unittest.TestCase):
             use_array_for_index_remapping=True,
             do_pruning=False,
             mixed_weights_ty=False,
+            indices_dtype=indices_dtype,
             output_dtype=SparseType.INT4,
         )
 

--- a/fbgemm_gpu/test/tbe/inference/nbit_split_embeddings_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_split_embeddings_test.py
@@ -191,12 +191,14 @@ class NBitSplitEmbeddingsTest(unittest.TestCase):
             ]
         ),
         emulate_pruning=st.booleans(),
+        indices_dtype=st.sampled_from([torch.int, torch.int64]),
     )
     @settings(verbosity=VERBOSITY, max_examples=MAX_EXAMPLES, deadline=None)
     def test_int_nbit_split_embedding_uvm_caching_codegen_lookup_function(
         self,
         weights_ty: SparseType,
         emulate_pruning: bool,
+        indices_dtype: torch.dtype,
     ) -> None:
         # TODO: support direct-mapped in int_nbit_split_embedding_uvm_caching_codegen_lookup_function
         # This test is for int_nbit_split_embedding_uvm_caching_codegen_lookup_function.
@@ -260,8 +262,8 @@ class NBitSplitEmbeddingsTest(unittest.TestCase):
         )
         for req in requests:
             indices, offsets = req.unpack_2()
-            indices = indices.int()
-            offsets = offsets.int()
+            indices = indices.to(dtype=indices_dtype)
+            offsets = offsets.to(dtype=indices_dtype)
             output_ref = cc_ref(indices, offsets)
 
             # int_nbit_split_embedding_uvm_caching_codegen_lookup_function for UVM_CACHING.


### PR DESCRIPTION
Summary: - Update tests to use int64_t indices and offsets

Differential Revision: D63807049


