### PR TITLE
Add Tensor overload for jagged_to_padded_dense max_lengths

### DIFF
--- a/.github/scripts/fbgemm_gpu_test.bash
+++ b/.github/scripts/fbgemm_gpu_test.bash
@@ -340,7 +340,15 @@ __determine_test_directories () {
   echo ""
 }
 
-__test_fbgemm_gpu_common_pre_steps () {
+fbgemm_gpu_testing_setup () {
+  env_name="$1"
+  if [ "$env_name" == "" ]; then
+    echo "Usage: ${FUNCNAME[0]} ENV_NAME"
+    echo "Example(s):"
+    echo "    ${FUNCNAME[0]} build_env        # Run test setup for FBGEMM_GPU"
+    return 1
+  fi
+
   # shellcheck disable=SC2155
   local env_prefix=$(env_name_or_prefix "${env_name}")
 
@@ -402,13 +410,13 @@ test_all_fbgemm_gpu_modules () {
     repo=$(pwd)
   fi
 
-  __test_fbgemm_gpu_common_pre_steps  || return 1
+  fbgemm_gpu_testing_setup "$env_name"  || return 1
 
   # Go to the repo root directory
-  print_exec pushd "${repo}"          || return 1
+  print_exec pushd "${repo}"            || return 1
 
   # Determine the test directories to include for testing
-  __determine_test_directories        || return 1
+  __determine_test_directories          || return 1
 
   # Iterate through the test directories and run bulk tests
   for test_dir in "${target_directories[@]}"; do

--- a/ci/integration/fbgemm_gpu_oss_build.bash
+++ b/ci/integration/fbgemm_gpu_oss_build.bash
@@ -28,7 +28,7 @@ else
   echo "[FBGEMM_GPU CI] Invalid build variant: $BUILD_VARIANT"
   exit 1
 fi
-BUILD_ENV=${BUILD_ENV:-"build-py${PYTHON_VERSION}-torch${PYTORCH_VERSION}-${BUILD_VARIANT}${BUILD_VARIANT_VERSION}"}
+BUILD_ENV=${BUILD_ENV:-"build-py${PYTHON_VERSION}-torch${PYTORCH_VERSION//\//-}-${BUILD_VARIANT}${BUILD_VARIANT_VERSION}"}
 
 echo "################################################################################"
 echo "# FBGEMM_GPU OSS Build and Install"
@@ -75,8 +75,18 @@ integration_setup_conda_environment "$BUILD_ENV" gcc "$PYTHON_VERSION" "$PYTORCH
 echo "[FBGEMM_GPU CI] Building the package ..."
 integration_fbgemm_gpu_build_and_install "$BUILD_ENV" "$BUILD_TARGET/$BUILD_VARIANT" "$REPO_ROOT" || exit 1
 
+# Run checks and update the Conda environment to support FBGEMM testing
+echo "[FBGEMM_GPU CI] Updating the conda environment to support testing ..."
+fbgemm_gpu_testing_setup "$BUILD_ENV" || exit 1
+
 echo "[FBGEMM_GPU CI] Exporting the build environment name ..."
 export CURRENT_FBGEMM_BUILD_ENV="$BUILD_ENV"
 
-echo ""
 echo "[FBGEMM_GPU CI] Package is now installed into $BUILD_ENV"
+echo ""
+echo ""
+echo "################################################################################"
+echo "#"
+echo "# FBGEMM_GPU package build and install has successfully completed!"
+echo "#"
+echo "################################################################################"

--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_host_cpu.cpp
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_host_cpu.cpp
@@ -519,8 +519,7 @@ class AtomicCounter : public torch::jit::CustomClassHolder {
   }
 
   std::tuple<std::tuple<std::string, int64_t>> __obj_flatten__() {
-    return std::make_tuple(
-        std::make_tuple(std::string("counter_"), counter_.load()));
+    return std::tuple{std::tuple{std::string("counter_"), counter_.load()}};
   }
 
   std::string serialize() const {
@@ -625,9 +624,9 @@ struct TensorQueue : torch::CustomClassHolder {
     for (const auto& val : queue_) {
       queue_vec.emplace_back(val);
     }
-    return std::make_tuple(
-        std::make_tuple("init_tensor", init_tensor_),
-        std::make_tuple("queue", queue_vec));
+    return std::tuple{
+        std::tuple{"init_tensor", init_tensor_},
+        std::tuple{"queue", queue_vec}};
   }
 
  private:

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -1252,7 +1252,9 @@ Tensor {{ embedding_cuda_op }}(
                     constexpr bool supported_grad_type = std::is_same_v<grad_t, float> || std::is_same_v<grad_t, at::Half>;
                     const bool cached = uvm_weights.numel() > 0 || lxu_cache_weights.numel() > 0;
 
-                    if (use_hip_kernel && !mixed_D && !cached && supported_weights_type && supported_grad_type && rocm::is_supported_cdna())
+                    constexpr bool same_precision = std::is_same_v<emb_t, grad_t>;
+
+                    if (use_hip_kernel && !mixed_D && !cached && supported_weights_type && supported_grad_type && same_precision && rocm::is_supported_cdna())
                     {
                         constexpr int segments_per_workgroup = 4;
                         {%- for kDimSize in [64, 128, 160, 192, 256, 320] %}

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_cpu.cpp
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_cpu.cpp
@@ -462,8 +462,8 @@ void csr2csc_template_(
       for (const auto p : c10::irange(pool_begin, pool_end)) {
         tmpBufKeys[p - FBo] = csr_indices[p];
         if (IS_VALUE_PAIR) {
-          reinterpret_cast<pair_t*>(tmpBufValues)[p - FBo] = std::make_pair(
-              FBs + b, scale_factor * (has_weights ? csr_weights[p] : 1.0f));
+          reinterpret_cast<pair_t*>(tmpBufValues)[p - FBo] = std::pair{
+              FBs + b, scale_factor * (has_weights ? csr_weights[p] : 1.0f)};
         } else {
           reinterpret_cast<int*>(tmpBufValues)[p - FBo] = FBs + b;
         }

--- a/fbgemm_gpu/experimental/hstu/src/hstu_hopper/hstu_bwd_kernel.h
+++ b/fbgemm_gpu/experimental/hstu/src/hstu_hopper/hstu_bwd_kernel.h
@@ -230,12 +230,12 @@ __global__ void __launch_bounds__(
     if constexpr (Is_target) {
       m_block_max = is_jump ? m_masking_block_max : m_block_max;
     }
-    return std::make_tuple(
+    return std::tuple{
         m_block_min,
         m_block_max,
         m_masking_steps,
         is_in_context,
-        m_block_context);
+        m_block_context};
   };
 
   if (warp_group_idx == 0) { // Producer

--- a/fbgemm_gpu/experimental/hstu/src/hstu_hopper/hstu_fwd_kernel.h
+++ b/fbgemm_gpu/experimental/hstu/src/hstu_hopper/hstu_fwd_kernel.h
@@ -200,13 +200,13 @@ __global__ void __launch_bounds__(
     const int n_masking_steps = (!Is_causal || is_in_context)
         ? 0
         : n_masking_block_max - n_masking_block_min;
-    return std::make_tuple(
+    return std::tuple{
         n_block_max,
         n_block_min,
         n_masking_steps,
         is_jump,
         n_block_history,
-        actual_seqlen_q);
+        actual_seqlen_q};
   };
 
   static_assert(Ktraits::kNWarps == 12 || Ktraits::kNWarps == 16);

--- a/fbgemm_gpu/include/fbgemm_gpu/rocm/split_embeddings_common.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/rocm/split_embeddings_common.h
@@ -548,9 +548,9 @@ struct store_row_per_warp<float, 320> {
     llvm_amdgcn_raw_buffer_store_fp32(
         acc[2], out_res, (lane_id + 128) * sizeof(float));
     llvm_amdgcn_raw_buffer_store_fp32(
-        acc[4], out_res, (lane_id + 192) * sizeof(float));
+        acc[3], out_res, (lane_id + 192) * sizeof(float));
     llvm_amdgcn_raw_buffer_store_fp32(
-        acc[5], out_res, (lane_id + 256) * sizeof(float));
+        acc[4], out_res, (lane_id + 256) * sizeof(float));
   }
 };
 

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_utilities.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_utilities.cuh
@@ -33,7 +33,7 @@ inline auto get_compute_versions() {
     int driver_version = 0;
     cudaDriverGetVersion(&driver_version);
 
-    return std::make_tuple(runtime_version, driver_version);
+    return std::tuple{runtime_version, driver_version};
   }();
 
   return versions;

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/enum_utils.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/enum_utils.h
@@ -68,8 +68,7 @@ class enum_registration {
     enum_result result;
 
     for (auto next = registration_list; next != nullptr; next = next->next_) {
-      result.emplace_back(
-          std::make_tuple(std::string(next->name_), next->items_));
+      result.emplace_back(std::tuple{std::string(next->name_), next->items_});
     }
 
     return result;

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
@@ -197,28 +197,21 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
       int64_t start,
       int64_t end,
       std::optional<int64_t> offset = std::nullopt) override {
-    std::vector<std::vector<int64_t>> ids;
-    for (int i = 0; i < num_shards_; i++) {
-      ids.push_back(std::vector<int64_t>());
-    }
+    std::vector<std::vector<int64_t>> ids(num_shards_);
     std::vector<folly::Future<folly::Unit>> futures;
+    futures.reserve(num_shards_);
     for (int shard_id = 0; shard_id < num_shards_; shard_id++) {
-      auto f =
-          folly::via(executor_.get())
-              .thenValue([this, shard_id, start, end, offset, &ids](
-                             folly::Unit) {
-                auto rlmap = kv_store_.by(shard_id).rlock();
-                for (auto iter = rlmap->begin(); iter != rlmap->end(); iter++) {
-                  if (iter->first >= start && iter->first < end) {
-                    if (offset.has_value()) {
-                      ids[shard_id].push_back(iter->first - offset.value());
-                    } else {
-                      ids[shard_id].push_back(iter->first);
-                    }
-                  }
-                }
-              });
-      futures.push_back(std::move(f));
+      auto f = folly::via(executor_.get())
+                   .thenValue([this, shard_id, start, end, offset, &ids](
+                                  folly::Unit) {
+                     auto rlmap = kv_store_.by(shard_id).rlock();
+                     for (const auto& [key, value] : *rlmap) {
+                       if (key >= start && key < end) {
+                         ids[shard_id].push_back(offset ? key - *offset : key);
+                       }
+                     }
+                   });
+      futures.emplace_back(std::move(f));
     }
     folly::collect(futures).get();
 
@@ -252,11 +245,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
     auto shardid_to_indexes = shard_input(indices, count);
     read_metadata_sharding_total_duration_ +=
         facebook::WallClockUtil::NowInUsecFast() - before_shard_ts;
-    for (auto iter = shardid_to_indexes.begin();
-         iter != shardid_to_indexes.end();
-         iter++) {
-      const auto shard_id = iter->first;
-      const auto indexes = iter->second;
+    for (const auto& [shard_id, indexes] : shardid_to_indexes) {
       futures.emplace_back(
           folly::via(executor_.get())
               .thenValue([this, shard_id, indexes, &indices, &metadata_tensor](
@@ -287,10 +276,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                         local_read_aquire_lock_duration =
                             facebook::WallClockUtil::NowInUsecFast() -
                             before_read_lock_ts;
-                        for (auto index_iter = indexes.begin();
-                             index_iter != indexes.end();
-                             index_iter++) {
-                          const auto& id_index = *index_iter;
+                        for (const auto& id_index : indexes) {
                           auto id = int64_t(indices_data_ptr[id_index]);
 
                           // use mempool
@@ -314,10 +300,10 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                         }
                       }
                     });
-                return std::make_tuple(
+                return std::tuple{
                     local_read_lookup_cache_total_duration,
                     local_read_cache_hit_copy_total_duration,
-                    local_read_aquire_lock_duration);
+                    local_read_aquire_lock_duration};
               }));
     }
     auto results = folly::collectAll(futures).get();
@@ -368,11 +354,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
     write_sharding_total_duration_ +=
         facebook::WallClockUtil::NowInUsecFast() - before_shard_ts;
 
-    for (auto iter = shardid_to_indexes.begin();
-         iter != shardid_to_indexes.end();
-         iter++) {
-      const auto shard_id = iter->first;
-      const auto indexes = iter->second;
+    for (const auto& [shard_id, indexes] : shardid_to_indexes) {
       futures.emplace_back(
           folly::via(executor_.get())
               .thenValue([this, shard_id, indexes, &indices, &weights](
@@ -410,10 +392,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                             facebook::WallClockUtil::NowInUsecFast() -
                             before_write_lock_ts;
                         auto* pool = kv_store_.pool_by(shard_id);
-                        for (auto index_iter = indexes.begin();
-                             index_iter != indexes.end();
-                             index_iter++) {
-                          const auto& id_index = *index_iter;
+                        for (const auto& id_index : indexes) {
                           auto id = int64_t(indices_data_ptr[id_index]);
                           // use mempool
                           weight_type* block = nullptr;
@@ -471,12 +450,12 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                         }
                       }
                     });
-                return std::make_tuple(
+                return std::tuple{
                     local_write_allocate_total_duration,
                     local_write_cache_copy_total_duration,
                     local_write_lookup_cache_total_duration,
                     local_write_acquire_lock_duration,
-                    local_write_missing_load);
+                    local_write_missing_load};
               }));
     }
     return folly::collect(std::move(futures))
@@ -546,17 +525,14 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
       const at::Tensor& weights,
       const at::Tensor& count,
       std::optional<uint32_t> inplace_update_ts) {
-    std::vector<folly::Future<std::tuple<int64_t, int64_t>>> futures;
     auto shardid_to_indexes = shard_input(indices, count);
+    std::vector<folly::Future<std::tuple<int64_t, int64_t>>> futures;
+    futures.reserve(shardid_to_indexes.size());
 
     auto* tt_evict = dynamic_cast<TimeThresholdBasedEvict<weight_type>*>(
         feature_evict_.get());
     CHECK(tt_evict != nullptr);
-    for (auto iter = shardid_to_indexes.begin();
-         iter != shardid_to_indexes.end();
-         iter++) {
-      const auto shard_id = iter->first;
-      const auto indexes = iter->second;
+    for (const auto& [shard_id, indexes] : shardid_to_indexes) {
       auto f =
           folly::via(executor_.get())
               .thenValue([this,
@@ -596,17 +572,13 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                         hit_info.reserve(indexes.size() / 2);
                         miss_info.reserve(indexes.size() / 10);
                         auto rlmap = kv_store_.by(shard_id).rlock();
-                        for (auto index_iter = indexes.begin();
-                             index_iter != indexes.end();
-                             index_iter++) {
-                          auto id = int64_t(indices_data_ptr[*index_iter]);
+                        for (const auto& idx : indexes) {
+                          auto id = int64_t(indices_data_ptr[idx]);
                           auto it = rlmap->find(id);
                           if (it != rlmap->end()) {
-                            hit_info.push_back(
-                                std::make_tuple(*index_iter, it->second));
+                            hit_info.emplace_back(idx, it->second);
                           } else {
-                            miss_info.push_back(
-                                std::make_tuple(id, *index_iter));
+                            miss_info.emplace_back(id, idx);
                           }
                         }
                         rlmap.unlock();
@@ -681,9 +653,9 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                         wlmap.unlock();
                       }
                     });
-                return std::make_tuple(hit_cnt, miss_cnt);
+                return std::tuple{hit_cnt, miss_cnt};
               });
-      futures.push_back(std::move(f));
+      futures.emplace_back(std::move(f));
     }
     return folly::collect(std::move(futures))
         .via(executor_.get())
@@ -733,11 +705,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
         folly::Future<std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t>>>
         futures;
 
-    for (auto iter = shardid_to_indexes.begin();
-         iter != shardid_to_indexes.end();
-         iter++) {
-      const auto shard_id = iter->first;
-      const auto indexes = iter->second;
+    for (const auto& [shard_id, indexes] : shardid_to_indexes) {
       futures.emplace_back(
           folly::via(executor_.get())
               .thenValue([this,
@@ -781,10 +749,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                             before_write_lock_ts;
                         auto* pool = kv_store_.pool_by(shard_id);
 
-                        for (auto index_iter = indexes.begin();
-                             index_iter != indexes.end();
-                             index_iter++) {
-                          const auto& id_index = *index_iter;
+                        for (const auto& id_index : indexes) {
                           auto id = int64_t(indices_data_ptr[id_index]);
                           float engege_rate = float(engage_rate_ptr[id_index]);
                           // use mempool
@@ -822,12 +787,12 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                         }
                       }
                     });
-                return std::make_tuple(
+                return std::tuple{
                     updated_id_count,
                     local_write_allocate_total_duration,
                     local_write_lookup_cache_total_duration,
                     local_write_acquire_lock_duration,
-                    local_write_cache_miss);
+                    local_write_cache_miss};
               }));
     }
     return folly::collect(std::move(futures))
@@ -909,11 +874,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
     read_sharding_total_duration_ +=
         facebook::WallClockUtil::NowInUsecFast() - before_shard_ts;
 
-    for (auto iter = shardid_to_indexes.begin();
-         iter != shardid_to_indexes.end();
-         iter++) {
-      const auto shard_id = iter->first;
-      const auto indexes = iter->second;
+    for (const auto& [shard_id, indexes] : shardid_to_indexes) {
       futures.emplace_back(
           folly::via(executor_.get())
               .thenValue([this,
@@ -976,10 +937,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                             init_storage.template data_ptr<weight_type>();
                       }
                       {
-                        for (auto index_iter = indexes.begin();
-                             index_iter != indexes.end();
-                             index_iter++) {
-                          const auto weights_row_index = *index_iter;
+                        for (const auto& weights_row_index : indexes) {
                           auto weight_idx =
                               int64_t(indices_data_ptr[weights_row_index]);
                           auto before_lookup_cache_ts =
@@ -1027,12 +985,12 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                         }
                       }
                     });
-                return std::make_tuple(
+                return std::tuple{
                     local_read_lookup_cache_total_duration,
                     local_read_fill_row_storage_total_duration,
                     local_read_cache_hit_copy_total_duration,
                     local_read_aquire_lock_duration,
-                    local_read_missing_load);
+                    local_read_missing_load};
               }));
     }
 
@@ -1425,10 +1383,6 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
             }
 
             const auto shard_id = kv_db_utils::hash_shard(index, num_shards_);
-
-            if (!shardid_to_indexes.contains(shard_id)) {
-              shardid_to_indexes[shard_id] = std::vector<int64_t>();
-            }
             shardid_to_indexes[shard_id].push_back(i);
           }
         });
@@ -1590,18 +1544,15 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
       const at::Tensor& count,
       int64_t width_offset = 0,
       std::optional<int64_t> width_length = std::nullopt) {
-    std::vector<folly::Future<folly::Unit>> futures;
     auto row_width = weights_with_metaheader.size(1);
     auto copy_width = width_length.value_or(row_width);
     CHECK_LE(row_width, block_size_);
     CHECK_EQ(copy_width, row_width);
     auto shardid_to_indexes = shard_input(indices, count);
+    std::vector<folly::Future<folly::Unit>> futures;
+    futures.reserve(shardid_to_indexes.size());
 
-    for (auto iter = shardid_to_indexes.begin();
-         iter != shardid_to_indexes.end();
-         iter++) {
-      const auto shard_id = iter->first;
-      const auto indexes = iter->second;
+    for (const auto& [shard_id, indexes] : shardid_to_indexes) {
       auto f =
           folly::via(executor_.get())
               .thenValue([this,
@@ -1631,10 +1582,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                       auto weights_data_ptr =
                           weights_with_metaheader.data_ptr<weight_type>();
                       {
-                        for (auto index_iter = indexes.begin();
-                             index_iter != indexes.end();
-                             index_iter++) {
-                          const auto weights_row_index = *index_iter;
+                        for (const auto& weights_row_index : indexes) {
                           auto weight_idx =
                               int64_t(indices_data_ptr[weights_row_index]);
                           const auto cached_iter = wlmap->find(weight_idx);
@@ -1665,7 +1613,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                       }
                     });
               });
-      futures.push_back(std::move(f));
+      futures.emplace_back(std::move(f));
     }
     return folly::collect(futures);
   }
@@ -1688,13 +1636,10 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
       const at::Tensor& indices,
       const at::Tensor& weights_with_metaheader,
       const at::Tensor& count) {
-    std::vector<folly::Future<folly::Unit>> futures;
     auto shardid_to_indexes = shard_input(indices, count);
-    for (auto iter = shardid_to_indexes.begin();
-         iter != shardid_to_indexes.end();
-         iter++) {
-      const auto shard_id = iter->first;
-      const auto indexes = iter->second;
+    std::vector<folly::Future<folly::Unit>> futures;
+    futures.reserve(shardid_to_indexes.size());
+    for (const auto& [shard_id, indexes] : shardid_to_indexes) {
       auto f =
           folly::via(executor_.get())
               .thenValue([this,
@@ -1722,10 +1667,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                         auto indices_data_ptr = indices.data_ptr<index_t>();
                         auto weights_data_ptr =
                             weights_with_metaheader.data_ptr<weight_type>();
-                        for (auto index_iter = indexes.begin();
-                             index_iter != indexes.end();
-                             index_iter++) {
-                          const auto& id_index = *index_iter;
+                        for (const auto& id_index : indexes) {
                           auto id = int64_t(indices_data_ptr[id_index]);
                           // Defensive programming
                           // used is false shouldn't occur under normal
@@ -1771,7 +1713,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                       }
                     });
               });
-      futures.push_back(std::move(f));
+      futures.emplace_back(std::move(f));
     }
     return folly::collect(futures);
   }

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/fixed_block_pool.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/fixed_block_pool.h
@@ -319,7 +319,7 @@ class FixedBlockPool : public std::pmr::memory_resource {
     // Record chunk information for later release
     {
       std::lock_guard<std::mutex> guard(chunks_mutex_);
-      chunks_.push_back({chunk_ptr, chunk_size, block_alignment_});
+      chunks_.emplace_back(chunk_ptr, chunk_size, block_alignment_);
     }
 
     // Initialize free list: link blocks in reverse order from chunk end to

--- a/fbgemm_gpu/src/merge_pooled_embedding_ops/merge_pooled_embedding_ops_gpu.cpp
+++ b/fbgemm_gpu/src/merge_pooled_embedding_ops/merge_pooled_embedding_ops_gpu.cpp
@@ -614,7 +614,7 @@ cat_dim_2d_output_shape(
     output_shape = {uncat_dim_size, total_cat_dim};
   }
 
-  return std::make_tuple(output_shape, cumulative_dims, total_cat_dim);
+  return std::tuple{output_shape, cumulative_dims, total_cat_dim};
 }
 
 Tensor cat_dim_2d(

--- a/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
@@ -2427,7 +2427,7 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_cpu(
             bin_ids.mutable_data_ptr<int64_t>());
       });
 
-  return std::make_tuple(calibrated_prediction, bin_ids);
+  return std::tuple{calibrated_prediction, bin_ids};
 }
 
 template <typename LogitType, typename SegmentValueType>
@@ -2540,7 +2540,7 @@ std::tuple<Tensor, Tensor> histogram_binning_calibration_by_feature_cpu(
             });
       });
 
-  return std::make_tuple(calibrated_prediction, bin_ids);
+  return std::tuple{calibrated_prediction, bin_ids};
 }
 
 template <typename LogitType, typename SegmentValueType>
@@ -2668,7 +2668,7 @@ std::tuple<Tensor, Tensor> generic_histogram_binning_calibration_by_feature_cpu(
             });
       });
 
-  return std::make_tuple(calibrated_prediction, bin_ids);
+  return std::tuple{calibrated_prediction, bin_ids};
 }
 template <typename value_t, typename index_t>
 void _segment_sum_csr_cpu_kernel(
@@ -3473,7 +3473,7 @@ group_index_select_dim0_unpack(
 
   TORCH_CHECK(group_size == static_cast<int64_t>(indices_group.size()));
 
-  return std::make_pair(input_group, indices_group);
+  return std::pair{input_group, indices_group};
 }
 
 torch::autograd::variable_list group_index_select_dim0(

--- a/fbgemm_gpu/src/split_embeddings_cache/cachelib_cache.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/cachelib_cache.cpp
@@ -218,10 +218,10 @@ CacheLibCache::get_n_items(int n, Cache::AccessIterator& itr) {
               }
             });
       });
-  return std::make_tuple(
+  return std::tuple{
       indices,
       weights,
-      at::tensor({cnt}, at::TensorOptions().dtype(at::kLong).device(at::kCPU)));
+      at::tensor({cnt}, at::TensorOptions().dtype(at::kLong).device(at::kCPU))};
 }
 
 void CacheLibCache::init_tensor_for_l2_eviction(
@@ -255,10 +255,10 @@ CacheLibCache::get_tensors_and_reset() {
   if (evicted_indices_opt_.has_value()) {
     CHECK(evicted_weights_opt_.has_value());
     if (eviction_row_id > 0) {
-      ret = std::make_tuple(
+      ret = std::tuple{
           evicted_indices_opt_.value(),
           evicted_weights_opt_.value(),
-          at::tensor(eviction_row_id, evicted_indices_opt_->options()));
+          at::tensor(eviction_row_id, evicted_indices_opt_->options())};
     }
   }
   reset_eviction_states();

--- a/fbgemm_gpu/src/split_embeddings_cache/kv_db_cpp_utils.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/kv_db_cpp_utils.cpp
@@ -60,9 +60,9 @@ std::tuple<at::Tensor, at::Tensor> get_bucket_sorted_indices_and_bucket_tensor(
         bucket_start,
         " the input data should be empty but get:",
         unordered_indices.numel());
-    return std::make_tuple(
+    return std::tuple{
         at::empty(unordered_indices.sizes(), unordered_indices.options()),
-        at::zeros({0, 1}, unordered_indices.options()));
+        at::zeros({0, 1}, unordered_indices.options())};
   }
 
   const auto indices_data_ptr = unordered_indices.const_data_ptr<int64_t>();
@@ -83,9 +83,6 @@ std::tuple<at::Tensor, at::Tensor> get_bucket_sorted_indices_and_bucket_tensor(
         bucket_start,
         " and ",
         bucket_end);
-    if (bucket_id_to_cnt.find(global_bucket_id) == bucket_id_to_cnt.end()) {
-      bucket_id_to_cnt[global_bucket_id] = 0;
-    }
     bucket_id_to_cnt[global_bucket_id] += 1;
   }
   // fill the bucket_tensor with counts
@@ -131,10 +128,10 @@ std::tuple<at::Tensor, at::Tensor> get_bucket_sorted_indices_and_bucket_tensor(
         bucket_id_to_offset[bucket_id] += 1;
       }
     });
-    futures.push_back(std::move(f));
+    futures.emplace_back(std::move(f));
   }
   folly::collect(futures).wait();
-  return std::make_tuple(id_tensor, bucket_tensor);
+  return std::tuple{id_tensor, bucket_tensor};
 }
 
 } // namespace kv_db_utils

--- a/fbgemm_gpu/src/split_embeddings_cache/linearize_cache_indices.cpp
+++ b/fbgemm_gpu/src/split_embeddings_cache/linearize_cache_indices.cpp
@@ -104,7 +104,7 @@ get_unique_indices_cpu_impl(
 
   // Handle empty input
   if (N == 0) {
-    return std::make_tuple(
+    return std::tuple{
         at::empty_like(linear_indices),
         at::zeros({1}, linear_indices.options().dtype(at::kInt)),
         compute_count ? std::optional<Tensor>(at::zeros(
@@ -113,7 +113,7 @@ get_unique_indices_cpu_impl(
         compute_inverse_indices
             ? std::optional<Tensor>(
                   at::zeros({0}, linear_indices.options().dtype(at::kInt)))
-            : std::nullopt);
+            : std::nullopt};
   }
 
   // Use torch::unique to get unique indices
@@ -164,11 +164,11 @@ get_unique_indices_cpu_impl(
     linear_index_positions_sorted = sort_indices.to(at::kInt);
   }
 
-  return std::make_tuple(
+  return std::tuple{
       unique_indices_output,
       unique_indices_length,
       unique_indices_count,
-      linear_index_positions_sorted);
+      linear_index_positions_sorted};
 }
 
 DLL_PUBLIC

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -556,7 +556,7 @@ std::shared_ptr<CacheContext> EmbeddingKVDB::get_cache(
                       }
                     });
               });
-      futures.push_back(std::move(f));
+      futures.emplace_back(std::move(f));
     }
     folly::collect(futures).wait();
 
@@ -658,7 +658,7 @@ EmbeddingKVDB::set_cache(
                       }
                     });
               });
-      futures.push_back(std::move(f));
+      futures.emplace_back(std::move(f));
     }
     // folly::coro::blockingWait(folly::coro::collectAllRange(std::move(tasks)));
     folly::collect(futures).wait();
@@ -704,7 +704,7 @@ folly::SemiFuture<std::vector<folly::Unit>> EmbeddingKVDB::cache_memcpy(
                       &weights_data_ptr[row_id * max_D_]); // dst_start
                 }
               });
-          futures.push_back(std::move(f));
+          futures.emplace_back(std::move(f));
         }
       });
   get_cache_memcpy_duration_ +=

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -546,7 +546,7 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
                           });
                     });
               });
-      futures.push_back(std::move(f));
+      futures.emplace_back(std::move(f));
     }
     // co_await folly::coro::collectAllRange(std::move(tasks));
 #ifdef FBGEMM_FBCODE
@@ -743,7 +743,7 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
 
                 delete it;
               });
-      futures.push_back(std::move(f));
+      futures.emplace_back(std::move(f));
     }
     folly::collect(futures).wait();
     int64_t total_num = 0;
@@ -841,7 +841,7 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
             }
             return false;
           });
-      futures.push_back(std::move(f));
+      futures.emplace_back(std::move(f));
     }
     auto results = folly::coro::blockingWait(folly::collectAll(futures));
     for (auto& result : results) {
@@ -1306,7 +1306,7 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
                           });
                     });
               });
-      futures.push_back(std::move(f));
+      futures.emplace_back(std::move(f));
     }
 #ifdef FBGEMM_FBCODE
     auto duration = facebook::WallClockUtil::NowInUsecFast() - start_ts;
@@ -1689,7 +1689,7 @@ class ReadOnlyEmbeddingKVDB : public torch::jit::CustomClassHolder {
                           });
                     });
               });
-      futures.push_back(std::move(f));
+      futures.emplace_back(std::move(f));
     }
     return folly::collect(futures);
   }

--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_test.py
@@ -9,12 +9,24 @@
 
 # pyre-ignore-all-errors[56]
 
+import logging
+import os
+import time
 import unittest
 from typing import Any
 
 import torch
+from fbgemm_gpu.split_embedding_configs import (
+    EmbeddingLocation,
+    EmbOptimType as OptimType,
+)
+from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
+    ComputeDevice,
+    SplitTableBatchedEmbeddingBagsCodegen,
+)
 from hypothesis import given, settings
 
+from ..common import create_tbe_from_config, load_tbe_configs_from_file  # noqa E402
 from .backward_adagrad_common import (
     additional_decorators,
     adjust_mixed_B_st,
@@ -242,6 +254,146 @@ class BackwardAdagradTest(unittest.TestCase):
             pooling_mode=PoolingMode.SUM,
             use_cpu=False,
             output_dtype=SparseType.FP16,
+        )
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_backward_adagrad_from_config_file(self) -> None:
+        """
+        Test backward adagrad pass using TBE specs loaded from a JSON file.
+
+        This test reads TBE init parameters from a JSON file, either input_tbe_specs.json by default
+        or specified by the TBE_CONFIG_PATH environment variable. It runs backward tests for each
+        configuration.
+
+        The config file can be generated using extract_specs_from_log.py:
+            python3 ${HOME}/fbsource/fbcode/ai_codesign/nonprod/supadchaya/scripts/fbgemm/extract_specs_from_log.py \
+                --specs_log <path_to_specs_log> \
+                --planner_log <path_to_planner_log> \
+                --output <output_json_path>
+
+        To run this test with a specific config file:
+            TBE_CONFIG_PATH=/path/to/config.json \
+                buck2 run @//mode/opt fbcode//deeplearning/fbgemm/fbgemm_gpu/test/tbe:backward_adagrad \
+                -- -r test_backward_adagrad_from_config_file
+        or
+            TBE_CONFIG_PATH=/path/to/config.json python3 -m pytest backward_adagrad_test.py \
+                -k test_backward_adagrad_from_config_file
+        """
+        default_config_path = os.path.join(
+            os.path.dirname(__file__), "input_tbe_specs.json"
+        )
+        config_path = os.environ.get("TBE_CONFIG_PATH", default_config_path)
+        if not config_path or not os.path.exists(config_path):
+            self.skipTest(f"Config file not found: {config_path}")
+
+        batch_size, _, common_config, tbe_configs = load_tbe_configs_from_file(
+            config_path
+        )
+
+        # Use a smaller batch size for testing to reduce memory usage (otherwise OOM)
+        test_batch_size = min(batch_size, 512)
+        L = 10 if test_batch_size < batch_size else 2
+        max_config = os.environ.get("TBE_MAX_CONFIG", "5")
+        max_config = int(max_config) if max_config != "all" else -1
+        configs_to_test = tbe_configs[:max_config]
+
+        total_start_time = time.perf_counter()
+        end_time = total_start_time
+
+        for i, config in enumerate(configs_to_test):
+            with self.subTest(config_index=i):
+                start_time = time.perf_counter()
+                try:
+                    tbe_op = create_tbe_from_config(
+                        config, common_config, use_cpu=False
+                    )
+                    T = len(tbe_op.embedding_specs)
+                    max_D = tbe_op.max_D
+                    mixed_D = tbe_op.mixed_D
+                    execute_backward_adagrad(
+                        T=T,
+                        D=max_D,
+                        B=test_batch_size,
+                        log_E=0,
+                        L=L,
+                        D_gradcheck=1,
+                        weights_precision=tbe_op.weights_precision,
+                        stochastic_rounding=tbe_op.stochastic_rounding,
+                        weighted=False,
+                        row_wise=(tbe_op.optimizer == OptimType.EXACT_ROWWISE_ADAGRAD),
+                        mixed=mixed_D,
+                        mixed_B=False,
+                        use_cache=False,
+                        cache_algorithm=tbe_op.cache_algorithm,
+                        pooling_mode=tbe_op.pooling_mode,
+                        use_cpu=False,
+                        output_dtype=SparseType.from_int(tbe_op.output_dtype),
+                        weight_decay_mode=tbe_op.weight_decay_mode,
+                        tbe_op=tbe_op,
+                    )
+                    end_time = time.perf_counter()
+                    logging.info(
+                        f"TBE_DEBUG: PASSED for config {i} T={T} max_D={max_D} (mixed: {mixed_D}), the test took {(end_time - start_time) / 60:.2f} mins"
+                    )
+                except Exception as e:
+                    # Log but don't fail - some configs may have unsupported features
+                    end_time = time.perf_counter()
+                    raise RuntimeError(
+                        f"TEST FAILED for config {i} uuid={config.get('tbe_uuid', '')}, the test took {(end_time - start_time) / 60:.2f} mins and failed: {e}"
+                    )
+        logging.info(
+            f"TBE_DEBUG: Total time taken to test {len(configs_to_test)} configs is {(end_time - total_start_time) / 60:.2f} mins"
+        )
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_backward_adagrad_with_simple_tbe_op(self) -> None:
+        """
+        Test execute_backward_adagrad with a pre-created TBE op.
+
+        This test verifies that execute_backward_adagrad works correctly
+        with a manually created TBE op passed via the cc parameter.
+        """
+        T = 1  # Number of tables
+        D = 4  # Embedding dimension
+        E = 10  # Number of embeddings per table
+        B = 1  # Batch size
+        L = 1  # Sequence length
+        pooling_mode = PoolingMode.SUM
+        weights_precision = SparseType.FP32
+        output_dtype = SparseType.FP32
+        embedding_specs = [
+            (E, D, EmbeddingLocation.DEVICE, ComputeDevice.CUDA) for _ in range(T)
+        ]
+
+        cc = SplitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=embedding_specs,
+            weights_precision=weights_precision,
+            optimizer=OptimType.EXACT_ROWWISE_ADAGRAD,
+            learning_rate=0.05,
+            eps=0.2,
+            pooling_mode=pooling_mode,
+            output_dtype=output_dtype,
+        )
+
+        execute_backward_adagrad(
+            T=T,
+            D=D,
+            B=B,
+            log_E=1,
+            L=L,
+            D_gradcheck=1,
+            weights_precision=weights_precision,
+            stochastic_rounding=False,
+            weighted=False,
+            row_wise=True,
+            mixed=False,
+            mixed_B=False,
+            use_cache=False,
+            cache_algorithm=CacheAlgorithm.LRU,
+            pooling_mode=pooling_mode,
+            use_cpu=False,
+            output_dtype=output_dtype,
+            tbe_op=cc,
         )
 
 

