### PR TITLE
Improve aarch64 Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf

### DIFF
--- a/src/QuantUtilsNeon.cc
+++ b/src/QuantUtilsNeon.cc
@@ -59,7 +59,8 @@ void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfNeon(
     svfloat32_t bias_v = svdup_n_f32(bias);
 
     float32x4x2_t* output_row_v = reinterpret_cast<float32x4x2_t*>(output_row);
-    float16x8_t* output_row_v_half = reinterpret_cast<float16x8_t*>(output_row);
+    float16x4x2_t* output_row_v_half =
+        reinterpret_cast<float16x4x2_t*>(output_row);
 
     size_t colIndex = 0;
     for (size_t colMax = output_columns / 8;
@@ -81,37 +82,41 @@ void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfNeon(
         output_row_v[colIndex].val[0] = svget_neonq(in_v_0_f);
         output_row_v[colIndex].val[1] = svget_neonq(in_v_1_f);
       } else {
+        float16x4_t dequantzed_v_half_low = vcvt_f16_f32(svget_neonq(in_v_0_f));
+        float16x4_t dequantzed_v_half_high =
+            vcvt_f16_f32(svget_neonq(in_v_1_f));
+        output_row_v_half[colIndex].val[0] = dequantzed_v_half_low;
+        output_row_v_half[colIndex].val[1] = dequantzed_v_half_high;
+      }
+    }
+
+    if (output_columns_mod != 0) {
+      svuint32_t in_v_0 = svld1ub_u32(
+          lastPredA,
+          reinterpret_cast<const uint8_t*>(input_row_v_0 + colIndex));
+      svuint32_t in_v_1 = svld1ub_u32(
+          lastPredB,
+          reinterpret_cast<const uint8_t*>(input_row_v_1 + colIndex));
+      svfloat32_t in_v_0_f = svcvt_f32_u32_x(lastPredA, in_v_0);
+      svfloat32_t in_v_1_f = svcvt_f32_u32_x(lastPredB, in_v_1);
+
+      in_v_0_f = svmad_f32_m(lastPredA, in_v_0_f, scale_v, bias_v);
+      in_v_1_f = svmad_f32_m(lastPredB, in_v_1_f, scale_v, bias_v);
+
+      if constexpr (std::is_same<OutputType, float>()) {
+        svst1_f32(lastPredA, (float32_t*)&(output_row_v[colIndex]), in_v_0_f);
+        svst1_f32(
+            lastPredB, (float32_t*)&(output_row_v[colIndex].val[1]), in_v_1_f);
+      } else {
         float16x4_t dequantzed_v_half_low_low =
             vcvt_f16_f32(svget_neonq(in_v_0_f));
         float16x8_t dequantzed_v_half_low =
             vcvt_high_f16_f32(dequantzed_v_half_low_low, svget_neonq(in_v_1_f));
-        output_row_v_half[colIndex] = dequantzed_v_half_low;
+        svst1_f16(
+            lastPredC,
+            (float16_t*)&(output_row_v_half[colIndex]),
+            svset_neonq_f16(svundef_f16(), dequantzed_v_half_low));
       }
-    }
-
-    svuint32_t in_v_0 = svld1ub_u32(
-        lastPredA, reinterpret_cast<const uint8_t*>(input_row_v_0 + colIndex));
-    svuint32_t in_v_1 = svld1ub_u32(
-        lastPredB, reinterpret_cast<const uint8_t*>(input_row_v_1 + colIndex));
-    svfloat32_t in_v_0_f = svcvt_f32_u32_x(lastPredA, in_v_0);
-    svfloat32_t in_v_1_f = svcvt_f32_u32_x(lastPredB, in_v_1);
-
-    in_v_0_f = svmad_f32_m(lastPredA, in_v_0_f, scale_v, bias_v);
-    in_v_1_f = svmad_f32_m(lastPredB, in_v_1_f, scale_v, bias_v);
-
-    if constexpr (std::is_same<OutputType, float>()) {
-      svst1_f32(lastPredA, (float32_t*)&(output_row_v[colIndex]), in_v_0_f);
-      svst1_f32(
-          lastPredB, (float32_t*)&(output_row_v[colIndex].val[1]), in_v_1_f);
-    } else {
-      float16x4_t dequantzed_v_half_low_low =
-          vcvt_f16_f32(svget_neonq(in_v_0_f));
-      float16x8_t dequantzed_v_half_low =
-          vcvt_high_f16_f32(dequantzed_v_half_low_low, svget_neonq(in_v_1_f));
-      svst1_f16(
-          lastPredC,
-          (float16_t*)&(output_row_v_half[colIndex]),
-          svset_neonq_f16(svundef_f16(), dequantzed_v_half_low));
     }
 
     input_row_v_0 = reinterpret_cast<const uint64_t*>(


### PR DESCRIPTION
Summary:
Adding a jump to avoid computing the remainder of input when the number of elements is a multiple of 8. We've been told this should be the case in prod, Bolt will move the branch away if it's effectively the case.

Additionally, FP16 computation further improves by allowing the downcasting of all floats to occurr in parallel. Before, the last 4 floats had a dependency on the first 4 being downcasted.

Microbenchmarks do show some improvement:

Before:

With result as float16
  rows,  cols,  elems_per_usec,    GB/Sec
   100,     16,         6107.92,      24.43
   100,     64,         6272.54,      25.09
   100,    128,         6464.12,      25.86
   100,    256,         6531.49,      26.13
   100,    512,         6568.60,      26.27
   100,   1024,         6562.85,      26.25
   100,   2048,         6662.07,      26.65
   120,     16,         6334.31,      25.34
   120,     64,         6346.20,      25.38
   120,    128,         6522.55,      26.09
   120,    256,         6567.54,      26.27
   120,    512,         6617.74,      26.47
   120,   1024,         6663.60,      26.65
   120,   2048,         6593.84,      26.38
  1000,     16,         6579.58,      26.32
  1000,     64,         6625.76,      26.50
  1000,    128,         6659.41,      26.64
  1000,    256,         6662.72,      26.65
  1000,    512,         6238.76,      24.96
  1000,   1024,         6602.40,      26.41
  1000,   2048,         6649.87,      26.60
With result as float
  rows,  cols,  elems_per_usec,    GB/Sec
   100,     16,         9974.61,      39.90
   100,     64,        11234.69,      44.94
   100,    128,        11320.90,      45.28
   100,    256,        11546.73,      46.19
   100,    512,        11617.51,      46.47
   100,   1024,        11668.08,      46.67
   100,   2048,        11654.73,      46.62
   120,     16,        10158.04,      40.63
   120,     64,        11296.97,      45.19
   120,    128,        11408.23,      45.63
   120,    256,        11666.91,      46.67
   120,    512,        11716.05,      46.86
   120,   1024,        11767.62,      47.07
   120,   2048,        11635.72,      46.54
  1000,     16,        10540.73,      42.16
  1000,     64,        11549.38,      46.20
  1000,    128,        11535.90,      46.14
  1000,    256,        11594.73,      46.38
  1000,    512,        11320.15,      45.28
  1000,   1024,         9871.51,      39.49
  1000,   2048,         9318.24,      37.27

After:

  rows,  cols,  elems_per_usec,    GB/Sec
   100,     16,        11066.59,      44.27
   100,     64,         7440.05,      29.76
   100,    128,         7024.48,      28.10
   100,    256,         6753.01,      27.01
   100,    512,         6686.10,      26.74
   100,   1024,         6657.10,      26.63
   100,   2048,         6287.93,      25.15
   120,     16,        11909.77,      47.64
   120,     64,         7295.94,      29.18
   120,    128,         6950.45,      27.80
   120,    256,         6772.01,      27.09
   120,    512,         6693.48,      26.77
   120,   1024,         6670.95,      26.68
   120,   2048,         6636.68,      26.55
  1000,     16,        12807.20,      51.23
  1000,     64,         7528.54,      30.11
  1000,    128,         7055.68,      28.22
  1000,    256,         6818.10,      27.27
  1000,    512,         6029.78,      24.12
  1000,   1024,         6608.16,      26.43
  1000,   2048,         6614.34,      26.46
With result as float
  rows,  cols,  elems_per_usec,    GB/Sec
   100,     16,        15364.85,      61.46
   100,     64,        12675.92,      50.70
   100,    128,        12037.55,      48.15
   100,    256,        11942.46,      47.77
   100,    512,        11818.91,      47.28
   100,   1024,        11780.00,      47.12
   100,   2048,        11706.71,      46.83
   120,     16,        16073.12,      64.29
   120,     64,        12737.05,      50.95
   120,    128,        12090.76,      48.36
   120,    256,        11920.23,      47.68
   120,    512,        11784.24,      47.14
   120,   1024,        11770.42,      47.08
   120,   2048,        11709.52,      46.84
  1000,     16,        17290.90,      69.16
  1000,     64,        13140.33,      52.56
  1000,    128,        12323.46,      49.29
  1000,    256,        11997.75,      47.99
  1000,    512,        10916.54,      43.67
  1000,   1024,        10026.54,      40.11
  1000,   2048,         9239.22,      36.96

Reviewed By: YifanYuan3

Differential Revision: D84206955


