### PR TITLE
[detailed][ops] open-source SLL jagged_self_substraction_jagged_out

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sll/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/__init__.py
@@ -10,11 +10,16 @@
 import torch
 
 from fbgemm_gpu.sll.cpu_sll import (  # noqa F401
+    cpu_dense_jagged_cat_jagged_out,
     cpu_jagged_dense_bmm,
     cpu_jagged_jagged_bmm,
 )
 
-from fbgemm_gpu.sll.triton_sll import jagged_dense_bmm, jagged_jagged_bmm  # noqa F401
+from fbgemm_gpu.sll.triton_sll import (  # noqa F401
+    dense_jagged_cat_jagged_out,
+    jagged_dense_bmm,
+    jagged_jagged_bmm,
+)
 
 
 def op_registeration(
@@ -73,6 +78,17 @@ if "fbgemm::sll_jagged_jagged_bmm" not in torch.library._defs:
         """
     )
 
+if "fbgemm::sll_dense_jagged_cat_jagged_out" not in torch.library._defs:
+    lib.define(
+        """sll_dense_jagged_cat_jagged_out(
+            Tensor a,
+            Tensor b,
+            Tensor a_offsets,
+            int max_seq_len
+        ) -> (Tensor, Tensor)
+        """
+    )
+
 op_registeration(lib, "sll_jagged_dense_bmm", jagged_dense_bmm, "CUDA")
 op_registeration(lib, "sll_jagged_dense_bmm", jagged_dense_bmm, "AutogradCUDA")
 op_registeration(lib, "sll_jagged_dense_bmm", cpu_jagged_dense_bmm, "CPU")
@@ -81,3 +97,9 @@ op_registeration(lib, "sll_jagged_jagged_bmm", jagged_jagged_bmm, "CUDA")
 op_registeration(lib, "sll_jagged_jagged_bmm", jagged_jagged_bmm, "AutogradCUDA")
 op_registeration(lib, "sll_jagged_jagged_bmm", cpu_jagged_jagged_bmm, "CPU")
 op_registeration(lib, "sll_jagged_jagged_bmm", cpu_jagged_jagged_bmm, "AutogradCPU")
+op_registeration(
+    lib, "sll_dense_jagged_cat_jagged_out", dense_jagged_cat_jagged_out, "CUDA"
+)
+op_registeration(
+    lib, "sll_dense_jagged_cat_jagged_out", cpu_dense_jagged_cat_jagged_out, "CPU"
+)

--- a/fbgemm_gpu/fbgemm_gpu/sll/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/__init__.py
@@ -9,9 +9,12 @@
 
 import torch
 
-from fbgemm_gpu.sll.cpu_sll import cpu_jagged_dense_bmm  # noqa F401
+from fbgemm_gpu.sll.cpu_sll import (  # noqa F401
+    cpu_jagged_dense_bmm,
+    cpu_jagged_jagged_bmm,
+)
 
-from fbgemm_gpu.sll.triton_sll import jagged_dense_bmm  # noqa F401
+from fbgemm_gpu.sll.triton_sll import jagged_dense_bmm, jagged_jagged_bmm  # noqa F401
 
 
 def op_registeration(
@@ -57,7 +60,24 @@ if "fbgemm::sll_jagged_dense_bmm" not in torch.library._defs:
         """
     )
 
+if "fbgemm::sll_jagged_jagged_bmm" not in torch.library._defs:
+    lib.define(
+        """sll_jagged_jagged_bmm(
+            Tensor x,
+            Tensor y,
+            Tensor x_offsets,
+            int N,
+            bool allow_tf32,
+            bool use_fbgemm_kernel=True
+        ) -> Tensor
+        """
+    )
+
 op_registeration(lib, "sll_jagged_dense_bmm", jagged_dense_bmm, "CUDA")
 op_registeration(lib, "sll_jagged_dense_bmm", jagged_dense_bmm, "AutogradCUDA")
 op_registeration(lib, "sll_jagged_dense_bmm", cpu_jagged_dense_bmm, "CPU")
 op_registeration(lib, "sll_jagged_dense_bmm", cpu_jagged_dense_bmm, "AutogradCPU")
