### PR TITLE
SWA attention backward optimization 1

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/collective/fmha_fusion.hpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/collective/fmha_fusion.hpp
@@ -513,7 +513,7 @@ struct LocalMask : NoMask {
 };
 
 template<bool kIsQBegin = true>
-struct LocalMaskForBackward : LocalMask<kIsQBegin> {
+struct LocalMaskForBackward : LocalMask<kIsQBegin>, ResidualMaskForBackward {
 
   using Base = LocalMask<kIsQBegin>;
 


### PR DESCRIPTION
Summary: Instead of setting local_masking=True, we change to do that by checking q_right_window_left, kv_left, q_left_window_right, kv_right.

Differential Revision: D81538024


