### PR TITLE
Register jagged_to_padded_dense to CompositeImplicitAutograd

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_autograd.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_autograd.cpp
@@ -955,8 +955,6 @@ std::tuple<Tensor, Tensor> jagged_slice(
 } // namespace fbgemm_gpu
 
 TORCH_LIBRARY_IMPL(fbgemm, Autograd, m) {
-  m.impl(
-      "jagged_to_padded_dense", TORCH_FN(fbgemm_gpu::jagged_to_padded_dense));
   m.impl("jagged_2d_to_dense", TORCH_FN(fbgemm_gpu::jagged_2d_to_dense));
   m.impl("jagged_1d_to_dense", TORCH_FN(fbgemm_gpu::jagged_1d_to_dense));
   m.impl(
@@ -980,4 +978,6 @@ TORCH_LIBRARY_IMPL(fbgemm, Autograd, m) {
 TORCH_LIBRARY_IMPL(fbgemm, CompositeImplicitAutograd, m) {
   m.impl("jagged_index_select", TORCH_FN(fbgemm_gpu::jagged_index_select_2d));
   m.impl("dense_to_jagged", TORCH_FN(fbgemm_gpu::dense_to_jagged));
+  m.impl(
+      "jagged_to_padded_dense", TORCH_FN(fbgemm_gpu::jagged_to_padded_dense));
 }


### PR DESCRIPTION
Summary:
Notebook: https://fburl.com/anp/5pf89vr7
context: according to summary of D64491489 `jagged_to_padded_dense is not decomposing` to `fbgemm.jagged_to_padded_dense_forward.default` because in inference mode Autograd is disabled and we need to register the op with CompositeImplicitAutograd

Reviewed By: StellarrZ

Differential Revision: D66205924


