### PR TITLE
Upgrade heuristic generation script

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/common/scripts/make_heuristic.py
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/common/scripts/make_heuristic.py
@@ -4,129 +4,212 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
 import argparse
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import Dict, List, Set, Tuple
 
 
-def build_heuristic(
-    file_path: str, threshold: float
-) -> Dict[Tuple[int, ...], List[Tuple[str, str]]]:
+@dataclass(frozen=True)
+class ProblemShape:
+    """Represents a problem shape with M, N, K dimensions."""
+
+    M: int
+    N: int
+    K: int
+
+    @classmethod
+    def from_tuple(cls, shape_tuple: Tuple[int, int, int]) -> "ProblemShape":
+        """Create ProblemShape from a tuple."""
+        return cls(M=shape_tuple[0], N=shape_tuple[1], K=shape_tuple[2])
+
+    def to_tuple(self) -> Tuple[int, int, int]:
+        """Convert to tuple for backwards compatibility."""
+        return (self.M, self.N, self.K)
+
+
+@dataclass(frozen=True)
+class KernelResult:
+    """Represents a parsed kernel profiling result."""
+
+    problem_shape: ProblemShape
+    kernel: str
+    time_ms: float
+
+
+@dataclass
+class KEntry:
+    """Represents a K dimension entry with its assigned kernel."""
+
+    K: int
+    kernel: str
+
+
+@dataclass
+class NEntry:
+    """Represents an N dimension entry with its K entries."""
+
+    N: int
+    k_entries: List[KEntry]
+
+
+@dataclass
+class MEntry:
+    """Represents an M dimension entry with its N entries."""
+
+    M: int
+    n_entries: List[NEntry]
+
+
+@dataclass
+class Heuristic:
+    """Represents the complete heuristic structure."""
+
+    m_entries: List[MEntry]
+
+
+def get_kernel_assignment(file_path: str, threshold: float) -> Dict[ProblemShape, str]:
     """
-    Builds a heuristic from a set of profiling runs on a kernel.
+    Assign kernels to problem shape from a set of profiling runs on a kernel.
     The heuristic is currently built in a greedy approach:
     1. For all problem shapes consider all kernels performing within (1+threshold) of the fastest kernel.
     2. For the above kernels, count how often it appeared across all problem shapes.
     3. When assigning a kernel to a problem shape, prioritize kernels that appear more often to minimize the number of kernels used.
-
-    Assumptions:
-
-    The ordering of the problem shape dimension is assumed to be (outer_dim, inner_shapes) where outer_dim varies but inner_shapes is fixed in a set of problem shapes.
-    This is how we decide how to map a set of problem shapes into a heuristic.
-    E.g. For the following problem shapes (5, 5120, 1024), (6, 5120, 1024), (7, 2048, 1024), (8, 2048, 1024) we would build a heuristic along:
-
-    Problem Shape (5120, 1024):
-      5: ...
-      6: ...
-
-    Problem Shape (2048, 1024):
-      7: ...
-      8: ...
     """
-    # Inner problem shapes
-    inner_shapes: Set[Tuple[int, ...]] = set()
-    # Problem Shape -> Best kernel time
-    best_times_ms: Dict[Tuple[int, ...], float] = {}
-    # Kernels count across all problem shapes
+    kernel_results: List[KernelResult] = []
+    best_times_ms: Dict[ProblemShape, float] = {}
     kernel_count: Dict[str, int] = defaultdict(int)
-    # Problem Shape -> Candidate kernels
-    kernel_candidates: Dict[Tuple[int, ...], Set[str]] = defaultdict(set)
-    # Problem Shape -> Assigned kernel
-    kernel_assignment: Dict[Tuple[int, ...], str] = {}
-    # Inner problem shape -> (Outer Dim, Kernel)
-    heuristics: Dict[Tuple[int, ...], List[Tuple[str, str]]] = {}
+    kernel_candidates: Dict[ProblemShape, Set[str]] = defaultdict(set)
+    kernel_assignment: Dict[ProblemShape, str] = {}
 
     with open(file_path, "r") as file:
-        parsed_rows = []
-
-        # Parse CSV and find the best time for each problem shape.
-        rows = file.readlines()
-        for row in rows:
-            problem_shape_str, kernel, time_ms_str = row.split(",")
-            problem_shape = tuple(int(x) for x in problem_shape_str.split("_"))
+        # Parse CSV and find the best time for each problem shape
+        for row in file:
+            problem_shape_str, kernel, time_ms_str = row.strip().split(",")
+            shape_tuple = tuple(int(x) for x in problem_shape_str.split("_"))
+            problem_shape = ProblemShape.from_tuple(shape_tuple)
             time_ms = float(time_ms_str)
 
-            inner_shapes.add(problem_shape[1:])
+            result = KernelResult(
+                problem_shape=problem_shape, kernel=kernel, time_ms=time_ms
+            )
+            kernel_results.append(result)
+
             best_times_ms[problem_shape] = (
                 time_ms
                 if problem_shape not in best_times_ms
                 else min(best_times_ms[problem_shape], time_ms)
             )
 
