### PR TITLE
Release Triton jagged tensor ops to OSS

### DIFF
--- a/.github/scripts/fbgemm_gpu_test.bash
+++ b/.github/scripts/fbgemm_gpu_test.bash
@@ -86,6 +86,7 @@ __configure_fbgemm_gpu_test_cpu () {
     ./sll/triton_sll_test.py
     ./sll/array_jagged_bmm_jagged_out_test.py
     ./sll/jagged_jagged_bmm_jagged_out_test.py
+    ./sll/jagged_flash_attention_basic_test.py
   )
 }
 

--- a/fbgemm_gpu/fbgemm_gpu/sll/triton_sll.py
+++ b/fbgemm_gpu/fbgemm_gpu/sll/triton_sll.py
@@ -44,6 +44,13 @@ def next_power_of_two(N: int) -> int:
         return 32
 
 
+def expect_contiguous(x: torch.Tensor) -> torch.Tensor:
+    if not x.is_contiguous():
+        return x.contiguous()
+    else:
+        return x
+
+
 # TODO add autotune to find best block size
 # add supergroup to optimize GPU cache
 @triton.jit
@@ -1402,8 +1409,8 @@ def jagged2_to_padded_dense(
     padding_value: value to use for padding
     return padded dense tensor of size [B, N, N]
     """
-    values = values.contiguous()
-    offsets = offsets.contiguous()
+    values = expect_contiguous(values)
+    offsets = expect_contiguous(offsets)
 
     return Jagged2ToPaddedDense.apply(values, offsets, max_length, padding_value)
 
@@ -1926,3 +1933,656 @@ def jagged_jagged_bmm_jagged_out(
         max_seq_len,
         allow_tf32,
     )
+
+
+@triton.jit
+def jagged_flash_attention_basic_kernel(
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    offset_ptr,
+    o_ptr,
+    lse_i_ptr,
+    stride_qm,
+    stride_qd,
+    stride_kd,
+    stride_kn,
+    stride_vn,
+    stride_vd,
+    stride_om,
+    stride_od,
+    max_seq_len,
+    D: tl.constexpr,
+    NEXT_D: tl.constexpr,
+    use_mask: tl.constexpr,
+    allow_tf32: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_D: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_batch = tl.program_id(axis=1)
+
+    begin = tl.load(offset_ptr + pid_batch)
+    end = tl.load(offset_ptr + pid_batch + 1)
+
+    seqlen = end - begin
+    seqlen = tl.minimum(seqlen, max_seq_len)
+
+    if pid_m * BLOCK_SIZE_M >= seqlen:
+        return
+
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_d = tl.arange(0, BLOCK_SIZE_D)
+    # Offset till next power of 2 for D
+    offs_nextd = tl.arange(0, NEXT_D)
+
+    acc = tl.zeros([BLOCK_SIZE_M, NEXT_D], dtype=tl.float32)
+
+    m_i = tl.zeros([BLOCK_SIZE_M], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([BLOCK_SIZE_M], dtype=tl.float32)
+    for j in range(0, seqlen, BLOCK_SIZE_N):
+        offs_n = tl.arange(0, BLOCK_SIZE_N) + j
+        q_ptrs = (
+            q_ptr
+            + (offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qd)
+            + begin * stride_qm
+        )
+
+        k_ptrs = (
+            k_ptr
+            + (offs_d[:, None] * stride_kd + offs_n[None, :] * stride_kn)
+            + begin * stride_kn
+        )
+
+        qk = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+        for d in range(0, D, BLOCK_SIZE_D):
+            updated_offset = d + offs_d
+            q = tl.load(
+                q_ptrs,
+                # pyre-fixme[16]: `int` has no attribute `__getitem__`.
+                mask=((updated_offset[None, :] < D) & (offs_m[:, None] < seqlen)),
+                other=0.0,
+            )
+            k = tl.load(
+                k_ptrs,
+                mask=((updated_offset[:, None] < D) & (offs_n[None, :] < seqlen)),
+                other=0.0,
+            )
+            qk += tl.dot(q, k, allow_tf32=allow_tf32)
+
+            q_ptrs += BLOCK_SIZE_D * stride_qd
+            k_ptrs += BLOCK_SIZE_D * stride_kd
+
+        m_ij = tl.maximum(tl.max(qk, axis=1), m_i)
+        # Add the correct mask here
+        mn_mask = (offs_m[:, None] < seqlen) & (offs_n[None, :] < seqlen)
+
+        p = tl.exp(qk - m_ij[:, None])
+        p = tl.where(mn_mask, p, 0.0)
+
+        l_ij = tl.sum(p, axis=1)
+        alpha = tl.exp(m_i - m_ij)
+
+        l_i = l_i * alpha + l_ij
+        acc = acc * alpha[:, None]
+
+        # Load V
+        v_ptrs = (
+            v_ptr
+            + (offs_nextd[None, :] * stride_vd + offs_n[:, None] * stride_vn)
+            + begin * stride_vn
+        )
+        v = tl.load(
+            v_ptrs,
+            mask=((offs_nextd[None, :] < D) & (offs_n[:, None] < seqlen)),
+            other=0.0,
+        )
+
+        p /= max_seq_len
+
+        if use_mask:
+            attn_mask = offs_m[:, None] - offs_n[None, :]
+            attn_mask = tl.where(mn_mask, attn_mask, 0.0)
+            attn_mask = tl.where(attn_mask > 0, 0.0, 1.0)
+            p = tl.where(attn_mask > 0, p, 0.0)
+
+        p = p.to(v_ptr.dtype.element_ty)
+        acc_j = tl.dot(p, v, allow_tf32=allow_tf32)
+        acc += acc_j
+        m_i = m_ij
+
+    lse_i = m_i + tl.math.log(l_i)
+    lse_i_offsets = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    lse_i_ptrs = lse_i_ptr + lse_i_offsets + begin
+
+    tl.store(lse_i_ptrs, lse_i, mask=lse_i_offsets < seqlen)
+
+    acc = acc / l_i[:, None]
+
+    # Store O
+    o_ptrs = o_ptr + (
+        offs_m[:, None] * stride_om
+        + offs_nextd[None, :] * stride_od
+        + begin * stride_om
+    )
+    o_mask = (offs_m[:, None] < seqlen) & (offs_nextd[None, :] < D)
+    tl.store(o_ptrs, acc, mask=o_mask)
+
+
+def jagged_flash_attention_basic_fwd(
+    jagged_Q,
+    jagged_K,
+    jagged_V,
+    offsets,
+    max_seq_len,
+    use_mask,
+    allow_tf32=False,
+):
+    assert jagged_Q.size(1) == jagged_K.size(0), "incompatible dimensions"
+
+    B = offsets.size(0) - 1
+    D = jagged_Q.size(1)
+
+    jagged_O = torch.zeros_like(jagged_Q)
+    lse = torch.empty((jagged_Q.size(0)), device=jagged_Q.device, dtype=jagged_Q.dtype)
+
+    BLOCK_SIZE_M = 32
+    BLOCK_SIZE_N = 32
+    BLOCK_SIZE_D = 32
+
+    grid = (triton.cdiv(max_seq_len, BLOCK_SIZE_M), B)
+
+    jagged_flash_attention_basic_kernel[grid](
+        jagged_Q,
+        jagged_K,
+        jagged_V,
+        offsets,
+        jagged_O,
+        lse,
+        jagged_Q.stride(0),
+        jagged_Q.stride(1),
+        jagged_K.stride(0),
+        jagged_K.stride(1),
+        jagged_V.stride(0),
+        jagged_V.stride(1),
+        jagged_O.stride(0),
+        jagged_O.stride(1),
+        max_seq_len,
+        D,
+        triton.next_power_of_2(D),
+        use_mask,
+        allow_tf32,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_D=BLOCK_SIZE_D,
+    )
+
+    return jagged_O, lse
+
+
+# Similar to fwd kernel, this one is using a grid of
+# (num_blocks_m, B) where num_blocks_m is seq_len / BLOCK_SIZE_M
+@triton.jit
+def _jagged_flash_attention_bwd_preprocess_basic_kernel(
+    o_ptr,
+    o_offset_ptr,
+    do_ptr,
+    delta_ptr,
+    stride_om,
+    stride_od,
+    max_seq_len,
+    D: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_D: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_batch = tl.program_id(axis=1)
+
+    begin_o = tl.load(o_offset_ptr + pid_batch)
+    end_o = tl.load(o_offset_ptr + pid_batch + 1)
+
+    M = end_o - begin_o
+    M = tl.minimum(M, max_seq_len)
+
+    offs_om = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_od = tl.arange(0, BLOCK_SIZE_D)
+
+    o_offsets = (
+        offs_om[:, None] * stride_om
+        + offs_od[None, :] * stride_od
+        + begin_o * stride_om
+    )
+    o_ptrs = o_ptr + o_offsets
+    do_ptrs = do_ptr + o_offsets
+    o_mask = (offs_om[:, None] < M) & (offs_od[None, :] < D)
+
+    # Load O
+    o = tl.load(o_ptrs, mask=o_mask)
+    do = tl.load(do_ptrs, mask=o_mask)
+
+    delta = tl.sum(o * do, axis=1)
+
+    tl.store(delta_ptr + begin_o + offs_om, delta, mask=offs_om < M)
+
+
+@triton.jit
+def _jagged_flash_attention_bwd_basic_kernel(
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    o_ptr,
+    offset_ptr,
+    dq_ptr,
+    dk_ptr,
+    dv_ptr,
+    do_ptr,
+    delta_ptr,
+    lse_ptr,
+    stride_qm,
+    stride_qd,
+    stride_kn,
+    stride_kd,
+    stride_vn,
+    stride_vd,
+    stride_om,
+    stride_od,
+    stride_dqm,
+    stride_dqd,
+    stride_dkn,
+    stride_dkd,
+    stride_dvn,
+    stride_dvd,
+    stride_dom,
+    stride_dod,
+    max_seq_len,
+    D: tl.constexpr,
+    use_mask: tl.constexpr,
+    allow_tf32: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_D: tl.constexpr,
+):
+    pid_batch = tl.program_id(axis=1)
+
+    begin = tl.load(offset_ptr + pid_batch)
+    end = tl.load(offset_ptr + pid_batch + 1)
+
+    M = tl.minimum(end - begin, max_seq_len)
+
+    pid_n = tl.program_id(axis=0)
+    offs_d = tl.arange(0, BLOCK_SIZE_D)
+
+    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    offs_m = tl.arange(0, BLOCK_SIZE_M)
+
+    q_ptrs = (
+        q_ptr
+        + begin * stride_qm
+        + (offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qd)
+    )
+
+    k_ptrs = (
+        k_ptr
+        + begin * stride_kn
+        + (offs_n[:, None] * stride_kn + offs_d[None, :] * stride_kd)
+    )
+
+    v_ptrs = (
+        v_ptr
+        + begin * stride_vn
+        + (offs_n[:, None] * stride_vn + offs_d[None, :] * stride_vd)
+    )
+
+    do_ptrs = (
+        do_ptr
+        + begin * stride_dom
+        + (offs_m[:, None] * stride_dom + offs_d[None, :] * stride_dod)
+    )
+
+    # Load K and V
+    k = tl.load(k_ptrs, mask=((offs_d[None, :] < D) & (offs_n[:, None] < M)))
+    v = tl.load(v_ptrs, mask=((offs_d[None, :] < D) & (offs_n[:, None] < M)))
+
+    # Initialize dv and dk
+    dv = tl.zeros([BLOCK_SIZE_N, BLOCK_SIZE_D], dtype=tl.float32)
+    dk = tl.zeros([BLOCK_SIZE_N, BLOCK_SIZE_D], dtype=tl.float32)
+
+    for begin_m in range(0, M, BLOCK_SIZE_M):
+        offs_m_temp = begin_m + offs_m
+
+        # Load Q
+        # pyre-fixme[16]: `int` has no attribute `__getitem__`.
+        q = tl.load(q_ptrs, mask=((offs_d[None, :] < D) & (offs_m_temp[:, None] < M)))
+        qk = tl.dot(q, tl.trans(k), allow_tf32=allow_tf32)
+
+        mn_mask = (offs_m_temp[:, None] < M) & (offs_n[None, :] < M)
+
+        # Load lse_i
+        lse_i = tl.load(lse_ptr + offs_m_temp + begin, mask=offs_m_temp < M)
+
+        p = tl.exp(qk - lse_i[:, None])
+        p = tl.where(mn_mask, p, 0.0)
+        p /= max_seq_len
+        p_masked = p
+
+        attn_mask = None
+        if use_mask:
+            attn_mask = offs_m_temp[:, None] - offs_n[None, :]
+            attn_mask = tl.where(mn_mask, attn_mask, 0.0)
+            attn_mask = tl.where(attn_mask > 0, 0.0, 1.0)
+            p_masked = tl.where(attn_mask > 0, p, 0.0)
+
+        p_masked = p_masked.to(do_ptr.dtype.element_ty)
+        do = tl.load(do_ptrs, mask=((offs_d[None, :] < D) & (offs_m_temp[:, None] < M)))
+        dv += tl.dot(tl.trans(p_masked), do, allow_tf32=allow_tf32)
+        dp = tl.dot(do, tl.trans(v), allow_tf32=allow_tf32)
+
+        # compute ds = p * (dp - delta[:, None])
+        Di = tl.load(delta_ptr + offs_m_temp + begin, mask=offs_m_temp < M)
+        dp_masked = dp
+        if use_mask:
+            dp_masked = tl.where(attn_mask > 0, dp, 0.0)
+
+        ds = p * (dp_masked - Di[:, None] * max_seq_len)
+
+        # compute dk = dot(ds.T, q)
+        ds = ds.to(q_ptr.dtype.element_ty)
+        dk += tl.dot(tl.trans(ds), q, allow_tf32=allow_tf32)
+
+        q_ptrs += BLOCK_SIZE_M * stride_qm
+        do_ptrs += BLOCK_SIZE_M * stride_dom
+
+    # store back dk and dv
+    dk_ptrs = (
+        dk_ptr
+        + begin * stride_dkn
+        + (offs_n[:, None] * stride_dkn + offs_d[None, :] * stride_dkd)
+    )
+
+    dv_ptrs = (
+        dv_ptr
+        + begin * stride_dvn
+        + (offs_n[:, None] * stride_dvn + offs_d[None, :] * stride_dvd)
+    )
+
+    tl.store(dk_ptrs, dk, mask=((offs_d[None, :] < D) & (offs_n[:, None] < M)))
+    tl.store(dv_ptrs, dv, mask=((offs_d[None, :] < D) & (offs_n[:, None] < M)))
+
+    start_m = tl.program_id(axis=0) * BLOCK_SIZE_N
+    offs_m_curr = start_m + tl.arange(0, BLOCK_SIZE_N)
+
+    dq_ptrs_curr = (
+        dq_ptr
+        + begin * stride_dqm
+        + (offs_m_curr[:, None] * stride_dqm + offs_d[None, :] * stride_dqd)
+    )
+
+    dq_curr = tl.zeros([BLOCK_SIZE_N, BLOCK_SIZE_D], dtype=tl.float32)
+
+    q_ptrs_curr = (
+        q_ptr
+        + begin * stride_qm
+        + (offs_m_curr[:, None] * stride_qm + offs_d[None, :] * stride_qd)
+    )
+
+    q_curr = tl.load(
+        q_ptrs_curr, mask=((offs_d[None, :] < D) & (offs_m_curr[:, None] < M))
+    )
+
+    # Load lse_i
+    lse_i_curr = tl.load(lse_ptr + offs_m_curr + begin, mask=offs_m_curr < M)
+
+    do_ptrs_curr = (
+        do_ptr
+        + begin * stride_dom
+        + (offs_m_curr[:, None] * stride_dom + offs_d[None, :] * stride_dod)
+    )
+
+    # Load do
+    do_curr = tl.load(
+        do_ptrs_curr, mask=((offs_d[None, :] < D) & (offs_m_curr[:, None] < M))
+    )
+    Di_curr = tl.load(delta_ptr + offs_m_curr + begin, mask=offs_m_curr < M)
+
+    # When computing dV, we want to compute [BLOCK_SIZE_N] rows of dV.
+    # Therefore, the loop's block size is BLOCK_SIZE_M instead of BLOCK_SIZE_N.
+    block_start = 0
+    while block_start < M:
+        offs_n_curr = block_start + tl.arange(0, BLOCK_SIZE_M)
+
+        k_ptrs_curr = (
+            k_ptr
+            + begin * stride_kn
+            + (offs_n_curr[:, None] * stride_kn + offs_d[None, :] * stride_kd)
+        )
+        v_ptrs_curr = (
+            v_ptr
+            + begin * stride_vn
+            + (offs_n_curr[:, None] * stride_vn + offs_d[None, :] * stride_vd)
+        )
+
+        k_curr = tl.load(
+            k_ptrs_curr, mask=((offs_d[None, :] < D) & (offs_n_curr[:, None] < M))
+        )
+        v_curr = tl.load(
+            v_ptrs_curr, mask=((offs_d[None, :] < D) & (offs_n_curr[:, None] < M))
+        )
+
+        qk_curr = tl.dot(q_curr, tl.trans(k_curr), allow_tf32=allow_tf32)
+        mn_mask_curr = (offs_m_curr[:, None] < M) & (offs_n_curr[None, :] < M)
+
+        p_curr = tl.exp(qk_curr - lse_i_curr[:, None])
+        p_curr = tl.where(mn_mask_curr, p_curr, 0.0)
+        p_curr /= max_seq_len
+
+        # compute dp = dot(v, do)
+        dp_curr = tl.dot(do_curr, tl.trans(v_curr), allow_tf32=allow_tf32)
+        dp_curr_masked = dp_curr
+
+        # compute ds = p * (dp - delta[:, None])
+        if use_mask:
+            attn_mask = offs_m_curr[:, None] - offs_n_curr[None, :]
+            attn_mask = tl.where(mn_mask_curr, attn_mask, 0.0)
+            attn_mask = tl.where(attn_mask > 0, 0.0, 1.0)
+            dp_curr_masked = tl.where(attn_mask > 0, dp_curr, 0.0)
+
+        ds_curr = p_curr * (dp_curr_masked - Di_curr[:, None] * max_seq_len)
+
+        ds_curr = ds_curr.to(k_ptr.dtype.element_ty)
+        dq_curr += tl.dot(ds_curr, k_curr, allow_tf32=allow_tf32)
+        block_start += BLOCK_SIZE_M
+
+    tl.store(
+        dq_ptrs_curr, dq_curr, mask=((offs_d[None, :] < D) & (offs_m_curr[:, None] < M))
+    )
+
+
+def jagged_flash_attention_basic_backward(
+    jagged_Q,
+    # K is non-transposed
+    jagged_K,
+    jagged_V,
+    jagged_O,
+    offsets,
+    dO,
+    lse,
+    max_seq_len,
+    use_mask,
+    allow_tf32=False,
+):
+    BLOCK_SIZE_M = 32
+    BLOCK_SIZE_N = 32
+
+    B = offsets.size(0) - 1
+    num_blocks_m = triton.cdiv(max_seq_len, BLOCK_SIZE_M)
+    pre_grid = (num_blocks_m, B)
+
+    BLOCK_SIZE_D = max(triton.next_power_of_2(jagged_Q.size(1)), 16)
+
+    delta = torch.empty_like(lse)
+    if not dO.is_contiguous():
+        dO = dO.contiguous()
+
+    _jagged_flash_attention_bwd_preprocess_basic_kernel[pre_grid](
+        jagged_O,
+        offsets,
+        dO,
+        delta,
+        jagged_O.stride(0),
+        jagged_O.stride(1),
+        max_seq_len,
+        jagged_O.size(1),
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_D,
+    )
+
+    grid = (triton.cdiv(max_seq_len, BLOCK_SIZE_N), B)
+
+    dq = torch.zeros_like(jagged_Q)
+    dk = torch.zeros_like(jagged_K)
+    dv = torch.zeros_like(jagged_V)
+
+    D = jagged_Q.size(1)
+    _jagged_flash_attention_bwd_basic_kernel[grid](
+        jagged_Q,
+        jagged_K,
+        jagged_V,
+        jagged_O,
+        offsets,
+        dq,
+        dk,
+        dv,
+        dO,
+        delta,
+        lse,
+        jagged_Q.stride(0),
+        jagged_Q.stride(1),
+        jagged_K.stride(0),
+        jagged_K.stride(1),
+        jagged_V.stride(0),
+        jagged_V.stride(1),
+        jagged_O.stride(0),
+        jagged_O.stride(1),
+        dq.stride(0),
+        dq.stride(1),
+        dk.stride(0),
+        dk.stride(1),
+        dv.stride(0),
+        dv.stride(1),
+        dO.stride(0),
+        dO.stride(1),
+        max_seq_len,
+        D,
+        use_mask=use_mask,
+        allow_tf32=allow_tf32,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_D=BLOCK_SIZE_D,
+    )
+
+    return dq, dk, dv
+
+
+class JaggedFlashAttentionBasic(torch.autograd.Function):
+    @staticmethod
+    # pyre-fixme
+    def forward(
+        ctx,
+        jagged_Q: torch.Tensor,
+        jagged_K: torch.Tensor,
+        jagged_V: torch.Tensor,
+        offsets: torch.Tensor,
+        max_seq_len: int,
+        use_mask: bool = True,
+        allow_tf32: bool = False,
+    ) -> torch.Tensor:
+        ctx.allow_tf32 = allow_tf32
+        ctx.max_seq_len = max_seq_len
+        ctx.use_mask = use_mask
+
+        jagged_O, lse = jagged_flash_attention_basic_fwd(
+            jagged_Q,
+            jagged_K.T,
+            jagged_V,
+            offsets,
+            max_seq_len,
+            use_mask,
+            allow_tf32,
+        )
+
+        ctx.save_for_backward(
+            jagged_Q,
+            jagged_K,
+            jagged_V,
+            offsets,
+            jagged_O,
+            lse,
+        )
+
+        return jagged_O
+
+    @staticmethod
+    # pyre-fixme
+    def backward(
+        ctx, grad_output: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, None, None, None, None]:
+        (
+            jagged_Q,
+            jagged_K,
+            jagged_V,
+            offsets,
+            jagged_O,
+            lse,
+        ) = ctx.saved_tensors
+
+        dq, dk, dv = jagged_flash_attention_basic_backward(
+            jagged_Q=jagged_Q,
+            jagged_K=jagged_K,
+            jagged_V=jagged_V,
+            jagged_O=jagged_O,
+            offsets=offsets,
+            dO=grad_output,
+            lse=lse,
+            max_seq_len=ctx.max_seq_len,
+            use_mask=ctx.use_mask,
+            allow_tf32=ctx.allow_tf32,
+        )
+
+        return (
+            dq,
+            dk,
+            dv,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+def jagged_flash_attention_basic(
+    q_weights: torch.Tensor,
+    k_weights: torch.Tensor,
+    v_weights: torch.Tensor,
+    offsets: torch.Tensor,
+    max_seq_len: int,
+    use_mask: bool = False,
+    allow_tf32: bool = True,
+) -> torch.Tensor:
+    q_weights = expect_contiguous(q_weights)
+    k_weights = expect_contiguous(k_weights)
+    v_weights = expect_contiguous(v_weights)
+    jagged_offsets = expect_contiguous(offsets)
+
+    jagged_O = JaggedFlashAttentionBasic.apply(
+        q_weights,
+        k_weights,
+        v_weights,
+        jagged_offsets,
+        max_seq_len,
+        use_mask,
+        allow_tf32,
+    )
+
+    return jagged_O

--- a/fbgemm_gpu/fbgemm_gpu/triton/jagged/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/triton/jagged/__init__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/fbgemm_gpu/fbgemm_gpu/triton/jagged/triton_jagged_tensor_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/triton/jagged/triton_jagged_tensor_ops.py
@@ -1,0 +1,824 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+# pyre-ignore-all-errors[6]
+
+from typing import List, Optional, Tuple, Union
+
+import torch
+import triton  # @manual
+import triton.language as tl  # @manual
+from torch._tensor import Tensor
+
+
+@triton.jit
+def jagged_jagged_elementwise_arithmetic_ops(
+    # pyre-fixme[2]: Parameter must be annotated.
+    x_ptr,  # x_ptr and y_ptr is pointer of jagged tensor value
+    # pyre-fixme[2]: Parameter must be annotated.
+    y_ptr,
+    M: tl.constexpr,  # M and N would be size of the tensor with (M , N)
+    N: tl.constexpr,
+    stride_row: tl.constexpr,  # shared row stride for tensor
+    stride_col: tl.constexpr,  # shared colume stride for tensor
+    # pyre-fixme[2]: Parameter must be annotated.
+    output,
+    thread_block_row_size: tl.constexpr,  # row and colume size of current thread block with size (thread_block_row_size * thread_block_col_size)
+    thread_block_col_size: tl.constexpr,
+    ops_func: tl.constexpr,  # function use for calculation either add or multiplication
+) -> None:
+    pid = tl.program_id(0)
+    # number of col group need for total N col
+    num_group_n = (N + thread_block_col_size - 1) // thread_block_col_size
+    # pid position in col perspective in range(0,num_group_n)
+    pid_n = pid % num_group_n
+    # pid position in row perspective since everytime row increase when we have num_group_n iteration
+    pid_m = pid // num_group_n
+
+    offset_m = pid_m * thread_block_row_size + tl.arange(0, thread_block_row_size)
+    offset_n = pid_n * thread_block_col_size + tl.arange(0, thread_block_col_size)
+    mask = (offset_m[:, None] < M) & (offset_n[None, :] < N)
+    offset = offset_m[:, None] * stride_row + offset_n[None, :] * stride_col
+
+    x_ptr += offset
+    y_ptr += offset
+
+    x = tl.load(x_ptr, mask=mask)
+    y = tl.load(y_ptr, mask=mask)
+
+    if ops_func == "add":
+        z = tensor_elementwise_add(x, y)
+    else:
+        z = tensor_elementwise_mul(x, y)
+
+    output += offset
+    tl.store(output, z, mask=mask)
+
+
+@triton.jit
+# pyre-fixme[3]: Return type must be annotated.
+# pyre-fixme[2]: Parameter must be annotated.
+def tensor_elementwise_add(x, y):
+    return x + y
+
+
+@triton.jit
+# pyre-fixme[3]: Return type must be annotated.
+# pyre-fixme[2]: Parameter must be annotated.
+def tensor_elementwise_mul(x, y):
+    return x * y
+
+
+def triton_jagged_add_jagged(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+
+    # x and y need to have same shape to do addition
+    assert x.shape == y.shape
+
+    thread_block_row_size = 32
+    thread_block_col_size = 32
+
+    # x and y would a tensor with same dimension (M,N)
+    M, N = x.shape
+
+    output = torch.empty((M, N), device="cuda", dtype=x.dtype)
+
+    # pyre-fixme[53]: Captured variable `M` is not annotated.
+    # pyre-fixme[53]: Captured variable `N` is not annotated.
+    # pyre-fixme[53]: Captured variable `thread_block_col_size` is not annotated.
+    # pyre-fixme[53]: Captured variable `thread_block_row_size` is not annotated.
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
+    def grid(META):
+        return (
+            triton.cdiv(M, thread_block_row_size)
+            * triton.cdiv(N, thread_block_col_size),
+        )
+
+    jagged_jagged_elementwise_arithmetic_ops[grid](
+        x,
+        y,
+        M,
+        N,
+        x.stride(0),
+        x.stride(1),
+        output,
+        thread_block_row_size,
+        thread_block_col_size,
+        ops_func="add",
+    )
+
+    return output
+
+
+def triton_jagged_mul_jagged(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+
+    # x and y need to have same shape to do addition
+    assert x.shape == y.shape
+
+    thread_block_row_size = 32
+    thread_block_col_size = 32
+    # x and y would a tensor with same dimension (M,N)
+    M, N = x.shape
+
+    output = torch.empty((M, N), device="cuda", dtype=x.dtype)
+
+    # pyre-fixme[53]: Captured variable `M` is not annotated.
+    # pyre-fixme[53]: Captured variable `N` is not annotated.
+    # pyre-fixme[53]: Captured variable `thread_block_col_size` is not annotated.
+    # pyre-fixme[53]: Captured variable `thread_block_row_size` is not annotated.
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
+    def grid(META):
+        return (
+            triton.cdiv(M, thread_block_row_size)
+            * triton.cdiv(N, thread_block_col_size),
+        )
+
+    jagged_jagged_elementwise_arithmetic_ops[grid](
+        x,
+        y,
+        M,
+        N,
+        x.stride(0),
+        x.stride(1),
+        output,
+        thread_block_row_size,
+        thread_block_col_size,
+        ops_func="mul",
+    )
+
+    return output
+
+
+# with bmm([B * H , 1 , N] , [B*H , N , D])
+# Each kernel function dealing with matmul of (1,N) * (N,D)
+@triton.jit
+def triton_batched_dense_vec_jagged_2d_matmul(
+    # pyre-fixme[2]: Parameter must be annotated.
+    jagged_tensor_ptr,
+    # pyre-fixme[2]: Parameter must be annotated.
+    dense_ptr,
+    # pyre-fixme[2]: Parameter must be annotated.
+    jagged_offset,
+    thread_block_col_size: tl.constexpr,
+    # pyre-fixme[2]: Parameter must be annotated.
+    dense_row_stride,
+    # pyre-fixme[2]: Parameter must be annotated.
+    jagged_value_row_stride,
+    # pyre-fixme[2]: Parameter must be annotated.
+    D,
+    H: tl.constexpr,
+    # pyre-fixme[2]: Parameter must be annotated.
+    output_ptr,
+) -> None:
+
+    pid = tl.program_id(0)
+
+    # number of kernel need for with matrix (N,D) calculated by D // thread_block_col_size
+    GRID_DIM_COL = (D + thread_block_col_size - 1) // thread_block_col_size
+
+    # current output row index
+    output_row_idx = pid // GRID_DIM_COL
+
+    # current jagged tensor offset index
+    jagged_offset_id = output_row_idx // H
+
+    # current index with D reference since the real shape of jagged values is [B , N , H * D]
+    D_refer_idx = output_row_idx % H
+
+    # current part of [N * D] id
+    group_id = pid % GRID_DIM_COL
+
+    # size of tile
+    offset = group_id * thread_block_col_size + tl.arange(0, thread_block_col_size)
+
+    # begin index and end index of values
+    begin = tl.load(jagged_offset + jagged_offset_id)
+    end = tl.load(jagged_offset + (jagged_offset_id + 1))
+
+    # update each pointer to the correct address
+    dense_ptr += output_row_idx * dense_row_stride
+    jagged_tensor_ptr += begin * jagged_value_row_stride + D_refer_idx * D
+    output_ptr += D * output_row_idx
+
+    # Number of row each kernel will go through
+    num_row = tl.minimum(end - begin, dense_row_stride)
+
+    # accumulation variable use for matmul
+    acc = tl.zeros((thread_block_col_size,), dtype=tl.float32)
+    mask = offset < D
+    for i in range(num_row):
+        val1 = tl.load(dense_ptr + i)
+        val2 = tl.load(jagged_tensor_ptr + offset, mask=mask, other=0.0)
+        result = val1 * val2
+        acc += result
+        jagged_tensor_ptr += jagged_value_row_stride
+
+    tl.store(output_ptr + offset, acc, mask=mask)
+
+
+# torch.bmm refer https://pytorch.org/docs/stable/generated/torch.bmm.html
+# Operation that take dense as format [B * H , N] where N is the max_length in the logical representation we treat dense like [B * H , 1 , N]
+# and 2D jagged tensor with format values format [B , N , H * D] in the logical representation we treat values like [B * H , N , D]
+# in the 2D jagged tensor case offset will be tensor instead of list of tensor
+# create output dense with shape [B * H , 1 , D]
+# dense * jagged_tesnor = output_dense -> [B * H , 1 , N] * [B * H , N , D] = [B * H , 1 , D]
+def batched_dense_vec_jagged_2d_matmul(
+    dense: torch.Tensor,
+    values: torch.Tensor,
+    offset: torch.Tensor,
+) -> torch.Tensor:
+    B = offset.size(0) - 1
+    H = dense.size(0) // B
+    D = values.size(-1) // H
+    thread_block_col_size = 32
+
+    output_dense = torch.empty((B * H, D), device="cuda", dtype=values.dtype)
+
+    # number of thread block need for jagged tensor with [B * H , N , D]
+    # pyre-fixme[53]: Captured variable `B` is not annotated.
+    # pyre-fixme[53]: Captured variable `D` is not annotated.
+    # pyre-fixme[53]: Captured variable `H` is not annotated.
+    # pyre-fixme[53]: Captured variable `thread_block_col_size` is not annotated.
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
+    def grid(META):
+        return (B * H * triton.cdiv(D, thread_block_col_size),)
+
+    triton_batched_dense_vec_jagged_2d_matmul[grid](
+        values,
+        dense,
+        offset,
+        thread_block_col_size,
+        dense.stride(0),
+        values.stride(0),
+        D,
+        H,
+        output_dense,
+    )
+
+    return output_dense
+
+
+# each kernel will handle the conversion of one jagged tensor offset range to corresponding dense index
+@triton.jit
+def triton_jagged_to_dense(
+    # only constexpr annotations support in triton now
+    # pyre-fixme[2]: Parameter must be annotated.
+    jagged_value_ptr,
+    # pyre-fixme[2]: Parameter must be annotated.
+    jagged_offsets_ptr,
+    # pyre-fixme[2]: Parameter must be annotated.
+    jagged_value_row_stride,
+    # pyre-fixme[2]: Parameter must be annotated.
+    output_dense_ptr,
+    # pyre-fixme[2]: Parameter must be annotated.
+    dense_indices_ptr,
+    # pyre-fixme[2]: Parameter must be annotated.
+    dense_col_stride,  # stride of output dense with dimension (z,y,x)
+    # pyre-fixme[2]: Parameter must be annotated.
+    dense_row_stride,
+    # pyre-fixme[2]: Parameter must be annotated.
+    dense_matrix_stride,
+    JAGGED_DIM: tl.constexpr,  # number of dimension of jagged tensor
+    thread_block_row_size: tl.constexpr,
+    thread_block_col_size: tl.constexpr,
+    operation_function: tl.constexpr,  # fusion arithmetic operation function and it's input dense
+    # pyre-fixme[2]: Parameter must be annotated.
+    operation_dense,
+) -> None:
+    pid = tl.program_id(0)
+
+    # begin index and end index of jagged tensor Values
+    begin = tl.load(jagged_offsets_ptr + pid)
+    end = tl.load(jagged_offsets_ptr + (pid + 1))
+
+    # adjust the address of the jagged tensor Values to the correct address
+    jagged_value_ptr += begin * jagged_value_row_stride
+
+    # if it's 2D (or 1D) Jagged tensor we can direct use the offset in offsets ( since there is only one offset )
+    # else we actually need to use the preprocess index to found the correct address of dense
+    if JAGGED_DIM > 2:
+        # read the index for current kernel
+        dense_indice = tl.load(dense_indices_ptr + pid)
+
+        # if the dense_indice is -1 which mean it's a truncation case
+        # in that case we don't need to do anything since the dense
+        # initialize with padded value
+        if dense_indice == -1:
+            return
+
+        # adjust the address of output dense ptr to the correct address
+        output_dense_ptr += dense_indice
+
+        # also need to update the operation function if exist
+        # notice dense_indice of two is same because we assume
+        # the two dense + dense are same size
+        if operation_function is not None:
+            operation_dense += dense_indice
+    else:
+        output_dense_ptr += pid * dense_matrix_stride
+
+        if operation_function is not None:
+            operation_dense += pid * dense_matrix_stride
+
+    offset_row = tl.arange(0, thread_block_row_size)
+
+    # boundary need for the mask since it could be dense's size smaller than jagged tensor or revert case
+    N = tl.minimum(dense_row_stride, jagged_value_row_stride)
+    M = tl.minimum(dense_matrix_stride // dense_row_stride, end - begin)
+
+    for _i in range(begin, end, thread_block_row_size):
+        offset_col = tl.arange(0, thread_block_col_size)
+        block_offset = (
+            offset_row[:, None] * dense_row_stride
+            + offset_col[None, :] * dense_col_stride
+        )
+        for _j in range(0, N, thread_block_col_size):
+            mask = (offset_row[:, None] < M) & (offset_col[None, :] < N)
+            jagged_val = tl.load(jagged_value_ptr + block_offset, mask=mask, other=0)
+
+            # if there is some arithmetic operation we do the fusion computation
+            if operation_function is not None:
+                val1 = jagged_val
+                val2 = tl.load(operation_dense + block_offset, mask=mask, other=0)
+                # do the arithmetic operation
+                if operation_function == "add":
+                    jagged_val = tensor_elementwise_add(val1, val2)
+                else:
+                    jagged_val = tensor_elementwise_mul(val1, val2)
+
+            # store the result
+            tl.store(output_dense_ptr + block_offset, jagged_val, mask=mask)
+
+            # update the block offset
+            offset_col += thread_block_col_size
+            block_offset += thread_block_col_size
+        offset_row += thread_block_row_size
+
+
+# This function will handle the 2d Jagged Tensor to Dense operation
+# each kernel will go through all the element in each 2D tensor in
+# Dense ( Notice that since it's 2d jagged tensor dense will be 3D ).
+# Each kernel will check if the current value in 2d tensor is in
+# range or out of range. If in the range of Jagged Tensor, it will load
+# corresponding value, otherwise it will load padded value into dense.
+# On the other hand, in the function triton_jagged_to_dense, we are
+# only able to fill the value from jagged tensor to corresponding dense
+# but we are not be able to fill the dense with padded value in kernel.
+# therefore in pervious function, we fill dense with padded value first
+# then load corresponding value. Instead this function can directly
+# fill the value in kernel to avoid extra latency.
+@triton.jit
+def triton_jagged_to_dense_optimization_2d(
+    # pyre-fixme[2]: Parameter must be annotated.
+    input_jagged_values_ptr,
+    # pyre-fixme[2]: Parameter must be annotated.
+    input_jagged_offset_ptr,
+    # pyre-fixme[2]: Parameter must be annotated.
+    input_jagged_row_stride,
+    # pyre-fixme[2]: Parameter must be annotated.
+    output_dense_ptr,
+    # pyre-fixme[2]: Parameter must be annotated.
+    output_dense_row_stride,
+    # pyre-fixme[2]: Parameter must be annotated.
+    output_dense_matrix_stride,
+    thread_block_row_size: tl.constexpr,
+    thread_block_col_size: tl.constexpr,
+    # pyre-fixme[2]: Parameter must be annotated.
+    padded_value,
+    operation_function: tl.constexpr,
+    # pyre-fixme[2]: Parameter must be annotated.
+    operation_dense,
+) -> None:
+    pid = tl.program_id(0)
+
+    # Current corresponding offset indice
+    offset_idx = pid
+
+    # begin index and end index of jagged tensor Values
+    begin = tl.load(input_jagged_offset_ptr + offset_idx)
+    end = tl.load(input_jagged_offset_ptr + offset_idx + 1)
+
+    # row size of current sub tensor
+    cur_jagged_tensor_row_size = end - begin
+
+    # update dense and jagged tensor Values to corresponding address
+    output_dense_ptr += pid * output_dense_matrix_stride
+    input_jagged_values_ptr += begin * input_jagged_row_stride
+
+    # also need to update the operation function if exist
+    # notice dense_indice of two is same because we assume
+    # the two dense + dense are same size
+    if operation_function is not None:
+        operation_dense += pid * output_dense_matrix_stride
+
+    # jagged tensor row block
+    offset_row = tl.arange(0, thread_block_row_size)
+
+    # dense row and col block
+    # notice jagged tensor and dense share same col block since embedding dimension is same
+    dense_col_size = output_dense_row_stride
+    dense_row_size = output_dense_matrix_stride // output_dense_row_stride
+
+    for _i in range(0, dense_row_size, thread_block_row_size):
+        offset_col = tl.arange(0, thread_block_col_size)
+        block_offset = (
+            offset_row[:, None] * output_dense_row_stride + offset_col[None, :]
+        )
+
+        for _j in range(0, dense_col_size, thread_block_col_size):
+
+            # create mask for dense and jagged tensor for boundary check
+            dense_mask = (offset_row[:, None] < dense_row_size) & (
+                offset_col[None, :] < dense_col_size
+            )
+            jagged_mask = (offset_row[:, None] < cur_jagged_tensor_row_size) & (
+                offset_col[None, :] < input_jagged_row_stride
+            )
+
+            # get value from jagged tesnor
+            jagged_val = tl.load(
+                input_jagged_values_ptr + block_offset,
+                mask=jagged_mask,
+                other=padded_value,
+            )
+
+            # do fusion operation if need
+            if operation_function is not None:
+                operation_dense_val = tl.load(
+                    operation_dense + block_offset, mask=dense_mask, other=0.0
+                )
+                jagged_val = operation_function(operation_dense_val, jagged_val)
+
+            # load value into empty dense
+            tl.store(output_dense_ptr + block_offset, jagged_val, mask=dense_mask)
+
+            # update each block
+            offset_col += thread_block_col_size
+            block_offset += thread_block_col_size
+        offset_row += thread_block_row_size
+
+
+# this function parse the jagged tensor offsets to corresponding dense index position
+# to see the detail of it see the quip note : https://fb.quip.com/gnzpA7d13vqO
+# the FBGEMM implementation refer : https://www.internalfb.com/code/fbsource/[308212b2902c3182edcb5b204768321e032e8175]/fbcode/deeplearning/fbgemm/fbgemm_gpu/src/jagged_tensor_ops.cu?lines=280
+# In FBGEMM it was computed by GPU but in triton currently has some compilation issue so we use CUP computation method as workaround
+# However in real-world case if we only dealing with 2d jagged tensor we don't need to use this function at all
+def _jagged_offsets_to_dense_indice(
+    offsets: List[torch.Tensor], dense_strides: List[int], dense_sizes: List[int]
+) -> torch.Tensor:
+
+    output_offset = torch.zeros(len(offsets[-1]) - 1, device="cpu", dtype=torch.int32)
+
+    offsets_cpu = []
+
+    for offset in offsets:
+        offsets_cpu.append(offset.cpu())
+
+    for i in range(0, len(offsets_cpu[-1]) - 1):
+        idx = i
+        result = 0
+
+        # flag to check if current offset is in the range of dense
+        in_range = True
+        for j in range(len(offsets_cpu) - 2, -1, -1):
+            left = 0
+            right = offsets_cpu[j].size(0)
+
+            # binary search found the corresponding offset group of current index
+            while left < right:
+                mid = left + (right - left) // 2
+
+                if offsets_cpu[j][mid] > idx:
+                    right = mid
+                else:
+                    left = mid + 1
+
+            cur_val = idx - offsets_cpu[j][left - 1]
+
+            if dense_sizes and cur_val >= dense_sizes[j + 1]:
+                in_range = False
+                break
+
+            result += cur_val * dense_strides[j + 1]
+            idx = left - 1
+
+        if in_range:
+            result += idx * dense_strides[0]
+
+            # another out of output dense range case
+            if dense_sizes and idx > dense_sizes[0]:
+                result = -1
+            output_offset[i] = result
+        else:
+            output_offset[i] = -1
+
+    return output_offset.cuda()
+
+
+# transfer jagged tensor to dense for referring the quip note for wiki : https://fb.quip.com/gnzpA7d13vqO
+# currently when doing the conversion if certain part of dense are not load from the jagged tensor Values
+# it will be skiped. Which mean we initialize the tensor with padded value instead of fill it with padded
+# value while conversion. Currently optimization approach implementation in triton faced some issue with
+# LLVM compile issue but will look a work around when make a comparsion with multiple dimension of
+# jagged tensot. However if currently we only dealing with 2d jagged tensor in real-world case this should
+# not be affected at all
+def jagged_to_dense(
+    jagged_values: torch.Tensor,
+    jagged_offsets: List[torch.Tensor],
+    jagged_max_lengths: List[int],
+    padding_value: float = 0.0,  # padding value currently use 0.0 as default value
+    operation_function: Union[
+        str, None
+    ] = None,  # fusioned operation currently could be add or multiplication
+    operation_dense: Union[
+        torch.Tensor, None
+    ] = None,  # dense to make the add/mul with the output dense
+) -> torch.Tensor:
+    outer_dense_size = len(jagged_offsets[0]) - 1
+    inner_dense_size = jagged_values.size(-1)
+
+    # dimension of jagged tensor
+    JAGGED_DIM = len(jagged_offsets) + 1
+
+    output_dense = None
+
+    # fill the padded value into dense if is multiple dimension
+    # other wise create empty dense
+    # this is for avoid multiple dimension cases
+    # it can create compile error if we going to fill the padding
+    # value inside of kernel function
+    if JAGGED_DIM > 2:
+        output_dense = torch.full(
+            ((outer_dense_size,) + tuple(jagged_max_lengths) + (inner_dense_size,)),
+            padding_value,
+            device="cuda",
+            dtype=jagged_values.dtype,
+        )
+    else:
+        output_dense = torch.empty(
+            ((outer_dense_size,) + tuple(jagged_max_lengths) + (inner_dense_size,)),
+            device="cuda",
+            dtype=jagged_values.dtype,
+        )
+
+    thread_block_row_size = 32
+    thread_block_col_size = 32
+
+    grid = (len(jagged_offsets[-1]) - 1,)
+
+    # dense index in address perspective
+    dense_indices = None
+
+    # if dimension of jagged tensor ( which is number of offset ) we will need calculated the related dense index referring to jagged offsets
+    if JAGGED_DIM > 2:
+        dense_indices = _jagged_offsets_to_dense_indice(
+            jagged_offsets,
+            output_dense.stride()[:-2],
+            output_dense.size()[:-2],
+        )
+
+    # dense stride for each column, row, and matrix
+    dense_col_stride = output_dense.stride(-1)
+    dense_row_stride = output_dense.stride(-2)
+    dense_matrix_stride = output_dense.stride(-3)
+
+    if JAGGED_DIM > 2:
+        triton_jagged_to_dense[grid](
+            jagged_values,
+            jagged_offsets[-1],
+            jagged_values.stride(0),
+            output_dense,
+            dense_indices,
+            dense_col_stride,
+            dense_row_stride,
+            dense_matrix_stride,
+            JAGGED_DIM,
+            thread_block_row_size,
+            thread_block_col_size,
+            operation_function=operation_function,
+            operation_dense=operation_dense,
+        )
+    else:
+        grid = (output_dense.size(0),)
+        triton_jagged_to_dense_optimization_2d[grid](
+            jagged_values,
+            jagged_offsets[-1],
+            jagged_values.stride(0),
+            output_dense,
+            dense_row_stride,
+            dense_matrix_stride,
+            thread_block_row_size,
+            thread_block_col_size,
+            padded_value=padding_value,
+            operation_function=operation_function,
+            operation_dense=operation_dense,
+        )
+
+    return output_dense
+
+
+# each kernel will handle the conversion of one jagged tensor offset range from corresponding dense index
+@triton.jit
+def triton_dense_to_jagged(
+    # pyre-fixme[2]: Parameter must be annotated.
+    jagged_value_ptr,
+    # pyre-fixme[2]: Parameter must be annotated.
+    jagged_offsets_ptr,
+    jagged_value_row_stride: int,
+    # pyre-fixme[2]: Parameter must be annotated.
+    output_dense_ptr,
+    # pyre-fixme[2]: Parameter must be annotated.
+    dense_indices_ptr,
+    # pyre-fixme[2]: Parameter must be annotated.
+    dense_col_stride,  # stride of output dense with dimension (z,y,x)
+    dense_row_stride: int,
+    # pyre-fixme[2]: Parameter must be annotated.
+    dense_matrix_stride,
+    JAGGED_DIM: tl.constexpr,  # number of dimension of jagged tensor
+    thread_block_row_size: tl.constexpr,
+    thread_block_col_size: tl.constexpr,
+    operation_function: tl.constexpr,  # fusion arithmetic opeartion function and it's input dense
+    # pyre-fixme[2]: Parameter must be annotated.
+    operation_jagged_value_ptr,
+) -> None:
+    pid = tl.program_id(0)
+
+    begin = tl.load(jagged_offsets_ptr + pid)
+    end = tl.load(jagged_offsets_ptr + (pid + 1))
+
+    # size of the current value offset range (M , N)
+    N = jagged_value_row_stride
+    M = end - begin
+
+    dense_boundary_col = dense_row_stride
+    # tl.minimum will change the return type cased compile issue
+    # in that case use if statement instead
+    if N < dense_row_stride:
+        dense_boundary_col = N
+
+    dense_boundary_row = tl.minimum(dense_matrix_stride // dense_row_stride, M)
+
+    jagged_value_ptr += begin * jagged_value_row_stride
+    if JAGGED_DIM > 2:
+        dense_indice = tl.load(dense_indices_ptr + pid)
+        # if dense output range we set dense_boundary to -1
+        # that mean dense values will not be use with mask
+        # since we still need the calculation of fusion step
+        # therefore we do not do return here
+        if dense_indice == -1:
+            dense_boundary_col = -1
+        else:
+            output_dense_ptr += dense_indice
+    else:
+        output_dense_ptr += pid * dense_matrix_stride
+
+    if operation_function is not None:
+        operation_jagged_value_ptr += begin * jagged_value_row_stride
+
+    offset_row = tl.arange(0, thread_block_row_size)
+
+    for _i in range(begin, end, thread_block_row_size):
+        offset_col = tl.arange(0, thread_block_col_size)
+        block_offset = (
+            offset_row[:, None] * dense_row_stride
+            + offset_col[None, :] * dense_col_stride
+        )
+
+        for _j in range(0, N, thread_block_col_size):
+            dense_mask = (offset_row[:, None] < dense_boundary_row) & (
+                offset_col[None, :] < dense_boundary_col
+            )
+            jagged_mask = (offset_row[:, None] < M) & (offset_col[None, :] < N)
+            dense_values = tl.load(
+                output_dense_ptr + block_offset, mask=dense_mask, other=0
+            )
+            if operation_function is not None:
+                operation_jagged_value = tl.load(
+                    operation_jagged_value_ptr + block_offset, mask=jagged_mask, other=0
+                )
+                if operation_function == "add":
+                    dense_values = tensor_elementwise_add(
+                        dense_values, operation_jagged_value
+                    )
+                else:
+                    dense_values = tensor_elementwise_mul(
+                        dense_values, operation_jagged_value
+                    )
+            tl.store(jagged_value_ptr + block_offset, dense_values, mask=jagged_mask)
+            offset_col += thread_block_col_size
+            block_offset += thread_block_col_size
+        offset_row += thread_block_row_size
+
+
+def dense_to_jagged(
+    dense: torch.Tensor,
+    jagged_offsets: List[torch.Tensor],
+    operation_function: Union[str, None] = None,
+    operation_jagged_values: Union[torch.Tensor, None] = None,
+) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+
+    thread_block_row_size = 32
+    thread_block_col_size = 32
+
+    if operation_function is None:
+        output_jagged_value = torch.empty(
+            (jagged_offsets[-1][-1], dense.size(-1)),
+            device="cuda",
+            dtype=dense.dtype,
+        )
+    else:
+        output_jagged_value = torch.empty(
+            # pyre-fixme [16]: Optional type has no attribute `shape`.Pyre
+            operation_jagged_values.shape,
+            device="cuda",
+            dtype=dense.dtype,
+        )
+
+    grid = (jagged_offsets[-1].size(0) - 1,)
+
+    JAGGED_DIM = len(jagged_offsets) + 1
+    dense_indices = None
+    if len(jagged_offsets) > 1:
+        dense_indices = _jagged_offsets_to_dense_indice(
+            jagged_offsets,
+            dense.stride()[:-2],
+            dense.size()[:-2],
+        )
+
+    # dense stride for each column, row, and matrix
+    dense_col_stride = dense.stride(-1)
+    dense_row_stride = dense.stride(-2)
+    dense_matrix_stride = dense.stride(-3)
+
+    triton_dense_to_jagged[grid](
+        output_jagged_value,
+        jagged_offsets[-1],
+        output_jagged_value.stride(0),
+        dense,
+        dense_indices,
+        dense_col_stride,
+        dense_row_stride,
+        dense_matrix_stride,
+        JAGGED_DIM,
+        thread_block_row_size,
+        thread_block_col_size,
+        operation_function=operation_function,
+        operation_jagged_value_ptr=operation_jagged_values,
+    )
+
+    return output_jagged_value, jagged_offsets
+
+
+# jagged_tensor + dense -> dense
+def jagged_dense_elementwise_add_dense_output(
+    jagged_values: Tensor,
+    jagged_offsets: List[Tensor],
+    # pyre-fixme[2]: Parameter must be annotated.
+    dense,
+) -> Tensor:
+
+    # max_length use to build output dense
+    # that has same size as input dense
+    max_length = dense.size()[1:-1]
+
+    # convert jagged tensor to dense
+    converted_dense = jagged_to_dense(jagged_values, jagged_offsets, max_length)
+
+    # add opeartion add two dense with same shape
+    # Once it's optimazied we can remove this statement
+    # and directly return converted_dense
+    return converted_dense + dense
+
+
+# jagged_tensor + dense -> jagged_tensor
+def jagged_dense_elementwise_add_jagged_output(
+    jagged_values: Optional[Tensor], jagged_offsets: List[Tensor], dense: Tensor
+) -> Tuple[Tensor, List[Tensor]]:
+
+    return dense_to_jagged(
+        dense,
+        jagged_offsets,
+        operation_function="add",
+        operation_jagged_values=jagged_values,
+    )
+
+
+# jagged_tensor * dense -> jagged_tensor
+def jagged_dense_elementwise_mul_jagged_output(
+    jagged_values: Optional[Tensor], jagged_offsets: List[Tensor], dense: Tensor
+) -> Tuple[Tensor, List[Tensor]]:
+
+    return dense_to_jagged(
+        dense,
+        jagged_offsets,
+        operation_function="mul",
+        operation_jagged_values=jagged_values,
+    )

--- a/fbgemm_gpu/test/sll/jagged_flash_attention_basic_test.py
+++ b/fbgemm_gpu/test/sll/jagged_flash_attention_basic_test.py
@@ -1,0 +1,196 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+import hypothesis.strategies as st
+import torch
+from hypothesis import given, settings
+
+from .common import open_source
+
+if open_source:
+    # pyre-ignore[21]
+    from test_utils import gpu_unavailable, running_on_rocm
+else:
+    from fbgemm_gpu.test.test_utils import gpu_unavailable, running_on_rocm
+
+
+def clone_tensor(data: torch.Tensor) -> torch.Tensor:
+    if data.requires_grad:
+        return data.detach().clone().requires_grad_()
+    return data.detach().clone()
+
+
+class JaggedFlashAttentionBasicTest(unittest.TestCase):
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @given(
+        B=st.integers(1, 10),
+        max_L=st.integers(1, 100),
+        D=st.integers(16, 64),
+        use_mask=st.booleans(),
+        allow_tf32=st.booleans(),
+        device_type=st.sampled_from(["cpu", "cuda"]),
+    )
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(*running_on_rocm)
+    @settings(deadline=40000)
+    def test_triton_jagged_flash_attention_basic(
+        self,
+        B: int,
+        max_L: int,
+        D: int,
+        use_mask: bool,
+        allow_tf32: bool,
+        device_type: str,
+    ) -> None:
+        device: torch.device = torch.device(device_type)
+        num_objects = torch.randint(1, max_L + 1, (B,)).to(device)
+
+        x_offsets = torch.cat(
+            [torch.IntTensor([0]).to(device), num_objects.cumsum(dim=0)], dim=0
+        )
+        attn_lengths = num_objects * num_objects
+        attn_offsets = torch.cat(
+            [torch.IntTensor([0]).to(device), attn_lengths.cumsum(dim=0)], dim=0
+        )
+
+        q_weights = torch.rand(
+            int(num_objects.sum().item()), D, device=device, requires_grad=True
+        )
+
+        k_weights = torch.rand(
+            int(num_objects.sum().item()), D, device=device, requires_grad=True
+        )
+
+        v_weights = torch.rand(
+            int(num_objects.sum().item()), D, device=device, requires_grad=True
+        )
+
+        do = torch.rand_like(q_weights) * 0.01
+
+        q_weights_clone = clone_tensor(q_weights)
+        k_weights_clone = clone_tensor(k_weights)
+        v_weights_clone = clone_tensor(v_weights)
+
+        def ref_attention_basic(
+            num_objects: torch.Tensor,
+            x_offsets: torch.Tensor,
+            attn_lengths: torch.Tensor,
+            attn_offsets: torch.Tensor,
+            q_weights: torch.Tensor,
+            k_weights: torch.Tensor,
+            v_weights: torch.Tensor,
+            max_seq_len: int,
+            use_mask: bool,
+            allow_tf32: bool,
+            do: torch.Tensor,
+        ) -> torch.Tensor:
+            s = torch.ops.fbgemm.sll_jagged_jagged_bmm_jagged_out(
+                x=q_weights,
+                y=k_weights,  # transpose is done inside the function
+                x_lengths=num_objects,
+                x_offsets=x_offsets,
+                y_lengths=num_objects,
+                y_offsets=x_offsets,
+                z_lengths=attn_lengths,
+                z_offsets=attn_offsets,
+                max_seq_len=max_seq_len,
+                allow_tf32=allow_tf32,
+            )
+
+            p = (
+                torch.ops.fbgemm.sll_jagged2_softmax(
+                    x=s,
+                    offsets=x_offsets,
+                    offsets_total=attn_offsets,
+                    max_seq_len=max_seq_len,
+                    transpose=False,
+                )
+                / max_seq_len
+            )
+
+            if use_mask:
+                attn_mask = torch.triu(
+                    torch.ones(
+                        (max_seq_len, max_seq_len),
+                        dtype=torch.bool,
+                        device=q_weights.device,
+                    ),
+                ).requires_grad_(False)
+                # p = p * attn_mask
+                p = torch.ops.fbgemm.sll_jagged_dense_elementwise_mul_jagged_out(
+                    x=p,
+                    y=attn_mask,
+                    x_seq_lengths=num_objects,
+                    x_offsets=attn_offsets,
+                    max_seq_len=max_seq_len,
+                )
+
+            attn_out = torch.ops.fbgemm.sll_array_jagged_bmm_jagged_out(
+                x=p,
+                y=v_weights,
+                x_lengths=attn_lengths,
+                x_offsets=attn_offsets,
+                y_lengths=num_objects,
+                y_offsets=x_offsets,
+                z_lengths=num_objects,
+                z_offsets=x_offsets,
+                max_seq_len=max_seq_len,
+                allow_tf32=allow_tf32,
+            )
+
+            attn_out.backward(do)
+
+            return attn_out
+
+        attn_out_ref = ref_attention_basic(
+            num_objects=num_objects,
+            x_offsets=x_offsets,
+            attn_lengths=attn_lengths,
+            attn_offsets=attn_offsets,
+            q_weights=q_weights,
+            k_weights=k_weights,
+            v_weights=v_weights,
+            max_seq_len=max_L,
+            use_mask=use_mask,
+            allow_tf32=allow_tf32,
+            do=do,
+        )
+
+        attn_out_test = torch.ops.fbgemm.sll_jagged_flash_attention_basic(
+            q_weights=q_weights_clone,
+            k_weights=k_weights_clone,
+            v_weights=v_weights_clone,
+            offsets=x_offsets,
+            max_seq_len=max_L,
+            use_mask=use_mask,
+            allow_tf32=allow_tf32,
+        )
+
+        assert torch.allclose(attn_out_ref, attn_out_test, atol=1e-5, rtol=1e-3)
+
+        attn_out_test.backward(do)
+
+        assert v_weights.grad is not None
+        assert v_weights_clone.grad is not None
+        assert torch.allclose(
+            v_weights.grad, v_weights_clone.grad, atol=1e-4, rtol=1e-3
+        )
+
+        assert k_weights.grad is not None
+        assert k_weights_clone.grad is not None
+        assert torch.allclose(
+            k_weights.grad, k_weights_clone.grad, atol=1e-4, rtol=1e-3
+        )
+
+        assert q_weights.grad is not None
+        assert q_weights_clone.grad is not None
+        assert torch.allclose(
+            q_weights.grad, q_weights_clone.grad, atol=1e-4, rtol=1e-3
+        )


### PR DESCRIPTION
Summary: - Release Triton jagged tensor ops to OSS.  In particular, the Triton `jagged_to_dense` needs to be in OSS for SLL `jagged_dense_elementwise_add` to be in OSS

Differential Revision: D66895475
