### PR TITLE
Migrate sparse ops kernels to `FBGEMM_LAUNCH_KERNEL`, pt 4

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_range.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_range.cu
@@ -94,13 +94,16 @@ offsets_range_cuda(const Tensor& offsets, int64_t range_size) {
 
   AT_DISPATCH_INDEX_TYPES(
       offsets_contig.scalar_type(), "offsets_range_kernel", [&] {
-        _offsets_range_cuda_kernel<index_t>
-            <<<num_blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-                N,
-                range_size,
-                offsets_contig.data_ptr<index_t>(),
-                range.data_ptr<index_t>());
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        FBGEMM_LAUNCH_KERNEL(
+            (_offsets_range_cuda_kernel<index_t>),
+            num_blocks,
+            threads,
+            0,
+            at::cuda::getCurrentCUDAStream(),
+            N,
+            range_size,
+            offsets_contig.data_ptr<index_t>(),
+            range.data_ptr<index_t>());
       });
 
   return range;
@@ -148,13 +151,16 @@ DLL_PUBLIC Tensor lengths_range_cuda(
 
   AT_DISPATCH_INDEX_TYPES(
       t_in_contig.scalar_type(), "lengths_range_compute", [&] {
-        fbgemm_gpu::_offsets_range_cuda_kernel<index_t>
-            <<<num_blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-                num_seq,
-                output_size,
-                offsets.data_ptr<index_t>(),
-                output.data_ptr<index_t>());
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        FBGEMM_LAUNCH_KERNEL(
+            (_offsets_range_cuda_kernel<index_t>),
+            num_blocks,
+            threads,
+            0,
+            at::cuda::getCurrentCUDAStream(),
+            num_seq,
+            output_size,
+            offsets.data_ptr<index_t>(),
+            output.data_ptr<index_t>());
       });
 
   return output;

--- a/fbgemm_gpu/src/sparse_ops/sparse_segment_sum_csr.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_segment_sum_csr.cu
@@ -73,17 +73,17 @@ DLL_PUBLIC Tensor segment_sum_csr_cuda(
         using values_t = scalar_t;
         AT_DISPATCH_INDEX_TYPES(
             csr_seg.scalar_type(), "_segment_sum_csr_cuda_2", [&] {
-              _segment_sum_csr_cuda_kernel<values_t, index_t>
-                  <<<num_blocks,
-                     threads_per_block,
-                     0,
-                     at::cuda::getCurrentCUDAStream()>>>(
-                      csr_seg.numel() - 1,
-                      batch_size,
-                      csr_seg.data_ptr<index_t>(),
-                      values.data_ptr<values_t>(),
-                      output.data_ptr<values_t>());
-              C10_CUDA_KERNEL_LAUNCH_CHECK();
+              FBGEMM_LAUNCH_KERNEL(
+                  (_segment_sum_csr_cuda_kernel<values_t, index_t>),
+                  num_blocks,
+                  threads_per_block,
+                  0,
+                  at::cuda::getCurrentCUDAStream(),
+                  csr_seg.numel() - 1,
+                  batch_size,
+                  csr_seg.data_ptr<index_t>(),
+                  values.data_ptr<values_t>(),
+                  output.data_ptr<values_t>());
             });
       });
 


### PR DESCRIPTION
Summary: - Migrate sparse ops kernels to `FBGEMM_LAUNCH_KERNEL`, pt 4

Reviewed By: r-barnes

Differential Revision: D76640378


