### PR TITLE
[fbgemm] Enable ARM build, pt 1

### DIFF
--- a/.github/workflows/fbgemm_ci.yml
+++ b/.github/workflows/fbgemm_ci.yml
@@ -42,6 +42,7 @@ jobs:
       matrix:
         host-machine: [
           { arch: x86, instance: "linux.12xlarge" },
+          { arch: arm, instance: "linux.arm64.2xlarge" },
         ]
         library-type: [ static, shared ]
         compiler: [
@@ -50,6 +51,14 @@ jobs:
           { name: gcc, version: 14.1.0 },
           { name: clang, version: 16.0.6 }
         ]
+        exclude:
+          # ARM SVE support doesn't exist in GCC 9
+          - host-machine:
+              arch: arm
+              instance: linux.arm64.2xlarge
+            compiler:
+              name: gcc
+              version: 9.5.0
 
     steps:
     - name: Setup Build Container

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,78 @@ else()
 endif()
 
 ################################################################################
+# FBGEMM Neon Target
+################################################################################
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64")
+  message(STATUS "Processor is ${CMAKE_SYSTEM_PROCESSOR}; will build Neon target")
+
+  get_filelist("get_fbgemm_inline_neon_srcs(msvc=${MSVC_BOOL})" FBGEMM_NEON_SRCS)
+
+  cpp_library(
+    PREFIX
+      fbgemm_neon
+    TYPE
+      OBJECT
+    SRCS
+      ${FBGEMM_NEON_SRCS}
+    CC_FLAGS
+      -ftree-vectorize
+      -fno-trapping-math
+      -Wignored-qualifiers
+    DEFINITIONS
+      FBGEMM_ENABLE_KLEIDIAI
+      FBGEMM_FP16_FALLBACK_TO_REF_KERNEL
+      FBGEMM_FP32_FALLBACK_TO_REF_KERNEL
+    DEPS
+      $<BUILD_INTERFACE:cpuinfo>
+      $<BUILD_INTERFACE:asmjit>
+      fbgemm_generic
+  )
+
+  list(APPEND fbgemm_targets fbgemm_neon)
+
+else()
+  message(STATUS "Processor is ${CMAKE_SYSTEM_PROCESSOR}; will NOT build Neon target")
+endif()
+
+################################################################################
+# FBGEMM SVE Target
+################################################################################
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64")
+  message(STATUS "Processor is ${CMAKE_SYSTEM_PROCESSOR}; will build SVE target")
+
+  get_filelist("get_fbgemm_inline_sve_srcs(msvc=${MSVC_BOOL})" FBGEMM_SVE_SRCS)
+
+  cpp_library(
+    PREFIX
+      fbgemm_sve
+    TYPE
+      OBJECT
+    SRCS
+      ${FBGEMM_SVE_SRCS}
+    CC_FLAGS
+      -ftree-vectorize
+      -fno-trapping-math
+      -Wignored-qualifiers
+    DEFINITIONS
+      FBGEMM_ENABLE_KLEIDIAI
+      FBGEMM_FP16_FALLBACK_TO_REF_KERNEL
+      FBGEMM_FP32_FALLBACK_TO_REF_KERNEL
+    DEPS
+      $<BUILD_INTERFACE:cpuinfo>
+      $<BUILD_INTERFACE:asmjit>
+      fbgemm_generic
+  )
+
+  list(APPEND fbgemm_targets fbgemm_sve)
+
+else()
+  message(STATUS "Processor is ${CMAKE_SYSTEM_PROCESSOR}; will NOT build SVE target")
+endif()
+
+################################################################################
 # FBGEMM Autovec Target
 ################################################################################
 

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -39,11 +39,13 @@ function(add_benchmark BENCHNAME)
     ${bench_sources})
 
   if(NOT MSVC)
-    target_compile_options(${BENCHNAME} PRIVATE
-      -m64
-      -mavx2
-      -mfma
-      -masm=intel)
+    if(COMPILER_SUPPORTS_AVX2)
+      target_compile_options(${BENCHNAME} PRIVATE
+        -m64
+        -mavx2
+        -mfma
+        -masm=intel)
+    endif()
   endif()
 
   target_link_libraries(${BENCHNAME} fbgemm)
@@ -87,7 +89,12 @@ endfunction()
 ################################################################################
 
 if(FBGEMM_BUILD_BENCHMARKS)
