### PR TITLE
fix cutlass tmem sync issue

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/kernel/sm100_fmha_fwd_kernel_tma_warpspecialized.hpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/kernel/sm100_fmha_fwd_kernel_tma_warpspecialized.hpp
@@ -557,6 +557,9 @@ struct Sm100FmhaFwdKernelTmaWarpspecialized {
         );
 
       }
+
+      cutlass::arch::NamedBarrier::arrive((1 + NumWarpsEpilogue) * NumThreadsPerWarp,
+                                    cutlass::arch::ReservedNamedBarriers::TmemAllocBarrier);
     }
     else if (role == WarpRole::Load) {
       warpgroup_reg_set<NumRegsOther>();
@@ -613,6 +616,9 @@ struct Sm100FmhaFwdKernelTmaWarpspecialized {
         );
 
       }
+
+      cutlass::arch::NamedBarrier::arrive_and_wait((1 + NumWarpsEpilogue) * NumThreadsPerWarp,
+                                    cutlass::arch::ReservedNamedBarriers::TmemAllocBarrier);
 
       static_assert(NumWarpsEpilogue <= 1);
       if constexpr (NumWarpsEpilogue == 1) {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2036

fixes tmem allocation race against the tmem ptr in smem when the persistent scheduler does not assign any work to the thread block

Reviewed By: sryap, henrylhtsang

Differential Revision: D84954166


