### PR TITLE
Fix MSVC build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,15 @@ option(FBGEMM_BUILD_FBGEMM_GPU "Build fbgemm_gpu library" OFF)
 option(FBGEMM_USE_IPO "Build fbgemm with interprocedural optimization" OFF)
 option(DISABLE_FBGEMM_AUTOVEC "Disable FBGEMM Autovec" OFF)
 
+
+if(FBGEMM_LIBRARY_TYPE STREQUAL "default")
+  if(BUILD_SHARED_LIB)
+    set(FBGEMM_LIBRARY_TYPE "shared")
+  else()
+    set(FBGEMM_LIBRARY_TYPE "static")
+  endif()
+endif()
+
 if(FBGEMM_BUILD_TESTS)
   enable_testing()
 endif()
@@ -138,7 +147,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/FindGnuH2fIeee.cmake)
 
 # We should default to a Release build
 if(NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
-    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
 endif()
 
 if(DISABLE_FBGEMM_AUTOVEC)
@@ -173,28 +182,26 @@ add_library(fbgemm_autovec OBJECT ${FBGEMM_AUTOVEC_SRCS})
 # Make libraries depend on defs.bzl
 add_custom_target(defs.bzl DEPENDS defs.bzl)
 add_dependencies(fbgemm_generic defs.bzl)
-add_dependencies(fbgemm_avx2 defs.bzl)
-add_dependencies(fbgemm_avx512 defs.bzl)
-add_dependencies(fbgemm_autovec defs.bzl)
+target_link_libraries(fbgemm_avx2 PUBLIC fbgemm_generic)
+target_link_libraries(fbgemm_avx512 PUBLIC fbgemm_generic)
+target_link_libraries(fbgemm_autovec PUBLIC fbgemm_generic)
+
+target_include_directories(fbgemm_generic PUBLIC
+      $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}>
+      $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}/include>
+      $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}/bench>)
+
+target_link_libraries(fbgemm_generic PUBLIC
+  $<BUILD_INTERFACE:asmjit>
+  $<BUILD_INTERFACE:cpuinfo>)
 
 # On Windows:
 # 1)  Adding definition of ASMJIT_STATIC to avoid generating asmjit function
 #     calls with _dllimport attribute
-# 2)  MSVC uses /MD in default cxx compiling flags,
-# Need to change it to /MT in static case
 if(MSVC)
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244 /wd4267 /wd4305 /wd4309")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244 /wd4267 /wd4305 /wd4309")
   if(FBGEMM_LIBRARY_TYPE STREQUAL "static")
-    target_compile_definitions(fbgemm_generic PRIVATE ASMJIT_STATIC)
-    target_compile_definitions(fbgemm_avx2 PRIVATE ASMJIT_STATIC)
-    target_compile_definitions(fbgemm_avx512 PRIVATE ASMJIT_STATIC)
-    foreach(flag_var
-      CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-      CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-      if(${flag_var} MATCHES "/MD")
-        string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-      endif(${flag_var} MATCHES "/MD")
-    endforeach(flag_var)
+    target_compile_definitions(fbgemm_generic PUBLIC ASMJIT_STATIC)
   endif()
   target_compile_options(fbgemm_avx2 PRIVATE "/arch:AVX2")
   target_compile_options(fbgemm_avx512 PRIVATE "/arch:AVX512")
@@ -238,11 +245,9 @@ else(MSVC)
 endif(MSVC)
 
 if(USE_SANITIZER)
-  target_compile_options(fbgemm_generic PRIVATE
+  target_link_options(fbgemm_generic PUBLIC
     "-fsanitize=${USE_SANITIZER}" "-fno-omit-frame-pointer")
-  target_compile_options(fbgemm_avx2 PRIVATE
-    "-fsanitize=${USE_SANITIZER}" "-fno-omit-frame-pointer")
-  target_compile_options(fbgemm_avx512 PRIVATE
+  target_compile_options(fbgemm_generic PUBLIC
     "-fsanitize=${USE_SANITIZER}" "-fno-omit-frame-pointer")
 endif()
 
@@ -303,78 +308,35 @@ if(NOT TARGET cpuinfo)
   set_property(TARGET cpuinfo PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 
-target_include_directories(fbgemm_generic BEFORE
-      PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}>
-      PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}/include>
-      PRIVATE "${ASMJIT_SRC_DIR}/src"
-      PRIVATE "${CPUINFO_SOURCE_DIR}/include")
-
-target_include_directories(fbgemm_avx2 BEFORE
-      PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}>
-      PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}/include>
-      PRIVATE "${ASMJIT_SRC_DIR}/src"
-      PRIVATE "${CPUINFO_SOURCE_DIR}/include")
-
-target_include_directories(fbgemm_avx512 BEFORE
-      PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}>
-      PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}/include>
-      PRIVATE "${ASMJIT_SRC_DIR}/src"
-      PRIVATE "${CPUINFO_SOURCE_DIR}/include")
-
-target_include_directories(fbgemm_autovec BEFORE
-      PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}>
-      PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}/include>
-      PRIVATE "${ASMJIT_SRC_DIR}/src"
-      PRIVATE "${CPUINFO_SOURCE_DIR}/include")
-
-if((FBGEMM_LIBRARY_TYPE STREQUAL "default" AND BUILD_SHARED_LIB) OR FBGEMM_LIBRARY_TYPE STREQUAL "shared")
-  add_library(fbgemm SHARED
-    $<TARGET_OBJECTS:fbgemm_generic>
-    $<TARGET_OBJECTS:fbgemm_avx2>
-    $<TARGET_OBJECTS:fbgemm_avx512>
-    $<TARGET_OBJECTS:fbgemm_autovec>)
+file(WRITE "${CMAKE_BINARY_DIR}/fbgemm_lib_dummy.cc" "")
+if(FBGEMM_LIBRARY_TYPE STREQUAL "shared")
+  add_library(fbgemm SHARED "${CMAKE_BINARY_DIR}/fbgemm_lib_dummy.cc")
+elseif(FBGEMM_LIBRARY_TYPE STREQUAL "static")
+  add_library(fbgemm STATIC "${CMAKE_BINARY_DIR}/fbgemm_lib_dummy.cc")
+  #MSVC need to define FBGEMM_STATIC for fbgemm_generic also to
+  #avoid generating _dllimport functions.
+  target_compile_definitions(fbgemm_generic PUBLIC FBGEMM_STATIC)
   set_property(TARGET fbgemm PROPERTY POSITION_INDEPENDENT_CODE ON)
   set_property(TARGET fbgemm_generic PROPERTY POSITION_INDEPENDENT_CODE ON)
   set_property(TARGET fbgemm_avx2 PROPERTY POSITION_INDEPENDENT_CODE ON)
   set_property(TARGET fbgemm_avx512 PROPERTY POSITION_INDEPENDENT_CODE ON)
   set_property(TARGET fbgemm_autovec PROPERTY POSITION_INDEPENDENT_CODE ON)
