### PR TITLE
Profile with kineto and warmup for more accurate benchmarking

### DIFF
--- a/fbgemm_gpu/bench/bench_utils.py
+++ b/fbgemm_gpu/bench/bench_utils.py
@@ -163,8 +163,10 @@ def benchmark_requests(
 ) -> float:
     times = []
     # Run at least one warmup iteration to avoid the long cudaLaunchKernel time
-    # for the first kernel
-    num_warmups = num_warmups + 1 if num_warmups >= 0 else 1
+    # for the first kernel if warmup_ms > 0
+    # warmup_ms is prioritized over num_warmups
+    if (warmup_ms is None):
+        num_warmups = num_warmups + 1 if num_warmups >= 0 else 1
 
     # warm-up the GPU before profiling
     if warmup_ms:
@@ -188,8 +190,7 @@ def benchmark_requests(
                 out = func(indices, offsets, weights)
                 if bwd_only:
                     out.backward(grad)
-
-    if num_warmups > 0:
+    else:
         indices, offsets, weights = requests[0].unpack_3()
         for _ in range(num_warmups):
             out = func(indices, offsets, weights)

--- a/fbgemm_gpu/bench/bench_utils.py
+++ b/fbgemm_gpu/bench/bench_utils.py
@@ -205,20 +205,18 @@ def benchmark_requests(
         num_warmups = num_warmups + 1 if num_warmups >= 0 else 1
 
     # warm-up the GPU before profiling
-    if warmup_ms or num_warmups:
-        warmup(
-            requests[0],
-            warmup_ms,
-            num_warmups,
-            lambda indices, offsets, per_sample_weights: func(
-                indices.int(),
-                offsets.int(),
-                per_sample_weights,
-
-            ),
-            bwd_only=bwd_only,
-            grad=grad,
-        )
+    warmup(
+        requests[0],
+        warmup_ms,
+        num_warmups,
+        lambda indices, offsets, per_sample_weights: func(
+            indices.int(),
+            offsets.int(),
+            per_sample_weights,
+        ),
+        bwd_only=bwd_only,
+        grad=grad,
+    )
 
     if callback_after_warmup is not None:
         callback_after_warmup()

--- a/fbgemm_gpu/bench/bench_utils.py
+++ b/fbgemm_gpu/bench/bench_utils.py
@@ -187,7 +187,8 @@ def benchmark_requests(
     # Run at least one warmup iteration to avoid the long cudaLaunchKernel time
     # for the first kernel if warmup_ms > 0
     # warmup_ms is prioritized over num_warmups
-    if (warmup_ms is None):
+
+    if warmup_ms is None:
         num_warmups = num_warmups + 1 if num_warmups >= 0 else 1
 
     # warm-up the GPU before profiling

--- a/fbgemm_gpu/bench/bench_utils.py
+++ b/fbgemm_gpu/bench/bench_utils.py
@@ -40,25 +40,11 @@ def warmup(
 ) -> None:
     indices, offsets, weights = request.unpack_3()
     if warmup_ms:
-        if torch.cuda.is_available():
-            elapsed_time_ms = 0
-            torch.cuda.synchronize()
-            start_events = torch.cuda.Event(enable_timing=True)
-            end_events = torch.cuda.Event(enable_timing=True)
-            while elapsed_time_ms < warmup_ms:
-                start_events.record()
-                out = func(indices, offsets, weights)
-                if bwd_only:
-                    out.backward(grad)
-                end_events.record()
-                torch.cuda.synchronize()
-                elapsed_time_ms += start_events.elapsed_time(end_events)
-        else:
-            start_time_ms = time.time() * 1000
-            while time.time() * 1000 - start_time_ms < warmup_ms:
-                out = func(indices, offsets, weights)
-                if bwd_only:
-                    out.backward(grad)
+        start_time_ms = time.time() * 1000
+        while time.time() * 1000 - start_time_ms < warmup_ms:
+            out = func(indices, offsets, weights)
+            if bwd_only:
+                out.backward(grad)
     else:
         for _ in range(warmup_runs):
             out = func(indices, offsets, weights)

--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -1331,6 +1331,9 @@ def nbit_device(  # noqa C901
         p.export_chrome_trace(
             trace_url.format(tbe_type=tbe_type, phase=phase, ospid=os.getpid())
         )
+        # averges the sum of all kernels
+        total_cuda_time = sum(event.device_time*event.count/(iters+1) for event in p.key_averages() if event.cpu_time == 0.0)
+        print(f"Total CUDA time: {total_cuda_time:.3f} ")
 
     # pyre-ignore[3]
     def context_factory(on_trace_ready: Callable[[profile], None]):

--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -1135,6 +1135,7 @@ def nbit_cpu(  # noqa C901
 @click.option("--iters", default=100)
 @click.option("--runs-of-iters", default=5)
 @click.option("--warmup-runs", default=2)
+@click.option("--warmup-ms", type=int, default=None)
 @click.option("--output-dtype", type=SparseType, default=SparseType.FP16)
 @click.option("--report-aibench", is_flag=True)
 @click.option("--run-reference", is_flag=True, default=False)
@@ -1169,6 +1170,7 @@ def nbit_device(  # noqa C901
     iters: int,
     runs_of_iters: int,
     warmup_runs: int,
+    warmup_ms: Optional[int],
     output_dtype: SparseType,
     report_aibench: bool,
     run_reference: bool,
@@ -1295,6 +1297,7 @@ def nbit_device(  # noqa C901
                 per_sample_weights,
             ),
             check_median=check_median,
+            warmup_ms=warmup_ms,
         )
 
         # free up GPU memory

--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -1410,17 +1410,18 @@ def nbit_device(  # noqa C901
             check_median=check_median,
         )
 
-    kernel_time = time_dict['kernel_time']
-    bandwidth = read_write_bytes / kernel_time / 1.0e3
+    if export_trace:
+        kernel_time = time_dict['kernel_time']
+        bandwidth = read_write_bytes / kernel_time / 1.0e3
 
-    logging.info(
-        f"kineto profiled stats: "
-        f"{weights_precision} Forward, B: {B}, "
-        f"E: {E}, T: {T}, D: {D}, L: {L}, W: {weighted}, "
-        f"BW: {bandwidth: .2f} GB/s, "  # noqa: B950
-        f"Time: {kernel_time:.0f}us, "
-        f"Memory Usage For Pruning: {mem_for_pruning / 1.0e9:.0f} GB"
-    )
+        logging.info(
+            f"kineto profiled stats: "
+            f"{weights_precision} Forward, B: {B}, "
+            f"E: {E}, T: {T}, D: {D}, L: {L}, W: {weighted}, "
+            f"BW: {bandwidth: .2f} GB/s, "  # noqa: B950
+            f"Time: {kernel_time:.0f}us, "
+            f"Memory Usage For Pruning: {mem_for_pruning / 1.0e9:.0f} GB"
+        )
 
     # free up GPU memory
     del requests
@@ -1831,17 +1832,18 @@ def nbit_device_with_spec(  # noqa C901
                 check_median=check_median,
             )
 
-        kernel_time = time_dict['kernel_time']
-        bandwidth = read_write_bytes / kernel_time / 1.0e3
+        if export_trace:
+            kernel_time = time_dict['kernel_time']
+            bandwidth = read_write_bytes / kernel_time / 1.0e3
 
-        logging.info(
-            f"kineto profiled stats: "
-            f"{weights_precision} Forward, B: {B}, "
-            f"E: {E}, T: {T}, D: {D}, L: {L}, W: {weighted}, "
-            f"BW: {bandwidth: .2f} GB/s, "  # noqa: B950
-            f"Time: {kernel_time:.0f}us, "
-            f"Memory Usage For Pruning: {mem_for_pruning / 1.0e9:.0f} GB"
-        )
+            logging.info(
+                f"kineto profiled stats: "
+                f"{weights_precision} Forward, B: {B}, "
+                f"E: {E}, T: {T}, D: {D}, L: {L}, W: {weighted}, "
+                f"BW: {bandwidth: .2f} GB/s, "  # noqa: B950
+                f"Time: {kernel_time:.0f}us, "
+                f"Memory Usage For Pruning: {mem_for_pruning / 1.0e9:.0f} GB"
+            )
 
     # free up memory
     del kineto_request

--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -95,10 +95,7 @@ else:
 logging.basicConfig(level=logging.DEBUG)
 
 
-def kineto_trace_profiler(
-    p: profile,
-    trace_info: tuple[str, str, str, str]
-) -> float:
+def kineto_trace_profiler(p: profile, trace_info: tuple[str, str, str, str]) -> float:
     phase, trace_url, tbe_type, kern_name = trace_info
     p.export_chrome_trace(
         trace_url.format(tbe_type=tbe_type, phase=phase, ospid=os.getpid())
@@ -1169,13 +1166,15 @@ def nbit_cpu(  # noqa C901
     default="{tbe_type}_tbe_{phase}_trace_{ospid}.json",
 )
 @click.option(
-    "--warmup-runs", default=2,
-    help="Number of warmup runs. Ignored if --warmup-ms is set.")
+    "--warmup-runs",
+    default=2,
+    help="Number of warmup runs. Ignored if --warmup-ms is set.",
+)
 @click.option(
     "--warmup-ms",
     type=int,
     default=None,
-    help="Warmup duration in milliseconds. Disables the --run-nums option."
+    help="Warmup duration in milliseconds. Disables the --run-nums option.",
 )
 def nbit_device(  # noqa C901
     alpha: float,
@@ -1393,7 +1392,7 @@ def nbit_device(  # noqa C901
                 indices.int(),
                 offsets.int(),
                 per_sample_weights,
-            )
+            ),
         )
 
     with context_factory(
@@ -1411,7 +1410,7 @@ def nbit_device(  # noqa C901
         )
 
     if export_trace:
-        kernel_time = time_dict['kernel_time']
+        kernel_time = time_dict["kernel_time"]
         bandwidth = read_write_bytes / kernel_time / 1.0e3
 
         logging.info(
@@ -1536,13 +1535,15 @@ def nbit_device(  # noqa C901
     default="{tbe_type}_tbe_spec_{phase}_trace_{ospid}.json",
 )
 @click.option(
-    "--warmup-runs", default=2,
-    help="Number of warmup runs. Ignored if --warmup-ms is set.")
+    "--warmup-runs",
+    default=2,
+    help="Number of warmup runs. Ignored if --warmup-ms is set.",
+)
 @click.option(
     "--warmup-ms",
     type=int,
     default=None,
-    help="Warmup duration in milliseconds. Disables the --run-nums option."
+    help="Warmup duration in milliseconds. Disables the --run-nums option.",
 )
 def nbit_device_with_spec(  # noqa C901
     alpha: float,
@@ -1760,11 +1761,11 @@ def nbit_device_with_spec(  # noqa C901
                     per_sample_weights,
                 ),
                 check_median=check_median,
-                warmup_ms=warmup_ms
+                warmup_ms=warmup_ms,
             )
 
         # copy the request of last iteration for kineto profile benchmark
-        if (i == runs_of_iters - 1):
+        if i == runs_of_iters - 1:
             kineto_request = requests
 
         # free up memory
@@ -1815,7 +1816,7 @@ def nbit_device_with_spec(  # noqa C901
                     indices.int(),
                     offsets.int(),
                     per_sample_weights,
-                )
+                ),
             )
 
         with context_factory(
@@ -1833,7 +1834,7 @@ def nbit_device_with_spec(  # noqa C901
             )
 
         if export_trace:
-            kernel_time = time_dict['kernel_time']
+            kernel_time = time_dict["kernel_time"]
             bandwidth = read_write_bytes / kernel_time / 1.0e3
 
             logging.info(

--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -1764,7 +1764,7 @@ def nbit_device_with_spec(  # noqa C901
             )
 
         # copy the request of last iteration for kineto profile benchmark
-        if (i == runs_of_iters-1):
+        if (i == runs_of_iters - 1):
             kineto_request = requests
 
         # free up memory


### PR DESCRIPTION
**Summary**
This PR introduces:
A new warm-up method to ensure sufficient GPU preparation before benchmarking.
Benchmark time calculation using the Kineto profiler for measuring the time and bandwidth of inference forward kernels.

**Motivation**
In small benchmark cases, kernel launch and synchronization overheads can be significant compared to the actual kernel runtime. By leveraging the Kineto profiler:
These overheads are eliminated.
Users get a more accurate estimation of kernel execution time and bandwidth of the forward kernel.

For small kernels the iteration based warm-up might not be sufficient.
By leveraging the time based warmup:
Users will be confident the GPU has done enough warm-up.

**Test instruction**
The below script shows how to use this features:
python bench/split_table_batched_embeddings_benchmark.py nbit-device-with-spec --export-trace --warmup_ms 50