### PR TITLE
torchrec support on kvzch emb lookup module

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -49,6 +49,24 @@ class EmbeddingLocation(enum.IntEnum):
             raise ValueError(f"Cannot parse value into EmbeddingLocation: {key}")
 
 
+class BackendType(enum.IntEnum):
+    SSD = 0
+    DRAM = 1
+    PS = 2
+
+    @classmethod
+    # pyre-ignore[3]
+    def from_str(cls, key: str):
+        lookup = {
+            "ssd": BackendType.SSD,
+            "dram": BackendType.DRAM,
+        }
+        if key in lookup:
+            return lookup[key]
+        else:
+            raise ValueError(f"Cannot parse value into BackendType: {key}")
+
+
 class CacheAlgorithm(enum.Enum):
     LRU = 0
     LFU = 1

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -267,7 +267,9 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             f"{cache_size / 1024.0 / 1024.0 / 1024.0 : .2f}GB, "
             f"weights precision: {weights_precision}, "
             f"output dtype: {output_dtype}, "
-            f"chunk size in bulk init: {bulk_init_chunk_size} bytes"
+            f"chunk size in bulk init: {bulk_init_chunk_size} bytes, "
+            f"bucket offsets: {bucket_offsets}, bucket_sizes: {bucket_sizes}, backend_type: {backend_type}, "
+            f"zero_collision_tbe: {zero_collision_tbe}"
         )
         self.register_buffer(
             "lxu_cache_state",
@@ -1761,8 +1763,12 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 bucket_id_start, bucket_id_end = self.bucket_offsets[t]
                 # pyre-ignore
                 bucket_size = self.bucket_sizes[t]
-                table_input_id_start = bucket_id_start * bucket_size + table_offset
-                table_input_id_end = bucket_id_end * bucket_size + table_offset
+                table_input_id_start = (
+                    min(bucket_id_start * bucket_size, row) + table_offset
+                )
+                table_input_id_end = (
+                    min(bucket_id_end * bucket_size, row) + table_offset
+                )
 
                 # TODO: this is a hack for preallocated optimizer, update this part once we have optimizer offloading
                 unlinearized_id_tensor = self._ssd_db.get_keys_in_range_by_snapshot(
@@ -1898,8 +1904,12 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 bucket_size = self.bucket_sizes[i]
 
                 # linearize with table offset
-                table_input_id_start = bucket_id_start * bucket_size + table_offset
-                table_input_id_end = bucket_id_end * bucket_size + table_offset
+                table_input_id_start = (
+                    min(bucket_id_start * bucket_size, emb_height) + table_offset
+                )
+                table_input_id_end = (
+                    min(bucket_id_end * bucket_size, emb_height) + table_offset
+                )
                 # 1. get all keys from backend for one table
                 unordered_id_tensor = self._ssd_db.get_keys_in_range_by_snapshot(
                     table_input_id_start,
@@ -1919,7 +1929,6 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 )
                 # pyre-ignore
                 bucket_sorted_id_splits.append(bucket_ascending_id_tensor)
-                # pyre-ignore
                 active_id_cnt_per_bucket_split.append(bucket_t)
 
             if virtual_local_rows:
@@ -1982,7 +1991,9 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
 
     def flush(self) -> None:
         if self.step == self.last_flush_step:
-            logging.info(f"SSD TBE has been flushed at {self.last_flush_step=} already")
+            logging.info(
+                f"SSD TBE has been flushed at {self.last_flush_step=} already for tbe:{self.tbe_unique_id}"
+            )
             return
         logging.info(
             f"SSD TBE flush at {self.step=}, it is an expensive call please be cautious"

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/utils/partially_materialized_tensor.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/utils/partially_materialized_tensor.py
@@ -33,7 +33,7 @@ class PartiallyMaterializedTensor:
     or use `full_tensor()` to get the full tensor (this could OOM).
     """
 
-    def __init__(self, wrapped) -> None:
+    def __init__(self, wrapped, is_virtual_size: bool = False) -> None:
         """
         Ensure caller loads the module before creating this object.
 
@@ -48,6 +48,7 @@ class PartiallyMaterializedTensor:
             wrapped: torch.classes.fbgemm.KVTensorWrapper
         """
         self._wrapped = wrapped
+        self._is_virtual_size = is_virtual_size
         self._requires_grad = False
 
     @property
@@ -56,6 +57,15 @@ class PartiallyMaterializedTensor:
         Get the wrapped extension class for C++ interop.
         """
         return self._wrapped
+
+    @property
+    def is_virtual(self):
+        """
+        Indicate whether PMT is a virtual tensor, in which the actual tensor shape would be different from virtual size
+        This indicator is needed for checkpoint or publish. They need to call all-gather to recalculate the correct
+        metadata of the ShardedTensor
+        """
+        return self._is_virtual_size
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/utils/partially_materialized_tensor.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/utils/partially_materialized_tensor.py
@@ -85,6 +85,12 @@ class PartiallyMaterializedTensor:
         """
         return self._wrapped.narrow(dim, start, length)
 
+    def set_weights_and_ids(self, weights: torch.Tensor, ids: torch.Tensor) -> None:
+        self._wrapped.set_weights_and_ids(weights, ids)
+
+    def get_weights_by_ids(self, ids: torch.Tensor) -> torch.Tensor:
+        return self._wrapped.get_weights_by_ids(ids)
+
     def full_tensor(self) -> torch.Tensor:
         """
         This loads the full tensor into memory (may OOM).

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/kv_db_cpp_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/kv_db_cpp_utils.h
@@ -46,7 +46,7 @@ inline size_t hash_shard(int64_t id, size_t num_shards) {
 ///
 /// @param unordered_indices unordered ids, the id here might be
 /// original(unlinearized) id
-/// @param hash_mode 0 for hash by mod, 1 for hash by interleave
+/// @param hash_mode 0 for chunk-based hashing, 1 for interleaved-based hashing
 /// @param bucket_start global bucket id, the start of the bucket range
 /// @param bucket_end global bucket id, the end of the bucket range
 /// @param bucket_size an optional, virtual size(input space, e.g. 2^50) of a

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
@@ -86,9 +86,14 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
       int64_t start_id,
       int64_t end_id,
       int64_t id_offset,
-      c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper> snapshot_handle) {
+      std::optional<c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper>>
+          snapshot_handle) {
     return impl_->get_keys_in_range_by_snapshot(
-        start_id, end_id, id_offset, snapshot_handle->handle);
+        start_id,
+        end_id,
+        id_offset,
+        snapshot_handle.has_value() ? snapshot_handle.value()->handle
+                                    : nullptr);
   }
 
   void toggle_compaction(bool enable) {

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
@@ -48,7 +48,7 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
       const int64_t length,
       const at::Tensor& weights);
 
-  void set_weights_and_ids(const at::Tensor& ids, const at::Tensor& weights);
+  void set_weights_and_ids(const at::Tensor& weights, const at::Tensor& ids);
 
   at::Tensor get_weights_by_ids(const at::Tensor& ids);
 

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
@@ -37,7 +37,8 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
       int64_t dtype,
       int64_t row_offset,
       std::optional<c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper>>
-          snapshot_handle);
+          snapshot_handle = std::nullopt,
+      std::optional<std::vector<int64_t>> materialized_shape = std::nullopt);
 
   at::Tensor narrow(int64_t dim, int64_t start, int64_t length);
 
