### PR TITLE
Remove assertion check inside  scatter_add when in_tokens and out_tokens have different shape

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/gen_ai/moe/gather_scatter.py
+++ b/fbgemm_gpu/experimental/gen_ai/gen_ai/moe/gather_scatter.py
@@ -198,6 +198,8 @@ def scatter_add_dense_tokens(
     assert out_tokens.is_contiguous()
 
     a, D = in_tokens.shape
+    if a == 0:
+        return
     assert token_indices.shape == (a,)
     assert out_tokens.ndim == 2 and out_tokens.shape[1] == D
 
@@ -205,11 +207,14 @@ def scatter_add_dense_tokens(
     if a >= NUM_SMS:
         BLOCK_D_OUTER = D
         BLOCK_D_INNER = 1024
-        assert D % BLOCK_D_INNER == 0
     else:
         BLOCK_D_OUTER = 512
         BLOCK_D_INNER = 256
-        assert D % BLOCK_D_OUTER == 0
+    while D % BLOCK_D_OUTER != 0:
+        BLOCK_D_OUTER //= 2
+    while D % BLOCK_D_INNER != 0:
+        BLOCK_D_INNER //= 2
+
     grid = (a, D // BLOCK_D_OUTER)
     _fbgemm_scatter_add_dense_tokens[grid](
         out_tokens,
@@ -223,18 +228,18 @@ def scatter_add_dense_tokens(
 
 
 def scatter_add_padded_tokens(
-    in_tokens: torch.Tensor,  # [EP, T, D]
+    in_tokens: torch.Tensor,  # [EP, T_K, D]
     token_counts: torch.Tensor,  # [E]
-    token_indices: torch.Tensor,  # [T]
+    token_indices: torch.Tensor,  # [T_K]
     out_tokens: torch.Tensor,  # [T, D]
 ) -> None:
     """
     Scatter add valid tokens based on token counts metadata.
 
     Args:
-        in_tokens (torch.Tensor): input tensor of shape (EP, T, D)
+        in_tokens (torch.Tensor): input tensor of shape (EP, T_K, D)
         token_counts (torch.Tensor): token counts of shape (E,)
-        token_indices (torch.Tensor): token indices of shape (T,)
+        token_indices (torch.Tensor): token indices of shape (T_K,)
         out_tokens (torch.Tensor): output tensor of shape (T, D)
 
     Returns:
@@ -249,10 +254,10 @@ def scatter_add_padded_tokens(
     assert token_indices.is_contiguous()
     assert out_tokens.is_contiguous()
 
-    EP, T, D = in_tokens.shape
+    EP, T_K, D = in_tokens.shape
     E = token_counts.shape[0]
-    assert tuple(token_indices.shape) == (T,)
-    assert tuple(out_tokens.shape) == (T, D)
+    assert tuple(token_indices.shape) == (T_K,)
+    assert T_K % out_tokens.shape[0] == 0 and out_tokens.shape[1] == D
 
     def grid(META):
         return (
@@ -261,7 +266,7 @@ def scatter_add_padded_tokens(
         )
 
     T_BUCKET_CAP = 16384
-    T_BUCKET = min(triton.next_power_of_2(T), T_BUCKET_CAP)
+    T_BUCKET = min(triton.next_power_of_2(T_K), T_BUCKET_CAP)
     BLOCK_E = max(triton.next_power_of_2(E), 8)
     _fbgemm_scatter_add_padded_tokens[grid](
         in_tokens,
@@ -271,7 +276,7 @@ def scatter_add_padded_tokens(
         EP,
         E,
         T_BUCKET,
-        T,
+        T_K,
         D,
         BLOCK_E,
     )
@@ -679,14 +684,14 @@ def _fbgemm_scatter_add_padded_tokens(
     EP: tl.constexpr,
     E: tl.constexpr,
     T_BUCKET,
-    T,
+    T_K,
     D: tl.constexpr,
     BLOCK_E: tl.constexpr,
     SPLIT_T: tl.constexpr,
     BLOCK_D: tl.constexpr,
 ):
     """
-    in_tokens: [EP, T, D]
+    in_tokens: [EP, T_K, D]
     token_counts: [E]
     out_tokens: [T, D]
     """
@@ -721,7 +726,9 @@ def _fbgemm_scatter_add_padded_tokens(
         output_global_offset = output_local_offset * D
 
         d_ptr = tl.arange(0, BLOCK_D)
-        input_global_ptr = in_tokens_ptr + rank * T * D + input_local_offset * D + d_ptr
+        input_global_ptr = (
+            in_tokens_ptr + rank * T_K * D + input_local_offset * D + d_ptr
+        )
         output_global_ptr = out_tokens_ptr + output_global_offset + d_ptr
 
         for _d in range(NUM_D_BLOCKS):

--- a/fbgemm_gpu/experimental/gen_ai/test/moe/gather_scatter_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/moe/gather_scatter_test.py
@@ -8,6 +8,7 @@
 # pyre-ignore-all-errors[16,21,53,56]
 
 import logging
+import random
 import unittest
 from typing import Optional, Tuple
 
@@ -217,10 +218,11 @@ class GatherScatterTests(unittest.TestCase):
         )
 
     @given(
-        num_tokens=st.sampled_from([1, 128, 2048, 4096, 16384]),
-        dim=st.sampled_from([5120]),
+        num_tokens=st.sampled_from([0, 1, 128, 2048, 4096, 16384]),
+        dim=st.sampled_from([1280, 5120]),
         partial=st.sampled_from([True, False]),
         compiled=st.sampled_from([True, False]),
+        k=st.sampled_from([1, 4]),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=_MAX_SAMPLES, deadline=None)
     def test_scatter_add_dense_tokens(
@@ -229,31 +231,40 @@ class GatherScatterTests(unittest.TestCase):
         dim: int,
         partial: bool,
         compiled: bool,
+        k: int,
     ) -> None:
         torch.manual_seed(0)
-
-        in_tokens: torch.Tensor = torch.randn(
-            num_tokens, dim, device="cuda", dtype=torch.bfloat16
+        random.seed(0)
+        num_in_tokens = num_tokens * k
+        dtype = torch.bfloat16
+        device = torch.accelerator.current_accelerator()
+        # Floating point addition is not associative, thus will not generate deterministic results
+        # Which can fail torch.testing.assert_close test.
+        # Therefore, for testing correctness, we use int32 instead.
+        if k > 1:
+            dtype = torch.int32
+        in_tokens: torch.Tensor = torch.randn(num_in_tokens, dim, device=device).to(
+            dtype
         )
-        out_tokens: torch.Tensor = torch.randn(
-            num_tokens, dim, device="cuda", dtype=torch.bfloat16
-        )
-
-        token_indices: torch.Tensor = torch.randperm(num_tokens, device="cuda").to(
-            torch.int32
-        )
+        out_tokens: torch.Tensor = torch.randn(num_tokens, dim, device=device).to(dtype)
 
         num_valid_tokens: int = num_tokens
         valid_token_count: Optional[torch.Tensor] = None
-        partial_token_indices: torch.Tensor = token_indices
         if partial:
-            num_valid_tokens = num_tokens // 2
+            if num_tokens == 0:
+                return
+            num_valid_tokens = random.randint(0, num_tokens - 1)
             valid_token_count = torch.tensor(
-                [num_valid_tokens], dtype=torch.int32, device="cuda"
+                [num_valid_tokens * k], dtype=torch.int32, device=device
             )
-            partial_token_indices = torch.where(
-                torch.arange(num_tokens).cuda() < num_valid_tokens, token_indices, -1
-            )
+
+        token_indices: torch.Tensor = -1 * torch.ones(
+            num_in_tokens, device=device, dtype=torch.int32
+        )
+        if num_valid_tokens > 0:
+            token_indices[: num_valid_tokens * k] = (
+                torch.randperm(num_valid_tokens * k, device=device) % num_valid_tokens
+            ).to(torch.int32)
 
         test_out_tokens: torch.Tensor = out_tokens.clone()
         ref_out_tokens: torch.Tensor = out_tokens.clone()
@@ -265,13 +276,13 @@ class GatherScatterTests(unittest.TestCase):
             op(
                 test_out_tokens,
                 in_tokens,
-                partial_token_indices,
+                token_indices,
                 valid_token_count,
             )
 
         fn()
 
-        token_indices: torch.Tensor = token_indices[:num_valid_tokens].to(torch.int64)
+        token_indices = token_indices[: num_valid_tokens * k]
 
         def ref_fn() -> None:
             ref_out_tokens.scatter_add_(
@@ -280,14 +291,20 @@ class GatherScatterTests(unittest.TestCase):
                 src=in_tokens.view(-1, dim),
             )
 
-        ref_fn()
+        if token_indices.numel() > 0:
+            ref_fn()
 
-        torch.testing.assert_close(
-            test_out_tokens[:num_valid_tokens],
-            ref_out_tokens[:num_valid_tokens],
-            atol=1e-3,
-            rtol=1.6e-2,
-        )
+        if dtype == torch.bfloat16:
+            torch.testing.assert_close(
+                test_out_tokens[:num_valid_tokens],
+                ref_out_tokens[:num_valid_tokens],
+                atol=1e-3,
+                rtol=1.6e-2,
+            )
+        else:
+            assert torch.equal(
+                test_out_tokens[:num_valid_tokens], ref_out_tokens[:num_valid_tokens]
+            )
 
     @given(
         num_tokens=st.sampled_from([64, 128, 256]),
@@ -296,6 +313,7 @@ class GatherScatterTests(unittest.TestCase):
         dim=st.sampled_from([5120]),
         balanced=st.sampled_from([True, False]),
         compiled=st.sampled_from([True, False]),
+        k=st.sampled_from([1, 2, 4]),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=_MAX_SAMPLES, deadline=None)
     def test_scatter_add_padded_tokens(
@@ -306,35 +324,42 @@ class GatherScatterTests(unittest.TestCase):
         dim: int,
         balanced: bool,
         compiled: bool,
+        k: int,
     ) -> None:
         torch.manual_seed(0)
 
         device = torch.accelerator.current_accelerator()
-
+        dtype = torch.bfloat16
+        # Floating point addition is not associative, thus will not generate deterministic results
+        # Which can fail torch.testing.assert_close test.
+        # Therefore, for testing correctness, we use int32 instead.
+        if k > 1:
+            dtype = torch.int32
+        num_in_tokens = num_tokens * k
         in_tokens: torch.Tensor = torch.randn(
-            ep_size, num_tokens, dim, device=device, dtype=torch.bfloat16
-        )
-        out_tokens: torch.Tensor = torch.randn(
-            num_tokens, dim, device=device, dtype=torch.bfloat16
-        )
+            ep_size, num_in_tokens, dim, device=device
+        ).to(dtype)
+        out_tokens: torch.Tensor = torch.randn(num_tokens, dim, device=device).to(dtype)
 
         if balanced:
-            if num_tokens < num_experts:
-                logger.info("Skipping test as num_tokens must be >= num_experts")
+            if num_in_tokens < num_experts:
+                logger.info("Skipping test as num_tokens * k must be >= num_experts")
                 return
-            num_tokens_per_expert = num_tokens // num_experts
+            num_tokens_per_expert = num_in_tokens // num_experts
             token_counts: torch.Tensor = torch.tensor(
                 [num_tokens_per_expert] * num_experts, device=device
             ).to(torch.int32)
         else:
-            token_choices = torch.randint(0, num_experts, (num_tokens,), device=device)
+            token_choices = torch.randint(
+                0, num_experts, (num_in_tokens,), device=device
+            )
             token_counts = torch.bincount(token_choices, minlength=num_experts)
 
         token_cumsums = torch.cumsum(token_counts, dim=0)
 
-        token_indices: torch.Tensor = torch.randperm(num_tokens, device=device).to(
-            torch.int32
-        )
+        token_indices: torch.Tensor = (
+            torch.randperm(num_in_tokens, device=device) % num_tokens
+        ).to(torch.int32)
 
         test_out_tokens: torch.Tensor = out_tokens.clone()
         ref_out_tokens: torch.Tensor = out_tokens.clone()
@@ -372,9 +397,12 @@ class GatherScatterTests(unittest.TestCase):
 
         ref_fn()
 
-        torch.testing.assert_close(
-            test_out_tokens, ref_out_tokens, atol=1e-3, rtol=1.6e-2
-        )
+        if dtype == torch.bfloat16:
+            torch.testing.assert_close(
+                test_out_tokens, ref_out_tokens, atol=1e-3, rtol=1.6e-2
+            )
+        else:
+            assert torch.equal(test_out_tokens, ref_out_tokens)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Allow scatter_add_padded_tokens to run with in_tokens.shape[0] different from out_tokens.shape[0]

Update unit tests.

Differential Revision: D79616705


