### PR TITLE
Support histogram_binning_calibration for export

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -1100,6 +1100,27 @@ def fused_8_bit_rowwise_quantized_to_half(
     return torch.empty(output_shape, dtype=torch.float16, device=input_t.device)
 
 
+def generic_histogram_binning_calibration_by_feature(
+    logit: Tensor,
+    segment_value: Tensor,
+    segment_lengths: Tensor,
+    num_segments: int,
+    bin_num_examples: Tensor,
+    bin_num_positives: Tensor,
+    bin_boundaries: Tensor,
+    positive_weight: float,
+    bin_ctr_in_use_after: int,
+    bin_ctr_weight_value: float,
+) -> Tuple[Tensor, Tensor]:
+    torch._check(bin_num_examples.numel() == bin_num_positives.numel())
+    torch._check(
+        bin_num_examples.numel() == (num_segments + 1) * (bin_boundaries.numel() + 1)
+    )
+    return torch.empty_like(logit), torch.empty(
+        [logit.numel()], dtype=torch.int64, device=logit.device
+    )
+
+
 def _setup() -> None:
     # pyre-ignore[16]
     _setup.done = getattr(_setup, "done", False)
@@ -1232,6 +1253,10 @@ def _setup() -> None:
         impl_abstract(
             "fbgemm::histogram_binning_calibration",
             histogram_binning_calibration_abstract,
+        )
+        impl_abstract(
+            "fbgemm::generic_histogram_binning_calibration_by_feature",
+            generic_histogram_binning_calibration_by_feature,
         )
         impl_abstract(
             "fbgemm::FloatToHFP8Quantized",

--- a/fbgemm_gpu/test/sparse/failures_dict.json
+++ b/fbgemm_gpu/test/sparse/failures_dict.json
@@ -141,19 +141,19 @@
     "fbgemm::generic_histogram_binning_calibration_by_feature": {
       "HistogramBinningCalibrationTest.test_aot_dispatch_dynamic__test_generic_histogram_binning_calibration_by_feature": {
         "comment": "",
-        "status": "xfail"
+        "status": "xsuccess"
       },
       "HistogramBinningCalibrationTest.test_aot_dispatch_dynamic__test_generic_histogram_binning_calibration_by_feature_cpu_gpu": {
         "comment": "",
-        "status": "xfail"
+        "status": "xsuccess"
       },
       "HistogramBinningCalibrationTest.test_faketensor__test_generic_histogram_binning_calibration_by_feature": {
         "comment": "",
-        "status": "xfail"
+        "status": "xsuccess"
       },
       "HistogramBinningCalibrationTest.test_faketensor__test_generic_histogram_binning_calibration_by_feature_cpu_gpu": {
         "comment": "",
-        "status": "xfail"
+        "status": "xsuccess"
       }
     },
     "fbgemm::group_index_select_dim0": {


### PR DESCRIPTION
Summary: Add fake tensor for `histogram_binning_calibration` which is needed to export old PA.

Differential Revision: D69089371