@@ -70,6 +71,7 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
   c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper> snapshot_handle_;
   at::TensorOptions options_;
   std::vector<int64_t> shape_;
+  std::optional<std::vector<int64_t>> materialized_shape_;
   std::vector<int64_t> strides_;
   int64_t row_offset_;
 };

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper_cpu.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper_cpu.cpp
@@ -34,9 +34,13 @@ KVTensorWrapper::KVTensorWrapper(
     [[maybe_unused]] int64_t dtype,
     int64_t row_offset,
     [[maybe_unused]] std::optional<
-        c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper>> snapshot_handle)
+        c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper>> snapshot_handle,
+    [[maybe_unused]] std::optional<std::vector<int64_t>> materialized_shape)
     // @lint-ignore CLANGTIDY clang-diagnostic-missing-noreturn
-    : db_(db->impl_), shape_(std::move(shape)), row_offset_(row_offset) {
+    : db_(db->impl_),
+      shape_(std::move(shape)),
+      materialized_shape_(materialized_shape),
+      row_offset_(row_offset) {
   FBEXCEPTION("Not implemented");
 }
 

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -360,26 +360,29 @@ void KVTensorWrapper::set_range(
 }
 
 void KVTensorWrapper::set_weights_and_ids(
-    const at::Tensor& ids,
-    const at::Tensor& weights) {
+    const at::Tensor& weights,
+    const at::Tensor& ids) {
   CHECK_EQ(ids.size(0), weights.size(0))
       << "ids and weights must have same # rows";
   CHECK_GE(db_->get_max_D(), shape_[1]);
+  auto linearized_ids = ids + row_offset_;
   int pad_right = db_->get_max_D() - weights.size(1);
   if (pad_right == 0) {
-    db_->set_kv_to_storage(ids, weights);
+    db_->set_kv_to_storage(linearized_ids, weights);
   } else {
     std::vector<int64_t> padding = {0, pad_right, 0, 0};
     auto padded_weights = torch::constant_pad_nd(weights, padding, 0);
     CHECK_EQ(db_->get_max_D(), padded_weights.size(1));
-    db_->set_kv_to_storage(ids, padded_weights);
+    db_->set_kv_to_storage(linearized_ids, padded_weights);
   }
 }
 
 at::Tensor KVTensorWrapper::get_weights_by_ids(const at::Tensor& ids) {
   auto weights =
       at::empty(c10::IntArrayRef({ids.size(0), db_->get_max_D()}), options_);
-  db_->get_kv_from_storage_by_snapshot(ids, weights, snapshot_handle_->handle);
+  auto linearized_ids = ids + row_offset_;
+  db_->get_kv_from_storage_by_snapshot(
+      linearized_ids, weights, snapshot_handle_->handle);
   return weights.narrow(1, 0, shape_[1]);
 }
 

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -547,7 +547,7 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
     }
 
     at::Tensor returned_keys = at::empty(
-        total_num, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+        {total_num, 1}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
     auto key_ptr = returned_keys.data_ptr<int64_t>();
     int64_t offset = 0;
     for (const auto& keys : keys_in_db_shards) {

--- a/fbgemm_gpu/test/tbe/ssd/kv_tensor_wrapper_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/kv_tensor_wrapper_test.py
@@ -58,7 +58,6 @@ class KvTensorWrapperTest(TestCase):
         weights_dtype = weights_precision.as_dtype()
 
         with tempfile.TemporaryDirectory() as ssd_directory:
-            # pyre-fixme[16]: Module `classes` has no attribute `fbgemm`.
             ssd_db = torch.classes.fbgemm.EmbeddingRocksDBWrapper(
                 ssd_directory,
                 8,  # num_shards
@@ -142,8 +141,9 @@ class KvTensorWrapperTest(TestCase):
         weights_precision, dtype_width = precision
         weights_dtype = weights_precision.as_dtype()
 
+        table_offsets = [0, E]
+
         with tempfile.TemporaryDirectory() as ssd_directory:
-            # pyre-fixme[16]: Module `classes` has no attribute `fbgemm`.
             ssd_db = torch.classes.fbgemm.EmbeddingRocksDBWrapper(
                 ssd_directory,
                 8,  # num_shards
@@ -162,45 +162,57 @@ class KvTensorWrapperTest(TestCase):
                 dtype_width,  # row_storage_bitwidth
                 10 * (2**20),  # block cache size
             )
-            weights = torch.arange(N * D, dtype=weights_dtype).view(N, D)
-            padded_weights = torch.nn.functional.pad(weights, (0, max_D - D))
-            output_weights = torch.empty_like(padded_weights, dtype=weights_dtype)
 
-            # no snapshot needed for writing to rocksdb
-            tensor_wrapper0 = torch.classes.fbgemm.KVTensorWrapper(
-                ssd_db, [E, D], weights.dtype, 0
-            )
-            step = N
-            for i in range(0, E, step):
-                tensor_wrapper0.set_range(0, i, step, weights)
+            weights = [
+                torch.randn(N * D, dtype=weights_dtype).view(N, D),
+                torch.randn(N * D, dtype=weights_dtype).view(N, D),
+            ]
 
-            # force waiting for set to complete
-            indices = torch.arange(step)
-            for i in range(0, E, step):
-                ssd_db.get(i + indices, output_weights, torch.tensor(indices.shape[0]))
+            for table_idx, offset in enumerate(table_offsets):
+                # no snapshot needed for writing to rocksdb
+                tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
+                    ssd_db, [E, D], weights[table_idx].dtype, offset
+                )
+                step = N
+                for i in range(0, E, step):
+                    tensor_wrapper.set_range(0, i, step, weights[table_idx])
 
             # create a view tensor wrapper
             snapshot = ssd_db.create_snapshot()
-            tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
-                ssd_db, [E, D], weights.dtype, 0, snapshot
-            )
-            self.assertEqual(tensor_wrapper.shape, [E, D])
 
-            # table has a total of E rows
-            # load 1000 rows at a time
-            step = 1000
-            for i in range(0, E, step):
-                narrowed = tensor_wrapper.narrow(0, i, step)
-                self.assertTrue(
-                    torch.equal(narrowed, weights),
-                    msg=(
-                        f"Tensor value mismatch :\n"
-                        f"actual\n{narrowed}\n\nexpected\n{weights}"
-                    ),
+            for table_idx, offset in enumerate(table_offsets):
+                wrong_tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
+                    ssd_db, [E, D], weights[table_idx].dtype, 1, snapshot
                 )
+                tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
+                    ssd_db, [E, D], weights[table_idx].dtype, offset, snapshot
+                )
+                self.assertEqual(tensor_wrapper.shape, [E, D])
 
-            del tensor_wrapper0
-            del tensor_wrapper
+                # table has a total of E rows
+                # load 1000 rows at a time
+                step = N
+                for i in range(0, E, step):
+                    narrowed = tensor_wrapper.narrow(0, i, step)
+                    self.assertTrue(
+                        torch.equal(narrowed, weights[table_idx]),
+                        msg=(
+                            f"Tensor value mismatch :\n"
+                            f"actual\n{narrowed}\n\nexpected\n{weights[table_idx]}"
+                        ),
+                    )
+
+                    wrong_narrowed = wrong_tensor_wrapper.narrow(0, i, step)
+                    self.assertTrue(
+                        not torch.equal(wrong_narrowed, weights[table_idx]),
+                        msg=(
+                            f"Tensor value shouldn't match :\n"
+                            f"actual\n{wrong_narrowed}\n\nexpected\n{weights[table_idx]}"
+                        ),
+                    )
+                del wrong_tensor_wrapper
+                del tensor_wrapper
+
             del snapshot
             self.assertEqual(ssd_db.get_snapshot_count(), 0)
 
@@ -224,6 +236,8 @@ class KvTensorWrapperTest(TestCase):
         weights_precision, dtype_width = precision
         weights_dtype = weights_precision.as_dtype()
 
+        table_offsets = [0, N]
+
         with tempfile.TemporaryDirectory() as ssd_directory:
             # pyre-fixme[16]: Module `classes` has no attribute `fbgemm`.
             ssd_db = torch.classes.fbgemm.EmbeddingRocksDBWrapper(
@@ -245,33 +259,56 @@ class KvTensorWrapperTest(TestCase):
                 10 * (2**20),  # block cache size
             )
             indices = torch.randperm(N)
-            weights = torch.arange(N * D, dtype=weights_dtype).view(N, D)
+            weights = [
+                torch.randn(N * D, dtype=weights_dtype).view(N, D),
+                torch.randn(N * D, dtype=weights_dtype).view(N, D),
+            ]
             new_weights_after_snapshot = torch.randn(N, D, dtype=weights_dtype)
 
             # no snapshot needed for writing to rocksdb
-            tensor_wrapper0 = torch.classes.fbgemm.KVTensorWrapper(
-                ssd_db, [E, D], weights.dtype, 0
-            )
-            tensor_wrapper0.set_weights_and_ids(indices, weights)
+            for table_idx, offset in enumerate(table_offsets):
+                tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
+                    ssd_db, [E, D], weights[table_idx].dtype, offset
+                )
+                tensor_wrapper.set_weights_and_ids(weights[table_idx], indices)
 
             # create a view tensor wrapper
             snapshot = ssd_db.create_snapshot()
-            tensor_wrapper0.set_weights_and_ids(indices, new_weights_after_snapshot)
-            tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
-                ssd_db, [E, D], weights.dtype, 0, snapshot
-            )
-            self.assertEqual(tensor_wrapper.shape, [E, D])
 
