### PR TITLE
Fix empty input view.

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
@@ -516,7 +516,8 @@ OutputType _f8f8bf16_rowwise_grouped(
   at::Tensor g_out = selected_kernel(XQ, WQ, x_scale, w_scale, kernel_args, Y);
   // Get output in appropriate format.
   if constexpr (std::is_same_v<OutputType, at::Tensor>) {
-    return g_out.view({total_M, -1});
+    int N = WQ[0].size(0);
+    return g_out.view({total_M, N});
   } else {
     std::vector<at::Tensor> output_groups = g_out.split(output_sizes);
     for (int i = 0; i < group_count; i++) {
@@ -644,6 +645,11 @@ at::Tensor f8f8bf16_rowwise_grouped_dynamic(
   // of kernel setup.
   at::Tensor Y =
       at::empty({group_count, M, N}, XQ.options().dtype(at::kBFloat16));
+
+  // Early exit for empty input.
+  if (Y.numel() == 0) {
+    return Y;
+  }
 
   // Prepare kernel arguments by copying them to the proper device location.
   at::Tensor kernel_args = at::empty(

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_grouped.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_grouped.cu
@@ -689,7 +689,8 @@ OutputType _f8f8bf16_rowwise_grouped(
 
   // Return appropriate output type.
   if constexpr (std::is_same_v<OutputType, at::Tensor>) {
-    return g_out.view({total_M, -1});
+    int N = WQ[0].size(0);
+    return g_out.view({total_M, N});
   } else {
     // Return grouped view of output.
     std::vector<at::Tensor> output_group = g_out.split(output_sizes);
@@ -769,7 +770,7 @@ at::Tensor f8f8bf16_rowwise_grouped_dynamic(
   at::Tensor output = dispatch_fp8_grouped_kernel<at::Tensor>(
       G * M, XQ, WQ, x_scale, w_scale, Y, zero_start_index_M);
   // View as proper shape.
-  return output.view({-1, M, N});
+  return output.view({G, M, N});
 }
 
 #else

--- a/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
@@ -744,7 +744,7 @@ class FP8Tests(unittest.TestCase):
     @settings(deadline=None)
     @given(
         G=st.sampled_from([1, 4, 5, 16]),
-        M=st.sampled_from([2048, 3584]),
+        M=st.sampled_from([0, 2048, 3584]),
         N=st.sampled_from([1024, 6144]),
         K=st.sampled_from([512, 3584]),
         use_cudagraph=st.booleans(),
@@ -759,15 +759,18 @@ class FP8Tests(unittest.TestCase):
         use_cudagraph: bool,
         mode: str,
     ) -> None:
-        ms = (
-            torch.randint(
-                (258 // 64) + 1 if mode == "padding" else 1,
-                (M // 64) + 1,
-                (G,),
-                dtype=torch.int,
+        if M > 0:
+            ms = (
+                torch.randint(
+                    (258 // 64) + 1 if mode == "padding" else 1,
+                    (M // 64) + 1,
+                    (G,),
+                    dtype=torch.int,
+                )
+                * 64
             )
-            * 64
-        )
+        else:
+            ms = torch.zeros((G,), dtype=torch.int)
         # Only default supports true dynamism.
         if mode != "default":
             ns = [N] * G


### PR DESCRIPTION
Summary: When inputs are empty an invalid view with shape {0, -1] occurred. this small change uses a fixed positive integer instead of -1 to avoid the issue.

Differential Revision: D71843894


