### PR TITLE
fix vbe benchmark for MTIA

### DIFF
--- a/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py
@@ -1345,6 +1345,7 @@ def vbe(
         "learning_rate": 0.1,
         "eps": 0.1,
         "feature_table_map": list(range(T)),
+        "device": get_device(),
     }
 
     if ssd:


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1782

This patch fixes the VBE benchmark for MTIA.

## Context
During D79868879, "device" arg is removed accidentally, but this is actually needed for MTIA initialization. This patch fixes it.

Differential Revision: D80855109