-            out_weights = tensor_wrapper.get_weights_by_ids(indices)
-            self.assertTrue(
-                torch.equal(out_weights, weights),
-                msg=(
-                    f"Tensor value mismatch :\n"
-                    f"actual\n{out_weights}\n\nexpected\n{weights}"
-                ),
-            )
+            for table_idx, offset in enumerate(table_offsets):
+                tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
+                    ssd_db, [E, D], weights[table_idx].dtype, offset
+                )
+                tensor_wrapper.set_weights_and_ids(new_weights_after_snapshot, indices)
 
-            del tensor_wrapper0
-            del tensor_wrapper
+            for table_idx, offset in enumerate(table_offsets):
+                wrong_tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
+                    ssd_db, [E, D], weights[table_idx].dtype, 1, snapshot
+                )
+                tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
+                    ssd_db, [E, D], weights[table_idx].dtype, offset, snapshot
+                )
+                self.assertEqual(tensor_wrapper.shape, [E, D])
+
+                wrong_out_weights = wrong_tensor_wrapper.get_weights_by_ids(indices)
+                self.assertTrue(
+                    not torch.equal(wrong_out_weights, weights[table_idx]),
+                    msg=(
+                        f"Tensor value should be mismatch but actually matches:\n"
+                        f"actual\n{wrong_out_weights}\n\nexpected\n{weights[table_idx]}"
+                    ),
+                )
+
+                out_weights = tensor_wrapper.get_weights_by_ids(indices)
+                self.assertTrue(
+                    torch.equal(out_weights, weights[table_idx]),
+                    msg=(
+                        f"Tensor value mismatch :\n"
+                        f"actual\n{out_weights}\n\nexpected\n{weights[table_idx]}"
+                    ),
+                )
+                del tensor_wrapper
+                del wrong_tensor_wrapper
+
             del snapshot
             self.assertEqual(ssd_db.get_snapshot_count(), 0)

--- a/fbgemm_gpu/test/tbe/ssd/ssd_l2_cache_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_l2_cache_test.py
@@ -291,11 +291,11 @@ class SSDCheckpointTest(unittest.TestCase):
         tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
             emb.ssd_db, [E, D], weights.dtype, 0
         )
-        tensor_wrapper.set_weights_and_ids(indices + offset, weights)
+        tensor_wrapper.set_weights_and_ids(weights, indices + offset)
 
         snapshot = emb.ssd_db.create_snapshot()
         tensor_wrapper.set_weights_and_ids(
-            new_indices + offset, new_weights_after_snapshot
+            new_weights_after_snapshot, new_indices + offset
         )
         start_id = 0
         end_id = int(E / 2)

--- a/fbgemm_gpu/test/tbe/ssd/ssd_l2_cache_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_l2_cache_test.py
@@ -269,7 +269,6 @@ class SSDCheckpointTest(unittest.TestCase):
         mixed: bool,
         weights_precision: SparseType,
     ) -> None:
-        weights_precision: SparseType = SparseType.FP32
         emb, Es, Ds, max_D = self.generate_fbgemm_ssd_tbe(
             T, D, log_E, weights_precision, mixed, False, 8
         )
@@ -307,7 +306,7 @@ class SSDCheckpointTest(unittest.TestCase):
             start_id + offset, end_id + offset, offset, snapshot
         )
         ids_in_range_ordered, _ = torch.sort(ids_in_range)
-        id_tensor_ordered, _ = torch.sort(id_tensor)
+        id_tensor_ordered, _ = torch.sort(id_tensor.view(-1))
 
         assert torch.equal(ids_in_range_ordered, id_tensor_ordered)
 
@@ -378,7 +377,8 @@ class SSDCheckpointTest(unittest.TestCase):
         else:
             # test failure
             with self.assertRaisesRegex(
-                RuntimeError, "only support hash by mod and interleaved for now"
+                RuntimeError,
+                "only support hash by chunk-based or interleaved-based hashing for now",
             ):
                 torch.ops.fbgemm.get_bucket_sorted_indices_and_bucket_tensor(
                     indices,
@@ -401,7 +401,7 @@ class SSDCheckpointTest(unittest.TestCase):
             last_bucket_id = cur_bucket_id
         # Calculate expected tensor output
         expected_bucket_tensor = torch.zeros(
-            bucket_end - bucket_start, 1, dtype=torch.int64
+            bucket_end - bucket_start, dtype=torch.int64
         )
         for index in indices:
             self.assertTrue(hash_mode >= 0 and hash_mode <= 1)
@@ -413,4 +413,4 @@ class SSDCheckpointTest(unittest.TestCase):
             expected_bucket_tensor[bucket_id - bucket_start] += 1
 
         # Compare actual and expected tensor outputs
-        self.assertTrue(torch.equal(bucket_t, expected_bucket_tensor))
+        self.assertTrue(torch.equal(bucket_t.view(-1), expected_bucket_tensor))

--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
@@ -7,6 +7,7 @@
 # pyre-strict
 # pyre-ignore-all-errors[3,6,56]
 
+import math
 import unittest
 from enum import Enum
 
@@ -17,6 +18,7 @@ import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
 from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+    BackendType,
     BoundsCheckMode,
     PoolingMode,
 )
@@ -30,6 +32,7 @@ from ..common import gen_mixed_B_batch_sizes, gpu_unavailable, running_in_oss
 
 MAX_EXAMPLES = 40
 MAX_PIPELINE_EXAMPLES = 10
