### PR TITLE
align output type

### DIFF
--- a/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
@@ -1640,7 +1640,11 @@ def matmul_fp8_row_meta(
     """Shape function for torch compile."""
     M, K = a.shape
     N, K = b.shape
-    return torch.empty((M, N), device=a.device, dtype=torch.bfloat16)
+    return torch.empty(
+        (M, N),
+        device=a.device,
+        dtype=torch.bfloat16 if dot_out_dtype is None else dot_out_dtype,
+    )
 
 
 # pruned some unreasonable config


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1723

As titled - the output data type should not be hard coded as bfloat16.

Differential Revision: D80205121


