### PR TITLE
Support get/set the whole row of metaheader+weight+optimizer from backend for checkpoint saving/loading

### DIFF
--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h
@@ -37,6 +37,7 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
       int64_t row_storage_bitwidth = 32,
       const std::optional<at::Tensor>& table_dims = std::nullopt,
       const std::optional<at::Tensor>& hash_size_cumsum = std::nullopt,
+      bool backend_return_whole_row = false,
       bool enable_async_update = false) {
     if (row_storage_bitwidth == 16) {
       impl_ = std::make_shared<kv_mem::DramKVEmbeddingCache<at::Half>>(
@@ -47,6 +48,7 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
           num_shards,
           num_threads,
           row_storage_bitwidth,
+          backend_return_whole_row,
           enable_async_update,
           table_dims,
           hash_size_cumsum);
@@ -59,6 +61,7 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
           num_shards,
           num_threads,
           row_storage_bitwidth,
+          backend_return_whole_row,
           enable_async_update,
           table_dims,
           hash_size_cumsum);

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/fixed_block_pool.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/fixed_block_pool.h
@@ -100,6 +100,12 @@ class FixedBlockPool : public std::pmr::memory_resource {
     return std::max(alignof(FixedBlockPool::MetaHeader), alignof(scalar_t));
   }
 
+  // Get dimension of Metaheader
+  template <typename scalar_t>
+  static size_t get_metaheader_dim() {
+    return sizeof(FixedBlockPool::MetaHeader) / sizeof(scalar_t);
+  }
+
   // Data pointer retrieval
   template <typename scalar_t>
   static scalar_t* data_ptr(scalar_t* block) {
@@ -112,6 +118,22 @@ class FixedBlockPool : public std::pmr::memory_resource {
     return reinterpret_cast<const scalar_t*>(
         reinterpret_cast<const char*>(block) +
         sizeof(FixedBlockPool::MetaHeader));
+  }
+
+  template <typename scalar_t>
+  static scalar_t* ptr_offset_from_front(
+      scalar_t* block,
+      const int64_t offset) {
+    return reinterpret_cast<scalar_t*>(
+        reinterpret_cast<char*>(block) + offset * sizeof(scalar_t));
+  }
+
+  template <typename scalar_t>
+  static const scalar_t* ptr_offset_from_front(
+      const scalar_t* block,
+      const int64_t offset) {
+    return reinterpret_cast<const scalar_t*>(
+        reinterpret_cast<const char*>(block) + offset * sizeof(scalar_t));
   }
 
   template <typename scalar_t>

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
@@ -402,6 +402,16 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
     return max_D_;
   }
 
+  virtual bool get_backend_return_whole_row() {
+    // only DRAM backend can enable this for now
+    return false;
+  }
+
+  virtual int64_t get_metaheader_width_in_front() {
+    // will return non-zero if DRAM enables backend_return_whole_row
+    return 0;
+  }
+
 #ifdef FBGEMM_FBCODE
   folly::coro::Task<void> tensor_stream(
       const at::Tensor& indices,

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
@@ -64,7 +64,8 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
       std::optional<at::Tensor> sorted_indices = std::nullopt,
       int64_t width_offset = 0,
       const std::optional<c10::intrusive_ptr<RocksdbCheckpointHandleWrapper>>
-          checkpoint_handle = std::nullopt);
+          checkpoint_handle = std::nullopt,
+      bool read_only = false);
 
   explicit KVTensorWrapper(const std::string& serialized);
 
@@ -112,7 +113,8 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
 
   std::string serialize() const;
 
-  // ONLY FOR DEBUGGING PURPOSES, Please don't use this function in production
+  // ONLY FOR DEBUGGING PURPOSES, Please don't use this function in
+  // production
   std::string logs() const;
 
   void deserialize(const std::string& serialized);
@@ -150,6 +152,7 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
   int64_t num_threads{};
   int64_t max_D{};
   std::string checkpoint_uuid;
