### PR TITLE
Enable arm64 convolution for fbgemm through the reference convolution APIs

### DIFF
--- a/bench/EmbeddingSpMDMNBitBenchmark.cc
+++ b/bench/EmbeddingSpMDMNBitBenchmark.cc
@@ -206,7 +206,8 @@ static int run_benchmark(
         /*output_bit_rate=*/-1);
 #endif
 
-    vector<OutType>& output = has_weight ? output_slws : output_sls;
+    [[maybe_unused]] vector<OutType>& output =
+        has_weight ? output_slws : output_sls;
     for (bool flush_cache : {false, true}) {
       bool success_ref = false;
       // Reference implementation

--- a/include/fbgemm/Fbgemm.h
+++ b/include/fbgemm/Fbgemm.h
@@ -161,11 +161,7 @@ class PackMatrix {
    * @brief Actual packing of a block of the source matrix in pmat buffer.
    */
   void pack(const block_type_t& block) {
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
     static_cast<PT*>(this)->pack(block);
-#else
-    throw std::runtime_error("PackMatrix::pack() not implemented for aarch64");
-#endif // __aarch64__
   }
 
   std::int32_t numRows() const {
@@ -616,11 +612,9 @@ class FBGEMM_API PackWeightsForConv {
     return W_im2col_packed_;
   }
 
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
   std::shared_ptr<PackedDepthWiseConvMatrix> getPackedWForDepthwise() {
     return W_dw_packed_;
   }
-#endif // __aarch64__
 
   std::shared_ptr<PackedDirectConvMatrix> getPackedWForDirectconv() {
     return W_dc_packed_;
@@ -672,10 +666,8 @@ class FBGEMM_API PackWeightsForConv {
   const conv_param_t<SPATIAL_DIM> conv_param_;
   // Packed weights if we use im2col based convolution implementation
   std::shared_ptr<PackBMatrix<T, accT>> W_im2col_packed_;
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
   // Packed weights if we use depthwise convolution implementation
   std::shared_ptr<PackedDepthWiseConvMatrix> W_dw_packed_;
-#endif // __aarch64__
   // Packed weights if we use direct convolution implementation
   std::shared_ptr<PackedDirectConvMatrix> W_dc_packed_;
   // Packed weights if we use groupwise (small channels per group) convolution

--- a/src/Fbgemm.cc
+++ b/src/Fbgemm.cc
@@ -203,6 +203,8 @@ void fbgemmPacked(
 
 template <int SPATIAL_DIM>
 bool fbgemmOptimizedGConv(const conv_param_t<SPATIAL_DIM>& conv_p) {
+#if defined(__x86_64__) || defined(__i386__) || \
+    (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86)))
   if constexpr (SPATIAL_DIM == 1)
     return false;
 
@@ -255,6 +257,9 @@ bool fbgemmOptimizedGConv(const conv_param_t<SPATIAL_DIM>& conv_p) {
              return areEqual(std::forward<decltype(PH1)>(PH1), 2);
            })) &&
       !conv_p.transposed;
+#else
+  return false;
+#endif
 }
 
 template FBGEMM_API bool fbgemmOptimizedGConv(const conv_param_t<1>& conv_p);

--- a/src/FbgemmI8DepthwiseAvx2-inl.h
+++ b/src/FbgemmI8DepthwiseAvx2-inl.h
@@ -13,7 +13,8 @@
 #include <cmath> // for lrintf and sqrt
 #include <cstdint>
 #include <type_traits> // for is_same
-
+#include "RefImplementations.h"
+#include "fbgemm/Fbgemm.h"
 #if defined(__x86_64__) || defined(__i386__) || \
     (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86)))
 #include <immintrin.h>

--- a/src/PackWeightsForConv.cc
+++ b/src/PackWeightsForConv.cc
@@ -7,11 +7,11 @@
  */
 
 #define FBGEMM_EXPORTS
-#include "fbgemm/Fbgemm.h"
-
 #include <algorithm>
 #include <memory>
 #include <utility>
