### PR TITLE
Optimize wgrad CUTLASS grouped gemm

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/bench/quantize_bench.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/quantize_bench.py
@@ -490,13 +490,15 @@ def print_kernels(kernels: Optional[List[str]]) -> List[QuantizeOpBase]:
     "--total-K",
     default=None,
     help="If set, adjusts the K values to sum to this number. "
-    "This can help simulate real grouped workloads in backward wgrad.",
+    "This can help simulate real grouped workloads in backward wgrad. "
+    "Comma separated list of total-K values to benchmark.",
 )
 @click.option(
     "--total-M",
     default=None,
     help="If set, adjusts the M values to sum to this number. "
-    "This can help simulate real grouped workloads.",
+    "This can help simulate real grouped workloads."
+    "Comma separated list of total-M values to benchmark.",
 )
 @click.option(
     "--no-cuda-graph",
@@ -634,25 +636,29 @@ def invoke_main(
     if groups:
         groups_list = [int(g) for g in groups.strip().split(",")]
         if total_m:
+            total_m_list = [int(tm) for tm in total_m.strip().split(",")]
             MNK = [
                 [
                     [b] * g,
-                    generate_group_tensor(g, int(total_m)),
+                    generate_group_tensor(g, tm),
                     [n] * g,
                     [k] * g,
                 ]
                 for g in groups_list
+                for tm in total_m_list
                 for b, _, n, k in MNK
             ]
         elif total_k:
+            total_k_list = [int(tk) for tk in total_k.strip().split(",")]
             MNK = [
                 [
                     [b] * g,
                     [m] * g,
                     [n] * g,
-                    generate_group_tensor(g, int(total_k)),
+                    generate_group_tensor(g, tk),
                 ]
                 for g in groups_list
+                for tk in total_k_list
                 for b, m, n, _ in MNK
             ]
         else:

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad.cu
@@ -131,7 +131,7 @@ get_wgrad_kernel_via_heuristic(int arch, int G, int total_M, int N, int K) {
     if (total_M == 65536) {
       if (N <= 512) {
         if (K <= 256) {
-          return bf16bf16bf16_grouped_wgrad_128_64_128_4_2_1_9_f;
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_2_1_9_f;
         } else if (K <= 512) {
           return bf16bf16bf16_grouped_wgrad_128_128_128_2_4_1_9_t;
         }
@@ -147,13 +147,13 @@ get_wgrad_kernel_via_heuristic(int arch, int G, int total_M, int N, int K) {
         }
       } else if (N <= 1280) {
         if (K <= 640) {
-          return bf16bf16bf16_grouped_wgrad_128_64_128_2_2_1_9_f;
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
         } else if (K <= 1280) {
           return bf16bf16bf16_grouped_wgrad_128_128_128_2_2_1_9_t;
         }
       } else if (N <= 1536) {
         if (K <= 768) {
-          return bf16bf16bf16_grouped_wgrad_128_64_128_1_4_1_9_f;
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
         } else if (K <= 1536) {
           return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
         }
@@ -181,51 +181,799 @@ get_wgrad_kernel_via_heuristic(int arch, int G, int total_M, int N, int K) {
     }
 
     // Fallback to legacy heuristic
-    if (total_M <= 256) {
-      if (N <= 256) {
-        return bf16bf16bf16_grouped_wgrad_128_32_128_1_1_1_9_f;
+    if (total_M <= 128) {
+      if (N <= 128) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_4_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        }
+      } else if (N <= 256) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        }
+      } else if (N <= 512) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        }
       } else if (N <= 1024) {
-        return bf16bf16bf16_grouped_wgrad_256_128_128_1_2_1_9_f;
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_256_64_128_1_4_1_9_f;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        }
+      } else if (N <= 2048) {
+        if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        }
       } else if (N <= 4096) {
-        return bf16bf16bf16_grouped_wgrad_128_256_128_1_1_1_9_f;
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else if (N <= 8192) {
+        if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
       } else {
-        return bf16bf16bf16_grouped_wgrad_128_256_128_1_2_1_9_f;
+        if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        }
+      }
+    } else if (total_M <= 256) {
+      if (N <= 128) {
+        if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        }
+      } else if (N <= 256) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        }
+      } else if (N <= 512) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        }
+      } else if (N <= 1024) {
+        if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        }
+      } else if (N <= 2048) {
+        if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        }
+      } else if (N <= 4096) {
+        if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else if (N <= 8192) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else {
+        if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        }
+      }
+    } else if (total_M <= 512) {
+      if (N <= 128) {
+        if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        }
+      } else if (N <= 256) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_256_64_128_1_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        }
+      } else if (N <= 512) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        }
+      } else if (N <= 1024) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        }
+      } else if (N <= 2048) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        }
+      } else if (N <= 4096) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        }
+      } else if (N <= 8192) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else {
+        if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        }
       }
     } else if (total_M <= 1024) {
-      if (N <= 256) {
-        return bf16bf16bf16_grouped_wgrad_128_32_128_2_2_1_9_f;
+      if (N <= 128) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_4_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        }
+      } else if (N <= 256) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        }
+      } else if (N <= 512) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        }
       } else if (N <= 1024) {
-        return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        }
+      } else if (N <= 2048) {
+        if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        }
       } else if (N <= 4096) {
-        return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        }
+      } else if (N <= 8192) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
       } else {
-        return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        }
+      }
+    } else if (total_M <= 2048) {
+      if (N <= 128) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_4_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_2_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_4_1_9_f;
+        }
+      } else if (N <= 256) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else if (N <= 512) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_2_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else if (N <= 1024) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else if (N <= 2048) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else if (N <= 4096) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        }
+      } else if (N <= 8192) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        }
+      } else {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
       }
     } else if (total_M <= 4096) {
-      if (N <= 256) {
-        return bf16bf16bf16_grouped_wgrad_128_32_128_1_4_1_9_f;
-      } else {
-        return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
-      }
-    } else if (total_M <= 16384) {
-      if (N <= 256) {
-        return bf16bf16bf16_grouped_wgrad_128_32_128_2_4_1_9_f;
+      if (N <= 128) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_4_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else if (N <= 256) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_4_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        }
+      } else if (N <= 512) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
       } else if (N <= 1024) {
-        return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else if (N <= 2048) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
       } else if (N <= 4096) {
-        return bf16bf16bf16_grouped_wgrad_128_128_128_1_4_1_9_t;
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        }
+      } else if (N <= 8192) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
       } else {
-        return bf16bf16bf16_grouped_wgrad_128_128_128_2_4_1_9_t;
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_4_1_1_9_t;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      }
+    } else if (total_M <= 8192) {
+      if (N <= 128) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_4_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_4_1_9_t;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else if (N <= 256) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_t;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else if (N <= 512) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_2_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_4_4_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else if (N <= 1024) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_4_2_1_9_t;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else if (N <= 2048) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else if (N <= 4096) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else if (N <= 8192) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_4_4_1_9_t;
+        }
+      } else {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_4_4_1_9_t;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_4_4_1_9_t;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        }
       }
     } else {
-      if (N <= 256) {
-        return bf16bf16bf16_grouped_wgrad_128_32_128_1_4_1_9_f;
+      if (N <= 128) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_4_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_2_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_2_1_9_f;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else if (N <= 256) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_32_128_1_2_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_2_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 1024) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_2_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else if (N <= 512) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_2_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 512) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
       } else if (N <= 1024) {
-        return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_f;
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_2_1_9_f;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        }
+      } else if (N <= 2048) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_4_4_1_9_t;
+        }
       } else if (N <= 4096) {
-        return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_64_128_1_2_1_9_f;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_4_4_1_9_t;
+        }
+      } else if (N <= 8192) {
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_t;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_4_4_1_9_t;
+        }
       } else {
-        return bf16bf16bf16_grouped_wgrad_128_128_128_2_4_1_9_t;
+        if (K <= 128) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f;
+        } else if (K <= 256) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 2048) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_4_1_9_t;
+        } else if (K <= 4096) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_2_1_9_t;
+        } else if (K <= 8192) {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_4_4_1_9_t;
+        } else {
+          return bf16bf16bf16_grouped_wgrad_128_128_128_1_4_1_9_t;
+        }
       }
     }
   }
