### PR TITLE
Enable v2 forward test for ROCm

### DIFF
--- a/fbgemm_gpu/test/tbe/training/forward_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_test.py
@@ -541,7 +541,7 @@ class ForwardTest(unittest.TestCase):
 
     @unittest.skipIf(*gpu_unavailable)
     @given(
-        use_experimental_tbe=st.booleans() if not TEST_WITH_ROCM else st.just(False),
+        use_experimental_tbe=st.booleans(),
     )
     @settings(
         verbosity=VERBOSITY,
@@ -670,7 +670,7 @@ class ForwardTest(unittest.TestCase):
     @unittest.skipIf(*gpu_unavailable)
     @given(
         cache_algorithm=st.sampled_from(CacheAlgorithm),
-        use_experimental_tbe=st.booleans() if not TEST_WITH_ROCM else st.just(False),
+        use_experimental_tbe=st.booleans(),
     )
     @settings(
         verbosity=VERBOSITY,
@@ -740,7 +740,7 @@ class ForwardTest(unittest.TestCase):
     @unittest.skipIf(*gpu_unavailable)
     @given(
         cache_algorithm=st.sampled_from(CacheAlgorithm),
-        use_experimental_tbe=st.booleans() if not TEST_WITH_ROCM else st.just(False),
+        use_experimental_tbe=st.booleans(),
     )
     @settings(
         verbosity=VERBOSITY,


### PR DESCRIPTION
Since https://github.com/pytorch/FBGEMM/pull/3266 is merged, the v2 forward kernel should be tested for ROCm devices as well. 

cc: @liligwu 