### PR TITLE
follow up to reflect rowwise scale inputs for x, w in `quantize_ops` scripts

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -125,7 +125,11 @@ at::Tensor f8f8bf16_cublas(
 at::Tensor bf16_fast_gemv(at::Tensor X, at::Tensor W);
 at::Tensor
 bf16fp8bf16_fast_gemv(at::Tensor X, at::Tensor W, at::Tensor w_scale);
-at::Tensor fp8fp8bf16_fast_gemv(at::Tensor X, at::Tensor W, at::Tensor scale);
+at::Tensor fp8fp8bf16_fast_gemv(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor x_scale,
+    at::Tensor w_scale);
 
 at::Tensor f8i4bf16_rowwise(
     at::Tensor XQ,
@@ -214,7 +218,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def("preshuffle_i4(Tensor WQ, Tensor w_scale) -> (Tensor, Tensor)");
   m.def("bf16_fast_gemv(Tensor X, Tensor W) -> Tensor");
   m.def("bf16fp8bf16_fast_gemv(Tensor X, Tensor W, Tensor w_scale) -> Tensor");
-  m.def("fp8fp8bf16_fast_gemv(Tensor X, Tensor W, Tensor scale) -> Tensor");
+  m.def(
+      "fp8fp8bf16_fast_gemv(Tensor X, Tensor W, Tensor x_scale, Tensor w_scale) -> Tensor");
   m.def("f8f8bf16_lite(Tensor XQ, Tensor WQ, Tensor scale) -> Tensor");
   m.def(
       "bf16i4bf16_rowwise(Tensor X, Tensor WQ, Tensor w_scale, Tensor w_zp) -> Tensor");
@@ -456,8 +461,11 @@ at::Tensor bf16fp8bf16_fast_gemv_meta(
   return Y;
 }
 
-at::Tensor
-fp8fp8bf16_fast_gemv_meta(at::Tensor X, at::Tensor W, at::Tensor /* scale */) {
+at::Tensor fp8fp8bf16_fast_gemv_meta(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor /* x_scale */,
+    at::Tensor /* w_scale */) {
   const at::SymInt M = X.sym_size(0);
   const at::SymInt N = W.sym_size(0);
   auto Y = at::empty_symint({M, N}, X.options().dtype(at::kBFloat16));

--- a/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
@@ -1147,9 +1147,10 @@ class FP8Tests(unittest.TestCase):
                 wq, w_scale = torch.ops.fbgemm.quantize_fp8_per_tensor(w)
                 z = gemv_op(x, wq, w_scale)
             elif quantize_w and quantize_x:
-                xq, x_scale = torch.ops.fbgemm.quantize_fp8_per_tensor(x)
-                wq, w_scale = torch.ops.fbgemm.quantize_fp8_per_tensor(w)
-                z = gemv_op(xq, wq, x_scale * w_scale)
+                # row-wise scaling
+                xq, x_scale = torch.ops.fbgemm.quantize_fp8_per_row(x)
+                wq, w_scale = torch.ops.fbgemm.quantize_fp8_per_row(w)
+                z = gemv_op(xq, wq, x_scale, w_scale)
             else:
                 z = gemv_op(x, w)
             z_ref = (x @ w.T).to(torch.bfloat16).to("cuda")
@@ -1220,7 +1221,10 @@ class FP8Tests(unittest.TestCase):
             (2, 8192, 1024),
             (2, 7168, 8192),
             (2, 8192, 3584),
+            (3, 1280, 8192),
             (3, 8192, 1024),
+            (3, 7168, 8192),
+            (3, 8192, 3584),
             (4, 1280, 8192),
             (4, 8192, 1024),
             (4, 7168, 8192),


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/926

As title.

Differential Revision: D71349550


