### PR TITLE
scatter_add 0 size support

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/gather_scatter/gather_scatter.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/gather_scatter/gather_scatter.cu
@@ -351,6 +351,10 @@ void scatter_add_along_first_dim(
     const int M = src.size(0);
     const int K = src.size(1);
     const int N = index.size(0);
+    if (N == 0) {
+      assert(M == 0);
+      return;
+    }
     assert(dst.size(1) == K);
     // TODO(shikaili): Make it supports more configurations.
     if (dst.dtype() == at::kBFloat16 && src.dtype() == at::kBFloat16 &&

--- a/fbgemm_gpu/experimental/gen_ai/test/gather_scatter/gather_scatter_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/gather_scatter/gather_scatter_test.py
@@ -149,6 +149,8 @@ class GatherScatterTests(unittest.TestCase):
         _test_scatter_add_along_first_dim(4096, 4096, 5120)
         _test_scatter_add_along_first_dim(8192, 8192, 5120)
 
+        _test_scatter_add_along_first_dim(0, 10, 5120)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary: Add support for 0-sized index in scatter_add_along_first_dim

Differential Revision: D71602180


