### PR TITLE
Speed up AMD training by reducing GPU atomic ops

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/embedding_backward_template_helpers.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/embedding_backward_template_helpers.cuh
@@ -39,12 +39,16 @@ constexpr size_t kBackwardMaxThreads = 512;
 constexpr int32_t kCacheLocationMissing = -1;
 
 DEVICE_INLINE int64_t gpuAtomicIncrement(int64_t* p) {
+#if defined(USE_ROCM)
+  return __atomic_fetch_add(p, 1, __ATOMIC_RELAXED);
+#else
   static_assert(
       sizeof(int64_t) == sizeof(unsigned long long),
       "expected int64_t to be unsigned long long");
   return static_cast<int64_t>(atomicAdd(
       reinterpret_cast<unsigned long long int*>(p),
       static_cast<unsigned long long int>(1)));
+#endif
 }
 
 namespace fbgemm_gpu {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1333

AMD GPUs perform badly with atomic operations. This diff

* avoids the invocation of `gpuAtomicIncrement` inside nested for-loops by keeping a local warning counter variable;
* uses relaxed atomic add for better efficiency (similar to how it's [used here for `gpuAtomicAdd`](https://www.internalfb.com/code/fbsource/[cbad3fa1b99b]/fbcode/caffe2/aten/src/ATen/cuda/Atomic.cuh?lines=204)).

This was inspired by xw285cornell 's previous finding that the slowness was in part coming from the bounds check kernel. With this diff, the performance is on par with Xiaodong's experiment which turns off bounds check warnings.

Differential Revision: D75959620


