### PR TITLE
Fix trunk health GenAI tests

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/test/gather_scatter/gather_scatter_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/gather_scatter/gather_scatter_test.py
@@ -19,13 +19,15 @@ logger: logging.Logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
-@unittest.skipIf(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
-    "Skip when no Hopper GPU is available. This test is only for Hopper GPU.",
-)
 class GatherScatterTests(unittest.TestCase):
     """Test Gathers."""
 
+    @unittest.skipIf(
+        torch.version.hip
+        or not torch.cuda.is_available()
+        or torch.cuda.get_device_capability() < (9, 0),
+        "Skip when no Hopper GPU is available. This test is only for Hopper GPU.",
+    )
     def test_gather_along_first_dim(self) -> None:
         def _test_gather_along_first_dim(
             M: int, N: int, K: int, compile: bool = False
@@ -67,6 +69,12 @@ class GatherScatterTests(unittest.TestCase):
         _test_gather_along_first_dim(8192, 8192, 5120)
         _test_gather_along_first_dim(16384, 16384, 5120)
 
+    @unittest.skipIf(
+        torch.version.hip
+        or not torch.cuda.is_available()
+        or torch.cuda.get_device_capability() < (9, 0),
+        "Skip when no Hopper GPU is available. This test is only for Hopper GPU.",
+    )
     def test_scatter_add_along_first_dim(self) -> None:
         def _test_scatter_add_along_first_dim(
             M: int, N: int, K: int, compile: bool = False

--- a/fbgemm_gpu/experimental/gen_ai/test/kv_cache/kv_cache_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/kv_cache/kv_cache_test.py
@@ -363,7 +363,7 @@ class KVCacheTests(unittest.TestCase):
         N_KVH_L=st.sampled_from([1, 2]),
     )
     @unittest.skipIf(
-        not torch.version.hip or not HAS_XFORMERS,
+        not torch.cuda.is_available() or not HAS_XFORMERS or not torch.version.hip,
         "Skip when no AMD GPU or xformers is not available",
     )
     def test_fp8_kv_e4m3fn_convert_to_e4m3fnuz(self, MAX_T: int, N_KVH_L: int) -> None:


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1465

This diff fixes the tests which fail when running with ` fbcode//mode/opt-amd-gpu`.

- Properly skip gather_scatter tests on ROCm since the ops are not available for ROCm
- Skip test_fp8_kv_e4m3fn_convert_to_e4m3fnuz on when there's no GPU available.
- Add HIP SDK dependency

Reviewed By: q10

Differential Revision: D77194089


