### PR TITLE
Add manifold wrapper

### DIFF
--- a/fbgemm_gpu/test/utils/filestore_test.py
+++ b/fbgemm_gpu/test/utils/filestore_test.py
@@ -125,7 +125,7 @@ class FileStoreTest(unittest.TestCase):
         self._test_filestore_readwrite(
             FileStore("tlparse_reports"),
             io.BytesIO("".join(random.choices(string.ascii_letters, k=128)).encode()),
-            f"tree/{''.join(random.choices(string.ascii_letters, k=15))}.unittest",
+            f"tree/unit_tests/{''.join(random.choices(string.ascii_letters, k=15))}.unittest",
         )
 
     @unittest.skipIf(open_source, "Test does not apply to OSS")
@@ -138,7 +138,7 @@ class FileStoreTest(unittest.TestCase):
         self._test_filestore_readwrite(
             FileStore("tlparse_reports"),
             torch.rand((random.randint(100, 1000), random.randint(100, 1000))),
-            f"tree/{''.join(random.choices(string.ascii_letters, k=15))}.unittest",
+            f"tree/unit_tests/{''.join(random.choices(string.ascii_letters, k=15))}.unittest",
         )
 
     @unittest.skipIf(open_source, "Test does not apply to OSS")
@@ -155,5 +155,5 @@ class FileStoreTest(unittest.TestCase):
         self._test_filestore_readwrite(
             FileStore("tlparse_reports"),
             Path(infile.name),
-            f"tree/{''.join(random.choices(string.ascii_letters, k=15))}.unittest",
+            f"tree/unit_tests/{''.join(random.choices(string.ascii_letters, k=15))}.unittest",
         )


### PR DESCRIPTION
Summary:
Integrating Manifold (python) with FBGEMM is causing some test failures (https://www.internalfb.com/intern/test/281475120056413) due to its dependency on C++. The tests expect dependencies to be purely in Python.

To resolve this, this diff wraps the Manifold C++ in torch classes/ops.

Differential Revision: D76186007
