### PR TITLE
Pass in sharding position information to TBE to facilitate logging / dump / etc.

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -604,6 +604,11 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         embedding_table_offset_type (torch.dtype = torch.int64): The data type of
             the embedding table offset tensor. Options are `torch.int32` and
             `torch.int64`
+
+        embedding_shard_info (Optional[List[Tuple[int, int, int, int]]] = None): the
+            information about shard position and pre-sharded table size. If not set,
+            the table is not sharded.
+            (preshard_table_height, preshard_table_dim, height_offset, dim_offset)
     """
 
     embedding_specs: List[Tuple[int, int, EmbeddingLocation, ComputeDevice]]
@@ -674,6 +679,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         tbe_input_multiplexer_config: Optional[TBEInputMultiplexerConfig] = None,
         embedding_table_index_type: torch.dtype = torch.int64,
         embedding_table_offset_type: torch.dtype = torch.int64,
+        embedding_shard_info: Optional[List[Tuple[int, int, int, int]]] = None,
     ) -> None:
         super(SplitTableBatchedEmbeddingBagsCodegen, self).__init__()
         self.uuid = str(uuid.uuid4())
@@ -868,6 +874,16 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             feature_table_map if feature_table_map is not None else list(range(T_))
         )
 
+        if embedding_shard_info:
+            (full_table_heights, full_table_dims, row_offset, col_offset) = zip(
+                *embedding_shard_info
+            )
+        else:
+            # Just assume the table is unsharded
+            full_table_heights = rows
+            full_table_dims = dims
+            row_offset = [0] * len(row_offset)
+            col_offset = [0] * len(row_offset)
         self.tbe_input_multiplexer: Optional[TBEInputMultiplexer] = (
             tbe_input_multiplexer_config.create_tbe_input_multiplexer(
                 tbe_info=TBEInfo(
@@ -879,6 +895,11 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                     table_heights=rows,
                     tbe_uuid=self.uuid,
                     feature_table_map=self.feature_table_map,
+                    table_dims=dims,
+                    full_table_heights=full_table_heights,
+                    full_table_dims=full_table_dims,
+                    row_offset=row_offset,
+                    col_offset=col_offset,
                 )
             )
             if tbe_input_multiplexer_config is not None

--- a/fbgemm_gpu/fbgemm_gpu/tbe_input_multiplexer.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe_input_multiplexer.py
@@ -25,12 +25,22 @@ class TBEInfo:
         table_heights: table heights (hashsize)
         tbe_uuid: a unique identifier for the TBE
         feature_table_map: feature to table map
+        table_dims: table dimensions
+        full_table_heights: table heights before sharding
+        full_table_dims: table dimensions before sharding
+        row_offset: the shard offset of the current rank on row (height)
+        col_offset: the shard offset of the current rank on column (dim)
     """
 
     table_names: List[str]
     table_heights: List[int]
     tbe_uuid: str
     feature_table_map: List[int]
+    table_dims: List[int]
+    full_table_heights: List[int]
+    full_table_dims: List[int]
+    row_offset: List[int]
+    col_offset: List[int]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Summary:
Knowing the exact sharding position information of embedding tables of a TBE is useful to TBE lookup functionalities, but helpful for logging, debugging. It's also useful to dedup TBE dump / delta tracking for CW if there're multiple shards of the same table.

This diff add the interface to pass it in.

Differential Revision: D72409903


