### PR TITLE
FP8 Rowwise compile fix followup for AMD

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/fp8_rowwise_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/fp8_rowwise_gemm.hip
@@ -325,7 +325,7 @@ at::Tensor f8f8bf16_rowwise(
       XQ, WQ, x_scale, w_scale, bias, use_fast_accum);
 }
 
-at::Tensor f8f8bf16_rowwise_out(
+void f8f8bf16_rowwise_out(
     at::Tensor XQ,
     at::Tensor WQ,
     at::Tensor x_scale,
@@ -333,8 +333,8 @@ at::Tensor f8f8bf16_rowwise_out(
     at::Tensor output,
     std::optional<at::Tensor> bias,
     bool use_fast_accum) {
-  // Invoke f8f8bf16 rowwise without preallocated output.
-  return f8f8bf16_rowwise_wrapper(
+  // Invoke f8f8bf16 rowwise with preallocated output.
+  f8f8bf16_rowwise_wrapper(
       XQ,
       WQ,
       x_scale,


### PR DESCRIPTION
Summary: This diff applies an additional fix on top of D66904697 to make sure that AMD compile signatures match those on nvidia. After this lands, all issues from the refactor should be resolved.

Reviewed By: henrylhtsang

Differential Revision: D66908478


