### PR TITLE
Reduce bulk init time and fix OOM

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
@@ -82,6 +82,10 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
     return impl_->set_range_to_storage(weights, start, length);
   }
 
+  void toggle_compaction(bool enable) {
+    impl_->toggle_compaction(enable);
+  }
+
   void get(
       at::Tensor indices,
       at::Tensor weights,

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -460,6 +460,7 @@ static auto embedding_rocks_db_wrapper =
         .def(
             "set_range_to_storage",
             &EmbeddingRocksDBWrapper::set_range_to_storage)
+        .def("toggle_compaction", &EmbeddingRocksDBWrapper::toggle_compaction)
         .def(
             "get",
             &EmbeddingRocksDBWrapper::get,

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -290,12 +290,67 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
     options.memtable_prefix_bloom_size_ratio = 0.05;
     options.memtable_whole_key_filtering = true;
     options.max_background_jobs = num_threads;
+    // disable auto compactions during bulk init, re-enable once done
+    // maximum number of concurrent flush operations
+    options.max_background_flushes = num_threads;
+    options.disable_auto_compactions = true;
     options.env->SetBackgroundThreads(4, rocksdb::Env::HIGH);
     options.env->SetBackgroundThreads(1, rocksdb::Env::LOW);
-
     options.max_open_files = -1;
 
+    initialize_dbs(num_shards, path, options, use_passed_in_path);
+    initialize_initializers(
+        num_shards,
+        max_D,
+        uniform_init_lower,
+        uniform_init_upper,
+        row_storage_bitwidth);
+    executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(num_shards);
+    ro_.verify_checksums = false;
+    ro_.async_io = true;
+    wo_.disableWAL = true;
+    wo_.sync = false;
+
+    // Setup staggered manual compaction data members
+    memtable_flush_period_ = memtable_flush_period;
+    if (memtable_flush_period_ > 0) {
+      done_staggered_flushes_ = false;
+      memtable_flush_offset_ = memtable_flush_offset;
+      l0_files_per_compact_ = l0_files_per_compact;
+      compaction_period_ = memtable_flush_period_ * l0_files_per_compact *
+          options.min_write_buffer_number_to_merge;
+      int64_t period_per_shard = memtable_flush_period_ / num_shards;
+      CHECK_GT(period_per_shard, 0);
+      // We want to stagger memory flushes (and then later
+      // stagger all compactions)
+
+      for (int64_t i = 0; i < num_shards; i++) {
+        shard_flush_compaction_deadlines_.push_back(
+            memtable_flush_offset_ + (i * period_per_shard));
+      }
+    }
+  }
+
+  ~EmbeddingRocksDB() override {
+    // clear all the snapshots if not released
+    if (snapshots_.size() > 0) {
+      LOG(WARNING)
+          << snapshots_.size()
+          << " snapshots have not been released when db is closing. Releasing them now.";
+    }
+    snapshots_.clear();
+    for (auto shard = 0; shard < dbs_.size(); ++shard) {
+      dbs_[shard]->Close();
+    }
+  }
+
+  void initialize_dbs(
+      int64_t num_shards,
+      std::string path,
+      rocksdb::Options& options,
+      bool use_passed_in_path) {
 #ifdef FBGEMM_FBCODE
+    std::string used_path = "";
     auto serviceInfo = std::make_shared<facebook::fb_rocksdb::ServiceInfo>();
     serviceInfo->oncall = "pyper_training";
     serviceInfo->service_name = "ssd_offloading_rocksb";
@@ -307,7 +362,6 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
       path = ssd_mount_point;
       tbe_uuid = facebook::strings::generateUUID();
     }
-    std::string used_path = "";
 #endif
     for (auto i = 0; i < num_shards; ++i) {
 #ifdef FBGEMM_FBCODE
@@ -350,6 +404,19 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
       }
       CHECK(s.ok()) << s.ToString();
       dbs_.emplace_back(db);
+    }
+#ifdef FBGEMM_FBCODE
+    LOG(INFO) << "TBE actual used_path: " << used_path;
+#endif
+  }
+
+  void initialize_initializers(
+      int64_t num_shards,
+      int64_t max_D,
+      float uniform_init_lower,
+      float uniform_init_upper,
+      int64_t row_storage_bitwidth) {
+    for (auto i = 0; i < num_shards; ++i) {
       auto* gen = at::check_generator<at::CPUGeneratorImpl>(
           at::detail::getDefaultCPUGenerator());
       {
@@ -361,46 +428,6 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
             uniform_init_upper,
             row_storage_bitwidth));
       }
