### PR TITLE
Support building for armv8.1

### DIFF
--- a/src/FbgemmFP16UKernelsSve128.cc
+++ b/src/FbgemmFP16UKernelsSve128.cc
@@ -11,7 +11,7 @@
 namespace fbgemm {
 
 void NOINLINE gemmkernel_1x2_Sve128_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-#ifdef __aarch64__
+#if defined(__aarch64__) && __ARM_FEATURE_SVE
   asm volatile(
 
       "mov x0, %[gp]\t\n"
@@ -275,7 +275,7 @@ void NOINLINE gemmkernel_1x2_Sve128_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 
 void NOINLINE gemmkernel_2x2_Sve128_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-#ifdef __aarch64__
+#if defined(__aarch64__) && __ARM_FEATURE_SVE
   asm volatile(
 
       "mov x0, %[gp]\t\n"
@@ -612,7 +612,7 @@ void NOINLINE gemmkernel_2x2_Sve128_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 
 void NOINLINE gemmkernel_3x2_Sve128_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-#ifdef __aarch64__
+#if defined(__aarch64__) && __ARM_FEATURE_SVE
   asm volatile(
 
       "mov x0, %[gp]\t\n"
@@ -997,7 +997,7 @@ void NOINLINE gemmkernel_3x2_Sve128_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 
 void NOINLINE gemmkernel_4x2_Sve128_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-#ifdef __aarch64__
+#if defined(__aarch64__) && __ARM_FEATURE_SVE
   asm volatile(
 
       "mov x0, %[gp]\t\n"
@@ -1427,7 +1427,7 @@ void NOINLINE gemmkernel_4x2_Sve128_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 
 void NOINLINE gemmkernel_5x2_Sve128_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-#ifdef __aarch64__
+#if defined(__aarch64__) && __ARM_FEATURE_SVE
   asm volatile(
 
       "mov x0, %[gp]\t\n"
@@ -1901,7 +1901,7 @@ void NOINLINE gemmkernel_5x2_Sve128_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 
 void NOINLINE gemmkernel_6x2_Sve128_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-#ifdef __aarch64__
+#if defined(__aarch64__) && __ARM_FEATURE_SVE
   asm volatile(
 
       "mov x0, %[gp]\t\n"

--- a/src/KleidiAIFP16UKernelsNeon.cc
+++ b/src/KleidiAIFP16UKernelsNeon.cc
@@ -13,7 +13,7 @@
 namespace kleidiai {
 
 void NOINLINE gemmkernel_1x1_Neon_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-#ifdef __aarch64__
+#if defined(__aarch64__) && __ARM_FEATURE_FP16FML
   __asm__ __volatile__(
       "ldr s16, [%x[gp], %[offsetof_beta]]\n"
       "mov x25, #0x1\n"
@@ -175,7 +175,7 @@ void NOINLINE gemmkernel_1x1_Neon_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 
 void NOINLINE gemmkernel_2x1_Neon_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-#ifdef __aarch64__
+#if defined(__aarch64__) && __ARM_FEATURE_FP16FML
   __asm__ __volatile__(
       "ldr s16, [%x[gp], %[offsetof_beta]]\n"
       "mov x26, #0x1\n"
@@ -382,7 +382,7 @@ void NOINLINE gemmkernel_2x1_Neon_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 
 void NOINLINE gemmkernel_3x1_Neon_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-#ifdef __aarch64__
+#if defined(__aarch64__) && __ARM_FEATURE_FP16FML
   __asm__ __volatile__(
       "ldr s16, [%x[gp], %[offsetof_beta]]\n"
       "mov x27, #0x1\n"
@@ -630,7 +630,7 @@ void NOINLINE gemmkernel_3x1_Neon_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 
 void NOINLINE gemmkernel_4x1_Neon_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-#ifdef __aarch64__
+#if defined(__aarch64__) && __ARM_FEATURE_FP16FML
   __asm__ __volatile__(
       "ldr s16, [%x[gp], %[offsetof_beta]]\n"
       "mov x28, #0x1\n"
@@ -919,7 +919,7 @@ void NOINLINE gemmkernel_4x1_Neon_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 
 void NOINLINE gemmkernel_5x1_Neon_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-#ifdef __aarch64__
+#if defined(__aarch64__) && __ARM_FEATURE_FP16FML
   __asm__ __volatile__(
       "ldr s16, [%x[gp], %[offsetof_beta]]\n"
       "mov x9, #0x1\n"
@@ -1249,7 +1249,7 @@ void NOINLINE gemmkernel_5x1_Neon_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 
 void NOINLINE gemmkernel_6x1_Neon_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-#ifdef __aarch64__
+#if defined(__aarch64__) && __ARM_FEATURE_FP16FML
   __asm__ __volatile__(
       "ldr s16, [%x[gp], %[offsetof_beta]]\n"
       "mov x10, #0x1\n"
@@ -1618,7 +1618,7 @@ void NOINLINE gemmkernel_6x1_Neon_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 
 void NOINLINE gemmkernel_7x1_Neon_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-#ifdef __aarch64__
+#if defined(__aarch64__) && __ARM_FEATURE_FP16FML
   __asm__ __volatile__(
       "ldr s16, [%x[gp], %[offsetof_beta]]\n"
       "mov x11, #0x1\n"
@@ -2025,7 +2025,7 @@ void NOINLINE gemmkernel_7x1_Neon_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
 }
 
 void NOINLINE gemmkernel_8x1_Neon_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-#ifdef __aarch64__
+#if defined(__aarch64__) && __ARM_FEATURE_FP16FML
   __asm__ __volatile__(
       "ldr s16, [%x[gp], %[offsetof_beta]]\n"
       "mov x12, #0x1\n"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1153

- Remove explicit `-march=` compiler flags, as they're already implied by
   the toolchain:
https://www.internalfb.com/code/fbsource/[7f85b0565073]/fbcode/tools/build/buck/wrappers/defs.bzl?lines=819
- Gate SVE-specific intrinsics code with `__ARM_FEATURE_*`.

Reviewed By: rahulg

Differential Revision: D74023602


