### PR TITLE
sync wait before L1 and L2 flush

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -1831,12 +1831,12 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
 
         torch.cuda.current_stream().wait_stream(self.ssd_eviction_stream)
 
+        torch.cuda.synchronize()
         self.ssd_db.set(
             active_ids_cpu,
             active_weights_cpu,
             torch.tensor([active_ids_cpu.numel()]),
         )
-
         self.ssd_db.flush()
 
     def prepare_inputs(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/791

during flush, make sure we blocking wait on all the pending kernels before we do sync flush on L1 and L2

Reviewed By: q10, sryap

Differential Revision: D69557437