+op_registeration(lib, "sll_jagged_jagged_bmm", jagged_jagged_bmm, "CUDA")
+op_registeration(lib, "sll_jagged_jagged_bmm", jagged_jagged_bmm, "AutogradCUDA")
+op_registeration(lib, "sll_jagged_jagged_bmm", cpu_jagged_jagged_bmm, "CPU")
+op_registeration(lib, "sll_jagged_jagged_bmm", cpu_jagged_jagged_bmm, "AutogradCPU")

--- a/fbgemm_gpu/fbgemm_gpu/sll/cpu_sll.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/cpu_sll.py
@@ -102,3 +102,66 @@ def cpu_jagged_dense_bmm(
         return torch.ops.fbgemm.jagged_dense_bmm(x, x_offsets, y, N)[0]
     else:
         return JaggedDenseBmmCPU.apply(x, y, x_offsets, N)
+
+
+class JaggedJaggedBmm(torch.autograd.Function):
+    """
+    Compute batch matrix multiplication between JaggedTensor and Jagged Tensor
+    dense: [B, D, N] * [B, N, T] = [B, D, T]
+    jagged: [Sum_B, D].T * [Sum_B, T] = [B, D, T]
+    """
+
+    @staticmethod
+    # pyre-fixme
+    def forward(
+        ctx: Any,  # pyre-ignore
+        x: torch.Tensor,
+        y: torch.Tensor,
+        x_offsets: torch.Tensor,
+        N: int,
+    ) -> torch.Tensor:
+        ctx.save_for_backward(x, y, x_offsets)
+        ctx.N = N
+        return cpu_jagged_jagged_bmm_kernel(x.T, y, x_offsets, N)
+
+    @staticmethod
+    # pyre-fixme
+    def backward(
+        ctx: Any, grad_output: torch.Tensor  # pyre-ignore
+    ) -> Tuple[torch.Tensor, torch.Tensor, None, None, None]:
+        """
+        # X = [Sum_B, D]
+        # Y = [Sum_B, T]
+        # Z = XT * Y = [B, D, T]
+        # dXT = dZ * YT -> dX = Y * dZT
+        # dY = X * dZ -> X * dZ
+        """
+        (x, y, offsets) = ctx.saved_tensors
+        N = ctx.N
+        grad_x = cpu_jagged_dense_bmm_kernel(
+            y, grad_output.permute(0, 2, 1), offsets, N
+        )
+        grad_y = cpu_jagged_dense_bmm_kernel(x, grad_output, offsets, N)
+        return grad_x, grad_y, None, None, None
+
+
+def cpu_jagged_jagged_bmm(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    x_offsets: torch.Tensor,
+    N: int,
+    allow_tf32: bool,
+    use_fbgemm_kernel: bool = True,
+) -> torch.Tensor:
+    """
+    Compute batch matrix multiplication between JaggedTensor and Jagged Tensor
+    dense: [B, D, N] * [B, N, T] = [B, D, T]
+    jagged: [Sum_B, D].T * [Sum_B, T] = [B, D, T]
+    """
+
+    # Force the CPU backend to use fbgemm kernel as it has better performance
+    use_fbgemm_kernel = True
+    if use_fbgemm_kernel:
+        return torch.ops.fbgemm.jagged_jagged_bmm(x, y, x_offsets, N)
+    else:
+        return JaggedJaggedBmm.apply(x, y, x_offsets, N)

--- a/fbgemm_gpu/fbgemm_gpu/sll/triton_sll.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/triton_sll.py
@@ -206,6 +206,35 @@ def jagged_jagged_bmm_kernel(
     tl.store(c_ptrs, c, mask=mask)
 
 
+@triton.jit
+def dense_jagged_cat_jagged_out_kernel(
+    a_ptr,  # dense
+    b_ptr,  # jagged
+    c_ptr,  # jagged
+    b_offsets_ptr,
+    c_offsets_ptr,
+    max_seq_len,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid_batch = tl.program_id(0)
+    b_start = tl.load(b_offsets_ptr + pid_batch)
+    b_end = tl.load(b_offsets_ptr + pid_batch + 1)
+    c_start = b_start + pid_batch
+    N = b_end - b_start
+    N = tl.minimum(N, max_seq_len)
+
+    a = tl.load(a_ptr + pid_batch)
+    tl.store(c_ptr + c_start, a)
+
+    offs_k = tl.arange(0, BLOCK_SIZE)
+    for k in range(0, N, BLOCK_SIZE):
+        b_offset = k + offs_k
+        b_ptrs = b_ptr + b_start + b_offset
+        b = tl.load(b_ptrs, mask=b_offset < N, other=0.0)
+        tl.store(c_ptr + c_start + 1 + b_offset, b, mask=b_offset < N)
+    tl.store(c_offsets_ptr + pid_batch, b_start + pid_batch)
+
+
 def triton_jagged_dense_bmm(a, b, a_offsets, max_seq_len, allow_tf32):
     # checks constraints
     assert a.shape[1] == b.shape[1], "incompatible dimensions"
@@ -289,6 +318,38 @@ def triton_jagged_jagged_bmm(a, b, a_offsets, max_seq_len, allow_tf32):
         BLOCK_SIZE_K,
     )
     return c
+
+
+def dense_jagged_cat_jagged_out(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    b_offsets: torch.Tensor,
+    max_seq_len: int,
+):
+    assert a.is_contiguous()
+    assert b.is_contiguous()
+    assert b_offsets.is_contiguous()
+    B = a.size(0)
+    BLOCK_SIZE = 128
+    c = torch.zeros(b.size(0) + a.size(0), dtype=a.dtype, device=a.device)
+    c_offsets = torch.empty(
+        b_offsets.size(0), dtype=b_offsets.dtype, device=b_offsets.device
+    )  # B + 1
+
+    dense_jagged_cat_jagged_out_kernel[(B,)](
+        a,
+        b,
+        c,
+        b_offsets,
+        c_offsets,
+        max_seq_len,
+        # pyre-fixme[6]: For 7th argument expected `constexpr` but got `int`.
+        BLOCK_SIZE,
+    )
+
+    c_offsets[-1] = b_offsets[-1] + B
+
+    return c, c_offsets
 
 
 class JaggedDenseBmm(torch.autograd.Function):

--- a/fbgemm_gpu/fbgemm_gpu/sll/triton_sll.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/triton_sll.py
@@ -20,6 +20,28 @@ def set_block_size(N: int) -> int:
         return 16
 
 
+def next_power_of_two(N: int) -> int:
+    if N > 4096:
+        raise Exception(f"{N} is too large that is not supported yet")
+
+    if N > 2048:
+        return 4096
+    elif N > 1024:
+        return 2048
+    elif N > 512:
+        return 1024
+    elif N > 256:
+        return 512
+    elif N > 128:
+        return 256
+    elif N > 64:
+        return 128
+    elif N > 32:
+        return 64
+    else:
+        return 32
+
+
 # TODO add autotune to find best block size
 # add supergroup to optimize GPU cache
 @triton.jit
@@ -235,6 +257,39 @@ def dense_jagged_cat_jagged_out_kernel(
     tl.store(c_offsets_ptr + pid_batch, b_start + pid_batch)
 
 
+@triton.jit
+def jagged_self_substraction_jagged_out_kernel(
+    a_ptr,  # jagged
+    b_ptr,  # jagged
+    a_offsets_ptr,
+    b_offsets_ptr,
+    max_seq_len,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid_batch = tl.program_id(0)
+    pid_index = tl.program_id(1)
+
+    a_offset = tl.load(a_offsets_ptr + pid_batch)
+    a_length = tl.load(a_offsets_ptr + pid_batch + 1) - a_offset
+    a_length = tl.minimum(a_length, max_seq_len + 1)
+
+    if a_length <= 1:
+        return
+
+    N = a_length - 1
+    if pid_index >= N:
+        return
+
+    a_cur = tl.load(a_ptr + a_offset + pid_index)
+    offs = tl.arange(0, BLOCK_SIZE)
+    mask = offs < N
+    a_row = tl.load(a_ptr + a_offset + offs + 1, mask=mask)
+    b = a_cur - a_row
+
+    b_offset = tl.load(b_offsets_ptr + pid_batch)
+    tl.store(b_ptr + b_offset + pid_index * N + offs, b, mask=mask)
+
+
 def triton_jagged_dense_bmm(a, b, a_offsets, max_seq_len, allow_tf32):
     # checks constraints
     assert a.shape[1] == b.shape[1], "incompatible dimensions"
@@ -350,6 +405,33 @@ def dense_jagged_cat_jagged_out(
     c_offsets[-1] = b_offsets[-1] + B
 
     return c, c_offsets
+
+
+def triton_jagged_self_substraction_jagged_out(
+    jagged_A: torch.Tensor,
+    offsets_a: torch.Tensor,
+    offsets_b: torch.Tensor,
+    max_seq_len,
+) -> torch.Tensor:
+    B = offsets_a.size(0) - 1
+
+    jagged_B = torch.empty(
+        (int(offsets_b[-1].item())), device=jagged_A.device, dtype=jagged_A.dtype
+    )
+
+    BLOCK_SIZE = max(next_power_of_two(max_seq_len), 16)
+    grid = (B, max_seq_len)
+
+    jagged_self_substraction_jagged_out_kernel[grid](
+        jagged_A,
+        jagged_B,
+        offsets_a,
+        offsets_b,
+        max_seq_len,
+        BLOCK_SIZE,  # pyre-fixme[6]: For 6th argument expected `constexpr` but got `int`.
+    )
+
+    return jagged_B
 
 
 class JaggedDenseBmm(torch.autograd.Function):

--- a/fbgemm_gpu/test/sll/triton_sll_test.py
+++ b/fbgemm_gpu/test/sll/triton_sll_test.py
@@ -155,3 +155,150 @@ class TritonBmmTest(unittest.TestCase):
             assert torch.allclose(x1.grad, x2.grad, 1e-5)
             # pyre-fixme[6]: In call `torch._C._VariableFunctions.allclose`, for 1st positional argument, expected `Tensor` but got `Optional[Tensor]`.Pyre
             assert torch.allclose(y1.grad, y2.grad, 1e-5)
+
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @given(
+        B=st.integers(1, 512),
+        D=st.integers(1, 256),
+        N=st.integers(1, 1000),
+        T=st.integers(1, 256),
+        use_fbgemm_kernel=st.booleans(),
+        allow_tf32=st.booleans(),
+        device_type=st.sampled_from(["cpu", "cuda"]),
+    )
+    @settings(deadline=None)
+    def test_triton_jagged_jagged_bmm(
+        self,
+        B: int,
+        D: int,
+        N: int,
+        T: int,
+        use_fbgemm_kernel: bool,
+        allow_tf32: bool,
+        device_type: str,
+    ) -> None:
+        device = torch.device(device_type)
+        lengths = torch.randint(0, N + 1, (B,), device=device)
+        offsets = torch.cat(
+            [
+                torch.tensor([0], dtype=torch.int32, device=device),
+                lengths.cumsum(dim=0),
+            ],
+            dim=0,
+        )
+        x = torch.rand(int(lengths.sum().item()), D, device=device)
+        y = torch.rand(int(lengths.sum().item()), T, device=device)
+        padded_x = torch.ops.fbgemm.jagged_to_padded_dense(
+            x,
+            [offsets],
+            max_lengths=[N],
+            padding_value=0.0,
+        )  # [B, N, D]
+        padded_y = torch.ops.fbgemm.jagged_to_padded_dense(
+            y,
+            [offsets],
+            max_lengths=[N],
+            padding_value=0.0,
+        )  # [B, N, T]
+        ret = torch.ops.fbgemm.sll_jagged_jagged_bmm(
+            x, y, offsets, N, allow_tf32=allow_tf32, use_fbgemm_kernel=use_fbgemm_kernel
+        )
+        ref = torch.bmm(padded_x.permute(0, 2, 1), padded_y)
+
+        if allow_tf32:
+            assert torch.allclose(ref, ret, atol=1e-3, rtol=1e-3)
+        else:
+            assert torch.allclose(ref, ret, 1e-5)
+
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @given(
+        B=st.integers(1, 512),
+        D=st.integers(1, 256),
+        N=st.integers(1, 1000),
+        T=st.integers(1, 256),
+        use_fbgemm_kernel=st.booleans(),
+        allow_tf32=st.booleans(),
+        device_type=st.sampled_from(["cpu", "cuda"]),
+    )
+    @settings(deadline=None)
+    def test_triton_jagged_jagged_bmm_with_grad(
+        self,
+        B: int,
+        D: int,
+        N: int,
+        T: int,
+        use_fbgemm_kernel: bool,
+        allow_tf32: bool,
+        device_type: str,
+    ) -> None:
+        device = torch.device(device_type)
+        lengths = torch.randint(0, N + 1, (B,), device=device)
+        offsets = torch.cat(
+            [
+                torch.tensor([0], dtype=torch.int32, device=device),
+                lengths.cumsum(dim=0),
+            ],
+            dim=0,
+        )
+
+        torch.manual_seed(0)
+        x1 = torch.rand(
+            (int(lengths.sum().item()), D), requires_grad=True, device=device
+        )  # [Sum_B, D]
+        padded_x1 = torch.ops.fbgemm.jagged_to_padded_dense(
+            x1,
+            [offsets],
+            max_lengths=[N],
+            padding_value=0.0,
+        )  # [B, N, D]
+        y1 = torch.rand(
+            (int(lengths.sum().item()), T), requires_grad=True, device=device
+        )  # [Sum_B, T]
+        padded_y1 = torch.ops.fbgemm.jagged_to_padded_dense(
+            y1,
+            [offsets],
+            max_lengths=[N],
+            padding_value=0.0,
+        )  # [B, N, T]
+
+        ref = torch.bmm(padded_x1.permute(0, 2, 1), padded_y1)
+
+        # triton version
+        torch.manual_seed(0)
+        x2 = torch.rand(
+            (int(lengths.sum().item()), D), requires_grad=True, device=device
+        )  # [Sum_B, D]
+        y2 = torch.rand(
+            (int(lengths.sum().item()), T), requires_grad=True, device=device
+        )  # [Sum_B, T]
+        ret = torch.ops.fbgemm.sll_jagged_jagged_bmm(
+            x2,
+            y2,
+            offsets,
+            N,
+            allow_tf32=allow_tf32,
+            use_fbgemm_kernel=use_fbgemm_kernel,
+        )
+
+        if allow_tf32:
+            assert torch.allclose(ref, ret, atol=1e-3, rtol=1e-3)
+        else:
+            assert torch.allclose(ref, ret, 1e-5)
+
+        # grad check
+        grad_output = torch.rand((B, D, T), device=device) * 0.01
+        ref.backward(grad_output)
+        ret.backward(grad_output)
+
+        if allow_tf32:
+            # pyre-fixme[6]: In call `torch._C._VariableFunctions.allclose`, for 1st positional argument, expected `Tensor` but got `Optional[Tensor]`.Pyre
+            assert torch.allclose(y1.grad, y2.grad, atol=1e-3, rtol=1e-3)
+            # pyre-fixme[6]: In call `torch._C._VariableFunctions.allclose`, for 1st positional argument, expected `Tensor` but got `Optional[Tensor]`.Pyre
+            assert torch.allclose(x1.grad, x2.grad, atol=1e-3, rtol=1e-3)
+        else:
+            # pyre-fixme[6]: In call `torch._C._VariableFunctions.allclose`, for 1st positional argument, expected `Tensor` but got `Optional[Tensor]`.Pyre
+            assert torch.allclose(y1.grad, y2.grad, 1e-5)
+            # pyre-fixme[6]: In call `torch._C._VariableFunctions.allclose`, for 1st positional argument, expected `Tensor` but got `Optional[Tensor]`.Pyre
+            assert torch.allclose(x1.grad, x2.grad, 1e-5)

--- a/fbgemm_gpu/test/sll/triton_sll_test.py
+++ b/fbgemm_gpu/test/sll/triton_sll_test.py
@@ -13,6 +13,7 @@ import fbgemm_gpu.sll.triton_sll  # noqa F401
 
 import torch
 from hypothesis import given, settings, strategies as st
+from torch.testing._internal.optests import opcheck
 
 # pyre-ignore[16]: Module `fbgemm_gpu` has no attribute `open_source`
 open_source: bool = getattr(fbgemm_gpu, "open_source", False)
@@ -352,3 +353,77 @@ class TritonBmmTest(unittest.TestCase):
 
         assert torch.allclose(ref, ret)
         assert torch.equal(c_offsets, c_offsets_computed)
+
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @given(
+        B=st.integers(10, 100),
+        L=st.integers(1, 200),
+        device_type=st.sampled_from(["cpu", "cuda"]),
+        enable_pt2=st.booleans(),
+    )
+    @settings(deadline=None)
+    def test_triton_jagged_self_substraction_jagged_out(
+        self,
+        B: int,
+        L: int,
+        device_type: str,
+        enable_pt2: bool,
+    ) -> None:
+        device = torch.device(device_type)
+        torch.manual_seed(0)
+        lengths_a = torch.randint(1, L + 2, (B,), device=device)
+        offsets_a = torch.cat(
+            [
+                torch.tensor([0], dtype=torch.int32, device=device),
+                lengths_a.cumsum(dim=0),
+            ],
+            dim=0,
+        )
+
+        lengths_b = (lengths_a - 1) * (lengths_a - 1)
+
+        offsets_b = torch.cat(
+            [
+                torch.tensor([0], dtype=torch.int32, device=device),
+                lengths_b.cumsum(dim=0),
+            ],
+            dim=0,
+        )
+
+        jagged_A = torch.randint(
+            0, 100000000, (int(lengths_a.sum().item()),), device=device
+        )
+
+        def model(
+            jagged_A: torch.Tensor,
+            offsets_a: torch.Tensor,
+            offsets_b: torch.Tensor,
+            L: int,
+        ) -> torch.Tensor:
+            return torch.ops.fbgemm.sll_jagged_self_substraction_jagged_out(
+                jagged_A,
+                offsets_a,
+                offsets_b,
+                L,
+            )
+
+        if enable_pt2:
+            torch._dynamo.config.capture_dynamic_output_shape_ops = True
+            torch._dynamo.config.capture_scalar_outputs = True
+            opcheck(
+                torch.ops.fbgemm.sll_jagged_self_substraction_jagged_out,
+                (jagged_A, offsets_a, offsets_b, L),
+            )
+            model = torch.compile(model)
+
+        result = model(jagged_A, offsets_a, offsets_b, L)
+
+        for i in range(B):
+            if lengths_a[i] == 1:
+                continue
+
+            a = jagged_A[offsets_a[i] : offsets_a[i + 1]]
+            ref = a[:-1].unsqueeze(1) - a[1:].unsqueeze(0)
+
+            assert torch.equal(result[offsets_b[i] : offsets_b[i + 1]], ref.flatten())

--- a/fbgemm_gpu/test/sll/triton_sll_test.py
+++ b/fbgemm_gpu/test/sll/triton_sll_test.py
@@ -302,3 +302,53 @@ class TritonBmmTest(unittest.TestCase):
             assert torch.allclose(y1.grad, y2.grad, 1e-5)
             # pyre-fixme[6]: In call `torch._C._VariableFunctions.allclose`, for 1st positional argument, expected `Tensor` but got `Optional[Tensor]`.Pyre
             assert torch.allclose(x1.grad, x2.grad, 1e-5)
+
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @given(
+        B=st.integers(10, 512),
+        max_L=st.integers(1, 200),
+        device_type=st.sampled_from(["cpu", "cuda"]),
+        enable_pt2=st.sampled_from([True, False]),
+    )
+    @settings(deadline=None)
+    def test_dense_jagged_cat_jagged_out(
+        self,
+        B: int,
+        max_L: int,
+        device_type: str,
+        enable_pt2: bool,
+    ) -> None:
+        device = torch.device(device_type)
+        lengths = torch.randint(0, max_L + 1, (B,), device=device)
+        offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(lengths)
+        c_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(lengths + 1)
+        a = torch.randint(0, 100000000, (B,), device=device)
+        b = torch.randint(0, 100000000, (int(lengths.sum().item()),), device=device)
+
+        ref = torch.cat(
+            [
+                (
+                    torch.cat((a[i : i + 1], b[offsets[i] : offsets[i + 1]]), dim=-1)
+                    if lengths[i] > 0
+                    else a[i : i + 1]
+                )
+                for i in range(B)
+            ],
+            dim=-1,
+        )
+
+        # pyre-fixme[3]: Return type must be annotated.
+        # pyre-fixme[2]: Parameter must be annotated.
+        def model(a, b, offsets, max_L):
+            return torch.ops.fbgemm.sll_dense_jagged_cat_jagged_out(
+                a, b, offsets, max_L
+            )
+
+        if enable_pt2:
+            model = torch.compile(model)
+
+        ret, c_offsets_computed = model(a, b, offsets, max_L)
+
+        assert torch.allclose(ref, ret)
+        assert torch.equal(c_offsets, c_offsets_computed)


### PR DESCRIPTION
## 1. Context

Time-aware / position-aware sequence models need, for each user, the **pairwise difference matrix of a variable-length sequence with itself** — given a row of timestamps or positions, produce the `L x L` matrix of "distance from element m to element n" that is later consumed as an attention bias. Materialising that as a padded dense `[B, L, L]` tensor is quadratic in the *padded* length and wastes most of its memory on a skewed batch; doing it row-by-row in eager PyTorch is `O(B)` launches.

This diff adds `fbgemm::sll_jagged_self_substraction_jagged_out`, which computes the self-difference matrix **jagged-in, jagged-out** — the `B` per-row square matrices are produced flattened and packed back-to-back, never materialising padding. It is the second half of the pattern started by `sll_dense_jagged_cat_jagged_out` (D65781881): prepend the anchor element to each row, then self-subtract to get every prior element's offset relative to it.

It also carries an infrastructure change to the SLL op-registration helper that unblocks PT2 tracing for **all** data-dependent-output SLL ops (see 4.1).

## 2. Op contract

```
sll_jagged_self_substraction_jagged_out(
    Tensor a,            # jagged values, [sum_i L_i]
    Tensor offsets_a,    # [B + 1]
    Tensor offsets_b,    # [B + 1], caller-provided output offsets
    int max_seq_len
) -> Tensor
```

For row `i` with length `L_i` and `N_i = L_i - 1`:

```
B_i[m][n] = A_i[m] - A_i[n + 1],    0 <= m, n < N_i
```

flattened row-major, so row `i` of the output occupies `N_i * N_i = (L_i - 1)^2` slots. The `[:-1]` / `[1:]` shift is what makes the head element (the anchor prepended by D65781881) the reference point rather than a self-pair.

## 3. Algorithm design

### 3.1 Output offsets are an input, not a computation

The output row length `(L_i - 1)^2` is **quadratic in a data-dependent quantity**, so the total output size cannot be known without reading the offsets. Rather than computing it inside the op, the schema takes `offsets_b` as a caller-supplied argument. Two consequences:

1. The caller (which already has `lengths_a`) computes `cumsum((L - 1)^2)` once and can reuse it across several ops in the same pipeline — the op does not pay for a scan it cannot amortise.
2. Allocation still needs the total, so the launcher reads `int(offsets_b[-1].item())`, which is a **device-to-host sync**. This is the single unavoidable serialisation point in the op; it is paid once per call, not per row.

### 3.2 Triton kernel — 2-D grid, one program per output row

`jagged_self_substraction_jagged_out_kernel` launches a rectangular grid `(B, max_seq_len)`. Program `(i, m)` produces **one full row** of row `i`'s difference matrix:

1. Load `a_offset`, and `a_length = min(offsets_a[i+1] - offsets_a[i], max_seq_len + 1)`. The `+1` is deliberate: `max_seq_len` bounds the *output* dimension `N`, and the input carries one extra element consumed by the shift.
2. Two early exits, in order:
   - `a_length <= 1` — the row degenerates to an empty matrix, nothing to write.
   - `pid_index >= N` where `N = a_length - 1` — the grid is rectangular over `max_seq_len`, so programs beyond this row's actual length retire immediately.
3. Load the scalar `a_cur = A[a_offset + m]` and the vector `a_row = A[a_offset + 1 + 0 : BLOCK_SIZE]`, masked to `< N`.
4. Compute `b = a_cur - a_row`. **Triton's scalar-vector broadcast is what makes this a one-instruction outer difference** — no explicit `L x L` intermediate, no transpose, no shared memory.
5. Store to `B[b_offset + m * N + 0 : N]`, masked. The row stride is `N`, which is *data-dependent per batch item* — this is the crux of jagged² addressing.

The whole output row lives in registers; the kernel uses zero shared memory and makes exactly one pass over the input row per output row.

### 3.3 Block size must cover a whole row

Because step 4 has **no inner loop over columns**, `BLOCK_SIZE` must be at least `N`. Hence:

```
BLOCK_SIZE = max(next_power_of_two(max_seq_len), 16)
```

with a new `next_power_of_two` helper that rounds up over the ladder 32 → 4096 and **raises above 4096**. This makes `max_seq_len <= 4096` a hard, explicit precondition of the op rather than silent corruption. The floor of 16 keeps degenerate small-`max_seq_len` launches at a sane warp granularity.

The alternative — a column loop with a fixed small block — would lift the cap but adds a loop to the innermost path of an op that is already bandwidth-bound at these sizes.

### 3.4 Load-balance trade-off

The grid is `B * max_seq_len` programs regardless of the actual lengths. On a skewed batch the short rows spawn programs that do nothing but load two offsets and retire at step 2. This is a deliberate trade: a rectangular grid needs no work-assignment prefix scan and no per-program search for "which row am I in", and the retiring programs cost only an offset load. The cost model degrades when `max_seq_len >> mean(L_i)`.

### 3.5 CPU reference

`cpu_jagged_self_substraction_jagged_out` allocates `torch.empty(offsets_b[-1])` and loops over the batch, skipping rows of length 1 (whose output span is empty, so nothing is left uninitialised), and writing `(a[:-1].unsqueeze(1) - a[1:].unsqueeze(0)).flatten()` — the same broadcast expression as the kernel, expressed in eager PyTorch. Correctness reference, not a performance path.

## 4. PT2 / dispatch design

### 4.1 `op_registeration` learns the `Meta` key

The output size is **data-dependent**, so `torch.compile` and `torch.export` cannot infer it from input metadata; they need a fake (meta) kernel that declares a dynamic size. `lib.impl(..., "Meta")` is the wrong registration path for that — PyTorch wants `lib._register_fake`. The shared helper is therefore extended:

```python
if dispatch_key == "Meta":
    lib._register_fake(op_name, fn)
else:
    lib.impl(op_name, fn, dispatch_key)
```

This is a small change with stack-wide reach: every later SLL op with a data-dependent or non-trivial output shape registers its meta kernel through the same helper (D65827782 uses it immediately).

### 4.2 The fake kernel

`meta_jagged_self_substraction_jagged_out` returns `torch.empty([torch.library.get_ctx().new_dynamic_size()], ...)` — it declares "one dimension, size unknown at trace time" rather than guessing. Callers under `torch.compile` must enable `capture_dynamic_output_shape_ops` and `capture_scalar_outputs`, which the test does explicitly.

Dispatch table added by this diff:

| Key | Implementation |
|---|---|
| `CUDA` | `triton_jagged_self_substraction_jagged_out` |
| `CPU` | `cpu_jagged_self_substraction_jagged_out` |
| `Meta` | `meta_jagged_self_substraction_jagged_out` (via `_register_fake`) |

No autograd registration: the payload is index/timestamp-like integer data.

## 5. Complexity

| | |
|---|---|
| Work | `O(sum_i (L_i - 1)^2)` useful; `B * max_seq_len` programs launched |
| Extra memory | output only; no padded `[B, L, L]` intermediate |
| Reads | each input row read `N_i` times (once per output row) — served from L2/broadcast, not recomputed |
| Syncs | one, from `offsets_b[-1].item()` at allocation time |

## 6. Analysis

1. **Caller contract on `max_seq_len`.** The kernel clamps `a_length` to `max_seq_len + 1` but the caller's `offsets_b` are built from untruncated `(L_i - 1)^2`. If any `L_i > max_seq_len + 1`, the written row stride `N` no longer matches the span reserved in `offsets_b` and the packing diverges. `max_seq_len >= max_i L_i - 1` is required, and `max_seq_len <= 4096` is enforced by `next_power_of_two`.
2. **Uninitialised tail.** The output is `torch.empty`; every reserved slot is written provided the contract in (1) holds. Under-sized `max_seq_len` would leave garbage rather than zeros.
3. **BC.** Additive only — new schema behind a `_defs` membership guard, new exports, and one behavioural extension to `op_registeration` that is a no-op for every existing call site (none of which used the `Meta` key).
4. **Test coverage.** `test_triton_jagged_self_substraction_jagged_out` sweeps `B in [10, 100]`, `L in [1, 200]`, `{cpu, cuda} x {eager, torch.compile}`, checks each row's flattened output against an eager outer-difference reference, and runs `opcheck` on the PT2 path to validate schema/fake-kernel/autograd consistency.

## 7. Changes

1. **`fbgemm_gpu/sll/triton_sll.py`**: adds `next_power_of_two` (capped at 4096), the `jagged_self_substraction_jagged_out_kernel` Triton kernel, and the `triton_jagged_self_substraction_jagged_out` launcher.
2. **`fbgemm_gpu/sll/cpu_sll.py`**: adds `cpu_jagged_self_substraction_jagged_out` (correctness reference) and `meta_jagged_self_substraction_jagged_out` (dynamic-size fake kernel).
3. **`fbgemm_gpu/sll/__init__.py`**: routes the `Meta` dispatch key through `lib._register_fake` in `op_registeration`; defines the `sll_jagged_self_substraction_jagged_out` schema; registers CUDA/CPU/Meta.
4. **`test/sll/triton_sll_test.py`**: adds the hypothesis test above, including `opcheck` coverage.

Differential Revision: D65786601
