### PR TITLE
put KVTensorWrapper in its own header

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ATen/Tensor.h> // @manual=//caffe2:ATen-core
+#include <torch/custom_class.h>
+
+namespace ssd {
+
+class EmbeddingRocksDB;
+class EmbeddingRocksDBWrapper;
+class SnapshotHandle;
+
+// @lint-ignore CLANGTIDY cppcoreguidelines-special-member-functions
+struct EmbeddingSnapshotHandleWrapper : public torch::jit::CustomClassHolder {
+  explicit EmbeddingSnapshotHandleWrapper(
+      const SnapshotHandle* handle,
+      std::shared_ptr<EmbeddingRocksDB> db);
+
+  ~EmbeddingSnapshotHandleWrapper();
+
+  const SnapshotHandle* handle;
+  std::shared_ptr<EmbeddingRocksDB> db;
+};
+
+class KVTensorWrapper : public torch::jit::CustomClassHolder {
+ public:
+  explicit KVTensorWrapper(
+      c10::intrusive_ptr<EmbeddingRocksDBWrapper> db,
+      std::vector<int64_t> shape,
+      int64_t dtype,
+      int64_t row_offset,
+      std::optional<c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper>>
+          snapshot_handle);
+
+  at::Tensor narrow(int64_t dim, int64_t start, int64_t length);
+
+  void set_range(
+      int64_t dim,
+      const int64_t start,
+      const int64_t length,
+      const at::Tensor& weights);
+
+  c10::IntArrayRef size();
+
+  c10::ScalarType dtype();
+
+  std::string_view dtype_str();
+
+  c10::Device device();
+
+  std::string device_str();
+
+  std::string layout_str();
+
+ private:
+  std::shared_ptr<EmbeddingRocksDB> db_;
+  c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper> snapshot_handle_;
+  at::TensorOptions options_;
+  std::vector<int64_t> shape_;
+  int64_t row_offset_;
+};
+
+} // namespace ssd

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper_cpu.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper_cpu.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <c10/core/ScalarTypeToTypeMeta.h>
+#include <torch/library.h>
+
+#include "./kv_tensor_wrapper.h"
+#include "common/base/Exception.h"
+
+using namespace at;
+using namespace ssd;
+
+namespace ssd {
+class EmbeddingRocksDB {};
+
+// @lint-ignore CLANGTIDY facebook-hte-ShadowingClass
+class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
+ private:
+  friend class KVTensorWrapper;
+  std::shared_ptr<EmbeddingRocksDB> impl_;
+};
+
+class SnapshotHandle {};
+
+KVTensorWrapper::KVTensorWrapper(
+    c10::intrusive_ptr<EmbeddingRocksDBWrapper> db,
+    std::vector<int64_t> shape,
+    [[maybe_unused]] int64_t dtype,
+    int64_t row_offset,
+    [[maybe_unused]] std::optional<
+        c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper>> snapshot_handle)
+    // @lint-ignore CLANGTIDY clang-diagnostic-missing-noreturn
+    : db_(db->impl_), shape_(std::move(shape)), row_offset_(row_offset) {
+  FBEXCEPTION("Not implemented");
+}
+
+at::Tensor KVTensorWrapper::narrow(
+    [[maybe_unused]] int64_t dim,
+    [[maybe_unused]] int64_t start,
+    [[maybe_unused]] int64_t length) {
+  FBEXCEPTION("Not implemented");
+  return at::empty(c10::IntArrayRef({1, 1}), options_);
+}
+
+void KVTensorWrapper::set_range(
+    [[maybe_unused]] int64_t dim,
+    [[maybe_unused]] const int64_t start,
+    [[maybe_unused]] const int64_t length,
+    // @lint-ignore CLANGTIDY clang-diagnostic-missing-noreturn
+    [[maybe_unused]] const at::Tensor& weights) {
+  FBEXCEPTION("Not implemented");
+}
+
+c10::IntArrayRef KVTensorWrapper::size() {
+  FBEXCEPTION("Not implemented");
+  return shape_;
+}
+
+c10::ScalarType KVTensorWrapper::dtype() {
+  FBEXCEPTION("Not implemented");
+  return options_.dtype().toScalarType();
+}
+
+std::string_view KVTensorWrapper::dtype_str() {
+  FBEXCEPTION("Not implemented");
+  return scalarTypeToTypeMeta(dtype()).name();
+}
+
+c10::Device KVTensorWrapper::device() {
+  FBEXCEPTION("Not implemented");
+  return options_.device();
+}
+
+std::string KVTensorWrapper::device_str() {
+  FBEXCEPTION("Not implemented");
+  return device().str();
+}
+
+std::string KVTensorWrapper::layout_str() {
+  FBEXCEPTION("Not implemented");
+  std::ostringstream oss;
+  oss << options_.layout();
+  return oss.str();
+}
+} // namespace ssd


### PR DESCRIPTION
Summary:
some consumers of KVTensorWrapper build cpu-only packages. this diff made the following changes to avoid linking against cuda libraries:
- put KVTensorWrapper in its own header file
- add a dummy cpu target for KVTensorWrapper

Reviewed By: q10, sryap

Differential Revision: D68060586


