### PR TITLE
Update cutlass verison to 3.8V2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,8 +14,7 @@
 # Go back to main cutlass when possible.
 [submodule "external/cutlass"]
 	path = external/cutlass
-	url = https://github.com/jwfromm/cutlass.git
-	branch = FBGEMM
+	url = https://github.com/NVIDIA/cutlass
 [submodule "external/json"]
 	path = external/json
 	url = https://github.com/nlohmann/json.git


### PR DESCRIPTION
#3767 updated APIs for cutlass 3.8 but due to fun phabricator <-> github issues did not properly bump the OSS version of cutlass. This small change does that.