### PR TITLE
Enable fp32 tests for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,18 +143,6 @@ endif()
 # Prepare Sources
 ################################################################################
 
-if(NOT MSVC)
-  set_source_files_properties(
-    src/FbgemmFP16UKernelsAvx2.cc
-    src/FbgemmFP16UKernelsAvx512.cc
-    src/FbgemmFP16UKernelsAvx512_256.cc
-    src/fp32/FbgemmFP32UKernelsAvx2.cc
-    src/fp32/FbgemmFP32UKernelsAvx512.cc
-    src/fp32/FbgemmFP32UKernelsAvx512_256.cc
-    PROPERTIES COMPILE_FLAGS "-masm=intel")
-
-endif()
-
 set(fbgemm_arm_defs)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64|arm64")
   set(fbgemm_arm_defs
@@ -170,9 +158,6 @@ endif()
 ################################################################################
 
 get_filelist("get_fbgemm_generic_srcs(with_base=True)" FBGEMM_GENERIC_SRCS)
-if(MSVC)
-  list(FILTER FBGEMM_GENERIC_SRCS EXCLUDE REGEX "src/fp32/.*\\.cc$")
-endif()
 
 set(fbgemm_generic_defs "${fbgemm_arm_defs}")
 if(FBGEMM_LIBRARY_TYPE STREQUAL STATIC)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -102,11 +102,6 @@ if(FBGEMM_BUILD_BENCHMARKS)
     list(FILTER BENCH_LIST EXCLUDE REGEX "quantize")
   endif()
 
-  if(MSVC)
-    # NOTE: Skip FP32 benchmark for MSVC until intrinsic kernels are implemented
-    list(FILTER BENCH_LIST EXCLUDE REGEX "FP32Benchmark\\.cc$")
-  endif()
-
   foreach(BENCH_FILE ${BENCH_LIST})
     get_filename_component(BENCH_NAME ${BENCH_FILE} NAME_WE)
     get_filename_component(BENCH_FILENAME ${BENCH_FILE} NAME)

--- a/defs.bzl
+++ b/defs.bzl
@@ -56,8 +56,10 @@ def get_fbgemm_generic_srcs(with_base = False, msvc = False, buck = False):
         "src/FbgemmSparseDense.cc",
         "src/FbgemmI8Spmdm.cc",
         "src/FbgemmPackMatrixB.cc",
+        "src/fp32/FbgemmFP32.cc",
         "src/GenerateKernelDirectConvU8S8S32ACC32.cc",
         "src/GenerateKernel.cc",
+        "src/GenerateKernelFP16FP32.cc",
         "src/GenerateKernelU8S8S32ACC16.cc",
         "src/GenerateKernelU8S8S32ACC16Avx512.cc",  # Acc16 AVX512 JIT code gen
         "src/GenerateKernelU8S8S32ACC16Avx512VNNI.cc",
@@ -82,17 +84,7 @@ def get_fbgemm_generic_srcs(with_base = False, msvc = False, buck = False):
         "src/TransposeUtils.cc",
     ] + (get_fbgemm_base_srcs() if with_base else [])
 
-    fp32sources = [
-        "src/fp32/FbgemmFP32.cc",
-    ]
-
-    if buck:
-        return select({
-            "DEFAULT": sources + fp32sources,
-            "ovr_config//compiler:cl": sources,
-        })
-
-    return sources + fp32sources if not msvc else sources
+    return sources
 
 def get_fbgemm_public_headers():
     return [
@@ -188,23 +180,8 @@ def get_fbgemm_avx512_srcs():
     ]
 
 def get_fbgemm_inline_avx512_srcs(msvc = False, buck = False):
