### PR TITLE
Add table_names as a instance variable of SplitTableBatchedEmbeddingBagsCodegen

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -710,6 +710,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             f"Feature Gates: {[(feature.name, feature.is_enabled()) for feature in FeatureGateName]}"
         )
 
+        self.table_names: Optional[list[str]] = table_names
         self.logging_table_name: str = self.get_table_name_for_logging(table_names)
         self.enable_raw_embedding_streaming: bool = enable_raw_embedding_streaming
         self.pooling_mode = pooling_mode


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2135

`table_names` is required for raw embedded streaming to support tracking in mpzch modules.

Example usage in embedding module to look up raw ids
```
        assert hasattr(
            self.emb_module, "res_params"
        ), "res_params should exist when raw_id_tracker is enabled"
        res_params: RESParams = self.emb_module.res_params  # pyre-ignore[9]
        table_names = res_params.table_names
        raw_ids_dict = raw_id_tracker_wrapper.get_indexed_lookups(
            table_names, self.emb_module.uuid
        )
```
`table_names` only exist when raw embedded streaming is enabled.

During testing, we may disable raw embedded streaming (hence no `res_params`) this tight coupling makes testing difficult. This diff adds `table_names` as a instance variable of `SplitTableBatchedEmbeddingBagsCodegen` so we can easily retrieve `table_names` w/o depending on raw embedded streaming.

Differential Revision: D87089649


