### PR TITLE
Making create_rocksdb_hard_link_snapshot function a no_op

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -2804,7 +2804,12 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         """
         Create a rocksdb hard link snapshot to provide cross procs access to the underlying data
         """
-        self.ssd_db.create_rocksdb_hard_link_snapshot(self.step)
+        if self.backend_type == BackendType.SSD:
+            self.ssd_db.create_rocksdb_hard_link_snapshot(self.step)
+        else:
+            logging.warning(
+                "create_rocksdb_hard_link_snapshot is only supported for SSD backend"
+            )
 
     def prepare_inputs(
         self,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1409

Context:
We currently only support rocksDB checkpoint creation for SSD backed KVTensors. Due to this, we are making the create_rocksdb_hard_link_snapshot function a no_op for kvtensors that are not backed by SSD

Differential Revision: D76548520
