### PR TITLE
Creating RocksDBCheckpointHandler to expose rocksdb checkpoint to python

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -2195,6 +2195,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             no_snapshot=no_snapshot,
             should_flush=should_flush,
         )
+        checkpoint_handle = self.ssd_db.get_active_checkpoint_uuid(self.step)
 
         dtype = self.weights_precision.as_dtype()
         if self.load_state_dict and self.kv_zch_params:
@@ -2286,6 +2287,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 sorted_indices=(
                     bucket_ascending_id_tensor if self.kv_zch_params else None
                 ),
+                checkpoint_handle=checkpoint_handle,
             )
             (
                 tensor_wrapper.set_embedding_rocks_dp_wrapper(self.ssd_db)

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -2520,6 +2520,12 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         self.ssd_db.flush()
         self.last_flush_step = self.step
 
+    def create_rocksdb_hard_link_snapshot(self) -> None:
+        """
+        Create a rocksdb hard link snapshot to provide cross procs access to the underlying data
+        """
+        self.ssd_db.create_rocksdb_hard_link_snapshot(self.step)
+
     def prepare_inputs(
         self,
         indices: Tensor,

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
@@ -182,6 +182,17 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
     impl_->create_checkpoint(global_step);
   }
 
+  c10::intrusive_ptr<RocksdbCheckpointHandleWrapper> get_active_checkpoint_uuid(
+      int64_t global_step) {
+    auto uuid_opt = impl_->get_active_checkpoint_uuid(global_step);
+    if (uuid_opt.has_value()) {
+      return c10::make_intrusive<RocksdbCheckpointHandleWrapper>(
+          uuid_opt.value(), impl_);
+    } else {
+      return nullptr;
+    }
+  }
+
  private:
   friend class KVTensorWrapper;
 

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
@@ -178,6 +178,10 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
     return impl_->get_snapshot_count();
   }
 
+  void create_rocksdb_hard_link_snapshot(int64_t global_step) {
+    impl_->create_checkpoint(global_step);
+  }
+
  private:
   friend class KVTensorWrapper;
 

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper_cpu.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper_cpu.cpp
@@ -35,7 +35,8 @@ KVTensorWrapper::KVTensorWrapper(
     [[maybe_unused]] const std::optional<
         c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper>> snapshot_handle,
     [[maybe_unused]] const std::optional<at::Tensor> sorted_indices,
-    [[maybe_unused]] int64_t width_offset)
+    [[maybe_unused]] int64_t width_offset,
+    [[maybe_unused]] c10::intrusive_ptr<RocksdbCheckpointHandleWrapper>)
     // @lint-ignore CLANGTIDY clang-diagnostic-missing-noreturn
     : shape_(std::move(shape)), row_offset_(row_offset) {
   FBEXCEPTION("Not implemented");

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -615,7 +615,10 @@ static auto embedding_rocks_db_wrapper =
         .def("get_snapshot_count", &EmbeddingRocksDBWrapper::get_snapshot_count)
         .def(
             "get_keys_in_range_by_snapshot",
-            &EmbeddingRocksDBWrapper::get_keys_in_range_by_snapshot);
+            &EmbeddingRocksDBWrapper::get_keys_in_range_by_snapshot)
+        .def(
+            "create_rocksdb_hard_link_snapshot",
+            &EmbeddingRocksDBWrapper::create_rocksdb_hard_link_snapshot);
 
 static auto dram_kv_embedding_cache_wrapper =
     torch::class_<DramKVEmbeddingCacheWrapper>(

--- a/fbgemm_gpu/test/tbe/ssd/embedding_cache/rocksdb_embedding_cache_test.cpp
+++ b/fbgemm_gpu/test/tbe/ssd/embedding_cache/rocksdb_embedding_cache_test.cpp
@@ -38,7 +38,8 @@ TEST(RocksDbEmbeddingCacheTest, TestPutAndGet) {
       -0.01, // uniform_init_lower,
       0.01, // uniform_init_upper,
       32, // row_storage_bitwidth = 32,
-      0 // cache_size = 0
+      0, // cache_size = 0
+      true // use_passed_in_path
   );
 
   auto write_indices =


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1302

Design doc: https://docs.google.com/document/d/149LdAEHOLP7ei4hwVVkAFXGa4N9uLs1J7efxfBZp3dY/edit?tab=t.0#heading=h.49t3yfaqmt54

Context:
We are enabling the usage of rocksDB checkpoint feature in KVTensorWrapper. This allows us to create checkpoints of the embedding tables in SSD. Later, these checkpoints are used by the checkpointing component to create a checkpoint and upload it it to the manifold 

In this diff:
1. Creating a RocksDBCheckpointHandlerWrapper class to expose the rocksdb checkpoint to python
2. Adding a checkpointhandle attribute to the KVTensorWrapper
3. Adding changes in the training loop to accommodate creation of KVTensor with checkpointHandle

Differential Revision: D75489849


