### PR TITLE
Improve bounds_check_indices for VBE

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/config/feature_list.py
+++ b/fbgemm_gpu/fbgemm_gpu/config/feature_list.py
@@ -51,6 +51,9 @@ class FeatureGateName(Enum):
     # Enable Ensemble Rowwise Adagrad (D60189486 stack)
     TBE_ENSEMBLE_ROWWISE_ADAGRAD = auto()
 
+    # Enable bounds_check_indices_v2
+    BOUNDS_CHECK_INDICES_V2 = auto()
+
     def is_enabled(self) -> bool:
         return FeatureGate.is_enabled(self)
 


### PR DESCRIPTION
Summary:
Instead of over launching thread blocks, use `b_t_map` to launch only
necessary thread blocks to increase occupancy for the VBE case

Note that `b_t_map` is necessary for the TBE look for the VBE case. It
is generated during the TBE forward pass.  In this diff, we call
`generate_vbe_metdata` twice (before bounds check and before forward
look up).  These two calls can be fused into one.  We will clean this
up in the subsequent diffs.

Differential Revision: D66084041


