### PR TITLE
disable random init in inference operator for embedding cache

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/cache/kv_embedding_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/cache/kv_embedding_ops_inference.py
@@ -76,6 +76,7 @@ class KVEmbeddingInference(IntNBitTableBatchedEmbeddingBagsCodegen):
         reverse_qparam: bool = False,  # True to load qparams at end of each row; False to load qparam at begnning of each row.
         feature_names_per_table: Optional[list[list[str]]] = None,
         indices_dtype: torch.dtype = torch.int32,  # Used for construction of the remap_indices tensors.  Should match the dtype of the indices passed in the forward() call (INT32 or INT64).
+        embedding_cache_mode: bool = False,  # True for zero initialization, False for randomized initialization
     ) -> None:  # noqa C901  # tuple of (rows, dims,)
         super(KVEmbeddingInference, self).__init__(
             embedding_specs=embedding_specs,
@@ -114,9 +115,13 @@ class KVEmbeddingInference(IntNBitTableBatchedEmbeddingBagsCodegen):
         num_shards = 32
         uniform_init_lower: float = -0.01
         uniform_init_upper: float = 0.01
+
         # pyre-fixme[4]: Attribute must be annotated.
         self.kv_embedding_cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(
-            num_shards, uniform_init_lower, uniform_init_upper
+            num_shards,
+            uniform_init_lower,
+            uniform_init_upper,
+            embedding_cache_mode,  # in embedding_cache_mode, we disable random init
         )
 
         self.specs: list[tuple[int, int, int]] = [

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.h
@@ -18,7 +18,8 @@ class DramKVEmbeddingInferenceWrapper : public torch::jit::CustomClassHolder {
   DramKVEmbeddingInferenceWrapper(
       int64_t num_shards = 32,
       double uniform_init_lower = 0.0,
-      double uniform_init_upper = 0.0);
+      double uniform_init_upper = 0.0,
+      bool disable_random_init = false);
 
   using SerializedSepcType =
       std::tuple<int64_t, int64_t, int64_t>; // (rows, dime, sparse_type)
@@ -55,6 +56,7 @@ class DramKVEmbeddingInferenceWrapper : public torch::jit::CustomClassHolder {
   int64_t num_shards_ = 32;
   double uniform_init_lower_ = 0.0;
   double uniform_init_upper_ = 0.0;
+  bool disable_random_init_ = false;
 
   std::shared_ptr<kv_mem::DramKVInferenceEmbedding<uint8_t>> dram_kv_;
   int64_t max_row_bytes_ = 0;


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/torchrec/pull/3466

X-link: https://github.com/facebookresearch/FBGEMM/pull/2040

For embedding cache mode, we  do not expect random value if there is cache missing.
This diff passed the embedding cache mode to inference operator, and use that to disable the backend random initialization.

Differential Revision: D84367061


