### PR TITLE
Revert D62784577: Multisect successfully blamed "D62784577: [fbgemm_gpu] Make `learning rate` tensor (Backend)" for one test failure

### DIFF
--- a/fbgemm_gpu/codegen/genscript/optimizers.py
+++ b/fbgemm_gpu/codegen/genscript/optimizers.py
@@ -36,10 +36,7 @@ def dense() -> Dict[str, Any]:
         "args": OptimizerArgsSet.create(
             [
                 OptimItem(ArgType.FLOAT, "unused"),
-            ],
-            {
-                "v1": "float unused = 0",
-            },
+            ]
         ),
         "has_cpu_support": True,
         "has_gpu_support": True,
@@ -78,10 +75,9 @@ def adagrad() -> Dict[str, Any]:
         "args": OptimizerArgsSet.create(
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
-                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
-            ],
-            {"v1": "Tensor momentum1, float eps = 0, float learning_rate = 0"},
+                OptimItem(ArgType.FLOAT, "learning_rate"),
+            ]
         ),
         "split_precomputation": "",
         "split_weight_update": split_weight_update,
@@ -246,15 +242,12 @@ def rowwise_adagrad() -> Dict[str, Any]:
         "args": OptimizerArgsSet.create(
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
-                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
                 OptimItem(ArgType.INT, "weight_decay_mode", 0),
                 OptimItem(ArgType.FLOAT, "max_norm", 0.0),
-            ],
-            {
-                "v1": "Tensor momentum1, float eps = 0, float learning_rate = 0, float weight_decay = 0.0, int weight_decay_mode = 0.0, float max_norm = 0.0"
-            },
+            ]
         ),
         "split_precomputation": split_precomputation,
         "split_weight_update": split_weight_update,
@@ -282,14 +275,11 @@ def approx_rowwise_adagrad() -> Dict[str, Any]:
         "args": OptimizerArgsSet.create(
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
-                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
                 OptimItem(ArgType.INT, "weight_decay_mode", 0),
-            ],
-            {
-                "v1": "Tensor momentum1, float eps = 0, float learning_rate = 0, float weight_decay = 0.0, int weight_decay_mode = 0.0",
-            },
+            ]
         ),
         "split_precomputation": rowwise_adagrad_args["split_precomputation"],
         "split_weight_update": approx_split_weight_update,
@@ -392,14 +382,11 @@ def rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
         "args": OptimizerArgsSet.create(
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
-                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
                 OptimItem(ArgType.INT, "weight_decay_mode", 0),
-            ],
-            {
-                "v1": "Tensor momentum1, float eps = 0, float learning_rate = 0, float weight_decay = 0.0, int weight_decay_mode = 0.0"
-            },
+            ]
         ),
         "split_precomputation": split_precomputation,
         "split_weight_update": split_weight_update,
@@ -428,14 +415,11 @@ def approx_rowwise_adagrad_with_weight_decay() -> Dict[str, Any]:
         "args": OptimizerArgsSet.create(
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
-                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
                 OptimItem(ArgType.INT, "weight_decay_mode", 0),
-            ],
-            {
-                "v1": "Tensor momentum1, float eps = 0, float learning_rate = 0, float weight_decay = 0.0, int weight_decay_mode = 0.0"
-            },
+            ]
         ),
         "split_precomputation": rowwise_adagrad_with_weight_decay_args[
             "split_precomputation"
@@ -597,8 +581,8 @@ def rowwise_adagrad_with_counter() -> Dict[str, Any]:
                 OptimItem(ArgType.TENSOR, "momentum1"),
                 OptimItem(ArgType.TENSOR, "prev_iter"),
                 OptimItem(ArgType.TENSOR, "row_counter"),
-                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
                 OptimItem(ArgType.INT, "iter"),
                 OptimItem(ArgType.INT, "counter_halflife", -1),
@@ -613,10 +597,7 @@ def rowwise_adagrad_with_counter() -> Dict[str, Any]:
                 OptimItem(ArgType.INT, "regularization_mode", 0),
                 OptimItem(ArgType.FLOAT, "weight_norm_coefficient", 0.0),
                 OptimItem(ArgType.FLOAT, "lower_bound", 0.0),
-            ],
-            {
-                "v1": "Tensor momentum1, Tensor prev_iter, Tensor row_counter, float eps = 0, float learning_rate = 0, float weight_decay = 0.0, int iter = 0, int counter_halflife = -1, int adjustment_iter = -1, float adjustment_ub = 1.0, int learning_rate_mode = -1, int weight_decay_mode = 1, int grad_sum_decay = -1, float max_counter = 0, float tail_id_threshold = 0.0, int is_tail_id_thresh_ratio = 0, int regularization_mode = 0, float weight_norm_coefficient = 0.0, float lower_bound = 0.0"
-            },
+            ]
         ),
         "split_precomputation": split_precomputation,
         "split_weight_update": split_weight_update,
