### PR TITLE
Add generic IEEE754 truncation code

### DIFF
--- a/include/fbgemm/FloatConversion.h
+++ b/include/fbgemm/FloatConversion.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <cassert>
+#include <climits>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -35,151 +37,217 @@ using native_fp16_t = void;
 
 namespace fbgemm {
 
-// The IEEE754 standard species a binary16 as having the following format:
-// SEEEEEMMMMMMMMMM
-// 0432109876543210
-// That is:
-//  *  1 sign bit
-//  *  5 exponent bits
-//  * 10 mantissa/significand bits (an 11th bit is implicit)
-constexpr uint32_t f16_num_bits = 16;
-constexpr uint32_t f16_num_exponent_bits = 5;
-constexpr uint32_t f16_num_mantissa_bits = 10;
-constexpr uint32_t f16_num_non_sign_bits =
-    f16_num_exponent_bits + f16_num_mantissa_bits;
-constexpr uint32_t f16_exponent_mask = 0b1'1111; // 5 bits
-constexpr uint32_t f16_sign_bit = 1u
-    << (f16_num_exponent_bits + f16_num_mantissa_bits);
-constexpr uint32_t f16_exponent_bits = f16_exponent_mask
-    << f16_num_mantissa_bits;
-constexpr uint32_t f16_mantissa_mask = 0b11'1111'1111; // 10 bits
-constexpr uint32_t f16_exponent_bias = 15;
-constexpr uint32_t f16_nan = 0x7F'FF;
+namespace detail {
 
-// The IEEE754 standard specifies a binary32 as having:
-// SEEEEEEEEMMMMMMMMMMMMMMMMMMMMMMM
-// That is:
-//  *  1 sign bit
-//  *  8 exponent bits
-//  * 23 mantissa/significand bits (a 24th bit is implicit)
-constexpr uint32_t f32_num_exponent_bits = 8;
-constexpr uint32_t f32_num_mantissa_bits = 23;
-constexpr uint32_t f32_exponent_mask = 0b1111'1111; // 8 bits
-constexpr uint32_t f32_mantissa_mask = 0x7F'FF'FF; // 23 bits
-constexpr uint32_t f32_exponent_bias = 127;
-constexpr uint32_t f32_all_non_sign_mask = 0x7F'FF'FF'FF; // 31 bits
-constexpr uint32_t f32_most_significant_bit = 1u << 22; // Turn on 23rd bit
-constexpr uint32_t f32_num_non_sign_bits =
-    f32_num_exponent_bits + f32_num_mantissa_bits;
+template <typename T, int ExponentBits, bool HasInfinity = true>
+struct FloatFormat {
+  using value_type = T;
+  static constexpr int bits = sizeof(T) * CHAR_BIT;
+  static constexpr int exponent_bits = ExponentBits;
+  static constexpr int mantissa_bits = bits - exponent_bits - 1;
+  static constexpr int sign_bit_pos = bits - 1;
+  static constexpr int exponent_bias = (1 << (exponent_bits - 1)) - 1;
+  static constexpr int unbiased_exponent_min = -exponent_bias + 1;
+  static constexpr int unbiased_exponent_max =
+      HasInfinity ? exponent_bias : (exponent_bias + 1);
+  static constexpr T sign_bit = T{1} << sign_bit_pos;
+  static constexpr T exponent_mask = ((T{1} << exponent_bits) - 1)
+      << mantissa_bits;
+  static constexpr T mantissa_mask = (T{1} << mantissa_bits) - 1;
+  // signaling/quiet encoding is unspecified by IEEE754. This mirrors x86/ARM.
+  static constexpr T quiet_nan_bit = T{1} << (mantissa_bits - 1);
 
-// Round to nearest even
-inline float16 cpu_float2half_rn(float f) {
-  static_assert(
-      sizeof(uint32_t) == sizeof(float),
-      "Programming error sizeof(uint32_t) != sizeof(float)");
+  static constexpr T nan = exponent_mask | mantissa_mask;
+  static constexpr T overflow_value = HasInfinity ? exponent_mask : nan;
+  static constexpr bool has_infinity = HasInfinity;
+  static constexpr bool has_nan_payload = HasInfinity;
+};
 
-  uint32_t* xp = reinterpret_cast<uint32_t*>(&f);
-  uint32_t x = *xp;
-  uint32_t u = (x & f32_all_non_sign_mask);
+using IEEE754Single = FloatFormat</*T=*/uint32_t, /*ExponentBits=*/8>;
+using IEEE754Half = FloatFormat</*T=*/uint16_t, /*ExponentBits=*/5>;
+// See https://arxiv.org/abs/1905.12322v3
+using BFloat16 = FloatFormat</*T=*/uint16_t, /*ExponentBits=*/8>;
+// See https://doi.org/10.48550/arXiv.2209.05433
+using FP8_E5M2 = FloatFormat</*T=*/uint8_t, /*ExponentBits=*/5>;
+// See https://doi.org/10.48550/arXiv.2209.05433
+using FP8_E4M3FN = FloatFormat<
+    /*T=*/uint8_t,
+    /*ExponentBits=*/4,
+    /*HasInfinity=*/false>;
 
-  // Get rid of +NaN/-NaN case first.
-  if (u > 0x7f800000) {
-    return static_cast<float16>(f16_nan);
+enum class RoundingMode {
+  ToNearestTiesToEven,
+  ToZero,
+};
+
+// Generic IEEE754 truncation algorithm.
+template <typename Src, typename Tgt, RoundingMode RoundingMode>
+[[gnu::always_inline]] inline typename Tgt::value_type ieee754_trunc(
+    typename Src::value_type value) {
+  static_assert(Src::exponent_bits >= Tgt::exponent_bits);
+  static_assert(Src::mantissa_bits > Tgt::mantissa_bits);
+  using ST = typename Src::value_type;
+  using TT = typename Tgt::value_type;
+
+  ST src_exponent = value & Src::exponent_mask;
+  ST src_mantissa = value & Src::mantissa_mask;
+  // Fast-path: If there is no difference in exponent sizes (e.g. fp32 -> bf16)
+  // and we round toward zero, then we can just drop the least significant bits.
+  if constexpr (
+      Src::exponent_bits == Tgt::exponent_bits && Src::has_infinity &&
+      Tgt::has_infinity && RoundingMode == RoundingMode::ToZero) {
+    TT result = value >> (Src::bits - Tgt::bits);
+    // Turn signaling NaN into quiet NaN. This also avoids that the mantissa
+    // is completely zero after truncation (which would be misinterpreted as
+    // INF).
+    if (src_exponent == Src::exponent_mask && src_mantissa != 0) {
+      result |= Tgt::quiet_nan_bit;
+    }
+    return result;
   }
 
-  uint32_t sign = ((x >> f16_num_bits) & f16_sign_bit);
-
-  // Get rid of +Inf/-Inf, +0/-0.
-  if (u > 0x477fefff) {
-    return static_cast<float16>(sign | f16_exponent_bits);
-  }
-  if (u < 0x33000001) {
-    return static_cast<float16>(sign | 0x0000);
-  }
-
-  uint32_t exponent = ((u >> f32_num_mantissa_bits) & f32_exponent_mask);
-  uint32_t mantissa = (u & f32_mantissa_mask);
-
-  uint32_t shift;
-  if (exponent > f32_exponent_bias - f16_exponent_bias) {
-    shift = f32_num_mantissa_bits - f16_num_mantissa_bits;
-    exponent -= f32_exponent_bias - f16_exponent_bias;
-  } else {
-    shift = (f32_exponent_bias - 1) - exponent;
-    exponent = 0;
-    mantissa |=
-        (1u
-         << f32_num_mantissa_bits); // Bump the least significant exponent bit
-  }
-  const uint32_t lsb = (1u << shift);
-  const uint32_t lsb_s1 = (lsb >> 1);
-  const uint32_t lsb_m1 = (lsb - 1);
-
-  // Round to nearest even.
-  const uint32_t remainder = (mantissa & lsb_m1);
-  mantissa >>= shift;
-  if (remainder > lsb_s1 || (remainder == lsb_s1 && (mantissa & 0x1))) {
-    ++mantissa;
-    if (!(mantissa & f16_mantissa_mask)) {
-      ++exponent;
-      mantissa = 0;
+  ST tgt_sign =
+      (value & Src::sign_bit) >> (Src::sign_bit_pos - Tgt::sign_bit_pos);
+  constexpr bool denormal_becomes_zero =
+      Tgt::unbiased_exponent_min - Src::unbiased_exponent_min >
+      Src::mantissa_bits - Tgt::mantissa_bits;
+  if constexpr (denormal_becomes_zero) {
+    // Fast-path for zero exponentbits: This means the number was zero or a
+    // denormal number that will turn into zero in the Tgt format.
+    if (src_exponent == 0) {
+      return tgt_sign; // tgt_exponent == 0, tgt_mantissa == 0
     }
   }
 
-  return static_cast<float16>(
-      sign | (exponent << f16_num_mantissa_bits) | mantissa);
-}
+  int unbiased_exponent =
+      (src_exponent >> Src::mantissa_bits) - Src::exponent_bias;
+  if (unbiased_exponent < Tgt::unbiased_exponent_min) {
+    int shift = Tgt::unbiased_exponent_min - unbiased_exponent;
+    if (shift <= Tgt::mantissa_bits + 1) {
+      // Result is denormal.
+      ST src_mantissa_one = src_mantissa;
+      // Add explicit one if the source was not denormal.
+      if (denormal_becomes_zero || src_exponent != 0) {
+        src_mantissa_one |= TT{1} << Src::mantissa_bits;
+      } else {
+        shift--;
+      }
+      TT tgt_mantissa =
+          src_mantissa_one >> (Src::mantissa_bits - Tgt::mantissa_bits + shift);
 
-// Round to zero
-inline float16 cpu_float2half_rz(float f) {
-  static_assert(
-      sizeof(uint32_t) == sizeof(float),
-      "Programming error sizeof(uint32_t) != sizeof(float)");
-
-  const uint32_t* xp = reinterpret_cast<uint32_t*>(&f);
-  const uint32_t x = *xp;
-  const uint32_t u = (x & f32_all_non_sign_mask);
-
-  // Get rid of +NaN/-NaN case first.
-  if (u > 0x7f800000) {
-    return static_cast<float16>(f16_nan);
+      if constexpr (RoundingMode == RoundingMode::ToNearestTiesToEven) {
+        int half_pos = Src::mantissa_bits - Tgt::mantissa_bits + shift - 1;
+        ST half = 1 << half_pos;
+        ST remainder = src_mantissa_one & ((half << 1) - 1);
+        if (remainder > half ||
+            (remainder == half && (tgt_mantissa & 1) != 0)) {
+          tgt_mantissa += 1;
+        }
+      } else {
+        assert(RoundingMode == RoundingMode::ToZero);
+      }
+      return tgt_sign | tgt_mantissa; // tgt_exponent == 0
+    } else {
+      // Result is +/- zero
+      return tgt_sign; // tgt_exponent == 0, tgt_mantissa == 0
+    }
   }
 
-  uint32_t sign = ((x >> f16_num_bits) & f16_sign_bit);
-
-  // Get rid of +Inf/-Inf, +0/-0.
-  if (u > 0x477fefff) {
-    return static_cast<float16>(sign | f16_exponent_bits);
+  if (unbiased_exponent > Tgt::unbiased_exponent_max) {
+    if (unbiased_exponent == Src::exponent_bias + 1 && src_mantissa != 0) {
+      TT tgt_mantissa;
+      if constexpr (Tgt::has_nan_payload) {
+        // NaN; not a number
+        tgt_mantissa =
+            src_mantissa >> (Src::mantissa_bits - Tgt::mantissa_bits);
+        tgt_mantissa |= Tgt::quiet_nan_bit;
+      } else {
+        tgt_mantissa = Tgt::mantissa_mask;
+      }
+      return tgt_sign | Tgt::exponent_mask | tgt_mantissa;
+    } else {
+      if (RoundingMode == RoundingMode::ToZero &&
+          (!Src::has_infinity || src_exponent != Src::exponent_mask)) {
+        // Return largest finite number.
+        return tgt_sign | (Tgt::exponent_mask - Tgt::has_infinity) |
+            Tgt::mantissa_mask;
+      }
+      // Infinity or NaN for formats without infinity.
+      return tgt_sign | Tgt::overflow_value;
+    }
   }
-  if (u < 0x33000001) {
-    return static_cast<float16>(sign | 0x0000);
-  }
 
-  uint32_t exponent = ((u >> f32_num_mantissa_bits) & f32_exponent_mask);
-  uint32_t mantissa = (u & f32_mantissa_mask);
+  // Normal number.
+  TT tgt_mantissa = src_mantissa >> (Src::mantissa_bits - Tgt::mantissa_bits);
+  TT tgt_exponent = (unbiased_exponent + Tgt::exponent_bias)
+      << Tgt::mantissa_bits;
+  if constexpr (RoundingMode == RoundingMode::ToNearestTiesToEven) {
+    ST half = 1 << (Src::mantissa_bits - Tgt::mantissa_bits - 1);
+    ST remainder = src_mantissa & ((half << 1) - 1);
+    if (remainder > half || (remainder == half && (tgt_mantissa & 1) != 0)) {
+      if (tgt_mantissa < Tgt::mantissa_mask) {
+        tgt_mantissa += 1;
+      } else {
+        // Mantissa overflowed, increment exponent.
 
-  uint32_t shift;
-  if (exponent > f32_exponent_bias - f16_exponent_bias) {
-    shift = f32_num_mantissa_bits - f16_num_mantissa_bits;
-    exponent -= f32_exponent_bias - f16_exponent_bias;
+        // Normally we can just add to the exponent and will naturally end up
+        // on infinity on overflow. But we need special treatments for formats
+        // without infinity.
+        if (Tgt::has_infinity || tgt_exponent != Tgt::exponent_mask) {
+          tgt_mantissa = 0;
+          tgt_exponent += TT{1} << Tgt::mantissa_bits;
+        } else {
+          // Return NaN.
+          tgt_mantissa = Tgt::mantissa_mask;
+        }
+      }
+    }
   } else {
-    shift = (f32_exponent_bias - 1) - exponent;
-    exponent = 0;
-    mantissa |=
-        (1u
-         << f32_num_mantissa_bits); // Bump the least significant exponent bit
+    assert(RoundingMode == RoundingMode::ToZero);
   }
-
-  // Round to zero.
-  mantissa >>= shift;
-
-  return static_cast<float16>(
-      sign | (exponent << f16_num_mantissa_bits) | mantissa);
+  return tgt_sign | tgt_exponent | tgt_mantissa;
 }
+
+} // namespace detail
+
+inline float16 cpu_float2half_rn(float f) {
+  uint32_t f_u32;
+  std::memcpy(&f_u32, &f, sizeof(f_u32));
+  return detail::ieee754_trunc<
+      /*Src=*/detail::IEEE754Single,
+      /*Tgt=*/detail::IEEE754Half,
+      detail::RoundingMode::ToNearestTiesToEven>(f_u32);
+}
+
+inline float16 cpu_float2half_rz(float f) {
+  uint32_t f_u32;
+  std::memcpy(&f_u32, &f, sizeof(f_u32));
+  return detail::ieee754_trunc<
+      /*Src=*/detail::IEEE754Single,
+      /*Tgt=*/detail::IEEE754Half,
+      detail::RoundingMode::ToZero>(f_u32);
+};
 
 // Converts a 16-bit unsigned integer representation of a IEEE754 half-precision
 // float into an IEEE754 32-bit single-precision float
 inline float cpu_half2float_ref(const float16 h) {
+  constexpr uint32_t f16_num_exponent_bits = 5;
+  constexpr uint32_t f16_num_mantissa_bits = 10;
+  constexpr uint32_t f16_num_non_sign_bits =
+      f16_num_exponent_bits + f16_num_mantissa_bits;
+  constexpr uint32_t f16_exponent_bias = 15;
+  constexpr uint32_t f16_exponent_mask = 0b1'1111;
+  constexpr uint32_t f16_mantissa_mask = 0b11'1111'1111;
+
+  constexpr uint32_t f32_num_exponent_bits = 8;
+  constexpr uint32_t f32_num_mantissa_bits = 23;
+  constexpr uint32_t f32_num_non_sign_bits =
+      f32_num_exponent_bits + f32_num_mantissa_bits;
+  constexpr uint32_t f32_exponent_bias = 127;
+  constexpr uint32_t f32_exponent_mask = 0b1111'1111;
+  constexpr uint32_t f32_mantissa_mask = 0x7F'FF'FF;
+  constexpr uint32_t f32_most_significant_bit = 1u << 22;
+
   // Get sign and exponent alone by themselves
   uint32_t sign_bit = (h >> f16_num_non_sign_bits) & 1;
   uint32_t exponent = (h >> f16_num_mantissa_bits) & f16_exponent_mask;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/905

This adds a generic implementation of IEEE754 floatingpoint truncation.

This is in preparation for conversion to FP8 E5M2 and FP8 E4M3FN formats but for consistency also replaces the existing float2half conversion functions.

Reviewed By: r-barnes

Differential Revision: D69941314


