### PR TITLE
Fix autodeps for torch/custom_class.h and use it in kv_tensor_wrapper_cpu (#677)

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper_cpu.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper_cpu.cpp
@@ -11,7 +11,7 @@
 #include <c10/core/ScalarTypeToTypeMeta.h>
 #include <torch/library.h>
 
-#include "./kv_tensor_wrapper.h"
+#include <fbgemm/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h>
 #include "common/base/Exception.h"
 
 using namespace at;


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/facebookresearch/FBGEMM/pull/677

Differential Revision: D68468152


