### PR TITLE
avx512 based int8 -> bf16 dequantization

### DIFF
--- a/fbgemm_gpu/cmake/Fbgemm.cmake
+++ b/fbgemm_gpu/cmake/Fbgemm.cmake
@@ -26,7 +26,8 @@ set(fbgemm_sources_avx2
   "${FBGEMM}/src/QuantUtilsAvx2.cc")
 
 set(fbgemm_sources_avx512
-  "${FBGEMM}/src/EmbeddingSpMDMAvx512.cc")
+  "${FBGEMM}/src/EmbeddingSpMDMAvx512.cc"
+  "${FBGEMM}/src/QuantUtilsAvx512.cc")
 
 if(CXX_AVX2_FOUND)
   set_source_files_properties(${fbgemm_sources_avx2}
@@ -46,7 +47,7 @@ if(CXX_AVX2_FOUND)
     ${fbgemm_sources}
     ${fbgemm_sources_avx2})
 endif()
-if((NOT FBGEMM_BUILD_VARIANT STREQUAL BUILD_VARIANT_ROCM) AND CXX_AVX512_FOUND)
+if(CXX_AVX512_FOUND)
   set(fbgemm_sources
     ${fbgemm_sources}
     ${fbgemm_sources_avx2}

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -411,6 +411,7 @@ at::Tensor FP8rowwise_to_float_cpu(
     const bool forward = true,
     const int64_t output_dtype = 0);
 at::Tensor fused8bitrowwise_to_half_cpu(const at::Tensor& input);
+at::Tensor fused8bitrowwise_to_bfloat16_cpu(const at::Tensor& input);
 at::Tensor fused8bitrowwise_to_float_or_half_cpu(
     const at::Tensor& input,
     const int64_t output_dtype,
@@ -467,6 +468,9 @@ at::Tensor _fusednbitrowwise_to_float_or_half_gpu(
     const int64_t bit_rate,
     const int64_t output_dtype);
 at::Tensor& _fused8bitrowwise_to_float_cpu_out(
+    at::Tensor& output,
+    const at::Tensor& input);
+at::Tensor& _fused8bitrowwise_to_bfloat16_cpu_out(
     at::Tensor& output,
     const at::Tensor& input);
 at::Tensor& _float_to_fused8bitrowwise_cpu_out(

--- a/include/fbgemm/QuantUtils.h
+++ b/include/fbgemm/QuantUtils.h
@@ -10,6 +10,7 @@
 
 #include "./FbgemmBuild.h" // @manual
 #include "./QuantUtilsAvx2.h" // @manual
+#include "./QuantUtilsAvx512.h" // @manual
 #include "./QuantUtilsNeon.h" // @manual
 #include "./Types.h" // @manual
 #include "./Utils.h" // @manual
@@ -330,7 +331,7 @@ FBGEMM_API void FloatOrHalfToFused8BitRowwiseQuantizedSBFloat(
  * This version intentionally supports only 8-bit because
  * the corresponding quantize version only supports 8-bit.
  */
-template <typename OutputType>
+template <typename OutputType, bool is_uint16_t_of_type_bf16 = false>
 FBGEMM_API void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf(
     const uint8_t* input,
     size_t input_rows,
@@ -377,7 +378,7 @@ FBGEMM_API void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef(
  * Same as Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf but unoptimized.
  * This should not be called directly except in testing.
  */
-template <typename OutputType>
+template <typename OutputType, bool is_uint16_t_of_type_bf16 = false>
 FBGEMM_API void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfRef(
     const uint8_t* input,
     size_t input_rows,

--- a/include/fbgemm/QuantUtilsAvx512.h
+++ b/include/fbgemm/QuantUtilsAvx512.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "Types.h"
 #if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
 
 #include <cstdint>
@@ -37,6 +38,12 @@ FBGEMM_API void requantizeOutputProcessingGConvAvx512(
     int ld_out,
     int ld_in,
     const requantizationParams_t<BIAS_TYPE>& r);
+
+void Fused8BitRowwiseQuantizedSBFloatToBfloat16Avx512(
+    const std::uint8_t* input,
+    size_t input_rows,
+    int input_columns,
+    bfloat16* output);
 } // namespace fbgemm
 
 #endif

--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -178,6 +178,11 @@ FBGEMM_API bool fbgemmHasAvx2Support();
 FBGEMM_API bool fbgemmHasAvx512VnniSupport();
 
 /**
+ * @brief Are we running on a AVX512_BF16 supported cpu?
+ */
+FBGEMM_API bool fbgemmHasAvx512Bf16Support();
+
+/**
  * @brief Are we running on a ARM Neon supported cpu?
  */
 FBGEMM_API bool fbgemmHasArmNeonSupport();

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -319,6 +319,10 @@ bool fbgemmHasAvx512VnniSupport() {
   return cpuinfo_has_x86_avx512vnni();
 }
 
+bool fbgemmHasAvx512Bf16Support() {
+  return cpuinfo_has_x86_avx512bf16();
+}
+
 bool fbgemmHasArmNeonSupport() {
   return cpuinfo_has_arm_neon();
 }


### PR DESCRIPTION
Summary: Use AVX512-bf16 intrinsics for int8 -> bf16 dequantization

Differential Revision: D82507938


