### PR TITLE
[ROCm] remove hipify work-around that is no longer needed

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/kernel_launcher.cuh
@@ -266,20 +266,10 @@ struct KernelLauncher {
         context.description(),
         " CUDA Error: ",
         cudaGetErrorString(cuda_error),
-#ifdef __HIPCC__
-        // c10::cuda::get_cuda_error_help has only been recently added to
-        // Torch HIPify mappings, so wrap with __HIPCC__ until the mapping land
-        // in PyTorch OSS.
-        //
-        // TODO: Remove when HIPify mappings are updated in PyTorch OSS
-        // c10::hip::get_hip_error_help(cuda_error),
-        c10::hip::get_hip_check_suffix(),
-#else
         // TODO: Re-enable when xformers is updated to use a more recent
         // version of PyTorch
         // c10::cuda::get_cuda_error_help(cuda_error),
         c10::cuda::get_cuda_check_suffix(),
-#endif
         "\n",
         c10::cuda::c10_retrieve_device_side_assertion_info());
   }


### PR DESCRIPTION
kernel_launch.cuh had __HIPCC__ ifdef workaround for a missing hipify mapping in upstream pytorch but the mapping exists now for some time.

Removing this is also necessary to work with hipify v2 changes, as well.