### PR TITLE
Use enum to select floating point format in FbgemmEmbedding APIs

### DIFF
--- a/bench/EmbeddingSpMDM8BitBenchmark.cc
+++ b/bench/EmbeddingSpMDM8BitBenchmark.cc
@@ -67,10 +67,10 @@ int run_benchmark(
     int embedding_dim,
     int average_len,
     bool normalize_by_lengths,
-    bool use_32_bit_indices = false,
-    bool prefetch = false,
-    bool stress_multi_threading = false,
-    bool is_bf16_out = false) {
+    bool use_32_bit_indices,
+    bool prefetch,
+    bool stress_multi_threading,
+    FloatFormat out_format) {
   // Create embedding table
   default_random_engine generator;
   normal_distribution<float> embedding_distribution;
@@ -190,10 +190,22 @@ int run_benchmark(
 
     auto kernel_32 =
         GenerateEmbeddingSpMDM<uint8_t, int32_t, std::int32_t, OutType>(
-            embedding_dim, has_weight, normalize_by_lengths, prefetch ? 16 : 0);
+            embedding_dim,
+            has_weight,
+            normalize_by_lengths,
+            prefetch ? 16 : 0,
+            /*is_weight_positional=*/false,
+            /*use_offsets=*/true,
+            /*out_format=*/out_format);
     auto kernel_64 =
         GenerateEmbeddingSpMDM<uint8_t, int64_t, std::int32_t, OutType>(
-            embedding_dim, has_weight, normalize_by_lengths, prefetch ? 16 : 0);
+            embedding_dim,
+            has_weight,
+            normalize_by_lengths,
+            prefetch ? 16 : 0,
+            /*is_weight_positional=*/false,
+            /*use_offsets=*/true,
+            /*out_format=*/out_format);
 
 #ifdef _OPENMP
 #pragma omp barrier
@@ -265,10 +277,11 @@ int run_benchmark(
               tmp1 = output[i];
               tmp2 = output_ref[i];
             } else if (std::is_same<OutType, uint16_t>::value) {
-              if (is_bf16_out) {
+              if (out_format == FloatFormat::BFLOAT16) {
                 tmp1 = cpu_bf162float(output[i]);
                 tmp2 = cpu_bf162float(output_ref[i]);
               } else {
+                assert(out_format == FloatFormat::FLOAT16);
                 tmp1 = cpu_half2float(output[i]);
                 tmp2 = cpu_half2float(output_ref[i]);
               }
@@ -291,9 +304,10 @@ int run_benchmark(
         if (std::is_same<OutType, float>::value) {
           cout << "out type fp32";
         } else if (std::is_same<OutType, uint16_t>::value) {
-          if (is_bf16_out) {
+          if (out_format == FloatFormat::BFLOAT16) {
             cout << "out type bf16";
           } else {
+            assert(out_format == FloatFormat::FLOAT16);
             cout << "out type fp16";
           }
         } else {
@@ -372,20 +386,22 @@ int main() {
         num_rows,
         embedding_dim,
         average_len,
-        false,
-        false,
-        false,
-        stress_multi_threading);
+        /*normalize_by_lengths=*/false,
+        /*use_32_bit_indices=*/false,
+        /*prefetch=*/false,
+        stress_multi_threading,
+        FloatFormat::FLOAT16);
 #else
     run_benchmark<float>(
         batch_size,
         num_rows,
         embedding_dim,
         average_len,
-        false,
-        false,
-        false,
-        stress_multi_threading);
+        /*normalize_by_lengths=*/false,
+        /*use_32_bit_indices=*/false,
+        /*prefetch=*/false,
+        stress_multi_threading,
+        FloatFormat::DEFAULT);
 #endif
     if (stress_multi_threading) {
       return 0;
@@ -394,27 +410,75 @@ int main() {
     cout << "64 bit indices with prefetching, ";
 #if defined(OUT_TYPE_FLOAT16)
     run_benchmark<float16>(
-        batch_size, num_rows, embedding_dim, average_len, false, false, true);
+        batch_size,
+        num_rows,
+        embedding_dim,
+        average_len,
+        /*normalize_by_lengths=*/false,
+        /*use_32_bit_indices=*/false,
+        /*prefetch=*/true,
+        /*stress_multi_threading=*/false,
+        FloatFormat::FLOAT16);
 #else
     run_benchmark<float>(
-        batch_size, num_rows, embedding_dim, average_len, false, false, true);
+        batch_size,
+        num_rows,
+        embedding_dim,
+        average_len,
+        /*normalize_by_lengths=*/false,
+        /*use_32_bit_indices=*/false,
+        /*prefetch=*/true,
+        /*stress_multi_threading=*/false,
+        FloatFormat::DEFAULT);
 #endif
     cout << "32 bit indices, ";
 #if defined(OUT_TYPE_FLOAT16)
     run_benchmark<float16>(
-        batch_size, num_rows, embedding_dim, average_len, false, true);
+        batch_size,
+        num_rows,
+        embedding_dim,
+        average_len,
+        /*normalize_by_lengths=*/false,
+        /*use_32_bit_indices=*/true,
+        /*prefetch=*/false,
+        /*stress_multi_threading=*/false,
+        FloatFormat::FLOAT16);
 #else
     run_benchmark<float>(
-        batch_size, num_rows, embedding_dim, average_len, false, true);
+        batch_size,
+        num_rows,
+        embedding_dim,
+        average_len,
+        /*normalize_by_lengths=*/false,
+        /*use_32_bit_indices=*/true,
+        /*prefetch=*/false,
+        /*stress_multi_threading=*/false,
+        FloatFormat::DEFAULT);
 #endif
 
     cout << "32 bit indices with prefetching, ";
 #if defined(OUT_TYPE_FLOAT16)
     run_benchmark<float16>(
-        batch_size, num_rows, embedding_dim, average_len, false, true, true);
+        batch_size,
+        num_rows,
+        embedding_dim,
+        average_len,
+        /*normalize_by_lengths=*/false,
+        /*use_32_bit_indices=*/true,
+        /*prefetch=*/true,
+        /*stress_multi_threading=*/false,
+        FloatFormat::FLOAT16);
 #else
     run_benchmark<float>(
-        batch_size, num_rows, embedding_dim, average_len, false, true, true);
+        batch_size,
+        num_rows,
+        embedding_dim,
+        average_len,
+        /*normalize_by_lengths=*/false,
+        /*use_32_bit_indices=*/true,
+        /*prefetch=*/true,
+        /*stress_multi_threading=*/false,
+        FloatFormat::DEFAULT);
 #endif
 
     // running with normalize by lengths
