### PR TITLE
Fix faketensor error when dev_weights is undefined.

### DIFF
--- a/fbgemm_gpu/codegen/genscript/generate_backward_split.py
+++ b/fbgemm_gpu/codegen/genscript/generate_backward_split.py
@@ -413,6 +413,8 @@ class BackwardSplitGenerator:
             ],
             "aux_int": [
                 "iter",  # 0
+                "info_B_num_bits",  # 1
+                "info_B_mask",  # 2
             ],
             "aux_float": [
                 "gwd_lower_bound",  # 0

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_meta_template.cpp
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_meta_template.cpp
@@ -176,18 +176,20 @@ Tensor
         // TODO: Why is kINT8QparamsBytes a float
         total_adjusted_D += T * int64_t(kINT8QparamsBytes);
     }
-
+    
+    // Fix tensor does not have device error for faketensor when all of the weights are undefined tensors.
+    auto options = dev_weights.defined() ? dev_weights.options() : at::TensorOptions().device(at::kMeta);
     {%- if vbe %}
     output = at::empty_symint(
         {vbe_output_size},
-        dev_weights.options().dtype(getScalarType(o_dtype))
+        options.dtype(getScalarType(o_dtype))
     );
     {%- else %}
     output = at::empty_symint(
         {B, total_adjusted_D},
-        dev_weights.options().dtype(getScalarType(o_dtype))
+        options.dtype(getScalarType(o_dtype))
     );
-    {%- endif %}
+    {%- endif %} {#-/* if vbe */#}
     {%- endif %} // if nobag
 
     return output;

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
@@ -685,19 +685,8 @@ class {{ autograd_func }} :
     // Default values for Dynamo tracing
     // SymInt does not support bitshifts operator
     // Constanting info_B_num_bits, info_B_mask for Dynamo for now.
-    int32_t info_B_num_bits = DEFAULT_INFO_B_NUM_BITS;
-    uint32_t info_B_mask = (1u << info_B_num_bits) - 1;
-    if (max_B_.is_symbolic()) {
-      // int32_t info_B_num_bits = 22;
-      // uint32_t info_B_mask = (1u << info_B_num_bits) - 1;
-
-      // TODO(ivankobzarev): Guarding Dynamo that T and B fits in constanted number of bits.
-      // TORCH_CHECK(max_B_ < 1u << info_B_num_bits)
-      // TORCH_CHECK(T < 1u << (DEFAULT_INFO_NUM_BITS - info_B_num_bits))
-    } else {
-      // TODO: don't guard here
-      std::tie(info_B_num_bits, info_B_mask) = adjust_info_B_num_bits(max_B_.guard_int(__FILE__, __LINE__), T.guard_int(__FILE__, __LINE__));
-    }
+    const auto info_B_num_bits = static_cast<int32_t>(aux_int[IDX_INFO_B_NUM_BITS]);
+    const auto info_B_mask = static_cast<uint32_t>(aux_int[IDX_INFO_B_MASK]);
 
     {%- if vbe %}
     static auto generate_vbe_metadata_op =

--- a/fbgemm_gpu/codegen/training/python/lookup_args.template
+++ b/fbgemm_gpu/codegen/training/python/lookup_args.template
@@ -77,6 +77,36 @@ class OptimizerArgs(NamedTuple):
     regularization_mode: int
     use_rowwise_bias_correction: bool # Used for OptimType.ADAM
 
+class CommonArgsPT2(NamedTuple):
+    placeholder_autograd_tensor: torch.Tensor
+    dev_weights: torch.Tensor
+    host_weights: torch.Tensor
+    uvm_weights: torch.Tensor
+    lxu_cache_weights: torch.Tensor
+    weights_placements: torch.Tensor
+    weights_offsets: torch.Tensor
+    D_offsets: torch.Tensor
+    total_D: int
+    max_D: int
+    hash_size_cumsum: torch.Tensor
+    total_hash_size_bits: int
+    indices: torch.Tensor
+    offsets: torch.Tensor
+    pooling_mode: int
+    indice_weights: Optional[torch.Tensor]
+    feature_requires_grad: Optional[torch.Tensor]
+    lxu_cache_locations: torch.Tensor
+    uvm_cache_stats: Optional[torch.Tensor]
+    output_dtype: int
+    vbe_metadata: VBEMetadata
+    is_experimental: bool
+    use_uniq_cache_locations_bwd: bool
+    use_homogeneous_placements: bool
+    info_B_num_bits: int
+    info_B_mask: int
+    {%- if ssd %}
+    ssd_tensors: Dict[str, torch.Tensor]
+    {%- endif %}
 
 class OptimizerArgsPT2(NamedTuple):
     """

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.h
@@ -22,6 +22,7 @@ std::tuple<int64_t, int64_t>
 get_infos_metadata(at::Tensor unused, int64_t B, int64_t T);
 
 std::tuple<int32_t, uint32_t> adjust_info_B_num_bits(int32_t B, int32_t T);
+std::tuple<int32_t, uint32_t> get_info_B_num_bits_from_T(int32_t T, int32_t B);
 
 std::tuple<at::Tensor /*row_output_offsets*/, at::Tensor /*b_t_map*/>
 generate_vbe_metadata(

--- a/fbgemm_gpu/src/sparse_ops/sparse_batched_unary_embeddings.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_batched_unary_embeddings.cu
@@ -186,7 +186,7 @@ DLL_PUBLIC Tensor batched_unary_embeddings_backward_cuda(
 
   int32_t info_B_num_bits;
   uint32_t info_B_mask;
-  std::tie(info_B_num_bits, info_B_mask) = adjust_info_B_num_bits(B, T);
+  std::tie(info_B_num_bits, info_B_mask) = get_info_B_num_bits_from_T(B, T);
 
   // weight: [N, sum_E]
   // total_hash_size_bits = log2(sum_E)

--- a/fbgemm_gpu/src/split_embeddings_utils/get_infos_metadata.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils/get_infos_metadata.cu
@@ -15,5 +15,5 @@ using namespace fbgemm_gpu;
 
 DLL_PUBLIC std::tuple<int64_t, int64_t>
 get_infos_metadata(Tensor unused, int64_t B, int64_t T) {
-  return adjust_info_B_num_bits(B, T);
+  return get_info_B_num_bits_from_T(T, B);
 }

--- a/fbgemm_gpu/test/tbe/utils/split_embeddings_utils_test.py
+++ b/fbgemm_gpu/test/tbe/utils/split_embeddings_utils_test.py
@@ -190,7 +190,8 @@ class SplitEmbeddingsUtilsTest(unittest.TestCase):
         self.assertTrue(
             torch.equal(linear_indices_sorted.cpu(), linear_indices_sorted_ref)
         )
-        self.assertTrue(torch.equal(infos_sorted.cpu(), infos_sorted_ref))
+        infos_sorted = infos_sorted.cpu()
+        self.assertTrue(torch.equal(infos_sorted, infos_sorted_ref.to(torch.int32)))
 
         # fbgemm impl has padding so we need slice
         num = sorted_linear_indices_run_ref.numel()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/837

test_faketensor__test_backward_adagrad_fp32_pmSUM failed with
```
RuntimeError: tensor does not have a device
```
`dev_weights` is found to be`undefined`, hence calling `dev_weights.options()` causes the error.

Reviewed By: sryap

Differential Revision: D70309633


