### PR TITLE
Simplify weight row cache load and evict routines, v2

### DIFF
--- a/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_populate.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_populate.cu
@@ -116,7 +116,8 @@ __global__ __launch_bounds__(kCacheMaxThreads) void lfu_cache_insert_kernel(
         if constexpr (std::is_same_v<emb_t, uint8_t>) {
           D_emb += kINT8QparamsBytes;
         }
-        auto weight_row = WeightRow<emb_t, cache_t, cache_t>(
+
+        WeightRow<emb_t, cache_t, cache_t>(
             &weights[weights_offset_current + idx_current * D_emb + 0],
             &lxu_cache_weights[cache_set * kWarpSize + insert_slot][0],
             D_current,
@@ -125,9 +126,8 @@ __global__ __launch_bounds__(kCacheMaxThreads) void lfu_cache_insert_kernel(
             (blockIdx.x * blockDim.x * blockDim.y + threadIdx.y * blockDim.x +
              threadIdx.x) *
                     kWarpSize +
-                l);
-
-        weight_row.warp_evict_cache(D_current, blockDim.x, threadIdx.x);
+                l)
+            .warp_cache_evict(blockDim.x, threadIdx.x);
       }
 
       // insert into cache
@@ -136,16 +136,11 @@ __global__ __launch_bounds__(kCacheMaxThreads) void lfu_cache_insert_kernel(
         D_emb += kINT8QparamsBytes;
       }
 
-      auto weight_row_emb = WeightRow<emb_t, cache_t, cache_t>(
+      WeightRow<emb_t, cache_t, cache_t>(
           &weights[weights_offset_insert + idx_insert * D_emb + 0],
-          nullptr,
-          D_insert);
-
-      weight_row_emb.warp_copy_to_cache(
           &lxu_cache_weights[cache_set * kWarpSize + insert_slot][0],
-          D_insert,
-          blockDim.x,
-          threadIdx.x);
+          D_insert)
+          .warp_cache_load(blockDim.x, threadIdx.x);
 
       if (threadIdx.x == 0) {
         lxu_cache_state[cache_set][insert_slot] = insert_idx;

--- a/fbgemm_gpu/src/split_embeddings_cache/lru_cache_populate.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lru_cache_populate.cu
@@ -118,20 +118,20 @@ __global__ __launch_bounds__(kMaxThreads) void lru_cache_insert_kernel(
         const int32_t D_start_current = D_offsets[t_current];
         const int32_t D_end_current = D_offsets[t_current + 1];
         const int32_t D_current = D_end_current - D_start_current;
+
         int32_t D_emb = D_current;
         if constexpr (std::is_same_v<emb_t, uint8_t>) {
           D_emb += kINT8QparamsBytes;
         }
 
-        auto weight_row = WeightRow<emb_t, cache_t, cache_t>(
+        WeightRow<emb_t, cache_t, cache_t>(
             &weights[weights_offset_current + idx_current * D_emb + 0],
             &lxu_cache_weights[cache_set * kWarpSize + insert_slot][0],
             D_current,
             stochastic_rounding,
             &stochastic_rounding_philox_args,
-            stoc_rounding_salt + l);
-
-        weight_row.warp_evict_cache(D_current, blockDim.x, threadIdx.x);
+            stoc_rounding_salt + l)
+            .warp_cache_evict(blockDim.x, threadIdx.x);
       }
 
       int32_t D_emb = D_insert;
@@ -139,16 +139,11 @@ __global__ __launch_bounds__(kMaxThreads) void lru_cache_insert_kernel(
         D_emb += kINT8QparamsBytes;
       }
 
-      auto weight_row_emb = WeightRow<emb_t, cache_t, cache_t>(
+      WeightRow<emb_t, cache_t, cache_t>(
           &weights[weights_offset_insert + idx_insert * D_emb + 0],
-          nullptr,
-          D_insert);
-
-      weight_row_emb.warp_copy_to_cache(
           &lxu_cache_weights[cache_set * kWarpSize + insert_slot][0],
-          D_insert,
-          blockDim.x,
-          threadIdx.x);
+          D_insert)
+          .warp_cache_load(blockDim.x, threadIdx.x);
 
       if (threadIdx.x == 0) {
         lxu_cache_state[cache_set][insert_slot] = insert_idx;


### PR DESCRIPTION
Summary:
- Simplify weight row cache load and evict routines

- Address the bug that caused v1 of the diff (D73693209) to fail on AMD

Reviewed By: sryap

Differential Revision: D74227315


