### PR TITLE
Track updated rows in SSDTBE

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/cache/split_embeddings_cache_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/cache/split_embeddings_cache_ops.py
@@ -22,8 +22,8 @@ def get_unique_indices_v2(
         torch.Tensor,
         torch.Tensor,
         Optional[torch.Tensor],
-        Tuple[torch.Tensor, torch.Tensor],
     ],
+    Tuple[torch.Tensor, torch.Tensor],
 ]:
     """
     A wrapper for get_unique_indices for overloading the return type
@@ -43,7 +43,6 @@ def get_unique_indices_v2(
         return ret[:-1]
     if compute_inverse_indices:
         # Return (unique_indices, length, inverse_indices)
-        # pyre-fixme[7]: The arity arity of this return is wrong (3 vs 4)
         return ret[0], ret[1], ret[3]
     # Return (unique_indices, length)
     return ret[:-2]

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -617,6 +617,62 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             # SSD scratch pad index queue lookup completion event
             self.ssd_event_sp_idxq_lookup: torch.cuda.streams.Event = torch.cuda.Event()
 
+        if self.enable_raw_embedding_streaming:
+            # RES reuse the eviction stream
+            self.ssd_event_cache_streamed: torch.cuda.streams.Event = torch.cuda.Event()
+            self.ssd_event_cache_streaming_synced: torch.cuda.streams.Event = (
+                torch.cuda.Event()
+            )
+            self.ssd_event_cache_streaming_computed: torch.cuda.streams.Event = (
+                torch.cuda.Event()
+            )
+            self.ssd_event_sp_streamed: torch.cuda.streams.Event = torch.cuda.Event()
+
+            # Updated buffers
+            self.register_buffer(
+                "lxu_cache_updated_weights",
+                torch.ops.fbgemm.new_unified_tensor(
+                    torch.zeros(
+                        1,
+                        device=self.current_device,
+                        dtype=cache_dtype,
+                    ),
+                    self.lxu_cache_weights.shape,
+                    is_host_mapped=self.uvm_host_mapped,
+                ),
+            )
+
+            # For storing embedding indices to update to
+            self.register_buffer(
+                "lxu_cache_updated_indices",
+                torch.ops.fbgemm.new_unified_tensor(
+                    torch.zeros(
+                        1,
+                        device=self.current_device,
+                        dtype=torch.long,
+                    ),
+                    (self.lxu_cache_weights.shape[0],),
+                    is_host_mapped=self.uvm_host_mapped,
+                ),
+            )
+
+            # For storing the number of updated rows
+            self.register_buffer(
+                "lxu_cache_updated_count",
+                torch.ops.fbgemm.new_unified_tensor(
+                    torch.zeros(
+                        1,
+                        device=self.current_device,
+                        dtype=torch.int,
+                    ),
+                    (1,),
+                    is_host_mapped=self.uvm_host_mapped,
+                ),
+            )
+
+            # (Indices, Count)
+            self.prefetched_info: List[Tuple[Tensor, Tensor]] = []
+
         self.timesteps_prefetched: List[int] = []
         # TODO: add type annotation
         # pyre-fixme[4]: Attribute must be annotated.
@@ -1104,6 +1160,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             is_rows_uvm (bool): A flag to indicate whether `rows` is a UVM
                                 tensor (which is accessible on both host and
                                 device)
+            is_bwd (bool): A flag to indicate if the eviction is during backward
         Returns:
             None
         """
@@ -1124,6 +1181,95 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                     actions_count_cpu,
                     self.timestep,
                     is_bwd,
