### PR TITLE
Add torch.jit.script to unit tests

### DIFF
--- a/fbgemm_gpu/test/tbe/training/backward_dense_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_dense_test.py
@@ -229,6 +229,9 @@ class BackwardDenseTest(unittest.TestCase):
             weights_precision=weights_precision,
             output_dtype=output_dtype,
         )
+        # Test torch JIT script compatibility
+        if not use_cpu:
+            cc = torch.jit.script(cc)
 
         for t in range(T):
             cc.split_embedding_weights()[t].data.copy_(bs[t].weight)

--- a/fbgemm_gpu/test/tbe/training/forward_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_test.py
@@ -76,6 +76,9 @@ additional_decorators.update(
         "test_faketensor__test_forward_gpu_uvm_cache_int8": [
             unittest.skip("Operator not implemented for Meta tensors"),
         ],
+        "test_faketensor__test_forward_cpu_fp32": [
+            unittest.skip("Operator not implemented for Meta tensors"),
+        ],
         # TODO: Make it compatible with opcheck tests
         "test_faketensor__test_forward_gpu_uvm_cache_fp16": [
             unittest.skip(
@@ -293,6 +296,9 @@ class ForwardTest(unittest.TestCase):
             output_dtype=output_dtype,
             use_experimental_tbe=use_experimental_tbe,
         )
+        # Test torch JIT script compatibility
+        if not use_cpu:
+            cc = torch.jit.script(cc)
 
         for t in range(T):
             cc.split_embedding_weights()[t].data.copy_(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/956

We previously removed torch.jit.script from the tests since it was long deprecated. However, many pyper and production models are still using `torch.jit.script`.

We add torch.jit.script to the tests to ensure torch script compatibility

Reviewed By: q10

Differential Revision: D71602117


