### PR TITLE
add batched support

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/quantize_utils.py
+++ b/fbgemm_gpu/fbgemm_gpu/quantize_utils.py
@@ -8,7 +8,7 @@
 # pyre-strict
 
 import logging
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 import torch
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1090

Add batched support for fp8fp8_oss_fast_gemv.

"TODO": to split and consolidate into two kernel for supporting both (B, M, N, K) and (M, N, K) cases.

Partial result for B = 2, 32 to get a ballpark estimate for perf difference (potentially can test more) on a few llama4 FFN and ATTN layer shapes:

Benchmarking B=2, M=1, N=4096, K=5120.
Average metrics over 1 iterations:
fp8fp8_oss_fast_gemv sim: 57.000.
fp8fp8_oss_fast_gemv ms: 0.031.
fp8fp8_oss_fast_gemv TFLOPS: 2.746.
fp8fp8_oss_fast_gemv GB/s: 1373.688.
Average metrics over 1 iterations:
cutlass_rowwise_batched sim: 7.000.
cutlass_rowwise_batched ms: 0.034.
cutlass_rowwise_batched TFLOPS: 2.457.
cutlass_rowwise_batched GB/s: 1229.242.

Benchmarking B=32, M=1, N=4096, K=5120.
Average metrics over 1 iterations:
fp8fp8_oss_fast_gemv sim: 115.000.
fp8fp8_oss_fast_gemv ms: 0.306.
fp8fp8_oss_fast_gemv TFLOPS: 4.383.
fp8fp8_oss_fast_gemv GB/s: 2192.709.
Average metrics over 1 iterations:
cutlass_rowwise_batched sim: 7.281.
cutlass_rowwise_batched ms: 0.329.
cutlass_rowwise_batched TFLOPS: 4.076.
cutlass_rowwise_batched GB/s: 2039.095.

Benchmarking B=32, M=1, N=5120, K=640.
Average metrics over 1 iterations:
fp8fp8_oss_fast_gemv sim: 31.625.
fp8fp8_oss_fast_gemv ms: 0.069.
fp8fp8_oss_fast_gemv TFLOPS: 3.051.
fp8fp8_oss_fast_gemv GB/s: 1530.593.
Average metrics over 1 iterations:
cutlass_rowwise_batched sim: 0.891.
cutlass_rowwise_batched ms: 0.072.
cutlass_rowwise_batched TFLOPS: 2.929.
cutlass_rowwise_batched GB/s: 1469.297.

...

Differential Revision: D73376584