-    intrinsics_srcs = [
-        "src/FbgemmFP16UKernelsIntrinsicAvx512.cc",
-        "src/FbgemmFP16UKernelsIntrinsicAvx512_256.cc",
-    ]
-    asm_srcs = [
-        "src/FbgemmFP16UKernelsAvx512.cc",
-        "src/FbgemmFP16UKernelsAvx512_256.cc",
-        "src/fp32/FbgemmFP32UKernelsAvx512.cc",
-        "src/fp32/FbgemmFP32UKernelsAvx512_256.cc",
-    ]
-    if buck:
-        return select({
-            "DEFAULT": asm_srcs,
-            "ovr_config//compiler:cl": intrinsics_srcs,
-            "ovr_config//cpu:arm64": intrinsics_srcs,
-        })
-    return asm_srcs if not msvc else intrinsics_srcs
+    # FP16/FP32 kernels are now JIT-generated via asmjit in GenerateKernelFP16FP32.cc
+    return []
 
 def get_fbgemm_inline_sve_srcs(msvc = False, buck = False):
     srcs = [

--- a/include/fbgemm/FbgemmFP16.h
+++ b/include/fbgemm/FbgemmFP16.h
@@ -13,6 +13,7 @@
 
 #include <cpuinfo.h>
 
+#include "fbgemm/FbgemmFPCommon.h"
 #include "./FbgemmPackMatrixB.h" // @manual
 #include "./FloatConversion.h" // @manual
 #include "./Types.h" // @manual

--- a/src/FbgemmFP16.cc
+++ b/src/FbgemmFP16.cc
@@ -11,9 +11,9 @@
 #include <cmath>
 #include <utility>
 
-#include "./FbgemmFP16UKernelsAvx2.h" // @manual
-#include "./FbgemmFP16UKernelsAvx512.h" // @manual
-#include "./FbgemmFP16UKernelsAvx512_256.h" // @manual
+#ifndef __aarch64__
+#include "./GenerateKernelFP16FP32.h" // @manual
+#endif
 #ifdef __aarch64__
 #include "./FbgemmFP16UKernelsSve128.h" // @manual
 #endif
@@ -33,17 +33,12 @@ namespace {
 // 2 in ?x2 should be the same as kernel_ncol_blocks.
 // Here with kernel_ncol_blocks = 2, we can provide up to 6x2 kernels, due to
 // the restrictions of ymm register numbers (16).
-constexpr kernel_array_t<float16> kernel_fp16_avx2 = {
-    nullptr,
 #if !defined(__aarch64__)
-    gemmkernel_1x2_Avx2_fp16_fA0fB0fC0,
-    gemmkernel_2x2_Avx2_fp16_fA0fB0fC0,
-    gemmkernel_3x2_Avx2_fp16_fA0fB0fC0,
-    gemmkernel_4x2_Avx2_fp16_fA0fB0fC0,
-    gemmkernel_5x2_Avx2_fp16_fA0fB0fC0,
-    gemmkernel_6x2_Avx2_fp16_fA0fB0fC0
+const auto kernel_fp16_avx2 =
+    makeKernelArray<float16, inst_set_t::avx2>(1, 6);
+#else
+constexpr kernel_array_t<float16> kernel_fp16_avx2 = {nullptr};
 #endif
-};
 
 #if defined(__aarch64__) && defined(FBGEMM_ENABLE_FP16_SVE128)
 constexpr kernel_array_t<float16> kernel_fp16_sve128 = {
@@ -77,45 +72,20 @@ constexpr kernel_array_t<float16> kernel_fp16_neon = {
 };
 #endif
 
-constexpr kernel_array_t<float16> kernel_fp16_avx512_256 = {
-    nullptr,
 #if !defined(__aarch64__)
-    gemmkernel_1x2_Avx2_fp16_fA0fB0fC0,
-    gemmkernel_2x2_Avx2_fp16_fA0fB0fC0,
-    gemmkernel_3x2_Avx2_fp16_fA0fB0fC0,
-    gemmkernel_4x2_Avx2_fp16_fA0fB0fC0,
-    gemmkernel_5x2_Avx2_fp16_fA0fB0fC0,
-    gemmkernel_6x2_Avx2_fp16_fA0fB0fC0,
-    gemmkernel_7x2_Avx512_256_fp16_fA0fB0fC0,
-    gemmkernel_8x2_Avx512_256_fp16_fA0fB0fC0,
-    gemmkernel_9x2_Avx512_256_fp16_fA0fB0fC0,
-    gemmkernel_10x2_Avx512_256_fp16_fA0fB0fC0,
-    gemmkernel_11x2_Avx512_256_fp16_fA0fB0fC0,
-    gemmkernel_12x2_Avx512_256_fp16_fA0fB0fC0,
-    gemmkernel_13x2_Avx512_256_fp16_fA0fB0fC0,
-    gemmkernel_14x2_Avx512_256_fp16_fA0fB0fC0
-#endif
-};
+const kernel_array_t<float16> kernel_fp16_avx512_256 = []() {
+  auto k = makeKernelArray<float16, inst_set_t::avx2>(1, 6);
+  for (int n = 7; n <= 14; n++)
+    k[n] = generateGemmKernel<float16, inst_set_t::avx512_ymm>(n);
+  return k;
+}();
 
-constexpr kernel_array_t<float16> kernel_fp16_avx512 = {
-    nullptr,
-#if !defined(__aarch64__)
-    gemmkernel_1x2_Avx512_fp16_fA0fB0fC0,
-    gemmkernel_2x2_Avx512_fp16_fA0fB0fC0,
-    gemmkernel_3x2_Avx512_fp16_fA0fB0fC0,
-    gemmkernel_4x2_Avx512_fp16_fA0fB0fC0,
-    gemmkernel_5x2_Avx512_fp16_fA0fB0fC0,
-    gemmkernel_6x2_Avx512_fp16_fA0fB0fC0,
-    gemmkernel_7x2_Avx512_fp16_fA0fB0fC0,
-    gemmkernel_8x2_Avx512_fp16_fA0fB0fC0,
-    gemmkernel_9x2_Avx512_fp16_fA0fB0fC0,
-    gemmkernel_10x2_Avx512_fp16_fA0fB0fC0,
-    gemmkernel_11x2_Avx512_fp16_fA0fB0fC0,
-    gemmkernel_12x2_Avx512_fp16_fA0fB0fC0,
-    gemmkernel_13x2_Avx512_fp16_fA0fB0fC0,
-    gemmkernel_14x2_Avx512_fp16_fA0fB0fC0
+const auto kernel_fp16_avx512 =
+    makeKernelArray<float16, inst_set_t::avx512>(1, 14);
+#else
+constexpr kernel_array_t<float16> kernel_fp16_avx512_256 = {nullptr};
+constexpr kernel_array_t<float16> kernel_fp16_avx512 = {nullptr};
 #endif
-};
 
 } // namespace
 

--- a/src/FbgemmFP16UKernelsIntrinsicAvx2.cc
+++ b/src/FbgemmFP16UKernelsIntrinsicAvx2.cc
@@ -11,12 +11,24 @@
 #include <immintrin.h>
 #endif
 #include "./FbgemmFP16UKernelsAvx2.h" // @manual
+#include "./fp32/FbgemmFP32UKernelsAvx2.h" // @manual
 
 namespace fbgemm {
 
-// Intrinsic kernel for MSVC
-void gemmkernel_Avx2_fp16_fA0fB0fC0(
-    GemmParamsFP16* gp,
+namespace {
+
+inline __m256 load_b_avx2(const float16* addr) {
+  return _mm256_cvtph_ps(
+      _mm_load_si128(reinterpret_cast<const __m128i*>(addr)));
+}
+inline __m256 load_b_avx2(const float* addr) {
+  return _mm256_load_ps(addr);
+}
+
+// Intrinsic kernel for MSVC - shared between FP16 and FP32
+template <typename T>
+void gemmkernel_Avx2_fA0fB0fC0(
+    GemmParams<T>* gp,
     const size_t kernel_nrows) {
   // register buffer
   __m256 ymmSum[12];
@@ -35,9 +47,8 @@ void gemmkernel_Avx2_fp16_fA0fB0fC0(
     // inner loop - k
     for (uint64_t kk = 0; kk < gp->k; kk++) {
       // load B
-      __m256 ymmB0 = _mm256_cvtph_ps(_mm_load_si128((__m128i*)(gp->B + idxB)));
-      __m256 ymmB1 =
-          _mm256_cvtph_ps(_mm_load_si128((__m128i*)(gp->B + idxB + 8)));
+      __m256 ymmB0 = load_b_avx2(gp->B + idxB);
+      __m256 ymmB1 = load_b_avx2(gp->B + idxB + 8);
       idxB += 16;
 
       // first element
@@ -95,23 +106,46 @@ void gemmkernel_Avx2_fp16_fA0fB0fC0(
   }
 }
 
+} // anonymous namespace
+
+// FP16 kernels
 void NOINLINE gemmkernel_1x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx2_fp16_fA0fB0fC0(gp, 1);
+  gemmkernel_Avx2_fA0fB0fC0(gp, 1);
 }
 void NOINLINE gemmkernel_2x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx2_fp16_fA0fB0fC0(gp, 2);
+  gemmkernel_Avx2_fA0fB0fC0(gp, 2);
 }
 void NOINLINE gemmkernel_3x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx2_fp16_fA0fB0fC0(gp, 3);
+  gemmkernel_Avx2_fA0fB0fC0(gp, 3);
 }
 void NOINLINE gemmkernel_4x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx2_fp16_fA0fB0fC0(gp, 4);
+  gemmkernel_Avx2_fA0fB0fC0(gp, 4);
 }
 void NOINLINE gemmkernel_5x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx2_fp16_fA0fB0fC0(gp, 5);
+  gemmkernel_Avx2_fA0fB0fC0(gp, 5);
 }
 void NOINLINE gemmkernel_6x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx2_fp16_fA0fB0fC0(gp, 6);
+  gemmkernel_Avx2_fA0fB0fC0(gp, 6);
+}
+
+// FP32 kernels
+void NOINLINE gemmkernel_1x2_Avx2_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx2_fA0fB0fC0(gp, 1);
+}
+void NOINLINE gemmkernel_2x2_Avx2_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx2_fA0fB0fC0(gp, 2);
+}
+void NOINLINE gemmkernel_3x2_Avx2_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx2_fA0fB0fC0(gp, 3);
+}
+void NOINLINE gemmkernel_4x2_Avx2_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx2_fA0fB0fC0(gp, 4);
+}
+void NOINLINE gemmkernel_5x2_Avx2_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx2_fA0fB0fC0(gp, 5);
+}
+void NOINLINE gemmkernel_6x2_Avx2_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx2_fA0fB0fC0(gp, 6);
 }
 
 } // namespace fbgemm

