### PR TITLE
IndexShuffling supports TP2EP.

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/moe/index_shuffling.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/moe/index_shuffling.cpp
@@ -13,17 +13,42 @@
 
 namespace fbgemm_gpu {
 
+/*
+Calculates sorted indices based on routing scores.
+
+Args:
+    - `routing_scores`: (T, E) tensor of routing scores.
+    - `expert_index_start`: Optional. Start index of the expert to be routed. If
+      not passed, it is assumed to be 0.
+    - `expert_index_end`: Optional. End index of
+      the expert to be routed, exclusive. If not passed, it is assumed to be E.
+    - `valid_token_count`: Optional. (1) tensor of valid token count per expert.
+      If not passed, it is assumed to be T.
+
+Returns:
+    - `token_count_per_expert`: (E + 2) tensor of token count per expert and
+      `num_total_tokens`, `num_sorted_tokens` are packed into as the last two
+      elements.
+  - `expert_indices`: (T) tensor of routed
+      expert indices. Only the first `num_sorted_tokens` elements are valid.
+  - `token_indices`: (T) tensor of pre-routing token indices. Only the first
+      `num_sorted_tokens` elements are valid.
+*/
 std::tuple<at::Tensor, at::Tensor, at::Tensor> index_shuffling_torch(
     const at::Tensor& routing_scores,
-    std::optional<at::Tensor> valid_token_count);
+    const std::optional<int64_t>& expert_index_start,
+    const std::optional<int64_t>& expert_index_end,
+    const std::optional<at::Tensor>& valid_token_count);
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor> index_shuffling_torch_meta(
     const at::Tensor& routing_scores,
-    std::optional<at::Tensor> valid_token_count) {
+    const std::optional<int64_t>& expert_index_start,
+    const std::optional<int64_t>& expert_index_end,
+    const std::optional<at::Tensor>& valid_token_count) {
   int T = routing_scores.size(0);
   int E = routing_scores.size(1);
   at::Tensor token_counts_per_expert =
-      at::empty({E + 1}, routing_scores.options().dtype(at::kInt));
+      at::empty({E + 2}, routing_scores.options().dtype(at::kInt));
   at::Tensor expert_indices =
       at::empty({T}, routing_scores.options().dtype(at::kInt));
   at::Tensor token_indices =
@@ -34,7 +59,11 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> index_shuffling_torch_meta(
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.set_python_module("fbgemm_gpu.experimental.gen_ai.moe");
   m.def(
-      "index_shuffling(Tensor routing_scores, Tensor? valid_token_count=None) -> (Tensor, Tensor, Tensor)");
+      "index_shuffling(Tensor routing_scores,             "
+      "                int? expert_index_start=None,      "
+      "                int? expert_index_end=None,        "
+      "                Tensor? valid_token_count=None) -> "
+      "(Tensor, Tensor, Tensor)");
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1258

IndexShuffling outputs number of tokens assigned to a specific range of experts.

Differential Revision: D75076838


