### PR TITLE
add mixed precision fp8 fast_gemv_quantized kernel

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/common_utils.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/common_utils.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <c10/util/Exception.h>
+
+namespace fbgemm_gpu {
+
+namespace {
+
+void check_if_valid_block_dimensions(int m, int n, int k, dim3 block_dim) {
+  TORCH_CHECK(
+      n % block_dim.y == 0,
+      "Invalid block dimensions: n (",
+      n,
+      ") must be divisible by block_dim.y (",
+      block_dim.y,
+      "). Received n: ",
+      n,
+      ", block_dim.y: ",
+      block_dim.y,
+      " Please either use a `n` which is divisible by `block_dim.y`, or update "
+      "`get_best_block_dim()` heuristics to choose another `block_dim.y`. "
+      " All current params - m: ",
+      m,
+      ", n: ",
+      n,
+      ", k: ",
+      k,
+      ", block_dim.x: ",
+      block_dim.x,
+      ", block_dim.y: ",
+      block_dim.y,
+      ".");
+  TORCH_CHECK(
+      k % block_dim.x == 0,
+      "Invalid block dimensions: k (",
+      k,
+      ") must be divisible by block_dim.x (",
+      block_dim.x,
+      "). Received k: ",
+      k,
+      ", block_dim.x: ",
+      block_dim.x,
+      " Please either use a `k` which is divisible by `block_dim.x`, or update "
+      "`get_best_block_dim()` heuristics to choose another `block_dim.x`."
+      " All current params - m: ",
+      m,
+      ", n: ",
+      n,
+      ", k: ",
+      k,
+      ", block_dim.x: ",
+      block_dim.x,
+      ", block_dim.y: ",
+      block_dim.y,
+      ".");
+  TORCH_CHECK(
+      (k / block_dim.x) % 8 == 0,
+      "Invalid num_per_thread: (",
+      k / block_dim.x,
+      ") must be divisible by 8.",
+      " Received k: ",
+      k,
+      ", block_dim.x: ",
+      block_dim.x,
+      " Please either use a `k` that `k / block_dim.x` that is divisble by 8, or update "
+      "`get_best_block_dim()` heuristics to choose another `block_dim.x`."
+      " All current params - m: ",
+      m,
+      ", n: ",
+      n,
+      ", k: ",
+      k,
+      ", block_dim.x: ",
+      block_dim.x,
+      ", block_dim.y: ",
+      block_dim.y,
+      ".");
+}
+} // namespace
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/fast_gemv.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/fast_gemv.cu
@@ -39,6 +39,7 @@
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
+#include <cutlass/float8.h>
 #include <cutlass/numeric_conversion.h>
 #include <driver_functions.h>
 
@@ -133,10 +134,10 @@ __global__ void gemv_bf16(
 
 ///////////////////////////// QUANTIZED-INT8 //////////////////////////////
 
-__global__ void gemv_quantized_int8(
-    int8_t* mat,
-    half* vec,
-    half* res,
+__global__ void gemv_quantized_bf16_fp8(
+    cutlass::float_e4m3_t* mat,
+    __nv_bfloat16* vec,
+    __nv_bfloat16* res,
     unsigned int n,
     half scale,
     half zero_point,
@@ -158,30 +159,54 @@ __global__ void gemv_quantized_int8(
     if (j < n >> 3) {
       float4 vec_val = vec4[j];
       half4 mat_val = mat4[row * (n >> 3) + j];
-      const half2* vec_h1 = (half2*)&vec_val.x;
-      const half2* vec_h2 = (half2*)&vec_val.y;
-      const half2* vec_h3 = (half2*)&vec_val.z;
-      const half2* vec_h4 = (half2*)&vec_val.w;
-      const int8_2* mat_h1 = (int8_2*)&mat_val.x;
-      const int8_2* mat_h2 = (int8_2*)&mat_val.y;
-      const int8_2* mat_h3 = (int8_2*)&mat_val.z;
-      const int8_2* mat_h4 = (int8_2*)&mat_val.w;
-      sum += static_cast<float>(vec_h1->x) *
-          (static_cast<float>(mat_h1->x) - zero_point_f);
-      sum += static_cast<float>(vec_h1->y) *
-          (static_cast<float>(mat_h1->y) - zero_point_f);
-      sum += static_cast<float>(vec_h2->x) *
-          (static_cast<float>(mat_h2->x) - zero_point_f);
-      sum += static_cast<float>(vec_h2->y) *
-          (static_cast<float>(mat_h2->y) - zero_point_f);
-      sum += static_cast<float>(vec_h3->x) *
-          (static_cast<float>(mat_h3->x) - zero_point_f);
-      sum += static_cast<float>(vec_h3->y) *
-          (static_cast<float>(mat_h3->y) - zero_point_f);
-      sum += static_cast<float>(vec_h4->x) *
-          (static_cast<float>(mat_h4->x) - zero_point_f);
-      sum += static_cast<float>(vec_h4->y) *
-          (static_cast<float>(mat_h4->y) - zero_point_f);
+      const bfloat16_2* vec_h1 = (bfloat16_2*)&vec_val.x;
+      const bfloat16_2* vec_h2 = (bfloat16_2*)&vec_val.y;
+      const bfloat16_2* vec_h3 = (bfloat16_2*)&vec_val.z;
+      const bfloat16_2* vec_h4 = (bfloat16_2*)&vec_val.w;
+      const fp8_2* mat_h1 = (fp8_2*)&mat_val.x;
+      const fp8_2* mat_h2 = (fp8_2*)&mat_val.y;
+      const fp8_2* mat_h3 = (fp8_2*)&mat_val.z;
+      const fp8_2* mat_h4 = (fp8_2*)&mat_val.w;
+      sum +=
+          cutlass::NumericConverter<float, __nv_bfloat16>::convert(vec_h1->x) *
+          (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+               mat_h1->x) -
+           zero_point_f);
+      sum +=
+          cutlass::NumericConverter<float, __nv_bfloat16>::convert(vec_h1->y) *
+          (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+               mat_h1->y) -
+           zero_point_f);
+      sum +=
+          cutlass::NumericConverter<float, __nv_bfloat16>::convert(vec_h2->x) *
+          (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+               mat_h2->x) -
+           zero_point_f);
+      sum +=
+          cutlass::NumericConverter<float, __nv_bfloat16>::convert(vec_h2->y) *
+          (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+               mat_h2->y) -
+           zero_point_f);
+      sum +=
+          cutlass::NumericConverter<float, __nv_bfloat16>::convert(vec_h3->x) *
+          (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+               mat_h3->x) -
+           zero_point_f);
+      sum +=
+          cutlass::NumericConverter<float, __nv_bfloat16>::convert(vec_h3->y) *
+          (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+               mat_h3->y) -
+           zero_point_f);
+      sum +=
+          cutlass::NumericConverter<float, __nv_bfloat16>::convert(vec_h4->x) *
+          (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+               mat_h4->x) -
+           zero_point_f);
+      sum +=
+          cutlass::NumericConverter<float, __nv_bfloat16>::convert(vec_h4->y) *
+          (cutlass::NumericConverter<float, cutlass::float_e4m3_t>::convert(
+               mat_h4->y) -
+           zero_point_f);
     }
   }
 
