### PR TITLE
Fine tune CMF 500x large&medium K shapes to boost flops

### DIFF
--- a/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
@@ -149,6 +149,16 @@ def get_configs_io_bound() -> List[Config]:
     return configs
 
 
+def dummy_prune_configs(configs, named_args, **kwargs):
+
+    M = named_args["M"]
+    N = named_args["N"]
+    K = named_args["K"]
+
+    logger.info(f"{len(configs)=} {len(configs)=} for {M=} {N=} {K=}")
+    return configs
+
+
 MATMUL_CONFIGS: List[Config] = [
     # basic configs for compute-bound matmuls
     Config(
@@ -173,6 +183,11 @@ MATMUL_CONFIGS: List[Config] = [
     ),
     Config(
         {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 128, "SPLIT_K": 1},
+        num_stages=4,
+        num_warps=4,
+    ),
+    Config(
+        {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 256, "SPLIT_K": 1},
         num_stages=4,
         num_warps=4,
     ),
@@ -252,6 +267,9 @@ MATMUL_CONFIGS: List[Config] = [
 
 @triton.autotune(
     configs=MATMUL_CONFIGS,
+    prune_configs_by={
+        "early_config_prune": dummy_prune_configs,
+    },
     key=[
         "m_key",
         "n_key",


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1788

For H100, add new option to persistent triton fp8 gemm to boost perf for CMF 500x gemm shapes:
- M=512, N=1024, K=19712, boost flops from 504 to 559, by 11%.
- M=512, N=1024, K=171712,  boost flops from 437 to 481, by 10%.

CMF 500x E2E QPS was [25k](https://www.internalfb.com/intern/paste/P1915458454/)

Differential Revision: D80881599


