### PR TITLE
Fix f8f8bf16_lite quantize op input in `quantize_and_compute`

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
@@ -788,7 +788,7 @@ class FP8LiteGemm(QuantizeOpBase):
 
     def quantize_and_compute(self, x, w):
         xq, wq, x_scale, w_scale = self.quantize(x, w)
-        return self.compute(xq, wq, x_scale * w_scale)
+        return self.compute(xq, wq, x_scale, w_scale)
 
     @property
     def name(self) -> str:

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/bf16fp8bf16_fast_gemv.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/bf16fp8bf16_fast_gemv.cu
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/core/ScalarType.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_bf16.h>
+
+#include "include/fast_gemv.cuh"
+
+namespace fbgemm_gpu {
+
+// The heuristics are derived by sweeping over 4 different
+// problem sizes we care about and selected the best elapsed time/bw
+// combination. See more in
+// deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/sweep_utils.py
+dim3 get_best_block_dim_2(int m, int n, int k) {
+  if (m == 1 && n == 1280 && k == 8192) {
+    return dim3(128, 1);
+  } else if (m == 1 && n == 8192 && k == 1024) {
+    return dim3(32, 4);
+  } else if (m == 1 && n == 7168 && k == 8192) {
+    return dim3(128, 1);
+  } else if (m == 1 && n == 8192 && k == 3584) {
+    return dim3(64, 2);
+  } else {
+    // Default block dimensions
+    return dim3(32, 4);
+  }
+}
+
+at::Tensor bf16fp8bf16_fast_gemv(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor w_scale,
+    at::Tensor /*w_zp*/) {
+  // X: M x K
+  // W: N x K
+  auto m = X.size(0);
+  auto n = W.size(0);
+  auto k = W.size(1);
+
+  TORCH_CHECK(X.is_cuda() && X.is_contiguous());
+  TORCH_CHECK(W.is_cuda() && W.is_contiguous());
+
+  dim3 block_dim = get_best_block_dim_2(m, n, k);
+
+  TORCH_CHECK(
+      n % block_dim.y == 0,
+      "Invalid block dimensions: n (",
+      n,
+      ") must be divisible by block_dim.y (",
+      block_dim.y,
+      "). Received n: ",
+      n,
+      ", block_dim.y: ",
+      block_dim.y,
+      " Please either use a `n` which is divisible by `block_dim.y`, or update "
+      "`get_best_block_dim()` heuristics to choose another `block_dim.y`. "
+      " All current params - m: ",
+      m,
+      ", n: ",
+      n,
+      ", k: ",
+      k,
+      ", block_dim.x: ",
+      block_dim.x,
+      ", block_dim.y: ",
+      block_dim.y,
+      ".");
+  TORCH_CHECK(
+      k % block_dim.x == 0,
+      "Invalid block dimensions: k (",
+      k,
+      ") must be divisible by block_dim.x (",
+      block_dim.x,
+      "). Received k: ",
+      k,
+      ", block_dim.x: ",
+      block_dim.x,
+      " Please either use a `k` which is divisible by `block_dim.x`, or update "
+      "`get_best_block_dim()` heuristics to choose another `block_dim.x`."
+      " All current params - m: ",
+      m,
+      ", n: ",
+      n,
+      ", k: ",
+      k,
+      ", block_dim.x: ",
+      block_dim.x,
+      ", block_dim.y: ",
+      block_dim.y,
+      ".");
+  TORCH_CHECK(
+      (k / block_dim.x) % 8 == 0,
+      "Invalid num_per_thread: (",
+      k / block_dim.x,
+      ") must be divisible by 8.",
+      " Received k: ",
+      k,
+      ", block_dim.x: ",
+      block_dim.x,
+      " Please either use a `k` that `k / block_dim.x` that is divisble by 8, or update "
+      "`get_best_block_dim()` heuristics to choose another `block_dim.x`."
+      " All current params - m: ",
+      m,
+      ", n: ",
+      n,
+      ", k: ",
+      k,
+      ", block_dim.x: ",
+      block_dim.x,
+      ", block_dim.y: ",
+      block_dim.y,
+      ".");
+
+  dim3 grid_dim(1, n / block_dim.y);
+  unsigned int num_per_thread = k / block_dim.x;
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  auto Y = at::empty({m, n}, X.options().dtype(at::kBFloat16));
+
+  gemv_quantized_fp8<<<grid_dim, block_dim, 0, stream>>>(
+      reinterpret_cast<cutlass::float_e4m3_t*>(W.data_ptr()), // mat
+      reinterpret_cast<__nv_bfloat16*>(X.data_ptr()), // vec
+      reinterpret_cast<__nv_bfloat16*>(Y.data_ptr()), // res
+      k,
+      __float2half(w_scale.item().toFloat()), // default_scale
+      __float2half(0), // default_zp
+      num_per_thread);
+
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  return Y;
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/fp8fp8bf16_fast_gemv.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/fp8fp8bf16_fast_gemv.cu
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/core/ScalarType.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_bf16.h>
+
+#include "include/fast_gemv.cuh"
+
+namespace fbgemm_gpu {
+
+// The heuristics are derived by sweeping over 4 different
+// problem sizes we care about and selected the best elapsed time/bw
+// combination. See more in
+// deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/sweep_utils.py
+dim3 get_best_block_dim_3(int m, int n, int k) {
+  if (m == 1 && n == 1280 && k == 8192) {
+    return dim3(128, 1);
+  } else if (m == 1 && n == 8192 && k == 1024) {
+    return dim3(32, 32);
+  } else if (m == 1 && n == 7168 && k == 8192) {
+    return dim3(128, 1);
+  } else if (m == 1 && n == 8192 && k == 3584) {
+    return dim3(64, 2);
+  } else {
+    // Default block dimensions
+    return dim3(32, 4);
+  }
+}
+
+at::Tensor fp8fp8bf16_fast_gemv(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor w_scale,
+    at::Tensor /*w_zp*/) {
+  // X: M x K
+  // W: N x K
+  auto m = X.size(0);
+  auto n = W.size(0);
+  auto k = W.size(1);
+
+  TORCH_CHECK(X.is_cuda() && X.is_contiguous());
+  TORCH_CHECK(W.is_cuda() && W.is_contiguous());
+
+  dim3 block_dim = get_best_block_dim_3(m, n, k);
+
+  TORCH_CHECK(
+      n % block_dim.y == 0,
+      "Invalid block dimensions: n (",
+      n,
+      ") must be divisible by block_dim.y (",
+      block_dim.y,
+      "). Received n: ",
+      n,
+      ", block_dim.y: ",
+      block_dim.y,
+      " Please either use a `n` which is divisible by `block_dim.y`, or update "
+      "`get_best_block_dim()` heuristics to choose another `block_dim.y`. "
+      " All current params - m: ",
+      m,
+      ", n: ",
+      n,
+      ", k: ",
+      k,
+      ", block_dim.x: ",
+      block_dim.x,
+      ", block_dim.y: ",
+      block_dim.y,
+      ".");
+  TORCH_CHECK(
+      k % block_dim.x == 0,
+      "Invalid block dimensions: k (",
+      k,
+      ") must be divisible by block_dim.x (",
+      block_dim.x,
+      "). Received k: ",
+      k,
+      ", block_dim.x: ",
+      block_dim.x,
+      " Please either use a `k` which is divisible by `block_dim.x`, or update "
+      "`get_best_block_dim()` heuristics to choose another `block_dim.x`."
+      " All current params - m: ",
+      m,
+      ", n: ",
+      n,
+      ", k: ",
+      k,
+      ", block_dim.x: ",
+      block_dim.x,
+      ", block_dim.y: ",
+      block_dim.y,
+      ".");
+  TORCH_CHECK(
+      (k / block_dim.x) % 8 == 0,
+      "Invalid num_per_thread: (",
+      k / block_dim.x,
+      ") must be divisible by 8.",
+      " Received k: ",
+      k,
+      ", block_dim.x: ",
+      block_dim.x,
+      " Please either use a `k` that `k / block_dim.x` that is divisble by 8, or update "
+      "`get_best_block_dim()` heuristics to choose another `block_dim.x`."
+      " All current params - m: ",
+      m,
+      ", n: ",
+      n,
+      ", k: ",
+      k,
+      ", block_dim.x: ",
+      block_dim.x,
+      ", block_dim.y: ",
+      block_dim.y,
+      ".");
+
+  dim3 grid_dim(1, n / block_dim.y);
+  unsigned int num_per_thread = k / block_dim.x;
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  auto Y = at::empty({m, n}, X.options().dtype(at::kBFloat16));
+
+  gemv_quantized_fp8fp8<<<grid_dim, block_dim, 0, stream>>>(
+      reinterpret_cast<cutlass::float_e4m3_t*>(W.data_ptr()), // mat
+      reinterpret_cast<cutlass::float_e4m3_t*>(X.data_ptr()), // vec
+      reinterpret_cast<__nv_bfloat16*>(Y.data_ptr()), // res
+      k,
+      __float2half(w_scale.item().toFloat()), // default_scale
+      __float2half(0), // default_zp
+      num_per_thread);
+
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  return Y;
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/fast_gemv.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/fast_gemv.cu
@@ -240,6 +240,123 @@ __global__ void gemv_quantized_fp8(
   }
 }
 
+///////////////////////////// QUANTIZED-FP8FP8 //////////////////////////////
+
+__global__ void gemv_quantized_fp8fp8(
+    cutlass::float_e4m3_t* mat,
+    cutlass::float_e4m3_t* vec,
+    __nv_bfloat16* res,
+    unsigned int n,
+    half scale,
+    half zero_point,
+    unsigned int num_per_thread) {
+  float sum = 0;
+  // each thread load num_per_thread elements from global
+  unsigned int tid = threadIdx.x;
+  unsigned int row = blockIdx.y * blockDim.y + threadIdx.y;
+  unsigned int start_idx = threadIdx.x;
+  half4* mat4 = reinterpret_cast<half4*>(mat);
+  half4* vec4 = reinterpret_cast<half4*>(vec);
+
+  float zero_point_f = static_cast<float>(
+      zero_point); // so far, we use a default 0 value zero_point
+  float scale_f = static_cast<float>(scale);
+
+#pragma unroll
+  for (int iter = 0; iter < num_per_thread >> 3; iter++) {
+    unsigned int j = start_idx + iter * blockDim.x;
+    if (j < n >> 3) {
+      half4 vec_val = vec4[j];
+      half4 mat_val = mat4[row * (n >> 3) + j];
+      const fp8_2* vec_h1 = (fp8_2*)&vec_val.x;
+      const fp8_2* vec_h2 = (fp8_2*)&vec_val.y;
+      const fp8_2* vec_h3 = (fp8_2*)&vec_val.z;
+      const fp8_2* vec_h4 = (fp8_2*)&vec_val.w;
+      const fp8_2* mat_h1 = (fp8_2*)&mat_val.x;
+      const fp8_2* mat_h2 = (fp8_2*)&mat_val.y;
+      const fp8_2* mat_h3 = (fp8_2*)&mat_val.z;
+      const fp8_2* mat_h4 = (fp8_2*)&mat_val.w;
+      sum += (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+                  vec_h1->x) -
+              zero_point_f) *
+          (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+               mat_h1->x) -
+           zero_point_f);
+      sum += (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+                  vec_h1->y) -
+              zero_point_f) *
+          (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+               mat_h1->y) -
+           zero_point_f);
+      sum += (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+                  vec_h2->x) -
+              zero_point_f) *
+          (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+               mat_h2->x) -
+           zero_point_f);
+      sum += (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+                  vec_h2->y) -
+              zero_point_f) *
+          (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+               mat_h2->y) -
+           zero_point_f);
+      sum += (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+                  vec_h3->x) -
+              zero_point_f) *
+          (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+               mat_h3->x) -
+           zero_point_f);
+      sum += (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+                  vec_h3->y) -
+              zero_point_f) *
+          (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+               mat_h3->y) -
+           zero_point_f);
+      sum += (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+                  vec_h4->x) -
+              zero_point_f) *
+          (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+               mat_h4->x) -
+           zero_point_f);
+      sum += (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+                  vec_h4->y) -
+              zero_point_f) *
+          (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+               mat_h4->y) -
+           zero_point_f);
+    }
+  }
+
+  sum *= (scale_f);
+
+  sum = warpReduceSum(sum, blockDim.x);
+
+  if (blockDim.x <= WARP_SIZE) {
+    if (tid == 0) {
+      res[row] = __float2bfloat16(sum);
+    }
+    return;
+  }
+
+  // Shared mem for partial sums (one per warp in the block)
+  static __shared__ float warpLevelSums[SHARED_MEM_MAX_ROWS][WARP_SIZE];
+  const int laneId = threadIdx.x % WARP_SIZE;
+  const int warpId = threadIdx.x / WARP_SIZE;
+  if (laneId == 0)
+    warpLevelSums[threadIdx.y][warpId] = sum;
+  __syncthreads();
+  // read from shared memory only if that warp existed
+  sum = (threadIdx.x < blockDim.x / WARP_SIZE)
+      ? warpLevelSums[threadIdx.y][laneId]
+      : 0.0;
+  // Final reduce using first warp
+  if (warpId == 0)
+    sum = warpReduceSum(sum, blockDim.x / WARP_SIZE);
+  if (tid == 0) {
+    res[row] = __float2bfloat16(sum);
+  }
+}
+
 ///////////////////////////// QUANTIZED-INT4 //////////////////////////////
 
 // based on previous experiments, num_per_thread can >= 16

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/fast_gemv.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/fast_gemv.cuh
@@ -67,6 +67,15 @@ __global__ void gemv_quantized_fp8(
     half zero_point,
     unsigned int num_per_thread);
 
