### PR TITLE
Make Cutlass FP8 Rowwise bias always FP32

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_common.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_common.cuh
@@ -37,8 +37,7 @@ template <
     bool COOP,
     bool FAST_ACCUM,
     bool USE_BIAS,
-    typename INPUT_DTYPE,
-    typename BIAS_DTYPE>
+    typename INPUT_DTYPE>
 at::Tensor f8f8bf16_rowwise_impl(
     at::Tensor XQ, // FP8
     at::Tensor WQ, // FP8
@@ -91,7 +90,7 @@ at::Tensor f8f8bf16_rowwise_impl(
   using LayoutB_Transpose =
       typename cutlass::layout::LayoutTranspose<LayoutB>::type;
 
-  using ElementBias = BIAS_DTYPE;
+  using ElementBias = float;
 
   using ElementOutput = cutlass::bfloat16_t;
   using LayoutOutput = cutlass::layout::RowMajor;
@@ -363,148 +362,74 @@ at::Tensor f8f8bf16_rowwise_wrapper(
       "Scale tensors must be float32.");
   if (bias.has_value()) {
     TORCH_CHECK(
-        bias.value().dtype() == at::kFloat ||
-            bias.value().dtype() == at::kBFloat16,
-        "Bias type must be bfloat16 or float32 if provided.");
+        bias.value().dtype() == at::kFloat,
+        "Bias type must be float32 if provided.");
   }
   bool use_bias = bias.has_value();
-  bool bf16_bias = use_bias && bias.value().dtype() == at::kBFloat16;
 
   // Templatize based on input dtype.
   bool use_e5m2 = XQ.dtype() == at::kFloat8_e5m2;
 
   if (use_bias) {
-    if (bf16_bias) {
-      if (use_fast_accum) {
-        if (use_e5m2) {
-          return f8f8bf16_rowwise_impl<
-              TB_M,
-              TB_N,
-              TB_K,
-              TBS_M,
-              TBS_N,
-              TBS_K,
-              ARCH,
-              PONG,
-              COOP,
-              true,
-              true,
-              cutlass::float_e5m2_t,
-              cutlass::bfloat16_t>(XQ, WQ, x_scale, w_scale, bias, output);
-        } else {
-          return f8f8bf16_rowwise_impl<
-              TB_M,
-              TB_N,
-              TB_K,
-              TBS_M,
-              TBS_N,
-              TBS_K,
-              ARCH,
-              PONG,
-              COOP,
-              true,
-              true,
-              cutlass::float_e4m3_t,
-              cutlass::bfloat16_t>(XQ, WQ, x_scale, w_scale, bias, output);
-        }
+    if (use_fast_accum) {
+      if (use_e5m2) {
+        return f8f8bf16_rowwise_impl<
+            TB_M,
+            TB_N,
+            TB_K,
+            TBS_M,
+            TBS_N,
+            TBS_K,
+            ARCH,
+            PONG,
+            COOP,
+            true,
+            true,
+            cutlass::float_e5m2_t>(XQ, WQ, x_scale, w_scale, bias, output);
       } else {
-        if (use_e5m2) {
-          return f8f8bf16_rowwise_impl<
-              TB_M,
-              TB_N,
-              TB_K,
-              TBS_M,
-              TBS_N,
-              TBS_K,
-              ARCH,
-              PONG,
-              COOP,
-              false,
-              true,
-              cutlass::float_e5m2_t,
-              cutlass::bfloat16_t>(XQ, WQ, x_scale, w_scale, bias, output);
-        } else {
-          return f8f8bf16_rowwise_impl<
-              TB_M,
-              TB_N,
-              TB_K,
-              TBS_M,
-              TBS_N,
-              TBS_K,
-              ARCH,
-              PONG,
-              COOP,
-              false,
-              true,
-              cutlass::float_e4m3_t,
-              cutlass::bfloat16_t>(XQ, WQ, x_scale, w_scale, bias, output);
-        }
+        return f8f8bf16_rowwise_impl<
+            TB_M,
+            TB_N,
+            TB_K,
+            TBS_M,
+            TBS_N,
+            TBS_K,
+            ARCH,
+            PONG,
+            COOP,
+            true,
+            true,
+            cutlass::float_e4m3_t>(XQ, WQ, x_scale, w_scale, bias, output);
       }
     } else {
-      if (use_fast_accum) {
-        if (use_e5m2) {
-          return f8f8bf16_rowwise_impl<
-              TB_M,
-              TB_N,
-              TB_K,
-              TBS_M,
-              TBS_N,
-              TBS_K,
-              ARCH,
-              PONG,
-              COOP,
-              true,
-              true,
-              cutlass::float_e5m2_t,
-              float>(XQ, WQ, x_scale, w_scale, bias, output);
-        } else {
-          return f8f8bf16_rowwise_impl<
-              TB_M,
-              TB_N,
-              TB_K,
-              TBS_M,
-              TBS_N,
-              TBS_K,
-              ARCH,
-              PONG,
-              COOP,
-              true,
-              true,
-              cutlass::float_e4m3_t,
-              float>(XQ, WQ, x_scale, w_scale, bias, output);
-        }
+      if (use_e5m2) {
+        return f8f8bf16_rowwise_impl<
+            TB_M,
+            TB_N,
+            TB_K,
+            TBS_M,
+            TBS_N,
+            TBS_K,
+            ARCH,
+            PONG,
+            COOP,
+            false,
+            true,
+            cutlass::float_e5m2_t>(XQ, WQ, x_scale, w_scale, bias, output);
       } else {
-        if (use_e5m2) {
-          return f8f8bf16_rowwise_impl<
-              TB_M,
-              TB_N,
-              TB_K,
-              TBS_M,
-              TBS_N,
-              TBS_K,
-              ARCH,
-              PONG,
-              COOP,
-              false,
-              true,
-              cutlass::float_e5m2_t,
-              float>(XQ, WQ, x_scale, w_scale, bias, output);
-        } else {
-          return f8f8bf16_rowwise_impl<
-              TB_M,
-              TB_N,
-              TB_K,
-              TBS_M,
-              TBS_N,
-              TBS_K,
-              ARCH,
-              PONG,
-              COOP,
-              false,
-              true,
-              cutlass::float_e4m3_t,
-              float>(XQ, WQ, x_scale, w_scale, bias, output);
-        }
+        return f8f8bf16_rowwise_impl<
+            TB_M,
+            TB_N,
+            TB_K,
+            TBS_M,
+            TBS_N,
+            TBS_K,
+            ARCH,
+            PONG,
+            COOP,
+            false,
+            true,
+            cutlass::float_e4m3_t>(XQ, WQ, x_scale, w_scale, bias, output);
       }
     }
   } else {
@@ -522,8 +447,7 @@ at::Tensor f8f8bf16_rowwise_wrapper(
             COOP,
             true,
             false,
-            cutlass::float_e5m2_t,
-            float>(XQ, WQ, x_scale, w_scale, bias, output);
+            cutlass::float_e5m2_t>(XQ, WQ, x_scale, w_scale, bias, output);
       } else {
         return f8f8bf16_rowwise_impl<
             TB_M,
@@ -537,8 +461,7 @@ at::Tensor f8f8bf16_rowwise_wrapper(
             COOP,
             true,
             false,
-            cutlass::float_e4m3_t,
-            float>(XQ, WQ, x_scale, w_scale, bias, output);
+            cutlass::float_e4m3_t>(XQ, WQ, x_scale, w_scale, bias, output);
       }
     } else {
       if (use_e5m2) {
@@ -554,8 +477,7 @@ at::Tensor f8f8bf16_rowwise_wrapper(
             COOP,
             false,
             false,
-            cutlass::float_e5m2_t,
-            float>(XQ, WQ, x_scale, w_scale, bias, output);
+            cutlass::float_e5m2_t>(XQ, WQ, x_scale, w_scale, bias, output);
       } else {
         return f8f8bf16_rowwise_impl<
             TB_M,
@@ -569,8 +491,7 @@ at::Tensor f8f8bf16_rowwise_wrapper(
             COOP,
             false,
             false,
-            cutlass::float_e4m3_t,
-            float>(XQ, WQ, x_scale, w_scale, bias, output);
+            cutlass::float_e4m3_t>(XQ, WQ, x_scale, w_scale, bias, output);
       }
     }
   }

--- a/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
@@ -270,7 +270,7 @@ class FP8Tests(unittest.TestCase):
             x = torch.randn(size=(B_T, D), dtype=torch.bfloat16, device="cuda") * 0.1
         w = torch.randn(size=(HD_L, D), dtype=torch.bfloat16, device="cuda") * 0.01
         bias = (
-            torch.randn(size=(HD_L,), dtype=torch.bfloat16, device="cuda")
+            torch.randn(size=(HD_L,), dtype=torch.float32, device="cuda")
             if Bias
             else None
         )


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1390

The problem we are running into is that adding more kernel configurations (MNK tile shapes & cluster shapes) causes a huge blow up in binary size. For each configuration of Cutlass FP8 rowwise we will compile 12 kernels, as we further template on (FAST_ACCUM, USE_BIAS, INPUT_DTYPE, BIAS_DTYPE). 

What we can do is just make bias always fp32, and use-cases could upcast bf16 to fp32 as required. The reason to keep fp32 is this gives us more flexibility around accuracy.

Currently there seems to be pretty limited use-cases for bias in fbgemm, but there is a new ads usecases looking to leverage the fp32 bias soon.

Differential Revision: D76342974


