### PR TITLE
Fix build CI bug for release

### DIFF
--- a/.github/workflows/_fbgemm_gpu_cuda_build.yml
+++ b/.github/workflows/_fbgemm_gpu_cuda_build.yml
@@ -124,7 +124,7 @@ jobs:
       run: . $PRELUDE; cd fbgemm_gpu; prepare_fbgemm_gpu_build $BUILD_ENV
 
     - name: Build FBGEMM_GPU Wheel
-      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_package $BUILD_ENV nightly ${{ matrix.build-target }}/cuda
+      run: . $PRELUDE; cd fbgemm_gpu; build_fbgemm_gpu_package $BUILD_ENV ${{ inputs.pytorch-channel-version }} ${{ matrix.build-target }}/cuda
 
     - name: Upload Built Wheel as GHA Artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2047

The script is hardcoded to always build nightly package, even for release builds. This diff fixes it such that it follows pytorch version.

Differential Revision: D85110273


