### PR TITLE
Migrate jagged tensor kernels to `FBGEMM_LAUNCH_KERNEL`, pt 4

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_bmm_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_dense_bmm_forward.cu
@@ -195,29 +195,24 @@ Tensor jagged_dense_bmm_forward_cuda(
           x_offsets.scalar_type(), "jagged_dense_bmm_kernel_1", [&] {
             FBGEMM_DISPATCH_FLOATING_TYPES(
                 x_values.scalar_type(), "jagged_dense_bmm_kernel_2", [&] {
-
-#ifdef FBGEMM_GPU_MEMCHECK
-                  const auto func_name1 = "jagged_dense_bmm_kernel";
-#endif
-
-                  jagged_dense_bmm_kernel<
-                      BLOCK_TILE_M,
-                      BLOCK_TILE_N,
-                      BLOCK_TILE_K,
-                      THREAD_TILE_M,
-                      THREAD_TILE_N,
-                      index_t,
-                      scalar_t>
-                      <<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
-                          MAKE_PTA_WITH_NAME(
-                              func_name1, x_values, scalar_t, 2, 32),
-                          MAKE_PTA_WITH_NAME(
-                              func_name1, x_offsets, index_t, 1, 32),
-                          MAKE_PTA_WITH_NAME(func_name1, y, scalar_t, 3, 32),
-                          MAKE_PTA_WITH_NAME(
-                              func_name1, output, scalar_t, 2, 32),
-                          (int)max_L);
-                  C10_CUDA_KERNEL_LAUNCH_CHECK();
+                  FBGEMM_LAUNCH_KERNEL(
+                      (jagged_dense_bmm_kernel<
+                          BLOCK_TILE_M,
+                          BLOCK_TILE_N,
+                          BLOCK_TILE_K,
+                          THREAD_TILE_M,
+                          THREAD_TILE_N,
+                          index_t,
+                          scalar_t>),
+                      grid,
+                      block,
+                      0,
+                      at::cuda::getCurrentCUDAStream(),
+                      PTA_B(x_values, scalar_t, 2, 32),
+                      PTA_B(x_offsets, index_t, 1, 32),
+                      PTA_B(y, scalar_t, 3, 32),
+                      PTA_B(output, scalar_t, 2, 32),
+                      (int)max_L);
                 });
           });
     } else {
@@ -238,29 +233,24 @@ Tensor jagged_dense_bmm_forward_cuda(
           x_offsets.scalar_type(), "jagged_dense_bmm_kernel_1", [&] {
             FBGEMM_DISPATCH_FLOATING_TYPES(
                 x_values.scalar_type(), "jagged_dense_bmm_kernel_2", [&] {
-
-#ifdef FBGEMM_GPU_MEMCHECK
-                  const auto func_name2 = "jagged_dense_bmm_kernel";
-#endif
-
-                  jagged_dense_bmm_kernel<
-                      BLOCK_TILE_M,
-                      BLOCK_TILE_N,
-                      BLOCK_TILE_K,
-                      THREAD_TILE_M,
-                      THREAD_TILE_N,
-                      index_t,
-                      scalar_t>
-                      <<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
-                          MAKE_PTA_WITH_NAME(
-                              func_name2, x_values, scalar_t, 2, 32),
-                          MAKE_PTA_WITH_NAME(
-                              func_name2, x_offsets, index_t, 1, 32),
-                          MAKE_PTA_WITH_NAME(func_name2, y, scalar_t, 3, 32),
-                          MAKE_PTA_WITH_NAME(
-                              func_name2, output, scalar_t, 2, 32),
-                          (int)max_L);
-                  C10_CUDA_KERNEL_LAUNCH_CHECK();
+                  FBGEMM_LAUNCH_KERNEL(
+                      (jagged_dense_bmm_kernel<
+                          BLOCK_TILE_M,
+                          BLOCK_TILE_N,
+                          BLOCK_TILE_K,
+                          THREAD_TILE_M,
+                          THREAD_TILE_N,
+                          index_t,
+                          scalar_t>),
+                      grid,
+                      block,
+                      0,
+                      at::cuda::getCurrentCUDAStream(),
+                      PTA_B(x_values, scalar_t, 2, 32),
+                      PTA_B(x_offsets, index_t, 1, 32),
+                      PTA_B(y, scalar_t, 3, 32),
+                      PTA_B(output, scalar_t, 2, 32),
+                      (int)max_L);
                 });
           });
     }


### PR DESCRIPTION
Summary: - Migrate jagged tensor kernels to `FBGEMM_LAUNCH_KERNEL`, pt 4

Reviewed By: r-barnes

Differential Revision: D75119656


