### PR TITLE
Dram integration test - dram kv tensor wrapper

### DIFF
--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
@@ -54,6 +54,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
   /// initializers. 32 kFloat || 16 kHalf || 8 kByte
   /// @param weight_ttl_in_hours ttl in hours for each entry before it being
   /// evicted
+  /// @param enable_async_update whether to enable async update for the cache
   /// @param table_dims the table dimension for each table
   /// @param hash_size_cumsum the hash size cumulative sum for each table
   /// @return None
@@ -65,12 +66,16 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
       int64_t num_threads = 32,
       int64_t row_storage_bitwidth = 32,
       int64_t weight_ttl_in_hours = 2,
+      bool enable_async_update = false,
       std::optional<at::Tensor> table_dims = std::nullopt,
       std::optional<at::Tensor> hash_size_cumsum = std::nullopt)
       : kv_db::EmbeddingKVDB(
             num_shards,
             max_D,
-            0), // l2_cache_size_gb =0 to disable l2 cache
+            0, // l2_cache_size_gb =0 to disable l2 cache
+            0, // tbe_unqiue_id
+            2, // ele_size_bytes
+            enable_async_update),
         max_D_(max_D),
         num_shards_(num_shards),
         weight_ttl_in_hours_(weight_ttl_in_hours),

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
@@ -54,6 +54,8 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
   /// initializers. 32 kFloat || 16 kHalf || 8 kByte
   /// @param weight_ttl_in_hours ttl in hours for each entry before it being
   /// evicted
+  /// @param table_dims the table dimension for each table
+  /// @param hash_size_cumsum the hash size cumulative sum for each table
   /// @return None
   explicit DramKVEmbeddingCache(
       int64_t max_D,
@@ -62,7 +64,9 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
       int64_t num_shards = 8,
       int64_t num_threads = 32,
       int64_t row_storage_bitwidth = 32,
-      int64_t weight_ttl_in_hours = 2)
+      int64_t weight_ttl_in_hours = 2,
+      std::optional<at::Tensor> table_dims = std::nullopt,
+      std::optional<at::Tensor> hash_size_cumsum = std::nullopt)
       : kv_db::EmbeddingKVDB(
             num_shards,
             max_D,
@@ -81,6 +85,29 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
         uniform_init_lower,
         uniform_init_upper,
         row_storage_bitwidth);
+    if (table_dims.has_value()) {
+      TORCH_CHECK(table_dims->dim() == 1);
+      TORCH_CHECK(table_dims->dtype() == at::ScalarType::Long);
+      TORCH_CHECK(table_dims->is_contiguous());
+      TORCH_CHECK(table_dims->device().is_cpu());
+      TORCH_CHECK(hash_size_cumsum.has_value());
+      TORCH_CHECK(hash_size_cumsum->dim() == 1);
+      TORCH_CHECK(hash_size_cumsum->dtype() == at::ScalarType::Long);
+      TORCH_CHECK(hash_size_cumsum->is_contiguous());
+      TORCH_CHECK(hash_size_cumsum->device().is_cpu());
+      TORCH_CHECK(
+          table_dims->numel() + 1 == hash_size_cumsum->numel(),
+          "hash_size_cumsum length must be one more than table_dims length, but got ",
+          hash_size_cumsum->numel(),
+          " and ",
+          table_dims->numel());
+      sub_table_dims_.assign(
+          table_dims->data_ptr<int64_t>(),
+          table_dims->data_ptr<int64_t>() + table_dims->numel());
+      sub_table_hash_cumsum_.assign(
+          hash_size_cumsum->data_ptr<int64_t>() + 1, // skip the first 0
+          hash_size_cumsum->data_ptr<int64_t>() + hash_size_cumsum->numel());
+    }
   }
 
   void initialize_initializers(
@@ -219,11 +246,17 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
   /// to be processed
   ///
   /// @return None
-  folly::SemiFuture<std::vector<folly::Unit>> get_kv_db_async(
+  folly::SemiFuture<std::vector<folly::Unit>> get_kv_db_async_impl(
       const at::Tensor& indices,
       const at::Tensor& weights,
-      const at::Tensor& count) override {
+      const at::Tensor& count,
+      int64_t width_offset = 0,
+      std::optional<int64_t> width_length = std::nullopt) {
     std::vector<folly::Future<folly::Unit>> futures;
+    auto row_width = weights.size(1);
+    auto copy_width = width_length.value_or(row_width);
+    CHECK_LE(row_width, max_D_);
+    CHECK_EQ(copy_width, row_width);
     auto shardid_to_indexes = shard_input(indices, count);
 
     for (auto iter = shardid_to_indexes.begin();
@@ -233,12 +266,23 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
       const auto indexes = iter->second;
       auto f =
           folly::via(executor_.get())
-              .thenValue([this, shard_id, indexes, &indices, &weights](
-                             folly::Unit) {
+              .thenValue([this,
+                          shard_id,
+                          indexes,
+                          &indices,
+                          &weights,
+                          width_offset,
+                          row_width](folly::Unit) {
                 FBGEMM_DISPATCH_INTEGRAL_TYPES(
                     indices.scalar_type(),
                     "dram_kvstore_set",
-                    [this, shard_id, indexes, &indices, &weights] {
+                    [this,
+                     shard_id,
+                     indexes,
+                     &indices,
+                     &weights,
+                     width_offset,
+                     row_width] {
                       using index_t = scalar_t;
                       CHECK(indices.is_contiguous());
                       CHECK(weights.is_contiguous());
@@ -261,19 +305,25 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                         for (auto index_iter = indexes.begin();
                              index_iter != indexes.end();
                              index_iter++) {
-                          const auto id_index = *index_iter;
                           auto weights_data_ptr =
                               weights.data_ptr<weight_type>();
-                          auto id = int64_t(indices_data_ptr[id_index]);
-                          const auto cached_iter = wlmap->find(id);
+                          const auto weights_row_index = *index_iter;
+                          auto weight_idx =
+                              int64_t(indices_data_ptr[weights_row_index]);
+                          const auto cached_iter = wlmap->find(weight_idx);
                           if (cached_iter == wlmap->end()) {
+                            auto weight_width = get_width_for_weights(
+                                weight_idx, width_offset, row_width);
                             fill_from_row_storage(
                                 shard_id,
                                 reinterpret_cast<unsigned char*>(
                                     weights_data_ptr),
-                                id_index,
+                                weights_row_index,
                                 reinterpret_cast<unsigned char*>(
-                                    row_storage_data_ptr));
+                                    row_storage_data_ptr),
+                                width_offset,
+                                row_width,
+                                weight_width);
                             continue;
                           }
                           const auto& cache_results =
@@ -281,11 +331,13 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                           CHECK_EQ(cache_results.size(), max_D_);
                           std::copy(
                               reinterpret_cast<const weight_type*>(
-                                  &(cache_results[0])),
+                                  &(cache_results[0])) +
+                                  width_offset,
                               reinterpret_cast<const weight_type*>(
-                                  &(cache_results[max_D_])),
+                                  &(cache_results[0])) +
+                                  width_offset + row_width,
                               &(weights_data_ptr
-                                    [id_index * max_D_])); // dst_start
+                                    [weights_row_index * row_width]));
                         }
                       }
                     });
@@ -294,6 +346,13 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
     }
     return folly::collect(futures);
   };
