### PR TITLE
Remove e5m2 from f8f8bf16_rowwise

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
@@ -349,9 +349,7 @@ class FP8Tests(unittest.TestCase):
             ["rowwise", "blockwise"]
             + (["tensorwise_broadcast", "tensorwise"] if torch.version.cuda else [])
         ),
-        QType=(
-            st.sampled_from([fp8_e4m3, fp8_e5m2] if torch.version.cuda else [fp8_e4m3])
-        ),
+        QType=(st.sampled_from([fp8_e4m3])),
         Bias=st.sampled_from([True, False]),
         CudaGraph=st.sampled_from([True, False]),
         UseTriton=st.sampled_from([False] + ([True] if torch.version.cuda else [])),


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1931

- e5m2 is not used, remove it to save code size and avoid more build issues
- possibly e5m2 was messed up to begin with, we hardcoded `using ElementB = cutlass::float_e4m3_t`

Differential Revision: D82965586


