### PR TITLE
Engage KVTensor aware checkpoint load paths.

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
@@ -66,6 +66,7 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
   c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper> snapshot_handle_;
   at::TensorOptions options_;
   std::vector<int64_t> shape_;
+  std::vector<int64_t> strides_;
   int64_t row_offset_;
 };
 


### PR DESCRIPTION
Summary: Save KVTensor, load it back using CP client APIs.

Differential Revision: D68747782


