### PR TITLE
Build time optimiaztion

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_bwd.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_bwd.cu
@@ -1,268 +1,6 @@
 // @nolint
-#include "blackwell_fmha_utils.hpp"
+#include "blackwell_fmha_bwd_template.cuh"
 #if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
-
-template <
-    typename Element,
-    typename ActiveMask,
-    int HeadDim,
-    bool kIsVarlen,
-    bool kIsDeterministic,
-    class... KernelOptions>
-std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd(
-    const at::Tensor& dO,
-    const at::Tensor& q,
-    const at::Tensor& k,
-    const at::Tensor& v,
-    const at::Tensor& o,
-    const at::Tensor& softmax_lse,
-    const std::optional<const at::Tensor>& cu_seqlens_q,
-    const std::optional<const at::Tensor>& cu_seqlens_k,
-    std::optional<int> max_seq_len_q,
-    std::optional<int> max_seq_len_k,
-    const std::optional<double> softmax_scale,
-    const int window_size_left,
-    const int window_size_right
-) {
-  const auto device = q.device();
-  at::cuda::CUDAGuard device_guard(device);
-
-  using ElementAccumulator = float;
-
-  // Q K D D_VO ((H_R, H_K) B)
-  using ProblemShapeType = std::conditional_t<
-    kIsVarlen,
-    cute::tuple<VariableLength, VariableLength, int, int, cute::tuple<cute::tuple<int, int>, int>>,
-    cute::tuple<int, int, int, int, cute::tuple<cute::tuple<int, int>, int>>
-  >;
-  using D_H = cute::Int<HeadDim>;
-  using TileShape = Shape<_128, _128, D_H>;
-
-  using Operation = cutlass::fmha::device::
-      Sm100FmhaBwd<ProblemShapeType, Element, ElementAccumulator, TileShape, /*kIsMla=*/false, ActiveMask, kIsDeterministic>;
-
-  using StrideQ = Stride<int, _1, Stride<Stride<int, int>, int>>; // Q D    ((H_R, H_K), B)
-  using StrideK = Stride<int, _1, Stride<Stride<_0, int>, int>>;  // K D    ((H_R, H_K), B)
-  using StrideV = StrideK;                                        // K D_VO ((H_R, H_K), B)
-  using StrideO = StrideQ;                                        // Q D_VO ((H_R, H_K), B)
-  using StrideLSE = Stride<_1, Stride<Stride<int, int>, int>>;    // Q      ((H_R, H_K), B)
-
-  // Backwards specific
-  using StrideDQ = StrideQ;
-  using StrideDK = StrideK;
-  using StrideDV = StrideV;
-  using StrideDO = StrideO;
-
-  if (kIsVarlen) {
-    TORCH_CHECK(
-        q.dim() == 3,
-        "Expect Q shape to be (total_Q_seqlen, num_Q_heads, head_dim) ",
-        "Found shape ", q.sizes());
-    TORCH_CHECK(
-        k.dim() == 3,
-        "Expect K shape to be (total_KV_seqlen, num_KV_heads, head_dim) ",
-        "Found shape ", k.sizes());
-    TORCH_CHECK(
-        v.dim() == 3,
-        "Expect V shape to be (total_KV_seqlen, num_KV_heads, head_dim) ",
-        "Found shape ", v.sizes());
-  }
-  else {
-    TORCH_CHECK(
-        q.dim() == 4,
-        "Expect Q shape to be (batch_size, Q_seqlen, num_Q_heads, head_dim). ",
-        "Found shape ", q.sizes());
-    TORCH_CHECK(
-        k.dim() == 4,
-        "Expect K shape to be (batch_size, KV_seqlen, num_KV_heads, head_dim) ",
-        "Found shape ", k.sizes());
-    TORCH_CHECK(
-        v.dim() == 4,
-        "Expect V shape to be (batch_size, KV_seqlen, num_KV_heads, head_dim) ",
-        "Found shape ", v.sizes());
-  }
-
-  if constexpr (kIsVarlen) {
-    TORCH_CHECK(cu_seqlens_q.has_value(), "cu_seqlens_q should be set");
-    TORCH_CHECK(cu_seqlens_k.has_value(), "cu_seqlens_k should be set");
-    TORCH_CHECK(max_seq_len_q.has_value(), "max_seq_len_q should be set");
-    TORCH_CHECK(max_seq_len_k.has_value(), "max_seq_len_k should be set");
-  }
-
-  int B = kIsVarlen ? cu_seqlens_q->size(0) - 1 : q.size(0);
-  // Q represents SumB(Q) for varlen (jagged len)
-  int Q = kIsVarlen ? q.size(0) : q.size(1);
-  int K = kIsVarlen ? k.size(0) : k.size(1);
-  int H_Q = kIsVarlen ? q.size(1) : q.size(2);
-  int H_K = kIsVarlen ? k.size(1) : k.size(2);
-  int D = q.size(q.dim() - 1); // Head dimension (D)
-
-  TORCH_CHECK(H_Q % H_K == 0, "Q heads must be a multiple of KV heads");
-  int H_R = H_Q / H_K;
-
-  ProblemShapeType problem_shape;
-  if constexpr (kIsVarlen) {
-    problem_shape = cute::make_tuple(
-        VariableLength{
-            *max_seq_len_q, static_cast<int*>(cu_seqlens_q->data_ptr()), int(q.size(0))},
-        VariableLength{
-            *max_seq_len_k, static_cast<int*>(cu_seqlens_k->data_ptr()), int(k.size(0))},
-        D,
-        D,
-        make_shape(make_shape(H_R, H_K), B));
-  }
-  else {
-    problem_shape = cute::make_tuple(
-        Q, K, D, D, make_shape(make_shape(H_R, H_K), B));
-  }
-  TORCH_CHECK(D == HeadDim);
-  TORCH_CHECK(D % 8 == 0); // Alignment
-  if constexpr (!kIsVarlen) {
-    // TODO: support Q < 8
-    TORCH_CHECK(Q >= 8);
-  }
-
-  // Reshape to get strides
-  auto B_ = kIsVarlen ? 1 : B;
-  auto q_ = q.reshape({B_, Q, H_K, H_R, D});
-  auto o_ = o.reshape({B_, Q, H_K, H_R, D});
-  auto dO_ = dO.reshape({B_, Q, H_K, H_R, D});
-  auto k_ = k.reshape({B_, K, H_K, 1, D}).expand({B_, K, H_K, H_R, D});
-  auto lse_ = softmax_lse.reshape({B_, H_K, H_R, Q});
-  auto ndim = q_.dim();
-
-  TORCH_CHECK(q_.stride(ndim - 1) == 1, "The head dim in Q must be contiguous");
-  TORCH_CHECK(k_.stride(ndim - 1) == 1, "The head dim in KV must be contiguous");
-  TORCH_CHECK(o_.stride(ndim - 1) == 1, "The head dim in O must be contiguous");
-  TORCH_CHECK(dO_.stride(ndim - 1) == 1, "The head dim in dO must be contiguous");
-  TORCH_CHECK(lse_.stride(lse_.dim() - 1) == 1, "The seqlen dim in LSE must be contiguous");
-  if (H_R != 1) {
-    TORCH_CHECK(k_.stride(3) == 0, "The shared KV head stride must be zero");
-  }
-
-  // Note: We use a different layout from 77_blackwell_fmha_bwd.cu.
-  // Q shape = (B, Q, H_K, H_R, D)
-  StrideQ stride_Q = make_stride(
-      static_cast<int>(q_.stride(1)), _1{},
-      make_stride(
-        make_stride(
-          static_cast<int>(q_.stride(3)),
-          static_cast<int>(q_.stride(2))),
-        static_cast<int>(q_.stride(0))));
-
-  // K shape = (B, K, H_K, 1, D)
-  StrideK stride_K = make_stride(
-      static_cast<int>(k_.stride(1)), _1{},
-      make_stride(
-        make_stride(_0{}, static_cast<int>(k_.stride(2))),
-        static_cast<int>(k_.stride(0))));
-
-  StrideV stride_V = stride_K;
-
-  // LSE shape = (B, H_K, H_R, Q)
-  StrideLSE stride_LSE = make_stride(
-      _1{},
-      make_stride(
-        make_stride(
-          static_cast<int>(lse_.stride(2)),
-          static_cast<int>(lse_.stride(1))),
-        static_cast<int>(lse_.stride(0))));
-
-  // O shape = (B, Q, H_K, H_R, D)
-  StrideO stride_O = make_stride(
-      static_cast<int>(o_.stride(1)), _1{},
-      make_stride(
-        make_stride(
-          static_cast<int>(o_.stride(3)),
-          static_cast<int>(o_.stride(2))),
-        static_cast<int>(o_.stride(0))));
-
-  // dO shape = (B, Q, H_K, H_R, D)
-  StrideDO stride_dO = make_stride(
-      static_cast<int>(dO_.stride(1)), _1{},
-      make_stride(
-        make_stride(
-          static_cast<int>(dO_.stride(3)),
-          static_cast<int>(dO_.stride(2))),
-        static_cast<int>(dO_.stride(0))));
-
-  // Outputs are always contiguous
-  StrideDQ stride_dQ = make_stride(
-      H_Q * D, _1{},
-      make_stride(make_stride(D, H_R * D), D * Q * H_Q));
-  StrideDK stride_dK = make_stride(
-      H_K * D, _1{},
-      make_stride(make_stride(_0{}, D), D * K * H_K));
-  StrideDV stride_dV = stride_dK;
-
-  if constexpr (kIsVarlen) {
-    get<2, 1>(stride_Q) = 0;
-    get<2, 1>(stride_K) = 0;
-    get<2, 1>(stride_V) = 0;
-    get<2, 1>(stride_O) = 0;
-    get<2, 1>(stride_dO) = 0;
-
-    get<1, 1>(stride_LSE) = 0;
-
-    get<2, 1>(stride_dQ) = 0;
-    get<2, 1>(stride_dK) = 0;
-    get<2, 1>(stride_dV) = 0;
-  }
-
-  ElementAccumulator softmax_scale_value = softmax_scale.has_value() ? softmax_scale.value() : (1.0f / sqrtf(D));
-
-  at::Tensor dQ = torch::empty_like(q);
-  at::Tensor dK = torch::empty_like(k);
-  at::Tensor dV = torch::empty_like(v);
-
-  cutlass::KernelHardwareInfo hw_info;
-  hw_info.device_id = device.index();
-  hw_info.sm_count =
-      cutlass::KernelHardwareInfo::query_device_multiprocessor_count(
-          hw_info.device_id);
-
-  auto seqlen_q = kIsVarlen ? max_seq_len_q.value() : q.size(1);
-
-  int* dq_semaphore_ptr = nullptr;
-  at::Tensor dq_semaphore;
-  if (kIsDeterministic) {
-    auto kBlockM = cute::get<0>(TileShape{});
-    auto opts = q.options();
-    dq_semaphore = torch::zeros(
-        {(seqlen_q + kBlockM - 1) / kBlockM, B, H_Q},
-        opts.dtype(torch::kInt32));
-    dq_semaphore_ptr = static_cast<int*>(dq_semaphore.data_ptr());
-  }
-
-  typename Operation::Arguments arguments{
-    problem_shape,
-    static_cast<Element*>(q.data_ptr()),
-    stride_Q,
-    static_cast<Element*>(k.data_ptr()),
-    stride_K,
-    static_cast<Element*>(v.data_ptr()),
-    stride_V,
-    static_cast<Element*>(o.data_ptr()),
-    stride_O,
-    static_cast<ElementAccumulator*>(softmax_lse.data_ptr()),
-    stride_LSE,
-    static_cast<Element*>(dO.data_ptr()),
-    stride_dO,
-    static_cast<Element*>(dQ.data_ptr()),
-    stride_dQ,
-    static_cast<Element*>(dK.data_ptr()),
-    stride_dK,
-    static_cast<Element*>(dV.data_ptr()),
-    stride_dV,
-    softmax_scale_value,
-    dq_semaphore_ptr,
-    window_size_left,
-    window_size_right,
-    hw_info};
-  launch_fmha_op<Operation>(arguments);
-
-  return std::make_tuple(dQ, dK, dV);
-}
 
 struct KernelCoop {};
 
