### PR TITLE
Revert "Use enum to select floating point format in FbgemmEmbedding APIs"

### DIFF
--- a/bench/EmbeddingSpMDMBenchmark.cc
+++ b/bench/EmbeddingSpMDMBenchmark.cc
@@ -55,7 +55,8 @@ void run_benchmark(
     int embedding_dim,
     int average_len,
     bool normalize_by_lengths,
-    FloatFormat in_format,
+    bool use_fp16_inputs = false,
+    bool use_bf16_inputs = false,
     bool use_32_bit_indices = false,
     bool prefetch = false) {
   // Create embedding table
@@ -68,13 +69,14 @@ void run_benchmark(
   }
   vector<float16> embedding_table_fp16;
   vector<bfloat16> embedding_table_bf16;
-  if (in_format == FloatFormat::FLOAT16) {
+  if (use_fp16_inputs) {
     embedding_table_fp16.resize(embedding_table.size());
     FloatToFloat16_simd(
         embedding_table.data(),
         embedding_table_fp16.data(),
         embedding_table.size());
-  } else if (in_format == FloatFormat::BFLOAT16) {
+  }
+  if (use_bf16_inputs) {
     embedding_table_bf16.resize(embedding_table.size());
     FloatToBfloat16_simd(
         embedding_table.data(),
@@ -124,17 +126,7 @@ void run_benchmark(
 
   constexpr int NUM_WARMUP = 4;
   constexpr int NUM_ITER = 10;
-  int elem_bytes = 0;
-  switch (in_format) {
-    case FloatFormat::FLOAT16:
-    case FloatFormat::BFLOAT16:
-      elem_bytes = sizeof(float16);
-      break;
-    case FloatFormat::DEFAULT:
-      elem_bytes = sizeof(float);
-      break;
-  }
-  assert(elem_bytes != 0);
+  int elem_bytes = use_fp16_inputs ? sizeof(float16) : sizeof(float);
   double bytes = lengths_sum *
           (embedding_dim * elem_bytes + (use_32_bit_indices ? 4 : 8)) +
       batch_size * sizeof(int);
@@ -148,7 +140,7 @@ void run_benchmark(
 
     bool success = false, success_ref = false;
 
-    if (in_format == FloatFormat::FLOAT16) {
+    if (use_fp16_inputs) {
       if (use_32_bit_indices) {
         success_ref = EmbeddingSpMDM_ref(
             embedding_dim,
@@ -160,15 +152,7 @@ void run_benchmark(
             offsets.data(),
             has_weight ? weights.data() : nullptr,
             normalize_by_lengths,
-            output_ref.data(),
-            /*is_weight_positional=*/false,
-            /*use_offsets=*/true,
-            /*output_stride=*/-1,
-            /*input_stride=*/-1,
-            /*scale_bias_last=*/true,
-            /*no_bag=*/false,
-            /*out_format=*/FloatFormat::DEFAULT,
-            /*in_format=*/in_format);
+            output_ref.data());
       } else {
         success_ref = EmbeddingSpMDM_ref(
             embedding_dim,
@@ -180,17 +164,9 @@ void run_benchmark(
             offsets.data(),
             has_weight ? weights.data() : nullptr,
             normalize_by_lengths,
-            output_ref.data(),
-            /*is_weight_positional=*/false,
-            /*use_offsets=*/true,
-            /*output_stride=*/-1,
-            /*input_stride=*/-1,
-            /*scale_bias_last=*/true,
-            /*no_bag=*/false,
-            /*out_format=*/FloatFormat::DEFAULT,
-            /*in_format=*/in_format);
+            output_ref.data());
       }
-    } else if (in_format == FloatFormat::BFLOAT16) {
+    } else if (use_bf16_inputs) {
       if (use_32_bit_indices) {
         success_ref = EmbeddingSpMDM_ref(
             embedding_dim,
@@ -202,15 +178,7 @@ void run_benchmark(
             offsets.data(),
             has_weight ? weights.data() : nullptr,
             normalize_by_lengths,
-            output_ref.data(),
-            /*is_weight_positional=*/false,
-            /*use_offsets=*/true,
-            /*output_stride=*/-1,
-            /*input_stride=*/-1,
-            /*scale_bias_last=*/true,
-            /*no_bag=*/false,
-            /*out_format=*/FloatFormat::DEFAULT,
-            /*in_format=*/in_format);
+            output_ref.data());
       } else {
         success_ref = EmbeddingSpMDM_ref(
             embedding_dim,
@@ -222,15 +190,7 @@ void run_benchmark(
             offsets.data(),
             has_weight ? weights.data() : nullptr,
             normalize_by_lengths,
-            output_ref.data(),
-            /*is_weight_positional=*/false,
-            /*use_offsets=*/true,
-            /*output_stride=*/-1,
-            /*input_stride=*/-1,
-            /*scale_bias_last=*/true,
-            /*no_bag=*/false,
-            /*out_format=*/FloatFormat::DEFAULT,
-            /*in_format=*/in_format);
+            output_ref.data());
       }
     } else {
       if (use_32_bit_indices) {
@@ -265,21 +225,9 @@ void run_benchmark(
     auto kernel_fp32_i64 = GenerateEmbeddingSpMDM<float, int64_t>(
         embedding_dim, has_weight, normalize_by_lengths, prefetch ? 16 : 0);
     auto kernel_fp16_i32 = GenerateEmbeddingSpMDM<float16, int32_t>(
-        embedding_dim,
-        has_weight,
-        normalize_by_lengths,
-        prefetch ? 16 : 0,
-        /*is_weight_positional=*/false,
-        /*use_offsets=*/true,
-        /*out_format=*/FloatFormat::FLOAT16);
+        embedding_dim, has_weight, normalize_by_lengths, prefetch ? 16 : 0);
     auto kernel_fp16_i64 = GenerateEmbeddingSpMDM<float16, int64_t>(
-        embedding_dim,
-        has_weight,
-        normalize_by_lengths,
-        prefetch ? 16 : 0,
-        /*is_weight_positional=*/false,
-        /*use_offsets=*/true,
-        /*out_format=*/FloatFormat::FLOAT16);
+        embedding_dim, has_weight, normalize_by_lengths, prefetch ? 16 : 0);
     auto kernel_bf16_i32 = GenerateEmbeddingSpMDM<bfloat16, int32_t>(
         embedding_dim,
         has_weight,
@@ -287,7 +235,7 @@ void run_benchmark(
         prefetch ? 16 : 0,
         /*is_weight_positional=*/false,
         /*use_offsets=*/true,
-        /*out_format=*/FloatFormat::BFLOAT16);
+        /*isbf16=*/true);
     auto kernel_bf16_i64 = GenerateEmbeddingSpMDM<bfloat16, int64_t>(
         embedding_dim,
         has_weight,
@@ -295,13 +243,13 @@ void run_benchmark(
         prefetch ? 16 : 0,
         /*is_weight_positional=*/false,
         /*is_weight_positional=*/true,
-        /*out_format=*/FloatFormat::BFLOAT16);
+        /*isbf16=*/true);
 
     vector<float>& output = has_weight ? output_slws : output_sls;
     for (bool flush_cache : {false, true}) {
       double t = measureWithWarmup(
           [&]() {
-            if (in_format == FloatFormat::FLOAT16) {
+            if (use_fp16_inputs) {
               if (use_32_bit_indices) {
                 success = kernel_fp16_i32(
                     batch_size,
@@ -323,7 +271,7 @@ void run_benchmark(
                     has_weight ? weights.data() : nullptr,
                     output.data());
               }
-            } else if (in_format == FloatFormat::BFLOAT16) {
+            } else if (use_bf16_inputs) {
               if (use_32_bit_indices) {
                 success = kernel_bf16_i32(
                     batch_size,
@@ -345,7 +293,7 @@ void run_benchmark(
                     has_weight ? weights.data() : nullptr,
                     output.data());
               }
-            } else if (in_format == FloatFormat::DEFAULT) {
+            } else {
               if (use_32_bit_indices) {
                 success = kernel_fp32_i32(
                     batch_size,
@@ -367,8 +315,6 @@ void run_benchmark(
                     has_weight ? weights.data() : nullptr,
                     output.data());
               }
-            } else {
-              std::abort(); // invalid/unexpected `in_format`
             }
           },
           NUM_WARMUP,
@@ -463,9 +409,8 @@ int main() {
               cout << "Mean ";
             }
             cout << input_dtype << " inputs";
-            FloatFormat in_format = input_dtype == "fp16" ? FloatFormat::FLOAT16
-                : input_dtype == "bf16" ? FloatFormat::BFLOAT16
-                                        : FloatFormat::DEFAULT;
+            bool use_fp16_inputs = input_dtype == "fp16" ? true : false;
+            bool use_bf16_inputs = input_dtype == "fp16" ? true : false;
             cout << (use_32_bit_indices ? " 32" : " 64") << " bit indices";
             if (prefetch) {
               cout << " with prefetching";
@@ -477,12 +422,13 @@ int main() {
                 embedding_dim,
                 average_len,
                 normalize_by_lengths,
-                in_format,
+                use_fp16_inputs,
+                use_bf16_inputs,
                 use_32_bit_indices,
                 prefetch);
           } // prefetch
         } // use_32_bit_indices
-      }
+      } // use_fp16_inputs
     } // normalize_by_length
   } // for each input
   return 0;

--- a/bench/EmbeddingSpMDMNBit2Benchmark.cc
+++ b/bench/EmbeddingSpMDMNBit2Benchmark.cc
@@ -313,7 +313,7 @@ int run_benchmark(
         /*output_stride=*/-1,
         /*input_stride=*/-1,
         /*scale_bias_last=*/true,
-        /*out_format=*/FloatFormat::DEFAULT,
+        /*is_bf16_out=*/false,
         /*no_bag=*/false,
         /*output_bit_rate=*/-1);
     auto kernel_64_autovec = GenerateEmbeddingSpMDMNBitWithStrides_autovec<
@@ -330,7 +330,7 @@ int run_benchmark(
         /*output_stride=*/-1,
         /*input_stride=*/-1,
         /*scale_bias_last=*/true,
-        /*out_format=*/FloatFormat::DEFAULT,
+        /*is_bf16_out=*/false,
         /*no_bag=*/false,
         /*output_bit_rate=*/-1);
 #endif

--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp
@@ -197,10 +197,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
     Tensor output;
     SparseType o_dtype = static_cast<SparseType>(output_dtype);
     TORCH_CHECK(o_dtype == SparseType::FP32 || o_dtype == SparseType::FP16 || o_dtype == SparseType::INT8 || o_dtype == SparseType::BF16 || o_dtype == SparseType::INT4);
-    fbgemm::FloatFormat out_format =
-      o_dtype == SparseType::FP16 ? fbgemm::FloatFormat::FLOAT16 :
-      (o_dtype == SparseType::BF16 ? fbgemm::FloatFormat::BFLOAT16 :
-       fbgemm::FloatFormat::DEFAULT);
+    bool output_is_bf16 = o_dtype == SparseType::BF16;
     bool output_is_int8 = o_dtype == SparseType::INT8;
     bool output_is_int4 = o_dtype == SparseType::INT4;
     {% if not nobag %}
@@ -312,9 +309,6 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
                     if use_base else ("GenerateEmbeddingSpMDMNBitWithStrides"
                     if use_nbit else "GenerateEmbeddingSpMDMFP8WithStrides")
                  %}
-                {% set in_format = "fbgemm::FloatFormat::FLOAT16" if weight_type == "float16" else
-                  "fbgemm::FloatFormat::DEFAULT" if weight_type in ("float", "uint8_t") else
-                  "$INVALID$" %}
                 using fbgemm_out_t = {{ "base_fbgemm_out_t" if use_base or use_nbit else "other_fbgemm_out_t" }};
                 {% if use_nbit %}
                 const int output_bit_rate = output_is_int4 ? 4 : sizeof(fbgemm_out_t) * 8;
@@ -362,14 +356,11 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
                     {% endif %}
                     {% if use_base %}
                     /*no_bag=*/nobag_op,
-                    /*out_format=*/out_format,
-                    /*in_format=*/{{ in_format }}
-                    {% elif use_nbit %}
-                    /*out_format=*/out_format,
-                    /*no_bag=*/nobag_op,
+                    {% endif %}
+                    /*is_bf16_out=*/output_is_bf16
+                    {% if use_nbit %}
+                    ,/*no_bag=*/nobag_op,
                     /*output_bit_rate=*/output_bit_rate
-                    {% else %}
-                    /*out_format=*/out_format
                     {% endif %}
                 );
                 success = kernel(

--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -11,7 +11,6 @@
 #include <functional>
 
 #include "fbgemm/FbgemmBuild.h"
-#include "fbgemm/Types.h"
 
 namespace fbgemm {
 
@@ -81,8 +80,8 @@ GenerateEmbeddingSpMDM(
     int prefetch = 16,
     bool is_weight_positional = false,
     bool use_offsets = true,
-    FloatFormat out_format = FloatFormat::DEFAULT,
-    FloatFormat in_format = FloatFormat::DEFAULT);
+    bool is_bf16_out = false,
+    bool is_bf16_in = false);
 
 /**
  * @param output_stride If -1, output_stride is same as block_size
@@ -114,8 +113,8 @@ GenerateEmbeddingSpMDMWithStrides(
     std::int64_t input_stride = -1,
     bool scale_bias_last = true,
     bool no_bag = false,
-    FloatFormat out_format = FloatFormat::DEFAULT,
-    FloatFormat in_format = FloatFormat::DEFAULT);
+    bool is_bf16_out = false,
+    bool is_bf16_in = false);
 
 /**
  * @tparam IndexType can be int32_t or int64_t
@@ -170,7 +169,7 @@ GenerateEmbeddingSpMDMNBitWithStrides(
     std::int64_t output_stride = -1,
     std::int64_t input_stride = -1,
     bool scale_bias_last = true,
-    FloatFormat out_format = FloatFormat::DEFAULT,
+    const bool is_bf16_out = false,
     const bool no_bag = false,
     int output_bit_rate = -1);
 
@@ -201,7 +200,7 @@ GenerateEmbeddingSpMDMFP8WithStrides(
     std::int64_t input_stride = -1,
     int exponent_bits = 4,
     int exponent_bias = 7,
-    FloatFormat out_format = FloatFormat::DEFAULT);
+    bool is_bf16_out = false);
 
 template <
     typename InType,
@@ -348,7 +347,7 @@ FBGEMM_API bool EmbeddingSpMDMBlockSize1_(
     float* out,
     bool is_weight_positional = false,
     bool use_offsets = true,
-    FloatFormat format = FloatFormat::DEFAULT);
+    bool is_bf16 = false);
 
 template <typename IndexType, bool HAS_WEIGHTS>
 void compressed_indices_remap_avx512(

--- a/include/fbgemm/Types.h
+++ b/include/fbgemm/Types.h
@@ -15,17 +15,11 @@ namespace fbgemm {
 using float16 = std::uint16_t;
 using bfloat16 = std::uint16_t;
 
-enum class FloatFormat : std::uint8_t {
-  DEFAULT, // `float` (aka IEEE754 "single").
-  FLOAT16, // float16 (aka IEEE754 "half") passed as `uint16_t`
-  BFLOAT16, // bfloat16 passed as `uint16_t`. https://arxiv.org/abs/1905.12322v3
-};
-
-inline std::int64_t round_up(std::int64_t val, std::int64_t unit) {
+inline int64_t round_up(int64_t val, int64_t unit) {
   return (val + unit - 1) / unit * unit;
 }
 
-inline std::int64_t div_up(std::int64_t val, std::int64_t unit) {
+inline int64_t div_up(int64_t val, int64_t unit) {
   return (val + unit - 1) / unit;
 }
 

--- a/src/EmbeddingSpMDMAutovec.cc
+++ b/src/EmbeddingSpMDMAutovec.cc
@@ -53,25 +53,19 @@ static inline void fill_output(
     OutType* out,
     const float* src,
     const int64_t block_size,
-    const FloatFormat out_format) {
+    const bool is_bf16_out) {
   if (std::is_same<OutType, float>::value) {
-    assert(out_format == FloatFormat::DEFAULT);
     for (int j = 0; j < block_size; ++j) {
       out[j] = src[j];
     }
-  } else if (std::is_same<OutType, float16>::value) {
-    if (out_format == FloatFormat::BFLOAT16) {
-      for (int j = 0; j < block_size; ++j) {
-        out[j] = cpu_float2bfloat16(src[j]);
-      }
-    } else {
-      assert(out_format == FloatFormat::FLOAT16);
-      for (int j = 0; j < block_size; ++j) {
-        out[j] = cpu_float2half(src[j]);
-      }
+  } else if (std::is_same<OutType, uint16_t>::value && is_bf16_out) {
+    for (int j = 0; j < block_size; ++j) {
+      out[j] = cpu_float2bfloat16(src[j]);
     }
   } else {
-    std::abort(); // invalid/unexpected OutType
+    for (int j = 0; j < block_size; ++j) {
+      out[j] = cpu_float2half(src[j]);
+    }
   }
 }
 
@@ -93,7 +87,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDM8Bit_autovec(
     const int64_t input_stride,
     const bool scale_bias_last,
     const bool no_bag,
-    const FloatFormat out_format) {
+    const bool is_bf16_out) {
   constexpr bool isOutput8bit = std::is_same<OutType, uint8_t>::value;
   if (data_size < 0) {
     return false;
@@ -173,7 +167,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDM8Bit_autovec(
           uint8_t value = input_row[j];
           buf[j] = std::fma(scale, (float)value, buf[j] + bias);
         }
-        fill_output(out, buf, block_size, out_format);
+        fill_output(out, buf, block_size, is_bf16_out);
       }
       out += output_stride;
     } // m
@@ -255,7 +249,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDM8Bit_autovec(
         buf[j] *= scale;
       }
     }
-    fill_output(out, buf, block_size, out_format);
+    fill_output(out, buf, block_size, is_bf16_out);
     out += output_stride;
   }
   return current == index_size;
@@ -279,7 +273,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
     const int64_t output_stride,
     const int64_t input_stride,
     const bool scale_bias_last,
-    const FloatFormat out_format,
+    const bool is_bf16_out,
     const bool no_bag,
     int output_bit_rate) {
   nbit_embedding_sanity_check<OutType>(input_bit_rate, output_bit_rate, no_bag);
@@ -445,7 +439,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
         buf[j] *= scale;
       }
     }
-    fill_output(out, buf, block_size, out_format);
+    fill_output(out, buf, block_size, is_bf16_out);
     out += output_stride;
   }
   return current == index_size;
@@ -483,9 +477,9 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
 /// set to `true` for FP32 autovec implementation (`bool`)
 /// @param no_bag If `true`, no embedding bag; set to `false` for FP32 autovec
 /// implementation (`bool`)
-/// @param out_format floating point format for output
+/// @param is_bf16_out If `true`, output is `BFLOAT16` type; set to `false` for
 /// FP32 autovec implementation (`bool`)
-/// @param in_format floating point format for input
+/// @param is_bf16_in If `true`, input is `BFLOAT16` type; set to `false` for
 /// FP32 autovec implementation (`bool`)
 template <
     typename InType,
@@ -508,8 +502,8 @@ static bool ALWAYS_INLINE EmbeddingSpMDM_autovec(
     const int64_t output_stride,
     const int64_t input_stride,
     const bool no_bag,
-    const FloatFormat out_format,
-    const FloatFormat in_format) {
+    const bool is_bf16_out,
+    const bool is_bf16_in) {
   if (data_size < 0) {
     return false;
   }
@@ -538,29 +532,29 @@ static bool ALWAYS_INLINE EmbeddingSpMDM_autovec(
 #ifdef FBGEMM_VECTOR_WIDTH
         for (; j < block_size - (block_size % FBGEMM_VECTOR_WIDTH); ++j) {
           const InType* inptr = input + input_stride * idx + j;
-          buf[j] =
-              std::fma(weight, convert_to_float_ref(*inptr, in_format), buf[j]);
+          buf[j] = std::fma(
+              weight, convert_to_float_ref(*inptr, is_bf16_in), buf[j]);
         }
 #endif
         for (; j < block_size; ++j) {
           const InType* inptr = input + input_stride * idx + j;
-          buf[j] =
-              std::fma(weight, convert_to_float_ref(*inptr, in_format), buf[j]);
+          buf[j] = std::fma(
+              weight, convert_to_float_ref(*inptr, is_bf16_in), buf[j]);
         }
       } else {
         int64_t j = 0;
 #ifdef FBGEMM_VECTOR_WIDTH
         for (; j < block_size - (block_size % FBGEMM_VECTOR_WIDTH); ++j) {
           const InType* inptr = input + input_stride * idx + j;
-          buf[j] += convert_to_float_ref(*inptr, in_format);
+          buf[j] += convert_to_float_ref(*inptr, is_bf16_in);
         }
 #endif
         for (; j < block_size; ++j) {
           const InType* inptr = input + input_stride * idx + j;
-          buf[j] += convert_to_float_ref(*inptr, in_format);
+          buf[j] += convert_to_float_ref(*inptr, is_bf16_in);
         }
       }
-      fill_output(out, buf, block_size, out_format);
+      fill_output(out, buf, block_size, is_bf16_out);
       out += output_stride;
     } // m
     return true;
@@ -632,12 +626,12 @@ static bool ALWAYS_INLINE EmbeddingSpMDM_autovec(
 #ifdef FBGEMM_VECTOR_WIDTH
       for (; j < block_size - (block_size % FBGEMM_VECTOR_WIDTH); ++j) {
         InType value = *input_row++;
-        buf[j] = std::fma(w, convert_to_float_ref(value, in_format), buf[j]);
+        buf[j] = std::fma(w, convert_to_float_ref(value, is_bf16_in), buf[j]);
       }
 #endif
       for (; j < block_size; ++j) {
         InType value = *input_row++;
-        buf[j] = std::fma(w, convert_to_float_ref(value, in_format), buf[j]);
+        buf[j] = std::fma(w, convert_to_float_ref(value, is_bf16_in), buf[j]);
       }
 
       ++current;
@@ -650,7 +644,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDM_autovec(
       }
     }
 
-    fill_output(out, buf, block_size, out_format);
+    fill_output(out, buf, block_size, is_bf16_out);
     out += output_stride;
   }
   return current == index_size;
@@ -856,7 +850,7 @@ void Float8ToFloat_ref_batch(
 /// for FP8 autovec implementation (`int64_t`)
 /// @param exponent_bits Bits to use in exponent
 /// @param exponent_bias Bias to use in exponent
-/// @param out_format  floating point format for output
+/// @param is_bf16_out If `true`, output is `BFLOAT16` type; set to `false` for
 /// FP8 autovec implementation (`bool`)
 template <typename IndexType, typename OffsetType, typename OutType>
 static bool ALWAYS_INLINE EmbeddingSpMDMFP8_autovec(
@@ -876,7 +870,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDMFP8_autovec(
     const int64_t input_stride,
     const int exponent_bits,
     const int exponent_bias,
-    const FloatFormat out_format) {
+    const bool is_bf16_out) {
   if (data_size < 0) {
     return false;
   }
@@ -1000,7 +994,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDMFP8_autovec(
       }
     }
 
-    fill_output(out, buf, block_size, out_format);
+    fill_output(out, buf, block_size, is_bf16_out);
     out += output_stride;
   }
   return current == index_size;
@@ -1078,8 +1072,8 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
         int64_t input_stride,
         bool scale_bias_last,
         bool no_bag,
-        FloatFormat out_format,
-        FloatFormat in_format) {
+        bool is_bf16_out,
+        bool is_bf16_in) {
   if (output_stride == -1) {
     output_stride = block_size;
   }
@@ -1103,8 +1097,8 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
     INPUT_STRIDE,                                                         \
     SCALE_BIAS_LAST,                                                      \
     NO_BAG,                                                               \
-    OUT_FORMAT,                                                           \
-    IN_FORMAT)                                                            \
+    IS_BF16_OUT,                                                          \
+    IS_BF16_IN)                                                           \
   if (match(BLOCK_SIZE, block_size) && match(HAS_WEIGHT, has_weight) &&   \
       match(NORMALIZE_BY_LENGTHS, normalize_by_lengths) &&                \
       match(PREFETCH, prefetch) &&                                        \
@@ -1113,7 +1107,7 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
       match(OUTPUT_STRIDE, output_stride) &&                              \
       match(INPUT_STRIDE, input_stride) &&                                \
       match(SCALE_BIAS_LAST, scale_bias_last) && match(NO_BAG, no_bag) && \
-      match(OUT_FORMAT, out_format) && match(IN_FORMAT, in_format)) {     \
+      match(IS_BF16_OUT, is_bf16_out) && match(IS_BF16_IN, is_bf16_in)) { \
     return [=](int64_t output_size,                                       \
                int64_t index_size,                                        \
                int64_t data_size,                                         \
@@ -1129,7 +1123,7 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
         weights = nullptr;                                                \
       }                                                                   \
       if (std::is_same<InType, uint8_t>::value) {                         \
-        assert(specialize(IN_FORMAT, in_format) == FloatFormat::DEFAULT); \
+        assert(!specialize(IS_BF16_IN, is_bf16_in));                      \
         return EmbeddingSpMDM8Bit_autovec(                                \
             specialize(BLOCK_SIZE, block_size),                           \
             output_size,                                                  \
@@ -1147,7 +1141,7 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
             specialize(INPUT_STRIDE, input_stride),                       \
             specialize(SCALE_BIAS_LAST, scale_bias_last),                 \
             specialize(NO_BAG, no_bag),                                   \
-            specialize(OUT_FORMAT, out_format));                          \
+            specialize(IS_BF16_OUT, is_bf16_out));                        \
       } else {                                                            \
         return EmbeddingSpMDM_autovec(                                    \
             /*block_size=*/specialize(BLOCK_SIZE, block_size),            \
@@ -1165,8 +1159,8 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
             /*output_stride=*/specialize(OUTPUT_STRIDE, output_stride),   \
             /*input_stride=*/specialize(INPUT_STRIDE, input_stride),      \
             /*no_bag=*/specialize(NO_BAG, no_bag),                        \
-            /*out_format=*/specialize(OUT_FORMAT, out_format),            \
-            /*in_format=*/specialize(IN_FORMAT, in_format));              \
+            /*is_bf16_out=*/specialize(IS_BF16_OUT, is_bf16_out),         \
+            /*is_bf16_in=*/specialize(IS_BF16_IN, is_bf16_in));           \
       }                                                                   \
     };                                                                    \
   }
@@ -1178,8 +1172,8 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
     IS_WEIGHT_POSITIONAL,                                                  \
     USE_OFFSETS,                                                           \
     NO_BAG,                                                                \
-    IN_FORMAT,                                                             \
-    OUT_FORMAT)                                                            \
+    IS_BF16_OUT,                                                           \
+    IS_BF16_IN)                                                            \
   SPECIALIZE(                                                              \
       /*BLOCK_SIZE*/ fixed(int64_t{32}),                                   \
       HAS_WEIGHT,                                                          \
@@ -1191,8 +1185,8 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
       /*INPUT_STRIDE*/ fixed(stride_SpMDMWithStrides<InType>(32, false)),  \
       /*SCALE_BIAS_LAST*/ fixed(false),                                    \
       NO_BAG,                                                              \
-      OUT_FORMAT,                                                          \
-      IN_FORMAT)                                                           \
+      IS_BF16_OUT,                                                         \
+      IS_BF16_IN)                                                          \
   SPECIALIZE(                                                              \
       /*BLOCK_SIZE*/ fixed(int64_t{64}),                                   \
       HAS_WEIGHT,                                                          \
@@ -1204,8 +1198,8 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
       /*INPUT_STRIDE*/ fixed(stride_SpMDMWithStrides<InType>(64, false)),  \
       /*SCALE_BIAS_LAST*/ fixed(false),                                    \
       NO_BAG,                                                              \
-      OUT_FORMAT,                                                          \
-      IN_FORMAT)                                                           \
+      IS_BF16_OUT,                                                         \
+      IS_BF16_IN)                                                          \
   SPECIALIZE(                                                              \
       /*BLOCK_SIZE*/ fixed(int64_t{124}),                                  \
       HAS_WEIGHT,                                                          \
@@ -1217,8 +1211,8 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
       /*INPUT_STRIDE*/ fixed(stride_SpMDMWithStrides<InType>(124, false)), \
       /*SCALE_BIAS_LAST*/ fixed(false),                                    \
       NO_BAG,                                                              \
-      OUT_FORMAT,                                                          \
-      IN_FORMAT)                                                           \
+      IS_BF16_OUT,                                                         \
+      IS_BF16_IN)                                                          \
   SPECIALIZE(                                                              \
       /*BLOCK_SIZE*/ fixed(int64_t{128}),                                  \
       HAS_WEIGHT,                                                          \
@@ -1230,8 +1224,8 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
       /*INPUT_STRIDE*/ fixed(stride_SpMDMWithStrides<InType>(128, false)), \
       /*SCALE_BIAS_LAST*/ fixed(false),                                    \
       NO_BAG,                                                              \
-      OUT_FORMAT,                                                          \
-      IN_FORMAT)                                                           \
+      IS_BF16_OUT,                                                         \
+      IS_BF16_IN)                                                          \
   SPECIALIZE(                                                              \
       /*BLOCK_SIZE*/ fixed(int64_t{252}),                                  \
       HAS_WEIGHT,                                                          \
@@ -1243,8 +1237,8 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
       /*INPUT_STRIDE*/ fixed(stride_SpMDMWithStrides<InType>(252, false)), \
       /*SCALE_BIAS_LAST*/ fixed(false),                                    \
       NO_BAG,                                                              \
-      OUT_FORMAT,                                                          \
-      IN_FORMAT)                                                           \
+      IS_BF16_OUT,                                                         \
+      IS_BF16_IN)                                                          \
   SPECIALIZE(                                                              \
       /*BLOCK_SIZE*/ fixed(int64_t{256}),                                  \
       HAS_WEIGHT,                                                          \
@@ -1256,8 +1250,8 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
       /*INPUT_STRIDE*/ fixed(stride_SpMDMWithStrides<InType>(256, false)), \
       /*SCALE_BIAS_LAST*/ fixed(false),                                    \
       NO_BAG,                                                              \
-      OUT_FORMAT,                                                          \
-      IN_FORMAT)                                                           \
+      IS_BF16_OUT,                                                         \
+      IS_BF16_IN)                                                          \
   SPECIALIZE(                                                              \
       /*BLOCK_SIZE*/ fixed(int64_t{508}),                                  \
       HAS_WEIGHT,                                                          \
@@ -1269,8 +1263,8 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
       /*INPUT_STRIDE*/ fixed(stride_SpMDMWithStrides<InType>(508, false)), \
       /*SCALE_BIAS_LAST*/ fixed(false),                                    \
       NO_BAG,                                                              \
-      OUT_FORMAT,                                                          \
-      IN_FORMAT)                                                           \
+      IS_BF16_OUT,                                                         \
+      IS_BF16_IN)                                                          \
   SPECIALIZE(                                                              \
       /*BLOCK_SIZE*/ fixed(int64_t{512}),                                  \
       HAS_WEIGHT,                                                          \
@@ -1282,8 +1276,8 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
       /*INPUT_STRIDE*/ fixed(stride_SpMDMWithStrides<InType>(512, false)), \
       /*SCALE_BIAS_LAST*/ fixed(false),                                    \
       NO_BAG,                                                              \
-      OUT_FORMAT,                                                          \
-      IN_FORMAT)
+      IS_BF16_OUT,                                                         \
+      IS_BF16_IN)
 
 #ifdef FBGEMM_MORE_SPECIALIZATION
   SPECIALIZE_BLOCK_SIZE(
@@ -1293,8 +1287,8 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
       /*IS_WEIGHT_POSITIONAL*/ fixed(false),
       /*USE_OFFSETS*/ fixed(true),
       /*NO_BAG*/ fixed(false),
-      /*OUT_FORMAT*/ var,
-      /*IN_FORMAT*/ var)
+      /*IS_BF16_OUT*/ var,
+      /*IS_BF16_IN*/ var)
   SPECIALIZE_BLOCK_SIZE(
       /*HAS_WEIGHT*/ fixed(false),
       /*NORMALIZE_BY_LENGTHS*/ fixed(false),
@@ -1302,8 +1296,8 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
       /*IS_WEIGHT_POSITIONAL*/ fixed(false),
       /*USE_OFFSETS*/ fixed(true),
       /*NO_BAG*/ fixed(false),
-      /*OUT_FORMAT*/ var,
-      /*IN_FORMAT*/ var)
+      /*IS_BF16_OUT*/ var,
+      /*IS_BF16_IN*/ var)
   WARN_ONCE(
       "fbgemm warning: "
       "using non-specialized EmbeddingSpMDM_autovec (may be slow)\n"
@@ -1352,7 +1346,7 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
     int64_t output_stride,
     int64_t input_stride,
     bool scale_bias_last,
-    FloatFormat out_format,
+    bool is_bf16_out,
     bool no_bag,
     int output_bit_rate) {
   if (output_bit_rate == -1) {
@@ -1381,7 +1375,7 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
     OUTPUT_STRIDE,                                                           \
     INPUT_STRIDE,                                                            \
     SCALE_BIAS_LAST,                                                         \
-    OUT_FORMAT,                                                              \
+    IS_BF16_OUT,                                                             \
     NO_BAG,                                                                  \
     OUTPUT_BIT_RATE)                                                         \
   if (match(INPUT_BIT_RATE, input_bit_rate) &&                               \
@@ -1392,7 +1386,7 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
       match(OUTPUT_STRIDE, output_stride) &&                                 \
       match(INPUT_STRIDE, input_stride) &&                                   \
       match(SCALE_BIAS_LAST, scale_bias_last) &&                             \
-      match(OUT_FORMAT, out_format) && match(NO_BAG, no_bag) &&              \
+      match(IS_BF16_OUT, is_bf16_out) && match(NO_BAG, no_bag) &&            \
       match(OUTPUT_BIT_RATE, output_bit_rate)) {                             \
     return [=](int64_t output_size,                                          \
                int64_t index_size,                                           \
@@ -1424,7 +1418,7 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
           /*output_stride=*/specialize(OUTPUT_STRIDE, output_stride),        \
           /*input_stride=*/specialize(INPUT_STRIDE, input_stride),           \
           /*scale_bias_last=*/specialize(SCALE_BIAS_LAST, scale_bias_last),  \
-          /*out_format=*/specialize(OUT_FORMAT, out_format),                 \
+          /*is_bf16_out=*/specialize(IS_BF16_OUT, is_bf16_out),              \
           /*no_bag=*/specialize(NO_BAG, no_bag),                             \
           /*output_bit_rate=*/specialize(OUTPUT_BIT_RATE, output_bit_rate)); \
     };                                                                       \
@@ -1437,7 +1431,7 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
     IS_WEIGHT_POSITIONAL,                                                      \
     USE_OFFSETS,                                                               \
     SCALE_BIAS_LAST,                                                           \
-    OUT_FORMAT,                                                                \
+    IS_BF16_OUT,                                                               \
     NO_BAG,                                                                    \
     OUTPUT_BIT_RATE)                                                           \
   SPECIALIZE(                                                                  \
@@ -1450,7 +1444,7 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
       /*OUTPUT_STRIDE*/ var,                                                   \
       /*INPUT_STRIDE*/ fixed(stride_SpMDMNBitWith(INPUT_BIT_RATE.value, 32)),  \
       SCALE_BIAS_LAST,                                                         \
-      OUT_FORMAT,                                                              \
+      IS_BF16_OUT,                                                             \
       NO_BAG,                                                                  \
       OUTPUT_BIT_RATE)                                                         \
   SPECIALIZE(                                                                  \
@@ -1463,7 +1457,7 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
       /*OUTPUT_STRIDE*/ var,                                                   \
       /*INPUT_STRIDE*/ fixed(stride_SpMDMNBitWith(INPUT_BIT_RATE.value, 56)),  \
       SCALE_BIAS_LAST,                                                         \
-      OUT_FORMAT,                                                              \
+      IS_BF16_OUT,                                                             \
       NO_BAG,                                                                  \
       OUTPUT_BIT_RATE)                                                         \
   SPECIALIZE(                                                                  \
@@ -1476,7 +1470,7 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
       /*OUTPUT_STRIDE*/ var,                                                   \
       /*INPUT_STRIDE*/ fixed(stride_SpMDMNBitWith(INPUT_BIT_RATE.value, 64)),  \
       SCALE_BIAS_LAST,                                                         \
-      OUT_FORMAT,                                                              \
+      IS_BF16_OUT,                                                             \
       NO_BAG,                                                                  \
       OUTPUT_BIT_RATE)                                                         \
   SPECIALIZE(                                                                  \
@@ -1489,7 +1483,7 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
       /*OUTPUT_STRIDE*/ var,                                                   \
       /*INPUT_STRIDE*/ fixed(stride_SpMDMNBitWith(INPUT_BIT_RATE.value, 120)), \
       SCALE_BIAS_LAST,                                                         \
-      OUT_FORMAT,                                                              \
+      IS_BF16_OUT,                                                             \
       NO_BAG,                                                                  \
       OUTPUT_BIT_RATE)                                                         \
   SPECIALIZE(                                                                  \
@@ -1502,7 +1496,7 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
       /*OUTPUT_STRIDE*/ var,                                                   \
       /*INPUT_STRIDE*/ fixed(stride_SpMDMNBitWith(INPUT_BIT_RATE.value, 128)), \
       SCALE_BIAS_LAST,                                                         \
-      OUT_FORMAT,                                                              \
+      IS_BF16_OUT,                                                             \
       NO_BAG,                                                                  \
       OUTPUT_BIT_RATE)                                                         \
   SPECIALIZE(                                                                  \
@@ -1515,7 +1509,7 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
       /*OUTPUT_STRIDE*/ var,                                                   \
       /*INPUT_STRIDE*/ fixed(stride_SpMDMNBitWith(INPUT_BIT_RATE.value, 248)), \
       SCALE_BIAS_LAST,                                                         \
-      OUT_FORMAT,                                                              \
+      IS_BF16_OUT,                                                             \
       NO_BAG,                                                                  \
       OUTPUT_BIT_RATE)                                                         \
   SPECIALIZE(                                                                  \
@@ -1528,7 +1522,7 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
       /*OUTPUT_STRIDE*/ var,                                                   \
       /*INPUT_STRIDE*/ fixed(stride_SpMDMNBitWith(INPUT_BIT_RATE.value, 256)), \
       SCALE_BIAS_LAST,                                                         \
-      OUT_FORMAT,                                                              \
+      IS_BF16_OUT,                                                             \
       NO_BAG,                                                                  \
       OUTPUT_BIT_RATE)
 
