### PR TITLE
Migrate GenAI kv cache kernel arguments to use `PTA_B`

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/kv_cache/kv_cache.cu
@@ -64,7 +64,7 @@ namespace fbgemm_gpu {
 template <typename T>
 __device__ void get_dst_row(
     T** dst_row,
-    at::PackedTensorAccessor64<T, 4, at::RestrictPtrTraits>&
+    pta::PackedTensorAccessor64<T, 4, at::RestrictPtrTraits>&
         cache_KV, // [B][MAX_T][N_KVH][D_H +4 or D_H]
     int32_t b,
     int32_t h,
@@ -244,23 +244,24 @@ __global__ void nope_qkv_varseq_prefill_kernel(
 
 template <PositionEmbeddingMode Mode>
 __global__ void rope_xpos_qkv_varseq_prefill_kernel(
-    at::PackedTensorAccessor32<at::BFloat16, 3, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor32<at::BFloat16, 3, at::RestrictPtrTraits>
         XQ, // [B_T][N_H][D_H]
-    at::PackedTensorAccessor32<at::BFloat16, 3, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor32<at::BFloat16, 3, at::RestrictPtrTraits>
         XK, // [B_T][N_KVH][D_H]
-    at::PackedTensorAccessor32<at::BFloat16, 3, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor32<at::BFloat16, 3, at::RestrictPtrTraits>
         XV, // [B_T][N_KVH][D_H]
-    at::PackedTensorAccessor64<at::BFloat16, 4, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor64<at::BFloat16, 4, at::RestrictPtrTraits>
         cache_K, // [B][MAX_T][N_KVH][D_H] or
                  // [1][MAX_PAGES * PAGE_SIZE][N_KVH][D_H] for paged attention
-    at::PackedTensorAccessor64<at::BFloat16, 4, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor64<at::BFloat16, 4, at::RestrictPtrTraits>
         cache_V, // [B][MAX_T][N_KVH][D_H] or
                  // [1][MAX_PAGES * PAGE_SIZE][N_KVH][D_H] for paged attention
-    at::PackedTensorAccessor32<at::BFloat16, 3, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor32<at::BFloat16, 3, at::RestrictPtrTraits>
         XQ_O, // [B_T][N_H][D]
     int32_t* varseq_batch, // in decoding case we have T == 1 and so just pass
                            // nullptr
-    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> varseq_seqpos,
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        varseq_seqpos,
     double theta,
     double gamma,
     double scale_base,
@@ -269,7 +270,7 @@ __global__ void rope_xpos_qkv_varseq_prefill_kernel(
                            // ones for paged attention
     int32_t page_size,
     int32_t block_tables_b_stride,
-    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         varseq_cache_seqpos,
     int64_t* actual_batch_size =
         nullptr, // When running in CUDA graph mode, the actual batch size
@@ -708,7 +709,8 @@ __global__ void rope_xpos_qkv_varseq_prefill_kernel_quantized(
         XQ_O, // [B_T][N_H][D]
     int32_t* varseq_batch, // in decoding case we have T == 1 and so just
                            // pass nullptr
-    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> varseq_seqpos,
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        varseq_seqpos,
     double theta,
     double gamma,
     double scale_base,
@@ -717,7 +719,7 @@ __global__ void rope_xpos_qkv_varseq_prefill_kernel_quantized(
                            // ones for paged attention
     int32_t page_size,
     int32_t block_tables_b_stride,
-    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         varseq_cache_seqpos,
     int64_t* actual_batch_size =
         nullptr, // When running in CUDA graph mode, the actual batch size
@@ -884,21 +886,22 @@ template <
     CacheLogicalDtype kCacheDtype,
     int KVQuantNumGroups = 1>
 __global__ void rope_xpos_qkv_varseq_prefill_kernel_fp8(
-    at::PackedTensorAccessor32<at::BFloat16, 3, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor32<at::BFloat16, 3, at::RestrictPtrTraits>
         XQ, // [B_T][N_H][D_H]
-    at::PackedTensorAccessor32<at::BFloat16, 3, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor32<at::BFloat16, 3, at::RestrictPtrTraits>
         XK, // [B_T][N_KVH][D_H]
-    at::PackedTensorAccessor32<at::BFloat16, 3, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor32<at::BFloat16, 3, at::RestrictPtrTraits>
         XV, // [B_T][N_KVH][D_H]
-    at::PackedTensorAccessor64<at::Float8_e4m3fn, 4, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor64<at::Float8_e4m3fn, 4, at::RestrictPtrTraits>
         cache_K, // [B][MAX_T][N_KVH][D_H +4]
-    at::PackedTensorAccessor64<at::Float8_e4m3fn, 4, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor64<at::Float8_e4m3fn, 4, at::RestrictPtrTraits>
         cache_V, // [B][MAX_T][N_KVH][D_H + 4]
     int32_t* qparam_k_ptr,
     int32_t* qparam_v_ptr,
     int32_t* varseq_batch, // in decoding case we have T == 1 and so just
                            // pass nullptr
-    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> varseq_seqpos,
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        varseq_seqpos,
     double theta,
     double gamma,
     double scale_base,
@@ -907,7 +910,7 @@ __global__ void rope_xpos_qkv_varseq_prefill_kernel_fp8(
                            // ones for paged attention
     int32_t page_size,
     int32_t block_tables_b_stride,
-    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         varseq_cache_seqpos,
     int64_t* actual_batch_size =
         nullptr, // When running in CUDA graph mode, the actual batch size
@@ -1151,8 +1154,7 @@ at::Tensor nope_qkv_varseq_prefill(
       qparam_v_ptr = static_cast<int32_t*>(qparam_v.value().data_ptr());
     }
     auto varseq_batch_ = varseq_batch.data_ptr<int32_t>();
-    auto varseq_seqpos_ =
-        varseq_seqpos.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>();
+    auto varseq_seqpos_ = PTA_B(varseq_seqpos, int32_t, 1, 32);
     if (cache_logical_dtype == CacheLogicalDtype::FP8) {
 #if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
     (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
@@ -1176,17 +1178,11 @@ at::Tensor nope_qkv_varseq_prefill(
             threads,
             0,
             at::cuda::getCurrentCUDAStream(),
-            XQ.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-            XK.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-            XV.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-            cache_K.packed_accessor64<
-                at::Float8_e4m3fn,
-                4,
-                at::RestrictPtrTraits>(),
-            cache_V.packed_accessor64<
-                at::Float8_e4m3fn,
-                4,
-                at::RestrictPtrTraits>(),
+            PTA_B(XQ, at::BFloat16, 3, 32),
+            PTA_B(XK, at::BFloat16, 3, 32),
+            PTA_B(XV, at::BFloat16, 3, 32),
+            PTA_B(cache_K, at::Float8_e4m3fn, 4, 64),
+            PTA_B(cache_V, at::Float8_e4m3fn, 4, 64),
             qparam_k_ptr,
             qparam_v_ptr,
             varseq_batch_,
@@ -1198,8 +1194,7 @@ at::Tensor nope_qkv_varseq_prefill(
             block_tables_ptr,
             page_size,
             block_tables_b_stride,
-            varseq_cache_seqpos_
-                .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+            PTA_B(varseq_cache_seqpos_, int32_t, 1, 32),
             nullptr,
             false,
             0,
@@ -1225,8 +1220,7 @@ at::Tensor nope_qkv_varseq_prefill(
             block_tables_ptr,
             page_size,
             block_tables_b_stride,
-            (varseq_cache_seqpos_
-                 .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>()),
+            (PTA_B(varseq_cache_seqpos_, int32_t, 1, 32)),
             actual_batch_size_ptr,
             false,
             0,
@@ -1255,8 +1249,7 @@ at::Tensor nope_qkv_varseq_prefill(
           block_tables_ptr,
           page_size,
           block_tables_b_stride,
-          (varseq_cache_seqpos_
-               .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>()),
+          (PTA_B(varseq_cache_seqpos_, int32_t, 1, 32)),
           actual_batch_size_ptr,
           false,
           0,
@@ -1361,8 +1354,7 @@ at::Tensor nope_qkv_decoding(
     }
     auto batch_ =
         batch.has_value() ? batch.value().data_ptr<int32_t>() : nullptr;
-    auto seqpos_ =
-        seqpos.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>();
+    auto seqpos_ = PTA_B(seqpos, int32_t, 1, 32);
     if (cache_logical_dtype == CacheLogicalDtype::FP8) {
 #if (defined(USE_ROCM) && ROCM_VERSION >= 60200) || \
     (defined(CUDA_VERSION) && CUDA_VERSION >= 12000)
@@ -1381,17 +1373,11 @@ at::Tensor nope_qkv_decoding(
             threads,
             0,
             at::cuda::getCurrentCUDAStream(),
-            XQ.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-            XK.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-            XV.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-            cache_K.packed_accessor64<
-                at::Float8_e4m3fn,
-                4,
-                at::RestrictPtrTraits>(),
-            cache_V.packed_accessor64<
-                at::Float8_e4m3fn,
-                4,
-                at::RestrictPtrTraits>(),
+            PTA_B(XQ, at::BFloat16, 3, 32),
+            PTA_B(XK, at::BFloat16, 3, 32),
+            PTA_B(XV, at::BFloat16, 3, 32),
+            PTA_B(cache_K, at::Float8_e4m3fn, 4, 64),
+            PTA_B(cache_V, at::Float8_e4m3fn, 4, 64),
             qparam_k_ptr,
             qparam_v_ptr,
             batch_,
@@ -1403,8 +1389,7 @@ at::Tensor nope_qkv_decoding(
             block_tables_ptr,
             page_size,
             block_tables_b_stride,
-            cache_seqpos_
-                .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+            PTA_B(cache_seqpos_, int32_t, 1, 32),
             actual_batch_size_ptr,
             false,
             0,
@@ -1430,8 +1415,7 @@ at::Tensor nope_qkv_decoding(
             block_tables_ptr,
             page_size,
             block_tables_b_stride,
-            (cache_seqpos_
-                 .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>()),
+            (PTA_B(cache_seqpos_, int32_t, 1, 32)),
             actual_batch_size_ptr,
             false,
             0,
@@ -1460,8 +1444,7 @@ at::Tensor nope_qkv_decoding(
           block_tables_ptr,
           page_size,
           block_tables_b_stride,
-          (cache_seqpos_
-               .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>()),
+          (PTA_B(cache_seqpos_, int32_t, 1, 32)),
           actual_batch_size_ptr,
           false,
           0,
@@ -1556,14 +1539,14 @@ at::Tensor rope_qkv_varseq_prefill(
         threads,
         0,
         at::cuda::getCurrentCUDAStream(),
-        XQ.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-        XK.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-        XV.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-        cache_K.packed_accessor64<at::BFloat16, 4, at::RestrictPtrTraits>(),
-        cache_V.packed_accessor64<at::BFloat16, 4, at::RestrictPtrTraits>(),
-        XQ_O.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
+        PTA_B(XQ, at::BFloat16, 3, 32),
+        PTA_B(XK, at::BFloat16, 3, 32),
+        PTA_B(XV, at::BFloat16, 3, 32),
+        PTA_B(cache_K, at::BFloat16, 4, 64),
+        PTA_B(cache_V, at::BFloat16, 4, 64),
+        PTA_B(XQ_O, at::BFloat16, 3, 32),
         varseq_batch.data_ptr<int32_t>(),
-        varseq_seqpos.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+        PTA_B(varseq_seqpos, int32_t, 1, 32),
         theta,
         0,
         0,
@@ -1571,8 +1554,7 @@ at::Tensor rope_qkv_varseq_prefill(
         block_tables_ptr,
         page_size,
         block_tables_b_stride,
-        varseq_cache_seqpos_
-            .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+        PTA_B(varseq_cache_seqpos_, int32_t, 1, 32),
         actual_batch_size_ptr,
         rope_scaling,
         old_context_len,
@@ -1585,8 +1567,7 @@ at::Tensor rope_qkv_varseq_prefill(
   } else {
     auto num_groups_ = num_groups ? num_groups.value() : 1;
     auto varseq_batch_ = varseq_batch.data_ptr<int32_t>();
-    auto varseq_seqpos_ =
-        varseq_seqpos.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>();
+    auto varseq_seqpos_ = PTA_B(varseq_seqpos, int32_t, 1, 32);
     int32_t* qparam_k_ptr = nullptr;
     int32_t* qparam_v_ptr = nullptr;
     if (qparam_k.has_value()) {
@@ -1616,17 +1597,11 @@ at::Tensor rope_qkv_varseq_prefill(
             threads,
             0,
             at::cuda::getCurrentCUDAStream(),
-            XQ.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-            XK.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-            XV.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-            cache_K.packed_accessor64<
-                at::Float8_e4m3fn,
-                4,
-                at::RestrictPtrTraits>(),
-            cache_V.packed_accessor64<
-                at::Float8_e4m3fn,
-                4,
-                at::RestrictPtrTraits>(),
+            PTA_B(XQ, at::BFloat16, 3, 32),
+            PTA_B(XK, at::BFloat16, 3, 32),
+            PTA_B(XV, at::BFloat16, 3, 32),
+            PTA_B(cache_K, at::Float8_e4m3fn, 4, 64),
+            PTA_B(cache_V, at::Float8_e4m3fn, 4, 64),
             qparam_k_ptr,
             qparam_v_ptr,
             varseq_batch_,
@@ -1638,8 +1613,7 @@ at::Tensor rope_qkv_varseq_prefill(
             block_tables_ptr,
             page_size,
             block_tables_b_stride,
-            varseq_cache_seqpos_
-                .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+            PTA_B(varseq_cache_seqpos_, int32_t, 1, 32),
             nullptr,
             rope_scaling,
             old_context_len,
@@ -1665,8 +1639,7 @@ at::Tensor rope_qkv_varseq_prefill(
             block_tables_ptr,
             page_size,
             block_tables_b_stride,
-            (varseq_cache_seqpos_
-                 .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>()),
+            (PTA_B(varseq_cache_seqpos_, int32_t, 1, 32)),
             actual_batch_size_ptr,
             rope_scaling,
             old_context_len,
@@ -1695,8 +1668,7 @@ at::Tensor rope_qkv_varseq_prefill(
           block_tables_ptr,
           page_size,
           block_tables_b_stride,
-          (varseq_cache_seqpos_
-               .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>()),
+          (PTA_B(varseq_cache_seqpos_, int32_t, 1, 32)),
           actual_batch_size_ptr,
           rope_scaling,
           old_context_len,
@@ -1776,14 +1748,14 @@ at::Tensor xpos_qkv_varseq_prefill(
         threads,
         0,
         at::cuda::getCurrentCUDAStream(),
-        XQ.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-        XK.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-        XV.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-        cache_K.packed_accessor64<at::BFloat16, 4, at::RestrictPtrTraits>(),
-        cache_V.packed_accessor64<at::BFloat16, 4, at::RestrictPtrTraits>(),
-        XQ_O.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
+        PTA_B(XQ, at::BFloat16, 3, 32),
+        PTA_B(XK, at::BFloat16, 3, 32),
+        PTA_B(XV, at::BFloat16, 3, 32),
+        PTA_B(cache_K, at::BFloat16, 4, 64),
+        PTA_B(cache_V, at::BFloat16, 4, 64),
+        PTA_B(XQ_O, at::BFloat16, 3, 32),
         varseq_batch.data_ptr<int32_t>(),
-        varseq_seqpos.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+        PTA_B(varseq_seqpos, int32_t, 1, 32),
         theta,
         gamma,
         scale_base,
@@ -1791,8 +1763,7 @@ at::Tensor xpos_qkv_varseq_prefill(
         block_tables_ptr,
         page_size,
         block_tables_b_stride,
-        varseq_cache_seqpos_
-            .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+        PTA_B(varseq_cache_seqpos_, int32_t, 1, 32),
         actual_batch_size_ptr,
         rope_scaling,
         old_context_len,
@@ -1805,8 +1776,7 @@ at::Tensor xpos_qkv_varseq_prefill(
   } else {
     auto num_groups_ = num_groups ? num_groups.value() : 1;
     auto varseq_batch_ = varseq_batch.data_ptr<int32_t>();
-    auto varseq_seqpos_ =
-        varseq_seqpos.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>();
+    auto varseq_seqpos_ = PTA_B(varseq_seqpos, int32_t, 1, 32);
     int32_t* qparam_k_ptr = nullptr;
     int32_t* qparam_v_ptr = nullptr;
     if (qparam_k.has_value()) {
@@ -1830,8 +1800,7 @@ at::Tensor xpos_qkv_varseq_prefill(
           block_tables_ptr,
           page_size,
           block_tables_b_stride,
-          (varseq_cache_seqpos_
-               .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>()),
+          (PTA_B(varseq_cache_seqpos_, int32_t, 1, 32)),
           actual_batch_size_ptr,
           rope_scaling,
           old_context_len,
@@ -1860,8 +1829,7 @@ at::Tensor xpos_qkv_varseq_prefill(
           block_tables_ptr,
           page_size,
           block_tables_b_stride,
-          (varseq_cache_seqpos_
-               .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>()),
+          (PTA_B(varseq_cache_seqpos_, int32_t, 1, 32)),
           actual_batch_size_ptr,
           rope_scaling,
           old_context_len,
@@ -1949,14 +1917,14 @@ at::Tensor rope_qkv_decoding(
         threads,
         0,
         at::cuda::getCurrentCUDAStream(),
-        XQ.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-        XK.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-        XV.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-        cache_K.packed_accessor64<at::BFloat16, 4, at::RestrictPtrTraits>(),
-        cache_V.packed_accessor64<at::BFloat16, 4, at::RestrictPtrTraits>(),
-        XQ_O.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
+        PTA_B(XQ, at::BFloat16, 3, 32),
+        PTA_B(XK, at::BFloat16, 3, 32),
+        PTA_B(XV, at::BFloat16, 3, 32),
+        PTA_B(cache_K, at::BFloat16, 4, 64),
+        PTA_B(cache_V, at::BFloat16, 4, 64),
+        PTA_B(XQ_O, at::BFloat16, 3, 32),
         batch.has_value() ? batch.value().data_ptr<int32_t>() : nullptr,
-        seqpos.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+        PTA_B(seqpos, int32_t, 1, 32),
         theta,
         0,
         0,
@@ -1964,7 +1932,7 @@ at::Tensor rope_qkv_decoding(
         block_tables_ptr,
         page_size,
         block_tables_b_stride,
-        cache_seqpos_.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+        PTA_B(cache_seqpos_, int32_t, 1, 32),
         actual_batch_size_ptr,
         rope_scaling,
         old_context_len,
@@ -1975,8 +1943,7 @@ at::Tensor rope_qkv_decoding(
         update_kv);
 
   } else {
-    auto seqpos_ =
-        seqpos.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>();
+    auto seqpos_ = PTA_B(seqpos, int32_t, 1, 32);
     auto num_groups_ = num_groups ? num_groups.value() : 1;
     int32_t* qparam_k_ptr = nullptr;
     int32_t* qparam_v_ptr = nullptr;
@@ -2002,17 +1969,11 @@ at::Tensor rope_qkv_decoding(
             threads,
             0,
             at::cuda::getCurrentCUDAStream(),
-            XQ.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-            XK.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-            XV.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-            cache_K.packed_accessor64<
-                at::Float8_e4m3fn,
-                4,
-                at::RestrictPtrTraits>(),
-            cache_V.packed_accessor64<
-                at::Float8_e4m3fn,
-                4,
-                at::RestrictPtrTraits>(),
+            PTA_B(XQ, at::BFloat16, 3, 32),
+            PTA_B(XK, at::BFloat16, 3, 32),
+            PTA_B(XV, at::BFloat16, 3, 32),
+            PTA_B(cache_K, at::Float8_e4m3fn, 4, 64),
+            PTA_B(cache_V, at::Float8_e4m3fn, 4, 64),
             qparam_k_ptr,
             qparam_v_ptr,
             batch.has_value() ? batch.value().data_ptr<int32_t>() : nullptr,
@@ -2024,8 +1985,7 @@ at::Tensor rope_qkv_decoding(
             block_tables_ptr,
             page_size,
             block_tables_b_stride,
-            cache_seqpos_
-                .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+            PTA_B(cache_seqpos_, int32_t, 1, 32),
             actual_batch_size_ptr,
             rope_scaling,
             old_context_len,
@@ -2051,8 +2011,7 @@ at::Tensor rope_qkv_decoding(
             block_tables_ptr,
             page_size,
             block_tables_b_stride,
-            (cache_seqpos_
-                 .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>()),
+            (PTA_B(cache_seqpos_, int32_t, 1, 32)),
             actual_batch_size_ptr,
             rope_scaling,
             old_context_len,
@@ -2082,8 +2041,7 @@ at::Tensor rope_qkv_decoding(
           block_tables_ptr,
           page_size,
           block_tables_b_stride,
-          (cache_seqpos_
-               .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>()),
+          (PTA_B(cache_seqpos_, int32_t, 1, 32)),
           actual_batch_size_ptr,
           rope_scaling,
           old_context_len,
@@ -2159,14 +2117,14 @@ at::Tensor xpos_qkv_decoding(
         threads,
         0,
         at::cuda::getCurrentCUDAStream(),
-        XQ.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-        XK.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-        XV.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
-        cache_K.packed_accessor64<at::BFloat16, 4, at::RestrictPtrTraits>(),
-        cache_V.packed_accessor64<at::BFloat16, 4, at::RestrictPtrTraits>(),
-        XQ_O.packed_accessor32<at::BFloat16, 3, at::RestrictPtrTraits>(),
+        PTA_B(XQ, at::BFloat16, 3, 32),
+        PTA_B(XK, at::BFloat16, 3, 32),
+        PTA_B(XV, at::BFloat16, 3, 32),
+        PTA_B(cache_K, at::BFloat16, 4, 64),
+        PTA_B(cache_V, at::BFloat16, 4, 64),
+        PTA_B(XQ_O, at::BFloat16, 3, 32),
         batch.has_value() ? batch.value().data_ptr<int32_t>() : nullptr,
-        seqpos.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+        PTA_B(seqpos, int32_t, 1, 32),
         theta,
         gamma,
         scale_base,
@@ -2174,7 +2132,7 @@ at::Tensor xpos_qkv_decoding(
         block_tables_ptr,
         page_size,
         block_tables_b_stride,
-        cache_seqpos_.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+        PTA_B(cache_seqpos_, int32_t, 1, 32),
         actual_batch_size_ptr,
         rope_scaling,
         old_context_len,
@@ -2186,8 +2144,7 @@ at::Tensor xpos_qkv_decoding(
 
   } else {
     auto num_groups_ = num_groups ? num_groups.value() : 1;
-    auto seqpos_ =
-        seqpos.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>();
+    auto seqpos_ = PTA_B(seqpos, int32_t, 1, 32);
     int32_t* qparam_k_ptr = nullptr;
     int32_t* qparam_v_ptr = nullptr;
     if (qparam_k.has_value()) {
@@ -2211,8 +2168,7 @@ at::Tensor xpos_qkv_decoding(
           block_tables_ptr,
           page_size,
           block_tables_b_stride,
-          (cache_seqpos_
-               .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>()),
+          (PTA_B(cache_seqpos_, int32_t, 1, 32)),
           actual_batch_size_ptr,
           rope_scaling,
           old_context_len,
@@ -2240,8 +2196,7 @@ at::Tensor xpos_qkv_decoding(
           block_tables_ptr,
           page_size,
           block_tables_b_stride,
-          (cache_seqpos_
-               .packed_accessor32<int32_t, 1, at::RestrictPtrTraits>()),
+          (PTA_B(cache_seqpos_, int32_t, 1, 32)),
           actual_batch_size_ptr,
           rope_scaling,
           old_context_len,


### PR DESCRIPTION
Summary: - Migrate GenAI kv cache kernel arguments to use `PTA_B`

Reviewed By: r-barnes

Differential Revision: D81703942


