### PR TITLE
Create cpu iterator irrespective of optimizer choice

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -1291,9 +1291,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                     torch.zeros(1, dtype=torch.int64, device=self.current_device),
                     persistent=False,
                 )
-            self.iter_cpu: torch.Tensor = torch.zeros(
-                1, dtype=torch.int64, device="cpu"
-            )
+
+        self.iter_cpu: torch.Tensor = torch.zeros(1, dtype=torch.int64, device="cpu")
 
         cache_state = construct_cache_state(rows, locations, self.feature_table_map)
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/765

Internal users indentified edge case where we Optimizer is None, which leads cpu iter to never be created, and fails later at forward call.

FB: Post https://fb.workplace.com/groups/fbgemmusers/permalink/9530179190396110/

Differential Revision: D69604468


