### PR TITLE
add unit test for offloading (metaheader included)

### DIFF
--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
@@ -822,6 +822,15 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
     // TODO: assert there isn't any eviction including paused
   }
 
+  void set_kv_to_storage(const at::Tensor& ids, const at::Tensor& weights) {
+    if (backend_return_whole_row_) {
+      set_kv_with_metaheader_to_storage(weights);
+    } else {
+      const auto count = at::tensor({ids.size(0)}, at::ScalarType::Long);
+      set_kv_db_async(ids, weights, count).wait();
+    }
+  }
+
   void get_kv_from_storage_by_snapshot(
       const at::Tensor& ids,
       const at::Tensor& weights,

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
@@ -379,9 +379,12 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
     FBEXCEPTION("Not implemented");
   }
 
-  void set_kv_to_storage(const at::Tensor& ids, const at::Tensor& weights) {
-    const auto count = at::tensor({ids.size(0)}, at::ScalarType::Long);
-    set_kv_db_async(ids, weights, count).wait();
+  virtual void set_kv_to_storage(
+      const at::Tensor& ids,
+      const at::Tensor& weights) {
+    (void)ids;
+    (void)weights;
+    FBEXCEPTION("Not implemented");
   }
 
   virtual void get_kv_from_storage_by_snapshot(

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -542,7 +542,9 @@ void KVTensorWrapper::set_range(
   } else {
     std::vector<int64_t> padding = {0, pad_right, 0, 0};
     auto padded_weights = torch::constant_pad_nd(weights, padding, 0);
-    CHECK_EQ(db_->get_max_D(), padded_weights.size(1));
+    CHECK_EQ(
+        db_->get_max_D() + db_->get_metaheader_width_in_front(),
+        padded_weights.size(1));
     db_->set_range_to_storage(padded_weights, start + row_offset_, length);
   }
 }
@@ -559,15 +561,18 @@ void KVTensorWrapper::set_weights_and_ids(
   CHECK_TRUE(db_ != nullptr);
   CHECK_EQ(ids.size(0), weights.size(0))
       << "ids and weights must have same # rows";
-  CHECK_GE(db_->get_max_D(), shape_[1]);
+  CHECK_GE(db_->get_max_D() + db_->get_metaheader_width_in_front(), shape_[1]);
   auto linearized_ids = ids + row_offset_;
-  int pad_right = db_->get_max_D() - weights.size(1);
+  int pad_right =
+      db_->get_max_D() + db_->get_metaheader_width_in_front() - weights.size(1);
   if (pad_right == 0) {
     db_->set_kv_to_storage(linearized_ids, weights);
   } else {
     std::vector<int64_t> padding = {0, pad_right, 0, 0};
     auto padded_weights = torch::constant_pad_nd(weights, padding, 0);
-    CHECK_EQ(db_->get_max_D(), padded_weights.size(1));
+    CHECK_EQ(
+        db_->get_max_D() + db_->get_metaheader_width_in_front(),
+        padded_weights.size(1));
     db_->set_kv_to_storage(linearized_ids, padded_weights);
   }
 }


### PR DESCRIPTION
Summary:
Added unit test for the following conditions, and fixed related bugs:
1. ZCH fused optimizer with offloading
2. Added DRAM kernel for stat dict loading (with metaheader)and numerical accuracy
3. Applied return whole row for DRAM kernel.

Reviewed By: emlin, bobbyliujb

Differential Revision: D77474510


