### PR TITLE
do not flush in eval flow

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -3498,6 +3498,10 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
     def flush(self, force: bool = False) -> None:
         # allow force flush from split_embedding_weights to cover edge cases, e.g. checkpointing
         # after trained 0 batches
+        if not self.training:
+            # for eval mode, we should not write anything to embedding
+            return
+
         if self.step == self.last_flush_step and not force:
             logging.info(
                 f"SSD TBE has been flushed at {self.last_flush_step=} already for tbe:{self.tbe_unique_id}"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1849

The SSD TBE is designed to accelerate data reading from the GPU by caching query results in the L1 cache and scratch pad. However, when the value is no longer needed for the current batch, it is written back to the CPU backend to free up space for the next batch. This write-back operation can occur during both forward pass and state dict flow to ensure data consistency during training.

However, this behavior is not desirable in eval flow, as there may be IDs that were not seen during training. In such cases, after querying these IDs, they could be written back to the backend even without a backward pass. This goes against the regular PyTorch embedding design, which expects embeddings to be frozen during evaluation.

This diff aims to prevent backend writing in flush, which can be triggered by state dict calls.

Reviewed By: EddyLXJ

Differential Revision: D81298474


