### PR TITLE
[fbgemm_gpu] Reduce OSS build sizes for non-GenAI FBGEMM_GPU

### DIFF
--- a/.github/scripts/fbgemm_gpu_test.bash
+++ b/.github/scripts/fbgemm_gpu_test.bash
@@ -257,7 +257,7 @@ __determine_test_directories () {
     )
   fi
 
-  if [ "$fbgemm_gpu_variant" == "cuda" ] || [ "$fbgemm_gpu_variant" == "genai" ]; then
+  if [ "$fbgemm_gpu_variant" == "genai" ]; then
     target_directories+=(
       fbgemm_gpu/experimental/example/test
       fbgemm_gpu/experimental/gemm/test

--- a/.github/workflows/build_wheels_genai_linux_aarch64.yml
+++ b/.github/workflows/build_wheels_genai_linux_aarch64.yml
@@ -61,4 +61,4 @@ jobs:
       trigger-event: ${{ github.event_name }}
       architecture: aarch64
       setup-miniconda: false
-      timeout: 210
+      timeout: 300

--- a/.github/workflows/build_wheels_genai_linux_x86.yml
+++ b/.github/workflows/build_wheels_genai_linux_x86.yml
@@ -51,4 +51,4 @@ jobs:
       test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       trigger-event: ${{ github.event_name }}
-      timeout: 240
+      timeout: 300

--- a/.github/workflows/build_wheels_linux_aarch64.yml
+++ b/.github/workflows/build_wheels_linux_aarch64.yml
@@ -60,4 +60,4 @@ jobs:
       trigger-event: ${{ github.event_name }}
       architecture: aarch64
       setup-miniconda: false
-      timeout: 210
+      timeout: 300

--- a/.github/workflows/build_wheels_linux_x86.yml
+++ b/.github/workflows/build_wheels_linux_x86.yml
@@ -50,4 +50,4 @@ jobs:
       test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       trigger-event: ${{ github.event_name }}
-      timeout: 240
+      timeout: 300

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -237,29 +237,21 @@ endfunction()
 
 
 ################################################################################
-# Build FBGEMM_GPU (Main) Module
+# Build Targets
 ################################################################################
 
-if(NOT FBGEMM_GENAI_ONLY)
-  include(FbgemmGpu.cmake)
-endif()
-
-
-################################################################################
-# Build Experimental Modules
-################################################################################
-
-if(NOT FBGEMM_CPU_ONLY AND NOT USE_ROCM)
-  add_subdirectory(experimental/example)
-endif()
-
-if(NOT FBGEMM_CPU_ONLY)
-  # Package Triton GEMM (GenAI) kernels
-  add_subdirectory(experimental/gemm)
-endif()
-
-if(NOT FBGEMM_CPU_ONLY AND NOT USE_ROCM)
-  # TODO: Re-enable gen_ai for ROCm once ck/tensor_operation/gpu/device/impl/device_gemm_multiple_d_xdl_cshuffle_v3_ab_scale.hpp
-  # lands into latest ROCm
+if(FBGEMM_GENAI_ONLY)
+  # Build FBGEMM GenAI
   add_subdirectory(experimental/gen_ai)
+
+  # Add experimental packaging example
+  add_subdirectory(experimental/example)
+
+  # Add Triton GEMM (GenAI) kernels if non-CPU build
+  add_subdirectory(experimental/gemm)
+
+else()
+  # Build FBGEMM_GPU
+  include(FbgemmGpu.cmake)
+
 endif()

--- a/fbgemm_gpu/fbgemm_gpu/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/__init__.py
@@ -69,7 +69,7 @@ if torch.cuda.is_available() and torch.version.hip:
 libraries_to_load = {
     "cpu": fbgemm_gpu_libraries,
     "docs": fbgemm_gpu_libraries,
-    "cuda": fbgemm_gpu_libraries + fbgemm_gpu_genai_libraries,
+    "cuda": fbgemm_gpu_libraries,
     "genai": fbgemm_gpu_genai_libraries,
     "rocm": fbgemm_gpu_libraries,
 }


### PR DESCRIPTION
- Remove GenAI build targetfrom the regular FBGEMM_GPU builds, now that we have GenAI-only release packages

- Increase the build times on Nova to prevent ROCm build timeouts