### PR TITLE
update the sorting kernel for bf16 ck fmoe kernel

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fused_moe/fused_moe.hpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fused_moe/fused_moe.hpp
@@ -17,6 +17,9 @@ struct fused_moe_args {
       y_smooth_scale_ptr; // [e, 1, n], smooth-quant-scale for 2nd gemm input
   const void* local_expert_mask_ptr; // [e], local_expert_mask_ptr for EP
   void* o_ptr; // [m, k], output token (no need to do zeroing)
+  void* ws_ptr; // size is moe_sorting_get_workspace_size()
+                // if return zero, then could be nullptr
+                // must be cleard before use
 
   const void* topk_ids_ptr; // [tokens, topk]
   const void* topk_weight_ptr; // [tokens, topk]

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fused_moe/fused_moe_kernel.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fused_moe/fused_moe_kernel.hip
@@ -77,6 +77,15 @@ at::Tensor fused_moe_impl(
   auto prec_o = get_prec_str(output);
   auto prec_tkw = get_prec_str(topk_weights);
 
+  int workspace_size = ck_tile::moe_sorting_get_workspace_size(tokens, experts);
+  void *ws_ptr = nullptr;
+  if (workspace_size > 0)
+  {
+      auto ws = at::zeros({workspace_size}, at::TensorOptions().dtype(topk_ids.dtype()).device(device_of(topk_ids)));
+      ws_ptr = ws.data_ptr();
+  }
+  
+
   // Set up traits structure
   fused_moe_traits traits{
       prec_i,
@@ -99,9 +108,10 @@ at::Tensor fused_moe_impl(
       down_weight.data_ptr(),
       gate_up_scales.has_value() ? gate_up_scales->data_ptr() : nullptr,
       down_scales.has_value() ? down_scales->data_ptr() : nullptr,
-      smooth_scales.has_value() ? smooth_scales->data_ptr() : nullptr,
+      smooth_scales.has_value() ? smooth_scales->data_ptr() : nullptr,  // expert_mask
       nullptr,
       output.data_ptr(),
+      ws_ptr,
       topk_ids.data_ptr(),
       topk_weights.data_ptr(),
       sorted_token_ids.data_ptr(),

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fused_moe/fused_moesorting.hpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fused_moe/fused_moesorting.hpp
@@ -19,3 +19,9 @@ float fused_moesorting(
     fused_moesorting_trait t,
     fused_moesorting_args a,
     ck_tile::stream_config s);
+
+int moe_sorting_get_workspace_size(int tokens, int num_experts);
+float moe_sorting_mp(
+    fused_moesorting_trait t,
+    fused_moesorting_args a,
+    ck_tile::stream_config s);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fused_moe/instances/fused_moe_api.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fused_moe/instances/fused_moe_api.hip
@@ -27,6 +27,7 @@ float fused_moe(fused_moe_traits t, fused_moe_args a, const ck_tile::stream_conf
         a.sorted_expert_ids_ptr,                     // void* p_sorted_expert_ids;
         a.num_sorted_tiles_ptr,                      // void* p_total_tokens_post_pad;
         a.o_ptr,                                     // void* p_moe_buf;
+        a.ws_ptr,                                    // moe_sorting_ws
         a.num_tokens,                                // index_t tokens;
         a.block_m,                                   // index_t unit_size;
         a.num_experts,                               // index_t num_experts;

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fused_moe/instances/fused_moesorting_api.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fused_moe/instances/fused_moesorting_api.hip
@@ -153,18 +153,106 @@ float fused_moesorting(fused_moesorting_trait t, fused_moesorting_args a, ck_til
         }
         }
 #else
-        using index_t            = ck_tile::index_t;
-        using ms_weight_type     = float;
-        auto [r_, c_]            = ck_tile::moe_sorting_get_smem_row_col(a.tokens, a.num_experts);
-        auto sub_token_          = r_ - 2;
-        r_                       = (r_ - 2) / 8;
-        bool is_sub_token_onshot = a.tokens <= sub_token_;
+        if(moe_sorting_get_workspace_size(a.tokens, a.num_experts) != 0)
+        {
+            return moe_sorting_mp(t, a, s);
+        }
+        using index_t                = ck_tile::index_t;
+        using ms_weight_type         = float;
+        auto sub_token_              = ck_tile::moe_sorting_get_sub_token(a.tokens, a.num_experts);
+        auto row_                    = sub_token_ / 8;
+        bool is_sub_token_onshot     = a.tokens <= sub_token_;
         bool is_local_expert_masking = t.local_expert_masking;
-        (void)c_;
 
-        MOE_SORTING_DISPATCH_EMASK_(r_);
+        MOE_SORTING_DISPATCH_EMASK_(row_);
         // MOE_SORTING_DISPATCH_ETILE(0, 0);
 #endif
     }
     return -1;
+}
+
+#define MOE_SORTING_MP_0(unroll_num_, expert_masking_)                                            \
+    [&]() {                                                                                       \
+        constexpr ck_tile::index_t unroll_num = unroll_num_;                                      \
+        constexpr bool expert_masking         = expert_masking_;                                  \
+        using ms_problem =                                                                        \
+            ck_tile::MoeSortingProblemMp<ms_index_t, ms_weight_type, unroll_num, expert_masking>; \
+        using kernel      = ck_tile::MoeSortingMultiPhaseKernel_P0<ms_problem>;                   \
+        auto kargs        = kernel::MakeKargs(a);                                                 \
+        const dim3 grids  = kernel::GridSize(a);                                                  \
+        const dim3 blocks = kernel::BlockSize(a);                                                 \
+        return ck_tile::make_kernel(kernel{}, grids, blocks, 0, kargs);                           \
+    }()
+
+#define MOE_SORTING_MP_1(unroll_num_, expert_masking_)                                            \
+    [&]() {                                                                                       \
+        constexpr ck_tile::index_t unroll_num = unroll_num_;                                      \
+        constexpr bool expert_masking         = expert_masking_;                                  \
+        using ms_problem =                                                                        \
+            ck_tile::MoeSortingProblemMp<ms_index_t, ms_weight_type, unroll_num, expert_masking>; \
+        using kernel      = ck_tile::MoeSortingMultiPhaseKernel_P1<ms_problem>;                   \
+        auto kargs        = kernel::MakeKargs(a);                                                 \
+        const dim3 grids  = kernel::GridSize(a);                                                  \
+        const dim3 blocks = kernel::BlockSize(a);                                                 \
+        return ck_tile::make_kernel(kernel{}, grids, blocks, 0, kargs);                           \
+    }()
+
+#define MOE_SORTING_MP_2(unroll_num_, expert_masking_)                                            \
+    [&]() {                                                                                       \
+        constexpr ck_tile::index_t unroll_num = unroll_num_;                                      \
+        constexpr bool expert_masking         = expert_masking_;                                  \
+        using ms_problem =                                                                        \
+            ck_tile::MoeSortingProblemMp<ms_index_t, ms_weight_type, unroll_num, expert_masking>; \
+        using kernel      = ck_tile::MoeSortingMultiPhaseKernel_P2<ms_problem>;                   \
+        auto kargs        = kernel::MakeKargs(a);                                                 \
+        const dim3 grids  = kernel::GridSize(a);                                                  \
+        const dim3 blocks = kernel::BlockSize(a);                                                 \
+        return ck_tile::make_kernel(kernel{}, grids, blocks, 0, kargs);                           \
+    }()
+
+#define MOE_SORTING_MP_3(unroll_num_, expert_masking_)                                            \
+    [&]() {                                                                                       \
+        constexpr ck_tile::index_t unroll_num = unroll_num_;                                      \
+        constexpr bool expert_masking         = expert_masking_;                                  \
+        using ms_problem =                                                                        \
+            ck_tile::MoeSortingProblemMp<ms_index_t, ms_weight_type, unroll_num, expert_masking>; \
+        using kernel      = ck_tile::MoeSortingMultiPhaseKernel_P3<ms_problem>;                   \
+        auto kargs        = kernel::MakeKargs(a);                                                 \
+        const dim3 grids  = kernel::GridSize(a);                                                  \
+        const dim3 blocks = kernel::BlockSize(a);                                                 \
+        return ck_tile::make_kernel(kernel{}, grids, blocks, 0, kargs);                           \
+    }()
+
+float moe_sorting_mp(fused_moesorting_trait t, fused_moesorting_args a, ck_tile::stream_config s)
+{
+    if(t.weight_type == "fp32" && t.index_type == "int32")
+    {
+        using ms_index_t     = ck_tile::index_t;
+        using ms_weight_type = float;
+
+        if(t.local_expert_masking)
+        {
+            float ave_time = ck_tile::launch_kernel(s,
+                                                    MOE_SORTING_MP_0(1, true),
+                                                    MOE_SORTING_MP_1(1, true),
+                                                    MOE_SORTING_MP_2(1, true),
+                                                    MOE_SORTING_MP_3(1, true));
+            return ave_time;
+        }
+        else
+        {
+            float ave_time = ck_tile::launch_kernel(s,
+                                                    MOE_SORTING_MP_0(1, false),
+                                                    MOE_SORTING_MP_1(1, false),
+                                                    MOE_SORTING_MP_2(1, false),
+                                                    MOE_SORTING_MP_3(1, false));
+            return ave_time;
+        }
+    }
+    return -1;
+}
+
+int moe_sorting_get_workspace_size(int tokens, int num_experts)
+{
+    return ck_tile::moe_sorting_get_workspace_size(tokens, num_experts);
 }

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fused_moe/run.py
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fused_moe/run.py
@@ -22,6 +22,8 @@ def main():
     intermediate_size = 8192
     topk = 5
 
+    print("Running fused MoE kernel...")
+
     # Create input tensors on GPU
     input = torch.randn(tokens, hidden_size, dtype=torch.bfloat16, device="cuda")
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/902

Cherry Pick the PR: https://github.com/ROCm/composable_kernel/pull/1910

The mp sorting kernel is not involved actually, we are still debugging with CK team

Differential Revision: D71179541


