### PR TITLE
Add Manifold wrapper (attemp 2)  Part1 Backend

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/utils/filestore.py
+++ b/fbgemm_gpu/fbgemm_gpu/utils/filestore.py
@@ -155,4 +155,53 @@ class FileStore:
             True if file exists, False otherwise.
         """
         filepath = f"{self.bucket}/{path}"
-        return os.path.isfile(filepath)
+        return os.path.exists(filepath)
+
+    def create_directory(self, path: str) -> "FileStore":
+        """
+        Creates a directory in the file store.
+
+        Args:
+            path (str): The path of the node or symlink to a directory (relative
+            to `self.bucket`) to be created.
+
+        Returns:
+            self.  This allows for method-chaining.
+        """
+        filepath = f"{self.bucket}/{path}"
+        event = f"creating directory {filepath}"
+        logger.info(f"FileStore: {event}")
+
+        try:
+            if not os.path.exists(filepath):
+                os.makedirs(filepath, exist_ok=True)
+        except Exception as e:
+            logger.error(f"FileStore: exception occurred when {event}: {e}")
+            raise e
+
+        return self
+
+    def remove_directory(self, path: str) -> "FileStore":
+        """
+        Removes a directory from the file store.
+
+        Args:
+            path (str): The path of the node or symlink to a directory (relative
+            to `self.bucket`) to be removed.
+
+        Returns:
+            self.  This allows for method-chaining.
+        """
+        filepath = f"{self.bucket}/{path}"
+        event = f"deleting {filepath}"
+        logger.info(f"FileStore: {event}")
+
+        try:
+            if os.path.isdir(filepath):
+                os.rmdir(filepath)
+
+        except Exception as e:
+            logger.error(f"Manifold: exception occurred when {event}: {e}")
+            raise e
+
+        return self

--- a/fbgemm_gpu/test/utils/filestore_test.py
+++ b/fbgemm_gpu/test/utils/filestore_test.py
@@ -60,6 +60,41 @@ class FileStoreTest(unittest.TestCase):
         store.remove(path)
         assert not store.exists(path), f"{path} is not removed"
 
+    def _test_filestore_directory(
+        self,
+        # pyre-fixme[2]
+        store,  # FileStore
+        root_dir: Optional[str] = None,
+    ) -> None:
+        """
+        Generic FileStore routines to test creating and removing directories
+
+        Args:
+            store (FileStore): The FileStore to test
+            root_dir (str): The root directory to create
+        """
+        if root_dir is not None:
+            root_dir += "/"
+        else:
+            root_dir = ""
+
+        dir1 = f"{''.join(random.choices(string.ascii_letters, k=15))}"
+        dir2 = f"{''.join(random.choices(string.ascii_letters, k=15))}"
+
+        store.create_directory(f"{root_dir}{dir1}/{dir2}")
+        assert store.exists(
+            f"{root_dir}{dir1}/{dir2}"
+        ), f"Failed creating directories /{dir1}/{dir2}, directoies does not exist"
+
+        store.remove_directory(f"{root_dir}{dir1}/{dir2}")
+        assert not store.exists(
+            f"{root_dir}{dir1}/{dir2}"
+        ), f"Failed removing directories /{dir1}/{dir2}, directory still exists"
+        store.remove_directory(f"{root_dir}{dir1}")
+        assert not store.exists(
+            f"{root_dir}{dir1}"
+        ), f"Failed removing directories /{dir1}, directory still exists"
+
     def test_filestore_oss_bad_bucket(self) -> None:
         """
         Test that OSS FileStore raises ValueError when an invalid bucket is provided
@@ -104,12 +139,20 @@ class FileStoreTest(unittest.TestCase):
 
         self._test_filestore_readwrite(FileStore("/tmp"), Path(infile.name))
 
+    def test_filestore_oss_directory(self) -> None:
+        """
+        Test that OSS FileStore can create and remove directories
+        """
+        from fbgemm_gpu.utils import FileStore
+
+        self._test_filestore_directory(FileStore("/tmp"))
+
     @unittest.skipIf(open_source, "Test does not apply to OSS")
     def test_filestore_fb_bad_bucket(self) -> None:
         """
         Test that FB FileStore raises ValueError when an invalid bucket is provided
         """
