### PR TITLE
Improve bounds_check_indices for VBE

### DIFF
--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_host.cpp
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_host.cpp
@@ -28,7 +28,10 @@ void _bounds_check_indices_cuda_v1(
     Tensor& warning,
     const std::optional<Tensor>& weights,
     const std::optional<Tensor>& B_offsets,
-    const int64_t max_B);
+    const int64_t max_B,
+    const std::optional<Tensor>& b_t_map,
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask);
 
 void _bounds_check_indices_cuda_v2(
     Tensor& rows_per_table,
@@ -38,7 +41,10 @@ void _bounds_check_indices_cuda_v2(
     Tensor& warning,
     const std::optional<Tensor>& weights,
     const std::optional<Tensor>& B_offsets,
-    const int64_t max_B);
+    const int64_t max_B,
+    const std::optional<Tensor>& b_t_map,
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask);
 
 ///@ingroup embedding-cuda
 void bounds_check_indices_cuda(
@@ -49,7 +55,10 @@ void bounds_check_indices_cuda(
     Tensor& warning,
     const std::optional<Tensor>& weights,
     const std::optional<Tensor>& B_offsets,
-    const int64_t max_B) {
+    const int64_t max_B,
+    const std::optional<Tensor>& b_t_map,
+    const int64_t info_B_num_bits,
+    const int64_t info_B_mask) {
   const static bool use_v2 = fbgemm_gpu::config::is_feature_enabled(
       fbgemm_gpu::config::FeatureGateName::BOUNDS_CHECK_INDICES_V2);
   const auto bounds_check_indices_fn =
@@ -62,7 +71,10 @@ void bounds_check_indices_cuda(
       warning,
       weights,
       B_offsets,
-      max_B);
+      max_B,
+      b_t_map,
+      static_cast<int32_t>(info_B_num_bits),
+      static_cast<uint32_t>(info_B_mask));
 }
 // Deprecated for fb namespace! Please use fbgemm namespace instead!
 TORCH_LIBRARY_FRAGMENT(fb, m) {

--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_host_cpu.cpp
@@ -48,7 +48,10 @@ void bounds_check_indices_cpu(
     Tensor& warning,
     const std::optional<Tensor>& weights,
     const std::optional<Tensor>& B_offsets,
-    const int64_t max_B) {
+    const int64_t max_B,
+    const std::optional<Tensor>& /*b_t_map*/,
+    const int64_t /*info_B_num_bits*/,
+    const int64_t /*info_B_mask*/) {
   if (offsets.scalar_type() != indices.scalar_type()) {
     offsets = offsets.toType(indices.scalar_type());
   }
@@ -190,7 +193,19 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
   // The (a!) tells PyTorch this is an impure operation and so cannot be CSE'd
   // or DCE'd, etc.
   m.def(
-      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(b!) offsets, int bounds_check_mode, Tensor(c!) warning, Tensor(d!)? weights=None, Tensor? B_offsets=None, SymInt max_B=-1) -> ()",
+      "bounds_check_indices("
+      "    Tensor rows_per_table, "
+      "    Tensor(a!) indices, "
+      "    Tensor(b!) offsets, "
+      "    int bounds_check_mode, "
+      "    Tensor(c!) warning, "
+      "    Tensor(d!)? weights=None, "
+      "    Tensor? B_offsets=None, "
+      "    SymInt max_B=-1, "
+      "    Tensor? b_t_map=None, "
+      "    int info_B_num_bits=-1, "
+      "    int info_B_mask=-1"
+      ") -> ()",
       {PT2_COMPLIANT_TAG});
   DISPATCH_TO_CPU("bounds_check_indices", bounds_check_indices_cpu);
 }
@@ -202,7 +217,19 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "fbgemm_gpu.sparse_ops",
       "//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_py");
   m.def(
-      "bounds_check_indices(Tensor rows_per_table, Tensor(a!) indices, Tensor(b!) offsets, int bounds_check_mode, Tensor(c!) warning, Tensor(d!)? weights=None, Tensor? B_offsets=None, SymInt max_B=-1) -> ()",
+      "bounds_check_indices("
+      "    Tensor rows_per_table, "
+      "    Tensor(a!) indices, "
+      "    Tensor(b!) offsets, "
+      "    int bounds_check_mode, "
+      "    Tensor(c!) warning, "
+      "    Tensor(d!)? weights=None, "
+      "    Tensor? B_offsets=None, "
+      "    SymInt max_B=-1, "
+      "    Tensor? b_t_map=None, "
+      "    int info_B_num_bits=-1, "
+      "    int info_B_mask=-1"
+      ") -> ()",
       {PT2_COMPLIANT_TAG});
   DISPATCH_TO_CPU("bounds_check_indices", bounds_check_indices_cpu);
 }

--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_v1.cu
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_v1.cu
@@ -187,7 +187,10 @@ void _bounds_check_indices_cuda_v1(
     Tensor& warning,
     const std::optional<Tensor>& weights,
     const std::optional<Tensor>& B_offsets,
-    const int64_t max_B) {
+    const int64_t max_B,
+    const std::optional<Tensor>& /*b_t_map*/,
+    const int32_t /*info_b_num_bits*/,
+    const uint32_t /*info_B_mask*/) {
   TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
       rows_per_table, indices, offsets, warning, weights, B_offsets);
   TENSOR_NDIM_EQUALS(rows_per_table, 1);

--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -826,6 +826,9 @@ def bounds_check_indices_abstract(
     per_sample_weights: Optional[torch.Tensor] = None,
     B_offsets: Optional[torch.Tensor] = None,
     max_B: Optional[SymInt] = None,
+    b_t_map: Optional[torch.Tensor] = None,
+    info_B_num_bits: int = -1,
+    info_B_mask: int = -1,
 ) -> None:
     """
     This meta function is used to fake the bounds checking

--- a/fbgemm_gpu/src/split_embeddings_utils/split_embeddings_utils.cpp
+++ b/fbgemm_gpu/src/split_embeddings_utils/split_embeddings_utils.cpp
@@ -33,6 +33,11 @@ generate_vbe_metadata_meta(
   return {row_output_offsets, b_t_map};
 }
 
+std::tuple<int64_t, int64_t>
+get_infos_metadata_meta(Tensor /*unused*/, int64_t /*B*/, int64_t /*T*/) {
+  return {-1, -1};
+}
+
 } // namespace
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
@@ -43,4 +48,5 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 
 TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
   m.impl("generate_vbe_metadata", &generate_vbe_metadata_meta);
+  m.impl("get_infos_metadata", &get_infos_metadata);
 }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/475

Instead of over launching thread blocks, use `b_t_map` to launch only
necessary thread blocks to increase occupancy for the VBE case

Note that `b_t_map` is necessary for the TBE look for the VBE case. It
is generated during the TBE forward pass.  In this diff, we call
`generate_vbe_metdata` twice (before bounds check and before forward
look up).  These two calls can be fused into one.  We will clean this
up in the subsequent diffs.

Differential Revision: D65735342


