### PR TITLE
Adjust kNumThreads for bounds_check_indices_kernel

### DIFF
--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_v2.cu
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_v2.cu
@@ -24,11 +24,13 @@ __device__ void adjust_offset_kernel(
   indices_start =
       std::max(static_cast<index_t>(0), std::min(indices_start, num_indices));
   indices_end = std::max(indices_start, std::min(indices_end, num_indices));
-  *offset_acc_start = indices_start;
-  *offset_acc_end = indices_end;
+  if (threadIdx.x == 0) {
+    *offset_acc_start = indices_start;
+    *offset_acc_end = indices_end;
+  }
 }
 
-template <typename index_t, bool vbe>
+template <typename index_t, bool vbe, BoundsCheckMode bounds_check_mode>
 __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel_v2(
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         rows_per_table,
@@ -36,7 +38,6 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel_v2(
     at::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> offsets,
     const int32_t* const B_offsets, // Use a raw pointer to avoid creating a
                                     // dummy PackedTensorAccessor
-    const int64_t bounds_check_mode_,
     at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> warning,
     FixedDivisor fd,
     const int32_t vbe_bound,
@@ -44,6 +45,39 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel_v2(
   int32_t T = rows_per_table.size(0);
   int32_t total_B = offsets.size(0) - 1;
   int32_t B = vbe ? 0 : (total_B / T);
+
+  const index_t num_indices = indices.size(0);
+  const int32_t b_t_start = blockIdx.x * blockDim.y + threadIdx.y;
+  index_t invalid_i = -1, invalid_idx = -1;
+  int32_t invalid_b_t = -1;
+
+  // Check the last element
+  if (b_t_start == 0 && threadIdx.x == 0) {
+    if (bounds_check_mode == BoundsCheckMode::FATAL) {
+      CUDA_KERNEL_ASSERT2(num_indices == offsets[total_B]);
+    } else if (bounds_check_mode == BoundsCheckMode::WARNING) {
+      if (num_indices != offsets[total_B]) {
+        if (gpuAtomicIncrement(&warning[0]) == 0) {
+          printf(
+              "EmbeddingBoundsCheck (VBE %s): the last element in offsets is incorrect for "
+              "total batch size %s: %d, total table num T: %d, "
+              " last element in offsets: %lld, indices size: %lld. "
+              " Setting the last element in offsets to be indices size.\n",
+              vbe ? "true" : "false",
+              vbe ? "total_B" : "B",
+              vbe ? total_B : B,
+              T,
+              static_cast<int64_t>(offsets[total_B]),
+              static_cast<int64_t>(num_indices));
+        }
+        offsets[total_B] = num_indices;
+      }
+    } else if (bounds_check_mode == BoundsCheckMode::IGNORE) {
+      if (num_indices != offsets[total_B]) {
+        offsets[total_B] = num_indices;
+      }
+    }
+  }
 
   for (int32_t b_t_init = blockIdx.x * blockDim.y + threadIdx.y;
        b_t_init < (vbe ? vbe_bound : total_B);
@@ -69,12 +103,9 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel_v2(
       b_t = B_start + b;
     }
 
-    const auto bounds_check_mode =
-        static_cast<BoundsCheckMode>(bounds_check_mode_);
     const auto num_rows = rows_per_table[t];
     auto indices_start = offsets[b_t];
     auto indices_end = offsets[b_t + 1];
-    const index_t num_indices = indices.size(0);
 
     if (bounds_check_mode == BoundsCheckMode::FATAL) {
       CUDA_KERNEL_ASSERT2(indices_start >= 0);
@@ -83,7 +114,7 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel_v2(
     } else if (bounds_check_mode == BoundsCheckMode::WARNING) {
       if (indices_start < 0 || indices_start > indices_end ||
           indices_end > num_indices) {
-        if (gpuAtomicIncrement(&warning[0]) == 0) {
+        if (threadIdx.x == 0 && gpuAtomicIncrement(&warning[0]) == 0) {
           printf(
               "EmbeddingBoundsCheck (VBE %s): (at least one) Out of bounds access for "
               "batch: %d, table: %d, indices_start: %lld, indices_end: %lld,"
@@ -127,22 +158,12 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel_v2(
             idx < num_rows && "Failed idx < num_rows in bounds_check_indices");
       } else if (bounds_check_mode == BoundsCheckMode::WARNING) {
         if (idx < 0 || idx >= num_rows) {
-          if (gpuAtomicIncrement(&warning[0]) == 0) {
-            printf(
-                "EmbeddingBoundsCheck (VBE %s): (at least one) Out of bounds access for batch: %d, table: %d, bag element: %lld, idx: %lld, num_rows: %lld, indices_start: %lld, indices_end: %lld, T: %d, B: %d, b_t: %d. Setting idx to zero.\n",
-                vbe ? "true" : "false",
-                b,
-                t,
-                static_cast<int64_t>(i),
-                static_cast<int64_t>(idx),
-                num_rows,
-                static_cast<int64_t>(indices_start),
-                static_cast<int64_t>(indices_end),
-                T,
-                B,
-                b_t);
-          }
+          invalid_i = i;
+          invalid_idx = idx;
+          invalid_b_t = b_t;
           indices[indices_start + i] = 0;
+          // Count warnings to keep the unit tests happy
+          gpuAtomicIncrement(&warning[0]);
         }
       } else if (bounds_check_mode == BoundsCheckMode::IGNORE) {
         if (idx < 0 || idx >= num_rows) {
@@ -150,31 +171,31 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel_v2(
         }
       }
     }
+  } // for b_t
 
-    if (bounds_check_mode == BoundsCheckMode::FATAL) {
-      CUDA_KERNEL_ASSERT2(num_indices == offsets[total_B]);
-    } else if (bounds_check_mode == BoundsCheckMode::WARNING) {
-      if (num_indices != offsets[total_B]) {
-        if (gpuAtomicIncrement(&warning[0]) == 0) {
-          printf(
-              "EmbeddingBoundsCheck (VBE %s): the last element in offsets is incorrect for "
-              "total batch size %s: %d, total table num T: %d, "
-              " last element in offsets: %lld, indices size: %lld. "
-              " Setting the last element in offsets to be indices size.\n",
-              vbe ? "true" : "false",
-              vbe ? "total_B" : "B",
-              vbe ? total_B : B,
-              T,
-              static_cast<int64_t>(offsets[total_B]),
-              static_cast<int64_t>(num_indices));
-        }
-        offsets[total_B] = num_indices;
-      }
-    } else if (bounds_check_mode == BoundsCheckMode::IGNORE) {
-      if (num_indices != offsets[total_B]) {
-        offsets[total_B] = num_indices;
-      }
-    }
+  if (bounds_check_mode == BoundsCheckMode::WARNING && invalid_i != -1 &&
+      static_cast<int64_t>(atomicAdd(
+          reinterpret_cast<unsigned long long int*>(&warning[0]), 0)) == 0) {
+    int32_t b;
+    int32_t t;
+
+    fd.DivMod(invalid_b_t, &t, &b);
+
+    int32_t B = vbe ? (B_offsets[t + 1] - B_offsets[t]) : (total_B / T);
+
+    printf(
+        "EmbeddingBoundsCheck (VBE %s): (at least one) Out of bounds access for batch: %d, table: %d, bag element: %lld, idx: %lld, num_rows: %lld, indices_start: %lld, indices_end: %lld, T: %d, B: %d, b_t: %d. Setting idx to zero.\n",
+        vbe ? "true" : "false",
+        b,
+        t,
+        static_cast<int64_t>(invalid_i),
+        static_cast<int64_t>(invalid_idx),
+        rows_per_table[t],
+        static_cast<int64_t>(offsets[invalid_b_t]),
+        static_cast<int64_t>(offsets[invalid_b_t + 1]),
+        T,
+        B,
+        invalid_b_t);
   }
 }
 
@@ -237,26 +258,36 @@ void _bounds_check_indices_cuda_v2(
   TORCH_CHECK(
       vbe_bound >= 0, "EmbeddingBoundsCheck: vbe_bound is out of bound");
 
-  AT_DISPATCH_INDEX_TYPES(
-      indices.scalar_type(), "bounds_check_indices_cuda", [&] {
-        const auto bounds_check_kernel =
-            (vbe ? bounds_check_indices_kernel_v2<index_t, true>
-                 : bounds_check_indices_kernel_v2<index_t, false>);
-        TORCH_DSA_KERNEL_LAUNCH(
-            bounds_check_kernel,
-            min(div_round_up(max_B_ * T, kNumThreads / fbgemm_gpu::kWarpSize),
-                get_max_thread_blocks_()),
-            dim3(fbgemm_gpu::kWarpSize, kNumThreads / fbgemm_gpu::kWarpSize),
-            0,
-            at::cuda::getCurrentCUDAStream(),
-            rows_per_table
-                .packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
-            indices.packed_accessor32<index_t, 1, at::RestrictPtrTraits>(),
-            offsets.packed_accessor32<index_t, 1, at::RestrictPtrTraits>(),
-            vbe ? B_offsets.value().data_ptr<int32_t>() : nullptr,
-            bounds_check_mode_,
-            warning.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),
-            FixedDivisor(max_B_),
-            vbe_bound);
-      });
+#define INVOKE_BOUNDS_CHECK_INDICES(MODE)                                      \
+  if (bounds_check_mode == MODE) {                                             \
+    AT_DISPATCH_INDEX_TYPES(                                                   \
+        indices.scalar_type(), "bounds_check_indices_cuda", [&] {              \
+          const auto bounds_check_kernel =                                     \
+              (vbe ? bounds_check_indices_kernel_v2<index_t, true, MODE>       \
+                   : bounds_check_indices_kernel_v2<index_t, false, MODE>);    \
+          TORCH_DSA_KERNEL_LAUNCH(                                             \
+              bounds_check_kernel,                                             \
+              min(div_round_up(                                                \
+                      max_B_* T, kNumThreads / fbgemm_gpu::kWarpSize),         \
+                  get_max_thread_blocks_()),                                   \
+              dim3(                                                            \
+                  fbgemm_gpu::kWarpSize, kNumThreads / fbgemm_gpu::kWarpSize), \
+              0,                                                               \
+              at::cuda::getCurrentCUDAStream(),                                \
+              rows_per_table                                                   \
+                  .packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),     \
+              indices.packed_accessor32<index_t, 1, at::RestrictPtrTraits>(),  \
+              offsets.packed_accessor32<index_t, 1, at::RestrictPtrTraits>(),  \
+              vbe ? B_offsets.value().data_ptr<int32_t>() : nullptr,           \
+              warning.packed_accessor32<int64_t, 1, at::RestrictPtrTraits>(),  \
+              FixedDivisor(max_B_),                                            \
+              vbe_bound);                                                      \
+        });                                                                    \
+  }
+
+  INVOKE_BOUNDS_CHECK_INDICES(BoundsCheckMode::FATAL)
+  INVOKE_BOUNDS_CHECK_INDICES(BoundsCheckMode::WARNING)
+  INVOKE_BOUNDS_CHECK_INDICES(BoundsCheckMode::IGNORE)
+
+#undef INVOKE_BOUNDS_CHECK_INDICES
 }

--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_v2.cu
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_v2.cu
@@ -251,7 +251,7 @@ void _bounds_check_indices_cuda_v2(
             " is not equal to indices size " + std::to_string(num_indices));
   }
 
-  constexpr size_t kNumThreads = 256;
+  constexpr size_t kNumThreads = 1024;
   const auto max_B_ = vbe ? max_B : B;
 
   const int32_t vbe_bound = max_B_ * T;


### PR DESCRIPTION
Summary:
Increase the thread block size to increase the number of warps per SM.
This results in a better kernel time

Differential Revision: D65071345
