### PR TITLE
FBGEMM TBE FP8 Embedding Weights (Part 1 Backend)

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
@@ -548,7 +548,7 @@ batch_index_select_dim0_codegen_backward_kernel_cta_per_row
 
 {%- macro bulk_template_instantiations(kFixedMaxVecsPerThread, kThreadGroupSize, kUseVecBlocking) %}
     {%- for grad_type in ['float', 'at::Half', 'at::BFloat16'] %}
-    {%- for emb_type in ['float', 'at::Half'] %}
+    {%- for emb_type in (['float', 'at::Half'] + (['at::Float8_e4m3fnuz'] if is_rocm else ['at::Float8_e4m3fn'])) %}
     {%- for cache_type in ['float', 'at::Half'] %}
     {%- for index_type in ['int32_t', 'int64_t'] %}
     {%- for ph_type_combo in args.placeholder_type_combos %}

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -451,7 +451,7 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row
 
 {%- macro bulk_template_instantiations(kFixedMaxVecsPerThread, kThreadGroupSize, kUseVecBlocking) %}
     {%- for grad_type in ['float', 'at::Half', 'at::BFloat16'] %}
-    {%- for emb_type in ['float', 'at::Half'] %}
+    {%- for emb_type in (['float', 'at::Half'] + (['at::Float8_e4m3fnuz'] if is_rocm else ['at::Float8_e4m3fn'])) %}
     {%- for cache_type in ['float', 'at::Half'] %}
     {%- for index_type in ['int32_t', 'int64_t'] %}
     {%- for ph_type_combo in args.placeholder_type_combos %}
@@ -781,7 +781,7 @@ hip_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vd
 
 {%- macro hip_bulk_template_instantiations(kFixedMaxVecsPerThread, kThreadGroupSize, kUseVecBlocking) %}
     {%- for grad_type in ['float', 'at::Half', 'at::BFloat16'] %}
-    {%- for emb_type in ['float', 'at::Half'] %}
+    {%- for emb_type in (['float', 'at::Half'] + (['at::Float8_e4m3fnuz'] if is_rocm else ['at::Float8_e4m3fn'])) %}
     {%- for cache_type in ['float', 'at::Half'] %}
     {%- for index_type in ['int32_t', 'int64_t'] %}
     {%- for kEmbeddingDim in [64, 128, 160, 192, 256] %}

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_nobag_small_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_nobag_small_template.cu
@@ -199,7 +199,7 @@ batch_index_select_dim0_codegen_forward_small_kernel(
 */
 
 {%- for output_type in ['float', 'at::Half', 'at::BFloat16'] %}
-{%- for emb_type in ['float', 'at::Half'] %}
+{%- for emb_type in (['float', 'at::Half'] + (['at::Float8_e4m3fnuz'] if is_rocm else ['at::Float8_e4m3fn'])) %}
 {%- for cache_type in ['float', 'at::Half'] %}
 {%- for kEmbeddingSize in [4, 8, 16, 32] %}
 {%- for index_type in ['int32_t', 'int64_t'] %}

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_template.cu
@@ -931,7 +931,7 @@ batch_index_select_dim0_codegen_forward_kernel
 
 {%- macro bulk_template_instantiations(use_cache, kMaxVecsPerThread, kThreadGroupSize) %}
     {%- set max_vecs_per_thread = 2 * kMaxVecsPerThread if is_rocm else kMaxVecsPerThread %}
-    {%- for emb_type in ['float', 'at::Half'] %}
+    {%- for emb_type in (['float', 'at::Half'] + (['at::Float8_e4m3fnuz'] if is_rocm else ['at::Float8_e4m3fn'])) %}
     {%- for cache_type in ['float', 'at::Half'] %}
     {%- for output_type in ['float', 'at::Half', 'at::BFloat16'] %}
     {%- for index_type in ['int32_t', 'int64_t'] %}

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_v2_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_v2_template.cu
@@ -92,6 +92,18 @@ struct Vec4Type<uint8_t> {
   using type = uint8_t;
 };
 
+{%- if is_rocm %}
+template <>
+struct Vec4Type<at::Float8_e4m3fnuz> {
+  using type = c10::Float8_e4m3fnuz;
+};
+{%- else %}
+template <>
+struct Vec4Type<at::Float8_e4m3fn> {
+  using type = c10::Float8_e4m3fn;
+};
+{%- endif %}
+
 template <typename T>
 using vec4_type = typename Vec4Type<T>::type;
 
@@ -987,7 +999,7 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel(
 
 {%- for output_type in ['float', 'at::Half', 'at::BFloat16'] %}
 {%- for index_type in ['int32_t', 'int64_t'] %}
-{%- for emb_type in ['float', 'at::Half'] %}
+{%- for emb_type in (['float', 'at::Half'] + (['at::Float8_e4m3fnuz'] if is_rocm else ['at::Float8_e4m3fn'])) %}
 {%- for cache_type in ['float', 'at::Half'] %}
 {%- for use_cache in ['true', 'false'] %}
 

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_kernel_template.cu
@@ -105,7 +105,7 @@ void split_{{ optimizer }}_update_kernel(
 
 {{ "#ifdef FBGEMM_USE_SUBWARP_SHUFFLE" if use_subwarp else "#else" }}
 
-{%- for emb_type in ['uint8_t', 'float', 'at::Half'] %}
+{%- for emb_type in (['uint8_t', 'float', 'at::Half'] + (['at::Float8_e4m3fnuz'] if is_rocm else ['at::Float8_e4m3fn'])) %}
 {%- for cache_type in ['float', 'at::Half'] %}
 {%- for ph_type_combo in args.placeholder_type_combos %}
 

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/dispatch_macros.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/dispatch_macros.h
@@ -31,6 +31,7 @@
             "'");                                                          \
     }                                                                      \
   }