+  bool read_only_{};
 };
 
 void to_json(json& j, const KVTensorWrapper& kvt);

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper_cpu.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper_cpu.cpp
@@ -37,7 +37,8 @@ KVTensorWrapper::KVTensorWrapper(
     [[maybe_unused]] const std::optional<at::Tensor> sorted_indices,
     [[maybe_unused]] int64_t width_offset,
     [[maybe_unused]] const std::optional<
-        c10::intrusive_ptr<RocksdbCheckpointHandleWrapper>>)
+        c10::intrusive_ptr<RocksdbCheckpointHandleWrapper>>,
+    [[maybe_unused]] bool read_only)
     // @lint-ignore CLANGTIDY clang-diagnostic-missing-noreturn
     : shape_(std::move(shape)), row_offset_(row_offset) {
   FBEXCEPTION("Not implemented");

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -356,11 +356,13 @@ KVTensorWrapper::KVTensorWrapper(
     std::optional<at::Tensor> sorted_indices,
     int64_t width_offset_,
     const std::optional<c10::intrusive_ptr<RocksdbCheckpointHandleWrapper>>
-        checkpoint_handle)
+        checkpoint_handle,
+    bool read_only)
     : db_(nullptr),
       shape_(std::move(shape)),
       row_offset_(row_offset),
