### PR TITLE
Make length check on mask numel in masked_select_jagged_1d optional

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -677,7 +677,8 @@ std::tuple<at::Tensor, at::Tensor> jagged_dense_bmm(
 std::tuple<at::Tensor, at::Tensor> masked_select_jagged_1d(
     const at::Tensor& values,
     const at::Tensor& lengths,
-    const at::Tensor& mask);
+    const at::Tensor& mask,
+    const std::optional<bool> check_length);
 
 #endif
 

--- a/fbgemm_gpu/test/jagged/misc_ops_test.py
+++ b/fbgemm_gpu/test/jagged/misc_ops_test.py
@@ -167,12 +167,13 @@ class JaggedTensorOpsTest(unittest.TestCase):
 
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Expected mask\.numel\(\) == values\.numel\(\) to be true, but got false\..*",
+            r"mask and values should have the same numel, but got mask numel: .+ values numel: .+",
         ):
             torch.ops.fbgemm.masked_select_jagged_1d(
                 values,
                 lengths,
                 mask,
+                True,
             )
 
     @given(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1655

Previously we added the length check in D79094024. Although it's a legit check to have, it seems like there are existing models depend the old "wrong" behavior to be more lenient on the input values and mask with different lengths, and this new check has caused some existing training jobs to fail. 

So in this diff, we will make the check optional and have the users to decide when they want to turn this on.

Reviewed By: cthi

Differential Revision: D79377460