@@ -282,8 +20,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> dispatch_fmha_bwd(
     int64_t window_size_left,
     int64_t window_size_right,
     bool bottom_right,
-    bool deterministic
-) {
+    bool deterministic) {
   // This workaround initializes the CUDA context to prevent the 201 error
   // (invalid context).  When this function is invoked through PyTorch
   // autograd, it runs on a new thread that hasn't been associated with a CUDA
@@ -297,10 +34,11 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> dispatch_fmha_bwd(
   // Handle local attention parameters
   bool local = (window_size_left >= 0 || window_size_right >= 0);
   if (local) {
-    // If causal is enabled, override window_size_right to 0 for causal+local behavior
+    // If causal is enabled, override window_size_right to 0 for causal+local
+    // behavior
     if (causal) {
       window_size_right = 0;
-      causal = false;  // Use local attention instead of causal
+      causal = false; // Use local attention instead of causal
     }
     // Expand -1 window sizes to full sequence length if available
     if (window_size_left < 0 && max_seq_len_k.has_value()) {
@@ -311,23 +49,20 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> dispatch_fmha_bwd(
     }
   }
 
-  auto dispatch_fmha =
-    [&](
-      auto element,
-      auto element_out,
-      auto head_dim,
-      auto varlen,
-      auto deterministic,
-      auto mask,
-      auto... kernel_options) {
-      return fmha_bwd<
+  auto dispatch_fmha = [&](auto element,
+                           auto element_out,
+                           auto head_dim,
+                           auto varlen,
+                           auto deterministic,
+                           auto mask,
+                           auto... kernel_options) {
+    return fmha_bwd<
         decltype(element),
         decltype(mask),
         head_dim,
         varlen,
         deterministic,
-        decltype(kernel_options)...>
-      (
+        decltype(kernel_options)...>(
         dOutput,
         query,
         key,
@@ -341,32 +76,46 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> dispatch_fmha_bwd(
         softmax_scale,
         window_size_left,
         window_size_right);
-    };
-
-  auto dispatch_type = [&](auto varlen, auto deterministic, auto mask, auto head_dim) {
-    if (query.dtype() == torch::kFloat16) {
-      return dispatch_fmha(
-          cutlass::half_t{}, cutlass::half_t{}, head_dim, varlen, deterministic, mask);
-    }
-    else if (query.dtype() == torch::kBFloat16) {
-      return dispatch_fmha(
-          cutlass::bfloat16_t{}, cutlass::bfloat16_t{}, head_dim, varlen, deterministic, mask);
-    }
-    else if (query.dtype() == torch::kFloat8_e4m3fn) {
-      return dispatch_fmha(
-          cutlass::float_e4m3_t{}, cutlass::bfloat16_t{}, head_dim, varlen, deterministic, mask);
-    }
-    TORCH_CHECK(false, "Unsupported dtype for q: ", query.dtype());
   };
+
+  auto dispatch_type =
+      [&](auto varlen, auto deterministic, auto mask, auto head_dim) {
+        if (query.dtype() == torch::kFloat16) {
+          return dispatch_fmha(
+              cutlass::half_t{},
+              cutlass::half_t{},
+              head_dim,
+              varlen,
+              deterministic,
+              mask);
+        } else if (query.dtype() == torch::kBFloat16) {
+          return dispatch_fmha(
+              cutlass::bfloat16_t{},
+              cutlass::bfloat16_t{},
+              head_dim,
+              varlen,
+              deterministic,
+              mask);
+        } else if (query.dtype() == torch::kFloat8_e4m3fn) {
+          return dispatch_fmha(
+              cutlass::float_e4m3_t{},
+              cutlass::bfloat16_t{},
+              head_dim,
+              varlen,
+              deterministic,
+              mask);
+        }
+        TORCH_CHECK(false, "Unsupported dtype for q: ", query.dtype());
+      };
 
   auto dispatch_head_dim = [&](auto varlen, auto deterministic, auto mask) {
     if (query.size(query.dim() - 1) == 128) {
-      return dispatch_type(varlen, deterministic, mask, std::integral_constant<int, 128>{});
-    }
-    else if (query.size(query.dim() - 1) == 64) {
-      return dispatch_type(varlen, deterministic, mask, std::integral_constant<int, 64>{});
-    }
-    else {
+      return dispatch_type(
+          varlen, deterministic, mask, std::integral_constant<int, 128>{});
+    } else if (query.size(query.dim() - 1) == 64) {
+      return dispatch_type(
+          varlen, deterministic, mask, std::integral_constant<int, 64>{});
+    } else {
       TORCH_CHECK(false, "Unsupported head dim: ", query.size(query.dim() - 1));
     }
   };
@@ -375,40 +124,35 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> dispatch_fmha_bwd(
     if (causal) {
       if (bottom_right) {
         return dispatch_head_dim(
-            varlen, deterministic, CausalForBackwardMask</*kIsQBegin=*/false>{});
-      }
-      else {
+            varlen,
+            deterministic,
+            CausalForBackwardMask</*kIsQBegin=*/false>{});
+      } else {
         return dispatch_head_dim(
             varlen, deterministic, CausalForBackwardMask</*kIsQBegin=*/true>{});
       }
-    }
-    else if (local) {
+    } else if (local) {
       if (bottom_right) {
         return dispatch_head_dim(
             varlen, deterministic, LocalMaskForBackward</*kIsQBegin=*/false>{});
-      }
-      else {
+      } else {
         return dispatch_head_dim(
             varlen, deterministic, LocalMaskForBackward</*kIsQBegin=*/true>{});
       }
-    }
-    else if (varlen || key.size(1) % 128 != 0) {
+    } else if (varlen || key.size(1) % 128 != 0) {
       // Use the residual mask for varlen or when K seqlen is not multiple of
       // blockN
       return dispatch_head_dim(
           varlen, deterministic, ResidualMaskForBackward{});
-    }
-    else {
-      return dispatch_head_dim(
-          varlen, deterministic, NoMask{});
+    } else {
+      return dispatch_head_dim(varlen, deterministic, NoMask{});
     }
   };
 
   auto dispatch_deterministic = [&](auto varlen) {
     if (deterministic) {
       return dispatch_mask(varlen, std::bool_constant<true>{});
-    }
-    else {
+    } else {
       return dispatch_mask(varlen, std::bool_constant<false>{});
     }
   };
@@ -425,28 +169,28 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> dispatch_fmha_bwd(
 // Op registration
 // -------------------------------------------------------------------------------------------------
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
-  m.def("fmha_bwd("
-        "    Tensor dOutput, "
-        "    Tensor query, "
-        "    Tensor key, "
-        "    Tensor value, "
-        "    Tensor output, "
-        "    Tensor softmax_lse, "
-        "    Tensor? cu_seqlens_q=None, "
-        "    Tensor? cu_seqlens_k=None, "
-        "    int? max_seq_len_q=None, "
-        "    int? max_seq_len_k=None, "
-        "    float? softmax_scale=None, "
-        "    bool causal=False, "
-        "    int window_size_left=-1, "
-        "    int window_size_right=-1, "
-        "    bool bottom_right=True, "
-        "    bool deterministic=False"
-        ") -> (Tensor, Tensor, Tensor)"
-  );
+  m.def(
+      "fmha_bwd("
+      "    Tensor dOutput, "
+      "    Tensor query, "
+      "    Tensor key, "
+      "    Tensor value, "
+      "    Tensor output, "
+      "    Tensor softmax_lse, "
+      "    Tensor? cu_seqlens_q=None, "
+      "    Tensor? cu_seqlens_k=None, "
+      "    int? max_seq_len_q=None, "
+      "    int? max_seq_len_k=None, "
+      "    float? softmax_scale=None, "
+      "    bool causal=False, "
+      "    int window_size_left=-1, "
+      "    int window_size_right=-1, "
+      "    bool bottom_right=True, "
+      "    bool deterministic=False"
+      ") -> (Tensor, Tensor, Tensor)");
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   m.impl("fmha_bwd", dispatch_fmha_bwd);
 }
-#endif  // CUTLASS_ARCH_MMA_SM100_SUPPORTED
+#endif // CUTLASS_ARCH_MMA_SM100_SUPPORTED

--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_bwd_bf16_inst.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_bwd_bf16_inst.cu
@@ -1,0 +1,223 @@
+// @nolint
+#include "blackwell_fmha_bwd_template.cuh"
+#if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+
+// Explicit template instantiations for BF16 data type
+// These instantiations cover the main combinations used by the dispatch
+// functions
+
+// BF16 + NoMask + Head Dim 128 instantiations
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::bfloat16_t, // Element
+    NoMask, // ActiveMask
+    128, // HeadDim
+    false, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::bfloat16_t, // Element
+    NoMask, // ActiveMask
+    128, // HeadDim
+    false, // kIsVarlen
+    true // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::bfloat16_t, // Element
+    NoMask, // ActiveMask
+    128, // HeadDim
+    true, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::bfloat16_t, // Element
+    NoMask, // ActiveMask
+    128, // HeadDim
+    true, // kIsVarlen
+    true // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+// BF16 + Head Dim 64 instantiations
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::bfloat16_t, // Element
+    NoMask, // ActiveMask
+    64, // HeadDim
+    false, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::bfloat16_t, // Element
+    NoMask, // ActiveMask
+    64, // HeadDim
+    true, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+// BF16 + ResidualMaskForBackward instantiations
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::bfloat16_t, // Element
+    ResidualMaskForBackward, // ActiveMask
+    128, // HeadDim
+    false, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::bfloat16_t, // Element
+    ResidualMaskForBackward, // ActiveMask
+    128, // HeadDim
+    true, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+// BF16 + CausalForBackwardMask instantiations
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::bfloat16_t, // Element
+    CausalForBackwardMask<true>, // ActiveMask
+    128, // HeadDim
+    false, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::bfloat16_t, // Element
+    CausalForBackwardMask<false>, // ActiveMask
+    128, // HeadDim
+    false, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+#endif // CUTLASS_ARCH_MMA_SM100_SUPPORTED

--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_bwd_fp16_inst.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_bwd_fp16_inst.cu
@@ -1,0 +1,266 @@
+// @nolint
+#include "blackwell_fmha_bwd_template.cuh"
+#if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+
+// Explicit template instantiations for FP16 data type
+// These instantiations cover the main combinations used by the dispatch
+// functions
+
+// FP16 + NoMask + Head Dim 128 instantiations
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::half_t, // Element
+    NoMask, // ActiveMask
+    128, // HeadDim
+    false, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::half_t, // Element
+    NoMask, // ActiveMask
+    128, // HeadDim
+    false, // kIsVarlen
+    true // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::half_t, // Element
+    NoMask, // ActiveMask
+    128, // HeadDim
+    true, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::half_t, // Element
+    NoMask, // ActiveMask
+    128, // HeadDim
+    true, // kIsVarlen
+    true // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+// FP16 + Head Dim 64 instantiations
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::half_t, // Element
+    NoMask, // ActiveMask
+    64, // HeadDim
+    false, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::half_t, // Element
+    NoMask, // ActiveMask
+    64, // HeadDim
+    true, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+// FP16 + ResidualMaskForBackward instantiations
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::half_t, // Element
+    ResidualMaskForBackward, // ActiveMask
+    128, // HeadDim
+    false, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::half_t, // Element
+    ResidualMaskForBackward, // ActiveMask
+    128, // HeadDim
+    true, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+// FP16 + CausalForBackwardMask instantiations
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::half_t, // Element
+    CausalForBackwardMask<true>, // ActiveMask
+    128, // HeadDim
+    false, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::half_t, // Element
+    CausalForBackwardMask<false>, // ActiveMask
+    128, // HeadDim
+    false, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+// FP16 + LocalMaskForBackward instantiations
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::half_t, // Element
+    LocalMaskForBackward<true>, // ActiveMask
+    128, // HeadDim
+    false, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::half_t, // Element
+    LocalMaskForBackward<false>, // ActiveMask
+    128, // HeadDim
+    false, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+#endif // CUTLASS_ARCH_MMA_SM100_SUPPORTED

--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_bwd_fp8_inst.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_bwd_fp8_inst.cu
@@ -1,0 +1,180 @@
+// @nolint
+#include "blackwell_fmha_bwd_template.cuh"
+#if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+
+// Explicit template instantiations for FP8 data type
+// These instantiations cover the main combinations used by the dispatch
+// functions Note: FP8 input type (cutlass::float_e4m3_t) for attention kernels
+
+// FP8 + NoMask + Head Dim 128 instantiations
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::float_e4m3_t, // Element (FP8)
+    NoMask, // ActiveMask
+    128, // HeadDim
+    false, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::float_e4m3_t, // Element (FP8)
+    NoMask, // ActiveMask
+    128, // HeadDim
+    false, // kIsVarlen
+    true // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::float_e4m3_t, // Element (FP8)
+    NoMask, // ActiveMask
+    128, // HeadDim
+    true, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::float_e4m3_t, // Element (FP8)
+    NoMask, // ActiveMask
+    128, // HeadDim
+    true, // kIsVarlen
+    true // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+// FP8 + Head Dim 64 instantiations
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::float_e4m3_t, // Element (FP8)
+    NoMask, // ActiveMask
+    64, // HeadDim
+    false, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::float_e4m3_t, // Element (FP8)
+    NoMask, // ActiveMask
+    64, // HeadDim
+    true, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+// FP8 + ResidualMaskForBackward instantiations
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::float_e4m3_t, // Element (FP8)
+    ResidualMaskForBackward, // ActiveMask
+    128, // HeadDim
+    false, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd<
+    cutlass::float_e4m3_t, // Element (FP8)
+    ResidualMaskForBackward, // ActiveMask
+    128, // HeadDim
+    true, // kIsVarlen
+    false // kIsDeterministic
+    >(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right);
+
+#endif // CUTLASS_ARCH_MMA_SM100_SUPPORTED

--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_bwd_template.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_bwd_template.cuh
@@ -1,0 +1,268 @@
+// @nolint
+#pragma once
+#include "blackwell_fmha_utils.hpp"
+#if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+
+template <
+    typename Element,
+    typename ActiveMask,
+    int HeadDim,
+    bool kIsVarlen,
+    bool kIsDeterministic,
+    class... KernelOptions>
+std::tuple<at::Tensor, at::Tensor, at::Tensor> fmha_bwd(
+    const at::Tensor& dO,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& o,
+    const at::Tensor& softmax_lse,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int> max_seq_len_q,
+    std::optional<int> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const int window_size_left,
+    const int window_size_right
+) {
+  const auto device = q.device();
+  at::cuda::CUDAGuard device_guard(device);
+
+  using ElementAccumulator = float;
+
+  // Q K D D_VO ((H_R, H_K) B)
+  using ProblemShapeType = std::conditional_t<
+    kIsVarlen,
+    cute::tuple<VariableLength, VariableLength, int, int, cute::tuple<cute::tuple<int, int>, int>>,
+    cute::tuple<int, int, int, int, cute::tuple<cute::tuple<int, int>, int>>
+  >;
+  using D_H = cute::Int<HeadDim>;
+  using TileShape = Shape<_128, _128, D_H>;
+
+  using Operation = cutlass::fmha::device::
+      Sm100FmhaBwd<ProblemShapeType, Element, ElementAccumulator, TileShape, /*kIsMla=*/false, ActiveMask, kIsDeterministic>;
+
+  using StrideQ = Stride<int, _1, Stride<Stride<int, int>, int>>; // Q D    ((H_R, H_K), B)
+  using StrideK = Stride<int, _1, Stride<Stride<_0, int>, int>>;  // K D    ((H_R, H_K), B)
+  using StrideV = StrideK;                                        // K D_VO ((H_R, H_K), B)
+  using StrideO = StrideQ;                                        // Q D_VO ((H_R, H_K), B)
+  using StrideLSE = Stride<_1, Stride<Stride<int, int>, int>>;    // Q      ((H_R, H_K), B)
+
+  // Backwards specific
+  using StrideDQ = StrideQ;
+  using StrideDK = StrideK;
+  using StrideDV = StrideV;
+  using StrideDO = StrideO;
+
+  if (kIsVarlen) {
+    TORCH_CHECK(
+        q.dim() == 3,
+        "Expect Q shape to be (total_Q_seqlen, num_Q_heads, head_dim) ",
+        "Found shape ", q.sizes());
+    TORCH_CHECK(
+        k.dim() == 3,
+        "Expect K shape to be (total_KV_seqlen, num_KV_heads, head_dim) ",
+        "Found shape ", k.sizes());
+    TORCH_CHECK(
+        v.dim() == 3,
+        "Expect V shape to be (total_KV_seqlen, num_KV_heads, head_dim) ",
+        "Found shape ", v.sizes());
+  }
+  else {
+    TORCH_CHECK(
+        q.dim() == 4,
+        "Expect Q shape to be (batch_size, Q_seqlen, num_Q_heads, head_dim). ",
+        "Found shape ", q.sizes());
+    TORCH_CHECK(
+        k.dim() == 4,
+        "Expect K shape to be (batch_size, KV_seqlen, num_KV_heads, head_dim) ",
+        "Found shape ", k.sizes());
+    TORCH_CHECK(
+        v.dim() == 4,
+        "Expect V shape to be (batch_size, KV_seqlen, num_KV_heads, head_dim) ",
+        "Found shape ", v.sizes());
+  }
+
+  if constexpr (kIsVarlen) {
+    TORCH_CHECK(cu_seqlens_q.has_value(), "cu_seqlens_q should be set");
+    TORCH_CHECK(cu_seqlens_k.has_value(), "cu_seqlens_k should be set");
+    TORCH_CHECK(max_seq_len_q.has_value(), "max_seq_len_q should be set");
+    TORCH_CHECK(max_seq_len_k.has_value(), "max_seq_len_k should be set");
+  }
+
+  int B = kIsVarlen ? cu_seqlens_q->size(0) - 1 : q.size(0);
+  // Q represents SumB(Q) for varlen (jagged len)
+  int Q = kIsVarlen ? q.size(0) : q.size(1);
+  int K = kIsVarlen ? k.size(0) : k.size(1);
+  int H_Q = kIsVarlen ? q.size(1) : q.size(2);
+  int H_K = kIsVarlen ? k.size(1) : k.size(2);
+  int D = q.size(q.dim() - 1); // Head dimension (D)
+
+  TORCH_CHECK(H_Q % H_K == 0, "Q heads must be a multiple of KV heads");
+  int H_R = H_Q / H_K;
+
+  ProblemShapeType problem_shape;
+  if constexpr (kIsVarlen) {
+    problem_shape = cute::make_tuple(
+        VariableLength{
+            *max_seq_len_q, static_cast<int*>(cu_seqlens_q->data_ptr()), int(q.size(0))},
+        VariableLength{
+            *max_seq_len_k, static_cast<int*>(cu_seqlens_k->data_ptr()), int(k.size(0))},
+        D,
+        D,
+        make_shape(make_shape(H_R, H_K), B));
+  }
+  else {
+    problem_shape = cute::make_tuple(
+        Q, K, D, D, make_shape(make_shape(H_R, H_K), B));
+  }
+  TORCH_CHECK(D == HeadDim);
+  TORCH_CHECK(D % 8 == 0); // Alignment
+  if constexpr (!kIsVarlen) {
+    // TODO: support Q < 8
+    TORCH_CHECK(Q >= 8);
+  }
+
+  // Reshape to get strides
+  auto B_ = kIsVarlen ? 1 : B;
+  auto q_ = q.reshape({B_, Q, H_K, H_R, D});
+  auto o_ = o.reshape({B_, Q, H_K, H_R, D});
+  auto dO_ = dO.reshape({B_, Q, H_K, H_R, D});
+  auto k_ = k.reshape({B_, K, H_K, 1, D}).expand({B_, K, H_K, H_R, D});
+  auto lse_ = softmax_lse.reshape({B_, H_K, H_R, Q});
+  auto ndim = q_.dim();
+
+  TORCH_CHECK(q_.stride(ndim - 1) == 1, "The head dim in Q must be contiguous");
+  TORCH_CHECK(k_.stride(ndim - 1) == 1, "The head dim in KV must be contiguous");
+  TORCH_CHECK(o_.stride(ndim - 1) == 1, "The head dim in O must be contiguous");
+  TORCH_CHECK(dO_.stride(ndim - 1) == 1, "The head dim in dO must be contiguous");
+  TORCH_CHECK(lse_.stride(lse_.dim() - 1) == 1, "The seqlen dim in LSE must be contiguous");
+  if (H_R != 1) {
+    TORCH_CHECK(k_.stride(3) == 0, "The shared KV head stride must be zero");
+  }
+
+  // Note: We use a different layout from 77_blackwell_fmha_bwd.cu.
+  // Q shape = (B, Q, H_K, H_R, D)
+  StrideQ stride_Q = make_stride(
+      static_cast<int>(q_.stride(1)), _1{},
+      make_stride(
+        make_stride(
+          static_cast<int>(q_.stride(3)),
+          static_cast<int>(q_.stride(2))),
+        static_cast<int>(q_.stride(0))));
+
+  // K shape = (B, K, H_K, 1, D)
+  StrideK stride_K = make_stride(
+      static_cast<int>(k_.stride(1)), _1{},
+      make_stride(
+        make_stride(_0{}, static_cast<int>(k_.stride(2))),
+        static_cast<int>(k_.stride(0))));
+
+  StrideV stride_V = stride_K;
+
+  // LSE shape = (B, H_K, H_R, Q)
+  StrideLSE stride_LSE = make_stride(
+      _1{},
+      make_stride(
+        make_stride(
+          static_cast<int>(lse_.stride(2)),
+          static_cast<int>(lse_.stride(1))),
+        static_cast<int>(lse_.stride(0))));
+
+  // O shape = (B, Q, H_K, H_R, D)
+  StrideO stride_O = make_stride(
+      static_cast<int>(o_.stride(1)), _1{},
+      make_stride(
+        make_stride(
+          static_cast<int>(o_.stride(3)),
+          static_cast<int>(o_.stride(2))),
+        static_cast<int>(o_.stride(0))));
+
+  // dO shape = (B, Q, H_K, H_R, D)
+  StrideDO stride_dO = make_stride(
+      static_cast<int>(dO_.stride(1)), _1{},
+      make_stride(
+        make_stride(
+          static_cast<int>(dO_.stride(3)),
+          static_cast<int>(dO_.stride(2))),
+        static_cast<int>(dO_.stride(0))));
+
+  // Outputs are always contiguous
+  StrideDQ stride_dQ = make_stride(
+      H_Q * D, _1{},
+      make_stride(make_stride(D, H_R * D), D * Q * H_Q));
+  StrideDK stride_dK = make_stride(
+      H_K * D, _1{},
+      make_stride(make_stride(_0{}, D), D * K * H_K));
+  StrideDV stride_dV = stride_dK;
+
+  if constexpr (kIsVarlen) {
+    get<2, 1>(stride_Q) = 0;
+    get<2, 1>(stride_K) = 0;
+    get<2, 1>(stride_V) = 0;
+    get<2, 1>(stride_O) = 0;
+    get<2, 1>(stride_dO) = 0;
+
+    get<1, 1>(stride_LSE) = 0;
+
+    get<2, 1>(stride_dQ) = 0;
+    get<2, 1>(stride_dK) = 0;
+    get<2, 1>(stride_dV) = 0;
+  }
+
+  ElementAccumulator softmax_scale_value = softmax_scale.has_value() ? softmax_scale.value() : (1.0f / sqrtf(D));
+
+  at::Tensor dQ = torch::empty_like(q);
+  at::Tensor dK = torch::empty_like(k);
+  at::Tensor dV = torch::empty_like(v);
+
+  cutlass::KernelHardwareInfo hw_info;
+  hw_info.device_id = device.index();
+  hw_info.sm_count =
+      cutlass::KernelHardwareInfo::query_device_multiprocessor_count(
+          hw_info.device_id);
+
+  auto seqlen_q = kIsVarlen ? max_seq_len_q.value() : q.size(1);
+
+  int* dq_semaphore_ptr = nullptr;
+  at::Tensor dq_semaphore;
+  if (kIsDeterministic) {
+    auto kBlockM = cute::get<0>(TileShape{});
+    auto opts = q.options();
+    dq_semaphore = torch::zeros(
+        {(seqlen_q + kBlockM - 1) / kBlockM, B, H_Q},
+        opts.dtype(torch::kInt32));
+    dq_semaphore_ptr = static_cast<int*>(dq_semaphore.data_ptr());
+  }
+
+  typename Operation::Arguments arguments{
+    problem_shape,
+    static_cast<Element*>(q.data_ptr()),
+    stride_Q,
+    static_cast<Element*>(k.data_ptr()),
+    stride_K,
+    static_cast<Element*>(v.data_ptr()),
+    stride_V,
+    static_cast<Element*>(o.data_ptr()),
+    stride_O,
+    static_cast<ElementAccumulator*>(softmax_lse.data_ptr()),
+    stride_LSE,
+    static_cast<Element*>(dO.data_ptr()),
+    stride_dO,
+    static_cast<Element*>(dQ.data_ptr()),
+    stride_dQ,
+    static_cast<Element*>(dK.data_ptr()),
+    stride_dK,
+    static_cast<Element*>(dV.data_ptr()),
+    stride_dV,
+    softmax_scale_value,
+    dq_semaphore_ptr,
+    window_size_left,
+    window_size_right,
+    hw_info};
+  launch_fmha_op<Operation>(arguments);
+
+  return std::make_tuple(dQ, dK, dV);
+}
+
+#endif // CUTLASS_ARCH_MMA_SM100_SUPPORTED

--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_fwd.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_fwd.cu
@@ -1,250 +1,6 @@
 // @nolint
-#include "blackwell_fmha_utils.hpp"
+#include "blackwell_fmha_fwd_template.cuh"
 #if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
-
-template <
-  typename Element,
-  typename ElementOut,
-  int HeadDim,
-  bool kIsVarlen,
-  typename ActiveMask
->
-std::tuple<at::Tensor, at::Tensor> fmha_fwd(
-    const at::Tensor& q,
-    const at::Tensor& k,
-    const at::Tensor& v,
-    const std::optional<const at::Tensor>& cu_seqlens_q,
-    const std::optional<const at::Tensor>& cu_seqlens_k,
-    std::optional<int64_t> max_seq_len_q,
-    std::optional<int64_t> max_seq_len_k,
-    const std::optional<double> softmax_scale,
-    const std::optional<const at::Tensor>& seqlen_kv,
-    const int window_size_left,
-    const int window_size_right
-  ) {
-  const auto device = q.device();
-  at::cuda::CUDAGuard device_guard(device);
-
-  using ElementAccumulatorQK = float;
-  using ElementAccumulatorPV = float;
-
-  // Q K D (H_r H_k) B
-  using ProblemShapeRegular =
-      cute::tuple<int, int, int, cute::tuple<cute::tuple<int, int>, int>>;
-  using ProblemShapeVarlen = cute::tuple<
-      VariableLength,
-      VariableLength,
-      int,
-      cute::tuple<cute::tuple<int, int>, int>>;
-  using ProblemShapeType =
-      std::conditional_t<kIsVarlen, ProblemShapeVarlen, ProblemShapeRegular>;
-
-  using StrideQ =
-      cute::tuple<int, _1, cute::tuple<cute::tuple<int, int>, int>>; // Q D (H_G
-                                                                     // H_R B)
-  using StrideK =
-      cute::tuple<int, _1, cute::tuple<cute::tuple<_0, int>, int>>; // K D (H_G
-                                                                    // H_R B)
-  using StrideV = StrideK;
-  using StrideO = StrideQ;
-  using StrideLSE =
-      cute::tuple<_1, cute::tuple<cute::tuple<int, int>, int>>; // Q   (H_G H_R
-                                                                // B)
-
-  static constexpr bool kIsPersistent = true;
-  using TileScheduler = std::conditional_t<
-      kIsPersistent,
-      cutlass::fmha::kernel::PersistentTileScheduler,
-      cutlass::fmha::kernel::IndividualTileScheduler>;
-
-  using D_H = cute::Int<HeadDim>;
-  using TileShape = Shape<_256, _128, D_H>;
-
-  using Mainloop =
-      cutlass::fmha::collective::Sm100FmhaFwdMainloopTmaWarpspecialized<
-          Element,
-          ElementAccumulatorQK,
-          ElementAccumulatorPV,
-          TileShape,
-          StrideQ,
-          StrideK,
-          StrideV,
-          ActiveMask>;
-
-  using Operation = cutlass::fmha::device::FMHA<
-      cutlass::fmha::kernel::Sm100FmhaFwdKernelTmaWarpspecialized<
-          ProblemShapeType,
-          Mainloop,
-          cutlass::fmha::collective::Sm100FmhaFwdEpilogueTmaWarpspecialized<
-              ElementOut,
-              ElementAccumulatorPV,
-              typename Mainloop::TileShapePV,
-              StrideO,
-              StrideLSE>,
-          TileScheduler>>;
-
-  if (kIsVarlen) {
-    TORCH_CHECK(
-        q.dim() == 3,
-        "Expect Q shape to be (total_Q_seqlen, num_Q_heads, head_dim) ",
-        "Found shape ", q.sizes());
-    TORCH_CHECK(
-        k.dim() == 3,
-        "Expect K shape to be (total_KV_seqlen, num_KV_heads, head_dim) ",
-        "Found shape ", k.sizes());
-    TORCH_CHECK(
-        v.dim() == 3,
-        "Expect V shape to be (total_KV_seqlen, num_KV_heads, head_dim) ",
-        "Found shape ", v.sizes());
-  }
-  else {
-    TORCH_CHECK(
-        q.dim() == 4,
-        "Expect Q shape to be (batch_size, Q_seqlen, num_Q_heads, head_dim). ",
-        "Found shape ", q.sizes());
-    TORCH_CHECK(
-        k.dim() == 4,
-        "Expect K shape to be (batch_size, KV_seqlen, num_KV_heads, head_dim) ",
-        "Found shape ", k.sizes());
-    TORCH_CHECK(
-        v.dim() == 4,
-        "Expect V shape to be (batch_size, KV_seqlen, num_KV_heads, head_dim) ",
-        "Found shape ", v.sizes());
-  }
-
-  if constexpr (kIsVarlen) {
-    TORCH_CHECK(cu_seqlens_q.has_value(), "cu_seqlens_q should be set");
-    TORCH_CHECK(cu_seqlens_k.has_value(), "cu_seqlens_k should be set");
-    TORCH_CHECK(max_seq_len_q.has_value(), "max_seq_len_q should be set");
-    TORCH_CHECK(max_seq_len_k.has_value(), "max_seq_len_k should be set");
-  }
-
-  // Extract dimensions from input tensors
-  int H_Q = kIsVarlen ? q.size(1) : q.size(2); // Number of Q heads
-  int H_K = kIsVarlen ? k.size(1) : k.size(2); // Number of K heads
-  int D = q.size(q.dim() - 1); // Head dimension (D)
-
-  TORCH_CHECK(H_Q % H_K == 0);
-  int H_R = H_Q / H_K; // Q heads per K head
-  TORCH_CHECK(D == HeadDim);
-
-  // SQ represents SumB(Q) for varlen (jagged len)
-  int SQ = kIsVarlen ? q.size(0) : q.size(1);
-  int SK = kIsVarlen ? k.size(0) : k.size(1);
-  int B = kIsVarlen ? cu_seqlens_q->size(0) - 1 : q.size(0);
-
-  ProblemShapeType problem_shape;
-  if constexpr (kIsVarlen) {
-    problem_shape = cute::make_tuple(
-        VariableLength{
-            static_cast<int>(*max_seq_len_q), static_cast<int*>(cu_seqlens_q->data_ptr()), SQ},
-        VariableLength{
-            static_cast<int>(*max_seq_len_k), static_cast<int*>(cu_seqlens_k->data_ptr()), SK},
-        D,
-        cute::make_tuple(cute::make_tuple(H_R, H_K), B));
-  }
-  else {
-    problem_shape = cute::make_tuple(
-        SQ, SK, D, cute::make_tuple(cute::make_tuple(H_R, H_K), B)
-    );
-  }
-
-  // Reshape to get strides
-  auto B_ = kIsVarlen ? 1 : B;
-  auto q_ = q.reshape({B_, SQ, H_K, H_R, D});
-  auto k_ = k.reshape({B_, SK, H_K, 1, D}).expand({B_, SK, H_K, H_R, D});
-  auto ndim = q_.dim();
-
-  TORCH_CHECK(q_.stride(ndim - 1) == 1, "The head dim in Q must be contiguous");
-  TORCH_CHECK(k_.stride(ndim - 1) == 1, "The head dim in K must be contiguous");
-
-  if (H_R != 1) {
-    TORCH_CHECK(k_.stride(3) == 0, "The shared K head stride must be zero");
-  }
-
-  // Convert torch tensors to CUTLASS format
-  // Set up strides for tensors based on dimensions
-  // Q shape = (B, Q, H_K, H_R, D)
-  StrideQ stride_Q = make_stride(
-      static_cast<int>(q_.stride(1)),
-      _1{},
-      make_stride(
-        make_stride(static_cast<int>(q_.stride(3)), static_cast<int>(q_.stride(2))),
-        static_cast<int>(q_.stride(0))));
-
-  // K shape = (B, K, H_K, 1, D)
-  StrideK stride_K = make_stride(
-      static_cast<int>(k_.stride(1)),
-      _1{},
-      make_stride(
-        make_stride(_0{}, static_cast<int>(k_.stride(2))),
-        static_cast<int>(k_.stride(0))));
-  StrideV stride_V = stride_K;
-
-  // O shape = (B, Q, H_K, H_R, D)
-  // O is always contiguous
-  StrideO stride_O = make_stride(
-      H_Q * D, _1{}, make_stride(make_stride(D, H_R * D), H_Q * D * SQ));
-
-  // LSE shape = (B, H_K, H_R, Q)
-  StrideLSE stride_LSE =
-      make_stride(_1{}, make_stride(make_stride(SQ, SQ * H_R), SQ * H_Q));
-
-  // The KernelHardwareInfo struct holds the number of SMs on the GPU with a
-  // given device ID. This information is used by the underlying kernel.
-  cutlass::KernelHardwareInfo hw_info;
-  hw_info.device_id = device.index();
-  hw_info.sm_count =
-      cutlass::KernelHardwareInfo::query_device_multiprocessor_count(
-          hw_info.device_id);
-
-  // Output tensors
-  TensorWrapper<ElementOut> block_O;
-  TensorWrapper<ElementAccumulatorPV> block_LSE;
-  block_O.reset(q.numel(), kIsVarlen ? D * (*max_seq_len_q) * H_Q : 0);
-  int size_LSE = SQ * H_Q * (kIsVarlen ? 1 : B);
-  block_LSE.reset(size_LSE);
-
-  typename Operation::Arguments arguments;
-  if constexpr (kIsVarlen) {
-    get<2, 1>(stride_Q) = 0;
-    get<2, 1>(stride_K) = 0;
-    get<2, 1>(stride_V) = 0;
-    get<2, 1>(stride_O) = 0;
-    get<1, 1>(stride_LSE) = 0;
-  }
-  arguments = {
-      problem_shape,
-      seqlen_kv.has_value()
-          ? static_cast<const int*>(seqlen_kv->data_ptr())
-          : nullptr,
-      {
-          {
-              static_cast<Element*>(q.data_ptr()), stride_Q,
-              static_cast<Element*>(k.data_ptr()), stride_K,
-              static_cast<Element*>(v.data_ptr()), stride_V,
-              window_size_left, window_size_right
-          },
-          static_cast<float>(softmax_scale.value_or(0.0f)) /* softmax_scale */,
-          1.0f /* scale_q */,
-          1.0f /* scale_k */,
-          1.0f /* scale_v */,
-          1.0f /* inv_scale_o */,
-          window_size_left,
-          window_size_right,
-      },
-      {
-          block_O.get(), stride_O,
-          block_LSE.get(), stride_LSE
-      },
-      hw_info
-  };
-
-  launch_fmha_op<Operation>(arguments);
-  return std::make_tuple(
-      block_O.get_data_tensor(q.sizes()),
-      block_LSE.get_data_tensor({kIsVarlen ? 1 : B, H_Q, SQ}));
-}
 
 std::tuple<at::Tensor, at::Tensor> dispatch_fmha_fwd(
     const at::Tensor& q,
@@ -259,15 +15,15 @@ std::tuple<at::Tensor, at::Tensor> dispatch_fmha_fwd(
     const std::optional<at::Tensor>& seqlen_kv,
     int64_t window_size_left,
     int64_t window_size_right,
-    bool bottom_right
-  ) {
+    bool bottom_right) {
   // Handle local attention parameters
   bool local = (window_size_left >= 0 || window_size_right >= 0);
   if (local) {
-    // If causal is enabled, override window_size_right to 0 for causal+local behavior
+    // If causal is enabled, override window_size_right to 0 for causal+local
+    // behavior
     if (causal) {
       window_size_right = 0;
-      causal = false;  // Use local attention instead of causal
+      causal = false; // Use local attention instead of causal
     }
     // Expand -1 window sizes to full sequence length if available
     if (window_size_left < 0 && max_seq_len_k.has_value()) {
@@ -278,13 +34,17 @@ std::tuple<at::Tensor, at::Tensor> dispatch_fmha_fwd(
     }
   }
 
-  auto dispatch_fmha = [&](auto element, auto element_out, auto head_dim, auto varlen, auto mask) {
+  auto dispatch_fmha = [&](auto element,
+                           auto element_out,
+                           auto head_dim,
+                           auto varlen,
+                           auto mask) {
     return fmha_fwd<
-      decltype(element),
-      decltype(element_out),
-      head_dim,
-      varlen,
-      decltype(mask)>(
+        decltype(element),
+        decltype(element_out),
+        head_dim,
+        varlen,
+        decltype(mask)>(
         q,
         k,
         v,
@@ -295,23 +55,24 @@ std::tuple<at::Tensor, at::Tensor> dispatch_fmha_fwd(
         softmax_scale,
         seqlen_kv,
         window_size_left,
-        window_size_right
-      );
+        window_size_right);
   };
 
   auto dispatch_type = [&](auto varlen, auto mask, auto head_dim) {
     if (q.dtype() == torch::kFloat16) {
       return dispatch_fmha(
           cutlass::half_t{}, cutlass::half_t{}, head_dim, varlen, mask);
-    }
-    else if (q.dtype() == torch::kBFloat16) {
+    } else if (q.dtype() == torch::kBFloat16) {
       return dispatch_fmha(
           cutlass::bfloat16_t{}, cutlass::bfloat16_t{}, head_dim, varlen, mask);
-    }
-    else if (q.dtype() == torch::kFloat8_e4m3fn) {
+    } else if (q.dtype() == torch::kFloat8_e4m3fn) {
       // Return BF16 when input is FP8
       return dispatch_fmha(
-          cutlass::float_e4m3_t{}, cutlass::bfloat16_t{}, head_dim, varlen, mask);
+          cutlass::float_e4m3_t{},
+          cutlass::bfloat16_t{},
+          head_dim,
+          varlen,
+          mask);
     }
     TORCH_CHECK(false, "Unsupported dtype for q: ", q.dtype());
   };
@@ -319,11 +80,9 @@ std::tuple<at::Tensor, at::Tensor> dispatch_fmha_fwd(
   auto dispatch_head_dim = [&](auto varlen, auto mask) {
     if (q.size(q.dim() - 1) == 128) {
       return dispatch_type(varlen, mask, std::integral_constant<int, 128>{});
-    }
-    else if (q.size(q.dim() - 1) == 64) {
+    } else if (q.size(q.dim() - 1) == 64) {
       return dispatch_type(varlen, mask, std::integral_constant<int, 64>{});
-    }
-    else {
+    } else {
       TORCH_CHECK(false, "Unsupported head dim: ", q.size(q.dim() - 1));
     }
   };
@@ -332,25 +91,20 @@ std::tuple<at::Tensor, at::Tensor> dispatch_fmha_fwd(
     if (causal) {
       if (bottom_right) {
         return dispatch_head_dim(varlen, CausalMask</*kIsQBegin=*/false>{});
-      }
-      else {
+      } else {
         return dispatch_head_dim(varlen, CausalMask</*kIsQBegin=*/true>{});
       }
-    }
-    else if (local) {
+    } else if (local) {
       if (bottom_right) {
         return dispatch_head_dim(varlen, LocalMask</*kIsQBegin=*/false>{});
-      }
-      else {
+      } else {
         return dispatch_head_dim(varlen, LocalMask</*kIsQBegin=*/true>{});
       }
-    }
-    else if (varlen || k.size(1) % 128 != 0) {
+    } else if (varlen || k.size(1) % 128 != 0) {
       // Use the residual mask for varlen or when K seqlen is not multiple of
       // blockN
       return dispatch_head_dim(varlen, ResidualMask{});
-    }
-    else {
+    } else {
       return dispatch_head_dim(varlen, NoMask{});
     }
   };
@@ -362,30 +116,29 @@ std::tuple<at::Tensor, at::Tensor> dispatch_fmha_fwd(
   }
 }
 
-
 // -------------------------------------------------------------------------------------------------
 // Op registration
 // -------------------------------------------------------------------------------------------------
 TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
-  m.def("fmha_fwd("
-        "    Tensor query, "
-        "    Tensor key, "
-        "    Tensor value, "
-        "    Tensor? cu_seqlens_q=None, "
-        "    Tensor? cu_seqlens_k=None, "
-        "    int? max_seq_len_q=None, "
-        "    int? max_seq_len_k=None, "
-        "    float? softmax_scale=None, "
-        "    bool causal=False, "
-        "    Tensor? seqlen_kv=None, "
-        "    int window_size_left=-1, "
-        "    int window_size_right=-1, "
-        "    bool bottom_right=True"
-        ") -> (Tensor, Tensor)"
-  );
+  m.def(
+      "fmha_fwd("
+      "    Tensor query, "
+      "    Tensor key, "
+      "    Tensor value, "
+      "    Tensor? cu_seqlens_q=None, "
+      "    Tensor? cu_seqlens_k=None, "
+      "    int? max_seq_len_q=None, "
+      "    int? max_seq_len_k=None, "
+      "    float? softmax_scale=None, "
+      "    bool causal=False, "
+      "    Tensor? seqlen_kv=None, "
+      "    int window_size_left=-1, "
+      "    int window_size_right=-1, "
+      "    bool bottom_right=True"
+      ") -> (Tensor, Tensor)");
 }
 
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   m.impl("fmha_fwd", dispatch_fmha_fwd);
 }
-#endif  // CUTLASS_ARCH_MMA_SM100_SUPPORTED
+#endif // CUTLASS_ARCH_MMA_SM100_SUPPORTED

--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_fwd_bf16_inst.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_fwd_bf16_inst.cu
@@ -1,0 +1,204 @@
+// @nolint
+#include "blackwell_fmha_fwd_template.cuh"
+#if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+
+// Explicit template instantiations for BF16 data type
+// These instantiations cover the main combinations used by the dispatch
+// functions
+
+// BF16 + Head Dim 128 + NoMask instantiations
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::bfloat16_t, // Element
+    cutlass::bfloat16_t, // ElementOut
+    128, // HeadDim
+    false, // kIsVarlen
+    NoMask // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::bfloat16_t, // Element
+    cutlass::bfloat16_t, // ElementOut
+    128, // HeadDim
+    true, // kIsVarlen
+    NoMask // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+// BF16 + Head Dim 64 + NoMask instantiations
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::bfloat16_t, // Element
+    cutlass::bfloat16_t, // ElementOut
+    64, // HeadDim
+    false, // kIsVarlen
+    NoMask // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::bfloat16_t, // Element
+    cutlass::bfloat16_t, // ElementOut
+    64, // HeadDim
+    true, // kIsVarlen
+    NoMask // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+// BF16 + Head Dim 128 + ResidualMask instantiations
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::bfloat16_t, // Element
+    cutlass::bfloat16_t, // ElementOut
+    128, // HeadDim
+    false, // kIsVarlen
+    ResidualMask // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::bfloat16_t, // Element
+    cutlass::bfloat16_t, // ElementOut
+    128, // HeadDim
+    true, // kIsVarlen
+    ResidualMask // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+// BF16 + Head Dim 128 + CausalMask instantiations
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::bfloat16_t, // Element
+    cutlass::bfloat16_t, // ElementOut
+    128, // HeadDim
+    false, // kIsVarlen
+    CausalMask<true> // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::bfloat16_t, // Element
+    cutlass::bfloat16_t, // ElementOut
+    128, // HeadDim
+    false, // kIsVarlen
+    CausalMask<false> // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+// BF16 + Head Dim 128 + LocalMask instantiations
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::bfloat16_t, // Element
+    cutlass::bfloat16_t, // ElementOut
+    128, // HeadDim
+    false, // kIsVarlen
+    LocalMask<true> // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::bfloat16_t, // Element
+    cutlass::bfloat16_t, // ElementOut
+    128, // HeadDim
+    false, // kIsVarlen
+    LocalMask<false> // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+#endif // CUTLASS_ARCH_MMA_SM100_SUPPORTED

--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_fwd_fp16_inst.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_fwd_fp16_inst.cu
@@ -1,0 +1,204 @@
+// @nolint
+#include "blackwell_fmha_fwd_template.cuh"
+#if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+
+// Explicit template instantiations for FP16 data type
+// These instantiations cover the main combinations used by the dispatch
+// functions
+
+// FP16 + Head Dim 128 + NoMask instantiations
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::half_t, // Element
+    cutlass::half_t, // ElementOut
+    128, // HeadDim
+    false, // kIsVarlen
+    NoMask // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::half_t, // Element
+    cutlass::half_t, // ElementOut
+    128, // HeadDim
+    true, // kIsVarlen
+    NoMask // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+// FP16 + Head Dim 64 + NoMask instantiations
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::half_t, // Element
+    cutlass::half_t, // ElementOut
+    64, // HeadDim
+    false, // kIsVarlen
+    NoMask // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::half_t, // Element
+    cutlass::half_t, // ElementOut
+    64, // HeadDim
+    true, // kIsVarlen
+    NoMask // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+// FP16 + Head Dim 128 + ResidualMask instantiations
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::half_t, // Element
+    cutlass::half_t, // ElementOut
+    128, // HeadDim
+    false, // kIsVarlen
+    ResidualMask // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::half_t, // Element
+    cutlass::half_t, // ElementOut
+    128, // HeadDim
+    true, // kIsVarlen
+    ResidualMask // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+// FP16 + Head Dim 128 + CausalMask instantiations
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::half_t, // Element
+    cutlass::half_t, // ElementOut
+    128, // HeadDim
+    false, // kIsVarlen
+    CausalMask<true> // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::half_t, // Element
+    cutlass::half_t, // ElementOut
+    128, // HeadDim
+    false, // kIsVarlen
+    CausalMask<false> // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+// FP16 + Head Dim 128 + LocalMask instantiations
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::half_t, // Element
+    cutlass::half_t, // ElementOut
+    128, // HeadDim
+    false, // kIsVarlen
+    LocalMask<true> // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::half_t, // Element
+    cutlass::half_t, // ElementOut
+    128, // HeadDim
+    false, // kIsVarlen
+    LocalMask<false> // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+#endif // CUTLASS_ARCH_MMA_SM100_SUPPORTED

--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_fwd_fp8_inst.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_fwd_fp8_inst.cu
@@ -1,0 +1,126 @@
+// @nolint
+#include "blackwell_fmha_fwd_template.cuh"
+#if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+
+// Explicit template instantiations for FP8 data type
+// These instantiations cover the main combinations used by the dispatch
+// functions Note: FP8 input with BF16 output (as seen in dispatch logic)
+
+// FP8 + Head Dim 128 + NoMask instantiations
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::float_e4m3_t, // Element (FP8 input)
+    cutlass::bfloat16_t, // ElementOut (BF16 output)
+    128, // HeadDim
+    false, // kIsVarlen
+    NoMask // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::float_e4m3_t, // Element (FP8 input)
+    cutlass::bfloat16_t, // ElementOut (BF16 output)
+    128, // HeadDim
+    true, // kIsVarlen
+    NoMask // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+// FP8 + Head Dim 64 + NoMask instantiations
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::float_e4m3_t, // Element (FP8 input)
+    cutlass::bfloat16_t, // ElementOut (BF16 output)
+    64, // HeadDim
+    false, // kIsVarlen
+    NoMask // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::float_e4m3_t, // Element (FP8 input)
+    cutlass::bfloat16_t, // ElementOut (BF16 output)
+    64, // HeadDim
+    true, // kIsVarlen
+    NoMask // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+// FP8 + Head Dim 128 + ResidualMask instantiations
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::float_e4m3_t, // Element (FP8 input)
+    cutlass::bfloat16_t, // ElementOut (BF16 output)
+    128, // HeadDim
+    false, // kIsVarlen
+    ResidualMask // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+template std::tuple<at::Tensor, at::Tensor> fmha_fwd<
+    cutlass::float_e4m3_t, // Element (FP8 input)
+    cutlass::bfloat16_t, // ElementOut (BF16 output)
+    128, // HeadDim
+    true, // kIsVarlen
+    ResidualMask // ActiveMask
+    >(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right);
+
+#endif // CUTLASS_ARCH_MMA_SM100_SUPPORTED

--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_fwd_template.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_fmha_fwd_template.cuh
@@ -1,0 +1,250 @@
+// @nolint
+#pragma once
+#include "blackwell_fmha_utils.hpp"
+#if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+
+template <
+  typename Element,
+  typename ElementOut,
+  int HeadDim,
+  bool kIsVarlen,
+  typename ActiveMask
+>
+std::tuple<at::Tensor, at::Tensor> fmha_fwd(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const std::optional<const at::Tensor>& cu_seqlens_q,
+    const std::optional<const at::Tensor>& cu_seqlens_k,
+    std::optional<int64_t> max_seq_len_q,
+    std::optional<int64_t> max_seq_len_k,
+    const std::optional<double> softmax_scale,
+    const std::optional<const at::Tensor>& seqlen_kv,
+    const int window_size_left,
+    const int window_size_right
+  ) {
+  const auto device = q.device();
+  at::cuda::CUDAGuard device_guard(device);
+
+  using ElementAccumulatorQK = float;
+  using ElementAccumulatorPV = float;
+
+  // Q K D (H_r H_k) B
+  using ProblemShapeRegular =
+      cute::tuple<int, int, int, cute::tuple<cute::tuple<int, int>, int>>;
+  using ProblemShapeVarlen = cute::tuple<
+      VariableLength,
+      VariableLength,
+      int,
+      cute::tuple<cute::tuple<int, int>, int>>;
+  using ProblemShapeType =
+      std::conditional_t<kIsVarlen, ProblemShapeVarlen, ProblemShapeRegular>;
+
+  using StrideQ =
+      cute::tuple<int, _1, cute::tuple<cute::tuple<int, int>, int>>; // Q D (H_G
+                                                                     // H_R B)
+  using StrideK =
+      cute::tuple<int, _1, cute::tuple<cute::tuple<_0, int>, int>>; // K D (H_G
+                                                                    // H_R B)
+  using StrideV = StrideK;
+  using StrideO = StrideQ;
+  using StrideLSE =
+      cute::tuple<_1, cute::tuple<cute::tuple<int, int>, int>>; // Q   (H_G H_R
+                                                                // B)
+
+  static constexpr bool kIsPersistent = true;
+  using TileScheduler = std::conditional_t<
+      kIsPersistent,
+      cutlass::fmha::kernel::PersistentTileScheduler,
+      cutlass::fmha::kernel::IndividualTileScheduler>;
+
+  using D_H = cute::Int<HeadDim>;
+  using TileShape = Shape<_256, _128, D_H>;
+
+  using Mainloop =
+      cutlass::fmha::collective::Sm100FmhaFwdMainloopTmaWarpspecialized<
+          Element,
+          ElementAccumulatorQK,
+          ElementAccumulatorPV,
+          TileShape,
+          StrideQ,
+          StrideK,
+          StrideV,
+          ActiveMask>;
+
+  using Operation = cutlass::fmha::device::FMHA<
+      cutlass::fmha::kernel::Sm100FmhaFwdKernelTmaWarpspecialized<
+          ProblemShapeType,
+          Mainloop,
+          cutlass::fmha::collective::Sm100FmhaFwdEpilogueTmaWarpspecialized<
+              ElementOut,
+              ElementAccumulatorPV,
+              typename Mainloop::TileShapePV,
+              StrideO,
+              StrideLSE>,
+          TileScheduler>>;
+
+  if (kIsVarlen) {
+    TORCH_CHECK(
+        q.dim() == 3,
+        "Expect Q shape to be (total_Q_seqlen, num_Q_heads, head_dim) ",
+        "Found shape ", q.sizes());
+    TORCH_CHECK(
+        k.dim() == 3,
+        "Expect K shape to be (total_KV_seqlen, num_KV_heads, head_dim) ",
+        "Found shape ", k.sizes());
+    TORCH_CHECK(
+        v.dim() == 3,
+        "Expect V shape to be (total_KV_seqlen, num_KV_heads, head_dim) ",
+        "Found shape ", v.sizes());
+  }
+  else {
+    TORCH_CHECK(
+        q.dim() == 4,
+        "Expect Q shape to be (batch_size, Q_seqlen, num_Q_heads, head_dim). ",
+        "Found shape ", q.sizes());
+    TORCH_CHECK(
+        k.dim() == 4,
+        "Expect K shape to be (batch_size, KV_seqlen, num_KV_heads, head_dim) ",
+        "Found shape ", k.sizes());
+    TORCH_CHECK(
+        v.dim() == 4,
+        "Expect V shape to be (batch_size, KV_seqlen, num_KV_heads, head_dim) ",
+        "Found shape ", v.sizes());
+  }
+
+  if constexpr (kIsVarlen) {
+    TORCH_CHECK(cu_seqlens_q.has_value(), "cu_seqlens_q should be set");
+    TORCH_CHECK(cu_seqlens_k.has_value(), "cu_seqlens_k should be set");
+    TORCH_CHECK(max_seq_len_q.has_value(), "max_seq_len_q should be set");
+    TORCH_CHECK(max_seq_len_k.has_value(), "max_seq_len_k should be set");
+  }
+
+  // Extract dimensions from input tensors
+  int H_Q = kIsVarlen ? q.size(1) : q.size(2); // Number of Q heads
+  int H_K = kIsVarlen ? k.size(1) : k.size(2); // Number of K heads
+  int D = q.size(q.dim() - 1); // Head dimension (D)
+
+  TORCH_CHECK(H_Q % H_K == 0);
+  int H_R = H_Q / H_K; // Q heads per K head
+  TORCH_CHECK(D == HeadDim);
+
+  // SQ represents SumB(Q) for varlen (jagged len)
+  int SQ = kIsVarlen ? q.size(0) : q.size(1);
+  int SK = kIsVarlen ? k.size(0) : k.size(1);
+  int B = kIsVarlen ? cu_seqlens_q->size(0) - 1 : q.size(0);
+
+  ProblemShapeType problem_shape;
+  if constexpr (kIsVarlen) {
+    problem_shape = cute::make_tuple(
+        VariableLength{
+            static_cast<int>(*max_seq_len_q), static_cast<int*>(cu_seqlens_q->data_ptr()), SQ},
+        VariableLength{
+            static_cast<int>(*max_seq_len_k), static_cast<int*>(cu_seqlens_k->data_ptr()), SK},
+        D,
+        cute::make_tuple(cute::make_tuple(H_R, H_K), B));
+  }
+  else {
+    problem_shape = cute::make_tuple(
+        SQ, SK, D, cute::make_tuple(cute::make_tuple(H_R, H_K), B)
+    );
+  }
+
+  // Reshape to get strides
+  auto B_ = kIsVarlen ? 1 : B;
+  auto q_ = q.reshape({B_, SQ, H_K, H_R, D});
+  auto k_ = k.reshape({B_, SK, H_K, 1, D}).expand({B_, SK, H_K, H_R, D});
+  auto ndim = q_.dim();
+
+  TORCH_CHECK(q_.stride(ndim - 1) == 1, "The head dim in Q must be contiguous");
+  TORCH_CHECK(k_.stride(ndim - 1) == 1, "The head dim in K must be contiguous");
+
+  if (H_R != 1) {
+    TORCH_CHECK(k_.stride(3) == 0, "The shared K head stride must be zero");
+  }
+
+  // Convert torch tensors to CUTLASS format
+  // Set up strides for tensors based on dimensions
+  // Q shape = (B, Q, H_K, H_R, D)
+  StrideQ stride_Q = make_stride(
+      static_cast<int>(q_.stride(1)),
+      _1{},
+      make_stride(
+        make_stride(static_cast<int>(q_.stride(3)), static_cast<int>(q_.stride(2))),
+        static_cast<int>(q_.stride(0))));
+
+  // K shape = (B, K, H_K, 1, D)
+  StrideK stride_K = make_stride(
+      static_cast<int>(k_.stride(1)),
+      _1{},
+      make_stride(
+        make_stride(_0{}, static_cast<int>(k_.stride(2))),
+        static_cast<int>(k_.stride(0))));
+  StrideV stride_V = stride_K;
+
+  // O shape = (B, Q, H_K, H_R, D)
+  // O is always contiguous
+  StrideO stride_O = make_stride(
+      H_Q * D, _1{}, make_stride(make_stride(D, H_R * D), H_Q * D * SQ));
+
+  // LSE shape = (B, H_K, H_R, Q)
+  StrideLSE stride_LSE =
+      make_stride(_1{}, make_stride(make_stride(SQ, SQ * H_R), SQ * H_Q));
+
+  // The KernelHardwareInfo struct holds the number of SMs on the GPU with a
+  // given device ID. This information is used by the underlying kernel.
+  cutlass::KernelHardwareInfo hw_info;
+  hw_info.device_id = device.index();
+  hw_info.sm_count =
+      cutlass::KernelHardwareInfo::query_device_multiprocessor_count(
+          hw_info.device_id);
+
+  // Output tensors
+  TensorWrapper<ElementOut> block_O;
+  TensorWrapper<ElementAccumulatorPV> block_LSE;
+  block_O.reset(q.numel(), kIsVarlen ? D * (*max_seq_len_q) * H_Q : 0);
+  int size_LSE = SQ * H_Q * (kIsVarlen ? 1 : B);
+  block_LSE.reset(size_LSE);
+
+  typename Operation::Arguments arguments;
+  if constexpr (kIsVarlen) {
+    get<2, 1>(stride_Q) = 0;
+    get<2, 1>(stride_K) = 0;
+    get<2, 1>(stride_V) = 0;
+    get<2, 1>(stride_O) = 0;
+    get<1, 1>(stride_LSE) = 0;
+  }
+  arguments = {
+      problem_shape,
+      seqlen_kv.has_value()
+          ? static_cast<const int*>(seqlen_kv->data_ptr())
+          : nullptr,
+      {
+          {
+              static_cast<Element*>(q.data_ptr()), stride_Q,
+              static_cast<Element*>(k.data_ptr()), stride_K,
+              static_cast<Element*>(v.data_ptr()), stride_V,
+              window_size_left, window_size_right
+          },
+          static_cast<float>(softmax_scale.value_or(0.0f)) /* softmax_scale */,
+          1.0f /* scale_q */,
+          1.0f /* scale_k */,
+          1.0f /* scale_v */,
+          1.0f /* inv_scale_o */,
+          window_size_left,
+          window_size_right,
+      },
+      {
+          block_O.get(), stride_O,
+          block_LSE.get(), stride_LSE
+      },
+      hw_info
+  };
+
+  launch_fmha_op<Operation>(arguments);
+  return std::make_tuple(
+      block_O.get_data_tensor(q.sizes()),
+      block_LSE.get_data_tensor({kIsVarlen ? 1 : B, H_Q, SQ}));
+}
+
+#endif // CUTLASS_ARCH_MMA_SM100_SUPPORTED


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1973

# FMHA Build Time Optimization

Build time optimization for the Blackwell FMHA kernels that implements the "one C++ template + its instantiations per source file" pattern.

## Problem

Previously, the code had M templates per file × N instantiations per template, which led to slow compilation times due to:
- Large translation units
- Redundant template instantiation across multiple files
- Increased memory usage during compilation

## Solution

The optimization splits the code structure as follows:

### Before (Original Structure)
- `blackwell_fmha_bwd.cu`: Template definition + dispatch + registration
- `blackwell_fmha_fwd.cu`: Template definition + dispatch + registration

### After (Optimized Structure)
- **Template Headers**:
  - `blackwell_fmha_bwd_template.cuh`: Template definition only
  - `blackwell_fmha_fwd_template.cuh`: Template definition only

- **Instantiation Files** (one template + its instantiations per file):
  - `blackwell_fmha_bwd_fp16_inst.cu`: FP16 backward instantiations
  - `blackwell_fmha_bwd_bf16_inst.cu`: BF16 backward instantiations
  - `blackwell_fmha_bwd_fp8_inst.cu`: FP8 backward instantiations
  - `blackwell_fmha_fwd_fp16_inst.cu`: FP16 forward instantiations
  - `blackwell_fmha_fwd_bf16_inst.cu`: BF16 forward instantiations
  - `blackwell_fmha_fwd_fp8_inst.cu`: FP8 forward instantiations

- **Dispatch Files** (logic only):
  - `blackwell_fmha_bwd.cu`: Dispatch + registration logic
  - `blackwell_fmha_fwd.cu`: Dispatch + registration logic

Differential Revision: D83523333


