### PR TITLE
Add large my_size support in _block_bucketize_pooled_sparse_features_cuda_kernel2

### DIFF
--- a/fbgemm_gpu/test/sparse/block_bucketize_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_test.py
@@ -1363,7 +1363,7 @@ class BlockBucketizeTest(unittest.TestCase):
         has_weight=st.booleans(),
         bucketize_pos=st.booleans(),
         sequence=st.booleans(),
-        my_size=st.sampled_from([3, 194, 256]),
+        my_size=st.sampled_from([3, 194, 256, 1024]),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=32, deadline=None)
     def test_block_bucketize_sparse_features_large(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/393

`_block_bucketize_pooled_sparse_features_cuda_kernel2` failed with
large `my_size` value due to the insufficient shared memory capacity.
This diff works around the issue by reducing the thread block size to
reduce the shared memory requirement.  However, if `my_size` is too
large, we can still run into the issue.  Currently, we catch this
problem and throw an error.

Differential Revision: D65225942


