### PR TITLE
Migrate TBE utility kernels to `FBGEMM_LAUNCH_KERNEL`

### DIFF
--- a/fbgemm_gpu/src/split_embeddings_utils/generate_vbe_metadata.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils/generate_vbe_metadata.cu
@@ -9,6 +9,7 @@
 #include "fbgemm_gpu/split_embeddings_utils.cuh" // @manual
 #include "fbgemm_gpu/utils/cuda_prelude.cuh"
 #include "fbgemm_gpu/utils/fixed_divisor.cuh"
+#include "fbgemm_gpu/utils/kernel_launcher.cuh" // @manual
 #include "fbgemm_gpu/utils/ops_utils.h" // @manual
 #include "fbgemm_gpu/utils/tensor_accessor_builder.h" // @manual
 #include "fbgemm_gpu/utils/tensor_utils.h"
@@ -166,26 +167,22 @@ generate_vbe_metadata(
       "generate_vbe_metadata: Invalid grid_size.z ",
       grid_size.z);
 
-#ifdef FBGEMM_GPU_MEMCHECK
-  const auto func_name = "generate_vbe_metadata_foreach_sample_kernel";
-#endif
   // Over allocate total number of threads to avoid using binary search
-  generate_vbe_metadata_foreach_sample_kernel<<<
+  FBGEMM_LAUNCH_KERNEL(
+      generate_vbe_metadata_foreach_sample_kernel,
       grid_size,
       kMaxThreads,
       0,
-      at::cuda::getCurrentCUDAStream()>>>(
-      MAKE_PTA_WITH_NAME(func_name, row_output_offsets, int64_t, 1, 32),
-      MAKE_PTA_WITH_NAME(func_name, b_t_map, int32_t, 1, 32),
-      MAKE_PTA_WITH_NAME(func_name, B_offsets, int32_t, 1, 32),
-      MAKE_PTA_WITH_NAME(func_name, B_offsets_rank_per_feature, int32_t, 2, 32),
-      MAKE_PTA_WITH_NAME(
-          func_name, output_offsets_feature_rank, int64_t, 1, 32),
-      MAKE_PTA_WITH_NAME(func_name, D_offsets, int32_t, 1, 32),
+      at::cuda::getCurrentCUDAStream(),
+      PTA_B(row_output_offsets, int64_t, 1, 32),
+      PTA_B(b_t_map, int32_t, 1, 32),
+      PTA_B(B_offsets, int32_t, 1, 32),
+      PTA_B(B_offsets_rank_per_feature, int32_t, 2, 32),
+      PTA_B(output_offsets_feature_rank, int64_t, 1, 32),
+      PTA_B(D_offsets, int32_t, 1, 32),
       D,
       nobag,
       info_B_num_bits);
-  C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return {row_output_offsets, b_t_map};
 }

--- a/fbgemm_gpu/src/split_embeddings_utils/transpose_embedding_input.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils/transpose_embedding_input.cu
@@ -8,6 +8,7 @@
 
 #include "fbgemm_gpu/embedding_backward_template_helpers.cuh" // @manual
 #include "fbgemm_gpu/split_embeddings_utils.cuh" // @manual
+#include "fbgemm_gpu/utils/kernel_launcher.cuh" // @manual
 #include "fbgemm_gpu/utils/ops_utils.h" // @manual
 #include "fbgemm_gpu/utils/tensor_accessor_builder.h" // @manual
 #ifdef USE_ROCM
