### PR TITLE
Fix weighted TBE inference NaN (un-init) row_weights

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
@@ -102,7 +102,7 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
   const uint32_t uint4_loads_per_row = div_round_up(D_bytes, sizeof(uint4));
 
   // Index of packed bag during load stage in current warp/wave. Should fit into NumUint4LoadsPerRow (3rd) shared
-  // memory buffer's dimension w.r.t. the actual size of the row in the bag. 
+  // memory buffer's dimension w.r.t. the actual size of the row in the bag.
   const uint32_t packed_bag_load_idx = PackedMode ? (threadIdx.x % NumUint4LoadsPerRow) / uint4_loads_per_row : 0;
   constexpr int32_t kUintsInUint4 = 4;
   const int32_t uints_per_row = kUintsInUint4 * uint4_loads_per_row;
@@ -212,20 +212,17 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
             buffers[warp_idx][i][input_row_idx][row_load_idx] = data;
           }
           {% if weighted %}
-          {%- if is_rocm %}
-          if (valid && row_load_idx == 0)  {
+          if (row_load_idx == 0)  {
             // Use only one thread to load the index weight to prevent a race
             // condition when writing to the shared memory
-            buffers_indice_weights[warp_idx][i][input_row_idx][packed_bag_load_idx] = indice_weights[indices_starts[i] + L_start + input_row_idx];
+            buffers_indice_weights[warp_idx][i][input_row_idx][packed_bag_load_idx] =
+              valid ? indice_weights[indices_starts[i] + L_start + input_row_idx] : 0.0;
           }
-          {%- else %}
-          buffers_indice_weights[warp_idx][i][input_row_idx][packed_bag_load_idx] = valid ? indice_weights[indices_starts[i] + L_start + input_row_idx] : 0.0;
-          {%- endif %}
           {% endif %}
         }
       }
       {%- endif %}
-      
+
       {%- if is_rocm %}
       if constexpr (OutputRowsPerThread % kRowUnroll)
       {
@@ -249,21 +246,18 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
           row = reinterpret_cast<const uint4*>(&weights[0]);
         }
         if constexpr (PackedMode) {
-          // Load valid packed row data w.r.t. packed_bag offset 
+          // Load valid packed row data w.r.t. packed_bag offset
           cp_async_zfill_cg<sizeof(uint4)>(&buffers[warp_idx][i][input_row_idx][row_load_idx + uint4_loads_per_row * packed_bag_load_idx], &row[row_load_idx], valid);
         } else {
           cp_async_zfill_cg<sizeof(uint4)>(&buffers[warp_idx][i][input_row_idx][row_load_idx], &row[row_load_idx], valid);
         }
         {% if weighted %}
-        {%- if is_rocm %}
-        if (valid && row_load_idx == 0) {
+        if (row_load_idx == 0) {
           // Use only one thread to load the index weight to prevent a race
           // condition when writing to the shared memory
-          buffers_indice_weights[warp_idx][i][input_row_idx][packed_bag_load_idx] = indice_weights[indices_starts[i] + L_start + input_row_idx];
+          buffers_indice_weights[warp_idx][i][input_row_idx][packed_bag_load_idx] =
+            valid ? indice_weights[indices_starts[i] + L_start + input_row_idx] : 0.0;
         }
-        {%- else %}
-        buffers_indice_weights[warp_idx][i][input_row_idx][packed_bag_load_idx] = valid ? indice_weights[indices_starts[i] + L_start + input_row_idx] : 0.0;
-        {%- endif %}
         {% endif %}
       }
       {%- if is_rocm %}
@@ -286,7 +280,7 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
         Ls[i] = shfl_sync(Ls[i], packed_bag_acc_idx * uint4_loads_per_row);
       }
     }
