### PR TITLE
Append columns to the SSD cache for storing optimizer data, v3

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
@@ -8,6 +8,7 @@
 # pyre-strict
 
 import enum
+import math
 from typing import Any, Dict  # noqa: F401
 
 import torch
@@ -39,6 +40,23 @@ class EmbOptimType(enum.Enum):
 
     def __str__(self) -> str:
         return self.value
+
+    def state_size(self) -> int:
+        """
+        Returns the size of the data (in bytes) required to hold the optimizer
+        state (per table row), or 0 if none needed
+        """
+        return {
+            # Only holds the momentum float value per row
+            EmbOptimType.EXACT_ROWWISE_ADAGRAD: torch.float32.itemsize,
+        }.get(self, 0)
+
+    def state_size_dim(self, dtype: torch.dtype) -> int:
+        """
+        Returns the size of the data (in units of elements of dtype) rquired to
+        hold optimizer information (per table row)
+        """
+        return int(math.ceil(self.state_size() / dtype.itemsize))
 
 
 # Base class for quantization configuration (in case other numeric types have

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/common.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/common.py
@@ -18,3 +18,25 @@ except Exception:
     pass
 
 ASSOC = 32
+
+
+def pad4(value: int) -> int:
+    """
+    Compute the smallest multiple of 4 that is greater than or equal to the given value.
+
+    Parameters:
+        value (int): The integer to align (must be non-negative).
+
+    Returns:
+        int: The aligned value.
+
+    Raises:
+        ValueError: If the input is negative.
+        TypeError: If the input is not an integer.
+    """
+    if not isinstance(value, int):
+        raise TypeError("Input must be an integer")
+    if value < 0:
+        raise ValueError("Input must be a non-negative integer")
+
+    return (value + 3) & ~3

--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
@@ -109,8 +109,6 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
             indices = torch.as_tensor(
                 np.random.choice(E, replace=False, size=(N,)), dtype=torch.int32
             )
-        weights = torch.randn(N, D, dtype=weights_precision.as_dtype())
-        output_weights = torch.empty_like(weights)
         count = torch.tensor([N])
 
         feature_table_map = list(range(1))
@@ -124,6 +122,10 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
             weights_precision=weights_precision,
             l2_cache_size=8,
         )
+
+        weights = torch.randn(N, emb.cache_row_dim, dtype=weights_precision.as_dtype())
+        output_weights = torch.empty_like(weights)
+
         emb.ssd_db.get_cuda(indices, output_weights, count)
         torch.cuda.synchronize()
         assert (output_weights <= 0.1).all().item()


### PR DESCRIPTION
Summary:
- Append columns to the SSD cache for storing optimizer data.  For backwards compatibility, this feature is disabled by default, unless the client builds `SSDTableBatchedEmbeddingBags` with `KVZCHParams` that has `enable_optimizer_offloading` set to `true`.

- This is a graft of D74051349 to land to main, since D74051349 is based on the
  ZCH WIP stack

Reviewed By: sryap, duduyi2013

Differential Revision: D74748058


