### PR TITLE
Updates and fixes to tensor_accessor.h

### DIFF
--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_cpu.cpp
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_cpu.cpp
@@ -14,6 +14,7 @@
 #include "fbgemm_gpu/utils/cpu_utils.h"
 #include "fbgemm_gpu/utils/dispatch_macros.h"
 #include "fbgemm_gpu/utils/ops_utils.h"
+#include "fbgemm_gpu/utils/tensor_accessor.h"
 #ifdef FBCODE_CAFFE2
 #include <libdivide.h>
 #else
@@ -384,9 +385,9 @@ template <typename index_t, typename scalar_t, bool IS_VALUE_PAIR>
 void csr2csc_template_(
     HyperCompressedSparseColumn& csc,
     int B,
-    const at::TensorAccessor<index_t, 1>& csr_offsets,
-    const at::TensorAccessor<index_t, 1>& csr_indices,
-    const at::TensorAccessor<scalar_t, 1>& csr_weights,
+    const pta::TensorAccessor<index_t, 1>& csr_offsets,
+    const pta::TensorAccessor<index_t, 1>& csr_indices,
+    const pta::TensorAccessor<scalar_t, 1>& csr_weights,
     int64_t pooling_mode,
     const int* table_to_feature_offset,
     int64_t num_embeddings) {
@@ -585,9 +586,9 @@ void csr2csc_template_(
   template void csr2csc_template_<index_t, scalar_t, is_value_pair>(     \
       HyperCompressedSparseColumn & csc,                                 \
       int B,                                                             \
-      const at::TensorAccessor<index_t, 1>& csr_offsets,                 \
-      const at::TensorAccessor<index_t, 1>& csr_indices,                 \
-      const at::TensorAccessor<scalar_t, 1>& csr_weights,                \
+      const pta::TensorAccessor<index_t, 1>& csr_offsets,                \
+      const pta::TensorAccessor<index_t, 1>& csr_indices,                \
+      const pta::TensorAccessor<scalar_t, 1>& csr_weights,               \
       int64_t pooling_mode,                                              \
       const int* table_to_feature_offset,                                \
       int64_t num_embeddings);
@@ -613,9 +614,9 @@ template <typename index_t, typename scalar_t>
 void csr2csc(
     HyperCompressedSparseColumn& csc,
     int B,
-    const at::TensorAccessor<index_t, 1>& csr_offsets,
-    const at::TensorAccessor<index_t, 1>& csr_indices,
-    const at::TensorAccessor<scalar_t, 1>& csr_weights,
+    const pta::TensorAccessor<index_t, 1>& csr_offsets,
+    const pta::TensorAccessor<index_t, 1>& csr_indices,
+    const pta::TensorAccessor<scalar_t, 1>& csr_weights,
     int64_t pooling_mode,
     const int* table_to_feature_offset,
     int64_t num_embeddings) {
@@ -644,15 +645,15 @@ void csr2csc(
   }
 }
 
-#define INSTANTIATE_CSR2CSC_0(index_t, scalar_t)          \
-  template void csr2csc<index_t, scalar_t>(               \
-      HyperCompressedSparseColumn & csc,                  \
-      int B,                                              \
-      const at::TensorAccessor<index_t, 1>& csr_offsets,  \
-      const at::TensorAccessor<index_t, 1>& csr_indices,  \
-      const at::TensorAccessor<scalar_t, 1>& csr_weights, \
-      int64_t pooling_mode,                               \
-      const int* table_to_feature_offset,                 \
+#define INSTANTIATE_CSR2CSC_0(index_t, scalar_t)           \
+  template void csr2csc<index_t, scalar_t>(                \
+      HyperCompressedSparseColumn & csc,                   \
+      int B,                                               \
+      const pta::TensorAccessor<index_t, 1>& csr_offsets,  \
+      const pta::TensorAccessor<index_t, 1>& csr_indices,  \
+      const pta::TensorAccessor<scalar_t, 1>& csr_weights, \
+      int64_t pooling_mode,                                \
+      const int* table_to_feature_offset,                  \
       int64_t num_embeddings);
 
 #define INSTANTIATE_CSR2CSC_1(index_t)   \

--- a/fbgemm_gpu/include/fbgemm_gpu/embedding_forward_split_cpu.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/embedding_forward_split_cpu.h
@@ -11,6 +11,7 @@
 #include <ATen/ATen.h>
 #include <ATen/Parallel.h>
 #include "fbgemm/Utils.h"
+#include "fbgemm_gpu/utils/tensor_accessor.h"
 
 at::Tensor split_embedding_codegen_forward_cpu(
     at::Tensor weights,
@@ -120,9 +121,9 @@ template <typename index_t, typename scalar_t>
 void csr2csc(
     HyperCompressedSparseColumn& csc,
     int B,
-    const at::TensorAccessor<index_t, 1>& csr_offsets,
-    const at::TensorAccessor<index_t, 1>& csr_indices,
-    const at::TensorAccessor<scalar_t, 1>& csr_weights,
+    const pta::TensorAccessor<index_t, 1>& csr_offsets,
+    const pta::TensorAccessor<index_t, 1>& csr_indices,
+    const pta::TensorAccessor<scalar_t, 1>& csr_weights,
     int64_t pooling_mode,
     const int* table_to_feature_offset,
     int64_t num_embeddings);

--- a/fbgemm_gpu/test/tbe/utils/cpu_kernel_test.cpp
+++ b/fbgemm_gpu/test/tbe/utils/cpu_kernel_test.cpp
@@ -13,7 +13,14 @@
 
 #include "fbgemm_gpu/embedding_common.h"
 #include "fbgemm_gpu/embedding_forward_split_cpu.h"
+#include "fbgemm_gpu/utils/tensor_accessor.h"
 #include "torch/types.h" // @manual=//caffe2:torch-cpp-cpu
+
+#if FBGEMM_GPU_MEMCHECK
+#define FBGEMM_MEM_CHECK_ONLY
+#else
+#define FBGEMM_MEM_CHECK_ONLY maybe_unused
+#endif
 
 template <c10::ScalarType DType, typename T>
 void test_csr2csc() {
@@ -27,13 +34,14 @@ void test_csr2csc() {
   int table_to_feature_offset[2] = {0, 1};
   int num_embeddings = 10;
 
+  const auto no_weights = at::empty({0}, at::TensorOptions().dtype(at::kFloat));
+  [[FBGEMM_MEM_CHECK_ONLY]] const auto func_name1 = "::internal::csr2csc_1";
   ::internal::csr2csc(
       csc,
       B,
-      offsets.accessor<T, 1>(),
-      indices.accessor<T, 1>(),
-      at::TensorAccessor<at::acc_type<float, true>, 1>(
-          nullptr, nullptr, nullptr), // no weights
+      MAKE_TA_WITH_NAME(func_name1, offsets, T, 1),
+      MAKE_TA_WITH_NAME(func_name1, indices, T, 1),
+      MAKE_TA_WITH_NAME(func_name1, no_weights, float, 1),
       pooling_mode,
       table_to_feature_offset,
       num_embeddings);
@@ -61,12 +69,16 @@ void test_csr2csc() {
   internal::HyperCompressedSparseColumn csc_weighted;
   at::Tensor indice_weights = torch::tensor(
       {1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f}, torch::kFloat32);
+
+  [[maybe_unused]] const auto func_name2 = "::internal::csr2csc_2";
+  using weight_t = at::acc_type<float, true>;
+
   ::internal::csr2csc(
       csc_weighted,
       B,
-      offsets.accessor<T, 1>(),
-      indices.accessor<T, 1>(),
-      indice_weights.accessor<at::acc_type<float, true>, 1>(),
+      MAKE_TA_WITH_NAME(func_name2, offsets, T, 1),
+      MAKE_TA_WITH_NAME(func_name2, indices, T, 1),
+      MAKE_TA_WITH_NAME(func_name2, indice_weights, weight_t, 1),
       pooling_mode,
       table_to_feature_offset,
       num_embeddings);
@@ -99,3 +111,5 @@ TEST(CpuKernelTest, csr2csc_test_int32) {
 TEST(CpuKernelTest, csr2csc_test_int64) {
   test_csr2csc<torch::kInt64, int64_t>();
 }
+
+#undef FBGEMM_MEM_CHECK_ONLY

--- a/fbgemm_gpu/test/utils/tensor_accessor_test.cu
+++ b/fbgemm_gpu/test/utils/tensor_accessor_test.cu
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <gtest/gtest.h>
+#include <torch/types.h> // @manual=//caffe2:torch-cpp-cpu
+
+// DISABLE compilation in FBGEMM_GPU_MEMCHECK mode as a test
+#ifdef FBGEMM_GPU_MEMCHECK
+#undef FBGEMM_GPU_MEMCHECK
+#endif
+
+#include "fbgemm_gpu/utils/tensor_accessor.h"
+
+template <typename T>
+void test_ta_create_1(const at::Tensor& tensor) {
+  [[maybe_unused]] const auto func_name = "test_ta_create";
+  [[maybe_unused]] const auto accessor =
+      MAKE_TA_WITH_NAME(func_name, tensor, T, 1);
+}
+
+template <size_t N>
+void test_ta_create_2(const at::Tensor& tensor) {
+  [[maybe_unused]] const auto func_name = "test_ta_create";
+  [[maybe_unused]] const auto accessor =
+      MAKE_TA_WITH_NAME(func_name, tensor, float, N);
+}
+
+void test_ta_create_3(const at::Tensor& tensor) {
+  [[maybe_unused]] const auto func_name = "test_ta_create";
+  [[maybe_unused]] const auto accessor =
+      MAKE_TA_WITH_NAME(func_name, tensor, float, 1);
+}
+
+TEST(TensorAccessorTest, test_ta_create) {
+  const auto tensor = torch::tensor(
+      {1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f}, torch::kFloat32);
+  // Test mismatched types
+  EXPECT_THROW({ test_ta_create_1<int32_t>(tensor); }, std::exception);
+  EXPECT_THROW({ test_ta_create_1<int64_t>(tensor); }, std::exception);
+  EXPECT_THROW({ test_ta_create_1<double>(tensor); }, std::exception);
+
+  // Test invalid dimensions
+  EXPECT_THROW({ test_ta_create_2<2>(tensor); }, std::exception);
+  EXPECT_THROW({ test_ta_create_2<3>(tensor); }, std::exception);
+  EXPECT_THROW({ test_ta_create_2<4>(tensor); }, std::exception);
+
+  // Test valid type and dimension
+  EXPECT_NO_THROW({ test_ta_create_3(tensor); });
+}
+
+template <typename T>
+void test_pta_create_1(const at::Tensor& tensor) {
+  [[maybe_unused]] const auto func_name = "test_pta_create";
+  [[maybe_unused]] const auto accessor =
+      MAKE_PTA_WITH_NAME(func_name, tensor, T, 1, 64);
+}
+
+template <size_t N>
+void test_pta_create_2(const at::Tensor& tensor) {
+  [[maybe_unused]] const auto func_name = "test_pta_create";
+  [[maybe_unused]] const auto accessor =
+      MAKE_PTA_WITH_NAME(func_name, tensor, float, N, 64);
+}
+
+void test_pta_create_3(const at::Tensor& tensor) {
+  [[maybe_unused]] const auto func_name = "test_pta_create";
+  [[maybe_unused]] const auto accessor =
+      MAKE_PTA_WITH_NAME(func_name, tensor, float, 1, 64);
+}
+
+TEST(PackedTensorAccessorTest, test_pta_create) {
+  const auto tensor = torch::tensor(
+      {1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f}, torch::kFloat32);
+  // Test mismatched types
+  EXPECT_THROW({ test_pta_create_1<int32_t>(tensor); }, std::exception);
+  EXPECT_THROW({ test_pta_create_1<int64_t>(tensor); }, std::exception);
+  EXPECT_THROW({ test_pta_create_1<double>(tensor); }, std::exception);
+
+  // Test invalid dimensions
+  EXPECT_THROW({ test_pta_create_2<2>(tensor); }, std::exception);
+  EXPECT_THROW({ test_pta_create_2<3>(tensor); }, std::exception);
+  EXPECT_THROW({ test_pta_create_2<4>(tensor); }, std::exception);
+
+  // Test valid type and dimension
+  EXPECT_NO_THROW({ test_pta_create_3(tensor); });
+}

--- a/fbgemm_gpu/test/utils/tensor_accessor_with_memcheck_test.cu
+++ b/fbgemm_gpu/test/utils/tensor_accessor_with_memcheck_test.cu
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <gtest/gtest.h>
+#include <torch/types.h> // @manual=//caffe2:torch-cpp-cpu
+
+// ENABLE compilation in FBGEMM_GPU_MEMCHECK mode as a test
+#ifndef FBGEMM_GPU_MEMCHECK
+#define FBGEMM_GPU_MEMCHECK
+#endif
+
+#include "fbgemm_gpu/utils/tensor_accessor.h"
+
+template <typename T>
+void test_ta_create_1(const at::Tensor& tensor) {
+  const auto func_name = "test_ta_make";
+  [[maybe_unused]] const auto accessor =
+      MAKE_TA_WITH_NAME(func_name, tensor, T, 1);
+}
+
+template <size_t N>
+void test_ta_create_2(const at::Tensor& tensor) {
+  const auto func_name = "test_ta_make";
+  [[maybe_unused]] const auto accessor =
+      MAKE_TA_WITH_NAME(func_name, tensor, float, N);
+}
+
+void test_ta_create_3(const at::Tensor& tensor) {
+  const auto func_name = "test_ta_make";
+  [[maybe_unused]] const auto accessor =
+      MAKE_TA_WITH_NAME(func_name, tensor, float, 1);
+}
+
+TEST(TensorAccessorWithMemcheckTest, test_ta_create) {
+  const auto tensor = torch::tensor(
+      {1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f}, torch::kFloat32);
+  // Test mismatched types
+  EXPECT_THROW({ test_ta_create_1<int32_t>(tensor); }, std::exception);
+  EXPECT_THROW({ test_ta_create_1<int64_t>(tensor); }, std::exception);
+  EXPECT_THROW({ test_ta_create_1<double>(tensor); }, std::exception);
+
+  // Test invalid dimensions
+  EXPECT_THROW({ test_ta_create_2<2>(tensor); }, std::exception);
+  EXPECT_THROW({ test_ta_create_2<3>(tensor); }, std::exception);
+  EXPECT_THROW({ test_ta_create_2<4>(tensor); }, std::exception);
+
+  // Test valid type and dimension
+  EXPECT_NO_THROW({ test_ta_create_3(tensor); });
+}
+
+template <c10::ScalarType DType, typename T>
+void test_ta_access() {
+  const auto func_name = "ta_access";
+  const auto tensor = at::empty({0}, at::TensorOptions().dtype(DType));
+  const auto accessor = MAKE_TA_WITH_NAME(func_name, tensor, T, 1);
+
+  EXPECT_DEATH({ accessor.at(10); }, "idx < numel_");
+}
+
+// NOTE: CUDA_KERNEL_ASSERT appears to be a no-op when HIPified
+#ifndef __HIPCC__
+TEST(TensorAccessorWithMemcheckTest, test_ta_access) {
+  test_ta_access<torch::kInt32, int32_t>();
+  test_ta_access<torch::kInt64, int64_t>();
+}
+#endif
+
+template <typename T>
+void test_pta_create_1(const at::Tensor& tensor) {
+  [[maybe_unused]] const auto func_name = "test_pta_create";
+  [[maybe_unused]] const auto accessor =
+      MAKE_PTA_WITH_NAME(func_name, tensor, T, 1, 64);
+}
+
+template <size_t N>
+void test_pta_create_2(const at::Tensor& tensor) {
+  [[maybe_unused]] const auto func_name = "test_pta_create";
+  [[maybe_unused]] const auto accessor =
+      MAKE_PTA_WITH_NAME(func_name, tensor, float, N, 64);
+}
+
+void test_pta_create_3(const at::Tensor& tensor) {
+  [[maybe_unused]] const auto func_name = "test_pta_create";
+  [[maybe_unused]] const auto accessor =
+      MAKE_PTA_WITH_NAME(func_name, tensor, float, 1, 64);
+}
+
+TEST(PackedTensorAccessorTest, test_pta_create) {
+  const auto tensor = torch::tensor(
+      {1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f}, torch::kFloat32);
+  // Test mismatched types
+  EXPECT_THROW({ test_pta_create_1<int32_t>(tensor); }, std::exception);
+  EXPECT_THROW({ test_pta_create_1<int64_t>(tensor); }, std::exception);
+  EXPECT_THROW({ test_pta_create_1<double>(tensor); }, std::exception);
+
+  // Test invalid dimensions
+  EXPECT_THROW({ test_pta_create_2<2>(tensor); }, std::exception);
+  EXPECT_THROW({ test_pta_create_2<3>(tensor); }, std::exception);
+  EXPECT_THROW({ test_pta_create_2<4>(tensor); }, std::exception);
+
+  // Test valid type and dimension
+  EXPECT_NO_THROW({ test_pta_create_3(tensor); });
+}
+
+template <c10::ScalarType DType, typename T>
+void test_pta_access() {
+  const auto func_name = "test_pta_access";
+  const auto tensor = at::empty({0}, at::TensorOptions().dtype(DType));
+  const auto accessor = MAKE_PTA_WITH_NAME(func_name, tensor, T, 1, 64);
+
+  EXPECT_DEATH({ accessor.at(10); }, "idx < numel_");
+}
+
+#ifndef __HIPCC__
+TEST(PackedTensorAccessorWithMemcheckTest, test_pta_access) {
+  test_pta_access<torch::kInt32, int32_t>();
+  test_pta_access<torch::kInt64, int64_t>();
+}
+#endif
+
+#undef FBGEMM_GPU_MEMCHECK


### PR DESCRIPTION
Summary:
- Fix `TensorAccessorBase` constructor to work with empty tensors, which are used in FBGEMM code

- Add better logging for errors

Differential Revision: D68048640


