### PR TITLE
Remove AVX compilation on aarch64 builds

### DIFF
--- a/src/TransposeUtils.cc
+++ b/src/TransposeUtils.cc
@@ -57,7 +57,7 @@ void transpose_simd(
 #else
   static const auto iset = fbgemmInstructionSet();
   // Run time CPU detection
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if defined(FBGEMM_FBCODE)
   if (isZmm(iset)) {
     internal::transpose_avx512<T>(M, N, src, ld_src, dst, ld_dst);
   } else if (isYmm(iset)) {

--- a/src/UtilsAvx2.cc
+++ b/src/UtilsAvx2.cc
@@ -15,6 +15,8 @@
 
 namespace fbgemm::internal {
 
+#ifdef __AVX2__
+
 template <>
 void transpose_avx2(
     int64_t M,
@@ -335,5 +337,7 @@ void transpose_avx2(
         src + i * ld_src + j, ld_src, dst + j * ld_dst + i, ld_dst, mrem, nrem);
   }
 }
+
+#endif // __AVX2__
 
 } // namespace fbgemm::internal

--- a/src/UtilsAvx512.cc
+++ b/src/UtilsAvx512.cc
@@ -16,6 +16,8 @@ namespace fbgemm {
 
 namespace {
 
+#ifdef __AVX512F__
+
 // 16 * 6 = 96 instructions
 inline void transpose_kernel_16x16_avx512(
     const float* src,
@@ -2440,6 +2442,8 @@ void transpose_avx512(
     }
   }
 }
+
+#endif // __AVX512F__
 
 } // namespace internal
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2056

We are no longer using SIMDE to build AVX code targeting aarch64

Build times should decrease

Reviewed By: mcfi

Differential Revision: D85361586


