### PR TITLE
Save some binary size

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_128_128_128_1_2_1_10_t.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_128_128_128_1_2_1_10_t.cu
@@ -15,12 +15,19 @@ at::Tensor f8f8bf16_rowwise_batched_128_128_128_1_2_1_10_t(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    bool use_fast_accum = true,
     std::optional<at::Tensor> bias = std::nullopt,
     std::optional<at::Tensor> output = std::nullopt) {
   // Dispatch this kernel to the correct underlying implementation.
-  return f8f8bf16_rowwise_batched_wrapper<128, 128, 128, 1, 2, 1, 10, true>(
-      XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+  return f8f8bf16_rowwise_batched_wrapper<
+      128,
+      128,
+      128,
+      1,
+      2,
+      1,
+      10,
+      true,
+      cutlass::float_e4m3_t>(XQ, WQ, x_scale, w_scale, bias, output);
 }
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_128_128_128_1_2_1_9_t.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_128_128_128_1_2_1_9_t.cu
@@ -15,12 +15,19 @@ at::Tensor f8f8bf16_rowwise_batched_128_128_128_1_2_1_9_t(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    bool use_fast_accum = true,
     std::optional<at::Tensor> bias = std::nullopt,
     std::optional<at::Tensor> output = std::nullopt) {
   // Dispatch this kernel to the correct underlying implementation.
-  return f8f8bf16_rowwise_batched_wrapper<128, 128, 128, 1, 2, 1, 9, true>(
-      XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+  return f8f8bf16_rowwise_batched_wrapper<
+      128,
+      128,
+      128,
+      1,
+      2,
+      1,
+      9,
+      true,
+      cutlass::float_e4m3_t>(XQ, WQ, x_scale, w_scale, bias, output);
 }
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_128_128_128_2_1_1_10_t.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_128_128_128_2_1_1_10_t.cu
@@ -15,12 +15,19 @@ at::Tensor f8f8bf16_rowwise_batched_128_128_128_2_1_1_10_t(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    bool use_fast_accum = true,
     std::optional<at::Tensor> bias = std::nullopt,
     std::optional<at::Tensor> output = std::nullopt) {
   // Dispatch this kernel to the correct underlying implementation.
-  return f8f8bf16_rowwise_batched_wrapper<128, 128, 128, 2, 1, 1, 10, true>(
-      XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+  return f8f8bf16_rowwise_batched_wrapper<
+      128,
+      128,
+      128,
+      2,
+      1,
+      1,
+      10,
+      true,
+      cutlass::float_e4m3_t>(XQ, WQ, x_scale, w_scale, bias, output);
 }
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_128_128_128_2_1_1_9_t.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_128_128_128_2_1_1_9_t.cu
@@ -15,12 +15,19 @@ at::Tensor f8f8bf16_rowwise_batched_128_128_128_2_1_1_9_t(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    bool use_fast_accum = true,
     std::optional<at::Tensor> bias = std::nullopt,
     std::optional<at::Tensor> output = std::nullopt) {
   // Dispatch this kernel to the correct underlying implementation.
-  return f8f8bf16_rowwise_batched_wrapper<128, 128, 128, 2, 1, 1, 9, true>(
-      XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+  return f8f8bf16_rowwise_batched_wrapper<
+      128,
+      128,
+      128,
+      2,
+      1,
+      1,
+      9,
+      true,
+      cutlass::float_e4m3_t>(XQ, WQ, x_scale, w_scale, bias, output);
 }
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_64_128_128_1_2_1_9_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_64_128_128_1_2_1_9_f.cu
@@ -15,12 +15,19 @@ at::Tensor f8f8bf16_rowwise_batched_64_128_128_1_2_1_9_f(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    bool use_fast_accum = true,
     std::optional<at::Tensor> bias = std::nullopt,
     std::optional<at::Tensor> output = std::nullopt) {
   // Dispatch this kernel to the correct underlying implementation.
-  return f8f8bf16_rowwise_batched_wrapper<64, 128, 128, 1, 2, 1, 9, false>(
-      XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+  return f8f8bf16_rowwise_batched_wrapper<
+      64,
+      128,
+      128,
+      1,
+      2,
+      1,
+      9,
+      false,
+      cutlass::float_e4m3_t>(XQ, WQ, x_scale, w_scale, bias, output);
 }
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_64_128_128_2_1_1_10_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_64_128_128_2_1_1_10_f.cu
@@ -15,12 +15,19 @@ at::Tensor f8f8bf16_rowwise_batched_64_128_128_2_1_1_10_f(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    bool use_fast_accum = true,
     std::optional<at::Tensor> bias = std::nullopt,
     std::optional<at::Tensor> output = std::nullopt) {
   // Dispatch this kernel to the correct underlying implementation.
-  return f8f8bf16_rowwise_batched_wrapper<64, 128, 128, 2, 1, 1, 10, false>(
-      XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+  return f8f8bf16_rowwise_batched_wrapper<
+      64,
+      128,
+      128,
+      2,
+      1,
+      1,
+      10,
+      false,
+      cutlass::float_e4m3_t>(XQ, WQ, x_scale, w_scale, bias, output);
 }
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_64_128_128_2_1_1_9_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_64_128_128_2_1_1_9_f.cu
@@ -15,12 +15,19 @@ at::Tensor f8f8bf16_rowwise_batched_64_128_128_2_1_1_9_f(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    bool use_fast_accum = true,
     std::optional<at::Tensor> bias = std::nullopt,
     std::optional<at::Tensor> output = std::nullopt) {
   // Dispatch this kernel to the correct underlying implementation.
-  return f8f8bf16_rowwise_batched_wrapper<64, 128, 128, 2, 1, 1, 9, false>(
-      XQ, WQ, x_scale, w_scale, use_fast_accum, bias, output);
+  return f8f8bf16_rowwise_batched_wrapper<
+      64,
+      128,
+      128,
+      2,
+      1,
+      1,
+      9,
+      false,
+      cutlass::float_e4m3_t>(XQ, WQ, x_scale, w_scale, bias, output);
 }
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_64_128_128_2_1_1_9_f_e5m2.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_64_128_128_2_1_1_9_f_e5m2.cu
@@ -10,7 +10,7 @@
 
 namespace fbgemm_gpu {
 
-at::Tensor f8f8bf16_rowwise_batched_64_128_128_1_2_1_10_f(
+at::Tensor f8f8bf16_rowwise_batched_64_128_128_2_1_1_9_f_e5m2(
     at::Tensor XQ,
     at::Tensor WQ,
     at::Tensor x_scale,
@@ -22,12 +22,12 @@ at::Tensor f8f8bf16_rowwise_batched_64_128_128_1_2_1_10_f(
       64,
       128,
       128,
-      1,
       2,
       1,
-      10,
+      1,
+      9,
       false,
-      cutlass::float_e4m3_t>(XQ, WQ, x_scale, w_scale, bias, output);
+      cutlass::float_e5m2_t>(XQ, WQ, x_scale, w_scale, bias, output);
 }
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_manifest.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_rowwise_batched/f8f8bf16_rowwise_batched_manifest.cuh
@@ -15,7 +15,6 @@ at::Tensor f8f8bf16_rowwise_batched_64_128_128_1_2_1_9_f(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    bool use_fast_accum = true,
     std::optional<at::Tensor> bias = std::nullopt,
     std::optional<at::Tensor> output = std::nullopt);
 
@@ -24,7 +23,6 @@ at::Tensor f8f8bf16_rowwise_batched_64_128_128_1_2_1_10_f(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    bool use_fast_accum = true,
     std::optional<at::Tensor> bias = std::nullopt,
     std::optional<at::Tensor> output = std::nullopt);
 
@@ -33,7 +31,6 @@ at::Tensor f8f8bf16_rowwise_batched_64_128_128_2_1_1_9_f(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    bool use_fast_accum = true,
     std::optional<at::Tensor> bias = std::nullopt,
     std::optional<at::Tensor> output = std::nullopt);
 
@@ -42,7 +39,6 @@ at::Tensor f8f8bf16_rowwise_batched_64_128_128_2_1_1_10_f(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    bool use_fast_accum = true,
     std::optional<at::Tensor> bias = std::nullopt,
     std::optional<at::Tensor> output = std::nullopt);
 
@@ -51,7 +47,6 @@ at::Tensor f8f8bf16_rowwise_batched_128_128_128_1_2_1_9_t(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    bool use_fast_accum = true,
     std::optional<at::Tensor> bias = std::nullopt,
     std::optional<at::Tensor> output = std::nullopt);
 
@@ -60,7 +55,6 @@ at::Tensor f8f8bf16_rowwise_batched_128_128_128_1_2_1_10_t(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    bool use_fast_accum = true,
     std::optional<at::Tensor> bias = std::nullopt,
     std::optional<at::Tensor> output = std::nullopt);
 
@@ -69,7 +63,6 @@ at::Tensor f8f8bf16_rowwise_batched_128_128_128_2_1_1_9_t(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    bool use_fast_accum = true,
     std::optional<at::Tensor> bias = std::nullopt,
     std::optional<at::Tensor> output = std::nullopt);
 
@@ -78,7 +71,14 @@ at::Tensor f8f8bf16_rowwise_batched_128_128_128_2_1_1_10_t(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    bool use_fast_accum = true,
+    std::optional<at::Tensor> bias = std::nullopt,
+    std::optional<at::Tensor> output = std::nullopt);
+
+at::Tensor f8f8bf16_rowwise_batched_64_128_128_2_1_1_9_f_e5m2(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
     std::optional<at::Tensor> bias = std::nullopt,
     std::optional<at::Tensor> output = std::nullopt);
 

--- a/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
@@ -566,7 +566,7 @@ class FP8Tests(unittest.TestCase):
         B_T=st.sampled_from([0, 2048, 4096]),
         D=st.sampled_from([128, 256]),
         HD_L=st.sampled_from([256, 512]),
-        QType=st.sampled_from([torch.float8_e4m3fn, torch.float8_e5m2]),
+        QType=st.sampled_from([torch.float8_e4m3fn]),
         CudaGraph=st.sampled_from([True, False]),
     )
     def test_quantize_int4_fp8_matmul(
@@ -933,7 +933,7 @@ class FP8Tests(unittest.TestCase):
         bias = (
             torch.randn(
                 size=(B, N),
-                dtype=torch.bfloat16,
+                dtype=torch.float32,
                 device=self.device,
             )
             if Bias


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1927

We need to urgently trim down the fbgemm binary size, as new kernels being added are running into relocation issues. Long/mid term, we will need to split up gemm into per-op buck targets and update targets to only pull in what is required, as it's becoming unwieldy to include all gemm targets (quantize_ops), and will likely continue to cause problems in fbcode usage, especially since many targets (e.g. torchAO, Sigrid predictor (MRS + Ads) are pulling in fbgemm now.

For now, let's do some house keeping to trim down the lib size.

[FP8 Batched GEMM](https://www.internalfb.com/code/search?q=repo%3Afbcode%20torch.ops.fbgemm.f8f8bf16_rowwise_batched&leading_context=5&trailing_context=5):
- Remove `fast_accum=False`, as no one uses it.
- Only support fp32 bias, remove bf16 bias. Bias itself is unused except for unit test.
- Significantly reduce FP8 e5m2 to only a single kernel instance. Its highly unlikely this is used, but hard for us to validate confidently right now.

FP8 Int4 Mixed precision GEMM (I beliee this kernel was purely exploratory, and should be unused):
- Remove FP8 e5m2 completely

Reviewed By: q10

Differential Revision: D82842915


