### PR TITLE
report L per table

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/stats/bench_params_reporter.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/stats/bench_params_reporter.py
@@ -305,6 +305,26 @@ class TBEBenchmarkParamsReporter:
                     for f in range(len(adhoc_config["Es"]))
                 ]
 
+            bag_sizes = (offsets[1:] - offsets[:-1]).tolist()
+            adhoc_config["Ls"] = []
+            pointer_counter = 0
+            if batch_size_per_feature_per_rank:
+                for batchs_size in adhoc_config["Bs"]:
+                    current_L = 0
+                    for _i in range(batchs_size):
+                        current_L += bag_sizes[pointer_counter]
+                        pointer_counter += 1
+                    adhoc_config["Ls"].append(current_L / batchs_size)
+            else:
+                batch_size = int(len(bag_sizes) // len(adhoc_config["Es"]))
+
+                for _j in range(len(adhoc_config["Es"])):
+                    current_L = 0
+                    for _i in range(batch_size):
+                        current_L += bag_sizes[pointer_counter]
+                        pointer_counter += 1
+                    adhoc_config["Ls"].append(current_L / batch_size)
+
             # Write the TBE config to FileStore
             self.filestore.write(
                 f"{self.path_prefix}/tbe-{op_id}-config-estimation-{iteration}.json",


### PR DESCRIPTION
Summary:
Here is a summary of the diff in markdown format:

**report L per table**

### Changed Files

* `fbcode/deeplearning/fbgemm/fbgemm_gpu/fbgemm_gpu/tbe/stats/bench_params_reporter.py`

### Summary

This diff modifies the `bench_params_reporter.py` file to report the `L` value per table. Specifically, it adds a new list `Ls` to the `adhoc_config` dictionary and updates the `bag_sizes` calculation to use the `offsets` variable.

The changes include:

* Adding a new list `Ls` to the `adhoc_config` dictionary to store the `L` values per table
* Calculating the `bag_sizes` using the `offsets` variable
* Updating the `pointer_counter` and `current_L` variables to calculate the `L` value per table

Differential Revision: D78900105


