### PR TITLE
Replace remaining uses of optimizer dtype() method with `optimizer_state_dtypes` dictionary

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
@@ -227,14 +227,6 @@ class EmbOptimType(enum.Enum):
             for (name, cumsum_table) in params.items()
         ]
 
-    def dtype(self) -> torch.dtype:
-        """
-        Returns the dtype of the optimizer state
-        """
-        return {
-            EmbOptimType.EXACT_ROWWISE_ADAGRAD: torch.float32,
-        }.get(self, torch.float32)
-
 
 # Base class for quantization configuration (in case other numeric types have
 # configs)


### PR DESCRIPTION
Summary: This diff replaces remaining usages of  `optimizer.dtype()` with `optimizer_state_dtypes` dictionary, to accomodate optimizers with multiple states.

Reviewed By: sryap, emlin

Differential Revision: D77902644