@@ -646,8 +627,8 @@ def approx_rowwise_adagrad_with_counter() -> Dict[str, Any]:
                 OptimItem(ArgType.TENSOR, "momentum1"),
                 OptimItem(ArgType.TENSOR, "prev_iter"),
                 OptimItem(ArgType.TENSOR, "row_counter"),
-                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "weight_decay", 0.0),
                 OptimItem(ArgType.INT, "iter"),
                 OptimItem(ArgType.INT, "counter_halflife", -1),
@@ -662,10 +643,7 @@ def approx_rowwise_adagrad_with_counter() -> Dict[str, Any]:
                 OptimItem(ArgType.INT, "regularization_mode", 0),
                 OptimItem(ArgType.FLOAT, "weight_norm_coefficient", 0.0),
                 OptimItem(ArgType.FLOAT, "lower_bound", 0.0),
-            ],
-            {
-                "v1": "Tensor momentum1, Tensor prev_iter, Tensor row_counter, float eps = 0, float learning_rate = 0, float weight_decay = 0.0, int iter = 0, int counter_halflife = -1, int adjustment_iter = -1, float adjustment_ub = 1.0, int learning_rate_mode = -1, int weight_decay_mode = 1, int grad_sum_decay = -1, float max_counter = 0, float tail_id_threshold = 0.0, int is_tail_id_thresh_ratio = 0, int regularization_mode = 0, float weight_norm_coefficient = 0.0, float lower_bound = 0.0"
-            },
+            ]
         ),
         "split_precomputation": rowwise_adagrad_with_counter_args[
             "split_precomputation"
@@ -744,14 +722,11 @@ def rowwise_weighted_adagrad() -> Dict[str, Any]:
         "args": OptimizerArgsSet.create(
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
-                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
                 OptimItem(ArgType.FLOAT, "eps"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "weight_decay"),
                 OptimItem(ArgType.INT, "iter"),
-            ],
-            {
-                "v1": "Tensor momentum1, float eps = 0, float learning_rate = 0, float weight_decay = 0, int iter = 0"
-            },
+            ]
         ),
         "split_precomputation": split_precomputation,
         "split_weight_update": split_weight_update,
