### PR TITLE
Use local counter for TBE boundary check warinings to improve performance

### DIFF
--- a/fbgemm_gpu/test/tbe/utils/split_embeddings_utils_test.py
+++ b/fbgemm_gpu/test/tbe/utils/split_embeddings_utils_test.py
@@ -368,8 +368,6 @@ class SplitEmbeddingsUtilsTest(unittest.TestCase):
                 **vbe_args,
             )
             torch.testing.assert_close(indices, torch.zeros_like(indices))
-            if bounds_check_mode == BoundsCheckMode.WARNING:
-                self.assertEqual(warning.item(), indices.numel())
         else:
             if use_cpu and indices.numel():
                 with self.assertRaises(RuntimeError):
@@ -409,10 +407,6 @@ class SplitEmbeddingsUtilsTest(unittest.TestCase):
                 self.assertEqual(offsets[0].item(), 0)
             if offsets.numel() > 1:
                 self.assertEqual(offsets[-1].item(), indices.numel())
-            if bounds_check_mode == BoundsCheckMode.WARNING:
-                # -1 because when we have 2 elements in offsets, we have only 1
-                # warning for the pair.
-                self.assertGreaterEqual(warning.item(), min(2, offsets.numel() - 1))
         else:
             if use_cpu and indices.numel():
                 with self.assertRaises(RuntimeError):


### PR DESCRIPTION
Summary:
This change aims to improve the cost for TBE boundary check. As it is only used to print out warining information, we can relax it to local counter and only add it up to global at the end when error is detected.

As there's no caller taking the return value of warning other than the unit test, we can remove the global warning counter completely and use local counter to further improve performance.

Differential Revision: D76029492


