### PR TITLE
Optimization of Groupwise GEMM

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_groupwise.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_groupwise.cu
@@ -25,9 +25,9 @@ get_kernel_via_heuristic(int arch, int M, int N, int K) {
   // Use shape heuristics to dispatch to optimized kernel configuration.
   // Initial enablement includes only one schedule.
   if (M <= 16) {
-    return f8f8bf16_groupwise_128_16_128_1_1_1_9_t;
+    return f8f8bf16_groupwise_128_16_128_1_1_1_9_t_t_0;
   } else {
-    return f8f8bf16_groupwise_128_128_128_1_2_1_9_f;
+    return f8f8bf16_groupwise_128_128_128_1_2_1_9_f_f_8;
   }
 }
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_groupwise/f8f8bf16_groupwise_128_128_128_1_2_1_9_f_f_8.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_groupwise/f8f8bf16_groupwise_128_128_128_1_2_1_9_f_f_8.cu
@@ -10,13 +10,13 @@
 
 namespace fbgemm_gpu {
 
-at::Tensor f8f8bf16_groupwise_128_16_128_1_1_1_9_t(
+at::Tensor f8f8bf16_groupwise_128_128_128_1_2_1_9_f_f_8(
     at::Tensor XQ,
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale) {
   // Dispatch this kernel to the correct underlying implementation.
-  return f8f8bf16_groupwise_wrapper<128, 16, 128, 1, 1, 1, 9, true>(
+  return f8f8bf16_groupwise_wrapper<128, 128, 128, 1, 2, 1, 9, false, false, 8>(
       XQ, WQ, x_scale, w_scale);
 }
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_groupwise/f8f8bf16_groupwise_128_16_128_1_1_1_9_t_t_0.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_groupwise/f8f8bf16_groupwise_128_16_128_1_1_1_9_t_t_0.cu
@@ -10,13 +10,13 @@
 
 namespace fbgemm_gpu {
 
-at::Tensor f8f8bf16_groupwise_128_128_128_1_2_1_9_f(
+at::Tensor f8f8bf16_groupwise_128_16_128_1_1_1_9_t_t_0(
     at::Tensor XQ,
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale) {
   // Dispatch this kernel to the correct underlying implementation.
-  return f8f8bf16_groupwise_wrapper<128, 128, 128, 1, 2, 1, 9, false>(
+  return f8f8bf16_groupwise_wrapper<128, 16, 128, 1, 1, 1, 9, true, true, 0>(
       XQ, WQ, x_scale, w_scale);
 }
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_groupwise/f8f8bf16_groupwise_manifest.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_groupwise/f8f8bf16_groupwise_manifest.cuh
@@ -10,13 +10,13 @@
 
 namespace fbgemm_gpu {
 
-at::Tensor f8f8bf16_groupwise_128_128_128_1_2_1_9_f(
+at::Tensor f8f8bf16_groupwise_128_128_128_1_2_1_9_f_f_8(
     at::Tensor XQ,
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale);
 
-at::Tensor f8f8bf16_groupwise_128_16_128_1_1_1_9_t(
+at::Tensor f8f8bf16_groupwise_128_16_128_1_1_1_9_t_t_0(
     at::Tensor XQ,
     at::Tensor WQ,
     at::Tensor x_scale,


### PR DESCRIPTION
Summary: This diff expands the templatization of FBGEMM's cutlass groupwise GEMM to include options to limit the swizzling of loaded tiles and implicitly transpose tiles. We introduce a bit of additional tuning that shows this allows us to get decent performance in both compute and memory bound domains. In a followup diff, we will dramatically expand these heuristics for better performance.

Differential Revision: D78537461
