### PR TITLE
Check arm_neon_sve_bridge.h header (#4959)

### DIFF
--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -21,7 +21,8 @@
 #include <type_traits>
 
 #ifndef HAVE_SVE
-#if defined(__aarch64__) && __ARM_FEATURE_SVE
+#if defined(__aarch64__) && __ARM_FEATURE_SVE && \
+    __has_include(<arm_neon_sve_bridge.h>)
 #define HAVE_SVE 1
 #else
 #define HAVE_SVE 0


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1985

aarch64 can fail even if CMake `FBGEMM_BUILD_SVE` is false. We have to check the existence of `arm_neon_sve_bridge.h`.


Reviewed By: cthi

Differential Revision: D83713749

Pulled By: q10


