### PR TITLE
add c++ bucket sorted id utils

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/kv_db_cpp_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/kv_db_cpp_utils.h
@@ -8,9 +8,11 @@
 
 #pragma once
 
+#include <ATen/ATen.h>
 #include <folly/hash/Hash.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <optional>
 
 /// @defgroup embedding-ssd Embedding SSD Operators
 ///
@@ -31,5 +33,36 @@ inline size_t hash_shard(int64_t id, size_t num_shards) {
   __uint128_t wide = __uint128_t{num_shards} * hash;
   return static_cast<size_t>(wide >> 64);
 }
+
+/// @ingroup embedding-ssd
+///
+/// @brief given a tensor containing ids in random order, returns 2 tensors
+/// tensor1 contains ids sorted in bucket ascending order, for example given
+/// [1,2,3,4] with 2 buckets [1, 4) and [4, 7), the output will be [1,2,3,4] or
+/// [2, 1, 3, 4], id 1, 2, 3 must be prior to 4, but 1 2 3 can be in any order
+/// tensor2 contains number of embeddings in each bucket id(tensor offset), in
+/// the above example tensor2 will be [3, 1] where first item corresponds to the
+/// first bucket id, value 3 means there are 3 ids in the first bucket id
+///
+/// @param unordered_indices unordered ids, the id here might be
+/// original(unlinearized) id
+/// @param hash_mode 0 for hash by mod, 1 for hash by interleave
+/// @param bucket_start global bucket id, the start of the bucket range
+/// @param bucket_end global bucket id, the end of the bucket range
+/// @param bucket_size an optional, virtual size(input space, e.g. 2^50) of a
+/// bucket
+/// @param total_num_buckets an optional with the total number of buckets per
+/// training model
+///
+/// @return list of 2 tensors, first tensor is bucket sorted ids, second tensor
+/// is bucket size
+
+std::tuple<at::Tensor, at::Tensor> get_bucket_sorted_indices_and_bucket_tensor(
+    const at::Tensor& unordered_indices,
+    int64_t hash_mode,
+    int64_t bucket_start,
+    int64_t bucket_end,
+    std::optional<int64_t> bucket_size,
+    std::optional<int64_t> total_num_buckets);
 
 }; // namespace kv_db_utils

