### PR TITLE
pyre fixes for D75477355, group 1

### DIFF
--- a/fbgemm_gpu/test/tbe/inference/nbit_split_embeddings_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_split_embeddings_test.py
@@ -161,6 +161,7 @@ class NBitSplitEmbeddingsTest(unittest.TestCase):
                 torch.testing.assert_close(
                     scale.cpu(),
                     torch.tensor(
+                        # pyre-ignore: ['Undefined attribute : Optional type has no attribute `__...
                         scale_bias[:, : scale_bias.size(1) // 2]
                         .contiguous()
                         .cpu()
@@ -169,6 +170,7 @@ class NBitSplitEmbeddingsTest(unittest.TestCase):
                     ),
                 )
                 torch.testing.assert_close(
+                    # pyre-ignore: ['Undefined attribute : Optional type has no attribute `cpu`.']
                     bias.cpu(),
                     torch.tensor(
                         scale_bias[:, scale_bias.size(1) // 2 :]

--- a/fbgemm_gpu/test/tbe/training/backward_optimizers_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_optimizers_test.py
@@ -555,6 +555,7 @@ class BackwardOptimizersTest(unittest.TestCase):
                     rtol=1.0e-2,
                 )
 
+                # pyre-ignore: ['Undefined attribute : `Optional` has no attribute `__getitem__`.']
                 optimizer_states_dict = get_optimizer_states[t]
                 expected_keys = {"sum"}
                 if rowwise and weight_decay_mode in (


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1287

Not sure why all typing tests didn't run on D75477355 but a bunch of tests apparently didn't run. All the changes in this file are comment-only pyre ignores.

Differential Revision: D75576855