+                )
+
+                if post_event is not None:
+                    stream.record_event(post_event)
+
+    def raw_embedding_stream_sync(
+        self,
+        stream: torch.cuda.Stream,
+        pre_event: Optional[torch.cuda.Event],
+        post_event: Optional[torch.cuda.Event],
+        name: Optional[str] = "",
+    ) -> None:
+        """
+        Blocking wait the copy operation of the tensors to be streamed,
+        to make sure they are not overwritten
+        Args:
+            stream (Stream): The CUDA stream that cudaStreamAddCallback will
+                             synchronize the host function with.  Moreover, the
+                             asynchronous D->H memory copies will operate on
+                             this stream
+            pre_event (Event): The CUDA event that the stream has to wait on
+            post_event (Event): The CUDA event that the current will record on
+                                when the eviction is done
+        Returns:
+            None
+        """
+        with record_function(f"## ssd_stream_{name} ##"):
+            with torch.cuda.stream(stream):
+                if pre_event is not None:
+                    stream.wait_event(pre_event)
+
+                self.record_function_via_dummy_profile(
+                    f"## ssd_stream_sync_{name} ##",
+                    self.ssd_db.stream_sync_cuda,
+                )
+
+                if post_event is not None:
+                    stream.record_event(post_event)
+
+    def raw_embedding_stream(
+        self,
+        rows: Tensor,
+        indices_cpu: Tensor,
+        actions_count_cpu: Tensor,
+        stream: torch.cuda.Stream,
+        pre_event: Optional[torch.cuda.Event],
+        post_event: Optional[torch.cuda.Event],
+        is_rows_uvm: bool,
+        blocking_tensor_copy: bool = True,
+        name: Optional[str] = "",
+    ) -> None:
+        """
+        Stream data from the given input tensors to a remote service
+        Args:
+            rows (Tensor): The 2D tensor that contains rows to evict
+            indices_cpu (Tensor): The 1D CPU tensor that contains the row
+                                  indices that the rows will be evicted to
+            actions_count_cpu (Tensor): A scalar tensor that contains the
+                                        number of rows that the evict function
+                                        has to process
+            stream (Stream): The CUDA stream that cudaStreamAddCallback will
+                             synchronize the host function with.  Moreover, the
+                             asynchronous D->H memory copies will operate on
+                             this stream
+            pre_event (Event): The CUDA event that the stream has to wait on
+            post_event (Event): The CUDA event that the current will record on
+                                when the eviction is done
+            is_rows_uvm (bool): A flag to indicate whether `rows` is a UVM
+                                tensor (which is accessible on both host and
+                                device)
+        Returns:
+            None
+        """
+        with record_function(f"## ssd_stream_{name} ##"):
+            with torch.cuda.stream(stream):
+                if pre_event is not None:
+                    stream.wait_event(pre_event)
+
+                rows_cpu = rows if is_rows_uvm else self.to_pinned_cpu(rows)
+
+                rows.record_stream(stream)
+
+                self.record_function_via_dummy_profile(
+                    f"## ssd_stream_{name} ##",
+                    self.ssd_db.stream_cuda,
+                    indices_cpu,
+                    rows_cpu,
+                    actions_count_cpu,
+                    blocking_tensor_copy,
                 )
 
                 if post_event is not None:
@@ -1165,6 +1311,18 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             if not do_evict:
                 return
 
+            if self.enable_raw_embedding_streaming:
+                self.raw_embedding_stream(
+                    rows=inserted_rows,
+                    indices_cpu=post_bwd_evicted_indices_cpu,
+                    actions_count_cpu=actions_count_cpu,
+                    stream=self.ssd_eviction_stream,
+                    pre_event=self.ssd_event_backward,
+                    post_event=self.ssd_event_sp_streamed,
+                    is_rows_uvm=True,
+                    blocking_tensor_copy=True,
+                    name="scratch_pad",
+                )
             self.evict(
                 rows=inserted_rows,
                 indices_cpu=post_bwd_evicted_indices_cpu,
@@ -1406,6 +1564,79 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 masks=torch.where(evicted_indices != -1, 1, 0),
                 count=actions_count_gpu,
             )
+            has_raw_embedding_streaming = False
+            if self.enable_raw_embedding_streaming:
+                # when pipelining is enabled
+                # prefetch in iter i happens before the backward sparse in iter i - 1
+                # so embeddings for iter i - 1's changed ids are not updated.
+                # so we can only fetch the indices from the iter i - 2
+                # when pipelining is disabled
+                # prefetch in iter i happens before forward iter i
+                # so we can get the iter i - 1's changed ids safely.
+                target_prev_iter = 1
+                if self.prefetch_pipeline:
+                    target_prev_iter = 2
+                if len(self.prefetched_info) > (target_prev_iter - 1):
+                    with record_function(
+                        "## ssd_lookup_prefetched_rows {} {} ##".format(
+                            self.timestep, self.tbe_unique_id
+                        )
+                    ):
+                        # wait for the copy to finish before overwriting the buffer
+                        self.raw_embedding_stream_sync(
+                            stream=self.ssd_eviction_stream,
+                            pre_event=self.ssd_event_cache_streamed,
+                            post_event=self.ssd_event_cache_streaming_synced,
+                            name="cache_update",
+                        )
+                        current_stream.wait_event(self.ssd_event_cache_streaming_synced)
+                        (updated_indices, updated_counts_gpu) = (
+                            self.prefetched_info.pop(0)
+                        )
+                        self.lxu_cache_updated_indices[: updated_indices.size(0)].copy_(
+                            updated_indices,
+                            non_blocking=True,
+                        )
+                        self.lxu_cache_updated_count[:1].copy_(
+                            updated_counts_gpu, non_blocking=True
+                        )
+                        has_raw_embedding_streaming = True
+
+                with record_function(
+                    "## ssd_save_prefetched_rows {} {} ##".format(
+                        self.timestep, self.tbe_unique_id
+                    )
+                ):
+                    masked_updated_indices = torch.where(
+                        torch.where(lxu_cache_locations != -1, True, False),
+                        linear_cache_indices,
+                        -1,
+                    )
+
+                    (
+                        uni_updated_indices,
+                        uni_updated_indices_length,
+                    ) = get_unique_indices_v2(
+                        masked_updated_indices,
+                        self.total_hash_size,
+                        compute_count=False,
+                        compute_inverse_indices=False,
+                    )
+                    assert uni_updated_indices is not None
+                    assert uni_updated_indices_length is not None
+                    # The unique indices has 1 more -1 element than needed,
+                    # which might make the tensor length go out of range
+                    # compared to the pre-allocated buffer.
+                    unique_len = min(
+                        self.lxu_cache_weights.size(0),
+                        uni_updated_indices.size(0),
+                    )
+                    self.prefetched_info.append(
+                        (
+                            uni_updated_indices.narrow(0, 0, unique_len),
+                            uni_updated_indices_length.clamp(max=unique_len),
+                        )
+                    )
 
             with record_function("## ssd_d2h_inserted_indices ##"):
                 # Transfer actions_count and insert_indices right away to
