### PR TITLE
Migrate make_pta_acc_format() away from old macros, v2]

### DIFF
--- a/fbgemm_gpu/codegen/genscript/jinja_environment.py
+++ b/fbgemm_gpu/codegen/genscript/jinja_environment.py
@@ -388,6 +388,30 @@ def make_pta_acc_format(pta_str_list: List[str], func_name: str) -> List[str]:
     return new_str_list
 
 
+def make_pta_acc_builder_format(pta_str_list: List[str]) -> List[str]:
+    new_str_list = []
+    for pta_str in pta_str_list:
+        if "packed_accessor" in pta_str:
+            match = re.search(
+                r"([a-zA-z0-9_]*)[.]packed_accessor([3|6][2|4])<(.*)>\(\)", pta_str
+            )
+            assert match is not None and len(match.groups()) == 3
+            tensor, acc_nbits, args = match.groups()
+            if "acc_type" in args:
+                match = re.search("at::acc_type<([a-zA-Z_0-9]*), true>", args)
+                assert match is not None and len(match.groups()) == 1
+                new_type = match.group(1)
+                args = re.sub("at::acc_type<[a-zA-Z_]*, true>", new_type, args)
+                macro_name = "PTA_ACC_B"
+            else:
+                macro_name = "PTA_B"
+            args = args.replace(", at::RestrictPtrTraits", "")
+            new_str_list.append(f"{macro_name}({tensor}, {args}, {acc_nbits})")
+        else:
+            new_str_list.append(pta_str)
+    return new_str_list
+
+
 def replace_pta_namespace(pta_str_list: List[str]) -> List[str]:
     return [
         pta_str.replace("at::PackedTensorAccessor", "pta::PackedTensorAccessor")
@@ -431,6 +455,7 @@ def to_upper_placeholder_types(arg_str_list: List[str]) -> List[str]:
 ################################################################################
 
 env.filters["make_pta_acc_format"] = make_pta_acc_format
+env.filters["make_pta_acc_builder_format"] = make_pta_acc_builder_format
 env.filters["replace_pta_namespace"] = replace_pta_namespace
 env.filters["replace_placeholder_types"] = replace_placeholder_types
 env.filters["to_upper_placeholder_types"] = to_upper_placeholder_types

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_template.cu
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_template.cu
@@ -9,6 +9,7 @@
 // clang-format off
 #include "fbgemm_gpu/embedding_backward_template_helpers.cuh"
 #include "fbgemm_gpu/utils/tensor_accessor_builder.h"
+#include "fbgemm_gpu/utils/kernel_launcher.cuh"
 
 using Tensor = at::Tensor;
 using namespace fbgemm_gpu;
@@ -172,9 +173,6 @@ void split_embedding_{{ optimizer }}_update(
 #else
                 constexpr int kThreadGroupSize = kWarpSize;
 #endif
-#ifdef FBGEMM_GPU_MEMCHECK
-                const auto func_name = "split_{{ optimizer }}_update_kernel";
-#endif
 
                 DISPATCH_PLACEHOLDER_TYPES(
                   {%- for ph_name in args.placeholder_tensor_names %}
@@ -182,38 +180,36 @@ void split_embedding_{{ optimizer }}_update(
                   {%- endfor %}
                   "split_embedding_{{ optimizer }}_update_placeholder_type_kernel",
                   [&] {
-                    split_{{ optimizer }}_update_kernel<
-                        emb_t,
-                        cache_t,
-                        {%- for ph_name in args.placeholder_tensor_names %}
-                        {{ ph_name + "_ph_t" }},
-                        {%- endfor %}
-                        kMaxVecsPerThread,
-                        kThreadGroupSize,
-                        4>
-                        <<<div_round_up(grad_dev_indices.numel(), kMaxThreads / kThreadGroupSize),
-                           dim3(kThreadGroupSize, kMaxThreads / kThreadGroupSize, 1),
-                           0, // Shared memory is not needed because uint8_t is not supported
-                           at::cuda::getCurrentCUDAStream()
-                        >>>
-                        (
-                            MAKE_PTA_WITH_NAME(func_name, dev_weights, emb_t, 1, 64),
-                            MAKE_PTA_WITH_NAME(func_name, uvm_weights, emb_t, 1, 64),
-                            MAKE_PTA_WITH_NAME(func_name, lxu_cache_weights, cache_t, 2, 64),
-                            MAKE_PTA_WITH_NAME(func_name, flatten_grad_dev_weights, emb_t, 1, 64),
-                            MAKE_PTA_WITH_NAME(func_name, flatten_grad_dev_indices, int64_t, 1, 64),
-                            MAKE_PTA_WITH_NAME(func_name, weights_placements, int32_t, 1, 32),
-                            MAKE_PTA_WITH_NAME(func_name, weights_offsets, int64_t, 1, 32),
-                            // Use weights_placements instead of
-                            // sorted_lxu_cache_locations because LXU cache is not
-                            // supported right now
-                            MAKE_PTA_WITH_NAME(func_name, weights_placements, int32_t, 1, 32),
-                            max_D,
-                            stochastic_rounding,
-                            rng_engine_inputs,
-                            {{ args.split_kernel_arg_constructors | make_pta_acc_format("func_name") | join(", ") }}
-                        );
-                    C10_CUDA_KERNEL_LAUNCH_CHECK();
+                    FBGEMM_LAUNCH_KERNEL(
+                        (split_{{ optimizer }}_update_kernel<
+                            emb_t,
+                            cache_t,
+                            {%- for ph_name in args.placeholder_tensor_names %}
+                            {{ ph_name + "_ph_t" }},
+                            {%- endfor %}
+                            kMaxVecsPerThread,
+                            kThreadGroupSize,
+                            4>),
+                        div_round_up(grad_dev_indices.numel(), kMaxThreads / kThreadGroupSize),
+                        dim3(kThreadGroupSize, kMaxThreads / kThreadGroupSize, 1),
+                        0, // Shared memory is not needed because uint8_t is not supported
+                        at::cuda::getCurrentCUDAStream(),
+                        PTA_B(dev_weights, emb_t, 1, 64),
+                        PTA_B(uvm_weights, emb_t, 1, 64),
+                        PTA_B(lxu_cache_weights, cache_t, 2, 64),
+                        PTA_B(flatten_grad_dev_weights, emb_t, 1, 64),
+                        PTA_B(flatten_grad_dev_indices, int64_t, 1, 64),
+                        PTA_B(weights_placements, int32_t, 1, 32),
+                        PTA_B(weights_offsets, int64_t, 1, 32),
+                        // Use weights_placements instead of
+                        // sorted_lxu_cache_locations because LXU cache is not
+                        // supported right now
+                        PTA_B(weights_placements, int32_t, 1, 32),
+                        max_D,
+                        stochastic_rounding,
+                        rng_engine_inputs,
+                        {{ args.split_kernel_arg_constructors | make_pta_acc_builder_format() | join(", ") }}
+                    );
                 }); // DISPATCH_PLACEHOLDER_TYPES
                 return;
             }

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
@@ -181,8 +181,8 @@ struct KernelLauncher {
       const cudaDeviceProp& properties,
       const size_t shared_mem_per_block) const {
     // NOTE: sharedMemPerBlockOptin is the maximum possible shared memory that
-    // can be used per block by explicit special opt-in, and is larger than
-    // sharedMemPerBlock.
+    // can be used per block by explicit special opt-in, and is generally larger
+    // than sharedMemPerBlock.
     const auto smem_limits = properties.sharedMemPerBlockOptin;
 
     TORCH_CHECK(


### PR DESCRIPTION
Summary:
- Migrate Jinja `make_pta_acc_format()` from the old `MAKE_PTA_WITH_NAME` and
  `MAKE_PTA_ACC_WITH_NAME` to  using `PTA_B` and `PTA_ACC_B`

Reviewed By: sryap

Differential Revision: D73417820


