### PR TITLE
Add logic to stream weights in EmbeddingKVDB

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -185,6 +185,19 @@ class UVMCacheStatsIndex(enum.IntEnum):
     num_conflict_misses = 5
 
 
+@dataclass
+class RESParams:
+    res_server_port: int = 0  # the port of the res server
+    res_store_shards: int = 1  # the number of shards to store the raw embeddings
+    table_names: List[str] = field(default_factory=list)  # table names the TBE holds
+    table_offsets: List[int] = field(
+        default_factory=list
+    )  # table offsets for the global rows the TBE holds
+    table_sizes: List[int] = field(
+        default_factory=list
+    )  # table sizes for the global rows the TBE holds
+
+
 def construct_split_state(
     embedding_specs: List[Tuple[int, int, EmbeddingLocation, ComputeDevice]],
     rowwise: bool,

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -157,6 +157,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         lazy_bulk_init_enabled: bool = False,
         backend_type: BackendType = BackendType.SSD,
         kv_zch_params: Optional[KVZCHParams] = None,
+        enable_raw_embedding_streaming: bool = False,  # whether enable raw embedding streaming
     ) -> None:
         super(SSDTableBatchedEmbeddingBags, self).__init__()
 
@@ -169,6 +170,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         # pyre-fixme[8]: Attribute has type `device`; used as `int`.
         self.current_device: torch.device = torch.cuda.current_device()
 
+        self.enable_raw_embedding_streaming = enable_raw_embedding_streaming
         self.feature_table_map: List[int] = (
             feature_table_map if feature_table_map is not None else list(range(T_))
         )
@@ -464,7 +466,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 f"write_buffer_size_per_tbe={ssd_rocksdb_write_buffer_size},max_write_buffer_num_per_db_shard={ssd_max_write_buffer_num},"
                 f"uniform_init_lower={ssd_uniform_init_lower},uniform_init_upper={ssd_uniform_init_upper},"
                 f"row_storage_bitwidth={weights_precision.bit_rate()},block_cache_size_per_tbe={ssd_block_cache_size_per_tbe},"
-                f"use_passed_in_path:{use_passed_in_path}, real_path will be printed in EmbeddingRocksDB"
+                f"use_passed_in_path:{use_passed_in_path}, real_path will be printed in EmbeddingRocksDB, enable_raw_embedding_streaming:{self.enable_raw_embedding_streaming}"
             )
             # pyre-fixme[4]: Attribute must be annotated.
             # pyre-ignore[16]
@@ -489,6 +491,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 tbe_unique_id,
                 l2_cache_size,
                 enable_async_update,
+                self.enable_raw_embedding_streaming,
             )
             if self.bulk_init_chunk_size > 0:
                 self.ssd_uniform_init_lower: float = ssd_uniform_init_lower

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
@@ -36,7 +36,12 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
       int64_t tbe_unique_id = 0,
       int64_t l2_cache_size_gb = 0,
       bool enable_async_update = false,
-      bool enable_raw_embedding_streaming = false)
+      bool enable_raw_embedding_streaming = false,
+      int64_t res_store_shards = 0,
+      int64_t res_server_port = 0,
+      std::vector<std::string> table_names = {},
+      std::vector<int64_t> table_offsets = {},
+      const std::vector<int64_t>& table_sizes = {})
       : impl_(std::make_shared<ssd::EmbeddingRocksDB>(
             path,
             num_shards,
@@ -58,7 +63,12 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
             tbe_unique_id,
             l2_cache_size_gb,
             enable_async_update,
-            enable_raw_embedding_streaming)) {}
+            enable_raw_embedding_streaming,
+            res_store_shards,
+            res_server_port,
+            std::move(table_names),
+            std::move(table_offsets),
+            table_sizes)) {}
 
   void set_cuda(
       at::Tensor indices,

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
@@ -35,7 +35,8 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
       bool use_passed_in_path = false,
       int64_t tbe_unique_id = 0,
       int64_t l2_cache_size_gb = 0,
-      bool enable_async_update = false)
+      bool enable_async_update = false,
+      bool enable_raw_embedding_streaming = false)
       : impl_(std::make_shared<ssd::EmbeddingRocksDB>(
             path,
             num_shards,
@@ -56,7 +57,8 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
             use_passed_in_path,
             tbe_unique_id,
             l2_cache_size_gb,
-            enable_async_update)) {}
+            enable_async_update,
+            enable_raw_embedding_streaming)) {}
 
   void set_cuda(
       at::Tensor indices,

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -73,12 +73,14 @@ EmbeddingKVDB::EmbeddingKVDB(
     int64_t cache_size_gb,
     int64_t unique_id,
     int64_t ele_size_bytes,
-    bool enable_async_update)
+    bool enable_async_update,
+    bool enable_raw_embedding_streaming)
     : unique_id_(unique_id),
       num_shards_(num_shards),
       max_D_(max_D),
       executor_tp_(std::make_unique<folly::CPUThreadPoolExecutor>(num_shards)),
