### PR TITLE
Remove setting total_cache_hash_size as buffer

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -13,6 +13,9 @@ import enum
 from dataclasses import dataclass
 from typing import List, NamedTuple
 
+import torch
+from torch import Tensor
+
 
 # Maximum number of times prefetch() can be called without
 # a corresponding forward() call
@@ -64,6 +67,14 @@ class BoundsCheckMode(enum.IntEnum):
     IGNORE = 2
     # No bounds checks.
     NONE = 3
+
+
+class EmbeddingSpecInfo(enum.IntEnum):
+    feature_names = 0
+    rows = 1
+    dims = 2
+    sparse_type = 3
+    embedding_location = 4
 
 
 RecordCacheMetrics: NamedTuple = NamedTuple(
@@ -134,3 +145,36 @@ def construct_cache_state(
 # breakage with Caffe2 module_factory because it will pull in numpy
 def round_up(a: int, b: int) -> int:
     return int((a + b - 1) // b) * b
+
+
+def tensor_to_device(tensor: torch.Tensor, device: torch.device) -> Tensor:
+    if tensor.device == torch.device("meta"):
+        return torch.empty_like(tensor, device=device)
+    return tensor.to(device)
+
+
+def get_new_embedding_location(
+    device: torch.device, cache_load_factor: float
+) -> EmbeddingLocation:
+    """
+    Based on the cache_load_factor and device, return the embedding location intended
+    for the TBE weights.
+    """
+    # Only support CPU and GPU device
+    assert device.type == "cpu" or device.type == "cuda"
+    if cache_load_factor < 0 or cache_load_factor > 1:
+        raise ValueError(
+            f"cache_load_factor must be between 0.0 and 1.0, got {cache_load_factor}"
+        )
+
+    if device.type == "cpu":
+        return EmbeddingLocation.HOST
+    # UVM only
+    elif cache_load_factor == 0:
+        return EmbeddingLocation.MANAGED
+    # HBM only
+    elif cache_load_factor == 1.0:
+        return EmbeddingLocation.DEVICE
+    # UVM caching
+    else:
+        return EmbeddingLocation.MANAGED_CACHING

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
@@ -1274,11 +1274,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 torch.zeros(1, dtype=torch.int64, device=self.current_device),
                 persistent=False,
             )
-            self.register_buffer(
-                "total_cache_hash_size",
-                torch.zeros(1, dtype=torch.int64, device=self.current_device),
-                persistent=False,
-            )
+            self.total_cache_hash_size = 0
             self.register_buffer(
                 "cache_index_table_map",
                 torch.zeros(1, dtype=torch.int64, device=self.current_device),
@@ -1564,10 +1560,6 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         ]
 
         self.max_D_cache: int = max(cached_dims) if len(cached_dims) > 0 else 0
-
-        # total_cache_hash_size is sometimes a buffer, sometimes an int
-        # deleting as we may modify the value in _apply_cache_state call
-        del self.total_cache_hash_size
 
         self._apply_cache_state(
             cache_state,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/526

total_cache_hash_size should always be an int, so removing where it's being registered as a buffer.


Setting it occasionally as a buffer can cause error if we are resetting the cache setting for an already-initialized TBE.

Had to change 1 unit test in TGIF, as the expected # of tensors/buffers per TBE is now reduced.

Differential Revision: D66673632


