### PR TITLE
[CUTLASS] Minor Cutlass change to fix CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,7 +14,8 @@
 # Go back to main cutlass when possible.
 [submodule "external/cutlass"]
 	path = external/cutlass
-	url = https://github.com/NVIDIA/cutlass
+	url = https://github.com/jwfromm/cutlass
+	branch = FBGEMM
 [submodule "external/json"]
 	path = external/json
 	url = https://github.com/nlohmann/json.git


### PR DESCRIPTION
In the ongoing saga of updating cutlass to version 3.8V2, there remains a minor bug in the OSS main branch that is causing build failures in OSS CI. This small diff moves our cutlass dependency back to my fork which tracks cutlass main but with the fix added. Hopefully this resolves the GPU build issues we're currently seeing.