### PR TITLE
Add tensor checks in FP8 batched GEMM

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_common.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_common.cuh
@@ -51,6 +51,19 @@ at::Tensor f8f8bf16_rowwise_batched_impl(
   N = WQ.size(1);
   K = WQ.size(2);
 
+  auto out_sizes = XQ.sizes().vec();
+  out_sizes.back() = N;
+  // Handle case where there is a zero dimension, we simply return an empty
+  // tensor.
+  if (M == 0 || N == 0 || K == 0) {
+    // Use zeros instead of empty for special case where K=0.
+    return at::zeros(out_sizes, XQ.options().dtype(at::kBFloat16));
+  }
+
+  TORCH_CHECK(XQ.size(-1) == K);
+  TORCH_CHECK(XQ.is_cuda() && XQ.is_contiguous());
+  TORCH_CHECK(WQ.is_cuda() && WQ.is_contiguous());
+
   at::Tensor Y;
   if (output.has_value()) {
     Y = output.value();


### PR DESCRIPTION
Summary: As title, to avoid any memory continuity or empty tensor issues

Reviewed By: jianyuh, q10

Differential Revision: D76627476
