### PR TITLE
Fix triton group gemm for tp4

### DIFF
--- a/fbgemm_gpu/experimental/gemm/triton_gemm/grouped_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/grouped_gemm.py
@@ -165,7 +165,7 @@ def _kernel_grouped_gemm(
         M_end_offset = M_start_offset + m_size
 
         if m_size > 0:
-            N_start_offset = g * N
+            N_start_offset = g.to(tl.int64) * N
             n_size = N
             num_m_tiles = tl.cdiv(m_size, BLOCK_SIZE_M)
             num_n_tiles = tl.cdiv(n_size, BLOCK_SIZE_N)
@@ -306,7 +306,7 @@ def _kernel_grouped_gemm_fp8_rowwise(
         M_end_offset = M_start_offset + m_size
 
         if m_size > 0:
-            N_start_offset = g * N
+            N_start_offset = g.to(tl.int64) * N
             n_size = N
             num_m_tiles = tl.cdiv(m_size, BLOCK_SIZE_M)
             num_n_tiles = tl.cdiv(n_size, BLOCK_SIZE_N)


### PR DESCRIPTION
Summary: For whatever reasons, there seems to be some integer overflow for this kernel on AMD, causing it to core dump with TP4 sharding for 17bx128E. On H100, there is no such problem.

Differential Revision: D70568729


