### PR TITLE
Support more dtypes for gather_scale_dense_tokens output

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/gen_ai/moe/gather_scatter.py
+++ b/fbgemm_gpu/experimental/gen_ai/gen_ai/moe/gather_scatter.py
@@ -53,7 +53,7 @@ def gather_scale_dense_tokens(
     # a = K * T
     a = token_indices.shape[0]
 
-    out = torch.empty((a, D), device="cuda", dtype=torch.bfloat16)
+    out = torch.empty((a, D), device=x.device, dtype=x.dtype)
     if a == 0 or D == 0:
         return out
 


### PR DESCRIPTION
Summary: The current gather_scale_dense_tokens uses BF16 for the output. Sometime we also need FP32. So this diff updates the output type to the same type as the input tokens type.

Differential Revision: D81546328


