### PR TITLE
[detailed][ops] open-source SLL jagged_dense_elementwise_mul_jagged_out

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sll/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/__init__.py
@@ -13,8 +13,10 @@ from fbgemm_gpu.sll.cpu_sll import (  # noqa F401
     cpu_dense_jagged_cat_jagged_out,
     cpu_jagged2_to_padded_dense,
     cpu_jagged_dense_bmm,
+    cpu_jagged_dense_elementwise_mul_jagged_out,
     cpu_jagged_jagged_bmm,
     cpu_jagged_self_substraction_jagged_out,
+    meta_jagged_dense_elementwise_mul_jagged_out,
     meta_jagged_self_substraction_jagged_out,
 )
 
@@ -22,6 +24,7 @@ from fbgemm_gpu.sll.triton_sll import (  # noqa F401
     dense_jagged_cat_jagged_out,
     jagged2_to_padded_dense,
     jagged_dense_bmm,
+    jagged_dense_elementwise_mul_jagged_out,
     jagged_jagged_bmm,
     triton_jagged_self_substraction_jagged_out,
 )
@@ -119,7 +122,21 @@ if "fbgemm::sll_jagged2_to_padded_dense" not in torch.library._defs:
         """
     )
 
+if "fbgemm::sll_jagged_dense_elementwise_mul_jagged_out" not in torch.library._defs:
+    lib.define(
+        """sll_jagged_dense_elementwise_mul_jagged_out(
+            Tensor x,
+            Tensor y,
+            Tensor x_seq_lengths,
+            Tensor x_offsets,
+            int max_seq_len
+        ) -> Tensor
+        """
+    )
 
+# NOTE: here we register the op for AutogradCUDA/CPU and CUDA/CPU with the same function
+# however, this is not ideal because in the inference case, we don't need the autograd forward
+# to save the context because we don't need to do backward.
 op_registeration(lib, "sll_jagged_dense_bmm", jagged_dense_bmm, "CUDA")
 op_registeration(lib, "sll_jagged_dense_bmm", jagged_dense_bmm, "AutogradCUDA")
 op_registeration(lib, "sll_jagged_dense_bmm", cpu_jagged_dense_bmm, "CPU")
@@ -159,4 +176,34 @@ op_registeration(
 op_registeration(lib, "sll_jagged2_to_padded_dense", cpu_jagged2_to_padded_dense, "CPU")
 op_registeration(
     lib, "sll_jagged2_to_padded_dense", cpu_jagged2_to_padded_dense, "AutogradCPU"
+)
+op_registeration(
+    lib,
+    "sll_jagged_dense_elementwise_mul_jagged_out",
+    jagged_dense_elementwise_mul_jagged_out,
+    "CUDA",
+)
+op_registeration(
+    lib,
+    "sll_jagged_dense_elementwise_mul_jagged_out",
+    jagged_dense_elementwise_mul_jagged_out,
+    "AutogradCUDA",
+)
+op_registeration(
+    lib,
+    "sll_jagged_dense_elementwise_mul_jagged_out",
+    cpu_jagged_dense_elementwise_mul_jagged_out,
+    "CPU",
+)
+op_registeration(
+    lib,
+    "sll_jagged_dense_elementwise_mul_jagged_out",
+    cpu_jagged_dense_elementwise_mul_jagged_out,
+    "AutogradCPU",
+)
+op_registeration(
+    lib,
+    "sll_jagged_dense_elementwise_mul_jagged_out",
+    meta_jagged_dense_elementwise_mul_jagged_out,
+    "Meta",
 )

--- a/fbgemm_gpu/fbgemm_gpu/sll/triton_sll.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/triton_sll.py
@@ -375,6 +375,63 @@ def padded_dense_to_jagged2_kernel(
     )
 
 
+@triton.jit
+def jagged_dense_elementwise_mul_jagged_out_kernel(
+    a_ptr,  # 1d jagged
+    b_ptr,  # dense
+    c_ptr,  # 1d jagged
+    a_seq_lengths_ptr,
+    a_offsets_ptr,
+    stride_a,
+    stride_bm,
+    stride_bn,
+    max_seq_len,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_batch = tl.program_id(0)
+    pid_row_block = tl.program_id(1)
+
+    batch_offset = tl.load(a_offsets_ptr + pid_batch)
+    batch_seq_len = tl.load(a_seq_lengths_ptr + pid_batch)
+    truncated_seq_len = tl.minimum(batch_seq_len, max_seq_len)
+
+    offs_row = tl.arange(0, BLOCK_M)
+    offs_col = tl.arange(0, BLOCK_N)
+
+    rows = pid_row_block * BLOCK_M + offs_row
+
+    # a start + batch offset + row offsets + initial col offsets
+    a_ptrs = (
+        a_ptr
+        + batch_offset * stride_a
+        + rows[:, None] * truncated_seq_len
+        + offs_col[None, :]
+    )
+
+    # b start + row offsets + initial col offsets
+    b_ptrs = b_ptr + rows[:, None] * stride_bm + offs_col[None, :] * stride_bn
+
+    # c start + batch offset + row offsets + initial col offsets
+    c_ptrs = (
+        c_ptr + batch_offset + rows[:, None] * truncated_seq_len + offs_col[None, :]
+    )
+
+    for block_start in range(0, truncated_seq_len, BLOCK_N):
+        cols = block_start + offs_col
+        # pyre-fixme[16]: `int` has no attribute `__getitem__`.
+        mask = (rows[:, None] < truncated_seq_len) & (cols[None, :] < truncated_seq_len)
+        a = tl.load(a_ptrs, mask=mask)
+        a_ptrs += BLOCK_N
+
+        b = tl.load(b_ptrs, mask=mask)
+        b_ptrs += BLOCK_N
+
+        c = a * b
+        tl.store(c_ptrs, c, mask=mask)
+        c_ptrs += BLOCK_N
+
+
 def triton_jagged_dense_bmm(a, b, a_offsets, max_seq_len, allow_tf32):
     # checks constraints
     assert a.shape[1] == b.shape[1], "incompatible dimensions"
@@ -592,6 +649,40 @@ def padded_dense_to_jagged2_fwd(
     return output_jagged
 
 
+def triton_jagged_dense_elementwise_mul_jagged_out(
+    jagged_A,
+    dense_B,
+    seq_lengths_a,
+    offsets_a,
+    max_seq_len,
+):
+    B = seq_lengths_a.size(0)
+    total_L = jagged_A.size(0)
+
+    jagged_C = torch.zeros((total_L), device=jagged_A.device, dtype=jagged_A.dtype)
+
+    BLOCK_M = 32
+    BLOCK_N = 32
+    num_blocks_m = triton.cdiv(max_seq_len, BLOCK_M)
+    grid = (B, num_blocks_m)
+
+    jagged_dense_elementwise_mul_jagged_out_kernel[grid](
+        jagged_A,
+        dense_B,
+        jagged_C,
+        seq_lengths_a,
+        offsets_a,
+        jagged_A.stride(0),
+        dense_B.stride(0),
+        dense_B.stride(1),
+        max_seq_len,
+        BLOCK_M,
+        BLOCK_N,
+    )
+
+    return jagged_C
+
+
 class JaggedDenseBmm(torch.autograd.Function):
     """
     Compute batch matrix multiplication between JaggedTensor and dense tensor
