### PR TITLE
fix OSS CI error with ROCM/clang build

### DIFF
--- a/src/QuantUtils.cc
+++ b/src/QuantUtils.cc
@@ -827,18 +827,19 @@ void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfRef(
     }
     OutputType* output_row = output + row * output_columns;
 
+    float scale = NAN, bias = NAN;
+    if (quant_padding_float_type) {
+      scale = *(reinterpret_cast<const float*>(input_row_scale_bias));
+      bias = *(reinterpret_cast<const float*>(
+          input_row_scale_bias + quant_padding_size));
+    } else {
+      scale = cpu_half2float_ref(
+          *(reinterpret_cast<const float16*>(input_row_scale_bias)));
+      bias = cpu_half2float_ref(*(reinterpret_cast<const float16*>(
+          input_row_scale_bias + quant_padding_size)));
+    }
+
     for (int col = 0; col < output_columns; ++col) {
-      float scale = NAN, bias = NAN;
-      if (quant_padding_float_type) {
-        scale = *(reinterpret_cast<const float*>(input_row_scale_bias));
-        bias = *(reinterpret_cast<const float*>(
-            input_row_scale_bias + quant_padding_size));
-      } else {
-        scale = cpu_half2float(
-            *(reinterpret_cast<const float16*>(input_row_scale_bias)));
-        bias = cpu_half2float(*(reinterpret_cast<const float16*>(
-            input_row_scale_bias + quant_padding_size)));
-      }
       float output_value = input_row[col] * scale + bias;
       if constexpr (std::is_same<OutputType, float>()) {
         output_row[col] = output_value;


### PR DESCRIPTION
Summary:
native __fp16 conversion does not reliably work with ROCM/clang build
and caused CI error. Falling back to ref kernel did address the issue.

Differential Revision: D84119001


