### PR TITLE
convert batch size to float before torch.std in params reporter

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/stats/bench_params_reporter.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/stats/bench_params_reporter.py
@@ -209,7 +209,7 @@ class TBEBenchmarkParamsReporter:
                                     for bs in batch_size_per_feature_per_rank
                                     for b in bs
                                 ]
-                            )
+                            ).float()
                         )
                     )
                 )


### PR DESCRIPTION
Summary:
### Description
This diff converts the batch size to a float before calculating the standard deviation in the `params_reporter` module. This change is made to ensure accurate calculations, as `torch.std` expects a floating-point input.

### Changes
- **Modified code in `bench_params_reporter.py`**
  - Changed the line `torch.std(torch.tensor([b for bs in batch_size_per_feature_per_rank for b in bs]))` to `torch.std(torch.tensor([b for bs in batch_size_per_feature_per_rank for b in bs])).float()`.

### Reason
The `torch.std` function requires a floating-point tensor to calculate the standard deviation. By converting the batch size to a float, we ensure that the calculation is performed correctly.

Differential Revision: D81809491


