### PR TITLE
Dram optimizer initialization

### DIFF
--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
@@ -54,6 +54,8 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
   /// initializers. 32 kFloat || 16 kHalf || 8 kByte
   /// @param weight_ttl_in_hours ttl in hours for each entry before it being
   /// evicted
+  /// @param table_dims the table dimension for each table
+  /// @param hash_size_cumsum the hash size cumulative sum for each table
   /// @return None
   explicit DramKVEmbeddingCache(
       int64_t max_D,
@@ -62,7 +64,9 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
       int64_t num_shards = 8,
       int64_t num_threads = 32,
       int64_t row_storage_bitwidth = 32,
-      int64_t weight_ttl_in_hours = 2)
+      int64_t weight_ttl_in_hours = 2,
+      std::optional<at::Tensor> table_dims = std::nullopt,
+      std::optional<at::Tensor> hash_size_cumsum = std::nullopt)
       : kv_db::EmbeddingKVDB(
             num_shards,
             max_D,
@@ -81,6 +85,29 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
         uniform_init_lower,
         uniform_init_upper,
         row_storage_bitwidth);
+    if (table_dims.has_value()) {
+      TORCH_CHECK(table_dims->dim() == 1);
+      TORCH_CHECK(table_dims->dtype() == at::ScalarType::Long);
+      TORCH_CHECK(table_dims->is_contiguous());
+      TORCH_CHECK(table_dims->device().is_cpu());
+      TORCH_CHECK(hash_size_cumsum.has_value());
+      TORCH_CHECK(hash_size_cumsum->dim() == 1);
+      TORCH_CHECK(hash_size_cumsum->dtype() == at::ScalarType::Long);
+      TORCH_CHECK(hash_size_cumsum->is_contiguous());
+      TORCH_CHECK(hash_size_cumsum->device().is_cpu());
+      TORCH_CHECK(
+          table_dims->numel() + 1 == hash_size_cumsum->numel(),
+          "hash_size_cumsum length must be one more than table_dims length, but got ",
+          hash_size_cumsum->numel(),
+          " and ",
+          table_dims->numel());
+      sub_table_dims_.assign(
+          table_dims->data_ptr<int64_t>(),
+          table_dims->data_ptr<int64_t>() + table_dims->numel());
+      sub_table_hash_cumsum_.assign(
+          hash_size_cumsum->data_ptr<int64_t>() + 1, // skip the first 0
+          hash_size_cumsum->data_ptr<int64_t>() + hash_size_cumsum->numel());
+    }
   }
 
   void initialize_initializers(
@@ -219,11 +246,17 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
   /// to be processed
   ///
   /// @return None
-  folly::SemiFuture<std::vector<folly::Unit>> get_kv_db_async(
+  folly::SemiFuture<std::vector<folly::Unit>> get_kv_db_async_impl(
       const at::Tensor& indices,
       const at::Tensor& weights,
-      const at::Tensor& count) override {
+      const at::Tensor& count,
+      int64_t width_offset = 0,
+      std::optional<int64_t> width_length = std::nullopt) {
     std::vector<folly::Future<folly::Unit>> futures;
+    auto row_width = weights.size(1);
+    auto copy_width = width_length.value_or(row_width);
+    CHECK_LE(row_width, max_D_);
+    CHECK_EQ(copy_width, row_width);
     auto shardid_to_indexes = shard_input(indices, count);
 
     for (auto iter = shardid_to_indexes.begin();
@@ -233,12 +266,23 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
       const auto indexes = iter->second;
       auto f =
           folly::via(executor_.get())
-              .thenValue([this, shard_id, indexes, &indices, &weights](
-                             folly::Unit) {
+              .thenValue([this,
+                          shard_id,
+                          indexes,
+                          &indices,
+                          &weights,
+                          width_offset,
+                          row_width](folly::Unit) {
                 FBGEMM_DISPATCH_INTEGRAL_TYPES(
                     indices.scalar_type(),
                     "dram_kvstore_set",
-                    [this, shard_id, indexes, &indices, &weights] {
+                    [this,
+                     shard_id,
+                     indexes,
+                     &indices,
+                     &weights,
+                     width_offset,
+                     row_width] {
                       using index_t = scalar_t;
                       CHECK(indices.is_contiguous());
                       CHECK(weights.is_contiguous());
@@ -261,19 +305,25 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                         for (auto index_iter = indexes.begin();
                              index_iter != indexes.end();
                              index_iter++) {
-                          const auto id_index = *index_iter;
                           auto weights_data_ptr =
                               weights.data_ptr<weight_type>();
-                          auto id = int64_t(indices_data_ptr[id_index]);
-                          const auto cached_iter = wlmap->find(id);
+                          const auto weights_row_index = *index_iter;
+                          auto weight_idx =
+                              int64_t(indices_data_ptr[weights_row_index]);
+                          const auto cached_iter = wlmap->find(weight_idx);
                           if (cached_iter == wlmap->end()) {
+                            auto weight_width = get_width_for_weights(
+                                weight_idx, width_offset, row_width);
                             fill_from_row_storage(
                                 shard_id,
                                 reinterpret_cast<unsigned char*>(
                                     weights_data_ptr),
-                                id_index,
+                                weights_row_index,
                                 reinterpret_cast<unsigned char*>(
-                                    row_storage_data_ptr));
+                                    row_storage_data_ptr),
+                                width_offset,
+                                row_width,
+                                weight_width);
                             continue;
                           }
                           const auto& cache_results =
@@ -281,11 +331,13 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                           CHECK_EQ(cache_results.size(), max_D_);
                           std::copy(
                               reinterpret_cast<const weight_type*>(
-                                  &(cache_results[0])),
+                                  &(cache_results[0])) +
+                                  width_offset,
                               reinterpret_cast<const weight_type*>(
-                                  &(cache_results[max_D_])),
+                                  &(cache_results[0])) +
+                                  width_offset + row_width,
                               &(weights_data_ptr
-                                    [id_index * max_D_])); // dst_start
+                                    [weights_row_index * row_width]));
                         }
                       }
                     });
@@ -294,6 +346,13 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
     }
     return folly::collect(futures);
   };
