### PR TITLE
Re-enable `c10_retrieve_device_side_assertion_info` in kernel launch check

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
@@ -258,11 +258,8 @@ struct KernelLauncher {
 #else
         c10::cuda::get_cuda_check_suffix(),
 #endif
-        "\n");
-    // NOTE: Re-include this after
-    // https://github.com/pytorch/pytorch/pull/153211 lands
-    //
-    // c10::cuda::c10_retrieve_device_side_assertion_info());
+        "\n",
+        c10::cuda::c10_retrieve_device_side_assertion_info());
   }
 
   template <typename KernelFunc, typename... Args>


### PR DESCRIPTION
Summary: - Re-enable `c10_retrieve_device_side_assertion_info` in kernel launch check

Differential Revision: D74549035