@@ -427,9 +491,11 @@ int main() {
     //     num_rows,
     //     embedding_dim,
     //     average_len,
-    //     false,
-    //     true,
-    //     true);
+    //     /*normalize_by_lengths=*/false,
+    //     /*use_32_bit_indices=*/true,
+    //     /*prefetch=*/true,
+    //     /*stress_multi_threading=*/false,
+    //     FloatFormat::DEFAULT);
   }
   return 0;
 }

--- a/bench/EmbeddingSpMDMNBit2Benchmark.cc
+++ b/bench/EmbeddingSpMDMNBit2Benchmark.cc
@@ -313,7 +313,7 @@ int run_benchmark(
         /*output_stride=*/-1,
         /*input_stride=*/-1,
         /*scale_bias_last=*/true,
-        /*is_bf16_out=*/false,
+        /*out_format=*/FloatFormat::DEFAULT,
         /*no_bag=*/false,
         /*output_bit_rate=*/-1);
     auto kernel_64_autovec = GenerateEmbeddingSpMDMNBitWithStrides_autovec<
@@ -330,7 +330,7 @@ int run_benchmark(
         /*output_stride=*/-1,
         /*input_stride=*/-1,
         /*scale_bias_last=*/true,
-        /*is_bf16_out=*/false,
+        /*out_format=*/FloatFormat::DEFAULT,
         /*no_bag=*/false,
         /*output_bit_rate=*/-1);
 #endif

--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -11,6 +11,7 @@
 #include <functional>
 
 #include "fbgemm/FbgemmBuild.h"