-    
+
     for (uint32_t input_row_idx = 0; input_row_idx < input_rows_in_flight; ++input_row_idx) {
       #pragma unroll OutputRowsPerThread
       for (uint32_t i = 0; i < OutputRowsPerThread; ++i) {
@@ -389,8 +383,8 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
         auto output_d = kWarpSize * j * kOutputsPerThread + threadIdx.x * kOutputsPerThread - D_padding;
         if constexpr (PackedMode) {
           // Offset global output_d index with the size of outputs per bag w.r.t. current
-          // packed bag index 
-          output_d -= packed_bag_store_idx * kOutputsPerThread * uints_per_row; 
+          // packed bag index
+          output_d -= packed_bag_store_idx * kOutputsPerThread * uints_per_row;
         }
         accumulators[i][j].mul(inv_L);
 

--- a/fbgemm_gpu/include/fbgemm_gpu/cumem_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/cumem_utils.h
@@ -195,4 +195,20 @@ void uvm_mem_advice_dont_fork(const Tensor& self);
 /// @return A new CPU tensor containing the data copied from the UVM tensor
 Tensor uvm_to_cpu_clone(const Tensor& self);
 
+/// @ingroup cumem-utils
+///
+/// Copy a tensors contents to shared memory. This can be useful for forcing
+/// the initialization state of gpu memory, which is relevant for testing.
+///
+/// @param self The input tensor
+void copy_to_shared(const Tensor& self);
+
+/// @ingroup cumem-utils
+///
+/// Copy nan values into a gpu's shared memory. This is useful for debugging or
+/// testing.
+///
+/// @param self The input tensor
+void initialize_nan_shared_mem(int64_t device_index);
+
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/memory_utils/common.cuh
+++ b/fbgemm_gpu/src/memory_utils/common.cuh
@@ -11,6 +11,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <cuda_runtime.h>
 #include <sys/mman.h>
 #include <unistd.h>
 #include <cstring>

--- a/fbgemm_gpu/src/memory_utils/memory_utils_ops.cu
+++ b/fbgemm_gpu/src/memory_utils/memory_utils_ops.cu
@@ -36,11 +36,17 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def("uvm_to_cpu(Tensor t) -> Tensor", TORCH_FN(uvm_to_cpu));
 
   m.def(FBGEMM_GPU_ENUM_OP(uvm, fbgemm_gpu_uvm_enum_query));
+  m.def("copy_to_shared(Tensor t) -> ()", TORCH_FN(copy_to_shared));
+  m.def(
+      "initialize_nan_shared_mem(int device_index) -> ()",
+      TORCH_FN(initialize_nan_shared_mem));
 
   DISPATCH_TO_CUDA("new_managed_tensor", new_managed_tensor);
   DISPATCH_TO_CUDA("new_host_mapped_tensor", new_host_mapped_tensor);
   DISPATCH_TO_CUDA("new_unified_tensor", new_unified_tensor);
   DISPATCH_TO_CUDA("new_vanilla_managed_tensor", new_vanilla_managed_tensor);
+  DISPATCH_TO_CUDA("copy_to_shared", copy_to_shared);
+  DISPATCH_TO_CUDA("initialize_nan_shared_mem", initialize_nan_shared_mem);
 }
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/test/tbe/inference/failures_dict_fast.json
+++ b/fbgemm_gpu/test/tbe/inference/failures_dict_fast.json
@@ -12,6 +12,7 @@
     "fbgemm::HFP8QuantizedToFloat": {},
     "fbgemm::asynchronous_complete_cumsum": {},
     "fbgemm::bounds_check_indices": {},
+    "fbgemm::check_feature_gate_key": {},
     "fbgemm::dense_embedding_codegen_lookup_function": {
       "BackwardDenseTest.test_autograd_registration__test_backward_dense": {
         "comment": "",
@@ -30,12 +31,14 @@
       }
     },
     "fbgemm::emb_inplace_update": {},
+    "fbgemm::get_infos_metadata": {},
     "fbgemm::get_unique_indices": {
       "LXUCacheTest.test_faketensor__test_unique_lxu_cache_lookup": {
         "comment": "",
         "status": "xfail"
       }
     },
+    "fbgemm::initialize_nan_shared_mem": {},
     "fbgemm::int_nbit_split_embedding_codegen_lookup_function": {
       "NBitForwardTest.test_faketensor__test_nbit_forward_fused_pooled_emb_quant": {
         "comment": "",
@@ -306,6 +309,7 @@
     "fbgemm::split_embedding_codegen_lookup_rowwise_adagrad_function_cpu": {},
     "fbgemm::split_embedding_codegen_lookup_rowwise_weighted_adagrad_function": {},
     "fbgemm::split_embedding_codegen_lookup_sgd_function": {},
-    "fbgemm::split_embedding_codegen_lookup_sgd_function_cpu": {}
+    "fbgemm::split_embedding_codegen_lookup_sgd_function_cpu": {},
+    "fbgemm::split_embedding_codegen_lookup_sgd_function_pt2": {}
   }
 }

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -115,6 +115,9 @@ additional_decorators: Dict[str, List[Callable]] = {
             "Operator outputs int4 tensors which do not support opcheck tests"
         ),
     ],
