### PR TITLE
Minor dtype change to MX4 quantize

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/triton/quantize.py
+++ b/fbgemm_gpu/fbgemm_gpu/triton/quantize.py
@@ -238,7 +238,7 @@ def _kernel_quantize_mx4(
         # We readd fp32_exp_bias for compatibility with cuda dequant.
         tl.store(
             out + exp_offset,
-            (group_exp + FP32_EXP_BIAS).to(tl.int8),
+            (group_exp + FP32_EXP_BIAS).to(tl.uint8),
             # Prevent writing outside this chunk or the main array.
             mask=(exp_offset < OUTPUT_SIZE)
             & (exp_offset < (OUTPUT_CHUNK_SIZE * (pid + 1))),


### PR DESCRIPTION
Summary: Our friends working on MTIA noted that the datatype we cast exponents to in the MX4 quantization kernel should be uint8 rather than int8. Because the backing pytorch tensor is defined as uint8, there is no functional difference from this minor change. It does however provide a bit of clarity for readers and is the right thing to do.

Differential Revision: D78987739


