### PR TITLE
Enable index_shuffling with top-K > 1

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/moe/index_shuffling.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/moe/index_shuffling.cpp
@@ -24,35 +24,40 @@ Args:
       the expert to be routed, exclusive. If not passed, it is assumed to be E.
     - `valid_token_count`: Optional. (1) tensor of valid token count per expert.
       If not passed, it is assumed to be T.
+    - `top_k`: Optional. Number of experts to activate per token. If not passed,
+it is assumed to be 1.
 
 Returns:
     - `token_count_per_expert`: (E + 2) tensor of token count per expert and
       `num_total_tokens`, `num_sorted_tokens` are packed into as the last two
       elements.
-  - `expert_indices`: (T) tensor of routed
-      expert indices. Only the first `num_sorted_tokens` elements are valid.
-  - `token_indices`: (T) tensor of pre-routing token indices. Only the first
-      `num_sorted_tokens` elements are valid.
+  - `expert_indices`: (T * top_k) tensor of routed
+      expert indices. Only the first `num_sorted_tokens * top_k` elements are
+valid.
+  - `token_indices`: (T * top_k) tensor of pre-routing token indices. Only the
+first `num_sorted_tokens * top_k` elements are valid.
 */
 std::tuple<at::Tensor, at::Tensor, at::Tensor> index_shuffling_torch(
     const at::Tensor& routing_scores,
     const std::optional<int64_t>& expert_index_start,
     const std::optional<int64_t>& expert_index_end,
-    const std::optional<at::Tensor>& valid_token_count);
+    const std::optional<at::Tensor>& valid_token_count,
+    const int64_t top_k = 1);
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor> index_shuffling_torch_meta(
     const at::Tensor& routing_scores,
     const std::optional<int64_t>& expert_index_start,
     const std::optional<int64_t>& expert_index_end,
-    const std::optional<at::Tensor>& valid_token_count) {
+    const std::optional<at::Tensor>& valid_token_count,
+    const int64_t top_k = 1) {
   int T = routing_scores.size(0);
   int E = routing_scores.size(1);
   at::Tensor token_counts_per_expert =
       at::empty({E + 2}, routing_scores.options().dtype(at::kInt));
   at::Tensor expert_indices =
-      at::empty({T}, routing_scores.options().dtype(at::kInt));
+      at::empty({T * top_k}, routing_scores.options().dtype(at::kInt));
   at::Tensor token_indices =
-      at::empty({T}, routing_scores.options().dtype(at::kInt));
+      at::empty({T * top_k}, routing_scores.options().dtype(at::kInt));
   return {token_counts_per_expert, expert_indices, token_indices};
 }
 

--- a/fbgemm_gpu/experimental/gen_ai/src/moe/index_shuffling.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/moe/index_shuffling.cu
@@ -74,10 +74,15 @@ __device__ __forceinline__ int load_aquire(int* addr) {
 };
 #endif
 
-template <class DataType, class IndexType, int NumExperts, int NumTokensPerTile>
+template <
+    class DataType,
+    class IndexType,
+    int NumExperts,
+    int NumTokensPerTile,
+    int TopK>
 struct SharedStorage {
-  DataType routing_scores[NumTokensPerTile * NumExperts];
-  IndexType expert_indices[NumTokensPerTile * NumExperts];
+  DataType routing_scores[NumTokensPerTile * NumExperts * TopK];
+  IndexType expert_indices[NumTokensPerTile * NumExperts * TopK];
   IndexType token_count_cumsums[NumExperts];
 };
 
@@ -106,7 +111,143 @@ struct Params {
   IndexType* shuffled_token_indices;
 };
 
