### PR TITLE
Support no eviction in Feature score eviction policy

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -120,6 +120,9 @@ class EvictionPolicy(NamedTuple):
     eviction_free_mem_check_interval_batch: Optional[int] = (
         None  # Number of batches between checks for free memory threshold when using free_mem trigger mode.
     )
+    enable_eviction_for_feature_score_eviction_policy: Optional[list[bool]] = (
+        None  # enable eviction if eviction policy is feature score, false means no eviction
+    )
 
     def validate(self) -> None:
         assert self.eviction_trigger_mode in [0, 1, 2, 3, 4, 5], (
@@ -217,13 +220,17 @@ class EvictionPolicy(NamedTuple):
                 "threshold_calculation_bucket_num must be set if eviction_strategy is 5,"
                 f"actual {self.threshold_calculation_bucket_num}"
             )
+            assert self.enable_eviction_for_feature_score_eviction_policy is not None, (
+                "enable_eviction_for_feature_score_eviction_policy must be set if eviction_strategy is 5,"
+                f"actual {self.enable_eviction_for_feature_score_eviction_policy}"
+            )
             assert (
-                len(self.training_id_keep_count)
+                len(self.enable_eviction_for_feature_score_eviction_policy)
+                == len(self.training_id_keep_count)
                 == len(self.feature_score_counter_decay_rates)
-                == len(self.training_id_eviction_trigger_count)
             ), (
-                "feature_score_thresholds, training_id_eviction_trigger_count and training_id_keep_count must have the same length, "
-                f"actual {self.training_id_keep_count} vs {self.feature_score_counter_decay_rates} vs {self.training_id_eviction_trigger_count}"
+                "feature_score_thresholds, enable_eviction_for_feature_score_eviction_policy, and training_id_keep_count must have the same length, "
+                f"actual {self.training_id_keep_count} vs {self.feature_score_counter_decay_rates} vs {self.enable_eviction_for_feature_score_eviction_policy}"
             )
 
 

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -707,6 +707,15 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                     # If trigger mode is free_mem(5), populate config
                     self.set_free_mem_eviction_trigger_config(eviction_policy)
 
