### PR TITLE
Enable asmjit static builds on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,12 +303,7 @@ if(NOT TARGET asmjit)
   endif()
 
   # Build asmjit
-  # For MSVC shared build, asmjit needs to be shared also.
-  if(MSVC AND (FBGEMM_LIBRARY_TYPE STREQUAL SHARED))
-    set(ASMJIT_STATIC OFF)
-  else()
-    set(ASMJIT_STATIC ON)
-  endif()
+  set(ASMJIT_STATIC ON)
   set(ASMJIT_NO_INSTALL ON)
 
   add_subdirectory("${ASMJIT_SRC_DIR}" "${FBGEMM_BINARY_DIR}/asmjit")


### PR DESCRIPTION
It is possible to always enable static asmjit builds and reduce the number of installed shared libraries.