### PR TITLE
Add torch_ops.h for ops being built with torch core

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
@@ -135,6 +135,7 @@ gpu_cpp_library(
   INCLUDE_DIRS
     ${fbgemm_sources_include_directories}
     ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize/include
     ${CMAKE_CURRENT_SOURCE_DIR}/src/quantize/common/include
     ${CMAKE_CURRENT_SOURCE_DIR}/src/kv_cache
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/include/fbgemm_gpu/torch_ops.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/include/fbgemm_gpu/torch_ops.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// For FBGEMM ops being exposed into torch core add them here.
+// The reason is that we need to only expose the declarations we will build,
+// otherwise we will have undefined symbols during linking.
+
+#pragma once
+
+#include <ATen/core/Tensor.h>
+
+namespace fbgemm_gpu {
+
+#ifdef USE_ROCM
+
+// Generic PyTorch grouped GEMM API is only available on AMD for now.
+at::Tensor f8f8bf16_rowwise_grouped_mm(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    std::optional<at::Tensor> offsets,
+    at::Tensor& output);
+
+#endif
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -6,18 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <ATen/ATen.h>
-#include <torch/library.h>
-
-#include "c10/core/ScalarType.h"
-
-#include <ATen/cuda/CUDAEvent.h>
-#include <algorithm>
-#include <atomic>
-#include <cassert>
-#include <cmath>
-#include <string>
 #include <vector>
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAEvent.h>
+#include <fbgemm_gpu/torch_ops.h>
+#include <torch/library.h>
+#include "c10/core/ScalarType.h"
 #include "c10/util/Exception.h"
 
 #if (defined(USE_ROCM) && ROCM_VERSION >= 60200)
@@ -32,14 +27,6 @@ namespace fbgemm_gpu {
 // flush icache
 void flush_icache_ck();
 
-// Generic PyTorch grouped GEMM API is only available on AMD for now.
-at::Tensor f8f8bf16_rowwise_grouped_mm(
-    at::Tensor XQ,
-    at::Tensor WQ,
-    at::Tensor x_scale,
-    at::Tensor w_scale,
-    std::optional<at::Tensor> offsets,
-    at::Tensor& output);
 #endif
 
 // SmoothQuant kernels


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1600

For ops we plan to build directly with torch we will need to expose only the header declarations required. In FBGEMM build we do this in the [quantize.cpp](https://www.internalfb.com/code/fbsource/fbcode/deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp) (which should also ideally be broken out) but we would need to prevent including all declarations as if those ops aren't built with torch core it would result in undefined symbols during linking.

I think for now best option is we have a separate header file and also rely on these in quantize.cpp.

Differential Revision: D78897613


