### PR TITLE
Skip load metadata tensor

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -3132,18 +3132,17 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                             device=torch.device("cpu"),
                             dtype=torch.int64,
                         )
-                    metadata_tensor = torch.zeros(
-                        (self.local_weight_counts[i], 1),
-                        device=torch.device("cpu"),
-                        dtype=torch.int64,
-                    )
+                    metadata_tensor = None
 
                     # self.local_weight_counts[i] = 0  # Reset the count
 
                 # pyre-ignore [16] bucket_sorted_id_splits is not None
                 bucket_sorted_id_splits.append(bucket_ascending_id_tensor)
                 active_id_cnt_per_bucket_split.append(bucket_t)
-                metadata_splits.append(metadata_tensor)
+                if metadata_tensor is not None:
+                    metadata_splits.append(metadata_tensor)
+                else:
+                    metadata_splits = None
 
                 # for KV ZCH tbe, the sorted_indices is global id for checkpointing and publishing
                 # but in backend, local id is used during training, so the KVTensorWrapper need to convert global id to local id


### PR DESCRIPTION
Summary:
The metadata tensor is newly added for kvzch table. Some old checkpoints may not have this fqn. Directly load old checkpoint can cause fqn missing error. 

This diff try to skip init metadata tensor at load checkpoint func. Metadata tensor is not used in training, so it is okay to skip load. It will be created during saving checkpoint.

Differential Revision: D81811024