--- a/fbgemm_gpu/src/split_embeddings_cache/kv_db_cpp_utils.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/kv_db_cpp_utils.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbgemm_gpu/split_embeddings_cache/kv_db_cpp_utils.h"
+
+#include <common/base/Proc.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/futures/Future.h>
+#include <glog/logging.h>
+#include <optional>
+
+namespace kv_db_utils {
+
+int64_t _get_bucket_id(
+    int64_t id,
+    int64_t hash_mode,
+    std::optional<int64_t> bucket_size = std::nullopt,
+    std::optional<int64_t> total_num_buckets = std::nullopt) {
+  if (hash_mode == 0) {
+    CHECK(bucket_size.has_value());
+    // hash by mod
+    return id / bucket_size.value();
+  } else {
+    // hash by interleave
+    CHECK(total_num_buckets.has_value());
+    return id % total_num_buckets.value();
+  }
+}
+
+std::tuple<at::Tensor, at::Tensor> get_bucket_sorted_indices_and_bucket_tensor(
+    const at::Tensor& unordered_indices,
+    int64_t hash_mode,
+    int64_t bucket_start,
+    int64_t bucket_end,
+    std::optional<int64_t> bucket_size,
+    std::optional<int64_t> total_num_buckets) {
+  TORCH_CHECK(unordered_indices.is_contiguous());
+  TORCH_CHECK(
+      hash_mode == 0 || hash_mode == 1,
+      "only support hash by mod and interleaved for now");
+  TORCH_CHECK(
+      bucket_start <= bucket_end,
+      "bucket_start:",
+      bucket_start,
+      " must be less than bucket_end:",
+      bucket_end);
+
+  if (bucket_end == bucket_start) {
+    // likely this is the last rank containing 0 bucket
+    TORCH_CHECK(
+        unordered_indices.numel() == 0,
+        "bucket_end:",
+        bucket_end,
+        " equals bucket_start:,",
+        bucket_start,
+        " the input data should be empty but get:",
+        unordered_indices.numel());
+    return std::make_tuple(
+        at::empty(unordered_indices.sizes(), unordered_indices.options()),
+        at::zeros({0, 1}, unordered_indices.options()));
+  }
+
+  auto indices_data_ptr = unordered_indices.data_ptr<int64_t>();
+  auto num_indices = unordered_indices.numel();
+
+  // first loop to figure out size per bucket id in ascending order
+  std::map<int64_t, int64_t> bucket_id_to_cnt;
+  for (int64_t i = 0; i < num_indices; ++i) {
+    auto global_bucket_id = _get_bucket_id(
+        indices_data_ptr[i], hash_mode, bucket_size, total_num_buckets);
+    CHECK(global_bucket_id >= bucket_start && global_bucket_id < bucket_end)
+        << "indices: " << indices_data_ptr[i]
+        << " bucket id: " << global_bucket_id
+        << " must fall into the range between:" << bucket_start << " and "
+        << bucket_end;
+    if (bucket_id_to_cnt.find(global_bucket_id) == bucket_id_to_cnt.end()) {
+      bucket_id_to_cnt[global_bucket_id] = 0;
+    }
+    bucket_id_to_cnt[global_bucket_id] += 1;
+  }
+  // fill the bucket_tensor with counts
+  at::Tensor bucket_tensor =
+      at::zeros({bucket_end - bucket_start, 1}, unordered_indices.options());
+  auto bucket_tensor_data_ptr = bucket_tensor.data_ptr<int64_t>();
+  for (int64_t i = bucket_start; i < bucket_end; ++i) {
+    if (bucket_id_to_cnt.find(i) != bucket_id_to_cnt.end()) {
+      bucket_tensor_data_ptr[i - bucket_start] = bucket_id_to_cnt[i];
+    } else {
+      bucket_tensor_data_ptr[i - bucket_start] = 0;
+    }
+  }
+
+  // calc offset
+  std::map<int64_t, int64_t> bucket_id_to_offset;
+  int64_t offset = 0;
+  for (auto& [bucket_id, cnt] : bucket_id_to_cnt) {
+    bucket_id_to_offset[bucket_id] = offset;
+    offset += cnt;
+  }
+
+  // second loop to parallel set each id into its bucket range
+  at::Tensor id_tensor =
+      at::empty(unordered_indices.sizes(), unordered_indices.options());
+  auto res_data_ptr = id_tensor.data_ptr<int64_t>();
+
+  auto executors = std::make_unique<folly::CPUThreadPoolExecutor>(
+      facebook::Proc::getCpuInfo().numCpuCores);
+
+  auto num_executors = executors->numThreads();
+  std::vector<folly::Future<folly::Unit>> futures;
+  for (int64_t i = 0; i < num_executors; ++i) {
+    auto f = folly::via(executors.get()).thenValue([&, i](folly::Unit) {
+      for (int64_t j = 0; j < num_indices; j++) {
+        auto bucket_id = _get_bucket_id(
+            indices_data_ptr[j], hash_mode, bucket_size, total_num_buckets);
+        if (bucket_id % num_executors != i) {
+          // each bucket will have a specific executor to handle
+          continue;
+        }
+        res_data_ptr[bucket_id_to_offset[bucket_id]] = indices_data_ptr[j];
+        bucket_id_to_offset[bucket_id] += 1;
+      }
+    });
+    futures.push_back(std::move(f));
+  }
+  folly::collect(futures).wait();
+  return std::make_tuple(id_tensor, bucket_tensor);
+}
+
+} // namespace kv_db_utils

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
@@ -82,6 +82,15 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
     return impl_->set_range_to_storage(weights, start, length);
   }
 