+#include "fbgemm/Types.h"
 
 namespace fbgemm {
 
@@ -80,8 +81,8 @@ GenerateEmbeddingSpMDM(
     int prefetch = 16,
     bool is_weight_positional = false,
     bool use_offsets = true,
-    bool is_bf16_out = false,
-    bool is_bf16_in = false);
+    FloatFormat out_format = FloatFormat::DEFAULT,
+    FloatFormat in_format = FloatFormat::DEFAULT);
 
 /**
  * @param output_stride If -1, output_stride is same as block_size
@@ -113,8 +114,8 @@ GenerateEmbeddingSpMDMWithStrides(
     std::int64_t input_stride = -1,
     bool scale_bias_last = true,
     bool no_bag = false,
-    bool is_bf16_out = false,
-    bool is_bf16_in = false);
+    FloatFormat out_format = FloatFormat::DEFAULT,
+    FloatFormat in_format = FloatFormat::DEFAULT);
 
 /**
  * @tparam IndexType can be int32_t or int64_t
@@ -169,7 +170,7 @@ GenerateEmbeddingSpMDMNBitWithStrides(
     std::int64_t output_stride = -1,
     std::int64_t input_stride = -1,
     bool scale_bias_last = true,
-    const bool is_bf16_out = false,
+    FloatFormat out_format = FloatFormat::DEFAULT,
     const bool no_bag = false,
     int output_bit_rate = -1);
 
@@ -200,7 +201,7 @@ GenerateEmbeddingSpMDMFP8WithStrides(
     std::int64_t input_stride = -1,
     int exponent_bits = 4,
     int exponent_bias = 7,
-    bool is_bf16_out = false);
+    FloatFormat out_format = FloatFormat::DEFAULT);
 
 template <
     typename InType,
@@ -347,7 +348,7 @@ FBGEMM_API bool EmbeddingSpMDMBlockSize1_(
     float* out,
     bool is_weight_positional = false,
     bool use_offsets = true,
-    bool is_bf16 = false);
+    FloatFormat format = FloatFormat::DEFAULT);
 
 template <typename IndexType, bool HAS_WEIGHTS>
 void compressed_indices_remap_avx512(

--- a/include/fbgemm/Types.h
+++ b/include/fbgemm/Types.h
@@ -15,11 +15,17 @@ namespace fbgemm {
 using float16 = std::uint16_t;
 using bfloat16 = std::uint16_t;
 
-inline int64_t round_up(int64_t val, int64_t unit) {
+enum class FloatFormat : std::uint8_t {
+  DEFAULT, // `float` (aka IEEE754 "single").
+  FLOAT16, // float16 (aka IEEE754 "half") passed as `uint16_t`
+  BFLOAT16, // bfloat16 passed as `uint16_t`. https://arxiv.org/abs/1905.12322v3
+};
+
+inline std::int64_t round_up(std::int64_t val, std::int64_t unit) {
   return (val + unit - 1) / unit * unit;
 }
 
-inline int64_t div_up(int64_t val, int64_t unit) {
+inline std::int64_t div_up(std::int64_t val, std::int64_t unit) {
   return (val + unit - 1) / unit;
 }
 

--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -109,8 +109,8 @@ class GenEmbeddingSpMDMLookup {
       int output_stride,
       int input_stride,
       bool scale_bias_last,
-      bool is_bf16_out,
-      bool is_bf16_in);
+      FloatFormat out_format,
+      FloatFormat in_format);
 
  private:
   static asmjit::JitRuntime& runtime() {
@@ -127,7 +127,18 @@ class GenEmbeddingSpMDMLookup {
   // positional weights, normalize by lenths, prefetch distance, use_offsets,
   // output_stride, input_stride, and scale_bias_last
   static CodeCache<
-      std::tuple<int, bool, bool, bool, int, bool, int, int, bool, bool, bool>,
+      std::tuple<
+          int,
+          bool,
+          bool,
+          bool,
+          int,
+          bool,
+          int,
+          int,
+          bool,
+          FloatFormat,
+          FloatFormat>,
       typename ReturnFunctionSignature<
           inType,
           indxType,
@@ -164,7 +175,18 @@ template <
     bool ROWWISE_SPARSE,
     bool THREAD_LOCAL>
 CodeCache<
-    std::tuple<int, bool, bool, bool, int, bool, int, int, bool, bool, bool>,
+    std::tuple<
+        int,
+        bool,
+        bool,
+        bool,
+        int,
+        bool,
+        int,
+        int,
+        bool,
+        FloatFormat,
+        FloatFormat>,
     typename ReturnFunctionSignature<
         inType,
         indxType,
@@ -213,8 +235,8 @@ GenEmbeddingSpMDMLookup<
         int output_stride,
         int input_stride,
         bool scale_bias_last,
-        bool is_bf16_out,
-        bool is_bf16_in) {
+        FloatFormat out_format,
+        FloatFormat in_format) {
   auto kernelSig = std::make_tuple(
       block_size,
       has_weight,
@@ -225,8 +247,8 @@ GenEmbeddingSpMDMLookup<
       output_stride,
       input_stride,
       scale_bias_last,
-      is_bf16_out,
-      is_bf16_in);
+      out_format,
+      in_format);
 
   return codeCache_.getOrCreate(
       kernelSig,
@@ -239,8 +261,15 @@ GenEmbeddingSpMDMLookup<
         bool is_8bit_in = std::is_same<inType, uint8_t>::value;
         bool is_16bit_in = std::is_same<inType, uint16_t>::value;
         bool is_16bit_out = std::is_same<outType, uint16_t>::value;
-        bool is_fp16_in = is_16bit_in && !is_bf16_in;
-        bool is_fp16_out = is_16bit_out && !is_bf16_out;
+        bool is_fp16_in = is_16bit_in && in_format == FloatFormat::FLOAT16;
+        bool is_bf16_in = is_16bit_in && in_format == FloatFormat::BFLOAT16;
+        bool is_fp16_out = is_16bit_out && out_format == FloatFormat::FLOAT16;
+        bool is_bf16_out = is_16bit_out && out_format == FloatFormat::BFLOAT16;
+        assert(
+            !is_16bit_in ||
+            (in_format == FloatFormat::FLOAT16 ||
+             in_format == FloatFormat::BFLOAT16));
+        assert(is_16bit_in || in_format == FloatFormat::DEFAULT);
 
         // TODO: Make this tunable
         int pref_dist = prefetch;
@@ -1030,10 +1059,11 @@ typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType, outType>::
         int64_t input_stride /*=-1*/,
         bool scale_bias_last /*=true*/,
         bool no_bag /*=false*/,