@@ -191,7 +216,7 @@ __global__ void gemv_quantized_int8(
 
   if (blockDim.x <= WARP_SIZE) {
     if (tid == 0) {
-      res[row] = __float2half(sum);
+      res[row] = __float2bfloat16(sum);
     }
     return;
   }
@@ -211,7 +236,7 @@ __global__ void gemv_quantized_int8(
   if (warpId == 0)
     sum = warpReduceSum(sum, blockDim.x / WARP_SIZE);
   if (tid == 0) {
-    res[row] = __float2half(sum);
+    res[row] = __float2bfloat16(sum);
   }
 }
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/fast_gemv.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/fast_gemv.cuh
@@ -42,6 +42,7 @@
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 #include <cutlass/cutlass.h>
+#include <cutlass/float8.h>
 
 #include "utility.cuh"
 
@@ -57,10 +58,10 @@ __global__ void gemv_bf16(
     unsigned int n,
     unsigned int num_per_thread);
 
-__global__ void gemv_quantized_int8(
-    int8_t* mat,
-    half* vec,
-    half* res,
+__global__ void gemv_quantized_bf16_fp8(
+    cutlass::float_e4m3_t* mat,
+    __nv_bfloat16* vec,
+    __nv_bfloat16* res,
     unsigned int n,
     half scale,
     half zero_point,

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/utility.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/utility.cuh
@@ -41,6 +41,8 @@
 #include <cuda.h>
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
+#include <cutlass/cutlass.h>
+#include <cutlass/float8.h>
 #include <stdio.h>
 
 #include <cstdint>
@@ -80,6 +82,9 @@ struct bfloat16_2 {
 };
 struct int8_2 {
   int8_t x, y;
+};
+struct fp8_2 {
+  cutlass::float_e4m3_t x, y;
 };
 struct uint4_2_4 {
   uint4_2 x, y, z, w;

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -121,6 +121,9 @@ at::Tensor f8f8bf16_cublas(
     bool use_fast_accum = true,
     std::optional<at::Tensor> output = std::nullopt);
 at::Tensor bf16_fast_gemv(at::Tensor X, at::Tensor W);
+at::Tensor
+bf16fp8bf16_fast_gemv(at::Tensor X, at::Tensor W, double scale, double zp);
+
 at::Tensor f8i4bf16_rowwise(
     at::Tensor XQ,
     at::Tensor WQ,
@@ -185,6 +188,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "f8i4bf16_rowwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor w_zp) -> Tensor");
   m.def("bf16_fast_gemv(Tensor X, Tensor W) -> Tensor");
+  m.def(
+      "bf16fp8bf16_fast_gemv(Tensor X, Tensor W, float w_scale, float w_zp) -> Tensor");
   m.def("f8f8bf16_lite(Tensor XQ, Tensor WQ, Tensor scale) -> Tensor");
   m.def(
       "bf16i4bf16_rowwise(Tensor X, Tensor WQ, Tensor w_scale, Tensor w_zp) -> Tensor");
@@ -266,6 +271,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   m.impl("f8f8bf16", f8f8bf16);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas);
   m.impl("bf16_fast_gemv", bf16_fast_gemv);
+  m.impl("bf16fp8bf16_fast_gemv", bf16fp8bf16_fast_gemv);
   m.impl("f8f8bf16_lite", f8f8bf16_lite);
   m.impl("f8i4bf16_rowwise", f8i4bf16_rowwise);
   m.impl("bf16i4bf16_rowwise_batched", bf16i4bf16_rowwise_batched);
@@ -293,6 +299,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
   m.impl("f8f8bf16", f8f8bf16);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas);
   m.impl("bf16_fast_gemv", bf16_fast_gemv);
+  m.impl("bf16fp8bf16_fast_gemv", bf16fp8bf16_fast_gemv);
   m.impl("f8f8bf16_lite", f8f8bf16_lite);
   m.impl("f8i4bf16_rowwise", f8i4bf16_rowwise);
   m.impl("bf16i4bf16_rowwise_batched", bf16i4bf16_rowwise_batched);
@@ -403,6 +410,17 @@ at::Tensor bf16_fast_gemv_meta(at::Tensor X, at::Tensor W) {
   const at::SymInt M = X.sym_size(0);
   const at::SymInt N = W.sym_size(0);
   auto Y = at::empty_symint({M, N}, X.options().dtype(at::kHalf));
+  return Y;
+}
+
+at::Tensor bf16fp8bf16_fast_gemv_meta(
+    at::Tensor X,
+    at::Tensor W,
+    double /*w_scale*/,
+    double /*w_zp*/) {
+  const at::SymInt M = X.sym_size(0);
+  const at::SymInt N = W.sym_size(0);
+  auto Y = at::empty_symint({M, N}, X.options().dtype(at::kBFloat16));
   return Y;
 }
 
@@ -523,6 +541,7 @@ TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
   m.impl("f8f8bf16", f8f8bf16_meta);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas_meta);
   m.impl("bf16_fast_gemv", bf16_fast_gemv_meta);
+  m.impl("bf16fp8bf16_fast_gemv", bf16fp8bf16_fast_gemv_meta);
   m.impl("f8f8bf16_rowwise_batched", f8f8bf16_rowwise_batched_meta);
   m.impl("f8i4bf16_rowwise", f8i4bf16_rowwise_meta);
   m.impl("bf16i4bf16_rowwise", bf16i4bf16_rowwise_meta);

--- a/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
@@ -1112,10 +1112,25 @@ class FP8Tests(unittest.TestCase):
                 block_scale[0],
                 block_scale[0],
             )
