### PR TITLE
Fix global weight decay Faketensor test

### DIFF
--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_global_weight_decay_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_global_weight_decay_test.py
@@ -63,6 +63,18 @@ test_st: Dict[str, Any] = {
     "gwd_lower_bound": st.sampled_from([0, 0.01, 0.001]),
 }
 
+additional_decorators.update(
+    {
+        # learning rate tensor needs to be on CPU to avoid D->H sync point since it will be used as float in the kernel
+        # this fails fake_tensor test as the test expects all tensors to be on the same device
+        "test_pt2_compliant_tag_fbgemm_split_embedding_codegen_lookup_rowwise_adagrad_function": [
+            unittest.skip(
+                "Operator failed on FakeTensor test since learning rate tensor is always on CPU regardless of other tensors"
+            ),
+        ]
+    }
+)
+
 
 def compare_output(
     output_ref: torch.Tensor,

--- a/fbgemm_gpu/test/tbe/training/failures_dict_fast.json
+++ b/fbgemm_gpu/test/tbe/training/failures_dict_fast.json
@@ -369,7 +369,16 @@
     "fbgemm::split_embedding_codegen_lookup_none_function": {},
     "fbgemm::split_embedding_codegen_lookup_partial_rowwise_adam_function": {},
     "fbgemm::split_embedding_codegen_lookup_partial_rowwise_lamb_function": {},
-    "fbgemm::split_embedding_codegen_lookup_rowwise_adagrad_function": {},
+    "fbgemm::split_embedding_codegen_lookup_rowwise_adagrad_function": {
+      "BackwardAdagradGlobalWeightDecay.test_faketensor__test_backward_adagrad_global_weight_decay": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BackwardAdagradGlobalWeightDecay.test_faketensor__test_backward_adagrad_global_weight_decay_vbe": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
     "fbgemm::split_embedding_codegen_lookup_rowwise_adagrad_function_cpu": {},
     "fbgemm::split_embedding_codegen_lookup_rowwise_adagrad_function_pt2": {
       "ForwardTest.test_faketensor__test_forward_cpu_fp32": {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/435

`learning_rate_tensor` is always on CPU  to avoid D->H sync since it will be converted and passed as a float in kernels. 

This fails FakeTensor test since the test expects all tensors with >1 dim to be on the same device.

Reviewed By: q10

Differential Revision: D65634037


