### PR TITLE
Make `learning rate` tensor (Backend)

### DIFF
--- a/fbgemm_gpu/codegen/genscript/optimizer_args.py
+++ b/fbgemm_gpu/codegen/genscript/optimizer_args.py
@@ -199,6 +199,9 @@ def make_kernel_arg(
     default: Union[int, float, None],
     pass_by_ref: bool = False,
 ) -> str:
+    if name == "learning_rate_tensor":
+        ty = ArgType.FLOAT
+        name = "learning_rate"
     return {
         ArgType.TENSOR: lambda x: acc_cache_tensor_arg(x, pass_by_ref=pass_by_ref),
         ArgType.INT_TENSOR: lambda x: int_tensor_arg(x, pass_by_ref=pass_by_ref),
@@ -225,6 +228,10 @@ def make_kernel_arg(
 
 
 def make_kernel_arg_constructor(ty: ArgType, name: str) -> str:
+    # learning_rate is a float in kernels
+    if name == "learning_rate_tensor":
+        ty = ArgType.FLOAT
+        name = "learning_rate"
     return {
         ArgType.TENSOR: acc_cache_tensor_arg_constructor,
         ArgType.INT_TENSOR: int_tensor_arg_constructor,
@@ -237,6 +244,10 @@ def make_kernel_arg_constructor(ty: ArgType, name: str) -> str:
 
 
 def make_cpu_kernel_arg(ty: ArgType, name: str, default: Union[int, float]) -> str:
+    # learning_rate is a float in kernels
+    if name == "learning_rate_tensor":
+        ty = ArgType.FLOAT
+        name = "learning_rate"
     return {
         ArgType.TENSOR: lambda x: acc_cache_tensor_arg(x, gpu=False),
         ArgType.INT_TENSOR: lambda x: int_tensor_arg(x, gpu=False),
@@ -249,6 +260,10 @@ def make_cpu_kernel_arg(ty: ArgType, name: str, default: Union[int, float]) -> s
 
 
 def make_cpu_kernel_arg_constructor(ty: ArgType, name: str) -> str:
+    # learning_rate is a float in kernels
+    if name == "learning_rate_tensor":
+        ty = ArgType.FLOAT
+        name = "learning_rate"
     return {
         ArgType.TENSOR: lambda x: acc_cache_tensor_arg_constructor(x, gpu=False),
         ArgType.INT_TENSOR: lambda x: int_tensor_arg_constructor(x, gpu=False),
@@ -301,6 +316,71 @@ def make_function_schema_arg(ty: ArgType, name: str, default: Union[int, float])
     }[ty](name)
 
 
+def _extend_tensor_str(name: str, is_cuda: bool) -> str:
+    """
+    Take a tensor name and extend for cpu or cuda
+
+    Parameters:
+    name (str)  - tensor name e.g., "momentum1"
+    is_cuda (bool) - If True, extend for cuda tensors. Otherwise, extend for cpu tensors
+
+    Returns:
+    String of extended tensors
+    """
+    if is_cuda:
+        return f"Tensor {name}_dev, Tensor {name}_uvm, Tensor {name}_placements, Tensor {name}_offsets"
+    else:
+        return f"Tensor {name}_host, Tensor {name}_placements, Tensor {name}_offsets"
+
+
+def extend_tensors_args_from_str(args_str: str, example_tensor: str) -> str:
+    """
+    Extend tensor name for cuda/cpu if tensor args exist.
+    For example, if `args_str` contains 'Tensor x', it needs to be extended to
+    'Tensor x_host' for cpu, and 'Tensor x_dev, Tensor x_uvm, ...' for cuda
+
+    Parameters:
+        args: str - function args e.g., "Tensor momentum1, float eps"
+        example_tensor: str - a tensor name already extended
+                e.g., "momentum1_dev" for cuda or "momentum1_host" for cpu
+
+    Returns:
+        function args where tensor args are extended
+    """
+    num_tensors = args_str.count("Tensor")
+    if num_tensors > 0:
+        is_cuda = "_dev" in example_tensor
+        args = args_str.split(", ", num_tensors)
+        tensors_args = args[:num_tensors]
+        non_tensors_args = args[-1]
+        extended_tensors_args = [
+            _extend_tensor_str(t.split(" ")[1], is_cuda) for t in tensors_args
+        ]
+        return ", ".join(extended_tensors_args + [non_tensors_args])
+    else:
+        return args_str
+
+
+def make_split_function_args_v1(args_str: str) -> str:
+    """
+    Create function args for V1 interface from the args_str
+
+    Parameters:
+    args: str - function args e.g., "Tensor momentum1_host, float eps"
+
+    Returns:
+    function args in string where
+        int -> int64_t
+        SymInt -> c10::SymInt
+        float -> double
+    """
+    return (
+        args_str.replace("int", "int64_t")
+        .replace("SymInt", "c10::SymInt")
+        .replace("float", "double")
+    )
+
+
 def make_ivalue_cast(ty: ArgType) -> str:
     return {
         ArgType.INT: "toInt",
@@ -325,6 +405,10 @@ class PT2ArgsSet:
         PT2ArgsSet.create() is a method that creates different formats given the optimization arguments
         to be used in TBE codegen PT2 templates.
 
+        Mainly, PT2 unified interface packs tensors to tensor list
+        due to limited number of arguments for registered torch ops
+        e.g., instead of passing `momentum_host, `momentum_dev`, etc, we pass `momentum`
+
         Parameters:
         split_arg_spec: List[OptimItem] - list of argument specs
 
@@ -344,7 +428,11 @@ class PT2ArgsSet:
         split_function_schemas = []
         split_saved_tensor_list = []
         for s in split_arg_spec:
-            if s.ty in (
+            if s.name == "learning_rate_tensor":
+                split_function_arg_names.append(s.name)
+                split_function_args.append(tensor_arg(s.name))
+                split_function_schemas.append(tensor_arg(s.name))
+            elif s.ty in (
                 ArgType.TENSOR,
                 ArgType.INT_TENSOR,
                 ArgType.LONG_TENSOR,
@@ -400,12 +488,16 @@ class OptimizerArgs:
     # pyre-fixme[11]: Annotation `TensorType` is not defined as a type.
     placeholder_type_combos: Union[List[Dict[str, TensorType]], List[None]]
     unified_pt2: PT2ArgsSet
+    split_kernel_arg_names: List[str]
+    split_function_args_v1: Optional[str] = None
+    split_function_schemas_v1: Optional[str] = None
 
     @staticmethod
     # pyre-ignore[3]
     def create(
         split_arg_spec: List[OptimItem],
         arg_spec: List[OptimItem],
+        additional_spec: Optional[dict[str, Any]] = None,
     ):
         # Compute placeholder tensor combinations
         ph_tensor_names = [
@@ -425,6 +517,32 @@ class OptimizerArgs:
             ]
         else:
             ph_combos = [None]
+
+        split_saved_tensors = [
+            s.name
+            for s in split_arg_spec
+            if s.ty
+            in (
+                ArgType.TENSOR,
+                ArgType.INT_TENSOR,
+                ArgType.LONG_TENSOR,
+                ArgType.PLACEHOLDER_TENSOR,
+            )
+        ]
+        # Create function args and schemas for V1 interface for backward compatibility
+        # V1 interface refers to separate CPU/CUDA lookup functions
+        # e.g., split_embedding_codegen_lookup_{}_funtion and split_embedding_codegen_lookup_{}_funtion_cpu)
+        split_function_args_v1 = None
+        split_function_schemas_v1 = None
+        if additional_spec is not None:
+            if len(split_saved_tensors) > 0:
+                extended_args_str = extend_tensors_args_from_str(
+                    additional_spec["v1"], split_saved_tensors[0]
+                )
+            else:
+                extended_args_str = additional_spec["v1"]
+            split_function_args_v1 = make_split_function_args_v1(extended_args_str)
+            split_function_schemas_v1 = extended_args_str
 
         # pyre-fixme[28]: Unexpected keyword argument `placeholder_type_combos`.
         return OptimizerArgs(
@@ -456,7 +574,8 @@ class OptimizerArgs:
             split_tensors=[
                 s.name
                 for s in arg_spec
-                if s.ty in (ArgType.TENSOR, ArgType.PLACEHOLDER_TENSOR)
+                if (s.ty in (ArgType.TENSOR, ArgType.PLACEHOLDER_TENSOR))
+                and s.name != "learning_rate_tensor"
             ],
             split_tensor_types={
                 s.name: (
@@ -467,17 +586,7 @@ class OptimizerArgs:
                 for s in arg_spec
                 if s.ty in (ArgType.TENSOR, ArgType.PLACEHOLDER_TENSOR)
             },
-            split_saved_tensors=[
-                s.name
-                for s in split_arg_spec
-                if s.ty
-                in (
-                    ArgType.TENSOR,
-                    ArgType.INT_TENSOR,
-                    ArgType.LONG_TENSOR,
-                    ArgType.PLACEHOLDER_TENSOR,
-                )
-            ],
+            split_saved_tensors=split_saved_tensors,
             saved_data=[
                 (s.name, make_ivalue_cast(s.ty))
                 for s in arg_spec
@@ -496,6 +605,13 @@ class OptimizerArgs:
             placeholder_tensor_names=ph_tensor_names,
             placeholder_type_combos=ph_combos,
             unified_pt2=PT2ArgsSet.create(split_arg_spec),
+            # learning rate remains float in kernels
+            split_kernel_arg_names=[
+                "learning_rate" if s.name == "learning_rate_tensor" else s.name
+                for s in split_arg_spec
+            ],
+            split_function_args_v1=split_function_args_v1,
+            split_function_schemas_v1=split_function_schemas_v1,
         )
 
 
@@ -512,18 +628,24 @@ class OptimizerArgsSet:
 
     @staticmethod
     def create_optim_args(
-        arg_spec: List[OptimItem], ext_fn: Callable[[OptimItem], List[OptimItem]]
+        arg_spec: List[OptimItem],
+        ext_fn: Callable[[OptimItem], List[OptimItem]],
+        additional_spec: Optional[dict[str, Any]] = None,
     ) -> OptimizerArgs:
         split_arg_spec = []
         for s in arg_spec:
-            if s.ty in (ArgType.FLOAT, ArgType.INT, ArgType.SYM_INT):
+            # no cpu/cuda extension for learning_rate
+            if (
+                s.ty in (ArgType.FLOAT, ArgType.INT, ArgType.SYM_INT)
+                or s.name == "learning_rate_tensor"
+            ):
                 # pyre-fixme[19]: Expected 1 positional argument.
                 split_arg_spec.append(OptimItem(s.ty, s.name, s.default))
             else:
                 assert s.ty in (ArgType.TENSOR, ArgType.PLACEHOLDER_TENSOR)
                 # Treat PLACEHOLDER_TENSOR as TENSOR for CPU
                 split_arg_spec.extend(ext_fn(s))
-        return OptimizerArgs.create(split_arg_spec, arg_spec)
+        return OptimizerArgs.create(split_arg_spec, arg_spec, additional_spec)
 
     @staticmethod
     def extend_for_cpu(spec: OptimItem) -> List[OptimItem]:
@@ -576,10 +698,12 @@ class OptimizerArgsSet:
 
     @staticmethod
     # pyre-ignore[3]
-    def create(arg_spec: List[OptimItem]):
+    def create(
+        arg_spec: List[OptimItem], additional_spec: Optional[dict[str, Any]] = None
+    ):
         return OptimizerArgsSet(
             *(
-                OptimizerArgsSet.create_optim_args(arg_spec, ext_fn)
+                OptimizerArgsSet.create_optim_args(arg_spec, ext_fn, additional_spec)
                 for ext_fn in (
                     OptimizerArgsSet.extend_for_cpu,
                     OptimizerArgsSet.extend_for_cuda,

--- a/fbgemm_gpu/codegen/genscript/optimizers.py
+++ b/fbgemm_gpu/codegen/genscript/optimizers.py
@@ -36,7 +36,10 @@ def dense() -> Dict[str, Any]:
         "args": OptimizerArgsSet.create(
             [
                 OptimItem(ArgType.FLOAT, "unused"),
-            ]
+            ],
+            {
+                "v1": "float unused = 0",
+            },
         ),
         "has_cpu_support": True,
         "has_gpu_support": True,
@@ -75,9 +78,10 @@ def adagrad() -> Dict[str, Any]:
         "args": OptimizerArgsSet.create(
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
-                OptimItem(ArgType.FLOAT, "learning_rate"),
-            ]
+            ],
+            {"v1": "Tensor momentum1, float eps = 0, float learning_rate = 0"},
         ),
         "split_precomputation": "",
         "split_weight_update": split_weight_update,
@@ -242,12 +246,15 @@ def rowwise_adagrad() -> Dict[str, Any]:
         "args": OptimizerArgsSet.create(
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
-                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
                 OptimItem(ArgType.INT, "weight_decay_mode", 0),
                 OptimItem(ArgType.FLOAT, "max_norm", 0.0),
-            ]
+            ],
+            {
+                "v1": "Tensor momentum1, float eps = 0, float learning_rate = 0, float weight_decay = 0.0, int weight_decay_mode = 0.0, float max_norm = 0.0"
+            },
         ),
         "split_precomputation": split_precomputation,
         "split_weight_update": split_weight_update,
@@ -275,11 +282,14 @@ def approx_rowwise_adagrad() -> Dict[str, Any]:
         "args": OptimizerArgsSet.create(
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
-                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
                 OptimItem(ArgType.INT, "weight_decay_mode", 0),
-            ]
+            ],
+            {
+                "v1": "Tensor momentum1, float eps = 0, float learning_rate = 0, float weight_decay = 0.0, int weight_decay_mode = 0.0",
+            },
         ),
         "split_precomputation": rowwise_adagrad_args["split_precomputation"],
         "split_weight_update": approx_split_weight_update,
@@ -382,11 +392,14 @@ def rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
         "args": OptimizerArgsSet.create(
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
-                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
                 OptimItem(ArgType.INT, "weight_decay_mode", 0),
-            ]
+            ],
+            {
+                "v1": "Tensor momentum1, float eps = 0, float learning_rate = 0, float weight_decay = 0.0, int weight_decay_mode = 0.0"
+            },
         ),
         "split_precomputation": split_precomputation,
         "split_weight_update": split_weight_update,
@@ -415,11 +428,14 @@ def approx_rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
         "args": OptimizerArgsSet.create(
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
-                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
                 OptimItem(ArgType.INT, "weight_decay_mode", 0),
-            ]
+            ],
+            {
+                "v1": "Tensor momentum1, float eps = 0, float learning_rate = 0, float weight_decay = 0.0, int weight_decay_mode = 0.0"
+            },
         ),
         "split_precomputation": rowwise_adagrad_with_weight_decay_args[
             "split_precomputation"
@@ -581,8 +597,8 @@ def rowwise_adagrad_with_counter() -> Dict[str, Any]:
                 OptimItem(ArgType.TENSOR, "momentum1"),
                 OptimItem(ArgType.TENSOR, "prev_iter"),
                 OptimItem(ArgType.TENSOR, "row_counter"),
+                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
-                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
                 OptimItem(ArgType.INT, "iter"),
                 OptimItem(ArgType.INT, "counter_halflife", -1),
@@ -597,7 +613,10 @@ def rowwise_adagrad_with_counter() -> Dict[str, Any]:
                 OptimItem(ArgType.INT, "regularization_mode", 0),
                 OptimItem(ArgType.FLOAT, "weight_norm_coefficient", 0.0),
                 OptimItem(ArgType.FLOAT, "lower_bound", 0.0),
-            ]
+            ],
+            {
+                "v1": "Tensor momentum1, Tensor prev_iter, Tensor row_counter, float eps = 0, float learning_rate = 0, float weight_decay = 0.0, int iter = 0, int counter_halflife = -1, int adjustment_iter = -1, float adjustment_ub = 1.0, int learning_rate_mode = -1, int weight_decay_mode = 1, int grad_sum_decay = -1, float max_counter = 0, float tail_id_threshold = 0.0, int is_tail_id_thresh_ratio = 0, int regularization_mode = 0, float weight_norm_coefficient = 0.0, float lower_bound = 0.0"
+            },
         ),
         "split_precomputation": split_precomputation,
         "split_weight_update": split_weight_update,
@@ -627,8 +646,8 @@ def approx_rowwise_adagrad_with_counter() -> Dict[str, Any]:
                 OptimItem(ArgType.TENSOR, "momentum1"),
                 OptimItem(ArgType.TENSOR, "prev_iter"),
                 OptimItem(ArgType.TENSOR, "row_counter"),
+                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
-                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
                 OptimItem(ArgType.INT, "iter"),
                 OptimItem(ArgType.INT, "counter_halflife", -1),
@@ -643,7 +662,10 @@ def approx_rowwise_adagrad_with_counter() -> Dict[str, Any]:
                 OptimItem(ArgType.INT, "regularization_mode", 0),
                 OptimItem(ArgType.FLOAT, "weight_norm_coefficient", 0.0),
                 OptimItem(ArgType.FLOAT, "lower_bound", 0.0),
-            ]
+            ],
+            {
+                "v1": "Tensor momentum1, Tensor prev_iter, Tensor row_counter, float eps = 0, float learning_rate = 0, float weight_decay = 0.0, int iter = 0, int counter_halflife = -1, int adjustment_iter = -1, float adjustment_ub = 1.0, int learning_rate_mode = -1, int weight_decay_mode = 1, int grad_sum_decay = -1, float max_counter = 0, float tail_id_threshold = 0.0, int is_tail_id_thresh_ratio = 0, int regularization_mode = 0, float weight_norm_coefficient = 0.0, float lower_bound = 0.0"
+            },
         ),
         "split_precomputation": rowwise_adagrad_with_counter_args[
             "split_precomputation"
@@ -722,11 +744,14 @@ def rowwise_weighted_adagrad() -> Dict[str, Any]:
         "args": OptimizerArgsSet.create(
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
+                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
-                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "weight_decay"),
                 OptimItem(ArgType.INT, "iter"),
-            ]
+            ],
+            {
+                "v1": "Tensor momentum1, float eps = 0, float learning_rate = 0, float weight_decay = 0, int iter = 0"
+            },
         ),
         "split_precomputation": split_precomputation,
         "split_weight_update": split_weight_update,
@@ -752,7 +777,10 @@ def sgd() -> Dict[str, Any]:
 
     return {
         "optimizer": "sgd",
-        "args": OptimizerArgsSet.create([OptimItem(ArgType.FLOAT, "learning_rate")]),
+        "args": OptimizerArgsSet.create(
+            [OptimItem(ArgType.TENSOR, "learning_rate_tensor")],
+            {"v1": "float learning_rate = 0"},
+        ),
         "split_precomputation": "",
         "split_weight_update": split_weight_update,
         "split_post_update": "",
@@ -777,7 +805,10 @@ def approx_sgd() -> Dict[str, Any]:
 
     return {
         "optimizer": "approx_sgd",
-        "args": OptimizerArgsSet.create([OptimItem(ArgType.FLOAT, "learning_rate")]),
+        "args": OptimizerArgsSet.create(
+            [OptimItem(ArgType.TENSOR, "learning_rate_tensor")],
+            {"v1": "float learning_rate = 0"},
+        ),
         "split_precomputation": "",
         "split_weight_update": approx_split_weight_update,
         "split_post_update": "",
@@ -849,13 +880,16 @@ def lamb() -> Dict[str, Any]:
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
                 OptimItem(ArgType.TENSOR, "momentum2"),
-                OptimItem(ArgType.FLOAT, "learning_rate"),
+                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
                 OptimItem(ArgType.FLOAT, "beta1"),
                 OptimItem(ArgType.FLOAT, "beta2"),
                 OptimItem(ArgType.FLOAT, "weight_decay"),
                 OptimItem(ArgType.INT, "iter"),
-            ]
+            ],
+            {
+                "v1": "Tensor momentum1, Tensor momentum2, float learning_rate = 0, float eps = 0, float beta1 = 0, float beta2 = 0, float weight_decay = 0, int iter = 0"
+            },
         ),
         "split_precomputation": split_precomputation,
         "split_weight_update": split_weight_update,
@@ -943,13 +977,16 @@ def partial_rowwise_lamb() -> Dict[str, Any]:
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
                 OptimItem(ArgType.TENSOR, "momentum2"),
-                OptimItem(ArgType.FLOAT, "learning_rate"),
+                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
                 OptimItem(ArgType.FLOAT, "beta1"),
                 OptimItem(ArgType.FLOAT, "beta2"),
                 OptimItem(ArgType.FLOAT, "weight_decay"),
                 OptimItem(ArgType.INT, "iter"),
-            ]
+            ],
+            {
+                "v1": "Tensor momentum1, Tensor momentum2, float learning_rate = 0, float eps = 0, float beta1 = 0, float beta2 = 0, float weight_decay = 0, int iter = 0"
+            },
         ),
         "split_precomputation": split_precomputation,
         "split_weight_update": split_weight_update,
@@ -1000,13 +1037,16 @@ def adam() -> Dict[str, Any]:
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
                 OptimItem(ArgType.TENSOR, "momentum2"),
-                OptimItem(ArgType.FLOAT, "learning_rate"),
+                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
                 OptimItem(ArgType.FLOAT, "beta1"),
                 OptimItem(ArgType.FLOAT, "beta2"),
                 OptimItem(ArgType.FLOAT, "weight_decay"),
                 OptimItem(ArgType.INT, "iter"),
-            ]
+            ],
+            {
+                "v1": "Tensor momentum1, Tensor momentum2, float learning_rate = 0, float eps = 0, float beta1 = 0, float beta2 = 0, float weight_decay = 0, int iter = 0"
+            },
         ),
         "split_precomputation": "",
         "split_weight_update": split_weight_update,
@@ -1077,13 +1117,16 @@ def partial_rowwise_adam() -> Dict[str, Any]:
                     "momentum2",
                     ph_tys=[ArgType.FLOAT_TENSOR, ArgType.BFLOAT16_TENSOR],
                 ),
-                OptimItem(ArgType.FLOAT, "learning_rate"),
+                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
                 OptimItem(ArgType.FLOAT, "beta1"),
                 OptimItem(ArgType.FLOAT, "beta2"),
                 OptimItem(ArgType.FLOAT, "weight_decay"),
                 OptimItem(ArgType.INT, "iter"),
-            ]
+            ],
+            {
+                "v1": "Tensor momentum1, Tensor momentum2, float learning_rate = 0, float eps = 0, float beta1 = 0, float beta2 = 0, float weight_decay = 0, int iter = 0"
+            },
         ),
         "split_precomputation": split_precomputation,
         "split_weight_update": split_weight_update,
@@ -1145,11 +1188,14 @@ def lars_sgd() -> Dict[str, Any]:
         "args": OptimizerArgsSet.create(
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
-                OptimItem(ArgType.FLOAT, "learning_rate"),
+                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eta"),
                 OptimItem(ArgType.FLOAT, "momentum"),
                 OptimItem(ArgType.FLOAT, "weight_decay"),
-            ]
+            ],
+            {
+                "v1": "Tensor momentum1, float learning_rate = 0, float eta = 0, float momentum = 0, float weight_decay = 0"
+            },
         ),
         "split_precomputation": split_precomputation,
         "split_weight_update": split_weight_update,
@@ -1171,7 +1217,10 @@ def none_optimizer() -> Dict[str, Any]:
             [
                 OptimItem(ArgType.INT, "total_hash_size"),
                 OptimItem(ArgType.SYM_INT, "total_unique_indices"),
-            ]
+            ],
+            {
+                "v1": "int total_hash_size = 0, SymInt total_unique_indices = 0",
+            },
         ),
         # Generate only GPU code
         "has_cpu_support": False,

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_cpu_template.cpp
@@ -315,6 +315,11 @@ for (const auto d : c10::irange(D)) {
   int64_t B = (offsets.size(0) - 1) / T;
   TORCH_CHECK_GE(B, 0);
 
+  {%- if "learning_rate" in args.split_cpu_kernel_arg_constructors %}
+  // convert `learning rate` to float since `learning rate` is float in kernels
+  const float learning_rate = learning_rate_tensor.item<float>();
+  {%- endif %}
+
   const auto weights_offsets_data = weights_offsets.accessor<int64_t, 1>();
   const auto D_offsets_data = D_offsets.accessor<int, 1>();
 

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_cpu_template.cpp
@@ -215,9 +215,16 @@ Tensor split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(
     bool gradient_clipping,
     double max_gradient,
     bool stochastic_rounding,
-    {{ args.split_function_args | join(", ") }},
+    {{ args.split_function_args_v1 }},
     int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)) {
   {% if has_cpu_support %}
+  {%- if "learning_rate_tensor" in args.split_function_arg_names %}
+  // `learning rate` is changed to tensor to prevent recompilation. 
+  // This interface (V1) still accepts learning rate as float for backward compatibility, 
+  // We convert learning rate to tensor here to work with the backend
+  // The unified PT2 interface already accepts learning rate as tensor.
+  const auto learning_rate_tensor = at::tensor({learning_rate}, at::TensorOptions().dtype(at::kFloat).device(host_weights.options().device()));
+  {%- endif %}
   return SplitLookupFunction_{{ optimizer }}_Op::apply(
       host_weights,
       weights_placements,
@@ -245,7 +252,7 @@ Tensor split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(
 
 // Deprecated for fb namespace! Please use fbgemm namespace instead!
 TORCH_LIBRARY_FRAGMENT(fb, m) {
-    m.def("split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(Tensor(a!) host_weights, Tensor weights_placements, Tensor weights_offsets, Tensor D_offsets, SymInt total_D, SymInt max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, bool gradient_clipping, float max_gradient, bool stochastic_rounding, {{ args.split_function_schemas | join(", ") }}, int output_dtype=0) -> Tensor");
+    m.def("split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(Tensor(a!) host_weights, Tensor weights_placements, Tensor weights_offsets, Tensor D_offsets, SymInt total_D, SymInt max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, bool gradient_clipping, float max_gradient, bool stochastic_rounding, {{ args.split_function_schemas_v1 }}, int output_dtype=0) -> Tensor");
     m.impl(
       "split_embedding_codegen_lookup_{{ optimizer }}_function_cpu",
       torch::dispatch(
@@ -254,7 +261,7 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
-    m.def("split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(Tensor(a!) host_weights, Tensor weights_placements, Tensor weights_offsets, Tensor D_offsets, SymInt total_D, SymInt max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, bool gradient_clipping, float max_gradient, bool stochastic_rounding, {{ args.split_function_schemas | join(", ") }}, int output_dtype=0) -> Tensor");
+    m.def("split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(Tensor(a!) host_weights, Tensor weights_placements, Tensor weights_offsets, Tensor D_offsets, SymInt total_D, SymInt max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, bool gradient_clipping, float max_gradient, bool stochastic_rounding, {{ args.split_function_schemas_v1 }}, int output_dtype=0) -> Tensor");
     m.impl(
       "split_embedding_codegen_lookup_{{ optimizer }}_function_cpu",
       torch::dispatch(

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
@@ -103,7 +103,7 @@ enum SSDTensor {
       {%- if is_gwd %}
       hash_size_cumsum,
       prev_iter_dev_,
-      learning_rate,
+      learning_rate_tensor,
       weight_decay,
       iter,
       gwd_lower_bound,
@@ -461,7 +461,7 @@ Tensor {{ fwd_mdesc }}_embedding{{ ndesc }}_codegen_forward{{ desc_suffix }}_cud
     {%- if is_gwd %}
     const Tensor& hash_size_cumsum,
     const Tensor& prev_iter_dev,
-    const double learning_rate,
+    const Tensor& learning_rate_tensor,
     const double weight_decay,
     const int64_t iter,
     const double gwd_lower_bound,
@@ -1048,7 +1048,7 @@ Tensor {{ bwd_mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function(
     const double max_gradient,
     const bool stochastic_rounding,
     {%- endif %}
-    {{ args.split_function_args | join(", ") }},
+    {{ args.split_function_args_v1 }},
     {%- endif %}
     const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32),
     const std::optional<Tensor>& B_offsets = std::nullopt,
@@ -1079,6 +1079,14 @@ Tensor {{ bwd_mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function(
 ) {
   // TODO: refactor into macro
   {%- if has_gpu_support %}
+
+    {%- if "learning_rate_tensor" in args.split_function_arg_names %}
+    // `learning rate` is changed to tensor to prevent recompilation. 
+    // This interface (V1) still accepts learning rate as float for backward compatibility, 
+    // We convert learning rate to tensor here to work with the backend
+    // The unified PT2 interface already accepts learning rate as tensor.
+    const auto learning_rate_tensor = at::tensor({learning_rate}, at::TensorOptions().dtype(at::kFloat).device(dev_weights.options().device()));
+    {%- endif %}
 
     {%- if not dense %}
     // Load the config value from JK once
@@ -1162,7 +1170,7 @@ TORCH_LIBRARY_FRAGMENT({{ lib_name }}, m) {
           "    float max_gradient, "
           "    bool stochastic_rounding, "
           {%- endif %}
-          "    {{ args.split_function_schemas | join(", ") }}, "
+          "    {{ args.split_function_schemas_v1 }}, "
           "    int output_dtype=0, "
           "    Tensor? B_offsets=None, "
           "    Tensor? vbe_output_offsets_feature_rank=None, "

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
@@ -385,7 +385,7 @@ batch_index_select_dim0_codegen_backward_kernel_cta_per_row(
               {%- endif %}
               shfl_sync_mask,
               max_vecs,
-              {{ args.split_function_arg_names | join(", ") }}
+              {{ args.split_kernel_arg_names | join(", ") }}
         );
         {%- else %}
         // Write deduplicated gradient to grad_dev_weights gradient is sparse

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -295,7 +295,7 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row(
               {%- endif %}
               shfl_sync_mask,
               max_vecs,
-              {{ args.split_function_arg_names | join(", ") }}
+              {{ args.split_kernel_arg_names | join(", ") }}
         );
         {%- else %}
         // Write deduplicated gradient to grad_dev_weights gradient is sparse

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -517,6 +517,11 @@ Tensor {{ embedding_cuda_op }}(
     const int64_t D = D_.guard_int(__FILE__, __LINE__);
     {%- endif %}
 
+    {%- if "learning_rate" in args.split_kernel_arg_names %}
+    // convert `learning rate` to float since `learning rate` is float in kernels
+    const float learning_rate = learning_rate_tensor.item<float>();
+    {%- endif %}
+
     TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
         {%- if optimizer != "none" %}
         dev_weights,

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_meta_template.cpp
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_meta_template.cpp
@@ -98,7 +98,7 @@ Tensor
     {%- if is_gwd %}
     const Tensor& hash_size_cumsum,
     const Tensor& prev_iter_dev,
-    const double learning_rate,
+    const Tensor& learning_rate_tensor,
     const double weight_decay,
     const int64_t iter,
     const double gwd_lower_bound,

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_kernel_template.cu
@@ -98,7 +98,7 @@ void split_{{ optimizer }}_update_kernel(
           {%- endif %}
           shfl_sync_mask,
           kMaxVecsPerThread,
-          {{ args.split_function_arg_names | join(", ") }});
+          {{ args.split_kernel_arg_names | join(", ") }});
 }
 
 {%- for use_subwarp in [True, False] %}

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_template.cu
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_template.cu
@@ -133,6 +133,10 @@ void split_embedding_{{ optimizer }}_update(
     if (grad_dev_indices.numel() == 0) {
         return;
     }
+    {%- if "learning_rate" in args.split_kernel_arg_constructors %}
+    // convert `learning rate` to float since `learning rate` is float in kernels
+    const float learning_rate = learning_rate_tensor.item<float>();
+    {%- endif %}
 
     CUDA_DEVICE_GUARD(dev_weights);
 

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
@@ -123,7 +123,7 @@ enum SSDTensor {
                 {%- endif %}
                 {%- if is_gwd %}
                 const Tensor& /*prev_iter_dev*/,
-                const double /*learning_rate*/,
+                const Tensor& /*learning_rate*/,
                 const double /*weight_decay*/,
                 const int64_t /*iter*/,
                 const double /*gwd_lower_bound*/,
@@ -167,7 +167,7 @@ enum SSDTensor {
       {%- endif %} {# /* if vbe */ #}
       {%- if is_gwd %}
       prev_iter_dev_,
-      learning_rate,
+      learning_rate_tensor,
       weight_decay,
       iter,
       gwd_lower_bound,

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
@@ -96,7 +96,7 @@ Tensor {{ fwd_mdesc }}_embedding{{ ndesc }}_codegen_forward_{{ desc_suffix }}_pt
     {%- endif %}
     {%- if is_gwd %}
     const Tensor& prev_iter_dev,
-    const double learning_rate,
+    const Tensor& learning_rate_tensor,
     const double weight_decay,
     const int64_t iter,
     const double gwd_lower_bound,
@@ -145,7 +145,7 @@ Tensor {{ fwd_mdesc }}_embedding{{ ndesc }}_codegen_forward_{{ desc_suffix }}_pt
                 {%- if is_gwd %}
                 const Tensor& /*hash_size_cumsum*/,
                 const Tensor& /*prev_iter_dev*/,
-                const double /*learning_rate*/,
+                const Tensor& /*learning_rate_tensor*/,
                 const double /*weight_decay*/,
                 const int64_t /*iter*/,
                 const double /*gwd_lower_bound*/,
@@ -191,7 +191,7 @@ Tensor {{ fwd_mdesc }}_embedding{{ ndesc }}_codegen_forward_{{ desc_suffix }}_pt
             {%- if is_gwd %}
             hash_size_cumsum,
             prev_iter_dev,
-            learning_rate,
+            learning_rate_tensor,
             weight_decay,
             iter,
             gwd_lower_bound,
@@ -529,7 +529,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         {%- endif %}
         {%- if is_gwd %}
         "    Tensor prev_iter_dev, "
-        "    float learning_rate, "
+        "    Tensor learning_rate_tensor, "
         "    float weight_decay, "
         "    int iter, "
         "    float gwd_lower_bound, "

--- a/fbgemm_gpu/codegen/training/python/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/training/python/split_embedding_codegen_lookup_invoker.template
@@ -133,7 +133,7 @@ def invoke(
             gradient_clipping = optimizer_args.gradient_clipping,
             max_gradient=optimizer_args.max_gradient,
             stochastic_rounding=optimizer_args.stochastic_rounding,
-            {%- if "learning_rate" in args.split_function_arg_names %}
+            {%- if "learning_rate" in args.split_function_args_v1 %}
             learning_rate=optimizer_args.learning_rate,
             {%- endif %}
             {%- if "eps" in args.split_function_arg_names %}
@@ -303,7 +303,8 @@ def invoke(
         max_gradient=optimizer_args.max_gradient,
         stochastic_rounding=optimizer_args.stochastic_rounding,
         {%- endif %} # if optimizer == none
-        {%- if "learning_rate" in args.split_function_arg_names %}
+        {%- if "learning_rate" in args.split_function_args_v1 %}
+        # V1 interface still accepts learning_rate as float
         learning_rate=optimizer_args.learning_rate,
         {%- endif %}
         {%- if "eps" in args.split_function_arg_names %}

--- a/fbgemm_gpu/codegen/training/python/split_embedding_optimizer_codegen.template
+++ b/fbgemm_gpu/codegen/training/python/split_embedding_optimizer_codegen.template
@@ -78,7 +78,7 @@ class SplitEmbedding{{ optimizer_class_name }}(Optimizer):
         embedding_specs: List[Tuple[int, int, EmbeddingLocation, ComputeDevice]],
         feature_table_map: Optional[List[int]] = None,
         stochastic_rounding: bool = True,
-        {%- if "learning_rate" in args.split_function_arg_names %}
+        {%- if "learning_rate_tensor" in args.split_function_arg_names %}
         learning_rate: float = 0.01,
         {%- endif %}
         {%- if "eps" in args.split_function_arg_names %}
@@ -106,7 +106,7 @@ class SplitEmbedding{{ optimizer_class_name }}(Optimizer):
 
         # TODO: Add arg checkers
         defaults = dict(
-            {%- if "learning_rate" in args.split_function_arg_names %}
+            {%- if "learning_rate_tensor" in args.split_function_arg_names %}
             learning_rate=learning_rate,
             {%- endif %}
             {%- if "eps" in args.split_function_arg_names %}
@@ -200,8 +200,10 @@ class SplitEmbedding{{ optimizer_class_name }}(Optimizer):
         self.embedding_args = embedding_args
         self.stochastic_rounding = stochastic_rounding
 
-        {%- if "learning_rate" in args.split_function_arg_names %}
-        self.learning_rate = learning_rate
+        {%- if "learning_rate_tensor" in args.split_function_arg_names %}
+        self.learning_rate_tensor = torch.tensor(
+            learning_rate, device=params.weights_dev.device, dtype=torch.float
+        )
         {%- endif %}
         {%- if "eps" in args.split_function_arg_names %}
         self.eps = eps
@@ -258,8 +260,8 @@ class SplitEmbedding{{ optimizer_class_name }}(Optimizer):
                 weights_offsets=self.embedding_args.weights_offsets,
                 max_D=self.embedding_args.max_D,
                 stochastic_rounding=self.stochastic_rounding,
-                {%- if "learning_rate" in args.split_function_arg_names %}
-                learning_rate=self.learning_rate,
+                {%- if "learning_rate_tensor" in args.split_function_arg_names %}
+                learning_rate_tensor=self.learning_rate_tensor,
                 {%- endif %}
                 {%- if "eps" in args.split_function_arg_names %}
                 eps=self.eps,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/386

Context problem from Microve:
pt2 adds a guard on the float inputs, and if it is changed, it will be recompiled. Because compilation itself is expensive, each recompilation could take several minutes to >20 mins. 
In e2e training, there is a warm up stage where the learning rate is gradually increased to a pre-defined value
e.g., say the final learning rate is 0.02 and the warm step is 10k, learning rate will increase from 0 to 0.02 with a step 0.00002 (each iteration, it increases by 0.00002). So, if we let pt2 recompile, it will recompile 10k times.
For a tensor, the guard is only on its shape; if its shape remains the same, it will not trigger recompilation.

----
To prevent recompilation, we change learning rate from float to tensor.
This, however, affects existing TBE frontend and backend.

We will enable learning rate being tensor through the new unified interface (D50481991).
For backward compatibility, the old interface (V1), i.e., `split_embedding_codegen_lookup_{{ optimizer }}_function` and `split_embedding_codegen_lookup_{{ optimizer }}_function_cpu` will continue to take learning rate as `float`.

This diff
- make learning rate tensor in codegen
- keep learning rate as float for kernel arguments
- create optional argument to OptimizerArgs for v1 signature
- make old interface takes tensor as float and converts to tensor before passing to autograd
- converts learning rate back to float before passing to kernels

Old interface:
```
          python -> C++ lookup -> autograd -> backend -> kernel
lr type:  (float)     (float)     (tensor)   (tensor)   (float)
```

PT2 unified interface (D50481991):
```
          python -> C++ lookup -> autograd -> backend -> kernel
lr type:  (tensor)   (tensor)     (tensor)   (tensor)   (float)
```

Differential Revision: D62784577


