### PR TITLE
Update GenAI CK Version

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/bf16_grouped_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/bf16_grouped_gemm.hip
@@ -28,7 +28,7 @@ namespace fbgemm_gpu {
 
 // Define useful types that are needed for various kernels.
 using KernelArguments =
-    ck::tensor_operation::device::GroupedGemmTileLoopKernelArguments<0>;
+    ck::tensor_operation::device::GroupedGemmKernelArgument<0>;
 using ADataType = ck::bhalf_t;
 using BDataType = ck::bhalf_t;
 using CDataType = ck::bhalf_t;

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_common.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_common.h
@@ -125,7 +125,7 @@ std::vector<at::Tensor> bf16_grouped_impl(
   // Get input information.
   int group_count = A.size();
   using KernelArguments =
-      ck::tensor_operation::device::GroupedGemmTileLoopKernelArguments<0>;
+      ck::tensor_operation::device::GroupedGemmKernelArgument<0>;
   using GemmDesc = ck::tensor_operation::device::GemmDesc;
   // Create gemm shape containers.
   std::vector<GemmDesc> gemm_descs;

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
@@ -29,7 +29,7 @@ namespace fbgemm_gpu {
 
 // Define useful types that are needed for various kernels.
 using KernelArguments =
-    ck::tensor_operation::device::GroupedGemmTileLoopKernelArguments<2>;
+    ck::tensor_operation::device::GroupedGemmKernelArgument<2>;
 using ADataType = ck::f8_t;
 using BDataType = ck::f8_t;
 using D0DataType = float;

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_common.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_common.h
@@ -133,7 +133,7 @@ std::vector<at::Tensor> f8f8bf16_rowwise_grouped_impl(
   // Get input information.
   int group_count = XQ.size();
   using KernelArguments =
-      ck::tensor_operation::device::GroupedGemmTileLoopKernelArguments<2>;
+      ck::tensor_operation::device::GroupedGemmKernelArgument<2>;
   using GemmDesc = ck::tensor_operation::device::GemmDesc;
   // Create gemm shape containers.
   std::vector<GemmDesc> gemm_descs;


### PR DESCRIPTION
Summary:
This diff pulls in the latest from the develop branch of CK. There have been a few small API changes that we also accommodate in fbgemm. It looks like AMD also fixed a bunch of their compilation issues so we were able to re-add a bunch of files to the ck-library target.

I dont see any performance or accuracy regressions from this bump in fbgemm kernels.

Differential Revision: D68113590


