### PR TITLE
inference eviction

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/cache/kv_embedding_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/cache/kv_embedding_ops_inference.py
@@ -114,10 +114,9 @@ class KVEmbeddingInference(IntNBitTableBatchedEmbeddingBagsCodegen):
         num_shards = 32
         uniform_init_lower: float = -0.01
         uniform_init_upper: float = 0.01
-        evict_trigger_mode: int = 0
         # pyre-fixme[4]: Attribute must be annotated.
         self.kv_embedding_cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(
-            num_shards, uniform_init_lower, uniform_init_upper, evict_trigger_mode
+            num_shards, uniform_init_lower, uniform_init_upper
         )
 
         self.specs: List[Tuple[int, int, int]] = [
@@ -295,6 +294,7 @@ class KVEmbeddingInference(IntNBitTableBatchedEmbeddingBagsCodegen):
         update_row_indices: List[List[int]],
         update_weights: List[Tensor],
     ) -> None:
+        # function is not used for now on the inference side
         for i in range(len(update_table_indices)):
             self.embedding_inplace_update_per_table(
                 update_table_indices[i],
@@ -302,6 +302,7 @@ class KVEmbeddingInference(IntNBitTableBatchedEmbeddingBagsCodegen):
                     update_row_indices[i], device=self.current_device, dtype=torch.int64
                 ),
                 update_weights[i],
+                None,
             )
 
     @torch.jit.export
@@ -310,6 +311,7 @@ class KVEmbeddingInference(IntNBitTableBatchedEmbeddingBagsCodegen):
         table_id: int,
         update_row_indices: Tensor,
         update_weights: Tensor,
+        inplace_update_ts_sec: Optional[int] = None,
     ) -> None:
         assert table_id < len(
             self.embedding_specs
@@ -325,7 +327,28 @@ class KVEmbeddingInference(IntNBitTableBatchedEmbeddingBagsCodegen):
         # convert global weight index to fused local weight index
         row_indices = update_row_indices + table_offset - sharding_offset
         # set weight by id
-        self.kv_embedding_cache.set_embeddings(row_indices, update_weights)
+        self.kv_embedding_cache.set_embeddings(
+            row_indices, update_weights, inplace_update_ts_sec
+        )
+
+    @torch.jit.export
+    def log_inplace_update_stats(
+        self,
+    ) -> None:
+        self.kv_embedding_cache.log_inplace_update_stats()
+
+    @torch.jit.export
+    def embedding_trigger_evict(
+        self,
+        inplace_update_ts_sec: int,
+    ) -> None:
+        self.kv_embedding_cache.trigger_evict(inplace_update_ts_sec)
+
+    @torch.jit.export
+    def embedding_wait_evict_completion(
+        self,
+    ) -> None:
+        self.kv_embedding_cache.wait_evict_completion()
 
     @torch.jit.export
     def initialize_kv_embedding_cache(self) -> None:

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -343,7 +343,8 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             f"weights precision: {weights_precision}, "
             f"output dtype: {output_dtype}, "
             f"chunk size in bulk init: {bulk_init_chunk_size} bytes, backend_type: {backend_type}, "
-            f"kv_zch_params: {kv_zch_params}"
+            f"kv_zch_params: {kv_zch_params}, "
+            f"embedding spec: {embedding_specs}"
         )
         self.register_buffer(
             "lxu_cache_state",

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.cpp
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.cpp
@@ -25,6 +25,7 @@ void DramKVEmbeddingInferenceWrapper::init(
     const int64_t row_alignment,
     const int64_t scale_bias_size_in_bytes,
     const std::optional<at::Tensor>& hash_size_cumsum) {
+  LOG(INFO) << "DramKVEmbeddingInferenceWrapper::init() starts";
   int64_t max_D = 0;
   for (auto i = 0; i < specs.size(); ++i) {
     max_D = std::max(max_D, std::get<1>(specs[i]));
@@ -50,14 +51,17 @@ void DramKVEmbeddingInferenceWrapper::init(
           std::nullopt /* counter_thresholds */,
           std::nullopt /* counter_decay_rates */,
           std::nullopt /* l2_weight_thresholds */,
-          std::nullopt /* embedding_dims */),
+          std::nullopt /* embedding_dims */,
+          0 /* interval for insufficient eviction s*/,
+          0 /* interval for sufficient eviction s*/),
       num_shards_ /* num_shards */,
       num_shards_ /* num_threads */,
       8 /* row_storage_bitwidth */,
-      false /* backend_return_whole_row */,
+      false, /* backend_return_whole_row */
       false /* enable_async_update */,
       std::nullopt /* table_dims */,
-      hash_size_cumsum);
+      hash_size_cumsum,
+      false /* is_training */);
   return;
 }
 