+__global__ void gemv_quantized_fp8fp8(
+    cutlass::float_e4m3_t* mat,
+    cutlass::float_e4m3_t* vec,
+    __nv_bfloat16* res,
+    unsigned int n,
+    half scale,
+    half zero_point,
+    unsigned int num_per_thread);
+
 __global__ void gemv_quantized_int4(
     uint4_2* mat,
     half* vec,

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/fast_gemv.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/fast_gemv.cuh
@@ -42,6 +42,7 @@
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 #include <cutlass/cutlass.h>
+#include <cutlass/float8.h>
 
 #include "utility.cuh"
 
@@ -57,10 +58,10 @@ __global__ void gemv_bf16(
     unsigned int n,
     unsigned int num_per_thread);
 
-__global__ void gemv_quantized_int8(
-    int8_t* mat,
-    half* vec,
-    half* res,
+__global__ void gemv_quantized_fp8(
+    cutlass::float_e4m3_t* mat,
+    __nv_bfloat16* vec,
+    __nv_bfloat16* res,
     unsigned int n,
     half scale,
     half zero_point,

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/utility.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/utility.cuh
@@ -41,6 +41,8 @@
 #include <cuda.h>
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
+#include <cutlass/cutlass.h>
+#include <cutlass/float8.h>
 #include <stdio.h>
 
 #include <cstdint>
@@ -80,6 +82,9 @@ struct bfloat16_2 {
 };
 struct int8_2 {
   int8_t x, y;
+};
+struct fp8_2 {
+  cutlass::float_e4m3_t x, y;
 };
 struct uint4_2_4 {
   uint4_2 x, y, z, w;

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -121,6 +121,12 @@ at::Tensor f8f8bf16_cublas(
     bool use_fast_accum = true,
     std::optional<at::Tensor> output = std::nullopt);
 at::Tensor bf16_fast_gemv(at::Tensor X, at::Tensor W);
+at::Tensor bf16fp8bf16_fast_gemv(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor scale,
+    at::Tensor zp);
+
 at::Tensor f8i4bf16_rowwise(
     at::Tensor XQ,
     at::Tensor WQ,
@@ -185,6 +191,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "f8i4bf16_rowwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor w_zp) -> Tensor");
   m.def("bf16_fast_gemv(Tensor X, Tensor W) -> Tensor");
+  m.def(
+      "bf16fp8bf16_fast_gemv(Tensor X, Tensor W, Tensor w_scale, Tensor w_zp) -> Tensor");
   m.def("f8f8bf16_lite(Tensor XQ, Tensor WQ, Tensor scale) -> Tensor");
   m.def(
       "bf16i4bf16_rowwise(Tensor X, Tensor WQ, Tensor w_scale, Tensor w_zp) -> Tensor");
@@ -266,6 +274,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   m.impl("f8f8bf16", f8f8bf16);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas);
   m.impl("bf16_fast_gemv", bf16_fast_gemv);
+  m.impl("bf16fp8bf16_fast_gemv", bf16fp8bf16_fast_gemv);
   m.impl("f8f8bf16_lite", f8f8bf16_lite);
   m.impl("f8i4bf16_rowwise", f8i4bf16_rowwise);
   m.impl("bf16i4bf16_rowwise_batched", bf16i4bf16_rowwise_batched);
@@ -293,6 +302,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
   m.impl("f8f8bf16", f8f8bf16);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas);
   m.impl("bf16_fast_gemv", bf16_fast_gemv);
+  m.impl("bf16fp8bf16_fast_gemv", bf16fp8bf16_fast_gemv);
   m.impl("f8f8bf16_lite", f8f8bf16_lite);
   m.impl("f8i4bf16_rowwise", f8i4bf16_rowwise);
   m.impl("bf16i4bf16_rowwise_batched", bf16i4bf16_rowwise_batched);
@@ -403,6 +413,17 @@ at::Tensor bf16_fast_gemv_meta(at::Tensor X, at::Tensor W) {
   const at::SymInt M = X.sym_size(0);
   const at::SymInt N = W.sym_size(0);
   auto Y = at::empty_symint({M, N}, X.options().dtype(at::kHalf));
+  return Y;
+}
+
+at::Tensor bf16fp8bf16_fast_gemv_meta(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor /*w_scale*/,
+    at::Tensor /*w_zp*/) {
+  const at::SymInt M = X.sym_size(0);
+  const at::SymInt N = W.sym_size(0);
+  auto Y = at::empty_symint({M, N}, X.options().dtype(at::kBFloat16));
   return Y;
 }
 
@@ -523,6 +544,7 @@ TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
   m.impl("f8f8bf16", f8f8bf16_meta);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas_meta);
   m.impl("bf16_fast_gemv", bf16_fast_gemv_meta);
+  m.impl("bf16fp8bf16_fast_gemv", bf16fp8bf16_fast_gemv_meta);
   m.impl("f8f8bf16_rowwise_batched", f8f8bf16_rowwise_batched_meta);
   m.impl("f8i4bf16_rowwise", f8i4bf16_rowwise_meta);
   m.impl("bf16i4bf16_rowwise", bf16i4bf16_rowwise_meta);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -127,6 +127,12 @@ at::Tensor bf16fp8bf16_fast_gemv(
     at::Tensor scale,
     at::Tensor zp);
 
+at::Tensor fp8fp8bf16_fast_gemv(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor scale,
+    at::Tensor zp);
+
 at::Tensor f8i4bf16_rowwise(
     at::Tensor XQ,
     at::Tensor WQ,
@@ -193,6 +199,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def("bf16_fast_gemv(Tensor X, Tensor W) -> Tensor");
   m.def(
       "bf16fp8bf16_fast_gemv(Tensor X, Tensor W, Tensor w_scale, Tensor w_zp) -> Tensor");
+  m.def(
+      "fp8fp8bf16_fast_gemv(Tensor X, Tensor W, Tensor w_scale, Tensor w_zp) -> Tensor");
   m.def("f8f8bf16_lite(Tensor XQ, Tensor WQ, Tensor scale) -> Tensor");
   m.def(
       "bf16i4bf16_rowwise(Tensor X, Tensor WQ, Tensor w_scale, Tensor w_zp) -> Tensor");
@@ -275,6 +283,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas);
   m.impl("bf16_fast_gemv", bf16_fast_gemv);
   m.impl("bf16fp8bf16_fast_gemv", bf16fp8bf16_fast_gemv);
+  m.impl("fp8fp8bf16_fast_gemv", fp8fp8bf16_fast_gemv);
   m.impl("f8f8bf16_lite", f8f8bf16_lite);
   m.impl("f8i4bf16_rowwise", f8i4bf16_rowwise);
   m.impl("bf16i4bf16_rowwise_batched", bf16i4bf16_rowwise_batched);
@@ -303,6 +312,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas);
   m.impl("bf16_fast_gemv", bf16_fast_gemv);
   m.impl("bf16fp8bf16_fast_gemv", bf16fp8bf16_fast_gemv);
