### PR TITLE
Fix cmake on clang12

### DIFF
--- a/cmake/modules/CppLibrary.cmake
+++ b/cmake/modules/CppLibrary.cmake
@@ -103,8 +103,6 @@ function(cpp_library)
             -Wunused-variable
             -Wno-sign-compare
             -Wno-vla
-            -Wno-error=unused-but-set-parameter
-            -Wno-error=unused-but-set-variable
             -Wno-error=unused-parameter
             -Wno-error=attributes)
 
@@ -113,6 +111,12 @@ function(cpp_library)
                 -Wno-c99-extensions
                 -Wno-gnu-zero-variadic-macro-arguments
                 -Wno-deprecated-enum-enum-conversion)
+
+            if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 13.0.0)
+                list(APPEND lib_cc_flags
+                    -Wno-error=unused-but-set-parameter
+                    -Wno-error=unused-but-set-variable)
+            endif()
 
             if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 17.0.0)
                 list(APPEND lib_cc_flags
@@ -123,7 +127,9 @@ function(cpp_library)
 
         elseif(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
             list(APPEND lib_cc_flags
-                -Wmaybe-uninitialized)
+                -Wmaybe-uninitialized
+                -Wno-error=unused-but-set-parameter
+                -Wno-error=unused-but-set-variable)
 
             if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10.0)
                 list(APPEND lib_cc_flags


### PR DESCRIPTION
Summary:
From [clang13 release notes for New Compiler Flags](https://releases.llvm.org/13.0.0/tools/clang/docs/ReleaseNotes.html#new-compiler-flagsF)

```
Wunused-but-set-parameter and -Wunused-but-set-variable emit warnings when a parameter or a variable is set but not used.
```

Look torch is using clang12 still in CI: https://github.com/pytorch/pytorch/actions/runs/16540850029/job/46781848078?pr=159075

Differential Revision: D79089685


