### PR TITLE
[fbgemm_gpu] Modularize CMake Code [1/N]

### DIFF
--- a/cmake/modules/GpuCppLibrary.cmake
+++ b/cmake/modules/GpuCppLibrary.cmake
@@ -1,0 +1,314 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/modules/Utilities.cmake)
+
+function(prepare_target_sources)
+    # This function does the following:
+    #   1. Take all the specified project sources for a target
+    #   1. Filter the files out based on CPU-only, CUDA, and HIP build modes
+    #   1. Bucketize them into sets of CXX, CU, and HIP files
+    #   1. Apply common source file properties for each bucket
+    #   1. Merge the buckets back into a single list of sources
+    #   1. Export the file list as ${args_PREFIX}_sources
+
+    set(flags)
+    set(singleValueArgs PREFIX)
+    set(multiValueArgs
+        CPU_SRCS
+        GPU_SRCS
+        CUDA_SPECIFIC_SRCS
+        HIP_SPECIFIC_SRCS
+        GPU_FLAGS
+        INCLUDE_DIRS
+    )
+
+    cmake_parse_arguments(
+        args
+        "${flags}" "${singleValueArgs}" "${multiValueArgs}"
+        ${ARGN})
+
+    ############################################################################
+    # Collect and Annotate, and Append CXX sources
+    ############################################################################
+
+    # Add the CPU CXX sources
+    set(${args_PREFIX}_sources_cpp ${args_CPU_SRCS})
+
+    # For GPU mode, add the CXX sources from GPU_SRCS
+    if(NOT FBGEMM_CPU_ONLY)
+        LIST_FILTER(
+            INPUT ${args_GPU_SRCS}
+            OUTPUT gpu_sources_cpp
+            REGEX "^.+\.cpp$"
+        )
+        list(APPEND ${args_PREFIX}_sources_cpp ${gpu_sources_cpp})
+    endif()
+
+    # Set source properties
+    set_source_files_properties(${${args_PREFIX}_sources_cpp}
+        PROPERTIES INCLUDE_DIRECTORIES
+        "${args_INCLUDE_DIRS}")
+
+    if(CXX_AVX2_FOUND)
+        set_source_files_properties(${${args_PREFIX}_sources_cpp}
+            PROPERTIES COMPILE_OPTIONS
+            "${AVX2_FLAGS}")
+    else()
+        set_source_files_properties(${${args_PREFIX}_sources_cpp}
+            PROPERTIES COMPILE_OPTIONS
+            "-fopenmp")
+    endif()
+
+    # Append to the full sources list
+    list(APPEND ${args_PREFIX}_sources_combined ${${args_PREFIX}_sources_cpp})
+
+    ############################################################################
+    # Collect, Annotate, and Append CU sources
+    ############################################################################
+
+    if(NOT FBGEMM_CPU_ONLY)
+        # Filter GPU_SRCS for CU sources - these may be HIPified later if building in ROCm mode
+        LIST_FILTER(
+            INPUT ${args_GPU_SRCS}
+            OUTPUT ${args_PREFIX}_sources_cu
+            REGEX "^.+\.cu$"
+        )
+
+        # Append CUDA-specific sources, but ONLY when building in CUDA mode
+        if(NOT USE_ROCM)
+            list(APPEND ${args_PREFIX}_sources_cu ${args_CUDA_SPECIFIC_SRCS})
+        endif()
+
+        # Set source properties
+        set_source_files_properties(${${args_PREFIX}_sources_cu}
+            PROPERTIES COMPILE_OPTIONS
+            "${args_GPU_FLAGS}")
+
+        set_source_files_properties(${${args_PREFIX}_sources_cu}
+            PROPERTIES INCLUDE_DIRECTORIES
+            "${args_INCLUDE_DIRS}")
+
+        # Append to the full sources list
+        list(APPEND ${args_PREFIX}_sources_combined ${${args_PREFIX}_sources_cu})
+    endif()
+
+    ############################################################################
+    # Collect, Annotate, and Append HIP sources
+    ############################################################################
+
+    if(NOT FBGEMM_CPU_ONLY AND USE_ROCM)
+        # Filter GPU_SRCS for HIP sources
+        LIST_FILTER(
+            INPUT ${args_GPU_SRCS}
+            OUTPUT ${args_PREFIX}_sources_hip
+            REGEX "^.+\.hip$"
+        )
+
+        # Append HIP-specific sources, but ONLY when building in HIP mode
+        list(APPEND ${args_PREFIX}_sources_hip ${args_HIP_SPECIFIC_SRCS})
+
+        # Set source properties
+        set_source_files_properties(${${args_PREFIX}_sources_hip}
+            PROPERTIES INCLUDE_DIRECTORIES
+            "${args_INCLUDE_DIRS}")
+
+        # Append to the full sources list
+        list(APPEND ${args_PREFIX}_sources_combined ${${args_PREFIX}_sources_hip})
+    endif()
+
+    ############################################################################
+    # Set the Output Variable(s)
+    ############################################################################
+
+    set(${args_PREFIX}_sources ${${args_PREFIX}_sources_combined} PARENT_SCOPE)
+endfunction()
+
+function(prepare_hipified_target_sources)
+    # This function does the following:
+    #   1. Take all the specified target sources
+    #   1. Look up their equivalent HIPified files if applicable (presumes that hipify() already been run)
+    #   1. Apply source file properties
+    #   1. Update the HIP include directories
+
+    set(flags)
+    set(singleValueArgs PREFIX)
+    set(multiValueArgs SRCS INCLUDE_DIRS)
+
+    cmake_parse_arguments(
+        args
+        "${flags}" "${singleValueArgs}" "${multiValueArgs}"
+        ${ARGN})
+
+    get_hipified_list("${args_SRCS}" args_SRCS)
+
+    set_source_files_properties(${args_SRCS}
+                                PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
+
+    # Add include directories
+    hip_include_directories("${args_INCLUDE_DIRS}")
+
+    ############################################################################
+    # Set the Output Variable(s)
+    ############################################################################
+
+    set(${args_PREFIX}_sources_hipified ${args_SRCS} PARENT_SCOPE)
+endfunction()
+
+function(gpu_cpp_library)
+    # This function does the following:
+    #   1. Take all the target sources and select relevant sources based on build type (CPU-only, CUDA, HIP)
+    #   1. Apply source file properties as needed
+    #   1. HIPify files as needed
+    #   1. Build the .SO file
+
+    set(flags)
+    set(singleValueArgs
+        PREFIX          # Desired name prefix for the library target
+    )
+    set(multiValueArgs
+        CPU_SRCS            # Sources for CPU-only build
+        GPU_SRCS            # Sources common to both CUDA and HIP builds.  .CU files specified here will be HIPified when building a HIP target
+        CUDA_SPECIFIC_SRCS  # Sources available only for CUDA build
+        HIP_SPECIFIC_SRCS   # Sources available only for HIP build
+        GPU_FLAGS           # Compile flags for GPU builds
+        INCLUDE_DIRS        # Include directories for compilation
+    )
+
+    cmake_parse_arguments(
+        args
+        "${flags}" "${singleValueArgs}" "${multiValueArgs}"
+        ${ARGN})
+
+    ############################################################################
+    # Prepare CXX and CU sources
+    ############################################################################
+
+    prepare_target_sources(
+        PREFIX ${args_PREFIX}
+        CPU_SRCS ${args_CPU_SRCS}
+        GPU_SRCS ${args_GPU_SRCS}
+        CUDA_SPECIFIC_SRCS ${args_CUDA_SPECIFIC_SRCS}
+        HIP_SPECIFIC_SRCS ${args_HIP_SPECIFIC_SRCS}
+        GPU_FLAGS ${args_GPU_FLAGS}
+        INCLUDE_DIRS ${args_INCLUDE_DIRS})
+    set(lib_sources ${${args_PREFIX}_sources})
+
+
+    ############################################################################
+    # Build the Library
+    ############################################################################
+
+    set(lib_name ${args_PREFIX}_py)
+    if(USE_ROCM)
+        # Fetch the HIPified sources
+        prepare_hipified_target_sources(
+            PREFIX ${args_PREFIX}
+            SRCS ${lib_sources}
+            INCLUDE_DIRS ${args_INCLUDE_DIRS})
+        set(lib_sources_hipified ${${args_PREFIX}_sources_hipified})
+
+        # Create the HIP library
+        hip_add_library(${lib_name} SHARED
+            ${lib_sources_hipified}
+            ${args_OTHER_SRCS}
+            ${FBGEMM_HIP_HCC_LIBRARIES}
+            HIPCC_OPTIONS
+            ${HIP_HCC_FLAGS})
+
+        # Append ROCM includes
+        target_include_directories(${lib_name} PUBLIC
+            ${FBGEMM_HIP_INCLUDE}
+            ${ROCRAND_INCLUDE}
+            ${ROCM_SMI_INCLUDE})
+
+    else()
+        # Create the C++/CUDA library
+        add_library(${lib_name} MODULE
+            ${lib_sources}
+            ${args_OTHER_SRCS})
+    endif()
+
+    ############################################################################
+    # Library Includes and Linking
+    ############################################################################
+
+    # Add PyTorch include/
+    target_include_directories(${lib_name} PRIVATE
+        ${TORCH_INCLUDE_DIRS}
+        ${NCCL_INCLUDE_DIRS})
+
+    # Remove `lib` from the output artifact name, i.e. `libfoo.so` -> `foo.so`
+    set_target_properties(${lib_name}
+        PROPERTIES PREFIX "")
+
+    # Link to PyTorch
+    target_link_libraries(${lib_name}
+        ${TORCH_LIBRARIES}
+        ${NCCL_LIBRARIES}
+        ${CUDA_DRIVER_LIBRARIES})
+
+    # Link to NVML if available
+    if(NVML_LIB_PATH)
+        target_link_libraries(${lib_name} ${NVML_LIB_PATH})
+    endif()
+
+    # Silence warnings (in asmjit)
+    target_compile_options(${lib_name} PRIVATE
+        -Wno-deprecated-anon-enum-enum-conversion
+        -Wno-deprecated-declarations)
+
+    ############################################################################
+    # Post-Build Steps
+    ############################################################################
+
+    # Add a post-build step to remove errant RPATHs from the .SO
+    add_custom_target(${lib_name}_postbuild ALL
+        DEPENDS
+        WORKING_DIRECTORY ${OUTPUT_DIR}
+        COMMAND bash ${FBGEMM}/.github/scripts/fbgemm_gpu_postbuild.bash)
+
+    # Run the post-build steps AFTER the build itself
+    add_dependencies(${lib_name}_postbuild ${lib_name})
+
+    ############################################################################
+    # Set the Output Variable(s)
+    ############################################################################
+
+    # PREFIX = `foo` --> Target Library = `foo_py`
+    set(${args_PREFIX}_py ${lib_name} PARENT_SCOPE)
+
+    BLOCK_PRINT(
+        "GPU CPP Library Target: ${args_PREFIX}"
+        " "
+        "CPU_SRCS:"
+        "${args_CPU_SRCS}"
+        " "
+        "GPU_SRCS:"
+        "${args_GPU_SRCS}"
+        " "
+        "CUDA_SPECIFIC_SRCS:"
+        "${args_CUDA_SPECIFIC_SRCS}"
+        " "
+        "HIP_SPECIFIC_SRCS"
+        "${args_HIP_SPECIFIC_SRCS}"
+        " "
+        "GPU_FLAGS:"
+        "${args_GPU_FLAGS}"
+        " "
+        "INCLUDE_DIRS:"
+        "${args_INCLUDE_DIRS}"
+        " "
+        "Selected Source Files:"
+        "${lib_sources}"
+        " "
+        "HIPified Source Files:"
+        "${lib_sources_hipified}"
+        " "
+        "Output Library:"
+        "${lib_name}"
+    )
+endfunction()

--- a/cmake/modules/PyTorchSetup.cmake
+++ b/cmake/modules/PyTorchSetup.cmake
@@ -13,14 +13,6 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/modules/Utilities.cmake)
 
 find_package(Torch REQUIRED)
 
