### PR TITLE
Expose EEG indices estimation to Python

### DIFF
--- a/fbgemm_gpu/FbgemmGpu.cmake
+++ b/fbgemm_gpu/FbgemmGpu.cmake
@@ -18,6 +18,7 @@ include(${CMAKEMODULES}/Utilities.cmake)
 set(tbe_eeg_cpu_sources
   src/tbe/eeg/eeg_models.cpp
   src/tbe/eeg/eeg_utils.cpp
+  src/tbe/eeg/indices_estimator_ops.cpp
   src/tbe/eeg/indices_estimator.cpp
   src/tbe/eeg/indices_generator_ops.cpp
   src/tbe/eeg/indices_generator.cpp)

--- a/fbgemm_gpu/fbgemm_gpu/tbe/bench/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/bench/__init__.py
@@ -7,6 +7,8 @@
 
 # pyre-unsafe
 
+import torch
+
 from .bench_config import (  # noqa F401
     TBEBenchmarkingConfig,
     TBEBenchmarkingConfigLoader,
@@ -33,3 +35,14 @@ from .tbe_data_config_param_models import (  # noqa F401
     PoolingParams,
 )
 from .utils import fill_random_scale_bias  # noqa F401
+
+try:
+    torch.ops.load_library(
+        "//deeplearning/fbgemm/fbgemm_gpu/src/tbe/eeg:indices_estimator"
+    )
+except Exception:
+    pass
+
+#: The max number of heavy heavy hitters, as defined in
+#: fbgemm_gpu/src/tbe/eeg/indices_estimator.h
+EEG_MAX_HEAVY_HITTERS: int = 20

--- a/fbgemm_gpu/src/tbe/eeg/indices_estimator.h
+++ b/fbgemm_gpu/src/tbe/eeg/indices_estimator.h
@@ -26,6 +26,8 @@ class IndicesEstimator {
  public:
   explicit IndicesEstimator(const std::filesystem::path& tensorPath);
 
+  explicit IndicesEstimator(const torch::Tensor& indices);
+
   // maximum likelihood estimate of the heavy hitters + Zipf parameters
   // Returns std::nullopt if there is no index data
   std::optional<IndicesDistributionParameters> estimate();

--- a/fbgemm_gpu/src/tbe/eeg/indices_estimator_ops.cpp
+++ b/fbgemm_gpu/src/tbe/eeg/indices_estimator_ops.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <torch/torch.h>
+#include <tuple>
+#include "indices_estimator.h"
+
+namespace fbgemm_gpu::tbe {
+
+/// @ingroup tbe-eeg
+///
+/// @brief Torch interface function for estimating the distribution of TBE
+/// indices from a given set of indices.
+///
+/// @param indices A tensor of either int32_t or int64_t indices
+///
+/// @return A tuple of parameters that describe the distribution of TBE indices
+///     - A tensor of probabilities describing the heavy hitters
+///     - The Q parameter of a Zipfian distribution
+///     - The S parameter of a Zipfian distribution
+///     - The maximum index value
+///     - The number of indices
+std::tuple<torch::Tensor, double, double, int64_t, int64_t>
+estimate_indices_distribution(const at::Tensor& indices) {
+  TORCH_CHECK(
+      indices.numel() > 0, "indices numel is ", indices.numel(), "(< 1)");
+  TORCH_CHECK(
+      indices.dtype() == at::kInt || indices.dtype() == at::kLong,
+      "indices dtype is ",
+      indices.dtype(),
+      "(!= I32 or I64)");
+
+  const auto params = *(IndicesEstimator(indices).estimate());
+
+  const auto hitters = torch::from_blob(
+      (void*)params.heavyHitters.data(),
+      params.heavyHitters.size(),
+      torch::TensorOptions().dtype(at::kDouble));
+
+  return {
+      hitters,
+      params.zipfParams.q,
+      params.zipfParams.s,
+      params.maxIndex,
+      params.numIndices,
+  };
+}
+
+} // namespace fbgemm_gpu::tbe
+
+TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  m.def(
+      "tbe_estimate_indices_distribution("
+      "Tensor indices)"
+      "-> (Tensor, float, float, int, int)",
+      TORCH_FN(fbgemm_gpu::tbe::estimate_indices_distribution));
+}

--- a/fbgemm_gpu/src/tbe/eeg/indices_generator_ops.cpp
+++ b/fbgemm_gpu/src/tbe/eeg/indices_generator_ops.cpp
@@ -11,6 +11,18 @@
 
 namespace fbgemm_gpu::tbe {
 
+/// @ingroup tbe-eeg
+///
+/// @brief Torch interface function for generating TBE indices given the
+/// parameters that describe its distribution
+///
+/// @param heavy_hitters A tensor of probabilities describing the heavy hitters
+/// @param zipf_q The Q parameter of a Zipfian distribution
+/// @param zipf_s The S parameter of a Zipfian distribution
+/// @param max_index The maximum index value
+/// @param num_indices The number of indices to generate
+///
+/// @return A tensor of in64_t TBE indices
 at::Tensor generate_indices_from_distribution(
     at::Tensor heavy_hitters,
     double zipf_q,

--- a/fbgemm_gpu/test/tbe/eeg/tbe_indices_estimator_test.py
+++ b/fbgemm_gpu/test/tbe/eeg/tbe_indices_estimator_test.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+# pyre-strict
+
+import random
+import unittest
+
+import fbgemm_gpu  # noqa F401
+import hypothesis.strategies as st
+
+import torch
+from fbgemm_gpu.tbe.bench import EEG_MAX_HEAVY_HITTERS
+from hypothesis import given, settings
+
+
+class TBEIndicesEstimatorTest(unittest.TestCase):
+    # pyre-ignore[56]
+    @given(
+        dtype=st.sampled_from([torch.float32, torch.float64]),
+    )
+    @settings(max_examples=20, deadline=None)
+    def test_indices_estimation(
+        self,
+        dtype: torch.dtype,
+    ) -> None:
+        max_i = random.randint(0, 200)
+        num_i = random.randint(100, 1000)
+        indices = torch.randint(0, max_i, (num_i,), dtype=torch.int64)
+
+        heavy_hitters, q, s, max_index, num_indices = (
+            torch.ops.fbgemm.tbe_estimate_indices_distribution(indices)
+        )
+
+        print(heavy_hitters, q, s, max_index, num_indices)
+
+        assert (
+            heavy_hitters.numel() <= EEG_MAX_HEAVY_HITTERS
+        ), "Materialized too many heavy hitters"
+        assert torch.all(heavy_hitters >= 0) and torch.all(
+            heavy_hitters < 1
+        ), "Invalid heavy hitter values"
+        assert q > 0, "Invalid q"
+        assert s >= 0, "Invalid s"
+        assert max_index >= 0 and max_index <= max_i, "Invalid max_index"
+        assert num_indices == num_i, "num_indices does not match num_i"


### PR DESCRIPTION
Summary: - Expose EEG indices estimation to Python

Reviewed By: sryap

Differential Revision: D71236926


