### PR TITLE
Improve assertions on fp8_rowwise_grouped_gemm

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
@@ -263,6 +263,8 @@ __global__ void set_kernel_args(
       }
     }
 
+    CUDA_KERNEL_ASSERT_MSG(N_group % 8 == 0, "N must be divisible by 8");
+
     // Only write actual group information if this group is nonzero.
     if (M_group > 0 && N_group > 0 && K_group > 0) {
       // Get index automatically for this group.
@@ -789,6 +791,12 @@ at::Tensor f8f8bf16_rowwise_grouped_mm(
     TORCH_CHECK(out.dim() == 3 && out.size(0) == G && out.size(1) == M && out.size(2) == N, "out shape must be (G, M, N).");
   } else {
     TORCH_CHECK(false, "Invalid input shapes. Must be one of 2D-2D, 3D-3D, 2D-3D, 3D-2D.");
+  }
+
+  // Enforce CK CShuffleBlockTransferScalarPerVector_NPerBlock divisibility
+  // Technically, 8 is more strict than required, but otherwise this validation becomes more complex.
+  if (inputType != GroupedGemmInputType::_3D2D) {
+    TORCH_CHECK(N % 8 == 0, "N must be divisible by 8.");
   }
 
   // Early exit for empty input.


### PR DESCRIPTION
Summary:
The kernel can support M, K dimensions dynamically, even sizes with padding.

For N, the situation is a bit trickier. In addition to the restrictions on the tile padding (which is already handled), N must also be divisible by a CK instance specific value, otherwise the kernel would not properly run. This is tricky as for grouped gemm, host does not have full problem shapes, so we can't call the Gemm validation.

Example (with manually hacked in checks):
```
Arg N (9) value is not a multiple of CShuffleBlockTransferScalarPerVector_NPerBlock (8 )
```
Specifically, its not always 8 - but the first value of [CBLOCK_SPV](https://www.internalfb.com/code/fbsource/[414675fb91f2]/fbcode/deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/kernels/fp8_rowwise_grouped_common.h?lines=68). This is at most 8 for our instances (otherwise 4,2,1), so using 8 is ok (albeit a bit more strict). For CUTLASS (and currently in torch._scaled_grouped_mm API) it already enforces divisible by 16, so if the problem shape is known we should be ok already (but better to add validation at kernel level).

We also add kernel level assertions for the jagged case, as that cannot be validated on the host (e.g. N in 2d-2d, 3d-2d), and would cause silent correctness issues.

Differential Revision: D81524823


