### PR TITLE
Correctly handle non-contiguous permute tensors in sparse permute kernel

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
@@ -113,7 +113,7 @@ permute_2D_sparse_data_cuda(
                 T,
                 B,
                 lengths_contig.data_ptr<index_t>(),
-                permute.data_ptr<int32_t>(),
+                permute_contig.data_ptr<int32_t>(),
                 permuted_lengths.data_ptr<index_t>());
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       });


### PR DESCRIPTION
Summary: Sparse permute 2D tensor should invoke `permute_2D_lengths_kernel` with `permute_contig` instead of `permute`, to correctly handle input tensors that might not be contiguous in memory (strided, transposed, indexed, etc.). Added a test to protect this behavior.

Differential Revision: D79047856


