### PR TITLE
Reduce OSS CI timeout

### DIFF
--- a/.github/workflows/build_wheels_genai_linux_aarch64.yml
+++ b/.github/workflows/build_wheels_genai_linux_aarch64.yml
@@ -62,4 +62,4 @@ jobs:
       trigger-event: ${{ github.event_name }}
       architecture: aarch64
       setup-miniconda: false
-      timeout: 300
+      timeout: 60

--- a/.github/workflows/build_wheels_genai_linux_x86.yml
+++ b/.github/workflows/build_wheels_genai_linux_x86.yml
@@ -51,4 +51,4 @@ jobs:
       test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       trigger-event: ${{ github.event_name }}
-      timeout: 300
+      timeout: 120

--- a/.github/workflows/build_wheels_linux_aarch64.yml
+++ b/.github/workflows/build_wheels_linux_aarch64.yml
@@ -60,4 +60,4 @@ jobs:
       trigger-event: ${{ github.event_name }}
       architecture: aarch64
       setup-miniconda: false
-      timeout: 300
+      timeout: 240

--- a/.github/workflows/build_wheels_linux_x86.yml
+++ b/.github/workflows/build_wheels_linux_x86.yml
@@ -50,4 +50,4 @@ jobs:
       test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       trigger-event: ${{ github.event_name }}
-      timeout: 300
+      timeout: 180


### PR DESCRIPTION
Summary:
Decrease OSS CI time-out to reduce turn-around time for release in case one of the job is timed-out.

The time-out is set to 5 hours. The problem is the upload jobs are not triggered unless all build jobs are done, and currently Nova's ROCm job for py3.13 somehow takes longer than 5 hours (still under investigation). So right now, we wait for 5 hours (for ROCm job to time-out) before the wheels are released. This is particularly inefficient when we want to re-release the wheels.

Currently for Nova:
-  linux builds take at most 3 hours (py3.10 cuda 12.8 ~2 hrs 50 mins), hence setting to 3 hours.
-  linux arm build take at most 3 hours 15 mins, hence setting to 4 hours.
- GenAI linux builds take at most 50 mins (all cuda12.8 ~47 mins), setting to 2 hours (adding 1 hour buffer as we previously see longer build time)
- GenAI arm build take at most 30 mins, setting to 1 hour.

Differential Revision: D74050411


