### PR TITLE
Add support for `int32_t` indices in TBE training (2H/N)

### DIFF
--- a/fbgemm_gpu/FbgemmGpu.cmake
+++ b/fbgemm_gpu/FbgemmGpu.cmake
@@ -725,8 +725,7 @@ endif()
 
 # Silence warnings in asmjit
 target_compile_options(fbgemm_gpu_py PRIVATE
-  -Wno-deprecated-anon-enum-enum-conversion)
-target_compile_options(fbgemm_gpu_py PRIVATE
+  -Wno-deprecated-anon-enum-enum-conversion
   -Wno-deprecated-declarations)
 
 

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -62,6 +62,7 @@ template <
     typename emb_t,
     typename grad_t,
     typename cache_t,
+    typename index_t,
     {%- for ph_name in args.placeholder_tensor_names %}
     typename {{ ph_name + "_ph_t"}},
     {%- endfor %}
@@ -90,7 +91,7 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row(
     int64_t D,
     {%- endif %}
     const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> hash_size_cumsum,
-    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_linear_indices_run,
+    const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> sorted_linear_indices_run,
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_cumulative_run_lengths,
     {%- if not nobag %}
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_infos,
@@ -341,6 +342,7 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row(
       emb_type,
       grad_type,
       cache_type,
+      index_type,
       ph_type_combo,
       kFixedMaxVecsPerThread,
       kThreadGroupSize,
@@ -358,6 +360,7 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row
 < {{ emb_type }},
   {{ grad_type }},
   {{ cache_type }},
+  {{ index_type }},
   {%- for ph_name in args.placeholder_tensor_names %}
   {{ ph_type_combo[ph_name].primitive_type }},
   {%- endfor %}
@@ -381,7 +384,7 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row
     int64_t D,
     {%- endif %}
     const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> hash_size_cumsum,
-    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_linear_indices_run,
+    const pta::PackedTensorAccessor32<{{ index_type }}, 1, at::RestrictPtrTraits> sorted_linear_indices_run,
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_cumulative_run_lengths,
     {%- if not nobag %}
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_infos,
@@ -441,17 +444,20 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row
     {%- for grad_type in ['float', 'at::Half', 'at::BFloat16'] %}
     {%- for emb_type in ['float', 'at::Half'] %}
     {%- for cache_type in ['float', 'at::Half'] %}
+    {%- for index_type in ['int32_t', 'int64_t'] %}
     {%- for ph_type_combo in args.placeholder_type_combos %}
         {{ template_instantiation(
             emb_type,
             grad_type,
             cache_type,
+            index_type,
             ph_type_combo,
             kFixedMaxVecsPerThread,
             kThreadGroupSize,
             kUseVecBlocking
           )
         }}
+    {%- endfor %}
     {%- endfor %}
     {%- endfor %}
     {%- endfor %}

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -134,6 +134,7 @@ template <
     typename emb_t,
     typename grad_t,
     typename cache_t,
+    typename index_t,
     {%- for ph_name in args.placeholder_tensor_names %}
     typename {{ ph_name + "_ph_t" }},
     {%- endfor %}
@@ -162,7 +163,7 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row(
     int64_t D,
     {%- endif %}
     const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> hash_size_cumsum,
-    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_linear_indices_run,
+    const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> sorted_linear_indices_run,
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_cumulative_run_lengths,
     {%- if not nobag %}
     const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_infos,
@@ -1082,6 +1083,7 @@ Tensor {{ embedding_cuda_op }}(
                             <emb_t,
                              grad_t,
                              cache_t,
+                             index_t,
                              {%- for ph_name in args.placeholder_tensor_names %}
                              {{ ph_name + "_ph_t" }},
                              {%- endfor %}
@@ -1135,7 +1137,7 @@ Tensor {{ embedding_cuda_op }}(
                             D,
                             {%- endif %}
                             MAKE_PTA_WITH_NAME(func_name4, hash_size_cumsum, int64_t, 1, 32),
-                            MAKE_PTA_WITH_NAME(func_name4, sorted_linear_indices_run, int64_t, 1, 32),
+                            MAKE_PTA_WITH_NAME(func_name4, sorted_linear_indices_run, index_t, 1, 32),
                             MAKE_PTA_WITH_NAME(func_name4, sorted_linear_indices_cumulative_run_lengths, int32_t, 1, 32),
                             {%- if not nobag %}
                             MAKE_PTA_WITH_NAME(func_name4, infos_sorted, int32_t, 1, 32),

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.cuh
@@ -59,9 +59,13 @@ transpose_embedding_input(
       int end_bit = sizeof(KeyT) * 8,          \
       cudaStream_t stream = 0)
 
+DECL_RADIX_SORT_PAIRS_FN(int64_t, int32_t);
+DECL_RADIX_SORT_PAIRS_FN(int64_t, int64_t);
 DECL_RADIX_SORT_PAIRS_FN(int64_t, float);
 DECL_RADIX_SORT_PAIRS_FN(int64_t, double);
-DECL_RADIX_SORT_PAIRS_FN(int64_t, int64_t);
-DECL_RADIX_SORT_PAIRS_FN(int64_t, int32_t);
+DECL_RADIX_SORT_PAIRS_FN(int32_t, int32_t);
+DECL_RADIX_SORT_PAIRS_FN(int32_t, int64_t);
+DECL_RADIX_SORT_PAIRS_FN(int32_t, float);
+DECL_RADIX_SORT_PAIRS_FN(int32_t, double);
 
 #undef DECL_RADIX_SORT_PAIRS_FN

--- a/fbgemm_gpu/src/split_embeddings_utils/radix_sort_pairs.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils/radix_sort_pairs.cu
@@ -77,7 +77,11 @@ using namespace fbgemm_gpu;
   }
 #endif
 
+DEF_RADIX_SORT_PAIRS_FN(int64_t, int32_t);
+DEF_RADIX_SORT_PAIRS_FN(int64_t, int64_t);
 DEF_RADIX_SORT_PAIRS_FN(int64_t, float);
 DEF_RADIX_SORT_PAIRS_FN(int64_t, double);
-DEF_RADIX_SORT_PAIRS_FN(int64_t, int64_t);
-DEF_RADIX_SORT_PAIRS_FN(int64_t, int32_t);
+DEF_RADIX_SORT_PAIRS_FN(int32_t, int32_t);
+DEF_RADIX_SORT_PAIRS_FN(int32_t, int64_t);
+DEF_RADIX_SORT_PAIRS_FN(int32_t, float);
+DEF_RADIX_SORT_PAIRS_FN(int32_t, double);

--- a/fbgemm_gpu/src/split_embeddings_utils/transpose_embedding_input.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils/transpose_embedding_input.cu
@@ -63,7 +63,7 @@ inline at::Tensor asynchronous_complete_cumsum(at::Tensor t_in) {
 
 template <typename index_t, typename info_acc_t, bool nobag, bool vbe>
 __global__ __launch_bounds__(kMaxThreads) void linearize_index_kernel(
-    const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         hash_size_cumsum,
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         indices,
@@ -79,7 +79,7 @@ __global__ __launch_bounds__(kMaxThreads) void linearize_index_kernel(
     // Use a raw pointer to avoid creating dummy PackedTensorAccessor
     const uint32_t* const __restrict__ vbe_b_t_map,
     FixedDivisor fd) {
-  const int32_t T = hash_size_cumsum.size(0) - 1;
+  const auto T = hash_size_cumsum.size(0) - 1;
   auto b_t = blockIdx.x * blockDim.x + threadIdx.x;
   int32_t b;
   int32_t t;
@@ -97,17 +97,16 @@ __global__ __launch_bounds__(kMaxThreads) void linearize_index_kernel(
   }
 
   const index_t hash_offset = valid ? hash_size_cumsum[t] : -1;
-  const index_t indices_start = valid ? offsets[b_t] : -1;
-  const int32_t L = valid ? offsets[b_t + 1] - indices_start : 0;
+  const auto indices_start = valid ? offsets[b_t] : -1;
+  const auto L = valid ? offsets[b_t + 1] - indices_start : 0;
   const int32_t lane_id = threadIdx.x % fbgemm_gpu::kWarpSize;
 
   // Compile-time conditional
   if (nobag) {
     for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
-      const index_t indices_start_warp =
-          fbgemm_gpu::shfl_sync(indices_start, j);
-      const int32_t t_warp = fbgemm_gpu::shfl_sync(t, j);
-      const int32_t L_warp = fbgemm_gpu::shfl_sync(L, j);
+      const auto indices_start_warp = fbgemm_gpu::shfl_sync(indices_start, j);
+      const auto t_warp = fbgemm_gpu::shfl_sync(t, j);
+      const auto L_warp = fbgemm_gpu::shfl_sync(L, j);
       const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
       for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
         const index_t idx = __ldg(&indices[indices_start_warp + i]);
@@ -124,10 +123,9 @@ __global__ __launch_bounds__(kMaxThreads) void linearize_index_kernel(
           reinterpret_cast<uint32_t*>(&b)[0];
     }
     for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
-      const index_t indices_start_warp =
-          fbgemm_gpu::shfl_sync(indices_start, j);
-      const uint32_t info_warp = fbgemm_gpu::shfl_sync(info, j);
-      const int32_t L_warp = fbgemm_gpu::shfl_sync(L, j);
+      const auto indices_start_warp = fbgemm_gpu::shfl_sync(indices_start, j);
+      const auto info_warp = fbgemm_gpu::shfl_sync(info, j);
+      const auto L_warp = fbgemm_gpu::shfl_sync(L, j);
       const index_t hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
       for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
         const index_t idx = __ldg(&indices[indices_start_warp + i]);
@@ -142,7 +140,7 @@ __global__ __launch_bounds__(kMaxThreads) void linearize_index_kernel(
 template <typename index_t, typename info_acc_t>
 __global__
 __launch_bounds__(kMaxThreads) void linearize_index_index_select_kernel(
-    const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         hash_size_cumsum,
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         indices,
@@ -153,7 +151,7 @@ __launch_bounds__(kMaxThreads) void linearize_index_index_select_kernel(
         linear_indices,
     FixedDivisor fd,
     int32_t fixed_L_per_warp) {
-  const int32_t T = hash_size_cumsum.size(0) - 1;
+  const auto T = hash_size_cumsum.size(0) - 1;
   auto b_t = blockIdx.x * blockDim.x + threadIdx.x;
   int32_t b;
   int32_t t;
@@ -258,7 +256,7 @@ transpose_embedding_input(
         kMaxThreads,                                                       \
         0,                                                                 \
         at::cuda::getCurrentCUDAStream()>>>(                               \
-        MAKE_PTA_WITH_NAME(func_name, hash_size_cumsum, index_t, 1, 32),   \
+        MAKE_PTA_WITH_NAME(func_name, hash_size_cumsum, int64_t, 1, 32),   \
         MAKE_PTA_WITH_NAME(func_name, indices, index_t, 1, 32),            \
         MAKE_PTA_WITH_NAME(func_name, offsets, index_t, 1, 32),            \
         MAKE_PTA_WITH_NAME(func_name, infos, INFO_ACC_T, 1, 32),           \
@@ -296,7 +294,7 @@ transpose_embedding_input(
                     0,
                     at::cuda::getCurrentCUDAStream()>>>(
                     MAKE_PTA_WITH_NAME(
-                        func_name, hash_size_cumsum, index_t, 1, 32),
+                        func_name, hash_size_cumsum, int64_t, 1, 32),
                     MAKE_PTA_WITH_NAME(func_name, indices, index_t, 1, 32),
                     MAKE_PTA_WITH_NAME(
                         func_name, total_L_offsets.value(), index_t, 1, 32),


### PR DESCRIPTION
Summary: - Add `index_t` support to TBE training backward kernels

Differential Revision: D65984314


