### PR TITLE
Fix "Cannot call numel() on tensor with symbolic sizes/strides"

### DIFF
--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
@@ -613,8 +613,8 @@ class {{ autograd_func }} :
         << "T=" << T << ","
         << "avg_D=" << ({{ "total_D / T" if not nobag else "D" }}) << ","
         << "max_D=" << {{ "max_D" if not nobag else "D" }} << ","
-        << "num_indices=" << indices.numel() << ","
-        << "avg_pooling_fac=" << (static_cast<float>(indices.numel()) / T / max_B_)
+        << "num_indices=" << indices.sym_numel() << ","
+        << "avg_pooling_fac=" << (static_cast<c10::SymFloat>(indices.sym_numel()) / T / max_B_)
         << "]";
       op_annotation = ss.str();
       record_trace = profiler::record_function_enter_new(


### PR DESCRIPTION
Summary:
This is to fix the issue reported in https://fb.workplace.com/groups/1075192433118967/permalink/1536587573646115/

That error message is the outcome but not the root cause. The cause is due to the error of calling `numel` on tensor with symbolic sizes/strides
 {F1959054688} 
And the line of code calling `numel` was pointed out by IvanKobzarev in https://fburl.com/workplace/4dvcfy9s

This happens when PT compiles Sparse Arch where `indices` has dynamic (symbolic) shapes.

The fix is straightforward. We apply `sym_numel` and `c10::SymFloat` for `indices`, instead.

Reviewed By: sryap

Differential Revision: D65883474


