### PR TITLE
re-enable decode tests

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/test/attention/blackwell_fmha_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/attention/blackwell_fmha_test.py
@@ -431,7 +431,6 @@ class CutlassBlackwellFMHATest(unittest.TestCase):
             assert torch.equal(dk, dk_d)
             assert torch.equal(dv, dv_d)
 
-    @unittest.skipIf(True, "Skip this until we figure out an issue with scaled_mm")
     @skip_cuda_lt_sm100
     @skip_rocm
     @parameterized.expand(


### PR DESCRIPTION
Summary:
Previously we disabled the test because it would crash. It seemed to be caused by tensorwise scaled_mm, but we couldn't bisect. 

After buck2 clean, it seems working again.

Differential Revision: D83501117


