### PR TITLE
Support INT4 Dequant onto GPU for Seq INT TBE look up

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -432,7 +432,8 @@ at::Tensor fusednbitrowwise_to_half_cpu(
 at::Tensor fusednbitrowwise_to_float_or_half_cpu(
     const at::Tensor& input,
     const int64_t bit_rate,
-    const int64_t output_dtype);
+    const int64_t output_dtype,
+    const bool scale_bias_last = true);
 
 at::Tensor quantize_mx_cuda(
     const at::Tensor& input,

--- a/fbgemm_gpu/src/quantize_ops/quantize_ops_meta.cpp
+++ b/fbgemm_gpu/src/quantize_ops/quantize_ops_meta.cpp
@@ -72,7 +72,8 @@ Tensor FloatToFP8RowwiseQuantized_meta(const Tensor& input, bool forward) {
 Tensor fusednbitrowwise_to_float_or_half_meta(
     const Tensor& input,
     const int64_t bit_rate,
-    const int64_t output_dtype) {
+    const int64_t output_dtype,
+    [[maybe_unused]] const bool scale_bias_last) {
   const at::SymIntArrayRef input_sizes = input.sym_sizes();
   const at::SymInt nrows = input_sizes[0];
   // Here we want the number of bytes in a row

--- a/fbgemm_gpu/test/tbe/inference/common.py
+++ b/fbgemm_gpu/test/tbe/inference/common.py
@@ -351,8 +351,10 @@ class NBitFowardTestCommon(unittest.TestCase):
             f = torch.cat(fs, dim=0).view(-1, D)
 
         if fc2.dtype == torch.quint4x2:
-            fc2_float = torch.ops.fbgemm.FusedNBitRowwiseQuantizedSBHalfFrontToFloat(
-                fc2.cpu(), bit_rate=4
+            fc2_float = (
+                torch.ops.fbgemm.FusedNBitRowwiseQuantizedSBHalfFrontToFloatOrHalf(
+                    fc2.cpu(), bit_rate=4, output_dtype=0
+                )
             )
         else:
             fc2_float = fc2.float()

--- a/fbgemm_gpu/test/tbe/inference/failures_dict_fast.json
+++ b/fbgemm_gpu/test/tbe/inference/failures_dict_fast.json
@@ -7,7 +7,8 @@
     "fbgemm::FloatToHFP8Quantized": {},
     "fbgemm::Fused8BitRowwiseQuantizedToFloat": {},
     "fbgemm::Fused8BitRowwiseQuantizedToFloatOrHalf": {},
-    "fbgemm::FusedNBitRowwiseQuantizedSBHalfFrontToFloat": {},
+    "fbgemm::FusedNBitRowwiseQuantizedSBHalfFrontToFloatOrHalf": {},
+    "fbgemm::FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf": {},
     "fbgemm::HFP8QuantizedToFloat": {},
     "fbgemm::asynchronous_complete_cumsum": {},
     "fbgemm::bounds_check_indices": {},
@@ -44,7 +45,15 @@
         "comment": "",
         "status": "xsuccess"
       },
+      "NBitFowardTest.test_faketensor__test_nbit_forward_cpu_gpu_dequantize_parity": {
+        "comment": "this operator outputs torch.quint4x2 tensors which is not compatible with generate_opcheck_tests",
+        "status": "xfail"
+      },
       "NBitFowardTest.test_faketensor__test_nbit_forward_cpu_seq_int4": {
+        "comment": "this operator outputs torch.quint4x2 tensors which is not compatible with generate_opcheck_tests",
+        "status": "xfail"
+      },
+      "NBitFowardTest.test_schema__test_nbit_forward_cpu_gpu_dequantize_parity": {
         "comment": "this operator outputs torch.quint4x2 tensors which is not compatible with generate_opcheck_tests",
         "status": "xfail"
       }

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -64,6 +64,18 @@ additional_decorators: Dict[str, List[Callable]] = {
     "test_faketensor__test_nbit_forward_cpu_gpu_dequantize_parity": [
         unittest.skip("Operator not implemented for Meta tensors"),
     ],
+    "test_schema__test_nbit_forward_cpu_gpu_dequantize_parity": [
+        unittest.skip("Operator not implemented for Meta tensors"),
+    ],
+    "test_autograd_registration__test_nbit_forward_cpu_gpu_dequantize_parity": [
+        unittest.skip("Operator not implemented for Meta tensors"),
+    ],
+    "test_aot_dispatch_static__test_nbit_forward_cpu_gpu_dequantize_parity": [
+        unittest.skip("Operator not implemented for Meta tensors"),
+    ],
+    "test_aot_dispatch_dynamic__test_nbit_forward_cpu_gpu_dequantize_parity": [
+        unittest.skip("Operator not implemented for Meta tensors"),
+    ],
     "test_faketensor__test_nbit_forward_cpu_seq_int4": {
         unittest.skip(
             "Operator outputs int4 tensors which do not support opcheck tests"
@@ -755,10 +767,11 @@ class NBitFowardTest(NBitFowardTestCommon):
         nbit_weights_ty=st.sampled_from(
             [
                 SparseType.INT8,
+                SparseType.INT4,
             ]
         ),
         pooling_mode=st.sampled_from([PoolingMode.NONE]),
-        output_dtype=st.sampled_from([SparseType.BF16, SparseType.FP16]),
+        output_dtype=st.sampled_from([SparseType.FP16, SparseType.BF16]),
         D=st.sampled_from([32, 256, 384, 512, 1024]),
         B=st.integers(min_value=8, max_value=32),
         T=st.integers(min_value=10, max_value=20),
@@ -827,13 +840,21 @@ class NBitFowardTest(NBitFowardTestCommon):
             (weights, scale_shift) = split_weights[t]
             (ref_weights, ref_scale_shift) = ref_split_weights[t]
             self.assertEqual(weights.size(), ref_weights.size())
-            element_size = SparseType.INT8.bit_rate() / 8.0
+            element_size = (
+                SparseType.INT8.bit_rate()
+                if nbit_weights_ty == SparseType.INT8
+                else SparseType.INT4.bit_rate()
+            ) / 8.0
             rand_tensor = torch.rand(
                 ref_weights.shape[0], int(ref_weights.shape[1] / element_size)
             )
             rand_weights, rand_scale_shift = quantize_embs(
                 rand_tensor,
-                SparseType.INT8,
+                (
+                    SparseType.INT8
+                    if nbit_weights_ty == SparseType.INT8
+                    else SparseType.INT4
+                ),
             )
             ref_weights.copy_(rand_weights)
             weights.copy_(ref_weights)
@@ -861,14 +882,35 @@ class NBitFowardTest(NBitFowardTestCommon):
         quant_cc_output = quant_cc(indices.int(), offsets.int())
         dequant_cc_output = dequant_cc(indices.int(), offsets.int())
         cuda_device = torch.device("cuda")
-        dequant_output_from_quant_cc = (
-            torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloatOrHalf(
-                quant_cc_output.to(cuda_device),
-                output_dtype.as_int(),
-                quant_padding_float_type=False,
-                scale_bias_last=False,
+        if nbit_weights_ty == SparseType.INT8:
+            dequant_output_from_quant_cc = (
+                torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloatOrHalf(
+                    quant_cc_output.to(cuda_device),
+                    output_dtype.as_int(),
+                    quant_padding_float_type=False,
+                    scale_bias_last=False,
+                )
             )
-        )
+        elif nbit_weights_ty == SparseType.INT4:
+            tensor_gpu = torch.zeros(
+                (quant_cc_output.shape[0], int((quant_cc_output.shape[1] + 1) / 2)),
+                dtype=torch.uint8,
+                device=cuda_device,
+            )
+            tensor_gpu.untyped_storage().copy_(quant_cc_output.untyped_storage())
+            dequant_output_from_quant_cc = (
+                torch.ops.fbgemm.FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf(
+                    tensor_gpu,
+                    bit_rate=4,
+                    output_dtype=output_dtype.as_int(),
+                    scale_bias_last=False,
+                )
+            )
+        else:
+            raise ValueError(
+                "Unsupported nbit_weights_ty in test_nbit_forward_cpu_gpu_dequantize_parity"
+            )
+
         torch.testing.assert_close(
             dequant_cc_output.cpu(),
             dequant_output_from_quant_cc.cpu(),

--- a/include/fbgemm/QuantUtils.h
+++ b/include/fbgemm/QuantUtils.h
@@ -300,7 +300,8 @@ FBGEMM_API void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf(
     const uint8_t* input,
     size_t input_rows,
     int input_columns,
-    OutputType* output);
+    OutputType* output,
+    bool scale_bias_last = true);
 
 /**
  * Convert float or half inputs to rowwise quantized (8-bit) outputs.
@@ -360,7 +361,7 @@ FBGEMM_API void FloatOrHalfToFused8BitRowwiseQuantizedSBFloatRef(
  * Same as FusedNBitRowwiseQuantizedSBHalfToFloat but unoptimized.
  * This should not be called directly except in testing.
  */
-template <typename OutputType>
+template <typename OutputType, bool is_uint16_t_of_type_bf16 = false>
 FBGEMM_API void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef(
     int bit_rate,
     const uint8_t* input,

--- a/src/QuantUtils.cc
+++ b/src/QuantUtils.cc
@@ -723,7 +723,7 @@ void FloatOrHalfToFused8BitRowwiseQuantizedSBFloat(
   }
 }
 
-template <typename OutputType>
+template <typename OutputType, bool is_uint16_t_of_type_bf16>
 void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef(
     int bit_rate,
     const uint8_t* input,
@@ -733,7 +733,7 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef(
     bool scale_bias_last) {
   static_assert(
       std::is_same<OutputType, float>() || std::is_same<OutputType, float16>(),
-      "Only float and float16 types are allowed.");
+      "Only float, float16 or bfloat16 types are allowed.");
   int num_elem_per_byte = 8 / bit_rate;
   const int64_t output_columns =
       static_cast<int64_t>(input_columns - 2 * sizeof(float16)) *
@@ -760,7 +760,11 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef(
       if (std::is_same<OutputType, float>()) {
         output_row[col] = output_value;
       } else {
-        output_row[col] = cpu_float2half_rn(output_value);
+        if constexpr (is_uint16_t_of_type_bf16) {
+          output_row[col] = cpu_float2bfloat16(output_value);
+        } else {
+          output_row[col] = cpu_float2half_rn(output_value);
+        }
       }
     }
   }
@@ -772,7 +776,8 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf(
     const uint8_t* input,
     size_t input_rows,
     int input_columns,
-    OutputType* output) {
+    OutputType* output,
+    [[maybe_unused]] bool scale_bias_last) {
   if (cpuinfo_initialize() && fbgemmHasAvx2Support()) {
 #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
     switch (bit_rate) {
@@ -857,7 +862,15 @@ void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf(
       int input_columns,                                                       \
       std::uint8_t* output);                                                   \
   template FBGEMM_API void                                                     \
-  FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef<type>(                       \
+  FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef<type, false>(                \
+      int bit_rate,                                                            \
+      const uint8_t* input,                                                    \
+      size_t input_rows,                                                       \
+      int input_columns,                                                       \
+      type* output,                                                            \
+      bool scale_bias_last);                                                   \
+  template FBGEMM_API void                                                     \
+  FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef<type, true>(                 \
       int bit_rate,                                                            \
       const uint8_t* input,                                                    \
       size_t input_rows,                                                       \
@@ -869,7 +882,8 @@ void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf(
       const uint8_t* input,                                                    \
       size_t input_rows,                                                       \
       int input_columns,                                                       \
-      type* output);                                                           \
+      type* output,                                                            \
+      bool scale_bias_last);                                                   \
   template FBGEMM_API void                                                     \
   FloatOrHalfToFused8BitRowwiseQuantizedSBFloatRef<type>(                      \
       const type* input,                                                       \


### PR DESCRIPTION
Summary:
Seq INT4 -> INT4 STBE look up is supported in the diff stack: https://www.internalfb.com/diff/D61305978 . 

This diff supports:

1. The dequanitzation of INT4 -> INT4 STBE look up onto Cuda for all float types
2. Extends the dequantization of INT4 > INT4 STBE look up onto CPU for BF16

The main gap is to handle the dequant for the case when scale bias for INT4 quantized tensor is in the front. While for CPU, just need to add the dequantization for BF16 based on dtype.

This will enable us to reduce the network overhead to remote embedding server as well as D2H data transfer from onto GPU host.

Differential Revision: D68187234


