### PR TITLE
Mark unified autograd function traceable

### DIFF
--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
@@ -526,6 +526,7 @@ enum SSDTensor {
 class {{ autograd_func }} :
     public torch::autograd::Function<{{ autograd_func }}> {
  public:
+  static constexpr bool is_traceable = true;
   static torch::autograd::variable_list forward(
     torch::autograd::AutogradContext* ctx,
     const Tensor& placeholder_autograd_tensor,


### PR DESCRIPTION
Summary: These changes make unified autograd function compatible with PT2 compiled autograd. It requires us to explicitly mark an Autograd Function is traceable.

Differential Revision: D65977420


