### PR TITLE
Add 2d-2d support to MXFP8 Grouped GEMM

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/mx8mx8bf16_grouped.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/mx8mx8bf16_grouped.cu
@@ -29,52 +29,52 @@ namespace fbgemm_gpu {
 
 template <typename InputType>
 Kernel_mx8mx8bf16_grouped<InputType>
-get_kernel_via_heuristics(int total_M, int N, int K, int G) {
+get_kernel_via_heuristics(int M, int N, int K, int G) {
   // Llama4 shapes
   if (N == 5120 && K == 1024) {
     if (G <= 8) {
-      if (total_M <= 256) {
+      if (M <= 256) {
         return mx8mx8bf16_grouped_256_64_256_2_1_1;
-      } else if (total_M <= 512) {
+      } else if (M <= 512) {
         return mx8mx8bf16_grouped_128_64_256_1_1_1;
-      } else if (total_M <= 1024) {
+      } else if (M <= 1024) {
         return mx8mx8bf16_grouped_128_128_256_1_1_1;
       }
     } else if (G <= 16) {
-      if (total_M <= 1024) {
+      if (M <= 1024) {
         return mx8mx8bf16_grouped_128_64_256_1_1_1;
-      } else if (total_M <= 2048) {
+      } else if (M <= 2048) {
         return mx8mx8bf16_grouped_256_128_256_2_1_1;
       }
     } else {
-      if (total_M <= 1024) {
+      if (M <= 1024) {
         return mx8mx8bf16_grouped_256_64_256_2_1_1;
-      } else if (total_M <= 4096) {
+      } else if (M <= 4096) {
         return mx8mx8bf16_grouped_128_64_256_1_1_1;
-      } else if (total_M <= 8192) {
+      } else if (M <= 8192) {
         return mx8mx8bf16_grouped_256_64_256_2_1_1;
       }
     }
     return mx8mx8bf16_grouped_256_256_256_2_1_1;
   } else if (N == 2048 && K == 5120) {
     if (G <= 8) {
-      if (total_M <= 256) {
+      if (M <= 256) {
         return mx8mx8bf16_grouped_256_64_256_2_1_1;
-      } else if (total_M <= 512) {
+      } else if (M <= 512) {
         return mx8mx8bf16_grouped_128_64_256_1_1_1;
-      } else if (total_M <= 1024) {
+      } else if (M <= 1024) {
         return mx8mx8bf16_grouped_128_128_256_1_1_1;
       }
     } else if (G <= 16) {
-      if (total_M <= 1024) {
+      if (M <= 1024) {
         return mx8mx8bf16_grouped_256_64_256_2_1_1;
-      } else if (total_M <= 2048) {
+      } else if (M <= 2048) {
         return mx8mx8bf16_grouped_128_128_256_1_1_1;
       }
     } else {
-      if (total_M <= 1024) {
+      if (M <= 1024) {
         return mx8mx8bf16_grouped_256_64_256_2_1_1;
-      } else if (total_M <= 16384) {
+      } else if (M <= 16384) {
         return mx8mx8bf16_grouped_256_128_256_2_1_1;
       }
     }
@@ -82,7 +82,7 @@ get_kernel_via_heuristics(int total_M, int N, int K, int G) {
   }
 
   // Fallback to legacy heuristic
-  if (total_M <= 1000) {
+  if (M <= 1000) {
     return mx8mx8bf16_grouped_256_128_256_2_1_1;
   } else {
     return mx8mx8bf16_grouped_256_256_256_2_1_1;
@@ -91,7 +91,7 @@ get_kernel_via_heuristics(int total_M, int N, int K, int G) {
 
 template <typename InputType>
 at::Tensor dispatch_mx8_grouped_kernel(
-    int total_M,
+    int M,
     int N,
     int K,
     int G,
@@ -100,86 +100,101 @@ at::Tensor dispatch_mx8_grouped_kernel(
     InputType x_scale,
     InputType w_scale,
     at::Tensor output,
-    std::optional<at::Tensor> zero_start_index_M = std::nullopt,
-    std::optional<at::Tensor> M_sizes = std::nullopt,
-    std::optional<at::Tensor> starting_row_after_padding = std::nullopt) {
-  TORCH_CHECK(
-      zero_start_index_M.has_value() != M_sizes.has_value(),
-      "One of zero_start_index_M or M_sizes must be provided.");
-  TORCH_CHECK(M_sizes.has_value(), "M_sizes is assumed to be provided.");
-  TORCH_CHECK(
-      starting_row_after_padding.has_value(),
-      "starting_row_after_padding is assumed to be provided.");
-  at::Tensor starting_row_after_padding_actual =
-      starting_row_after_padding.value_or(at::zeros({0}));
-  TORCH_CHECK(starting_row_after_padding_actual.size(0) % (G + 1) == 0);
-
+    at::Tensor offsets) {
   // Select kernel to run via heuristics.
   auto kernel = [&]() {
-    return get_kernel_via_heuristics<InputType>(total_M, N, K, G);
+    return get_kernel_via_heuristics<InputType>(M, N, K, G);
   }();
   // Invoke kernel
-  return kernel(
-      XQ,
-      WQ,
-      x_scale,
-      w_scale,
-      output,
-      G,
-      zero_start_index_M,
-      M_sizes,
-      starting_row_after_padding);
+  return kernel(XQ, WQ, x_scale, w_scale, output, G, offsets);
 }
 
-at::Tensor mx8mx8bf16_grouped_stacked(
-    at::Tensor XQ, // FP8
-    at::Tensor WQ, // FP8
+at::Tensor mx8mx8bf16_grouped_mm(
+    at::Tensor XQ,
+    at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    at::Tensor M_sizes,
-    std::optional<at::Tensor> starting_row_after_padding = std::nullopt) {
-  int64_t total_M = XQ.size(0);
-  int64_t N = WQ.size(1);
-  int64_t K = WQ.size(2);
-  int64_t G = M_sizes.size(0);
-  TORCH_CHECK(
-      M_sizes.device() == XQ.device(),
-      "M_sizes must be on same device as inputs.");
-  TORCH_CHECK(
-      WQ.dim() == 3 && WQ.size(0) == G, "Weights should be shape [G, N, K].")
-  at::Tensor Y = at::empty({total_M, N}, XQ.options().dtype(at::kBFloat16));
-  // Early exit for empty inputs.
-  if (total_M == 0) {
-    return Y;
+    at::Tensor offsets,
+    std::optional<at::Tensor> output) {
+  TORCH_CHECK(offsets.dtype() == at::kInt, "offsets must be int32.");
+  TORCH_CHECK(offsets.dim() == 1, "offsets must be 1D tensor.");
+  TORCH_CHECK(XQ.is_contiguous(), "XQ must be row major.");
+  TORCH_CHECK(WQ.transpose(-2, -1).is_contiguous(), "WQ must be column major.");
+  TORCH_CHECK(x_scale.is_contiguous(), "x_scale must be contiguous.");
+  TORCH_CHECK(w_scale.is_contiguous(), "w_scale must be contiguous.");
+
+  int64_t G = offsets.size(0);
+  int64_t M = XQ.size(0);
+  int64_t N = WQ.size(-1);
+  int64_t K = WQ.size(-2);
+
+  at::Tensor output_actual;
+
+  // 2d-3d case.
+  if (XQ.dim() == 2 && WQ.dim() == 3) {
+    // Alias for clarity that groups are along M dimension for 2d-3d case.
+    int64_t total_M = M;
+
+    // Allocate output tensor if necessary.
+    output_actual = output.has_value()
+        ? output.value()
+        : at::empty({total_M, N}, XQ.options().dtype(at::kBFloat16));
+
+    TORCH_CHECK(
+        XQ.size(-1) == K && WQ.size(0) == G,
+        "for 2d-3d grouped GEMM, XQ shape must be (total_M, K) and WQ shape must be (G, K, N).");
+
+    TORCH_CHECK(
+        output_actual.dim() == 2 && output_actual.size(0) == total_M &&
+            output_actual.size(1) == N,
+        "for 2d-3d grouped GEMM, output shape must be (total_M, N).");
+
+    // 2d-2d case.
+  } else if (XQ.dim() == 2 && WQ.dim() == 2) {
+    // Alias for clarity that groups are along K dimension for 2d-2d case.
+    int64_t total_K = K;
+
+    // Allocate output tensor if necessary.
+    output_actual = output.has_value()
+        ? output.value()
+        : at::empty({G, M, N}, XQ.options().dtype(at::kBFloat16));
+
+    TORCH_CHECK(
+        XQ.dim() == 2 && WQ.dim() == 2 && WQ.size(-2) == total_K,
+        "for 2d-2d grouped GEMM, XQ shape must be (M, total_K) and WQ shape must be (total_K, N).");
+
+    TORCH_CHECK(
+        output_actual.dim() == 3 && output_actual.size(0) == G &&
+            output_actual.size(1) == M && output_actual.size(2) == N,
+        "for 2d-2d grouped GEMM, output shape must be (G, M, N).");
+
+  } else {
+    TORCH_CHECK(false, "Invalid input shapes. Must be one of 2D-2D, 2D-3D.");
   }
+
+  // Early exit for empty inputs.
+  if (M == 0) {
+    return output_actual;
+  }
+
   // Return continuous view of output.
   return dispatch_mx8_grouped_kernel<at::Tensor>(
-      total_M,
-      N,
-      K,
-      G,
-      XQ,
-      WQ,
-      x_scale,
-      w_scale,
-      Y,
-      std::nullopt,
-      M_sizes,
-      starting_row_after_padding);
+      M, N, K, G, XQ, WQ, x_scale, w_scale, output_actual, offsets);
 }
 
 #else
 
-at::Tensor mx8mx8bf16_grouped_stacked(
-    at::Tensor XQ, // FP8
-    at::Tensor WQ, // FP8
+at::Tensor mx8mx8bf16_grouped_mm(
+    at::Tensor XQ,
+    at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    at::Tensor M_sizes,
-    std::optional<at::Tensor> starting_row_after_padding = std::nullopt) {
+    at::Tensor offsets,
+    std::optional<at::Tensor> output) {
   throw std::runtime_error(
       "CUDA version is older than 12.8"); // requires CUDA>=12.8
 }
+
 #endif
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/mx8mx8bf16_grouped/mx8mx8bf16_grouped_128_128_256_1_1_1.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/mx8mx8bf16_grouped/mx8mx8bf16_grouped_128_128_256_1_1_1.cu
@@ -19,19 +19,9 @@ at::Tensor mx8mx8bf16_grouped_128_128_256_1_1_1(
     at::Tensor w_scale,
     at::Tensor output,
     int64_t G,
-    std::optional<at::Tensor> zero_start_index_M,
-    std::optional<at::Tensor> M_sizes,
-    std::optional<at::Tensor> starting_row_after_padding) {
+    at::Tensor offsets) {
   return mx8mx8bf16_grouped_impl<at::Tensor, 128, 128, 256, 1, 1, 1>(
-      XQ,
-      WQ,
-      x_scale,
-      w_scale,
-      output,
-      G,
-      zero_start_index_M,
-      M_sizes,
-      starting_row_after_padding);
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
 }
 
 #endif

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/mx8mx8bf16_grouped/mx8mx8bf16_grouped_128_64_256_1_1_1.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/mx8mx8bf16_grouped/mx8mx8bf16_grouped_128_64_256_1_1_1.cu
@@ -19,19 +19,9 @@ at::Tensor mx8mx8bf16_grouped_128_64_256_1_1_1(
     at::Tensor w_scale,
     at::Tensor output,
     int64_t G,
-    std::optional<at::Tensor> zero_start_index_M,
-    std::optional<at::Tensor> M_sizes,
-    std::optional<at::Tensor> starting_row_after_padding) {
+    at::Tensor offsets) {
   return mx8mx8bf16_grouped_impl<at::Tensor, 128, 64, 256, 1, 1, 1>(
-      XQ,
-      WQ,
-      x_scale,
-      w_scale,
-      output,
-      G,
-      zero_start_index_M,
-      M_sizes,
-      starting_row_after_padding);
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
 }
 
 #endif

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/mx8mx8bf16_grouped/mx8mx8bf16_grouped_256_128_256_2_1_1.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/mx8mx8bf16_grouped/mx8mx8bf16_grouped_256_128_256_2_1_1.cu
@@ -19,19 +19,9 @@ at::Tensor mx8mx8bf16_grouped_256_128_256_2_1_1(
     at::Tensor w_scale,
     at::Tensor output,
     int64_t G,
-    std::optional<at::Tensor> zero_start_index_M,
-    std::optional<at::Tensor> M_sizes,
-    std::optional<at::Tensor> starting_row_after_padding) {
+    at::Tensor offsets) {
   return mx8mx8bf16_grouped_impl<at::Tensor, 256, 128, 256, 2, 1, 1>(
-      XQ,
-      WQ,
-      x_scale,
-      w_scale,
-      output,
-      G,
-      zero_start_index_M,
-      M_sizes,
-      starting_row_after_padding);
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
 }
 
 #endif

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/mx8mx8bf16_grouped/mx8mx8bf16_grouped_256_256_256_2_1_1.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/mx8mx8bf16_grouped/mx8mx8bf16_grouped_256_256_256_2_1_1.cu
@@ -19,19 +19,9 @@ at::Tensor mx8mx8bf16_grouped_256_256_256_2_1_1(
     at::Tensor w_scale,
     at::Tensor output,
     int64_t G,
-    std::optional<at::Tensor> zero_start_index_M,
-    std::optional<at::Tensor> M_sizes,
-    std::optional<at::Tensor> starting_row_after_padding) {
+    at::Tensor offsets) {
   return mx8mx8bf16_grouped_impl<at::Tensor, 256, 256, 256, 2, 1, 1>(
-      XQ,
-      WQ,
-      x_scale,
-      w_scale,
-      output,
-      G,
-      zero_start_index_M,
-      M_sizes,
-      starting_row_after_padding);
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
 }
 
 #endif

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/mx8mx8bf16_grouped/mx8mx8bf16_grouped_256_64_256_2_1_1.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/mx8mx8bf16_grouped/mx8mx8bf16_grouped_256_64_256_2_1_1.cu
@@ -19,19 +19,9 @@ at::Tensor mx8mx8bf16_grouped_256_64_256_2_1_1(
     at::Tensor w_scale,
     at::Tensor output,
     int64_t G,
-    std::optional<at::Tensor> zero_start_index_M,
-    std::optional<at::Tensor> M_sizes,
-    std::optional<at::Tensor> starting_row_after_padding) {
+    at::Tensor offsets) {
   return mx8mx8bf16_grouped_impl<at::Tensor, 256, 64, 256, 2, 1, 1>(
-      XQ,
-      WQ,
-      x_scale,
-      w_scale,
-      output,
-      G,
-      zero_start_index_M,
-      M_sizes,
-      starting_row_after_padding);
+      XQ, WQ, x_scale, w_scale, output, G, offsets);
 }
 
 #endif

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/mx8mx8bf16_grouped/mx8mx8bf16_grouped_manifest.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/mx8mx8bf16_grouped/mx8mx8bf16_grouped_manifest.cuh
@@ -19,9 +19,7 @@ at::Tensor mx8mx8bf16_grouped_128_64_256_1_1_1(
     at::Tensor w_scale,
     at::Tensor output,
     int64_t G,
-    std::optional<at::Tensor> zero_start_index_M,
-    std::optional<at::Tensor> M_sizes,
-    std::optional<at::Tensor> starting_row_after_padding);
+    at::Tensor offsets);
 
 at::Tensor mx8mx8bf16_grouped_128_128_256_1_1_1(
     at::Tensor XQ, // FP8
@@ -30,9 +28,7 @@ at::Tensor mx8mx8bf16_grouped_128_128_256_1_1_1(
     at::Tensor w_scale,
     at::Tensor output,
     int64_t G,
-    std::optional<at::Tensor> zero_start_index_M,
-    std::optional<at::Tensor> M_sizes,
-    std::optional<at::Tensor> starting_row_after_padding);
+    at::Tensor offsets);
 
 at::Tensor mx8mx8bf16_grouped_256_64_256_2_1_1(
     at::Tensor XQ, // FP8
@@ -41,9 +37,7 @@ at::Tensor mx8mx8bf16_grouped_256_64_256_2_1_1(
     at::Tensor w_scale,
     at::Tensor output,
     int64_t G,
-    std::optional<at::Tensor> zero_start_index_M,
-    std::optional<at::Tensor> M_sizes,
-    std::optional<at::Tensor> starting_row_after_padding);
+    at::Tensor offsets);
 
 at::Tensor mx8mx8bf16_grouped_256_128_256_2_1_1(
     at::Tensor XQ, // FP8
@@ -52,9 +46,7 @@ at::Tensor mx8mx8bf16_grouped_256_128_256_2_1_1(
     at::Tensor w_scale,
     at::Tensor output,
     int64_t G,
-    std::optional<at::Tensor> zero_start_index_M,
-    std::optional<at::Tensor> M_sizes,
-    std::optional<at::Tensor> starting_row_after_padding);
+    at::Tensor offsets);
 
 at::Tensor mx8mx8bf16_grouped_256_256_256_2_1_1(
     at::Tensor XQ, // FP8
@@ -63,21 +55,17 @@ at::Tensor mx8mx8bf16_grouped_256_256_256_2_1_1(
     at::Tensor w_scale,
     at::Tensor output,
     int64_t G,
-    std::optional<at::Tensor> zero_start_index_M,
-    std::optional<at::Tensor> M_sizes,
-    std::optional<at::Tensor> starting_row_after_padding);
+    at::Tensor offsets);
 
 template <typename InputType>
 using Kernel_mx8mx8bf16_grouped = at::Tensor (*)(
-    InputType,
-    InputType,
-    InputType,
-    InputType,
-    at::Tensor,
-    int64_t,
-    std::optional<at::Tensor>,
-    std::optional<at::Tensor>,
-    std::optional<at::Tensor>);
+    InputType, // XQ
+    InputType, // WQ
+    InputType, // x_scale
+    InputType, // w_scale
+    at::Tensor, // output
+    int64_t, // G
+    at::Tensor); // offsets
 
 template <typename InputType>
 const std::unordered_map<std::string, Kernel_mx8mx8bf16_grouped<InputType>>&

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -64,13 +64,13 @@ at::Tensor f4f4bf16_grouped_stacked(
     std::optional<at::Tensor> global_scale = std::nullopt,
     std::optional<at::Tensor> starting_row_after_padding = std::nullopt,
     bool use_mx = true);
-at::Tensor mx8mx8bf16_grouped_stacked(
+at::Tensor mx8mx8bf16_grouped_mm(
     at::Tensor XQ,
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    at::Tensor M_sizes,
-    std::optional<at::Tensor> starting_row_after_padding = std::nullopt);
+    at::Tensor offsets,
+    std::optional<at::Tensor> output = std::nullopt);
 at::Tensor f8f8bf16(
     at::Tensor XQ,
     at::Tensor WQ,
@@ -320,7 +320,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   m.impl("f4f4bf16", f4f4bf16);
   m.impl("f4f4bf16_grouped", f4f4bf16_grouped);
   m.impl("f4f4bf16_grouped_stacked", f4f4bf16_grouped_stacked);
-  m.impl("mx8mx8bf16_grouped_stacked", mx8mx8bf16_grouped_stacked);
+  m.impl("mx8mx8bf16_grouped_mm", mx8mx8bf16_grouped_mm);
   m.impl("f8f8bf16", f8f8bf16);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas);
   m.impl("bf16_fast_gemv", bf16_fast_gemv);
@@ -376,7 +376,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
   m.impl("f4f4bf16", f4f4bf16);
   m.impl("f4f4bf16_grouped", f4f4bf16_grouped);
   m.impl("f4f4bf16_grouped_stacked", f4f4bf16_grouped_stacked);
-  m.impl("mx8mx8bf16_grouped_stacked", mx8mx8bf16_grouped_stacked);
+  m.impl("mx8mx8bf16_grouped_mm", mx8mx8bf16_grouped_mm);
   m.impl("f8f8bf16", f8f8bf16);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas);
   m.impl("bf16_fast_gemv", bf16_fast_gemv);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize_defs.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize_defs.cpp
@@ -25,7 +25,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "f4f4bf16_grouped_stacked(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor M_sizes, Tensor? global_scale=None, Tensor? starting_row_after_padding=None, bool use_mx=True) -> Tensor");
   m.def(
-      "mx8mx8bf16_grouped_stacked(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor M_sizes, Tensor? starting_row_after_padding=None) -> Tensor");
+      "mx8mx8bf16_grouped_mm(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor offsets, Tensor(a!)? output=None) -> Tensor");
   m.def(
       "f8f8bf16(Tensor XQ, Tensor WQ, Tensor scale, bool use_fast_accum=True) -> Tensor");
   m.def(


### PR DESCRIPTION
Summary:
## MXFP8 grouped GEMM updates to (1) handle 2d-2d case, and (2) have a PyTorch compliant API

- Add support for 2d-2d inputs with dynamic groups along K dimension
- Added tests to ensure correct numerics for both 2d-2d and 2d-3d cases, with randomly group sizes
- Add benchmarks for both 2d-3d and 2d-2d cases

Reviewed By: ngimel, cthi

Differential Revision: D81362680