--- a/src/FbgemmFP16UKernelsIntrinsicAvx512.cc
+++ b/src/FbgemmFP16UKernelsIntrinsicAvx512.cc
@@ -11,12 +11,24 @@
 #include <immintrin.h>
 #endif
 #include "./FbgemmFP16UKernelsAvx512.h" // @manual
+#include "./fp32/FbgemmFP32UKernelsAvx512.h" // @manual
 
 namespace fbgemm {
 
-// Intrinsic kernel for MSVC
-void gemmkernel_Avx512_fp16_fA0fB0fC0(
-    GemmParamsFP16* gp,
+namespace {
+
+inline __m512 load_b_avx512(const float16* addr) {
+  return _mm512_cvtph_ps(
+      _mm256_load_si256(reinterpret_cast<const __m256i*>(addr)));
+}
+inline __m512 load_b_avx512(const float* addr) {
+  return _mm512_load_ps(addr);
+}
+
+// Intrinsic kernel for MSVC - shared between FP16 and FP32
+template <typename T>
+void gemmkernel_Avx512_fA0fB0fC0(
+    GemmParams<T>* gp,
     const size_t kernel_nrows) {
   // register buffer
   __m512 zmmSum[28];
@@ -35,10 +47,8 @@ void gemmkernel_Avx512_fp16_fA0fB0fC0(
     // inner loop - k
     for (uint64_t kk = 0; kk < gp->k; kk++) {
       // load B
-      __m512 zmmB0 =
-          _mm512_cvtph_ps(_mm256_load_si256((__m256i*)(gp->B + idxB)));
-      __m512 zmmB1 =
-          _mm512_cvtph_ps(_mm256_load_si256((__m256i*)(gp->B + idxB + 16)));
+      __m512 zmmB0 = load_b_avx512(gp->B + idxB);
+      __m512 zmmB1 = load_b_avx512(gp->B + idxB + 16);
       idxB += 32;
 
       // first element
@@ -96,47 +106,94 @@ void gemmkernel_Avx512_fp16_fA0fB0fC0(
   }
 }
 
+} // anonymous namespace
+
+// FP16 kernels
 void NOINLINE gemmkernel_1x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 1);
+  gemmkernel_Avx512_fA0fB0fC0(gp, 1);
 }
 void NOINLINE gemmkernel_2x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 2);
+  gemmkernel_Avx512_fA0fB0fC0(gp, 2);
 }
 void NOINLINE gemmkernel_3x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 3);
+  gemmkernel_Avx512_fA0fB0fC0(gp, 3);
 }
 void NOINLINE gemmkernel_4x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 4);
+  gemmkernel_Avx512_fA0fB0fC0(gp, 4);
 }
 void NOINLINE gemmkernel_5x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 5);
+  gemmkernel_Avx512_fA0fB0fC0(gp, 5);
 }
 void NOINLINE gemmkernel_6x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 6);
+  gemmkernel_Avx512_fA0fB0fC0(gp, 6);
 }
 void NOINLINE gemmkernel_7x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 7);
+  gemmkernel_Avx512_fA0fB0fC0(gp, 7);
 }
 void NOINLINE gemmkernel_8x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 8);
+  gemmkernel_Avx512_fA0fB0fC0(gp, 8);
 }
 void NOINLINE gemmkernel_9x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 9);
+  gemmkernel_Avx512_fA0fB0fC0(gp, 9);
 }
 void NOINLINE gemmkernel_10x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 10);
+  gemmkernel_Avx512_fA0fB0fC0(gp, 10);
 }
 void NOINLINE gemmkernel_11x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 11);
+  gemmkernel_Avx512_fA0fB0fC0(gp, 11);
 }
 void NOINLINE gemmkernel_12x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 12);
+  gemmkernel_Avx512_fA0fB0fC0(gp, 12);
 }
 void NOINLINE gemmkernel_13x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 13);
+  gemmkernel_Avx512_fA0fB0fC0(gp, 13);
 }
 void NOINLINE gemmkernel_14x2_Avx512_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_fp16_fA0fB0fC0(gp, 14);