@@ -1548,6 +1779,41 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             current_stream.wait_event(self.ssd_event_sp_evict)
             # Ensure that D2H is done
             current_stream.wait_event(self.ssd_event_get_inputs_cpy)
+
+            if self.enable_raw_embedding_streaming and has_raw_embedding_streaming:
+                current_stream.wait_event(self.ssd_event_sp_streamed)
+                with record_function(
+                    "## ssd_compute_updated_rows {} {} ##".format(
+                        self.timestep, self.tbe_unique_id
+                    )
+                ):
+                    # cache rows that are changed in the previous iteration
+                    updated_cache_locations = torch.ops.fbgemm.lxu_cache_lookup(
+                        self.lxu_cache_updated_indices,
+                        self.lxu_cache_state,
+                        self.total_hash_size,
+                        self.gather_ssd_cache_stats,
+                        self.local_ssd_cache_stats,
+                    )
+                    torch.ops.fbgemm.masked_index_select(
+                        self.lxu_cache_updated_weights,
+                        updated_cache_locations,
+                        self.lxu_cache_weights,
+                        self.lxu_cache_updated_count,
+                    )
+                current_stream.record_event(self.ssd_event_cache_streaming_computed)
+
+                self.raw_embedding_stream(
+                    rows=self.lxu_cache_updated_weights,
+                    indices_cpu=self.lxu_cache_updated_indices,
+                    actions_count_cpu=self.lxu_cache_updated_count,
+                    stream=self.ssd_eviction_stream,
+                    pre_event=self.ssd_event_cache_streaming_computed,
+                    post_event=self.ssd_event_cache_streamed,
+                    is_rows_uvm=True,
+                    blocking_tensor_copy=False,
+                    name="cache_update",
+                )
 
             if self.gather_ssd_cache_stats:
                 # call to collect past SSD IO dur right before next rocksdb IO

--- a/fbgemm_gpu/src/ps_split_embeddings_cache/ps_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ps_split_embeddings_cache/ps_split_table_batched_embeddings.cpp
@@ -52,6 +52,18 @@ class EmbeddingParameterServerWrapper : public torch::jit::CustomClassHolder {
     return impl_->set_cuda(indices, weights, count, timestep, is_bwd);
   }
 
+  void stream_cuda(
+      const Tensor& indices,
+      const Tensor& weights,
+      const Tensor& count,
+      bool blocking_tensor_copy = true) {
+    return impl_->stream_cuda(indices, weights, count, blocking_tensor_copy);
+  }
+
+  void stream_sync_cuda() {
+    return impl_->stream_sync_cuda();
+  }
+
   void get_cuda(Tensor indices, Tensor weights, Tensor count) {
     return impl_->get_cuda(indices, weights, count);
   }
@@ -95,6 +107,10 @@ static auto embedding_parameter_server_wrapper =
              int64_t,
              int64_t>())
         .def("set_cuda", &EmbeddingParameterServerWrapper::set_cuda)
+        .def("stream_cuda", &EmbeddingParameterServerWrapper::stream_cuda)
+        .def(
+            "stream_sync_cuda",
+            &EmbeddingParameterServerWrapper::stream_sync_cuda)
         .def("get_cuda", &EmbeddingParameterServerWrapper::get_cuda)
         .def("compact", &EmbeddingParameterServerWrapper::compact)
         .def("flush", &EmbeddingParameterServerWrapper::flush)

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
@@ -83,6 +83,18 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
     return impl_->set_cuda(indices, weights, count, timestep, is_bwd);
   }
 
+  void stream_cuda(
+      const at::Tensor& indices,
+      const at::Tensor& weights,
+      const at::Tensor& count,
+      bool blocking_tensor_copy = true) {
+    return impl_->stream_cuda(indices, weights, count, blocking_tensor_copy);
+  }
+
+  void stream_sync_cuda() {
+    return impl_->stream_sync_cuda();
+  }
+
   void get_cuda(at::Tensor indices, at::Tensor weights, at::Tensor count) {
     return impl_->get_cuda(indices, weights, count);
   }

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -203,7 +203,8 @@ EmbeddingKVDB::~EmbeddingKVDB() {
   }
 #ifdef FBGEMM_FBCODE
   if (enable_raw_embedding_streaming_) {
-    weights_stream_thread_->join();
+    join_stream_tensor_copy_thread();
+    join_weights_stream_thread();
   }
 #endif
 }
@@ -300,6 +301,39 @@ folly::coro::Task<void> EmbeddingKVDB::tensor_stream(
   }
   co_return;
 }
