### PR TITLE
Use hardware-accelerated float16 conversion

### DIFF
--- a/include/fbgemm/FbgemmFP16.h
+++ b/include/fbgemm/FbgemmFP16.h
@@ -30,7 +30,7 @@ struct TypeConverter<float16> {
   float16 operator()(float src) const {
     constexpr float FP16_MAX = 65504.f;
     const float fp16 = std::max(-FP16_MAX, std::min(src, FP16_MAX));
-    return cpu_float2half_rn(fp16);
+    return cpu_float2half(fp16);
   }
 };
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1310

Diff enables hardware-accelerated float to float16 casting

Canary: https://www.internalfb.com/servicelab/experiment/5501471107/

Per-ad breakdown CPU time went down 1.91%
Total CPU time  went down 1.71%

Differential Revision: D75728324