-      width_offset_(width_offset_) {
+      width_offset_(width_offset_),
+      read_only_(read_only) {
   CHECK_GE(width_offset_, 0);
   CHECK_EQ(shape_.size(), 2) << "Only 2D emb tensors are supported";
   options_ = at::TensorOptions()
@@ -480,7 +482,8 @@ at::Tensor KVTensorWrapper::narrow(int64_t dim, int64_t start, int64_t length) {
   CHECK_EQ(dim, 0) << "Only narrow on dim 0 is supported";
   if (db_) {
     CHECK_TRUE(db_ != nullptr);
-    CHECK_GE(db_->get_max_D(), shape_[1]);
+    CHECK_GE(
+        db_->get_max_D() + db_->get_metaheader_width_in_front(), shape_[1]);
     TORCH_CHECK(
         (snapshot_handle_ == nullptr) ==
             (std::dynamic_pointer_cast<EmbeddingRocksDB>(db_).get() == nullptr),
@@ -521,14 +524,19 @@ void KVTensorWrapper::set_range(
     const int64_t start,
     const int64_t length,
     const at::Tensor& weights) {
+  if (read_only_) {
+    XLOG(INFO) << "KVTensorWrapper is read only, set_range() is no-op";
+    return;
+  }
   // Mutex lock for disabling concurrent writes to the same KVTensor
   std::lock_guard<std::mutex> lock(mtx);
   CHECK_EQ(weights.device(), at::kCPU);
   CHECK(db_) << "EmbeddingRocksDB must be a valid pointer to call set_range";
   CHECK_EQ(dim, 0) << "Only set_range on dim 0 is supported";
   CHECK_TRUE(db_ != nullptr);
-  CHECK_GE(db_->get_max_D(), shape_[1]);
-  int pad_right = db_->get_max_D() - weights.size(1);
+  CHECK_GE(db_->get_max_D() + db_->get_metaheader_width_in_front(), shape_[1]);
+  int pad_right =
+      db_->get_max_D() + db_->get_metaheader_width_in_front() - weights.size(1);
   if (pad_right == 0) {
     db_->set_range_to_storage(weights, start + row_offset_, length);
   } else {
@@ -542,6 +550,11 @@ void KVTensorWrapper::set_range(
 void KVTensorWrapper::set_weights_and_ids(
     const at::Tensor& weights,
     const at::Tensor& ids) {
+  if (read_only_) {
+    XLOG(INFO)
+        << "KVTensorWrapper is read only, set_weights_and_ids() is no-op";
+    return;
+  }
   CHECK_EQ(weights.device(), at::kCPU);
   CHECK_TRUE(db_ != nullptr);
   CHECK_EQ(ids.size(0), weights.size(0))
@@ -614,8 +627,10 @@ void from_json(const ssd::json& j, KVTensorWrapper& kvt) {
 
 at::Tensor KVTensorWrapper::get_weights_by_ids(const at::Tensor& ids) {
   CHECK_TRUE(db_ != nullptr);
-  CHECK_GE(db_->get_max_D(), shape_[1]);
-  CHECK_GE(db_->get_max_D(), shape_[1] + width_offset_);
+  CHECK_GE(db_->get_max_D() + db_->get_metaheader_width_in_front(), shape_[1]);
+  CHECK_GE(
+      db_->get_max_D() + db_->get_metaheader_width_in_front(),
+      shape_[1] + width_offset_);
   TORCH_CHECK(
       (snapshot_handle_ == nullptr) ==
           (std::dynamic_pointer_cast<EmbeddingRocksDB>(db_).get() == nullptr),
@@ -851,6 +866,7 @@ static auto dram_kv_embedding_cache_wrapper =
                 int64_t,
                 std::optional<at::Tensor>,
                 std::optional<at::Tensor>,
+                bool,
                 bool>(),
             "",
             {
@@ -863,6 +879,7 @@ static auto dram_kv_embedding_cache_wrapper =
                 torch::arg("row_storage_bitwidth") = 32,
                 torch::arg("table_dims") = std::nullopt,
                 torch::arg("hash_size_cumsum") = std::nullopt,
+                torch::arg("backend_return_whole_row") = false,
                 torch::arg("enable_async_update") = false,
             })
         .def(
@@ -948,7 +965,8 @@ static auto kv_tensor_wrapper =
                 std::optional<at::Tensor>,
                 int64_t,
                 std::optional<
-                    c10::intrusive_ptr<RocksdbCheckpointHandleWrapper>>>(),
+                    c10::intrusive_ptr<RocksdbCheckpointHandleWrapper>>,
+                bool>(),
             "",
             {torch::arg("shape"),
              torch::arg("dtype"),
@@ -958,7 +976,8 @@ static auto kv_tensor_wrapper =
              torch::arg("snapshot_handle") = std::nullopt,
              torch::arg("sorted_indices") = std::nullopt,
              torch::arg("width_offset") = 0,
-             torch::arg("checkpoint_handle") = std::nullopt})
+             torch::arg("checkpoint_handle") = std::nullopt,
+             torch::arg("read_only") = false})
         .def(
             "set_embedding_rocks_dp_wrapper",
             &KVTensorWrapper::set_embedding_rocks_dp_wrapper,


### PR DESCRIPTION
Summary:
# Context
In our current KVZCH cp loading flow, we will keep hold of weight_id, weight, optimizer tensors throughout the checkpoint loading lifecycle, and at the end when all these tensors are downloaded in hand, we will explicitly call "apply_state_dict" to actually write them by chunk to the backend to ensure id->weight and id->opt are mapped correctly. The problem is when we have large number of weights, we will be short of memory since we need to hold all 3 tensors (double memory issue). To solve this challenge, we are going to save the whole row of (metaheader + weight + opt) as the same "weight" tensor during checkpoint saving, and when downloading the checkpoint, we will be able to extract the id from the header, and directly write the weight+opt part to the backend by id. When loading cp for optimizer, we added a no-op KVTensor, so it won't need to write to backend for optimizer states again.

# This diff
* added `backend_return_whole_row` flag in KVZCH params, with validation to make sure it's only True when opt_offloading is used
* added `read_only_` flag in KVTensorWrapper to be used for checkpoint calls. When read-only=True, all write operations to this KVT will be no-op
* added metadata recalc for optimizer state dict, because we are now returning read-only KVT for opt state dict, and model store will need to correct the global metadata before creating the save plan for KVZCH opt tensors
* updated dram backend and mem pool, so it can return the metaheader + weight + optimizer_state together, as well as set them back to backend (use pointers to skip metaheader part when write weight+opt to backend)
* by default the opt offloading and return whole row is False on trunk, so should not break existing KVZCH runs

Differential Revision:
D77604158

Privacy Context Container: L1138451


