### PR TITLE
Optimize kv cache usage for yoco

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.cpp
@@ -28,8 +28,8 @@ namespace fbgemm_gpu {
 
 at::Tensor nope_qkv_varseq_prefill(
     at::Tensor XQ,
-    at::Tensor XK,
-    at::Tensor XV,
+    std::optional<at::Tensor> XK,
+    std::optional<at::Tensor> XV,
     at::Tensor cache_K,
     at::Tensor cache_V,
     at::Tensor varseq_batch,
@@ -39,12 +39,13 @@ at::Tensor nope_qkv_varseq_prefill(
     std::optional<at::Tensor> varseq_cache_seqpos,
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> qparam_v,
-    bool k_norm);
+    bool k_norm,
+    bool update_kv);
 
 at::Tensor nope_qkv_decoding(
     at::Tensor XQ,
-    at::Tensor XK,
-    at::Tensor XV,
+    std::optional<at::Tensor> XK,
+    std::optional<at::Tensor> XV,
     at::Tensor cache_K,
     at::Tensor cache_V,
     at::Tensor seqpos,
@@ -55,12 +56,13 @@ at::Tensor nope_qkv_decoding(
     std::optional<at::Tensor> cache_seqpos,
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> qparam_v,
-    bool k_norm);
+    bool k_norm,
+    bool update_kv);
 
 at::Tensor rope_qkv_varseq_prefill(
     at::Tensor XQ,
-    at::Tensor XK,
-    at::Tensor XV,
+    std::optional<at::Tensor> XK,
+    std::optional<at::Tensor> XV,
     at::Tensor cache_K,
     at::Tensor cache_V,
     at::Tensor varseq_batch,
@@ -79,12 +81,13 @@ at::Tensor rope_qkv_varseq_prefill(
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> qparam_v,
     bool write_k_back,
-    bool k_norm);
+    bool k_norm,
+    bool update_kv);
 
 at::Tensor rope_qkv_decoding(
     at::Tensor XQ,
-    at::Tensor XK,
-    at::Tensor XV,
+    std::optional<at::Tensor> XK,
+    std::optional<at::Tensor> XV,
     at::Tensor cache_K,
     at::Tensor cache_V,
     at::Tensor seqpos,
@@ -103,7 +106,8 @@ at::Tensor rope_qkv_decoding(
     double hi_freq_factor,
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> qparam_v,
-    bool k_norm);
+    bool k_norm,
+    bool update_kv);
 
 at::Tensor xpos_qkv_varseq_prefill(
     at::Tensor XQ,
@@ -181,15 +185,15 @@ at::Tensor mqa_attn(
     int64_t cache_logical_dtype_int);
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
-  m.def("rope_qkv_varseq_prefill(Tensor XQ, Tensor(a!) XK, Tensor XV, Tensor(b!) cache_K, Tensor(c!) cache_V,  Tensor varseq_batch, Tensor varseq_seqpos, float theta, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
-      DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192"
-      ", float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32,  Tensor? qparam_k=None, Tensor? qparam_v=None, bool write_k_back=False, bool k_norm=False) -> Tensor");
-  m.def("rope_qkv_decoding(Tensor XQ, Tensor XK, Tensor XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor seqpos, float theta, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
-      DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None,  int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192, float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False) -> Tensor");
-  m.def("nope_qkv_varseq_prefill(Tensor XQ, Tensor XK, Tensor XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor varseq_batch, Tensor varseq_seqpos, Tensor? block_tables=None, int page_size=" STRING(
-      DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False) -> Tensor");
-  m.def("nope_qkv_decoding(Tensor XQ, Tensor XK, Tensor XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor seqpos, Tensor? block_tables=None, int page_size=" STRING(
-      DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False) -> Tensor");
+  m.def("rope_qkv_varseq_prefill(Tensor XQ, Tensor(a!)? XK, Tensor? XV, Tensor(b!) cache_K, Tensor(c!) cache_V,  Tensor varseq_batch, Tensor varseq_seqpos, float theta, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
+       DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192"
+       ", float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32,  Tensor? qparam_k=None, Tensor? qparam_v=None, bool write_k_back=False, bool k_norm=False, bool update_kv=True) -> Tensor");
+  m.def("rope_qkv_decoding(Tensor XQ, Tensor? XK, Tensor? XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor seqpos, float theta, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
+      DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None,  int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192, float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False, bool update_kv=True) -> Tensor");
+  m.def("nope_qkv_varseq_prefill(Tensor XQ, Tensor? XK, Tensor? XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor varseq_batch, Tensor varseq_seqpos, Tensor? block_tables=None, int page_size=" STRING(
+      DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False, bool update_kv=True) -> Tensor");
+  m.def("nope_qkv_decoding(Tensor XQ, Tensor? XK, Tensor? XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor seqpos, Tensor? block_tables=None, int page_size=" STRING(
+      DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False, bool update_kv=True) -> Tensor");
   m.def("xpos_qkv_varseq_prefill(Tensor XQ, Tensor XK, Tensor XV, Tensor(a!) cache_K, Tensor(b!) cache_V, Tensor varseq_batch, Tensor varseq_seqpos, float theta, float gamma, float scale_base, float exponent_offset, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
       DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192, float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32,  Tensor? qparam_k=None, Tensor? qparam_v=None) -> Tensor");
   m.def("xpos_qkv_decoding(Tensor XQ, Tensor XK, Tensor XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor seqpos, float theta, float gamma, float scale_base, float exponent_offset, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
@@ -225,8 +229,8 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
 
 at::Tensor rope_qkv_varseq_prefill_meta(
     at::Tensor XQ,
-    at::Tensor /* XK */,
-    at::Tensor /* XV */,
+    std::optional<at::Tensor> /* XK */,
+    std::optional<at::Tensor> /* XV */,
     at::Tensor /* cache_K */,
     at::Tensor /* cache_V */,
     at::Tensor /* varseq_batch */,
@@ -245,15 +249,16 @@ at::Tensor rope_qkv_varseq_prefill_meta(
     std::optional<at::Tensor> /* qparam_k */,
     std::optional<at::Tensor> /* qparam_v */,
     bool /* write_k_back */,
-    bool /* k_norm */
+    bool /* k_norm */,
+    bool /* update_kv */
 ) {
   return at::empty_like(XQ);
 }
 
 at::Tensor rope_qkv_decoding_meta(
     at::Tensor XQ,
-    at::Tensor /* XK */,
-    at::Tensor /* XV */,
+    std::optional<at::Tensor> /* XK */,
+    std::optional<at::Tensor> /* XV */,
     at::Tensor /* cache_K */,
     at::Tensor /* cache_V */,
     at::Tensor /* seqpos */,
@@ -272,15 +277,16 @@ at::Tensor rope_qkv_decoding_meta(
     double /* hi_freq_factor */,
     std::optional<at::Tensor> /* qparam_k */,
     std::optional<at::Tensor> /* qparam_v */,
-    bool /* k_norm */
+    bool /* k_norm */,
+    bool /* update_kv */
 ) {
   return at::empty_like(XQ);
 }
 
 at::Tensor nope_qkv_varseq_prefill_meta(
     at::Tensor XQ,
-    at::Tensor /* XK */,
-    at::Tensor /* XV */,
+    std::optional<at::Tensor> /* XK */,
+    std::optional<at::Tensor> /* XV */,
     at::Tensor /* cache_K */,
     at::Tensor /* cache_V */,
     at::Tensor /* varseq_batch */,
@@ -290,15 +296,16 @@ at::Tensor nope_qkv_varseq_prefill_meta(
     std::optional<at::Tensor> /* varseq_cache_seqpos */,
     std::optional<at::Tensor> /* qparam_k */,
     std::optional<at::Tensor> /* qparam_v */,
-    bool /* k_norm */
+    bool /* k_norm */,
+    bool /* update_kv */
 ) {
   return at::empty_like(XQ);
 }
 
 at::Tensor nope_qkv_decoding_meta(
     at::Tensor XQ,
-    at::Tensor /* XK */,
-    at::Tensor /* XV */,
+    std::optional<at::Tensor> /* XK */,
+    std::optional<at::Tensor> /* XV */,
     at::Tensor /* cache_K */,
     at::Tensor /* cache_V */,
     at::Tensor /* seqpos */,
@@ -309,7 +316,8 @@ at::Tensor nope_qkv_decoding_meta(
     std::optional<at::Tensor> /* cache_seqpos */,
     std::optional<at::Tensor> /* qparam_k */,
     std::optional<at::Tensor> /* qparam_v */,
-    bool /* k_norm */
+    bool /* k_norm */,
+    bool /* update_kv */
 ) {
   return at::empty_like(XQ);
 }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1114

This diff aims to remove redundant temporary tensors and KV caches when using yoco. This includes changes for allowing optional xk, xv for rope/nope kernels, adding flag for checking to update kv cache or not, etc.

Reviewed By: Aya-ZIbra

Differential Revision: D73570737