-    }
-#ifdef FBGEMM_FBCODE
-    LOG(INFO) << "TBE actual used_path: " << used_path;
-#endif
-    executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(num_shards);
-    ro_.verify_checksums = false;
-    ro_.async_io = true;
-    wo_.disableWAL = true;
-    wo_.sync = false;
-
-    // Setup staggered manual compaction data members
-    memtable_flush_period_ = memtable_flush_period;
-    if (memtable_flush_period_ > 0) {
-      done_staggered_flushes_ = false;
-      memtable_flush_offset_ = memtable_flush_offset;
-      l0_files_per_compact_ = l0_files_per_compact;
-      compaction_period_ = memtable_flush_period_ * l0_files_per_compact *
-          options.min_write_buffer_number_to_merge;
-      int64_t period_per_shard = memtable_flush_period_ / num_shards;
-      CHECK_GT(period_per_shard, 0);
-      // We want to stagger memory flushes (and then later
-      // stagger all compactions)
-
-      for (int64_t i = 0; i < num_shards; i++) {
-        shard_flush_compaction_deadlines_.push_back(
-            memtable_flush_offset_ + (i * period_per_shard));
-      }
-    }
-  }
-
-  ~EmbeddingRocksDB() override {
-    // clear all the snapshots if not released
-    if (snapshots_.size() > 0) {
-      LOG(WARNING)
-          << snapshots_.size()
-          << " snapshots have not been released when db is closing. Releasing them now.";
-    }
-    snapshots_.clear();
-    for (auto shard = 0; shard < dbs_.size(); ++shard) {
-      dbs_[shard]->Close();
     }
   }
 
@@ -547,6 +574,48 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
         at::arange(start, start + length, at::TensorOptions().dtype(at::kLong));
     const auto count = at::tensor({length}, at::ScalarType::Long);
     folly::coro::blockingWait(set_kv_db_async(seq_indices, weights, count));
