### PR TITLE
Migrate to new device TMA API for grouped_gemm.py

### DIFF
--- a/fbgemm_gpu/experimental/gemm/triton_gemm/grouped_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/grouped_gemm.py
@@ -227,7 +227,6 @@ def _fbgemm_grouped_gemm(
     a_desc_ptr,
     b_desc_ptr,
     c_ptr,
-    workspace,
     scatter_add_indices,
     m_sizes,
     # problem sizes
@@ -254,11 +253,7 @@ def _fbgemm_grouped_gemm(
     tidx = tl.program_id(0)
 
     dtype: tl.dtype = c_ptr.dtype.element_ty
-    TMA_SIZE: tl.constexpr = tl.constexpr(128)
-    if USE_TMA_STORE:
-        c_desc_ptr = workspace + tidx * TMA_SIZE
-    else:
-        c_desc_ptr = None
+    c_desc_ptr = None
 
     M_end_offset = 0
     M_end_offset = M_end_offset.to(tl.int64)  # pyre-ignore
@@ -279,15 +274,12 @@ def _fbgemm_grouped_gemm(
 
             if USE_TMA_STORE:
                 # pyre-ignore
-                tl.extra.cuda.experimental_device_tensormap_create2d(
-                    desc_ptr=c_desc_ptr,
-                    global_address=c_ptr + M_start_offset * N,
-                    load_size=[BLOCK_SIZE_M, BLOCK_SIZE_N],
-                    global_size=[m_size, n_size],
-                    element_ty=c_ptr.dtype.element_ty,
+                c_desc_ptr = tl.make_tensor_descriptor(
+                    c_ptr + M_start_offset * N,
+                    shape=[m_size, n_size],
+                    strides=[n_size, 1],
+                    block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_N],
                 )
-                # pyre-ignore
-                tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(c_desc_ptr)
 
             # Move across tiles
             while tidx >= iterated_tiles and tidx < iterated_tiles + num_tiles:
@@ -353,10 +345,9 @@ def _fbgemm_grouped_gemm(
                 if USE_TMA_STORE:
                     m_offset = (tile_m_idx * BLOCK_SIZE_M).to(tl.int32)
                     n_offset = (tile_n_idx * BLOCK_SIZE_N).to(tl.int32)
-                    tl._experimental_descriptor_store(
-                        c_desc_ptr,
-                        accumulator.to(c_ptr.dtype.element_ty),
-                        [m_offset, n_offset],
+                    # pyre-ignore
+                    c_desc_ptr.store(
+                        [m_offset, n_offset], accumulator.to(c_ptr.dtype.element_ty)
                     )
                 elif FUSE_SCATTER_ADD:
                     offs_am = tile_m_idx * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
@@ -402,7 +393,6 @@ def _fbgemm_grouped_gemm_ws(
     a_desc_ptr,
     b_desc_ptr,
     c_ptr,
-    workspace,
     scatter_add_indices,
     m_sizes,
     # problem sizes
@@ -432,11 +422,7 @@ def _fbgemm_grouped_gemm_ws(
     tidx = tl.program_id(0)
 
     dtype: tl.dtype = c_ptr.dtype.element_ty
-    TMA_SIZE: tl.constexpr = tl.constexpr(128)
-    if USE_TMA_STORE:
-        c_desc_ptr = workspace + tidx * TMA_SIZE
-    else:
-        c_desc_ptr = None
+    c_desc_ptr = None
 
     M_end_offset = 0
     M_end_offset = M_end_offset.to(tl.int64)  # pyre-ignore
@@ -458,15 +444,12 @@ def _fbgemm_grouped_gemm_ws(
             if USE_TMA_STORE:
                 with tl.async_task([0]):
                     # pyre-ignore
-                    tl.extra.cuda.experimental_device_tensormap_create2d(
-                        desc_ptr=c_desc_ptr,
-                        global_address=c_ptr + M_start_offset * N,
-                        load_size=[BLOCK_SIZE_M, BLOCK_SIZE_N],
-                        global_size=[m_size, N],
-                        element_ty=c_ptr.dtype.element_ty,
+                    c_desc_ptr = tl.make_tensor_descriptor(
+                        c_ptr + M_start_offset * N,
+                        shape=[m_size, N],
+                        strides=[N, 1],
+                        block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_N],
                     )
-                    # pyre-ignore
-                    tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(c_desc_ptr)
 
             # Move across tiles
             next_iterated_tiles = iterated_tiles + num_tiles
@@ -507,10 +490,10 @@ def _fbgemm_grouped_gemm_ws(
                         with tl.async_task([1, NUM_CONSUMER_GROUPS]):
                             m_offset = (tile_m_idx * BLOCK_SIZE_M).to(tl.int32)
                             n_offset = (tile_n_idx * BLOCK_SIZE_N).to(tl.int32)
-                            tl._experimental_descriptor_store(
-                                c_desc_ptr,
-                                accumulator.to(c_ptr.dtype.element_ty),
+                            # pyre-ignore
+                            c_desc_ptr.store(
                                 [m_offset, n_offset],
+                                accumulator.to(c_ptr.dtype.element_ty),
                             )
                     elif FUSE_SCATTER_ADD:
                         with tl.async_task([1, NUM_CONSUMER_GROUPS]):
@@ -577,7 +560,6 @@ def _fbgemm_grouped_gemm_fp8_rowwise(
     b_scale_ptr,
     b_scale_desc_ptr,
     c_ptr,
-    workspace,
     scatter_add_indices,
     m_sizes,
     # problem sizes
@@ -604,11 +586,7 @@ def _fbgemm_grouped_gemm_fp8_rowwise(
     tidx = tl.program_id(0)
 
     dtype = TT_FP8_DTYPE
-    TMA_SIZE: tl.constexpr = tl.constexpr(128)
-    if USE_TMA_STORE:
-        c_desc_ptr = workspace + tidx * TMA_SIZE
-    else:
-        c_desc_ptr = None
+    c_desc_ptr = None
 
     M_end_offset = 0
     M_end_offset = M_end_offset.to(tl.int64)  # pyre-ignore
@@ -629,15 +607,12 @@ def _fbgemm_grouped_gemm_fp8_rowwise(
 
             if USE_TMA_STORE:
                 # pyre-ignore
-                tl.extra.cuda.experimental_device_tensormap_create2d(
-                    desc_ptr=c_desc_ptr,
-                    global_address=c_ptr + M_start_offset * N,
-                    load_size=[BLOCK_SIZE_M, BLOCK_SIZE_N],
-                    global_size=[m_size, n_size],
-                    element_ty=c_ptr.dtype.element_ty,
+                c_desc_ptr = tl.make_tensor_descriptor(
+                    c_ptr + M_start_offset * N,
+                    shape=[m_size, n_size],
+                    strides=[n_size, 1],
+                    block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_N],
                 )
-                # pyre-ignore
-                tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(c_desc_ptr)
 
             # Move across tiles
             while tidx >= iterated_tiles and tidx < iterated_tiles + num_tiles:
@@ -704,11 +679,8 @@ def _fbgemm_grouped_gemm_fp8_rowwise(
                 if USE_TMA_STORE:
                     m_offset = (tile_m_idx * BLOCK_SIZE_M).to(tl.int32)
                     n_offset = (tile_n_idx * BLOCK_SIZE_N).to(tl.int32)
-                    tl._experimental_descriptor_store(
-                        c_desc_ptr,
-                        c.to(c_ptr.dtype.element_ty),
-                        [m_offset, n_offset],
-                    )
+                    # pyre-ignore
+                    c_desc_ptr.store([m_offset, n_offset], c.to(c_ptr.dtype.element_ty))
                 elif FUSE_SCATTER_ADD:
                     offs_am = tile_m_idx * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
                     mask = offs_am < m_size
@@ -756,7 +728,6 @@ def _fbgemm_grouped_gemm_fp8_rowwise_ws(
     b_scale_ptr,
     b_scale_desc_ptr,
     c_ptr,
-    workspace,
     scatter_add_indices,
     m_sizes,
     # problem sizes
@@ -785,11 +756,7 @@ def _fbgemm_grouped_gemm_fp8_rowwise_ws(
     tidx = tl.program_id(0)
 
     dtype = TT_FP8_DTYPE
-    TMA_SIZE: tl.constexpr = tl.constexpr(128)
-    if USE_TMA_STORE:
-        c_desc_ptr = workspace + tidx * TMA_SIZE
-    else:
-        c_desc_ptr = None
+    c_desc_ptr = None
 
     M_end_offset = 0
     M_end_offset = M_end_offset.to(tl.int64)  # pyre-ignore
@@ -811,15 +778,12 @@ def _fbgemm_grouped_gemm_fp8_rowwise_ws(
             if USE_TMA_STORE:
                 with tl.async_task([0]):
                     # pyre-ignore
-                    tl.extra.cuda.experimental_device_tensormap_create2d(
-                        desc_ptr=c_desc_ptr,
-                        global_address=c_ptr + M_start_offset * N,
-                        load_size=[BLOCK_SIZE_M, BLOCK_SIZE_N],
-                        global_size=[m_size, N],
-                        element_ty=c_ptr.dtype.element_ty,
+                    c_desc_ptr = tl.make_tensor_descriptor(
+                        c_ptr + M_start_offset * N,
+                        shape=[m_size, N],
+                        strides=[N, 1],
+                        block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_N],
                     )
-                    # pyre-ignore
-                    tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(c_desc_ptr)
 
             # Move across tiles
             next_iterated_tiles = iterated_tiles + num_tiles
@@ -899,10 +863,9 @@ def _fbgemm_grouped_gemm_fp8_rowwise_ws(
                         with tl.async_task([1, NUM_CONSUMER_GROUPS]):
                             m_offset = (tile_m_idx * BLOCK_SIZE_M).to(tl.int32)
                             n_offset = (tile_n_idx * BLOCK_SIZE_N).to(tl.int32)
-                            tl._experimental_descriptor_store(
-                                c_desc_ptr,
-                                c.to(c_ptr.dtype.element_ty),
-                                [m_offset, n_offset],
+                            # pyre-ignore
+                            c_desc_ptr.store(
+                                [m_offset, n_offset], c.to(c_ptr.dtype.element_ty)
                             )
                     elif FUSE_SCATTER_ADD:
                         with tl.async_task([1, NUM_CONSUMER_GROUPS]):
@@ -1053,11 +1016,11 @@ def _grouped_gemm(
             desc_ws = desc_helper.get_tma_descriptor_kernel_param("ws")
 
     if USE_TMA_STORE:
-        workspace = torch.empty(
-            NUM_SMS * utils.TmaAutoTuneHelper.TMA_SIZE,
-            device=x.device,
-            dtype=torch.uint8,
-        )
+
+        def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+            return torch.empty(size, device="cuda", dtype=torch.int8)
+
+        triton.set_allocator(alloc_fn)
 
     def grid(META):
         if USE_TMA_LOAD:
@@ -1110,7 +1073,6 @@ def _grouped_gemm(
             w_scale,
             desc_ws,
             y,
-            workspace,
             scatter_add_indices,
             m_sizes,
             G,
@@ -1136,7 +1098,6 @@ def _grouped_gemm(
             desc_x,
             desc_w,
             y,
-            workspace,
             scatter_add_indices,
             m_sizes,
             G,


### PR DESCRIPTION
Summary:
Old experimental TMA API is deprecated.

Migration examples: D78531083 or https://www.internalfb.com/intern/diffing/?paste_number=1942966879

Differential Revision: D82256338