-            # test f16_fast_gemv is torch compileable
+            # test bf16_fast_gemv is torch compileable
             X_bf16 = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
             W_bf16 = torch.randn(N, K, device="cuda", dtype=torch.bfloat16)
             torch.compile(torch.ops.fbgemm.bf16_fast_gemv)(X_bf16, W_bf16)
+
+    @unittest.skipIf(
+        not torch.version.cuda, "Skip on AMD: fast gemv op is not yet supported."
+    )
+    def test_gemv(self, test_cases, gemv_op, atol, rtol, quantize_w=False):
+        for M, N, K in test_cases:
+            x = torch.randn(size=(M, K), dtype=torch.bfloat16, device="cuda") * 0.1
+            w = torch.randn(size=(N, K), dtype=torch.bfloat16, device="cuda") * 0.01
+            if quantize_w:
+                wq, w_scale = torch.ops.fbgemm.quantize_fp8_per_tensor(w)
+                z = gemv_op(x, wq, w_scale.item(), 0.0)
+            else:
+                z = gemv_op(x, w)
+            z_ref = (x @ w.T).to(torch.bfloat16).to("cuda")
+            torch.testing.assert_close(z, z_ref, atol=atol, rtol=rtol)
 
     @unittest.skipIf(
         not torch.version.cuda, "Skip on AMD: fast gemv op is not yet supported."
@@ -1129,14 +1144,27 @@ class FP8Tests(unittest.TestCase):
             (1, 7168, 8192),
             (1, 8192, 3584),
         ]
