### PR TITLE
Remove FENV pragma

### DIFF
--- a/src/FbgemmFloat16ConvertSVE.cc
+++ b/src/FbgemmFloat16ConvertSVE.cc
@@ -60,7 +60,6 @@ void FloatToFloat16_sve2(
     float16* dst,
     size_t size,
     bool do_clip) {
-#pragma STDC FENV_ROUND FE_TONEAREST
   const size_t chunkSize = svcntw() * 2;
 
   // Note: we don't use predicates here, because then we can't use svld2. This


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/706

We are seeing this error in an internal build:
```
   fbcode/deeplearning/fbgemm/src/FbgemmFloat16ConvertSVE.cc:63:25: error: expected identifier in '#pragma FENV_ROUND' - ignored [-Werror,-Wignored-pragmas]
       63 | #pragma STDC FENV_ROUND FE_TONEAREST
```
Until we figure out the floating-point environment business, let's remove this pragma.

Differential Revision: D68815786


