### PR TITLE
Remove unused-variable in deeplearning/fbgemm/fbgemm_gpu/codegen/training/backward/embedding_backward_split_meta_template.cpp +1

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_meta_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_meta_template.cpp
@@ -198,9 +198,6 @@ Tensor {{ mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ desc
         std::tie(info_B_num_bits, info_B_mask) = adjust_info_B_num_bits(max_B.guard_int(__FILE__, __LINE__), T.guard_int(__FILE__, __LINE__));
     }
 
-    {%- else %}
-    // Cast info_B_mask from int64_t to uint32_t
-    const uint32_t info_B_mask = info_B_mask_int64;
     {%- endif %}
 
     {%- if dense %}


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/454

Public message about deeplearning/fbgemm/fbgemm_gpu/codegen/training/backward/embedding_backward_split_meta_template.cpp here

Differential Revision: D65842445


