### PR TITLE
[detailed][ops] open-source SLL jagged2_to_padded_dense

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sll/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/__init__.py
@@ -11,6 +11,7 @@ import torch
 
 from fbgemm_gpu.sll.cpu_sll import (  # noqa F401
     cpu_dense_jagged_cat_jagged_out,
+    cpu_jagged2_to_padded_dense,
     cpu_jagged_dense_bmm,
     cpu_jagged_jagged_bmm,
     cpu_jagged_self_substraction_jagged_out,
@@ -19,6 +20,7 @@ from fbgemm_gpu.sll.cpu_sll import (  # noqa F401
 
 from fbgemm_gpu.sll.triton_sll import (  # noqa F401
     dense_jagged_cat_jagged_out,
+    jagged2_to_padded_dense,
     jagged_dense_bmm,
     jagged_jagged_bmm,
     triton_jagged_self_substraction_jagged_out,
@@ -106,6 +108,18 @@ if "fbgemm::sll_jagged_self_substraction_jagged_out" not in torch.library._defs:
         """
     )
 
+if "fbgemm::sll_jagged2_to_padded_dense" not in torch.library._defs:
+    lib.define(
+        """sll_jagged2_to_padded_dense(
+            Tensor values,
+            Tensor offsets,
+            int max_length,
+            float padding_value
+        ) -> Tensor
+        """
+    )
+
+
 op_registeration(lib, "sll_jagged_dense_bmm", jagged_dense_bmm, "CUDA")
 op_registeration(lib, "sll_jagged_dense_bmm", jagged_dense_bmm, "AutogradCUDA")
 op_registeration(lib, "sll_jagged_dense_bmm", cpu_jagged_dense_bmm, "CPU")
@@ -137,4 +151,12 @@ op_registeration(
     "sll_jagged_self_substraction_jagged_out",
     meta_jagged_self_substraction_jagged_out,
     "Meta",
+)
+op_registeration(lib, "sll_jagged2_to_padded_dense", jagged2_to_padded_dense, "CUDA")
+op_registeration(
+    lib, "sll_jagged2_to_padded_dense", jagged2_to_padded_dense, "AutogradCUDA"
+)
+op_registeration(lib, "sll_jagged2_to_padded_dense", cpu_jagged2_to_padded_dense, "CPU")
+op_registeration(
+    lib, "sll_jagged2_to_padded_dense", cpu_jagged2_to_padded_dense, "AutogradCPU"
 )

--- a/fbgemm_gpu/fbgemm_gpu/sll/triton_sll.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/triton_sll.py
@@ -6,6 +6,8 @@
 
 # pyre-unsafe
 
+from typing import Tuple
+
 import torch
 import triton
 import triton.language as tl
@@ -290,6 +292,89 @@ def jagged_self_substraction_jagged_out_kernel(
     tl.store(b_ptr + b_offset + pid_index * N + offs, b, mask=mask)
 
 
+@triton.jit
+def jagged2_to_padded_dense_kernel(
+    x_ptr,
+    lengths_ptr,
+    offsets_ptr,
+    output_dense_ptr,
+    stride_b,
+    stride_m,
+    stride_n,
+    max_length,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_batch = tl.program_id(2)
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    begin = tl.load(offsets_ptr + pid_batch)
+    seqlen = tl.load(lengths_ptr + pid_batch)
+
+    seqlen = tl.minimum(seqlen, max_length)
+    if seqlen == 0:
+        return
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    x_ptrs = x_ptr + begin + offs_m[:, None] * seqlen + offs_n[None, :]
+    x = tl.load(x_ptrs, mask=((offs_m[:, None] < seqlen) & (offs_n[None, :] < seqlen)))
+
+    out_ptrs = (
+        output_dense_ptr
+        + pid_batch * stride_b
+        + offs_m[:, None] * stride_m
+        + offs_n[None, :] * stride_n
+    )
+    tl.store(
+        out_ptrs, x, mask=((offs_m[:, None] < seqlen) & (offs_n[None, :] < seqlen))
+    )
+
+
+@triton.jit
+def padded_dense_to_jagged2_kernel(
+    x_ptr,
+    lengths_ptr,
+    offsets_ptr,
+    output_jagged_ptr,
+    stride_b,
+    stride_m,
+    stride_n,
+    max_length,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_batch = tl.program_id(2)
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    begin = tl.load(offsets_ptr + pid_batch)
+    # end = tl.load(offsets_ptr + pid_batch + 1)
+    seqlen = tl.load(lengths_ptr + pid_batch)
+
+    seqlen = tl.minimum(seqlen, max_length)
+
+    if seqlen == 0:
+        return
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    x_ptrs = (
+        x_ptr
+        + pid_batch * stride_b
+        + offs_m[:, None] * stride_m
+        + offs_n[None, :] * stride_n
+    )
+    x = tl.load(x_ptrs, mask=((offs_m[:, None] < seqlen) & (offs_n[None, :] < seqlen)))
+    out_ptrs = output_jagged_ptr + begin + offs_m[:, None] * seqlen + offs_n[None, :]
+    tl.store(
+        out_ptrs, x, mask=((offs_m[:, None] < seqlen) & (offs_n[None, :] < seqlen))
+    )
+
+
 def triton_jagged_dense_bmm(a, b, a_offsets, max_seq_len, allow_tf32):
     # checks constraints
     assert a.shape[1] == b.shape[1], "incompatible dimensions"
@@ -434,6 +519,79 @@ def triton_jagged_self_substraction_jagged_out(
     return jagged_B
 
 
+def jagged2_to_padded_dense_fwd(
+    values: torch.Tensor,
+    lengths: torch.Tensor,
+    offsets: torch.Tensor,
+    max_length: int,
+    padding_value: float,
+) -> torch.Tensor:
+    B = offsets.size(0) - 1
+
+    output_dense = torch.full(
+        (B, max_length, max_length),
+        padding_value,
+        dtype=values.dtype,
+        device=values.device,
+    )
+    BLOCK_M = 32
+    BLOCK_N = 32
+    num_blocks_m = triton.cdiv(max_length, BLOCK_M)
+    num_blocks_n = triton.cdiv(max_length, BLOCK_N)
+    grid = (num_blocks_m, num_blocks_n, B)
+
+    jagged2_to_padded_dense_kernel[grid](
+        values,
+        lengths,
+        offsets,
+        output_dense,
+        output_dense.stride(0),
+        output_dense.stride(1),
+        output_dense.stride(2),
+        max_length,
+        # pyre-fixme[6]: Incompatible parameter type [6]: expected `constexpr` but got `int`.
+        BLOCK_M,
+        # pyre-fixme[6]: Incompatible parameter type [6]: expected `constexpr` but got `int`.
+        BLOCK_N,
+    )
+
+    return output_dense
+
+
+def padded_dense_to_jagged2_fwd(
+    values: torch.Tensor,
+    lengths: torch.Tensor,
+    offsets: torch.Tensor,
+    max_length: int,
+) -> torch.Tensor:
+    B = values.size(0)
+    output_jagged = torch.empty(
+        int(offsets[-1]), dtype=values.dtype, device=values.device
+    )
+    BLOCK_M = 32
+    BLOCK_N = 32
+    num_blocks_m = triton.cdiv(max_length, BLOCK_M)
+    num_blocks_n = triton.cdiv(max_length, BLOCK_N)
+    grid = (num_blocks_m, num_blocks_n, B)
+
+    padded_dense_to_jagged2_kernel[grid](
+        values,
+        lengths,
+        offsets,
+        output_jagged,
+        values.stride(0),
+        values.stride(1),
+        values.stride(2),
+        max_length,
+        # pyre-fixme[6]: Incompatible parameter type [6]: expected `constexpr` but got `int`.
+        BLOCK_M,
+        # pyre-fixme[6]: Incompatible parameter type [6]: expected `constexpr` but got `int`.
+        BLOCK_N,
+    )
+
+    return output_jagged
+
+
 class JaggedDenseBmm(torch.autograd.Function):
     """
     Compute batch matrix multiplication between JaggedTensor and dense tensor
@@ -523,6 +681,38 @@ class JaggedJaggedBmm(torch.autograd.Function):
         return grad_x, grad_y, None, None, None
 
 
+class Jagged2ToPaddedDense(torch.autograd.Function):
+    @staticmethod
+    # pyre-fixme
+    def forward(
+        ctx,
+        values: torch.Tensor,
+        offsets: torch.Tensor,
+        max_length: int,
+        padding_value: float,
+    ) -> torch.Tensor:
+        lengths_square = offsets[1:] - offsets[0:-1:1]
+        lengths = torch.sqrt(lengths_square).to(torch.int32)
+
+        ctx.max_length = max_length
+        ctx.save_for_backward(lengths, offsets)
+
+        output = jagged2_to_padded_dense_fwd(
+            values, lengths, offsets, max_length, padding_value
+        )
+        return output
+
+    @staticmethod
+    # pyre-fixme
+    def backward(
+        ctx, grad_output: torch.Tensor
+    ) -> Tuple[torch.Tensor, None, None, None]:
+        max_length = ctx.max_length
+        (lengths, offsets) = ctx.saved_tensors
+        grad_in = padded_dense_to_jagged2_fwd(grad_output, lengths, offsets, max_length)
+        return (grad_in, None, None, None)
+
+
 def jagged_dense_bmm(
     x: torch.Tensor,
     y: torch.Tensor,
@@ -559,3 +749,22 @@ def jagged_jagged_bmm(
         return torch.ops.fbgemm.jagged_jagged_bmm(x, y, x_offsets, N)
     else:
         return JaggedJaggedBmm.apply(x, y, x_offsets, N, allow_tf32)
+
+
+def jagged2_to_padded_dense(
+    values: torch.Tensor,
+    offsets: torch.Tensor,
+    max_length: int,
+    padding_value: float = 0.0,
+) -> torch.Tensor:
+    """
+    values: jagged tensor with size [sum(Ni * Ni)]
+    offsets: offsets for jagged tensor, with size [B + 1]
+    max_length: maximum sequence length in the batch
+    padding_value: value to use for padding
+    return padded dense tensor of size [B, N, N]
+    """
+    values = values.contiguous()
+    offsets = offsets.contiguous()
+
+    return Jagged2ToPaddedDense.apply(values, offsets, max_length, padding_value)

--- a/fbgemm_gpu/test/sll/triton_sll_test.py
+++ b/fbgemm_gpu/test/sll/triton_sll_test.py
@@ -427,3 +427,76 @@ class TritonBmmTest(unittest.TestCase):
             ref = a[:-1].unsqueeze(1) - a[1:].unsqueeze(0)
 
             assert torch.equal(result[offsets_b[i] : offsets_b[i + 1]], ref.flatten())
+
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @given(
+        B=st.integers(1, 10),
+        max_L=st.integers(1, 100),
+        device_type=st.sampled_from(["cpu", "cuda"]),
+    )
+    @settings(deadline=None)
+    def test_jagged2_to_padded_dense(
+        self,
+        B: int,
+        max_L: int,
+        device_type: str,
+    ) -> None:
+        device = torch.device(device_type)
+
+        lengths = torch.randint(1, max_L + 1, (B,), device=device)
+        lengths_square = lengths * lengths
+        offsets = torch.cat(
+            [
+                torch.tensor([0], device=device, dtype=torch.int),
+                lengths_square.cumsum(dim=0),
+            ],
+            dim=0,
+        )
+
+        x = torch.rand(
+            int(lengths_square.sum().item()),
+            requires_grad=True,
+            device=device,
+        )
+
+        def ref_jagged2_to_padded_dense(
+            x: torch.Tensor, offsets: torch.Tensor, max_L: int, padding_value: float
+        ) -> torch.Tensor:
+            B = offsets.size(0) - 1
+            dense_output = torch.full(
+                (B, max_L, max_L),
+                padding_value,
+                dtype=x.dtype,
+                device=x.device,
+            )
+            for b in range(B):
+                begin = offsets[b]
+                end = offsets[b + 1]
+                Ni = int(torch.sqrt(end - begin))
+                if Ni == 0:
+                    continue
+                dense_output[b, 0:Ni, 0:Ni] = x[begin:end].view(Ni, Ni)
+
+            return dense_output
+
+        x_clone = (
+            x.detach().clone().requires_grad_()
+            if x.requires_grad
+            else x.detach().clone()
+        )
+        padding_value = 0.0
+        ref_out = ref_jagged2_to_padded_dense(x, offsets, max_L, padding_value)
+        test_out = torch.ops.fbgemm.sll_jagged2_to_padded_dense(
+            x_clone, offsets, max_L, padding_value
+        )
+        assert torch.allclose(ref_out, test_out)
+
+        # Backward pass
+        dout = torch.rand((B, max_L, max_L), dtype=x.dtype, device=x.device) * 0.1
+        test_out.backward(dout)
+        ref_out.backward(dout)
+
+        assert x.grad is not None
+        assert x_clone.grad is not None
+        assert torch.allclose(x.grad, x_clone.grad)


### PR DESCRIPTION
## 1. Context

The SLL ops built in D65781881 and D65786601 produce **jagged² tensors**: a batch of `B` variable-sized *square* matrices, row `i` being `N_i x N_i`, flattened row-major and packed back-to-back into a single 1-D buffer of `sum_i N_i^2` elements. This layout is memory-optimal for the jagged pipeline, but the moment such a tensor has to meet a dense consumer — an existing `[B, L, L]` kernel, a softmax over a padded attention matrix, a debugging path — it has to be expanded into a padded dense tensor.

This diff adds `fbgemm::sll_jagged2_to_padded_dense`, the **differentiable** bridge from the jagged² layout to `[B, max_length, max_length]`.

## 2. Op contract

```
sll_jagged2_to_padded_dense(
    Tensor values,        # jagged^2, [sum_i N_i * N_i]
    Tensor offsets,       # [B + 1], offsets into `values`
    int max_length,
    float padding_value
) -> Tensor               # [B, max_length, max_length]
```

```
out[i, m, n] = values[offsets[i] + m * N_i + n]   for m, n < N_i
out[i, m, n] = padding_value                      otherwise
```

Differentiable in `values`.

## 3. Algorithm design

### 3.1 Lengths recovered from offsets by square root

The op's signature deliberately does **not** take a lengths tensor. The jagged² invariant — each row occupies exactly `N_i^2` slots — means the side length is recoverable from the offsets alone:

```python
lengths_square = offsets[1:] - offsets[:-1]
lengths = torch.sqrt(lengths_square).to(torch.int32)
```

This is computed once in `Jagged2ToPaddedDense.forward` and `save_for_backward`-ed, so the backward pass reuses it rather than re-deriving. The trade: one vectorised `sqrt` + cast over `B` elements (negligible) in exchange for a 4-argument schema that matches PyTorch's existing `jagged_to_padded_dense` shape and one fewer tensor for callers to keep in sync. The cost is that the square invariant is now load-bearing — a non-square jagged input silently produces a wrong `N_i`.

### 3.2 Forward kernel — 3-D tiled grid

`jagged2_to_padded_dense_kernel` launches

```
grid = (cdiv(max_length, BLOCK_M), cdiv(max_length, BLOCK_N), B),  BLOCK_M = BLOCK_N = 32
```

so each program owns one `32 x 32` tile of one batch item's output matrix. Per program:

1. `begin = offsets[b]`, `seqlen = min(lengths[b], max_length)`; return immediately if `seqlen == 0`.
2. **Source addressing (the jagged² crux):** `x_ptr + begin + m * seqlen + n`. The row stride is `seqlen` — *data-dependent per batch item*, unlike a dense tensor where the stride is a launch constant. Every jagged² kernel in this stack shares this addressing form.
3. **Destination addressing:** `out_ptr + b * stride_b + m * stride_m + n * stride_n`, using the real strides of the output tensor so it need not be assumed contiguous.
4. A single mask `(m < seqlen) & (n < seqlen)` guards both the load and the store, so partially-valid tiles at the row/column boundary and fully-invalid tiles for short rows are handled by the same code path with no branching.

**Padding is not written by the kernel.** The output is allocated with `torch.full((B, max_length, max_length), padding_value)`, and the kernel only ever stores inside the valid `seqlen x seqlen` region. This costs one extra fill pass over the output but keeps the kernel branch-free and makes the mask the *only* correctness argument — there is no second code path that could disagree about where the boundary is.

### 3.3 Backward is the exact inverse scatter

Forward is a **pure permutation**: every valid output element has exactly one source element, and no source element is read twice. Therefore the gradient is the transposed gather — read the dense grad tile, write it back into the jagged buffer — with **no accumulation and no atomics**.

`padded_dense_to_jagged2_kernel` is the mirror image of the forward kernel: identical grid, identical `seqlen` clamp, identical mask, with the source and destination addressing expressions swapped. Elements of the dense gradient that fall in the padding region are simply never read, which is the correct gradient for a padded output.

This symmetry is the main reason the op is cheap to make differentiable: the backward pass reuses the forward's tiling, its saved `lengths`, and its mask logic verbatim.

### 3.4 CPU path gets autograd for free

`cpu_jagged2_to_padded_dense` builds the output with `torch.full` and then `dense_output[b, 0:Ni, 0:Ni] = values[begin:end].view(Ni, Ni)` per batch item. Because this is expressed entirely in differentiable tensor operations (`view` + index-put), **autograd tracks it automatically** — no hand-written CPU backward is needed, which is why the op can be registered for `AutogradCPU` with the same function. The implementation reuses the reference function already written for the test, keeping reference and implementation from drifting apart.

## 4. Dispatch

| Key | Implementation |
|---|---|
| `CUDA` | `jagged2_to_padded_dense` (Triton, via `Jagged2ToPaddedDense` autograd Function) |
| `AutogradCUDA` | same |
| `CPU` | `cpu_jagged2_to_padded_dense` |
| `AutogradCPU` | same |

## 5. Complexity

| | |
|---|---|
| Useful work | `O(sum_i N_i^2)` reads/writes, forward and backward each one pass |
| Output memory | `B * max_length^2` — the padding cost this op exists to pay, quadratic in the length skew |
| Tiles launched | `B * cdiv(max_length, 32)^2`; tiles fully outside a short row retire on the `seqlen == 0` guard or write nothing under the mask |
| Atomics / shared memory | none |

## 6. Analysis

1. **`max_length` contract.** Both kernels clamp with `seqlen = min(lengths[b], max_length)`. Forward is safe under a too-small `max_length` (the row is truncated), but backward allocates with `torch.empty(offsets[-1])` and only writes the clamped region, so the truncated tail of the jagged gradient would be left uninitialised. `max_length >= max_i N_i` is the intended contract.
2. **Square invariant.** `N_i = sqrt(offsets[i+1] - offsets[i])` is exact only for perfect squares; the integer cast silently floors otherwise. This is an invariant of the jagged² layout produced upstream by `sll_jagged_self_substraction_jagged_out`, not a runtime check.
3. **Padding value and gradients.** Padding cells are constants, so they contribute no gradient — consistent with never reading them in backward.
4. **Contiguity.** The launcher forces `values` and `offsets` contiguous before dispatching, because the source addressing in 3.2 uses raw element offsets. The dense output is addressed by real strides and so does not need the assumption.
5. **BC.** Additive: new schema behind a `_defs` guard, new exports, four new registrations. No existing op touched.
6. **Test coverage.** `test_jagged2_to_padded_dense` sweeps `B in [1, 10]`, `max_L in [1, 100]` over `{cpu, cuda}`, checks forward against an eager per-row `view`-and-place reference, then runs `backward` on both and compares `values.grad` — so the inverse-scatter argument in 3.3 is verified numerically, not just by construction.

## 7. Changes

1. **`fbgemm_gpu/sll/triton_sll.py`**: adds `jagged2_to_padded_dense_kernel` and `padded_dense_to_jagged2_kernel`, their `*_fwd` launchers, the `Jagged2ToPaddedDense` autograd Function (which derives and saves `lengths`), and the public `jagged2_to_padded_dense` entry point.
2. **`fbgemm_gpu/sll/cpu_sll.py`**: adds `cpu_jagged2_to_padded_dense`, autograd-transparent by construction.
3. **`fbgemm_gpu/sll/__init__.py`**: defines the `sll_jagged2_to_padded_dense` schema; registers CUDA/AutogradCUDA/CPU/AutogradCPU.
4. **`test/sll/triton_sll_test.py`**: adds the forward + backward hypothesis test described above.

Differential Revision: D65787664
