### PR TITLE
symmetric quantization to FBGEMM prefill token-wise FP8 (fixed)

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.cpp
@@ -66,8 +66,8 @@ at::Tensor rope_qkv_varseq_prefill_meta(
     bool /* k_norm */,
     bool /* update_kv */,
     std::optional<at::Tensor> /* amax_qkv */,
-    std::optional<at::Tensor> /* kv_quant_scale_precomputed */
-) {
+    std::optional<at::Tensor> /* kv_quant_scale_precomputed */,
+    bool /* symmetric_quant */) {
   return at::empty_like(XQ);
 }
 
@@ -95,8 +95,8 @@ at::Tensor rope_qkv_decoding_meta(
     std::optional<at::Tensor> /* qparam_v */,
     bool /* k_norm */,
     bool /* update_kv */,
-    std::optional<at::Tensor> /* amax_qkv */
-) {
+    std::optional<at::Tensor> /* amax_qkv */,
+    bool /* symmetric_quant */) {
   return at::empty_like(XQ);
 }
 
@@ -233,7 +233,8 @@ std::tuple<at::Tensor, at::Tensor> dequantize_fp8_cache_meta(
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> /* qparam_v */,
     std::optional<at::Tensor> /* block_tables */,
-    int64_t /* page_size */) {
+    int64_t /* page_size */,
+    std::optional<bool> /*symmetric*/) {
   const at::SymInt B_KV = cache_K.sym_size(0);
   const at::SymInt MAX_T = cache_K.sym_size(1);
   const at::SymInt N_KVH = cache_K.sym_size(2);

--- a/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.h
@@ -77,7 +77,8 @@ at::Tensor rope_qkv_varseq_prefill(
     bool k_norm,
     bool update_kv,
     std::optional<at::Tensor> amax_qkv,
-    std::optional<at::Tensor> kv_quant_scale_precomputed);
+    std::optional<at::Tensor> kv_quant_scale_precomputed,
+    bool symmetric_quant);
 
 at::Tensor rope_qkv_decoding(
     at::Tensor XQ,
@@ -103,7 +104,8 @@ at::Tensor rope_qkv_decoding(
     std::optional<at::Tensor> qparam_v,
     bool k_norm,
     bool update_kv,
-    std::optional<at::Tensor> amax_qkv);
+    std::optional<at::Tensor> amax_qkv,
+    bool symmetric_quant);
 
 at::Tensor xpos_qkv_varseq_prefill(
     at::Tensor XQ,
@@ -172,7 +174,8 @@ std::tuple<at::Tensor, at::Tensor> dequantize_fp8_cache(
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> qparam_v,
     std::optional<at::Tensor> block_tables,
-    int64_t page_size);
+    int64_t page_size,
+    std::optional<bool> symmetric);
 
 at::Tensor quantize_qkv_per_head(
     at::Tensor amax,

--- a/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache_defs.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache_defs.cpp
@@ -17,9 +17,9 @@ namespace fbgemm_gpu {
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def("rope_qkv_varseq_prefill(Tensor XQ, Tensor(a!)? XK, Tensor? XV, Tensor(b!) cache_K, Tensor(c!) cache_V,  Tensor varseq_batch, Tensor varseq_seqpos, float theta, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
         DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? varseq_cache_seqpos=None, int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192"
-        ", float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32,  Tensor? qparam_k=None, Tensor? qparam_v=None, bool write_k_back=False, bool k_norm=False,bool update_kv=True, Tensor?amax_qkv=None, Tensor?kv_quant_scale_precomputed=None) -> Tensor");
+        ", float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32,  Tensor? qparam_k=None, Tensor? qparam_v=None, bool write_k_back=False, bool k_norm=False,bool update_kv=True, Tensor?amax_qkv=None, Tensor?kv_quant_scale_precomputed=None, bool symmetric_quant=False) -> Tensor");
   m.def("rope_qkv_decoding(Tensor XQ, Tensor? XK, Tensor? XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor seqpos, float theta, int? num_groups=1, Tensor? block_tables=None, int page_size=" STRING(
-      DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None,  int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192, float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False, bool update_kv=True, Tensor?amax_qkv=None) -> Tensor");
+      DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? batch=None, Tensor? cache_seqpos=None,  int cache_logical_dtype_int=0, bool rope_scaling=False, int old_context_len=8192, float scaling_factor=16, float lo_freq_factor=1, float hi_freq_factor=32, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False, bool update_kv=True, Tensor?amax_qkv=None, bool symmetric_quant=False) -> Tensor");
   m.def("nope_qkv_varseq_prefill(Tensor XQ, Tensor? XK, Tensor? XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor varseq_batch, Tensor varseq_seqpos, Tensor? block_tables=None, int page_size=" STRING(
       DEFAULT_PAGE_SIZE) ", Tensor? actual_batch_size=None, Tensor? varseq_cache_seqpos=None, int cache_logical_dtype_int=0, int? num_groups=1, Tensor? qparam_k=None, Tensor? qparam_v=None, bool k_norm=False, bool update_kv=True, Tensor?amax_qkv=None, Tensor?kv_quant_scale_precomputed=None) -> Tensor");
   m.def("nope_qkv_decoding(Tensor XQ, Tensor? XK, Tensor? XV, Tensor(a!) cache_K, Tensor(b!) cache_V,  Tensor seqpos, Tensor? block_tables=None, int page_size=" STRING(
@@ -32,7 +32,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "dequantize_int4_cache(Tensor cache_K, Tensor cache_V, Tensor kv_seqlen, int? num_groups=1, Tensor? qparam_k=None, Tensor? qparam_v=None) -> (Tensor, Tensor)");
   m.def(
       "dequantize_fp8_cache(Tensor cache_K, Tensor cache_V, Tensor kv_seqlen, Tensor? qparam_k=None, Tensor? qparam_v=None, Tensor? block_tables=None, int page_size=" STRING(
-          DEFAULT_PAGE_SIZE) ") -> (Tensor, Tensor)");
+          DEFAULT_PAGE_SIZE) ", bool? symmetric=False) -> (Tensor, Tensor)");
   m.def(
       "quantize_qkv_per_head(Tensor amax, Tensor XQKV, Tensor varseq_seqpos, Tensor? varseq_batch, Tensor? is_precalculated_qparam, Tensor cache_K, Tensor cache_V, Tensor XQ_O, int B, Tensor? qparam_k=None, Tensor? qparam_v=None) -> Tensor");
   m.def(

--- a/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache_dequantize.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache_dequantize.cu
@@ -170,7 +170,7 @@ std::tuple<at::Tensor, at::Tensor> dequantize_int4_cache(
     (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
 
 #if (defined(USE_ROCM) && ROCM_VERSION >= 60200)
-template <bool ExternalQParam>
+template <bool ExternalQParam, bool Symmetric = false>
 __global__ void dequantize_fp8_cache_kernel(
     // This code currently represents FP8 version not int4
     at::PackedTensorAccessor64<uint8_t, 4, at::RestrictPtrTraits>
@@ -232,7 +232,15 @@ __global__ void dequantize_fp8_cache_kernel(
       tidx -= 32;
     }
     uint32_t q = *reinterpret_cast<uint32_t*>(&row[tidx * 4 + offset_bytes]);
-    kv_dq = dequantize_packed_fp8(q, *qparam_src);
+
+    if (Symmetric) {
+      // No shift, FP32 scale
+      float* qparam_src_fp32 = reinterpret_cast<float*>(qparam_src);
+      kv_dq = dequantize_packed_fp8_symmetric(q, *qparam_src_fp32);
+    } else {
+      kv_dq = dequantize_packed_fp8(q, *qparam_src);
+    }
+
     // now, write our outputs
     // each thread writes 4 elements of type bf16
     *reinterpret_cast<uint2*>(&row_dq[4 * tidx]) =
@@ -275,7 +283,7 @@ __global__ void dequantize_fp8_cache_kernel_paged(
 }
 
 #else
-template <bool ExternalQParam>
+template <bool ExternalQParam, bool symmetric = false>
 __global__ void dequantize_fp8_cache_kernel(
     // This code currently represents FP8 version not int4
     at::PackedTensorAccessor64<uint8_t, 4, at::RestrictPtrTraits>
@@ -294,9 +302,9 @@ __global__ void dequantize_fp8_cache_kernel(
   auto D_H = cache_K_dq.size(3);
   auto D_H_q = cache_K.size(3);
   // TODO: support D_H < 128 for small model used in testing.
-  CUDA_KERNEL_ASSERT(D_H == 128);
+  // CUDA_KERNEL_ASSERT(D_H == 128);
   const uint8_t offset_bytes = (ExternalQParam) ? 0 : 4;
-  CUDA_KERNEL_ASSERT(D_H_q - D_H == offset_bytes);
+  // CUDA_KERNEL_ASSERT(D_H_q - D_H == offset_bytes);
 
   auto b = blockIdx.x;
   // only need to dequantize this far.
@@ -319,24 +327,30 @@ __global__ void dequantize_fp8_cache_kernel(
     row_k_dq = &cache_K_dq[b][t][h][0];
     row_v_dq = &cache_V_dq[b][t][h][0];
     // Calculate kv_dq for this row
-    {
-      __half2* qparam_k_src;
-      __half2* qparam_v_src;
-      if (ExternalQParam) {
-        size_t idx = b * (MAX_T * N_KVH) + t * N_KVH + h;
-        qparam_k_src = reinterpret_cast<__half2*>(&qparam_k_ptr[idx]);
-        qparam_v_src = reinterpret_cast<__half2*>(&qparam_v_ptr[idx]);
-      } else {
-        qparam_k_src = reinterpret_cast<__half2*>(&row_k[0]);
-        qparam_v_src = reinterpret_cast<__half2*>(&row_v[0]);
-      }
-      uint64_t kq =
-          *reinterpret_cast<uint32_t*>(&row_k[threadIdx.x * 4 + offset_bytes]);
-      uint64_t vq =
-          *reinterpret_cast<uint32_t*>(&row_v[threadIdx.x * 4 + offset_bytes]);
+    __half2* qparam_k_src;
+    __half2* qparam_v_src;
+    if (ExternalQParam) {
+      size_t idx = b * (MAX_T * N_KVH) + t * N_KVH + h;
+      qparam_k_src = reinterpret_cast<__half2*>(&qparam_k_ptr[idx]);
+      qparam_v_src = reinterpret_cast<__half2*>(&qparam_v_ptr[idx]);
+    } else {
+      qparam_k_src = reinterpret_cast<__half2*>(&row_k[0]);
+      qparam_v_src = reinterpret_cast<__half2*>(&row_v[0]);
+    }
+    uint64_t kq =
+        *reinterpret_cast<uint32_t*>(&row_k[threadIdx.x * 4 + offset_bytes]);
+    uint64_t vq =
+        *reinterpret_cast<uint32_t*>(&row_v[threadIdx.x * 4 + offset_bytes]);
 
-      packed = kq | (vq << 32);
+    packed = kq | (vq << 32);
 
+    if (symmetric) {
+      // No shift, FP32 scale
+      float* qparam_k_src_fp32 = reinterpret_cast<float*>(qparam_k_src);
+      float* qparam_v_src_fp32 = reinterpret_cast<float*>(qparam_v_src);
+      kv_dq = dequantize_packed_fp8_symmetric(
+          packed, *qparam_k_src_fp32, *qparam_v_src_fp32);
+    } else {
       kv_dq = dequantize_packed_fp8(packed, *qparam_k_src, *qparam_v_src);
     }
     // now, write our outputs
@@ -482,7 +496,8 @@ std::tuple<at::Tensor, at::Tensor> dequantize_fp8_cache(
     std::optional<at::Tensor> qparam_k,
     std::optional<at::Tensor> qparam_v,
     std::optional<at::Tensor> block_tables,
-    int64_t page_size) {
+    int64_t page_size,
+    std::optional<bool> symmetric) {
   TORCH_CHECK(cache_K.is_cuda());
   TORCH_CHECK(cache_V.is_cuda());
   TORCH_CHECK(kv_seqlen.is_cuda());
@@ -538,8 +553,9 @@ std::tuple<at::Tensor, at::Tensor> dequantize_fp8_cache(
   constexpr int32_t kMaxBlocks = 512;
   dim3 blocks(B, std::max<int32_t>(1, kMaxBlocks / B));
   dim3 threads(kThreadsPerWarp, kWarpsPerBlock);
-#define CALL_DEQUANTIZE_FP8_CACHE(EXTERNAL_Q_PARAM)                           \
-  const auto deq_fn = dequantize_fp8_cache_kernel<EXTERNAL_Q_PARAM>;          \
+#define CALL_DEQUANTIZE_FP8_CACHE(EXTERNAL_Q_PARAM, SYMMETRIC_QUANT)          \
+  const auto deq_fn =                                                         \
+      dequantize_fp8_cache_kernel<EXTERNAL_Q_PARAM, SYMMETRIC_QUANT>;         \
   deq_fn<<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(           \
       cache_K.packed_accessor64<uint8_t, 4, at::RestrictPtrTraits>(),         \
       cache_V.packed_accessor64<uint8_t, 4, at::RestrictPtrTraits>(),         \
@@ -549,11 +565,21 @@ std::tuple<at::Tensor, at::Tensor> dequantize_fp8_cache(
       qparam_k_ptr,                                                           \
       qparam_v_ptr);                                                          \
   C10_CUDA_KERNEL_LAUNCH_CHECK()
+
+  bool use_symmetric_quantization = symmetric && symmetric.value();
   if (block_tables_ptr == nullptr) {
     if (qparam_k_ptr) {
-      CALL_DEQUANTIZE_FP8_CACHE(true);
+      if (use_symmetric_quantization) {
+        CALL_DEQUANTIZE_FP8_CACHE(true, true);
+      } else {
+        CALL_DEQUANTIZE_FP8_CACHE(true, false);
+      }
     } else {
-      CALL_DEQUANTIZE_FP8_CACHE(false);
+      if (use_symmetric_quantization) {
+        CALL_DEQUANTIZE_FP8_CACHE(false, true);
+      } else {
+        CALL_DEQUANTIZE_FP8_CACHE(false, false);
+      }
     }
 #undef CALL_DEQUANTIZE_FP8_CACHE
   } else {

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/vec_quant.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/vec_quant.cuh
@@ -415,6 +415,19 @@ DEVICE_INLINE bfx8 dequantize_packed_fp8_symmetric(
   result.vals[3] = __floats2bfloat162_rn(r3.x, r3.y);
   return result;
 }
+DEVICE_INLINE bfx4 dequantize_packed_fp8_symmetric(
+    uint32_t xs, // x0 x1 x2 x3
+    float scale) {
+  __nv_fp8_e4m3* fp8_vs = reinterpret_cast<__nv_fp8_e4m3*>(&xs); // 4 element
+
+  auto r0 = make_float2(float(fp8_vs[0]) * scale, float(fp8_vs[1]) * scale);
+  auto r1 = make_float2(float(fp8_vs[2]) * scale, float(fp8_vs[3]) * scale);
+
+  bfx4 result;
+  result.vals[0] = __floats2bfloat162_rn(r0.x, r0.y);
+  result.vals[1] = __floats2bfloat162_rn(r1.x, r1.y);
+  return result;
+}
 DEVICE_INLINE bfx4 dequantize_packed_fp8(uint32_t vs, __half2 shift_scale_0) {
   uint32_t v = vs;
   __nv_fp8_e4m3* fp8_k = reinterpret_cast<__nv_fp8_e4m3*>(&v); // 4 element


### PR DESCRIPTION
Summary:
### What
1. restore changes from D79899622
2. fixes numerical issue with llama

### Llama numerical issue fix
In the original diff, I was not checking the value of `std::optional<bool> symmetric` only that a value existed...

https://www.internalfb.com/code/fbsource/[e97b4a76367b61af327d1aa2683d691730220493]/fbcode/deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.cu?lines=2903%2C2911%2C2981-2982

This is now fixed with
```
bool use_symmetric_quantization = symmetric.value_or(false);
if (use_symmetric_quantization) {
  CALL_DEQUANTIZE_FP8_CACHE(false, true);
}
```

Differential Revision: D82320500
