### PR TITLE
Support any EP in combine or split shuffling

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/test/moe/shuffling_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/moe/shuffling_test.py
@@ -218,7 +218,7 @@ class ShufflingTests(unittest.TestCase):
             [1, 3, 123, 128, 1234, 2048, 4567, 4096, 8192, 16384]
         ),
         num_experts=st.sampled_from([16, 80, 128]),
-        ep_size=st.sampled_from([4, 8]),
+        ep_size=st.sampled_from([4, 5, 8, 11]),
         dim=st.sampled_from([5120]),
         top_k=st.sampled_from([1, 4]),
         sparse=st.sampled_from([True, False]),
@@ -241,7 +241,6 @@ class ShufflingTests(unittest.TestCase):
         device = device = torch.accelerator.current_accelerator()
 
         is_combine_shuffling: bool = target_fn == "combine_shuffling"
-        assert num_experts % ep_size == 0
 
         if sparse:
             num_tokens *= ep_size


### PR DESCRIPTION
Summary: tl.arange(0, EP) requires EP to be power of 2. This diff removes this restriction to support any EP number.

Differential Revision: D79757546


