### PR TITLE
Add custom reduce scatter to llama_comms

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/test/comm/multi_gpu_car_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/comm/multi_gpu_car_test.py
@@ -404,11 +404,11 @@ class LLamaMultiGpuTests(unittest.TestCase):
                 nproc_per_node=torch.cuda.device_count(),
                 run_id=str(uuid.uuid4()),
                 rdzv_backend="c10d",
-                rdzv_endpoint=os.path.join(tmpdir, "rdzv"),
-                rdzv_configs={"store_type": "file"},
+                rdzv_endpoint="localhost:0",
                 start_method="spawn",
                 monitor_interval=1,
                 max_restarts=0,
+                local_addr="localhost",
             )
             elastic_launch(config=lc, entrypoint=_run_reducescatter_inner)(path)
 


### PR DESCRIPTION
Summary: In MOE, we have a pattern of allreduce -> split -> alltoall: https://fburl.com/gdoc/c2x38qxo. Add custom reduce scatter to simplilfy allreduce -> split path.

Reviewed By: feikou

Differential Revision: D69444988