+KV_WORLD_SIZE = 4
 
 default_st: Dict["str", Any] = {
     "T": st.integers(min_value=1, max_value=10),
@@ -130,6 +133,37 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
         torch.cuda.synchronize()
         torch.testing.assert_close(weights, output_weights)
 
+    def generate_in_bucket_indices(
+        self,
+        hash_mode: int,
+        bucket_id_range: Tuple[int, int],
+        bucket_size: int,
+        # max height in ref_emb, the logical id high, physically id in kv is a shift from [0,h) to [table_offset, table_offset+h]
+        high: int,
+        size: Tuple[int, int],
+    ) -> torch.Tensor:
+        """
+        Generate indices in embedding bucket, this is guarantee on the torchrec input_dist
+        """
+        assert hash_mode == 0, "only support hash_mode=0, aka chunk-based hashing"
+
+        # hash mode is chunk-based hashing
+        # STEP 1: generate all the eligible indices in the given range
+        bucket_id_start = bucket_id_range[0]
+        bucket_id_end = bucket_id_range[1]
+        rank_input_range = (bucket_id_end - bucket_id_start) * bucket_size
+        rank_input_range = min(rank_input_range, high)
+        indices = torch.as_tensor(
+            np.random.choice(rank_input_range, replace=False, size=(rank_input_range,)),
+            dtype=torch.int64,
+        )
+        indices += bucket_id_start * bucket_size
+
+        # STEP 2: generate random indices with the given shape from the eligible indices above                      # 想要的输出形状
+        idx = torch.randint(0, indices.numel(), size)
+        random_indices = indices[idx]
+        return random_indices
+
     def generate_inputs_(
         self,
         B: int,
@@ -139,6 +173,9 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
         weights_precision: SparseType = SparseType.FP32,
         trigger_bounds_check: bool = False,
         mixed_B: bool = False,
+        is_kv_tbes: bool = False,
+        bucket_offsets: Optional[List[Tuple[int, int]]] = None,
+        bucket_sizes: Optional[List[int]] = None,
     ) -> Tuple[
         List[torch.Tensor],
         List[torch.Tensor],
@@ -158,12 +195,28 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
             Bs_rank_feature, Bs = gen_mixed_B_batch_sizes(B, T)
 
         # Generate random indices and per sample weights
-        indices_list = [
-            torch.randint(
-                low=0, high=Es[t] * (2 if trigger_bounds_check else 1), size=(b, L)
-            ).cuda()
-            for (b, t) in zip(Bs, feature_table_map)
-        ]
+        if is_kv_tbes:
+            assert len(bucket_offsets) == len(bucket_sizes)
+            assert len(bucket_offsets) <= len(feature_table_map)
+            indices_list = [
+                self.generate_in_bucket_indices(
+                    0,
+                    # pyre-ignore
+                    bucket_offsets[t],
+                    # pyre-ignore
+                    bucket_sizes[t],
+                    Es[t] * (2 if trigger_bounds_check else 1),
+                    size=(b, L),
+                ).cuda()
+                for (b, t) in zip(Bs, feature_table_map)
+            ]
+        else:
+            indices_list = [
+                torch.randint(
+                    low=0, high=Es[t] * (2 if trigger_bounds_check else 1), size=(b, L)
+                ).cuda()
+                for (b, t) in zip(Bs, feature_table_map)
+            ]
         per_sample_weights_list = [torch.randn(size=(b, L)).cuda() for b in Bs]
 
         # Concat inputs for SSD TBE
@@ -196,6 +249,178 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
             per_sample_weights.contiguous().view(-1).cuda(),
             batch_size_per_feature_per_rank,
         )
+
+    def generate_kv_tbes(
+        self,
+        T: int,
+        D: int,
+        B: int,
+        log_E: int,
+        L: int,
+        weighted: bool,
+        lr: float = 0.01,  # from SSDTableBatchedEmbeddingBags
+        eps: float = 1.0e-8,  # from SSDTableBatchedEmbeddingBags
+        ssd_shards: int = 1,  # from SSDTableBatchedEmbeddingBags
+        optimizer: OptimType = OptimType.EXACT_ROWWISE_ADAGRAD,
+        cache_set_scale: float = 1.0,
+        # pyre-fixme[9]: pooling_mode has type `bool`; used as `PoolingMode`.
+        pooling_mode: bool = PoolingMode.SUM,
+        weights_precision: SparseType = SparseType.FP32,
+        output_dtype: SparseType = SparseType.FP32,
+        stochastic_rounding: bool = True,
+        share_table: bool = False,
+        prefetch_pipeline: bool = False,
+        zero_collision_tbe: bool = False,
+        backend_type: BackendType = BackendType.SSD,
+        num_buckets: int = 5,
+    ) -> Tuple[
+        SSDTableBatchedEmbeddingBags,
+        List[torch.nn.EmbeddingBag],
+        List[int],
+        List[Tuple[int, int]],
+        List[int],
+    ]:
+        """
+        Generate embedding modules (i,e., SSDTableBatchedEmbeddingBags and
+        torch.nn.EmbeddingBags)
+
+        Idea in this UT, originally we have a ref_emb using EmbeddingBag/Embedding with the same size in emb,
+        to stimulate the lookup result from different pooling, weighted, etc..., and doing lookup on both
+        ref_emb and emb and compare the result.
+
+        However when we test with kv zch embedding lookup, we are using virtual space which can not be preallocated
+        in ref_emb using EmbeddingBag/Embeddings.
+
+        The little trick we do here is we still pre-allocate ref_emb with the given table size,
+        but when we create SSD TBE, we passed in the virtual table size.
+
+        For example if the given table size is [100, 256], we have ref_emb with [100, 256], and SSD TBE with [2^25, 256]
+        the input id will always be in the range of [0, 100)
+        """
+        import tempfile
+
+        torch.manual_seed(42)
+        E = int(10**log_E)
+        virtual_E = int(
+            2**18
+        )  # relatively large for now given optimizer is still pre-allocated
+        D = D * 4
+        Ds = [D] * T
+        Es = [E] * T
+
+        if pooling_mode == PoolingMode.SUM:
+            mode = "sum"
+            do_pooling = True
+        elif pooling_mode == PoolingMode.MEAN:
+            mode = "mean"
+            do_pooling = True
+        elif pooling_mode == PoolingMode.NONE:
+            mode = "sum"
+            do_pooling = False
+        else:
+            # This proves that we have exhaustively checked all PoolingModes
+            raise RuntimeError("Unknown PoolingMode!")
+
+        # Generate torch EmbeddingBag
+        # in kv tbes, we still maintain a small emb in EmbeddingBag or Embedding as a reference for expected outcome,
+        # but the virual space passed into TBE will be super large, e.g. 2^50
+        # NOTE we will use a relative large virtual size for now, given that optimizer is still pre-allocated
+        if do_pooling:
+            emb_ref = [
+                torch.nn.EmbeddingBag(E, D, mode=mode, sparse=True).cuda()
+                for (E, D) in zip(Es, Ds)
+            ]
+        else:
+            emb_ref = [
+                torch.nn.Embedding(E, D, sparse=True).cuda() for (E, D) in zip(Es, Ds)
+            ]
+
+        # Cast type
+        if weights_precision == SparseType.FP16:
+            emb_ref = [emb.half() for emb in emb_ref]
+
+        # Init weights
+        [emb.weight.data.uniform_(-2.0, 2.0) for emb in emb_ref]
+
+        # Construct feature_table_map
+        feature_table_map = list(range(T))
+        table_to_replicate = -1
+        if share_table:
+            # autograd with shared embedding only works for exact
+            table_to_replicate = T // 2
+            # pyre-ignore
+            feature_table_map.insert(table_to_replicate, table_to_replicate)
+            emb_ref.insert(table_to_replicate, emb_ref[table_to_replicate])
+
+        cache_sets = max(int(max(T * B * L, 1) * cache_set_scale), 1)
+
+        # Generate TBE SSD
+        bucket_sizes = []
+        bucket_offsets = []
+        for _ in Es:
+            bucket_sizes.append(math.ceil(virtual_E / num_buckets))
+            bucket_start = (
+                0  # since ref_emb is dense format, we need to start from 0th bucket
+            )
+            bucket_end = min(math.ceil(num_buckets / KV_WORLD_SIZE), num_buckets)
+            bucket_offsets.append((bucket_start, bucket_end))
+        emb = SSDTableBatchedEmbeddingBags(
+            embedding_specs=[(virtual_E, D) for D in Ds],
+            feature_table_map=feature_table_map,
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=cache_sets,
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            learning_rate=lr,
+            eps=eps,
+            ssd_rocksdb_shards=ssd_shards,
+            optimizer=optimizer,
+            pooling_mode=pooling_mode,
+            weights_precision=weights_precision,
+            output_dtype=output_dtype,
+            stochastic_rounding=stochastic_rounding,
+            prefetch_pipeline=prefetch_pipeline,
+            bounds_check_mode=BoundsCheckMode.WARNING,
+            l2_cache_size=8,
+            zero_collision_tbe=zero_collision_tbe,
+            backend_type=backend_type,
+            bucket_offsets=bucket_offsets,
+            bucket_sizes=bucket_sizes,
+        ).cuda()
+
+        self.assertTrue(emb.ssd_db.is_auto_compaction_enabled())
+
+        # By doing the check for ssd_db being None below, we also access the getter property of ssd_db, which will
+        # force the synchronization of lazy_init_thread, and then reset it to None.
+        if emb.ssd_db is not None:
+            self.assertIsNone(emb.lazy_init_thread)
+
+        # A list to keep the CPU tensor alive until `set` (called inside
+        # `set_cuda`) is complete. Note that `set_cuda` is non-blocking
+        # asynchronous
+        emb_ref_cpu = []
+
+        # Initialize TBE SSD weights
+        for f, t in self.get_physical_table_arg_indices_(emb.feature_table_map):
+            emb_ref_ = emb_ref[f].weight.clone().detach().cpu()
+            emb.ssd_db.set_cuda(
+                torch.arange(t * virtual_E, t * virtual_E + E).to(torch.int64),
+                emb_ref_,
+                torch.as_tensor([E]),
+                t,
+            )
+            emb_ref_cpu.append(emb_ref_)
+
+        # Ensure that `set` (invoked by `set_cuda`) is done
+        torch.cuda.synchronize()
+
+        # Convert back to float (to make sure that accumulation is done
+        # in FP32 -- like TBE)
+        if weights_precision == SparseType.FP16:
+            emb_ref = [emb.float() for emb in emb_ref]
+
+        # pyre-fixme[7]
+        return emb, emb_ref, Es, bucket_offsets, bucket_sizes
 
     def generate_ssd_tbes(
         self,
@@ -659,7 +884,7 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
         )
 
         # Compare optimizer states
-        split_optimizer_states = [s for (s,) in emb.debug_split_optimizer_states()]
+        split_optimizer_states = [s for (s, _, _) in emb.debug_split_optimizer_states()]
         for f, t in self.get_physical_table_arg_indices_(emb.feature_table_map):
             # pyre-fixme[16]: Optional type has no attribute `float`.
             ref_optimizer_state = emb_ref[f].weight.grad.float().to_dense().pow(2)
@@ -801,11 +1026,11 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
             else 1.0e-2
         )
 
