### PR TITLE
Performance Optimization: Optimized TileShape Configuration for f8

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_grouped.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_grouped.cu
@@ -145,17 +145,17 @@ __global__ void set_kernel_args_kernel(
             GroupedGemmArgs::ProblemShape::UnderlyingProblemShape*>(
             problem_shape_buf);
     // Pass dummy configs to get Stride structure
-    GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
         StrideInputA* stride_input_A_ptr = reinterpret_cast<
-            GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
                 StrideInputA*>(stride_buf);
-    GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
         StrideInputB* stride_input_B_ptr = reinterpret_cast<
-            GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
                 StrideInputB*>(stride_buf + stride_size);
-    GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
         StrideOutput* stride_output_ptr = reinterpret_cast<
-            GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
                 StrideOutput*>(stride_buf + (stride_size * 2));
 
     output_args_ptr[group_index] =
@@ -169,15 +169,15 @@ __global__ void set_kernel_args_kernel(
         GroupedGemmArgs::ProblemShape::UnderlyingProblemShape(M, N, K);
     stride_input_A_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
-            GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::StrideInputA{},
+            GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::StrideInputA{},
         {M, K, 1});
     stride_input_B_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
-            GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::StrideInputB{},
+            GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::StrideInputB{},
         {N, K, 1});
     stride_output_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
-            GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::StrideOutput{},
+            GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::StrideOutput{},
         {M, N, 1});
   }
 }
@@ -219,17 +219,17 @@ __global__ void set_dynamic_kernel_args_kernel(
             GroupedGemmArgs::ProblemShape::UnderlyingProblemShape*>(
             problem_shape_buf);
     // Pass dummy configs to get Stride structure
-    GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
         StrideInputA* stride_input_A_ptr = reinterpret_cast<
-            GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
                 StrideInputA*>(stride_buf);
-    GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
         StrideInputB* stride_input_B_ptr = reinterpret_cast<
-            GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
                 StrideInputB*>(stride_buf + stride_size);
-    GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
         StrideOutput* stride_output_ptr = reinterpret_cast<
-            GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
                 StrideOutput*>(stride_buf + (stride_size * 2));
 
     output_args_ptr[group_index] =
@@ -244,15 +244,15 @@ __global__ void set_dynamic_kernel_args_kernel(
             zero_start_index_M[group_index], N, K);
     stride_input_A_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
-            GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::StrideInputA{},
+            GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::StrideInputA{},
         {zero_start_index_M[group_index], K, 1});
     stride_input_B_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
-            GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::StrideInputB{},
+            GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::StrideInputB{},
         {N, K, 1});
     stride_output_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
-            GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::StrideOutput{},
+            GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::StrideOutput{},
         {zero_start_index_M[group_index], N, 1});
   }
 }
