### PR TITLE
Fix meta implementation for nobag

### DIFF
--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_meta_template.cpp
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_meta_template.cpp
@@ -106,7 +106,6 @@ Tensor
     const bool is_experimental
 ) {
     // NB: omitted the device tests TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL
-
     {%- if not nobag %}
     auto T = D_offsets.sym_numel() - 1;
     {%- else %}
@@ -140,6 +139,8 @@ Tensor
     {%- endif %}
 
     Tensor output;
+    // Fix tensor does not have device error for faketensor when all of the weights are undefined tensors.
+    auto options = dev_weights.defined() ? dev_weights.options() : at::TensorOptions().device(at::kMeta);
     {%- if nobag %}
     SparseType o_dtype = static_cast<SparseType>(output_dtype);
     {%- if is_index_select %}
@@ -155,7 +156,7 @@ Tensor
 
     // If permute_output_dim_0_1 is true, output shape is (batch_size * total_D)
     // Else, output shape is (output_size)
-    output = at::empty_symint({output_size}, dev_weights.options().dtype(getScalarType(o_dtype)));
+    output = at::empty_symint({output_size}, options.dtype(getScalarType(o_dtype)));
     {%- else %}
     TORCH_CHECK(o_dtype == SparseType::FP32 || o_dtype == SparseType::FP16 ||
                 o_dtype == SparseType::BF16 || o_dtype == SparseType::INT8);
@@ -165,15 +166,13 @@ Tensor
         adjusted_D += T * int64_t(kINT8QparamsBytes);
     }
 
-    output = at::empty_symint({total_L, adjusted_D}, dev_weights.options().dtype(getScalarType(o_dtype)));
+    output = at::empty_symint({total_L, adjusted_D}, options.dtype(getScalarType(o_dtype)));
     {%- endif %}
     {%- else %}
     SparseType o_dtype = static_cast<SparseType>(output_dtype);
     TORCH_CHECK(o_dtype == SparseType::FP32 || o_dtype == SparseType::FP16 ||
                 o_dtype == SparseType::BF16 || o_dtype == SparseType::INT8);
     
-    // Fix tensor does not have device error for faketensor when all of the weights are undefined tensors.
-    auto options = dev_weights.defined() ? dev_weights.options() : at::TensorOptions().device(at::kMeta);
     {%- if vbe %}
     output = at::empty_symint(
         {vbe_output_size},

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_nobag_cpu.cpp
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_nobag_cpu.cpp
@@ -155,26 +155,6 @@ Tensor split_embedding_nobag_codegen_forward_cpu(
   return output;
 }
 
-Tensor split_embedding_nobag_codegen_forward_cpu_meta(
-    const Tensor& weights,
-    const Tensor& /* weights_offsets */,
-    int64_t D,
-    const Tensor& /* hash_size_cumsum */,
-    const Tensor& indices,
-    const Tensor& /* offsets */,
-    int64_t output_dtype) {
-  c10::SymInt num_indices = indices.sym_size(0);
-  auto dtype = weights.options();
-  if (output_dtype == static_cast<int64_t>(SparseType::FP32)) {
-    dtype = weights.options().dtype(at::kFloat);
-  } else if (output_dtype == static_cast<int64_t>(SparseType::FP16)) {
-    dtype = weights.options().dtype(at::kHalf);
-  } else if (output_dtype == static_cast<int64_t>(SparseType::BF16)) {
-    dtype = weights.options().dtype(at::kBFloat16);
-  }
-  return at::empty_symint({num_indices, D}, dtype);
-}
-
 namespace {
 
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
@@ -190,9 +170,5 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   DISPATCH_TO_CPU(
       "split_embedding_nobag_codegen_forward_cpu",
       split_embedding_nobag_codegen_forward_cpu);
-
-  DISPATCH_TO_META(
-      "split_embedding_nobag_codegen_forward_cpu",
-      split_embedding_nobag_codegen_forward_cpu_meta);
 }
 } // namespace

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
@@ -512,7 +512,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       fwd_mdesc, ndesc, desc_suffix
       )
     %}
