### PR TITLE
[CUTLASS] Use custom copy of cutlass to enable FP8 Grouped Gemm.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,12 @@
 [submodule "external/hipify_torch"]
 	path = external/hipify_torch
 	url = https://github.com/ROCmSoftwarePlatform/hipify_torch.git
+# TODO Using a private copy of cutlass is a temporary mitigation to enable grouped gemm.
+# Go back to main cutlass when possible.
 [submodule "external/cutlass"]
 	path = external/cutlass
-	url = https://github.com/NVIDIA/cutlass.git
+	url = https://github.com/jwfromm/cutlass.git
+	branch = FBGEMM
 [submodule "external/json"]
 	path = external/json
 	url = https://github.com/nlohmann/json.git


### PR DESCRIPTION
To support MOE models, we need to enable FP8 rowwise grouped gemm in FBGEMM. One missing piece to do this is support for rowwise scaling in cutlass. We have enabled this feature in a custom copy of cutlass but getting it into mainline will take a while. As a temporary measure, we can point FBGEMM to a custom copy of cutlass instead. Once the feature lands in mainline and we bump our support, we can go back to using the main repo.