### PR TITLE
[fbgemm_gpu] [OSS] Reusable Workflows

### DIFF
--- a/.github/scripts/generate_ci_matrix.py
+++ b/.github/scripts/generate_ci_matrix.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import itertools
+import json
+import sys
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+TARGET_DEFAULT = "default"
+TARGET_GENAI = "genai"
+TARGET_HSTU = "hstu"
+ALL_TARGETS = [TARGET_DEFAULT, TARGET_GENAI, TARGET_HSTU]
+
+VARIANT_CPU = "cpu"
+VARIANT_CUDA = "cuda"
+VARIANT_ROCM = "rocm"
+
+JOBTYPE_BUILD = "build"
+JOBTYPE_TEST = "test"
+
+
+@dataclass(frozen=True)
+class BuildConfigScheme:
+    """
+    Immutable generator that produces matrix entries for a given build target,
+    variant, and job type.
+    """
+
+    target: str
+    variant: str
+    jobtype: str
+
+    @classmethod
+    def _create_parser(cls) -> argparse.ArgumentParser:
+        """
+        Create and return the argument parser for this class.
+        """
+        parser = argparse.ArgumentParser(
+            description="Generate GitHub CI build matrix based on target, variant, and job type."
+        )
+        parser.add_argument(
+            "--targets",
+            required=True,
+            type=str,
+            help=f"Comma-separated build targets: {', '.join(ALL_TARGETS)}",
+        )
+        parser.add_argument(
+            "--variant",
+            required=True,
+            choices=[VARIANT_CPU, VARIANT_CUDA, VARIANT_ROCM],
+            help="Build variant: cpu, cuda, or rocm",
+        )
+        parser.add_argument(
+            "--jobtype",
+            required=True,
+            choices=[JOBTYPE_BUILD, JOBTYPE_TEST],
+            help="Job type",
+        )
+        return parser
+
+    @classmethod
+    def from_args(cls) -> List["BuildConfigScheme"]:
+        """
+        Construct a BuildConfigScheme from command-line arguments.
+        Parses args if not provided.
+        """
+        parser = cls._create_parser()
+        args = parser.parse_args()
+
+        targets = [t.strip() for t in args.targets.strip().split(",") if t.strip()]
+
+        if not targets:
+            raise ValueError("Target string cannot be empty")
+
+        # Validate each target
+        for t in targets:
+            if t not in ALL_TARGETS:
+                raise argparse.ArgumentTypeError(
+                    f"Invalid target: '{t}'. Allowed: {ALL_TARGETS}"
+                )
+
+        return [
+            cls(target=t, variant=args.variant, jobtype=args.jobtype).validated()
+            for t in targets
+        ]
+
+    def _dict_cartesian_product(
+        self, table: Dict[str, List[Any]]
+    ) -> List[Dict[str, Any]]:
+        """
+        Compute the Cartesian product of lists in a dictionary, e.g.:
+
+        { "x": [1, 2], "y": [3, 4] }
+        -> [
+            { "x": 1, "y": 3 },
+            { "x": 1, "y": 4 },
+            { "x": 2, "y": 3 },
+            { "x": 2, "y": 4 }
+        ]
+
+        :param table: Dictionary where each value is a list
+        :return: List of dictionaries, each representing one combination
+        """
+        keys = table.keys()
+        # Create list of value lists, ordered by keys
+        value_lists = [table[key] for key in keys]
+
+        # Compute Cartesian product of the value lists
+        product_combinations = itertools.product(*value_lists)
+
+        # Reconstruct dicts
+        return [dict(zip(keys, combination)) for combination in product_combinations]
+
+    def validated(self) -> "BuildConfigScheme":
+        """
+        Validate the build config scheme.
+        """
+        if self.target not in ALL_TARGETS:
+            raise ValueError(f"Invalid target: {self.target}")
+        if self.variant not in [VARIANT_CPU, VARIANT_CUDA, VARIANT_ROCM]:
+            raise ValueError(f"Invalid variant: {self.variant}")
+        if self.jobtype not in [JOBTYPE_BUILD, JOBTYPE_TEST]:
+            raise ValueError(f"Invalid job type: {self.jobtype}")
+
+        if self.target == TARGET_GENAI and self.variant not in [
+            VARIANT_CUDA,
+            VARIANT_ROCM,
+        ]:
+            raise ValueError("GenAI target must be CUDA or ROCM")
+        if self.target == TARGET_HSTU and self.variant != VARIANT_CUDA:
+            raise ValueError("HSTU target must be CUDA")
+
+        return self
+
+    def python_versions(self) -> List[str]:
+        if self.target == TARGET_HSTU:
+            # FBGEMM HSTU is expensive, so conserve CI resources
+            return ["3.13"]
+        if self.variant == VARIANT_ROCM:
+            return ["3.13"]
+        return ["3.9", "3.10", "3.11", "3.12", "3.13"]
+
+    def compilers(self) -> List[str]:
+        if self.target == TARGET_HSTU:
+            return ["gcc"]
+        else:
+            return ["gcc", "clang"]
+
+    def cuda_versions(self) -> List[str]:
+        if self.target == TARGET_HSTU:
+            # FBGEMM HSTU is expensive, so conserve CI resources
+            return ["12.9.1"]
+        else:
+            # GenAI is unable to support 11.8.0 anymore as of https://github.com/pytorch/FBGEMM/pull/4138
+            return ["12.6.3", "12.8.1", "12.9.1"]
+
+    def rocm_versions(self) -> List[str]:
+        return ["6.3", "6.4"]
+
+    def host_machines(self) -> List[Dict[str, str]]:
+        if self.variant == VARIANT_CPU:
+            return [
+                {"arch": "x86", "instance": "linux.4xlarge"},
+                {"arch": "arm", "instance": "linux.arm64.2xlarge"},
+            ]
+
+        elif self.variant == VARIANT_CUDA:
+            # TODO: Enable when A100 machine queues are reasonably small enough for doing per-PR CI
+            # https://hud.pytorch.org/metrics
+            # { arch: x86, instance: "linux.gcp.a100" },
+            if self.jobtype == JOBTYPE_BUILD:
+                table = {
+                    TARGET_DEFAULT: [{"arch": "x86", "instance": "linux.24xlarge"}],
+                    TARGET_GENAI: [
+                        {"arch": "x86", "instance": "linux.12xlarge.memory"}
+                    ],
+                    TARGET_HSTU: [{"arch": "x86", "instance": "linux.24xlarge.memory"}],
+                }
+                return table[self.target]
+            else:
+                return [{"arch": "x86", "instance": "linux.g5.4xlarge.nvidia.gpu"}]
+
+        elif self.variant == VARIANT_ROCM:
+            return [{"arch": "x86", "instance": "linux.rocm.gpu.2"}]
+
+        else:
+            return []
+
+    def generate(self) -> List[Dict[str, Any]]:
+        # Build a table of dimensions to values for each dimension
+        table: Dict[str, List[Any]] = {
+            "compiler": self.compilers(),
+            "python-version": self.python_versions(),
+            "host-machine": self.host_machines(),
+            "build-target": [self.target],
+        }
+
+        if self.variant == VARIANT_CUDA:
+            table |= {"cuda-version": self.cuda_versions()}
+
+        if self.variant == VARIANT_ROCM:
+            table |= {"rocm-version": self.rocm_versions()}
+
+        # Generate the Cartesian product matrix from the table
+        return self._dict_cartesian_product(table)
+
+
+def main():
+    try:
+        configs = BuildConfigScheme.from_args()
+
+        matrix = []
+        for c in configs:
+            matrix.extend(c.generate())
+
+        print(json.dumps({"include": matrix}))
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/_fbgemm_gpu_cuda_build.yml
+++ b/.github/workflows/_fbgemm_gpu_cuda_build.yml
@@ -1,0 +1,100 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This callable workflow is used for building FBGEMM GPU/GenAI/HSTU CUDA wheels.
+name: FBGEMM GPU/GenAI/HSTU CUDA Build
+
+on:
+  workflow_call:
+    inputs:
+      matrix:
+        required: true
+        type: string
+      repo-ref:
+        description: Repo ref/sha
+        type: string
+        required: true
+        default: ""
+      pytorch-channel-version:
+        description: Package Channel + Version to Use for PyTorch Installation, in `<channel>[/<version>]` Format
+        type: string
+        required: false
+        default: ""
+
+jobs:
+  # Build on CPU hosts and upload to GHA
+  build_artifact:
+    runs-on: ${{ matrix.host-machine.instance }}
+    container:
+      image: amazonlinux:2023
+      options: --user root --privileged --pid=host
+    defaults:
+      run:
+        shell: bash
+    env:
+      PRELUDE: .github/scripts/setup_env.bash
+      BUILD_ENV: build_binary
+      BUILD_TARGET: ${{ matrix.build-target }}
+      BUILD_VARIANT: cuda
+      BUILD_CUDA_VERSION: ${{ matrix.cuda-version }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(inputs.matrix) }}
+    continue-on-error: true
+
+    steps:
+    - name: Setup Build Container
+      run: yum update -y; yum install -y binutils findutils git pciutils sudo tar wget which xz
+
+    - name: Checkout the Repository
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+        ref: ${{ inputs.repo-ref }}
+
+    - name: Display System Info
+      run: . $PRELUDE; print_system_info
+
+    - name: Display GPU Info
+      run: . $PRELUDE; print_gpu_info
+
+    - name: Setup Miniconda
+      run: . $PRELUDE; setup_miniconda $HOME/miniconda
+
+    - name: Create Conda Environment
+      run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
+
+    - name: Install C/C++ Compilers
+      run: . $PRELUDE; install_cxx_compiler $BUILD_ENV ${{ matrix.compiler }}
+
+    - name: Install Build Tools
+      run: . $PRELUDE; install_build_tools $BUILD_ENV
+
+    - name: Install CUDA
+      run: . $PRELUDE; install_cuda $BUILD_ENV ${{ matrix.cuda-version }}
+
+    # Install via PIP to avoid defaulting to the CPU variant if the GPU variant of the day is not ready
+    - name: Install PyTorch (${{ inputs.pytorch-channel-version }})
+      run: . $PRELUDE; install_pytorch_pip $BUILD_ENV ${{ inputs.pytorch-channel-version }} cuda/${{ matrix.cuda-version }}
+
+    - name: Collect PyTorch Environment Info
+      if: ${{ success() || failure() }}
+      run: if . $PRELUDE && which conda; then collect_pytorch_env_info $BUILD_ENV; fi
+
+    - name: Install cuDNN
+      run: . $PRELUDE; install_cudnn $BUILD_ENV "$(pwd)/build_only/cudnn" ${{ matrix.cuda-version }}
+
+    - name: Prepare FBGEMM_GPU Build
+      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
+
+    - name: Build FBGEMM_GPU Wheel
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_package $BUILD_ENV nightly ${{ matrix.build-target }}/cuda
+
+    - name: Upload Built Wheel as GHA Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: fbgemm_${{ matrix.build-target }}_${{ matrix.host-machine.arch }}_${{ matrix.compiler }}_py${{ matrix.python-version }}_cu${{ matrix.cuda-version }}.whl
+        path: fbgemm_gpu/dist/*.whl
+        if-no-files-found: error

--- a/.github/workflows/_fbgemm_gpu_cuda_test.yml
+++ b/.github/workflows/_fbgemm_gpu_cuda_test.yml
@@ -1,0 +1,127 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This callable workflow is used for testing FBGEMM GPU/GenAI/HSTU CUDA wheels
+# as well as optionally publish the wheels to PyPI after a successful test.
+name: FBGEMM GPU/GenAI/HSTU CUDA Test
+
+on:
+  workflow_call:
+    inputs:
+      matrix:
+        required: true
+        type: string
+      repo-ref:
+        description: Repo ref/sha
+        type: string
+        required: true
+        default: ""
+      extra-env:
+        description: 'JSON string of extra environment variables, e.g. {"KEY1": "value1", "KEY2": "value2"}'
+        type: string
+        required: false
+        default: '{}'
+      pytorch-channel-version:
+        description: Package Channel + Version to Use for PyTorch Installation, in `<channel>[/<version>]` Format
+        type: string
+        required: false
+        default: ""
+      publish-to-pypi:
+        description: Publish Artifact to PyPI
+        type: boolean
+        required: false
+        default: false
+      cuda-version-publish:
+        description: CUDA Target Version for Artifact Publishing
+        type: string
+        required: false
+        default: ""
+    secrets:
+      PYPI_TOKEN:
+        required: true
+
+jobs:
+  # Download the built artifact from GHA, test on GPU, and push to PyPI
+  test_and_publish_artifact:
+    # runs-on: linux.4xlarge.nvidia.gpu
+    # Use available instance types - https://github.com/pytorch/test-infra/blob/main/.github/scale-config.yml
+    runs-on: ${{ matrix.host-machine.instance }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      PRELUDE: .github/scripts/setup_env.bash
+      BUILD_ENV: build_binary
+      BUILD_TARGET: ${{ matrix.build-target }}
+      BUILD_VARIANT: cuda
+      BUILD_CUDA_VERSION: ${{ matrix.cuda-version }}
+      ENFORCE_CUDA_DEVICE: 1
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(inputs.matrix) }}
+
+    steps:
+    # Cannot upgrade to actions/checkout@v4 yet because GLIBC on the instance is too old
+    - name: Checkout the Repository
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+        ref: ${{ inputs.repo-ref }}
+
+    - name: Download Wheel Artifact from GHA
+      # Cannot upgrade to actions/download-artifact@v4 yet because GLIBC on the instance is too old
+      uses: actions/download-artifact@v4
+      with:
+        name: fbgemm_${{ matrix.build-target }}_${{ matrix.host-machine.arch }}_${{ matrix.compiler }}_py${{ matrix.python-version }}_cu${{ matrix.cuda-version }}.whl
+
+    # Use PyTorch test infrastructure action - https://github.com/pytorch/test-infra/blob/main/.github/actions/setup-nvidia/action.yml
+    - name: Install NVIDIA Drivers and NVIDIA-Docker Runtime
+      uses: pytorch/test-infra/.github/actions/setup-nvidia@main
+
+    - name: Display System Info
+      run: . $PRELUDE; print_system_info; print_ec2_info
+
+    - name: Display GPU Info
+      run: . $PRELUDE; print_gpu_info
+
+    - name: Setup Miniconda
+      run: . $PRELUDE; setup_miniconda $HOME/miniconda
+
+    - name: Create Conda Environment
+      run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
+
+    - name: Install C/C++ Compilers for Updated LIBGCC
+      # NOTE: gcc is required for torch dynamo to work properly, as some of
+      # the compilation flags used by torch dynamo are gcc-specific:
+      #
+      #   clang-16: error: unknown argument: '-fno-tree-loop-vectorize'
+      run: . $PRELUDE; install_cxx_compiler $BUILD_ENV gcc
+
+    - name: Install CUDA
+      run: . $PRELUDE; install_cuda $BUILD_ENV ${{ matrix.cuda-version }}
+
+    # Install via PIP to avoid defaulting to the CPU variant if the GPU variant of the day is not ready
+    - name: Install PyTorch (${{ inputs.pytorch-channel-version }})
+      run: . $PRELUDE; install_pytorch_pip $BUILD_ENV ${{ inputs.pytorch-channel-version }} cuda/${{ matrix.cuda-version }}
+
+    - name: Collect PyTorch Environment Info
+      if: ${{ success() || failure() }}
+      run: if . $PRELUDE && which conda; then collect_pytorch_env_info $BUILD_ENV; fi
+
+    - name: Prepare FBGEMM_GPU Build
+      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
+
+    - name: Install FBGEMM_GPU Wheel
+      run: . $PRELUDE; install_fbgemm_gpu_wheel $BUILD_ENV *.whl
+
+    - name: Test with PyTest
+      timeout-minutes: 60
+      run: . $PRELUDE; test_all_fbgemm_gpu_modules $BUILD_ENV
+
+    - name: Push Wheel to PyPI
+      if: ${{ inputs.publish-to-pypi && matrix.cuda-version == inputs.cuda-version-publish }}
+      env:
+        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      run: . $PRELUDE; publish_to_pypi $BUILD_ENV "$PYPI_TOKEN" *.whl

--- a/.github/workflows/_fbgemm_gpu_generate_ci_matrix.yml
+++ b/.github/workflows/_fbgemm_gpu_generate_ci_matrix.yml
@@ -1,0 +1,80 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This callable workflow is used for generating the build matrix for FBGEMM
+# GPU/GenAI/HSTU CPU, CUDA, and ROCm CI jobs.
+name: Generate CI Matrix
+
+on:
+  workflow_call:
+    inputs:
+      repo-ref:
+        description: FBGEMM Repository Ref/SHA
+        type: string
+        required: true
+        default: ""
+      targets:
+        description: Build Target(s) (comma-separated values)
+        type: string
+        required: true
+        default: ""
+      variant:
+        description: Build Variant
+        type: string
+        required: true
+        default: ""
+      jobtype:
+        description: Job Type
+        type: string
+        required: true
+        default: ""
+    outputs:
+      matrix:
+        value: ${{ jobs.generate_ci_matrix.outputs.matrix }}
+
+jobs:
+  generate_ci_matrix:
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+    runs-on: ubuntu-latest
+    env:
+      GEN_TARGETS: ${{ inputs.targets }}
+      GEN_VARIANT: ${{ inputs.variant }}
+      GEN_JOBTYPE: ${{ inputs.jobtype }}
+    steps:
+      - name: Checkout the Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          ref: ${{ inputs.repo-ref }}
+
+      - name: Generate CI Matrix
+        id: generate
+        run: |
+          set -eou pipefail
+
+          SCRIPT_PATH=.github/scripts/generate_ci_matrix.py
+
+          if [[ ! -f "$SCRIPT_PATH" ]]; then
+            echo "Error: Script $SCRIPT_PATH not found."
+            exit 1
+          fi
+
+          MATRIX_BLOB=$(python3 "$SCRIPT_PATH" \
+            --target "$GEN_TARGETS" \
+            --variant "$GEN_VARIANT" \
+            --jobtype "$GEN_JOBTYPE")
+
+          echo "$MATRIX_BLOB" | python3 -m json.tool > /dev/null 2>&1
+          if [[ $? -ne 0 ]]; then
+            echo "Error: Generated matrix is not valid JSON"
+            echo "$MATRIX_BLOB"
+            exit 1
+          fi
+
+          echo "Generated CI matrix:"
+          echo "$MATRIX_BLOB" | python3 -m json.tool
+
+          echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/fbgemm_gpu_ci_cuda.yml
+++ b/.github/workflows/fbgemm_gpu_ci_cuda.yml
@@ -32,12 +32,12 @@ on:
   #
   workflow_dispatch:
     inputs:
-      pytorch_channel_version:
+      pytorch-channel-version:
         description: Package Channel + Version to Use for PyTorch Installation, in `<channel>[/<version>]` Format
         type: string
         required: false
         default: ""
-      publish_to_pypi:
+      publish-to-pypi:
         description: Publish Artifact to PyPI
         type: boolean
         required: false
@@ -49,199 +49,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Build on CPU hosts and upload to GHA
-  build_artifact:
-    if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: ${{ matrix.host-machine.instance }}
-    container:
-      image: amazonlinux:2023
-      options: --user root
-    defaults:
-      run:
-        shell: bash
-    env:
-      PRELUDE: .github/scripts/setup_env.bash
-      BUILD_ENV: build_binary
-      BUILD_TARGET: ${{ matrix.host-machine.build-target }}
-      BUILD_VARIANT: cuda
-      BUILD_CUDA_VERSION: ${{ matrix.host-machine.cuda-version }}
-    continue-on-error: true
-    strategy:
-      # Don't fast-fail all the other builds if one of the them fails
-      fail-fast: false
-      matrix:
-        host-machine: [
-          { arch: x86, instance: "linux.24xlarge", build-target: "default", cuda-version: "12.6.3" },
-          { arch: x86, instance: "linux.24xlarge", build-target: "default", cuda-version: "12.8.1" },
-          { arch: x86, instance: "linux.24xlarge", build-target: "default", cuda-version: "12.9.1" },
+  generate_build_matrix:
+    uses: ./.github/workflows/_fbgemm_gpu_generate_ci_matrix.yml
+    with:
+      repo-ref: ${{ (github.event_name == 'schedule' && 'nightly') || github.ref }}
+      targets: "default,genai,hstu"
+      variant: cuda
+      jobtype: build
 
-          # GenAI is unable to support 11.8.0 anymore as of https://github.com/pytorch/FBGEMM/pull/4138
-          { arch: x86, instance: "linux.12xlarge.memory", build-target: "genai", cuda-version: "12.6.3" },
-          { arch: x86, instance: "linux.12xlarge.memory", build-target: "genai", cuda-version: "12.8.1" },
-          { arch: x86, instance: "linux.12xlarge.memory", build-target: "genai", cuda-version: "12.9.1" },
+  build:
+    needs: generate_build_matrix
+    uses: ./.github/workflows/_fbgemm_gpu_cuda_build.yml
+    with:
+      matrix: ${{ needs.generate_build_matrix.outputs.matrix }}
+      repo-ref: ${{ (github.event_name == 'schedule' && 'nightly') || github.ref }}
+      pytorch-channel-version: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.pytorch-channel-version) || 'nightly' }}
 
-          # Since FBGEMM HSTU is released yet, we reduce to one CUDA version to conserve CI resources
-          { arch: x86, instance: "linux.24xlarge.memory", build-target: "hstu", cuda-version: "12.9.1" },
-        ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
-        compiler: [ "gcc", "clang" ]
+  generate_test_matrix:
+    needs: build
+    uses: ./.github/workflows/_fbgemm_gpu_generate_ci_matrix.yml
+    with:
+      repo-ref: ${{ (github.event_name == 'schedule' && 'nightly') || github.ref }}
+      targets: "default,genai,hstu"
+      variant: cuda
+      jobtype: test
 
-    steps:
-    - name: Setup Build Container
-      run: yum update -y; yum install -y binutils findutils git pciutils sudo tar wget which xz
-
-    - name: Checkout the Repository
-      uses: actions/checkout@v4
-      with:
-        submodules: true
-        ref: ${{ (github.event_name == 'schedule' && 'nightly') || github.ref }}
-
-    - name: Display System Info
-      run: . $PRELUDE; print_system_info
-
-    - name: Display GPU Info
-      run: . $PRELUDE; print_gpu_info
-
-    - name: Setup Miniconda
-      run: . $PRELUDE; setup_miniconda $HOME/miniconda
-
-    - name: Create Conda Environment
-      run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
-
-    - name: Install C/C++ Compilers
-      run: . $PRELUDE; install_cxx_compiler $BUILD_ENV ${{ matrix.compiler }}
-
-    - name: Install Build Tools
-      run: . $PRELUDE; install_build_tools $BUILD_ENV
-
-    - name: Install CUDA
-      run: . $PRELUDE; install_cuda $BUILD_ENV ${{ matrix.host-machine.cuda-version }}
-
-    # Install via PIP to avoid defaulting to the CPU variant if the GPU variant of the day is not ready
-    - name: Install PyTorch Nightly
-      run: . $PRELUDE; install_pytorch_pip $BUILD_ENV ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.pytorch_channel_version) || 'nightly' }} cuda/${{ matrix.host-machine.cuda-version }}
-
-    - name: Collect PyTorch Environment Info
-      if: ${{ success() || failure() }}
-      run: if . $PRELUDE && which conda; then collect_pytorch_env_info $BUILD_ENV; fi
-
-    - name: Install cuDNN
-      run: . $PRELUDE; install_cudnn $BUILD_ENV "$(pwd)/build_only/cudnn" ${{ matrix.host-machine.cuda-version }}
-
-    - name: Prepare FBGEMM_GPU Build
-      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
-
-    - name: Build FBGEMM_GPU Wheel
-      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_package $BUILD_ENV nightly ${{ matrix.host-machine.build-target }}/cuda
-
-    - name: Upload Built Wheel as GHA Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: fbgemm_${{ matrix.host-machine.build-target }}_${{ matrix.host-machine.arch }}_${{ matrix.compiler }}_py${{ matrix.python-version }}_cu${{ matrix.host-machine.cuda-version }}.whl
-        path: fbgemm_gpu/dist/*.whl
-        if-no-files-found: error
-
-
-  # Download the built artifact from GHA, test on GPU, and push to PyPI
-  test_and_publish_artifact:
-    if: ${{ github.repository_owner == 'pytorch' }}
-    # runs-on: linux.4xlarge.nvidia.gpu
-    # Use available instance types - https://github.com/pytorch/test-infra/blob/main/.github/scale-config.yml
-    runs-on: ${{ matrix.host-machine.instance }}
-    defaults:
-      run:
-        shell: bash
-    env:
-      PRELUDE: .github/scripts/setup_env.bash
-      BUILD_ENV: build_binary
-      BUILD_TARGET: ${{ matrix.build-target }}
-      BUILD_VARIANT: cuda
-      BUILD_CUDA_VERSION: ${{ matrix.build.cuda-version }}
-      ENFORCE_CUDA_DEVICE: 1
-    strategy:
-      fail-fast: false
-      matrix:
-        host-machine: [
-          { arch: x86, instance: "linux.g5.4xlarge.nvidia.gpu" },
-          # TODO: Enable when A100 machine queues are reasonably small enough for doing per-PR CI
-          # https://hud.pytorch.org/metrics
-          # { arch: x86, instance: "linux.gcp.a100" },
-        ]
-        build: [
-          { build-target: "default", cuda-version: "12.6.3" },
-          { build-target: "default", cuda-version: "12.8.1" },
-          { build-target: "default", cuda-version: "12.9.1" },
-          { build-target: "genai", cuda-version: "12.6.3" },
-          { build-target: "genai", cuda-version: "12.8.1" },
-          { build-target: "genai", cuda-version: "12.9.1" },
-          { build-target: "hstu", cuda-version: "12.9.1" },
-        ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
-        # Specify exactly ONE CUDA version for artifact publish
-        cuda-version-publish: [ "12.6.3" ]
-        compiler: [ "gcc", "clang" ]
-    needs: build_artifact
-
-    steps:
-    # Cannot upgrade to actions/checkout@v4 yet because GLIBC on the instance is too old
-    - name: Checkout the Repository
-      uses: actions/checkout@v4
-      with:
-        submodules: true
-        ref: ${{ (github.event_name == 'schedule' && 'nightly') || github.ref }}
-
-    - name: Download Wheel Artifact from GHA
-      # Cannot upgrade to actions/download-artifact@v4 yet because GLIBC on the instance is too old
-      uses: actions/download-artifact@v4
-      with:
-        name: fbgemm_${{ matrix.build.build-target }}_${{ matrix.host-machine.arch }}_${{ matrix.compiler }}_py${{ matrix.python-version }}_cu${{ matrix.build.cuda-version }}.whl
-
-    # Use PyTorch test infrastructure action - https://github.com/pytorch/test-infra/blob/main/.github/actions/setup-nvidia/action.yml
-    - name: Install NVIDIA Drivers and NVIDIA-Docker Runtime
-      uses: pytorch/test-infra/.github/actions/setup-nvidia@main
-
-    - name: Display System Info
-      run: . $PRELUDE; print_system_info; print_ec2_info
-
-    - name: Display GPU Info
-      run: . $PRELUDE; print_gpu_info
-
-    - name: Setup Miniconda
-      run: . $PRELUDE; setup_miniconda $HOME/miniconda
-
-    - name: Create Conda Environment
-      run: . $PRELUDE; create_conda_environment $BUILD_ENV ${{ matrix.python-version }}
-
-    - name: Install C/C++ Compilers for Updated LIBGCC
-      # NOTE: gcc is required for torch dynamo to work properly, as some of
-      # the compilation flags used by torch dynamo are gcc-specific:
-      #
-      #   clang-16: error: unknown argument: '-fno-tree-loop-vectorize'
-      run: . $PRELUDE; install_cxx_compiler $BUILD_ENV gcc
-
-    - name: Install CUDA
-      run: . $PRELUDE; install_cuda $BUILD_ENV ${{ matrix.build.cuda-version }}
-
-    # Install via PIP to avoid defaulting to the CPU variant if the GPU variant of the day is not ready
-    - name: Install PyTorch Nightly
-      run: . $PRELUDE; install_pytorch_pip $BUILD_ENV ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.pytorch_channel_version) || 'nightly' }} cuda/${{ matrix.build.cuda-version }}
-
-    - name: Collect PyTorch Environment Info
-      if: ${{ success() || failure() }}
-      run: if . $PRELUDE && which conda; then collect_pytorch_env_info $BUILD_ENV; fi
-
-    - name: Prepare FBGEMM_GPU Build
-      run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
-
-    - name: Install FBGEMM_GPU Wheel
-      run: . $PRELUDE; install_fbgemm_gpu_wheel $BUILD_ENV *.whl
-
-    - name: Test with PyTest
-      timeout-minutes: 60
-      run: . $PRELUDE; test_all_fbgemm_gpu_modules $BUILD_ENV
-
-    - name: Push Wheel to PyPI
-      if: ${{ (github.event_name == 'schedule' && matrix.build.cuda-version == matrix.cuda-version-publish) || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_to_pypi == 'true' && matrix.build.cuda-version == matrix.cuda-version-publish) }}
-      env:
-        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      run: . $PRELUDE; publish_to_pypi $BUILD_ENV "$PYPI_TOKEN" *.whl
+  test:
+    needs: generate_test_matrix
+    uses: ./.github/workflows/_fbgemm_gpu_cuda_test.yml
+    with:
+      matrix: ${{ needs.generate_test_matrix.outputs.matrix }}
+      repo-ref: ${{ (github.event_name == 'schedule' && 'nightly') || github.ref }}
+      pytorch-channel-version: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.pytorch-channel-version) || 'nightly' }}
+      publish-to-pypi: ${{ (github.event_name == 'schedule') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-to-pypi == 'true') }}
+      cuda-version-publish: 12.6.3
+      extra-env: >-
+        {
+          "ENFORCE_CUDA_DEVICE": 1
+        }
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/fbgemm_gpu_ci_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_ci_rocm.yml
@@ -73,6 +73,7 @@ jobs:
         ]
         container-image: [ "ubuntu:22.04" ]
         build-target: [ "default", "genai" ]
+        # NOTE: we test only a subset of Python versions to reduce CI expenses
         python-version: [ "3.13" ]
         # NOTE: PyTorch releases for ROCm include the ROCm patch version,
         # unlike releases for CUDA


### PR DESCRIPTION
Migrate CUDA CI to reusable workflows.  This is done for a few reasons:

1. To be able to cut the HSTU CI down to one job per PR, since the CI machines for HSTU are expensive to use. This can be done by manually expanding the job matrix in the workflow definitions, but would be tiresome to maintain.
2. To pave the way for reducing workflow definition duplication and fold common operations (build, test) into reusable worfklow components
3. To give us an injection point in the future, where we can dynamically decide the job matrix based on files touched in a PR, in order to save on CI expenditure.

This PR enables reusable workflow usage for the CUDA CI workflows.  In subsequent PRs, CUDA Release, CUDA Benchmark, and Generic Infra GenAI workflows will be converted to use reusable workflows.

Example sucessful run: https://github.com/pytorch/FBGEMM/actions/runs/16813307848/job/47628710094