### PR TITLE
Print the node infos when CUDA p2p init fails

### DIFF
--- a/fbgemm_gpu/src/merge_pooled_embedding_ops/merge_pooled_embedding_ops_gpu.cpp
+++ b/fbgemm_gpu/src/merge_pooled_embedding_ops/merge_pooled_embedding_ops_gpu.cpp
@@ -620,7 +620,12 @@ void init_p2p_access() {
     for (const auto i : c10::irange(at::cuda::getNumGPUs())) {
       for (const auto j : c10::irange(at::cuda::getNumGPUs())) {
         if (i != j) {
-          AT_ASSERT(at::cuda::get_p2p_access(i, j));
+          TORCH_INTERNAL_ASSERT(
+              at::cuda::get_p2p_access(i, j),
+              "Failed to init p2p access for node ",
+              i,
+              ",",
+              j);
         }
       }
     }


### PR DESCRIPTION
Summary: When debugging IG ESR, we try to run the model on the zion4s, however, we don't have p2p for all the cards on zion4s. So improving the error message to ensure the problem is easy to understand.

Differential Revision: D66110017