@@ -777,10 +752,7 @@ def sgd() -> Dict[str, Any]:
 
     return {
         "optimizer": "sgd",
-        "args": OptimizerArgsSet.create(
-            [OptimItem(ArgType.TENSOR, "learning_rate_tensor")],
-            {"v1": "float learning_rate = 0"},
-        ),
+        "args": OptimizerArgsSet.create([OptimItem(ArgType.FLOAT, "learning_rate")]),
         "split_precomputation": "",
         "split_weight_update": split_weight_update,
         "split_post_update": "",
@@ -805,10 +777,7 @@ def approx_sgd() -> Dict[str, Any]:
 
     return {
         "optimizer": "approx_sgd",
-        "args": OptimizerArgsSet.create(
-            [OptimItem(ArgType.TENSOR, "learning_rate_tensor")],
-            {"v1": "float learning_rate = 0"},
-        ),
+        "args": OptimizerArgsSet.create([OptimItem(ArgType.FLOAT, "learning_rate")]),
         "split_precomputation": "",
         "split_weight_update": approx_split_weight_update,
         "split_post_update": "",
@@ -880,16 +849,13 @@ def lamb() -> Dict[str, Any]:
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
                 OptimItem(ArgType.TENSOR, "momentum2"),
-                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "eps"),
                 OptimItem(ArgType.FLOAT, "beta1"),
                 OptimItem(ArgType.FLOAT, "beta2"),
                 OptimItem(ArgType.FLOAT, "weight_decay"),
                 OptimItem(ArgType.INT, "iter"),
-            ],
-            {
-                "v1": "Tensor momentum1, Tensor momentum2, float learning_rate = 0, float eps = 0, float beta1 = 0, float beta2 = 0, float weight_decay = 0, int iter = 0"
-            },
+            ]
         ),
         "split_precomputation": split_precomputation,
         "split_weight_update": split_weight_update,
@@ -977,16 +943,13 @@ def partial_rowwise_lamb() -> Dict[str, Any]:
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
                 OptimItem(ArgType.TENSOR, "momentum2"),
-                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "eps"),
                 OptimItem(ArgType.FLOAT, "beta1"),
                 OptimItem(ArgType.FLOAT, "beta2"),
                 OptimItem(ArgType.FLOAT, "weight_decay"),
                 OptimItem(ArgType.INT, "iter"),
-            ],
-            {
-                "v1": "Tensor momentum1, Tensor momentum2, float learning_rate = 0, float eps = 0, float beta1 = 0, float beta2 = 0, float weight_decay = 0, int iter = 0"
-            },
+            ]
         ),
         "split_precomputation": split_precomputation,
         "split_weight_update": split_weight_update,
@@ -1037,16 +1000,13 @@ def adam() -> Dict[str, Any]:
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
                 OptimItem(ArgType.TENSOR, "momentum2"),
-                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "eps"),
                 OptimItem(ArgType.FLOAT, "beta1"),
                 OptimItem(ArgType.FLOAT, "beta2"),
                 OptimItem(ArgType.FLOAT, "weight_decay"),
                 OptimItem(ArgType.INT, "iter"),
-            ],
-            {
-                "v1": "Tensor momentum1, Tensor momentum2, float learning_rate = 0, float eps = 0, float beta1 = 0, float beta2 = 0, float weight_decay = 0, int iter = 0"
-            },
+            ]
         ),
         "split_precomputation": "",
         "split_weight_update": split_weight_update,
@@ -1117,16 +1077,13 @@ def partial_rowwise_adam() -> Dict[str, Any]:
                     "momentum2",
                     ph_tys=[ArgType.FLOAT_TENSOR, ArgType.BFLOAT16_TENSOR],
                 ),
-                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "eps"),
                 OptimItem(ArgType.FLOAT, "beta1"),
                 OptimItem(ArgType.FLOAT, "beta2"),
                 OptimItem(ArgType.FLOAT, "weight_decay"),
                 OptimItem(ArgType.INT, "iter"),
-            ],
-            {
-                "v1": "Tensor momentum1, Tensor momentum2, float learning_rate = 0, float eps = 0, float beta1 = 0, float beta2 = 0, float weight_decay = 0, int iter = 0"
-            },
+            ]
         ),
         "split_precomputation": split_precomputation,
         "split_weight_update": split_weight_update,
