### PR TITLE
Fix bounds_check_indices v2 bug

### DIFF
--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_host.cpp
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_host.cpp
@@ -15,6 +15,7 @@
 #include "fbgemm_gpu/utils/ops_utils.h"
 
 #include "fbgemm_gpu/config/feature_gates.h"
+#include "fbgemm_gpu/embedding_common.h"
 
 using Tensor = at::Tensor;
 
@@ -67,6 +68,15 @@ void bounds_check_indices_cuda(
       bounds_check_version == 2;
   const auto bounds_check_indices_fn =
       use_v2 ? _bounds_check_indices_cuda_v2 : _bounds_check_indices_cuda_v1;
+  const auto bounds_check_mode_ =
+      static_cast<fbgemm_gpu::BoundsCheckMode>(bounds_check_mode);
+  TORCH_CHECK(
+      bounds_check_mode_ == fbgemm_gpu::BoundsCheckMode::WARNING ||
+          bounds_check_mode_ == fbgemm_gpu::BoundsCheckMode::FATAL ||
+          bounds_check_mode_ == fbgemm_gpu::BoundsCheckMode::IGNORE,
+      "bounds_check_indices: bounds_check_mode=",
+      bounds_check_mode,
+      " is not supported");
   bounds_check_indices_fn(
       rows_per_table,
       indices,


### PR DESCRIPTION
Summary:
Before this diff, the `bounds_check_mode_int` value was not propagated
to the `forward` of TBE properly (the `bounds_check_mode_int` was not
updated when `bounds_check_mode.name.startswith("V2_")`) causing the
`bounds_check_indices` v2 to not run since it did not recognize the
bounds check mode.

This diff fixes the `bounds_check_mode` propagation, adds an assert to
check if the `bounds_check_mode` is valid, and prints the
`bounds_check_mode` to stdout for better debug-ability.

Differential Revision: D73163694


