### PR TITLE
st publish mode only load weight

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -248,6 +248,7 @@ class KVZCHParams(NamedTuple):
     backend_return_whole_row: bool = False
     eviction_policy: EvictionPolicy = EvictionPolicy()
     embedding_cache_mode: bool = False
+    load_ckpt_without_opt: bool = False
 
     def validate(self) -> None:
         assert len(self.bucket_offsets) == len(self.bucket_sizes), (
@@ -271,6 +272,8 @@ class KVZCHTBEConfig(NamedTuple):
     threshold_calculation_bucket_stride: float = 0.2
     # Total number of feature score buckets used for threshold calculation in feature score-based eviction.
     threshold_calculation_bucket_num: Optional[int] = 1000000  # 1M
+    # When true, we only save weight to kvzch backend and not optimizer state.
+    load_ckpt_without_opt: bool = False
 
 
 class BackendType(enum.IntEnum):

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper.h
@@ -65,7 +65,8 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
       int64_t width_offset = 0,
       const std::optional<c10::intrusive_ptr<RocksdbCheckpointHandleWrapper>>
           checkpoint_handle = std::nullopt,
-      bool read_only = false);
+      bool read_only = false,
+      bool only_load_weight = false);
 
   explicit KVTensorWrapper(const std::string& serialized);
 
@@ -153,6 +154,7 @@ class KVTensorWrapper : public torch::jit::CustomClassHolder {
   int64_t max_D{};
   std::string checkpoint_uuid;
   bool read_only_{};
+  bool only_load_weight_{};
 };
 
 void to_json(json& j, const KVTensorWrapper& kvt);

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper_cpu.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_tensor_wrapper_cpu.cpp
@@ -38,7 +38,8 @@ KVTensorWrapper::KVTensorWrapper(
     [[maybe_unused]] int64_t width_offset,
     [[maybe_unused]] const std::optional<
         c10::intrusive_ptr<RocksdbCheckpointHandleWrapper>>,
-    [[maybe_unused]] bool read_only)
+    [[maybe_unused]] bool read_only,
+    [[maybe_unused]] bool only_load_weight)
     // @lint-ignore CLANGTIDY clang-diagnostic-missing-noreturn
     : shape_(std::move(shape)), row_offset_(row_offset) {
   FBEXCEPTION("Not implemented");


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/torchrec/pull/3538

X-link: https://github.com/facebookresearch/FBGEMM/pull/2122

For silvertorch publish, we don't want to load opt into backend due to limited cpu memory in publish host.
So we need to load the whole row into state dict which loading the checkpoint in st publish, then only save weight into backend, after that backend will only have metaheader + weight.
For the first loading, we need to set dim with metaheader_dim + emb_dim + optimizer_state_dim, otherwise the checkpoint loadding will throw size mismatch error. after the first loading, we only need to get metaheader+weight from backend for state dict, so we can set dim with metaheader_dim + emb

Differential Revision: D85830053


