### PR TITLE
Allow registering SSD prefetcher after initiliaztion of the TBE module

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
@@ -31,6 +31,15 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
     round_up,
     SplitState,
 )
+from fbgemm_gpu.split_table_batched_embeddings_ops_utils import (  # noqa: F401
+    align_to_cacheline,  # noqa: F401
+    inputs_to_device,
+    nbit_construct_split_state,
+    random_quant_scaled_tensor,
+    rounded_row_size_in_bytes,
+    unpadded_row_size_in_bytes,
+)
+from fbgemm_gpu.ssd_prefetcher import SSDPrefetcher
 from fbgemm_gpu.utils.loader import load_torch_module, load_torch_module_bc
 
 try:
@@ -51,126 +60,6 @@ except Exception:
     pass
 
 import fbgemm_gpu  # noqa
-
-
-def rounded_row_size_in_bytes(
-    dim: int,
-    weight_ty: SparseType,
-    row_alignment: int,
-    scale_bias_size_in_bytes: int = DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
-) -> int:
-    r = unpadded_row_size_in_bytes(dim, weight_ty, scale_bias_size_in_bytes)
-    # align each row to 16-byte boundaries.
-    return round_up(r, row_alignment)
-
-
-def unpadded_row_size_in_bytes(
-    dim: int,
-    weight_ty: SparseType,
-    scale_bias_size_in_bytes: int = DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
-) -> int:
-    r = {
-        SparseType.FP32.value: dim * 4,
-        SparseType.FP16.value: dim * 2,
-        SparseType.FP8.value: dim,
-        SparseType.INT8.value: dim + scale_bias_size_in_bytes,
-        SparseType.INT4.value: dim // 2 + scale_bias_size_in_bytes,
-        SparseType.INT2.value: dim // 4 + scale_bias_size_in_bytes,
-    }[weight_ty.value]
-    return r
-
-
-def align_to_cacheline(a: int) -> int:
-    # align each table to 128b cache line boundary.
-    return round_up(a, 128)
-
-
-def nbit_construct_split_state(
-    embedding_specs: List[Tuple[str, int, int, SparseType, EmbeddingLocation]],
-    cacheable: bool,
-    row_alignment: int,
-    scale_bias_size_in_bytes: int = DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
-    cacheline_alignment: bool = True,
-) -> SplitState:
-    placements = torch.jit.annotate(List[EmbeddingLocation], [])
-    offsets = torch.jit.annotate(List[int], [])
-    dev_size = 0
-    host_size = 0
-    uvm_size = 0
-    for _, num_embeddings, embedding_dim, weight_ty, location in embedding_specs:
-        embedding_dim = rounded_row_size_in_bytes(
-            embedding_dim, weight_ty, row_alignment, scale_bias_size_in_bytes
-        )
-        state_size = num_embeddings * embedding_dim
-        if cacheline_alignment:
-            state_size = align_to_cacheline(state_size)
-        if location == EmbeddingLocation.HOST:
-            placements.append(EmbeddingLocation.HOST)
-            offsets.append(host_size)
-            host_size += state_size
-        elif location == EmbeddingLocation.DEVICE or location == EmbeddingLocation.MTIA:
-            placements.append(location)
-            offsets.append(dev_size)
-            dev_size += state_size
-        else:
-            if cacheable and location == EmbeddingLocation.MANAGED_CACHING:
-                placements.append(EmbeddingLocation.MANAGED_CACHING)
-            else:
-                placements.append(EmbeddingLocation.MANAGED)
-            offsets.append(uvm_size)
-            uvm_size += state_size
-    assert len(placements) == len(offsets)
-    return SplitState(
-        dev_size=dev_size,
-        host_size=host_size,
-        uvm_size=uvm_size,
-        placements=placements,
-        offsets=offsets,
-    )
-
-
-def random_quant_scaled_tensor(
-    shape: torch.Size,
-    device: torch.device,
-    output_tensor: Optional[torch.Tensor] = None,
-) -> torch.Tensor:
-    if output_tensor is not None:
-        return torch.randint(
-            0,
-            255,
-            size=shape,
-            out=output_tensor,
-            dtype=torch.uint8,
-            device=device,
-        )
-    else:
-        return torch.randint(
-            0,
-            255,
-            size=shape,
-            dtype=torch.uint8,
-            device=device,
-        )
-
-
-@torch.fx.wrap
-def inputs_to_device(
-    indices: torch.Tensor,
-    offsets: torch.Tensor,
-    per_sample_weights: Optional[torch.Tensor],
-    device: torch.device,
-) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
-    if device.type == "meta":
-        return indices, offsets, per_sample_weights
-
-    non_blocking = device.type != "cpu"
-    if indices.device != device:
-        indices = indices.to(device, non_blocking=non_blocking)
-    if offsets.device != device:
-        offsets = offsets.to(device, non_blocking=non_blocking)
-    if per_sample_weights is not None and per_sample_weights.device != device:
-        per_sample_weights = per_sample_weights.to(device, non_blocking=non_blocking)
-    return indices, offsets, per_sample_weights
 
 
 # pyre-fixme[13]: Attribute `cache_miss_counter` is never initialized.
