### PR TITLE
Optimizing 4-bit dequant to FP32 on AArch64 using vectorized intrinsics in EmbeddingSpMDMAutovec

### DIFF
--- a/src/EmbeddingSpMDMAutovec.cc
+++ b/src/EmbeddingSpMDMAutovec.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -20,6 +21,10 @@
 #include <arm_sve.h>
 
 #include <arm_neon_sve_bridge.h>
+#endif
+
+#if defined(__ARM_NEON)
+#include <arm_neon.h>
 #endif
 
 #include <cmath>
@@ -115,6 +120,117 @@ static inline void fillZero(float* ptr, int64_t count) {
   }
 #endif
 }
+
+#if defined(__ARM_NEON)
+namespace {
+  // Internal constant table for AArch64 vectorized table lookup
+  static constexpr uint8x16_t idx[] = {
+    // Precompute table indices for packing 4 uint8 per uint32x4 (zeros in between lanes)
+    // idx0: select bytes 0-3 → positions 0,4,8,12
+    {
+        0, 255, 255, 255,   // byte 0 to lane 0
+        1, 255, 255, 255,   // byte 1 to lane 4
+        2, 255, 255, 255,   // byte 2 to lane 8
+        3, 255, 255, 255    // byte 3 to lane 12
+    },
+    // idx1: bytes 4-7
+    {
+        4, 255, 255, 255,
+        5, 255, 255, 255,
+        6, 255, 255, 255,
+        7, 255, 255, 255
+    },
+    // idx2: bytes 8-11
+    {
+        8, 255, 255, 255,
+        9, 255, 255, 255,
+        10, 255, 255, 255,
+        11, 255, 255, 255
+    },
+    // idx3: bytes 12-15
+    {
+        12, 255, 255, 255,
+        13, 255, 255, 255,
+        14, 255, 255, 255,
+        15, 255, 255, 255
+    }
+  };
+}
+
+// 4-bit dequant (vectorized AArch64 path)
+// Processes 16 input bytes -> 32 FP32 outputs per iteration
+// -----------------------------
+static ALWAYS_INLINE void Dequant4bitToF32_neon(
+    const uint8_t* input_row,
+    float* buf,
+    const int block_size,
+    const float scale,
+    const float bias,
+    int64_t offset) {
+  if (block_size >= 32) {
+    // Main vectorized loop: processes 32 floats per iteration (16 input bytes) using table lookup for nibble packing
+    const int64_t vec_end = (block_size / 32) * 32;
+    // Broadcast scale and bias to vectors
+    const float32x4_t vscale = vdupq_n_f32(scale);
+    const float32x4_t vbias = vdupq_n_f32(bias);
+
+    // tbl_low_res/tbl_high_res: table lookup result for low/high nibbles
+    // q_u32  : reinterpret as u32 lanes
+    // q_f32  : converted quant values (float)
+    // buf_tmp: buffer chunk for FMA
+    uint8x16_t tbl_low_res[4];
+    uint8x16_t tbl_high_res[4];
+    uint32x4_t q_u32[8];
+    float32x4_t q_f32[8];
+    float32x4_t buf_tmp[8];
+
+    const uint8x16_t vmask = vdupq_n_u8(0x0F);
+
+    for (; offset < vec_end; offset += 32) {
+        // Load 16 input bytes (two 4-bit values per byte)
+        const uint8x16_t bytes = vld1q_u8(input_row);
+        input_row += 16;
+
+        // Extract low 4-bit nibbles (0x0F mask)
+        const uint8x16_t low_nibs_tmp = vandq_u8(bytes, vmask);
+        // Extract high 4-bit nibbles (>>4)
+        const uint8x16_t high_nibs_tmp = vshrq_n_u8(bytes, 4);
+        // Interleave high/low nibbles for correct line mapping
+        const uint8x16_t low_nibs  = vzip1q_u8(low_nibs_tmp, high_nibs_tmp);
+        const uint8x16_t high_nibs = vzip2q_u8(low_nibs_tmp, high_nibs_tmp);
+
+        // Table lookup -> u32 view -> f32 convert (low/high)
+        for (int i=0; i < 4; i++) {
+          tbl_low_res[i] = vqtbl1q_u8(low_nibs, idx[i]);
+          q_u32[i] = vreinterpretq_u32_u8(tbl_low_res[i]);
+          q_f32[i] = vcvtq_f32_u32(q_u32[i]);
+
+          tbl_high_res[i] = vqtbl1q_u8(high_nibs, idx[i]);
+          q_u32[i + 4] = vreinterpretq_u32_u8(tbl_high_res[i]);
+          q_f32[i + 4] = vcvtq_f32_u32(q_u32[i + 4]);
+        }
+
+        for (int i=0; i < 8; i++) {
+          // Load corresponding buf sections (32 floats = 8x4)
+          buf_tmp[i] = vld1q_f32(buf + offset + i * 4);
+          // FMA: buf + bias + scale * quantized
+          buf_tmp[i]  = vfmaq_f32(vaddq_f32(buf_tmp[i], vbias), vscale, q_f32[i]);
+          // Store back to buf
+          vst1q_f32(buf + offset + i * 4, buf_tmp[i]);
+        }
+    }
+  }
+
+  // Scalar tail: handle remaining elements (<32 floats)
+  for (; offset < block_size; offset += 2) {
+      uint8_t tmp = *input_row++;
+      float quantized1 = float(tmp & 0xf);
+      float quantized2 = float(tmp >> 4);
+      buf[offset] = std::fma(scale, quantized1, buf[offset] + bias);
+      buf[offset + 1] = std::fma(scale, quantized2, buf[offset + 1] + bias);
+  }
+}
+#endif
 
 template <typename OutType>
 static inline EmbeddingStatsTracker::DataType get_output_type(
@@ -483,6 +599,9 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
           buf[j + 1] = std::fma(scale, quantized2, buf[j + 1] + bias);
         }
 #endif