+
+  folly::SemiFuture<std::vector<folly::Unit>> get_kv_db_async(
+      const at::Tensor& indices,
+      const at::Tensor& weights,
+      const at::Tensor& count) override {
+    return get_kv_db_async_impl(indices, weights, count);
+  }
 
   void set_range_to_storage(
       const at::Tensor& weights,
@@ -305,21 +364,95 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
     folly::coro::blockingWait(set_kv_db_async(seq_indices, weights, count));
   }
 
+  void get_range_from_snapshot(
+      const at::Tensor& weights,
+      const int64_t start,
+      const int64_t length,
+      const ssd::SnapshotHandle* snapshot_handle, // should be nullptr for dram
+      int64_t width_offset = 0,
+      std::optional<int64_t> width_length = std::nullopt) override {
+    CHECK(snapshot_handle == nullptr);
+    const auto seq_indices =
+        at::arange(start, start + length, at::TensorOptions().dtype(at::kLong));
+    const auto count = at::tensor({length}, at::ScalarType::Long);
+    get_kv_db_async_impl(
+        seq_indices, weights, count, width_offset, width_length)
+        .wait();
+  }
+
+  void get_kv_from_storage_by_snapshot(
+      const at::Tensor& ids,
+      const at::Tensor& weights,
+      const ssd::SnapshotHandle* snapshot_handle, // should be nullptr for dram
+      int64_t width_offset = 0,
+      std::optional<int64_t> width_length = std::nullopt) override {
+    CHECK(snapshot_handle == nullptr);
+    const auto count = at::tensor({ids.size(0)}, at::ScalarType::Long);
+    get_kv_db_async_impl(ids, weights, count, width_offset, width_length)
+        .wait();
+  }
+
   void compact() override {}
 
  private:
+  int64_t get_dim_from_index(int64_t weight_idx) const {
+    if (sub_table_dims_.empty()) {
+      return max_D_;
+    }
+    for (int i = 0; i < sub_table_hash_cumsum_.size(); i++) {
+      if (weight_idx < sub_table_hash_cumsum_[i]) {
+        return sub_table_dims_[i];
+      }
+    }
+    CHECK(false) << "weight_idx " << weight_idx
+                 << " doesn't belong to any feature";
+    return max_D_;
+  }
+
+  int64_t get_width_for_weights(
+      int64_t weight_idx,
+      int64_t width_offset,
+      int64_t row_width) const {
+    // when init an untouch embedding, we only want to init the weights part
+    // and set the optimizer part to 0. This function helps us to get the dim
+    // for each sub table, calculate the max bytes we should copy to the passed
+    // in weights_data_ptr before optimizer section
+    auto feature_dim = get_dim_from_index(weight_idx);
+    CHECK_GT(feature_dim, width_offset);
+    auto feature_width = feature_dim - width_offset;
+    return std::min(feature_width, row_width);
+  }
+
   void fill_from_row_storage(
       int shard_id,
       unsigned char* weights_data_ptr,
       int64_t weights_row_index,
-      unsigned char* row_storage_data_ptr) {
-    int64_t row_width = elem_size_ * max_D_;
+      unsigned char* row_storage_data_ptr,
+      int64_t width_offset,
+      int64_t row_width,
+      int64_t copied_width) {
+    CHECK_GE(row_width, copied_width);
+    CHECK_GE(max_D_, row_width);
+    int64_t storage_row_bytes = elem_size_ * max_D_;
+    int64_t row_bytes = row_width * elem_size_;
+    auto copied_bytes = elem_size_ * copied_width;
+    int64_t start_offset_bytes = elem_size_ * width_offset;
     int64_t row_index;
     initializers_[shard_id]->producer_queue_.dequeue(row_index);
+    // TODO: fill the opt state as zeros for init value?
     std::copy(
-        &(row_storage_data_ptr[row_index * row_width]),
-        &(row_storage_data_ptr[row_index * row_width + row_width]),
-        &(weights_data_ptr[weights_row_index * row_width]));
+        &(row_storage_data_ptr
+              [row_index * storage_row_bytes + start_offset_bytes]),
+        &(row_storage_data_ptr
+              [row_index * storage_row_bytes + start_offset_bytes +
+               copied_bytes]),
+        &(weights_data_ptr[weights_row_index * row_bytes]));
+    if (row_bytes > copied_bytes) {
+      std::memset(
+          &(weights_data_ptr[weights_row_index * row_bytes + copied_bytes]),
+          0,
+          row_bytes - copied_bytes);
+    }
     initializers_[shard_id]->consumer_queue_.enqueue(row_index);
   }
 