+#if defined(USE_ROCM)
 
 #define _DISPATCH_EMB_CACHE_TYPES(emb_enum_type, cache_enum_type, NAME, ...)  \
   at::ScalarType _emb_t = emb_enum_type;                                      \
@@ -40,9 +41,37 @@
         at::ScalarType::Float, _cache_t, float, NAME, __VA_ARGS__)            \
     PRIVATE_CASE_TYPE_EMB(                                                    \
         at::ScalarType::Half, _cache_t, at::Half, NAME, __VA_ARGS__)          \
+    PRIVATE_CASE_TYPE_EMB(                                                    \
+        at::ScalarType::Float8_e4m3fnuz,                                      \
+        _cache_t,                                                             \
+        at::Float8_e4m3fnuz,                                                  \
+        NAME,                                                                 \
+        __VA_ARGS__)                                                          \
     default:                                                                  \
       AT_ERROR(#NAME, " not implemented for emb_t '", toString(_emb_t), "'"); \
   }
+
+#else
+
+#define _DISPATCH_EMB_CACHE_TYPES(emb_enum_type, cache_enum_type, NAME, ...)  \
+  at::ScalarType _emb_t = emb_enum_type;                                      \
+  at::ScalarType _cache_t = cache_enum_type;                                  \
+  switch (_emb_t) {                                                           \
+    PRIVATE_CASE_TYPE_EMB(                                                    \
+        at::ScalarType::Float, _cache_t, float, NAME, __VA_ARGS__)            \
+    PRIVATE_CASE_TYPE_EMB(                                                    \
+        at::ScalarType::Half, _cache_t, at::Half, NAME, __VA_ARGS__)          \
+    PRIVATE_CASE_TYPE_EMB(                                                    \
+        at::ScalarType::Float8_e4m3fn,                                        \
+        _cache_t,                                                             \
+        at::Float8_e4m3fn,                                                    \
+        NAME,                                                                 \
+        __VA_ARGS__)                                                          \
+    default:                                                                  \
+      AT_ERROR(#NAME, " not implemented for emb_t '", toString(_emb_t), "'"); \
+  }
+
+#endif
 
 #define DISPATCH_EMB_CACHE_TYPES(EMB_TYPE, CACHE_TYPE, NAME, ...)      \
   [&] {                                                                \
@@ -151,6 +180,8 @@
 
 #endif
 
+#if defined(USE_ROCM)
+
 #define PRIVATE_CASE_TYPE_CACHE_EMB(                                       \
     grad_enum_type, _cache_t, _emb_t, grad_cxx_type, NAME, ...)            \
   case grad_enum_type: {                                                   \
@@ -160,11 +191,42 @@
           at::ScalarType::Float, _cache_t, float, NAME, __VA_ARGS__)       \
       PRIVATE_CASE_TYPE_EMB(                                               \
           at::ScalarType::Half, _cache_t, at::Half, NAME, __VA_ARGS__)     \
+      PRIVATE_CASE_TYPE_EMB(                                               \
+          at::ScalarType::Float8_e4m3fnuz,                                 \
+          _cache_t,                                                        \
+          at::Float8_e4m3fnuz,                                             \
+          Name,                                                            \
+          __VA_ARGS__)                                                     \
       default:                                                             \
         AT_ERROR(                                                          \
             #NAME, " not implemented for emb_t '", toString(_emb_t), "'"); \
     }                                                                      \
   }
