### PR TITLE
Support ordered read based on weight id in KVT

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -2026,6 +2026,22 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 dtype=dtype,
                 row_offset=table_offset,
                 snapshot_handle=snapshot_handle,
+                materialized_shape=(
+                    [bucket_ascending_id_tensor.size(0), emb_dim]
+                    if self.kv_zch_params
+                    # no_snapshot means it is for trec shardedTensor init,
+                    # we don't need to return the materialized size, in order to pass the virtual shardtensor check
+                    and not no_snapshot
+                    else None
+                ),
+                sorted_indices=(
+                    bucket_ascending_id_tensor
+                    if self.kv_zch_params
+                    # no_snapshot means it is for trec shardedTensor init,
+                    # we don't need to return the materialized size, in order to pass the virtual shardtensor check
+                    and not no_snapshot
+                    else None
+                ),
             )
             # TODO add if else support in the future for dram integration.
             tensor_wrapper.set_embedding_rocks_dp_wrapper(self.ssd_db)

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
@@ -44,7 +44,11 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
       int64_t dtype,
       int64_t row_offset,
       std::optional<c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper>>
-          snapshot_handle = std::nullopt);
+          snapshot_handle = std::nullopt,
+      std::optional<std::vector<int64_t>> materialized_shape = std::nullopt,
+      // using reference here to avoid copy, please make sure the lifetime of
+      // sorted_indices is longer than KVTensorWrapper
+      const at::Tensor& sorted_indices = at::Tensor());
 
   at::Tensor narrow(int64_t dim, int64_t start, int64_t length);
 
@@ -95,6 +99,8 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
   std::vector<int64_t> shape_;
   std::vector<int64_t> strides_;
   int64_t row_offset_;
+  std::optional<std::vector<int64_t>> materialized_shape_;
+  std::optional<at::Tensor> sorted_indices_ = std::nullopt;
 };
 
 } // namespace ssd

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper_cpu.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper_cpu.cpp
@@ -32,8 +32,10 @@ KVTensorWrapper::KVTensorWrapper(
     std::vector<int64_t> shape,
     [[maybe_unused]] int64_t dtype,
     int64_t row_offset,
-    [[maybe_unused]] std::optional<
-        c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper>> snapshot_handle)
+    [[maybe_unused]] const std::optional<
+        c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper>> snapshot_handle,
+    [[maybe_unused]] std::optional<std::vector<int64_t>> materialized_shape,
+    [[maybe_unused]] const at::Tensor& sorted_indices)
     // @lint-ignore CLANGTIDY clang-diagnostic-missing-noreturn
     : shape_(std::move(shape)), row_offset_(row_offset) {
   FBEXCEPTION("Not implemented");

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -306,9 +306,14 @@ KVTensorWrapper::KVTensorWrapper(
     std::vector<int64_t> shape,
     int64_t dtype,
     int64_t row_offset,
-    std::optional<c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper>>
-        snapshot_handle)
-    : db_(nullptr), shape_(std::move(shape)), row_offset_(row_offset) {
+    const std::optional<c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper>>
+        snapshot_handle,
+    std::optional<std::vector<int64_t>> materialized_shape,
+    const at::Tensor& sorted_indices)
+    : db_(nullptr),
+      shape_(std::move(shape)),
+      row_offset_(row_offset),
+      materialized_shape_(std::move(materialized_shape)) {
   CHECK_EQ(shape_.size(), 2) << "Only 2D emb tensors are supported";
   options_ = at::TensorOptions()
                  .dtype(static_cast<c10::ScalarType>(dtype))
@@ -317,10 +322,15 @@ KVTensorWrapper::KVTensorWrapper(
   if (snapshot_handle.has_value()) {
     snapshot_handle_ = std::move(snapshot_handle.value());
   }
+
   // derive strides details assuming contiguous tensor
   strides_ = std::vector<int64_t>(shape_.size(), 1);
   for (auto dim = shape_.size() - 1; dim > 0; --dim) {
     strides_[dim - 1] = strides_[dim] * shape_[dim];
+  }
+
+  if (sorted_indices.numel() > 0) {
+    sorted_indices_ = sorted_indices;
   }
 }
 
@@ -339,12 +349,19 @@ at::Tensor KVTensorWrapper::narrow(int64_t dim, int64_t start, int64_t length) {
   CHECK_GE(db_->get_max_D(), shape_[1]);
   CHECK_TRUE(db_ != nullptr);
   CHECK_TRUE(snapshot_handle_ != nullptr);
-  auto t = at::empty(c10::IntArrayRef({length, db_->get_max_D()}), options_);
-  db_->get_range_from_snapshot(
-      t, start + row_offset_, length, snapshot_handle_->handle);
-  // TBE may have multiple embeddings in one table padded to max D
-  // narrow to the actual shape here before returning
-  return t.narrow(1, 0, shape_[1]);
+  if (!sorted_indices_.has_value()) {
+    auto t = at::empty(c10::IntArrayRef({length, db_->get_max_D()}), options_);
+    db_->get_range_from_snapshot(
+        t, start + row_offset_, length, snapshot_handle_->handle);
+    // TBE may have multiple embeddings in one table padded to max D
+    // narrow to the actual shape here before returning
+    return t.narrow(1, 0, shape_[1]);
+  } else {
+    at::Tensor sliced_ids =
+        sorted_indices_.value().slice(0, start, start + length);
+    auto out_weights = get_weights_by_ids(sliced_ids);
+    return out_weights.narrow(1, 0, shape_[1]);
+  }
 }
 
 void KVTensorWrapper::set_range(
@@ -610,14 +627,18 @@ static auto kv_tensor_wrapper =
                 int64_t,
                 int64_t,
                 std::optional<
-                    c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper>>>(),
+                    c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper>>,
+                std::optional<std::vector<int64_t>>,
+                at::Tensor&>(),
             "",
             {torch::arg("shape"),
              torch::arg("dtype"),
              torch::arg("row_offset"),
              // snapshot must be provided for reading
              // not needed for writing
-             torch::arg("snapshot_handle") = std::nullopt})
+             torch::arg("snapshot_handle") = std::nullopt,
+             torch::arg("materialized_shape") = std::nullopt,
+             torch::arg("sorted_indices") = at::Tensor()})
         .def(
             "set_embedding_rocks_dp_wrapper",
             &KVTensorWrapper::set_embedding_rocks_dp_wrapper,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1192

if kvt is created with id, KVT will return weights following id order, instead of based on offset.
this feature can help to integrate with model state_dict, to make sure the weight and optimizer tensors are all ordered consistently with weight_id tensor

Differential Revision: D74303407


