### PR TITLE
Use PackedAccessor64 for index_remappings in pruned_array_lookup

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_lookup.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_lookup.cu
@@ -107,7 +107,7 @@ __launch_bounds__(kMaxThreads) void int_nbit_split_embedding_codegen_forward_pru
         indices,
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         offsets,
-    const pta::PackedTensorAccessor32<remap_t, 1, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor64<remap_t, 1, at::RestrictPtrTraits>
         index_remappings,
     const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         index_remappings_offsets,
@@ -131,7 +131,7 @@ __launch_bounds__(kMaxThreads) void int_nbit_split_embedding_codegen_forward_pru
 
   if (capacity > 0) {
     for (index_t l = threadIdx.x; l < L; l += blockDim.x) {
-      index_t idx = indices[indices_start + l];
+      const overflow_safe_int_t idx = indices[indices_start + l];
       dense_indices[indices_start + l] =
           static_cast<index_t>(index_remappings[index_remappings_start + idx]);
     }
@@ -249,7 +249,7 @@ Tensor pruned_array_lookup_cuda(
                   MAKE_PTA_WITH_NAME(func_name, indices, index_t, 1, 32),
                   MAKE_PTA_WITH_NAME(func_name, offsets, index_t, 1, 32),
                   MAKE_PTA_WITH_NAME(
-                      func_name, index_remappings, remap_t, 1, 32),
+                      func_name, index_remappings, remap_t, 1, 64),
                   MAKE_PTA_WITH_NAME(
                       func_name, index_remappings_offsets, int64_t, 1, 32),
                   B,

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/tensor_accessor.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/tensor_accessor.h
@@ -823,3 +823,9 @@ pta::PackedTensorAccessor64<T, N, PtrTraits> make_packed_tensor_accessor64(
 #define MAKE_PTA_ACC_WITH_NAME(FUNC_NAME, TENSOR, T, N, INDEX_NBITS) \
   MAKE_PACKED_TENSOR_ACCESSOR_ACC_TYPE_BASE(                         \
       FUNC_NAME, TENSOR, T, N, at::RestrictPtrTraits, INDEX_NBITS)
+
+// !! Please do not modify the overflow_safe_int_t value unless you absolutely
+// understand what you are doing !!
+//
+// An integer datatype for preventing the integer overflow problem
+using overflow_safe_int_t = int64_t;


### PR DESCRIPTION
Summary:
Use the int64_t index for index_remappings in pruned_array_lookup to
address the `numel needs to be smaller than int32_t max; otherwise,
please use packed_accessor64` issue

Differential Revision: D71576185


