### PR TITLE
add kvtensor discrete id IO support

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
@@ -47,6 +47,10 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
       const int64_t length,
       const at::Tensor& weights);
 
+  void set_weights_and_ids(const at::Tensor& ids, const at::Tensor& weights);
+
+  at::Tensor get_weights_by_ids(const at::Tensor& ids);
+
   c10::IntArrayRef sizes();
 
   c10::IntArrayRef strides();

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -575,6 +575,21 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
     folly::coro::blockingWait(set_kv_db_async(seq_indices, weights, count));
   }
 
+  void set_kv_to_storage(const at::Tensor& ids, const at::Tensor& weights) {
+    const auto count = at::tensor({ids.size(0)}, at::ScalarType::Long);
+    folly::coro::blockingWait(set_kv_db_async(ids, weights, count));
+  }
+
+  void get_kv_from_storage_by_snapshot(
+      const at::Tensor& ids,
+      const at::Tensor& weights,
+      const SnapshotHandle* snapshot_handle) {
+    const auto count = at::tensor({ids.size(0)}, at::ScalarType::Long);
+    get_kv_db_async_impl</*use_iterator=*/false>(
+        ids, weights, count, snapshot_handle)
+        .wait();
+  }
+
   virtual rocksdb::Status set_rocksdb_option(
       int shard,
       const std::string& key,


### PR DESCRIPTION
Summary: before, kvt only supports range set and get, adding support for set/get by list of ids

Differential Revision: D73086245


