### PR TITLE
Fix runner for ROCm CI

### DIFF
--- a/.github/workflows/fbgemm_gpu_ci_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_ci_rocm.yml
@@ -150,7 +150,7 @@ jobs:
       fail-fast: false
       matrix:
         host-machine: [
-          { arch: x86, instance: "rocm" },
+          { arch: x86, instance: "linux.rocm.gpu.2" },
         ]
         # ROCm machines are limited, so we only test a subset of Python versions
         python-version: [ "3.13" ]

--- a/.github/workflows/fbgemm_gpu_pip.yml
+++ b/.github/workflows/fbgemm_gpu_pip.yml
@@ -193,7 +193,7 @@ jobs:
       fail-fast: false
       matrix:
         host-machine: [
-          { arch: x86, instance: "rocm" },
+          { arch: x86, instance: "linux.rocm.gpu.2" },
         ]
         # ROCm machines are limited, so we only test a subset of Python versions
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]


### PR DESCRIPTION
Summary:
ROCm CI test jobs have not been running with the error:
```
Canceling since a higher priority waiting request for FBGEMM_GPU-ROCm CI-refs/heads/main exists
```

This is due to wrong label of the runner and the jobs wait for a runner that does not exist.

Differential Revision: D73233659


