### PR TITLE
make `iter` PT2 compatible

### DIFF
--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_global_weight_decay_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_global_weight_decay_test.py
@@ -332,8 +332,10 @@ def execute_global_weight_decay(  # noqa C901
                     gwd_lower_bound,
                 )
             if i != 1:
-                tbe.iter_int = i - 1  # step will be incremented when forward is called
-                tbe.iter = torch.Tensor([tbe.iter_int])
+                tbe.iter_cpu.fill_(
+                    i - 1
+                )  # step will be incremented when forward is called
+                tbe.iter.fill_(i - 1)
 
             # Run forward pass
             output = tbe(


### PR DESCRIPTION
Summary: Use `int` and dynamic condition is not compatible with PT2 compile. Fixing it by using a cpu tensor and sync at the first forward. Need to wrap it with `is_torchdynamo_compiling`, PT2 happens at 3rd iteration according to Microve

Differential Revision: D64510142