@@ -1188,14 +1145,11 @@ def lars_sgd() -> Dict[str, Any]:
         "args": OptimizerArgsSet.create(
             [
                 OptimItem(ArgType.TENSOR, "momentum1"),
-                OptimItem(ArgType.TENSOR, "learning_rate_tensor"),
+                OptimItem(ArgType.FLOAT, "learning_rate"),
                 OptimItem(ArgType.FLOAT, "eta"),
                 OptimItem(ArgType.FLOAT, "momentum"),
                 OptimItem(ArgType.FLOAT, "weight_decay"),
-            ],
-            {
-                "v1": "Tensor momentum1, float learning_rate = 0, float eta = 0, float momentum = 0, float weight_decay = 0"
-            },
+            ]
         ),
         "split_precomputation": split_precomputation,
         "split_weight_update": split_weight_update,
@@ -1217,10 +1171,7 @@ def none_optimizer() -> Dict[str, Any]:
             [
                 OptimItem(ArgType.INT, "total_hash_size"),
                 OptimItem(ArgType.SYM_INT, "total_unique_indices"),
-            ],
-            {
-                "v1": "int total_hash_size = 0, SymInt total_unique_indices = 0",
-            },
+            ]
         ),
         # Generate only GPU code
         "has_cpu_support": False,

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_cpu_template.cpp
@@ -315,11 +315,6 @@ for (const auto d : c10::irange(D)) {
   int64_t B = (offsets.size(0) - 1) / T;
   TORCH_CHECK_GE(B, 0);
 
-  {%- if "learning_rate" in args.split_cpu_kernel_arg_constructors %}
-  // convert `learning rate` to float since `learning rate` is float in kernels
-  const float learning_rate = learning_rate_tensor.item<float>();
-  {%- endif %}
-
   const auto weights_offsets_data = weights_offsets.accessor<int64_t, 1>();
   const auto D_offsets_data = D_offsets.accessor<int, 1>();
 

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_cpu_template.cpp
@@ -215,16 +215,9 @@ Tensor split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(
     bool gradient_clipping,
     double max_gradient,
     bool stochastic_rounding,
-    {{ args.split_function_args_v1 }},
+    {{ args.split_function_args | join(", ") }},
     int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)) {
   {% if has_cpu_support %}
-  {%- if "learning_rate_tensor" in args.split_function_arg_names %}
-  // `learning rate` is changed to tensor to prevent recompilation. 
-  // This interface (V1) still accepts learning rate as float for backward compatibility, 
-  // We convert learning rate to tensor here to work with the backend
-  // The unified PT2 interface already accepts learning rate as tensor.
-  const auto learning_rate_tensor = at::tensor({learning_rate}, at::TensorOptions().dtype(at::kFloat).device(host_weights.options().device()));
-  {%- endif %}
   return SplitLookupFunction_{{ optimizer }}_Op::apply(
       host_weights,
       weights_placements,
@@ -252,7 +245,7 @@ Tensor split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(
 
 // Deprecated for fb namespace! Please use fbgemm namespace instead!
 TORCH_LIBRARY_FRAGMENT(fb, m) {
-    m.def("split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(Tensor(a!) host_weights, Tensor weights_placements, Tensor weights_offsets, Tensor D_offsets, SymInt total_D, SymInt max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, bool gradient_clipping, float max_gradient, bool stochastic_rounding, {{ args.split_function_schemas_v1 }}, int output_dtype=0) -> Tensor");
+    m.def("split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(Tensor(a!) host_weights, Tensor weights_placements, Tensor weights_offsets, Tensor D_offsets, SymInt total_D, SymInt max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, bool gradient_clipping, float max_gradient, bool stochastic_rounding, {{ args.split_function_schemas | join(", ") }}, int output_dtype=0) -> Tensor");
     m.impl(
       "split_embedding_codegen_lookup_{{ optimizer }}_function_cpu",
       torch::dispatch(
@@ -261,7 +254,7 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
 }
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
-    m.def("split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(Tensor(a!) host_weights, Tensor weights_placements, Tensor weights_offsets, Tensor D_offsets, SymInt total_D, SymInt max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, bool gradient_clipping, float max_gradient, bool stochastic_rounding, {{ args.split_function_schemas_v1 }}, int output_dtype=0) -> Tensor");
+    m.def("split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(Tensor(a!) host_weights, Tensor weights_placements, Tensor weights_offsets, Tensor D_offsets, SymInt total_D, SymInt max_D, Tensor hash_size_cumsum, int total_hash_size_bits, Tensor indices, Tensor offsets, int pooling_mode, Tensor? indice_weights, Tensor? feature_requires_grad, bool gradient_clipping, float max_gradient, bool stochastic_rounding, {{ args.split_function_schemas | join(", ") }}, int output_dtype=0) -> Tensor");
     m.impl(
       "split_embedding_codegen_lookup_{{ optimizer }}_function_cpu",
       torch::dispatch(

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
@@ -385,7 +385,7 @@ batch_index_select_dim0_codegen_backward_kernel_cta_per_row(
               {%- endif %}
               shfl_sync_mask,
               max_vecs,
-              {{ args.split_kernel_arg_names | join(", ") }}
+              {{ args.split_function_arg_names | join(", ") }}
         );
         {%- else %}
         // Write deduplicated gradient to grad_dev_weights gradient is sparse

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -295,7 +295,7 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row(
               {%- endif %}
               shfl_sync_mask,
               max_vecs,
-              {{ args.split_kernel_arg_names | join(", ") }}
+              {{ args.split_function_arg_names | join(", ") }}
         );
         {%- else %}
         // Write deduplicated gradient to grad_dev_weights gradient is sparse

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -517,11 +517,6 @@ Tensor {{ embedding_cuda_op }}(
     const int64_t D = D_.guard_int(__FILE__, __LINE__);
     {%- endif %}
 
-    {%- if "learning_rate" in args.split_kernel_arg_names %}
-    // convert `learning rate` to float since `learning rate` is float in kernels
-    const float learning_rate = learning_rate_tensor.item<float>();
-    {%- endif %}
-
     TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
         {%- if optimizer != "none" %}
         dev_weights,

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_meta_template.cpp
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_meta_template.cpp
@@ -98,7 +98,7 @@ Tensor
     {%- if is_gwd %}
     const Tensor& hash_size_cumsum,
     const Tensor& prev_iter_dev,
-    const Tensor& learning_rate_tensor,
+    const double learning_rate,
     const double weight_decay,
     const int64_t iter,
     const double gwd_lower_bound,

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
@@ -384,7 +384,7 @@ batch_index_select_dim0_codegen_forward_cuda(
     {%- if is_gwd_kernel %}
     const Tensor& hash_size_cumsum,
     const Tensor& prev_iter_dev,
-    const Tensor& learning_rate_tensor,
+    const double learning_rate,
     const double weight_decay,
     const int64_t iter,
     const double gwd_lower_bound,
@@ -483,14 +483,12 @@ batch_index_select_dim0_codegen_forward_cuda(
     TENSORS_HAVE_SAME_NUMEL(vbe_row_output_offsets, vbe_b_t_map);
     TORCH_CHECK_GE(vbe_output_size, 0);
 
-    // Cast info_B_mask from int64_t to uint32_t
-    const uint32_t info_B_mask = info_B_mask_int64;
+    {%- if is_gwd_kernel %}
+    TORCH_CHECK(learning_rate >= 0, "Expect to apply weight decay but learning rate is < 0")
     {%- endif %}
 
-    {%- if is_gwd_kernel %}
-    // convert `learning rate` to float since `learning rate` is float in kernels
-    const float learning_rate = learning_rate_tensor.item<float>();
-    TORCH_CHECK(learning_rate >= 0, "Expect to apply weight decay but learning rate is < 0");
+    // Cast info_B_mask from int64_t to uint32_t
+    const uint32_t info_B_mask = info_B_mask_int64;
     {%- endif %}
 
     Tensor output;
@@ -874,7 +872,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
           {%- if is_gwd_kernel %}
           "    Tensor hash_size_cumsum, "
           "    Tensor prev_iter_dev, "
-          "    Tensor learning_rate_tensor, "
+          "    float learning_rate, "
           "    float weight_decay, "
           "    int iter, "
           "    float gwd_lower_bound, "

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_kernel_template.cu
@@ -98,7 +98,7 @@ void split_{{ optimizer }}_update_kernel(
           {%- endif %}
           shfl_sync_mask,
           kMaxVecsPerThread,
-          {{ args.split_kernel_arg_names | join(", ") }});
+          {{ args.split_function_arg_names | join(", ") }});
 }
 
 {%- for use_subwarp in [True, False] %}

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_template.cu
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_template.cu
@@ -133,10 +133,6 @@ void split_embedding_{{ optimizer }}_update(
     if (grad_dev_indices.numel() == 0) {
         return;
     }
-    {%- if "learning_rate" in args.split_kernel_arg_constructors %}
-    // convert `learning rate` to float since `learning rate` is float in kernels
-    const float learning_rate = learning_rate_tensor.item<float>();
-    {%- endif %}
 
     CUDA_DEVICE_GUARD(dev_weights);
 

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
@@ -123,7 +123,7 @@ enum SSDTensor {
                 {%- endif %}
                 {%- if is_gwd %}
                 const Tensor& /*prev_iter_dev*/,
-                const Tensor& /*learning_rate*/,
+                const double /*learning_rate*/,
                 const double /*weight_decay*/,
                 const int64_t /*iter*/,
                 const double /*gwd_lower_bound*/,
@@ -167,7 +167,7 @@ enum SSDTensor {
       {%- endif %} {# /* if vbe */ #}
       {%- if is_gwd %}
       prev_iter_dev_,
-      learning_rate_tensor,
+      learning_rate,
       weight_decay,
       iter,
       gwd_lower_bound,

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
@@ -96,7 +96,7 @@ Tensor {{ fwd_mdesc }}_embedding{{ ndesc }}_codegen_forward_{{ desc_suffix }}_pt
     {%- endif %}
     {%- if is_gwd %}
     const Tensor& prev_iter_dev,
-    const Tensor& learning_rate_tensor,
+    const double learning_rate,
     const double weight_decay,
     const int64_t iter,
     const double gwd_lower_bound,
@@ -145,7 +145,7 @@ Tensor {{ fwd_mdesc }}_embedding{{ ndesc }}_codegen_forward_{{ desc_suffix }}_pt
                 {%- if is_gwd %}
                 const Tensor& /*hash_size_cumsum*/,
                 const Tensor& /*prev_iter_dev*/,
-                const Tensor& /*learning_rate_tensor*/,
+                const double /*learning_rate*/,
                 const double /*weight_decay*/,
                 const int64_t /*iter*/,
                 const double /*gwd_lower_bound*/,
@@ -191,7 +191,7 @@ Tensor {{ fwd_mdesc }}_embedding{{ ndesc }}_codegen_forward_{{ desc_suffix }}_pt
             {%- if is_gwd %}
             hash_size_cumsum,
             prev_iter_dev,
-            learning_rate_tensor,
+            learning_rate,
             weight_decay,
             iter,
             gwd_lower_bound,
@@ -529,7 +529,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         {%- endif %}
         {%- if is_gwd %}
         "    Tensor prev_iter_dev, "
-        "    Tensor learning_rate_tensor, "
+        "    float learning_rate, "
         "    float weight_decay, "
         "    int iter, "
         "    float gwd_lower_bound, "

--- a/fbgemm_gpu/codegen/training/python/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/training/python/split_embedding_codegen_lookup_invoker.template
@@ -133,7 +133,7 @@ def invoke(
             gradient_clipping = optimizer_args.gradient_clipping,
             max_gradient=optimizer_args.max_gradient,
             stochastic_rounding=optimizer_args.stochastic_rounding,
-            {%- if "learning_rate" in args.split_function_args_v1 %}
+            {%- if "learning_rate" in args.split_function_arg_names %}
             learning_rate=optimizer_args.learning_rate,
             {%- endif %}
             {%- if "eps" in args.split_function_arg_names %}
@@ -303,8 +303,7 @@ def invoke(
         max_gradient=optimizer_args.max_gradient,
         stochastic_rounding=optimizer_args.stochastic_rounding,
         {%- endif %} # if optimizer == none
-        {%- if "learning_rate" in args.split_function_args_v1 %}
-        # V1 interface still accepts learning_rate as float
+        {%- if "learning_rate" in args.split_function_arg_names %}
         learning_rate=optimizer_args.learning_rate,
         {%- endif %}
         {%- if "eps" in args.split_function_arg_names %}

--- a/fbgemm_gpu/codegen/training/python/split_embedding_optimizer_codegen.template
+++ b/fbgemm_gpu/codegen/training/python/split_embedding_optimizer_codegen.template
@@ -78,7 +78,7 @@ class SplitEmbedding{{ optimizer_class_name }}(Optimizer):
         embedding_specs: List[Tuple[int, int, EmbeddingLocation, ComputeDevice]],
         feature_table_map: Optional[List[int]] = None,
         stochastic_rounding: bool = True,
-        {%- if "learning_rate_tensor" in args.split_function_arg_names %}
+        {%- if "learning_rate" in args.split_function_arg_names %}
         learning_rate: float = 0.01,
         {%- endif %}
         {%- if "eps" in args.split_function_arg_names %}
@@ -106,7 +106,7 @@ class SplitEmbedding{{ optimizer_class_name }}(Optimizer):
 
         # TODO: Add arg checkers
         defaults = dict(
-            {%- if "learning_rate_tensor" in args.split_function_arg_names %}
+            {%- if "learning_rate" in args.split_function_arg_names %}
             learning_rate=learning_rate,
             {%- endif %}
             {%- if "eps" in args.split_function_arg_names %}
@@ -200,10 +200,8 @@ class SplitEmbedding{{ optimizer_class_name }}(Optimizer):
         self.embedding_args = embedding_args
         self.stochastic_rounding = stochastic_rounding
 
-        {%- if "learning_rate_tensor" in args.split_function_arg_names %}
-        self.learning_rate_tensor = torch.tensor(
-            learning_rate, device=params.weights_dev.device, dtype=torch.float
-        )
+        {%- if "learning_rate" in args.split_function_arg_names %}
+        self.learning_rate = learning_rate
         {%- endif %}
         {%- if "eps" in args.split_function_arg_names %}
         self.eps = eps
@@ -260,8 +258,8 @@ class SplitEmbedding{{ optimizer_class_name }}(Optimizer):
                 weights_offsets=self.embedding_args.weights_offsets,
                 max_D=self.embedding_args.max_D,
                 stochastic_rounding=self.stochastic_rounding,
-                {%- if "learning_rate_tensor" in args.split_function_arg_names %}
-                learning_rate_tensor=self.learning_rate_tensor,
+                {%- if "learning_rate" in args.split_function_arg_names %}
+                learning_rate=self.learning_rate,
                 {%- endif %}
                 {%- if "eps" in args.split_function_arg_names %}
                 eps=self.eps,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/405

This diff reverts D62784577
D62784577: [fbgemm_gpu] Make `learning rate` tensor (Backend) by spcyppt causes the following test failure:

Tests affected:
- [cogwheel:cogwheel_light_cinder_fire_qps_test#test](https://www.internalfb.com/intern/test/844425039298448/)

Here's the Multisect link:
https://www.internalfb.com/multisect/13065502
Here are the tasks that are relevant to this breakage:
T191381073: 500+ CI signals unhealthy for minimal_viable_ai

The backout may land if someone accepts it.

If this diff has been generated in error, you can Commandeer and Abandon it.

Differential Revision: D65354664


