### PR TITLE
Implement generate_vbe_metadata cpu

### DIFF
--- a/fbgemm_gpu/cmake/TbeTraining.cmake
+++ b/fbgemm_gpu/cmake/TbeTraining.cmake
@@ -158,6 +158,8 @@ gpu_cpp_library(
     ${gen_gpu_files_forward_split}
   NVCC_FLAGS
     ${TORCH_CUDA_OPTIONS}
+  DEPS
+    fbgemm_gpu_tbe_common
   DESTINATION
     fbgemm_gpu)
 

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cpu_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cpu_wrapper_template.cpp
@@ -26,6 +26,9 @@
 #include "fbgemm_gpu/utils/ops_utils.h"
 #include "fbgemm_gpu/utils/dispatch_macros.h"
 #include "fbgemm_gpu/embedding_common.h"
+{%- if has_vbe_support %}
+#include "fbgemm_gpu/utils/pt2_autograd_utils.h"
+{%- endif %}
 
 using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
@@ -53,23 +56,39 @@ Tensor split_embedding_codegen_grad_indice_weights{{ vdesc }}_pt2_cpu_wrapper(
     const Tensor& vbe_row_output_offsets,
     const Tensor& vbe_b_t_map,
     const int64_t info_B_num_bits,
-    const int64_t info_B_mask_int64
+    const int64_t info_B_mask_int64,
+    const Tensor& vbe_B_offsets_rank_per_feature,
+    const int64_t max_B
     {%- else %}
     const Tensor& feature_requires_grad
     {%- endif %}
 ) {
+    {%- if vbe %}
+    const auto offsets_ = reshape_vbe_offsets(
+        offsets,
+        vbe_B_offsets_rank_per_feature,
+        max_B,
+        D_offsets.numel() - 1
+    );
+    const auto grad_output_ = reshape_vbe_output(
+        grad_output,
+        max_B,
+        vbe_B_offsets_rank_per_feature,
+        D_offsets
+    );
+    {%- endif %}
   static auto op =
       torch::Dispatcher::singleton()
         .findSchemaOrThrow(
               "fbgemm::split_embedding_codegen_grad_indice_weights_cpu", "")
         .typed<Tensor(Tensor,Tensor,Tensor,Tensor,Tensor,Tensor,Tensor)>();
   return op.call(
-      grad_output,
+      {{ "grad_output_" if vbe else "grad_output" }},
       host_weights,
       weights_offsets,
       D_offsets,
       indices,
-      offsets,
+      {{ "offsets_" if vbe else "offsets" }},
       feature_requires_grad);
 }
 {%- endif %}
@@ -96,14 +115,20 @@ Tensor split_embedding_codegen_forward_{{ wdesc }}{{ vdesc }}_pt2_cpu_wrapper(
     const Tensor& /*lxu_cache_locations*/,
     const Tensor& /*uvm_cache_stats*/,
     {%- if vbe %}
-    const Tensor& vbe_row_output_offsets, /*vbe_output_offsets_feature_rank*/
-    const Tensor& vbe_b_t_map, /*vbe_B_offsets_rank_per_feature*/
+    const Tensor& vbe_row_output_offsets,
+    const Tensor& vbe_b_t_map,
     const c10::SymInt vbe_output_size,
     const int64_t info_B_num_bits,
     const int64_t info_B_mask_int64,
+    const Tensor& vbe_B_offsets_rank_per_feature,
+    const Tensor& vbe_output_offsets_feature_rank,
+    const int64_t max_B,
     {%- endif %}
     const bool /*is_experimental = false*/,
     const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)) {
+    {%- if vbe %}
+    const auto offsets_ = reshape_vbe_offsets(offsets, vbe_B_offsets_rank_per_feature, max_B, D_offsets.numel() - 1);
+    {%- endif %}
     static auto op =
         torch::Dispatcher::singleton()
             .findSchemaOrThrow("fbgemm::split_embedding_codegen_forward_cpu", "")
@@ -112,8 +137,6 @@ Tensor split_embedding_codegen_forward_{{ wdesc }}{{ vdesc }}_pt2_cpu_wrapper(
             )>();
     {%- if vbe %}
     // TODO: remove this after vbe is implemented for CPU kernel
-    Tensor vbe_B_offsets_rank_per_feature = vbe_b_t_map;
-    Tensor vbe_output_offsets_feature_rank = vbe_row_output_offsets;
     const auto output = op.call(
         host_weights,
         weights_offsets,
@@ -121,7 +144,7 @@ Tensor split_embedding_codegen_forward_{{ wdesc }}{{ vdesc }}_pt2_cpu_wrapper(
         total_D,
         hash_size_cumsum,
         indices,
-        offsets,
+        offsets_,
         pooling_mode,
         indice_weights,
         output_dtype);
@@ -192,6 +215,8 @@ Tensor split_embedding_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc }}_p
     const Tensor& B_offsets,
     const Tensor& vbe_row_output_offsets,
     const Tensor& vbe_b_t_map,
