### PR TITLE
Improve FP8 BMM heuristic for large shapes and MoE E2E performance

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched.cu
@@ -495,7 +495,7 @@ at::Tensor dispatch_fp8_rowwise_batched_kernel_on_cluster_size_and_transpose(
         1,
         FastAccum,
         UseBias,
-        true,
+        false,
         InputDType,
         BiasDType>(XQ, WQ, x_scale, w_scale, bias, output);
   }
@@ -507,7 +507,7 @@ at::Tensor dispatch_fp8_rowwise_batched_kernel_on_cluster_size_and_transpose(
         1,
         FastAccum,
         UseBias,
-        true,
+        false,
         InputDType,
         BiasDType>(XQ, WQ, x_scale, w_scale, bias, output);
   }
@@ -533,7 +533,7 @@ at::Tensor dispatch_fp8_rowwise_batched_kernel_on_cluster_size_and_transpose(
           1,
           FastAccum,
           UseBias,
-          true,
+          false,
           InputDType,
           BiasDType>(XQ, WQ, x_scale, w_scale, bias, output);
     }
@@ -557,7 +557,7 @@ at::Tensor dispatch_fp8_rowwise_batched_kernel_on_cluster_size_and_transpose(
           1,
           FastAccum,
           UseBias,
-          true,
+          false,
           InputDType,
           BiasDType>(XQ, WQ, x_scale, w_scale, bias, output);
     } else {
@@ -574,24 +574,24 @@ at::Tensor dispatch_fp8_rowwise_batched_kernel_on_cluster_size_and_transpose(
   }
 
   // General case for large tensors.
-  if ((M <= N) ^ (M >= 2048 && N >= 2048)) {
+  if (M >= 1024 && N >= 1024) {
     return handle_transposition<
-        1,
         2,
+        1,
         1,
         FastAccum,
         UseBias,
-        true,
+        false,
         InputDType,
         BiasDType>(XQ, WQ, x_scale, w_scale, bias, output);
   } else {
     return handle_transposition<
-        2,
         1,
+        2,
         1,
         FastAccum,
         UseBias,
-        true,
+        false,
         InputDType,
         BiasDType>(XQ, WQ, x_scale, w_scale, bias, output);
   }


### PR DESCRIPTION
Summary:
This Diff improves FP8 BMM heuristic large shapes and MoE E2E performance
- Improve FP8 BMM heuristic large shapes with up to 2.5x speedup compared to existing heuristic

- Make bmm torch.compile optional instead of by default, as it recompiles every fp8 rowwise quantization triton call which slows down prefill that lacks cudagraph support. Will revisit it in the future

## Microbenchmark:
 {F1955650829} 

## E2E loadgen
With 17B x 16: input length 2048 (max input length: 8192), output length: 150, batch sizes: 32 (max batch size = 64):

BF16 Trace: https://fburl.com/perfdoctor/uqlwiwre
- TTFT: 289.850 ms
- TTIT: 38.749 ms

FP8 Trace: https://fburl.com/perfdoctor/ruun55sb
- TTFT: 252.600 ms (**1.14x**)
- TTIT: 30.577 ms (**1.26x**)

Differential Revision: D65647034