+
+  folly::SemiFuture<std::vector<folly::Unit>> get_kv_db_async(
+      const at::Tensor& indices,
+      const at::Tensor& weights,
+      const at::Tensor& count) override {
+    return get_kv_db_async_impl(indices, weights, count);
+  }
 
   void set_range_to_storage(
       const at::Tensor& weights,
@@ -305,21 +364,95 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
     folly::coro::blockingWait(set_kv_db_async(seq_indices, weights, count));
   }
 
+  void get_range_from_snapshot(
+      const at::Tensor& weights,
+      const int64_t start,
+      const int64_t length,
+      const ssd::SnapshotHandle* snapshot_handle, // should be nullptr for dram
+      int64_t width_offset = 0,
+      std::optional<int64_t> width_length = std::nullopt) override {
+    CHECK(snapshot_handle == nullptr);
+    const auto seq_indices =
+        at::arange(start, start + length, at::TensorOptions().dtype(at::kLong));
+    const auto count = at::tensor({length}, at::ScalarType::Long);
+    get_kv_db_async_impl(
+        seq_indices, weights, count, width_offset, width_length)
+        .wait();
+  }
+
+  void get_kv_from_storage_by_snapshot(
+      const at::Tensor& ids,
+      const at::Tensor& weights,
+      const ssd::SnapshotHandle* snapshot_handle, // should be nullptr for dram
+      int64_t width_offset = 0,
+      std::optional<int64_t> width_length = std::nullopt) override {
+    CHECK(snapshot_handle == nullptr);
+    const auto count = at::tensor({ids.size(0)}, at::ScalarType::Long);
+    get_kv_db_async_impl(ids, weights, count, width_offset, width_length)
+        .wait();
+  }
+
   void compact() override {}
 
  private:
+  int64_t get_dim_from_index(int64_t weight_idx) const {
+    if (sub_table_dims_.empty()) {
+      return max_D_;
+    }
+    for (int i = 0; i < sub_table_hash_cumsum_.size(); i++) {
+      if (weight_idx < sub_table_hash_cumsum_[i]) {
+        return sub_table_dims_[i];
+      }
+    }
+    CHECK(false) << "weight_idx " << weight_idx
+                 << " doesn't belong to any feature";
+    return max_D_;
+  }
+
+  int64_t get_width_for_weights(
+      int64_t weight_idx,
+      int64_t width_offset,
+      int64_t row_width) const {
+    // when init an untouch embedding, we only want to init the weights part
+    // and set the optimizer part to 0. This function helps us to get the dim
+    // for each sub table, calculate the max bytes we should copy to the passed
+    // in weights_data_ptr before optimizer section
+    auto feature_dim = get_dim_from_index(weight_idx);
+    CHECK_GT(feature_dim, width_offset);
+    auto feature_width = feature_dim - width_offset;
+    return std::min(feature_width, row_width);
+  }
+
   void fill_from_row_storage(
       int shard_id,
       unsigned char* weights_data_ptr,
       int64_t weights_row_index,
-      unsigned char* row_storage_data_ptr) {
-    int64_t row_width = elem_size_ * max_D_;
+      unsigned char* row_storage_data_ptr,
+      int64_t width_offset,
+      int64_t row_width,
+      int64_t copied_width) {
+    CHECK_GE(row_width, copied_width);
+    CHECK_GE(max_D_, row_width);
+    int64_t storage_row_bytes = elem_size_ * max_D_;
+    int64_t row_bytes = row_width * elem_size_;
+    auto copied_bytes = elem_size_ * copied_width;
+    int64_t start_offset_bytes = elem_size_ * width_offset;
     int64_t row_index;
     initializers_[shard_id]->producer_queue_.dequeue(row_index);
+    // TODO: fill the opt state as zeros for init value?
     std::copy(
-        &(row_storage_data_ptr[row_index * row_width]),
-        &(row_storage_data_ptr[row_index * row_width + row_width]),
-        &(weights_data_ptr[weights_row_index * row_width]));
+        &(row_storage_data_ptr
+              [row_index * storage_row_bytes + start_offset_bytes]),
+        &(row_storage_data_ptr
+              [row_index * storage_row_bytes + start_offset_bytes +
+               copied_bytes]),
+        &(weights_data_ptr[weights_row_index * row_bytes]));
+    if (row_bytes > copied_bytes) {
+      std::memset(
+          &(weights_data_ptr[weights_row_index * row_bytes + copied_bytes]),
+          0,
+          row_bytes - copied_bytes);
+    }
     initializers_[shard_id]->consumer_queue_.enqueue(row_index);
   }
 
@@ -372,6 +505,8 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
   std::atomic_bool is_eviction_ongoing_ = false;
   std::vector<std::unique_ptr<ssd::Initializer>> initializers_;
   int64_t elem_size_;
+  std::vector<int64_t> sub_table_dims_;
+  std::vector<int64_t> sub_table_hash_cumsum_;
 }; // class DramKVEmbeddingCache
 
 } // namespace kv_mem

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h
@@ -29,7 +29,9 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
       int64_t num_shards = 8,
       int64_t num_threads = 32,
       int64_t row_storage_bitwidth = 32,
-      int64_t weight_ttl_in_hours = 2) {
+      int64_t weight_ttl_in_hours = 2,
+      const std::optional<at::Tensor>& table_dims = std::nullopt,
+      const std::optional<at::Tensor>& hash_size_cumsum = std::nullopt) {
     if (row_storage_bitwidth == 16) {
       impl_ = std::make_shared<kv_mem::DramKVEmbeddingCache<at::Half>>(
           max_D,
@@ -38,7 +40,9 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
           num_shards,
           num_threads,
           row_storage_bitwidth,
-          weight_ttl_in_hours);
+          weight_ttl_in_hours,
+          table_dims,
+          hash_size_cumsum);
     } else if (row_storage_bitwidth == 32) {
       impl_ = std::make_shared<kv_mem::DramKVEmbeddingCache<float>>(
           max_D,
@@ -47,7 +51,9 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
           num_shards,
           num_threads,
           row_storage_bitwidth,
-          weight_ttl_in_hours);
+          weight_ttl_in_hours,
+          table_dims,
+          hash_size_cumsum);
     } else {
       throw std::runtime_error("Failed to create recording device");
     }

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
@@ -396,6 +396,8 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
   const int64_t unique_id_;
   const int64_t num_shards_;
   const int64_t max_D_;