+
+void EmbeddingKVDB::copy_and_enqueue_stream_tensors(
+    const at::Tensor& indices,
+    const at::Tensor& weights,
+    const at::Tensor& count) {
+  auto rec = torch::autograd::profiler::record_function_enter_new(
+      "## EmbeddingKVDB::copy_and_enqueue_stream_tensors ##");
+  auto stream_item =
+      tensor_copy(indices, weights, count, kv_db::RocksdbWriteMode::STREAM);
+  weights_to_stream_queue_.enqueue(stream_item);
+  rec->record.end();
+}
+
+void EmbeddingKVDB::join_stream_tensor_copy_thread() {
+  auto rec = torch::autograd::profiler::record_function_enter_new(
+      "## EmbeddingKVDB::join_stream_tensor_copy_thread ##");
+  if (stream_tensor_copy_thread_ != nullptr &&
+      stream_tensor_copy_thread_->joinable()) {
+    stream_tensor_copy_thread_->join();
+  }
+  rec->record.end();
+}
+
+void EmbeddingKVDB::join_weights_stream_thread() {
+  if (weights_stream_thread_ != nullptr && weights_stream_thread_->joinable()) {
+    stop_ = true;
+    weights_stream_thread_->join();
+  }
+}
+
+uint64_t EmbeddingKVDB::get_weights_to_stream_queue_size() {
+  return weights_to_stream_queue_.size();
+}
 #endif
 
 void EmbeddingKVDB::update_cache_and_storage(
@@ -389,6 +423,45 @@ void EmbeddingKVDB::set_cuda(
   rec->record.end();
 }
 
+void EmbeddingKVDB::stream_cuda(
+    const at::Tensor& indices,
+    const at::Tensor& weights,
+    const at::Tensor& count,
+    bool blocking_tensor_copy) {
+#ifdef FBGEMM_FBCODE
+  auto rec = torch::autograd::profiler::record_function_enter_new(
+      "## EmbeddingKVDB::stream_cuda ##");
+  check_tensor_type_consistency(indices, weights);
+  // take reference to self to avoid lifetime issues.
+  auto self = shared_from_this();
+  std::function<void()>* functor = new std::function<void()>(
+      [=]() { self->stream(indices, weights, count, blocking_tensor_copy); });
+  AT_CUDA_CHECK(cudaStreamAddCallback(
+      at::cuda::getCurrentCUDAStream(),
+      kv_db_utils::cuda_callback_func,
+      functor,
+      0));
+  rec->record.end();
+#endif
+}
+
+void EmbeddingKVDB::stream_sync_cuda() {
+#ifdef FBGEMM_FBCODE
+  auto rec = torch::autograd::profiler::record_function_enter_new(
+      "## EmbeddingKVDB::stream_sync_cuda ##");
+  // take reference to self to avoid lifetime issues.
+  auto self = shared_from_this();
+  std::function<void()>* functor = new std::function<void()>(
+      [=]() { self->join_stream_tensor_copy_thread(); });
+  AT_CUDA_CHECK(cudaStreamAddCallback(
+      at::cuda::getCurrentCUDAStream(),
+      kv_db_utils::cuda_callback_func,
+      functor,
+      0));
+  rec->record.end();
+#endif
+}
+
 std::vector<double> EmbeddingKVDB::get_l2cache_perf(
     const int64_t step,
     const int64_t interval) {
@@ -458,6 +531,9 @@ void EmbeddingKVDB::set(
     return;
   }
   CHECK_EQ(max_D_, weights.size(1));
+
+  auto rec = torch::autograd::profiler::record_function_enter_new(
+      "## EmbeddingKVDB::set_callback ##");
   // defer the L2 cache/rocksdb update to the background thread as it could
   // be parallelized with other cuda kernels, as long as all updates are
   // finished before the next L2 cache lookup
@@ -473,6 +549,7 @@ void EmbeddingKVDB::set(
   } else {
     update_cache_and_storage(indices, weights, count, write_mode);
   }
+  rec->record.end();
 }
 
 void EmbeddingKVDB::get(
@@ -486,6 +563,8 @@ void EmbeddingKVDB::get(
         << num_lookups;
     return;
   }
+  auto rec = torch::autograd::profiler::record_function_enter_new(
+      "## EmbeddingKVDB::get_callback ##");
   CHECK_GE(max_D_, weights.size(1));
   auto start_ts = facebook::WallClockUtil::NowInUsecFast();
   wait_util_filling_work_done();
@@ -546,6 +625,33 @@ void EmbeddingKVDB::get(
     get_kv_db_async(indices, weights, count).wait();
   }
   get_total_duration_ += facebook::WallClockUtil::NowInUsecFast() - start_ts;
+  rec->record.end();
+}
+
+void EmbeddingKVDB::stream(
+    const at::Tensor& indices,
+    const at::Tensor& weights,
+    const at::Tensor& count,
+    bool blocking_tensor_copy) {
+  if (!enable_raw_embedding_streaming_) {
+    return;
+  }
+  auto rec = torch::autograd::profiler::record_function_enter_new(
+      "## EmbeddingKVDB::stream_callback ##");
+  if (blocking_tensor_copy) {
+    copy_and_enqueue_stream_tensors(indices, weights, count);
+    return;
+  }
+  // Make sure the previous thread is done before starting a new one
+  join_stream_tensor_copy_thread();
+  // Cuda dispatches the host callbacks all in the same CPU thread. But the
+  // callbacks don't need to be serialized.
+  // So, We need to spin up a new thread to unblock the CUDA stream, so the CUDA
+  // can continue executing other host callbacks, eg. get/evict.
+  stream_tensor_copy_thread_ = std::make_unique<std::thread>([=, this]() {
+    copy_and_enqueue_stream_tensors(indices, weights, count);
+  });
+  rec->record.end();
 }
 
 std::shared_ptr<CacheContext> EmbeddingKVDB::get_cache(

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
@@ -80,8 +80,11 @@ class CacheContext {
 /// BWD_L1_CNFLCT_MISS_WRITE_BACK: L1 conflict miss will insert into L2 for
 /// embedding update on bwd path
 ///
-/// All the L2 cache filling above will potentially trigger rocksdb write once
-/// L2 cache is full
+/// All the L2 cache filling above will
+/// potentially trigger rocksdb write once L2 cache is full
+///
+/// STREAM: placeholder for raw embedding streaming requests, it doesn't
+/// directly interact with L2 and rocksDB
 ///
 /// Additionally we will do ssd io on L2 flush
 enum RocksdbWriteMode {
@@ -89,6 +92,7 @@ enum RocksdbWriteMode {
   FWD_L1_EVICTION = 1,
   BWD_L1_CNFLCT_MISS_WRITE_BACK = 2,
   FLUSH = 3,
+  STREAM = 4,
 };
 
 /// @ingroup embedding-ssd
@@ -195,6 +199,33 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
       const at::Tensor& count,
       int64_t sleep_ms = 0);
 
+  /// Stream out non-negative elements in <indices> and its paired embeddings
+  /// from <weights> for the first <count> elements in the tensor.
+  /// It spins up a thread that will copy all 3 tensors to CPU and inject them
+  /// into the background queue which will be picked up by another set of thread
+  /// pools for streaming out to the thrift server (co-located on same host
+  /// now).
+  ///
+  /// This is used in cuda stream callback, which doesn't require to be
+  /// serialized with other callbacks, thus a separate thread is used to
+  /// maximize the overlapping with other callbacks.
+  ///
+  /// @param indices The 1D embedding index tensor, should skip on negative
+  /// value
+  /// @param weights The 2D tensor that each row(embeddings) is paired up with
+  /// relative element in <indices>
+  /// @param count A single element tensor that contains the number of indices
+  /// to be processed
+  /// @param blocking_tensor_copy whether to copy the tensors to be streamed in
+  /// a blocking manner
+  ///
+  /// @return None
+  void stream(
+      const at::Tensor& indices,
+      const at::Tensor& weights,
+      const at::Tensor& count,
+      bool blocking_tensor_copy = true);
+
   /// storage tier counterpart of function get()
   virtual folly::SemiFuture<std::vector<folly::Unit>> get_kv_db_async(
       const at::Tensor& indices,
@@ -232,6 +263,14 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
       const at::Tensor& count,
       const int64_t timestep,
       const bool is_bwd = false);
+
+  void stream_cuda(
+      const at::Tensor& indices,
+      const at::Tensor& weights,
+      const at::Tensor& count,
+      bool blocking_tensor_copy = true);
+
+  void stream_sync_cuda();
 
   /// export internally collected L2 performance metrics out
   ///
@@ -310,6 +349,28 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
   folly::coro::Task<void> tensor_stream(
       const at::Tensor& indices,
       const at::Tensor& weights);
+  /*
+   * Copy the indices, weights and count tensors and enqueue them for
+   * asynchronous stream.
+   */
+  void copy_and_enqueue_stream_tensors(
+      const at::Tensor& indices,
+      const at::Tensor& weights,
+      const at::Tensor& count);
+
+  /*
+   * Join the stream tensor copy thread, make sure the thread is properly
+   * finished before creating new.
+   */
+  void join_stream_tensor_copy_thread();
+
+  /*
+   * FOR TESTING: Join the weight stream thread, make sure the thread is
+   * properly finished for destruction and testing.
+   */
+  void join_weights_stream_thread();
+  // FOR TESTING: get queue size.
+  uint64_t get_weights_to_stream_queue_size();
 #endif
 
  private:
@@ -447,7 +508,8 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
   std::vector<int64_t> table_offsets_;
   at::Tensor table_sizes_;
   std::unique_ptr<std::thread> weights_stream_thread_;
-  folly::USPSCQueue<QueueItem, true> weights_to_stream_queue_;
+  folly::UMPSCQueue<QueueItem, true> weights_to_stream_queue_;
+  std::unique_ptr<std::thread> stream_tensor_copy_thread_;
 }; // class EmbeddingKVDB
 
 } // namespace kv_db

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -543,6 +543,17 @@ static auto embedding_rocks_db_wrapper =
                 torch::arg("timestep"),
                 torch::arg("is_bwd") = false,
             })
