### PR TITLE
Enable groupwise scales for F8I4 Grouped Gemm

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
@@ -1402,10 +1402,7 @@ class F8I4ShuffledGroupedGemm(QuantizeOpBase):
         m_sizes = torch.tensor(m_values).to(dtype=torch.int32, device=x[0].device)
         # Quantize weights.
         # TODO Only rowwise scaling is currently supported. This needs to be fixed.
-        K = x[0].shape[-1]
-        wq, row_scale, group_scale = zip(
-            *[quantize_int4_preshuffle(i, group_size=K) for i in w]
-        )
+        wq, row_scale, group_scale = zip(*[quantize_int4_preshuffle(i) for i in w])
         # Group weights as single tensor.
         wq = torch.stack(wq, dim=0).contiguous()
         row_scale = torch.stack(row_scale, dim=0).contiguous()

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8i4bf16_shuffled_grouped.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8i4bf16_shuffled_grouped.cu
@@ -145,10 +145,6 @@ void _f8i4bf16_shuffled_grouped(
   // Group scales should have shape [G, num_scale_groups, 8, N]
   int num_scale_groups = w_scale_group.size(1);
   int group_size = K / num_scale_groups;
-  TORCH_CHECK(
-      num_scale_groups == 1,
-      "Mixed dtype grouped gemm only supports rowwise scaling currently (group_size=K).");
-
   // Define cutlass types.
   using ProblemShape = cutlass::gemm::GroupProblemShape<
       cute::Shape<int, int, int>>; // <M,N,K> per group.


### PR DESCRIPTION
Summary: Due to cutlass support limitations, we previously required that F8I4 grouped gemm use rowwise scales for its weights. This leaves a lot of accuracy on the table compared to groupwise scales (which we use for standard f8i4 gemm). This diff adds support for groupwise scaling and lifts the restriction from our implementation.

Differential Revision: D71905839


