### PR TITLE
Fix vbe benchmark for MTIA

### DIFF
--- a/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py
@@ -1350,6 +1350,7 @@ def vbe(
         output_dtype=embconfig.output_dtype,
         pooling_mode=embconfig.pooling_mode,
         bounds_check_mode=embconfig.bounds_check_mode,
+        device=get_device(),
     ).to(get_device())
 
     all_requests = {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1251

This Diff fixes the VBE benchmark for MTIA.

Differential Revision: D75195213