+
+#else
+
+#define PRIVATE_CASE_TYPE_CACHE_EMB(                                       \
+    grad_enum_type, _cache_t, _emb_t, grad_cxx_type, NAME, ...)            \
+  case grad_enum_type: {                                                   \
+    using grad_t = grad_cxx_type;                                          \
+    switch (_emb_t) {                                                      \
+      PRIVATE_CASE_TYPE_EMB(                                               \
+          at::ScalarType::Float, _cache_t, float, NAME, __VA_ARGS__)       \
+      PRIVATE_CASE_TYPE_EMB(                                               \
+          at::ScalarType::Half, _cache_t, at::Half, NAME, __VA_ARGS__)     \
+      PRIVATE_CASE_TYPE_EMB(                                               \
+          at::ScalarType::Float8_e4m3fn,                                   \
+          _cache_t,                                                        \
+          at::Float8_e4m3fn,                                               \
+          Name,                                                            \
+          __VA_ARGS__)                                                     \
+      default:                                                             \
+        AT_ERROR(                                                          \
+            #NAME, " not implemented for emb_t '", toString(_emb_t), "'"); \
+    }                                                                      \
+  }
+
+#endif
 
 #define DISPATCH_EMB_GRAD_CACHE_TYPES(                                         \
     EMB_TYPE, GRAD_TYPE, CACHE_TYPE, NAME, ...)                                \
@@ -208,6 +270,22 @@
   AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)  \
   AT_DISPATCH_CASE(at::ScalarType::BFloat16, __VA_ARGS__)
 
+#if defined(USE_ROCM)
+
+#define FBGEMM_DISPATCH_FLOAT_HALF_AND_FP8_CASE(...)   \
+  AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__) \
+  AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)  \
+  AT_DISPATCH_CASE(at::ScalarType::Float8_e4m3fnuz, __VA_ARGS__)
+
+#else
+
+#define FBGEMM_DISPATCH_FLOAT_HALF_AND_FP8_CASE(...)   \
+  AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__) \
+  AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)  \
+  AT_DISPATCH_CASE(at::ScalarType::Float8_e4m3fn, __VA_ARGS__)
+
+#endif
+
 #define FBGEMM_DISPATCH_FLOAT_AND_HALF_CASE(...)       \
   AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__) \
   AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)
@@ -241,6 +319,13 @@
       TYPE,                                                  \
       NAME,                                                  \
       FBGEMM_DISPATCH_FLOAT_AND_HALF_CASE(__VA_ARGS__)       \
+          AT_DISPATCH_CASE(at::ScalarType::Byte, __VA_ARGS__))
+
+#define FBGEMM_DISPATCH_FLOAT_HALF_FP8_AND_BYTE(TYPE, NAME, ...) \
+  AT_DISPATCH_SWITCH(                                            \
+      TYPE,                                                      \
+      NAME,                                                      \
+      FBGEMM_DISPATCH_FLOAT_HALF_AND_FP8_CASE(__VA_ARGS__)       \
           AT_DISPATCH_CASE(at::ScalarType::Byte, __VA_ARGS__))
 
 #define FBGEMM_DISPATCH_FLOATING_TYPES(TYPE, NAME, ...) \

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/float.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/float.cuh
@@ -20,6 +20,24 @@
 #include <cuda_fp16.h>
 #include "fbgemm_gpu/utils/cuda_prelude.cuh"
 
