### PR TITLE
[FBGEMM][PR] [fbgemm_gpu] Enable ROCm builds for GenAI, pt 2

### DIFF
--- a/cmake/modules/CxxCompilerSetup.cmake
+++ b/cmake/modules/CxxCompilerSetup.cmake
@@ -62,7 +62,7 @@ add_link_options($<$<CONFIG:RELEASE>:-s>)
 
 # Set flags for AVX2
 set(AVX2_FLAGS "-mavx2;-mf16c;-mfma;-fopenmp")
-if(NOT FBGEMM_CPU_ONLY AND WSL_MODE)
+if(NOT FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_CPU AND WSL_MODE)
   # NVCC in WSL complains about unknown -mavx options
   # https://github.com/pytorch/FBGEMM/issues/2135
   set(AVX2_FLAGS "-Xcompiler;-mavx;-Xcompiler;-mavx2;-Xcompiler;-mf16c;-Xcompiler;-mfma;-fopenmp")
@@ -70,6 +70,18 @@ endif()
 
 # Set flags for AVX512
 set(AVX512_FLAGS "-mavx2;-mf16c;-mfma;-mavx512f;-mavx512bw;-mavx512dq;-mavx512vl;-fopenmp")
-if(NOT FBGEMM_CPU_ONLY AND WSL_MODE)
+if(NOT FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_CPU AND WSL_MODE)
   set(AVX512_FLAGS "-Xcompiler;-mavx2;-Xcompiler;-mf16c;-Xcompiler;-mfma;-Xcompiler;-mavx512f;-Xcompiler;-mavx512bw;-Xcompiler;-mavx512dq;-Xcompiler;-mavx512vl;-fopenmp")
 endif()
+
+BLOCK_PRINT(
+  "AVX2_FLAGS:"
+  ""
+  "${AVX2_FLAGS}"
+)
+
+BLOCK_PRINT(
+  "AVX512_FLAGS:"
+  ""
+  "${AVX512_FLAGS}"
+)

--- a/cmake/modules/GpuCppLibrary.cmake
+++ b/cmake/modules/GpuCppLibrary.cmake
@@ -85,7 +85,7 @@ function(prepare_target_sources)
         )
 
         # Append CUDA-specific sources, but ONLY when building in CUDA mode
-        if(NOT USE_ROCM)
+        if(NOT FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM)
             list(APPEND ${args_PREFIX}_sources_cu ${args_CUDA_SPECIFIC_SRCS})
         endif()
 
@@ -209,7 +209,7 @@ function(gpu_cpp_library)
     # Set the build target name
     set(lib_name ${args_PREFIX})
 
-    if(USE_ROCM)
+    if(FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM)
         if(lib_sources)
             # Fetch the equivalent HIPified sources if available.  The mapping
             # is provided by a table that is generated during transpilation

--- a/cmake/modules/GpuCppLibrary.cmake
+++ b/cmake/modules/GpuCppLibrary.cmake
@@ -45,7 +45,7 @@ function(prepare_target_sources)
     set(${args_PREFIX}_sources_cpp ${cpu_sources_cpp})
 
     # For GPU mode, add the CXX sources from GPU_SRCS
