### PR TITLE
Modernize FP8 Rowwise Tuning

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
@@ -978,7 +978,8 @@ class DeepGemmBlockwise(QuantizeOpBase):
 
     @property
     def cuda(self) -> bool:
-        return True
+        # Temporarily disabled due to DeepGemm update removing support.
+        return False
 
 
 @register_quantize_op

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise.cu
@@ -8,504 +8,116 @@
 
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <cutlass/util/host_tensor.h>
-#include <cutlass/util/packed_stride.hpp>
-
-// clang-format off
-// The fixed ordering of the headers is required for CUTLASS 3.2+
-#include <cute/tensor.hpp>
-#include <cutlass/gemm/collective/collective_builder.hpp>     // @manual
-#include <cutlass/gemm/device/gemm_universal_adapter.h>       // @manual
-#include <cutlass/epilogue/collective/collective_builder.hpp> // @manual
 // clang-format on
 
-#include "cutlass_extensions/include/kernel_mode.h"
+#include "f8f8bf16_rowwise/f8f8bf16_rowwise_manifest.cuh"
 
 namespace fbgemm_gpu {
 
 #if CUDART_VERSION >= 12000
 
-// Cutlass rowwise kernel
-template <
-    int TB_M,
-    int TB_N,
-    int TB_K,
-    int TBS_M,
-    int TBS_N,
-    int TBS_K,
-    bool PONG,
-    bool COOP,
-    bool FAST_ACCUM,
-    bool USE_BIAS,
-    typename INPUT_DTYPE,
-    typename BIAS_DTYPE>
-at::Tensor f8f8bf16_rowwise_impl(
-    at::Tensor XQ, // FP8
-    at::Tensor WQ, // FP8
-    at::Tensor x_scale,
-    at::Tensor w_scale,
-    std::optional<at::Tensor> bias,
-    std::optional<at::Tensor> output) {
-  // XQ: M x K
-  // WQ: N x K
-  // output: M x N
-  int M = size_to_dim_(XQ.dim() - 1, XQ.sizes());
-  int N = WQ.size(0);
-  int K = WQ.size(1);
-  // 1. If the input tensor is {M, K}, the output tensor is {M, N}.
-  // 2. If the input tensor is {b, M, K}, the output tensor is {b, M, N}.
-  auto out_sizes = XQ.sizes().vec();
-  out_sizes.back() = N;
-  // Handle case where there is a zero dimension, we simply return an empty
-  // tensor.
-  if (M == 0 || N == 0 || K == 0) {
-    // Use zeros instead of empty for special case where K=0.
-    return at::zeros(out_sizes, XQ.options().dtype(at::kBFloat16));
-  }
-
-  TORCH_CHECK(XQ.size(-1) == K);
-  TORCH_CHECK(XQ.is_cuda() && XQ.is_contiguous());
-  TORCH_CHECK(WQ.is_cuda() && WQ.is_contiguous());
-
-  at::Tensor Y;
-  if (output.has_value()) {
-    Y = output.value();
-    // Make sure the provided output has the proper shape and dtype.
-    TORCH_CHECK(Y.sizes().vec() == out_sizes);
-    TORCH_CHECK(Y.dtype() == at::kBFloat16);
-  } else {
-    Y = at::empty(out_sizes, XQ.options().dtype(at::kBFloat16));
-  }
-
-  using ElementInputA = INPUT_DTYPE;
-  using LayoutInputA = cutlass::layout::RowMajor;
-  constexpr int AlignmentInputA = 16 / sizeof(ElementInputA);
-
-  using ElementInputB = cutlass::float_e4m3_t;
-  using LayoutInputB = cutlass::layout::ColumnMajor;
-  constexpr int AlignmentInputB = 16 / sizeof(ElementInputB);
-
-  using ElementBias = BIAS_DTYPE;
-
-  using ElementOutput = cutlass::bfloat16_t;
-  using LayoutOutput = cutlass::layout::RowMajor;
-  constexpr int AlignmentOutput = 16 / sizeof(ElementOutput);
-
-  using ElementAccumulator = float;
-  using ElementComputeEpilogue = float;
-  using ArchTag = cutlass::arch::Sm90; // Tag indicating the minimum SM that
-                                       // supports the intended feature
-  using OperatorClass = cutlass::arch::OpClassTensorOp;
-  using TileShape = cute::Shape<
-      cute::Int<TB_M>,
-      cute::Int<TB_N>,
-      cute::Int<TB_K>>; // Threadblock-level
-                        // tile size
-  using ClusterShape = cute::Shape<
-      cute::Int<TBS_M>,
-      cute::Int<TBS_N>,
-      cute::Int<TBS_K>>; // Shape of the
-                         // threadblocks in a
-                         // cluster
-  using StageCountType =
-      cutlass::gemm::collective::StageCountAuto; // Stage count maximized
-                                                 // based on the tile size
-  using KernelSchedule = cutlass::gemm::collective::
-      KernelScheduleAuto; // Kernel to launch based on the default setting in
-                          // the Collective Builder
-
-  // Implement rowwise scaling epilogue.
-  using XScale = cutlass::epilogue::fusion::Sm90ColBroadcast<
-      0,
-      TileShape,
-      ElementComputeEpilogue,
-      ElementComputeEpilogue,
-      cute::Stride<cute::Int<1>, cute::Int<0>, cute::Int<0>>>;
-
-  using WScale = cutlass::epilogue::fusion::Sm90RowBroadcast<
-      0,
-      TileShape,
-      ElementComputeEpilogue,
-      ElementComputeEpilogue,
-      cute::Stride<cute::Int<0>, cute::Int<1>, cute::Int<0>>>;
-
-  using Bias = cutlass::epilogue::fusion::Sm90RowBroadcast<
-      0,
-      TileShape,
-      ElementBias,
-      ElementBias,
-      cute::Stride<cute::Int<0>, cute::Int<1>, cute::Int<0>>>;
-
-  using Accum = cutlass::epilogue::fusion::Sm90AccFetch;
-
-  using Compute0 = cutlass::epilogue::fusion::Sm90Compute<
-      cutlass::multiplies,
-      ElementComputeEpilogue, // First stage output type.
-      ElementComputeEpilogue, // First stage input types.
-      cutlass::FloatRoundStyle::round_to_nearest>;
-
-  using EVTCompute0 =
-      cutlass::epilogue::fusion::Sm90EVT<Compute0, WScale, Accum>;
-
-  using Compute1 = cutlass::epilogue::fusion::Sm90Compute<
-      cutlass::multiplies,
-      cute::conditional_t< // Second stage output type.
-          USE_BIAS,
-          ElementBias,
-          ElementOutput>,
-      ElementComputeEpilogue, // Second stage input types.
-      cutlass::FloatRoundStyle::round_to_nearest>;
-
-  using EVTCompute1 =
-      cutlass::epilogue::fusion::Sm90EVT<Compute1, XScale, EVTCompute0>;
-
-  using ComputeBias = cutlass::epilogue::fusion::Sm90Compute<
-      cutlass::plus,
-      ElementOutput, // Final (optional) stage output type.
-      ElementBias, // Final stage input types.
-      cutlass::FloatRoundStyle::round_to_nearest>;
-
-  using EVTComputeBias =
-      cutlass::epilogue::fusion::Sm90EVT<ComputeBias, Bias, EVTCompute1>;
-
-  using EpilogueEVT =
-      cute::conditional_t<USE_BIAS, EVTComputeBias, EVTCompute1>;
-
-  using DefaultSchedule = cutlass::gemm::KernelTmaWarpSpecialized;
-  using PongSchedule = cutlass::gemm::KernelTmaWarpSpecializedPingpong;
-  using SlowAccum = cute::conditional_t<PONG, PongSchedule, DefaultSchedule>;
-  using FastAccum = cute::conditional_t<
-      COOP,
-      cutlass::gemm::KernelTmaWarpSpecializedCooperativeFP8FastAccum,
-      cute::conditional_t<
-          PONG,
-          cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum,
-          cutlass::gemm::KernelTmaWarpSpecializedFP8FastAccum>>;
-  using MainLoopSchedule =
-      cute::conditional_t<FAST_ACCUM, FastAccum, SlowAccum>;
-  using EpilogueSchedule = cute::conditional_t<
-      COOP,
-      cutlass::epilogue::TmaWarpSpecializedCooperative,
-      cutlass::epilogue::TmaWarpSpecialized>;
-
-  using CollectiveEpilogue =
-      typename cutlass::epilogue::collective::CollectiveBuilder<
-          cutlass::arch::Sm90,
-          cutlass::arch::OpClassTensorOp,
-          TileShape,
-          ClusterShape,
-          cutlass::epilogue::collective::EpilogueTileAuto,
-          ElementAccumulator,
-          ElementComputeEpilogue,
-          ElementOutput,
-          LayoutOutput,
-          AlignmentOutput,
-          ElementOutput,
-          LayoutOutput,
-          AlignmentOutput,
-          EpilogueSchedule,
-          EpilogueEVT>::CollectiveOp;
-
-  using CollectiveMainloop =
-      typename cutlass::gemm::collective::CollectiveBuilder<
-          ArchTag,
-          OperatorClass,
-          ElementInputA,
-          LayoutInputA,
-          AlignmentInputA,
-          ElementInputB,
-          LayoutInputB,
-          AlignmentInputB,
-          ElementAccumulator,
-          TileShape,
-          ClusterShape,
-          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
-              sizeof(typename CollectiveEpilogue::SharedStorage))>,
-          MainLoopSchedule>::CollectiveOp;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int, int, int>,
-      CollectiveMainloop,
-      CollectiveEpilogue>;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
-
-  using StrideInputA = typename Gemm::GemmKernel::StrideA;
-  using StrideInputB = typename Gemm::GemmKernel::StrideB;
-  using StrideOutput = typename Gemm::GemmKernel::StrideC;
-
-  StrideInputA stride_a = cutlass::make_cute_packed_stride(
-      StrideInputA{}, cute::make_shape(M, K, 1));
-  StrideInputB stride_b = cutlass::make_cute_packed_stride(
-      StrideInputB{}, cute::make_shape(N, K, 1));
-  StrideOutput stride_output = cutlass::make_cute_packed_stride(
-      StrideOutput{}, cute::make_shape(M, N, 1));
-
-  typename Gemm::Arguments arguments{
-      cutlass::gemm::GemmUniversalMode::kGemm,
-      {M, N, K},
-      {reinterpret_cast<ElementInputA*>(XQ.data_ptr()),
-       stride_a,
-       reinterpret_cast<ElementInputB*>(WQ.data_ptr()),
-       stride_b},
-      {{}, // Epilogue thread we populate below.
-       (ElementOutput*)Y.data_ptr<at::BFloat16>(),
-       stride_output,
-       (ElementOutput*)Y.data_ptr<at::BFloat16>(),
-       stride_output}};
-
-  if constexpr (USE_BIAS) {
-    arguments.epilogue.thread = {
-        {reinterpret_cast<ElementBias*>(bias.value().data_ptr())}, // bias
-        // compute_1
-        {
-            {reinterpret_cast<ElementComputeEpilogue*>(
-                x_scale.data_ptr())}, // x_scale
-            // compute_0
-            {
-                {reinterpret_cast<ElementComputeEpilogue*>(
-                    w_scale.data_ptr())}, // w_scale
-                {}, // Accumulator
-                {} // Multiplies
-            },
-            {}, // Multiplies
-        },
-        {}, // Plus
-    };
-  } else {
-    arguments.epilogue.thread = {
-        {reinterpret_cast<ElementComputeEpilogue*>(
-            x_scale.data_ptr())}, // x_scale
-        // compute_0
-        {
-            {reinterpret_cast<ElementComputeEpilogue*>(
-                w_scale.data_ptr())}, // w_scale
-            {}, // Accumulator
-            {} // Multiplies
-        },
-        {}, // Multiplies
-    };
-  }
-
-  Gemm gemm;
-
-  // Using the arguments, query for extra workspace required for matrix
-  // multiplication computation
-  size_t workspace_size = Gemm::get_workspace_size(arguments);
-
-  // Allocate workspace memory
-  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
-
-  // Check the problem size is supported or not
-  cutlass::Status status = gemm.can_implement(arguments);
-  if (status != cutlass::Status::kSuccess) {
-    throw std::runtime_error("cutlass cannot implement");
-  }
-
-  // Initialize CUTLASS kernel with arguments and workspace pointer
-  status = gemm.initialize(arguments, workspace.get());
-  if (status != cutlass::Status::kSuccess) {
-    throw std::runtime_error("cutlass cannot initialize");
-  }
-
-  status = gemm(at::cuda::getCurrentCUDAStream());
-  if (status != cutlass::Status::kSuccess) {
-    throw std::runtime_error(
-        std::string("cutlass cannot run") +
-        cutlass::cutlassGetStatusString(status));
-  }
-  C10_CUDA_KERNEL_LAUNCH_CHECK();
-
-  return Y;
-}
-
 // FP8 Rowwise Cutlass kernel dispatch.
