### PR TITLE
group gemm w/o padding

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped.cu
@@ -10,6 +10,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <cutlass/util/device_memory.h>
 #include <cutlass/util/packed_stride.hpp>
+#include <torch/script.h>
 
 // clang-format off
 // The fixed ordering of the headers is required for CUTLASS 3.2+
@@ -330,6 +331,10 @@ at::Tensor bf16bf16bf16_grouped_impl(
   int numBlocks = 1;
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   int64_t output_offset = 0;
+
+  if (zero_start_index_M.has_value() == true) {
+    TORCH_CHECK(zero_start_index_M.value().dtype() == torch::kInt32);
+  }
 
   // Set arguments
   for (int i = 0; i < problem_count; ++i) {


### PR DESCRIPTION
Summary:
Just some scaffolding code for group gemm. The idea is that: 
* for router score, we'll move the non-zero to the left side, and calculate the indices and the number of non-zeros for each local expert
* group gemm input (needs more discussion): 
    * input: 3D tensor [local_expert, tokens, D]
    * input: router_nonzeros tensor - on the M dimension, how many of them needs to be calculated
    * output: We need pad 0 to those 0 entries to make it work with cudagraph.

We only support bf16 grouped gemm for now. FP8 grouped gemm only supports tensor-wise scaling and rowwise scaling has some limitation in cutlass that requires some further work.

Differential Revision: D65260109


