### PR TITLE
`PackedTensorAccessor` cleanup

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/tensor_accessor2.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/tensor_accessor2.h
@@ -9,15 +9,6 @@
 #pragma once
 
 #include <ATen/ATen.h>
-#include <c10/core/ScalarType.h>
-#include <c10/macros/Macros.h>
-#include <c10/util/ArrayRef.h>
-#include <c10/util/Deprecated.h>
-#include <c10/util/Exception.h>
-#include <c10/util/irange.h>
-
-#include <cstddef>
-#include <cstdint>
 
 ////////////////////////////////////////////////////////////////////////////////
 // Extended TensorAccessor
@@ -34,6 +25,12 @@
 
 namespace fbgemm_gpu::utils {
 
+////////////////////////////////////////////////////////////////////////////////
+// Pointer Trait Aliases
+//
+// Map from at:: namespace
+////////////////////////////////////////////////////////////////////////////////
+
 template <typename T>
 using DefaultPtrTraits = at::DefaultPtrTraits<T>;
 
@@ -44,6 +41,12 @@ using RestrictPtrTraits = at::RestrictPtrTraits<T>;
 
 static constexpr size_t NAME_MAX_LEN = 32;
 static constexpr size_t CONTEXT_MAX_LEN = 256;
+
+////////////////////////////////////////////////////////////////////////////////
+// String Copy
+//
+// Implemented bc std::copy does not exist on the device side
+////////////////////////////////////////////////////////////////////////////////
 
 C10_HOST_DEVICE inline void
 copy_str(char* dst, const char* src, const size_t max_len) {
@@ -151,7 +154,7 @@ class TensorAccessor : public at::TensorAccessorBase<T, N, PtrTraits, index_t> {
   C10_HOST_DEVICE T& at(const index_t idx) const {
     if (idx < 0) {
       printf(
-          "[%s][Tensor %s] ERROR: (idx=%ld) < 0\n",
+          "[%s][Tensor %s] ERROR: outside of accessor bounds (idx=%ld) < 0\n",
           this->context_,
           this->name_,
           static_cast<int64_t>(idx));
@@ -159,7 +162,7 @@ class TensorAccessor : public at::TensorAccessorBase<T, N, PtrTraits, index_t> {
 
     } else if (idx >= numel_) {
       printf(
-          "[%s][Tensor %s] ERROR: (idx=%ld) >= (numel=%ld)\n",
+          "[%s][Tensor %s] ERROR: outside of accessor bounds (idx=%ld) >= (numel=%ld)\n",
           this->context_,
           this->name_,
           static_cast<int64_t>(idx),
@@ -174,6 +177,174 @@ class TensorAccessor : public at::TensorAccessorBase<T, N, PtrTraits, index_t> {
   size_t numel_;
   char name_[NAME_MAX_LEN];
   char context_[CONTEXT_MAX_LEN];
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// PackedTensorAccessor
+//
+// This is an extension of at::GeneticPackedTensorAccessorBase that consolidates
+// some methods defined in at::GeneticPackedTensorAccessor.
+//
+// `GenericPackedTensorAccessor`s are used on for CUDA `Tensor`s on the host and
+// as In contrast to `TensorAccessor`s, they copy the strides and sizes on
+// instantiation (on the host) in order to transfer them on the device when
+// calling kernels.  On the device, indexing of multidimensional tensors gives
+// to `TensorAccessor`s.
+////////////////////////////////////////////////////////////////////////////////
+
+template <
+    typename T,
+    size_t N,
+    template <typename U> class PtrTraits = DefaultPtrTraits,
+    typename index_t = int64_t>
+class PackedTensorAccessor
+    : public at::GenericPackedTensorAccessorBase<T, N, PtrTraits, index_t> {
+ public:
+  typedef typename PtrTraits<T>::PtrType PtrType;
+
+  C10_HOST PackedTensorAccessor(
+      const PtrType data_,
+      const index_t* const sizes_,
+      const index_t* const strides_,
+      const char* const _name_,
+      const char* const _context_)
+      : at::GenericPackedTensorAccessorBase<T, N, PtrTraits, index_t>(
+            data_,
+            sizes_,
+            strides_) {
+    if (sizes_ && strides_) {
+      numel_ = 1;
+      for (size_t d = 0; d < N; d++) {
+        numel_ += (sizes_[d] - 1) * strides_[d];
+      }
+    }
+
+    copy_str(name_, _name_, NAME_MAX_LEN);
+    copy_str(context_, _context_, CONTEXT_MAX_LEN);
+  }
+
+  // if index_t is not int64_t, we want to have an int64_t constructor
+  template <
+      typename source_index_t,
+      class = std::enable_if_t<std::is_same_v<source_index_t, int64_t>>>
+  C10_HOST PackedTensorAccessor(
+      PtrType data_,
+      const source_index_t* sizes_,
+      const source_index_t* strides_,
+      const char* const _name_,
+      const char* const _context_)
+      : at::GenericPackedTensorAccessorBase<T, N, PtrTraits, index_t>(
+            data_,
+            sizes_,
+            strides_) {
+    if (sizes_ && strides_) {
+      numel_ = 1;
+      for (size_t d = 0; d < N; d++) {
+        numel_ += (sizes_[d] - 1) * strides_[d];
+      }
+    }
+
+    copy_str(name_, _name_, NAME_MAX_LEN);
+    copy_str(context_, _context_, CONTEXT_MAX_LEN);
+  }
+
+  template <size_t M = N>
+  C10_HOST_DEVICE inline auto operator[](const index_t i)
+      -> std::
+          enable_if_t<(M > 1), TensorAccessor<T, N - 1, PtrTraits, index_t>> {
+    return TensorAccessor<T, N - 1, PtrTraits, index_t>(
+        this->data_ + this->strides_[0] * i,
+        this->sizes_ + 1,
+        this->strides_ + 1,
+        this->name_,
+        this->context_);
+  }
+
+  template <size_t M = N>
+  C10_HOST_DEVICE inline auto operator[](const index_t i) const
+      -> std::enable_if_t<
+          (M > 1),
+          const TensorAccessor<T, N - 1, PtrTraits, index_t>> {
+    return TensorAccessor<T, N - 1, PtrTraits, index_t>(
+        this->data_ + this->strides_[0] * i,
+        this->sizes_ + 1,
+        this->strides_ + 1,
+        this->name_,
+        this->context_);
+  }
+
+  template <size_t M = N>
+  C10_HOST_DEVICE inline auto operator[](const index_t i)
+      -> std::enable_if_t<(M == 1), T&> {
+    // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
+    return this->at(this->strides_[0] * i);
+  }
+
+  template <size_t M = N>
+  C10_HOST_DEVICE inline auto operator[](const index_t i) const
+      -> std::enable_if_t<(M == 1), const T&> {
+    // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
+    return this->at(this->strides_[0] * i);
+  }
+
+  C10_HOST_DEVICE T& at(const index_t idx) const {
+    if (idx < 0) {
+      printf(
+          "[%s][Tensor %s] ERROR: index is outside of accessor bounds (idx=%ld) < 0\n",
+          this->context_,
+          this->name_,
+          static_cast<int64_t>(idx));
+      CUDA_KERNEL_ASSERT(idx >= 0);
+
+    } else if (idx >= numel_) {
+      printf(
+          "[%s][Tensor %s] ERROR: index is outside of accessor bounds (idx=%ld) >= (numel=%ld)\n",
+          this->context_,
+          this->name_,
+          static_cast<int64_t>(idx),
+          static_cast<int64_t>(numel_));
+      CUDA_KERNEL_ASSERT(idx < numel_);
+    }
+
+    return this->data_[idx];
+  }
+
+  C10_HOST inline auto transpose(const index_t dim1, const index_t dim2) const {
+    if constexpr (N > 1) {
+      this->bounds_check_(dim1);
+      this->bounds_check_(dim2);
+      auto result = PackedTensorAccessor<T, N, PtrTraits, index_t>(
+          this->data_, this->sizes_, this->strides_, name_, context_);
+      std::swap(result.strides_[dim1], result.strides_[dim2]);
+      std::swap(result.sizes_[dim1], result.sizes_[dim2]);
+      return result;
+
+    } else {
+      this->bounds_check_(dim1);
+      this->bounds_check_(dim2);
+      return PackedTensorAccessor<T, 1, PtrTraits, index_t>(
+          this->data_, this->sizes_, this->strides_, name_, context_);
+    }
+  }
+
+ protected:
+  size_t numel_;
+  char name_[NAME_MAX_LEN];
+  char context_[CONTEXT_MAX_LEN];
+
+  C10_HOST inline void bounds_check_(const index_t i) const {
+    TORCH_CHECK_INDEX(
+        0 <= i && i < index_t{N},
+        "[",
+        context_,
+        "][",
+        name_,
+        "]: ",
+        "Index ",
+        i,
+        " is not within bounds of a tensor of dimension ",
+        N);
+  }
 };
 
 } // namespace fbgemm_gpu::utils

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/tensor_accessor_builder.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/tensor_accessor_builder.h
@@ -66,6 +66,10 @@ struct TensorAccessorBuilder {
       N > 0,
       "Accessor is used for indexing tensor; for scalars use *data_ptr<T>() instead!");
 
+  static_assert(
+      index_nbits == 32 || index_nbits == 64,
+      "index_nbits must be 32 or 64!");
+
   //////////////////////////////////////////////////////////////////////////////
   // Attributes
   //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Summary: - This follows up on D72940055 to clean up FBGEMM_GPU's `PackedTensorAccessor` implementation.  The new version consolidates template class overload methods into the same class using modern langauge features to reduce maintenance burden.

Reviewed By: spcyppt

Differential Revision: D73016308


