### PR TITLE
[build] OSS build fixes

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,4 +5,4 @@
 
 module(name = "fbgemm")
 
-bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -8,6 +8,15 @@ workspace(name = "fbgemm")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "bazel_skylib",
+    sha256 = "bc283cdfcd526a52c3201279cda4bc298652efa898b10b4db0837dc51652756f",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+    ],
+)
+
+http_archive(
     name = "com_google_googletest",
     strip_prefix = "googletest-1.14.0",
     urls = [
@@ -29,3 +38,6 @@ new_local_repository(
     build_file = "@//external:asmjit.BUILD",
     path = "external/asmjit",
 )
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -8,7 +8,7 @@
 # CMake Prelude
 ################################################################################
 
-cmake_minimum_required(VERSION 3.25.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 
 set(CMAKEMODULES ${CMAKE_CURRENT_SOURCE_DIR}/../cmake/modules)
 set(FBGEMM_GPU ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
- Fix the CMake minimum version in conda install
- Fix issue with missing `librhash.so.0` when installing `gcc`
- Fix build issues with bazel, and upgrade bazel version to latest