### PR TITLE
- Clean torch.check

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/quantize_comm.py
+++ b/fbgemm_gpu/fbgemm_gpu/quantize_comm.py
@@ -230,7 +230,7 @@ class QuantizedCommCodec:
             ctx = none_throws(ctx)
             torch._check(
                 input_len % ctx.row_dim == 0,
-                lambda: f"input_len  {input_len} is not a multiple of row dim {ctx.row_dim}",
+                f"input_len  {input_len} is not a multiple of row dim {ctx.row_dim}",
             )
             assert input_len % ctx.row_dim == 0, (
                 f"input_len {input_len} is not a multiple of row dim {ctx.row_dim} "


### PR DESCRIPTION
Summary:
torch._check expects a string, however this was passing a lambda function that returned a string, which was causing a issues when compiling the code with PT2.

Just cleaned it up to use f-string.

Differential Revision: D82347053


