### PR TITLE
Improve cutlass bf16 grouped gemm

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/include/kernel_mode.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/include/kernel_mode.h
@@ -32,8 +32,8 @@ inline KernelMode get_kernel_mode(at::Tensor XQ, at::Tensor WQ) {
 }
 
 inline std::tuple<int64_t, int64_t, int64_t> selectLargestProductDimensions(
-    const std::vector<at::Tensor>& XQ,
-    const std::vector<at::Tensor>& WQ) {
+    at::TensorList XQ,
+    at::TensorList WQ) {
   size_t maxProduct = 0;
   std::tuple<int64_t, int64_t, int64_t> dimensions;
   for (size_t i = 0; i < XQ.size(); ++i) {
@@ -55,8 +55,8 @@ inline std::tuple<int64_t, int64_t, int64_t> selectLargestProductDimensions(
 }
 
 inline KernelMode get_grouped_kernel_mode(
-    const std::vector<at::Tensor>& XQ,
-    const std::vector<at::Tensor>& WQ) {
+    at::TensorList XQ,
+    at::TensorList WQ) {
   // Select the dimensions M, N, K from the pair of tensors with the largest
   // product
   auto [M, N, K] = selectLargestProductDimensions(XQ, WQ);


### PR DESCRIPTION
Summary:
This diff cleans up some of the APIs for FBGEMM grouped gemm and updates CUTLASS bf16 grouped gemm to use a single kernel launch to initialize gemm arguments. This should help reduce overhead a bit.

The only notable API change exposed to the user is that all grouped gemm functions now return lists of outputs where bf16 previously returned a single tensor blob. This does mean that in some cases we'll have to do an extra `torch.stack` to unify the groups. If this turns out to be costly, I think we can instead have two grouped gemm implementations, one for dynamic (which returns a single tensor) and one for static shapes which returns a list of tensors.

Reviewed By: jianyuh

Differential Revision: D67423469