-  file(GLOB BENCH_LIST "*Benchmark.cc")
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64")
+    set(BENCH_LIST FP16Benchmark.cc)
+  else()
+    file(GLOB BENCH_LIST "*Benchmark.cc")
+  endif()
+
   # NOTE: Skip FP32 benchmark until FP32 is properly integrated into OSS builds
   list(FILTER BENCH_LIST EXCLUDE REGEX "FP32Benchmark\\.cc$")
 

--- a/defs.bzl
+++ b/defs.bzl
@@ -174,42 +174,35 @@ def get_fbgemm_inline_avx512_srcs(msvc = False, buck = False):
     return asm_srcs if not msvc else intrinsics_srcs
 
 def get_fbgemm_inline_sve_srcs(msvc = False, buck = False):
-    intrinsics_srcs = [
+    srcs = [
         "src/FbgemmFP16UKernelsSve128.cc",
         "src/KleidiAIFP16UKernelsNeon.cc",
         "src/QuantUtilsNeon.cc",
         "src/UtilsSve.cc",
-    ] + select({
-        "DEFAULT": [],
-        "ovr_config//cpu:arm64": [
-            "src/FbgemmFloat16ConvertSVE.cc",
-        ],
-    })
+        "src/FbgemmFloat16ConvertSVE.cc",
+    ]
 
-    #FP16 kernels contain inline assembly and inline assembly syntax for MSVC is different.
-    asm_srcs = [
-        "src/FbgemmFP16UKernelsSve128.cc",
-        "src/KleidiAIFP16UKernelsNeon.cc",
-        "src/QuantUtilsNeon.cc",
-        "src/UtilsSve.cc",
-    ] + select({
-        "DEFAULT": [],
-        "ovr_config//cpu:arm64": [
-            "src/FbgemmFloat16ConvertSVE.cc",
-        ],
-    })
     if buck:
