### PR TITLE
[fbgemm_gpu] Nova job update

### DIFF
--- a/.github/scripts/nova_dir.bash
+++ b/.github/scripts/nova_dir.bash
@@ -18,7 +18,8 @@ if [[ "$CONDA_ENV" != "" ]]; then export CONDA_RUN="conda run --no-capture-outpu
 
 if  [[ "$CU_VERSION" == "cu121" ]] ||
     [[ "$CU_VERSION" == "cu124" ]] ||
-    [[ "$CU_VERSION" == "cu126" ]]; then
+    [[ "$CU_VERSION" == "cu126" ]] ||
+    [[ "$CU_VERSION" == "cu128" ]]; then
     export TORCH_CUDA_ARCH_LIST="7.0;8.0;9.0;9.0a"
     echo "Set TORCH_CUDA_ARCH_LIST to: ${TORCH_CUDA_ARCH_LIST}"
 


### PR DESCRIPTION
- Update Nova jobs to account for CUDA 12.8 builds.  This appears to fix the existing nova builds for both aarch64 and x86