@@ -1538,7 +1532,7 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
     IS_WEIGHT_POSITIONAL,          \
     USE_OFFSETS,                   \
     SCALE_BIAS_LAST,               \
-    OUT_FORMAT,                    \
+    IS_BF16_OUT,                   \
     NO_BAG)                        \
   SPECIALIZE_BLOCK_SIZE(           \
       /*INPUT_BIT_RATE*/ fixed(4), \
@@ -1547,7 +1541,7 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
       IS_WEIGHT_POSITIONAL,        \
       USE_OFFSETS,                 \
       SCALE_BIAS_LAST,             \
-      OUT_FORMAT,                  \
+      IS_BF16_OUT,                 \
       NO_BAG,                      \
       /*OUTPUT_BIT_RATE*/ fixed(int{8 * sizeof(OutType)}))
 
@@ -1558,7 +1552,7 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
       /*IS_WEIGHT_POSITIONAL*/ fixed(false),
       /*USE_OFFSETS*/ fixed(true),
       /*SCALE_BIAS_LAST*/ fixed(false),
-      /*OUT_FORMAT*/ var,
+      /*IS_BF16_OUT*/ var,
       /*NO_BAG*/ fixed(false))
   SPECIALIZE_INPUT_RATE(
       /*HAS_WEIGHT*/ fixed(false),
@@ -1566,7 +1560,7 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
       /*IS_WEIGHT_POSITIONAL*/ fixed(false),
       /*USE_OFFSETS*/ fixed(true),
       /*SCALE_BIAS_LAST*/ fixed(false),
-      /*OUT_FORMAT*/ var,
+      /*IS_BF16_OUT*/ var,
       /*NO_BAG*/ fixed(false))
   WARN_ONCE(
       "fbgemm warning: "
@@ -1637,7 +1631,7 @@ GenerateEmbeddingSpMDMFP8WithStrides_autovec(
     int64_t input_stride,
     int exponent_bits,
     int exponent_bias,
-    FloatFormat out_format) {
+    bool is_bf16_out) {
   if (output_stride == -1) {
     output_stride = block_size;
   }
@@ -1669,7 +1663,7 @@ GenerateEmbeddingSpMDMFP8WithStrides_autovec(
         /*input_stride=*/input_stride,
         /*exponent_bits=*/exponent_bits,
         /*exponent_bias=*/exponent_bias,
-        /*out_format=*/out_format);
+        /*is_bf16_out=*/is_bf16_out);
   };
 }
 
