### PR TITLE
add feature flag to gate detailed memory breakdown (#5023)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -1877,6 +1877,15 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             tbe_id=self.uuid,
         )
 
+        # Check if detailed memory breakdown is enabled via environment variable
+        # Set FBGEMM_TBE_MEM_BREAKDOWN=1 to enable expensive detailed breakdown
+        enable_detailed_breakdown = (
+            int(os.environ.get("FBGEMM_TBE_MEM_BREAKDOWN", "0")) == 1
+        )
+
+        if not enable_detailed_breakdown:
+            return
+
         # Tensor groups for sparse memory categorization
         weight_tensors = ["weights_dev", "weights_host", "weights_uvm"]
         optimizer_tensors = [


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2034

detailed analysis revealed QPS drop when enabling additional logging. head to head comparison of time it takes to do the logging reveals 4x increase in duration (see (https://fburl.com/scuba/tbe_stats_runtime/y85ur4k9)

- avg QPS across 4 runs w/o logging: 246k vs. avg QPS across 4 runs w/ added logging: 243k (~1.2% QPS drop)

ran the following models w/o added logging:
- aps-icvrbase-tbe-dump-test-old-1-d234a33214
- aps-icvrbase-tbe-dump-test-old-2-f5d7f5d97a
- aps-icvrbase-tbe-dump-test-old-3-92aa2d14c3
- aps-icvrbase-tbe-dump-test-old-timed-9ac1869846

ran the following models w/ added logging:
- aps-icvrbase-tbe-dump-test-new-1-fcb93df6a6
- aps-icvrbase-tbe-dump-test-new-2-3f15ec3a29
- aps-icvrbase-tbe-dump-test-new-3-211d3c3f01
- aps-icvrbase-tbe-dump-test-new-timed-6e6a932849

Pulled By:
ashuaibi7

X-link: https://github.com/facebookresearch/FBGEMM/pull/2033

ashuaibi7

Differential Revision: D84727563
