### PR TITLE
Add support for int64_t indices and offsets in TBE inference [11/N]

### DIFF
--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -332,6 +332,7 @@ class NBitFowardTest(unittest.TestCase):
         use_array_for_index_remapping: bool,
         do_pruning: bool,
         mixed_weights_ty: bool,
+        indices_dtype: torch.dtype,
         output_dtype: SparseType,
     ) -> None:
         # NOTE: weighted operation can be done only for SUM.
@@ -360,8 +361,14 @@ class NBitFowardTest(unittest.TestCase):
                         SparseType.FP8,
                         SparseType.INT8,
                         SparseType.INT4,
-                        SparseType.INT2,
                     ]
+                    + (
+                        [
+                            SparseType.INT2,
+                        ]
+                        if output_dtype != SparseType.FP32
+                        else []
+                    )
                 )
                 for _ in range(T)
             ]
@@ -453,19 +460,25 @@ class NBitFowardTest(unittest.TestCase):
             # Initialize and insert Array index remapping based data structure
             index_remappings_array = []
             for t in range(T):
-                indice_t = (indices.view(T, B, L))[t].long().view(-1).to(current_device)
+                indice_t = (
+                    (indices.view(T, B, L))[t]
+                    .view(-1)
+                    .to(dtype=indices_dtype, device=current_device)
+                )
                 dense_indice_t = (
-                    (dense_indices.view(T, B, L))[t].view(-1).to(current_device)
+                    (dense_indices.view(T, B, L))[t]
+                    .view(-1)
+                    .to(dtype=indices_dtype, device=current_device)
                 )
                 index_remappings_array_t = torch.tensor(
                     [-1] * original_E,
-                    dtype=torch.int32,
+                    dtype=indices_dtype,
                     device=current_device,
                 )
                 index_remappings_array_t[indice_t] = dense_indice_t
                 index_remappings_array.append(index_remappings_array_t.cpu())
         else:
-            index_remappings_array = [torch.arange(E, dtype=torch.int32) for E in Es]
+            index_remappings_array = [torch.arange(E, dtype=indices_dtype) for E in Es]
             x = torch.cat([x.view(1, B, L) for x in xs], dim=0)
             xw = torch.cat([xw.view(1, B, L) for xw in xws], dim=0)
             (indices, offsets) = get_table_batched_offsets_from_dense(
@@ -495,6 +508,7 @@ class NBitFowardTest(unittest.TestCase):
             fp8_exponent_bias=(
                 fp8_config.get("exponent_bias") if has_fp8_weight else None
             ),
+            indices_dtype=indices_dtype,
         )
         # Initialize the random weights for int nbit table split embedding bag
         cc.fill_random_weights()
@@ -538,19 +552,22 @@ class NBitFowardTest(unittest.TestCase):
                 fp8_config=fp8_config if has_fp8_weight else None,
             )
 
+        indices = indices.to(dtype=indices_dtype)
+        offsets = offsets.to(dtype=indices_dtype)
+
         if not use_cpu:
             fc2 = (
-                cc(indices.int(), offsets.int())
+                cc(indices, offsets)
                 if not weighted
-                else cc(indices.int(), offsets.int(), xw.contiguous().view(-1))
+                else cc(indices, offsets, xw.contiguous().view(-1))
             )
         else:
             cc = cc.cpu()
             indices, offsets = indices.cpu(), offsets.cpu()
             fc2 = (
-                cc(indices.int(), offsets.int())
+                cc(indices, offsets)
                 if not weighted
-                else cc(indices.int(), offsets.int(), xw.contiguous().view(-1).cpu())
+                else cc(indices, offsets, xw.contiguous().view(-1).cpu())
             )
 
         if do_pooling and B == 0:
@@ -594,6 +611,7 @@ class NBitFowardTest(unittest.TestCase):
             )
         else:
             fc2_float = fc2.float()
+
         torch.testing.assert_close(
             fc2_float.cpu(),
             f.float().cpu(),
@@ -608,6 +626,7 @@ class NBitFowardTest(unittest.TestCase):
         pooling_mode=st.sampled_from(
             [PoolingMode.SUM, PoolingMode.NONE, PoolingMode.MEAN]
         ),
+        indices_dtype=st.sampled_from([torch.int32, torch.int64]),
         output_dtype=st.sampled_from(
             [SparseType.FP32, SparseType.FP16, SparseType.BF16]
         ),
@@ -623,6 +642,7 @@ class NBitFowardTest(unittest.TestCase):
         use_array_for_index_remapping: bool,
         do_pruning: bool,
         pooling_mode: PoolingMode,
+        indices_dtype: torch.dtype,
         output_dtype: SparseType,
     ) -> None:
         use_cpu = True
@@ -666,11 +686,18 @@ class NBitFowardTest(unittest.TestCase):
             use_array_for_index_remapping,
             do_pruning,
             mixed_weights_ty,
+            indices_dtype,
             output_dtype,
         )
 
+    @given(
+        indices_dtype=st.sampled_from([torch.int32, torch.int64]),
+    )
+    @settings(deadline=None)
     @unittest.skipIf(*gpu_unavailable)
