### PR TITLE
Add support for `int32_t` indices in TBE training (1/N)

### DIFF
--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_template.cu
@@ -560,6 +560,7 @@ batch_index_select_dim0_codegen_forward_kernel(
     emb_type,
     cache_type,
     output_type,
+    index_type,
     use_cache,
     kMaxVecsPerThread,
     kThreadGroupSize)
@@ -577,7 +578,7 @@ batch_index_select_dim0_codegen_forward_kernel
     {%- if not dense %}
     {{ use_cache }},
     {%- endif %}
-    int64_t,
+    {{ index_type }},
     {%- if not nobag %}
     {{ kMaxVecsPerThread }},
     {%- endif %}
@@ -603,9 +604,9 @@ batch_index_select_dim0_codegen_forward_kernel
     {%- else %}
     FixedDivisor fd_B,
     {%- endif %}
-    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> indices,
+    const pta::PackedTensorAccessor32<{{ index_type }}, 1, at::RestrictPtrTraits> indices,
     {%- if not is_index_select %}
-    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> offsets,
+    const pta::PackedTensorAccessor32<{{ index_type }}, 1, at::RestrictPtrTraits> offsets,
     {%- endif %}
     {%- if not nobag %}
     int64_t pooling_mode,
@@ -638,14 +639,17 @@ batch_index_select_dim0_codegen_forward_kernel
     {%- for emb_type in ['float', 'at::Half'] %}
     {%- for cache_type in ['float', 'at::Half'] %}
     {%- for output_type in ['float', 'at::Half', 'at::BFloat16'] %}
+    {%- for index_type in ['int32_t', 'int64_t'] %}
         {{ template_instantiation(
             emb_type,
             cache_type,
             output_type,
+            index_type,
             use_cache,
             kMaxVecsPerThread,
             kThreadGroupSize)
         }}
+    {%- endfor %}
     {%- endfor %}
     {%- endfor %}
     {%- endfor %}

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_v2_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_v2_template.cu
@@ -986,6 +986,7 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel(
 */
 
 {%- for output_type in ['float', 'at::Half', 'at::BFloat16'] %}
+{%- for index_type in ['int32_t', 'int64_t'] %}
 {%- for emb_type in ['float', 'at::Half'] %}
 {%- for cache_type in ['float', 'at::Half'] %}
 {%- for use_cache in ['true', 'false'] %}
@@ -996,7 +997,7 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel
     {{ emb_type }},
     {{ cache_type }},
     {{ output_type }},
-    int64_t, // index_t
+    {{ index_type }},
     {{ use_cache }}
 > (
     const {{ emb_type }}* __restrict__ const dev_weights,
@@ -1008,16 +1009,17 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel
     const bool mean_pooling,
     const uint32_t max_D_cache,
     const FixedDivisor fd_num_warps_per_table,
-    const int64_t* __restrict__ const indices,
+    const {{ index_type }}* __restrict__ const indices,
     {%- if weighted %}
     const float* __restrict__ const index_weights,
     {%- endif %}
-    const int64_t* __restrict__ const  offsets,
+    const {{ index_type }}* __restrict__ const  offsets,
     const uint32_t* __restrict__ const D_offsets,
     const int64_t* __restrict__ const weights_offsets,
     const int32_t* __restrict__ const lxu_cache_locations,
     {{ output_type }}* __restrict__ const output);
 
+{%- endfor %}
 {%- endfor %}
 {%- endfor %}
 {%- endfor %}

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/cpu_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/cpu_utils.h
@@ -22,13 +22,13 @@ namespace fbgemm_gpu {
  *         scale_bias_last == false that can take -1 indices (output from
  *         pruned embedding id mapping)
  */
-template <typename IndexType>
+template <typename IndexType, typename OffsetType>
 void report_embedding_error(
     int t,
     int B,
     int b_begin,
     int b_end,
-    const IndexType* offsets_data,
+    const OffsetType* offsets_data,
     const IndexType* indices_data,
     int64_t hash_size,
     bool allow_minus_one = false) {


### PR DESCRIPTION
Summary: - Add `index_t` support to TBE training forward kernels

Differential Revision: D65457179