-        for M, N, K in test_cases:
-            x = torch.randn(size=(M, K), dtype=torch.bfloat16, device="cuda") * 0.1
-            w = torch.randn(size=(N, K), dtype=torch.bfloat16, device="cuda") * 0.01
+        self.test_gemv(test_cases, torch.ops.fbgemm.bf16_fast_gemv, 9.0e-3, 9.0e-3)
 
-            z = torch.ops.fbgemm.bf16_fast_gemv(x, w)
-            z_ref = (x @ w.T).to(torch.bfloat16).to("cuda")
-
-            torch.testing.assert_close(z, z_ref, atol=9.0e-3, rtol=9.0e-3)
+    @unittest.skipIf(
+        not torch.version.cuda, "Skip on AMD: fast gemv op is not yet supported."
+    )
+    def test_bf16_fp8_gemv(self) -> None:
+        test_cases = [
+            (1, 128, 256),
+            (1, 256, 256),
+            (1, 1280, 8192),
+            (1, 8192, 1024),
+            (1, 7168, 8192),
+            (1, 8192, 3584),
+        ]
+        self.test_gemv(
+            test_cases,
+            torch.ops.fbgemm.bf16fp8bf16_fast_gemv,
+            1.0e-2,
+            1.0e-2,
+            quantize_w=True,
+        )
 
     @unittest.skipIf(
         torch.version.hip, "Skip on AMD: cuda quantize op is yet supported."


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/752

Add fp8 (w) bf16 (x) mixed precision fast_gemv kernel support.

perf comparison:
P1727377260 achieved perf numbers on par/almost identical with `cuda_lite_fp8` (trt-llm gemv kernel).

Differential Revision: D69128901


