### PR TITLE
Fix fbgemm _kernel_quantize_mx4

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/triton/quantize.py
+++ b/fbgemm_gpu/fbgemm_gpu/triton/quantize.py
@@ -549,7 +549,7 @@ def _kernel_dequantize_mx4(
             other=0.0,
         )
         # Remove fp32 exponent bias.
-        exp = exp.to(tl.uint8, bitcast=True) - FP32_EXP_BIAS
+        exp = exp.to(tl.int16) - FP32_EXP_BIAS
 
         # Convert exponent to scale and apply to input.
         # Requires higher precision to avoid rounding out small values.


### PR DESCRIPTION
Summary:
Triton 3.2 includes a breaking change related to constexpr integers: https://github.com/triton-lang/triton/pull/4613

In Triton 3.1, small constexpr integers are always `tl.int32`. In 3.2, the type is inferred based on usage. For each binary op `op(constexpr_val, tensor_val)`, the type of `constexpr_val` will be determined based on the type of `tensor_val`. This is a breaking change in the language.

For fbgemm quantization, this showed up in a funny way. We have
```
c = a.to(tl.uint8) + constexpr_val
d = c.to(tl.float32)
```
In Triton 3.1, the type of `c` is `tl.int32`, so float-conversion will interpret the integer as signed. In Triton 3.2, the type of `c` is `tl.uint8`, so float-conversion will interpret the integer as unsigned. Sign is very important for float conversion, so this leads to incorrect results.

The fix is to replace `tl.uint8` with `tl.int16`.

Differential Revision: D65771036


