### PR TITLE
Migrate GenAI gqa attn splitk kernel arguments to use `PTA_B`

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/gqa_attn_splitk.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/gqa_attn_splitk.cu
@@ -81,16 +81,16 @@ template <
     CacheLogicalDtype KVDataType>
 __global__ void __launch_bounds__(kThreadsPerWarp* kSplitKWarpsPerBlock, 1)
     gqa_attn_splitk_wmma_kernel(
-        const at::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits>
-            XQ,
-        const at::PackedTensorAccessor64<kv_t, 4, at::RestrictPtrTraits>
+        const pta::
+            PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits> XQ,
+        const pta::PackedTensorAccessor64<kv_t, 4, at::RestrictPtrTraits>
             cache_K,
-        const at::PackedTensorAccessor64<kv_t, 4, at::RestrictPtrTraits>
+        const pta::PackedTensorAccessor64<kv_t, 4, at::RestrictPtrTraits>
             cache_V,
-        at::PackedTensorAccessor32<float, 4, at::RestrictPtrTraits> out_splitK,
-        const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        pta::PackedTensorAccessor32<float, 4, at::RestrictPtrTraits> out_splitK,
+        const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
             seq_positions,
-        at::PackedTensorAccessor32<float, 4, at::RestrictPtrTraits> metadata,
+        pta::PackedTensorAccessor32<float, 4, at::RestrictPtrTraits> metadata,
         float qk_scale) {
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800))
   // Need kWarpsPerBlock == blockDim.y;