+#if defined(__ARM_NEON)
+        Dequant4bitToF32_neon(input_row, buf, block_size, scale, bias, j);
+#else
         for (; j < block_size; j += 2) {
           uint8_t tmp = *input_row++;
           float quantized1 = float(tmp & 0xf);
@@ -490,6 +609,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
           buf[j] = std::fma(scale, quantized1, buf[j] + bias);
           buf[j + 1] = std::fma(scale, quantized2, buf[j + 1] + bias);
         }
+#endif
       } else if (input_bit_rate == 2) {
         int64_t j = 0;
 #ifdef FBGEMM_VECTOR_WIDTH

--- a/src/EmbeddingSpMDMAutovec.cc
+++ b/src/EmbeddingSpMDMAutovec.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -21,6 +22,10 @@
 #include <arm_sve.h>
 
 #include <arm_neon_sve_bridge.h>
+#endif
+
+#if defined(__ARM_NEON)
+#include <arm_neon.h>
 #endif
 
 #include <cmath>
@@ -128,6 +133,117 @@ static inline void fillZero(float* ptr, int64_t count) {
   }
 #endif
 }
+
+#if defined(__ARM_NEON)
+namespace {
+  // Internal constant table for AArch64 vectorized table lookup
+  static constexpr uint8x16_t idx[] = {
+    // Precompute table indices for packing 4 uint8 per uint32x4 (zeros in between lanes)
+    // idx0: select bytes 0-3 → positions 0,4,8,12
+    {
+        0, 255, 255, 255,   // byte 0 to lane 0
+        1, 255, 255, 255,   // byte 1 to lane 4
+        2, 255, 255, 255,   // byte 2 to lane 8
+        3, 255, 255, 255    // byte 3 to lane 12
+    },
+    // idx1: bytes 4-7
+    {
+        4, 255, 255, 255,
+        5, 255, 255, 255,
+        6, 255, 255, 255,
+        7, 255, 255, 255
+    },
+    // idx2: bytes 8-11
+    {
+        8, 255, 255, 255,
+        9, 255, 255, 255,
+        10, 255, 255, 255,
+        11, 255, 255, 255
+    },
+    // idx3: bytes 12-15
+    {
+        12, 255, 255, 255,
+        13, 255, 255, 255,
+        14, 255, 255, 255,
+        15, 255, 255, 255
+    }
+  };
+}
+
+// 4-bit dequant (vectorized AArch64 path)
+// Processes 16 input bytes -> 32 FP32 outputs per iteration
+// -----------------------------
+static ALWAYS_INLINE void Dequant4bitToF32_neon(
+    const uint8_t* input_row,
+    float* buf,
+    const int block_size,
+    const float scale,
+    const float bias,
+    int64_t offset) {
+  if (block_size >= 32) {
+    // Main vectorized loop: processes 32 floats per iteration (16 input bytes) using table lookup for nibble packing
+    const int64_t vec_end = (block_size / 32) * 32;
+    // Broadcast scale and bias to vectors
+    const float32x4_t vscale = vdupq_n_f32(scale);
+    const float32x4_t vbias = vdupq_n_f32(bias);
+
+    // tbl_low_res/tbl_high_res: table lookup result for low/high nibbles
+    // q_u32  : reinterpret as u32 lanes
+    // q_f32  : converted quant values (float)
+    // buf_tmp: buffer chunk for FMA
+    uint8x16_t tbl_low_res[4];
+    uint8x16_t tbl_high_res[4];
+    uint32x4_t q_u32[8];
+    float32x4_t q_f32[8];
+    float32x4_t buf_tmp[8];
+
+    const uint8x16_t vmask = vdupq_n_u8(0x0F);
+
+    for (; offset < vec_end; offset += 32) {
+        // Load 16 input bytes (two 4-bit values per byte)
+        const uint8x16_t bytes = vld1q_u8(input_row);
+        input_row += 16;
+
+        // Extract low 4-bit nibbles (0x0F mask)
+        const uint8x16_t low_nibs_tmp = vandq_u8(bytes, vmask);
+        // Extract high 4-bit nibbles (>>4)
+        const uint8x16_t high_nibs_tmp = vshrq_n_u8(bytes, 4);
+        // Interleave high/low nibbles for correct line mapping
+        const uint8x16_t low_nibs  = vzip1q_u8(low_nibs_tmp, high_nibs_tmp);
+        const uint8x16_t high_nibs = vzip2q_u8(low_nibs_tmp, high_nibs_tmp);
+
+        // Table lookup -> u32 view -> f32 convert (low/high)
+        for (int i=0; i < 4; i++) {
+          tbl_low_res[i] = vqtbl1q_u8(low_nibs, idx[i]);
+          q_u32[i] = vreinterpretq_u32_u8(tbl_low_res[i]);
+          q_f32[i] = vcvtq_f32_u32(q_u32[i]);
+
+          tbl_high_res[i] = vqtbl1q_u8(high_nibs, idx[i]);
+          q_u32[i + 4] = vreinterpretq_u32_u8(tbl_high_res[i]);
+          q_f32[i + 4] = vcvtq_f32_u32(q_u32[i + 4]);
+        }
+
+        for (int i=0; i < 8; i++) {
+          // Load corresponding buf sections (32 floats = 8x4)
+          buf_tmp[i] = vld1q_f32(buf + offset + i * 4);
+          // FMA: buf + bias + scale * quantized
+          buf_tmp[i]  = vfmaq_f32(vaddq_f32(buf_tmp[i], vbias), vscale, q_f32[i]);
+          // Store back to buf
+          vst1q_f32(buf + offset + i * 4, buf_tmp[i]);
+        }
+    }
+  }
+
+  // Scalar tail: handle remaining elements (<32 floats)
+  for (; offset < block_size; offset += 2) {
+      uint8_t tmp = *input_row++;
+      float quantized1 = float(tmp & 0xf);
+      float quantized2 = float(tmp >> 4);
+      buf[offset] = std::fma(scale, quantized1, buf[offset] + bias);
+      buf[offset + 1] = std::fma(scale, quantized2, buf[offset + 1] + bias);
+  }
+}
+#endif
 
 template <typename OutType>
 static constexpr EmbeddingStatsTracker::DataType get_output_type(
@@ -520,6 +636,9 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
           buf[j + 1] = std::fma(scale, quantized2, buf[j + 1] + bias);
         }
 #endif
