### PR TITLE
use sym int in quantize.cpp for f8f8bf16_rowwise_meta

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -295,9 +295,9 @@ at::Tensor f8f8bf16_rowwise_meta(
     std::optional<at::Tensor> /* bias = c10::nullopt */,
     bool /* use_fast_accum = true */,
     std::optional<at::Tensor> /* output = c10::nullopt */) {
-  int M = XQ.size(0);
-  int N = WQ.size(0);
-  auto Y = at::empty({M, N}, XQ.options().dtype(at::kBFloat16));
+  const at::SymInt M = XQ.sym_size(0);
+  const at::SymInt N = WQ.sym_size(0);
+  auto Y = at::empty_symint({M, N}, XQ.options().dtype(at::kBFloat16));
   return Y;
 }
 


### PR DESCRIPTION
Summary:
We want to use these kernels for AOT inductor, with dynamic support. 

We would encounter batch size specialization errors
```
  - Not all values of batch_size = L['getitem_4'].size()[0] in the specified range batch_size <= 2048 are valid because batch_size was inferred to be a constant (2048).
```

Differential Revision: D66382346


