### PR TITLE
[fbgemm_gpu] Modularize CMake Build [3/N]

### DIFF
--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -151,7 +151,10 @@ if(USE_ROCM)
     ${CMAKE_CURRENT_SOURCE_DIR}/experimental/gen_ai)
 
   # HIPify all .CU and .CUH sources under the current directory (`/fbgemm_gpu`)
-  # .H sources are not automatically HIPified, so they need #ifdef USE_ROCM guards
+  #
+  # Note that .H sources are not automatically HIPified, so if they reference
+  # CUDA-specific code, e.g. `#include <c10/cuda/CUDAStream.h>`, they will need
+  # to be updated with `#ifdef USE_ROCM` guards.
   hipify(
     CUDA_SOURCE_DIR
       ${PROJECT_SOURCE_DIR}

--- a/fbgemm_gpu/experimental/example/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/example/CMakeLists.txt
@@ -24,7 +24,9 @@ set(experimental_example_python_source_files
 
 gpu_cpp_library(
     PREFIX
-        fbgemm_gpu_experimental_example
+        fbgemm_gpu_experimental_example_py
+    TYPE
+        MODULE
     INCLUDE_DIRS
         ${fbgemm_sources_include_directories}
     GPU_SRCS

--- a/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
@@ -52,7 +52,9 @@ file(GLOB_RECURSE experimental_gen_ai_python_source_files
 
 gpu_cpp_library(
   PREFIX
-    fbgemm_gpu_experimental_gen_ai
+    fbgemm_gpu_experimental_gen_ai_py
+  TYPE
+    MODULE
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
     ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize


### PR DESCRIPTION
- Remove duplicated CMake instructions now that `gpu_cpp_library()` is in place
- Add support for building using target dependencies in `gpu_cpp_library()`