### PR TITLE
change pmt require grad to false when detached

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/utils/partially_materialized_tensor.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/utils/partially_materialized_tensor.py
@@ -86,6 +86,7 @@ class PartiallyMaterializedTensor:
 
     @implements(torch.detach)
     def detach(self) -> PartiallyMaterializedTensor:
+        self._requires_grad = False
         return self
 
     def to(self, *args, **kwargs) -> PartiallyMaterializedTensor:


### PR DESCRIPTION
Summary: after calling tensor.detach, tensor.require_grad will automatically switch to false, following the same pattern in PMT tensor

Differential Revision: D67563018