@@ -1734,7 +1728,7 @@ GenerateEmbeddingSpMDMRowWiseSparse_autovec(
       int64_t output_stride,                                                   \
       int64_t input_stride,                                                    \
       bool scale_bias_last,                                                    \
-      FloatFormat out_format,                                                  \
+      bool is_bf16_out,                                                        \
       bool no_bag,                                                             \
       int output_bit_rate);
 
@@ -1756,7 +1750,7 @@ GenerateEmbeddingSpMDMRowWiseSparse_autovec(
       int64_t input_stride,                                      \
       int exponent_bits,                                         \
       int exponent_bias,                                         \
-      FloatFormat out_format);
+      bool is_bf16_out);
 
 #define INSTANTIATE_SPMDM_BASE(INDEX_TYPE, OFFSET_TYPE, OUT_TYPE)        \
   INSTANTIATE_SPMDM_NBIT_WITH_STRIDES(INDEX_TYPE, OFFSET_TYPE, OUT_TYPE) \
@@ -1812,8 +1806,8 @@ INSTANTIATE_SPMDM_OFFSET_T(int64_t)
       int64_t input_stride,                                                \
       bool scale_bias_last,                                                \
       bool no_bag,                                                         \
-      FloatFormat out_format,                                              \
-      FloatFormat in_format);
+      bool is_bf16_out,                                                    \
+      bool is_bf16_in);
 
 #define INSTANTIATE_SPMDM_OUT_T(IN_TYPE, INDEX_TYPE, OFFSET_TYPE)        \
   INSTANTIATE_SPMDM_BASE(IN_TYPE, INDEX_TYPE, OFFSET_TYPE, float)        \

