### PR TITLE
Use `c10::irange` in deeplearning/fbgemm/fbgemm_gpu/fb/src/programmable_kernel/plan_ngram.cpp +10

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/tensor_accessor.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/tensor_accessor.h
@@ -67,7 +67,7 @@ class TensorAccessorBase {
         ptr_name_(ptr_name),
         func_name_(func_name) {
     numel_ = 1;
-    for (size_t d = 0; d < N; d++) {
+    for (const auto d : c10::irange(N)) {
       numel_ += (sizes[d] - 1) * strides[d];
     }
   }
@@ -220,7 +220,7 @@ class GenericPackedTensorAccessorBase {
     std::copy(strides, strides + N, std::begin(strides_));
     // Compute numel_
     numel_ = 1;
-    for (size_t d = 0; d < N; d++) {
+    for (const auto d : c10::irange(N)) {
       numel_ += (sizes[d] - 1) * strides[d];
     }
     copy_str(ptr_name_, ptr_name, PTR_NAME_MAX_LEN);
@@ -245,7 +245,7 @@ class GenericPackedTensorAccessorBase {
     }
     // Compute numel_
     numel_ = 1;
-    for (size_t d = 0; d < N; d++) {
+    for (const auto d : c10::irange(N)) {
       numel_ += (sizes[d] - 1) * strides[d];
     }
     copy_str(ptr_name_, ptr_name, PTR_NAME_MAX_LEN);

--- a/fbgemm_gpu/src/embedding_inplace_ops/embedding_inplace_update_cpu.cpp
+++ b/fbgemm_gpu/src/embedding_inplace_ops/embedding_inplace_update_cpu.cpp
@@ -11,6 +11,7 @@
 #include <functional>
 
 #include <ATen/ATen.h>
+#include <c10/util/irange.h>
 #include <torch/library.h>
 
 #include "fbgemm_gpu/embedding_inplace_update.h"
@@ -34,7 +35,7 @@ void embedding_inplace_update_cpu_kernel(
     const at::TensorAccessor<index_t, 1>& update_row_idx,
     const at::TensorAccessor<int64_t, 1>& update_offsets,
     int64_t row_alignment) {
-  for (int64_t n = 0; n < update_row_idx.size(0); n++) {
+  for (const auto n : c10::irange(update_row_idx.size(0))) {
     int32_t t = update_table_idx[n];
     auto row_idx = update_row_idx[n];
 

--- a/fbgemm_gpu/src/embedding_inplace_ops/embedding_inplace_update_test.cpp
+++ b/fbgemm_gpu/src/embedding_inplace_ops/embedding_inplace_update_test.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <c10/util/irange.h>
 #include <folly/Random.h>
 #include <gtest/gtest.h>
 #include "fbgemm_gpu/embedding_inplace_update.h"
@@ -101,7 +102,7 @@ void test_embedding_inplace_update() {
   std::vector<int64_t> update_offsets;
   int64_t update_offset = 0;
   update_offsets.push_back(0);
-  for (int i = 0; i < update_table_idx.size(); ++i) {
+  for (const auto i : c10::irange(update_table_idx.size())) {
     int32_t idx = update_table_idx[i];
     update_offset +=
         get_D_bytes(D_offsets_tensor, weights_tys_tensor, idx, row_alignment);
@@ -149,7 +150,7 @@ void test_embedding_inplace_update() {
   auto uvm_weight_cpu = uvm_weight.cpu();
   auto update_weight_cpu = update_weight.cpu();
   int offset = 0;
-  for (int i = 0; i < update_table_idx.size(); i++) {
+  for (const auto i : c10::irange(update_table_idx.size())) {
     auto table_idx = update_table_idx[i];
     auto row_idx = update_row_idx[i];
     auto weight_offset = weights_offsets[table_idx];

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_autograd.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_autograd.cpp
@@ -11,6 +11,7 @@
 #include <ATen/TensorUtils.h>
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <c10/core/SymIntArrayRef.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/autograd/custom_function.h>
 #include <torch/library.h>
 #include <torch/torch.h>
@@ -179,7 +180,7 @@ class JaggedDenseMulOp : public torch::autograd::Function<JaggedDenseMulOp> {
       torch::autograd::variable_list grad_outputs) {
     const Tensor x_values = ctx->get_saved_variables().front();
     std::vector<Tensor> x_offsets;
-    for (size_t i = 1; i < ctx->get_saved_variables().size() - 1; ++i) {
+    for (const auto i : c10::irange(1, ctx->get_saved_variables().size() - 1)) {
       x_offsets.push_back(ctx->get_saved_variables()[i]);
     }
     Tensor y = ctx->get_saved_variables().back();
@@ -802,7 +803,7 @@ Tensor jagged_dense_elementwise_add(
   // Construct max_lengths from y
   std::vector<c10::SymInt> max_lengths;
   max_lengths.reserve(x_offsets.size());
-  for (int d = 1; d < y.dim() - 1; d++) {
+  for (const auto d : c10::irange(1, y.dim() - 1)) {
     max_lengths.push_back(y.sym_size(d));
   }
   TORCH_CHECK(max_lengths.size() == x_offsets.size());


### PR DESCRIPTION
Summary: `c10::irange` provides a const-safe, type-safe loop abstraction. Since we have many for-loops with implicit downcasts, this improves type safety and prevents unexpected behaviour on large datasets.

Differential Revision: D65021228


