### PR TITLE
Back out "Migrate TBE UVM cache kernels to `FBGEMM_LAUNCH_KERNEL`"

### DIFF
--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_v1.cu
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_v1.cu
@@ -188,6 +188,9 @@ void _bounds_check_indices_cuda_v1(
 
   AT_DISPATCH_INDEX_TYPES(
       indices.scalar_type(), "bounds_check_indices_cuda_v1", [&] {
+#ifdef FBGEMM_GPU_MEMCHECK
+        const auto func_name = "bounds_check_indices_cuda_v1";
+#endif
         const auto bounds_check_kernel =
             (vbe ? bounds_check_indices_kernel_v1<index_t, true>
                  : bounds_check_indices_kernel_v1<index_t, false>);

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/weight_row.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/weight_row.cuh
@@ -279,7 +279,7 @@ class WeightRow {
   }
 
   //////////////////////////////////////////////////////////////////////////////
-  // Copy the row from the cache into embedding table
+  // Copy the row from the embedding table into the cache
   //////////////////////////////////////////////////////////////////////////////
 
   DEVICE_INLINE void evict_cache(const uint32_t d, const float2 qparams) {

--- a/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_find.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_find.cu
@@ -40,7 +40,7 @@ __global__ __launch_bounds__(kMaxThreads) void lfu_cache_find_uncached_kernel(
         lfu_state) {
   const int32_t C = lxu_cache_state.size(0);
 
-  for (auto n = blockIdx.x * blockDim.y + threadIdx.y; n < *N_unique;
+  for (int32_t n = blockIdx.x * blockDim.y + threadIdx.y; n < *N_unique;
        n += gridDim.x * blockDim.y) {
     const int64_t idx = unique_indices[n];
     if (idx == max_indices) {
@@ -87,18 +87,21 @@ void lfu_update_counts_cuda(
   const int32_t N = unique_indices.size(0);
   AT_DISPATCH_INDEX_TYPES(
       unique_indices.scalar_type(), "lfu_update_counts_cuda", [&] {
-        FBGEMM_LAUNCH_KERNEL(
-            (lfu_update_counts_kernel<index_t>),
+#ifdef FBGEMM_GPU_MEMCHECK
+        const char* func_name = "lfu_update_counts_kernel";
+#endif
+        lfu_update_counts_kernel<<<
             std::min(
                 div_round_up(N, kMaxThreads),
                 get_max_thread_blocks_for_cache_kernels_()),
             kMaxThreads,
             0,
-            at::cuda::getCurrentCUDAStream(),
-            PTA_B(unique_indices, index_t, 1, 32),
+            at::cuda::getCurrentCUDAStream()>>>(
+            MAKE_PTA_WITH_NAME(func_name, unique_indices, index_t, 1, 32),
             unique_indices_length.data_ptr<int32_t>(),
-            PTA_B(unique_indices_count, int32_t, 1, 32),
-            PTA_B(lfu_state, int64_t, 1, 64));
+            MAKE_PTA_WITH_NAME(func_name, unique_indices_count, int32_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, lfu_state, int64_t, 1, 64));
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
       });
 }
 
@@ -124,22 +127,24 @@ std::pair<Tensor, Tensor> lfu_cache_find_uncached_cuda(
 
   AT_DISPATCH_INDEX_TYPES(
       unique_indices.scalar_type(), "lfu_cache_find_uncached_cuda", [&] {
+#ifdef FBGEMM_GPU_MEMCHECK
+        const char* func_name = "lfu_cache_find_uncached_kernel";
+#endif
         // Find uncached indices
-        FBGEMM_LAUNCH_KERNEL(
-            (lfu_cache_find_uncached_kernel<index_t>),
+        lfu_cache_find_uncached_kernel<<<
             std::min(
                 div_round_up(N, kMaxThreads / kWarpSize),
                 get_max_thread_blocks_for_cache_kernels_()),
             dim3(kWarpSize, kMaxThreads / kWarpSize),
             0,
-            at::cuda::getCurrentCUDAStream(),
-            PTA_B(unique_indices, index_t, 1, 32),
+            at::cuda::getCurrentCUDAStream()>>>(
+            MAKE_PTA_WITH_NAME(func_name, unique_indices, index_t, 1, 32),
             unique_indices_length.data_ptr<int32_t>(),
             max_indices,
-            PTA_B(lxu_cache_state, int64_t, 2, 32),
+            MAKE_PTA_WITH_NAME(func_name, lxu_cache_state, int64_t, 2, 32),
             (uint64_t*)cache_sets.data_ptr<int64_t>(),
-            PTA_B(lfu_state, int64_t, 1, 64));
-
+            MAKE_PTA_WITH_NAME(func_name, lfu_state, int64_t, 1, 64));
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
         // Sort the cache sets and ids
         size_t temp_storage_bytes = 0;
         AT_CUDA_CHECK(FBGEMM_GPU_CUB_NS_PREFIX cub::DeviceRadixSort::SortPairs(

--- a/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_populate_byte.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_populate_byte.cu
@@ -54,7 +54,7 @@ __launch_bounds__(kCacheMaxThreads) void lfu_cache_insert_byte_kernel(
         lfu_state,
     const int64_t row_alignment) {
   const int32_t C = lxu_cache_state.size(0);
-  for (auto n = blockIdx.x * blockDim.y + threadIdx.y; n < *N_unique;
+  for (int32_t n = blockIdx.x * blockDim.y + threadIdx.y; n < *N_unique;
        n += gridDim.x * blockDim.y) {
     // check if this warp is responsible for this whole segment.
     const bool segment_start =
@@ -81,20 +81,20 @@ __launch_bounds__(kCacheMaxThreads) void lfu_cache_insert_byte_kernel(
 
     // now, we need to insert the (unique!) values in indices[n:n + SL] into
     // our slots.
-    const auto slot = threadIdx.x;
+    const int32_t slot = threadIdx.x;
     const int64_t current_idx = lxu_cache_state[cache_set][slot];
     const int64_t current_lfu_cost =
         (current_idx != static_cast<int64_t>(kCacheStateInvalid))
         ? lfu_state[current_idx]
         : -1;
     int64_t costs[1] = {current_lfu_cost};
-    uint32_t slots[1] = {slot};
+    int32_t slots[1] = {slot};
 
-    BitonicSort<int64_t, uint32_t, 1, Comparator<int64_t>>::sort(costs, slots);
-    const auto sorted_slot = slots[0];
-    const auto sorted_lfu_cost = costs[0];
+    BitonicSort<int64_t, int32_t, 1, Comparator<int64_t>>::sort(costs, slots);
+    const int32_t sorted_slot = slots[0];
+    const int64_t sorted_lfu_cost = costs[0];
 
-    for (auto l = 0; l < min(SL, kWarpSize); ++l) {
+    for (int32_t l = 0; l < min(SL, kWarpSize); ++l) {
       const int32_t insert_slot = shfl_sync(sorted_slot, l);
       const int64_t insert_current_lfu_cost = shfl_sync(sorted_lfu_cost, l);
       const index_t insert_idx = cache_set_sorted_indices[n + l];
@@ -126,7 +126,7 @@ __launch_bounds__(kCacheMaxThreads) void lfu_cache_insert_byte_kernel(
           &weights[weights_offset_insert + idx_insert * D_insert_bytes + 0]);
       auto cache_row = reinterpret_cast<uint4*>(
           &lxu_cache_weights[cache_set * kWarpSize + insert_slot][0]);
-      for (auto d = threadIdx.x; d * sizeof(uint4) < D_insert_bytes;
+      for (int32_t d = threadIdx.x; d * sizeof(uint4) < D_insert_bytes;
            d += blockDim.x) {
         cache_row[d] = row[d];
       }
@@ -173,27 +173,33 @@ void lfu_cache_insert_byte_cuda(
       cache_set_sorted_unique_indices.scalar_type(),
       "lfu_cache_insert_byte_cuda",
       [&] {
-        FBGEMM_LAUNCH_KERNEL(
-            (lfu_cache_insert_byte_kernel<index_t>),
+#ifdef FBGEMM_GPU_MEMCHECK
+        const char* func_name = "lfu_cache_insert_byte_kernel";
+#endif
+        lfu_cache_insert_byte_kernel<<<
             std::min(
                 div_round_up(N, kCacheMaxThreads / kWarpSize),
                 get_max_thread_blocks_for_cache_kernels_()),
             dim3(kWarpSize, kCacheMaxThreads / kWarpSize),
             0,
-            at::cuda::getCurrentCUDAStream(),
-            PTA_B(weights, uint8_t, 1, 64),
-            PTA_B(cache_hash_size_cumsum, int64_t, 1, 32),
-            PTA_B(cache_index_table_map, int32_t, 1, 64),
-            PTA_B(weights_offsets, int64_t, 1, 32),
-            PTA_B(weights_tys, uint8_t, 1, 32),
-            PTA_B(D_offsets, int32_t, 1, 32),
+            at::cuda::getCurrentCUDAStream()>>>(
+            MAKE_PTA_WITH_NAME(func_name, weights, uint8_t, 1, 64),
+            MAKE_PTA_WITH_NAME(
+                func_name, cache_hash_size_cumsum, int64_t, 1, 32),
+            MAKE_PTA_WITH_NAME(
+                func_name, cache_index_table_map, int32_t, 1, 64),
+            MAKE_PTA_WITH_NAME(func_name, weights_offsets, int64_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, weights_tys, uint8_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, D_offsets, int32_t, 1, 32),
             (uint64_t*)sorted_cache_sets.data_ptr<int64_t>(),
-            PTA_B(cache_set_sorted_unique_indices, index_t, 1, 32),
+            MAKE_PTA_WITH_NAME(
+                func_name, cache_set_sorted_unique_indices, index_t, 1, 32),
             unique_indices_length.data_ptr<int32_t>(),
-            PTA_B(lxu_cache_state, int64_t, 2, 32),
-            PTA_B(lxu_cache_weights, uint8_t, 2, 64),
-            PTA_B(lfu_state, int64_t, 1, 64),
+            MAKE_PTA_WITH_NAME(func_name, lxu_cache_state, int64_t, 2, 32),
+            MAKE_PTA_WITH_NAME(func_name, lxu_cache_weights, uint8_t, 2, 64),
+            MAKE_PTA_WITH_NAME(func_name, lfu_state, int64_t, 1, 64),
             row_alignment);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
       });
 }
 

--- a/fbgemm_gpu/src/split_embeddings_cache/linearize_cache_indices.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/linearize_cache_indices.cu
@@ -105,17 +105,22 @@ DLL_PUBLIC Tensor linearize_cache_indices_cuda(
         using offset_t = index_t;
         AT_DISPATCH_INDEX_TYPES(
             indices.scalar_type(), "linearize_cache_indices_kernel_2", [&] {
-              FBGEMM_LAUNCH_KERNEL(
-                  (linearize_cache_indices_kernel<index_t, offset_t>),
+#ifdef FBGEMM_GPU_MEMCHECK
+              const char* func_name = "linearize_cache_indices_kernel";
+#endif
+              linearize_cache_indices_kernel<<<
                   div_round_up(num_indices, kMaxThreads),
                   kMaxThreads,
                   0,
-                  at::cuda::getCurrentCUDAStream(),
-                  PTA_B(cache_hash_size_cumsum, int64_t, 1, 32),
-                  PTA_B(indices, index_t, 1, 32),
-                  PTA_B(table_offsets, offset_t, 1, 32),
-                  PTA_B(linear_cache_indices, int64_t, 1, 32),
+                  at::cuda::getCurrentCUDAStream()>>>(
+                  MAKE_PTA_WITH_NAME(
+                      func_name, cache_hash_size_cumsum, int64_t, 1, 32),
+                  MAKE_PTA_WITH_NAME(func_name, indices, index_t, 1, 32),
+                  MAKE_PTA_WITH_NAME(func_name, table_offsets, offset_t, 1, 32),
+                  MAKE_PTA_WITH_NAME(
+                      func_name, linear_cache_indices, int64_t, 1, 32),
                   indices_base_offset);
+              C10_CUDA_KERNEL_LAUNCH_CHECK();
             });
       });
   return linear_cache_indices;
@@ -176,16 +181,21 @@ DLL_PUBLIC Tensor linearize_cache_indices_from_row_idx_cuda(
       update_row_indices.scalar_type(),
       "linearize_cache_indices_from_row_idx_kernel",
       [&] {
-        FBGEMM_LAUNCH_KERNEL(
-            (linearize_cache_indices_from_row_idx_kernel<index_t>),
+#ifdef FBGEMM_GPU_MEMCHECK
+        const char* func_name = "linearize_cache_indices_from_row_idx_kernel";
+#endif
+        linearize_cache_indices_from_row_idx_kernel<<<
             div_round_up(num_indices, kMaxThreads),
             kMaxThreads,
             0,
-            at::cuda::getCurrentCUDAStream(),
-            PTA_B(cache_hash_size_cumsum, int64_t, 1, 32),
-            PTA_B(update_table_indices, index_t, 1, 32),
-            PTA_B(update_row_indices, index_t, 1, 32),
-            PTA_B(linear_cache_indices, index_t, 1, 32));
+            at::cuda::getCurrentCUDAStream()>>>(
+            MAKE_PTA_WITH_NAME(
+                func_name, cache_hash_size_cumsum, int64_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, update_table_indices, index_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, update_row_indices, index_t, 1, 32),
+            MAKE_PTA_WITH_NAME(
+                func_name, linear_cache_indices, index_t, 1, 32));
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
       });
   return linear_cache_indices;
 }

--- a/fbgemm_gpu/src/split_embeddings_cache/lru_cache_find.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lru_cache_find.cu
@@ -59,17 +59,20 @@ DLL_PUBLIC Tensor emulate_cache_miss(
       div_round_up(N, kMaxThreads),
       get_max_thread_blocks_for_cache_kernels_()));
 
-  FBGEMM_LAUNCH_KERNEL(
-      (emulate_cache_miss_kernel),
+#ifdef FBGEMM_GPU_MEMCHECK
+  const char* func_name = "emulate_cache_miss_kernel";
+#endif
+
+  emulate_cache_miss_kernel<<<
       blocks,
       kMaxThreads,
       0,
-      at::cuda::getCurrentCUDAStream(),
-      PTA_B(lxu_cache_locations, int32_t, 1, 32),
+      at::cuda::getCurrentCUDAStream()>>>(
+      MAKE_PTA_WITH_NAME(func_name, lxu_cache_locations, int32_t, 1, 32),
       enforced_misses_per_256,
       gather_cache_stats,
-      PTA_B(uvm_cache_stats, int32_t, 1, 32));
-
+      MAKE_PTA_WITH_NAME(func_name, uvm_cache_stats, int32_t, 1, 32));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
   return lxu_cache_locations;
 }
 
@@ -107,7 +110,7 @@ __global__ __launch_bounds__(kMaxThreads) void lru_cache_find_uncached_kernel(
   const int32_t C = lxu_cache_state.size(0);
   int32_t n_misses = 0;
 
-  for (auto n = blockIdx.x * blockDim.y + threadIdx.y; n < *N_unique;
+  for (int32_t n = blockIdx.x * blockDim.y + threadIdx.y; n < *N_unique;
        n += gridDim.x * blockDim.y) {
     int64_t idx = unique_indices[n];
     if (idx == max_indices) {
@@ -211,6 +214,9 @@ lru_cache_find_uncached_cuda(
 
   AT_DISPATCH_INDEX_TYPES(
       unique_indices.scalar_type(), "lru_cache_find_uncached_cuda", [&] {
+#ifdef FBGEMM_GPU_MEMCHECK
+        const char* func_name = "lru_cache_find_uncached_kernel";
+#endif
         // During concurrent prefetch, cache lines are locked and we use less
         // SMs for some of the prefetch kernels to leave SMs for main stream to
         // overlap
@@ -222,24 +228,24 @@ lru_cache_find_uncached_cuda(
                             : get_max_thread_blocks_for_cache_kernels_());
 
         // Find uncached indices
-        FBGEMM_LAUNCH_KERNEL(
-            (lru_cache_find_uncached_kernel<index_t>),
+        lru_cache_find_uncached_kernel<<<
             grid_size,
             dim3(kWarpSize, kMaxThreads / kWarpSize),
             0,
-            at::cuda::getCurrentCUDAStream(),
-            PTA_B(unique_indices, index_t, 1, 32),
+            at::cuda::getCurrentCUDAStream()>>>(
+            MAKE_PTA_WITH_NAME(func_name, unique_indices, index_t, 1, 32),
             unique_indices_length.data_ptr<int32_t>(),
             max_indices,
-            PTA_B(lxu_cache_state, int64_t, 2, 32),
-            PTA_B(cache_sets, int32_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, lxu_cache_state, int64_t, 2, 32),
+            MAKE_PTA_WITH_NAME(func_name, cache_sets, int32_t, 1, 32),
             time_stamp,
-            PTA_B(lru_state, int64_t, 2, 32),
+            MAKE_PTA_WITH_NAME(func_name, lru_state, int64_t, 2, 32),
             gather_cache_stats,
-            PTA_B(uvm_cache_stats, int32_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, uvm_cache_stats, int32_t, 1, 32),
             lock_cache_line,
-            PTA_B(lxu_cache_locking_counter, int32_t, 2, 32));
-
+            MAKE_PTA_WITH_NAME(
+                func_name, lxu_cache_locking_counter, int32_t, 2, 32));
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
         // Sort the cache sets and ids
         size_t temp_storage_bytes = 0;
         INVOKE_CUB_SORT_PAIRS(

--- a/fbgemm_gpu/src/split_embeddings_cache/lru_cache_populate_byte.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lru_cache_populate_byte.cu
@@ -115,24 +115,28 @@ Tensor direct_mapped_lru_cache_find_uncached_cuda(
       linear_cache_indices.scalar_type(),
       "direct_mapped_lru_cache_find_uncached_cuda",
       [&] {
+#ifdef FBGEMM_GPU_MEMCHECK
+        const char* func_name = "direct_mapped_lru_cache_find_uncached_kernel";
+#endif
         // Find uncached indices
-        FBGEMM_LAUNCH_KERNEL(
-            (direct_mapped_lru_cache_find_uncached_kernel<index_t>),
+        direct_mapped_lru_cache_find_uncached_kernel<<<
             std::min(
                 div_round_up(N, kMaxThreads),
                 get_max_thread_blocks_for_cache_kernels_()),
             kMaxThreads,
             0,
-            at::cuda::getCurrentCUDAStream(),
-            PTA_B(linear_cache_indices, index_t, 1, 32),
-            PTA_B(cache_sets, int32_t, 1, 32),
+            at::cuda::getCurrentCUDAStream()>>>(
+            MAKE_PTA_WITH_NAME(func_name, linear_cache_indices, index_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, cache_sets, int32_t, 1, 32),
             max_indices,
-            PTA_B(lxu_cache_state, int64_t, 2, 32),
+            MAKE_PTA_WITH_NAME(func_name, lxu_cache_state, int64_t, 2, 32),
             time_stamp,
-            PTA_B(lru_state, int64_t, 2, 32),
+            MAKE_PTA_WITH_NAME(func_name, lru_state, int64_t, 2, 32),
             gather_cache_stats,
-            PTA_B(uvm_cache_stats, int32_t, 1, 32),
-            PTA_B(lxu_cache_miss_timestamp, int64_t, 2, 32));
+            MAKE_PTA_WITH_NAME(func_name, uvm_cache_stats, int32_t, 1, 32),
+            MAKE_PTA_WITH_NAME(
+                func_name, lxu_cache_miss_timestamp, int64_t, 2, 32));
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
       });
 
   return cache_sets;
@@ -168,7 +172,7 @@ __global__ __launch_bounds__(kMaxThreads) void lru_cache_insert_byte_kernel(
     const int64_t row_alignment) {
   const int32_t C = lxu_cache_state.size(0);
   int64_t n_conflict_misses = 0;
-  for (auto n = blockIdx.x * blockDim.y + threadIdx.y; n < *N_unique;
+  for (int32_t n = blockIdx.x * blockDim.y + threadIdx.y; n < *N_unique;
        n += gridDim.x * blockDim.y) {
     // check if this warp is responsible for this whole segment.
     const bool segment_start =
@@ -193,16 +197,16 @@ __global__ __launch_bounds__(kMaxThreads) void lru_cache_insert_byte_kernel(
 
     // now, we need to insert the (unique!) values in indices[n:n + SL] into
     // our slots.
-    const auto slot = threadIdx.x;
+    const int32_t slot = threadIdx.x;
     const int64_t slot_time = lru_state[cache_set][slot];
     int64_t costs[1] = {slot_time};
-    uint32_t slots[1] = {slot};
+    int32_t slots[1] = {slot};
 
-    BitonicSort<int64_t, uint32_t, 1, Comparator<int64_t>>::sort(costs, slots);
-    const auto sorted_slot = slots[0];
-    const auto sorted_lru_cost = costs[0];
+    BitonicSort<int64_t, int32_t, 1, Comparator<int64_t>>::sort(costs, slots);
+    const int32_t sorted_slot = slots[0];
+    const int64_t sorted_lru_cost = costs[0];
 
-    for (auto l = 0; l < min(SL, kWarpSize); ++l) {
+    for (int32_t l = 0; l < min(SL, kWarpSize); ++l) {
       const int32_t insert_slot = shfl_sync(sorted_slot, l);
       const int64_t insert_current_lru_cost = shfl_sync(sorted_lru_cost, l);
       if (insert_current_lru_cost == time_stamp) {
@@ -228,7 +232,7 @@ __global__ __launch_bounds__(kMaxThreads) void lru_cache_insert_byte_kernel(
           &weights[weights_offset_insert + idx_insert * D_insert_bytes + 0]);
       auto cache_row = reinterpret_cast<uint4*>(
           &lxu_cache_weights[cache_set * kWarpSize + insert_slot][0]);
-      for (auto d = threadIdx.x; d * sizeof(uint4) < D_insert_bytes;
+      for (int32_t d = threadIdx.x; d * sizeof(uint4) < D_insert_bytes;
            d += blockDim.x) {
         cache_row[d] = row[d];
       }
@@ -281,7 +285,7 @@ __launch_bounds__(kMaxThreads) void direct_mapped_lru_cache_insert_byte_kernel(
 
   // one warp for each set (multiple times)
   // (no divergence for each control branch)
-  for (auto pos = blockIdx.x * blockDim.y + threadIdx.y; pos < N;
+  for (int32_t pos = blockIdx.x * blockDim.y + threadIdx.y; pos < N;
        pos += gridDim.x * blockDim.y) {
     auto cache_set = cache_sets[pos];
 
@@ -342,7 +346,7 @@ __launch_bounds__(kMaxThreads) void direct_mapped_lru_cache_insert_byte_kernel(
     auto row = reinterpret_cast<const uint4*>(
         &weights[weights_offset_insert + idx_insert * D_insert_bytes + 0]);
     auto cache_row = reinterpret_cast<uint4*>(&lxu_cache_weights[cache_set][0]);
-    for (auto d = threadIdx.x; d * sizeof(uint4) < D_insert_bytes;
+    for (int32_t d = threadIdx.x; d * sizeof(uint4) < D_insert_bytes;
          d += blockDim.x) {
       cache_row[d] = row[d];
     }
@@ -394,30 +398,36 @@ void lru_cache_insert_byte_cuda(
       cache_set_sorted_unique_indices.scalar_type(),
       "lru_cache_insert_byte_cuda",
       [&] {
-        FBGEMM_LAUNCH_KERNEL(
-            (lru_cache_insert_byte_kernel<index_t>),
+#ifdef FBGEMM_GPU_MEMCHECK
+        const char* func_name = "lru_cache_insert_byte_kernel";
+#endif
+        lru_cache_insert_byte_kernel<<<
             std::min(
                 div_round_up(N, kMaxThreads / kWarpSize),
                 get_max_thread_blocks_for_cache_kernels_()),
             dim3(kWarpSize, kMaxThreads / kWarpSize),
             0,
-            at::cuda::getCurrentCUDAStream(),
-            PTA_B(weights, uint8_t, 1, 64),
-            PTA_B(cache_hash_size_cumsum, int64_t, 1, 32),
-            PTA_B(cache_index_table_map, int32_t, 1, 64),
-            PTA_B(weights_offsets, int64_t, 1, 32),
-            PTA_B(weights_tys, uint8_t, 1, 32),
-            PTA_B(D_offsets, int32_t, 1, 32),
-            PTA_B(sorted_cache_sets, int32_t, 1, 32),
-            PTA_B(cache_set_sorted_unique_indices, index_t, 1, 32),
+            at::cuda::getCurrentCUDAStream()>>>(
+            MAKE_PTA_WITH_NAME(func_name, weights, uint8_t, 1, 64),
+            MAKE_PTA_WITH_NAME(
+                func_name, cache_hash_size_cumsum, int64_t, 1, 32),
+            MAKE_PTA_WITH_NAME(
+                func_name, cache_index_table_map, int32_t, 1, 64),
+            MAKE_PTA_WITH_NAME(func_name, weights_offsets, int64_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, weights_tys, uint8_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, D_offsets, int32_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, sorted_cache_sets, int32_t, 1, 32),
+            MAKE_PTA_WITH_NAME(
+                func_name, cache_set_sorted_unique_indices, index_t, 1, 32),
             unique_indices_length.data_ptr<int32_t>(),
-            PTA_B(lxu_cache_state, int64_t, 2, 32),
-            PTA_B(lxu_cache_weights, uint8_t, 2, 64),
+            MAKE_PTA_WITH_NAME(func_name, lxu_cache_state, int64_t, 2, 32),
+            MAKE_PTA_WITH_NAME(func_name, lxu_cache_weights, uint8_t, 2, 64),
             time_stamp,
-            PTA_B(lru_state, int64_t, 2, 32),
+            MAKE_PTA_WITH_NAME(func_name, lru_state, int64_t, 2, 32),
             gather_cache_stats,
-            PTA_B(uvm_cache_stats, int32_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, uvm_cache_stats, int32_t, 1, 32),
             row_alignment);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
       });
 }
 
@@ -459,30 +469,36 @@ void direct_mapped_lru_cache_insert_byte_cuda(
       linear_cache_indices.scalar_type(),
       "direct_mapped_lru_cache_insert_byte_cuda",
       [&] {
-        FBGEMM_LAUNCH_KERNEL(
-            (direct_mapped_lru_cache_insert_byte_kernel<index_t>),
+#ifdef FBGEMM_GPU_MEMCHECK
+        const char* func_name = "direct_mapped_lru_cache_insert_byte_kernel";
+#endif
+        direct_mapped_lru_cache_insert_byte_kernel<<<
             std::min(
                 div_round_up(N, kMaxThreads / kWarpSize),
                 get_max_thread_blocks_for_cache_kernels_()),
             dim3(kWarpSize, kMaxThreads / kWarpSize),
             0,
-            at::cuda::getCurrentCUDAStream(),
-            PTA_B(weights, uint8_t, 1, 64),
-            PTA_B(cache_hash_size_cumsum, int64_t, 1, 32),
-            PTA_B(cache_index_table_map, int32_t, 1, 64),
-            PTA_B(weights_offsets, int64_t, 1, 32),
-            PTA_B(weights_tys, uint8_t, 1, 32),
-            PTA_B(D_offsets, int32_t, 1, 32),
-            PTA_B(lxu_cache_state, int64_t, 2, 32),
-            PTA_B(lxu_cache_weights, uint8_t, 2, 64),
+            at::cuda::getCurrentCUDAStream()>>>(
+            MAKE_PTA_WITH_NAME(func_name, weights, uint8_t, 1, 64),
+            MAKE_PTA_WITH_NAME(
+                func_name, cache_hash_size_cumsum, int64_t, 1, 32),
+            MAKE_PTA_WITH_NAME(
+                func_name, cache_index_table_map, int32_t, 1, 64),
+            MAKE_PTA_WITH_NAME(func_name, weights_offsets, int64_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, weights_tys, uint8_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, D_offsets, int32_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, lxu_cache_state, int64_t, 2, 32),
+            MAKE_PTA_WITH_NAME(func_name, lxu_cache_weights, uint8_t, 2, 64),
             time_stamp,
-            PTA_B(lru_state, int64_t, 2, 32),
-            PTA_B(linear_cache_indices, index_t, 1, 32),
-            PTA_B(lxu_cache_miss_timestamp, int64_t, 2, 32),
-            PTA_B(cache_sets, int32_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, lru_state, int64_t, 2, 32),
+            MAKE_PTA_WITH_NAME(func_name, linear_cache_indices, index_t, 1, 32),
+            MAKE_PTA_WITH_NAME(
+                func_name, lxu_cache_miss_timestamp, int64_t, 2, 32),
+            MAKE_PTA_WITH_NAME(func_name, cache_sets, int32_t, 1, 32),
             gather_cache_stats,
-            PTA_B(uvm_cache_stats, int32_t, 1, 32),
+            MAKE_PTA_WITH_NAME(func_name, uvm_cache_stats, int32_t, 1, 32),
             row_alignment);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
       });
 }
 

--- a/fbgemm_gpu/src/split_embeddings_cache/reset_weight_momentum.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/reset_weight_momentum.cu
@@ -283,27 +283,39 @@ DLL_PUBLIC void reset_weight_momentum_cuda(
       lxu_cache_weights.scalar_type(),
       "reset_weight_momentum_kernel",
       ([&] {
-        FBGEMM_LAUNCH_KERNEL(
-            (reset_weight_momentum_kernel<emb_t, cache_t>),
-            num_pruned_tables * blocks_per_table,
-            kMaxThreads,
-            0,
-            at::cuda::getCurrentCUDAStream(),
-            blocks_per_table,
-            PTA_B(dev_weights, emb_t, 1, 64),
-            PTA_B(uvm_weights, emb_t, 1, 64),
-            PTA_B(lxu_cache_weights, cache_t, 2, 64),
-            PTA_B(weights_placements, int32_t, 1, 32),
-            PTA_B(weights_offsets, int64_t, 1, 32),
-            PTA_ACC_B(momentum1_dev, cache_t, 1, 64),
-            PTA_ACC_B(momentum1_uvm, cache_t, 1, 64),
-            PTA_B(momentum1_placements, int32_t, 1, 32),
-            PTA_B(momentum1_offsets, int64_t, 1, 32),
-            PTA_B(D_offsets, int32_t, 1, 32),
-            PTA_B(pruned_indices, int64_t, 1, 32),
-            PTA_B(pruned_indices_offsets, int64_t, 1, 32),
-            PTA_B(logical_table_ids, int32_t, 1, 32),
-            PTA_B(buffer_ids, int32_t, 1, 32),
-            PTA_B(lxu_cache_locations, int32_t, 1, 32));
+#ifdef FBGEMM_GPU_MEMCHECK
+        const char* func_name2 = "get_cache_indices_kernel";
+#endif
+        reset_weight_momentum_kernel<emb_t, cache_t>
+            <<<num_pruned_tables * blocks_per_table,
+               kMaxThreads,
+               0,
+               at::cuda::getCurrentCUDAStream()>>>(
+                blocks_per_table,
+                MAKE_PTA_WITH_NAME(func_name2, dev_weights, emb_t, 1, 64),
+                MAKE_PTA_WITH_NAME(func_name2, uvm_weights, emb_t, 1, 64),
+                MAKE_PTA_WITH_NAME(
+                    func_name2, lxu_cache_weights, cache_t, 2, 64),
+                MAKE_PTA_WITH_NAME(
+                    func_name2, weights_placements, int32_t, 1, 32),
+                MAKE_PTA_WITH_NAME(func_name2, weights_offsets, int64_t, 1, 32),
+                MAKE_PTA_ACC_WITH_NAME(
+                    func_name2, momentum1_dev, cache_t, 1, 64),
+                MAKE_PTA_ACC_WITH_NAME(
+                    func_name2, momentum1_uvm, cache_t, 1, 64),
+                MAKE_PTA_WITH_NAME(
+                    func_name2, momentum1_placements, int32_t, 1, 32),
+                MAKE_PTA_WITH_NAME(
+                    func_name2, momentum1_offsets, int64_t, 1, 32),
+                MAKE_PTA_WITH_NAME(func_name2, D_offsets, int32_t, 1, 32),
+                MAKE_PTA_WITH_NAME(func_name2, pruned_indices, int64_t, 1, 32),
+                MAKE_PTA_WITH_NAME(
+                    func_name2, pruned_indices_offsets, int64_t, 1, 32),
+                MAKE_PTA_WITH_NAME(
+                    func_name2, logical_table_ids, int32_t, 1, 32),
+                MAKE_PTA_WITH_NAME(func_name2, buffer_ids, int32_t, 1, 32),
+                MAKE_PTA_WITH_NAME(
+                    func_name2, lxu_cache_locations, int32_t, 1, 32));
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
       }));
 }


### PR DESCRIPTION
Summary:
Backout diff: D74758371, it introduced performance regression for AMD training.

NOTE: Let's revert it for now and reland after a forward fix.

Reviewed By: yinbinm, xw285cornell, sryap

Differential Revision: D76043625


