### PR TITLE
add block_bucketize_2d_weights kernel

### DIFF
--- a/fbgemm_gpu/FbgemmGpu.cmake
+++ b/fbgemm_gpu/FbgemmGpu.cmake
@@ -126,7 +126,8 @@ if(NOT FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_CPU)
       src/sparse_ops/sparse_range.cu
       src/sparse_ops/sparse_reorder_batched_ad.cu
       src/sparse_ops/sparse_segment_sum_csr.cu
-      src/sparse_ops/sparse_zipf.cu)
+      src/sparse_ops/sparse_zipf.cu
+      src/sparse_ops/sparse_block_bucketize_features_2d_weights.cu)
 
   if(NOT FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM)
     list(APPEND fbgemm_gpu_sources_gpu_static

--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -485,6 +485,41 @@ def block_bucketize_sparse_features_meta(
     )
 
 
+def block_bucketize_sparse_features_2d_weights_meta(
+    lengths: torch.Tensor,
+    indices: torch.Tensor,
+    bucketize_pos: bool,
+    sequence: bool,
+    block_sizes: torch.Tensor,
+    my_size: int,
+    weights: torch.Tensor,
+    weights_dim: int = 1,
+    batch_size_per_feature: Optional[torch.Tensor] = None,
+    max_B: int = -1,
+    block_bucketize_pos: Optional[torch.Tensor] = None,
+    keep_orig_idx: bool = False,
+    total_num_blocks: Optional[torch.Tensor] = None,
+    keep_orig_idx_per_feature: Optional[torch.Tensor] = None,
+) -> Tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    Optional[torch.Tensor],
+    Optional[torch.Tensor],
+]:
+    # Output: lengths, indices, weights", pos?, unbucketize_permute?
+    num_buckets = my_size
+    num_features = lengths.size(0)
+    num_values = indices.size(0)
+    return (
+        lengths.new_empty([num_buckets * num_features]),
+        indices.new_empty([num_values]),
+        weights.new_empty([num_values, weights_dim]),
+        indices.new_empty([num_values]) if bucketize_pos else None,
+        indices.new_empty([num_values]),
+    )
+
+
 def merge_pooled_embeddings(
     pooled_embeddings: List[torch.Tensor],
     uncat_dim_size: int,
@@ -1233,6 +1268,10 @@ def _setup() -> None:
         impl_abstract(
             "fbgemm::block_bucketize_sparse_features",
             block_bucketize_sparse_features_meta,
+        )
+        impl_abstract(
+            "fbgemm::block_bucketize_sparse_features_2d_weights",
+            block_bucketize_sparse_features_2d_weights_meta,
         )
         impl_abstract("fbgemm::merge_pooled_embeddings", merge_pooled_embeddings)
         impl_abstract(

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -273,6 +273,54 @@ block_bucketize_sparse_features_inference_cpu(
     const std::optional<at::Tensor>& total_num_blocks,
     const std::optional<at::Tensor>& keep_orig_idx_per_feature);
 
+std::tuple<
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    std::optional<at::Tensor>,
+    std::optional<at::Tensor>>
+
+///@ingroup sparse-data-cuda
+block_bucketize_sparse_features_2d_weights_cuda(
+    const at::Tensor& lengths,
+    const at::Tensor& indices,
+    const bool bucketize_pos,
+    const bool sequence,
+    const at::Tensor& block_sizes,
+    const int64_t my_size,
+    const at::Tensor& weights,
+    const int64_t weights_dim,
+    const std::optional<at::Tensor>& batch_size_per_feature,
+    const int64_t max_batch_size,
+    const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
+    const bool keep_orig_idx,
+    const std::optional<at::Tensor>& total_num_blocks,
+    const std::optional<at::Tensor>& keep_orig_idx_per_feature);
+
+std::tuple<
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    std::optional<at::Tensor>,
+    std::optional<at::Tensor>>
+
+///@ingroup sparse-data-cpu
+block_bucketize_sparse_features_2d_weights_cpu(
+    const at::Tensor& lengths,
+    const at::Tensor& indices,
+    const bool bucketize_pos,
+    const bool sequence,
+    const at::Tensor& block_sizes,
+    const int64_t my_size,
+    const at::Tensor& weights,
+    const int64_t weights_dim,
+    const std::optional<at::Tensor>& batch_size_per_feature,
+    const int64_t max_batch_size,
+    const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
+    const bool keep_orig_idx,
+    const std::optional<at::Tensor>& total_num_blocks,
+    const std::optional<at::Tensor>& keep_orig_idx_per_feature);
+
 ///@ingroup sparse-data-cpu
 at::Tensor populate_bucketized_permute_cpu(
     const at::Tensor& length,

--- a/fbgemm_gpu/src/sparse_ops/sparse_block_bucketize_features_2d_weights.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_block_bucketize_features_2d_weights.cu
@@ -1,0 +1,835 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "common.cuh"
+
+using Tensor = at::Tensor;
+
+namespace fbgemm_gpu {
+
+// Kernel for calulating lengthh idx to feature id mapping. Used for block
+// bucketize sparse features with variable batch size for row-wise partition
+template <typename offset_t>
+__global__
+__launch_bounds__(kMaxThreads) void _populate_length_to_feature_id_inplace_kernel(
+    const uint64_t max_B,
+    const int T,
+    const offset_t* const __restrict__ batch_size_per_feature,
+    const offset_t* const __restrict__ batch_size_offsets,
+    offset_t* const __restrict__ length_to_feature_idx) {
+  const auto b_t = blockIdx.x * blockDim.x + threadIdx.x;
+
+  const auto t = b_t / max_B;
+  const auto b = b_t % max_B;
+
+  if (t >= T || b >= batch_size_per_feature[t]) {
+    return;
+  }
+
+  length_to_feature_idx[batch_size_offsets[t] + b] = t;
+}
+
+void adjust_block_bucketize_sparse_features_2d_weights_kernel_launch_configs_based_on_smem(
+    int* smem_size,
+    dim3* block_dims,
+    dim3* grid_dims,
+    int* max_smem,
+    const int lengths_size,
+    const int my_size,
+    const int device) {
+  // V100: 96 KB; A100: 160 KB; H100: 228 KB.
+  int max_shared_bytes = 0;
+  C10_CUDA_CHECK(cudaDeviceGetAttribute(
+      &max_shared_bytes,
+#ifndef __HIP_PLATFORM_AMD__
+      cudaDevAttrMaxSharedMemoryPerBlockOptin,
+#else
+      hipDeviceAttributeMaxSharedMemoryPerBlock,
+#endif
+      device));
+
+  int shared_kb = max_shared_bytes >> 10;
+  // Use 2/3 of the available GPU shared mem; leave rooms for L1$.
+  // V100: 64 KB; A100: 96 KB; H100: 144 KB
+  int used_shared_kb = round_down(shared_kb * 2 / 3, 16);
+  TORCH_CHECK(used_shared_kb > 0);
+
+  *max_smem = used_shared_kb << 10;
+  while (*smem_size > *max_smem && block_dims->y > 0) {
+    block_dims->y--;
+    *smem_size = my_size * block_dims->y * sizeof(uint64_t);
+  }
+  TORCH_CHECK(
+      block_dims->y > 0,
+      "block_bucketize_sparse_features_2d_weights does not have sufficient shared memory."
+      "Please contact the FBGEMM team.")
+  grid_dims->x = cuda_calc_xblock_count(lengths_size, block_dims->y);
+}
+
+// Kernel for bucketize lengths, with the Block distribution (vs. cyclic,
+// block-cyclic distribution). Used for bucketize sparse feature, especially for
+// checkpointing with row-wise partition (sparse_feature is partitioned
+// continuously along the sparse dimension into my_size blocks)
+template <typename offset_t, typename index_t>
+__global__
+__launch_bounds__(kMaxThreads) void _block_bucketize_sparse_features_cuda_kernel1(
+    const int32_t lengths_size,
+    const int32_t B,
+    const index_t* const __restrict__ block_sizes_data,
+    const index_t* const __restrict__ total_num_blocks,
+    const int my_size,
+    const offset_t* const __restrict__ offsets_data,
+    const index_t* const __restrict__ indices_data,
+    offset_t* const __restrict__ new_lengths_data,
+    offset_t* __restrict__ length_to_feature_idx,
+    const index_t* const __restrict__ block_bucketize_pos_concat,
+    const index_t* const __restrict__ block_bucketize_pos_offsets,
+    index_t* __restrict__ indices_to_lb) {
+  using uindex_t = std::make_unsigned_t<index_t>;
+  const auto bt_start = blockIdx.x * blockDim.y + threadIdx.y;
+  const auto stride = gridDim.x * blockDim.y;
+  for (auto b_t = bt_start; b_t < lengths_size; b_t += stride) {
+    const auto t = length_to_feature_idx ? length_to_feature_idx[b_t] : b_t / B;
+    index_t blk_size = block_sizes_data[t];
+    const index_t local_num_blks =
+        total_num_blocks == nullptr ? 1 : (total_num_blocks[t] / my_size);
+    const index_t global_num_blks =
+        total_num_blocks == nullptr ? my_size : total_num_blocks[t];
+    const index_t global_idx_size = blk_size * global_num_blks;
+    const index_t local_idx_size = blk_size * local_num_blks;
+    offset_t rowstart = (b_t == 0 ? 0 : offsets_data[b_t - 1]);
+    offset_t rowend = offsets_data[b_t];
+    const auto use_block_bucketize_pos =
+        (block_bucketize_pos_concat != nullptr);
+    // We have use cases using none-hashed raw indices that can be either
+    // negative or larger than embedding table hash_size (blk_size *
+    // my_size). In cases of none-hashed indices we need to ensure
+    // bucketization can distribute them into different ranks and within
+    // range of blk_size, we expect the later embedding module to take care
+    // of hashing indices calculation.
+    if (!use_block_bucketize_pos) {
+      for (auto i = rowstart + threadIdx.x; i < rowend; i += blockDim.x) {
+        uindex_t idx = static_cast<uindex_t>(indices_data[i]);
+        uindex_t p = idx < global_idx_size
+            ? idx / local_idx_size
+            : (idx % global_num_blks) / local_num_blks;
+        atomicAdd(&new_lengths_data[p * lengths_size + b_t], 1);
+      }
+      return;
+    }
+
+    const index_t bucketize_max_idx = (t + 1) * (my_size + 1) - 1;
+    const uindex_t blk_scalar =
+        block_bucketize_pos_concat[bucketize_max_idx] / global_num_blks;
+    for (auto i = rowstart + threadIdx.x; i < rowend; i += blockDim.x) {
+      uindex_t idx = static_cast<uindex_t>(indices_data[i]);
+      uindex_t p = 0;
+      index_t first = block_bucketize_pos_offsets[t];
+      index_t last = block_bucketize_pos_offsets[t + 1];
+      if (blk_size == 0) {
+        idx = (idx % global_num_blks) * blk_scalar;
+      }
+
+      while (first < last) {
+        index_t middle = first + ((last - first) / 2);
+        if (static_cast<uindex_t>(block_bucketize_pos_concat[middle]) <= idx) {
+          first = ++middle;
+        } else {
+          last = middle;
+        }
+      }
+      uindex_t lb =
+          static_cast<uindex_t>(first - block_bucketize_pos_offsets[t] - 1);
+      indices_to_lb[i] = lb;
+      p = lb < my_size ? lb : idx % my_size;
+      atomicAdd(&new_lengths_data[p * lengths_size + b_t], 1);
+    }
+  }
+}
+
+// Kernel for bucketize offsets, indices, and positional weights, with the Block
+// distribution (vs. cyclic, block-cyclic distribution). Used for bucketize
+// sparse feature, especially for checkpointing with row-wise partition
+// (sparse_feature is partitioned continuously along the sparse dimension into
+// my_size blocks)
+// This kernel handles pooled sparse features
+// WHERE THE ORDER OF INDICES DOES NOT MATTER
+template <
+    bool has_weight,
+    bool bucketize_pos,
+    typename offset_t,
+    typename index_t,
+    typename scalar_t>
+__global__
+__launch_bounds__(kMaxThreads) void _block_bucketize_pooled_sparse_features_2d_weights_cuda_kernel2(
+    int lengths_size,
+    int32_t B,
+    const index_t* __restrict__ block_sizes_data,
+    const index_t* __restrict__ total_num_blocks,
+    int my_size,
+    const offset_t* __restrict__ offsets_data,
+    const index_t* __restrict__ indices_data,
+    const scalar_t* __restrict__ weights_data,
+    const int64_t weights_dim,
+    offset_t* __restrict__ new_offsets_data,
+    index_t* __restrict__ new_indices_data,
+    scalar_t* __restrict__ new_weights_data,
+    index_t* __restrict__ new_pos_data,
+    const offset_t* const __restrict__ length_to_feature_idx,
+    const index_t* const __restrict__ block_bucketize_pos_concat,
+    const index_t* const __restrict__ block_bucketize_pos_offsets,
+    const index_t* const __restrict__ indices_to_lb,
+    const bool keep_orig_idx,
+    const bool* const __restrict__ keep_orig_idx_per_feature) {
+  using uindex_t = std::make_unsigned_t<index_t>;
+  const auto bt_start = blockIdx.x * blockDim.y + threadIdx.y;
+  const auto stride = gridDim.x * blockDim.y;
+
+  extern __shared__ uint64_t smem[];
+  uint64_t* offset_in_different_ranks = &smem[my_size * threadIdx.y];
+
+  for (auto b_t = bt_start; b_t < lengths_size; b_t += stride) {
+    const auto t = length_to_feature_idx ? length_to_feature_idx[b_t] : b_t / B;
+    const index_t blk_size = block_sizes_data[t];
+    const offset_t rowstart = (b_t == 0 ? 0 : offsets_data[b_t - 1]);
+    const offset_t rowend = offsets_data[b_t];
+    const auto use_block_bucketize_pos =
+        (block_bucketize_pos_concat != nullptr);
+
+    /* Re-init the offset array to be 0 for the current iteration */
+    syncwarp();
+    for (auto i = threadIdx.x; i < my_size; i += blockDim.x) {
+      offset_in_different_ranks[i] = 0;
+    }
+    syncwarp();
+
+    const index_t local_num_blks =
+        total_num_blocks == nullptr ? 1 : (total_num_blocks[t] / my_size);
+    const index_t global_num_blks =
+        total_num_blocks == nullptr ? my_size : total_num_blocks[t];
+    const index_t global_idx_size = blk_size * global_num_blks;
+    const index_t local_idx_size = blk_size * local_num_blks;
+    auto keep_idx = keep_orig_idx;
+    if (keep_orig_idx_per_feature != nullptr) {
+      // When keep_orig_idx_per_feature is set, override global
+      // keep_orig_idx settings
+      keep_idx = keep_orig_idx_per_feature[t];
+    }
+    for (auto i = rowstart + threadIdx.x; i < rowend; i += blockDim.x) {
+      // We have use cases using none-hashed raw indices that can be either
+      // negative or larger than embedding table hash_size (blk_size *
+      // my_size). In cases of none-hashed indices we need to ensure
+      // bucketization can distribute them into different ranks and within
+      // range of blk_size, we expect the later embedding module to take care
+      // of hashing indices calculation.
+      const uindex_t idx = static_cast<uindex_t>(indices_data[i]);
+      uindex_t p = 0;
+      uindex_t new_idx = 0;
+      if (!use_block_bucketize_pos) { // uniform bucket sizes
+        p = idx < global_idx_size ? idx / local_idx_size
+                                  : (idx % global_num_blks) / local_num_blks;
+        if (keep_idx) {
+          new_idx = idx;
+        } else if (idx < global_idx_size) {
+          new_idx = idx % local_idx_size;
+        } else {
+          new_idx = idx / global_num_blks;
+        }
+      } else { // variable bucket sizes
+        uindex_t lb = indices_to_lb[i];
+        p = lb < my_size ? lb : idx % my_size;
+        if (keep_idx) {
+          new_idx = idx;
+        } else if (blk_size == 0) {
+          new_idx = idx / global_num_blks;
+        } else if (lb < my_size) {
+          new_idx = idx -
+              block_bucketize_pos_concat[lb + block_bucketize_pos_offsets[t]];
+        } else {
+          new_idx = idx / my_size;
+        }
+      }
+      static_assert(
+          sizeof(unsigned long long int) == sizeof(uint64_t),
+          "bitwidth change is not allowed");
+      const uint64_t pos = atomicAdd(
+                               reinterpret_cast<unsigned long long int*>(
+                                   &offset_in_different_ranks[p]),
+                               1) +
+          new_offsets_data[p * lengths_size + b_t];
+      new_indices_data[pos] = new_idx;
+      if (has_weight) {
+        // Copy all weight dimensions for this index
+        for (int64_t d = 0; d < weights_dim; ++d) {
+          new_weights_data[pos * weights_dim + d] =
+              weights_data[i * weights_dim + d];
+        }
+      }
+      if (bucketize_pos) {
+        new_pos_data[pos] = i - rowstart;
+      }
+    }
+  }
+}
+
+// Kernel for bucketize offsets, indices, and positional weights, with the Block
+// distribution (vs. cyclic, block-cyclic distribution). Used for bucketize
+// sparse feature, especially for checkpointing with row-wise partition
+// (sparse_feature is partitioned continuously along the sparse dimension into
+// my_size blocks)
+// This kernel handles SEQUENCE sparse features WHERE THE ORDER OF INDICES
+// MATTERS
+template <
+    bool has_weight,
+    bool bucketize_pos,
+    bool return_bucket_mapping,
+    typename offset_t,
+    typename index_t,
+    typename scalar_t>
+__global__
+__launch_bounds__(kMaxThreads) void _block_bucketize_sequence_sparse_features_2d_weights_cuda_kernel2(
+    int lengths_size,
+    int32_t B,
+    const index_t* __restrict__ block_sizes_data,
+    const index_t* __restrict__ total_num_blocks,
+    int my_size,
+    const offset_t* __restrict__ offsets_data,
+    const index_t* __restrict__ indices_data,
+    const scalar_t* __restrict__ weights_data,
+    const int64_t weights_dim,
+    offset_t* __restrict__ new_offsets_data,
+    index_t* __restrict__ new_indices_data,
+    scalar_t* __restrict__ new_weights_data,
+    index_t* __restrict__ new_pos_data,
+    index_t* const __restrict__ unbucketize_permute_data,
+    index_t* const __restrict__ bag_mapping_data,
+    const offset_t* const __restrict__ length_to_feature_idx,
+    const index_t* const __restrict__ block_bucketize_pos_concat,
+    const index_t* const __restrict__ block_bucketize_pos_offsets,
+    const index_t* const __restrict__ indices_to_lb,
+    const bool keep_orig_idx,
+    const bool* const __restrict__ keep_orig_idx_per_feature) {
+  using uindex_t = std::make_unsigned_t<index_t>;
+  using uoffset_t = std::make_unsigned_t<offset_t>;
+  CUDA_KERNEL_LOOP(b_t, lengths_size) {
+    const auto t = length_to_feature_idx ? length_to_feature_idx[b_t] : b_t / B;
+    index_t blk_size = block_sizes_data[t];
+    const index_t local_num_blks =
+        total_num_blocks == nullptr ? 1 : (total_num_blocks[t] / my_size);
+    const index_t global_num_blks =
+        total_num_blocks == nullptr ? my_size : total_num_blocks[t];
+    const index_t global_idx_size = blk_size * global_num_blks;
+    const index_t local_idx_size = blk_size * local_num_blks;
+
+    offset_t rowstart = (b_t == 0 ? 0 : offsets_data[b_t - 1]);
+    offset_t rowend = offsets_data[b_t];
+    const auto use_block_bucketize_pos =
+        (block_bucketize_pos_concat != nullptr);
+    auto keep_idx = keep_orig_idx;
+    if (keep_orig_idx_per_feature != nullptr) {
+      // When keep_orig_idx_per_feature is set, override global
+      // keep_orig_idx settings
+      keep_idx = keep_orig_idx_per_feature[t];
+    }
+    for (index_t i = rowstart; i < rowend; ++i) {
+      // We have use cases using none-hashed raw indices that can be either
+      // negative or larger than embedding table hash_size (blk_size *
+      // my_size). In cases of none-hashed indices we need to ensure
+      // bucketization can distribute them into different ranks and within
+      // range of blk_size, we expect the later embedding module to take care
+      // of hashing indices calculation.
+      uindex_t idx = static_cast<uindex_t>(indices_data[i]);
+      uindex_t p = 0;
+      uindex_t new_idx = 0;
+      if (!use_block_bucketize_pos) {
+        p = idx < global_idx_size ? idx / local_idx_size
+                                  : (idx % global_num_blks) / local_num_blks;
+        if (keep_idx) {
+          new_idx = idx;
+        } else if (idx < global_idx_size) {
+          new_idx = idx % local_idx_size;
+        } else {
+          new_idx = idx / global_num_blks;
+        }
+      } else {
+        uindex_t lb = indices_to_lb[i];
+        p = lb < my_size ? lb : idx % my_size;
+        if (keep_idx) {
+          new_idx = idx;
+        } else if (blk_size == 0) {
+          new_idx = idx / global_num_blks;
+        } else if (lb < my_size) {
+          new_idx = idx -
+              block_bucketize_pos_concat[lb + block_bucketize_pos_offsets[t]];
+        } else {
+          new_idx = idx / my_size;
+        }
+      }
+      uoffset_t pos = new_offsets_data[p * lengths_size + b_t];
+      new_indices_data[pos] = new_idx;
+      new_offsets_data[p * lengths_size + b_t]++;
+      unbucketize_permute_data[i] = pos;
+      if constexpr (return_bucket_mapping) {
+        bag_mapping_data[i] = p;
+      }
+      if (has_weight) {
+        // Copy all weight dimensions for this index
+        for (int64_t d = 0; d < weights_dim; ++d) {
+          new_weights_data[pos * weights_dim + d] =
+              weights_data[i * weights_dim + d];
+        }
+      }
+      if (bucketize_pos) {
+        new_pos_data[pos] = i - rowstart;
+      }
+    }
+  }
+}
+
+template <typename offset_t, typename index_t>
+__global__
+__launch_bounds__(kMaxThreads) void _populate_bucketized_permute_cuda_kernel(
+    const offset_t* const length_data,
+    const offset_t* const offset_data,
+    offset_t* const bucketized_offsets_data,
+    const index_t* const bucket_mapping_data,
+    index_t* const bucketized_permute_data_out,
+    int32_t lengths_size) {
+  CUDA_KERNEL_LOOP(b_t, lengths_size) {
+    const auto length = length_data[b_t];
+    const auto offset = offset_data[b_t];
+    for (size_t i = 0; i < length; i++) {
+      const auto index = offset + i;
+      const auto bucket = bucket_mapping_data[index];
+      bucketized_permute_data_out[index] =
+          bucketized_offsets_data[bucket * lengths_size + b_t]++;
+    }
+  }
+}
+
+#define LAUNCH_BLOCK_BUCKETIZE_SEQUENCE_SPARSE_FEATURES_2D_WEIGHTS_CUDA_KERNEL_WITH_WEIGHT( \
+    bucketize_pos, return_bucket_mapping)                                                   \
+  AT_DISPATCH_INDEX_TYPES(                                                                  \
+      offsets_contig.scalar_type(),                                                         \
+      "_block_bucketize_sequence_sparse_features_2d_weights_cuda_kernel2_1",                \
+      [&] {                                                                                 \
+        using offset_t = index_t;                                                           \
+        AT_DISPATCH_INDEX_TYPES(                                                            \
+            indices_contig.scalar_type(),                                                   \
+            "_block_bucketize_sequence_sparse_features_2d_weights_cuda_kernel2_2",          \
+            [&] {                                                                           \
+              FBGEMM_DISPATCH_FLOATING_TYPES_AND(                                           \
+                  at::ScalarType::Double,                                                   \
+                  weights_value.scalar_type(),                                              \
+                  "_block_bucketize_sequence_sparse_features_2d_weights_cuda_kernel2_3",    \
+                  [&] {                                                                     \
+                    _block_bucketize_sequence_sparse_features_2d_weights_cuda_kernel2<      \
+                        true,                                                               \
+                        bucketize_pos,                                                      \
+                        return_bucket_mapping,                                              \
+                        offset_t,                                                           \
+                        index_t,                                                            \
+                        scalar_t>                                                           \
+                        <<<num_blocks,                                                      \
+                           threads_per_block,                                               \
+                           0,                                                               \
+                           at::cuda::getCurrentCUDAStream()>>>(                             \
+                            lengths_size,                                                   \
+                            B,                                                              \
+                            block_sizes.data_ptr<index_t>(),                                \
+                            total_num_blocks.has_value()                                    \
+                                ? total_num_blocks.value().data_ptr<index_t>()              \
+                                : static_cast<index_t*>(nullptr),                           \
+                            my_size,                                                        \
+                            offsets_contig.data_ptr<offset_t>(),                            \
+                            indices_contig.data_ptr<index_t>(),                             \
+                            weights_value_contig.data_ptr<scalar_t>(),                      \
+                            weights_dim,                                                    \
+                            new_offsets.data_ptr<offset_t>(),                               \
+                            new_indices.data_ptr<index_t>(),                                \
+                            new_weights.data_ptr<scalar_t>(),                               \
+                            bucketize_pos ? new_pos.data_ptr<index_t>()                     \
+                                          : static_cast<index_t*>(nullptr),                 \
+                            unbucketize_permute.data_ptr<index_t>(),                        \
+                            (return_bucket_mapping)                                         \
+                                ? bucket_mapping.data_ptr<index_t>()                        \
+                                : static_cast<index_t*>(nullptr),                           \
+                            batch_size_per_feature.has_value()                              \
+                                ? length_to_feature_idx.data_ptr<offset_t>()                \
+                                : static_cast<offset_t*>(nullptr),                          \
+                            block_bucketize_pos.has_value()                                 \
+                                ? block_bucketize_pos_concat                                \
+                                      .data_ptr<index_t>()                                  \
+                                : static_cast<index_t*>(nullptr),                           \
+                            block_bucketize_pos.has_value()                                 \
+                                ? block_bucketize_pos_offsets                               \
+                                      .data_ptr<index_t>()                                  \
+                                : static_cast<index_t*>(nullptr),                           \
+                            block_bucketize_pos.has_value()                                 \
+                                ? indices_to_lb.data_ptr<index_t>()                         \
+                                : static_cast<index_t*>(nullptr),                           \
+                            keep_orig_idx,                                                  \
+                            keep_orig_idx_per_feature.has_value()                           \
+                                ? keep_orig_idx_per_feature->data_ptr<bool>()               \
+                                : static_cast<bool*>(nullptr));                             \
+                    C10_CUDA_KERNEL_LAUNCH_CHECK();                                         \
+                  });                                                                       \
+            });                                                                             \
+      });
+
+#define LAUNCH_BLOCK_BUCKETIZE_POOLED_SPARSE_FEATURES_2D_WEIGHTS_CUDA_KERNEL_2_WITH_WEIGHT( \
+    bucketize_pos, return_new_pos)                                                          \
+  AT_DISPATCH_INDEX_TYPES(                                                                  \
+      offsets_contig.scalar_type(),                                                         \
+      "_block_bucketize_pooled_sparse_features_2d_weights_cuda_kernel2_1",                  \
+      [&] {                                                                                 \
+        using offset_t = index_t;                                                           \
+        AT_DISPATCH_INDEX_TYPES(                                                            \
+            indices_contig.scalar_type(),                                                   \
+            "_block_bucketize_pooled_sparse_features_2d_weights_cuda_kernel2_2",            \
+            [&] {                                                                           \
+              FBGEMM_DISPATCH_FLOATING_TYPES_AND(                                           \
+                  at::ScalarType::Double,                                                   \
+                  weights_value.scalar_type(),                                              \
+                  "_block_bucketize_pooled_sparse_features_2d_weights_cuda_kernel2_3",      \
+                  [&] {                                                                     \
+                    const auto block_bucketize_kernel =                                     \
+                        _block_bucketize_pooled_sparse_features_2d_weights_cuda_kernel2<    \
+                            true,                                                           \
+                            bucketize_pos,                                                  \
+                            offset_t,                                                       \
+                            index_t,                                                        \
+                            scalar_t>;                                                      \
+                    if (smem_size > smem_adjust_threshold) {                                \
+                      utils::cuda::set_max_dynamic_smem(                                    \
+                          block_bucketize_kernel, max_smem);                                \
+                    }                                                                       \
+                    block_bucketize_kernel<<<                                               \
+                        grid_dims,                                                          \
+                        block_dims,                                                         \
+                        smem_size,                                                          \
+                        at::cuda::getCurrentCUDAStream()>>>(                                \
+                        lengths_size,                                                       \
+                        B,                                                                  \
+                        block_sizes.data_ptr<index_t>(),                                    \
+                        total_num_blocks.has_value()                                        \
+                            ? total_num_blocks.value().data_ptr<index_t>()                  \
+                            : static_cast<index_t*>(nullptr),                               \
+                        my_size,                                                            \
+                        offsets_contig.data_ptr<offset_t>(),                                \
+                        indices_contig.data_ptr<index_t>(),                                 \
+                        weights_value_contig.data_ptr<scalar_t>(),                          \
+                        weights_dim,                                                        \
+                        new_offsets.data_ptr<offset_t>(),                                   \
+                        new_indices.data_ptr<index_t>(),                                    \
+                        new_weights.data_ptr<scalar_t>(),                                   \
+                        (return_new_pos) ? new_pos.data_ptr<index_t>()                      \
+                                         : static_cast<index_t*>(nullptr),                  \
+                        batch_size_per_feature.has_value()                                  \
+                            ? length_to_feature_idx.data_ptr<offset_t>()                    \
+                            : static_cast<offset_t*>(nullptr),                              \
+                        block_bucketize_pos.has_value()                                     \
+                            ? block_bucketize_pos_concat.data_ptr<index_t>()                \
+                            : static_cast<index_t*>(nullptr),                               \
+                        block_bucketize_pos.has_value()                                     \
+                            ? block_bucketize_pos_offsets.data_ptr<index_t>()               \
+                            : static_cast<index_t*>(nullptr),                               \
+                        block_bucketize_pos.has_value()                                     \
+                            ? indices_to_lb.data_ptr<index_t>()                             \
+                            : static_cast<index_t*>(nullptr),                               \
+                        keep_orig_idx,                                                      \
+                        keep_orig_idx_per_feature.has_value()                               \
+                            ? keep_orig_idx_per_feature->data_ptr<bool>()                   \
+                            : static_cast<bool*>(nullptr));                                 \
+                    C10_CUDA_KERNEL_LAUNCH_CHECK();                                         \
+                  });                                                                       \
+            });                                                                             \
+      });
+
+// This function partitions sparse features
+// continuously along the sparse dimension into
+// my_size blocks with 2D weights support
+std::tuple<
+    Tensor,
+    Tensor,
+    Tensor,
+    std::optional<Tensor>,
+    std::optional<Tensor>,
+    std::optional<Tensor>>
+_block_bucketize_sparse_features_2d_weights_cuda(
+    const Tensor& lengths,
+    const Tensor& indices,
+    const bool bucketize_pos,
+    const bool sequence,
+    const Tensor& block_sizes,
+    const std::optional<Tensor>& total_num_blocks,
+    const int64_t my_size,
+    const Tensor& weights,
+    const int64_t weights_dim,
+    const std::optional<Tensor>& batch_size_per_feature,
+    const int64_t max_B,
+    const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
+    const bool return_bucket_mapping,
+    const bool keep_orig_idx,
+    const std::optional<Tensor>& keep_orig_idx_per_feature) {
+  TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(lengths, indices);
+
+  CUDA_DEVICE_GUARD(lengths);
+
+  // allocate tensors and buffers
+  const auto lengths_size = lengths.numel();
+  const auto T = block_sizes.numel();
+  const auto B = lengths_size / T;
+  const auto new_lengths_size = lengths_size * my_size;
+  auto offsets = at::empty({lengths_size}, lengths.options());
+  auto new_lengths = at::zeros({new_lengths_size}, lengths.options());
+  auto new_offsets = at::empty({new_lengths_size}, lengths.options());
+  auto new_indices = at::empty_like(indices);
+  auto lengths_contig = lengths.contiguous();
+  auto indices_contig = indices.contiguous();
+  auto offsets_contig = offsets.contiguous();
+  auto batch_sizes_contig =
+      batch_size_per_feature.value_or(at::empty({T}, lengths.options()))
+          .contiguous();
+  auto batch_sizes_offsets_contig =
+      at::empty({T}, batch_sizes_contig.options());
+  Tensor new_weights;
+  Tensor new_pos;
+  Tensor unbucketize_permute;
+  Tensor bucket_mapping;
+  // count nonzeros
+  offsets_contig = asynchronous_inclusive_cumsum_gpu(lengths);
+  if (batch_size_per_feature.has_value()) {
+    TORCH_CHECK(max_B > 0);
+    batch_sizes_offsets_contig =
+        asynchronous_exclusive_cumsum_gpu(batch_size_per_feature.value());
+  }
+  auto length_to_feature_idx =
+      at::empty({lengths_size}, lengths_contig.options());
+  auto indices_to_lb = at::empty_like(indices);
+  if (batch_size_per_feature.has_value()) {
+    constexpr auto threads_per_block = 256;
+    const auto num_blocks =
+        cuda_calc_xblock_count(max_B * T, threads_per_block);
+
+    AT_DISPATCH_INDEX_TYPES(
+        offsets_contig.scalar_type(),
+        "_populate_length_to_feature_id_inplace_kernel",
+        [&] {
+          using offset_t = index_t;
+          _populate_length_to_feature_id_inplace_kernel<<<
+              num_blocks,
+              threads_per_block,
+              0,
+              at::cuda::getCurrentCUDAStream()>>>(
+              max_B,
+              T,
+              batch_sizes_contig.data_ptr<offset_t>(),
+              batch_sizes_offsets_contig.data_ptr<offset_t>(),
+              length_to_feature_idx.data_ptr<offset_t>());
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        });
+  }
+
+  at::Tensor block_bucketize_pos_concat =
+      at::empty({1}, indices_contig.options());
+  at::Tensor block_bucketize_pos_offsets =
+      at::empty({1}, indices_contig.options());
+
+  if (block_bucketize_pos.has_value()) {
+    block_bucketize_pos_concat = at::cat(block_bucketize_pos.value(), 0);
+    std::vector<int64_t> sizes_;
+    sizes_.reserve(block_bucketize_pos.value().size() + 1);
+    for (auto const& t : block_bucketize_pos.value()) {
+      sizes_.push_back(t.numel());
+    }
+    sizes_.push_back(0);
+    at::Tensor sizes_vec =
+        at::tensor(sizes_, at::TensorOptions().dtype(indices_contig.dtype()));
+    block_bucketize_pos_offsets = asynchronous_exclusive_cumsum_cpu(
+        sizes_vec); // expect sizes_vec to be a
+                    // small tensor, using cpu
+                    // instead of gpu for cumsum
+    block_bucketize_pos_offsets = block_bucketize_pos_offsets.to(
+        block_bucketize_pos_concat.device(), true);
+  }
+  static_assert(kMaxThreads % kWarpSize == 0);
+  dim3 block_dims(kWarpSize, kMaxThreads / kWarpSize);
+  dim3 grid_dims(cuda_calc_xblock_count(lengths_size, block_dims.y));
+  const auto smem_adjust_threshold =
+      at::cuda::getCurrentDeviceProperties()->sharedMemPerBlock;
+  AT_DISPATCH_INDEX_TYPES(
+      offsets_contig.scalar_type(),
+      "_block_bucketize_sparse_features_cuda_kernel1",
+      [&] {
+        using offset_t = index_t;
+        AT_DISPATCH_INDEX_TYPES(
+            indices_contig.scalar_type(),
+            "_block_bucketize_sparse_features_cuda_kernel2",
+            [&] {
+              _block_bucketize_sparse_features_cuda_kernel1<<<
+                  grid_dims,
+                  block_dims,
+                  0,
+                  at::cuda::getCurrentCUDAStream()>>>(
+                  lengths_size,
+                  B,
+                  block_sizes.data_ptr<index_t>(),
+                  total_num_blocks.has_value()
+                      ? total_num_blocks.value().data_ptr<index_t>()
+                      : static_cast<index_t*>(nullptr),
+                  my_size,
+                  offsets_contig.data_ptr<offset_t>(),
+                  indices_contig.data_ptr<index_t>(),
+                  new_lengths.data_ptr<offset_t>(),
+                  batch_size_per_feature.has_value()
+                      ? length_to_feature_idx.data_ptr<offset_t>()
+                      : static_cast<offset_t*>(nullptr),
+                  block_bucketize_pos.has_value()
+                      ? block_bucketize_pos_concat.data_ptr<index_t>()
+                      : static_cast<index_t*>(nullptr),
+                  block_bucketize_pos.has_value()
+                      ? block_bucketize_pos_offsets.data_ptr<index_t>()
+                      : static_cast<index_t*>(nullptr),
+                  block_bucketize_pos.has_value()
+                      ? indices_to_lb.data_ptr<index_t>()
+                      : static_cast<index_t*>(nullptr));
+              C10_CUDA_KERNEL_LAUNCH_CHECK();
+            });
+      });
+  constexpr auto threads_per_block = 256;
+  const auto num_blocks =
+      cuda_calc_xblock_count(lengths_size, threads_per_block);
+  // bucketize nonzeros
+  new_offsets = asynchronous_exclusive_cumsum_gpu(new_lengths);
+  if (sequence) {
+    const auto lengths_sum = indices.numel();
+    unbucketize_permute = at::empty({lengths_sum}, indices.options());
+
+    Tensor weights_value = weights.contiguous();
+    auto weights_value_contig = weights_value;
+    // For 2D weights, we need to reshape the weights tensor
+    new_weights =
+        at::empty({indices.numel(), weights_dim}, weights_value.options());
+
+    if (bucketize_pos) {
+      new_pos = at::empty_like(indices);
+      if (return_bucket_mapping) {
+        bucket_mapping = at::empty({lengths_sum}, indices.options());
+        LAUNCH_BLOCK_BUCKETIZE_SEQUENCE_SPARSE_FEATURES_2D_WEIGHTS_CUDA_KERNEL_WITH_WEIGHT(
+            true, true);
+      } else {
+        LAUNCH_BLOCK_BUCKETIZE_SEQUENCE_SPARSE_FEATURES_2D_WEIGHTS_CUDA_KERNEL_WITH_WEIGHT(
+            true, false);
+      }
+    } else {
+      if (return_bucket_mapping) {
+        bucket_mapping = at::empty({lengths_sum}, indices.options());
+        LAUNCH_BLOCK_BUCKETIZE_SEQUENCE_SPARSE_FEATURES_2D_WEIGHTS_CUDA_KERNEL_WITH_WEIGHT(
+            false, true);
+      } else {
+        LAUNCH_BLOCK_BUCKETIZE_SEQUENCE_SPARSE_FEATURES_2D_WEIGHTS_CUDA_KERNEL_WITH_WEIGHT(
+            false, false);
+      }
+    }
+  } else {
+    int smem_size = my_size * block_dims.y * sizeof(uint64_t);
+    int max_smem = 0;
+    adjust_block_bucketize_sparse_features_2d_weights_kernel_launch_configs_based_on_smem(
+        &smem_size,
+        &block_dims,
+        &grid_dims,
+        &max_smem,
+        lengths_size,
+        my_size,
+        lengths.get_device());
+    Tensor weights_value = weights.contiguous();
+    auto weights_value_contig = weights_value;
+    // For 2D weights, we need to reshape the weights tensor
+    new_weights =
+        at::empty({indices.numel(), weights_dim}, weights_value.options());
+
+    if (bucketize_pos) {
+      new_pos = at::empty_like(indices);
+      LAUNCH_BLOCK_BUCKETIZE_POOLED_SPARSE_FEATURES_2D_WEIGHTS_CUDA_KERNEL_2_WITH_WEIGHT(
+          true, true);
+    } else {
+      LAUNCH_BLOCK_BUCKETIZE_POOLED_SPARSE_FEATURES_2D_WEIGHTS_CUDA_KERNEL_2_WITH_WEIGHT(
+          false, false);
+    }
+  }
+
+  return {
+      new_lengths,
+      new_indices,
+      new_weights,
+      new_pos,
+      unbucketize_permute,
+      bucket_mapping};
+}
+
+#undef LAUNCH_BLOCK_BUCKETIZE_SEQUENCE_SPARSE_FEATURES_2D_WEIGHTS_CUDA_KERNEL_WITH_WEIGHT
+#undef LAUNCH_BLOCK_BUCKETIZE_POOLED_SPARSE_FEATURES_2D_WEIGHTS_CUDA_KERNEL_2_WITH_WEIGHT
+
+// This function partitions sparse features
+// continuously along the sparse dimension into
+// my_size blocks with 2D weights support
+DLL_PUBLIC std::
+    tuple<Tensor, Tensor, Tensor, std::optional<Tensor>, std::optional<Tensor>>
+    block_bucketize_sparse_features_2d_weights_cuda(
+        const Tensor& lengths,
+        const Tensor& indices,
+        const bool bucketize_pos,
+        const bool sequence,
+        const Tensor& block_sizes,
+        const int64_t my_size,
+        const Tensor& weights,
+        const int64_t weights_dim,
+        const std::optional<Tensor>& batch_size_per_feature,
+        const int64_t max_B,
+        const std::optional<std::vector<at::Tensor>>& block_bucketize_pos,
+        const bool keep_orig_idx,
+        const std::optional<Tensor>& total_num_blocks,
+        const std::optional<at::Tensor>& keep_orig_idx_per_feature) {
+  Tensor new_lengths;
+  Tensor new_indices;
+  Tensor new_weights;
+  std::optional<Tensor> new_pos;
+  std::optional<Tensor> unbucketize_permute;
+  std::tie(
+      new_lengths,
+      new_indices,
+      new_weights,
+      new_pos,
+      unbucketize_permute,
+      std::ignore) =
+      _block_bucketize_sparse_features_2d_weights_cuda(
+          lengths,
+          indices,
+          bucketize_pos,
+          sequence,
+          block_sizes,
+          total_num_blocks,
+          my_size,
+          weights,
+          weights_dim,
+          batch_size_per_feature,
+          max_B,
+          block_bucketize_pos,
+          false,
+          keep_orig_idx,
+          keep_orig_idx_per_feature);
+  return {new_lengths, new_indices, new_weights, new_pos, unbucketize_permute};
+}
+
+} // namespace fbgemm_gpu
+
+FBGEMM_OP_DISPATCH(
+    CUDA,
+    "block_bucketize_sparse_features_2d_weights",
+    fbgemm_gpu::block_bucketize_sparse_features_2d_weights_cuda);

--- a/fbgemm_gpu/test/sparse/block_bucketize_2d_weights_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_2d_weights_test.py
@@ -1,0 +1,1016 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+# pyre-ignore-all-errors[56]
+
+import unittest
+from typing import Type
+
+import hypothesis.strategies as st
+import torch
+from hypothesis import given, settings, Verbosity
+
+from .common import extend_test_class, open_source
+
+if open_source:
+    # pyre-ignore[21]
+    from test_utils import gpu_available, skipIfRocm
+else:
+    from fbgemm_gpu.test.test_utils import gpu_available, skipIfRocm
+
+ROCM_FAILURE_MESSAGE = "Test is causing HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION"
+
+
+class BlockBucketize2DWeightsTest(unittest.TestCase):
+    def validate_out_of_order_output(
+        self,
+        expected: torch.Tensor,
+        actual: torch.Tensor,
+        lengths: torch.Tensor,
+        is_int: bool = True,
+    ) -> None:
+        self.assertEqual(actual.numel(), expected.numel())
+        self.assertEqual(torch.sum(lengths).item(), actual.numel())
+        expected_list = expected.tolist()
+        actual_list = actual.tolist()
+        offset_list = torch.ops.fbgemm.asynchronous_complete_cumsum(lengths).tolist()
+
+        for i in range(len(offset_list) - 1):
+            expected_sample = sorted(expected_list[offset_list[i] : offset_list[i + 1]])
+            actual_sample = sorted(actual_list[offset_list[i] : offset_list[i + 1]])
+            if is_int:
+                self.assertEqual(expected_sample, actual_sample)
+            else:
+                for left, right in zip(expected_sample, actual_sample):
+                    self.assertAlmostEqual(left, right)
+        return
+
+    @skipIfRocm(ROCM_FAILURE_MESSAGE)
+    @given(
+        index_type=st.sampled_from([torch.int, torch.long]),
+        bucketize_pos=st.booleans(),
+        sequence=st.booleans(),
+        weights_dim=st.sampled_from([2, 3, 4]),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    def test_block_bucketize_sparse_features_2d_weights(
+        self,
+        index_type: Type[torch.dtype],
+        bucketize_pos: bool,
+        sequence: bool,
+        weights_dim: int,
+    ) -> None:
+        """Test block bucketize sparse features with 2D weights.
+
+        Tests both CPU and GPU implementations for 2D weights.
+        """
+        # pyre-ignore [6]
+        lengths = torch.tensor([0, 2, 1, 3, 2, 3, 3, 1], dtype=index_type)
+        indices = torch.tensor(
+            [3, 4, 15, 11, 28, 29, 1, 10, 11, 12, 13, 11, 22, 20, 20],
+            # pyre-ignore [6]
+            dtype=index_type,
+        )
+        # Create 2D weights with shape [indices.numel(), weights_dim]
+        weights = torch.rand(
+            (indices.numel(), weights_dim),
+            dtype=torch.float,
+        )
+        # pyre-ignore [6]
+        block_sizes = torch.tensor([5, 15, 10, 20], dtype=index_type)
+        my_size = 2
+
+        new_lengths_ref = torch.tensor(
+            [0, 2, 0, 1, 1, 0, 1, 0, 0, 0, 1, 2, 1, 3, 2, 1],
+            # pyre-ignore [6]
+            dtype=index_type,
+        )
+        new_indices_ref = torch.tensor(
+            [3, 4, 11, 1, 11, 0, 13, 14, 0, 1, 2, 3, 2, 0, 0],
+            # pyre-ignore [6]
+            dtype=index_type,
+        )
+
+        # CPU implementation
+        (
+            new_lengths_cpu,
+            new_indices_cpu,
+            new_weights_cpu,
+            new_pos_cpu,
+            unbucketize_permute,
+        ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+            lengths,
+            indices,
+            bucketize_pos,
+            sequence,
+            block_sizes,
+            my_size,
+            weights,
+            weights_dim,
+        )
+
+        # Verify output shapes and types
+        torch.testing.assert_close(new_lengths_cpu, new_lengths_ref, rtol=0, atol=0)
+        torch.testing.assert_close(new_indices_cpu, new_indices_ref, rtol=0, atol=0)
+        self.assertEqual(new_weights_cpu.shape, (indices.numel(), weights_dim))
+        self.assertEqual(new_weights_cpu.dtype, weights.dtype)
+
+        # Test GPU implementation if available
+        if gpu_available:
+            (
+                new_lengths_gpu,
+                new_indices_gpu,
+                new_weights_gpu,
+                new_pos_gpu,
+                unbucketize_permute_gpu,
+            ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+                lengths.cuda(),
+                indices.cuda(),
+                bucketize_pos,
+                sequence,
+                block_sizes.cuda(),
+                my_size,
+                weights.cuda(),
+                weights_dim,
+            )
+
+            torch.testing.assert_close(
+                new_lengths_gpu.cpu(), new_lengths_ref, rtol=0, atol=0
+            )
+
+            # Verify output shapes and types
+            self.assertEqual(new_weights_gpu.shape, (indices.numel(), weights_dim))
+            self.assertEqual(new_weights_gpu.dtype, weights.dtype)
+
+            if sequence:
+                torch.testing.assert_close(
+                    new_indices_gpu.cpu(), new_indices_ref, rtol=0, atol=0
+                )
+
+                # For sequence mode, weights should be in the same order
+                for d in range(weights_dim):
+                    weights_cpu_d = new_weights_cpu[:, d]
+                    weights_gpu_d = new_weights_gpu.cpu()[:, d]
+                    torch.testing.assert_close(weights_gpu_d, weights_cpu_d)
+
+                if bucketize_pos:
+                    torch.testing.assert_close(new_pos_gpu.cpu(), new_pos_cpu)
+            else:
+                # For non-sequence mode, indices may be in different order
+                self.validate_out_of_order_output(
+                    new_indices_ref, new_indices_gpu.cpu(), new_lengths_ref
+                )
+
+                # For non-sequence mode, we can't directly compare weights
+                # but we can verify that all dimensions are preserved
+                self.assertEqual(new_weights_gpu.shape[1], weights_dim)
+
+    @skipIfRocm(ROCM_FAILURE_MESSAGE)
+    @given(
+        index_type=st.sampled_from([torch.int, torch.long]),
+        bucketize_pos=st.booleans(),
+        sequence=st.booleans(),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    def test_block_bucketize_sparse_features_2d_weights_vs_original(
+        self,
+        index_type: Type[torch.dtype],
+        bucketize_pos: bool,
+        sequence: bool,
+    ) -> None:
+        """Test that block_bucketize_sparse_features_2d_weights with weights_dim=1
+        produces the same results as block_bucketize_sparse_features.
+        """
+        # pyre-ignore [6]
+        lengths = torch.tensor([0, 2, 1, 3, 2, 3, 3, 1], dtype=index_type)
+        indices = torch.tensor(
+            [3, 4, 15, 11, 28, 29, 1, 10, 11, 12, 13, 11, 22, 20, 20],
+            # pyre-ignore [6]
+            dtype=index_type,
+        )
+
+        # Create 1D weights for original operator
+        weights_1d = torch.rand(
+            indices.numel(),
+            dtype=torch.float,
+        )
+
+        # Create 2D weights with only one column for new operator
+        weights_2d = weights_1d.clone().view(-1, 1)
+
+        # pyre-ignore [6]
+        block_sizes = torch.tensor([5, 15, 10, 20], dtype=index_type)
+        my_size = 2
+
+        # Call original operator
+        (
+            lengths_1d,
+            indices_1d,
+            weights_1d_out,
+            pos_1d,
+            unbucketize_permute_1d,
+        ) = torch.ops.fbgemm.block_bucketize_sparse_features(
+            lengths,
+            indices,
+            bucketize_pos,
+            sequence,
+            block_sizes,
+            my_size,
+            weights_1d,
+        )
+
+        # Call new operator with weights_dim=1
+        (
+            lengths_2d,
+            indices_2d,
+            weights_2d_out,
+            pos_2d,
+            unbucketize_permute_2d,
+        ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+            lengths,
+            indices,
+            bucketize_pos,
+            sequence,
+            block_sizes,
+            my_size,
+            weights_2d,
+            weights_dim=1,
+        )
+
+        # Verify outputs are the same
+        torch.testing.assert_close(lengths_1d, lengths_2d, rtol=0, atol=0)
+        torch.testing.assert_close(indices_1d, indices_2d, rtol=0, atol=0)
+
+        # Compare weights - need to reshape 2D weights to 1D for comparison
+        torch.testing.assert_close(weights_1d_out, weights_2d_out.view(-1))
+
+        if bucketize_pos:
+            torch.testing.assert_close(pos_1d, pos_2d, rtol=0, atol=0)
+
+        if unbucketize_permute_1d is not None and unbucketize_permute_2d is not None:
+            torch.testing.assert_close(
+                unbucketize_permute_1d, unbucketize_permute_2d, rtol=0, atol=0
+            )
+
+        # Test on GPU if available
+        if gpu_available:
+            # Call original operator on GPU
+            (
+                lengths_1d_gpu,
+                indices_1d_gpu,
+                weights_1d_out_gpu,
+                pos_1d_gpu,
+                unbucketize_permute_1d_gpu,
+            ) = torch.ops.fbgemm.block_bucketize_sparse_features(
+                lengths.cuda(),
+                indices.cuda(),
+                bucketize_pos,
+                sequence,
+                block_sizes.cuda(),
+                my_size,
+                weights_1d.cuda(),
+            )
+
+            # Call new operator on GPU
+            (
+                lengths_2d_gpu,
+                indices_2d_gpu,
+                weights_2d_out_gpu,
+                pos_2d_gpu,
+                unbucketize_permute_2d_gpu,
+            ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+                lengths.cuda(),
+                indices.cuda(),
+                bucketize_pos,
+                sequence,
+                block_sizes.cuda(),
+                my_size,
+                weights_2d.cuda(),
+                weights_dim=1,
+            )
+
+            # Verify GPU outputs are the same
+            torch.testing.assert_close(lengths_1d_gpu, lengths_2d_gpu, rtol=0, atol=0)
+
+            if sequence:
+                torch.testing.assert_close(
+                    indices_1d_gpu, indices_2d_gpu, rtol=0, atol=0
+                )
+                torch.testing.assert_close(
+                    weights_1d_out_gpu, weights_2d_out_gpu.view(-1)
+                )
+                if bucketize_pos:
+                    torch.testing.assert_close(pos_1d_gpu, pos_2d_gpu, rtol=0, atol=0)
+            else:
+                # For non-sequence mode, indices may be in different order
+                # but should contain the same values
+                self.validate_out_of_order_output(
+                    indices_1d_gpu, indices_2d_gpu, lengths_1d_gpu
+                )
+
+                # For weights, we need to compare by sample since order may differ
+                self.validate_out_of_order_output(
+                    weights_1d_out_gpu,
+                    weights_2d_out_gpu.view(-1),
+                    lengths_1d_gpu,
+                    is_int=False,
+                )
+
+                if bucketize_pos:
+                    self.validate_out_of_order_output(
+                        pos_1d_gpu, pos_2d_gpu, lengths_1d_gpu
+                    )
+
+    @skipIfRocm(ROCM_FAILURE_MESSAGE)
+    @given(
+        index_type=st.sampled_from([torch.int, torch.long]),
+        bucketize_pos=st.booleans(),
+        weights_dtype=st.sampled_from([torch.float, torch.double]),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    def test_block_bucketize_sparse_features_2d_weights_pooled_vs_sequence(
+        self,
+        index_type: Type[torch.dtype],
+        bucketize_pos: bool,
+        weights_dtype: torch.dtype,
+    ) -> None:
+        """Test block bucketize sparse features with 2D weights in both pooled and sequence modes.
+
+        This test explicitly compares the behavior between pooled (sequence=False) and
+        sequence (sequence=True) modes with the same inputs.
+        """
+        weights_dim = 3
+        # pyre-ignore [6]
+        lengths = torch.tensor([0, 2, 1, 3, 2, 3, 3, 1], dtype=index_type)
+        indices = torch.tensor(
+            [3, 4, 15, 11, 28, 29, 1, 10, 11, 12, 13, 11, 22, 20, 20],
+            # pyre-ignore [6]
+            dtype=index_type,
+        )
+
+        # Create 2D weights with specified dtype
+        weights = torch.rand(
+            (indices.numel(), weights_dim),
+            dtype=weights_dtype,
+        )
+
+        # pyre-ignore [6]
+        block_sizes = torch.tensor([5, 15, 10, 20], dtype=index_type)
+        my_size = 2
+
+        # Run with sequence=True (order matters)
+        (
+            lengths_seq,
+            indices_seq,
+            weights_seq,
+            pos_seq,
+            unbucketize_permute_seq,
+        ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+            lengths,
+            indices,
+            bucketize_pos,
+            True,  # sequence=True
+            block_sizes,
+            my_size,
+            weights,
+            weights_dim,
+        )
+
+        # Run with sequence=False (order doesn't matter)
+        (
+            lengths_pooled,
+            indices_pooled,
+            weights_pooled,
+            pos_pooled,
+            unbucketize_permute_pooled,
+        ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+            lengths,
+            indices,
+            bucketize_pos,
+            False,  # sequence=False
+            block_sizes,
+            my_size,
+            weights,
+            weights_dim,
+        )
+
+        # Verify lengths are the same regardless of sequence mode
+        torch.testing.assert_close(lengths_seq, lengths_pooled, rtol=0, atol=0)
+
+        # Verify weights have the same shape and dtype
+        self.assertEqual(weights_seq.shape, weights_pooled.shape)
+        self.assertEqual(weights_seq.dtype, weights_dtype)
+        self.assertEqual(weights_pooled.dtype, weights_dtype)
+
+        # In pooled mode, indices may be in different order but should contain the same values
+        self.validate_out_of_order_output(indices_seq, indices_pooled, lengths_seq)
+
+        # For weights, we need to compare by sample since order may differ
+        for d in range(weights_dim):
+            self.validate_out_of_order_output(
+                weights_seq[:, d], weights_pooled[:, d], lengths_seq, is_int=False
+            )
+
+        if bucketize_pos:
+            self.assertTrue(pos_seq is not None)
+            self.assertTrue(pos_pooled is not None)
+            self.validate_out_of_order_output(pos_seq, pos_pooled, lengths_seq)
+
+        # Test on GPU if available
+        if gpu_available:
+            # Run with sequence=True on GPU
+            (
+                lengths_seq_gpu,
+                indices_seq_gpu,
+                weights_seq_gpu,
+                pos_seq_gpu,
+                unbucketize_permute_seq_gpu,
+            ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+                lengths.cuda(),
+                indices.cuda(),
+                bucketize_pos,
+                True,  # sequence=True
+                block_sizes.cuda(),
+                my_size,
+                weights.cuda(),
+                weights_dim,
+            )
+
+            # Run with sequence=False on GPU
+            (
+                lengths_pooled_gpu,
+                indices_pooled_gpu,
+                weights_pooled_gpu,
+                pos_pooled_gpu,
+                unbucketize_permute_pooled_gpu,
+            ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+                lengths.cuda(),
+                indices.cuda(),
+                bucketize_pos,
+                False,  # sequence=False
+                block_sizes.cuda(),
+                my_size,
+                weights.cuda(),
+                weights_dim,
+            )
+
+            # Verify GPU results match between modes
+            torch.testing.assert_close(
+                lengths_seq_gpu, lengths_pooled_gpu, rtol=0, atol=0
+            )
+
+            # Verify weights have the same shape and dtype
+            self.assertEqual(weights_seq_gpu.shape, weights_pooled_gpu.shape)
+            self.assertEqual(weights_seq_gpu.dtype, weights_dtype)
+            self.assertEqual(weights_pooled_gpu.dtype, weights_dtype)
+
+            # In pooled mode, indices may be in different order
+            self.validate_out_of_order_output(
+                indices_seq_gpu.cpu(), indices_pooled_gpu.cpu(), lengths_seq_gpu.cpu()
+            )
+
+    @skipIfRocm(ROCM_FAILURE_MESSAGE)
+    @given(
+        index_type=st.sampled_from([torch.int, torch.long]),
+        bucketize_pos=st.booleans(),
+        sequence=st.booleans(),
+        keep_orig_idx=st.booleans(),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    def test_block_bucketize_sparse_features_2d_weights_keep_orig_idx(
+        self,
+        index_type: Type[torch.dtype],
+        bucketize_pos: bool,
+        sequence: bool,
+        keep_orig_idx: bool,
+    ) -> None:
+        """Test block bucketize sparse features with 2D weights and keep_orig_idx parameter."""
+        weights_dim = 2
+        # pyre-ignore [6]
+        lengths = torch.tensor([0, 2, 1, 3, 2, 3, 3, 1], dtype=index_type)
+        indices = torch.tensor(
+            [3, 4, 15, 11, 28, 29, 1, 10, 11, 12, 13, 11, 22, 20, 20],
+            # pyre-ignore [6]
+            dtype=index_type,
+        )
+
+        # Create 2D weights
+        weights = torch.rand(
+            (indices.numel(), weights_dim),
+            dtype=torch.float,
+        )
+
+        # pyre-ignore [6]
+        block_sizes = torch.tensor([5, 15, 10, 20], dtype=index_type)
+        my_size = 2
+
+        # Run with keep_orig_idx=True/False
+        (
+            lengths_out,
+            indices_out,
+            weights_out,
+            pos_out,
+            unbucketize_permute_out,
+        ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+            lengths,
+            indices,
+            bucketize_pos,
+            sequence,
+            block_sizes,
+            my_size,
+            weights,
+            weights_dim,
+            keep_orig_idx=keep_orig_idx,
+        )
+
+        # Verify output shapes
+        self.assertEqual(weights_out.shape, (indices.numel(), weights_dim))
+
+        # If keep_orig_idx is True, indices should match the original indices
+        if keep_orig_idx and sequence:
+            # In sequence mode with keep_orig_idx=True, indices should be preserved exactly
+            # We need to use the unbucketize_permute to reorder the indices back to original order
+            if unbucketize_permute_out is not None:
+                reordered_indices = torch.zeros_like(indices_out)
+                for i in range(indices.numel()):
+                    reordered_indices[i] = indices_out[unbucketize_permute_out[i]]
+
+                # Check that reordered indices match original indices
+                torch.testing.assert_close(reordered_indices, indices, rtol=0, atol=0)
+
+        # Test on GPU if available
+        if gpu_available:
+            (
+                lengths_out_gpu,
+                indices_out_gpu,
+                weights_out_gpu,
+                pos_out_gpu,
+                unbucketize_permute_out_gpu,
+            ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+                lengths.cuda(),
+                indices.cuda(),
+                bucketize_pos,
+                sequence,
+                block_sizes.cuda(),
+                my_size,
+                weights.cuda(),
+                weights_dim,
+                keep_orig_idx=keep_orig_idx,
+            )
+
+            # Verify output shapes
+            self.assertEqual(weights_out_gpu.shape, (indices.numel(), weights_dim))
+
+            # Check that GPU results match CPU results
+            torch.testing.assert_close(
+                lengths_out_gpu.cpu(), lengths_out, rtol=0, atol=0
+            )
+
+            if sequence:
+                torch.testing.assert_close(
+                    indices_out_gpu.cpu(), indices_out, rtol=0, atol=0
+                )
+
+                for d in range(weights_dim):
+                    torch.testing.assert_close(
+                        weights_out_gpu.cpu()[:, d], weights_out[:, d]
+                    )
+            else:
+                # For non-sequence mode, indices may be in different order
+                self.validate_out_of_order_output(
+                    indices_out, indices_out_gpu.cpu(), lengths_out
+                )
+
+    @skipIfRocm(ROCM_FAILURE_MESSAGE)
+    @given(
+        index_type=st.sampled_from([torch.int, torch.long]),
+        bucketize_pos=st.booleans(),
+        sequence=st.booleans(),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    def test_block_bucketize_sparse_features_2d_weights_keep_orig_idx_per_feature(
+        self,
+        index_type: Type[torch.dtype],
+        bucketize_pos: bool,
+        sequence: bool,
+    ) -> None:
+        """Test block bucketize sparse features with 2D weights and keep_orig_idx_per_feature parameter."""
+        weights_dim = 2
+        # pyre-ignore [6]
+        lengths = torch.tensor([0, 2, 1, 3, 2, 3, 3, 1], dtype=index_type)
+        indices = torch.tensor(
+            [3, 4, 15, 11, 28, 29, 1, 10, 11, 12, 13, 11, 22, 20, 20],
+            # pyre-ignore [6]
+            dtype=index_type,
+        )
+
+        # Create 2D weights
+        weights = torch.rand(
+            (indices.numel(), weights_dim),
+            dtype=torch.float,
+        )
+
+        # pyre-ignore [6]
+        block_sizes = torch.tensor([5, 15, 10, 20], dtype=index_type)
+        my_size = 2
+
+        # Create keep_orig_idx_per_feature tensor
+        # First and third features keep original indices, others don't
+        keep_orig_idx_per_feature = torch.tensor(
+            [True, False, True, False], dtype=torch.bool
+        )
+
+        # Run with keep_orig_idx_per_feature
+        (
+            lengths_out,
+            indices_out,
+            weights_out,
+            pos_out,
+            unbucketize_permute_out,
+        ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+            lengths,
+            indices,
+            bucketize_pos,
+            sequence,
+            block_sizes,
+            my_size,
+            weights,
+            weights_dim,
+            keep_orig_idx=False,  # Global setting is False
+            keep_orig_idx_per_feature=keep_orig_idx_per_feature,  # Per-feature setting
+        )
+
+        # Verify output shapes
+        self.assertEqual(weights_out.shape, (indices.numel(), weights_dim))
+
+        # Test on GPU if available
+        if gpu_available:
+            (
+                lengths_out_gpu,
+                indices_out_gpu,
+                weights_out_gpu,
+                pos_out_gpu,
+                unbucketize_permute_out_gpu,
+            ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+                lengths.cuda(),
+                indices.cuda(),
+                bucketize_pos,
+                sequence,
+                block_sizes.cuda(),
+                my_size,
+                weights.cuda(),
+                weights_dim,
+                keep_orig_idx=False,
+                keep_orig_idx_per_feature=keep_orig_idx_per_feature.cuda(),
+            )
+
+            # Verify output shapes
+            self.assertEqual(weights_out_gpu.shape, (indices.numel(), weights_dim))
+
+            # Check that GPU results match CPU results
+            torch.testing.assert_close(
+                lengths_out_gpu.cpu(), lengths_out, rtol=0, atol=0
+            )
+
+            if sequence:
+                torch.testing.assert_close(
+                    indices_out_gpu.cpu(), indices_out, rtol=0, atol=0
+                )
+
+                for d in range(weights_dim):
+                    torch.testing.assert_close(
+                        weights_out_gpu.cpu()[:, d], weights_out[:, d]
+                    )
+            else:
+                # For non-sequence mode, indices may be in different order
+                self.validate_out_of_order_output(
+                    indices_out, indices_out_gpu.cpu(), lengths_out
+                )
+
+    @skipIfRocm(ROCM_FAILURE_MESSAGE)
+    @given(
+        index_type=st.sampled_from([torch.int, torch.long]),
+        bucketize_pos=st.booleans(),
+        sequence=st.booleans(),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    def test_block_bucketize_sparse_features_2d_weights_total_num_blocks(
+        self,
+        index_type: Type[torch.dtype],
+        bucketize_pos: bool,
+        sequence: bool,
+    ) -> None:
+        """Test block bucketize sparse features with 2D weights and total_num_blocks parameter."""
+        weights_dim = 2
+        # pyre-ignore [6]
+        lengths = torch.tensor([0, 2, 1, 3, 2, 3, 3, 1], dtype=index_type)
+        indices = torch.tensor(
+            [3, 4, 15, 11, 28, 29, 1, 10, 11, 12, 13, 11, 22, 20, 20],
+            # pyre-ignore [6]
+            dtype=index_type,
+        )
+
+        # Create 2D weights
+        weights = torch.rand(
+            (indices.numel(), weights_dim),
+            dtype=torch.float,
+        )
+
+        # pyre-ignore [6]
+        block_sizes = torch.tensor([5, 15, 10, 20], dtype=index_type)
+        my_size = 2
+
+        # Create total_num_blocks tensor
+        # pyre-ignore [6]
+        total_num_blocks = torch.tensor([6, 6, 6, 6], dtype=index_type)
+
+        # Run with total_num_blocks
+        (
+            lengths_out,
+            indices_out,
+            weights_out,
+            pos_out,
+            unbucketize_permute_out,
+        ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+            lengths,
+            indices,
+            bucketize_pos,
+            sequence,
+            block_sizes,
+            my_size,
+            weights,
+            weights_dim,
+            total_num_blocks=total_num_blocks,
+        )
+
+        # Verify output shapes
+        self.assertEqual(weights_out.shape, (indices.numel(), weights_dim))
+
+        # Test on GPU if available
+        if gpu_available:
+            (
+                lengths_out_gpu,
+                indices_out_gpu,
+                weights_out_gpu,
+                pos_out_gpu,
+                unbucketize_permute_out_gpu,
+            ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+                lengths.cuda(),
+                indices.cuda(),
+                bucketize_pos,
+                sequence,
+                block_sizes.cuda(),
+                my_size,
+                weights.cuda(),
+                weights_dim,
+                total_num_blocks=total_num_blocks.cuda(),
+            )
+
+            # Verify output shapes
+            self.assertEqual(weights_out_gpu.shape, (indices.numel(), weights_dim))
+
+            # Check that GPU results match CPU results
+            torch.testing.assert_close(
+                lengths_out_gpu.cpu(), lengths_out, rtol=0, atol=0
+            )
+
+            if sequence:
+                torch.testing.assert_close(
+                    indices_out_gpu.cpu(), indices_out, rtol=0, atol=0
+                )
+
+                for d in range(weights_dim):
+                    torch.testing.assert_close(
+                        weights_out_gpu.cpu()[:, d], weights_out[:, d]
+                    )
+            else:
+                # For non-sequence mode, indices may be in different order
+                self.validate_out_of_order_output(
+                    indices_out, indices_out_gpu.cpu(), lengths_out
+                )
+
+    @skipIfRocm(ROCM_FAILURE_MESSAGE)
+    @given(
+        index_type=st.sampled_from([torch.int, torch.long]),
+        bucketize_pos=st.booleans(),
+        sequence=st.booleans(),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    def test_block_bucketize_sparse_features_2d_weights_block_bucketize_pos(
+        self,
+        index_type: Type[torch.dtype],
+        bucketize_pos: bool,
+        sequence: bool,
+    ) -> None:
+        """Test block bucketize sparse features with 2D weights and block_bucketize_pos parameter."""
+        weights_dim = 2
+        # pyre-ignore [6]
+        lengths = torch.tensor([2, 1, 1, 2, 0, 2], dtype=index_type)
+        indices = torch.tensor(
+            [1, 8, 5, 6, 7, 8, 8, 4],
+            # pyre-ignore [6]
+            dtype=index_type,
+        )
+
+        # Create 2D weights
+        weights = torch.rand(
+            (indices.numel(), weights_dim),
+            dtype=torch.float,
+        )
+
+        # pyre-ignore [6]
+        block_sizes = torch.tensor([5, 10, 8], dtype=index_type)
+        my_size = 2
+
+        # Create block_bucketize_pos
+        block_bucketize_pos = [
+            # pyre-ignore [6]
+            torch.tensor([0, 2, 8], dtype=index_type),
+            # pyre-ignore [6]
+            torch.tensor([0, 5, 10], dtype=index_type),
+            # pyre-ignore [6]
+            torch.tensor([0, 7, 12], dtype=index_type),
+        ]
+
+        # Run with block_bucketize_pos
+        (
+            lengths_out,
+            indices_out,
+            weights_out,
+            pos_out,
+            unbucketize_permute_out,
+        ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+            lengths,
+            indices,
+            bucketize_pos,
+            sequence,
+            block_sizes,
+            my_size,
+            weights,
+            weights_dim,
+            block_bucketize_pos=block_bucketize_pos,
+        )
+
+        # Verify output shapes
+        self.assertEqual(weights_out.shape, (indices.numel(), weights_dim))
+
+        # Test on GPU if available
+        if gpu_available:
+            block_bucketize_pos_gpu = [t.cuda() for t in block_bucketize_pos]
+
+            (
+                lengths_out_gpu,
+                indices_out_gpu,
+                weights_out_gpu,
+                pos_out_gpu,
+                unbucketize_permute_out_gpu,
+            ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+                lengths.cuda(),
+                indices.cuda(),
+                bucketize_pos,
+                sequence,
+                block_sizes.cuda(),
+                my_size,
+                weights.cuda(),
+                weights_dim,
+                block_bucketize_pos=block_bucketize_pos_gpu,
+            )
+
+            # Verify output shapes
+            self.assertEqual(weights_out_gpu.shape, (indices.numel(), weights_dim))
+
+            # Check that GPU results match CPU results
+            torch.testing.assert_close(
+                lengths_out_gpu.cpu(), lengths_out, rtol=0, atol=0
+            )
+
+            if sequence:
+                torch.testing.assert_close(
+                    indices_out_gpu.cpu(), indices_out, rtol=0, atol=0
+                )
+
+                for d in range(weights_dim):
+                    torch.testing.assert_close(
+                        weights_out_gpu.cpu()[:, d], weights_out[:, d]
+                    )
+            else:
+                # For non-sequence mode, indices may be in different order
+                self.validate_out_of_order_output(
+                    indices_out, indices_out_gpu.cpu(), lengths_out
+                )
+
+    @skipIfRocm(ROCM_FAILURE_MESSAGE)
+    @given(
+        index_type=st.sampled_from([torch.int, torch.long]),
+        bucketize_pos=st.booleans(),
+        sequence=st.booleans(),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
+    def test_block_bucketize_sparse_features_2d_weights_with_variable_batch_sizes(
+        self,
+        index_type: Type[torch.dtype],
+        bucketize_pos: bool,
+        sequence: bool,
+    ) -> None:
+        """Test block bucketize sparse features with 2D weights and variable batch sizes."""
+        weights_dim = 3
+        # pyre-ignore [6]
+        lengths = torch.tensor([2, 1, 1, 2, 0, 2], dtype=index_type)
+        indices = torch.tensor(
+            [1, 8, 5, 6, 7, 8, 8, 4],
+            # pyre-ignore [6]
+            dtype=index_type,
+        )
+        # pyre-ignore [6]
+        batch_sizes = torch.tensor([3, 1, 2], dtype=index_type)
+
+        # Create 2D weights with shape [indices.numel(), weights_dim]
+        weights = torch.rand(
+            (indices.numel(), weights_dim),
+            dtype=torch.float,
+        )
+
+        # pyre-ignore [6]
+        block_sizes = torch.tensor([5, 10, 8], dtype=index_type)
+        my_size = 2
+        max_B = batch_sizes.max().item()
+
+        new_lengths_ref = torch.tensor(
+            [1, 0, 0, 2, 0, 1, 1, 1, 1, 0, 0, 1],
+            # pyre-ignore [6]
+            dtype=index_type,
+        )
+        new_indices_ref = torch.tensor(
+            [1, 7, 8, 4, 3, 0, 1, 0],
+            # pyre-ignore [6]
+            dtype=index_type,
+        )
+
+        (
+            new_lengths_cpu,
+            new_indices_cpu,
+            new_weights_cpu,
+            new_pos_cpu,
+            unbucketize_permute,
+        ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+            lengths,
+            indices,
+            bucketize_pos,
+            sequence,
+            block_sizes,
+            my_size,
+            weights,
+            weights_dim,
+            batch_sizes,
+            max_B,
+        )
+
+        torch.testing.assert_close(new_lengths_cpu, new_lengths_ref, rtol=0, atol=0)
+        torch.testing.assert_close(new_indices_cpu, new_indices_ref, rtol=0, atol=0)
+        self.assertEqual(new_weights_cpu.shape, (indices.numel(), weights_dim))
+
+        if gpu_available:
+            (
+                new_lengths_gpu,
+                new_indices_gpu,
+                new_weights_gpu,
+                new_pos_gpu,
+                unbucketize_permute_gpu,
+            ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+                lengths.cuda(),
+                indices.cuda(),
+                bucketize_pos,
+                sequence,
+                block_sizes.cuda(),
+                my_size,
+                weights.cuda(),
+                weights_dim,
+                batch_sizes.cuda(),
+                max_B,
+            )
+
+            torch.testing.assert_close(
+                new_lengths_gpu.cpu(), new_lengths_ref, rtol=0, atol=0
+            )
+            self.assertEqual(new_weights_gpu.shape, (indices.numel(), weights_dim))
+
+            if sequence:
+                torch.testing.assert_close(
+                    new_indices_gpu.cpu(), new_indices_ref, rtol=0, atol=0
+                )
+            else:
+                self.validate_out_of_order_output(
+                    new_indices_ref, new_indices_gpu.cpu(), new_lengths_ref
+                )
+
+
+extend_test_class(BlockBucketize2DWeightsTest)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/fbgemm_gpu/test/sparse/failures_dict.json
+++ b/fbgemm_gpu/test/sparse/failures_dict.json
@@ -17,6 +17,14 @@
     "fbgemm::asynchronous_inclusive_cumsum": {},
     "fbgemm::batch_index_select_dim0": {},
     "fbgemm::block_bucketize_sparse_features": {
+      "BlockBucketize2DWeightsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_2d_weights_vs_original": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights_vs_original": {
+        "comment": "",
+        "status": "xfail"
+      },
       "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features": {
         "comment": "",
         "status": "xfail"
@@ -102,6 +110,72 @@
         "status": "xfail"
       },
       "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_with_variable_batch_sizes": {
+        "comment": "",
+        "status": "xfail"
+      }
+    },
+    "fbgemm::block_bucketize_sparse_features_2d_weights": {
+      "BlockBucketize2DWeightsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_2d_weights": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketize2DWeightsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_2d_weights_block_bucketize_pos": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketize2DWeightsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_2d_weights_keep_orig_idx": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketize2DWeightsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_2d_weights_keep_orig_idx_per_feature": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketize2DWeightsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_2d_weights_pooled_vs_sequence": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketize2DWeightsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_2d_weights_total_num_blocks": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketize2DWeightsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_2d_weights_vs_original": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketize2DWeightsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_2d_weights_with_variable_batch_sizes": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights_block_bucketize_pos": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights_keep_orig_idx": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights_keep_orig_idx_per_feature": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights_pooled_vs_sequence": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights_total_num_blocks": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights_vs_original": {
+        "comment": "",
+        "status": "xfail"
+      },
+      "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights_with_variable_batch_sizes": {
         "comment": "",
         "status": "xfail"
       }


### PR DESCRIPTION
Summary:
for new embedding cache feature requirement, we need to distribute id with weight to sharded embedding, and then write the embedding value directly instead of via backward pass and optimizer step.
this feature will be able to extend kvzch tbe to be an embedding cache. here has more information about the requirement details
https://docs.google.com/document/d/1_wlH1qoNOkK7nQmphCqBATDTHNvFJMclURwO1SDDJsQ/edit?tab=t.0#heading=h.sb19p9vr4aha

and how to support it from kvzch:
https://docs.google.com/document/d/1TJHKvO1m3-5tYAKZGhacXnGk7iCNAzz7wQlrFbX_LDI/edit?tab=t.0#heading=h.70vdya87lyup

due to this requirement, we need a block bucketization with 2d weight tensor kernel to help distribute data in the same way with input dist.
to avoid pollute the original input dist kernel, and we do not need the function of pooling, I added a separate kernel to support 2d weight

Differential Revision: D78928659


