### PR TITLE
load kv weights by chunk

### DIFF
--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.h
@@ -33,6 +33,11 @@ class DramKVEmbeddingInferenceWrapper : public torch::jit::CustomClassHolder {
 
   at::Tensor get_embeddings(const at::Tensor& indices);
 
+  std::shared_ptr<kv_mem::DramKVEmbeddingCache<uint8_t>> get_dram_kv();
+
+  void set_dram_kv(
+      std::shared_ptr<kv_mem::DramKVEmbeddingCache<uint8_t>> dram_kv);
+
   c10::List<at::Tensor> serialize() const;
 
   void deserialize(const c10::List<at::Tensor>& states);
@@ -43,7 +48,7 @@ class DramKVEmbeddingInferenceWrapper : public torch::jit::CustomClassHolder {
   double uniform_init_upper_ = 0.0;
   int64_t evict_trigger_mode_ = 0;
 
-  std::unique_ptr<kv_mem::DramKVEmbeddingCache<uint8_t>> dram_cache_;
+  std::shared_ptr<kv_mem::DramKVEmbeddingCache<uint8_t>> dram_kv_;
   int64_t max_row_bytes_ = 0;
 };
 


### PR DESCRIPTION
Summary: Add chunk loading for kv weights, the code path is shared for both initial load and inplace update. We use different flag to control the chunk size.

Reviewed By: emlin

Differential Revision:
D76995700

Privacy Context Container: L1299884


