### PR TITLE
Support Blackwell CUTLASS attention kernels in torch.compile

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_gen_impl.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/blackwell_gen_impl.cu
@@ -310,6 +310,16 @@ at::Tensor dispatch_fmha_gen_fwd(
   });
 }
 
+at::Tensor dispatch_fmha_gen_fwd_meta(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& seqlen_kv,
+    const std::optional<at::Tensor>& batch_idx,
+    int64_t kernel_type
+  ) {
+  return at::empty_like(q);
+}
 
 // -------------------------------------------------------------------------------------------------
 // Op registration
@@ -328,5 +338,8 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
 
 TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   m.impl("fmha_gen_fwd", dispatch_fmha_gen_fwd);
+}
+TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
+  m.impl("fmha_gen_fwd", dispatch_fmha_gen_fwd_meta);
 }
 #endif // CUTLASS_ARCH_MMA_SM100_SUPPORTED


### PR DESCRIPTION
Summary: Support the fbgemm Blackwell CUTLASS attention kernel in torch.compile by adding a C++-side meta function.

Reviewed By: henrylhtsang

Differential Revision: D86986981


