### PR TITLE
reland fp8 kv cache dequantization fix

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/test/kv_cache/kv_cache_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/kv_cache/kv_cache_test.py
@@ -192,9 +192,9 @@ class KVCacheTests(unittest.TestCase):
             torch.version.cuda
             and torch.cuda.get_device_properties(torch.cuda.current_device()).major < 9
         )
-        or (torch.version.hip)
+        or (torch.version.hip and torch.version.hip < "6.2")
         or not HAS_XFORMERS,
-        "Skip when H100 is not available",
+        "Skip when H100 is not available or MI300 is not available",
     )
     def test_fp8_kv_cache(self, MAX_T: int, N_KVH_L: int) -> None:
         N_H_L = 2


### PR DESCRIPTION
Summary:
This is a reland of D72062745, which was reverted as it broke NV.

In this diff, we have separate kernels for AMD and NV, so it won't have any unintended side effects to NV kernels.

For the AMD kernel, we continue to use one warp for a row. And because AMD has 64 threads per warp, we let the first 32 threads handle K and second 32 threads handle V.

Differential Revision: D72799994


