### PR TITLE
Migrate TBE UVM cache kernels to `FBGEMM_LAUNCH_KERNEL`

### DIFF
--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_v1.cu
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_v1.cu
@@ -188,9 +188,6 @@ void _bounds_check_indices_cuda_v1(
 
   AT_DISPATCH_INDEX_TYPES(
       indices.scalar_type(), "bounds_check_indices_cuda_v1", [&] {
-#ifdef FBGEMM_GPU_MEMCHECK
-        const auto func_name = "bounds_check_indices_cuda_v1";
-#endif
         const auto bounds_check_kernel =
             (vbe ? bounds_check_indices_kernel_v1<index_t, true>
                  : bounds_check_indices_kernel_v1<index_t, false>);

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/weight_row.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/weight_row.cuh
@@ -279,7 +279,7 @@ class WeightRow {
   }
 
   //////////////////////////////////////////////////////////////////////////////
-  // Copy the row from the embedding table into the cache
+  // Copy the row from the cache into embedding table
   //////////////////////////////////////////////////////////////////////////////
 
   DEVICE_INLINE void evict_cache(const uint32_t d, const float2 qparams) {

--- a/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_find.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_find.cu
@@ -40,7 +40,7 @@ __global__ __launch_bounds__(kMaxThreads) void lfu_cache_find_uncached_kernel(
         lfu_state) {
   const int32_t C = lxu_cache_state.size(0);
 
-  for (int32_t n = blockIdx.x * blockDim.y + threadIdx.y; n < *N_unique;
+  for (auto n = blockIdx.x * blockDim.y + threadIdx.y; n < *N_unique;
        n += gridDim.x * blockDim.y) {
     const int64_t idx = unique_indices[n];
     if (idx == max_indices) {
@@ -87,21 +87,18 @@ void lfu_update_counts_cuda(
   const int32_t N = unique_indices.size(0);
   AT_DISPATCH_INDEX_TYPES(
       unique_indices.scalar_type(), "lfu_update_counts_cuda", [&] {
-#ifdef FBGEMM_GPU_MEMCHECK
-        const char* func_name = "lfu_update_counts_kernel";
-#endif
-        lfu_update_counts_kernel<<<
+        FBGEMM_LAUNCH_KERNEL(
+            (lfu_update_counts_kernel<index_t>),
             std::min(
                 div_round_up(N, kMaxThreads),
                 get_max_thread_blocks_for_cache_kernels_()),
             kMaxThreads,
             0,
-            at::cuda::getCurrentCUDAStream()>>>(
-            MAKE_PTA_WITH_NAME(func_name, unique_indices, index_t, 1, 32),
+            at::cuda::getCurrentCUDAStream(),
+            PTA_B(unique_indices, index_t, 1, 32),
             unique_indices_length.data_ptr<int32_t>(),
-            MAKE_PTA_WITH_NAME(func_name, unique_indices_count, int32_t, 1, 32),
-            MAKE_PTA_WITH_NAME(func_name, lfu_state, int64_t, 1, 64));
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
+            PTA_B(unique_indices_count, int32_t, 1, 32),
+            PTA_B(lfu_state, int64_t, 1, 64));
       });
 }
 
@@ -127,24 +124,22 @@ std::pair<Tensor, Tensor> lfu_cache_find_uncached_cuda(
 
   AT_DISPATCH_INDEX_TYPES(
       unique_indices.scalar_type(), "lfu_cache_find_uncached_cuda", [&] {
-#ifdef FBGEMM_GPU_MEMCHECK
-        const char* func_name = "lfu_cache_find_uncached_kernel";
-#endif
         // Find uncached indices
-        lfu_cache_find_uncached_kernel<<<
+        FBGEMM_LAUNCH_KERNEL(
+            (lfu_cache_find_uncached_kernel<index_t>),
             std::min(
                 div_round_up(N, kMaxThreads / kWarpSize),
                 get_max_thread_blocks_for_cache_kernels_()),
             dim3(kWarpSize, kMaxThreads / kWarpSize),
             0,
-            at::cuda::getCurrentCUDAStream()>>>(
-            MAKE_PTA_WITH_NAME(func_name, unique_indices, index_t, 1, 32),
+            at::cuda::getCurrentCUDAStream(),
+            PTA_B(unique_indices, index_t, 1, 32),
             unique_indices_length.data_ptr<int32_t>(),
             max_indices,
-            MAKE_PTA_WITH_NAME(func_name, lxu_cache_state, int64_t, 2, 32),
+            PTA_B(lxu_cache_state, int64_t, 2, 32),
             (uint64_t*)cache_sets.data_ptr<int64_t>(),
-            MAKE_PTA_WITH_NAME(func_name, lfu_state, int64_t, 1, 64));
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
+            PTA_B(lfu_state, int64_t, 1, 64));
+
         // Sort the cache sets and ids
         size_t temp_storage_bytes = 0;
         AT_CUDA_CHECK(FBGEMM_GPU_CUB_NS_PREFIX cub::DeviceRadixSort::SortPairs(

--- a/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_populate_byte.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_populate_byte.cu
@@ -54,7 +54,7 @@ __launch_bounds__(kCacheMaxThreads) void lfu_cache_insert_byte_kernel(
         lfu_state,
     const int64_t row_alignment) {
   const int32_t C = lxu_cache_state.size(0);
-  for (int32_t n = blockIdx.x * blockDim.y + threadIdx.y; n < *N_unique;
+  for (auto n = blockIdx.x * blockDim.y + threadIdx.y; n < *N_unique;
        n += gridDim.x * blockDim.y) {
     // check if this warp is responsible for this whole segment.
     const bool segment_start =
@@ -81,20 +81,20 @@ __launch_bounds__(kCacheMaxThreads) void lfu_cache_insert_byte_kernel(
 
     // now, we need to insert the (unique!) values in indices[n:n + SL] into
     // our slots.
-    const int32_t slot = threadIdx.x;
+    const auto slot = threadIdx.x;
     const int64_t current_idx = lxu_cache_state[cache_set][slot];
     const int64_t current_lfu_cost =
         (current_idx != static_cast<int64_t>(kCacheStateInvalid))
         ? lfu_state[current_idx]
         : -1;
     int64_t costs[1] = {current_lfu_cost};
-    int32_t slots[1] = {slot};
+    uint32_t slots[1] = {slot};
 
-    BitonicSort<int64_t, int32_t, 1, Comparator<int64_t>>::sort(costs, slots);
-    const int32_t sorted_slot = slots[0];
-    const int64_t sorted_lfu_cost = costs[0];
+    BitonicSort<int64_t, uint32_t, 1, Comparator<int64_t>>::sort(costs, slots);
+    const auto sorted_slot = slots[0];
+    const auto sorted_lfu_cost = costs[0];
 
-    for (int32_t l = 0; l < min(SL, kWarpSize); ++l) {
+    for (auto l = 0; l < min(SL, kWarpSize); ++l) {
       const int32_t insert_slot = shfl_sync(sorted_slot, l);
       const int64_t insert_current_lfu_cost = shfl_sync(sorted_lfu_cost, l);
       const index_t insert_idx = cache_set_sorted_indices[n + l];
@@ -126,7 +126,7 @@ __launch_bounds__(kCacheMaxThreads) void lfu_cache_insert_byte_kernel(
           &weights[weights_offset_insert + idx_insert * D_insert_bytes + 0]);
       auto cache_row = reinterpret_cast<uint4*>(
           &lxu_cache_weights[cache_set * kWarpSize + insert_slot][0]);
-      for (int32_t d = threadIdx.x; d * sizeof(uint4) < D_insert_bytes;
+      for (auto d = threadIdx.x; d * sizeof(uint4) < D_insert_bytes;
            d += blockDim.x) {
         cache_row[d] = row[d];
       }
@@ -173,33 +173,27 @@ void lfu_cache_insert_byte_cuda(
       cache_set_sorted_unique_indices.scalar_type(),
       "lfu_cache_insert_byte_cuda",
       [&] {
-#ifdef FBGEMM_GPU_MEMCHECK
-        const char* func_name = "lfu_cache_insert_byte_kernel";
-#endif
-        lfu_cache_insert_byte_kernel<<<
+        FBGEMM_LAUNCH_KERNEL(
+            (lfu_cache_insert_byte_kernel<index_t>),
             std::min(
                 div_round_up(N, kCacheMaxThreads / kWarpSize),
                 get_max_thread_blocks_for_cache_kernels_()),
             dim3(kWarpSize, kCacheMaxThreads / kWarpSize),
             0,
-            at::cuda::getCurrentCUDAStream()>>>(
-            MAKE_PTA_WITH_NAME(func_name, weights, uint8_t, 1, 64),
-            MAKE_PTA_WITH_NAME(
-                func_name, cache_hash_size_cumsum, int64_t, 1, 32),
-            MAKE_PTA_WITH_NAME(
-                func_name, cache_index_table_map, int32_t, 1, 64),
-            MAKE_PTA_WITH_NAME(func_name, weights_offsets, int64_t, 1, 32),
-            MAKE_PTA_WITH_NAME(func_name, weights_tys, uint8_t, 1, 32),
-            MAKE_PTA_WITH_NAME(func_name, D_offsets, int32_t, 1, 32),
+            at::cuda::getCurrentCUDAStream(),
+            PTA_B(weights, uint8_t, 1, 64),
+            PTA_B(cache_hash_size_cumsum, int64_t, 1, 32),
+            PTA_B(cache_index_table_map, int32_t, 1, 64),
+            PTA_B(weights_offsets, int64_t, 1, 32),
+            PTA_B(weights_tys, uint8_t, 1, 32),
+            PTA_B(D_offsets, int32_t, 1, 32),
             (uint64_t*)sorted_cache_sets.data_ptr<int64_t>(),
-            MAKE_PTA_WITH_NAME(
-                func_name, cache_set_sorted_unique_indices, index_t, 1, 32),
+            PTA_B(cache_set_sorted_unique_indices, index_t, 1, 32),
             unique_indices_length.data_ptr<int32_t>(),
-            MAKE_PTA_WITH_NAME(func_name, lxu_cache_state, int64_t, 2, 32),
-            MAKE_PTA_WITH_NAME(func_name, lxu_cache_weights, uint8_t, 2, 64),
-            MAKE_PTA_WITH_NAME(func_name, lfu_state, int64_t, 1, 64),
+            PTA_B(lxu_cache_state, int64_t, 2, 32),
+            PTA_B(lxu_cache_weights, uint8_t, 2, 64),
+            PTA_B(lfu_state, int64_t, 1, 64),
             row_alignment);
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
       });
 }
 

--- a/fbgemm_gpu/src/split_embeddings_cache/lru_cache_find.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lru_cache_find.cu
@@ -59,20 +59,17 @@ DLL_PUBLIC Tensor emulate_cache_miss(
       div_round_up(N, kMaxThreads),
       get_max_thread_blocks_for_cache_kernels_()));
 
-#ifdef FBGEMM_GPU_MEMCHECK
-  const char* func_name = "emulate_cache_miss_kernel";
-#endif
-
-  emulate_cache_miss_kernel<<<
+  FBGEMM_LAUNCH_KERNEL(
+      (emulate_cache_miss_kernel),
       blocks,
       kMaxThreads,
       0,
-      at::cuda::getCurrentCUDAStream()>>>(
-      MAKE_PTA_WITH_NAME(func_name, lxu_cache_locations, int32_t, 1, 32),
+      at::cuda::getCurrentCUDAStream(),
+      PTA_B(lxu_cache_locations, int32_t, 1, 32),
       enforced_misses_per_256,
       gather_cache_stats,
-      MAKE_PTA_WITH_NAME(func_name, uvm_cache_stats, int32_t, 1, 32));
-  C10_CUDA_KERNEL_LAUNCH_CHECK();
+      PTA_B(uvm_cache_stats, int32_t, 1, 32));
+
   return lxu_cache_locations;
 }
 
@@ -110,7 +107,7 @@ __global__ __launch_bounds__(kMaxThreads) void lru_cache_find_uncached_kernel(
   const int32_t C = lxu_cache_state.size(0);
   int32_t n_misses = 0;
 
-  for (int32_t n = blockIdx.x * blockDim.y + threadIdx.y; n < *N_unique;
+  for (auto n = blockIdx.x * blockDim.y + threadIdx.y; n < *N_unique;
        n += gridDim.x * blockDim.y) {
     int64_t idx = unique_indices[n];
     if (idx == max_indices) {
@@ -214,9 +211,6 @@ lru_cache_find_uncached_cuda(
 
   AT_DISPATCH_INDEX_TYPES(
       unique_indices.scalar_type(), "lru_cache_find_uncached_cuda", [&] {
-#ifdef FBGEMM_GPU_MEMCHECK
-        const char* func_name = "lru_cache_find_uncached_kernel";
-#endif
         // During concurrent prefetch, cache lines are locked and we use less
         // SMs for some of the prefetch kernels to leave SMs for main stream to
         // overlap
@@ -228,24 +222,24 @@ lru_cache_find_uncached_cuda(
                             : get_max_thread_blocks_for_cache_kernels_());
 
         // Find uncached indices
-        lru_cache_find_uncached_kernel<<<
+        FBGEMM_LAUNCH_KERNEL(
+            (lru_cache_find_uncached_kernel<index_t>),
             grid_size,
             dim3(kWarpSize, kMaxThreads / kWarpSize),
             0,
-            at::cuda::getCurrentCUDAStream()>>>(
-            MAKE_PTA_WITH_NAME(func_name, unique_indices, index_t, 1, 32),
+            at::cuda::getCurrentCUDAStream(),
+            PTA_B(unique_indices, index_t, 1, 32),
             unique_indices_length.data_ptr<int32_t>(),
             max_indices,
-            MAKE_PTA_WITH_NAME(func_name, lxu_cache_state, int64_t, 2, 32),
-            MAKE_PTA_WITH_NAME(func_name, cache_sets, int32_t, 1, 32),
+            PTA_B(lxu_cache_state, int64_t, 2, 32),
+            PTA_B(cache_sets, int32_t, 1, 32),
             time_stamp,
-            MAKE_PTA_WITH_NAME(func_name, lru_state, int64_t, 2, 32),
+            PTA_B(lru_state, int64_t, 2, 32),
             gather_cache_stats,
-            MAKE_PTA_WITH_NAME(func_name, uvm_cache_stats, int32_t, 1, 32),
+            PTA_B(uvm_cache_stats, int32_t, 1, 32),
             lock_cache_line,
-            MAKE_PTA_WITH_NAME(
-                func_name, lxu_cache_locking_counter, int32_t, 2, 32));
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
+            PTA_B(lxu_cache_locking_counter, int32_t, 2, 32));
+
         // Sort the cache sets and ids
         size_t temp_storage_bytes = 0;
         INVOKE_CUB_SORT_PAIRS(

--- a/fbgemm_gpu/src/split_embeddings_cache/reset_weight_momentum.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/reset_weight_momentum.cu
@@ -283,39 +283,27 @@ DLL_PUBLIC void reset_weight_momentum_cuda(
       lxu_cache_weights.scalar_type(),
       "reset_weight_momentum_kernel",
       ([&] {
-#ifdef FBGEMM_GPU_MEMCHECK
-        const char* func_name2 = "get_cache_indices_kernel";
-#endif
-        reset_weight_momentum_kernel<emb_t, cache_t>
-            <<<num_pruned_tables * blocks_per_table,
-               kMaxThreads,
-               0,
-               at::cuda::getCurrentCUDAStream()>>>(
-                blocks_per_table,
-                MAKE_PTA_WITH_NAME(func_name2, dev_weights, emb_t, 1, 64),
-                MAKE_PTA_WITH_NAME(func_name2, uvm_weights, emb_t, 1, 64),
-                MAKE_PTA_WITH_NAME(
-                    func_name2, lxu_cache_weights, cache_t, 2, 64),
-                MAKE_PTA_WITH_NAME(
-                    func_name2, weights_placements, int32_t, 1, 32),
-                MAKE_PTA_WITH_NAME(func_name2, weights_offsets, int64_t, 1, 32),
-                MAKE_PTA_ACC_WITH_NAME(
-                    func_name2, momentum1_dev, cache_t, 1, 64),
-                MAKE_PTA_ACC_WITH_NAME(
-                    func_name2, momentum1_uvm, cache_t, 1, 64),
-                MAKE_PTA_WITH_NAME(
-                    func_name2, momentum1_placements, int32_t, 1, 32),
-                MAKE_PTA_WITH_NAME(
-                    func_name2, momentum1_offsets, int64_t, 1, 32),
-                MAKE_PTA_WITH_NAME(func_name2, D_offsets, int32_t, 1, 32),
-                MAKE_PTA_WITH_NAME(func_name2, pruned_indices, int64_t, 1, 32),
-                MAKE_PTA_WITH_NAME(
-                    func_name2, pruned_indices_offsets, int64_t, 1, 32),
-                MAKE_PTA_WITH_NAME(
-                    func_name2, logical_table_ids, int32_t, 1, 32),
-                MAKE_PTA_WITH_NAME(func_name2, buffer_ids, int32_t, 1, 32),
-                MAKE_PTA_WITH_NAME(
-                    func_name2, lxu_cache_locations, int32_t, 1, 32));
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        FBGEMM_LAUNCH_KERNEL(
+            (reset_weight_momentum_kernel<emb_t, cache_t>),
+            num_pruned_tables * blocks_per_table,
+            kMaxThreads,
+            0,
+            at::cuda::getCurrentCUDAStream(),
+            blocks_per_table,
+            PTA_B(dev_weights, emb_t, 1, 64),
+            PTA_B(uvm_weights, emb_t, 1, 64),
+            PTA_B(lxu_cache_weights, cache_t, 2, 64),
+            PTA_B(weights_placements, int32_t, 1, 32),
+            PTA_B(weights_offsets, int64_t, 1, 32),
+            PTA_ACC_B(momentum1_dev, cache_t, 1, 64),
+            PTA_ACC_B(momentum1_uvm, cache_t, 1, 64),
+            PTA_B(momentum1_placements, int32_t, 1, 32),
+            PTA_B(momentum1_offsets, int64_t, 1, 32),
+            PTA_B(D_offsets, int32_t, 1, 32),
+            PTA_B(pruned_indices, int64_t, 1, 32),
+            PTA_B(pruned_indices_offsets, int64_t, 1, 32),
+            PTA_B(logical_table_ids, int32_t, 1, 32),
+            PTA_B(buffer_ids, int32_t, 1, 32),
+            PTA_B(lxu_cache_locations, int32_t, 1, 32));
       }));
 }


### PR DESCRIPTION
Summary: - Migrate TBE UVM cache kernels to `FBGEMM_LAUNCH_KERNEL`

Reviewed By: r-barnes

Differential Revision: D74758371