@@ -785,14 +785,14 @@ __global__ void __launch_bounds__(kThreadsPerWarp* kSplitKWarpsPerBlock, 1)
 
 __global__ void gqa_attn_splitk_reduce_wmma_kernel(
     // {B, H, num_split_ks, D_H}
-    const at::PackedTensorAccessor32<float, 4, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor32<float, 4, at::RestrictPtrTraits>
         out_splitK,
     // {B, H, 2, num_split_ks, 1},
-    const at::PackedTensorAccessor32<float, 4, at::RestrictPtrTraits> metadata,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor32<float, 4, at::RestrictPtrTraits> metadata,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         seq_positions,
     // [B, 1, H, D]
-    at::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits> O) {
+    pta::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits> O) {
   const auto b = blockIdx.x;
   const auto h = blockIdx.y;
   const auto num_split_ks = out_splitK.size(1);
@@ -833,12 +833,13 @@ __global__ void gqa_attn_splitk_reduce_wmma_kernel(
 }
 
 __global__ void gqa_attn_splitk_qk_kernel(
-    const at::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits> XQ,
-    const at::PackedTensorAccessor64<at::BFloat16, 4, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits>
+        XQ,
+    const pta::PackedTensorAccessor64<at::BFloat16, 4, at::RestrictPtrTraits>
         cache_K,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         seq_positions,
-    at::PackedTensorAccessor32<float, 3, at::RestrictPtrTraits> QK_out) {
+    pta::PackedTensorAccessor32<float, 3, at::RestrictPtrTraits> QK_out) {
   static_assert(kWarpsPerBlock <= kThreadsPerWarp, "");
 
   // Each block handles a single batch and head
@@ -936,11 +937,13 @@ __global__ void gqa_attn_splitk_qk_kernel(
 
 template <int KVQuantNumGroups = 1>
 __global__ void gqa_attn_splitk_qk_int4_kernel(
-    const at::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits> XQ,
-    const at::PackedTensorAccessor64<uint8_t, 4, at::RestrictPtrTraits> cache_K,
-    const at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits>
+        XQ,
+    const pta::PackedTensorAccessor64<uint8_t, 4, at::RestrictPtrTraits>
+        cache_K,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         seq_positions,
-    at::PackedTensorAccessor32<float, 3, at::RestrictPtrTraits> QK_out) {
+    pta::PackedTensorAccessor32<float, 3, at::RestrictPtrTraits> QK_out) {
   static_assert(kWarpsPerBlock <= kThreadsPerWarp, "");
 
   // Each block handles a single batch and head
@@ -1056,9 +1059,10 @@ __global__ void gqa_attn_splitk_qk_int4_kernel(
 
 // TODO: can also fuse RoPe into this kernel. Doesn't seem worth it.
 __global__ void gqa_attn_splitk_attn_kernel(
-    at::PackedTensorAccessor32<float, 3, at::RestrictPtrTraits> XQ_out,
-    at::PackedTensorAccessor32<float, 3, at::RestrictPtrTraits> attn_out,
-    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> seq_positions,
+    pta::PackedTensorAccessor32<float, 3, at::RestrictPtrTraits> XQ_out,
+    pta::PackedTensorAccessor32<float, 3, at::RestrictPtrTraits> attn_out,
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        seq_positions,
     float qk_scale) {
   static_assert(kWarpsPerBlock <= kThreadsPerWarp, "");
 
@@ -1131,10 +1135,10 @@ __global__ void gqa_attn_splitk_attn_kernel(
 
 // TODO: can also fuse RoPe into this kernel. Doesn't seem worth it.
 __global__ void gqa_attn_splitk_v_kernel(
-    at::PackedTensorAccessor32<float, 3, at::RestrictPtrTraits> attn_out,
-    at::PackedTensorAccessor64<at::BFloat16, 4, at::RestrictPtrTraits> cache_V,
-    at::PackedTensorAccessor32<float, 5, at::RestrictPtrTraits> O,
-    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor32<float, 3, at::RestrictPtrTraits> attn_out,
+    pta::PackedTensorAccessor64<at::BFloat16, 4, at::RestrictPtrTraits> cache_V,
+    pta::PackedTensorAccessor32<float, 5, at::RestrictPtrTraits> O,
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         seq_positions) {
   static_assert(kWarpsPerBlock <= kThreadsPerWarp, "");
 
@@ -1236,10 +1240,10 @@ __global__ void gqa_attn_splitk_v_kernel(
 // TODO: can also fuse RoPe into this kernel. Doesn't seem worth it.
 template <int KVQuantNumGroups = 1>
 __global__ void gqa_attn_splitk_v_int4_kernel(
-    at::PackedTensorAccessor32<float, 3, at::RestrictPtrTraits> attn_out,
-    at::PackedTensorAccessor64<uint8_t, 4, at::RestrictPtrTraits> cache_V,
-    at::PackedTensorAccessor32<float, 5, at::RestrictPtrTraits> O,
-    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+    pta::PackedTensorAccessor32<float, 3, at::RestrictPtrTraits> attn_out,
+    pta::PackedTensorAccessor64<uint8_t, 4, at::RestrictPtrTraits> cache_V,
+    pta::PackedTensorAccessor32<float, 5, at::RestrictPtrTraits> O,
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
         seq_positions) {
   static_assert(kWarpsPerBlock <= kThreadsPerWarp, "");
 
@@ -1446,28 +1450,28 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> gqa_attn_splitk_wmma_impl(
           (t_per_block_round_up + kSplitKWarpsPerBlock + D_H) * sizeof(float) +
       smem_staging_size;
 
-#define CALL_GQA_ATTN_SPLITK_WMMA(                                          \
-    CACHE_TYPE, NUM_GROUPS, KV_LOAD_T, KV_DATA_TYPE)                        \
-  auto gqa_fn = gqa_attn_splitk_wmma_kernel<                                \
-      CACHE_TYPE,                                                           \
-      NUM_GROUPS,                                                           \
-      KV_LOAD_T,                                                            \
-      KV_DATA_TYPE>;                                                        \
-  if (smem > SMEM_ADJUST_THRESHOLD) {                                       \
-    set_gpu_max_dynamic_shared_memory(gqa_fn, smem, XQ.get_device());       \
-  }                                                                         \
-  FBGEMM_LAUNCH_KERNEL(                                                     \
-      (gqa_fn),                                                             \
-      blocks,                                                               \
-      threads,                                                              \
-      smem,                                                                 \
-      at::cuda::getCurrentCUDAStream(),                                     \
-      XQ.packed_accessor32<at::BFloat16, 4, at::RestrictPtrTraits>(),       \
-      cache_K.packed_accessor64<CACHE_TYPE, 4, at::RestrictPtrTraits>(),    \
-      cache_V.packed_accessor64<CACHE_TYPE, 4, at::RestrictPtrTraits>(),    \
-      out_splitK.packed_accessor32<float, 4, at::RestrictPtrTraits>(),      \
-      seq_positions.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(), \
-      metadata.packed_accessor32<float, 4, at::RestrictPtrTraits>(),        \
+#define CALL_GQA_ATTN_SPLITK_WMMA(                                    \
+    CACHE_TYPE, NUM_GROUPS, KV_LOAD_T, KV_DATA_TYPE)                  \
+  auto gqa_fn = gqa_attn_splitk_wmma_kernel<                          \
+      CACHE_TYPE,                                                     \
+      NUM_GROUPS,                                                     \
+      KV_LOAD_T,                                                      \
+      KV_DATA_TYPE>;                                                  \
+  if (smem > SMEM_ADJUST_THRESHOLD) {                                 \
+    set_gpu_max_dynamic_shared_memory(gqa_fn, smem, XQ.get_device()); \
+  }                                                                   \
+  FBGEMM_LAUNCH_KERNEL(                                               \
+      (gqa_fn),                                                       \
+      blocks,                                                         \
+      threads,                                                        \
+      smem,                                                           \
+      at::cuda::getCurrentCUDAStream(),                               \
+      PTA_B(XQ, at::BFloat16, 4, 32),                                 \
+      PTA_B(cache_K, CACHE_TYPE, 4, 64),                              \
+      PTA_B(cache_V, CACHE_TYPE, 4, 64),                              \
+      PTA_B(out_splitK, float, 4, 32),                                \
+      PTA_B(seq_positions, int32_t, 1, 32),                           \
+      PTA_B(metadata, float, 4, 32),                                  \
       qk_scale);
 
   if (cache_K.dtype() == at::kBFloat16) {
@@ -1497,10 +1501,10 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> gqa_attn_splitk_wmma_impl(
       dim3(kThreadsPerWarp, D_H / kThreadsPerWarp),
       0,
       at::cuda::getCurrentCUDAStream(),
-      out_splitK.packed_accessor32<float, 4, at::RestrictPtrTraits>(),
-      metadata.packed_accessor32<float, 4, at::RestrictPtrTraits>(),
-      seq_positions.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
-      O.packed_accessor32<at::BFloat16, 4, at::RestrictPtrTraits>());
+      PTA_B(out_splitK, float, 4, 32),
+      PTA_B(metadata, float, 4, 32),
+      PTA_B(seq_positions, int32_t, 1, 32),
+      PTA_B(O, at::BFloat16, 4, 32));
   return {O, out_splitK, metadata};
 }
 
@@ -1556,22 +1560,22 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> gqa_attn_splitk_impl(
           threads,
           0,
           at::cuda::getCurrentCUDAStream(),
-          XQ.packed_accessor32<at::BFloat16, 4, at::RestrictPtrTraits>(),
-          cache_K.packed_accessor64<at::BFloat16, 4, at::RestrictPtrTraits>(),
-          seq_positions.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
-          QK_out.packed_accessor32<float, 3, at::RestrictPtrTraits>());
+          PTA_B(XQ, at::BFloat16, 4, 32),
+          PTA_B(cache_K, at::BFloat16, 4, 64),
+          PTA_B(seq_positions, int32_t, 1, 32),
+          PTA_B(QK_out, float, 3, 32));
     } else {
-#define CALL_MQA_ATTN_SPLITK_QK_INT4_GROUPWISE_KERNEL(NUM_GROUPS, ...)      \
-  FBGEMM_LAUNCH_KERNEL(                                                     \
-      (gqa_attn_splitk_qk_int4_kernel<NUM_GROUPS>),                         \
-      blocks,                                                               \
-      threads,                                                              \
-      0,                                                                    \
-      at::cuda::getCurrentCUDAStream(),                                     \
-      XQ.packed_accessor32<at::BFloat16, 4, at::RestrictPtrTraits>(),       \
-      cache_K.packed_accessor64<uint8_t, 4, at::RestrictPtrTraits>(),       \
-      seq_positions.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(), \
-      QK_out.packed_accessor32<float, 3, at::RestrictPtrTraits>());
+#define CALL_MQA_ATTN_SPLITK_QK_INT4_GROUPWISE_KERNEL(NUM_GROUPS, ...) \
+  FBGEMM_LAUNCH_KERNEL(                                                \
+      (gqa_attn_splitk_qk_int4_kernel<NUM_GROUPS>),                    \
+      blocks,                                                          \
+      threads,                                                         \
+      0,                                                               \
+      at::cuda::getCurrentCUDAStream(),                                \
+      PTA_B(XQ, at::BFloat16, 4, 32),                                  \
+      PTA_B(cache_K, uint8_t, 4, 64),                                  \
+      PTA_B(seq_positions, int32_t, 1, 32),                            \
+      PTA_B(QK_out, float, 3, 32));
 
       auto num_groups_ = num_groups ? num_groups.value() : 1;
       CALL_INT4_KERNEL_WITH_KV_GROUPWISE_QUANT_CHECK(
@@ -1602,9 +1606,9 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> gqa_attn_splitk_impl(
         threads,
         smem,
         at::cuda::getCurrentCUDAStream(),
-        QK_out.packed_accessor32<float, 3, at::RestrictPtrTraits>(),
-        attn_out.packed_accessor32<float, 3, at::RestrictPtrTraits>(),
-        seq_positions.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+        PTA_B(QK_out, float, 3, 32),
+        PTA_B(attn_out, float, 3, 32),
+        PTA_B(seq_positions, int32_t, 1, 32),
         qk_scale);
   }
   auto O = at::empty({split_k, B, 1, H, D_H}, XQ.options().dtype(at::kFloat));
@@ -1627,26 +1631,26 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> gqa_attn_splitk_impl(
           threads,
           smem,
           at::cuda::getCurrentCUDAStream(),
-          attn_out.packed_accessor32<float, 3, at::RestrictPtrTraits>(),
-          cache_V.packed_accessor64<at::BFloat16, 4, at::RestrictPtrTraits>(),
-          O.packed_accessor32<float, 5, at::RestrictPtrTraits>(),
-          seq_positions.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>());
+          PTA_B(attn_out, float, 3, 32),
+          PTA_B(cache_V, at::BFloat16, 4, 64),
+          PTA_B(O, float, 5, 32),
+          PTA_B(seq_positions, int32_t, 1, 32));
     } else {
-#define CALL_MQA_ATTN_SPLITKV_INT4_GROUPWISE_KERNEL(NUM_GROUPS, ...)  \
-  if (set_max_dynamic_smem) {                                         \
-    set_gpu_max_dynamic_shared_memory(                                \
-        gqa_attn_splitk_v_int4_kernel<NUM_GROUPS>, smem, device);     \
-  }                                                                   \
-  FBGEMM_LAUNCH_KERNEL(                                               \
-      (gqa_attn_splitk_v_int4_kernel<NUM_GROUPS>),                    \
-      blocks,                                                         \
-      threads,                                                        \
-      smem,                                                           \
-      at::cuda::getCurrentCUDAStream(),                               \
-      attn_out.packed_accessor32<float, 3, at::RestrictPtrTraits>(),  \
-      cache_V.packed_accessor64<uint8_t, 4, at::RestrictPtrTraits>(), \
-      O.packed_accessor32<float, 5, at::RestrictPtrTraits>(),         \
-      seq_positions.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>());
+#define CALL_MQA_ATTN_SPLITKV_INT4_GROUPWISE_KERNEL(NUM_GROUPS, ...) \
+  if (set_max_dynamic_smem) {                                        \
+    set_gpu_max_dynamic_shared_memory(                               \
+        gqa_attn_splitk_v_int4_kernel<NUM_GROUPS>, smem, device);    \
+  }                                                                  \
+  FBGEMM_LAUNCH_KERNEL(                                              \
+      (gqa_attn_splitk_v_int4_kernel<NUM_GROUPS>),                   \
+      blocks,                                                        \
+      threads,                                                       \
+      smem,                                                          \
+      at::cuda::getCurrentCUDAStream(),                              \
+      PTA_B(attn_out, float, 3, 32),                                 \
+      PTA_B(cache_V, uint8_t, 4, 64),                                \
+      PTA_B(O, float, 5, 32),                                        \
+      PTA_B(seq_positions, int32_t, 1, 32));
 
       auto num_groups_ = num_groups ? num_groups.value() : 1;
       CALL_INT4_KERNEL_WITH_KV_GROUPWISE_QUANT_CHECK(
@@ -1748,11 +1752,12 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> gqa_attn_splitk(
 
 // TODO: can also fuse RoPe into this kernel. Doesn't seem worth it.
 __global__ void mqa_attn_kernel(
-    at::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits> XQ,
-    at::PackedTensorAccessor64<at::BFloat16, 4, at::RestrictPtrTraits> cache_K,
-    at::PackedTensorAccessor64<at::BFloat16, 4, at::RestrictPtrTraits> cache_V,
-    at::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits> O,
-    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> seq_positions,
+    pta::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits> XQ,
+    pta::PackedTensorAccessor64<at::BFloat16, 4, at::RestrictPtrTraits> cache_K,
+    pta::PackedTensorAccessor64<at::BFloat16, 4, at::RestrictPtrTraits> cache_V,
+    pta::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits> O,
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        seq_positions,
     float qk_scale) {
   static_assert(kWarpsPerBlock <= kThreadsPerWarp, "");
 
@@ -1953,11 +1958,12 @@ __global__ void mqa_attn_kernel(
 
 #if CUDART_VERSION >= 12000
 __global__ void mqa_attn_fp8_kernel(
-    at::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits> XQ,
-    at::PackedTensorAccessor64<uint8_t, 4, at::RestrictPtrTraits> cache_K,
-    at::PackedTensorAccessor64<uint8_t, 4, at::RestrictPtrTraits> cache_V,
-    at::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits> O,
-    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> seq_positions,
+    pta::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits> XQ,
+    pta::PackedTensorAccessor64<uint8_t, 4, at::RestrictPtrTraits> cache_K,
+    pta::PackedTensorAccessor64<uint8_t, 4, at::RestrictPtrTraits> cache_V,
+    pta::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits> O,
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        seq_positions,
     float qk_scale) {
   static_assert(kWarpsPerBlock <= kThreadsPerWarp, "");
 
@@ -2188,11 +2194,12 @@ __global__ void mqa_attn_fp8_kernel(
 // TODO: can also fuse RoPe into this kernel. Doesn't seem worth it.
 template <int KVQuantNumGroups = 1>
 __global__ void mqa_attn_int4_kernel(
-    at::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits> XQ,
-    at::PackedTensorAccessor64<uint8_t, 4, at::RestrictPtrTraits> cache_K,
-    at::PackedTensorAccessor64<uint8_t, 4, at::RestrictPtrTraits> cache_V,
-    at::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits> O,
-    at::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> seq_positions,
+    pta::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits> XQ,
+    pta::PackedTensorAccessor64<uint8_t, 4, at::RestrictPtrTraits> cache_K,
+    pta::PackedTensorAccessor64<uint8_t, 4, at::RestrictPtrTraits> cache_V,
+    pta::PackedTensorAccessor32<at::BFloat16, 4, at::RestrictPtrTraits> O,
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        seq_positions,
     float qk_scale) {
   static_assert(kWarpsPerBlock <= kThreadsPerWarp, "");
 
@@ -2544,11 +2551,11 @@ at::Tensor mqa_attn(
         threads,
         smem,
         at::cuda::getCurrentCUDAStream(),
-        XQ.packed_accessor32<at::BFloat16, 4, at::RestrictPtrTraits>(),
-        cache_K.packed_accessor64<at::BFloat16, 4, at::RestrictPtrTraits>(),
-        cache_V.packed_accessor64<at::BFloat16, 4, at::RestrictPtrTraits>(),
-        O.packed_accessor32<at::BFloat16, 4, at::RestrictPtrTraits>(),
-        seq_positions.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+        PTA_B(XQ, at::BFloat16, 4, 32),
+        PTA_B(cache_K, at::BFloat16, 4, 64),
+        PTA_B(cache_V, at::BFloat16, 4, 64),
+        PTA_B(O, at::BFloat16, 4, 32),
+        PTA_B(seq_positions, int32_t, 1, 32),
         qk_scale);
   } else {
     if (cache_logical_dtype == CacheLogicalDtype::FP8) {
@@ -2563,32 +2570,32 @@ at::Tensor mqa_attn(
           threads,
           smem,
           at::cuda::getCurrentCUDAStream(),
-          XQ.packed_accessor32<at::BFloat16, 4, at::RestrictPtrTraits>(),
-          cache_K.packed_accessor64<uint8_t, 4, at::RestrictPtrTraits>(),
-          cache_V.packed_accessor64<uint8_t, 4, at::RestrictPtrTraits>(),
-          O.packed_accessor32<at::BFloat16, 4, at::RestrictPtrTraits>(),
-          seq_positions.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(),
+          PTA_B(XQ, at::BFloat16, 4, 32),
+          PTA_B(cache_K, uint8_t, 4, 64),
+          PTA_B(cache_V, uint8_t, 4, 64),
+          PTA_B(O, at::BFloat16, 4, 32),
+          PTA_B(seq_positions, int32_t, 1, 32),
           qk_scale);
 #else
       throw std::runtime_error("CUDA version is older than 12.0");
 #endif
     } else {
-#define CALL_MQA_ATTN_INT4_GROUPWISE_KERNEL(NUM_GROUPS, ...)                \
-  if (set_max_dynamic_smem) {                                               \
-    set_gpu_max_dynamic_shared_memory(                                      \
-        mqa_attn_int4_kernel<NUM_GROUPS>, smem, XQ.get_device());           \
-  }                                                                         \
-  FBGEMM_LAUNCH_KERNEL(                                                     \
-      (mqa_attn_int4_kernel<NUM_GROUPS>),                                   \
-      blocks,                                                               \
-      threads,                                                              \
-      smem,                                                                 \
-      at::cuda::getCurrentCUDAStream(),                                     \
-      XQ.packed_accessor32<at::BFloat16, 4, at::RestrictPtrTraits>(),       \
-      cache_K.packed_accessor64<uint8_t, 4, at::RestrictPtrTraits>(),       \
-      cache_V.packed_accessor64<uint8_t, 4, at::RestrictPtrTraits>(),       \
-      O.packed_accessor32<at::BFloat16, 4, at::RestrictPtrTraits>(),        \
-      seq_positions.packed_accessor32<int32_t, 1, at::RestrictPtrTraits>(), \
+#define CALL_MQA_ATTN_INT4_GROUPWISE_KERNEL(NUM_GROUPS, ...)      \
+  if (set_max_dynamic_smem) {                                     \
+    set_gpu_max_dynamic_shared_memory(                            \
+        mqa_attn_int4_kernel<NUM_GROUPS>, smem, XQ.get_device()); \
+  }                                                               \
+  FBGEMM_LAUNCH_KERNEL(                                           \
+      (mqa_attn_int4_kernel<NUM_GROUPS>),                         \
+      blocks,                                                     \
+      threads,                                                    \
+      smem,                                                       \
+      at::cuda::getCurrentCUDAStream(),                           \
+      PTA_B(XQ, at::BFloat16, 4, 32),                             \
+      PTA_B(cache_K, uint8_t, 4, 64),                             \
+      PTA_B(cache_V, uint8_t, 4, 64),                             \
+      PTA_B(O, at::BFloat16, 4, 32),                              \
+      PTA_B(seq_positions, int32_t, 1, 32),                       \
       qk_scale);
 
       auto num_groups_ = num_groups ? num_groups.value() : 1;


### PR DESCRIPTION
Summary: -  Migrate GenAI gqa attn splitk kernel arguments to use `PTA_B`

Reviewed By: cthi

Differential Revision: D81829444