-    if(NOT FBGEMM_CPU_ONLY)
+    if(NOT FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_CPU)
         LIST_FILTER(
             INPUT ${args_GPU_SRCS}
             OUTPUT gpu_sources_cpp
@@ -76,7 +76,7 @@ function(prepare_target_sources)
     # Collect, Annotate, and Append CU sources
     ############################################################################
 
-    if(NOT FBGEMM_CPU_ONLY)
+    if(NOT FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_CPU)
         # Filter GPU_SRCS for CU sources - these may be HIPified later if building in ROCm mode
         LIST_FILTER(
             INPUT ${args_GPU_SRCS}
@@ -106,7 +106,7 @@ function(prepare_target_sources)
     # Collect, Annotate, and Append HIP sources
     ############################################################################
 
-    if(NOT FBGEMM_CPU_ONLY AND USE_ROCM)
+    if(FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM)
         # Filter GPU_SRCS for HIP sources
         LIST_FILTER(
             INPUT ${args_GPU_SRCS}

--- a/cmake/modules/RocmSetup.cmake
+++ b/cmake/modules/RocmSetup.cmake
@@ -11,7 +11,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/modules/Utilities.cmake)
 # ROCm and HIPify Setup
 ################################################################################
 
-if(USE_ROCM)
+if(FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM)
   # Load CMake modules
   list(APPEND CMAKE_MODULE_PATH
     "${PROJECT_SOURCE_DIR}/cmake"

--- a/cmake/modules/Utilities.cmake
+++ b/cmake/modules/Utilities.cmake
@@ -67,7 +67,7 @@ macro(handle_genfiles variable)
 endmacro()
 
 macro(handle_genfiles_rocm variable)
-  if(USE_ROCM)
+  if(FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM)
     handle_genfiles(${variable})
   endif()
 endmacro()

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -45,7 +45,6 @@ set(BUILD_VARIANT_ROCM "rocm")
 set(BUILD_VARIANT_VALUES
   "${BUILD_VARIANT_CPU};${BUILD_VARIANT_CUDA};${BUILD_VARIANT_ROCM}")
 
-option(FBGEMM_CPU_ONLY   "Build FBGEMM_GPU without GPU support" OFF)
 option(USE_ROCM          "Build FBGEMM_GPU for ROCm" OFF)
 
 if (DEFINED FBGEMM_BUILD_VARIANT)
@@ -57,12 +56,7 @@ if (DEFINED FBGEMM_BUILD_VARIANT)
   endif()
 
 else()
-  # Else fall back to looking at FBGEMM_CPU_ONLY and filesystem paths to see if
-  # the build variant should be set to CPU, CUDA. or ROCM (legacy)
-  if(FBGEMM_CPU_ONLY)
-    set(FBGEMM_BUILD_VARIANT "${BUILD_VARIANT_CPU}")
-
-  elseif(((EXISTS "/opt/rocm/") OR (EXISTS $ENV{ROCM_PATH})) AND
+  if(((EXISTS "/opt/rocm/") OR (EXISTS $ENV{ROCM_PATH})) AND
     (NOT EXISTS "/bin/nvcc"))
     message(
       "CMake has been set to build a non-CPU variant"
@@ -86,7 +80,8 @@ endif()
 # FBGEMM_GPU Build Kickstart
 ################################################################################
 
-# FBGEMM_GPU C++ Setup - must be set BEFORE project declaration
+# FBGEMM_GPU C++ Setup - must be set AFTER FBGEMM_BUILD_VARIANT declaration but
+# BEFORE project declaration
 include(${CMAKEMODULES}/CxxCompilerSetup.cmake)
 
 if(SKBUILD)

--- a/fbgemm_gpu/CMakeLists.txt
+++ b/fbgemm_gpu/CMakeLists.txt
@@ -23,9 +23,9 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 # Set Build Target
 ################################################################################
 
-set(BUILD_TARGET_DEFAULT "default")
-set(BUILD_TARGET_GENAI "genai")
-set(BUILD_TARGET_VALUES "${BUILD_TARGET_DEFAULT};${BUILD_TARGET_GENAI}")
+set(BUILD_TARGET_DEFAULT  "default")
+set(BUILD_TARGET_GENAI    "genai")
+set(BUILD_TARGET_VALUES   "${BUILD_TARGET_DEFAULT};${BUILD_TARGET_GENAI}")
 
 if(NOT DEFINED FBGEMM_BUILD_TARGET)
   set(FBGEMM_BUILD_TARGET "${BUILD_TARGET_DEFAULT}")
@@ -39,13 +39,11 @@ endif()
 # Set Build Variant
 ################################################################################
 
-set(BUILD_VARIANT_CPU "cpu")
-set(BUILD_VARIANT_CUDA "cuda")
-set(BUILD_VARIANT_ROCM "rocm")
+set(BUILD_VARIANT_CPU     "cpu")
+set(BUILD_VARIANT_CUDA    "cuda")
+set(BUILD_VARIANT_ROCM    "rocm")
 set(BUILD_VARIANT_VALUES
   "${BUILD_VARIANT_CPU};${BUILD_VARIANT_CUDA};${BUILD_VARIANT_ROCM}")
-
-option(USE_ROCM          "Build FBGEMM_GPU for ROCm" OFF)
 
 if (DEFINED FBGEMM_BUILD_VARIANT)
   # If FBGEMM_BUILD_VARIANT is set, validate it
@@ -55,25 +53,16 @@ if (DEFINED FBGEMM_BUILD_VARIANT)
       Allowed values: ${BUILD_VARIANT_VALUES}")
   endif()
 
+elseif(((EXISTS "/opt/rocm/") OR (EXISTS $ENV{ROCM_PATH})) AND
+  (NOT EXISTS "/bin/nvcc"))
+  message(
+    "AMD GPU has been detected; will default to ROCm build"
+  )
+  set(FBGEMM_BUILD_VARIANT "${BUILD_VARIANT_ROCM}")
+
 else()
-  if(((EXISTS "/opt/rocm/") OR (EXISTS $ENV{ROCM_PATH})) AND
-    (NOT EXISTS "/bin/nvcc"))
-    message(
-      "CMake has been set to build a non-CPU variant"
-      "and AMD GPU has been detected; "
-      "will default to ROCm build"
-    )
-    set(FBGEMM_BUILD_VARIANT "${BUILD_VARIANT_ROCM}")
+  set(FBGEMM_BUILD_VARIANT "${BUILD_VARIANT_CUDA}")
 
-    # Set USE_ROCM (legacy)
-    # NOTE: Should be removed once other CMake scripts have migrated over to
-    # FBGEMM_BUILD_VARIANT
-    set(USE_ROCM ON)
-
-  else()
-    set(FBGEMM_BUILD_VARIANT "${BUILD_VARIANT_CUDA}")
-
-  endif()
 endif()
 
 ################################################################################
@@ -175,7 +164,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Fbgemm.cmake)
 set(CMAKE_CODEGEN_DIR ${CMAKE_CURRENT_SOURCE_DIR}/codegen)
 
 macro(RUN_GEN_SCRIPT SCRIPT)
-  if(USE_ROCM)
+  if(FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM)
     set(rocm_flag --is_rocm)
   endif()
 
@@ -202,7 +191,7 @@ endforeach()
 # HIP Code Generation
 ################################################################################
 
-if(USE_ROCM)
+if(FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM)
   set(include_dirs_for_hipification
     # All directories need to be included for headers to be properly HIPified
     ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/fbgemm_gpu/FbgemmGpu.cmake
+++ b/fbgemm_gpu/FbgemmGpu.cmake
@@ -54,7 +54,7 @@ if(NOT FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_CPU)
     src/metric_ops/metric_ops_host.cpp
     src/input_combine_ops/input_combine_gpu.cpp)
 
-  if(NVML_LIB_PATH OR USE_ROCM)
+  if(NVML_LIB_PATH OR FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM)
     message(STATUS "Adding merge_pooled_embeddings sources")
     list(APPEND fbgemm_gpu_sources_cpu_static
       src/merge_pooled_embedding_ops/merge_pooled_embedding_ops_gpu.cpp

--- a/fbgemm_gpu/FbgemmGpu.cmake
+++ b/fbgemm_gpu/FbgemmGpu.cmake
@@ -43,7 +43,7 @@ set(fbgemm_gpu_sources_cpu_static
     src/sparse_ops/sparse_ops_meta.cpp
     ${tbe_eeg_cpu_sources})
 
-if(NOT FBGEMM_CPU_ONLY)
+if(NOT FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_CPU)
   list(APPEND fbgemm_gpu_sources_cpu_static
     src/intraining_embedding_pruning_ops/intraining_embedding_pruning_gpu.cpp
     src/layout_transform_ops/layout_transform_ops_gpu.cpp
@@ -64,7 +64,7 @@ if(NOT FBGEMM_CPU_ONLY)
   endif()
 endif()
 
-if(NOT FBGEMM_CPU_ONLY)
+if(NOT FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_CPU)
   set(fbgemm_gpu_sources_gpu_static
       src/histogram_binning_calibration_ops.cu
       src/input_combine_ops/input_combine.cu

--- a/fbgemm_gpu/cmake/Fbgemm.cmake
+++ b/fbgemm_gpu/cmake/Fbgemm.cmake
@@ -43,7 +43,7 @@ if(CXX_AVX2_FOUND)
     ${fbgemm_sources}
     ${fbgemm_sources_avx2})
 endif()
-if(NOT USE_ROCM AND CXX_AVX512_FOUND)
+if((NOT FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM) AND CXX_AVX512_FOUND)
   set(fbgemm_sources
     ${fbgemm_sources}
     ${fbgemm_sources_avx2}

--- a/fbgemm_gpu/cmake/Hip.cmake
+++ b/fbgemm_gpu/cmake/Hip.cmake
@@ -35,6 +35,7 @@ endif()
 message("Building FBGEMM for GPU arch: ${PYTORCH_ROCM_ARCH}")
 
 ADD_DEFINITIONS(-DNDEBUG)
+# USE_ROCM flag is used inside FBGEMM_GPU C++ code
 ADD_DEFINITIONS(-DUSE_ROCM)
 
 # Add HIP to the CMAKE Module Path

--- a/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
@@ -62,12 +62,11 @@ file(GLOB_RECURSE experimental_gen_ai_cpp_source_files_hip
   src/quantize/ck_extensions/*.hip
   src/quantize/ck_extensions/**/*.hip)
 
-# Python sources
-file(GLOB_RECURSE experimental_gen_ai_python_source_files
-  bench/*.py
-  bench/**/*.py
-  gen_ai/*.py
-  gen_ai/**/*.py)
+# # Python sources
+# file(GLOB_RECURSE experimental_gen_ai_python_source_files
+#   bench/*.py
+#   gen_ai/*.py
+#   gen_ai/moe/*.py)
 
 
 ################################################################################
@@ -98,8 +97,16 @@ gpu_cpp_library(
 
 add_to_package(
   DESTINATION fbgemm_gpu/experimental/gen_ai
-  TARGETS fbgemm_gpu_experimental_gen_ai
-  FILES ${experimental_gen_ai_python_source_files})
+  TARGETS fbgemm_gpu_experimental_gen_ai)
+  # FILES ${experimental_gen_ai_python_source_files})
+
+install(
+  DIRECTORY bench
+  DESTINATION fbgemm_gpu/experimental)
+
+install(
+  DIRECTORY gen_ai
+  DESTINATION fbgemm_gpu/experimental)
 
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/fb/gen_ai)
   install(

--- a/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
@@ -20,14 +20,16 @@ if(FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_CUDA)
     src/coalesce/*.cpp
     src/comm/*.cpp
     src/gather_scatter/*.cpp
-    src/kv_cache/*.cpp)
+    src/kv_cache/*.cpp
+    src/moe/*.cpp)
 
   file(GLOB tmp_list_gpu
     src/attention/*.cu
     src/coalesce/*.cu
     src/comm/*.cu
     src/gather_scatter/*.cu
-    src/kv_cache/*.cu)
+    src/kv_cache/*.cu
+    src/moe/*.cu)
 
   list(APPEND experimental_gen_ai_cpp_source_files_cpu ${tmp_list_cpu})
   list(APPEND experimental_gen_ai_cpp_source_files_gpu ${tmp_list_gpu})
@@ -36,11 +38,9 @@ endif()
 # Set the source file for FB only CPP
 if(USE_FB_ONLY AND (FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_CUDA))
   file(GLOB fb_only_sources_cpu
-      fb/src/moe/*.cpp
       fb/src/trt_llm/*.cpp)
 
   file(GLOB fb_only_sources_gpu
-      fb/src/moe/*.cu
       fb/src/trt_llm/*.cu)
 
   list(APPEND experimental_gen_ai_cpp_source_files_cpu ${fb_only_sources_cpu})
@@ -61,12 +61,6 @@ file(GLOB_RECURSE experimental_gen_ai_cpp_source_files_hip
   src/gemm/ck_extensions.hip
   src/quantize/ck_extensions/*.hip
   src/quantize/ck_extensions/**/*.hip)
-
-# # Python sources
-# file(GLOB_RECURSE experimental_gen_ai_python_source_files
-#   bench/*.py
-#   gen_ai/*.py
-#   gen_ai/moe/*.py)
 
 
 ################################################################################
@@ -98,7 +92,6 @@ gpu_cpp_library(
 add_to_package(
   DESTINATION fbgemm_gpu/experimental/gen_ai
   TARGETS fbgemm_gpu_experimental_gen_ai)
-  # FILES ${experimental_gen_ai_python_source_files})
 
 install(
   DIRECTORY bench

--- a/fbgemm_gpu/experimental/gen_ai/gen_ai/moe/__init__.py
+++ b/fbgemm_gpu/experimental/gen_ai/gen_ai/moe/__init__.py
@@ -24,10 +24,16 @@ except Exception:
 # pyre-ignore[16]
 if open_source:
     torch.ops.load_library(
-        os.path.join(os.path.dirname(__file__), "fbgemm_gpu_experimental_gen_ai.so")
+        os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "fbgemm_gpu_experimental_gen_ai.so",
+        )
     )
     torch.classes.load_library(
-        os.path.join(os.path.dirname(__file__), "fbgemm_gpu_experimental_gen_ai.so")
+        os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "fbgemm_gpu_experimental_gen_ai.so",
+        )
     )
 else:
     torch.ops.load_library(

--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -287,8 +287,12 @@ class FbgemmGpuBuild:
             #
             #   https://github.com/pytorch/FBGEMM/pull/3477
             #   https://github.com/pytorch/FBGEMM/pull/3717
-            print("[SETUP.PY] Building the CPU-ONLY variant of FBGEMM_GPU ...")
+            print("[SETUP.PY] Building the CPU ...")
             cmake_args.append("-DFBGEMM_BUILD_VARIANT=cpu")
+
+        if self.args.package_variant == "rocm":
+            print("[SETUP.PY] Building the ROCm variant ...")
+            cmake_args.append("-DFBGEMM_BUILD_VARIANT=rocm")
 
         if self.args.package_variant == "genai":
             print("[SETUP.PY] Building the GENAI-ONLY variant of FBGEMM_GPU ...")

--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -288,7 +288,7 @@ class FbgemmGpuBuild:
             #   https://github.com/pytorch/FBGEMM/pull/3477
             #   https://github.com/pytorch/FBGEMM/pull/3717
             print("[SETUP.PY] Building the CPU-ONLY variant of FBGEMM_GPU ...")
-            cmake_args.append("-DFBGEMM_CPU_ONLY=ON")
+            cmake_args.append("-DFBGEMM_BUILD_VARIANT=cpu")
 
         if self.args.package_variant == "genai":
             print("[SETUP.PY] Building the GENAI-ONLY variant of FBGEMM_GPU ...")


### PR DESCRIPTION
- Migrate CMake away from `FBGEMM_CPU_ONLY` and `USE_ROCM` flags in favor of `FBGEMM_BUILD_VARIANT`
- Fix import issue with `fbgemm_gpu.experimental.gen_ai.moe`

This follows the work in https://github.com/pytorch/FBGEMM/pull/3910 / D73196494.