### PR TITLE
Revert D74441627: Multisect successfully blamed "D74441627: [fbgemm_gpu][GPU preproc] Fix illegal memory access when weights are partially empty in input combine cuda" for one test failure

### DIFF
--- a/fbgemm_gpu/src/input_combine_ops/input_combine.cu
+++ b/fbgemm_gpu/src/input_combine_ops/input_combine.cu
@@ -90,7 +90,7 @@ __launch_bounds__(kMaxThreads) void tbe_input_combine_with_length_kernel(
                          lengths_start + src_idx,
                          lengths_end - lengths_start);
 
-  if (per_sample_weights_addrs && per_sample_weights_addrs[list_id] > 0) {
+  if (per_sample_weights_addrs) {
     vec_copy_with_implicit_type_cast<float, float, VEC_WIDTH>(
         combined_weights,
         per_sample_weights_addrs[list_id],
@@ -124,7 +124,7 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_with_length_cuda(
   Tensor combined_lengths =
       at::empty({static_cast<int64_t>(total_lengths)}, int_options);
   // combined_weights is a float tensor
-  Tensor combined_weights = at::ones(
+  Tensor combined_weights = at::empty(
       {per_sample_weights_addrs ? static_cast<int64_t>(total_indices)
                                 : static_cast<int64_t>(0)},
       at::TensorOptions()

--- a/fbgemm_gpu/src/input_combine_ops/input_combine_gpu.cpp
+++ b/fbgemm_gpu/src/input_combine_ops/input_combine_gpu.cpp
@@ -182,8 +182,6 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_with_length_gpu(
 
       per_sample_weights_addrs[i] =
           reinterpret_cast<uint64_t>(weights.data_ptr());
-    } else {
-      per_sample_weights_addrs[i] = 0;
     }
   }
   indices_offsets[num_lists] = total_indices;

--- a/fbgemm_gpu/test/combine/empty_weights_test.py
+++ b/fbgemm_gpu/test/combine/empty_weights_test.py
@@ -10,10 +10,9 @@
 import unittest
 
 import torch
-from fbgemm_gpu import sparse_ops  # noqa: F401
 from hypothesis import given, settings
 
-from .common import open_source, TBEInputPrepareReference
+from .common import open_source
 
 if open_source:
     # pyre-ignore[21]
@@ -24,6 +23,7 @@ else:
 
 @optests.generate_opcheck_tests()
 class EmptyWeightsTest(unittest.TestCase):
+    @unittest.skip("Fix is not implemented yet")
     # pyre-fixme[56]: Pyre was not able to infer the type of argument
     @given(device=cpu_and_maybe_gpu())
     @settings(deadline=None)
@@ -72,20 +72,11 @@ class EmptyWeightsTest(unittest.TestCase):
         ]
         arg2 = [torch.tensor(t, dtype=torch.float, device=device) for t in arg2_list]
 
-        outputs = torch.ops.fbgemm.tbe_input_combine_with_length(
+        torch.ops.fbgemm.tbe_input_combine_with_length(
             arg0,
             arg1,
             arg2,
         )
-
-        include_last_offsets = [False] * (len(arg0) - 1) + [True]
-        ref_mod = TBEInputPrepareReference(include_last_offsets)
-        ref_outputs = ref_mod(arg0, arg1, arg2)
-
-        # indices
-        self.assertTrue(ref_outputs[0].allclose(outputs[0]))
-        # per sample weights
-        self.assertTrue(ref_outputs[2].allclose(outputs[2]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
This diff reverts D74441627
D74441627: [fbgemm_gpu][GPU preproc] Fix illegal memory access when weights are partially empty in input combine cuda by coufon causes the following test failure:

Tests affected:
- [cogwheel:cogwheel_ads_gpu_preproc_accuracy_regular_run#test_dper_frontend_benchmark_local_correctness](https://www.internalfb.com/intern/test/562950163758659/)

Here's the Multisect link:
https://www.internalfb.com/multisect/27752646
Here are the tasks that are relevant to this breakage:
T223824919: Test cogwheel:cogwheel_ads_gpu_preproc_accuracy_regular_run#test_dper_frontend_benchmark_local_correctness failing for gpu_preproc_reliability

The backout may land if someone accepts it.

If this diff has been generated in error, you can Commandeer and Abandon it.

Reviewed By: coufon

Differential Revision: D74511507


