### PR TITLE
[ROCm] add tbb as library dep explicitly in cmake

### DIFF
--- a/.github/scripts/utils_build.bash
+++ b/.github/scripts/utils_build.bash
@@ -379,10 +379,14 @@ install_build_tools () {
   echo "[INSTALL] Adding symlink librhash.so.0, which is needed by CMake ..."
   # shellcheck disable=SC2155,SC2086
   local conda_prefix=$(conda run ${env_prefix} printenv CONDA_PREFIX)
-  (print_exec ln -s "${conda_prefix}/lib/librhash.so" "${conda_prefix}/lib/librhash.so.0") || return 1
+  if [ ! -e "${conda_prefix}/lib/librhash.so.0" ]; then
+    (print_exec ln -s "${conda_prefix}/lib/librhash.so" "${conda_prefix}/lib/librhash.so.0") || return 1
+  fi
 
   echo "[INSTALL] Adding symlink libtbb.so, which is needed by HIPCC ..."
-  (print_exec ln -s "${conda_prefix}/lib/libtbb.so.12" "${conda_prefix}/lib/libtbb.so") || return 1
+  if [ ! -e "${conda_prefix}/lib/libtbb.so" ]; then
+    (print_exec ln -s "${conda_prefix}/lib/libtbb.so.12" "${conda_prefix}/lib/libtbb.so") || return 1
+  fi
 
   # For some reason, the build package for Python 3.12+ is missing from conda,
   # so we have to install through pip instead.

--- a/fbgemm_gpu/FbgemmGpu.cmake
+++ b/fbgemm_gpu/FbgemmGpu.cmake
@@ -179,7 +179,12 @@ else()
 endif()
 if(FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM AND NOT IS_NOVA)
   message(STATUS "Adding tbb as dep.")
-  set(DEP_MAYBE_TBB tbb)
+  find_library(DEP_MAYBE_TBB NAMES tbb HINTS $ENV{CONDA_ENV}/lib)
+  if(DEP_MAYBE_TBB)
+    message(STATUS "Found tbb: ${DEP_MAYBE_TBB}")
+  else()
+    message(FATAL_ERROR "tbb not found")
+  endif()
 endif()
 
 gpu_cpp_library(

--- a/fbgemm_gpu/FbgemmGpu.cmake
+++ b/fbgemm_gpu/FbgemmGpu.cmake
@@ -162,6 +162,25 @@ gpu_cpp_library(
   DESTINATION
     fbgemm_gpu)
 
+# For the ROCm case on non-Nova, an explicit link to
+# libtbb is required, or the following error is
+# encountered on library load:
+# undefined symbol: _ZN3tbb6detail2r117deallocate_memoryEPv
+if (DEFINED ENV{BUILD_FROM_NOVA})
+  message(STATUS "BUILD_FROM_NOVA is $ENV{BUILD_FROM_NOVA}.")
+  if($ENV{BUILD_FROM_NOVA} STREQUAL "0")
+    set(IS_NOVA FALSE)
+  else()
+    set(IS_NOVA TRUE)
+  endif()
+else()
+  message(STATUS "BUILD_FROM_NOVA is not defined.")
+  set(IS_NOVA FALSE)
+endif()
+if(FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM AND NOT IS_NOVA)
+  message(STATUS "Adding tbb as dep.")
+  set(DEP_MAYBE_TBB tbb)
+endif()
 
 gpu_cpp_library(
   PREFIX
@@ -184,5 +203,6 @@ gpu_cpp_library(
     fbgemm_gpu_tbe_cache
     fbgemm_gpu_tbe_optimizers
     fbgemm_gpu_tbe_utils
+    ${DEP_MAYBE_TBB}
   DESTINATION
     fbgemm_gpu)

--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -379,18 +379,6 @@ class FbgemmGpuBuild:
                 ]
             )
 
-            if self.nova_flag() is None:
-                cxx_flags.extend(
-                    [
-                        # For the ROCm case on non-Nova, an explicit link to
-                        # libtbb is required, or the following error is
-                        # encountered on library load:
-                        #
-                        # undefined symbol: _ZN3tbb6detail2r117deallocate_memoryEPv
-                        "-ltbb",
-                    ]
-                )
-
         cmake_args.extend(
             [
                 f"-DCMAKE_C_FLAGS='{' '.join(cxx_flags)}'",


### PR DESCRIPTION
The existing setup.py solution is not robust and is failing to properly link when building fbgemm in torch dynamo benchmarks.