### PR TITLE
bf16 stacked group gemm

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/bf16_grouped_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/bf16_grouped_gemm.hip
@@ -57,75 +57,76 @@ struct IntTupleHash {
 
 // For certain high priority shapes, we directly map to the best kernel rather
 // than use heuristics.
-static const std::unordered_map<std::tuple<int, int, int, int>, GroupedKernel, IntTupleHash> bf16_grouped_lookup_dispatch = {
-{{16,16,2048,5120},bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_intrawave_v2},
-{{16,16,5120,1024},bf16_grouped_64x16x16x128_16x16_1x1_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_interwave_v2},
-{{16,16,16384,5120},bf16_grouped_64x16x32x128_16x16_1x2_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v2},
-{{16,16,5120,8192},bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v1},
-{{16,32,2048,5120},bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2},
-{{16,32,5120,1024},bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2},
-{{16,32,16384,5120},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v1},
-{{16,32,5120,8192},bf16_grouped_128x16x96x64_16x16_1x3_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1},
-{{16,64,2048,5120},bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2},
-{{16,64,5120,1024},bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2},
-{{16,64,16384,5120},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v1},
-{{16,64,5120,8192},bf16_grouped_128x16x96x64_16x16_1x3_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1},
-{{16,128,2048,5120},bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2},
-{{16,128,5120,1024},bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2},
-{{16,128,16384,5120},bf16_grouped_64x16x64x128_16x16_1x4_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v2},
-{{16,128,5120,8192},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v1},
-{{16,256,2048,5120},bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2},
-{{16,256,5120,1024},bf16_grouped_128x16x32x128_16x16_1x1_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2},
-{{16,256,16384,5120},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v1},
-{{16,256,5120,8192},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v1},
-{{16,512,2048,5120},bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_interwave_v2},
-{{16,512,5120,1024},bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v2},
-{{16,512,16384,5120},bf16_grouped_128x32x96x128_16x16_2x3_16x8x1_16x8x1_1x32x1x4_8x8x1_2x1_intrawave_v2},
-{{16,512,5120,8192},bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v1},
-{{16,1024,2048,5120},bf16_grouped_256x64x128x128_32x32_2x1_16x16x1_16x16x1_1x16x1x16_8x8x1_1x1_intrawave_v3},
-{{16,1024,5120,1024},bf16_grouped_256x64x96x64_16x16_2x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3},
-{{16,1024,16384,5120},bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawave_v3},
-{{16,1024,5120,8192},bf16_grouped_128x64x96x64_16x16_4x3_8x16x1_8x16x1_1x32x1x4_8x8x1_2x1_intrawave_v3},
-{{16,2048,2048,5120},bf16_grouped_256x128x128x128_32x32_2x2_16x16x1_16x16x1_1x32x1x8_8x8x1_1x1_intrawave_v3},
-{{16,2048,5120,1024},bf16_grouped_256x128x96x64_16x16_4x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3},
-{{16,2048,16384,5120},bf16_grouped_256x128x224x64_16x16_4x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3},
-{{16,2048,5120,8192},bf16_grouped_256x128x96x64_16x16_4x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3},
-{{16,4096,2048,5120},bf16_grouped_256x128x256x64_32x32_4x2_8x32x1_8x32x1_1x16x1x16_8x8x1_1x1_intrawave_v3},
-{{16,4096,5120,1024},bf16_grouped_256x128x96x64_16x16_4x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3},
-{{16,4096,16384,5120},bf16_grouped_256x256x224x64_16x16_8x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3},
-{{16,4096,5120,8192},bf16_grouped_256x256x160x64_16x16_8x5_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3},
-{{16,8192,2048,5120},bf16_grouped_256x256x256x64_32x32_4x4_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3},
-{{16,8192,5120,1024},bf16_grouped_256x256x192x64_32x32_4x3_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3},
-{{16,8192,16384,5120},bf16_grouped_256x256x224x64_16x16_8x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3},
-{{16,8192,5120,8192},bf16_grouped_256x256x192x64_32x32_4x3_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3},
-{{128,128,2048,5120},bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2},
-{{128,128,5120,1024},bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2},
-{{128,128,16384,5120},bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v2},
-{{128,128,5120,8192},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2},
-{{128,256,2048,5120},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v1},
-{{128,256,5120,1024},bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2},
-{{128,256,16384,5120},bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v1},
-{{128,256,5120,8192},bf16_grouped_64x16x48x128_16x16_1x3_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_intrawave_v1},
-{{128,512,2048,5120},bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_intrawave_v2},
-{{128,512,5120,1024},bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2},
-{{128,512,16384,5120},bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v2},
-{{128,512,5120,8192},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2},
-{{128,1024,2048,5120},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v2},
-{{128,1024,5120,1024},bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_intrawave_v2},
-{{128,1024,16384,5120},bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v2},
-{{128,1024,5120,8192},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2},
-{{128,2048,2048,5120},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v2},
-{{128,2048,5120,1024},bf16_grouped_128x16x32x128_16x16_1x1_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2},
-{{128,2048,16384,5120},bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v2},
-{{128,2048,5120,8192},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v1},
-{{128,4096,2048,5120},bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_intrawave_v1},
-{{128,4096,5120,1024},bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_interwave_v2},
-{{128,4096,16384,5120},bf16_grouped_256x32x128x128_16x16_1x4_16x16x1_16x16x1_1x32x1x8_8x8x1_1x2_intrawave_v2},
-{{128,4096,5120,8192},bf16_grouped_256x32x224x64_16x16_1x7_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_intrawave_v1},
-{{128,8192,2048,5120},bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawave_v3},
-{{128,8192,5120,1024},bf16_grouped_128x64x128x64_32x32_2x2_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_intrawave_v3},
-{{128,8192,16384,5120},bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawave_v3},
-{{128,8192,5120,8192},bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawave_v3},
+template <typename InputType, typename OutputType>
+static const std::unordered_map<std::tuple<int, int, int, int>, GroupedKernel<InputType, OutputType>, IntTupleHash> bf16_grouped_lookup_dispatch = {
+{{16,16,2048,5120},bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_intrawave_v2<InputType, OutputType>},
+{{16,16,5120,1024},bf16_grouped_64x16x16x128_16x16_1x1_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_interwave_v2<InputType, OutputType>},
+{{16,16,16384,5120},bf16_grouped_64x16x32x128_16x16_1x2_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v2<InputType, OutputType>},
+{{16,16,5120,8192},bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v1<InputType, OutputType>},
+{{16,32,2048,5120},bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2<InputType, OutputType>},
+{{16,32,5120,1024},bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2<InputType, OutputType>},
+{{16,32,16384,5120},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v1<InputType, OutputType>},
+{{16,32,5120,8192},bf16_grouped_128x16x96x64_16x16_1x3_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1<InputType, OutputType>},
+{{16,64,2048,5120},bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2<InputType, OutputType>},
+{{16,64,5120,1024},bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2<InputType, OutputType>},
+{{16,64,16384,5120},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v1<InputType, OutputType>},
+{{16,64,5120,8192},bf16_grouped_128x16x96x64_16x16_1x3_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1<InputType, OutputType>},
+{{16,128,2048,5120},bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2<InputType, OutputType>},
+{{16,128,5120,1024},bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2<InputType, OutputType>},
+{{16,128,16384,5120},bf16_grouped_64x16x64x128_16x16_1x4_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v2<InputType, OutputType>},
+{{16,128,5120,8192},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v1<InputType, OutputType>},
+{{16,256,2048,5120},bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2<InputType, OutputType>},
+{{16,256,5120,1024},bf16_grouped_128x16x32x128_16x16_1x1_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2<InputType, OutputType>},
+{{16,256,16384,5120},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v1<InputType, OutputType>},
+{{16,256,5120,8192},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v1<InputType, OutputType>},
+{{16,512,2048,5120},bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_interwave_v2<InputType, OutputType>},
+{{16,512,5120,1024},bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v2<InputType, OutputType>},
+{{16,512,16384,5120},bf16_grouped_128x32x96x128_16x16_2x3_16x8x1_16x8x1_1x32x1x4_8x8x1_2x1_intrawave_v2<InputType, OutputType>},
+{{16,512,5120,8192},bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v1<InputType, OutputType>},
+{{16,1024,2048,5120},bf16_grouped_256x64x128x128_32x32_2x1_16x16x1_16x16x1_1x16x1x16_8x8x1_1x1_intrawave_v3<InputType, OutputType>},
+{{16,1024,5120,1024},bf16_grouped_256x64x96x64_16x16_2x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3<InputType, OutputType>},
+{{16,1024,16384,5120},bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawave_v3<InputType, OutputType>},
+{{16,1024,5120,8192},bf16_grouped_128x64x96x64_16x16_4x3_8x16x1_8x16x1_1x32x1x4_8x8x1_2x1_intrawave_v3<InputType, OutputType>},
+{{16,2048,2048,5120},bf16_grouped_256x128x128x128_32x32_2x2_16x16x1_16x16x1_1x32x1x8_8x8x1_1x1_intrawave_v3<InputType, OutputType>},
+{{16,2048,5120,1024},bf16_grouped_256x128x96x64_16x16_4x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3<InputType, OutputType>},
+{{16,2048,16384,5120},bf16_grouped_256x128x224x64_16x16_4x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3<InputType, OutputType>},
+{{16,2048,5120,8192},bf16_grouped_256x128x96x64_16x16_4x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3<InputType, OutputType>},
+{{16,4096,2048,5120},bf16_grouped_256x128x256x64_32x32_4x2_8x32x1_8x32x1_1x16x1x16_8x8x1_1x1_intrawave_v3<InputType, OutputType>},
+{{16,4096,5120,1024},bf16_grouped_256x128x96x64_16x16_4x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3<InputType, OutputType>},
+{{16,4096,16384,5120},bf16_grouped_256x256x224x64_16x16_8x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3<InputType, OutputType>},
+{{16,4096,5120,8192},bf16_grouped_256x256x160x64_16x16_8x5_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3<InputType, OutputType>},
+{{16,8192,2048,5120},bf16_grouped_256x256x256x64_32x32_4x4_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3<InputType, OutputType>},
+{{16,8192,5120,1024},bf16_grouped_256x256x192x64_32x32_4x3_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3<InputType, OutputType>},
+{{16,8192,16384,5120},bf16_grouped_256x256x224x64_16x16_8x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3<InputType, OutputType>},
+{{16,8192,5120,8192},bf16_grouped_256x256x192x64_32x32_4x3_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3<InputType, OutputType>},
+{{128,128,2048,5120},bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2<InputType, OutputType>},
+{{128,128,5120,1024},bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2<InputType, OutputType>},
+{{128,128,16384,5120},bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v2<InputType, OutputType>},
+{{128,128,5120,8192},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2<InputType, OutputType>},
+{{128,256,2048,5120},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v1<InputType, OutputType>},
+{{128,256,5120,1024},bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2<InputType, OutputType>},
+{{128,256,16384,5120},bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v1<InputType, OutputType>},
+{{128,256,5120,8192},bf16_grouped_64x16x48x128_16x16_1x3_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_intrawave_v1<InputType, OutputType>},
+{{128,512,2048,5120},bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_intrawave_v2<InputType, OutputType>},
+{{128,512,5120,1024},bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2<InputType, OutputType>},
+{{128,512,16384,5120},bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v2<InputType, OutputType>},
+{{128,512,5120,8192},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2<InputType, OutputType>},
+{{128,1024,2048,5120},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v2<InputType, OutputType>},
+{{128,1024,5120,1024},bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_intrawave_v2<InputType, OutputType>},
+{{128,1024,16384,5120},bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v2<InputType, OutputType>},
+{{128,1024,5120,8192},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2<InputType, OutputType>},
+{{128,2048,2048,5120},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v2<InputType, OutputType>},
+{{128,2048,5120,1024},bf16_grouped_128x16x32x128_16x16_1x1_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2<InputType, OutputType>},
+{{128,2048,16384,5120},bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v2<InputType, OutputType>},
+{{128,2048,5120,8192},bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v1<InputType, OutputType>},
+{{128,4096,2048,5120},bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_intrawave_v1<InputType, OutputType>},
+{{128,4096,5120,1024},bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_interwave_v2<InputType, OutputType>},
+{{128,4096,16384,5120},bf16_grouped_256x32x128x128_16x16_1x4_16x16x1_16x16x1_1x32x1x8_8x8x1_1x2_intrawave_v2<InputType, OutputType>},
+{{128,4096,5120,8192},bf16_grouped_256x32x224x64_16x16_1x7_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_intrawave_v1<InputType, OutputType>},
+{{128,8192,2048,5120},bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawave_v3<InputType, OutputType>},
+{{128,8192,5120,1024},bf16_grouped_128x64x128x64_32x32_2x2_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_intrawave_v3<InputType, OutputType>},
+{{128,8192,16384,5120},bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawave_v3<InputType, OutputType>},
+{{128,8192,5120,8192},bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawave_v3<InputType, OutputType>},
 };
 
 
@@ -137,8 +138,8 @@ static constexpr int nextPow2(unsigned int num)
     return 1;
   return 1 << (CHAR_BIT * sizeof(num) - __builtin_clz(num - 1));
 }
-
-GroupedKernel grouped_heuristic_dispatch(int G, int total_M, int N, int K) {
+template <typename InputType, typename OutputType>
+GroupedKernel<InputType, OutputType> grouped_heuristic_dispatch(int G, int total_M, int N, int K) {
   // We use shape heuristics to find the best kernel.
   // To do this, we divide by the size of M and find the best
   // option within that grouping.
@@ -147,14 +148,14 @@ GroupedKernel grouped_heuristic_dispatch(int G, int total_M, int N, int K) {
   int padded_m = nextPow2(total_M);
   padded_m = padded_m < G ? G : padded_m;
   padded_m = padded_m > 8192 ? 8192 : padded_m;
-  auto it = bf16_grouped_lookup_dispatch.find({G, padded_m, N, K});
+  auto it = bf16_grouped_lookup_dispatch<InputType, OutputType>.find({G, padded_m, N, K});
   // If we found an optimal kernel, use it.
-  if (it != bf16_grouped_lookup_dispatch.end()) {
+  if (it != bf16_grouped_lookup_dispatch<InputType, OutputType>.end()) {
     return it->second;
   }
 
   // Default kernel for all other shapes.
-  return bf16_grouped_256x128x128x64_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_interwave_v1;
+  return bf16_grouped_256x128x128x64_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_interwave_v1<InputType, OutputType>;
 }
 
 __global__ void set_kernel_args_kernel(
@@ -275,6 +276,43 @@ __global__ void set_kernel_args_fixed_nk_kernel(
   }
 }
 
+__global__ void set_kernel_args_m_sizes_kernel(
+    KernelArguments* kernel_args,
+    ADataType* A,
+    BDataType* B,
+    CDataType* output,
+    int64_t* M_sizes,
+    int M,
+    int N,
+    int K,
+    int group_count) {
+  int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  // Each thread is responsible for setting up the arguments for one group.
+  if (thread_idx < group_count) {
+    // Get M information for this group.
+    int kernel_M = M_sizes[thread_idx];
+    int offset_M = 0;
+    // Offset is computed by finding the sum of previous group Ms.
+    for (int i = 0; i < thread_idx; i++) {
+      offset_M += M_sizes[i];
+    }
+    KernelArguments kernel_group_args = {
+        A + (offset_M * K),
+        B + (thread_idx * N * K),
+        {},
+        output + (offset_M * N),
+        kernel_M,
+        N,
+        K,
+        K,
+        K,
+        {},
+        N};
+    // Write kernel args to memory.
+    kernel_args[thread_idx] = kernel_group_args;
+  }
+}
+
 void set_dynamic_kernel_args(
     at::Tensor kernel_args,
     at::TensorList A,
@@ -363,6 +401,37 @@ at::Tensor get_grouped_kernel_args(
   return kernel_args;
 }
 
+at::Tensor get_stacked_kernel_args(
+    at::Tensor A,
+    at::Tensor B,
+    at::Tensor Y,
+    at::Tensor M_sizes) {
+  // Get current cuda stream.
+  auto stream = at::cuda::getCurrentHIPStream().stream();
+
+  int group_count = M_sizes.size(0);
+  // Get space on device for the kernel argument tensor.
+  at::Tensor kernel_args = at::empty(
+      {static_cast<long>(group_count * sizeof(KernelArguments))},
+      A.options().dtype(at::kByte));
+
+  int M = A.size(A.dim() - 2);
+  int K = B.size(2);
+  int N = B.size(1);
+
+  set_kernel_args_m_sizes_kernel<<<1, group_count, 0, stream>>>(
+      reinterpret_cast<KernelArguments*>(kernel_args.data_ptr()),
+      reinterpret_cast<ADataType*>(A.data_ptr()),
+      reinterpret_cast<BDataType*>(B.data_ptr()),
+      reinterpret_cast<CDataType*>(Y.data_ptr()),
+      reinterpret_cast<int64_t*>(M_sizes.data_ptr()),
+      M,
+      N,
+      K,
+      group_count);
+  return kernel_args;
+}
+
 std::vector<at::Tensor> bf16bf16bf16_grouped(
     at::TensorList A,
     at::TensorList B,
@@ -423,7 +492,7 @@ std::vector<at::Tensor> bf16bf16bf16_grouped(
     MaxN = max(MaxN, B[i].size(0));
     MaxK = max(MaxK, A[i].size(1));
   }
-  GroupedKernel selected_kernel = grouped_heuristic_dispatch(group_count, MaxM, MaxN, MaxK);
+  auto selected_kernel = grouped_heuristic_dispatch<at::TensorList, std::vector<at::Tensor>>(group_count, MaxM, MaxN, MaxK);
   return selected_kernel(A, B, kernel_args, Y);
 }
 
@@ -498,11 +567,66 @@ at::Tensor bf16bf16bf16_grouped_dynamic(
     MaxN = max(MaxN, B[i].size(0));
     MaxK = max(MaxK, A[i].size(1));
   }
-  GroupedKernel selected_kernel = grouped_heuristic_dispatch(group_count, MaxM, MaxN, MaxK);
+  auto selected_kernel = grouped_heuristic_dispatch<at::TensorList, std::vector<at::Tensor>>(group_count, MaxM, MaxN, MaxK);
   // Run kernel to populate output.
   selected_kernel(A, B, kernel_args, Y);
   // Return coalesced view of output tensor.
   return Y_full;
+}
+
+// Wrapper function for list input single tensor output.
+at::Tensor bf16bf16bf16_grouped_stacked(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor M_sizes,
+    std::optional<at::Tensor> output = std::nullopt) {
+  // Check that input datatypes are valid.
+  // First confirm that there are the same number of groups in all inputs.
+  int group_count = M_sizes.size(0);
+  // X is expected to be shape [total_M, K].
+  int total_M = X.size(0);
+  // W is expected to be shape [G, N, K].
+  int N = W.size(1);
+  int K = X.size(1);
+  TORCH_CHECK(W.size(0) == group_count,
+      "All inputs must have the same number of groups.");
+
+  // Iterate over inputs and check they are valid.
+  TORCH_CHECK(X.is_cuda() && X.is_contiguous());
+  TORCH_CHECK(X.dim() == 2, "Input X must be 2D (total_M,K).");
+  TORCH_CHECK(
+      X.dtype() == at::kBFloat16,
+      "Input XQ must be type bfloat16.");
+
+  TORCH_CHECK(W.is_cuda() && W.is_contiguous());
+  TORCH_CHECK(W.dim() == 3, "Input W must be 3D (G,N,K).");
+  TORCH_CHECK(
+      W.dtype() == at::kBFloat16,
+      "Input W must be type bfloat16");
+  TORCH_CHECK(
+      W.size(1) >= 512 && W.size(2) >= 512,
+      "N and K must be at least 512 for grouped gemm. For smaller inputs, consider unrolling.");
+
+  TORCH_CHECK(
+      X.device() == M_sizes.device(),
+      "M_sizes and inputs must be on the same device.");
+  TORCH_CHECK(M_sizes.dtype() == at::kLong, "M_sizes must be int64.");
+
+  // Allocate an empty output array. We will set its values to zero as part
+  // of kernel setup.
+  at::Tensor Y = at::empty({total_M, N}, X.options().dtype(at::kBFloat16));
+
+  // Early exit for empty input.
+  if (total_M == 0) {
+    return Y;
+  }
+
+  // Prepare kernel arguments by copying them to the proper device location.
+  at::Tensor kernel_args = get_stacked_kernel_args(X, W, Y, M_sizes);
+
+  auto selected_kernel = grouped_heuristic_dispatch<at::Tensor, at::Tensor>(group_count, total_M, N, K);
+
+  return selected_kernel(X, W, kernel_args, Y);
 }
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x32x128_16x16_1x1_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x32x128_16x16_1x1_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_128x16x32x128_16x16_1x1_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_128x16x32x128_16x16_1x1_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_128x16x32x128_16x16_1x1_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_128x16x32x128_16x16_1x1_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x32x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x32x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_intrawave_v2.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_128x16x32x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_intrawave_v2(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_128x16x32x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_intrawave_v
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_128x16x32x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_intrawave_v2(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_128x16x32x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_intrawave_v2(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x32x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x32x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_128x16x32x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_128x16x32x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_128x16x32x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_128x16x32x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v1.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v1(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v1(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v1(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_intrawave_v2.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_intrawave_v2(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,17 @@ bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_intrawave_
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_intrawave_v2(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_intrawave_v2(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v1.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v1(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v1(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v1(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v1.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v1(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v1(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v1(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v2(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v2(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v2(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x96x64_16x16_1x3_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x16x96x64_16x16_1x3_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_128x16x96x64_16x16_1x3_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_128x16x96x64_16x16_1x3_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_128x16x96x64_16x16_1x3_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_128x16x96x64_16x16_1x3_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x32x16x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x32x16x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_interwave_v2.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_128x32x16x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_interwave_v2(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_128x32x16x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_interwave_v
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_128x32x16x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_interwave_v2(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_128x32x16x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_interwave_v2(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_interwave_v2.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_interwave_v2(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_interwave_
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_interwave_v2(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_interwave_v2(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_intrawave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_intrawave_v1.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_intrawave_v1(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_intrawave_
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_intrawave_v1(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_intrawave_v1(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x32x96x128_16x16_2x3_16x8x1_16x8x1_1x32x1x4_8x8x1_2x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x32x96x128_16x16_2x3_16x8x1_16x8x1_1x32x1x4_8x8x1_2x1_intrawave_v2.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_128x32x96x128_16x16_2x3_16x8x1_16x8x1_1x32x1x4_8x8x1_2x1_intrawave_v2(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_128x32x96x128_16x16_2x3_16x8x1_16x8x1_1x32x1x4_8x8x1_2x1_intrawave_
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_128x32x96x128_16x16_2x3_16x8x1_16x8x1_1x32x1x4_8x8x1_2x1_intrawave_v2(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_128x32x96x128_16x16_2x3_16x8x1_16x8x1_1x32x1x4_8x8x1_2x1_intrawave_v2(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x64x128x64_32x32_2x2_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x64x128x64_32x32_2x2_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_intrawave_v3.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_128x64x128x64_32x32_2x2_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_intrawave_v3(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_128x64x128x64_32x32_2x2_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_intrawave_
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_128x64x128x64_32x32_2x2_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_intrawave_v3(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_128x64x128x64_32x32_2x2_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_intrawave_v3(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x64x96x64_16x16_4x3_8x16x1_8x16x1_1x32x1x4_8x8x1_2x1_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_128x64x96x64_16x16_4x3_8x16x1_8x16x1_1x32x1x4_8x8x1_2x1_intrawave_v3.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_128x64x96x64_16x16_4x3_8x16x1_8x16x1_1x32x1x4_8x8x1_2x1_intrawave_v3(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_128x64x96x64_16x16_4x3_8x16x1_8x16x1_1x32x1x4_8x8x1_2x1_intrawave_v
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_128x64x96x64_16x16_4x3_8x16x1_8x16x1_1x32x1x4_8x8x1_2x1_intrawave_v3(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_128x64x96x64_16x16_4x3_8x16x1_8x16x1_1x32x1x4_8x8x1_2x1_intrawave_v3(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x128x128x128_32x32_2x2_16x16x1_16x16x1_1x32x1x8_8x8x1_1x1_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x128x128x128_32x32_2x2_16x16x1_16x16x1_1x32x1x8_8x8x1_1x1_intrawave_v3.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x128x128x128_32x32_2x2_16x16x1_16x16x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x128x128x128_32x32_2x2_16x16x1_16x16x1_1x32x1x8_8x8x1_1x1_intraw
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x128x128x128_32x32_2x2_16x16x1_16x16x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x128x128x128_32x32_2x2_16x16x1_16x16x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x128x128x64_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_interwave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x128x128x64_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_interwave_v1.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x128x128x64_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_interwave_v1(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x128x128x64_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_interwave
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x128x128x64_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_interwave_v1(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x128x128x64_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_interwave_v1(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x128x128x64_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x128x128x64_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x128x128x64_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x128x128x64_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x128x128x64_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x128x128x64_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x128x224x64_16x16_4x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x128x224x64_16x16_4x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x128x224x64_16x16_4x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x128x224x64_16x16_4x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x128x224x64_16x16_4x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x128x224x64_16x16_4x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x128x256x64_32x32_4x2_8x32x1_8x32x1_1x16x1x16_8x8x1_1x1_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x128x256x64_32x32_4x2_8x32x1_8x32x1_1x16x1x16_8x8x1_1x1_intrawave_v3.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x128x256x64_32x32_4x2_8x32x1_8x32x1_1x16x1x16_8x8x1_1x1_intrawave_v3(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x128x256x64_32x32_4x2_8x32x1_8x32x1_1x16x1x16_8x8x1_1x1_intrawav
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x128x256x64_32x32_4x2_8x32x1_8x32x1_1x16x1x16_8x8x1_1x1_intrawave_v3(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x128x256x64_32x32_4x2_8x32x1_8x32x1_1x16x1x16_8x8x1_1x1_intrawave_v3(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x128x96x64_16x16_4x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x128x96x64_16x16_4x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x128x96x64_16x16_4x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x128x96x64_16x16_4x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x128x96x64_16x16_4x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x128x96x64_16x16_4x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v1.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v1(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intraw
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v1(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v1(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v2.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v2(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intraw
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v2(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v2(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwa
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x224x256x32_16x16_7x8_8x32x1_8x32x1_1x32x1x8_8x8x1_1x2_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x224x256x32_16x16_7x8_8x32x1_8x32x1_1x32x1x8_8x8x1_1x2_intrawave_v3.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x224x256x32_16x16_7x8_8x32x1_8x32x1_1x32x1x8_8x8x1_1x2_intrawave_v3(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x224x256x32_16x16_7x8_8x32x1_8x32x1_1x32x1x8_8x8x1_1x2_intrawave
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x224x256x32_16x16_7x8_8x32x1_8x32x1_1x32x1x8_8x8x1_1x2_intrawave_v3(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x224x256x32_16x16_7x8_8x32x1_8x32x1_1x32x1x8_8x8x1_1x2_intrawave_v3(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x256x128x32_32x32_4x2_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_interwave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x256x128x32_32x32_4x2_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_interwave_v1.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x256x128x32_32x32_4x2_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_interwave_v1(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x256x128x32_32x32_4x2_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_interwave
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x256x128x32_32x32_4x2_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_interwave_v1(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x256x128x32_32x32_4x2_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_interwave_v1(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x256x160x64_16x16_8x5_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x256x160x64_16x16_8x5_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x256x160x64_16x16_8x5_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x256x160x64_16x16_8x5_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x256x160x64_16x16_8x5_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x256x160x64_16x16_8x5_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x256x192x64_32x32_4x3_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x256x192x64_32x32_4x3_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x256x192x64_32x32_4x3_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x256x192x64_32x32_4x3_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x256x192x64_32x32_4x3_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x256x192x64_32x32_4x3_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x256x224x64_16x16_8x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x256x224x64_16x16_8x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x256x224x64_16x16_8x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x256x224x64_16x16_8x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x256x224x64_16x16_8x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x256x224x64_16x16_8x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x256x256x64_32x32_4x4_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x256x256x64_32x32_4x4_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x256x256x64_32x32_4x4_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x256x256x64_32x32_4x4_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x256x256x64_32x32_4x4_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x256x256x64_32x32_4x4_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x32x128x128_16x16_1x4_16x16x1_16x16x1_1x32x1x8_8x8x1_1x2_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x32x128x128_16x16_1x4_16x16x1_16x16x1_1x32x1x8_8x8x1_1x2_intrawave_v2.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x32x128x128_16x16_1x4_16x16x1_16x16x1_1x32x1x8_8x8x1_1x2_intrawave_v2(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x32x128x128_16x16_1x4_16x16x1_16x16x1_1x32x1x8_8x8x1_1x2_intrawa
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x32x128x128_16x16_1x4_16x16x1_16x16x1_1x32x1x8_8x8x1_1x2_intrawave_v2(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x32x128x128_16x16_1x4_16x16x1_16x16x1_1x32x1x8_8x8x1_1x2_intrawave_v2(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x32x224x64_16x16_1x7_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_intrawave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x32x224x64_16x16_1x7_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_intrawave_v1.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x32x224x64_16x16_1x7_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_intrawave_v1(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x32x224x64_16x16_1x7_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_intrawave_
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x32x224x64_16x16_1x7_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_intrawave_v1(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x32x224x64_16x16_1x7_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_intrawave_v1(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v1.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v1(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v1(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v1(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v2.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v2(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v2(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v2(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x64x128x128_32x32_2x1_16x16x1_16x16x1_1x16x1x16_8x8x1_1x1_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x64x128x128_32x32_2x1_16x16x1_16x16x1_1x16x1x16_8x8x1_1x1_intrawave_v3.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x64x128x128_32x32_2x1_16x16x1_16x16x1_1x16x1x16_8x8x1_1x1_intrawave_v3(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x64x128x128_32x32_2x1_16x16x1_16x16x1_1x16x1x16_8x8x1_1x1_intraw
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x64x128x128_32x32_2x1_16x16x1_16x16x1_1x16x1x16_8x8x1_1x1_intrawave_v3(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x64x128x128_32x32_2x1_16x16x1_16x16x1_1x16x1x16_8x8x1_1x1_intrawave_v3(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawave_v3.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawave_v3(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawa
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawave_v3(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawave_v3(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x64x96x64_16x16_2x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_256x64x96x64_16x16_2x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x64x96x64_16x16_2x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_256x64x96x64_16x16_2x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_256x64x96x64_16x16_2x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_256x64x96x64_16x16_2x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_64x16x16x128_16x16_1x1_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_64x16x16x128_16x16_1x1_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_interwave_v2.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_64x16x16x128_16x16_1x1_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_interwave_v2(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_64x16x16x128_16x16_1x1_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_interwave_v
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_64x16x16x128_16x16_1x1_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_interwave_v2(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_64x16x16x128_16x16_1x1_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_interwave_v2(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_64x16x16x128_16x16_1x1_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_intrawave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_64x16x16x128_16x16_1x1_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_intrawave_v1.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_64x16x16x128_16x16_1x1_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_intrawave_v1(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_64x16x16x128_16x16_1x1_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_intrawave_v
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_64x16x16x128_16x16_1x1_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_intrawave_v1(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_64x16x16x128_16x16_1x1_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_intrawave_v1(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_64x16x16x64_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_64x16x16x64_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v2.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_64x16x16x64_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v2(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_64x16x16x64_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v2(
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_64x16x16x64_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v2(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_64x16x16x64_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v2(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_64x16x32x128_16x16_1x2_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_64x16x32x128_16x16_1x2_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v2.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_64x16x32x128_16x16_1x2_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v2(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_64x16x32x128_16x16_1x2_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_64x16x32x128_16x16_1x2_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v2(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_64x16x32x128_16x16_1x2_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v2(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_64x16x48x128_16x16_1x3_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_intrawave_v1.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_64x16x48x128_16x16_1x3_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_intrawave_v1.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_64x16x48x128_16x16_1x3_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_intrawave_v1(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_64x16x48x128_16x16_1x3_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_intrawave_v
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_64x16x48x128_16x16_1x3_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_intrawave_v1(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_64x16x48x128_16x16_1x3_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_intrawave_v1(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_64x16x64x128_16x16_1x4_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_64x16x64x128_16x16_1x4_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v2.hip
@@ -8,12 +8,13 @@
 
 #include "bf16_grouped_common.h"
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_64x16x64x128_16x16_1x4_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v2(
-    at::TensorList A,
-    at::TensorList B,
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y)
+    OutputType Y)
 {
     // Check if this input needs to be padded.
 #if 0
@@ -83,3 +84,18 @@ bf16_grouped_64x16x64x128_16x16_1x4_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v
 }
 
 
+
+template std::vector<at::Tensor>
+bf16_grouped_64x16x64x128_16x16_1x4_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v2(
+    at::TensorList X,
+    at::TensorList W,
+    at::Tensor kernel_args,
+    std::vector<at::Tensor> Y);
+
+template at::Tensor
+bf16_grouped_64x16x64x128_16x16_1x4_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v2(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor kernel_args,
+    at::Tensor Y);
+    

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_common.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_common.h
@@ -116,14 +116,20 @@ using DeviceGemmHelper =
         PIPELINE_VERSION,
         ComputeType>;
 
-template <typename DeviceGemmInstance>
-std::vector<at::Tensor> bf16_grouped_impl(
-    at::TensorList A,
-    at::TensorList B,
+// Templated kernel launch to accommodate different input and output types.
+template <typename DeviceGemmInstance, typename InputType, typename OutputType>
+OutputType bf16_grouped_impl(
+    InputType A,
+    InputType B,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y) {
+    OutputType Y) {
   // Get input information.
-  int group_count = A.size();
+  int group_count;
+  if constexpr (std::is_same_v<InputType, at::Tensor>) {
+    group_count = B.size(0);
+  } else {
+    group_count = A.size();
+  }
   using KernelArguments =
       ck::tensor_operation::device::GroupedGemmKernelArgument<0>;
   using GemmDesc = ck::tensor_operation::device::GemmDesc;
@@ -139,18 +145,31 @@ std::vector<at::Tensor> bf16_grouped_impl(
   A_args.reserve(group_count);
   B_args.reserve(group_count);
   C_args.reserve(group_count);
+  int M, N, K;
   // Populate arguments.
   for (int i = 0; i < group_count; i++) {
     // Set the shape arguments for this gemm.
-    int M = A[i].size(0);
-    int K = A[i].size(1);
-    int N = B[i].size(0);
+    if constexpr (std::is_same_v<InputType, at::Tensor>) {
+      M = A.size(A.dim() - 2);
+      N = B.size(1);
+      K = B.size(2);
+      // These pointers dont seem to actually be used since the kernel arguments
+      // contains the correct version. For simplicity, we just point to the
+      // start of the tensor.
+      A_args.push_back(reinterpret_cast<ADataType*>(A.data_ptr()));
+      B_args.push_back(reinterpret_cast<BDataType*>(B.data_ptr()));
+      C_args.push_back(reinterpret_cast<CDataType*>(Y.data_ptr()));
+    } else {
+      M = A[i].size(0);
+      K = A[i].size(1);
+      N = B[i].size(0);
+      // Set pointers to inputs and outputs.
+      A_args.push_back(reinterpret_cast<ADataType*>(A[i].data_ptr()));
+      B_args.push_back(reinterpret_cast<BDataType*>(B[i].data_ptr()));
+      C_args.push_back(reinterpret_cast<CDataType*>(Y[i].data_ptr()));
+    }
     GemmDesc gemm_desc = {M, N, K, K, K, N, {}};
     gemm_descs.push_back(gemm_desc);
-    // Set pointers to inputs and outputs.
-    A_args.push_back(reinterpret_cast<ADataType*>(A[i].data_ptr()));
-    B_args.push_back(reinterpret_cast<BDataType*>(B[i].data_ptr()));
-    C_args.push_back(reinterpret_cast<CDataType*>(Y[i].data_ptr()));
   }
 
   // Create gemm launcher and arguments.

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_kernel_manifest.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_kernel_manifest.h
@@ -16,547 +16,366 @@
 #define KERNEL_NAME_MAP_ENTRY(name) \
   { #name, name }
 
-using GroupedKernel = std::function<std::vector<at::Tensor>(
-    at::TensorList,
-    at::TensorList,
-    at::Tensor,
-    std::vector<at::Tensor>)>;
-
-std::vector<at::Tensor>
-bf16_grouped_64x16x16x64_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x32x16x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_64x16x16x128_16x16_1x1_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_intrawave_v1(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x32x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_intrawave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x128x128x64_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_interwave_v1(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x128x128x64_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x256x128x32_32x32_4x2_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_interwave_v1(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x224x256x32_16x16_7x8_8x32x1_8x32x1_1x32x1x8_8x8x1_1x2_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x32x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_intrawave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_64x16x16x128_16x16_1x1_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_64x16x32x128_16x16_1x2_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v1(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v1(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x96x64_16x16_1x3_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v1(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x96x64_16x16_1x3_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_64x16x64x128_16x16_1x4_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v1(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x32x128_16x16_1x1_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v1(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v1(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x32x96x128_16x16_2x3_16x8x1_16x8x1_1x32x1x4_8x8x1_2x1_intrawave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v1(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x64x128x128_32x32_2x1_16x16x1_16x16x1_1x16x1x16_8x8x1_1x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x64x96x64_16x16_2x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x64x96x64_16x16_4x3_8x16x1_8x16x1_1x32x1x4_8x8x1_2x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x128x128x128_32x32_2x2_16x16x1_16x16x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x128x96x64_16x16_4x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x128x224x64_16x16_4x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x128x96x64_16x16_4x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x128x256x64_32x32_4x2_8x32x1_8x32x1_1x16x1x16_8x8x1_1x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x128x96x64_16x16_4x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x256x224x64_16x16_8x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x256x160x64_16x16_8x5_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x256x256x64_32x32_4x4_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x256x192x64_32x32_4x3_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x256x224x64_16x16_8x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x256x192x64_32x32_4x3_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v1(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v1(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_64x16x48x128_16x16_1x3_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_intrawave_v1(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_intrawave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_intrawave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x32x128_16x16_1x1_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v1(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_intrawave_v1(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
-bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_interwave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
-    at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
-
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+using GroupedKernel =
+    std::function<OutputType(InputType, InputType, at::Tensor, OutputType)>;
+
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x32x128x128_16x16_1x4_16x16x1_16x16x1_1x32x1x8_8x8x1_1x2_intrawave_v2(
-    at::TensorList XQ,
-    at::TensorList WQ,
+    InputType X,
+    InputType W,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
+    OutputType Y);
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x128x128x64_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_interwave_v1(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x256x256x64_32x32_4x4_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x256x192x64_32x32_4x3_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x128x128x64_32x32_2x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x128x96x64_16x16_4x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v2(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_128x32x96x128_16x16_2x3_16x8x1_16x8x1_1x32x1x4_8x8x1_2x1_intrawave_v2(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawave_v3(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x128x256x64_32x32_4x2_8x32x1_8x32x1_1x16x1x16_8x8x1_1x1_intrawave_v3(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x16x128x128_16x16_1x2_16x16x1_16x16x1_1x16x1x16_8x8x1_1x2_intrawave_v1(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_128x16x32x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_intrawave_v2(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_64x16x16x128_16x16_1x1_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_interwave_v2(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_128x16x32x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v2(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_intrawave_v1(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_256x32x224x64_16x16_1x7_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_intrawave_v1(
-    at::TensorList XQ,
-    at::TensorList WQ,
+    InputType X,
+    InputType W,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
+    OutputType Y);
 
-std::vector<at::Tensor>
-bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v2(
+    InputType X,
+    InputType W,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
+    OutputType Y);
 
-std::vector<at::Tensor>
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x256x128x32_32x32_4x2_4x64x1_4x64x1_1x32x1x8_8x8x1_1x1_interwave_v1(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_128x32x64x128_32x32_1x1_16x8x1_16x8x1_1x16x1x8_8x8x1_1x1_interwave_v2(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v1(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v2(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_128x16x32x128_16x16_1x1_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_interwave_v2(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_64x16x16x128_16x16_1x1_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_intrawave_v1(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_64x16x48x128_16x16_1x3_16x4x1_16x4x1_1x16x1x4_4x4x1_1x1_intrawave_v1(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_128x64x96x64_16x16_4x3_8x16x1_8x16x1_1x32x1x4_8x8x1_2x1_intrawave_v3(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x128x128x128_32x32_2x2_16x16x1_16x16x1_1x32x1x8_8x8x1_1x1_intrawave_v3(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x64x128x128_32x32_2x1_16x16x1_16x16x1_1x16x1x16_8x8x1_1x1_intrawave_v3(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v1(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x16x64x128_16x16_1x1_16x16x1_16x16x1_1x16x1x16_4x4x1_1x1_interwave_v2(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_intrawave_v2(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_128x16x96x64_16x16_1x3_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_intrawave_v1(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_128x32x16x64_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_interwave_v2(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_128x16x96x128_16x16_1x3_16x8x1_16x8x1_1x16x1x8_4x4x1_1x1_intrawave_v1(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_128x16x64x128_16x16_1x2_16x8x1_16x8x1_1x16x1x8_8x8x1_1x2_interwave_v2(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x256x160x64_16x16_8x5_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x224x256x32_16x16_7x8_8x32x1_8x32x1_1x32x1x8_8x8x1_1x2_intrawave_v3(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_64x16x16x64_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4x4x1_1x1_interwave_v2(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x256x224x64_16x16_8x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
 bf16_grouped_128x64x128x64_32x32_2x2_8x16x1_8x16x1_1x16x1x8_8x8x1_1x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
+    InputType X,
+    InputType W,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
+    OutputType Y);
 
-std::vector<at::Tensor>
-bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x64x96x64_16x16_2x3_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
+    InputType X,
+    InputType W,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
+    OutputType Y);
 
-std::vector<at::Tensor>
-bf16_grouped_256x64x192x128_16x16_4x3_16x16x1_16x16x1_1x32x1x8_8x8x1_2x1_intrawave_v3(
-    at::TensorList XQ,
-    at::TensorList WQ,
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x128x224x64_16x16_4x7_8x32x1_8x32x1_1x64x1x4_8x8x1_2x1_intrawave_v3(
+    InputType X,
+    InputType W,
     at::Tensor kernel_args,
-    std::vector<at::Tensor> Y);
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_64x16x64x128_16x16_1x4_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v2(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_256x32x96x64_16x16_1x3_8x32x1_8x32x1_1x32x1x8_4x4x1_1x1_interwave_v1(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);
+
+template <typename InputType, typename OutputType>
+OutputType
+bf16_grouped_64x16x32x128_16x16_1x2_16x4x1_16x4x1_1x16x1x4_8x8x1_1x2_intrawave_v2(
+    InputType X,
+    InputType W,
+    at::Tensor kernel_args,
+    OutputType Y);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped.cu
@@ -544,6 +544,14 @@ at::Tensor bf16bf16bf16_grouped_dynamic(
   return output_full;
 }
 
+at::Tensor bf16bf16bf16_grouped_stacked(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor M_sizes,
+    std::optional<at::Tensor> output = std::nullopt) {
+  throw std::runtime_error("Unimplemented");
+}
+
 #else
 
 std::vector<at::Tensor> bf16bf16bf16_grouped(
@@ -558,6 +566,15 @@ at::Tensor bf16bf16bf16_grouped_dynamic(
     at::TensorList /* x_group */, // BF16
     at::TensorList /* w_group */, // BF16
     std::optional<at::Tensor> /* zero_start_index_M */) {
+  throw std::runtime_error(
+      "CUDA version is older than 12.0"); // requires CUDA>=12
+}
+
+at::Tensor bf16bf16bf16_grouped_stacked(
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    std::optional<at::Tensor>) {
   throw std::runtime_error(
       "CUDA version is older than 12.0"); // requires CUDA>=12
 }

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -64,6 +64,11 @@ at::Tensor bf16bf16bf16_grouped_dynamic(
     at::TensorList X,
     at::TensorList W,
     std::optional<at::Tensor> zero_start_index_M = std::nullopt);
+at::Tensor bf16bf16bf16_grouped_stacked(
+    at::Tensor X,
+    at::Tensor W,
+    at::Tensor M_sizes,
+    std::optional<at::Tensor> output = std::nullopt);
 at::Tensor f8f8bf16_rowwise(
     at::Tensor XQ,
     at::Tensor WQ,
@@ -238,6 +243,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "bf16bf16bf16_grouped_dynamic(Tensor[] X, Tensor[] W, Tensor? zero_start_index_M=None) -> Tensor");
   m.def(
+      "bf16bf16bf16_grouped_stacked(Tensor X, Tensor W, Tensor M_sizes, Tensor(a!)? output=None) -> Tensor");
+  m.def(
       "f8f8bf16_blockwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, int block_m=128, int block_n=128, int block_k=128) -> Tensor");
   m.def(
       "f8f8bf16_rowwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor? bias=None, bool use_fast_accum=True) -> Tensor");
@@ -302,6 +309,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   m.impl("quantize_fp8_per_col", quantize_fp8_per_col);
   m.impl("bf16bf16bf16_grouped", bf16bf16bf16_grouped);
   m.impl("bf16bf16bf16_grouped_dynamic", bf16bf16bf16_grouped_dynamic);
+  m.impl("bf16bf16bf16_grouped_stacked", bf16bf16bf16_grouped_stacked);
 
 #ifndef USE_ROCM
   m.impl("i8i8bf16", i8i8bf16);
@@ -335,6 +343,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
   m.impl("quantize_fp8_per_col", quantize_fp8_per_col);
   m.impl("bf16bf16bf16_grouped", bf16bf16bf16_grouped);
   m.impl("bf16bf16bf16_grouped_dyanmic", bf16bf16bf16_grouped_dynamic);
+  m.impl("bf16bf16bf16_grouped_stacked", bf16bf16bf16_grouped_stacked);
 #ifndef USE_ROCM
   m.impl("i8i8bf16", i8i8bf16);
   m.impl("f8f8bf16", f8f8bf16);


### PR DESCRIPTION
Summary: Add bf16 group gemm `bf16bf16bf16_grouped_stacked`  for token shuffling. This diff only has implementation for CK on AMD

Reviewed By: zjing14

Differential Revision: D71629472
