### PR TITLE
FP4 grouped API for torch

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped.cu
@@ -150,18 +150,14 @@ at::Tensor dispatch_fp4_grouped_kernel(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets = std::nullopt,
     std::optional<at::Tensor> M_sizes = std::nullopt,
     std::optional<at::Tensor> global_scale = std::nullopt,
     std::optional<at::Tensor> starting_row_after_padding = std::nullopt,
     bool use_mx = true) {
-  TORCH_CHECK(M_sizes.has_value(), "M_sizes is assumed to be provided.");
   TORCH_CHECK(
-      starting_row_after_padding.has_value(),
-      "starting_row_after_padding is assumed to be provided.");
-  at::Tensor starting_row_after_padding_actual =
-      starting_row_after_padding.value_or(at::zeros({0}));
-  TORCH_CHECK(starting_row_after_padding_actual.size(0) % (G + 1) == 0);
-
+      offsets.has_value() ^ M_sizes.has_value(),
+      "Exactly one of M_sizes or offsets must be present.");
   // Select kernel to run via heuristics.
   auto kernel = [&]() {
     return get_kernel_via_heuristics(total_M, N, K, G, use_mx);
@@ -173,6 +169,7 @@ at::Tensor dispatch_fp4_grouped_kernel(
       x_scale,
       w_scale,
       output,
+      offsets,
       M_sizes,
       global_scale,
       starting_row_after_padding);
@@ -194,8 +191,22 @@ at::Tensor f4f4bf16_grouped_stacked(
   TORCH_CHECK(
       M_sizes.device() == XQ.device(),
       "M_sizes must be on same device as inputs.");
+  TORCH_CHECK(M_sizes.dtype() == at::kLong, "M_sizes must be int64.");
+  TORCH_CHECK(
+      x_scale.dim() == 2 || x_scale.dim() == 3,
+      "x_scale must be either 2D or 3D tensor")
+  TORCH_CHECK(
+      w_scale.dim() == 2 || w_scale.dim() == 3,
+      "w_scale must be either 2D or 3D tensor")
   TORCH_CHECK(
       WQ.dim() == 3 && WQ.size(0) == G, "Weights should be shape [G, N, K].")
+  TORCH_CHECK(
+      starting_row_after_padding.has_value(),
+      "starting_row_after_padding is assumed to be provided when using f4f4bf16_grouped_stacked.");
+  at::Tensor starting_row_after_padding_actual =
+      starting_row_after_padding.value_or(at::zeros({0}));
+  TORCH_CHECK(starting_row_after_padding_actual.size(0) % (G + 1) == 0);
+
   at::Tensor Y = at::empty({total_M, N}, XQ.options().dtype(at::kBFloat16));
   // Early exit for empty inputs.
   if (total_M == 0) {
@@ -205,20 +216,131 @@ at::Tensor f4f4bf16_grouped_stacked(
   return dispatch_fp4_grouped_kernel(
       total_M,
       N,
-      K * 2, // Since K is packed
+      K * 2, // 2 FP4 values are packed into uint8
       G,
       XQ,
       WQ,
       x_scale,
       w_scale,
       Y,
+      std::nullopt, // offsets
       M_sizes,
       global_scale,
       starting_row_after_padding,
       use_mx);
 }
 
+at::Tensor f4f4bf16_grouped_mm(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    std::optional<at::Tensor> output_maybe,
+    std::optional<at::Tensor> global_scale = std::nullopt) {
+  TORCH_CHECK(offsets.dtype() == at::kInt, "offsets must be int32.");
+  TORCH_CHECK(offsets.dim() == 1, "offsets must be 1D tensor.");
+  TORCH_CHECK(XQ.is_contiguous(), "XQ must be row major.");
+  TORCH_CHECK(WQ.transpose(-2, -1).is_contiguous(), "WQ must be column major.");
+  TORCH_CHECK(XQ.dtype() == at::kFloat4_e2m1fn_x2, "XQ must be FP4.")
+  TORCH_CHECK(WQ.dtype() == at::kFloat4_e2m1fn_x2, "WQ must be FP4.")
+  TORCH_CHECK(
+      x_scale.dtype() == w_scale.dtype(),
+      "x_scale and w_scale must be same type.")
+  TORCH_CHECK(x_scale.is_contiguous(), "x_scale must be contiguous.");
+  TORCH_CHECK(w_scale.is_contiguous(), "w_scale must be contiguous.");
+
+  const bool use_mx = [&]() {
+    if (x_scale.dtype() == at::kFloat8_e4m3fn) {
+      TORCH_CHECK(
+          global_scale.has_value(), "global_scale must be provided for NVFP4.")
+      TORCH_CHECK(
+          global_scale->dtype() == at::kFloat, "global_scale must be FP32.")
+      return false;
+    } else if (x_scale.dtype() == at::kFloat8_e8m0fnu) {
+      TORCH_CHECK(
+          !global_scale.has_value(), "global_scale must be unset for MXFP4.")
+      return true;
+    } else {
+      TORCH_CHECK(
+          false, "Scales must be FP8 e8m0 for MXFP4 or FP8 e4m3 for NVFP4")
+    }
+  }();
+
+  int64_t G = offsets.size(0);
+  int64_t M = XQ.size(-2);
+  int64_t N = WQ.size(-1);
+  int64_t K = WQ.size(-2);
+
+  at::Tensor out;
+
+  if (XQ.dim() == 2 && WQ.dim() == 3) {
+    out = output_maybe.has_value()
+        ? output_maybe.value()
+        : at::empty({M, N}, XQ.options().dtype(at::kBFloat16));
+
+    TORCH_CHECK(
+        XQ.size(-1) == K && WQ.size(0) == G,
+        "for 2d-3d grouped GEMM, XQ shape must be (total_M, K) and WQ shape must be (G, K, N).");
+    TORCH_CHECK(
+        out.dim() == 2 && out.size(0) == M && out.size(1) == N,
+        "for 2d-3d grouped GEMM, output shape must be (total_M, N).");
+
+  } else if (XQ.dim() == 2 && WQ.dim() == 2) {
+    out = output_maybe.has_value()
+        ? output_maybe.value()
+        : at::empty({G, M, N}, XQ.options().dtype(at::kBFloat16));
+
+    TORCH_CHECK(
+        XQ.dim() == 2 && WQ.dim() == 2 && WQ.size(-2) == K,
+        "for 2d-2d grouped GEMM, XQ shape must be (M, total_K) and WQ shape must be (total_K, N).");
+    TORCH_CHECK(
+        out.dim() == 3 && out.size(0) == G && out.size(1) == M &&
+            out.size(2) == N,
+        "for 2d-2d grouped GEMM, output shape must be (G, M, N).");
+
+  } else {
+    TORCH_CHECK(false, "Invalid input shapes. Must be one of 2D-2D, 2D-3D.");
+  }
+
+  // Early exit for empty inputs.
+  if (out.numel() == 0) {
+    return out;
+  }
+
+  return dispatch_fp4_grouped_kernel(
+      M,
+      N,
+      K * 2, // 2 FP4 values are packed into float4_e2m1fn_x2
+      G,
+      XQ,
+      // WQ is shape (K, N) or (G, K, N) in column major layout, to align with
+      // torch._scaled_grouped_mm. We transpose here to match cutlass kernel
+      // requirements.
+      WQ.transpose(-2, -1),
+      x_scale,
+      w_scale,
+      out,
+      offsets,
+      std::nullopt, // M_sizes
+      global_scale,
+      std::nullopt, // starting_row_after_padding
+      use_mx);
+}
+
 #else
+
+at::Tensor f4f4bf16_grouped_mm(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    std::optional<at::Tensor> output,
+    std::optional<at::Tensor> global_scale = std::nullopt) {
+  throw std::runtime_error(
+      "CUDA version is older than 12.8"); // requires CUDA>=12.8
+}
 
 at::Tensor f4f4bf16_grouped_stacked(
     at::Tensor XQ, // FP4

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_128_128_256_1_1_1_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_128_128_256_1_1_1_f.cu
@@ -18,6 +18,7 @@ at::Tensor f4f4bf16_grouped_128_128_256_1_1_1_f(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding) {
@@ -34,6 +35,7 @@ at::Tensor f4f4bf16_grouped_128_128_256_1_1_1_f(
       x_scale,
       w_scale,
       output,
+      offsets,
       M_sizes,
       global_scale,
       starting_row_after_padding);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_128_128_256_1_1_1_t.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_128_128_256_1_1_1_t.cu
@@ -18,6 +18,7 @@ at::Tensor f4f4bf16_grouped_128_128_256_1_1_1_t(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding) {
@@ -34,6 +35,7 @@ at::Tensor f4f4bf16_grouped_128_128_256_1_1_1_t(
       x_scale,
       w_scale,
       output,
+      offsets,
       M_sizes,
       global_scale,
       starting_row_after_padding);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_128_64_256_1_1_1_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_128_64_256_1_1_1_f.cu
@@ -18,6 +18,7 @@ at::Tensor f4f4bf16_grouped_128_64_256_1_1_1_f(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding) {
@@ -34,6 +35,7 @@ at::Tensor f4f4bf16_grouped_128_64_256_1_1_1_f(
       x_scale,
       w_scale,
       output,
+      offsets,
       M_sizes,
       global_scale,
       starting_row_after_padding);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_128_64_256_1_1_1_t.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_128_64_256_1_1_1_t.cu
@@ -18,6 +18,7 @@ at::Tensor f4f4bf16_grouped_128_64_256_1_1_1_t(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding) {
@@ -34,6 +35,7 @@ at::Tensor f4f4bf16_grouped_128_64_256_1_1_1_t(
       x_scale,
       w_scale,
       output,
+      offsets,
       M_sizes,
       global_scale,
       starting_row_after_padding);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_256_128_256_2_1_1_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_256_128_256_2_1_1_f.cu
@@ -18,6 +18,7 @@ at::Tensor f4f4bf16_grouped_256_128_256_2_1_1_f(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding) {
@@ -34,6 +35,7 @@ at::Tensor f4f4bf16_grouped_256_128_256_2_1_1_f(
       x_scale,
       w_scale,
       output,
+      offsets,
       M_sizes,
       global_scale,
       starting_row_after_padding);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_256_128_256_2_1_1_t.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_256_128_256_2_1_1_t.cu
@@ -18,6 +18,7 @@ at::Tensor f4f4bf16_grouped_256_128_256_2_1_1_t(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding) {
@@ -34,6 +35,7 @@ at::Tensor f4f4bf16_grouped_256_128_256_2_1_1_t(
       x_scale,
       w_scale,
       output,
+      offsets,
       M_sizes,
       global_scale,
       starting_row_after_padding);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_256_256_256_2_1_1_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_256_256_256_2_1_1_f.cu
@@ -18,6 +18,7 @@ at::Tensor f4f4bf16_grouped_256_256_256_2_1_1_f(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding) {
@@ -34,6 +35,7 @@ at::Tensor f4f4bf16_grouped_256_256_256_2_1_1_f(
       x_scale,
       w_scale,
       output,
+      offsets,
       M_sizes,
       global_scale,
       starting_row_after_padding);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_256_256_256_2_1_1_t.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_256_256_256_2_1_1_t.cu
@@ -18,6 +18,7 @@ at::Tensor f4f4bf16_grouped_256_256_256_2_1_1_t(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding) {
@@ -34,6 +35,7 @@ at::Tensor f4f4bf16_grouped_256_256_256_2_1_1_t(
       x_scale,
       w_scale,
       output,
+      offsets,
       M_sizes,
       global_scale,
       starting_row_after_padding);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_256_64_256_2_1_1_f.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_256_64_256_2_1_1_f.cu
@@ -18,6 +18,7 @@ at::Tensor f4f4bf16_grouped_256_64_256_2_1_1_f(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding) {
@@ -34,6 +35,7 @@ at::Tensor f4f4bf16_grouped_256_64_256_2_1_1_f(
       x_scale,
       w_scale,
       output,
+      offsets,
       M_sizes,
       global_scale,
       starting_row_after_padding);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_256_64_256_2_1_1_t.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_256_64_256_2_1_1_t.cu
@@ -18,6 +18,7 @@ at::Tensor f4f4bf16_grouped_256_64_256_2_1_1_t(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding) {
@@ -34,6 +35,7 @@ at::Tensor f4f4bf16_grouped_256_64_256_2_1_1_t(
       x_scale,
       w_scale,
       output,
+      offsets,
       M_sizes,
       global_scale,
       starting_row_after_padding);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_manifest.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f4f4bf16_grouped/f4f4bf16_grouped_manifest.cuh
@@ -18,6 +18,7 @@ at::Tensor f4f4bf16_grouped_128_64_256_1_1_1_f(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding);
@@ -28,6 +29,7 @@ at::Tensor f4f4bf16_grouped_128_64_256_1_1_1_t(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding);
@@ -38,6 +40,7 @@ at::Tensor f4f4bf16_grouped_128_128_256_1_1_1_f(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding);
@@ -48,6 +51,7 @@ at::Tensor f4f4bf16_grouped_128_128_256_1_1_1_t(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding);
@@ -58,6 +62,7 @@ at::Tensor f4f4bf16_grouped_256_64_256_2_1_1_f(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding);
@@ -68,6 +73,7 @@ at::Tensor f4f4bf16_grouped_256_64_256_2_1_1_t(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding);
@@ -78,6 +84,7 @@ at::Tensor f4f4bf16_grouped_256_128_256_2_1_1_f(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding);
@@ -88,6 +95,7 @@ at::Tensor f4f4bf16_grouped_256_128_256_2_1_1_t(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding);
@@ -98,6 +106,7 @@ at::Tensor f4f4bf16_grouped_256_256_256_2_1_1_f(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding);
@@ -108,6 +117,7 @@ at::Tensor f4f4bf16_grouped_256_256_256_2_1_1_t(
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor output,
+    std::optional<at::Tensor> offsets,
     std::optional<at::Tensor> M_sizes,
     std::optional<at::Tensor> global_scale,
     std::optional<at::Tensor> starting_row_after_padding);
@@ -118,6 +128,7 @@ using Kernel_f4f4bf16_grouped = at::Tensor (*)(
     at::Tensor,
     at::Tensor,
     at::Tensor,
+    std::optional<at::Tensor>,
     std::optional<at::Tensor>,
     std::optional<at::Tensor>,
     std::optional<at::Tensor>);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/include/fbgemm_gpu/torch_ops.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/include/fbgemm_gpu/torch_ops.h
@@ -38,6 +38,16 @@ at::Tensor mx8mx8bf16_grouped_mm(
     at::Tensor offsets,
     std::optional<at::Tensor> output = std::nullopt);
 
+// Torch compliant FP4 grouped GEMM.
+at::Tensor f4f4bf16_grouped_mm(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor offsets,
+    std::optional<at::Tensor> output = std::nullopt,
+    std::optional<at::Tensor> global_scale = std::nullopt);
+
 #endif
 
 } // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -309,6 +309,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   m.impl("f4f4bf16", f4f4bf16);
   m.impl("f4f4bf16_grouped_stacked", f4f4bf16_grouped_stacked);
   m.impl("mx8mx8bf16_grouped_mm", mx8mx8bf16_grouped_mm);
+  m.impl("f4f4bf16_grouped_mm", f4f4bf16_grouped_mm);
   m.impl("f8f8bf16", f8f8bf16);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas);
   m.impl("bf16_fast_gemv", bf16_fast_gemv);
@@ -364,6 +365,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
   m.impl("f4f4bf16", f4f4bf16);
   m.impl("f4f4bf16_grouped_stacked", f4f4bf16_grouped_stacked);
   m.impl("mx8mx8bf16_grouped_mm", mx8mx8bf16_grouped_mm);
+  m.impl("f4f4bf16_grouped_mm", f4f4bf16_grouped_mm);
   m.impl("f8f8bf16", f8f8bf16);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas);
   m.impl("bf16_fast_gemv", bf16_fast_gemv);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize_defs.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize_defs.cpp
@@ -25,6 +25,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "mx8mx8bf16_grouped_mm(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor offsets, Tensor(a!)? output=None) -> Tensor");
   m.def(
+      "f4f4bf16_grouped_mm(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor offsets, Tensor(a!)? output=None, Tensor(a!)? global_scale=None) -> Tensor");
+  m.def(
       "f8f8bf16(Tensor XQ, Tensor WQ, Tensor scale, bool use_fast_accum=True) -> Tensor");
   m.def(
       "f8f8bf16_groupwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale) -> Tensor");


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1979

We upgrade the FP4 grouped kernel with new API `f4f4bf16_grouped_mm`  that could be used in torch and vLLM. The kernel will support both MX and NV FP4, determined based on the scale dtypes (E4M3 vs E8M0). The API largely matches existing one we added for MXFP8. We also add unit tests for these new APIs.

Next steps:
- Full re-tune of the kernel
- Add other layouts to better support backwards

Differential Revision: D83171662


