### PR TITLE
Creating Checkpointhandle and connecting to EmbeddingRocksDB

### DIFF
--- a/fbgemm_gpu/test/tbe/ssd/embedding_cache/rocksdb_embedding_cache_test.cpp
+++ b/fbgemm_gpu/test/tbe/ssd/embedding_cache/rocksdb_embedding_cache_test.cpp
@@ -38,7 +38,8 @@ TEST(RocksDbEmbeddingCacheTest, TestPutAndGet) {
       -0.01, // uniform_init_lower,
       0.01, // uniform_init_upper,
       32, // row_storage_bitwidth = 32,
-      0 // cache_size = 0
+      0, // cache_size = 0
+      true // use_passed_in_path
   );
 
   auto write_indices =


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1300

Design doc: https://docs.google.com/document/d/149LdAEHOLP7ei4hwVVkAFXGa4N9uLs1J7efxfBZp3dY/edit?tab=t.0#heading=h.49t3yfaqmt54

Context:
We are enabling the usage of rocksDB checkpoint feature in KVTensorWrapper. This allows us to create checkpoints of the embedding tables in SSD. Later, these checkpoints are used by the checkpointing component to create a checkpoint and upload it it to the manifold 

In this diff:
CheckpointHandle: 
It is an entity is responsible for storing the details of the rocksDB Checkpoint. It consists of the file paths to the checkpoint of all shards. When creating KVTensorWrappers, we use the same checkpointHandle object

1. Creating CheckpointHandle class 
2. Adding the definition for CheckpointHandle constructor 
3. Adding CRUD functions for CheckpointHandle 
4. Connecting CheckpointHandle to EmbeddingRocksDB entity

Differential Revision: D75489827


