### PR TITLE
Redo D78182966: Extend backend_return_whole_row to support multiple optimizer states

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
@@ -96,6 +96,18 @@ class EmbOptimType(enum.Enum):
         else:
             return {}
 
+    def state_size_bytes_table(
+        self, D: int, optimizer_state_dtypes: Dict[str, "SparseType"]
+    ) -> Dict[str, int]:
+        """
+        Returns the table of state names to state sizes in terms of number of
+        elements (per table row)
+        """
+        return dict(
+            (name, count * self._extract_dtype(optimizer_state_dtypes, name).itemsize)
+            for name, count in self.state_size_table(D).items()
+        )
+
     def state_size_nbytes(
         self, D: int, optimizer_state_dtypes: Dict[str, "SparseType"] = {}  # noqa: B006
     ) -> int:


### PR DESCRIPTION
Summary:
This diff is a redo of D78182966.  

There are 4 cases to handle when attempting to fetch the split optimizer states.  All 4 cases have been already handled.

With D77666892, we introduce a 5th case - the KV ZCH case, where  `backend_return_whole_row` is `True`.

This diff extends the work by cleaning up the code, handling the merge conflicts with diff D77666892, and expanding it to support returning multiple optimizer states.

Reviewed By: sryap

Differential Revision: D78879243