+    "test_faketensor__test_nbit_forward_fused_pooled_emb_quant_nan_weighted": [
+        unittest.skip("Operator not implemented for fake tensors"),
+    ],
 }
 
 
@@ -353,6 +356,92 @@ class NBitFowardTest(NBitFowardTestCommon):
             ref_module=SplitTableBatchedEmbeddingBagsCodegen,
             **kwargs,
         )
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_nbit_forward_fused_pooled_emb_quant_nan_weighted(self) -> None:
+        # Hash size
+        E = 10
+        # Embedding dimensoin
+        D = 160
+        # Pooling factor
+        L = 64
+
+        # Use TBE training op as a reference
+        op_ref = SplitTableBatchedEmbeddingBagsCodegen(
+            [
+                (E, D, EmbeddingLocation.DEVICE, ComputeDevice.CUDA),
+            ],
+            weights_precision=SparseType.FP32,
+            output_dtype=SparseType.FP32,
+            device=torch.cuda.current_device(),
+        )
+
+        # Instantiate TBE inference
+        op = IntNBitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (
+                    "",
+                    E,
+                    D,
+                    SparseType.INT4,
+                    EmbeddingLocation.DEVICE,
+                ),
+            ],
+            output_dtype=SparseType.FP16,
+        )
+
+        # Initialize weights_ref with 1.0
+        weights_ref = op_ref.split_embedding_weights()
+        weights_ref[0].fill_(1.0)
+
+        # Copy weights_ref to weights
+        op.initialize_weights()
+        weights = op.split_embedding_weights()
+        quant_weights, quant_scale_shift = quantize_embs(
+            weights_ref[0], SparseType.INT4
+        )
+        weights[0][0].copy_(quant_weights)
+        weights[0][1].copy_(quant_scale_shift)
+
+        # Generate inputs
+        indices = torch.as_tensor(
+            [0] * L, device=torch.cuda.current_device(), dtype=torch.int
+        )
+        offsets = torch.as_tensor(
+            [0, L], device=torch.cuda.current_device(), dtype=torch.int
+        )
+        per_sample_weights = torch.arange(
+            L, device=torch.cuda.current_device(), dtype=torch.float
+        )
+
+        # Set a bunch of indices to -1 to simulate pruning.
+        pruned_indices = indices.clone().detach()
+        prune_select = torch.arange(pruned_indices.numel()) % 8 == 0
+        pruned_indices[prune_select] = -1
+
+        # Pre-prune per_sample_weights for reference
+        pruned_per_sample_weights = per_sample_weights.clone().detach()
+        pruned_per_sample_weights[prune_select] = 0.0
+
+        # Run reference
+        output_ref = op_ref(
+            indices=indices,
+            offsets=offsets,
+            per_sample_weights=pruned_per_sample_weights,
+        )
+
+        # Initialize shared memory to NaNs.
+        torch.ops.fbgemm.initialize_nan_shared_mem(torch.cuda.current_device())
+
+        # Run test
+        output = op(
+            indices=pruned_indices,
+            offsets=offsets,
+            per_sample_weights=per_sample_weights,
+        )
+
+        # Expect the outputs to be bit-wise equivalent
+        assert torch.equal(output_ref, output)
 
     @unittest.skipIf(*gpu_unavailable)
     @given(


### PR DESCRIPTION
Summary:
This diff fixes the problem introduced by D70855331 that the
`per_sample_weights` in the TBE inference kernels were not properly
initialized and became NaNs, causing the embedding lookup output to
contain NaNs.

Differential Revision: D73387999
