### PR TITLE
add kernel to accumulate weight value and counts based on jagged unique inverse indices

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/dispatch_macros.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/dispatch_macros.h
@@ -299,6 +299,10 @@
   AT_DISPATCH_CASE(at::ScalarType::BFloat16, __VA_ARGS__) \
   FBGEMM_DISPATCH_INTEGRAL_TYPES_CASE(__VA_ARGS__)
 
+#define FBGEMM_DISPATCH_FLOAT_AND_DOUBLE_CASE(...)     \
+  AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__) \
+  AT_DISPATCH_CASE(at::ScalarType::Double, __VA_ARGS__)
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Type Dispatch Macros
 ///
@@ -309,6 +313,10 @@
 #define FBGEMM_DISPATCH_FLOAT_ONLY(TYPE, NAME, ...) \
   AT_DISPATCH_SWITCH(                               \
       TYPE, NAME, AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__))
+
+#define FBGEMM_DISPATCH_FLOAT_AND_DOUBLE(TYPE, NAME, ...) \
+  AT_DISPATCH_SWITCH(                                     \
+      TYPE, NAME, FBGEMM_DISPATCH_FLOAT_AND_DOUBLE_CASE(__VA_ARGS__))
 
 #define FBGEMM_DISPATCH_FLOAT_AND_HALF(TYPE, NAME, ...) \
   AT_DISPATCH_SWITCH(                                   \
@@ -349,6 +357,14 @@
       NAME,                                            \
       FBGEMM_DISPATCH_FLOATING_TYPES_CASE(__VA_ARGS__) \
           FBGEMM_DISPATCH_INTEGRAL_TYPES_CASE(__VA_ARGS__))
+
+#define FBGEMM_DISPATCH_ALL_TYPES_AND_DOUBLE(TYPE, NAME, ...) \
+  AT_DISPATCH_SWITCH(                                         \
+      TYPE,                                                   \
+      NAME,                                                   \
+      FBGEMM_DISPATCH_FLOATING_TYPES_CASE(__VA_ARGS__)        \
+          FBGEMM_DISPATCH_INTEGRAL_TYPES_CASE(__VA_ARGS__)    \
+              AT_DISPATCH_CASE(at::ScalarType::Double, __VA_ARGS__))
 
 // We can cleanup the following once fbgemm uses PyTorch 2.2 in January 2024.
 #ifndef PT2_COMPLIANT_TAG

