### PR TITLE
Use asmjit 1.17 (#4569)

### DIFF
--- a/include/fbgemm/SimdUtils.h
+++ b/include/fbgemm/SimdUtils.h
@@ -10,9 +10,53 @@
 
 #include "./Utils.h" // @manual
 
+#include <asmjit/core.h> // @manual
 #include <asmjit/x86.h> // @manual
 
 namespace fbgemm {
+
+#if ASMJIT_LIBRARY_VERSION >= ASMJIT_LIBRARY_MAKE_VERSION(1, 17, 0)
+//! 128-bit XMM register (SSE+).
+class Xmm : public asmjit::x86::Vec {
+ public:
+  using Vec::Vec;
+  using Vec::operator=;
+  Xmm(uint32_t regId) : Vec(asmjit::x86::Vec::make_xmm(regId)) {}
+  //! Casts this register to a register that has half the size (XMM).
+  ASMJIT_INLINE_NODEBUG Xmm half() const noexcept {
+    return Xmm(id());
+  }
+};
+
+//! 256-bit YMM register (AVX+).
+class Ymm : public asmjit::x86::Vec {
+ public:
+  using Vec::Vec;
+  using Vec::operator=;
+  Ymm(uint32_t regId) : Vec(asmjit::x86::Vec::make_ymm(regId)) {}
+  //! Casts this register to a register that has half the size (XMM).
+  ASMJIT_INLINE_NODEBUG Xmm half() const noexcept {
+    return Xmm(id());
+  }
+};
+
+//! 512-bit ZMM register (AVX512+).
+class Zmm : public asmjit::x86::Vec {
+ public:
+  using Vec::Vec;
+  using Vec::operator=;
+  Zmm(uint32_t regId) : Vec(asmjit::x86::Vec::make_zmm(regId)) {}
+  //! Casts this register to a register that has half the size (YMM).
+  ASMJIT_INLINE_NODEBUG Ymm half() const noexcept {
+    return Ymm(id());
+  }
+};
+#else
+using Xmm = asmjit::x86::Xmm;
+using Ymm = asmjit::x86::Ymm;
+using Zmm = asmjit::x86::Zmm;
+#endif
+
 /**
  * @brief Some commonly used variables for different instruction sets
  */
@@ -26,7 +70,7 @@ struct simd_info<inst_set_t::avx2> {
   static constexpr int WIDTH_32BIT_ELEMS = 8;
   static constexpr int NUM_VEC_REGS = 16;
 
-  using vec_reg_t = asmjit::x86::Ymm;
+  using vec_reg_t = Ymm;
 };
 
 template <>
@@ -45,7 +89,7 @@ struct simd_info<inst_set_t::avx512> {
   static constexpr int WIDTH_32BIT_ELEMS = 16;
   static constexpr int NUM_VEC_REGS = 32;
 
-  using vec_reg_t = asmjit::x86::Zmm;
+  using vec_reg_t = Zmm;
 };
 
 template <>
@@ -59,7 +103,7 @@ struct simd_info<inst_set_t::avx512_ymm> {
   static constexpr int WIDTH_32BIT_ELEMS = 8;
   static constexpr int NUM_VEC_REGS = 32;
 
-  using vec_reg_t = asmjit::x86::Ymm;
+  using vec_reg_t = Ymm;
 };
 
 template <>

--- a/src/CodeGenHelpers.h
+++ b/src/CodeGenHelpers.h
@@ -17,7 +17,7 @@ namespace x86 = asmjit::x86;
 
 /**
  * @brief Create instruction sequence to generate 16-bit 1s
- * @tparam T Register type of destination, e.g., x86::Ymm or x86::Zmm
+ * @tparam T Register type of destination, e.g., Ymm or Zmm
  *
  * @param dest Once the instruction sequence is executed,
  *             dest[0:15] will have 0x0001, dest[16:31]
@@ -48,7 +48,7 @@ void gen16BitVectorOne(x86::Emitter* a, T dest) {
 /**
  * @brief Emit instruction do load 32-bit integer. AVX512 has
  *        different instrunction to load registers with index >= 16
- * @tparam T Register type of destination, e.g., x86::Ymm or x86::Zmm
+ * @tparam T Register type of destination, e.g., Ymm or Zmm
  *
  * @param dest Destination vector register
  */
@@ -91,8 +91,8 @@ template <
         int> = 0>
 void emitExtractHalfVector(
     x86::Emitter* a,
-    const x86::Ymm& half,
-    const x86::Zmm& vec,
+    const Ymm& half,
+    const Zmm& vec,
     int idx) {
   a->vextracti32x8(half, vec, idx);
 }
@@ -107,8 +107,8 @@ template <
         int> = 0>
 void emitExtractHalfVector(
     x86::Emitter* a,
-    const x86::Xmm& half,
-    const x86::Ymm& vec,
+    const Xmm& half,
+    const Ymm& vec,
     int idx) {
   a->vextracti32x4(half, vec, idx);
 }
@@ -119,27 +119,27 @@ template <
     std::enable_if_t<instSet == inst_set_t::avx2, int> = 0>
 void emitExtractHalfVector(
     x86::Emitter* a,
-    const x86::Xmm& half,
-    const x86::Ymm& vec,
+    const Xmm& half,
+    const Ymm& vec,
     int idx) {
   a->vextracti128(half, vec, idx);
 }
 
 /**
  * @brief Create instruction sequence to generate 8-bit 1s
- * @tparam T Register type of destination, e.g., x86::Ymm or x86::Zmm
+ * @tparam T Register type of destination, e.g., Ymm or Zmm
  *
  * @param dest Once the instruction sequence is executed,
  *             dest[0:7] will have 0x01, dest[8:15]
  *             will have 0x01 and so on
  */
-template <typename T, std::enable_if_t<std::is_same_v<T, x86::Ymm>, int> = 0>
+template <typename T, std::enable_if_t<std::is_same_v<T, Ymm>, int> = 0>
 void gen8BitVectorOne(x86::Emitter* a, T dest) {
   a->vpcmpeqw(dest, dest, dest);
   a->vpabsb(dest, dest);
 }
 
-template <typename T, std::enable_if_t<std::is_same_v<T, x86::Zmm>, int> = 0>
+template <typename T, std::enable_if_t<std::is_same_v<T, Zmm>, int> = 0>
 void gen8BitVectorOne(x86::Emitter* a, T dest) {
   a->vpternlogd(dest, dest, dest, 0xff);
   a->vpabsb(dest, dest);
@@ -147,7 +147,7 @@ void gen8BitVectorOne(x86::Emitter* a, T dest) {
 
 /**
  * @brief Generates instruction sequence to compute s32 += U8 * I8
- * @tparam T Register type of destination, e.g., x86::Ymm or x86::Zmm
+ * @tparam T Register type of destination, e.g., Ymm or Zmm
  *
  * @param cReg contains result
  *
@@ -188,7 +188,7 @@ void genU8I8S32FMA(
  *        and emit their sum as 32-bit numbers.
  *        i.e., dest[0:31] contains
  *        src[0:7] + src[8:15] + src[16:23] + src[24:31]
- * @tparam T Register type of destination, e.g., x86::Ymm or x86::Zmm
+ * @tparam T Register type of destination, e.g., Ymm or Zmm
  *
  * @param dest contains result
  *
@@ -243,7 +243,7 @@ void genU8Sum4(
  *
  *        so on
  *
- * @tparam T Register type of destination, e.g., x86::Ymm or x86::Zmm
+ * @tparam T Register type of destination, e.g., Ymm or Zmm
  *
  * @param dest contains result
  *

--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -418,8 +418,8 @@ GenEmbeddingSpMDMLookup<
         vec_reg_t
             vlen_inv_vreg; // used for normalize by lengths -- 1/ lengths[i]
         vec_reg_t src_vreg; // for holding embedding value temporarily
-        x86::Ymm mask_vreg; // mask for avx2
-        x86::Xmm mask_fp16_vreg; // mask for loading fp16 in avx2
+        Ymm mask_vreg; // mask for avx2
+        Xmm mask_fp16_vreg; // mask for loading fp16 in avx2
         vec_reg_t ones_vreg; // 2^15 for bf16_2_fp32_rn
 
         if constexpr (is_8bit_in) {

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -276,7 +276,7 @@ GenEmbeddingSpMDMNBitLookup<
         x86::Gp scratchReg1_ = a->gpz(reg_id); // 12 or 13
 
         ++reg_id;
-        x86::Gpd lengths_R_ = a->gpz(reg_id).r32(); // 13 or 14
+        auto lengths_R_ = a->gpz(reg_id).r32(); // 13 or 14
 
         ++reg_id;
         x86::Gp scratchReg2_ = a->gpz(reg_id); // 14 or 15
@@ -391,9 +391,9 @@ GenEmbeddingSpMDMNBitLookup<
         vec_reg_t
             vlen_inv_vreg; // used for normalize by lengths -- 1/ lengths[i]
         vec_reg_t src_vreg; // for holding embedding value temporarily
-        x86::Ymm mask_vreg; // mask for avx2
-        x86::Xmm mask2_vreg;
-        x86::Xmm mask_fp16_vreg;
+        Ymm mask_vreg; // mask for avx2
+        Xmm mask2_vreg;
+        Xmm mask_fp16_vreg;
         vec_reg_t ones_vreg;
 
         // We need 2 vec registers for 1. scale 2. bias

--- a/src/GenerateI8Depthwise.cc
+++ b/src/GenerateI8Depthwise.cc
@@ -52,19 +52,19 @@ namespace x86 = asmjit::x86;
 // c3_v: c[12:16], c[28:32]
 static void genMaddEpi16xNPacked(
     x86::Emitter* e,
-    x86::Ymm a[4],
+    Ymm a[4],
     const x86::Gp& b,
-    x86::Ymm c[4],
-    x86::Ymm* a_sum,
+    Ymm c[4],
+    Ymm* a_sum,
     int n,
     int remainder,
     bool accumulation,
-    const x86::Ymm& one_epi8,
-    const x86::Ymm& one_epi16,
-    const x86::Ymm& zero) {
+    const Ymm& one_epi8,
+    const Ymm& one_epi16,
+    const Ymm& zero) {
   // Interleave inputs corresponding to 4 filter positions.
   // Reuse a[1] and a[3] to save registers
-  x86::Ymm a01_lo(0), a01_hi(1), a23_lo(a[1]), a23_hi(a[3]);
+  Ymm a01_lo(0), a01_hi(1), a23_lo(a[1]), a23_hi(a[3]);
   e->vpunpcklbw(a01_lo, a[0], n == 1 ? zero : a[1]);
   if (remainder >= 8) {
     e->vpunpckhbw(a01_hi, a[0], n == 1 ? zero : a[1]);
@@ -306,24 +306,24 @@ GenI8Depthwise::jit_kernel_signature GenI8Depthwise::getOrCreate(
     e->emitArgsAssignment(frame, args);
 
     // Assign vector registers
-    x86::Ymm a[4];
-    x86::Ymm c[4];
-    x86::Ymm a_sum[2];
+    Ymm a[4];
+    Ymm c[4];
+    Ymm a_sum[2];
 
     int vreg_id = 2; // reserve 2 for temp vreg
     for (int i = 0; i < 4; ++i, ++vreg_id) {
-      a[i] = x86::Ymm(vreg_id);
+      a[i] = Ymm(vreg_id);
     }
     for (int i = 0; i < 4; ++i, ++vreg_id) {
-      c[i] = x86::Ymm(vreg_id);
+      c[i] = Ymm(vreg_id);
     }
     if (compute_a_sum) {
-      a_sum[0] = x86::Ymm(vreg_id);
+      a_sum[0] = Ymm(vreg_id);
       ++vreg_id;
-      a_sum[1] = x86::Ymm(vreg_id);
+      a_sum[1] = Ymm(vreg_id);
       ++vreg_id;
     }
-    x86::Ymm mask_vreg(vreg_id);
+    Ymm mask_vreg(vreg_id);
     constexpr int vlen = simd_info<inst_set_t::avx2>::WIDTH_32BIT_ELEMS;
     if (remainder != simd_info<inst_set_t::avx2>::WIDTH_BYTES) {
       ++vreg_id;
@@ -333,17 +333,17 @@ GenI8Depthwise::jit_kernel_signature GenI8Depthwise::getOrCreate(
               mask_addr,
               (vlen - remainder / 4 / oc_per_g) % vlen * sizeof(int32_t)));
     }
-    x86::Ymm one_epi8(vreg_id);
+    Ymm one_epi8(vreg_id);
     if (compute_a_sum) {
       ++vreg_id;
       gen8BitVectorOne(e, one_epi8);
     }
 
     int K = std::accumulate(F.begin(), F.end(), 1, std::multiplies<int>());
-    x86::Ymm one_epi16(vreg_id);
+    Ymm one_epi16(vreg_id);
     if (K > 2) {
       ++vreg_id;
-      gen16BitVectorOne<inst_set_t::avx2, x86::Ymm>(e, one_epi16);
+      gen16BitVectorOne<inst_set_t::avx2, Ymm>(e, one_epi16);
     }
 
     bool has_pad = prev_skip || next_skip || top_skip || bottom_skip ||
@@ -352,7 +352,7 @@ GenI8Depthwise::jit_kernel_signature GenI8Depthwise::getOrCreate(
     // When out of registers, zero and A_zero_point_vreg need to share.
     bool recompute_zero = vreg_id == 15 && need_zero;
 
-    x86::Ymm a_zero_point_vreg(vreg_id);
+    Ymm a_zero_point_vreg(vreg_id);
     if (!recompute_zero && has_pad) {
       e->movq(a_zero_point_vreg.half(), a_zero_point);
       e->vpbroadcastb(a_zero_point_vreg, a_zero_point_vreg.half());
@@ -360,7 +360,7 @@ GenI8Depthwise::jit_kernel_signature GenI8Depthwise::getOrCreate(
     if (vreg_id < 15) {
       ++vreg_id;
     }
-    x86::Ymm zero(vreg_id);
+    Ymm zero(vreg_id);
     if (need_zero && (!recompute_zero || !has_pad)) {
       e->vpxor(zero.xmm(), zero.xmm(), zero.xmm());
     }

--- a/src/GenerateKernel.cc
+++ b/src/GenerateKernel.cc
@@ -17,7 +17,7 @@ namespace x86 = asmjit::x86;
  * Accumulation kernel.
  */
 void initCRegs(x86::Emitter* a, int rowRegs, int colRegs) {
-  using CRegs = x86::Xmm;
+  using CRegs = Xmm;
   // Take advantage of implicit zeroing out
   // i.e., zero out xmm and ymm will be zeroed out too
   for (int i = 0; i < rowRegs; ++i) {

--- a/src/GenerateKernelU8S8S32ACC16.cc
+++ b/src/GenerateKernelU8S8S32ACC16.cc
@@ -29,12 +29,12 @@ void CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::genComputeBlock<
     int rowRegs,
     int colRegs,
     int lda) {
-  using CRegs = x86::Ymm;
+  using CRegs = Ymm;
   static constexpr int vectorLen = simd_info<inst_set_t::avx2>::WIDTH_BYTES;
 
   // used for matrix A
-  x86::Ymm AReg = x86::ymm13;
-  x86::Ymm tmpReg = x86::ymm14;
+  auto AReg = x86::ymm13;
+  auto tmpReg = x86::ymm14;
   for (int i = 0; i < rowRegs; ++i) {
     // broadcast A
     a->vpbroadcastw(

--- a/src/GenerateKernelU8S8S32ACC32Avx512VNNI.cc
+++ b/src/GenerateKernelU8S8S32ACC32Avx512VNNI.cc
@@ -171,7 +171,7 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate(
     x86::Gp kIdx = a->gpz(15);
     // x86::Gp B_pf = a->gpz(8);
 
-    x86::Zmm oneReg = x86::zmm29;
+    auto oneReg = x86::zmm29;
     // create 16-bit 1s
     // i.e., oneReg[0:15] contains 0x0001, oneReg[16:31] contains 0x0001
     // and so on

--- a/src/GroupwiseConv.cc
+++ b/src/GroupwiseConv.cc
@@ -597,10 +597,10 @@ void GenConvKernel<SPATIAL_DIM, INST_SET>::initResultRegs(x86::Emitter* a) {
     // Take advantage of implicit zeroing out
     // i.e., zero out xmm and ymm and zmm will be zeroed out too
     for (int k = 0; k < kLoopIters_; ++k) {
-      a->vpxor(x86::Xmm(9 - k), x86::Xmm(9 - k), x86::Xmm(9 - k));
+      a->vpxor(Xmm(9 - k), Xmm(9 - k), Xmm(9 - k));
     }
   } else {
-    a->vpxor(x86::Xmm(9), x86::Xmm(9), x86::Xmm(9));
+    a->vpxor(Xmm(9), Xmm(9), Xmm(9));
   }
 }
 

--- a/src/GroupwiseConvAcc32Avx2.cc
+++ b/src/GroupwiseConvAcc32Avx2.cc
@@ -20,7 +20,7 @@ GCONV_INST_DEF_AVX2_HEADER
 GenConvKernel<SPATIAL_DIM, INST_SET>::genConstForPermutations(x86::Emitter* a) {
   if (this->C_per_G_ == 4) {
     x86::Gp permute_const_reg = a->gpz(12);
-    x86::Xmm const_reg_xmm = x86::xmm11;
+    auto const_reg_xmm = x86::xmm11;
     // We have 1st group in even lanes and 2nd group in odd lanes.
     // Permute to put 1st group to lower 128-bit and 2nd group in upper
     // 128-bit.
@@ -33,7 +33,7 @@ GenConvKernel<SPATIAL_DIM, INST_SET>::genConstForPermutations(x86::Emitter* a) {
   } else {
     // this->C_per_G_ == 2
     x86::Gp permute_const_reg = a->gpz(12);
-    x86::Xmm const_reg_xmm = x86::xmm11;
+    auto const_reg_xmm = x86::xmm11;
     // We have 1st group in position 0 and 4, 2nd group 1 and 5 and so on.
     // Permute to put 1st group to lower 64-bit and 2nd group to next
     // 64-bit and so on.
@@ -46,7 +46,7 @@ GenConvKernel<SPATIAL_DIM, INST_SET>::genConstForPermutations(x86::Emitter* a) {
 
 GCONV_INST_DEF_AVX2_HEADER
 GenConvKernel<SPATIAL_DIM, INST_SET>::genForLoadingWeights(x86::Emitter* a) {
-  using WRegs = x86::Ymm;
+  using WRegs = Ymm;
   int paddedICPerG = (this->C_per_G_ + 3) / 4 * 4;
   // load weights
   for (int r = 0; r < this->R_; ++r) {
@@ -69,45 +69,45 @@ GCONV_INST_DEF_AVX2_HEADER GenConvKernel<SPATIAL_DIM, INST_SET>::storeResult(
     x86::Emitter* a) {
   if (GTogether_ > 1) {
     // store with permutation
-    a->vpermd(x86::Ymm(9), stPermReg_V_, x86::Ymm(9));
+    a->vpermd(Ymm(9), stPermReg_V_, Ymm(9));
     if (this->accum_) {
-      a->vpaddd(x86::Ymm(9), x86::Ymm(9), x86::dword_ptr(out_acts_R_));
+      a->vpaddd(Ymm(9), Ymm(9), x86::dword_ptr(out_acts_R_));
     }
-    a->vmovups(x86::dword_ptr(out_acts_R_), x86::Ymm(9));
+    a->vmovups(x86::dword_ptr(out_acts_R_), Ymm(9));
   } else {
     // horizontal add and store
     if (this->C_per_G_ == 8) {
-      a->vphaddd(x86::Ymm(9), x86::Ymm(9), x86::Ymm(8));
-      a->vpermq(x86::Ymm(9), x86::Ymm(9), static_cast<asmjit::Imm>(0xd8));
+      a->vphaddd(Ymm(9), Ymm(9), Ymm(8));
+      a->vpermq(Ymm(9), Ymm(9), static_cast<asmjit::Imm>(0xd8));
       if (this->accum_) {
-        a->vpaddd(x86::Ymm(9), x86::Ymm(9), x86::dword_ptr(out_acts_R_));
+        a->vpaddd(Ymm(9), Ymm(9), x86::dword_ptr(out_acts_R_));
       }
-      a->vmovups(x86::dword_ptr(out_acts_R_), x86::Ymm(9));
+      a->vmovups(x86::dword_ptr(out_acts_R_), Ymm(9));
     } else if (this->K_per_G_ == 16) {
-      a->vphaddd(x86::Ymm(9), x86::Ymm(9), x86::Ymm(8));
-      a->vpermq(x86::Ymm(9), x86::Ymm(9), static_cast<asmjit::Imm>(0xd8));
+      a->vphaddd(Ymm(9), Ymm(9), Ymm(8));
+      a->vpermq(Ymm(9), Ymm(9), static_cast<asmjit::Imm>(0xd8));
 
-      a->vphaddd(x86::Ymm(7), x86::Ymm(7), x86::Ymm(6));
-      a->vpermq(x86::Ymm(7), x86::Ymm(7), static_cast<asmjit::Imm>(0xd8));
+      a->vphaddd(Ymm(7), Ymm(7), Ymm(6));
+      a->vpermq(Ymm(7), Ymm(7), static_cast<asmjit::Imm>(0xd8));
 
-      a->vphaddd(x86::Ymm(5), x86::Ymm(5), x86::Ymm(4));
-      a->vpermq(x86::Ymm(5), x86::Ymm(5), static_cast<asmjit::Imm>(0xd8));
+      a->vphaddd(Ymm(5), Ymm(5), Ymm(4));
+      a->vpermq(Ymm(5), Ymm(5), static_cast<asmjit::Imm>(0xd8));
 
-      a->vphaddd(x86::Ymm(3), x86::Ymm(3), x86::Ymm(2));
-      a->vpermq(x86::Ymm(3), x86::Ymm(3), static_cast<asmjit::Imm>(0xd8));
+      a->vphaddd(Ymm(3), Ymm(3), Ymm(2));
+      a->vpermq(Ymm(3), Ymm(3), static_cast<asmjit::Imm>(0xd8));
 
-      a->vphaddd(x86::Ymm(9), x86::Ymm(9), x86::Ymm(7));
-      a->vpermq(x86::Ymm(9), x86::Ymm(9), static_cast<asmjit::Imm>(0xd8));
+      a->vphaddd(Ymm(9), Ymm(9), Ymm(7));
+      a->vpermq(Ymm(9), Ymm(9), static_cast<asmjit::Imm>(0xd8));
 
-      a->vphaddd(x86::Ymm(5), x86::Ymm(5), x86::Ymm(3));
-      a->vpermq(x86::Ymm(5), x86::Ymm(5), static_cast<asmjit::Imm>(0xd8));
+      a->vphaddd(Ymm(5), Ymm(5), Ymm(3));
+      a->vpermq(Ymm(5), Ymm(5), static_cast<asmjit::Imm>(0xd8));
 
       if (this->accum_) {
-        a->vpaddd(x86::Ymm(9), x86::Ymm(9), x86::dword_ptr(out_acts_R_));
-        a->vpaddd(x86::Ymm(5), x86::Ymm(5), x86::dword_ptr(out_acts_R_, 32));
+        a->vpaddd(Ymm(9), Ymm(9), x86::dword_ptr(out_acts_R_));
+        a->vpaddd(Ymm(5), Ymm(5), x86::dword_ptr(out_acts_R_, 32));
       }
-      a->vmovups(x86::dword_ptr(out_acts_R_), x86::Ymm(9));
-      a->vmovups(x86::dword_ptr(out_acts_R_, 32), x86::Ymm(5));
+      a->vmovups(x86::dword_ptr(out_acts_R_), Ymm(9));
+      a->vmovups(x86::dword_ptr(out_acts_R_, 32), Ymm(5));
     }
   }
 }
@@ -161,7 +161,7 @@ GenConvKernel<SPATIAL_DIM, INST_SET>::genForSingleFilterPoint(
     int s,
     int act_s,
     bool use_zero_reg) {
-  using WRegs = x86::Ymm;
+  using WRegs = Ymm;
 
   if (GTogether_ > 1) {
     if (this->C_per_G_ == 2) { // group together = 4
@@ -197,7 +197,7 @@ GenConvKernel<SPATIAL_DIM, INST_SET>::genForSingleFilterPoint(
         a,
         actReg_V_,
         WRegs(r * this->S_ + s),
-        x86::Ymm(9),
+        Ymm(9),
         oneReg16Bit_V_,
         tmpReg1_V_);
   } else {
@@ -235,7 +235,7 @@ GenConvKernel<SPATIAL_DIM, INST_SET>::genForSingleFilterPoint(
       // which consectutive 2 elements if summedforms one final output over
       // K_Per_G dimension
       genU8I8S32FMA<INST_SET>(
-          a, actReg_V_, WRegs(0), x86::Ymm(9 - k), oneReg16Bit_V_, tmpReg1_V_);
+          a, actReg_V_, WRegs(0), Ymm(9 - k), oneReg16Bit_V_, tmpReg1_V_);
     }
   }
 }

--- a/src/GroupwiseConvAcc32Avx512.cc
+++ b/src/GroupwiseConvAcc32Avx512.cc
@@ -20,7 +20,7 @@ GCONV_INST_DEF_AVX512_AND_VNNI_HEADER
 GenConvKernel<SPATIAL_DIM, INST_SET>::genConstForPermutations(x86::Emitter* a) {
   x86::Gp permute_const_reg_upper_half = a->gpz(12);
   x86::Gp permute_const_reg_lower_half = a->gpz(13);
-  x86::Xmm const_reg_xmm = x86::xmm11;
+  auto const_reg_xmm = x86::xmm11;
   if (this->C_per_G_ == 4) {
     // 4 group together
     // We have 1st group in position 0 and 4, 2nd group 1 and 5 and so on.
@@ -68,7 +68,7 @@ GenConvKernel<SPATIAL_DIM, INST_SET>::genConstForPermutations(x86::Emitter* a) {
 
 GCONV_INST_DEF_AVX512_AND_VNNI_HEADER
 GenConvKernel<SPATIAL_DIM, INST_SET>::genForLoadingWeights(x86::Emitter* a) {
-  using WRegs = x86::Zmm;
+  using WRegs = Zmm;
   int paddedICPerG = (this->C_per_G_ + 3) / 4 * 4;
   // load weights
   for (int r = 0; r < this->R_; ++r) {
@@ -94,36 +94,36 @@ GCONV_INST_DEF_AVX512_AND_VNNI_HEADER
 GenConvKernel<SPATIAL_DIM, INST_SET>::storeResult(x86::Emitter* a) {
   if (GTogether_ > 1) {
     // store with permutation
-    a->vpermd(x86::Zmm(9), stPermReg_V_, x86::Zmm(9));
+    a->vpermd(Zmm(9), stPermReg_V_, Zmm(9));
     if (this->accum_) {
-      a->vpaddd(x86::Zmm(9), x86::Zmm(9), x86::zmmword_ptr(out_acts_R_));
+      a->vpaddd(Zmm(9), Zmm(9), x86::zmmword_ptr(out_acts_R_));
     }
-    a->vmovups(x86::zmmword_ptr(out_acts_R_), x86::Zmm(9));
+    a->vmovups(x86::zmmword_ptr(out_acts_R_), Zmm(9));
   } else {
     // horizontal add and store
     if (this->C_per_G_ == 8) {
-      a->vextracti32x8(tmpReg1_V_.ymm(), x86::Zmm(9), 1);
-      a->vphaddd(x86::Ymm(9), x86::Ymm(9), tmpReg1_V_.ymm());
-      a->vpermq(x86::Ymm(9), x86::Ymm(9), static_cast<asmjit::Imm>(0xd8));
+      a->vextracti32x8(tmpReg1_V_.ymm(), Zmm(9), 1);
+      a->vphaddd(Ymm(9), Ymm(9), tmpReg1_V_.ymm());
+      a->vpermq(Ymm(9), Ymm(9), static_cast<asmjit::Imm>(0xd8));
       if (this->accum_) {
-        a->vpaddd(x86::Ymm(9), x86::Ymm(9), x86::ymmword_ptr(out_acts_R_));
+        a->vpaddd(Ymm(9), Ymm(9), x86::ymmword_ptr(out_acts_R_));
       }
-      a->vmovups(x86::ymmword_ptr(out_acts_R_), x86::Ymm(9));
+      a->vmovups(x86::ymmword_ptr(out_acts_R_), Ymm(9));
     } else if (this->K_per_G_ == 16) {
       // we have results in 4 Zmm registers, need to reduce them to 2 Ymm
       // register 2 * 8 * 32 where 16 is K_per_g
       // first reduce 4 * 16 * 32bits to 4 * 8 * 32bits
       for (int k = 0; k < kLoopIters_; ++k) {
-        auto source_reg = x86::Zmm(9 - k);
-        auto result_reg = x86::Ymm(9 - k);
-        a->vextracti32x8(x86::Ymm(0), source_reg, 1);
-        a->vphaddd(result_reg, result_reg, x86::Ymm(0));
+        auto source_reg = Zmm(9 - k);
+        auto result_reg = Ymm(9 - k);
+        a->vextracti32x8(Ymm(0), source_reg, 1);
+        a->vphaddd(result_reg, result_reg, Ymm(0));
         a->vpermq(result_reg, result_reg, static_cast<asmjit::Imm>(0xd8));
       }
       // secondly reduce 4 * 8 * 32  to 2 * 8 * 32 bits;
       for (int k = 0, i = 0; k < kLoopIters_; k += 2, i++) {
-        auto result_reg = x86::Ymm(9 - k);
-        auto adjacent_result_reg = x86::Ymm(9 - k - 1);
+        auto result_reg = Ymm(9 - k);
+        auto adjacent_result_reg = Ymm(9 - k - 1);
         a->vphaddd(result_reg, result_reg, adjacent_result_reg);
         a->vpermq(result_reg, result_reg, static_cast<asmjit::Imm>(0xd8));
         if (this->accum_) {
@@ -192,7 +192,7 @@ GenConvKernel<SPATIAL_DIM, INST_SET>::genForSingleFilterPoint(
     int s,
     int act_s,
     bool use_zero_reg) {
-  using WRegs = x86::Zmm;
+  using WRegs = Zmm;
 
   if (use_zero_reg) {
     a->vmovapd(actReg_V_, zeroPTReg_V_); // 64 * 8 bit zero points

--- a/src/RowWiseSparseAdagradFused.cc
+++ b/src/RowWiseSparseAdagradFused.cc
@@ -158,9 +158,9 @@ typename ReturnFunctionSignature<indxType, offsetType, dataType>::
         x86::Gp h = a->gpz(9);
         x86::Gp indices = a->gpz(10);
         x86::Gp lengths = a->gpz(11);
-        x86::Xmm epsilon(0);
-        x86::Xmm lr(1);
-        x86::Gpd lengths_R = a->gpz(12).r32();
+        Xmm epsilon(0);
+        Xmm lr(1);
+        auto lengths_R = a->gpz(12).r32();
         x86::Gp scratchReg1 = a->gpz(13);
         x86::Gp scratchReg2 = a->gpz(14); // for prefetching
 
@@ -230,13 +230,13 @@ typename ReturnFunctionSignature<indxType, offsetType, dataType>::
         int remainder = block_size % vlen;
 
         vec_reg_t src_vreg; // for holding embedding value temporarily
-        x86::Ymm mask_vreg;
+        Ymm mask_vreg;
 
         // Reserve registers with small ids first because some of them need to
         // be used with an instruction not supported in avx512 for which a big
         // register id won't work.
         int first_available_vec_reg_id = 0;
-        x86::Ymm partial_sum_vreg = x86::Ymm(first_available_vec_reg_id);
+        Ymm partial_sum_vreg = Ymm(first_available_vec_reg_id);
         ++first_available_vec_reg_id;
         vec_reg_t float_step_vreg = vec_reg_t(first_available_vec_reg_id);
         ++first_available_vec_reg_id;
@@ -301,7 +301,7 @@ typename ReturnFunctionSignature<indxType, offsetType, dataType>::
             src_vreg = vec_reg_t(first_available_vec_reg_id);
             ++first_available_vec_reg_id;
 
-            mask_vreg = x86::Ymm(first_available_vec_reg_id);
+            mask_vreg = Ymm(first_available_vec_reg_id);
             ++first_available_vec_reg_id;
             // Use scratchReg1 as temp
             a->mov(scratchReg1, asmjit::imm(mask_avx2));
@@ -362,7 +362,7 @@ typename ReturnFunctionSignature<indxType, offsetType, dataType>::
           int cur_unroll_factor =
               std::min(unroll_factor, num_vec_regs_per_block_avx2 - vec_idx);
           for (int v = 0; v < cur_unroll_factor; ++v) {
-            x86::Ymm out_vreg = x86::Ymm(v + first_available_vec_reg_id);
+            Ymm out_vreg = Ymm(v + first_available_vec_reg_id);
 
             auto g_ptr =
                 x86::dword_ptr(g, (vec_idx + v) * vlen_avx2 * sizeof(float));
@@ -385,8 +385,8 @@ typename ReturnFunctionSignature<indxType, offsetType, dataType>::
         // __m256 partial_sum_3 = _mm256_hadd_ps(partial_sum_2, partial_sum_2);
         // Use YMM/XMMs with smaller ids for AVX2 specific instructions like
         // vhaddps
-        x86::Xmm partial_sum_xmm(partial_sum_vreg.id());
-        x86::Xmm float_step_xmm(float_step_vreg.id());
+        Xmm partial_sum_xmm(partial_sum_vreg.id());
+        Xmm float_step_xmm(float_step_vreg.id());
         // a->vmovups(partial_sum_temp0_ymm, partial_sum_vreg);
         a->vhaddps(partial_sum_vreg, partial_sum_vreg, partial_sum_vreg);
         a->vhaddps(partial_sum_vreg, partial_sum_vreg, partial_sum_vreg);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1624

Update asmjit to 1.17. Due to breaking API changes, we have to construct `XMM`, `YMM` and `ZMM` ourselves to enable template dispatch.


Reviewed By: cthi

Differential Revision: D78986762

Pulled By: q10
