### PR TITLE
Fix uninitialized access (#4448)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,12 +224,6 @@ else(MSVC)
     src/FbgemmFP16UKernelsAvx512.cc
     src/FbgemmFP16UKernelsAvx512_256.cc
     PROPERTIES COMPILE_FLAGS "-masm=intel")
-  set_source_files_properties(
-    src/FbgemmI64.cc
-    src/FbgemmI8Depthwise3DAvx2.cc
-    src/FbgemmI8DepthwiseAvx2.cc
-    src/UtilsAvx2.cc
-    PROPERTIES COMPILE_FLAGS "-Wno-uninitialized")
   set_source_files_properties(src/PackMatrix.cc
     PROPERTIES COMPILE_FLAGS "-Wno-infinite-recursion")
   # Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80947

--- a/src/TransposeUtilsAvx2.h
+++ b/src/TransposeUtilsAvx2.h
@@ -746,9 +746,9 @@ static void transpose_kernel_mxn_avx2_uint8(
     input[i] = _mm256_loadu_si256(reinterpret_cast<__m256i*>(&local_buffer[0]));
   }
 
-  // for (; i < 8; ++i) {
-  // input[i] = _mm256_setzero_si256();
-  //}
+  for (; i < 8; ++i) {
+    input[i] = _mm256_setzero_si256();
+  }
 
   // interleaving 8-bit elements
   // e.g., temp[0] now becomes: a0 b0 a1 b1 a2 b2 ...


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1512

These bugs are real for small values of M, I don't know why the tests passed before, but it is no harm to add initialization with little overhead.


Differential Revision: D77828637

Pulled By: q10


