### PR TITLE
convert data type of indices and offsets in int_nbit_split_embedding_codegen_lookup_function

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_host.cpp
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_host.cpp
@@ -283,6 +283,9 @@ Tensor int_nbit_split_embedding_codegen_lookup_function(
     std::optional<int64_t> max_float8_D,
     std::optional<int64_t> fp8_exponent_bits,
     std::optional<int64_t> fp8_exponent_bias) {
+  if (offsets.scalar_type() != indices.scalar_type()) {
+    offsets = offsets.toType(indices.scalar_type());
+  }
   if (static_cast<PoolingMode>(pooling_mode) == PoolingMode::NONE) {
     std::vector<int64_t> max_D_list{
         max_int2_D,


### PR DESCRIPTION
Summary: The two tensor need to keep same dtype

Differential Revision: D64085749


