### PR TITLE
cutlass_blackwell_fmha_gen make kernel call argument batch_idx optional.

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/gen_ai/attention/cutlass_blackwell_fmha/cutlass_blackwell_fmha_interface.py
+++ b/fbgemm_gpu/experimental/gen_ai/gen_ai/attention/cutlass_blackwell_fmha/cutlass_blackwell_fmha_interface.py
@@ -232,17 +232,13 @@ def cutlass_blackwell_fmha_decode_forward(
     q, k, v, batch_size, needs_reshape_output, original_shape = _prepare_decode_inputs(
         q, k, v
     )
-
-    # Create batch_idx tensor
-    batch_idx = torch.arange(batch_size, dtype=torch.int32, device=q.device)
-
     # Call the gen kernel (optimized for decode)
     out = torch.ops.fbgemm.fmha_gen_fwd(
         q,
         k,
         v,
         seqlen_kv,
-        batch_idx,
+        None,
         kernel_type=GenKernelType.UMMA_I,
         # window_left=window_left,
         # window_right=window_right,

--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_gen_interface.hpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_gen_interface.hpp
@@ -19,6 +19,8 @@
 
 using namespace cutlass;
 
+#include <optional>
+
 enum class KernelType { UMMA_I = 0, UMMA_P = 1 };
 
 // Template function definition for type conversion
@@ -44,5 +46,5 @@ at::Tensor dispatch_fmha_gen_fwd(
     const at::Tensor& k,
     const at::Tensor& v,
     const at::Tensor& seqlen_kv,
-    const at::Tensor& batch_idx,
+    const std::optional<at::Tensor>& batch_idx,
     int64_t kernel_type);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2110

Since the kernel impl already assumes the batch remapping argument to be optional, there is no need to always construct one.

Reviewed By: Aya-ZIbra

Differential Revision: D85631785


