### PR TITLE
Migrate jagged tensor kernels to `FBGEMM_LAUNCH_KERNEL`, pt 1

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/common.cuh
+++ b/fbgemm_gpu/src/jagged_tensor_ops/common.cuh
@@ -31,6 +31,7 @@
 #include "fbgemm_gpu/utils/dispatch_macros.h"
 #include "fbgemm_gpu/utils/fixed_divisor.cuh"
 #include "fbgemm_gpu/utils/inclusive_sum_scan.cuh"
+#include "fbgemm_gpu/utils/kernel_launcher.cuh"
 #include "fbgemm_gpu/utils/ops_utils.h"
 #include "fbgemm_gpu/utils/shared_memory.cuh"
 #include "fbgemm_gpu/utils/tensor_accessor_builder.h"
@@ -259,32 +260,38 @@ void jagged_dense_elementwise_dense_output_(
   const Tensor y_reshaped = y.view({y.size(0), -1, y.size(-1)});
   Tensor output_reshaped = output.view(y_reshaped.sizes());
 
-#define INVOKE_KERNEL_WITH_DIM(NUM_JAGGED_DIM)                               \
-  {                                                                          \
-    std::vector<Tensor> x_offsets_contig;                                    \
-    x_offsets_contig.resize(num_jagged_dim);                                 \
-    StackArray<index_t*> x_offset_ptrs;                                      \
-    x_offset_ptrs.ndim = num_jagged_dim;                                     \
-    for (int d = 0; d < num_jagged_dim; ++d) {                               \
-      x_offsets_contig[d] = x_offsets[d].contiguous();                       \
-      x_offset_ptrs.vals[d] =                                                \
-          x_offsets_contig[d].template data_ptr<index_t>();                  \
-    }                                                                        \
-    [[maybe_unused]] const auto func_name =                                  \
-        "jagged_dense_elementwise_dense_output_kernel_";                     \
-    jagged_dense_elementwise_dense_output_kernel_<NUM_JAGGED_DIM, index_t>   \
-        <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(          \
-            MAKE_PTA_WITH_NAME(func_name, x_values, scalar_t, 2, 32),        \
-            x_offset_ptrs,                                                   \
-            MAKE_PTA_WITH_NAME(func_name, y_reshaped, scalar_t, 3, 32),      \
-            MAKE_PTA_WITH_NAME(func_name, output_reshaped, scalar_t, 3, 32), \
-            jagged_dims_tensor,                                              \
-            f,                                                               \
-            padding_value);                                                  \
+#define INVOKE_KERNEL_WITH_DIM(NUM_JAGGED_DIM)              \
+  {                                                         \
+    std::vector<Tensor> x_offsets_contig;                   \
+    x_offsets_contig.resize(num_jagged_dim);                \
+    StackArray<index_t*> x_offset_ptrs;                     \
+    x_offset_ptrs.ndim = num_jagged_dim;                    \
+    for (int d = 0; d < num_jagged_dim; ++d) {              \
+      x_offsets_contig[d] = x_offsets[d].contiguous();      \
+      x_offset_ptrs.vals[d] =                               \
+          x_offsets_contig[d].template data_ptr<index_t>(); \
+    }                                                       \
+                                                            \
+    FBGEMM_LAUNCH_KERNEL(                                   \
+        (jagged_dense_elementwise_dense_output_kernel_<     \
+            NUM_JAGGED_DIM,                                 \
+            index_t,                                        \
+            scalar_t,                                       \
+            F>),                                            \
+        blocks,                                             \
+        threads,                                            \
+        0,                                                  \
+        at::cuda::getCurrentCUDAStream(),                   \
+        PTA_B(x_values, scalar_t, 2, 32),                   \
+        x_offset_ptrs,                                      \
+        PTA_B(y_reshaped, scalar_t, 3, 32),                 \
+        PTA_B(output_reshaped, scalar_t, 3, 32),            \
+        jagged_dims_tensor,                                 \
+        f,                                                  \
+        padding_value);                                     \
   }
 
   JAGGED_TENSOR_DISPATCH_DIMS();
-  C10_CUDA_KERNEL_LAUNCH_CHECK();
 
 #undef INVOKE_KERNEL_WITH_DIM
 }
@@ -709,39 +716,49 @@ inline bool jagged_dense_dense_elementwise_jagged_output_matches_opt(
   return matches;
 }
 
-#define INVOKE_KERNEL_WITH_DIM(NUM_JAGGED_DIM)                              \
-  {                                                                         \
-    dim3 threads, blocks;                                                   \
-    StackArray<int64_t> jagged_dims_tensor;                                 \
-    std::tie(threads, blocks, jagged_dims_tensor) =                         \
-        check_shape_and_partition_(x_values, x_offsets, y);                 \
-    blocks.x = div_round_up(x_values.size(0), threads.y);                   \
-    std::vector<Tensor> x_offsets_contig;                                   \
-    x_offsets_contig.resize(num_jagged_dim);                                \
-    StackArray<index_t*> x_offset_ptrs;                                     \
-    x_offset_ptrs.ndim = num_jagged_dim;                                    \
-    StackArray<int64_t> x_offset_sizes;                                     \
-    x_offset_sizes.ndim = num_jagged_dim;                                   \
-    for (int d = 0; d < num_jagged_dim; ++d) {                              \
-      x_offsets_contig[d] = x_offsets[d].contiguous();                      \
-      x_offset_ptrs.vals[d] =                                               \
-          x_offsets_contig[d].template data_ptr<index_t>();                 \
-      x_offset_sizes.vals[d] = x_offsets[d].numel();                        \
-    }                                                                       \
-    [[maybe_unused]] const auto func_name =                                 \
-        "jagged_dense_dense_elementwise_jagged_output_kernel_";             \
-    jagged_dense_dense_elementwise_jagged_output_kernel_<                   \
-        NUM_JAGGED_DIM,                                                     \
-        index_t><<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>( \
-        MAKE_PTA_WITH_NAME(func_name, x_values, scalar_t, 2, 32),           \
-        x_offset_ptrs,                                                      \
-        x_offset_sizes,                                                     \
-        MAKE_PTA_WITH_NAME(func_name, y_reshaped, scalar_t, 3, 32),         \
-        MAKE_PTA_WITH_NAME(func_name, y_reshaped, scalar_t, 3, 32),         \
-        MAKE_PTA_WITH_NAME(func_name, output_values, scalar_t, 2, 32),      \
-        jagged_dims_tensor,                                                 \
-        [f] __device__(scalar_t x, scalar_t y, scalar_t /*unused*/)         \
-            -> scalar_t { return f(x, y); });                               \
+#define INVOKE_KERNEL_WITH_DIM(NUM_JAGGED_DIM)                          \
+  {                                                                     \
+    dim3 threads, blocks;                                               \
+    StackArray<int64_t> jagged_dims_tensor;                             \
+    std::tie(threads, blocks, jagged_dims_tensor) =                     \
+        check_shape_and_partition_(x_values, x_offsets, y);             \
+    blocks.x = div_round_up(x_values.size(0), threads.y);               \
+    std::vector<Tensor> x_offsets_contig;                               \
+    x_offsets_contig.resize(num_jagged_dim);                            \
+    StackArray<index_t*> x_offset_ptrs;                                 \
+    x_offset_ptrs.ndim = num_jagged_dim;                                \
+    StackArray<int64_t> x_offset_sizes;                                 \
+    x_offset_sizes.ndim = num_jagged_dim;                               \
+    for (int d = 0; d < num_jagged_dim; ++d) {                          \
+      x_offsets_contig[d] = x_offsets[d].contiguous();                  \
+      x_offset_ptrs.vals[d] =                                           \
+          x_offsets_contig[d].template data_ptr<index_t>();             \
+      x_offset_sizes.vals[d] = x_offsets[d].numel();                    \
+    }                                                                   \
+    const auto ff =                                                     \
+        ([f] __device__(                                                \
+             scalar_t x, scalar_t y, scalar_t /*unused*/) -> scalar_t { \
+          return f(x, y);                                               \
+        });                                                             \
+                                                                        \
+    FBGEMM_LAUNCH_KERNEL(                                               \
+        (jagged_dense_dense_elementwise_jagged_output_kernel_<          \
+            NUM_JAGGED_DIM,                                             \
+            index_t,                                                    \
+            scalar_t,                                                   \
+            decltype(ff)>),                                             \
+        blocks,                                                         \
+        threads,                                                        \
+        0,                                                              \
+        at::cuda::getCurrentCUDAStream(),                               \
+        PTA_B(x_values, scalar_t, 2, 32),                               \
+        x_offset_ptrs,                                                  \
+        x_offset_sizes,                                                 \
+        PTA_B(y_reshaped, scalar_t, 3, 32),                             \
+        PTA_B(y_reshaped, scalar_t, 3, 32),                             \
+        PTA_B(output_values, scalar_t, 2, 32),                          \
+        jagged_dims_tensor,                                             \
+        ff);                                                            \
   }
 
 ///@addtogroup jagged-tensor-ops-cuda
@@ -827,54 +844,52 @@ void jagged_dense_elementwise_jagged_output_opt_(
             C10_CUDA_KERNEL_LAUNCH_CHECK();
             TORCH_CHECK(dynamic_smem_size <= used_shared_bytes);
           }
+
           dim3 threads_bs = dim3(1024, 1, 1);
-          dim3 blocks_bs = dim3(div_round_up(nnz, threads_bs.x), 1, 1);
-#ifdef FBGEMM_GPU_MEMCHECK
-          const auto func_name1 =
-              "jagged_dense_dense_elementwise_jagged_output_opt_search_kernel_";
-#endif
-          jagged_dense_dense_elementwise_jagged_output_opt_search_kernel_<
-              index_t>
-              <<<blocks_bs,
-                 threads_bs,
-                 dynamic_smem_size,
-                 at::cuda::getCurrentCUDAStream()>>>(
-                  MAKE_PTA_WITH_NAME(func_name1, x_offsets[0], index_t, 1, 32),
-                  MAKE_PTA_WITH_NAME(func_name1, t_rows_after_bs, int, 1, 32),
-                  MAKE_PTA_WITH_NAME(func_name1, t_cols_after_bs, int, 1, 32),
-                  nnz,
-                  B);
-          C10_CUDA_KERNEL_LAUNCH_CHECK();
+          FBGEMM_LAUNCH_KERNEL(
+              (jagged_dense_dense_elementwise_jagged_output_opt_search_kernel_<
+                  index_t>),
+              dim3(div_round_up(nnz, threads_bs.x), 1, 1),
+              threads_bs,
+              dynamic_smem_size,
+              at::cuda::getCurrentCUDAStream(),
+              PTA_B(x_offsets[0], index_t, 1, 32),
+              PTA_B(t_rows_after_bs, int, 1, 32),
+              PTA_B(t_cols_after_bs, int, 1, 32),
+              nnz,
+              B);
+
           // Gather kernel
           dim3 threads = dim3(16, 16, 1);
           dim3 blocks = dim3(1, div_round_up(nnz, threads.y), 1);
           if (blocks.y > 65535) {
             blocks.y = 65535;
           }
-#ifdef FBGEMM_GPU_MEMCHECK
-          const auto func_name2 =
-              "jagged_dense_dense_elementwise_jagged_output_opt_gather_kernel_";
-#endif
-          jagged_dense_dense_elementwise_jagged_output_opt_gather_kernel_<
-              index_t>
-              <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-                  MAKE_PTA_WITH_NAME(
-                      func_name2, output_values, c10::Half, 2, 32),
-                  MAKE_PTA_WITH_NAME(func_name2, x_values, c10::Half, 2, 32),
-                  MAKE_PTA_WITH_NAME(func_name2, y_reshaped, c10::Half, 3, 32),
-                  MAKE_PTA_WITH_NAME(func_name2, y_reshaped, c10::Half, 3, 32),
-                  MAKE_PTA_WITH_NAME(func_name2, t_rows_after_bs, int, 1, 32),
-                  MAKE_PTA_WITH_NAME(func_name2, t_cols_after_bs, int, 1, 32),
-                  nnz,
-                  E,
-                  [f] __device__(__half x, __half y0, __half) -> __half {
-                    return f(x, y0);
-                  });
-          C10_CUDA_KERNEL_LAUNCH_CHECK();
+          const auto ff =
+              ([f] __device__(__half x, __half y0, __half) -> __half {
+                return f(x, y0);
+              });
+
+          FBGEMM_LAUNCH_KERNEL(
+              (jagged_dense_dense_elementwise_jagged_output_opt_gather_kernel_<
+                  index_t,
+                  decltype(ff)>),
+              blocks,
+              threads,
+              0,
+              at::cuda::getCurrentCUDAStream(),
+              PTA_B(output_values, c10::Half, 2, 32),
+              PTA_B(x_values, c10::Half, 2, 32),
+              PTA_B(y_reshaped, c10::Half, 3, 32),
+              PTA_B(y_reshaped, c10::Half, 3, 32),
+              PTA_B(t_rows_after_bs, int, 1, 32),
+              PTA_B(t_cols_after_bs, int, 1, 32),
+              nnz,
+              E,
+              ff);
         }); // AT_DISPATCH
   } else {
     JAGGED_TENSOR_DISPATCH_DIMS();
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
 }
 
@@ -907,7 +922,6 @@ void jagged_dense_elementwise_jagged_output_(
   const Tensor y_reshaped = y.view({y.size(0), -1, y.size(-1)});
 
   JAGGED_TENSOR_DISPATCH_DIMS();
-  C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 #undef INVOKE_KERNEL_WITH_DIM


### PR DESCRIPTION
Summary: - Migrate jagged tensor kernels to `FBGEMM_LAUNCH_KERNEL`, pt 1

Reviewed By: r-barnes

Differential Revision: D74923383