-    def test_nbit_forward_gpu_no_cache_fp8_2048(self) -> None:
+    def test_nbit_forward_gpu_no_cache_fp8_2048(
+        self, indices_dtype: torch.dtype
+    ) -> None:
         # Test the case of FB8 table with 128B*8 < D <= 128B*16
         self.execute_nbit_forward_(
             T=1,
@@ -688,6 +715,7 @@ class NBitFowardTest(unittest.TestCase):
             use_array_for_index_remapping=True,
             do_pruning=False,
             mixed_weights_ty=False,
+            indices_dtype=indices_dtype,
             output_dtype=SparseType.FP16,
         )
 
@@ -696,6 +724,8 @@ class NBitFowardTest(unittest.TestCase):
         nbit_weights_ty=get_nbit_weights_ty(),
         use_array_for_index_remapping=st.booleans(),
         do_pruning=st.booleans(),
+        indices_dtype=st.sampled_from([torch.int32, torch.int64]),
+        output_dtype=st.sampled_from([SparseType.FP32, SparseType.FP16]),
     )
     @settings(
         verbosity=VERBOSITY,
@@ -706,8 +736,25 @@ class NBitFowardTest(unittest.TestCase):
         self,
         nbit_weights_ty: Optional[SparseType],
         use_array_for_index_remapping: bool,
+        indices_dtype: torch.dtype,
         do_pruning: bool,
+        output_dtype: SparseType,
     ) -> None:
+        # NOTE: The combination of INT2 and FP32 as weight and output types, respectively, is
+        # currently not supported.
+        if nbit_weights_ty == SparseType.INT2 and output_dtype == SparseType.FP32:
+            self.skipTest(
+                "The combination of INT2 and FP32 as weight and output types, respectively, is not supported"
+            )
+
+        # NOTE: Hash-based index remapping in general is an experimental feature
+        if indices_dtype != torch.int32 and not use_array_for_index_remapping:
+            self.skipTest(
+                "Hash-based index_remapping is an experimental feature and is "
+                "currently not supported for indices.dtype == torch.int64 and "
+                "indices.device != cpu"
+            )
+
         use_cpu = False
         T = random.randint(1, 50)
         B = random.randint(0, 128)
@@ -742,9 +789,7 @@ class NBitFowardTest(unittest.TestCase):
         else:
             weights_ty: SparseType = nbit_weights_ty
             mixed_weights_ty = False
-        output_dtype = random.choice(
-            [SparseType.FP32, SparseType.FP16, SparseType.BF16]
-        )
+
         self.execute_nbit_forward_(
             T,
             D,
@@ -761,6 +806,7 @@ class NBitFowardTest(unittest.TestCase):
             use_array_for_index_remapping,
             do_pruning,
             mixed_weights_ty,
+            indices_dtype,
             output_dtype,
         )
 
@@ -983,6 +1029,7 @@ class NBitFowardTest(unittest.TestCase):
         T=st.integers(min_value=10, max_value=20),
         L=st.integers(min_value=10, max_value=100),
         MAXH=st.integers(min_value=50, max_value=100),
+        indices_dtype=st.sampled_from([torch.int32, torch.int64]),
     )
     @settings(
         verbosity=VERBOSITY,
@@ -996,6 +1043,7 @@ class NBitFowardTest(unittest.TestCase):
         T: int,
         L: int,
         MAXH: int,
+        indices_dtype: torch.dtype,
     ) -> None:
         """
         we init a quant table split embedding bag with int4 weights and scale of 1 and 0 bias
@@ -1017,6 +1065,7 @@ class NBitFowardTest(unittest.TestCase):
             use_array_for_index_remapping=True,
             do_pruning=False,
             mixed_weights_ty=False,
+            indices_dtype=indices_dtype,
             output_dtype=SparseType.INT4,
         )
 

--- a/fbgemm_gpu/test/tbe/utils/split_embeddings_utils_test.py
+++ b/fbgemm_gpu/test/tbe/utils/split_embeddings_utils_test.py
@@ -469,7 +469,7 @@ class SplitEmbeddingsUtilsTest(unittest.TestCase):
         # Initialize and insert Hashmap index remapping based data structure
         hash_table = torch.empty(
             (sum(capacities), 2),
-            dtype=torch.int32,
+            dtype=torch.int64,
         )
         hash_table[:, :] = -1
         hash_table_offsets = torch.tensor([0] + np.cumsum(capacities).tolist()).long()
@@ -486,7 +486,7 @@ class SplitEmbeddingsUtilsTest(unittest.TestCase):
         # Initialize and insert Array index remapping based data structure
         index_remappings_array = torch.tensor(
             [-1] * original_E * T,
-            dtype=torch.int32,
+            dtype=torch.int64,
             device=current_device,
         )
         index_remappings_array_offsets = torch.empty(
@@ -498,7 +498,7 @@ class SplitEmbeddingsUtilsTest(unittest.TestCase):
         for t in range(T):
             indice_t = (indices.view(T, B, L))[t].long().view(-1).to(current_device)
             dense_indice_t = (
-                (dense_indices.view(T, B, L))[t].view(-1).to(current_device)
+                (dense_indices.view(T, B, L))[t].long().view(-1).to(current_device)
             )
             selected_indices = torch.add(indice_t, t * original_E)[:E]
             index_remappings_array[selected_indices] = dense_indice_t


### PR DESCRIPTION
Summary: This is a re-land of parts of D63778645 (7C) combined with D63807049 (8).  They were reverted earlier due to S460368 (D64618134 and D64618221), but with D64619774 (9) and D64705072(19) in place, the issues with deploying `int64_t`-based index remap arrays should be resolved, at least on the FBGEMM side

Differential Revision: D64725653


