### PR TITLE
Utilities for slicing preshuffled tensors

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16i4bf16.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16i4bf16.cu
@@ -260,8 +260,13 @@ at::Tensor bf16i4bf16_dispatch(
       "and be contiguous on GPU.");
   // Make sure group scales and zeros are in proper format.
   TORCH_CHECK(
-      w_scale_group.dim() == 2 && w_scale_group.size(1) == N,
-      "Group scales are expected to have shape [num_groups, N].");
+      w_scale_group.dim() == 2 && w_scale_group.size(1) == N &&
+          w_scale_group.is_cuda() && w_scale_group.is_contiguous(),
+      "Group scales are expected to have shape [num_groups, N] and be contiguous on GPU.");
+  TORCH_CHECK(
+      w_zero_group.dim() == 2 && w_zero_group.size(1) == N &&
+          w_zero_group.is_cuda() && w_zero_group.is_contiguous(),
+      "Group zeros are expected to have shape [num_groups, N] and be contiguous on GPU.");
 
   // Allocate output or return an empty tensor if input is empty.
   if (M == 0 || N == 0 || K == 0) {

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8i4bf16_shuffled.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8i4bf16_shuffled.cu
@@ -278,17 +278,18 @@ at::Tensor f8i4bf16_shuffled(
       "and be contiguous on GPU.");
   TORCH_CHECK(
       x_scale.numel() == M && x_scale.dtype() == at::kFloat &&
-          x_scale.is_cuda(),
-      "x_scale must be fp32 and have M total elements.");
+          x_scale.is_cuda() && x_scale.is_contiguous(),
+      "x_scale must be fp32 and have M total elements and be contiguous.");
   TORCH_CHECK(
       w_scale.numel() == N && w_scale.dtype() == at::kFloat &&
-          w_scale.is_cuda(),
-      "Weight row scale should have N elements and be on GPU.");
+          w_scale.is_cuda() && w_scale.is_contiguous(),
+      "Weight row scale should have N elements and be contiguous on GPU.");
   // Make sure w_scale_group is in proper format.
   TORCH_CHECK(
       w_scale_group.dtype() == at::kFloat8_e4m3fn && w_scale_group.dim() == 3 &&
-          w_scale_group.size(1) == 8 && w_scale_group.size(2) == N,
-      "Weights and group scales must be prepacked with preshuffle_i4. "
+          w_scale_group.size(1) == 8 && w_scale_group.size(2) == N &&
+          w_scale_group.is_contiguous(),
+      "Weights and group scales must be contiguous and prepacked with preshuffle_i4. "
       "Group scales are expected to be FP8 and have shape [num_groups, 8, N].");
 
   // Allocate output or return an empty tensor if input is empty.


### PR DESCRIPTION
Summary:
Some integrations of fbgemm kernels and oss systems like VLLM would be made simpler by the ability to slice preshuffled tensors. Prior to this diff, there were two blockers to doing that:
- Scales were required to be contiguous. This is easily addressed by more carefully setting the stride argument.
- Shuffled tensors have a non-trivial layout. We add a python helper function for slicing int4 shuffled tensors. Notably, it involves some data copying that I believe is unavoidable. Hopefully it only needs to be done during model setup.

Differential Revision: D77239566


