### PR TITLE
Optimize integration test

### DIFF
--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
@@ -2047,9 +2047,11 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
     @given(
         **default_st,
         num_buckets=st.integers(min_value=10, max_value=15),
+        backend_type=st.sampled_from([BackendType.SSD, BackendType.DRAM]),
+        enable_optimizer_offloading=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
-    def test_apply_kv_state_dict_ssd(
+    def test_apply_kv_state_dict(
         self,
         T: int,
         D: int,
@@ -2065,12 +2067,13 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
         trigger_bounds_check: bool,
         mixed_B: bool,
         num_buckets: int,
+        backend_type: BackendType,
+        enable_optimizer_offloading: bool,
     ) -> None:
         # Constants
         lr = 0.5
         eps = 0.2
         ssd_shards = 2
-        backend_type = BackendType.SSD
 
         trigger_bounds_check = False  # don't stimulate boundary check cases
         assume(not weighted or pooling_mode == PoolingMode.SUM)
@@ -2101,7 +2104,7 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
             output_dtype=output_dtype,
             share_table=share_table,
             num_buckets=num_buckets,
-            enable_optimizer_offloading=False,
+            enable_optimizer_offloading=enable_optimizer_offloading,
             backend_type=backend_type,
         )
 
@@ -2173,7 +2176,9 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
         emb_state_dict_list, bucket_asc_ids_list, num_active_id_per_bucket_list = (
             emb.split_embedding_weights(no_snapshot=False, should_flush=True)
         )
-        split_optimizer_states = emb.split_optimizer_states(bucket_asc_ids_list)
+        split_optimizer_states = emb.split_optimizer_states(
+            bucket_asc_ids_list, no_snapshot=False, should_flush=True
+        )
 
         # create an empty emb with same parameters
         # Construct feature_table_map
@@ -2234,222 +2239,9 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
             bucket_asc_ids_list2,
             num_active_id_per_bucket_list2,
         ) = emb2.split_embedding_weights(no_snapshot=False, should_flush=True)
