### PR TITLE
fix fp8 kv cache dequantize kernels

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/test/kv_cache/kv_cache_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/kv_cache/kv_cache_test.py
@@ -192,9 +192,9 @@ class KVCacheTests(unittest.TestCase):
             torch.version.cuda
             and torch.cuda.get_device_properties(torch.cuda.current_device()).major < 9
         )
-        or (torch.version.hip)
+        or (torch.version.hip and torch.version.hip < "6.2")
         or not HAS_XFORMERS,
-        "Skip when H100 is not available",
+        "Skip when H100 is not available or MI300 is not available",
     )
     def test_fp8_kv_cache(self, MAX_T: int, N_KVH_L: int) -> None:
         N_H_L = 2


### PR DESCRIPTION
Summary:
Fix fp8 kv cache dequantization kernel and enable unit test on AMD.

The kernel uses each thread to dequantize 4 elements for both K and V and each warp for a head. The dim is always 128. So on NV this works as one warp has 32 threads on NV (4 * 32 = 128).

On AMD, each wavefront (warp) has 64 threads, so the second 32 threads will all do out-of-bound memory access....

This diff simply masks those threads to do nothing. Obviously the perf is not good but from E2E testing, it does not seem to matter. If we need to optimize the perf for AMD, we can let thread 0 ~ 31 dequantize 4 elements for K and thread 32 ~ 63 thread dequantize 4 elements for V.

Differential Revision: D72062745