-BLOCK_PRINT(
-  "PyTorch Flags"
-  ""
-  "TORCH_INCLUDE_DIRS=${TORCH_INCLUDE_DIRS}"
-  ""
-  "TORCH_LIBRARIES=${TORCH_LIBRARIES}"
-)
-
 #
 # PyTorch CUDA Extensions are normally compiled with the flags below. However we
 # disabled -D__CUDA_NO_HALF_CONVERSIONS__ here as it caused "error: no suitable
@@ -29,6 +21,21 @@ BLOCK_PRINT(
 #
 
 set(TORCH_CUDA_OPTIONS
-    --expt-relaxed-constexpr -D__CUDA_NO_HALF_OPERATORS__
-    # -D__CUDA_NO_HALF_CONVERSIONS__
-    -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__)
+  --expt-relaxed-constexpr
+  -D__CUDA_NO_HALF_OPERATORS__
+  # -D__CUDA_NO_HALF_CONVERSIONS__
+  -D__CUDA_NO_BFLOAT16_CONVERSIONS__
+  -D__CUDA_NO_HALF2_OPERATORS__)
+
+BLOCK_PRINT(
+  "PyTorch Flags:"
+  " "
+  "TORCH_INCLUDE_DIRS:"
+  "${TORCH_INCLUDE_DIRS}"
+  " "
+  "TORCH_LIBRARIES:"
+  "${TORCH_LIBRARIES}"
+  " "
+  "TORCH_CUDA_OPTIONS:"
+  "${TORCH_CUDA_OPTIONS}"
+)