--- a/src/EmbeddingSpMDMAutovec.h
+++ b/src/EmbeddingSpMDMAutovec.h
@@ -36,8 +36,8 @@ typename EmbeddingSpMDMKernelSignature<InType, IndexType, OffsetType, OutType>::
         int64_t input_stride,
         bool scale_bias_last,
         bool no_bag,
-        FloatFormat out_format,
-        FloatFormat in_format);
+        bool is_bf16_out,
+        bool is_bf16_in);
 
 template <typename IndexType, typename OffsetType, typename OutType>
 typename EmbeddingSpMDMKernelSignature<
@@ -56,7 +56,7 @@ GenerateEmbeddingSpMDMNBitWithStrides_autovec(
     int64_t output_stride,
     int64_t input_stride,
     bool scale_bias_last,
-    FloatFormat out_format,
+    bool is_bf16_out,
     bool no_bag,
     int output_bit_rate);
 
@@ -75,7 +75,7 @@ GenerateEmbeddingSpMDMFP8WithStrides_autovec(
     int64_t input_stride,
     int exponent_bits,
     int exponent_bias,
-    FloatFormat out_format);
+    bool is_bf16_out);
 
 template <typename InType, typename IndexType, typename OffsetType>
 typename EmbeddingSpMDMRowWiseSparseKernelSignature<