-        bool is_bf16_out /*=false*/,
-        bool is_bf16_in /*=false*/) {
+        FloatFormat out_format /*=FloatFormat::DEFAULT*/,
+        FloatFormat in_format /*=FloatFormat::DEFAULT*/) {
 #if defined(__APPLE__) || defined(_WIN32)
-  if (std::is_same<inType, uint16_t>::value && is_bf16_in &&
+  if (std::is_same<inType, uint16_t>::value &&
+      in_format == FloatFormat::BFLOAT16 &&
       std::is_same<outType, float>::value) {
     throw std::runtime_error(
         "Bfloat16 input with float32 output is not yet supported on Apple or Windows");
@@ -1084,7 +1114,7 @@ typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType, outType>::
             reinterpret_cast<float*>(out),
             is_weight_positional,
             use_offsets,
-            is_bf16_out);
+            out_format);
       };
     }
     if (isZmm(isa) && !is_asmjit_disabled()) {
@@ -1107,8 +1137,8 @@ typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType, outType>::
           output_stride,
           input_stride,
           scale_bias_last,
-          is_bf16_out,
-          is_bf16_in);
+          out_format,
+          in_format);
       return [=](int64_t output_size,
                  int64_t index_size,
                  int64_t data_size,
@@ -1149,8 +1179,8 @@ typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType, outType>::
           output_stride,
           input_stride,
           scale_bias_last,
-          is_bf16_out,
-          is_bf16_in);
+          out_format,
+          in_format);
       return [=](int64_t output_size,
                  int64_t index_size,
                  int64_t data_size,
@@ -1192,8 +1222,8 @@ typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType, outType>::
         /*input_stride=*/input_stride,
         /*scale_bias_last=*/scale_bias_last,
         /*no_bag=*/no_bag,
-        /*is_bf16_out=*/is_bf16_out,
-        /*is_bf16_in=*/is_bf16_in);
+        /*out_format=*/out_format,
+        /*in_format=*/in_format);
   }
 #endif
 
@@ -1225,8 +1255,8 @@ typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType, outType>::
         input_stride,
         scale_bias_last,
         no_bag,
-        is_bf16_out,
-        is_bf16_in);
+        out_format,
+        in_format);
   };
 }
 
@@ -1245,8 +1275,8 @@ typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType, outType>::
         int prefetch,
         bool is_weight_positional,
         bool use_offsets,
-        bool is_bf16_out,
-        bool is_bf16_in) {
+        FloatFormat out_format,
+        FloatFormat in_format) {
   return GenerateEmbeddingSpMDMWithStrides<
       inType,
       indxType,
@@ -1263,8 +1293,8 @@ typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType, outType>::
       /*input_stride=*/-1,
       /*scale_bias_last=*/true,
       /*no_bag=*/false,
-      is_bf16_out,
-      is_bf16_in);
+      out_format,
+      in_format);
 }
 
 template <typename indxType, typename offsetType, typename outType>
@@ -1279,7 +1309,7 @@ typename EmbeddingSpMDMKernelSignature<uint8_t, indxType, offsetType, outType>::
         int64_t input_stride /*=-1*/,
         int exponent_bits,
         int exponent_bias,
-        bool is_bf16_out) {
+        FloatFormat out_format) {
   if (output_stride == -1) {
     output_stride = block_size;
   }
@@ -1302,7 +1332,7 @@ typename EmbeddingSpMDMKernelSignature<uint8_t, indxType, offsetType, outType>::
         /*input_stride=*/input_stride,
         /*exponent_bits=*/exponent_bits,
         /*exponent_bias=*/exponent_bias,
-        /*is_bf16_out=*/is_bf16_out);
+        /*out_format=*/out_format);
   }
 #endif
 
@@ -1332,7 +1362,7 @@ typename EmbeddingSpMDMKernelSignature<uint8_t, indxType, offsetType, outType>::
         input_stride,
         exponent_bits,
         exponent_bias,
-        is_bf16_out);
+        out_format);
   };
 }
 
