### PR TITLE
Fix pid_m calculation

### DIFF
--- a/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
@@ -3921,7 +3921,7 @@ def _kernel_matmul_fp8_row_non_persistent(
     width = GROUP_M * grid_n
     group_id = pid // width
     group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
-    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_m = group_id * GROUP_M + ((pid % width) % group_size)
     pid_n = (pid % width) // (group_size)
     tl.assume(pid_m >= 0)
     tl.assume(pid_n >= 0)


### PR DESCRIPTION
Summary:
When calculating current pid_m, pid should be first mode by width, then by group_size, not directly by group_size.
Assume we have:
- grid_m = 5
- grid_n = 5
- group_m = 3

Then for pid 15, the corresponding pid_m should be 4.
However, following the current logic that

``` 
id_m = group_id * GROUP_M + (pid % group_size)
```

pid_m = 1 * 3 + (15%2) = 3+1 = 4 !?

Differential Revision: D78712591


