### PR TITLE
Set default value to null

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
@@ -1139,10 +1139,10 @@ _block_bucketize_sparse_features_cpu(
   const auto new_lengths_size = lengths_size * my_size;
   auto new_lengths = at::zeros({new_lengths_size}, lengths.options());
   auto new_indices = native_empty_like(indices);
-  Tensor new_weights;
-  Tensor new_pos;
-  Tensor unbucketize_permute;
-  Tensor bucket_mapping;
+  std::optional<Tensor> new_weights;
+  std::optional<Tensor> new_pos;
+  std::optional<Tensor> unbucketize_permute;
+  std::optional<Tensor> bucket_mapping;
   if (bucketize_pos) {
     new_pos = native_empty_like(indices);
   }

--- a/fbgemm_gpu/test/sparse/block_bucketize_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_test.py
@@ -525,6 +525,7 @@ class BlockBucketizeTest(unittest.TestCase):
         torch.testing.assert_close(
             new_indices.cpu(), new_indices_ref, msg=f"{new_indices=}"
         )
+        assert new_weights is None and new_pos is None
         if unbucketize_permute is not None:
             torch.testing.assert_close(
                 unbucketize_permute.cpu(),


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/814

Context:

We use block_bucketize_sparse_features_cpu kernel to bucketize kjt, for kjt with weights = none, the returned kjt has weights tensor to be `Tensor (undefined)` which cause it couldn't be serialized. This diff set the default value to std::nullopt and only initialize the weights when the orignal kjt has weights.

Error message
```
terminate called after throwing an instance of 'c10::ValueError'
  what():  The tensor at position 1 cannot be serialized. Only tensors with allocated storage are supported.
```

Apply same logic to all other 3 fields

Reviewed By: sryap

Differential Revision: D70143698


