### PR TITLE
disable random initialization in embedding cache mode

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -639,6 +639,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                     else None
                 ),
                 flushing_block_size,
+                self._embedding_cache_mode,  # disable_random_init
             )
             if self.bulk_init_chunk_size > 0:
                 self.ssd_uniform_init_lower: float = ssd_uniform_init_lower
@@ -722,6 +723,8 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                     else None
                 ),  # hash_size_cumsum
                 self.backend_return_whole_row,  # backend_return_whole_row
+                False,  # enable_async_update
+                self._embedding_cache_mode,  # disable_random_init
             )
         else:
             raise AssertionError(f"Invalid backend type {self.backend_type}")

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
@@ -109,7 +109,8 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
       bool enable_async_update = false,
       std::optional<at::Tensor> table_dims = std::nullopt,
       std::optional<at::Tensor> hash_size_cumsum = std::nullopt,
-      bool is_training = true)
+      bool is_training = true,
+      bool disable_random_init = false)
       : kv_db::EmbeddingKVDB(
             num_shards,
             max_D,
@@ -138,7 +139,8 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
         max_D,
         uniform_init_lower,
         uniform_init_upper,
-        row_storage_bitwidth);
+        row_storage_bitwidth,
+        disable_random_init);
     if (table_dims.has_value()) {
       TORCH_CHECK_TENSOR_PROPERTIES(table_dims, at::ScalarType::Long);
       TORCH_NUM_CHECK_AND_ASSIGN_TENSOR_DATA(
@@ -167,13 +169,14 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
       int64_t max_D,
       double uniform_init_lower,
       double uniform_init_upper,
-      int64_t row_storage_bitwidth) {
+      int64_t row_storage_bitwidth,
+      bool disable_random_init) {
     for (auto i = 0; i < num_shards; ++i) {
       auto* gen = at::check_generator<at::CPUGeneratorImpl>(
           at::detail::getDefaultCPUGenerator());
       {
         std::lock_guard<std::mutex> lock(gen->mutex_);
-        initializers_.push_back(std::make_unique<ssd ::Initializer>(
+        initializers_.push_back(std::make_unique<ssd::Initializer>(
             gen->random64(),
             max_D,
             uniform_init_lower,
@@ -181,6 +184,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
             row_storage_bitwidth));
       }
     }
+    disable_random_init_ = disable_random_init;
   }
 
   /// get all ids in the kvstore
@@ -1219,8 +1223,16 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
       int64_t copied_width) {
     CHECK_GE(row_width, copied_width);
     CHECK_GE(max_D_, row_width);
-    int64_t storage_row_bytes = elem_size_ * max_D_;
     int64_t row_bytes = row_width * elem_size_;
+
+    if (disable_random_init_) {
+      // Skip data copy and leave values empty (zero-initialized)
+      std::memset(
+          &(weights_data_ptr[weights_row_index * row_bytes]), 0, row_bytes);
+      return;
+    }
+
+    int64_t storage_row_bytes = elem_size_ * max_D_;
     auto copied_bytes = elem_size_ * copied_width;
     int64_t start_offset_bytes = elem_size_ * width_offset;
     int64_t row_index = 0;
@@ -1632,6 +1644,8 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
 
   std::atomic<int64_t> inplace_update_hit_cnt_{0};
   std::atomic<int64_t> inplace_update_miss_cnt_{0};
+
+  bool disable_random_init_;
 }; // class DramKVEmbeddingCache
 
 } // namespace kv_mem

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h
@@ -38,7 +38,8 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
       const std::optional<at::Tensor>& table_dims = std::nullopt,
       const std::optional<at::Tensor>& hash_size_cumsum = std::nullopt,
       bool backend_return_whole_row = false,
-      bool enable_async_update = false) {
+      bool enable_async_update = false,
+      bool disable_random_init = false) {
     if (row_storage_bitwidth == 16) {
       impl_ = std::make_shared<kv_mem::DramKVEmbeddingCache<at::Half>>(
           max_D,
@@ -51,7 +52,9 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
           backend_return_whole_row,
           enable_async_update,
           table_dims,
-          hash_size_cumsum);
+          hash_size_cumsum,
+          true, // is_training
+          disable_random_init);
     } else if (row_storage_bitwidth == 32) {
       impl_ = std::make_shared<kv_mem::DramKVEmbeddingCache<float>>(
           max_D,
@@ -64,7 +67,9 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
           backend_return_whole_row,
           enable_async_update,
           table_dims,
-          hash_size_cumsum);
+          hash_size_cumsum,
+          true, // is_training
+          disable_random_init);
     } else {
       throw std::runtime_error("Failed to create recording device");
     }

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
@@ -44,7 +44,8 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
       const std::vector<int64_t>& table_sizes = {},
       std::optional<at::Tensor> table_dims = std::nullopt,
       std::optional<at::Tensor> hash_size_cumsum = std::nullopt,
-      int64_t flushing_block_size = 2000000000 /*2GB*/)
+      int64_t flushing_block_size = 2000000000 /*2GB*/,
+      bool disable_random_init = false)
       : impl_(std::make_shared<ssd::EmbeddingRocksDB>(
             path,
             num_shards,
@@ -74,7 +75,8 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
             table_sizes,
             table_dims,
             hash_size_cumsum,
-            flushing_block_size)) {}
+            flushing_block_size,
+            disable_random_init)) {}
 
   void set_cuda(
       at::Tensor indices,

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -808,7 +808,8 @@ static auto embedding_rocks_db_wrapper =
                 std::vector<int64_t>,
                 std::optional<at::Tensor>,
                 std::optional<at::Tensor>,
-                int64_t>(),
+                int64_t,
+                bool>(),
             "",
             {
                 torch::arg("path"),
@@ -840,6 +841,7 @@ static auto embedding_rocks_db_wrapper =
                 torch::arg("table_dims") = std::nullopt,
                 torch::arg("hash_size_cumsum") = std::nullopt,
                 torch::arg("flushing_block_size") = 2000000000 /* 2GB */,
+                torch::arg("disable_random_init") = false,
             })
         .def(
             "set_cuda",
@@ -942,6 +944,7 @@ static auto dram_kv_embedding_cache_wrapper =
                 std::optional<at::Tensor>,
                 std::optional<at::Tensor>,
                 bool,
+                bool,
                 bool>(),
             "",
             {
@@ -956,6 +959,7 @@ static auto dram_kv_embedding_cache_wrapper =
                 torch::arg("hash_size_cumsum") = std::nullopt,
                 torch::arg("backend_return_whole_row") = false,
                 torch::arg("enable_async_update") = false,
+                torch::arg("disable_random_init") = false,
             })
         .def(
             "set_cuda",


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1833

X-link: https://github.com/pytorch/torchrec/pull/3340

add one flag for embedding_cache_mode TBE. when it's embedding_cache_mode, return empty value instead of generate random value for missing ids. Here is the design for embedding cache : https://docs.google.com/document/d/1TJHKvO1m3-5tYAKZGhacXnGk7iCNAzz7wQlrFbX_LDI/edit?tab=t.0#heading=h.15hoa4gn7e85

 {F1981653046}

Reviewed By: kausv

Differential Revision: D81462543


