### PR TITLE
comment out benchmark UT

### DIFF
--- a/fbgemm_gpu/test/dram_kv_embedding_cache/fixed_block_pool_test.cpp
+++ b/fbgemm_gpu/test/dram_kv_embedding_cache/fixed_block_pool_test.cpp
@@ -102,10 +102,12 @@ double benchmark_memory_allocators() {
 }
 
 // Basic functionality test: Integer keys
-TEST(FixedBlockPoolTest, benchmark_memory_allocators) {
-  auto min_speed_up = benchmark_memory_allocators();
-  EXPECT_GT(min_speed_up, 1.0);
-}
+// comment out on purpose to skip CI and diff landing test
+// uncomment it for local benchmarking
+// TEST(FixedBlockPoolTest, benchmark_memory_allocators) {
+//   auto min_speed_up = benchmark_memory_allocators();
+//   EXPECT_GT(min_speed_up, 1.0);
+// }
 
 // Test constructor normal case
 TEST(FixedBlockPoolTest, ConstructorNormal) {

--- a/fbgemm_gpu/test/dram_kv_embedding_cache/sharded_map_test.cpp
+++ b/fbgemm_gpu/test/dram_kv_embedding_cache/sharded_map_test.cpp
@@ -216,26 +216,13 @@ int benchmark() {
   for (int dim : dimensions) {
     memPoolEmbeddingMemSize(dim, numInserts);
   }
-
-  EXPECT_EQ(results_by_dim_with_ts.size(), results_by_dim_wo_ts.size());
-  for (std::size_t i = 0; i < results_by_dim_with_ts.size(); i++) {
-    double perf_insert_ratio =
-        results_by_dim_with_ts[i][0] / results_by_dim_wo_ts[i][0];
-    double perf_lookup_ratio =
-        results_by_dim_with_ts[i][1] / results_by_dim_wo_ts[i][1];
-
-    EXPECT_GE(perf_insert_ratio, 0.5);
-    EXPECT_LE(perf_insert_ratio, 1.5);
-    EXPECT_GE(perf_lookup_ratio, 0.5);
-    EXPECT_LE(perf_lookup_ratio, 1.5);
-
-    EXPECT_EQ(results_by_dim_with_ts[i][2], results_by_dim_wo_ts[i][2]);
-    EXPECT_EQ(results_by_dim_with_ts[i][2], 1);
-  }
   return 0;
 }
-TEST(SynchronizedShardedMap, benchmark) {
-  benchmark();
-}
+
+// comment out on purpose to skip CI and diff landing test
+// uncomment it for local benchmarking
+// TEST(SynchronizedShardedMap, benchmark) {
+//   benchmark();
+// }
 
 } // namespace kv_mem


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1407

the benchmark UT is unreliable on CI and diff landing, comment this out and we can run it only for local benchmarking

Differential Revision: D76555572