@@ -372,6 +505,8 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
   std::atomic_bool is_eviction_ongoing_ = false;
   std::vector<std::unique_ptr<ssd::Initializer>> initializers_;
   int64_t elem_size_;
+  std::vector<int64_t> sub_table_dims_;
+  std::vector<int64_t> sub_table_hash_cumsum_;
 }; // class DramKVEmbeddingCache
 
 } // namespace kv_mem

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h
@@ -29,7 +29,9 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
       int64_t num_shards = 8,
       int64_t num_threads = 32,
       int64_t row_storage_bitwidth = 32,
-      int64_t weight_ttl_in_hours = 2) {
+      int64_t weight_ttl_in_hours = 2,
+      const std::optional<at::Tensor>& table_dims = std::nullopt,
+      const std::optional<at::Tensor>& hash_size_cumsum = std::nullopt) {
     if (row_storage_bitwidth == 16) {
       impl_ = std::make_shared<kv_mem::DramKVEmbeddingCache<at::Half>>(
           max_D,
@@ -38,7 +40,9 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
           num_shards,
           num_threads,
           row_storage_bitwidth,
-          weight_ttl_in_hours);
+          weight_ttl_in_hours,
+          table_dims,
+          hash_size_cumsum);
     } else if (row_storage_bitwidth == 32) {
       impl_ = std::make_shared<kv_mem::DramKVEmbeddingCache<float>>(
           max_D,
@@ -47,7 +51,9 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
           num_shards,
           num_threads,
           row_storage_bitwidth,
-          weight_ttl_in_hours);
+          weight_ttl_in_hours,
+          table_dims,
+          hash_size_cumsum);
     } else {
       throw std::runtime_error("Failed to create recording device");
     }

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h
@@ -31,7 +31,8 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
       int64_t row_storage_bitwidth = 32,
       int64_t weight_ttl_in_hours = 2,
       const std::optional<at::Tensor>& table_dims = std::nullopt,
