### PR TITLE
Fix split_embeddings_utils in CMake

### DIFF
--- a/fbgemm_gpu/cmake/TbeTraining.cmake
+++ b/fbgemm_gpu/cmake/TbeTraining.cmake
@@ -87,6 +87,7 @@ gpu_cpp_library(
     ${fbgemm_sources_include_directories}
   CPU_SRCS
     src/split_embeddings_utils/split_embeddings_utils_cpu.cpp
+    src/split_embeddings_utils/split_embeddings_utils_meta.cpp
   GPU_SRCS
     src/split_embeddings_utils/split_embeddings_utils.cpp
     src/split_embeddings_utils/generate_vbe_metadata.cu

--- a/fbgemm_gpu/src/split_embeddings_utils/split_embeddings_utils.cpp
+++ b/fbgemm_gpu/src/split_embeddings_utils/split_embeddings_utils.cpp
@@ -14,39 +14,8 @@
 using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
 
-namespace {
-
-std::tuple<Tensor /*row_output_offsets*/, Tensor /*b_t_map*/>
-generate_vbe_metadata_meta(
-    const Tensor& B_offsets,
-    const Tensor& B_offsets_rank_per_feature,
-    const Tensor& output_offsets_feature_rank,
-    const Tensor& D_offsets,
-    const int64_t D,
-    const bool nobag,
-    const c10::SymInt max_B_feature_rank,
-    const int64_t info_B_num_bits,
-    const c10::SymInt total_B) {
-  Tensor row_output_offsets =
-      at::empty_symint({total_B}, output_offsets_feature_rank.options());
-  Tensor b_t_map = at::empty_symint({total_B}, B_offsets.options());
-  return {row_output_offsets, b_t_map};
-}
-
-std::tuple<int64_t, int64_t>
-get_infos_metadata_meta(Tensor /*unused*/, int64_t /*B*/, int64_t /*T*/) {
-  return {-1, -1};
-}
-
-} // namespace
-
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   DISPATCH_TO_CUDA("transpose_embedding_input", transpose_embedding_input);
   DISPATCH_TO_CUDA("get_infos_metadata", get_infos_metadata);
   DISPATCH_TO_CUDA("generate_vbe_metadata", generate_vbe_metadata);
-}
-
-TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
-  m.impl("generate_vbe_metadata", &generate_vbe_metadata_meta);
-  m.impl("get_infos_metadata", &get_infos_metadata_meta);
 }

--- a/fbgemm_gpu/src/split_embeddings_utils/split_embeddings_utils_meta.cpp
+++ b/fbgemm_gpu/src/split_embeddings_utils/split_embeddings_utils_meta.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <torch/library.h>
+
+using Tensor = at::Tensor;
+
+namespace {
+
+std::tuple<Tensor /*row_output_offsets*/, Tensor /*b_t_map*/>
+generate_vbe_metadata_meta(
+    const Tensor& B_offsets,
+    const Tensor& /*B_offsets_rank_per_feature*/,
+    const Tensor& output_offsets_feature_rank,
+    const Tensor& /*D_offsets*/,
+    const int64_t /*D*/,
+    const bool /*nobag*/,
+    const c10::SymInt /*max_B_feature_rank*/,
+    const int64_t /*info_B_num_bits*/,
+    const c10::SymInt total_B) {
+  Tensor row_output_offsets =
+      at::empty_symint({total_B}, output_offsets_feature_rank.options());
+  Tensor b_t_map = at::empty_symint({total_B}, B_offsets.options());
+  return {row_output_offsets, b_t_map};
+}
+
+std::tuple<int64_t, int64_t>
+get_infos_metadata_meta(Tensor /*unused*/, int64_t /*B*/, int64_t /*T*/) {
+  return {-1, -1};
+}
+
+} // namespace
+
+TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
+  m.impl("generate_vbe_metadata", &generate_vbe_metadata_meta);
+  m.impl("get_infos_metadata", &get_infos_metadata_meta);
+}


### PR DESCRIPTION
Summary:
Usage of `get_infos_metadata` in CPU package causes error: 
```
NotImplementedError: fbgemm::get_infos_metadata: attempted to run this operator with Meta tensors, but there was no fake impl or Meta kernel registered. You may have run into this message while using an operator with PT2 compilation APIs (torch.compile/torch.export); in order to use this operator with those APIs you'll need to add a fake impl. Please see the following for next steps:  https://pytorch.org/tutorials/advanced/custom_ops_landing_page.html
```

This is because `src/split_embeddings_utils/split_embeddings_utils.cpp` is not included in CPU build in Cmake.

Differential Revision: D73150650


