### PR TITLE
Add hash_zch_identities to SplitTableBatchedEmbeddingBagsCodegen forward

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -2054,6 +2054,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         feature_requires_grad: Optional[Tensor] = None,
         batch_size_per_feature_per_rank: Optional[list[list[int]]] = None,
         total_unique_indices: Optional[int] = None,
+        hash_zch_identities: Optional[Tensor] = None,
     ) -> Tensor:
         """
         The forward pass function that
@@ -2235,7 +2236,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 offsets,
                 vbe_metadata,
                 multipass_prefetch_config=None,
-                hash_zch_identities=None,
+                hash_zch_identities=hash_zch_identities,
             )
 
         if len(self.timesteps_prefetched) > 0:

--- a/fbgemm_gpu/test/tbe/training/forward_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_test.py
@@ -351,12 +351,22 @@ class ForwardTest(unittest.TestCase):
 
         batch_size_per_feature_per_rank = Bs_rank_feature if mixed_B else None
 
+        hash_zch_identities = to_device(
+            torch.randint(
+                low=0,
+                high=E * 10,  # The upper-bound doesn't matter
+                size=(B * T * L,),  # Matches dimension 0 of indices
+                dtype=torch.int64,
+            ),
+            use_cpu,
+        )
         # Run TBE
         fc2 = (
             cc(
                 indices,
                 offsets,
                 batch_size_per_feature_per_rank=batch_size_per_feature_per_rank,
+                hash_zch_identities=hash_zch_identities,
             )
             if not weighted
             else cc(
@@ -364,6 +374,7 @@ class ForwardTest(unittest.TestCase):
                 offsets,
                 to_device(xw.contiguous().view(-1), use_cpu),
                 batch_size_per_feature_per_rank=batch_size_per_feature_per_rank,
+                hash_zch_identities=hash_zch_identities,
             )
         )
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2143

We need the signature change in tbe for hash_zch_identities tracking to work e2e https://fburl.com/mlhub/gj74u04u 
```
  File "/dev/shm/uid-99/0e23d97f-seed-nspid4026559588_cgpid7415242-ns-4026559309/torchrec/distributed/embedding_lookup.py", line 710, in forward
    lookup = emb_op(features)
  File "/dev/shm/uid-99/0e23d97f-seed-nspid4026559588_cgpid7415242-ns-4026559309/torch/nn/modules/module.py", line 1783, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/dev/shm/uid-99/0e23d97f-seed-nspid4026559588_cgpid7415242-ns-4026559309/torch/nn/modules/module.py", line 1794, in _call_impl
    return forward_call(*args, **kwargs)
  File "/dev/shm/uid-99/0e23d97f-seed-nspid4026559588_cgpid7415242-ns-4026559309/torchrec/distributed/batched_embedding_kernel.py", line 2695, in forward
    return self.emb_module(
  File "/dev/shm/uid-99/0e23d97f-seed-nspid4026559588_cgpid7415242-ns-4026559309/torch/nn/modules/module.py", line 1783, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/dev/shm/uid-99/0e23d97f-seed-nspid4026559588_cgpid7415242-ns-4026559309/torch/nn/modules/module.py", line 1889, in _call_impl
    return inner()
  File "/dev/shm/uid-99/0e23d97f-seed-nspid4026559588_cgpid7415242-ns-4026559309/torch/nn/modules/module.py", line 1837, in inner
    result = forward_call(*args, **kwargs)
TypeError: SplitTableBatchedEmbeddingBagsCodegen.forward() got an unexpected keyword argument 'hash_zch_identities'
```

Reviewed By: chouxi

Differential Revision: D87244481


