### PR TITLE
Use cudagraph for autotune

### DIFF
--- a/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
@@ -2610,6 +2610,7 @@ MATMUL_CONFIGS_NON_PERSISTENT: List[Config] = get_full_non_persistent_tuning_spa
         "perf_model": None,
         "top_k": None,
     },
+    use_cuda_graph=True,
 )
 @triton.heuristics(
     {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/390

Cudagraph seems to give much more stable performance than non-cudagraph on AMD. Let's use that for autotune as well.

Differential Revision: D65180943


