### PR TITLE
Pass B_offsets to forward wrapper for MTIA

### DIFF
--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
@@ -127,6 +127,7 @@ enum SSDTensor {
                 const Tensor& /*vbe_B_offsets_rank_per_feature*/, // for reshaping vbe cpu offsets and output
                 const Tensor& /*vbe_output_offsets_feature_rank*/, // for reshaping vbe cpu output
                 const c10::SymInt /*max_B*/, // for reshaping vbe cpu offsets
+                const Tensor& /*B_offsets_*/, // for MTIA kernel
                 {%- endif %}
                 {%- if is_gwd %}
                 const Tensor& /*prev_iter_dev*/,
@@ -174,6 +175,7 @@ enum SSDTensor {
       vbe_B_offsets_rank_per_feature_, // for reshaping vbe cpu offsets and output
       vbe_output_offsets_feature_rank_, // for reshaping vbe cpu output
       max_B_, // for reshaping vbe cpu offsets
+      B_offsets_, // for MTIA kernel
       {%- endif %} {# /* if vbe */ #}
       {%- if is_gwd %}
       prev_iter_dev_,

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cpu_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cpu_wrapper_template.cpp
@@ -130,6 +130,7 @@ Tensor split_embedding_codegen_forward_{{ wdesc }}{{ vdesc }}_pt2_cpu_wrapper(
     const Tensor& vbe_B_offsets_rank_per_feature,
     const Tensor& vbe_output_offsets_feature_rank,
     const c10::SymInt max_B,
+    const Tensor& B_offsets,
     {%- endif %}
     const bool /*is_experimental = false*/,
     const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)) {
@@ -340,6 +341,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         "    Tensor vbe_B_offsets_rank_per_feature, "
         "    Tensor vbe_output_offsets_feature_rank, "
         "    SymInt max_B, "
+        "    Tensor B_offsets, "
         {%- endif %}
         "    bool is_experimental, "
         "    int output_dtype "

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
@@ -96,6 +96,7 @@ Tensor {{ fwd_mdesc }}_embedding{{ ndesc }}_codegen_forward_{{ desc_suffix }}_pt
     const Tensor& vbe_B_offsets_rank_per_feature,
     const Tensor& vbe_output_offsets_feature_rank,
     const c10::SymInt max_B,
+    const Tensor& B_offsets,
     {%- endif %}
     {%- if is_gwd %}
     const Tensor& prev_iter_dev,
@@ -548,6 +549,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         "    Tensor vbe_B_offsets_rank_per_feature, "
         "    Tensor vbe_output_offsets_feature_rank, "
         "    SymInt max_B, "
+        "    Tensor B_offsets, "
         {%- endif %}
         {%- if is_gwd %}
         "    Tensor{{ schema_annotation['prev_iter_dev'] }} prev_iter_dev, "


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1320

The diff passes `B_offsets` to forward wrapper function to be used in MTIA kernel.
This will save computation overhead in MTIA kernel from calculating batch offsets 
from `b_t_map`, which is currently significant.

sarithad-fb confirms over 90% performance speedup for VBE forward on Athena silicon.

Differential Revision: D75593041