@@ -307,7 +1055,15 @@ at::Tensor bf16bf16bf16_grouped_wgrad(
   at::Tensor Y;
   if (output.has_value()) {
     Y = output.value();
-    TORCH_CHECK(Y.dtype() == at::kBFloat16);
+    if (output_accum) {
+      TORCH_CHECK(
+          Y.dtype() == at::kFloat,
+          "Output tensor must be Float32 when output_accum=True");
+    } else {
+      TORCH_CHECK(
+          Y.dtype() == at::kBFloat16,
+          "Output tensor must be BFloat16 when output_accum=False");
+    }
   } else {
     Y = at::empty(G * N * K, X.options().dtype(at::kBFloat16));
   }

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_t.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_t.cu
@@ -10,25 +10,18 @@
 
 namespace fbgemm_gpu {
 
-at::Tensor bf16bf16bf16_grouped_wgrad_256_128_128_1_2_1_9_f(
+at::Tensor bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_t(
     at::Tensor X, // BF16
     at::Tensor W, // BF16
     at::Tensor M_sizes,
     at::Tensor output,
     bool output_accum) {
   if (output_accum) {
-    return bf16bf16bf16_grouped_wgrad_impl<256, 128, 128, 1, 2, 1, true, false>(
+    return bf16bf16bf16_grouped_wgrad_impl<128, 128, 128, 1, 1, 1, true, true>(
         X, W, M_sizes, output);
   } else {
-    return bf16bf16bf16_grouped_wgrad_impl<
-        256,
-        128,
-        128,
-        1,
-        2,
-        1,
-        false,
-        false>(X, W, M_sizes, output);
+    return bf16bf16bf16_grouped_wgrad_impl<128, 128, 128, 1, 1, 1, false, true>(
+        X, W, M_sizes, output);
   }
 }
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_128_128_128_1_4_1_9_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_128_128_128_1_4_1_9_f.cu
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "bf16bf16bf16_grouped_wgrad_common.cuh"
+
+namespace fbgemm_gpu {
+
+at::Tensor bf16bf16bf16_grouped_wgrad_128_128_128_1_4_1_9_f(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor M_sizes,
+    at::Tensor output,
+    bool output_accum) {
+  if (output_accum) {
+    return bf16bf16bf16_grouped_wgrad_impl<128, 128, 128, 1, 4, 1, true, false>(
+        X, W, M_sizes, output);
+  } else {
+    return bf16bf16bf16_grouped_wgrad_impl<
+        128,
+        128,
+        128,
+        1,
+        4,
+        1,
+        false,
+        false>(X, W, M_sizes, output);
+  }
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f.cu
@@ -10,22 +10,22 @@
 
 namespace fbgemm_gpu {
 
-at::Tensor bf16bf16bf16_grouped_wgrad_128_256_128_1_2_1_9_f(
+at::Tensor bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f(
     at::Tensor X, // BF16
     at::Tensor W, // BF16
     at::Tensor M_sizes,
     at::Tensor output,
     bool output_accum) {
   if (output_accum) {
-    return bf16bf16bf16_grouped_wgrad_impl<128, 256, 128, 1, 2, 1, true, false>(
+    return bf16bf16bf16_grouped_wgrad_impl<128, 128, 128, 2, 1, 1, true, false>(
         X, W, M_sizes, output);
   } else {
     return bf16bf16bf16_grouped_wgrad_impl<
         128,
-        256,
         128,
-        1,
+        128,
         2,
+        1,
         1,
         false,
         false>(X, W, M_sizes, output);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_128_128_128_4_1_1_9_t.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_128_128_128_4_1_1_9_t.cu
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "bf16bf16bf16_grouped_wgrad_common.cuh"
+
+namespace fbgemm_gpu {
+
+at::Tensor bf16bf16bf16_grouped_wgrad_128_128_128_4_1_1_9_t(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor M_sizes,
+    at::Tensor output,
+    bool output_accum) {
+  if (output_accum) {
+    return bf16bf16bf16_grouped_wgrad_impl<128, 128, 128, 4, 1, 1, true, true>(
+        X, W, M_sizes, output);
+  } else {
+    return bf16bf16bf16_grouped_wgrad_impl<128, 128, 128, 4, 1, 1, false, true>(
+        X, W, M_sizes, output);
+  }
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_128_32_128_1_2_1_9_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_128_32_128_1_2_1_9_f.cu
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "bf16bf16bf16_grouped_wgrad_common.cuh"
+
+namespace fbgemm_gpu {
+
+at::Tensor bf16bf16bf16_grouped_wgrad_128_32_128_1_2_1_9_f(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor M_sizes,
+    at::Tensor output,
+    bool output_accum) {
+  if (output_accum) {
+    return bf16bf16bf16_grouped_wgrad_impl<128, 32, 128, 1, 2, 1, true, false>(
+        X, W, M_sizes, output);
+  } else {
+    return bf16bf16bf16_grouped_wgrad_impl<128, 32, 128, 1, 2, 1, false, false>(
+        X, W, M_sizes, output);
+  }
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f.cu
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "bf16bf16bf16_grouped_wgrad_common.cuh"
+
+namespace fbgemm_gpu {
+
+at::Tensor bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor M_sizes,
+    at::Tensor output,
+    bool output_accum) {
+  if (output_accum) {
+    return bf16bf16bf16_grouped_wgrad_impl<128, 64, 128, 1, 1, 1, true, false>(
+        X, W, M_sizes, output);
+  } else {
+    return bf16bf16bf16_grouped_wgrad_impl<128, 64, 128, 1, 1, 1, false, false>(
+        X, W, M_sizes, output);
+  }
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_256_64_128_1_1_1_9_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_256_64_128_1_1_1_9_f.cu
@@ -10,25 +10,18 @@
 
 namespace fbgemm_gpu {
 
-at::Tensor bf16bf16bf16_grouped_wgrad_128_256_128_1_1_1_9_f(
+at::Tensor bf16bf16bf16_grouped_wgrad_256_64_128_1_1_1_9_f(
     at::Tensor X, // BF16
     at::Tensor W, // BF16
     at::Tensor M_sizes,
     at::Tensor output,
     bool output_accum) {
   if (output_accum) {
-    return bf16bf16bf16_grouped_wgrad_impl<128, 256, 128, 1, 1, 1, true, false>(
+    return bf16bf16bf16_grouped_wgrad_impl<256, 64, 128, 1, 1, 1, true, false>(
         X, W, M_sizes, output);
   } else {
-    return bf16bf16bf16_grouped_wgrad_impl<
-        128,
-        256,
-        128,
-        1,
-        1,
-        1,
-        false,
-        false>(X, W, M_sizes, output);
+    return bf16bf16bf16_grouped_wgrad_impl<256, 64, 128, 1, 1, 1, false, false>(
+        X, W, M_sizes, output);
   }
 }
 

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f.cu
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "bf16bf16bf16_grouped_wgrad_common.cuh"
+
+namespace fbgemm_gpu {
+
+at::Tensor bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor M_sizes,
+    at::Tensor output,
+    bool output_accum) {
+  if (output_accum) {
+    return bf16bf16bf16_grouped_wgrad_impl<256, 64, 128, 1, 2, 1, true, false>(
+        X, W, M_sizes, output);
+  } else {
+    return bf16bf16bf16_grouped_wgrad_impl<256, 64, 128, 1, 2, 1, false, false>(
+        X, W, M_sizes, output);
+  }
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_256_64_128_1_4_1_9_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_256_64_128_1_4_1_9_f.cu
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "bf16bf16bf16_grouped_wgrad_common.cuh"
+
+namespace fbgemm_gpu {
+
+at::Tensor bf16bf16bf16_grouped_wgrad_256_64_128_1_4_1_9_f(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor M_sizes,
+    at::Tensor output,
+    bool output_accum) {
+  if (output_accum) {
+    return bf16bf16bf16_grouped_wgrad_impl<256, 64, 128, 1, 4, 1, true, false>(
+        X, W, M_sizes, output);
+  } else {
+    return bf16bf16bf16_grouped_wgrad_impl<256, 64, 128, 1, 4, 1, false, false>(
+        X, W, M_sizes, output);
+  }
+}
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_common.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_common.cuh
@@ -127,7 +127,9 @@ at::Tensor bf16bf16bf16_grouped_wgrad_impl(
       cutlass::gemm::GroupProblemShape<cute::Shape<int, int, int>>;
   using ElementA = cutlass::bfloat16_t;
   using ElementB = cutlass::bfloat16_t;
-  using ElementC = cutlass::bfloat16_t;
+  using ElementC =
+      cute::conditional_t<OUTPUT_ACCUM, float, cutlass::bfloat16_t>;
+
   using LayoutA = cutlass::layout::ColumnMajor;
   using LayoutB = cutlass::layout::RowMajor;
   using LayoutC = cutlass::layout::RowMajor;
@@ -393,7 +395,8 @@ at::Tensor bf16bf16bf16_grouped_wgrad_sm100_impl(
       cutlass::gemm::GroupProblemShape<cute::Shape<int, int, int>>;
   using ElementA = cutlass::bfloat16_t;
   using ElementB = cutlass::bfloat16_t;
-  using ElementC = cutlass::bfloat16_t;
+  using ElementC =
+      cute::conditional_t<OUTPUT_ACCUM, float, cutlass::bfloat16_t>;
   using LayoutA = cutlass::layout::ColumnMajor;
   using LayoutB = cutlass::layout::RowMajor;
   using LayoutC = cutlass::layout::RowMajor;

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_manifest.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/bf16bf16bf16_grouped_wgrad/bf16bf16bf16_grouped_wgrad_manifest.cuh
@@ -117,27 +117,6 @@ at::Tensor bf16bf16bf16_grouped_wgrad_128_128_128_4_2_1_9_t(
     at::Tensor output,
     bool output_accum);
 
-at::Tensor bf16bf16bf16_grouped_wgrad_128_256_128_1_1_1_9_f(
-    at::Tensor X, // BF16
-    at::Tensor W, // BF16
-    at::Tensor M_sizes,
-    at::Tensor output,
-    bool output_accum);
-
-at::Tensor bf16bf16bf16_grouped_wgrad_128_256_128_1_2_1_9_f(
-    at::Tensor X, // BF16
-    at::Tensor W, // BF16
-    at::Tensor M_sizes,
-    at::Tensor output,
-    bool output_accum);
-
-at::Tensor bf16bf16bf16_grouped_wgrad_256_128_128_1_2_1_9_f(
-    at::Tensor X, // BF16
-    at::Tensor W, // BF16
-    at::Tensor M_sizes,
-    at::Tensor output,
-    bool output_accum);
-
 at::Tensor bf16bf16bf16_grouped_wgrad_256_32_128_2_1_1_10_f(
     at::Tensor X, // BF16
     at::Tensor W, // BF16
@@ -187,6 +166,83 @@ at::Tensor bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_10_f(
     at::Tensor output,
     bool output_accum);
 
+at::Tensor bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor M_sizes,
+    at::Tensor output,
+    bool output_accum);
+
+at::Tensor bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_t(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor M_sizes,
+    at::Tensor output,
+    bool output_accum);
+
+at::Tensor bf16bf16bf16_grouped_wgrad_128_128_128_1_4_1_9_f(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor M_sizes,
+    at::Tensor output,
+    bool output_accum);
+
+at::Tensor bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor M_sizes,
+    at::Tensor output,
+    bool output_accum);
+
+at::Tensor bf16bf16bf16_grouped_wgrad_128_128_128_4_1_1_9_t(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor M_sizes,
+    at::Tensor output,
+    bool output_accum);
+
+at::Tensor bf16bf16bf16_grouped_wgrad_128_128_128_4_4_1_9_t(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor M_sizes,
+    at::Tensor output,
+    bool output_accum);
+
+at::Tensor bf16bf16bf16_grouped_wgrad_128_32_128_1_2_1_9_f(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor M_sizes,
+    at::Tensor output,
+    bool output_accum);
+
+at::Tensor bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor M_sizes,
+    at::Tensor output,
+    bool output_accum);
+
+at::Tensor bf16bf16bf16_grouped_wgrad_256_64_128_1_1_1_9_f(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor M_sizes,
+    at::Tensor output,
+    bool output_accum);
+
+at::Tensor bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor M_sizes,
+    at::Tensor output,
+    bool output_accum);
+
+at::Tensor bf16bf16bf16_grouped_wgrad_256_64_128_1_4_1_9_f(
+    at::Tensor X, // BF16
+    at::Tensor W, // BF16
+    at::Tensor M_sizes,
+    at::Tensor output,
+    bool output_accum);
+
 using Kernel_bf16bf16bf16_grouped_wgrad =
     at::Tensor (*)(at::Tensor, at::Tensor, at::Tensor, at::Tensor, bool);
 
@@ -225,12 +281,28 @@ get_bf16bf16bf16_grouped_wgrad_kernels(int arch) {
                bf16bf16bf16_grouped_wgrad_128_128_128_2_4_1_9_t},
               {"bf16bf16bf16_grouped_wgrad_128_128_128_4_2_1_9_t",
                bf16bf16bf16_grouped_wgrad_128_128_128_4_2_1_9_t},
-              {"bf16bf16bf16_grouped_wgrad_128_256_128_1_1_1_9_f",
-               bf16bf16bf16_grouped_wgrad_128_256_128_1_1_1_9_f},
-              {"bf16bf16bf16_grouped_wgrad_128_256_128_1_2_1_9_f",
-               bf16bf16bf16_grouped_wgrad_128_256_128_1_2_1_9_f},
-              {"bf16bf16bf16_grouped_wgrad_256_128_128_1_2_1_9_f",
-               bf16bf16bf16_grouped_wgrad_256_128_128_1_2_1_9_f},
+              {"bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f",
+               bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_f},
+              {"bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_t",
+               bf16bf16bf16_grouped_wgrad_128_128_128_1_1_1_9_t},
+              {"bf16bf16bf16_grouped_wgrad_128_128_128_1_4_1_9_f",
+               bf16bf16bf16_grouped_wgrad_128_128_128_1_4_1_9_f},
+              {"bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f",
+               bf16bf16bf16_grouped_wgrad_128_128_128_2_1_1_9_f},
+              {"bf16bf16bf16_grouped_wgrad_128_128_128_4_1_1_9_t",
+               bf16bf16bf16_grouped_wgrad_128_128_128_4_1_1_9_t},
+              {"bf16bf16bf16_grouped_wgrad_128_128_128_4_4_1_9_t",
+               bf16bf16bf16_grouped_wgrad_128_128_128_4_4_1_9_t},
+              {"bf16bf16bf16_grouped_wgrad_128_32_128_1_2_1_9_f",
+               bf16bf16bf16_grouped_wgrad_128_32_128_1_2_1_9_f},
+              {"bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f",
+               bf16bf16bf16_grouped_wgrad_128_64_128_1_1_1_9_f},
+              {"bf16bf16bf16_grouped_wgrad_256_64_128_1_1_1_9_f",
+               bf16bf16bf16_grouped_wgrad_256_64_128_1_1_1_9_f},
+              {"bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f",
+               bf16bf16bf16_grouped_wgrad_256_64_128_1_2_1_9_f},
+              {"bf16bf16bf16_grouped_wgrad_256_64_128_1_4_1_9_f",
+               bf16bf16bf16_grouped_wgrad_256_64_128_1_4_1_9_f},
           };
   static const std::
       unordered_map<std::string, Kernel_bf16bf16bf16_grouped_wgrad>

--- a/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
@@ -2259,7 +2259,7 @@ class BF16Tests(unittest.TestCase):
         if output_accum:
             wgrad_accum = torch.randn(
                 (G, N, K),
-                dtype=torch.bfloat16,
+                dtype=torch.float32,
                 device=torch.accelerator.current_accelerator(),
             )
         else:
@@ -2272,6 +2272,9 @@ class BF16Tests(unittest.TestCase):
             output=wgrad_accum.clone() if output_accum else None,
             output_accum=output_accum,
         )
+
+        if output_accum:
+            assert test_wgrad.dtype == torch.float32
 
         # Reference
         dy_fp32 = dy_bf16.to(torch.float32)
@@ -2297,18 +2300,26 @@ class BF16Tests(unittest.TestCase):
 
         if output_accum:
             assert wgrad_accum is not None
-            ref_wgrad += wgrad_accum.to(torch.float32)
+            ref_wgrad += wgrad_accum
 
-        ref_wgrad = ref_wgrad.to(torch.bfloat16)
+        ref_wgrad = ref_wgrad.to(test_wgrad.dtype)
 
         # Compare groups with non-zero m_size
         if non_zero_groups:
-            torch.testing.assert_close(
-                test_wgrad[non_zero_groups],
-                ref_wgrad[non_zero_groups],
-                atol=1e-4,
-                rtol=1e-2,
-            )
+            if test_wgrad.dtype == torch.float32:
+                torch.testing.assert_close(
+                    test_wgrad[non_zero_groups],
+                    ref_wgrad[non_zero_groups],
+                    atol=1e-4,
+                    rtol=1e-4,
+                )
+            else:
+                torch.testing.assert_close(
+                    test_wgrad[non_zero_groups],
+                    ref_wgrad[non_zero_groups],
+                    atol=1e-4,
+                    rtol=1e-2,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1916

- Make wgrad CUTLASS grouped gemm return float32 output when wgrad is provided, respecting e2e
- Optimize general heuristic
- Make tests cover wgrad accum with float32 output

Differential Revision: D82700455


