### PR TITLE
[detailed][ops] open-source SLL dense_jagged_cat_jagged_out

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sll/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/__init__.py
@@ -10,11 +10,16 @@
 import torch
 
 from fbgemm_gpu.sll.cpu_sll import (  # noqa F401
+    cpu_dense_jagged_cat_jagged_out,
     cpu_jagged_dense_bmm,
     cpu_jagged_jagged_bmm,
 )
 
-from fbgemm_gpu.sll.triton_sll import jagged_dense_bmm, jagged_jagged_bmm  # noqa F401
+from fbgemm_gpu.sll.triton_sll import (  # noqa F401
+    dense_jagged_cat_jagged_out,
+    jagged_dense_bmm,
+    jagged_jagged_bmm,
+)
 
 
 def op_registeration(
@@ -73,6 +78,17 @@ if "fbgemm::sll_jagged_jagged_bmm" not in torch.library._defs:
         """
     )
 
+if "fbgemm::sll_dense_jagged_cat_jagged_out" not in torch.library._defs:
+    lib.define(
+        """sll_dense_jagged_cat_jagged_out(
+            Tensor a,
+            Tensor b,
+            Tensor a_offsets,
+            int max_seq_len
+        ) -> (Tensor, Tensor)
+        """
+    )
+
 op_registeration(lib, "sll_jagged_dense_bmm", jagged_dense_bmm, "CUDA")
 op_registeration(lib, "sll_jagged_dense_bmm", jagged_dense_bmm, "AutogradCUDA")
 op_registeration(lib, "sll_jagged_dense_bmm", cpu_jagged_dense_bmm, "CPU")
@@ -81,3 +97,9 @@ op_registeration(lib, "sll_jagged_jagged_bmm", jagged_jagged_bmm, "CUDA")
 op_registeration(lib, "sll_jagged_jagged_bmm", jagged_jagged_bmm, "AutogradCUDA")
 op_registeration(lib, "sll_jagged_jagged_bmm", cpu_jagged_jagged_bmm, "CPU")
 op_registeration(lib, "sll_jagged_jagged_bmm", cpu_jagged_jagged_bmm, "AutogradCPU")
+op_registeration(
+    lib, "sll_dense_jagged_cat_jagged_out", dense_jagged_cat_jagged_out, "CUDA"
+)
+op_registeration(
+    lib, "sll_dense_jagged_cat_jagged_out", cpu_dense_jagged_cat_jagged_out, "CPU"
+)

--- a/fbgemm_gpu/fbgemm_gpu/sll/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/__init__.py
@@ -9,9 +9,12 @@
 
 import torch
 
-from fbgemm_gpu.sll.cpu_sll import cpu_jagged_dense_bmm  # noqa F401
+from fbgemm_gpu.sll.cpu_sll import (  # noqa F401
+    cpu_jagged_dense_bmm,
+    cpu_jagged_jagged_bmm,
+)
 
-from fbgemm_gpu.sll.triton_sll import jagged_dense_bmm  # noqa F401
+from fbgemm_gpu.sll.triton_sll import jagged_dense_bmm, jagged_jagged_bmm  # noqa F401
 
 
 def op_registeration(
@@ -57,7 +60,24 @@ if "fbgemm::sll_jagged_dense_bmm" not in torch.library._defs:
         """
     )
 
+if "fbgemm::sll_jagged_jagged_bmm" not in torch.library._defs:
+    lib.define(
+        """sll_jagged_jagged_bmm(
+            Tensor x,
+            Tensor y,
+            Tensor x_offsets,
+            int N,
+            bool allow_tf32,
+            bool use_fbgemm_kernel=True
+        ) -> Tensor
+        """
+    )
+
 op_registeration(lib, "sll_jagged_dense_bmm", jagged_dense_bmm, "CUDA")
 op_registeration(lib, "sll_jagged_dense_bmm", jagged_dense_bmm, "AutogradCUDA")
 op_registeration(lib, "sll_jagged_dense_bmm", cpu_jagged_dense_bmm, "CPU")
 op_registeration(lib, "sll_jagged_dense_bmm", cpu_jagged_dense_bmm, "AutogradCPU")
