### PR TITLE
Remove torch/scripth.h header and use at::kInt

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped.cu
@@ -10,7 +10,6 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <cutlass/util/device_memory.h>
 #include <cutlass/util/packed_stride.hpp>
-#include <torch/script.h>
 
 // clang-format off
 // The fixed ordering of the headers is required for CUTLASS 3.2+
@@ -332,9 +331,9 @@ at::Tensor bf16bf16bf16_grouped_impl(
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   int64_t output_offset = 0;
 
-  if (zero_start_index_M.has_value() == true) {
-    TORCH_CHECK(zero_start_index_M.value().dtype() == torch::kInt32);
-  }
+  TORCH_CHECK(
+      !zero_start_index_M.has_value() ||
+      zero_start_index_M->dtype() == at::kInt);
 
   // Set arguments
   for (int i = 0; i < problem_count; ++i) {


### PR DESCRIPTION
Summary: It seems this header torch/script.h is causing trouble; so just use the at::kInt to avoid torch data types.

Reviewed By: malfet

Differential Revision: D66516739


