### PR TITLE
Fix CK FP8 rowwise quantization for some GEMM shapes

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/kernels/fp8_rowwise_common.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/kernels/fp8_rowwise_common.h
@@ -160,9 +160,9 @@ at::Tensor f8f8bf16_rowwise_impl(
     at::Tensor w_scale,
     at::Tensor Y) {
   // Get input information.
-  int M = XQ.size(0);
+  int M = size_to_dim_(XQ.dim() - 1, XQ.sizes());
   int N = WQ.size(0);
-  int K = XQ.size(1);
+  int K = WQ.size(1);
 
   int StrideA = K;
   int StrideB = K;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/566

Fix f8f8bf16_rowwise_impl for the case where XQ.shape = (1, B_T, D). New implementation aligns with Nvidia side (https://www.internalfb.com/code/fbsource/[a6987b1ea17d6b283f4767042c15b26d42052730]/fbcode/deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise.cu?lines=51) (the fix was identified by zjing14)

Reviewed By: feikou

Differential Revision: D66947828
