### PR TITLE
Quantization with min & max bounds support - float to 8 bit on X86-64

### DIFF
--- a/include/fbgemm/QuantUtils.h
+++ b/include/fbgemm/QuantUtils.h
@@ -318,7 +318,8 @@ FBGEMM_API void FloatOrHalfToFused8BitRowwiseQuantizedSBFloat(
     const InputType* input,
     size_t input_rows,
     int input_columns,
-    std::uint8_t* output);
+    std::uint8_t* output,
+    const InputType* rowwise_min_max = nullptr);
 
 /**
  * Convert fused rowwise quantized (8-bit) inputs to float or half outputs.

--- a/include/fbgemm/QuantUtilsAvx2.h
+++ b/include/fbgemm/QuantUtilsAvx2.h
@@ -151,7 +151,8 @@ void FloatOrHalfToFused8BitRowwiseQuantizedSBFloatAvx2(
     const InputType* input,
     size_t input_rows,
     int input_columns,
-    std::uint8_t* output);
+    std::uint8_t* output,
+    const InputType* rowwise_min_max = nullptr);
 
 template <typename OutputType, int BIT_RATE>
 void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfAvx2(

--- a/src/QuantUtils.cc
+++ b/src/QuantUtils.cc
@@ -711,11 +711,12 @@ void FloatOrHalfToFused8BitRowwiseQuantizedSBFloat(
     const InputType* input,
     size_t input_rows,
     int input_columns,
-    std::uint8_t* output) {
+    std::uint8_t* output,
+    const InputType* rowwise_min_max) {
   if (cpuinfo_initialize() && fbgemmHasAvx2Support()) {
 #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
     FloatOrHalfToFused8BitRowwiseQuantizedSBFloatAvx2<InputType>(
-        input, input_rows, input_columns, output);
+        input, input_rows, input_columns, output, rowwise_min_max);
 #endif
   } else {
     FloatOrHalfToFused8BitRowwiseQuantizedSBFloatRef<InputType>(
@@ -900,7 +901,8 @@ void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf(
       const type* input,                                                       \
       size_t input_rows,                                                       \
       int input_columns,                                                       \
-      std::uint8_t* output);                                                   \
+      std::uint8_t* output,                                                    \
+      const type* rowwise_min_max);                                            \
   template FBGEMM_API void                                                     \
   Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfRef<type>(                      \
       const uint8_t* input,                                                    \


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1813

At present quantization is performed at whole tensor level where each row's minimum and maximum values are calculated. In order to scale the quantization when tensor's are col-wise sharded, we are introducing these changes.

These changes enable passing the minimum and maximum values of each row of the whole tensor and use it to quantize the col-wise sharded tensors individually.

In this specific change, the support is added for float to 8-bit quantization on X86-64 architecture. In the future changes we will expand the support for other source/target bit rates and architectures.

Reviewed By: excelle08

Differential Revision: D78181177


