### PR TITLE
Add meta functions for cache ops

### DIFF
--- a/fbgemm_gpu/src/split_embeddings_cache/common.h
+++ b/fbgemm_gpu/src/split_embeddings_cache/common.h
@@ -33,6 +33,14 @@ Tensor linearize_cache_indices_cpu(
     const int64_t max_B,
     const int64_t indices_base_offset);
 
+Tensor linearize_cache_indices_meta(
+    const Tensor& cache_hash_size_cumsum,
+    const Tensor& indices,
+    const Tensor& offsets,
+    const std::optional<Tensor>& B_offsets,
+    const int64_t max_B,
+    const int64_t indices_base_offset);
+
 Tensor linearize_cache_indices_from_row_idx_cpu(
     Tensor cache_hash_size_cumsum,
     Tensor update_table_indices,
@@ -88,6 +96,15 @@ void lfu_cache_populate_byte_cpu(
     int64_t row_alignment);
 
 Tensor lxu_cache_lookup_cpu(
+    Tensor linear_cache_indices,
+    Tensor lxu_cache_state,
+    int64_t invalid_index,
+    bool gather_cache_stats,
+    std::optional<Tensor> uvm_cache_stats,
+    std::optional<Tensor> num_uniq_cache_indices,
+    std::optional<Tensor> lxu_cache_locations_output);
+
+Tensor lxu_cache_lookup_meta(
     Tensor linear_cache_indices,
     Tensor lxu_cache_state,
     int64_t invalid_index,

--- a/fbgemm_gpu/src/split_embeddings_cache/linearize_cache_indices.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/linearize_cache_indices.cpp
@@ -29,4 +29,14 @@ DLL_PUBLIC Tensor linearize_cache_indices_from_row_idx_cpu(
   return at::empty_like(update_row_indices);
 }
 
+DLL_PUBLIC Tensor linearize_cache_indices_meta(
+    const Tensor& /*cache_hash_size_cumsum*/,
+    const Tensor& indices,
+    const Tensor& /*offsets*/,
+    const std::optional<Tensor>& /*B_offsets*/,
+    const int64_t /*max_B*/,
+    const int64_t /*indices_base_offset*/) {
+  return at::empty_like(indices, indices.options().dtype(at::kLong));
+}
+
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/split_embeddings_cache/lxu_cache.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/lxu_cache.cpp
@@ -34,4 +34,16 @@ DLL_PUBLIC Tensor direct_mapped_lxu_cache_lookup_cpu(
       linear_cache_indices, linear_cache_indices.options().dtype(at::kInt));
 }
 
+DLL_PUBLIC Tensor lxu_cache_lookup_meta(
+    Tensor linear_cache_indices,
+    Tensor /* lxu_cache_state */,
+    int64_t /* invalid_index */,
+    bool /* gather_cache_stats */,
+    std::optional<Tensor> /* uvm_cache_stats */,
+    std::optional<Tensor> /* num_uniq_cache_indices */,
+    std::optional<Tensor> lxu_cache_locations_output) {
+  return lxu_cache_locations_output.value_or(empty_like(
+      linear_cache_indices, linear_cache_indices.options().dtype(at::kInt)));
+}
+
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/split_embeddings_cache_ops.cpp
@@ -68,6 +68,9 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   DISPATCH_TO_CPU("lxu_cache_lookup", lxu_cache_lookup_cpu);
   DISPATCH_TO_CPU(
       "direct_mapped_lxu_cache_lookup", direct_mapped_lxu_cache_lookup_cpu);
+
+  DISPATCH_TO_META("linearize_cache_indices", linearize_cache_indices_meta);
+  DISPATCH_TO_META("lxu_cache_lookup", lxu_cache_lookup_meta);
 }
 
 } // namespace

--- a/fbgemm_gpu/test/tbe/cache/failures_dict_fast.json
+++ b/fbgemm_gpu/test/tbe/cache/failures_dict_fast.json
@@ -72,68 +72,7 @@
         "status": "xfail"
       }
     },
