### PR TITLE
Add external qparams parameters to mqa_attn API

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/attention/attention.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/attention.cpp
@@ -30,7 +30,9 @@ at::Tensor mqa_attn(
     at::Tensor seq_positions,
     double qk_scale,
     std::optional<int64_t> num_groups,
-    int64_t cache_logical_dtype_int);
+    int64_t cache_logical_dtype_int,
+    std::optional<at::Tensor> qparam_k,
+    std::optional<at::Tensor> qparam_v);
 
 } // namespace fbgemm_gpu::gen_ai::attention
 
@@ -48,7 +50,17 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "    int cache_logical_dtype_int=0"
       ") -> (Tensor, Tensor, Tensor)");
   m.def(
-      "mqa_attn(Tensor XQ, Tensor cache_K, Tensor cache_V, Tensor seq_positions, float qk_scale, int? num_groups=1, int cache_logical_dtype_int=0) -> Tensor");
+      "mqa_attn("
+      "    Tensor XQ, "
+      "    Tensor cache_K, "
+      "    Tensor cache_V, "
+      "    Tensor seq_positions, "
+      "    float qk_scale, "
+      "    int? num_groups=1, "
+      "    int cache_logical_dtype_int=0, "
+      "    Tensor? qparam_k=None, "
+      "    Tensor? qparam_v=None"
+      ") -> Tensor");
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {

--- a/fbgemm_gpu/experimental/gen_ai/src/attention/gqa_attn_splitk.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/gqa_attn_splitk.cu
@@ -2473,13 +2473,21 @@ at::Tensor mqa_attn(
     at::Tensor seq_positions, // [B]
     double qk_scale,
     std::optional<int64_t> num_groups,
-    int64_t cache_logical_dtype_int) {
+    int64_t cache_logical_dtype_int,
+    std::optional<at::Tensor> qparam_k,
+    std::optional<at::Tensor> qparam_v) {
   at::OptionalDeviceGuard guard(XQ.device());
   TORCH_CHECK(XQ.is_cuda());
   TORCH_CHECK(cache_K.is_cuda());
   TORCH_CHECK(cache_V.is_cuda());
   TORCH_CHECK(cache_K.is_contiguous());
   TORCH_CHECK(cache_V.is_contiguous());
+  TORCH_CHECK(
+      !qparam_k.has_value(),
+      "CUDA doesn't support external qparams in mqa_attn");
+  TORCH_CHECK(
+      !qparam_v.has_value(),
+      "CUDA doesn't support external qparams in mqa_attn");
 
   TORCH_CHECK(seq_positions.is_cuda());
 

--- a/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.cpp
@@ -205,7 +205,9 @@ at::Tensor mqa_attn(
     at::Tensor seq_positions,
     double qk_scale,
     std::optional<int64_t> num_groups,
-    int64_t cache_logical_dtype_int);
+    int64_t cache_logical_dtype_int,
+    std::optional<at::Tensor> qparam_k,
+    std::optional<at::Tensor> qparam_v);
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def("rope_qkv_varseq_prefill(Tensor XQ, Tensor(a!)? XK, Tensor? XV, Tensor(b!) cache_K, Tensor(c!) cache_V,  Tensor varseq_batch, Tensor varseq_seqpos, float theta, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(


### PR DESCRIPTION
Summary: Add external qparams parameters to mqa_attn API, which can be used by device implementations that have more strict alignment requirements.

Differential Revision: D73554137


