### PR TITLE
Handle fetch optimizer states for the KV ZCH load state dict case

### DIFF
--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
@@ -2477,7 +2477,7 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
         emb2.local_weight_counts = [ids.numel() for ids in bucket_asc_ids_list]
         emb2.enable_load_state_dict_mode()
         self.assertIsNotNone(emb2._cached_kvzch_data)
-        for i in range(len(emb.embedding_specs)):
+        for i, _ in enumerate(emb.embedding_specs):
             # pyre-ignore [16]
             emb2._cached_kvzch_data.cached_weight_tensor_per_table[i].copy_(
                 # pyre-fixme[16]: Undefined attribute: Item `torch._tensor.Tensor` of `typing.Uni...
@@ -2487,7 +2487,7 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
             # EXACT_ROWWISE_ADAGRAD optimizer.  The test in general should
             # be upgraded in the future to support multiple optimizers
             # pyre-ignore [16]
-            emb2._cached_kvzch_data.cached_optimizer_state_per_table[i].copy_(
+            emb2._cached_kvzch_data.cached_optimizer_states_per_table[i][0].copy_(
                 split_optimizer_states[i][0]
             )
             # pyre-ignore [16]


### PR DESCRIPTION
Summary:
This diff updates `KVZCHCachedData` to hold multiple optimizer states per table in cached_optimizer_states_per_table, and updates apply_state_dict to handle writing out multiple optimizer states per table row to the cache.  This is needed for enabling other optimizers to work with SSD TBE, such as Partial Rowwise Adam.

There are 4 cases to handle when attempting to fetch the split optimizer states:

1. The no-KV ZCH case
1. The KV ZCH case, but where `self.load_state_dict` is `True` (i.e. fall back to `self._cached_kvzch_data`)
1. The KV ZCH case, where `self.load_state_dict` is `False`, and `self.enable_optimizer_offloading` is false 
1. The KV ZCH case, where `self.load_state_dict` is `False`, and `self.enable_optimizer_offloading` is `True`

The diff completes the handling of returning optimizer states for the KV ZCH case, but where `self.load_state_dict` is true (case 2).

Reviewed By: emlin

Differential Revision: D77771359


