### PR TITLE
Migrate faster hash ops kernels to `FBGEMM_LAUNCH_KERNEL`

### DIFF
--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_v1.cu
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_v1.cu
@@ -188,9 +188,6 @@ void _bounds_check_indices_cuda_v1(
 
   AT_DISPATCH_INDEX_TYPES(
       indices.scalar_type(), "bounds_check_indices_cuda_v1", [&] {
-#ifdef FBGEMM_GPU_MEMCHECK
-        const auto func_name = "bounds_check_indices_cuda_v1";
-#endif
         const auto bounds_check_kernel =
             (vbe ? bounds_check_indices_kernel_v1<index_t, true>
                  : bounds_check_indices_kernel_v1<index_t, false>);

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/weight_row.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/weight_row.cuh
@@ -367,7 +367,7 @@ class WeightRow {
   }
 
   //////////////////////////////////////////////////////////////////////////////
-  // Copy the row from the embedding table into the cache
+  // Copy the row from the cache into embedding table
   //////////////////////////////////////////////////////////////////////////////
 
   DEVICE_INLINE void evict_cache(const uint32_t d, const float2 qparams) {


### PR DESCRIPTION
Summary: - Migrate faster hash ops kernels to `FBGEMM_LAUNCH_KERNEL`

Reviewed By: ionuthristodorescu

Differential Revision: D79607121


