### PR TITLE
add monitroing metrics for dram cache perf

### DIFF
--- a/fbgemm_gpu/src/dram_kv_embedding_cache/SynchronizedShardedMap.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/SynchronizedShardedMap.h
@@ -58,13 +58,24 @@ class SynchronizedShardedMap {
     return shards_.size();
   }
 
-  auto getUsedMemSize() const {
+  auto getUsedMemSizeInBytes() const {
     size_t used_mem_size = 0;
     size_t block_size = mempools_[0]->get_aligned_block_size();
     for (size_t i = 0; i < shards_.size(); ++i) {
-      auto rlmap = shards_[i].rlock();
+      int64_t mempool_idx = i % mempools_.size();
       // only calculate the sizes of K, V and block that are used
-      used_mem_size += rlmap->size() * (sizeof(K) + sizeof(V) + block_size);
+      if (mempools_[mempool_idx]->get_allocated_chunk_bytes() > 0) {
+        auto rlmap = shards_[i].rlock();
+        used_mem_size += rlmap->size() * (sizeof(K) + sizeof(V) + block_size);
+      }
+    }
+    return used_mem_size;
+  }
+
+  auto getActualUsedChunkInBytes() const {
+    size_t used_mem_size = 0;
+    for (size_t i = 0; i < mempools_.size(); ++i) {
+      used_mem_size += mempools_[i]->get_allocated_chunk_bytes();
     }
     return used_mem_size;
   }

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h
@@ -121,8 +121,14 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
     return impl_->get_keys_in_range_impl(start, end, std::nullopt);
   }
 
-  size_t get_map_used_memsize() const {
-    return impl_->get_map_used_memsize();
+  size_t get_map_used_memsize_in_bytes() const {
+    return impl_->get_map_used_memsize_in_bytes();
+  }
+
+  std::vector<double> get_dram_kv_perf(
+      const int64_t step,
+      const int64_t interval) {
+    return impl_->get_dram_kv_perf(step, interval);
   }
 
   void get_feature_evict_metric(

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
@@ -290,7 +290,7 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
    *
    * @return Size of memory used by the map in bytes.
    */
-  virtual size_t get_map_used_memsize() const {
+  virtual size_t get_map_used_memsize_in_bytes() const {
     FBEXCEPTION("Not implemented");
   };
 
@@ -345,7 +345,15 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
     FBEXCEPTION("Not implemented");
   }
 
-  void set_range_to_storage(
+  virtual std::vector<double> get_dram_kv_perf(
+      const int64_t step,
+      const int64_t interval) {
+    (void)step;
+    (void)interval;
+    FBEXCEPTION("Not implemented");
+  }
+
+  virtual void set_range_to_storage(
       const at::Tensor& weights,
       const int64_t start,
       const int64_t length) {
@@ -373,7 +381,7 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
 
   void set_kv_to_storage(const at::Tensor& ids, const at::Tensor& weights) {
     const auto count = at::tensor({ids.size(0)}, at::ScalarType::Long);
-    folly::coro::blockingWait(set_kv_db_async(ids, weights, count));
+    set_kv_db_async(ids, weights, count).wait();
   }
 
   virtual void get_kv_from_storage_by_snapshot(

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -911,7 +911,10 @@ static auto dram_kv_embedding_cache_wrapper =
             &DramKVEmbeddingCacheWrapper::get_keys_in_range_by_snapshot)
         .def(
             "get_feature_evict_metric",
-            &DramKVEmbeddingCacheWrapper::get_feature_evict_metric);
+            &DramKVEmbeddingCacheWrapper::get_feature_evict_metric)
+        .def(
+            "get_dram_kv_perf",
+            &DramKVEmbeddingCacheWrapper::get_dram_kv_perf);
 static auto embedding_rocks_db_read_only_wrapper =
     torch::class_<ReadOnlyEmbeddingKVDB>("fbgemm", "ReadOnlyEmbeddingKVDB")
         .def(

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -721,7 +721,7 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
 
   void set_kv_to_storage(const at::Tensor& ids, const at::Tensor& weights) {
     const auto count = at::tensor({ids.size(0)}, at::ScalarType::Long);
-    folly::coro::blockingWait(set_kv_db_async(ids, weights, count));
+    set_kv_db_async(ids, weights, count).wait();
   }
 
   void get_kv_from_storage_by_snapshot(

--- a/fbgemm_gpu/test/dram_kv_embedding_cache/sharded_map_test.cpp
+++ b/fbgemm_gpu/test/dram_kv_embedding_cache/sharded_map_test.cpp
@@ -164,12 +164,14 @@ void memPoolEmbeddingMemSize(int dimension, size_t numInserts) {
       wlock->insert_or_assign(i, block);
     }
   }
-  size_t totalMemory = embeddingMap.getUsedMemSize();
+  size_t totalMemory = embeddingMap.getUsedMemSizeInBytes();
+  size_t actualUsedChunkInBytes = embeddingMap.getActualUsedChunkInBytes();
   fmt::print(
-      "{:<20}{:<20}{:<20.2f}\n",
+      "{:<20}{:<20}{:<20.2f}{:<20.2f}\n",
       dimension,
       numInserts,
-      static_cast<double>(totalMemory) / (1024 * 1024)); // MB
+      static_cast<double>(totalMemory) / (1024 * 1024),
+      static_cast<double>(actualUsedChunkInBytes) / (1024 * 1024)); // MB
 }
 
 int benchmark() {
@@ -212,7 +214,12 @@ int benchmark() {
   fmt::print(
       "======================= memory usage statistics "
       "====================================\n");
-  fmt::print("{:<20}{:<20}{:<20}\n", "dim", "numInserts", "total memory (MB)");
+  fmt::print(
+      "{:<20}{:<20}{:<20}{:<20}\n",
+      "dim",
+      "numInserts",
+      "total memory (MB)",
+      "actual used chunk (MB))");
   for (int dim : dimensions) {
     memPoolEmbeddingMemSize(dim, numInserts);
   }


### PR DESCRIPTION
Summary:
Add metrics breakdown to better understand DRAM cache perf
- read perf breakdown
- write perf breakdown: with a distinguisher between fwd `l1_eviction_write` and bwd `l1_cnflct_miss_write`
- emb  allocation and actual chunk allocated size

Reviewed By: duduyi2013

Differential Revision: D76309945


