### PR TITLE
Use 3.12 for building docs

### DIFF
--- a/.github/workflows/fbgemm_gpu_docs.yml
+++ b/.github/workflows/fbgemm_gpu_docs.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.13" ]
+        python-version: [ "3.12" ]
 
     steps:
     - name: Setup Build Container

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,7 +18,7 @@
 
     # Set up Conda environment
     setup_miniconda             $HOME/miniconda
-    create_conda_environment    $BUILD_ENV 3.13
+    create_conda_environment    $BUILD_ENV 3.12
 
     # Install tools
     install_cxx_compiler        $BUILD_ENV


### PR DESCRIPTION
I'm switching to 3.12 to build FBGEMM docs for now.  The trigger of the failure is that we now have torch 3.13t as an experimental nightly build.

cc @atalman There seems to be a mix up in how 3.13 and 3.13t are used in this workflow.  This could mean troubles when people try to use torch 3.13 and 3.13t.

### Testing

https://github.com/pytorch/FBGEMM/actions/runs/12474407777/job/34816361009?pr=3531