### PR TITLE
Improve FP8 grouped GEMM perf via tileshape and cooperative

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
@@ -522,39 +522,22 @@ class FP8RowwiseGroupedGemm(QuantizeOpBase):
 
     def compute(self, xq, wq, x_scale, w_scale, m_values, kernel_name=None):
         if m_values is None:
-            if torch.version.cuda:
-                return torch.ops.fbgemm.f8f8bf16_grouped(
-                    xq,
-                    wq,
-                    x_scale,
-                    w_scale,
-                )
-            else:
-                return torch.ops.fbgemm.f8f8bf16_rowwise_grouped(
-                    xq,
-                    wq,
-                    x_scale,
-                    w_scale,
-                    kernel_name=kernel_name,
-                )
+            return torch.ops.fbgemm.f8f8bf16_rowwise_grouped(
+                xq,
+                wq,
+                x_scale,
+                w_scale,
+                kernel_name=kernel_name,
+            )
         else:
-            if torch.version.cuda:
-                return torch.ops.fbgemm.f8f8bf16_grouped(
-                    xq,
-                    wq,
-                    x_scale,
-                    w_scale,
-                    zero_start_index_M=m_values,
-                )
-            else:
-                return torch.ops.fbgemm.f8f8bf16_rowwise_grouped_dynamic(
-                    xq,
-                    wq,
-                    x_scale,
-                    w_scale,
-                    zero_start_index_M=m_values,
-                    kernel_name=kernel_name,
-                )
+            return torch.ops.fbgemm.f8f8bf16_rowwise_grouped_dynamic(
+                xq,
+                wq,
+                x_scale,
+                w_scale,
+                zero_start_index_M=m_values,
+                kernel_name=kernel_name,
+            )
 
     def quantize_and_compute(self, x, w):
         xq, wq, x_scale, w_scale, m_values = self.quantize(x, w)

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_grouped.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_grouped.cu
@@ -185,17 +185,17 @@ __global__ void set_kernel_args_kernel(
             GroupedGemmArgs::ProblemShape::UnderlyingProblemShape*>(
             problem_shape_buf);
     // Pass dummy configs to get Stride structure
-    GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
         StrideInputA* stride_input_A_ptr = reinterpret_cast<
-            GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
                 StrideInputA*>(stride_buf);
-    GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
         StrideInputB* stride_input_B_ptr = reinterpret_cast<
-            GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
                 StrideInputB*>(stride_buf + stride_size);
-    GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
         StrideOutput* stride_output_ptr = reinterpret_cast<
-            GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
                 StrideOutput*>(stride_buf + (stride_size * 2));
 
     output_args_ptr[group_index] =
@@ -210,15 +210,15 @@ __global__ void set_kernel_args_kernel(
         GroupedGemmArgs::ProblemShape::UnderlyingProblemShape(M, N, K);
     stride_input_A_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
-            GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::StrideInputA{},
+            GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::StrideInputA{},
         {M, K, 1});
     stride_input_B_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
-            GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::StrideInputB{},
+            GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::StrideInputB{},
         {N, K, 1});
     stride_output_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
-            GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::StrideOutput{},
+            GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::StrideOutput{},
         {M, N, 1});
   }
 }
@@ -263,17 +263,17 @@ __global__ void set_dynamic_kernel_args_kernel(
             GroupedGemmArgs::ProblemShape::UnderlyingProblemShape*>(
             problem_shape_buf);
     // Pass dummy configs to get Stride structure
-    GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
         StrideInputA* stride_input_A_ptr = reinterpret_cast<
-            GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
                 StrideInputA*>(stride_buf);
-    GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
         StrideInputB* stride_input_B_ptr = reinterpret_cast<
-            GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
                 StrideInputB*>(stride_buf + stride_size);
-    GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
         StrideOutput* stride_output_ptr = reinterpret_cast<
-            GroupedGemmArgs::GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::
+            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
                 StrideOutput*>(stride_buf + (stride_size * 2));
 
     output_args_ptr[group_index] =
@@ -289,15 +289,15 @@ __global__ void set_dynamic_kernel_args_kernel(
             zero_start_index_M[group_index], N, K);
     stride_input_A_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
-            GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::StrideInputA{},
+            GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::StrideInputA{},
         {zero_start_index_M[group_index], K, 1});
     stride_input_B_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