-      const std::optional<at::Tensor>& hash_size_cumsum = std::nullopt) {
+      const std::optional<at::Tensor>& hash_size_cumsum = std::nullopt,
+      bool enable_async_update = false) {
     if (row_storage_bitwidth == 16) {
       impl_ = std::make_shared<kv_mem::DramKVEmbeddingCache<at::Half>>(
           max_D,
@@ -41,6 +42,7 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
           num_threads,
           row_storage_bitwidth,
           weight_ttl_in_hours,
+          enable_async_update,
           table_dims,
           hash_size_cumsum);
     } else if (row_storage_bitwidth == 32) {
@@ -52,6 +54,7 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
           num_threads,
           row_storage_bitwidth,
           weight_ttl_in_hours,
+          enable_async_update,
           table_dims,
           hash_size_cumsum);
     } else {

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
@@ -396,6 +396,8 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
   const int64_t unique_id_;
   const int64_t num_shards_;
   const int64_t max_D_;
+  std::vector<int64_t> sub_table_dims_;
+  std::vector<int64_t> sub_table_hash_cumsum_;
   folly::Optional<at::ScalarType> index_dtype_{folly::none};
   folly::Optional<at::ScalarType> weights_dtype_{folly::none};
   std::unique_ptr<folly::CPUThreadPoolExecutor> executor_tp_;

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -596,7 +596,8 @@ static auto dram_kv_embedding_cache_wrapper =
                 int64_t,
                 int64_t,
                 std::optional<at::Tensor>,
-                std::optional<at::Tensor>>(),
+                std::optional<at::Tensor>,
+                bool>(),
             "",
             {
                 torch::arg("max_D"),
@@ -608,6 +609,7 @@ static auto dram_kv_embedding_cache_wrapper =
                 torch::arg("weight_ttl_in_hours") = 2,
                 torch::arg("table_dims") = std::nullopt,
                 torch::arg("hash_size_cumsum") = std::nullopt,
+                torch::arg("enable_async_update") = false,
             })
         .def(
             "set_cuda",

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -349,20 +349,20 @@ at::Tensor KVTensorWrapper::narrow(int64_t dim, int64_t start, int64_t length) {
   CHECK_EQ(dim, 0) << "Only narrow on dim 0 is supported";
   CHECK_TRUE(db_ != nullptr);
   CHECK_GE(db_->get_max_D(), shape_[1]);
+  CHECK_GE(db_->get_max_D(), shape_[1] + width_offset_);
   TORCH_CHECK(
       (snapshot_handle_ == nullptr) ==
           (std::dynamic_pointer_cast<EmbeddingRocksDB>(db_).get() == nullptr),
       "snapshot handler must be valid for rocksdb and nullptr for emb kvdb");
   if (!sorted_indices_.has_value()) {
-    int64_t tensor_width = shape_[1] - width_offset_;
-    auto t = at::empty(c10::IntArrayRef({length, tensor_width}), options_);
+    auto t = at::empty(c10::IntArrayRef({length, shape_[1]}), options_);
     db_->get_range_from_snapshot(
         t,
         start + row_offset_,
         length,
         snapshot_handle_ != nullptr ? snapshot_handle_->handle : nullptr,
         width_offset_,
-        tensor_width);
+        shape_[1]);
     CHECK(t.is_contiguous());
     return t;
   } else {
@@ -415,20 +415,20 @@ void KVTensorWrapper::set_weights_and_ids(
 at::Tensor KVTensorWrapper::get_weights_by_ids(const at::Tensor& ids) {
   CHECK_TRUE(db_ != nullptr);
   CHECK_GE(db_->get_max_D(), shape_[1]);
+  CHECK_GE(db_->get_max_D(), shape_[1] + width_offset_);
   TORCH_CHECK(
       (snapshot_handle_ == nullptr) ==
           (std::dynamic_pointer_cast<EmbeddingRocksDB>(db_).get() == nullptr),
       "snapshot handler must be valid for rocksdb and nullptr for emb kvdb");
-  int64_t tensor_width = shape_[1] - width_offset_;
   auto weights =
-      at::empty(c10::IntArrayRef({ids.size(0), tensor_width}), options_);
+      at::empty(c10::IntArrayRef({ids.size(0), shape_[1]}), options_);
   auto linearized_ids = ids + row_offset_;
   db_->get_kv_from_storage_by_snapshot(
       linearized_ids,
       weights,
       snapshot_handle_ != nullptr ? snapshot_handle_->handle : nullptr,
       width_offset_,
-      tensor_width);
+      shape_[1]);
   CHECK(weights.is_contiguous());
   return weights;
 }
@@ -594,7 +594,9 @@ static auto dram_kv_embedding_cache_wrapper =
                 int64_t,
                 int64_t,
                 int64_t,
-                int64_t>(),
+                int64_t,
+                std::optional<at::Tensor>,
+                std::optional<at::Tensor>>(),
             "",
             {
                 torch::arg("max_D"),
@@ -604,6 +606,8 @@ static auto dram_kv_embedding_cache_wrapper =
                 torch::arg("num_threads") = 32,
                 torch::arg("row_storage_bitwidth") = 32,
                 torch::arg("weight_ttl_in_hours") = 2,
+                torch::arg("table_dims") = std::nullopt,
+                torch::arg("hash_size_cumsum") = std::nullopt,
             })
         .def(
             "set_cuda",

--- a/fbgemm_gpu/test/tbe/ssd/kv_tensor_wrapper_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/kv_tensor_wrapper_test.py
@@ -498,7 +498,11 @@ class KvTensorWrapperTest(TestCase):
             # case 1
             width_offset = 10
             tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
-                [E, D], weights.dtype, 0, snapshot, width_offset=width_offset
+                [E, D - width_offset],
+                weights.dtype,
+                0,
+                snapshot,
+                width_offset=width_offset,
             )
             tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
             narrowed = tensor_wrapper.narrow(0, 0, 1)
@@ -524,7 +528,11 @@ class KvTensorWrapperTest(TestCase):
 
             width_offset = 10
             tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
-                [E, new_D], weights.dtype, 0, snapshot, width_offset=width_offset
+                [E, new_D - width_offset],
+                weights.dtype,
+                0,
+                snapshot,
+                width_offset=width_offset,
             )
             tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
             narrowed = tensor_wrapper.narrow(0, 0, 1)

--- a/fbgemm_gpu/test/tbe/ssd/kv_tensor_wrapper_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/kv_tensor_wrapper_test.py
@@ -16,6 +16,7 @@ import fbgemm_gpu  # noqa E402
 import torch
 import torch.testing
 from fbgemm_gpu.split_embedding_configs import SparseType
+from fbgemm_gpu.split_table_batched_embeddings_ops_common import BackendType
 from fbgemm_gpu.utils.loader import load_torch_module
 from hypothesis import given, settings, strategies as st, Verbosity
 