@@ -1349,6 +1379,9 @@ GenerateEmbeddingSpMDMRowWiseSparse(
     bool is_weight_positional,
     bool use_offsets) {
 #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
+  FloatFormat in_format = std::is_same<inType, float16>::value
+      ? FloatFormat::FLOAT16
+      : FloatFormat::DEFAULT;
   int64_t input_stride = block_size;
   if (std::is_same<inType, uint8_t>::value) {
     const auto scale_bias_offset = 2 * sizeof(float);
@@ -1377,8 +1410,8 @@ GenerateEmbeddingSpMDMRowWiseSparse(
         /*output_stride=*/block_size,
         input_stride,
         /*scale_bias_last=*/true,
-        /*is_bf16_out=*/false,
-        /*is_bf16_in=*/false);
+        /*out_format=*/FloatFormat::DEFAULT,
+        /*in_format=*/in_format);
     return [=](int64_t output_size,
                int64_t index_size,
                int64_t uncompressed_data_size,
@@ -1420,8 +1453,8 @@ GenerateEmbeddingSpMDMRowWiseSparse(
         /*output_stride=*/block_size,
         input_stride,
         /*scale_bias_last=*/true,
-        /*is_bf16_out=*/false,
-        /*is_bf16_in=*/false);
+        /*out_format=*/FloatFormat::DEFAULT,
+        /*in_format=*/in_format);
     return [=](int64_t output_size,
                int64_t index_size,
                int64_t uncompressed_data_size,
@@ -1515,8 +1548,8 @@ GenerateEmbeddingSpMDMRowWiseSparse(
       int64_t input_stride,                                   \
       bool scale_bias_last,                                   \
       bool no_bag,                                            \
-      bool is_bf16_out,                                       \
-      bool is_bf16_in);
+      FloatFormat out_format,                                 \
+      FloatFormat in_format);
 
 #define INSTANTIATE_SPMDMFP8_BASE(INDEX_TYPE, OFFSET_TYPE, OUT_TYPE)       \
   template FBGEMM_API typename EmbeddingSpMDMKernelSignature<              \
@@ -1533,7 +1566,7 @@ GenerateEmbeddingSpMDMRowWiseSparse(
       int64_t input_stride,                                                \
       int exponent_bits,                                                   \
       int exponent_bias,                                                   \
-      bool is_bf16_out);
+      FloatFormat out_format);
 
 #define INSTANTIATE_SPMDM_NOSTRIDE_BASE(                      \
     IN_TYPE, INDEX_TYPE, OFFSET_TYPE, OUT_TYPE, THREAD_LOCAL) \
@@ -1554,8 +1587,8 @@ GenerateEmbeddingSpMDMRowWiseSparse(
       int prefetch,                                           \
       bool is_weight_positional,                              \
       bool use_offsets,                                       \
-      bool is_bf16_out,                                       \
-      bool is_bf16_in);
+      FloatFormat out_format,                                 \
+      FloatFormat in_format);
 
 #define INSTANTIATE_SPMDM_ROWWISE_BASE(IN_TYPE, INDEX_TYPE, OFFSET_TYPE)   \
   template FBGEMM_API typename EmbeddingSpMDMRowWiseSparseKernelSignature< \

--- a/src/EmbeddingSpMDMAutovec.h
+++ b/src/EmbeddingSpMDMAutovec.h
@@ -36,8 +36,8 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
         int64_t input_stride,
         bool scale_bias_last,
         bool no_bag,
-        bool is_bf16_out,
-        bool is_bf16_in);
+        FloatFormat out_format,
+        FloatFormat in_format);
 
 template <typename IndexType, typename OffsetType, typename OutType>
 typename EmbeddingSpMDMKernelSignature<
@@ -56,7 +56,7 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
     int64_t output_stride,
     int64_t input_stride,
     bool scale_bias_last,
-    bool is_bf16_out,
+    FloatFormat out_format,
     bool no_bag,
     int output_bit_rate);
 
@@ -75,7 +75,7 @@ GenerateEmbeddingSpMDMFP8WithStrides_autovec(
     int64_t input_stride,
     int exponent_bits,
     int exponent_bias,
-    bool is_bf16_out);
+    FloatFormat out_format);
 
 template <typename InType, typename IndexType, typename OffsetType>
 typename EmbeddingSpMDMRowWiseSparseKernelSignature<

--- a/src/EmbeddingSpMDMAvx2.cc
+++ b/src/EmbeddingSpMDMAvx2.cc
@@ -29,7 +29,7 @@ bool EmbeddingSpMDMBlockSize1_(
     float* out,
     bool is_weight_positional,
     bool use_offsets,
-    bool is_bf16) {
+    FloatFormat format) {
   int64_t current = 0;
   for (int m = 0; m < output_size; ++m) {
     out[m] = 0;
@@ -116,7 +116,7 @@ bool EmbeddingSpMDMBlockSize1_(
       }
 
       const InType* inptr = input + indices[current];
-      temp = std::fma(w, convert_to_float_ref(*inptr, is_bf16), temp);
+      temp = std::fma(w, convert_to_float_ref(*inptr, format), temp);
 
       ++current;
     }
@@ -142,7 +142,7 @@ bool EmbeddingSpMDMBlockSize1_(
       float* out,                                                \
       bool is_weight_positional,                                 \
       bool use_offsets,                                          \
-      bool is_bf16);
+      FloatFormat format);
 
 #define INSTANTIATE_SPMDM_OFFSET_T(IN_TYPE, INDEX_TYPE)     \
   INSTANTIATE_SPMDM_BASE(IN_TYPE, INDEX_TYPE, std::int32_t) \

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -239,8 +239,8 @@ FBGEMM_API bool EmbeddingSpMDM_ref(
     std::int64_t input_stride = -1,
     bool scale_bias_last = true,
     bool no_bag = false,
-    bool is_bf16_out = false,
-    bool is_bf16_in = false);
+    FloatFormat out_format = FloatFormat::DEFAULT,
+    FloatFormat in_format = FloatFormat::DEFAULT);
 
 template <
     typename IndexType = std::int64_t,
