### PR TITLE
Update early prune to support any N

### DIFF
--- a/fbgemm_gpu/experimental/gemm/triton_gemm/grouped_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/grouped_gemm.py
@@ -184,7 +184,7 @@ def early_config_prune(configs, named_args, dtsize=None, dtype=None, **kwargs):
         num_sm = driver.active.utils.get_device_properties(device)[
             "multiprocessor_count"
         ]
-        N_TILES = N // BLOCK_N
+        N_TILES = (N + BLOCK_N - 1) // BLOCK_N
         MIN_N_TILES = 32 if torch.version.hip else 64
         # 4. make sure we don't load N tiles that are too big
         if (


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1754

When N is small and not multiple of BLOCK_N, e.g. 221, and M=121, the early prune will prune all configs and then an empty config is returned. This will lead to error "ValueError: min() arg is an empty sequence". This diff fixes this issue.

Differential Revision: D80542648