@@ -38,28 +39,18 @@ default_settings: Dict[str, Any] = {
 
 @unittest.skipIf(*running_in_oss)
 class KvTensorWrapperTest(TestCase):
-    # pyre-ignore[56]
-    @given(
-        precision=st.sampled_from(
-            [
-                (SparseType.FP16, 16),
-                (SparseType.FP32, 32),
-            ]
-        ),
-        D=st.integers(min_value=64, max_value=MAX_D),
-    )
-    @settings(**default_settings)
-    def test_read_tensor_using_wrapper_from_db(
-        self, precision: tuple[SparseType, int], D: int
-    ) -> None:
-        E = int(1e4)
-        max_D = MAX_D  # max emb dimension seen by rocksDB
-        N = 1000
-        weights_precision, dtype_width = precision
-        weights_dtype = weights_precision.as_dtype()
 
-        with tempfile.TemporaryDirectory() as ssd_directory:
-            ssd_db = torch.classes.fbgemm.EmbeddingRocksDBWrapper(
+    def create_db(
+        self,
+        ssd_directory: str,
+        backend_type: BackendType,
+        max_D: int,
+        D: int,
+        E: int,
+        weights_precision: SparseType,
+    ) -> object:
+        if backend_type == BackendType.SSD:
+            return torch.classes.fbgemm.EmbeddingRocksDBWrapper(
                 ssd_directory,
                 8,  # num_shards
                 8,  # num_threads
@@ -74,8 +65,49 @@ class KvTensorWrapperTest(TestCase):
                 8,  # ssd_max_write_buffer_num,
                 -0.01,  # ssd_uniform_init_lower
                 0.01,  # ssd_uniform_init_upper
-                dtype_width,  # row_storage_bitwidth
+                weights_precision.bit_rate(),  # row_storage_bitwidth
                 10 * (2**20),  # block cache size
+                enable_async_update=False,
+                table_dims=torch.tensor([D]),
+                hash_size_cumsum=torch.tensor([0, E]),
+            )
+        elif backend_type == BackendType.DRAM:
+            return torch.classes.fbgemm.DramKVEmbeddingCacheWrapper(
+                max_D=max_D,
+                uniform_init_lower=-0.1,
+                uniform_init_upper=0.1,
+                num_shards=8,
+                num_threads=32,
+                row_storage_bitwidth=weights_precision.bit_rate(),
+                table_dims=torch.tensor([D]),
+                hash_size_cumsum=torch.tensor([0, E]),
+                enable_async_update=False,
+            )
+
+    # pyre-ignore[56]
+    @given(
+        precision=st.sampled_from(
+            [
+                (SparseType.FP16, 16),
+                (SparseType.FP32, 32),
+            ]
+        ),
+        D=st.integers(min_value=64, max_value=MAX_D),
+        backend_type=st.sampled_from([BackendType.DRAM, BackendType.SSD]),
+    )
+    @settings(**default_settings)
+    def test_read_tensor_using_wrapper_from_db(
+        self, precision: tuple[SparseType, int], D: int, backend_type: BackendType
+    ) -> None:
+        E = int(1e4)
+        max_D = MAX_D  # max emb dimension seen by rocksDB
+        N = 1000
+        weights_precision, dtype_width = precision
+        weights_dtype = weights_precision.as_dtype()
+
+        with tempfile.TemporaryDirectory() as ssd_directory:
+            ssd_db = self.create_db(
+                ssd_directory, backend_type, max_D, D, E, weights_precision
             )
 
             # create random index tensor with size N
@@ -83,20 +115,20 @@ class KvTensorWrapperTest(TestCase):
             # insert the weights with the corresponding indices into the table
             weights = torch.arange(N * D, dtype=weights_dtype).view(N, D)
             padded_weights = torch.nn.functional.pad(weights, (0, max_D - D))
-            output_weights = torch.empty_like(padded_weights)
             count = torch.tensor([N])
             ssd_db.set(indices, padded_weights, count)
 
-            # force waiting for set to complete
-            ssd_db.get(indices, output_weights, torch.tensor(indices.shape[0]))
-            torch.testing.assert_close(padded_weights, output_weights)
-
             # create a view tensor wrapper
-            snapshot = ssd_db.create_snapshot()
+            snapshot = (
+                ssd_db.create_snapshot() if backend_type == BackendType.SSD else None
+            )
             tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
                 [E, D], weights.dtype, 0, snapshot
             )
-            tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+            if backend_type == BackendType.SSD:
+                tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+            elif backend_type == BackendType.DRAM:
+                tensor_wrapper.set_dram_db_wrapper(ssd_db)
             self.assertEqual(tensor_wrapper.shape, [E, D])
 
             # read one row as an extreme case
@@ -121,7 +153,8 @@ class KvTensorWrapperTest(TestCase):
 
             del tensor_wrapper
             del snapshot
-            self.assertEqual(ssd_db.get_snapshot_count(), 0)
+            if backend_type == BackendType.SSD:
+                self.assertEqual(ssd_db.get_snapshot_count(), 0)
 
     # pyre-ignore[56]
     @given(
@@ -132,10 +165,11 @@ class KvTensorWrapperTest(TestCase):
             ]
         ),
         D=st.integers(min_value=64, max_value=MAX_D),
+        backend_type=st.sampled_from([BackendType.DRAM, BackendType.SSD]),
     )
     @settings(**default_settings)
     def test_write_tensor_to_db(
-        self, precision: tuple[SparseType, int], D: int
+        self, precision: tuple[SparseType, int], D: int, backend_type: BackendType
     ) -> None:
         E = int(1e4)  # num total rows
         max_D = MAX_D  # max emb dimension seen by rocksDB
@@ -146,25 +180,9 @@ class KvTensorWrapperTest(TestCase):
         table_offsets = [0, E]
 
         with tempfile.TemporaryDirectory() as ssd_directory:
-            ssd_db = torch.classes.fbgemm.EmbeddingRocksDBWrapper(
-                ssd_directory,
-                8,  # num_shards
-                8,  # num_threads
-                0,  # ssd_memtable_flush_period,
-                0,  # ssd_memtable_flush_offset,
-                4,  # ssd_l0_files_per_compact,
-                max_D,  # embedding_dim
-                0,  # ssd_rate_limit_mbps,
-                1,  # ssd_size_ratio,
-                8,  # ssd_compaction_trigger,
-                536870912,  # 512MB ssd_write_buffer_size,
-                8,  # ssd_max_write_buffer_num,
-                -0.01,  # ssd_uniform_init_lower
-                0.01,  # ssd_uniform_init_upper
-                dtype_width,  # row_storage_bitwidth
-                10 * (2**20),  # block cache size
+            ssd_db = self.create_db(
+                ssd_directory, backend_type, max_D, D, E, weights_precision
             )
-
             weights = [
                 torch.randn(N * D, dtype=weights_dtype).view(N, D),
                 torch.randn(N * D, dtype=weights_dtype).view(N, D),
@@ -175,23 +193,32 @@ class KvTensorWrapperTest(TestCase):
                 tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
                     [E, D], weights[table_idx].dtype, offset
                 )
-                tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+                if backend_type == BackendType.SSD:
+                    tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+                elif backend_type == BackendType.DRAM:
+                    tensor_wrapper.set_dram_db_wrapper(ssd_db)
                 step = N
                 for i in range(0, E, step):
                     tensor_wrapper.set_range(0, i, step, weights[table_idx])
 
             # create a view tensor wrapper
-            snapshot = ssd_db.create_snapshot()
+            snapshot = (
+                ssd_db.create_snapshot() if backend_type == BackendType.SSD else None
+            )
 
             for table_idx, offset in enumerate(table_offsets):
                 wrong_tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
                     [E, D], weights[table_idx].dtype, 1, snapshot
                 )
