### PR TITLE
Fix unused-local-typedef issue in surreal/raynier/third-party/lietorch/lietorch/src/lietorch_cpu.cpp +1

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_common.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/bf16_grouped/kernels/bf16_grouped_common.h
@@ -129,8 +129,6 @@ OutputType bf16_grouped_impl(
   } else {
     group_count = A.size();
   }
-  using KernelArguments =
-      ck::tensor_operation::device::GroupedGemmKernelArgument<0>;
   using GemmDesc = ck::tensor_operation::device::GemmDesc;
   // Create gemm shape containers.
   std::vector<GemmDesc> gemm_descs;

--- a/fbgemm_gpu/src/tbe/eeg/indices_generator.cpp
+++ b/fbgemm_gpu/src/tbe/eeg/indices_generator.cpp
@@ -59,7 +59,6 @@ struct IndexMetadata {
 torch::Tensor IndicesGenerator::generate() {
   using timer = std::chrono::high_resolution_clock;
   using us = std::chrono::microseconds;
-  using ns = std::chrono::nanoseconds;
 
   const auto t0 = timer::now();
   std::vector<std::pair<int64_t, double>> indicesWithTags(params_.numIndices);


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wunused-local-typedef` which we are enabling to remove unused code. This has the side-effect of making it easier to do refactors should as removing unnecessary includes.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: meyering

Differential Revision: D80512757


