### PR TITLE
Remove unused-variable in deeplearning/fbgemm/fbgemm_gpu/fb/test/preproc_test_reference.hpp +3

### DIFF
--- a/fbgemm_gpu/src/embedding_inplace_ops/embedding_inplace_update_test.cpp
+++ b/fbgemm_gpu/src/embedding_inplace_ops/embedding_inplace_update_test.cpp
@@ -65,7 +65,7 @@ void test_embedding_inplace_update() {
     }
     int n = folly::Random::rand32() % 10 + 5;
     std::set<int32_t> rows;
-    for (const auto j : c10::irange(n)) {
+    for ([[maybe_unused]] const auto j : c10::irange(n)) {
       rows.insert(folly::Random::rand32() % total_rows);
     }
     std::string update_row_idx_str = "";


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/500

LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

#buildsonlynotests - Builds are sufficient

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D66330353


