### PR TITLE
Fix CQS signal facebook-unused-include-check in fbcode/deeplearning/fbgemm/src [B] [B] [A]

### DIFF
--- a/src/PackWeightMatrixForGConv.cc
+++ b/src/PackWeightMatrixForGConv.cc
@@ -9,7 +9,6 @@
 #define FBGEMM_EXPORTS
 #include <cpuinfo.h>
 #include <cassert>
-#include <iomanip>
 #include <numeric>
 #include "./RefImplementations.h" // @manual
 #include "fbgemm/Fbgemm.h"

--- a/src/PackWeightsForDirectConv.cc
+++ b/src/PackWeightsForDirectConv.cc
@@ -11,7 +11,6 @@
 
 #if defined(__x86_64__) || defined(__i386__) || \
     (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86)))
-#include <immintrin.h>
 #endif
 #include <cassert>
 
@@ -27,7 +26,6 @@
 #include "./OptimizedKernelsAvx2.h" // @manual
 #include "./RefImplementations.h" // @manual
 #include "./TransposeUtils.h" // @manual
-#include "fbgemm/QuantUtilsAvx512.h"
 namespace fbgemm {
 
 PackedDirectConvMatrix::PackedDirectConvMatrix(


### PR DESCRIPTION
Reviewed By: q10

Differential Revision: D76641862


