### PR TITLE
Fix CUDA kernel index data type in deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped.cu +10

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped.cu
@@ -124,7 +124,7 @@ __global__ void set_dynamic_kernel_args_kernel(
     int M,
     int N,
     int K) {
-  int group_index = blockIdx.x * blockDim.x + threadIdx.x;
+  auto group_index = blockIdx.x * blockDim.x + threadIdx.x;
   if (group_index < problem_count) {
     int64_t* x_ptr_ = input_args_ptr + x_ptr_offset;
     int64_t* w_ptr_ = input_args_ptr + w_ptr_offset;
@@ -197,7 +197,7 @@ __global__ void set_static_kernel_args_kernel(
     int M,
     int N,
     int K) {
-  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  auto idx = blockIdx.x * blockDim.x + threadIdx.x;
   // We only set one group's information per kernel launch.
   if (idx == 0) {
     int64_t* x_ptr_ = input_args_ptr + x_ptr_offset;

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_grouped.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_grouped.cu
@@ -167,7 +167,7 @@ __global__ void set_kernel_args_kernel(
     int M,
     int N,
     int K) {
-  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  auto idx = blockIdx.x * blockDim.x + threadIdx.x;
   // Each kernel annoyingly can only set the kernel args for one group.
   // This could only be avoided with complicated memory management.
   if (idx == 0) {
@@ -245,7 +245,7 @@ __global__ void set_dynamic_kernel_args_kernel(
     int M,
     int N,
     int K) {
-  int group_index = blockIdx.x * blockDim.x + threadIdx.x;
+  auto group_index = blockIdx.x * blockDim.x + threadIdx.x;
   // If this thread corresponds to a valid group, write kernel args to device
   // memory.
   if (group_index < group_count) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/fast_gemv.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/fast_gemv.cu
@@ -68,7 +68,7 @@ __global__ void gemv_bf16(
 
 #pragma unroll
   for (int iter = 0; iter < num_per_thread >> 3; iter++) {
-    unsigned int j = start_idx + iter * blockDim.x;
+    auto j = start_idx + iter * blockDim.x;
     if (j < k >> 3) {
       const auto mat_val = mat4[row * (k >> 3) + j];
       const bfloat16_2* mat_h1 = (bfloat16_2*)&mat_val.x;
@@ -133,8 +133,8 @@ __global__ void gemv_bf16(
 
   // Shared mem for partial sums (one per warp in the block)
   static __shared__ float warpLevelSums[SHARED_MEM_MAX_ROWS][WARP_SIZE];
-  const int laneId = threadIdx.x % WARP_SIZE;
-  const int warpId = threadIdx.x / WARP_SIZE;
+  const auto laneId = threadIdx.x % WARP_SIZE;
+  const auto warpId = threadIdx.x / WARP_SIZE;
 #pragma unroll
   for (int col = 0; col < m; col++) {
     if (laneId == 0)
@@ -175,7 +175,7 @@ __global__ void gemv_quantized_bf16_fp8(
 
 #pragma unroll
   for (int iter = 0; iter < num_per_thread >> 3; iter++) {
-    unsigned int j = start_idx + iter * blockDim.x;
+    auto j = start_idx + iter * blockDim.x;
     if (j < k >> 3) {
       const auto mat_val = mat4[row * (k >> 3) + j];
       const fp8_2* mat_h1 = (fp8_2*)&mat_val.x;
@@ -250,8 +250,8 @@ __global__ void gemv_quantized_bf16_fp8(
 
   // Shared mem for partial sums (one per warp in the block)
   static __shared__ float warpLevelSums[SHARED_MEM_MAX_ROWS][WARP_SIZE];
-  const int laneId = threadIdx.x % WARP_SIZE;
-  const int warpId = threadIdx.x / WARP_SIZE;
+  const auto laneId = threadIdx.x % WARP_SIZE;
+  const auto warpId = threadIdx.x / WARP_SIZE;
 #pragma unroll
   for (int col = 0; col < m; col++) {
     if (laneId == 0)
@@ -283,9 +283,9 @@ __global__ void gemv_quantized_int4(
     unsigned int num_per_thread) {
   float sum = 0;
   // each thread load num_per_thread elements from global
-  unsigned int tid = threadIdx.x;
-  unsigned int row = blockIdx.y * blockDim.y + threadIdx.y;
-  unsigned int start_idx = threadIdx.x;
+  auto tid = threadIdx.x;
+  auto row = blockIdx.y * blockDim.y + threadIdx.y;
+  auto start_idx = threadIdx.x;
   uint4_2_4* mat4 = reinterpret_cast<uint4_2_4*>(mat);
   float4* vec4 = reinterpret_cast<float4*>(vec);
 
@@ -366,8 +366,8 @@ __global__ void gemv_quantized_int4(
 
   // Shared mem for partial sums (one per warp in the block)
   static __shared__ float warpLevelSums[SHARED_MEM_MAX_ROWS][WARP_SIZE];
-  const int laneId = threadIdx.x % WARP_SIZE;
-  const int warpId = threadIdx.x / WARP_SIZE;
+  const auto laneId = threadIdx.x % WARP_SIZE;
+  const auto warpId = threadIdx.x / WARP_SIZE;
   if (laneId == 0)
     warpLevelSums[threadIdx.y][warpId] = sum;
   __syncthreads();

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cu
@@ -879,8 +879,8 @@ std::vector<at::Tensor> quantize_fp8_per_tensor(
 template <typename T>
 __inline__ __device__ T blockAllReduceMax(T val) {
   static __shared__ T shared[32];
-  int lane = threadIdx.x & 0x1f;
-  int wid = threadIdx.x >> 5;
+  auto lane = threadIdx.x & 0x1f;
+  auto wid = threadIdx.x >> 5;
   val = warpReduceMax(val);
   if (lane == 0)
     shared[wid] = val;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/934

CUDA kernel variables matching the type `(thread|block|grid).(Idx|Dim).(x|y|z)` [have the data type `uint`](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#built-in-variables).

Many programmers mistakenly use implicit casts to turn these data types into `int`. In fact, the [CUDA Programming Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/) it self is inconsistent and incorrect in its use of data types in programming examples.

The result of these implicit casts is that our kernels may give unexpected results when exposed to large datasets, i.e., those exceeding >~2B items.

While we now have linters in place to prevent simple mistakes (D71236150), our codebase has many problematic instances. This diff fixes some of them.

Reviewed By: sryap, dtolnay

Differential Revision: D71355297


