### PR TITLE
- Kernel support for multiple buckets per rank

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -459,6 +459,7 @@ def block_bucketize_sparse_features_meta(
     max_B: int = -1,
     block_bucketize_pos: Optional[torch.Tensor] = None,
     keep_orig_idx: bool = False,
+    total_num_blocks: Optional[torch.Tensor] = None,
 ) -> Tuple[
     torch.Tensor,
     torch.Tensor,

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -185,7 +185,8 @@ block_bucketize_sparse_features_cuda(
     const std::optional<at::Tensor>& batch_size_per_feature,
     const int64_t max_batch_size,
     const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
-    const bool keep_orig_idx);
+    const bool keep_orig_idx,
+    const std::optional<at::Tensor>& total_num_blocks);
 
 std::tuple<
     at::Tensor,
@@ -206,7 +207,8 @@ block_bucketize_sparse_features_cpu(
     const std::optional<at::Tensor>& batch_size_per_feature,
     const int64_t max_batch_size,
     const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
-    const bool keep_orig_idx);
+    const bool keep_orig_idx,
+    const std::optional<at::Tensor>& total_num_blocks);
 
 std::tuple<
     at::Tensor,
@@ -228,7 +230,8 @@ block_bucketize_sparse_features_inference_cuda(
     const int64_t max_batch_size,
     const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
     const bool return_bucket_mapping,
-    const bool keep_orig_idx);
+    const bool keep_orig_idx,
+    const std::optional<at::Tensor>& total_num_blocks);
 
 ///@ingroup sparse-data-cuda
 at::Tensor populate_bucketized_permute_cuda(
@@ -257,7 +260,8 @@ block_bucketize_sparse_features_inference_cpu(
     const int64_t max_batch_size,
     const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
     const bool return_bucket_mapping,
-    const bool keep_orig_idx);
+    const bool keep_orig_idx,
+    const std::optional<at::Tensor>& total_num_blocks);
 
 ///@ingroup sparse-data-cpu
 at::Tensor populate_bucketized_permute_cpu(

--- a/fbgemm_gpu/test/sparse/failures_dict.json
+++ b/fbgemm_gpu/test/sparse/failures_dict.json
@@ -29,6 +29,22 @@
         "comment": "",
         "status": "xfail"
       },
+      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_total_num_blocks": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_total_num_blocks_raw_ids": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_total_num_blocks_uneven": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_total_num_blocks_uneven_raw_ids": {
+        "comment": "",
+        "status": "xfail"
+      },
       "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_with_block_bucketize_pos": {
         "comment": "",
         "status": "xfail"
@@ -46,6 +62,22 @@
         "status": "xfail"
       },
       "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_long_indices": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_total_num_blocks": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_total_num_blocks_raw_ids": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_total_num_blocks_uneven": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_total_num_blocks_uneven_raw_ids": {
         "comment": "",
         "status": "xfail"
       },


### PR DESCRIPTION
Summary: For resharding ZCH we need to do two layer bucketization, the first at the rank level, then the second within rank.  this lets us do thinks like [8,8], [128,1], [4, 16] etc.

Differential Revision: D64994666


