### PR TITLE
Add `TBEDataConfig` to Python side

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/utils/requests.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/utils/requests.py
@@ -239,11 +239,13 @@ def generate_indices_uniform(
     # each bag is usually sorted
     (indices, _) = torch.sort(indices)
     if use_variable_L:
+        # 1D layout, where row offsets are determined by L_offsets
         indices = torch.ops.fbgemm.bottom_k_per_row(
             indices.to(torch.long), L_offsets, False
         )
         indices = indices.to(get_device()).int()
     else:
+        # 2D layout
         indices = indices.reshape(iters, total_B * L)
     return indices
 


### PR DESCRIPTION
Summary: - Add `TBEDataConfig` and `IndicesDistributionParameters` to Python side to leverage EEG

Reviewed By: sryap

Differential Revision: D70046760
