### PR TITLE
Make FP8 BMM output contiguous

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched.cu
@@ -448,7 +448,7 @@ at::Tensor handle_transposition(
           BIAS_DTYPE>(
           WQ.transpose(1, 2), XQ.transpose(1, 2), w_scale, x_scale, bias, out);
     }
-    return out_.transpose(1, 2);
+    return out_.transpose(1, 2).contiguous();
   }
 }
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/370

Make fp8 bmm output contiguous as [silu_mul](https://fburl.com/code/sa1faq0w) requests output tensor of fp8 bmm stride(-1) to be 1. This Diff fixes the issue

Differential Revision: D64811808


