### PR TITLE
Reuse prepacked pmat for PackBMatrix if smat is nullptr

### DIFF
--- a/src/PackBMatrix.cc
+++ b/src/PackBMatrix.cc
@@ -248,6 +248,8 @@ PackBMatrix<T, accT>::PackBMatrix(
         64,
         BaseType::numGroups() * BaseType::blockRows() * BaseType::brow_ *
             BaseType::blockCols() * BaseType::bcol_ * sizeof(T)));
+  } else if (!smat) {
+    return;
   }
   pack(block, params);
 }


### PR DESCRIPTION
This patch solves the problem addressed in #427 and #542 in a more non-intrusive way: the PackBMatrix constructor now skips the actual packing and allows reuse of `pmat` if `smat == nullptr`. This feature is crucial for offline packing and caching `pmat` for better load speed.

Doing so eliminates the need for a separate constructor and ensures the pack parameters are identical.