### PR TITLE
fix: topology_utils.h compilation issue

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/topology_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/topology_utils.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
 
 using Node = int64_t;


### PR DESCRIPTION
cstdint include is required if using libstdc++-14-dev, in case of libstdc++-13-dev int64_t was being transitively included