--- a/cmake/modules/Utilities.cmake
+++ b/cmake/modules/Utilities.cmake
@@ -18,3 +18,48 @@ function(BLOCK_PRINT)
   message("================================================================================")
   message("")
 endfunction()
+
+function(LIST_FILTER)
+  set(flags)
+  set(singleValueArgs OUTPUT REGEX)
+  set(multiValueArgs INPUT)
+
+  cmake_parse_arguments(
+    args
+    "${flags}" "${singleValueArgs}" "${multiValueArgs}"
+    ${ARGN})
+
+  set(${args_OUTPUT})
+
+  foreach(value ${args_INPUT})
+    if("${value}" MATCHES "${args_REGEX}")
+      list(APPEND ${args_OUTPUT} ${value})
+    endif()
+  endforeach()
+
+  set(${args_OUTPUT} ${${args_OUTPUT}} PARENT_SCOPE)
+endfunction()
+
+function(add_to_package)
+  set(flags)
+  set(singleValueArgs DESTINATION)
+  set(multiValueArgs FILES TARGETS)
+
+  cmake_parse_arguments(
+    args
+    "${flags}" "${singleValueArgs}" "${multiValueArgs}"
+    ${ARGN})
+
+  install(TARGETS ${args_TARGETS} DESTINATION ${args_DESTINATION})
+  install(FILES ${args_FILES} DESTINATION ${args_DESTINATION})
+
+  BLOCK_PRINT(
+    "Adding to Package: ${args_DESTINATION}"
+    " "
+    "TARGETS:"
+    "${args_TARGETS}"
+    " "
+    "FILES:"
+    "${args_FILES}"
+  )
+endfunction()

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -82,6 +82,31 @@ include(${CMAKEMODULES}/CudaSetup.cmake)
 # ROCm and HIPify Setup
 include(${CMAKEMODULES}/RocmSetup.cmake)
 
