### PR TITLE
inference eviction interfaces

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/cache/kv_embedding_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/cache/kv_embedding_ops_inference.py
@@ -354,5 +354,6 @@ class KVEmbeddingInference(IntNBitTableBatchedEmbeddingBagsCodegen):
                 self.specs,
                 self.row_alignment,
                 self.scale_bias_size_in_bytes,
+                self.hash_size_cumsum,
             )
             self.kv_embedding_cache_initialized = True

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.cpp
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.cpp
@@ -15,17 +15,16 @@ namespace fbgemm_gpu {
 DramKVEmbeddingInferenceWrapper::DramKVEmbeddingInferenceWrapper(
     int64_t num_shards,
     double uniform_init_lower,
-    double uniform_init_upper,
-    int64_t evict_trigger_mode)
+    double uniform_init_upper)
     : num_shards_(num_shards),
       uniform_init_lower_(uniform_init_lower),
-      uniform_init_upper_(uniform_init_upper),
-      evict_trigger_mode_(evict_trigger_mode) {}
+      uniform_init_upper_(uniform_init_upper) {}
 
 void DramKVEmbeddingInferenceWrapper::init(
     const std::vector<SerializedSepcType>& specs,
     const int64_t row_alignment,
-    const int64_t scale_bias_size_in_bytes) {
+    const int64_t scale_bias_size_in_bytes,
+    const std::optional<at::Tensor>& hash_size_cumsum) {
   int64_t max_D = 0;
   for (auto i = 0; i < specs.size(); ++i) {
     max_D = std::max(max_D, std::get<1>(specs[i]));
@@ -35,13 +34,16 @@ void DramKVEmbeddingInferenceWrapper::init(
       static_cast<fbgemm_gpu::SparseType>(std::get<2>(specs[0])),
       static_cast<int32_t>(row_alignment),
       static_cast<int32_t>(scale_bias_size_in_bytes));
-  dram_kv_ = std::make_unique<kv_mem::DramKVEmbeddingCache<uint8_t>>(
+  if (dram_kv_ != nullptr) {
+    return;
+  }
+  dram_kv_ = std::make_shared<kv_mem::DramKVEmbeddingCache<uint8_t>>(
       max_row_bytes_,
       uniform_init_lower_,
       uniform_init_upper_,
       c10::make_intrusive<kv_mem::FeatureEvictConfig>(
-          evict_trigger_mode_,
-          0 /* evict_trigger_strategy */,
+          3 /* EvictTriggerMode.MANUAL */,
+          4 /* EvictTriggerStrategy::BY_TIMESTAMP_THRESHOLD */,
           0 /* trigger_step_intervals */,
           0 /* mem_util_threshold_in_GB */,
           std::nullopt /* ttls_in_mins */,
@@ -51,7 +53,11 @@ void DramKVEmbeddingInferenceWrapper::init(
           std::nullopt /* embedding_dims */),
       num_shards_ /* num_shards */,
       num_shards_ /* num_threads */,
-      8 /* row_storage_bitwidth */);
+      8 /* row_storage_bitwidth */,
+      false /* backend_return_whole_row */,
+      false /* enable_async_update */,
+      std::nullopt /* table_dims */,
+      hash_size_cumsum);
   return;
 }
 
@@ -86,10 +92,18 @@ at::Tensor DramKVEmbeddingInferenceWrapper::get_embeddings(
   return weights;
 }
 
+void DramKVEmbeddingInferenceWrapper::trigger_evict() {
+  dram_kv_->trigger_feature_evict();
+  // dram_kv_->resume_ongoing_eviction();
+}
+
+void DramKVEmbeddingInferenceWrapper::wait_evict_completion() {
+  dram_kv_->wait_until_eviction_done();
+}
+
 c10::List<at::Tensor> DramKVEmbeddingInferenceWrapper::serialize() const {
   c10::List<at::Tensor> results;
-  results.push_back(
-      torch::tensor({num_shards_, evict_trigger_mode_}, torch::kInt64));
+  results.push_back(torch::tensor({num_shards_}, torch::kInt64));
   results.push_back(torch::tensor(
       {uniform_init_lower_, uniform_init_upper_}, torch::kDouble));
   return results;
@@ -103,9 +117,8 @@ void DramKVEmbeddingInferenceWrapper::deserialize(
   TORCH_CHECK(states.size() >= 2);
 
   auto* intPtr = states[0].data_ptr<int64_t>();
-  TORCH_CHECK(states[0].numel() >= 2)
+  TORCH_CHECK(states[0].numel() >= 1)
   num_shards_ = intPtr[0];
-  evict_trigger_mode_ = intPtr[1];
 
   TORCH_CHECK(states[1].numel() >= 2)
   auto* floatPtr = states[1].data_ptr<double>();
@@ -119,7 +132,7 @@ static auto dram_kv_embedding_inference_wrapper =
     torch::class_<fbgemm_gpu::DramKVEmbeddingInferenceWrapper>(
         "fbgemm",
         "DramKVEmbeddingInferenceWrapper")
-        .def(torch::init<int64_t, double, double, int64_t>())
+        .def(torch::init<int64_t, double, double>())
         .def("init", &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::init)
         .def(
             "set_embeddings",
@@ -127,6 +140,12 @@ static auto dram_kv_embedding_inference_wrapper =
         .def(
             "get_embeddings",
             &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::get_embeddings)
+        .def(
+            "trigger_evict",
+            &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::trigger_evict)
+        .def(
+            "wait_evict_completion",
+            &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::wait_evict_completion)
         .def(
             "serialize",
             &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::serialize)

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.h
@@ -33,6 +33,11 @@ class DramKVEmbeddingInferenceWrapper : public torch::jit::CustomClassHolder {
 
   at::Tensor get_embeddings(const at::Tensor& indices);
 
+  std::shared_ptr<kv_mem::DramKVEmbeddingCache<uint8_t>> get_dram_kv();
+
+  void set_dram_kv(
+      std::shared_ptr<kv_mem::DramKVEmbeddingCache<uint8_t>> dram_kv);
+
   c10::List<at::Tensor> serialize() const;
 
   void deserialize(const c10::List<at::Tensor>& states);
@@ -43,7 +48,7 @@ class DramKVEmbeddingInferenceWrapper : public torch::jit::CustomClassHolder {
   double uniform_init_upper_ = 0.0;
   int64_t evict_trigger_mode_ = 0;
 
-  std::unique_ptr<kv_mem::DramKVEmbeddingCache<uint8_t>> dram_cache_;
+  std::shared_ptr<kv_mem::DramKVEmbeddingCache<uint8_t>> dram_kv_;
   int64_t max_row_bytes_ = 0;
 };
 

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.h
@@ -18,8 +18,7 @@ class DramKVEmbeddingInferenceWrapper : public torch::jit::CustomClassHolder {
   DramKVEmbeddingInferenceWrapper(
       int64_t num_shards = 32,
       double uniform_init_lower = 0.0,
-      double uniform_init_upper = 0.0,
-      int64_t evict_trigger_mode = 0);
+      double uniform_init_upper = 0.0);
 
   using SerializedSepcType =
       std::tuple<int64_t, int64_t, int64_t>; // (rows, dime, sparse_type)
@@ -27,11 +26,16 @@ class DramKVEmbeddingInferenceWrapper : public torch::jit::CustomClassHolder {
   void init(
       const std::vector<SerializedSepcType>& specs,
       const int64_t row_alignment,
-      const int64_t scale_bias_size_in_bytes);
+      const int64_t scale_bias_size_in_bytes,
+      const std::optional<at::Tensor>& hash_size_cumsum);
 
   void set_embeddings(const at::Tensor& indices, const at::Tensor& weights);
 
   at::Tensor get_embeddings(const at::Tensor& indices);
+
+  void trigger_evict();
+
+  void wait_evict_completion();
 
   std::shared_ptr<kv_mem::DramKVEmbeddingCache<uint8_t>> get_dram_kv();
 
@@ -46,7 +50,6 @@ class DramKVEmbeddingInferenceWrapper : public torch::jit::CustomClassHolder {
   int64_t num_shards_ = 32;
   double uniform_init_lower_ = 0.0;
   double uniform_init_upper_ = 0.0;
-  int64_t evict_trigger_mode_ = 0;
 
   std::shared_ptr<kv_mem::DramKVEmbeddingCache<uint8_t>> dram_kv_;
   int64_t max_row_bytes_ = 0;

--- a/fbgemm_gpu/test/tbe/dram_kv/dram_kv_inference_test.py
+++ b/fbgemm_gpu/test/tbe/dram_kv/dram_kv_inference_test.py
@@ -1,0 +1,99 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+import fbgemm_gpu
+
+import torch
+from fbgemm_gpu.split_embedding_configs import SparseType
+from fbgemm_gpu.utils.loader import load_torch_module
+
+# pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
+open_source: bool = getattr(fbgemm_gpu, "open_source", False)
+
+if not open_source:
+    load_torch_module(
+        "//deeplearning/fbgemm/fbgemm_gpu:dram_kv_embedding_inference",
+    )
+
+
+@unittest.skipIf(open_source, "Not supported in open source yet")
+class DramKvInferenceTest(unittest.TestCase):
+    def test_serialize(self) -> None:
+        num_shards = 32
+        uniform_init_lower: float = -0.01
+        uniform_init_upper: float = 0.01
+
+        kv_embedding_cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(
+            num_shards, uniform_init_lower, uniform_init_upper
+        )
+        serialized_result = kv_embedding_cache.serialize()
+
+        self.assertEqual(serialized_result[0][0], num_shards)
+
+        self.assertEqual(serialized_result[1][0], uniform_init_lower)
+        self.assertEqual(serialized_result[1][1], uniform_init_upper)
+
+    def test_serialize_deserialize(self) -> None:
+        num_shards = 32
+        uniform_init_lower: float = -0.01
+        uniform_init_upper: float = 0.01
+
+        kv_embedding_cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(
+            num_shards, uniform_init_lower, uniform_init_upper
+        )
+        serialized_result = kv_embedding_cache.serialize()
+
+        kv_embedding_cache_2 = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(
+            0, 0.0, 0.0
+        )
+        kv_embedding_cache_2.deserialize(serialized_result)
+
+        self.assertEqual(str(serialized_result), str(kv_embedding_cache_2.serialize()))
+
+    def test_set_get_embeddings(self) -> None:
+        num_shards = 32
+        uniform_init_lower: float = 0.0
+        uniform_init_upper: float = 0.0
+
+        kv_embedding_cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(
+            num_shards, uniform_init_lower, uniform_init_upper
+        )
+        kv_embedding_cache.init(
+            [(20, 4, SparseType.INT8.as_int())],
+            8,
+            4,
+            torch.tensor([0, 32], dtype=torch.int64),
+        )
+
+        kv_embedding_cache.set_embeddings(
+            torch.tensor([0, 1, 2, 3], dtype=torch.int64),
+            torch.tensor(
+                [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]],
+                dtype=torch.uint8,
+            ),
+        )
+
+        embs = kv_embedding_cache.get_embeddings(
+            torch.tensor([1, 4, 3, 0, 5, 2], dtype=torch.int64),
+        )
+        assert torch.equal(
+            embs[:, :4],
+            torch.tensor(
+                [
+                    [5, 6, 7, 8],
+                    [0, 0, 0, 0],
+                    [13, 14, 15, 16],
+                    [1, 2, 3, 4],
+                    [0, 0, 0, 0],
+                    [9, 10, 11, 12],
+                ],
+                dtype=torch.uint8,
+            ),
+        )


### PR DESCRIPTION
Summary: Add a few inference eviction interfaces. The are interfaces breaking changes, but since model is not in production and it's not affecting other models so it should be fine.

Reviewed By: duduyi2013

Differential Revision: D78010843


