### PR TITLE
MI350X FP8 triton patch

### DIFF
--- a/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py
@@ -1246,8 +1246,19 @@ def matmul_fp8_row(
     # View inputs into proper torch fp8 dtype.
     if torch.version.cuda:
         assert a.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+    elif torch.version.hip:
+        if torch.cuda.get_device_capability() < (9, 5):
+            assert a.dtype in (
+                torch.float8_e4m3fnuz,
+                torch.float8_e5m2fnuz,
+            )
+        else:
+            assert a.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
     else:
-        assert a.dtype in (torch.float8_e4m3fnuz, torch.float8_e5m2fnuz)
+        assert a.dtype in (
+            torch.float8_e4m3fnuz,
+            torch.float8_e5m2fnuz,
+        )
     assert b.dtype == pt_fp8_dtype
     M, N, K, m_key, n_key, k_key, c, c_dtype_triton, dot_out_dtype_triton, device = (
         prep_matmul(a, b, dot_out_dtype)
@@ -3885,34 +3896,6 @@ MATMUL_CONFIGS_NON_PERSISTENT_PINGPONG_4K_8K_16K = [
     triton.Config(
         {
             "BLOCK_M": 256,
-            "BLOCK_N": 256,
-            "BLOCK_K": 64,
-            "GROUP_M": 2,
-            "SPLIT_K": 1,
-            "waves_per_eu": 2,
-            "matrix_instr_nonkdim": 16,
-            "kpack": 1,
-        },
-        num_warps=8,
-        num_stages=2,
-    ),
-    triton.Config(
-        {
-            "BLOCK_M": 128,
-            "BLOCK_N": 256,
-            "BLOCK_K": 64,
-            "GROUP_M": 2,
-            "SPLIT_K": 1,
-            "waves_per_eu": 2,
-            "matrix_instr_nonkdim": 16,
-            "kpack": 1,
-        },
-        num_warps=4,
-        num_stages=2,
-    ),
-    triton.Config(
-        {
-            "BLOCK_M": 256,
             "BLOCK_N": 128,
             "BLOCK_K": 128,
             "GROUP_M": 4,
@@ -3954,62 +3937,6 @@ MATMUL_CONFIGS_NON_PERSISTENT_PINGPONG_4K_8K_16K = [
     ),
     triton.Config(
         {
-            "BLOCK_M": 128,
-            "BLOCK_N": 128,
-            "BLOCK_K": 64,
-            "GROUP_M": 4,
-            "SPLIT_K": 1,
-            "waves_per_eu": 2,
-            "matrix_instr_nonkdim": 16,
-            "kpack": 2,
-        },
-        num_warps=4,
-        num_stages=2,
-    ),
-    triton.Config(
-        {
-            "BLOCK_M": 128,
-            "BLOCK_N": 128,
-            "BLOCK_K": 64,
-            "GROUP_M": 1,
-            "SPLIT_K": 1,
-            "waves_per_eu": 2,
-            "matrix_instr_nonkdim": 16,
-            "kpack": 2,
-        },
-        num_warps=4,
-        num_stages=2,
-    ),
-    triton.Config(
-        {
-            "BLOCK_M": 128,
-            "BLOCK_N": 64,
-            "BLOCK_K": 64,
-            "GROUP_M": 4,
-            "SPLIT_K": 1,
-            "waves_per_eu": 0,
-            "matrix_instr_nonkdim": 16,
-            "kpack": 2,
-        },
-        num_warps=4,
-        num_stages=2,
-    ),
-    triton.Config(
-        {
-            "BLOCK_M": 128,
-            "BLOCK_N": 64,
-            "BLOCK_K": 64,
-            "GROUP_M": 1,
-            "SPLIT_K": 1,
-            "waves_per_eu": 0,
-            "matrix_instr_nonkdim": 16,
-            "kpack": 2,
-        },
-        num_warps=4,
-        num_stages=2,
-    ),
-    triton.Config(
-        {
             "BLOCK_M": 256,
             "BLOCK_N": 128,
             "BLOCK_K": 128,
@@ -4022,7 +3949,96 @@ MATMUL_CONFIGS_NON_PERSISTENT_PINGPONG_4K_8K_16K = [
         num_warps=8,
         num_stages=2,
     ),
-]
+] + (
+    [
+        triton.Config(
+            {
+                "BLOCK_M": 128,
+                "BLOCK_N": 64,
+                "BLOCK_K": 64,
+                "GROUP_M": 1,
+                "SPLIT_K": 1,
+                "waves_per_eu": 0,
+                "matrix_instr_nonkdim": 16,
+                "kpack": 2,
+            },
+            num_warps=4,
+            num_stages=2,
+        ),
+        triton.Config(
+            {
+                "BLOCK_M": 128,
+                "BLOCK_N": 64,
+                "BLOCK_K": 64,
+                "GROUP_M": 4,
+                "SPLIT_K": 1,
+                "waves_per_eu": 0,
+                "matrix_instr_nonkdim": 16,
+                "kpack": 2,
+            },
+            num_warps=4,
+            num_stages=2,
+        ),
+        triton.Config(
+            {
+                "BLOCK_M": 128,
+                "BLOCK_N": 128,
+                "BLOCK_K": 128,
+                "GROUP_M": 4,
+                "SPLIT_K": 1,
+                "waves_per_eu": 2,
+                "matrix_instr_nonkdim": 16,
+                "kpack": 2,
+            },
+            num_warps=4,
+            num_stages=2,
+        ),
+        triton.Config(
+            {
+                "BLOCK_M": 128,
+                "BLOCK_N": 128,
+                "BLOCK_K": 128,
+                "GROUP_M": 1,
+                "SPLIT_K": 1,
+                "waves_per_eu": 2,
+                "matrix_instr_nonkdim": 16,
+                "kpack": 2,
+            },
+            num_warps=4,
+            num_stages=2,
+        ),
+        triton.Config(
+            {
+                "BLOCK_M": 256,
+                "BLOCK_N": 256,
+                "BLOCK_K": 64,
+                "GROUP_M": 2,
+                "SPLIT_K": 1,
+                "waves_per_eu": 2,
+                "matrix_instr_nonkdim": 16,
+                "kpack": 1,
+            },
+            num_warps=8,
+            num_stages=2,
+        ),
+        triton.Config(
+            {
+                "BLOCK_M": 128,
+                "BLOCK_N": 256,
+                "BLOCK_K": 64,
+                "GROUP_M": 2,
+                "SPLIT_K": 1,
+                "waves_per_eu": 2,
+                "matrix_instr_nonkdim": 16,
+                "kpack": 1,
+            },
+            num_warps=4,
+            num_stages=2,
+        ),
+    ]
+    if torch.version.hip is None or torch.cuda.get_device_capability() < (9, 5)
+    else []
+)
 
 # Set this to enable full autotuning for proper benchmarking.
 # This should only be used when invoking the kernel through


### PR DESCRIPTION
Summary:
MI350X has some incompatibilities with the current AMD triton FP8 setup, namely:
Moving from FNUZ to OCP format
Instruction set not supporting BLOCK_K=128 & matrix_instr_nonkdim=16 combo, leading to crash.
Fix by adding gates

Differential Revision: D81180838