+#if CUDART_VERSION >= 12000
+#include <cuda_fp8.h>
+#elif (defined(USE_ROCM) && ROCM_VERSION >= 60200)
+#include <hip/hip_fp8.h>
+#endif
+
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200)
+#if HIP_FP8_TYPE_OCP
+using __nv_fp8_e4m3 = __hip_fp8_e4m3;
+using __nv_fp8x2_e4m3 = __hip_fp8x2_e4m3;
+using __nv_fp8x4_e4m3 = __hip_fp8x4_e4m3;
+#else // HIP_FP8_TYPE_OCP
+using __nv_fp8_e4m3 = __hip_fp8_e4m3_fnuz;
+using __nv_fp8x2_e4m3 = __hip_fp8x2_e4m3_fnuz;
+using __nv_fp8x4_e4m3 = __hip_fp8x4_e4m3_fnuz;
+#endif // HIP_FP8_TYPE_OCP
+#endif // (defined(USE_ROCM) && ROCM_VERSION >= 60200)
+
 namespace fbgemm_gpu {
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/rocm/stochastic_rounding.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/rocm/stochastic_rounding.h
@@ -129,4 +129,50 @@ DEVICE_INLINE void nearest_rounding_vector(
   output[1] = lrintf((value.acc.y - qparams.y) * inv_scale);
 }
 
+template <>
+DEVICE_INLINE void nearest_rounding_vector(
+    at::Float8_e4m3fnuz* output,
+    const Vec2T<at::Half>& value,
+    const float2 /* Not used yet */) {
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+  __nv_fp8x2_e4m3* fp8_ptr = reinterpret_cast<__nv_fp8x2_e4m3*>(output);
+  fp8_ptr[0] = static_cast<__nv_fp8x2_e4m3>(value.acc);
+#else
+  CUDA_KERNEL_ASSERT(false);
+#endif
+}
+
+template <>
+DEVICE_INLINE void stochastic_rounding_vector(
+    at::Float8_e4m3fnuz* output,
+    const Vec2T<float>& value,
+    StochasticRoundingRNGState& state,
+    const float2 qparams) {
+// TODO, make this actually stochastic later.
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+  __nv_fp8x2_e4m3* fp8_ptr = reinterpret_cast<__nv_fp8x2_e4m3*>(output);
+  fp8_ptr[0] = static_cast<__nv_fp8x2_e4m3>(value.acc);
+#else
+  CUDA_KERNEL_ASSERT(false);
+#endif
+}
+
+template <>
+DEVICE_INLINE void stochastic_rounding_vector(
+    at::Float8_e4m3fnuz* output,
+    const Vec2T<at::Half>& value,
+    StochasticRoundingRNGState& state,
+    const float2 qparams) {
+// TODO, make this stochastic later.
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+  __nv_fp8x2_e4m3* fp8_ptr = reinterpret_cast<__nv_fp8x2_e4m3*>(output);
+  fp8_ptr[0] = static_cast<__nv_fp8x2_e4m3>(value.acc);
+#else
+  CUDA_KERNEL_ASSERT(false);
+#endif
+}
+
 } // namespace fbgemm_gpu::rocm

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/rocm/vec2.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/rocm/vec2.h
@@ -112,6 +112,17 @@ struct Vec2T<float> : public Vec2BaseT<float> {
     acc.y = p[1];
   }
 
+  DEVICE_INLINE void load(const at::Float8_e4m3fnuz* p) {
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+    const __nv_fp8x2_e4m3* fp8_ptr =
+        reinterpret_cast<const __nv_fp8x2_e4m3*>(p);
+    acc = static_cast<float2>(fp8_ptr[0]);
+#else
+    CUDA_KERNEL_ASSERT(false);
+#endif
+  }
+
   DEVICE_INLINE void load(const uint8_t* p) {
     CUDA_KERNEL_ASSERT(false);
   }