+  }
+
+  virtual rocksdb::Status
+  set_rocksdb_option(int shard, std::string key, std::string value) {
+    return dbs_[shard]->SetOptions({{key, value}});
+  }
+
+  void toggle_compaction(bool enable) {
+    int max_retries = 10;
+    std::vector<folly::Future<bool>> futures;
+    for (auto shard = 0; shard < dbs_.size(); ++shard) {
+      auto f = folly::via(executor_.get()).thenValue([=](folly::Unit) -> bool {
+        for (int attempt = 0; attempt < max_retries; ++attempt) {
+          auto s = set_rocksdb_option(
+              shard, "disable_auto_compactions", enable ? "false" : "true");
+          if (s.ok()) {
+            return true;
+          }
+          LOG(WARNING) << "Failed to toggle compaction to " << enable
+                       << " for shard " << shard << ", attempt=" << attempt
+                       << ", max_retries=" << max_retries << std::endl;
+        }
+        return false;
+      });
+      futures.push_back(std::move(f));
+    }
+    auto results = folly::coro::blockingWait(folly::collectAll(futures));
+    for (auto& result : results) {
+      if (result.hasValue()) {
+        if (result.value() == false) {
+          folly::throw_exception<std::runtime_error>(fmt::format(
+              "Failed to toggle compaction to {} after exhausing all retries with max_retry={}\n",
+              enable,
+              max_retries));
+        }
+      } else {
+        folly::throw_exception<std::runtime_error>(fmt::format(
+            "Failed to toggle compaction to {} with exception {}\n",
+            enable,
+            result.exception().what()));
+      }
+    }
   }
 
   int64_t get_max_D() {

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/test/ssd_table_batched_embeddings_test.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/test/ssd_table_batched_embeddings_test.cpp
@@ -1,0 +1,110 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <filesystem>
+#include "deeplearning/fbgemm/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h"
+
+using namespace ::testing;
+
+class MockEmbeddingRocksDB : public ssd::EmbeddingRocksDB {
+ public:
+  MockEmbeddingRocksDB(
+      std::string path,
+      int64_t num_shards,
+      int64_t num_threads,
+      int64_t memtable_flush_period,
+      int64_t memtable_flush_offset,
+      int64_t l0_files_per_compact,
+      int64_t max_D,
+      int64_t rate_limit_mbps,
+      int64_t size_ratio,
+      int64_t compaction_trigger,
+      int64_t write_buffer_size,
+      int64_t max_write_buffer_num,
+      float uniform_init_lower,
+      float uniform_init_upper,
+      int64_t row_storage_bitwidth = 32,
+      int64_t cache_size = 0,
+      bool use_passed_in_path = false,
+      int64_t tbe_unqiue_id = 0,
+      int64_t l2_cache_size_gb = 0,
+      bool enable_async_update = false)
+      : ssd::EmbeddingRocksDB(
+            path,
+            num_shards,
+            num_threads,
+            memtable_flush_period,
+            memtable_flush_offset,
+            l0_files_per_compact,
+            max_D,
+            rate_limit_mbps,
+            size_ratio,
+            compaction_trigger,
+            write_buffer_size,
+            max_write_buffer_num,
+            uniform_init_lower,
+            uniform_init_upper,
+            row_storage_bitwidth,
+            cache_size,
+            use_passed_in_path,
+            tbe_unqiue_id,
+            l2_cache_size_gb,
+            enable_async_update){};
+  MOCK_METHOD(
+      rocksdb::Status,
+      set_rocksdb_option,
+      (int, std::string, std::string),
+      (override));
+};
+
+std::unique_ptr<MockEmbeddingRocksDB> getMockEmbeddingRocksDB(
+    int num_shards,
+    std::string dir) {
+  std::filesystem::path temp_dir = std::filesystem::temp_directory_path();
+  std::filesystem::path rocksdb_dir = temp_dir / dir;
+  std::filesystem::create_directories(rocksdb_dir);
+  auto EMBEDDING_DIMENSION = 8;
+
+  return std::make_unique<MockEmbeddingRocksDB>(
+      rocksdb_dir,
+      num_shards, // num_shards,
+      8, // num_threads,
+      0, // memtable_flush_period,
+      0, // memtable_flush_offset,
+      4, // l0_files_per_compact,
+      EMBEDDING_DIMENSION, // max embedding dimension,
+      0, // rate_limit_mbps,
+      1, // size_ratio,
+      8, // compaction_trigger,
+      536870912, // 512M write_buffer_size,
+      8, // max_write_buffer_num,
+      -0.01, // uniform_init_lower,
+      0.01, // uniform_init_upper,
+      32, // row_storage_bitwidth = 32,
+      0, // cache_size = 0
+      false,
+      0,
+      0,
+      false);
+}
+TEST(SSDTableBatchedEmbeddingsTest, TestToggleCompactionSuccess) {
+  int num_shards = 8;
+  auto mock_embedding_rocks = getMockEmbeddingRocksDB(num_shards, "success");
+  EXPECT_CALL(*mock_embedding_rocks, set_rocksdb_option)
+      .Times(num_shards)
+      .WillRepeatedly(Return(rocksdb::Status::OK()));
+  mock_embedding_rocks->toggle_compaction(true);
+}
+
+TEST(SSDTableBatchedEmbeddingsTest, TestToggleCompactionFail) {
+  int num_shards = 8;
+  auto mock_embedding_rocks = getMockEmbeddingRocksDB(num_shards, "fail");
+  int max_retry = 10;
+  EXPECT_CALL(*mock_embedding_rocks, set_rocksdb_option)
+      .Times(max_retry * num_shards)
+      .WillRepeatedly(Return(rocksdb::Status::NotFound()));
+  // eventually throw after exhaust all retries
+  EXPECT_THROW(
+      mock_embedding_rocks->toggle_compaction(true), std::runtime_error);
+}


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/908

Disable compaction when bulk initialize TBE in SSD, this reduce the initialization time from over 5mins to 2-3 mins. Also use bytes as the chunk size rather than row count, as each row might have different dimensions in different TBE, to avoid OOM issue.

Differential Revision: D70921864


