### PR TITLE
c10::string_view -> std::string_view in deeplearning/fbgemm/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -433,7 +433,7 @@ c10::ScalarType KVTensorWrapper::dtype() {
   return options_.dtype().toScalarType();
 }
 
-c10::string_view KVTensorWrapper::dtype_str() {
+std::string_view KVTensorWrapper::dtype_str() {
   return scalarTypeToTypeMeta(dtype()).name();
 }
 

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -868,7 +868,7 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
 
   c10::ScalarType dtype();
 
-  c10::string_view dtype_str();
+  std::string_view dtype_str();
 
   c10::Device device();
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/450

`c10::string_view` is being removed, so we need to migrate.

Reviewed By: xunnanxu

Differential Revision: D65830271