+  std::vector<int64_t> sub_table_dims_;
+  std::vector<int64_t> sub_table_hash_cumsum_;
   folly::Optional<at::ScalarType> index_dtype_{folly::none};
   folly::Optional<at::ScalarType> weights_dtype_{folly::none};
   std::unique_ptr<folly::CPUThreadPoolExecutor> executor_tp_;

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -349,20 +349,20 @@ at::Tensor KVTensorWrapper::narrow(int64_t dim, int64_t start, int64_t length) {
   CHECK_EQ(dim, 0) << "Only narrow on dim 0 is supported";
   CHECK_TRUE(db_ != nullptr);
   CHECK_GE(db_->get_max_D(), shape_[1]);
+  CHECK_GE(db_->get_max_D(), shape_[1] + width_offset_);
   TORCH_CHECK(
       (snapshot_handle_ == nullptr) ==
           (std::dynamic_pointer_cast<EmbeddingRocksDB>(db_).get() == nullptr),
       "snapshot handler must be valid for rocksdb and nullptr for emb kvdb");
   if (!sorted_indices_.has_value()) {
-    int64_t tensor_width = shape_[1] - width_offset_;
-    auto t = at::empty(c10::IntArrayRef({length, tensor_width}), options_);
+    auto t = at::empty(c10::IntArrayRef({length, shape_[1]}), options_);
     db_->get_range_from_snapshot(
         t,
         start + row_offset_,
         length,
         snapshot_handle_ != nullptr ? snapshot_handle_->handle : nullptr,
         width_offset_,
-        tensor_width);
+        shape_[1]);
     CHECK(t.is_contiguous());
     return t;
   } else {
@@ -415,20 +415,20 @@ void KVTensorWrapper::set_weights_and_ids(
 at::Tensor KVTensorWrapper::get_weights_by_ids(const at::Tensor& ids) {
   CHECK_TRUE(db_ != nullptr);
   CHECK_GE(db_->get_max_D(), shape_[1]);
+  CHECK_GE(db_->get_max_D(), shape_[1] + width_offset_);
   TORCH_CHECK(
       (snapshot_handle_ == nullptr) ==
           (std::dynamic_pointer_cast<EmbeddingRocksDB>(db_).get() == nullptr),
       "snapshot handler must be valid for rocksdb and nullptr for emb kvdb");
-  int64_t tensor_width = shape_[1] - width_offset_;
   auto weights =
-      at::empty(c10::IntArrayRef({ids.size(0), tensor_width}), options_);
+      at::empty(c10::IntArrayRef({ids.size(0), shape_[1]}), options_);
   auto linearized_ids = ids + row_offset_;
   db_->get_kv_from_storage_by_snapshot(
       linearized_ids,
       weights,
       snapshot_handle_ != nullptr ? snapshot_handle_->handle : nullptr,
       width_offset_,
-      tensor_width);
+      shape_[1]);
   CHECK(weights.is_contiguous());
   return weights;
 }
@@ -594,7 +594,9 @@ static auto dram_kv_embedding_cache_wrapper =
                 int64_t,
                 int64_t,
                 int64_t,
-                int64_t>(),
+                int64_t,
+                std::optional<at::Tensor>,
+                std::optional<at::Tensor>>(),
             "",
             {
                 torch::arg("max_D"),
@@ -604,6 +606,8 @@ static auto dram_kv_embedding_cache_wrapper =
                 torch::arg("num_threads") = 32,
                 torch::arg("row_storage_bitwidth") = 32,
                 torch::arg("weight_ttl_in_hours") = 2,
+                torch::arg("table_dims") = std::nullopt,
+                torch::arg("hash_size_cumsum") = std::nullopt,
             })
         .def(
             "set_cuda",

--- a/fbgemm_gpu/test/tbe/ssd/kv_tensor_wrapper_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/kv_tensor_wrapper_test.py
@@ -498,7 +498,11 @@ class KvTensorWrapperTest(TestCase):
             # case 1
             width_offset = 10
             tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
-                [E, D], weights.dtype, 0, snapshot, width_offset=width_offset
+                [E, D - width_offset],
+                weights.dtype,
+                0,
+                snapshot,
+                width_offset=width_offset,
             )
             tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
             narrowed = tensor_wrapper.narrow(0, 0, 1)
@@ -524,7 +528,11 @@ class KvTensorWrapperTest(TestCase):
 
             width_offset = 10
             tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
-                [E, new_D], weights.dtype, 0, snapshot, width_offset=width_offset
+                [E, new_D - width_offset],
+                weights.dtype,
+                0,
+                snapshot,
+                width_offset=width_offset,
             )
             tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
             narrowed = tensor_wrapper.narrow(0, 0, 1)


### PR DESCRIPTION
Summary:
similar to D74790101
**Context**
To support extremely large virtual table size for ZCH v.Next, we cannot preallocate optimizer state tensor in HBM with full table size.
The solution is to offload optimizer state from HBM to CPU together with weight value.
There is one caveat of this solution, which is that every weight value will be initialized with random value if the weight is not found from backend. However, at this time, the optimizer value should not be randomly initialized. This diff is to fill in random value only for weight, but not optimizer state.

**This diff**
- apply the same thing but for DRAM solution
- contains changes mentioned in D75264932

Reviewed By: duduyi2013

Differential Revision: D75232079
