### PR TITLE
Fix learning_rate_tensor to avoid in-place op and recompilation issues

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -2996,9 +2996,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         Helper function to script `set_learning_rate`.
         Note that returning None does not work.
         """
-        self.learning_rate_tensor = torch.tensor(
-            lr, device=torch.device("cpu"), dtype=torch.float32
-        )
+        self.learning_rate_tensor.fill_(lr)
         return 0.0
 
     @torch.jit.ignore


### PR DESCRIPTION
Summary:
TBE has a method to set learning rate, i.e., `set_learning_rate(lr)` where `lr` is the learning rate value to be set.

D71010630 removes `optimizer_args.learning_rate (float)` and introduces `self.learning_rate_tensor (tensor)` to avoid recompilation (see D65511904). Hence setting learning rate value means changing the value of the leanring_rate_tensor. We changed this by using `tensor._fill(lr)`.

This however breaks aps_models/examples/dlrm/tutorials:test_kernel_apf_dlrm_with_basic_training_demo, which potentially breaks `apf_dlrm` bento kernel with the error:

```
RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.FloatTensor []] is at version 2; expected version 1 instead. Hint: enable anomaly detection to find the operation that failed to compute its gradient, with torch.autograd.set_detect_anomaly(True).
```

The autograd has this error check because when a tensor is saved for backward during forward pass and is mutated later, this can cause correctness problem. This is because the forward compute and backward compute may see different data values for this tensor.

We then introduced the fix D72617537 by creating a new tensor which removes the in-place operation.

**This however causes recompilation issue**.

The workaround suggested by bdhirsh us to clone the learning rate tensor, and save this cloned tensor for backward in stead of using the `learning_rate_tensor` itself, which will be mutated later (through `set_learning_rate()`). The `learning_rate_tensor` is small and is always on CPU, so the clone should be cheap.

Microve confirmed this workaround fixes the recompilation issues.
https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-ig_v4_lr_recomp_fix_test_2-7db0169383?job_attempt=0&version=0&tab=summary&env=PRODUCTION

Reviewed By: sryap, Microve

Differential Revision: D72835395


