### PR TITLE
fix bounds check v2 mode with vbe input

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -926,11 +926,13 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             "feature_dims",
             torch.tensor(feature_dims, device="cpu", dtype=torch.int64),
         )
-        (self.info_B_num_bits, self.info_B_mask) = torch.ops.fbgemm.get_infos_metadata(
+        (_info_B_num_bits, _info_B_mask) = torch.ops.fbgemm.get_infos_metadata(
             self.D_offsets,  # unused tensor
             1,  # max_B
             T,  # T
         )
+        self.info_B_num_bits: int = _info_B_num_bits
+        self.info_B_mask: int = _info_B_mask
 
         # A flag for indicating whether all embedding tables are placed in the
         # same locations
@@ -1374,6 +1376,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.use_bounds_check_v2: bool = self._feature_is_enabled(
             FeatureGateName.BOUNDS_CHECK_INDICES_V2
         )
+        if self.bounds_check_version == 2:
+            self.use_bounds_check_v2 = True
 
         if embedding_table_index_type not in [torch.int32, torch.int64]:
             raise ValueError(

--- a/fbgemm_gpu/fbgemm_gpu/tbe/bench/utils.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/bench/utils.py
@@ -13,13 +13,12 @@ import torch
 
 from fbgemm_gpu.split_embedding_configs import SparseType
 from fbgemm_gpu.tbe.utils import TBERequest  # noqa: F401
-from torch import nn
 
 logging.basicConfig(level=logging.DEBUG)
 
 
 def fill_random_scale_bias(
-    emb: nn.Module,
+    emb: torch.nn.Module,
     T: int,
     weights_precision: SparseType,
 ) -> None:


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/835

as title, v2 bounds check handling logic for vbe enabled branch is only triggered by JK but not by version passed from APS user config now.

this diff fixed this so that we can have valid VBE metadata computed and passed to TBE kernel

Differential Revision: D70218740


