### PR TITLE
Revert D76342974: Multisect successfully blamed "D76342974: [FBGEMM] Make Cutlass FP8 Rowwise bias always FP32" for one test failure

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_common.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise/f8f8bf16_rowwise_common.cuh
@@ -37,7 +37,8 @@ template <
     bool COOP,
     bool FAST_ACCUM,
     bool USE_BIAS,
-    typename INPUT_DTYPE>
+    typename INPUT_DTYPE,
+    typename BIAS_DTYPE>
 at::Tensor f8f8bf16_rowwise_impl(
     at::Tensor XQ, // FP8
     at::Tensor WQ, // FP8
@@ -90,7 +91,7 @@ at::Tensor f8f8bf16_rowwise_impl(
   using LayoutB_Transpose =
       typename cutlass::layout::LayoutTranspose<LayoutB>::type;
 
-  using ElementBias = float;
+  using ElementBias = BIAS_DTYPE;
 
   using ElementOutput = cutlass::bfloat16_t;
   using LayoutOutput = cutlass::layout::RowMajor;
@@ -362,74 +363,148 @@ at::Tensor f8f8bf16_rowwise_wrapper(
       "Scale tensors must be float32.");
   if (bias.has_value()) {
     TORCH_CHECK(
-        bias.value().dtype() == at::kFloat,
-        "Bias type must be float32 if provided.");
+        bias.value().dtype() == at::kFloat ||
+            bias.value().dtype() == at::kBFloat16,
+        "Bias type must be bfloat16 or float32 if provided.");
   }
   bool use_bias = bias.has_value();
+  bool bf16_bias = use_bias && bias.value().dtype() == at::kBFloat16;
 
   // Templatize based on input dtype.
   bool use_e5m2 = XQ.dtype() == at::kFloat8_e5m2;
 
   if (use_bias) {
-    if (use_fast_accum) {
-      if (use_e5m2) {
-        return f8f8bf16_rowwise_impl<
-            TB_M,
-            TB_N,
-            TB_K,
-            TBS_M,
-            TBS_N,
-            TBS_K,
-            ARCH,
-            PONG,
-            COOP,
-            true,
-            true,
-            cutlass::float_e5m2_t>(XQ, WQ, x_scale, w_scale, bias, output);
+    if (bf16_bias) {
+      if (use_fast_accum) {
+        if (use_e5m2) {
+          return f8f8bf16_rowwise_impl<
+              TB_M,
+              TB_N,
+              TB_K,
+              TBS_M,
+              TBS_N,
+              TBS_K,
+              ARCH,
+              PONG,
+              COOP,
+              true,
+              true,
+              cutlass::float_e5m2_t,
+              cutlass::bfloat16_t>(XQ, WQ, x_scale, w_scale, bias, output);
+        } else {
+          return f8f8bf16_rowwise_impl<
+              TB_M,
+              TB_N,
+              TB_K,
+              TBS_M,
+              TBS_N,
+              TBS_K,
+              ARCH,
+              PONG,
+              COOP,
+              true,
+              true,
+              cutlass::float_e4m3_t,
+              cutlass::bfloat16_t>(XQ, WQ, x_scale, w_scale, bias, output);
+        }
       } else {
-        return f8f8bf16_rowwise_impl<
-            TB_M,
-            TB_N,
-            TB_K,
-            TBS_M,
-            TBS_N,
-            TBS_K,
-            ARCH,
-            PONG,
-            COOP,
-            true,
-            true,
-            cutlass::float_e4m3_t>(XQ, WQ, x_scale, w_scale, bias, output);
+        if (use_e5m2) {
+          return f8f8bf16_rowwise_impl<
+              TB_M,
+              TB_N,
+              TB_K,
+              TBS_M,
+              TBS_N,
+              TBS_K,
+              ARCH,
+              PONG,
+              COOP,
+              false,
+              true,
+              cutlass::float_e5m2_t,
+              cutlass::bfloat16_t>(XQ, WQ, x_scale, w_scale, bias, output);
+        } else {
+          return f8f8bf16_rowwise_impl<
+              TB_M,
+              TB_N,
+              TB_K,
+              TBS_M,
+              TBS_N,
+              TBS_K,
+              ARCH,
+              PONG,
+              COOP,
+              false,
+              true,
+              cutlass::float_e4m3_t,
+              cutlass::bfloat16_t>(XQ, WQ, x_scale, w_scale, bias, output);
+        }
       }
     } else {
-      if (use_e5m2) {
-        return f8f8bf16_rowwise_impl<
-            TB_M,
-            TB_N,
-            TB_K,
-            TBS_M,
-            TBS_N,
-            TBS_K,
-            ARCH,
-            PONG,
-            COOP,
-            false,
-            true,
-            cutlass::float_e5m2_t>(XQ, WQ, x_scale, w_scale, bias, output);
+      if (use_fast_accum) {
+        if (use_e5m2) {
+          return f8f8bf16_rowwise_impl<
+              TB_M,
+              TB_N,
+              TB_K,
+              TBS_M,
+              TBS_N,
+              TBS_K,
+              ARCH,
+              PONG,
+              COOP,
+              true,
+              true,
+              cutlass::float_e5m2_t,
+              float>(XQ, WQ, x_scale, w_scale, bias, output);
+        } else {
+          return f8f8bf16_rowwise_impl<
+              TB_M,
+              TB_N,
+              TB_K,
+              TBS_M,
+              TBS_N,
+              TBS_K,
+              ARCH,
+              PONG,
+              COOP,
+              true,
+              true,
+              cutlass::float_e4m3_t,
+              float>(XQ, WQ, x_scale, w_scale, bias, output);
+        }
       } else {
-        return f8f8bf16_rowwise_impl<
-            TB_M,
-            TB_N,
-            TB_K,
-            TBS_M,
-            TBS_N,
-            TBS_K,
-            ARCH,
-            PONG,
-            COOP,
-            false,
-            true,
-            cutlass::float_e4m3_t>(XQ, WQ, x_scale, w_scale, bias, output);
+        if (use_e5m2) {
+          return f8f8bf16_rowwise_impl<
+              TB_M,
+              TB_N,
+              TB_K,
+              TBS_M,
+              TBS_N,
+              TBS_K,
+              ARCH,
+              PONG,
+              COOP,
+              false,
+              true,
+              cutlass::float_e5m2_t,
+              float>(XQ, WQ, x_scale, w_scale, bias, output);
+        } else {
+          return f8f8bf16_rowwise_impl<
+              TB_M,
+              TB_N,
+              TB_K,
+              TBS_M,
+              TBS_N,
+              TBS_K,
+              ARCH,
+              PONG,
+              COOP,
+              false,
+              true,
+              cutlass::float_e4m3_t,
+              float>(XQ, WQ, x_scale, w_scale, bias, output);
+        }
       }
     }
   } else {
@@ -447,7 +522,8 @@ at::Tensor f8f8bf16_rowwise_wrapper(
             COOP,
             true,
             false,
-            cutlass::float_e5m2_t>(XQ, WQ, x_scale, w_scale, bias, output);
+            cutlass::float_e5m2_t,
+            float>(XQ, WQ, x_scale, w_scale, bias, output);
       } else {
         return f8f8bf16_rowwise_impl<
             TB_M,
@@ -461,7 +537,8 @@ at::Tensor f8f8bf16_rowwise_wrapper(
             COOP,
             true,
             false,
-            cutlass::float_e4m3_t>(XQ, WQ, x_scale, w_scale, bias, output);
+            cutlass::float_e4m3_t,
+            float>(XQ, WQ, x_scale, w_scale, bias, output);
       }
     } else {
       if (use_e5m2) {
@@ -477,7 +554,8 @@ at::Tensor f8f8bf16_rowwise_wrapper(
             COOP,
             false,
             false,
-            cutlass::float_e5m2_t>(XQ, WQ, x_scale, w_scale, bias, output);
+            cutlass::float_e5m2_t,
+            float>(XQ, WQ, x_scale, w_scale, bias, output);
       } else {
         return f8f8bf16_rowwise_impl<
             TB_M,
@@ -491,7 +569,8 @@ at::Tensor f8f8bf16_rowwise_wrapper(
             COOP,
             false,
             false,
-            cutlass::float_e4m3_t>(XQ, WQ, x_scale, w_scale, bias, output);
+            cutlass::float_e4m3_t,
+            float>(XQ, WQ, x_scale, w_scale, bias, output);
       }
     }
   }

--- a/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
@@ -270,7 +270,7 @@ class FP8Tests(unittest.TestCase):
             x = torch.randn(size=(B_T, D), dtype=torch.bfloat16, device="cuda") * 0.1
         w = torch.randn(size=(HD_L, D), dtype=torch.bfloat16, device="cuda") * 0.01
         bias = (
-            torch.randn(size=(HD_L,), dtype=torch.float32, device="cuda")
+            torch.randn(size=(HD_L,), dtype=torch.bfloat16, device="cuda")
             if Bias
             else None
         )


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1394

This diff reverts D76342974
D76342974: [FBGEMM] Make Cutlass FP8 Rowwise bias always FP32 by cthi causes the following test failure:

Tests affected:
- [cogwheel:cogwheel_ip_emu_animate_e2e#main](https://www.internalfb.com/intern/test/562950127744806/)

Here's the Multisect link:
https://www.internalfb.com/multisect/29413137
Here are the tasks that are relevant to this breakage:
T191383874: 10+ CI signals, 10+ tests, 10+ build rules unhealthy for genai_media_editing

The backout may land if someone accepts it.

If this diff has been generated in error, you can Commandeer and Abandon it.

Depends on D76342974

Reviewed By: cthi

Differential Revision: D76435345
