### PR TITLE
[FBGEMM] Fix performance on FP8 AMD kernels

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
@@ -149,7 +149,18 @@ gpu_cpp_library(
     ${experimental_gen_ai_cpp_source_files_hip}
   TORCH_LIBS
     # Used when building as part of PyTorch
-    ${FBGEMM_GENAI_TORCH_LIBS})
+    ${FBGEMM_GENAI_TORCH_LIBS}
+  HIPCC_FLAGS
+    # Below flags are required for strong CK performance
+    # on certain kernel instances
+    -mllvm
+    # Reduce register spillage on certain kernels
+    -amdgpu-coerce-illegal-types=1
+    -mllvm
+    -enable-post-misched=0
+    -mllvm
+    -greedy-reverse-local-assignment=1
+    -fhip-new-launch-api)
 
 
 


### PR DESCRIPTION
Summary: This adds some missing hipcc compiler flags, without these flags certain kernel instances suffer from major performance issues.

Test Plan:

Built FBGEMM GenAI AMD on MI300, and compared performance with internal FB builds.

Will check build signals to ensure all AMD builds are green.

Reviewers:

Subscribers:

Tasks:

Tags: