### PR TITLE
Back out "Simplify weight row cache load and evict routines"

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/weight_row.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/weight_row.cuh
@@ -212,14 +212,16 @@ struct WeightRow {
     }
   }
 
-  DEVICE_INLINE void warp_cache_load(
+  DEVICE_INLINE void warp_copy_to_cache(
+      cache_t* dst_row,
+      const uint32_t dim_length,
       const uint32_t num_lanes,
       const uint32_t lane_id) {
     if constexpr (std::is_same_v<emb_t, cache_t>) {
       // No conversion required when emb_t and cache_t are the same type
-      for (auto d = lane_id * 4; d < dim_; d += num_lanes * 4) {
+      for (auto d = lane_id * 4; d < dim_length; d += num_lanes * 4) {
         same_type_vector_copy(
-            cache_row_ + d, reinterpret_cast<const cache_t*>(row_ + d));
+            dst_row + d, reinterpret_cast<const cache_t*>(row_ + d));
       }
     } else {
       // Load quantization params from embedding row
@@ -227,15 +229,15 @@ struct WeightRow {
 
       // Copy over for each warp-sized slice of Vec4's
       // Does 2-step conversion: weight_t -> FP32 -> cache_t
-      for (auto d = lane_id * 4; d < dim_; d += num_lanes * 4) {
+      for (auto d = lane_id * 4; d < dim_length; d += num_lanes * 4) {
         const auto slice = load(d, qparams);
-        quantize_store(
-            cache_row_ + d, slice, stoc_rounding_state_ptr_, qparams);
+        quantize_store(dst_row + d, slice, stoc_rounding_state_ptr_, qparams);
       }
     }
   }
 
-  DEVICE_INLINE void warp_cache_evict(
+  DEVICE_INLINE void warp_evict_cache(
+      const uint32_t dim_length,
       const uint32_t num_lanes,
       const uint32_t lane_id) {
     float2 qparams;
@@ -246,7 +248,7 @@ struct WeightRow {
           std::numeric_limits<at::acc_type<cache_t, true>>::lowest();
 
       // Compute the qparams from the cache row (not embedding row) weights
-      for (auto d = lane_id; d * 4 < dim_; d += num_lanes) {
+      for (auto d = lane_id; d * 4 < dim_length; d += num_lanes) {
         const auto cache_slice = load(d * 4, qparams); // qparams not used
         local_max = max(local_max, cache_slice.vmax());
         local_min = min(local_min, cache_slice.vmin());
@@ -261,7 +263,7 @@ struct WeightRow {
       }
     }
 
-    for (auto d = lane_id * 4; d < dim_; d += num_lanes * 4) {
+    for (auto d = lane_id * 4; d < dim_length; d += num_lanes * 4) {
       // Evict the slice into the embedding row
       evict_cache(d, qparams);
     }

--- a/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_populate.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_populate.cu
@@ -116,7 +116,6 @@ __global__ __launch_bounds__(kCacheMaxThreads) void lfu_cache_insert_kernel(
         if constexpr (std::is_same_v<emb_t, uint8_t>) {
           D_emb += kINT8QparamsBytes;
         }
-
         auto weight_row = WeightRow<emb_t, cache_t, cache_t>(
             &weights[weights_offset_current + idx_current * D_emb + 0],
             &lxu_cache_weights[cache_set * kWarpSize + insert_slot][0],
@@ -128,7 +127,7 @@ __global__ __launch_bounds__(kCacheMaxThreads) void lfu_cache_insert_kernel(
                     kWarpSize +
                 l);
 
-        weight_row.warp_cache_evict(blockDim.x, threadIdx.x);
+        weight_row.warp_evict_cache(D_current, blockDim.x, threadIdx.x);
       }
 
       // insert into cache
@@ -139,10 +138,14 @@ __global__ __launch_bounds__(kCacheMaxThreads) void lfu_cache_insert_kernel(
 
       auto weight_row_emb = WeightRow<emb_t, cache_t, cache_t>(
           &weights[weights_offset_insert + idx_insert * D_emb + 0],
-          &lxu_cache_weights[cache_set * kWarpSize + insert_slot][0],
+          nullptr,
           D_insert);
 
-      weight_row_emb.warp_cache_load(blockDim.x, threadIdx.x);
+      weight_row_emb.warp_copy_to_cache(
+          &lxu_cache_weights[cache_set * kWarpSize + insert_slot][0],
+          D_insert,
+          blockDim.x,
+          threadIdx.x);
 
       if (threadIdx.x == 0) {
         lxu_cache_state[cache_set][insert_slot] = insert_idx;


### PR DESCRIPTION
Summary:
Original commit changeset: c8c4e6fff8ef

- D73693209 seems to have caused regressions on the backward adagrad test for AMD, though it passes without issue on NVIDIA.

Original Phabricator Diff: D73693209

Reviewed By: sryap

Differential Revision: D73983618