@@ -364,6 +253,10 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         reverse_qparam: bool = False,  # True to load qparams at end of each row; False to load qparam at begnning of each row.
         feature_names_per_table: Optional[List[List[str]]] = None,
         indices_dtype: torch.dtype = torch.int32,  # Used for construction of the remap_indices tensors.  Should match the dtype of the indices passed in the forward() call (INT32 or INT64).
+        ssd_prefetcher: Optional[SSDPrefetcher] = None,
+        ssd_placements: Optional[
+            Union[List[int], torch.Tensor]
+        ] = None,  # Indicies to embedding tables in the storage
     ) -> None:  # noqa C901  # tuple of (rows, dims,)
         super(IntNBitTableBatchedEmbeddingBagsCodegen, self).__init__()
 
@@ -389,6 +282,9 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.uvm_host_mapped = uvm_host_mapped
         self.feature_names_per_table = feature_names_per_table
         self.indices_dtype = indices_dtype
+        self.ssd_prefetcher = ssd_prefetcher
+        if ssd_placements is not None and self.ssd_prefetcher is not None:
+            self.set_ssd_placements(ssd_placements)
         # (feature_names, rows, dims, weights_tys, locations) = zip(*embedding_specs)
         # Pyre workaround
         self.feature_names: List[str] = [e[0] for e in embedding_specs]
@@ -497,7 +393,9 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 weights_tys_int, device=self.current_device, dtype=torch.uint8
             ),
         )
