### PR TITLE
Remove unused-variable in /fbcode/deeplearning/fbgemm/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -258,7 +258,6 @@ void EmbeddingKVDB::set(
         << "]skip set_cuda since number evictions is " << num_evictions;
     return;
   }
-  auto start_ts = facebook::WallClockUtil::NowInUsecFast();
 
   // defer the L2 cache/rocksdb update to the background thread as it could be
   // parallelized with other cuda kernels, as long as all updates are finished


### PR DESCRIPTION
Summary:
[codemod] Remove unused-variable in {filename}


LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

#buildsonlynotests - Builds are sufficient to verify
 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D65445266