+  at::Tensor get_keys_in_range_by_snapshot(
+      int64_t start_id,
+      int64_t end_id,
+      int64_t id_offset,
+      c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper> snapshot_handle) {
+    return impl_->get_keys_in_range_by_snapshot(
+        start_id, end_id, id_offset, snapshot_handle->handle);
+  }
+
   void toggle_compaction(bool enable) {
     impl_->toggle_compaction(enable);
   }

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
@@ -47,6 +47,10 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
       const int64_t length,
       const at::Tensor& weights);
 
+  void set_weights_and_ids(const at::Tensor& ids, const at::Tensor& weights);
+
+  at::Tensor get_weights_by_ids(const at::Tensor& ids);
+
   c10::IntArrayRef sizes();
 
   c10::IntArrayRef strides();

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -15,6 +15,7 @@
 
 #include "./ssd_table_batched_embeddings.h"
 #include "embedding_rocksdb_wrapper.h"
+#include "fbgemm_gpu/split_embeddings_cache/kv_db_cpp_utils.h"
 #include "fbgemm_gpu/utils/ops_utils.h"
 
 using namespace at;
@@ -546,6 +547,18 @@ static auto kv_tensor_wrapper =
         .def_property("strides", &KVTensorWrapper::strides);
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  m.def(
+      "get_bucket_sorted_indices_and_bucket_tensor("
+      "    Tensor unordered_indices,"
+      "    int hash_mode,"
+      "    int bucket_start,"
+      "    int bucket_end,"
+      "    int? bucket_size=None,"
+      "    int? total_num_buckets=None"
+      ") -> (Tensor, Tensor)");
+  DISPATCH_TO_CPU(
+      "get_bucket_sorted_indices_and_bucket_tensor",
+      kv_db_utils::get_bucket_sorted_indices_and_bucket_tensor);
   m.def(
       "masked_index_put("
       "    Tensor self, "

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -504,9 +504,10 @@ static auto embedding_rocks_db_wrapper =
             &EmbeddingRocksDBWrapper::wait_util_filling_work_done)
         .def("create_snapshot", &EmbeddingRocksDBWrapper::create_snapshot)
         .def("release_snapshot", &EmbeddingRocksDBWrapper::release_snapshot)
+        .def("get_snapshot_count", &EmbeddingRocksDBWrapper::get_snapshot_count)
         .def(
-            "get_snapshot_count",
-            &EmbeddingRocksDBWrapper::get_snapshot_count);
+            "get_keys_in_range_by_snapshot",
+            &EmbeddingRocksDBWrapper::get_keys_in_range_by_snapshot);
 
 static auto kv_tensor_wrapper =
     torch::class_<KVTensorWrapper>("fbgemm", "KVTensorWrapper")

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -551,6 +551,85 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
     snapshots_.erase(snapshot_handle);
   }
 
