### PR TITLE
General adoption for Mtile = 64

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/test/attention/blackwell_fmha_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/attention/blackwell_fmha_test.py
@@ -687,7 +687,7 @@ class CutlassBlackwellFMHATest(unittest.TestCase):
                 sm_scale,
                 num_groups,
             )
-            for dtype in [torch.bfloat16]
+            for dtype in [torch.bfloat16, torch.float8_e4m3fn]
             for seqlen_k in [64, 128, 256, 1024]
             for batch_size in [1, 2]
             for is_mqa in [True, False]


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2080

This diff generalizes the work in (D85155388) based on Gefei's diff D85631781 .

Compared to D85631781, we avoid registers warp shuffling by using 32b TMEM atoms.

This diff supports:
1. Different dtypes (fp8, bf16)
2. Different mtiles (128, 64)

Reviewed By: v0i0

Differential Revision: D85893883