--- a/src/EmbeddingSpMDMAvx2.cc
+++ b/src/EmbeddingSpMDMAvx2.cc
@@ -29,7 +29,7 @@ bool EmbeddingSpMDMBlockSize1_(
     float* out,
     bool is_weight_positional,
     bool use_offsets,
-    FloatFormat format) {
+    bool is_bf16) {
   int64_t current = 0;
   for (int m = 0; m < output_size; ++m) {
     out[m] = 0;
@@ -116,7 +116,7 @@ bool EmbeddingSpMDMBlockSize1_(
       }
 
       const InType* inptr = input + indices[current];
-      temp = std::fma(w, convert_to_float_ref(*inptr, format), temp);
+      temp = std::fma(w, convert_to_float_ref(*inptr, is_bf16), temp);
 
       ++current;
     }
@@ -142,7 +142,7 @@ bool EmbeddingSpMDMBlockSize1_(
       float* out,                                                \
       bool is_weight_positional,                                 \
       bool use_offsets,                                          \
-      FloatFormat format);
+      bool is_bf16);
 
 #define INSTANTIATE_SPMDM_OFFSET_T(IN_TYPE, INDEX_TYPE)     \
   INSTANTIATE_SPMDM_BASE(IN_TYPE, INDEX_TYPE, std::int32_t) \

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -1181,10 +1181,10 @@ void transposeConvWeights(
   }
 }
 
