### PR TITLE
Adding get_kvtensor_serializable_metadata function to

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
@@ -117,6 +117,8 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
 
   void deserialize(const std::string& serialized);
 
+  std::vector<std::string> get_kvtensor_serializable_metadata() const;
+
   friend void to_json(json& j, const KVTensorWrapper& kvt);
   friend void from_json(const json& j, KVTensorWrapper& kvt);
 

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -1286,8 +1286,7 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
 ///
 /// @brief An implementation of ReadOnlyEmbeddingKVDB for RocksDB
 ///
-class ReadOnlyEmbeddingKVDB
-    : public std::enable_shared_from_this<ReadOnlyEmbeddingKVDB> {
+class ReadOnlyEmbeddingKVDB : public torch::jit::CustomClassHolder {
  public:
   explicit ReadOnlyEmbeddingKVDB(
       const std::vector<std::string>& rdb_shard_checkpoint_paths,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1374

Context:

In the Publish Component, we have aligned to not use the conventional serialization and deserialization. We need to create a KVTensorMetaData object to pass data to the publish component 


In this Diff:
We introduce a get_kvtensor_serializable_metadata function to serialize data. This will be used to create a KVTensorMetaData Object

Differential Revision: D76234752


