### PR TITLE
Hack to fix building on gcc 9.5.0

### DIFF
--- a/src/GenerateKernelU8S8S32ACC32.cc
+++ b/src/GenerateKernelU8S8S32ACC32.cc
@@ -108,7 +108,8 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate(
     bool accum,
     int32_t mc,
     int32_t nc,
-    int32_t kc [[maybe_unused]]) {
+    int32_t kc) {
+  (void)kc; // Temporarily hack to appease gcc9.5.0
   using VecRegT = typename simd_info<instSet>::vec_reg_t;
   constexpr int numRegs = simd_info<instSet>::NUM_VEC_REGS;
   static constexpr int vectorLen = simd_info<instSet>::WIDTH_BYTES;

--- a/src/RefImplementations.h
+++ b/src/RefImplementations.h
@@ -420,6 +420,7 @@ float convert_to_float_ref(T src, bool is_bf16 = false) {
   if constexpr (std::is_same_v<T, uint16_t>) {
     return is_bf16 ? cpu_bf162float(src) : cpu_half2float(src);
   }
+  (void)is_bf16; // Temporarily hack to appease gcc9.5.0
   return src;
 }
 
@@ -428,6 +429,7 @@ T convert_from_float_ref(float src, bool is_bf16 = false) {
   if constexpr (std::is_same_v<T, uint16_t>) {
     return is_bf16 ? cpu_float2bfloat16(src) : cpu_float2half_rn(src);
   }
+  (void)is_bf16; // Temporarily hack to appease gcc9.5.0
   return src;
 }
 


### PR DESCRIPTION
Summary:
torch still support gcc 9.5.0 - try this hack to see if we can fix it.

Rollback Plan:

Differential Revision: D79008587


