### PR TITLE
[fbgemm_gpu] Add build support for CUDA 12.9

### DIFF
--- a/.github/scripts/fbgemm_gpu_build.bash
+++ b/.github/scripts/fbgemm_gpu_build.bash
@@ -129,7 +129,8 @@ __configure_fbgemm_gpu_build_nvcc () {
 
 __configure_fbgemm_gpu_cuda_home () {
   if  [[ "$BUILD_CUDA_VERSION" =~ ^12.6.*$ ]] ||
-      [[ "$BUILD_CUDA_VERSION" =~ ^12.8.*$ ]]; then
+      [[ "$BUILD_CUDA_VERSION" =~ ^12.8.*$ ]] ||
+      [[ "$BUILD_CUDA_VERSION" =~ ^12.9.*$ ]]; then
     # shellcheck disable=SC2155,SC2086
     local conda_prefix=$(conda run ${env_prefix} printenv CONDA_PREFIX)
     local new_cuda_home="${conda_prefix}/targets/${MACHINE_NAME_LC}-linux"

--- a/.github/scripts/fbgemm_gpu_test.bash
+++ b/.github/scripts/fbgemm_gpu_test.bash
@@ -500,10 +500,9 @@ test_fbgemm_gpu_setup_and_pip_install () {
 
   if [ "$variant_type" == "cuda" ] || [ "$variant_type" == "genai" ]; then
     local variant_versions=(
-      11.8.0
-      12.4.1
       12.6.3
-      12.8.0
+      12.8.1
+      12.9.1
     )
   elif [ "$variant_type" == "rocm" ]; then
     local variant_versions=(

--- a/.github/scripts/nova_dir.bash
+++ b/.github/scripts/nova_dir.bash
@@ -22,7 +22,8 @@ fi
 ## Overwrite existing ENV VAR in Nova
 if [[ "$CONDA_ENV" != "" ]]; then export CONDA_RUN="conda run --no-capture-output -p ${CONDA_ENV}" && echo "$CONDA_RUN"; fi
 
-if  [[ "$CU_VERSION" == "cu128" ]]; then
+if  [[ "$CU_VERSION" == "cu129" ]] ||
+    [[ "$CU_VERSION" == "cu128" ]]; then
     export TORCH_CUDA_ARCH_LIST="7.0;8.0;9.0a;10.0a;12.0a"
     echo "[NOVA] Set TORCH_CUDA_ARCH_LIST to: ${TORCH_CUDA_ARCH_LIST}"
 

--- a/.github/scripts/utils_cuda.bash
+++ b/.github/scripts/utils_cuda.bash
@@ -19,7 +19,8 @@ __set_cuda_symlinks_envvars () {
   local new_cuda_home="${conda_prefix}/targets/${MACHINE_NAME_LC}-linux"
 
   if  [[ "$BUILD_CUDA_VERSION" =~ ^12.6.*$ ]] ||
-      [[ "$BUILD_CUDA_VERSION" =~ ^12.8.*$ ]]; then
+      [[ "$BUILD_CUDA_VERSION" =~ ^12.8.*$ ]] ||
+      [[ "$BUILD_CUDA_VERSION" =~ ^12.9.*$ ]]; then
     # CUDA 12.6 installation has a very different package layout than previous
     # CUDA versions - notably, NVTX has been moved elsewhere, which causes
     # PyTorch CMake scripts to complain.
@@ -91,7 +92,8 @@ __set_nvcc_prepend_flags () {
   # unwanted hook
   print_exec ls -la "${conda_prefix}/etc/conda/activate.d"
   if  [[ "$BUILD_CUDA_VERSION" =~ ^12.6.*$ ]] ||
-      [[ "$BUILD_CUDA_VERSION" =~ ^12.8.*$ ]]; then
+      [[ "$BUILD_CUDA_VERSION" =~ ^12.8.*$ ]] ||
+      [[ "$BUILD_CUDA_VERSION" =~ ^12.9.*$ ]]; then
     echo "[INSTALL] Removing the -ccbin=CXX hook from NVCC activation scripts ..."
     print_exec sed -i '/-ccbin=/d' "${conda_prefix}/etc/conda/activate.d/*cuda-nvcc_activate.sh"
   fi
@@ -195,7 +197,8 @@ install_cuda () {
   # (except for versions 11.8 and below, which are only available through
   # nvidia/label/cuda-*)
   if  [[ "$cuda_version" =~ ^12.6.*$ ]] ||
-      [[ "$cuda_version" =~ ^12.8.*$ ]]; then
+      [[ "$cuda_version" =~ ^12.8.*$ ]] ||
+      [[ "$cuda_version" =~ ^12.9.*$ ]]; then
     # shellcheck disable=SC2086
     (exec_with_retries 3 conda install --force-reinstall ${env_prefix} -c conda-forge --override-channels -y \
       cuda=${cuda_version}) || return 1

--- a/.github/workflows/fbgemm_gpu_benchmark_cuda.yml
+++ b/.github/workflows/fbgemm_gpu_benchmark_cuda.yml
@@ -53,7 +53,7 @@ jobs:
           { arch: x86, instance: "linux.24xlarge" },
         ]
         python-version: [ "3.13" ]
-        cuda-version: [ "12.8.0" ]
+        cuda-version: [ "12.8.1" ]
         compiler: [ "gcc" ]
 
     steps:
@@ -136,7 +136,7 @@ jobs:
           # { arch: x86, instance: "linux.gcp.a100" },
         ]
         python-version: [ "3.13" ]
-        cuda-version: [ "12.8.0" ]
+        cuda-version: [ "12.8.1" ]
         compiler: [ "gcc" ]
     needs: build_artifact
 

--- a/.github/workflows/fbgemm_gpu_ci_cuda.yml
+++ b/.github/workflows/fbgemm_gpu_ci_cuda.yml
@@ -71,16 +71,18 @@ jobs:
       fail-fast: false
       matrix:
         host-machine: [
-          { arch: x86, instance: "linux.24xlarge", build-target: "default", cuda-version: "11.8.0" },
           { arch: x86, instance: "linux.24xlarge", build-target: "default", cuda-version: "12.6.3" },
-          { arch: x86, instance: "linux.24xlarge", build-target: "default", cuda-version: "12.8.0" },
+          { arch: x86, instance: "linux.24xlarge", build-target: "default", cuda-version: "12.8.1" },
+          { arch: x86, instance: "linux.24xlarge", build-target: "default", cuda-version: "12.9.1" },
 
           # GenAI is unable to support 11.8.0 anymore as of https://github.com/pytorch/FBGEMM/pull/4138
           { arch: x86, instance: "linux.8xlarge.memory", build-target: "genai", cuda-version: "12.6.3" },
-          { arch: x86, instance: "linux.8xlarge.memory", build-target: "genai", cuda-version: "12.8.0" },
+          { arch: x86, instance: "linux.8xlarge.memory", build-target: "genai", cuda-version: "12.8.1" },
+          { arch: x86, instance: "linux.8xlarge.memory", build-target: "genai", cuda-version: "12.9.1" },
 
           { arch: x86, instance: "linux.12xlarge.memory", build-target: "hstu", cuda-version: "12.6.3" },
-          { arch: x86, instance: "linux.12xlarge.memory", build-target: "hstu", cuda-version: "12.8.0" },
+          { arch: x86, instance: "linux.12xlarge.memory", build-target: "hstu", cuda-version: "12.8.1" },
+          { arch: x86, instance: "linux.12xlarge.memory", build-target: "hstu", cuda-version: "12.9.1" },
         ]
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
         compiler: [ "gcc", "clang" ]
@@ -166,13 +168,15 @@ jobs:
           # { arch: x86, instance: "linux.gcp.a100" },
         ]
         build: [
-          { build-target: "default", cuda-version: "11.8.0" },
           { build-target: "default", cuda-version: "12.6.3" },
-          { build-target: "default", cuda-version: "12.8.0" },
+          { build-target: "default", cuda-version: "12.8.1" },
+          { build-target: "default", cuda-version: "12.9.1" },
           { build-target: "genai", cuda-version: "12.6.3" },
-          { build-target: "genai", cuda-version: "12.8.0" },
+          { build-target: "genai", cuda-version: "12.8.1" },
+          { build-target: "genai", cuda-version: "12.9.1" },
           { build-target: "hstu", cuda-version: "12.6.3" },
-          { build-target: "hstu", cuda-version: "12.8.0" },
+          { build-target: "hstu", cuda-version: "12.8.1" },
+          { build-target: "hstu", cuda-version: "12.9.1" },
         ]
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
         # Specify exactly ONE CUDA version for artifact publish

--- a/.github/workflows/fbgemm_gpu_ci_genai_generic_infra.yml
+++ b/.github/workflows/fbgemm_gpu_ci_genai_generic_infra.yml
@@ -60,7 +60,7 @@ jobs:
           { arch: x86, instance: "32-core-ubuntu" },
         ]
         python-version: [ "3.13" ]
-        cuda-version: [ "12.8.0" ]
+        cuda-version: [ "12.9.1" ]
         compiler: [ "gcc" ]
 
     steps:
@@ -147,7 +147,7 @@ jobs:
           { arch: x86, instance: "ubuntu-latest" },
         ]
         python-version: [ "3.13" ]
-        cuda-version: [ "12.8.0" ]
+        cuda-version: [ "12.9.1" ]
         compiler: [ "gcc" ]
     needs: build_artifact
 

--- a/.github/workflows/fbgemm_gpu_pip.yml
+++ b/.github/workflows/fbgemm_gpu_pip.yml
@@ -125,7 +125,7 @@ jobs:
           { instance: "linux.g5.4xlarge.nvidia.gpu" },
         ]
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
-        cuda-version: [ "11.8.0", "12.6.3", "12.8.0" ]
+        cuda-version: [ "12.6.3", "12.8.1", "12.9.1" ]
 
     steps:
     # Cannot upgrade to actions/checkout@v4 yet because GLIBC on the instance is too old

--- a/.github/workflows/fbgemm_gpu_release_cuda.yml
+++ b/.github/workflows/fbgemm_gpu_release_cuda.yml
@@ -34,8 +34,8 @@ on:
         description: CUDA Version to Use for Building Artifact
         type: choice
         required: false
-        options: [ "11.8.0", "12.6.3", "12.8.0" ]
-        default: "12.4.1"
+        options: [ "12.6.3", "12.8.1", "12.9.1" ]
+        default: "12.6.3"
       publish_to_pypi:
         description: Publish Artifact to PyPI
         type: boolean
@@ -72,7 +72,7 @@ jobs:
           { arch: x86, instance: "linux.24xlarge" },
         ]
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
-        cuda-version: [ "11.8.0", "12.6.3", "12.8.0" ]
+        cuda-version: [ "12.6.3", "12.8.1", "12.9.1" ]
 
     steps:
     - name: Setup Build Container
