### PR TITLE
Fixes and enhancements to FBGEMM_LAUNCH_KERNEL

### DIFF
--- a/fbgemm_gpu/test/utils/kernel_launcher_test.cu
+++ b/fbgemm_gpu/test/utils/kernel_launcher_test.cu
@@ -296,8 +296,8 @@ TEST(KernelLauncherTest, kernel_launch_checks) {
             tensor_sum_kernel<float>,
             8,
             1024,
-            // shared memory size is too large
-            properties.sharedMemPerBlock + 1,
+            // Requested shared memory size is too large
+            properties.sharedMemPerBlockOptin + 1,
             at::cuda::getCurrentCUDAStream(),
             PTA_B(C, float, 1, 64),
             PTA_B(A, float, 1, 64),


### PR DESCRIPTION
Summary:
- Fix a constexpr issue with FBGEMM_LAUNCH_KERNEL macro

- Check shared memory allocation against `sharedMemPerBlockOptin` instead of `sharedMemPerBlock`(error was caught in a test as a detailed and formatted string)
 {F1977345209}

- Support barrier isolation in debug mode

Differential Revision: D73450460


