### PR TITLE
Invoke AMD specific kernel reorder_batched_ad_indices_kernel_vec

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/common.cuh
+++ b/fbgemm_gpu/src/sparse_ops/common.cuh
@@ -32,6 +32,7 @@
 #include "fbgemm_gpu/split_embeddings_utils.cuh"
 #include "fbgemm_gpu/utils/binary_search_range.cuh"
 #include "fbgemm_gpu/utils/dispatch_macros.h"
+#include "fbgemm_gpu/utils/kernel_launcher.cuh"
 #include "fbgemm_gpu/utils/log2.h"
 #include "fbgemm_gpu/utils/tensor_accessor_builder.h"
 


### PR DESCRIPTION
Summary:
For the benchmark in the codebase, the larger the profuct of length and num-ads is, the better performance.

Two optimization:
1. Vector loading in a warp.
2. The product of batch-size and table-size determines the # of thread blocks (https://www.internalfb.com/code/fbsource/[cecfed562b79afad0eb9c44259141f50352da342]/fbcode/deeplearning/fbgemm/fbgemm_gpu/src/sparse_ops/sparse_reorder_batched_ad.cu?lines=361). In MRS models, we expect more thread blocks in our user cases. As such, we shrink the block size to achieve more thread blocks, thus improving compute utilization.

Performance results and local test benchmarks: D77066925

Differential Revision: D77459476


