### PR TITLE
Add correctness testing for shuffled mixed dtype GEMMs.

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/gen_ai/quantize.py
+++ b/fbgemm_gpu/experimental/gen_ai/gen_ai/quantize.py
@@ -109,6 +109,8 @@ def quantize_int4_preshuffle(
         scales is a tuple of row_scale ([N]) and group_scale ([K / group_size, 8, N]). When BF16 is
         used, scales is a tuple of group_scale([K / group_size, N]) and group_zero ([K / group_size, N])
     """
+    # Check that K is divisible by group size.
+    assert w.shape[-1] % group_size == 0, "K must be divisible by group size."
 
     def _quantize(
         w: torch.Tensor, dtype: str = "fp8"


### PR DESCRIPTION
Summary: We recently added a collection of high performance mixed dtype gemms using shuffled weights and scales. While we confirmed their functionality through empirical testing, this diff adds explicit correctness tests to our quantization test suite for them.

Differential Revision: D72489551


