### PR TITLE
New autotune config for M=4

### DIFF
--- a/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
@@ -734,6 +734,11 @@ def _kernel_matmul_fp8_row_imprecise_acc(
             num_stages=4,
             num_warps=4,
         ),
+        Config(
+            {"BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_K": 512, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=4,
+        ),
     ],
     key=[
         "m_key",


### PR DESCRIPTION
Summary:
Closes the gap with CUTLASS on two llama shapes.

Why this config? We need BLOCK_N=64 to increase the grid size. With BLOCK_N=128 or BLOCK_N=256, we are launching less than 66 thread-blocks (covering less than half the device).

After setting BLOCK_N=64, we then increase BLOCK_K to take advantage of the freed up smem.

Before:
```
       (M, N, K)    _triton-tflops    _cutlass-tflops    _cutlass-speedup    _cutlass-accuracy    cublas_12.4.0-tflops    cublas_12.4.0-speedup    cublas_12.4.0-accuracy
----------------  ----------------  -----------------  ------------------  -------------------  ----------------------  -----------------------  ------------------------
(4, 6656, 13312)           8.64942           11.0645              1.27922                    1                10.1239                   1.17048                         1
(4, 6656, 16384)           8.96808           11.289               1.2588                     1                11.1414                   1.24234                         1
```

After:
```
       (M, N, K)    _triton-tflops    _cutlass-tflops    _cutlass-speedup    _cutlass-accuracy    cublas_12.4.0-tflops    cublas_12.4.0-speedup    cublas_12.4.0-accuracy
----------------  ----------------  -----------------  ------------------  -------------------  ----------------------  -----------------------  ------------------------
(4, 6656, 13312)          10.5582            11.059              1.04743                     1                10.1332                  0.959744                         1
(4, 6656, 16384)          11.3738            11.2378             0.988046                    1                11.1459                  0.979967                         1
```

Differential Revision: D64919881