-    "fbgemm::linearize_cache_indices": {
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmMEAN": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmNONE": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmSUM": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmMEAN": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmNONE": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmSUM": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardSGDTest.test_faketensor__test_backward_sgd": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardSGDTest.test_faketensor__test_backward_sgd_really_long_segments": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "CacheTest.test_faketensor__test_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "LXUCacheTest.test_faketensor__test_unique_lxu_cache_lookup": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "LinearizeCacheIndicesTest.test_faketensor__test_linearize_cache_indices": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitCacheTest.test_faketensor__test_nbit_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitForwardTest.test_faketensor__test_nbit_forward_uvm_cache": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitSplitEmbeddingsTest.test_faketensor__test_int_nbit_split_embedding_uvm_caching_codegen_lookup_function": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_stb_uvm_cache_stats": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
+    "fbgemm::linearize_cache_indices": {},
     "fbgemm::linearize_cache_indices_from_row_idx": {
       "LinearizeCacheIndicesTest.test_faketensor__test_linearize_cache_indices_from_row_idx": {
         "comment": "",
@@ -186,67 +125,7 @@
     "fbgemm::lxu_cache_flush": {},
     "fbgemm::lxu_cache_locking_counter_decrement": {},
     "fbgemm::lxu_cache_lookup": {
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmMEAN": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmNONE": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmSUM": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmMEAN": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmNONE": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmSUM": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardSGDTest.test_faketensor__test_backward_sgd": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardSGDTest.test_faketensor__test_backward_sgd_really_long_segments": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "CacheTest.test_faketensor__test_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
       "CacheTest.test_schema__test_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "LXUCacheTest.test_faketensor__test_lxu_cache_lookup": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "LXUCacheTest.test_faketensor__test_unique_lxu_cache_lookup": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitCacheTest.test_faketensor__test_nbit_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitForwardTest.test_faketensor__test_nbit_forward_uvm_cache": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitSplitEmbeddingsTest.test_faketensor__test_int_nbit_split_embedding_uvm_caching_codegen_lookup_function": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_stb_uvm_cache_stats": {
         "comment": "",
         "status": "xfail"
       }

--- a/fbgemm_gpu/test/tbe/inference/failures_dict_fast.json
+++ b/fbgemm_gpu/test/tbe/inference/failures_dict_fast.json
@@ -87,68 +87,7 @@
         "status": "xfail"
       }
     },
-    "fbgemm::linearize_cache_indices": {
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmMEAN": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmNONE": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmSUM": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmMEAN": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmNONE": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmSUM": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardSGDTest.test_faketensor__test_backward_sgd": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardSGDTest.test_faketensor__test_backward_sgd_really_long_segments": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "CacheTest.test_faketensor__test_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "LXUCacheTest.test_faketensor__test_unique_lxu_cache_lookup": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "LinearizeCacheIndicesTest.test_faketensor__test_linearize_cache_indices": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitCacheTest.test_faketensor__test_nbit_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitForwardTest.test_faketensor__test_nbit_forward_uvm_cache": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitSplitEmbeddingsTest.test_faketensor__test_int_nbit_split_embedding_uvm_caching_codegen_lookup_function": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_stb_uvm_cache_stats": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
+    "fbgemm::linearize_cache_indices": {},
     "fbgemm::linearize_cache_indices_from_row_idx": {
       "LinearizeCacheIndicesTest.test_faketensor__test_linearize_cache_indices_from_row_idx": {
         "comment": "",
@@ -200,68 +139,7 @@
     "fbgemm::lru_cache_populate_byte": {},
     "fbgemm::lxu_cache_flush": {},
     "fbgemm::lxu_cache_locking_counter_decrement": {},
-    "fbgemm::lxu_cache_lookup": {
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmMEAN": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmNONE": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmSUM": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmMEAN": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmNONE": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmSUM": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardSGDTest.test_faketensor__test_backward_sgd": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardSGDTest.test_faketensor__test_backward_sgd_really_long_segments": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "CacheTest.test_faketensor__test_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "LXUCacheTest.test_faketensor__test_lxu_cache_lookup": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "LXUCacheTest.test_faketensor__test_unique_lxu_cache_lookup": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitCacheTest.test_faketensor__test_nbit_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitForwardTest.test_faketensor__test_nbit_forward_uvm_cache": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitSplitEmbeddingsTest.test_faketensor__test_int_nbit_split_embedding_uvm_caching_codegen_lookup_function": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_stb_uvm_cache_stats": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
+    "fbgemm::lxu_cache_lookup": {},
     "fbgemm::new_managed_tensor": {},
     "fbgemm::new_unified_tensor": {
       "NBitForwardTest.test_faketensor__test_nbit_forward_gpu_no_cache": {

--- a/fbgemm_gpu/test/tbe/training/failures_dict_fast.json
+++ b/fbgemm_gpu/test/tbe/training/failures_dict_fast.json
@@ -76,76 +76,7 @@
         "status": "xfail"
       }
     },
-    "fbgemm::linearize_cache_indices": {
-      "BackwardAdagradLargeDimTest.test_faketensor__test_backward_adagrad_large_dims": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmMEAN": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmNONE": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmSUM": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmSUM_with_max_norm": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmMEAN": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmNONE": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmSUM": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardSGDTest.test_faketensor__test_backward_sgd": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardSGDTest.test_faketensor__test_backward_sgd_really_long_segments": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "CacheTest.test_faketensor__test_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "LXUCacheTest.test_faketensor__test_unique_lxu_cache_lookup": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "LinearizeCacheIndicesTest.test_faketensor__test_linearize_cache_indices": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitCacheTest.test_faketensor__test_nbit_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitForwardTest.test_faketensor__test_nbit_forward_uvm_cache": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitSplitEmbeddingsTest.test_faketensor__test_int_nbit_split_embedding_uvm_caching_codegen_lookup_function": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_stb_uvm_cache_stats": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
+    "fbgemm::linearize_cache_indices": {},
     "fbgemm::linearize_cache_indices_from_row_idx": {
       "LinearizeCacheIndicesTest.test_faketensor__test_linearize_cache_indices_from_row_idx": {
         "comment": "",
@@ -198,39 +129,7 @@
     "fbgemm::lxu_cache_flush": {},
     "fbgemm::lxu_cache_locking_counter_decrement": {},
     "fbgemm::lxu_cache_lookup": {
-      "BackwardAdagradLargeDimTest.test_faketensor__test_backward_adagrad_large_dims": {
-        "comment": "",
-        "status": "xfail"
-      },
       "BackwardAdagradLargeDimTest.test_schema__test_backward_adagrad_large_dims": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmMEAN": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmNONE": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmSUM": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmSUM_with_max_norm": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmMEAN": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmNONE": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmSUM": {
         "comment": "",
         "status": "xfail"
       },
@@ -258,14 +157,6 @@
         "comment": "",
         "status": "xfail"
       },
-      "BackwardSGDTest.test_faketensor__test_backward_sgd": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardSGDTest.test_faketensor__test_backward_sgd_really_long_segments": {
-        "comment": "",
-        "status": "xfail"
-      },
       "BackwardSGDTest.test_schema__test_backward_sgd": {
         "comment": "",
         "status": "xfail"
@@ -274,35 +165,7 @@
         "comment": "",
         "status": "xfail"
       },
-      "CacheTest.test_faketensor__test_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
       "CacheTest.test_schema__test_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "LXUCacheTest.test_faketensor__test_lxu_cache_lookup": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "LXUCacheTest.test_faketensor__test_unique_lxu_cache_lookup": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitCacheTest.test_faketensor__test_nbit_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitForwardTest.test_faketensor__test_nbit_forward_uvm_cache": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitSplitEmbeddingsTest.test_faketensor__test_int_nbit_split_embedding_uvm_caching_codegen_lookup_function": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_stb_uvm_cache_stats": {
         "comment": "",
         "status": "xfail"
       },

--- a/fbgemm_gpu/test/tbe/training/forward_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_test.py
@@ -80,16 +80,6 @@ additional_decorators.update(
             unittest.skip("Operator not implemented for Meta tensors"),
         ],
         # TODO: Make it compatible with opcheck tests
-        "test_faketensor__test_forward_gpu_uvm_cache_fp16": [
-            unittest.skip(
-                "Failed for fbgemm::linearize_cache_indices. Operator not implemented for Meta tensors."
-            ),
-        ],
-        "test_faketensor__test_forward_gpu_uvm_cache_fp32": [
-            unittest.skip(
-                "Failed for fbgemm::linearize_cache_indices. Operator not implemented for Meta tensors."
-            ),
-        ],
         "test_schema__test_forward_gpu_uvm_cache_fp16": [
             unittest.skip(
                 "Failed with Argument lxu_cache_locations_output is not defined to alias output but was aliasing"

--- a/fbgemm_gpu/test/tbe/utils/failures_dict_fast.json
+++ b/fbgemm_gpu/test/tbe/utils/failures_dict_fast.json
@@ -72,68 +72,7 @@
         "status": "xfail"
       }
     },
-    "fbgemm::linearize_cache_indices": {
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmMEAN": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmNONE": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmSUM": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmMEAN": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmNONE": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmSUM": {
-        "comment": "",
-        "status": "skip"
-      },
-      "BackwardSGDTest.test_faketensor__test_backward_sgd": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardSGDTest.test_faketensor__test_backward_sgd_really_long_segments": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "CacheTest.test_faketensor__test_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "LXUCacheTest.test_faketensor__test_unique_lxu_cache_lookup": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "LinearizeCacheIndicesTest.test_faketensor__test_linearize_cache_indices": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitCacheTest.test_faketensor__test_nbit_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitForwardTest.test_faketensor__test_nbit_forward_uvm_cache": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitSplitEmbeddingsTest.test_faketensor__test_int_nbit_split_embedding_uvm_caching_codegen_lookup_function": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_stb_uvm_cache_stats": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
+    "fbgemm::linearize_cache_indices": {},
     "fbgemm::linearize_cache_indices_from_row_idx": {
       "LinearizeCacheIndicesTest.test_faketensor__test_linearize_cache_indices_from_row_idx": {
         "comment": "",
@@ -186,66 +125,6 @@
     "fbgemm::lxu_cache_flush": {},
     "fbgemm::lxu_cache_locking_counter_decrement": {},
     "fbgemm::lxu_cache_lookup": {
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmMEAN": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmNONE": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp16_pmSUM": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmMEAN": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmNONE": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardAdagradTest.test_faketensor__test_backward_adagrad_fp32_pmSUM": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardSGDTest.test_faketensor__test_backward_sgd": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardSGDTest.test_faketensor__test_backward_sgd_really_long_segments": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "CacheTest.test_faketensor__test_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "LXUCacheTest.test_faketensor__test_lxu_cache_lookup": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "LXUCacheTest.test_faketensor__test_unique_lxu_cache_lookup": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitCacheTest.test_faketensor__test_nbit_cache_miss_counter": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitForwardTest.test_faketensor__test_nbit_forward_uvm_cache": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "NBitSplitEmbeddingsTest.test_faketensor__test_int_nbit_split_embedding_uvm_caching_codegen_lookup_function": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_stb_uvm_cache_stats": {
-        "comment": "",
-        "status": "xfail"
-      },
       "SplitTableBatchedEmbeddingsTest.test_schema__test_stb_uvm_cache_stats": {
         "comment": "",
         "status": "xfail"


### PR DESCRIPTION
Summary:
Add meta function for cache ops.

This is to fix opchecktest failures for D73644969.

Reviewed By: sryap

Differential Revision: D74520715


