### PR TITLE
training QPS improvement

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -1352,12 +1352,63 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 self.record_function_via_dummy_profile(
                     f"## ssd_set_{name} ##",
                     self.ssd_db.set_cuda,
-                    indices_cpu.cpu(),
+                    indices_cpu,
                     rows_cpu,
                     actions_count_cpu,
                     self.timestep,
                     is_bwd,
                 )
+
+                if post_event is not None:
+                    stream.record_event(post_event)
+
+    def update_feature_score_metadata(
+        self,
+        linear_cache_indices: Tensor,
+        weights: Tensor,
+        stream: torch.cuda.Stream,
+        pre_event: Optional[torch.cuda.Event],
+        post_event: Optional[torch.cuda.Event],
+    ) -> None:
+        """
+        Write feature score to SSD to DRAM
+        Args:
+            stream (Stream): The CUDA stream that cudaStreamAddCallback will
+                             synchronize the host function with.  Moreover, the
+                             asynchronous D->H memory copies will operate on
+                             this stream
+            pre_event (Event): The CUDA event that the stream has to wait on
+            post_event (Event): The CUDA event that the current will record on
+                                when the eviction is done
+        Returns:
+            None
+        """
+        with record_function("## ssd_write_feature_score ##"):
+            with torch.cuda.stream(stream):
+                if pre_event is not None:
+                    stream.wait_event(pre_event)
+
+                    cpu_pinned_linear_cache_indices = torch.empty_like(
+                        linear_cache_indices, device="cpu", pin_memory=True
+                    )
+                    cpu_pinned_linear_cache_indices.copy_(
+                        linear_cache_indices, non_blocking=True
+                    )
+
+                    cpu_pinned_weights = torch.empty_like(
+                        weights, device="cpu", pin_memory=True
+                    )
+                    cpu_pinned_weights.copy_(weights, non_blocking=True)
+
+                    self.record_function_via_dummy_profile(
+                        "## ssd_write_feature_score_metadata ##",
+                        self.ssd_db.set_feature_score_metadata_cuda,
+                        cpu_pinned_linear_cache_indices,
+                        torch.tensor(
+                            [weights.shape[0]], device="cpu", dtype=torch.long
+                        ),
+                        cpu_pinned_weights.view(torch.float32).view(-1, 2),
+                    )
 
                 if post_event is not None:
                     stream.record_event(post_event)
@@ -1685,12 +1736,6 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
 
             self.timestep += 1
             self.timesteps_prefetched.append(self.timestep)
-            if self.backend_type == BackendType.DRAM and weights is not None:
-                # DRAM backend supports feature score eviction, if there is weights available
-                # in the prefetch call, we will set metadata for feature score eviction asynchronously
-                cloned_linear_cache_indices = linear_cache_indices.clone()
-            else:
-                cloned_linear_cache_indices = None
 
             # Lookup and virtually insert indices into L1. After this operator,
             # we know:
@@ -2050,13 +2095,13 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
 
             if self.backend_type == BackendType.DRAM and weights is not None:
                 # Write feature score metadata to DRAM
-                self.record_function_via_dummy_profile(
-                    "## ssd_write_feature_score_metadata ##",
-                    self.ssd_db.set_feature_score_metadata_cuda,
-                    cloned_linear_cache_indices.cpu(),
-                    torch.tensor([weights.shape[0]], device="cpu", dtype=torch.long),
-                    weights.cpu().view(torch.float32).view(-1, 2),
-                )
+                if weights is not None:
+                    self.update_feature_score_metadata(
+                        linear_cache_indices=linear_cache_indices,
+                        weights=weights,
+                        stream=self.ssd_memcpy_stream,
+                        pre_event=self.ssd_event_cache_evict,
+                    )
 
             # Generate row addresses (pointing to either L1 or the current
             # iteration's scratch pad)


### PR DESCRIPTION
Summary:
According to https://fburl.com/gdoc/wij87gpm, we have opportunities to improve the training QPS a bit.

Optimization 1
- put `set_feature_score_metadata_cuda`  execution in another stream out of critical path
Optimization 2
- pin tensor nonblocking copy
Optimization 3
- remove unnecessary expensive logging

Reviewed By: emlin

Differential Revision: D80491163


