### PR TITLE
Fix scaled_mm_rowwise in quantize_bench

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/bench/quantize_bench.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/quantize_bench.py
@@ -169,6 +169,7 @@ def benchmark_grouped(
     trace: bool = False,
     num_iters: int = 1,
     fast_accum: bool = True,
+    torch_compile: bool = False,
 ) -> Dict[str, Any]:
     num_groups = len(m)
     # Create input tensors.
@@ -197,6 +198,8 @@ def benchmark_grouped(
         # Set fast accum mode if applicable.
         if hasattr(quantize_op, "fast_accum"):
             quantize_op.fast_accum = fast_accum
+        if hasattr(quantize_op, "torch_compile"):
+            quantize_op.torch_compile = torch_compile
         # Get the quantized tensors for this operator.
         preprocessed_args = quantize_op.preprocess(A, B)
         quantized_vals = quantize_op.quantize(*preprocessed_args)
@@ -282,6 +285,7 @@ def benchmark(
     trace: bool = False,
     num_iters: int = 1,
     fast_accum: bool = True,
+    torch_compile: bool = False,
 ) -> Dict[str, Any]:
     # Create input tensors.
     if b > 1:
@@ -301,6 +305,8 @@ def benchmark(
         # Set fast accum mode if applicable.
         if hasattr(quantize_op, "fast_accum"):
             quantize_op.fast_accum = fast_accum
+        if hasattr(quantize_op, "torch_compile"):
+            quantize_op.torch_compile = torch_compile
         # Preprocess data if needed.
         preprocessed_args = quantize_op.preprocess(A, B)
         # Get the quantized tensors for this operator.
@@ -495,6 +501,7 @@ def main(args: Any):
             args.trace,
             args.num_iters,
             not args.disable_fast_accum,
+            args.torch_compile,
         )
         benchmark_results.append(quantize_measurements)
     if args.export_csv or args.plot:
@@ -624,6 +631,12 @@ def invoke_main() -> None:
         default=False,
         action="store_true",
         help="If set, disable fast accumulation for FP8 implementations.",
+    )
+    parser.add_argument(
+        "--torch_compile",
+        default=False,
+        action="store_true",
+        help="If set, torch.compile will be used for scaled_mm backed ops.",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1594

When looking at this with samanamp recently I noticed the scaled_mm is not actually using the rowwise scaling with it, I think this was before it was supported properly.

We also add support for compile, which will be useful for testing.

Differential Revision: D78844879


