### PR TITLE
Migrate permute  ops to `FBGEMM_LAUNCH_KERNEL`

### DIFF
--- a/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split.cu
+++ b/fbgemm_gpu/src/permute_pooled_embedding_ops/permute_pooled_embedding_ops_split.cu
@@ -16,6 +16,7 @@
 #include "fbgemm_gpu/layout_transform_ops.cuh"
 #include "fbgemm_gpu/permute_pooled_embedding_ops_split.h"
 #include "fbgemm_gpu/utils/dispatch_macros.h"
+#include "fbgemm_gpu/utils/kernel_launcher.cuh"
 #include "fbgemm_gpu/utils/tensor_utils.h"
 
 using Tensor = at::Tensor;
@@ -116,17 +117,20 @@ Tensor permute_pooled_embs_split_gpu_impl(
 
   FBGEMM_DISPATCH_FLOATING_TYPES(
       pooled_embs_contiguous.scalar_type(), "permute_pooled_embeddings", [&] {
-        permute_pooled_embs_kernel<scalar_t>
-            <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-                pooled_embs_contiguous.data_ptr<scalar_t>(),
-                offset_dim_list.data_ptr<int64_t>(),
-                permute_list.data_ptr<int64_t>(),
-                inv_offset_dim_list.data_ptr<int64_t>(),
-                permuted_pooled_embs.data_ptr<scalar_t>(),
-                B,
-                T,
-                dim_sum);
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        FBGEMM_LAUNCH_KERNEL(
+            (permute_pooled_embs_kernel<scalar_t>),
+            blocks,
+            threads,
+            0,
+            at::cuda::getCurrentCUDAStream(),
+            pooled_embs_contiguous.data_ptr<scalar_t>(),
+            offset_dim_list.data_ptr<int64_t>(),
+            permute_list.data_ptr<int64_t>(),
+            inv_offset_dim_list.data_ptr<int64_t>(),
+            permuted_pooled_embs.data_ptr<scalar_t>(),
+            B,
+            T,
+            dim_sum);
       });
 
   return permuted_pooled_embs;


### PR DESCRIPTION
Summary: - Migrate permute  ops to `FBGEMM_LAUNCH_KERNEL`

Reviewed By: r-barnes

Differential Revision: D77055759