-        self.weight_initialized: bool = False
+        # When we use SSD offloading, weights are located in local or remote storage
+        # and we rely on prefetcher to query them.
+        self.weight_initialized: bool = False if self.ssd_prefetcher is None else True
 
         self.weights_dev: torch.Tensor = torch.zeros(
             0,
@@ -528,6 +426,9 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.reverse_qparam = reverse_qparam
         # Assign weights after weights and weights_offsets are initialized.
         if weight_lists:
+            assert (
+                self.ssd_prefetcher is None
+            ), "Weights are read-only by prefetcher in SSD mode."
             self._apply_split(
                 self.dev_size,
                 self.host_size,
@@ -617,6 +518,20 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         else:
             self.fp8_exponent_bits = -1
             self.fp8_exponent_bias = -1
+
+    def set_ssd_placements(
+        self,
+        ssd_placements: Union[List[int], torch.Tensor],
+    ) -> None:
+        assert (
+            self.ssd_prefetcher is not None
+        ), "set_ssd_placements is not meaningful in non-ssd mode"
+        if isinstance(ssd_placements, torch.Tensor):
+            self.ssd_placements = ssd_placements.to(self.current_device)
+        else:
+            self.ssd_placements = torch.tensor(
+                ssd_placements, device=self.current_device, dtype=torch.int32
+            )
 
     def get_cache_miss_counter(self) -> Tensor:
         # cache_miss_counter[0]: cache_miss_forward_count which records the total number of forwards which has at least one cache miss
@@ -981,6 +896,57 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 self.bounds_check_warning,
                 per_sample_weights,
             )
+
+        # If we use SSD mode, use SSD prefetcher to query weights with given
+        # indices and offsets
+        if self.ssd_prefetcher is not None:
+            weights_ssd, indices_ssd, weights_offsets = self.ssd_prefetcher.prefetch(
+                indices, offsets, self.ssd_placements
+            )
+            weights_ssd = weights_ssd.to(self.current_device)
+            if indices_ssd is not None:
+                indices_ssd = indices_ssd.to(self.current_device)
+            else:
+                indices_ssd = torch.arange(
+                    0, len(indices), dtype=indices.dtype, device=indices.device
+                )
+            if weights_offsets is not None:
+                weights_offsets = weights_offsets.to(self.current_device)
+            else:
+                weights_offsets = torch.tensor(
+                    [0], dtype=torch.int64, device=self.current_device
+                )
+
+            # This is different from self.ssd_placements: this tensor specifies which device each
+            # table is located on (e.g. HOST or DEVICE).
+            weights_placements = torch.tensor(
+                self.weights_physical_placements,
+                device=self.current_device,
+                dtype=torch.int32,
+            )
+            return torch.ops.fbgemm.int_nbit_split_embedding_codegen_lookup_function(
+                dev_weights=weights_ssd,
+                uvm_weights=self.weights_uvm,
+                weights_placements=weights_placements,
+                weights_offsets=weights_offsets,
+                weights_tys=self.weights_tys,
+                D_offsets=self.D_offsets,
+                total_D=self.total_D,
+                max_int2_D=self.max_int2_D,
+                max_int4_D=self.max_int4_D,
+                max_int8_D=self.max_int8_D,
+                max_float16_D=self.max_float16_D,
+                max_float32_D=self.max_float32_D,
+                indices=indices_ssd,
+                offsets=offsets,
+                pooling_mode=int(self.pooling_mode),
+                indice_weights=per_sample_weights,
+                output_dtype=self.output_dtype,
+                max_float8_D=self.max_float8_D,
+                fp8_exponent_bits=self.fp8_exponent_bits,
+                fp8_exponent_bias=self.fp8_exponent_bias,
+            )
+
         # Note: CPU and CUDA ops use the same interface to facilitate JIT IR
         # generation for CUDA/CPU. For CPU op, we don't need weights_uvm and
         # weights_placements
@@ -1183,6 +1149,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
         if uvm_size > 0:
             assert not self.use_cpu
+            assert self.ssd_prefetcher is None
             if enforce_hbm:
                 if not torch.jit.is_scripting():
                     logging.info("Enforce hbm for the cache location")
@@ -1450,6 +1417,9 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
             2: return weights, scale, bias.
         """
         assert self.weight_initialized
+        assert (
+            self.ssd_prefetcher is None
+        ), "split_embedding_weights not available in SSD mode"
         splits: List[Tuple[Tensor, Optional[Tensor], Optional[Tensor]]] = []
         for t, (_, rows, dim, weight_ty, _) in enumerate(self.embedding_specs):
             placement = self.weights_physical_placements[t]
@@ -1579,8 +1549,12 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         """
         Returns a list of weights, split by table
         """
+        assert (
+            self.ssd_prefetcher is None
+        ), "split_embedding_weights not available in SSD mode"
+
         # fmt: off
-        splits: List[Tuple[Tensor, Optional[Tensor], Optional[Tensor]]] = (
+        splits = (
             self.split_embedding_weights_with_scale_bias(
                 split_scale_bias_mode=(1 if split_scale_shifts else 0)
             )
@@ -1608,6 +1582,9 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         """
         Fill the buffer with random weights, table by table
         """
+        assert (
+            self.ssd_prefetcher is None
+        ), "fill_random_weights not available in SSD mode"
         self.initialize_weights()
         weights = self.split_embedding_weights()
         for dest_weight in weights:
@@ -1623,6 +1600,9 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         """
         Assigns self.split_embedding_weights() with values from the input list of weights and scale_shifts.
         """
+        assert (
+            self.ssd_prefetcher is None
+        ), "assign_embedding_weights not available in SSD mode"
         weights = self.split_embedding_weights()
         assert len(q_weight_list) == len(weights)
 

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_utils.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_utils.py
@@ -1,0 +1,138 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional, Tuple
+
+import fbgemm_gpu  # noqa: F401
+import torch  # usort:skip
+
+from fbgemm_gpu.split_embedding_configs import SparseType
+from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+    DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
+    EmbeddingLocation,
+    round_up,
+    SplitState,
+)
+
+
+def rounded_row_size_in_bytes(
+    dim: int,
+    weight_ty: SparseType,
+    row_alignment: int,
+    scale_bias_size_in_bytes: int = DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
+) -> int:
+    r = unpadded_row_size_in_bytes(dim, weight_ty, scale_bias_size_in_bytes)
+    # align each row to 16-byte boundaries.
+    return round_up(r, row_alignment)
+
+
+def unpadded_row_size_in_bytes(
+    dim: int,
+    weight_ty: SparseType,
+    scale_bias_size_in_bytes: int = DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
+) -> int:
+    r = {
+        SparseType.FP32.value: dim * 4,
+        SparseType.FP16.value: dim * 2,
+        SparseType.FP8.value: dim,
+        SparseType.INT8.value: dim + scale_bias_size_in_bytes,
+        SparseType.INT4.value: dim // 2 + scale_bias_size_in_bytes,
+        SparseType.INT2.value: dim // 4 + scale_bias_size_in_bytes,
+    }[weight_ty.value]
+    return r
+
+
+def align_to_cacheline(a: int) -> int:
+    # align each table to 128b cache line boundary.
+    return round_up(a, 128)
+
+
+def nbit_construct_split_state(
+    embedding_specs: List[Tuple[str, int, int, SparseType, EmbeddingLocation]],
+    cacheable: bool,
+    row_alignment: int,
+    scale_bias_size_in_bytes: int = DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
+    cacheline_alignment: bool = True,
+) -> SplitState:
+    placements = torch.jit.annotate(List[EmbeddingLocation], [])
+    offsets = torch.jit.annotate(List[int], [])
+    dev_size = 0
+    host_size = 0
+    uvm_size = 0
+    for _, num_embeddings, embedding_dim, weight_ty, location in embedding_specs:
+        embedding_dim = rounded_row_size_in_bytes(
+            embedding_dim, weight_ty, row_alignment, scale_bias_size_in_bytes
+        )
+        state_size = num_embeddings * embedding_dim
+        if cacheline_alignment:
+            state_size = align_to_cacheline(state_size)
+        if location == EmbeddingLocation.HOST:
+            placements.append(EmbeddingLocation.HOST)
+            offsets.append(host_size)
+            host_size += state_size
+        elif location == EmbeddingLocation.DEVICE or location == EmbeddingLocation.MTIA:
+            placements.append(location)
+            offsets.append(dev_size)
+            dev_size += state_size
+        else:
+            if cacheable and location == EmbeddingLocation.MANAGED_CACHING:
+                placements.append(EmbeddingLocation.MANAGED_CACHING)
+            else:
+                placements.append(EmbeddingLocation.MANAGED)
+            offsets.append(uvm_size)
+            uvm_size += state_size
+    assert len(placements) == len(offsets)
+    return SplitState(
+        dev_size=dev_size,
+        host_size=host_size,
+        uvm_size=uvm_size,
+        placements=placements,
+        offsets=offsets,
+    )
+
+
+def random_quant_scaled_tensor(
+    shape: torch.Size,
+    device: torch.device,
+    output_tensor: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    if output_tensor is not None:
+        return torch.randint(
+            0,
+            255,
+            size=shape,
+            out=output_tensor,
+            dtype=torch.uint8,
+            device=device,
+        )
+    else:
+        return torch.randint(
+            0,
+            255,
+            size=shape,
+            dtype=torch.uint8,
+            device=device,
+        )
+
+
+@torch.fx.wrap
+def inputs_to_device(
+    indices: torch.Tensor,
+    offsets: torch.Tensor,
+    per_sample_weights: Optional[torch.Tensor],
+    device: torch.device,
+) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    if device.type == "meta":
+        return indices, offsets, per_sample_weights
+
+    non_blocking = device.type != "cpu"
+    if indices.device != device:
+        indices = indices.to(device, non_blocking=non_blocking)
+    if offsets.device != device:
+        offsets = offsets.to(device, non_blocking=non_blocking)
+    if per_sample_weights is not None and per_sample_weights.device != device:
+        per_sample_weights = per_sample_weights.to(device, non_blocking=non_blocking)
+    return indices, offsets, per_sample_weights

--- a/fbgemm_gpu/fbgemm_gpu/ssd_prefetcher.py
+++ b/fbgemm_gpu/fbgemm_gpu/ssd_prefetcher.py
@@ -1,0 +1,189 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import abc
+from typing import List, Optional, Tuple
+
+import torch
+
+from fbgemm_gpu.split_embedding_configs import SparseType
+from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+    DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
+    EmbeddingLocation,
+)
+from fbgemm_gpu.split_table_batched_embeddings_ops_utils import (
+    random_quant_scaled_tensor,
+    rounded_row_size_in_bytes,
+    unpadded_row_size_in_bytes,
+)
+from torch import Tensor
+
+
+class SSDPrefetcher:
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def prefetch(
+        self,
+        indices: torch.Tensor,
+        offsets: torch.Tensor,
+        table_placement: torch.Tensor,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+        """
+        Fetch embedding table rows specified by the indicies
+        And return the requested rows and remapped indcies as two Tensors
+
+        @param indices Indices of the rows that we want to fetch
+        @param offsets Pooling offsets
+        @param table_placement Indices of the tables that we want to query from the storage
+
+        @return A tuple of tensors:
+            The first tensor will be the fetched embedding table rows (required).
+            The second tensor will be the remapped indices (optional). Its size should be equal to the
+              size of `indices`. If the second element is None, it means the fetched rows should be
+              used sequentially by the TBE module (equivalent to `indices = torch.arange(0, indices.numel())`).
+            The third tensor will be the remapped weights offsets (optional). Its size should be equal
+            to the number of tables involved. Each value in this tensor indicates each individual table's
+            offset (in bytes, since weights are stored as int8 regardless of the actual type) in the returned
+            embedding tables tensor. If the third element is None, the returned embedding tables tensor
+            will be treated as a single table (equivalent to `weights_offsets = [0]`).
+        """
+        pass
+
+    def split_embedding_weights(
+        self, split_scale_shifts: bool = True
+    ) -> List[Tuple[Tensor, Optional[Tensor]]]:
+        """
+        Provide a view of the embedding tables with quantized values and scales/bias
+        split into two tensors.  Please implement this method if you would like to use
+        the SSD prefetcher in tests or benchmarks.
+
+        @param split_scale_shifts Whether to split the scales and bias from the embedding
+               table row.
+
+        @return A list of tuples.  Each tuple contains the quantized embedding table row
+                and the scales and bias.  The scales and bias will be None if
+                `split_scale_shifts` is False (meaning not splitting).
+        """
+        return []
+
+
+class DummyPrefetcher(SSDPrefetcher):
+    """
+    A dummy fake SSD prefetcher intended to test if the TBE module can work with
+    the SSD prefetcher interface. It simply takes a range of embedding table shapes
+    and generate random weights based on the shapes during initialization, and
+    returns the picked rows when the prefetch() function is called.
+    """
+
+    def _generate_weights(
+        self, embedding_specs: List[Tuple[str, int, int, SparseType, EmbeddingLocation]]
+    ) -> None:
+        for _, rows, dim, weight_ty, _ in embedding_specs:
+            weights = random_quant_scaled_tensor(
+                torch.Size(
+                    (
+                        rows,
+                        rounded_row_size_in_bytes(
+                            dim,
+                            weight_ty,
+                            self.row_alignment,
+                            self.scale_bias_size_in_bytes,
+                        ),
+                    ),
+                ),
+                device=torch.device("cpu"),
+            )
+            self.weights.append(weights)
+            self.nrows.append(self.nrows[-1] + rows)
+
+    def split_embedding_weights(
+        self, split_scale_shifts: bool = True
+    ) -> List[Tuple[Tensor, Optional[Tensor]]]:
+        splits: List[Tuple[Tensor, Optional[Tensor]]] = []
+        for i, (_, rows, dim, weight_ty, _) in enumerate(self.embedding_specs):
+            weights_shifts = self.weights[i].detach()
+            if split_scale_shifts:
+                # remove the padding at the end of each row.
+                weights_shifts = weights_shifts[
+                    :,
+                    : unpadded_row_size_in_bytes(
+                        dim, weight_ty, self.scale_bias_size_in_bytes
+                    ),
+                ]
+                if (
+                    weight_ty == SparseType.INT8
+                    or weight_ty == SparseType.INT4
+                    or weight_ty == SparseType.INT2
+                ):
+                    splits.append(
+                        (
+                            weights_shifts[:, self.scale_bias_size_in_bytes :],
+                            weights_shifts[:, : self.scale_bias_size_in_bytes],
+                        )
+                    )
+                else:
+                    assert (
+                        weight_ty == SparseType.FP8
+                        or weight_ty == SparseType.FP16
+                        or weight_ty == SparseType.FP32
+                    )
+                    splits.append(
+                        (
+                            weights_shifts,
+                            None,
+                        )
+                    )
+            else:
+                splits.append((weights_shifts, None))
+
+        return splits
+
+    def __init__(
+        self,
+        embedding_specs: List[Tuple[str, int, int, SparseType, EmbeddingLocation]],
+        row_alignment: int = 1,
+        scale_bias_size_in_bytes: int = DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
+    ) -> None:
+        self.embedding_specs = embedding_specs
+        self.row_alignment = row_alignment
+        self.scale_bias_size_in_bytes = scale_bias_size_in_bytes
+        self.weights: List[torch.Tensor] = []
+        self.nrows: List[int] = [0]
+        self._generate_weights(embedding_specs)
+
+    def prefetch(
+        self,
+        indices: torch.Tensor,
+        offsets: torch.Tensor,
+        table_placement: torch.Tensor,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+        if indices.numel() == 0:
+            return (torch.tensor([], dtype=torch.uint8, device="cpu"), None, None)
+        assert indices.numel() == table_placement.numel()
+        fetched_rows = []
+        new_indices = []
+        weights_offsets = [0]
+        prev_table_id = None
+        idx = 0
+        bytes_added = 0
+        for i, tbl in enumerate(table_placement):
+            if prev_table_id is None:
+                prev_table_id = tbl
+            if prev_table_id != tbl:
+                idx = 0
+                prev_table_id = tbl
+                weights_offsets.append(bytes_added)
+            fetched_rows.append(self.weights[tbl][indices[i]])
+            new_indices.append(idx)
+            idx += 1
+            bytes_added += self.weights[tbl][indices[i]].numel()
+
+        return (
+            torch.cat(fetched_rows),
+            torch.tensor(new_indices, dtype=indices.dtype, device="cpu"),
+            torch.tensor(weights_offsets, dtype=torch.int64, device="cpu"),
+        )

--- a/fbgemm_gpu/fbgemm_gpu/ssd_prefetcher.py
+++ b/fbgemm_gpu/fbgemm_gpu/ssd_prefetcher.py
@@ -33,8 +33,10 @@ class SSDPrefetcher:
         table_placement: torch.Tensor,
     ) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
         """
-        Fetch embedding table rows specified by the indicies
-        And return the requested rows and remapped indcies as two Tensors
+        Fetch embedding table rows specified by the indicies,
+        push the tuple of [Tensor, Optional[Tensor], Optional[Tensor]] into a
+        queue of this prefetcher, and return a reference to the tuple. For meaning of
+        elements in the tuple, see the @return section.
 
         @param indices Indices of the rows that we want to fetch
         @param offsets Pooling offsets
@@ -187,3 +189,10 @@ class DummyPrefetcher(SSDPrefetcher):
             torch.tensor(new_indices, dtype=indices.dtype, device="cpu"),
             torch.tensor(weights_offsets, dtype=torch.int64, device="cpu"),
         )
