### PR TITLE
Fix test_indices_estimation max_i should not be <1

### DIFF
--- a/fbgemm_gpu/test/tbe/eeg/tbe_indices_estimator_test.py
+++ b/fbgemm_gpu/test/tbe/eeg/tbe_indices_estimator_test.py
@@ -19,7 +19,7 @@ from fbgemm_gpu.tbe.bench import EEG_MAX_HEAVY_HITTERS
 
 class TBEIndicesEstimatorTest(unittest.TestCase):
     def test_indices_estimation(self) -> None:
-        max_i = random.randint(0, 200)
+        max_i = random.randint(1, 200)
         num_i = random.randint(100, 1000)
         indices = torch.randint(0, max_i, (num_i,), dtype=torch.int64)
 


### PR DESCRIPTION
Summary:
- Fix test where 'max_i' can be 0
  - To test `tbe_estimate_indices_distribution`, `max_i` shouldn't be <1.

Differential Revision: D73951289