+  gemmkernel_Avx512_fA0fB0fC0(gp, 14);
+}
+
+// FP32 kernels
+void NOINLINE gemmkernel_1x2_Avx512_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_fA0fB0fC0(gp, 1);
+}
+void NOINLINE gemmkernel_2x2_Avx512_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_fA0fB0fC0(gp, 2);
+}
+void NOINLINE gemmkernel_3x2_Avx512_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_fA0fB0fC0(gp, 3);
+}
+void NOINLINE gemmkernel_4x2_Avx512_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_fA0fB0fC0(gp, 4);
+}
+void NOINLINE gemmkernel_5x2_Avx512_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_fA0fB0fC0(gp, 5);
+}
+void NOINLINE gemmkernel_6x2_Avx512_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_fA0fB0fC0(gp, 6);
+}
+void NOINLINE gemmkernel_7x2_Avx512_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_fA0fB0fC0(gp, 7);
+}
+void NOINLINE gemmkernel_8x2_Avx512_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_fA0fB0fC0(gp, 8);
+}
+void NOINLINE gemmkernel_9x2_Avx512_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_fA0fB0fC0(gp, 9);
+}
+void NOINLINE gemmkernel_10x2_Avx512_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_fA0fB0fC0(gp, 10);
+}
+void NOINLINE gemmkernel_11x2_Avx512_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_fA0fB0fC0(gp, 11);
+}
+void NOINLINE gemmkernel_12x2_Avx512_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_fA0fB0fC0(gp, 12);
+}
+void NOINLINE gemmkernel_13x2_Avx512_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_fA0fB0fC0(gp, 13);
+}
+void NOINLINE gemmkernel_14x2_Avx512_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_fA0fB0fC0(gp, 14);
 }
 
 } // namespace fbgemm

--- a/src/FbgemmFP16UKernelsIntrinsicAvx512_256.cc
+++ b/src/FbgemmFP16UKernelsIntrinsicAvx512_256.cc
@@ -11,12 +11,24 @@
 #include <immintrin.h>
 #endif
 #include "./FbgemmFP16UKernelsAvx512_256.h" // @manual
+#include "./fp32/FbgemmFP32UKernelsAvx512_256.h" // @manual
 
 namespace fbgemm {
 
-// Intrinsic kernel for MSVC
-void gemmkernel_Avx512_256_fp16_fA0fB0fC0(
-    GemmParamsFP16* gp,
+namespace {
+
+inline __m256 load_b_avx2(const float16* addr) {
+  return _mm256_cvtph_ps(
+      _mm_load_si128(reinterpret_cast<const __m128i*>(addr)));
+}
+inline __m256 load_b_avx2(const float* addr) {
+  return _mm256_load_ps(addr);
+}
+
+// Intrinsic kernel for MSVC - shared between FP16 and FP32
+template <typename T>
+void gemmkernel_Avx512_256_fA0fB0fC0(
+    GemmParams<T>* gp,
     const size_t kernel_nrows) {
   // register buffer
   __m256 ymmSum[28];
@@ -35,9 +47,8 @@ void gemmkernel_Avx512_256_fp16_fA0fB0fC0(
     // inner loop - k
     for (uint64_t kk = 0; kk < gp->k; kk++) {
       // load B
-      __m256 ymmB0 = _mm256_cvtph_ps(_mm_load_si128((__m128i*)(gp->B + idxB)));
-      __m256 ymmB1 =
-          _mm256_cvtph_ps(_mm_load_si128((__m128i*)(gp->B + idxB + 8)));
+      __m256 ymmB0 = load_b_avx2(gp->B + idxB);
+      __m256 ymmB1 = load_b_avx2(gp->B + idxB + 8);
       idxB += 16;
 
       // first element
@@ -95,29 +106,58 @@ void gemmkernel_Avx512_256_fp16_fA0fB0fC0(
   }
 }
 
+} // anonymous namespace
+
+// FP16 kernels
 void NOINLINE gemmkernel_7x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_256_fp16_fA0fB0fC0(gp, 7);
+  gemmkernel_Avx512_256_fA0fB0fC0(gp, 7);
 }
 void NOINLINE gemmkernel_8x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_256_fp16_fA0fB0fC0(gp, 8);
+  gemmkernel_Avx512_256_fA0fB0fC0(gp, 8);
 }
 void NOINLINE gemmkernel_9x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_256_fp16_fA0fB0fC0(gp, 9);
+  gemmkernel_Avx512_256_fA0fB0fC0(gp, 9);
 }
 void NOINLINE gemmkernel_10x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_256_fp16_fA0fB0fC0(gp, 10);
+  gemmkernel_Avx512_256_fA0fB0fC0(gp, 10);
 }
 void NOINLINE gemmkernel_11x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_256_fp16_fA0fB0fC0(gp, 11);
+  gemmkernel_Avx512_256_fA0fB0fC0(gp, 11);
 }
 void NOINLINE gemmkernel_12x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_256_fp16_fA0fB0fC0(gp, 12);
+  gemmkernel_Avx512_256_fA0fB0fC0(gp, 12);
 }
 void NOINLINE gemmkernel_13x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_256_fp16_fA0fB0fC0(gp, 13);
+  gemmkernel_Avx512_256_fA0fB0fC0(gp, 13);
 }
 void NOINLINE gemmkernel_14x2_Avx512_256_fp16_fA0fB0fC0(GemmParamsFP16* gp) {
-  gemmkernel_Avx512_256_fp16_fA0fB0fC0(gp, 14);
+  gemmkernel_Avx512_256_fA0fB0fC0(gp, 14);
+}
+
+// FP32 kernels
+void NOINLINE gemmkernel_7x2_Avx512_256_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_256_fA0fB0fC0(gp, 7);
+}
+void NOINLINE gemmkernel_8x2_Avx512_256_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_256_fA0fB0fC0(gp, 8);
+}
+void NOINLINE gemmkernel_9x2_Avx512_256_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_256_fA0fB0fC0(gp, 9);
+}
+void NOINLINE gemmkernel_10x2_Avx512_256_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_256_fA0fB0fC0(gp, 10);
+}
+void NOINLINE gemmkernel_11x2_Avx512_256_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_256_fA0fB0fC0(gp, 11);
+}
+void NOINLINE gemmkernel_12x2_Avx512_256_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_256_fA0fB0fC0(gp, 12);
+}
+void NOINLINE gemmkernel_13x2_Avx512_256_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_256_fA0fB0fC0(gp, 13);
+}
+void NOINLINE gemmkernel_14x2_Avx512_256_fp32_fA0fB0fC0(GemmParamsFP32* gp) {
+  gemmkernel_Avx512_256_fA0fB0fC0(gp, 14);
 }
 
 } // namespace fbgemm

