### PR TITLE
Change set_learning_rate_tensor

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -2975,7 +2975,9 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         Helper function to script `set_learning_rate`.
         Note that returning None does not work.
         """
-        self.learning_rate_tensor.fill_(lr)
+        self.learning_rate_tensor = torch.tensor(
+            lr, device=torch.device("cpu"), dtype=torch.float32
+        )
         return 0.0
 
     @torch.jit.ignore

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -1849,7 +1849,9 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         Helper function to script `set_learning_rate`.
         Note that returning None does not work.
         """
-        self.learning_rate_tensor.fill_(lr)
+        self.learning_rate_tensor = torch.tensor(
+            lr, device=torch.device("cpu"), dtype=torch.float32
+        )
         return 0.0
 
     def flush(self) -> None:


### PR DESCRIPTION
Summary:
The change in D71010630 breaks `aps_models/examples/dlrm/tutorials:test_kernel_apf_dlrm_with_basic_training_demo`, which potentially breaks `apf_dlrm` bento kernel. 

```
RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.FloatTensor []] is at version 2; expected version 1 instead. Hint: enable anomaly detection to find the operation that failed to compute its gradient, with torch.autograd.set_detect_anomaly(True).
```
See [Full error log](https://www.internalfb.com/intern/everpaste/?handle=GHmNRBnyyiCXTVkCAP28ClWARWwPbswMAAAz)

TBE has a method to set learning rate, i.e., `set_learning_rate(lr)` where `lr` is the learning rate value to be set.

D71010630 removes `optimizer_args.learning_rate` (float) and introduces `self.learning_rate_tensor` (tensor). Hence setting learning rate value means changing the value of the `leanring_rate_tensor`. We changed this by using `tensor._fill(lr)`.

However, this seems to break bento kernel which is built from APF code, which causes issues when an in-place operation occurs i.e.,  `tensor._fill(lr)`.


The workaround is to create a new tensor to avoid the in-place operation. The change passes the test

https://www.internalfb.com/intern/testinfra/testconsole/testrun/3659174972188704/

Reviewed By: sryap, nautsimon

Differential Revision: D72617537


