### PR TITLE
Fix group_gemm_ops_test on AMD

### DIFF
--- a/fbgemm_gpu/test/test_utils.py
+++ b/fbgemm_gpu/test/test_utils.py
@@ -52,6 +52,12 @@ gpu_unavailable: Tuple[bool, str] = (
 # Used for `if` statements inside tests
 gpu_available: bool = not gpu_unavailable[0]
 
+is_nvidia_device: bool = gpu_available and torch.version.cuda is not None
+
+is_sm80_or_greater: bool = (
+    is_nvidia_device and torch.cuda.get_device_capability()[0] >= 8
+)
+
 running_on_sm70: Tuple[bool, str] = (
     not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 8,
     "Skip test if SM70, since the code is hardcoded to sm80+ support",


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1592

Noticed bunch of these were broken on AMD on the testX page. The cause is that these ops are not supported on AMD, so the test should just skip AMD on "cuda" devices.

Differential Revision: D78820563


