### PR TITLE
Add meta for FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/quantize_ops_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/quantize_ops_utils.h
@@ -130,4 +130,22 @@ inline int32_t nbit_elems_to_bytes(const at::Tensor& input) {
   }
 }
 
+inline at::SymInt nbit_elems_to_bytes_meta(const at::Tensor& input) {
+  const at::SymIntArrayRef input_sizes = input.sym_sizes();
+  const at::SymInt ncols = input_sizes[1];
+  // at::kQUInt4x2 is the dtype for quantized int4 tensors and at::kQUInt2x4 is
+  // for quantized int2 tensors. QUIntMxN (M*N=8) means quantized M-bit integer
+  // with each byte holding N such elements.
+  // input_sizes[1] is the number of elements in each row, so we need to divide
+  // it by 2 or 4 for quint4x2 or quint2x4 respectively to get the number of
+  // bytes in each row.
+  if (input.dtype() == at::kQUInt2x4) {
+    return (ncols + 4 - 1) / 4;
+  } else if (input.dtype() == at::kQUInt4x2) {
+    return (ncols + 2 - 1) / 2;
+  } else {
+    return ncols;
+  }
+}
+
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/quantize_ops/quantize_ops_meta.cpp
+++ b/fbgemm_gpu/src/quantize_ops/quantize_ops_meta.cpp
@@ -12,6 +12,7 @@
 
 #include "c10/core/ScalarType.h"
 #include "fbgemm_gpu/embedding_common.h"
+#include "fbgemm_gpu/quantize_ops_utils.h"
 #include "fbgemm_gpu/sparse_ops.h"
 
 using Tensor = at::Tensor;
@@ -66,6 +67,33 @@ Tensor FloatToFP8RowwiseQuantized_meta(const Tensor& input, bool forward) {
   return at::empty_symint(output_dims, input.options().dtype(at::kByte));
 }
 
+/// @ingroup quantize-data-meta
+///
+Tensor fusednbitrowwise_to_float_or_half_meta(
+    const Tensor& input,
+    const int64_t bit_rate,
+    const int64_t output_dtype) {
+  const at::SymIntArrayRef input_sizes = input.sym_sizes();
+  const at::SymInt nrows = input_sizes[0];
+  // Here we want the number of bytes in a row
+  const at::SymInt ncols = nbit_elems_to_bytes_meta(input);
+  const at::SymInt num_elem_per_byte = 8 / bit_rate;
+  const at::SymInt output_columns =
+      (ncols - 2 * sizeof(at::Half)) * num_elem_per_byte;
+
+  SparseType output_sparse_dtype = static_cast<SparseType>(output_dtype);
+  switch (output_sparse_dtype) {
+    case SparseType::FP32:
+      return at::empty_symint(
+          {nrows, output_columns}, input.options().dtype(at::kFloat));
+    case SparseType::FP16:
+      return at::empty_symint(
+          {nrows, output_columns}, input.options().dtype(at::kHalf));
+    default:
+      TORCH_CHECK(false, "Unsupported output dtype ");
+  }
+}
+
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
@@ -75,4 +103,7 @@ TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
   m.impl(
       "FloatToFP8RowwiseQuantized",
       TORCH_FN(fbgemm_gpu::FloatToFP8RowwiseQuantized_meta));
+  m.impl(
+      "FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf",
+      TORCH_FN(fbgemm_gpu::fusednbitrowwise_to_float_or_half_meta));
 }


### PR DESCRIPTION
Summary:
Fix error in Dynamo trace
torch._dynamo.exc.Unsupported: unsupported operator: FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf

Differential Revision: D64353491


