### PR TITLE
Remove code for old compilers (#4526)

### DIFF
--- a/include/fbgemm/FbgemmBuild.h
+++ b/include/fbgemm/FbgemmBuild.h
@@ -30,7 +30,7 @@
 #endif
 #define FBGEMM_ENUM_CLASS_API
 #else
-#if __clang__ || __GNUC__ >= 4 || __INTEL_COMPILER
+#if __clang__ || __GNUC__ || __INTEL_COMPILER
 #define FBGEMM_API __attribute__((__visibility__("default")))
 #else
 #define FBGEMM_API
@@ -46,7 +46,7 @@
 #endif
 
 // Use this to indicate to not inline functions
-#if __clang__ || __GNUC__ >= 4 || __INTEL_COMPILER
+#if __clang__ || __GNUC__ || __INTEL_COMPILER
 #define NOINLINE __attribute__((noinline))
 #elif _MSC_VER
 #define NOINLINE __declspec(noinline)
@@ -55,7 +55,7 @@
 #endif
 
 // Use this to indicate always inline functions
-#if __clang__ || __GNUC__ >= 4 || __INTEL_COMPILER
+#if __clang__ || __GNUC__ || __INTEL_COMPILER
 #define ALWAYS_INLINE inline __attribute__((__always_inline__))
 #elif _MSC_VER
 // commenting out because __forceinline takes too long time in MSVC

--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -21,8 +21,7 @@
 #include <type_traits>
 
 #ifndef HAVE_SVE
-#if defined(__aarch64__) && (__GNUC__ >= 8 || __clang_major__ >= 5) && \
-    __ARM_FEATURE_SVE
+#if defined(__aarch64__) && __ARM_FEATURE_SVE
 #define HAVE_SVE 1
 #else
 #define HAVE_SVE 0


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1574

The C++20 requirement invalidates some old compilers, their branches can be removed.


Reviewed By: cthi

Differential Revision: D78617259

Pulled By: q10


