### PR TITLE
add torch._check in QuantizedCommCodec

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/quantize_comm.py
+++ b/fbgemm_gpu/fbgemm_gpu/quantize_comm.py
@@ -221,6 +221,7 @@ class QuantizedCommCodec:
             self._comm_precision == SparseType.FP8 and self._row_dim > 0
         ):
             ctx = none_throws(ctx)
+            torch._check(input_len % ctx.row_dim == 0)
             assert input_len % ctx.row_dim == 0, (
                 f"input_len {input_len} is not a multiple of row dim {ctx.row_dim} "
                 "Please check your batch size (power of 2 batch size is recommended)"


### PR DESCRIPTION
Summary:
# context
* to address the following [graph break](https://interncache-all.fbcdn.net/manifold/tlparse_reports/tree/logs/.tmpIJn896/failures_and_restarts.html)
```
Consider annotating your code using torch._check*(). Could not guard on data-dependent expression Eq(Mod(139156*u1573, 256), 0) (unhinted: Eq(Mod(139156*u1573, 256), 0)).  (Size-like symbols: u1573)

Caused by: assert input_len % ctx.row_dim == 0, (  # fbgemm_gpu/quantize_comm.py:224 in calc_quantized_size (_dynamo/variables/tensor.py:1167 in evaluate_expr)
For more information, run with TORCH_LOGS="dynamic"
For extended logs when we create symbols, also add TORCHDYNAMO_EXTENDED_DEBUG_CREATE_SYMBOL="u1573"
If you suspect the guard was triggered from C++, add TORCHDYNAMO_EXTENDED_DEBUG_CPP=1
For more debugging help, see https://docs.google.com/document/d/1HSuTTVvYH1pTew89Rtpeu84Ht3nQEFTYhAX3Ypa_xJs/edit?usp=sharing

User Stack (most recent call last):
  (snipped, see stack below for prefix)
  File "/data/users/hhy/fbsource/buck-out/v2/gen/fbcode/f315e3781b29ac13/aps_models/ads/icvr/__icvr_launcher_publish__/icvr_launcher_publish-inplace#link-tree/aps_models/ads/icvr/models/rc/ig_fm_interformer.py", line 1318, in forward
    embs_kt_list = self.sparse_arch(
  File "/data/users/hhy/fbsource/buck-out/v2/gen/fbcode/f315e3781b29ac13/aps_models/ads/icvr/__icvr_launcher_publish__/icvr_launcher_publish-inplace#link-tree/torch/nn/modules/module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/users/hhy/fbsource/buck-out/v2/gen/fbcode/f315e3781b29ac13/aps_models/ads/icvr/__icvr_launcher_publish__/icvr_launcher_publish-inplace#link-tree/apf/rec/modules/embedding_bag_collections_sparse_arch.py", line 359, in forward
    ret.append(self.ebc(id_list_features))
  File "/data/users/hhy/fbsource/buck-out/v2/gen/fbcode/f315e3781b29ac13/aps_models/ads/icvr/__icvr_launcher_publish__/icvr_launcher_publish-inplace#link-tree/torch/nn/modules/module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/users/hhy/fbsource/buck-out/v2/gen/fbcode/f315e3781b29ac13/aps_models/ads/icvr/__icvr_launcher_publish__/icvr_launcher_publish-inplace#link-tree/torchrec/distributed/types.py", line 940, in forward
    return self.compute_and_output_dist(ctx, dist_input)
  File "/data/users/hhy/fbsource/buck-out/v2/gen/fbcode/f315e3781b29ac13/aps_models/ads/icvr/__icvr_launcher_publish__/icvr_launcher_publish-inplace#link-tree/torchrec/distributed/embeddingbag.py", line 1254, in compute_and_output_dist
    awaitables.append(dist(embs, sharding_context))
  File "/data/users/hhy/fbsource/buck-out/v2/gen/fbcode/f315e3781b29ac13/aps_models/ads/icvr/__icvr_launcher_publish__/icvr_launcher_publish-inplace#link-tree/torch/nn/modules/module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/users/hhy/fbsource/buck-out/v2/gen/fbcode/f315e3781b29ac13/aps_models/ads/icvr/__icvr_launcher_publish__/icvr_launcher_publish-inplace#link-tree/torchrec/distributed/sharding/tw_sharding.py", line 360, in forward
    return cast(PooledEmbeddingsAllToAll, self._dist)(
  File "/data/users/hhy/fbsource/buck-out/v2/gen/fbcode/f315e3781b29ac13/aps_models/ads/icvr/__icvr_launcher_publish__/icvr_launcher_publish-inplace#link-tree/torch/nn/modules/module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data/users/hhy/fbsource/buck-out/v2/gen/fbcode/f315e3781b29ac13/aps_models/ads/icvr/__icvr_launcher_publish__/icvr_launcher_publish-inplace#link-tree/torchrec/distributed/dist_data.py", line 828, in forward
    tensor_awaitable = alltoall_pooled(
  File "/data/users/hhy/fbsource/buck-out/v2/gen/fbcode/f315e3781b29ac13/aps_models/ads/icvr/__icvr_launcher_publish__/icvr_launcher_publish-inplace#link-tree/torchrec/distributed/comm_ops.py", line 391, in alltoall_pooled
    return NoWait(all2all_pooled_sync(group, a2ai, a2a_pooled_embs_tensor))
  File "/data/users/hhy/fbsource/buck-out/v2/gen/fbcode/f315e3781b29ac13/aps_models/ads/icvr/__icvr_launcher_publish__/icvr_launcher_publish-inplace#link-tree/torchrec/distributed/comm_ops.py", line 424, in all2all_pooled_sync
    output_split_sizes = [
  File "/data/users/hhy/fbsource/buck-out/v2/gen/fbcode/f315e3781b29ac13/aps_models/ads/icvr/__icvr_launcher_publish__/icvr_launcher_publish-inplace#link-tree/torchrec/distributed/comm_ops.py", line 425, in 
    codecs.forward.calc_quantized_size(
  File "/data/users/hhy/fbsource/buck-out/v2/gen/fbcode/f315e3781b29ac13/aps_models/ads/icvr/__icvr_launcher_publish__/icvr_launcher_publish-inplace#link-tree/fbgemm_gpu/quantize_comm.py", line 224, in calc_quantized_size
    assert input_len % ctx.row_dim == 0, (
```
* add torch._check in the code

Differential Revision: D64667000


