### PR TITLE
Use kleidiAI on static builds

### DIFF
--- a/include/fbgemm/FbgemmPackMatrixB.h
+++ b/include/fbgemm/FbgemmPackMatrixB.h
@@ -299,7 +299,7 @@ class PackedGemmMatrixB {
   bool pmat_passed_in{false};
 };
 
-#ifndef FBGEMM_STATIC
+#ifndef _M_X64
 
 template <>
 FBGEMM_API

--- a/src/FbgemmPackMatrixB.cc
+++ b/src/FbgemmPackMatrixB.cc
@@ -28,7 +28,7 @@ namespace fbgemm {
 // register layouts), 2 (with kernels of 1x2~6x2 register layout), or 3 (with
 // kernels of 1x3~4x3 register layout).
 
-#ifndef FBGEMM_STATIC
+#ifndef _M_X64
 
 template <>
 FBGEMM_API


### PR DESCRIPTION
Summary: Open-source builds as static library were failing

Differential Revision: D71078076


