### PR TITLE
Fix illegal memory access when weights are partially empty in input combine cuda

### DIFF
--- a/fbgemm_gpu/src/input_combine_ops/input_combine.cu
+++ b/fbgemm_gpu/src/input_combine_ops/input_combine.cu
@@ -90,7 +90,7 @@ __launch_bounds__(kMaxThreads) void tbe_input_combine_with_length_kernel(
                          lengths_start + src_idx,
                          lengths_end - lengths_start);
 
-  if (per_sample_weights_addrs) {
+  if (per_sample_weights_addrs && per_sample_weights_addrs[list_id] > 0) {
     vec_copy_with_implicit_type_cast<float, float, VEC_WIDTH>(
         combined_weights,
         per_sample_weights_addrs[list_id],
@@ -124,7 +124,7 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_with_length_cuda(
   Tensor combined_lengths =
       at::empty({static_cast<int64_t>(total_lengths)}, int_options);
   // combined_weights is a float tensor
-  Tensor combined_weights = at::empty(
+  Tensor combined_weights = at::ones(
       {per_sample_weights_addrs ? static_cast<int64_t>(total_indices)
                                 : static_cast<int64_t>(0)},
       at::TensorOptions()

--- a/fbgemm_gpu/src/input_combine_ops/input_combine_gpu.cpp
+++ b/fbgemm_gpu/src/input_combine_ops/input_combine_gpu.cpp
@@ -182,6 +182,8 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_with_length_gpu(
 
       per_sample_weights_addrs[i] =
           reinterpret_cast<uint64_t>(weights.data_ptr());
+    } else {
+      per_sample_weights_addrs[i] = 0;
     }
   }
   indices_offsets[num_lists] = total_indices;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1185

InputCombine CUDA op throws error "CUDA error: an illegal memory access was encountered" when per_sample_weights contains both empty and non-empty weights, e.g., [None, None, Tensor([1.0, 2.0, 3.0])]. It is because per_sample_weights_addrs is not initialized for None weights, but its content is still copied to output. The fix is explicitly setting these pointers to 0 and avoiding copy from them.

Reviewed By: sryap

Differential Revision: D74441627