+#include "RefImplementations.h"
+#include "fbgemm/Fbgemm.h"
 
 namespace fbgemm {
 
@@ -25,17 +25,12 @@ PackWeightsForConv<SPATIAL_DIM, T, accT>::PackWeightsForConv(
   // FbgemmConv.cc
   switch (ConvFastPath<SPATIAL_DIM, accT>(conv_p)) {
     case optimized_conv_t::depthwise: {
-#if !defined(FBGEMM_FBCODE) && defined(__aarch64__)
-      throw std::runtime_error(
-          "PackWeightsForConv<SPATIAL_DIM, T, accT>::PackWeightsForConv(): No fallback available for aarch64");
-#else
       const int kernel_d = SPATIAL_DIM <= 2 ? 1 : conv_p.K[0];
       const int kernel_h = SPATIAL_DIM == 1 ? 1 : conv_p.K[SPATIAL_DIM - 2];
       const int kernel_w = conv_p.K[SPATIAL_DIM - 1];
       W_dw_packed_ = std::make_shared<PackedDepthWiseConvMatrix>(
           conv_p.OC, kernel_d * kernel_h * kernel_w, sdata);
       break;
-#endif // __aarch64__
     }
     case optimized_conv_t::groupwise: {
       W_gconv_packed_ =
@@ -61,17 +56,12 @@ PackWeightsForConv<SPATIAL_DIM, T, accT>::PackWeightsForConv(
       break;
     }
     case optimized_conv_t::directconv: {
-#if !defined(FBGEMM_FBCODE) && defined(__aarch64__)
-      throw std::runtime_error(
-          "PackWeightsForConv<SPATIAL_DIM, T, accT>::PackWeightsForConv(): No fallback available for aarch64");
-#else
       const int kernel_h = SPATIAL_DIM == 1 ? 1 : conv_p.K[SPATIAL_DIM - 2];
       const int kernel_w = conv_p.K[SPATIAL_DIM - 1];
       const int K = kernel_h * kernel_w;
       W_dc_packed_ = std::make_shared<PackedDirectConvMatrix>(
           conv_p.IC, conv_p.OC, K, sdata);
       break;
-#endif
     }
     case optimized_conv_t::fastpath1d: {
       break;
@@ -98,20 +88,17 @@ PackWeightsForConv<SPATIAL_DIM, T, accT>::PackWeightsForConv(
 
 template <int SPATIAL_DIM, typename T, typename accT>
 void PackWeightsForConv<SPATIAL_DIM, T, accT>::unpack(T* origin_buf) {
-#if defined(FBGEMM_FBCODE) || !defined(__aarch64__)
   if (W_dw_packed_) {
     W_dw_packed_->unpack(origin_buf);
-  } else
-#endif // __aarch64__
-    if (W_gconv_packed_) {
-      W_gconv_packed_->unpack(origin_buf);
-    } else if (W_im2col_packed_) {
-      W_im2col_packed_->unpack(origin_buf);
-    } else if (W_pointwise_packed_) {
-      W_pointwise_packed_->unpack(origin_buf);
-    } else {
-      assert(false && "At least one packed weights object should exist");
-    }
+  } else if (W_gconv_packed_) {
+    W_gconv_packed_->unpack(origin_buf);
+  } else if (W_im2col_packed_) {
+    W_im2col_packed_->unpack(origin_buf);
+  } else if (W_pointwise_packed_) {
+    W_pointwise_packed_->unpack(origin_buf);
+  } else {
+    assert(false && "At least one packed weights object should exist");
+  }
 }
 
 template <int SPATIAL_DIM, typename T, typename accT>

--- a/test/I8DirectconvTest.cc
+++ b/test/I8DirectconvTest.cc
@@ -108,6 +108,7 @@ static void transposeConvWeights_KwIchO8I4(
   }
 }
 
+#if 0
 static void col_offsets_with_zero_pt_s8acc32_DirectConvT_ref(
     const conv_param_t<2>& conv_p,
     const int8_t* Bint8,
@@ -159,6 +160,7 @@ static void col_offsets_with_zero_pt_s8acc32_DirectConvT_ref(
     }
   }
 }
+#endif
 
 /*
 
@@ -532,16 +534,21 @@ TEST_P(FBGemmDirectConvTransTest, Test2D) {
 
     // computing column offset
     vector<int32_t> col_offsetsT(conv_p.OC * MDim);
-    for (int g = 0; g < conv_p.G; ++g) {
-      col_offsets_with_zero_pt_s8acc32_DirectConvT_ref(
-          conv_p,
-          Bint8_tr_vec.data() + g * KDimPerGroup * OC_per_G,
-          Bint8_zero_point.data(),
-          col_offsetsT.data() + g * OC_per_G,
-          conv_p.OC);
-    }
+    // for (int g = 0; g < conv_p.G; ++g) {
+    //   col_offsets_with_zero_pt_s8acc32_DirectConvT_ref(
+    //       conv_p,
+    //       Bint8_tr_vec.data() + g * KDimPerGroup * OC_per_G,
+    //       Bint8_zero_point.data(),
+    //       col_offsetsT.data() + g * OC_per_G,
+    //       conv_p.OC);
+    // }
 
     PackedDirectConvMatrix packedB(conv_p.IC, conv_p.OC, kernel_dim, Bint8.data());
+    packedB.col_offsets_with_zero_pt_s8acc32_DirectConvT(
+          conv_p,
+          Bint8_zero_point.data(),
+          col_offsetsT,
+          conv_p.OC);
 
     DoNothing<> doNothingObj{};
     ReQuantizeOutput<false, QuantizationGranularity::TENSOR> outputProcObj(

--- a/test/UniConvTest.cc
+++ b/test/UniConvTest.cc
@@ -751,6 +751,9 @@ static void runRequantizeTest(
     // conv_ref expects weights to be in G (R S C/G) K/G
     transposeConvWeights(conv_p, Bint8.data(), Bint8_tr.data());
     int8_t* rightBData = Bint8_tr.data();
+    conv_ref(
+        conv_p, Aint8.data(), Aint8_zero_point, rightBData, Cint32_ref.data());
+
     for (int g = 0; g < G; ++g) {
       col_offsets_with_zero_pt_s8acc32_ref(
           R * S * IC_per_G,
@@ -760,11 +763,7 @@ static void runRequantizeTest(
           Bint8_zero_point.data() + g * OC_per_G / ncols_per_quant_group,
           col_offsets.data() + g * OC_per_G,
           ncols_per_quant_group);
-    }
-    conv_ref(
-        conv_p, Aint8.data(), Aint8_zero_point, rightBData, Cint32_ref.data());
 
-    for (int g = 0; g < G; ++g) {
       row_offsets_u8acc32_ref(
           MDim,
           KDim,


### PR DESCRIPTION
Summary:
This diff adds convolution support to arm64 fbgemm by reusing existing reference implementations.
1. Introduced conv_requant_ref that invokes the reference conv_ref and requantize_u8acc32_ref and added it in places where only x86 conv implementations are available.
2. Changed weights matrix packing to basically do nothing or call transposeConvWeights.

This diff unblocks fbgemm users' convolution code on Arm64. We plan to add follow-up diffs to optimize each kind of convolution (e.g., depthwise, directconv, etc.)

Differential Revision: D86548699


