### PR TITLE
emit eviction metrics per tbe + bug fix

### DIFF
--- a/fbgemm_gpu/test/tbe/ssd/kv_backend_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/kv_backend_test.py
@@ -748,6 +748,9 @@ class SSDCheckpointTest(unittest.TestCase):
         shard_load = E / 4
         # init
         dram_kv_backend.set(indices, weights, count)  # pyre-ignore
+        dram_kv_backend.get_feature_evict_metric(  # pyre-ignore
+            evicted_counts, processed_counts, full_duration_ms, exec_duration_ms
+        )
         for _ in range(10):
             dram_kv_backend.get(indices.clone(), weights_out, count)  # pyre-ignore
             dram_kv_backend.set(indices, weights, count)


### PR DESCRIPTION
Summary:
Adding eviction metrics per TBE and per feature table.
FeatureEvictMetricTensors needs to be initialized otherwise will get "RuntimeError: Expected a proper Tensor but got None (or an undefined Tensor in C++) for argument #0 'self'"

Reviewed By: emlin, steven1327

Differential Revision:
D78604226

Privacy Context Container: L1138451


