### PR TITLE
Migrate quantization kernels to `FBGEMM_LAUNCH_KERNEL`, pt 1

### DIFF
--- a/fbgemm_gpu/src/quantize_ops/common.cuh
+++ b/fbgemm_gpu/src/quantize_ops/common.cuh
@@ -25,6 +25,7 @@
 #include "fbgemm_gpu/utils/cuda_block_count.h"
 #include "fbgemm_gpu/utils/dispatch_macros.h"
 #include "fbgemm_gpu/utils/float.cuh"
+#include "fbgemm_gpu/utils/kernel_launcher.cuh"
 #include "fbgemm_gpu/utils/ops_utils.h"
 #include "fbgemm_gpu/utils/tensor_accessor_builder.h"
 #include "fbgemm_gpu/utils/tensor_utils.h"


### PR DESCRIPTION
Summary: - Migrate quantization kernels to `FBGEMM_LAUNCH_KERNEL`, pt 1

Reviewed By: r-barnes

Differential Revision: D75259308