-template float convert_to_float_ref(float src, FloatFormat format);
-template float convert_to_float_ref(uint16_t src, FloatFormat format);
-template float convert_from_float_ref(float src, FloatFormat format);
-template uint16_t convert_from_float_ref(float bfloat16, FloatFormat format);
+template float convert_to_float_ref(float src, bool is_bf16_out);
+template float convert_to_float_ref(uint16_t src, bool is_bf16_out);
+template float convert_from_float_ref(float src, bool is_bf16_out);
+template uint16_t convert_from_float_ref(float bfloat16, bool is_bf16_out);
 
 template <
     typename InType,
@@ -1208,8 +1208,8 @@ bool EmbeddingSpMDM_ref(
     int64_t input_stride /*=-1*/,
     bool scale_bias_last /*=true*/,
     bool no_bag /*=false*/,
-    FloatFormat out_format /*=FloatFormat::DEFAULT*/,
-    FloatFormat in_format /*=FloatFormat::DEFAULT*/) {
+    bool is_bf16_out /*=false*/,
+    bool is_bf16_in /*=false*/) {
   const bool isWeight8bit = is_same<InType, uint8_t>::value;
   const bool isOutput8bit = is_same<OutType, uint8_t>::value;
   if (output_stride == -1) {
@@ -1272,7 +1272,7 @@ bool EmbeddingSpMDM_ref(
                 buf[j] + bias);
           }
           for (int j = 0; j < block_size; ++j) {
-            out[j] = convert_from_float_ref<OutType>(buf[j], out_format);
+            out[j] = convert_from_float_ref<OutType>(buf[j], is_bf16_out);
           }
         }
         out += output_stride;
