### PR TITLE
Remove redundant FBGEMM_STATIC in test CMakelist.txt

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -11,15 +11,15 @@ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 ################################################################################
 
 find_package(MKL)
-if (NOT ${MKL_FOUND})
+if(NOT ${MKL_FOUND})
   find_package(BLAS)
 endif()
 
-if (${MKL_FOUND})
+if(${MKL_FOUND})
   message(STATUS "MKL_LIBRARIES= ${MKL_LIBRARIES}")
 endif()
 
-if (${BLAS_FOUND})
+if(${BLAS_FOUND})
   message(STATUS "BLAS_LIBRARIES= ${BLAS_LIBRARIES}")
 endif()
 
@@ -64,7 +64,7 @@ function(add_benchmark BENCHNAME)
       -DUSE_MKL)
   endif()
 
-  if (${BLAS_FOUND})
+  if(${BLAS_FOUND})
     target_link_libraries(${BENCHNAME}
       ${BLAS_LIBRARIES})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,8 +49,6 @@ function(add_gtest TESTNAME)
       ${test_sources})
 
   # To compile test files with AVX2 turned on
-  # For static build, defining FBGEMM_STATIC to avoid generating
-  # functions with _dllimport attributes.
   if(MSVC)
     target_compile_options(${TESTNAME} PRIVATE
       /arch:AVX2
@@ -58,11 +56,6 @@ function(add_gtest TESTNAME)
       /wd4267
       /wd4305
       /wd4309)
-
-    if(FBGEMM_LIBRARY_TYPE STREQUAL STATIC)
-      target_compile_definitions(${TESTNAME} PRIVATE
-        FBGEMM_STATIC)
-    endif()
 
   else()
     if(COMPILER_SUPPORTS_AVX2)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,9 +44,7 @@ function(add_gtest TESTNAME)
     QuantizationHelpers.cc
     TestUtils.cc)
 
-    add_executable(
-      ${TESTNAME}
-      ${test_sources})
+  add_executable(${TESTNAME} ${test_sources})
 
   # To compile test files with AVX2 turned on
   if(MSVC)


### PR DESCRIPTION
Because FBGEMM_STATIC is exported as a public definition.