### PR TITLE
Change to warn_once for frontend/backend mismatch

### DIFF
--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
@@ -1236,7 +1236,7 @@ Tensor {{ bwd_mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function_pt2(
 
   {%- if has_gpu_support or has_cpu_support %}
 
-  TORCH_WARN(aux_tensor.size() <= AUX_TENSOR_SIZE, 
+  TORCH_WARN_ONCE(aux_tensor.size() <= AUX_TENSOR_SIZE, 
     "aux_tensor.size() should not be larger than ", 
     AUX_TENSOR_SIZE,
     "but found to be  ", 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2104

Use TORCH_WARN_ONCE instead of TORCH_WARN to reduce the warning message.

Differential Revision: D86381414