+#if defined(__ARM_NEON)
+        Dequant4bitToF32_neon(input_row, buf, block_size, scale, bias, j);
+#else
         for (; j < block_size; j += 2) {
           uint8_t tmp = *input_row++;
           float quantized1 = float(tmp & 0xf);
@@ -527,6 +646,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
           buf[j] = std::fma(scale, quantized1, buf[j] + bias);
           buf[j + 1] = std::fma(scale, quantized2, buf[j + 1] + bias);
         }
+#endif
       } else if (input_bit_rate == 2) {
         int64_t j = 0;
 #ifdef FBGEMM_VECTOR_WIDTH


### PR DESCRIPTION
This patch introduces an AArch64 vectorized optimization for the 4‑bit dequantization path in `EmbeddingSpMDMAutovec.cc`. The previous implementation processes one byte at a time (each byte contains two nibbles). The new path uses AArch64 vector intrinsics to process 16 bytes per iteration, yielding 32 FP32 outputs.

`EmbeddingSpMDMNBitBenchmark`(4-bit cases) shows up to 47% improvement on AArch64

Test environment: AWS r8g.4xlarge (Graviton4) instance; compiler: gcc 14.3.0

Example benchmark results:
Before:

bit_rate 4 batch size 10 num rows 4000000 emb dim 256 avg length 100
32 bit indices	lengths_sum 898										
out type fp32                               SLS    cache not flushed     prefetch off	b/w    2.15088	GB/s	effective b/w	3.12855	GB/s	time	5.51E-05
out type fp32	                             SLS     cache flushed            prefetch off	b/w    1.97542	GB/s	effective b/w	2.87335	GB/s	time	6.00E-05
out type fp32    SLW(WEIGHTED)     cache not flushed	  prefetch off	b/w    2.14381     GB/s	effective b/w	3.11827	GB/s	time	5.53E-05
out type fp32    SLW(WEIGHTED)     cache flushed	          prefetch off	b/w    1.9467	    GB/s	effective b/w	2.83157	GB/s	time	6.09E-05

After:

bit_rate 4 batch size 10 num rows 4000000 emb dim 256 avg length 100
32 bit indices	lengths_sum 898	
out type fp32	                            SLS    cache not flushed     prefetch off     b/w	3.18089	 GB/s	 effective b/w	4.62675	 GB/s	 time	3.73E-05
out type fp32	                            SLS	 cache flushed	        prefetch off     b/w	2.75099	 GB/s	 effective b/w	4.00144	 GB/s	 time	4.31E-05
out type fp32    SLW(WEIGHTED)   cache not flushed    prefetch off     b/w	3.15288	 GB/s	 effective b/w	4.58601	 GB/s	 time	3.76E-05
out type fp32    SLW(WEIGHTED)   cache flushed	        prefetch off     b/w	2.67149	 GB/s	 effective b/w	3.8858	     GB/s	 time	4.44E-05
