### PR TITLE
Add Gather/Scatter related benchmark.

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/bench/gather_scatter_bench.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/gather_scatter_bench.py
@@ -1,0 +1,149 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+
+import torch
+import triton  # noqa: F401
+from fbgemm_gpu.experimental.gen_ai.moe import (
+    gather_along_first_dim,
+    gather_scale_dense_tokens,
+    scatter_add_along_first_dim,
+)
+from triton.testing import do_bench
+
+
+def bench_gather_along_first_dim(M: int, N: int, K: int) -> None:
+    src = torch.randn([M, K], device="cuda", dtype=torch.bfloat16).abs()
+    if M == N:
+        indices = torch.randperm(N, device="cuda", dtype=torch.int32)
+    else:
+        indices = torch.randint(0, M, [N], device="cuda", dtype=torch.int32)
+
+    def fn():
+        return gather_along_first_dim(src, indices)
+
+    def ref_fn():
+        return torch.index_select(src, 0, indices)
+
+    # Load src, store dst. x2.
+    data_size_in_gigabytes = N * K * 2 * 2 / 1e9
+
+    time_in_us = triton.testing.do_bench(fn) * 1e3
+    time_in_second = time_in_us / 1e6
+    gigabytes_per_second = data_size_in_gigabytes / time_in_second
+
+    ref_time_in_us = triton.testing.do_bench(ref_fn) * 1e3
+    ref_time_in_second = ref_time_in_us / 1e6
+    ref_gigabytes_per_second = data_size_in_gigabytes / ref_time_in_second
+
+    print(
+        f"Benchmark gather_along_first_dim: {M=:5d}, {N=:5d}, {K=:5d}, "
+        f"FBGEMM time: {time_in_us:10.3f} us. Bandwidth: {gigabytes_per_second:10.3f} GB/s, "
+        f"Torch time: {ref_time_in_us:10.3f} us. Bandwidth: {ref_gigabytes_per_second:10.3f} GB/s"
+    )
+
+
+def bench_scatter_add_along_first_dim(M: int, N: int, K: int) -> None:
+    src = torch.randn([M, K], device="cuda", dtype=torch.bfloat16).abs()
+    dst = torch.randn([N, K], device="cuda", dtype=torch.bfloat16).abs()
+    if M == N:
+        indices_1d = torch.randperm(N, device="cuda", dtype=torch.int64)
+    else:
+        indices_1d = torch.randint(0, N, [M], device="cuda", dtype=torch.int64)
+
+    indices_2d = indices_1d.to(torch.int64).unsqueeze(1).expand(-1, K)
+
+    test_dst = dst.clone()
+    ref_dst = dst.clone()
+
+    def fn():
+        scatter_add_along_first_dim(test_dst, src, indices_1d)
+
+    def ref_fn():
+        ref_dst.scatter_add_(0, indices_2d, src)
+
+    # Load src, load dst, store dst. x3.
+    data_size_in_gigabytes = N * K * 2 * 3 / 1e9
+
+    time_in_us = triton.testing.do_bench(fn) * 1e3
+    time_in_second = time_in_us / 1e6
+    gigabytes_per_second = data_size_in_gigabytes / time_in_second
+
+    ref_time_in_us = triton.testing.do_bench(ref_fn) * 1e3
+    ref_time_in_second = ref_time_in_us / 1e6
+    ref_gigabytes_per_second = data_size_in_gigabytes / ref_time_in_second
+
+    print(
+        f"Benchmark scatter_add_along_first_dim: {M=:5d}, {N=:5d}, {K=:5d}, "
+        f"FBGEMM time: {time_in_us:10.3f} us. Bandwidth: {gigabytes_per_second:10.3f} GB/s, "
+        f"Torch time: {ref_time_in_us:10.3f} us. Bandwidth: {ref_gigabytes_per_second:10.3f} GB/s"
+    )
+
+
+def bench_gather_scale_dense_tokens(E: int, T: int, D: int):
+    x = torch.randn((T, D), dtype=torch.bfloat16, device="cuda").abs()
+    expert_indices = torch.randint(0, E, (T,), device="cuda")
+    token_indices = torch.randperm(T, device="cuda")
+    scores = torch.rand((E, T), dtype=torch.bfloat16, device="cuda")
+
+    def torch_fn():
+        shuffled_x = torch.index_select(x, dim=0, index=token_indices)
+        shuffled_scores = torch.index_select(scores, dim=1, index=token_indices)
+        shuffled_selected_scores = torch.gather(
+            shuffled_scores, dim=0, index=expert_indices.view(1, T)
+        )
+        ref_output = shuffled_x * shuffled_selected_scores.view(-1, 1)
+        return ref_output
+
+    torch_output = torch_fn()
+
+    scores_TE = scores.transpose(0, 1).contiguous()
+
+    def triton_fn():
+        test_output = gather_scale_dense_tokens(
+            x, token_indices, expert_indices, scores_TE
+        )
+        return test_output
+
+    test_output = triton_fn()
+
+    torch.testing.assert_close(torch_output, test_output)
+
+    # Run benchmark
+    data_size_in_gigabytes = T * D * 2 * 2 / 1e9
+
+    fbgemm_time = do_bench(triton_fn, rep=1000) * 1e3
+    fbgemm_bw = data_size_in_gigabytes / (fbgemm_time / 1e6)
+
+    torch_time = do_bench(torch_fn, rep=1000) * 1e3
+    torch_bw = data_size_in_gigabytes / (torch_time / 1e6)
+    print(
+        f"Benchmark gather_scale_dense_tokens, {E=:3d}, {T=:5d}, {D=:5d}, "
+        f"FBGEMM time: {fbgemm_time:10.3f} us. Bandwidth: {fbgemm_bw:10.3f} GB/s, "
+        f"Torch time: {torch_time:10.3f} us. Bandwidth: {torch_bw:10.3f} GB/s"
+    )
+
+
+def main():
+    Es = [16, 128]
+    Ts = [1, 128, 2048, 4096, 8192, 16384]
+    Ds = [5120]
+
+    for E, T, D in itertools.product(Es, Ts, Ds):
+        bench_gather_scale_dense_tokens(E, T, D)
+
+    if gather_along_first_dim is not None:
+        for T, D in itertools.product(Ts, Ds):
+            bench_gather_along_first_dim(T, T, D)
+
+    if scatter_add_along_first_dim is not None:
+        for T, D in itertools.product(Ts, Ds):
+            bench_scatter_add_along_first_dim(T, T, D)
+
+
+if __name__ == "__main__":
+    main()

