### PR TITLE
shortcut for merge_pooled_embedding

### DIFF
--- a/fbgemm_gpu/src/merge_pooled_embedding_ops/merge_pooled_embedding_ops_gpu.cpp
+++ b/fbgemm_gpu/src/merge_pooled_embedding_ops/merge_pooled_embedding_ops_gpu.cpp
@@ -688,6 +688,20 @@ Tensor merge_pooled_embeddings(
   at::cuda::OptionalCUDAGuard g;
 
   at::Device out_device = target_device;
+
+  // if target_device is the same as input devices, we can directly call
+  // cat
+  bool is_same_device = true;
+  for (const auto& t : pooled_embeddings) {
+    if (t.device() != target_device) {
+      is_same_device = false;
+      break;
+    }
+  }
+  if (is_same_device) {
+    return at::cat(pooled_embeddings, cat_dim);
+  }
+
   if (target_device.is_cuda()) {
     init_p2p_access();
     g.set_device(target_device);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2146

att. When all the input embedding are from the same device, we can just use cat as a short cut. This can avoid unnecessary cross device sync with current impl.

Differential Revision: D87306514


