### PR TITLE
MXFP8 Grouped GEMM tuning

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/mx8mx8bf16_grouped/mx8mx8bf16_grouped_manifest.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/mx8mx8bf16_grouped/mx8mx8bf16_grouped_manifest.cuh
@@ -13,8 +13,8 @@ namespace fbgemm_gpu {
 #if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)
 
 at::Tensor mx8mx8bf16_grouped_128_64_256_1_1_1(
-    at::Tensor XQ, // FP8
-    at::Tensor WQ, // FP8
+    at::Tensor XQ,
+    at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
@@ -22,8 +22,8 @@ at::Tensor mx8mx8bf16_grouped_128_64_256_1_1_1(
     at::Tensor offsets);
 
 at::Tensor mx8mx8bf16_grouped_128_128_256_1_1_1(
-    at::Tensor XQ, // FP8
-    at::Tensor WQ, // FP8
+    at::Tensor XQ,
+    at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
@@ -31,8 +31,8 @@ at::Tensor mx8mx8bf16_grouped_128_128_256_1_1_1(
     at::Tensor offsets);
 
 at::Tensor mx8mx8bf16_grouped_256_64_256_2_1_1(
-    at::Tensor XQ, // FP8
-    at::Tensor WQ, // FP8
+    at::Tensor XQ,
+    at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
@@ -40,8 +40,8 @@ at::Tensor mx8mx8bf16_grouped_256_64_256_2_1_1(
     at::Tensor offsets);
 
 at::Tensor mx8mx8bf16_grouped_256_128_256_2_1_1(
-    at::Tensor XQ, // FP8
-    at::Tensor WQ, // FP8
+    at::Tensor XQ,
+    at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
@@ -49,41 +49,38 @@ at::Tensor mx8mx8bf16_grouped_256_128_256_2_1_1(
     at::Tensor offsets);
 
 at::Tensor mx8mx8bf16_grouped_256_256_256_2_1_1(
-    at::Tensor XQ, // FP8
-    at::Tensor WQ, // FP8
+    at::Tensor XQ,
+    at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
     int64_t G,
     at::Tensor offsets);
 
-template <typename InputType>
 using Kernel_mx8mx8bf16_grouped = at::Tensor (*)(
-    InputType, // XQ
-    InputType, // WQ
-    InputType, // x_scale
-    InputType, // w_scale
+    at::Tensor, // XQ
+    at::Tensor, // WQ
+    at::Tensor, // x_scale
+    at::Tensor, // w_scale
     at::Tensor, // output
     int64_t, // G
     at::Tensor); // offsets
 
-template <typename InputType>
-const std::unordered_map<std::string, Kernel_mx8mx8bf16_grouped<InputType>>&
+const std::unordered_map<std::string, Kernel_mx8mx8bf16_grouped>&
 get_mx8mx8bf16_grouped_kernels() {
-  static const std::
-      unordered_map<std::string, Kernel_mx8mx8bf16_grouped<InputType>>
-          kernels = {
-              {"mx8mx8bf16_grouped_128_64_256_1_1_1",
-               mx8mx8bf16_grouped_128_64_256_1_1_1},
-              {"mx8mx8bf16_grouped_128_128_256_1_1_1",
-               mx8mx8bf16_grouped_128_128_256_1_1_1},
-              {"mx8mx8bf16_grouped_256_64_256_2_1_1",
-               mx8mx8bf16_grouped_256_64_256_2_1_1},
-              {"mx8mx8bf16_grouped_256_128_256_2_1_1",
-               mx8mx8bf16_grouped_256_128_256_2_1_1},
-              {"mx8mx8bf16_grouped_256_256_256_2_1_1",
-               mx8mx8bf16_grouped_256_256_256_2_1_1},
-          };
+  static const std::unordered_map<std::string, Kernel_mx8mx8bf16_grouped>
+      kernels = {
+          {"mx8mx8bf16_grouped_128_64_256_1_1_1",
+           mx8mx8bf16_grouped_128_64_256_1_1_1},
+          {"mx8mx8bf16_grouped_128_128_256_1_1_1",
+           mx8mx8bf16_grouped_128_128_256_1_1_1},
+          {"mx8mx8bf16_grouped_256_64_256_2_1_1",
+           mx8mx8bf16_grouped_256_64_256_2_1_1},
+          {"mx8mx8bf16_grouped_256_128_256_2_1_1",
+           mx8mx8bf16_grouped_256_128_256_2_1_1},
+          {"mx8mx8bf16_grouped_256_256_256_2_1_1",
+           mx8mx8bf16_grouped_256_256_256_2_1_1},
+      };
   return kernels;
 }
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1848

Re-tune MXFP8 grouped gemm with tuning tooling to autogen a heuristic on B200 @ peak 750W
- We see peak tflops of 1963, so we can achieve near roofline for some MNK which is nice. Some shapes still cannot achieve it, so likely room for further improvements. But let's get something out the door first.
- Remove some unnecessary template code.

Differential Revision: D81683544