@@ -73,9 +77,16 @@ void DramKVEmbeddingInferenceWrapper::set_dram_kv(
 
 void DramKVEmbeddingInferenceWrapper::set_embeddings(
     const at::Tensor& indices,
-    const at::Tensor& weights) {
+    const at::Tensor& weights,
+    std::optional<int64_t> inplace_update_ts_opt) {
   const auto count = at::tensor({indices.numel()}, at::ScalarType::Long);
-  folly::coro::blockingWait(dram_kv_->set_kv_db_async(indices, weights, count));
+  std::optional<uint32_t> inplacee_update_ts = std::nullopt;
+  if (inplace_update_ts_opt.has_value()) {
+    inplacee_update_ts =
+        static_cast<std::uint32_t>(inplace_update_ts_opt.value());
+  }
+  folly::coro::blockingWait(dram_kv_->inference_set_kv_db_async(
+      indices, weights, count, inplacee_update_ts));
   return;
 }
 
@@ -92,9 +103,16 @@ at::Tensor DramKVEmbeddingInferenceWrapper::get_embeddings(
   return weights;
 }
 
-void DramKVEmbeddingInferenceWrapper::trigger_evict() {
-  dram_kv_->trigger_feature_evict();
-  // dram_kv_->resume_ongoing_eviction();
+void DramKVEmbeddingInferenceWrapper::log_inplace_update_stats() {
+  return dram_kv_->log_inplace_update_stats();
+}
+
+void DramKVEmbeddingInferenceWrapper::trigger_evict(
+    int64_t inplace_update_ts_64b) {
+  uint32_t inplace_update_ts_32b =
+      static_cast<std::uint32_t>(inplace_update_ts_64b);
+  dram_kv_->trigger_feature_evict(inplace_update_ts_32b);
+  dram_kv_->resume_ongoing_eviction();
 }
 
 void DramKVEmbeddingInferenceWrapper::wait_evict_completion() {
@@ -136,7 +154,13 @@ static auto dram_kv_embedding_inference_wrapper =
         .def("init", &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::init)
         .def(
             "set_embeddings",
-            &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::set_embeddings)
+            &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::set_embeddings,
+            "",
+            {
+                torch::arg("indices"),
+                torch::arg("weights"),
+                torch::arg("inplace_update_ts_opt") = std::nullopt,
+            })
         .def(
             "get_embeddings",
             &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::get_embeddings)
@@ -146,6 +170,10 @@ static auto dram_kv_embedding_inference_wrapper =
         .def(
             "wait_evict_completion",
             &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::wait_evict_completion)
+        .def(
+            "log_inplace_update_stats",
+            &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::
+                log_inplace_update_stats)
         .def(
             "serialize",
             &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::serialize)

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.h
@@ -29,11 +29,16 @@ class DramKVEmbeddingInferenceWrapper : public torch::jit::CustomClassHolder {
       const int64_t scale_bias_size_in_bytes,
       const std::optional<at::Tensor>& hash_size_cumsum);
 
-  void set_embeddings(const at::Tensor& indices, const at::Tensor& weights);
+  void set_embeddings(
+      const at::Tensor& indices,
+      const at::Tensor& weights,
+      std::optional<int64_t> inplace_update_ts_opt = std::nullopt);
 
   at::Tensor get_embeddings(const at::Tensor& indices);
 
-  void trigger_evict();
+  void log_inplace_update_stats();
+
+  void trigger_evict(int64_t inplace_update_ts_64b);
 
   void wait_evict_completion();
 

--- a/fbgemm_gpu/src/embedding_inplace_ops/embedding_inplace_update_cpu.cpp
+++ b/fbgemm_gpu/src/embedding_inplace_ops/embedding_inplace_update_cpu.cpp
@@ -146,6 +146,8 @@ void dram_kv_embedding_inplace_update_cpu(
   auto embedding_inplace_update_method =
       tbe_module->find_method(tbe_module_update_func_name);
   TORCH_CHECK(embedding_inplace_update_method.has_value());
+  auto embedding_log_inplace_update_stats_method =
+      tbe_module->find_method("log_inplace_update_stats");
 
   const uint8_t* weights_tys_ptr = weights_tys.data_ptr<uint8_t>();
   const int32_t* D_offsets_ptr = D_offsets.data_ptr<int32_t>();
@@ -175,6 +177,9 @@ void dram_kv_embedding_inplace_update_cpu(
     at::Tensor row_id =
         at::full({1}, row_idx, at::TensorOptions().dtype(at::kLong));
     (*embedding_inplace_update_method)({t, row_id, update_weight});
+  }
+  if (embedding_log_inplace_update_stats_method.has_value()) {
+    (*embedding_log_inplace_update_stats_method)({});
   }
 }
 

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -140,7 +140,8 @@ EmbeddingKVDB::EmbeddingKVDB(
              << " shards, dimension:" << max_D_
              << ", enable_async_update_:" << enable_async_update_
              << ", enable_raw_embedding_streaming_:"
-             << enable_raw_embedding_streaming_;
+             << enable_raw_embedding_streaming_
+             << ", cache_size_gb:" << cache_size_gb;
 
   if (enable_async_update_) {
     cache_filling_thread_ = std::make_unique<std::thread>([=] {

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
@@ -297,7 +297,7 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
   /**
    * @brief pause any ongoing eviction, usually called before backend IO
    */
-  virtual void pause_ongoing_eviction() {
+  virtual void pause_ongoing_eviction(bool force_resume = false) {
     FBEXCEPTION("Not implemented");
   }
 
@@ -305,7 +305,7 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
    * @brief resume ongoing eviction, if any, usually called when there won't be
    * backend IO for a while
    */
-  virtual void resume_ongoing_eviction() {
+  virtual void resume_ongoing_eviction(bool force_pause = false) {
     FBEXCEPTION("Not implemented");
   }
 

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -423,7 +423,7 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
     return;
   }
 
-  void resume_ongoing_eviction() override {
+  void resume_ongoing_eviction(bool force_pause = false) override {
     // no op for now
     return;
   }

--- a/fbgemm_gpu/test/dram_kv_embedding_cache/feature_evict_test.cpp
+++ b/fbgemm_gpu/test/dram_kv_embedding_cache/feature_evict_test.cpp
@@ -74,6 +74,7 @@ TEST(FeatureEvictTest, CounterBasedEviction) {
       feature_evict_config,
       *kv_store_.get(),
       sub_table_hash_cumsum,
+      true, // is training
       TestMode::NORMAL);
 
   // Initial validation
@@ -153,7 +154,11 @@ TEST(FeatureEvictTest, TimeBasedEviction) {
           0); // embedding_dims
 
   auto feature_evict = create_feature_evict(
-      feature_evict_config, *kv_store_.get(), sub_table_hash_cumsum);
+      feature_evict_config,
+      *kv_store_.get(),
+      sub_table_hash_cumsum,
+      true // is training
+  );
 
   // Initial validation
   size_t total_blocks = 0;
@@ -238,7 +243,11 @@ TEST(FeatureEvictTest, TimeCounterBasedEviction) {
           0); // embedding_dims
 
   auto feature_evict = create_feature_evict(
-      feature_evict_config, *kv_store_.get(), sub_table_hash_cumsum);
+      feature_evict_config,
+      *kv_store_.get(),
+      sub_table_hash_cumsum,
+      true // is training
+  );
 
   // Initial validation
   size_t total_blocks = 0;
@@ -319,7 +328,11 @@ TEST(FeatureEvictTest, L2WeightBasedEviction) {
           0); // embedding_dims
 
   auto feature_evict = create_feature_evict(
-      feature_evict_config, *kv_store_.get(), sub_table_hash_cumsum);
+      feature_evict_config,
+      *kv_store_.get(),
+      sub_table_hash_cumsum,
+      true // is training
+  );
 
   // Initial validation
   size_t total_blocks = 0;
@@ -389,6 +402,7 @@ TEST(FeatureEvictTest, PerformanceTest) {
         counter_thresholds,
         0,
         0,
+        true, // is training
         TestMode::NORMAL);
 
     auto start_time = std::chrono::high_resolution_clock::now();
@@ -471,6 +485,7 @@ TEST(FeatureEvictTest, DupAPINoOpCheck) {
       feature_evict_config,
       *kv_store_.get(),
       sub_table_hash_cumsum,
+      true, // is training
       TestMode::NORMAL);
 
   // Initial validation
@@ -598,6 +613,7 @@ TEST(FeatureEvictTest, EdgeCase_NoPause) {
       feature_evict_config,
       *kv_store_.get(),
       sub_table_hash_cumsum,
+      true, // is training
       TestMode::NORMAL);
 
   // Initial validation
@@ -712,6 +728,7 @@ TEST(FeatureEvictTest, EdgeCase_PauseOnLastIter) {
       feature_evict_config,
       *kv_store_.get(),
       sub_table_hash_cumsum,
+      true, // is training
       TestMode::PAUSE_ON_LAST_ITERATION);
 
   // Initial validation

--- a/fbgemm_gpu/test/tbe/dram_kv/dram_kv_inference_test.py
+++ b/fbgemm_gpu/test/tbe/dram_kv/dram_kv_inference_test.py
@@ -6,10 +6,13 @@
 
 # pyre-strict
 
+import threading
+import time
 import unittest
+from time import sleep
+from typing import List
 
 import fbgemm_gpu
-
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
 from fbgemm_gpu.utils.loader import load_torch_module
@@ -29,15 +32,13 @@ class DramKvInferenceTest(unittest.TestCase):
         num_shards = 32
         uniform_init_lower: float = -0.01
         uniform_init_upper: float = 0.01
-        evict_trigger_mode: int = 1
 
         kv_embedding_cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(
-            num_shards, uniform_init_lower, uniform_init_upper, evict_trigger_mode
+            num_shards, uniform_init_lower, uniform_init_upper
         )
         serialized_result = kv_embedding_cache.serialize()
 
         self.assertEqual(serialized_result[0][0], num_shards)
-        self.assertEqual(serialized_result[0][1], evict_trigger_mode)
 
         self.assertEqual(serialized_result[1][0], uniform_init_lower)
         self.assertEqual(serialized_result[1][1], uniform_init_upper)
@@ -46,15 +47,14 @@ class DramKvInferenceTest(unittest.TestCase):
         num_shards = 32
         uniform_init_lower: float = -0.01
         uniform_init_upper: float = 0.01
-        evict_trigger_mode: int = 1
 
         kv_embedding_cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(
-            num_shards, uniform_init_lower, uniform_init_upper, evict_trigger_mode
+            num_shards, uniform_init_lower, uniform_init_upper
         )
         serialized_result = kv_embedding_cache.serialize()
 
         kv_embedding_cache_2 = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(
-            0, 0.0, 0.0, 0
+            0, 0.0, 0.0
         )
         kv_embedding_cache_2.deserialize(serialized_result)
 
@@ -64,10 +64,9 @@ class DramKvInferenceTest(unittest.TestCase):
         num_shards = 32
         uniform_init_lower: float = 0.0
         uniform_init_upper: float = 0.0
-        evict_trigger_mode: int = 0
 
         kv_embedding_cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(
-            num_shards, uniform_init_lower, uniform_init_upper, evict_trigger_mode
+            num_shards, uniform_init_lower, uniform_init_upper
         )
         kv_embedding_cache.init(
             [(20, 4, SparseType.INT8.as_int())],
@@ -85,19 +84,169 @@ class DramKvInferenceTest(unittest.TestCase):
         )
 
         embs = kv_embedding_cache.get_embeddings(
-            torch.tensor([1, 4, 3, 0, 5, 2], dtype=torch.int64),
+            torch.tensor([1, 3, 0, 2, 4, 5], dtype=torch.int64),
         )
         assert torch.equal(
-            embs[:, :4],
+            embs[:4, :4],
             torch.tensor(
                 [
                     [5, 6, 7, 8],
-                    [0, 0, 0, 0],
                     [13, 14, 15, 16],
                     [1, 2, 3, 4],
-                    [0, 0, 0, 0],
                     [9, 10, 11, 12],
                 ],
                 dtype=torch.uint8,
             ),
         )
+
+        def equal_one_of(t1: torch.Tensor, t2: List[torch.Tensor]) -> bool:
+            any_equal = False
+            for t in t2:
+                any_equal = torch.equal(t1, t)
+                if any_equal:
+                    return any_equal
+            return any_equal
+
+        possible_embs = [
+            torch.tensor([5, 6, 7, 8], dtype=torch.uint8),
+            torch.tensor([13, 14, 15, 16], dtype=torch.uint8),
+            torch.tensor([1, 2, 3, 4], dtype=torch.uint8),
+            torch.tensor([9, 10, 11, 12], dtype=torch.uint8),
+            torch.tensor([0, 0, 0, 0], dtype=torch.uint8),
+        ]
+        self.assertTrue(equal_one_of(embs[4, :4], possible_embs))
+        self.assertTrue(equal_one_of(embs[5, :4], possible_embs))
+
+    def test_inplace_update(self) -> None:
+        num_shards = 1
+        uniform_init_lower: float = 0.0
+        uniform_init_upper: float = 0.0
+
+        kv_embedding_cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(
+            num_shards, uniform_init_lower, uniform_init_upper
+        )
+        kv_embedding_cache.init(
+            [(20, 4, SparseType.INT8.as_int())],
+            8,
+            4,
+            torch.tensor([0, 20], dtype=torch.int64),
+        )
+        init_ids = torch.tensor([0, 1, 2, 3], dtype=torch.int64)
+        init_weights = torch.tensor(
+            [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]],
+            dtype=torch.uint8,
+        )
+        kv_embedding_cache.set_embeddings(
+            init_ids,
+            init_weights,
+        )
+        full_ids: torch.Tensor = torch.tensor([0, 1, 2, 3, 4, 5], dtype=torch.int64)
+
+        def equal_one_of(t1: torch.Tensor, t2: List[torch.Tensor]) -> bool:
+            any_equal = False
+            for t in t2:
+                any_equal = torch.equal(t1, t)
+                if any_equal:
+                    return any_equal
+            return any_equal
+
+        possible_embs = [
+            torch.tensor([5, 6, 7, 8], dtype=torch.uint8),
+            torch.tensor([17, 18, 19, 20], dtype=torch.uint8),
+            torch.tensor([1, 2, 3, 4], dtype=torch.uint8),
+            torch.tensor([21, 22, 23, 24], dtype=torch.uint8),
+            torch.tensor([0, 0, 0, 0], dtype=torch.uint8),
+        ]
+
+        import logging
+
+        logging.basicConfig(level=logging.INFO, format="%(threadName)s: %(message)s")
+
+        reader_start_event = threading.Event()
+
+        reader_failed_event = threading.Event()
+
+        def reader_thread() -> None:  # pyre-ignore
+            itr = 0
+            reader_start_event.wait()
+            try:
+                while itr < 100:
+                    embs = kv_embedding_cache.get_embeddings(full_ids)
+                    self.assertEqual(embs.size(0), 6)
+                    self.assertEqual(embs.size(1), 8)
+                    self.assertTrue(
+                        torch.equal(
+                            embs[0][:4],
+                            torch.tensor([1, 2, 3, 4], dtype=torch.uint8),
+                        ),
+                        f"id0: {embs[0][:4]} failed",
+                    )
+                    self.assertTrue(
+                        torch.equal(
+                            embs[1][:4],
+                            torch.tensor([5, 6, 7, 8], dtype=torch.uint8),
+                        ),
+                        f"id1: {embs[1][:4]} failed",
+                    )
+                    self.assertTrue(
+                        equal_one_of(embs[2][:4], possible_embs + [9, 10, 11, 12]),
+                        f"id2: {embs[2][:4]} failed",
+                    )
+                    self.assertTrue(
+                        equal_one_of(embs[3][:4], possible_embs + [13, 14, 15, 16]),
+                        f"id3: {embs[3][:4]} failed",
+                    )
+                    self.assertTrue(
+                        equal_one_of(embs[4][:4], possible_embs),
+                        f"id3: {embs[4][:4]} failed",
+                    )
+                    self.assertTrue(
+                        equal_one_of(embs[5][:4], possible_embs),
+                        f"id3: {embs[5][:4]} failed",
+                    )
+                    itr += 1
+            except Exception as e:
+                reader_failed_event.set()
+                raise e
+
+        reader_thread = threading.Thread(target=reader_thread, name="ReaderThread")
+        reader_thread.start()
+        sleep(1)
+
+        reader_start_event.set()
+        sleep(0.001)  # 10 us to make sure reader thread is reading
+        current_ts_sec = int(time.time())
+
+        ipu_ids = torch.tensor([0, 1, 4, 5], dtype=torch.int64)
+        ipu_weights = torch.tensor(
+            [[1, 2, 3, 4], [5, 6, 7, 8], [17, 18, 19, 20], [21, 22, 23, 24]],
+            dtype=torch.uint8,
+        )
+        kv_embedding_cache.set_embeddings(
+            ipu_ids,
+            ipu_weights,
+            current_ts_sec,
+        )
+
+        kv_embedding_cache.trigger_evict(current_ts_sec)
+        kv_embedding_cache.wait_evict_completion()
+
+        embs = kv_embedding_cache.get_embeddings(
+            torch.tensor([1, 4, 0, 5, 2, 3], dtype=torch.int64),
+        )
+        assert torch.equal(
+            embs[:4, :4],
+            torch.tensor(
+                [
+                    [5, 6, 7, 8],
+                    [17, 18, 19, 20],
+                    [1, 2, 3, 4],
+                    [21, 22, 23, 24],
+                ],
+                dtype=torch.uint8,
+            ),
+        )
+        self.assertTrue(equal_one_of(embs[4, :4], possible_embs))
+        self.assertTrue(equal_one_of(embs[5, :4], possible_embs))
+        reader_thread.join()
+        self.assertFalse(reader_failed_event.is_set())


### PR DESCRIPTION
Summary:
pseudo code design: D77081139

changeset:
- introduce new dram kv set io function to minimize lock content and improve inference QPS during IPU, consist of 4 parts
   1. collect hit/miss per inplace update chunk, only requires rlock on each shard
   2. no lock on update hits, it is possible that nference read is accessing a weight being updated, we assume it is fine for now, will iterate on it if we find QE regress during inplace update
   3. update misses in fixed block pool, we only need mempool lock at this stage to avoid race condition with eviction, if any. the mempool lock is not acquired when serving request, it is only acquired during eviction
   4. update shard hmap with newly allocated info, this acquires wlock, we minimize it from original set_kv_db_async to only include hmap update, this helps reduce the blocking time for inference read significantly
- update eviction logic to break it down into multiple steps, following the same design principle above and reduce the serving QPS blocking duration
- For every full snapshot transition, we will trigger eviction after IPU finishes with the start_ts that helps evict out the untouched embeddings. We specifically disable eviction during delta snapshot transition.

Differential Revision: D77096462
