### PR TITLE
[fbgemm_gpu] Increase CUDA test timeout

### DIFF
--- a/.github/workflows/fbgemm_gpu_ci_cuda.yml
+++ b/.github/workflows/fbgemm_gpu_ci_cuda.yml
@@ -216,7 +216,7 @@ jobs:
       run: . $PRELUDE; install_fbgemm_gpu_wheel $BUILD_ENV *.whl
 
     - name: Test with PyTest
-      timeout-minutes: 40
+      timeout-minutes: 60
       run: . $PRELUDE; test_all_fbgemm_gpu_modules $BUILD_ENV
 
     - name: Push Wheel to PyPI


### PR DESCRIPTION
- Increase CUDA test timeout.  It should be noted that the timeout is mainly applicable to Clang builds, which have been experiencing test slowdowns