### PR TITLE
Fix build issue for FP32 OSS and enable tests (#4666)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -42,9 +42,10 @@ cc_library(
     name = "fbgemm",
     visibility = ["//visibility:public"],
     srcs = get_fbgemm_generic_srcs(),
-    hdrs = glob(["src/*.h"]),
+    hdrs = glob(["src/*.h", "src/fp32/*.h"]),
     includes = [
         "src",
+        "src/fp32",
     ],
     deps = [
         ":fbgemm_autovec",
@@ -62,7 +63,7 @@ cc_library(
 cc_library(
     name = "fbgemm_avx2",
     srcs = get_fbgemm_avx2_srcs(),
-    hdrs = glob(["src/*.h"]),
+    hdrs = glob(["src/*.h", "src/fp32/*.h"]),
     copts = [
         "-m64",
         "-mavx2",
@@ -79,7 +80,7 @@ cc_library(
 cc_library(
     name = "fbgemm_inline_avx2",
     srcs = get_fbgemm_inline_avx2_srcs(),
-    hdrs = glob(["src/*.h"]),
+    hdrs = glob(["src/*.h", "src/fp32/*.h"]),
     copts = [
         "-m64",
         "-mavx2",
@@ -97,7 +98,7 @@ cc_library(
 cc_library(
     name = "fbgemm_avx512",
     srcs = get_fbgemm_avx512_srcs(),
-    hdrs = glob(["src/*.h"]),
+    hdrs = glob(["src/*.h", "src/fp32/*.h"]),
     copts = [
         "-m64",
         "-mfma",
@@ -116,7 +117,7 @@ cc_library(
 cc_library(
     name = "fbgemm_inline_avx512",
     srcs = get_fbgemm_inline_avx512_srcs(),
-    hdrs = glob(["src/*.h"]),
+    hdrs = glob(["src/*.h", "src/fp32/*.h"]),
     copts = [
         "-m64",
         "-mfma",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,9 @@ if(NOT MSVC)
     src/FbgemmFP16UKernelsAvx2.cc
     src/FbgemmFP16UKernelsAvx512.cc
     src/FbgemmFP16UKernelsAvx512_256.cc
+    src/fp32/FbgemmFP32UKernelsAvx2.cc
+    src/fp32/FbgemmFP32UKernelsAvx512.cc
+    src/fp32/FbgemmFP32UKernelsAvx512_256.cc
     PROPERTIES COMPILE_FLAGS "-masm=intel")
 
   # Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80947
@@ -159,6 +162,9 @@ endif()
 ################################################################################
 
 get_filelist("get_fbgemm_generic_srcs(with_base=True)" FBGEMM_GENERIC_SRCS)
+if(MSVC)
+  list(FILTER FBGEMM_GENERIC_SRCS EXCLUDE REGEX "src/fp32/.*\\.cc$")
+endif()
 
 if(FBGEMM_LIBRARY_TYPE STREQUAL STATIC)
   set(fbgemm_generic_defs FBGEMM_STATIC)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -95,8 +95,10 @@ if(FBGEMM_BUILD_BENCHMARKS)
     file(GLOB BENCH_LIST "*Benchmark.cc")
   endif()
 
-  # NOTE: Skip FP32 benchmark until FP32 is properly integrated into OSS builds
-  list(FILTER BENCH_LIST EXCLUDE REGEX "FP32Benchmark\\.cc$")
+  if(MSVC)
+    # NOTE: Skip FP32 benchmark for MSVC until intrinsic kernels are implemented
+    list(FILTER BENCH_LIST EXCLUDE REGEX "FP32Benchmark\\.cc$")
+  endif()
 
   foreach(BENCH_FILE ${BENCH_LIST})
     get_filename_component(BENCH_NAME ${BENCH_FILE} NAME_WE)

--- a/defs.bzl
+++ b/defs.bzl
@@ -31,8 +31,8 @@ def get_fbgemm_base_srcs():
         "src/Utils.cc",
     ]
 
-def get_fbgemm_generic_srcs(with_base = False):
-    return [
+def get_fbgemm_generic_srcs(with_base = False, msvc = False, buck = False):
+    sources = [
         "src/EmbeddingSpMDM.cc",
         "src/EmbeddingSpMDMNBit.cc",
         "src/ExecuteKernel.cc",
@@ -47,7 +47,6 @@ def get_fbgemm_generic_srcs(with_base = False):
         "src/FbgemmSparseDense.cc",
         "src/FbgemmI8Spmdm.cc",
         "src/FbgemmPackMatrixB.cc",
-        # "src/fp32/FbgemmFP32.cc",
         "src/GenerateKernelDirectConvU8S8S32ACC32.cc",
         "src/GenerateKernel.cc",
         "src/GenerateKernelU8S8S32ACC16.cc",
@@ -73,6 +72,18 @@ def get_fbgemm_generic_srcs(with_base = False):
         "src/spmmUtils.cc",
         "src/TransposeUtils.cc",
     ] + (get_fbgemm_base_srcs() if with_base else [])
+
+    fp32sources = [
+        "src/fp32/FbgemmFP32.cc",
+    ]
+
+    if buck:
+        return select({
+            "DEFAULT": sources + fp32sources,
+            "ovr_config//compiler:cl": sources,
+        })
+
+    return sources + fp32sources if not msvc else sources
 
 def get_fbgemm_public_headers():
     return [
@@ -129,7 +140,7 @@ def get_fbgemm_inline_avx2_srcs(msvc = False, buck = False):
 
     #FP16 kernels contain inline assembly and inline assembly syntax for MSVC is different.
     asm_srcs = [
-        # "src/fp32/FbgemmFP32UKernelsAvx2.cc",
+        "src/fp32/FbgemmFP32UKernelsAvx2.cc",
         "src/FbgemmFP16UKernelsAvx2.cc",
     ]
     if buck:
@@ -162,8 +173,8 @@ def get_fbgemm_inline_avx512_srcs(msvc = False, buck = False):
     asm_srcs = [
         "src/FbgemmFP16UKernelsAvx512.cc",
         "src/FbgemmFP16UKernelsAvx512_256.cc",
-        # "src/fp32/FbgemmFP32UKernelsAvx512.cc",
-        # "src/fp32/FbgemmFP32UKernelsAvx512_256.cc",
+        "src/fp32/FbgemmFP32UKernelsAvx512.cc",
+        "src/fp32/FbgemmFP32UKernelsAvx512_256.cc",
     ]
     if buck:
         return select({
@@ -218,7 +229,7 @@ def get_fbgemm_autovec_srcs():
         "src/EmbeddingStatsTracker.cc",
     ]
 
-def get_fbgemm_tests(skip_tests = ["test/FP32Test.cc"]):
+def get_fbgemm_tests(skip_tests = []):
     return native.glob(["test/*Test.cc"], exclude = skip_tests)
 
 def read_bool(section, field, default):

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -105,21 +105,22 @@ endfunction()
 
 file(GLOB TEST_LIST "*Test.cc")
 foreach(TEST_FILE ${TEST_LIST})
-  # NOTE: Skip FP32 test until FP32 is properly integrated into OSS builds
-  if(TEST_FILE MATCHES "FP32Test.cc$")
-    continue()
-  endif()
-
   # NOTE: Skip tests on ARM for now until linking issues are fixed
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64|arm64")
     if(TEST_FILE MATCHES "Conv"
     OR TEST_FILE MATCHES "I8DepthwiseTest.cc$"
     OR TEST_FILE MATCHES "FP16Test.cc$"
+    OR TEST_FILE MATCHES "FP32Test.cc$"
     OR TEST_FILE MATCHES "I8SpmdmTest.cc$"
     OR TEST_FILE MATCHES "I8DirectconvTest.cc$"
     OR TEST_FILE MATCHES "Requantize")
       continue()
     endif()
+  endif()
+
+  if(MSVC AND TEST_FILE MATCHES "FP32Test.cc$")
+    # NOTE: Skip FP32 test for MSVC until intrinsic kernels are implemented
+    continue()
   endif()
 
   message(STATUS "Processing: ${TEST_FILE}")


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1715

Hi q10 , thanks for the great project!

I noticed your previous work in https://github.com/pytorch/FBGEMM/issues/3568 . After digging into the issue, I believe the build failures are caused by the missing `-masm=intel` flag on various files [here](https://github.com/omegacoleman/FBGEMM/blob/29686bd7085f69b667bdcf1a2fdd2bfff48854e3/CMakeLists.txt#L146) After adding these files, it works like a charm on my machine. The tests and benchmarks have no issues.

If that's the sole problem, the FP32 kernels, tests, and benchmarks can be enabled for OSS, as in this PR.


Differential Revision: D80068135

Pulled By: q10


