### PR TITLE
support zero collision tables in ssd operator

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -57,6 +57,12 @@ class KVZCHParams(NamedTuple):
     # the value indicates corresponding input space for each bucket id, e.g. 2^50 / total_num_buckets
     bucket_sizes: List[int] = []
 
+    def validate(self) -> None:
+        assert len(self.bucket_offsets) == len(self.bucket_sizes), (
+            "bucket_offsets and bucket_sizes must have the same length, "
+            f"actual {self.bucket_offsets} vs {self.bucket_sizes}"
+        )
+
 
 class BackendType(enum.IntEnum):
     SSD = 0

--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
@@ -659,7 +659,7 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
         )
 
         # Compare optimizer states
-        split_optimizer_states = [s for (s,) in emb.debug_split_optimizer_states()]
+        split_optimizer_states = [s for (s, _, _) in emb.debug_split_optimizer_states()]
         for f, t in self.get_physical_table_arg_indices_(emb.feature_table_map):
             # pyre-fixme[16]: Optional type has no attribute `float`.
             ref_optimizer_state = emb_ref[f].weight.grad.float().to_dense().pow(2)
@@ -801,11 +801,11 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
             else 1.0e-2
         )
 
-        split_optimizer_states = [s for (s,) in emb.debug_split_optimizer_states()]
+        split_optimizer_states = [s for (s, _, _) in emb.debug_split_optimizer_states()]
         emb.flush()
 
         # Compare emb state dict with expected values from nn.EmbeddingBag
-        emb_state_dict = emb.split_embedding_weights(no_snapshot=False)
+        emb_state_dict, _, _ = emb.split_embedding_weights(no_snapshot=False)
         for feature_index, table_index in self.get_physical_table_arg_indices_(
             emb.feature_table_map
         ):
@@ -886,7 +886,7 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
         )
 
         optimizer_states_ref = [
-            s.clone().float() for (s,) in emb.debug_split_optimizer_states()
+            s.clone().float() for (s, _, _) in emb.debug_split_optimizer_states()
         ]
 
         Es = [emb.embedding_specs[t][0] for t in range(T)]
@@ -1032,7 +1032,9 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 emb.flush()
 
             # Compare optimizer states
-            split_optimizer_states = [s for (s,) in emb.debug_split_optimizer_states()]
+            split_optimizer_states = [
+                s for (s, _, _) in emb.debug_split_optimizer_states()
+            ]
             for f, t in self.get_physical_table_arg_indices_(emb.feature_table_map):
                 optim_state_r = optimizer_states_ref[t]
                 optim_state_t = split_optimizer_states[t]


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/torchrec/pull/2919

change list
1. add bucket concept into ssd tbe
2. update split_embedding_weights to make it return a tuple of 3 tensors(weight, weight_id, id_cnt_per_bucket)
3. add new ut for the key value embedding cases

Differential Revision: D73274786