-template <typename InputDType, bool FastAccum, bool UseBias, typename BiasDType>
 at::Tensor dispatch_fp8_rowwise_kernel(
     at::Tensor XQ,
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    std::optional<at::Tensor> bias,
-    std::optional<at::Tensor> output) {
-  auto K = XQ.size(1);
-  KernelMode kernel = get_kernel_mode(XQ, WQ);
-  if (kernel == KernelMode::Small) {
-    return f8f8bf16_rowwise_impl<
-        64,
-        128,
-        128,
-        2,
-        1,
-        1,
-        false,
-        false,
-        FastAccum,
-        UseBias,
-        InputDType,
-        BiasDType>(XQ, WQ, x_scale, w_scale, bias, output);
-  } else if (kernel == KernelMode::Large) {
-    if (K < 4096) {
-      return f8f8bf16_rowwise_impl<
-          128,
-          128,
-          128,
-          2,
-          1,
-          1,
-          true,
-          false,
-          FastAccum,
-          UseBias,
-          InputDType,
-          BiasDType>(XQ, WQ, x_scale, w_scale, bias, output);
-    } else {
-      return f8f8bf16_rowwise_impl<
-          128,
-          256,
-          128,
-          2,
-          1,
-          1,
-          false,
-          true,
-          FastAccum,
-          UseBias,
-          InputDType,
-          BiasDType>(XQ, WQ, x_scale, w_scale, bias, output);
-    }
-  } else {
-    return f8f8bf16_rowwise_impl<
-        128,
-        128,
-        128,
-        1,
-        2,
-        1,
-        false,
-        false,
-        FastAccum,
-        UseBias,
-        InputDType,
-        BiasDType>(XQ, WQ, x_scale, w_scale, bias, output);
-  }
-}
-
-at::Tensor f8f8bf16_rowwise_wrapper(
-    at::Tensor XQ, // FP8
-    at::Tensor WQ, // FP8
-    at::Tensor x_scale, // FP32
-    at::Tensor w_scale, // FP32
+    bool use_fast_accum,
     std::optional<at::Tensor> bias = std::nullopt,
-    bool use_fast_accum = true,
     std::optional<at::Tensor> output = std::nullopt) {
-  // Check datatypes.
-  TORCH_CHECK(
-      x_scale.dtype() == at::kFloat && w_scale.dtype() == at::kFloat,
-      "Scale tensors must be float32.");
-  if (bias.has_value()) {
-    TORCH_CHECK(
-        bias.value().dtype() == at::kFloat ||
-            bias.value().dtype() == at::kBFloat16,
-        "Bias type must be bfloat16 or float32 if provided.");
-  }
-  bool use_bias = bias.has_value();
-  bool bf16_bias = use_bias && bias.value().dtype() == at::kBFloat16;
+  int M = size_to_dim_(XQ.dim() - 1, XQ.sizes());
+  int N = size_to_dim_(WQ.dim() - 1, WQ.sizes());
+  int K = XQ.size(-1);
 
-  // Templatize based on input dtype.
-  bool use_e5m2 = XQ.dtype() == at::kFloat8_e5m2;
-
-  if (use_bias) {
-    if (bf16_bias) {
-      if (use_fast_accum) {
-        if (use_e5m2) {
-          return dispatch_fp8_rowwise_kernel<
-              cutlass::float_e5m2_t,
-              true,
-              true,
-              cutlass::bfloat16_t>(XQ, WQ, x_scale, w_scale, bias, output);
-        } else {
-          return dispatch_fp8_rowwise_kernel<
-              cutlass::float_e4m3_t,
-              true,
-              true,
-              cutlass::bfloat16_t>(XQ, WQ, x_scale, w_scale, bias, output);
-        }
-      } else {
-        if (use_e5m2) {
-          return dispatch_fp8_rowwise_kernel<
-              cutlass::float_e5m2_t,
-              false,
-              true,
-              cutlass::bfloat16_t>(XQ, WQ, x_scale, w_scale, bias, output);
-        } else {
-          return dispatch_fp8_rowwise_kernel<
-              cutlass::float_e4m3_t,
-              false,
-              true,
-              cutlass::bfloat16_t>(XQ, WQ, x_scale, w_scale, bias, output);
-        }
-      }
+  // Use shape heuristics to dispatch to optimized kernel configuration.
+  if (M <= 16) {
+    return f8f8bf16_rowwise_64_16_128_1_1_1_f_f(
+        XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+  } else if (M <= 32) {
+    if (N <= 4096) {
+      return f8f8bf16_rowwise_64_16_128_1_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
     } else {
-      if (use_fast_accum) {
-        if (use_e5m2) {
-          return dispatch_fp8_rowwise_kernel<
-              cutlass::float_e5m2_t,
-              true,
-              true,
-              float>(XQ, WQ, x_scale, w_scale, bias, output);
-        } else {
-          return dispatch_fp8_rowwise_kernel<
-              cutlass::float_e4m3_t,
-              true,
-              true,
-              float>(XQ, WQ, x_scale, w_scale, bias, output);
-        }
-      } else {
-        if (use_e5m2) {
-          return dispatch_fp8_rowwise_kernel<
-              cutlass::float_e5m2_t,
-              false,
-              true,
-              float>(XQ, WQ, x_scale, w_scale, bias, output);
-        } else {
-          return dispatch_fp8_rowwise_kernel<
-              cutlass::float_e4m3_t,
-              false,
-              true,
-              float>(XQ, WQ, x_scale, w_scale, bias, output);
-        }
-      }
+      return f8f8bf16_rowwise_64_32_128_2_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    }
+  } else if (M <= 64) {
+    if (N <= 2048) {
+      return f8f8bf16_rowwise_64_16_128_1_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    } else if (N <= 4096) {
+      return f8f8bf16_rowwise_64_32_128_2_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    } else {
+      return f8f8bf16_rowwise_64_64_128_2_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    }
+  } else if (M <= 128) {
+    if (N <= 1024) {
+      return f8f8bf16_rowwise_64_16_128_1_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    } else if (N <= 2048) {
+      return f8f8bf16_rowwise_64_32_128_2_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    } else if (N <= 4096) {
+      return f8f8bf16_rowwise_64_64_128_2_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    } else {
+      return f8f8bf16_rowwise_64_128_128_1_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    }
+  } else if (M <= 256) {
+    if (N <= 1024) {
+      return f8f8bf16_rowwise_64_32_128_2_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    } else if (N <= 2048) {
+      return f8f8bf16_rowwise_64_64_128_2_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    } else if (N <= 4096) {
+      return f8f8bf16_rowwise_64_128_128_1_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    } else {
+      return f8f8bf16_rowwise_64_256_128_1_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    }
+  } else if (M <= 512) {
+    if (N <= 1024) {
+      return f8f8bf16_rowwise_64_64_128_2_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    } else if (N <= 2048) {
+      return f8f8bf16_rowwise_64_128_128_1_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    } else if (N <= 4096) {
+      return f8f8bf16_rowwise_64_256_128_1_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    } else {
+      return f8f8bf16_rowwise_128_256_128_2_1_1_f_t(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    }
+  } else if (M <= 1024) {
+    if (N <= 1024) {
+      return f8f8bf16_rowwise_64_128_128_1_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    } else if (N <= 2048) {
+      return f8f8bf16_rowwise_64_256_128_1_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    } else {
+      return f8f8bf16_rowwise_128_256_128_2_1_1_f_t(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
     }
   } else {
-    if (use_fast_accum) {
-      if (use_e5m2) {
-        return dispatch_fp8_rowwise_kernel<
-            cutlass::float_e5m2_t,
-            true,
-            false,
-            float>(XQ, WQ, x_scale, w_scale, bias, output);
-      } else {
-        return dispatch_fp8_rowwise_kernel<
-            cutlass::float_e4m3_t,
-            true,
-            false,
-            float>(XQ, WQ, x_scale, w_scale, bias, output);
-      }
+    if (M <= 2048 && N <= 1024) {
+      return f8f8bf16_rowwise_64_256_128_2_1_1_f_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    } else if (K <= 4096) {
+      return f8f8bf16_rowwise_128_128_128_2_1_1_t_f(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+    } else if (M > 8192 && N > 8192) {
+      return f8f8bf16_rowwise_128_256_128_4_4_1_f_t(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
     } else {
-      if (use_e5m2) {
-        return dispatch_fp8_rowwise_kernel<
-            cutlass::float_e5m2_t,
-            false,
-            false,
-            float>(XQ, WQ, x_scale, w_scale, bias, output);
-      } else {
-        return dispatch_fp8_rowwise_kernel<
-            cutlass::float_e4m3_t,
-            false,
-            false,
-            float>(XQ, WQ, x_scale, w_scale, bias, output);
-      }
+      return f8f8bf16_rowwise_128_256_128_2_1_1_f_t(
+          XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
     }
   }
 }
@@ -519,8 +131,8 @@ void f8f8bf16_rowwise_out(
     std::optional<at::Tensor> bias = std::nullopt,
     bool use_fast_accum = true) {
   // Invoke rowwise kernel with output argument.
-  f8f8bf16_rowwise_wrapper(
-      XQ, WQ, x_scale, w_scale, bias, use_fast_accum, output);
+  dispatch_fp8_rowwise_kernel(
+      XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
 }
 
 at::Tensor f8f8bf16_rowwise(
@@ -531,8 +143,8 @@ at::Tensor f8f8bf16_rowwise(
     std::optional<at::Tensor> bias = std::nullopt,
     bool use_fast_accum = true) {
   // Invoke and return rowwise kernel without output argument.
-  return f8f8bf16_rowwise_wrapper(
-      XQ, WQ, x_scale, w_scale, bias, use_fast_accum);
+  return dispatch_fp8_rowwise_kernel(
+      XQ, WQ, x_scale, w_scale, use_fast_accum, bias);
 }
 
 #else

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_128_128_128_2_1_1_t_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_128_128_128_2_1_1_t_f.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_rowwise_common.cuh"
+
+namespace fbgemm_gpu {
+
+at::Tensor f8f8bf16_rowwise_128_128_128_2_1_1_t_f(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt) {
+  // Dispatch this kernel to the correct underlying implementation.
+  return f8f8bf16_rowwise_wrapper<128, 128, 128, 2, 1, 1, true, false>(
+      XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_128_256_128_2_1_1_f_t.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_128_256_128_2_1_1_f_t.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_rowwise_common.cuh"
+
+namespace fbgemm_gpu {
+
+at::Tensor f8f8bf16_rowwise_128_256_128_2_1_1_f_t(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt) {
+  // Dispatch this kernel to the correct underlying implementation.
+  return f8f8bf16_rowwise_wrapper<128, 256, 128, 2, 1, 1, false, true>(
+      XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_128_256_128_4_4_1_f_t.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_128_256_128_4_4_1_f_t.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_rowwise_common.cuh"
+
+namespace fbgemm_gpu {
+
+at::Tensor f8f8bf16_rowwise_128_256_128_4_4_1_f_t(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt) {
+  // Dispatch this kernel to the correct underlying implementation.
+  return f8f8bf16_rowwise_wrapper<128, 256, 128, 4, 4, 1, false, true>(
+      XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_64_128_128_1_1_1_f_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_64_128_128_1_1_1_f_f.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_rowwise_common.cuh"
+
+namespace fbgemm_gpu {
+
+at::Tensor f8f8bf16_rowwise_64_128_128_1_1_1_f_f(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt) {
+  // Dispatch this kernel to the correct underlying implementation.
+  return f8f8bf16_rowwise_wrapper<64, 128, 128, 1, 1, 1, false, false>(
+      XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_64_16_128_1_1_1_f_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_64_16_128_1_1_1_f_f.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_rowwise_common.cuh"
+
+namespace fbgemm_gpu {
+
+at::Tensor f8f8bf16_rowwise_64_16_128_1_1_1_f_f(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt) {
+  // Dispatch this kernel to the correct underlying implementation.
+  return f8f8bf16_rowwise_wrapper<64, 16, 128, 1, 1, 1, false, false>(
+      XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_64_256_128_1_1_1_f_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_64_256_128_1_1_1_f_f.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_rowwise_common.cuh"
+
+namespace fbgemm_gpu {
+
+at::Tensor f8f8bf16_rowwise_64_256_128_1_1_1_f_f(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt) {
+  // Dispatch this kernel to the correct underlying implementation.
+  return f8f8bf16_rowwise_wrapper<64, 256, 128, 1, 1, 1, false, false>(
+      XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_64_256_128_2_1_1_f_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_64_256_128_2_1_1_f_f.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_rowwise_common.cuh"
+
+namespace fbgemm_gpu {
+
+at::Tensor f8f8bf16_rowwise_64_256_128_2_1_1_f_f(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt) {
+  // Dispatch this kernel to the correct underlying implementation.
+  return f8f8bf16_rowwise_wrapper<64, 256, 128, 2, 1, 1, false, false>(
+      XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_64_32_128_2_1_1_f_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_64_32_128_2_1_1_f_f.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_rowwise_common.cuh"
+
+namespace fbgemm_gpu {
+
+at::Tensor f8f8bf16_rowwise_64_32_128_2_1_1_f_f(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt) {
+  // Dispatch this kernel to the correct underlying implementation.
+  return f8f8bf16_rowwise_wrapper<64, 32, 128, 2, 1, 1, false, false>(
+      XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_64_64_128_2_1_1_f_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_64_64_128_2_1_1_f_f.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "f8f8bf16_rowwise_common.cuh"
+
+namespace fbgemm_gpu {
+
+at::Tensor f8f8bf16_rowwise_64_64_128_2_1_1_f_f(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt) {
+  // Dispatch this kernel to the correct underlying implementation.
+  return f8f8bf16_rowwise_wrapper<64, 64, 128, 2, 1, 1, false, false>(
+      XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_common.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_common.cuh
@@ -1,0 +1,584 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cutlass/util/host_tensor.h>
+#include <cutlass/util/packed_stride.hpp>
+
+// clang-format off
+// The fixed ordering of the headers is required for CUTLASS 3.2+
+#include <cute/tensor.hpp>
+#include <cutlass/gemm/collective/collective_builder.hpp>     // @manual
+#include <cutlass/gemm/device/gemm_universal_adapter.h>       // @manual
+#include <cutlass/epilogue/collective/collective_builder.hpp> // @manual
+
+// clang-format on
+
+namespace fbgemm_gpu {
+
+#if CUDART_VERSION >= 12000
+
+// Cutlass rowwise kernel
+template <
+    int TB_M,
+    int TB_N,
+    int TB_K,
+    int TBS_M,
+    int TBS_N,
+    int TBS_K,
+    bool PONG,
+    bool COOP,
+    bool FAST_ACCUM,
+    bool USE_BIAS,
+    typename INPUT_DTYPE,
+    typename BIAS_DTYPE>
+at::Tensor f8f8bf16_rowwise_impl(
+    at::Tensor XQ, // FP8
+    at::Tensor WQ, // FP8
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    std::optional<at::Tensor> bias,
+    std::optional<at::Tensor> output) {
+  // XQ: M x K
+  // WQ: N x K
+  // output: M x N
+  int M = size_to_dim_(XQ.dim() - 1, XQ.sizes());
+  int N = WQ.size(0);
+  int K = WQ.size(1);
+  // 1. If the input tensor is {M, K}, the output tensor is {M, N}.
+  // 2. If the input tensor is {b, M, K}, the output tensor is {b, M, N}.
+  auto out_sizes = XQ.sizes().vec();
+  out_sizes.back() = N;
+  // Handle case where there is a zero dimension, we simply return an empty
+  // tensor.
+  if (M == 0 || N == 0 || K == 0) {
+    // Use zeros instead of empty for special case where K=0.
+    return at::zeros(out_sizes, XQ.options().dtype(at::kBFloat16));
+  }
+
+  TORCH_CHECK(XQ.size(-1) == K);
+  TORCH_CHECK(XQ.is_cuda() && XQ.is_contiguous());
+  TORCH_CHECK(WQ.is_cuda() && WQ.is_contiguous());
+
+  at::Tensor Y;
+  if (output.has_value()) {
+    Y = output.value();
+    // Make sure the provided output has the proper shape and dtype.
+    TORCH_CHECK(Y.sizes().vec() == out_sizes);
+    TORCH_CHECK(Y.dtype() == at::kBFloat16);
+  } else {
+    Y = at::empty(out_sizes, XQ.options().dtype(at::kBFloat16));
+  }
+
+  using ElementA = INPUT_DTYPE;
+  using LayoutA = cutlass::layout::RowMajor;
+  constexpr int AlignmentInputA = 16 / sizeof(ElementA);
+
+  using ElementB = cutlass::float_e4m3_t;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  constexpr int AlignmentInputB = 16 / sizeof(ElementB);
+
+  // Use implicit transpose to enable more flexible configurations.
+  using LayoutA_Transpose =
+      typename cutlass::layout::LayoutTranspose<LayoutA>::type;
+  using LayoutB_Transpose =
+      typename cutlass::layout::LayoutTranspose<LayoutB>::type;
+
+  using ElementBias = BIAS_DTYPE;
+
+  using ElementOutput = cutlass::bfloat16_t;
+  using LayoutOutput = cutlass::layout::RowMajor;
+  constexpr int AlignmentOutput = 16 / sizeof(ElementOutput);
+
+  using ElementAccumulator = float;
+  using ElementComputeEpilogue = float;
+  using ArchTag = cutlass::arch::Sm90; // Tag indicating the minimum SM that
+                                       // supports the intended feature
+  using OperatorClass = cutlass::arch::OpClassTensorOp;
+  using TileShape = cute::Shape<
+      cute::Int<TB_M>,
+      cute::Int<TB_N>,
+      cute::Int<TB_K>>; // Threadblock-level
+                        // tile size
+  using ClusterShape = cute::Shape<
+      cute::Int<TBS_M>,
+      cute::Int<TBS_N>,
+      cute::Int<TBS_K>>; // Shape of the
+                         // threadblocks in a
+                         // cluster
+  using StageCountType =
+      cutlass::gemm::collective::StageCountAuto; // Stage count maximized
+                                                 // based on the tile size
+  using KernelSchedule = cutlass::gemm::collective::
+      KernelScheduleAuto; // Kernel to launch based on the default setting in
+                          // the Collective Builder
+
+  // Implement rowwise scaling epilogue.
+  using XScale = cutlass::epilogue::fusion::Sm90ColBroadcast<
+      0,
+      TileShape,
+      ElementComputeEpilogue,
+      ElementComputeEpilogue,
+      cute::Stride<cute::Int<1>, cute::Int<0>, cute::Int<0>>>;
+
+  using WScale = cutlass::epilogue::fusion::Sm90RowBroadcast<
+      0,
+      TileShape,
+      ElementComputeEpilogue,
+      ElementComputeEpilogue,
+      cute::Stride<cute::Int<0>, cute::Int<1>, cute::Int<0>>>;
+
+  using Bias = cutlass::epilogue::fusion::Sm90ColBroadcast<
+      0,
+      TileShape,
+      ElementBias,
+      ElementBias,
+      cute::Stride<cute::Int<1>, cute::Int<0>, cute::Int<0>>>;
+
+  using Accum = cutlass::epilogue::fusion::Sm90AccFetch;
+
+  using Compute0 = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::multiplies,
+      ElementComputeEpilogue, // First stage output type.
+      ElementComputeEpilogue, // First stage input types.
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using EVTCompute0 =
+      cutlass::epilogue::fusion::Sm90EVT<Compute0, WScale, Accum>;
+
+  using Compute1 = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::multiplies,
+      cute::conditional_t< // Second stage output type.
+          USE_BIAS,
+          ElementBias,
+          ElementOutput>,
+      ElementComputeEpilogue, // Second stage input types.
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using EVTCompute1 =
+      cutlass::epilogue::fusion::Sm90EVT<Compute1, XScale, EVTCompute0>;
+
+  using ComputeBias = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::plus,
+      ElementOutput, // Final (optional) stage output type.
+      ElementBias, // Final stage input types.
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using EVTComputeBias =
+      cutlass::epilogue::fusion::Sm90EVT<ComputeBias, Bias, EVTCompute1>;
+
+  using EpilogueEVT =
+      cute::conditional_t<USE_BIAS, EVTComputeBias, EVTCompute1>;
+
+  using DefaultSchedule = cutlass::gemm::KernelTmaWarpSpecialized;
+  using PongSchedule = cutlass::gemm::KernelTmaWarpSpecializedPingpong;
+  using SlowAccum = cute::conditional_t<PONG, PongSchedule, DefaultSchedule>;
+  using FastAccum = cute::conditional_t<
+      COOP,
+      cutlass::gemm::KernelTmaWarpSpecializedCooperativeFP8FastAccum,
+      cute::conditional_t<
+          PONG,
+          cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum,
+          cutlass::gemm::KernelTmaWarpSpecializedFP8FastAccum>>;
+  using MainLoopSchedule =
+      cute::conditional_t<FAST_ACCUM, FastAccum, SlowAccum>;
+  using EpilogueSchedule = cute::conditional_t<
+      COOP,
+      cutlass::epilogue::TmaWarpSpecializedCooperative,
+      cutlass::epilogue::TmaWarpSpecialized>;
+
+  using CollectiveEpilogue =
+      typename cutlass::epilogue::collective::CollectiveBuilder<
+          cutlass::arch::Sm90,
+          cutlass::arch::OpClassTensorOp,
+          TileShape,
+          ClusterShape,
+          cutlass::epilogue::collective::EpilogueTileAuto,
+          ElementAccumulator,
+          ElementComputeEpilogue,
+          void,
+          typename cutlass::layout::LayoutTranspose<LayoutOutput>::type,
+          AlignmentOutput,
+          ElementOutput,
+          typename cutlass::layout::LayoutTranspose<LayoutOutput>::type,
+          AlignmentOutput,
+          EpilogueSchedule,
+          EpilogueEVT>::CollectiveOp;
+
+  using CollectiveMainloop =
+      typename cutlass::gemm::collective::CollectiveBuilder<
+          ArchTag,
+          OperatorClass,
+          ElementB,
+          LayoutB_Transpose,
+          AlignmentInputA,
+          ElementA,
+          LayoutA_Transpose,
+          AlignmentInputB,
+          ElementAccumulator,
+          TileShape,
+          ClusterShape,
+          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+              sizeof(typename CollectiveEpilogue::SharedStorage))>,
+          MainLoopSchedule>::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      cute::Shape<int, int, int>,
+      CollectiveMainloop,
+      CollectiveEpilogue>;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+  using StrideInputA = typename Gemm::GemmKernel::StrideA;
+  using StrideInputB = typename Gemm::GemmKernel::StrideB;
+  using StrideOutput = typename Gemm::GemmKernel::StrideC;
+
+  StrideInputA stride_a = cutlass::make_cute_packed_stride(
+      StrideInputA{}, cute::make_shape(M, K, 1));
+  StrideInputB stride_b = cutlass::make_cute_packed_stride(
+      StrideInputB{}, cute::make_shape(N, K, 1));
+  StrideOutput stride_output = cutlass::make_cute_packed_stride(
+      StrideOutput{}, cute::make_shape(N, M, 1));
+
+  typename Gemm::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      {N, M, K},
+      {reinterpret_cast<ElementB*>(WQ.data_ptr()),
+       stride_b,
+       reinterpret_cast<ElementA*>(XQ.data_ptr()),
+       stride_a},
+      {{}, // Epilogue thread we populate below.
+       nullptr,
+       stride_output,
+       (ElementOutput*)Y.data_ptr<at::BFloat16>(),
+       stride_output}};
+
+  if constexpr (USE_BIAS) {
+    arguments.epilogue.thread = {
+        {reinterpret_cast<ElementBias*>(bias.value().data_ptr())}, // bias
+        // compute_1
+        {
+            {reinterpret_cast<ElementComputeEpilogue*>(
+                w_scale.data_ptr())}, // x_scale
+            // compute_0
+            {
+                {reinterpret_cast<ElementComputeEpilogue*>(
+                    x_scale.data_ptr())}, // w_scale
+                {}, // Accumulator
+                {} // Multiplies
+            },
+            {}, // Multiplies
+        },
+        {}, // Plus
+    };
+  } else {
+    arguments.epilogue.thread = {
+        {reinterpret_cast<ElementComputeEpilogue*>(
+            w_scale.data_ptr())}, // x_scale
+        // compute_0
+        {
+            {reinterpret_cast<ElementComputeEpilogue*>(
+                x_scale.data_ptr())}, // w_scale
+            {}, // Accumulator
+            {} // Multiplies
+        },
+        {}, // Multiplies
+    };
+  }
+
+  int sm_count =
+      at::cuda::getDeviceProperties(Y.device().index())->multiProcessorCount;
+  if (at::globalContext()._SMCarveout_EXPERIMENTAL().has_value()) {
+    sm_count -= at::globalContext()._SMCarveout_EXPERIMENTAL().value();
+  }
+  arguments.hw_info.sm_count = sm_count;
+
+  Gemm gemm;
+
+  // Using the arguments, query for extra workspace required for matrix
+  // multiplication computation
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+
+  // Allocate workspace memory
+  at::Tensor workspace =
+      at::empty(workspace_size, XQ.options().dtype(at::kByte));
+
+  // Check the problem size is supported or not
+  cutlass::Status status = gemm.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot implement");
+  }
+
+  // Initialize CUTLASS kernel with arguments and workspace pointer
+  status = gemm.initialize(arguments, workspace.data_ptr());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error("cutlass cannot initialize");
+  }
+
+  status = gemm(at::cuda::getCurrentCUDAStream());
+  if (status != cutlass::Status::kSuccess) {
+    throw std::runtime_error(
+        std::string("cutlass cannot run") +
+        cutlass::cutlassGetStatusString(status));
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  return Y;
+}
+
+template <
+    int TB_M,
+    int TB_N,
+    int TB_K,
+    int TBS_M,
+    int TBS_N,
+    int TBS_K,
+    bool PONG,
+    bool COOP>
+at::Tensor f8f8bf16_rowwise_wrapper(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum,
+    std::optional<at::Tensor> bias,
+    std::optional<at::Tensor> output) {
+  // Check datatypes.
+  TORCH_CHECK(
+      x_scale.dtype() == at::kFloat && w_scale.dtype() == at::kFloat,
+      "Scale tensors must be float32.");
+  if (bias.has_value()) {
+    TORCH_CHECK(
+        bias.value().dtype() == at::kFloat ||
+            bias.value().dtype() == at::kBFloat16,
+        "Bias type must be bfloat16 or float32 if provided.");
+  }
+  bool use_bias = bias.has_value();
+  bool bf16_bias = use_bias && bias.value().dtype() == at::kBFloat16;
+
+  // Templatize based on input dtype.
+  bool use_e5m2 = XQ.dtype() == at::kFloat8_e5m2;
+
+  if (use_bias) {
+    if (bf16_bias) {
+      if (use_fast_accum) {
+        if (use_e5m2) {
+          return f8f8bf16_rowwise_impl<
+              TB_M,
+              TB_N,
+              TB_K,
+              TBS_M,
+              TBS_N,
+              TBS_K,
+              PONG,
+              COOP,
+              true,
+              true,
+              cutlass::float_e5m2_t,
+              cutlass::bfloat16_t>(XQ, WQ, x_scale, w_scale, bias, output);
+        } else {
+          return f8f8bf16_rowwise_impl<
+              TB_M,
+              TB_N,
+              TB_K,
+              TBS_M,
+              TBS_N,
+              TBS_K,
+              PONG,
+              COOP,
+              true,
+              true,
+              cutlass::float_e4m3_t,
+              cutlass::bfloat16_t>(XQ, WQ, x_scale, w_scale, bias, output);
+        }
+      } else {
+        if (use_e5m2) {
+          return f8f8bf16_rowwise_impl<
+              TB_M,
+              TB_N,
+              TB_K,
+              TBS_M,
+              TBS_N,
+              TBS_K,
+              PONG,
+              COOP,
+              false,
+              true,
+              cutlass::float_e5m2_t,
+              cutlass::bfloat16_t>(XQ, WQ, x_scale, w_scale, bias, output);
+        } else {
+          return f8f8bf16_rowwise_impl<
+              TB_M,
+              TB_N,
+              TB_K,
+              TBS_M,
+              TBS_N,
+              TBS_K,
+              PONG,
+              COOP,
+              false,
+              true,
+              cutlass::float_e4m3_t,
+              cutlass::bfloat16_t>(XQ, WQ, x_scale, w_scale, bias, output);
+        }
+      }
+    } else {
+      if (use_fast_accum) {
+        if (use_e5m2) {
+          return f8f8bf16_rowwise_impl<
+              TB_M,
+              TB_N,
+              TB_K,
+              TBS_M,
+              TBS_N,
+              TBS_K,
+              PONG,
+              COOP,
+              true,
+              true,
+              cutlass::float_e5m2_t,
+              float>(XQ, WQ, x_scale, w_scale, bias, output);
+        } else {
+          return f8f8bf16_rowwise_impl<
+              TB_M,
+              TB_N,
+              TB_K,
+              TBS_M,
+              TBS_N,
+              TBS_K,
+              PONG,
+              COOP,
+              true,
+              true,
+              cutlass::float_e4m3_t,
+              float>(XQ, WQ, x_scale, w_scale, bias, output);
+        }
+      } else {
+        if (use_e5m2) {
+          return f8f8bf16_rowwise_impl<
+              TB_M,
+              TB_N,
+              TB_K,
+              TBS_M,
+              TBS_N,
+              TBS_K,
+              PONG,
+              COOP,
+              false,
+              true,
+              cutlass::float_e5m2_t,
+              float>(XQ, WQ, x_scale, w_scale, bias, output);
+        } else {
+          return f8f8bf16_rowwise_impl<
+              TB_M,
+              TB_N,
+              TB_K,
+              TBS_M,
+              TBS_N,
+              TBS_K,
+              PONG,
+              COOP,
+              false,
+              true,
+              cutlass::float_e4m3_t,
+              float>(XQ, WQ, x_scale, w_scale, bias, output);
+        }
+      }
+    }
+  } else {
+    if (use_fast_accum) {
+      if (use_e5m2) {
+        return f8f8bf16_rowwise_impl<
+            TB_M,
+            TB_N,
+            TB_K,
+            TBS_M,
+            TBS_N,
+            TBS_K,
+            PONG,
+            COOP,
+            true,
+            false,
+            cutlass::float_e5m2_t,
+            float>(XQ, WQ, x_scale, w_scale, bias, output);
+      } else {
+        return f8f8bf16_rowwise_impl<
+            TB_M,
+            TB_N,
+            TB_K,
+            TBS_M,
+            TBS_N,
+            TBS_K,
+            PONG,
+            COOP,
+            true,
+            false,
+            cutlass::float_e4m3_t,
+            float>(XQ, WQ, x_scale, w_scale, bias, output);
+      }
+    } else {
+      if (use_e5m2) {
+        return f8f8bf16_rowwise_impl<
+            TB_M,
+            TB_N,
+            TB_K,
+            TBS_M,
+            TBS_N,
+            TBS_K,
+            PONG,
+            COOP,
+            false,
+            false,
+            cutlass::float_e5m2_t,
+            float>(XQ, WQ, x_scale, w_scale, bias, output);
+      } else {
+        return f8f8bf16_rowwise_impl<
+            TB_M,
+            TB_N,
+            TB_K,
+            TBS_M,
+            TBS_N,
+            TBS_K,
+            PONG,
+            COOP,
+            false,
+            false,
+            cutlass::float_e4m3_t,
+            float>(XQ, WQ, x_scale, w_scale, bias, output);
+      }
+    }
+  }
+}
+
+#else
+
+template <
+    int TB_M,
+    int TB_N,
+    int TB_K,
+    int TBS_M,
+    int TBS_N,
+    int TBS_K,
+    bool PONG,
+    bool COOP>
+at::Tensor f8f8bf16_rowwise_wrapper(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum,
+    std::optional<at::Tensor> bias,
+    std::optional<at::Tensor> output) {
+  throw std::runtime_error(
+      "CUDA version is older than 12.0"); // requires CUDA>=12
+}
+
+#endif
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_manifest.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_manifest.cuh
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+
+namespace fbgemm_gpu {
+
+at::Tensor f8f8bf16_rowwise_64_16_128_1_1_1_f_f(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt);
+
+at::Tensor f8f8bf16_rowwise_64_32_128_2_1_1_f_f(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt);
+
+at::Tensor f8f8bf16_rowwise_64_64_128_2_1_1_f_f(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt);
+
+at::Tensor f8f8bf16_rowwise_64_128_128_1_1_1_f_f(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt);
+
+at::Tensor f8f8bf16_rowwise_64_256_128_1_1_1_f_f(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt);
+
+at::Tensor f8f8bf16_rowwise_128_256_128_2_1_1_f_t(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt);
+
+at::Tensor f8f8bf16_rowwise_64_256_128_2_1_1_f_f(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt);
+
+at::Tensor f8f8bf16_rowwise_128_128_128_2_1_1_t_f(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt);
+
+at::Tensor f8f8bf16_rowwise_128_256_128_4_4_1_f_t(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt);
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -549,13 +549,13 @@ at::Tensor bf16i4bf16_rowwise_meta(
 
 at::Tensor bf16i4bf16_rowwise_batched_meta(
     at::Tensor X, // BF16
-    at::Tensor WQ, // INT4
-    at::Tensor /* w_scale */,
-    at::Tensor /* w_zp */
+    at::Tensor W, // INT4
+    at::Tensor /* w_scale_group */,
+    at::Tensor /* w_zero_group */
 ) {
   int B = X.size(0);
   int M = X.size(1);
-  int N = WQ.size(1);
+  int N = W.size(1);
   auto Y = at::empty({B, M, N}, X.options().dtype(at::kBFloat16));
   return Y;
 }

--- a/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
@@ -1202,22 +1202,18 @@ class FP8Tests(unittest.TestCase):
             torch.compile(torch.ops.fbgemm.bf16i4bf16_rowwise)(
                 X,
                 WQ[:, ::2].view(torch.int8).contiguous(),
-                block_scale[0],
-                block_scale[0],
+                block_scale[0].repeat(M).view(-1, M),
+                block_scale[0].repeat(N).view(-1, N),
             )
             torch.compile(torch.ops.fbgemm.bf16i4bf16_rowwise_batched)(
                 X.view(1, M, K),
                 WQ[:, ::2].view(1, N, K // 2).view(torch.int8).contiguous(),
-                block_scale[0],
-                block_scale[0],
+                block_scale[0].repeat(M).view(1, -1, M),
+                block_scale[0].repeat(N).view(1, -1, N),
             )
             # test bf16_fast_gemv is torch compileable
             W_bf16 = torch.randn(N, K, device="cuda", dtype=torch.bfloat16)
             torch.compile(torch.ops.fbgemm.bf16_fast_gemv)(X, W_bf16)
-            # test fp8fp8bf16_fast_gemv is torch compileable
-            torch.compile(torch.ops.fbgemm.fp8fp8bf16_fast_gemv)(XQ, WQ, tensor_scale)
-            # test bf16bf16bf16_fast_gemv is torch compileable
-            torch.compile(torch.ops.fbgemm.bf16fp8bf16_fast_gemv)(X, WQ, tensor_scale)
 
     @unittest.skipIf(
         not torch.version.cuda, "Skip on AMD: fast gemv op is not yet supported."


### PR DESCRIPTION
Summary: D72617756 recently added some new tuning to FBGEMM's flagship fp8 rowwise gemm kernel. I noticed that it introduced regressions for some shapes, so did a full new tuning sweep. This diff improves performance across all shapes and I wasnt able to find any regressions. Speedups are as large as 2X for some mid-size workloads. Notably, this change also makes cutlass faster than deepgemm (even after the latest updates) for virtually all workloads.

Differential Revision: D72805539


