### PR TITLE
support get state dict and apply state dict

### DIFF
--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
@@ -8,6 +8,7 @@
 # pyre-ignore-all-errors[3,6,56]
 
 import math
+import tempfile
 import unittest
 from enum import Enum
 
@@ -2004,6 +2005,217 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
             torch.testing.assert_close(
                 emb_w,
                 new_ref_weight,
+                atol=tolerance,
+                rtol=tolerance,
+            )
+
+    @given(
+        **default_st,
+        num_buckets=st.integers(min_value=10, max_value=15),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    def test_apply_kv_state_dict(
+        self,
+        T: int,
+        D: int,
+        B: int,
+        log_E: int,
+        L: int,
+        weighted: bool,
+        cache_set_scale: float,
+        pooling_mode: PoolingMode,
+        weights_precision: SparseType,
+        output_dtype: SparseType,
+        share_table: bool,
+        trigger_bounds_check: bool,
+        mixed_B: bool,
+        num_buckets: int,
+    ) -> None:
+        # Constants
+        lr = 0.5
+        eps = 0.2
+        ssd_shards = 2
+
+        trigger_bounds_check = False  # don't stimulate boundary check cases
+        assume(not weighted or pooling_mode == PoolingMode.SUM)
+        assume(not mixed_B or pooling_mode != PoolingMode.NONE)
+
+        # TODO: check split_optimizer_states when optimizer offloading is ready
+        # Generate embedding modules and inputs
+        (
+            emb,
+            emb_ref,
+            Es,
+            _,
+            bucket_offsets,
+            bucket_sizes,
+        ) = self.generate_kvzch_tbes(
+            T,
+            D,
+            B,
+            log_E,
+            L,
+            weighted,
+            lr=lr,
+            eps=eps,
+            ssd_shards=ssd_shards,
+            cache_set_scale=cache_set_scale,
+            pooling_mode=pooling_mode,
+            weights_precision=weights_precision,
+            output_dtype=output_dtype,
+            share_table=share_table,
+            num_buckets=num_buckets,
+            enable_optimizer_offloading=False,
+        )
+
+        # Generate inputs
+        (
+            indices_list,
+            per_sample_weights_list,
+            indices,
+            offsets,
+            per_sample_weights,
+            batch_size_per_feature_per_rank,
+        ) = self.generate_inputs_(
+            B,
+            L,
+            Es,
+            emb.feature_table_map,
+            weights_precision=weights_precision,
+            trigger_bounds_check=trigger_bounds_check,
+            mixed_B=mixed_B,
+            bucket_offsets=bucket_offsets,
+            bucket_sizes=bucket_sizes,
+            is_kv_tbes=True,
+        )
+
+        # Execute forward
+        output_ref_list, output = self.execute_ssd_forward_(
+            emb,
+            emb_ref,
+            indices_list,
+            per_sample_weights_list,
+            indices,
+            offsets,
+            per_sample_weights,
+            B,
+            L,
+            weighted,
+            batch_size_per_feature_per_rank=batch_size_per_feature_per_rank,
+        )
+
+        # Generate output gradient
+        output_grad_list = [torch.randn_like(out) for out in output_ref_list]
+
+        # Execute torch EmbeddingBag backward
+        [out.backward(grad) for (out, grad) in zip(output_ref_list, output_grad_list)]
+        if batch_size_per_feature_per_rank is not None:
+            grad_test = self.concat_ref_tensors_vbe(
+                output_grad_list, batch_size_per_feature_per_rank
+            )
+        else:
+            grad_test = self.concat_ref_tensors(
+                output_grad_list,
+                pooling_mode != PoolingMode.NONE,  # do_pooling
+                B,
+                D * 4,
+            )
+
+        # Execute TBE SSD backward
+        output.backward(grad_test)
+
+        tolerance = (
+            1.0e-4
+            if weights_precision == SparseType.FP32 and output_dtype == SparseType.FP32
+            else 1.0e-2
+        )
+
+        emb.flush()
+
+        # Compare emb state dict with expected values from nn.EmbeddingBag
+        emb_state_dict_list, bucket_asc_ids_list, num_active_id_per_bucket_list = (
+            emb.split_embedding_weights(no_snapshot=False, should_flush=True)
+        )
+        split_optimizer_states = emb.split_optimizer_states(bucket_asc_ids_list)
+
+        # create an empty emb with same parameters
+        # Construct feature_table_map
+
+        cache_sets = max(int(max(T * B * L, 1) * cache_set_scale), 1)
+        emb2 = SSDTableBatchedEmbeddingBags(
+            embedding_specs=emb.embedding_specs,
+            feature_table_map=emb.feature_table_map,
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=cache_sets,
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            learning_rate=lr,
+            eps=eps,
+            ssd_rocksdb_shards=ssd_shards,
+            optimizer=OptimType.EXACT_ROWWISE_ADAGRAD,
+            pooling_mode=pooling_mode,
+            weights_precision=weights_precision,
+            output_dtype=output_dtype,
+            stochastic_rounding=True,
+            prefetch_pipeline=False,
+            bounds_check_mode=BoundsCheckMode.WARNING,
+            l2_cache_size=8,
+            backend_type=BackendType.SSD,
+            kv_zch_params=emb.kv_zch_params,
+        ).cuda()
+
+        emb2.local_weight_counts = [ids.numel() for ids in bucket_asc_ids_list]
+        emb2.enable_load_state_dict_mode()
+        self.assertIsNotNone(emb2._cached_kvzch_data)
+        for i in range(len(emb.embedding_specs)):
+            # pyre-ignore [16]
+            emb2._cached_kvzch_data.cached_weight_tensor_per_table[i].copy_(
+                emb_state_dict_list[i].full_tensor()
+            )
+            # pyre-ignore [16]
+            emb2._cached_kvzch_data.cached_optimizer_state_per_table[i].copy_(
+                split_optimizer_states[i]
+            )
+            # pyre-ignore [16]
+            emb2._cached_kvzch_data.cached_id_tensor_per_table[i].copy_(
+                bucket_asc_ids_list[i]
+            )
+            # pyre-ignore [16]
+            emb2._cached_kvzch_data.cached_bucket_splits[i].copy_(
+                num_active_id_per_bucket_list[i]
+            )
+
+        emb2.apply_state_dict()
+
+        emb2.flush(True)
+        # Compare emb state dict with expected values from nn.EmbeddingBag
+        emb_state_dict_list2, bucket_asc_ids_list2, num_active_id_per_bucket_list2 = (
+            emb2.split_embedding_weights(no_snapshot=False, should_flush=True)
+        )
+        split_optimizer_states2 = emb2.split_optimizer_states(bucket_asc_ids_list2)
+
+        for t in range(len(emb.embedding_specs)):
+            torch.testing.assert_close(
+                split_optimizer_states[t],
+                split_optimizer_states2[t],
+                atol=tolerance,
+                rtol=tolerance,
+            )
+            torch.testing.assert_close(
+                emb_state_dict_list[t].full_tensor(),
+                emb_state_dict_list2[t].full_tensor(),
+                atol=tolerance,
+                rtol=tolerance,
+            )
+            torch.testing.assert_close(
+                bucket_asc_ids_list[t],
+                bucket_asc_ids_list2[t],
+                atol=tolerance,
+                rtol=tolerance,
+            )
+            torch.testing.assert_close(
+                num_active_id_per_bucket_list[t],
+                num_active_id_per_bucket_list2[t],
                 atol=tolerance,
                 rtol=tolerance,
             )


### PR DESCRIPTION
Summary:
- while loading state dict, convert id from local to global, so when table is resharded, no need to shift id based on sharding decision
- enable load state dict mode for checkpoint loading. 
Since checkpoint client does not support ordered tensor loading, we implemented a short term solution to cache all id, weight and bucket tensor in memory, and after all data are loaded, apply everything to backend.

The current solution is to cache all data in python tensor, here is the flow to use these interfaces:
  - set self.local_weight_counts based on checkpoint bucket tensor size
  - enable_load_state_dict_mode to initialize local cache tensor
  - call state_dict to get empty tensors from checkpoint loader
  - write checkpoint data to cached tensors by checkpoint loader
  - call apply_state_dict to write all cached tensor to backend
    - in apply_state_dict:
      - if optimizer offloading is enabled:
        - for loop chunk of weight and optimizer
        - concat weight and optimizer together
        - write to backend through KVTensorWrapper interface
      - if optimizer offloading is disabled:
        - set optimizer to device tensor based on id
        - write id weight to backend

With this solution is that, when write data to backend, the python tensor's memory cannot be released until all tensor data is duplicated in backend. In a short time, there will have one table's weight tensor be duplicated, we need to make sure the memory capacity is enough.
In addition, with optimizer offloading, we need to concat weight and optimizer together before we can write to backend, since the input data need to be contiguous. To avoid triple the memory consumption, we write chunk data in a for loop, which will cause write performance regression.

After the first version e2e is ready, we'll support unordered loading from backend to improve performance and also reduce memory overhead.

**Saving State Dict**
When saving state dict, we convert IDs from local to global. This allows us to avoid shifting IDs based on sharding decisions when tables are resharded.

**Checkpoint Loading Mode**
We have enabled load state dict mode for checkpoint loading, which allows us to cache all ID, weight, and bucket tensors in memory before applying them to the backend. This approach ensures that all data is loaded correctly, even though the checkpoint client does not support ordered tensor loading.

**Current Solution**
The current solution involves caching all data in Python tensors, following these steps:
- Set self.local_weight_counts based on checkpoint bucket tensor size.
- Enable load state dict mode to initialize local cache tensors.
- Call state_dict to get empty tensors for the checkpoint loader.
- Write checkpoint data to cached tensors from persisted checkpoint by the checkpoint loader.
- Call apply_state_dict to write all cached tensors to the backend.

**Apply State Dict Flow**
During the apply_state_dict step, we perform the following operations:
- If optimizer offloading is enabled:
  - Loop through chunks of weight and optimizer.
  - Concatenate weight and optimizer together.
  - Write to backend using KVTensorWrapper interface.
- If optimizer offloading is disabled:
  - Set optimizer to device tensor based on ID.
  - Write ID weight to backend for each table.

**Limitations**
The current solution has two limitations:
- Memory overhead: 
  - When writing data to the backend, the Python tensor's memory cannot be released until the whole tensor data is duplicated in the backend. This can lead to high memory usage, especially when dealing with single large tables.
- Performance regression: 
  - With optimizer offloading, we need to concatenate weight and optimizer together before writing to the backend. To avoid triple one large tensor's memory, we loop through smaller chunks during writing, which can cause performance regression.

**Future Improvements**
After the first version e2e is ready, we plan to support unordered loading from the backend to improve performance and reduce memory overhead.

Differential Revision: D74790154


