### PR TITLE
fix gen_ai:quantize_ops_gpu build for b200

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cu
@@ -1287,7 +1287,8 @@ std::vector<at::Tensor> quantize_fp8_per_col(
 #if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
 // Convert 8 float32 values into 8 e2m1 values (represented as one uint32_t).
 inline __device__ uint32_t fp32_vec_to_e2m1(float (&array)[8]) {
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000) && \
+    defined(__CUDA_ARCH_FEAT_SM100_ALL)
   uint32_t val;
   asm volatile(
       "{\n"
@@ -1318,7 +1319,8 @@ inline __device__ uint32_t fp32_vec_to_e2m1(float (&array)[8]) {
 
 // Convert 4 float2 values into 8 e2m1 values (represented as one uint32_t).
 inline __device__ uint32_t fp32_vec_to_e2m1(float2 (&array)[4]) {
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000) && \
+    defined(__CUDA_ARCH_FEAT_SM100_ALL)
   uint32_t val;
   asm volatile(
       "{\n"
@@ -1360,7 +1362,8 @@ __device__ uint8_t* cvt_quant_to_fp4_get_sf_out_offset(
     int colIdx,
     int numCols,
     SFType* SFout) {
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000) && \
+    defined(__CUDA_ARCH_FEAT_SM100_ALL)
   static_assert(
       CVT_FP4_NUM_THREADS_PER_SF == 1 || CVT_FP4_NUM_THREADS_PER_SF == 2);
 
@@ -1420,7 +1423,8 @@ struct PackedVec<__nv_fp8_e4m3> {
 template <class Type, bool UE8M0_SF = false>
 __device__ uint32_t
 cvt_warp_fp16_to_fp4(PackedVec<Type>& vec, float SFScaleVal, uint8_t* SFout) {
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000) && \
+    defined(__CUDA_ARCH_FEAT_SM100_ALL)
   // Get absolute maximum values among the local 8 values.
   auto localMax = __habs2(vec.elts[0]);
 
@@ -1496,7 +1500,8 @@ cvt_warp_fp16_to_fp4(PackedVec<Type>& vec, float SFScaleVal, uint8_t* SFout) {
 // Use UE4M3 by default.
 template <class Type, bool UE8M0_SF = false>
 __global__ void
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000) && \
+    defined(__CUDA_ARCH_FEAT_SM100_ALL)
 __launch_bounds__(512, 4) cvt_fp16_to_fp4(
 #else
 cvt_fp16_to_fp4(
@@ -1507,7 +1512,8 @@ cvt_fp16_to_fp4(
     float const* SFScale,
     uint32_t* out,
     uint32_t* SFout) {
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000) && \
+    defined(__CUDA_ARCH_FEAT_SM100_ALL)
   using PackedVec = PackedVec<Type>;
   static constexpr int CVT_FP4_NUM_THREADS_PER_SF =
       (CVT_FP4_SF_VEC_SIZE / CVT_FP4_ELTS_PER_THREAD);


### PR DESCRIPTION
Summary:
Fix with help of CCA: https://fburl.com/confucius/674upz3w

The issue is that the FP4 quantization code assumes that cvt.rn.satfinite.e2m1x2.f32 instructions are supported on all SM100+ architectures, but they're actually only supported on SM100A (B200A), not the base SM100 (B200) architecture you're targeting.

Reviewed By: q10, jiawenliu64

Differential Revision: D80075798


