### PR TITLE
Fix CQS signal facebook-unused-include-check in fbcode/deeplearning/fbgemm/src [B] [A]

### DIFF
--- a/src/FbgemmI8DepthwisePerChannelQuantAvx2.cc
+++ b/src/FbgemmI8DepthwisePerChannelQuantAvx2.cc
@@ -9,9 +9,6 @@
 #define FBGEMM_EXPORTS
 #include "fbgemm/FbgemmI8DepthwiseAvx2.h"
 
-#include <stdexcept> // for logic_error
-#include <string>
-
 #include "./FbgemmI8Depthwise2DAvx2-inl.h" // @manual
 
 namespace fbgemm {

--- a/src/FbgemmSparseDense.cc
+++ b/src/FbgemmSparseDense.cc
@@ -12,7 +12,6 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
-#include <cstdio>
 #include <cstring>
 #include <memory>
 #include <sstream>

--- a/src/GenerateKernelU8S8S32ACC16Avx512VNNI.cc
+++ b/src/GenerateKernelU8S8S32ACC16Avx512VNNI.cc
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <iostream>
 #include "./GenerateKernel.h" // @manual
 
 namespace fbgemm {

--- a/src/GroupwiseConv.cc
+++ b/src/GroupwiseConv.cc
@@ -12,7 +12,6 @@
 #include <cpuinfo.h>
 #include <array>
 #include <iostream>
-#include <map>
 #include <stdexcept>
 #include <tuple>
 #include <type_traits>


### PR DESCRIPTION
Reviewed By: aelatawy

Differential Revision: D76626790


