### PR TITLE
[fbgemm_gpu] Increase timeout for Nova jobs

### DIFF
--- a/.github/workflows/build_wheels_linux_aarch64.yml
+++ b/.github/workflows/build_wheels_linux_aarch64.yml
@@ -61,4 +61,4 @@ jobs:
       trigger-event: ${{ github.event_name }}
       architecture: aarch64
       setup-miniconda: false
-      timeout: 180
+      timeout: 210

--- a/.github/workflows/build_wheels_linux_x86.yml
+++ b/.github/workflows/build_wheels_linux_x86.yml
@@ -51,4 +51,4 @@ jobs:
       test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       trigger-event: ${{ github.event_name }}
-      timeout: 180
+      timeout: 240


### PR DESCRIPTION
- Increase timeout for Nova jobs to facilitate B200-targeted builds