### PR TITLE
add tests to decode and padded jagged_vs_padded_kv

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/test/attention/blackwell_fmha_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/attention/blackwell_fmha_test.py
@@ -338,7 +338,7 @@ class CutlassBlackwellFMHATest(unittest.TestCase):
             for seqlen_k in [64, 128, 256, 1024]
             for batch_size in [1, 2]
             for is_mqa in [True]
-            for window_size in [(-1, -1)]
+            for window_size in [(-1, -1), (0, 0), (0, 128), (128, 0), (1024, 0)]
         ]
     )
     def test_decode(
@@ -381,7 +381,7 @@ class CutlassBlackwellFMHATest(unittest.TestCase):
             for kv_padding in [128, 256, 512, 1024]
             for batch_size in [2, 8]
             for causal in [True, False]
-            for window_size in [(-1, -1)]
+            for window_size in [(-1, -1), (0, 0), (0, 128), (128, 0), (1024, 0)]
         ]
     )
     def test_jagged_vs_padded_kv(


### PR DESCRIPTION
Summary:
Adding test cases for the other two tests.

NOTE: you can't have window size like (-1, 1024) or (1024, -1) without passing in max_seqlen_q / max_seqlen_k

Reviewed By: Aya-ZIbra

Differential Revision: D81169147


