### PR TITLE
Fix type-safety of `torch.nn.Module` instances

### DIFF
--- a/fbgemm_gpu/bench/bench_utils.py
+++ b/fbgemm_gpu/bench/bench_utils.py
@@ -496,6 +496,7 @@ def fill_random_scale_bias(
     weights_precision: SparseType,
 ) -> None:
     for t in range(T):
+        # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
         (weights, scale_shift) = emb.split_embedding_weights()[t]
         if scale_shift is not None:
             (E, R) = scale_shift.shape

--- a/fbgemm_gpu/test/tbe/cache/cache_overflow_test.py
+++ b/fbgemm_gpu/test/tbe/cache/cache_overflow_test.py
@@ -81,6 +81,7 @@ class CacheOverflowTest(unittest.TestCase):
         lxu_cache_locations = to_device(lxu_cache_locations, use_cpu=False)
 
         # Does prefetch into the cache
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         cc.lxu_cache_weights[cache_idx] = cc_ref.weights_dev.view(-1, D)[0]
 
         # Mimic cache prefetching behavior

--- a/fbgemm_gpu/test/tbe/cache/cache_test.py
+++ b/fbgemm_gpu/test/tbe/cache/cache_test.py
@@ -264,6 +264,8 @@ class CacheTest(unittest.TestCase):
             .cuda()
         )
         torch.cuda.synchronize()  # make sure TBEs and inputs are ready
+        # pyre-fixme[6]: For 1st argument expected `Tensor` but got `Union[bool,
+        #  Tensor]`.
         self.assertTrue(torch.all(cc.lxu_cache_locking_counter == 0))
 
         cur_stream: torch.cuda.Stream = torch.cuda.current_stream()
@@ -335,6 +337,8 @@ class CacheTest(unittest.TestCase):
             )
 
         assert_cache(output, output_ref, stochastic_rounding)
+        # pyre-fixme[6]: For 1st argument expected `Tensor` but got `Union[bool,
+        #  Tensor]`.
         self.assertTrue(torch.all(cc.lxu_cache_locking_counter == 0))
 
         if prefetch_stream:

--- a/fbgemm_gpu/test/tbe/inference/nbit_split_embeddings_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_split_embeddings_test.py
@@ -308,9 +308,13 @@ class NBitSplitEmbeddingsTest(unittest.TestCase):
             # cache status; we use the exact same logic, but still assigning ways in a associative cache can be
             # arbitrary. We compare sum along ways in each set, instead of expecting exact tensor match.
             cache_weights_ref = torch.reshape(
+                # pyre-fixme[6]: For 1st argument expected `Tensor` but got
+                #  `Union[Tensor, Module]`.
                 cc_ref.lxu_cache_weights,
                 [-1, associativity],
             )
+            # pyre-fixme[6]: For 1st argument expected `Tensor` but got
+            #  `Union[Tensor, Module]`.
             cache_weights = torch.reshape(cc.lxu_cache_weights, [-1, associativity])
             torch.testing.assert_close(
                 torch.sum(cache_weights_ref, 1),
@@ -318,16 +322,26 @@ class NBitSplitEmbeddingsTest(unittest.TestCase):
                 equal_nan=True,
             )
             torch.testing.assert_close(
+                # pyre-fixme[6]: For 1st argument expected `Tensor` but got
+                #  `Union[Tensor, Module]`.
                 torch.sum(cc.lxu_cache_state, 1),
+                # pyre-fixme[6]: For 1st argument expected `Tensor` but got
+                #  `Union[Tensor, Module]`.
                 torch.sum(cc_ref.lxu_cache_state, 1),
                 equal_nan=True,
             )
             # lxu_state can be different as time_stamp values can be different.
             # we check the entries with max value.
+            # pyre-fixme[6]: For 1st argument expected `Tensor` but got
+            #  `Union[Tensor, Module]`.
             max_timestamp_ref = torch.max(cc_ref.lxu_state)
+            # pyre-fixme[6]: For 1st argument expected `Tensor` but got
+            #  `Union[Tensor, Module]`.
             max_timestamp_uvm_caching = torch.max(cc.lxu_state)
             x = cc_ref.lxu_state == max_timestamp_ref
             y = cc.lxu_state == max_timestamp_uvm_caching
