### PR TITLE
Adding a new function for read-only rocksDB instantiation

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
@@ -87,6 +87,8 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
   void set_dram_db_wrapper(
       c10::intrusive_ptr<kv_mem::DramKVEmbeddingCacheWrapper> db);
 
+  void set_read_only_embedding_rocks_dp_wrapper();
+
   void set_range(
       int64_t dim,
       const int64_t start,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1610

Created a new function that creates a read-only rocksDB connection in the KV Tensor. 
This connection is then used by multiple processes for process based async checkpointing

Differential Revision: D78936211


