### PR TITLE
Fix arm64 issues (#4680)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,9 @@ else(MSVC)
   set(MSVC_BOOL False)
   check_cxx_compiler_flag(-mavx2 COMPILER_SUPPORTS_AVX2)
   check_cxx_compiler_flag(-mavx512f COMPILER_SUPPORTS_AVX512)
+  check_cxx_compiler_flag(-march=armv8-a+sve COMPILER_SUPPORTS_SVE)
+  check_cxx_compiler_flag(-march=armv8-a+sve2 COMPILER_SUPPORTS_SVE2)
+  check_cxx_compiler_flag(-march=armv8-a+fp16fml COMPILER_SUPPORTS_FP16FML)
 endif(MSVC)
 
 ################################################################################
@@ -181,6 +184,10 @@ if(FBGEMM_LIBRARY_TYPE STREQUAL STATIC)
   list(APPEND fbgemm_generic_defs FBGEMM_STATIC)
 endif()
 list(REMOVE_ITEM fbgemm_generic_defs "FBGEMM_ENABLE_KLEIDIAI")
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64|arm64")
+  set(fbgemm_generic_defs ${fbgemm_generic_defs} FBGEMM_ENABLE_KLEIDIAI)
+endif()
 
 cpp_library(
   PREFIX
@@ -285,6 +292,10 @@ endif()
 ################################################################################
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64|arm64")
+  if(NOT COMPILER_SUPPORTS_FP16FML)
+    message(FATAL_ERROR "The current compiler does not support building FP16FML code")
+  endif()
+
   message(STATUS "Processor is ${CMAKE_SYSTEM_PROCESSOR}; will build Neon target")
 
   get_filelist("get_fbgemm_inline_neon_srcs(msvc=${MSVC_BOOL})" FBGEMM_NEON_SRCS)
@@ -300,6 +311,7 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64|arm64")
       -ftree-vectorize
       -fno-trapping-math
       -Wignored-qualifiers
+      -march=armv8-a+fp16fml
     DEFINITIONS
       ${fbgemm_arm_defs}
     DEPS
@@ -318,7 +330,18 @@ endif()
 # FBGEMM SVE Target
 ################################################################################
 
+set(FBGEMM_BUILD_SVE False)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64")
+  if(COMPILER_SUPPORTS_SVE2)
+    set(FBGEMM_BUILD_SVE True)
+    set(fbgemm_sve_flags "-march=armv8-a+sve2")
+  elseif(COMPILER_SUPPORTS_SVE)
+    set(FBGEMM_BUILD_SVE True)
+    set(fbgemm_sve_flags "-march=armv8-a+sve")
+  endif()
+endif()
+
+if(FBGEMM_BUILD_SVE)
   message(STATUS "Processor is ${CMAKE_SYSTEM_PROCESSOR}; will build SVE target")
 
   get_filelist("get_fbgemm_inline_sve_srcs(msvc=${MSVC_BOOL})" FBGEMM_SVE_SRCS)
@@ -334,6 +357,9 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64")
       -ftree-vectorize
       -fno-trapping-math
       -Wignored-qualifiers
+      -Wno-inline-asm
+      -Wno-asm-operand-widths
+      ${fbgemm_sve_flags}
     DEFINITIONS
       ${fbgemm_arm_defs}
     DEPS

--- a/defs.bzl
+++ b/defs.bzl
@@ -187,8 +187,6 @@ def get_fbgemm_inline_avx512_srcs(msvc = False, buck = False):
 def get_fbgemm_inline_sve_srcs(msvc = False, buck = False):
     srcs = [
         "src/FbgemmFP16UKernelsSve128.cc",
-        "src/KleidiAIFP16UKernelsNeon.cc",
-        "src/QuantUtilsNeon.cc",
         "src/UtilsSve.cc",
         "src/FbgemmFloat16ConvertSVE.cc",
     ]
@@ -214,12 +212,17 @@ def get_fbgemm_inline_neon_srcs(msvc = False, buck = False):
     intrinsics_srcs = ["src/UtilsNeon.cc"]
 
     # FP16 kernels contain inline assembly and inline assembly syntax for MSVC is different.
-    asm_srcs = ["src/UtilsNeon.cc"]
+    asm_srcs = [
+        "src/UtilsNeon.cc",
+        "src/KleidiAIFP16UKernelsNeon.cc",
+        "src/fp32/KleidiAIFP32UKernelsNeon.cc",
+        "src/QuantUtilsNeon.cc",
+    ]
     if buck:
         return select({
             "DEFAULT": asm_srcs,
             "ovr_config//compiler:cl": intrinsics_srcs,
-            "ovr_config//cpu:arm64": intrinsics_srcs,
+            "ovr_config//cpu:arm64": asm_srcs,
         })
     return asm_srcs if not msvc else intrinsics_srcs
 

--- a/src/FbgemmFP16.cc
+++ b/src/FbgemmFP16.cc
@@ -45,24 +45,21 @@ constexpr kernel_array_t<float16> kernel_fp16_avx2 = {
 #endif
 };
 
-#ifndef FBGEMM_ENABLE_KLEIDIAI
+#if defined(__aarch64__) && defined(FBGEMM_ENABLE_FP16_SVE128)
 constexpr kernel_array_t<float16> kernel_fp16_sve128 = {
     nullptr,
-#if defined(__aarch64__) && __ARM_FEATURE_SVE
     gemmkernel_1x2_Sve128_fp16_fA0fB0fC0,
     gemmkernel_2x2_Sve128_fp16_fA0fB0fC0,
     gemmkernel_3x2_Sve128_fp16_fA0fB0fC0,
     gemmkernel_4x2_Sve128_fp16_fA0fB0fC0,
     gemmkernel_5x2_Sve128_fp16_fA0fB0fC0,
     gemmkernel_6x2_Sve128_fp16_fA0fB0fC0,
-#else
     nullptr,
     nullptr,
     nullptr,
     nullptr,
     nullptr,
     nullptr,
-#endif
 };
 #endif
 
@@ -130,24 +127,29 @@ const isa_descriptor<float16>& getIsaHandlers(inst_set_t isa) {
       std::make_tuple(kernel_fp16_avx512, partition_avx512);
   static isa_descriptor<float16> avx512_256_descriptor =
       std::make_tuple(kernel_fp16_avx512_256, partition_avx512);
+#ifdef __aarch64__
 #ifdef FBGEMM_ENABLE_KLEIDIAI
   static isa_descriptor<float16> neon_descriptor =
       std::make_tuple(kernel_fp16_neon, partition_neon);
-#else
+#endif
+#ifdef FBGEMM_ENABLE_FP16_SVE128
   static isa_descriptor<float16> sve128_descriptor =
       std::make_tuple(kernel_fp16_sve128, partition_sve128);
+#endif
 #endif
 
   switch (isa) {
     case inst_set_t::sve:
+#ifdef __aarch64__
+#ifdef FBGEMM_ENABLE_FP16_SVE128
+      return sve128_descriptor;
+#endif
+    case inst_set_t::anyarch:
 #ifdef FBGEMM_ENABLE_KLEIDIAI
       return neon_descriptor;
 #else
-      return sve128_descriptor;
-#endif
-#ifdef __aarch64__
-    case inst_set_t::anyarch:
       throw std::runtime_error("Unsupported uArch");
+#endif
 #else
     case inst_set_t::anyarch:
 #endif

--- a/src/fp32/FbgemmFP32.cc
+++ b/src/fp32/FbgemmFP32.cc
@@ -119,12 +119,13 @@ const isa_descriptor<float>& getIsaHandlers(inst_set_t isa) {
 
   switch (isa) {
     case inst_set_t::sve:
-#ifdef FBGEMM_ENABLE_KLEIDIAI
-      return neon_descriptor;
-#endif
 #ifdef __aarch64__
     case inst_set_t::anyarch:
+#ifdef FBGEMM_ENABLE_KLEIDIAI
+      return neon_descriptor;
+#else
       throw std::runtime_error("Unsupported uArch");
+#endif
 #else
     case inst_set_t::anyarch:
 #endif


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1734

Partly fixes problems in https://github.com/pytorch/FBGEMM/issues/4679 

1. SVE and NEON are distinct instruction sets. If you have SVE you should not select NEON isa handlers for performance.
2. otoh NEON is alway present on modern aarch64 (as avx2 for x86). So it should be selected if SVE is not present.
3. defs.bzl listed some NEON sources as SVE sources, I corrected them.
4. FBGEMM_ENABLE_KLEIDIAI needs to be defined for generic sources, for getIsaHandler function to know that the NEON handler is present.
5. After that the tests can be enabled, though the performance seems not worth the effort.. currently

..and then it works on my machine™

Depends on https://github.com/pytorch/FBGEMM/issues/4666 so we don't have to fix FP32 again


Reviewed By: cthi

Differential Revision: D80134401

Pulled By: q10


