### PR TITLE
make torch._check() more informational

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/quantize_comm.py
+++ b/fbgemm_gpu/fbgemm_gpu/quantize_comm.py
@@ -221,7 +221,10 @@ class QuantizedCommCodec:
             self._comm_precision == SparseType.FP8 and self._row_dim > 0
         ):
             ctx = none_throws(ctx)
-            torch._check(input_len % ctx.row_dim == 0)
+            torch._check(
+                input_len % ctx.row_dim == 0,
+                lambda: "input_len  {input_len} is not a multiple of row dim {ctx.row_dim}",
+            )
             assert input_len % ctx.row_dim == 0, (
                 f"input_len {input_len} is not a multiple of row dim {ctx.row_dim} "
                 "Please check your batch size (power of 2 batch size is recommended)"


### PR DESCRIPTION
Summary:
> [rank14]:   File "<torch_package_0>.torchrec/distributed/comm_ops.py", line 1530, in <listcomp>
[rank14]:     codecs.forward.calc_quantized_size(
[rank14]:   File "<torch_package_0>.fbgemm_gpu/quantize_comm.py", line 224, in calc_quantized_size
[rank14]:     torch._check(input_len % ctx.row_dim == 0)
[rank14]:   File "/packages/lex_ig_o3_package/workflow-inplace#link-tree/torch/__init__.py", line 1617, in _check
[rank14]:     _check_with(RuntimeError, cond, message)
[rank14]:   File "/packages/lex_ig_o3_package/workflow-inplace#link-tree/torch/__init__.py", line 1599, in _check_with
[rank14]:     raise error_type(message_evaluated)
[rank14]: RuntimeError: Expected cond to be True, but got False. (Could this error message be improved? If so, please report an enhancement request to PyTorch.)


Based on above the error message is not that useful. Adding the message in torch._check() will help.

Differential Revision: D66106690


