### PR TITLE
Fix output strides in Cutlass kernels

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_fwd.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_fwd.cu
@@ -171,7 +171,6 @@ std::tuple<at::Tensor, at::Tensor> fmha_fwd(
       make_stride(
         make_stride(static_cast<int>(q_.stride(3)), static_cast<int>(q_.stride(2))),
         static_cast<int>(q_.stride(0))));
-  StrideO stride_O = stride_Q;
 
   // K shape = (B, K, H_K, 1, D)
   StrideK stride_K = make_stride(
@@ -181,6 +180,11 @@ std::tuple<at::Tensor, at::Tensor> fmha_fwd(
         make_stride(_0{}, static_cast<int>(k_.stride(2))),
         static_cast<int>(k_.stride(0))));
   StrideV stride_V = stride_K;
+
+  // O shape = (B, Q, H_K, H_R, D)
+  // O is always contiguous
+  StrideO stride_O = make_stride(
+      H_Q * D, _1{}, make_stride(make_stride(D, H_R * D), H_Q * D * SQ));
 
   // LSE shape = (B, H_K, H_R, Q)
   StrideLSE stride_LSE =

--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_utils.hpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_utils.hpp
@@ -82,7 +82,11 @@ struct TensorWrapper {
     if (offset_ == 0) {
       return tensor_.view(shape);
     }
-    return tensor_.narrow(0, offset_, size_).view(shape);
+    auto t = tensor_.narrow(0, offset_, size_).view(shape);
+    TORCH_CHECK(
+        t.is_contiguous(),
+        "The underlying tensor in TensorWrapper must be contiguous");
+    return t;
   }
 
   void copy_from_device(const at::Tensor& tensor) {

--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/device/fmha_device_bwd.hpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/device/fmha_device_bwd.hpp
@@ -123,6 +123,9 @@ public:
 
     ElementAccumulator softmax_scale;
 
+    int window_size_left = -1;
+    int window_size_right = -1;
+
     cutlass::KernelHardwareInfo hw_info;
   };
 
@@ -220,7 +223,7 @@ private:
         scaled_lse, to_bwd_stride(stride_scaled_lse),
         sum_OdO, to_bwd_stride(stride_sum_OdO),
         dQ_acc, to_bwd_stride(stride_dQ),
-        args.softmax_scale },
+        args.softmax_scale, args.window_size_left, args.window_size_right},
       { args.ptr_dK, to_bwd_stride(args.stride_dK),
         args.ptr_dV, to_bwd_stride(args.stride_dV) },
       args.hw_info

--- a/fbgemm_gpu/experimental/gen_ai/test/attention/blackwell_fmha_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/attention/blackwell_fmha_test.py
@@ -600,7 +600,9 @@ class CutlassBlackwellFMHATest(unittest.TestCase):
         causal=st.booleans(),
         is_varlen=st.booleans(),
         is_gqa=st.booleans(),
-        window_size=st.sampled_from([(-1, -1)]),
+        window_size=st.sampled_from(
+            [(-1, -1), (128, 0), (256, 0), (128, 128), (512, 0)]
+        ),
     )
     @settings(**common_settings)
     def test_backward(


### PR DESCRIPTION
Summary:
Before this diff, we use the input stride as the output stride.
However, they can be different as the input can be non-contiguous
while the output is always contiguous.  This diff computes the output
stride separately.

Reviewed By: henrylhtsang

Differential Revision: D81275032
