### PR TITLE
Update AI Codesign Cutlass to 4.0

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16/f4f4bf16_common.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16/f4f4bf16_common.cuh
@@ -152,11 +152,11 @@ at::Tensor _f4f4bf16(
       decltype(cute::make_layout(cute::make_shape(0, 0, 0), StrideOutput{}));
 
   // For SFA and SFB tensors layouts
-  using Sm100BlkScaledConfig =
-      typename Gemm::GemmKernel::CollectiveMainloop::Sm100BlkScaledConfig;
+  using Sm1xxBlkScaledConfig =
+      typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
   // For SFD tensor layout
   using Sm100BlockScaledOutputConfig =
-      typename Gemm::GemmKernel::CollectiveMainloop::Sm100BlkScaledConfig;
+      typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
 
   StrideA stride_A =
       cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(M, K, 1));
@@ -169,9 +169,9 @@ at::Tensor _f4f4bf16(
   LayoutB layout_B = make_layout(cute::make_shape(N, K, 1), stride_B);
   LayoutOutput layout_output =
       make_layout(cute::make_shape(N, M, 1), stride_output);
-  LayoutSFA layout_SFA = Sm100BlkScaledConfig::tile_atom_to_shape_SFA(
+  LayoutSFA layout_SFA = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(
       cute::make_shape(M, N, K, 1));
-  LayoutSFB layout_SFB = Sm100BlkScaledConfig::tile_atom_to_shape_SFB(
+  LayoutSFB layout_SFB = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(
       cute::make_shape(M, N, K, 1));
 
   using DataTypeA = typename ElementA::DataType;

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped.cu
@@ -84,9 +84,9 @@ __global__ void set_kernel_args_kernel(
         StrideB{}, cute::make_shape(int(N), int(K), 1));
     stride_c_ptr[i] = cutlass::make_cute_packed_stride(
         StrideC{}, cute::make_shape(int(N), int(M), 1));
-    layout_SFA[i] = cutlass::detail::Sm100BlockScaledConfig<SFVecSize>::
+    layout_SFA[i] = cutlass::detail::Sm1xxBlockScaledConfig<SFVecSize>::
         tile_atom_to_shape_SFA(cute::make_shape(int(M), int(N), int(K), 1));
-    layout_SFB[i] = cutlass::detail::Sm100BlockScaledConfig<SFVecSize>::
+    layout_SFB[i] = cutlass::detail::Sm1xxBlockScaledConfig<SFVecSize>::
         tile_atom_to_shape_SFB(cute::make_shape(int(M), int(N), int(K), 1));
     if (global_scale != nullptr) {
       global_scale_ptr[i] = global_scale;
@@ -179,10 +179,10 @@ __global__ void set_stacked_kernel_args_kernel(
       stride_c_ptr[non_zero_idx] = cutlass::make_cute_packed_stride(
           StrideC{}, cute::make_shape(int(N), int(M), 1));
       layout_SFA[non_zero_idx] = cutlass::detail::
-          Sm100BlockScaledConfig<SFVecSize>::tile_atom_to_shape_SFA(
+          Sm1xxBlockScaledConfig<SFVecSize>::tile_atom_to_shape_SFA(
               cute::make_shape(int(M), int(N), int(K), 1));
       layout_SFB[non_zero_idx] = cutlass::detail::
-          Sm100BlockScaledConfig<SFVecSize>::tile_atom_to_shape_SFB(
+          Sm1xxBlockScaledConfig<SFVecSize>::tile_atom_to_shape_SFB(
               cute::make_shape(int(M), int(N), int(K), 1));
       if (global_scale != nullptr) {
         global_scale_ptr[non_zero_idx] = global_scale + group_index;


### PR DESCRIPTION
Summary:
This diff pulls in the latest changes from cutlass 4.0. This should improve performance in a few cases and adds fun new features like cutedsl.

I added python files that include cutedsl but havent been able to get them working with buck yet. It seems like there might be a few pieces missing like the necessary MLIR lowering.

Reviewed By: jiawenliu64, jianyuh

Differential Revision: D76060924


