### PR TITLE
Support zero-size inputs in FP8 cuda quantize kernel

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cu
@@ -1091,7 +1091,6 @@ std::vector<at::Tensor> quantize_fp8_per_row(
     std::optional<at::Tensor> scale_ub, // scale upperbound
     std::optional<c10::ScalarType> output_dtype, // Quantization type
     bool stochastic_rounding) {
-  TORCH_CHECK(input.numel() != 0, "input should not be empty tensor");
   TORCH_CHECK(
       input.dim() >= 2,
       "Invalid dim. The dim of input should be greater than or equal to 2");
@@ -1129,6 +1128,11 @@ std::vector<at::Tensor> quantize_fp8_per_row(
       torch::dtype(torch::kFloat32)
           .device(torch::kCUDA, at::cuda::current_device())
           .requires_grad(false));
+
+  if (input.numel() == 0) {
+    return std::vector<at::Tensor>{quantized_input, scales};
+  }
+
   // Templatize implementation based on output type.
   if (quantization_type == torch_fp8_e4m3) {
     auto* const quantized_input_ptr =

--- a/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
@@ -1103,6 +1103,19 @@ class FP8Tests(unittest.TestCase):
                 block_scale[0],
             )
 
+    @unittest.skipIf(
+        torch.version.hip, "Skip on AMD: cuda quantize op is yet suported."
+    )
+    @given(
+        K=st.sampled_from([0, 128]),
+    )
+    def test_quantize_zero_input(self, K) -> None:
+        w = torch.randn(size=(0, K), dtype=torch.bfloat16, device="cuda")
+        w_scale_ref = torch.empty(size=(0,), dtype=torch.float32, device="cuda")
+        wq, w_scale = torch.ops.fbgemm.quantize_fp8_per_row(w)
+        torch.testing.assert_close(w.shape, wq.shape)
+        torch.testing.assert_close(w_scale.shape, w_scale_ref.shape)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
For MOE, if tokens are not routed (in dynamic case), we could have some experts running 0 tokens, found by Jason

This Diff supports zero-size inputs in FP8 cuda quantize kernel in this case

Differential Revision: D66727399


