### PR TITLE
Replace rms_norm as norm

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.cpp
@@ -39,7 +39,7 @@ at::Tensor nope_qkv_varseq_prefill(
     std::optional<at::Tensor> varseq_cache_seqpos,
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> qparam_v,
-    bool k_rms_norm);
+    bool k_norm);
 
 at::Tensor nope_qkv_decoding(
     at::Tensor XQ,
@@ -55,7 +55,7 @@ at::Tensor nope_qkv_decoding(
     std::optional<at::Tensor> cache_seqpos,
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> qparam_v,
-    bool k_rms_norm);
+    bool k_norm);
 
 at::Tensor rope_qkv_varseq_prefill(
     at::Tensor XQ,
@@ -79,7 +79,7 @@ at::Tensor rope_qkv_varseq_prefill(
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> qparam_v,
     bool write_k_back,
-    bool k_rms_norm);
+    bool k_norm);
 
 at::Tensor rope_qkv_decoding(
     at::Tensor XQ,
@@ -103,7 +103,7 @@ at::Tensor rope_qkv_decoding(
     double hi_freq_factor,
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> qparam_v,
-    bool k_rms_norm);
+    bool k_norm);
 
 at::Tensor xpos_qkv_varseq_prefill(
     at::Tensor XQ,
@@ -183,13 +183,13 @@ at::Tensor mqa_attn(
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def("rope_qkv_varseq_prefill(Tensor XQ, Tensor(a!) XK, Tensor XV, Tensor(b!) cache_K, Tensor(c!) cache_V,  Tensor varseq_batch, Tensor varseq_seqpos, float theta, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
       DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192"
-      ", float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32,  Tensor? qparam_k=None, Tensor? qparam_v=None, bool write_k_back=False, bool k_rms_norm=False) -> Tensor");
+      ", float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32,  Tensor? qparam_k=None, Tensor? qparam_v=None, bool write_k_back=False, bool k_norm=False) -> Tensor");
   m.def("rope_qkv_decoding(Tensor XQ, Tensor XK, Tensor XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor seqpos, float theta, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
-      DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None,  int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192, float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_rms_norm=False) -> Tensor");
+      DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None,  int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192, float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False) -> Tensor");
   m.def("nope_qkv_varseq_prefill(Tensor XQ, Tensor XK, Tensor XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor varseq_batch, Tensor varseq_seqpos, Tensor? block_tables=None, int page_size=" STRING(
-      DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_rms_norm=False) -> Tensor");
+      DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False) -> Tensor");
   m.def("nope_qkv_decoding(Tensor XQ, Tensor XK, Tensor XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor seqpos, Tensor? block_tables=None, int page_size=" STRING(
-      DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_rms_norm=False) -> Tensor");
+      DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False) -> Tensor");
   m.def("xpos_qkv_varseq_prefill(Tensor XQ, Tensor XK, Tensor XV, Tensor(a!) cache_K, Tensor(b!) cache_V, Tensor varseq_batch, Tensor varseq_seqpos, float theta, float gamma, float scale_base, float exponent_offset, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
       DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192, float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32,  Tensor? qparam_k=None, Tensor? qparam_v=None) -> Tensor");
   m.def("xpos_qkv_decoding(Tensor XQ, Tensor XK, Tensor XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor seqpos, float theta, float gamma, float scale_base, float exponent_offset, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
@@ -245,7 +245,7 @@ at::Tensor rope_qkv_varseq_prefill_meta(
     std::optional<at::Tensor> /* qparam_k */,
     std::optional<at::Tensor> /* qparam_v */,
     bool /* write_k_back */,
-    bool /* k_rms_norm */
+    bool /* k_norm */
 ) {
   return at::empty_like(XQ);
 }
@@ -272,7 +272,7 @@ at::Tensor rope_qkv_decoding_meta(
     double /* hi_freq_factor */,
     std::optional<at::Tensor> /* qparam_k */,
     std::optional<at::Tensor> /* qparam_v */,
-    bool /* k_rms_norm */
+    bool /* k_norm */
 ) {
   return at::empty_like(XQ);
 }
@@ -290,7 +290,7 @@ at::Tensor nope_qkv_varseq_prefill_meta(
     std::optional<at::Tensor> /* varseq_cache_seqpos */,
     std::optional<at::Tensor> /* qparam_k */,
     std::optional<at::Tensor> /* qparam_v */,
-    bool /* k_rms_norm */
+    bool /* k_norm */
 ) {
   return at::empty_like(XQ);
 }
@@ -309,7 +309,7 @@ at::Tensor nope_qkv_decoding_meta(
     std::optional<at::Tensor> /* cache_seqpos */,
     std::optional<at::Tensor> /* qparam_k */,
     std::optional<at::Tensor> /* qparam_v */,
-    bool /* k_rms_norm */
+    bool /* k_norm */
 ) {
   return at::empty_like(XQ);
 }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/918

qk norm applies L2 norm, not rms norm. So we just use k_norm instead of k_rms_norm.

Reviewed By: jasonjk-park, Aya-ZIbra

Differential Revision: D71268903


