### PR TITLE
Fix include module errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,17 +13,18 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 # Set up paths
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
+set(MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
+list(APPEND CMAKE_MODULE_PATH "${MODULE_PATH}")
 set(FBGEMM_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(FBGEMM_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
-include(${CMAKE_MODULE_PATH}/Utilities.cmake)
+include(${MODULE_PATH}/Utilities.cmake)
 
 # C++ Compiler Setup - must be set BEFORE project declaration
-include(${CMAKE_MODULE_PATH}/CxxCompilerSetup.cmake)
+include(${MODULE_PATH}/CxxCompilerSetup.cmake)
 
 # Load cpp_library()
-include(${CMAKE_MODULE_PATH}/CppLibrary.cmake)
+include(${MODULE_PATH}/CppLibrary.cmake)
 
 # Define function to extract filelists from defs.bzl file
 function(get_filelist name outputvar)


### PR DESCRIPTION
Fix the errors for PT integration:
```
CMake Error at third_party/fbgemm/CMakeLists.txt:20 (include):
  include called with invalid argument:
  /var/lib/jenkins/workspace/third_party/fbgemm/cmake/modules/Utilities.cmake


CMake Error at third_party/fbgemm/CMakeLists.txt:23 (include):
  include called with invalid argument:
  /var/lib/jenkins/workspace/third_party/fbgemm/cmake/modules/CxxCompilerSetup.cmake


CMake Error at third_party/fbgemm/CMakeLists.txt:26 (include):
  include called with invalid argument:
  /var/lib/jenkins/workspace/third_party/fbgemm/cmake/modules/CppLibrary.cmake
```