### PR TITLE
Fix for T209749755 ("Your diff, D66861418, broke one test")

### DIFF
--- a/fbgemm_gpu/test/sll/triton_sll_test.py
+++ b/fbgemm_gpu/test/sll/triton_sll_test.py
@@ -15,8 +15,6 @@ import torch
 from hypothesis import given, settings, strategies as st
 from torch.testing._internal.optests import opcheck
 
-open_source: bool = getattr(fbgemm_gpu, "open_source", False)
-
 from .common import open_source  # noqa
 
 if open_source:


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/562

This diff was created by the [Meta Engineering Agent](https://fb.workplace.com/groups/1205375940786433/permalink/1205378807452813/) to automatically fix the broken tests assigned to you / your team in T209749755:
- The agent searched for and edited the files it deemed relevant for fixing the tests
- After generating the patch, the broken test(s) were rerun to verify they now pass
- Regression tests were also run to verify CI still passes

---

**If this diff is the correct fix for T209749755, please accept and land the diff**. *Note that while we set a high quality bar for the agent publishing these diffs, LLM-powered agents still make mistakes, so your critical review is much appreciated and will help us improve!*

**If changes need to be made:** Please commandeer the diff, or comment with the specific changes needed.

---

*P.S. If you have broader feedback, please post in the [Meta Engineering Agent - Users group](https://fb.workplace.com/groups/1205375940786433)! We would love to hear from you on improving the agent to better assist you in your daily work.*

Reviewed By: brad-mengchi

Differential Revision: D66911501


