### PR TITLE
group gemm float8 dtype for AMD GPU

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
@@ -19,6 +19,7 @@ from fbgemm_gpu.experimental.gemm.triton_gemm.fp4_quantize import (
 )
 
 from fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm import (
+    get_fp8_constants,
     matmul_fp8_block,
     matmul_fp8_row,
     quantize_fp8_block,
@@ -255,10 +256,7 @@ class ScaledMMBaseline(QuantizeOpBase):
     """
 
     def __init__(self):
-        if torch.version.cuda is not None:
-            self.fp8_dtype = torch.float8_e4m3fn
-        else:
-            self.fp8_dtype = torch.float8_e4m3fnuz
+        self.fp8_dtype, _, _, _ = get_fp8_constants()
         self.E4M3_MAX_POS: float = torch.finfo(self.fp8_dtype).max
         self.E5M2_MAX_POS: float = torch.finfo(torch.float8_e5m2).max
         self.FP16_MAX_POS: float = torch.finfo(torch.float16).max

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
@@ -17,6 +17,7 @@
 #include <unordered_map>
 
 #include <ATen/ATen.h>
+#include <ATen/hip/HIPContext.h>
 #include <c10/hip/HIPStream.h>
 #include <torch/torch.h>
 
@@ -504,6 +505,17 @@ void set_dynamic_kernel_args(
   }
 }
 
+static std::pair<at::ScalarType, std::string> get_float8_e4m3_dtype() {
+  if (at::detail::getCUDAHooks().isGPUArch({"gfx942"})) {
+    return std::make_pair(at::kFloat8_e4m3fnuz, "float8_e4m3fnuz");
+  } else if (at::detail::getCUDAHooks().isGPUArch({"gfx950"})) {
+    return std::make_pair(at::kFloat8_e4m3fn, "float8_e4m3fn");
+  } else {
+    std::string gcn_arch_name = at::cuda::getCurrentDeviceProperties()->gcnArchName;
+    TORCH_CHECK(false, "Unsupported GPU architecture for FP8: ", gcn_arch_name);
+  }
+}
+
 template <typename OutputType>
 OutputType _f8f8bf16_rowwise_grouped(
     at::TensorList XQ,
@@ -512,6 +524,7 @@ OutputType _f8f8bf16_rowwise_grouped(
     at::TensorList w_scale) {
   // Check that input datatypes are valid.
   // First confirm that there are the same number of groups in all inputs.
+  static auto float8_dtype = get_float8_e4m3_dtype();
   TORCH_CHECK(
       XQ.size() == WQ.size() && XQ.size() == x_scale.size() &&
           XQ.size() == w_scale.size(),
@@ -522,15 +535,15 @@ OutputType _f8f8bf16_rowwise_grouped(
     TORCH_CHECK(x.is_cuda() && x.is_contiguous());
     TORCH_CHECK(x.dim() == 2, "Inputs must be 2D.");
     TORCH_CHECK(
-        x.dtype() == at::kFloat8_e4m3fnuz,
-        "Inputs must be type float8_e4m3fnuz.");
+        x.dtype() == float8_dtype.first,
+        "Inputs must be type ", float8_dtype.second);
   }
   for (at::Tensor w : WQ) {
     TORCH_CHECK(w.is_cuda() && w.is_contiguous());
     TORCH_CHECK(w.dim() == 2, "Inputs must be 2D.");
     TORCH_CHECK(
-        w.dtype() == at::kFloat8_e4m3fnuz,
-        "Inputs must be type float8_e4m3fnuz.");
+        w.dtype() == float8_dtype.first,
+        "Inputs must be type ", float8_dtype.second);
     TORCH_CHECK(
         w.size(0) >= 512 && w.size(1) >= 512,
         "N and K must be at least 512 for grouped gemm. For smaller inputs, consider unrolling.");
@@ -626,15 +639,16 @@ at::Tensor f8f8bf16_rowwise_grouped_stacked(
   // Iterate over inputs and check they are valid.
   TORCH_CHECK(XQ.is_cuda() && XQ.is_contiguous());
   TORCH_CHECK(XQ.dim() == 2, "Input XQ must be 2D (total_M,K).");
+  static auto float8_dtype = get_float8_e4m3_dtype();
   TORCH_CHECK(
-      XQ.dtype() == at::kFloat8_e4m3fnuz,
-      "Input XQ must be type float8_e4m3fnuz.");
+      XQ.dtype() == float8_dtype.first,
+      "Input XQ must be type ", float8_dtype.second);
 
   TORCH_CHECK(WQ.is_cuda() && WQ.is_contiguous());
   TORCH_CHECK(WQ.dim() == 3, "Input WQ must be 3D (G,N,K).");
   TORCH_CHECK(
-      WQ.dtype() == at::kFloat8_e4m3fnuz,
-      "Input WQ must be type float8_e4m3fnuz.");
+      WQ.dtype() == float8_dtype.first,
+      "Input WQ must be type ", float8_dtype.second);
   TORCH_CHECK(
       WQ.size(1) >= 512 && WQ.size(2) >= 512,
       "N and K must be at least 512 for grouped gemm. For smaller inputs, consider unrolling.");
@@ -684,15 +698,16 @@ at::Tensor f8f8bf16_rowwise_grouped_dynamic(
   // Iterate over inputs and check they are valid.
   TORCH_CHECK(XQ.is_cuda() && XQ.is_contiguous());
   TORCH_CHECK(XQ.dim() == 3, "Input XQ must be 3D (G,M,K).");
+  static auto float8_dtype = get_float8_e4m3_dtype();
   TORCH_CHECK(
-      XQ.dtype() == at::kFloat8_e4m3fnuz,
-      "Input XQ must be type float8_e4m3fnuz.");
+      XQ.dtype() == float8_dtype.first,
+      "Input XQ must be type ", float8_dtype.second);
 
   TORCH_CHECK(WQ.is_cuda() && WQ.is_contiguous());
   TORCH_CHECK(WQ.dim() == 3, "Input WQ must be 3D (G,N,K).");
   TORCH_CHECK(
-      WQ.dtype() == at::kFloat8_e4m3fnuz,
-      "Input WQ must be type float8_e4m3fnuz.");
+      WQ.dtype() == float8_dtype.first,
+      "Input WQ must be type ", float8_dtype.second);
   TORCH_CHECK(
       WQ.size(1) >= 512 && WQ.size(2) >= 512,
       "N and K must be at least 512 for grouped gemm. For smaller inputs, consider unrolling.");

--- a/fbgemm_gpu/experimental/gen_ai/test/comm/multi_gpu_car_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/comm/multi_gpu_car_test.py
@@ -20,6 +20,7 @@ import fbgemm_gpu.experimental.gen_ai  # noqa: F401
 
 import numpy as np
 import torch
+from fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm import supports_float8_fnuz
 from hypothesis import given, settings, strategies as st, Verbosity
 from torch.distributed.launcher.api import elastic_launch, LaunchConfig
 
@@ -323,7 +324,7 @@ class LLamaMultiGpuTests(unittest.TestCase):
     def test_allgather(self, dtype: torch.dtype) -> None:
         # float8 is only supported in H100 or MI300x
         if dtype == torch.float8_e4m3fn:
-            if torch.version.hip:
+            if supports_float8_fnuz():
                 dtype = torch.float8_e4m3fnuz
             elif torch.cuda.get_device_capability() < (9, 0):
                 self.skipTest(
@@ -366,9 +367,9 @@ class LLamaMultiGpuTests(unittest.TestCase):
         if dst_dtype == torch.float8_e4m3fn or src_dtype == torch.float8_e4m3fn:
             if torch.version.hip:
                 if dst_dtype == torch.float8_e4m3fn:
-                    dst_dtype = torch.float8_e4m3fnuz
+                    dst_dtype = self._hip_float8_e4m3_dtype()
                 if src_dtype == torch.float8_e4m3fn:
-                    src_dtype = torch.float8_e4m3fnuz
+                    src_dtype = self._hip_float8_e4m3_dtype()
             elif torch.cuda.get_device_capability() < (9, 0):
                 self.skipTest(
                     "float8_e4m3fn is only supported in H100 or MI300x, but we're running "

--- a/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
@@ -16,6 +16,7 @@ import fbgemm_gpu.experimental.gen_ai  # noqa: F401
 
 import torch
 import triton  # noqa: F401
+from fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm import supports_float8_fnuz
 
 if torch.cuda.is_available():
     from fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm import (
@@ -41,7 +42,7 @@ except ImportError:
 running_on_github: bool = os.getenv("GITHUB_ENV") is not None
 
 # Supported FP8 format is different on NV and AMD.
-if torch.version.hip is not None:
+if supports_float8_fnuz():
     fp8_e4m3: torch.dtype = torch.float8_e4m3fnuz
     fp8_e5m2: torch.dtype = torch.float8_e5m2fnuz
 else:


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1359

AMD no longer supports uz format in MI350+ - so adjust the TORCH_CHECK accordingly

Reviewed By: mxz297

Differential Revision: D76112192