--- a/src/GenerateKernelFP16FP32.cc
+++ b/src/GenerateKernelFP16FP32.cc
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "./GenerateKernelFP16FP32.h" // @manual
+
+#include <asmjit/core.h> // @manual
+#include <asmjit/x86.h> // @manual
+#include <cstddef>
+#include <mutex>
+#include <type_traits>
+
+#include "fbgemm/SimdUtils.h"
+#include "fbgemm/Types.h"
+
+namespace fbgemm {
+
+namespace {
+
+using namespace asmjit;
+
+JitRuntime& runtime() {
+  static JitRuntime rt;
+  return rt;
+}
+
+static std::mutex rtMutex_;
+
+// Create a vector register of the appropriate width for this ISA.
+template <inst_set_t instSet>
+x86::Vec makeVec(uint32_t id) {
+  constexpr int VEC_BYTES = simd_info<instSet>::WIDTH_BYTES;
+  if constexpr (VEC_BYTES == 64) {
+    return x86::Vec::make_v512(id);
+  } else {
+    return x86::Vec::make_v256(id);
+  }
+}
+
+// Emit a B-load instruction: FP16 uses vcvtph2ps, FP32 uses vmovups.
+// offset is in bytes from basePtr.
+template <typename T, inst_set_t instSet>
+void emitBLoad(
+    x86::Emitter* a,
+    x86::Vec dest,
+    const x86::Gp& basePtr,
+    int offset) {
+  constexpr int VEC_BYTES = simd_info<instSet>::WIDTH_BYTES;
+  if constexpr (std::is_same_v<T, float16>) {
+    if constexpr (VEC_BYTES == 32) {
+      // vcvtph2ps ymm, xmmword [mem] -- load 128-bit FP16 -> 256-bit FP32
+      a->vcvtph2ps(dest, x86::xmmword_ptr(basePtr, offset));
+    } else {
+      // vcvtph2ps zmm, ymmword [mem] -- load 256-bit FP16 -> 512-bit FP32
+      a->vcvtph2ps(dest, x86::ymmword_ptr(basePtr, offset));
+    }
+  } else {
+    if constexpr (VEC_BYTES == 32) {
+      a->vmovups(dest, x86::ymmword_ptr(basePtr, offset));
+    } else {
+      a->vmovups(dest, x86::zmmword_ptr(basePtr, offset));
+    }
+  }
+}
+
+template <typename T, inst_set_t instSet>
+funcptr_t<T> generateGemmKernelImpl(int kernel_nrows) {
+  constexpr int NUM_REGS = simd_info<instSet>::NUM_VEC_REGS;
+  constexpr int VEC_BYTES = simd_info<instSet>::WIDTH_BYTES;
+  constexpr int VEC_ELEMS = simd_info<instSet>::WIDTH_32BIT_ELEMS;
+  constexpr bool is_fp16 = std::is_same_v<T, float16>;
+  // B stride in bytes per k-iteration: 2 vectors worth of T elements
+  constexpr int B_STRIDE_BYTES = 2 * VEC_ELEMS * static_cast<int>(sizeof(T));
+  // C stride in bytes to advance to next block column: 2 vectors of floats
+  constexpr int C_STRIDE_BYTES = 2 * VEC_BYTES;
+  // B half-vector size in bytes (for second vector load offset)
+  constexpr int B_VEC_BYTES = is_fp16 ? (VEC_BYTES / 2) : VEC_BYTES;
+
+  // Vector register assignment
+  // Accumulators: vec[0 .. 2*nrows-1]
+  const int aRegId = 2 * kernel_nrows;
+  const int bReg0Id = 2 * kernel_nrows + 1;
+  const int bReg1Id = 2 * kernel_nrows + 2;
+  const int betaRegId = NUM_REGS - 1;
+
+  x86::Vec aReg = makeVec<instSet>(aRegId);
+  x86::Vec bReg0 = makeVec<instSet>(bReg0Id);
+  x86::Vec bReg1 = makeVec<instSet>(bReg1Id);
+  x86::Vec betaReg = makeVec<instSet>(betaRegId);
+
+  CodeHolder code;
+  code.init(runtime().environment());
+  x86::Assembler assembler(&code);
+  x86::Emitter* a = assembler.as<x86::Emitter>();
+
+  // Function signature: void(GemmParams<T>*)
+  FuncDetail func;
+  func.init(
+      FuncSignature::build<void, GemmParams<T>*>(), a->environment());
+
+  FuncFrame frame;
+  frame.init(func);
+
+  // Mark all used vector regs as dirty
+  uint32_t dirtyVecRegs =
+      Support::bitMask(0, 1, 2, 3, 4, 5, 6, 7) |
+      Support::bitMask(8, 9, 10, 11, 12, 13, 14, 15);
+  if constexpr (NUM_REGS > 16) {
+    dirtyVecRegs |=
+        Support::bitMask(16, 17, 18, 19, 20, 21, 22, 23) |
+        Support::bitMask(24, 25, 26, 27, 28, 29, 30, 31);
+  }
+  frame.setDirtyRegs(RegGroup::kVec, dirtyVecRegs);
+
+  // GP registers we use (callee-saved ones need to be declared dirty)
+  frame.setDirtyRegs(
+      RegGroup::kGp,
+      Support::bitMask(0, 1, 2, 3, 6, 7) | // rax, rcx, rdx, rbx, rsi, rdi
+          Support::bitMask(8, 9, 10, 11, 12, 13, 14, 15));
+
+  // Function argument: GemmParams<T>* in a GP register
+  const x86::Gp gpReg = a->gpz(0); // rax temporarily, reassigned by asmjit
+  FuncArgsAssignment args(&func);
+  args.assignAll(gpReg);
+  args.updateFuncFrame(frame);
+  frame.finalize();
+
+  a->emitProlog(frame);
+  a->emitArgsAssignment(frame, args);
+
+  // GP register allocation
+  const x86::Gp& kReg = a->gpz(8); // r8: k
+  const x86::Gp& APtr = a->gpz(9); // r9: A pointer
+  const x86::Gp& BPtr = a->gpz(10); // r10: B pointer
+  const x86::Gp& CPtr = a->gpz(12); // r12: C pointer
+  const x86::Gp& ldcReg = a->gpz(13); // r13: ldc (in bytes)
+  const x86::Gp& betaPtr = a->gpz(15); // r15: &beta
+  const x86::Gp& bColsReg = a->gpz(7); // rdi: b_block_cols
+  const x86::Gp& ASaved = a->gpz(1); // rcx: saved A base
+  const x86::Gp& CSaved = a->gpz(2); // rdx: saved C base
+  const x86::Gp& outerIdx = a->gpz(3); // rbx: outer loop counter
+  const x86::Gp& innerIdx = a->gpz(14); // r14: inner loop counter
+
+  // Load GemmParams fields from struct pointer (gpReg = rax)
+  a->mov(kReg, x86::qword_ptr(gpReg, offsetof(GemmParams<T>, k)));
+  a->mov(APtr, x86::qword_ptr(gpReg, offsetof(GemmParams<T>, A)));
+  a->mov(BPtr, x86::qword_ptr(gpReg, offsetof(GemmParams<T>, B)));
+  a->lea(betaPtr, x86::ptr(gpReg, offsetof(GemmParams<T>, beta)));
+  a->mov(CPtr, x86::qword_ptr(gpReg, offsetof(GemmParams<T>, C)));
+  a->mov(ldcReg, x86::qword_ptr(gpReg, offsetof(GemmParams<T>, ldc)));
+  a->mov(
+      bColsReg,
+      x86::qword_ptr(gpReg, offsetof(GemmParams<T>, b_block_cols)));
+
+  // Save base pointers
+  a->mov(ASaved, APtr);
+  a->mov(CSaved, CPtr);
+
+  // ====== Outer loop (over b_block_cols) ======
+  a->xor_(outerIdx.r32(), outerIdx.r32());
+
+  Label loopOuter = a->newLabel();
+  Label loopEnd = a->newLabel();
+
+  a->bind(loopOuter);
+  a->cmp(outerIdx, bColsReg);
+  a->jge(loopEnd);
+
+  // Reset A for each column block
+  a->mov(APtr, ASaved);
+
+  // innerIdx = k - 1 (peel first iteration)
+  a->mov(innerIdx, kReg);
+  a->dec(innerIdx);
+
+  // Broadcast beta
+  a->vbroadcastss(betaReg, x86::dword_ptr(betaPtr));
+
+  // Load first B pair
+  emitBLoad<T, instSet>(a, bReg0, BPtr, 0);
+  emitBLoad<T, instSet>(a, bReg1, BPtr, B_VEC_BYTES);
+
+  // Check if beta == 0
+  x86::Vec xmmZero = x86::Vec::make_v128(aRegId);
+  a->vxorps(xmmZero, xmmZero, xmmZero);
+  a->vucomiss(x86::Vec::make_v128(betaRegId), xmmZero);
+
+  Label zeroRegs = a->newLabel();
+  Label innerLoopEntry = a->newLabel();
+  Label innerLoop = a->newLabel();
+  Label dumpC = a->newLabel();
+
+  a->je(zeroRegs);
+
+  // ------ First k iteration, beta != 0 ------
+  // Load C rows and multiply by beta, then FMA with A*B
+  {
+    x86::Gp tempC = a->gpz(11); // r11 as temp for C row pointer
+    a->mov(tempC, CPtr);
+    for (int jj = 0; jj < kernel_nrows; jj++) {
+      // C_row0 = beta * C[jj*ldc + 0..VEC_ELEMS-1]
+      a->vmulps(makeVec<instSet>(2 * jj), betaReg, x86::ptr(tempC, 0));
+      // C_row1 = beta * C[jj*ldc + VEC_ELEMS..2*VEC_ELEMS-1]
+      a->vmulps(
+          makeVec<instSet>(2 * jj + 1),
+          betaReg,
+          x86::ptr(tempC, VEC_BYTES));
+      if (jj < kernel_nrows - 1) {
+        a->add(tempC, ldcReg);
+      }
+    }
+    // FMA: accum += A[jj] * B
+    for (int jj = 0; jj < kernel_nrows; jj++) {
+      a->vbroadcastss(
+          aReg, x86::dword_ptr(APtr, jj * static_cast<int>(sizeof(float))));
+      a->vfmadd231ps(makeVec<instSet>(2 * jj), aReg, bReg0);
+      a->vfmadd231ps(makeVec<instSet>(2 * jj + 1), aReg, bReg1);
+    }
+    a->add(APtr, kernel_nrows * static_cast<int>(sizeof(float)));
+    a->add(BPtr, B_STRIDE_BYTES);
+  }
+
+  // Check if k > 1
+  a->test(innerIdx, innerIdx);
+  a->jnz(innerLoopEntry);
+  a->jmp(dumpC);
+
+  // ------ First k iteration, beta == 0 ------
+  a->bind(zeroRegs);
+  {
+    for (int jj = 0; jj < kernel_nrows; jj++) {
+      a->vbroadcastss(
+          aReg, x86::dword_ptr(APtr, jj * static_cast<int>(sizeof(float))));
+      a->vmulps(makeVec<instSet>(2 * jj), aReg, bReg0);
+      a->vmulps(makeVec<instSet>(2 * jj + 1), aReg, bReg1);
+    }
+    a->add(APtr, kernel_nrows * static_cast<int>(sizeof(float)));
+    a->add(BPtr, B_STRIDE_BYTES);
+  }
+
+  a->test(innerIdx, innerIdx);
+  a->jz(dumpC);
+
+  // ------ Inner loop (k iterations 2..k) ------
+  a->bind(innerLoopEntry);
+  a->bind(innerLoop);
+  {
+    // Load next B pair
+    emitBLoad<T, instSet>(a, bReg0, BPtr, 0);
+    emitBLoad<T, instSet>(a, bReg1, BPtr, B_VEC_BYTES);
+
+    // FMA: accum += A[jj] * B
+    for (int jj = 0; jj < kernel_nrows; jj++) {
+      a->vbroadcastss(
+          aReg, x86::dword_ptr(APtr, jj * static_cast<int>(sizeof(float))));
+      a->vfmadd231ps(makeVec<instSet>(2 * jj), aReg, bReg0);
+      a->vfmadd231ps(makeVec<instSet>(2 * jj + 1), aReg, bReg1);
+    }
+    a->add(APtr, kernel_nrows * static_cast<int>(sizeof(float)));
+    a->add(BPtr, B_STRIDE_BYTES);
+
+    a->dec(innerIdx);
+    a->jnz(innerLoop);
+  }
+
+  // ------ Store C ------
+  a->bind(dumpC);
+  {
+    x86::Gp tempC = a->gpz(11); // r11
+    a->mov(tempC, CPtr);
+    for (int jj = 0; jj < kernel_nrows; jj++) {
+      a->vmovups(x86::ptr(tempC, 0), makeVec<instSet>(2 * jj));
+      a->vmovups(x86::ptr(tempC, VEC_BYTES), makeVec<instSet>(2 * jj + 1));
+      if (jj < kernel_nrows - 1) {
+        a->add(tempC, ldcReg);
+      }
+    }
+  }
+
+  // Advance C to next block column
+  a->add(CPtr, C_STRIDE_BYTES);
+
+  // Increment outer counter
+  a->inc(outerIdx);
+  a->jmp(loopOuter);
+
+  // ====== End ======
+  a->bind(loopEnd);
+  a->emitEpilog(frame);
+
+  funcptr_t<T> fn = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(rtMutex_);
+    Error err = runtime().add(&fn, &code);
+    if (err) {
+      return nullptr;
+    }
+  }
+  return fn;
+}
+
+} // anonymous namespace
+
+template <typename T, inst_set_t instSet>
+funcptr_t<T> generateGemmKernel(int kernel_nrows) {
+  return generateGemmKernelImpl<T, instSet>(kernel_nrows);
+}
+
+// Explicit template instantiations
+// FP16
+template funcptr_t<float16>
+generateGemmKernel<float16, inst_set_t::avx2>(int);
+template funcptr_t<float16>
+generateGemmKernel<float16, inst_set_t::avx512>(int);
+template funcptr_t<float16>
+generateGemmKernel<float16, inst_set_t::avx512_ymm>(int);
+
+// FP32
+template funcptr_t<float> generateGemmKernel<float, inst_set_t::avx2>(int);
+template funcptr_t<float> generateGemmKernel<float, inst_set_t::avx512>(int);
+template funcptr_t<float>
+generateGemmKernel<float, inst_set_t::avx512_ymm>(int);
+
+} // namespace fbgemm

