### PR TITLE
Improve Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfNeon by 2%-10%

### DIFF
--- a/bench/EmbeddingQuantizeFloatToFloatOrHalfBenchmark.cc
+++ b/bench/EmbeddingQuantizeFloatToFloatOrHalfBenchmark.cc
@@ -52,10 +52,14 @@ void performance_test() {
 
       double duration = 0.0f;
 
+      int constexpr kNumRepeats = is_same<T, float16>::value ? 16 : 32;
+
       duration = measureWithWarmup(
           [&]() {
-            Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf(
-                inpVec.data(), rowSize, colSize, outVec.data());
+            for (int i = 0; i < kNumRepeats; ++i) {
+              Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf(
+                  inpVec.data(), rowSize, colSize, outVec.data());
+            }
           },
           NWARMUP,
           NITER,
@@ -64,10 +68,11 @@ void performance_test() {
             cache_evict(outVec);
           });
 
-      float elements_per_usec = rowSize * colSize / (duration * 1e6);
+      float elements_per_usec =
+          rowSize * colSize * kNumRepeats / (duration * 1e6);
 
       duration *= 1e9; // convert to ns
-      long bytes_read = rowSize * colSize * sizeof(float);
+      long bytes_read = rowSize * colSize * sizeof(float) * kNumRepeats;
       float gigabyes_per_sec = bytes_read / duration;
 
       cout << setw(6) << rowSize << ", " << setw(6) << colSize << ",";


### PR DESCRIPTION
Summary:
Improve pointer handling, which resulted in fewer instructions being emmitted.
Benchmark has been tweaked to run many iterations, results variance has decreased.
Throughput has shown to slightly increase on average:

before:

  rows,  cols,  elems_per_usec,    GB/Sec
   100,     16,          284.98,      36.48
   100,     64,          343.60,      43.98
   100,    128,          345.09,      44.17
   100,    256,          349.13,      44.69
   100,    512,          359.58,      46.03
   100,   1024,          363.10,      46.48
   100,   2048,          361.29,      46.24
   120,     16,          255.53,      32.71
   120,     64,          328.49,      42.05
   120,    128,          336.15,      43.03
   120,    256,          341.72,      43.74
   120,    512,          346.44,      44.34
   120,   1024,          353.13,      45.20
   120,   2048,          352.42,      45.11
  1000,     16,          285.37,      36.53
  1000,     64,          351.33,      44.97
  1000,    128,          358.20,      45.85
  1000,    256,          356.01,      45.57
  1000,    512,          330.18,      42.26
  1000,   1024,          296.49,      37.95
  1000,   2048,          276.04,      35.33

after:

  rows,  cols,  elems_per_usec,    GB/Sec
   100,     16,          314.54,      40.26
   100,     64,          330.03,      42.24
   100,    128,          343.18,      43.93
   100,    256,          341.87,      43.76
   100,    512,          359.40,      46.00
   100,   1024,          360.88,      46.19
   100,   2048,          365.71,      46.81
   120,     16,          318.10,      40.72
   120,     64,          337.54,      43.21
   120,    128,          335.05,      42.89
   120,    256,          346.33,      44.33
   120,    512,          362.96,      46.46
   120,   1024,          367.23,      47.01
   120,   2048,          362.73,      46.43
  1000,     16,          321.24,      41.12
  1000,     64,          360.85,      46.19
  1000,    128,          362.14,      46.35
  1000,    256,          363.73,      46.56
  1000,    512,          347.99,      44.54
  1000,   1024,          298.69,      38.23
  1000,   2048,          276.86,      35.44

Differential Revision: D71684779


