### PR TITLE
do not create random value for optimizer

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/common.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/common.py
@@ -8,6 +8,7 @@
 # pyre-strict
 # pyre-ignore-all-errors[56]
 
+import torch
 from fbgemm_gpu.utils.loader import load_torch_module
 
 try:
@@ -34,9 +35,11 @@ def pad4(value: int) -> int:
         ValueError: If the input is negative.
         TypeError: If the input is not an integer.
     """
-    if not isinstance(value, int):
-        raise TypeError("Input must be an integer")
-    if value < 0:
-        raise ValueError("Input must be a non-negative integer")
+    return (int(value) + 3) & ~3
 
+
+def tensor_pad4(value: torch.Tensor) -> torch.Tensor:
+    """
+    The equivalent of pad4 for tensors.
+    """
     return (value + 3) & ~3

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
@@ -41,7 +41,9 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
       int64_t res_server_port = 0,
       std::vector<std::string> table_names = {},
       std::vector<int64_t> table_offsets = {},
-      const std::vector<int64_t>& table_sizes = {})
+      const std::vector<int64_t>& table_sizes = {},
+      std::optional<at::Tensor> table_dims = std::nullopt,
+      std::optional<at::Tensor> hash_size_cumsum = std::nullopt)
       : impl_(std::make_shared<ssd::EmbeddingRocksDB>(
             path,
             num_shards,
@@ -68,7 +70,9 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
             res_server_port,
             std::move(table_names),
             std::move(table_offsets),
-            table_sizes)) {}
+            table_sizes,
+            table_dims,
+            hash_size_cumsum)) {}
 
   void set_cuda(
       at::Tensor indices,

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -475,7 +475,9 @@ static auto embedding_rocks_db_wrapper =
                 int64_t,
                 std::vector<std::string>,
                 std::vector<int64_t>,
-                std::vector<int64_t>>(),
+                std::vector<int64_t>,
+                std::optional<at::Tensor>,
+                std::optional<at::Tensor>>(),
             "",
             {
                 torch::arg("path"),
@@ -504,6 +506,8 @@ static auto embedding_rocks_db_wrapper =
                 torch::arg("table_names") = torch::List<std::string>(),
                 torch::arg("table_offsets") = torch::List<int64_t>(),
                 torch::arg("table_sizes") = torch::List<int64_t>(),
+                torch::arg("table_dims") = std::nullopt,
+                torch::arg("hash_size_cumsum") = std::nullopt,
             })
         .def(
             "set_cuda",

--- a/fbgemm_gpu/test/tbe/ssd/ssd_l2_cache_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_l2_cache_test.py
@@ -7,6 +7,7 @@
 # pyre-strict
 # pyre-ignore-all-errors[3,6,56]
 
+import logging
 import math
 import tempfile
 
@@ -14,7 +15,7 @@ import threading
 import time
 import unittest
 
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import patch
 
 import hypothesis.strategies as st
@@ -22,6 +23,7 @@ import numpy as np
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
 from fbgemm_gpu.tbe.ssd import SSDTableBatchedEmbeddingBags
+from fbgemm_gpu.tbe.ssd.training import KVZCHParams
 from fbgemm_gpu.tbe.utils import round_up
 from hypothesis import given, settings, Verbosity
 
@@ -57,6 +59,7 @@ class SSDCheckpointTest(unittest.TestCase):
         mixed: bool,
         enable_l2: bool = True,
         ssd_rocksdb_shards: int = 1,
+        kv_zch_params: Optional[KVZCHParams] = None,
     ) -> Tuple[SSDTableBatchedEmbeddingBags, List[int], List[int]]:
         E = int(10**log_E)
         D = D * 4
@@ -83,6 +86,7 @@ class SSDCheckpointTest(unittest.TestCase):
             weights_precision=weights_precision,
             l2_cache_size=1 if enable_l2 else 0,
             ssd_rocksdb_shards=ssd_rocksdb_shards,
+            kv_zch_params=kv_zch_params,
         )
         return emb, Es, Ds
 
@@ -407,3 +411,53 @@ class SSDCheckpointTest(unittest.TestCase):
 
         # Compare actual and expected tensor outputs
         self.assertTrue(torch.equal(bucket_t.view(-1), expected_bucket_tensor))
+
+    @given(
+        T=st.integers(min_value=2, max_value=10),
+        D=st.integers(min_value=2, max_value=128),
+        log_E=st.integers(min_value=2, max_value=3),
+        weights_precision=st.sampled_from([SparseType.FP32, SparseType.FP16]),
+        enable_l2=st.sampled_from([True, False]),
+    )
+    @settings(**default_settings)
+    def test_all_zero_opt_state_offloading(
+        self,
+        T: int,
+        D: int,
+        log_E: int,
+        weights_precision: SparseType,
+        enable_l2: bool,
+    ) -> None:
+        kv_zch_params = KVZCHParams(
+            enable_optimizer_offloading=True,
+        )
+        emb, Es, Ds = self.generate_fbgemm_ssd_tbe(
+            T,
+            D,
+            log_E,
+            weights_precision,
+            mixed=True,
+            enable_l2=enable_l2,
+            kv_zch_params=kv_zch_params,
+        )
+        dtype = weights_precision.as_dtype()
+        opt_dim = int(math.ceil(4 / dtype.itemsize))
+        snapshot = emb.ssd_db.create_snapshot()
+        offsets = 0
+        max_D = max(Ds)
+        for E, D in zip(Es, Ds):
+            if D + opt_dim > max_D:
+                # skip this case, we need enough space to simulate optimizer state query
+                offsets += E
+                continue
+
+            tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
+                [E, max_D], dtype, offsets, snapshot
+            )
+            tensor_wrapper.set_embedding_rocks_dp_wrapper(emb.ssd_db)
+            weight_opt = tensor_wrapper.narrow(0, 0, 1)
+            pad4_d = (D + 3) & ~3
+            torch.testing.assert_close(
+                weight_opt[:, pad4_d:], torch.zeros(1, max_D - pad4_d, dtype=dtype)
+            )
+            offsets += E


### PR DESCRIPTION
Summary:
To support extremely large virtual table size for ZCH v.Next, we cannot preallocate optimizer state tensor in HBM with full table size.
The solution is to offload optimizer state from HBM to CPU together with weight value.

There is one caveat of this solution, which is that every weight value will be initialized with random value if the weight is not found from backend. However, at this time, the optimizer value should not be randomly initialized. This diff is to fill in random value only for weight, but not optimizer state.

Differential Revision: D74790101


