### PR TITLE
Deprecate `get_device_properties` for `at::cuda::getDeviceProperties`

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/device_properties.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/device_properties.cuh
@@ -10,7 +10,6 @@
 
 #include <c10/cuda/CUDAException.h>
 #include <cuda.h>
-#include <unordered_map>
 
 namespace fbgemm_gpu::utils {
 
@@ -26,30 +25,6 @@ inline auto get_compute_versions() {
   }();
 
   return versions;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Get CUDA Device Properties
-//
-// Given a device by its ID, fetch the device properties.  This function is
-// memoized since cudaGetDeviceProperties is a very expensive operation.
-////////////////////////////////////////////////////////////////////////////////
-
-inline auto get_device_properties(const int device) {
-  // Keep as thread local to avoid race conditions (cudaGetDeviceProperties is
-  // known to be thread-safe)
-  static thread_local std::unordered_map<int, cudaDeviceProp> table;
-
-  if (const auto search = table.find(device); search != table.end()) {
-    return search->second;
-
-  } else {
-    cudaDeviceProp prop;
-    C10_CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
-
-    table.insert({device, prop});
-    return prop;
-  }
 }
 
 } // namespace fbgemm_gpu::utils

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAStream.h>
 
 #include "fbgemm_gpu/utils/device_properties.cuh"
@@ -237,7 +238,7 @@ struct KernelLauncher {
       Args&&... args) const {
     // Fetch device properties from the stream information
     const auto device = stream.device_index();
-    const auto properties = get_device_properties(device);
+    const auto properties = *at::cuda::getDeviceProperties(device);
     const auto streamId = stream.id();
 
     // Check that the grid sizes are within the range per the device associated

--- a/fbgemm_gpu/test/utils/kernel_launcher_test.cu
+++ b/fbgemm_gpu/test/utils/kernel_launcher_test.cu
@@ -14,6 +14,7 @@
 #define FBGEMM_GPU_TENSORCHECK
 
 #include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDADeviceAssertion.h>
 #include <cuda.h>
 #include <gmock/gmock.h>
@@ -275,7 +276,7 @@ TEST(KernelLauncherTest, kernel_launch_checks) {
   std::tie(A, B, C) = sample_tensors(size);
 
   const auto device = at::cuda::getCurrentCUDAStream().device_index();
-  const auto properties = get_device_properties(device);
+  const auto properties = *at::cuda::getDeviceProperties(device);
   const auto grid_max = properties.maxGridSize;
   const auto block_max = properties.maxThreadsDim;
 


### PR DESCRIPTION
Summary: - Deprecate `get_device_properties` for `at::cuda::getDeviceProperties`

Reviewed By: sryap

Differential Revision: D74356248


