### PR TITLE
Add assertion on mask numel in masked_select_jagged_1d

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -917,6 +917,8 @@ std::tuple<Tensor, Tensor> masked_select_jagged_1d(
     const Tensor& mask) {
   TORCH_CHECK(values.dim() == 1);
   TORCH_CHECK(lengths.dim() == 1);
+  TORCH_CHECK(mask.dim() == 1);
+  TORCH_CHECK(mask.numel() == values.numel());
 
   auto values_contiguous = values.expect_contiguous();
   auto lengths_contiguous = lengths.expect_contiguous();

--- a/fbgemm_gpu/test/jagged/misc_ops_test.py
+++ b/fbgemm_gpu/test/jagged/misc_ops_test.py
@@ -145,6 +145,36 @@ class JaggedTensorOpsTest(unittest.TestCase):
         torch.testing.assert_close(masked_values, masked_values_ref)
         torch.testing.assert_close(masked_lengths, masked_lengths_ref)
 
+    def test_masked_select_jagged_1d_invalid_mask(
+        self,
+    ) -> None:
+        lengths = torch.randint(
+            low=0,
+            high=100,
+            size=(1,),
+            dtype=torch.int,
+            device="cpu",
+        )
+        N = int(lengths.sum().item())
+        values = torch.randint(
+            2**16,
+            (N,),
+            dtype=torch.int,
+            device="cpu",
+        )
+        # Use a broken mask that is greater than values.numel()
+        mask = torch.randint(2, (N + 10,)) > 0
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"Expected mask\.numel\(\) == values\.numel\(\) to be true, but got false\..*",
+        ):
+            torch.ops.fbgemm.masked_select_jagged_1d(
+                values,
+                lengths,
+                mask,
+            )
+
     @given(
         B=st.integers(1, 512),
         max_L=st.integers(1, 1000),


### PR DESCRIPTION
Summary: There is a pre-existing issue in this op where if someone erroneously passes in a mask with a numel that does not match the values, it would break. We should just add the assertion. This was identified from a user report: https://fb.workplace.com/groups/425722592211490/posts/1458739355576470/?comment_id=1459778265472579

Differential Revision: D79094024