+# Load gpu_cpp_library()
+include(${CMAKEMODULES}/GpuCppLibrary.cmake)
+
+
+################################################################################
+# Source Includes
+################################################################################
+
+set(fbgemm_sources_include_directories
+  # FBGEMM
+  ${FBGEMM}/include
+  # FBGEMM_GPU
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../include
+  # PyTorch
+  ${TORCH_INCLUDE_DIRS}
+  # Third-party
+  ${THIRDPARTY}/asmjit/src
+  ${THIRDPARTY}/cpuinfo/include
+  ${THIRDPARTY}/cutlass/include
+  ${THIRDPARTY}/cutlass/tools/util/include
+  ${THIRDPARTY}/json/include
+  ${NCCL_INCLUDE_DIRS})
+
 
 ################################################################################
 # Build FBGEMM_GPU (Main) Module
@@ -90,6 +115,7 @@ include(${CMAKEMODULES}/RocmSetup.cmake)
 if(NOT FBGEMM_GENAI_ONLY)
   include(FbgemmGpu.cmake)
 endif()
+
 
 ################################################################################
 # Build Experimental Modules
@@ -105,10 +131,6 @@ if(NOT FBGEMM_CPU_ONLY)
 endif()
 
 if(NOT FBGEMM_CPU_ONLY AND NOT USE_ROCM)
