### PR TITLE
Add cache-precision arg to TBE device_with_spec bench

### DIFF
--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -309,9 +309,7 @@ def device(  # noqa C901
                 )
                 for d in Ds
             ],
-            cache_precision=(
-                weights_precision if cache_precision is None else cache_precision
-            ),
+            cache_precision=cache_precision,
             cache_algorithm=CacheAlgorithm.LRU,
             cache_load_factor=cache_load_factor,
             **common_split_args,
@@ -3280,6 +3278,7 @@ def emb_inplace_update(  # noqa C901
 @click.option("--batch-size", default=512)
 @click.option("--embedding-dim-list", type=str, default="128")
 @click.option("--weights-precision", type=SparseType, default=SparseType.FP32)
+@click.option("--cache-precision", type=SparseType, default=None)
 @click.option("--stoc", is_flag=True, default=False)
 @click.option("--iters", default=100)
 @click.option("--warmup-runs", default=0)
@@ -3299,6 +3298,7 @@ def device_with_spec(  # noqa C901
     batch_size: int,
     embedding_dim_list: str,
     weights_precision: SparseType,
+    cache_precision: Optional[SparseType],
     stoc: bool,
     iters: int,
     warmup_runs: int,
@@ -3387,6 +3387,7 @@ def device_with_spec(  # noqa C901
         learning_rate=0.1,
         eps=0.1,
         weights_precision=weights_precision,
+        cache_precision=cache_precision,
         stochastic_rounding=stoc,
         output_dtype=output_dtype,
         pooling_mode=pooling_mode,


### PR DESCRIPTION
Summary:
For completeness, this commit adds `cache_precision` argument to the `device_with_spec` benchmark for TBE kernels.

 - `cache_precision` already exists for `device`, so this commit just copies it to `device_with_spec`

This commit also applies minor refactoring by simplifying the following redundant logic since anyway the same conversion is done in the constructor of `SplitTableBatchedEmbeddingBagsCodegen` (https://github.com/pytorch/FBGEMM/blob/main/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py#L707-L709)
```
SplitTableBatchedEmbeddingBagsCodegen(
    ...
    cache_precision=(
        weights_precision if cache_precision is None else cache_precision
    ),
    ...
)
-> 
SplitTableBatchedEmbeddingBagsCodegen(
    ...
    cache_precision=cache_precision,
    ...
)
```

Differential Revision: D70893898


