### PR TITLE
Remove unused-variable in deeplearning/fbgemm/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp +1

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
@@ -888,8 +888,8 @@ class {{ autograd_func }} :
     auto max_gradient = ctx->saved_data["max_gradient"].toDouble();
     auto stochastic_rounding = ctx->saved_data["stochastic_rounding"].toBool();
     {%- endif %} {#-/* if optimizer != "none" */#}
-    const int32_t info_B_num_bits = ctx->saved_data["info_B_num_bits"].toInt();
-    const int64_t info_B_mask_int64 = ctx->saved_data["info_B_mask"].toInt();
+    [[maybe_unused]] const int32_t info_B_num_bits = ctx->saved_data["info_B_num_bits"].toInt();
+    [[maybe_unused]] const int64_t info_B_mask_int64 = ctx->saved_data["info_B_mask"].toInt();
     {%- if not dense %}
     const auto use_uniq_cache_locations_bwd =
       ctx->saved_data["use_uniq_cache_locations_bwd"].toBool();


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/456

Public message about deeplearning/fbgemm/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp here

Differential Revision: D65842449