--- a/fbgemm_gpu/test/tbe/training/input_tbe_specs.json
+++ b/fbgemm_gpu/test/tbe/training/input_tbe_specs.json
@@ -1,0 +1,12855 @@
+{
+  "batch_size": 2048,
+  "total_ranks": 128,
+  "common_config": {
+    "cache_algorithm": "LRU",
+    "cache_load_factor": 0.2,
+    "weights_precision": "fp16",
+    "output_dtype": "fp32",
+    "optimizer": "exact_rowwise_adagrad",
+    "pooling_mode": "SUM",
+    "learning_rate": 0.056568542494924,
+    "stochastic_rounding": true,
+    "prefetch_pipeline": true
+  },
+  "tbe_configs": [
+    {
+      "tbe_uuid": "41475c69-1470-4795-aded-846df375a1c8",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 284285,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4348658,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784913,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 642110,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 236,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 278,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3618081,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_UDS_FIR_AD_IMPRESSION_UNSAMPLED_PHOTO_DNA_HASH__MOST_RECENT_100__F3_ADPUBLISHER_ADS_CREATIVE_FATIGUE_IMDS_PHOTO_DNA_HASH_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_XRAY_2022A_DOUBLE_CLUSTERING_ADS_SIDE_IMAGE_UNDERSTANDING_VLBLENDER_AD_SIDE_FEATURES_ID_LIST_REALTIME_3_DECODED_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_AUTO_ID_MATCHING__SPARSE_NEW_CAMPAIGN_ID__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_NEW_CAMPAIGN_ID_TOP_7D_mix_sparse_arch",
+        "table_group_10_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_CONTENT_UNDERSTANDING_MARKETPLACE_POSITIVE_ENGAGEMENT_F3_MP_USER_POSITIVE_ENGAGEMENT_7D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_GRAPH_LEARNING_FLEXIBLE_BATCH_GLFF_GLFF_PPR_FEATURES_2025H1_GLFF_2025H1_PPR_IDLIST_OFFSITE_ALL_ADCLKS_USER_EKEY_user_sparse_arch",
+        "table_EVENT_AGG_2D_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_DWELLING_TIME_LIST_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_UNATTRIBUTED_CONVERSION_DENSE_REALTIME_SAFE_V2_COUNT_FLOAT_EARLY_TRIGGER_1MIN_TARGET_ID_ALL_240MIN_user_sparse_arch",
+        "table_densebmb_23_23_MBDT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_LINK_CLICK_240MIN_user_sparse_arch"
+      ],
+      "device_index": 2
+    },
+    {
+      "tbe_uuid": "3b5f84ef-3bf2-44d4-93d6-af9cf63d6e8c",
+      "embedding_specs": [
+        {
+          "num_embeddings": 661,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 48,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5801,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 653,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 224,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 612,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 710,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784921,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 375,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 11,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2658,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5376992,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 296,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 236,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 760,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 763,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        8,
+        8,
+        8,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17
+      ],
+      "table_names": [
+        "table_DENSE_BMB__GFF_C7006_ADS_USER_SUM_DECAY_950_84_PAGE_TYPE_ADFINDER_STORY_TYPE_COUNTER_CONVERSION_FINAL_mix_sparse_arch",
+        "table_DENSE_BMB__GFF_C869_ADS_USER_SUM_28_ACCOUNT_ID_COUNTER_CLICK_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_POSTRAY_AD_AND_USER_SIDE_FEATURES_CTX_AD_SIDE_POSTRAY_CLUSTER_IDS_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_R70015_ADS_NEW_VIDEO_ID_SUM_2_RATIO_CONVERSION_IMPRESSION_mix_sparse_arch",
+        "table_densebmb_4_4_MBDT_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_NATIVE_BATCH_IG_BOR_PROFILE_ACTION_CROSS_FEATURES_ORGANIC_PROSPECTING_PROFILE_ACTIONS_COUNT_WEBCLICK_28D_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C1229433_ADS_ENTITY_EQUIVALENCE_KEY_SUM_7_PAGE_TYPE_USER_COUNTRY_RATIO_CLICK_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C4010_ADS_USER_SUM_84_PAGE_TYPE_PAGE_CTA_ACTION_TYPE_RATIO_XOUT_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_group_22_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_CLICK_ECG_IG_AD_CLICK_NON_REELS_AD_ID_INT_LATEST50_28D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_NON_ENGAGEMENT_IMP_NO_CLICK_MT_USER_AD_NON_ENGAGE_AD_MEGATAXON_L2_24H_TOP_K_WITH_COUNT_user_sparse_arch",
+        "table_EVENT_MOST_RECENT_5_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_PLACEMENT_PAGE_TYPE_LIST_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_POSTRAY_AD_AND_USER_SIDE_FEATURES_CTX_USER_REPLY_AD_POSTRAY_4K_CLUSTER_IDS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_FB_REELS_AD_ENGAGEMENT_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_AD_EEK_EVENT_TYPE_ALL_1440MIN_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_LEGACY_MIGRATION_BROWSE_ENVIRONMENT_TRAITS_MOBILE_APP_BUILD_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_UNATTRIBUTED_CONVERSION_DENSE_REALTIME_SAFE_V2_COUNT_FLOAT_EARLY_TRIGGER_1MIN_TARGET_ID_ALL_240MIN_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_IG_CONNECTION_CLASS_LATENCY_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C79_INSTAGRAM_USER_SUM_84_RATIO_IG_ORGANIC_LIKE_IG_ORGANIC_IMPRESSION_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 4
+    },
+    {
+      "tbe_uuid": "18e770e3-18e9-408a-9a57-9bef8da0afbd",
+      "embedding_specs": [
+        {
+          "num_embeddings": 227,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1605631,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 31,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 642,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6783150,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 478,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 237,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4539974,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5755862,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 690,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        7,
+        7,
+        7,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__GFF_R1313_ADS_USER_SUM_2_CONVERSION_TYPE_VERSION_COUNTER_CONVERSION_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_INSTAGRAM_MEDIA_ID_TOP_7D_TO_28D__SPARSE_INSTAGRAM_MEDIA_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_ADSLLM_IFT_AD_SIDE_ADS_LLM_ADSLLAMA_MM_KEYWORDS_LIST_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_F3_ADFINDER_USER_ADS_CREATIVE_FATIGUE_FLEXIBLE_BATCH_HOURLY_BATCH_USER_FATIGUE_HASHED_ENCODED_F3_7D_PDNA_SPOOKY_UINT32_FP16_IDLIST_ST_DECODED_F3_ADPUBLISHER_ADS_CREATIVE_FATIGUE_IMDS_PHOTO_DNA_HASH_ID_ST_HASHED_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_7D_mix_sparse_arch",
+        "table_densebmb_78_78_MBDT_mix_spec_densebmb_regular",
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_UDS_FIR_AD_IMPRESSION_UNSAMPLED_PHOTO_DNA_HASH__MOST_RECENT_500__F3_ADPUBLISHER_ADS_CREATIVE_FATIGUE_IMDS_PHOTO_DNA_HASH_ID_mix_spec_id_matching",
+        "table_group_30_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_GRAPH_LEARNING_FLEXIBLE_BATCH_GLFF_GLFF_PPR_FEATURES_2025H1_GLFF_2025H1_PPR_IDLIST_OFFSITE_ALL_ONSITE_ALL_USER_EKEY_user_sparse_arch",
+        "table_DENSE_BMB__GFF_C883_INSTAGRAM_USER_SUM_28_PAGE_TYPE_49_RATIO_IG_VIDEO_VIEW_COUNT_IG_VIDEO_VIEW_SESSION_IMP_EXPLODED_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_NUM_ADS_SEEN_LAST_1HR_F3_DENSE_IG_USER_NUM_ADS_SEEN_LAST_1HR_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_NON_ENGAGEMENT_IMP_NO_CLICK_USER_AD_NON_ENGAGE_AD_ACCOUNT_ID_24H_LATEST_N_WITH_TIMESTAMP_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_USER_LATESTN_AD_ID_CLICK_HA_IG_ADS_USER_LATEST_20_1D_PAGE_TYPE_94_95_AD_ID_CLICK_HA_user_sparse_arch",
+        "table_densebmb_2025h1_14_14_MBDT_user_spec_densebmb_igctr_25h1"
+      ],
+      "device_index": 6
+    },
+    {
+      "tbe_uuid": "d3be5892-54fc-413b-9d8f-89e33f35dbbc",
+      "embedding_specs": [
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 301571,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 26077834,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 752,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5287864,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2307981,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 518,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 613,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7677271,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3489261,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 313,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 484,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 773,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 504,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__F3_ADINDEXER_ADS_ID_MATCHING_AUTO_SPARSE_NEW_PAGE_RID__GFF_S_R11595_ADS_USER_CONVERSION_CONVERSION_UNATTR_OPT_PIXEL_RID_SORTBY_TIME_EVENT_TS_TOP50_D1_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_INSTAGRAM_MEDIA_ID_TOP_7D_TO_28D__SPARSE_INSTAGRAM_MEDIA_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_ATOM_FLEXIBLE_BATCH_ATOM_AD_SIDE_INPUT_HOURLY_ATOM_ADS_TEXT_INPUT_HOURLY_V2_IDENTITY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SEM_ID_AD_SEMID_TEXTRAY_AVG_SEM_ID_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_NO_CREATIVE_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_28D_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_USER_PAGE_TOP_ENGAGED_30D_RID__GSF_IDLIST_PAGE_PPR_9_RID_mix_spec_id_matching",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_AUTO_ID_MATCHING__SPARSE_NEW_CAMPAIGN_ID__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_NEW_CAMPAIGN_ID_TOP_7D_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_AD_ADS_SAFE_REALTIME_REALTIME_OLD_IG_USER_COUNT_DENSE_REALTIME_SAFE_V2_COUNT_FLOAT_USER_AUTHOR_EVENT_INSTAGRAM_ORGANIC_BRAND_PROFILE_7D_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_R1025165_ADS_ENTITY_EQUIVALENCE_KEY_SUM_2_PAGE_TYPE_USER_COUNTRY_RATIO_CLICK_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_AD_CTA_ITEM_IDS_STORY_F3_SPARSE_IG_USER_AD_CTA_ITEM_IDS_STORY_user_sparse_arch",
+        "table_GSF_IDLIST_USER_ENGAGED_PAGE_RID_CLUSTERING_V6_OTHER_CLICKS_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D84_user_sparse_arch",
+        "table_DENSE_BMB__GFF_C3015_INSTAGRAM_USER_SUM_84_COUNTER_IG_ORGANIC_TIMESPENT_CORRECTED_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_AVG_TIMESPENT_PER_ORGANIC_POST_FEED_F3_DENSE_IG_USER_AVG_TIMESPENT_PER_ORGANIC_POST_FEED_user_sparse_arch",
+        "table_GFF_IDS_C70077_ADS_USER_IMPRESSION_NEW_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D28_user_sparse_arch",
+        "table_TIMEGAP_WITH_AD_REQUEST__F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_NON_ENGAGEMENT_IMP_NO_CLICK_USER_AD_NON_ENGAGE_AD_ACCOUNT_ID_4H_LATEST_N_WITH_TIMESTAMP_user_sparse_arch",
+        "table_densebmb_58_58_MBDT_user_spec_densebmb_regular",
+        "table_densebmb_87_87_MBDT_user_spec_densebmb_regular",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_NATIVE_BATCH_GFF_C72000_C72000_ADS_USER_SUM_28_PAGE_TYPE_CONVERSION_TYPE_V2_EXPLODED_ADFINDER_STORY_TYPE_EXPLODED_COUNTER_IMPRESSION_CONVERSION_TYPE_V2_43_ADFINDER_STORY_TYPE_128_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_TIME_SINCE_LAST_AD_CTA_IG_TIME_SINCE_LAST_AD_CTA_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_ADS_ML_MODELING_SHORT_AGGREGATION_WINDOW_DENSE_FEATURES_GFF_R1318_ADS_USER_SUM_4_HOUR_PAGE_TYPE_RATIO_CLICK_IMPRESSION_GFF_R1318_ADS_USER_SUM_4_HOUR_PAGE_TYPE_RATIO_CLICK_IMPRESSION_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "2a123f65-481d-4eb2-bba6-0dc9a0488323",
+      "embedding_specs": [
+        {
+          "num_embeddings": 144058,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4415538,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2089,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2221,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 87354,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 209,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 146,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3810222,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      "table_names": [
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_VLBLENDER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_TEXTRAY_OCR_IMG_100K_KNN_FIX_QUANTIZED_DECODED_mix_sparse_arch",
+        "table_GSF_IDLIST_PAGE_PPR_6_GFF_IDS_C70070_ADS_USER_IMPRESSION_NEW_PAGE_ID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D28_MATCHING_mix_sparse_arch",
+        "table_SPARSE_AD_PRODUCT_FORMAT_TYPE_LIST_IDENTITY_mix_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_PA_GEOGRAPHIC_REGION_SPARSE_IG_USER_REGION_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ATOM_FLEXIBLE_BATCH_ATOM_USER_SIDE_IAB_RQVAE_FEATURES_ATOM_USER_SIDE_IAB_RQVAE_BIGRAM_1_user_sparse_arch",
+        "table_DENSE_BMB__F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_UNATTRIBUTED_CONV_ONSITE_DENSE_SAFE_V2_COUNT_FLOAT_UNATTRIBUTED_CONV_ONSITE_CNT_EVENT_TYPE_INSTAGRAM_PROFILE_FOLLOW_56D_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_EXPLODED_REALTIME_R1307_ADS_USER_SUM_2_PAGE_TYPE_CONVERSION_TYPE_VERSION_EXPLODED_COUNTER_IMPRESSION_CONVERSION_TYPE_VERSION_48_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_NON_ENGAGEMENT_IMP_NO_CLICK_USER_AD_NON_ENGAGE_AD_ACCOUNT_ID_4H_LATEST_N_WITH_TIMESTAMP_user_sparse_arch"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "9991e9e7-7d7e-4fe2-ae1e-949e64b6e323",
+      "embedding_specs": [
+        {
+          "num_embeddings": 426463,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 8171523,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5587,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1943,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 107153,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 424,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6442728,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4062956,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "table_names": [
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_TEXT_APP_LVBLENDER_ADS_ADSLLAMA_TEXT_APP_LVBLENDER_FEATURES_TEXT_APP_LVBLENDER_TEXT_300K_KNN_DECODED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBV2_XRAY2023_IMG_RQ_VAE_DECODED_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_POSTRAY_ID_MATCHING_CTX_AD_ONSITE_CONVERSION_REPLY_POSTRAY_CLUSTER_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADPUBLISHER_VIDEOS_VI_SIGNALS_FLEXIBLE_BATCH_FB_AD_LEVEL_EVV_FEATURES_AD_LEVEL_ADS_TIME_SPENT_SEC_P25_mix_spec_tail_sigrid_features",
+        "table_group_6_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_CONTENT_UNDERSTANDING_MARKETPLACE_POSITIVE_ENGAGEMENT_MEGATAXON_F3_MP_USER_POSITIVE_ENGAGEMENT_MEGATAXON_28D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_UUDL_OFFSITE_CONVERSION_APP_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_5MIN_APP_ID_FB_MOBILE_ACTIVATE_APP_1440MIN_user_sparse_arch",
+        "table_AGES_DENSEBMB__GSF_FLOAT_REQUEST_LEVEL_USER_RT_LOC_IP_GEO_LOCATION_CONFIDENCE_SCORE_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_IAW_VIEW_DURATION_MS__1_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_ACCOUNT_ID__1_DAYS_user_sparse_arch"
+      ],
+      "device_index": 2
+    },
+    {
+      "tbe_uuid": "2c82f2cc-06dd-4ada-b88d-bfd36fca46e5",
+      "embedding_specs": [
+        {
+          "num_embeddings": 661,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 48,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5801,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 653,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 266,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784921,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 375,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 11,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2658,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5376992,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 353,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 486,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 62,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        8,
+        8,
+        8,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17
+      ],
+      "table_names": [
+        "table_DENSE_BMB__GFF_C7006_ADS_USER_SUM_DECAY_950_84_PAGE_TYPE_ADFINDER_STORY_TYPE_COUNTER_CONVERSION_FINAL_mix_sparse_arch",
+        "table_DENSE_BMB__GFF_C869_ADS_USER_SUM_28_ACCOUNT_ID_COUNTER_CLICK_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_POSTRAY_AD_AND_USER_SIDE_FEATURES_CTX_AD_SIDE_POSTRAY_CLUSTER_IDS_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_R70015_ADS_NEW_VIDEO_ID_SUM_2_RATIO_CONVERSION_IMPRESSION_mix_sparse_arch",
+        "table_densebmb_4_4_MBDT_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_AUTO_ID_MATCHING__SPARSE_NEW_PAGE_RID__GFF_S_R64504_ADS_USER_CLICK_NEW_PAGE_RID_SORTBY_TIME_EVENT_TS_TOP200_D2_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C72000_ADS_USER_SUM_84_PAGE_TYPE_CONVERSION_TYPE_V2_ADFINDER_STORY_TYPE_COUNTER_CLICK_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADPUBLISHER_VIDEOS_VI_SIGNALS_FLEXIBLE_BATCH_FB_AD_LEVEL_EVV_FEATURES_AD_LEVEL_ADS_TIME_SPENT_SEC_P90_mix_spec_tail_sigrid_features",
+        "table_group_22_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_CLICK_ECG_IG_AD_CLICK_NON_REELS_AD_ID_INT_LATEST50_28D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_NON_ENGAGEMENT_IMP_NO_CLICK_MT_USER_AD_NON_ENGAGE_AD_MEGATAXON_L2_24H_TOP_K_WITH_COUNT_user_sparse_arch",
+        "table_EVENT_MOST_RECENT_5_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_PLACEMENT_PAGE_TYPE_LIST_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_POSTRAY_AD_AND_USER_SIDE_FEATURES_CTX_USER_REPLY_AD_POSTRAY_4K_CLUSTER_IDS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_FB_REELS_AD_ENGAGEMENT_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_AD_EEK_EVENT_TYPE_ALL_1440MIN_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_TIME_SINCE_LAST_AD_CTA_REELS_F3_DENSE_IG_USER_TIME_SINCE_LAST_AD_CTA_REELS_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_USER_SESSION_CTR_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_IG_ML_CORE_TRAITS_VIDEO_SESSION_SUMMARY_DELTA_COUNTS_COUNT_FLOAT_CLIPS_ONLINE_TIME_SPENT_TOTAL_EVENT_TYPE_ALL_6H_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_ADS_ML_MODELING_SHORT_AGGREGATION_WINDOW_DENSE_FEATURES_GFF_R1425220_ADS_USER_SUM_4_HOUR_COUNTER_CONVERSION_GFF_R1425220_ADS_USER_SUM_4_HOUR_COUNTER_CONVERSION_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 4
+    },
+    {
+      "tbe_uuid": "d33a51cf-b908-457a-bd86-0bf078f05c24",
+      "embedding_specs": [
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 53,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5748,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 155,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 11899818,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5287056,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 32,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1812,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        5,
+        5,
+        5,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "table_names": [
+        "table_DENSE_BMB__F3_ADINDEXER_ADS_ID_MATCHING_AUTO_AUTO_ID_MATCHING__SPARSE_NEW_VIDEO_ID__GSF_IDLIST_USER_EVENT_CONVERSION_SPARSE_NEW_VIDEO_ID_TOP_7D_mix_sparse_arch",
+        "table_DENSE_BMB__GFF_R1304_ADS_USER_SUM_7_PAGE_TYPE_CONVERSION_TYPE_VERSION_COUNTER_CONVERSION_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_TEXTRAY_AD_AND_USER_SIDE_FEATURES_CTX_AD_SIDE_TEXTRY_CLUSTER_IDS_IDENTITY_mix_sparse_arch",
+        "table_SPARSE_IG_FORMAT_RANKING_DECISIONS_IDENTITY_mix_sparse_arch",
+        "table_densebmb_0_0_stability_mix_sparse_arch",
+        "table_group_23_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SEM_ID_USER_IMP_3D_TEXTRAY_TEXT_50K_SEM_ID_user_sparse_arch",
+        "table_F3_ADFINDER_USER_VIDEOS_VI_SIGNALS_FLEXIBLE_BATCH_FB_VIEWER_ADS_AGG_EVV_FEATURES_SPARSE_AD_ID_LIST_10S_EVV_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_AD_IMPRESSION_AD_REQUEST_PAGE_TYPE_LIST__84_DAYS_user_sparse_arch",
+        "table_F3_ADINDEXER_DA_PRODUCT_FEATURES_NATIVE_BATCH_FPT_USER_CATEGORY_IMPS_TOP_25_ENGAGED_L4_CATEGORY_ID_IMPS_7D_user_sparse_arch"
+      ],
+      "device_index": 6
+    },
+    {
+      "tbe_uuid": "e683282e-1a1d-4e6d-8263-c64b3151c42f",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1126,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 523283,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6783068,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3794412,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 187,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 773,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2406434,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3848173,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_USER_PAGE_TOP_ENGAGED_30D_RID__SPARSE_NEW_PAGE_RID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_ATOM_FEATURIZATION_REAL_TIME_AD_TEXTRAY_RQVAE_ATOM_AD_TEXTRAY_RQVAE_CLUSTER_ID2_IDENTITY_mix_sparse_arch",
+        "table_GSF_IDLIST_PRODUCT_SET_COUNT_IDF_SEARCH_PHRASE_100_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_NO_CREATIVE_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_7D_mix_sparse_arch",
+        "table_group_33_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_CLICK_ECG_IG_AD_CLICK_REELS_AD_ID_INT_TOP50_28D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_FLEXIBLE_BATCH_IG_BOR_VPVD_SPARSE_FEATURES_ORGANIC_PROSPECTING_VPVD_LIST_1D_user_sparse_arch",
+        "table_DENSE_BMB__GFF_C25302_DA_PRODUCT_FEATURES_USER_SUM_84_PAGE_TYPE_COUNTER_CLICK_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_TIME_SINCE_LAST_AD_CTA_IG_TIME_SINCE_LAST_AD_CTA_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_VIDEO_VIEW_240MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_IMPRESSION_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_AD_ACCOUNT_ID_EVENT_TYPE_ALL_1440MIN_TIMEGAP_WITH_AD_REQUEST_user_sparse_arch"
+      ],
+      "device_index": 6
+    },
+    {
+      "tbe_uuid": "e4077eaa-0d64-43c4-826d-9a804b718114",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 134792,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 70,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 98,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4459713,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 11,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 758,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 514,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__GFF_S_R64006_ADS_USER_CONVERSION_CONVERSION_UNATTR_OPT_ALL_SPARSE_AD_HYBRID_ID_SORTBY_TIME_EVENT_TS_TOP50_D7__F3_ADPUBLISHER_BASIC_ADS_RANKING_IMDS_AD_ACCOUNT_ID_AD_ACCOUNT_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_PA_INTERESTFM_AD_ACCOUNT_AD_ACCOUNT_INTERESTFM_HASHTAG_GENERATION_MM_100K_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C1112_INSTAGRAM_USER_SUM_7_INSTAGRAM_ACTOR_FBIDV2_COUNTER_IG_ORGANIC_IMPRESSION_mix_sparse_arch",
+        "table_densebmb_2025h1_8_8_MBDT_mix_spec_densebmb_igctr_25h1",
+        "table_group_14_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_AD_CTA_ITEM_IDS_REELS_F3_SPARSE_IG_USER_AD_CTA_ITEM_IDS_REELS_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_PLACEMENT_PAGE_TYPE_LIST_user_sparse_arch",
+        "table_densebmb_31_31_MBDT_user_sparse_arch",
+        "table_densebmb_51_51_MBDT_user_sparse_arch"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "3576deae-c8e7-45fe-b83e-6722f846d074",
+      "embedding_specs": [
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 48636,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 144013,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5992143,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2599259,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 522,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 112,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 306,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 14,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "table_names": [
+        "table_group_47_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_IMPRESSION_REALTIME_SAFE_TOP_ENGAGED_ENTITY_ID_SCORE_LIST_AD_EEK_ALL_EVENTS_1440MIN__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_SFV_TOP_CLUSTER_IDS_FOR_ADS_VIDEO_SFV_TOP_FIRST_CLIP_50K_QUANTIZED_DECODED_mix_sparse_arch",
+        "table_GSF_IDLIST_MEGATAXON_MMF_AD_CLUSTERING_IDENTITY_mix_sparse_arch",
+        "table_SPARSE_IG_AUTHOR_BIO_HASHES_IDENTITY_mix_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_USER_TOPK_AD_ACCOUNT_ID_CLICK_HA_IG_ADS_USER_TOP_10_30MIN_PAGE_TYPE_35_49_72_94_95_108_AD_ID_CLICK_HA_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_ATOM_FEATURIZATION_ATOM_TEXTRAY_RQVAE_USER_FEATURE_TEXTRAY_RQVAE_USER_ADS_TEXTRAY_RQVAE_CLUSTER_ID2_1_user_sparse_arch",
+        "table_DENSE_BMB__GFF_R1321_INSTAGRAM_USER_SUM_2_COUNTER_IG_ORGANIC_BRAND_PROFILE_ENGAGEMENT_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_LEGACY_MIGRATION_BROWSE_ENVIRONMENT_TRAITS_BATTERY_LEVEL_user_sparse_arch",
+        "table_densebmb_1_1_MBDT_user_sparse_arch"
+      ],
+      "device_index": 5
+    },
+    {
+      "tbe_uuid": "868901c6-dddd-42cb-8b3b-ecc2378c1d0a",
+      "embedding_specs": [
+        {
+          "num_embeddings": 487,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 757,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 72363,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 282670,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 773,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5748,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1015487,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3875104,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 12,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3684743,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4372274,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        6,
+        6,
+        6,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__GSF_FLOAT_AD_CREATIVE_FATIGUE_SCORE_mix_sparse_arch",
+        "table_DENSE_BMB__GFF_R1506146_ADS_ENTITY_EQUIVALENCE_KEY_SUM_2_RATIO_CLICK_IMPRESSION_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_USER_AD_CLICK_PPR_REC_EKEY_RMV3_ID_MATCHING_EFE_HARD_MATCH_RMV3_AD_50K_CENTROID_TOP20_ID_LIST_INTERSECTION_IDENTITY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_VLB_IMAGE_200K_KNN_DECODED_mix_sparse_arch",
+        "table_densebmb_44_44_MBDT_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_IMDS_TEXTRAY_ID_MATCHING_AD_IMPRESSION_IMDS_WEIGHTED_TIME_GAP_POOLING_AD_IMPRESSION_TEXTRAY_SMALL_EMBEDDING_4K_CLUSTER_IDENTITY_mix_sparse_arch",
+        "table_group_31_user_sparse_arch",
+        "table_GSF_IDLIST_REQUEST_LEVEL_IG_ADS_FEED_SEEN_STATE_AUTHOR_CLUSTER_ALL_LONG_DWELLTIME_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_CLICK_ECG_IG_AD_CLICK_NON_REELS_AD_ACCOUNT_ID_TOP50_7D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_EVENT_TYPE_LIST__2_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_IG_REELS_INSTAGRAM_ENGAGEMENT_REALTIME_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_AUTHOR_ID_SCORE_LIST_IG_REELS_INSTAGRAM_ENGAGEMENT_EVENTS_HIGH_INTENT_AD_EVENT_TYPE_HIGH_INTENT_AD_1440MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_IMPRESSION_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_AD_ACCOUNT_ID_EVENT_TYPE_ALL_1440MIN_user_sparse_arch"
+      ],
+      "device_index": 7
+    },
+    {
+      "tbe_uuid": "fb6bfe5b-d9c2-461d-8a48-309a4583abfb",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 141095,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 69695,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 72221,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4053,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2716612,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1397269,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6782903,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1389,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 457,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6313539,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 33230,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        5,
+        5,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_UDS_FIR_AD_IMPRESSION_UNSAMPLED_PHOTO_DNA_HASH__MOST_RECENT_500__F3_ADPUBLISHER_ADS_CREATIVE_FATIGUE_IMDS_PHOTO_DNA_HASH_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_VLBLENDER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_LVB_TEXT_100K_KNN_FIX_QUANTIZED_DECODED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_POSTRAY_TEXTRAY_MARSV1_ADS_SIDE_TEXTRAY_50K_CLUSTER_IDS_AD_SIDE_FEATURE_IDENTITY_mix_sparse_arch",
+        "table_GSF_IDLIST_MEGATAXON_AD_CLUSTERING_V2_DECODED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_DA_PRODUCT_FEATURES_NATIVE_BATCH_FPT_AD_CATEGORY_IMPS_TOP_20_ENGAGED_L4_CATEGORY_ID_IMPS_7D_IDENTITY_mix_sparse_arch",
+        "table_group_38_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_UUDL_OFFSITE_CONVERSION_WEB_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_5MIN_PIXEL_ID_PAGEVIEW_1440MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_NATIVE_BATCH_SI_MONETIZATION_USER_TO_FRIENDS_SPARSE_FUNDRAISER_USER_TO_FRIENDS_FUNDRAISER_LIST_VIEW_FUNDRAISER_CAMPAIGN_ID_D_45_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_GT_3S_AD_ID_LATEST50_7D_ECG_user_sparse_arch",
+        "table_MOBILE_DEVICE_BRAND_MODEL_HASH_MAPID_TRANSFORMED_ID_LIST_user_sparse_arch",
+        "table_MOBILE_SCREEN_WIDTH_AND_DEVICE_TYPE_ENUM_AND_IG_DEVICE_WIDTH_AND_IG_DEVICE_HEIGHT_QUADGRAM_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_IMPRESSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_ADD_EEK_NO_CREATIVE_ALL_EVENTS_720MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_CONTENT_UNDERSTANDING_USER_AD_CLUSTERS_USER_ENGAGED_ADS_CLUSTERS_28D_user_sparse_arch"
+      ],
+      "device_index": 4
+    },
+    {
+      "tbe_uuid": "109b6b4e-bf96-4400-a004-a6d22293796e",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 14451,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 714,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784941,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4364852,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 257,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6171979,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 758,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 257,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_AD_BUSINESS_ID_TOP_7D__SPARSE_AD_BUSINESS_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_PA_INTERESTFM_AD_ACCOUNT_AD_ACCOUNT_INTERESTFM_HASHTAG_GENERATION_MM_10K_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C67_ADS_USER_SUM_DECAY_900_84_PAGE_TYPE_ADFINDER_STORY_TYPE_RATIO_CLICK_IMPRESSION_mix_sparse_arch",
+        "table_densebmb_84_84_MBDT_mix_spec_densebmb_regular",
+        "table_group_15_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_GT_3S_AD_ID_TOP50_28D_ECG_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_AUTHOR_RID_LIST_user_sparse_arch",
+        "table_densebmb_5_5_MBDT_user_sparse_arch",
+        "table_densebmb_user_side_0_77_77_MBDT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_XPUB_FLEXIBLE_BATCH_INTEREST_SCORE_XPUB_INTEREST_SCORE_USER_EVENT_7D_user_sparse_arch",
+        "table_densebmb_60_60_MBDT_user_spec_densebmb_regular",
+        "table_densebmb_5_5_MBDT_user_spec_densebmb_regular"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "2cdb0c8f-39c0-4b8b-ade1-d655e1c0101e",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4572,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2248,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 13569887,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 43934,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 10,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 695,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 16,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4455728,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_UDS_FIR_AD_IMPRESSION_UNSAMPLED_PHOTO_DNA_HASH__MOST_RECENT_200__F3_ADPUBLISHER_ADS_CREATIVE_FATIGUE_IMDS_PHOTO_DNA_HASH_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_FAM_FBE_FLEXIBLE_BATCH_ADS_INTERESTFM_FEATURES_AD_INTERESTFM_UIR_TOP_5_CLUSTERS_IDENTITY_mix_sparse_arch",
+        "table_GSF_IDLIST_PRODUCT_SET_COUNT_IDF_XRAY_V11_CONCEPT_100_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_AUTO_ID_MATCHING__SPARSE_NEW_PAGE_RID__GFF_S_C40010071_ADS_USER_PAGE_OTHER_CLICKS_USER_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D84_mix_sparse_arch",
+        "table_group_36_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SEMID_FLEXIBLE_BATCH_USER_IMPRESSION_28D_F3_AD_IMPRESSION_TOP50_COUNT_TEXTRAY_TRIGRAM_SEM_IDS_USERSIDE_28D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_FLEXIBLE_BATCH_INTERESTFM_USER_USER_INTERESTFM_HASHTAG_GENERATION_MM__70K_7D_user_sparse_arch",
+        "table_EVENT_AGG_2D_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_PLACEMENT_PAGE_TYPE_LIST_user_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_R1302_ADS_USER_LATEST_EVENT_TIMESTAMP_7_TIME_SINCE_CLICK_user_sparse_arch",
+        "table_densebmb_29_29_MBDT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_ALL_EVENTS_240MIN_user_sparse_arch"
+      ],
+      "device_index": 5
+    },
+    {
+      "tbe_uuid": "271f67d0-b068-47c4-9dc0-4d19b1efcbc8",
+      "embedding_specs": [
+        {
+          "num_embeddings": 227,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1605631,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 31,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 628,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6783150,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 478,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 237,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4539974,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5755862,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 668,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        7,
+        7,
+        7,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__GFF_R1313_ADS_USER_SUM_2_CONVERSION_TYPE_VERSION_COUNTER_CONVERSION_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_INSTAGRAM_MEDIA_ID_TOP_7D_TO_28D__SPARSE_INSTAGRAM_MEDIA_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_ADSLLM_IFT_AD_SIDE_ADS_LLM_ADSLLAMA_MM_KEYWORDS_LIST_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_F3_ADFINDER_USER_ADS_CREATIVE_FATIGUE_FLEXIBLE_BATCH_HOURLY_BATCH_USER_FATIGUE_HASHED_ENCODED_F3_7D_PDNA_SPOOKY_UINT32_FP16_IDLIST_ST_DECODED_F3_ADPUBLISHER_ADS_CREATIVE_FATIGUE_IMDS_PHOTO_DNA_HASH_ID_ST_HASHED_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_7D_mix_sparse_arch",
+        "table_densebmb_68_68_MBDT_mix_spec_densebmb_regular",
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_UDS_FIR_AD_IMPRESSION_AD_ENTITY_EQUIVALENCE_KEY_LIST__84_DAYS__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_spec_id_matching",
+        "table_group_30_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_GRAPH_LEARNING_FLEXIBLE_BATCH_GLFF_GLFF_PPR_FEATURES_2025H1_GLFF_2025H1_PPR_IDLIST_OFFSITE_ALL_ONSITE_ALL_USER_EKEY_user_sparse_arch",
+        "table_DENSE_BMB__GFF_C883_INSTAGRAM_USER_SUM_28_PAGE_TYPE_49_RATIO_IG_VIDEO_VIEW_COUNT_IG_VIDEO_VIEW_SESSION_IMP_EXPLODED_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_NUM_ADS_SEEN_LAST_1HR_F3_DENSE_IG_USER_NUM_ADS_SEEN_LAST_1HR_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_NON_ENGAGEMENT_IMP_NO_CLICK_USER_AD_NON_ENGAGE_AD_ACCOUNT_ID_24H_LATEST_N_WITH_TIMESTAMP_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_USER_LATESTN_AD_ID_CLICK_HA_IG_ADS_USER_LATEST_20_1D_PAGE_TYPE_94_95_AD_ID_CLICK_HA_user_sparse_arch",
+        "table_densebmb_2025h1_3_3_MBDT_user_spec_densebmb_igctr_25h1"
+      ],
+      "device_index": 6
+    },
+    {
+      "tbe_uuid": "1cc69503-aa5a-46c3-8cb8-b598b1082317",
+      "embedding_specs": [
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 71905,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3154533,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3349,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5669160,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 11,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 296,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5570279,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        0,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ],
+      "table_names": [
+        "table_group_48_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_ALL_EVENTS_1440MIN__SPARSE_AD_ACCOUNT_ID_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_IG_STORY_AD_USER_LOW_INTENT_V1_NAVIGATION_GESTURE_AUTHOR_RID_7D__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_SFV_TOP_CLUSTER_IDS_FOR_ADS_VIDEO_SFV_TOP_THIRD_CLIP_50K_QUANTIZED_DECODED_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_7D_mix_sparse_arch",
+        "table_SPARSE_TRACKING_TARGET_ID_IDENTITY_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C70077_ADS_USER_IMPRESSION_NEW_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D7__SPARSE_NEW_PAGE_RID_mix_spec_id_matching",
+        "table_MATCHING_MRI__F3_ADFINDER_USER_ADS_UDS_FIR_APPS_APP_ID_LIST__200_INDEXES__SPARSE_MOBILE_APP_ID_mix_spec_mrim_igctr_25h1",
+        "table_F3_ADFINDER_USER_ADS_XPUB_FLEXIBLE_BATCH_TOP_ACTION_ADS_20_XPUB_TOP_20_ACCESSED_AD_IDS_USER_EVENT_7D_user_sparse_arch",
+        "table_DENSE_BMB__GSF_FLOAT_REQUEST_LEVEL_OS_VERSION_MAJOR_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_LEGACY_MIGRATION_BROWSE_ENVIRONMENT_TRAITS_MOBILE_APP_BUILD_user_sparse_arch",
+        "table_GFF_IDS_C30132_INSTAGRAM_IGUSER_IG_FEED_ADS_TIMESPENT_PAIR_IG_ACTOR_RID_SORTBY_SCORE_IG_TIMESPENT_TOP200_D28_user_sparse_arch"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "dc3006ee-2747-494d-bdba-f49d5940c107",
+      "embedding_specs": [
+        {
+          "num_embeddings": 396760,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 14148422,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 791,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5748,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 580,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 10252398,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 13569887,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 79,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 96575,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 13,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 149,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 668,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 762,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17
+      ],
+      "table_names": [
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_ADSLLAMA_EEL_EMB_ADS_ADSLLAMA_EEL_EMB_FEATURES_COCLICK_100M_RM_SIMCSE_DDP_300K_KNN_FB_DECODED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SEM_ID_AD_SEMID_CRDL_RQ2048X6_PREFIX5_SEM_IDS_IDENTITY_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_IMDS_MEGATAXON_CATEGORY_ID_MATCHING_USER_AD_IMDS_WEIGHTED_TIME_GAP_POOLING_AD_IMPRESSION_MEGATAXON_CATEGORY_L2_IDENTITY_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_IMDS_TEXTRAY_ID_MATCHING_AD_CLICK_IMDS_WEIGHTED_TIME_GAP_POOLING_AD_CLICK_TEXTRAY_SMALL_EMBEDDING_4K_CLUSTER_IDENTITY_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_S_R64504_ADS_USER_CLICK_NEW_PAGE_RID_SORTBY_TIME_EVENT_TS_TOP200_D2__SPARSE_NEW_PAGE_RID_mix_spec_id_matching",
+        "table_TTH_AGES_densebmb_IG_CREATIVE_MEDIA_CAPTION_LENGTH_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_AUTO_ID_MATCHING__SPARSE_AD_BUSINESS_ID__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_AD_BUSINESS_ID_TOP_7D_TO_28D_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_SPARSE_NEW_PAGE_RID__GFF_S_R10265_ADS_USER_USER_PAGE_EVENT_USER_PAGE_RID_SORTBY_TIME_EVENT_TS_TOP50_D7_mix_spec_tail_sigrid_features",
+        "table_F3_ADFINDER_USER_ADS_SEMID_FLEXIBLE_BATCH_USER_IAB_METRICS_28D_F3_IAB_METRICS_TOP50_COUNT_TEXTRAY_TRIGRAM_SEM_IDS_USERSIDE_28D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SEM_ID_USER_IMP_7D_CRDL_SUM_SEM_ID_TRIGRAM_user_sparse_arch",
+        "table_AGES_DENSEBMB__F3_ADFINDER_USER_ADS_LEGACY_MIGRATION_AAP_REBUILT_MOBILE_ATTRIBUTE_DFC_AAP_REBUILT_MOBILE_ATTR_DISPLAY_SIZE_INCH_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_IG_STORIES_EVENT_TYPE_LIST__1_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_VLBLENDERV2_AD_AND_USER_SIDE_FEATURES_CTX_USER_NUM_VIDEO_VIEW_ADS_PAST_7D_VLBLENDER_V2_CLUSTER_IDS_user_sparse_arch",
+        "table_densebmb_46_46_MBDT_user_spec_densebmb_regular",
+        "table_densebmb_85_85_MBDT_user_spec_densebmb_regular",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_OLD_IG_USER_COUNT_DENSE_REALTIME_SAFE_V2_COUNT_FLOAT_USER_EVENT_INSTAGRAM_ORGANIC_MEDIA_TAP_2D_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_MAX_TIMESPENT_PER_AD_F3_DENSE_IG_USER_MAX_TIMESPENT_PER_AD_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C1290333_ADS_USER_SUM_84_PAGE_TYPE_RATIO_GOOD_CLICK_1SEC_IMPRESSION_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 1
+    },
+    {
+      "tbe_uuid": "1eedda44-2ebc-4455-8b2c-18481f87ef33",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 275878,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 294,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 33,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 16,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3349,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1087830,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6783306,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3416342,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 748724,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 96,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 626,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6708940,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        7,
+        7,
+        7,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_TOP_ENGAGED_ENTITY_ID_SCORE_LIST_E_KEY_ALL_EVENTS_720MIN__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C40011550_ADS_RID_PAGE_LINK_CLICKS_USER_PAGE_RID_TOP_N_WITH_TIMESTAMP_EVENT_FREQUENCY_TOP200_D173__SPARSE_NEW_PAGE_RID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_VLBLENDER_DOUBLE_CLUSTERING_ADS_SIDE_IMAGE_UNDERSTANDING_VLBLENDER_AD_SIDE_FEATURES_ID_LIST_REALTIME_5_DECODED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_AUDIO_UNDERSTANDING_FEATURES_AUDIO_UNDERSTANDING_CLUSTERING_200_48_DECODED_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_AUTOMATED_SHOPPING_ADS_AUTO_TARGETING_COUNTER_AND_VALUE_FEATURES_AUTO_CA_PAGE_VIEW_COUNT_mix_sparse_arch",
+        "table_densebmb_28_28_MBDT_mix_spec_densebmb_regular",
+        "table_MATCHING_MRI__F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_ENTITY_EQUIVALENCE_KEY__200_INDEXES__F3_ADPUBLISHER_ADS_GRAPH_LEARNING_SATORI_SATORI_REALTIME_EEK_SATORI_ONSITE_CONV_EEK_RT_RW_mix_spec_mrim_igctr_25h1",
+        "table_group_20_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_NATIVE_BATCH_OAE_ML_IAB_NUM_NO_BOUNCE_IAB_NUM_NO_BOUNCE_SPARSE_SEPARABLE_ID_SPARSE_USER_PIXEL_ID_IDLIST_14D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_GT_3S_AD_ID_TOP50_7D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_CONTENT_UNDERSTANDING_MARKETPLACE_POSITIVE_ENGAGEMENT_F3_MP_USER_POSITIVE_ENGAGEMENT_2D_user_sparse_arch",
+        "table_EVENT_AGG_1D_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_DWELLING_TIME_LIST_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_LEGACY_MIGRATION_USER_SESSION_DFC_USER_AD_SESSION_IMP_user_sparse_arch",
+        "table_densebmb_17_17_MBDT_user_sparse_arch",
+        "table_GFF_IDS_C30133_INSTAGRAM_IGUSER_IG_STORY_ADS_TIMESPENT_PAIR_IG_ACTOR_RID_SORTBY_SCORE_IG_TIMESPENT_TOP200_D28_user_sparse_arch"
+      ],
+      "device_index": 7
+    },
+    {
+      "tbe_uuid": "21882812-8644-4f1a-8926-c8fa9ebc1ef5",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 132508,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 102,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 433,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6780771,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 13569887,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 216,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 33187,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 278,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6737064,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 511,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 614,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 529,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 23,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__SPARSE_UTR_GFF_S_C19823_INSTAGRAM_IGUSER_IG_AD_TIME_SPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP50_D14__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_sparse_arch",
+        "table_DENSE_BMB__F3_ADINDEXER_ADS_ID_MATCHING_AUTO_AUTO_ID_MATCHING__SPARSE_NEW_VIDEO_ID__GSF_IDLIST_USER_EVENT_CONVERSION_SPARSE_NEW_VIDEO_ID_TOP_7D_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_PA_INTERESTFM_AD_ACCOUNT_AD_ACCOUNT_INTERESTFM_OPEN_VOCAB_MM_100K_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_TIMESPENT_STORY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C870_ADS_USER_SUM_DECAY_900_84_ACCOUNT_ID_PAGE_TYPE_COUNTER_CLICK_mix_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_RAX_ML_FLEXIBLE_BATCH_IAB_PRODUCT_MATCHING_FEATURES_USER_TOP_PRODUCTS_F3_IAB_LH_USER_TOP_30_PRODUCTS_CLICKED_28D_user_sparse_arch",
+        "table_GSF_IDLIST_USER_FATIGUED_CREATIVES_TOP_1000_ENCODED_user_sparse_arch",
+        "table_EBFS_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_PAGE_TYPE_ID__7_DAYS_user_sparse_arch",
+        "table_EVENT_MOST_RECENT_10_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURES_FROM_FMCU_RMV3_STAGE3_AD_50K_CENTROID_TOP20_CLUSTER_IDS_user_sparse_arch",
+        "table_densebmb_62_62_MBDT_user_sparse_arch",
+        "table_TIMEGAP_WITH_AD_REQUEST__F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_SEEN_STATE_VIDEO_ID_DWELLTIME_IG_SEEN_STATE_VIDEO_ID_DWELLTIME_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_NATIVE_BATCH_GFF_C72000_C72000_ADS_USER_SUM_84_PAGE_TYPE_CONVERSION_TYPE_V2_EXPLODED_ADFINDER_STORY_TYPE_EXPLODED_COUNTER_IMPRESSION_CONVERSION_TYPE_V2_60_ADFINDER_STORY_TYPE_128_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C74700_VIDEO_ADS_CONSUMPTION_USER_SUM_7_PAGE_TYPE_COUNTER_FCT_VIDEO_IMPRESSION_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C3092_ADS_USER_SUM_84_PAGE_TYPE_COUNTER_IMPRESSION_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_ADS_ML_MODELING_SHORT_AGGREGATION_WINDOW_DENSE_FEATURES_GFF_R1320_ADS_USER_SUM_4_HOUR_COUNTER_CLICK_GFF_R1320_ADS_USER_SUM_4_HOUR_COUNTER_CLICK_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 4
+    },
+    {
+      "tbe_uuid": "89c4e8e5-2004-4ec5-b189-296c40a34209",
+      "embedding_specs": [
+        {
+          "num_embeddings": 569,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5431054,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 224,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1647008,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5586548,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6750223,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3231183,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7645696,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 652,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 553,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 645,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__F3_ADPUBLISHER_IG_IG_ADS_RANKING_IG_STORY_ACTION_COUNT_AD_SPARSE_RT_IG_STORY_ENTITY_EQUIVALENCE_KEY_NAVIGATION_TAP_FORWARD_COUNT_2D_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C11563_ADS_USER_CLICK_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_LATEST_N_WITH_TIMESTAMP_EVENT_TS_TOP100_D84__SPARSE_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_FOR_APP_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_S_R27051_ADS_USER_IMPRESSION_ENTITY_EQUIVALENCE_KEY_SORTBY_TIME_EVENT_TS_TOP50_D2__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_GRAPH_LEARNING_SATORI_SATORI_REALTIME_ACCOUNT_ID_SATORI_ONSITE_CONV_ACCOUNT_ID_RT_RW_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_ALL_EVENTS_240MIN_MATCHING_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_56D_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_NATIVE_BATCH_IG_BOR_PROFILE_ACTION_CROSS_FEATURES_ORGANIC_PROSPECTING_PROFILE_ACTIONS_COUNT_WEBCLICK_28D_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_SPARSE_AD_CONVERSION_TAG_PIXEL_ID__GFF_S_R11595_ADS_USER_CONVERSION_CONVERSION_UNATTR_OPT_PIXEL_RID_SORTBY_TIME_EVENT_TS_TOP50_D1_mix_spec_tail_sigrid_features",
+        "table_SPARSE_UTR_GFF_S_C19821_INSTAGRAM_IGUSER_IG_ORGANIC_TIMESPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP50_D14_user_sparse_arch",
+        "table_SPARSE_UTR_GFF_S_C19823_INSTAGRAM_IGUSER_IG_AD_TIME_SPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP50_D14_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_CLICK_ECG_IG_AD_CLICK_REELS_AD_ID_INT_TOP50_7D_ECG_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_HIVE_VLBV2_LVB_AVG_CLUSTER_FIX_CODEWORD_IDS_user_sparse_arch",
+        "table_TTH_AGES_densebmb_IG_REQUEST_IS_FIRST_PAGE_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_ENGAGEMENT_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_E_KEY_INSTAGRAM_PROFILE_720MIN_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_NATIVE_BATCH_GFF_C72000_C72000_ADS_USER_SUM_28_PAGE_TYPE_CONVERSION_TYPE_V2_EXPLODED_ADFINDER_STORY_TYPE_EXPLODED_COUNTER_IMPRESSION_CONVERSION_TYPE_V2_24_ADFINDER_STORY_TYPE_263_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_NATIVE_BATCH_GFF_C72000_C72000_ADS_USER_SUM_84_PAGE_TYPE_CONVERSION_TYPE_V2_EXPLODED_ADFINDER_STORY_TYPE_EXPLODED_COUNTER_IMPRESSION_CONVERSION_TYPE_V2_58_ADFINDER_STORY_TYPE_263_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C1432087_ADS_USER_SUM_84_PAGE_TYPE_RATIO_GOOD_CLICK_TTI_CLICK_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 1
+    },
+    {
+      "tbe_uuid": "0b104ae7-201f-4d8b-a085-598fdc4ce2a3",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4219081,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2248,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 32,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6227329,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 134200,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 713,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 420,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6055689,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6495731,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 33,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 306,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 642,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 101,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__GFF_IDS_C70077_ADS_USER_IMPRESSION_NEW_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D28__SPARSE_NEW_PAGE_RID_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C70077_ADS_USER_IMPRESSION_NEW_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D7__SPARSE_NEW_PAGE_RID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_ADS_RANKING_FLEXIBLE_BATCH_F3_TOP_ADVERTISERS_F3_TOP_ADVERTISERS_ID_LIST_IDENTITY_mix_sparse_arch",
+        "table_GSF_IDLIST_PRODUCT_SET_COUNT_IDF_XRAY_V11_CONCEPT_100_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C1110_INSTAGRAM_USER_SUM_28_INSTAGRAM_ACTOR_FBIDV2_COUNTER_IG_VIDEO_VIEW_COUNT_mix_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_XPUB_FLEXIBLE_BATCH_TOP_ACTION_ADS_XPUB_TOP_ACCESSED_AD_IDS_USER_EVENT_14D_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_VLBLENDER_AD_SIDE_CLUSTER_user_sparse_arch",
+        "table_TTH_AGES_densebmb_USER_SECONDS_SINCE_LAST_AD_CLICK_user_sparse_arch",
+        "table_densebmb_30_30_MBDT_user_sparse_arch",
+        "table_GFF_IDS_C70077_ADS_USER_IMPRESSION_NEW_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D7_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_USER_LATESTN_AD_ID_CLICK_HA_IG_ADS_USER_LATEST_20_1D_PAGE_TYPE_35_49_72_94_95_108_AD_ID_CLICK_HA_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_EXPLODED_REALTIME_R1304_ADS_USER_SUM_7_PAGE_TYPE_CONVERSION_TYPE_VERSION_EXPLODED_COUNTER_CLICK_CONVERSION_TYPE_VERSION_48_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_LEGACY_MIGRATION_BROWSE_ENVIRONMENT_TRAITS_BATTERY_LEVEL_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_IG_DEVICE_HEIGHT_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_USER_AD_SESSION_IMP_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "2397a96c-6fdf-4ca7-bb49-7915b08dde8a",
+      "embedding_specs": [
+        {
+          "num_embeddings": 413,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 142996,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 544,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3349,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5083251,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 381,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 12,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 64670,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4859936,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "table_names": [
+        "table_DENSE_BMB__VIDEO_DURATION_MS_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_TEXTRAY_OCR_IMAGE_100K_KNN_DECODED_mix_sparse_arch",
+        "table_densebmb_42_42_MBDT_mix_sparse_arch",
+        "table_MATCHING_MRI__F3_ADFINDER_USER_ADS_UDS_FIR_SETSUNA_PAGES_PAGE_RID_LIST__200_INDEXES__SPARSE_NEW_PAGE_RID_mix_spec_mrim_igctr_25h1",
+        "table_group_3_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_AD_CTA_ITEM_IDS_FEED_F3_SPARSE_IG_USER_AD_CTA_ITEM_IDS_FEED_user_sparse_arch",
+        "table_DENSE_BMB__GFF_R7009_ADS_USER_SUM_7_COUNTER_CONVERSION_UNATTR_OPT_ALL_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_EVENT_TYPE_LIST__1_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_VLBLENDERV2_AD_AND_USER_SIDE_FEATURES_CTX_USER_NUM_REPLY_ADS_PAST_7D_VLBLENDER_V2_CLUSTER_IDS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_ALL_EVENTS_1440MIN_user_sparse_arch"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "108e4f4b-0e40-4b56-a0ed-4785620f4678",
+      "embedding_specs": [
+        {
+          "num_embeddings": 117,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5801,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 27242,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 13569887,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 17,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3700960,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3454156,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__GFF_R1309_ADS_USER_SUM_2_PAGE_TYPE_CONVERSION_TYPE_VERSION_COUNTER_CONVERSION_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C10525_ADS_USER_IMPRESSION_NEW_VIDEO_ID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D28__SPARSE_NEW_VIDEO_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_POSTRAY_TEXTRAY_MARSV1_ADS_SIDE_POSTRAY_4K_CLUSTER_IDS_AD_SIDE_FEATURE_IDENTITY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_SFV_TOP_CLUSTER_IDS_FOR_ADS_VIDEO_SFV_TOP_AVG_CLIP_20K_QUANTIZED_IDENTITY_mix_sparse_arch",
+        "table_group_34_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SEM_ID_USER_CLICK_3D_TEXTRAY_AVG_SEM_ID_user_sparse_arch",
+        "table_NGRAM_IG_REQUEST_NGRAM_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_IG_REELS_INSTAGRAM_ENGAGEMENT_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_AUTHOR_ID_SCORE_LIST_IG_REELS_INSTAGRAM_ENGAGEMENT_EVENTS_HIGH_INTENT_AD_EVENT_TYPE_HIGH_INTENT_AD_1440MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_IG_REELS_INSTAGRAM_ENGAGEMENT_REALTIME_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_AUTHOR_ID_SCORE_LIST_IG_REELS_INSTAGRAM_ENGAGEMENT_EVENTS_HIGH_INTENT_AD_EVENT_TYPE_HIGH_INTENT_AD_720MIN_user_sparse_arch"
+      ],
+      "device_index": 7
+    },
+    {
+      "tbe_uuid": "7624722d-f848-4ef4-88b8-0f4dea901857",
+      "embedding_specs": [
+        {
+          "num_embeddings": 183253,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 621919,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5748,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 112987,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784917,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 31,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5980506,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4633185,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 13,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ],
+      "table_names": [
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_UBA_ADS_ADSLLAMA_UBA_AD_ID_590_4_EMB_DIM_384_FEATURE_DECODED_mix_sparse_arch",
+        "table_GSF_IDLIST_CLUSTER_BASED_AD_ACCOUNT_ID_PPR_EXPANSION_23_V1_IDENTITY_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_TEXTRAY_ID_MATCHING_CTX_AD_ONSITE_CONVERSION_REPLY_TEXTRAY_CLUSTER_IDENTITY_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C11563_ADS_USER_CLICK_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_LATEST_N_WITH_TIMESTAMP_EVENT_TS_TOP100_D84__SPARSE_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_mix_spec_id_matching",
+        "table_group_5_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_UUDL_OFFSITE_CONVERSION_APP_REALTIME_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_5MIN_APP_ID_FB_MOBILE_ACTIVATE_APP_1440MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_GT_3S_REELS_AD_ID_TOP50_28D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_IAW_EVENT_TYPE_ID__1_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_PAGE_TYPE_ID__84_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_IMPRESSION_REALTIME_SAFE_TOP_ENGAGED_ENTITY_ID_SCORE_LIST_ADD_EEK_NO_CREATIVE_ALL_EVENTS_1440MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_USER_LATESTN_AD_ID_CLICK_HA_IG_ADS_USER_LATEST_20_5MIN_PAGE_TYPE_94_95_AD_ID_CLICK_HA_user_sparse_arch",
+        "table_densebmb_10_10_MBDT_user_spec_densebmb_regular"
+      ],
+      "device_index": 2
+    },
+    {
+      "tbe_uuid": "bbe38bf4-7d3d-488c-86e4-a25e97838e40",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4092,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 182,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 429,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 563,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5313067,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784922,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 33201,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 762,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 758,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 595,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 300,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 146,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        7,
+        7,
+        7,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__GFF_S_R11596_ADS_USER_CONVERSION_PIXEL_RID_SORTBY_TIME_EVENT_TS_TOP50_D2__SPARSE_NEW_PAGE_RID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_GEOGRAPHIC_REGION_SPARSE_IG_ACTOR_REGION_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C1112_INSTAGRAM_USER_SUM_28_INSTAGRAM_ACTOR_FBIDV2_COUNTER_IG_ORGANIC_IMPRESSION_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C30132_INSTAGRAM_IGUSER_IG_FEED_ADS_TIMESPENT_PAIR_IG_ACTOR_RID_SORTBY_SCORE_IG_TIMESPENT_TOP200_D28__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_spec_id_matching",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_AUTOMATED_SHOPPING_ADS_AUTO_TARGETING_EXTENDED_FEATURES_AUTO_CA_WCA_PURCHASE_EXTEND_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C67_ADS_USER_SUM_84_PAGE_TYPE_ADFINDER_STORY_TYPE_COUNTER_CLICK_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADPUBLISHER_ADS_LEGACY_MIGRATION_FLEXIBLE_BATCH_ADGROUP_STAT_DFC_ADGROUP_CTR_NO_CORRECTION_90D_mix_spec_tail_sigrid_features",
+        "table_group_13_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_NATIVE_BATCH_OAE_ML_IAW_AUTOFILL_ALL_FEATURES_V4_IAW_ACCEPTED_CONTACT_AUTOFILL_SPARSE_ENTITY_EQUIVALENCE_KEY_V4_28D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_CLICK_ECG_IG_AD_CLICK_NON_REELS_AD_ID_INT_TOP50_28D_ECG_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURES_FROM_FMCU_RMV3_STAGE3_AD_50K_CENTROID_TOP20_CLUSTER_IDS_user_sparse_arch",
+        "table_densebmb_2_2_MBDT_user_sparse_arch",
+        "table_densebmb_31_31_MBDT_user_sparse_arch",
+        "table_densebmb_14_14_MBDT_user_spec_densebmb_regular",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_NUM_ORGANIC_POST_SEEN_FEED_F3_DENSE_IG_USER_NUM_ORGANIC_POST_SEEN_FEED_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_EXPLODED_REALTIME_R1307_ADS_USER_SUM_2_PAGE_TYPE_CONVERSION_TYPE_VERSION_EXPLODED_COUNTER_IMPRESSION_CONVERSION_TYPE_VERSION_48_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "b807f579-d160-4b1f-a78d-661e9705aa8c",
+      "embedding_specs": [
+        {
+          "num_embeddings": 205,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 396464,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6551575,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2295,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 433,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6131701,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 355,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 14,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1785,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3542131,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2671,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 16,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        8,
+        8,
+        8,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__GFF_C1112_INSTAGRAM_USER_SUM_28_INSTAGRAM_ACTOR_FBIDV2_RATIO_IG_ORGANIC_LIKE_IG_ORGANIC_IMPRESSION_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_NEW_CAMPAIGN_ID_TOP_7D_TO_28D__SPARSE_NEW_CAMPAIGN_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_ADSLLAMA_EEL_EMB_ADS_ADSLLAMA_EEL_EMB_FEATURES_COCLICK_100M_RM_SIMCSE_DDP_300K_KNN_IG_DECODED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBV2_VLB_AVG_RQ_VAE_DECODED_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_NO_CREATIVE_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_7D_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_IMDS_MEGATAXON_CATEGORY_ID_MATCHING_USER_AD_IMDS_WEIGHTED_TIME_GAP_POOLING_AD_IMPRESSION_MEGATAXON_CATEGORY_L3_IDENTITY_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_IMPRESSION_REALTIME_SAFE_TOP_ENGAGED_ENTITY_ID_SCORE_LIST_AD_EEK_ALL_EVENTS_1440MIN__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_spec_id_matching",
+        "table_TTH_AGES_densebmb_GFF_C870_ADS_USER_SUM_DECAY_900_84_ACCOUNT_ID_PAGE_TYPE_COUNTER_CLICK_mix_spec_tail_sigrid_features",
+        "table_group_37_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_FLEXIBLE_BATCH_IG_BOR_FOLLOW_SPARSE_FEATURES_ORGANIC_PROSPECTING_FOLLOWED_ADVERTISER_LIST_14D_user_sparse_arch",
+        "table_AGES_DENSEBMB__F3_ADFINDER_USER_ADS_LEGACY_MIGRATION_AAP_REBUILT_MOBILE_ATTRIBUTE_DFC_AAP_REBUILT_MOBILE_ATTR_POPULARITY_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_EVENT_TYPE_ID__1_DAYS_user_sparse_arch",
+        "table_F3_ADINDEXER_DA_PRODUCT_FEATURES_NATIVE_BATCH_FPT_USER_CATEGORY_CLKS_TOP_25_ENGAGED_L4_CATEGORY_ID_CLKS_7D_user_sparse_arch",
+        "table_IDSCORE_LIST_UTR_GFF_IDS_C30053_INSTAGRAM_IGUSER_IG_AD_TIME_SPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP100_D2_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_POSTRAY_AD_AND_USER_SIDE_FEATURES_CTX_USER_VIDEO_VIEW_AD_POSTRAY_4K_CLUSTER_IDS_user_sparse_arch",
+        "table_densebmb_29_29_MBDT_user_spec_densebmb_regular"
+      ],
+      "device_index": 5
+    },
+    {
+      "tbe_uuid": "b5b880ce-def6-4eb5-b1c9-a3041c020a81",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 61787,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 144013,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 685,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 603,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 692,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1776198,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784906,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 11,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 729,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 16,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6561149,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3086,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 420,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 507,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 22,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 613,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        9,
+        9,
+        9,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__GFF_IDS_C11526_ADS_USER_CLICK_ENTITY_EQUIVALENCE_KEY_LATEST_N_WITH_TIMESTAMP_EVENT_TS_TOP100_D84__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C40011550_ADS_RID_PAGE_LINK_CLICKS_USER_PAGE_RID_TOP_N_WITH_TIMESTAMP_EVENT_FREQUENCY_TOP200_D173__SPARSE_NEW_PAGE_RID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_FAM_FBE_FLEXIBLE_BATCH_FAM_ADS_LOCATION_FEATURES_F3_IDLIST_TOP_5_CITY_BY_IMP_7_DAYS_IDENTITY_mix_sparse_arch",
+        "table_GSF_IDLIST_MEGATAXON_MMF_AD_CLUSTERING_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_SPARSE_NEW_PAGE_RID__GFF_S_C40010064_ADS_USER_PAGE_LINK_CLICKS_USER_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D84_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C10524_ADS_USER_IMPRESSION_ENTITY_EQUIVALENCE_KEY_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D7__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_spec_id_matching",
+        "table_TTH_AGES_densebmb_GFF_C72000_ADS_USER_SUM_84_PAGE_TYPE_CONVERSION_TYPE_V2_ADFINDER_STORY_TYPE_COUNTER_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C72000_ADS_USER_SUM_28_PAGE_TYPE_CONVERSION_TYPE_V2_ADFINDER_STORY_TYPE_COUNTER_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C70516_ADS_USER_SUM_84_GEO_TARGETING_ID_GEO_TARGETING_CURRENT_RATIO_CLICK_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_group_17_user_sparse_arch",
+        "table_GSF_IDLIST_IG_USER_FOLLOW_GRAPH_CLUSTER_ALL_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_GT_3S_REELS_AD_ID_LATEST50_28D_ECG_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_EVENT_TYPE_LIST_user_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_R1321_INSTAGRAM_USER_LATEST_EVENT_TIMESTAMP_7_TIME_SINCE_IG_ORGANIC_LIKE_ENGAGEMENT_user_sparse_arch",
+        "table_densebmb_29_29_MBDT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_XPUB_FLEXIBLE_BATCH_INTEREST_SCORE_XPUB_INTEREST_SCORE_USER_EVENT_14D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_FB_ALL_POSTS_FEED_VPVS_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_FACTOR_IDS_FB_PAGE_USER_POST_FB_ALL_POST_MEGATAXON_I18N_TOP1_L7_PREDICTION_HASH_EVENT_TYPE_ALL_240MIN_user_sparse_arch",
+        "table_densebmb_30_30_MBDT_user_spec_densebmb_regular",
+        "table_densebmb_76_76_MBDT_user_spec_densebmb_regular",
+        "table_TTH_AGES_densebmb_IG_REQUEST_IS_FIRST_PAGE_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_CLICK_DENSE_REALTIME_SAFE_V2_COUNT_FLOAT_EARLY_TRIGGER_1MIN_AD_ID_ALL_240MIN_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_AVG_TIMESPENT_PER_ORGANIC_POST_FEED_F3_DENSE_IG_USER_AVG_TIMESPENT_PER_ORGANIC_POST_FEED_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 7
+    },
+    {
+      "tbe_uuid": "e8f91772-1d3e-4b7c-b492-4c3514e4356d",
+      "embedding_specs": [
+        {
+          "num_embeddings": 3395653,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 310,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5643,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1936559,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6790191,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6628581,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 431,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      "table_names": [
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_ADSLLAMA_EEL_EMB_ADS_ADSLLAMA_EEL_EMB_FEATURES_COCLICK_100M_RM_SIMCSE_DDP_HIVE_98BIT_CODEWORD_IDS_IDENTITY_mix_sparse_arch",
+        "table_GSF_IDLIST_AD_ACCOUNT_SF_SUB_VERTICAL_ID_IDENTITY_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_IMDS_POSTRAY_ID_MATCHING_IMDS_WEIGHTED_TIME_GAP_POOLING_AD_IMPRESSION_POSTRAY_CLUSTER_IDENTITY_mix_sparse_arch",
+        "table_group_1_user_sparse_arch",
+        "table_F3_ADFINDER_USER_DA_PRODUCT_FEATURES_NATIVE_BATCH_PFR_USER_SA_MAPPED_PRODUCT_CLK_HISTORY_LATEST_500_ENGAGED_USER_SA_MAPPED_PRODUCT_CLK_CLKS_7D_user_sparse_arch",
+        "table_GFF_S_R64505_ADS_USER_CLICK_NEW_ENTITY_RID_SORTBY_TIME_EVENT_TS_TOP200_D7_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_XPUB_FLEXIBLE_BATCH_TOP_ACTION_ADS_20_XPUB_TOP_20_ACCESSED_AD_IDS_USER_EVENT_28D_user_sparse_arch",
+        "table_AGES_DENSEBMB__F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_MIN_TIMESPENT_PER_AD_F3_DENSE_IG_USER_MIN_TIMESPENT_PER_AD_user_sparse_arch"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "9e566f9a-5d04-402f-8363-e7646c2fe3c1",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 144480,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 69695,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1342857,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 141217,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 733,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2734650,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6586887,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 66471,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1056064,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784904,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 134110,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        6,
+        6,
+        6,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_SEEN_STATE_IMAGE_ID_DWELLTIME_IG_SEEN_STATE_IMAGE_ID_DWELLTIME__SPARSE_INSTAGRAM_MEDIA_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_VLBLENDER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_LVB_AVG_100K_KNN_FIX_QUANTIZED_DECODED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_POSTRAY_TEXTRAY_MARSV1_ADS_SIDE_TEXTRAY_50K_CLUSTER_IDS_AD_SIDE_FEATURE_IDENTITY_mix_sparse_arch",
+        "table_GSF_IDLIST_IG_BUSINESS_AUTHOR_PPR_ORGANIC_ENGAGEMENT_UNIFORM_POPULAR_CLUSTERS_IDENTITY_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_VLBLENDER_ID_MATCHING_CTX_AD_ONSITE_CONVERSION_VLBLENDER_V2_CLUSTER_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C7006_ADS_USER_SUM_84_PAGE_TYPE_ADFINDER_STORY_TYPE_RATIO_CONVERSION_FINAL_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_group_29_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_UUDL_OFFSITE_CONVERSION_WEB_REALTIME_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_5MIN_PIXEL_ID_PAGEVIEW_1440MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_AD_LOOKALIKE_CUSTOM_AUDIENCE_OFFSITE_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_ENCODED_AD_CLUSTER_ID_EVENT_ALL_1440MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_AD_MT_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_FACTOR_IDS_TRIGGER_1MIN_ENTITY_EQUIVALENCE_KEY_AD_MEGATAXON_MMT_CLUSTER_EVENT_TYPE_ALL_240MIN_user_sparse_arch",
+        "table_GSF_IDLIST_REQUEST_LEVEL_SPARSE_PRODUCT_MPI_FB_TAXONOMY_ID_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_LT_1S_REELS_AD_ID_TOP50_28D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_IAW_EVENT_TYPE_ID__1_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_VLBLENDER_AD_SIDE_CLUSTER__84_DAYS_user_sparse_arch"
+      ],
+      "device_index": 6
+    },
+    {
+      "tbe_uuid": "6cfdf8e5-d448-44f6-a24b-2afb72db8069",
+      "embedding_specs": [
+        {
+          "num_embeddings": 37808487,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 569,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7411365,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 563,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1577803,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2478169,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "table_names": [
+        "table_group_49_mix_sparse_arch",
+        "table_AGES_DENSEBMB__F3_ADPUBLISHER_IG_IG_ADS_RANKING_IG_STORY_ACTION_COUNT_AD_SPARSE_RT_IG_STORY_ENTITY_EQUIVALENCE_KEY_NAVIGATION_TAP_FORWARD_COUNT_2D_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C70077_ADS_USER_IMPRESSION_NEW_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D1__SPARSE_NEW_PAGE_RID_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_S_R27051_ADS_USER_IMPRESSION_ENTITY_EQUIVALENCE_KEY_SORTBY_TIME_EVENT_TS_TOP50_D2__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_GRAPH_LEARNING_SATORI_SATORI_REALTIME_ACCOUNT_ID_SATORI_ONSITE_CONV_ACCOUNT_ID_RT_RW_GFF_S_C10215_ADS_RID_CLICK_AD_ACCOUNT_ID_SORTBY_TIME_EVENT_TS_TOP200_D173_MATCHING_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_28D_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADPUBLISHER_ADS_LEGACY_MIGRATION_FLEXIBLE_BATCH_ADGROUP_STAT_DFC_ADGROUP_CTR_NO_CORRECTION_90D_mix_sparse_arch",
+        "table_SPARSE_UTR_GFF_S_C19830_INSTAGRAM_IGUSER_IG_VIDEO_VIEW_COUNT_IG_ACTOR_ID_MOST_FREQUENT_IG_VIDEO_TIME_SPENT_MS_TOP50_D14_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_USER_TOPK_AD_ACCOUNT_ID_CLICK_HA_IG_ADS_USER_TOP_10_1D_PAGE_TYPE_94_95_AD_ID_CLICK_HA_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_PAGE_TYPE_ID_user_sparse_arch"
+      ],
+      "device_index": 1
+    },
+    {
+      "tbe_uuid": "23a3c91a-5d00-47dd-8ad8-15f2d9c1eebc",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 134792,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 70,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4459713,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 11,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 758,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 514,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__GFF_S_R64006_ADS_USER_CONVERSION_CONVERSION_UNATTR_OPT_ALL_SPARSE_AD_HYBRID_ID_SORTBY_TIME_EVENT_TS_TOP50_D7__F3_ADPUBLISHER_BASIC_ADS_RANKING_IMDS_AD_ACCOUNT_ID_AD_ACCOUNT_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_PA_INTERESTFM_AD_ACCOUNT_AD_ACCOUNT_INTERESTFM_HASHTAG_GENERATION_MM_100K_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C1112_INSTAGRAM_USER_SUM_7_INSTAGRAM_ACTOR_FBIDV2_COUNTER_IG_ORGANIC_IMPRESSION_mix_sparse_arch",
+        "table_densebmb_2025h1_7_7_MBDT_mix_spec_densebmb_igctr_25h1",
+        "table_group_14_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_AD_CTA_ITEM_IDS_REELS_F3_SPARSE_IG_USER_AD_CTA_ITEM_IDS_REELS_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_PLACEMENT_PAGE_TYPE_LIST_user_sparse_arch",
+        "table_densebmb_31_31_MBDT_user_sparse_arch",
+        "table_densebmb_51_51_MBDT_user_sparse_arch"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "f4872d2d-a2a6-4548-97ee-8e474a02d0e0",
+      "embedding_specs": [
+        {
+          "num_embeddings": 253623,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2404507,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 138776,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 445,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6442728,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 133588,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 703,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6382409,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2931646,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 773,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ],
+      "table_names": [
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_UBA_ADS_ADSLLAMA_UBA_AD_ID_590_EMB_DIM_96_FEATURE_DECODED_mix_sparse_arch",
+        "table_GSF_IDLIST_IG_BUSINESS_AUTHOR_PPR_ORGANIC_ENGAGEMENT_UNIFORM_ALL_CLUSTERS_IDENTITY_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_VLBLENDER_ID_MATCHING_CTX_AD_ONSITE_CONVERSION_VIDEO_VIEW_VLBLENDER_V2_CLUSTER_IDENTITY_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C30133_INSTAGRAM_IGUSER_IG_STORY_ADS_TIMESPENT_PAIR_IG_ACTOR_RID_SORTBY_SCORE_IG_TIMESPENT_TOP200_D28__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_spec_id_matching",
+        "table_group_7_user_sparse_arch",
+        "table_AGES_DENSEBMB__MOBILE_SCREEN_HEIGHT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_IAW_VIEW_DURATION_MS__1_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_VLBLENDER_AD_SIDE_CLUSTER__1_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_DA_PRODUCT_FEATURES_EVENTS_RT_USER_FPT_CLICKS_SAFE_LATEST_30_L3_FPT_CATEGORY_ID_CLKS_7D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_IMPRESSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_ADD_EEK_NO_CREATIVE_ALL_EVENTS_1440MIN_user_sparse_arch",
+        "table_NGRAM__IDSCORE_LIST_UTR_GFF_IDS_C30053_INSTAGRAM_IGUSER_IG_AD_TIME_SPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP100_D84_FIRST15__USER_COUNTRY_BUCKET__10000000_user_sparse_arch",
+        "table_densebmb_2025h1_5_5_MBDT_user_spec_densebmb_igctr_25h1"
+      ],
+      "device_index": 2
+    },
+    {
+      "tbe_uuid": "7afdc5b4-8341-4010-8f27-907ecb329a64",
+      "embedding_specs": [
+        {
+          "num_embeddings": 144619,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 107095,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2089,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4138,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 87,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2202374,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 177,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2360099,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3815474,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "table_names": [
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_VLBLENDER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_TEXTRAY_OCR_AVG_100K_KNN_FIX_QUANTIZED_DECODED_mix_sparse_arch",
+        "table_GSF_IDLIST_MEGATAXON_WITH_FIT_AD_CLUSTERING_V0_IDENTITY_mix_sparse_arch",
+        "table_SPARSE_AD_PRODUCT_FORMAT_TYPE_LIST_IDENTITY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_DA_PRODUCT_FEATURES_NATIVE_BATCH_FPT_AD_CATEGORY_IMPS_TOP_40_ENGAGED_L4_CATEGORY_ID_IMPS_7D_IDENTITY_mix_sparse_arch",
+        "table_densebmb_2025h1_6_6_MBDT_mix_spec_densebmb_igctr_25h1",
+        "table_BIGRAM__GSF_IDLIST_REQUEST_LEVEL_SPARSE_PRODUCT_MPI_FB_TAXONOMY_ID__SPARSE_NEW_PAGE_TYPE_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_ADS_ML_MODELING_SHORT_AGGREGATION_WINDOW_DENSE_FEATURES_GFF_R4025_ADS_USER_SUM_4_HOUR_BROWSER_TYPE_RATIO_XOUT_IMPRESSION_GFF_R4025_ADS_USER_SUM_4_HOUR_BROWSER_TYPE_RATIO_XOUT_IMPRESSION_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_TOP_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_VIDEO_VIEW_240MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_NON_ENGAGEMENT_IMP_NO_CLICK_USER_AD_NON_ENGAGE_AD_ACCOUNT_ID_4H_TOP_K_WITH_COUNT_user_sparse_arch"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "127a9653-cd46-44c3-954b-d53664180b41",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 109,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 635,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 273535,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5748,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 860921,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 66471,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784935,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7992550,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1382133,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 97543,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        6,
+        6,
+        6,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_SEEN_STATE_IMAGE_ID_DWELLTIME_IG_SEEN_STATE_IMAGE_ID_DWELLTIME__SPARSE_INSTAGRAM_MEDIA_ID_mix_sparse_arch",
+        "table_DENSE_BMB__IG_PAGE_POST_AD_PAGE_ID_NTH_IMP_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_USER_AD_CLICK_PPR_REC_EKEY_RMV3_SOFT_MATCHING_COSINE_SIMILARITY_BUCKETIZED_EFE_SOFT_MATCH_USER_AD_CLICK_PPR_REC_EKEY_RMV3_EMB_COSINE_SIMILARITY_RELEVANCE_SCORE_BUCKETIZED_IDENTITY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_VLB_TEXT_200K_KNN_DECODED_mix_sparse_arch",
+        "table_densebmb_49_49_MBDT_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_IMDS_TEXTRAY_ID_MATCHING_AD_IMPRESSION_IMDS_WEIGHTED_TIME_GAP_POOLING_AD_IMPRESSION_TEXTRAY_SMALL_EMBEDDING_4K_CLUSTER_IDENTITY_mix_sparse_arch",
+        "table_group_32_user_sparse_arch",
+        "table_GSF_IDLIST_IG_PROFILE_ACTION_AUTHOR_PPR_CLUSTER_POPULAR_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_AD_MT_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_FACTOR_IDS_TRIGGER_1MIN_ENTITY_EQUIVALENCE_KEY_AD_MEGATAXON_MMT_CLUSTER_EVENT_TYPE_ALL_240MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_LT_1S_AD_ID_TOP50_28D_ECG_user_sparse_arch",
+        "table_GFF_S_R64501_ADS_USER_CLICK_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_SORTBY_TIME_EVENT_TS_TOP200_D7_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_CLUSTERS_KNN_T1__TOP_100_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_VLBLENDERV2_AD_AND_USER_SIDE_FEATURES_CTX_USER_NUM_ALL_ONSITE_CONVERSION_ADS_PAST_7D_VLBLENDER_V2_CLUSTER_IDS_user_sparse_arch"
+      ],
+      "device_index": 6
+    },
+    {
+      "tbe_uuid": "a28b32c1-68ae-4a3f-8444-925b04afc518",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 14451,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 714,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784941,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4364852,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 257,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6171979,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 614,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 710,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_AD_BUSINESS_ID_TOP_7D__SPARSE_AD_BUSINESS_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_PA_INTERESTFM_AD_ACCOUNT_AD_ACCOUNT_INTERESTFM_HASHTAG_GENERATION_MM_10K_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C67_ADS_USER_SUM_DECAY_900_84_PAGE_TYPE_ADFINDER_STORY_TYPE_RATIO_CLICK_IMPRESSION_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_R11530_ADS_USER_CLICK_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_LATEST_N_WITH_TIMESTAMP_EVENT_TS_TOP50_D7__SPARSE_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_mix_spec_id_matching",
+        "table_group_15_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_GT_3S_AD_ID_TOP50_28D_ECG_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_AUTHOR_RID_LIST_user_sparse_arch",
+        "table_densebmb_5_5_MBDT_user_sparse_arch",
+        "table_densebmb_user_side_0_77_77_MBDT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_XPUB_FLEXIBLE_BATCH_INTEREST_SCORE_XPUB_INTEREST_SCORE_USER_EVENT_7D_user_sparse_arch",
+        "table_densebmb_20_20_MBDT_user_spec_densebmb_regular",
+        "table_densebmb_77_77_MBDT_user_spec_densebmb_regular"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "5739159a-f575-4ec6-a0e5-560e4ea33883",
+      "embedding_specs": [
+        {
+          "num_embeddings": 144314,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 71786,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 774,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 773,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 168364,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 134130,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1389,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4489188,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "table_names": [
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_VLBLENDER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_LVB_IMG_100K_KNN_FIX_QUANTIZED_DECODED_mix_sparse_arch",
+        "table_GSF_IDLIST_MEGATAXON_AD_CLUSTERING_V1_IDENTITY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_AUDIO_UNDERSTANDING_FEATURES_AUDIO_UNDERSTANDING_AED_TOP_8_SCORES_DECODED_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C1996885_ADS_ENTITY_EQUIVALENCE_KEY_SUM_7_PAGE_TYPE_RATIO_CLICK_EVENT_PAGE_POST_LINK_OPEN_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_group_8_user_sparse_arch",
+        "table_GSF_IDLIST_LAST_USED_MOBILE_APP_100_FEATURE_user_sparse_arch",
+        "table_AGES_DENSEBMB__USER_RT_LOC_IS_ON_MOBILE_NETWORK_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_VLBLENDER_AD_SIDE_CLUSTER__TOP_100_user_sparse_arch",
+        "table_MOBILE_DEVICE_BRAND_MODEL_HASH_MAPID_TRANSFORMED_ID_LIST_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_NATIVE_BATCH_OAE_ML_IAB_ORGANIC_DOMAIN_HASH_IAB_ORGANIC_DOMAIN_HASH_DWELL_TIME_SPARSE_SEPARABLE_ID_DOMAIN_HASH_IDSCORELIST_7D_user_sparse_arch"
+      ],
+      "device_index": 2
+    },
+    {
+      "tbe_uuid": "80e195ad-5fe0-4ab2-aa4a-65c45baead8d",
+      "embedding_specs": [
+        {
+          "num_embeddings": 509,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1002108,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 102,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784944,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 435,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 56,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6197911,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3557246,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        5,
+        5,
+        5,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__GSF_FLOAT_ADSIDE_TIMESPENT_28D_FEED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_MEGAENTITIES_ADS_SIDE_FEATURES_MEGAENTITIES_V_2_TYPE_1_ADS_FEATURE_I18N_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_TIMESPENT_FEED_mix_sparse_arch",
+        "table_densebmb_49_49_MBDT_mix_spec_densebmb_regular",
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_AD_BUSINESS_ID_TOP_7D_TO_28D__SPARSE_AD_BUSINESS_ID_mix_spec_id_matching",
+        "table_group_28_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_GRAPH_LEARNING_FLEXIBLE_BATCH_GLFF_SUM_USER_ATTRIBUTE_SUM_KMEANS_USER_ATTRIBUTES_NGRAM_0_user_sparse_arch",
+        "table_DENSE_BMB__GFF_R1321_INSTAGRAM_USER_LATEST_EVENT_TIMESTAMP_2_TIME_SINCE_IG_ORGANIC_LIKE_ENGAGEMENT_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_NUM_ADS_SEEN_LAST_5MIN_F3_DENSE_IG_USER_NUM_ADS_SEEN_LAST_5MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_IMPRESSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_ADD_EEK_NO_CREATIVE_ALL_EVENTS_240MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_UNATTRIBUTED_CONVERSION_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_1MIN_TARGET_ID_EVENT_TYPE_ALL_240MIN_user_sparse_arch"
+      ],
+      "device_index": 4
+    },
+    {
+      "tbe_uuid": "2e2dcd2a-2736-4c4f-a0c9-5469a7b6ce77",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 42389,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 692,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6777141,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 796875,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 758,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6149214,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__IDSCORE_LIST_UTR_GFF_IDS_C30053_INSTAGRAM_IGUSER_IG_AD_TIME_SPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP100_D2__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_PA_INTERESTFM_AD_ACCOUNT_AD_ACCOUNT_INTERESTFM_HASHTAG_GENERATION_MM_30K_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C70516_ADS_USER_SUM_84_GEO_TARGETING_ID_GEO_TARGETING_CURRENT_RATIO_CLICK_IMPRESSION_mix_sparse_arch",
+        "table_group_24_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_LT_1S_REELS_AD_ID_TOP50_7D_ECG_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_DWELLING_TIME_LIST_user_sparse_arch",
+        "table_densebmb_60_60_MBDT_user_sparse_arch",
+        "table_densebmb_user_side_0_77_77_MBDT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_USER_LATESTN_AD_ID_CLICK_HA_IG_ADS_USER_LATEST_20_30MIN_PAGE_TYPE_35_49_72_94_95_108_AD_ID_CLICK_HA_user_sparse_arch"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "13e37ec5-0488-4945-9ba6-e120b41b3533",
+      "embedding_specs": [
+        {
+          "num_embeddings": 109,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1160963,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5220,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4790378,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6131701,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1546868,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 431,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 423,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 33230,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6225560,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      "table_names": [
+        "table_DENSE_BMB__IG_PAGE_POST_AD_PAGE_ID_NTH_IMP_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_ADSLLAMA_EEL_EMB_ADS_ADSLLAMA_EEL_EMB_FEATURES_COCLICK_100M_RM_SIMCSE_DDP_300K_KNN_DECODED_mix_sparse_arch",
+        "table_GSF_IDLIST_ADU_ADTAXON_I18N_PREDICTION_TOP1_L0_L7_IDENTITY_mix_sparse_arch",
+        "table_F3_ADFINDER_USER_AD_ADS_GRAPH_LEARNING_GRAPH_LEARNING_FEATURE_ADS_GL_AD_ACCOUNT_PPR_5_IDENTITY_mix_sparse_arch",
+        "table_group_36_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_FLEXIBLE_BATCH_IG_BOR_FOLLOW_SPARSE_FEATURES_ORGANIC_PROSPECTING_FOLLOWED_ADVERTISER_LIST_14D_user_sparse_arch",
+        "table_GFF_S_R30139_INSTAGRAM_IGUSER_IG_ORGANIC_HIGH_INTENT_ENGAGEMENT_IG_AUTHOR_CLUSTER_ID_T1_MOST_FREQUENT_EVENT_FREQUENCY_TOP50_D1_user_sparse_arch",
+        "table_AGES_DENSEBMB__F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_MIN_TIMESPENT_PER_AD_F3_DENSE_IG_USER_MIN_TIMESPENT_PER_AD_user_sparse_arch",
+        "table_AGES_DENSEBMB__F3_ADFINDER_USER_ADS_LEGACY_MIGRATION_AAP_REBUILT_MOBILE_ATTRIBUTE_DFC_AAP_REBUILT_MOBILE_ATTRIBUTE_EST_PRICE_EUR_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_CONTENT_UNDERSTANDING_USER_AD_CLUSTERS_USER_ENGAGED_ADS_CLUSTERS_15D_user_sparse_arch",
+        "table_GFF_IDS_R11530_ADS_USER_CLICK_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_LATEST_N_WITH_TIMESTAMP_EVENT_TS_TOP50_D1_user_sparse_arch"
+      ],
+      "device_index": 5
+    },
+    {
+      "tbe_uuid": "2bc36a0e-0fb9-4721-a7cf-db30f0de6615",
+      "embedding_specs": [
+        {
+          "num_embeddings": 396760,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 14148422,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 791,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5748,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 245,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 71,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 182,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 10252398,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 13569887,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 79,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 96575,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 13,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 532,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 453,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 762,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 312,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17
+      ],
+      "table_names": [
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_ADSLLAMA_EEL_EMB_ADS_ADSLLAMA_EEL_EMB_FEATURES_COCLICK_100M_RM_SIMCSE_DDP_300K_KNN_FB_DECODED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SEM_ID_AD_SEMID_CRDL_RQ2048X6_PREFIX5_SEM_IDS_IDENTITY_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_IMDS_MEGATAXON_CATEGORY_ID_MATCHING_USER_AD_IMDS_WEIGHTED_TIME_GAP_POOLING_AD_IMPRESSION_MEGATAXON_CATEGORY_L2_IDENTITY_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_IMDS_TEXTRAY_ID_MATCHING_AD_CLICK_IMDS_WEIGHTED_TIME_GAP_POOLING_AD_CLICK_TEXTRAY_SMALL_EMBEDDING_4K_CLUSTER_IDENTITY_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__SPARSE_UTR_GFF_S_C19815_INSTAGRAM_IGUSER_IG_REEL_PLAYBACK_NAVIGATION_IG_ACTOR_ID_SORTBY_TIME_EVENT_TS_TOP50_D14__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_spec_id_matching",
+        "table_TTH_AGES_densebmb_GFF_C870_ADS_USER_SUM_DECAY_900_28_ACCOUNT_ID_PAGE_TYPE_COUNTER_CLICK_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_IG_CREATIVE_MEDIA_WIDTH_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C1112_INSTAGRAM_USER_SUM_28_INSTAGRAM_ACTOR_FBIDV2_COUNTER_IG_ORGANIC_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_F3_ADFINDER_USER_ADS_SEMID_FLEXIBLE_BATCH_USER_IAB_METRICS_28D_F3_IAB_METRICS_TOP50_COUNT_TEXTRAY_TRIGRAM_SEM_IDS_USERSIDE_28D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SEM_ID_USER_IMP_7D_CRDL_SUM_SEM_ID_TRIGRAM_user_sparse_arch",
+        "table_AGES_DENSEBMB__F3_ADFINDER_USER_ADS_LEGACY_MIGRATION_AAP_REBUILT_MOBILE_ATTRIBUTE_DFC_AAP_REBUILT_MOBILE_ATTR_DISPLAY_SIZE_INCH_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_IG_STORIES_EVENT_TYPE_LIST__1_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_VLBLENDERV2_AD_AND_USER_SIDE_FEATURES_CTX_USER_NUM_VIDEO_VIEW_ADS_PAST_7D_VLBLENDER_V2_CLUSTER_IDS_user_sparse_arch",
+        "table_densebmb_0_0_MBDT_user_spec_densebmb_regular",
+        "table_densebmb_75_75_MBDT_user_spec_densebmb_regular",
+        "table_TTH_AGES_densebmb_GFF_C3143_ADS_USER_SUM_28_AD_CREATIVE_OPTIMIZATION_IG_V2C_NUM_CARDS_OPTVAL_440003_COUNTER_IMPRESSION_EXPLODED_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C817_INSTAGRAM_USER_SUM_28_RATIO_IG_VIDEO_VIEW_COUNT_IG_VIDEO_VIEW_SESSION_IMP_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_UUDL_OFFSITE_CONVERSION_WEB_COUNT_DENSE_REALTIME_SAFE_V2_COUNT_FLOAT_EARLY_TRIGGER_5MIN_PIXEL_ID_EVENT_PAGEVIEW_1440MIN_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 1
+    },
+    {
+      "tbe_uuid": "d8932b6b-5b0f-4bbf-9ccc-88264a3366ff",
+      "embedding_specs": [
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 71905,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3154533,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5669160,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 11,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 296,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5570279,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 331,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        0,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ],
+      "table_names": [
+        "table_group_48_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_ALL_EVENTS_1440MIN__SPARSE_AD_ACCOUNT_ID_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_IG_STORY_AD_USER_LOW_INTENT_V1_NAVIGATION_GESTURE_AUTHOR_RID_7D__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_SFV_TOP_CLUSTER_IDS_FOR_ADS_VIDEO_SFV_TOP_THIRD_CLIP_50K_QUANTIZED_DECODED_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_7D_mix_sparse_arch",
+        "table_SPARSE_TRACKING_TARGET_ID_IDENTITY_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_S_R64501_ADS_USER_CLICK_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_SORTBY_TIME_EVENT_TS_TOP200_D7__SPARSE_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_mix_spec_id_matching",
+        "table_F3_ADFINDER_USER_ADS_XPUB_FLEXIBLE_BATCH_TOP_ACTION_ADS_20_XPUB_TOP_20_ACCESSED_AD_IDS_USER_EVENT_7D_user_sparse_arch",
+        "table_DENSE_BMB__GSF_FLOAT_REQUEST_LEVEL_OS_VERSION_MAJOR_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_LEGACY_MIGRATION_BROWSE_ENVIRONMENT_TRAITS_MOBILE_APP_BUILD_user_sparse_arch",
+        "table_GFF_IDS_C30132_INSTAGRAM_IGUSER_IG_FEED_ADS_TIMESPENT_PAIR_IG_ACTOR_RID_SORTBY_SCORE_IG_TIMESPENT_TOP200_D28_user_sparse_arch",
+        "table_densebmb_2025h1_9_9_MBDT_user_spec_densebmb_igctr_25h1"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "14f7ecf2-c310-4fc7-80b3-1a2190ab9be0",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5799,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 294,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 56,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2697446,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6744837,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 495,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3992,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6708940,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2601371,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        5,
+        5,
+        5,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_IMPRESSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_ADD_EEK_NO_CREATIVE_ALL_EVENTS_240MIN__SPARSE_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C30133_INSTAGRAM_IGUSER_IG_STORY_ADS_TIMESPENT_PAIR_IG_ACTOR_RID_SORTBY_SCORE_IG_TIMESPENT_TOP200_D28__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_POSTRAY_TEXTRAY_MARSV1_ADS_SIDE_POSTRAY_SMALL_EMBEDDING_4K_CLUSTER_IDS_AD_SIDE_FEATURE_IDENTITY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_AUDIO_UNDERSTANDING_FEATURES_AUDIO_UNDERSTANDING_CLUSTERING_200_48_DECODED_mix_sparse_arch",
+        "table_SPARSE_CTA_TYPE_IDENTITY_mix_sparse_arch",
+        "table_group_19_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_NATIVE_BATCH_OAE_ML_ADCONV_SB_IAB_ALL_FEATURES_EVENT_ADS_CONVS_ON_SB_SPARSE_ENTITY_EQUIVALENCE_KEY_LIST_PER_USER_SID_28D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_RAX_ML_REALTIME_IAB_LH_USER_PRODUCT_FEATURES_IAB_LH_RT_LATEST_30_PRODUCT_ID_CLICKS_7D_user_sparse_arch",
+        "table_DENSE_BMB__GFF_R1321_INSTAGRAM_USER_LATEST_EVENT_TIMESTAMP_7_TIME_SINCE_IG_ORGANIC_BRAND_PROFILE_ENGAGEMENT_user_sparse_arch",
+        "table_SESSION_NGRAM_ID_LIST_AUTO_NGRAM_TRANSFORMED_ID_LIST_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_TIME_SINCE_LAST_AD_CTA_REELS_F3_DENSE_IG_USER_TIME_SINCE_LAST_AD_CTA_REELS_user_sparse_arch",
+        "table_GFF_IDS_C30133_INSTAGRAM_IGUSER_IG_STORY_ADS_TIMESPENT_PAIR_IG_ACTOR_RID_SORTBY_SCORE_IG_TIMESPENT_TOP200_D28_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_VIDEO_VIEW_1440MIN_user_sparse_arch"
+      ],
+      "device_index": 7
+    },
+    {
+      "tbe_uuid": "aa6b1cb6-3e2d-4bd1-abaa-3d8f51745cde",
+      "embedding_specs": [
+        {
+          "num_embeddings": 36622028,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 276422,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 137237,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 693,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6781913,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 11,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 578,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 626,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4634909,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 762,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12
+      ],
+      "table_names": [
+        "table_group_45_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_UDS_FIR_AD_IMPRESSION_AD_ACCOUNT_ID__84_DAYS__SPARSE_AD_ACCOUNT_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_VLBLENDER_DOUBLE_CLUSTERING_ADS_SIDE_IMAGE_UNDERSTANDING_VLBLENDER_AD_SIDE_FEATURES_ID_LIST_REALTIME_6_DECODED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_TEXTRAY_OCR_AVG_100K_KNN_DECODED_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_USER_AD_CLICK_PPR_REC_EKEY_RMV3_SOFT_MATCHING_DENSE_EFE_SOFT_MATCH_USER_AD_CLICK_PPR_REC_EKEY_RMV3_EMB_COSINE_SIMILARITY_MAX_RELEVANCE_SCORE_mix_sparse_arch",
+        "table_densebmb_39_39_MBDT_mix_spec_densebmb_regular",
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_CONTENT_UNDERSTANDING_MARKETPLACE_POSITIVE_ENGAGEMENT_F3_MP_USER_POSITIVE_ENGAGEMENT_7D__SPARSE_AD_ACCOUNT_ID_mix_spec_id_matching",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_LT_1S_AD_ID_TOP50_7D_ECG_user_sparse_arch",
+        "table_EVENT_AGG_1D_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_PLACEMENT_PAGE_TYPE_LIST_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_NATIVE_BATCH_GFF_C72000_C72000_ADS_USER_SUM_84_PAGE_TYPE_CONVERSION_TYPE_V2_EXPLODED_ADFINDER_STORY_TYPE_EXPLODED_COUNTER_IMPRESSION_CONVERSION_TYPE_V2_26_ADFINDER_STORY_TYPE_128_user_sparse_arch",
+        "table_densebmb_17_17_MBDT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_ALL_EVENTS_720MIN_user_sparse_arch",
+        "table_densebmb_7_7_MBDT_user_spec_densebmb_regular"
+      ],
+      "device_index": 5
+    },
+    {
+      "tbe_uuid": "d8a3b437-3831-4ef5-8521-9e391fcce0b4",
+      "embedding_specs": [
+        {
+          "num_embeddings": 205,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5407318,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 99,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1647008,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6776820,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4526565,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2267990,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 15,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 642,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6745558,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__GFF_C1112_INSTAGRAM_USER_SUM_28_INSTAGRAM_ACTOR_FBIDV2_RATIO_IG_ORGANIC_LIKE_IG_ORGANIC_IMPRESSION_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C11548_ADS_RID_CLICK_ENTITY_EQUIVALENCE_KEY_LATEST_N_WITH_TIMESTAMP_EVENT_TS_TOP200_D173__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_IG_STORY_AD_USER_LOW_INTENT_V1_NAVIGATION_GESTURE_AUTHOR_RID_7D__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_GRAPH_LEARNING_SATORI_SATORI_REALTIME_ACCOUNT_ID_SATORI_CLICK_ACCOUNT_ID_RT_RW_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_ALL_EVENTS_240MIN_MATCHING_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_56D_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_NATIVE_BATCH_IG_BOR_PROFILE_ACTION_CROSS_FEATURES_ORGANIC_PROSPECTING_PROFILE_ACTIONS_COUNT_APPINSTALL_7D_mix_sparse_arch",
+        "table_SPARSE_UTR_GFF_S_C19821_INSTAGRAM_IGUSER_IG_ORGANIC_TIMESPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP50_D14_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_GT_3S_REELS_AD_ID_TOP50_7D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_FLEXIBLE_BATCH_SHOPS_BFL_USER_PRODUCT_TOP_PRODUCTS_ID_LIST_user_sparse_arch",
+        "table_GSF_IDLIST_L2CLUSTER_ENGAGE_PAGE_ID_ALL_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_EVENT_TYPE_ID_user_sparse_arch",
+        "table_TTH_AGES_densebmb_IG_DEVICE_HEIGHT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_XPUB_FLEXIBLE_BATCH_INTEREST_SCORE_XPUB_INTEREST_SCORE_USER_EVENT_28D_user_sparse_arch"
+      ],
+      "device_index": 1
+    },
+    {
+      "tbe_uuid": "649b9431-6e2f-499c-8cb2-194ab177b275",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 141883,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4051573,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 102,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4797854,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2381704,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 214,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7842559,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_USER_PAGE_TOP_ENGAGED_30D_RID__SPARSE_NEW_PAGE_RID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_VLBLENDER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_TEXTRAY_OCR_TEXT_100K_KNN_FIX_QUANTIZED_DECODED_mix_sparse_arch",
+        "table_GSF_IDLIST_PAGE_PPR_9_GFF_IDS_C70070_ADS_USER_IMPRESSION_NEW_PAGE_ID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D28_MATCHING_mix_sparse_arch",
+        "table_ID_MATCHING_TIMESPENT5__mix_sparse_arch",
+        "table_group_16_user_sparse_arch",
+        "table_SPARSE_UTR_GFF_S_C19815_INSTAGRAM_IGUSER_IG_REEL_PLAYBACK_NAVIGATION_IG_ACTOR_ID_SORTBY_TIME_EVENT_TS_TOP50_D14_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_FLEXIBLE_BATCH_3PD_ATT_AGGREGATED_SPARSE_FEATURES_TRACKING_OC_ENTITY_EQUIVALENCE_KEY_SORTEDBY_TIMESTAMP_TOP50_D14_V2_user_sparse_arch",
+        "table_DENSE_BMB__GFF_C1290333_ADS_USER_SUM_84_PAGE_TYPE_COUNTER_GOOD_CLICK_1SEC_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_TOP_ENGAGED_ENTITY_ID_SCORE_LIST_E_KEY_VIDEO_VIEW_240MIN_user_sparse_arch"
+      ],
+      "device_index": 4
+    },
+    {
+      "tbe_uuid": "33355415-722d-4f5b-98b4-d6f9e2e877a8",
+      "embedding_specs": [
+        {
+          "num_embeddings": 473,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2996,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 729,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 606,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 209,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 606,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 374,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784936,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 332,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 978427,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 467,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4434912,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 724,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 517,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 33,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 746,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        6,
+        6,
+        6,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16
+      ],
+      "table_names": [
+        "table_DENSE_BMB__GFF_C3138_INSTAGRAM_ENTITY_EQUIVALENCE_KEY_SUM_28_COUNTER_IG_AD_BRAND_PROFILE_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_MARKETPLACE_ADS_MARKETPLACE_ADS_FPT_CATEGORIES_PREDICTION_IMAGE_V1_F3_MARKETPLACE_ADS_FPT_IMAGE_V1_L1_CATEGORIES_PREDICTION_FEATURE_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_R1548893_ADS_NEW_AD_ID_REFINED_SUM_2_RATIO_CONVERSION_IMPRESSION_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C1229433_ADS_ENTITY_EQUIVALENCE_KEY_SUM_28_PAGE_TYPE_USER_COUNTRY_RATIO_CLICK_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_IG_CREATIVE_MEDIA_ASPECT_RATIO_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C1229433_ADS_ENTITY_EQUIVALENCE_KEY_SUM_28_PAGE_TYPE_USER_COUNTRY_COUNTER_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_group_4_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_NON_ENGAGEMENT_IMP_NO_CLICK_MT_USER_AD_NON_ENGAGE_AD_MEGATAXON_L2_4H_LATEST_N_WITH_TIMESTAMP_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_GT_3S_AD_ID_LATEST50_28D_ECG_user_sparse_arch",
+        "table_DENSE_BMB__GSF_FLOAT_REQUEST_LEVEL_IG_ADS_FEED_SEEN_STATE_LAST_IMP_DWELL_TIME_user_sparse_arch",
+        "table_EVENT_MOST_RECENT_5_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_DWELLING_TIME_LIST_user_sparse_arch",
+        "table_densebmb_user_side_0_29_29_MBDT_user_sparse_arch",
+        "table_GFF_IDS_C73007_ADS_USER_MESSENGER_INBOX_INTERSTITIAL_TIME_SPENT_ENTITY_EQUIVALENCE_KEY_MOST_FREQUENT_MESSENGER_INTERSTITIAL_TIME_SPENT_TOP50_D84_user_sparse_arch",
+        "table_TTH_AGES_densebmb_GSF_FLOAT_REQUEST_LEVEL_USER_RT_LOC_STALENESS_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_R1318_ADS_USER_SUM_1_PAGE_TYPE_RATIO_CLICK_IMPRESSION_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_IG_IG_ADS_RANKING_IG_REELS_USER_COUNTER_ENGAGEMENT_INSTAGRAM_USER_SUM_7_COUNTER_INSTAGRAM_AD_CAPTION_MORE_CLICK_REELS_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_R1306_ADS_USER_LATEST_EVENT_TIMESTAMP_2_PAGE_TYPE_TIME_SINCE_IMPRESSION_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "e2f9de4b-10b7-4a44-801b-63b4f0c9053b",
+      "embedding_specs": [
+        {
+          "num_embeddings": 473,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2996,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 729,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 681,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 603,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 374,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784936,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 332,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 978427,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 467,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4434912,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 576,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 296,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 723,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        6,
+        6,
+        6,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16
+      ],
+      "table_names": [
+        "table_DENSE_BMB__GFF_C3138_INSTAGRAM_ENTITY_EQUIVALENCE_KEY_SUM_28_COUNTER_IG_AD_BRAND_PROFILE_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_MARKETPLACE_ADS_MARKETPLACE_ADS_FPT_CATEGORIES_PREDICTION_IMAGE_V1_F3_MARKETPLACE_ADS_FPT_IMAGE_V1_L1_CATEGORIES_PREDICTION_FEATURE_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_R1548893_ADS_NEW_AD_ID_REFINED_SUM_2_RATIO_CONVERSION_IMPRESSION_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_R1312_ADS_USER_LATEST_EVENT_TIMESTAMP_7_CONVERSION_TYPE_VERSION_TIME_SINCE_CONVERSION_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_AUTO_ID_MATCHING__SPARSE_AD_BUSINESS_ID__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_AD_BUSINESS_ID_TOP_7D_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C1996885_ADS_ENTITY_EQUIVALENCE_KEY_SUM_28_PAGE_TYPE_RATIO_GOOD_CLICK_5SEC_CLICK_mix_spec_tail_sigrid_features",
+        "table_group_4_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_NON_ENGAGEMENT_IMP_NO_CLICK_MT_USER_AD_NON_ENGAGE_AD_MEGATAXON_L2_4H_LATEST_N_WITH_TIMESTAMP_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_GT_3S_AD_ID_LATEST50_28D_ECG_user_sparse_arch",
+        "table_DENSE_BMB__GSF_FLOAT_REQUEST_LEVEL_IG_ADS_FEED_SEEN_STATE_LAST_IMP_DWELL_TIME_user_sparse_arch",
+        "table_EVENT_MOST_RECENT_5_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_DWELLING_TIME_LIST_user_sparse_arch",
+        "table_densebmb_user_side_0_29_29_MBDT_user_sparse_arch",
+        "table_GFF_IDS_C73007_ADS_USER_MESSENGER_INBOX_INTERSTITIAL_TIME_SPENT_ENTITY_EQUIVALENCE_KEY_MOST_FREQUENT_MESSENGER_INTERSTITIAL_TIME_SPENT_TOP50_D84_user_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_R1320_ADS_USER_SUM_1_COUNTER_IMPRESSION_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_NATIVE_BATCH_IG_ADS_RANKING_IG_AD_CLICK_REFINEMENT_ADS_USER_SUM_28_PAGE_TYPE_RATIO_CTA_CLICK_IMPRESSION_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_MOBILE_APP_BUILD_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_UNATTRIBUTED_CONV_ONSITE_DENSE_SAFE_V2_COUNT_FLOAT_UNATTRIBUTED_CONV_ONSITE_CNT_EVENT_TYPE_INSTAGRAM_PROFILE_VIEW_56D_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "d6d9c608-9800-48ac-ae8b-c2bcdb14d8d8",
+      "embedding_specs": [
+        {
+          "num_embeddings": 413,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 287032,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 72685,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2067206,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4350638,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 515,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1464,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5934592,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3700960,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3454156,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        5,
+        5,
+        5,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__F3_ADPUBLISHER_ADS_LEGACY_MIGRATION_AD_VIDEO_TRAITS_VIDEO_DURATION_MS_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_UDS_FIR_AD_IMPRESSION_UNSAMPLED_PHOTO_DNA_HASH__MOST_RECENT_500__F3_ADPUBLISHER_ADS_CREATIVE_FATIGUE_IMDS_PHOTO_DNA_HASH_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_COIN_RELEVANCE_EFE_REAL_TIME_AD_RELEVANCE_EMBEDDING_CLUSTER_ID_V2_RELEVANCE_F448437730_TARGET_32D_EMB_200K_CLUSTER_ID_V2_LIST_DECODED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_RMV3_AD_SIDE_RMV3_STAGE3_AD_50K_CENTROIDS_TOP20_CLUSTER_IDS_IDENTITY_mix_sparse_arch",
+        "table_GSF_IDLIST_SPARSE_NEW_AD_PAGE_ID_CLUSTERING_PPR_52_V6_5M_IDENTITY_mix_sparse_arch",
+        "table_group_25_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_CLICK_ECG_IG_AD_CLICK_REELS_AD_ACCOUNT_ID_TOP50_28D_ECG_user_sparse_arch",
+        "table_DENSE_BMB__GFF_C3019_INSTAGRAM_USER_AVERAGE_84_PAGE_TYPE_49_COUNTER_IG_ORGANIC_TIMESPENT_CORRECTED_EXPLODED_user_sparse_arch",
+        "table_NGRAM_IG_PAGE_TYPE_IG_START_INDEX_NGRAM_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_IMPRESSION_REALTIME_SAFE_TOP_ENGAGED_ENTITY_ID_SCORE_LIST_ADD_EEK_NO_CREATIVE_ALL_EVENTS_720MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_IG_REELS_INSTAGRAM_ENGAGEMENT_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_AUTHOR_ID_SCORE_LIST_IG_REELS_INSTAGRAM_ENGAGEMENT_EVENTS_HIGH_INTENT_AD_EVENT_TYPE_HIGH_INTENT_AD_1440MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_IG_REELS_INSTAGRAM_ENGAGEMENT_REALTIME_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_AUTHOR_ID_SCORE_LIST_IG_REELS_INSTAGRAM_ENGAGEMENT_EVENTS_HIGH_INTENT_AD_EVENT_TYPE_HIGH_INTENT_AD_720MIN_user_sparse_arch"
+      ],
+      "device_index": 7
+    },
+    {
+      "tbe_uuid": "de063542-84b7-4063-a4ab-60fd41d9e8bb",
+      "embedding_specs": [
+        {
+          "num_embeddings": 123734,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 662,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6782121,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784932,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 103,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3325018,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 107,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "table_names": [
+        "table_GSF_IDLIST_TFIDF_ACTIVE_APP_DESC_FEATURE_TOP__DF_3_MTO_5_MAX_WORDS_50_IDENTITY_mix_sparse_arch",
+        "table_densebmb_16_16_MBDT_mix_spec_densebmb_regular",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C11549_ADS_RID_CLICK_AD_ACCOUNT_ID_LATEST_N_WITH_TIMESTAMP_EVENT_TS_TOP200_D173__SPARSE_AD_ACCOUNT_ID_mix_spec_id_matching",
+        "table_group_27_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_LT_1S_AD_ID_LATEST50_7D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_GRAPH_LEARNING_FLEXIBLE_BATCH_GLFF_GLFF_PPR_FEATURES_2025H1_GLFF_2025H1_PPR_IDLIST_ADCLKS_ONSITE_VV_USER_EKEY_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_NUM_ADS_SEEN_LAST_15MIN_F3_DENSE_IG_USER_NUM_ADS_SEEN_LAST_15MIN_user_sparse_arch",
+        "table_TIMEGAP_WITH_AD_REQUEST__F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_UNATTRIBUTED_CONVERSION_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_1MIN_TARGET_ID_EVENT_TYPE_ALL_240MIN_user_sparse_arch",
+        "table_densebmb_66_66_MBDT_user_spec_densebmb_regular"
+      ],
+      "device_index": 4
+    },
+    {
+      "tbe_uuid": "89adf9ce-b5d7-4ec4-a3b5-45a209da9d71",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 11899818,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__IDSCORE_LIST_UTR_GFF_IDS_C30053_INSTAGRAM_IGUSER_IG_AD_TIME_SPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP100_D84__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SEM_ID_USER_IMP_3D_TEXTRAY_TEXT_50K_SEM_ID_user_sparse_arch"
+      ],
+      "device_index": 6
+    },
+    {
+      "tbe_uuid": "4e3ea708-e977-4dc6-89a2-12834b911884",
+      "embedding_specs": [
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 285890,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 137237,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6293420,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 14,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3443263,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "table_names": [
+        "table_group_46_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_ALL_EVENTS_240MIN__SPARSE_AD_ACCOUNT_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_VLBLENDER_DOUBLE_CLUSTERING_ADS_SIDE_IMAGE_UNDERSTANDING_VLBLENDER_AD_SIDE_FEATURES_ID_LIST_REALTIME_4_DECODED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_TEXTRAY_OCR_AVG_100K_KNN_DECODED_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_AD_ADS_SAFE_REALTIME_REALTIME_OLD_IG_USER_COUNT_DENSE_REALTIME_SAFE_V2_COUNT_FLOAT_USER_AUTHOR_EVENT_INSTAGRAM_AD_BRAND_PROFILE_7D_mix_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_XPUB_FLEXIBLE_BATCH_TOP_ACTION_ADS_20_XPUB_TOP_20_ACCESSED_AD_IDS_USER_EVENT_14D_user_sparse_arch",
+        "table_EVENT_AGG_1D_F3_ADFINDER_USER_ADS_UDS_FIR_IAW_EVENT_TYPE_ID_user_sparse_arch",
+        "table_densebmb_1_1_MBDT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_IG_REELS_INSTAGRAM_ENGAGEMENT_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_AUTHOR_ID_SCORE_LIST_IG_REELS_INSTAGRAM_ENGAGEMENT_EVENTS_HIGH_INTENT_AD_EVENT_TYPE_HIGH_INTENT_AD_720MIN_user_sparse_arch"
+      ],
+      "device_index": 5
+    },
+    {
+      "tbe_uuid": "2bbfaa38-c03c-4a73-9400-019ead6ddb7a",
+      "embedding_specs": [
+        {
+          "num_embeddings": 325,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 757,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 41818,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 727,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 746,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 693,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 877544,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6315074,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6776541,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 11,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 281,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 177,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 572,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 758,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        9,
+        9,
+        9,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18
+      ],
+      "table_names": [
+        "table_DENSE_BMB__F3_ADPUBLISHER_IG_IG_ADS_RANKING_IG_STORY_ACTION_COUNT_AD_SPARSE_RT_IG_STORY_ENTITY_EQUIVALENCE_KEY_PAUSE_COUNT_1D_mix_sparse_arch",
+        "table_DENSE_BMB__GFF_R1506146_ADS_ENTITY_EQUIVALENCE_KEY_SUM_2_RATIO_CLICK_IMPRESSION_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_PA_INTERESTFM_AD_ACCOUNT_AD_ACCOUNT_INTERESTFM_OPEN_VOCAB_MM_30K_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_R1506146_ADS_ENTITY_EQUIVALENCE_KEY_SUM_2_RATIO_CONVERSION_IMPRESSION_mix_sparse_arch",
+        "table_densebmb_vertical_5_5_MBDT_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_AUTOMATED_SHOPPING_ADS_AUTO_TARGETING_APP_FEATURES_AUTO_CA_APP_OPEN_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_SPARSE_AD_ACCOUNT_ID__GFF_S_R64002_ADS_USER_CONVERSION_SPARSE_AD_HYBRID_ID_SORTBY_TIME_EVENT_TS_TOP50_D1_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_AD_REPETITION_WEIGHT_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_R1322_INSTAGRAM_USER_SUM_7_INSTAGRAM_ACTOR_FBIDV2_COUNTER_IG_ORGANIC_BRAND_PROFILE_ENGAGEMENT_mix_spec_tail_sigrid_features",
+        "table_group_18_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ATOM_FLEXIBLE_BATCH_ATOM_USER_SIDE_MASTER_FEATURES_ATOM_USER_SIDE_MASTER_TIMESTAMP_user_sparse_arch",
+        "table_GFF_S_C10324_ADS_USER_XOUT_AD_ACCOUNT_ID_SORTBY_TIME_EVENT_TS_TOP50_D84_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_LT_1S_REELS_AD_ID_LATEST50_7D_ECG_user_sparse_arch",
+        "table_EVENT_MOST_RECENT_10_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_PLACEMENT_PAGE_TYPE_LIST_user_sparse_arch",
+        "table_densebmb_user_side_0_19_19_MBDT_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_ADS_ML_MODELING_SHORT_AGGREGATION_WINDOW_DENSE_FEATURES_GFF_R4025_ADS_USER_SUM_4_HOUR_BROWSER_TYPE_RATIO_XOUT_IMPRESSION_GFF_R4025_ADS_USER_SUM_4_HOUR_BROWSER_TYPE_RATIO_XOUT_IMPRESSION_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_R1318_ADS_USER_SUM_1_PAGE_TYPE_RATIO_XOUT_IMPRESSION_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C1290333_ADS_USER_SUM_84_PAGE_TYPE_RATIO_GOOD_CLICK_5SEC_IMPRESSION_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_NATIVE_BATCH_IG_ADS_RANKING_IG_AD_CLICK_REFINEMENT_ADS_USER_SUM_28_PAGE_TYPE_RATIO_PV_CLICK_IMPRESSION_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 4
+    },
+    {
+      "tbe_uuid": "ca3c10b7-5a41-4518-8c8e-45dbc119e66c",
+      "embedding_specs": [
+        {
+          "num_embeddings": 205,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 396464,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6551575,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2295,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 509,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6131701,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 355,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 14,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1785,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3542131,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2671,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 641,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        8,
+        8,
+        8,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__GFF_C1112_INSTAGRAM_USER_SUM_28_INSTAGRAM_ACTOR_FBIDV2_RATIO_IG_ORGANIC_LIKE_IG_ORGANIC_IMPRESSION_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_NEW_CAMPAIGN_ID_TOP_7D_TO_28D__SPARSE_NEW_CAMPAIGN_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_ADSLLAMA_EEL_EMB_ADS_ADSLLAMA_EEL_EMB_FEATURES_COCLICK_100M_RM_SIMCSE_DDP_300K_KNN_IG_DECODED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBV2_VLB_AVG_RQ_VAE_DECODED_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_NO_CREATIVE_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_7D_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_IMDS_MEGATAXON_CATEGORY_ID_MATCHING_USER_AD_IMDS_WEIGHTED_TIME_GAP_POOLING_AD_IMPRESSION_MEGATAXON_CATEGORY_L3_IDENTITY_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__IDSCORE_LIST_UTR_GFF_IDS_C30053_INSTAGRAM_IGUSER_IG_AD_TIME_SPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP100_D84__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_spec_id_matching",
+        "table_TTH_AGES_densebmb_GSF_FLOAT_ADSIDE_TIMESPENT_28D_STORY_mix_spec_tail_sigrid_features",
+        "table_group_37_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_FLEXIBLE_BATCH_IG_BOR_FOLLOW_SPARSE_FEATURES_ORGANIC_PROSPECTING_FOLLOWED_ADVERTISER_LIST_14D_user_sparse_arch",
+        "table_AGES_DENSEBMB__F3_ADFINDER_USER_ADS_LEGACY_MIGRATION_AAP_REBUILT_MOBILE_ATTRIBUTE_DFC_AAP_REBUILT_MOBILE_ATTR_POPULARITY_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_EVENT_TYPE_ID__1_DAYS_user_sparse_arch",
+        "table_F3_ADINDEXER_DA_PRODUCT_FEATURES_NATIVE_BATCH_FPT_USER_CATEGORY_CLKS_TOP_25_ENGAGED_L4_CATEGORY_ID_CLKS_7D_user_sparse_arch",
+        "table_IDSCORE_LIST_UTR_GFF_IDS_C30053_INSTAGRAM_IGUSER_IG_AD_TIME_SPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP100_D2_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_POSTRAY_AD_AND_USER_SIDE_FEATURES_CTX_USER_VIDEO_VIEW_AD_POSTRAY_4K_CLUSTER_IDS_user_sparse_arch",
+        "table_densebmb_50_50_MBDT_user_spec_densebmb_regular"
+      ],
+      "device_index": 5
+    },
+    {
+      "tbe_uuid": "adce60c6-3420-4bf7-984d-4c68a4fec3b2",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 278189,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25548,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 563,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6783030,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 13569887,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 13569887,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6779573,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3992,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 300,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7607803,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_CONTENT_UNDERSTANDING_MARKETPLACE_POSITIVE_ENGAGEMENT_F3_MP_USER_POSITIVE_ENGAGEMENT_7D__SPARSE_AD_ACCOUNT_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_MEGAENTITIES_ADS_SIDE_FEATURES_MEGAENTITIES_V_2_TYPE_3_ADS_FEATURE_I18N_IDENTITY_mix_sparse_arch",
+        "table_SPARSE_AD_MEDIA_XRAY_V11_TOPIC_ID_IDENTITY_mix_sparse_arch",
+        "table_densebmb_9_9_MBDT_mix_spec_densebmb_regular",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_CLICK_ECG_IG_AD_CLICK_REELS_AD_ID_INT_LATEST50_28D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SEMID_FLEXIBLE_BATCH_USER_CONVERSION_28D_F3_AD_CONVERSION_TOP50_COUNT_TEXTRAY_TRIGRAM_SEM_IDS_USERSIDE_28D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ATOM_FLEXIBLE_BATCH_ATOM_USER_SIDE_IAB_RQVAE_FEATURES_ATOM_USER_SIDE_IAB_ADS_CLK_TS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_RAX_ML_FLEXIBLE_BATCH_IAB_PRODUCT_MATCHING_FEATURES_USER_LATEST_PRODUCTS_F3_IAB_LH_USER_LATEST_30_PRODUCTS_CLICKED_28D_user_sparse_arch",
+        "table_SESSION_NGRAM_ID_LIST_AUTO_NGRAM_TRANSFORMED_ID_LIST_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_NUM_ORGANIC_POST_SEEN_FEED_F3_DENSE_IG_USER_NUM_ORGANIC_POST_SEEN_FEED_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_ENGAGEMENT_REALTIME_SAFE_TOP_ENGAGED_ENTITY_ID_SCORE_LIST_E_KEY_INSTAGRAM_PROFILE_720MIN_user_sparse_arch"
+      ],
+      "device_index": 1
+    },
+    {
+      "tbe_uuid": "ac2c75fc-0413-48fe-b264-48fd8b3f3de3",
+      "embedding_specs": [
+        {
+          "num_embeddings": 325,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 757,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 41818,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 727,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 746,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 33,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 32,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 431,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 877544,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6315074,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6776541,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 11,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 281,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 56,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 11,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 762,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        9,
+        9,
+        9,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17
+      ],
+      "table_names": [
+        "table_DENSE_BMB__F3_ADPUBLISHER_IG_IG_ADS_RANKING_IG_STORY_ACTION_COUNT_AD_SPARSE_RT_IG_STORY_ENTITY_EQUIVALENCE_KEY_PAUSE_COUNT_1D_mix_sparse_arch",
+        "table_DENSE_BMB__GFF_R1506146_ADS_ENTITY_EQUIVALENCE_KEY_SUM_2_RATIO_CLICK_IMPRESSION_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_PA_INTERESTFM_AD_ACCOUNT_AD_ACCOUNT_INTERESTFM_OPEN_VOCAB_MM_30K_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_R1506146_ADS_ENTITY_EQUIVALENCE_KEY_SUM_2_RATIO_CONVERSION_IMPRESSION_mix_sparse_arch",
+        "table_densebmb_vertical_5_5_MBDT_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_AUTOMATED_SHOPPING_ADS_AUTO_TARGETING_COUNTER_AND_VALUE_FEATURES_AUTO_CA_PAGE_VIEW_COUNT_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C1110_INSTAGRAM_USER_SUM_28_INSTAGRAM_ACTOR_FBIDV2_COUNTER_IG_VIDEO_VIEW_COUNT_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_NATIVE_BATCH_IG_ADS_RANKING_IG_AD_CLICK_REFINEMENT_ADS_ENTITY_EQUIVALENCE_KEY_SUM_28_PAGE_TYPE_COUNTER_CTA_CLICK_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C27017_ADS_USER_SUM_7_PAGE_TYPE_AD_CONVERSION_TYPE_COUNTER_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_group_18_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ATOM_FLEXIBLE_BATCH_ATOM_USER_SIDE_MASTER_FEATURES_ATOM_USER_SIDE_MASTER_TIMESTAMP_user_sparse_arch",
+        "table_GFF_S_C10324_ADS_USER_XOUT_AD_ACCOUNT_ID_SORTBY_TIME_EVENT_TS_TOP50_D84_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_LT_1S_REELS_AD_ID_LATEST50_7D_ECG_user_sparse_arch",
+        "table_EVENT_MOST_RECENT_10_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_PLACEMENT_PAGE_TYPE_LIST_user_sparse_arch",
+        "table_densebmb_user_side_0_19_19_MBDT_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_NUM_ADS_SEEN_LAST_5MIN_F3_DENSE_IG_USER_NUM_ADS_SEEN_LAST_5MIN_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GSF_FLOAT_REQUEST_LEVEL_TOP_IP_V2_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C3_ADS_USER_SUM_84_PAGE_TYPE_RATIO_CLICK_IMPRESSION_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 4
+    },
+    {
+      "tbe_uuid": "daa8612a-07cf-47b7-a9fa-384731502029",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 61787,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 144013,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 685,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1776198,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784906,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 11,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 729,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 16,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6561149,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3086,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 626,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 511,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 759,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 520,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 59,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        9,
+        9,
+        9,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__GFF_IDS_C11526_ADS_USER_CLICK_ENTITY_EQUIVALENCE_KEY_LATEST_N_WITH_TIMESTAMP_EVENT_TS_TOP100_D84__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C40011550_ADS_RID_PAGE_LINK_CLICKS_USER_PAGE_RID_TOP_N_WITH_TIMESTAMP_EVENT_FREQUENCY_TOP200_D173__SPARSE_NEW_PAGE_RID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_FAM_FBE_FLEXIBLE_BATCH_FAM_ADS_LOCATION_FEATURES_F3_IDLIST_TOP_5_CITY_BY_IMP_7_DAYS_IDENTITY_mix_sparse_arch",
+        "table_GSF_IDLIST_MEGATAXON_MMF_AD_CLUSTERING_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_SPARSE_NEW_PAGE_RID__GFF_S_C40010064_ADS_USER_PAGE_LINK_CLICKS_USER_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D84_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_SEEN_STATE_IMAGE_ID_DWELLTIME_IG_SEEN_STATE_IMAGE_ID_DWELLTIME__SPARSE_INSTAGRAM_MEDIA_ID_mix_spec_id_matching",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_AUTO_ID_MATCHING__SPARSE_NEW_PAGE_RID__GFF_S_C40010071_ADS_USER_PAGE_OTHER_CLICKS_USER_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D84_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_GSF_IDLIST_SPARSE_AD_ACCOUNT_ID_CLUSTERING_V1__GSF_IDLIST_CLUSTER_BASED_SPARSE_USER_TOP_LINK_CLICK_CONV_ID_LONGTERM_TOP50_D84_V1_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_R1307_ADS_USER_LATEST_EVENT_TIMESTAMP_2_PAGE_TYPE_CONVERSION_TYPE_VERSION_TIME_SINCE_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_group_17_user_sparse_arch",
+        "table_GSF_IDLIST_IG_USER_FOLLOW_GRAPH_CLUSTER_ALL_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_GT_3S_REELS_AD_ID_LATEST50_28D_ECG_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_EVENT_TYPE_LIST_user_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_R1321_INSTAGRAM_USER_LATEST_EVENT_TIMESTAMP_7_TIME_SINCE_IG_ORGANIC_LIKE_ENGAGEMENT_user_sparse_arch",
+        "table_densebmb_29_29_MBDT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_XPUB_FLEXIBLE_BATCH_INTEREST_SCORE_XPUB_INTEREST_SCORE_USER_EVENT_14D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_FB_ALL_POSTS_FEED_VPVS_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_FACTOR_IDS_FB_PAGE_USER_POST_FB_ALL_POST_MEGATAXON_I18N_TOP1_L7_PREDICTION_HASH_EVENT_TYPE_ALL_240MIN_user_sparse_arch",
+        "table_densebmb_17_17_MBDT_user_spec_densebmb_regular",
+        "table_densebmb_72_72_MBDT_user_spec_densebmb_regular",
+        "table_TTH_AGES_densebmb_GFF_C27007_ADS_USER_SUM_28_DEVICE_TYPE_PAGE_TYPE_COUNTER_IMPRESSION_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_R1303_ADS_USER_LATEST_EVENT_TIMESTAMP_7_PAGE_TYPE_TIME_SINCE_CLICK_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_LEGACY_MIGRATION_AAP_REBUILT_MOBILE_ATTRIBUTE_DFC_AAP_REBUILT_MOBILE_ATTR_OS_VERSION_SCALAR_V2_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 7
+    },
+    {
+      "tbe_uuid": "ad627434-beb4-46b6-bf97-8f3f3c30decc",
+      "embedding_specs": [
+        {
+          "num_embeddings": 487,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 48,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 750,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 28903,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 12,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1015487,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3057106,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1076475,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 873606,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3684743,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2680,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 665,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        7,
+        7,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__GSF_FLOAT_AD_CREATIVE_FATIGUE_SCORE_mix_sparse_arch",
+        "table_DENSE_BMB__GFF_C869_ADS_USER_SUM_28_ACCOUNT_ID_COUNTER_CLICK_mix_sparse_arch",
+        "table_DENSE_BMB__GFF_R1506146_ADS_ENTITY_EQUIVALENCE_KEY_SUM_2_COUNTER_IMPRESSION_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_SUBJECTIVE_UNDERSTANDING_APPEALINGNESS_IMAGE_FEATURES_RT_SUBJECTIVE_UNDERSTANDING_DIGESTIBILITY_APPEALINGNESS_FUSION_CLUSTER_IDS_TOP_32_DECODED_mix_sparse_arch",
+        "table_densebmb_12_12_MBDT_mix_sparse_arch",
+        "table_densebmb_4_4_MBDT_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__SPARSE_UTR_GFF_S_C19823_INSTAGRAM_IGUSER_IG_AD_TIME_SPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP50_D14__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_spec_id_matching",
+        "table_group_38_user_sparse_arch",
+        "table_GSF_IDLIST_REQUEST_LEVEL_IG_ADS_FEED_SEEN_STATE_AUTHOR_CLUSTER_ALL_LONG_DWELLTIME_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_ATOM_FEATURIZATION_ATOM_TEXTRAY_RQVAE_USER_FEATURE_TEXTRAY_RQVAE_USER_TS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_RAX_ML_REALTIME_IAW_LH_URL_DOMAIN_HASH_RT_FEATURES_IAB_LH_DOMAIN_HASH_RT_SPARSE_SEPARABLE_ID_SPARSE_URL_HASH_IDLIST_1D_user_sparse_arch",
+        "table_EVENT_TOPK_30_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_DWELLING_TIME_LIST_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_IG_REELS_INSTAGRAM_ENGAGEMENT_REALTIME_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_AUTHOR_ID_SCORE_LIST_IG_REELS_INSTAGRAM_ENGAGEMENT_EVENTS_HIGH_INTENT_AD_EVENT_TYPE_HIGH_INTENT_AD_1440MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_POSTRAY_AD_AND_USER_SIDE_FEATURES_CTX_USER_ONSITE_CONVERSION_AD_POSTRAY_4K_CLUSTER_IDS_user_sparse_arch",
+        "table_densebmb_22_22_MBDT_user_spec_densebmb_regular"
+      ],
+      "device_index": 4
+    },
+    {
+      "tbe_uuid": "a394e837-005c-4ce2-8290-f48c246ba290",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 96127,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 102,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 685,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6709188,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 971568,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 216,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2674624,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 146,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7212274,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 473,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__IDSCORE_LIST_UTR_GFF_IDS_C30053_INSTAGRAM_IGUSER_IG_AD_TIME_SPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP100_D84__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__SPARSE_UTR_GFF_S_C19822_INSTAGRAM_IGUSER_IG_ORGANIC_TIMESPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP50_D14__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_PA_INTERESTFM_AD_ACCOUNT_AD_ACCOUNT_INTERESTFM_HASHTAG_GENERATION_MM_70K_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_TIMESPENT5__mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C72000_ADS_USER_SUM_84_PAGE_TYPE_CONVERSION_TYPE_V2_ADFINDER_STORY_TYPE_COUNTER_IMPRESSION_mix_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_GRAPH_LEARNING_FLEXIBLE_BATCH_GLFF_GLFF_PPR_FEATURES_2025H1_GLFF_2025H1_PPR_IDLIST_ADCLKS_USER_NOCREATIVE_EKEY_user_sparse_arch",
+        "table_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_FACTOR_BIGRAM_SAFE_V2_TOP_ENGAGED_ENTITY_FACTOR_IDS_AD_NON_ENGAGEMENT_FACTOR_BIGRAM_DOMAIN_X_BRAND_V4_EVENT_TYPE_ALL_28D_user_sparse_arch",
+        "table_EBFS_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_PAGE_TYPE_ID__7_DAYS_user_sparse_arch",
+        "table_EVENT_MOST_RECENT_10_F3_ADFINDER_USER_ADS_UDS_FIR_PIXEL_PIXEL_ID_LIST_user_sparse_arch",
+        "table_densebmb_61_61_MBDT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_ENGAGEMENT_REALTIME_SAFE_TOP_ENGAGED_ENTITY_ID_SCORE_LIST_E_KEY_INSTAGRAM_PROFILE_240MIN_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_NATIVE_BATCH_GFF_C72000_C72000_ADS_USER_SUM_84_PAGE_TYPE_CONVERSION_TYPE_V2_EXPLODED_ADFINDER_STORY_TYPE_EXPLODED_COUNTER_IMPRESSION_CONVERSION_TYPE_V2_24_ADFINDER_STORY_TYPE_263_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 1
+    },
+    {
+      "tbe_uuid": "1b92a8d9-ab33-47d5-a3a7-11d591543247",
+      "embedding_specs": [
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7758,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 274506,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2282,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5748,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6735006,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2492864,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 15529,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 12,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1786,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "table_names": [
+        "table_group_44_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_ADS_RANKING_INTENT_UNDERSTANDING_FLEXIBLE_BATCH_CONTENT_UNDERSTANDING_MEGATAXON_AD_SIDE_FEATURES_MEGATAXON_IDLIST_EKEY_TOP3_L0_L7_NODEID_IDENTITY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_XRAY2023_TEXT_200K_KNN_DECODED_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_IMDS_MEGATAXON_CATEGORY_ID_MATCHING_USER_AD_IMDS_WEIGHTED_TIME_GAP_POOLING_AD_CLICK_MEGATAXON_CATEGORY_L3_IDENTITY_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_IMDS_TEXTRAY_ID_MATCHING_AD_CLICK_IMDS_WEIGHTED_TIME_GAP_POOLING_AD_CLICK_TEXTRAY_SMALL_EMBEDDING_4K_CLUSTER_IDENTITY_mix_sparse_arch",
+        "table_GSF_IDLIST_INTENT_SCD_ADS_CLICKS_UNIGRAM_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_USER_TOPK_AD_ACCOUNT_ID_CLICK_HA_IG_ADS_USER_TOP_10_5MIN_PAGE_TYPE_35_49_72_94_95_108_AD_ID_CLICK_HA_user_sparse_arch",
+        "table_GFF_S_R70003_ADS_USER_IMPRESSION_NEW_ENTITY_ID_SORTBY_TIME_EVENT_TS_TOP200_D2_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_EVENT_TYPE_LIST__84_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_DA_PRODUCT_FEATURES_EVENTS_RT_USER_FPT_CLICKS_SAFE_LATEST_40_L4_FPT_CATEGORY_ID_CLKS_7D_user_sparse_arch"
+      ],
+      "device_index": 7
+    },
+    {
+      "tbe_uuid": "a5bc8f56-08c8-4cd2-903c-0c9359697d0c",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 282387,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25383824,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 132305,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3349,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784895,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6165,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 750618,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7137443,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7636117,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 704,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_NEW_CAMPAIGN_ID_TOP_7D_TO_28D__SPARSE_NEW_CAMPAIGN_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_UBA_ADS_ADSLLAMA_UBA_AD_ID_590_4_LOG10_EMB_DIM_384_20_DAY_FEATURE_DECODED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SEM_ID_AD_SEMID_LVB_AVG_SEM_ID_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_NO_CREATIVE_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_56D_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_VLBLENDER_ID_MATCHING_CTX_AD_ONSITE_CONVERSION_REPLY_VLBLENDER_V2_CLUSTER_IDENTITY_mix_sparse_arch",
+        "table_MATCHING_MRI__F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_AUTHOR_RID__200_INDEXES__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_spec_mrim_igctr_25h1",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_LT_1S_REELS_AD_ID_LATEST50_28D_ECG_user_sparse_arch",
+        "table_GFF_S_C30034_INSTAGRAM_IGUSER_SPARSE_IG_TIMESPENT_XRAY_TOPIC_FILTERED_28D_AD_ID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D28_user_sparse_arch",
+        "table_GFF_S_R30143_INSTAGRAM_IGUSER_IG_AD_HIGH_INTENT_ENGAGEMENT_IG_AUTHOR_CLUSTER_ID_T1_MOST_FREQUENT_EVENT_FREQUENCY_TOP50_D1_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_IAW_VIEW_DURATION_MS__TOP_5_user_sparse_arch",
+        "table_GFF_IDS_R11570_ADS_USER_CONVERSION_UNATTR_OPT_ALL_CONVERSION_SPARSE_AD_HYBRID_ID_LATEST_N_WITH_TIMESTAMP_EVENT_TS_TOP50_D7_user_sparse_arch",
+        "table_F3_ADFINDER_USER_DA_PRODUCT_FEATURES_EVENTS_RT_USER_FPT_CLICKS_SAFE_TOP_7_L3_FPT_CATEGORY_ID_CLKS_7D_user_sparse_arch"
+      ],
+      "device_index": 1
+    },
+    {
+      "tbe_uuid": "7f4e06cf-91d3-4c56-9e3c-da9255b7cafc",
+      "embedding_specs": [
+        {
+          "num_embeddings": 3519,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7529582,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 155,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5797,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2737037,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 66450,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "table_names": [
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_TEXT_APP_LVBLENDER_ADS_ADSLLAMA_IMAGE_APP_IMG_300K_KNN_DECODED_mix_sparse_arch",
+        "table_GSF_IDLIST_AD_ACCOUNT_PPR_34_IDENTITY_mix_sparse_arch",
+        "table_SPARSE_IG_FORMAT_RANKING_DECISIONS_IDENTITY_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_IMDS_POSTRAY_SMALL_EMBEDDING_ID_MATCHING_IMDS_WEIGHTED_TIME_GAP_POOLING_AD_CLICK_POSTRAY_SMALL_EMBEDDING_CLUSTER_IDENTITY_mix_sparse_arch",
+        "table_GFF_S_C10031_ADS_USER_CONVERSION_FINAL_AD_CAMPAIGN_ID_SORTBY_TIME_EVENT_TS_TOP50_D84_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_CLICK_AD_MT_CLUSTER_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_FACTOR_IDS_TRIGGER_1MIN_ENTITY_EQUIVALENCE_KEY_AD_MEGATAXON_MMT_CLUSTER_EVENT_TYPE_ALL_240MIN_user_sparse_arch"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "c242714b-376b-4694-b649-e93c9608be8c",
+      "embedding_specs": [
+        {
+          "num_embeddings": 509,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1002108,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 102,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 12,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784944,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 435,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 56,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6197911,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3557246,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        5,
+        5,
+        5,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__GSF_FLOAT_ADSIDE_TIMESPENT_28D_FEED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_MEGAENTITIES_ADS_SIDE_FEATURES_MEGAENTITIES_V_2_TYPE_1_ADS_FEATURE_I18N_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_TIMESPENT_FEED_mix_sparse_arch",
+        "table_densebmb_12_12_MBDT_mix_spec_densebmb_regular",
+        "table_AUTO_ID_MATCHING__IDSCORE_LIST_UTR_GFF_IDS_C30053_INSTAGRAM_IGUSER_IG_AD_TIME_SPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP100_D2__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_spec_id_matching",
+        "table_group_28_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_GRAPH_LEARNING_FLEXIBLE_BATCH_GLFF_SUM_USER_ATTRIBUTE_SUM_KMEANS_USER_ATTRIBUTES_NGRAM_0_user_sparse_arch",
+        "table_DENSE_BMB__GFF_R1321_INSTAGRAM_USER_LATEST_EVENT_TIMESTAMP_2_TIME_SINCE_IG_ORGANIC_LIKE_ENGAGEMENT_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_NUM_ADS_SEEN_LAST_5MIN_F3_DENSE_IG_USER_NUM_ADS_SEEN_LAST_5MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_IMPRESSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_ADD_EEK_NO_CREATIVE_ALL_EVENTS_240MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_UNATTRIBUTED_CONVERSION_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_1MIN_TARGET_ID_EVENT_TYPE_ALL_240MIN_user_sparse_arch"
+      ],
+      "device_index": 4
+    },
+    {
+      "tbe_uuid": "995d2fc9-652f-4631-99ae-800c93d59f86",
+      "embedding_specs": [
+        {
+          "num_embeddings": 569,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5431054,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 224,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1647008,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5586548,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6750223,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3231183,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7645696,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 729,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 713,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 96,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 382,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__F3_ADPUBLISHER_IG_IG_ADS_RANKING_IG_STORY_ACTION_COUNT_AD_SPARSE_RT_IG_STORY_ENTITY_EQUIVALENCE_KEY_NAVIGATION_TAP_FORWARD_COUNT_2D_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C11563_ADS_USER_CLICK_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_LATEST_N_WITH_TIMESTAMP_EVENT_TS_TOP100_D84__SPARSE_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_FOR_APP_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_S_R27051_ADS_USER_IMPRESSION_ENTITY_EQUIVALENCE_KEY_SORTBY_TIME_EVENT_TS_TOP50_D2__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_GRAPH_LEARNING_SATORI_SATORI_REALTIME_ACCOUNT_ID_SATORI_ONSITE_CONV_ACCOUNT_ID_RT_RW_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_ALL_EVENTS_240MIN_MATCHING_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_56D_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_NATIVE_BATCH_IG_BOR_PROFILE_ACTION_CROSS_FEATURES_ORGANIC_PROSPECTING_PROFILE_ACTIONS_COUNT_WEBCLICK_28D_mix_sparse_arch",
+        "table_SPARSE_UTR_GFF_S_C19821_INSTAGRAM_IGUSER_IG_ORGANIC_TIMESPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP50_D14_user_sparse_arch",
+        "table_SPARSE_UTR_GFF_S_C19823_INSTAGRAM_IGUSER_IG_AD_TIME_SPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP50_D14_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_CLICK_ECG_IG_AD_CLICK_REELS_AD_ID_INT_TOP50_7D_ECG_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_HIVE_VLBV2_LVB_AVG_CLUSTER_FIX_CODEWORD_IDS_user_sparse_arch",
+        "table_TTH_AGES_densebmb_IG_REQUEST_IS_FIRST_PAGE_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_ENGAGEMENT_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_E_KEY_INSTAGRAM_PROFILE_720MIN_user_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_R1321_INSTAGRAM_USER_LATEST_EVENT_TIMESTAMP_7_TIME_SINCE_IG_ORGANIC_LIKE_ENGAGEMENT_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_USER_SECONDS_SINCE_LAST_AD_CLICK_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_LEGACY_MIGRATION_USER_SESSION_DFC_USER_AD_SESSION_IMP_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_NATIVE_BATCH_GFF_C72000_C72000_ADS_USER_SUM_84_PAGE_TYPE_CONVERSION_TYPE_V2_EXPLODED_ADFINDER_STORY_TYPE_EXPLODED_COUNTER_IMPRESSION_CONVERSION_TYPE_V2_24_ADFINDER_STORY_TYPE_128_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 1
+    },
+    {
+      "tbe_uuid": "e2067d5e-03c2-4adf-a668-e845b5a08c19",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 132508,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 102,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 433,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6780771,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 13569887,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 957839,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 33187,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 278,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6737064,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 237,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 448,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 209,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 205,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__SPARSE_UTR_GFF_S_C19823_INSTAGRAM_IGUSER_IG_AD_TIME_SPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP50_D14__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_sparse_arch",
+        "table_DENSE_BMB__F3_ADINDEXER_ADS_ID_MATCHING_AUTO_AUTO_ID_MATCHING__SPARSE_NEW_VIDEO_ID__GSF_IDLIST_USER_EVENT_CONVERSION_SPARSE_NEW_VIDEO_ID_TOP_7D_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_PA_INTERESTFM_AD_ACCOUNT_AD_ACCOUNT_INTERESTFM_OPEN_VOCAB_MM_100K_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_TIMESPENT_STORY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C870_ADS_USER_SUM_DECAY_900_84_ACCOUNT_ID_PAGE_TYPE_COUNTER_CLICK_mix_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_RAX_ML_FLEXIBLE_BATCH_IAB_PRODUCT_MATCHING_FEATURES_USER_TOP_PRODUCTS_F3_IAB_LH_USER_TOP_30_PRODUCTS_CLICKED_28D_user_sparse_arch",
+        "table_GSF_IDLIST_USER_FATIGUED_CREATIVES_TOP_1000_ENCODED_user_sparse_arch",
+        "table_EBFS_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_VLBLENDER_AD_SIDE_CLUSTER__7_DAYS_user_sparse_arch",
+        "table_EVENT_MOST_RECENT_10_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURES_FROM_FMCU_RMV3_STAGE3_AD_50K_CENTROID_TOP20_CLUSTER_IDS_user_sparse_arch",
+        "table_densebmb_62_62_MBDT_user_sparse_arch",
+        "table_TIMEGAP_WITH_AD_REQUEST__F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_SEEN_STATE_VIDEO_ID_DWELLTIME_IG_SEEN_STATE_VIDEO_ID_DWELLTIME_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_NUM_ADS_SEEN_LAST_1HR_F3_DENSE_IG_USER_NUM_ADS_SEEN_LAST_1HR_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C3060_ADS_USER_SUM_14_COUNTER_IMPRESSION_INSTAGRAM_TOP_CTA_TYPES_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_EXPLODED_REALTIME_R1307_ADS_USER_SUM_2_PAGE_TYPE_CONVERSION_TYPE_VERSION_EXPLODED_COUNTER_IMPRESSION_CONVERSION_TYPE_VERSION_24_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C25302_DA_PRODUCT_FEATURES_USER_SUM_28_PAGE_TYPE_COUNTER_CLICK_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 4
+    },
+    {
+      "tbe_uuid": "51697782-18f7-43e9-9fd8-6dcb9decd50e",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 288727,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 20,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6773750,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6750164,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 261,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2436205,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_UDS_FIR_AD_IMPRESSION_AD_ENTITY_EQUIVALENCE_KEY_LIST__2_DAYS__SPARSE_ENTITY_EQUIVALENCE_KEY_FOR_APP_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_XRAYVIDEO_2022B_AV_100D_SEGMENT_AWARE_CLUSTERING_ADS_SIDE_VIDEO_UNDERSTANDING_XRAYVIDEO2022B_AV_100D_AD_SIDE_FEATURES_ID_LIST_REALTIME_1_DECODED_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_AUTO_ID_MATCHING__SPARSE_AD_BUSINESS_ID__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_AD_BUSINESS_ID_TOP_7D_mix_sparse_arch",
+        "table_densebmb_2025h1_1_1_MBDT_mix_spec_densebmb_igctr_25h1",
+        "table_group_12_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_CLICK_ECG_IG_AD_CLICK_NON_REELS_AD_ID_INT_TOP50_7D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_CLICK_ECG_IG_AD_CLICK_REELS_AD_ID_INT_LATEST50_7D_ECG_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_NATIVE_BATCH_IG_ADS_RANKING_IG_AD_CLICK_REFINEMENT_ADS_USER_SUM_28_PAGE_TYPE_RATIO_PV_CLICK_IMPRESSION_user_sparse_arch",
+        "table_densebmb_24_24_MBDT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_TOP_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_VIDEO_VIEW_720MIN_user_sparse_arch"
+      ],
+      "device_index": 2
+    },
+    {
+      "tbe_uuid": "54929460-4d19-4623-93b2-ee41aaaf8edb",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4092,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 182,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5313067,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784922,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 33201,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 762,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 758,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 278,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 468,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 263,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 717,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        7,
+        7,
+        7,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__GFF_S_R11596_ADS_USER_CONVERSION_PIXEL_RID_SORTBY_TIME_EVENT_TS_TOP50_D2__SPARSE_NEW_PAGE_RID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_GEOGRAPHIC_REGION_SPARSE_IG_ACTOR_REGION_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C1112_INSTAGRAM_USER_SUM_28_INSTAGRAM_ACTOR_FBIDV2_COUNTER_IG_ORGANIC_IMPRESSION_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_S_R27051_ADS_USER_IMPRESSION_ENTITY_EQUIVALENCE_KEY_SORTBY_TIME_EVENT_TS_TOP50_D2__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_spec_id_matching",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_AD_ADS_SAFE_REALTIME_REALTIME_OLD_IG_USER_COUNT_DENSE_REALTIME_SAFE_V2_COUNT_FLOAT_USER_AUTHOR_EVENT_INSTAGRAM_AD_BRAND_PROFILE_7D_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_SPARSE_NEW_PAGE_RID__GFF_S_C40010064_ADS_USER_PAGE_LINK_CLICKS_USER_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D84_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_SPARSE_ENTITY_EQUIVALENCE_KEY__GFF_S_R64500_ADS_USER_CLICK_ENTITY_EQUIVALENCE_KEY_SORTBY_TIME_EVENT_TS_TOP200_D7_mix_spec_tail_sigrid_features",
+        "table_group_13_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_NATIVE_BATCH_OAE_ML_IAW_AUTOFILL_ALL_FEATURES_V4_IAW_ACCEPTED_CONTACT_AUTOFILL_SPARSE_ENTITY_EQUIVALENCE_KEY_V4_28D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_CLICK_ECG_IG_AD_CLICK_NON_REELS_AD_ID_INT_TOP50_28D_ECG_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURES_FROM_FMCU_RMV3_STAGE3_AD_50K_CENTROID_TOP20_CLUSTER_IDS_user_sparse_arch",
+        "table_densebmb_2_2_MBDT_user_sparse_arch",
+        "table_densebmb_31_31_MBDT_user_sparse_arch",
+        "table_densebmb_23_23_MBDT_user_spec_densebmb_regular",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_ADS_ML_MODELING_SHORT_AGGREGATION_WINDOW_DENSE_FEATURES_GFF_R1306_ADS_USER_SUM_4_HOUR_PAGE_TYPE_RATIO_EVENT_LIKE_IMPRESSION_GFF_R1306_ADS_USER_SUM_4_HOUR_PAGE_TYPE_RATIO_EVENT_LIKE_IMPRESSION_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_ADS_ML_MODELING_SHORT_AGGREGATION_WINDOW_DENSE_FEATURES_GFF_R1318_ADS_USER_SUM_4_HOUR_PAGE_TYPE_COUNTER_IMPRESSION_GFF_R1318_ADS_USER_SUM_4_HOUR_PAGE_TYPE_COUNTER_IMPRESSION_user_spec_tail_sigrid_features",
+        "table_densebmb_2025h1_12_12_MBDT_user_spec_densebmb_igctr_25h1"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "9f027b24-7d3d-441d-a9f7-8f1670287ba5",
+      "embedding_specs": [
+        {
+          "num_embeddings": 183253,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 621919,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5748,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 112987,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784917,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 31,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5980506,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4633185,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 475,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ],
+      "table_names": [
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_UBA_ADS_ADSLLAMA_UBA_AD_ID_590_4_EMB_DIM_384_FEATURE_DECODED_mix_sparse_arch",
+        "table_GSF_IDLIST_CLUSTER_BASED_AD_ACCOUNT_ID_PPR_EXPANSION_23_V1_IDENTITY_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_TEXTRAY_ID_MATCHING_CTX_AD_ONSITE_CONVERSION_REPLY_TEXTRAY_CLUSTER_IDENTITY_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_LAST_USED_MOBILE_APP_100_FEATURE__SPARSE_MOBILE_APP_ID_mix_spec_id_matching",
+        "table_group_5_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_UUDL_OFFSITE_CONVERSION_APP_REALTIME_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_5MIN_APP_ID_FB_MOBILE_ACTIVATE_APP_1440MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_GT_3S_REELS_AD_ID_TOP50_28D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_IAW_EVENT_TYPE_ID__1_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_PAGE_TYPE_ID__84_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_IMPRESSION_REALTIME_SAFE_TOP_ENGAGED_ENTITY_ID_SCORE_LIST_ADD_EEK_NO_CREATIVE_ALL_EVENTS_1440MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_USER_LATESTN_AD_ID_CLICK_HA_IG_ADS_USER_LATEST_20_5MIN_PAGE_TYPE_94_95_AD_ID_CLICK_HA_user_sparse_arch",
+        "table_densebmb_37_37_MBDT_user_spec_densebmb_regular"
+      ],
+      "device_index": 2
+    },
+    {
+      "tbe_uuid": "605e32c9-1de8-4178-8706-03680211eced",
+      "embedding_specs": [
+        {
+          "num_embeddings": 773,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 14306,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 102,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 681,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 629,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 669,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1991740,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 957839,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 977939,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 442,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      "table_names": [
+        "table_DENSE_BMB__AD_REPETITION_SECOND_SINCE_LAST_METAID_IMP_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_PA_INTERESTFM_AD_ACCOUNT_AD_ACCOUNT_INTERESTFM_OPEN_VOCAB_MM_10K_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_TIMESPENT_STORY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_R1312_ADS_USER_LATEST_EVENT_TIMESTAMP_7_CONVERSION_TYPE_VERSION_TIME_SINCE_CONVERSION_mix_sparse_arch",
+        "table_densebmb_54_54_MBDT_mix_spec_densebmb_regular",
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_NEW_CAMPAIGN_ID_TOP_7D_TO_28D__SPARSE_NEW_CAMPAIGN_ID_mix_spec_id_matching",
+        "table_TTH_AGES_densebmb_GFF_C1822467_ADS_ENTITY_EQUIVALENCE_KEY_SUM_28_PAGE_TYPE_RATIO_XOUT_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_F3_ADFINDER_USER_ADS_FLEXIBLE_BATCH_3PD_ATT_AGGREGATED_SPARSE_FEATURES_CONVERSION_ENTITY_EQUIVALENCE_KEY_SORTEDBY_TIMESTAMP_TOP50_D14_V2_user_sparse_arch",
+        "table_EBFS_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_VLBLENDER_AD_SIDE_CLUSTER__7_DAYS_user_sparse_arch",
+        "table_EVENT_MOST_RECENT_10_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_DWELLING_TIME_LIST_user_sparse_arch",
+        "table_densebmb_pagehomefeed_2_2_MBDT_user_sparse_arch"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "72906e18-9bdc-4b62-aaee-4feebaddfccf",
+      "embedding_specs": [
+        {
+          "num_embeddings": 123734,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 548,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6782121,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784932,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 103,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3325018,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 16,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "table_names": [
+        "table_GSF_IDLIST_TFIDF_ACTIVE_APP_DESC_FEATURE_TOP__DF_3_MTO_5_MAX_WORDS_50_IDENTITY_mix_sparse_arch",
+        "table_densebmb_67_67_MBDT_mix_spec_densebmb_regular",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C10524_ADS_USER_IMPRESSION_ENTITY_EQUIVALENCE_KEY_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D28__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_spec_id_matching",
+        "table_group_27_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_LT_1S_AD_ID_LATEST50_7D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_GRAPH_LEARNING_FLEXIBLE_BATCH_GLFF_GLFF_PPR_FEATURES_2025H1_GLFF_2025H1_PPR_IDLIST_ADCLKS_ONSITE_VV_USER_EKEY_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_NUM_ADS_SEEN_LAST_15MIN_F3_DENSE_IG_USER_NUM_ADS_SEEN_LAST_15MIN_user_sparse_arch",
+        "table_TIMEGAP_WITH_AD_REQUEST__F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_UNATTRIBUTED_CONVERSION_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_1MIN_TARGET_ID_EVENT_TYPE_ALL_240MIN_user_sparse_arch",
+        "table_densebmb_52_52_MBDT_user_spec_densebmb_regular"
+      ],
+      "device_index": 4
+    },
+    {
+      "tbe_uuid": "c17d6e28-2b70-4856-a933-4f4a43a1adbb",
+      "embedding_specs": [
+        {
+          "num_embeddings": 533,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 143439,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 746,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2628856,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4785338,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4785338,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 850098,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 370368,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "table_names": [
+        "table_DENSE_BMB__GFF_R70513_ADS_NEW_TARGET_ID_SUM_2_PAGE_TYPE_USER_REGION_RATIO_CONVERSION_CLICK_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_LVB_IMAGE_100K_KNN_DECODED_mix_sparse_arch",
+        "table_densebmb_36_36_MBDT_mix_sparse_arch",
+        "table_densebmb_vertical_5_5_MBDT_mix_sparse_arch",
+        "table_group_0_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_USER_TOPK_AD_ACCOUNT_ID_CLICK_HA_IG_ADS_USER_TOP_10_1H_PAGE_TYPE_35_49_72_94_95_108_AD_ID_CLICK_HA_user_sparse_arch",
+        "table_GSF_IDLIST_IG_STORY_AD_USER_LOW_INTENT_V1_NAVIGATION_GESTURE_AUTHOR_RID_7D_user_sparse_arch",
+        "table_GSF_IDLIST_IG_STORY_AD_USER_LOW_INTENT_V1_NAVIGATION_GESTURE_AUTHOR_RID_7D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_CLUSTERS_KNN_POP__TOP_60_user_sparse_arch",
+        "table_GSF_IDSCORELIST_REQUEST_LEVEL_IG_ADS_FEED_SEEN_STATE_AUTHOR_CLUSTER_POPULAR_DWELLTIME_PAIR_user_sparse_arch"
+      ],
+      "device_index": 7
+    },
+    {
+      "tbe_uuid": "c0457f7c-9b80-485d-9326-4f400a478869",
+      "embedding_specs": [
+        {
+          "num_embeddings": 144314,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 71786,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 774,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 168364,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 134130,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1389,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4489188,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "table_names": [
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_VLBLENDER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_LVB_IMG_100K_KNN_FIX_QUANTIZED_DECODED_mix_sparse_arch",
+        "table_GSF_IDLIST_MEGATAXON_AD_CLUSTERING_V1_IDENTITY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_AUDIO_UNDERSTANDING_FEATURES_AUDIO_UNDERSTANDING_AED_TOP_8_SCORES_DECODED_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_SPARSE_NEW_PAGE_RID__GFF_S_R11595_ADS_USER_CONVERSION_CONVERSION_UNATTR_OPT_PIXEL_RID_SORTBY_TIME_EVENT_TS_TOP50_D7_mix_spec_tail_sigrid_features",
+        "table_group_8_user_sparse_arch",
+        "table_GSF_IDLIST_LAST_USED_MOBILE_APP_100_FEATURE_user_sparse_arch",
+        "table_AGES_DENSEBMB__USER_RT_LOC_IS_ON_MOBILE_NETWORK_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_VLBLENDER_AD_SIDE_CLUSTER__TOP_100_user_sparse_arch",
+        "table_MOBILE_DEVICE_BRAND_MODEL_HASH_MAPID_TRANSFORMED_ID_LIST_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_NATIVE_BATCH_OAE_ML_IAB_ORGANIC_DOMAIN_HASH_IAB_ORGANIC_DOMAIN_HASH_DWELL_TIME_SPARSE_SEPARABLE_ID_DOMAIN_HASH_IDSCORELIST_7D_user_sparse_arch"
+      ],
+      "device_index": 2
+    },
+    {
+      "tbe_uuid": "337bd4bc-f756-4042-9a70-8743d75497f9",
+      "embedding_specs": [
+        {
+          "num_embeddings": 688,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 139554,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 608,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 373,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 13569887,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 160,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 332,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1709,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 444,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 735,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13
+      ],
+      "table_names": [
+        "table_DENSE_BMB__GFF_R70513_ADS_NEW_TARGET_ID_SUM_2_PAGE_TYPE_USER_REGION_RATIO_CLICK_IMPRESSION_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_LVB_AVG_100K_KNN_DECODED_mix_sparse_arch",
+        "table_densebmb_33_33_MBDT_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C11526_ADS_USER_CLICK_ENTITY_EQUIVALENCE_KEY_LATEST_N_WITH_TIMESTAMP_EVENT_TS_TOP100_D84__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_spec_id_matching",
+        "table_group_37_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_NON_ENGAGEMENT_IMP_NO_CLICK_MT_USER_AD_NON_ENGAGE_AD_MEGATAXON_L2_4H_TOP_K_WITH_COUNT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SEMID_FLEXIBLE_BATCH_USER_CLICK_AND_IMPRESSION_28D_F3_AD_CLICK_AND_IMPRESSION_TOP50_COUNT_TEXTRAY_TRIGRAM_SEM_IDS_USERSIDE_28D_user_sparse_arch",
+        "table_AGES_DENSEBMB__AD_FEED_MOBILE_SCREEN_PIXEL_DENSITY_user_sparse_arch",
+        "table_DENSE_BMB__GSF_FLOAT_REQUEST_LEVEL_IG_ADS_FEED_SEEN_STATE_LAST_IMP_DWELL_TIME_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_APPS_EVENT_LIST__1_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_NATIVE_BATCH_OAE_ML_IAB_LH_USER_PRODUCT_FPT_FEATURES_IAB_LH_TOP_10_WITH_COUNTS_L4_FPT_CATEGORY_VISITED_28D_user_sparse_arch",
+        "table_densebmb_41_41_MBDT_user_spec_densebmb_regular",
+        "table_densebmb_79_79_MBDT_user_spec_densebmb_regular",
+        "table_densebmb_2025h1_0_0_MBDT_user_spec_densebmb_igctr_25h1"
+      ],
+      "device_index": 5
+    },
+    {
+      "tbe_uuid": "73287e33-6c68-4d30-9ca4-0e73b9a3acc9",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 275156,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 9939,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 11,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 693,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 741,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4742227,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784935,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4523258,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1857487,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 629,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 578,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        8,
+        8,
+        8,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_AD_CLICKS_FOR_DELIVERY_RT_GFF_MIGRATED_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_EEK_ALL_7D__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_MEGAENTITIES_X_ARM_AD_SIDE_FEATURE_E_KEY_ENHANCED_MEGAENTITY_BY_ARM_V_3_TYPE_3_CAP5_ADS_FEATURE_EKEY_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_NO_CREATIVE_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_28D_mix_sparse_arch",
+        "table_SPARSE_AD_PRODUCT_FORMAT_TYPE_LIST_FIRST_5_SPARSE_AD_PRODUCT_FORMAT_TYPE_LIST_FIRST_5_BIGRAM_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_INSTAGRAM_MEDIA_ID_TOP_7D_TO_28D__SPARSE_INSTAGRAM_MEDIA_ID_mix_spec_id_matching",
+        "table_TTH_AGES_densebmb_GFF_C869_ADS_USER_SUM_84_ACCOUNT_ID_COUNTER_EVENT_LIKE_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_USER_AD_CLICK_PPR_REC_EKEY_RMV3_SOFT_MATCHING_DENSE_EFE_SOFT_MATCH_USER_AD_CLICK_PPR_REC_EKEY_RMV3_EMB_COSINE_SIMILARITY_MAX_RELEVANCE_SCORE_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_R1317_ADS_USER_LATEST_EVENT_TIMESTAMP_2_CONVERSION_TYPE_VERSION_TIME_SINCE_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_group_26_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_FLEXIBLE_BATCH_3PD_ATT_AGGREGATED_SPARSE_FEATURES_TRACKING_OC_ENTITY_EQUIVALENCE_KEY_SORTEDBY_TIMESTAMP_TOP50_D56_V2_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_GRAPH_LEARNING_FLEXIBLE_BATCH_GLFF_GLFF_PPR_FEATURES_2025H1_GLFF_2025H1_PPR_IDLIST_ADCLKS_ONSITE_LC_USER_EKEY_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_TIME_SINCE_LAST_AD_CTA_FEED_F3_DENSE_IG_USER_TIME_SINCE_LAST_AD_CTA_FEED_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_NON_ENGAGEMENT_IMP_NO_CLICK_USER_AD_NON_ENGAGE_AD_ACCOUNT_ID_24H_TOP_K_WITH_COUNT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_UNATTRIBUTED_CONVERSION_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_1MIN_TARGET_ID_LANDING_PAGE_VIEW_240MIN_user_sparse_arch",
+        "table_densebmb_56_56_MBDT_user_spec_densebmb_regular",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_NATIVE_BATCH_GFF_C72000_C72000_ADS_USER_SUM_84_PAGE_TYPE_CONVERSION_TYPE_V2_EXPLODED_ADFINDER_STORY_TYPE_EXPLODED_COUNTER_IMPRESSION_CONVERSION_TYPE_V2_26_ADFINDER_STORY_TYPE_128_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 5
+    },
+    {
+      "tbe_uuid": "d64f0183-b3d4-4741-a18e-0456f8e6e997",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 288221,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 132,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784934,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3804538,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 22,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 261,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4063570,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_UDS_FIR_AD_IMPRESSION_AD_ENTITY_EQUIVALENCE_KEY_LIST__84_DAYS__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_XRAY_2022A_DOUBLE_CLUSTERING_ADS_SIDE_IMAGE_UNDERSTANDING_VLBLENDER_AD_SIDE_FEATURES_ID_LIST_REALTIME_1_DECODED_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_AUTO_ID_MATCHING__SPARSE_AD_BUSINESS_ID__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_AD_BUSINESS_ID_TOP_7D_TO_28D_mix_sparse_arch",
+        "table_densebmb_3_3_MBDT_mix_spec_densebmb_regular",
+        "table_group_11_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_GRAPH_LEARNING_FLEXIBLE_BATCH_GLFF_GLFF_PPR_FEATURES_2025H1_GLFF_2025H1_PPR_IDLIST_ADCLKS_ONSITE_ALL_USER_EKEY_user_sparse_arch",
+        "table_EVENT_AGG_2D_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_AUTHOR_RID_LIST_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_CLICK_DENSE_REALTIME_SAFE_V2_COUNT_FLOAT_EARLY_TRIGGER_1MIN_AD_ID_ALL_240MIN_user_sparse_arch",
+        "table_densebmb_24_24_MBDT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_UNATTRIBUTED_CONVERSION_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_1MIN_TARGET_ID_EVENT_TYPE_ALL_1440MIN_user_sparse_arch"
+      ],
+      "device_index": 2
+    },
+    {
+      "tbe_uuid": "828b0e85-985f-409d-bbbd-176507ca1f32",
+      "embedding_specs": [
+        {
+          "num_embeddings": 413,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 142996,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 544,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 248,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5083251,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 381,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 12,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 64670,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4859936,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "table_names": [
+        "table_DENSE_BMB__VIDEO_DURATION_MS_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_TEXTRAY_OCR_IMAGE_100K_KNN_DECODED_mix_sparse_arch",
+        "table_densebmb_42_42_MBDT_mix_sparse_arch",
+        "table_densebmb_2025h1_10_10_MBDT_mix_spec_densebmb_igctr_25h1",
+        "table_group_3_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_AD_CTA_ITEM_IDS_FEED_F3_SPARSE_IG_USER_AD_CTA_ITEM_IDS_FEED_user_sparse_arch",
+        "table_DENSE_BMB__GFF_R7009_ADS_USER_SUM_7_COUNTER_CONVERSION_UNATTR_OPT_ALL_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_EVENT_TYPE_LIST__1_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_VLBLENDERV2_AD_AND_USER_SIDE_FEATURES_CTX_USER_NUM_REPLY_ADS_PAST_7D_VLBLENDER_V2_CLUSTER_IDS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_ALL_EVENTS_1440MIN_user_sparse_arch"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "0df78daf-ba90-45ce-832c-976872b97d18",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 275156,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 9939,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 586,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 728,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 653,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4742227,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784935,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4523258,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1857487,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 146,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        8,
+        8,
+        8,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_AD_CLICKS_FOR_DELIVERY_RT_GFF_MIGRATED_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_EEK_ALL_7D__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_MEGAENTITIES_X_ARM_AD_SIDE_FEATURE_E_KEY_ENHANCED_MEGAENTITY_BY_ARM_V_3_TYPE_3_CAP5_ADS_FEATURE_EKEY_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_NO_CREATIVE_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_28D_mix_sparse_arch",
+        "table_SPARSE_AD_PRODUCT_FORMAT_TYPE_LIST_FIRST_5_SPARSE_AD_PRODUCT_FORMAT_TYPE_LIST_FIRST_5_BIGRAM_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_S_R64504_ADS_USER_CLICK_NEW_PAGE_RID_SORTBY_TIME_EVENT_TS_TOP200_D7__SPARSE_NEW_PAGE_RID_mix_spec_id_matching",
+        "table_TTH_AGES_densebmb_GFF_C72003_ADS_ENTITY_EQUIVALENCE_KEY_SUM_84_PAGE_TYPE_RATIO_CONVERSION_FINAL_CLICK_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C4010_ADS_USER_SUM_84_PAGE_TYPE_PAGE_CTA_ACTION_TYPE_RATIO_CLICK_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_R70015_ADS_NEW_VIDEO_ID_SUM_2_RATIO_CONVERSION_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_group_26_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_FLEXIBLE_BATCH_3PD_ATT_AGGREGATED_SPARSE_FEATURES_TRACKING_OC_ENTITY_EQUIVALENCE_KEY_SORTEDBY_TIMESTAMP_TOP50_D56_V2_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_GRAPH_LEARNING_FLEXIBLE_BATCH_GLFF_GLFF_PPR_FEATURES_2025H1_GLFF_2025H1_PPR_IDLIST_ADCLKS_ONSITE_LC_USER_EKEY_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_TIME_SINCE_LAST_AD_CTA_FEED_F3_DENSE_IG_USER_TIME_SINCE_LAST_AD_CTA_FEED_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_NON_ENGAGEMENT_IMP_NO_CLICK_USER_AD_NON_ENGAGE_AD_ACCOUNT_ID_24H_TOP_K_WITH_COUNT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_UNATTRIBUTED_CONVERSION_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_1MIN_TARGET_ID_LANDING_PAGE_VIEW_240MIN_user_sparse_arch",
+        "table_densebmb_61_61_MBDT_user_spec_densebmb_regular",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_TIME_SINCE_LAST_AD_CTA_FEED_F3_DENSE_IG_USER_TIME_SINCE_LAST_AD_CTA_FEED_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 5
+    },
+    {
+      "tbe_uuid": "73f3a486-bd26-4522-b73f-a6c7280db1b6",
+      "embedding_specs": [
+        {
+          "num_embeddings": 37808487,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 427946,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 41,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5782,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 79526,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 868264,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1978542,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 42,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6110848,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      "table_names": [
+        "table_group_49_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_TEXT_APP_LVBLENDER_ADS_ADSLLAMA_TEXT_APP_LVBLENDER_FEATURES_TEXT_APP_LVBLENDER_IMG_300K_KNN_DECODED_mix_sparse_arch",
+        "table_GSF_IDLIST_AD_ACCOUNT_SF_VERTICAL_ID_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_NO_CREATIVE_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_56D_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_IMDS_POSTRAY_SMALL_EMBEDDING_ID_MATCHING_IMDS_WEIGHTED_TIME_GAP_POOLING_AD_IMPRESSION_POSTRAY_SMALL_EMBEDDING_CLUSTER_IDENTITY_mix_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_ATOM_FEATURIZATION_ATOM_TEXTRAY_RQVAE_USER_FEATURE_TEXTRAY_RQVAE_USER_ADS_TEXTRAY_RQVAE_CLUSTER_BIGRAM_12_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_RAX_ML_REALTIME_IAW_NO_BOUNCE_RT_FEATURES_IAB_NO_BOUNCE_RT_SPARSE_SEPARABLE_ID_SPARSE_USER_PIXEL_ID_IDLIST_2D_user_sparse_arch",
+        "table_GSF_IDLIST_USER_ENGAGED_PAGE_RID_CLUSTERING_V6_LINK_CLICKS_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D84_user_sparse_arch",
+        "table_AGES_DENSEBMB__GFF_R1958_ADS_USER_SUM_2_PAGE_TYPE_COUNTER_VIDEO_VIEW_10S_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_PAGE_TYPE_ID__1_DAYS_user_sparse_arch",
+        "table_GSF_IDSCORELIST_MOBILE_STORY_AD_ACCOUNT_ID_NON_ENGAGEMENT_90D_user_sparse_arch"
+      ],
+      "device_index": 1
+    },
+    {
+      "tbe_uuid": "db5ca92c-189d-4938-a6ad-05de28765553",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 96127,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 102,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 685,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6709188,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 971568,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 216,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2674624,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 146,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7212274,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 605,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__IDSCORE_LIST_UTR_GFF_IDS_C30053_INSTAGRAM_IGUSER_IG_AD_TIME_SPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP100_D84__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__SPARSE_UTR_GFF_S_C19822_INSTAGRAM_IGUSER_IG_ORGANIC_TIMESPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP50_D14__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_PA_INTERESTFM_AD_ACCOUNT_AD_ACCOUNT_INTERESTFM_HASHTAG_GENERATION_MM_70K_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_TIMESPENT5__mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C72000_ADS_USER_SUM_84_PAGE_TYPE_CONVERSION_TYPE_V2_ADFINDER_STORY_TYPE_COUNTER_IMPRESSION_mix_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_GRAPH_LEARNING_FLEXIBLE_BATCH_GLFF_GLFF_PPR_FEATURES_2025H1_GLFF_2025H1_PPR_IDLIST_ADCLKS_USER_NOCREATIVE_EKEY_user_sparse_arch",
+        "table_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_FACTOR_BIGRAM_SAFE_V2_TOP_ENGAGED_ENTITY_FACTOR_IDS_AD_NON_ENGAGEMENT_FACTOR_BIGRAM_DOMAIN_X_BRAND_V4_EVENT_TYPE_ALL_28D_user_sparse_arch",
+        "table_EBFS_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_PAGE_TYPE_ID__7_DAYS_user_sparse_arch",
+        "table_EVENT_MOST_RECENT_10_F3_ADFINDER_USER_ADS_UDS_FIR_PIXEL_PIXEL_ID_LIST_user_sparse_arch",
+        "table_densebmb_61_61_MBDT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_ENGAGEMENT_REALTIME_SAFE_TOP_ENGAGED_ENTITY_ID_SCORE_LIST_E_KEY_INSTAGRAM_PROFILE_240MIN_user_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C3039_ADS_USER_SUM_84_PAGE_CTA_ACTION_TYPE_589832_PAGE_TYPE_COUNTER_IMPRESSION_EXPLODED_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 1
+    },
+    {
+      "tbe_uuid": "f6e79590-f858-4931-8605-41213cdd5ce7",
+      "embedding_specs": [
+        {
+          "num_embeddings": 418738,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7082169,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5734,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7571,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6583262,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3844321,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 381,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 31,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1787,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "table_names": [
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_ADSLLAMA_EEL_EMB_ADS_ADSLLAMA_EEL_EMB_FEATURES_COCLICK_100M_RM_SIMCSE_DDP_HIVE_64BIT_CODEWORD_IDS_IDENTITY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBV2_VLB_IMAGE_RQ_VAE_DECODED_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_IMDS_POSTRAY_ID_MATCHING_IMDS_WEIGHTED_TIME_GAP_POOLING_AD_CLICK_POSTRAY_CLUSTER_IDENTITY_mix_sparse_arch",
+        "table_group_2_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_UUDL_OFFSITE_CONVERSION_APP_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_5MIN_APP_ID_FB_MOBILE_CONTENT_VIEW_1440MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_CONTENT_UNDERSTANDING_MARKETPLACE_POSITIVE_ENGAGEMENT_F3_MP_USER_POSITIVE_ENGAGEMENT_28D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_CLICK_ECG_IG_AD_CLICK_REELS_AD_ACCOUNT_ID_TOP50_7D_ECG_user_sparse_arch",
+        "table_DENSE_BMB__GFF_R7009_ADS_USER_SUM_7_COUNTER_CONVERSION_UNATTR_OPT_ALL_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_PAGE_TYPE_ID__14_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_DA_PRODUCT_FEATURES_EVENTS_RT_USER_FPT_CLICKS_SAFE_TOP_10_L4_FPT_CATEGORY_ID_CLKS_7D_user_sparse_arch"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "268732fe-3a00-4e8d-b71e-36dfb281dc58",
+      "embedding_specs": [
+        {
+          "num_embeddings": 669,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 133222,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 27242,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 21677113,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 756,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 502,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784932,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3611543,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6065200,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 439,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 17,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 126,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5933364,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 278,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__GFF_R70015_ADS_NEW_VIDEO_ID_SUM_2_RATIO_CLICK_IMPRESSION_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C30133_INSTAGRAM_IGUSER_IG_STORY_ADS_TIMESPENT_PAIR_IG_ACTOR_RID_SORTBY_SCORE_IG_TIMESPENT_TOP200_D28__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_CRDL_MULTIMODAL_SUM_ADS_SIDE_CRDL_MULTIMODAL_SUM_100K_TOP20_CLUSTER_IDS_IDENTITY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_SFV_TOP_CLUSTER_IDS_FOR_ADS_VIDEO_SFV_TOP_AVG_CLIP_20K_QUANTIZED_IDENTITY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SEM_ID_AD_SEMID_TEXTRAY_TEXT_SEM_ID_IDENTITY_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C10525_ADS_USER_IMPRESSION_NEW_VIDEO_ID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D28__SPARSE_NEW_VIDEO_ID_mix_spec_id_matching",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_SPARSE_AD_ACCOUNT_ID__GFF_S_R64002_ADS_USER_CONVERSION_SPARSE_AD_HYBRID_ID_SORTBY_TIME_EVENT_TS_TOP50_D7_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_R1506146_ADS_ENTITY_EQUIVALENCE_KEY_SUM_2_RATIO_XOUT_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GSF_FLOAT_ADSIDE_TIMESPENT_2D_FEED_mix_spec_tail_sigrid_features",
+        "table_F3_ADFINDER_USER_ADS_GRAPH_LEARNING_FLEXIBLE_BATCH_GLFF_GLFF_PPR_FEATURES_2025H1_GLFF_2025H1_PPR_IDLIST_ADCLKS_USER_EKEY_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_NATIVE_BATCH_OAE_ML_IAW_LH_TRACKING_ALL_FEATURES_IAW_LH_TRACKING_UPPER_FUNNEL_SPARSE_ENTITY_EQUIVALENCE_KEY_LIST_PER_USER_ID_14D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_ENCODED_BASIC_NEW_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_NO_CREATIVE_HASH32_ENCODE32_NEW_EVENT_NON_AND_NEG_ENGAGEMENT_7D_user_sparse_arch",
+        "table_DENSE_BMB__GFF_R1321_INSTAGRAM_USER_LATEST_EVENT_TIMESTAMP_2_TIME_SINCE_IG_ORGANIC_BRAND_PROFILE_ENGAGEMENT_user_sparse_arch",
+        "table_NGRAM_IG_REQUEST_NGRAM_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_NUM_ADS_SEEN_LAST_30MIN_F3_DENSE_IG_USER_NUM_ADS_SEEN_LAST_30MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_IMPRESSION_REALTIME_SAFE_TOP_ENGAGED_ENTITY_ID_SCORE_LIST_ADD_EEK_NO_CREATIVE_ALL_EVENTS_240MIN_user_sparse_arch",
+        "table_densebmb_62_62_MBDT_user_spec_densebmb_regular"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "d12cc77c-d9f6-4064-a50a-4c050f197a99",
+      "embedding_specs": [
+        {
+          "num_embeddings": 773,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 14306,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 102,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 681,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 593,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 99,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1991740,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 957839,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 977939,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 442,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      "table_names": [
+        "table_DENSE_BMB__AD_REPETITION_SECOND_SINCE_LAST_METAID_IMP_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_PA_INTERESTFM_AD_ACCOUNT_AD_ACCOUNT_INTERESTFM_OPEN_VOCAB_MM_10K_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_TIMESPENT_STORY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_R1312_ADS_USER_LATEST_EVENT_TIMESTAMP_7_CONVERSION_TYPE_VERSION_TIME_SINCE_CONVERSION_mix_sparse_arch",
+        "table_densebmb_48_48_MBDT_mix_spec_densebmb_regular",
+        "table_AUTO_ID_MATCHING__SPARSE_UTR_GFF_S_C19822_INSTAGRAM_IGUSER_IG_ORGANIC_TIMESPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP50_D14__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_spec_id_matching",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_NATIVE_BATCH_IG_BOR_PROFILE_ACTION_CROSS_FEATURES_ORGANIC_PROSPECTING_PROFILE_ACTIONS_COUNT_APPINSTALL_7D_mix_spec_tail_sigrid_features",
+        "table_F3_ADFINDER_USER_ADS_FLEXIBLE_BATCH_3PD_ATT_AGGREGATED_SPARSE_FEATURES_CONVERSION_ENTITY_EQUIVALENCE_KEY_SORTEDBY_TIMESTAMP_TOP50_D14_V2_user_sparse_arch",
+        "table_EBFS_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_VLBLENDER_AD_SIDE_CLUSTER__7_DAYS_user_sparse_arch",
+        "table_EVENT_MOST_RECENT_10_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_DWELLING_TIME_LIST_user_sparse_arch",
+        "table_densebmb_pagehomefeed_2_2_MBDT_user_sparse_arch"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "cf8a0c65-683a-44bb-8570-74b6c8406bb3",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 60410,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 773,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2852945,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6740367,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 801331,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 746,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 278,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6192824,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__GFF_IDS_C10524_ADS_USER_IMPRESSION_ENTITY_EQUIVALENCE_KEY_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D28__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_FAM_FBE_FLEXIBLE_BATCH_FAM_ADS_LOCATION_FEATURES_F3_IDLIST_TOP_5_CITY_BY_IMP_30_DAYS_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_AUTO_ID_MATCHING__SPARSE_NEW_PAGE_RID__GFF_S_R64504_ADS_USER_CLICK_NEW_PAGE_RID_SORTBY_TIME_EVENT_TS_TOP200_D2_mix_sparse_arch",
+        "table_densebmb_44_44_MBDT_mix_spec_densebmb_regular",
+        "table_group_9_user_sparse_arch",
+        "table_GFF_S_R7019_ADS_USER_CONVERSION_UNATTR_OPT_ALL_SPARSE_AD_HYBRID_ID_SORTBY_TIME_EVENT_TS_TOP50_D7_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_RAX_ML_REALTIME_IAB_LH_USER_PRODUCT_FEATURES_IAB_LH_TOP_30_ENGAGED_PRODUCT_ID_CLICKS_7D_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_CLUSTERS_KNN_POP_user_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_R1306_ADS_USER_LATEST_EVENT_TIMESTAMP_2_PAGE_TYPE_TIME_SINCE_IMPRESSION_user_sparse_arch",
+        "table_densebmb_23_23_MBDT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_USER_LATESTN_AD_ID_CLICK_HA_IG_ADS_USER_LATEST_20_1H_PAGE_TYPE_35_49_72_94_95_108_AD_ID_CLICK_HA_user_sparse_arch"
+      ],
+      "device_index": 2
+    },
+    {
+      "tbe_uuid": "8fee9282-0f0a-4da4-9ce2-f8e8e9127f17",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 278189,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25548,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 544,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6783030,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 13569887,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 13569887,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6779573,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3992,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 300,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7607803,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_CONTENT_UNDERSTANDING_MARKETPLACE_POSITIVE_ENGAGEMENT_F3_MP_USER_POSITIVE_ENGAGEMENT_7D__SPARSE_AD_ACCOUNT_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_MEGAENTITIES_ADS_SIDE_FEATURES_MEGAENTITIES_V_2_TYPE_3_ADS_FEATURE_I18N_IDENTITY_mix_sparse_arch",
+        "table_SPARSE_AD_MEDIA_XRAY_V11_TOPIC_ID_IDENTITY_mix_sparse_arch",
+        "table_densebmb_42_42_MBDT_mix_spec_densebmb_regular",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_CLICK_ECG_IG_AD_CLICK_REELS_AD_ID_INT_LATEST50_28D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SEMID_FLEXIBLE_BATCH_USER_CONVERSION_28D_F3_AD_CONVERSION_TOP50_COUNT_TEXTRAY_TRIGRAM_SEM_IDS_USERSIDE_28D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ATOM_FLEXIBLE_BATCH_ATOM_USER_SIDE_IAB_RQVAE_FEATURES_ATOM_USER_SIDE_IAB_ADS_CLK_TS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_RAX_ML_FLEXIBLE_BATCH_IAB_PRODUCT_MATCHING_FEATURES_USER_LATEST_PRODUCTS_F3_IAB_LH_USER_LATEST_30_PRODUCTS_CLICKED_28D_user_sparse_arch",
+        "table_SESSION_NGRAM_ID_LIST_AUTO_NGRAM_TRANSFORMED_ID_LIST_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_NUM_ORGANIC_POST_SEEN_FEED_F3_DENSE_IG_USER_NUM_ORGANIC_POST_SEEN_FEED_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_ENGAGEMENT_REALTIME_SAFE_TOP_ENGAGED_ENTITY_ID_SCORE_LIST_E_KEY_INSTAGRAM_PROFILE_720MIN_user_sparse_arch"
+      ],
+      "device_index": 1
+    },
+    {
+      "tbe_uuid": "06b84470-b76d-4f13-adc6-d145fb39961a",
+      "embedding_specs": [
+        {
+          "num_embeddings": 253623,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2404507,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 138776,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 445,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6442728,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 133588,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 703,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6382409,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2931646,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 632,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ],
+      "table_names": [
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_UBA_ADS_ADSLLAMA_UBA_AD_ID_590_EMB_DIM_96_FEATURE_DECODED_mix_sparse_arch",
+        "table_GSF_IDLIST_IG_BUSINESS_AUTHOR_PPR_ORGANIC_ENGAGEMENT_UNIFORM_ALL_CLUSTERS_IDENTITY_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_VLBLENDER_ID_MATCHING_CTX_AD_ONSITE_CONVERSION_VIDEO_VIEW_VLBLENDER_V2_CLUSTER_IDENTITY_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C40011550_ADS_RID_PAGE_LINK_CLICKS_USER_PAGE_RID_TOP_N_WITH_TIMESTAMP_EVENT_FREQUENCY_TOP200_D173__SPARSE_NEW_PAGE_RID_mix_spec_id_matching",
+        "table_group_7_user_sparse_arch",
+        "table_AGES_DENSEBMB__MOBILE_SCREEN_HEIGHT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_IAW_VIEW_DURATION_MS__1_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_VLBLENDER_AD_SIDE_CLUSTER__1_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_DA_PRODUCT_FEATURES_EVENTS_RT_USER_FPT_CLICKS_SAFE_LATEST_30_L3_FPT_CATEGORY_ID_CLKS_7D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_IMPRESSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_ADD_EEK_NO_CREATIVE_ALL_EVENTS_1440MIN_user_sparse_arch",
+        "table_NGRAM__IDSCORE_LIST_UTR_GFF_IDS_C30053_INSTAGRAM_IGUSER_IG_AD_TIME_SPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP100_D84_FIRST15__USER_COUNTRY_BUCKET__10000000_user_sparse_arch",
+        "table_densebmb_2025h1_4_4_MBDT_user_spec_densebmb_igctr_25h1"
+      ],
+      "device_index": 2
+    },
+    {
+      "tbe_uuid": "e8d1a962-dc14-4b8e-b334-3dffbf244776",
+      "embedding_specs": [
+        {
+          "num_embeddings": 487,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 48,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 750,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 28903,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 12,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1015487,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3057106,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1076475,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 873606,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3684743,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2680,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 14,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        7,
+        7,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__GSF_FLOAT_AD_CREATIVE_FATIGUE_SCORE_mix_sparse_arch",
+        "table_DENSE_BMB__GFF_C869_ADS_USER_SUM_28_ACCOUNT_ID_COUNTER_CLICK_mix_sparse_arch",
+        "table_DENSE_BMB__GFF_R1506146_ADS_ENTITY_EQUIVALENCE_KEY_SUM_2_COUNTER_IMPRESSION_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_SUBJECTIVE_UNDERSTANDING_APPEALINGNESS_IMAGE_FEATURES_RT_SUBJECTIVE_UNDERSTANDING_DIGESTIBILITY_APPEALINGNESS_FUSION_CLUSTER_IDS_TOP_32_DECODED_mix_sparse_arch",
+        "table_densebmb_12_12_MBDT_mix_sparse_arch",
+        "table_densebmb_4_4_MBDT_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_IMPRESSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_ADD_EEK_NO_CREATIVE_ALL_EVENTS_240MIN__SPARSE_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_mix_spec_id_matching",
+        "table_group_38_user_sparse_arch",
+        "table_GSF_IDLIST_REQUEST_LEVEL_IG_ADS_FEED_SEEN_STATE_AUTHOR_CLUSTER_ALL_LONG_DWELLTIME_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_ATOM_FEATURIZATION_ATOM_TEXTRAY_RQVAE_USER_FEATURE_TEXTRAY_RQVAE_USER_TS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_RAX_ML_REALTIME_IAW_LH_URL_DOMAIN_HASH_RT_FEATURES_IAB_LH_DOMAIN_HASH_RT_SPARSE_SEPARABLE_ID_SPARSE_URL_HASH_IDLIST_1D_user_sparse_arch",
+        "table_EVENT_TOPK_30_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_DWELLING_TIME_LIST_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_IG_REELS_INSTAGRAM_ENGAGEMENT_REALTIME_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_AUTHOR_ID_SCORE_LIST_IG_REELS_INSTAGRAM_ENGAGEMENT_EVENTS_HIGH_INTENT_AD_EVENT_TYPE_HIGH_INTENT_AD_1440MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_POSTRAY_AD_AND_USER_SIDE_FEATURES_CTX_USER_ONSITE_CONVERSION_AD_POSTRAY_4K_CLUSTER_IDS_user_sparse_arch",
+        "table_densebmb_1_1_MBDT_user_spec_densebmb_regular"
+      ],
+      "device_index": 4
+    },
+    {
+      "tbe_uuid": "85ff0b2d-837d-49c4-bae7-3b9ab607be9a",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 275878,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 294,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 33,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 14,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3349,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1087830,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6783306,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3416342,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 748724,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 96,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 626,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6708940,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        7,
+        7,
+        7,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_TOP_ENGAGED_ENTITY_ID_SCORE_LIST_E_KEY_ALL_EVENTS_720MIN__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C40011550_ADS_RID_PAGE_LINK_CLICKS_USER_PAGE_RID_TOP_N_WITH_TIMESTAMP_EVENT_FREQUENCY_TOP200_D173__SPARSE_NEW_PAGE_RID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_VLBLENDER_DOUBLE_CLUSTERING_ADS_SIDE_IMAGE_UNDERSTANDING_VLBLENDER_AD_SIDE_FEATURES_ID_LIST_REALTIME_5_DECODED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_AUDIO_UNDERSTANDING_FEATURES_AUDIO_UNDERSTANDING_CLUSTERING_200_48_DECODED_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_AUTOMATED_SHOPPING_ADS_AUTO_TARGETING_COUNTER_AND_VALUE_FEATURES_AUTO_CA_PAGE_VIEW_COUNT_mix_sparse_arch",
+        "table_densebmb_38_38_MBDT_mix_spec_densebmb_regular",
+        "table_MATCHING_MRI__F3_ADFINDER_USER_ADS_UDS_FIR_PIXEL_PIXEL_ID_LIST__200_INDEXES__SPARSE_TRACKING_TARGET_ID_mix_spec_mrim_igctr_25h1",
+        "table_group_20_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_NATIVE_BATCH_OAE_ML_IAB_NUM_NO_BOUNCE_IAB_NUM_NO_BOUNCE_SPARSE_SEPARABLE_ID_SPARSE_USER_PIXEL_ID_IDLIST_14D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_GT_3S_AD_ID_TOP50_7D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_CONTENT_UNDERSTANDING_MARKETPLACE_POSITIVE_ENGAGEMENT_F3_MP_USER_POSITIVE_ENGAGEMENT_2D_user_sparse_arch",
+        "table_EVENT_AGG_1D_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_DWELLING_TIME_LIST_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_LEGACY_MIGRATION_USER_SESSION_DFC_USER_AD_SESSION_IMP_user_sparse_arch",
+        "table_densebmb_17_17_MBDT_user_sparse_arch",
+        "table_GFF_IDS_C30133_INSTAGRAM_IGUSER_IG_STORY_ADS_TIMESPENT_PAIR_IG_ACTOR_RID_SORTBY_SCORE_IG_TIMESPENT_TOP200_D28_user_sparse_arch"
+      ],
+      "device_index": 7
+    },
+    {
+      "tbe_uuid": "2641aba8-c37a-4900-9b31-312930681111",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 288727,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6773750,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6750164,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 261,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2436205,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_UDS_FIR_AD_IMPRESSION_AD_ENTITY_EQUIVALENCE_KEY_LIST__2_DAYS__SPARSE_ENTITY_EQUIVALENCE_KEY_FOR_APP_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_XRAYVIDEO_2022B_AV_100D_SEGMENT_AWARE_CLUSTERING_ADS_SIDE_VIDEO_UNDERSTANDING_XRAYVIDEO2022B_AV_100D_AD_SIDE_FEATURES_ID_LIST_REALTIME_1_DECODED_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_AUTO_ID_MATCHING__SPARSE_AD_BUSINESS_ID__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_AD_BUSINESS_ID_TOP_7D_mix_sparse_arch",
+        "table_densebmb_2025h1_11_11_MBDT_mix_spec_densebmb_igctr_25h1",
+        "table_group_12_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_CLICK_ECG_IG_AD_CLICK_NON_REELS_AD_ID_INT_TOP50_7D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_CLICK_ECG_IG_AD_CLICK_REELS_AD_ID_INT_LATEST50_7D_ECG_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_NATIVE_BATCH_IG_ADS_RANKING_IG_AD_CLICK_REFINEMENT_ADS_USER_SUM_28_PAGE_TYPE_RATIO_PV_CLICK_IMPRESSION_user_sparse_arch",
+        "table_densebmb_24_24_MBDT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_TOP_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_VIDEO_VIEW_720MIN_user_sparse_arch"
+      ],
+      "device_index": 2
+    },
+    {
+      "tbe_uuid": "890037e2-a44d-4d4d-a7fc-c9c01c743fd0",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 60410,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2852945,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6740367,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 801331,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 746,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 278,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6192824,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__GFF_IDS_C10524_ADS_USER_IMPRESSION_ENTITY_EQUIVALENCE_KEY_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D28__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_FAM_FBE_FLEXIBLE_BATCH_FAM_ADS_LOCATION_FEATURES_F3_IDLIST_TOP_5_CITY_BY_IMP_30_DAYS_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_AUTO_ID_MATCHING__SPARSE_NEW_PAGE_RID__GFF_S_R64504_ADS_USER_CLICK_NEW_PAGE_RID_SORTBY_TIME_EVENT_TS_TOP200_D2_mix_sparse_arch",
+        "table_densebmb_36_36_MBDT_mix_spec_densebmb_regular",
+        "table_group_9_user_sparse_arch",
+        "table_GFF_S_R7019_ADS_USER_CONVERSION_UNATTR_OPT_ALL_SPARSE_AD_HYBRID_ID_SORTBY_TIME_EVENT_TS_TOP50_D7_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_RAX_ML_REALTIME_IAB_LH_USER_PRODUCT_FEATURES_IAB_LH_TOP_30_ENGAGED_PRODUCT_ID_CLICKS_7D_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_CLUSTERS_KNN_POP_user_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_R1306_ADS_USER_LATEST_EVENT_TIMESTAMP_2_PAGE_TYPE_TIME_SINCE_IMPRESSION_user_sparse_arch",
+        "table_densebmb_23_23_MBDT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_USER_LATESTN_AD_ID_CLICK_HA_IG_ADS_USER_LATEST_20_1H_PAGE_TYPE_35_49_72_94_95_108_AD_ID_CLICK_HA_user_sparse_arch"
+      ],
+      "device_index": 2
+    },
+    {
+      "tbe_uuid": "03bdfa4c-a1f5-4cb9-9f94-61bd73356468",
+      "embedding_specs": [
+        {
+          "num_embeddings": 36622028,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 276422,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 137237,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 693,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6781913,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 11,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 578,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 626,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4634909,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 261,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12
+      ],
+      "table_names": [
+        "table_group_45_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_UDS_FIR_AD_IMPRESSION_AD_ACCOUNT_ID__84_DAYS__SPARSE_AD_ACCOUNT_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_VLBLENDER_DOUBLE_CLUSTERING_ADS_SIDE_IMAGE_UNDERSTANDING_VLBLENDER_AD_SIDE_FEATURES_ID_LIST_REALTIME_6_DECODED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_TEXTRAY_OCR_AVG_100K_KNN_DECODED_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_COIN_RELEVANCE_EFE_IMDS_USER_AD_CLICK_PPR_REC_EKEY_RMV3_SOFT_MATCHING_DENSE_EFE_SOFT_MATCH_USER_AD_CLICK_PPR_REC_EKEY_RMV3_EMB_COSINE_SIMILARITY_MAX_RELEVANCE_SCORE_mix_sparse_arch",
+        "table_densebmb_4_4_MBDT_mix_spec_densebmb_regular",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C10525_ADS_USER_IMPRESSION_NEW_VIDEO_ID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D7__SPARSE_NEW_VIDEO_ID_mix_spec_id_matching",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_LT_1S_AD_ID_TOP50_7D_ECG_user_sparse_arch",
+        "table_EVENT_AGG_1D_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_PLACEMENT_PAGE_TYPE_LIST_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_NATIVE_BATCH_GFF_C72000_C72000_ADS_USER_SUM_84_PAGE_TYPE_CONVERSION_TYPE_V2_EXPLODED_ADFINDER_STORY_TYPE_EXPLODED_COUNTER_IMPRESSION_CONVERSION_TYPE_V2_26_ADFINDER_STORY_TYPE_128_user_sparse_arch",
+        "table_densebmb_17_17_MBDT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_ALL_EVENTS_720MIN_user_sparse_arch",
+        "table_densebmb_24_24_MBDT_user_spec_densebmb_regular"
+      ],
+      "device_index": 5
+    },
+    {
+      "tbe_uuid": "72436c79-4729-48ff-8002-d492b3733c93",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 4,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 11899818,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__IDSCORE_LIST_UTR_GFF_IDS_C30053_INSTAGRAM_IGUSER_IG_AD_TIME_SPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP100_D84__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_sparse_arch",
+        "table_densebmb_0_0_stability_mix_spec_densebmb_stability",
+        "table_F3_ADFINDER_USER_ADS_SEM_ID_USER_IMP_3D_TEXTRAY_TEXT_50K_SEM_ID_user_sparse_arch"
+      ],
+      "device_index": 6
+    },
+    {
+      "tbe_uuid": "4ee3a1f8-7460-4664-afe3-61a1229aa854",
+      "embedding_specs": [
+        {
+          "num_embeddings": 144619,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 107095,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2089,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4138,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 27,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2202374,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 177,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2360099,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3815474,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "table_names": [
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_VLBLENDER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_TEXTRAY_OCR_AVG_100K_KNN_FIX_QUANTIZED_DECODED_mix_sparse_arch",
+        "table_GSF_IDLIST_MEGATAXON_WITH_FIT_AD_CLUSTERING_V0_IDENTITY_mix_sparse_arch",
+        "table_SPARSE_AD_PRODUCT_FORMAT_TYPE_LIST_IDENTITY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_DA_PRODUCT_FEATURES_NATIVE_BATCH_FPT_AD_CATEGORY_IMPS_TOP_40_ENGAGED_L4_CATEGORY_ID_IMPS_7D_IDENTITY_mix_sparse_arch",
+        "table_densebmb_2025h1_2_2_MBDT_mix_spec_densebmb_igctr_25h1",
+        "table_BIGRAM__GSF_IDLIST_REQUEST_LEVEL_SPARSE_PRODUCT_MPI_FB_TAXONOMY_ID__SPARSE_NEW_PAGE_TYPE_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_ADS_ML_MODELING_SHORT_AGGREGATION_WINDOW_DENSE_FEATURES_GFF_R4025_ADS_USER_SUM_4_HOUR_BROWSER_TYPE_RATIO_XOUT_IMPRESSION_GFF_R4025_ADS_USER_SUM_4_HOUR_BROWSER_TYPE_RATIO_XOUT_IMPRESSION_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_TOP_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_VIDEO_VIEW_240MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_NON_ENGAGEMENT_IMP_NO_CLICK_USER_AD_NON_ENGAGE_AD_ACCOUNT_ID_4H_TOP_K_WITH_COUNT_user_sparse_arch"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "5071336b-6496-4e81-a325-de48da1fe310",
+      "embedding_specs": [
+        {
+          "num_embeddings": 601,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 707246,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 72685,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3125464,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 13439526,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 123447,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1753720,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 515,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1464,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 668,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        5,
+        5,
+        5,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__GFF_C1041181_ADS_ENTITY_EQUIVALENCE_KEY_SUM_7_RATIO_CLICK_IMPRESSION_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C10525_ADS_USER_IMPRESSION_NEW_VIDEO_ID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D28__SPARSE_NEW_VIDEO_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_COIN_RELEVANCE_EFE_REAL_TIME_AD_RELEVANCE_EMBEDDING_CLUSTER_ID_V2_RELEVANCE_F448437730_TARGET_32D_EMB_500K_CLUSTER_ID_V2_LIST_DECODED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_RMV3_AD_SIDE_RMV3_STAGE3_AD_50K_CENTROIDS_TOP20_CLUSTER_IDS_IDENTITY_mix_sparse_arch",
+        "table_GSF_IDLIST_SPARSE_NEW_AD_PAGE_ID_CLUSTERING_PPR_6_V6_5M_IDENTITY_mix_sparse_arch",
+        "table_group_35_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SEM_ID_USER_CLICK_3D_LVB_AVG_SEM_ID_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_PA_GEOGRAPHIC_REGION_SPARSE_IG_USER_CITY_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_RAX_ML_REALTIME_IAW_LH_TRACKING_ALL_RT_FEATURES_IAW_LH_TRACKING_LOWER_FUNNEL_RT_SPARSE_ENTITY_EQUIVALENCE_KEY_LIST_PER_USER_ID_1D_user_sparse_arch",
+        "table_DENSE_BMB__GFF_C3023_INSTAGRAM_USER_AVERAGE_28_COUNTER_IG_AD_TIME_SPENT_CORRECTED_user_sparse_arch",
+        "table_NGRAM_IG_PAGE_TYPE_IG_START_INDEX_NGRAM_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_MAX_TIMESPENT_PER_AD_F3_DENSE_IG_USER_MAX_TIMESPENT_PER_AD_user_sparse_arch"
+      ],
+      "device_index": 6
+    },
+    {
+      "tbe_uuid": "c18dadf3-de92-4260-9854-9fba3af3fe9c",
+      "embedding_specs": [
+        {
+          "num_embeddings": 688,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 139554,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 608,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 373,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 13569887,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 160,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 332,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1709,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 758,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 685,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 59,
+          "embedding_dim": 12,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13
+      ],
+      "table_names": [
+        "table_DENSE_BMB__GFF_R70513_ADS_NEW_TARGET_ID_SUM_2_PAGE_TYPE_USER_REGION_RATIO_CLICK_IMPRESSION_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_LVB_AVG_100K_KNN_DECODED_mix_sparse_arch",
+        "table_densebmb_33_33_MBDT_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_S_C10215_ADS_RID_CLICK_AD_ACCOUNT_ID_SORTBY_TIME_EVENT_TS_TOP200_D173__SPARSE_AD_ACCOUNT_ID_mix_spec_id_matching",
+        "table_group_37_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_NON_ENGAGEMENT_IMP_NO_CLICK_MT_USER_AD_NON_ENGAGE_AD_MEGATAXON_L2_4H_TOP_K_WITH_COUNT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SEMID_FLEXIBLE_BATCH_USER_CLICK_AND_IMPRESSION_28D_F3_AD_CLICK_AND_IMPRESSION_TOP50_COUNT_TEXTRAY_TRIGRAM_SEM_IDS_USERSIDE_28D_user_sparse_arch",
+        "table_AGES_DENSEBMB__AD_FEED_MOBILE_SCREEN_PIXEL_DENSITY_user_sparse_arch",
+        "table_DENSE_BMB__GSF_FLOAT_REQUEST_LEVEL_IG_ADS_FEED_SEEN_STATE_LAST_IMP_DWELL_TIME_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_APPS_EVENT_LIST__1_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_NATIVE_BATCH_OAE_ML_IAB_LH_USER_PRODUCT_FPT_FEATURES_IAB_LH_TOP_10_WITH_COUNTS_L4_FPT_CATEGORY_VISITED_28D_user_sparse_arch",
+        "table_densebmb_31_31_MBDT_user_spec_densebmb_regular",
+        "table_densebmb_74_74_MBDT_user_spec_densebmb_regular",
+        "table_densebmb_2025h1_13_13_MBDT_user_spec_densebmb_igctr_25h1"
+      ],
+      "device_index": 5
+    },
+    {
+      "tbe_uuid": "595decf4-420e-4a90-b160-0698f884d5f3",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4219081,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2248,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 32,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6227329,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 134200,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 713,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 420,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6055689,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6495731,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 695,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 103,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 760,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 51,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__GFF_IDS_C70077_ADS_USER_IMPRESSION_NEW_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D28__SPARSE_NEW_PAGE_RID_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C70077_ADS_USER_IMPRESSION_NEW_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D7__SPARSE_NEW_PAGE_RID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_ADS_RANKING_FLEXIBLE_BATCH_F3_TOP_ADVERTISERS_F3_TOP_ADVERTISERS_ID_LIST_IDENTITY_mix_sparse_arch",
+        "table_GSF_IDLIST_PRODUCT_SET_COUNT_IDF_XRAY_V11_CONCEPT_100_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C1110_INSTAGRAM_USER_SUM_28_INSTAGRAM_ACTOR_FBIDV2_COUNTER_IG_VIDEO_VIEW_COUNT_mix_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_XPUB_FLEXIBLE_BATCH_TOP_ACTION_ADS_XPUB_TOP_ACCESSED_AD_IDS_USER_EVENT_14D_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_VLBLENDER_AD_SIDE_CLUSTER_user_sparse_arch",
+        "table_TTH_AGES_densebmb_USER_SECONDS_SINCE_LAST_AD_CLICK_user_sparse_arch",
+        "table_densebmb_30_30_MBDT_user_sparse_arch",
+        "table_GFF_IDS_C70077_ADS_USER_IMPRESSION_NEW_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D7_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_ADS_USER_LATESTN_AD_ID_CLICK_HA_IG_ADS_USER_LATEST_20_1D_PAGE_TYPE_35_49_72_94_95_108_AD_ID_CLICK_HA_user_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_R1302_ADS_USER_LATEST_EVENT_TIMESTAMP_7_TIME_SINCE_CLICK_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_NUM_ADS_SEEN_LAST_15MIN_F3_DENSE_IG_USER_NUM_ADS_SEEN_LAST_15MIN_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C3023_INSTAGRAM_USER_SUM_84_COUNTER_IG_AD_TIME_SPENT_CORRECTED_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_OLD_IG_USER_COUNT_DENSE_REALTIME_SAFE_V2_COUNT_FLOAT_USER_EVENT_INSTAGRAM_AD_BRAND_PROFILE_2D_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "a922f68d-40f9-4199-8d62-1b55eb038741",
+      "embedding_specs": [
+        {
+          "num_embeddings": 669,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 133222,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 27242,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 21677113,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 727,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 70,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 659,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784932,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3611543,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6065200,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 439,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 17,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 126,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5933364,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 514,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__GFF_R70015_ADS_NEW_VIDEO_ID_SUM_2_RATIO_CLICK_IMPRESSION_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C30133_INSTAGRAM_IGUSER_IG_STORY_ADS_TIMESPENT_PAIR_IG_ACTOR_RID_SORTBY_SCORE_IG_TIMESPENT_TOP200_D28__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_CRDL_MULTIMODAL_SUM_ADS_SIDE_CRDL_MULTIMODAL_SUM_100K_TOP20_CLUSTER_IDS_IDENTITY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_SFV_TOP_CLUSTER_IDS_FOR_ADS_VIDEO_SFV_TOP_AVG_CLIP_20K_QUANTIZED_IDENTITY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SEM_ID_AD_SEMID_TEXTRAY_TEXT_SEM_ID_IDENTITY_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_USER_PAGE_TOP_ENGAGED_30D_RID__SPARSE_NEW_PAGE_RID_mix_spec_id_matching",
+        "table_TTH_AGES_densebmb_GFF_R1506146_ADS_ENTITY_EQUIVALENCE_KEY_SUM_2_RATIO_CONVERSION_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C1112_INSTAGRAM_USER_SUM_7_INSTAGRAM_ACTOR_FBIDV2_COUNTER_IG_ORGANIC_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C1996885_ADS_ENTITY_EQUIVALENCE_KEY_SUM_28_PAGE_TYPE_RATIO_GOOD_CLICK_3SEC_CLICK_mix_spec_tail_sigrid_features",
+        "table_F3_ADFINDER_USER_ADS_GRAPH_LEARNING_FLEXIBLE_BATCH_GLFF_GLFF_PPR_FEATURES_2025H1_GLFF_2025H1_PPR_IDLIST_ADCLKS_USER_EKEY_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_NATIVE_BATCH_OAE_ML_IAW_LH_TRACKING_ALL_FEATURES_IAW_LH_TRACKING_UPPER_FUNNEL_SPARSE_ENTITY_EQUIVALENCE_KEY_LIST_PER_USER_ID_14D_user_sparse_arch",
+        "table_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_ENCODED_BASIC_NEW_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_NO_CREATIVE_HASH32_ENCODE32_NEW_EVENT_NON_AND_NEG_ENGAGEMENT_7D_user_sparse_arch",
+        "table_DENSE_BMB__GFF_R1321_INSTAGRAM_USER_LATEST_EVENT_TIMESTAMP_2_TIME_SINCE_IG_ORGANIC_BRAND_PROFILE_ENGAGEMENT_user_sparse_arch",
+        "table_NGRAM_IG_REQUEST_NGRAM_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_NUM_ADS_SEEN_LAST_30MIN_F3_DENSE_IG_USER_NUM_ADS_SEEN_LAST_30MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_IMPRESSION_REALTIME_SAFE_TOP_ENGAGED_ENTITY_ID_SCORE_LIST_ADD_EEK_NO_CREATIVE_ALL_EVENTS_240MIN_user_sparse_arch",
+        "table_densebmb_51_51_MBDT_user_spec_densebmb_regular"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "da9d2be6-55fb-42e2-946e-3f2d7049480c",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 145376,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 97,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 603,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1776198,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6776641,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2383688,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 65545,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1066,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 420,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        7,
+        7,
+        7,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__GFF_IDS_C70077_ADS_USER_IMPRESSION_NEW_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D28__SPARSE_NEW_PAGE_RID_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_S_C10266_ADS_USER_CONVERSION_UNATTR_OPT_LONGTERM_CONVERSION_ATTR_OPT_LONGTERM_PIXEL_RID_SORTBY_TIME_EVENT_TS_TOP50_D84__SPARSE_NEW_PAGE_RID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_GEOGRAPHIC_REGION_SPARSE_IG_ACTOR_CITY_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_28D_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C1110_INSTAGRAM_USER_SUM_28_INSTAGRAM_ACTOR_FBIDV2_COUNTER_IG_VIDEO_VIEW_SESSION_IMP_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C70077_ADS_USER_IMPRESSION_NEW_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D28__SPARSE_NEW_PAGE_RID_mix_spec_id_matching",
+        "table_TTH_AGES_densebmb_GFF_C1996885_ADS_ENTITY_EQUIVALENCE_KEY_SUM_28_PAGE_TYPE_RATIO_GOOD_CLICK_1SEC_CLICK_mix_spec_tail_sigrid_features",
+        "table_group_21_user_sparse_arch",
+        "table_GSF_IDLIST_IG_USER_FOLLOW_GRAPH_CLUSTER_ALL_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_GT_3S_REELS_AD_ID_LATEST50_7D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_NATIVE_BATCH_OAE_ML_IAW_AUTOFILL_ALL_FEATURES_V4_IAW_ACCEPTED_CONTACT_AUTOFILL_SPARSE_ENTITY_EQUIVALENCE_KEY_V4_7D_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_VLBV2_LVB_AVG_CLUSTER_FIX_user_sparse_arch",
+        "table_ctxmd_features_9_user_sparse_arch",
+        "table_densebmb_30_30_MBDT_user_sparse_arch"
+      ],
+      "device_index": 6
+    },
+    {
+      "tbe_uuid": "4c09ad87-69dd-44ce-9e16-847b98ebeea3",
+      "embedding_specs": [
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 301571,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 26077834,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 412,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 714,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 5287864,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2307981,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 518,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 613,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 7677271,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3489261,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 762,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 621,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 759,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 57,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 126,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19
+      ],
+      "table_names": [
+        "table_AGES_DENSEBMB__F3_ADINDEXER_ADS_ID_MATCHING_AUTO_SPARSE_NEW_PAGE_RID__GFF_S_R11595_ADS_USER_CONVERSION_CONVERSION_UNATTR_OPT_PIXEL_RID_SORTBY_TIME_EVENT_TS_TOP50_D1_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_INSTAGRAM_MEDIA_ID_TOP_7D_TO_28D__SPARSE_INSTAGRAM_MEDIA_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_ATOM_FLEXIBLE_BATCH_ATOM_AD_SIDE_INPUT_HOURLY_ATOM_ADS_TEXT_INPUT_HOURLY_V2_IDENTITY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_SEM_ID_AD_SEMID_TEXTRAY_AVG_SEM_ID_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_NO_CREATIVE_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_28D_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_IDS_C70077_ADS_USER_IMPRESSION_NEW_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D1__SPARSE_NEW_PAGE_RID_mix_spec_id_matching",
+        "table_TTH_AGES_densebmb_GFF_R1307_ADS_USER_SUM_2_PAGE_TYPE_CONVERSION_TYPE_VERSION_RATIO_CLICK_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_GFF_C67_ADS_USER_SUM_DECAY_900_84_PAGE_TYPE_ADFINDER_STORY_TYPE_RATIO_CLICK_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_SPARSE_UTR_IG_ACTOR_FBIDV2__SPARSE_UTR_GFF_S_C19823_INSTAGRAM_IGUSER_IG_AD_TIME_SPENT_CORRECTED_IG_ACTOR_ID_MOST_FREQUENT_IG_TIMESPENT_TOP50_D14_mix_spec_tail_sigrid_features",
+        "table_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_AD_CTA_ITEM_IDS_STORY_F3_SPARSE_IG_USER_AD_CTA_ITEM_IDS_STORY_user_sparse_arch",
+        "table_GSF_IDLIST_USER_ENGAGED_PAGE_RID_CLUSTERING_V6_OTHER_CLICKS_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D84_user_sparse_arch",
+        "table_DENSE_BMB__GFF_C3015_INSTAGRAM_USER_SUM_84_COUNTER_IG_ORGANIC_TIMESPENT_CORRECTED_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_AVG_TIMESPENT_PER_ORGANIC_POST_FEED_F3_DENSE_IG_USER_AVG_TIMESPENT_PER_ORGANIC_POST_FEED_user_sparse_arch",
+        "table_GFF_IDS_C70077_ADS_USER_IMPRESSION_NEW_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D28_user_sparse_arch",
+        "table_TIMEGAP_WITH_AD_REQUEST__F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_NON_ENGAGEMENT_IMP_NO_CLICK_USER_AD_NON_ENGAGE_AD_ACCOUNT_ID_4H_LATEST_N_WITH_TIMESTAMP_user_sparse_arch",
+        "table_densebmb_2_2_MBDT_user_spec_densebmb_regular",
+        "table_densebmb_81_81_MBDT_user_spec_densebmb_regular",
+        "table_TTH_AGES_densebmb_GFF_C3023_INSTAGRAM_USER_STANDARD_DEVIATION_84_COUNTER_IG_AD_TIME_SPENT_CORRECTED_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_IG_DEVICE_WIDTH_user_spec_tail_sigrid_features",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_USER_NUM_ADS_SEEN_LAST_30MIN_F3_DENSE_IG_USER_NUM_ADS_SEEN_LAST_30MIN_user_spec_tail_sigrid_features"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "0a398f88-13e4-4c26-ac73-32c4097007a0",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 145376,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 97,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 729,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1776198,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6776641,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2383688,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 65545,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1066,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 420,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        7,
+        7,
+        7,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__GFF_IDS_C70077_ADS_USER_IMPRESSION_NEW_PAGE_RID_MOST_FREQUENT_EVENT_FREQUENCY_TOP100_D28__SPARSE_NEW_PAGE_RID_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GFF_S_C10266_ADS_USER_CONVERSION_UNATTR_OPT_LONGTERM_CONVERSION_ATTR_OPT_LONGTERM_PIXEL_RID_SORTBY_TIME_EVENT_TS_TOP50_D84__SPARSE_NEW_PAGE_RID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_IG_VERTICAL_ADS_FLEXIBLE_BATCH_IG_GEOGRAPHIC_REGION_SPARSE_IG_ACTOR_CITY_IDENTITY_mix_sparse_arch",
+        "table_ID_MATCHING_SPARSE_ENTITY_EQUIVALENCE_KEY_F3_ADFINDER_USER_SAFE_NATIVE_BATCH_BATCH_V2_USER_AD_NON_ENGAGEMENT_SPLITTED_BASIC_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_EEK_SPLITTED_EVENT_NON_AND_NEG_ENGAGEMENT_28D_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C1110_INSTAGRAM_USER_SUM_28_INSTAGRAM_ACTOR_FBIDV2_COUNTER_IG_VIDEO_VIEW_SESSION_IMP_mix_sparse_arch",
+        "table_AUTO_ID_MATCHING__GSF_IDLIST_IG_STORY_AD_USER_LOW_INTENT_V1_NAVIGATION_GESTURE_AUTHOR_RID_7D__SPARSE_UTR_IG_ACTOR_FBIDV2_mix_spec_id_matching",
+        "table_TTH_AGES_densebmb_GFF_R1548893_ADS_NEW_AD_ID_REFINED_SUM_2_RATIO_CONVERSION_IMPRESSION_mix_spec_tail_sigrid_features",
+        "table_group_21_user_sparse_arch",
+        "table_GSF_IDLIST_IG_USER_FOLLOW_GRAPH_CLUSTER_ALL_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_GT_3S_REELS_AD_ID_LATEST50_7D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_NATIVE_BATCH_OAE_ML_IAW_AUTOFILL_ALL_FEATURES_V4_IAW_ACCEPTED_CONTACT_AUTOFILL_SPARSE_ENTITY_EQUIVALENCE_KEY_V4_7D_user_sparse_arch",
+        "table_EVENT_AGG_7D_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_VLBV2_LVB_AVG_CLUSTER_FIX_user_sparse_arch",
+        "table_ctxmd_features_9_user_sparse_arch",
+        "table_densebmb_30_30_MBDT_user_sparse_arch"
+      ],
+      "device_index": 6
+    },
+    {
+      "tbe_uuid": "f25ae2de-1dfc-4497-9a19-06fb5d697e63",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 288221,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 608,
+          "embedding_dim": 24,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784934,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3804538,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 22,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 261,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4063570,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_UDS_FIR_AD_IMPRESSION_AD_ENTITY_EQUIVALENCE_KEY_LIST__84_DAYS__SPARSE_ENTITY_EQUIVALENCE_KEY_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_XRAY_2022A_DOUBLE_CLUSTERING_ADS_SIDE_IMAGE_UNDERSTANDING_VLBLENDER_AD_SIDE_FEATURES_ID_LIST_REALTIME_1_DECODED_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADINDEXER_ADS_ID_MATCHING_AUTO_AUTO_ID_MATCHING__SPARSE_AD_BUSINESS_ID__GSF_IDLIST_USER_EVENT_IMPRESSION_SPARSE_AD_BUSINESS_ID_TOP_7D_TO_28D_mix_sparse_arch",
+        "table_densebmb_33_33_MBDT_mix_spec_densebmb_regular",
+        "table_group_11_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_GRAPH_LEARNING_FLEXIBLE_BATCH_GLFF_GLFF_PPR_FEATURES_2025H1_GLFF_2025H1_PPR_IDLIST_ADCLKS_ONSITE_ALL_USER_EKEY_user_sparse_arch",
+        "table_EVENT_AGG_2D_F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_AUTHOR_RID_LIST_user_sparse_arch",
+        "table_TTH_AGES_densebmb_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_AD_CLICK_DENSE_REALTIME_SAFE_V2_COUNT_FLOAT_EARLY_TRIGGER_1MIN_AD_ID_ALL_240MIN_user_sparse_arch",
+        "table_densebmb_24_24_MBDT_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_UNATTRIBUTED_CONVERSION_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_1MIN_TARGET_ID_EVENT_TYPE_ALL_1440MIN_user_sparse_arch"
+      ],
+      "device_index": 2
+    },
+    {
+      "tbe_uuid": "e20506b5-659f-4329-912e-f68bf5091bcd",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 144480,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 69695,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1342857,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 141217,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 97,
+          "embedding_dim": 20,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 30000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2734650,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6586887,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 66471,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1056064,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 6784904,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 134110,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        6,
+        6,
+        6,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13
+      ],
+      "table_names": [
+        "table_AUTO_ID_MATCHING__F3_ADFINDER_USER_ADS_IG_QUANTUM_SIGNALS_REALTIME_IG_SEEN_STATE_IMAGE_ID_DWELLTIME_IG_SEEN_STATE_IMAGE_ID_DWELLTIME__SPARSE_INSTAGRAM_MEDIA_ID_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_AD_SIDE_ADMARKET_AD_VLBLENDER_ADS_SFV_VLBLENDER_V2_FEATURES_VLBLENDER_V2_LVB_AVG_100K_KNN_FIX_QUANTIZED_DECODED_mix_sparse_arch",
+        "table_F3_ADPUBLISHER_ADS_CONTENT_UNDERSTANDING_POSTRAY_TEXTRAY_MARSV1_ADS_SIDE_TEXTRAY_50K_CLUSTER_IDS_AD_SIDE_FEATURE_IDENTITY_mix_sparse_arch",
+        "table_GSF_IDLIST_IG_BUSINESS_AUTHOR_PPR_ORGANIC_ENGAGEMENT_UNIFORM_POPULAR_CLUSTERS_IDENTITY_mix_sparse_arch",
+        "table_F3_ADINDEXER_ADS_MESSENGER_EFE_REALTIME_CTX_REALTIME_VLBLENDER_ID_MATCHING_CTX_AD_ONSITE_CONVERSION_VLBLENDER_V2_CLUSTER_IDENTITY_mix_sparse_arch",
+        "table_TTH_AGES_densebmb_GFF_C1110_INSTAGRAM_USER_SUM_28_INSTAGRAM_ACTOR_FBIDV2_COUNTER_IG_VIDEO_VIEW_SESSION_IMP_mix_spec_tail_sigrid_features",
+        "table_group_29_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_UUDL_OFFSITE_CONVERSION_WEB_REALTIME_SAFE_V2_TOP_ENGAGED_ENTITY_IDS_5MIN_PIXEL_ID_PAGEVIEW_1440MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_AD_LOOKALIKE_CUSTOM_AUDIENCE_OFFSITE_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_ENCODED_AD_CLUSTER_ID_EVENT_ALL_1440MIN_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_AD_MT_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_FACTOR_IDS_TRIGGER_1MIN_ENTITY_EQUIVALENCE_KEY_AD_MEGATAXON_MMT_CLUSTER_EVENT_TYPE_ALL_240MIN_user_sparse_arch",
+        "table_GSF_IDLIST_REQUEST_LEVEL_SPARSE_PRODUCT_MPI_FB_TAXONOMY_ID_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_IG_ADS_RANKING_STREAMING_IG_IMPRESSION_ECG_IG_IMPRESSION_DWELLING_TIME_LT_1S_REELS_AD_ID_TOP50_28D_ECG_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_IAW_EVENT_TYPE_ID__1_DAYS_user_sparse_arch",
+        "table_F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_VLBLENDER_AD_SIDE_CLUSTER__84_DAYS_user_sparse_arch"
+      ],
+      "device_index": 6
+    },
+    {
+      "tbe_uuid": "a2c3b22b-0509-4e62-a823-420776611c29",
+      "embedding_specs": [],
+      "feature_table_map": [
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "table_names": [
+        "table_group_41_user_sparse_arch"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "9472be88-a6ef-4a99-a559-e1d08b322eac",
+      "embedding_specs": [
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4022396,
+          "embedding_dim": 128,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        1
+      ],
+      "table_names": [
+        "table_group_40_user_sparse_arch",
+        "table_TIMEGAP_WITH_AD_REQUEST__F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_USER_ONSITE_CONVERSION_REALTIME_SAFE_LATEST_N_ENGAGED_ENTITY_ID_SCORE_LIST_AD_ACCOUNT_ID_LINK_CLICK_1440MIN_user_sparse_arch"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "e1f704e3-12ff-4561-be26-c9e72cee9926",
+      "embedding_specs": [],
+      "feature_table_map": [
+        0
+      ],
+      "table_names": [
+        "table_TIMEGAP_WITH_AD_REQUEST__F3_ADFINDER_USER_ADS_SAFE_REALTIME_REALTIME_NEW_PAGES_REALTIME_SAFE_V2_LATEST_N_ENGAGED_ENTITY_IDS_EARLY_TRIGGER_1MIN_PAGE_RID_MESSAGE_CTA_VIEW_1440MIN_user_sparse_arch"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "f49c5114-de88-4487-89a0-12e27a7a486b",
+      "embedding_specs": [
+        {
+          "num_embeddings": 20072405,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 633,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_DWELLING_TIME_LIST",
+        "F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_MEDIA_TYPE_INT_LIST"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "69f5db50-0275-4bbd-8af6-bb9f1f24784d",
+      "embedding_specs": [
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25505561,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 24606546,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 24606546,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 24606546,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 24606546,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_AUTHOR_RID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_CLUSTERS_KNN_POP",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_CLUSTERS_KNN_T1",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_CLUSTERS_KNN_T1",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_IG_MEDIA_ID_LIST",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_IG_MEDIA_ID_LIST",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_AD_ID_LIST",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_AD_ID_LIST",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_AD_ID_LIST",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_AD_ID_LIST"
+      ],
+      "device_index": 1
+    },
+    {
+      "tbe_uuid": "f21bbe8e-4088-47a6-a6ef-cf44f5523d3f",
+      "embedding_specs": [
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_AUTHOR_RID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_AUTHOR_RID"
+      ],
+      "device_index": 4
+    },
+    {
+      "tbe_uuid": "bd4ef0ad-78b3-48ea-9230-5a8582522e03",
+      "embedding_specs": [
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25505561,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_AUTHOR_RID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_CLUSTERS_KNN_POP",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_CLUSTERS_KNN_T1",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_CLUSTERS_KNN_T1",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_IG_MEDIA_ID_LIST",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_IG_MEDIA_ID_LIST"
+      ],
+      "device_index": 1
+    },
+    {
+      "tbe_uuid": "e7b9aca9-c74e-46f6-bb65-3337a03b1b72",
+      "embedding_specs": [
+        {
+          "num_embeddings": 633,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 633,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_MEDIA_TYPE_INT_LIST",
+        "F3_ADFINDER_USER_ADS_UDS_IG_AD_VPV_FEATURE_PLACEMENT_PAGE_TYPE_LIST"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "45809eda-1672-4ef1-814f-48d50b7dee39",
+      "embedding_specs": [
+        {
+          "num_embeddings": 1697201,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_AD_ACCOUNT_PPR_34",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_PAGE_TYPE_ID"
+      ],
+      "device_index": 6
+    },
+    {
+      "tbe_uuid": "ff64debb-654d-4a57-a4cd-0e20f5ee28e9",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2111901,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2048812,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_CLUSTER_ID_T1",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_MEGATAXON_HASH"
+      ],
+      "device_index": 7
+    },
+    {
+      "tbe_uuid": "80f6ef19-cd77-40ca-9acd-11e044146dad",
+      "embedding_specs": [
+        {
+          "num_embeddings": 1697201,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 529272,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_AD_ACCOUNT_PPR_34",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_ME_TYPE3_EXPANDED"
+      ],
+      "device_index": 6
+    },
+    {
+      "tbe_uuid": "b24216cb-9dd6-404b-8375-152f3d07fe0b",
+      "embedding_specs": [
+        {
+          "num_embeddings": 8334266,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_HIVE_TEXTRAY_CLUSTER_CODEWORD_IDS",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_AD_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE"
+      ],
+      "device_index": 4
+    },
+    {
+      "tbe_uuid": "a5f93a7e-e983-4bf8-b336-e03f60f5fdff",
+      "embedding_specs": [
+        {
+          "num_embeddings": 8334266,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_HIVE_TEXTRAY_CLUSTER_CODEWORD_IDS",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_ACCOUNT_ID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_AD_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_MT_CLUSTERS",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_VLBLENDER_AD_SIDE_CLUSTER"
+      ],
+      "device_index": 4
+    },
+    {
+      "tbe_uuid": "cea4c73c-2fbe-443b-92c1-cf4444bfd779",
+      "embedding_specs": [
+        {
+          "num_embeddings": 121685,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 10018104,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_APP_ID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_PAGE_RID"
+      ],
+      "device_index": 2
+    },
+    {
+      "tbe_uuid": "05e6f695-5757-46ee-9f9a-c921f4156625",
+      "embedding_specs": [
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_ACCOUNT_ID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_AD_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_AD_ID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_MT_CLUSTERS",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_VLBLENDER_AD_SIDE_CLUSTER"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "5d0bca87-2dc2-4ddc-98e0-c362b076aca6",
+      "embedding_specs": [
+        {
+          "num_embeddings": 5755833,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 2048812,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_ENTITY_EQUIVALENCE_KEY",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_FEED_XRAY_TOPIC_HASHTAG"
+      ],
+      "device_index": 4
+    },
+    {
+      "tbe_uuid": "24f13934-23b5-4401-b14c-7c3af3415d74",
+      "embedding_specs": [
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 40000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_ACCOUNT_ID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_AD_ID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_MT_CLUSTERS",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_ONSITE_CONVERSION_FIR_ONSITE_CONVERSION_VLBLENDER_AD_SIDE_CLUSTER"
+      ],
+      "device_index": 1
+    },
+    {
+      "tbe_uuid": "151c0e49-878f-4d5a-8546-050d9dad5b3f",
+      "embedding_specs": [
+        {
+          "num_embeddings": 25000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_STORIES_IG_MEDIA_ID_LIST",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_STORIES_AUTHOR_RID"
+      ],
+      "device_index": 7
+    },
+    {
+      "tbe_uuid": "5000b8b9-e5fb-4d2e-9732-9f66a68aa1fa",
+      "embedding_specs": [
+        {
+          "num_embeddings": 100000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_MARKETPLACE_MARKPETLACE_CLUSTERING_RESULTS_FEATURES",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_MARKETPLACE_PRODUCT_ITEM_ID_LIST"
+      ],
+      "device_index": 6
+    },
+    {
+      "tbe_uuid": "60024670-1e01-46c3-b38b-6128016e07dd",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2520161,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3293761,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4256078,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 100000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 305933,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1357158,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_ACCOUNT_ID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_AD_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_AD_PAGE_SIMILAR_PAGES_EMBEDDING_ONLINE_KNN_RID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_MEGATAXON_HASH",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_ME_TYPE3_RAW",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_PAGE_PPR_6_RID"
+      ],
+      "device_index": 5
+    },
+    {
+      "tbe_uuid": "89ae053f-38ec-4b62-9a36-c9aa1178d846",
+      "embedding_specs": [
+        {
+          "num_embeddings": 655500,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 655500,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_AD_ACCOUNT_PPR_34",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_AD_ACCOUNT_PPR_34"
+      ],
+      "device_index": 7
+    },
+    {
+      "tbe_uuid": "ba6d84d7-4143-4923-a024-5a36624afd7a",
+      "embedding_specs": [
+        {
+          "num_embeddings": 100000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 100000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_APP_ID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_EVENT_TYPE_ID"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "50f82bdf-df34-4dea-93e8-4f301152c7c1",
+      "embedding_specs": [
+        {
+          "num_embeddings": 14794452,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4256078,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_AD_ENTITY_EQUIVALENCE_KEY",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_AD_PAGE_SIMILAR_PAGES_EMBEDDING_ONLINE_KNN_RID"
+      ],
+      "device_index": 5
+    },
+    {
+      "tbe_uuid": "a115b3bd-1c6d-457d-9f2a-46083adbf129",
+      "embedding_specs": [
+        {
+          "num_embeddings": 25000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_STORIES_IG_MEDIA_ID_LIST",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_STORIES_AUTHOR_RID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_STORIES_AUTHOR_RID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_STORIES_AD_ID_LIST",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_STORIES_ENTITY_EQUIVALENCE_KEY"
+      ],
+      "device_index": 1
+    },
+    {
+      "tbe_uuid": "f59875a9-849c-4128-991a-a06d79db3f6e",
+      "embedding_specs": [
+        {
+          "num_embeddings": 25000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 25000000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_STORIES_IG_MEDIA_ID_LIST",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_STORIES_AUTHOR_RID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_STORIES_AD_ID_LIST",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_IG_STORIES_ENTITY_EQUIVALENCE_KEY"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "2e24ed33-3a99-4c8f-a731-7707c26c6e48",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2520161,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 14794452,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 100000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_ACCOUNT_ID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_AD_ENTITY_EQUIVALENCE_KEY",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_EVENT_TYPE_ID"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "99e48e8f-3449-47c8-bd00-8f9b2e6b663a",
+      "embedding_specs": [
+        {
+          "num_embeddings": 409571,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 409571,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 409571,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_PIXEL_EVENT_NAME_LIST",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_PIXEL_EVENT_NAME_LIST",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_PIXEL_EVENT_NAME_LIST"
+      ],
+      "device_index": 1
+    },
+    {
+      "tbe_uuid": "1b39b4ea-d026-49f3-8004-422dcf8b8f2d",
+      "embedding_specs": [
+        {
+          "num_embeddings": 655500,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3293761,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 100000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 261026,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 100000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1567318,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_AD_ACCOUNT_PPR_34",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_AD_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_MEGATAXON_HASH",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_ME_TYPE3_EXPANDED",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_MT_CLUSTERS_MMF",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_PAGE_RID"
+      ],
+      "device_index": 2
+    },
+    {
+      "tbe_uuid": "fa1cfc58-cca6-4439-a1d8-20e6a3073dc1",
+      "embedding_specs": [
+        {
+          "num_embeddings": 652923,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 652923,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_PIXEL_AD_ACCOUNT_ID_LIST",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_PIXEL_AD_ACCOUNT_ID_LIST"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "6136ed2f-8406-429c-ab4e-d23d79f65e16",
+      "embedding_specs": [
+        {
+          "num_embeddings": 655500,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3293761,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 100000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 261026,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 100000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1357158,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1567318,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_AD_ACCOUNT_PPR_34",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_AD_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_EVENT_TYPE_ID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_ME_TYPE3_EXPANDED",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_MT_CLUSTERS_MMF",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_PAGE_PPR_6_RID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_PAGE_RID"
+      ],
+      "device_index": 5
+    },
+    {
+      "tbe_uuid": "3fd119b8-f2d3-48cb-be92-f9916b93ad69",
+      "embedding_specs": [
+        {
+          "num_embeddings": 2520161,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 14794452,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 100000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 261026,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 305933,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1357158,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1567318,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_ACCOUNT_ID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_AD_ENTITY_EQUIVALENCE_KEY",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_EVENT_TYPE_ID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_ME_TYPE3_EXPANDED",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_ME_TYPE3_RAW",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_PAGE_PPR_6_RID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_PAGE_RID"
+      ],
+      "device_index": 0
+    },
+    {
+      "tbe_uuid": "1495e8af-c6de-43b6-a78c-dd1ab573318a",
+      "embedding_specs": [
+        {
+          "num_embeddings": 3293761,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4256078,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 100000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 305933,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_AD_ENTITY_EQUIVALENCE_KEY_NO_CREATIVE",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_AD_PAGE_SIMILAR_PAGES_EMBEDDING_ONLINE_KNN_RID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_MEGATAXON_HASH",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_ME_TYPE3_RAW"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "9be0b329-4b88-40df-861d-fa661f84abee",
+      "embedding_specs": [
+        {
+          "num_embeddings": 14794452,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 4256078,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 100000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 305933,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 100000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1567318,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_AD_ENTITY_EQUIVALENCE_KEY",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_AD_PAGE_SIMILAR_PAGES_EMBEDDING_ONLINE_KNN_RID",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_MEGATAXON_HASH",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_ME_TYPE3_RAW",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_MT_CLUSTERS_MMF",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_PAGE_RID"
+      ],
+      "device_index": 2
+    },
+    {
+      "tbe_uuid": "f9bb94ea-c1fd-437a-9338-b4206360cd5e",
+      "embedding_specs": [
+        {
+          "num_embeddings": 3503664,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 3503664,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_PIXEL_PIXEL_ID_LIST",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_PIXEL_PIXEL_ID_LIST"
+      ],
+      "device_index": 3
+    },
+    {
+      "tbe_uuid": "755d6c95-e201-470f-8551-8134ac7e82ce",
+      "embedding_specs": [
+        {
+          "num_embeddings": 261026,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 100000,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        },
+        {
+          "num_embeddings": 1357158,
+          "embedding_dim": 8,
+          "location": "DEVICE",
+          "compute_device": "CUDA"
+        }
+      ],
+      "feature_table_map": [
+        0,
+        1,
+        2
+      ],
+      "table_names": [
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_ME_TYPE3_EXPANDED",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_MT_CLUSTERS_MMF",
+        "F3_ADFINDER_USER_ADS_UDS_FIR_OFFSITE_CONVERSION_PAGE_PPR_6_RID"
+      ],
+      "device_index": 3
+    }
+  ]
+}

--- a/include/fbgemm/FbgemmFPCommon.h
+++ b/include/fbgemm/FbgemmFPCommon.h
@@ -275,7 +275,7 @@ void cblas_gemm_compute(
                 for (int j = last_blk_col; j < n; j++) {
                   assert(
                       i * Bp.blockColSize() + (j - last_blk_col) <
-                      static_cast<int64_t>(sizeof(c_tmp) / sizeof(c_tmp[0])));
+                      static_cast<int64_t>(c_tmp.size()));
                   if (beta_ == 0.f) {
                     C[(m2 + i) * ldc + j] =
                         c_tmp[i * Bp.blockColSize() + (j - last_blk_col)];

--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -170,7 +170,7 @@ GenEmbeddingSpMDMLookup<
         bool scale_bias_last,
         bool is_bf16_out,
         bool is_bf16_in) {
-  auto kernelSig = std::make_tuple(
+  auto kernelSig = std::tuple{
       block_size,
       has_weight,
       is_weight_positional,
@@ -181,7 +181,7 @@ GenEmbeddingSpMDMLookup<
       input_stride,
       scale_bias_last,
       is_bf16_out,
-      is_bf16_in);
+      is_bf16_in};
 
   return codeCache_.getOrCreate(
       kernelSig,

--- a/src/FbgemmFP16.cc
+++ b/src/FbgemmFP16.cc
@@ -121,20 +121,20 @@ constexpr kernel_array_t<float16> kernel_fp16_avx512 = {
 
 template <>
 const isa_descriptor<float16>& getIsaHandlers(inst_set_t isa) {
-  static isa_descriptor<float16> avx2_descriptor =
-      std::make_tuple(kernel_fp16_avx2, partition_avx2);
-  static isa_descriptor<float16> avx512_descriptor =
-      std::make_tuple(kernel_fp16_avx512, partition_avx512);
-  static isa_descriptor<float16> avx512_256_descriptor =
-      std::make_tuple(kernel_fp16_avx512_256, partition_avx512);
+  static isa_descriptor<float16> avx2_descriptor{
+      kernel_fp16_avx2, partition_avx2};
+  static isa_descriptor<float16> avx512_descriptor{
+      kernel_fp16_avx512, partition_avx512};
+  static isa_descriptor<float16> avx512_256_descriptor{
+      kernel_fp16_avx512_256, partition_avx512};
 #ifdef __aarch64__
 #ifdef FBGEMM_ENABLE_KLEIDIAI
-  static isa_descriptor<float16> neon_descriptor =
-      std::make_tuple(kernel_fp16_neon, partition_neon);
+  static isa_descriptor<float16> neon_descriptor{
+      kernel_fp16_neon, partition_neon};
 #endif
 #ifdef FBGEMM_ENABLE_FP16_SVE128
-  static isa_descriptor<float16> sve128_descriptor =
-      std::make_tuple(kernel_fp16_sve128, partition_sve128);
+  static isa_descriptor<float16> sve128_descriptor{
+      kernel_fp16_sve128, partition_sve128};
 #endif
 #endif
 

--- a/src/GenerateI8Depthwise.cc
+++ b/src/GenerateI8Depthwise.cc
@@ -186,21 +186,20 @@ GenI8Depthwise::jit_kernel_signature GenI8Depthwise::getOrCreate(
     int bottom_skip,
     int left_skip,
     int right_skip) {
-  std::tuple<int, int, int, int, int, bool, int, int, int, int, int, int, int>
-      kernelSig = std::make_tuple(
-          D,
-          F[0],
-          F[1],
-          F[2],
-          oc_per_g,
-          compute_a_sum,
-          remainder,
-          prev_skip,
-          next_skip,
-          top_skip,
-          bottom_skip,
-          left_skip,
-          right_skip);
+  auto kernelSig = std::tuple{
+      D,
+      F[0],
+      F[1],
+      F[2],
+      oc_per_g,
+      compute_a_sum,
+      remainder,
+      prev_skip,
+      next_skip,
+      top_skip,
+      bottom_skip,
+      left_skip,
+      right_skip};
 
   return codeCache_.getOrCreate(kernelSig, [&]() -> jit_kernel_signature {
     asmjit::CodeHolder code;

--- a/src/GenerateKernelDirectConvU8S8S32ACC32.cc
+++ b/src/GenerateKernelDirectConvU8S8S32ACC32.cc
@@ -186,8 +186,8 @@ DirectConvCodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreateDirectConv(
   // int nRegBlockSizeMin;
   int row_interleave = 4;
 
-  auto kernelSig = std::make_tuple(
-      accum, O1, i1Xich, strideXich, i1Xich, mRegBlockSize, nRegBlockSize);
+  auto kernelSig = std::tuple{
+      accum, O1, i1Xich, strideXich, i1Xich, mRegBlockSize, nRegBlockSize};
 
   return codeCache_.getOrCreate(kernelSig, [&]() -> jit_micro_kernel_fp {
     asmjit::CodeHolder code;
@@ -608,7 +608,7 @@ DirectConvCodeGenBase<uint8_t, int8_t, int32_t, int32_t>::
   // int nRegBlockSizeMin;
   int row_interleave = 4;
 
-  auto kernelSig = std::make_tuple(accum, stride, mRegBlockSize, nRegBlockSize);
+  auto kernelSig = std::tuple{accum, stride, mRegBlockSize, nRegBlockSize};
 
   return codeCacheT_.getOrCreate(kernelSig, [&]() -> jit_micro_kernel_fp_convT {
     asmjit::CodeHolder code;

--- a/src/GenerateKernelU8S8S32ACC16.cc
+++ b/src/GenerateKernelU8S8S32ACC16.cc
@@ -131,8 +131,8 @@ CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate<inst_set_t::avx2>(
         PackingTraits<uint8_t, int16_t, inst_set_t::avx2>::ROW_INTERLEAVE;
   }
 
-  auto kernelSig = std::make_tuple(
-      accum, mc, nc, nBlock, kBlock, mRegBlockSize, nRegBlockSize);
+  auto kernelSig =
+      std::tuple{accum, mc, nc, nBlock, kBlock, mRegBlockSize, nRegBlockSize};
 
   return codeCache_.getOrCreate(kernelSig, [&]() -> jit_micro_kernel_fp {
     asmjit::CodeHolder code;

--- a/src/GenerateKernelU8S8S32ACC16Avx512.cc
+++ b/src/GenerateKernelU8S8S32ACC16Avx512.cc
@@ -97,8 +97,8 @@ CodeGenBase<uint8_t, int8_t, int32_t, int16_t>::getOrCreate(
     row_interleave = PackingTraits<uint8_t, int16_t, instSet>::ROW_INTERLEAVE;
   }
 
-  auto kernelSig = std::make_tuple(
-      accum, mc, nc, nBlock, kBlock, mRegBlockSize, nRegBlockSize);
+  auto kernelSig =
+      std::tuple{accum, mc, nc, nBlock, kBlock, mRegBlockSize, nRegBlockSize};
 
   return codeCache_.getOrCreate(kernelSig, [&]() -> jit_micro_kernel_fp {
     asmjit::CodeHolder code;

--- a/src/GenerateKernelU8S8S32ACC32.cc
+++ b/src/GenerateKernelU8S8S32ACC32.cc
@@ -136,8 +136,8 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate(
     row_interleave = PackingTraits<uint8_t, int32_t, instSet>::ROW_INTERLEAVE;
   }
 
-  auto kernelSig = std::make_tuple(
-      accum, mc, nc, nBlock, kBlock, mRegBlockSize, nRegBlockSize);
+  auto kernelSig =
+      std::tuple{accum, mc, nc, nBlock, kBlock, mRegBlockSize, nRegBlockSize};
 
   return codeCache_.getOrCreate(kernelSig, [&]() -> jit_micro_kernel_fp {
     asmjit::CodeHolder code;

--- a/src/GenerateKernelU8S8S32ACC32Avx512VNNI.cc
+++ b/src/GenerateKernelU8S8S32ACC32Avx512VNNI.cc
@@ -88,8 +88,8 @@ CodeGenBase<uint8_t, int8_t, int32_t, int32_t>::getOrCreate(
     row_interleave = PackingTraits<uint8_t, int32_t, instSet>::ROW_INTERLEAVE;
   }
 
-  auto kernelSig = std::make_tuple(
-      accum, mc, nc, nBlock, kBlock, mRegBlockSize, nRegBlockSize);
+  auto kernelSig =
+      std::tuple{accum, mc, nc, nBlock, kBlock, mRegBlockSize, nRegBlockSize};
 
   return codeCache_.getOrCreate(kernelSig, [&]() -> jit_micro_kernel_fp {
     asmjit::CodeHolder code;

--- a/src/PackWeightsForConv.cc
+++ b/src/PackWeightsForConv.cc
@@ -153,8 +153,7 @@ std::string PackWeightsForConv<SPATIAL_DIM, T, accT>::mismatchingParams(
   };
 
   auto combineInt = [&combineStr](const std::string& id, int int1, int int2) {
-    return combineStr(
-        std::move(id), std::to_string(int1), std::to_string(int2));
+    return combineStr(id, std::to_string(int1), std::to_string(int2));
   };
 
   if (conv_param_.IC != test_conv_p.IC) {

--- a/src/SparseAdagrad.cc
+++ b/src/SparseAdagrad.cc
@@ -437,8 +437,7 @@ GenSparseAdagrad<indxType, instSet>::getOrCreate(
     int prefetch,
     bool rowwise,
     bool has_weight_decay) {
-  std::tuple<int, int, bool, bool> kernelSig =
-      std::make_tuple(block_size, prefetch, rowwise, has_weight_decay);
+  auto kernelSig = std::tuple{block_size, prefetch, rowwise, has_weight_decay};
 
   return codeCache_.getOrCreate(
       kernelSig,

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -753,8 +753,8 @@ std::pair<K*, V*> radix_sort_parallel(
   fbgemm::fbgemmAlignedFree(histogram_ps);
 #endif
   return (
-      num_passes % 2 == 0 ? std::make_pair(inp_key_buf, inp_value_buf)
-                          : std::make_pair(tmp_key_buf, tmp_value_buf));
+      num_passes % 2 == 0 ? std::pair{inp_key_buf, inp_value_buf}
+                          : std::pair{tmp_key_buf, tmp_value_buf});
 }
 
 #define FORALL_INT_TYPES_AND_KEY(key_t, _) \

--- a/src/codegen_fp16fp32.cc
+++ b/src/codegen_fp16fp32.cc
@@ -39,8 +39,7 @@ struct ISA {
 enum class DataType { Float32, Float16, BFloat16 };
 
 constexpr std::array<std::pair<DataType, std::string>, 2> types_to_gen = {
-    std::make_pair(DataType::Float32, "FP32"),
-    std::make_pair(DataType::Float16, "FP16")};
+    {{DataType::Float32, "FP32"}, {DataType::Float16, "FP16"}}};
 
 constexpr int cache_line_size = 64;
 

--- a/src/fp32/FbgemmFP32.cc
+++ b/src/fp32/FbgemmFP32.cc
@@ -103,16 +103,15 @@ constexpr kernel_array_t<float> kernel_fp32_neon = {
 
 template <>
 const isa_descriptor<float>& getIsaHandlers(inst_set_t isa) {
-  static isa_descriptor<float> avx2_descriptor =
-      std::make_tuple(kernel_f32_avx2, partition_avx2);
-  static isa_descriptor<float> avx512_descriptor =
-      std::make_tuple(kernel_f32_avx512, partition_avx512);
-  static isa_descriptor<float> avx512_256_descriptor =
-      std::make_tuple(kernel_f32_avx512_256, partition_avx512);
+  static isa_descriptor<float> avx2_descriptor{kernel_f32_avx2, partition_avx2};
+  static isa_descriptor<float> avx512_descriptor{
+      kernel_f32_avx512, partition_avx512};
+  static isa_descriptor<float> avx512_256_descriptor{
+      kernel_f32_avx512_256, partition_avx512};
 #ifdef __aarch64__
 #ifdef FBGEMM_ENABLE_KLEIDIAI
-  static isa_descriptor<float> neon_descriptor =
-      std::make_tuple(kernel_fp32_neon, partition_sve128);
+  static isa_descriptor<float> neon_descriptor{
+      kernel_fp32_neon, partition_sve128};
 #endif
 #endif
 

--- a/src/fp32/FbgemmFP32.cc
+++ b/src/fp32/FbgemmFP32.cc
@@ -20,6 +20,7 @@
 #include "./KleidiAIFP32UKernelsNeon.h" // @manual
 #endif
 #endif
+#include "fbgemm/Assert.h"
 #include "fbgemm/Fbgemm.h"
 #include "fbgemm/FbgemmFPCommon.h"
 
@@ -160,7 +161,7 @@ FBGEMM_API void ref_kernel<float>(
         for (int j = 0; j < block_col_size; ++j) {
           float* C_ptr =
               gp->C + i * (gp->ldc / sizeof(float)) + jb * block_col_size + j;
-          assert(C_ptr < C_base + m_total * n_total);
+          FBGEMM_CHECK(C_ptr < C_base + m_total * n_total);
           float b = gp->B[(jb * gp->k + k) * block_col_size + j];
           if (k == 0) {
             if (gp->beta) {

--- a/test/AssertTest.cc
+++ b/test/AssertTest.cc
@@ -53,18 +53,18 @@ TEST(AssertTest, CheckMessageContainsSourceLocation) {
     FAIL() << "Expected fbgemm::Error to be thrown";
   } catch (const Error& e) {
     std::string what = e.what();
-    // Format: [file_name(line:column)] [function_name]: message
+    // Format: [file_name(line)] [function_name]: message
     // Should start with [
     EXPECT_EQ(what[0], '[')
         << "Error message should start with [. Got: " << what;
     // Should contain file name
     EXPECT_NE(what.find("AssertTest.cc"), std::string::npos)
         << "Error message should contain file name. Got: " << what;
-    // Should contain line and column in format (line:column)]
+    // Should contain line number in format (line)]
     EXPECT_NE(what.find("("), std::string::npos)
         << "Error message should contain opening paren. Got: " << what;
     EXPECT_NE(what.find(")]"), std::string::npos)
-        << "Error message should contain )] after line:column. Got: " << what;
+        << "Error message should contain )] after line number. Got: " << what;
     // Should contain function name in brackets
     EXPECT_NE(what.find("] ["), std::string::npos)
         << "Error message should contain ] [ between location and function. Got: "


### PR DESCRIPTION
Summary:
The existing `fbgemm::jagged_to_padded_dense` op requires `max_lengths` to be
passed as `SymInt[]` (a Python list of ints). This is inconvenient when
`max_lengths` is already available as a Tensor at the call site, requiring
callers to convert via `.tolist()`.

This diff adds a new named overload `.tensor_max_lengths` for both
`jagged_to_padded_dense` and `jagged_to_padded_dense_forward` that accepts
a 1-D int64 `Tensor` for `max_lengths`. The overload converts the Tensor to
a `SymInt` vector internally and delegates to the existing implementation.
PyTorch's dispatcher automatically routes to the correct overload based on
argument type, so callers can pass either a list or a Tensor seamlessly.

Registered across all backends: CPU, CUDA, Meta, Autograd, and
CompositeImplicitAutograd.

Authored with Claude.

Reviewed By: insect9

Differential Revision: D92612144


