### PR TITLE
optimization of perKVhead quantization

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.cpp
@@ -31,11 +31,11 @@ namespace fbgemm_gpu {
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def("rope_qkv_varseq_prefill(Tensor XQ, Tensor(a!)? XK, Tensor? XV, Tensor(b!) cache_K, Tensor(c!) cache_V,  Tensor varseq_batch, Tensor varseq_seqpos, float theta, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
       DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192"
-      ", float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32,  Tensor? qparam_k=None, Tensor? qparam_v=None, bool write_k_back=False, bool k_norm=False,bool update_kv=True, Tensor?amax_qkv=None) -> Tensor");
+      ", float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32,  Tensor? qparam_k=None, Tensor? qparam_v=None, bool write_k_back=False, bool k_norm=False,bool update_kv=True, Tensor?amax_qkv=None, Tensor?kv_quant_scale_precomputed=None) -> Tensor");
   m.def("rope_qkv_decoding(Tensor XQ, Tensor? XK, Tensor? XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor seqpos, float theta, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
       DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None,  int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192, float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False, bool update_kv=True, Tensor?amax_qkv=None) -> Tensor");
   m.def("nope_qkv_varseq_prefill(Tensor XQ, Tensor? XK, Tensor? XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor varseq_batch, Tensor varseq_seqpos, Tensor? block_tables=None, int page_size=" STRING(
-      DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, int cache_logical_dtype_int=0, int? num_groups=1, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False, bool update_kv=True, Tensor?amax_qkv=None) -> Tensor");
+      DEFAULT_PAGE_SIZE) ", Tensor? varseq_cache_seqpos=None, int cache_logical_dtype_int=0, int? num_groups=1, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False, bool update_kv=True, Tensor?amax_qkv=None, Tensor?kv_quant_scale_precomputed=None) -> Tensor");
   m.def("nope_qkv_decoding(Tensor XQ, Tensor? XK, Tensor? XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor seqpos, Tensor? block_tables=None, int page_size=" STRING(
       DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None, int cache_logical_dtype_int=0, int? num_groups=1, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False, bool update_kv=True, Tensor?amax_qkv=None) -> Tensor");
   m.def("xpos_qkv_varseq_prefill(Tensor XQ, Tensor XK, Tensor XV, Tensor(a!) cache_K, Tensor(b!) cache_V, Tensor varseq_batch, Tensor varseq_seqpos, float theta, float gamma, float scale_base, float exponent_offset, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
@@ -48,7 +48,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "dequantize_fp8_cache(Tensor cache_K, Tensor cache_V, Tensor kv_seqlen, Tensor? qparam_k=None, Tensor? qparam_v=None, Tensor? block_tables=None, int page_size=" STRING(
           DEFAULT_PAGE_SIZE) ") -> (Tensor, Tensor)");
   m.def(
-      "quantize_qkv_per_head(Tensor amax, Tensor XQKV, Tensor varseq_seqpos, Tensor? varseq_batch, Tensor q_seqstarts, Tensor cache_K, Tensor cache_V, Tensor XQ_O, int max_seq_len, Tensor? qparam_k=None, Tensor? qparam_v=None) -> Tensor");
+      "quantize_qkv_per_head(Tensor amax, Tensor XQKV, Tensor varseq_seqpos, Tensor? varseq_batch, Tensor? is_precalculated_qparam, Tensor cache_K, Tensor cache_V, Tensor XQ_O, int B, Tensor? qparam_k=None, Tensor? qparam_v=None) -> Tensor");
   m.def(
       "convert_e4m3fn_kv_cache_to_e4m3fnuz_inplace(Tensor cache_K, Tensor cache_V, Tensor qparam_K, Tensor qparam_V) -> ()");
 }
@@ -104,7 +104,8 @@ at::Tensor rope_qkv_varseq_prefill_meta(
     bool /* write_k_back */,
     bool /* k_norm */,
     bool /* update_kv */,
-    std::optional<at::Tensor> /* amax_qkv */
+    std::optional<at::Tensor> /* amax_qkv */,
+    std::optional<at::Tensor> /* kv_quant_scale_precomputed */
 ) {
   return at::empty_like(XQ);
 }
