### PR TITLE
Make quantize_bench easier to use in OSS

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
@@ -56,6 +56,7 @@ file(GLOB_RECURSE experimental_gen_ai_cpp_source_files_hip
 
 # Python sources
 file(GLOB_RECURSE experimental_gen_ai_python_source_files
+  bench/*.py
   gen_ai/*.py)
 
 

--- a/fbgemm_gpu/experimental/gen_ai/bench/quantize_bench.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/quantize_bench.py
@@ -29,7 +29,7 @@ except ImportError:
             super().__init__()
 
 
-from .quantize_ops import get_quantize_ops, QuantizeOpBase
+from fbgemm_gpu.experimental.gen_ai.quantize_ops import get_quantize_ops, QuantizeOpBase
 
 
 def generate_group_tensor(G, M):
@@ -592,3 +592,7 @@ def invoke_main() -> None:
 
     args = parser.parse_args()
     main(args)
+
+
+if __name__ == "__main__":
+    invoke_main()  # pragma: no cover

--- a/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
@@ -26,10 +26,15 @@ from fbgemm_gpu.experimental.gemm.triton_gemm.grouped_gemm import (
     grouped_gemm_fp8_rowwise,
 )
 from fbgemm_gpu.experimental.gen_ai.quantize import quantize_int4_preshuffle
-from tinygemm.utils import group_quantize_tensor
 
-if torch.cuda.is_available() and torch.version.cuda:
-    torch.ops.load_library("//tinygemm:tinygemm")
+try:
+    from tinygemm.utils import group_quantize_tensor
+
+    if torch.cuda.is_available() and torch.version.cuda:
+        torch.ops.load_library("//tinygemm:tinygemm")
+    TINYGEMM_ENABLED = True
+except ImportError:
+    TINYGEMM_ENABLED = False
 
 # Marlin currently only is supported only internally at Meta.
 try:
@@ -1812,7 +1817,8 @@ class TinyGemmBF16I4(QuantizeOpBase):
 
     @property
     def cuda(self) -> bool:
-        return True
+        # Only enabled if import works.
+        return TINYGEMM_ENABLED
 
 
 @register_quantize_op


### PR DESCRIPTION
Summary: This small diff cleans up a few aspects of quantize_bench and quantize_ops to make them compatible with OSS runs. Specifically we use a more careful import path and add a few wrappers around internal only libraries.

Differential Revision: D73053772


