### PR TITLE
pipelining one_shot and two_shot allreduce

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/comm/car.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/comm/car.cpp
@@ -253,12 +253,14 @@ void one_shot_car_allreduce(
     at::Tensor dst,
     at::Tensor src,
     std::optional<at::Tensor> bias,
-    int64_t comm_idx);
+    int64_t comm_idx,
+    bool enable_pipelining);
 void two_shot_car_allreduce(
     at::Tensor dst,
     at::Tensor src,
     std::optional<at::Tensor> bias,
-    int64_t comm_idx);
+    int64_t comm_idx,
+    bool enable_pipelining);
 void car_reducescatter(
     at::Tensor dst,
     at::Tensor src,
@@ -303,10 +305,10 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.impl("car_init", car_init);
 
   m.def(
-      "one_shot_car_allreduce(Tensor(a!) dst, Tensor src, Tensor? bias=None, int comm_idx=0) -> ()");
+      "one_shot_car_allreduce(Tensor(a!) dst, Tensor src, Tensor? bias=None, int comm_idx=0, bool enable_pipelining=False) -> ()");
 
   m.def(
-      "two_shot_car_allreduce(Tensor(a!) dst, Tensor src, Tensor? bias=None, int comm_idx=0) -> ()");
+      "two_shot_car_allreduce(Tensor(a!) dst, Tensor src, Tensor? bias=None, int comm_idx=0, bool enable_pipelining=False) -> ()");
 
   m.def(
       "car_reducescatter(Tensor(a!) dst, Tensor src, bool split_last_dim=False, int comm_idx=0) -> ()");
@@ -378,7 +380,8 @@ void one_shot_car_allreduce_meta(
     at::Tensor /* dst */,
     at::Tensor /* src */,
     std::optional<at::Tensor> /* bias */,
-    int64_t /* comm_idx */) {
+    int64_t /* comm_idx */,
+    bool /* enable_pipelining */) {
   return;
 }
 
@@ -386,7 +389,8 @@ void two_shot_car_allreduce_meta(
     at::Tensor /* dst */,
     at::Tensor /* src */,
     std::optional<at::Tensor> /* bias */,
-    int64_t /* comm_idx */) {
+    int64_t /* comm_idx */,
+    bool /* enable_pipelining */) {
   return;
 }
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1165

While investigating decode perf on AMD (bs=64), allreduce is done with two_shot allreduce. ATT profiles shows significant and consecutive memory waits in the kernel:

 {F1977687098} 

This shows a clear perf problem where it does not overlap memory load with compute. And we do have many compute instructions after the these memory waits.

Examining the source code, we can see in the kernel, each thread first reads from all ranks, and then perf reduction, matching the profile where there is no overlap between loads and compute. Essentially, we are doing { read_rank0, read_rank1 ..., read_rank7, add_rank0, add_rank1, .. , add add_rank7}.

In this diff, we pipeline the reads and compute, essentially doing {read_rank0, read_rank1, add_rank0, read_rank2, add_rank1, ...}, and thus creating overlapping between memory load and compute. 

With this change, the new profile shows much fewer cycles on memory wait and we can see from the assembly code that there is clear overlap between compute and memory load

{F1977687199}

Besides two_shot allreduce, this idea also applies to one_shot.

Implementation wise, to be backward compatible, we add a optional input argument `enable_pipelining` to one_shot and two_shot API, and by default to be false. This diff does not integrate this pipelined version into E2E stack yet.

One side note: this idea should apply to NV as well, but we expect smaller gain on NV side. This is because on AMD, since there is no bf16 add instruction, we have a very long step to do bf16 add by "bf16 -> FP32 -> add in FP32 -> RTN -> bf16". So, there are way more compute instructions to overlap on AMD.

Differential Revision: D74182448


