### PR TITLE
Fix learning rate as tensor for PT2 compile

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
@@ -1085,7 +1085,8 @@ Tensor {{ bwd_mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function(
     // This interface (V1) still accepts learning rate as float for backward compatibility, 
     // We convert learning rate to tensor here to work with the backend
     // The unified PT2 interface already accepts learning rate as tensor.
-    const auto learning_rate_tensor = at::tensor({learning_rate}, at::TensorOptions().dtype(at::kFloat).device(at::kCPU));
+    auto learning_rate_tensor = at::empty({1}, at::TensorOptions().dtype(at::kFloat).device(at::kCPU));
+    learning_rate_tensor.fill_(learning_rate);
     {%- endif %}
 
     {%- if not dense %}

--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_global_weight_decay_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_global_weight_decay_test.py
@@ -63,18 +63,6 @@ test_st: Dict[str, Any] = {
     "gwd_lower_bound": st.sampled_from([0, 0.01, 0.001]),
 }
 
-additional_decorators.update(
-    {
-        # learning rate tensor needs to be on CPU to avoid D->H sync point since it will be used as float in the kernel
-        # this fails fake_tensor test as the test expects all tensors to be on the same device
-        "test_pt2_compliant_tag_fbgemm_split_embedding_codegen_lookup_rowwise_adagrad_function": [
-            unittest.skip(
-                "Operator failed on FakeTensor test since learning rate tensor is always on CPU regardless of other tensors"
-            ),
-        ]
-    }
-)
-
 
 def compare_output(
     output_ref: torch.Tensor,

--- a/fbgemm_gpu/test/test_utils.py
+++ b/fbgemm_gpu/test/test_utils.py
@@ -34,7 +34,14 @@ additional_decorators: Dict[str, List[Callable]] = {
     # fake_tensor test is added in failures_dict but failing fake_tensor test still cause pt2_compliant tag test to fail
     "test_pt2_compliant_tag_fbgemm_split_embedding_codegen_lookup_rowwise_adagrad_function_pt2": [
         unittest.skip("Operator failed on pt2 compliant tag"),
-    ]
+    ],
+    # learning rate tensor needs to be on CPU to avoid D->H sync point since it will be used as float in the kernel
+    # this fails fake_tensor test as the test expects all tensors to be on the same device
+    "test_pt2_compliant_tag_fbgemm_split_embedding_codegen_lookup_rowwise_adagrad_function": [
+        unittest.skip(
+            "Operator failed on FakeTensor test since learning rate tensor is always on CPU regardless of other tensors"
+        ),
+    ],
 }
 
 # Used for `@unittest.skipIf`


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/495

Fix pt2 compile
```
Failed running call_function fbgemm.split_embedding_codegen_lookup_rowwise_adagrad_function(*(), **{'placeholder_autograd_tensor': Parameter(FakeTensor(..., device='cuda:1', size=(0,), requires_grad=True)), 'dev_weights': FakeTensor(..., }):
The tensor has a non-zero number of elements, but its data is not allocated yet.
If you're using torch.compile/export/fx, it is likely that we are erroneously tracing into a custom kernel. To fix this, please wrap the custom kernel into an opaque custom op. Please see the following for details: https://pytorch.org/tutorials/advanced/custom_ops_landing_page.html
If you're using Caffe2, Caffe2 uses a lazy allocation, so you will need to call mutable_data() or raw_mutable_data() to actually allocate memory.
Exception raised from data_ptr_impl_impl at fbcode/caffe2/c10/core/TensorImpl.h:1595 (most recent call first):
```

Reviewed By: Microve

Differential Revision: D66346438


