### PR TITLE
add patchelf as a required package in fbgemm_gpu/requirements.txt

### DIFF
--- a/fbgemm_gpu/requirements.txt
+++ b/fbgemm_gpu/requirements.txt
@@ -23,3 +23,4 @@ scikit-build
 setuptools
 setuptools_git_versioning
 tabulate
+patchelf


### PR DESCRIPTION
As https://github.com/pytorch/FBGEMM/blob/4f620223837d68303097775db0afbcff8013603d/.github/scripts/fbgemm_gpu_postbuild.bash#L20 uses `patchelf`, it should be in requirements.txt