--- a/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
@@ -756,7 +756,7 @@ class BF16TritonStackedGroupedGemm(QuantizeOpBase):
         return x, w, m_sizes
 
     def compute(self, x, w, m_sizes):
-        return grouped_gemm(x, w, m_sizes)
+        return grouped_gemm(x, w, m_sizes, _use_warp_specialization=True)
 
     def quantize_and_compute(self, x, w, m_sizes):
         x, w, m_sizes = self.quantize(x, w, m_sizes)
@@ -802,7 +802,9 @@ class FP8TritonStackedGroupedGemm(QuantizeOpBase):
         return xq, wq, x_scale, w_scale, m_sizes
 
     def compute(self, xq, wq, x_scale, w_scale, m_sizes):
-        return grouped_gemm_fp8_rowwise(xq, wq, m_sizes, x_scale, w_scale)
+        return grouped_gemm_fp8_rowwise(
+            xq, wq, m_sizes, x_scale, w_scale, _use_warp_specialization=True
+        )
 
     def quantize_and_compute(self, x, wq, w_scale, m_sizes):
         xq, wq, x_scale, w_scale, m_sizes = self.quantize(x, wq, w_scale, m_sizes)

--- a/fbgemm_gpu/experimental/gen_ai/test/gather_scatter/gather_scatter_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/gather_scatter/gather_scatter_test.py
@@ -53,24 +53,6 @@ class GatherScatterTests(unittest.TestCase):
 
             self.assertTrue((dst == ref_dst).all().item())
 
