### PR TITLE
Enrich auto-tune shapes for OC OBA model

### DIFF
--- a/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
@@ -3418,6 +3418,34 @@ MATMUL_CONFIGS_NON_PERSISTENT_PINGPONG_4K_8K_16K = [
         num_warps=8,
         num_stages=2,
     ),
+    triton.Config(
+        {
+            "BLOCK_M": 128,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_M": 4,
+            "SPLIT_K": 1,
+            "waves_per_eu": 2,
+            "matrix_instr_nonkdim": 16,
+            "kpack": 2,
+        },
+        num_warps=4,
+        num_stages=2,
+    ),
+    triton.Config(
+        {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_M": 4,
+            "SPLIT_K": 1,
+            "waves_per_eu": 0,
+            "matrix_instr_nonkdim": 16,
+            "kpack": 2,
+        },
+        num_warps=4,
+        num_stages=2,
+    ),
 ]
 
 # Set this to enable full autotuning for proper benchmarking.


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1436

Adding two shapes for the OC OBA model to best perf using the triton fp8 non-persistent kernel, as suggested by the [log](https://www.internalfb.com/intern/paste/P1843910441/). By which the triton kernel on-pars the torch rowwise:

|fp8 kernel|Flops|Time per iter|QPS
|pytorch|304.07|35.23ms|87205.84
|triton|302.63|35.39ms|86793.45

Reviewed By: njriasan, karthik-man

Differential Revision: D76631650
