### PR TITLE
Release PyPI nightly using nightly branch

### DIFF
--- a/.github/workflows/fbgemm_gpu_ci_cpu.yml
+++ b/.github/workflows/fbgemm_gpu_ci_cpu.yml
@@ -84,6 +84,8 @@ jobs:
 
     - name: Checkout the Repository
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event_name == 'schedule' && 'nightly' || 'main' }}
 
     - name: Display System Info
       run: . $PRELUDE; print_system_info
@@ -157,6 +159,8 @@ jobs:
 
     - name: Checkout the Repository
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event_name == 'schedule' && 'nightly' || 'main' }}
 
     - name: Download Wheel Artifact from GHA
       uses: actions/download-artifact@v4

--- a/.github/workflows/fbgemm_gpu_ci_cuda.yml
+++ b/.github/workflows/fbgemm_gpu_ci_cuda.yml
@@ -94,6 +94,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        ref: ${{ github.event_name == 'schedule' && 'nightly' || 'main' }}
 
     - name: Display System Info
       run: . $PRELUDE; print_system_info
@@ -187,6 +188,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        ref: ${{ github.event_name == 'schedule' && 'nightly' || 'main' }}
 
     - name: Download Wheel Artifact from GHA
       # Cannot upgrade to actions/download-artifact@v4 yet because GLIBC on the instance is too old

--- a/.github/workflows/fbgemm_gpu_ci_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_ci_rocm.yml
@@ -88,6 +88,8 @@ jobs:
 
     - name: Checkout the Repository
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event_name == 'schedule' && 'nightly' || 'main' }}
 
     - name: Display System Info
       run: . $PRELUDE; print_system_info
@@ -173,6 +175,8 @@ jobs:
 
     - name: Checkout the Repository
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event_name == 'schedule' && 'nightly' || 'main' }}
 
     - name: Download Wheel Artifact from GHA
       uses: actions/download-artifact@v4


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1636

Currently, we release Nova nightly packages on nightly branch but release PyPI ones based on main.

This diff changes PyPI release to be on nightly branch, to be on the same commit as Nova.

Reviewed By: q10

Differential Revision: D78848927


