### PR TITLE
[fbgemm_gpu] Fix Nova package labeling for GenAI

### DIFF
--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -157,7 +157,10 @@ class FbgemmGpuBuild:
             )
             return pkg_vver
 
-        if self.args.package_variant == "cuda":
+        # NOTE: This is a workaround for the fact that we currently overload
+        # package target (e.g. GPU, GenAI), and variant (e.g. CPU, CUDA, ROCm)
+        # into the same `package_variant` variable, and should be fixed soon.
+        if self.args.package_variant == "cuda" or self.args.package_variant == "genai":
             CudaUtils.set_cuda_environment_variables()
             if torch.version.cuda is not None:
                 cuda_version = torch.version.cuda.split(".")


### PR DESCRIPTION
-  Fix Nova package labeling for GenAI.  This is a workaround until the build scripts are cleaned up to support variants and targets in an orthogonal manner