@@ -250,17 +251,17 @@ transpose_embedding_input(
     const auto linearize_index_kernel_ =                                   \
         (vbe ? linearize_index_kernel<index_t, INFO_ACC_T, NOBAG, true>    \
              : linearize_index_kernel<index_t, INFO_ACC_T, NOBAG, false>); \
-    [[maybe_unused]] const auto func_name = "linearize_index_kernel_";     \
-    linearize_index_kernel_<<<                                             \
+    FBGEMM_LAUNCH_KERNEL(                                                  \
+        linearize_index_kernel_,                                           \
         div_round_up(total_B, kMaxThreads),                                \
         kMaxThreads,                                                       \
         0,                                                                 \
-        at::cuda::getCurrentCUDAStream()>>>(                               \
-        MAKE_PTA_WITH_NAME(func_name, hash_size_cumsum, int64_t, 1, 32),   \
-        MAKE_PTA_WITH_NAME(func_name, indices, index_t, 1, 32),            \
-        MAKE_PTA_WITH_NAME(func_name, offsets, index_t, 1, 32),            \
-        MAKE_PTA_WITH_NAME(func_name, infos, INFO_ACC_T, 1, 32),           \
-        MAKE_PTA_WITH_NAME(func_name, linear_indices, index_t, 1, 32),     \
+        at::cuda::getCurrentCUDAStream(),                                  \
+        PTA_B(hash_size_cumsum, int64_t, 1, 32),                           \
+        PTA_B(indices, index_t, 1, 32),                                    \
+        PTA_B(offsets, index_t, 1, 32),                                    \
+        PTA_B(infos, INFO_ACC_T, 1, 32),                                   \
+        PTA_B(linear_indices, index_t, 1, 32),                             \
         info_B_num_bits,                                                   \
         info_B_mask,                                                       \
         (1u << (DEFAULT_INFO_NUM_BITS - info_B_num_bits)) - 1,             \
@@ -268,7 +269,6 @@ transpose_embedding_input(
         vbe ? reinterpret_cast<uint32_t*>(vbe_b_t_map.value().data_ptr())  \
             : nullptr,                                                     \
         FixedDivisor(total_B / T));                                        \
-    C10_CUDA_KERNEL_LAUNCH_CHECK();                                        \
   }
 
   AT_DISPATCH_INDEX_TYPES(
@@ -283,27 +283,21 @@ transpose_embedding_input(
                   INVOKE_LINEARIZE_INDEX_KERNEL(int64_t, true);
                 }
               } else {
-        // index_select is a special case of TBE (dense, nobag, with
-        // fixed_L_per_warp)
-#ifdef FBGEMM_GPU_MEMCHECK
-                const auto func_name = "linearize_index_index_select_kernel";
-#endif
-                linearize_index_index_select_kernel<<<
+                // index_select is a special case of TBE (dense, nobag, with
+                // fixed_L_per_warp)
+                FBGEMM_LAUNCH_KERNEL(
+                    (linearize_index_index_select_kernel<index_t, int64_t>),
                     div_round_up(total_B, kMaxThreads),
                     kMaxThreads,
                     0,
-                    at::cuda::getCurrentCUDAStream()>>>(
-                    MAKE_PTA_WITH_NAME(
-                        func_name, hash_size_cumsum, int64_t, 1, 32),
-                    MAKE_PTA_WITH_NAME(func_name, indices, index_t, 1, 32),
-                    MAKE_PTA_WITH_NAME(
-                        func_name, total_L_offsets.value(), index_t, 1, 32),
-                    MAKE_PTA_WITH_NAME(func_name, infos, int64_t, 1, 32),
-                    MAKE_PTA_WITH_NAME(
-                        func_name, linear_indices, index_t, 1, 32),
+                    at::cuda::getCurrentCUDAStream(),
+                    PTA_B(hash_size_cumsum, int64_t, 1, 32),
+                    PTA_B(indices, index_t, 1, 32),
+                    PTA_B(total_L_offsets.value(), index_t, 1, 32),
+                    PTA_B(infos, int64_t, 1, 32),
+                    PTA_B(linear_indices, index_t, 1, 32),
                     FixedDivisor(total_B / T),
                     fixed_L_per_warp);
-                C10_CUDA_KERNEL_LAUNCH_CHECK();
               }
               {
                 size_t temp_storage_bytes = 0;


### PR DESCRIPTION
Summary: - Migrate TBE utility kernels to `FBGEMM_LAUNCH_KERNEL`

Differential Revision: D74159175


