### PR TITLE
Support prefetch pipeline in bounds_check_indices

### DIFF
--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_host.cpp
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_host.cpp
@@ -32,7 +32,8 @@ void _bounds_check_indices_cuda_v1(
     const int64_t max_B,
     const std::optional<Tensor>& b_t_map,
     const int32_t info_B_num_bits,
-    const uint32_t info_B_mask);
+    const uint32_t info_B_mask,
+    const bool prefetch_pipeline);
 
 void _bounds_check_indices_cuda_v2(
     Tensor& rows_per_table,
@@ -45,7 +46,8 @@ void _bounds_check_indices_cuda_v2(
     const int64_t max_B,
     const std::optional<Tensor>& b_t_map,
     const int32_t info_B_num_bits,
-    const uint32_t info_B_mask);
+    const uint32_t info_B_mask,
+    const bool prefetch_pipeline);
 
 ///@ingroup embedding-cuda
 void bounds_check_indices_cuda(
@@ -60,7 +62,8 @@ void bounds_check_indices_cuda(
     const std::optional<Tensor>& b_t_map,
     const int64_t info_B_num_bits,
     const int64_t info_B_mask,
-    const int8_t bounds_check_version) {
+    const int8_t bounds_check_version,
+    const bool prefetch_pipeline) {
   TORCH_CHECK(bounds_check_version == 1 || bounds_check_version == 2);
   const static bool use_v2 =
       fbgemm_gpu::config::is_feature_enabled(
@@ -88,7 +91,8 @@ void bounds_check_indices_cuda(
       max_B,
       b_t_map,
       static_cast<int32_t>(info_B_num_bits),
-      static_cast<uint32_t>(info_B_mask));
+      static_cast<uint32_t>(info_B_mask),
+      prefetch_pipeline);
 }
 // Deprecated for fb namespace! Please use fbgemm namespace instead!
 TORCH_LIBRARY_FRAGMENT(fb, m) {

--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_host_cpu.cpp
@@ -70,7 +70,8 @@ void bounds_check_indices_cpu(
     const std::optional<Tensor>& /*b_t_map*/,
     const int64_t /*info_B_num_bits*/,
     const int64_t /*info_B_mask*/,
-    const int8_t /*bounds_check_version*/) {
+    const int8_t /*bounds_check_version*/,
+    const bool /*prefetch_pipeline*/) {
   if (offsets.scalar_type() != indices.scalar_type()) {
     offsets = offsets.toType(indices.scalar_type());
   }
@@ -220,7 +221,8 @@ TORCH_LIBRARY_FRAGMENT(fb, m) {
       "    Tensor? b_t_map=None, "
       "    int info_B_num_bits=-1, "
       "    int info_B_mask=-1, "
-      "    int bounds_check_version=1"
+      "    int bounds_check_version=1, "
+      "    bool prefetch_pipeline=False"
       ") -> ()",
       {PT2_COMPLIANT_TAG});
   DISPATCH_TO_CPU("bounds_check_indices", bounds_check_indices_cpu);
@@ -245,7 +247,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "    Tensor? b_t_map=None, "
       "    int info_B_num_bits=-1, "
       "    int info_B_mask=-1, "
-      "    int bounds_check_version=1"
+      "    int bounds_check_version=1, "
+      "    bool prefetch_pipeline=False"
       ") -> ()",
       {PT2_COMPLIANT_TAG});
   DISPATCH_TO_CPU("bounds_check_indices", bounds_check_indices_cpu);

--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_v1.cu
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_v1.cu
@@ -201,13 +201,17 @@ void _bounds_check_indices_cuda_v1(
     const int64_t max_B,
     const std::optional<Tensor>& /*b_t_map*/,
     const int32_t /*info_b_num_bits*/,
-    const uint32_t /*info_B_mask*/) {
+    const uint32_t /*info_B_mask*/,
+    const bool prefetch_pipeline) {
   TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
       rows_per_table, indices, offsets, warning, weights, B_offsets);
   TENSOR_NDIM_EQUALS(rows_per_table, 1);
   TENSOR_NDIM_EQUALS(indices, 1);
   TENSOR_NDIM_EQUALS(offsets, 1);
   TENSOR_NDIM_EQUALS(warning, 1);
+  TORCH_CHECK(
+      !prefetch_pipeline,
+      "bounds_check_indices_v1 does not support prefetch_pipeline=true")
 
   const auto vbe = B_offsets.has_value();
   if (vbe) {


### PR DESCRIPTION
Summary:
Backend of D72365505

This diff reduces the grid dimension of the bounds_check_indices
kernel when pipeline prefetching is used (in embedding memory
offloading).  We need to use the v2 kernel since v1 does not support
grid dimension reduction.

Reviewed By: q10

Differential Revision: D72343128
