### PR TITLE
[fbgemm_gpu] Disable MoE tests in OSS

### DIFF
--- a/fbgemm_gpu/experimental/gemm/test/grouped_gemm_test.py
+++ b/fbgemm_gpu/experimental/gemm/test/grouped_gemm_test.py
@@ -13,7 +13,15 @@ from typing import Tuple
 
 import torch
 
-if torch.cuda.is_available():
+try:
+    # pyre-ignore[21]
+    # @manual=//deeplearning/fbgemm/fbgemm_gpu:test_utils
+    from fbgemm_gpu import open_source
+except Exception:
+    open_source: bool = False
+
+
+if not open_source and torch.cuda.is_available():
     from fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm import quantize_fp8_row
     from fbgemm_gpu.experimental.gemm.triton_gemm.grouped_gemm import (
         grouped_gemm,
@@ -21,6 +29,10 @@ if torch.cuda.is_available():
     )
 
 
+@unittest.skipIf(
+    open_source,
+    "TypeError: __init__() got an unexpected keyword argument 'num_consumer_groups'",
+)
 @unittest.skipIf(
     not torch.cuda.is_available(),
     "Skip when CUDA is not available",

--- a/fbgemm_gpu/experimental/gen_ai/test/moe/__init__.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/moe/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict

--- a/fbgemm_gpu/experimental/gen_ai/test/moe/gather_scatter_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/moe/gather_scatter_test.py
@@ -15,6 +15,7 @@ import torch
 import triton  # noqa: F401
 from fbgemm_gpu.experimental.gen_ai.moe import (
     gather_scale_dense_tokens,
+    open_source,
     scatter_add_padded_tokens,
 )
 from hypothesis import given, settings, strategies as st, Verbosity
@@ -29,6 +30,7 @@ _BENCHMARK_IN_TEST: bool = os.environ.get("BENCHMARK_IN_TEST", "0") == "1"
 _MAX_SAMPLES: int = 100
 
 
+@unittest.skipIf(open_source, "Tests currently fail in open source")
 @unittest.skipIf(
     not torch.cuda.is_available()
     or (torch.version.hip is None and torch.version.cuda < "12.4"),

--- a/fbgemm_gpu/experimental/gen_ai/test/moe/shuffling_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/moe/shuffling_test.py
@@ -19,6 +19,7 @@ import triton  # noqa: F401
 from fbgemm_gpu.experimental.gen_ai.moe import (
     combine_shuffling,
     index_shuffling,
+    open_source,
     split_shuffling,
 )
 from hypothesis import given, settings, strategies as st, Verbosity
@@ -36,6 +37,7 @@ _BENCHMARK_IN_TEST: bool = os.environ.get("BENCHMARK_IN_TEST", "0") == "1"
 _MAX_SAMPLES: int = 100
 
 
+@unittest.skipIf(open_source, "Tests currently fail in open source")
 @unittest.skipIf(
     not torch.cuda.is_available(),
     "Skip when no GPU is available.",


### PR DESCRIPTION
- Add __init__.py to fix import issue

- Disable tests in gather_scatter_test.py bc it seems to fail in OSS: P1791972136.  One of the tests can pass, but it would require commenting out 2 parameters in grouped_gemm.py (bc the test seems to complain about them being non-existent: P1791972647), which is not acceptable.

- Disable tests in shuffling_test.py bc it seems to hang in OSS