### PR TITLE
Use static functions/variables if possible (#4423)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,8 +4,10 @@
 # Get options for config files in parent directories,
 # but override them if there's a conflict.
 InheritParentConfig: true
+# @nolint
 Checks: '
 bugprone-argument-comment,
+misc-use-internal-linkage,
 '
 CheckOptions:
  - key: facebook-cuda-safe-api-call-check.HandlerName

--- a/bench/BenchUtils.cc
+++ b/bench/BenchUtils.cc
@@ -19,7 +19,7 @@
 
 namespace fbgemm {
 
-std::default_random_engine eng;
+static std::default_random_engine eng;
 
 template <typename T>
 void randFill(aligned_vector<T>& vec, T low, T high, std::true_type) {

--- a/bench/ConvUnifiedBenchmark.cc
+++ b/bench/ConvUnifiedBenchmark.cc
@@ -28,7 +28,7 @@ using namespace fbgemm;
 
 // clang-format off
 // 1D conv shapes
-vector<conv_param_t<1>> shapes_1d = {
+static vector<conv_param_t<1>> shapes_1d = {
   // MB, IC, OC, IW, G, KW, stride_w, pad_w_left, pad_w_right,
   // (dilation, output_padding_w, tranpose)
   // regular
@@ -46,7 +46,7 @@ vector<conv_param_t<1>> shapes_1d = {
 };
 
 // 2D conv shapes
-vector<conv_param_t<2>> shapes_2d = {
+static vector<conv_param_t<2>> shapes_2d = {
   // MB, IC, OC, IH, IW, G, KH, KW, stride_h, stride_w,
   // pad_h_top, pad_w_left, pad_h_bottom, pad_w_right,
   // (dilation_h, dilation_w, output_padding_h, output_padding_w, tranpose)
@@ -84,7 +84,7 @@ vector<conv_param_t<2>> shapes_2d = {
       {1, 1}, {0, 0, 0, 0})
 };
 
-vector<conv_param_t<2>> shapes_2d_resnext_101 = {
+static vector<conv_param_t<2>> shapes_2d_resnext_101 = {
   // ResNext-101 (unique shapes only)
   // conv_param_t<>(N, C, M, H, W, groups, /* kern */ {KH, KW}, /* stride */
   //   {stride_h, stride_w}, /* padding pad_l = pad_h */ {pad_l, pad_l, pad_l, pad_l}, /* dialation */
@@ -143,7 +143,7 @@ vector<conv_param_t<2>> shapes_2d_resnext_101 = {
 };
 
 // 3D conv shapes
-vector<conv_param_t<3>> shapes_3d = {
+static vector<conv_param_t<3>> shapes_3d = {
   // MB, IC, OC, {IT, IH, IW}, G, {KT, KH, KW}, {stride_t, stride_h,
   // stride_w},
   // {pad_prev, pad_h_top, pad_w_left, pad_next, pad_h_bottom, pad_w_right},
@@ -216,7 +216,7 @@ vector<conv_param_t<3>> shapes_3d = {
 // clang-format on
 
 template <int SPATIAL_DIM, typename Acc_t>
-void performance_test(
+static void performance_test(
     const vector<conv_param_t<SPATIAL_DIM>>& shapes,
     bool flush,
     int repetitions) {

--- a/bench/ConvertBenchmark.cc
+++ b/bench/ConvertBenchmark.cc
@@ -21,7 +21,7 @@
 using namespace std;
 using namespace fbgemm;
 
-void performance_test() {
+static void performance_test() {
   constexpr int NWARMUP = 4;
   constexpr int NITER = 256;
 

--- a/bench/EmbeddingIndexRemappingBenchmark.cc
+++ b/bench/EmbeddingIndexRemappingBenchmark.cc
@@ -37,7 +37,7 @@ static vector<vector<int>> GetInputs_() {
   return input_dims;
 }
 
-int run_benchmark(
+static int run_benchmark(
     int batch_size,
     int num_rows,
     int average_len,

--- a/bench/EmbeddingQuantizeBenchmark.cc
+++ b/bench/EmbeddingQuantizeBenchmark.cc
@@ -25,7 +25,7 @@ using namespace fbgemm;
 
 // T is the type of scale and bias
 template <typename T>
-void performance_test() {
+static void performance_test() {
   constexpr int NWARMUP = 4;
   constexpr int NITER = 256;
 

--- a/bench/EmbeddingQuantizeFloatToFloatOrHalfBenchmark.cc
+++ b/bench/EmbeddingQuantizeFloatToFloatOrHalfBenchmark.cc
@@ -25,7 +25,7 @@ using namespace fbgemm;
 
 // T is the type of scale and bias
 template <typename T>
-void performance_test() {
+static void performance_test() {
   constexpr int NWARMUP = 4;
   constexpr int NITER = 256;
 

--- a/bench/EmbeddingSpMDM8BitBenchmark.cc
+++ b/bench/EmbeddingSpMDM8BitBenchmark.cc
@@ -30,15 +30,16 @@
 using namespace std;
 using namespace fbgemm;
 
-void print_fused_table(int rows, int embedding_dim, const uint8_t* table) {
-  for (int i = 0; i < rows; i++) {
-    cout << "row: " << i << " : " << endl;
-    for (int ii = 0; ii < embedding_dim; ii++) {
-      cout << (int)table[i * (embedding_dim + 2 * sizeof(float)) + ii] << ",";
+/*
+static void print_fused_table(int rows, int embedding_dim, const uint8_t* table)
+{ for (int i = 0; i < rows; i++) { cout << "row: " << i << " : " << endl; for
+(int ii = 0; ii < embedding_dim; ii++) { cout << (int)table[i * (embedding_dim +
+2 * sizeof(float)) + ii] << ",";
     }
     cout << endl;
   }
 }
+*/
 
 static vector<vector<int>> GetInputs_() {
   vector<vector<int>> input_dims = {
@@ -58,10 +59,10 @@ static vector<vector<int>> GetInputs_() {
   return input_dims;
 }
 
-vector<double> benchmarkTimes;
+static vector<double> benchmarkTimes;
 
 template <typename OutType>
-int run_benchmark(
+static int run_benchmark(
     int batch_size,
     int num_rows,
     int embedding_dim,

--- a/bench/EmbeddingSpMDMBenchmark.cc
+++ b/bench/EmbeddingSpMDMBenchmark.cc
@@ -49,7 +49,7 @@ static vector<vector<int>> GetInputs_() {
   return input_dims;
 }
 
-void run_benchmark(
+static void run_benchmark(
     int batch_size,
     int num_rows,
     int embedding_dim,

--- a/bench/EmbeddingSpMDMNBit2Benchmark.cc
+++ b/bench/EmbeddingSpMDMNBit2Benchmark.cc
@@ -171,17 +171,6 @@ static void print_benchmark_results() {
   }
 }
 
-void print_fused_table(int rows, int embedding_dim, const uint8_t* table) {
-  for (int i = 0; i < rows; i++) {
-    std::cout << "row: " << i << " : " << std::endl;
-    for (int ii = 0; ii < embedding_dim; ii++) {
-      std::cout << (int)table[i * (embedding_dim + 2 * sizeof(float)) + ii]
-                << ",";
-    }
-    std::cout << std::endl;
-  }
-}
-
 static vector<vector<int>> GetInputs_() {
   vector<vector<int>> input_dims = {
       // batch size, number of rows of table, emb dim , avg lengthl
@@ -200,7 +189,7 @@ static vector<vector<int>> GetInputs_() {
   return input_dims;
 }
 
-int run_benchmark(
+static int run_benchmark(
     int bit_rate,
     int batch_size,
     int num_rows,
@@ -488,7 +477,7 @@ int run_benchmark(
   return 0;
 }
 
-void sweep_benchmark(KernelType kern_type) {
+static void sweep_benchmark(KernelType kern_type) {
   int batch_size;
   int num_rows;
   int embedding_dim;

--- a/bench/EmbeddingSpMDMNBitBenchmark.cc
+++ b/bench/EmbeddingSpMDMNBitBenchmark.cc
@@ -32,16 +32,17 @@
 using namespace std;
 using namespace fbgemm;
 
-void print_fused_table(int rows, int embedding_dim, const uint8_t* table) {
-  for (int i = 0; i < rows; i++) {
-    std::cout << "row: " << i << " : " << std::endl;
-    for (int ii = 0; ii < embedding_dim; ii++) {
-      std::cout << (int)table[i * (embedding_dim + 2 * sizeof(float)) + ii]
+/*
+static void print_fused_table(int rows, int embedding_dim, const uint8_t* table)
+{ for (int i = 0; i < rows; i++) { std::cout << "row: " << i << " : " <<
+std::endl; for (int ii = 0; ii < embedding_dim; ii++) { std::cout <<
+(int)table[i * (embedding_dim + 2 * sizeof(float)) + ii]
                 << ",";
     }
     std::cout << std::endl;
   }
 }
+*/
 
 static vector<vector<int>> GetInputs_() {
   vector<vector<int>> input_dims = {
@@ -62,7 +63,7 @@ static vector<vector<int>> GetInputs_() {
 }
 
 template <typename OutType>
-int run_benchmark(
+static int run_benchmark(
     int bit_rate,
     int batch_size,
     int num_rows,

--- a/bench/EmbeddingSpMDMNBitRowWiseSparseBenchmark.cc
+++ b/bench/EmbeddingSpMDMNBitRowWiseSparseBenchmark.cc
@@ -31,16 +31,17 @@
 using namespace std;
 using namespace fbgemm;
 
-void print_fused_table(int rows, int embedding_dim, const uint8_t* table) {
-  for (int i = 0; i < rows; i++) {
-    std::cout << "row: " << i << " : " << std::endl;
-    for (int ii = 0; ii < embedding_dim; ii++) {
-      std::cout << (int)table[i * (embedding_dim + 2 * sizeof(float)) + ii]
+/*
+static void print_fused_table(int rows, int embedding_dim, const uint8_t* table)
+{ for (int i = 0; i < rows; i++) { std::cout << "row: " << i << " : " <<
+std::endl; for (int ii = 0; ii < embedding_dim; ii++) { std::cout <<
+(int)table[i * (embedding_dim + 2 * sizeof(float)) + ii]
                 << ",";
     }
     std::cout << std::endl;
   }
 }
+*/
 
 static vector<vector<int>> GetInputs_() {
   vector<vector<int>> input_dims = {
@@ -60,7 +61,7 @@ static vector<vector<int>> GetInputs_() {
   return input_dims;
 }
 
-int run_benchmark(
+static int run_benchmark(
     int bit_rate,
     int batch_size,
     int num_rows,

--- a/bench/GEMMsBenchmark.cc
+++ b/bench/GEMMsBenchmark.cc
@@ -29,11 +29,8 @@
 using namespace std;
 using namespace fbgemm;
 
-void performance_test(
-    const int M,
-    const int N,
-    const int K,
-    const bool timebreak) {
+static void
+performance_test(const int M, const int N, const int K, const bool timebreak) {
   // clang-format off
   const vector<vector<int>> shapes = {
     // NOTE: clang-format wants to use a different formatting but the current

--- a/bench/GEMMsTunableBenchmark.cc
+++ b/bench/GEMMsTunableBenchmark.cc
@@ -27,7 +27,7 @@
 using namespace std;
 using namespace fbgemm;
 
-void performance_test(
+static void performance_test(
     const BlockingFactors* tuning_params,
     set<vector<int>>& incorrect_configs,
     const vector<int>& shape,

--- a/bench/GroupwiseConvRequantizeBenchmark.cc
+++ b/bench/GroupwiseConvRequantizeBenchmark.cc
@@ -25,7 +25,7 @@
 using namespace std;
 using namespace fbgemm;
 
-void performance_test() {
+static void performance_test() {
   // clang-format off
   const vector<conv_param_t<>> shapes = {
     // MB, IC, OC, {IH, IW}, G, {KH, KW}, {stride_h, stride_w}, pad_t, pad_l,

--- a/bench/Im2ColFusedRequantizeBenchmark.cc
+++ b/bench/Im2ColFusedRequantizeBenchmark.cc
@@ -26,7 +26,7 @@ using namespace std;
 using namespace fbgemm;
 
 template <typename Acc_t>
-void performance_test() {
+static void performance_test() {
   vector<conv_param_t<>> shapes = {
       // MB, IC, OC, IH, IW, G, KH, KW, stride_h, stride_w,
       // pad_h_top, pad_w_left, pad_h_bottom, pad_w_right

--- a/bench/PackedFloatInOutBenchmark.cc
+++ b/bench/PackedFloatInOutBenchmark.cc
@@ -29,7 +29,7 @@
 using namespace std;
 using namespace fbgemm;
 
-void performance_test() {
+static void performance_test() {
   // clang-format off
   const vector<vector<int>> shapes = {
     // NOTE: clang-format wants to use a different formatting but the current

--- a/bench/PackedRequantizeAcc16Benchmark.cc
+++ b/bench/PackedRequantizeAcc16Benchmark.cc
@@ -38,7 +38,7 @@ enum class BenchmarkType {
   EVERYTHING, // row-offset in input packing, and requantization + spmdm
 };
 
-void performance_test() {
+static void performance_test() {
   // clang-format off
   vector<vector<int>> shapes = {
     // NOTE: clang-format wants to use a different formatting but the current

--- a/bench/PackedRequantizeAcc32Benchmark.cc
+++ b/bench/PackedRequantizeAcc32Benchmark.cc
@@ -29,7 +29,7 @@
 using namespace std;
 using namespace fbgemm;
 
-void performance_test() {
+static void performance_test() {
   // clang-format off
   vector<vector<int>> shapes = {
     // NOTE: clang-format wants to use a different formatting but the current

--- a/bench/RequantizeBenchmark.cc
+++ b/bench/RequantizeBenchmark.cc
@@ -29,7 +29,7 @@ enum class BenchmarkType {
   PER_CHANNEL,
 };
 
-void performance_test() {
+static void performance_test() {
   constexpr int NWARMUP = 4;
   constexpr int NITER = 256;
 

--- a/bench/RowOffsetBenchmark.cc
+++ b/bench/RowOffsetBenchmark.cc
@@ -22,7 +22,7 @@
 using namespace std;
 using namespace fbgemm;
 
-void performance_test() {
+static void performance_test() {
   constexpr int NWARMUP = 4;
   constexpr int NITER = 256;
 

--- a/bench/RowwiseAdagradBenchmark.cc
+++ b/bench/RowwiseAdagradBenchmark.cc
@@ -36,9 +36,9 @@ static vector<vector<int>> GetInputs_() {
   return input_dims;
 }
 
-vector<int> prefetch_distances{16};
+static vector<int> prefetch_distances{16};
 
-void run_benchmark(
+static void run_benchmark(
     const int num_rows, // number of rows reading
     const int block_size, // number of parameters per row
     const uint64_t param_size, // total number of parameters

--- a/bench/RowwiseAdagradFusedBenchmark.cc
+++ b/bench/RowwiseAdagradFusedBenchmark.cc
@@ -42,7 +42,7 @@ static vector<vector<int>> GetInputs_() {
   return input_dims;
 }
 
-void run_benchmark(
+static void run_benchmark(
     int batch_size,
     int num_rows,
     int embedding_dim,

--- a/bench/SparseAdagradBenchmark.cc
+++ b/bench/SparseAdagradBenchmark.cc
@@ -40,7 +40,7 @@ static vector<vector<int>> GetInputs_() {
   return input_dims;
 }
 
-void run_benchmark(
+static void run_benchmark(
     const int num_rows, // number of rows reading
     const int block_size, // number of parameters per row
     const uint64_t param_size, // total number of parameters

--- a/bench/TransposeBenchmark.cc
+++ b/bench/TransposeBenchmark.cc
@@ -21,7 +21,7 @@ using namespace std;
 using namespace fbgemm;
 
 template <typename T>
-void performance_test() {
+static void performance_test() {
   constexpr int NWARMUP = 4;
   constexpr int NITER = 256;
 

--- a/src/FbgemmConv.cc
+++ b/src/FbgemmConv.cc
@@ -64,12 +64,12 @@ bool takePointWiseFastPath(const conv_param_t<SPATIAL_DIM>& conv_p) {
 }
 
 template <int SPATIAL_DIM>
-bool take1DFastPath(const conv_param_t<SPATIAL_DIM>& conv_p) {
+static bool take1DFastPath(const conv_param_t<SPATIAL_DIM>& conv_p) {
   return false && !conv_p.transposed;
 }
 
 template <int SPATIAL_DIM, typename ACC_T>
-bool takeDirectConvPath(const conv_param_t<SPATIAL_DIM>& conv_p) {
+static bool takeDirectConvPath(const conv_param_t<SPATIAL_DIM>& conv_p) {
   // Note: Direct convolutions (2D) are optimized for
   // filter size: 2 x 1 to 2 x 6,  transposed conv,
   // in_channel % 8 == 0, out_channel % 8 == 0

--- a/src/GroupwiseConv.cc
+++ b/src/GroupwiseConv.cc
@@ -27,7 +27,7 @@ namespace fbgemm {
 using namespace std;
 
 template <int SPATIAL_DIM>
-void calculateRowOffsets(
+static void calculateRowOffsets(
     const conv_param_t<SPATIAL_DIM>& conv_param,
     const uint8_t* activations,
     int32_t* rowOffsetBuf,
@@ -67,7 +67,7 @@ void calculateRowOffsets(
 }
 
 template <int SPATIAL_DIM = 2>
-kernel_sig_t getKernelSig(
+static kernel_sig_t getKernelSig(
     const conv_param_t<SPATIAL_DIM>& conv_param,
     bool isAZeroPointZero,
     bool needRowOffset,
@@ -104,7 +104,7 @@ kernel_sig_t getKernelSig(
 }
 
 template <int SPATIAL_DIM = 2>
-jit_conv_kernel_fp getOrCreateConvKernel(
+static jit_conv_kernel_fp getOrCreateConvKernel(
     const conv_param_t<SPATIAL_DIM>& conv_param,
     int a_zero_point,
     bool needRowOffset,
@@ -808,7 +808,7 @@ void fbgemmGroupwiseConv(
  * This function does exactly the same compute as the JIT'ed kernel
  */
 template <int SPATIAL_DIM>
-void kernel_compute(
+static void kernel_compute(
     const conv_param_t<SPATIAL_DIM>& conv_p,
     const uint8_t* in_acts,
     int8_t* wghts,
@@ -879,7 +879,7 @@ void kernel_compute(
 }
 
 template <typename processOutputType, typename outT, typename inT>
-void dispatchOutputProcessing(
+static void dispatchOutputProcessing(
     const processOutputType& outProcess,
     int32_t* rowOffsetBuf,
     outT* out,

--- a/src/PackAWithIm2Col.cc
+++ b/src/PackAWithIm2Col.cc
@@ -123,7 +123,7 @@ PackAWithIm2Col<T, accT, SPATIAL_DIM>::PackAWithIm2Col(
 }
 
 template <int SPATIAL_DIM, int BCOL>
-void pack_a_with_im2col_opt(
+static void pack_a_with_im2col_opt(
     const conv_param_t<SPATIAL_DIM>& conv_p,
     const block_type_t& block,
     const uint8_t* sdata,

--- a/src/PackWeightsForDirectConv.cc
+++ b/src/PackWeightsForDirectConv.cc
@@ -161,7 +161,7 @@ PackedDirectConvMatrix::col_offsets_with_zero_pt_s8acc32_DirectConvT<3>(
     int ncols_per_quant_group);
 
 template <int SPATIAL_DIM>
-void directConvRowSum(
+static void directConvRowSum(
     const conv_param_t<SPATIAL_DIM>& conv_p,
     const uint8_t* A,
     int32_t* inSum,

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -33,7 +33,7 @@ using fint32 = union {
 //
 // Return a random 32bit integer using xoshiro128++
 // http://prng.di.unimi.it/xoshiro128plusplus.c
-inline uint32_t rnd128_next(int idx, int vlen) {
+static inline uint32_t rnd128_next(int idx, int vlen) {
   constexpr int VLEN_MAX = 16; // max vector size
   alignas(64) static thread_local uint32_t g_rnd128_buffer[4 * VLEN_MAX];
   static thread_local bool g_rnd128_initialized = false;

--- a/src/UtilsAvx512.cc
+++ b/src/UtilsAvx512.cc
@@ -1485,7 +1485,7 @@ static inline void transpose_contiguous_32x2_block(
 }
 
 template <bool MREM = false, bool NREM = false>
-void transpose_16x16_block(
+static void transpose_16x16_block(
     const uint16_t* src,
     int64_t ld_src,
     uint16_t* dst,
@@ -1611,7 +1611,7 @@ void transpose_16x16_block(
 }
 
 template <bool MREM = false, bool NREM = false>
-void transpose_16x32_block(
+static void transpose_16x32_block(
     const uint8_t* src,
     int64_t ld_src,
     uint8_t* dst,

--- a/test/EmbeddingSpMDM8BitTest.cc
+++ b/test/EmbeddingSpMDM8BitTest.cc
@@ -46,7 +46,7 @@ static vector<vector<int>> GetInputs_() {
   return input_dims;
 }
 
-vector<int> prefetch_distances{0, 16, 1000000};
+static vector<int> prefetch_distances{0, 16, 1000000};
 
 namespace {
 

--- a/test/EmbeddingSpMDMNBitTest.cc
+++ b/test/EmbeddingSpMDMNBitTest.cc
@@ -49,7 +49,7 @@ static vector<vector<int>> GetInputs_() {
   return input_dims;
 }
 
-vector<int> prefetch_distances{0, 16, 1000000};
+static vector<int> prefetch_distances{0, 16, 1000000};
 
 namespace {
 

--- a/test/EmbeddingSpMDMTest.cc
+++ b/test/EmbeddingSpMDMTest.cc
@@ -64,7 +64,7 @@ class IndexRemapTest
     : public testing::TestWithParam<tuple<int, int, int, bool, bool>> {};
 } // namespace
 
-vector<int> prefetch_distances = {0, 16, 1000000};
+static vector<int> prefetch_distances = {0, 16, 1000000};
 
 INSTANTIATE_TEST_CASE_P(
     InstantiationName,

--- a/test/GConvTest.cc
+++ b/test/GConvTest.cc
@@ -27,11 +27,11 @@
 using namespace std;
 using namespace fbgemm;
 
-vector<matrix_op_t> transposeVals{
+static vector<matrix_op_t> transposeVals{
     matrix_op_t::NoTranspose,
     matrix_op_t::Transpose};
 
-vector<QuantizationGranularity> qGranularityVals{
+static vector<QuantizationGranularity> qGranularityVals{
     QuantizationGranularity::TENSOR,
     QuantizationGranularity::GROUP,
     QuantizationGranularity::OUT_CHANNEL};
@@ -269,7 +269,7 @@ GetShapes_() {
  * accumulation. Output processing: requantization -> nothing
  */
 template <int SPATIAL_DIM = 2>
-void runRequantizeTest(matrix_op_t /* unused */,
+static void runRequantizeTest(matrix_op_t /* unused */,
     matrix_op_t btrans,
     QuantizationGranularity q_granularity,
     bool a_symmetric, bool b_symmetric) {
@@ -591,7 +591,7 @@ TEST_P(fbgemmGConvAcc32Test, NoRequantizeTest) {
 */
 
 template <int SPATIAL_DIM = 2>
-void runPackUnpackTest(matrix_op_t btrans) {
+static void runPackUnpackTest(matrix_op_t btrans) {
   vector<conv_param_t<SPATIAL_DIM>> shapes(GetShapes_<SPATIAL_DIM>());
 
   for (auto conv_p : shapes) {

--- a/test/I8SpmdmTest.cc
+++ b/test/I8SpmdmTest.cc
@@ -27,7 +27,7 @@
 using namespace std;
 using namespace fbgemm;
 
-std::vector<float> densities{0.0001f, 0.001f, 0.01f, 0.1f, 1.0f};
+static std::vector<float> densities{0.0001f, 0.001f, 0.01f, 0.1f, 1.0f};
 
 namespace {
 class fbgemmSPMDMTest

--- a/test/Im2ColFusedRequantizeTest.cc
+++ b/test/Im2ColFusedRequantizeTest.cc
@@ -26,7 +26,7 @@
 using namespace std;
 using namespace fbgemm;
 
-vector<QuantizationGranularity> qGranularityVals{
+static vector<QuantizationGranularity> qGranularityVals{
     QuantizationGranularity::TENSOR,
     QuantizationGranularity::GROUP,
     QuantizationGranularity::OUT_CHANNEL};
@@ -262,7 +262,7 @@ TEST_P(fbgemmIm2colTest, Acc16Test) {
 }
 
 template <QuantizationGranularity Q_GRAN>
-void SConvTest() {
+static void SConvTest() {
   for (auto conv_p : shapes) {
     for (int groups : {1, 4}) {
       if (conv_p.IC % groups != 0 || conv_p.OC % groups != 0) {

--- a/test/PackedRequantizeAcc16Test.cc
+++ b/test/PackedRequantizeAcc16Test.cc
@@ -29,11 +29,11 @@
 using namespace std;
 using namespace fbgemm;
 
-vector<matrix_op_t> transposeVals{
+static vector<matrix_op_t> transposeVals{
     matrix_op_t::NoTranspose,
     matrix_op_t::Transpose};
 
-vector<QuantizationGranularity> qGranularityVals{
+static vector<QuantizationGranularity> qGranularityVals{
     QuantizationGranularity::TENSOR,
     QuantizationGranularity::GROUP,
     QuantizationGranularity::OUT_CHANNEL};

--- a/test/PackedRequantizeTest.cc
+++ b/test/PackedRequantizeTest.cc
@@ -28,11 +28,11 @@
 using namespace std;
 using namespace fbgemm;
 
-vector<matrix_op_t> transposeVals{
+static vector<matrix_op_t> transposeVals{
     matrix_op_t::NoTranspose,
     matrix_op_t::Transpose};
 
-vector<QuantizationGranularity> qGranularityVals{
+static vector<QuantizationGranularity> qGranularityVals{
     QuantizationGranularity::TENSOR,
     QuantizationGranularity::GROUP,
     QuantizationGranularity::OUT_CHANNEL};

--- a/test/QuantUtilsTest.cc
+++ b/test/QuantUtilsTest.cc
@@ -76,7 +76,7 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::ValuesIn({1, 2, 5, 8, 9, 16, 20, 28, 32, 33, 64, 65})));
 
 template <typename T, layout_t LT>
-void ref_impl(
+static void ref_impl(
     const vector<float>& src,
     int K,
     int C,
@@ -111,7 +111,7 @@ void ref_impl(
 }
 
 template <typename T, layout_t LT>
-void runTests(
+static void runTests(
     const vector<float>& src,
     int K,
     int C,
@@ -134,7 +134,7 @@ void runTests(
  * while comparing results.
  */
 template <typename T>
-::testing::AssertionResult isNear(
+static ::testing::AssertionResult isNear(
     const vector<T>& res,
     const vector<T>& res_ref) {
   bool match = true;
@@ -154,7 +154,7 @@ template <typename T>
 }
 
 template <typename T>
-::testing::AssertionResult isQEmbeddingClose(
+static ::testing::AssertionResult isQEmbeddingClose(
     const vector<uint8_t>& res_ref,
     const vector<uint8_t>& res,
     int out_rows,
@@ -297,7 +297,7 @@ TEST_P(QuantizeGroupwiseTest, quantizeGTest) {
 }
 
 template <typename T>
-void runQuantizeTests(
+static void runQuantizeTests(
     const vector<float>& src,
     float scale,
     int zero_point,
@@ -431,7 +431,7 @@ TEST(QuantizeTestQParams, chooseQParamsSymmetric) {
 }
 
 template <typename T>
-void runFusedQuantizeDequantizeTests(
+static void runFusedQuantizeDequantizeTests(
     const vector<float>& src,
     float scale,
     int zero_point,

--- a/test/RequantizeOnlyTest.cc
+++ b/test/RequantizeOnlyTest.cc
@@ -22,7 +22,7 @@
 using namespace std;
 using namespace fbgemm;
 
-vector<QuantizationGranularity> qGranularityVals{
+static vector<QuantizationGranularity> qGranularityVals{
     QuantizationGranularity::TENSOR,
     QuantizationGranularity::OUT_CHANNEL};
 

--- a/test/RowWiseSparseAdagradFusedTest.cc
+++ b/test/RowWiseSparseAdagradFusedTest.cc
@@ -51,7 +51,7 @@ static vector<vector<int>> GetInputs_() {
   return input_dims;
 }
 
-vector<int> prefetch_distances{0, 16, 1000000};
+static vector<int> prefetch_distances{0, 16, 1000000};
 
 namespace {
 

--- a/test/SparseAdagradTest.cc
+++ b/test/SparseAdagradTest.cc
@@ -42,7 +42,7 @@ static vector<vector<int>> GetInputs_() {
   return input_dims;
 }
 
-vector<int> prefetch_distances{0, 16, 1000000};
+static vector<int> prefetch_distances{0, 16, 1000000};
 
 namespace {
 class SparseAdagradTest

--- a/test/SparseDenseMMInt8Test.cc
+++ b/test/SparseDenseMMInt8Test.cc
@@ -18,7 +18,7 @@
 using namespace std;
 using namespace fbgemm;
 
-vector<QuantizationGranularity> qGranularityVals{
+static vector<QuantizationGranularity> qGranularityVals{
     QuantizationGranularity::TENSOR,
     QuantizationGranularity::OUT_CHANNEL};
 

--- a/test/TransposeTest.cc
+++ b/test/TransposeTest.cc
@@ -18,7 +18,7 @@ using namespace std;
 using namespace fbgemm;
 
 template <typename T>
-::testing::AssertionResult compare_tranpose_results(
+static ::testing::AssertionResult compare_tranpose_results(
     vector<T> expected,
     vector<T> acutal,
     int m,

--- a/test/TransposedRequantizeTest.cc
+++ b/test/TransposedRequantizeTest.cc
@@ -22,7 +22,7 @@
 using namespace std;
 using namespace fbgemm;
 
-vector<QuantizationGranularity> qGranularityVals{
+static vector<QuantizationGranularity> qGranularityVals{
     QuantizationGranularity::TENSOR,
     QuantizationGranularity::OUT_CHANNEL};
 

--- a/test/UniConvTest.cc
+++ b/test/UniConvTest.cc
@@ -22,7 +22,7 @@
 using namespace std;
 using namespace fbgemm;
 
-vector<QuantizationGranularity> qGranularityVals{
+static vector<QuantizationGranularity> qGranularityVals{
     QuantizationGranularity::TENSOR,
     QuantizationGranularity::GROUP,
     QuantizationGranularity::OUT_CHANNEL};
@@ -606,7 +606,7 @@ TEST(uniConvTest, cornerCases) {
 }
 
 template <int SPATIAL_DIM, typename ACC_T>
-bool takeDirectConvPath(const conv_param_t<SPATIAL_DIM>& conv_p) {
+static bool takeDirectConvPath(const conv_param_t<SPATIAL_DIM>& conv_p) {
   // Note: Direct convolutions (2D) are optimized for
   // filter size: 2 x 1 to 2 x 6,  transposed conv,
   // in_channel % 8 == 0, out_channel % 8 == 0
@@ -638,7 +638,7 @@ bool takeDirectConvPath(const conv_param_t<SPATIAL_DIM>& conv_p) {
  */
 
 template <int SPATIAL_DIM = 2>
-void runRequantizeTest(
+static void runRequantizeTest(
     QuantizationGranularity q_granularity,
     bool a_symmetric,
     bool b_symmetric,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1497

There are two changes:
1. Marks in-file templates and other inner functions as static; this provides more opportunities to optimise code, i.e. followed by enabling link time optimization. An unused function in test code is removed.
2. Enables `misc-use-internal-linkage` check.


Differential Revision: D77635949

Pulled By: q10
