### PR TITLE
[fbgemm_gpu] Fix undefined symbol error

### DIFF
--- a/fbgemm_gpu/docs/src/conf.py
+++ b/fbgemm_gpu/docs/src/conf.py
@@ -180,7 +180,6 @@ html_theme_options = {
     "collapse_navigation": True,
     "display_version": True,
     "analytics_id": "UA-117752657-2",
-    "collapse_navigation": False,
 }
 
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped.cu
@@ -623,17 +623,12 @@ at::Tensor bf16bf16bf16_grouped_cat(at::TensorList X, at::TensorList W) {
 at::Tensor bf16bf16bf16_grouped_dynamic(
     at::Tensor X,
     at::Tensor W,
-    at::Tensor zero_start_index_M,
-    bool zeroing_output_tensor = true) {
+    at::Tensor zero_start_index_M) {
   throw std::runtime_error(
       "CUDA version is older than 12.0"); // requires CUDA>=12
 }
 
-at::Tensor bf16bf16bf16_grouped_stacked(
-    at::Tensor,
-    at::Tensor,
-    at::Tensor,
-    std::optional<at::Tensor>) {
+at::Tensor bf16bf16bf16_grouped_stacked(at::Tensor, at::Tensor, at::Tensor) {
   throw std::runtime_error(
       "CUDA version is older than 12.0"); // requires CUDA>=12
 }


### PR DESCRIPTION
- Fix undefined symbol error on CUDA 11.8 (`_ZN10fbgemm_gpu28bf16bf16bf16_grouped_stackedEN2at6TensorES1_S1_`)