### PR TITLE
Fix weights pointer not moving in idx==-1 case

### DIFF
--- a/src/EmbeddingSpMDMAutovec.cc
+++ b/src/EmbeddingSpMDMAutovec.cc
@@ -202,6 +202,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDM8Bit_autovec(
         if (!scale_bias_last && idx == -1) {
           // When scale_bias_last == false, assume this is for table batched
           // embedding (TBE) that can get -1 for pruned rows.
+          weights_addr++;
           continue;
         }
         return false;
@@ -693,6 +694,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDMRowWiseSparse_autovec(
         }
         IndexType idx = compressed_indices_table[uncompressed_idx];
         if (idx == -1) {
+          weights_addr++;
           continue;
         }
         // if (idx < 0 || idx >= compressed_data_size) {
@@ -758,6 +760,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDMRowWiseSparse_autovec(
         }
         IndexType idx = compressed_indices_table[uncompressed_idx];
         if (idx == -1) {
+          weights_addr++;
           continue;
         }
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1274

This fixes the weights pointer not correctly advancing when taking the loop shortcut when an input `idx == -1`.

Differential Revision: D75489926