-                wrong_tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
                 tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
                     [E, D], weights[table_idx].dtype, offset, snapshot
                 )
-                tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+                if backend_type == BackendType.SSD:
+                    wrong_tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+                    tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+                elif backend_type == BackendType.DRAM:
+                    wrong_tensor_wrapper.set_dram_db_wrapper(ssd_db)
+                    tensor_wrapper.set_dram_db_wrapper(ssd_db)
                 self.assertEqual(tensor_wrapper.shape, [E, D])
 
                 # table has a total of E rows
@@ -219,7 +246,8 @@ class KvTensorWrapperTest(TestCase):
                 del tensor_wrapper
 
             del snapshot
-            self.assertEqual(ssd_db.get_snapshot_count(), 0)
+            if backend_type == BackendType.SSD:
+                self.assertEqual(ssd_db.get_snapshot_count(), 0)
 
     # pyre-ignore[56]
     @given(
@@ -230,10 +258,11 @@ class KvTensorWrapperTest(TestCase):
             ]
         ),
         D=st.integers(min_value=64, max_value=MAX_D),
+        backend_type=st.sampled_from([BackendType.DRAM, BackendType.SSD]),
     )
     @settings(**default_settings)
     def test_discrete_id_weights_io(
-        self, precision: tuple[SparseType, int], D: int
+        self, precision: tuple[SparseType, int], D: int, backend_type: BackendType
     ) -> None:
         E = int(1e4)  # num total rows
         max_D = MAX_D  # max emb dimension seen by rocksDB
@@ -244,24 +273,8 @@ class KvTensorWrapperTest(TestCase):
         table_offsets = [0, N]
 
         with tempfile.TemporaryDirectory() as ssd_directory:
-            # pyre-fixme[16]: Module `classes` has no attribute `fbgemm`.
-            ssd_db = torch.classes.fbgemm.EmbeddingRocksDBWrapper(
-                ssd_directory,
-                8,  # num_shards
-                8,  # num_threads
-                0,  # ssd_memtable_flush_period,
-                0,  # ssd_memtable_flush_offset,
-                4,  # ssd_l0_files_per_compact,
-                max_D,  # embedding_dim
-                0,  # ssd_rate_limit_mbps,
-                1,  # ssd_size_ratio,
-                8,  # ssd_compaction_trigger,
-                536870912,  # 512MB ssd_write_buffer_size,
-                8,  # ssd_max_write_buffer_num,
-                -0.01,  # ssd_uniform_init_lower
-                0.01,  # ssd_uniform_init_upper
-                dtype_width,  # row_storage_bitwidth
-                10 * (2**20),  # block cache size
+            ssd_db = self.create_db(
+                ssd_directory, backend_type, max_D, D, E, weights_precision
             )
             indices = torch.randperm(N)
             weights = [
@@ -275,28 +288,40 @@ class KvTensorWrapperTest(TestCase):
                 tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
                     [E, D], weights[table_idx].dtype, offset
                 )
-                tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+                if backend_type == BackendType.SSD:
+                    tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+                elif backend_type == BackendType.DRAM:
+                    tensor_wrapper.set_dram_db_wrapper(ssd_db)
                 tensor_wrapper.set_weights_and_ids(weights[table_idx], indices)
 
             # create a view tensor wrapper
-            snapshot = ssd_db.create_snapshot()
+            snapshot = (
+                ssd_db.create_snapshot() if backend_type == BackendType.SSD else None
+            )
 
             for table_idx, offset in enumerate(table_offsets):
                 tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
                     [E, D], weights[table_idx].dtype, offset
                 )
-                tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+                if backend_type == BackendType.SSD:
+                    tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+                elif backend_type == BackendType.DRAM:
+                    tensor_wrapper.set_dram_db_wrapper(ssd_db)
                 tensor_wrapper.set_weights_and_ids(new_weights_after_snapshot, indices)
 
             for table_idx, offset in enumerate(table_offsets):
                 wrong_tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
                     [E, D], weights[table_idx].dtype, 1, snapshot
                 )
-                wrong_tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
                 tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
                     [E, D], weights[table_idx].dtype, offset, snapshot
                 )
-                tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+                if backend_type == BackendType.SSD:
+                    wrong_tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+                    tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+                elif backend_type == BackendType.DRAM:
+                    wrong_tensor_wrapper.set_dram_db_wrapper(ssd_db)
+                    tensor_wrapper.set_dram_db_wrapper(ssd_db)
                 self.assertEqual(tensor_wrapper.shape, [E, D])
 
                 wrong_out_weights = wrong_tensor_wrapper.get_weights_by_ids(indices)
@@ -320,7 +345,8 @@ class KvTensorWrapperTest(TestCase):
                 del wrong_tensor_wrapper
 
             del snapshot
-            self.assertEqual(ssd_db.get_snapshot_count(), 0)
+            if backend_type == BackendType.SSD:
+                self.assertEqual(ssd_db.get_snapshot_count(), 0)
 
     # pyre-ignore[56]
     @given(
@@ -331,11 +357,11 @@ class KvTensorWrapperTest(TestCase):
             ]
         ),
         D=st.integers(min_value=8, max_value=16),
-        # D=st.integers(min_value=64, max_value=MAX_D),
+        backend_type=st.sampled_from([BackendType.DRAM, BackendType.SSD]),
     )
     @settings(**default_settings)
     def test_narrow_mapping_offset_to_weight_id(
-        self, precision: tuple[SparseType, int], D: int
+        self, precision: tuple[SparseType, int], D: int, backend_type: BackendType
     ) -> None:
         E = int(1e4)  # num total rows
         max_D = MAX_D  # max emb dimension seen by rocksDB
