### PR TITLE
Add initial version of TuningCache and scripts for heuristic + kernel

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/common/scripts/gen_kernels.py
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/common/scripts/gen_kernels.py
@@ -1,0 +1,337 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import os
+import subprocess
+
+COPYRIGHT = """/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+ """
+
+KERNEL_ID_TEMPLATES = {
+    "bf16bf16bf16_grouped": "bf16bf16bf16_grouped_{tM}_{tN}_{tK}_{cM}_{cN}_{cK}_{pong[0]}",
+    "f8f8bf16_rowwise": "f8f8bf16_rowwise_{tM}_{tN}_{tK}_{cM}_{cN}_{cK}_{arch}_{pong[0]}_{coop[0]}",
+}
+
+bf16bf16bf16_grouped_decl_template = """
+at::Tensor {kernel_id}(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor output,
+    std::optional<at::Tensor> zero_start_index_M,
+    std::optional<at::Tensor> M_sizes);
+
+at::Tensor {kernel_id}(
+    at::TensorList X, // BF16
+    at::TensorList W, // BF16
+    at::Tensor output,
+    std::optional<at::Tensor> zero_start_index_M,
+    std::optional<at::Tensor> M_sizes);
+    """
+
+f8f8bf16_rowwise_decl_template = """
+at::Tensor {kernel_id}(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt);
+    """
+
+DECL_TEMPLATES = {
+    "bf16bf16bf16_grouped": bf16bf16bf16_grouped_decl_template,
+    "f8f8bf16_rowwise": f8f8bf16_rowwise_decl_template,
+}
+
+
+bf16bf16bf16_grouped_file_template = """
+at::Tensor {kernel_id}(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor output,
+    std::optional<at::Tensor> zero_start_index_M,
+    std::optional<at::Tensor> M_sizes) {{
+  return bf16bf16bf16_grouped_impl<at::Tensor, {tM}, {tN}, {tK}, {cM}, {cN}, {cK}, {pong}>(
+      X, W, output, zero_start_index_M, M_sizes);
+}}
+
+at::Tensor {kernel_id}(
+    at::TensorList X, // BF16
+    at::TensorList W, // BF16
+    at::Tensor output,
+    std::optional<at::Tensor> zero_start_index_M,
+    std::optional<at::Tensor> M_sizes) {{
+  return bf16bf16bf16_grouped_impl<at::TensorList, {tM}, {tN}, {tK}, {cM}, {cN}, {cK}, {pong}>(
+      X, W, output, zero_start_index_M, M_sizes);
+}}
+"""
+
+f8f8bf16_rowwise_file_template = """
+at::Tensor {kernel_id}(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt) {{
+  // Dispatch this kernel to the correct underlying implementation.
+  return f8f8bf16_rowwise_wrapper<{tM}, {tN}, {tK}, {cM}, {cN}, {cK}, {arch}, {pong}, {coop}>(
+      XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+}}
+"""
+
+FILE_TEMPLATES = {
+    "bf16bf16bf16_grouped": bf16bf16bf16_grouped_file_template,
+    "f8f8bf16_rowwise": f8f8bf16_rowwise_file_template,
+}
+
+bf16bf16bf16_grouped_kernel_map_template = """
+template <typename InputType>
+using Kernel_bf16bf16bf16_grouped = at::Tensor (*)(
+    InputType,
+    InputType,
+    at::Tensor,
+    std::optional<at::Tensor>,
+    std::optional<at::Tensor>);
+
+template <typename InputType>
+const std::unordered_map<std::string, Kernel_bf16bf16bf16_grouped<InputType>>&
+get_bf16bf16bf16_grouped_kernels() {{
+  static const std::unordered_map<std::string, Kernel_bf16bf16bf16_grouped<InputType>> kernels = {{
+    {body}
+  }};
+  return kernels;
+}}
+"""
+
+f8f8bf16_rowwise_kernel_map_template = """
+using Kernel_f8f8bf16_rowwise = at::Tensor (*)(
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    bool,
+    std::optional<at::Tensor>,
+    std::optional<at::Tensor>);
+
+const std::unordered_map<std::string, Kernel_f8f8bf16_rowwise>&
+get_f8f8bf16_rowwise_kernels(int arch) {{
+  static const std::unordered_map<std::string, Kernel_f8f8bf16_rowwise> kernelsSM90 = {{
+    {bodySM90}
+  }};
+  static const std::unordered_map<std::string, Kernel_f8f8bf16_rowwise> kernelsSM100 = {{
+    {bodySM100}
+  }};
+  if (arch == 10) {{
+    return kernelsSM100;
+  }} else {{
+    return kernelsSM90;
+  }}
+}}
+"""
+
+ARCH_MAP_TEMPLATES = {"f8f8bf16_rowwise": f8f8bf16_rowwise_kernel_map_template}
+MAP_TEMPLATES = {"bf16bf16bf16_grouped": bf16bf16bf16_grouped_kernel_map_template}
+
+
+def gen_kernel_map_body(kernel_confs, arch=None):
+    return "\n".join(
+        [
+            f'{{"{kernel_conf['kernel_id']}", {kernel_conf['kernel_id']}}},'
+            for kernel_conf in kernel_confs
+            if arch is None or kernel_conf["arch"] == arch
+        ]
+    )
+
+
+def gen_kernel_map(kernel_name, kernel_confs):
+    if kernel_name in MAP_TEMPLATES:
+        body = gen_kernel_map_body(kernel_confs)
+        return MAP_TEMPLATES[kernel_name].format(body=body)
+
+    # ARCH_MAP_TEMPLATES
+    bodySM90 = gen_kernel_map_body(kernel_confs, 9)
+    bodySM100 = gen_kernel_map_body(kernel_confs, 10)
+    return ARCH_MAP_TEMPLATES[kernel_name].format(
+        bodySM90=bodySM90, bodySM100=bodySM100
+    )
+
+
+def get_kernel_confs_nv(kernel_name):
+    # Change these as needed to explore different kernels configurations.
+    tiles = [
+        (M, N, K)
+        for M in (64, 128, 256)
+        for N in (
+            16,
+            32,
+            64,
+            128,
+            256,
+        )
+        for K in (128,)
+    ]
+    clusters = [(1, 1, 1), (2, 1, 1), (4, 1, 1)]
+    schedules = [("false", "false"), ("true", "false"), ("false", "true")]
+    # SM90 and SM100
+    archs = [9, 10]
+
+    # Some kernels may not support all parameters (e.g. only 1 type of schedule), filter them out to prevent duplicates.
+    generated = set()
+
+    kernel_confs = []
+    for arch in archs:
+        for tM, tN, tK in tiles:
+            for cM, cN, cK in clusters:
+                for pong, coop in schedules:
+                    # Co-operative requires tM >= 128
+                    if tM < 128 and (
+                        coop == "true"
+                        # This kernel only supports pong OR coop, and not regular warp persistent
+                        or (kernel_name == "bf16bf16bf16_grouped" and pong == "false")
+                    ):
+                        continue
+
+                    # This tile size is generally bad
+                    if tM == 256 and tN == 256:
+                        continue
+
+                    # To compile less kernels skip pong & coop for smaller tiles as they don't reach the compute roofline
+                    if (pong == "true" or coop == "true") and not (
+                        tM >= 128 and tN >= 128
+                    ):
+                        continue
+
+                    # SM100 specific
+                    if arch == 10:
+                        # M cluster == 1 requires specific M tile size
+                        if cM == 1 and not (tM == 64 or tM == 128):
+                            continue
+
+                        # M cluter > 1 requires N tile >= 32
+                        if cM > 1 and tN < 32:
+                            continue
+
+                    kernel_conf = {
+                        "arch": arch,
+                        "tM": tM,
+                        "tN": tN,
+                        "tK": tK,
+                        "cM": cM,
+                        "cN": cN,
+                        "cK": cK,
+                        "pong": pong,
+                        "coop": coop,
+                    }
+                    kernel_id = gen_kernel_id(kernel_name, kernel_conf)
+                    if kernel_id not in generated:
+                        generated.add(kernel_id)
+
+                        kernel_conf["kernel_id"] = kernel_id
+                        kernel_confs.append(kernel_conf)
+
+    return kernel_confs
+
+
+def gen_kernel_id(kernel_name, kernel_conf):
+    template = KERNEL_ID_TEMPLATES[kernel_name]
+    return template.format(**kernel_conf)
+
+
+def gen_kernel_file(kernel_name, kernel_conf):
+    template = FILE_TEMPLATES[kernel_name]
+    formatted = template.format(**kernel_conf)
+
+    return f"""{COPYRIGHT}
+#include "{kernel_name}_common.cuh"
+
+namespace fbgemm_gpu {{
+
+{formatted}
+
+}} // namespace fbgemm_gpu
+"""
+
+
+def gen_kernel_files(kernel_name, kernel_confs, output_dir):
+    for kernel_conf in kernel_confs:
+        kernel_id = kernel_conf["kernel_id"]
+        file_path = os.path.join(output_dir, f"{kernel_id}.cu")
+        with open(file_path, "w") as f:
+            f.write(gen_kernel_file(kernel_name, kernel_conf))
+
+
+def gen_kernel_manifest_decl(kernel_name, kernel_conf):
+    template = DECL_TEMPLATES[kernel_name]
+    return template.format(**kernel_conf)
+
+
+def gen_kernel_manifest(kernel_name, kernel_confs, output_dir):
+    body = "\n".join(
+        gen_kernel_manifest_decl(kernel_name, kernel_conf)
+        for kernel_conf in kernel_confs
+    )
+    kernel_map = gen_kernel_map(kernel_name, kernel_confs)
+
+    manifest_content = f"""{COPYRIGHT}
+#pragma once
+
+#include <ATen/ATen.h>
+
+namespace fbgemm_gpu {{
+
+{body}
+
+{kernel_map}
+
+}} // namespace fbgemm_gpu
+"""
+
+    manifest_path = os.path.join(output_dir, f"{kernel_name}_manifest.cuh")
+    with open(manifest_path, "w") as f:
+        f.write(manifest_content)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate kernel files and manifest.")
+    parser.add_argument(
+        "--kernel_name",
+        type=str,
+        required=True,
+        help="Name of the kernel to generate, e.g. bf16bf16bf16_grouped.",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        help="Directory to place generated kernels. If unset, will default to the current working directory.",
+    )
+    args = parser.parse_args()
+
+    # Determine the output directory
+    output_dir = args.output_dir if args.output_dir is not None else os.getcwd()
+    print(f"Will place generated files in {output_dir}")
+
+    kernel_confs = get_kernel_confs_nv(args.kernel_name)
+    print(f"Will generate {len(kernel_confs)}  kernels")
+    gen_kernel_files(args.kernel_name, kernel_confs, output_dir)
+    gen_kernel_manifest(args.kernel_name, kernel_confs, output_dir)
+
+    # Format the generated files
+    command = f"clang-format -i {output_dir}/*.{{cu,cuh}}"
+    subprocess.run(command, shell=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/common/scripts/make_heuristic.py
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/common/scripts/make_heuristic.py
@@ -1,0 +1,170 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+from collections import defaultdict
+from typing import Dict, List, Set, Tuple
+
+
+def build_heuristic(
+    file_path: str, threshold: float
+) -> Dict[Tuple[int, ...], List[Tuple[str, str]]]:
+    """
+    Builds a heuristic from a set of profiling runs on a kernel.
+    The heuristic is currently built in a greedy approach:
+    1. For all problem shapes consider all kernels performing within (1+threshold) of the fastest kernel.
+    2. For the above kernels, count how often it appeared across all problem shapes.
+    3. When assigning a kernel to a problem shape, prioritize kernels that appear more often to minimize the number of kernels used.
+
+    Assumptions:
+
+    The ordering of the problem shape dimension is assumed to be (outer_dim, inner_shapes) where outer_dim varies but inner_shapes is fixed in a set of problem shapes.
+    This is how we decide how to map a set of problem shapes into a heuristic.
+    E.g. For the following problem shapes (5, 5120, 1024), (6, 5120, 1024), (7, 2048, 1024), (8, 2048, 1024) we would build a heuristic along:
+
+    Problem Shape (5120, 1024):
+      5: ...
+      6: ...
+
+    Problem Shape (2048, 1024):
+      7: ...
+      8: ...
+    """
+    # Inner problem shapes
+    inner_shapes: Set[Tuple[int, ...]] = set()
+    # Problem Shape -> Best kernel time
+    best_times_ms: Dict[Tuple[int, ...], float] = {}
+    # Kernels count across all problem shapes
+    kernel_count: Dict[str, int] = defaultdict(int)
+    # Problem Shape -> Candidate kernels
+    kernel_candidates: Dict[Tuple[int, ...], Set[str]] = defaultdict(set)
+    # Problem Shape -> Assigned kernel
+    kernel_assignment: Dict[Tuple[int, ...], str] = {}
+    # Inner problem shape -> (Outer Dim, Kernel)
+    heuristics: Dict[Tuple[int, ...], List[Tuple[str, str]]] = {}
+
+    with open(file_path, "r") as file:
+        parsed_rows = []
+
+        # Parse CSV and find the best time for each problem shape.
+        rows = file.readlines()
+        for row in rows:
+            problem_shape_str, kernel, time_ms_str = row.split(",")
+            problem_shape = tuple(int(x) for x in problem_shape_str.split("_"))
+            time_ms = float(time_ms_str)
+
+            inner_shapes.add(problem_shape[1:])
+            best_times_ms[problem_shape] = (
+                time_ms
+                if problem_shape not in best_times_ms
+                else min(best_times_ms[problem_shape], time_ms)
+            )
+
+            parsed_rows.append((problem_shape, kernel, time_ms))
+
+        # Filter kernels for each problem shape based on the permitted threshold
+        for problem_shape, kernel, time_ms in parsed_rows:
+            if time_ms < (best_times_ms[problem_shape] * (1 + threshold)):
+                kernel_candidates[problem_shape].add(kernel)
+                kernel_count[kernel] += 1
+
+    # Prefer kernels that are used more often
+    kernel_order = sorted(kernel_count.keys(), key=kernel_count.get, reverse=True)
+
+    for kernel in kernel_order:
+        for problem_shape, candidates in kernel_candidates.items():
+            if problem_shape not in kernel_assignment and kernel in candidates:
+                kernel_assignment[problem_shape] = kernel
+
+    for inner_shape in inner_shapes:
+        outer_dims_and_kernel = sorted(
+            [
+                (problem_shape[0], kernel)
+                for problem_shape, kernel in kernel_assignment.items()
+                if problem_shape[1:] == inner_shape
+            ],
+            key=lambda x: x[0],
+        )
+
+        heuristic: List[Tuple[str, str]] = []
+        last_outer_dim, last_kernel = outer_dims_and_kernel[0]
+        for outer_dim, assigned_kernel in outer_dims_and_kernel[1:]:
+            if last_kernel != assigned_kernel:
+                heuristic.append((str(last_outer_dim), last_kernel))
+            last_outer_dim, last_kernel = outer_dim, assigned_kernel
+        heuristic.append(("else", last_kernel))
+
+        heuristics[inner_shape] = heuristic
+
+    return heuristics
+
+
+# A basic codegen to make the if statements, customize as needed for your kernel.
+def print_heuristic_cpp(
+    heuristics: Dict[Tuple[int, ...], List[Tuple[str, str]]],
+    varnames_arg: str,
+) -> None:
+    varnames = dict(enumerate(varnames_arg.split(",")))
+
+    for inner_shape, outer_dims_and_kernels in heuristics.items():
+        condition = " && ".join(
+            [f"{varnames[idx + 1]} == {val}" for idx, val in enumerate(inner_shape)]
+        )
+        print(f"if ({condition}) {{")
+        for idx, (outer_dim, kernel) in enumerate(outer_dims_and_kernels):
+            if idx == 0:
+                print(f"  if ({varnames[0]} <= {outer_dim}) {{")
+            elif idx == len(outer_dims_and_kernels) - 1:
+                print("  } else {")
+            else:
+                print(f"  }} else if ({varnames[0]} <= {outer_dim}) {{")
+            print(f"    return {kernel};")
+        print("  }")
+        print("}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate heuristics from FBGEMM kernel tuning cache detailed info."
+    )
+    parser.add_argument(
+        "--file-path",
+        type=str,
+        required=True,
+        help="Path to the input data file generated by the FBGEMM tuning cache.",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.01,
+        help="Kernels performing within --threshold of the best fastest kernel will be considered.",
+    )
+    parser.add_argument(
+        "--cpp", action="store_true", help="Generate C++ code for the heuristic."
+    )
+    parser.add_argument(
+        "--cpp_varnames",
+        type=str,
+        help="Variable names to use for C++ heuristic generation, comma separated in same order of the problem shape. E.g. M,N,K",
+    )
+
+    args = parser.parse_args()
+
+    heuristic = build_heuristic(args.file_path, args.threshold)
+    if args.cpp:
+        if args.cpp_varnames is None:
+            print("If setting --cpp must also set --cpp_varnames.")
+            exit(1)
+        print_heuristic_cpp(heuristic, args.cpp_varnames)
+    else:
+        for inner_shape, outer_dims in heuristic.items():
+            print(f"Problem Shape: {inner_shape}")
+            for outer_dim, assigned_kernel in outer_dims:
+                print(f"  {outer_dim}: {assigned_kernel}")
+
+
+if __name__ == "__main__":
+    main()

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/common/tuning_cache.hpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/common/tuning_cache.hpp
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cfloat>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <unordered_map>
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAEvent.h>
+#include <ATen/cuda/CUDAGraph.h>
+#include <cuda_runtime.h>
+#include <fmt/core.h>
+#include <glog/logging.h>
+
+/**
+ * Tuning cache for kernels. This class is responsible for evaluating new
+ * problem shapes (keyed by a string) against a predefined set of kernels, and
+ * caching the best kernel found.
+ */
+class TuningCache final {
+ public:
+  // kernelName should be unique for each type of kernel, as it is used to
+  // construct the filename.
+  explicit TuningCache(const std::string& kernelName)
+      : useCudaGraph_(std::getenv("FBGEMM_AUTOTUNE_USE_CUDA_GRAPH") != nullptr),
+        cacheDirectory_(getCacheDirectory()),
+        cacheFilename_(getCacheFilename(kernelName)),
+        detailedFilename_(getDetailedFilename(kernelName)) {
+    LOG(INFO) << fmt::format("Using cache file at {}", cacheFilename_);
+
+    createCacheDirectory();
+    loadCache();
+  }
+
+  TuningCache(const TuningCache&) = delete;
+  TuningCache& operator=(const TuningCache&) = delete;
+  TuningCache(TuningCache&&) = delete;
+  TuningCache& operator=(TuningCache&&) = delete;
+
+  ~TuningCache() {
+    saveCache();
+  }
+
+  template <typename Kernel, typename... Args>
+  Kernel findBestKernelMaybeAutotune(
+      const std::string& cache_key,
+      const std::unordered_map<std::string, Kernel>& kernels,
+      Args&&... args) {
+    TORCH_CHECK(!kernels.empty(), "Kernels to tune over is empty.");
+
+    auto it = cache_.find(cache_key);
+    if (it != cache_.end()) {
+      return getKernel(it->second, kernels);
+    }
+
+    const auto start = std::chrono::high_resolution_clock::now();
+    auto kernel_key =
+        findBestKernel(cache_key, kernels, std::forward<Args>(args)...);
+    const auto end = std::chrono::high_resolution_clock::now();
+    const auto elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    LOG(INFO) << fmt::format(
+        "Tuned {} for key {} in {} ms.",
+        kernel_key,
+        cache_key,
+        elapsed.count());
+
+    cache_.insert({cache_key, kernel_key});
+    return getKernel(kernel_key, kernels);
+  }
+
+ private:
+  template <typename Kernel>
+  Kernel getKernel(
+      const std::string& kernel_key,
+      const std::unordered_map<std::string, Kernel>& kernels) {
+    auto it = kernels.find(kernel_key);
+    TORCH_CHECK(
+        it != kernels.end(),
+        fmt::format(
+            "Failed to find kernel keyed by {}. Consider deleting your fbgemm cache (~/.fbgemm).",
+            kernel_key));
+    return it->second;
+  }
+
+  std::string getCacheDirectory() {
+    // If the environment variable is set, use that instead of the default
+    const char* cache_dir = std::getenv("FBGEMM_CACHE_DIR");
+    if (cache_dir) {
+      return cache_dir;
+    }
+
+    return fmt::format("{}/{}", getenv("HOME"), FBGEMM_CACHE_DIR);
+  }
+
+  std::string getCacheFilename(const std::string& kernel_name) {
+    return fmt::format("{}/{}.txt", getCacheDirectory(), kernel_name);
+  }
+
+  std::string getDetailedFilename(const std::string& kernel_name) {
+    return fmt::format("{}/{}_detailed.txt", getCacheDirectory(), kernel_name);
+  }
+
+  bool cacheDirExists() {
+    return std::filesystem::exists(cacheDirectory_) &&
+        std::filesystem::is_directory(cacheDirectory_);
+  }
+
+  void createCacheDirectory() {
+    if (!cacheDirExists()) {
+      // Try to create the directory, multiple caches/processes may attempt
+      // this, and only one would succeed.
+      std::string error;
+      try {
+        if (std::filesystem::create_directory(cacheDirectory_)) {
+          return;
+        }
+      } catch (const std::filesystem::filesystem_error& e) {
+        error = e.what();
+      }
+
+      // If the directory still doesn't exist, error out
+      if (!cacheDirExists()) {
+        LOG(FATAL) << fmt::format(
+            "FBGEMM cache directory creation at {} failed: {}.",
+            cacheDirectory_,
+            error);
+      }
+    }
+  }
+
+  void loadCache() {
+    std::ifstream file(cacheFilename_);
+    if (!file.is_open()) {
+      // Create a new cache file if it doesn't exist
+      std::ofstream newFile(cacheFilename_);
+      newFile.close();
+    } else {
+      std::string line;
+      while (std::getline(file, line)) {
+        size_t pos = line.find('=');
+        if (pos != std::string::npos) {
+          std::string key = line.substr(0, pos);
+          std::string value = line.substr(pos + 1);
+          cache_.insert_or_assign(key, value);
+        }
+      }
+      file.close();
+    }
+  }
+
+  void saveCache() {
+    // Only one rank needs to save the cache. This is fine as the cache
+    // should be largely equivalent across ranks.
+    if (at::cuda::current_device() != 0) {
+      return;
+    }
+
+    std::ofstream file(cacheFilename_);
+    if (file.is_open()) {
+      for (const auto& pair : cache_) {
+        file << fmt::format("{}={}", pair.first, pair.second) << std::endl;
+      }
+      file.close();
+    }
+
+    if (!detailedTuningInfo_.empty()) {
+      std::ofstream detailed_file(detailedFilename_, std::ios_base::app);
+      if (detailed_file.is_open()) {
+        for (auto& [cache_key, kernels] : detailedTuningInfo_) {
+          // Sort for convenience in descending order of time_ms
+          std::sort(
+              kernels.begin(), kernels.end(), [](const auto& a, const auto& b) {
+                return a.second < b.second;
+              });
+          for (const auto& [kernel_name, time_ms] : kernels) {
+            detailed_file << fmt::format(
+                                 "{},{},{}", cache_key, kernel_name, time_ms)
+                          << std::endl;
+          }
+        }
+
+        detailed_file.close();
+      }
+    }
+  }
+
+  template <typename Kernel, typename... Args>
+  float benchmark(Kernel kernel, Args&&... args) {
+    // Warmup iteration
+    kernel(std::forward<Args>(args)...);
+
+    // Estimate the number of iterations needed to run for 10 ms. This
+    // helps with stability for fast kernels.
+    start_.record();
+    kernel(std::forward<Args>(args)...);
+    stop_.record();
+    stop_.synchronize();
+    const auto estimated_time_ms = start_.elapsed_time(stop_);
+    const int num_iters = std::max(1, int(10 / estimated_time_ms));
+
+    if (useCudaGraph_) {
+      at::cuda::CUDAGraph graph;
+      {
+        // CUDAGraph capture must happen on non-default stream
+        at::cuda::CUDAStream stream = at::cuda::getStreamFromPool(true);
+        at::cuda::CUDAStreamGuard streamGuard(stream);
+
+        // For flexibility, we use cudaStreamCaptureModeRelaxed.
+        // - cudaStreamCaptureModeGlobal prevents other threads from calling
+        // certain CUDA APIs such as cudaEventQuery. This can conflict with
+        // things like ProcessGroupNCCL.
+        // - cudaStreamCaptureModeThreadLocal prevents CCA from freeing memory.
+        // Since CUDA graph is preferred for offline benchmark this should be
+        // fine.
+        graph.capture_begin({0, 0}, cudaStreamCaptureModeRelaxed);
+        for (int i = 0; i < num_iters; ++i) {
+          kernel(std::forward<Args>(args)...);
+        }
+        graph.capture_end();
+      }
+
+      // Time execution of graph
+      start_.record();
+      graph.replay();
+      stop_.record();
+      stop_.synchronize();
+      const auto graph_time_ms = start_.elapsed_time(stop_);
+
+      return graph_time_ms / num_iters;
+    } else {
+      // Time execution of kernels
+      start_.record();
+      for (int i = 0; i < num_iters; ++i) {
+        kernel(std::forward<Args>(args)...);
+      }
+      stop_.record();
+      stop_.synchronize();
+      const auto kernels_time_ms = start_.elapsed_time(stop_);
+
+      return kernels_time_ms / num_iters;
+    }
+  }
+
+  template <typename Kernel, typename... Args>
+  std::string findBestKernel(
+      const std::string& cache_key,
+      const std::unordered_map<std::string, Kernel>& kernels,
+      Args&&... args) {
+    std::string best_kernel;
+    float best_time = FLT_MAX;
+
+    for (const auto& [kernel_name, kernel] : kernels) {
+      const float time = benchmark(kernel, std::forward<Args>(args)...);
+      if (time < best_time) {
+        best_time = time;
+        best_kernel = kernel_name;
+      }
+      if (std::getenv("FBGEMM_AUTOTUNE_COLLECT_STATS")) {
+        detailedTuningInfo_[cache_key].push_back({kernel_name, time});
+      }
+    }
+
+    return best_kernel;
+  }
+
+  constexpr static std::string_view FBGEMM_CACHE_DIR = ".fbgemm";
+
+  at::cuda::CUDAEvent start_ = at::cuda::CUDAEvent(cudaEventDefault);
+  at::cuda::CUDAEvent stop_ = at::cuda::CUDAEvent(cudaEventDefault);
+
+  // If FBGEMM_AUTOTUNE_USE_CUDA_GRAPH is set, use CUDA graph for benchmarking.
+  // CUDA graphs use a separate memory pool to do allocation in PyTorch
+  // CUDACachingAllocator to ensure the memory is valid throughout the graph,
+  // which can memory fragmentation (and higher chance of CUDA OOM). We can
+  // prefer to use CUDA graph for offline benchmarking, but not for online
+  // serving.
+  bool useCudaGraph_;
+  // Absolute path of the cache directory
+  std::string cacheDirectory_;
+  // Absolute path of the cache file for the kernel
+  std::string cacheFilename_;
+  // Absolute path of the detailed tuning info
+  std::string detailedFilename_;
+  // (cache key, best kernel)
+  std::unordered_map<std::string, std::string> cache_;
+  // If FBGEMM_AUTOTUNE_COLLECT_STATS is set, we will log the timing for each
+  // kernel for each problem shape. This is useful to distill the best kernels
+  // into a smaller set.
+  std::unordered_map<std::string, std::vector<std::pair<std::string, float>>>
+      detailedTuningInfo_;
+};

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/common/utils.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/common/utils.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbgemm_gpu/quantize/common/utils.h" // @manual
+
+namespace fbgemm_gpu {
+
+int nextPowerOf2(int n) {
+  if (n == 0) {
+    return 1;
+  }
+  n--;
+  n |= n >> 1;
+  n |= n >> 2;
+  n |= n >> 4;
+  n |= n >> 8;
+  n |= n >> 16;
+  return n + 1;
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/common/utils.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/common/utils.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace fbgemm_gpu {
+
+int nextPowerOf2(int n);
+
+} // namespace fbgemm_gpu


### PR DESCRIPTION
Summary:
This diff adds 3 new things:
- Tuning Cache
  - The cache is templated, so it is integrated for the 2 kernels in above diffs.
- Script to generate kernels configurations
  - Currently only supports kernels Cutlass FP8 Rowwise & Cutlass BF16 Grouped, but hoping other kernels can be added to it.
- Script to generate heuristics from tuning cache output

Above diffs in the stack will start integrating the cache into the kernels.

Differential Revision: D75540999