-        split_optimizer_states2 = emb2.split_optimizer_states(bucket_asc_ids_list2)
-
-        for t in range(len(emb.embedding_specs)):
-            torch.testing.assert_close(
-                bucket_asc_ids_list[t],
-                bucket_asc_ids_list2[t],
-                atol=tolerance,
-                rtol=tolerance,
-            )
-
-            torch.testing.assert_close(
-                emb_state_dict_list[t].full_tensor(),
-                emb_state_dict_list2[t].full_tensor(),
-                atol=tolerance,
-                rtol=tolerance,
-            )
-            torch.testing.assert_close(
-                split_optimizer_states[t],
-                split_optimizer_states2[t],
-                atol=tolerance,
-                rtol=tolerance,
-            )
-            torch.testing.assert_close(
-                num_active_id_per_bucket_list[t],
-                num_active_id_per_bucket_list2[t],
-                atol=tolerance,
-                rtol=tolerance,
-            )
-
-    def test_apply_kv_state_dict_dram(
-        self,
-    ) -> None:
-        # Constants
-        lr = 0.5
-        eps = 0.2
-        ssd_shards = 2
-        log_E = 3
-        T = 10
-        D = 128
-        B = 128
-        log_E = 5
-        L = 20
-        weighted = False
-        cache_set_scale = 0.0
-        pooling_mode = PoolingMode.NONE
-        weights_precision = SparseType.FP32
-        output_dtype = SparseType.FP32
-        share_table = False
-        trigger_bounds_check = False
-        mixed_B = False
-        num_buckets = 10
-        backend_type = BackendType.DRAM
-
-        trigger_bounds_check = False  # don't stimulate boundary check cases
-        assume(not weighted or pooling_mode == PoolingMode.SUM)
-        assume(not mixed_B or pooling_mode != PoolingMode.NONE)
-
-        # TODO: check split_optimizer_states when optimizer offloading is ready
-        # Generate embedding modules and inputs
-        (
-            emb,
-            emb_ref,
-            Es,
-            _,
-            bucket_offsets,
-            bucket_sizes,
-        ) = self.generate_kvzch_tbes(
-            T,
-            D,
-            B,
-            log_E,
-            L,
-            weighted,
-            lr=lr,
-            eps=eps,
-            ssd_shards=ssd_shards,
-            cache_set_scale=cache_set_scale,
-            pooling_mode=pooling_mode,
-            weights_precision=weights_precision,
-            output_dtype=output_dtype,
-            share_table=share_table,
-            num_buckets=num_buckets,
-            enable_optimizer_offloading=False,
-            backend_type=backend_type,
+        split_optimizer_states2 = emb2.split_optimizer_states(
+            bucket_asc_ids_list2, no_snapshot=False, should_flush=True
         )
-
-        # Generate inputs
-        (
-            indices_list,
-            per_sample_weights_list,
-            indices,
-            offsets,
-            per_sample_weights,
-            batch_size_per_feature_per_rank,
-        ) = self.generate_inputs_(
-            B,
-            L,
-            Es,
-            emb.feature_table_map,
-            weights_precision=weights_precision,
-            trigger_bounds_check=trigger_bounds_check,
-            mixed_B=mixed_B,
-            bucket_offsets=bucket_offsets,
-            bucket_sizes=bucket_sizes,
-            is_kv_tbes=True,
-        )
-
-        # Execute forward
-        output_ref_list, output = self.execute_ssd_forward_(
-            emb,
-            emb_ref,
-            indices_list,
-            per_sample_weights_list,
-            indices,
-            offsets,
-            per_sample_weights,
-            B,
-            L,
-            weighted,
-            batch_size_per_feature_per_rank=batch_size_per_feature_per_rank,
-        )
-
-        # Generate output gradient
-        output_grad_list = [torch.randn_like(out) for out in output_ref_list]
-
-        # Execute torch EmbeddingBag backward
-        [out.backward(grad) for (out, grad) in zip(output_ref_list, output_grad_list)]
-        if batch_size_per_feature_per_rank is not None:
-            grad_test = self.concat_ref_tensors_vbe(
-                output_grad_list, batch_size_per_feature_per_rank
-            )
-        else:
-            grad_test = self.concat_ref_tensors(
-                output_grad_list,
-                pooling_mode != PoolingMode.NONE,  # do_pooling
-                B,
-                D * 4,
-            )
-
-        # Execute TBE SSD backward
-        output.backward(grad_test)
-
-        tolerance = (
-            1.0e-4
-            if weights_precision == SparseType.FP32 and output_dtype == SparseType.FP32
-            else 1.0e-2
-        )
-
-        emb.flush()
-
-        # Compare emb state dict with expected values from nn.EmbeddingBag
-        emb_state_dict_list, bucket_asc_ids_list, num_active_id_per_bucket_list = (
-            emb.split_embedding_weights(no_snapshot=False, should_flush=True)
-        )
-        split_optimizer_states = emb.split_optimizer_states(bucket_asc_ids_list)
-
-        # create an empty emb with same parameters
-        # Construct feature_table_map
-
-        cache_sets = max(int(max(T * B * L, 1) * cache_set_scale), 1)
-        emb2 = SSDTableBatchedEmbeddingBags(
-            embedding_specs=emb.embedding_specs,
-            feature_table_map=emb.feature_table_map,
-            ssd_storage_directory=tempfile.mkdtemp(),
-            cache_sets=cache_sets,
-            ssd_uniform_init_lower=-0.1,
-            ssd_uniform_init_upper=0.1,
-            learning_rate=lr,
-            eps=eps,
-            ssd_rocksdb_shards=ssd_shards,
-            optimizer=OptimType.EXACT_ROWWISE_ADAGRAD,
-            pooling_mode=pooling_mode,
-            weights_precision=weights_precision,
-            output_dtype=output_dtype,
-            stochastic_rounding=True,
-            prefetch_pipeline=False,
-            bounds_check_mode=BoundsCheckMode.WARNING,
-            l2_cache_size=8,
-            backend_type=backend_type,
-            kv_zch_params=emb.kv_zch_params,
-        ).cuda()
-
-        # pyre-fixme[16]: Undefined attribute: `Optional` has no attribute `__iter__`.
-        emb2.local_weight_counts = [ids.numel() for ids in bucket_asc_ids_list]
-        emb2.enable_load_state_dict_mode()
-        self.assertIsNotNone(emb2._cached_kvzch_data)
-        for i in range(len(emb.embedding_specs)):
-            # pyre-ignore [16]
-            emb2._cached_kvzch_data.cached_weight_tensor_per_table[i].copy_(
-                # pyre-fixme[16]: Undefined attribute: Item `torch._tensor.Tensor` of `typing.Uni...
-                emb_state_dict_list[i].full_tensor()
-            )
-            # pyre-ignore [16]
-            emb2._cached_kvzch_data.cached_optimizer_state_per_table[i].copy_(
-                split_optimizer_states[i]
-            )
-            # pyre-ignore [16]
-            emb2._cached_kvzch_data.cached_id_tensor_per_table[i].copy_(
-                # pyre-fixme[16]: Undefined attribute: `Optional` has no attribute `__getitem__`.
-                bucket_asc_ids_list[i]
-            )
-            # pyre-ignore [16]
-            emb2._cached_kvzch_data.cached_bucket_splits[i].copy_(
-                num_active_id_per_bucket_list[i]
-            )
-
-        emb2.apply_state_dict()
-
-        emb2.flush(True)
-        # Compare emb state dict with expected values from nn.EmbeddingBag
-        (
-            emb_state_dict_list2,
-            bucket_asc_ids_list2,
-            num_active_id_per_bucket_list2,
-        ) = emb2.split_embedding_weights(no_snapshot=False, should_flush=True)
-        split_optimizer_states2 = emb2.split_optimizer_states(bucket_asc_ids_list2)
 
         for t in range(len(emb.embedding_specs)):
             sorted_ids = torch.sort(bucket_asc_ids_list[t].flatten())


### PR DESCRIPTION
Summary:
**This diff**

- combine `test_apply_kv_state_dict_ssd` and `test_apply_kv_state_dict_dram` into one unified test after we had sorting optimization.

- fix: added snapshot to `split_optimizer_states = emb.split_optimizer_states(bucket_asc_ids_list, no_snapshot=False, should_flush=True`

Reviewed By: steven1327

Differential Revision: D76096658