+                enable_eviction_for_feature_score_eviction_policy = (  # pytorch api in c++ doesn't support vertor<bool>, convert to int here, 0: no eviction 1: eviction
+                    [
+                        int(x)
+                        for x in eviction_policy.enable_eviction_for_feature_score_eviction_policy
+                    ]
+                    if eviction_policy.enable_eviction_for_feature_score_eviction_policy
+                    is not None
+                    else None
+                )
                 # Please refer to https://fburl.com/gdoc/nuupjwqq for the following eviction parameters.
                 eviction_config = torch.classes.fbgemm.FeatureEvictConfig(
                     eviction_policy.eviction_trigger_mode,  # eviction is disabled, 0: disabled, 1: iteration, 2: mem_util, 3: manual, 4: id count
@@ -719,6 +728,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                     eviction_policy.feature_score_counter_decay_rates,  # feature_score_counter_decay_rates for each table if eviction strategy is feature score
                     eviction_policy.training_id_eviction_trigger_count,  # training_id_eviction_trigger_count for each table
                     eviction_policy.training_id_keep_count,  # training_id_keep_count for each table
+                    enable_eviction_for_feature_score_eviction_policy,  # no eviction setting for feature score eviction policy
                     eviction_policy.l2_weight_thresholds,  # l2_weight_thresholds for each table if eviction strategy is feature l2 norm
                     table_dims.tolist() if table_dims is not None else None,
                     eviction_policy.threshold_calculation_bucket_stride,  # threshold_calculation_bucket_stride if eviction strategy is feature score

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.cpp
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.cpp
@@ -76,6 +76,7 @@ void DramKVEmbeddingInferenceWrapper::init(
           std::nullopt /* feature_score_counter_decay_rates */,
           std::nullopt /* training_id_eviction_trigger_count */,
           std::nullopt /* training_id_keep_count */,
+          std::nullopt /* enable_eviction_for_feature_score_eviction_policy */,
           std::nullopt /* l2_weight_thresholds */,
           std::nullopt /* embedding_dims */,
           std::nullopt /* threshold_calculation_bucket_stride */,

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -737,6 +737,7 @@ static auto feature_evict_config =
                 std::optional<std::vector<double>>,
                 std::optional<std::vector<int64_t>>,
                 std::optional<std::vector<int64_t>>,
+                std::optional<std::vector<int8_t>>,
                 std::optional<std::vector<double>>,
                 std::optional<std::vector<int64_t>>,
                 std::optional<double>,
@@ -756,6 +757,9 @@ static auto feature_evict_config =
                 torch::arg("feature_score_counter_decay_rates") = std::nullopt,
                 torch::arg("training_id_eviction_trigger_count") = std::nullopt,
                 torch::arg("training_id_keep_count") = std::nullopt,
+                torch::arg(
+                    "enable_eviction_for_feature_score_eviction_policy") =
+                    std::nullopt,
                 torch::arg("l2_weight_thresholds") = std::nullopt,
                 torch::arg("embedding_dims") = std::nullopt,
                 torch::arg("threshold_calculation_bucket_stride") = 0.2,

--- a/fbgemm_gpu/test/dram_kv_embedding_cache/kv_embedding_inference_test.cpp
+++ b/fbgemm_gpu/test/dram_kv_embedding_cache/kv_embedding_inference_test.cpp
@@ -39,6 +39,7 @@ class KVEmbeddingInferenceTest : public ::testing::Test {
         std::nullopt,
         std::nullopt,
         std::nullopt,
+        std::nullopt,
         std::vector<int64_t>{EMBEDDING_DIM},
         std::nullopt,
         std::nullopt,

--- a/fbgemm_gpu/test/tbe/ssd/kv_backend_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/kv_backend_test.py
@@ -102,6 +102,15 @@ class SSDCheckpointTest(unittest.TestCase):
         elif backend_type == BackendType.DRAM:
             eviction_config = None
             if eviction_policy:
+                enable_eviction_for_feature_score_eviction_policy = (  # pytorch api in c++ doesn't support vertor<bool> convert to int here, 0: no_eviction 1: eviction
+                    [
+                        int(x)
+                        for x in eviction_policy.enable_eviction_for_feature_score_eviction_policy
+                    ]
+                    if eviction_policy.enable_eviction_for_feature_score_eviction_policy
+                    is not None
+                    else None
+                )
                 eviction_config = torch.classes.fbgemm.FeatureEvictConfig(
                     eviction_policy.eviction_trigger_mode,  # eviction is disabled, 0: disabled, 1: iteration, 2: mem_util, 3: manual, 4: id count
                     eviction_policy.eviction_strategy,  # evict_trigger_strategy: 0: timestamp, 1: counter, 2: counter + timestamp, 3: feature l2 norm, 4: timestamp threshold 5: feature score
@@ -113,6 +122,7 @@ class SSDCheckpointTest(unittest.TestCase):
                     eviction_policy.feature_score_counter_decay_rates,  # feature_score_counter_decay_rates for each table if eviction strategy is feature score
                     eviction_policy.training_id_eviction_trigger_count,  # training_id_eviction_trigger_count for each table
                     eviction_policy.training_id_keep_count,  # training_id_keep_count for each table
+                    enable_eviction_for_feature_score_eviction_policy,  # no eviction setting for feature score eviction policy
                     eviction_policy.l2_weight_thresholds,  # l2_weight_thresholds for each table if eviction strategy is feature l2 norm
                     feature_dims.tolist() if feature_dims is not None else None,
                     eviction_policy.threshold_calculation_bucket_stride,  # threshold_calculation_bucket_stride if eviction strategy is feature score


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/torchrec/pull/3488

X-link: https://github.com/facebookresearch/FBGEMM/pull/2068

As title
If one table is using feature score eviction in one tbe, then all tables in this tbe need to use the same policy. Feature score eviction can support ttl based eviction now. This diff is adding support no eviction in feature score eviction policy.

Differential Revision: D84660528


