### PR TITLE
Enable USE_FBGEMM_GENAI

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
@@ -12,7 +12,6 @@
 #include <tuple>
 
 #include <ATen/core/Tensor.h>
-#include <ATen/hip/HIPContext.h>
 #include <c10/hip/HIPStream.h>
 
 #include "ck/ck.hpp"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1728

In this diff we enable the support for the new FBGEMM backed FP8 _scaled_grouped_mm on ROCm. For now we only enable support for gfx942 as that is what we have thoroughly tested performance and correctness on.

Differential Revision: D79564024


