### PR TITLE
Use float8e4m3fn for MI350+

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
@@ -20,6 +20,7 @@ from fbgemm_gpu.experimental.gemm.triton_gemm.fp4_quantize import (
 )
 
 from fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm import (
+    get_fp8_constants,
     matmul_fp8_block,
     matmul_fp8_row,
     quantize_fp8_block,
@@ -256,10 +257,7 @@ class ScaledMMBaseline(QuantizeOpBase):
     """
 
     def __init__(self):
-        if torch.version.cuda is not None:
-            self.fp8_dtype = torch.float8_e4m3fn
-        else:
-            self.fp8_dtype = torch.float8_e4m3fnuz
+        self.fp8_dtype, _, _, _ = get_fp8_constants()
         self.E4M3_MAX_POS: float = torch.finfo(self.fp8_dtype).max
         self.E5M2_MAX_POS: float = torch.finfo(torch.float8_e5m2).max
         self.FP16_MAX_POS: float = torch.finfo(torch.float16).max

--- a/fbgemm_gpu/experimental/gen_ai/test/comm/multi_gpu_car_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/comm/multi_gpu_car_test.py
@@ -20,6 +20,10 @@ import fbgemm_gpu.experimental.gen_ai  # noqa: F401
 
 import numpy as np
 import torch
+from fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm import (
+    get_fp8_constants,
+    supports_float8_fnuz,
+)
 from hypothesis import given, settings, strategies as st, Verbosity
 from torch.distributed.launcher.api import elastic_launch, LaunchConfig
 
@@ -323,7 +327,7 @@ class LLamaMultiGpuTests(unittest.TestCase):
     def test_allgather(self, dtype: torch.dtype) -> None:
         # float8 is only supported in H100 or MI300x
         if dtype == torch.float8_e4m3fn:
-            if torch.version.hip:
+            if supports_float8_fnuz():
                 dtype = torch.float8_e4m3fnuz
             elif torch.cuda.get_device_capability() < (9, 0):
                 self.skipTest(
@@ -363,12 +367,13 @@ class LLamaMultiGpuTests(unittest.TestCase):
     ) -> None:
         dst_dtype, src_dtype = dtypes
         # float8 is only supported in H100 or MI300x
+        float8_e4m3_dtype, _, _, _ = get_fp8_constants()
         if dst_dtype == torch.float8_e4m3fn or src_dtype == torch.float8_e4m3fn:
             if torch.version.hip:
                 if dst_dtype == torch.float8_e4m3fn:
-                    dst_dtype = torch.float8_e4m3fnuz
+                    dst_dtype = float8_e4m3_dtype
                 if src_dtype == torch.float8_e4m3fn:
-                    src_dtype = torch.float8_e4m3fnuz
+                    src_dtype = float8_e4m3_dtype
             elif torch.cuda.get_device_capability() < (9, 0):
                 self.skipTest(
                     "float8_e4m3fn is only supported in H100 or MI300x, but we're running "

--- a/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
@@ -16,6 +16,7 @@ import fbgemm_gpu.experimental.gen_ai  # noqa: F401
 
 import torch
 import triton  # noqa: F401
+from fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm import supports_float8_fnuz
 
 if torch.cuda.is_available():
     from fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm import (
@@ -41,7 +42,7 @@ except ImportError:
 running_on_github: bool = os.getenv("GITHUB_ENV") is not None
 
 # Supported FP8 format is different on NV and AMD.
-if torch.version.hip is not None:
+if supports_float8_fnuz():
     fp8_e4m3: torch.dtype = torch.float8_e4m3fnuz
     fp8_e5m2: torch.dtype = torch.float8_e5m2fnuz
 else:


### PR DESCRIPTION
Summary:
X-link: https://github.com/fairinternal/moviegen/pull/1414

X-link: https://github.com/facebookresearch/FBGEMM/pull/1358

Only MI300 supports e4m3fnuz - MI350 supports e4m3fn. So change it

Differential Revision: D76020875


