### PR TITLE
Check src & dst dtypes in allgather to prevent silent failures.

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/comm/car.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/comm/car.cpp
@@ -141,6 +141,9 @@ void nccl_allgather(at::Tensor dst, at::Tensor src, int64_t comm_idx) {
   using namespace c10d;
   TORCH_CHECK(src.is_contiguous());
   TORCH_CHECK(dst.is_contiguous());
+  TORCH_CHECK(
+      src.dtype() == dst.dtype(),
+      "dst and src tensors must have the same dtype.");
   ncclDataType_t type = to_nccl_data_type(src.scalar_type());
   C10D_NCCL_CHECK(
       ncclAllGather(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/604

We noticed silent failures when dst & src dtypes mismatch. fbgemm allgather copies memory buffer which produces junk output. Here we add an explicit dtype check.

Differential Revision: D67535285


