### PR TITLE
Add keep_orig_idx_per_feature parameter to block_bucketize_sparse_features kernel

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -463,6 +463,7 @@ def block_bucketize_sparse_features_meta(
     block_bucketize_pos: Optional[torch.Tensor] = None,
     keep_orig_idx: bool = False,
     total_num_blocks: Optional[torch.Tensor] = None,
+    keep_orig_idx_per_feature: Optional[torch.Tensor] = None,
 ) -> Tuple[
     torch.Tensor,
     torch.Tensor,

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -192,7 +192,8 @@ block_bucketize_sparse_features_cuda(
     const int64_t max_batch_size,
     const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
     const bool keep_orig_idx,
-    const std::optional<at::Tensor>& total_num_blocks);
+    const std::optional<at::Tensor>& total_num_blocks,
+    const std::optional<at::Tensor>& keep_orig_idx_per_feature);
 
 std::tuple<
     at::Tensor,
@@ -214,7 +215,8 @@ block_bucketize_sparse_features_cpu(
     const int64_t max_batch_size,
     const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
     const bool keep_orig_idx,
-    const std::optional<at::Tensor>& total_num_blocks);
+    const std::optional<at::Tensor>& total_num_blocks,
+    const std::optional<at::Tensor>& keep_orig_idx_per_feature);
 
 std::tuple<
     at::Tensor,
