### PR TITLE
Support config based bound check version via extended modes

### DIFF
--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_host.cpp
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_host.cpp
@@ -58,9 +58,13 @@ void bounds_check_indices_cuda(
     const int64_t max_B,
     const std::optional<Tensor>& b_t_map,
     const int64_t info_B_num_bits,
-    const int64_t info_B_mask) {
-  const static bool use_v2 = fbgemm_gpu::config::is_feature_enabled(
-      fbgemm_gpu::config::FeatureGateName::BOUNDS_CHECK_INDICES_V2);
+    const int64_t info_B_mask,
+    const int8_t bounds_check_version) {
+  TORCH_CHECK(bounds_check_version == 1 || bounds_check_version == 2);
+  const static bool use_v2 =
+      fbgemm_gpu::config::is_feature_enabled(
+          fbgemm_gpu::config::FeatureGateName::BOUNDS_CHECK_INDICES_V2) ||
+      bounds_check_version == 2;
   const auto bounds_check_indices_fn =
       use_v2 ? _bounds_check_indices_cuda_v2 : _bounds_check_indices_cuda_v1;
   bounds_check_indices_fn(

--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_host_cpu.cpp
@@ -51,7 +51,8 @@ void bounds_check_indices_cpu(
     const int64_t max_B,
     const std::optional<Tensor>& /*b_t_map*/,
     const int64_t /*info_B_num_bits*/,
-    const int64_t /*info_B_mask*/) {
+    const int64_t /*info_B_mask*/,
+    const int8_t /*bounds_check_version*/) {
   if (offsets.scalar_type() != indices.scalar_type()) {
     offsets = offsets.toType(indices.scalar_type());
   }
@@ -204,7 +205,8 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
       "    SymInt max_B=-1, "
       "    Tensor? b_t_map=None, "
       "    int info_B_num_bits=-1, "
-      "    int info_B_mask=-1"
+      "    int info_B_mask=-1, "
+      "    int bounds_check_version=1"
       ") -> ()",
       {PT2_COMPLIANT_TAG});
   DISPATCH_TO_CPU("bounds_check_indices", bounds_check_indices_cpu);
@@ -228,7 +230,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "    SymInt max_B=-1, "
       "    Tensor? b_t_map=None, "
       "    int info_B_num_bits=-1, "
-      "    int info_B_mask=-1"
+      "    int info_B_mask=-1, "
+      "    int bounds_check_version=1"
       ") -> ()",
       {PT2_COMPLIANT_TAG});
   DISPATCH_TO_CPU("bounds_check_indices", bounds_check_indices_cpu);


### PR DESCRIPTION
Summary:
1/2 of enabling bounds check V2 for APS FM, following APS principles, we would like to surface the V2 switch up to the APS user config, hence in this diff we are extending existing BoundsCheckMode with V2 counterparts, and pass the version flag into the operator.

this diff implemented backend switch between v1/v2 with compatibility of JK for non-APS model usages, we will also keep JK controled switch for future massive rollout, this change is only targeting APS based models where explicit control is preferred.


More context can be found in https://docs.google.com/document/d/1hEhk2isMOXuWPyQJxiOzNq0ivfECsZUT7kT_IBmou_I/edit?tab=t.0#heading=h.q89rllowo3eb

Differential Revision: D66512088


