### PR TITLE
Enable clang-tidy bugprone-argument-comment check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,9 @@
 # Get options for config files in parent directories,
 # but override them if there's a conflict.
 InheritParentConfig: true
+Checks: '
+bugprone-argument-comment,
+'
 CheckOptions:
  - key: facebook-cuda-safe-api-call-check.HandlerName
    # This is PyTorch's handler; you may need to define your own


### PR DESCRIPTION
Summary:
Enable the `bugprone-argument-comment` clang-tidy check. For code like `call(/*foo=*/...)` this checks that the comment matches the parameter name in the function declaration.

See also: https://clang.llvm.org/extra/clang-tidy/checks/bugprone/argument-comment.html

Reviewed By: r-barnes

Differential Revision: D66115072


