### PR TITLE
Add CPU group_index_select fwd and bwd impl

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_ops_gpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops/sparse_ops_gpu.cpp
@@ -391,6 +391,8 @@ static torch::autograd::variable_list group_index_select_dim0_backward_impl_gpu(
     c10::SymIntArrayRef output_shape_group_ref) {
   TORCH_CHECK(all_inputs.size() > 2);
 
+  // all_input size =  group_size * 2 (from grads, indices)
+  // + 1 args_tensor + 1 saved_data + 1 first input
   const int64_t group_size = (all_inputs.size() - 3) / 2;
 
   Tensor fwd_input = all_inputs[2 * group_size + 2];

--- a/fbgemm_gpu/test/sparse/index_select_test.py
+++ b/fbgemm_gpu/test/sparse/index_select_test.py
@@ -419,6 +419,7 @@ additional_decorators: Dict[str, List[Callable]] = {
     "test_faketensor__test_index_select_dim0": [unittest.skip("hangs")],
     "test_autograd_registration__test_index_select_dim0": [unittest.skip("hangs")],
     "test_schema__test_index_select_dim0": [unittest.skip("hangs")],
+    "test_faketensor__test_group_index_select_dim0": [unittest.skip("hangs")],
 }
 
 extend_test_class(IndexSelectTest, additional_decorators)


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/369

The GIS op interfaces are unified for all device backends, but the CPU group_index_select_dim0 is still using the decomposed version due to lack of fused impl for fwd/bwd.

This diff implements the following functions on CPU:
- group_index_select_dim0_forward_impl_cpu
- group_index_select_dim0_backward_impl_cpu

Reviewed By: q10, egienvalue

Differential Revision: D64556901


