### PR TITLE
Fix computation of maxIndex in EEG

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/bench/eeg_cli.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/bench/eeg_cli.py
@@ -65,7 +65,7 @@ def estimate(indices: str) -> None:
     "--max-index",
     type=int,
     default=20,
-    help="Max index value (E)",
+    help="Max index value (< E)",
 )
 @click.option(
     "-n",

--- a/fbgemm_gpu/src/tbe/eeg/eeg_models.h
+++ b/fbgemm_gpu/src/tbe/eeg/eeg_models.h
@@ -57,7 +57,8 @@ struct IndicesDistributionParameters {
   // Parameters for the Zipf distribution (x+q)^{-s}
   ZipfParameters zipfParams;
 
-  // Max index value (i.e. number of rows in the embedding table, or E)
+  // Max index value in the distribution - should be in the range [0, E), where
+  // E is the number of rows in the embedding table
   int64_t maxIndex;
 
   // Number of indices to generate

--- a/fbgemm_gpu/src/tbe/eeg/indices_estimator.cpp
+++ b/fbgemm_gpu/src/tbe/eeg/indices_estimator.cpp
@@ -15,10 +15,29 @@
 
 namespace fbgemm_gpu::tbe {
 
-// Helper: log table computation for fast maximum likelihood estimation
-void IndicesEstimator::computeLogTable_() {
-  auto maxIndex = freqs_.size();
-  logTable_.resize((maxIndex + kMaxQ + 1) * kLevels_);
+void IndicesEstimator::populateIndexFreqs_(const torch::Tensor& indices) {
+  // Count the frequency of indices
+  const auto* data = indices.data_ptr<int64_t>();
+  for (auto i = 0; i < indices.numel(); i++) {
+    const auto idx = data[i];
+    indexCounts_[idx] += 1;
+  }
+
+  // Collect the frequencies
+  for (const auto& [_, count] : indexCounts_) {
+    freqs_.emplace_back(static_cast<double>(count));
+  }
+
+  // Sort and normalize the frequencies
+  std::sort(std::begin(freqs_), std::end(freqs_), std::greater{});
+  auto normalize_const = std::reduce(std::begin(freqs_), std::end(freqs_));
+  for (auto& freq : freqs_) {
+    freq /= normalize_const;
+  }
+}
+
+void IndicesEstimator::populateLogTable_() {
+  logTable_.resize((maxIndex() + kMaxQ + 1) * kLevels_);
   double cur = 1.0;
   for (int64_t i = 0; i < logTable_.size(); ++i) {
     logTable_[i] = log(cur);
@@ -27,35 +46,20 @@ void IndicesEstimator::computeLogTable_() {
 }
 
 IndicesEstimator::IndicesEstimator(const torch::Tensor& indices) {
-  tensor_ = indices;
-  assert(
-      (tensor_.dtype().itemsize() == 8) &&
-      "Indices are abnormal, not 8 byte each");
+  TORCH_CHECK(
+      indices.numel() > 0, "indices numel is ", indices.numel(), "(< 1)");
 
-  indices_ = std::vector<int64_t>{
-      tensor_.data_ptr<int64_t>(),
-      tensor_.data_ptr<int64_t>() + tensor_.numel()};
-  assert(
-      !indices_.empty() &&
-      "No indices found in the tensor, not possible to run estimation!");
+  TORCH_CHECK(
+      indices.dtype() == at::kLong,
+      "indices dtype is ",
+      indices.dtype(),
+      "(!= I64)");
 
-  // Setup the frequency data structures
-  for (auto idx : indices_) {
-    indexToLocations_[idx].emplace_back(idx);
-  }
+  // Populate the index frequencies
+  populateIndexFreqs_(indices);
 
-  for (const auto& item : indexToLocations_) {
-    freqs_.emplace_back(static_cast<double>(item.second.size()));
-  }
-
-  // Sort the frequencies into descending order and normalize
-  std::sort(std::begin(freqs_), std::end(freqs_), std::greater{});
-  auto normalize_const = std::reduce(std::begin(freqs_), std::end(freqs_));
-  std::for_each(std::begin(freqs_), std::end(freqs_), [=](double& freq) {
-    freq /= normalize_const;
-  });
-
-  computeLogTable_();
+  // Populate the log table
+  populateLogTable_();
 }
 
 IndicesEstimator::IndicesEstimator(const std::filesystem::path& tensors_path) {
@@ -78,40 +82,52 @@ IndicesEstimator::IndicesEstimator(const std::filesystem::path& tensors_path) {
   IndicesEstimator(ival.toTensor());
 }
 
-std::vector<double> IndicesEstimator::estimateHeavyHitters_() {
-  std::vector<double> heavyHitters;
+std::vector<double> IndicesEstimator::heavyHitters() const {
+  std::vector<double> hitters;
+
   double cdf = 0.0;
   for (int i = 0; i < kHeavyHitterMaxEntries_; ++i) {
-    heavyHitters.emplace_back(freqs_[i]);
+    hitters.emplace_back(freqs_[i]);
     cdf += freqs_[i];
     if (cdf > kHeavyHitterThreshold_) {
       break;
     }
   }
-  return heavyHitters;
+
+  return hitters;
 }
 
-std::optional<IndicesDistributionParameters> IndicesEstimator::estimate() {
-  if (indices_.empty()) {
-    return std::nullopt;
+int64_t IndicesEstimator::numIndices() const {
+  int64_t sum = 0;
+  for (const auto& [_, value] : indexCounts_) {
+    sum += value;
+  }
+  return sum;
+}
+
+int64_t IndicesEstimator::maxIndex() const {
+  if (!cacheMaxIndex_.has_value()) {
+    cacheMaxIndex_ =
+        std::max_element(
+            indexCounts_.begin(),
+            indexCounts_.end(),
+            [](const auto& a, const auto& b) { return a.first < b.first; })
+            ->first;
   }
 
-  using timer = std::chrono::high_resolution_clock;
-  using us = std::chrono::microseconds;
+  return *cacheMaxIndex_;
+}
 
-  auto t0 = timer::now();
-  IndicesDistributionParameters params;
-  // First get the heavy hitters
-  params.heavyHitters = estimateHeavyHitters_();
-  params.maxIndex = freqs_.size() - 1;
-  params.numIndices = indices_.size();
-  auto zipfStart = params.heavyHitters.size();
+ZipfParameters IndicesEstimator::zipfParams(
+    const std::vector<double>& heavyHitters) const {
+  ZipfParameters zipfParams;
+
+  auto zipfStart = heavyHitters.size();
 
   // Now do the MLE estimation conditioned on the rest
   auto zipfTotalFreq =
       std::reduce(std::begin(freqs_) + zipfStart, std::end(freqs_));
-  double maxLogLikelihood = -std::numeric_limits<double>::infinity();
-  ZipfParameters zipfParams;
+  auto maxLogLikelihood = -std::numeric_limits<double>::infinity();
 
   // Sweep over q in outer loop, and s in the inner
   // loop since q requires recomputing inner products
@@ -125,15 +141,18 @@ std::optional<IndicesDistributionParameters> IndicesEstimator::estimate() {
   static constexpr double kHeavyHitterUpperBound_ = 5.0;
   static constexpr double kHeavyHitterLowerBound_ = 1.0;
 
-  double minHeavyHitterProb = params.heavyHitters.back();
+  double minHeavyHitterProb = heavyHitters.back();
   double qIncr = 1.0;
+
   for (double q = 1.0; q < kMaxQ; q += qIncr) {
     double freqTerm = 0.0;
     long logTableIdx = lrint((zipfStart + q) * kLevels_ - 1);
+
     for (int64_t k = zipfStart; k < freqs_.size();
          ++k, logTableIdx += kLevels_) {
       freqTerm -= freqs_[k] * logTable_[logTableIdx];
     }
+
     for (double s = kMinS_; s < kMaxS_; s += kSStep_) {
       // Consistency test before proceeding with estimate.
       double normalizeConst =
@@ -141,6 +160,7 @@ std::optional<IndicesDistributionParameters> IndicesEstimator::estimate() {
       double zipfMaxProb =
           (zipfTotalFreq / normalizeConst) * std::pow(q + zipfStart, -s);
       double ratio = minHeavyHitterProb / zipfMaxProb;
+
       if ((ratio < kHeavyHitterLowerBound_) ||
           (ratio > kHeavyHitterUpperBound_)) {
         std::cout << "Skipping (s,q) (" << s << ", " << q
@@ -158,18 +178,39 @@ std::optional<IndicesDistributionParameters> IndicesEstimator::estimate() {
         zipfParams.s = s;
       }
     }
+
     qIncr = exp10(std::floor(std::log10(q))) / kQSweepGranularity_;
   }
 
-  params.zipfParams = zipfParams;
+  return zipfParams;
+}
+
+std::optional<IndicesDistributionParameters> IndicesEstimator::estimate()
+    const {
+  if (indexCounts_.empty()) {
+    return std::nullopt;
+  }
+
+  using timer = std::chrono::high_resolution_clock;
+  using us = std::chrono::microseconds;
+  auto t0 = timer::now();
+
+  const auto hitters = heavyHitters();
+  auto params = IndicesDistributionParameters{
+      hitters,
+      zipfParams(hitters),
+      maxIndex(),
+      numIndices(),
+  };
+
   auto t1 = timer::now();
   std::cout << "Time taken to estimate parameters (us): "
             << std::chrono::duration_cast<us>(t1 - t0).count() << "\n";
   return params;
 }
 
-double IndicesEstimator::getEstimateQuality(
-    const IndicesDistributionParameters& params) {
+double IndicesEstimator::estimateQuality(
+    const IndicesDistributionParameters& params) const {
   // KL divergence between the true indices distribution and the estimated one
   // (in bits)
   const auto zipfStart = params.heavyHitters.size();
@@ -186,15 +227,18 @@ double IndicesEstimator::getEstimateQuality(
     if (trueProb == 0.0) {
       continue;
     }
-    double estProb;
+
+    double estProb = 1; // Initializing to 1 to silence lint errors
     if (i < zipfStart) {
       estProb = params.heavyHitters[i];
     } else {
       estProb = (zipfTotalFreq / normalizeConst) *
           std::pow(params.zipfParams.q + i, -params.zipfParams.s);
     }
+
     kl += trueProb * std::log2(trueProb / estProb);
   }
+
   return kl;
 }
 

--- a/fbgemm_gpu/src/tbe/eeg/indices_estimator.h
+++ b/fbgemm_gpu/src/tbe/eeg/indices_estimator.h
@@ -30,11 +30,11 @@ class IndicesEstimator {
 
   // maximum likelihood estimate of the heavy hitters + Zipf parameters
   // Returns std::nullopt if there is no index data
-  std::optional<IndicesDistributionParameters> estimate();
+  std::optional<IndicesDistributionParameters> estimate() const;
 
   // Quality of the fit, measured by KL divergence to a set of parameters. Lower
   // score is better, with best possible score of 0.0.
-  double getEstimateQuality(const IndicesDistributionParameters& params);
+  double estimateQuality(const IndicesDistributionParameters& params) const;
 
  private:
   // Hardcoded parameters
@@ -61,29 +61,41 @@ class IndicesEstimator {
       kLevels_ % kQSweepGranularity_ == 0,
       "kLevels_ must be a multiple of kQSweepGranularity_");
   static constexpr auto kMaxQ = 100000; // Maximum q over which we sweep over
-  std::vector<double> logTable_;
-
-  // containers for the raw index data
-  std::vector<int64_t> indices_;
-  torch::Tensor tensor_;
 
   // index to locations/frequencies data
 #ifdef FBGEMM_USE_FOLLY
-  folly::F14FastMap<int64_t, std::vector<int64_t>> indexToLocations_;
+  folly::F14FastMap<int64_t, int64_t> indexCounts_;
 #else
-  std::map<int64_t, std::vector<int64_t>> indexToLocations_;
+  std::map<int64_t, int64_t> indexCounts_;
 #endif
 
   // After constructor is called, freqs_ is kept in descending order and is
   // normalized to sum up to one
   std::vector<double> freqs_;
 
-  // Estimate the heavy hitters. Returns a vector containing their
-  // probabilities.
-  std::vector<double> estimateHeavyHitters_();
+  // Stores the log table for fast computation of maximum likelihood estimation
+  std::vector<double> logTable_;
 
-  // Fill the log table.
-  void computeLogTable_();
+  // Cache of the computed max index value
+  mutable std::optional<int64_t> cacheMaxIndex_;
+
+  // Populate the index frequencies
+  void populateIndexFreqs_(const torch::Tensor&);
+
+  // Populate the log table from the index frequencies
+  void populateLogTable_();
+
+  // Returns a vector containing the probabilities of the heavy hitters
+  std::vector<double> heavyHitters() const;
+
+  // Returns the number of indices used to estimate the distribution
+  int64_t numIndices() const;
+
+  // Returns the max index value in the indices data
+  int64_t maxIndex() const;
+
+  // Returns zipf parameters used to fit the distribution
+  ZipfParameters zipfParams(const std::vector<double>&) const;
 };
 
 } // namespace fbgemm_gpu::tbe


### PR DESCRIPTION
Summary: - Fix computation of maxIndex in EEG.  Previously it was set to be the number of index buckets, now it is set to be the max index value

Differential Revision: D74551158


