### PR TITLE
Fix PT2 compliant opcheck tests

### DIFF
--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_global_weight_decay_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_global_weight_decay_test.py
@@ -63,18 +63,6 @@ test_st: Dict[str, Any] = {
     "gwd_lower_bound": st.sampled_from([0, 0.01, 0.001]),
 }
 
-additional_decorators.update(
-    {
-        # learning rate tensor needs to be on CPU to avoid D->H sync point since it will be used as float in the kernel
-        # this fails fake_tensor test as the test expects all tensors to be on the same device
-        "test_pt2_compliant_tag_fbgemm_split_embedding_codegen_lookup_rowwise_adagrad_function": [
-            unittest.skip(
-                "Operator failed on FakeTensor test since learning rate tensor is always on CPU regardless of other tensors"
-            ),
-        ]
-    }
-)
-
 
 def compare_output(
     output_ref: torch.Tensor,

--- a/fbgemm_gpu/test/test_utils.py
+++ b/fbgemm_gpu/test/test_utils.py
@@ -34,7 +34,14 @@ additional_decorators: Dict[str, List[Callable]] = {
     # fake_tensor test is added in failures_dict but failing fake_tensor test still cause pt2_compliant tag test to fail
     "test_pt2_compliant_tag_fbgemm_split_embedding_codegen_lookup_rowwise_adagrad_function_pt2": [
         unittest.skip("Operator failed on pt2 compliant tag"),
-    ]
+    ],
+    # learning rate tensor needs to be on CPU to avoid D->H sync point since it will be used as float in the kernel
+    # this fails fake_tensor test as the test expects all tensors to be on the same device
+    "test_pt2_compliant_tag_fbgemm_split_embedding_codegen_lookup_rowwise_adagrad_function": [
+        unittest.skip(
+            "Operator failed on FakeTensor test since learning rate tensor is always on CPU regardless of other tensors"
+        ),
+    ],
 }
 
 # Used for `@unittest.skipIf`


### PR DESCRIPTION
Summary:
Add decorator to skip PT2 compliant opcheck tests.

```
AssertionError: op 'fbgemm::split_embedding_codegen_lookup_rowwise_adagrad_function' was tagged with torch.Tag.pt2_compliant_tag but it failed some of the generated opcheck tests (['BackwardAdagradGlobalWeightDecay.test_faketensor__test_backward_adagrad_global_weight_decay', 
```
This is due to faketensor test being added to the failure_dict.

Faketensor tests fail because it expect all tensors to be on the same device, whereas we set learning_rate_tensor to be on CPU to avoid D->H sync as it will be converted to float for the kernel.

Reviewed By: q10

Differential Revision: D66346179


