### PR TITLE
[fbgemm_gpu] Update `TORCH_CUDA_ARCH_LIST` for Nova builds with CUDA 12.6

### DIFF
--- a/.github/scripts/nova_dir.bash
+++ b/.github/scripts/nova_dir.bash
@@ -15,6 +15,22 @@ export BUILD_FROM_NOVA=1
 
 ## Overwrite existing ENV VAR in Nova
 if [[ "$CONDA_ENV" != "" ]]; then export CONDA_RUN="conda run --no-capture-output -p ${CONDA_ENV}" && echo "$CONDA_RUN"; fi
-if [[ "$CU_VERSION" == "cu118" ]]; then export TORCH_CUDA_ARCH_LIST='7.0;8.0' && echo "$TORCH_CUDA_ARCH_LIST"; fi
-if [[ "$CU_VERSION" == "cu121" ]]; then export TORCH_CUDA_ARCH_LIST='7.0;8.0;9.0;9.0a' && echo "$TORCH_CUDA_ARCH_LIST"; fi
-if [[ "$CU_VERSION" == "cu124" ]]; then export TORCH_CUDA_ARCH_LIST='7.0;8.0;9.0;9.0a' && echo "$TORCH_CUDA_ARCH_LIST"; fi
+
+if  [[ "$CU_VERSION" == "cu121" ]] ||
+    [[ "$CU_VERSION" == "cu124" ]] ||
+    [[ "$CU_VERSION" == "cu126" ]]; then
+    export TORCH_CUDA_ARCH_LIST="7.0;8.0;9.0;9.0a"
+    echo "Set TORCH_CUDA_ARCH_LIST to: ${TORCH_CUDA_ARCH_LIST}"
+
+elif [[ "$CU_VERSION" == "cu118" ]]; then
+    export TORCH_CUDA_ARCH_LIST="7.0;8.0;9.0"
+    echo "Set TORCH_CUDA_ARCH_LIST to: ${TORCH_CUDA_ARCH_LIST}"
+
+elif [[ "$CU_VERSION" == "cu"* ]]; then
+    echo "################################################################################"
+    echo "[NOVA] Currently building the CUDA variant, but the supplied CU_VERSION is"
+    echo "unknown or not supported in FBGEMM_GPU: ${CU_VERSION}"
+    echo ""
+    echo "Will default to the TORCH_CUDA_ARCH_LIST supplied by the environment!!!"
+    echo "################################################################################"
+fi

--- a/.github/scripts/utils_cuda.bash
+++ b/.github/scripts/utils_cuda.bash
@@ -171,12 +171,13 @@ install_cudnn () {
   local cuda_version_arr=(${cuda_version//./ })
   # Fetch the major and minor version to concat
   local cuda_concat_version="${cuda_version_arr[0]}${cuda_version_arr[1]}"
+  echo "[INSTALL] cuda_concat_version is determined to be: ${cuda_concat_version}"
 
   # Get the URL
   local cudnn_url="${cudnn_packages[$cuda_concat_version]}"
   if [ "$cudnn_url" == "" ]; then
     # Default to cuDNN for 11.8 if no CUDA version fits
-    echo "[INSTALL] Defaulting to cuDNN for CUDA 11.8"
+    echo "[INSTALL] Could not find cuDNN URL for the given cuda_concat_version ${cuda_concat_version}; defaulting to cuDNN for CUDA 11.8"
     cudnn_url="${cudnn_packages[118]}"
   fi
 


### PR DESCRIPTION
Update `TORCH_CUDA_ARCH_LIST` for Nova builds with CUDA 12.6

The issue shows up in the cryptic build error

```
error: identifier "__hfma2" is undefined
```

Solution based on https://github.com/turboderp/exllamav2/issues/380