-            # Load src, store dst. x2.
-            data_size_in_terabytes = N * K * 2 * 2 / 1e12
-
-            time_in_us = triton.testing.do_bench(fn) * 1e3
-            time_in_second = time_in_us / 1e6
-            terabytes_per_second = data_size_in_terabytes / time_in_second
-
-            ref_time_in_us = triton.testing.do_bench(ref_fn) * 1e3
-            ref_time_in_second = ref_time_in_us / 1e6
-            ref_terabytes_per_second = data_size_in_terabytes / ref_time_in_second
-
-            logger.info(
-                f"FBGEMM time: {time_in_us:.2f} us. Bandwidth: {terabytes_per_second:.2f} TB/s"
-            )
-            logger.info(
-                f"PyTorch time: {ref_time_in_us:.2f} us. Bandwidth: {ref_terabytes_per_second:.2f} TB/s"
-            )
-
         _test_gather_along_first_dim(127, 257, 1023)
         _test_gather_along_first_dim(127, 257, 1024)
         _test_gather_along_first_dim(255, 129, 2049)
@@ -83,6 +65,7 @@ class GatherScatterTests(unittest.TestCase):
         _test_gather_along_first_dim(2048, 2048, 5120)
         _test_gather_along_first_dim(4096, 4096, 5120)
         _test_gather_along_first_dim(8192, 8192, 5120)
+        _test_gather_along_first_dim(16384, 16384, 5120)
 
     def test_scatter_add_along_first_dim(self) -> None:
         def _test_scatter_add_along_first_dim(
@@ -109,33 +92,6 @@ class GatherScatterTests(unittest.TestCase):
 
             torch.testing.assert_close(test_dst, ref_dst, atol=1e-3, rtol=2.1e-2)
 
-            def fn():
-                op = torch.ops.fbgemm.scatter_add_along_first_dim
-                if compile:
-                    op = torch.compile(op, backend="inductor", fullgraph=True)
-                op(test_dst, src, indices_1d)
-
-            def ref_fn():
-                ref_dst.scatter_add_(0, indices_2d, src)
-
-            # Load src, load dst, store dst. x3.
-            data_size_in_terabytes = N * K * 2 * 3 / 1e12
-
-            time_in_us = triton.testing.do_bench(fn) * 1e3
-            time_in_second = time_in_us / 1e6
-            terabytes_per_second = data_size_in_terabytes / time_in_second
-
-            ref_time_in_us = triton.testing.do_bench(ref_fn) * 1e3
-            ref_time_in_second = ref_time_in_us / 1e6
-            ref_terabytes_per_second = data_size_in_terabytes / ref_time_in_second
-
-            logger.info(
-                f"FBGEMM time: {time_in_us:.2f} us. Bandwidth: {terabytes_per_second:.2f} TB/s"
-            )
-            logger.info(
-                f"PyTorch time: {ref_time_in_us:.2f} us. Bandwidth: {ref_terabytes_per_second:.2f} TB/s"
-            )
-
         _test_scatter_add_along_first_dim(127, 257, 1023)
         _test_scatter_add_along_first_dim(127, 257, 1024)
         _test_scatter_add_along_first_dim(255, 129, 2049)
@@ -148,6 +104,7 @@ class GatherScatterTests(unittest.TestCase):
         _test_scatter_add_along_first_dim(2048, 2048, 5120)
         _test_scatter_add_along_first_dim(4096, 4096, 5120)
         _test_scatter_add_along_first_dim(8192, 8192, 5120)
+        _test_scatter_add_along_first_dim(16384, 16384, 5120)
 
         _test_scatter_add_along_first_dim(0, 10, 5120)
 


### PR DESCRIPTION
Summary:
Benchmark to check if effective BW of gather/scatter related ops.

On H100 80GB SMX5 HBM3 700W SKUs, the peak memory bandwidth achieved:
- gather_scale_dense_tokens: 2771.442 GB/s
- gather_along_first_dim: 2646.431 GB/s
- scatter_add_along_first_dim: 2535.945 GB/s

Differential Revision: D73316972
