### PR TITLE
fix output dtype issue in merge_pooled_embeddings when input tensors are all empty

### DIFF
--- a/fbgemm_gpu/src/merge_pooled_embedding_ops/merge_pooled_embedding_ops_cpu.cpp
+++ b/fbgemm_gpu/src/merge_pooled_embedding_ops/merge_pooled_embedding_ops_cpu.cpp
@@ -29,7 +29,7 @@ Tensor merge_pooled_embeddings_cpu(
       n += t.numel();
     }
     Tensor r;
-    if (n == 0) {
+    if (ts.empty()) {
       r = at::empty({n});
     } else {
       r = at::empty({n}, ts[0].options());

--- a/fbgemm_gpu/src/merge_pooled_embedding_ops/merge_pooled_embedding_ops_gpu.cpp
+++ b/fbgemm_gpu/src/merge_pooled_embedding_ops/merge_pooled_embedding_ops_gpu.cpp
@@ -596,8 +596,12 @@ Tensor cat_dim_2d(
       cat_dim_2d_output_shape(tensors, uncat_dim_size, cat_dim);
 
   auto* prop = at::cuda::getCurrentDeviceProperties();
-  auto output =
-      at::empty(output_shape, tensors.front().options().device(output_device));
+  auto output = at::empty(
+      output_shape,
+      tensors.front()
+          .options()
+          .device(output_device)
+          .dtype(tensors[0].dtype()));
   TORCH_CHECK(
       output.stride(0) * output.element_size() <=
       static_cast<int64_t>(prop->memPitch));

--- a/fbgemm_gpu/test/merge_pooled_embeddings_test.py
+++ b/fbgemm_gpu/test/merge_pooled_embeddings_test.py
@@ -266,6 +266,34 @@ class MergePooledEmbeddingsTest(unittest.TestCase):
 
         assert output_meta.shape == output_cpu.shape
 
+    def test_merge_pooled_embeddings_empty_input_tensors(self) -> None:
+        uncat_size = 2
+        pooled_embeddings = [
+            torch.ones(uncat_size, 0, dtype=torch.int32),
+            torch.ones(uncat_size, 0, dtype=torch.int32),
+        ]
+        output = torch.ops.fbgemm.merge_pooled_embeddings(
+            pooled_embeddings,
+            uncat_size,
+            torch.device("cpu"),
+            1,
+        )
+        self.assertEqual(output.numel(), 0)
+        self.assertEqual(output.dtype, torch.int32)
+
+        pooled_embeddings = [
+            torch.ones(uncat_size, 0, dtype=torch.int32).cuda(),
+            torch.ones(uncat_size, 0, dtype=torch.int32).cuda(),
+        ]
+        output = torch.ops.fbgemm.merge_pooled_embeddings(
+            pooled_embeddings,
+            uncat_size,
+            torch.device("cuda"),
+            1,
+        )
+        self.assertEqual(output.numel(), 0)
+        self.assertEqual(output.dtype, torch.int32)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1398

When input tensors are all empty we have a fast path in merge_pooled_embeddings to return an empty tensor. However, we didn't specify the dtype for the empty tensor so it would always be torch.float32. We should make it have the same dtype as the srcs.

Reviewed By: sayitmemory

Differential Revision: D76451161
