### PR TITLE
cache quantization

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.cpp
@@ -39,7 +39,8 @@ at::Tensor nope_qkv_varseq_prefill(
     std::optional<at::Tensor> varseq_cache_seqpos,
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> qparam_v,
-    bool k_norm);
+    bool k_norm,
+    std::optional<at::Tensor> amax_qkv);
 
 at::Tensor nope_qkv_decoding(
     at::Tensor XQ,
@@ -55,7 +56,8 @@ at::Tensor nope_qkv_decoding(
     std::optional<at::Tensor> cache_seqpos,
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> qparam_v,
-    bool k_norm);
+    bool k_norm,
+    std::optional<at::Tensor> amax_qkv);
 
 at::Tensor rope_qkv_varseq_prefill(
     at::Tensor XQ,
@@ -79,7 +81,8 @@ at::Tensor rope_qkv_varseq_prefill(
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> qparam_v,
     bool write_k_back,
-    bool k_norm);
+    bool k_norm,
+    std::optional<at::Tensor> amax_qkv);
 
 at::Tensor rope_qkv_decoding(
     at::Tensor XQ,
@@ -103,7 +106,8 @@ at::Tensor rope_qkv_decoding(
     double hi_freq_factor,
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> qparam_v,
-    bool k_norm);
+    bool k_norm,
+    std::optional<at::Tensor> amax_qkv);
 
 at::Tensor xpos_qkv_varseq_prefill(
     at::Tensor XQ,
@@ -171,6 +175,19 @@ std::tuple<at::Tensor, at::Tensor> dequantize_fp8_cache(
     std::optional<at::Tensor> block_tables,
     int64_t page_size);
 
+at::Tensor quantize_qkv_per_head(
+    at::Tensor amax,
+    at::Tensor XQKV,
+    at::Tensor varseq_seqpos,
+    std::optional<at::Tensor> varseq_batch,
+    at::Tensor q_seqstarts,
+    at::Tensor cache_K,
+    at::Tensor cache_V,
+    at::Tensor XQ_O,
+    int64_t max_seq_len,
+    std::optional<at::Tensor> qparam_k,
+    std::optional<at::Tensor> qparam_v);
+
 at::Tensor mqa_attn(
     at::Tensor XQ,
     at::Tensor cache_K,
@@ -183,13 +200,13 @@ at::Tensor mqa_attn(
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def("rope_qkv_varseq_prefill(Tensor XQ, Tensor(a!) XK, Tensor XV, Tensor(b!) cache_K, Tensor(c!) cache_V,  Tensor varseq_batch, Tensor varseq_seqpos, float theta, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
       DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192"
-      ", float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32,  Tensor? qparam_k=None, Tensor? qparam_v=None, bool write_k_back=False, bool k_norm=False) -> Tensor");
+      ", float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32,  Tensor? qparam_k=None, Tensor? qparam_v=None, bool write_k_back=False, bool k_norm=False, Tensor?amax_qkv=None) -> Tensor");
   m.def("rope_qkv_decoding(Tensor XQ, Tensor XK, Tensor XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor seqpos, float theta, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
-      DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None,  int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192, float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False) -> Tensor");
+      DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None,  int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192, float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False, Tensor?amax_qkv=None) -> Tensor");
   m.def("nope_qkv_varseq_prefill(Tensor XQ, Tensor XK, Tensor XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor varseq_batch, Tensor varseq_seqpos, Tensor? block_tables=None, int page_size=" STRING(
-      DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False) -> Tensor");
+      DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False, Tensor?amax_qkv=None) -> Tensor");
   m.def("nope_qkv_decoding(Tensor XQ, Tensor XK, Tensor XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor seqpos, Tensor? block_tables=None, int page_size=" STRING(
-      DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False) -> Tensor");
+      DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False, Tensor?amax_qkv=None) -> Tensor");
   m.def("xpos_qkv_varseq_prefill(Tensor XQ, Tensor XK, Tensor XV, Tensor(a!) cache_K, Tensor(b!) cache_V, Tensor varseq_batch, Tensor varseq_seqpos, float theta, float gamma, float scale_base, float exponent_offset, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
       DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192, float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32,  Tensor? qparam_k=None, Tensor? qparam_v=None) -> Tensor");
   m.def("xpos_qkv_decoding(Tensor XQ, Tensor XK, Tensor XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor seqpos, float theta, float gamma, float scale_base, float exponent_offset, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
@@ -199,6 +216,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "dequantize_fp8_cache(Tensor cache_K, Tensor cache_V, Tensor kv_seqlen, Tensor? qparam_k=None, Tensor? qparam_v=None, Tensor? block_tables=None, int page_size=" STRING(
           DEFAULT_PAGE_SIZE) ") -> (Tensor, Tensor)");
+  m.def(
+      "quantize_qkv_per_head(Tensor amax, Tensor XQKV, Tensor varseq_seqpos, Tensor? varseq_batch, Tensor q_seqstarts, Tensor cache_K, Tensor cache_V, Tensor XQ_O, int max_seq_len, Tensor? qparam_k=None, Tensor? qparam_v=None) -> Tensor");
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
@@ -210,6 +229,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
   m.impl("xpos_qkv_decoding", xpos_qkv_decoding);
   m.impl("dequantize_int4_cache", dequantize_int4_cache);
   m.impl("dequantize_fp8_cache", dequantize_fp8_cache);
+  m.impl("quantize_qkv_per_head", quantize_qkv_per_head);
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
@@ -221,6 +241,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   m.impl("xpos_qkv_decoding", xpos_qkv_decoding);
   m.impl("dequantize_int4_cache", dequantize_int4_cache);
   m.impl("dequantize_fp8_cache", dequantize_fp8_cache);
+  m.impl("quantize_qkv_per_head", quantize_qkv_per_head);
 }
 
 at::Tensor rope_qkv_varseq_prefill_meta(
@@ -245,7 +266,8 @@ at::Tensor rope_qkv_varseq_prefill_meta(
     std::optional<at::Tensor> /* qparam_k */,
     std::optional<at::Tensor> /* qparam_v */,
     bool /* write_k_back */,
-    bool /* k_norm */
+    bool /* k_norm */,
+    std::optional<at::Tensor> /* amax_qkv */
 ) {
   return at::empty_like(XQ);
 }
@@ -272,7 +294,8 @@ at::Tensor rope_qkv_decoding_meta(
     double /* hi_freq_factor */,
     std::optional<at::Tensor> /* qparam_k */,
     std::optional<at::Tensor> /* qparam_v */,
-    bool /* k_norm */
+    bool /* k_norm */,
+    std::optional<at::Tensor> /* amax_qkv */
 ) {
   return at::empty_like(XQ);
 }
@@ -290,7 +313,8 @@ at::Tensor nope_qkv_varseq_prefill_meta(
     std::optional<at::Tensor> /* varseq_cache_seqpos */,
     std::optional<at::Tensor> /* qparam_k */,
     std::optional<at::Tensor> /* qparam_v */,
-    bool /* k_norm */
+    bool /* k_norm */,
+    std::optional<at::Tensor> /* amax_qkv */
 ) {
   return at::empty_like(XQ);
 }
@@ -309,7 +333,8 @@ at::Tensor nope_qkv_decoding_meta(
     std::optional<at::Tensor> /* cache_seqpos */,
     std::optional<at::Tensor> /* qparam_k */,
     std::optional<at::Tensor> /* qparam_v */,
-    bool /* k_norm */
+    bool /* k_norm */,
+    std::optional<at::Tensor> /* amax_qkv */
 ) {
   return at::empty_like(XQ);
 }
@@ -411,6 +436,24 @@ std::tuple<at::Tensor, at::Tensor> dequantize_fp8_cache_meta(
   return {cache_K_dq, cache_V_dq};
 }
 
+at::Tensor quantize_qkv_per_head_meta(
+    at::Tensor /* amax */,
+    at::Tensor XQKV,
+    at::Tensor /* varseq_seqpos */,
+    std::optional<at::Tensor> /* varseq_batch */,
+    at::Tensor /* q_seqstarts */,
+    at::Tensor cache_K /* cache_K */,
+    at::Tensor /* cache_V */,
+    at::Tensor /* XQ_O */,
+    int64_t /* max_seq_len */,
+    std::optional<at::Tensor> /* qparam_k */,
+    std::optional<at::Tensor> /* qparam_v */) {
+  const at::SymInt B_KV = cache_K.sym_size(0);
+  const at::SymInt N_KVH = cache_K.sym_size(2);
+  auto xq_scale =
+      at::empty_symint({B_KV, N_KVH}, cache_K.options().dtype(at::kFloat));
+  return at::empty_like(XQKV);
+}
 TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
   m.impl("rope_qkv_varseq_prefill", rope_qkv_varseq_prefill_meta);
   m.impl("rope_qkv_decoding", rope_qkv_decoding_meta);

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/vec_quant.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/vec_quant.cuh
@@ -162,7 +162,14 @@ DEVICE_INLINE float bfx4_dot(bfx4 a, bfx4 b) {
   // auto r = bf1622float2(acc);
   // return r.x + r.y;
 }
-
+DEVICE_INLINE fx4 fx4_abs(const fx4& src) {
+  fx4 result;
+  result.x = fabsf(src.x);
+  result.y = fabsf(src.y);
+  result.z = fabsf(src.z);
+  result.w = fabsf(src.w);
+  return result;
+}
 DEVICE_INLINE fx4 bfx4_scale_acc(fx4 acc, bfx4 a, float b) {
   auto axy = bf1622float2(a.vals[0]);
   auto azw = bf1622float2(a.vals[1]);


### PR DESCRIPTION
Summary:
# Context
Enablement of FP8 attention involves FP8 QKV quantization, passing FP8 inputs and descales to FAv3.

Based on our study, FP8 quantization per kv head provides reasonable accuracy while maintaining performance gains in prefill TFLOPS and decode latency. 

TODO
Benchmarks to estimate performance gains.  For PD, num_generations = 4 and success rate = 0.5. The decode latency is improved for large batch sizes and sequence lengths. 
| Batch Size | Sequence Position | bf16 | fp8_KV | fp8_perhead+fp8attn | fp8 attn TTIT estimated difference(ms) 
| --- | --- | --- | --- | --- | --- | --- |
| 64 | 2048 | 41.43437743 | 89.68185633 | 35.24733707 | -0.1237408072 
|64|  4096 | 72.47199118 | 170.5418229 | 56.11991137 | -0.3270415962 
| 64|16384 | 252.3710728 | 521.9820738 | 182.0285916 | -1.406849623 
| 64| 32767 | 487.8227115 | 800.8700609 | 356.9591939 | -2.61727035

# This Diff
< Anything you want to highlight so reviewers pay extra attention >

# This Stack
1. **< This step >**
2. < Step 2 >
3. < Step 3 >

Differential Revision: D73386673


