### PR TITLE
Make fp8 ck gemm support both OCP and FNUZ FP8

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/gen_ai/quantize.py
+++ b/fbgemm_gpu/experimental/gen_ai/gen_ai/quantize.py
@@ -289,9 +289,7 @@ def ck_preshuffle(src: torch.Tensor, NXdl: int = 16) -> torch.Tensor:
     Returns:
         torch.Tensor: The shuffled tensor.
     """
-    # Check input datatype
-    if src.dtype != torch.float8_e4m3fnuz:
-        raise TypeError("Input must be type float8_e4m3fnuz.")
+    # Input datatype will be checked in the kernel impl
     N, K = src.shape
     KPack = 16
     NLane = NXdl

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/fp8fp8bf16_rowwise_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/fp8fp8bf16_rowwise_gemm.hip
@@ -17,6 +17,7 @@
 #include <ATen/ATen.h>
 #include <c10/hip/HIPStream.h>
 
+#include "ck/utility/data_type.hpp"
 #include "kernels/fp8fp8bf16_rowwise_kernel_manifest.h"
 
 namespace fbgemm_gpu {
@@ -505,10 +506,11 @@ at::Tensor f8f8_rowwise_wrapper(
     bool use_fast_accum,
     std::optional<at::Tensor> output = std::nullopt) {
   // Check that input datatypes are valid.
+  constexpr auto kExpectedTorchFP8DType = std::is_same_v<ck::f8_t, ck::f8_ocp_t> ? at::kFloat8_e4m3fn : at::kFloat8_e4m3fnuz;
   TORCH_CHECK(
-      (XQ.dtype() == at::kFloat8_e4m3fnuz) &&
-          (WQ.dtype() == at::kFloat8_e4m3fnuz),
-      "Inputs must be type float8_e4m3fnuz.");
+      (XQ.dtype() == kExpectedTorchFP8DType) &&
+          (WQ.dtype() == kExpectedTorchFP8DType),
+      "Inputs must be type ", kExpectedTorchFP8DType);
   TORCH_CHECK(
       (x_scale.dtype() == at::kFloat) && (w_scale.dtype() == at::kFloat),
       "Scales must be float32.");

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/fp8fp8fp16_rowwise_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/fp8fp8fp16_rowwise_gemm.hip
@@ -8,6 +8,7 @@
 
 #include <ATen/ATen.h>
 
+#include "ck/utility/data_type.hpp"
 #include "kernels/fp8fp8fp16_rowwise_kernel_manifest.h"
 
 namespace fbgemm_gpu {
@@ -73,10 +74,11 @@ at::Tensor f8f8_rowwise_wrapper(
     bool use_fast_accum,
     std::optional<at::Tensor> output = std::nullopt) {
   // Check that input datatypes are valid.
+  constexpr auto kExpectedTorchFP8DType = std::is_same_v<ck::f8_t, ck::f8_ocp_t> ? at::kFloat8_e4m3fn : at::kFloat8_e4m3fnuz;
   TORCH_CHECK(
-      (XQ.dtype() == at::kFloat8_e4m3fnuz) &&
-          (WQ.dtype() == at::kFloat8_e4m3fnuz),
-      "Inputs must be type float8_e4m3fnuz.");
+      (XQ.dtype() == kExpectedTorchFP8DType) &&
+          (WQ.dtype() == kExpectedTorchFP8DType),
+      "Inputs must be type ", kExpectedTorchFP8DType);
   TORCH_CHECK(
       (x_scale.dtype() == at::kFloat) && (w_scale.dtype() == at::kFloat),
       "Scales must be float32.");

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_preshuffle/fp8_rowwise_preshuffle_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_preshuffle/fp8_rowwise_preshuffle_gemm.hip
@@ -17,6 +17,7 @@
 #include <ATen/ATen.h>
 #include <c10/hip/HIPStream.h>
 
+#include "ck/utility/data_type.hpp"
 #include "kernels/fp8_rowwise_preshuffle_kernel_manifest.h"
 
 namespace fbgemm_gpu {
@@ -101,10 +102,11 @@ at::Tensor f8f8_rowwise_preshuffle_wrapper(
     bool use_fast_accum,
     std::optional<at::Tensor> output = std::nullopt) {
   // Check that input datatypes are valid.
+  constexpr auto kExpectedTorchFP8DType = std::is_same_v<ck::f8_t, ck::f8_ocp_t> ? at::kFloat8_e4m3fn : at::kFloat8_e4m3fnuz;
   TORCH_CHECK(
-      (XQ.dtype() == at::kFloat8_e4m3fnuz) &&
-          (WQ.dtype() == at::kFloat8_e4m3fnuz),
-      "Inputs must be type float8_e4m3fnuz.");
+      (XQ.dtype() == kExpectedTorchFP8DType) &&
+          (WQ.dtype() == kExpectedTorchFP8DType),
+      "Inputs must be type ", kExpectedTorchFP8DType);
   TORCH_CHECK(
       (x_scale.dtype() == at::kFloat) && (w_scale.dtype() == at::kFloat),
       "Scales must be float32.");


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1751

Use type info from ck to tell whether we are using OCP FP8 or FNUZ FP8.
Updated fp8_rowwise and fp8_rowwise_preshuffle wrappers.

Note that header macros like CK_USE_OCP_FP8 and CK_USE_FNUZ_FP8 could be both defined (if need to support multiple architectures).

Reviewed By: mxz297

Differential Revision: D80138910


