### PR TITLE
Remove AVX compilation on aarch64

### DIFF
--- a/include/fbgemm/Fbgemm.h
+++ b/include/fbgemm/Fbgemm.h
@@ -616,7 +616,7 @@ class FBGEMM_API PackWeightsForConv {
     return W_im2col_packed_;
   }
 
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if !defined(__aarch64__)
   std::shared_ptr<PackedDepthWiseConvMatrix> getPackedWForDepthwise() {
     return W_dw_packed_;
   }
@@ -672,7 +672,7 @@ class FBGEMM_API PackWeightsForConv {
   const conv_param_t<SPATIAL_DIM> conv_param_;
   // Packed weights if we use im2col based convolution implementation
   std::shared_ptr<PackBMatrix<T, accT>> W_im2col_packed_;
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if !defined(__aarch64__)
   // Packed weights if we use depthwise convolution implementation
   std::shared_ptr<PackedDepthWiseConvMatrix> W_dw_packed_;
 #endif // __aarch64__

--- a/include/fbgemm/FbgemmConvert.h
+++ b/include/fbgemm/FbgemmConvert.h
@@ -47,6 +47,7 @@ FloatToBfloat16_simd(const float* src, bfloat16* dst, size_t size);
 FBGEMM_API void
 Bfloat16ToFloat_simd(const bfloat16* src, float* dst, size_t size);
 
+#if !defined(__aarch64__)
 /**
  * @brief AVX2 implementation to convert fp32 numbers to bf16 numbers.
  *
@@ -58,10 +59,8 @@ FloatToBfloat16_avx2(const float* src, bfloat16* dst, size_t size);
  * @brief AVX512 implementation to convert fp32 numbers to bf16 numbers.
  *
  */
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
 FBGEMM_API void
 FloatToBfloat16_avx512(const float* src, bfloat16* dst, size_t size);
-#endif
 
 /**
  * @brief AVX2 implementation to convert bf16 numbers to fp32 numbers.
@@ -74,7 +73,6 @@ Bfloat16ToFloat_avx2(const bfloat16* src, float* dst, size_t size);
  * @brief AVX512 implementation to convert bf16 numbers to fp32 numbers.
  *
  */
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
 FBGEMM_API void
 Bfloat16ToFloat_avx512(const bfloat16* src, float* dst, size_t size);
 #endif
@@ -124,6 +122,7 @@ Float16ToFloat_simd(const float16* src, float* dst, size_t size);
  * @brief AVX2 implementation to convert fp32 numbers to fp16 numbers.
  *
  */
+#if !defined(__aarch64__)
 FBGEMM_API void FloatToFloat16_avx2(
     const float* src,
     float16* dst,
@@ -134,7 +133,6 @@ FBGEMM_API void FloatToFloat16_avx2(
  * @brief AVX512 implementation to convert fp32 numbers to fp16 numbers.
  *
  */
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
 FBGEMM_API void FloatToFloat16_avx512(
     const float* src,
     float16* dst,
@@ -152,6 +150,7 @@ FBGEMM_API void FloatToFloat16_sve2(
     size_t size,
     bool do_clip = false);
 
+#if !defined(__aarch64__)
 /**
  * @brief AVX2 implementation to convert fp16 numbers to fp32 numbers.
  *
@@ -163,7 +162,6 @@ Float16ToFloat_avx2(const float16* src, float* dst, size_t size);
  * @brief AVX512 implementation to convert fp16 numbers to fp32 numbers.
  *
  */
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
 FBGEMM_API void
 Float16ToFloat_avx512(const float16* src, float* dst, size_t size);
 #endif

--- a/include/fbgemm/FbgemmEmbedding.h
+++ b/include/fbgemm/FbgemmEmbedding.h
@@ -349,7 +349,7 @@ FBGEMM_API bool EmbeddingSpMDMBlockSize1_(
     bool use_offsets = true,
     bool is_bf16 = false);
 
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if !defined(__aarch64__)
 template <typename IndexType, bool HAS_WEIGHTS>
 void compressed_indices_remap_avx512(
     std::int32_t offsets_numel,

--- a/include/fbgemm/FbgemmI8DepthwiseAvx2.h
+++ b/include/fbgemm/FbgemmI8DepthwiseAvx2.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#if !defined(__aarch64__)
+
 #include <cstdint>
 #include "fbgemm/ConvUtils.h"
 #include "fbgemm/FbgemmBuild.h"
@@ -110,3 +112,5 @@ FBGEMM_API void depthwise_3d_same_pad(
     int num_threads = 1);
 
 } // namespace fbgemm
+
+#endif // !defined(__aarch64__)

--- a/include/fbgemm/FbgemmSparse.h
+++ b/include/fbgemm/FbgemmSparse.h
@@ -166,7 +166,7 @@ void SparseDenseMMAvx2(
     int ldc,
     bool accum = false);
 
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if !defined(__aarch64__)
 void SparseDenseMMAvx512(
     int M,
     int N,

--- a/include/fbgemm/OutputProcessing-inl.h
+++ b/include/fbgemm/OutputProcessing-inl.h
@@ -125,7 +125,7 @@ ReQuantizeOutput<FUSE_RELU, Q_GRAN, BIAS_TYPE, outT, inT, nextOPType>::f(
       }
     }
 
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if !defined(__aarch64__)
 
   } else if constexpr (
       instSet == inst_set_t::avx2 || instSet == inst_set_t::avx512) {
@@ -249,7 +249,7 @@ inline int ReQuantizeForFloat<FUSE_RELU, Q_GRAN, outT, inT, nextOPType>::f(
       }
     }
 
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if !defined(__aarch64__)
   } else if constexpr (
       instSet == inst_set_t::avx2 || instSet == inst_set_t::avx512) {
     bool b_symmetric =

--- a/include/fbgemm/QuantUtilsAvx2.h
+++ b/include/fbgemm/QuantUtilsAvx2.h
@@ -52,6 +52,13 @@ struct FBGEMM_API RequantizationParams {
   TensorQuantizationParams target_qparams;
 };
 
+/// @ingroup fbgemm-quant-utils-avx2
+///
+/// @brief Find the min and max value in a float matrix.
+void FBGEMM_API FindMinMax(const float* m, float* min, float* max, int64_t len);
+
+#if !defined(__aarch64__)
+
 ////////////////////////////////////////////////////////////////////////////////
 // Utility functions
 ////////////////////////////////////////////////////////////////////////////////
@@ -76,11 +83,6 @@ void FusedQuantizeDequantizeAvx2(
 /// Random number generator in [0, 9] based on
 /// <a href="https://www.jstatsoft.org/v08/i14/paper">this paper</a>.
 uint32_t FBGEMM_API Xor128();
-
-/// @ingroup fbgemm-quant-utils-avx2
-///
-/// @brief Find the min and max value in a float matrix.
-void FBGEMM_API FindMinMax(const float* m, float* min, float* max, int64_t len);
 
 void RequantizeFixedPointAvx2(
     const std::int32_t* src,
@@ -175,5 +177,7 @@ void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfAvx2(
     size_t input_rows,
     int input_columns,
     OutputType* output);
+
+#endif // !defined(__aarch64__)
 
 } // namespace fbgemm

--- a/include/fbgemm/QuantUtilsAvx512.h
+++ b/include/fbgemm/QuantUtilsAvx512.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "Types.h"
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if !defined(__aarch64__)
 
 #include <cstdint>
 #include "./FbgemmBuild.h" // @manual

--- a/src/FbgemmBfloat16Convert.cc
+++ b/src/FbgemmBfloat16Convert.cc
@@ -29,7 +29,7 @@ namespace fbgemm {
 void FloatToBfloat16_simd(const float* src, bfloat16* dst, size_t size) {
   // Run time CPU detection
   if (cpuinfo_initialize()) {
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if !defined(__aarch64__)
     if (fbgemmHasAvx512Support()) {
       FloatToBfloat16_avx512(src, dst, size);
     } else if (fbgemmHasAvx2Support()) {
@@ -48,7 +48,7 @@ void FloatToBfloat16_simd(const float* src, bfloat16* dst, size_t size) {
 void Bfloat16ToFloat_simd(const bfloat16* src, float* dst, size_t size) {
   // Run time CPU detection
   if (cpuinfo_initialize()) {
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if !defined(__aarch64__)
     if (fbgemmHasAvx512Support()) {
       Bfloat16ToFloat_avx512(src, dst, size);
     } else if (fbgemmHasAvx2Support()) {

--- a/src/FbgemmFP16.cc
+++ b/src/FbgemmFP16.cc
@@ -35,7 +35,7 @@ namespace {
 // the restrictions of ymm register numbers (16).
 constexpr kernel_array_t<float16> kernel_fp16_avx2 = {
     nullptr,
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if !defined(__aarch64__)
     gemmkernel_1x2_Avx2_fp16_fA0fB0fC0,
     gemmkernel_2x2_Avx2_fp16_fA0fB0fC0,
     gemmkernel_3x2_Avx2_fp16_fA0fB0fC0,
@@ -79,7 +79,7 @@ constexpr kernel_array_t<float16> kernel_fp16_neon = {
 
 constexpr kernel_array_t<float16> kernel_fp16_avx512_256 = {
     nullptr,
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if !defined(__aarch64__)
     gemmkernel_1x2_Avx2_fp16_fA0fB0fC0,
     gemmkernel_2x2_Avx2_fp16_fA0fB0fC0,
     gemmkernel_3x2_Avx2_fp16_fA0fB0fC0,

--- a/src/FbgemmFP16UKernelsAvx2.h
+++ b/src/FbgemmFP16UKernelsAvx2.h
@@ -16,11 +16,15 @@ namespace fbgemm {
 
 using GemmParamsFP16 = GemmParams<float16>;
 
+#if !defined(__aarch64__)
+
 void NOINLINE gemmkernel_1x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp);
 void NOINLINE gemmkernel_2x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp);
 void NOINLINE gemmkernel_3x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp);
 void NOINLINE gemmkernel_4x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp);
 void NOINLINE gemmkernel_5x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp);
 void NOINLINE gemmkernel_6x2_Avx2_fp16_fA0fB0fC0(GemmParamsFP16* gp);
+
+#endif // !defined(__aarch64__)
 
 } // namespace fbgemm

--- a/src/FbgemmFloat16Convert.cc
+++ b/src/FbgemmFloat16Convert.cc
@@ -23,7 +23,7 @@ void FloatToFloat16_simd(
     bool do_clip) {
   // Run time CPU detection
   if (cpuinfo_initialize()) {
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if !defined(__aarch64__)
     if (fbgemmHasAvx512Support()) {
       FloatToFloat16_avx512(src, dst, size, do_clip);
     } else if (fbgemmHasAvx2Support()) {
@@ -42,7 +42,7 @@ void FloatToFloat16_simd(
 void Float16ToFloat_simd(const float16* src, float* dst, size_t size) {
   // Run time CPU detection
   if (cpuinfo_initialize()) {
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if !defined(__aarch64__)
     if (fbgemmHasAvx512Support()) {
       Float16ToFloat_avx512(src, dst, size);
     } else if (fbgemmHasAvx2Support()) {

--- a/src/FbgemmSparseDense.cc
+++ b/src/FbgemmSparseDense.cc
@@ -193,7 +193,7 @@ void SparseDenseMM(
     float* C,
     int ldc,
     bool accum) {
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if !defined(__aarch64__)
   // Run time CPU detection
   static const auto iset = fbgemmInstructionSet();
 
@@ -229,7 +229,7 @@ FBGEMM_API void fbgemmSparseDenseInt8MM(
     return;
   }
 
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if !defined(__aarch64__)
   // Run time CPU detection
   static const auto iset = fbgemmInstructionSet();
 

--- a/src/GroupwiseConv.cc
+++ b/src/GroupwiseConv.cc
@@ -121,7 +121,7 @@ static jit_conv_kernel_fp getOrCreateConvKernel(
       accum);
 
   if (cpuinfo_initialize()) {
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if !defined(__aarch64__)
     if (fbgemmHasAvx512VnniSupport()) {
       return GenConvKernel<SPATIAL_DIM, inst_set_t::avx512_vnni>::codeCache_
           .getOrCreate(kernelSig, [&]() {
@@ -954,7 +954,7 @@ static void dispatchOutputProcessing(
   }
 
   if (cpuinfo_initialize()) {
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if !defined(__aarch64__)
     if (fbgemmHasAvx512Support() || fbgemmHasAvx512VnniSupport()) {
       REQUANTIZE_C_PER_G(Avx512);
     } else if (fbgemmHasAvx2Support() || fbgemmHasArmNeonSupport()) {

--- a/src/PackWeightsForConv.cc
+++ b/src/PackWeightsForConv.cc
@@ -25,7 +25,7 @@ PackWeightsForConv<SPATIAL_DIM, T, accT>::PackWeightsForConv(
   // FbgemmConv.cc
   switch (ConvFastPath<SPATIAL_DIM, accT>(conv_p)) {
     case optimized_conv_t::depthwise: {
-#if !defined(FBGEMM_FBCODE) && defined(__aarch64__)
+#if defined(__aarch64__)
       throw std::runtime_error(
           "PackWeightsForConv<SPATIAL_DIM, T, accT>::PackWeightsForConv(): No fallback available for aarch64");
 #else
@@ -98,7 +98,7 @@ PackWeightsForConv<SPATIAL_DIM, T, accT>::PackWeightsForConv(
 
 template <int SPATIAL_DIM, typename T, typename accT>
 void PackWeightsForConv<SPATIAL_DIM, T, accT>::unpack(T* origin_buf) {
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#if !defined(__aarch64__)
   if (W_dw_packed_) {
     W_dw_packed_->unpack(origin_buf);
   } else

--- a/src/PackWeightsForDirectConv.cc
+++ b/src/PackWeightsForDirectConv.cc
@@ -239,7 +239,7 @@ void fbgemmDirectConv(
     return;
   }
 
-#if !defined(FBGEMM_FBCODE) && defined(__aarch64__)
+#if defined(__aarch64__)
   throw std::runtime_error(
       "fbgemmDirectConv<SPATIAL_DIM, Q_GRAN, FUSE_RELU, BIAS_TYPE>(): No fallback available for aarch64");
 #else
@@ -459,7 +459,7 @@ void fbgemmDirectConv(
     }
   } // else SPATIAL_DIM
 
-#endif // defined(FBGEMM_FBCODE) || !defined(__aarch64__)
+#endif // !defined(__aarch64__)
 }
 
 #define INSTANTIATE_REQUANTIZE_SPATIAL_DIM(                        \

--- a/src/TransposeUtils.cc
+++ b/src/TransposeUtils.cc
@@ -57,14 +57,11 @@ void transpose_simd(
 #else
   static const auto iset = fbgemmInstructionSet();
   // Run time CPU detection
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
   if (isZmm(iset)) {
     internal::transpose_avx512<T>(M, N, src, ld_src, dst, ld_dst);
   } else if (isYmm(iset)) {
     internal::transpose_avx2<T>(M, N, src, ld_src, dst, ld_dst);
-  } else
-#endif
-  {
+  } else {
     transpose_ref<T>(M, N, src, ld_src, dst, ld_dst);
   }
 


### PR DESCRIPTION
Summary:
We are removing AVX2/AVX512 compilation of fbgemm for aarch64.
These modules are no longer used, thus removing them should decrease build time and code size.

Reviewed By: mcfi, YifanYuan3

Differential Revision: D85603930