@@ -155,7 +156,8 @@ at::Tensor nope_qkv_varseq_prefill_meta(
     std::optional<at::Tensor> /* qparam_v */,
     bool /* k_norm */,
     bool /* update_kv */,
-    std::optional<at::Tensor> /* amax_qkv */
+    std::optional<at::Tensor> /* amax_qkv */,
+    std::optional<at::Tensor> /* kv_quant_scale_precomputed */
 ) {
   return at::empty_like(XQ);
 }
@@ -287,11 +289,11 @@ at::Tensor quantize_qkv_per_head_meta(
     at::Tensor XQKV,
     at::Tensor /* varseq_seqpos */,
     std::optional<at::Tensor> /* varseq_batch */,
-    at::Tensor /* q_seqstarts */,
+    std::optional<at::Tensor> /* is_precalculated_qparam */,
     at::Tensor cache_K /* cache_K */,
     at::Tensor /* cache_V */,
     at::Tensor /* XQ_O */,
-    int64_t /* max_seq_len */,
+    int64_t /* B */,
     std::optional<at::Tensor> /* qparam_k */,
     std::optional<at::Tensor> /* qparam_v */) {
   const at::SymInt B_KV = cache_K.sym_size(0);

--- a/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.h
@@ -27,7 +27,8 @@ at::Tensor nope_qkv_varseq_prefill(
     std::optional<at::Tensor> qparam_v,
     bool k_norm,
     bool update_kv,
-    std::optional<at::Tensor> amax_qkv);
+    std::optional<at::Tensor> amax_qkv,
+    std::optional<at::Tensor> kv_quant_scale_precomputed);
 
 at::Tensor nope_qkv_decoding(
     at::Tensor XQ,
@@ -73,7 +74,8 @@ at::Tensor rope_qkv_varseq_prefill(
     bool write_k_back,
     bool k_norm,
     bool update_kv,
-    std::optional<at::Tensor> amax_qkv);
+    std::optional<at::Tensor> amax_qkv,
+    std::optional<at::Tensor> kv_quant_scale_precomputed);
 
 at::Tensor rope_qkv_decoding(
     at::Tensor XQ,
@@ -174,11 +176,11 @@ at::Tensor quantize_qkv_per_head(
     at::Tensor XQKV,
     at::Tensor varseq_seqpos,
     std::optional<at::Tensor> varseq_batch,
-    at::Tensor q_seqstarts,
+    std::optional<at::Tensor> is_precalculated_qparam,
     at::Tensor cache_K,
     at::Tensor cache_V,
     at::Tensor XQ_O,
-    int64_t max_seq_len,
+    int64_t B,
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> qparam_v);
 


### PR DESCRIPTION
Summary:
y-sq noticed that for prefill chunk of 64k, the improvement in attention kernel runtime for local layers is cancelled out by around 0.4 ms overhead from the quantization kernel. 

https://docs.google.com/document/d/193GL7o5GMlpVlwEDVxqoDB6O85zDuS8A5-PUOSsZc1s/edit?tab=t.0#bookmark=id.zh92spta1uxw

Before:
BS =1 , Seqlen = 64k
  Elapsed Cycles                cycle      530,268
  Memory Throughput                 %        17.24
  Duration                         us       392.93


After:
    ----------------------- ----------- ------------
    DRAM Frequency                  Ghz         1.59
    SM Frequency                    Ghz         1.34
    Elapsed Cycles                cycle      192,884
    Memory Throughput                 %        46.01
    DRAM Throughput                   %        46.01
    Duration                         us       143.23
    L1/TEX Cache Throughput           %        15.15
    L2 Cache Throughput               %        39.31
    SM Active Cycles              cycle   181,953.16
    Compute (SM) Throughput           %        71.92
    ----------------------- ----------- ------------

Reviewed By: y-sq

Differential Revision: D74924275


