### PR TITLE
Fix global namespace pollution in ATen/Dispatch.h

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -345,7 +345,7 @@ using namespace embedding_ops;
 #define DISPATCH_PLACEHOLDER_TYPES({{ args.placeholder_tensor_names | to_upper_placeholder_types() | join(", ") }}, NAME, ...) \
   {%- for ph_name in args.placeholder_tensor_names %}
   at::ScalarType _{{ph_name}}_t =                                       \
-    ::detail::scalar_type({{ ph_name.upper() + "_T" }});                \
+    {{ ph_name.upper() + "_T" }};                                       \
   {%- endfor %}
   {%- for ph_combo in args.placeholder_type_combos %}
   if (                                                                  \

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_template.cu
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_template.cu
@@ -55,7 +55,7 @@ split_{{ optimizer }}_update_kernel(
 #define DISPATCH_PLACEHOLDER_TYPES({{ args.placeholder_tensor_names | to_upper_placeholder_types() | join(", ") }}, NAME, ...) \
   {%- for ph_name in args.placeholder_tensor_names %}
   at::ScalarType _{{ph_name}}_t =                                       \
-    ::detail::scalar_type({{ ph_name.upper() + "_T" }});                \
+    {{ ph_name.upper() + "_T" }};                                       \
   {%- endfor %}
   {%- for ph_combo in args.placeholder_type_combos %}
   if (                                                                  \

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/dispatch_macros.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/dispatch_macros.h
@@ -33,8 +33,8 @@
   }
 
 #define _DISPATCH_EMB_CACHE_TYPES(emb_enum_type, cache_enum_type, NAME, ...)  \
-  at::ScalarType _emb_t = ::detail::scalar_type(emb_enum_type);               \
-  at::ScalarType _cache_t = ::detail::scalar_type(cache_enum_type);           \
+  at::ScalarType _emb_t = emb_enum_type;                                      \
+  at::ScalarType _cache_t = cache_enum_type;                                  \
   switch (_emb_t) {                                                           \
     PRIVATE_CASE_TYPE_EMB(                                                    \
         at::ScalarType::Float, _cache_t, float, NAME, __VA_ARGS__)            \
@@ -67,10 +67,9 @@
 #define DISPATCH_EMB_CACHE_OUTPUT_TYPES(                           \
     EMB_TYPE, CACHE_TYPE, OUTPUT_TYPE, NAME, ...)                  \
   [&] {                                                            \
-    const auto& output_type = OUTPUT_TYPE;                         \
+    const at::ScalarType _output_t = OUTPUT_TYPE; /*            */ \
     const auto& emb_type = EMB_TYPE;                               \
     const auto& cache_type = CACHE_TYPE;                           \
-    at::ScalarType _output_t = ::detail::scalar_type(output_type); \
     switch (_output_t) {                                           \
       PRIVATE_CASE_TYPE_OUTPUT(                                    \
           at::ScalarType::Half,                                    \
@@ -114,8 +113,7 @@
 
 #define DISPATCH_OUTPUT_TYPES(OUTPUT_TYPE, NAME, ...)                        \
   [&] {                                                                      \
-    const auto& output_type = OUTPUT_TYPE;                                   \
-    at::ScalarType _output_t = ::detail::scalar_type(output_type);           \
+    const at::ScalarType _output_t = OUTPUT_TYPE;                            \
     switch (_output_t) {                                                     \
       PRIVATE_CASE_TYPE_OUTPUT2(at::ScalarType::Half, at::Half, __VA_ARGS__) \
       PRIVATE_CASE_TYPE_OUTPUT2(                                             \
@@ -137,8 +135,7 @@
 
 #define DISPATCH_OUTPUT_TYPES(OUTPUT_TYPE, NAME, ...)                        \
   [&] {                                                                      \
-    const auto& output_type = OUTPUT_TYPE;                                   \
-    at::ScalarType _output_t = ::detail::scalar_type(output_type);           \
+    const at::ScalarType _output_t = OUTPUT_TYPE;                            \
     switch (_output_t) {                                                     \
       PRIVATE_CASE_TYPE_OUTPUT2(at::ScalarType::Half, at::Half, __VA_ARGS__) \
       PRIVATE_CASE_TYPE_OUTPUT2(at::ScalarType::Float, float, __VA_ARGS__)   \
@@ -175,9 +172,9 @@
     const auto& emb_type = EMB_TYPE;                                           \
     const auto& grad_type = GRAD_TYPE;                                         \
     const auto& cache_type = CACHE_TYPE;                                       \
-    at::ScalarType _emb_t = ::detail::scalar_type(emb_type);                   \
-    at::ScalarType _grad_t = ::detail::scalar_type(grad_type);                 \
-    at::ScalarType _cache_t = ::detail::scalar_type(cache_type);               \
+    at::ScalarType _emb_t = emb_type;                                          \
+    at::ScalarType _grad_t = grad_type;                                        \
+    at::ScalarType _cache_t = cache_type;                                      \
     switch (_grad_t) {                                                         \
       PRIVATE_CASE_TYPE_CACHE_EMB(                                             \
           at::ScalarType::Float, _cache_t, _emb_t, float, NAME, __VA_ARGS__)   \


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/138626

Was it a typo? Since we already have `at::detail::record_kernel_function_dtype()` in `ATen/Dispatch.h`

Reviewed By: gineshidalgo99

Differential Revision: D64642080