@@ -713,6 +804,63 @@ class Jagged2ToPaddedDense(torch.autograd.Function):
         return (grad_in, None, None, None)
 
 
+class JaggedDenseElementwiseMul(torch.autograd.Function):
+    """
+    Compute elementwise multiplication between jagged tensor and dense tensor.
+    z = x * y
+    x: [sum_B(L_i)]
+    y: dense tensor
+    z: [sum_B(L_i)]
+    """
+
+    @staticmethod
+    # pyre-fixme
+    def forward(
+        ctx,
+        x: torch.Tensor,
+        y: torch.Tensor,
+        x_seq_lengths: torch.Tensor,
+        x_offsets: torch.Tensor,
+        max_seq_len: int,
+    ):
+        ctx.max_seq_len = max_seq_len
+
+        ctx.save_for_backward(
+            x,
+            y,
+            x_seq_lengths,
+            x_offsets,
+        )
+
+        return triton_jagged_dense_elementwise_mul_jagged_out(
+            x,
+            y,
+            x_seq_lengths,
+            x_offsets,
+            max_seq_len,
+        )
+
+    @staticmethod
+    # pyre-fixme
+    def backward(ctx, grad_output: torch.Tensor):
+        (
+            x,
+            y,
+            x_seq_lengths,
+            x_offsets,
+        ) = ctx.saved_tensors
+
+        grad_x = triton_jagged_dense_elementwise_mul_jagged_out(
+            grad_output,
+            y,
+            x_seq_lengths,
+            x_offsets,
+            ctx.max_seq_len,
+        )
+
+        return grad_x, None, None, None, None
+
+
 def jagged_dense_bmm(
     x: torch.Tensor,
     y: torch.Tensor,
@@ -768,3 +916,19 @@ def jagged2_to_padded_dense(
     offsets = offsets.contiguous()
 
     return Jagged2ToPaddedDense.apply(values, offsets, max_length, padding_value)
+
+
+def jagged_dense_elementwise_mul_jagged_out(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    x_seq_lengths: torch.Tensor,
+    x_offsets: torch.Tensor,
+    max_seq_len: int,
+) -> torch.Tensor:
+    return JaggedDenseElementwiseMul.apply(
+        x,
+        y,
+        x_seq_lengths,
+        x_offsets,
+        max_seq_len,
+    )

--- a/fbgemm_gpu/test/sll/triton_sll_test.py
+++ b/fbgemm_gpu/test/sll/triton_sll_test.py
@@ -500,3 +500,205 @@ class TritonBmmTest(unittest.TestCase):
         assert x.grad is not None
         assert x_clone.grad is not None
         assert torch.allclose(x.grad, x_clone.grad)
+
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @given(
+        B=st.integers(10, 512),
+        L=st.integers(1, 200),
+    )
+    @settings(deadline=20000)
+    def test_triton_jagged_dense_elementwise_mul_jagged_out(
+        self,
+        B: int,
+        L: int,
+    ) -> None:
+        torch.manual_seed(0)
+        seq_lengths_a = torch.randint(0, L + 1, (B,)).cuda()
+
+        offsets_a = torch.cat(
+            [torch.IntTensor([0]).cuda(), torch.square(seq_lengths_a).cumsum(dim=0)],
+            dim=0,
+        )
+
+        jagged_A = torch.rand(int(offsets_a[-1] - offsets_a[0])).cuda()
+
+        # test zero out upper triangle
+        mask = torch.tril(
+            torch.ones(
+                (L, L),
+                dtype=torch.bool,
+            ).cuda(),
+        )
+        mask = mask.fill_diagonal_(False)
+        result = torch.ops.fbgemm.sll_jagged_dense_elementwise_mul_jagged_out(
+            jagged_A,
+            mask,
+            seq_lengths_a,
+            offsets_a,
+            L,
+        )
+
+        for i in range(B):
+            if seq_lengths_a[i] == 0:
+                continue
+
+            a = jagged_A[offsets_a[i] : offsets_a[i + 1]]
+            a = a.view(int(seq_lengths_a[i]), int(seq_lengths_a[i]))
+            ref = a * mask[0 : seq_lengths_a[i], 0 : seq_lengths_a[i]]
+
+            assert torch.equal(result[offsets_a[i] : offsets_a[i + 1]], ref.flatten())
+
+        # test general jagged dense elementwise mul
+        dense_B = torch.rand((L, L)).cuda()
+        result = torch.ops.fbgemm.sll_jagged_dense_elementwise_mul_jagged_out(
+            jagged_A,
+            dense_B,
+            seq_lengths_a,
+            offsets_a,
+            L,
+        )
+
+        for i in range(B):
+            if seq_lengths_a[i] == 0:
+                continue
+
+            a = jagged_A[offsets_a[i] : offsets_a[i + 1]]
+            a = a.view(int(seq_lengths_a[i]), int(seq_lengths_a[i]))
+
+            b = dense_B[: seq_lengths_a[i], : seq_lengths_a[i]]
+            ref = a * b
+            assert torch.equal(result[offsets_a[i] : offsets_a[i + 1]], ref.flatten())
+
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @given(
+        B=st.integers(10, 512),
+        L=st.integers(1, 200),
+        device_type=st.sampled_from(["cpu", "cuda"]),
+    )
+    @settings(deadline=20000)
+    def test_jagged_dense_elementwise_mul_jagged_out_with_grad(
+        self,
+        B: int,
+        L: int,
+        device_type: str,
+    ) -> None:
+        torch.manual_seed(0)
+
+        device = torch.device(device_type)
+        seq_lengths_a = torch.randint(0, L + 1, (B,), device=device)
+
+        offsets_a = torch.cat(
+            [
+                torch.IntTensor([0]).to(device_type),
+                torch.square(seq_lengths_a).cumsum(dim=0),
+            ],
+            dim=0,
+        )
+
+        jagged_A = (
+            torch.rand(int(offsets_a[-1] - offsets_a[0]), device=device)
+            .detach()
+            .requires_grad_(True)
+        )
+        dense_B = torch.rand((L, L), device=device)
+        jagged_A_ref = jagged_A.clone().detach().requires_grad_(True)
+
+        # check forward
+        result = torch.ops.fbgemm.sll_jagged_dense_elementwise_mul_jagged_out(
+            jagged_A,
+            dense_B,
+            seq_lengths_a,
+            offsets_a,
+            L,
+        )
+
+        ref = []
+        for i in range(B):
+            if seq_lengths_a[i] == 0:
+                continue
+            a = jagged_A_ref[offsets_a[i] : offsets_a[i + 1]].view(
+                int(seq_lengths_a[i]), int(seq_lengths_a[i])
+            )
+            b = dense_B[: seq_lengths_a[i], : seq_lengths_a[i]]
+            c = a * b
+            ref.append(c.flatten())
+
+        ref = torch.cat(ref)
+        assert torch.equal(result, ref)
+
+        # check backward
+        grad_output = torch.rand(ref.shape, device=device) * 0.01
+        ref.backward(grad_output)
+        result.backward(grad_output)
+
+        assert torch.allclose(jagged_A_ref.grad, jagged_A.grad)
+
+    @unittest.skipIf(*gpu_unavailable)
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @given(
+        B=st.integers(10, 512),
+        L=st.integers(1, 200),
+        device_type=st.sampled_from(["meta"]),
+    )
+    @settings(deadline=20000)
+    def test_jagged_dense_elementwise_mul_jagged_out_meta_backend(
+        self,
+        B: int,
+        L: int,
+        device_type: str,
+    ) -> None:
+        device = torch.device(device_type)
+        torch.manual_seed(0)
+
+        device = torch.device(device_type)
+        seq_lengths_a = torch.randint(0, L + 1, (B,))
+
+        offsets_a = torch.cat(
+            [
+                torch.IntTensor([0]),
+                torch.square(seq_lengths_a).cumsum(dim=0),
+            ],
+            dim=0,
+        )
+
+        jagged_A = (
+            torch.rand(int(offsets_a[-1] - offsets_a[0]), device=device)
+            .detach()
+            .requires_grad_(True)
+        )
+        dense_B = torch.rand((L, L), device=device)
+        jagged_A_ref = jagged_A.clone().detach().requires_grad_(True)
+
+        # check forward
+        result = torch.ops.fbgemm.sll_jagged_dense_elementwise_mul_jagged_out(
+            jagged_A,
+            dense_B,
+            seq_lengths_a.to(device),
+            offsets_a.to(device),
+            L,
+        )
+
+        ref = []
+        for i in range(B):
+            if seq_lengths_a[i] == 0:
+                continue
+            a = jagged_A_ref[offsets_a[i] : offsets_a[i + 1]].view(
+                int(seq_lengths_a[i]), int(seq_lengths_a[i])
+            )
+            b = dense_B[: seq_lengths_a[i], : seq_lengths_a[i]]
+            c = a * b
+            ref.append(c.flatten())
+
+        ref = torch.cat(ref)
+        assert result.is_meta and result.size() == ref.size()
+
+        # check backward
+        grad_output = torch.rand(ref.shape, device=device) * 0.01
+        ref.backward(grad_output)
+        result.backward(grad_output)
+
+        assert (
+            jagged_A.grad.is_meta and jagged_A_ref.grad.size() == jagged_A.grad.size()
+        )


### PR DESCRIPTION
## 1. Context

The dominant consumer of a jagged² attention matrix is **masking**: zeroing the upper triangle (and diagonal) so each position only attends to strictly earlier positions, or scaling by a shared positional/decay matrix. The obvious route is to expand jagged² → padded dense (`sll_jagged2_to_padded_dense`, D65787664), multiply by the `[L, L]` mask, and fold back — which materialises a `B * L^2` dense tensor and two extra passes purely to apply a mask.

This diff adds `fbgemm::sll_jagged_dense_elementwise_mul_jagged_out`, which applies a **single dense `[L, L]` operand broadcast across the whole batch, directly in the jagged² layout** — jagged in, jagged out, no padded intermediate. It also completes the backend matrix for the SLL op set by shipping CUDA, CPU, and Meta implementations with autograd on all three.

## 2. Op contract

```
sll_jagged_dense_elementwise_mul_jagged_out(
    Tensor x,              # jagged^2, [sum_i N_i * N_i]
    Tensor y,              # dense, [max_seq_len, max_seq_len], shared by all rows
    Tensor x_seq_lengths,  # [B]
    Tensor x_offsets,      # [B + 1]
    int max_seq_len
) -> Tensor                # jagged^2, same shape as x
```

```
z_i[m][n] = x_i[m][n] * y[m][n],   0 <= m, n < min(N_i, max_seq_len)
```

Differentiable in `x`; `y` is treated as a constant.

## 3. Algorithm design

### 3.1 Broadcasting a single dense operand over a jagged batch

The key structural choice: `y` is **one** `[max_seq_len, max_seq_len]` matrix, not a batch of them, and it is indexed by the *same* `(m, n)` as the jagged element — with **no batch offset in its address**:

```
a_ptrs = a_ptr + batch_offset * stride_a + rows[:, None] * truncated_seq_len + cols   # jagged: data-dependent stride
b_ptrs = b_ptr +                            rows[:, None] * stride_bm  + cols * stride_bn  # dense: no batch term
```

So every batch item reads the *top-left `N_i x N_i` corner* of the same dense matrix. That is exactly the semantics a causal mask or a distance-decay matrix wants — the mask for a length-`N_i` sequence is the leading `N_i x N_i` submatrix of the length-`max_seq_len` mask. Because all `B` programs hit the same `y`, it stays resident in L2 and the op is effectively a single streaming pass over `x`.

Contrast with the alternative designs: a per-batch dense `y` would need `B * L^2` of operand memory, and expanding `x` to dense first would need `B * L^2` of *intermediate* memory. This op needs neither.

### 3.2 Triton kernel — 2-D grid, row stripes with a column loop

`jagged_dense_elementwise_mul_jagged_out_kernel` launches `grid = (B, cdiv(max_seq_len, BLOCK_M))` with `BLOCK_M = BLOCK_N = 32`. Program `(i, r)` owns a 32-row stripe of batch item `i` and walks it across the columns:

1. `batch_offset = x_offsets[i]`, `truncated_seq_len = min(x_seq_lengths[i], max_seq_len)`.
2. Set up the three pointer blocks above, plus `c_ptrs` mirroring `a_ptrs`.
3. Loop `for block_start in range(0, truncated_seq_len, BLOCK_N)`: load `a` and `b` under `mask = (rows < truncated) & (cols < truncated)`, compute `c = a * b`, store, and advance all three pointer blocks by `BLOCK_N`.

Two properties fall out of this shape:

- The **column loop is bounded by `truncated_seq_len`, not `max_seq_len`**, so short rows do proportionally less work rather than masking away a full-width sweep. Only the row-stripe dimension of the grid is over-provisioned; those stripes still enter the loop but mask everything out.
- The mask is computed once per iteration and reused for the load of `a`, the load of `b`, and the store of `c` — one boundary condition, three uses, no way for them to disagree.

The output is allocated with `torch.zeros`, so any slot outside `truncated_seq_len` (i.e. the tail of a row longer than `max_seq_len`) is a deterministic zero rather than garbage.

### 3.3 Backward reuses the forward kernel verbatim

For `z = x ⊙ y` with `y` constant, `dz/dx = y`, so

```
grad_x = grad_output ⊙ y
```

which is **the same operation with the same operands' shapes**. `JaggedDenseElementwiseMul.backward` therefore calls `triton_jagged_dense_elementwise_mul_jagged_out(grad_output, y, x_seq_lengths, x_offsets, max_seq_len)` — no second kernel, no transpose, no accumulation, and the masking behaviour of the forward pass is automatically inherited by the gradient (masked-out positions get exactly zero gradient, which is correct).

`y`, `x_seq_lengths`, `x_offsets` and `max_seq_len` all return `None`: `y` is a mask/constant. Producing `dL/dy` would require a reduction over the batch (`sum_i x_i ⊙ grad_i` into the shared `[L, L]`), a fundamentally different kernel with atomics or a two-stage reduction — deliberately out of scope here.

### 3.4 Three backends, three autograd Functions

| Key | Implementation |
|---|---|
| `CUDA` / `AutogradCUDA` | `JaggedDenseElementwiseMul` (Triton) |
| `CPU` / `AutogradCPU` | `CPUJaggedDenseElementwiseMul` — per-row `view(N_i, N_i)` and multiply against `y[:N_i, :N_i]`; backward reuses the same helper, mirroring 3.3 |
| `Meta` | `MetaJaggedDenseElementwiseMul` — returns correctly-shaped `zeros([sum_i N_i^2])` in both directions |

The `Meta` registration goes through the `lib._register_fake` path added to `op_registeration` in D65786601. Because the output shape here is a pure function of the *input* shape (`z` has exactly `x`'s shape), the fake kernel can return a concrete size rather than a dynamic one — so this op traces under `torch.compile` / `torch.export` without needing `capture_dynamic_output_shape_ops`.

Two design compromises are documented inline in the code rather than left implicit:

1. The same function is registered for both `CUDA` and `AutogradCUDA` (and likewise CPU). In the inference case this still runs the autograd `forward`, which saves context that will never be used. A dedicated non-autograd inference kernel is the follow-up.
2. CPU, CUDA, and Meta each carry their own `torch.autograd.Function` subclass. One Function that dispatches internally would remove the triplication; the current shape keeps each backend's forward/backward adjacent and independently testable.

## 4. Complexity

| | |
|---|---|
| Useful work | `O(sum_i min(N_i, max_seq_len)^2)`, one pass forward, one pass backward |
| Extra memory | output only — no `B * L^2` padded intermediate at any point |
| Dense operand traffic | `L^2` loaded once into L2 and reused by all `B` programs |
| Atomics / shared memory | none |

## 5. Analysis

1. **Column-contiguity contract on `y`.** The pointer blocks are advanced with `b_ptrs += BLOCK_N` (and likewise for `a`/`c`), i.e. by `BLOCK_N` *elements*, while the initial address applies `stride_bn`. That is only consistent when `stride_bn == 1`. The dense operand must therefore be contiguous in its last dimension — true for the masks and dense matrices this op is called with, but worth stating as a precondition rather than discovering it via a transposed `y`.
2. **Truncation.** `max_seq_len` clamps both the loop bound and the mask, so rows longer than `max_seq_len` keep their tail at the allocated zero. As elsewhere in the stack, the intended contract is `max_seq_len >= max_i N_i`.
3. **Saved tensors.** `forward` saves `x` alongside `y`, `x_seq_lengths` and `x_offsets`, but `backward` only needs the latter three. Dropping `x` from `save_for_backward` would shave the activation footprint by the full size of the jagged input — a straightforward follow-up.
4. **`x_seq_lengths` is passed explicitly** here, whereas `sll_jagged2_to_padded_dense` derives lengths via `sqrt(offsets diff)`. Explicit lengths avoid the square-root round trip on a hot path where the caller already has them.
5. **BC.** Additive: new schema behind a `_defs` guard, new exports, five new registrations. No existing op signature or registration changes.
6. **Test coverage.** Three hypothesis tests over `B in [10, 512]`, `L in [1, 200]`:
   - `test_triton_jagged_dense_elementwise_mul_jagged_out` — the causal-mask case (`tril` with the diagonal cleared) and the general dense case, both checked per row with exact equality.
   - `test_jagged_dense_elementwise_mul_jagged_out_with_grad` — forward *and* backward against an eager reference, on both `cpu` and `cuda`, validating the `grad_x = grad_output ⊙ y` identity from 3.3.
   - `test_jagged_dense_elementwise_mul_jagged_out_meta_backend` — asserts the meta backend produces meta tensors of the right shape in both directions.

## 6. Changes

1. **`fbgemm_gpu/sll/triton_sll.py`**: adds `jagged_dense_elementwise_mul_jagged_out_kernel`, the `triton_jagged_dense_elementwise_mul_jagged_out` launcher, the `JaggedDenseElementwiseMul` autograd Function, and the public `jagged_dense_elementwise_mul_jagged_out` entry point.
2. **`fbgemm_gpu/sll/cpu_sll.py`**: adds `CPUJaggedDenseElementwiseMul` / `cpu_jagged_dense_elementwise_mul_jagged_out` and `MetaJaggedDenseElementwiseMul` / `meta_jagged_dense_elementwise_mul_jagged_out`.
3. **`fbgemm_gpu/sll/__init__.py`**: defines the `sll_jagged_dense_elementwise_mul_jagged_out` schema; registers CUDA/AutogradCUDA/CPU/AutogradCPU/Meta; adds the inline note about the shared autograd/non-autograd registration.
4. **`test/sll/triton_sll_test.py`**: adds the three tests described in 5.6.

Differential Revision: D65827782