-        from fbgemm_gpu.fb.utils import FileStore
+        from fbgemm_gpu.fb.utils.manifold_wrapper import FileStore
 
         self.assertRaises(
             ValueError, FileStore, "".join(random.choices(string.ascii_letters, k=15))
@@ -120,12 +163,12 @@ class FileStoreTest(unittest.TestCase):
         """
         Test that FB FileStore can read and write binary data
         """
-        from fbgemm_gpu.fb.utils import FileStore
+        from fbgemm_gpu.fb.utils.manifold_wrapper import FileStore
 
         self._test_filestore_readwrite(
             FileStore("tlparse_reports"),
             io.BytesIO("".join(random.choices(string.ascii_letters, k=128)).encode()),
-            f"tree/{''.join(random.choices(string.ascii_letters, k=15))}.unittest",
+            f"tree/unit_tests/{''.join(random.choices(string.ascii_letters, k=15))}.unittest",
         )
 
     @unittest.skipIf(open_source, "Test does not apply to OSS")
@@ -133,12 +176,12 @@ class FileStoreTest(unittest.TestCase):
         """
         Test that FB FileStore can read and write tensors
         """
-        from fbgemm_gpu.fb.utils import FileStore
+        from fbgemm_gpu.fb.utils.manifold_wrapper import FileStore
 
         self._test_filestore_readwrite(
             FileStore("tlparse_reports"),
             torch.rand((random.randint(100, 1000), random.randint(100, 1000))),
-            f"tree/{''.join(random.choices(string.ascii_letters, k=15))}.unittest",
+            f"tree/unit_tests/{''.join(random.choices(string.ascii_letters, k=15))}.unittest",
         )
 
     @unittest.skipIf(open_source, "Test does not apply to OSS")
@@ -146,7 +189,7 @@ class FileStoreTest(unittest.TestCase):
         """
         Test that FB FileStore can read and write files
         """
-        from fbgemm_gpu.fb.utils import FileStore
+        from fbgemm_gpu.fb.utils.manifold_wrapper import FileStore
 
         input = torch.rand((random.randint(100, 1000), random.randint(100, 1000)))
         infile = tempfile.NamedTemporaryFile()
@@ -155,5 +198,14 @@ class FileStoreTest(unittest.TestCase):
         self._test_filestore_readwrite(
             FileStore("tlparse_reports"),
             Path(infile.name),
-            f"tree/{''.join(random.choices(string.ascii_letters, k=15))}.unittest",
+            f"tree/unit_tests/{''.join(random.choices(string.ascii_letters, k=15))}.unittest",
         )
+
+    @unittest.skipIf(open_source, "Test does not apply to OSS")
+    def test_filestore_fb_directory(self) -> None:
+        """
+        Test that FB FileStore can create and remove directories
+        """
+        from fbgemm_gpu.fb.utils.manifold_wrapper import FileStore
+
+        self._test_filestore_directory(FileStore("tlparse_reports"), "tree/unit_tests")


### PR DESCRIPTION
Summary:
## Summary
This diff is a second attempt to add Manifold wrapper. The intention for adding manifold wrapper is to unblock reporter integration to TBE forward operation (see D73927918), which failed test (https://www.internalfb.com/intern/test/281475120056413) due to the manifold python library has dependency on C++. The tests expect dependencies to be purely in Python.

This diff add manifold wrapper class is to replace the existing manifold Python library, which includes C++ dependencies that are causing test failures, with a manifold C++ version wrapped in a Torch class. This change aims to resolve the test failures by eliminating the C++ dependencies, ensuring compatibility with tests that expect dependencies to be purely in Python.

---
This diff merged two reverted diffs D76186007, D76603891.
The reversion is due to S532997. The SEV cause is the backend (manifold cpp wrapper) is separately packaged from the frontend. And the frontend get packed before the essential backend exist. 

To re-land the manifold wrapper, ~~this diff separates to two parts backend (cpp) and frontend (py). Then, making sure that backend diff has landed and packed before landing the frontend.~~

To re-land the manifold wrapper, this diff leaves the `utils` untouched. Previous attempt the manifold wrapper was replace the python manifold in `utils`.
In this diff, manifold wrapper was introduced separately in `utils/wrapper`.

Reviewed By: q10

Differential Revision: D77241003


