### PR TITLE
support quantize_fp8_row for up to 4d non contiguous tensor

### DIFF
--- a/fbgemm_gpu/experimental/gemm/test/fp8_gemm_test.py
+++ b/fbgemm_gpu/experimental/gemm/test/fp8_gemm_test.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+import itertools
 import unittest
 from typing import Optional, Tuple
 
@@ -37,38 +38,62 @@ class TestFp8Matmul(unittest.TestCase):
             device: torch.device,
             output_device: Optional[torch.device] = None,
             use_scale_ub: bool = False,
+            transpose_inputs: bool = False,
         ) -> None:
             a = torch.randn(shape, dtype=torch.bfloat16, device=device)
-
+            inputs = [a]
+            # if transpose_inputs is true, get all possible dimension combinations
+            # of the input tensor and transposes each pair
+            if transpose_inputs:
+                dims = range(a.ndim)
+                for dim1, dim2 in itertools.combinations(dims, 2):
+                    dims_list = list(dims)
+                    dims_list[dim1], dims_list[dim2] = dims_list[dim2], dims_list[dim1]
+                    inputs.append(a.permute(dims_list))
             scale_ub = (
                 torch.tensor([1200], dtype=torch.float, device=device)
                 if use_scale_ub
                 else None
             )
-
-            a_fp8, a_scale = quantize_fp8_row(
-                a, scale_ub=scale_ub, use_triton=use_triton, output_device=output_device
-            )
-
-            # Undo scaling.
-            a_torch = a_fp8.to(torch.bfloat16)
-            broadcast_shape = list(a_torch.shape[:-1]) + [-1]
-            a_torch *= a_scale.view(broadcast_shape)
-
-            self.assertTrue(
-                torch.allclose(
-                    a.to(device=output_device), a_torch, atol=2e-1, rtol=1e-1
+            for input_a in inputs:
+                a_fp8, a_scale = quantize_fp8_row(
+                    input_a,
+                    scale_ub=scale_ub,
+                    use_triton=use_triton,
+                    output_device=output_device,
                 )
-            )
 
-        _test_quantize_fp8_row((2, 3), True, torch.device("cuda"))
+                # Undo scaling.
+                a_torch = a_fp8.to(torch.bfloat16)
+                broadcast_shape = list(a_torch.shape[:-1]) + [-1]
+                a_torch *= a_scale.view(broadcast_shape)
+
+                self.assertTrue(
+                    torch.allclose(
+                        input_a.to(device=output_device), a_torch, atol=2e-1, rtol=1e-1
+                    )
+                )
+
+        for n_col in range(1, 9000, 100):
+            _test_quantize_fp8_row((2, n_col), True, torch.device("cuda"))
         # Test with batched input.
         _test_quantize_fp8_row((4, 2, 3), True, torch.device("cuda"))
+        _test_quantize_fp8_row((6, 4, 2, 3), True, torch.device("cuda"))
+        # Test with non-contiguous input
+        _test_quantize_fp8_row(
+            (4, 2, 3), True, torch.device("cuda"), transpose_inputs=True
+        )
+        _test_quantize_fp8_row(
+            (6, 4, 2, 3), True, torch.device("cuda"), transpose_inputs=True
+        )
         _test_quantize_fp8_row((2, 3), True, torch.device("cuda"), use_scale_ub=True)
+        # Test with cpu
         _test_quantize_fp8_row((2, 3), False, torch.device("cpu"), torch.device("cuda"))
         _test_quantize_fp8_row(
             (2, 3), False, torch.device("cpu"), torch.device("cuda"), use_scale_ub=True
         )
+        _test_quantize_fp8_row((4, 2, 3), True, torch.device("cpu"))
+        _test_quantize_fp8_row((6, 4, 2, 3), True, torch.device("cpu"))
 
     def test_scale_fp8_row(self) -> None:
         def _test_scale_fp8_row(


### PR DESCRIPTION
Summary:
reland D66990975 with fix for the NaN issued observed during LLaMa4 17B model run with fp8_rowwise FFN

Specifically, offset was not properly updated when loading/storing data.

Differential Revision: D67303282