+
+
+class SSDPrefetcherTestSetting:
+
+    def __init__(self):
+        self.register_prefetcher_at_tbe_init: bool = True
+        self.add_ssd_placement_at_tbe_init: bool = True

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -25,7 +25,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import DEFAULT_ASSOC
-from fbgemm_gpu.ssd_prefetcher import DummyPrefetcher
+from fbgemm_gpu.ssd_prefetcher import SSDPrefetcherTestSetting
 from fbgemm_gpu.tbe.utils import generate_requests, quantize_embs, round_up
 from hypothesis import assume, given, HealthCheck, settings, Verbosity
 
@@ -365,10 +365,12 @@ class NBitFowardTest(NBitFowardTestCommon):
         output_dtype=st.sampled_from(
             [SparseType.FP32, SparseType.FP16, SparseType.BF16]
         ),
+        register_prefetcher_at_tbe_init=st.booleans(),
+        add_ssd_placement_at_tbe_init=st.booleans(),
     )
     @settings(
         verbosity=VERBOSITY,
-        max_examples=MAX_EXAMPLES_LONG_RUNNING,
+        max_examples=MAX_EXAMPLES,
         deadline=None,
     )
     def test_nbit_forward_cpu_fake_ssd(
@@ -379,6 +381,8 @@ class NBitFowardTest(NBitFowardTestCommon):
         pooling_mode: PoolingMode,
         indices_dtype: torch.dtype,
         output_dtype: SparseType,
+        register_prefetcher_at_tbe_init: bool,
+        add_ssd_placement_at_tbe_init: bool,
     ) -> None:
         use_cpu = True
         T = random.randint(1, 50)
