### PR TITLE
Writeback support

### DIFF
--- a/fbgemm_gpu/test/tbe/training/failures_dict_fast.json
+++ b/fbgemm_gpu/test/tbe/training/failures_dict_fast.json
@@ -165,6 +165,10 @@
         "comment": "",
         "status": "xfail"
       },
+      "BackwardSGDTest.test_schema__test_backward_sgd_writeback": {
+        "comment": "",
+        "status": "xfail"
+      },
       "CacheTest.test_schema__test_cache_miss_counter": {
         "comment": "",
         "status": "xfail"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1187

Introduce writeback functionality to support value assignment on TBE table instead of through gradient.

The algorithm have following steps:

1. In model, construct the loss to make gradient to TBE as the  current value - target_value
2. in TBE, create a writeback prebackward hook to only keep gradient for first appearance for an index, so each index will be update exactly once
3. set SGD lr=1, so after each update the new value = current_value - 1 * (current_value - target_value) = target_value to achieve the assign objective

Differential Revision: D73644969