-  # CUTLASS currently doesn't build on ROCm and CK hasnt yet been added:
-  #
-  # 2024-05-06T23:09:35.5730483Z /__w/FBGEMM/FBGEMM/fbgemm_gpu/../external/cutlass/include/cutlass/half.h:73:10: fatal error: 'cuda_fp16.h' file not found
-  # #include <cuda_fp16.h>
-  #
+  # TODO: Re-enable gen_ai for ROCm after enabling build support for ROCm 6.2
   add_subdirectory(experimental/gen_ai)
 endif()

--- a/fbgemm_gpu/FbgemmGpu.cmake
+++ b/fbgemm_gpu/FbgemmGpu.cmake
@@ -14,28 +14,6 @@ set(CMAKE_CODEGEN_DIR ${CMAKE_CURRENT_SOURCE_DIR}/codegen)
 
 
 ################################################################################
-# Source Includes
-################################################################################
-
-set(fbgemm_sources_include_directories
-  # FBGEMM
-  ${FBGEMM}/include
-  # FBGEMM_GPU
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_SOURCE_DIR}/include
-  ${CMAKE_CURRENT_SOURCE_DIR}/../include
-  # PyTorch
-  ${TORCH_INCLUDE_DIRS}
-  # Third-party
-  ${THIRDPARTY}/asmjit/src
-  ${THIRDPARTY}/cpuinfo/include
-  ${THIRDPARTY}/cutlass/include
-  ${THIRDPARTY}/cutlass/tools/util/include
-  ${THIRDPARTY}/json/include
-  ${NCCL_INCLUDE_DIRS})
-
-
-################################################################################
 # Third Party Sources
 ################################################################################
 
@@ -735,16 +713,30 @@ target_compile_options(fbgemm_gpu_py PRIVATE
 ################################################################################
 
 install(TARGETS fbgemm_gpu_py
-        DESTINATION fbgemm_gpu)
+  DESTINATION fbgemm_gpu)
 
 install(FILES ${gen_python_source_files}
-        DESTINATION fbgemm_gpu/split_embedding_codegen_lookup_invokers)
+  DESTINATION fbgemm_gpu/split_embedding_codegen_lookup_invokers)
 
 install(FILES ${gen_defused_optim_py_files}
-        DESTINATION fbgemm_gpu/split_embedding_optimizer_codegen)
+  DESTINATION fbgemm_gpu/split_embedding_optimizer_codegen)
 
 add_custom_target(fbgemm_gpu_py_clean_rpath ALL
   WORKING_DIRECTORY ${OUTPUT_DIR}
   COMMAND bash ${FBGEMM}/.github/scripts/fbgemm_gpu_postbuild.bash)
 
 add_dependencies(fbgemm_gpu_py_clean_rpath fbgemm_gpu_py)
+
+# TODO: Test target, need to properly integrate into FBGEMM_GPU main build
+gpu_cpp_library(
+  PREFIX
+    embedding_inplace_ops
+  INCLUDE_DIRS
+    ${fbgemm_sources_include_directories}
+  CPU_SRCS
+    src/embedding_inplace_ops/embedding_inplace_update_cpu.cpp
+  GPU_SRCS
+    src/embedding_inplace_ops/embedding_inplace_update_gpu.cpp
+    src/embedding_inplace_ops/embedding_inplace_update.cu
+  GPU_FLAGS
+    ${TORCH_CUDA_OPTIONS})

--- a/fbgemm_gpu/experimental/example/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/example/CMakeLists.txt
@@ -4,37 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-include(${CMAKEMODULES}/Utilities.cmake)
-
 ################################################################################
 # Target Sources
 ################################################################################
-
-set(fbgemm_sources_include_directories
-  # FBGEMM
-  ${FBGEMM}/include
-  # FBGEMM_GPU
-  ${CMAKE_CURRENT_SOURCE_DIR}../..
-  ${CMAKE_CURRENT_SOURCE_DIR}../../include
-  ${CMAKE_CURRENT_SOURCE_DIR}../../../include
-  # PyTorch
-  ${TORCH_INCLUDE_DIRS}
-  # Third-party
-  ${THIRDPARTY}/asmjit/src
-  ${THIRDPARTY}/cpuinfo/include
-  ${THIRDPARTY}/cutlass/include
-  ${THIRDPARTY}/cutlass/tools/util/include
-  ${THIRDPARTY}/json/include
-  ${NCCL_INCLUDE_DIRS})
 
 set(experimental_example_cpp_source_files
     src/cutlass_sgemm_nn.cu
     src/example_ops.cpp
     src/nccl_example.cpp)
