### PR TITLE
fix benchmark logging after script reorganization

### DIFF
--- a/fbgemm_gpu/bench/bench_utils.py
+++ b/fbgemm_gpu/bench/bench_utils.py
@@ -14,7 +14,8 @@ from typing import List, Tuple
 
 import torch
 
-logging.basicConfig(level=logging.DEBUG)
+logger: logging.Logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
 
 
 def benchmark_torch_function(  # noqa: C901

--- a/fbgemm_gpu/bench/tbe/batch_benchmark_run.py
+++ b/fbgemm_gpu/bench/tbe/batch_benchmark_run.py
@@ -13,7 +13,8 @@ import subprocess
 
 import click
 
-logging.basicConfig(level=logging.DEBUG)
+logger: logging.Logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
 
 
 @click.command()

--- a/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py
@@ -41,7 +41,8 @@ from fbgemm_gpu.tbe.utils import generate_requests, get_device, round_up, TBEReq
 from torch import Tensor
 from torch.profiler import profile
 
-logging.basicConfig(level=logging.DEBUG)
+logger: logging.Logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
 
 
 @click.group()

--- a/fbgemm_gpu/bench/tbe/tbe_inference_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/tbe_inference_benchmark.py
@@ -47,7 +47,8 @@ from fbgemm_gpu.tbe.bench import (
 from fbgemm_gpu.tbe.utils import generate_requests, round_up, TBERequest
 from torch.profiler import profile
 
-logging.basicConfig(level=logging.DEBUG)
+logger: logging.Logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
 
 
 def kineto_trace_profiler(p: profile, trace_info: tuple[str, str, str, str]) -> float:


### PR DESCRIPTION
Fix the logging message in benchmarks as they were reorganized recently (similar to https://github.com/pytorch/FBGEMM/pull/3113). 