### PR TITLE
support scale_bias_last and quant_padding_float_type for cpu dequant kernel

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -469,10 +469,19 @@ at::Tensor _fusednbitrowwise_to_float_or_half_gpu(
     const int64_t output_dtype);
 at::Tensor& _fused8bitrowwise_to_float_cpu_out(
     at::Tensor& output,
-    const at::Tensor& input);
+    const at::Tensor& input,
+    const bool scale_bias_last = true,
+    const bool quant_padding_float_type = true);
+at::Tensor& fused8bitrowwise_to_half_cpu_out(
+    at::Tensor& output,
+    const at::Tensor& input,
+    const bool scale_bias_last = true,
+    const bool quant_padding_float_type = true);
 at::Tensor& _fused8bitrowwise_to_bfloat16_cpu_out(
     at::Tensor& output,
-    const at::Tensor& input);
+    const at::Tensor& input,
+    const bool scale_bias_last = true,
+    const bool quant_padding_float_type = true);
 at::Tensor& _float_to_fused8bitrowwise_cpu_out(
     at::Tensor& output,
     const at::Tensor& input);

--- a/fbgemm_gpu/test/quantize/fused_8bit_rowwise_test.py
+++ b/fbgemm_gpu/test/quantize/fused_8bit_rowwise_test.py
@@ -144,14 +144,37 @@ class TestFused8BitRowwiseQuantizationConversion(unittest.TestCase):
             # cpu path only supports bf16 dequantization
             if output_dtype == SparseType.BF16:
                 input_data = input_data.float()
+            if not test_generic_op and not quant_padding_float_type:
+                return
+            if not quant_padding_float_type and output_dtype == SparseType.FP32:
+                return
             if test_generic_op:
-                quantized_data = (
+                quantized_data_ref = (
                     torch.ops.fbgemm.FloatOrHalfToFused8BitRowwiseQuantized(input_data)
                 )
+                # fbgemm weight 2byte storages are scale_bias first layout
+                if quant_padding_float_type is False:
+                    scale_bias_last = False
+                    quant_pad = quantized_data_ref[:, -8:]
+                    quant_data = quantized_data_ref[:, :-8]
+                    quantized_data = torch.cat(
+                        [
+                            quant_pad.view(torch.float)
+                            .to(torch.half)
+                            .view(torch.uint8),
+                            quant_data,
+                        ],
+                        dim=1,
+                    )
+                else:
+                    scale_bias_last = True
+                    quantized_data = quantized_data_ref
                 dequantized_data = (
                     torch.ops.fbgemm.Fused8BitRowwiseQuantizedToFloatOrHalf(
                         quantized_data,
                         output_dtype.as_int(),
+                        quant_padding_float_type=quant_padding_float_type,
+                        scale_bias_last=scale_bias_last,
                     )
                 )
             else:
@@ -187,9 +210,17 @@ class TestFused8BitRowwiseQuantizationConversion(unittest.TestCase):
                 assert dequantized_data.numel() == 0
                 return
 
-            reference = torch.from_numpy(
-                fused_rowwise_8bit_dequantize_reference(quantized_data.numpy())
-            )
+            quantize_data_numpy = quantized_data.numpy()
+            if quant_padding_float_type:
+                reference = torch.from_numpy(
+                    fused_rowwise_8bit_dequantize_reference(quantize_data_numpy)
+                )
+            else:
+                reference = torch.from_numpy(
+                    fused_rowwise_8bit_dequantize_2bytes_padding_scale_bias_first_reference(
+                        quantize_data_numpy
+                    )
+                )
             if output_dtype == SparseType.FP32:
                 torch.testing.assert_close(dequantized_data.float(), reference.float())
             elif output_dtype == SparseType.FP16:

--- a/include/fbgemm/QuantUtils.h
+++ b/include/fbgemm/QuantUtils.h
@@ -336,7 +336,9 @@ FBGEMM_API void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf(
     const uint8_t* input,
     size_t input_rows,
     int input_columns,
-    OutputType* output);
+    OutputType* output,
+    const bool scale_bias_last = true,
+    const bool quant_padding_float_type = true);
 
 /**
  * Same as ToFusedNBitRowwiseQuantizedSBHalf but unoptimized.
@@ -383,6 +385,8 @@ FBGEMM_API void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfRef(
     const uint8_t* input,
     size_t input_rows,
     int input_columns,
-    OutputType* output);
+    OutputType* output,
+    const bool scale_bias_last = true,
+    const bool quant_padding_float_type = true);
 
 } // namespace fbgemm

--- a/include/fbgemm/QuantUtilsAvx2.h
+++ b/include/fbgemm/QuantUtilsAvx2.h
@@ -166,7 +166,10 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfAvx2(
     int input_columns,
     OutputType* output);
 
-template <typename OutputType>
+template <
+    typename OutputType,
+    bool scale_bias_last = true,
+    bool quant_padding_float_type = true>
 void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfAvx2(
     const std::uint8_t* input,
     size_t input_rows,

--- a/include/fbgemm/QuantUtilsAvx512.h
+++ b/include/fbgemm/QuantUtilsAvx512.h
@@ -39,6 +39,7 @@ FBGEMM_API void requantizeOutputProcessingGConvAvx512(
     int ld_in,
     const requantizationParams_t<BIAS_TYPE>& r);
 
+template <bool scale_bias_last = true, bool quant_padding_float_type = true>
 void Fused8BitRowwiseQuantizedSBFloatToBfloat16Avx512(
     const std::uint8_t* input,
     size_t input_rows,


### PR DESCRIPTION
Summary:
scale_bias_last: decides whether scale/bias padding is at the front or end of the row
quant_padding_float_type: decides if scale/bias is represented by fp32 or fp16

this is to match the cuda kernel implementation functionalities and allow cpu dequantization with front padded FP16 scale/bias

Differential Revision: D83405212