@@ -1332,7 +1332,7 @@ bool EmbeddingSpMDM_ref(
         }
       }
       for (int j = 0; j < block_size; ++j) {
-        out[j] = convert_from_float_ref<OutType>(buf[j], out_format);
+        out[j] = convert_from_float_ref<OutType>(buf[j], is_bf16_out);
       }
       out += output_stride;
     }
@@ -1357,10 +1357,11 @@ bool EmbeddingSpMDM_ref(
 
         for (int j = 0; j < block_size; ++j) {
           const InType* inptr = input + input_stride * idx + j;
-          buf[j] = std::fma(w, convert_to_float_ref(*inptr, in_format), buf[j]);
+          buf[j] =
+              std::fma(w, convert_to_float_ref(*inptr, is_bf16_in), buf[j]);
         }
         for (int j = 0; j < block_size; ++j) {
-          out[j] = convert_from_float_ref<OutType>(buf[j], out_format);
+          out[j] = convert_from_float_ref<OutType>(buf[j], is_bf16_out);
         }
         out += output_stride;
       } // m
@@ -1389,7 +1390,8 @@ bool EmbeddingSpMDM_ref(
 
         for (int j = 0; j < block_size; ++j) {
           const InType* inptr = input + input_stride * idx + j;
-          buf[j] = std::fma(w, convert_to_float_ref(*inptr, in_format), buf[j]);
+          buf[j] =
+              std::fma(w, convert_to_float_ref(*inptr, is_bf16_in), buf[j]);
         }
 
         ++current;
@@ -1401,7 +1403,7 @@ bool EmbeddingSpMDM_ref(
         }
       }
       for (int j = 0; j < block_size; ++j) {
-        out[j] = convert_from_float_ref<OutType>(buf[j], out_format);
+        out[j] = convert_from_float_ref<OutType>(buf[j], is_bf16_out);
       }
       out += output_stride;
     }
@@ -1427,7 +1429,7 @@ bool EmbeddingSpMDMNBit_ref(
     int64_t output_stride /*=-1*/,
     int64_t input_stride /*=-1*/,
     const bool scale_bias_last /*=true*/,
-    const FloatFormat out_format /*=FloatFormat::DEFAULT*/,
+    const bool is_bf16_out /*=false*/,
     const bool no_bag /*=false*/,
     int output_bit_rate /*=-1*/) {
   if (output_bit_rate == -1) {
@@ -1518,7 +1520,7 @@ bool EmbeddingSpMDMNBit_ref(
       }
     }
     for (int j = 0; j < block_size; ++j) {
-      out[j] = convert_from_float_ref<OutType>(buf[j], out_format);
+      out[j] = convert_from_float_ref<OutType>(buf[j], is_bf16_out);
     }
     out += output_stride;
   }
