### PR TITLE
Uses `FastAccum=True` by default for Triton GroupedGEMM.

### DIFF
--- a/fbgemm_gpu/experimental/gemm/triton_gemm/grouped_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/grouped_gemm.py
@@ -885,7 +885,7 @@ def grouped_gemm(
     x: torch.Tensor,
     w: torch.Tensor,
     m_sizes: torch.Tensor,
-    use_fast_accum: bool = False,
+    use_fast_accum: bool = True,
     *,
     _use_warp_specialization: bool = False,
 ) -> torch.Tensor:
@@ -904,7 +904,7 @@ def grouped_gemm_fp8_rowwise(
     m_sizes: torch.Tensor,
     x_scale: torch.Tensor,
     w_scale: torch.Tensor,
-    use_fast_accum: bool = False,
+    use_fast_accum: bool = True,
     *,
     _use_warp_specialization: bool = False,
 ) -> torch.Tensor:


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1007

Respect `DISABLE_FAST_ACCUM` environment variable and use `fast_accum=True` by default for Triton based GroupedGEMM on H100.

Refer D70800084 for performance delta.

Reviewed By: jianyuh

Differential Revision: D72321876


