### PR TITLE
Adding and Exposing functions to destruct rocksDB checkpoint from ReadOnlyEmbeddingKVDB

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -9,10 +9,9 @@
 #include <ATen/ATen.h>
 #include <ATen/core/op_registration/op_registration.h>
 #include <c10/core/ScalarTypeToTypeMeta.h>
-#include <torch/library.h>
-
 #include <nlohmann/json.hpp>
 #include <torch/custom_class.h>
+#include <torch/library.h>
 #include <mutex>
 #include "../dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h"
 #include "./ssd_table_batched_embeddings.h"
@@ -1012,7 +1011,10 @@ static auto embedding_rocks_db_read_only_wrapper =
              torch::arg("cache_size") = 0})
         .def(
             "get_range_from_rdb_checkpoint",
-            &ReadOnlyEmbeddingKVDB::get_range_from_rdb_checkpoint);
+            &ReadOnlyEmbeddingKVDB::get_range_from_rdb_checkpoint)
+        .def(
+            "delete_rocksdb_checkpoint_dir",
+            &ReadOnlyEmbeddingKVDB::delete_rocksdb_checkpoint_dir);
 
 static auto kv_tensor_wrapper =
     torch::class_<KVTensorWrapper>("fbgemm", "KVTensorWrapper")

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -1475,6 +1475,14 @@ class ReadOnlyEmbeddingKVDB : public torch::jit::CustomClassHolder {
         .wait();
   }
 
+  void delete_rocksdb_checkpoint_dir() {
+    for (auto shard = 0; shard < dbs_.size(); ++shard) {
+      LOG(INFO) << "removing checkpoint directories: "
+                << rdb_shard_checkpoint_paths_[shard];
+      kv_db_utils::remove_dir(rdb_shard_checkpoint_paths_[shard]);
+    }
+  }
+
   int64_t get_max_D() {
     return max_D_;
   }


### PR DESCRIPTION
Summary:
Context:

The lifecycle of the rocksDB checkpoint is controlled by the client (checkpoint and publish) components. Due to this, we need to expose an API to destruct the rocksDB checkpoint and delete the folders.

In this diff, we have added delete functionality

Rollback Plan:

Differential Revision: D76737185