@@ -345,24 +371,8 @@ class KvTensorWrapperTest(TestCase):
         weights_dtype = weights_precision.as_dtype()
 
         with tempfile.TemporaryDirectory() as ssd_directory:
-            # pyre-fixme[16]: Module `classes` has no attribute `fbgemm`.
-            ssd_db = torch.classes.fbgemm.EmbeddingRocksDBWrapper(
-                ssd_directory,
-                8,  # num_shards
-                8,  # num_threads
-                0,  # ssd_memtable_flush_period,
-                0,  # ssd_memtable_flush_offset,
-                4,  # ssd_l0_files_per_compact,
-                max_D,  # embedding_dim
-                0,  # ssd_rate_limit_mbps,
-                1,  # ssd_size_ratio,
-                8,  # ssd_compaction_trigger,
-                536870912,  # 512MB ssd_write_buffer_size,
-                8,  # ssd_max_write_buffer_num,
-                -0.01,  # ssd_uniform_init_lower
-                0.01,  # ssd_uniform_init_upper
-                dtype_width,  # row_storage_bitwidth
-                10 * (2**20),  # block cache size
+            ssd_db = self.create_db(
+                ssd_directory, backend_type, max_D, D, E, weights_precision
             )
             indices = torch.randperm(N)
             weights = torch.arange(N * D, dtype=weights_dtype).view(N, D)
@@ -372,16 +382,24 @@ class KvTensorWrapperTest(TestCase):
             tensor_wrapper0 = torch.classes.fbgemm.KVTensorWrapper(
                 [E, D], weights.dtype, 0
             )
-            tensor_wrapper0.set_embedding_rocks_dp_wrapper(ssd_db)
+            if backend_type == BackendType.SSD:
+                tensor_wrapper0.set_embedding_rocks_dp_wrapper(ssd_db)
+            elif backend_type == BackendType.DRAM:
+                tensor_wrapper0.set_dram_db_wrapper(ssd_db)
             tensor_wrapper0.set_weights_and_ids(weights, indices)
 
             # create a view tensor wrapper
-            snapshot = ssd_db.create_snapshot()
+            snapshot = (
+                ssd_db.create_snapshot() if backend_type == BackendType.SSD else None
+            )
             tensor_wrapper0.set_weights_and_ids(new_weights_after_snapshot, indices)
             tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
                 [E, D], weights.dtype, 0, snapshot, indices
             )
-            tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+            if backend_type == BackendType.SSD:
+                tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+            elif backend_type == BackendType.DRAM:
+                tensor_wrapper.set_dram_db_wrapper(ssd_db)
             self.assertEqual(tensor_wrapper.shape, [E, D])
             indices_copy = indices.clone()
             del indices
@@ -416,7 +434,8 @@ class KvTensorWrapperTest(TestCase):
             del tensor_wrapper0
             del tensor_wrapper
             del snapshot
-            self.assertEqual(ssd_db.get_snapshot_count(), 0)
+            if backend_type == BackendType.SSD:
+                self.assertEqual(ssd_db.get_snapshot_count(), 0)
 
     # pyre-ignore[56]
     @given(
@@ -426,68 +445,49 @@ class KvTensorWrapperTest(TestCase):
                 (SparseType.FP32, 32),
             ]
         ),
-        D=st.integers(min_value=64, max_value=MAX_D),
+        D=st.integers(min_value=64, max_value=MAX_D - 10),  # D = max_D - extra_width
+        backend_type=st.sampled_from([BackendType.SSD, BackendType.DRAM]),
     )
     @settings(**default_settings)
     def test_read_weights_with_specified_width(
-        self, precision: tuple[SparseType, int], D: int
+        self, precision: tuple[SparseType, int], D: int, backend_type: BackendType
     ) -> None:
-        precision = (SparseType.FP16, 16)
-        D = 64
         E = int(1e4)
-        max_D = MAX_D  # max emb dimension seen by rocksDB
+        extra_width = 10
+        width_offset = 10
+        max_D = MAX_D
         N = 1000
         weights_precision, dtype_width = precision
         weights_dtype = weights_precision.as_dtype()
 
-        table_dims = torch.tensor([D])
-        hash_size_cumsum = torch.tensor([0, E])
-
         with tempfile.TemporaryDirectory() as ssd_directory:
-            ssd_db = torch.classes.fbgemm.EmbeddingRocksDBWrapper(
-                ssd_directory,
-                8,  # num_shards
-                8,  # num_threads
-                0,  # ssd_memtable_flush_period,
-                0,  # ssd_memtable_flush_offset,
-                4,  # ssd_l0_files_per_compact,
-                max_D,  # embedding_dim
-                0,  # ssd_rate_limit_mbps,
-                1,  # ssd_size_ratio,
-                8,  # ssd_compaction_trigger,
-                536870912,  # 512MB ssd_write_buffer_size,
-                8,  # ssd_max_write_buffer_num,
-                -0.01,  # ssd_uniform_init_lower
-                0.01,  # ssd_uniform_init_upper
-                dtype_width,  # row_storage_bitwidth
-                10 * (2**20),  # block cache size
-                table_dims=table_dims,
-                hash_size_cumsum=hash_size_cumsum,
+            ssd_db = self.create_db(
+                ssd_directory, backend_type, max_D, D, E, weights_precision
             )
-
             # create random index tensor with size N
             indices = torch.arange(N)
             # insert the weights with the corresponding indices into the table
             weights = torch.arange(N * D, dtype=weights_dtype).view(N, D)
             padded_weights = torch.nn.functional.pad(weights, (0, max_D - D), value=1.0)
-            output_weights = torch.empty_like(padded_weights)
+
             count = torch.tensor([N])
             ssd_db.set(indices, padded_weights, count)
-
-            # force waiting for set to complete
-            ssd_db.get(indices, output_weights, torch.tensor(indices.shape[0]))
-            torch.testing.assert_close(padded_weights, output_weights)
 
             """
             create a new case with kvt dim == weight dim
             test different width offset to read the weights out
             """
             # case 0
-            snapshot = ssd_db.create_snapshot()
+            snapshot = (
+                ssd_db.create_snapshot() if backend_type == BackendType.SSD else None
+            )
             tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
                 [E, D], weights.dtype, 0, snapshot
             )