-            GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::StrideInputB{},
+            GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::StrideInputB{},
         {N, K, 1});
     stride_output_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
-            GroupedGemmConfigs<128, 128, 128, 2, 1, 1, true>::StrideOutput{},
+            GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::StrideOutput{},
         {zero_start_index_M[group_index], N, 1});
   }
 }
@@ -530,11 +530,8 @@ std::tuple<at::Tensor, std::vector<at::Tensor>> dispatch_fp8_grouped_kernel(
   if (kernel == KernelMode::Small) {
     return f8f8bf16_rowwise_grouped_impl<64, 128, 128, 2, 1, 1, true>(
         XQ, WQ, x_scale, w_scale, output, zero_start_index_M);
-  } else if (kernel == KernelMode::Large) {
-    return f8f8bf16_rowwise_grouped_impl<128, 128, 128, 2, 1, 1, true>(
-        XQ, WQ, x_scale, w_scale, output, zero_start_index_M);
   } else {
-    return f8f8bf16_rowwise_grouped_impl<128, 128, 128, 1, 2, 1, true>(
+    return f8f8bf16_rowwise_grouped_impl<128, 256, 64, 2, 1, 1, false>(
         XQ, WQ, x_scale, w_scale, output, zero_start_index_M);
   }
 }

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -59,7 +59,8 @@ at::Tensor f8f8bf16_lite(at::Tensor XQ, at::Tensor WQ, at::Tensor scale);
 std::vector<at::Tensor> f8f8bf16_grouped(
     at::TensorList XQ,
     at::TensorList WQ,
-    at::TensorList scale,
+    at::TensorList x_scale,
+    at::TensorList w_scale,
     std::optional<at::Tensor> zero_start_index_M,
     bool use_fast_accum = true);
 std::vector<at::Tensor> bf16bf16bf16_grouped(
@@ -187,7 +188,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "f8i4bf16_rowwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor w_zp) -> Tensor");
   m.def(
-      "f8f8bf16_grouped(Tensor[] XQ, Tensor[] WQ, Tensor[] scale, Tensor? zero_start_index_M=None, bool use_fast_accum=True) -> Tensor[]");
+      "f8f8bf16_grouped(Tensor[] XQ, Tensor[] WQ, Tensor[] x_scale, Tensor[] w_scale, Tensor? zero_start_index_M=None, bool use_fast_accum=True) -> Tensor[]");
   m.def("f8f8bf16_lite(Tensor XQ, Tensor WQ, Tensor scale) -> Tensor");
   m.def(
       "bf16i4bf16_rowwise(Tensor X, Tensor WQ, Tensor w_scale, Tensor w_zp) -> Tensor");
@@ -488,7 +489,8 @@ std::vector<at::Tensor> quantize_fp8_per_col_meta(
 std::vector<at::Tensor> f8f8bf16_grouped_meta(
     at::TensorList XQ,
     at::TensorList WQ,
-    at::TensorList /* scale */,
+    at::TensorList /* x_scale */,
+    at::TensorList /* w_scale */,
     std::optional<at::Tensor> /* zero_start_index_M = std::nullopt */,
     bool /* use_fast_accum = true */) {
   std::vector<at::Tensor> Y;


### PR DESCRIPTION
Summary: Tuning tileshape and leveraging cooperative bring **additional up to 1.4x speedup** compared to the existing FP8 grouped GEMM kernel configs for non-memory-bound shapes

Reviewed By: jianyuh, jwfromm

Differential Revision: D68609019