-        return select({
-            "DEFAULT": asm_srcs,
-            "ovr_config//compiler:cl": intrinsics_srcs,
-            "ovr_config//cpu:arm64": intrinsics_srcs,
+        # FP16 kernels contain inline assembly and inline assembly syntax for MSVC is different.
+        srcs += select({
+            "DEFAULT": [],
+            "ovr_config//cpu:arm64": [
+                "src/FbgemmFloat16ConvertSVE.cc",
+            ],
         })
-    return asm_srcs if not msvc else intrinsics_srcs
+        return select({
+            "DEFAULT": srcs,
+            "ovr_config//compiler:cl": srcs,
+            "ovr_config//cpu:arm64": srcs,
+        })
+
+    else:
+        return srcs
 
 def get_fbgemm_inline_neon_srcs(msvc = False, buck = False):
     intrinsics_srcs = ["src/UtilsNeon.cc"]
 
-    #FP16 kernels contain inline assembly and inline assembly syntax for MSVC is different.
+    # FP16 kernels contain inline assembly and inline assembly syntax for MSVC is different.
     asm_srcs = ["src/UtilsNeon.cc"]
     if buck:
         return select({

--- a/src/FbgemmFloat16ConvertSVE.cc
+++ b/src/FbgemmFloat16ConvertSVE.cc
@@ -13,6 +13,8 @@
 #define FBGEMM_EXPORTS
 #include "fbgemm/FbgemmConvert.h"
 
+#include <stdexcept>
+
 namespace fbgemm {
 
 #if defined(__ARM_FEATURE_SVE2)

--- a/src/GroupwiseConv.cc
+++ b/src/GroupwiseConv.cc
@@ -891,24 +891,26 @@ static void dispatchOutputProcessing(
     int C_per_G,
     true_type /*unused*/) {
   constexpr QuantizationGranularity Q_GRAN = processOutputType::QGRANType;
-  constexpr int FUSE_RELU = processOutputType::RELU_FUSED;
-  bool b_symmetric = (Q_GRAN == QuantizationGranularity::TENSOR &&
-                      outProcess.getBZeroPoint()[0] == 0) ||
+  [[maybe_unused]] constexpr int FUSE_RELU = processOutputType::RELU_FUSED;
+  [[maybe_unused]] bool b_symmetric =
+      (Q_GRAN == QuantizationGranularity::TENSOR &&
+       outProcess.getBZeroPoint()[0] == 0) ||
       rowOffsetBuf == nullptr;
   int32_t a_zero_point = outProcess.getAZeroPoint();
 
   // Requantization
-  requantizationParams_t<typename processOutputType::BIAS_T> r = {
-      a_zero_point,
-      outProcess.getBZeroPoint(),
-      outProcess.getCZeroPoint(),
-      outProcess.getCMultiplier(),
-      rowOffsetBuf,
-      outProcess.getColOffsets(),
-      outProcess.getBias(),
-      outProcess.getNCols(),
-      groups,
-      outProcess.getActWScale()};
+  [[maybe_unused]] requantizationParams_t<typename processOutputType::BIAS_T>
+      r = {
+          a_zero_point,
+          outProcess.getBZeroPoint(),
+          outProcess.getCZeroPoint(),
+          outProcess.getCMultiplier(),
+          rowOffsetBuf,
+          outProcess.getColOffsets(),
+          outProcess.getBias(),
+          outProcess.getNCols(),
+          groups,
+          outProcess.getActWScale()};
 
 #define REQUANTIZE_BASE(ISA, C_PER_G, A_SYM, B_SYM, BIAS) \
   requantizeOutputProcessingGConv##ISA<                   \

--- a/src/TransposeUtils.cc
+++ b/src/TransposeUtils.cc
@@ -118,4 +118,5 @@ template FBGEMM_API void transpose_simd<uint16_t>(
     int64_t ld_src,
     uint16_t* dst,
     int64_t ld_dst);
+
 } // namespace fbgemm

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,11 +65,13 @@ function(add_gtest TESTNAME)
     endif()
 
   else()
-    target_compile_options(${TESTNAME} PRIVATE
-      -m64
-      -mavx2
-      -mfma
-      -masm=intel)
+    if(COMPILER_SUPPORTS_AVX2)
+      target_compile_options(${TESTNAME} PRIVATE
+        -m64
+        -mavx2
+        -mfma
+        -masm=intel)
+    endif()
   endif()
 
   if (FBGEMM_USE_SANITIZER)
@@ -107,18 +109,12 @@ foreach(TEST_FILE ${TEST_LIST})
     continue()
   endif()
 
-  message(STATUS "Processing: ${TEST_FILE}")
-  message(STATUS "COMPILER_SUPPORTS_AVX512 = ${FBGEMM_ENABLE_AVX512}")
+  # NOTE: Skip tests on ARM for now until linking issues are fixed
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64")
+    continue()
+  endif()
 
-  # # Skip the following tests when AVX512 is not available
-  # if(NOT FBGEMM_ENABLE_AVX512)
-  #   if(TEST_FILE MATCHES "FP16Test.cc$"
-  #       OR TEST_FILE MATCHES "GConvTest.cc$"
-  #       OR TEST_FILE MATCHES "UniConvTest.cc$"
-  #       OR TEST_FILE MATCHES "SparseDenseMMInt8Test.cc$")
-  #     continue()
-  #   endif()
-  # endif()
+  message(STATUS "Processing: ${TEST_FILE}")
 
   get_filename_component(TEST_NAME "${TEST_FILE}" NAME_WE)
   get_filename_component(TEST_FILE_ONLY "${TEST_FILE}" NAME)

--- a/test/TransposedRequantizeTest.cc
+++ b/test/TransposedRequantizeTest.cc
@@ -119,6 +119,14 @@ TEST_P(RequantizeTest, reqTest) {
       bias_data_ptr,
       act_times_w_scale.data()};
 
+#ifdef __aarch64__
+
+#define TESTCODE(FUSE_RELU, ACT_SYMMETRIC, WEIGHT_SYMMETRIC, HAS_BIAS, Q_GRAN) \
+  trRequantizeRef<FUSE_RELU, Q_GRAN>(                                          \
+      output_ref.data(), input.data(), block, cols, cols, reqParams);
+
+#else
+
 #define TESTCODE(FUSE_RELU, ACT_SYMMETRIC, WEIGHT_SYMMETRIC, HAS_BIAS, Q_GRAN) \
   trRequantizeRef<FUSE_RELU, Q_GRAN>(                                          \
       output_ref.data(), input.data(), block, cols, cols, reqParams);          \
@@ -128,6 +136,8 @@ TEST_P(RequantizeTest, reqTest) {
       WEIGHT_SYMMETRIC,                                                        \
       HAS_BIAS,                                                                \
       Q_GRAN>(output_test.data(), input.data(), block, cols, cols, reqParams);
+
+#endif
 
   if (fuse_relu) {
     if (q_gran == QuantizationGranularity::TENSOR) {


### PR DESCRIPTION
- Enable basic Linux ARM build in OSS.  Tests and benchmarks are currently disabled (except for FP16Benchmark) due to unreferenced symbols, which are to be addressed in subsequent PRs