--- a/src/GenerateKernelFP16FP32.h
+++ b/src/GenerateKernelFP16FP32.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbgemm/FbgemmFPCommon.h"
+#include "fbgemm/Utils.h"
+
+namespace fbgemm {
+
+/// Generate a JIT-compiled GEMM micro-kernel for the given ISA and data type.
+/// Returns a function pointer matching funcptr_t<T>.
+/// Thread-safe: uses static local for lazy one-time generation.
+template <typename T, inst_set_t instSet>
+funcptr_t<T> generateGemmKernel(int kernel_nrows);
+
+/// Build a kernel_array_t by JIT-generating kernels for rows [from, to].
+template <typename T, inst_set_t instSet>
+kernel_array_t<T> makeKernelArray(int from, int to) {
+  kernel_array_t<T> k{};
+  for (int n = from; n <= to; n++)
+    k[n] = generateGemmKernel<T, instSet>(n);
+  return k;
+}
+
+} // namespace fbgemm

--- a/src/fp32/FbgemmFP32.cc
+++ b/src/fp32/FbgemmFP32.cc
@@ -12,9 +12,7 @@
 #include <utility>
 
 #ifndef __aarch64__
-#include "./FbgemmFP32UKernelsAvx2.h" // @manual
-#include "./FbgemmFP32UKernelsAvx512.h" // @manual
-#include "./FbgemmFP32UKernelsAvx512_256.h" // @manual
+#include "../GenerateKernelFP16FP32.h" // @manual
 #else
 #ifdef FBGEMM_ENABLE_KLEIDIAI
 #include "./KleidiAIFP32UKernelsNeon.h" // @manual
