### PR TITLE
[AMD] Add CK to dependencies to enable AMD build.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,6 +16,10 @@
 	path = external/cutlass
 	url = https://github.com/jwfromm/cutlass
 	branch = FBGEMM
+[submodule "external/composable_kernel"]
+	path = external/composable_kernel
+	url = https://github.com/jwfromm/composable_kernel.git
+	branch = FBGEMM
 [submodule "external/json"]
 	path = external/json
 	url = https://github.com/nlohmann/json.git


### PR DESCRIPTION
We previously did not attempt to build our GenAI kernels in opensource as we use a somewhat customized composable kernel build internally. This diff adds a copy of CK used internally to our dependencies so we can start enabling OSS AMD use.