-elseif((FBGEMM_LIBRARY_TYPE STREQUAL "default" AND NOT BUILD_SHARED_LIB) OR FBGEMM_LIBRARY_TYPE STREQUAL "static")
-  add_library(fbgemm STATIC
-    $<TARGET_OBJECTS:fbgemm_generic>
-    $<TARGET_OBJECTS:fbgemm_avx2>
-    $<TARGET_OBJECTS:fbgemm_avx512>
-    $<TARGET_OBJECTS:fbgemm_autovec>)
-  #MSVC need to define FBGEMM_STATIC for fbgemm_generic also to
-  #avoid generating _dllimport functions.
-  target_compile_definitions(fbgemm_generic PRIVATE FBGEMM_STATIC)
-  target_compile_definitions(fbgemm_avx2 PRIVATE FBGEMM_STATIC)
-  target_compile_definitions(fbgemm_avx512 PRIVATE FBGEMM_STATIC)
-  target_compile_definitions(fbgemm_autovec PRIVATE FBGEMM_STATIC)
-  target_compile_definitions(fbgemm PRIVATE FBGEMM_STATIC)
 else()
   message(FATAL_ERROR "Unsupported library type ${FBGEMM_LIBRARY_TYPE}")
 endif()
 
-if(USE_SANITIZER)
-  target_link_options(fbgemm PRIVATE
-    "-fsanitize=${USE_SANITIZER}" "-fno-omit-frame-pointer")
-endif()
-
-target_include_directories(fbgemm BEFORE
-    PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}>
-    PUBLIC $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}/include>)
-
 target_link_libraries(fbgemm PUBLIC
-  $<BUILD_INTERFACE:asmjit>
-  $<BUILD_INTERFACE:cpuinfo>)
+    fbgemm_generic
+    fbgemm_avx2
+    fbgemm_avx512
+    fbgemm_autovec)
 
 if(OpenMP_FOUND)
