### PR TITLE
Migrate jagged tensor kernels to `FBGEMM_LAUNCH_KERNEL`, pt 3

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_dense_elementwise_add_jagged_output_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_dense_elementwise_add_jagged_output_forward.cu
@@ -134,52 +134,47 @@ void jagged_dense_dense_elementwise_jagged_output_opt_(
 
           const auto threads_bs = dim3(1024, 1, 1);
           const auto blocks_bs = dim3(div_round_up(nnz, threads_bs.x), 1, 1);
+          FBGEMM_LAUNCH_KERNEL(
+              (jagged_dense_dense_elementwise_jagged_output_opt_search_kernel_<
+                  index_t>),
+              blocks_bs,
+              threads_bs,
+              dynamic_smem_size,
+              at::cuda::getCurrentCUDAStream(),
+              PTA_B((x_offsets[0]), index_t, 1, 32),
+              PTA_B(t_rows_after_bs, int, 1, 32),
+              PTA_B(t_cols_after_bs, int, 1, 32),
+              nnz,
+              B);
 
-#ifdef FBGEMM_GPU_MEMCHECK
-          const auto func_name1 =
-              "jagged_dense_dense_elementwise_jagged_output_opt_search_kernel_";
-#endif
-          jagged_dense_dense_elementwise_jagged_output_opt_search_kernel_<
-              index_t>
-              <<<blocks_bs,
-                 threads_bs,
-                 dynamic_smem_size,
-                 at::cuda::getCurrentCUDAStream()>>>(
-                  MAKE_PTA_WITH_NAME(func_name1, x_offsets[0], index_t, 1, 32),
-                  MAKE_PTA_WITH_NAME(func_name1, t_rows_after_bs, int, 1, 32),
-                  MAKE_PTA_WITH_NAME(func_name1, t_cols_after_bs, int, 1, 32),
-                  nnz,
-                  B);
-          C10_CUDA_KERNEL_LAUNCH_CHECK();
           // Gather kernel
           dim3 threads = dim3(16, 16, 1);
           dim3 blocks = dim3(1, div_round_up(nnz, threads.y), 1);
           if (blocks.y > 65535) {
             blocks.y = 65535;
           }
+          const auto ff = [f] __device__(
+                              __half x, __half y0, __half y1) -> __half {
+            return f(x, y0, y1);
+          };
 
-#ifdef FBGEMM_GPU_MEMCHECK
-          const auto func_name2 =
-              "jagged_dense_dense_elementwise_jagged_output_opt_gather_kernel_";
-#endif
-          jagged_dense_dense_elementwise_jagged_output_opt_gather_kernel_<
-              index_t>
-              <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-                  MAKE_PTA_WITH_NAME(
-                      func_name2, output_values, c10::Half, 2, 32),
-                  MAKE_PTA_WITH_NAME(func_name2, x_values, c10::Half, 2, 32),
-                  MAKE_PTA_WITH_NAME(
-                      func_name2, y_0_reshaped, c10::Half, 3, 32),
-                  MAKE_PTA_WITH_NAME(
-                      func_name2, y_1_reshaped, c10::Half, 3, 32),
-                  MAKE_PTA_WITH_NAME(func_name2, t_rows_after_bs, int, 1, 32),
-                  MAKE_PTA_WITH_NAME(func_name2, t_cols_after_bs, int, 1, 32),
-                  nnz,
-                  E,
-                  [f] __device__(__half x, __half y0, __half y1) -> __half {
-                    return f(x, y0, y1);
-                  });
-          C10_CUDA_KERNEL_LAUNCH_CHECK();
+          FBGEMM_LAUNCH_KERNEL(
+              (jagged_dense_dense_elementwise_jagged_output_opt_gather_kernel_<
+                  index_t,
+                  decltype(ff)>),
+              blocks,
+              threads,
+              0,
+              at::cuda::getCurrentCUDAStream(),
+              PTA_B(output_values, c10::Half, 2, 32),
+              PTA_B(x_values, c10::Half, 2, 32),
+              PTA_B(y_0_reshaped, c10::Half, 3, 32),
+              PTA_B(y_1_reshaped, c10::Half, 3, 32),
+              PTA_B(t_rows_after_bs, int, 1, 32),
+              PTA_B(t_cols_after_bs, int, 1, 32),
+              nnz,
+              E,
+              ff);
         }); // AT_DISPATCH
   } else {
     JAGGED_TENSOR_DISPATCH_DIMS();

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_jagged_bmm_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_jagged_bmm_forward.cu
@@ -209,33 +209,24 @@ Tensor jagged_jagged_bmm_forward_cuda(
           offsets.scalar_type(), "jagged_jagged_bmm_kernel_1", [&] {
             FBGEMM_DISPATCH_FLOATING_TYPES(
                 x_values.scalar_type(), "jagged_jagged_bmm_kernel_2", [&] {
-
-#ifdef FBGEMM_GPU_MEMCHECK
-                  const auto func_name1 = "jagged_jagged_bmm_kernel.1";
-#endif
-
-                  jagged_jagged_bmm_kernel<
-                      BLOCK_TILE_M,
-                      BLOCK_TILE_N,
-                      BLOCK_TILE_K,
-                      THREAD_TILE_M,
-                      THREAD_TILE_N,
-                      index_t,
-                      scalar_t>
-                      <<<grid,
-                         THREADS_PER_BLOCK,
-                         0,
-                         at::cuda::getCurrentCUDAStream()>>>(
-                          MAKE_PTA_WITH_NAME(
-                              func_name1, x_values, scalar_t, 2, 32),
-                          MAKE_PTA_WITH_NAME(
-                              func_name1, y_values, scalar_t, 2, 32),
-                          MAKE_PTA_WITH_NAME(
-                              func_name1, offsets, index_t, 1, 32),
-                          MAKE_PTA_WITH_NAME(
-                              func_name1, output, scalar_t, 3, 32),
-                          (int)max_L);
-                  C10_CUDA_KERNEL_LAUNCH_CHECK();
+                  FBGEMM_LAUNCH_KERNEL(
+                      (jagged_jagged_bmm_kernel<
+                          BLOCK_TILE_M,
+                          BLOCK_TILE_N,
+                          BLOCK_TILE_K,
+                          THREAD_TILE_M,
+                          THREAD_TILE_N,
+                          index_t,
+                          scalar_t>),
+                      grid,
+                      THREADS_PER_BLOCK,
+                      0,
+                      at::cuda::getCurrentCUDAStream(),
+                      PTA_B(x_values, scalar_t, 2, 32),
+                      PTA_B(y_values, scalar_t, 2, 32),
+                      PTA_B(offsets, index_t, 1, 32),
+                      PTA_B(output, scalar_t, 3, 32),
+                      (int)max_L);
                 });
           });
     } else {
@@ -265,33 +256,24 @@ Tensor jagged_jagged_bmm_forward_cuda(
           offsets.scalar_type(), "jagged_jagged_bmm_kernel_1", [&] {
             FBGEMM_DISPATCH_FLOATING_TYPES(
                 x_values.scalar_type(), "jagged_jagged_bmm_kernel_2", [&] {
-
-#ifdef FBGEMM_GPU_MEMCHECK
-                  const auto func_name2 = "jagged_jagged_bmm_kernel.2";
-#endif
-
-                  jagged_jagged_bmm_kernel<
-                      BLOCK_TILE_M,
-                      BLOCK_TILE_N,
-                      BLOCK_TILE_K,
-                      THREAD_TILE_M,
-                      THREAD_TILE_N,
-                      index_t,
-                      scalar_t>
-                      <<<grid,
-                         THREADS_PER_BLOCK,
-                         0,
-                         at::cuda::getCurrentCUDAStream()>>>(
-                          MAKE_PTA_WITH_NAME(
-                              func_name2, x_values, scalar_t, 2, 32),
-                          MAKE_PTA_WITH_NAME(
-                              func_name2, y_values, scalar_t, 2, 32),
-                          MAKE_PTA_WITH_NAME(
-                              func_name2, offsets, index_t, 1, 32),
-                          MAKE_PTA_WITH_NAME(
-                              func_name2, output, scalar_t, 3, 32),
-                          (int)max_L);
-                  C10_CUDA_KERNEL_LAUNCH_CHECK();
+                  FBGEMM_LAUNCH_KERNEL(
+                      (jagged_jagged_bmm_kernel<
+                          BLOCK_TILE_M,
+                          BLOCK_TILE_N,
+                          BLOCK_TILE_K,
+                          THREAD_TILE_M,
+                          THREAD_TILE_N,
+                          index_t,
+                          scalar_t>),
+                      grid,
+                      THREADS_PER_BLOCK,
+                      0,
+                      at::cuda::getCurrentCUDAStream(),
+                      PTA_B(x_values, scalar_t, 2, 32),
+                      PTA_B(y_values, scalar_t, 2, 32),
+                      PTA_B(offsets, index_t, 1, 32),
+                      PTA_B(output, scalar_t, 3, 32),
+                      (int)max_L);
                 });
           });
     }


### PR DESCRIPTION
Summary: - Migrate jagged tensor kernels to `FBGEMM_LAUNCH_KERNEL`, pt 3

Reviewed By: r-barnes

Differential Revision: D75104796