-            parsed_rows.append((problem_shape, kernel, time_ms))
-
         # Filter kernels for each problem shape based on the permitted threshold
-        for problem_shape, kernel, time_ms in parsed_rows:
-            if time_ms < (best_times_ms[problem_shape] * (1 + threshold)):
-                kernel_candidates[problem_shape].add(kernel)
-                kernel_count[kernel] += 1
+        for result in kernel_results:
+            if result.time_ms < (best_times_ms[result.problem_shape] * (1 + threshold)):
+                kernel_candidates[result.problem_shape].add(result.kernel)
+                kernel_count[result.kernel] += 1
 
-    # Prefer kernels that are used more often
-    kernel_order = sorted(kernel_count.keys(), key=kernel_count.get, reverse=True)
-
-    for kernel in kernel_order:
+    # Prefer kernels that are used more often across all problem shapes
+    while len(kernel_assignment) < len(kernel_candidates):
+        top_kernel = sorted(kernel_count.keys(), key=kernel_count.get, reverse=True)[0]
         for problem_shape, candidates in kernel_candidates.items():
-            if problem_shape not in kernel_assignment and kernel in candidates:
-                kernel_assignment[problem_shape] = kernel
+            if problem_shape not in kernel_assignment and top_kernel in candidates:
+                kernel_assignment[problem_shape] = top_kernel
+                # Adjust kernel count to reflect this problem shape was just assigned
+                for candidate in candidates:
+                    kernel_count[candidate] -= 1
 
-    for inner_shape in inner_shapes:
-        outer_dims_and_kernel = sorted(
-            [
-                (problem_shape[0], kernel)
-                for problem_shape, kernel in kernel_assignment.items()
-                if problem_shape[1:] == inner_shape
-            ],
-            key=lambda x: x[0],
-        )
-
-        heuristic: List[Tuple[str, str]] = []
-        last_outer_dim, last_kernel = outer_dims_and_kernel[0]
-        for outer_dim, assigned_kernel in outer_dims_and_kernel[1:]:
-            if last_kernel != assigned_kernel:
-                heuristic.append((str(last_outer_dim), last_kernel))
-            last_outer_dim, last_kernel = outer_dim, assigned_kernel
-        heuristic.append(("else", last_kernel))
-
-        heuristics[inner_shape] = heuristic
-
-    return heuristics
+    return kernel_assignment
 
 
-# A basic codegen to make the if statements, customize as needed for your kernel.
-def print_heuristic_cpp(
-    heuristics: Dict[Tuple[int, ...], List[Tuple[str, str]]],
-    varnames_arg: str,
-) -> None:
-    varnames = dict(enumerate(varnames_arg.split(",")))
+def get_heuristic(kernel_assignment: Dict[ProblemShape, str]) -> Heuristic:
+    """Build hierarchical heuristic structure from kernel assignments."""
+    M_vals = sorted({problem_shape.M for problem_shape in kernel_assignment.keys()})
+    N_vals = sorted({problem_shape.N for problem_shape in kernel_assignment.keys()})
+    K_vals = sorted({problem_shape.K for problem_shape in kernel_assignment.keys()})
 
-    for inner_shape, outer_dims_and_kernels in heuristics.items():
-        condition = " && ".join(
-            [f"{varnames[idx + 1]} == {val}" for idx, val in enumerate(inner_shape)]
-        )
-        print(f"if ({condition}) {{")
-        for idx, (outer_dim, kernel) in enumerate(outer_dims_and_kernels):
-            if idx == 0:
-                print(f"  if ({varnames[0]} <= {outer_dim}) {{")
-            elif idx == len(outer_dims_and_kernels) - 1:
+    m_entries = []
+
+    for M in M_vals:
+        n_entries = []
+        for N in N_vals:
+            k_entries = []
+            for K in K_vals:
+                assignment = kernel_assignment[ProblemShape(M, N, K)]
+                # Check if we can merge with the previous K entry
+                if k_entries and k_entries[-1].kernel == assignment:
+                    k_entries[-1].K = K
+                else:
+                    k_entries.append(KEntry(K=K, kernel=assignment))
+
+            # If there's only one K entry, set K to 0 to indicate "all K values" so we can de-duplicate
+            if len(k_entries) == 1:
+                k_entries[0].K = 0
+
+            # Check if we can merge with the previous N entry
+            if n_entries and n_entries[-1].k_entries == k_entries:
+                n_entries[-1].N = N
+            else:
+                n_entries.append(NEntry(N=N, k_entries=k_entries))
+
+        # Check if we can merge with the previous M entry
+        if m_entries and m_entries[-1].n_entries == n_entries:
+            m_entries[-1].M = M
+        else:
+            m_entries.append(MEntry(M=M, n_entries=n_entries))
+
+    return Heuristic(m_entries=m_entries)
+
+
+def print_heuristic_cpp(heuristic: Heuristic) -> None:
+    for m_idx, m_entry in enumerate(heuristic.m_entries):
+        if m_idx == 0:
+            print(f"if (M <= {m_entry.M}) {{")
+        elif m_idx == len(heuristic.m_entries) - 1:
+            print("} else {")
+        else:
+            print(f"}} else if (M <= {m_entry.M}) {{")
+
+        for n_idx, n_entry in enumerate(m_entry.n_entries):
+            if n_idx == 0:
+                print(f"  if (N <= {n_entry.N}) {{")
+            elif n_idx == len(m_entry.n_entries) - 1:
                 print("  } else {")
             else:
-                print(f"  }} else if ({varnames[0]} <= {outer_dim}) {{")
-            print(f"    return {kernel};")
-        print("  }")
-        print("}\n")
+                print(f"  }} else if (N <= {n_entry.N}) {{")
+
+            if len(n_entry.k_entries) == 1:
+                print(f"    return {n_entry.k_entries[0].kernel};")
+            else:
+                for k_idx, k_entry in enumerate(n_entry.k_entries):
+                    if k_idx == 0:
+                        print(f"    if (K <= {k_entry.K}) {{")
+                    elif k_idx == len(n_entry.k_entries) - 1:
+                        print("    } else {")
+                    else:
+                        print(f"    }} else if (K <= {k_entry.K}) {{")
+                    print(f"      return {k_entry.kernel};")
+                    if k_idx == len(n_entry.k_entries) - 1:
+                        print("    }")
+
+            if n_idx == len(m_entry.n_entries) - 1:
+                print("  }")
+
+        if m_idx == len(heuristic.m_entries) - 1:
+            print("}")
 
 
-def main():
+def print_heuristic(heuristic: Heuristic) -> None:
+    for m_entry in heuristic.m_entries:
+        print(f"M: {m_entry.M}")
+        for n_entry in m_entry.n_entries:
+            print(f" N: {n_entry.N}")
+            for k_idx, k_entry in enumerate(n_entry.k_entries):
+                k_val = k_entry.K if k_idx != len(n_entry.k_entries) - 1 else "else"
+                print(f"  K: {k_val} -> {k_entry.kernel}")
+
+
+def main() -> None:
     parser = argparse.ArgumentParser(
         description="Generate heuristics from FBGEMM kernel tuning cache detailed info."
     )
@@ -145,25 +228,16 @@ def main():
     parser.add_argument(
         "--cpp", action="store_true", help="Generate C++ code for the heuristic."
     )
-    parser.add_argument(
-        "--cpp_varnames",
-        type=str,
-        help="Variable names to use for C++ heuristic generation, comma separated in same order of the problem shape. E.g. M,N,K",
-    )
 
     args = parser.parse_args()
 
-    heuristic = build_heuristic(args.file_path, args.threshold)
+    kernel_assignment = get_kernel_assignment(args.file_path, args.threshold)
+    heuristic = get_heuristic(kernel_assignment)
+
     if args.cpp:
-        if args.cpp_varnames is None:
-            print("If setting --cpp must also set --cpp_varnames.")
-            exit(1)
-        print_heuristic_cpp(heuristic, args.cpp_varnames)
+        print_heuristic_cpp(heuristic)
     else:
-        for inner_shape, outer_dims in heuristic.items():
-            print(f"Problem Shape: {inner_shape}")
-            for outer_dim, assigned_kernel in outer_dims:
-                print(f"  {outer_dim}: {assigned_kernel}")
+        print_heuristic(heuristic)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1850

The script can generate model agnostic kernel heuristic over MNK. Example workflow:

Collect the perf data from FBGEMM
```
FBGEMM_AUTOTUNE_ENABLE=1 FBGEMM_AUTOTUNE_USE_CUDA_GRAPH=1 FBGEMM_AUTOTUNE_COLLECT_STATS=1 buck2 run @//mode/{opt,inplace} -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=b200a  -c fbcode.platform010_cuda_version=12.8 -m ovr_config//triton:trunk //deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai/bench:quantize_bench -- --kernels=cutlass_mx8mx8bf16_grouped_mm_2d_3d --M=1,2,4,8,16,32,64,128,512,1024,2048,4096,8192,16384 --N=512,1024,2048,4096,8192,16384 --K=512,1024,2048,4096,8192,16384 --grouped --groups 8
```
P1933264035

Run the script. You can play with `--threshold` to see how things look at larger/smaller thresholds.
```
buck2 run :make_heuristic -- --file-path /home/cthi/.fbgemm/mx8mx8bf16_grouped_detailed.txt --threshold 0.01
```
P1933258755

Or if you want to copy paste it into fbgemm, generate some C++ if statements 

```
buck2 run :make_heuristic -- --file-path /home/cthi/.fbgemm/mx8mx8bf16_grouped_detailed.txt --threshold 0.01 --cpp
```
P1933259486

For now the script still requires the user to be smart about the range of MNK to sweep, but with very low effort we can get pretty good heuristic without thinking much. I used this to generate the MXFP8 Grouped GEMM heuristics (with some small modification to remove the small M stuff we don't need), and the performance is 10-30% better than hand tuned.

Differential Revision: D81782156