+    const Tensor& vbe_B_offsets_rank_per_feature,
+    const int64_t max_B,
     {%- endif %}
     const bool /*use_uniq_cache_locations*/,
     const bool /*use_homogeneous_placements*/,
@@ -200,6 +225,10 @@ Tensor split_embedding_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc }}_p
     , const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)
     {%- endif %})
     {
+        {%- if vbe %}
+        const auto offsets_ = reshape_vbe_offsets(offsets, vbe_B_offsets_rank_per_feature, max_B, D_offsets.numel() - 1);
+        const auto grad_output_ = reshape_vbe_output(grad_output, max_B, vbe_B_offsets_rank_per_feature, D_offsets);
+        {%- endif %}
         {%- set backward_op = "split_embedding_backward_codegen_{}_cpu".format(
                 optimizer
             )
@@ -230,7 +259,7 @@ Tensor split_embedding_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc }}_p
                 )>();
 
         op.call(
-            grad_output,
+            {{ "grad_output_" if vbe else "grad_output" }},
             host_weights,
             weights_placements,
             weights_offsets,
@@ -239,7 +268,7 @@ Tensor split_embedding_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc }}_p
             hash_size_cumsum,
             total_hash_size_bits,
             indices,
-            offsets,
+            {{ "offsets_" if vbe else "offsets" }},
             pooling_mode,
             indice_weights,
             stochastic_rounding,
@@ -248,7 +277,7 @@ Tensor split_embedding_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc }}_p
             , output_dtype
             {%- endif %}
             );