+  m.impl("fp8fp8bf16_fast_gemv", fp8fp8bf16_fast_gemv);
   m.impl("f8f8bf16_lite", f8f8bf16_lite);
   m.impl("f8i4bf16_rowwise", f8i4bf16_rowwise);
   m.impl("bf16i4bf16_rowwise_batched", bf16i4bf16_rowwise_batched);
@@ -417,6 +427,17 @@ at::Tensor bf16_fast_gemv_meta(at::Tensor X, at::Tensor W) {
 }
 
 at::Tensor bf16fp8bf16_fast_gemv_meta(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor /*w_scale*/,
+    at::Tensor /*w_zp*/) {
+  const at::SymInt M = X.sym_size(0);
+  const at::SymInt N = W.sym_size(0);
+  auto Y = at::empty_symint({M, N}, X.options().dtype(at::kBFloat16));
+  return Y;
+}
+
+at::Tensor fp8fp8bf16_fast_gemv_meta(
     at::Tensor X,
     at::Tensor W,
     at::Tensor /*w_scale*/,
@@ -545,6 +566,7 @@ TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas_meta);
   m.impl("bf16_fast_gemv", bf16_fast_gemv_meta);
   m.impl("bf16fp8bf16_fast_gemv", bf16fp8bf16_fast_gemv_meta);
+  m.impl("fp8fp8bf16_fast_gemv", fp8fp8bf16_fast_gemv_meta);
   m.impl("f8f8bf16_rowwise_batched", f8f8bf16_rowwise_batched_meta);
   m.impl("f8i4bf16_rowwise", f8i4bf16_rowwise_meta);
   m.impl("bf16i4bf16_rowwise", bf16i4bf16_rowwise_meta);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/745

A minor fix for trt-llm cudaCoreGemm `cuda_lite` op in quantize_bench script.

when testing with `--bench_quantize` detected a failure with input

```
...
tree/deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py", line 797, in quantize_and_compute
    return self.compute(xq, wq, x_scale * w_scale)
TypeError: FP8LiteGemm.compute() missing 1 required positional argument: 'w_scale'
```

Reviewed By: jwfromm

Differential Revision: D69272912