-    {%- if ssd or is_gwd or nobag %}
+    {%- if ssd or is_gwd %}
     /* Register scehema for wrappers with GPU-only support */    
     if (!utils::torch::schemaExists("fbgemm::{{ embedding_codegen_forward_op }}_wrapper")) {
     m.def("{{ embedding_codegen_forward_op }}_wrapper("
@@ -582,7 +582,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         bwd_mdesc, ndesc, optimizer, desc_suffix
         )
     %}
-    {%- if ssd or is_gwd or nobag or not has_cpu_support %}
+    {%- if ssd or is_gwd or not has_cpu_support %}
     /* Register scehema for wrappers with GPU-only support */
     if (!utils::torch::schemaExists("fbgemm::{{ embedding_codegen_backward_op }}_wrapper")) {
     m.def("{{ embedding_codegen_backward_op }}_wrapper("


### PR DESCRIPTION
Summary:
.
**TL;DR**

- `test_forward_cpu_fp32_nobag` fails `faketensor` PT2 opcheck test with error `tensor does not have a device`.
See full error P1844039424.
- With fake tensors, `dev_weights` is `undefined`. Hence, calling `dev_weights.options()` causes the error `tensor does not have a device`.
- function `split_embedding_nobag_codegen_forward_cpu` would be called through CPU dispatch. `split_embedding_nobag_codegen_forward_cpu_meta`, would never be called.
- meta implementation of nobag case already exists (since nobag for CUDA already exists)

**This diff**
- fixes meta implementation for nobag case
- removes `split_embedding_nobag_codegen_forward_cpu_meta`
- fixes duplicate registration.

 ---

Previously, nobag case is only available for CUDA. So there exists meta implementation for nobag ops.

__**Dispatch**__

For nobag case, the forward function is:
`split_embedding_nobag_codegen_forward_unweighted_wrapper`.
The wrapper is dispatched to `cpu`, `cuda` or `meta` based on device.
In other words:
- CPU wrapper will call `split_embedding_nobag_codegen_forward_cpu`.
- CUDA wrapper will call `split_embedding_nobag_codegen_forward_unweighted_cuda`.
- META wrapper will call `split_embedding_nobag_codegen_forward_unweighted_meta`.

The function `split_embedding_nobag_codegen_forward_cpu` would be called from CPU dispatch.
This means the device has already been determined to be `cpu`.
So there should be no dispatch to `meta` at this point, and  `split_embedding_nobag_codegen_forward_cpu_meta` would never be called.

__**Ops registration of the wrapper function**__
- CPU source files are included in GPU build, but not vice versa.
- GPU source files will not be included in CPU build.
- wrapper ops that have cpu support is registered (i.e., `m.def`) in `embedding_split_host_pt2_cpu_wrapper_template.cpp`
- wrapper ops with __ONLY GPU support__ would be registered (i.e., `m.def`) in
`embedding_split_host_pt2_cuda_wrapper_template.cpp`. (i.e., these ops will not exist in CPU-only build)
- So `m.def` should be done **once**, either in `cpu_wrapper_template` or `cuda_wrapper_template`.

So, nobag was previously not supported in CPU, hence the registration was done in `cuda_wrapper_template.cpp`. Now that it is supported in CPU, the registration should be *moved* to `cpu_wrapper_template.cpp` to avoid duplication.

__**Ops dispatch of wrapper function**__
- CPU dispatch (i.e., using macro `DISPATCH_TO_CPU`) is done in `embedding_split_host_pt2_cpu_wrapper_template.cpp`
- CUDA dispatch (i.e., using macro `DISPATCH_TO_CUDA`) is done in `embedding_split_host_pt2_cuda_wrapper_template.cpp`.
- META dispatch (i.e., using `m.impl`) is done in `embedding_split_host_pt2_cuda_wrapper_template.cpp`.
- the wrapper function (i.e., `{}_wrapper`) should be registered for dispatch (to CPU/CUDA/META) according to its corresponding support.

Differential Revision: D76863912
