### PR TITLE
PyTorch version compatibility check in `_load_library`

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/__init__.py
@@ -15,6 +15,7 @@ import torch
 # Based on the FBGEMM-PyTorch compatibility table at
 # https://docs.pytorch.org/FBGEMM/general/Releases.html#fbgemm-releases-compatibility
 _fbgemm_torch_compat_table = {
+    "1.4": "2.9",
     "1.3": "2.8",
     "1.2": "2.7",
     "1.1": "2.6",
@@ -80,7 +81,7 @@ def _load_library(filename: str, version: str, no_throw: bool = False) -> None:
             """
         )
 
-    elif str(torch.__version__) != _fbgemm_torch_compat_table[keys[0]]:
+    elif not str(torch.__version__).startswith(_fbgemm_torch_compat_table[keys[0]]):
         logging.warning(
             f"""
             \033[31m


### PR DESCRIPTION
Summary:
The version compatibility check in `_load_library` incorrectly uses exact string equality when comparing PyTorch versions, causing false incompatibility warnings.

PyTorch versions typically include build metadata like `"2.8.0+cu118"` or `"2.8.1+cpu"`, while the compatibility table contains base versions like `"2.8"`.

Differential Revision: D85167315