@@ -263,7 +263,7 @@ FBGEMM_API bool EmbeddingSpMDMNBit_ref(
     std::int64_t output_stride = -1,
     std::int64_t input_stride = -1,
     const bool scale_bias_last = true,
-    const bool is_bf16_out = false,
+    const FloatFormat out_format = FloatFormat::DEFAULT,
     const bool no_bag = false,
     int output_bit_rate = -1);
 
@@ -288,7 +288,7 @@ bool EmbeddingSpMDMFP8_ref(
     int64_t input_stride = -1,
     int exponent_bits = 4,
     int exponent_bias = 7,
-    bool is_bf16_out = false);
+    FloatFormat out_format = FloatFormat::DEFAULT);
 
 template <
     typename InType = std::uint8_t,
@@ -416,10 +416,11 @@ FBGEMM_API void compressed_indices_remap_ref(
     float* out_weights);
 
 template <typename T>
-float convert_to_float_ref(T src, bool is_bf16 = false) {
+float convert_to_float_ref(T src, FloatFormat format = FloatFormat::DEFAULT) {
   float f_value;
   if (std::is_same<T, uint16_t>::value) {
-    f_value = is_bf16 ? cpu_bf162float(src) : cpu_half2float(src);
+    f_value = format == FloatFormat::BFLOAT16 ? cpu_bf162float(src)
+                                              : cpu_half2float(src);
   } else {
     f_value = src;
   }
@@ -427,10 +428,11 @@ float convert_to_float_ref(T src, bool is_bf16 = false) {
 }
 
 template <typename T>
-T convert_from_float_ref(float src, bool is_bf16 = false) {
+T convert_from_float_ref(float src, FloatFormat format = FloatFormat::DEFAULT) {
   T o_value;
   if (std::is_same<T, uint16_t>::value) {
-    o_value = is_bf16 ? cpu_float2bfloat16(src) : cpu_float2half_rn(src);
+    o_value = format == FloatFormat::BFLOAT16 ? cpu_float2bfloat16(src)
+                                              : cpu_float2half_rn(src);
   } else {
     o_value = src;
   }

--- a/test/EmbeddingSpMDM8BitTest.cc
+++ b/test/EmbeddingSpMDM8BitTest.cc
@@ -183,10 +183,10 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
     for (size_t i = output_size_wo_sentries; i < output.size(); ++i) {
       output_ref[i] = sentry_value;
       output[i] = sentry_value;
-      output_ref_16b[i] =
-          convert_from_float_ref<uint16_t>(sentry_value, out_type == BFLOAT16);
-      output_16b[i] =
-          convert_from_float_ref<uint16_t>(sentry_value, out_type == BFLOAT16);
+      output_ref_16b[i] = convert_from_float_ref<uint16_t>(
+          sentry_value, floatFormatFor(out_type));
+      output_16b[i] = convert_from_float_ref<uint16_t>(
+          sentry_value, floatFormatFor(out_type));
     }
 
     bool success, success_ref;
@@ -215,8 +215,9 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
       /*output_stride=*/-1,                                    \
       /*input_stride=*/-1,                                     \
       scale_bias_last,                                         \
-      /*is_bf16_out=*/out_type == BFLOAT16,                    \
-      /*is_bf16_in=*/false);                                   \
+      /*no_bag=*/false,                                        \
+      /*out_format=*/floatFormatFor(out_type),                 \
+      /*in_format=*/FloatFormat::DEFAULT);                     \
                                                                \
   auto kernel = GenerateEmbeddingSpMDMWithStrides<             \
       uint8_t,                                                 \
@@ -232,8 +233,9 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
       /*output_stride=*/-1,                                    \
       /*input_stride=*/-1,                                     \
       scale_bias_last,                                         \
-      /*is_bf16_out=*/out_type == BFLOAT16,                    \
-      /*is_bf16_in=*/false);                                   \
+      /*no_bag=*/false,                                        \
+      /*out_format=*/floatFormatFor(out_type),                 \
+      /*in_format=*/FloatFormat::DEFAULT);                     \
   success = kernel(                                            \
       batch_size,                                              \
       lengths_sum,                                             \
@@ -293,10 +295,10 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
       for (size_t i = 0; i < output.size(); ++i) {
         float actual = (out_type == FLOAT)
             ? output[i]
-            : convert_to_float_ref(output_16b[i], out_type == BFLOAT16);
+            : convert_to_float_ref(output_16b[i], floatFormatFor(out_type));
         float expected = (out_type == FLOAT)
             ? output_ref[i]
-            : convert_to_float_ref(output_ref_16b[i], out_type == BFLOAT16);
+            : convert_to_float_ref(output_ref_16b[i], floatFormatFor(out_type));
         EXPECT_EQ(actual, expected)
             << "results differ at (" << i << ") reference: " << expected
             << ", FBGEMM: " << actual << " emb dim :" << embedding_dim;
@@ -306,11 +308,12 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
            ++offset) {
         float actual = (out_type == FLOAT)
             ? output[offset]
-            : convert_to_float_ref(output_16b[offset], out_type == BFLOAT16);
+            : convert_to_float_ref(
+                  output_16b[offset], floatFormatFor(out_type));
         float expected = (out_type == FLOAT)
             ? output_ref[offset]
             : convert_to_float_ref(
-                  output_ref_16b[offset], out_type == BFLOAT16);
+                  output_ref_16b[offset], floatFormatFor(out_type));
         EXPECT_EQ(actual, expected)
             << "results differ at (" << offset << ") reference: " << expected
             << ", FBGEMM: " << actual << " emb dim :" << embedding_dim;

--- a/test/EmbeddingSpMDMNBitTest.cc
+++ b/test/EmbeddingSpMDMNBitTest.cc
@@ -98,7 +98,7 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
   tie(bit_rate, prefetch, weight_choice, corner_case, out_type) = GetParam();
   bool is_wt_positional = weight_choice == POSITIONAL_WEIGHTED;
   bool use_weight = weight_choice != UNWEIGHTED;
-  bool is_bf16_out = out_type == BFLOAT16;
+  FloatFormat out_format = floatFormatFor(out_type);
 
   if (corner_case != NONE || weight_choice == POSITIONAL_WEIGHTED) {
     // Check corner case only for subset of tests.
@@ -226,7 +226,7 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
       /*output_stride=*/-1,                                             \
       /*input_stride=*/-1,                                              \
       scale_bias_last,                                                  \
-      is_bf16_out);                                                     \
+      out_format);                                                      \
                                                                         \
   auto kernel = GenerateEmbeddingSpMDMNBitWithStrides<                  \
       IndexType,                                                        \
