### PR TITLE
introduce kernel for converting e4m3fn kv_cache to e4m3fnuz

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.h
@@ -193,4 +193,10 @@ at::Tensor mqa_attn(
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> qparam_v);
 
+void convert_e4m3fn_kv_cache_to_e4m3fnuz_inplace(
+    at::Tensor cache_K,
+    at::Tensor cache_V,
+    at::Tensor qparam_K,
+    at::Tensor qparam_v);
+
 } // namespace fbgemm_gpu


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1197

As titled. NV uses e4m3fn for fp8 KV cache, and AMD uses e4m3fnuz. If we want to do HH serving with NV prefill and AMD decode, we need a way to convert between the two.

In practice this can be done with two operations: overwriting -0 (which are valid in e4m3fn but not in uz) with +0, and multiplying the scale qparam by 2, since the exponent bias differs by 1 between the two formats. The scale qparam is packed as the low bits of a __half2 (fp16x2).

Differential Revision: D74502334


