### PR TITLE
BF16 re-enabled w/ Cutlass update

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_gen_impl.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_gen_impl.cu
@@ -262,12 +262,14 @@ struct GenRunner {
 };
 
 // Dispatch macros for different element types
-// TODO(henrylhtsang / ayaoibrahim1123): Add support for other data types.
 #define DISPATCH_ELEMENT_TYPE(DTYPE, ELEMENT_TYPE, ...)                       \
   [&] {                                                                       \
     if (DTYPE == at::kFloat8_e4m3fn) {                                 \
       using ELEMENT_TYPE = cutlass::float_e4m3_t;                             \
       return __VA_ARGS__();                                                   \
+    } else if (DTYPE == at::kBFloat16) {                                    \
+      using ELEMENT_TYPE = cutlass::bfloat16_t;                             \
+      return __VA_ARGS__();                                                 \
     } else {                                                                  \
       throw std::runtime_error("Unsupported dtype: " + std::to_string(static_cast<int>(DTYPE))); \
     }                                                                         \

--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/device/fmha.hpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/device/fmha.hpp
@@ -39,7 +39,7 @@
 // common
 #include "cutlass/cutlass.h"
 #include "cutlass/device_kernel.h"
-
+#include "cutlass/arch/arch.h"
 #if !defined(__CUDACC_RTC__)
 #include "cutlass/cluster_launch.hpp"
 #include "cutlass/trace.h"
@@ -57,7 +57,7 @@ template <class Kernel_>
 class FMHA {
 public:
   using Kernel = Kernel_;
-
+  static_assert(Kernel::SharedStorageSize <= cutlass::arch::sm100_smem_capacity_bytes, "SMEM usage exceeded capacity.");
   static int const kThreadCount = Kernel::MaxThreadsPerBlock;
 
   /// Argument structure: User API

--- a/fbgemm_gpu/experimental/gen_ai/test/attention/blackwell_fmha_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/attention/blackwell_fmha_test.py
@@ -435,6 +435,7 @@ class CutlassBlackwellFMHATest(unittest.TestCase):
     @parameterized.expand(
         [
             (
+                dtype,
                 seqlen_k,
                 batch_size,
                 is_mqa,
@@ -442,9 +443,10 @@ class CutlassBlackwellFMHATest(unittest.TestCase):
                 head_dim,
                 sm_scale,
             )
+            for dtype in [torch.bfloat16, torch.float8_e4m3fn]
             for seqlen_k in [64, 128, 256, 1024]
             for batch_size in [1, 2]
-            for is_mqa in [True]
+            for is_mqa in [True, False]
             for window_size in [(-1, -1), (0, 0), (0, 128), (128, 0), (1024, 0)]
             for head_dim in [128]
             for sm_scale in [None, 1.0 / head_dim]
@@ -452,6 +454,7 @@ class CutlassBlackwellFMHATest(unittest.TestCase):
     )
     def test_decode(
         self,
+        dtype: torch.dtype,
         seqlen_k: int,
         batch_size: int,
         is_mqa: bool,
@@ -459,13 +462,9 @@ class CutlassBlackwellFMHATest(unittest.TestCase):
         head_dim: int,
         sm_scale: Optional[float],
         q_heads: int = 8,
-        dtype: torch.dtype = torch.float8_e4m3fn,
     ) -> None:
         seqlen_q = 1
         causal = True
-        assert (
-            dtype == torch.float8_e4m3fn
-        ), "Gen Kernel only supports float8_e4m3fn for now"
         self._execute_cutlass_blackwell_attn_dense(
             batch_size,
             seqlen_q,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2026

This diff updates the code to enable BF16 enablement with latest Cutlass version.

The changes include updating the code in the `blackwell_gen_impl.cu` and `collective/sm100_fmha_gen_mainloop_warpspecialized.hpp` files to support BF16 data type.

The `fmha.hpp` file also includes a check to ensure that the SMEM usage does not exceed the capacity.

Reviewed By: jianyuh

Differential Revision: D84624233
