### PR TITLE
Fix non-round N in group gemm

### DIFF
--- a/fbgemm_gpu/experimental/gemm/test/grouped_gemm_test.py
+++ b/fbgemm_gpu/experimental/gemm/test/grouped_gemm_test.py
@@ -155,7 +155,7 @@ class TestGroupedGEMM(unittest.TestCase):
     @given(
         G=st.sampled_from([1, 4, 16, 128]),
         M=st.sampled_from([0, 128, 2048, 16384]),
-        N=st.sampled_from([256]),
+        N=st.sampled_from([256, 451]),
         K=st.sampled_from([100, 256, 257]),
         warp_specialization=st.sampled_from(
             [True, False] if torch.cuda.is_available() and _HAS_WS_SUPPORT else [False]
@@ -179,8 +179,9 @@ class TestGroupedGEMM(unittest.TestCase):
         warp_specialization: bool,
         fuse_scatter_add: bool,
     ) -> None:
-        if K % 8 != 0:
-            # When K is not a multiple of 8, using fuse_scatter_add has large numerical discrepancy,
+        # TODO: fix crashes for K divisible by 8 but not divisible by 128, like 264.
+        if K % 8 != 0 or N % 8 != 0:
+            # When K or N are not a multiple of 8, using fuse_scatter_add has large numerical discrepancy,
             # possibly due to atomic add in scatter_add or larger rounding error with negative numbers.
             fuse_scatter_add = False
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1675

Non-round N triggers static assert on TMA path, so disable TMA for them.

Differential Revision: D79656255
