### PR TITLE
Update bwd.py

### DIFF
--- a/fbgemm_gpu/experimental/simplicial_attention/simplicial/ops/triton/bwd.py
+++ b/fbgemm_gpu/experimental/simplicial_attention/simplicial/ops/triton/bwd.py
@@ -741,7 +741,7 @@ def bwd_pre_triton(o, dO):
     return d
 
 
-def triton_bwd(q, k1, k2, v1, v2, o, dO, m, w1, w2, k2_bias=None, v2_bias=None):
+def triton_bwd(q, k1, k2, v1, v2,w1, w2, o, dO, m, k2_bias=None, v2_bias=None):
     dq = torch.zeros_like(q, dtype=torch.float32)
     dk1 = torch.zeros_like(k1)
     dk2 = torch.zeros_like(k2)


### PR DESCRIPTION
As attached,  this is the expected order of arguments for backwards of 2 simplicial triton kernel, without this the invocation fails.

<img width="582" height="335" alt="image" src="https://github.com/user-attachments/assets/c6e6f621-1a1c-4b39-99c3-be7e373a66ff" />
