### PR TITLE
Remove unused-variable in some generated code

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp
@@ -250,11 +250,8 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
             const auto* indices_acc = indices.data_ptr<index_t>();
             const auto* offsets_acc = offsets.data_ptr<index_t>();
             const auto* weights_offsets_acc = weights_offsets.data_ptr<int64_t>();
-            int32_t total_output_size = 0;
 
             auto* output_acc = output.data_ptr<output_t>();
-            int32_t num_indices_m_1 = indices.numel() - 1;
-            int32_t D_start_ = 0;
 
             for (const auto t : c10::irange(T)) {
                 {% if not nobag %}

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_cpu_approx_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_cpu_approx_template.cpp
@@ -67,7 +67,7 @@ for (const auto b : c10::irange(b_begin,b_end)) {
             : 1.0;
 for (const auto p : c10::irange(pool_begin,pool_end)) {
           auto idx = indices_data[p];
-          const int64_t embedding_begin = table_begin + idx * D;
+          [[maybe_unused]] const int64_t embedding_begin = table_begin + idx * D;
           scalar_t grad_buffer[D];
 for (const auto d : c10::irange(D)) {
             grad_buffer[d] = scale_factor *

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
@@ -888,8 +888,8 @@ class {{ autograd_func }} :
     auto max_gradient = ctx->saved_data["max_gradient"].toDouble();
     auto stochastic_rounding = ctx->saved_data["stochastic_rounding"].toBool();
     {%- endif %} {#-/* if optimizer != "none" */#}
-    const int32_t info_B_num_bits = ctx->saved_data["info_B_num_bits"].toInt();
-    const int64_t info_B_mask_int64 = ctx->saved_data["info_B_mask"].toInt();
+    [[maybe_unused]] const int32_t info_B_num_bits = ctx->saved_data["info_B_num_bits"].toInt();
+    [[maybe_unused]] const int64_t info_B_mask_int64 = ctx->saved_data["info_B_mask"].toInt();
     {%- if not dense %}
     const auto use_uniq_cache_locations_bwd =
       ctx->saved_data["use_uniq_cache_locations_bwd"].toBool();

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_meta_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_meta_template.cpp
@@ -209,9 +209,6 @@ Tensor {{ mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ desc
         std::tie(info_B_num_bits, info_B_mask) = adjust_info_B_num_bits(max_B.guard_int(__FILE__, __LINE__), T.guard_int(__FILE__, __LINE__));
     }
 
-    {%- else %}
-    // Cast info_B_mask from int64_t to uint32_t
-    const uint32_t info_B_mask = info_B_mask_int64;
     {%- endif %}
 
     {%- if dense %}

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_meta_template.cpp
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_meta_template.cpp
@@ -137,9 +137,6 @@ Tensor
     TORCH_SYM_CHECK(vbe_row_output_offsets.sym_numel().sym_eq(total_B), "");
     TENSORS_HAVE_SAME_SYM_NUMEL(vbe_row_output_offsets, vbe_b_t_map);
     TORCH_SYM_CHECK(vbe_output_size.sym_ge(0), "");
-
-    // Cast info_B_mask from int64_t to uint32_t
-    const uint32_t info_B_mask = info_B_mask_int64;
     {%- endif %}
 
     Tensor output;

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
@@ -633,8 +633,8 @@ class {{ autograd_func }} :
     int32_t info_B_num_bits = DEFAULT_INFO_B_NUM_BITS;
     uint32_t info_B_mask = (1u << info_B_num_bits) - 1;
     if (max_B_.is_symbolic()) {
-      int32_t info_B_num_bits = 22;
-      uint32_t info_B_mask = (1u << info_B_num_bits) - 1;
+      // int32_t info_B_num_bits = 22;
+      // uint32_t info_B_mask = (1u << info_B_num_bits) - 1;
 
       // TODO(ivankobzarev): Guarding Dynamo that T and B fits in constanted number of bits.
       // TORCH_CHECK(max_B_ < 1u << info_B_num_bits)
@@ -848,8 +848,8 @@ static torch::autograd::variable_list backward(
     auto max_gradient = ctx->saved_data["max_gradient"].toDouble();
     auto stochastic_rounding = ctx->saved_data["stochastic_rounding"].toBool();
     {%- endif %} {#-/* if optimizer != "none" */#}
-    const int32_t info_B_num_bits = ctx->saved_data["info_B_num_bits"].toInt();
-    const int64_t info_B_mask_int64 = ctx->saved_data["info_B_mask"].toInt();
+    [[maybe_unused]] const int32_t info_B_num_bits = ctx->saved_data["info_B_num_bits"].toInt();
+    [[maybe_unused]] const int64_t info_B_mask_int64 = ctx->saved_data["info_B_mask"].toInt();
     const auto use_uniq_cache_locations_bwd = ctx->saved_data["use_uniq_cache_locations_bwd"].toBool();
     const auto use_homogeneous_placements = ctx->saved_data["use_homogeneous_placements"].toBool();
     {%- if is_gwd %}


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

#buildsonlynotests - Builds are sufficient

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: sryap

Differential Revision: D65449535