@@ -243,7 +243,7 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
       /*output_stride=*/-1,                                             \
       /*input_stride=*/-1,                                              \
       scale_bias_last,                                                  \
-      is_bf16_out);                                                     \
+      out_format);                                                      \
   success = kernel(                                                     \
       batch_size,                                                       \
       lengths_sum,                                                      \

--- a/test/EmbeddingSpMDMTest.cc
+++ b/test/EmbeddingSpMDMTest.cc
@@ -129,15 +129,14 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
   tie(prefetch, weight_choice, corner_case, in_type, out_type) = GetParam();
   bool is_wt_positional = weight_choice == POSITIONAL_WEIGHTED;
   bool use_weight = weight_choice != UNWEIGHTED;
-  bool isFp16 = in_type == FLOAT16;
-  bool isBf16 = in_type == BFLOAT16;
-  bool is_output_float = (out_type == FLOAT);
-  bool is_output_bfloat16 = (out_type == BFLOAT16);
+  FloatFormat in_format = floatFormatFor(in_type);
+  FloatFormat out_format = floatFormatFor(out_type);
 
   if (corner_case != NONE || is_wt_positional) {
     // Check corner case only for subset of tests.
-    if (isFp16 || normalize_by_lengths || use_output_input_stride ||
-        !is_output_float || test_thread_local) {
+    if (in_format == FloatFormat::FLOAT16 || normalize_by_lengths ||
+        use_output_input_stride || out_format != FloatFormat::DEFAULT ||
+        test_thread_local) {
       return;
     }
   }
@@ -147,7 +146,8 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
   }
 
 #if defined(__APPLE__) || defined(_WIN32)
-  if (in_type == BFLOAT16 && out_type == FLOAT) {
+  if (in_format == FloatFormat::BFLOAT16 &&
+      out_format == FloatFormat::DEFAULT) {
     return;
   }
 #endif
@@ -172,7 +172,7 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
       }
     }
     vector<float16> embedding_table_fp16;