-
-set_source_files_properties(${experimental_example_cpp_source_files}
-    PROPERTIES INCLUDE_DIRECTORIES
-    "${fbgemm_sources_include_directories}")
 
 set(experimental_example_python_source_files
     example/__init__.py
@@ -45,35 +22,19 @@ set(experimental_example_python_source_files
 # Build Shared Library
 ################################################################################
 
-add_library(fbgemm_gpu_experimental_example_py MODULE
-    ${experimental_example_cpp_source_files})
-
-target_include_directories(fbgemm_gpu_experimental_example_py PRIVATE
-    ${TORCH_INCLUDE_DIRS}
-    ${NCCL_INCLUDE_DIRS})
-
-target_link_libraries(fbgemm_gpu_experimental_example_py
-    ${TORCH_LIBRARIES}
-    ${NCCL_LIBRARIES}
-    ${CUDA_DRIVER_LIBRARIES})
-
-# Remove `lib` from the output artifact name
-set_target_properties(fbgemm_gpu_experimental_example_py PROPERTIES PREFIX "")
+gpu_cpp_library(
+    PREFIX
+        fbgemm_gpu_experimental_example
+    INCLUDE_DIRS
+        ${fbgemm_sources_include_directories}
+    GPU_SRCS
+        ${experimental_example_cpp_source_files})
 
 
 ################################################################################
 # Install Shared Library and Python Files
 ################################################################################
 
-install(TARGETS fbgemm_gpu_experimental_example_py
-        DESTINATION fbgemm_gpu/experimental/example)
-
-install(FILES ${experimental_example_python_source_files}
-        DESTINATION fbgemm_gpu/experimental/example)
-
-add_custom_target(fbgemm_gpu_experimental_example_py_clean_rpath ALL
-    WORKING_DIRECTORY ${OUTPUT_DIR}
-    COMMAND bash ${FBGEMM}/.github/scripts/fbgemm_gpu_postbuild.bash)
-
-add_dependencies(fbgemm_gpu_experimental_example_py_clean_rpath
-    fbgemm_gpu_experimental_example_py)
+add_to_package(DESTINATION fbgemm_gpu/experimental/example
+    TARGETS fbgemm_gpu_experimental_example_py
+    FILES ${experimental_example_python_source_files})

--- a/fbgemm_gpu/experimental/gemm/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/gemm/CMakeLists.txt
@@ -18,5 +18,5 @@ set(experimental_triton_python_source_files
 # Install Python Files
 ################################################################################
 
-install(FILES ${experimental_triton_python_source_files}
-        DESTINATION fbgemm_gpu/experimental/gemm/triton_gemm)
+add_to_package(DESTINATION fbgemm_gpu/experimental/gemm/triton_gemm
+    FILES ${experimental_triton_python_source_files})

--- a/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
@@ -8,86 +8,43 @@
 # Target Sources
 ################################################################################
 
-set(fbgemm_sources_include_directories
-  # FBGEMM
-  ${FBGEMM}/include
-  # FBGEMM_GPU
-  ${CMAKE_CURRENT_SOURCE_DIR}/../..
-  ${CMAKE_CURRENT_SOURCE_DIR}/../../include
-  ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
-  ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize
-  # PyTorch
-  ${TORCH_INCLUDE_DIRS}
-  # Third-party
-  ${THIRDPARTY}/asmjit/src
-  ${THIRDPARTY}/cpuinfo/include
-  ${THIRDPARTY}/cutlass/include
-  ${THIRDPARTY}/cutlass/tools/util/include
-  ${THIRDPARTY}/json/include
-  ${NCCL_INCLUDE_DIRS})
-
-set(attention_ops_sources
+set(experimental_gen_ai_cpp_source_files_gpu
+    # Attention Ops
     src/attention/attention.cpp
-    src/attention/gqa_attn_splitk.cu)
-
-if(USE_ROCM)
-  set(quantize_ops_sources
-    src/quantize/ck_extensions/fp8_tensorwise_gemm.hip
-    src/quantize/ck_extensions/fp8_rowwise_gemm.hip
-    src/quantize/ck_extensions/fp8_blockwise_gemm.hip
+    src/attention/gqa_attn_splitk.cu
+    # Quantize Ops
     src/quantize/quantize.cu
-    src/quantize/quantize.cpp)
-else()
-  set(quantize_ops_sources
-    src/quantize/cutlass_extensions/f8f8bf16.cu
-    src/quantize/cutlass_extensions/f8f8bf16_blockwise.cu
-    src/quantize/cutlass_extensions/f8f8bf16_cublas.cu
-    src/quantize/cutlass_extensions/f8f8bf16_grouped.cu
-    src/quantize/cutlass_extensions/f8f8bf16_rowwise.cu
-    src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched.cu
-    src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_impl.cu
-    src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/dispatch_fp8_rowwise_batched_kernel_on_tile_size.cu
-    src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/dispatch_fp8_rowwise_batched_kernel_on_cluster_size_and_transpose.cu
-    src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/handle_transposition.cu
-    src/quantize/cutlass_extensions/f8f8bf16_tensorwise.cu
-    src/quantize/cutlass_extensions/i8i8bf16.cu
-    src/quantize/cutlass_extensions/f8i4bf16_rowwise.cu
-    src/quantize/cutlass_extensions/i8i8bf16_dynamic.cu
-    src/quantize/cutlass_extensions/bf16i4bf16_rowwise.cu
-    src/quantize/cutlass_extensions/bf16i4bf16_rowwise_batched.cu
-    src/quantize/quantize.cu
-    src/quantize/quantize.cpp)
-endif()
-
-set(comm_ops_sources
+    src/quantize/quantize.cpp
+    # Comm Ops
     src/comm/car.cu
-    src/comm/car.cpp)
-
-set(kv_cache_ops_sources
+    src/comm/car.cpp
+    # KV Cache Ops
     src/kv_cache/kv_cache.cu
     src/kv_cache/kv_cache.cpp)
-
-set(experimental_gen_ai_cpp_source_files
-    ${attention_ops_sources}
-    ${quantize_ops_sources}
-    ${comm_ops_sources}
-    ${kv_cache_ops_sources})
 
 # Set the source file for FB only CPP
 if(USE_FB_ONLY)
   file(GLOB fb_only_ops_sources
       fb/src/*/*.cu
       fb/src/*/*.cpp)
-  list(APPEND experimental_gen_ai_cpp_source_files ${fb_only_ops_sources})
+  list(APPEND experimental_gen_ai_cpp_source_files_gpu ${fb_only_ops_sources})
 endif()
 
-set_source_files_properties(${experimental_gen_ai_cpp_source_files}
-    PROPERTIES INCLUDE_DIRECTORIES
-    "${fbgemm_sources_include_directories}")
+# CUDA-specific sources
+file(GLOB_RECURSE experimental_gen_ai_cpp_source_files_cuda
+  src/quantize/cutlass_extensions/*.cu
+  src/quantize/cutlass_extensions/**/*.cu)
 
+# HIP-specific sources
+file(GLOB_RECURSE experimental_gen_ai_cpp_source_files_hip
+  src/quantize/ck_extensions/*.hip
+  src/quantize/ck_extensions/**/*.hip)
+
+# Python sources
 file(GLOB_RECURSE experimental_gen_ai_python_source_files
   RELATIVE gen_ai
   *.py)
+
 
 ################################################################################
 # FBGEMM_GPU HIP Code Generation
@@ -103,16 +60,6 @@ if(USE_ROCM)
 
   hipify(CUDA_SOURCE_DIR ${PROJECT_SOURCE_DIR}
          HEADER_INCLUDE_DIR ${header_include_dir})
-
-  # HIPify source files
-  get_hipified_list("${experimental_gen_ai_cpp_source_files}"
-    experimental_gen_ai_cpp_source_files_hip)
-
-  set_source_files_properties(${experimental_gen_ai_cpp_source_files_hip}
-                              PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
-
-  # Add include directories
-  hip_include_directories("${fbgemm_sources_include_directories}")
 endif()
 
 
@@ -120,51 +67,25 @@ endif()
 # Build Shared Library
 ################################################################################
 
-if(USE_ROCM)
-  # Create a HIP library if using ROCm
-  hip_add_library(fbgemm_gpu_experimental_gen_ai_py SHARED
-    ${experimental_gen_ai_cpp_source_files_hip}
-    ${FBGEMM_HIP_HCC_LIBRARIES}
-    HIPCC_OPTIONS
-    ${HIP_HCC_FLAGS})
-
-  target_include_directories(fbgemm_gpu_experimental_gen_ai_py PUBLIC
-    ${FBGEMM_HIP_INCLUDE}
-    ${ROCRAND_INCLUDE}
-    ${ROCM_SMI_INCLUDE})
-
-else()
-  # Else create a CUDA library
-  add_library(fbgemm_gpu_experimental_gen_ai_py MODULE
-      ${experimental_gen_ai_cpp_source_files})
-endif()
-
-target_include_directories(fbgemm_gpu_experimental_gen_ai_py PRIVATE
-  ${TORCH_INCLUDE_DIRS}
-  ${NCCL_INCLUDE_DIRS})
-
-target_link_libraries(fbgemm_gpu_experimental_gen_ai_py
-  ${TORCH_LIBRARIES}
-  ${NCCL_LIBRARIES}
-  ${CUDA_DRIVER_LIBRARIES})
-
-# Remove `lib` from the output artifact name
-set_target_properties(fbgemm_gpu_experimental_gen_ai_py PROPERTIES PREFIX "")
+gpu_cpp_library(
+  PREFIX
+    fbgemm_gpu_experimental_gen_ai
+  INCLUDE_DIRS
+    ${fbgemm_sources_include_directories}
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize
+  GPU_SRCS
+    ${experimental_gen_ai_cpp_source_files_gpu}
+  CUDA_SPECIFIC_SRCS
+    ${experimental_gen_ai_cpp_source_files_cuda}
+  HIP_SPECIFIC_SRCS
+    ${experimental_gen_ai_cpp_source_files_hip})
 
 
 ################################################################################
 # Install Shared Library and Python Files
 ################################################################################
 
-install(TARGETS fbgemm_gpu_experimental_gen_ai_py
-        DESTINATION fbgemm_gpu/experimental/gen_ai)
-
-install(FILES ${experimental_gen_ai_python_source_files}
-        DESTINATION fbgemm_gpu/experimental/gen_ai)
-
-add_custom_target(fbgemm_gpu_experimental_gen_ai_py_clean_rpath ALL
-  WORKING_DIRECTORY ${OUTPUT_DIR}
-  COMMAND bash ${FBGEMM}/.github/scripts/fbgemm_gpu_postbuild.bash)
-
-add_dependencies(fbgemm_gpu_experimental_gen_ai_py_clean_rpath
-  fbgemm_gpu_experimental_gen_ai_py)
+add_to_package(
+  DESTINATION fbgemm_gpu/experimental/gen_ai
+  TARGETS fbgemm_gpu_experimental_gen_ai_py
+  FILES ${experimental_gen_ai_python_source_files})

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/kernels/fp8_rowwise_common.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/kernels/fp8_rowwise_common.h
@@ -12,7 +12,11 @@
 #include <numeric>
 
 #include <ATen/ATen.h>
+#ifdef USE_ROCM
+#include <c10/hip/HIPStream.h>
+#else
 #include <c10/cuda/CUDAStream.h>
+#endif
 #include <torch/torch.h>
 
 #include "ck/ck.hpp"

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_common.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_common.h
@@ -7,7 +7,11 @@
  */
 
 #include <ATen/ATen.h>
+#ifdef USE_ROCM
+#include <c10/hip/HIPStream.h>
+#else
 #include <c10/cuda/CUDAStream.h>
+#endif
 #include <torch/torch.h>
 
 #include "ck/ck.hpp"

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_common.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_common.h
@@ -7,7 +7,11 @@
  */
 
 #include <ATen/ATen.h>
+#ifdef USE_ROCM
+#include <c10/hip/HIPStream.h>
+#else
 #include <c10/cuda/CUDAStream.h>
+#endif
 #include <torch/torch.h>
 
 #include "ck/ck.hpp"


### PR DESCRIPTION
- Currently, the logic for building a .SO file from source files is unorganized and scattered across CMakefiles.  This becomes a problem when we have to consider building libraries targeted for CPU-only, CUDA, and HIP backends.  
- This code brings all the scattered CMake instructions into one function, `gpu_cpp_library()`, where the user specifies the all the relevant sources in one place.  During the build, the function will determine which sources to use based on the designated build target, apply all the correct source properties annotations, HIPification, includes, and linking as needed, and output a single `.SO` file.
- This first step is needed for us to be able to break up the FBGEMM build reliably into multiple .SO files