### PR TITLE
return right away if keys is empty

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -846,6 +846,12 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
                               }
                               key_indices.push_back(i);
                             }
+
+                            // bail if nothing to do
+                            if (key_indices.empty()) {
+                              return;
+                            }
+
                             std::sort(
                                 key_indices.begin(),
                                 key_indices.end(),

--- a/fbgemm_gpu/test/tbe/ssd/kv_tensor_wrapper_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/kv_tensor_wrapper_test.py
@@ -89,6 +89,9 @@ class KvTensorWrapperTest(TestCase):
             )
             self.assertEqual(tensor_wrapper.shape, [E, D])
 
+            # read one row as an extreme case
+            narrowed = tensor_wrapper.narrow(0, 0, 1)
+
             # table has a total of E rows
             # load 1000 rows at a time
             step = 1000


### PR DESCRIPTION
Summary: when reading embedding rows from rocks db, skip reading from a db shard if this db shard doesn't contain any requested rows.

Differential Revision: D68913784


