### PR TITLE
[fbgemm_gpu] Fix python docs not being visible

### DIFF
--- a/.github/workflows/fbgemm_gpu_docs.yml
+++ b/.github/workflows/fbgemm_gpu_docs.yml
@@ -83,7 +83,7 @@ jobs:
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
     - name: Build + Install FBGEMM_GPU (CPU version)
-      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_install $BUILD_ENV $BUILD_VARIANT
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_install $BUILD_ENV docs
 
     - name: Build FBGEMM_GPU Documentation
       run: . $PRELUDE; cd fbgemm_gpu/docs; build_fbgemm_gpu_docs $BUILD_ENV

--- a/fbgemm_gpu/docs/src/fbgemm_gpu-development/BuildInstructions.rst
+++ b/fbgemm_gpu/docs/src/fbgemm_gpu-development/BuildInstructions.rst
@@ -543,6 +543,9 @@ For CPU-only builds, the ``--cpu_only`` flag needs to be specified.
   python setup.py install \
       --package_variant=cpu
 
+  # NOTE: To build the package as part of generating the documentation, use
+  # `--package_variant=docs` flag instead!
+
 To build using Clang + ``libstdc++`` instead of GCC, simply append the
 ``--cxxprefix`` flag:
 

--- a/fbgemm_gpu/fbgemm_gpu/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/__init__.py
@@ -11,14 +11,15 @@ import os
 import torch
 
 
-def _load_library(filename: str) -> None:
+def _load_library(filename: str, no_throw: bool = False) -> None:
     """Load a shared library from the given filename."""
     try:
         torch.ops.load_library(os.path.join(os.path.dirname(__file__), filename))
         logging.info(f"Successfully loaded: '{filename}'")
     except Exception as error:
         logging.error(f"Could not load the library '{filename}': {error}")
-        raise error
+        if not no_throw:
+            raise error
 
 
 # Since __init__.py is only used in OSS context, we define `open_source` here
@@ -67,13 +68,24 @@ if torch.cuda.is_available() and torch.version.hip:
 
 libraries_to_load = {
     "cpu": fbgemm_gpu_libraries,
+    "docs": fbgemm_gpu_libraries,
     "cuda": fbgemm_gpu_libraries + fbgemm_gpu_genai_libraries,
     "genai": fbgemm_gpu_genai_libraries,
     "rocm": fbgemm_gpu_libraries,
 }
 
 for library in libraries_to_load.get(__variant__, []):
-    _load_library(f"{library}.so")
+    # NOTE: In all cases, we want to throw an error if we cannot load the
+    # library.  However, this appears to break the OSS documentation build,
+    # where the Python documentation doesn't show up in the generated docs.
+    #
+    # To work around this problem, we introduce a fake build variant called
+    # `docs` and we only throw a library load error when the variant is not
+    # `docs`.  For more information, see:
+    #
+    #   https://github.com/pytorch/FBGEMM/pull/3477
+    #   https://github.com/pytorch/FBGEMM/pull/3717
+    _load_library(f"{library}.so", __variant__ == "docs")
 
 try:
     # Trigger meta operator registrations

--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -52,7 +52,7 @@ class FbgemmGpuBuild:
         parser.add_argument(
             "--package_variant",
             type=str,
-            choices=["cpu", "cuda", "rocm", "genai"],
+            choices=["docs", "cpu", "cuda", "rocm", "genai"],
             default="cuda",
             help="The FBGEMM_GPU variant to build.",
         )
@@ -270,7 +270,16 @@ class FbgemmGpuBuild:
             # https://stackoverflow.com/questions/44284275/passing-compiler-options-in-cmake-command-line
             cxx_flags.extend(["-DTORCH_USE_CUDA_DSA", "-DTORCH_USE_HIP_DSA"])
 
-        if self.args.package_variant == "cpu":
+        if self.args.package_variant in ["docs", "cpu"]:
+            # NOTE: The docs variant is a fake variant that is effectively the
+            # cpu variant, but marks __VARIANT__ as "docs" instead of "cpu".
+            #
+            # This minor change lets the library loader know not throw
+            # exceptions on failed load, which is the workaround for a bug in
+            # the Sphinx documentation generation process, see:
+            #
+            #   https://github.com/pytorch/FBGEMM/pull/3477
+            #   https://github.com/pytorch/FBGEMM/pull/3717
             print("[SETUP.PY] Building the CPU-ONLY variant of FBGEMM_GPU ...")
             cmake_args.append("-DFBGEMM_CPU_ONLY=ON")
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -29,7 +29,7 @@
     # Build the code
     cd ..
     prepare_fbgemm_gpu_build    $BUILD_ENV
-    build_fbgemm_gpu_install    $BUILD_ENV cpu
+    build_fbgemm_gpu_install    $BUILD_ENV docs
 
     # Build the docs
     cd docs


### PR DESCRIPTION
- Fix python docs not being visible.  Bisection reveals that this bug first appeared in 887e5bf1a4e59dafd605d0784d99e255715a5514 (https://github.com/pytorch/FBGEMM/pull/3477)