-    if (isFp16) {
+    if (in_format == FloatFormat::FLOAT16) {
       embedding_table_fp16.resize(embedding_table.size());
       FloatToFloat16_simd(
           embedding_table.data(),
@@ -181,7 +181,7 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
     }
 
     vector<bfloat16> embedding_table_bf16;
-    if (isBf16) {
+    if (in_format == FloatFormat::BFLOAT16) {
       embedding_table_bf16.resize(embedding_table.size());
       FloatToBfloat16_simd(
           embedding_table.data(),
@@ -258,8 +258,8 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
       input_stride,                                            \
       true,                                                    \
       false,                                                   \
-      is_output_bfloat16,                                      \
-      isBf16);                                                 \
+      /*out_format=*/out_format,                               \
+      /*in_format=*/in_format);                                \
                                                                \
   auto kernel = GenerateEmbeddingSpMDMWithStrides<             \
       InType,                                                  \
@@ -277,8 +277,8 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
       input_stride,                                            \
       true,                                                    \
       false,                                                   \
-      is_output_bfloat16,                                      \
-      isBf16);                                                 \
+      /*out_format=*/out_format,                               \
+      /*in_format=*/in_format);                                \
   success = kernel(                                            \
       batch_size,                                              \
       lengths_sum,                                             \
@@ -327,7 +327,7 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
 
 #define TEST_OUT_TYPE(                                                 \
     table, indices, offsets_or_lengths, InType, IndexType, OffsetType) \
-  if (is_output_float) {                                               \
+  if (out_format == FloatFormat::DEFAULT) {                            \
     TEST_THREAD_LOCAL(                                                 \
         table,                                                         \
         indices,                                                       \
@@ -338,7 +338,7 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
         IndexType,                                                     \
         OffsetType,                                                    \
         float);                                                        \
-  } else if (is_output_bfloat16) {                                     \
+  } else if (out_format == FloatFormat::BFLOAT16) {                    \
     TEST_THREAD_LOCAL(                                                 \
         table,                                                         \
         indices,                                                       \
@@ -378,12 +378,14 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
     TEST_OFFSET_TYPE(table, indices_32, InType, int32_t); \
   }
 
-    if (isFp16) {
+    if (in_format == FloatFormat::FLOAT16) {
       TEST_INDEX_TYPE(embedding_table_fp16, float16);
-    } else if (isBf16) {
+    } else if (in_format == FloatFormat::BFLOAT16) {
       TEST_INDEX_TYPE(embedding_table_bf16, bfloat16);
-    } else {
+    } else if (in_format == FloatFormat::DEFAULT) {
       TEST_INDEX_TYPE(embedding_table, float);
+    } else {
+      std::abort();
     }
 
 #undef TEST_INDEX_TYPE
@@ -401,25 +403,31 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
     }
 
     auto get_actual = [&](int offset) {
-      if (is_output_float)
+      if (out_format == FloatFormat::DEFAULT) {
         return output[offset];
-      else if (is_output_bfloat16) {
+      } else if (out_format == FloatFormat::BFLOAT16) {
         float v;
         Bfloat16ToFloat_ref(&output_bf16[offset], &v, 1);
         return v;
-      } else
+      } else if (out_format == FloatFormat::FLOAT16) {
         return cpu_half2float(output_fp16[offset]);
+      } else {
+        std::abort();
+      }
     };
 
     auto get_expected = [&](int offset) {
-      if (is_output_float)
+      if (out_format == FloatFormat::DEFAULT) {
         return output_ref[offset];
-      else if (is_output_bfloat16) {
+      } else if (out_format == FloatFormat::BFLOAT16) {
         float v;
         Bfloat16ToFloat_ref(&output_ref_bf16[offset], &v, 1);
         return v;
-      } else
+      } else if (out_format == FloatFormat::FLOAT16) {
         return cpu_half2float(output_ref_fp16[offset]);
+      } else {
+        std::abort();
+      }
     };
 
     if (success) {

--- a/test/EmbeddingSpMDMTestUtils.h
+++ b/test/EmbeddingSpMDMTestUtils.h
@@ -9,7 +9,10 @@
 #pragma once
 
 #include <cstdint>
+#include <cstdlib>
 #include <vector>
+
+#include "fbgemm/Types.h"
 
 namespace fbgemm {
 
@@ -58,5 +61,18 @@ int CreateMappingTableForRowWiseSparsity(
     std::vector<std::int32_t>& mapping_table,
     int num_rows,
     float sparsity);
+
+inline FloatFormat floatFormatFor(EmbeddingSpMDMDtypeChoice DTC) {
+  switch (DTC) {
+    case FLOAT:
+      return FloatFormat::DEFAULT;
+    case FLOAT16:
+      return FloatFormat::FLOAT16;
+    case BFLOAT16:
+      return FloatFormat::BFLOAT16;
+  }
+  // unknown/invalid float format.
+  std::abort();
+}
 
 } // namespace fbgemm


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/149338

Most FBGemmEmbedding APIs currently feature a `bool is_bf16_out` parameter to differentiate between the float16 and bfloat16 format when the output array has type `uint16_t`.

I am in the process of adding E5M2 and E4M3FN formats for output arrays with type `uint8_t`. Instead of adding another parameter, I would like to change the `bool is_bf16_out` parameter to `enum FloatFormat` to make it easier to add new formats:

```
enum class FloatFormat {
  DEFAULT,
  FLOAT16,
  BFLOAT16,
  FP8_E5M2,
  FP8_E4M3FN,
};
```

Reviewed By: excelle08

Differential Revision: D68046358


