### PR TITLE
Async initialization of RockDB SSD tensors

### DIFF
--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
@@ -304,6 +304,17 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
             bulk_init_chunk_size=bulk_init_chunk_size,
         ).cuda()
 
+        if bulk_init_chunk_size > 0:
+            self.assertIsNotNone(
+                emb.lazy_init_thread,
+                "if bulk_init_chunk_size > 0, lazy_init_thread must be set and it should not be force-synchronized yet",
+            )
+
+        # By doing the check for ssd_db being None below, we also access the getter property of ssd_db, which will
+        # force the synchronization of lazy_init_thread, and then reset it to None.
+        if emb.ssd_db is not None:
+            self.assertIsNone(emb.lazy_init_thread)
+
         # A list to keep the CPU tensor alive until `set` (called inside
         # `set_cuda`) is complete. Note that `set_cuda` is non-blocking
         # asynchronous


### PR DESCRIPTION
Summary:
In the diff D66465811 we introduced a bulk initialization function `_insert_all_kv` for ssd tensors. However, large tensors take a long time to fully initialize, and ideally this can happen in the background so it doesn't increase TTFB of the training jobs.

This change does exactly that, moves this initialization to a separate thread, allowing other initialization in the training job, like reading data, to happen concurrently. In order to avoid pushing synchronization to the user space, this change introduces getter and setter for ssd_db, which ensure initialization is fully done before weights are used.

Reviewed By: duduyi2013

Differential Revision: D67480511