+        .def(
+            "stream_cuda",
+            &EmbeddingRocksDBWrapper::stream_cuda,
+            "",
+            {
+                torch::arg("indices"),
+                torch::arg("weights"),
+                torch::arg("count"),
+                torch::arg("blocking_tensor_copy"),
+            })
+        .def("stream_sync_cuda", &EmbeddingRocksDBWrapper::stream_sync_cuda)
         .def("get_cuda", &EmbeddingRocksDBWrapper::get_cuda)
         .def("compact", &EmbeddingRocksDBWrapper::compact)
         .def("flush", &EmbeddingRocksDBWrapper::flush)

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -483,6 +483,8 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
       case kv_db::RocksdbWriteMode::FLUSH:
         flush_write_dur_ += duration;
         break;
+      case kv_db::RocksdbWriteMode::STREAM:
+        break;
     }
 #endif
     return folly::collect(futures);

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/test/ssd_table_batched_embeddings_test.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/test/ssd_table_batched_embeddings_test.cpp
@@ -245,3 +245,67 @@ TEST(KvDbTableBatchedEmbeddingsTest, TestTensorStream) {
   folly::coro::blockingWait(mock_embedding_rocks->tensor_stream(ind, weights));
 }
 #endif
+
+#ifdef FBGEMM_FBCODE
+TEST(KvDbTableBatchedEmbeddingsTest, TestStream) {
+  int num_shards = 8;
+  std::vector<std::string> table_names = {"tb1", "tb2", "tb3"};
+  std::vector<int64_t> table_offsets = {0, 100, 300};
+  std::vector<int64_t> table_sizes = {0, 50, 200, 300};
+  auto mock_embedding_rocks = getMockEmbeddingRocksDB(
+      num_shards, "test_stream", true, table_names, table_offsets, table_sizes);
+  auto ind = at::tensor(
+      {10, 2, 1, 150, 170, 230, 280},
+      at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  auto weights = at::randn(
+      {ind.size(0), 8},
+      at::TensorOptions().device(at::kCPU).dtype(c10::kFloat));
+  auto count = at::tensor(
+      {ind.size(0)}, at::TensorOptions().device(at::kCPU).dtype(at::kLong));
+  // stop the dequeue thread to get accurate queue size
+  mock_embedding_rocks->join_weights_stream_thread();
+
+  // blocking
+  mock_embedding_rocks->stream(ind, weights, count, true);
+  EXPECT_EQ(mock_embedding_rocks->get_weights_to_stream_queue_size(), 1);
+  // non-blocking
+  mock_embedding_rocks->stream(ind, weights, count, false);
+  EXPECT_EQ(mock_embedding_rocks->get_weights_to_stream_queue_size(), 1);
+  mock_embedding_rocks->join_stream_tensor_copy_thread();
+  EXPECT_EQ(mock_embedding_rocks->get_weights_to_stream_queue_size(), 2);
+  mock_embedding_rocks.reset();
+
+  // E2E
+  auto default_response =
+      [](std::unique_ptr<
+          aiplatform::gmpp::experimental::training_ps::SetEmbeddingsRequest>
+             request)
+      -> folly::coro::Task<std::unique_ptr<
+          aiplatform::gmpp::experimental::training_ps::SetEmbeddingsResponse>> {
+    co_return std::make_unique<
+        aiplatform::gmpp::experimental::training_ps::SetEmbeddingsResponse>();
+  };
+  // Mock TrainingParameterServerService
+  auto mock_service = std::make_shared<MockTrainingParameterServerService>();
+  auto mock_server =
+      std::make_shared<apache::thrift::ScopedServerInterfaceThread>(
+          mock_service,
+          "::1",
+          0,
+          facebook::services::TLSConfig::applyDefaultsToThriftServer);
+  auto& mock_client_factory =
+      facebook::servicerouter::getMockSRClientFactory(false /* strict */);
+  mock_client_factory.registerMockService(
+      "realtime.delta.publish.esr", mock_server);
+  EXPECT_CALL(*mock_service, co_setEmbeddings(_))
+      .Times(3) // 3 shards with consistent hashing
+      .WillRepeatedly(folly::coro::gmock_helpers::CoInvoke(default_response));
+
+  mock_embedding_rocks = getMockEmbeddingRocksDB(
+      num_shards, "test_stream", true, table_names, table_offsets, table_sizes);
+  mock_embedding_rocks->stream(ind, weights, count, true);
+  // make sure dequeue finished.
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  mock_embedding_rocks->join_weights_stream_thread();
+}
+#endif

--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
@@ -24,6 +24,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
     KVZCHParams,
     PoolingMode,
 )
