### PR TITLE
int4 kv

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.cpp
@@ -37,6 +37,8 @@ at::Tensor nope_qkv_varseq_prefill(
     std::optional<at::Tensor> block_tables,
     int64_t page_size,
     std::optional<at::Tensor> varseq_cache_seqpos,
+    int64_t cache_logical_dtype_int,
+    std::optional<int64_t> num_groups,
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> qparam_v,
     bool k_norm,
@@ -54,6 +56,8 @@ at::Tensor nope_qkv_decoding(
     std::optional<at::Tensor> actual_batch_size,
     std::optional<at::Tensor> batch,
     std::optional<at::Tensor> cache_seqpos,
+    int64_t cache_logical_dtype_int,
+    std::optional<int64_t> num_groups,
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> qparam_v,
     bool k_norm,
@@ -191,9 +195,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def("rope_qkv_decoding(Tensor XQ, Tensor? XK, Tensor? XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor seqpos, float theta, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
       DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None,  int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192, float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False, bool update_kv=True) -> Tensor");
   m.def("nope_qkv_varseq_prefill(Tensor XQ, Tensor? XK, Tensor? XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor varseq_batch, Tensor varseq_seqpos, Tensor? block_tables=None, int page_size=" STRING(
-      DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False, bool update_kv=True) -> Tensor");
+      DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, int cache_logical_dtype_int=0, int? num_groups=1, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False, bool update_kv=True) -> Tensor");
   m.def("nope_qkv_decoding(Tensor XQ, Tensor? XK, Tensor? XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor seqpos, Tensor? block_tables=None, int page_size=" STRING(
-      DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False, bool update_kv=True) -> Tensor");
+      DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None, int cache_logical_dtype_int=0, int? num_groups=1, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False, bool update_kv=True) -> Tensor");
   m.def("xpos_qkv_varseq_prefill(Tensor XQ, Tensor XK, Tensor XV, Tensor(a!) cache_K, Tensor(b!) cache_V, Tensor varseq_batch, Tensor varseq_seqpos, float theta, float gamma, float scale_base, float exponent_offset, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
       DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192, float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32,  Tensor? qparam_k=None, Tensor? qparam_v=None) -> Tensor");
   m.def("xpos_qkv_decoding(Tensor XQ, Tensor XK, Tensor XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor seqpos, float theta, float gamma, float scale_base, float exponent_offset, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
@@ -294,6 +298,8 @@ at::Tensor nope_qkv_varseq_prefill_meta(
     std::optional<at::Tensor> /* block_tables */,
     int64_t /* page_size */,
     std::optional<at::Tensor> /* varseq_cache_seqpos */,
+    int64_t /* cache_logical_dtype_int */,
+    std::optional<int64_t> /* num_groups */,
     std::optional<at::Tensor> /* qparam_k */,
     std::optional<at::Tensor> /* qparam_v */,
     bool /* k_norm */,
@@ -314,6 +320,8 @@ at::Tensor nope_qkv_decoding_meta(
     std::optional<at::Tensor> /* actual_batch_size */,
     std::optional<at::Tensor> /* batch */,
     std::optional<at::Tensor> /* cache_seqpos */,
+    int64_t /* cache_logical_dtype_int */,
+    std::optional<int64_t> /* num_groups */,
     std::optional<at::Tensor> /* qparam_k */,
     std::optional<at::Tensor> /* qparam_v */,
     bool /* k_norm */,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/968

Enabling int4 KV for LLama4 numeric evals
Changes:
1) k_norm
2) zero init dequantization.
3) Add NoPE for int4

Differential Revision: D70508737