-        split_optimizer_states = [s for (s,) in emb.debug_split_optimizer_states()]
+        split_optimizer_states = [s for (s, _, _) in emb.debug_split_optimizer_states()]
         emb.flush()
 
         # Compare emb state dict with expected values from nn.EmbeddingBag
-        emb_state_dict = emb.split_embedding_weights(no_snapshot=False)
+        emb_state_dict, _, _ = emb.split_embedding_weights(no_snapshot=False)
         for feature_index, table_index in self.get_physical_table_arg_indices_(
             emb.feature_table_map
         ):
@@ -886,7 +1111,7 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
         )
 
         optimizer_states_ref = [
-            s.clone().float() for (s,) in emb.debug_split_optimizer_states()
+            s.clone().float() for (s, _, _) in emb.debug_split_optimizer_states()
         ]
 
         Es = [emb.embedding_specs[t][0] for t in range(T)]
@@ -1032,7 +1257,9 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 emb.flush()
 
             # Compare optimizer states
-            split_optimizer_states = [s for (s,) in emb.debug_split_optimizer_states()]
+            split_optimizer_states = [
+                s for (s, _, _) in emb.debug_split_optimizer_states()
+            ]
             for f, t in self.get_physical_table_arg_indices_(emb.feature_table_map):
                 optim_state_r = optimizer_states_ref[t]
                 optim_state_t = split_optimizer_states[t]
