### PR TITLE
Fix CUDA kernel index data type in deeplearning/fbgemm/fbgemm_gpu/src/embedding_inplace_ops/embedding_inplace_update.cu +10

### DIFF
--- a/fbgemm_gpu/src/embedding_inplace_ops/embedding_inplace_update.cu
+++ b/fbgemm_gpu/src/embedding_inplace_ops/embedding_inplace_update.cu
@@ -85,7 +85,7 @@ inline __device__ void embedding_inplace_update_kernel_impl(
       reinterpret_cast<const uint4*>(&update_weights[update_weight_offset]);
   // Do wider loads/stores so that each 16 Byte segment in the row can be
   // updated in a single memory transaction
-  for (int32_t d = threadIdx.x; d * sizeof(uint4) < D_bytes; d += blockDim.x) {
+  for (auto d = threadIdx.x; d * sizeof(uint4) < D_bytes; d += blockDim.x) {
     vec_weight_row[d] = update_weight_row[d];
   }
 
@@ -96,8 +96,7 @@ inline __device__ void embedding_inplace_update_kernel_impl(
     auto vec_cache_row = reinterpret_cast<uint4*>(
         &lxu_cache_weights[static_cast<int64_t>(cache_idx)][0]);
 
-    for (int32_t d = threadIdx.x; d * sizeof(uint4) < D_bytes;
-         d += blockDim.x) {
+    for (auto d = threadIdx.x; d * sizeof(uint4) < D_bytes; d += blockDim.x) {
       vec_cache_row[d] = update_weight_row[d];
     }
   }

--- a/fbgemm_gpu/src/histogram_binning_calibration_ops.cu
+++ b/fbgemm_gpu/src/histogram_binning_calibration_ops.cu
@@ -31,7 +31,7 @@ __launch_bounds__(kMaxThreads) void histogram_binning_calibration_kernel(
     const double* const bin_num_positives_data,
     T* const calibrated_prediction_data,
     int64_t* const bin_ids_data) {
-  const int32_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index >= num_logits) {
     return;
   }
@@ -106,7 +106,7 @@ __global__ __launch_bounds__(kMaxThreads) void to_dense_segment_value_kernel(
     const ValueType* const segment_value_data,
     const OffsetType* const segment_offsets_data,
     ValueType* const dense_segment_value_data) {
-  const int32_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index >= num_lengths - 1) {
     return;
   }
@@ -138,7 +138,7 @@ __launch_bounds__(kMaxThreads) void histogram_binning_calibration_by_feature_ker
     const double* const bin_num_positives_data,
     LogitType* const calibrated_prediction_data,
     int64_t* const bin_ids_data) {
-  const int32_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index >= num_logits) {
     return;
   }
@@ -281,7 +281,7 @@ __launch_bounds__(kMaxThreads) void generic_histogram_binning_calibration_by_fea
     const double* const bin_boundaries,
     LogitType* const calibrated_prediction_data,
     int64_t* const bin_ids_data) {
-  const int32_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto index = blockIdx.x * blockDim.x + threadIdx.x;
   if (index >= num_logits) {
     return;
   }

--- a/fbgemm_gpu/src/intraining_embedding_pruning_ops/intraining_embedding_pruning.cu
+++ b/fbgemm_gpu/src/intraining_embedding_pruning_ops/intraining_embedding_pruning.cu
@@ -42,8 +42,8 @@ __global__ void init_address_lookup_kernel(
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         emb_sizes) {
   int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
-  int32_t t_i = blockIdx.x / blocks_per_table;
-  int32_t threads_per_table = blocks_per_table * blockDim.x;
+  auto t_i = blockIdx.x / blocks_per_table;
+  auto threads_per_table = blocks_per_table * blockDim.x;
   int32_t idx_table = idx % threads_per_table;
 
   int64_t rows = buffer_offsets[t_i + 1] - buffer_offsets[t_i];
@@ -96,14 +96,14 @@ __global__ void get_util_samples(
     const at::PackedTensorAccessor32<float, 1, at::RestrictPtrTraits>
         row_utils) {
   int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
-  int32_t t_i = blockIdx.x / blocks_per_table;
+  auto t_i = blockIdx.x / blocks_per_table;
   int32_t num_tables = buffer_offsets.size(0) - 1;
 
   if (t_i >= num_tables) {
     return;
   }
 
-  int32_t threads_per_table = blocks_per_table * blockDim.x;
+  auto threads_per_table = blocks_per_table * blockDim.x;
   int32_t idx_table = idx % threads_per_table;
 
   int64_t rows = buffer_offsets[t_i + 1] - buffer_offsets[t_i];
@@ -163,8 +163,8 @@ __global__ void prune_indices_per_table(
     at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         address_lookups) {
   int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
-  int32_t t_i = blockIdx.x / blocks_per_table;
-  int32_t threads_per_table = blocks_per_table * blockDim.x;
+  auto t_i = blockIdx.x / blocks_per_table;
+  auto threads_per_table = blocks_per_table * blockDim.x;
   int32_t idx_table = idx % threads_per_table;
 
   int64_t rows = buffer_offsets[t_i + 1] - buffer_offsets[t_i];
@@ -217,7 +217,7 @@ __global__ void get_pruning_lengths(
         inserted_row_lengths,
     at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         pruning_lengths) {
-  int32_t t_i = blockIdx.x;
+  auto t_i = blockIdx.x;
   int64_t rows = buffer_offsets[t_i + 1] - buffer_offsets[t_i];
   int64_t segment_length = div_round_up(rows, blockDim.x);
   int64_t segment_start = threadIdx.x * segment_length;
@@ -270,7 +270,7 @@ __global__ void retrieve_pruned_and_inserted_rows(
         buffer_offsets,
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         address_lookups) {
-  int32_t t_i = blockIdx.x;
+  auto t_i = blockIdx.x;
   int64_t rows = buffer_offsets[t_i + 1] - buffer_offsets[t_i];
   int64_t segment_length = div_round_up(rows, blockDim.x);
   int64_t segment_start = threadIdx.x * segment_length;
@@ -319,7 +319,7 @@ __global__ void retrieve_pruned_indices(
         buffer_offsets,
     at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         address_lookups) {
-  int32_t t_i = blockIdx.x;
+  auto t_i = blockIdx.x;
   int64_t rows = pruning_offsets[t_i + 1] - pruning_offsets[t_i];
   int64_t segment_length = div_round_up(rows, blockDim.x);
   int64_t segment_start = threadIdx.x * segment_length;
@@ -357,8 +357,8 @@ __global__ void cleanup_address_lookups(
     at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         address_lookups) {
   int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
-  int32_t t_i = blockIdx.x / blocks_per_table;
-  int32_t threads_per_table = blocks_per_table * blockDim.x;
+  auto t_i = blockIdx.x / blocks_per_table;
+  auto threads_per_table = blocks_per_table * blockDim.x;
   int32_t idx_table = idx % threads_per_table;
 
   int64_t rows = buffer_offsets[t_i + 1] - buffer_offsets[t_i];
@@ -407,7 +407,7 @@ __launch_bounds__(kMaxThreads) void remap_indices_update_utils_per_table_sorted_
     at::PackedTensorAccessor32<float, 1, at::RestrictPtrTraits> row_util,
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         buffer_offsets) {
-  const int32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx >= num_indices) {
     return;
   }
@@ -439,7 +439,7 @@ __global__ __launch_bounds__(kMaxThreads) void remap_indices_per_table_kernel(
         address_lookup,
     const at::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         buffer_offsets) {
-  const int32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx >= num_indices) {
     return;
   }

--- a/fbgemm_gpu/src/jagged_tensor_ops/batched_dense_vec_jagged_2d_mul_backward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/batched_dense_vec_jagged_2d_mul_backward.cu
@@ -24,8 +24,8 @@ __global__ __launch_bounds__(kMaxThreads) void outer_prod_jagged_2d_output(
   const int max_L = x.size(1);
   const int D = y.size(1);
 
-  const int b_h_l_begin = blockIdx.x * blockDim.y + threadIdx.y;
-  const int b_h_l_step = gridDim.x * blockDim.y;
+  const auto b_h_l_begin = blockIdx.x * blockDim.y + threadIdx.y;
+  const auto b_h_l_step = gridDim.x * blockDim.y;
   for (int b_h_l = b_h_l_begin; b_h_l < B * H * max_L; b_h_l += b_h_l_step) {
     const int b_h = b_h_l / max_L;
     const int b = b_h / H;
@@ -36,7 +36,7 @@ __global__ __launch_bounds__(kMaxThreads) void outer_prod_jagged_2d_output(
     const int row_end = offsets[b + 1];
     const int length = row_end - row_start;
     if (l < length) {
-      for (int d = threadIdx.x; d < D; d += blockDim.x) {
+      for (auto d = threadIdx.x; d < D; d += blockDim.x) {
         output_values[row_start + l][h * D + d] = x[b_h][l] * y[b_h][d];
       }
     }
@@ -55,8 +55,8 @@ __launch_bounds__(kMaxThreads) void dense_vec_jagged_2d_transposed_bmm(
   const int max_L = output.size(1);
   const int D = v.size(1);
 
-  const int b_h_begin = blockIdx.x * blockDim.y + threadIdx.y;
-  const int b_h_step = gridDim.x * blockDim.y;
+  const auto b_h_begin = blockIdx.x * blockDim.y + threadIdx.y;
+  const auto b_h_step = gridDim.x * blockDim.y;
   for (int b_h = b_h_begin; b_h < B * H; b_h += b_h_step) {
     const int b = b_h / H;
     const int h = b_h % H;
@@ -65,7 +65,7 @@ __launch_bounds__(kMaxThreads) void dense_vec_jagged_2d_transposed_bmm(
     const int row_end = a_offsets[b + 1];
     const int length = std::min(row_end - row_start, max_L);
     if (D == 0) {
-      for (int l = threadIdx.x; l < max_L; ++l) {
+      for (auto l = threadIdx.x; l < max_L; ++l) {
         output[b_h][l] = 0;
       }
     } else {

--- a/fbgemm_gpu/src/jagged_tensor_ops/batched_dense_vec_jagged_2d_mul_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/batched_dense_vec_jagged_2d_mul_forward.cu
@@ -24,8 +24,8 @@ __global__ __launch_bounds__(kMaxThreads) void dense_vec_jagged_2d_bmm(
   const int max_L = v.size(1);
   const int D = output.size(1);
 
-  const int b_h_begin = blockIdx.x * blockDim.y + threadIdx.y;
-  const int b_h_step = gridDim.x * blockDim.y;
+  const auto b_h_begin = blockIdx.x * blockDim.y + threadIdx.y;
+  const auto b_h_step = gridDim.x * blockDim.y;
   for (int b_h = b_h_begin; b_h < B * H; b_h += b_h_step) {
     const int b = b_h / H;
     const int h = b_h % H;
@@ -34,12 +34,12 @@ __global__ __launch_bounds__(kMaxThreads) void dense_vec_jagged_2d_bmm(
     const int row_end = a_offsets[b + 1];
     const int length = std::min(row_end - row_start, max_L);
     if (length == 0) {
-      for (int d = threadIdx.x; d < D; d += blockDim.x) {
+      for (auto d = threadIdx.x; d < D; d += blockDim.x) {
         output[b_h][d] = 0;
       }
     } else {
       // TODO: use shared memory
-      for (int d = threadIdx.x; d < D; d += blockDim.x) {
+      for (auto d = threadIdx.x; d < D; d += blockDim.x) {
         at::acc_type<scalar_t, true> acc =
             v[b_h][0] * a_values[row_start][h * D + d];
         for (int l = 1; l < length; ++l) {

--- a/fbgemm_gpu/src/jagged_tensor_ops/common.cuh
+++ b/fbgemm_gpu/src/jagged_tensor_ops/common.cuh
@@ -146,8 +146,8 @@ __launch_bounds__(kMaxThreads) void jagged_dense_elementwise_dense_output_kernel
   const int jagged_folded_size = y.size(1);
   const int inner_dense_size = y.size(2);
 
-  const int outer_begin = blockIdx.x * blockDim.y + threadIdx.y;
-  const int outer_stride = gridDim.x * blockDim.y;
+  const auto outer_begin = blockIdx.x * blockDim.y + threadIdx.y;
+  const auto outer_stride = gridDim.x * blockDim.y;
   for (int outer = outer_begin; outer < outer_dense_size * jagged_folded_size;
        outer += outer_stride) {
     const int oidx = outer / jagged_folded_size;
@@ -319,8 +319,8 @@ __launch_bounds__(kMaxThreads) void jagged_dense_dense_elementwise_jagged_output
   const int inner_dense_size = y_0.size(2);
   const int nnz = x_values.size(0);
 
-  const int offset_begin = blockIdx.x * blockDim.y + threadIdx.y;
-  const int offset_stride = gridDim.x * blockDim.y;
+  const auto offset_begin = blockIdx.x * blockDim.y + threadIdx.y;
+  const auto offset_stride = gridDim.x * blockDim.y;
   for (int offset = offset_begin; offset < nnz; offset += offset_stride) {
     int offset_temp = offset;
     int jidx = 0;
@@ -405,11 +405,11 @@ __global__ void jagged_dense_dense_elementwise_jagged_output_opt_search_kernel_(
   struct SharedMemory<index_t> smem;
   index_t* offsets_sh = smem.getPointer();
 
-  for (int i = threadIdx.x; i < B + 1; i += blockDim.x) {
+  for (auto i = threadIdx.x; i < B + 1; i += blockDim.x) {
     offsets_sh[i] = offsets[i];
   }
   __syncthreads();
-  int row = threadIdx.x + blockIdx.x * blockDim.x;
+  auto row = threadIdx.x + blockIdx.x * blockDim.x;
   if (row >= nnz)
     return;
   int first = -1;
@@ -546,7 +546,7 @@ __global__ void jagged_dense_dense_elementwise_jagged_output_opt_gather_kernel_(
     const int nnz,
     const int E,
     F f) {
-  int values_row = threadIdx.y + blockIdx.y * blockDim.y;
+  auto values_row = threadIdx.y + blockIdx.y * blockDim.y;
   if (values_row >= nnz)
     return;
   for (int real_row = values_row; real_row < nnz;
@@ -563,7 +563,7 @@ __global__ void jagged_dense_dense_elementwise_jagged_output_opt_gather_kernel_(
     if ((dense_col < y0.size(1)) && (dense_row < y0.size(0)) &&
         (dense_col < y1.size(1)) && (dense_row < y1.size(0)) &&
         (dense_col >= 0) && (dense_row >= 0)) {
-      for (int tid = threadIdx.x; tid < E / 8; tid += blockDim.x) {
+      for (auto tid = threadIdx.x; tid < E / 8; tid += blockDim.x) {
         VecType128 v_x, v_out, v_y0, v_y1;
         v_x.data.mask =
             (reinterpret_cast<const VecType128::TType*>(x_ptr))[tid];
@@ -575,7 +575,7 @@ __global__ void jagged_dense_dense_elementwise_jagged_output_opt_gather_kernel_(
         (reinterpret_cast<VecType128::TType*>(values_ptr))[tid] =
             v_out.data.mask;
       }
-      for (int tid = threadIdx.x + (E / 8) * 8; tid < E / 4;
+      for (auto tid = threadIdx.x + (E / 8) * 8; tid < E / 4;
            tid += blockDim.x) {
         VecType64 v_x, v_out, v_y0, v_y1;
         v_x.data.mask = (reinterpret_cast<const VecType64::TType*>(x_ptr))[tid];
@@ -587,7 +587,7 @@ __global__ void jagged_dense_dense_elementwise_jagged_output_opt_gather_kernel_(
         (reinterpret_cast<VecType64::TType*>(values_ptr))[tid] =
             v_out.data.mask;
       }
-      for (int tid = threadIdx.x + (E / 4) * 4; tid < E / 2;
+      for (auto tid = threadIdx.x + (E / 4) * 4; tid < E / 2;
            tid += blockDim.x) {
         VecType32 v_x, v_out, v_y0, v_y1;
         v_x.data.mask = (reinterpret_cast<const VecType32::TType*>(x_ptr))[tid];
@@ -599,7 +599,7 @@ __global__ void jagged_dense_dense_elementwise_jagged_output_opt_gather_kernel_(
         (reinterpret_cast<VecType32::TType*>(values_ptr))[tid] =
             v_out.data.mask;
       }
-      for (int tid = threadIdx.x + (E / 2) * 2; tid < E; tid += blockDim.x) {
+      for (auto tid = threadIdx.x + (E / 2) * 2; tid < E; tid += blockDim.x) {
         __half v_x, v_out, v_y0, v_y1;
         v_x = static_cast<__half>(x_ptr[tid]);
         v_y0 = static_cast<__half>(y0_ptr[tid]);
@@ -608,7 +608,7 @@ __global__ void jagged_dense_dense_elementwise_jagged_output_opt_gather_kernel_(
         values_ptr[tid] = v_out;
       }
     } else {
-      for (int tid = threadIdx.x; tid < E / 8; tid += blockDim.x) {
+      for (auto tid = threadIdx.x; tid < E / 8; tid += blockDim.x) {
         VecType128 v_x, v_out, v_y0, v_y1;
         v_x.data.mask =
             (reinterpret_cast<const VecType128::TType*>(x_ptr))[tid];
@@ -616,7 +616,7 @@ __global__ void jagged_dense_dense_elementwise_jagged_output_opt_gather_kernel_(
         (reinterpret_cast<VecType128::TType*>(values_ptr))[tid] =
             v_out.data.mask;
       }
-      for (int tid = threadIdx.x + (E / 8) * 8; tid < E / 4;
+      for (auto tid = threadIdx.x + (E / 8) * 8; tid < E / 4;
            tid += blockDim.x) {
         VecType64 v_x, v_out, v_y0, v_y1;
         v_x.data.mask = (reinterpret_cast<const VecType64::TType*>(x_ptr))[tid];
@@ -624,7 +624,7 @@ __global__ void jagged_dense_dense_elementwise_jagged_output_opt_gather_kernel_(
         (reinterpret_cast<VecType64::TType*>(values_ptr))[tid] =
             v_out.data.mask;
       }
-      for (int tid = threadIdx.x + (E / 4) * 4; tid < E / 2;
+      for (auto tid = threadIdx.x + (E / 4) * 4; tid < E / 2;
            tid += blockDim.x) {
         VecType32 v_x, v_out, v_y0, v_y1;
         v_x.data.mask = (reinterpret_cast<const VecType32::TType*>(x_ptr))[tid];
@@ -632,7 +632,7 @@ __global__ void jagged_dense_dense_elementwise_jagged_output_opt_gather_kernel_(
         (reinterpret_cast<VecType32::TType*>(values_ptr))[tid] =
             v_out.data.mask;
       }
-      for (int tid = threadIdx.x + (E / 2) * 2; tid < E; tid += blockDim.x) {
+      for (auto tid = threadIdx.x + (E / 2) * 2; tid < E; tid += blockDim.x) {
         __half v_x, v_out, v_y0, v_y1;
         v_x = static_cast<__half>(x_ptr[tid]);
         fh(v_out, v_x, v_y0, v_y1, f);

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_elementwise_mul_backward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_elementwise_mul_backward.cu
@@ -34,8 +34,8 @@ __launch_bounds__(kMaxThreads) void jagged_jagged_elementwise_dense_output_kerne
   const int jagged_folded_size = output.size(1);
   const int inner_dense_size = output.size(2);
 
-  const int outer_begin = blockIdx.x * blockDim.y + threadIdx.y;
-  const int outer_stride = gridDim.x * blockDim.y;
+  const auto outer_begin = blockIdx.x * blockDim.y + threadIdx.y;
+  const auto outer_stride = gridDim.x * blockDim.y;
   for (int outer = outer_begin; outer < outer_dense_size * jagged_folded_size;
        outer += outer_stride) {
     const int oidx = outer / jagged_folded_size;
@@ -46,12 +46,12 @@ __launch_bounds__(kMaxThreads) void jagged_jagged_elementwise_dense_output_kerne
         offset, jidx, jagged_dims, x_offsets);
 
     if (is_zero) {
-      for (int iidx = threadIdx.x; iidx < inner_dense_size;
+      for (auto iidx = threadIdx.x; iidx < inner_dense_size;
            iidx += blockDim.x) {
         output[oidx][jidx][iidx] = padding_value;
       }
     } else {
-      for (int iidx = threadIdx.x; iidx < inner_dense_size;
+      for (auto iidx = threadIdx.x; iidx < inner_dense_size;
            iidx += blockDim.x) {
         output[oidx][jidx][iidx] =
             f(x_values[offset][iidx], y_values[offset][iidx]);

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_index_add_2d_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_index_add_2d_forward.cu
@@ -52,7 +52,7 @@ __global__ __launch_bounds__(kMaxThreads) void jagged_index_add_2d_kernel(
     // TODO: Avoid using atoimcAdd (because it could lead to the numerical
     // indeterminism issue)
     const auto num_cols = output.size(1);
-    for (int i = threadIdx.x; i < num_cols; i += blockDim.x) {
+    for (auto i = threadIdx.x; i < num_cols; i += blockDim.x) {
       gpuAtomicAdd(&output[output_offset][i], values[dense_input_offset][i]);
     }
   }

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_index_select_2d_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_index_select_2d_forward.cu
@@ -49,7 +49,7 @@ __global__ __launch_bounds__(kMaxThreads) void jagged_index_select_2d_kernel(
         (index == 0 ? 0 : input_offsets[index - 1]) + rel_index;
 
     const auto num_cols = input.size(1);
-    for (int i = threadIdx.x; i < num_cols; i += blockDim.x) {
+    for (auto i = threadIdx.x; i < num_cols; i += blockDim.x) {
       output[dense_output_offset][i] = input[input_offset][i];
     }
   }

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_unique_indices.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_unique_indices.cu
@@ -37,7 +37,7 @@ __global__ __launch_bounds__(kMaxThreads) void linearize_index_wo_infos_kernel(
   const auto hash_offset = valid ? hash_size_cumsum[t] : -1;
   const auto indices_start = valid ? offsets[b_t] : -1;
   const int32_t L = valid ? offsets[b_t + 1] - indices_start : 0;
-  const int32_t lane_id = threadIdx.x % fbgemm_gpu::kWarpSize;
+  const auto lane_id = threadIdx.x % fbgemm_gpu::kWarpSize;
 
   for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
     const auto indices_start_warp = fbgemm_gpu::shfl_sync(indices_start, j);
@@ -88,9 +88,9 @@ __global__ __launch_bounds__(kMaxThreads) void unique_indices_length_kernel(
   __shared__ typename BlockReduce::TempStorage temp_storage_min;
   __shared__ index_t block_results[2];
 
-  const int32_t tid = threadIdx.x;
-  const int32_t bid = blockIdx.x;
-  const int32_t num_blocks = gridDim.x;
+  const auto tid = threadIdx.x;
+  const auto bid = blockIdx.x;
+  const auto num_blocks = gridDim.x;
   const int32_t batch_size = (offsets.size(0) - 1) / num_blocks;
 
   const auto offset_begin = hash_size_offsets[bid] * batch_size;
@@ -230,8 +230,8 @@ __global__ __launch_bounds__(kMaxThreads) void compute_hash_size_kernel(
   typedef cub::BlockReduce<index_t, kMaxThreads> BlockReduce;
   __shared__ typename BlockReduce::TempStorage temp_storage_max;
 
-  const int32_t tid = threadIdx.x;
-  const int32_t bid = blockIdx.x;
+  const auto tid = threadIdx.x;
+  const auto bid = blockIdx.x;
 
   const auto offset_begin = bid * batch_size;
   const auto offset_end = (bid + 1) * batch_size;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/936

CUDA kernel variables matching the type `(thread|block|grid).(Idx|Dim).(x|y|z)` [have the data type `uint`](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#built-in-variables).

Many programmers mistakenly use implicit casts to turn these data types into `int`. In fact, the [CUDA Programming Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/) it self is inconsistent and incorrect in its use of data types in programming examples.

The result of these implicit casts is that our kernels may give unexpected results when exposed to large datasets, i.e., those exceeding >~2B items.

While we now have linters in place to prevent simple mistakes (D71236150), our codebase has many problematic instances. This diff fixes some of them.

Reviewed By: sryap, dtolnay

Differential Revision: D71355405