+from fbgemm_gpu.split_table_batched_embeddings_ops_training import RESParams
 from fbgemm_gpu.tbe.ssd import SSDTableBatchedEmbeddingBags
 from fbgemm_gpu.tbe.utils import (
     b_indices,
@@ -31,6 +32,7 @@ from fbgemm_gpu.tbe.utils import (
     round_up,
 )
 from hypothesis import assume, given, settings, Verbosity
+from torch import distributed as dist
 
 from .. import common  # noqa E402
 from ..common import gen_mixed_B_batch_sizes, gpu_unavailable, running_in_oss
@@ -471,6 +473,7 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
         prefetch_pipeline: bool = False,
         bulk_init_chunk_size: int = 0,
         lazy_bulk_init_enabled: bool = False,
+        enable_raw_embedding_streaming: bool = False,
     ) -> Tuple[SSDTableBatchedEmbeddingBags, List[torch.nn.EmbeddingBag]]:
         """
         Generate embedding modules (i,e., SSDTableBatchedEmbeddingBags and
@@ -527,29 +530,40 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
             emb_ref.insert(table_to_replicate, emb_ref[table_to_replicate])
 
         cache_sets = max(int(max(T * B * L, 1) * cache_set_scale), 1)
+        res_params: Optional[RESParams] = None
+        if enable_raw_embedding_streaming:
+            res_params = RESParams(
+                res_server_port=0,
+                res_store_shards=1,
+                table_names=["t" + str(x) for x in range(0, T)],
+                table_offsets=[0] * T,
+            )
 
-        # Generate TBE SSD
-        emb = SSDTableBatchedEmbeddingBags(
-            embedding_specs=[(E, D) for (E, D) in zip(Es, Ds)],
-            feature_table_map=feature_table_map,
-            ssd_storage_directory=tempfile.mkdtemp(),
-            cache_sets=cache_sets,
-            ssd_uniform_init_lower=-0.1,
-            ssd_uniform_init_upper=0.1,
-            learning_rate=lr,
-            eps=eps,
-            ssd_rocksdb_shards=ssd_shards,
-            optimizer=optimizer,
-            pooling_mode=pooling_mode,
-            weights_precision=weights_precision,
-            output_dtype=output_dtype,
-            stochastic_rounding=stochastic_rounding,
-            prefetch_pipeline=prefetch_pipeline,
-            bounds_check_mode=BoundsCheckMode.WARNING,
-            l2_cache_size=8,
-            bulk_init_chunk_size=bulk_init_chunk_size,
-            lazy_bulk_init_enabled=lazy_bulk_init_enabled,
-        ).cuda()
+        with unittest.mock.patch.object(dist, "get_rank", return_value=0):
+            # Generate TBE SSD
+            emb = SSDTableBatchedEmbeddingBags(
+                embedding_specs=[(E, D) for (E, D) in zip(Es, Ds)],
+                feature_table_map=feature_table_map,
+                ssd_storage_directory=tempfile.mkdtemp(),
+                cache_sets=cache_sets,
+                ssd_uniform_init_lower=-0.1,
+                ssd_uniform_init_upper=0.1,
+                learning_rate=lr,
+                eps=eps,
+                ssd_rocksdb_shards=ssd_shards,
+                optimizer=optimizer,
+                pooling_mode=pooling_mode,
+                weights_precision=weights_precision,
+                output_dtype=output_dtype,
+                stochastic_rounding=stochastic_rounding,
+                prefetch_pipeline=prefetch_pipeline,
+                bounds_check_mode=BoundsCheckMode.WARNING,
+                l2_cache_size=8,
+                bulk_init_chunk_size=bulk_init_chunk_size,
+                lazy_bulk_init_enabled=lazy_bulk_init_enabled,
+                enable_raw_embedding_streaming=enable_raw_embedding_streaming,
+                res_params=res_params,
+            ).cuda()
 
         if bulk_init_chunk_size > 0 and lazy_bulk_init_enabled:
             self.assertIsNotNone(
@@ -1102,6 +1116,8 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
         flush_location: Optional[FlushLocation],
         trigger_bounds_check: bool,
         mixed_B: bool = False,
+        enable_raw_embedding_streaming: bool = False,
+        num_iterations: int = 10,
     ) -> None:
         # If using pipeline prefetching, explicit prefetching must be True
         assert not prefetch_pipeline or explicit_prefetch
@@ -1135,6 +1151,7 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
             stochastic_rounding=False,
             share_table=share_table,
             prefetch_pipeline=prefetch_pipeline,
+            enable_raw_embedding_streaming=enable_raw_embedding_streaming,
         )
 
         optimizer_states_ref = [
@@ -1150,7 +1167,7 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
         )
 
         batches = []
-        for it in range(10):
+        for _it in range(num_iterations):
             batches.append(
                 self.generate_inputs_(
                     B,
@@ -1168,8 +1185,6 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
         )
         forward_stream = torch.cuda.current_stream() if use_prefetch_stream else None
 
-        iters = 10
-
         force_flush = flush_location == FlushLocation.ALL
 
         if force_flush or flush_location == FlushLocation.BEFORE_TRAINING:
@@ -1177,7 +1192,7 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
 
         # pyre-ignore[53]
         def _prefetch(b_it: int) -> int:
-            if not explicit_prefetch or b_it >= iters:
+            if not explicit_prefetch or b_it >= num_iterations:
                 return b_it + 1
 
             (
@@ -1204,7 +1219,7 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
         else:
             b_it = 0
 
-        for it in range(iters):
+        for it in range(num_iterations):
             (
                 indices_list,
                 per_sample_weights_list,
@@ -2218,4 +2233,121 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
                 num_active_id_per_bucket_list2[t],
                 atol=tolerance,
                 rtol=tolerance,
+            )
+
+    def _check_raw_embedding_stream_call_counts(
+        self,
+        mock_raw_embedding_stream: unittest.mock.Mock,
+        mock_raw_embedding_stream_sync: unittest.mock.Mock,
+        num_iterations: int,
+        prefetch_pipeline: bool,
+        L: int,
+    ) -> None:
+        offset = 2 if prefetch_pipeline else 1
+        self.assertEqual(
+            mock_raw_embedding_stream.call_count,
+            num_iterations * 2 - offset if L > 0 else num_iterations - offset,
+        )
+        self.assertEqual(
+            mock_raw_embedding_stream_sync.call_count, num_iterations - offset
+        )
+
+    @staticmethod
+    def _record_event_mock(
+        stream: torch.cuda.Stream,
+        pre_event: Optional[torch.cuda.Event],
+        post_event: Optional[torch.cuda.Event],
+        **kwargs_: Any,
+    ) -> None:
+        with torch.cuda.stream(stream):
+            if pre_event is not None:
+                stream.wait_event(pre_event)
+
+            if post_event is not None:
+                stream.record_event(post_event)
+
+    @given(
+        use_prefetch_stream=st.booleans(),
+        prefetch_location=st.sampled_from(PrefetchLocation),
+        **default_st,
+    )
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=MAX_PIPELINE_EXAMPLES,
+        deadline=None,
+    )
+    def test_raw_embedding_streaming(
+        self,
+        **kwargs: Any,
+    ):
+        assume(not kwargs["weighted"] or kwargs["pooling_mode"] == PoolingMode.SUM)
+        assume(not kwargs["mixed_B"] or kwargs["pooling_mode"] != PoolingMode.NONE)
+        num_iterations = 10
+        prefetch_pipeline = False
+        with unittest.mock.patch.object(
+            SSDTableBatchedEmbeddingBags,
+            "raw_embedding_stream",
+            side_effect=self._record_event_mock,
+        ) as mock_raw_embedding_stream, unittest.mock.patch.object(
+            SSDTableBatchedEmbeddingBags,
+            "raw_embedding_stream_sync",
+            side_effect=self._record_event_mock,
+        ) as mock_raw_embedding_stream_sync:
+            self.execute_ssd_cache_pipeline_(
+                prefetch_pipeline=prefetch_pipeline,
+                explicit_prefetch=prefetch_pipeline,
+                enable_raw_embedding_streaming=True,
+                flush_location=None,
+                num_iterations=num_iterations,
+                **kwargs,
+            )
+            self._check_raw_embedding_stream_call_counts(
+                mock_raw_embedding_stream=mock_raw_embedding_stream,
+                mock_raw_embedding_stream_sync=mock_raw_embedding_stream_sync,
+                num_iterations=num_iterations,
+                prefetch_pipeline=prefetch_pipeline,
+                L=kwargs["L"],
+            )
+
+    @given(
+        use_prefetch_stream=st.booleans(),
+        prefetch_location=st.sampled_from(PrefetchLocation),
+        **default_st,
+    )
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=MAX_PIPELINE_EXAMPLES,
+        deadline=None,
+    )
+    def test_raw_embedding_streaming_prefetch_pipeline(
+        self,
+        **kwargs: Any,
+    ):
+        assume(not kwargs["weighted"] or kwargs["pooling_mode"] == PoolingMode.SUM)
+        assume(not kwargs["mixed_B"] or kwargs["pooling_mode"] != PoolingMode.NONE)
+        num_iterations = 10
+        prefetch_pipeline = True
+        with unittest.mock.patch.object(
+            SSDTableBatchedEmbeddingBags,
+            "raw_embedding_stream",
+            side_effect=self._record_event_mock,
+        ) as mock_raw_embedding_stream, unittest.mock.patch.object(
+            SSDTableBatchedEmbeddingBags,
+            "raw_embedding_stream_sync",
+            side_effect=self._record_event_mock,
+        ) as mock_raw_embedding_stream_sync:
+            self.execute_ssd_cache_pipeline_(
+                prefetch_pipeline=prefetch_pipeline,
+                explicit_prefetch=prefetch_pipeline,
+                enable_raw_embedding_streaming=True,
+                flush_location=None,
+                num_iterations=num_iterations,
+                **kwargs,
+            )
+            self._check_raw_embedding_stream_call_counts(
+                mock_raw_embedding_stream=mock_raw_embedding_stream,
+                mock_raw_embedding_stream_sync=mock_raw_embedding_stream_sync,
+                num_iterations=num_iterations,
+                prefetch_pipeline=prefetch_pipeline,
+                L=kwargs["L"],
             )


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1286

Tracking the updated rows inside the prefetch
- track ids going to be changed in prefetch for L1
- stream in the prefetch for the rows that are updated in previous iterations for L1
- stream in sp evict for the rows in SP.

Reviewed By: q10

Differential Revision: D73819098