@@ -405,6 +409,10 @@ class NBitFowardTest(NBitFowardTestCommon):
             weights_ty: SparseType = nbit_weights_ty
             mixed_weights_ty = False
 
+        settings = SSDPrefetcherTestSetting()
+        settings.register_prefetcher_at_tbe_init = register_prefetcher_at_tbe_init
+        settings.add_ssd_placement_at_tbe_init = add_ssd_placement_at_tbe_init
+
         self.execute_nbit_forward_(
             T,
             D,
@@ -424,6 +432,7 @@ class NBitFowardTest(NBitFowardTestCommon):
             indices_dtype,
             output_dtype,
             test_ssd_prefetcher=True,
+            ssd_prefetcher_test_setting=settings,
         )
 
     @given(

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -25,6 +25,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import DEFAULT_ASSOC
+from fbgemm_gpu.ssd_prefetcher import DummyPrefetcher
 from fbgemm_gpu.tbe.utils import generate_requests, quantize_embs, round_up
 from hypothesis import assume, given, HealthCheck, settings, Verbosity
 
@@ -351,6 +352,78 @@ class NBitFowardTest(NBitFowardTestCommon):
             mixed_weights_ty,
             indices_dtype,
             output_dtype,
+        )
+
+    @given(
+        nbit_weights_ty=get_nbit_weights_ty(),
+        use_array_for_index_remapping=st.booleans(),
+        do_pruning=st.booleans(),
+        pooling_mode=st.sampled_from(
+            [PoolingMode.SUM, PoolingMode.NONE, PoolingMode.MEAN]
+        ),
+        indices_dtype=st.sampled_from([torch.int32, torch.int64]),
+        output_dtype=st.sampled_from(
+            [SparseType.FP32, SparseType.FP16, SparseType.BF16]
+        ),
+    )
+    @settings(
+        verbosity=VERBOSITY,
+        max_examples=MAX_EXAMPLES_LONG_RUNNING,
+        deadline=None,
+    )
+    def test_nbit_forward_cpu_fake_ssd(
+        self,
+        nbit_weights_ty: Optional[SparseType],
+        use_array_for_index_remapping: bool,
+        do_pruning: bool,
+        pooling_mode: PoolingMode,
+        indices_dtype: torch.dtype,
+        output_dtype: SparseType,
+    ) -> None:
+        use_cpu = True
+        T = random.randint(1, 50)
+        B = random.randint(0, 128)
+        L = random.randint(0, 32)
+        D = random.randint(2, 2048)
+        log_E = random.randint(2, 4)
+
+        use_cache = False
+        # cache_algorithm is don't care as we don't use cache.
+        cache_algorithm = CacheAlgorithm.LRU
+
+        mixed = random.choice([True, False])
+        if pooling_mode == PoolingMode.SUM:
+            weighted = random.choice([True, False])
+        else:
+            weighted = False
+
+        if nbit_weights_ty is None:
+            # don't care when mixed type is used.
+            weights_ty: SparseType = SparseType.INT8
+            mixed_weights_ty = True
+        else:
+            weights_ty: SparseType = nbit_weights_ty
+            mixed_weights_ty = False
+
+        self.execute_nbit_forward_(
+            T,
+            D,
+            B,
+            log_E,
+            L,
+            weighted,
+            mixed,
+            pooling_mode,
+            weights_ty,
+            use_cache,
+            cache_algorithm,
+            use_cpu,
+            use_array_for_index_remapping,
+            do_pruning,
+            mixed_weights_ty,
+            indices_dtype,
+            output_dtype,
+            test_ssd_prefetcher=True,
         )
 
     @given(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/408

Add a method `register_ssd_prefetcher` in the inference TBE module to allow converting the module to SSD mode after initialization. Also extended the unit test to test the case of registering prefetcher at/after init and adding SSD placement list during/after init.

Differential Revision: D65371577


