### PR TITLE
Adding Create rocksDB checkpoint call-site to checkpointing flow

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -2759,6 +2759,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                     f"flush latency for weight states: {(time.time() - start_time) * 1000} ms"
                 )
                 snapshot_handle = self.ssd_db.create_snapshot()
+                self.ssd_db.create_rocksdb_hard_link_snapshot(self.step)
                 checkpoint_handle = self.ssd_db.get_active_checkpoint_uuid(self.step)
                 logging.info(
                     f"created snapshot for weight states: {snapshot_handle}, latency: {(time.time() - start_time) * 1000} ms"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1658

The current flow of checkpointing doesn't call the create rocksDB checkpoint function, due to this the returned checkpoint handle is a null_ptr and is not added to the KV Tensor.

In this diff, added a call to create the rocksdb checkpoint to complete the usage

Differential Revision: D79393821
