### PR TITLE
Enable K that is not divisible by group size for shuffled mixed dtype kernels.

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16i4bf16.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16i4bf16.cu
@@ -217,14 +217,13 @@ at::Tensor _bf16i4bf16(
   at::Tensor workspace =
       at::empty(workspace_size, X.options().dtype(at::kByte));
 
-  // Check the problem size is supported or not
-  cutlass::Status status = gemm.can_implement(arguments);
-  if (status != cutlass::Status::kSuccess) {
-    throw std::runtime_error("cutlass cannot implement");
-  }
+  // TODO shuffled argument checking is stricter than it needs to be.
+  // For example it complains when K isnt divisible by group size despite
+  // that not being an actual restriction. We adopt a dont-ask-dont-tell
+  // approach to argument verification for now.
 
   // Initialize CUTLASS kernel with arguments and workspace pointer
-  status = gemm.initialize(arguments, workspace.data_ptr());
+  cutlass::Status status = gemm.initialize(arguments, workspace.data_ptr());
   if (status != cutlass::Status::kSuccess) {
     throw std::runtime_error("cutlass cannot initialize");
   }

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8i4bf16_shuffled.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8i4bf16_shuffled.cu
@@ -235,14 +235,13 @@ at::Tensor _f8i4bf16_shuffled(
   at::Tensor workspace =
       at::empty(workspace_size, XQ.options().dtype(at::kByte));
 
-  // Check the problem size is supported or not
-  cutlass::Status status = gemm.can_implement(arguments);
-  if (status != cutlass::Status::kSuccess) {
-    throw std::runtime_error("cutlass cannot implement");
-  }
+  // TODO shuffled argument checking is stricter than it needs to be.
+  // For example it complains when K isnt divisible by group size despite
+  // that not being an actual restriction. We adopt a dont-ask-dont-tell
+  // approach to argument verification for now.
 
   // Initialize CUTLASS kernel with arguments and workspace pointer
-  status = gemm.initialize(arguments, workspace.data_ptr());
+  cutlass::Status status = gemm.initialize(arguments, workspace.data_ptr());
   if (status != cutlass::Status::kSuccess) {
     throw std::runtime_error("cutlass cannot initialize");
   }

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -525,13 +525,11 @@ std::vector<at::Tensor> quantize_fp8_per_tensor_meta(
   TORCH_CHECK(dims == 2 || dims == 3, "The dim of input should be 2 or 3");
   at::Tensor Y = at::empty_like(input, input.options().dtype(torch_fp8_e4m3));
   at::Tensor scale;
-  if (dims == 2) {
-    const at::SymInt M = input.sym_size(0);
-    scale = at::empty_symint({M}, input.options().dtype(at::kFloat));
+  if (dims <= 2) {
+    scale = at::empty({}, input.options().dtype(at::kFloat));
   } else {
     const at::SymInt B = input.sym_size(0);
-    const at::SymInt M = input.sym_size(1);
-    scale = at::empty_symint({B, M}, input.options().dtype(at::kFloat));
+    scale = at::empty_symint({B}, input.options().dtype(at::kFloat));
   }
   return {Y, scale};
 }


### PR DESCRIPTION
Summary: This diff enables the use of shuffled mixed input kernels for workloads where K is not divisible by group size (typically 128).

Differential Revision: D76002016


