### PR TITLE
Migrate `embedding_bounds_check` to `FBGEMM_LAUNCH_KERNEL`

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -921,12 +921,12 @@ Tensor {{ embedding_cuda_op }}(
             const auto grad_output_reshaped = aligned_grad_output;
             {%- endif %}
 
-            auto grad_output_accessor = MAKE_PTA_WITH_NAME(
-                "{{ embedding_cuda_op }}.1",
+            auto grad_output_accessor = PTA_B(
                 grad_output_reshaped,
-                grad_t, {{ "1" if is_index_select else "2" }},
+                grad_t,
+                {{ "1" if is_index_select else "2" }},
                 64
-            );
+            ).build("{{ embedding_cuda_op }}.1");
 
             {%- if not nobag %}
             Tensor grad_output_mean;
@@ -953,7 +953,7 @@ Tensor {{ embedding_cuda_op }}(
                     {%- endif %}
                 );
 
-                grad_output_accessor = MAKE_PTA_WITH_NAME("{{ embedding_cuda_op }}.2", grad_output_mean, grad_t, 2, 64);
+                grad_output_accessor = PTA_B(grad_output_mean, grad_t, 2, 64).build("{{ embedding_cuda_op }}.2");
             }
             {%- endif %}
 

--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_v1.cu
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_v1.cu
@@ -194,18 +194,18 @@ void _bounds_check_indices_cuda_v1(
         const auto bounds_check_kernel =
             (vbe ? bounds_check_indices_kernel_v1<index_t, true>
                  : bounds_check_indices_kernel_v1<index_t, false>);
-        TORCH_DSA_KERNEL_LAUNCH(
+        FBGEMM_LAUNCH_DSA_KERNEL(
             bounds_check_kernel,
             div_round_up(max_B_ * T, kNumThreads / fbgemm_gpu::kWarpSize),
             dim3(fbgemm_gpu::kWarpSize, kNumThreads / fbgemm_gpu::kWarpSize),
             0,
             at::cuda::getCurrentCUDAStream(),
-            MAKE_PTA_WITH_NAME(func_name, rows_per_table, int64_t, 1, 32),
-            MAKE_PTA_WITH_NAME(func_name, indices, index_t, 1, 32),
-            MAKE_PTA_WITH_NAME(func_name, offsets, index_t, 1, 32),
+            PTA_B(rows_per_table, int64_t, 1, 32),
+            PTA_B(indices, index_t, 1, 32),
+            PTA_B(offsets, index_t, 1, 32),
             vbe ? B_offsets.value().data_ptr<int32_t>() : nullptr,
             bounds_check_mode,
-            MAKE_PTA_WITH_NAME(func_name, warning, int64_t, 1, 32),
+            PTA_B(warning, int64_t, 1, 32),
             FixedDivisor(max_B_));
       });
 }

--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_v2.cu
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_v2.cu
@@ -216,18 +216,18 @@ void _bounds_check_indices_cuda_v2(
           const auto bounds_check_kernel =                                     \
               (vbe ? bounds_check_indices_kernel_v2<index_t, true, MODE>       \
                    : bounds_check_indices_kernel_v2<index_t, false, MODE>);    \
-          TORCH_DSA_KERNEL_LAUNCH(                                             \
+          FBGEMM_LAUNCH_DSA_KERNEL(                                            \
               bounds_check_kernel,                                             \
               grid_dim,                                                        \
               dim3(                                                            \
                   fbgemm_gpu::kWarpSize, kNumThreads / fbgemm_gpu::kWarpSize), \
               0,                                                               \
               at::cuda::getCurrentCUDAStream(),                                \
-              MAKE_PTA_WITH_NAME(func_name, rows_per_table, int64_t, 1, 32),   \
-              MAKE_PTA_WITH_NAME(func_name, indices, index_t, 1, 32),          \
-              MAKE_PTA_WITH_NAME(func_name, offsets, index_t, 1, 32),          \
+              PTA_B(rows_per_table, int64_t, 1, 32),                           \
+              PTA_B(indices, index_t, 1, 32),                                  \
+              PTA_B(offsets, index_t, 1, 32),                                  \
               vbe ? B_offsets.value().data_ptr<int32_t>() : nullptr,           \
-              MAKE_PTA_WITH_NAME(func_name, warning, int64_t, 1, 32),          \
+              PTA_B(warning, int64_t, 1, 32),                                  \
               FixedDivisor(B),                                                 \
               vbe ? b_t_map.value().data_ptr<int32_t>() : nullptr,             \
               info_B_num_bits,                                                 \

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/embedding_bounds_check_common.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/embedding_bounds_check_common.cuh
@@ -7,6 +7,7 @@
  */
 
 #include "fbgemm_gpu/embedding_backward_template_helpers.cuh"
+#include "fbgemm_gpu/utils/kernel_launcher.cuh"
 #include "fbgemm_gpu/utils/tensor_accessor_builder.h"
 
 #include <c10/cuda/CUDADeviceAssertion.h>


### PR DESCRIPTION
Summary: -  Migrate `embedding_bounds_check` to `FBGEMM_LAUNCH_KERNEL`

Differential Revision: D73743056


