### PR TITLE
Remove all imports of <torch/torch.h> from CK extensions

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/bf16_grouped_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/bf16_grouped_gemm.hip
@@ -18,7 +18,6 @@
 
 #include <ATen/ATen.h>
 #include <c10/hip/HIPStream.h>
-#include <torch/torch.h>
 
 #include "ck/ck.hpp"
 #include "ck/tensor_operation/gpu/device/impl/device_grouped_gemm_multiple_d_xdl_cshuffle_tile_loop.hpp"

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_common.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_common.h
@@ -12,7 +12,6 @@
 #else
 #include <c10/cuda/CUDAStream.h>
 #endif
-#include <torch/torch.h>
 
 #include "ck/ck.hpp"
 #include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/ck_utility.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/ck_utility.hip
@@ -16,7 +16,6 @@
 
 #include <ATen/ATen.h>
 #include <c10/hip/HIPStream.h>
-#include <torch/torch.h>
 
 #if defined(USE_ROCM)
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_blockwise_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_blockwise_gemm.hip
@@ -13,7 +13,6 @@
 
 #include <ATen/ATen.h>
 #include <c10/hip/HIPStream.h>
-#include <torch/torch.h>
 
 #include "ck/ck.hpp"
 #include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/fp8_rowwise_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/fp8_rowwise_gemm.hip
@@ -16,7 +16,6 @@
 
 #include <ATen/ATen.h>
 #include <c10/hip/HIPStream.h>
-#include <torch/torch.h>
 
 #include "kernels/fp8_rowwise_kernel_manifest.h"
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/kernels/fp8_rowwise_common.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/kernels/fp8_rowwise_common.h
@@ -14,7 +14,6 @@
 #else
 #include <c10/cuda/CUDAStream.h>
 #endif
-#include <torch/torch.h>
 
 #include "ck/ck.hpp"
 #include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/fp8_rowwise_batched_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/fp8_rowwise_batched_gemm.hip
@@ -16,7 +16,6 @@
 
 #include <ATen/ATen.h>
 #include <c10/hip/HIPStream.h>
-#include <torch/torch.h>
 
 #include "kernels/fp8_rowwise_batched_kernel_manifest.h"
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_common.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_batched/kernels/fp8_rowwise_batched_common.h
@@ -12,7 +12,6 @@
 #else
 #include <c10/cuda/CUDAStream.h>
 #endif
-#include <torch/torch.h>
 
 #include "ck/ck.hpp"
 #include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
@@ -19,7 +19,6 @@
 #include <ATen/ATen.h>
 #include <ATen/hip/HIPContext.h>
 #include <c10/hip/HIPStream.h>
-#include <torch/torch.h>
 
 #include "ck/ck.hpp"
 #include "ck/tensor_operation/gpu/device/impl/device_grouped_gemm_multiple_d_xdl_cshuffle_tile_loop.hpp"

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_common.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_common.h
@@ -12,7 +12,6 @@
 #else
 #include <c10/cuda/CUDAStream.h>
 #endif
-#include <torch/torch.h>
 
 #include "ck/ck.hpp"
 #include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_preshuffle/fp8_rowwise_preshuffle_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_preshuffle/fp8_rowwise_preshuffle_gemm.hip
@@ -16,7 +16,6 @@
 
 #include <ATen/ATen.h>
 #include <c10/hip/HIPStream.h>
-#include <torch/torch.h>
 
 #include "kernels/fp8_rowwise_preshuffle_kernel_manifest.h"
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_preshuffle/kernels/fp8_rowwise_preshuffle_common.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_preshuffle/kernels/fp8_rowwise_preshuffle_common.h
@@ -14,7 +14,6 @@
 #else
 #include <c10/cuda/CUDAStream.h>
 #endif
-#include <torch/torch.h>
 
 #include "ck/ck.hpp"
 #include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_tensorwise_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_tensorwise_gemm.hip
@@ -13,7 +13,6 @@
 
 #include <ATen/ATen.h>
 #include <c10/hip/HIPStream.h>
-#include <torch/torch.h>
 
 #include "ck/ck.hpp"
 #include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1477

As we are starting to integrate FBGEMM GenAI into torch, we ran into this issue.

The problem is that we cannot depend on the libtorch include during the build. It's actually fine to use other things from their own import. In this case, I think we don't actually need it at all?

Differential Revision: D77393016