@@ -1543,7 +1545,7 @@ bool EmbeddingSpMDMFP8_ref(
     int64_t input_stride,
     int exponent_bits,
     int exponent_bias,
-    FloatFormat out_format /*=FloatFormat::DEFAULT*/) {
+    bool is_bf16_out /*=false*/) {
   if (output_stride == -1) {
     output_stride = block_size;
   }
@@ -1593,7 +1595,7 @@ bool EmbeddingSpMDMFP8_ref(
     }
     for (int j = 0; j < block_size; ++j) {
       out[j] = is_same<OutType, uint16_t>::value
-          ? convert_from_float_ref<OutType>(buf[j], out_format)
+          ? convert_from_float_ref<OutType>(buf[j], is_bf16_out)
           : buf[j];
     }
     out += output_stride;
@@ -2090,8 +2092,8 @@ template FBGEMM_API void transposeConvWeights(
       int64_t output_stride,                                               \
       bool scale_bias_last,                                                \
       bool no_bag,                                                         \
-      FloatFormat out_format,                                              \
-      FloatFormat in_format);
+      bool is_bf16_out,                                                    \
+      bool is_bf16_in);
 
 #define INSTANTIATE_SPMDM_OUT_T(IN_TYPE, INDEX_TYPE, OFFSET_TYPE)        \
   INSTANTIATE_SPMDM_BASE(IN_TYPE, INDEX_TYPE, OFFSET_TYPE, float)        \
@@ -2147,7 +2149,7 @@ INSTANTIATE_SPMDM_INDEX_T(std::uint8_t)
       int64_t output_stride,                                           \
       int64_t input_stride,                                            \
       const bool scale_bias_last,                                      \
-      const FloatFormat out_format,                                    \
+      const bool is_bf16_out,                                          \
       const bool no_bag,                                               \
       int output_bit_rate);
 #define INSTANTIATE_SPMDM_FP8_BASE(INDEX_TYPE, OFFSET_TYPE, OUT_TYPE) \
@@ -2168,7 +2170,7 @@ INSTANTIATE_SPMDM_INDEX_T(std::uint8_t)
       int64_t input_stride,                                           \
       int exponent_bits,                                              \
       int exponent_bias,                                              \
-      FloatFormat out_format);
+      bool is_bf16_out);
 
 #define INSTANTIATE_SPMDM_OUT_T(INDEX_TYPE, OFFSET_TYPE)        \
   INSTANTIATE_SPMDM_NBIT_BASE(INDEX_TYPE, OFFSET_TYPE, float)   \

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -239,8 +239,8 @@ FBGEMM_API bool EmbeddingSpMDM_ref(
     std::int64_t input_stride = -1,
     bool scale_bias_last = true,
     bool no_bag = false,
-    FloatFormat out_format = FloatFormat::DEFAULT,
-    FloatFormat in_format = FloatFormat::DEFAULT);
+    bool is_bf16_out = false,
+    bool is_bf16_in = false);
 
 template <
     typename IndexType = std::int64_t,
@@ -263,7 +263,7 @@ FBGEMM_API bool EmbeddingSpMDMNBit_ref(
     std::int64_t output_stride = -1,
     std::int64_t input_stride = -1,
     const bool scale_bias_last = true,
-    const FloatFormat out_format = FloatFormat::DEFAULT,
+    const bool is_bf16_out = false,
     const bool no_bag = false,
     int output_bit_rate = -1);
 
@@ -288,7 +288,7 @@ bool EmbeddingSpMDMFP8_ref(
     int64_t input_stride = -1,
     int exponent_bits = 4,
     int exponent_bias = 7,
-    FloatFormat out_format = FloatFormat::DEFAULT);
+    bool is_bf16_out = false);
 
 template <
     typename InType = std::uint8_t,
@@ -416,11 +416,10 @@ FBGEMM_API void compressed_indices_remap_ref(
     float* out_weights);
 
 template <typename T>
-float convert_to_float_ref(T src, FloatFormat format = FloatFormat::DEFAULT) {
+float convert_to_float_ref(T src, bool is_bf16 = false) {
   float f_value;
   if (std::is_same<T, uint16_t>::value) {
-    f_value = format == FloatFormat::BFLOAT16 ? cpu_bf162float(src)
-                                              : cpu_half2float(src);
+    f_value = is_bf16 ? cpu_bf162float(src) : cpu_half2float(src);
   } else {
     f_value = src;
   }
@@ -428,11 +427,10 @@ float convert_to_float_ref(T src, FloatFormat format = FloatFormat::DEFAULT) {
 }
 
 template <typename T>
-T convert_from_float_ref(float src, FloatFormat format = FloatFormat::DEFAULT) {
+T convert_from_float_ref(float src, bool is_bf16 = false) {
   T o_value;
   if (std::is_same<T, uint16_t>::value) {
-    o_value = format == FloatFormat::BFLOAT16 ? cpu_float2bfloat16(src)
-                                              : cpu_float2half_rn(src);
+    o_value = is_bf16 ? cpu_float2bfloat16(src) : cpu_float2half_rn(src);
   } else {
     o_value = src;
   }

--- a/test/EmbeddingSpMDMNBitTest.cc
+++ b/test/EmbeddingSpMDMNBitTest.cc
@@ -98,7 +98,7 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
   tie(bit_rate, prefetch, weight_choice, corner_case, out_type) = GetParam();
   bool is_wt_positional = weight_choice == POSITIONAL_WEIGHTED;
   bool use_weight = weight_choice != UNWEIGHTED;
-  FloatFormat out_format = floatFormatFor(out_type);
+  bool is_bf16_out = out_type == BFLOAT16;
 
   if (corner_case != NONE || weight_choice == POSITIONAL_WEIGHTED) {
     // Check corner case only for subset of tests.
@@ -226,7 +226,7 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
       /*output_stride=*/-1,                                             \
       /*input_stride=*/-1,                                              \
       scale_bias_last,                                                  \
-      out_format);                                                      \
+      is_bf16_out);                                                     \
                                                                         \
   auto kernel = GenerateEmbeddingSpMDMNBitWithStrides<                  \
       IndexType,                                                        \
@@ -243,7 +243,7 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
       /*output_stride=*/-1,                                             \
       /*input_stride=*/-1,                                              \
       scale_bias_last,                                                  \
-      out_format);                                                      \
+      is_bf16_out);                                                     \
   success = kernel(                                                     \
       batch_size,                                                       \
       lengths_sum,                                                      \

--- a/test/EmbeddingSpMDMTestUtils.h
+++ b/test/EmbeddingSpMDMTestUtils.h
@@ -9,10 +9,7 @@
 #pragma once
 
 #include <cstdint>
-#include <cstdlib>
 #include <vector>
-
-#include "fbgemm/Types.h"
 
 namespace fbgemm {
 
@@ -61,18 +58,5 @@ int CreateMappingTableForRowWiseSparsity(
     std::vector<std::int32_t>& mapping_table,
     int num_rows,
     float sparsity);
-
-inline FloatFormat floatFormatFor(EmbeddingSpMDMDtypeChoice DTC) {
-  switch (DTC) {
-    case FLOAT:
-      return FloatFormat::DEFAULT;
-    case FLOAT16:
-      return FloatFormat::FLOAT16;
-    case BFLOAT16:
-      return FloatFormat::BFLOAT16;
-  }
-  // unknown/invalid float format.
-  std::abort();
-}
 
 } // namespace fbgemm


### PR DESCRIPTION
Reverts pytorch/FBGEMM#3842

I was not able to land the corresponding pytorch commit https://github.com/pytorch/pytorch/pull/149338 so preparing the revert commit now so it is ready when needed.