@@ -137,6 +148,16 @@ struct Vec2T<float> : public Vec2BaseT<float> {
   DEVICE_INLINE void store(at::BFloat16* p) const {
     p[0] = acc.x;
     p[1] = acc.y;
+  }
+
+  DEVICE_INLINE void store(at::Float8_e4m3fnuz* p) const {
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+    __nv_fp8x2_e4m3* fp8_ptr = reinterpret_cast<__nv_fp8x2_e4m3*>(p);
+    fp8_ptr[0] = static_cast<__nv_fp8x2_e4m3>(acc);
+#else
+    CUDA_KERNEL_ASSERT(false);
+#endif
   }
 
   DEVICE_INLINE void store(uint8_t* p) const {

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/rocm/weight_row.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/rocm/weight_row.h
@@ -73,6 +73,38 @@ DEVICE_INLINE Vec2T<at::Half> dequantize_load(
   return out;
 }
 
+template <>
+DEVICE_INLINE Vec2T<float> dequantize_load(
+    const at::Float8_e4m3fnuz* value,
+    const float2 /* currently unused */) {
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+  Vec2T<float> out;
+  const __nv_fp8x2_e4m3* fp8_ptr =
+      reinterpret_cast<const __nv_fp8x2_e4m3*>(value);
+  out.acc = static_cast<float2>(fp8_ptr[0]);
+  return out;
+#else
+  CUDA_KERNEL_ASSERT(false);
+#endif
+}
+
+template <>
+DEVICE_INLINE Vec2T<at::Half> dequantize_load(
+    const at::Float8_e4m3fnuz* value,
+    const float2 /* currently unused */) {
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+  Vec2T<at::Half> out;
+  const __nv_fp8x2_e4m3* fp8_ptr =
+      reinterpret_cast<const __nv_fp8x2_e4m3*>(value);
+  out.acc = static_cast<float2>(fp8_ptr[0]);
+  return out;
+#else
+  CUDA_KERNEL_ASSERT(false);
+#endif
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Weight Row Accessor for Vec2T
 ////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/stochastic_rounding.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/stochastic_rounding.cuh
@@ -230,4 +230,124 @@ DEVICE_INLINE void nearest_rounding_vector(
   output[3] = lrintf((value.acc.w - qparams.y) * inv_scale);
 }
 
+template <>
+DEVICE_INLINE void nearest_rounding_vector(
+    at::Float8_e4m3fn* output,
+    const Vec4T<float>& value,
+    const float2 /* Not used yet */) {
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+  __nv_fp8x4_e4m3* fp8_ptr = reinterpret_cast<__nv_fp8x4_e4m3*>(output);
+  fp8_ptr[0] = static_cast<__nv_fp8x4_e4m3>(value.acc);
+#else
+  CUDA_KERNEL_ASSERT(false);
+#endif
+}
+
+template <>
+DEVICE_INLINE void nearest_rounding_vector(
+    at::Float8_e4m3fnuz* output,
+    const Vec4T<float>& value,
+    const float2 /* Not used yet */) {
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+  __nv_fp8x4_e4m3* fp8_ptr = reinterpret_cast<__nv_fp8x4_e4m3*>(output);
+  fp8_ptr[0] = static_cast<__nv_fp8x4_e4m3>(value.acc);
+#else
+  CUDA_KERNEL_ASSERT(false);
+#endif
+}
+
+template <>
+DEVICE_INLINE void nearest_rounding_vector(
+    at::Float8_e4m3fn* output,
+    const Vec4T<at::Half>& value,
+    const float2 /* Not used yet */) {
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+  __nv_fp8x4_e4m3* fp8_ptr = reinterpret_cast<__nv_fp8x4_e4m3*>(output);
+  fp8_ptr[0] = static_cast<__nv_fp8x4_e4m3>(value.acc);
+#else
+  CUDA_KERNEL_ASSERT(false);
+#endif
+}
+
+template <>
+DEVICE_INLINE void nearest_rounding_vector(
+    at::Float8_e4m3fnuz* output,
+    const Vec4T<at::Half>& value,
+    const float2 /* Not used yet */) {
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+  __nv_fp8x4_e4m3* fp8_ptr = reinterpret_cast<__nv_fp8x4_e4m3*>(output);
+  fp8_ptr[0] = static_cast<__nv_fp8x4_e4m3>(value.acc);
+#else
+  CUDA_KERNEL_ASSERT(false);
+#endif
+}
+
+template <>
+DEVICE_INLINE void stochastic_rounding_vector(
+    at::Float8_e4m3fn* output,
+    const Vec4T<float>& value,
+    StochasticRoundingRNGState& state,
+    const float2 qparams) {
+// TODO, make this actually stochastic later.
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+  __nv_fp8x4_e4m3* fp8_ptr = reinterpret_cast<__nv_fp8x4_e4m3*>(output);
+  fp8_ptr[0] = static_cast<__nv_fp8x4_e4m3>(value.acc);
+#else
+  CUDA_KERNEL_ASSERT(false);
+#endif
+}
+
+template <>
+DEVICE_INLINE void stochastic_rounding_vector(
+    at::Float8_e4m3fnuz* output,
+    const Vec4T<float>& value,
+    StochasticRoundingRNGState& state,
+    const float2 qparams) {
+// TODO, make this actually stochastic later.
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+  __nv_fp8x4_e4m3* fp8_ptr = reinterpret_cast<__nv_fp8x4_e4m3*>(output);
+  fp8_ptr[0] = static_cast<__nv_fp8x4_e4m3>(value.acc);
+#else
+  CUDA_KERNEL_ASSERT(false);
+#endif
+}
+
+template <>
+DEVICE_INLINE void stochastic_rounding_vector(
+    at::Float8_e4m3fn* output,
+    const Vec4T<at::Half>& value,
+    StochasticRoundingRNGState& state,
+    const float2 qparams) {
+// TODO, make this stochastic later.
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+  __nv_fp8x4_e4m3* fp8_ptr = reinterpret_cast<__nv_fp8x4_e4m3*>(output);
+  fp8_ptr[0] = static_cast<__nv_fp8x4_e4m3>(value.acc);
+#else
+  CUDA_KERNEL_ASSERT(false);
+#endif
+}
+
+template <>
+DEVICE_INLINE void stochastic_rounding_vector(
+    at::Float8_e4m3fnuz* output,
+    const Vec4T<at::Half>& value,
+    StochasticRoundingRNGState& state,
+    const float2 qparams) {
+// TODO, make this stochastic later.
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+  __nv_fp8x4_e4m3* fp8_ptr = reinterpret_cast<__nv_fp8x4_e4m3*>(output);
+  fp8_ptr[0] = static_cast<__nv_fp8x4_e4m3>(value.acc);
+#else
+  CUDA_KERNEL_ASSERT(false);
+#endif
+}
+
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/vec4.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/vec4.cuh
@@ -124,6 +124,28 @@ struct Vec4T<float> : public Vec4BaseT<float> {
     acc.w = p[3];
   }
 
+  DEVICE_INLINE void load(const at::Float8_e4m3fnuz* p) {
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+    const __nv_fp8x4_e4m3* fp8_ptr =
+        reinterpret_cast<const __nv_fp8x4_e4m3*>(p);
+    acc = static_cast<float4>(fp8_ptr[0]);
+#else
+    CUDA_KERNEL_ASSERT(false);
+#endif
+  }
+
+  DEVICE_INLINE void load(const at::Float8_e4m3fn* p) {
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+    const __nv_fp8x4_e4m3* fp8_ptr =
+        reinterpret_cast<const __nv_fp8x4_e4m3*>(p);
+    acc = static_cast<float4>(fp8_ptr[0]);
+#else
+    CUDA_KERNEL_ASSERT(false);
+#endif
+  }
+
   DEVICE_INLINE void load(const uint8_t* p) {
     CUDA_KERNEL_ASSERT(false);
   }
@@ -156,6 +178,26 @@ struct Vec4T<float> : public Vec4BaseT<float> {
     p[1] = acc.y;
     p[2] = acc.z;
     p[3] = acc.w;
+  }
+
+  DEVICE_INLINE void store(at::Float8_e4m3fn* p) const {
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+    __nv_fp8x4_e4m3* fp8_ptr = reinterpret_cast<__nv_fp8x4_e4m3*>(p);
+    fp8_ptr[0] = static_cast<__nv_fp8x4_e4m3>(acc);
+#else
+    CUDA_KERNEL_ASSERT(false);
+#endif
+  }
+
+  DEVICE_INLINE void store(at::Float8_e4m3fnuz* p) const {
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+    __nv_fp8x4_e4m3* fp8_ptr = reinterpret_cast<__nv_fp8x4_e4m3*>(p);
+    fp8_ptr[0] = static_cast<__nv_fp8x4_e4m3>(acc);
+#else
+    CUDA_KERNEL_ASSERT(false);
+#endif
   }
 
   DEVICE_INLINE void store(uint8_t* p) const {

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/vec4acc.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/vec4acc.cuh
@@ -114,6 +114,22 @@ struct Vec4AccT {
     CUDA_KERNEL_ASSERT(false);
   }
 
+  DEVICE_INLINE void add(const c10::Float8_e4m3fn* ptr) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void fma(const c10::Float8_e4m3fn* ptr, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void add(const c10::Float8_e4m3fnuz* ptr) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void fma(const c10::Float8_e4m3fnuz* ptr, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
   DEVICE_INLINE void div(uint32_t denom) {
     acc[0] /= denom;
     acc[1] /= denom;
@@ -365,6 +381,134 @@ struct Vec4StepT<STEP, uint8_t> : Vec4AccT {
 
   DEVICE_INLINE void
   index_weighted_store(uint32_t idx, uint8_t* ptr, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+};
+
+template <uint32_t STEP>
+struct Vec4StepT<STEP, c10::Float8_e4m3fn> : Vec4AccT {
+  DEVICE_INLINE Vec4StepT() {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void load(const c10::Float8_e4m3fn* ptr, const uint32_t idx) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void sum() {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void weighted_sum(
+      const float* const weights,
+      const uint32_t idx_shift,
+      const uint32_t idx_scale) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void index_add(uint32_t idx) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void index_fma(uint32_t idx, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void index_store(uint32_t idx, float4* ptr) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void index_store(uint32_t idx, float2* ptr) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void index_store(uint32_t idx, c10::Float8_e4m3fn* ptr) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, float4* ptr, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, float2* ptr, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, uint8_t* ptr, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void index_weighted_store(
+      uint32_t idx,
+      c10::Float8_e4m3fn* ptr,
+      const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+};
+
+template <uint32_t STEP>
+struct Vec4StepT<STEP, c10::Float8_e4m3fnuz> : Vec4AccT {
+  DEVICE_INLINE Vec4StepT() {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void load(const c10::Float8_e4m3fnuz* ptr, const uint32_t idx) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void sum() {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void weighted_sum(
+      const float* const weights,
+      const uint32_t idx_shift,
+      const uint32_t idx_scale) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void index_add(uint32_t idx) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void index_fma(uint32_t idx, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void index_store(uint32_t idx, float4* ptr) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void index_store(uint32_t idx, float2* ptr) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void index_store(uint32_t idx, c10::Float8_e4m3fnuz* ptr) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, float4* ptr, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, float2* ptr, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, uint8_t* ptr, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void index_weighted_store(
+      uint32_t idx,
+      c10::Float8_e4m3fnuz* ptr,
+      const float weight) {
     CUDA_KERNEL_ASSERT(false);
   }
 };

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/weight_row.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/weight_row.cuh
@@ -65,6 +65,94 @@ DEVICE_INLINE Vec4T<dst_t> dequantize_load(
   }
 }
 
+template <>
+DEVICE_INLINE Vec4T<float> dequantize_load(
+    const at::Float8_e4m3fn* value,
+    const float2 /* currently unused */) {
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+  Vec4T<float> out;
+  const __nv_fp8x4_e4m3* fp8_ptr =
+      reinterpret_cast<const __nv_fp8x4_e4m3*>(value);
+  out.acc = static_cast<float4>(fp8_ptr[0]);
+  return out;
+#else
+  CUDA_KERNEL_ASSERT(false);
+#endif
+}
+
+template <>
+DEVICE_INLINE Vec4T<float> dequantize_load(
+    const at::Float8_e4m3fnuz* value,
+    const float2 /* currently unused */) {
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+  Vec4T<float> out;
+  const __nv_fp8x4_e4m3* fp8_ptr =
+      reinterpret_cast<const __nv_fp8x4_e4m3*>(value);
+  out.acc = static_cast<float4>(fp8_ptr[0]);
+  return out;
+#else
+  CUDA_KERNEL_ASSERT(false);
+#endif
+}
+
+template <>
+DEVICE_INLINE Vec4T<at::Half> dequantize_load(
+    const at::Float8_e4m3fn* value,
+    const float2 /* currently unused */) {
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+  Vec4T<at::Half> out;
+  const __nv_fp8x4_e4m3* fp8_ptr =
+      reinterpret_cast<const __nv_fp8x4_e4m3*>(value);
+  out.acc = static_cast<float4>(fp8_ptr[0]);
+  return out;
+#else
+  CUDA_KERNEL_ASSERT(false);
+#endif
+}
+
+template <>
+DEVICE_INLINE Vec4T<at::Half> dequantize_load(
+    const at::Float8_e4m3fnuz* value,
+    const float2 /* currently unused */) {
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
+    (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
+  Vec4T<at::Half> out;
+  const __nv_fp8x4_e4m3* fp8_ptr =
+      reinterpret_cast<const __nv_fp8x4_e4m3*>(value);
+  out.acc = static_cast<float4>(fp8_ptr[0]);
+  return out;
+#else
+  CUDA_KERNEL_ASSERT(false);
+#endif
+}
+
+template <>
+DEVICE_INLINE Vec4T<float> dequantize_load(
+    const uint8_t* value,
+    const float2 qparams) {
+  Vec4T<float> out;
+  out.acc.x = value[0] * qparams.x + qparams.y;
+  out.acc.y = value[1] * qparams.x + qparams.y;
+  out.acc.z = value[2] * qparams.x + qparams.y;
+  out.acc.w = value[3] * qparams.x + qparams.y;
+  return out;
+}
+
+template <>
+DEVICE_INLINE Vec4T<at::Half> dequantize_load(
+    const uint8_t* value,
+    const float2 qparams) {
+  Vec4T<at::Half> out;
+  out.acc.x = value[0] * qparams.x + qparams.y;
+  out.acc.y = value[1] * qparams.x + qparams.y;
+  out.acc.z = value[2] * qparams.x + qparams.y;
+  out.acc.w = value[3] * qparams.x + qparams.y;
+  return out;
+}
+
 template <typename emb_t>
 DEVICE_INLINE float2 load_qparams_from_row(emb_t* qparam_ptr) {
   float2 qparams;


### PR DESCRIPTION
Summary:
This diff enables embeddings to be stored as FP8 during training. To prevent interaction with the inference version of FP8, I instead added a new FP8 datatype `NFP8` that is aligned with the officially supported E4M3 format in pytorch.

Current Limitations:
* I have not yet added rowwise scaling, I think this should be easy to add but thought it might be worth experimenting without it since it allows us to do much more efficient vectorized reads and writes to the table.
* I hardcoded in E4M3 but there is also an E5M2 format that would be easy to support. I was thinking instead of `NFP8` we could have two custom datatypes like `FP8_E4M3` and `FP8_E5M2` so that the proper one could be chosen for specific use cases. For gradient accumulation, I would expect E5M2 to be a bit better for example.
* I havent yet added AMD compatibility but it should be doable without too much work.

Hopefully despite these limitations, this is a useful starting point for experimentation. Certainly the performance looks initially compelling.

Performance measurements suggest that FP8 weights are quite fast compared to FP32, which is a good sign that this may be a useful optimization.

FP32:
```
INFO:root:Embedding tables: 3200000 rows,  0.41 GParam,  1.64 GB
INFO:root:Accessed weights per batch: 327680 rows,  0.17 GB
INFO:root:ForwardBackward (UVM), B: 512, E: 100000, T: 32, D: 128, L: 20, BW:  54.06 GB/s, T: 9310us
INFO:root:Exchanged cache lines -- mean:  225378.69, max: 225973, min: 224687
INFO:root:Cache miss -- mean: 2.99, max: 12, min: 0
INFO:root:ForwardBackward (LXU), reuse: 0.1, alpha: 1.0, B: 512, E: 100000, T: 32, D: 128, L: 20, BW:  66.53 GB/s, Tprefetch: 7050us,  32.73 GB/s, Tfwdbwd: 515us,  977.75 GB/s, Te2e: 7565us,
```

FP8:
```
INFO:root:Embedding tables: 3200000 rows,  0.41 GParam,  0.41 GB
INFO:root:Accessed weights per batch: 327680 rows,  0.04 GB
INFO:root:ForwardBackward (UVM), B: 512, E: 100000, T: 32, D: 128, L: 20, BW:  50.38 GB/s, T: 2498us
INFO:root:Exchanged cache lines -- mean:  225378.69, max: 225973, min: 224687
INFO:root:Cache miss -- mean: 2.99, max: 12, min: 0
INFO:root:ForwardBackward (LXU), reuse: 0.1, alpha: 1.0, B: 512, E: 100000, T: 32, D: 128, L: 20, BW:  47.43 GB/s, Tprefetch: 2139us,  26.98 GB/s, Tfwdbwd: 514us,  244.77 GB/s, Te2e: 2653us,
```

Differential Revision: D63492414


