### PR TITLE
Try to fix fbgemm for pytorch

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise_grouped/fp8_rowwise_grouped_gemm.hip
@@ -23,7 +23,7 @@
 #include "kernels/fp8_rowwise_grouped_kernel_manifest.h"
 #include "kernels/fp8_rowwise_grouped_heuristic.hpp"
 
-#ifdef FBGEMM_FBCODE
+#if defined(FBGEMM_FBCODE) || !defined(HIPIFY_V2)
 #include "fbgemm_gpu/quantize/tuning_cache.cuh"
 #else
 #include "fbgemm_gpu/quantize/tuning_cache_hip.cuh"


### PR DESCRIPTION
Summary: We need to support the hipifyV2 in OSS fbgemm, but PyTorch is not using hipifyV2 yet and PyTorch + FBGEMM would pull in FBGEMM sources directly, so add a quick fix for backwards compatibility there. Will check FBGEMM ROCm CI to ensure ROCm build continue working.

Differential Revision: D84827329