-  target_link_libraries(fbgemm PUBLIC OpenMP::OpenMP_CXX)
   target_link_libraries(fbgemm_generic PUBLIC OpenMP::OpenMP_CXX)
 endif()
 
 install(
-  TARGETS fbgemm
+  TARGETS fbgemm fbgemm_generic fbgemm_avx2 fbgemm_avx512 fbgemm_autovec
   EXPORT fbgemmLibraryConfig
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,14 +316,14 @@ elseif(FBGEMM_LIBRARY_TYPE STREQUAL "static")
   #MSVC need to define FBGEMM_STATIC for fbgemm_generic also to
   #avoid generating _dllimport functions.
   target_compile_definitions(fbgemm_generic PUBLIC FBGEMM_STATIC)
-  set_property(TARGET fbgemm PROPERTY POSITION_INDEPENDENT_CODE ON)
-  set_property(TARGET fbgemm_generic PROPERTY POSITION_INDEPENDENT_CODE ON)
-  set_property(TARGET fbgemm_avx2 PROPERTY POSITION_INDEPENDENT_CODE ON)
-  set_property(TARGET fbgemm_avx512 PROPERTY POSITION_INDEPENDENT_CODE ON)
-  set_property(TARGET fbgemm_autovec PROPERTY POSITION_INDEPENDENT_CODE ON)
 else()
   message(FATAL_ERROR "Unsupported library type ${FBGEMM_LIBRARY_TYPE}")
 endif()
+set_property(TARGET fbgemm PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET fbgemm_generic PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET fbgemm_avx2 PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET fbgemm_avx512 PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET fbgemm_autovec PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_link_libraries(fbgemm PUBLIC
     fbgemm_generic

--- a/bench/BenchUtils.h
+++ b/bench/BenchUtils.h
@@ -381,7 +381,7 @@ void performance_test(
         if (std::abs(C_ref[0][i] - C_fb[0][i]) > 1e-3) {
           fprintf(
               stderr,
-              "Error: too high diff between fp32 ref %f and fp16 %f at %ld\n",
+              "Error: too high diff between fp32 ref %f and fp16 %f at %zu\n",
               C_ref[0][i],
               C_fb[0][i],
               i);

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -45,20 +45,15 @@ macro(add_benchmark BENCHNAME)
     ../test/EmbeddingSpMDMTestUtils.cc
   )
 
-  target_compile_options(
-    ${BENCHNAME}
-    PRIVATE
-    "-m64" "-mavx2" "-mfma" "-masm=intel"
-  )
+  if(NOT MSVC)
+    target_compile_options(
+      ${BENCHNAME}
+      PRIVATE
+      "-m64" "-mavx2" "-mfma" "-masm=intel"
+    )
+  endif()
 
   target_link_libraries(${BENCHNAME} fbgemm)
-  add_dependencies(${BENCHNAME} fbgemm)
-
-  if (USE_SANITIZER)
-    target_compile_options(${BENCHNAME} PRIVATE
-      "-fsanitize=${USE_SANITIZER}" "-fno-omit-frame-pointer")
-    target_link_options(${BENCHNAME} PRIVATE "-fsanitize=${USE_SANITIZER}")
-  endif()
 
   if(OpenMP_FOUND)
     target_link_libraries(${BENCHNAME} OpenMP::OpenMP_CXX)
@@ -99,9 +94,5 @@ if(FBGEMM_BUILD_BENCHMARKS)
 
   add_dependencies(run_benchmarks
     ${BENCHMARKS})
-
-  set_source_files_properties(
-    bench/GEMMsBenchmark.cc
-    PROPERTIES COMPILE_FLAGS "-Wno-unused-variable")
 
 endif()

--- a/bench/SparseDenseMMInt8Benchmark.cc
+++ b/bench/SparseDenseMMInt8Benchmark.cc
@@ -166,7 +166,7 @@ int main(int /*unused*/, char** /*unused*/) {
         if (std::abs(ctDataRef_u8[i] - ctDataIntrin_u8[i]) > 0) {
           fprintf(
               stderr,
-              "Error: Results differ ref %d and test %d at %ld\n",
+              "Error: Results differ ref %d and test %d at %zu\n",
               ctDataRef_u8[i],
               ctDataIntrin_u8[i],
               i);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,13 +23,6 @@ if(FBGEMM_BUILD_TESTS AND NOT TARGET gtest)
   endif()
 
   #build Googletest framework
-  #MSVC needs gtest_for_shared_crt to select right runtime lib
-  if (MSVC AND FBGEMM_LIBRARY_TYPE STREQUAL "shared")
-    message(WARNING "gtest_force_shared_crt is ON")
-    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-  else()
-    message(WARNING "gtest_force_shared_crt is OFF")
-  endif()
   add_subdirectory("${GOOGLETEST_SOURCE_DIR}" "${FBGEMM_BINARY_DIR}/googletest")
   # add flags required for mac build
   if(NOT MSVC)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 if(FBGEMM_BUILD_TESTS AND NOT TARGET gtest)
   #Download Googletest framework from github if
   #GOOGLETEST_SOURCE_DIR is not specified.
+  set(INSTALL_GTEST OFF)
   if(NOT DEFINED GOOGLETEST_SOURCE_DIR)
     set(GOOGLETEST_SOURCE_DIR "${FBGEMM_SOURCE_DIR}/external/googletest"
       CACHE STRING "googletest source directory from submodules")


### PR DESCRIPTION
This PR fixes all warnings I encountered when trying to build FBGEMM on Windows and integrating the latest FBGEMM to PyTorch. Redundant public settings are removed. Other public settings are removed to `fbgemm_generic` because it is relied by other targets.