### PR TITLE
Include NONE in bounds_check_mode validation

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -717,6 +717,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             BoundsCheckMode.IGNORE,
             BoundsCheckMode.WARNING,
             BoundsCheckMode.FATAL,
+            BoundsCheckMode.NONE,
         ):
             raise NotImplementedError(
                 f"SplitTableBatchedEmbeddingBagsCodegen bounds_check_mode={bounds_check_mode} is not supported"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1075

D73163694 introduces a bug when using `BoundsCheckMode.NONE`.
This diff adds `BoundsCheckMode.NONE` when validating the input
`bounds_check_mode`

Reviewed By: q10, spcyppt

Differential Revision: D73283929