-      enable_async_update_(enable_async_update) {
+      enable_async_update_(enable_async_update),
+      enable_raw_embedding_streaming_(enable_raw_embedding_streaming) {
   CHECK(num_shards > 0);
   if (cache_size_gb > 0) {
     l2_cache::CacheLibCache::CacheConfig cache_config;
@@ -93,7 +95,9 @@ EmbeddingKVDB::EmbeddingKVDB(
   }
   XLOG(INFO) << "[TBE_ID" << unique_id_ << "] L2 created with " << num_shards_
              << " shards, dimension:" << max_D_
-             << ", enable_async_update_:" << enable_async_update_;
+             << ", enable_async_update_:" << enable_async_update_
+             << ", enable_raw_embedding_streaming_:"
+             << enable_raw_embedding_streaming_;
 
   if (enable_async_update_) {
     cache_filling_thread_ = std::make_unique<std::thread>([=] {

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -13,6 +13,14 @@
 #include "common/time/Time.h"
 #include "kv_db_cuda_utils.h"
 #include "torch/csrc/autograd/record_function_ops.h"
+#ifdef FBGEMM_FBCODE
+#include <folly/stop_watch.h>
+#include "aiplatform/gmpp/experimental/training_ps/gen-cpp2/TrainingParameterServerService.h"
+#include "caffe2/torch/fb/distributed/wireSerializer/WireSerializer.h"
+#include "servicerouter/client/cpp2/ClientParams.h"
+#include "servicerouter/client/cpp2/ServiceRouter.h"
+#include "torch/types.h"
+#endif
 
 namespace kv_db {
 
@@ -26,6 +34,27 @@ inline int64_t get_maybe_uvm_scalar(const at::Tensor& tensor) {
       ? *(tensor.data_ptr<int64_t>())
       : *(tensor.data_ptr<int32_t>());
 }
+
+#ifdef FBGEMM_FBCODE
+/*
+ * Get the thrift client to the training parameter server service
+ * There is a destruction double free issue when wrapping the member
+ * variable under ifdef, and creating client is relatively cheap, so create this
+ * helper function to get the client just before sending requests.
+ */
+std::unique_ptr<
+    apache::thrift::Client<aiplatform::gmpp::experimental::training_ps::
+                               TrainingParameterServerService>>
+get_res_client(int64_t res_server_port) {
+  auto& factory = facebook::servicerouter::cpp2::getClientFactory();
+  auto& params = facebook::servicerouter::ClientParams().setSingleHost(
+      "::", res_server_port);
+  return factory.getSRClientUnique<
+      apache::thrift::Client<aiplatform::gmpp::experimental::training_ps::
+                                 TrainingParameterServerService>>(
+      "realtime.delta.publish.esr", params);
+}
+#endif
 
 }; // namespace
 
@@ -74,13 +103,23 @@ EmbeddingKVDB::EmbeddingKVDB(
     int64_t unique_id,
     int64_t ele_size_bytes,
     bool enable_async_update,
-    bool enable_raw_embedding_streaming)
+    bool enable_raw_embedding_streaming,
+    int64_t res_store_shards,
+    int64_t res_server_port,
+    std::vector<std::string> table_names,
+    std::vector<int64_t> table_offsets,
+    const std::vector<int64_t>& table_sizes)
     : unique_id_(unique_id),
       num_shards_(num_shards),
       max_D_(max_D),
       executor_tp_(std::make_unique<folly::CPUThreadPoolExecutor>(num_shards)),
       enable_async_update_(enable_async_update),
-      enable_raw_embedding_streaming_(enable_raw_embedding_streaming) {
+      enable_raw_embedding_streaming_(enable_raw_embedding_streaming),
+      res_store_shards_(res_store_shards),
+      res_server_port_(res_server_port),
+      table_names_(std::move(table_names)),
+      table_offsets_(std::move(table_offsets)),
+      table_sizes_(at::tensor(table_sizes)) {
   CHECK(num_shards > 0);
   if (cache_size_gb > 0) {
     l2_cache::CacheLibCache::CacheConfig cache_config;
@@ -123,6 +162,38 @@ EmbeddingKVDB::EmbeddingKVDB(
       }
     });
   }
+#ifdef FBGEMM_FBCODE
+  if (enable_raw_embedding_streaming_) {
+    XLOG(INFO) << "[TBE_ID" << unique_id_
+               << "] Raw embedding streaming enabled with res_server_port at"
+               << res_server_port;
+    // The first call to get the client is expensive, so eagerly get it here
+    auto _eager_client = get_res_client(res_server_port_);
+
+    weights_stream_thread_ = std::make_unique<std::thread>([=, this] {
+      while (!stop_) {
+        auto stream_item_ptr = weights_to_stream_queue_.try_peek();
+        if (!stream_item_ptr) {
+          std::this_thread::sleep_for(std::chrono::milliseconds(10));
+          continue;
+        }
+        if (stop_) {
+          return;
+        }
+        auto& indices = stream_item_ptr->indices;
+        auto& weights = stream_item_ptr->weights;
+        folly::stop_watch<std::chrono::milliseconds> stop_watch;
+        folly::coro::blockingWait(tensor_stream(indices, weights));
+
+        weights_to_stream_queue_.dequeue();
+        XLOG_EVERY_MS(INFO, 60000)
+            << "[TBE_ID" << unique_id_
+            << "] end stream queue size: " << weights_to_stream_queue_.size()
+            << " stream takes " << stop_watch.elapsed().count() << "ms";
+      }
+    });
+  }
+#endif
 }
 
 EmbeddingKVDB::~EmbeddingKVDB() {
@@ -130,7 +201,106 @@ EmbeddingKVDB::~EmbeddingKVDB() {
   if (enable_async_update_) {
     cache_filling_thread_->join();
   }
+#ifdef FBGEMM_FBCODE
+  if (enable_raw_embedding_streaming_) {
+    weights_stream_thread_->join();
+  }
+#endif
 }
+
+#ifdef FBGEMM_FBCODE
+folly::coro::Task<void> EmbeddingKVDB::tensor_stream(
+    const at::Tensor& indices,
+    const at::Tensor& weights) {
+  using namespace ::aiplatform::gmpp::experimental::training_ps;
+  if (indices.size(0) != weights.size(0)) {
+    XLOG(ERR) << "[TBE_ID" << unique_id_
+              << "] Indices and weights size mismatched " << indices.size(0)
+              << " " << weights.size(0);
+    co_return;
+  }
+  folly::stop_watch<std::chrono::milliseconds> stop_watch;
+  XLOG_EVERY_MS(INFO, 60000)
+      << "[TBE_ID" << unique_id_
+      << "] send streaming request: indices = " << indices.size(0)
+      << ", weights = " << weights.size(0);
+
+  auto biggest_idx = table_sizes_.index({table_sizes_.size(0) - 1});
+  auto mask =
+      at::logical_and(indices >= 0, indices < biggest_idx).nonzero().squeeze();
+  auto filtered_indices = indices.index_select(0, mask);
+  auto filtered_weights = weights.index_select(0, mask);
+  auto num_invalid_indices = indices.size(0) - filtered_indices.size(0);
+  if (num_invalid_indices > 0) {
+    XLOG(INFO) << "[TBE_ID" << unique_id_
+               << "] number of invalid indices: " << num_invalid_indices;
+  }
+  // 1. Transform local row indices to embedding table global row indices
+  at::Tensor table_indices =
+      (at::searchsorted(table_sizes_, filtered_indices, false, true) - 1)
+          .to(torch::kInt8);
+  auto tb_ac = table_indices.accessor<int8_t, 1>();
+  auto indices_ac = filtered_indices.accessor<int64_t, 1>();
+  auto tb_sizes_ac = table_sizes_.accessor<int64_t, 1>();
+  std::vector<int64_t> global_indices(tb_ac.size(0), 0);
+  std::vector<int16_t> shard_indices(tb_ac.size(0), 0);
+
+  for (int i = 0; i < tb_ac.size(0); ++i) {
+    int tb_idx = tb_ac[i];
+    global_indices[i] =
+        indices_ac[i] - tb_sizes_ac[tb_idx] + table_offsets_[tb_idx];
+    // hash to shard
+    // if we do row range sharding, also shard here.
+    auto fqn = table_names_[tb_idx];
+    auto hash_key = folly::to<std::string>(fqn, global_indices[i]);
+    auto shard_id =
+        furcHash(hash_key.data(), hash_key.size(), res_store_shards_);
+    shard_indices[i] = shard_id;
+  }
+  auto global_indices_tensor = at::tensor(global_indices);
+  auto shard_indices_tensor = at::tensor(shard_indices);
+  auto total_rows = global_indices_tensor.size(0);
+  XLOG_EVERY_MS(INFO, 60000)
+      << "[TBE_ID" << unique_id_ << "] hash and gloablize rows " << total_rows
+      << " in: " << stop_watch.elapsed().count() << "ms";
+  stop_watch.reset();
+
+  auto res_client = get_res_client(res_server_port_);
+  // 2. Split by shards
+  for (int i = 0; i < res_store_shards_; ++i) {
+    auto shrad_mask = shard_indices_tensor.eq(i).nonzero().squeeze();
+    auto table_indices_masked = table_indices.index_select(0, shrad_mask);
+    auto rows_in_shard = table_indices_masked.numel();
+    if (rows_in_shard == 0) {
+      continue;
+    }
+    auto global_indices_masked =
+        global_indices_tensor.index_select(0, shrad_mask);
+    auto weights_masked = filtered_weights.index_select(0, shrad_mask);
+
+    if (weights_masked.size(0) != rows_in_shard ||
+        global_indices_masked.numel() != rows_in_shard) {
+      XLOG(ERR)
+          << "[TBE_ID" << unique_id_
+          << "] don't send the request for size mismatched tensors table: "
+          << rows_in_shard << " weights: " << weights_masked.size(0)
+          << " global_indices: " << global_indices_masked.numel();
+      continue;
+    }
+    SetEmbeddingsRequest req;
+    req.shardId() = i;
+    req.fqns() = table_names_;
+
+    req.tableIndices() =
+        torch::distributed::wireDumpTensor(table_indices_masked);
+    req.rowIndices() =
+        torch::distributed::wireDumpTensor(global_indices_masked);
+    req.weights() = torch::distributed::wireDumpTensor(weights_masked);
+    co_await res_client->co_setEmbeddings(req);
+  }
+  co_return;
+}
+#endif
 
 void EmbeddingKVDB::update_cache_and_storage(
     const at::Tensor& indices,
@@ -288,9 +458,9 @@ void EmbeddingKVDB::set(
     return;
   }
 
-  // defer the L2 cache/rocksdb update to the background thread as it could be
-  // parallelized with other cuda kernels, as long as all updates are finished
-  // before the next L2 cache lookup
+  // defer the L2 cache/rocksdb update to the background thread as it could
+  // be parallelized with other cuda kernels, as long as all updates are
+  // finished before the next L2 cache lookup
   kv_db::RocksdbWriteMode write_mode = is_bwd
       ? kv_db::RocksdbWriteMode::BWD_L1_CNFLCT_MISS_WRITE_BACK
       : kv_db::RocksdbWriteMode::FWD_L1_EVICTION;
@@ -324,7 +494,8 @@ void EmbeddingKVDB::get(
   get_cache_lock_wait_duration_ +=
       facebook::WallClockUtil::NowInUsecFast() - start_ts;
 
-  // this is for unittest to repro synchronization situation deterministically
+  // this is for unittest to repro synchronization situation
+  // deterministically
   if (sleep_ms > 0) {
     std::this_thread::sleep_for(std::chrono::milliseconds(sleep_ms));
     XLOG(INFO) << "get sleep end";
@@ -347,9 +518,9 @@ void EmbeddingKVDB::get(
       get_weights_fillup_total_duration_ +=
           facebook::WallClockUtil::NowInUsecFast() - weight_fillup_start_ts;
 
-      // defer the L2 cache/rocksdb update to the background thread as it could
-      // be parallelized with other cuda kernels, as long as all updates are
-      // finished before the next L2 cache lookup
+      // defer the L2 cache/rocksdb update to the background thread as it
+      // could be parallelized with other cuda kernels, as long as all
+      // updates are finished before the next L2 cache lookup
       if (enable_async_update_) {
         auto tensor_copy_start_ts = facebook::WallClockUtil::NowInUsecFast();
         auto new_item = tensor_copy(
@@ -425,8 +596,8 @@ std::shared_ptr<CacheContext> EmbeddingKVDB::get_cache(
     folly::collect(futures).wait();
 
     // the following metrics added here as the current assumption is
-    // get_cache will only be called in get_cuda path, if assumption no longer
-    // true, we should wrap this up on the caller side
+    // get_cache will only be called in get_cuda path, if assumption no
+    // longer true, we should wrap this up on the caller side
     auto dur = facebook::WallClockUtil::NowInUsecFast() - start_ts;
     get_cache_lookup_total_duration_ += dur;
     auto cache_misses = cache_context->num_misses.load();
@@ -471,9 +642,10 @@ EmbeddingKVDB::set_cache(
   if (l2_cache_ == nullptr) {
     return folly::none;
   }
-  // TODO: consider whether need to reconstruct indices/weights/count and free
-  //       the original tensor since most of the tensor elem will be invalid,
-  //       this will trade some perf for peak DRAM util saving
+  // TODO: consider whether need to reconstruct indices/weights/count and
+  // free
+  //       the original tensor since most of the tensor elem will be
+  //       invalid, this will trade some perf for peak DRAM util saving
 
   auto cache_update_start_ts = facebook::WallClockUtil::NowInUsecFast();
 

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
@@ -136,7 +136,8 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
       int64_t cache_size_gb = 0,
       int64_t unique_id = 0,
       int64_t ele_size_bytes = 2 /*assume by default fp16*/,
-      bool enable_async_update = false);
+      bool enable_async_update = false,
+      bool enable_raw_embedding_streamnig = false);
 
   virtual ~EmbeddingKVDB();
 
@@ -418,6 +419,9 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
 
   // -- commone path
   std::atomic<int64_t> total_cache_update_duration_{0};
+
+  // -- raw embedding streaming
+  bool enable_raw_embedding_streaming_;
 }; // class EmbeddingKVDB
 
 } // namespace kv_db

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -456,6 +456,7 @@ static auto embedding_rocks_db_wrapper =
                 bool,
                 int64_t,
                 int64_t,
+                bool,
                 bool>(),
             "",
             {
@@ -479,6 +480,7 @@ static auto embedding_rocks_db_wrapper =
                 torch::arg("tbe_unique_id") = 0,
                 torch::arg("l2_cache_size_gb") = 0,
                 torch::arg("enable_async_update") = true,
+                torch::arg("enable_raw_embedding_streaming") = false,
             })
         .def(
             "set_cuda",

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -457,7 +457,12 @@ static auto embedding_rocks_db_wrapper =
                 int64_t,
                 int64_t,
                 bool,
-                bool>(),
+                bool,
+                int64_t,
+                int64_t,
+                std::vector<std::string>,
+                std::vector<int64_t>,
+                std::vector<int64_t>>(),
             "",
             {
                 torch::arg("path"),
@@ -481,6 +486,11 @@ static auto embedding_rocks_db_wrapper =
                 torch::arg("l2_cache_size_gb") = 0,
                 torch::arg("enable_async_update") = true,
                 torch::arg("enable_raw_embedding_streaming") = false,
+                torch::arg("res_store_shards") = 0,
+                torch::arg("res_server_port") = 0,
+                torch::arg("table_names") = torch::List<std::string>(),
+                torch::arg("table_offsets") = torch::List<int64_t>(),
+                torch::arg("table_sizes") = torch::List<int64_t>(),
             })
         .def(
             "set_cuda",

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -96,7 +96,12 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
       int64_t tbe_unqiue_id = 0,
       int64_t l2_cache_size_gb = 0,
       bool enable_async_update = false,
-      bool enable_raw_embedding_streaming = false)
+      bool enable_raw_embedding_streaming = false,
+      int64_t res_store_shards = 0,
+      int64_t res_server_port = 0,
+      std::vector<std::string> table_names = {},
+      std::vector<int64_t> table_offsets = {},
+      const std::vector<int64_t>& table_sizes = {})
       : kv_db::EmbeddingKVDB(
             num_shards,
             max_D,
@@ -104,7 +109,12 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
             tbe_unqiue_id,
             row_storage_bitwidth / 8,
             enable_async_update,
-            enable_raw_embedding_streaming),
+            enable_raw_embedding_streaming,
+            res_store_shards,
+            res_server_port,
+            std::move(table_names),
+            std::move(table_offsets),
+            table_sizes),
         auto_compaction_enabled_(true),
         max_D_(max_D),
         elem_size_(row_storage_bitwidth / 8) {

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -95,14 +95,16 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
       bool use_passed_in_path = false,
       int64_t tbe_unqiue_id = 0,
       int64_t l2_cache_size_gb = 0,
-      bool enable_async_update = false)
+      bool enable_async_update = false,
+      bool enable_raw_embedding_streaming = false)
       : kv_db::EmbeddingKVDB(
             num_shards,
             max_D,
             l2_cache_size_gb,
             tbe_unqiue_id,
             row_storage_bitwidth / 8,
-            enable_async_update),
+            enable_async_update,
+            enable_raw_embedding_streaming),
         auto_compaction_enabled_(true),
         max_D_(max_D),
         elem_size_(row_storage_bitwidth / 8) {

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/test/ssd_table_batched_embeddings_test.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/test/ssd_table_batched_embeddings_test.cpp
@@ -35,7 +35,8 @@ class MockEmbeddingRocksDB : public ssd::EmbeddingRocksDB {
       bool use_passed_in_path = false,
       int64_t tbe_unqiue_id = 0,
       int64_t l2_cache_size_gb = 0,
-      bool enable_async_update = false)
+      bool enable_async_update = false,
+      bool enable_raw_embedding_streaming = false)
       : ssd::EmbeddingRocksDB(
             path,
             num_shards,
@@ -56,7 +57,8 @@ class MockEmbeddingRocksDB : public ssd::EmbeddingRocksDB {
             use_passed_in_path,
             tbe_unqiue_id,
             l2_cache_size_gb,
-            enable_async_update){};
+            enable_async_update,
+            enable_raw_embedding_streaming) {}
   MOCK_METHOD(
       rocksdb::Status,
       set_rocksdb_option,


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/torchrec/pull/2930

Gated by enable_raw_embedding_streaming
Add the logic to send the passed in tensors to `TrainingParameterServerService` thrift service in EmbeddingKVDB
The passed in
- `table_names` to get the table FQN when streaming
- `table_offsets` to get the global row id across TBEs.
- `table_sizes` to get size of each table in TBE to infer which table a specific row belongs to.
- `ps_server_port` is the port that runs the local `TrainingParameterServerService` to stream tensors to.

It creates a new thread `weights_stream_thread_` in EmbeddingKBDB to stream the weights out of trainers asynchronously.

Differential Revision: D73792631


