### PR TITLE
Fix calling `numel` on symbolic shapes issue

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
@@ -662,8 +662,8 @@ class {{ autograd_func }} :
         << "T=" << T << ","
         << "avg_D=" << ({{ "total_D / T" if not nobag else "D" }}) << ","
         << "max_D=" << {{ "max_D" if not nobag else "D" }} << ","
-        << "num_indices=" << indices.numel() << ","
-        << "avg_pooling_fac=" << (static_cast<float>(indices.numel()) / T / max_B_)
+        << "num_indices=" << indices.sym_numel() << ","
+        << "avg_pooling_fac=" << (static_cast<c10::SymFloat>(indices.sym_numel()) / T / max_B_)
         << "]";
       op_annotation = ss.str();
       record_trace = profiler::record_function_enter_new(


### PR DESCRIPTION
Summary:
`indices` could be symbolic shapes, calling `numel` on symbolic shapes will trigger a compilation issue as below: {F1974666689}

To fix the issue, we change `numel` to `sym_numel` in this diff to be compatible with symbolic shapes

Differential Revision: D68675691


