### PR TITLE
Performance Optimization: Optimized TileShape Configuration for f8 (#3617)

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_grouped.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_grouped.cu
@@ -185,17 +185,17 @@ __global__ void set_kernel_args_kernel(
             GroupedGemmArgs::ProblemShape::UnderlyingProblemShape*>(
             problem_shape_buf);
     // Pass dummy configs to get Stride structure
-    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
+    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
         StrideInputA* stride_input_A_ptr = reinterpret_cast<
-            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
+            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
                 StrideInputA*>(stride_buf);
-    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
+    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
         StrideInputB* stride_input_B_ptr = reinterpret_cast<
-            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
+            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
                 StrideInputB*>(stride_buf + stride_size);
-    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
+    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
         StrideOutput* stride_output_ptr = reinterpret_cast<
-            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
+            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
                 StrideOutput*>(stride_buf + (stride_size * 2));
 
     output_args_ptr[group_index] =
@@ -210,15 +210,15 @@ __global__ void set_kernel_args_kernel(
         GroupedGemmArgs::ProblemShape::UnderlyingProblemShape(M, N, K);
     stride_input_A_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
-            GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::StrideInputA{},
+            GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::StrideInputA{},
         {M, K, 1});
     stride_input_B_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
-            GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::StrideInputB{},
+            GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::StrideInputB{},
         {N, K, 1});
     stride_output_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
-            GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::StrideOutput{},
+            GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::StrideOutput{},
         {M, N, 1});
   }
 }
@@ -263,17 +263,17 @@ __global__ void set_dynamic_kernel_args_kernel(
             GroupedGemmArgs::ProblemShape::UnderlyingProblemShape*>(
             problem_shape_buf);
     // Pass dummy configs to get Stride structure
-    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
+    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
         StrideInputA* stride_input_A_ptr = reinterpret_cast<
-            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
+            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
                 StrideInputA*>(stride_buf);
-    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
+    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
         StrideInputB* stride_input_B_ptr = reinterpret_cast<
-            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
+            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
                 StrideInputB*>(stride_buf + stride_size);
-    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
+    GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
         StrideOutput* stride_output_ptr = reinterpret_cast<
-            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::
+            GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
                 StrideOutput*>(stride_buf + (stride_size * 2));
 
     output_args_ptr[group_index] =
@@ -289,15 +289,15 @@ __global__ void set_dynamic_kernel_args_kernel(
             zero_start_index_M[group_index], N, K);
     stride_input_A_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
-            GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::StrideInputA{},
+            GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::StrideInputA{},
         {zero_start_index_M[group_index], K, 1});
     stride_input_B_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
-            GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::StrideInputB{},
+            GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::StrideInputB{},
         {N, K, 1});
     stride_output_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
-            GroupedGemmConfigs<128, 256, 64, 2, 1, 1, false>::StrideOutput{},
+            GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::StrideOutput{},
         {zero_start_index_M[group_index], N, 1});
   }
 }
@@ -567,6 +567,16 @@ at::Tensor dispatch_fp8_grouped_kernel(
         1,
         1,
         true>(XQ, WQ, x_scale, w_scale, output, zero_start_index_M);
+  } else if (kernel == KernelMode::Large) {
+    return f8f8bf16_rowwise_grouped_impl<
+        InputType,
+        128,
+        256,
+        128,
+        2,
+        1,
+        1,
+        false>(XQ, WQ, x_scale, w_scale, output, zero_start_index_M);
   } else {
     return f8f8bf16_rowwise_grouped_impl<
         InputType,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/816

## Performance Issue with Current F8 TileShape Configuration
The current FBGEMM f8 kernel uses a TileShape configuration of 128x128x128,  
while the optimal shape for dense f8 tensor core on H100 is m64n256k32.  
The current configuration leads to suboptimal performance for  
tensor cores and bandwidth usage.

## Optimized TileShape (128x256x128) Implementation 
Modification of the TileShape configuration from 128x128x128 to 128x256x128 for large GEMM  
operations using a cooperative kernel, enabling optimal bandwidth and tensor cores utilization.  
This configuration is notably used in Flash Attention V3 for f8.

## Benchmark Results on H100 GPU
### Benchmark configuration:
PyTorch 2.6
CUDA 12.4
CPU: AMD EPYC
GPU: NVIDIA H100
Benchmarks are configured with 30 kernel launch iterations  
and averaged over 25 Benchmark calculations.
We used the same gemm sizes as in the Colfax benchmarks

### Benchmark
#### f8f8bf16_grouped (G = 4, M = 2,048, N = 8,192, K = 8,192)
| TileShape   | TFlops  |
|-------------|-------- |
| 128-128-128 |    1244 |
| 128-256-128 |    1374 |
  
#### f8f8bf16_rowwise (M = N = K = 8,192)
| TileShape   | TFlops |
|-------------|------- |
| 128-128-128 |   1300 |
| 128-256-128 |   1480 |

#### f8f8bf16_tensorwise (M=N=K = 8,192)
| TileShape   | TFlops |
|-------------|------- |
| 128-128-128 |   1271 |
| 128-256-128 |   1463 |

## Technical Implementation
Modified TileShape from 128-128-128 to 128-256-128 for:
 - f8f8bf16_grouped
 - f8f8bf16_rowwise
 - f8f8bf16_tensorwise

Added cooperative kernel by default for:
 - f8f8bf16_rowwise
 - f8f8bf16_tensorwise
 
f8f8f16.cu was not modified because it was deprecated compared to f8f8bf16_tensorwise

The modifications only affect large where M > 128 and N > 128 and M or N > 2,048.  
The matrices are divided into tiles twice as large, but with kernels using 3   
SMs instead of 2. The smaller heuristics of large kernels may experience a  
slight reduced efficiency compared to the previous configuration.  
An empirical study between F8 kernel configurations and GEMM sizes could benefit FBGEMM.  

These changes were made by modifying the minimum necessary code while respecting  
existing coding practices in FBGEMM.


## Test Coverage
### Unit Tests Results
The unit tests in fbgemm_gpu/experimental/gen_ai/test/quantize  
have been verified for the modified kernels.

jiawenliu64 jwfromm Thank you!


Differential Revision: D68719476

Pulled By: jiawenliu64


