### PR TITLE
Unifying TBE API using List (Backend)

### DIFF
--- a/fbgemm_gpu/cmake/tbe_sources.py
+++ b/fbgemm_gpu/cmake/tbe_sources.py
@@ -191,6 +191,9 @@ gen_fused_optim_header_files = (
     + [
         "gen_embedding_backward_split_common_device_kernel.cuh",
     ]
+    + [
+        "pt2_arg_utils.h",
+    ]
 )
 
 gen_defused_optim_templates = [
@@ -502,7 +505,6 @@ gen_py_files_training = (
         for optimizer in COMMON_OPTIMIZERS + CPU_ONLY_OPTIMIZERS + GPU_ONLY_OPTIMIZERS
         for fstring in [
             "lookup_{}.py",
-            "lookup_{}_pt2.py",
         ]
     ]
     + [
@@ -510,7 +512,6 @@ gen_py_files_training = (
         for optimizer in SSD_OPTIMIZERS
         for fstring in [
             "lookup_{}_ssd.py",
-            "lookup_{}_ssd_pt2.py",
         ]
     ]
     + [

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cpu_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cpu_wrapper_template.cpp
@@ -175,6 +175,7 @@ Tensor split_embedding_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc }}_p
     const Tensor& weights_offsets,
     const Tensor& D_offsets,
     const int64_t max_D,
+    const bool mixed_D,
     const Tensor& hash_size_cumsum,
     const int64_t total_hash_size_bits,
     const Tensor& indices,
@@ -207,19 +208,19 @@ Tensor split_embedding_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc }}_p
             torch::Dispatcher::singleton()
                 .findSchemaOrThrow("fbgemm::{{ backward_op }}", "")
                 .typed<void(
-                    Tensor,
-                    Tensor,
-                    Tensor,
-                    Tensor,
-                    Tensor,
-                    int64_t,
-                    Tensor,
-                    int64_t,
-                    Tensor,
-                    Tensor,
-                    int64_t,
-                    Tensor,
-                    bool,
+                    Tensor, /* grad_output */
+                    Tensor, /* host_weights */
+                    Tensor, /* weights_placements */
+                    Tensor, /* weights_offsets */
+                    Tensor, /* D_offsets */
+                    int64_t, /* max_D */
+                    Tensor, /* hash_size_cumsum */
+                    int64_t, /* total_hash_size_bits */
+                    Tensor, /* indices */
+                    Tensor, /* offsets */
+                    int64_t, /* pooling_mode */
+                    Tensor, /* indices_weights */
+                    bool, /* stochastic_rounding */
                     {%- for arg_type in args.split_function_args %}
                     {{ arg_type.split(' ')[0]}}{%- if not loop.last %}{{ "," }}{%- endif %}
                     {%- endfor %}
@@ -322,6 +323,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         {%- else %}
         "    Tensor D_offsets, "
         "    SymInt max_D, "
+        "    bool mixed_D, "
         {%- endif %}
         "    Tensor hash_size_cumsum, "
         "    int total_hash_size_bits, "

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
@@ -215,6 +215,7 @@ Tensor {{ bwd_mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ 
     {%- else %}
     const Tensor& D_offsets,
     const c10::SymInt max_D,
+    const bool mixed_D,
     {%- endif %}
     const Tensor& hash_size_cumsum,
     const int64_t total_hash_size_bits,
@@ -275,6 +276,7 @@ Tensor {{ bwd_mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ 
                         {%- else %}
                         const Tensor& /*D_offsets*/,
                         const c10::SymInt /*max_D*/,
+                        const bool /*mixed_D*/,
                         {%- endif %}
                         const Tensor& /*hash_size_cumsum*/,
                         const int64_t /*total_hash_size_bits*/,
@@ -327,6 +329,7 @@ Tensor {{ bwd_mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ 
             {%- else %}
             D_offsets,
             max_D,
+            mixed_D,
             {%- endif %}
             hash_size_cumsum,
             total_hash_size_bits,
@@ -570,6 +573,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         {%- else %}
         "    Tensor D_offsets, "
         "    SymInt max_D, "
+        "    bool mixed_D, "
         {%- endif %}
         "    Tensor hash_size_cumsum, "
         "    int total_hash_size_bits, "

--- a/fbgemm_gpu/codegen/training/pt2/pt2_arg_utils_template.h
+++ b/fbgemm_gpu/codegen/training/pt2/pt2_arg_utils_template.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// clang-format off
+#pragma once
+
+namespace fbgemm_gpu {
+
+/* This file is code-generated from generate_backward_split.py to enumerate index of
+ * auxiliary arguments in the list. The enum is generated from the dict `aux_args`,
+ * which is a single source that controls and maintains the argument position.
+*/
+
+{% for name in aux_names %}
+enum ArgIndex_{{ name }} {
+  {%- for var in aux_args[name] %}
+  IDX_{{ var | upper }} = {{ loop.index - 1 }},
+  {%- endfor %}
+  {{ name | upper }}_SIZE = {{ name | length }}
+};
+
+{% endfor %}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/codegen/training/python/lookup_args.template
+++ b/fbgemm_gpu/codegen/training/python/lookup_args.template
@@ -7,7 +7,7 @@
 
 # pyre-strict
 
-from typing import NamedTuple, Optional, Dict
+from typing import NamedTuple, Optional, Dict, List
 
 import torch
 
@@ -57,6 +57,36 @@ class OptimizerArgs(NamedTuple):
     max_gradient: float
     max_norm: float
     learning_rate: float
+    eps: float
+    beta1: float
+    beta2: float
+    weight_decay: float
+    weight_decay_mode: int
+    eta: float
+    momentum: float
+    counter_halflife: int
+    adjustment_iter: int
+    adjustment_ub: float
+    learning_rate_mode: int
+    grad_sum_decay: int
+    tail_id_threshold: float
+    is_tail_id_thresh_ratio: int
+    total_hash_size: int  # Required for OptimType.NONE
+    weight_norm_coefficient: float
+    lower_bound: float
+    regularization_mode: int
+    use_rowwise_bias_correction: bool # Used for OptimType.ADAM
+
+
+class OptimizerArgsPT2(NamedTuple):
+    """
+    Optimizer arguments for PT2 interface
+    """
+    stochastic_rounding: bool
+    gradient_clipping: bool
+    max_gradient: float
+    max_norm: float
+    learning_rate_tensor: torch.Tensor
     eps: float
     beta1: float
     beta2: float

--- a/fbgemm_gpu/codegen/training/python/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/training/python/split_embedding_codegen_lookup_invoker.template
@@ -414,7 +414,7 @@ def invoke(
         row_counter_offsets=row_counter_offsets,
         row_counter_placements=row_counter_placements,
         {%- endif %}
-        {%- if "use_rowwise_bias_correction" in args_pt2.unified_pt2.split_function_arg_names %}
+        {%- if "use_rowwise_bias_correction" in args_pt2.split_function_arg_names %}
         use_rowwise_bias_correction=optimizer_args.use_rowwise_bias_correction,
         {%- endif %}
         # iter

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/tensor_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/tensor_utils.h
@@ -94,6 +94,16 @@ inline bool torch_tensor_empty_or_on_cpu_check(
   return !ten.has_value() || torch_tensor_empty_or_on_cpu_check(ten.value());
 }
 
+inline bool torch_tensor_on_cpu_or_on_mtia_check(const at::Tensor& ten) {
+  return ten.is_cpu() || ten.is_mtia();
+}
+
+#define TENSOR_ON_CPU_OR_MTIA(x)                                      \
+  TORCH_CHECK(                                                        \
+      torch_tensor_on_cpu_or_on_mtia_check(x),                        \
+      #x " must be a CPU or MTIA tensor; it is currently on device ", \
+      torch_tensor_device_name(x))
+
 #define TENSOR_ON_CPU(x)                                      \
   TORCH_CHECK(                                                \
       torch_tensor_on_cpu_check(x),                           \


### PR DESCRIPTION
Summary:
As the number of arguments in TBE keeps growing, some of the optimizers run into number of arguments limitation (i.e., 64) during pytorch operation registration. 

**For long-term growth and maintenance, we hence redesign TBE API by packing some of the arguments into list. Note that not all arguments are packed.**

We pack the arguments as a list for each type.
For **common** arguments, we pack 
- weights and arguments of type `Momentum` into TensorList
- other tensors and optional tensors to list of optional tensors `aux_tensor`
- `int` arguments into `aux_int`
- `float` arguments into `aux_float`
- `bool` arguments into `aux_bool`.

Similarly for **optimizer-specific** arguments, we pack
- arguments of type `Momentum` that are *__not__ optional* into TensorList
- *optional* tensors to list of optional tensors `optim_tensor`
- `int` arguments into `optim_int`
- `float` arguments into `optim_float`
- `bool` arguments into `optim_bool`.

We see issues with pytorch registration across packing SymInt in python-C++, so we unroll and pass SymInt arguments individually. 

**This significantly reduces number of arguments.** For example, `split_embedding_codegen_lookup_rowwise_adagrad_with_counter_function`, which currently has 61 arguments only have 26 arguments with this API design. 

Please refer to the design doc on which arguments are packed and signature.
Design doc:
https://docs.google.com/document/d/1dCBg7dcf7Yq9FHVrvXsAmFtBxkDi9o6u0r-Ptd4UDPE/edit?tab=t.0#heading=h.6bip5pwqq8xb

Full signature for each optimizer lookup function will be provided shortly.

Differential Revision: D68054868