-        return grad_output;
+        return Tensor();
     }
 {% endif %}
 {%- endfor %} {#-/*for weighted*/#}
@@ -293,6 +322,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         "    SymInt vbe_output_size, "
         "    int info_B_num_bits, "
         "    int info_B_mask_int64, "
+        "    Tensor vbe_B_offsets_rank_per_feature, "
+        "    Tensor vbe_output_offsets_feature_rank, "
+        "    int max_B, "
         {%- endif %}
         "    bool is_experimental, "
         "    int output_dtype "
@@ -345,6 +377,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         "    Tensor B_offsets, "
         "    Tensor vbe_row_output_offsets, "
         "    Tensor vbe_b_t_map, "
+        "    Tensor vbe_B_offsets_rank_per_feature, "
+        "    int max_B, "
         {%- endif %}
         "    bool use_uniq_cache_locations, "
         "    bool use_homogeneous_placements,"
@@ -381,7 +415,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         "    Tensor vbe_row_output_offsets, "
         "    Tensor vbe_b_t_map, "
         "    int info_B_num_bits, "
-        "    int info_B_mask_int64"
+        "    int info_B_mask_int64, "
+        "    Tensor vbe_B_offsets_rank_per_feature, "
+        "    int max_B "
         {%- else %}
         "    Tensor feature_requires_grad"
         {%- endif %}

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
@@ -93,6 +93,9 @@ Tensor {{ fwd_mdesc }}_embedding{{ ndesc }}_codegen_forward_{{ desc_suffix }}_pt
     const c10::SymInt vbe_output_size,
     const int64_t info_B_num_bits,
     const int64_t info_B_mask_int64,
+    const Tensor& vbe_B_offsets_rank_per_feature,
+    const Tensor& vbe_output_offsets_feature_rank,
+    const int64_t max_B,
     {%- endif %}
     {%- if is_gwd %}
     const Tensor& prev_iter_dev,
@@ -241,6 +244,8 @@ Tensor {{ bwd_mdesc }}_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ 
     const Tensor& B_offsets,
     const Tensor& vbe_row_output_offsets,
     const Tensor& vbe_b_t_map,
+    const Tensor& vbe_B_offsets_rank_per_feature,
+    const int64_t max_B,
     {%- endif %}
     const bool use_uniq_cache_locations,
     const bool use_homogeneous_placements,
@@ -403,7 +408,9 @@ Tensor {{ fwd_mdesc }}_embedding_codegen_grad_indice_weights{{ vdesc }}_pt2_{{ d
     const Tensor& vbe_row_output_offsets,
     const Tensor& vbe_b_t_map,
     const int64_t info_B_num_bits,
-    const int64_t info_B_mask_int64
+    const int64_t info_B_mask_int64,
+    const Tensor& vbe_B_offsets_rank_per_feature,
+    const int64_t max_B
     {%- else %}
     const Tensor& feature_requires_grad
     {%- endif %}
@@ -529,6 +536,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         "    SymInt vbe_output_size, "
         "    int info_B_num_bits, "
         "    int info_B_mask_int64, "
+        "    Tensor vbe_B_offsets_rank_per_feature, "
+        "    Tensor vbe_output_offsets_feature_rank, "
+        "    int max_B, "
         {%- endif %}
         {%- if is_gwd %}
         "    Tensor{{ schema_annotation['prev_iter_dev'] }} prev_iter_dev, "
@@ -599,6 +609,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         "    Tensor B_offsets, "
         "    Tensor vbe_row_output_offsets, "
         "    Tensor vbe_b_t_map, "
+        "    Tensor vbe_B_offsets_rank_per_feature, "
+        "    int max_B, "
         {%- endif %}
         "    bool use_uniq_cache_locations, "
         "    bool use_homogeneous_placements,"
@@ -656,7 +668,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         "    Tensor vbe_row_output_offsets, "
         "    Tensor vbe_b_t_map, "
         "    int info_B_num_bits, "
-        "    int info_B_mask_int64"
+        "    int info_B_mask_int64, "
+        "    Tensor vbe_B_offsets_rank_per_feature, "
+        "    int max_B "
         {%- else %}
         "    Tensor feature_requires_grad"
         {%- endif %}

--- a/fbgemm_gpu/codegen/training/pt2/pt2_autograd_utils.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/pt2_autograd_utils.cpp
@@ -14,37 +14,47 @@ using Tensor = at::Tensor;
 namespace fbgemm_gpu {
 
 ////////////////////////////////////////////////////////////////////////////////
-// Helper Functions
+// Utils Functions for PT2 Autograd
 ////////////////////////////////////////////////////////////////////////////////
 
+/// Reshape VBE output (or grad_output) to be in a fixed-batch size format to
+/// work with non-VBE CPU kernel.
+///
+/// reshaped_grad_output              A 2D tensor that contains the grad output
+///                                    of shape [max_B, total_D] where max_B is
+///                                    maximum batch size and total_D is the
+///                                    accumulated embedding dimensions
+/// @param grad_output                A 1D tensor that contains the grad_output
+///                                    in a VBE output format
+/// @param max_B                      Maximum batch size
+/// @param B_offsets_rank_per_feature A 2D tensor that contains batch size
+///                                    offsets for all ranks for each feature
+///                                    size(0) is number of features
+///                                    size(1) is number of ranks
+/// @param D_offsets                  Embedding dimension offsets. Dimension of
+///                                    feature t = D_offsets[t-1] - D_offsets[t]
 Tensor reshape_vbe_output(
     const Tensor& grad_output,
-    const Tensor& B_offsets,
+    const int64_t max_B,
     const Tensor& B_offsets_rank_per_feature,
     const Tensor& D_offsets) {
   /* FOR CPU VBE to use the same backend */
   const auto T = D_offsets.numel() - 1;
-  int32_t max_B = 0;
-  int32_t total_D = 0;
-  // find max_B, total_D to create output [max_B, total_D]
-  for (int32_t t = 0; t < T; t++) {
-    auto b = B_offsets[t + 1].item<int32_t>() - B_offsets[t].item<int32_t>();
-    max_B = std::max(max_B, b);
-    total_D += D_offsets[t + 1].item<int32_t>() - D_offsets[t].item<int32_t>();
-  }
+  auto D_offsets_acc = D_offsets.accessor<int32_t, 1>();
+  const int32_t total_D = D_offsets_acc[T] - D_offsets_acc[0];
   auto grad_output_ = at::empty({max_B, total_D}, grad_output.options());
   // for each feature
   auto offset = 0;
 
   const int32_t R = B_offsets_rank_per_feature.size(1) - 1;
+  auto B_offsets_rank_per_feature_acc =
+      B_offsets_rank_per_feature.accessor<int32_t, 2>();
   for (int32_t r = 0; r < R; r++) {
     auto D_offset = 0;
     for (int32_t t = 0; t < T; t++) {
-      const int32_t b_begin = B_offsets_rank_per_feature[t][r].item<int32_t>();
-      const int32_t b_end =
-          B_offsets_rank_per_feature[t][r + 1].item<int32_t>();
-      const int32_t D =
-          D_offsets[t + 1].item<int32_t>() - D_offsets[t].item<int32_t>();
+      const int32_t b_begin = B_offsets_rank_per_feature_acc[t][r];
+      const int32_t b_end = B_offsets_rank_per_feature_acc[t][r + 1];
+      const int32_t D = D_offsets_acc[t + 1] - D_offsets_acc[t];
       const int32_t b = b_end - b_begin;
       const int32_t num_elm = b * D;
       auto values = grad_output.slice(0, offset, offset + num_elm);
@@ -59,4 +69,102 @@ Tensor reshape_vbe_output(
   }
   return grad_output_;
 }
+
+/// Bounds checking to ensure there's no buffer overflow for memcpy.
+///
+/// @param dst          Pointer to the destination.
+/// @param dst_index    Starting index where the content is to be copied to
+/// @param dst_size     Max number of bytes to modify in the destination.
+/// @param src          Pointer to the source.
+/// @param src_index    Starting index where the content is to be copied from
+/// @param src_size     Max number of bytes to copy from the source
+/// @param copy_size    Number of bytes to copy.
+void checked_memcpy(
+    void* dst,
+    size_t dst_buffer,
+    const void* src,
+    size_t src_buffer,
+    size_t copy_size) {
+  TORCH_CHECK(
+      dst_buffer >= copy_size,
+      "Possible buffer overflow for memcpy. Expected to copy ",
+      copy_size,
+      " bytes, but destination buffer has only ",
+      dst_buffer,
+      " bytes.");
+  TORCH_CHECK(
+      src_buffer >= copy_size,
+      "Possible buffer overflow for memcpy. Expected to copy ",
+      copy_size,
+      " bytes, but source buffer has only ",
+      src_buffer,
+      " bytes.");
+  std::memcpy(dst, src, copy_size);
+}
+
+/// Pad VBE offsets to work with non-VBE CPU kernel.
+///
+/// reshaped_offsets                  A 1D tensor that contains the offsets
+///                                    in a fixed-batch-size format
+/// @param offsets                    A 1D tensor of VBE offsets for indices
+/// @param B_offsets_rank_per_feature A 2D tensor that contains batch size
+///                                    offsets for all ranks for each feature.
+///                                    size(0) is number of features
+///                                    size(1) is number of ranks
+/// @param max_B                      Maximum batch size
+/// @param T                          Number of embedding tables (features)
+Tensor reshape_vbe_offsets(
+    const Tensor& offsets,
+    const Tensor& B_offsets_rank_per_feature,
+    const int64_t max_B,
+    const int32_t T) {
+  if (offsets.numel() == 0) {
+    return offsets;
+  }
+  auto B_offsets_rank_per_feature_acc =
+      B_offsets_rank_per_feature.accessor<int32_t, 2>();
+  auto reshaped_offsets = at::empty({T * max_B + 1}, offsets.options());
+  // TODO: support other types
+  TORCH_CHECK(
+      offsets.dtype() == at::kLong,
+      "Expected offsets to be int64 but got ",
+      offsets.dtype());
+  auto reshaped_offsets_acc = reshaped_offsets.accessor<int64_t, 1>();
+  auto offsets_acc = offsets.accessor<int64_t, 1>();
+  auto begin = 0;
+  for (int32_t t = 0; t < T; t++) {
+    const auto batch_size =
+        B_offsets_rank_per_feature_acc[t]
+                                      [B_offsets_rank_per_feature[t].numel() -
+                                       1];
+    const auto end = batch_size + begin;
+    TORCH_CHECK(
+        batch_size <= max_B && max_B >= 0 && batch_size >= 0,
+        "batch size cannot exceed max_B of ",
+        max_B,
+        " but got ",
+        batch_size);
+
+    // copy the offsets
+    auto dst_idx = t * max_B;
+    checked_memcpy(
+        &reshaped_offsets_acc[dst_idx],
+        sizeof(offsets) * (reshaped_offsets.numel() - dst_idx),
+        &offsets_acc[begin],
+        sizeof(offsets) * (offsets.numel() - begin),
+        sizeof(offsets) * batch_size);
+
+    // fill the rest of the offsets with the last offset
+    if (max_B - batch_size > 0) {
+      dst_idx += batch_size;
+      for (auto i = 0; i < max_B - batch_size; i++) {
+        reshaped_offsets_acc[dst_idx + i] = offsets_acc[end];
+      }
+    }
+    begin = end;
+  }
+  reshaped_offsets[reshaped_offsets.numel() - 1] = offsets[offsets.numel() - 1];
+  return reshaped_offsets;
+}
+
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/pt2_autograd_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/pt2_autograd_utils.h
@@ -25,7 +25,13 @@ namespace fbgemm_gpu {
 
 Tensor reshape_vbe_output(
     const Tensor& grad_output,
-    const Tensor& B_offsets,
+    const int64_t max_B,
     const Tensor& B_offsets_rank_per_feature,
     const Tensor& D_offsets);
+
+Tensor reshape_vbe_offsets(
+    const Tensor& offsets,
+    const Tensor& B_offsets_rank_per_feature,
+    const int64_t max_B,
+    const int32_t T);
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/test/tbe/training/failures_dict_fast.json
+++ b/fbgemm_gpu/test/tbe/training/failures_dict_fast.json
@@ -384,10 +384,6 @@
       "ForwardTest.test_faketensor__test_forward_cpu_fp32": {
         "comment": "",
         "status": "xfail"
-      },
-      "ForwardTest.test_schema__test_forward_cpu_fp32": {
-        "comment": "",
-        "status": "xfail"
       }
     },
     "fbgemm::split_embedding_codegen_lookup_rowwise_adagrad_with_counter_function": {},


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/796

This diff implements `generate_vbe_metadata` for cpu, such that the function returns the same output for CPU, CUDA and MTIA.

To support VBE on CPU with existing fixed-batch-size CPU kernel, we need to recompute offsets, which is previously done in python. This diff implements offsets recomputation in C++ such that all manipulations are done in C++.

Note that reshaping offsets and grad_input to work with existing fixed-batch-size CPU kernels are done in Autograd instead of wrapper to avoid multiple computations.

VBE CPU tests are in the next diff.

Reviewed By: sryap

Differential Revision: D69162870