@@ -146,7 +146,7 @@ jobs:
           { arch: x86, instance: "linux.g5.4xlarge.nvidia.gpu" },
         ]
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
-        cuda-version: [ "11.8.0", "12.6.3", "12.8.0" ]
+        cuda-version: [ "12.6.3", "12.8.1", "12.9.1" ]
     needs: build_artifact
 
     steps:

--- a/.github/workflows/fbgemm_gpu_release_genai.yml
+++ b/.github/workflows/fbgemm_gpu_release_genai.yml
@@ -34,8 +34,8 @@ on:
         description: CUDA Version to Use for Building Artifact
         type: choice
         required: false
-        options: [ "11.8.0", "12.6.3", "12.8.0" ]
-        default: "12.4.1"
+        options: [ "12.6.3", "12.8.1", "12.9.1" ]
+        default: "12.6.3"
       publish_to_pypi:
         description: Publish Artifact to PyPI
         type: boolean
@@ -72,7 +72,7 @@ jobs:
           { arch: x86, instance: "linux.12xlarge.memory" },
         ]
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
-        cuda-version: [ "11.8.0", "12.6.3", "12.8.0" ]
+        cuda-version: [ "12.6.3", "12.8.1", "12.9.1" ]
 
     steps:
     - name: Setup Build Container
