### PR TITLE
allow multiple paths in ssd TBE passed_in_path

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -14,7 +14,6 @@ import itertools
 import logging
 import math
 import os
-import tempfile
 import threading
 import time
 from functools import cached_property
@@ -107,6 +106,8 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         embedding_specs: List[Tuple[int, int]],  # tuple of (rows, dims)
         feature_table_map: Optional[List[int]],  # [T]
         cache_sets: int,
+        # A comma-separated string, e.g. "/data00_nvidia0,/data01_nvidia0/", db shards
+        # will be placed in these paths round-robin.
         ssd_storage_directory: str,
         ssd_rocksdb_shards: int = 1,
         ssd_memtable_flush_period: int = -1,
@@ -151,8 +152,11 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         ps_client_thread_num: Optional[int] = None,
         ps_max_local_index_length: Optional[int] = None,
         tbe_unique_id: int = -1,
-        # in local test we need to use the pass in path for rocksdb creation
-        # in production we need to do it inside SSD mount path which will ignores the passed in path
+        # If set to True, will use `ssd_storage_directory` as the ssd paths.
+        # If set to False, will use the default ssd paths.
+        # In local test we need to use the pass in path for rocksdb creation
+        # fn production we could either use the default ssd mount points or explicity specify ssd
+        # mount points using `ssd_storage_directory`.
         use_passed_in_path: int = True,
         gather_ssd_cache_stats: Optional[bool] = False,
         stats_reporter_config: Optional[TBEStatsReporterConfig] = None,
@@ -522,11 +526,12 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             self.record_function_via_dummy_profile_factory(use_dummy_profile)
         )
 
-        os.makedirs(ssd_storage_directory, exist_ok=True)
+        if use_passed_in_path:
+            ssd_dir_list = ssd_storage_directory.split(",")
+            for ssd_dir in ssd_dir_list:
+                os.makedirs(ssd_dir, exist_ok=True)
 
-        ssd_directory = tempfile.mkdtemp(
-            prefix="ssd_table_batched_embeddings", dir=ssd_storage_directory
-        )
+        ssd_directory = ssd_storage_directory
         # logging.info("DEBUG: weights_precision {}".format(weights_precision))
 
         """

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -305,8 +305,9 @@ CheckpointHandle::CheckpointHandle(
   CHECK_GT(num_shards, 0);
   shard_checkpoints_.reserve(num_shards);
   for (auto shard = 0; shard < num_shards; ++shard) {
+    std::string curr_base_path = db->paths_[shard % db->paths_.size()];
     auto rocksdb_path = kv_db_utils::get_rocksdb_path(
-        base_path, shard, tbe_uuid, use_default_ssd_path);
+        curr_base_path, shard, tbe_uuid, use_default_ssd_path);
     auto checkpoint_shard_dir =
         kv_db_utils::get_rocksdb_checkpoint_dir(shard, rocksdb_path);
     kv_db_utils::create_dir(checkpoint_shard_dir);
@@ -323,6 +324,8 @@ CheckpointHandle::CheckpointHandle(
                   << s.ToString();
     shard_checkpoints_.push_back(checkpoint_shard_path);
   }
+
+  XLOG(INFO) << "rocksdb checkpoint shards paths: " << shard_checkpoints_;
 }
 
 std::vector<std::string> CheckpointHandle::get_shard_checkpoints() const {

--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
@@ -685,7 +685,7 @@ class SSDSplitTableBatchedEmbeddingsTest(unittest.TestCase):
             emb = SSDTableBatchedEmbeddingBags(
                 embedding_specs=[(E, D) for (E, D) in zip(Es, Ds)],
                 feature_table_map=feature_table_map,
-                ssd_storage_directory=tempfile.mkdtemp(),
+                ssd_storage_directory=f"{tempfile.mkdtemp()},{tempfile.mkdtemp()}",
                 cache_sets=cache_sets,
                 ssd_uniform_init_lower=-0.1,
                 ssd_uniform_init_upper=0.1,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1716

change meaning of SSD TBE parameter `ssd_storage_directory`. Machines could have different ssd mount points, this patch allows the user to pass in the actual mount points to ssd TBE.

## before:
a single path

## after:
a comma-separated string of paths. rocks db shards will be placed in these paths in a round-robin fashion.

Reviewed By: duduyi2013

Differential Revision: D79929690