-            tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+            if backend_type == BackendType.SSD:
+                tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+            elif backend_type == BackendType.DRAM:
+                tensor_wrapper.set_dram_db_wrapper(ssd_db)
             self.assertEqual(tensor_wrapper.shape, [E, D])
 
             narrowed = tensor_wrapper.narrow(0, 0, 1)
@@ -496,7 +496,6 @@ class KvTensorWrapperTest(TestCase):
             self.assertTrue(torch.equal(weight_by_id[0], weights[0]))
 
             # case 1
-            width_offset = 10
             tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
                 [E, D - width_offset],
                 weights.dtype,
@@ -504,7 +503,10 @@ class KvTensorWrapperTest(TestCase):
                 snapshot,
                 width_offset=width_offset,
             )
-            tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+            if backend_type == BackendType.SSD:
+                tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+            elif backend_type == BackendType.DRAM:
+                tensor_wrapper.set_dram_db_wrapper(ssd_db)
             narrowed = tensor_wrapper.narrow(0, 0, 1)
             weight_by_id = tensor_wrapper.get_weights_by_ids(torch.tensor([0]))
             self.assertTrue(torch.equal(narrowed[0], weights[0][width_offset:]))
@@ -514,17 +516,23 @@ class KvTensorWrapperTest(TestCase):
             create a new case with kvt dim > weight dim
             we should only get upto weight dim and the rest should be 0s
             """
-            extra_width = 10
             new_D = D + extra_width
             tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
                 [E, new_D], weights.dtype, 0, snapshot
             )
-            tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+
+            if backend_type == BackendType.SSD:
+                tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+            elif backend_type == BackendType.DRAM:
+                tensor_wrapper.set_dram_db_wrapper(ssd_db)
             self.assertEqual(tensor_wrapper.shape, [E, new_D])
 
             narrowed = tensor_wrapper.narrow(0, 0, 1)
             weight_by_id = tensor_wrapper.get_weights_by_ids(torch.tensor([0]))
-            self.assertTrue(torch.equal(narrowed[0], padded_weights[0][:new_D]))
+            if backend_type == BackendType.SSD:
+                self.assertTrue(torch.equal(narrowed[0], padded_weights[0][:new_D]))
+            elif backend_type == BackendType.DRAM:
+                self.assertTrue(torch.equal(narrowed[0], padded_weights[0][:new_D]))
 
             width_offset = 10
             tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
@@ -534,7 +542,10 @@ class KvTensorWrapperTest(TestCase):
                 snapshot,
                 width_offset=width_offset,
             )
-            tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+            if backend_type == BackendType.SSD:
+                tensor_wrapper.set_embedding_rocks_dp_wrapper(ssd_db)
+            elif backend_type == BackendType.DRAM:
+                tensor_wrapper.set_dram_db_wrapper(ssd_db)
             narrowed = tensor_wrapper.narrow(0, 0, 1)
             weight_by_id = tensor_wrapper.get_weights_by_ids(torch.tensor([0]))
             self.assertTrue(
@@ -558,7 +569,8 @@ class KvTensorWrapperTest(TestCase):
 
             del tensor_wrapper
             del snapshot
-            self.assertEqual(ssd_db.get_snapshot_count(), 0)
+            if backend_type == BackendType.SSD:
+                self.assertEqual(ssd_db.get_snapshot_count(), 0)
 
     def test_dram_kv_and_rdb_snapshot_check(self) -> None:
         max_D = MAX_D  # max emb dimension seen by rocksDB
@@ -613,13 +625,12 @@ class KvTensorWrapperTest(TestCase):
             with self.assertRaises(RuntimeError):
                 tensor_wrapper.get_weights_by_ids(torch.tensor([1]))
 
-            # uncomment it when dram kv has width offset support
-            # tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
-            #     [E, D], weights_dtype, 0
-            # )
-            # tensor_wrapper.set_dram_db_wrapper(dram_kv)
-            # tensor_wrapper.narrow(0, 0, 1)
-            # tensor_wrapper.get_weights_by_ids(torch.tensor([1]))
+            tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
+                [E, D], weights_dtype, 0
+            )
+            tensor_wrapper.set_dram_db_wrapper(dram_kv)
+            tensor_wrapper.narrow(0, 0, 1)
+            tensor_wrapper.get_weights_by_ids(torch.tensor([1]))
 
             tensor_wrapper = torch.classes.fbgemm.KVTensorWrapper(
                 [E, D], weights_dtype, 0, snapshot


### PR DESCRIPTION
Summary:
**This diff**
Conduct Dram KV tensor wrapper test:
- test_read_tensor_using_wrapper_from_dram_db
- test_write_tensor_to_dram_db
- test_discrete_id_weights_io_dram_db
- test_narrow_mapping_offset_to_weight_id_dram_db
- test_read_weights_with_specified_width_dram_db

contains changes mentioned in D75264932

Reviewed By: duduyi2013

Differential Revision: D75465803
