### PR TITLE
Vectorize f16 conversion

### DIFF
--- a/src/FbgemmFloat16Convert.cc
+++ b/src/FbgemmFloat16Convert.cc
@@ -43,10 +43,6 @@ void FloatToFloat16_simd(
       FloatToFloat16_avx512(src, dst, size, do_clip);
     } else if (fbgemmHasAvx2Support()) {
       FloatToFloat16_avx2(src, dst, size, do_clip);
-#ifdef __aarch64__
-    } else if (fbgemmHasArmSve2Support()) {
-      FloatToFloat16_sve2(src, dst, size, do_clip);
-#endif
     } else {
       FloatToFloat16_ref(src, dst, size, do_clip);
       return;

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -91,11 +91,11 @@ void FloatToFloat16_ref(
   if (do_clip) {
     for (size_t i = 0; i < size; i++) {
       float cur_src = std::max(-FP16_MAX, std::min(src[i], FP16_MAX));
-      dst[i] = cpu_float2half_rn(cur_src);
+      dst[i] = cpu_float2half(cur_src);
     }
   } else {
     for (size_t i = 0; i < size; i++) {
-      dst[i] = cpu_float2half_rn(src[i]);
+      dst[i] = cpu_float2half(src[i]);
     }
   }
 }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1330

Use C++ language extension type '__fp16' to let clang vectorize float16 conversion, on aarch64 compilation.

'float16 to float' will now be vectorized
'float to float16' gets improved

before (higher is better):

     M elements_per_ns_ref elements_per_ns_simd
     1     0.0302            0.0242
    10     0.205             0.231
    32     0.328             0.579
    40     0.354             0.697
   129     0.442             1.87
   256     0.466             1.92
  1024     0.488             2.38 
  8000     0.494             2.55

after:

     M elements_per_ns_ref elements_per_ns_simd
     1     0.0307           0.0253
    10     0.301            0.256
    32     0.898            0.793
    40     1.12             0.967
   129     2.76             2.59
   256     4.09             3.7
  1024     5.67             5.47 
  8000     6.3              6.31

Differential Revision: D75926678


