### PR TITLE
Merge VBE output [backend] reland

### DIFF
--- a/fbgemm_gpu/codegen/genscript/generate_backward_split.py
+++ b/fbgemm_gpu/codegen/genscript/generate_backward_split.py
@@ -422,6 +422,7 @@ class BackwardSplitGenerator:
                 "lxu_cache_locations",  # 3
                 "uvm_cache_stats",  # 4
                 "prev_iter_dev",  # 5
+                "vbe_output_offsets",  # 6
             ],
             "aux_int": [
                 "iter",  # 0

--- a/fbgemm_gpu/codegen/genscript/optimizer_args.py
+++ b/fbgemm_gpu/codegen/genscript/optimizer_args.py
@@ -73,9 +73,7 @@ annotation_dict: Dict[str, str] = {
     "row_counter_dev": "(q!)",
     "row_counter_uvm": "(r!)",
     "optim_tensor": "(s!)",
-    "delta_weights_host": "(t!)",
-    "delta_weights_dev": "(u!)",
-    "delta_weights_uvm": "(v!)",
+    "vbe_output": "(t!)",
 }
 
 ######################################################################

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_meta_template.cpp
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_meta_template.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// clang-format off
 {#
 // @lint-ignore LINTIGNORE
 // @lint-ignore-every CLANGFORMAT
@@ -103,7 +104,12 @@ Tensor
     const int64_t iter,
     const double gwd_lower_bound,
     {%- endif %}
+    {%- if vbe and not dense %}
+    const bool is_experimental,
+    std::optional<Tensor> vbe_output
+    {%- else %}
     const bool is_experimental
+    {%- endif %}
 ) {
     // NB: omitted the device tests TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL
     {%- if not nobag %}
@@ -210,4 +216,4 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 {%- endfor %} {#-/* for is_gwd */#}
 {%- endif %} {#/* if (not nobag or (not weighted and not vbe)) */#}
 {%- endfor %} {#-/* for nobag */#}
-    // clang-format on
+  // clang-format on

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
@@ -6,10 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-{#
 // @lint-ignore LINTIGNORE
 // @lint-ignore-every CLANGFORMAT
 // clang-format off
+{#
 // Note: clang-format off doesn't work with this templaterized code,
 // so we need to keep lint-ignore-every.
 // See https://fburl.com/dw9ljh4h
@@ -391,7 +391,12 @@ batch_index_select_dim0_codegen_forward_cuda(
     const int64_t iter,
     const double gwd_lower_bound,
     {%- endif %}
+    {%- if vbe and not dense %}
+    const bool is_experimental,
+    std::optional<Tensor> vbe_output
+    {%- else %}
     const bool is_experimental
+    {%- endif %}
     {%- endif %} {#- /*if is_index_select*/ #}
 ) {
     {%- if not nobag or is_index_select %}
@@ -529,11 +534,24 @@ batch_index_select_dim0_codegen_forward_cuda(
                 o_dtype == SparseType::BF16 || o_dtype == SparseType::INT8);
 
     {%- if vbe %}
-    // Use a 2D tensor to make it compatible with 2D PackedTensorsAccessor of other output
+    {%- if dense %}
     output = at::empty(
         {1, vbe_output_size},
         dev_weights.options().dtype(getScalarType(o_dtype))
-    );
+      );
+    {%- else %}
+    // Use a 2D tensor to make it compatible with 2D PackedTensorsAccessor of other output
+    TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(vbe_row_output_offsets, vbe_output);
+    if (vbe_output.has_value()){
+      output = vbe_output.value().reshape({1, -1});
+    }
+    else {
+      output = at::empty(
+        {1, vbe_output_size},
+        dev_weights.options().dtype(getScalarType(o_dtype))
+      );
+    }
+    {%- endif %} {#-/* if dense */#}
     {%- else %}
     int64_t total_adjusted_D = total_D;
     if (o_dtype == SparseType::INT8) {
@@ -877,7 +895,12 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
           "    int iter, "
           "    float gwd_lower_bound, "
           {%- endif %}
+          {%- if vbe and not dense %}
+          "    bool is_experimental,"
+          "    Tensor? vbe_output"
+          {%- else %}
           "    bool is_experimental"
+          {%- endif %}
           ") -> Tensor"
           {%- if not dense and not nobag and not vbe %}
           // only split_embedding_codegen_forward_[un]weighted_cuda

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
@@ -137,7 +137,12 @@ enum SSDTensor {
                 const double /*gwd_lower_bound*/,
                 {%- endif %}
                 const bool /*is_experimental*/,
+                {%- if vbe and not dense %}
+                const int64_t /*output_dtype*/,
+                std::optional<Tensor> /*vbe_output*/
+                {%- else %}
                 const int64_t /*output_dtype*/
+                {%- endif %}
             )>();
 
     auto output = embedding_codegen_forward_op.call(
@@ -186,7 +191,12 @@ enum SSDTensor {
       {%- endif %} {# /* if is_gwd */ #}
       {%- endif %} {# /* if not nobag */ #}
       is_experimental,
+      {%- if vbe and not dense %}
+      output_dtype,
+      vbe_output
+      {%- else %}
       output_dtype
+      {%- endif %}
     );
 
     if (is_annotate_trace_enabled) {
@@ -259,7 +269,7 @@ enum SSDTensor {
                 const bool /*use_homogeneous_placements*/,
                 {%- if ssd %}
                 const bool /*enable_optimizer_offloading*/,
-                {%- endif %}                
+                {%- endif %}
                 {%- if is_gwd %}
                 {%- if "prev_iter_dev" not in args_pt2.split_function_arg_names %}
                 const Tensor& /*prev_iter_dev*/,
@@ -359,6 +369,14 @@ enum SSDTensor {
     // The number of items in the tensorlist differ between devices and is determined at runtime
     std::vector<Tensor> ret;
 
+    {%- if vbe and not dense %}
+    // To avoid overhead of merging multiple VBE embedding outputs, each embedding ops return 
+    // the same output tensor i.e., vbe_output. To ensure all backward ops are triggered, the embedding 
+    // ops are called in chain. We hence need to pass the grad_outputs to the next embedding op.
+    // So, if vbe_output is passed, we return the grad_outputs.
+    Tensor grad_vbe_output = has_vbe_output ? grad_outputs[0] : Variable();
+    {%- endif %}
+
     {%- if not dense %}
     ret.push_back(Variable()); // placeholder autograd tensor
     {%- endif %}
@@ -400,18 +418,21 @@ enum SSDTensor {
     ret.push_back(Variable()); // max_B
     ret.push_back(Variable()); // max_B_feature_rank
     ret.push_back(Variable()); // vbe_output_size
+    {%- if not dense %}
+    ret.push_back(grad_vbe_output); // vbe_output
+    {%- endif %} {# /* if not dense */ #}
     {%- endif %} {# /* if vbe */ #}
     {%- if not dense %}
     ret.push_back(Variable()); // aux_tensor
     ret.push_back(Variable()); // aux_int
     ret.push_back(Variable()); // aux_float
     ret.push_back(Variable()); // aux_bool
-    {%- endif %}
+    {%- endif %} {# /* if not dense */ #}
     {%- if ssd %}
     {%- for tensor in ssd_tensors %}
     ret.push_back(Variable()); // {{ tensor }}
     {%- endfor %}
-    {%- endif %}
+    {%- endif %} {# /* if ssd */ #}
     {{ args_pt2.unified_pt2.split_variables | join("\n") }}
     return ret;
 {%- endmacro %}
@@ -472,6 +493,9 @@ enum SSDTensor {
           max_B,
           max_B_feature_rank,
           vbe_output_size,
+          {%- if not dense %}
+          vbe_output,
+          {%- endif %} {# /* if not dense */ #}
           {%- endif %} {# /* if vbe */ #}
           {%- if not dense %}
           aux_tensor,
@@ -504,7 +528,7 @@ enum SSDTensor {
       TENSORS_EMPTY_OR_ON_SAME_DEVICE({{ name }}[0], {{ name }}[2]);
       {{ name }}_host = {{ name }}[0];
       {{ name }}_placements = {{ name }}[1];
-      {{ name }}_offsets = {{ name }}[2]; 
+      {{ name }}_offsets = {{ name }}[2];
     }
     else if ({{ name }}.size() == {{ 5 if name == "weights" else 4 }})  {
       TENSOR_ON_CUDA_GPU({{ name }}[0]);
@@ -514,7 +538,7 @@ enum SSDTensor {
       {%- if name == "weights" %}
       TENSORS_EMPTY_OR_ON_SAME_DEVICE({{ name }}[0], {{ name }}[4]);
       {%- endif %}
-      {{ name }}_dev = {{ name }}[0]; 
+      {{ name }}_dev = {{ name }}[0];
       {{ name }}_uvm = {{ name }}[1];
       {{ name }}_placements = {{ name }}[2];
       {{ name }}_offsets = {{ name }}[3];
@@ -548,7 +572,7 @@ enum SSDTensor {
 {%- endmacro %}
 
 ////////////////////////////////////////////////////////////////////////////////
-// MACROS 
+// MACROS
 ////////////////////////////////////////////////////////////////////////////////
 #define GET_OPTIONAL_TENSOR_VALUE(name, empty_tensor) name.has_value() ? name.value() : empty_tensor;
 
@@ -631,6 +655,9 @@ class {{ autograd_func }} :
     const c10::SymInt max_B,
     const c10::SymInt max_B_feature_rank,
     const c10::SymInt vbe_output_size,
+    {%- if not dense %}
+    std::optional<Tensor> vbe_output,
+    {%- endif %} {# /* if not dense */ #}
     {%- endif %} {# /* if vbe */ #}
     {%- if not dense %}
     std::vector<std::optional<at::Tensor>> aux_tensor,
@@ -662,6 +689,24 @@ class {{ autograd_func }} :
     const auto vbe_output_offsets_feature_rank_ = GET_OPTIONAL_TENSOR_VALUE(aux_tensor[IDX_VBE_OUTPUT_OFFSETS_FEATURE_RANK], Tensor());
     const auto vbe_B_offsets_rank_per_feature_ = GET_OPTIONAL_TENSOR_VALUE(aux_tensor[IDX_VBE_B_OFFSETS_RANK_PER_FEATURE], Tensor());
     const c10::SymInt max_B_ = max_B;
+    {%- if not dense %}
+    // The pipeline relies on frontend to supply vbe_output_offsets through aux_tensor
+    // However, if a model uses old frontend package (i.e., does not include frontend changes from this diff)
+    // with new backend package, aux_tensor will not contain vbe_output_offsets.
+    // This means old frontend will send aux_tensor of size 6, but the new backend (from this diff) expects 7,
+    // which accessing aux_tensor[IDX_VBE_OUTPUT_OFFSETS] can cause segmentation fault
+    const std::optional<Tensor> vbe_output_offsets = aux_tensor.size() == AUX_TENSOR_SIZE ? aux_tensor[IDX_VBE_OUTPUT_OFFSETS] : std::nullopt;
+    TORCH_CHECK(
+      vbe_output.has_value() == vbe_output_offsets.has_value(),
+      "Expected both vbe_output and vbe_output_offsets to either be None or have value. However, vbe_output ",
+      vbe_output.has_value() ? " has value" : " is None",
+      " but vbe_output_offsets ",
+      vbe_output_offsets.has_value() ? " has value." : " is None. ",
+      "Note: Frontend passes aux_tensor of size ", aux_tensor.size(),
+      "and backend expects aux_tensor of ", AUX_TENSOR_SIZE,
+      ". If the aux_tensor size mismatch, please update your frontend/backend package. Contact FBGEMM team for any assistance."
+    );
+    {%- endif %}
     {%- else %}
     const auto max_B_ = offsets.sym_size(0) / T;
     {%- endif %}
@@ -719,7 +764,8 @@ class {{ autograd_func }} :
                 const bool,
                 const c10::SymInt,
                 const int64_t,
-                const c10::SymInt)>();
+                const c10::SymInt,
+                const std::optional<Tensor>&)>();
     auto [
         vbe_row_output_offsets,
         vbe_b_t_map
@@ -739,7 +785,8 @@ class {{ autograd_func }} :
         {%- endif %}
         max_B_feature_rank,
         info_B_num_bits,
-        /*total_B=*/offsets.sym_size(0) - 1
+        /*total_B=*/offsets.sym_size(0) - 1,
+        vbe_output_offsets
         );
     {%- endif %} // vbe
 
@@ -755,9 +802,9 @@ class {{ autograd_func }} :
     const auto indice_weights_value = GET_OPTIONAL_TENSOR_VALUE(indice_weights, Tensor());
     {%- endif %}
 
-    // Setting learning rate tensor with `.fill_()` breaks apf_dlrm bento kernel with 
+    // Setting learning rate tensor with `.fill_()` breaks apf_dlrm bento kernel with
     // `RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation.`
-    // This is because if a tensor is saved for backward and it is mutated later, this can cause correctness problems. 
+    // This is because if a tensor is saved for backward and it is mutated later, this can cause correctness problems.
     // Since the forward compute and backward compute see different data values for this tensor.
     // To work around, we pass the cloned tensor instead the mutated tensor
     {%- if "learning_rate_tensor" in args_pt2.unified_pt2.split_unpacked_arg_names %}
@@ -844,8 +891,12 @@ class {{ autograd_func }} :
     ctx->saved_data["output_dtype"] = output_dtype;
     {%- endif %}
     {%- if vbe %}
-    ctx->saved_data["max_B"] = max_B_; // for reshaping vbe cpu offsets and grad_output 
-    {%- endif %}
+    ctx->saved_data["max_B"] = max_B_; // for reshaping vbe cpu offsets and grad_output
+    // This is needed to determine whether to return grads_output
+    {%- if not dense %}
+    ctx->saved_data["has_vbe_output"] = vbe_output.has_value();
+    {%- endif %} {# /* if not dense */ #}
+    {%- endif %} {# /* if vbe */ #}
 
     {%- if not dense %}
     // unpack optim args
@@ -978,13 +1029,16 @@ static torch::autograd::variable_list backward(
     {%- if is_gwd %}
     const auto gwd_lower_bound = ctx->saved_data["gwd_lower_bound"].toDouble();
     {%- endif %}
-    
+
     {%- if not nobag %}
     auto output_dtype = ctx->saved_data["output_dtype"].toInt();
     {%- endif %}
     {%- if not dense %}
     {%- if vbe %}
     auto max_B = ctx->saved_data["max_B"].toSymInt(); // for reshaping vbe cpu offsets and grad_output
+    {%- if not dense %}
+    const auto has_vbe_output = ctx->saved_data["has_vbe_output"].toBool(); // for whether to return grad_output
+    {%- endif %} {# /* if not dense */ #}
     {%- endif %}
 
     {%- for (var, _ , ivalue_cast, type) in args_pt2.unified_pt2.split_saved_data %}
@@ -1097,7 +1151,7 @@ static torch::autograd::variable_list backward(
         feature_requires_grad
         {%- endif %}
         );
-    
+
     Tensor grad_weights_dev;
     // weighted
     if (indice_weights.defined())
@@ -1147,7 +1201,7 @@ Tensor {{ bwd_mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function_pt2(
     {%- else %}
     const Tensor& placeholder_autograd_tensor,
     const at::TensorList weights,
-    {%- endif %}
+    {%- endif %} {#-/* if dense */#}
     const Tensor& D_offsets,
     const c10::SymInt total_D,
     const c10::SymInt max_D,
@@ -1164,19 +1218,31 @@ Tensor {{ bwd_mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function_pt2(
     const std::vector<int64_t>& aux_int,
     const std::vector<double>& aux_float,
     c10::List<bool> aux_bool,
-    {%- endif %}
+    {%- endif %} {#-/* if not dense */#}
     {{ args_pt2.unified_pt2.split_function_args | join(", ") }},
     const c10::SymInt max_B = -1,
     const c10::SymInt max_B_feature_rank = -1,
-    {%- if ssd %}
+    {%- if not dense %}
     const c10::SymInt vbe_output_size = -1,
-    const std::optional<at::TensorList>& ssd_tensors = std::nullopt
+    {%- if ssd %}
+    const std::optional<at::TensorList>& ssd_tensors = std::nullopt,
+    {%- endif %} {#-/* if ssd */#}
+    std::optional<Tensor> vbe_output = std::nullopt
     {%- else %}
+    {#- /* ssd and pre-allocated vbe_output is not yet supported in Dense TBE */ -#}
     const c10::SymInt vbe_output_size = -1
-    {%- endif %}
+    {%- endif %} {#-/* if not dense */#}
 ) {
 
   {%- if has_gpu_support or has_cpu_support %}
+
+  TORCH_WARN(aux_tensor.size() <= AUX_TENSOR_SIZE, 
+    "aux_tensor.size() should not be larger than ", 
+    AUX_TENSOR_SIZE,
+    "but found to be  ", 
+    aux_tensor.size(),
+    ". This means frontend package does not match with backend package, so some functionalities might be missing. Please contact FBGEMM team for any assistance."
+  );
 
     {%- if not dense %}
     // Load the config value from JK once
@@ -1229,7 +1295,7 @@ Tensor {{ bwd_mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function_pt2(
       "{{ bwd_mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function is deprecated. Please see https://github.com/pytorch/FBGEMM/discussions/1727 for more detail."
   );
   return Tensor();
-  {%- endif %} 
+  {%- endif %}
 }
 
 
@@ -1259,16 +1325,19 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         "    int[] aux_int, "
         "    float[] aux_float, "
         "    bool[] aux_bool, "
+        {%- endif %} {#-/* if not dense */#}
         "    {{ args_pt2.unified_pt2.split_function_schemas | join(", ") }}, "
         "    SymInt max_B=-1, "
         "    SymInt max_B_feature_rank=-1, "
-        {%- if ssd %}
+        {%- if not dense %}
         "    SymInt vbe_output_size=-1, "
-        "    Tensor[]? ssd_tensors=None "
+        {%- if ssd %}
+        "    Tensor[]? ssd_tensors=None, "
+        {%- endif %}
+        "    Tensor? vbe_output=None "
         {%- else %}
-         "    SymInt vbe_output_size=-1 "
-        {%- endif %}
-        {%- endif %}
+        "    SymInt vbe_output_size=-1 "
+        {%- endif %} {#-/* if not dense */#}
         ") -> Tensor",
         {PT2_COMPLIANT_TAG});
     // We're playing a funny trick here: we're using the autograd

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cpu_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cpu_wrapper_template.cpp
@@ -143,7 +143,13 @@ Tensor split_embedding{{ ndesc }}_codegen_forward_{{ wdesc }}{{ vdesc }}_pt2_cpu
     const Tensor& B_offsets,
     {%- endif %}
     const bool /*is_experimental = false*/,
-    const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)) {
+    {%- if vbe %}
+    const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32),
+    std::optional<Tensor> vbe_output = std::nullopt
+    {%- else %}
+    const int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)
+    {%- endif %}
+    ){
     Tensor offsets_;
     {%- if vbe %}
     const int64_t max_B_int = max_B.guard_int(__FILE__, __LINE__);
@@ -406,7 +412,12 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         "    Tensor B_offsets, "
         {%- endif %}
         "    bool is_experimental, "
+        {%- if vbe %}
+        "    int output_dtype, "
+        "    Tensor? vbe_output "
+        {%- else %}
         "    int output_dtype "
+        {%- endif %}
         ") -> Tensor"
         {%- if not nobag and not vbe %}
           // only split_embedding_codegen_forward_[un]weighted_cuda

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_cuda_wrapper_template.cpp
@@ -107,7 +107,12 @@ Tensor {{ fwd_mdesc }}_embedding{{ ndesc }}_codegen_forward_{{ desc_suffix }}_pt
     const double gwd_lower_bound,
     {%- endif %}
     const bool is_experimental,
+    {%- if vbe and not dense %}
+    const int64_t output_dtype,
+    std::optional<Tensor> vbe_output
+    {%- else %}
     const int64_t output_dtype
+    {%- endif %}
     ){
     {%- set op = "{}_embedding{}_codegen_forward_{}_cuda".format(
         fwd_mdesc, ndesc, desc_suffix
@@ -155,7 +160,12 @@ Tensor {{ fwd_mdesc }}_embedding{{ ndesc }}_codegen_forward_{{ desc_suffix }}_pt
                 const int64_t /*iter*/,
                 const double /*gwd_lower_bound*/,
                 {%- endif %}
+                {%- if vbe and not dense %}
+                const bool,
+                std::optional<Tensor> /*vbe_output*/
+                {%- else %}
                 const bool
+                {%- endif %}
             )>();
 
     return op.call(
@@ -201,7 +211,12 @@ Tensor {{ fwd_mdesc }}_embedding{{ ndesc }}_codegen_forward_{{ desc_suffix }}_pt
             iter,
             gwd_lower_bound,
             {%- endif %} {# /* if is_gwd */ #}
+            {%- if vbe and not dense %}
+            is_experimental,
+            vbe_output
+            {%- else %}
             is_experimental
+            {%- endif %}
         );
     };
 {%- else %}
@@ -561,7 +576,12 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
         "    float gwd_lower_bound, "
         {%- endif %}
         "    bool is_experimental, "
+        {%- if vbe and not dense %}
+        "    int output_dtype, "
+        "    Tensor? vbe_output"
+        {%- else %}
         "    int output_dtype "
+        {%- endif %}
         ") -> Tensor"
         {%- if not nobag and not vbe %}
           // only split_embedding_codegen_forward_[un]weighted_cuda

--- a/fbgemm_gpu/codegen/training/pt2/pt2_arg_utils_template.h
+++ b/fbgemm_gpu/codegen/training/pt2/pt2_arg_utils_template.h
@@ -21,7 +21,7 @@ enum ArgIndex_{{ name }} {
   {%- for var in aux_args[name] %}
   IDX_{{ var | upper }} = {{ loop.index - 1 }},
   {%- endfor %}
-  {{ name | upper }}_SIZE = {{ name | length }}
+  {{ name | upper }}_SIZE = {{ aux_args[name] | length }}
 };
 {%- endfor %}
 

--- a/fbgemm_gpu/codegen/training/python/split_embedding_codegen_lookup_invoker.template
+++ b/fbgemm_gpu/codegen/training/python/split_embedding_codegen_lookup_invoker.template
@@ -42,7 +42,7 @@ torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
 
 {%- endif %}
 
-{# This macro generates a code blob to pack Tensor arguments into a TensorList 
+{# This macro generates a code blob to pack Tensor arguments into a TensorList
     as number of arguments for some optimizers exceed 64 #}
 {%- macro pack_tensors(arg) %}
     {{ arg }}_list = [
@@ -58,7 +58,7 @@ torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
 {%- endmacro %}
 
 {# This macro generates a code blob to pack optim optional tensor into an optional TensorList.
-    All optim optional tensors are packed together into `optim_tensor`. 
+    All optim optional tensors are packed together into `optim_tensor`.
     This poses challenge to handle unpacking in autograd if we do per device (i.e, 3 for cpu and 4 for cuda).
     Hence, we pack unified args (i.e., 5 items) for readability and programmability.
  #}
@@ -92,14 +92,14 @@ torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
         "Please check the frontend and backend version. "
     )
     {{ arg_type }}.append(dict_{{ arg_type }}["{{ var }}"])
-    
+
     {%- endfor %}
 {%- endmacro %}
 
 
 {%- if is_prototype_optimizer %}
 # Decorate the prototype optimizers which may be deprecated in the future with jit.ignore to avoid
-# possible errors from torch.jit.script. 
+# possible errors from torch.jit.script.
 # Note that backends can be removed but the lookup invoker is still needed for backward compatibility
 @torch.jit.ignore
 {%- endif %}
@@ -187,14 +187,15 @@ def invoke(
         "vbe_B_offsets_rank_per_feature": vbe_metadata.B_offsets_rank_per_feature,
         "lxu_cache_locations": common_args.lxu_cache_locations,
         "uvm_cache_stats": common_args.uvm_cache_stats,
+        "vbe_output_offsets" : None,
     }
 
     dict_aux_int: Dict[str, int] = {
-        "iter": iter, 
-        "info_B_num_bits": common_args.info_B_num_bits, 
+        "iter": iter,
+        "info_B_num_bits": common_args.info_B_num_bits,
         "info_B_mask": common_args.info_B_mask,
     }
-    
+
     dict_aux_float: Dict[str, float] = {
         "gwd_lower_bound": gwd_lower_bound,
     }
@@ -219,7 +220,7 @@ def invoke(
     {%- else %}
     dict_aux_tensor["prev_iter_dev"] = prev_iter.dev
     {%- endif %}
-    
+
 
     # optimizer_args
     {%- if optimizer == "none" %}
@@ -302,13 +303,13 @@ def invoke(
     {{ pack_tensors("row_counter") }}
     {%- endif %}
     {%- if "row_counter" in args_pt2.unified_pt2.split_saved_tensorlist_optional %}
-    
+
     if optimizer_args.use_rowwise_bias_correction and row_counter is not None:
         row_counter_host = None # not supported on CPU
         row_counter_dev = row_counter.dev
         row_counter_uvm = row_counter.uvm
         row_counter_offsets = row_counter.offsets
-        row_counter_placements = row_counter.placements   
+        row_counter_placements = row_counter.placements
     elif optimizer_args.use_rowwise_bias_correction:
         assert False, "`use_rowwise_bias_correction` is set, `row_counter` cannot be None"
     else:
@@ -316,7 +317,7 @@ def invoke(
         row_counter_dev = None
         row_counter_uvm = None
         row_counter_offsets = None
-        row_counter_placements = None  
+        row_counter_placements = None
     {%- endif %}
 
     {{ pack_to_list("aux_tensor") }}
@@ -358,7 +359,7 @@ def invoke(
     {%- for name in args_pt2.unified_pt2.split_args_dict["optim_bool"] %}
     optim_bool.append(dict_optim_bool["{{ name }}"])
     {%- endfor %}
-    {%- endif %} 
+    {%- endif %}
 
     return torch.ops.fbgemm.{{ mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function_pt2(
         # common_args

--- a/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/split_embeddings_utils.h
@@ -32,6 +32,7 @@ generate_vbe_metadata(
     const at::Tensor& D_offsets,
     const int64_t D,
     const bool nobag,
-    const int64_t max_B_feature_rank,
+    const c10::SymInt max_B_feature_rank,
     const int64_t info_B_num_bits,
-    const int64_t total_B);
+    const c10::SymInt total_B,
+    const std::optional<at::Tensor>& vbe_output_offsets);

--- a/fbgemm_gpu/src/split_embeddings_utils/generate_vbe_metadata.cu
+++ b/fbgemm_gpu/src/split_embeddings_utils/generate_vbe_metadata.cu
@@ -34,7 +34,9 @@ __launch_bounds__(kMaxThreads) void generate_vbe_metadata_foreach_sample_kernel(
         D_offsets,
     const int32_t D,
     const bool nobag,
-    const int32_t info_B_num_bits) {
+    const int32_t info_B_num_bits,
+    const pta::PackedTensorAccessor32<int64_t, 2, at::RestrictPtrTraits>
+        predefined_vbe_output_offsets) {
   // Relative sample ID in the rank-table matrix
   const auto b = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   // Rank ID
@@ -50,6 +52,8 @@ __launch_bounds__(kMaxThreads) void generate_vbe_metadata_foreach_sample_kernel(
     return;
   }
 
+  const bool use_predefined_offsets = predefined_vbe_output_offsets.size(0) > 0;
+
   const auto* __restrict__ output_offsets_feature =
       &output_offsets_feature_rank[r * T];
 
@@ -57,8 +61,9 @@ __launch_bounds__(kMaxThreads) void generate_vbe_metadata_foreach_sample_kernel(
   const auto b_t =
       static_cast<int64_t>(B_start_t) + static_cast<int64_t>(B_start_r_t) + b;
   const auto D_ = nobag ? D : (D_offsets[t + 1] - D_offsets[t]);
-  row_output_offsets[b_t] =
-      output_offsets_feature[t] + b * static_cast<int64_t>(D_);
+  auto offset = use_predefined_offsets ? predefined_vbe_output_offsets[r][t]
+                                       : output_offsets_feature[t];
+  row_output_offsets[b_t] = offset + b * static_cast<int64_t>(D_);
 
   // Relative sample ID in the table
   const auto b_ = B_start_r_t + b;
@@ -114,11 +119,15 @@ generate_vbe_metadata(
     const Tensor& D_offsets,
     const int64_t D,
     const bool nobag,
-    const int64_t max_B_feature_rank,
+    const c10::SymInt max_B_feature_rank,
     const int64_t info_B_num_bits,
-    const int64_t total_B) {
+    const c10::SymInt total_B,
+    const std::optional<Tensor>& vbe_output_offsets = std::nullopt) {
   TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(
-      B_offsets, B_offsets_rank_per_feature, output_offsets_feature_rank);
+      B_offsets,
+      B_offsets_rank_per_feature,
+      output_offsets_feature_rank,
+      vbe_output_offsets);
 
   TENSOR_NDIM_EQUALS(B_offsets, 1);
   TENSOR_NDIM_EQUALS(B_offsets_rank_per_feature, 2);
@@ -132,25 +141,53 @@ generate_vbe_metadata(
     TORCH_CHECK(D_offsets.numel() == T + 1)
   }
 
+  const int64_t total_B_ = total_B.guard_int(__FILE__, __LINE__);
+  const int64_t max_B_feature_rank_ =
+      max_B_feature_rank.guard_int(__FILE__, __LINE__);
+
   const auto num_ranks = B_offsets_rank_per_feature.size(1) - 1;
   TORCH_CHECK(
       num_ranks > 0, "generate_vbe_metadata: Invalid num_ranks ", num_ranks);
   TORCH_CHECK(T > 0, "generate_vbe_metadata: Invalid T ", T);
   TORCH_CHECK(
-      max_B_feature_rank > 0,
+      max_B_feature_rank_ > 0,
       "generate_vbe_metadata: Invalid max_B_feature_rank ",
-      max_B_feature_rank);
+      max_B_feature_rank_);
 
   TORCH_CHECK(B_offsets_rank_per_feature.size(0) == T);
   TORCH_CHECK(output_offsets_feature_rank.numel() == num_ranks * T + 1);
 
+  Tensor predefined_vbe_output_offsets;
+  if (vbe_output_offsets.has_value()) {
+    predefined_vbe_output_offsets = vbe_output_offsets.value();
+    TORCH_CHECK(
+        predefined_vbe_output_offsets.dim() == 2,
+        "Expected a tensor of 2 dims: [num_ranks, num_features] but got ",
+        predefined_vbe_output_offsets.dim());
+    TORCH_CHECK(
+        predefined_vbe_output_offsets.size(0) == num_ranks,
+        "Expected predefined_vbe_output_offsets.size(0) to be",
+        num_ranks,
+        " but got ",
+        predefined_vbe_output_offsets.size(0));
+    TORCH_CHECK(
+        predefined_vbe_output_offsets.size(1) == T,
+        "Expected predefined_vbe_output_offsets.size(1) to be",
+        T,
+        " but got ",
+        predefined_vbe_output_offsets.size(1));
+  } else {
+    predefined_vbe_output_offsets =
+        at::empty({0, 0}, output_offsets_feature_rank.options());
+  }
+
   CUDA_DEVICE_GUARD(B_offsets);
 
   Tensor row_output_offsets =
-      at::empty({total_B}, output_offsets_feature_rank.options());
-  Tensor b_t_map = at::empty({total_B}, B_offsets.options());
+      at::empty({total_B_}, output_offsets_feature_rank.options());
+  Tensor b_t_map = at::empty({total_B_}, B_offsets.options());
 
-  const auto grid_dim_x = div_round_up(max_B_feature_rank, kMaxThreads);
+  const auto grid_dim_x = div_round_up(max_B_feature_rank_, kMaxThreads);
   const dim3 grid_size(grid_dim_x, num_ranks, T);
   const auto& [max_grid_x, max_grid_y, max_grid_z] = get_max_grid_size();
   TORCH_CHECK(
@@ -181,7 +218,9 @@ generate_vbe_metadata(
       PTA_B(D_offsets, int32_t, 1, 32),
       D,
       nobag,
-      info_B_num_bits);
+      info_B_num_bits,
+      MAKE_PTA_WITH_NAME(
+          func_name, predefined_vbe_output_offsets, int64_t, 2, 32));
 
   return {row_output_offsets, b_t_map};
 }

--- a/fbgemm_gpu/src/split_embeddings_utils/split_embeddings_utils_cpu.cpp
+++ b/fbgemm_gpu/src/split_embeddings_utils/split_embeddings_utils_cpu.cpp
@@ -119,7 +119,8 @@ generate_vbe_metadata_cpu(
     const bool /*nobag*/,
     const c10::SymInt /*max_B_feature_rank*/,
     const int64_t info_B_num_bits,
-    const c10::SymInt total_B) {
+    const c10::SymInt total_B,
+    const std::optional<Tensor>& vbe_output_offsets = std::nullopt) {
   TENSOR_ON_CPU(B_offsets);
   TENSORS_ON_SAME_DEVICE(B_offsets, B_offsets_rank_per_feature);
   TENSORS_ON_SAME_DEVICE(B_offsets, output_offsets_feature_rank);
@@ -139,6 +140,11 @@ generate_vbe_metadata_cpu(
   Tensor row_output_offsets =
       at::empty({total_B_}, output_offsets_feature_rank.options());
   TORCH_CHECK(B_offsets.dtype() == at::kInt, "B_offsets should be int32");
+
+  if (vbe_output_offsets.has_value()) {
+    TORCH_CHECK(vbe_output_offsets->numel() == total_B, "size mismatch");
+  }
+
   Tensor b_t_map = at::empty({total_B_}, B_offsets.options());
   auto B_offsets_acc = B_offsets.accessor<int32_t, 1>();
   auto D_offsets_acc = D_offsets.accessor<int32_t, 1>();
@@ -166,7 +172,8 @@ generate_vbe_metadata_cpu(
       }
     }
   }
-  return {row_output_offsets, b_t_map};
+  auto row_output_offsets_ = vbe_output_offsets.value_or(row_output_offsets);
+  return {row_output_offsets_, b_t_map};
 }
 
 std::tuple<int64_t, int64_t>
@@ -204,7 +211,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "    bool nobag, "
       "    SymInt max_B_feature_rank, "
       "    int info_B_num_bits, "
-      "    SymInt total_B"
+      "    SymInt total_B, "
+      "    Tensor? vbe_output_offsets=None"
       ") -> (Tensor, Tensor)");
   DISPATCH_TO_CPU("generate_vbe_metadata", generate_vbe_metadata_cpu);
   DISPATCH_TO_CPU("get_infos_metadata", get_infos_metadata_cpu);

--- a/fbgemm_gpu/src/split_embeddings_utils/split_embeddings_utils_meta.cpp
+++ b/fbgemm_gpu/src/split_embeddings_utils/split_embeddings_utils_meta.cpp
@@ -23,7 +23,8 @@ generate_vbe_metadata_meta(
     const bool /*nobag*/,
     const c10::SymInt /*max_B_feature_rank*/,
     const int64_t /*info_B_num_bits*/,
-    const c10::SymInt total_B) {
+    const c10::SymInt total_B,
+    const std::optional<Tensor>& /*vbe_output_offsets*/ = std::nullopt) {
   Tensor row_output_offsets =
       at::empty_symint({total_B}, output_offsets_feature_rank.options());
   Tensor b_t_map = at::empty_symint({total_B}, B_offsets.options());


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2100

Reland of D79704318


Currently, Torchrec merges the outputs of individual VBE TBE ops to be ordered by ranks using [_merge_variable_batch_embeddings](https://www.internalfb.com/code/fbsource/[3bd69d7fa3534144dcb0162ca59803a6c3ff6e70]/fbcode/torchrec/distributed/embedding_lookup.py?lines=593-604). This function seems to cause ~30% QPS regression compared to baseline (HBM+UVM) for Jupiter V1 model with VBE enabled.

To get rid of _merge_variable_batch_embeddings() function, we pre-allocate the `vbe_output` tensor which holds  outputs from all VBE ops and calculate `vbe_output_offsets` to allow each individual VBE ops to write to the correct location in the `vbe_output` tensor.

By default, `vbe_output` and `vbe_output_offsets` are `None`, which means VBE ops will return individual tensor the way it currently does. The feature is enabled when `vbe_output` and `vbe_output_offsets` are not `None`.

---
**NOTE**
1. This feature is currently supported for Sparse TBE. 
2. The support is limited for CUDA. 
3. For backward compatibility, we append the newly introduced `vbe_output` to the existing API. Hence, we need to make the `vbe_output` tensor as `optional` with default value as `None` (there's no default value for Tensor).
4. We *cannot* annotate  `vbe_output` because PyTorch registration does not support annotation of optional tensor.  Adding annotation will incur the following error below. This may cause some issues to support this on MTIA, if MTIA relies on tensor annotation.
```
E0903 09:50:32.966235 2850885 ExceptionTracer.cpp:227] exception stack complete
terminate called after throwing an instance of 'std::runtime_error'
  what():  expected ident but found '(' here:
split_embedding_codegen_lookup_adagrad_function_pt2(    Tensor placeholder_autograd_tensor,     Tensor[](a!) weights,     Tensor D_offsets,     SymInt total_D,     SymInt max_D,     Tensor hash_size_cumsum,     int total_hash_size_bits,     Tensor indices,     Tensor offsets,     int pooling_mode,     Tensor? indice_weights,     Tensor? feature_requires_grad,     int output_dtype,     Tensor?[](e!) aux_tensor,     int[] aux_int,     float[] aux_float,     bool[] aux_bool,     Tensor[](g!) momentum1, Tensor learning_rate_tensor, float[] optim_float,     SymInt max_B=-1,     SymInt max_B_feature_rank=-1,     SymInt vbe_output_size=-1,     Tensor?(t!) vbe_output=None ) -> Tensor
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            ~ <--- HERE
```

Reviewed By: q10

Differential Revision: D83881544