-template <class DataType, class IndexType, int NumExperts, int NumTokensPerTile>
+template <class DataType, class IndexType>
+__device__ __forceinline__ void merge_top1(
+    DataType* routing_scores,
+    IndexType* expert_indices,
+    int lhs_smem_index,
+    int rhs_smem_index) {
+  auto lhs_score = routing_scores[lhs_smem_index];
+  auto rhs_score = routing_scores[rhs_smem_index];
+  auto lhs_expert_index = expert_indices[lhs_smem_index];
+  auto rhs_expert_index = expert_indices[rhs_smem_index];
+
+  bool lhs_larger = lhs_score >= rhs_score;
+  routing_scores[lhs_smem_index] = lhs_larger ? lhs_score : rhs_score;
+  expert_indices[lhs_smem_index] =
+      lhs_larger ? lhs_expert_index : rhs_expert_index;
+}
+
+template <class DataType, class IndexType>
+__device__ __forceinline__ void merge_top2(
+    DataType* routing_scores,
+    IndexType* expert_indices,
+    int lhs_smem_index,
+    int rhs_smem_index,
+    bool skip_duplicates) {
+  auto lhs_score0 = routing_scores[lhs_smem_index];
+  auto lhs_score1 = routing_scores[lhs_smem_index + 1];
+  auto rhs_score0 = routing_scores[rhs_smem_index];
+  auto rhs_score1 = routing_scores[rhs_smem_index + 1];
+  auto lhs_expert_index0 = expert_indices[lhs_smem_index];
+  auto lhs_expert_index1 = expert_indices[lhs_smem_index + 1];
+  auto rhs_expert_index0 = expert_indices[rhs_smem_index];
+  auto rhs_expert_index1 = expert_indices[rhs_smem_index + 1];
+
+  if (lhs_score0 >= rhs_score0) {
+    routing_scores[lhs_smem_index] = lhs_score0;
+    expert_indices[lhs_smem_index] = lhs_expert_index0;
+
+    if ((lhs_score1 >= rhs_score0) && !skip_duplicates) {
+      routing_scores[lhs_smem_index + 1] = lhs_score1;
+      expert_indices[lhs_smem_index + 1] = lhs_expert_index1;
+    } else {
+      routing_scores[lhs_smem_index + 1] = rhs_score0;
+      expert_indices[lhs_smem_index + 1] = rhs_expert_index0;
+    }
+  } else {
+    routing_scores[lhs_smem_index] = rhs_score0;
+    expert_indices[lhs_smem_index] = rhs_expert_index0;
+
+    if ((rhs_score1 > lhs_score0) && !skip_duplicates) {
+      routing_scores[lhs_smem_index + 1] = rhs_score1;
+      expert_indices[lhs_smem_index + 1] = rhs_expert_index1;
+    } else {
+      routing_scores[lhs_smem_index + 1] = lhs_score0;
+      expert_indices[lhs_smem_index + 1] = lhs_expert_index0;
+    }
+  }
+}
+
+template <class DataType, class IndexType, int K>
+__device__ __forceinline__ void merge_topk(
+    DataType* routing_scores,
+    IndexType* expert_indices,
+    int lhs_smem_index,
+    int rhs_smem_index,
+    int num_valid_values) {
+  /**
+  @param num_valid_values At first log2(K) calls to this function, both inputs
+  would only contain num_valid_values = 2 ** (step_number - 1) meaningful
+  values, the rest are duplicates. So the function should take exactly
+  num_valid_values elements from the first input and num_valid_values elements
+  from the second input. After the first log2(K) calls, all elements in the
+  inputs are meaningful, and num_valid_values doesn't have any effect (i.e.
+  num_valid_values >= K).
+  */
+  // Temporary arrays to store the merged result
+  DataType merged_scores[K];
+  IndexType merged_indices[K];
+
+  // Pointers to the left and right arrays
+  DataType* lhs_scores = &routing_scores[lhs_smem_index];
+  DataType* rhs_scores = &routing_scores[rhs_smem_index];
+  IndexType* lhs_indices = &expert_indices[lhs_smem_index];
+  IndexType* rhs_indices = &expert_indices[rhs_smem_index];
+
+  // Merge the two sorted arrays (assuming both are sorted in descending order)
+  int lhs_idx = 0;
+  int rhs_idx = 0;
+  int merged_idx = 0;
+
+  int max_from_one_array = std::min(num_valid_values, K);
+
+  // Get the top K elements from the two arrays
+  while (merged_idx < K) {
+    // If we've exhausted the left array, take from the right
+    if (lhs_idx >= max_from_one_array) {
+      merged_scores[merged_idx] = rhs_scores[rhs_idx];
+      merged_indices[merged_idx] = rhs_indices[rhs_idx];
+      rhs_idx++;
+      merged_idx++;
+      continue;
+    }
+
+    // If we've exhausted the right array, take from the left
+    if (rhs_idx >= max_from_one_array) {
+      merged_scores[merged_idx] = lhs_scores[lhs_idx];
+      merged_indices[merged_idx] = lhs_indices[lhs_idx];
+      lhs_idx++;
+      merged_idx++;
+      continue;
+    }
+
+    // Compare the current elements from both arrays and take the larger one
+    if (lhs_scores[lhs_idx] >= rhs_scores[rhs_idx]) {
+      merged_scores[merged_idx] = lhs_scores[lhs_idx];
+      merged_indices[merged_idx] = lhs_indices[lhs_idx];
+      lhs_idx++;
+    } else {
+      merged_scores[merged_idx] = rhs_scores[rhs_idx];
+      merged_indices[merged_idx] = rhs_indices[rhs_idx];
+      rhs_idx++;
+    }
+    merged_idx++;
+  }
+
+  // Write the merged result back to the left-hand side positions
+  for (int i = 0; i < K; i++) {
+    routing_scores[lhs_smem_index + i] = merged_scores[i];
+    expert_indices[lhs_smem_index + i] = merged_indices[i];
+  }
+}
+
+template <
+    class DataType,
+    class IndexType,
+    int NumExperts,
+    int NumTokensPerTile,
+    int TopK>
 __global__ void index_shuffling_kernel(Params<DataType, IndexType> params) {
   // scores: [num_tokens, num_experts]
   // counts: [num_experts]
@@ -120,8 +261,10 @@ __global__ void index_shuffling_kernel(Params<DataType, IndexType> params) {
   constexpr int kNumWarps = (NumExperts > 128) ? 8 : 4;
   constexpr int kNumThreads = kNumThreadsPerWarp * kNumWarps;
 
-  __shared__ SharedStorage<DataType, IndexType, NumExperts, NumTokensPerTile>
-      smem;
+  extern __shared__ char shared_memory[];
+  auto& smem = *reinterpret_cast<
+      SharedStorage<DataType, IndexType, NumExperts, NumTokensPerTile, TopK>*>(
+      shared_memory);
 
   const auto tidx = threadIdx.x;
   const auto bidx = blockIdx.x;
@@ -143,7 +286,7 @@ __global__ void index_shuffling_kernel(Params<DataType, IndexType> params) {
   const int stride_t = params.stride_t;
   const int stride_e = params.stride_e;
 
-  const DataType zero = static_cast<DataType>(0.0f);
+  const DataType zero = static_cast<DataType>(-INFINITY);
   for (int token_index_offset = token_index_start;
        token_index_offset < token_index_end;
        token_index_offset += NumTokensPerTile) {
@@ -153,12 +296,14 @@ __global__ void index_shuffling_kernel(Params<DataType, IndexType> params) {
     for (int i = tidx; i < NumTokensPerTile * NumExperts; i += kNumThreads) {
       const int token_index = token_index_offset + i / NumExperts;
       const int expert_index = i % NumExperts;
-
-      smem.routing_scores[i] = (token_index < num_valid_tokens)
-          ? params.routing_scores
-                [token_index * stride_t + expert_index * stride_e]
-          : zero;
-      smem.expert_indices[i] = expert_index;
+#pragma unroll
+      for (int j = 0; j < TopK; j++) {
+        smem.routing_scores[i * TopK + j] = (token_index < num_valid_tokens)
+            ? params.routing_scores
+                  [token_index * stride_t + expert_index * stride_e]
+            : zero;
+        smem.expert_indices[i * TopK + j] = expert_index;
+      }
     }
     __syncthreads();
 
@@ -188,21 +333,35 @@ __global__ void index_shuffling_kernel(Params<DataType, IndexType> params) {
               local_token_offset + tidx / kNumParallelReductionThreads;
           int lhs_expert_offset = (tidx % kNumParallelReductionThreads) * 2;
           int lhs_smem_index =
-              local_token_index * NumExperts + lhs_expert_offset;
+              (local_token_index * NumExperts + lhs_expert_offset) * TopK;
 
-          int rhs_smem_index = lhs_smem_index + num_reduced_threads;
+          int rhs_smem_index = lhs_smem_index + num_reduced_threads * TopK;
           if (lhs_expert_offset + num_reduced_threads < NumExperts) {
-            auto lhs_score = smem.routing_scores[lhs_smem_index];
-            auto rhs_score = smem.routing_scores[rhs_smem_index];
-            auto lhs_expert_index = smem.expert_indices[lhs_smem_index];
-            auto rhs_expert_index = smem.expert_indices[rhs_smem_index];
-
-            bool lhs_larger = lhs_score >= rhs_score;
-            smem.routing_scores[lhs_smem_index] =
-                lhs_larger ? lhs_score : rhs_score;
-            smem.expert_indices[lhs_smem_index] =
-                lhs_larger ? lhs_expert_index : rhs_expert_index;
+            if (TopK == 1) {
+              merge_top1(
+                  smem.routing_scores,
+                  smem.expert_indices,
+                  lhs_smem_index,
+                  rhs_smem_index);
+            } else if (TopK == 2) {
+              merge_top2(
+                  smem.routing_scores,
+                  smem.expert_indices,
+                  lhs_smem_index,
+                  rhs_smem_index,
+                  num_reduced_threads == 1);
+            } else {
+              merge_topk<DataType, IndexType, 4>(
+                  smem.routing_scores,
+                  smem.expert_indices,
+                  lhs_smem_index,
+                  rhs_smem_index,
+                  num_reduced_threads);
+            }
           }
+        }
+        if (TopK > 1) {
+          __syncthreads();
         }
       }
 #ifdef USE_ROCM
@@ -225,13 +384,18 @@ __global__ void index_shuffling_kernel(Params<DataType, IndexType> params) {
       int local_token_index = i;
       int token_index = token_index_offset + i;
       if (token_index < num_valid_tokens) {
-        auto expert_index = smem.expert_indices[local_token_index * NumExperts];
-        params.buffered_expert_indices[token_index] = expert_index;
-        if (expert_index >= expert_index_start &&
-            expert_index < expert_index_end) {
-          auto token_index_in_expert = atomic_add_relaxed(
-              &params.token_count_per_expert[expert_index], 1);
-          params.buffered_token_indices[token_index] = token_index_in_expert;
+#pragma unroll
+        for (int j = 0; j < TopK; j++) {
+          auto expert_index =
+              smem.expert_indices[local_token_index * NumExperts * TopK + j];
+          params.buffered_expert_indices[token_index * TopK + j] = expert_index;
+          if (expert_index >= expert_index_start &&
+              expert_index < expert_index_end) {
+            auto token_index_in_expert = atomic_add_relaxed(
+                &params.token_count_per_expert[expert_index], 1);
+            params.buffered_token_indices[token_index * TopK + j] =
+                token_index_in_expert;
+          }
         }
       }
     }
@@ -267,7 +431,7 @@ __global__ void index_shuffling_kernel(Params<DataType, IndexType> params) {
   __syncthreads();
 
   // 5. Store
-  auto get_token_count_cumsum = [](int index) {
+  auto get_token_count_cumsum = [&smem](int index) {
     return index == 0 ? 0 : smem.token_count_cumsums[index - 1];
   };
 
@@ -282,16 +446,20 @@ __global__ void index_shuffling_kernel(Params<DataType, IndexType> params) {
        global_token_offset += kNumThreads) {
     int token_index = global_token_offset + tidx;
     if (token_index < num_valid_tokens) {
-      int expert_index = params.buffered_expert_indices[token_index];
-      if (expert_index >= expert_index_start &&
-          expert_index < expert_index_end) {
-        int new_token_index_in_expert =
-            params.buffered_token_indices[token_index];
-        int new_token_index = get_token_count_cumsum(expert_index) -
-            token_count_cumsum_start + new_token_index_in_expert;
-        params.shuffled_expert_indices[new_token_index] =
-            expert_index - expert_index_start;
-        params.shuffled_token_indices[new_token_index] = token_index;
+#pragma unroll
+      for (int j = 0; j < TopK; j++) {
+        int expert_index =
+            params.buffered_expert_indices[token_index * TopK + j];
+        if (expert_index >= expert_index_start &&
+            expert_index < expert_index_end) {
+          int new_token_index_in_expert =
+              params.buffered_token_indices[token_index * TopK + j];
+          int new_token_index = get_token_count_cumsum(expert_index) -
+              token_count_cumsum_start + new_token_index_in_expert;
+          params.shuffled_expert_indices[new_token_index] =
+              expert_index - expert_index_start;
+          params.shuffled_token_indices[new_token_index] = token_index;
+        }
       }
     }
   }
@@ -306,7 +474,8 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> index_shuffling_torch(
     const at::Tensor& routing_scores,
     const std::optional<int64_t>& expert_index_start,
     const std::optional<int64_t>& expert_index_end,
-    const std::optional<at::Tensor>& valid_token_count) {
+    const std::optional<at::Tensor>& valid_token_count,
+    const int64_t top_k = 1) {
   TORCH_CHECK(
       routing_scores.dtype() == torch::kBFloat16 ||
           routing_scores.dtype() == torch::kFloat,
@@ -333,6 +502,8 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> index_shuffling_torch(
             num_experts == 16 || num_experts == 32 || num_experts == 128 ||
             num_experts == 320);
 
+        TORCH_CHECK(top_k == 1 || top_k == 2 || top_k == 4);
+
         auto allocate_index_tensor = [&](int size) {
           return at::empty(
               {size},
@@ -340,11 +511,12 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> index_shuffling_torch(
                   routing_scores.device()));
         };
         token_count_per_expert = allocate_index_tensor(num_experts + 2);
-        shuffled_expert_indices = allocate_index_tensor(num_tokens);
-        shuffled_token_indices = allocate_index_tensor(num_tokens);
-        at::Tensor buffered_expert_indices = allocate_index_tensor(num_tokens);
-        at::Tensor buffered_token_indices = allocate_index_tensor(num_tokens);
-
+        shuffled_expert_indices = allocate_index_tensor(num_tokens * top_k);
+        shuffled_token_indices = allocate_index_tensor(num_tokens * top_k);
+        at::Tensor buffered_expert_indices =
+            allocate_index_tensor(num_tokens * top_k);
+        at::Tensor buffered_token_indices =
+            allocate_index_tensor(num_tokens * top_k);
 #ifdef USE_ROCM
         // TODO(shikaili): hipMetsetAsync is more expensive than ATen set zero.
         token_count_per_expert.zero_();
@@ -374,24 +546,67 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> index_shuffling_torch(
         void* kernel;
         int smem_size;
 
-#define DISPATCH(E, B)                                               \
-  kernel = (void*)index_shuffling_kernel<DataType, IndexType, E, B>; \
-  smem_size = sizeof(SharedStorage<DataType, IndexType, E, B>);
+// Reducing tile size as problem size increases to avoid
+// cudaErrorCooperativeLaunchTooLarge.
+// TopK > 1 is not supported on AMD yet.
+#ifndef USE_ROCM
+#define DISPATCH(E, B, K, S)          \
+  if (S <= 128) {                     \
+    DISPATCH_K(E, B, K);              \
+  } else if (storage_factor <= 256) { \
+    DISPATCH_K(E, B / 2, K);          \
+  } else if (storage_factor <= 512) { \
+    DISPATCH_K(E, B / 4, K);          \
+  } else {                            \
+    DISPATCH_K(E, B / 8, K);          \
+  }
+#else
+#define DISPATCH(E, B, K, S) \
+  TORCH_CHECK(K == 1);       \
+  DISPATCH_EB(E, 8, 1)
+#endif
+
+#define DISPATCH_K(E, B, K) \
+  if (K == 1) {             \
+    DISPATCH_EB(E, B, 1)    \
+  } else if (K == 2) {      \
+    DISPATCH_EB(E, B, 2)    \
+  } else {                  \
+    TORCH_CHECK(K == 4);    \
+    DISPATCH_EB(E, B, 4)    \
+  }
+#define DISPATCH_EB(E, B, K)                                            \
+  kernel = (void*)index_shuffling_kernel<DataType, IndexType, E, B, K>; \
+  smem_size = sizeof(SharedStorage<DataType, IndexType, E, B, K>);
+
+        int storage_factor = top_k * num_experts;
 
         if (num_experts == 16) {
-          DISPATCH(16, kNumTokensPerTileFewExperts);
+          DISPATCH_K(16, kNumTokensPerTileFewExperts, top_k)
         } else if (num_experts == 32) {
-          DISPATCH(32, kNumTokensPerTileFewExperts);
+          DISPATCH_K(32, kNumTokensPerTileFewExperts, top_k)
         } else if (num_experts == 128) {
-          DISPATCH(128, kNumTokensPerTileFewExperts);
+          DISPATCH(128, kNumTokensPerTileFewExperts, top_k, storage_factor)
         } else {
-          // Reducing tile size to avoid cudaErrorCooperativeLaunchTooLarge.
           TORCH_CHECK(num_experts == 320);
-          DISPATCH(320, 8);
+          DISPATCH(320, kNumTokensPerTileFewExperts, top_k, storage_factor)
         }
+    // This is to avoid build errors (divisibility asserts and local memory
+    // overflow) on AMD.
+#ifndef USE_ROCM
+        const int num_tokens_per_tile = (storage_factor <= 128)
+            ? kNumTokensPerTileFewExperts
+            : ((storage_factor <= 256)
+                   ? kNumTokensPerTileFewExperts / 2
+                   : ((storage_factor <= 512)
+                          ? kNumTokensPerTileFewExperts / 4
+                          : kNumTokensPerTileFewExperts / 8));
+#else
+        const int num_tokens_per_tile = (num_experts <= 128)
+            ? kNumTokensPerTileFewExperts
+            : kNumTokensPerTileFewExperts / 4;
+#endif
 
-        const int num_tokens_per_tile =
-            (num_experts > 128) ? 8 : kNumTokensPerTileFewExperts;
         const int num_tiles = ceil_of_ratio(num_tokens, num_tokens_per_tile);
         const int num_ctas = std::min(num_tiles, num_sms);
         const int num_tiles_per_cta = ceil_of_ratio(
@@ -439,6 +654,10 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> index_shuffling_torch(
         C10_CUDA_CHECK(hipLaunchKernel(
             (void*)kernel, grids, blocks, args, smem_size, stream));
 #else
+        if (smem_size >= 48 * 1024) {
+          C10_CUDA_CHECK(cudaFuncSetAttribute(
+              kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+        }
         C10_CUDA_CHECK(cudaLaunchCooperativeKernel(
             (void*)kernel, grids, blocks, args, smem_size, stream));
 #endif

--- a/fbgemm_gpu/experimental/gen_ai/src/moe/index_shuffling_defs.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/moe/index_shuffling_defs.cpp
@@ -16,7 +16,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "index_shuffling(Tensor routing_scores,             "
       "                int? expert_index_start=None,      "
       "                int? expert_index_end=None,        "
-      "                Tensor? valid_token_count=None) -> "
+      "                Tensor? valid_token_count=None,    "
+      "                int top_k=1) ->                    "
       "(Tensor, Tensor, Tensor)");
 }
 

--- a/fbgemm_gpu/experimental/gen_ai/test/moe/shuffling_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/moe/shuffling_test.py
@@ -56,17 +56,19 @@ class ShufflingTests(unittest.TestCase):
         ),
         num_experts=st.sampled_from([16, 32, 128, 320]),
         num_local_experts=st.sampled_from([None, 8]),
+        top_k=st.sampled_from([1, 2, 4] if torch.version.cuda else [1]),
         padded=st.sampled_from([True, False]),
         rowmajor=st.sampled_from([True, False]),
         compiled=st.sampled_from([True, False]),
         routing_score_dtype=st.sampled_from([torch.float, torch.bfloat16]),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=_MAX_SAMPLES, deadline=None)
-    def test_top1_index_shuffling(
+    def test_topk_index_shuffling(
         self,
         num_tokens: int,
         num_experts: int,
         num_local_experts: Optional[int],
+        top_k: int,
         padded: bool,
         rowmajor: bool,
         compiled: bool,
@@ -97,12 +99,9 @@ class ShufflingTests(unittest.TestCase):
             num_valid_tokens = num_tokens
             valid_token_counts = torch.tensor([num_tokens], device="cuda")
 
-        routing_scores: torch.Tensor = torch.randn(
-            num_total_tokens,
-            num_experts,
-            device=torch.accelerator.current_accelerator(),
-            dtype=routing_score_dtype,
-        ).contiguous()
+        routing_scores: torch.Tensor = _get_scores_without_ties(
+            num_total_tokens, num_experts, routing_score_dtype
+        )
         if not rowmajor:
             routing_scores = routing_scores.transpose(0, 1).contiguous().transpose(0, 1)
 
@@ -111,19 +110,23 @@ class ShufflingTests(unittest.TestCase):
             if compiled:
                 op = torch.compile(op, backend="inductor", fullgraph=True)
             if num_local_experts is None and valid_token_counts is None:
-                return op(routing_scores)
+                return op(routing_scores, top_k=top_k)
             else:
                 return op(
                     routing_scores,
                     expert_index_start,
                     expert_index_end,
                     valid_token_counts,
+                    top_k,
                 )
 
         def ref_fn() -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
             valid_routing_scores = routing_scores[:num_valid_tokens].contiguous()
-            selected_expert_indices = torch.topk(valid_routing_scores, 1, dim=1)[1]
-            expert_indices, token_indices = torch.sort(selected_expert_indices, dim=0)
+            selected_expert_indices = torch.topk(valid_routing_scores, top_k, dim=1)[1]
+            expert_indices, flattened_position_indices = torch.sort(
+                selected_expert_indices.flatten(), dim=0
+            )
+            token_indices = flattened_position_indices // top_k
             expert_ids = torch.arange(num_experts, device=expert_indices.device)
             token_counts_per_expert = (
                 expert_indices[:, None] == expert_ids[None, :]
@@ -152,8 +155,8 @@ class ShufflingTests(unittest.TestCase):
         self.assertEqual(token_counts_per_expert[-1].item(), ref_num_sorted_tokens)
 
         # 2. Checks `expert_indices` and `token_indices` returns are correct.
-        self.assertEqual(expert_indices.shape, (num_total_tokens,))
-        self.assertEqual(token_indices.shape, (num_total_tokens,))
+        self.assertEqual(expert_indices.shape, (num_total_tokens * top_k,))
+        self.assertEqual(token_indices.shape, (num_total_tokens * top_k,))
 
         # Test behavior assertions
         if padded:
@@ -366,6 +369,35 @@ class ShufflingTests(unittest.TestCase):
             self.assertTrue(reverse_input_tokens.equal(tokens[:num_valid_tokens]))
         else:
             self.assertTrue(output_tokens[:num_valid_tokens].equal(ref_output_tokens))
+
+
+def _get_scores_without_ties(
+    num_total_tokens: int, num_experts: int, routing_score_dtype: torch.dtype
+) -> torch.Tensor:
+    """
+    Generate routing scores without ties in each row - ties are harmless in a real run, but difficult to test.
+    """
+    diffs = (
+        torch.randn(
+            num_total_tokens,
+            num_experts,
+            device=torch.accelerator.current_accelerator(),
+            dtype=routing_score_dtype,
+        ).abs()
+        + 0.1
+    )
+    rand_shifts = torch.randn(
+        num_total_tokens,
+        1,
+        device=torch.accelerator.current_accelerator(),
+        dtype=routing_score_dtype,
+    )
+    # Cumulative sums are all positive, so add random shifts to make some score values negative for testing.
+    routing_scores_sorted = diffs.cumsum(dim=1) - rand_shifts
+    random_indices = torch.argsort(
+        torch.rand(num_total_tokens, num_experts, device=diffs.device), dim=1
+    )
+    return routing_scores_sorted.gather(1, random_indices).contiguous()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1641

Add support for top-k=1, 2, 4. Should be possible to add larger top-K, but one needs to tune tiles sizes depending on the number of experts and top-K to fit intermediate buffers (`SharedStorage`) into the shared memory.

Differential Revision: D79059745


