### PR TITLE
Move ComputeDevice to split_table_batched_embeddings_ops_common

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -106,6 +106,12 @@ class BoundsCheckMode(enum.IntEnum):
     V2_FATAL = 6
 
 
+class ComputeDevice(enum.IntEnum):
+    CPU = 0
+    CUDA = 1
+    MTIA = 2
+
+
 class EmbeddingSpecInfo(enum.IntEnum):
     feature_names = 0
     rows = 1

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -37,6 +37,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
     BoundsCheckMode,
     CacheAlgorithm,
     CacheState,
+    ComputeDevice,
     construct_cache_state,
     EmbeddingLocation,
     MAX_PREFETCH_DEPTH,
@@ -78,12 +79,6 @@ INT8_EMB_ROW_DIM_OFFSET = 8
 
 class DoesNotHavePrefix(Exception):
     pass
-
-
-class ComputeDevice(enum.IntEnum):
-    CPU = 0
-    CUDA = 1
-    MTIA = 2
 
 
 class WeightDecayMode(enum.IntEnum):


### PR DESCRIPTION
Summary: - Moved `ComputeDevice` to `split_table_batched_embeddings_ops_common`

Differential Revision: D73608722


