### PR TITLE
Adding backend api to get kvzch eviction metadata

### DIFF
--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h
@@ -108,6 +108,15 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
     return impl_->get_keys_in_range_impl(start_id, end_id, id_offset);
   }
 
+  at::Tensor get_kv_zch_eviction_metadata_by_snapshot(
+      const at::Tensor& indices,
+      const at::Tensor& count,
+      const std::optional<
+          c10::intrusive_ptr<ssd::EmbeddingSnapshotHandleWrapper>>&
+      /*snapshot_handle*/) {
+    return impl_->get_kv_zch_eviction_metadata_impl(indices, count);
+  }
+
   void get(
       at::Tensor indices,
       at::Tensor weights,

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
@@ -130,6 +130,18 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
                                     : nullptr);
   }
 
+  at::Tensor get_kv_zch_eviction_metadata_by_snapshot(
+      const at::Tensor& indices,
+      const at::Tensor& count,
+      std::optional<c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper>>
+          snapshot_handle) {
+    return impl_->get_kv_zch_eviction_metadata_by_snapshot(
+        indices,
+        count,
+        snapshot_handle.has_value() ? snapshot_handle.value()->handle
+                                    : nullptr);
+  }
+
   void toggle_compaction(bool enable) {
     impl_->toggle_compaction(enable);
   }

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
@@ -345,6 +345,14 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
     FBEXCEPTION("Not implemented");
   }
 
+  virtual at::Tensor get_kv_zch_eviction_metadata_impl(
+      const at::Tensor& indices,
+      const at::Tensor& count) {
+    (void)indices;
+    (void)count;
+    FBEXCEPTION("Not implemented");
+  }
+
   virtual std::vector<double> get_dram_kv_perf(
       const int64_t step,
       const int64_t interval) {

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -851,6 +851,9 @@ static auto embedding_rocks_db_wrapper =
             "get_keys_in_range_by_snapshot",
             &EmbeddingRocksDBWrapper::get_keys_in_range_by_snapshot)
         .def(
+            "get_kv_zch_eviction_metadata_by_snapshot",
+            &EmbeddingRocksDBWrapper::get_kv_zch_eviction_metadata_by_snapshot)
+        .def(
             "create_rocksdb_hard_link_snapshot",
             &EmbeddingRocksDBWrapper::create_rocksdb_hard_link_snapshot)
         .def(
@@ -932,6 +935,10 @@ static auto dram_kv_embedding_cache_wrapper =
         .def(
             "get_keys_in_range_by_snapshot",
             &DramKVEmbeddingCacheWrapper::get_keys_in_range_by_snapshot)
+        .def(
+            "get_kv_zch_eviction_metadata_by_snapshot",
+            &DramKVEmbeddingCacheWrapper::
+                get_kv_zch_eviction_metadata_by_snapshot)
         .def(
             "get_feature_evict_metric",
             &DramKVEmbeddingCacheWrapper::get_feature_evict_metric)

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -698,6 +698,14 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
     return returned_keys;
   }
 
+  at::Tensor get_kv_zch_eviction_metadata_by_snapshot(
+      const at::Tensor& indices,
+      const at::Tensor& count,
+      const SnapshotHandle* snapshot_handle) {
+    // no op for ssd embedding now, default value is 0
+    return at::zeros_like(indices, at::kLong);
+  }
+
   void get_range_from_snapshot(
       const at::Tensor& weights,
       const int64_t start,


### PR DESCRIPTION
Summary: To support eviction in kvzch, we are adding a new backend api to get the metadata information in kvzch weight metaheader, including timestamp+count+used.

Differential Revision: D78464934


