### PR TITLE
Migrate sparse ops kernels to `FBGEMM_LAUNCH_KERNEL`, pt 3

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_compute_frequency_sequence.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_compute_frequency_sequence.cu
@@ -37,16 +37,16 @@ DLL_PUBLIC void compute_frequency_sequence(
 
   AT_DISPATCH_INDEX_TYPES(
       input.scalar_type(), "compute_frequency_sequence_kernel_1", [&] {
-        compute_frequency_sequence_kernel<index_t>
-            <<<cuda_calc_xblock_count(input.numel(), kWarpSize),
-               kWarpSize,
-               0,
-               at::cuda::getCurrentCUDAStream()>>>(
-                input.data_ptr<index_t>(),
-                output.data_ptr<int64_t>(),
-                start_input,
-                input.numel());
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        FBGEMM_LAUNCH_KERNEL(
+            (compute_frequency_sequence_kernel<index_t>),
+            cuda_calc_xblock_count(input.numel(), kWarpSize),
+            kWarpSize,
+            0,
+            at::cuda::getCurrentCUDAStream(),
+            input.data_ptr<index_t>(),
+            output.data_ptr<int64_t>(),
+            start_input,
+            input.numel());
       });
 }
 

--- a/fbgemm_gpu/src/sparse_ops/sparse_expand_into_jagged_permute.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_expand_into_jagged_permute.cu
@@ -60,14 +60,17 @@ DLL_PUBLIC Tensor expand_into_jagged_permute_cuda(
   AT_DISPATCH_INDEX_TYPES(
       permute.scalar_type(), "expand_into_jagged_permute_kernel", [&] {
         using offsets_t = index_t;
-        expand_into_jagged_permute_kernel<index_t, offsets_t>
-            <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-                input_offsets.data_ptr<offsets_t>(),
-                output_offsets.data_ptr<offsets_t>(),
-                permute_size,
-                permute.data_ptr<index_t>(),
-                output_permute.data_ptr<index_t>());
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        FBGEMM_LAUNCH_KERNEL(
+            (expand_into_jagged_permute_kernel<index_t, offsets_t>),
+            blocks,
+            threads,
+            0,
+            at::cuda::getCurrentCUDAStream(),
+            input_offsets.data_ptr<offsets_t>(),
+            output_offsets.data_ptr<offsets_t>(),
+            permute_size,
+            permute.data_ptr<index_t>(),
+            output_permute.data_ptr<index_t>());
       });
 
   return output_permute;

--- a/fbgemm_gpu/src/sparse_ops/sparse_invert_permute.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_invert_permute.cu
@@ -37,12 +37,15 @@ DLL_PUBLIC Tensor invert_permute_cuda(const Tensor& permute) {
   constexpr int32_t threads_1 = kMaxThreads;
   const auto blocks_1 = cuda_calc_xblock_count(permute_size, threads_1);
   AT_DISPATCH_INDEX_TYPES(permute.scalar_type(), "invert_permute_kernel", [&] {
-    invert_permute_kernel<index_t>
-        <<<blocks_1, threads_1, 0, at::cuda::getCurrentCUDAStream()>>>(
-            permute_size,
-            permute_contig.data_ptr<index_t>(),
-            inversed_permute.data_ptr<index_t>());
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    FBGEMM_LAUNCH_KERNEL(
+        (invert_permute_kernel<index_t>),
+        blocks_1,
+        threads_1,
+        0,
+        at::cuda::getCurrentCUDAStream(),
+        permute_size,
+        permute_contig.data_ptr<index_t>(),
+        inversed_permute.data_ptr<index_t>());
   });
   return inversed_permute;
 }

--- a/fbgemm_gpu/src/sparse_ops/sparse_pack_segments_backward.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_pack_segments_backward.cu
@@ -92,19 +92,19 @@ DLL_PUBLIC Tensor pack_segments_backward_cuda(
           const auto* const data_ptr = data_contig->data_ptr<scalar_t>();
           auto* const out_data = unpacked_tensor.data_ptr<scalar_t>();
 
-          unpack_segments_cuda_kernel<index_t, scalar_t>
-              <<<cuda_calc_xblock_count(num_seq * max_length * cell_size, 128),
-                 128,
-                 0,
-                 at::cuda::getCurrentCUDAStream()>>>(
-                  data_ptr,
-                  lengths_data,
-                  lps_data,
-                  max_length,
-                  num_seq,
-                  cell_size,
-                  out_data);
-          C10_CUDA_KERNEL_LAUNCH_CHECK();
+          FBGEMM_LAUNCH_KERNEL(
+              (unpack_segments_cuda_kernel<index_t, scalar_t>),
+              cuda_calc_xblock_count(num_seq * max_length * cell_size, 128),
+              128,
+              0,
+              at::cuda::getCurrentCUDAStream(),
+              data_ptr,
+              lengths_data,
+              lps_data,
+              max_length,
+              num_seq,
+              cell_size,
+              out_data);
         });
   });
 

--- a/fbgemm_gpu/src/sparse_ops/sparse_zipf.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_zipf.cu
@@ -95,20 +95,20 @@ __global__ void zipf_kernel(
 
 DLL_PUBLIC Tensor
 zipf_cuda(const double a, const int64_t n, const int64_t seed) {
-  Tensor y = at::empty(
+  auto y = at::empty(
       {n},
       at::TensorOptions().dtype(at::kLong).device(
           at::kCUDA, at::cuda::current_device()));
-#ifdef FBGEMM_GPU_MEMCHECK
-  const auto func_name = "zipf_kernel";
-#endif
-  zipf_kernel<<<
+
+  FBGEMM_LAUNCH_KERNEL(
+      (zipf_kernel),
       cuda_calc_xblock_count(n, kMaxThreads),
       kMaxThreads,
       0,
-      at::cuda::getCurrentCUDAStream()>>>(
-      a, seed, MAKE_PTA_WITH_NAME(func_name, y, long, 1, 64));
-  C10_CUDA_KERNEL_LAUNCH_CHECK();
+      at::cuda::getCurrentCUDAStream(),
+      a,
+      seed,
+      PTA_B(y, long, 1, 64));
 
   return y;
 }


### PR DESCRIPTION
Summary: - Migrate sparse ops kernels to `FBGEMM_LAUNCH_KERNEL`, pt 3

Reviewed By: jianyuh

Differential Revision: D76639555