--- a/fbgemm_gpu/src/sparse_ops/sparse_block_bucketize_features.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_block_bucketize_features.cu
@@ -413,7 +413,7 @@ __launch_bounds__(kMaxThreads) void _populate_bucketized_permute_cuda_kernel(
             indices_contig.scalar_type(),                                        \
             "_block_bucketize_sequence_sparse_features_cuda_kernel2_2",          \
             [&] {                                                                \
-              FBGEMM_DISPATCH_FLOAT_ONLY(                                        \
+              FBGEMM_DISPATCH_FLOAT_AND_DOUBLE(                                  \
                   weights_value.scalar_type(),                                   \
                   "_block_bucketize_sequence_sparse_features_cuda_kernel2_3",    \
                   [&] {                                                          \
@@ -539,7 +539,7 @@ __launch_bounds__(kMaxThreads) void _populate_bucketized_permute_cuda_kernel(
             indices_contig.scalar_type(),                                        \
             "_block_bucketize_pooled_sparse_features_cuda_kernel2_2",            \
             [&] {                                                                \
-              FBGEMM_DISPATCH_FLOAT_ONLY(                                        \
+              FBGEMM_DISPATCH_FLOAT_AND_DOUBLE(                                  \
                   weights_value.scalar_type(),                                   \
                   "_block_bucketize_pooled_sparse_features_cuda_kernel2_3",      \
                   [&] {                                                          \

--- a/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
@@ -778,7 +778,7 @@ std::tuple<Tensor, Tensor, std::optional<Tensor>> permute_2D_sparse_data_cpu(
         FBGEMM_DISPATCH_ALL_TYPES(
             indices.scalar_type(), "permute_2D_indices_weights_kernel_2", [&] {
               using indices_t = scalar_t;
-              FBGEMM_DISPATCH_FLOAT_ONLY(
+              FBGEMM_DISPATCH_FLOAT_AND_DOUBLE(
                   weights.has_value() ? weights.value().scalar_type()
                                       : at::ScalarType::Float,
                   "permute_2D_indices_weights_kernel_3",
@@ -1166,7 +1166,7 @@ _block_bucketize_sparse_features_cpu(
             indices.scalar_type(),                               \
             "block_bucketize_sparse_features_weights_cpu_2",     \
             [&] {                                                \
-              FBGEMM_DISPATCH_FLOAT_ONLY(                        \
+              FBGEMM_DISPATCH_FLOAT_AND_DOUBLE(                  \
                   weights_value.scalar_type(),                   \
                   "bucketize_sparse_features_weights_cpu_3",     \
                   [&] {                                          \

--- a/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
@@ -145,7 +145,7 @@ permute_2D_sparse_data_cuda(
                 const auto weights_value_contig = weights_value.contiguous();
                 permuted_weights =
                     at::empty(permuted_indices_size, weights_value.options());
-                FBGEMM_DISPATCH_ALL_TYPES(
+                FBGEMM_DISPATCH_ALL_TYPES_AND_DOUBLE(
                     weights_value.scalar_type(),
                     "permute_2D_data_kernel_3",
                     [&] {

--- a/fbgemm_gpu/test/jagged/failures_dict.json
+++ b/fbgemm_gpu/test/jagged/failures_dict.json
@@ -16,6 +16,32 @@
       }
     },
     "fbgemm::jagged_2d_to_dense": {},
+    "fbgemm::jagged_acc_weights_and_counts": {
+      "UniqueIndicesTest.test_aot_dispatch_dynamic__test_jagged_acc_weights_and_counts_1d": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_aot_dispatch_dynamic__test_jagged_acc_weights_and_counts_different_sizes": {
+        "comment": "Test fails during AOT dispatch dynamic checks. The operator doesn't handle different sized weights and counts correctly, which could lead to silently incorrect behavior.",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_aot_dispatch_dynamic__test_jagged_acc_weights_and_counts_edge_cases": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_faketensor__test_jagged_acc_weights_and_counts_1d": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_faketensor__test_jagged_acc_weights_and_counts_different_sizes": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_faketensor__test_jagged_acc_weights_and_counts_edge_cases": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
     "fbgemm::jagged_dense_bmm": {},
     "fbgemm::jagged_dense_dense_elementwise_add_jagged_output": {},
     "fbgemm::jagged_dense_elementwise_add": {

--- a/fbgemm_gpu/test/sparse/failures_dict.json
+++ b/fbgemm_gpu/test/sparse/failures_dict.json
@@ -21,6 +21,10 @@
         "comment": "",
         "status": "xfail"
       },
+      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_float64_weights": {
+        "comment": "",
+        "status": "xfail"
+      },
       "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_keep_orig_idx_per_feature": {
         "comment": "",
         "status": "xfail"
@@ -58,6 +62,10 @@
         "status": "xfail"
       },
       "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_float64_weights": {
         "comment": "",
         "status": "xfail"
       },
@@ -191,6 +199,32 @@
       }
     },
     "fbgemm::invert_permute": {},
+    "fbgemm::jagged_acc_weights_and_counts": {
+      "UniqueIndicesTest.test_aot_dispatch_dynamic__test_jagged_acc_weights_and_counts_1d": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_aot_dispatch_dynamic__test_jagged_acc_weights_and_counts_different_sizes": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_aot_dispatch_dynamic__test_jagged_acc_weights_and_counts_edge_cases": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_faketensor__test_jagged_acc_weights_and_counts_1d": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_faketensor__test_jagged_acc_weights_and_counts_different_sizes": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_faketensor__test_jagged_acc_weights_and_counts_edge_cases": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
     "fbgemm::pack_segments": {},
     "fbgemm::permute102_baddbmm_permute102": {
       "MiscOpsTest.test_aot_dispatch_dynamic__test_permute102_baddbmm_permute102": {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1689

during EC input dist, we have id dedup, which will lose the id occurance information, and potentially the weight associated with id for weighted lookup.
added this kernel to accumulate the weight and occurance for each unique indices.

at the same time, extend fbgemm dispatch to support float64 dtype.

Reviewed By: steven1327

Differential Revision: D78928682


