### PR TITLE
Enable tf32 precision acceleration for h100

### DIFF
--- a/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
@@ -1245,6 +1245,8 @@ def matmul_fp8_row(
     a = a.view(-1, a.size(-1))
     # View inputs into proper torch fp8 dtype.
     if torch.version.cuda:
+        # Enable tf32 tensor core to accelerate CUDA
+        torch.set_float32_matmul_precision("high")
         assert a.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
     else:
         assert a.dtype in (torch.float8_e4m3fnuz, torch.float8_e5m2fnuz)


### PR DESCRIPTION
Summary:
As indicated by previous MTS [benchmark](https://www.internalfb.com/intern/everpaste/?handle=GEHWGSBdCZC6Q5QFALLQJHKASQUnbsIXAAAB&phabricator_paste_number=1916364403):
```
TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled.
Consider setting `torch.set_float32_matmul_precision('high')` for better performance.
```
By this diff, enable fp32 high precision. E2E, the diff pushes CMF500x QPS from [25319.47](https://www.internalfb.com/intern/everpaste/?handle=GEHWGSBdCZC6Q5QFALLQJHKASQUnbsIXAAAB&phabricator_paste_number=1916364403) to [25737.61](https://www.internalfb.com/intern/everpaste/?handle=GAsZ7R9ASEeoe9sIABHwORv6SG89bsIXAAAB&phabricator_paste_number=1916396963)

Differential Revision: D80908603


