### PR TITLE
BF16I4 Preshuffled Batched GEMM

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/gen_ai/quantize.py
+++ b/fbgemm_gpu/experimental/gen_ai/gen_ai/quantize.py
@@ -181,6 +181,40 @@ def quantize_int4_preshuffle(
     return wq, scales
 
 
+def shuffle_slice(
+    x: torch.Tensor, dim: int, start: int, length: int, dtype: str = "fp8"
+) -> torch.Tensor:
+    """
+    Helper function to slice a preshuffled int4 tensor. This is needed since the shuffling
+    reorders rows based on the size of the input. Slicing a tensor shuffled for a larger input
+    is no longer valid. We must reorder the tensor to the appropriate size then slice.
+    Args:
+        x (Tensor): [N, K // 2] Preshuffled int4 tensor.
+        dim (int): Dimension to slice.
+        start (int): Start of slice.
+        length (int): Number of elements to slice.
+        dtype (str): Type of corresponding activations. Must be fp8 or bf16.
+    Returns:
+        sliced (Tensor): [stop-start, K // 2] Sliced tensor.
+    """
+    # Get the size of the input tensor.
+    assert dim == x.ndim - 2, "Only slicing along N is supported."
+    assert length % 16 == 0, "Slicing must be a multiple of 16."
+    orig_shape = x.shape
+    N = x.shape[-2]
+    K = x.shape[-1]
+    # Tile shape is based on the activation dtype.
+    assert dtype in ("fp8", "bf16"), "Only fp8 and bf16 activations supported."
+    tile_shape = 8 if dtype == "fp8" else 16
+    block_size = N // length
+    # View the shape in terms of shuffled tiles then permute to allow slicing.
+    x_s = x.view(-1, tile_shape, block_size, length // tile_shape, K)
+    x_s = x_s.permute(0, 2, 1, 3, 4).contiguous().view(-1, N, K)
+    out_slice = x_s.narrow(1, start, length)
+    # Reshape back to original shape.
+    return out_slice.view(*orig_shape[:-2], length, K)
+
+
 def scale_nvfp4_quant(
     input: torch.Tensor, input_global_scale: torch.Tensor
 ) -> Tuple[torch.Tensor, torch.Tensor]:

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16i4bf16.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16i4bf16.cu
@@ -185,8 +185,11 @@ at::Tensor _bf16i4bf16(
   }
 
   using StrideS = typename CollectiveMainloopShuffled::StrideScale;
+  // Note we can support non contiguous strides by actually using the
+  // strides of the scales here. This applies to both scale and zeros.
+  int32_t scale_stride = w_scale_group.stride(0);
   StrideS stride_S = cutlass::make_cute_packed_stride(
-      StrideS{}, cute::make_shape(N, num_groups, 1));
+      StrideS{}, cute::make_shape(scale_stride, num_groups, 1));
 
   // Define Gemm arguments.
   typename GemmShuffled::Arguments arguments{

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16i4bf16_rowwise_batched.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16i4bf16_rowwise_batched.cu
@@ -11,12 +11,20 @@
 #include <cutlass/util/device_memory.h>
 #include <cutlass/util/packed_stride.hpp>
 
+#include "cutlass/cutlass.h"
+
 // clang-format off
 // The fixed ordering of the headers is required for CUTLASS 3.2+
 #include <cute/tensor.hpp>
 #include <cutlass/gemm/collective/collective_builder.hpp>     // @manual
 #include <cutlass/gemm/device/gemm_universal_adapter.h>       // @manual
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
 #include <cutlass/epilogue/collective/collective_builder.hpp> // @manual
+#include "cutlass/epilogue/collective/default_epilogue.hpp"
+
+#include "cutlass/util/mixed_dtype_utils.hpp"
+#include "cutlass/util/packed_stride.hpp"
 // clang-format on
 
 #include "cutlass_extensions/include/kernel_mode.h"
@@ -26,6 +34,7 @@ namespace fbgemm_gpu {
 #if CUDART_VERSION >= 12000
 
 template <
+    bool SHUFFLE,
     int TB_M,
     int TB_N,
     int TB_K,
@@ -49,6 +58,9 @@ at::Tensor bf16i4bf16_rowwise_batched_impl(
 
   int num_groups = w_scale.size(0) / B;
 
+  using MmaType = cutlass::bfloat16_t;
+  using QuantType = cutlass::int4b_t;
+
   TORCH_CHECK(X.is_cuda() && X.is_contiguous());
   TORCH_CHECK(WQ.is_cuda() && WQ.is_contiguous());
   TORCH_CHECK(w_scale.is_cuda() && w_scale.is_contiguous());
@@ -59,34 +71,59 @@ at::Tensor bf16i4bf16_rowwise_batched_impl(
 
   auto Y = at::empty({B, M, N}, X.options().dtype(at::kBFloat16));
 
-  using ElementInputA = cutlass::bfloat16_t;
-  using LayoutInputA = cutlass::layout::ColumnMajor;
-  constexpr int AlignmentInputA =
+  using ElementA = MmaType;
+  using LayoutA = cutlass::layout::RowMajor;
+  constexpr int AlignmentA =
       128 /
       cutlass::sizeof_bits<
-          ElementInputA>::value; // Memory access granularity/alignment of A
-                                 // matrix in units of elements (up to 16 bytes)
+          ElementA>::value; // Memory access granularity/alignment of A
+                            // matrix in units of elements (up to 16 bytes)
 
-  using ElementInputB = cutlass::int4b_t;
-  using LayoutInputB = cutlass::layout::RowMajor;
-  constexpr int AlignmentInputB =
-      128 /
-      cutlass::sizeof_bits<
-          ElementInputB>::value; // Memory access granularity/alignment of B
-                                 // matrix in units of elements (up to 16 bytes)
+  using ElementB = QuantType;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  constexpr int AlignmentB =
+      128 / cutlass::sizeof_bits<ElementB>::value; // Memory access
+                                                   // granularity/alignment of B
+  // matrix in units of elements (up to 16 bytes)
+
+  using LayoutA_Transpose =
+      typename cutlass::layout::LayoutTranspose<LayoutA>::type;
+  using LayoutB_Transpose =
+      typename cutlass::layout::LayoutTranspose<LayoutB>::type;
+
+  using StrideA = cutlass::detail::TagToStrideA_t<LayoutA>;
+  using StrideB = cutlass::detail::TagToStrideB_t<LayoutB>;
+
+  // Define layout for shuffled weight tensor.
+  using ValueShuffle = cute::Layout<
+      cute::Shape<cute::_2, cute::_4>,
+      cute::Stride<cute::_4, cute::_1>>; // order [0,2,4,6,1,3,5,7]
+  int constexpr NumShuffleAtoms = 1;
+  using MmaAtomShape =
+      cute::Layout<cute::Shape<cute::_1, cute::Int<NumShuffleAtoms>>>;
+  using LayoutAtomQuant = decltype(cutlass::compute_memory_reordering_atom<
+                                   MmaType,
+                                   MmaAtomShape,
+                                   ValueShuffle>());
+  using LayoutB_Reordered = decltype(cute::tile_to_shape(
+      LayoutAtomQuant{}, cute::Layout<cute::Shape<int, int, int>, StrideB>{}));
+
+  using B_Layout =
+      cute::conditional_t<SHUFFLE, LayoutB_Reordered, LayoutB_Transpose>;
 
   using ElementScale = WEIGHT_SCALE_DTYPE;
   using ElementZeroPoint = WEIGHT_SCALE_DTYPE;
   using ElementComputeEpilogue = float;
   using ElementAccumulator = float;
 
-  using ElementOutput = cutlass::bfloat16_t;
-  using LayoutOutput = cutlass::layout::ColumnMajor;
-  constexpr int AlignmentOutput =
+  using ElementC = cutlass::bfloat16_t;
+
+  using LayoutC = cutlass::layout::RowMajor;
+  constexpr int AlignmentC =
       128 /
       cutlass::sizeof_bits<
-          ElementOutput>::value; // Memory access granularity/alignment of C
-                                 // matrix in units of elements (up to 16 bytes)
+          ElementC>::value; // Memory access granularity/alignment of C
+                            // matrix in units of elements (up to 16 bytes)
 
   using ArchTag = cutlass::arch::Sm90; // Tag indicating the minimum SM that
                                        // supports the intended feature
@@ -123,24 +160,24 @@ at::Tensor bf16i4bf16_rowwise_batched_impl(
           EpilogueTileType,
           ElementAccumulator,
           ElementAccumulator,
-          ElementOutput,
-          LayoutOutput,
-          AlignmentOutput,
-          ElementOutput,
-          LayoutOutput,
-          AlignmentOutput,
+          ElementC,
+          typename cutlass::layout::LayoutTranspose<LayoutC>::type,
+          AlignmentC,
+          ElementC,
+          typename cutlass::layout::LayoutTranspose<LayoutC>::type,
+          AlignmentC,
           EpilogueSchedule>::CollectiveOp;
 
   using CollectiveMainloop =
       typename cutlass::gemm::collective::CollectiveBuilder<
           ArchTag,
           OperatorClass,
-          cute::tuple<ElementInputB, ElementScale, ElementZeroPoint>,
-          LayoutInputB,
-          AlignmentInputB,
-          ElementInputA,
-          LayoutInputA,
-          AlignmentInputA,
+          cute::tuple<ElementB, ElementScale, ElementZeroPoint>,
+          B_Layout,
+          AlignmentB,
+          ElementA,
+          LayoutA_Transpose,
+          AlignmentA,
           ElementAccumulator,
           TileShape,
           ClusterShape,
@@ -155,36 +192,50 @@ at::Tensor bf16i4bf16_rowwise_batched_impl(
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 
-  using StrideInputA = typename Gemm::GemmKernel::StrideA;
-  using StrideInputB = typename Gemm::GemmKernel::StrideB;
-  using StrideOutput = typename Gemm::GemmKernel::StrideC;
-  using StrideS = typename CollectiveMainloop::StrideScale;
+  using StrideC = typename Gemm::GemmKernel::StrideC;
 
-  StrideInputA stride_a = cutlass::make_cute_packed_stride(
-      StrideInputA{}, cute::make_shape(M, K, B));
-  StrideInputB stride_b = cutlass::make_cute_packed_stride(
-      StrideInputB{}, cute::make_shape(N, K, B));
-  StrideOutput stride_output = cutlass::make_cute_packed_stride(
-      StrideOutput{}, cute::make_shape(N, M, B));
+  auto shape_b = cute::make_shape(N, K, B);
+  StrideA stride_a =
+      cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(M, K, B));
+  StrideB stride_b =
+      cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(N, K, B));
+  StrideC stride_c =
+      cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(N, M, B));
+
+  LayoutB_Reordered layout_b_reordered =
+      cute::tile_to_shape(LayoutAtomQuant{}, shape_b);
+
+  using stride_type = cute::conditional_t<SHUFFLE, LayoutB_Reordered, StrideB>;
+  stride_type b_stride;
+  if constexpr (SHUFFLE) {
+    b_stride = layout_b_reordered;
+  } else {
+    b_stride = stride_b;
+  }
+
+  using StrideS = typename CollectiveMainloop::StrideScale;
+  // Note we can support non contiguous strides by actually using the
+  // strides of the scales here. This applies to both scale and zeros.
+  int32_t scale_stride = w_scale.stride(0);
   StrideS stride_S = cutlass::make_cute_packed_stride(
-      StrideS{}, cute::make_shape(N, num_groups, B));
+      StrideS{}, cute::make_shape(scale_stride, num_groups, B));
 
   typename Gemm::Arguments arguments{
       cutlass::gemm::GemmUniversalMode::kGemm,
       {N, M, K, B},
-      {reinterpret_cast<ElementInputB*>(WQ.data_ptr()),
-       stride_b,
-       reinterpret_cast<ElementInputA*>(X.data_ptr()),
+      {reinterpret_cast<ElementB*>(WQ.data_ptr()),
+       b_stride,
+       reinterpret_cast<ElementA*>(X.data_ptr()),
        stride_a,
        reinterpret_cast<ElementScale*>(w_scale.data_ptr()),
        stride_S,
        group_size,
        reinterpret_cast<ElementZeroPoint*>(w_zp.data_ptr())},
       {{1.0, 0.0},
-       (ElementOutput*)Y.data_ptr<at::BFloat16>(),
-       stride_output,
-       (ElementOutput*)Y.data_ptr<at::BFloat16>(),
-       stride_output}};
+       (ElementC*)Y.data_ptr<at::BFloat16>(),
+       stride_c,
+       (ElementC*)Y.data_ptr<at::BFloat16>(),
+       stride_c}};
 
   Gemm gemm;
 
@@ -219,7 +270,7 @@ at::Tensor bf16i4bf16_rowwise_batched_impl(
   return Y;
 }
 
-template <typename WEIGHT_SCALE_DTYPE>
+template <bool SHUFFLE, typename WEIGHT_SCALE_DTYPE>
 at::Tensor dispatch_bf16i4bf16_rowwise_batched_kernel(
     at::Tensor X, // BF16
     at::Tensor WQ, // INT4
@@ -228,6 +279,7 @@ at::Tensor dispatch_bf16i4bf16_rowwise_batched_kernel(
   KernelMode kernel = get_batched_kernel_mode(X, WQ);
   if (kernel == KernelMode::Small) {
     return bf16i4bf16_rowwise_batched_impl<
+        SHUFFLE,
         64,
         128,
         64,
@@ -238,6 +290,7 @@ at::Tensor dispatch_bf16i4bf16_rowwise_batched_kernel(
         WEIGHT_SCALE_DTYPE>(X, WQ, w_scale, w_zp);
   } else if (kernel == KernelMode::Large) {
     return bf16i4bf16_rowwise_batched_impl<
+        SHUFFLE,
         128,
         256,
         64,
@@ -248,6 +301,7 @@ at::Tensor dispatch_bf16i4bf16_rowwise_batched_kernel(
         WEIGHT_SCALE_DTYPE>(X, WQ, w_scale, w_zp);
   } else {
     return bf16i4bf16_rowwise_batched_impl<
+        SHUFFLE,
         128,
         256,
         64,
@@ -256,6 +310,34 @@ at::Tensor dispatch_bf16i4bf16_rowwise_batched_kernel(
         1,
         false,
         WEIGHT_SCALE_DTYPE>(X, WQ, w_scale, w_zp);
+  }
+}
+
+at::Tensor bf16i4bf16_shuffled_batched(
+    at::Tensor X, // BF16
+    at::Tensor WQ, // INT4
+    at::Tensor w_scale,
+    at::Tensor w_zp) {
+  // Check datatypes.
+  TORCH_CHECK(
+      (w_scale.dtype() == at::kFloat && w_zp.dtype() == at::kFloat) ||
+          (w_scale.dtype() == at::kHalf && w_zp.dtype() == at::kHalf) ||
+          (w_scale.dtype() == at::kBFloat16 && w_zp.dtype() == at::kBFloat16),
+      "Weight scale and zero point tensors must be float32, bfloat16, or float16, and dtype of weight scale and zero point tensors must be the same .");
+
+  if (w_scale.dtype() == at::kFloat) {
+    return dispatch_bf16i4bf16_rowwise_batched_kernel<true, float>(
+        X, WQ, w_scale, w_zp);
+  } else if (w_scale.dtype() == at::kHalf) {
+    return dispatch_bf16i4bf16_rowwise_batched_kernel<true, cutlass::half_t>(
+        X, WQ, w_scale, w_zp);
+  } else if (w_scale.dtype() == at::kBFloat16) {
+    return dispatch_bf16i4bf16_rowwise_batched_kernel<
+        true,
+        cutlass::bfloat16_t>(X, WQ, w_scale, w_zp);
+  } else {
+    throw std::runtime_error(
+        "Weight scale and zero point data type not supported in bf16i4bf16_rowwise_batched");
   }
 }
 
@@ -272,14 +354,15 @@ at::Tensor bf16i4bf16_rowwise_batched(
       "Weight scale and zero point tensors must be float32, bfloat16, or float16, and dtype of weight scale and zero point tensors must be the same .");
 
   if (w_scale.dtype() == at::kFloat) {
-    return dispatch_bf16i4bf16_rowwise_batched_kernel<float>(
+    return dispatch_bf16i4bf16_rowwise_batched_kernel<false, float>(
         X, WQ, w_scale, w_zp);
   } else if (w_scale.dtype() == at::kHalf) {
-    return dispatch_bf16i4bf16_rowwise_batched_kernel<cutlass::half_t>(
+    return dispatch_bf16i4bf16_rowwise_batched_kernel<false, cutlass::half_t>(
         X, WQ, w_scale, w_zp);
   } else if (w_scale.dtype() == at::kBFloat16) {
-    return dispatch_bf16i4bf16_rowwise_batched_kernel<cutlass::bfloat16_t>(
-        X, WQ, w_scale, w_zp);
+    return dispatch_bf16i4bf16_rowwise_batched_kernel<
+        false,
+        cutlass::bfloat16_t>(X, WQ, w_scale, w_zp);
   } else {
     throw std::runtime_error(
         "Weight scale and zero point data type not supported in bf16i4bf16_rowwise_batched");
@@ -287,6 +370,15 @@ at::Tensor bf16i4bf16_rowwise_batched(
 }
 
 #else
+
+at::Tensor bf16i4bf16_shuffled_batched(
+    at::Tensor X, // BF16
+    at::Tensor WQ, // INT4
+    at::Tensor w_scale,
+    at::Tensor w_zp) {
+  throw std::runtime_error(
+      "CUDA version is older than 12.0"); // requires CUDA>=12
+}
 
 at::Tensor bf16i4bf16_rowwise_batched(
     at::Tensor X, // BF16

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8i4bf16_shuffled.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8i4bf16_shuffled.cu
@@ -191,8 +191,11 @@ at::Tensor _f8i4bf16_shuffled(
   LayoutB_Reordered layout_B_reordered =
       cute::tile_to_shape(LayoutAtomQuant{}, shape_B);
   using StrideS = typename CollectiveMainloopShuffled::StrideScale;
+  // Note we can support non contiguous strides by actually using the
+  // strides of the scales here.
+  int32_t scale_stride = w_scale_group.stride(0);
   StrideS stride_S = cutlass::make_cute_packed_stride(
-      StrideS{}, cute::make_shape(N, num_groups, 1));
+      StrideS{}, cute::make_shape(scale_stride, num_groups, 1));
 
   // Define Gemm arguments.
   typename GemmShuffled::Arguments arguments{

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -218,6 +218,11 @@ at::Tensor bf16i4bf16_rowwise(
     at::Tensor W,
     at::Tensor w_scale_group,
     at::Tensor w_zero_group);
+at::Tensor bf16i4bf16_shuffled_batched(
+    at::Tensor X,
+    at::Tensor WQ,
+    at::Tensor w_scale,
+    at::Tensor w_zp);
 at::Tensor bf16i4bf16_rowwise_batched(
     at::Tensor X,
     at::Tensor WQ,
@@ -310,6 +315,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   m.impl("f8i4bf16_shuffled_grouped", f8i4bf16_shuffled_grouped);
   m.impl("bf16i4bf16_shuffled_grouped", bf16i4bf16_shuffled_grouped);
   m.impl("preshuffle_i4", preshuffle_i4);
+  m.impl("bf16i4bf16_shuffled_batched", bf16i4bf16_shuffled_batched);
   m.impl("bf16i4bf16_rowwise_batched", bf16i4bf16_rowwise_batched);
   m.impl("bf16i4bf16_rowwise", bf16i4bf16_rowwise);
   m.impl("scaled_fp4_quant", scaled_fp4_quant);
@@ -361,6 +367,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
   m.impl("f8i4bf16_shuffled_grouped", f8i4bf16_shuffled_grouped);
   m.impl("bf16i4bf16_shuffled_grouped", bf16i4bf16_shuffled_grouped);
   m.impl("preshuffle_i4", preshuffle_i4);
+  m.impl("bf16i4bf16_shuffled_batched", bf16i4bf16_shuffled_batched);
   m.impl("bf16i4bf16_rowwise_batched", bf16i4bf16_rowwise_batched);
   m.impl("bf16i4bf16_rowwise", bf16i4bf16_rowwise);
   m.impl("scaled_fp4_quant", scaled_fp4_quant);
@@ -593,6 +600,19 @@ at::Tensor bf16i4bf16_rowwise_meta(
   return Y;
 }
 
+at::Tensor bf16i4bf16_shuffled_batched_meta(
+    at::Tensor X, // BF16
+    at::Tensor W, // INT4
+    at::Tensor /* w_scale_group */,
+    at::Tensor /* w_zero_group */
+) {
+  const at::SymInt B = X.sym_size(0);
+  const at::SymInt M = X.sym_size(1);
+  const at::SymInt N = W.sym_size(1);
+  auto Y = at::empty_symint({B, M, N}, X.options().dtype(at::kBFloat16));
+  return Y;
+}
+
 at::Tensor bf16i4bf16_rowwise_batched_meta(
     at::Tensor X, // BF16
     at::Tensor W, // INT4
@@ -699,6 +719,7 @@ TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
   m.impl("f8f8bf16_rowwise_batched", f8f8bf16_rowwise_batched_meta);
   m.impl("f8i4bf16_rowwise", f8i4bf16_rowwise_meta);
   m.impl("bf16i4bf16_rowwise", bf16i4bf16_rowwise_meta);
+  m.impl("bf16i4bf16_shuffled_batched", bf16i4bf16_shuffled_batched_meta);
   m.impl("bf16i4bf16_rowwise_batched", bf16i4bf16_rowwise_batched_meta);
   m.impl("f8f8bf16_lite", f8f8bf16_lite_meta);
   m.impl("scaled_fp4_quant", scaled_fp4_quant_meta);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize_defs.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize_defs.cpp
@@ -47,6 +47,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "bf16i4bf16_rowwise(Tensor X, Tensor W, Tensor w_scale_group, Tensor w_zero_group) -> Tensor");
   m.def(
+      "bf16i4bf16_shuffled_batched(Tensor X, Tensor WQ, Tensor w_scale, Tensor w_zp) -> Tensor");
+  m.def(
       "bf16i4bf16_rowwise_batched(Tensor X, Tensor WQ, Tensor w_scale, Tensor w_zp) -> Tensor");
   m.def(
       "i8i8bf16_dynamic(Tensor XQ, Tensor WQ, Tensor scale, int split_k=1) -> Tensor");


### PR DESCRIPTION
Summary:
The preshuffled BF16I4 batched gemm is much faster than BF16I4 batched gemm, especially in memory-bound shapes, which will be used in fbgemm + other oss system integration

Add BF16I4 preshuffled batched gemm to unblock the integration as requested

Differential Revision: D77311295
