### PR TITLE
Fix cpuinfo not being initialized before checking for ARM SVE2

### DIFF
--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -1175,6 +1175,9 @@ typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType, outType>::
 #endif // CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
 
 #ifdef FBGEMM_AUTOVEC_AVAILABLE
+  if (!cpuinfo_initialize()) {
+    throw std::runtime_error("Failed to initialize cpuinfo!");
+  }
   if ((is_autovec_forced() || fbgemmHasArmSve2Support()) &&
       !is_autovec_disabled()) {
     return GenerateEmbeddingSpMDMWithStrides_autovec<

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -1147,6 +1147,9 @@ typename EmbeddingSpMDMKernelSignature<uint8_t, indxType, offsetType, outType>::
 #endif // CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
 
 #ifdef FBGEMM_AUTOVEC_AVAILABLE
+  if (!cpuinfo_initialize()) {
+    throw std::runtime_error("Failed to initialize cpuinfo!");
+  }
   if ((fbgemmHasArmSve2Support() && !is_autovec_disabled()) ||
       is_autovec_forced()) {
     return GenerateEmbeddingSpMDMNBitWithStrides_autovec<


### PR DESCRIPTION
Summary: Make sure `cpuinfo_initialize` is called before testing for availability of SVE2. This fixes arm64 not using the autovectorizer optimized code on default on aarch64!

Differential Revision: D74688095