@@ -146,7 +146,7 @@ jobs:
           { arch: x86, instance: "linux.g5.4xlarge.nvidia.gpu" },
         ]
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
-        cuda-version: [ "11.8.0", "12.6.3", "12.8.0" ]
+        cuda-version: [ "12.6.3", "12.8.1", "12.9.1" ]
     needs: build_artifact
 
     steps:

--- a/fbgemm_gpu/README.md
+++ b/fbgemm_gpu/README.md
@@ -9,9 +9,6 @@ PyTorch GPU operator libraries for training and inference.  The library provides
 efficient table batched embedding bag, data layout transformation, and
 quantization supports.
 
-FBGEMM_GPU is currently tested with CUDA 12.4 and 11.8 in CI, and with PyTorch
-packages (2.1+) that are built against those CUDA versions.
-
 See the full [Documentation](https://pytorch.org/FBGEMM) for more information
 on building, installing, and developing with FBGEMM_GPU, as well as the most
 up-to-date support matrix for this library.

--- a/fbgemm_gpu/docs/src/fbgemm_gpu/development/BuildInstructions.rst
+++ b/fbgemm_gpu/docs/src/fbgemm_gpu/development/BuildInstructions.rst
@@ -100,8 +100,8 @@ distribution and CUDA version.
 
 .. code:: sh
 
-  # Run for Ubuntu 22.04, CUDA 11.8
-  docker run -it --entrypoint "/bin/bash" nvidia/cuda:11.8.0-devel-ubuntu22.04
+  # Run for Ubuntu 22.04, CUDA 12.6
+  docker run -it --entrypoint "/bin/bash" nvidia/cuda:12.6.0-devel-ubuntu22.04
 
 From here, the rest of the build environment may be constructed through Conda,
 as it is still the recommended mechanism for creating an isolated and


### PR DESCRIPTION
- Add build support for CUDA 12.9, following PyTorch nightlies

- Drop build support for CUDA 11.8, since it has been dropped from PyTorch nightlies