### PR TITLE
Fix grid size overflow in generate_vbe_metadata

### DIFF
--- a/fbgemm_gpu/src/split_embeddings_utils/generate_vbe_metadata.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils/generate_vbe_metadata.cu
@@ -33,27 +33,15 @@ __launch_bounds__(kMaxThreads) void generate_vbe_metadata_foreach_sample_kernel(
         D_offsets,
     const int32_t D,
     const bool nobag,
-    FixedDivisor fd_max_B,
-    FixedDivisor fd_max_B_T,
     const int32_t info_B_num_bits) {
-  const auto r_b_t = blockIdx.x * blockDim.x + threadIdx.x;
-  const auto T = B_offsets.size(0) - 1; // Num tables
-  const auto R = B_offsets_rank_per_feature.size(1) - 1; // Num ranks
-
-  int32_t b_t;
-  int32_t r; // Rank ID
-  int32_t t; // Table ID
-  int32_t b; // Relative sample ID in the rank-table matrix
-
-  fd_max_B_T.DivMod(r_b_t, &r, &b_t);
-  if (r >= R) {
-    return;
-  }
-
-  fd_max_B.DivMod(b_t, &t, &b);
-  if (t >= T) {
-    return;
-  }
+  // Relative sample ID in the rank-table matrix
+  const auto b = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  // Rank ID
+  const auto r = blockIdx.y;
+  // Table ID
+  const auto t = blockIdx.z;
+  // Num tables
+  const auto T = B_offsets.size(0) - 1;
 
   const auto B_start_r_t = B_offsets_rank_per_feature[t][r];
   const auto B_r_t = B_offsets_rank_per_feature[t][r + 1] - B_start_r_t;
@@ -61,21 +49,35 @@ __launch_bounds__(kMaxThreads) void generate_vbe_metadata_foreach_sample_kernel(
     return;
   }
 
+  const auto* __restrict__ output_offsets_feature =
+      &output_offsets_feature_rank[r * T];
+
   const auto B_start_t = B_offsets[t];
-  // Update b_t
-  b_t = B_start_t + B_start_r_t + b;
-  const auto D_ = nobag ? D : D_offsets[t + 1] - D_offsets[t];
-  row_output_offsets[b_t] = output_offsets_feature_rank[r * T + t] + b * D_;
+  const auto b_t =
+      static_cast<int64_t>(B_start_t) + static_cast<int64_t>(B_start_r_t) + b;
+  const auto D_ = nobag ? D : (D_offsets[t + 1] - D_offsets[t]);
+  row_output_offsets[b_t] =
+      output_offsets_feature[t] + b * static_cast<int64_t>(D_);
 
   // Relative sample ID in the table
   const auto b_ = B_start_r_t + b;
   // b_t is always positive.
   *reinterpret_cast<uint32_t*>(&b_t_map[b_t]) =
-      (reinterpret_cast<uint32_t*>(&t)[0] << info_B_num_bits) |
+      (reinterpret_cast<const uint32_t*>(&t)[0] << info_B_num_bits) |
       reinterpret_cast<const uint32_t*>(&b_)[0];
 }
 
 } // namespace
+
+std::tuple<int, int, int> get_max_grid_size(int device) {
+  static auto max_grid = [&]() -> std::tuple<int, int, int> {
+    cudaDeviceProp prop;
+    C10_CUDA_CHECK(cudaGetDeviceProperties(&prop, at::cuda::current_device()));
+    return {prop.maxGridSize[0], prop.maxGridSize[1], prop.maxGridSize[2]};
+  }();
+
+  return max_grid;
+}
 
 /// Generate VBE metadata namely output_offsets and b_t_map
 ///
@@ -121,7 +123,8 @@ generate_vbe_metadata(
   TENSOR_NDIM_EQUALS(B_offsets_rank_per_feature, 2);
   TENSOR_NDIM_EQUALS(output_offsets_feature_rank, 1);
 
-  const int32_t T = B_offsets.numel() - 1;
+  const auto T = B_offsets.numel() - 1;
+
   if (!nobag) {
     TENSOR_ON_CUDA_GPU(D_offsets);
     TENSORS_ON_SAME_DEVICE(B_offsets, D_offsets);
@@ -129,6 +132,14 @@ generate_vbe_metadata(
   }
 
   const auto num_ranks = B_offsets_rank_per_feature.size(1) - 1;
+  TORCH_CHECK(
+      num_ranks > 0, "generate_vbe_metadata: Invalid num_ranks ", num_ranks);
+  TORCH_CHECK(T > 0, "generate_vbe_metadata: Invalid T ", T);
+  TORCH_CHECK(
+      max_B_feature_rank > 0,
+      "generate_vbe_metadata: Invalid max_B_feature_rank ",
+      max_B_feature_rank);
+
   TORCH_CHECK(B_offsets_rank_per_feature.size(0) == T);
   TORCH_CHECK(output_offsets_feature_rank.numel() == num_ranks * T + 1);
 
@@ -138,13 +149,29 @@ generate_vbe_metadata(
       at::empty({total_B}, output_offsets_feature_rank.options());
   Tensor b_t_map = at::empty({total_B}, B_offsets.options());
 
+  const auto grid_dim_x = div_round_up(max_B_feature_rank, kMaxThreads);
+  const dim3 grid_size(grid_dim_x, num_ranks, T);
+  const auto& [max_grid_x, max_grid_y, max_grid_z] =
+      get_max_grid_size(at::cuda::current_device());
+  TORCH_CHECK(
+      grid_size.x > 0 && grid_size.x <= max_grid_x,
+      "generate_vbe_metadata: Invalid grid_size.x ",
+      grid_size.x);
+  TORCH_CHECK(
+      grid_size.y > 0 && grid_size.y <= max_grid_y,
+      "generate_vbe_metadata: Invalid grid_size.y ",
+      grid_size.y);
+  TORCH_CHECK(
+      grid_size.z > 0 && grid_size.z <= max_grid_z,
+      "generate_vbe_metadata: Invalid grid_size.z ",
+      grid_size.z);
+
 #ifdef FBGEMM_GPU_MEMCHECK
   const auto func_name = "generate_vbe_metadata_foreach_sample_kernel";
 #endif
-
   // Over allocate total number of threads to avoid using binary search
   generate_vbe_metadata_foreach_sample_kernel<<<
-      div_round_up(max_B_feature_rank * T * num_ranks, kMaxThreads),
+      grid_size,
       kMaxThreads,
       0,
       at::cuda::getCurrentCUDAStream()>>>(
@@ -157,8 +184,6 @@ generate_vbe_metadata(
       MAKE_PTA_WITH_NAME(func_name, D_offsets, int32_t, 1, 32),
       D,
       nobag,
-      FixedDivisor(max_B_feature_rank),
-      FixedDivisor(max_B_feature_rank * T),
       info_B_num_bits);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 


### PR DESCRIPTION
Summary:
Use 3D grid to reduce the risk of running into grid size overflow in
generate_vbe_metadata

Differential Revision: D66948760


