### PR TITLE
Add tensor_stream unit test

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/test/ssd_table_batched_embeddings_test.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/test/ssd_table_batched_embeddings_test.cpp
@@ -10,8 +10,15 @@
 #include <gtest/gtest.h>
 #include <filesystem>
 #include "deeplearning/fbgemm/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h"
+#ifdef FBGEMM_FBCODE
+#include <folly/experimental/coro/GmockHelpers.h>
+#include "aiplatform/gmpp/experimental/training_ps/gen-cpp2/TrainingParameterServerService.h"
+#include "servicerouter/client/cpp2/mocks/MockSRClientFactory.h"
+#include "thrift/lib/cpp2/util/ScopedServerInterfaceThread.h"
+#endif
 
 using namespace ::testing;
+constexpr int64_t EMBEDDING_DIMENSION = 8;
 
 class MockEmbeddingRocksDB : public ssd::EmbeddingRocksDB {
  public:
@@ -36,7 +43,12 @@ class MockEmbeddingRocksDB : public ssd::EmbeddingRocksDB {
       int64_t tbe_unqiue_id = 0,
       int64_t l2_cache_size_gb = 0,
       bool enable_async_update = false,
-      bool enable_raw_embedding_streaming = false)
+      bool enable_raw_embedding_streaming = false,
+      int64_t res_store_shards = 0,
+      int64_t res_server_port = 0,
+      std::vector<std::string> table_names = {},
+      std::vector<int64_t> table_offsets = {},
+      const std::vector<int64_t>& table_sizes = {})
       : ssd::EmbeddingRocksDB(
             path,
             num_shards,
@@ -58,7 +70,12 @@ class MockEmbeddingRocksDB : public ssd::EmbeddingRocksDB {
             tbe_unqiue_id,
             l2_cache_size_gb,
             enable_async_update,
-            enable_raw_embedding_streaming) {}
+            enable_raw_embedding_streaming,
+            res_store_shards,
+            res_server_port,
+            std::move(table_names),
+            std::move(table_offsets),
+            table_sizes) {}
   MOCK_METHOD(
       rocksdb::Status,
       set_rocksdb_option,
@@ -66,13 +83,31 @@ class MockEmbeddingRocksDB : public ssd::EmbeddingRocksDB {
       (override));
 };
 
+#ifdef FBGEMM_FBCODE
+class MockTrainingParameterServerService
+    : public ::apache::thrift::ServiceHandler<
+          aiplatform::gmpp::experimental::training_ps::
+              TrainingParameterServerService> {
+ public:
+  MOCK_METHOD(
+      folly::coro::Task<std::unique_ptr<
+          aiplatform::gmpp::experimental::training_ps::SetEmbeddingsResponse>>,
+      co_setEmbeddings,
+      (std::unique_ptr<
+          aiplatform::gmpp::experimental::training_ps::SetEmbeddingsRequest>));
+};
+#endif
+
 std::unique_ptr<MockEmbeddingRocksDB> getMockEmbeddingRocksDB(
     int num_shards,
-    std::string dir) {
+    const std::string& dir,
+    bool enable_raw_embedding_streaming = false,
+    const std::vector<std::string>& table_names = {},
+    const std::vector<int64_t>& table_offsets = {},
+    const std::vector<int64_t>& table_sizes = {}) {
   std::filesystem::path temp_dir = std::filesystem::temp_directory_path();
   std::filesystem::path rocksdb_dir = temp_dir / dir;
   std::filesystem::create_directories(rocksdb_dir);
-  auto EMBEDDING_DIMENSION = 8;
 
   return std::make_unique<MockEmbeddingRocksDB>(
       rocksdb_dir,
@@ -91,10 +126,16 @@ std::unique_ptr<MockEmbeddingRocksDB> getMockEmbeddingRocksDB(
       0.01, // uniform_init_upper,
       32, // row_storage_bitwidth = 32,
       0, // cache_size = 0
-      false,
-      0,
-      0,
-      false);
+      true, // use_passed_in_path
+      0, // tbe_unqiue_id
+      0, // l2_cache_size_gb
+      false, // enable_async_update
+      enable_raw_embedding_streaming, // enable_raw_embedding_streaming
+      3, // res_store_shards
+      0, // res_server_port
+      table_names, // table_names
+      table_offsets, // table_offsets
+      table_sizes); // table_sizes);
 }
 TEST(SSDTableBatchedEmbeddingsTest, TestToggleCompactionSuccess) {
   int num_shards = 8;
@@ -146,3 +187,61 @@ TEST(SSDTableBatchedEmbeddingsTest, TestToggleCompactionFailOnThronw) {
       { mock_embedding_rocks->toggle_compaction(true); },
       "Failed to toggle compaction to 1 with exception std::runtime_error: some error message");
 }
+
+#ifdef FBGEMM_FBCODE
+TEST(KvDbTableBatchedEmbeddingsTest, TestTensorStream) {
+  int num_shards = 8;
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+  auto mock_embedding_rocks = getMockEmbeddingRocksDB(
+      num_shards,
+      "tensor_stream",
+      true,
+      table_names,
+      table_offsets,
+      table_sizes);
+  // Mock TrainingParameterServerService
+  auto mock_service = std::make_shared<MockTrainingParameterServerService>();
+  auto mock_server =
+      std::make_shared<apache::thrift::ScopedServerInterfaceThread>(
+          mock_service,
+          "::1",
+          0,
+          facebook::services::TLSConfig::applyDefaultsToThriftServer);
+  auto& mock_client_factory =
+      facebook::servicerouter::getMockSRClientFactory(false /* strict */);
+  mock_client_factory.registerMockService(
+      "realtime.delta.publish.esr", mock_server);
+
+  auto invalid_ind = at::tensor(
+      {300, 301, 999}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {invalid_ind.size(0), EMBEDDING_DIMENSION},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  EXPECT_CALL(*mock_service, co_setEmbeddings(_)).Times(0);
+  folly::coro::blockingWait(
+      mock_embedding_rocks->tensor_stream(invalid_ind, weights));
+
+  auto ind = at::tensor(
+      {10, 2, 1, 150, 170, 230, 280},
+      at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  weights = at::randn(
+      {ind.size(0), 8},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  EXPECT_CALL(*mock_service, co_setEmbeddings(_))
+      .Times(3) // 3 shards with consistent hashing
+      .WillRepeatedly(folly::coro::gmock_helpers::CoInvoke(
+          [](std::unique_ptr<
+              aiplatform::gmpp::experimental::training_ps::SetEmbeddingsRequest>
+                 request)
+              -> folly::coro::Task<
+                  std::unique_ptr<aiplatform::gmpp::experimental::training_ps::
+                                      SetEmbeddingsResponse>> {
+            co_return std::make_unique<
+                aiplatform::gmpp::experimental::training_ps::
+                    SetEmbeddingsResponse>();
+          }));
+  folly::coro::blockingWait(mock_embedding_rocks->tensor_stream(ind, weights));
+}
+#endif


### PR DESCRIPTION
Summary:
As titled,
since the logic to be tested is guarded by FBGEMM_FBCODE flag, duplicated the test buck target to make it runs both under FBGEMM_FBCODE and without it.

Differential Revision: D74435759