@@ -31,60 +29,23 @@ namespace {
 // 2 in ?x2 should be the same as kernel_ncol_blocks.
 // Here with kernel_ncol_blocks = 2, we can provide up to 6x2 kernels, due to
 // the restrictions of ymm register numbers (16).
-constexpr kernel_array_t<float> kernel_f32_avx2 = {
 #ifndef __aarch64__
-    nullptr,
-    gemmkernel_1x2_Avx2_fp32_fA0fB0fC0,
-    gemmkernel_2x2_Avx2_fp32_fA0fB0fC0,
-    gemmkernel_3x2_Avx2_fp32_fA0fB0fC0,
-    gemmkernel_4x2_Avx2_fp32_fA0fB0fC0,
-    gemmkernel_5x2_Avx2_fp32_fA0fB0fC0,
-    gemmkernel_6x2_Avx2_fp32_fA0fB0fC0};
-#else
-    nullptr};
-#endif
+const auto kernel_f32_avx2 =
+    makeKernelArray<float, inst_set_t::avx2>(1, 6);
 
-constexpr kernel_array_t<float> kernel_f32_avx512 = {
-#ifndef __aarch64__
-    nullptr,
-    gemmkernel_1x2_Avx512_fp32_fA0fB0fC0,
-    gemmkernel_2x2_Avx512_fp32_fA0fB0fC0,
-    gemmkernel_3x2_Avx512_fp32_fA0fB0fC0,
-    gemmkernel_4x2_Avx512_fp32_fA0fB0fC0,
-    gemmkernel_5x2_Avx512_fp32_fA0fB0fC0,
-    gemmkernel_6x2_Avx512_fp32_fA0fB0fC0,
-    gemmkernel_7x2_Avx512_fp32_fA0fB0fC0,
-    gemmkernel_8x2_Avx512_fp32_fA0fB0fC0,
-    gemmkernel_9x2_Avx512_fp32_fA0fB0fC0,
-    gemmkernel_10x2_Avx512_fp32_fA0fB0fC0,
-    gemmkernel_11x2_Avx512_fp32_fA0fB0fC0,
-    gemmkernel_12x2_Avx512_fp32_fA0fB0fC0,
-    gemmkernel_13x2_Avx512_fp32_fA0fB0fC0,
-    gemmkernel_14x2_Avx512_fp32_fA0fB0fC0};
-#else
-    nullptr};
-#endif
+const auto kernel_f32_avx512 =
+    makeKernelArray<float, inst_set_t::avx512>(1, 14);
 
