### PR TITLE
skip broken inference test that uses ssd TBE

### DIFF
--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_inference_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_inference_test.py
@@ -48,6 +48,7 @@ MAX_EXAMPLES = 40
 
 @unittest.skipIf(*running_on_github)
 @unittest.skipIf(*gpu_unavailable)
+@unittest.skipIf(True, "Test is broken.")
 class SSDIntNBitTableBatchedEmbeddingsTest(unittest.TestCase):
     def test_nbit_ssd(self) -> None:
         import tempfile


### PR DESCRIPTION
Summary: skip broken inference test that uses ssd TBE. the test is broken, SSD TBE is not borken.

Differential Revision: D67047995


