### PR TITLE
Extend raw_id_tracker to track ShardedManagedCollisionEmbeddingCollection

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -710,6 +710,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             f"Feature Gates: {[(feature.name, feature.is_enabled()) for feature in FeatureGateName]}"
         )
 
+        self.table_names: Optional[list[str]] = table_names
         self.logging_table_name: str = self.get_table_name_for_logging(table_names)
         self.enable_raw_embedding_streaming: bool = enable_raw_embedding_streaming
         self.pooling_mode = pooling_mode


### PR DESCRIPTION
Summary: This diff extends `raw_id_tracker` to support both `ShardedManagedCollisionEmbeddingCollection` and `ShardedManagedCollisionEmbeddingBagCollection`. To avoid code duplication, the diff refactors the initialization and identity parsing logic into the `BaseEmbedding` class.

Differential Revision: D87018676


