### PR TITLE
remove std out in EEG estimator

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/stats/bench_params_reporter.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/stats/bench_params_reporter.py
@@ -209,7 +209,7 @@ class TBEBenchmarkParamsReporter:
                                     for bs in batch_size_per_feature_per_rank
                                     for b in bs
                                 ]
-                            )
+                            ).float()
                         )
                     )
                 )

--- a/fbgemm_gpu/src/tbe/eeg/indices_estimator.cpp
+++ b/fbgemm_gpu/src/tbe/eeg/indices_estimator.cpp
@@ -163,16 +163,12 @@ ZipfParameters IndicesEstimator::zipfParams(
 
       if ((ratio < kHeavyHitterLowerBound_) ||
           (ratio > kHeavyHitterUpperBound_)) {
-        std::cout << "Skipping (s,q) (" << s << ", " << q
-                  << "): " << " inconsistent with heavy hitters!" << "\n";
         continue;
       }
 
       double logLikelihood = -zipfTotalFreq * log(normalizeConst) +
           s * freqTerm - kQRegularizer_ * q;
       if (logLikelihood > maxLogLikelihood) {
-        std::cout << "Found best Log likelihood so far on (s,q) (" << s << ", "
-                  << q << "): " << logLikelihood << "\n";
         maxLogLikelihood = logLikelihood;
         zipfParams.q = q;
         zipfParams.s = s;


### PR DESCRIPTION
Summary:
### Summary

* Removed `std::cout` statements from `indices_estimator.cpp` to suppress output.

Differential Revision: D81830197


