### PR TITLE
Replace references to folly::hash::fnv(32|64) with the _BROKEN alias

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/kv_db_cpp_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache/kv_db_cpp_utils.h
@@ -33,7 +33,7 @@ constexpr size_t num_ssd_drives = 8;
 ///
 /// @return shard id ranges from [0, num_shards)
 inline size_t hash_shard(int64_t id, size_t num_shards) {
-  auto hash = folly::hash::fnv64_buf(
+  auto hash = folly::hash::fnv64_buf_BROKEN(
       reinterpret_cast<const char*>(&id), sizeof(int64_t));
   __uint128_t wide = __uint128_t{num_shards} * hash;
   return static_cast<size_t>(wide >> 64);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1403

The implementation in upstream folly is broken, and we're making the bare name be the fixed version. Since a good number of references to this function persist the resulting hash, we need to keep existing references producing the same result.

Reviewed By: dtolnay

Differential Revision: D73147593
