### PR TITLE
Check arm_neon_sve_bridge.h header

### DIFF
--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -21,7 +21,7 @@
 #include <type_traits>
 
 #ifndef HAVE_SVE
-#if defined(__aarch64__) && __ARM_FEATURE_SVE
+#if defined(__aarch64__) && __ARM_FEATURE_SVE && __has_include(<arm_neon_sve_bridge.h>)
 #define HAVE_SVE 1
 #include <arm_neon_sve_bridge.h> // @manual
 #include <arm_sve.h>


### PR DESCRIPTION
aarch64 can fail even if CMake `FBGEMM_BUILD_SVE` is false. We have to check the existence of `arm_neon_sve_bridge.h`.