@@ -237,7 +239,8 @@ block_bucketize_sparse_features_inference_cuda(
     const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
     const bool return_bucket_mapping,
     const bool keep_orig_idx,
-    const std::optional<at::Tensor>& total_num_blocks);
+    const std::optional<at::Tensor>& total_num_blocks,
+    const std::optional<at::Tensor>& keep_orig_idx_per_feature);
 
 ///@ingroup sparse-data-cuda
 at::Tensor populate_bucketized_permute_cuda(
@@ -267,7 +270,8 @@ block_bucketize_sparse_features_inference_cpu(
     const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
     const bool return_bucket_mapping,
     const bool keep_orig_idx,
-    const std::optional<at::Tensor>& total_num_blocks);
+    const std::optional<at::Tensor>& total_num_blocks,
+    const std::optional<at::Tensor>& keep_orig_idx_per_feature);
 
 ///@ingroup sparse-data-cpu
 at::Tensor populate_bucketized_permute_cpu(

--- a/fbgemm_gpu/test/sparse/block_bucketize_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_test.py
@@ -279,6 +279,203 @@ class BlockBucketizeTest(unittest.TestCase):
         use_cpu=st.booleans() if gpu_available else st.just(True),
         keep_orig_idx=st.booleans(),
         sequence=st.booleans(),
+        bucketize_pos=st.booleans(),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    def test_block_bucketize_sparse_features_keep_orig_idx_per_feature(
+        self,
+        long_indices: bool,
+        use_cpu: bool,
+        keep_orig_idx: bool,
+        sequence: bool,
+        bucketize_pos: bool,
+    ) -> None:
+        index_type = torch.long if long_indices else torch.int
+        # 3 GPUs
+        my_size = 3
+        block_sizes = torch.tensor([3, 4, 5], dtype=index_type)
+        keep_orig_idx_per_feature = None
+
+        if not long_indices:
+            # batch size 2, 3 features to 3 gpus
+            lengths = torch.tensor([0, 3, 2, 0, 1, 5], dtype=index_type)
+            indices = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0], dtype=index_type)
+
+            new_lengths_ref = torch.tensor(
+                [
+                    0,
+                    2,
+                    0,
+                    0,
+                    0,
+                    1,  # GPU 0, F0 = [0-3), F1 = [0-4), F2 = [0-5)
+                    0,
+                    1,
+                    2,
+                    0,
+                    1,
+                    3,  # GPU 1, F0 = [3-6), F1 = [4-8), F2 = [5-10)
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    1,  # GPU 2, F0 = [6-9), F1 = [8-12), F2 = [10-15)
+                ],
+                dtype=index_type,
+            )
+            if keep_orig_idx:
+                # override keep_orig_idx settings: f0 to keep original indices, and f1, f2 to bucketized indices
+                keep_orig_idx_per_feature = torch.tensor(
+                    [True, False, False], dtype=torch.bool
+                )
+
+                new_indices_ref = torch.tensor(
+                    [
+                        1,  # R0 F0 B1 keep original indices
+                        2,  # R0 F0 B1 keep original indices
+                        0,
+                        3,  # R1 F0 B1 keep original indices
+                        0,
+                        1,
+                        1,
+                        2,
+                        3,
+                        4,
+                        0,
+                    ],
+                    dtype=index_type,
+                )
+            else:
+                # override keep_orig_idx settings: f1 to keep original indices, and f0, f2 to bucketized indices
+                keep_orig_idx_per_feature = torch.tensor(
+                    [False, True, False], dtype=torch.bool
+                )
+                new_indices_ref = torch.tensor(
+                    [
+                        1,
+                        2,
+                        0,
+                        0,
+                        4,  # R1 F1 B0 keep original indices
+                        5,  # R1 F1 B0 keep original indices
+                        1,
+                        2,
+                        3,
+                        4,
+                        0,
+                    ],
+                    dtype=index_type,
+                )
+
+        else:
+            lengths = torch.tensor([0, 3, 2, 0, 1, 5], dtype=index_type)
+            # Test long and negative indices: -8 will be casted to 18446644015555759292
+            indices = torch.tensor(
+                [1, 2, 3, 100061827127359, 5, 6, 7, -8, 100058153792324, 10, 0],
+                dtype=index_type,
+            )
+            new_lengths_ref = torch.tensor(
+                [
+                    0,
+                    2,
+                    0,
+                    0,
+                    0,
+                    1,  # GPU 0, F0 = [0-3), F1 = [0-4), F2 = [0-5) + relevant outliers
+                    0,
+                    1,
+                    2,
+                    0,
+                    1,
+                    1,  # GPU 1, F0 = [3-6), F1 = [4-8), F2 = [5-10) + relevant outliers
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    3,  # GPU 2, F0 = [6-9), F1 = [8-12), F2 = [10-15) + relevant outliers
+                ],
+                dtype=index_type,
+            )
+
+            if keep_orig_idx:
+                # override keep_orig_idx settings: f2 to keep original indices, and f0, f1 to bucketized indices
+                keep_orig_idx_per_feature = torch.tensor(
+                    [False, False, True], dtype=torch.bool
+                )
+                new_indices_ref = torch.tensor(
+                    [
+                        1,
+                        2,
+                        0,  # F2 original indices
+                        0,
+                        33353942375786,  # bucketized indices: 100061827127359/3 = 33353942375786
+                        1,
+                        6,  # F2 original indices
+                        7,  # F2 original indices
+                        -8,  # F2 original indices
+                        100058153792324,  # F2 original indices
+                        10,  # F2 original indices
+                    ],
+                    dtype=index_type,
+                )
+
+            else:
+                # override keep_orig_idx settings: f0, f2 to keep original indices, and f1 to bucketized indices
+                keep_orig_idx_per_feature = torch.tensor(
+                    [True, False, True], dtype=torch.bool
+                )
+                new_indices_ref = torch.tensor(
+                    [
+                        1,  # F0 original indices
+                        2,  # F0 original indices
+                        0,
+                        3,  # F0 original indices
+                        33353942375786,  # 100061827127359/3 = 33353942375786
+                        1,
+                        6,  # F2 original indices
+                        7,  # F2 original indices
+                        -8,  # F2 original indices
+                        100058153792324,  # F2 original indices
+                        10,  # F2 original indices
+                    ],
+                    dtype=index_type,
+                )
+        (
+            new_lengths,
+            new_indices,
+            _,
+            _,
+            _,
+        ) = torch.ops.fbgemm.block_bucketize_sparse_features(
+            lengths.cuda() if not use_cpu else lengths,
+            indices.cuda() if not use_cpu else indices,
+            bucketize_pos,
+            sequence,
+            block_sizes.cuda() if not use_cpu else block_sizes,
+            my_size,
+            None,
+            keep_orig_idx=keep_orig_idx,
+            keep_orig_idx_per_feature=(
+                keep_orig_idx_per_feature.cuda()
+                if not use_cpu
+                else keep_orig_idx_per_feature
+            ),
+        )
+        torch.testing.assert_close(new_lengths.cpu(), new_lengths_ref)
+        torch.testing.assert_close(
+            new_indices.cpu(),
+            new_indices_ref,
+            msg=f"{new_indices.cpu()=} != {new_indices_ref=}",
+        )
+
+    @skipIfRocm(ROCM_FAILURE_MESSAGE)
+    @given(
+        long_indices=st.booleans(),
+        use_cpu=st.booleans() if gpu_available else st.just(True),
+        keep_orig_idx=st.booleans(),
+        sequence=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_total_num_blocks_uneven_raw_ids(

--- a/fbgemm_gpu/test/sparse/failures_dict.json
+++ b/fbgemm_gpu/test/sparse/failures_dict.json
@@ -21,6 +21,10 @@
         "comment": "",
         "status": "xfail"
       },
+      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_keep_orig_idx_per_feature": {
+        "comment": "",
+        "status": "xfail"
+      },
       "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_large": {
         "comment": "",
         "status": "xfail"
@@ -54,6 +58,10 @@
         "status": "xfail"
       },
       "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_keep_orig_idx_per_feature": {
         "comment": "",
         "status": "xfail"
       },


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1112

**Context**
Enhance block_bucketize_sparse_features and block_bucketize_sparse_features_inference kernels to support mixed-format embedding tables. 

Previously, the keep_orig_idx parameter was a boolean flag applied uniformly across all features, determining whether to retain the original index. With the introduction of [the Flexible Collision-Free Embedding Table](https://github.com/pytorch/torchrec/blob/main/rfc/RFC-0002-Flexible-Collision-Free-Embedding-Table.md), one embedding collection may include both collision-free and collision tables. This update allows the kernel to handle mixed formats by supporting feature-wise control over index retention. 

For collision-free tables, a large table size of 2^50 is set, maintaining parameters as id-value pairs and preserving the original global id. This change facilitates the use of mixed-style embedding tables effectively.

Spec:
- keep_orig_idx_per_feature is an optional parameter with per feature settings. 
- If the keep_orig_idx_per_feature is not None, the value will override global flag keep_orig_idx, no matter it's true for false.
- If keep_orig_idx_per_feature is None, fallback to keep_orig_idx control.

Note:
Adding additional parameter keep_orig_idx_per_feature, instead of change keep_orig_idx directly, is to avoid backward compatibility issue.

Differential Revision: D73606958


