### PR TITLE
cache quantization

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/vec_quant.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/vec_quant.cuh
@@ -167,7 +167,14 @@ DEVICE_INLINE float bfx4_dot(bfx4 a, bfx4 b) {
   // auto r = bf1622float2(acc);
   // return r.x + r.y;
 }
-
+DEVICE_INLINE fx4 fx4_abs(const fx4& src) {
+  fx4 result;
+  result.x = fabsf(src.x);
+  result.y = fabsf(src.y);
+  result.z = fabsf(src.z);
+  result.w = fabsf(src.w);
+  return result;
+}
 DEVICE_INLINE fx4 bfx4_scale_acc(fx4 acc, bfx4 a, float b) {
   auto axy = bf1622float2(a.vals[0]);
   auto azw = bf1622float2(a.vals[1]);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1115

# Context
Enablement of FP8 attention involves FP8 QKV quantization, passing FP8 inputs and descales to FAv3.

Based on our study, FP8 quantization per kv head provides reasonable accuracy while maintaining performance gains in prefill TFLOPS and decode latency. 

TODO
Benchmarks to estimate performance gains.  For PD, num_generations = 4 and success rate = 0.5. The decode latency is improved for large batch sizes and sequence lengths. 
| Batch Size | Sequence Position | bf16 | fp8_KV | fp8_perhead+fp8attn | fp8 attn TTIT estimated difference(ms) 
| --- | --- | --- | --- | --- | --- | --- |
| 64 | 2048 | 41.43437743 | 89.68185633 | 35.24733707 | -0.1237408072 
|64|  4096 | 72.47199118 | 170.5418229 | 56.11991137 | -0.3270415962 
| 64|16384 | 252.3710728 | 521.9820738 | 182.0285916 | -1.406849623 
| 64| 32767 | 487.8227115 | 800.8700609 | 356.9591939 | -2.61727035

# This Diff
Introduces a kernel to quantize per head. 

# This Stack
1. **< This step >**
2. < Step 2 >
3. < Step 3 >

Differential Revision: D73386673


