### PR TITLE
Fuse cumsum into stacked FP8 Grouped Gemm

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
@@ -867,6 +867,58 @@ class DeepGemmBlockwise(QuantizeOpBase):
         return True
 
 
+class FP8StackedGroupedGemm(QuantizeOpBase):
+    """
+    FP8 grouped matmul with rowwise scaling and stacked inputs.
+    """
+
+    def preprocess(self, x, w):
+        m_values = [i.shape[0] for i in x]
+        # Convert m_values into offsets into grouped tensor.
+        m_offsets = torch.tensor(np.cumsum(m_values)).to(
+            dtype=torch.int64, device=x[0].device
+        )
+        # Quantize weights.
+        wq, w_scale = zip(*[quantize_fp8_row(i) for i in w])
+        # Group weights as single tensor.
+        wq = torch.stack(wq, dim=0).contiguous()
+        w_scale = torch.stack(w_scale, dim=0).contiguous()
+        # Also view input as flattened.
+        x = torch.concat(x, dim=0).contiguous()
+        # Return processed tensors.
+        return x, wq, w_scale, m_offsets
+
+    def quantize(self, x, wq, w_scale, m_offsets):
+        B = x.shape[0]
+        xq, x_scale = triton_quantize_fp8_row(x)
+        x_scale = x_scale.view(B, -1)
+        return xq, wq, x_scale, w_scale, m_offsets
+
+    def compute(self, xq, wq, x_scale, w_scale, m_offsets):
+        return torch.ops.fbgemm.f8f8bf16_rowwise_grouped_stacked(
+            xq, wq, x_scale, w_scale, m_offsets
+        )
+
+    def quantize_and_compute(self, x, wq, w_scale, m_offsets):
+        xq, wq, x_scale, w_scale, m_offsets = self.quantize(x, wq, w_scale, m_offsets)
+        return self.compute(xq, wq, x_scale, w_scale, m_offsets)
+
+    @property
+    def name(self) -> str:
+        if torch.version.cuda:
+            return "cutlass_grouped_stacked"
+        else:
+            return "ck_grouped_stacked"
+
+    @property
+    def hip(self) -> bool:
+        return True
+
+    @property
+    def cuda(self) -> bool:
+        return True
+
+
 @register_quantize_op
 class BF16GroupedGemm(QuantizeOpBase):
     """

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_common.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_common.h
@@ -132,7 +132,7 @@ at::Tensor f8f8bf16_rowwise_batched_impl(
   int B = XQ.size(0);
   int M = XQ.size(1);
   int N = WQ.size(1);
-  int K = XQ.size(2);
+  int K = WQ.size(2);
 
   int StrideA = K;
   int StrideB = K;

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
@@ -195,7 +195,49 @@ void set_static_kernel_args(
   }
 }
 
-__global__ void set_kernel_args_fixed_nk_kernel_only(
+__global__ void set_kernel_args_m_offsets_kernel(
+    KernelArguments* kernel_args,
+    ADataType* XQ,
+    BDataType* WQ,
+    D0DataType* w_scale,
+    D1DataType* x_scale,
+    EDataType* output,
+    int64_t* M_offsets,
+    int M,
+    int N,
+    int K,
+    int group_count) {
+  int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  // Each thread is responsible for setting up the arguments for one group.
+  if (thread_idx < group_count) {
+    // Compute offsets for this group.
+    int offset_M;
+    int kernel_M;
+    if (thread_idx == 0) {
+      offset_M = 0;
+      kernel_M = M_offsets[thread_idx];
+    } else {
+      offset_M = M_offsets[thread_idx - 1];
+      kernel_M = M_offsets[thread_idx] - offset_M;
+    }
+    KernelArguments kernel_group_args = {
+        XQ + (offset_M * K),
+        WQ + (thread_idx * N * K),
+        {w_scale + (thread_idx * N), x_scale + offset_M},
+        output + (offset_M * N),
+        kernel_M,
+        N,
+        K,
+        K,
+        K,
+        {0, 0},
+        N};
+    // Write kernel args to memory.
+    kernel_args[thread_idx] = kernel_group_args;
+  }
+}
+
+__global__ void set_kernel_args_fixed_nk_kernel(
     KernelArguments* kernel_args,
     ADataType* XQ,
     BDataType* WQ,
@@ -286,26 +328,38 @@ void set_dynamic_kernel_args(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
-    at::Tensor zero_start_index_M,
+    std::optional<at::Tensor> zero_start_index_M,
+    std::optional<at::Tensor> M_offsets,
     bool zeroing_output_tensor) {
   // Get current cuda stream.
   auto stream = at::cuda::getCurrentHIPStream().stream();
-  int group_count = XQ.size(0);
-  // Confirm M is on the proper device.
+  int group_count;
+  // Check provided tensors are valid.
   TORCH_CHECK(
-      XQ.device() == zero_start_index_M.device(),
-      "zero_start_index_M and inputs must be on the same device.");
-  TORCH_CHECK(
-      zero_start_index_M.size(0) == group_count,
-      "zero_start_index_M must have an entry for each group.");
-  TORCH_CHECK(
-      zero_start_index_M.dtype() == at::kLong,
-      "zero_start_index_M must be int64.");
+      zero_start_index_M.has_value() != M_offsets.has_value(),
+      "One of zero_start_index_M or M_offsets must be provided.");
+  if (zero_start_index_M.has_value()) {
+    group_count = zero_start_index_M.value().size(0);
+    TORCH_CHECK(
+        XQ.device() == zero_start_index_M.value().device(),
+        "zero_start_index_M and inputs must be on the same device.");
+    TORCH_CHECK(
+        zero_start_index_M.value().dtype() == at::kLong,
+        "zero_start_index_M must be int64.");
+  }
+  if (M_offsets.has_value()) {
+    group_count = M_offsets.value().size(0);
+    TORCH_CHECK(
+        XQ.device() == M_offsets.value().device(),
+        "M_offsets and inputs must be on the same device.");
+    TORCH_CHECK(
+        M_offsets.value().dtype() == at::kLong, "M_offsets must be int64.");
+  }
 
-  // We assume that M, N, and K are fixed across groups.
-  // The actual m values are sstored in the passed M tensor.
-  int M = XQ.size(1);
-  int K = XQ.size(2);
+  // When m_offsets is used XQ is shape [tota_M, K]. When zero_start_index_M is
+  // used it is shape [G, M, K].
+  int M = XQ.size(XQ.dim() - 2);
+  int K = WQ.size(2);
   int N = WQ.size(1);
 
   // Launch a kernel that sets kernel argument memory.
@@ -345,13 +399,12 @@ void set_dynamic_kernel_args(
   }
 }
 
-template <typename OutputType>
-OutputType _f8f8bf16_rowwise_grouped(
+std::vector<at::Tensor> f8f8bf16_rowwise_grouped(
     at::TensorList XQ,
     at::TensorList WQ,
     at::TensorList x_scale,
     at::TensorList w_scale,
-    std::optional<OutputType> output = std::nullopt) {
+    std::optional<std::vector<at::Tensor>> output = std::nullopt) {
   // Check that input datatypes are valid.
   // First confirm that there are the same number of groups in all inputs.
   TORCH_CHECK(
@@ -384,54 +437,31 @@ OutputType _f8f8bf16_rowwise_grouped(
     TORCH_CHECK(ws.dtype() == at::kFloat, "Scales must be float32.");
   }
 
-  OutputType Y;
+  std::vector<at::Tensor> Y;
   // Need to handle different output modes separately.
   // First handle tensor list output.
-  if constexpr (std::is_same_v<OutputType, std::vector<at::Tensor>>) {
-    if (output.has_value()) {
-      Y = output.value();
-      TORCH_CHECK(
-          Y.size() == group_count,
-          "Output and input must have same number of groups.");
-      // Check that output shapes are correct.
-      for (int i = 0; i < group_count; i++) {
-        int M = XQ[i].size(0);
-        int N = WQ[i].size(0);
-        int out_M = Y[i].size(0);
-        int out_N = Y[i].size(1);
-        TORCH_CHECK(
-            M == out_M && N == out_N,
-            "Output tensors do not have the expected shape.");
-        TORCH_CHECK(
-            Y[i].dtype() == at::kBFloat16, "Output dtype must be bfloat16.");
-      }
-    } else {
-      for (int i = 0; i < group_count; i++) {
-        int M = XQ[i].size(0);
-        int N = WQ[i].size(0);
-        Y.push_back(at::empty({M, N}, XQ[i].options().dtype(at::kBFloat16)));
-      }
-    }
-    // Now handle single tensor output.
-  } else {
-    // Compute total M across groups.
-    int total_M = 0;
-    int N = WQ[0].size(0);
+  if (output.has_value()) {
+    Y = output.value();
+    TORCH_CHECK(
+        Y.size() == group_count,
+        "Output and input must have same number of groups.");
+    // Check that output shapes are correct.
     for (int i = 0; i < group_count; i++) {
-      total_M += XQ[i].size(0);
-      // Also make sure N is constant across shapes.
+      int M = XQ[i].size(0);
+      int N = WQ[i].size(0);
+      int out_M = Y[i].size(0);
+      int out_N = Y[i].size(1);
       TORCH_CHECK(
-          WQ[i].size(0) == N,
-          "N must be constant across groups for stacked output.");
+          M == out_M && N == out_N,
+          "Output tensors do not have the expected shape.");
+      TORCH_CHECK(
+          Y[i].dtype() == at::kBFloat16, "Output dtype must be bfloat16.");
     }
-    if (output.has_value()) {
-      Y = output.value();
-      // Check that shape is expected.
-      TORCH_CHECK(
-          Y.size(0) == total_M && Y.size(1) == N,
-          "Preallocated output should have size [total_M, N].");
-    } else {
-      Y = at::empty({total_M, N}, XQ[0].options().dtype(at::kBFloat16));
+  } else {
+    for (int i = 0; i < group_count; i++) {
+      int M = XQ[i].size(0);
+      int N = WQ[i].size(0);
+      Y.push_back(at::empty({M, N}, XQ[i].options().dtype(at::kBFloat16)));
     }
   }
 
@@ -439,7 +469,8 @@ OutputType _f8f8bf16_rowwise_grouped(
   at::Tensor kernel_args = at::empty(
       {static_cast<long>(group_count * sizeof(KernelArguments))},
       XQ[0].options().dtype(at::kByte));
-  set_static_kernel_args<OutputType>(kernel_args, XQ, WQ, x_scale, w_scale, Y);
+  set_static_kernel_args<std::vector<at::Tensor>>(
+      kernel_args, XQ, WQ, x_scale, w_scale, Y);
 
   // We use the largest of each shape for heuristics.
   int MaxM = 0;
@@ -450,32 +481,72 @@ OutputType _f8f8bf16_rowwise_grouped(
     MaxN = max(MaxN, WQ[i].size(0));
     MaxK = max(MaxK, XQ[i].size(1));
   }
-  RowwiseGroupedKernel<at::TensorList, OutputType> selected_kernel =
-      rowwise_grouped_heuristic_dispatch<at::TensorList, OutputType>(
-          MaxM, MaxN, MaxK);
+  RowwiseGroupedKernel<at::TensorList, std::vector<at::Tensor>>
+      selected_kernel = rowwise_grouped_heuristic_dispatch<
+          at::TensorList,
+          std::vector<at::Tensor>>(MaxM, MaxN, MaxK);
   return selected_kernel(XQ, WQ, x_scale, w_scale, kernel_args, Y);
-}
-
-// Wrapper function for list input list output.
-std::vector<at::Tensor> f8f8bf16_rowwise_grouped(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::TensorList x_scale,
-    at::TensorList w_scale,
-    std::optional<std::vector<at::Tensor>> output = std::nullopt) {
-  return _f8f8bf16_rowwise_grouped<std::vector<at::Tensor>>(
-      XQ, WQ, x_scale, w_scale, output);
 }
 
 // Wrapper function for list input single tensor output.
 at::Tensor f8f8bf16_rowwise_grouped_stacked(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::TensorList x_scale,
-    at::TensorList w_scale,
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor M_offsets,
     std::optional<at::Tensor> output = std::nullopt) {
-  return _f8f8bf16_rowwise_grouped<at::Tensor>(
-      XQ, WQ, x_scale, w_scale, output);
+  // Check that input datatypes are valid.
+  // First confirm that there are the same number of groups in all inputs.
+  int group_count = M_offsets.size(0);
+  // XQ is expected to be shape [total_M, K].
+  int total_M = XQ.size(0);
+  // WQ is expected to be shape [G, N, K].
+  int N = WQ.size(1);
+  int K = XQ.size(1);
+  TORCH_CHECK(
+      WQ.size(0) == group_count && x_scale.numel() == total_M &&
+          w_scale.numel() / group_count == N,
+      "All inputs must have the same number of groups.");
+  // Iterate over inputs and check they are valid.
+  TORCH_CHECK(XQ.is_cuda() && XQ.is_contiguous());
+  TORCH_CHECK(XQ.dim() == 2, "Input XQ must be 2D (total_M,K).");
+  TORCH_CHECK(
+      XQ.dtype() == at::kFloat8_e4m3fnuz,
+      "Input XQ must be type float8_e4m3fnuz.");
+
+  TORCH_CHECK(WQ.is_cuda() && WQ.is_contiguous());
+  TORCH_CHECK(WQ.dim() == 3, "Input WQ must be 3D (G,N,K).");
+  TORCH_CHECK(
+      WQ.dtype() == at::kFloat8_e4m3fnuz,
+      "Input WQ must be type float8_e4m3fnuz.");
+  TORCH_CHECK(
+      WQ.size(1) >= 512 && WQ.size(2) >= 512,
+      "N and K must be at least 512 for grouped gemm. For smaller inputs, consider unrolling.");
+
+  TORCH_CHECK(x_scale.dtype() == at::kFloat, "Scales must be float32.");
+  TORCH_CHECK(w_scale.dtype() == at::kFloat, "Scales must be float32.");
+
+  // Allocate an empty output array. We will set its values to zero as part
+  // of kernel setup.
+  at::Tensor Y = at::empty({total_M, N}, XQ.options().dtype(at::kBFloat16));
+
+  // Early exit for empty input.
+  if (total_M == 0) {
+    return Y;
+  }
+
+  // Prepare kernel arguments by copying them to the proper device location.
+  at::Tensor kernel_args = at::empty(
+      {static_cast<long>(group_count * sizeof(KernelArguments))},
+      XQ.options().dtype(at::kByte));
+  set_dynamic_kernel_args(
+      kernel_args, XQ, WQ, x_scale, w_scale, Y, std::nullopt, M_offsets, false);
+
+  RowwiseGroupedKernel<at::Tensor, at::Tensor> selected_kernel =
+      rowwise_grouped_heuristic_dispatch<at::Tensor, at::Tensor>(
+          total_M / group_count, N, K);
+  return selected_kernel(XQ, WQ, x_scale, w_scale, kernel_args, Y);
 }
 
 at::Tensor f8f8bf16_rowwise_grouped_dynamic(
@@ -490,7 +561,7 @@ at::Tensor f8f8bf16_rowwise_grouped_dynamic(
   int group_count = XQ.size(0);
   int M = XQ.size(1);
   int N = WQ.size(1);
-  int K = XQ.size(2);
+  int K = WQ.size(2);
   TORCH_CHECK(
       WQ.size(0) == group_count && x_scale.numel() / group_count == M &&
           w_scale.numel() / group_count == N,
@@ -524,7 +595,7 @@ at::Tensor f8f8bf16_rowwise_grouped_dynamic(
       {static_cast<long>(group_count * sizeof(KernelArguments))},
       XQ.options().dtype(at::kByte));
   set_dynamic_kernel_args(
-      kernel_args, XQ, WQ, x_scale, w_scale, Y, zero_start_index_M, zeroing_output_tensor);
+      kernel_args, XQ, WQ, x_scale, w_scale, Y, zero_start_index_M, std::nullopt, zeroing_output_tensor);
 
   RowwiseGroupedKernel<at::Tensor, at::Tensor> selected_kernel =
       rowwise_grouped_heuristic_dispatch<at::Tensor, at::Tensor>(M, N, K);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
@@ -195,14 +195,14 @@ void set_static_kernel_args(
   }
 }
 
-__global__ void set_kernel_args_m_offsets_kernel(
+__global__ void set_kernel_args_m_sizes_kernel(
     KernelArguments* kernel_args,
     ADataType* XQ,
     BDataType* WQ,
     D0DataType* w_scale,
     D1DataType* x_scale,
     EDataType* output,
-    int64_t* M_offsets,
+    int64_t* M_sizes,
     int M,
     int N,
     int K,
@@ -210,15 +210,12 @@ __global__ void set_kernel_args_m_offsets_kernel(
   int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
   // Each thread is responsible for setting up the arguments for one group.
   if (thread_idx < group_count) {
-    // Compute offsets for this group.
-    int offset_M;
-    int kernel_M;
-    if (thread_idx == 0) {
-      offset_M = 0;
-      kernel_M = M_offsets[thread_idx];
-    } else {
-      offset_M = M_offsets[thread_idx - 1];
-      kernel_M = M_offsets[thread_idx] - offset_M;
+    // Get M information for this group.
+    int kernel_M = M_sizes[thread_idx];
+    int offset_M = 0;
+    // Offset is computed by finding the sum of previous group Ms.
+    for (int i = 0; i < thread_idx; i++) {
+      offset_M += M_sizes[i];
     }
     KernelArguments kernel_group_args = {
         XQ + (offset_M * K),
@@ -329,15 +326,15 @@ void set_dynamic_kernel_args(
     at::Tensor w_scale,
     at::Tensor output,
     std::optional<at::Tensor> zero_start_index_M,
-    std::optional<at::Tensor> M_offsets,
+    std::optional<at::Tensor> M_sizes,
     bool zeroing_output_tensor) {
   // Get current cuda stream.
   auto stream = at::cuda::getCurrentHIPStream().stream();
   int group_count;
   // Check provided tensors are valid.
   TORCH_CHECK(
-      zero_start_index_M.has_value() != M_offsets.has_value(),
-      "One of zero_start_index_M or M_offsets must be provided.");
+      zero_start_index_M.has_value() != M_sizes.has_value(),
+      "One of zero_start_index_M or M_sizes must be provided.");
   if (zero_start_index_M.has_value()) {
     group_count = zero_start_index_M.value().size(0);
     TORCH_CHECK(
@@ -347,51 +344,69 @@ void set_dynamic_kernel_args(
         zero_start_index_M.value().dtype() == at::kLong,
         "zero_start_index_M must be int64.");
   }
-  if (M_offsets.has_value()) {
-    group_count = M_offsets.value().size(0);
+  if (M_sizes.has_value()) {
+    group_count = M_sizes.value().size(0);
     TORCH_CHECK(
-        XQ.device() == M_offsets.value().device(),
-        "M_offsets and inputs must be on the same device.");
-    TORCH_CHECK(
-        M_offsets.value().dtype() == at::kLong, "M_offsets must be int64.");
+        XQ.device() == M_sizes.value().device(),
+        "M_sizes and inputs must be on the same device.");
+    TORCH_CHECK(M_sizes.value().dtype() == at::kLong, "M_sizes must be int64.");
   }
 
-  // When m_offsets is used XQ is shape [tota_M, K]. When zero_start_index_M is
+  // When m_sizes is used XQ is shape [tota_M, K]. When zero_start_index_M is
   // used it is shape [G, M, K].
   int M = XQ.size(XQ.dim() - 2);
   int K = WQ.size(2);
   int N = WQ.size(1);
 
-  // Launch a kernel that sets kernel argument memory.
-  // Each thread sets one float4 which corresponds to 8 bf16 values.
-  const int BLOCK_SIZE = 8;
-  TORCH_CHECK(
-      N % BLOCK_SIZE == 0, "N must be divisible 8 for dynamic grouped gemm.");
-  int block_factor = std::max(group_count, (group_count * M * N) / BLOCK_SIZE);
-  int blockSize = std::min(512, block_factor);
-  int numBlocks = (block_factor + blockSize - 1) / blockSize;
-  if (zeroing_output_tensor) {
-    set_kernel_args_fixed_nk_kernel_zeroing<<<numBlocks, blockSize, 0, stream>>>(
+  // Depending on the mode, use appropriate setup kernel.
+  if (M_sizes.has_value()) {
+    set_kernel_args_m_sizes_kernel<<<1, group_count, 0, stream>>>(
         reinterpret_cast<KernelArguments*>(kernel_args.data_ptr()),
         reinterpret_cast<ADataType*>(XQ.data_ptr()),
         reinterpret_cast<BDataType*>(WQ.data_ptr()),
         reinterpret_cast<D0DataType*>(w_scale.data_ptr()),
         reinterpret_cast<D1DataType*>(x_scale.data_ptr()),
         reinterpret_cast<EDataType*>(output.data_ptr()),
-        reinterpret_cast<int64_t*>(zero_start_index_M.data_ptr()),
+        reinterpret_cast<int64_t*>(M_sizes.value().data_ptr()),
+        M,
+        N,
+        K,
+        group_count);
+  } else if (zeroing_output_tensor) {
+    // Launch a kernel that sets kernel argument memory and zeros the output.
+    // Each thread sets one float4 which corresponds to 8 bf16 values.
+    const int BLOCK_SIZE = 8;
+    TORCH_CHECK(
+        N % BLOCK_SIZE == 0, "N must be divisible 8 for dynamic grouped gemm.");
+    int block_factor =
+        std::max(group_count, (group_count * M * N) / BLOCK_SIZE);
+    int blockSize = std::min(512, block_factor);
+    int numBlocks = (block_factor + blockSize - 1) / blockSize;
+    set_kernel_args_fixed_nk_kernel_zeroing<<<
+        numBlocks,
+        blockSize,
+        0,
+        stream>>>(
+        reinterpret_cast<KernelArguments*>(kernel_args.data_ptr()),
+        reinterpret_cast<ADataType*>(XQ.data_ptr()),
+        reinterpret_cast<BDataType*>(WQ.data_ptr()),
+        reinterpret_cast<D0DataType*>(w_scale.data_ptr()),
+        reinterpret_cast<D1DataType*>(x_scale.data_ptr()),
+        reinterpret_cast<EDataType*>(output.data_ptr()),
+        reinterpret_cast<int64_t*>(zero_start_index_M.value().data_ptr()),
         M,
         N,
         K,
         group_count);
   } else {
-    set_kernel_args_fixed_nk_kernel_only<<<1, group_count, 0, stream>>>(
+    set_kernel_args_fixed_nk_kernel<<<1, group_count, 0, stream>>>(
         reinterpret_cast<KernelArguments*>(kernel_args.data_ptr()),
         reinterpret_cast<ADataType*>(XQ.data_ptr()),
         reinterpret_cast<BDataType*>(WQ.data_ptr()),
         reinterpret_cast<D0DataType*>(w_scale.data_ptr()),
         reinterpret_cast<D1DataType*>(x_scale.data_ptr()),
         reinterpret_cast<EDataType*>(output.data_ptr()),
-        reinterpret_cast<int64_t*>(zero_start_index_M.data_ptr()),
+        reinterpret_cast<int64_t*>(zero_start_index_M.value().data_ptr()),
         M,
         N,
         K,
@@ -494,11 +509,11 @@ at::Tensor f8f8bf16_rowwise_grouped_stacked(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    at::Tensor M_offsets,
+    at::Tensor M_sizes,
     std::optional<at::Tensor> output = std::nullopt) {
   // Check that input datatypes are valid.
   // First confirm that there are the same number of groups in all inputs.
-  int group_count = M_offsets.size(0);
+  int group_count = M_sizes.size(0);
   // XQ is expected to be shape [total_M, K].
   int total_M = XQ.size(0);
   // WQ is expected to be shape [G, N, K].
@@ -541,7 +556,7 @@ at::Tensor f8f8bf16_rowwise_grouped_stacked(
       {static_cast<long>(group_count * sizeof(KernelArguments))},
       XQ.options().dtype(at::kByte));
   set_dynamic_kernel_args(
-      kernel_args, XQ, WQ, x_scale, w_scale, Y, std::nullopt, M_offsets, false);
+      kernel_args, XQ, WQ, x_scale, w_scale, Y, std::nullopt, M_sizes, false);
 
   RowwiseGroupedKernel<at::Tensor, at::Tensor> selected_kernel =
       rowwise_grouped_heuristic_dispatch<at::Tensor, at::Tensor>(
@@ -595,7 +610,15 @@ at::Tensor f8f8bf16_rowwise_grouped_dynamic(
       {static_cast<long>(group_count * sizeof(KernelArguments))},
       XQ.options().dtype(at::kByte));
   set_dynamic_kernel_args(
-      kernel_args, XQ, WQ, x_scale, w_scale, Y, zero_start_index_M, std::nullopt, zeroing_output_tensor);
+      kernel_args,
+      XQ,
+      WQ,
+      x_scale,
+      w_scale,
+      Y,
+      zero_start_index_M,
+      std::nullopt,
+      zeroing_output_tensor);
 
   RowwiseGroupedKernel<at::Tensor, at::Tensor> selected_kernel =
       rowwise_grouped_heuristic_dispatch<at::Tensor, at::Tensor>(M, N, K);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x128x16x128_16x16_4x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x128x16x128_16x16_4x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x128x16x128_16x16_4x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_in
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x128x16x128_16x16_4x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x128x16x128_16x16_4x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x128x16x128_16x16_4x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_in
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x128x32x128_32x32_2x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x128x32x128_32x32_2x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x128x32x128_32x32_2x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_in
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x128x32x128_32x32_2x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x128x32x128_32x32_2x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x128x32x128_32x32_2x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_in
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x128x128_16x16_1x4_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x128x128_16x16_1x4_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x16x128x128_16x16_1x4_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_in
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x128x128_16x16_1x4_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x128x128_16x16_1x4_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x16x128x128_16x16_1x4_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_in
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v1.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v1.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 256 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 256 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 256 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x16x32x256_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 256 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x512_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x512_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v1.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x16x32x512_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 512 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x512_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x512_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x16x32x512_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 512 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x512_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x512_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x16x32x512_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 512 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x512_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x32x512_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x16x32x512_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 512 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x64x128_16x16_1x2_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x64x128_16x16_1x2_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x16x64x128_16x16_1x2_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x64x128_16x16_1x2_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x16x64x128_16x16_1x2_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x16x64x128_16x16_1x2_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x32x128x128_32x32_1x2_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x32x128x128_32x32_1x2_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x32x128x128_32x32_1x2_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_in
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x32x128x128_32x32_1x2_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x32x128x128_32x32_1x2_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x32x128x128_32x32_1x2_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_in
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x32x16x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_interwave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x32x16x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_interwave_v1.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x32x16x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x32x16x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x32x16x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x32x16x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x32x16x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_intrawave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x32x16x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_intrawave_v1.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x32x16x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x32x16x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x32x16x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x32x16x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x32x64x128_32x32_1x1_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x32x64x128_32x32_1x1_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x32x64x128_32x32_1x1_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x32x64x128_32x32_1x1_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x32x64x128_32x32_1x1_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x32x64x128_32x32_1x1_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x64x16x128_16x16_2x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x64x16x128_16x16_2x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x64x16x128_16x16_2x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x64x16x128_16x16_2x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x64x16x128_16x16_2x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x64x16x128_16x16_2x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x64x32x128_32x32_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x64x32x128_32x32_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x64x32x128_32x32_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x64x32x128_32x32_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_128x64x32x128_32x32_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_128x64x32x128_32x32_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x128x128x128_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_interwave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x128x128x128_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_interwave_v1.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x128x128x128_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_i
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x128x128x128_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x128x128x128_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x128x128x128_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_i
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x128x128x128_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v4.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x128x128x128_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v4.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x128x128x128_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_i
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x128x128x64_32x32_2x2_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_intrawave_v4.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x128x128x64_32x32_2x2_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_intrawave_v4.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x128x128x64_32x32_2x2_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_in
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 64 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x128x256x64_32x32_2x4_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_interwave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x128x256x64_32x32_2x4_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_interwave_v1.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x128x256x64_32x32_2x4_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_in
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 64 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x128x64x128_32x32_2x1_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x128x64x128_32x32_2x1_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x128x64x128_32x32_2x1_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_in
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x16x256x128_16x16_1x4_8x16x1_8x16x1_1x16x1x16_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x16x256x128_16x16_1x4_8x16x1_8x16x1_1x16x1x16_4x4x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x16x256x128_16x16_1x4_8x16x1_8x16x1_1x16x1x16_4x4x1_1x1_i
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x16x256x128_16x16_1x4_8x16x1_8x16x1_1x16x1x16_4x4x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x16x256x128_16x16_1x4_8x16x1_8x16x1_1x16x1x16_4x4x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x16x256x128_16x16_1x4_8x16x1_8x16x1_1x16x1x16_4x4x1_1x1_i
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x224x256x128_16x16_7x8_8x32x1_8x32x1_1x32x1x8_8x8x1_1x2_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x224x256x128_16x16_7x8_8x32x1_8x32x1_1x32x1x8_8x8x1_1x2_intrawave_v3.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x224x256x128_16x16_7x8_8x32x1_8x32x1_1x32x1x8_8x8x1_1x2_i
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x256x128x64_32x32_4x2_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_interwave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x256x128x64_32x32_4x2_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_interwave_v1.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x256x128x64_32x32_4x2_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_in
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 64 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x256x16x128_16x16_4x1_8x32x1_8x16x1_1x32x1x8_2x2x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x256x16x128_16x16_4x1_8x32x1_8x16x1_1x32x1x8_2x2x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x256x16x128_16x16_4x1_8x32x1_8x16x1_1x32x1x8_2x2x1_1x1_in
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x256x16x128_16x16_4x1_8x32x1_8x16x1_1x32x1x8_2x2x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x256x16x128_16x16_4x1_8x32x1_8x16x1_1x32x1x8_2x2x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x256x16x128_16x16_4x1_8x32x1_8x16x1_1x32x1x8_2x2x1_1x1_in
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x256x224x128_16x16_8x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x256x224x128_16x16_8x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x256x224x128_16x16_8x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_i
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x256x256x128_16x16_8x8_8x32x1_8x32x1_1x32x1x8_8x8x1_1x2_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x256x256x128_16x16_8x8_8x32x1_8x32x1_1x32x1x8_8x8x1_1x2_intrawave_v3.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x256x256x128_16x16_8x8_8x32x1_8x32x1_1x32x1x8_8x8x1_1x2_i
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x256x256x64_16x16_8x8_4x64x1_4x64x1_1x32x1x8_8x8x1_1x2_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x256x256x64_16x16_8x8_4x64x1_4x64x1_1x32x1x8_8x8x1_1x2_intrawave_v3.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x256x256x64_16x16_8x8_4x64x1_4x64x1_1x32x1x8_8x8x1_1x2_in
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 64 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x256x256x64_32x32_4x4_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_intrawave_v4.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x256x256x64_32x32_4x4_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_intrawave_v4.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x256x256x64_32x32_4x4_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_in
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 64 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x256x32x128_32x32_2x1_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x256x32x128_32x32_2x1_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x256x32x128_32x32_2x1_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_in
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x256x32x128_32x32_2x1_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x256x32x128_32x32_2x1_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x256x32x128_32x32_2x1_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_in
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x32x256x128_32x32_1x2_8x32x1_8x32x1_1x16x1x16_8x8x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x32x256x128_32x32_1x2_8x32x1_8x32x1_1x16x1x16_8x8x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x32x256x128_32x32_1x2_8x32x1_8x32x1_1x16x1x16_8x8x1_1x1_i
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x32x256x128_32x32_1x2_8x32x1_8x32x1_1x16x1x16_8x8x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x32x256x128_32x32_1x2_8x32x1_8x32x1_1x16x1x16_8x8x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x32x256x128_32x32_1x2_8x32x1_8x32x1_1x16x1x16_8x8x1_1x1_i
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x64x64x128_32x32_1x1_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_256x64x64x128_32x32_1x1_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_256x64x64x128_32x32_1x1_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_int
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x128_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x128_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v1.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_64x16x16x128_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interw
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x128_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x128_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_64x16x16x128_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interw
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x128_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_intrawave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x128_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_intrawave_v1.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_64x16x16x128_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_intraw
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x128_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x128_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_64x16x16x128_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_intraw
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 128 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x256_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x256_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v1.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_64x16x16x256_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interw
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 256 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x256_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x256_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_64x16x16x256_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interw
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 256 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x256_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_intrawave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x256_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_intrawave_v1.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_64x16x16x256_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_intraw
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 256 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x256_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x256_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_64x16x16x256_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_intraw
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 256 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x512_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x512_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v1.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_64x16x16x512_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interw
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 512 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x512_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x512_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_64x16x16x512_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interw
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 512 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x512_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_intrawave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x512_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_intrawave_v1.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_64x16x16x512_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_intraw
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 512 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x512_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x512_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_64x16x16x512_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_intraw
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 512 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x64_16x16_1x1_4x16x1_4x16x1_1x16x1x4_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x64_16x16_1x1_4x16x1_4x16x1_1x16x1x4_4x4x1_1x1_interwave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_64x16x16x64_16x16_1x1_4x16x1_4x16x1_1x16x1x4_4x4x1_1x1_inter
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 64 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x64_16x16_1x1_4x16x1_4x16x1_1x16x1x4_4x4x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_64x16x16x64_16x16_1x1_4x16x1_4x16x1_1x16x1x4_4x4x1_1x1_intrawave_v2.hip
@@ -20,7 +20,7 @@ fp8_rowwise_grouped_64x16x16x64_16x16_1x1_4x16x1_4x16x1_1x16x1x4_4x4x1_1x1_intra
   // Check if this input needs to be padded.
   bool pad = false;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    int K = XQ.size(2);
+    int K = WQ.size(2);
     pad = K % 64 != 0;
   } else {
     for (int i = 0; i < XQ.size(); i++) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_common.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_common.h
@@ -134,7 +134,7 @@ OutputType f8f8bf16_rowwise_grouped_impl(
   // Get input information.
   int group_count;
   if constexpr (std::is_same_v<InputType, at::Tensor>) {
-    group_count = XQ.size(0);
+    group_count = WQ.size(0);
   } else {
     group_count = XQ.size();
   }
@@ -168,13 +168,16 @@ OutputType f8f8bf16_rowwise_grouped_impl(
     // Compute appropriate data pointers.
     // Set the shape arguments for this gemm.
     if constexpr (std::is_same_v<InputType, at::Tensor>) {
-      M = XQ.size(1);
+      M = XQ.size(XQ.dim() - 2);
       N = WQ.size(1);
-      K = XQ.size(2);
-      a_ptr = reinterpret_cast<ADataType*>(XQ.data_ptr()) + (i * M * K);
-      b_ptr = reinterpret_cast<BDataType*>(WQ.data_ptr()) + (i * N * K);
-      d0_ptr = reinterpret_cast<D0DataType*>(w_scale.data_ptr()) + (i * N);
-      d1_ptr = reinterpret_cast<D1DataType*>(x_scale.data_ptr()) + (i * M);
+      K = WQ.size(2);
+      // These pointers dont seem to actually be used since the kernel arguments
+      // contains the correct version. For simplicity, we just point to the
+      // start of the tensor.
+      a_ptr = reinterpret_cast<ADataType*>(XQ.data_ptr());
+      b_ptr = reinterpret_cast<BDataType*>(WQ.data_ptr());
+      d0_ptr = reinterpret_cast<D0DataType*>(w_scale.data_ptr());
+      d1_ptr = reinterpret_cast<D1DataType*>(x_scale.data_ptr());
     } else {
       M = XQ[i].size(0);
       N = WQ[i].size(0);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_grouped.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_grouped.cu
@@ -224,14 +224,13 @@ __global__ void set_kernel_args_kernel(
 }
 
 __global__ void set_dynamic_kernel_args_kernel(
-    int64_t xq_ptr,
-    int64_t wq_ptr,
-    int64_t x_scale_ptr,
-    int64_t w_scale_ptr,
+    GroupedGemmArgs::ElementInputA* xq_ptr,
+    GroupedGemmArgs::ElementInputB* wq_ptr,
+    GroupedGemmArgs::ElementComputeEpilogue* x_scale_ptr,
+    GroupedGemmArgs::ElementComputeEpilogue* w_scale_ptr,
     int64_t* input_args_ptr,
     int64_t* output_args_ptr,
-    at::BFloat16* output_data,
-    int output_offset,
+    GroupedGemmArgs::ElementOutput* output_data,
     int xq_ptr_offset,
     int wq_ptr_offset,
     int x_scale_ptr_offset,
@@ -241,14 +240,15 @@ __global__ void set_dynamic_kernel_args_kernel(
     int stride_size,
     int group_count,
     int problem_shape_size,
-    int group_index,
-    int64_t* zero_start_index_M,
+    std::optional<int64_t*> zero_start_index_M,
+    std::optional<int64_t*> M_offsets,
+    int M,
     int N,
     int K) {
-  int idx = blockIdx.x * blockDim.x + threadIdx.x;
-  // Each kernel annoyingly can only set the kernel args for one group.
-  // This could only be avoided with complicated memory management.
-  if (idx == 0) {
+  int group_index = blockIdx.x * blockDim.x + threadIdx.x;
+  // If this thread corresponds to a valid group, write kernel args to device
+  // memory.
+  if (group_index < group_count) {
     int64_t* xq_ptr_ = input_args_ptr + xq_ptr_offset;
     int64_t* wq_ptr_ = input_args_ptr + wq_ptr_offset;
     int64_t* x_scale_ptr_ = input_args_ptr + x_scale_ptr_offset;
@@ -276,21 +276,43 @@ __global__ void set_dynamic_kernel_args_kernel(
             GroupedGemmArgs::GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::
                 StrideOutput*>(stride_buf + (stride_size * 2));
 
+    int offset_M;
+    int kernel_M;
+    if (zero_start_index_M.has_value()) {
+      // For inputs with padding, M is fixed and the number of rows
+      // to operate on is available in zero_start_index_M.
+      offset_M = group_index * M;
+      kernel_M = zero_start_index_M.value()[group_index];
+    } else {
+      // For stacked inputs without padding, M for current group
+      // can be found be found by comparing current and next offset.
+      // The offset we can get directly from M_offsets.
+      if (group_index == 0) {
+        offset_M = 0;
+        kernel_M = M_offsets.value()[group_index];
+      } else {
+        offset_M = M_offsets.value()[group_index - 1];
+        kernel_M = M_offsets.value()[group_index] - offset_M;
+      }
+    }
+
     output_args_ptr[group_index] =
-        reinterpret_cast<int64_t>(output_data + output_offset);
+        reinterpret_cast<int64_t>(output_data + (offset_M * N));
 
     // Write kernel arguments directly to memory.
-    xq_ptr_[group_index] = xq_ptr;
-    wq_ptr_[group_index] = wq_ptr;
-    x_scale_ptr_[group_index] = x_scale_ptr;
-    w_scale_ptr_[group_index] = w_scale_ptr;
+    xq_ptr_[group_index] = reinterpret_cast<int64_t>(xq_ptr + (offset_M * K));
+    wq_ptr_[group_index] =
+        reinterpret_cast<int64_t>(wq_ptr + (group_index * N * K));
+    x_scale_ptr_[group_index] =
+        reinterpret_cast<int64_t>(x_scale_ptr + offset_M);
+    w_scale_ptr_[group_index] =
+        reinterpret_cast<int64_t>(w_scale_ptr + (group_index * N));
     problem_shape_ptr[group_index] =
-        GroupedGemmArgs::ProblemShape::UnderlyingProblemShape(
-            zero_start_index_M[group_index], N, K);
+        GroupedGemmArgs::ProblemShape::UnderlyingProblemShape(kernel_M, N, K);
     stride_input_A_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
             GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::StrideInputA{},
-        {zero_start_index_M[group_index], K, 1});
+        {kernel_M, K, 1});
     stride_input_B_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
             GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::StrideInputB{},
@@ -298,7 +320,7 @@ __global__ void set_dynamic_kernel_args_kernel(
     stride_output_ptr[group_index] = cutlass::make_cute_packed_stride(
         typename GroupedGemmArgs::
             GroupedGemmConfigs<128, 256, 128, 2, 1, 1, false>::StrideOutput{},
-        {zero_start_index_M[group_index], N, 1});
+        {kernel_M, N, 1});
   }
 }
 
@@ -317,7 +339,8 @@ at::Tensor f8f8bf16_rowwise_grouped_impl(
     InputType x_scale,
     InputType w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> zero_start_index_M) {
+    std::optional<at::Tensor> zero_start_index_M,
+    std::optional<at::Tensor> M_offsets) {
   int group_count;
   at::TensorOptions options;
   if constexpr (std::is_same_v<InputType, at::TensorList>) {
@@ -325,9 +348,11 @@ at::Tensor f8f8bf16_rowwise_grouped_impl(
     options = XQ[0].options();
     TORCH_CHECK(WQ.size() == group_count);
   } else {
-    group_count = XQ.size(0);
+    TORCH_CHECK(
+        zero_start_index_M.has_value() != M_offsets.has_value(),
+        "One of zero_start_index_M or M_offsets must be provided.");
+    group_count = WQ.size(0);
     options = XQ.options();
-    TORCH_CHECK(WQ.size(0) == group_count);
   }
   if (group_count == 0) {
     return at::Tensor();
@@ -374,22 +399,20 @@ at::Tensor f8f8bf16_rowwise_grouped_impl(
     }
   }
 
-  int blockSize = 256;
-  int numBlocks = 1;
   auto stream = at::cuda::getCurrentCUDAStream().stream();
-  int64_t output_offset = 0;
+  // Set kernel arguments for tensor list inputs.
+  // The strategy here is to iterate over each group and set the corresponding
+  // device memory separately. This is the best way to allow true dynamic
+  // shapes.
+  if constexpr (std::is_same_v<InputType, at::TensorList>) {
+    int const blockSize = 256;
+    int const numBlocks = 1;
+    int64_t output_offset = 0;
 
-  TORCH_CHECK(
-      !zero_start_index_M.has_value() ||
-          zero_start_index_M->dtype() == at::kLong,
-      "zero_start_index_M must be int64.");
-
-  // Set arguments
-  for (int i = 0; i < group_count; ++i) {
-    int M, N, K;
-    int64_t xq_ptr, wq_ptr, x_scale_ptr, w_scale_ptr;
-    // Compute buffer pointers based on input type.
-    if constexpr (std::is_same_v<InputType, at::TensorList>) {
+    for (int i = 0; i < group_count; ++i) {
+      int M, N, K;
+      int64_t xq_ptr, wq_ptr, x_scale_ptr, w_scale_ptr;
+      // Compute buffer pointers based on input type.
       M = XQ[i].size(0);
       N = WQ[i].size(0);
       K = XQ[i].size(1);
@@ -399,44 +422,6 @@ at::Tensor f8f8bf16_rowwise_grouped_impl(
       wq_ptr = reinterpret_cast<int64_t>(WQ[i].data_ptr());
       x_scale_ptr = reinterpret_cast<int64_t>(x_scale[i].data_ptr());
       w_scale_ptr = reinterpret_cast<int64_t>(w_scale[i].data_ptr());
-    } else {
-      M = XQ.size(1);
-      N = WQ.size(1);
-      K = XQ.size(2);
-      // Calculate data pointer for this group.
-      xq_ptr = reinterpret_cast<int64_t>(XQ.data_ptr()) +
-          (i * M * K * sizeof(GroupedGemmArgs::ElementInputA));
-      wq_ptr = reinterpret_cast<int64_t>(WQ.data_ptr()) +
-          (i * N * K * sizeof(GroupedGemmArgs::ElementInputB));
-      x_scale_ptr = reinterpret_cast<int64_t>(x_scale.data_ptr()) +
-          (i * M * sizeof(GroupedGemmArgs::ElementAccumulator));
-      w_scale_ptr = reinterpret_cast<int64_t>(w_scale.data_ptr()) +
-          (i * N * sizeof(GroupedGemmArgs::ElementAccumulator));
-    }
-    if (zero_start_index_M.has_value() == true) {
-      set_dynamic_kernel_args_kernel<<<numBlocks, blockSize, 0, stream>>>(
-          xq_ptr,
-          wq_ptr,
-          x_scale_ptr,
-          w_scale_ptr,
-          input_args.data_ptr<int64_t>(),
-          output_args.data_ptr<int64_t>(),
-          output.data_ptr<at::BFloat16>(),
-          output_offset,
-          xq_ptr_offset,
-          wq_ptr_offset,
-          x_scale_ptr_offset,
-          w_scale_ptr_offset,
-          problem_shape_buf_offset,
-          stride_buf_offset,
-          stride_size,
-          group_count,
-          problem_shape_size,
-          i,
-          reinterpret_cast<int64_t*>(zero_start_index_M.value().data_ptr()),
-          N,
-          K);
-    } else {
       set_kernel_args_kernel<<<numBlocks, blockSize, 0, stream>>>(
           xq_ptr,
           wq_ptr,
@@ -459,8 +444,59 @@ at::Tensor f8f8bf16_rowwise_grouped_impl(
           M,
           N,
           K);
+      output_offset += output_sizes[i];
     }
-    output_offset += output_sizes[i];
+  } else {
+    // For Tensor inputs, we can set all group arguments in a single kernel
+    // launch.
+    TORCH_CHECK(
+        !zero_start_index_M.has_value() ||
+            zero_start_index_M->dtype() == at::kLong,
+        "zero_start_index_M must be int64.");
+
+    TORCH_CHECK(
+        !M_offsets.has_value() || M_offsets->dtype() == at::kLong,
+        "M_offsets must be int64.");
+    int const blockSize = std::min(1024, group_count);
+    int const numBlocks = (group_count + blockSize - 1) / blockSize;
+    // When m_offsets is used, XQ is shape [total_M, K]. When zero_start_index_M
+    // is used, shape is [G, M, K].
+    int M = XQ.size(XQ.dim() - 2);
+    int N = WQ.size(1);
+    int K = WQ.size(2);
+    std::optional<int64_t*> zero_start_index_M_ptr = std::nullopt;
+    std::optional<int64_t*> M_offsets_ptr = std::nullopt;
+    if (zero_start_index_M.has_value()) {
+      zero_start_index_M_ptr =
+          reinterpret_cast<int64_t*>(zero_start_index_M.value().data_ptr());
+    }
+    if (M_offsets.has_value()) {
+      M_offsets_ptr = reinterpret_cast<int64_t*>(M_offsets.value().data_ptr());
+    }
+    set_dynamic_kernel_args_kernel<<<numBlocks, blockSize, 0, stream>>>(
+        reinterpret_cast<GroupedGemmArgs::ElementInputA*>(XQ.data_ptr()),
+        reinterpret_cast<GroupedGemmArgs::ElementInputB*>(WQ.data_ptr()),
+        reinterpret_cast<GroupedGemmArgs::ElementComputeEpilogue*>(
+            x_scale.data_ptr()),
+        reinterpret_cast<GroupedGemmArgs::ElementComputeEpilogue*>(
+            w_scale.data_ptr()),
+        input_args.data_ptr<int64_t>(),
+        output_args.data_ptr<int64_t>(),
+        reinterpret_cast<GroupedGemmArgs::ElementOutput*>(output.data_ptr()),
+        xq_ptr_offset,
+        wq_ptr_offset,
+        x_scale_ptr_offset,
+        w_scale_ptr_offset,
+        problem_shape_buf_offset,
+        stride_buf_offset,
+        stride_size,
+        group_count,
+        problem_shape_size,
+        zero_start_index_M_ptr,
+        M_offsets_ptr,
+        M,
+        N,
+        K);
   }
 
   int64_t* output_ptr = output_args.data_ptr<int64_t>();
@@ -555,7 +591,8 @@ at::Tensor dispatch_fp8_grouped_kernel(
     InputType x_scale,
     InputType w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> zero_start_index_M) {
+    std::optional<at::Tensor> zero_start_index_M = std::nullopt,
+    std::optional<at::Tensor> M_offsets = std::nullopt) {
   KernelMode kernel = get_grouped_kernel_mode(XQ, WQ);
   if (kernel == KernelMode::Small) {
     return f8f8bf16_rowwise_grouped_impl<
@@ -566,7 +603,7 @@ at::Tensor dispatch_fp8_grouped_kernel(
         2,
         1,
         1,
-        true>(XQ, WQ, x_scale, w_scale, output, zero_start_index_M);
+        true>(XQ, WQ, x_scale, w_scale, output, zero_start_index_M, M_offsets);
   } else if (kernel == KernelMode::Large) {
     return f8f8bf16_rowwise_grouped_impl<
         InputType,
@@ -576,7 +613,7 @@ at::Tensor dispatch_fp8_grouped_kernel(
         2,
         1,
         1,
-        false>(XQ, WQ, x_scale, w_scale, output, zero_start_index_M);
+        false>(XQ, WQ, x_scale, w_scale, output, zero_start_index_M, M_offsets);
   } else {
     return f8f8bf16_rowwise_grouped_impl<
         InputType,
@@ -586,60 +623,42 @@ at::Tensor dispatch_fp8_grouped_kernel(
         2,
         1,
         1,
-        false>(XQ, WQ, x_scale, w_scale, output, zero_start_index_M);
+        false>(XQ, WQ, x_scale, w_scale, output, zero_start_index_M, M_offsets);
   }
 }
 
-template <typename OutputType>
-OutputType _f8f8bf16_rowwise_grouped(
+std::vector<at::Tensor> f8f8bf16_rowwise_grouped(
     at::TensorList XQ, // FP8
     at::TensorList WQ, // FP8
     at::TensorList x_scale,
     at::TensorList w_scale,
-    std::optional<OutputType> output = std::nullopt) {
+    std::optional<std::vector<at::Tensor>> output = std::nullopt) {
   at::Tensor Y;
   int group_count = XQ.size();
   std::vector<int64_t> output_sizes;
   if (output.has_value()) {
     // Handle initialization check for output list.
-    if constexpr (std::is_same_v<OutputType, std::vector<at::Tensor>>) {
-      std::vector<at::Tensor> output_;
-      output_ = output.value();
+    std::vector<at::Tensor> output_;
+    output_ = output.value();
+    TORCH_CHECK(
+        output_.size() == group_count,
+        "Output and input must have same number of groups.");
+    // Check that output shapes are correct.
+    for (int i = 0; i < group_count; i++) {
+      int M = XQ[i].size(0);
+      int N = WQ[i].size(0);
+      int out_M = output_[i].size(0);
+      int out_N = output_[i].size(1);
       TORCH_CHECK(
-          output_.size() == group_count,
-          "Output and input must have same number of groups.");
-      // Check that output shapes are correct.
-      for (int i = 0; i < group_count; i++) {
-        int M = XQ[i].size(0);
-        int N = WQ[i].size(0);
-        int out_M = output_[i].size(0);
-        int out_N = output_[i].size(1);
-        TORCH_CHECK(
-            M == out_M && N == out_N,
-            "Output tensors do not have the expected shape.");
-        TORCH_CHECK(
-            output_[i].dtype() == at::kBFloat16,
-            "Output dtype must be bfloat16.");
-        output_sizes.push_back(out_M * out_N);
-      }
-      Y = at::stack(output.value(), 0);
-      // Handle initialization check for output tensor.
-    } else {
-      at::Tensor output_ = output.value();
-      // Check that output shapes are correct.
-      int N = WQ[0].size(0);
-      for (int i = 0; i < group_count; i++) {
-        TORCH_CHECK(
-            WQ[i].size(0) == N,
-            "N must be static for single output tensor mode.");
-        TORCH_CHECK(
-            output_.size(0) == group_count &&
-                output_.size(1) == XQ[i].size(0) && output_.size(2) == N,
-            "Output must be shape [G, M, N]");
-      }
-      TORCH_CHECK(output_.dtype() == at::kBFloat16, "Output must be bfloat16.")
-      Y = output_.view(-1);
+          M == out_M && N == out_N,
+          "Output tensors do not have the expected shape.");
+      TORCH_CHECK(
+          output_[i].dtype() == at::kBFloat16,
+          "Output dtype must be bfloat16.");
+      output_sizes.push_back(out_M * out_N);
     }
+    Y = at::stack(output.value(), 0);
+    // Otherwise allocate a new output tensor.
   } else {
     int64_t total_output_size = 0;
     for (int i = 0; i < group_count; ++i) {
@@ -651,40 +670,42 @@ OutputType _f8f8bf16_rowwise_grouped(
   }
 
   // Run kernel.
-  at::Tensor g_out = dispatch_fp8_grouped_kernel<at::TensorList>(
-      XQ, WQ, x_scale, w_scale, Y, std::nullopt);
+  at::Tensor g_out =
+      dispatch_fp8_grouped_kernel<at::TensorList>(XQ, WQ, x_scale, w_scale, Y);
 
-  // Return proper output type.
-  if constexpr (std::is_same_v<OutputType, std::vector<at::Tensor>>) {
-    // Return grouped view of output.
-    std::vector<at::Tensor> output_group = g_out.split(output_sizes);
-    for (int i = 0; i < group_count; ++i) {
-      output_group[i] = output_group[i].view({XQ[i].size(0), WQ[i].size(0)});
-    }
-    return output_group;
-  } else {
-    // When stacked we assume N is fixed.
-    return g_out.view({-1, WQ[0].size(0)});
+  // Return grouped view of output.
+  std::vector<at::Tensor> output_group = g_out.split(output_sizes);
+  for (int i = 0; i < group_count; ++i) {
+    output_group[i] = output_group[i].view({XQ[i].size(0), WQ[i].size(0)});
   }
-}
-
-std::vector<at::Tensor> f8f8bf16_rowwise_grouped(
-    at::TensorList XQ, // FP8
-    at::TensorList WQ, // FP8
-    at::TensorList x_scale,
-    at::TensorList w_scale,
-    std::optional<std::vector<at::Tensor>> output = std::nullopt) {
-  return _f8f8bf16_rowwise_grouped<std::vector<at::Tensor>>(
-      XQ, WQ, x_scale, w_scale);
+  return output_group;
 }
 
 at::Tensor f8f8bf16_rowwise_grouped_stacked(
-    at::TensorList XQ, // FP8
-    at::TensorList WQ, // FP8
-    at::TensorList x_scale,
-    at::TensorList w_scale,
+    at::Tensor XQ, // FP8
+    at::Tensor WQ, // FP8
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor M_offsets,
     std::optional<at::Tensor> output = std::nullopt) {
-  return _f8f8bf16_rowwise_grouped<at::Tensor>(XQ, WQ, x_scale, w_scale);
+  int total_M = XQ.size(0);
+  int N = WQ.size(1);
+  int group_count = M_offsets.size(0);
+  TORCH_CHECK(
+      M_offsets.device() == XQ.device(),
+      "M_offsets must be on same device as inputs.");
+  TORCH_CHECK(
+      WQ.dim() == 3 && WQ.size(0) == group_count,
+      "Weights should be shape [G, N, K].")
+  at::Tensor Y = at::empty(total_M * N, XQ.options().dtype(at::kBFloat16));
+  // Early exit for empty inputs.
+  if (total_M == 0) {
+    return Y.view({total_M, N});
+  }
+  // Return continuous view of output.
+  at::Tensor out = dispatch_fp8_grouped_kernel<at::Tensor>(
+      XQ, WQ, x_scale, w_scale, Y, std::nullopt, M_offsets);
+  return out.view({total_M, N});
 }
 
 at::Tensor f8f8bf16_rowwise_grouped_dynamic(
@@ -694,12 +715,15 @@ at::Tensor f8f8bf16_rowwise_grouped_dynamic(
     at::Tensor w_scale,
     at::Tensor zero_start_index_M,
     bool zeroing_output_tensor = true) {
-  at::Tensor Y;
+  TORCH_CHECK(
+      zero_start_index_M.device() == XQ.device(),
+      "zero_start_index_M must be on same device as inputs.");
   int group_count = XQ.size(0);
   int M = XQ.size(1);
   int N = WQ.size(1);
   int K = XQ.size(0);
   int total_output_size = group_count * M * N;
+  at::Tensor Y;
   if (zeroing_output_tensor) {
     Y = at::zeros(total_output_size, XQ.options().dtype(at::kBFloat16));
   } else {
@@ -726,10 +750,11 @@ std::vector<at::Tensor> f8f8bf16_rowwise_grouped(
 }
 
 at::Tensor f8f8bf16_rowwise_grouped_stacked(
-    at::TensorList XQ, // FP8
-    at::TensorList WQ, // FP8
-    at::TensorList x_scale,
-    at::TensorList w_scale,
+    at::Tensor XQ, // FP8
+    at::Tensor WQ, // FP8
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor M_offsets,
     std::optional<at::Tensor> output = std::nullopt) {
   throw std::runtime_error(
       "CUDA version is older than 12.0"); // requires CUDA>=12

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -98,7 +98,7 @@ at::Tensor f8f8bf16_rowwise_grouped_stacked(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    at::Tensor M_offsets,
+    at::Tensor M_sizes,
     std::optional<at::Tensor> output = std::nullopt);
 at::Tensor f8f8bf16_rowwise_grouped_dynamic(
     at::Tensor XQ,
@@ -228,7 +228,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "f8f8bf16_rowwise_grouped(Tensor[] XQ, Tensor[] WQ, Tensor[] x_scale, Tensor[] w_scale, Tensor[](a!)? output=None) -> Tensor[]");
   m.def(
-      "f8f8bf16_rowwise_grouped_stacked(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor M_offsets, Tensor(a!)? output=None) -> Tensor");
+      "f8f8bf16_rowwise_grouped_stacked(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor M_sizes, Tensor(a!)? output=None) -> Tensor");
   m.def(
       "f8f8bf16_rowwise_grouped_dynamic(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor zero_start_index_M, bool zeroing_output_tensor=True) -> Tensor");
   m.def(

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -94,10 +94,11 @@ std::vector<at::Tensor> f8f8bf16_rowwise_grouped(
     at::TensorList w_scale,
     std::optional<std::vector<at::Tensor>> output = std::nullopt);
 at::Tensor f8f8bf16_rowwise_grouped_stacked(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::TensorList x_scale,
-    at::TensorList w_scale,
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor M_offsets,
     std::optional<at::Tensor> output = std::nullopt);
 at::Tensor f8f8bf16_rowwise_grouped_dynamic(
     at::Tensor XQ,
@@ -227,7 +228,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "f8f8bf16_rowwise_grouped(Tensor[] XQ, Tensor[] WQ, Tensor[] x_scale, Tensor[] w_scale, Tensor[](a!)? output=None) -> Tensor[]");
   m.def(
-      "f8f8bf16_rowwise_grouped_stacked(Tensor[] XQ, Tensor[] WQ, Tensor[] x_scale, Tensor[] w_scale, Tensor(a!)? output=None) -> Tensor");
+      "f8f8bf16_rowwise_grouped_stacked(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor M_offsets, Tensor(a!)? output=None) -> Tensor");
   m.def(
       "f8f8bf16_rowwise_grouped_dynamic(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor zero_start_index_M, bool zeroing_output_tensor=True) -> Tensor");
   m.def(

--- a/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
@@ -805,28 +805,30 @@ class FP8Tests(unittest.TestCase):
             wq_group = torch.stack(wq_group, dim=0).contiguous()
             x_scale_group = torch.stack(x_scale_group, dim=0).contiguous()
             w_scale_group = torch.stack(w_scale_group, dim=0).contiguous()
+        elif return_stacked:
+            xq_group = torch.cat(xq_group, dim=0).contiguous()
+            wq_group = torch.stack(wq_group, dim=0).contiguous()
+            x_scale_group = torch.cat(x_scale_group, dim=0).contiguous()
+            w_scale_group = torch.stack(w_scale_group, dim=0).contiguous()
 
         # FP8 grouped gemm kernel
-        fp8_args = (
-            [
+        if use_padding_zeros:
+            fp8_op = torch.ops.fbgemm.f8f8bf16_rowwise_grouped_dynamic
+            fp8_args = [
                 xq_group,
                 wq_group,
                 x_scale_group,
                 w_scale_group,
                 zero_start_index_M,
             ]
-            if use_padding_zeros
-            else [xq_group, wq_group, x_scale_group, w_scale_group]
-        )
-        fp8_op = (
-            torch.ops.fbgemm.f8f8bf16_rowwise_grouped_dynamic
-            if use_padding_zeros
-            else (
-                torch.ops.fbgemm.f8f8bf16_rowwise_grouped_stacked
-                if return_stacked
-                else torch.ops.fbgemm.f8f8bf16_rowwise_grouped
-            )
-        )
+        elif return_stacked:
+            fp8_op = torch.ops.fbgemm.f8f8bf16_rowwise_grouped_stacked
+            M_offsets = torch.cumsum(ms, dim=0).to(device="cuda", dtype=torch.int64)
+            fp8_args = [xq_group, wq_group, x_scale_group, w_scale_group, M_offsets]
+        else:
+            fp8_op = torch.ops.fbgemm.f8f8bf16_rowwise_grouped
+            fp8_args = [xq_group, wq_group, x_scale_group, w_scale_group]
+
         if use_cudagraph:
             # warmup
             fp8_op(*fp8_args)

--- a/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
@@ -823,7 +823,7 @@ class FP8Tests(unittest.TestCase):
             ]
         elif return_stacked:
             fp8_op = torch.ops.fbgemm.f8f8bf16_rowwise_grouped_stacked
-            M_offsets = torch.cumsum(ms, dim=0).to(device="cuda", dtype=torch.int64)
+            M_offsets = ms.to(device="cuda", dtype=torch.int64)
             fp8_args = [xq_group, wq_group, x_scale_group, w_scale_group, M_offsets]
         else:
             fp8_op = torch.ops.fbgemm.f8f8bf16_rowwise_grouped


### PR DESCRIPTION
Summary: Rather than require an explicit cumulative sum to be performed on the M sizes of each group to generate the M_offsets argument, we can instead compute the offsets based on the sizes as part of kernel setup. This should be quite a bit faster than doing a separate kernel launch.

Differential Revision: D71152287