+  /// get existing ids from rocksdb in a given range at a given rocksdb
+  /// snapshot
+  /// @param start_id the inclusive start stored_id of the range
+  /// @param end_id the exclusive end stored_id of the range
+  /// @param id_offset to translate the rocksdb stored id(linearized id) to
+  /// original id(unlinearized id)
+  /// @return unlinearized ids in random order
+  at::Tensor get_keys_in_range_by_snapshot(
+      int64_t start_id,
+      int64_t end_id,
+      int64_t id_offset,
+      const SnapshotHandle* snapshot_handle) {
+    std::vector<folly::Future<folly::Unit>> futures;
+
+    const auto start_key = rocksdb::Slice(
+        reinterpret_cast<const char*>(&start_id), sizeof(int64_t));
+    // [db shard -> [original_ids]]
+    std::vector<std::vector<int64_t>> keys_in_db_shards(dbs_.size());
+    for (auto& keys : keys_in_db_shards) {
+      keys.reserve(1 * 1024 * 1024); // reserve 1M items space
+    }
+
+    // parallel loop through all db shards by iterating from start id to end id
+    for (auto shard = 0; shard < dbs_.size(); ++shard) {
+      // Get a snapshot for the shard
+      snapshot_ptr_t snapshot = snapshot_handle == nullptr
+          ? nullptr
+          : snapshot_handle->get_snapshot_for_shard(shard);
+      auto local_ro = ro_;
+      local_ro.snapshot = snapshot;
+      auto f =
+          folly::via(executor_.get())
+              .thenValue([&, local_ro, shard](folly::Unit) {
+                auto* dcf = dbs_[shard]->DefaultColumnFamily();
+
+                auto iterator_ro = local_ro;
+                iterator_ro.total_order_seek = true; // disable prefix filter
+                auto it = dbs_[shard]->NewIterator(iterator_ro, dcf);
+                it->Seek(start_key);
+                while (true) {
+                  CHECK(it->status().ok());
+                  if (!it->Valid()) {
+                    CHECK(it->status().ok());
+                    // the iterator reaches the end of the data
+                    break;
+                  }
+                  int64_t stored_value =
+                      *reinterpret_cast<const int64_t*>(it->key().data());
+                  if (stored_value >= end_id) {
+                    // go beyond the end of the range
+                    break;
+                  }
+                  keys_in_db_shards[shard].push_back(stored_value - id_offset);
+                  it->Next();
+                }
+
+                delete it;
+              });
+      futures.push_back(std::move(f));
+    }
+    folly::collect(futures).wait();
+    int64_t total_num = 0;
+
+    // calc total num for tensor allocation and count_in_ranges
+    for (const auto& keys : keys_in_db_shards) {
+      total_num += keys.size();
+    }
+
+    at::Tensor returned_keys = at::empty(
+        total_num, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+    auto key_ptr = returned_keys.data_ptr<int64_t>();
+    int64_t offset = 0;
+    for (const auto& keys : keys_in_db_shards) {
+      std::copy(keys.begin(), keys.end(), &key_ptr[offset]);
+      offset += keys.size();
+    }
+    return returned_keys;
+  }
+
   void get_range_from_snapshot(
       const at::Tensor& weights,
       const int64_t start,
@@ -766,8 +845,8 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
     initializers_[shard_id]->consumer_queue_.enqueue(row_index);
   }
 
-  // use this iterator approach only when the keys in indices are contiguous and
-  // matches the key order as defined by the comparator. i.e. the values
+  // use this iterator approach only when the keys in indices are contiguous
+  // and matches the key order as defined by the comparator. i.e. the values
   // returned by the itertor are not thrown away. in other cases using an
   // iterator doesn't provide performance benefits.
   template <typename VALUE_T>
@@ -1017,7 +1096,8 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
   int64_t l0_files_per_compact_;
   bool auto_compaction_enabled_;
 
-  // break down on rocksdb write duration for details checkout RocksdbWriteMode
+  // break down on rocksdb write duration for details checkout
+  // RocksdbWriteMode
   std::atomic<int64_t> read_total_duration_{0};
   std::atomic<int64_t> fwd_rocksdb_read_dur_{0};
   std::atomic<int64_t> fwd_l1_eviction_dur_{0};

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -575,6 +575,21 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
     folly::coro::blockingWait(set_kv_db_async(seq_indices, weights, count));
   }
 
+  void set_kv_to_storage(const at::Tensor& ids, const at::Tensor& weights) {
+    const auto count = at::tensor({ids.size(0)}, at::ScalarType::Long);
+    folly::coro::blockingWait(set_kv_db_async(ids, weights, count));
+  }
+
+  void get_kv_from_storage_by_snapshot(
+      const at::Tensor& ids,
+      const at::Tensor& weights,
+      const SnapshotHandle* snapshot_handle) {
+    const auto count = at::tensor({ids.size(0)}, at::ScalarType::Long);
+    get_kv_db_async_impl</*use_iterator=*/false>(
+        ids, weights, count, snapshot_handle)
+        .wait();
+  }
+
   virtual rocksdb::Status set_rocksdb_option(
       int shard,
       const std::string& key,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1065

add util function to return a id in bucket ascending order and bucket tensor.

implemented in c++ to allow parallelism

Differential Revision: D72576540


