### PR TITLE
Limit the grid size for the TBE forward kernel

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/device_properties.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/device_properties.cuh
@@ -8,10 +8,22 @@
 
 #pragma once
 
+#include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAStream.h>
 #include <cuda.h>
 
-namespace fbgemm_gpu::utils {
+namespace fbgemm_gpu::utils::cuda {
+
+// Based on the empirical study, max grid size that is 64x larger than the
+// number of SMs gives good performance across the board
+constexpr int32_t MAX_THREAD_BLOCKS_FACTOR = 64;
+
+inline auto get_max_thread_blocks(const c10::cuda::CUDAStream& stream) {
+  const auto device = stream.device_index();
+  return MAX_THREAD_BLOCKS_FACTOR *
+      at::cuda::getDeviceProperties(device)->multiProcessorCount;
+}
 
 inline auto get_compute_versions() {
   static const auto versions = [] {
@@ -27,4 +39,4 @@ inline auto get_compute_versions() {
   return versions;
 }
 
-} // namespace fbgemm_gpu::utils
+} // namespace fbgemm_gpu::utils::cuda

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
@@ -180,7 +180,13 @@ struct KernelLauncher {
     TORCH_CHECK(
         threads_per_block <= properties.maxThreadsPerBlock,
         context.description(),
-        ": Threads per block ",
+        ": [block dim ",
+        block.x,
+        " x ",
+        block.y,
+        " x ",
+        block.z,
+        "] Threads per block ",
         threads_per_block,
         " is greater than the limit of ",
         properties.maxThreadsPerBlock);
@@ -190,15 +196,28 @@ struct KernelLauncher {
     // automatically work around problem like CUDA does (V100 or newer
     // architectures), see:
     //    https://github.com/ROCm/hip/issues/2253
+    //    https://rocm.docs.amd.com/projects/HIP/en/docs-develop/reference/hip_runtime_api/modules/occupancy.html
     const uint64_t total_threads = U64(grid.x) * U64(grid.y) * U64(grid.z) *
         U64(block.x) * U64(block.y) * U64(block.z);
 
     TORCH_CHECK(
         total_threads < U64(std::numeric_limits<uint32_t>::max()),
         context.description(),
-        ": Total number of threads ",
+        " [grid dim ",
+        grid.x,
+        " x ",
+        grid.y,
+        " x ",
+        grid.z,
+        "] [block dim ",
+        block.x,
+        " x ",
+        block.y,
+        " x ",
+        block.z,
+        "]: Total number of threads ",
         total_threads,
-        " is greater than the limit of 2^32");
+        " is greater than the HIP limit of 2^32");
 #endif
   }
 

--- a/fbgemm_gpu/test/tbe/common.py
+++ b/fbgemm_gpu/test/tbe/common.py
@@ -45,6 +45,8 @@ MAX_EXAMPLES = 40
 # For long running tests reduce the number of iterations to reduce timeout errors.
 MAX_EXAMPLES_LONG_RUNNING = 15
 
+FORWARD_MAX_THREADS = 512
+
 VERBOSITY: Verbosity = Verbosity.verbose
 
 
@@ -83,3 +85,14 @@ def format_ref_tensors_in_mixed_B_layout(
 
 def assert_torch_equal(tensor_a: torch.Tensor, tensor_b: torch.Tensor) -> None:
     assert torch.equal(tensor_a, tensor_b)
+
+
+def get_max_thread_blocks(stream: torch.cuda.streams.Stream) -> int:
+    # Based on the empirical studies, having a max grid size that is 64x larger than
+    # the number of SMs gives good performance across the board
+    MAX_THREAD_BLOCKS_FACTOR = 64
+    device = stream.device_index
+    return (
+        MAX_THREAD_BLOCKS_FACTOR
+        * torch.cuda.get_device_properties(device).multi_processor_count
+    )


### PR DESCRIPTION
Summary:
- Limit the grid size for the TBE forward kernel, as we are observing thread
  counts over 2^32 for AMD runs

Reviewed By: yoyoyocmu, r-barnes

Differential Revision: D75543767


