### PR TITLE
quantize functions: make export friendly

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -184,11 +184,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.impl("quantize_fp8_per_tensor", quantize_fp8_per_tensor);
   m.def(
       "quantize_fp8_per_row(Tensor input, Tensor? bs=None, Tensor? scale_ub=None, ScalarType? output_dtype=None, bool stochastic_rounding = False) -> Tensor[] ");
-  m.impl("quantize_fp8_per_row", quantize_fp8_per_row);
 
   m.def(
       "quantize_fp8_per_col(Tensor input, Tensor? bs=None, Tensor? scale_ub=None) -> Tensor[]");
-  m.impl("quantize_fp8_per_col", quantize_fp8_per_col);
 
   m.def(
       "get_fp8_per_tensor_scale(Tensor input, Tensor? bs=None, Tensor? scale_ub=None) -> Tensor");


### PR DESCRIPTION
Summary:
# Why

These functions right now fail when trying to export. Tracing tries to trace through the cuda implementation

# What

- remove the `m.impl` from the library (fragment) definition. This `m.impl` registers one function for everything, overwriting the `Meta` implementation below with canonical (in this case, `CUDA`) implementation
- add a unit test that exercises exporting with a model that just calls the quantize functions

Differential Revision: D64502332


