### PR TITLE
directly pass update_util as int flag without syncing iter

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/intraining_embedding_pruning.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/intraining_embedding_pruning.h
@@ -45,6 +45,7 @@ Tensor remap_indices_update_utils_cuda(
     const Tensor& address_lookup,
     Tensor& row_util,
     const Tensor& buffer_offsets,
-    const std::optional<std::vector<Tensor>>& full_values_list);
+    const std::optional<std::vector<Tensor>>& full_values_list,
+    const std::optional<bool>& update_util);
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/intraining_embedding_pruning_ops/intraining_embedding_pruning_gpu.cpp
+++ b/fbgemm_gpu/src/intraining_embedding_pruning_ops/intraining_embedding_pruning_gpu.cpp
@@ -32,7 +32,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "    Tensor address_lookup, "
       "    Tensor(a!) row_util, "
       "    Tensor buffer_offsets, "
-      "    Tensor[]? full_values_list=None"
+      "    Tensor[]? full_values_list=None, "
+      "    bool? update_util=None"
       ") -> Tensor");
   DISPATCH_TO_CUDA(
       "remap_indices_update_utils",


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/678

as title, this change will eliminate device to host sync for the iter buffer during each iteration, which achieves better performance and avoid pottential bottleneck due to the sync point

Differential Revision: D68466120