+            # pyre-fixme[6]: For 1st argument expected `Tensor` but got `Union[bool,
+            #  Tensor]`.
             torch.testing.assert_close(torch.sum(x, 1), torch.sum(y, 1))
 
             # int_nbit_split_embedding_uvm_caching_codegen_lookup_function for UVM.

--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_global_weight_decay_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_global_weight_decay_test.py
@@ -336,6 +336,8 @@ def execute_global_weight_decay(  # noqa C901
                     T,
                     Bs,
                     tbe_ref,
+                    # pyre-fixme[6]: For 4th argument expected `Tensor` but got
+                    #  `Union[Tensor, Module]`.
                     tbe.prev_iter_dev,
                     i,
                     indices,
@@ -365,7 +367,11 @@ def execute_global_weight_decay(  # noqa C901
             # compare weights
             output_ref.backward(grad_ref)
             compare_output(
+                # pyre-fixme[6]: For 1st argument expected `Tensor` but got
+                #  `Union[Tensor, Module]`.
                 tbe_ref.weights_dev,
+                # pyre-fixme[6]: For 2nd argument expected `Tensor` but got
+                #  `Union[Tensor, Module]`.
                 tbe.weights_dev,
                 is_fp32,
             )

--- a/fbgemm_gpu/test/tbe/training/backward_none_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_none_test.py
@@ -370,9 +370,15 @@ class BackwardNoneTest(unittest.TestCase):
         fc2.backward(goc)
 
         if optimizer is not None:
+            # pyre-fixme[6]: For 1st argument expected `Parameter` but got
+            #  `Union[Tensor, Module]`.
             params = SplitEmbeddingOptimizerParams(weights_dev=cc.weights_dev)
             embedding_args = SplitEmbeddingArgs(
+                # pyre-fixme[6]: For 1st argument expected `Tensor` but got
+                #  `Union[Tensor, Module]`.
                 weights_placements=cc.weights_placements,
+                # pyre-fixme[6]: For 2nd argument expected `Tensor` but got
+                #  `Union[Tensor, Module]`.
                 weights_offsets=cc.weights_offsets,
                 max_D=cc.max_D,
             )
@@ -403,6 +409,8 @@ class BackwardNoneTest(unittest.TestCase):
                 ref_grad.half() if weights_precision == SparseType.FP16 else ref_grad
             )
         else:
+            # pyre-fixme[16]: Item `None` of `None | Tensor | Module` has no
+            #  attribute `_indices`.
             indices = cc.weights_dev.grad._indices().flatten()
             # Select only the part in the table that is updated
             test_tensor = torch.index_select(cc.weights_dev.view(-1, D), 0, indices)


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/476

X-link: https://github.com/pytorch/torchrec/pull/2562

As laid out in https://github.com/pytorch/pytorch/issues/81462#issuecomment-1838731223 the change in https://github.com/pytorch/pytorch/pull/104321 was not necessary and largely destroys the type-safety of `torch.nn.Module` instances.

As far as I can see, the underlying issue of https://github.com/pytorch/pytorch/issues/81462 in `torch.nn.parallel.DistributedDataParallel` has been fixed in the meantime by actually typing `register_comm_hook` correctly.

The proper solution to issues like https://github.com/pytorch/pytorch/issues/81462 is to give the underlying field/method a proper type annotation, then there should be no need to go for a "type system disabling `__getattr__`".

(I'll probably be offline for a while, not able to react here...)

cc H-Huang awgu kwen2501 wanchaol fegin fduwjj wz337 wconstab d4l3k c-p-i-o voznesenskym penguinwu EikanWang jgong5 Guobing-Chen XiaobingSuper zhuhaozhe blzheng wenzhe-nrv jiayisunx ipiszy yf225 chenyang78 kadeng muchulee8 ColinPeppler amjames desertfire chauhang aakhundov avikchaudhuri gmagogsfm zhxchen17 tugsbayasgalan angelayi suo ydwu4 XilunWu rec mrshenli pritamdamania87 zhaojuanmao satgera rohan-varma gqchen aazzolini osalpekar jiayisuse tianyu-l kiukchung lucasllc

X-link: https://github.com/pytorch/pytorch/pull/115074

Reviewed By: aorenste, larryliu0820

Differential Revision: D52890934

Pulled By: ezyang


