### PR TITLE
Fix gcc warning suppression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,9 +149,6 @@ if(NOT MSVC)
     src/FbgemmFP16UKernelsAvx512_256.cc
     PROPERTIES COMPILE_FLAGS "-masm=intel")
 
-  set_source_files_properties(src/PackMatrix.cc
-    PROPERTIES COMPILE_FLAGS "-Wno-infinite-recursion")
-
   # Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80947
   if(CMAKE_COMPILER_IS_GNUCXX AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.3.0))
     set_source_files_properties(

--- a/include/fbgemm/FbgemmBuild.h
+++ b/include/fbgemm/FbgemmBuild.h
@@ -90,7 +90,7 @@
 #endif
 
 // Macro for silencing warnings
-#ifdef __clang__
+#if __clang__ || __GNUC__
 // clang-format off
 #define FBGEMM_PUSH_WARNING _Pragma("GCC diagnostic push")
 #define FBGEMM_DISABLE_WARNING_INTERNAL2(warningName) #warningName


### PR DESCRIPTION
Fix `FBGEMM_PUSH_WARNING` on gcc