### PR TITLE
[fbgemm_gpu] Upgrade Triton pinned version to v3.3.1

### DIFF
--- a/.github/scripts/utils_triton.bash
+++ b/.github/scripts/utils_triton.bash
@@ -86,8 +86,8 @@ install_triton_pip () {
   #
   # https://github.com/pytorch/pytorch/commits/main/.ci/docker/ci_commit_pins/triton.txt
   # https://github.com/pytorch/pytorch/blob/main/.ci/docker/ci_commit_pins/triton.txt
-  # https://github.com/pytorch/pytorch/pull/126098
-  local triton_version="nightly/3.2.0+git4b3bb1f8"
+  # https://github.com/pytorch/pytorch/pull/153951
+  local triton_version="nightly/3.3.1+gitc8757738"
 
   # BUILD_VARIANT is provided by the github workflow file
   if [ "$BUILD_VARIANT" == "cuda" ]; then


### PR DESCRIPTION
- Upgrade Triton pinned version to 3.3.1 to follow https://github.com/pytorch/pytorch/pull/153951
- This enables existing code to be able to use `num_consumer_groups` in `Config.__init__` (https://github.com/triton-lang/triton/blob/v3.3.1/python/triton/runtime/autotuner.py#L40)