+op_registeration(lib, "sll_jagged_jagged_bmm", jagged_jagged_bmm, "CUDA")
+op_registeration(lib, "sll_jagged_jagged_bmm", jagged_jagged_bmm, "AutogradCUDA")
+op_registeration(lib, "sll_jagged_jagged_bmm", cpu_jagged_jagged_bmm, "CPU")
+op_registeration(lib, "sll_jagged_jagged_bmm", cpu_jagged_jagged_bmm, "AutogradCPU")

--- a/fbgemm_gpu/fbgemm_gpu/sll/cpu_sll.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/cpu_sll.py
@@ -102,3 +102,66 @@ def cpu_jagged_dense_bmm(
         return torch.ops.fbgemm.jagged_dense_bmm(x, x_offsets, y, N)[0]
     else:
         return JaggedDenseBmmCPU.apply(x, y, x_offsets, N)
+
+
+class JaggedJaggedBmm(torch.autograd.Function):
+    """
+    Compute batch matrix multiplication between JaggedTensor and Jagged Tensor
+    dense: [B, D, N] * [B, N, T] = [B, D, T]
+    jagged: [Sum_B, D].T * [Sum_B, T] = [B, D, T]
+    """
+
+    @staticmethod
+    # pyre-fixme
+    def forward(
+        ctx: Any,  # pyre-ignore
+        x: torch.Tensor,
+        y: torch.Tensor,
+        x_offsets: torch.Tensor,
+        N: int,
+    ) -> torch.Tensor:
+        ctx.save_for_backward(x, y, x_offsets)
+        ctx.N = N
+        return cpu_jagged_jagged_bmm_kernel(x.T, y, x_offsets, N)
+
+    @staticmethod
+    # pyre-fixme
+    def backward(
+        ctx: Any, grad_output: torch.Tensor  # pyre-ignore
+    ) -> Tuple[torch.Tensor, torch.Tensor, None, None, None]:
+        """
+        # X = [Sum_B, D]
+        # Y = [Sum_B, T]
+        # Z = XT * Y = [B, D, T]
+        # dXT = dZ * YT -> dX = Y * dZT
+        # dY = X * dZ -> X * dZ
+        """
+        (x, y, offsets) = ctx.saved_tensors
+        N = ctx.N
+        grad_x = cpu_jagged_dense_bmm_kernel(
+            y, grad_output.permute(0, 2, 1), offsets, N
+        )
+        grad_y = cpu_jagged_dense_bmm_kernel(x, grad_output, offsets, N)
+        return grad_x, grad_y, None, None, None
+
+
+def cpu_jagged_jagged_bmm(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    x_offsets: torch.Tensor,
+    N: int,
+    allow_tf32: bool,
+    use_fbgemm_kernel: bool = True,
+) -> torch.Tensor:
+    """
+    Compute batch matrix multiplication between JaggedTensor and Jagged Tensor
+    dense: [B, D, N] * [B, N, T] = [B, D, T]
+    jagged: [Sum_B, D].T * [Sum_B, T] = [B, D, T]
+    """
+
+    # Force the CPU backend to use fbgemm kernel as it has better performance
+    use_fbgemm_kernel = True
+    if use_fbgemm_kernel:
+        return torch.ops.fbgemm.jagged_jagged_bmm(x, y, x_offsets, N)
+    else:
+        return JaggedJaggedBmm.apply(x, y, x_offsets, N)

--- a/fbgemm_gpu/fbgemm_gpu/sll/triton_sll.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/triton_sll.py
@@ -206,6 +206,35 @@ def jagged_jagged_bmm_kernel(
     tl.store(c_ptrs, c, mask=mask)
 
 
+@triton.jit
+def dense_jagged_cat_jagged_out_kernel(
+    a_ptr,  # dense
+    b_ptr,  # jagged
+    c_ptr,  # jagged
+    b_offsets_ptr,
+    c_offsets_ptr,
+    max_seq_len,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid_batch = tl.program_id(0)
+    b_start = tl.load(b_offsets_ptr + pid_batch)
+    b_end = tl.load(b_offsets_ptr + pid_batch + 1)
+    c_start = b_start + pid_batch
+    N = b_end - b_start
+    N = tl.minimum(N, max_seq_len)
+
+    a = tl.load(a_ptr + pid_batch)
+    tl.store(c_ptr + c_start, a)
+
+    offs_k = tl.arange(0, BLOCK_SIZE)
+    for k in range(0, N, BLOCK_SIZE):
+        b_offset = k + offs_k
+        b_ptrs = b_ptr + b_start + b_offset
+        b = tl.load(b_ptrs, mask=b_offset < N, other=0.0)
+        tl.store(c_ptr + c_start + 1 + b_offset, b, mask=b_offset < N)
+    tl.store(c_offsets_ptr + pid_batch, b_start + pid_batch)
+
+
 def triton_jagged_dense_bmm(a, b, a_offsets, max_seq_len, allow_tf32):
     # checks constraints
     assert a.shape[1] == b.shape[1], "incompatible dimensions"
@@ -289,6 +318,38 @@ def triton_jagged_jagged_bmm(a, b, a_offsets, max_seq_len, allow_tf32):
         BLOCK_SIZE_K,
     )
     return c
+
+
+def dense_jagged_cat_jagged_out(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    b_offsets: torch.Tensor,
+    max_seq_len: int,
+):
+    assert a.is_contiguous()
+    assert b.is_contiguous()
+    assert b_offsets.is_contiguous()
+    B = a.size(0)
+    BLOCK_SIZE = 128
+    c = torch.zeros(b.size(0) + a.size(0), dtype=a.dtype, device=a.device)
+    c_offsets = torch.empty(
+        b_offsets.size(0), dtype=b_offsets.dtype, device=b_offsets.device
+    )  # B + 1
+
+    dense_jagged_cat_jagged_out_kernel[(B,)](
+        a,
+        b,
+        c,
+        b_offsets,
+        c_offsets,
+        max_seq_len,
+        # pyre-fixme[6]: For 7th argument expected `constexpr` but got `int`.
+        BLOCK_SIZE,
+    )
+
+    c_offsets[-1] = b_offsets[-1] + B
+
+    return c, c_offsets
 
 
 class JaggedDenseBmm(torch.autograd.Function):

--- a/fbgemm_gpu/test/sll/triton_sll_test.py
+++ b/fbgemm_gpu/test/sll/triton_sll_test.py
@@ -155,3 +155,150 @@ class TritonBmmTest(unittest.TestCase):
             assert torch.allclose(x1.grad, x2.grad, 1e-5)
             # pyre-fixme[6]: In call `torch._C._VariableFunctions.allclose`, for 1st positional argument, expected `Tensor` but got `Optional[Tensor]`.Pyre
             assert torch.allclose(y1.grad, y2.grad, 1e-5)
+
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @given(
+        B=st.integers(1, 512),
+        D=st.integers(1, 256),
+        N=st.integers(1, 1000),
+        T=st.integers(1, 256),
+        use_fbgemm_kernel=st.booleans(),
+        allow_tf32=st.booleans(),
+        device_type=st.sampled_from(["cpu", "cuda"]),
+    )
+    @settings(deadline=None)
+    def test_triton_jagged_jagged_bmm(
+        self,
+        B: int,
+        D: int,
+        N: int,
+        T: int,
+        use_fbgemm_kernel: bool,
+        allow_tf32: bool,
+        device_type: str,
+    ) -> None:
+        device = torch.device(device_type)
+        lengths = torch.randint(0, N + 1, (B,), device=device)
+        offsets = torch.cat(
+            [
+                torch.tensor([0], dtype=torch.int32, device=device),
+                lengths.cumsum(dim=0),
+            ],
+            dim=0,
+        )
+        x = torch.rand(int(lengths.sum().item()), D, device=device)
+        y = torch.rand(int(lengths.sum().item()), T, device=device)
+        padded_x = torch.ops.fbgemm.jagged_to_padded_dense(
+            x,
+            [offsets],
+            max_lengths=[N],
+            padding_value=0.0,
+        )  # [B, N, D]
+        padded_y = torch.ops.fbgemm.jagged_to_padded_dense(
+            y,
+            [offsets],
+            max_lengths=[N],
+            padding_value=0.0,
+        )  # [B, N, T]
+        ret = torch.ops.fbgemm.sll_jagged_jagged_bmm(
+            x, y, offsets, N, allow_tf32=allow_tf32, use_fbgemm_kernel=use_fbgemm_kernel
+        )
+        ref = torch.bmm(padded_x.permute(0, 2, 1), padded_y)
+
+        if allow_tf32:
+            assert torch.allclose(ref, ret, atol=1e-3, rtol=1e-3)
+        else:
+            assert torch.allclose(ref, ret, 1e-5)
+
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @given(
+        B=st.integers(1, 512),
+        D=st.integers(1, 256),
+        N=st.integers(1, 1000),
+        T=st.integers(1, 256),
+        use_fbgemm_kernel=st.booleans(),
+        allow_tf32=st.booleans(),
+        device_type=st.sampled_from(["cpu", "cuda"]),
+    )
+    @settings(deadline=None)
+    def test_triton_jagged_jagged_bmm_with_grad(
+        self,
+        B: int,
+        D: int,
+        N: int,
+        T: int,
+        use_fbgemm_kernel: bool,
+        allow_tf32: bool,
+        device_type: str,
+    ) -> None:
+        device = torch.device(device_type)
+        lengths = torch.randint(0, N + 1, (B,), device=device)
+        offsets = torch.cat(
+            [
+                torch.tensor([0], dtype=torch.int32, device=device),
+                lengths.cumsum(dim=0),
+            ],
+            dim=0,
+        )
+
+        torch.manual_seed(0)
+        x1 = torch.rand(
+            (int(lengths.sum().item()), D), requires_grad=True, device=device
+        )  # [Sum_B, D]
+        padded_x1 = torch.ops.fbgemm.jagged_to_padded_dense(
+            x1,
+            [offsets],
+            max_lengths=[N],
+            padding_value=0.0,
+        )  # [B, N, D]
+        y1 = torch.rand(
+            (int(lengths.sum().item()), T), requires_grad=True, device=device
+        )  # [Sum_B, T]
+        padded_y1 = torch.ops.fbgemm.jagged_to_padded_dense(
+            y1,
+            [offsets],
+            max_lengths=[N],
+            padding_value=0.0,
+        )  # [B, N, T]
+
+        ref = torch.bmm(padded_x1.permute(0, 2, 1), padded_y1)
+
+        # triton version
+        torch.manual_seed(0)
+        x2 = torch.rand(
+            (int(lengths.sum().item()), D), requires_grad=True, device=device
+        )  # [Sum_B, D]
+        y2 = torch.rand(
+            (int(lengths.sum().item()), T), requires_grad=True, device=device
+        )  # [Sum_B, T]
+        ret = torch.ops.fbgemm.sll_jagged_jagged_bmm(
+            x2,
+            y2,
+            offsets,
+            N,
+            allow_tf32=allow_tf32,
+            use_fbgemm_kernel=use_fbgemm_kernel,
+        )
+
+        if allow_tf32:
+            assert torch.allclose(ref, ret, atol=1e-3, rtol=1e-3)
+        else:
+            assert torch.allclose(ref, ret, 1e-5)
+
+        # grad check
+        grad_output = torch.rand((B, D, T), device=device) * 0.01
+        ref.backward(grad_output)
+        ret.backward(grad_output)
+
+        if allow_tf32:
+            # pyre-fixme[6]: In call `torch._C._VariableFunctions.allclose`, for 1st positional argument, expected `Tensor` but got `Optional[Tensor]`.Pyre
+            assert torch.allclose(y1.grad, y2.grad, atol=1e-3, rtol=1e-3)
+            # pyre-fixme[6]: In call `torch._C._VariableFunctions.allclose`, for 1st positional argument, expected `Tensor` but got `Optional[Tensor]`.Pyre
+            assert torch.allclose(x1.grad, x2.grad, atol=1e-3, rtol=1e-3)
+        else:
+            # pyre-fixme[6]: In call `torch._C._VariableFunctions.allclose`, for 1st positional argument, expected `Tensor` but got `Optional[Tensor]`.Pyre
+            assert torch.allclose(y1.grad, y2.grad, 1e-5)
+            # pyre-fixme[6]: In call `torch._C._VariableFunctions.allclose`, for 1st positional argument, expected `Tensor` but got `Optional[Tensor]`.Pyre
+            assert torch.allclose(x1.grad, x2.grad, 1e-5)

--- a/fbgemm_gpu/test/sll/triton_sll_test.py
+++ b/fbgemm_gpu/test/sll/triton_sll_test.py
@@ -302,3 +302,53 @@ class TritonBmmTest(unittest.TestCase):
             assert torch.allclose(y1.grad, y2.grad, 1e-5)
             # pyre-fixme[6]: In call `torch._C._VariableFunctions.allclose`, for 1st positional argument, expected `Tensor` but got `Optional[Tensor]`.Pyre
             assert torch.allclose(x1.grad, x2.grad, 1e-5)
+
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @given(
+        B=st.integers(10, 512),
+        max_L=st.integers(1, 200),
+        device_type=st.sampled_from(["cpu", "cuda"]),
+        enable_pt2=st.sampled_from([True, False]),
+    )
+    @settings(deadline=None)
+    def test_dense_jagged_cat_jagged_out(
+        self,
+        B: int,
+        max_L: int,
+        device_type: str,
+        enable_pt2: bool,
+    ) -> None:
+        device = torch.device(device_type)
+        lengths = torch.randint(0, max_L + 1, (B,), device=device)
+        offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(lengths)
+        c_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(lengths + 1)
+        a = torch.randint(0, 100000000, (B,), device=device)
+        b = torch.randint(0, 100000000, (int(lengths.sum().item()),), device=device)
+
+        ref = torch.cat(
+            [
+                (
+                    torch.cat((a[i : i + 1], b[offsets[i] : offsets[i + 1]]), dim=-1)
+                    if lengths[i] > 0
+                    else a[i : i + 1]
+                )
+                for i in range(B)
+            ],
+            dim=-1,
+        )
+
+        # pyre-fixme[3]: Return type must be annotated.
+        # pyre-fixme[2]: Parameter must be annotated.
+        def model(a, b, offsets, max_L):
+            return torch.ops.fbgemm.sll_dense_jagged_cat_jagged_out(
+                a, b, offsets, max_L
+            )
+
+        if enable_pt2:
+            model = torch.compile(model)
+
+        ret, c_offsets_computed = model(a, b, offsets, max_L)
+
+        assert torch.allclose(ref, ret)
+        assert torch.equal(c_offsets, c_offsets_computed)


### PR DESCRIPTION
## 1. Context

Sequence models over variable-length user histories repeatedly need to **prepend a per-request "anchor" element to every jagged row** before doing pairwise work on the row — e.g. splicing the current event's timestamp/position onto the front of a user's history so that a downstream pairwise operator can produce "time since each prior event". In eager PyTorch this is a `B`-way Python loop of `torch.cat`, which costs `O(B)` kernel launches, allocates `B` intermediates, and forces the offsets to be recomputed with a `cumsum`.

This diff adds `fbgemm::sll_dense_jagged_cat_jagged_out` to the SLL (sequence-length-list) op set: a single fused op that concatenates a dense `[B]` head tensor onto a jagged value tensor and returns both the new jagged values and the new offsets. It is the first half of the "prepend anchor → self-subtract" pattern completed by `sll_jagged_self_substraction_jagged_out` (D65786601).

## 2. Op contract

```
sll_dense_jagged_cat_jagged_out(
    Tensor a,            # dense, [B]        -- one head element per row
    Tensor b,            # jagged values, [sum_i L_i]
    Tensor b_offsets,    # [B + 1]
    int max_seq_len
) -> (Tensor c, Tensor c_offsets)
```

Semantics, for row `i` with length `L_i = b_offsets[i+1] - b_offsets[i]`:

```
c_i = concat(a[i], b_i[0 : L_i])          # new length L_i + 1
```

so `|c| = |b| + B` and `c_offsets[i] = b_offsets[i] + i`.

## 3. Algorithm design

### 3.1 Offsets in closed form — no prefix sum

Every row grows by **exactly one** element, so the output offsets are not data-dependent beyond the input offsets: the new offset array is just the old one shifted by each row's rank.

```
c_offsets = b_offsets + arange(B + 1)
```

This is the central simplification. A naive implementation would recompute lengths, add 1, and run `asynchronous_complete_cumsum` — an extra scan kernel plus a temporary. Here the offsets fall out as a rank shift that each program computes locally (`c_start = b_start + pid_batch`), i.e. `O(1)` per row with no cross-program communication and no scan.

### 3.2 Triton kernel — one program per row

`dense_jagged_cat_jagged_out_kernel` uses a **1-D grid of `B` programs**, one per jagged row. Each program:

1. Loads `b_start`/`b_end` from `b_offsets` and computes `N = min(b_end - b_start, max_seq_len)` — the per-row copy length, clamped so a pathological row cannot run away.
2. Computes its destination base `c_start = b_start + pid_batch` (the rank shift from 3.1).
3. Stores the dense head: `c[c_start] = a[pid_batch]`. This is a single scalar store and needs no mask — every row has a head, including empty rows, which is what makes the offset arithmetic uniform.
4. Streams the row body in `BLOCK_SIZE = 128` chunks: `c[c_start + 1 + k : ...] = b[b_start + k : ...]`, masked by `offset < N`. The loop is a coalesced device-to-device copy; consecutive lanes touch consecutive addresses in both source and destination, so the shift by one element costs an unaligned start but no gather.
5. Writes its own offset entry `c_offsets[pid_batch] = b_start + pid_batch`.

The `B + 1`-th offset entry is not owned by any program, so it is patched on the host side after launch (`c_offsets[-1] = b_offsets[-1] + B`). This is a device-side tensor op — it does **not** introduce a device-to-host sync.

**Parallelisation trade-off.** The grid is `(B,)` rather than `(B, cdiv(max_L, BLOCK))`. One program owns a whole row and walks it serially. This keeps the offset write trivially single-owner (step 5) and avoids a second kernel for offsets, at the cost of not parallelising *within* a long row. The op is pure memory traffic with no reuse, so occupancy is driven by `B`; for the recommendation-model regime this targets (`B` in the hundreds, `L_i` in the tens-to-low-hundreds) `B` alone saturates the machine. For very small `B` with very long rows, a 2-D grid would be the better shape.

### 3.3 CPU reference

`cpu_dense_jagged_cat_jagged_out` mirrors the same two-part structure: the closed-form offsets (`b_offsets + arange`) and a value concat. It is written for **correctness, not throughput** — a per-row `torch.cat` inside a list comprehension, with the `lengths[i] > 0` branch keeping empty rows from degenerating.

## 4. Complexity

| | |
|---|---|
| Work | `O(sum_i L_i + B)` — single pass, every element read once and written once |
| Extra memory | Only the output `c` (`|b| + B`) and `c_offsets` (`B + 1`); no intermediates |
| Kernel launches | 1 (vs. `O(B)` for the eager loop) |
| Syncs | none |

## 5. Analysis

1. **Truncation asymmetry.** The Triton kernel clamps the copy to `max_seq_len` while offsets are derived from the untruncated `b_offsets`; the CPU op ignores `max_seq_len` entirely. Rows longer than `max_seq_len` therefore leave a zero-filled tail on CUDA (`c` is allocated with `torch.zeros`, so the result is deterministic) and are copied whole on CPU. The intended contract is `max_seq_len >= max_i L_i`, matching how the caller sizes the rest of the pipeline.
2. **No autograd.** The op is registered for `CUDA` and `CPU` only. Its target payload is index/timestamp-like integer data that is never differentiated; adding an autograd rule would just be a masked slice of the incoming gradient and can be added later without changing the schema.
3. **Contiguity contract.** All three inputs are asserted contiguous. The kernel indexes with raw element offsets rather than strides, so this assert is load-bearing rather than defensive.
4. **PT2.** The output shape is a pure function of the input shapes (`|b| + B`), not of the input *values*, so no fake/meta kernel is required for tracing — the test covers `torch.compile` on both backends.
5. **BC.** Purely additive: a new schema guarded by a `torch.library._defs` membership check, plus new symbol exports. No existing op signature or dispatch registration changes.

## 6. Changes

1. **`fbgemm_gpu/sll/triton_sll.py`**: adds `dense_jagged_cat_jagged_out_kernel` (Triton) and the `dense_jagged_cat_jagged_out` launcher that allocates `c`/`c_offsets` and patches the final offset entry.
2. **`fbgemm_gpu/sll/cpu_sll.py`**: adds `cpu_dense_jagged_cat_jagged_out`, the CPU correctness reference.
3. **`fbgemm_gpu/sll/__init__.py`**: defines the `sll_dense_jagged_cat_jagged_out` schema and registers the CUDA and CPU kernels.
4. **`test/sll/triton_sll_test.py`**: adds `test_dense_jagged_cat_jagged_out`, a hypothesis test over `B in [10, 512]` and `max_L in [1, 200]`, sweeping `{cpu, cuda} x {eager, torch.compile}` and checking both returned values and returned offsets against an eager `torch.cat` reference.


Differential Revision: D65781881
