### PR TITLE
replace weight id with sorted indices value in KVTensorWrapper

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
@@ -91,7 +91,7 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
       int64_t dim,
       const int64_t start,
       const int64_t length,
-      const at::Tensor& weights);
+      at::Tensor& weights);
 
   void set_weights_and_ids(const at::Tensor& weights, const at::Tensor& ids);
 

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper_cpu.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper_cpu.cpp
@@ -67,7 +67,7 @@ void KVTensorWrapper::set_range(
     [[maybe_unused]] const int64_t start,
     [[maybe_unused]] const int64_t length,
     // @lint-ignore CLANGTIDY clang-diagnostic-missing-noreturn
-    [[maybe_unused]] const at::Tensor& weights) {
+    [[maybe_unused]] at::Tensor& weights) {
   FBEXCEPTION("Not implemented");
 }
 


### PR DESCRIPTION
Summary:
when backend_return_whole_row_ flag is true, we used the keys in metaheader directly, without convert it to global id during checkpoint saving, also did not convert global id back to local linearized id during loading.
when resharding happens, there could be key/value mismatch issue.

Differential Revision: D80221965
