### PR TITLE
Don't use deprecated asmjit templates (#4481)

### DIFF
--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -319,7 +319,7 @@ GenEmbeddingSpMDMLookup<
 
         if constexpr (ROWWISE_SPARSE) {
           func.init(
-              asmjit::FuncSignatureT<
+              asmjit::FuncSignature::build<
                   bool,
                   int64_t, // output_size
                   int64_t, // index_size
@@ -334,7 +334,7 @@ GenEmbeddingSpMDMLookup<
               a->environment());
         } else {
           func.init(
-              asmjit::FuncSignatureT<
+              asmjit::FuncSignature::build<
                   bool,
                   int64_t, // output_size
                   int64_t, // index_size

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -290,7 +290,7 @@ GenEmbeddingSpMDMNBitLookup<
 
         if constexpr (ROWWISE_SPARSE) {
           func.init(
-              asmjit::FuncSignatureT<
+              asmjit::FuncSignature::build<
                   bool,
                   int64_t, // output_size
                   int64_t, // index_size
@@ -305,7 +305,7 @@ GenEmbeddingSpMDMNBitLookup<
               a->environment());
         } else {
           func.init(
-              asmjit::FuncSignatureT<
+              asmjit::FuncSignature::build<
                   bool,
                   int64_t, // output_size
                   int64_t, // index_size

--- a/src/FbgemmI64.cc
+++ b/src/FbgemmI64.cc
@@ -178,14 +178,9 @@ CodeGenBase<int64_t, int64_t, int64_t, int64_t>::getOrCreate(
 
     asmjit::FuncDetail func;
     func.init(
-        asmjit::FuncSignatureT<
-            void,
-            int64_t*,
-            int64_t*,
-            int64_t*,
-            int64_t*,
-            int,
-            int>(asmjit::CallConvId::kHost),
+        asmjit::FuncSignature::
+            build<void, int64_t*, int64_t*, int64_t*, int64_t*, int, int>(
+                asmjit::CallConvId::kHost),
         a->environment());
 
     asmjit::FuncFrame frame;

--- a/src/GenerateI8Depthwise.cc
+++ b/src/GenerateI8Depthwise.cc
@@ -262,7 +262,7 @@ GenI8Depthwise::jit_kernel_signature GenI8Depthwise::getOrCreate(
 
     asmjit::FuncDetail func;
     func.init(
-        asmjit::FuncSignatureT<
+        asmjit::FuncSignature::build<
             void,
             const std::uint8_t*,
             const std::int8_t*,

--- a/src/GenerateKernelDirectConvU8S8S32ACC32.cc
+++ b/src/GenerateKernelDirectConvU8S8S32ACC32.cc
@@ -226,14 +226,9 @@ DirectConvCodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreateDirectConv(
 
     asmjit::FuncDetail func;
     func.init(
-        asmjit::FuncSignatureT<
-            void,
-            uint8_t*,
-            int8_t*,
-            int8_t*,
-            int32_t*,
-            int,
-            int>(asmjit::CallConvId::kHost),
+        asmjit::FuncSignature::
+            build<void, uint8_t*, int8_t*, int8_t*, int32_t*, int, int>(
+                asmjit::CallConvId::kHost),
         a->environment());
 
     asmjit::FuncFrame frame;
@@ -650,15 +645,9 @@ DirectConvCodeGenBase<uint8_t, int8_t, int32_t, int32_t>::
 
     asmjit::FuncDetail func;
     func.init(
-        asmjit::FuncSignatureT<
-            void,
-            uint8_t*,
-            int8_t*,
-            int32_t*,
-            int,
-            int,
-            int,
-            int>(asmjit::CallConvId::kHost),
+        asmjit::FuncSignature::
+            build<void, uint8_t*, int8_t*, int32_t*, int, int, int, int>(
+                asmjit::CallConvId::kHost),
         a->environment());
 
     asmjit::FuncFrame frame;

--- a/src/GenerateKernelU8S8S32ACC16.cc
+++ b/src/GenerateKernelU8S8S32ACC16.cc
@@ -180,14 +180,9 @@ CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate<inst_set_t::avx2>(
 
     asmjit::FuncDetail func;
     func.init(
-        asmjit::FuncSignatureT<
-            void,
-            uint8_t*,
-            int8_t*,
-            int8_t*,
-            int32_t*,
-            int,
-            int>(asmjit::CallConvId::kHost),
+        asmjit::FuncSignature::
+            build<void, uint8_t*, int8_t*, int8_t*, int32_t*, int, int>(
+                asmjit::CallConvId::kHost),
         a->environment());
 
     asmjit::FuncFrame frame;

--- a/src/GenerateKernelU8S8S32ACC16Avx512.cc
+++ b/src/GenerateKernelU8S8S32ACC16Avx512.cc
@@ -142,14 +142,9 @@ CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate(
 
     asmjit::FuncDetail func;
     func.init(
-        asmjit::FuncSignatureT<
-            void,
-            uint8_t*,
-            int8_t*,
-            int8_t*,
-            int32_t*,
-            int,
-            int>(asmjit::CallConvId::kHost),
+        asmjit::FuncSignature::
+            build<void, uint8_t*, int8_t*, int8_t*, int32_t*, int, int>(
+                asmjit::CallConvId::kHost),
         a->environment());
 
     asmjit::FuncFrame frame;

--- a/src/GenerateKernelU8S8S32ACC32.cc
+++ b/src/GenerateKernelU8S8S32ACC32.cc
@@ -179,14 +179,9 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate(
 
     asmjit::FuncDetail func;
     func.init(
-        asmjit::FuncSignatureT<
-            void,
-            uint8_t*,
-            int8_t*,
-            int8_t*,
-            int32_t*,
-            int,
-            int>(asmjit::CallConvId::kHost),
+        asmjit::FuncSignature::
+            build<void, uint8_t*, int8_t*, int8_t*, int32_t*, int, int>(
+                asmjit::CallConvId::kHost),
         a->environment());
 
     asmjit::FuncFrame frame;

--- a/src/GenerateKernelU8S8S32ACC32Avx512VNNI.cc
+++ b/src/GenerateKernelU8S8S32ACC32Avx512VNNI.cc
@@ -133,14 +133,9 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate(
 
     asmjit::FuncDetail func;
     func.init(
-        asmjit::FuncSignatureT<
-            void,
-            uint8_t*,
-            int8_t*,
-            int8_t*,
-            int32_t*,
-            int,
-            int>(asmjit::CallConvId::kHost),
+        asmjit::FuncSignature::
+            build<void, uint8_t*, int8_t*, int8_t*, int32_t*, int, int>(
+                asmjit::CallConvId::kHost),
         a->environment());
 
     asmjit::FuncFrame frame;

--- a/src/GroupwiseConv.cc
+++ b/src/GroupwiseConv.cc
@@ -217,7 +217,7 @@ jit_conv_kernel_fp GenConvKernel<SPATIAL_DIM, INST_SET>::getOrCreate() {
   scratchReg2_ = a->gpz(13);
 
   func_.init(
-      asmjit::FuncSignatureT<
+      asmjit::FuncSignature::build<
           void,
           uint8_t*,
           int8_t*,

--- a/src/RowWiseSparseAdagradFused.cc
+++ b/src/RowWiseSparseAdagradFused.cc
@@ -168,7 +168,7 @@ typename ReturnFunctionSignature<indxType, offsetType, dataType>::
 
         asmjit::FuncDetail func;
         func.init(
-            asmjit::FuncSignatureT<
+            asmjit::FuncSignature::build<
                 bool, // return type
                 int64_t, // output_size
                 int64_t, // index_size

--- a/src/SparseAdagrad.cc
+++ b/src/SparseAdagrad.cc
@@ -500,7 +500,7 @@ GenSparseAdagrad<indxType, instSet>::getOrCreate(
 
         asmjit::FuncDetail func;
         func.init(
-            asmjit::FuncSignatureT<
+            asmjit::FuncSignature::build<
                 int, // return type
                 int, // num rows
                 std::uint64_t, // param_size

--- a/test/EmbeddingSpMDM8BitTest.cc
+++ b/test/EmbeddingSpMDM8BitTest.cc
@@ -58,7 +58,7 @@ class Fused8BitRowwiseEmbeddingLookupTest
           EmbeddingSpMDMOutputDtypeChoice>> {};
 }; // namespace
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     Fused8BitRowwiseEmbeddingLookupTest,
     ::testing::Combine(

--- a/test/EmbeddingSpMDMNBitTest.cc
+++ b/test/EmbeddingSpMDMNBitTest.cc
@@ -61,7 +61,7 @@ class FusedNBitRowwiseEmbeddingLookupTest : public testing::TestWithParam<tuple<
                                                 EmbeddingSpMDMDtypeChoice>> {};
 }; // namespace
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     FusedNBitRowwiseEmbeddingLookupTest,
     ::testing::Combine(

--- a/test/EmbeddingSpMDMTest.cc
+++ b/test/EmbeddingSpMDMTest.cc
@@ -67,7 +67,7 @@ class IndexRemapTest
 
 static vector<int> prefetch_distances = {0, 16, 1000000};
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     EmbeddingSpMDMTest,
     ::testing::Combine(
@@ -84,7 +84,7 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Values(FLOAT, FLOAT16, BFLOAT16),
         ::testing::Values(FLOAT, FLOAT16, BFLOAT16)));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     rowwiseSparseEmbeddingSpMDMTest,
     ::testing::Combine(
@@ -99,7 +99,7 @@ INSTANTIATE_TEST_CASE_P(
             OUT_OF_BOUND_INDICES,
             UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM)));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     IndexRemapTest,
     ::testing::Combine(

--- a/test/FP16Test.cc
+++ b/test/FP16Test.cc
@@ -13,7 +13,7 @@
 
 using FBGemmFP16Test = fbgemm::FBGemmFPTest<fbgemm::float16>;
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     FBGemmFP16Test,
     ::testing::Values(

--- a/test/FP32Test.cc
+++ b/test/FP32Test.cc
@@ -20,7 +20,7 @@
 
 using FBGemmFP32Test = fbgemm::FBGemmFPTest<float>;
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     FBGemmFP32Test,
     ::testing::Values(

--- a/test/Float16ConvertTest.cc
+++ b/test/Float16ConvertTest.cc
@@ -21,7 +21,7 @@ namespace {
 class FBGemmFloat16Test : public testing::TestWithParam<bool> {};
 }; // namespace
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     FBGemmFloat16Test,
     ::testing::Bool());

--- a/test/GConvTest.cc
+++ b/test/GConvTest.cc
@@ -49,14 +49,14 @@ class fbgemmGConvAcc32WithQuantGranularityTest
 class fbgemmGConvPackTest : public testing::TestWithParam<matrix_op_t> {};
 }; // namespace
 
-// INSTANTIATE_TEST_CASE_P(
+// INSTANTIATE_TEST_SUITE_P(
 //     InstantiationName,
 //     fbgemmGConvAcc32Test,
 //     ::testing::Combine(
 //         ::testing::Values(matrix_op_t::NoTranspose),
 //         ::testing::ValuesIn(transposeVals)));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     fbgemmGConvAcc32WithQuantGranularityTest,
     ::testing::Combine(
@@ -66,7 +66,7 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Bool(), // A symmetric
         ::testing::Bool())); // B symmetric
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     fbgemmGConvPackTest,
     ::testing::ValuesIn(transposeVals));

--- a/test/I8DepthwiseTest.cc
+++ b/test/I8DepthwiseTest.cc
@@ -107,7 +107,7 @@ class FBGemmDepthWisePackUnpackTest
 
 } // namespace
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     FBGemmDepthWiseTest,
     ::testing::Combine(
@@ -115,12 +115,12 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Bool(), // b_symmetric
         ::testing::Values(1, 2))); // oc_per_g
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     FBGemmDepthWisePerChannelQuantizationTest,
     ::testing::Values(1, 2));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     FBGemmDepthWisePackUnpackTest,
     ::testing::Combine(

--- a/test/I8DirectconvTest.cc
+++ b/test/I8DirectconvTest.cc
@@ -248,7 +248,7 @@ static void QuantizeDirectConv_ref(
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     FBGemmDirectConvTest,
     ::testing::Combine(
@@ -418,7 +418,7 @@ TEST_P(FBGemmDirectConvTest, Test2D) {
 */
 
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     FBGemmDirectConvTransTest,
     ::testing::Combine(
@@ -606,7 +606,7 @@ TEST_P(FBGemmDirectConvTransTest, Test2D) {
 }
 
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     FBGemmDirectConvTransFbgemmTest,
     ::testing::Combine(

--- a/test/I8SpmdmTest.cc
+++ b/test/I8SpmdmTest.cc
@@ -35,7 +35,7 @@ class fbgemmSPMDMTest
     : public testing::TestWithParam<std::tuple<float, bool, bool>> {};
 } // namespace
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Instance0,
     fbgemmSPMDMTest,
     ::testing::Combine(

--- a/test/Im2ColFusedRequantizeTest.cc
+++ b/test/Im2ColFusedRequantizeTest.cc
@@ -36,7 +36,7 @@ class fbgemmIm2colTest
     : public testing::TestWithParam<tuple<QuantizationGranularity, bool>> {};
 }; // namespace
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     fbgemmIm2colTest,
     ::testing::Combine(

--- a/test/PackedRequantizeAcc16Test.cc
+++ b/test/PackedRequantizeAcc16Test.cc
@@ -48,7 +48,7 @@ class fbgemmPackUnpackAcc16Test
     : public testing::TestWithParam<tuple<matrix_op_t, bool>> {};
 }; // namespace
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     fbgemmu8s8acc16WithQuantGranularityTest,
     ::testing::Combine(
@@ -57,7 +57,7 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Bool(),
         ::testing::ValuesIn(qGranularityVals)));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     fbgemmu8s8acc16Test,
     ::testing::Combine(
@@ -65,7 +65,7 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::ValuesIn(transposeVals),
         ::testing::Bool()));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     fbgemmPackUnpackAcc16Test,
     ::testing::Combine(::testing::ValuesIn(transposeVals), ::testing::Bool()));

--- a/test/PackedRequantizeTest.cc
+++ b/test/PackedRequantizeTest.cc
@@ -46,7 +46,7 @@ class fbgemmPackUnpackAcc32Test
     : public testing::TestWithParam<tuple<matrix_op_t, bool>> {};
 }; // namespace
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     fbgemmu8s8acc32WithQuantGranularityTest,
     ::testing::Combine(
@@ -55,7 +55,7 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Bool(),
         ::testing::ValuesIn(qGranularityVals)));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     fbgemmu8s8acc32Test,
     ::testing::Combine(
@@ -63,7 +63,7 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::ValuesIn(transposeVals),
         ::testing::Bool()));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     fbgemmPackUnpackAcc32Test,
     ::testing::Combine(::testing::ValuesIn(transposeVals), ::testing::Bool()));

--- a/test/QuantUtilsTest.cc
+++ b/test/QuantUtilsTest.cc
@@ -42,7 +42,7 @@ class EmbeddingQuantizeTest
 class EmbeddingQuantizeSBFloatTest
     : public testing::TestWithParam<tuple<int, int>> {};
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     QuantizeGroupwiseTest,
     ::testing::Combine(
@@ -52,17 +52,17 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::ValuesIn({1, 4}), // G
         ::testing::ValuesIn({layout_t::KCX, layout_t::KXC})));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     QuantizeTest,
     ::testing::Values(1, 2, 5, 8, 9, 16, 20, 28, 32, 33));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     FusedQuantizeDequantizeTest,
     ::testing::Values(1, 2, 5, 8, 9, 16, 20, 28, 32, 33));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     EmbeddingQuantizeTest,
     ::testing::Combine(
@@ -70,7 +70,7 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::ValuesIn({1, 2, 3}),
         ::testing::ValuesIn({4, 8, 16, 20, 28, 32, 64, 84})));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     EmbeddingQuantizeSBFloatTest,
     ::testing::Combine(
@@ -604,7 +604,7 @@ class EmbeddingQuantizeFixedNumberTest : public testing::TestWithParam<int> {
   std::vector<uint8_t> expected_output_float;
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     EmbeddingQuantizeFixedNumberTest,
     ::testing::ValuesIn({2, 4, 8}));

--- a/test/RequantizeOnlyTest.cc
+++ b/test/RequantizeOnlyTest.cc
@@ -35,7 +35,7 @@ class FloatRequantizeTest
 
 }; // namespace
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     FloatRequantizeTest,
     ::testing::Combine(

--- a/test/RowWiseSparseAdagradFusedTest.cc
+++ b/test/RowWiseSparseAdagradFusedTest.cc
@@ -68,7 +68,7 @@ class RowWiseSparseAdagradFusedTest : public testing::TestWithParam<tuple<
 
 constexpr float DEFAULT_TOL = 1.0e-6;
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     RowWiseSparseAdagradFusedTest,
     ::testing::Combine(

--- a/test/SparseAdagradTest.cc
+++ b/test/SparseAdagradTest.cc
@@ -52,7 +52,7 @@ class SparseAdagradTest
 constexpr float DEFAULT_TOL = 1.0e-6;
 
 // Test:
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     SparseAdagradTest,
     ::testing::Combine(

--- a/test/SparseDenseMMInt8Test.cc
+++ b/test/SparseDenseMMInt8Test.cc
@@ -28,7 +28,7 @@ class SPMMInt8Test
     : public testing::TestWithParam<
           tuple<int, int, int, float, bool, QuantizationGranularity>> {};
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     SPMMInt8Test,
     ::testing::Combine(

--- a/test/SparsePackUnpackTest.cc
+++ b/test/SparsePackUnpackTest.cc
@@ -20,7 +20,7 @@ using namespace fbgemm;
 // tuple represents N and K
 class packUnpackTest : public testing::TestWithParam<tuple<int, int, float>> {};
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     packUnpackTest,
     ::testing::Combine(

--- a/test/TransposedRequantizeTest.cc
+++ b/test/TransposedRequantizeTest.cc
@@ -35,7 +35,7 @@ class RequantizeTest
 
 }; // namespace
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     RequantizeTest,
     ::testing::Combine(

--- a/test/UniConvTest.cc
+++ b/test/UniConvTest.cc
@@ -165,7 +165,7 @@ class UniConvQGranTest
 }; // namespace
 
 // Combine only allows at most 10 generators.
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     uniConvTest,
     ::testing::Combine(
@@ -180,7 +180,7 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::ValuesIn({1, 2}), // stride
         ::testing::ValuesIn({0, 1, 2}))); // pad
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
     UniConvQGranTest,
     ::testing::Combine(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1550

Clean up these deprecation warnings before it is possible to build newer asmjit.


Reviewed By: cthi

Differential Revision: D78252575

Pulled By: q10
