### PR TITLE
Adding Serialization and Deserialization functions for KVTensor

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/utils/partially_materialized_tensor.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/utils/partially_materialized_tensor.py
@@ -93,6 +93,12 @@ class PartiallyMaterializedTensor:
     def get_weights_by_ids(self, ids: torch.Tensor) -> torch.Tensor:
         return self._wrapped.get_weights_by_ids(ids)
 
+    def __reduce__(self):
+        return (
+            PartiallyMaterializedTensor,
+            (self._wrapped,),
+        )
+
     def full_tensor(self) -> torch.Tensor:
         """
         This loads the full tensor into memory (may OOM).

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -452,28 +452,42 @@ void KVTensorWrapper::set_dram_db_wrapper(
 
 at::Tensor KVTensorWrapper::narrow(int64_t dim, int64_t start, int64_t length) {
   CHECK_EQ(dim, 0) << "Only narrow on dim 0 is supported";
-  CHECK_TRUE(db_ != nullptr);
-  CHECK_GE(db_->get_max_D(), shape_[1]);
-  CHECK_GE(db_->get_max_D(), shape_[1] + width_offset_);
-  TORCH_CHECK(
-      (snapshot_handle_ == nullptr) ==
-          (std::dynamic_pointer_cast<EmbeddingRocksDB>(db_).get() == nullptr),
-      "snapshot handler must be valid for rocksdb and nullptr for emb kvdb");
-  if (!sorted_indices_.has_value()) {
-    auto t = at::empty(c10::IntArrayRef({length, shape_[1]}), options_);
-    db_->get_range_from_snapshot(
-        t,
-        start + row_offset_,
-        length,
-        snapshot_handle_ != nullptr ? snapshot_handle_->handle : nullptr,
-        width_offset_,
-        shape_[1]);
-    CHECK(t.is_contiguous());
-    return t;
+  if (db_) {
+    CHECK_TRUE(db_ != nullptr);
+    CHECK_GE(db_->get_max_D(), shape_[1]);
+    TORCH_CHECK(
+        (snapshot_handle_ == nullptr) ==
+            (std::dynamic_pointer_cast<EmbeddingRocksDB>(db_).get() == nullptr),
+        "snapshot handler must be valid for rocksdb and nullptr for emb kvdb");
+    if (!sorted_indices_.has_value()) {
+      int64_t tensor_width = shape_[1] - width_offset_;
+      auto t = at::empty(c10::IntArrayRef({length, tensor_width}), options_);
+      db_->get_range_from_snapshot(
+          t,
+          start + row_offset_,
+          length,
+          snapshot_handle_ != nullptr ? snapshot_handle_->handle : nullptr,
+          width_offset_,
+          tensor_width);
+      CHECK(t.is_contiguous());
+      return t;
+    } else {
+      at::Tensor sliced_ids =
+          sorted_indices_.value().slice(0, start, start + length);
+      return get_weights_by_ids(sliced_ids);
+    }
   } else {
-    at::Tensor sliced_ids =
-        sorted_indices_.value().slice(0, start, start + length);
-    return get_weights_by_ids(sliced_ids);
+    CHECK(readonly_db_)
+        << "ReadOnlyEmbeddingKVDB pointer must be valid to read tensor";
+    int64_t tensor_width = shape_[1] - width_offset_;
+    auto t = at::empty(c10::IntArrayRef({length, tensor_width}), options_);
+    // auto t = at::empty(
+    // c10::IntArrayRef({length, readonly_db_->get_max_D()}), options_);
+    readonly_db_->get_range_from_rdb_checkpoint(
+        t, start + row_offset_, length, width_offset_);
+    // TBE may have multiple embeddings in one table padded to max D
+    // narrow to the actual shape here before returning
+    return t.narrow(1, 0, shape_[1]);
   }
 }
 
@@ -485,6 +499,7 @@ void KVTensorWrapper::set_range(
   // Mutex lock for disabling concurrent writes to the same KVTensor
   std::lock_guard<std::mutex> lock(mtx);
   CHECK_EQ(weights.device(), at::kCPU);
+  CHECK(db_) << "EmbeddingRocksDB must be a valid pointer to call set_range";
   CHECK_EQ(dim, 0) << "Only set_range on dim 0 is supported";
   CHECK_TRUE(db_ != nullptr);
   CHECK_GE(db_->get_max_D(), shape_[1]);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1303


Design doc: https://docs.google.com/document/d/149LdAEHOLP7ei4hwVVkAFXGa4N9uLs1J7efxfBZp3dY/edit?tab=t.0#heading=h.49t3yfaqmt54

Context:
We are enabling the usage of rocksDB checkpoint feature in KVTensorWrapper. This allows us to create checkpoints of the embedding tables in SSD. Later, these checkpoints are used by the checkpointing component to create a checkpoint and upload it it to the manifold 

In this diff:
We add serialization and deserialization support for KVTensor

Differential Revision: D75489887


