### PR TITLE
Compilation flag for pytorch

### DIFF
--- a/cmake/modules/CppLibrary.cmake
+++ b/cmake/modules/CppLibrary.cmake
@@ -104,7 +104,8 @@ function(cpp_library)
             -Wno-sign-compare
             -Wno-vla
             -Wno-error=unused-parameter
-            -Wno-error=attributes)
+            -Wno-error=attributes
+            -Wno-tautological-compare)
 
         if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
             list(APPEND lib_cc_flags


### PR DESCRIPTION
Summary:
Example build failure: 
```
/home/danielsjohnson/oss_pytorch/pytorch/third_party/fbgemm/external/asmjit/src/asmjit/core/../core/../core/../core/globals.h:96:62: error: bitwise comparison always evaluates to false [-Werror=tautological-compare]
     96 | static constexpr uint32_t kMaxTreeHeight = (ASMJIT_ARCH_BITS == 32 ? 30 : 61) + 1;
        |                                             ~~~~~~~~~~~~~~~~ ^~ ~~
  cc1plus: all warnings being treated as errors
```

Differential Revision: D88427233


