### PR TITLE
Remove call to c10_retrieve_device_side_assertion_info for now

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
@@ -258,8 +258,11 @@ struct KernelLauncher {
 #else
         c10::cuda::get_cuda_check_suffix(),
 #endif
-        "\n",
-        c10::cuda::c10_retrieve_device_side_assertion_info());
+        "\n");
+    // NOTE: Re-include this after
+    // https://github.com/pytorch/pytorch/pull/153211 lands
+    //
+    // c10::cuda::c10_retrieve_device_side_assertion_info());
   }
 
   template <typename KernelFunc, typename... Args>


### PR DESCRIPTION
Summary:
- Remove call to c10_retrieve_device_side_assertion_info until
  https://github.com/pytorch/pytorch/pull/153211 lands

Reviewed By: sryap

Differential Revision: D74434669


