### PR TITLE
Fix illegal memory access when weights are partially empty in input combine cuda (#4101)

### DIFF
--- a/fbgemm_gpu/src/input_combine_ops/input_combine.cu
+++ b/fbgemm_gpu/src/input_combine_ops/input_combine.cu
@@ -90,7 +90,7 @@ __launch_bounds__(kMaxThreads) void tbe_input_combine_with_length_kernel(
                          lengths_start + src_idx,
                          lengths_end - lengths_start);
 
-  if (per_sample_weights_addrs) {
+  if (per_sample_weights_addrs && per_sample_weights_addrs[list_id] > 0) {
     vec_copy_with_implicit_type_cast<float, float, VEC_WIDTH>(
         combined_weights,
         per_sample_weights_addrs[list_id],
@@ -124,9 +124,8 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_with_length_cuda(
   Tensor combined_lengths =
       at::empty({static_cast<int64_t>(total_lengths)}, int_options);
   // combined_weights is a float tensor
-  Tensor combined_weights = at::empty(
-      {per_sample_weights_addrs ? static_cast<int64_t>(total_indices)
-                                : static_cast<int64_t>(0)},
+  Tensor combined_weights = at::ones(
+      {per_sample_weights_addrs ? static_cast<int64_t>(total_indices) : 0},
       at::TensorOptions()
           .dtype(at::kFloat)
           .device(at::kCUDA, at::cuda::current_device()));

--- a/fbgemm_gpu/src/input_combine_ops/input_combine_gpu.cpp
+++ b/fbgemm_gpu/src/input_combine_ops/input_combine_gpu.cpp
@@ -182,6 +182,8 @@ std::tuple<Tensor, Tensor, Tensor> tbe_input_combine_with_length_gpu(
 
       per_sample_weights_addrs[i] =
           reinterpret_cast<uint64_t>(weights.data_ptr());
+    } else if (need_weights) {
+      per_sample_weights_addrs[i] = 0;
     }
   }
   indices_offsets[num_lists] = total_indices;

--- a/fbgemm_gpu/test/combine/empty_weights_test.py
+++ b/fbgemm_gpu/test/combine/empty_weights_test.py
@@ -10,9 +10,10 @@
 import unittest
 
 import torch
+from fbgemm_gpu import sparse_ops  # noqa: F401
 from hypothesis import given, settings
 
-from .common import open_source
+from .common import open_source, TBEInputPrepareReference
 
 if open_source:
     # pyre-ignore[21]
@@ -23,13 +24,10 @@ else:
 
 @optests.generate_opcheck_tests()
 class EmptyWeightsTest(unittest.TestCase):
-    @unittest.skip("Fix is not implemented yet")
-    # pyre-fixme[56]: Pyre was not able to infer the type of argument
-    @given(device=cpu_and_maybe_gpu())
-    @settings(deadline=None)
-    def test_tbe_input_combine_with_length_empty_weights(
-        self, device: torch.device
-    ) -> None:
+
+    def _get_inputs(
+        self, device: torch.device, all_weights_empty: bool
+    ) -> tuple[list[torch.Tensor], list[torch.Tensor], list[torch.Tensor]]:
         arg0_list = [
             [88, 55],
             [80, 29],
@@ -58,25 +56,60 @@ class EmptyWeightsTest(unittest.TestCase):
         ]
         arg1 = [torch.tensor(t, dtype=torch.int32, device=device) for t in arg1_list]
 
-        arg2_list = [
-            [],
-            [],
-            [],
-            [],
-            [3.0, 3.0],
-            [],
-            [],
-            [3.0, 3.0],
-            [3.0, 3.0],
-            [],
-        ]
+        if all_weights_empty:
+            arg2_list = [[] for _ in range(len(arg0))]
+        else:
+            arg2_list = [
+                [],
+                [],
+                [],
+                [],
+                [3.0, 3.0],
+                [],
+                [],
+                [3.0, 3.0],
+                [3.0, 3.0],
+                [],
+            ]
         arg2 = [torch.tensor(t, dtype=torch.float, device=device) for t in arg2_list]
 
-        torch.ops.fbgemm.tbe_input_combine_with_length(
-            arg0,
-            arg1,
-            arg2,
-        )
+        return (arg0, arg1, arg2)
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @given(device=cpu_and_maybe_gpu())
+    @settings(deadline=None)
+    def test_tbe_input_combine_with_length_partially_empty_weights(
+        self, device: torch.device
+    ) -> None:
+        arg0, arg1, arg2 = self._get_inputs(device, all_weights_empty=False)
+        outputs = torch.ops.fbgemm.tbe_input_combine_with_length(arg0, arg1, arg2)
+
+        include_last_offsets = [False] * (len(arg0) - 1) + [True]
+        ref_mod = TBEInputPrepareReference(include_last_offsets)
+        ref_outputs = ref_mod(arg0, arg1, arg2)
+
+        # indices
+        self.assertTrue(ref_outputs[0].allclose(outputs[0]))
+        # per sample weights
+        self.assertTrue(ref_outputs[2].allclose(outputs[2]))
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @given(device=cpu_and_maybe_gpu())
+    @settings(deadline=None)
+    def test_tbe_input_combine_with_length_all_empty_weights(
+        self, device: torch.device
+    ) -> None:
+        arg0, arg1, arg2 = self._get_inputs(device, all_weights_empty=True)
+        outputs = torch.ops.fbgemm.tbe_input_combine_with_length(arg0, arg1, arg2)
+
+        include_last_offsets = [False] * (len(arg0) - 1) + [True]
+        ref_mod = TBEInputPrepareReference(include_last_offsets)
+        ref_outputs = ref_mod(arg0, arg1, arg2)
+
+        # indices
+        self.assertTrue(ref_outputs[0].allclose(outputs[0]))
+        # per sample weights
+        self.assertEqual(outputs[2].numel(), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/1185

InputCombine CUDA op throws error "CUDA error: an illegal memory access was encountered" when per_sample_weights contains both empty and non-empty weights, e.g., [None, None, Tensor([1.0, 2.0, 3.0])]. It is because per_sample_weights_addrs is not initialized for None weights, but its content is still copied to output. The fix is explicitly setting these pointers to 0 and avoiding copy from them.

Re-submit a previous trial D74441627 (https://github.com/pytorch/FBGEMM/pull/4101, https://github.com/facebookresearch/FBGEMM/pull/1185). Fixed a bug that when need_weights is false (all weights are empty), per_sample_weights_addrs is null but still set to 0. Added a unit test to cover this case.

Differential Revision: D74546552