@@ -487,7 +487,7 @@ std::vector<at::Tensor> dispatch_fp8_grouped_kernel(
     return f8f8bf16_grouped_impl<64, 128, 128, 2, 1, 1, true, FastAccum>(
         xq_group, wq_group, scale, zero_start_index_M);
   } else if (kernel == KernelMode::Large) {
-    return f8f8bf16_grouped_impl<128, 128, 128, 2, 1, 1, true, FastAccum>(
+    return f8f8bf16_grouped_impl<128, 256, 128, 2, 1, 1, false, FastAccum>(
         xq_group, wq_group, scale, zero_start_index_M);
   } else {
     return f8f8bf16_grouped_impl<128, 128, 128, 1, 2, 1, true, FastAccum>(

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise.cu
@@ -170,6 +170,24 @@ at::Tensor f8f8bf16_rowwise_impl(
   using EpilogueEVT =
       cute::conditional_t<USE_BIAS, EVTComputeBias, EVTCompute1>;
 
+  using DefaultSchedule = cutlass::gemm::KernelTmaWarpSpecializedCooperative;
+  using PongSchedule = cutlass::gemm::KernelTmaWarpSpecializedPingpong;
+  using FastDefaultSchedule =
+      cutlass::gemm::KernelTmaWarpSpecializedCooperativeFP8FastAccum;
+  using FastPongSchedule =
+      cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum;
+  using SlowAccum = cute::conditional_t<PONG, PongSchedule, DefaultSchedule>;
+  using FastAccum =
+      cute::conditional_t<PONG, FastPongSchedule, FastDefaultSchedule>;
+  using CooperativeEpilogueSchedule =
+      cutlass::epilogue::TmaWarpSpecializedCooperative;
+  using PongEpilogueSchedule =
+      cutlass::epilogue::TmaWarpSpecialized;
+  using MainLoopSchedule =
+      cute::conditional_t<FAST_ACCUM, FastAccum, SlowAccum>;
+  using EpilogueSchedule = cute::
+      conditional_t<PONG, PongEpilogueSchedule, CooperativeEpilogueSchedule>;
+
   using CollectiveEpilogue =
       typename cutlass::epilogue::collective::CollectiveBuilder<
           cutlass::arch::Sm90,
@@ -185,20 +203,8 @@ at::Tensor f8f8bf16_rowwise_impl(
           ElementOutput,
           LayoutOutput,
           AlignmentOutput,
-          cutlass::epilogue::TmaWarpSpecialized,
+          EpilogueSchedule,
           EpilogueEVT>::CollectiveOp;
-
-  using DefaultSchedule = cutlass::gemm::KernelTmaWarpSpecialized;
-  using PongSchedule = cutlass::gemm::KernelTmaWarpSpecializedPingpong;
-  using FastDefaultSchedule =
-      cutlass::gemm::KernelTmaWarpSpecializedFP8FastAccum;
-  using FastPongSchedule =
-      cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum;
-  using SlowAccum = cute::conditional_t<PONG, PongSchedule, DefaultSchedule>;
-  using FastAccum =
-      cute::conditional_t<PONG, FastPongSchedule, FastDefaultSchedule>;
-  using MainLoopSchedule =
-      cute::conditional_t<FAST_ACCUM, FastAccum, SlowAccum>;
 
   using CollectiveMainloop =
       typename cutlass::gemm::collective::CollectiveBuilder<
@@ -331,7 +337,7 @@ at::Tensor dispatch_fp8_rowwise_kernel(
         2,
         1,
         1,
-        false,
+        true,
         FastAccum,
         UseBias,
         InputDType,
@@ -339,12 +345,12 @@ at::Tensor dispatch_fp8_rowwise_kernel(
   } else if (kernel == KernelMode::Large) {
     return f8f8bf16_rowwise_impl<
         128,
-        128,
+        256,
         128,
         2,
         1,
         1,
-        true,
+        false,
         FastAccum,
         UseBias,
         InputDType,
@@ -354,10 +360,10 @@ at::Tensor dispatch_fp8_rowwise_kernel(
         128,
         128,
         128,
-        1,
         2,
         1,
-        false,
+        1,
+        true,
         FastAccum,
         UseBias,
         InputDType,

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise.cu
@@ -181,8 +181,7 @@ at::Tensor f8f8bf16_rowwise_impl(
       cute::conditional_t<PONG, FastPongSchedule, FastDefaultSchedule>;
   using CooperativeEpilogueSchedule =
       cutlass::epilogue::TmaWarpSpecializedCooperative;
-  using PongEpilogueSchedule =
-      cutlass::epilogue::TmaWarpSpecialized;
+  using PongEpilogueSchedule = cutlass::epilogue::TmaWarpSpecialized;
   using MainLoopSchedule =
       cute::conditional_t<FAST_ACCUM, FastAccum, SlowAccum>;
   using EpilogueSchedule = cute::

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_tensorwise.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_tensorwise.cu
@@ -110,8 +110,7 @@ at::Tensor f8f8bf16_tensorwise_impl(
       cute::conditional_t<PONG, FastPongSchedule, FastDefaultSchedule>;
   using CooperativeEpilogueSchedule =
       cutlass::epilogue::TmaWarpSpecializedCooperative;
-  using PongEpilogueSchedule =
-      cutlass::epilogue::TmaWarpSpecialized;
+  using PongEpilogueSchedule = cutlass::epilogue::TmaWarpSpecialized;
   using MainLoopSchedule =
       cute::conditional_t<FAST_ACCUM, FastAccum, SlowAccum>;
   using EpilogueSchedule = cute::

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_tensorwise.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_tensorwise.cu
@@ -99,17 +99,23 @@ at::Tensor f8f8bf16_tensorwise_impl(
       KernelScheduleAuto; // Kernel to launch based on the default setting in
                           // the Collective Builder
 
-  using DefaultSchedule = cutlass::gemm::KernelTmaWarpSpecialized;
+  using DefaultSchedule = cutlass::gemm::KernelTmaWarpSpecializedCooperative;
   using PongSchedule = cutlass::gemm::KernelTmaWarpSpecializedPingpong;
   using FastDefaultSchedule =
-      cutlass::gemm::KernelTmaWarpSpecializedFP8FastAccum;
+      cutlass::gemm::KernelTmaWarpSpecializedCooperativeFP8FastAccum;
   using FastPongSchedule =
       cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum;
   using SlowAccum = cute::conditional_t<PONG, PongSchedule, DefaultSchedule>;
   using FastAccum =
       cute::conditional_t<PONG, FastPongSchedule, FastDefaultSchedule>;
+  using CooperativeEpilogueSchedule =
+      cutlass::epilogue::TmaWarpSpecializedCooperative;
+  using PongEpilogueSchedule =
+      cutlass::epilogue::TmaWarpSpecialized;
   using MainLoopSchedule =
       cute::conditional_t<FAST_ACCUM, FastAccum, SlowAccum>;
+  using EpilogueSchedule = cute::
+      conditional_t<PONG, PongEpilogueSchedule, CooperativeEpilogueSchedule>;
 
   using Scale_ =
       cutlass::epilogue::fusion::Sm90ScalarBroadcast<ElementComputeEpilogue>;
@@ -140,7 +146,7 @@ at::Tensor f8f8bf16_tensorwise_impl(
           ElementOutput,
           LayoutOutput,
           AlignmentOutput,
-          cutlass::epilogue::TmaWarpSpecialized,
+          EpilogueSchedule,
           EpilogueEVT>::CollectiveOp;
 
   using CollectiveMainloop =
@@ -239,10 +245,10 @@ at::Tensor f8f8bf16_tensorwise(
     return f8f8bf16_tensorwise_impl<64, 128, 128, 2, 1, 1, true, true>(
         XQ, WQ, scale);
   } else if (kernel == KernelMode::Large) {
-    return f8f8bf16_tensorwise_impl<128, 128, 128, 2, 1, 1, true, true>(
+    return f8f8bf16_tensorwise_impl<128, 256, 128, 2, 1, 1, false, true>(
         XQ, WQ, scale);
   } else {
-    return f8f8bf16_tensorwise_impl<128, 128, 128, 1, 2, 1, false, true>(
+    return f8f8bf16_tensorwise_impl<128, 128, 128, 1, 2, 1, true, true>(
         XQ, WQ, scale);
   }
 }


### PR DESCRIPTION
## Performance Issue with Current F8 TileShape Configuration
The current FBGEMM f8 kernel uses a TileShape configuration of 128x128x128,  
while the optimal shape for dense f8 tensor core on H100 is m64n256k32.  
The current configuration leads to suboptimal performance for  
tensor cores and bandwidth usage.

## Optimized TileShape (128x256x128) Implementation 
Modification of the TileShape configuration from 128x128x128 to 128x256x128 for large GEMM  
operations using a cooperative kernel, enabling optimal bandwidth and tensor cores utilization.  
This configuration is notably used in Flash Attention V3 for f8.

## Benchmark Results on H100 GPU
### Benchmark configuration:
PyTorch 2.6
CUDA 12.4
CPU: AMD EPYC
GPU: NVIDIA H100
Benchmarks are configured with 30 kernel launch iterations  
and averaged over 25 Benchmark calculations.
We used the same gemm sizes as in the Colfax benchmarks

### Benchmark
#### f8f8bf16_grouped (G = 4, M = 2,048, N = 8,192, K = 8,192)
| TileShape   | TFlops  |
|-------------|-------- |
| 128-128-128 |    1244 |
| 128-256-128 |    1374 |
  
#### f8f8bf16_rowwise (M = N = K = 8,192)
| TileShape   | TFlops |
|-------------|------- |
| 128-128-128 |   1300 |
| 128-256-128 |   1480 |

#### f8f8bf16_tensorwise (M=N=K = 8,192)
| TileShape   | TFlops |
|-------------|------- |
| 128-128-128 |   1271 |
| 128-256-128 |   1463 |

## Technical Implementation
Modified TileShape from 128-128-128 to 128-256-128 for:
 - f8f8bf16_grouped
 - f8f8bf16_rowwise
 - f8f8bf16_tensorwise

Added cooperative kernel by default for:
 - f8f8bf16_rowwise
 - f8f8bf16_tensorwise
 
f8f8f16.cu was not modified because it was deprecated compared to f8f8bf16_tensorwise

The modifications only affect large where M > 128 and N > 128 and M or N > 2,048.  
The matrices are divided into tiles twice as large, but with kernels using 3   
SMs instead of 2. The smaller heuristics of large kernels may experience a  
slight reduced efficiency compared to the previous configuration.  
An empirical study between F8 kernel configurations and GEMM sizes could benefit FBGEMM.  

These changes were made by modifying the minimum necessary code while respecting  
existing coding practices in FBGEMM.


## Test Coverage
### Unit Tests Results
The unit tests in fbgemm_gpu/experimental/gen_ai/test/quantize  
have been verified for the modified kernels.

@jiawenliu64 @jwfromm Thank you!