-// clang-format on
-constexpr kernel_array_t<float> kernel_f32_avx512_256 = {
-#ifndef __aarch64__
-    nullptr,
-    gemmkernel_1x2_Avx2_fp32_fA0fB0fC0,
-    gemmkernel_2x2_Avx2_fp32_fA0fB0fC0,
-    gemmkernel_3x2_Avx2_fp32_fA0fB0fC0,
-    gemmkernel_4x2_Avx2_fp32_fA0fB0fC0,
-    gemmkernel_5x2_Avx2_fp32_fA0fB0fC0,
-    gemmkernel_6x2_Avx2_fp32_fA0fB0fC0,
-    gemmkernel_7x2_Avx512_256_fp32_fA0fB0fC0,
-    gemmkernel_8x2_Avx512_256_fp32_fA0fB0fC0,
-    gemmkernel_9x2_Avx512_256_fp32_fA0fB0fC0,
-    gemmkernel_10x2_Avx512_256_fp32_fA0fB0fC0,
-    gemmkernel_11x2_Avx512_256_fp32_fA0fB0fC0,
-    gemmkernel_12x2_Avx512_256_fp32_fA0fB0fC0,
-    gemmkernel_13x2_Avx512_256_fp32_fA0fB0fC0,
-    gemmkernel_14x2_Avx512_256_fp32_fA0fB0fC0};
+const kernel_array_t<float> kernel_f32_avx512_256 = []() {
+  auto k = makeKernelArray<float, inst_set_t::avx2>(1, 6);
+  for (int n = 7; n <= 14; n++)
+    k[n] = generateGemmKernel<float, inst_set_t::avx512_ymm>(n);
+  return k;
+}();
 #else
-    nullptr};
+constexpr kernel_array_t<float> kernel_f32_avx2 = {nullptr};
+constexpr kernel_array_t<float> kernel_f32_avx512 = {nullptr};
+constexpr kernel_array_t<float> kernel_f32_avx512_256 = {nullptr};
 #endif
 
 #ifdef __aarch64__
@@ -179,7 +140,7 @@ FBGEMM_API void ref_kernel<float>(
 }
 #endif // FBGEMM_FP32_FALLBACK_TO_REF_KERNEL
 
-template void cblas_gemm_compute(
+template FBGEMM_API void cblas_gemm_compute(
     const matrix_op_t transa,
     const int m,
     const float* A,

--- a/test/FBGemmFPTest.h
+++ b/test/FBGemmFPTest.h
@@ -18,6 +18,7 @@
 #include "bench/AlignedVec.h" // @manual
 #include "bench/BenchUtils.h" // @manual
 #include "fbgemm/FbgemmPackMatrixB.h"
+#include "fbgemm/Utils.h"
 #include "src/RefImplementations.h" // @manual
 
 #ifdef USE_IACA
@@ -51,8 +52,7 @@ class FBGemmFPTest : public testing::TestWithParam<
   void TestRun() {
     auto shapes = GenShapes();
     float alpha = 1.f, beta = 0.f;
-    matrix_op_t atrans, btrans;
-    std::tie(atrans, btrans) = GetParam();
+    auto [atrans, btrans] = GetParam();
 
     for (const auto& s : shapes) {
       int m = s[0];
@@ -121,11 +121,16 @@ class FBGemmFPTest : public testing::TestWithParam<
     }
   }
 
+  void TestRunWithIsa(inst_set_t isa) {
+    fbgemmForceIsa(isa);
+    TestRun();
+    fbgemmForceIsa(inst_set_t::anyarch);
+  }
+
   void UnpackTestRun() {
     auto shapes = GenShapes();
     float alpha = 1.f, beta = 0.f;
-    matrix_op_t atrans, btrans;
-    std::tie(atrans, btrans) = GetParam();
+    auto [atrans, btrans] = GetParam();
 
     for (const auto& s : shapes) {
       int m = s[0];

--- a/test/FP16Test.cc
+++ b/test/FP16Test.cc
@@ -10,6 +10,7 @@
 
 #include "./FBGemmFPTest.h"
 #include "fbgemm/FbgemmFP16.h"
+#include "fbgemm/Utils.h"
 
 using FBGemmFP16Test = fbgemm::FBGemmFPTest<fbgemm::float16>;
 
@@ -30,4 +31,22 @@ TEST_P(FBGemmFP16Test, Test) {
 
 TEST_P(FBGemmFP16Test, Unpack) {
   UnpackTestRun();
+}
+
+TEST_P(FBGemmFP16Test, TestAvx2) {
+  TestRunWithIsa(fbgemm::inst_set_t::avx2);
+}
+
+TEST_P(FBGemmFP16Test, TestAvx512) {
+  if (!fbgemm::fbgemmHasAvx512Support()) {
+    GTEST_SKIP() << "AVX512 not supported on this CPU";
+  }
+  TestRunWithIsa(fbgemm::inst_set_t::avx512);
+}
+
+TEST_P(FBGemmFP16Test, TestAvx512_256) {
+  if (!fbgemm::fbgemmHasAvx512Support()) {
+    GTEST_SKIP() << "AVX512 not supported on this CPU";
+  }
+  TestRunWithIsa(fbgemm::inst_set_t::avx512_ymm);
 }

--- a/test/FP32Test.cc
+++ b/test/FP32Test.cc
@@ -16,6 +16,7 @@
 
 #include "bench/BenchUtils.h" // @manual
 #include "fbgemm/FbgemmFP32.h"
+#include "fbgemm/Utils.h"
 #include "test/FBGemmFPTest.h"
 
 using FBGemmFP32Test = fbgemm::FBGemmFPTest<float>;
@@ -37,4 +38,22 @@ TEST_P(FBGemmFP32Test, Test) {
 
 TEST_P(FBGemmFP32Test, Unpack) {
   UnpackTestRun();
+}
+
+TEST_P(FBGemmFP32Test, TestAvx2) {
+  TestRunWithIsa(fbgemm::inst_set_t::avx2);
+}
+
+TEST_P(FBGemmFP32Test, TestAvx512) {
+  if (!fbgemm::fbgemmHasAvx512Support()) {
+    GTEST_SKIP() << "AVX512 not supported on this CPU";
+  }
+  TestRunWithIsa(fbgemm::inst_set_t::avx512);
+}
+
+TEST_P(FBGemmFP32Test, TestAvx512_256) {
+  if (!fbgemm::fbgemmHasAvx512Support()) {
+    GTEST_SKIP() << "AVX512 not supported on this CPU";
+  }
+  TestRunWithIsa(fbgemm::inst_set_t::avx512_ymm);
 }


### PR DESCRIPTION
src/fp32/FbgemmFP32.cc could work on Windows by commenting out ASM code.