### PR TITLE
Add kernel to initialize shared memory for testing

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/cumem_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/cumem_utils.h
@@ -195,4 +195,20 @@ void uvm_mem_advice_dont_fork(const Tensor& self);
 /// @return A new CPU tensor containing the data copied from the UVM tensor
 Tensor uvm_to_cpu_clone(const Tensor& self);
 
+/// @ingroup cumem-utils
+///
+/// Copy a tensors contents to shared memory. This can be useful for forcing
+/// the initialization state of gpu memory, which is relevant for testing.
+///
+/// @param self The input tensor
+void copy_to_shared(const Tensor& self);
+
+/// @ingroup cumem-utils
+///
+/// Copy nan values into a gpu's shared memory. This is useful for debugging or
+/// testing.
+///
+/// @param self The input tensor
+void initialize_nan_shared_mem(int64_t device_index);
+
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/memory_utils/common.cuh
+++ b/fbgemm_gpu/src/memory_utils/common.cuh
@@ -11,6 +11,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <cuda_runtime.h>
 #include <sys/mman.h>
 #include <unistd.h>
 #include <cstring>

--- a/fbgemm_gpu/src/memory_utils/memory_utils_ops.cu
+++ b/fbgemm_gpu/src/memory_utils/memory_utils_ops.cu
@@ -36,11 +36,17 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def("uvm_to_cpu(Tensor t) -> Tensor", TORCH_FN(uvm_to_cpu));
 
   m.def(FBGEMM_GPU_ENUM_OP(uvm, fbgemm_gpu_uvm_enum_query));
+  m.def("copy_to_shared(Tensor t) -> ()", TORCH_FN(copy_to_shared));
+  m.def(
+      "initialize_nan_shared_mem(int device_index) -> ()",
+      TORCH_FN(initialize_nan_shared_mem));
 
   DISPATCH_TO_CUDA("new_managed_tensor", new_managed_tensor);
   DISPATCH_TO_CUDA("new_host_mapped_tensor", new_host_mapped_tensor);
   DISPATCH_TO_CUDA("new_unified_tensor", new_unified_tensor);
   DISPATCH_TO_CUDA("new_vanilla_managed_tensor", new_vanilla_managed_tensor);
+  DISPATCH_TO_CUDA("copy_to_shared", copy_to_shared);
+  DISPATCH_TO_CUDA("initialize_nan_shared_mem", initialize_nan_shared_mem);
 }
 
 } // namespace fbgemm_gpu


### PR DESCRIPTION
Summary: This diff adds a few helper functions for initializing a GPU's shared memory. This can be useful for correctness tests. For example, setting the shared memory to NaN may help capture behavior where uninitialized memory is used.

Differential Revision: D73292641


