### PR TITLE
Make the scale match the shape of quantized value with N-D tensors

### DIFF
--- a/fbgemm_gpu/experimental/gemm/test/fp8_gemm_test.py
+++ b/fbgemm_gpu/experimental/gemm/test/fp8_gemm_test.py
@@ -66,6 +66,9 @@ class TestFp8Matmul(unittest.TestCase):
                 # Undo scaling.
                 a_torch = a_fp8.to(torch.bfloat16)
                 broadcast_shape = list(a_torch.shape[:-1]) + [-1]
+
+                assert a_scale.shape == a_torch.shape[:-1]
+
                 a_torch *= a_scale.view(broadcast_shape)
 
                 self.assertTrue(


### PR DESCRIPTION
Summary:
It will be used by the FP8 quantization of Q, which is a 3-D tensors.

With it, we don't need a special reshape of the scale outside the kernel call

Differential Revision: D66196131