@@ -1220,3 +1447,299 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
             flush_location=None,
             **kwargs,
         )
+
+    @given(
+        **default_st,
+        num_buckets=st.integers(min_value=10, max_value=15),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    def test_kv_db_forward(
+        self,
+        T: int,
+        D: int,
+        B: int,
+        log_E: int,
+        L: int,
+        weighted: bool,
+        cache_set_scale: float,
+        pooling_mode: PoolingMode,
+        weights_precision: SparseType,
+        output_dtype: SparseType,
+        share_table: bool,
+        trigger_bounds_check: bool,
+        mixed_B: bool,
+        num_buckets: int,
+    ) -> None:
+        trigger_bounds_check = False  # don't stimulate boundary check cases
+        assume(not weighted or pooling_mode == PoolingMode.SUM)
+        assume(not mixed_B or pooling_mode != PoolingMode.NONE)
+
+        # Generate embedding modules
+        (
+            emb,
+            emb_ref,
+            Es,
+            bucket_offsets,
+            bucket_sizes,
+        ) = self.generate_kv_tbes(
+            T,
+            D,
+            B,
+            log_E,
+            L,
+            weighted,
+            cache_set_scale=cache_set_scale,
+            pooling_mode=pooling_mode,
+            weights_precision=weights_precision,
+            output_dtype=output_dtype,
+            share_table=share_table,
+            zero_collision_tbe=True,
+            num_buckets=num_buckets,
+        )
+
+        # Generate inputs
+        (
+            indices_list,
+            per_sample_weights_list,
+            indices,
+            offsets,
+            per_sample_weights,
+            batch_size_per_feature_per_rank,
+        ) = self.generate_inputs_(
+            B,
+            L,
+            Es,
+            emb.feature_table_map,
+            weights_precision=weights_precision,
+            trigger_bounds_check=trigger_bounds_check,
+            mixed_B=mixed_B,
+            bucket_offsets=bucket_offsets,
+            bucket_sizes=bucket_sizes,
+            is_kv_tbes=True,
+        )
+
+        # Execute forward
+        self.execute_ssd_forward_(
+            emb,
+            emb_ref,
+            indices_list,
+            per_sample_weights_list,
+            indices,
+            offsets,
+            per_sample_weights,
+            B,
+            L,
+            weighted,
+            batch_size_per_feature_per_rank=batch_size_per_feature_per_rank,
+        )
+
+    @given(
+        **default_st,
+        num_buckets=st.integers(min_value=10, max_value=15),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    def test_kv_emb_state_dict(
+        self,
+        T: int,
+        D: int,
+        B: int,
+        log_E: int,
+        L: int,
+        weighted: bool,
+        cache_set_scale: float,
+        pooling_mode: PoolingMode,
+        weights_precision: SparseType,
+        output_dtype: SparseType,
+        share_table: bool,
+        trigger_bounds_check: bool,
+        mixed_B: bool,
+        num_buckets: int,
+    ) -> None:
+        # Constants
+        lr = 0.5
+        eps = 0.2
+        ssd_shards = 2
+
+        trigger_bounds_check = False  # don't stimulate boundary check cases
+        assume(not weighted or pooling_mode == PoolingMode.SUM)
+        assume(not mixed_B or pooling_mode != PoolingMode.NONE)
+
+        # Generate embedding modules and inputs
+        (
+            emb,
+            emb_ref,
+            Es,
+            bucket_offsets,
+            bucket_sizes,
+        ) = self.generate_kv_tbes(
+            T,
+            D,
+            B,
+            log_E,
+            L,
+            weighted,
+            lr=lr,
+            eps=eps,
+            ssd_shards=ssd_shards,
+            cache_set_scale=cache_set_scale,
+            pooling_mode=pooling_mode,
+            weights_precision=weights_precision,
+            output_dtype=output_dtype,
+            share_table=share_table,
+            zero_collision_tbe=True,
+            num_buckets=num_buckets,
+        )
+
+        # Generate inputs
+        (
+            indices_list,
+            per_sample_weights_list,
+            indices,
+            offsets,
+            per_sample_weights,
+            batch_size_per_feature_per_rank,
+        ) = self.generate_inputs_(
+            B,
+            L,
+            Es,
+            emb.feature_table_map,
+            weights_precision=weights_precision,
+            trigger_bounds_check=trigger_bounds_check,
+            mixed_B=mixed_B,
+            bucket_offsets=bucket_offsets,
+            bucket_sizes=bucket_sizes,
+            is_kv_tbes=True,
+        )
+
+        # Execute forward
+        output_ref_list, output = self.execute_ssd_forward_(
+            emb,
+            emb_ref,
+            indices_list,
+            per_sample_weights_list,
+            indices,
+            offsets,
+            per_sample_weights,
+            B,
+            L,
+            weighted,
+            batch_size_per_feature_per_rank=batch_size_per_feature_per_rank,
+        )
+
+        # Generate output gradient
+        output_grad_list = [torch.randn_like(out) for out in output_ref_list]
+
+        # Execute torch EmbeddingBag backward
+        [out.backward(grad) for (out, grad) in zip(output_ref_list, output_grad_list)]
+        if batch_size_per_feature_per_rank is not None:
+            grad_test = self.concat_ref_tensors_vbe(
+                output_grad_list, batch_size_per_feature_per_rank
+            )
+        else:
+            grad_test = self.concat_ref_tensors(
+                output_grad_list,
+                pooling_mode != PoolingMode.NONE,  # do_pooling
+                B,
+                D * 4,
+            )
+
+        # Execute TBE SSD backward
+        output.backward(grad_test)
+
+        tolerance = (
+            1.0e-4
+            if weights_precision == SparseType.FP32 and output_dtype == SparseType.FP32
+            else 1.0e-2
+        )
+
+        emb.flush()
+
+        split_optimizer_states = []
+        table_input_id_range = []
+        for s, input_id_start, input_id_end in emb.debug_split_optimizer_states():
+            split_optimizer_states.append(s)
+            # the ref_emb might contains ids out of the bucket input range
+            table_input_id_range.append((input_id_start, input_id_end))
+            # since we use ref_emb in dense format, the rows start from id 0
+            self.assertEqual(input_id_start, 0)
+
+        # Compare optimizer states
+        for f, t in self.get_physical_table_arg_indices_(emb.feature_table_map):
+            # pyre-fixme[16]: Optional type has no attribute `float`.
+            ref_optimizer_state = emb_ref[f].weight.grad.float().to_dense().pow(2)
+            torch.testing.assert_close(
+                split_optimizer_states[t].float(),
+                ref_optimizer_state.mean(dim=1)[
+                    table_input_id_range[t][0] : min(
+                        table_input_id_range[t][1], emb_ref[f].weight.size(0)
+                    )
+                ],
+                atol=tolerance,
+                rtol=tolerance,
+            )
+
+        # Compare emb state dict with expected values from nn.EmbeddingBag
+        emb_state_dict_list, bucket_asc_ids_list, num_active_id_per_bucket_list = (
+            emb.split_embedding_weights(no_snapshot=False, should_flush=True)
+        )
+        for feature_index, table_index in self.get_physical_table_arg_indices_(
+            emb.feature_table_map
+        ):
+            #################################################################
+            ## validate bucket_asc_ids_list and num_active_id_per_bucket_list
+            #################################################################
+            bucket_asc_id = bucket_asc_ids_list[table_index]
+            num_active_id_per_bucket = num_active_id_per_bucket_list[table_index]
+
+            bucket_id_start = bucket_offsets[table_index][0]
+            bucket_id_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
+                num_active_id_per_bucket.view(-1)
+            )
+            for bucket_idx, id_count in enumerate(num_active_id_per_bucket):
+                bucket_id = bucket_idx + bucket_id_start
+                active_id_cnt = 0
+                for idx in range(
+                    bucket_id_offsets[bucket_idx],
+                    bucket_id_offsets[bucket_idx + 1],
+                ):
+                    # for chunk-based hashing
+                    self.assertEqual(
+                        bucket_id, bucket_asc_id[idx] // bucket_sizes[table_index]
+                    )
+                    active_id_cnt += 1
+                self.assertEqual(active_id_cnt, id_count)
+
+            ######################
+            ## validate embeddings
+            ######################
+            id_range_start = table_input_id_range[table_index][
+                0
+            ]  # should be 0 because ref_emb is preallocated
+            id_range_end = min(table_input_id_range[table_index][1], Es[table_index])
+            emb_r = emb_ref[feature_index]
+            self.assertLess(table_index, len(emb_state_dict_list))
+            new_ref_weight = torch.addcdiv(
+                emb_r.weight.float()[id_range_start:id_range_end,],
+                value=-lr,
+                tensor1=emb_r.weight.grad.float().to_dense()[id_range_start:id_range_end,],  # pyre-ignore[16]
+                tensor2=split_optimizer_states[table_index]
+                .float()
+                .sqrt_()
+                .add_(eps)
+                .view(
+                    id_range_end - id_range_start,
+                    1,
+                ),
+            ).cpu()
+
+            emb_w = (
+                emb_state_dict_list[table_index]
+                .narrow(0, 0, id_range_end - id_range_start)
+                .float()
+            )
+            torch.testing.assert_close(
+                emb_w,
+                new_ref_weight,
+                atol=tolerance,
+                rtol=tolerance,
+            )


### PR DESCRIPTION
Summary:
# Change logs
1. add ZeroCollisionKeyValueEmbedding emb lookup
2. address existing unit test missing for ssd offloading
3. add new ut for kv zch embedding module
4. add a temp hack solution for calculate bucket metadata
5. embedding updates, details illustrated below

#######################################################################
###########################  embedding.py updates ##########################
#######################################################################

1. keep the original idea to init shardedTensor during training init
2. for kv zch table, the shardeTensor will be init using virtual size for metadata calculation, and skip actual tensor size check for ST init, this is needed as during training init, the table has 0 rows
3. the new tensor, weight_id will not be registered in the EC becuase its shape is changing in realtime, the weight_id tensor will be generated in post_state_dict hooks
4. the new tensor, bucket could be registered and preserved, but in this diff we keep it the same way as weight_id
5. in post state dict hook, we call get_named_split_embedding_weights_snapshot to get Tuple[table_name, weight(ST), weight_id(ST), bucket(ST)], all 3 tensors are return in the format of ST, and we will update destination with the returned ST directly
6. in pre_load_state_dict_hook, which is called upon load_state_dict(), we will skip all 3 tensors update, because the tensor assignment is done [on the nn.module side](https://fburl.com/code/it5nior8), which doesn't support updating KVT through PMT. This is fine for now because, checkpoint loading will be done outside of the load_state_dict call, but we need future plans to make it work cohesively with other type of tensors

Differential Revision: D73567631
