### PR TITLE
Temporary disable nbit_forward_test on OSS rocm clang

### DIFF
--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -282,6 +282,10 @@ class NBitFowardTest(NBitFowardTestCommon):
                 equal_nan=True,
             )
 
+    @unittest.skipIf(
+        TEST_WITH_ROCM,
+        "This test is currently running into failing on rocm clang in OSS, and is being investigated.",
+    )
     @given(
         nbit_weights_ty=get_nbit_weights_ty(),
         use_array_for_index_remapping=st.booleans(),


### PR DESCRIPTION
Summary: as titled

Differential Revision: D66724476


