### PR TITLE
Fix use __fp16 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,6 +431,6 @@ if(FBGEMM_BUILD_FBGEMM_GPU)
   add_subdirectory(fbgemm_gpu)
 endif()
 
-if(HAVE_GNU_F2H_IEEE)
-  add_definitions(-DHAVE_GNU_F2H_IEEE)
+if(NOT HAVE_GNU_F2H_IEEE)
+  add_definitions(-DMISSING_GNU_F2H_IEEE)
 endif()

--- a/include/fbgemm/FloatConversion.h
+++ b/include/fbgemm/FloatConversion.h
@@ -287,7 +287,7 @@ inline float cpu_half2float_ref(const float16 h) {
 // Same as the previous function, but use the built-in fp16 to fp32
 // conversion provided by the compiler
 inline float cpu_half2float(const float16 h) {
-#if defined(HAS_NATIVE_FP16_TYPE) && defined(HAVE_GNU_F2H_IEEE)
+#if defined(HAS_NATIVE_FP16_TYPE) && not defined(MISSING_GNU_F2H_IEEE)
   __fp16 h_fp16;
   std::memcpy(&h_fp16, &h, sizeof(__fp16));
   return h_fp16;
@@ -297,7 +297,7 @@ inline float cpu_half2float(const float16 h) {
 }
 
 inline float16 cpu_float2half(const float f) {
-#if defined(HAS_NATIVE_FP16_TYPE) && defined(HAVE_GNU_F2H_IEEE)
+#if defined(HAS_NATIVE_FP16_TYPE) && not defined(MISSING_GNU_F2H_IEEE)
   __fp16 h = f;
   float16 res;
   std::memcpy(&res, &h, sizeof(__fp16));


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1335

HAVE_GNU_F2H_IEEE was flag introduced to check if this function exist for OSS. And previously use as a default flag to enable `__fp16` which makes `__fb16` disable by default.
This diff enable __fp16 by default, and disable it with explicit flag.

Differential Revision: D75975271


