### PR TITLE
Fix Signed-Unsigned Comparison in Tensor Utils

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/tensor_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/tensor_utils.h
@@ -50,7 +50,7 @@ inline const std::string torch_tensor_shape_str(const at::Tensor& ten) {
   std::stringstream ss;
   const auto sizes = ten.sizes();
   ss << "[";
-  for (auto i = 0; i < sizes.size(); ++i) {
+  for (std::size_t i = 0; i < sizes.size(); ++i) {
     ss << sizes[i];
     if (i != sizes.size() - 1) {
       ss << ", ";


### PR DESCRIPTION
Summary:
Resolved warnings caused by comparisons between signed and unsigned integers in tensor_utils.h. Changed the loop index variable i from int to size_t to match the type of sizes.size(), ensuring consistent and safe comparisons. This change eliminates the -Wsign-compare warnings during compilation.

The original error message here:
```
buck-out/v2/gen/fbcode/b43bb943fef57626/deeplearning/fbgemm/fbgemm_gpu/__fbgemm_gpu_cpu__/buck-headers/fbgemm_gpu/utils/tensor_utils.h:53:20: error: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Werror,-Wsign-compare]
   53 | for (auto i = 0; i < sizes.size(); ++i) {
      |                  ~ ^ ~~~~~~~~~~~~
buck-out/v2/gen/fbcode/b43bb943fef57626/deeplearning/fbgemm/fbgemm_gpu/__fbgemm_gpu_cpu__/buck-headers/fbgemm_gpu/utils/tensor_utils.h:55:7: error: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Werror,-Wsign-compare]
   55 | if (i != (sizes.size() - (1))) {
      |     ~ ^   ~~~~~~~~~~~~~~~~~~
2 errors generated.
```

Differential Revision: D76093914


