### PR TITLE
reduce scatter supports last dim

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/test/comm/multi_gpu_car_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/comm/multi_gpu_car_test.py
@@ -14,7 +14,7 @@ import os
 import tempfile
 import unittest
 import uuid
-from typing import Callable, Tuple
+from typing import Callable, Dict, List, Tuple, Union
 
 import fbgemm_gpu.experimental.gen_ai  # noqa: F401
 
@@ -126,8 +126,13 @@ def _run_reducescatter_inner(path: str) -> None:
     def round_up(a: int, b: int) -> int:
         return int(math.ceil(a / b)) * b
 
-    # pyre-ignore
-    def _test_fn(fn: Callable, W: int, rank: int, roundup: int, skip_bias) -> None:
+    def _test_fn(
+        fn: Callable,  # pyre-ignore
+        W: int,
+        rank: int,
+        roundup: int,
+        split_last_dim: bool = False,
+    ) -> None:
         for N in np.logspace(10, 24, num=20, base=2).tolist():
             N = round_up(int(N), roundup)
             y = torch.zeros(size=(N,), dtype=torch.bfloat16, device="cuda")
@@ -137,33 +142,31 @@ def _run_reducescatter_inner(path: str) -> None:
             )
             rank_start = N // W * rank
             rank_end = N // W * (rank + 1)
-            fn(y_reducescatter, y)
-            torch.testing.assert_close(
-                y_reducescatter,
-                torch.full(
-                    size=(N,),
-                    fill_value=(W * (W - 1) // 2),
-                    dtype=torch.bfloat16,
-                    device=y.device,
-                )[rank_start:rank_end],
+            args: List[torch.Tensor] = [y_reducescatter, y]
+            kwargs: Dict[str, Union[bool, torch.Tensor]] = {}
+
+            if split_last_dim:
+                kwargs["split_last_dim"] = True
+
+            fn(*args, **kwargs)
+            target = torch.full(
+                size=(N,),
+                fill_value=(W * (W - 1) // 2),
+                dtype=torch.bfloat16,
+                device=y.device,
             )
 
-            if not skip_bias:
-                z = torch.ones(size=(N,), dtype=torch.bfloat16, device="cuda")
-                fn(y_reducescatter, y, z)
-                torch.testing.assert_close(
-                    y_reducescatter,
-                    torch.full(
-                        size=(N,),
-                        fill_value=(W * (W - 1) // 2),
-                        dtype=torch.bfloat16,
-                        device=y.device,
-                    )[rank_start:rank_end]
-                    + 1,
-                )
+            torch.testing.assert_close(
+                y_reducescatter,
+                target[rank_start:rank_end],
+            )
 
-    _test_fn(reducescatter_compiled, W, rank, W, True)
+    # nccl allreduce doesn't support split_last_dim
+    _test_fn(reducescatter_compiled, W, rank, W)
+    _test_fn(reducescatter_compiled, W, rank, W)
+
     _test_fn(car_reducescatter_compiled, W, rank, 1024, False)
+    _test_fn(car_reducescatter_compiled, W, rank, 1024, True)
 
 
 def _run_allreduce_inner(path: str) -> None:


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/809

The normal reduce scatter operates on the continguous space. But there are cases where for a N-D tensor, we want each rank to split on the last dimension which won't be contiguous. So implement a special operator for it.

Reviewed By: feikou

Differential Revision: D69477917


