### PR TITLE
update hipify_torch submodule for version 2 (#4028)

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_prelude.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_prelude.cuh
@@ -13,10 +13,10 @@
 #include <cuda.h>
 
 #ifdef __HIP_PLATFORM_AMD__
+#include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAGeneratorImpl.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <ATen/cuda/PhiloxUtils.cuh>
-
-#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h> // @manual
 #else
 #include <ATen/cuda/CUDAGraphsUtils.cuh>
 #endif
@@ -25,15 +25,9 @@
 namespace {
 
 inline int get_device_sm_cnt_() {
-#ifdef __HIP_PLATFORM_AMD__
-  hipDeviceProp_t deviceProp;
-  hipGetDeviceProperties(&deviceProp, c10::hip::current_device());
-  return deviceProp.multiProcessorCount;
-#else
   cudaDeviceProp* deviceProp =
       at::cuda::getDeviceProperties(c10::cuda::current_device());
   return deviceProp->multiProcessorCount;
-#endif
 }
 
 } // namespace

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
@@ -276,16 +276,7 @@ struct KernelLauncher {
       // transformation.
 
       auto& launch_registry =
-#ifdef __HIPCC__
-          // CUDAKernelLaunchRegistry has only been recently added to Torch
-          // HIPify mappings, so wrap this with USE_ROCM until the mappings land
-          // in PyTorch OSS.
-          //
-          // TODO: Remove when CUDAKernelLaunchRegistry lands in the nightlies
-          c10::hip::HIPKernelLaunchRegistry::get_singleton_ref();
-#else
           c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref();
-#endif
 
       // Launch the kernel
       kernel<<<grid, block, shared_mem_per_block, stream>>>(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1177

Update the hipify_torch submodule to conditionally use version 2 of the hipify mappings.


Reviewed By: spcyppt

Differential Revision: D74350676

Pulled By: q10
