### PR TITLE
Set `pta::DefaultPtrTraits` as default in `TA_B` macro

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/tensor_accessor_builder.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/tensor_accessor_builder.h
@@ -266,9 +266,11 @@ struct TensorAccessorBuilder {
 //  ```
 ////////////////////////////////////////////////////////////////////////////////
 
-#define TA_B(TENSOR, T, N, INDEX_NBITS)                                      \
-  fbgemm_gpu::utils::                                                        \
-      TensorAccessorBuilder<T, N, INDEX_NBITS, false, at::DefaultPtrTraits>( \
+// Default to pta::DefaultPtrTraits here since the rest of the codebase declares
+// pta::TensorAccessor without specifying the PtrTraits template argument.
+#define TA_B(TENSOR, T, N, INDEX_NBITS)                                       \
+  fbgemm_gpu::utils::                                                         \
+      TensorAccessorBuilder<T, N, INDEX_NBITS, false, pta::DefaultPtrTraits>( \
           #TENSOR, TENSOR)
 
 #define PTA_B(TENSOR, T, N, INDEX_NBITS)                                     \


### PR DESCRIPTION
Summary: - Set `pta::DefaultPtrTraits` as default in `TA_B` macro, since the rest of the codebase declares `pta::TensorAccessor` without specifying the PtrTraits template argument

Differential Revision: D81565111


