### PR TITLE
Clean up kernel code by deleting unused options and code logic

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/faster_hash_ops/common_utils.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/faster_hash_ops/common_utils.cuh
@@ -102,27 +102,9 @@ murmur_hash3_2x64(const uint64_t x, const uint64_t y, const uint64_t seed) {
 }
 
 // NOLINTNEXTLINE:
-template <bool CIRCULAR_PROBE>
-TORBOREC_INLINE int64_t next_output_index(
-    int64_t output_index,
-    int64_t modulo,
-    int64_t& /* max_probe_local */) {
-  static_assert(CIRCULAR_PROBE);
+TORBOREC_INLINE int64_t
+next_output_index(int64_t output_index, int64_t modulo) {
   return (output_index + 1) % modulo;
-}
-
-// NOLINTNEXTLINE:
-template <>
-TORBOREC_INLINE int64_t next_output_index<false>(
-    int64_t output_index,
-    int64_t modulo,
-    int64_t& max_probe_local) {
-  output_index = (output_index + 1) % modulo;
-  if (output_index == 0) {
-    // circular, using max_probe_local to control exit.
-    max_probe_local = 0;
-  }
-  return output_index;
 }
 
 TORBOREC_INLINE bool is_eviction_enabled(

--- a/fbgemm_gpu/src/faster_hash_ops/faster_hash.cpp
+++ b/fbgemm_gpu/src/faster_hash_ops/faster_hash.cpp
@@ -30,7 +30,6 @@ constexpr int64_t kMaxIdentityNum = INT32_MAX;
 template <
     bool DISABLE_FALLBACK,
     int32_t HASH_IDENTITY,
-    bool CIRCULAR_PROBE,
     bool HAS_OFFSET,
     typename TInput,
     typename TIdentity>
@@ -98,10 +97,9 @@ void process_item_zch(
               break;
             }
 
-            output_index = next_output_index<CIRCULAR_PROBE>(
+            output_index = next_output_index(
                 output_index,
-                opt_in_block_size, // only probe within the opt-in block
-                max_probe_local);
+                opt_in_block_size);
           }
 
           // can't find a slot (all slot full after probing)
@@ -145,12 +143,11 @@ void _zero_collision_hash_cpu_out(
       offsets.has_value() ? offsets->const_data_ptr<int64_t>() : nullptr;
 
 #define INVOKE_KERNEL(                                           \
-    DISABLE_FALLBACK, HASH_IDENTITY, CIRCULAR_PROBE, HAS_OFFSET) \
+    DISABLE_FALLBACK, HASH_IDENTITY, HAS_OFFSET)                  \
   {                                                              \
     process_item_zch<                                            \
         DISABLE_FALLBACK,                                        \
         HASH_IDENTITY,                                           \
-        CIRCULAR_PROBE,                                          \
         HAS_OFFSET,                                              \
         TInput,                                                  \
         TIdentity>(                                              \
@@ -165,34 +162,25 @@ void _zero_collision_hash_cpu_out(
         num_reserved_slots);                                     \
   }
 
-#define INVOKE_HASH_IDENTITY(HASH_IDENTITY, CIRCULAR_PROBE, HAS_OFFSET) \
-  {                                                                     \
-    if (disable_fallback) {                                             \
-      INVOKE_KERNEL(true, HASH_IDENTITY, CIRCULAR_PROBE, HAS_OFFSET)    \
-    } else {                                                            \
-      INVOKE_KERNEL(false, HASH_IDENTITY, CIRCULAR_PROBE, HAS_OFFSET)   \
-    }                                                                   \
+#define INVOKE_HASH_IDENTITY(HASH_IDENTITY, HAS_OFFSET) \
+  {                                                      \
+    if (disable_fallback) {                              \
+      INVOKE_KERNEL(true, HASH_IDENTITY, HAS_OFFSET)     \
+    } else {                                             \
+      INVOKE_KERNEL(false, HASH_IDENTITY, HAS_OFFSET)    \
+    }                                                    \
   }
 
-#define INVOKE_KERNEL_CIRCULAR_PROBE(CIRCULAR_PROBE, HAS_OFFSET) \
-  {                                                              \
-    if (hash_identity == 1) {                                    \
-      INVOKE_HASH_IDENTITY(1, CIRCULAR_PROBE, HAS_OFFSET);       \
-    }                                                            \
-    if (hash_identity == 2) {                                    \
-      INVOKE_HASH_IDENTITY(2, CIRCULAR_PROBE, HAS_OFFSET);       \
-    } else {                                                     \
-      INVOKE_HASH_IDENTITY(0, CIRCULAR_PROBE, HAS_OFFSET);       \
-    }                                                            \
-  }
-
-#define INVOKE_KERNEL_HAS_OFFSET(HAS_OFFSET)           \
-  {                                                    \
-    if (circular_probe) {                              \
-      INVOKE_KERNEL_CIRCULAR_PROBE(true, HAS_OFFSET);  \
-    } else {                                           \
-      INVOKE_KERNEL_CIRCULAR_PROBE(false, HAS_OFFSET); \
-    }                                                  \
+#define INVOKE_KERNEL_HAS_OFFSET(HAS_OFFSET)        \
+  {                                                 \
+    if (hash_identity == 1) {                       \
+      INVOKE_HASH_IDENTITY(1, HAS_OFFSET);          \
+    }                                               \
+    if (hash_identity == 2) {                       \
+      INVOKE_HASH_IDENTITY(2, HAS_OFFSET);          \
+    } else {                                        \
+      INVOKE_HASH_IDENTITY(0, HAS_OFFSET);          \
+    }                                               \
   }
 
   if (local_sizes_ptr != nullptr) {
@@ -202,7 +190,6 @@ void _zero_collision_hash_cpu_out(
   }
 
 #undef INVOKE_KERNEL_HAS_OFFSET
-#undef INVOKE_KERNEL_CIRCULAR_PROBE
 #undef INVOKE_HASH_IDENTITY
 #undef INVOKE_KERNEL
 }
@@ -281,7 +268,9 @@ void zero_collision_hash_cpu_out(
   TORCH_CHECK(input.is_cpu());
   TORCH_CHECK(identities.dim() == 2);
 
-  int hash_identity = _modulo_identity_DPRECATED ? 2 : 1;
+  TORCH_CHECK(circular_probe, "circular_probe must be true");
+  TORCH_CHECK(!_modulo_identity_DPRECATED, "_modulo_identity_DPRECATED must be false");
+  int hash_identity = 1;
   if (identities.dtype() == input.dtype()) {
     hash_identity = 0;
   }

--- a/fbgemm_gpu/src/faster_hash_ops/faster_hash.cu
+++ b/fbgemm_gpu/src/faster_hash_ops/faster_hash.cu
@@ -259,7 +259,7 @@ __device__ __inline__ bool check_and_maybe_update_slot(
   return false;
 }
 
-template <bool CIRCULAR_PROBE, typename TIdentity>
+template <typename TIdentity>
 __device__ __inline__ int64_t get_identity_slot(
     at::PackedTensorAccessor64<TIdentity, 2, at::RestrictPtrTraits> identities,
     TIdentity identity,
@@ -279,7 +279,7 @@ __device__ __inline__ int64_t get_identity_slot(
     }
 
     output_index =
-        next_output_index<CIRCULAR_PROBE>(output_index, modulo, max_probe);
+        next_output_index(output_index, modulo);
   }
 
   // Nothing found, don't disable eviction.
@@ -292,7 +292,6 @@ template <
     bool DISABLE_FALLBACK,
     int32_t HASH_IDENTITY,
     int32_t METADATA_COUNT,
-    bool CIRCULAR_PROBE,
     bool READONLY,
     typename TInput,
     typename TIdentity,
@@ -376,7 +375,7 @@ __global__ void process_item_zch(
     // time, it would pick up an expired slot.
     // Also, we don't need lock here. As we are readonly here and other
     // concurrent write should have no impact on us.
-    int64_t identity_slot = get_identity_slot<CIRCULAR_PROBE, TIdentity>(
+    int64_t identity_slot = get_identity_slot<TIdentity>(
         identities,
         identity,
         output_index,
@@ -420,10 +419,9 @@ __global__ void process_item_zch(
         }
       }
 
-      output_index = next_output_index<CIRCULAR_PROBE>(
+      output_index = next_output_index(
           output_index,
-          opt_in_block_size, // only probe within the opt-in block
-          max_probe_local);
+          opt_in_block_size);
     }
 
     // can't find a slot (all slot full after probing), collide
@@ -448,7 +446,6 @@ template <
     bool DISABLE_FALLBACK,
     int32_t HASH_IDENTITY,
     int32_t METADATA_COUNT,
-    bool CIRCULAR_PROBE,
     bool READONLY,
     typename TInput,
     typename TIdentity,
@@ -519,7 +516,7 @@ __global__ void process_item_zch(
 
     // Pre-check if identity already exists in probing distance.
     // This avoids evicting a slot when the identity is already present.
-    int64_t identity_slot = get_identity_slot<CIRCULAR_PROBE, TIdentity>(
+    int64_t identity_slot = get_identity_slot<TIdentity>(
         identities,
         identity,
         output_index,
@@ -567,10 +564,9 @@ __global__ void process_item_zch(
           min_slot_identity,
           eviction_threshold);
 
-      output_index = next_output_index<CIRCULAR_PROBE>(
+      output_index = next_output_index(
           output_index,
-          opt_in_block_size, // only probe within the opt-in block
-          max_probe_local);
+          opt_in_block_size);
     }
 
     if (max_probe_local < 0) {
@@ -622,7 +618,6 @@ void _zero_collision_hash_cuda(
     const Tensor& input,
     Tensor& identities,
     int64_t max_probe,
-    bool circular_probe,
     int64_t cur_hour,
     bool readonly,
     bool support_evict,
@@ -663,7 +658,6 @@ void _zero_collision_hash_cuda(
     DISABLE_FALLBACK,                                                         \
     HASH_IDENTITY,                                                            \
     METADATA_COUNT,                                                           \
-    CIRCULAR_PROBE,                                                           \
     READONLY)                                                                 \
   {                                                                           \
     FBGEMM_LAUNCH_DSA_KERNEL(                                                 \
@@ -673,7 +667,6 @@ void _zero_collision_hash_cuda(
             DISABLE_FALLBACK,                                                 \
             HASH_IDENTITY,                                                    \
             METADATA_COUNT,                                                   \
-            CIRCULAR_PROBE,                                                   \
             READONLY,                                                         \
             TInput,                                                           \
             TIdentity>),                                                      \
@@ -709,7 +702,6 @@ void _zero_collision_hash_cuda(
     DISABLE_FALLBACK,          \
     HASH_IDENTITY,             \
     METADATA_COUNT,            \
-    CIRCULAR_PROBE,            \
     READONLY)                  \
   {                            \
     if (track_id_freq) {       \
@@ -719,7 +711,6 @@ void _zero_collision_hash_cuda(
           DISABLE_FALLBACK,    \
           HASH_IDENTITY,       \
           METADATA_COUNT,      \
-          CIRCULAR_PROBE,      \
           READONLY);           \
     } else {                   \
       INVOKE_KERNEL(           \
@@ -728,72 +719,60 @@ void _zero_collision_hash_cuda(
           DISABLE_FALLBACK,    \
           HASH_IDENTITY,       \
           METADATA_COUNT,      \
-          CIRCULAR_PROBE,      \
           READONLY);           \
     }                          \
   }
 
-#define INVOKE_KERNEL_EVICT_POLICY(                                            \
-    DISABLE_FALLBACK, HASH_IDENTITY, METADATA_COUNT, CIRCULAR_PROBE, READONLY) \
-  {                                                                            \
-    if (eviction_policy == 0) {                                                \
-      INVOKE_KERNEL_ID_FREQ(                                                   \
-          0,                                                                   \
-          DISABLE_FALLBACK,                                                    \
-          HASH_IDENTITY,                                                       \
-          METADATA_COUNT,                                                      \
-          CIRCULAR_PROBE,                                                      \
-          READONLY);                                                           \
-    } else {                                                                   \
-      INVOKE_KERNEL_ID_FREQ(                                                   \
-          1,                                                                   \
-          DISABLE_FALLBACK,                                                    \
-          HASH_IDENTITY,                                                       \
-          METADATA_COUNT,                                                      \
-          CIRCULAR_PROBE,                                                      \
-          READONLY);                                                           \
-    }                                                                          \
+#define INVOKE_KERNEL_EVICT_POLICY(                             \
+    DISABLE_FALLBACK, HASH_IDENTITY, METADATA_COUNT, READONLY)  \
+  {                                                             \
+    if (eviction_policy == 0) {                                 \
+      INVOKE_KERNEL_ID_FREQ(                                    \
+          0,                                                    \
+          DISABLE_FALLBACK,                                     \
+          HASH_IDENTITY,                                        \
+          METADATA_COUNT,                                       \
+          READONLY);                                            \
+    } else {                                                    \
+      INVOKE_KERNEL_ID_FREQ(                                    \
+          1,                                                    \
+          DISABLE_FALLBACK,                                     \
+          HASH_IDENTITY,                                        \
+          METADATA_COUNT,                                       \
+          READONLY);                                            \
+    }                                                           \
   }
 
-#define INVOKE_HASH_IDENTITY(                                             \
-    HASH_IDENTITY, METADATA_COUNT, CIRCULAR_PROBE, READONLY)              \
-  {                                                                       \
-    if (disable_fallback) {                                               \
-      INVOKE_KERNEL_EVICT_POLICY(                                         \
-          true, HASH_IDENTITY, METADATA_COUNT, CIRCULAR_PROBE, READONLY)  \
-    } else {                                                              \
-      INVOKE_KERNEL_EVICT_POLICY(                                         \
-          false, HASH_IDENTITY, METADATA_COUNT, CIRCULAR_PROBE, READONLY) \
-    }                                                                     \
+#define INVOKE_HASH_IDENTITY(                                           \
+    HASH_IDENTITY, METADATA_COUNT, READONLY)                             \
+  {                                                                     \
+    if (disable_fallback) {                                             \
+      INVOKE_KERNEL_EVICT_POLICY(                                       \
+          true, HASH_IDENTITY, METADATA_COUNT, READONLY)                \
+    } else {                                                            \
+      INVOKE_KERNEL_EVICT_POLICY(                                       \
+          false, HASH_IDENTITY, METADATA_COUNT, READONLY)               \
+    }                                                                   \
   }
 
-#define INVOKE_KERNEL_METADATA_COUNT(METADATA_COUNT, CIRCULAR_PROBE, READONLY) \
-  {                                                                            \
-    if (hash_identity == 1) {                                                  \
-      INVOKE_HASH_IDENTITY(1, METADATA_COUNT, CIRCULAR_PROBE, READONLY);       \
-    } else if (hash_identity == 2) {                                           \
-      INVOKE_HASH_IDENTITY(2, METADATA_COUNT, CIRCULAR_PROBE, READONLY);       \
-    } else {                                                                   \
-      INVOKE_HASH_IDENTITY(0, METADATA_COUNT, CIRCULAR_PROBE, READONLY);       \
-    }                                                                          \
+#define INVOKE_KERNEL_METADATA_COUNT(METADATA_COUNT, READONLY) \
+  {                                                           \
+    if (hash_identity == 1) {                                 \
+      INVOKE_HASH_IDENTITY(1, METADATA_COUNT, READONLY);      \
+    } else if (hash_identity == 2) {                          \
+      INVOKE_HASH_IDENTITY(2, METADATA_COUNT, READONLY);      \
+    } else {                                                  \
+      INVOKE_HASH_IDENTITY(0, METADATA_COUNT, READONLY);      \
+    }                                                         \
   }
 
-#define INVOKE_KERNEL_CIRCULAR_PROBE(CIRCULAR_PROBE, READONLY)   \
-  {                                                              \
-    if (support_evict) {                                         \
-      INVOKE_KERNEL_METADATA_COUNT(1, CIRCULAR_PROBE, READONLY); \
-    } else {                                                     \
-      INVOKE_KERNEL_METADATA_COUNT(0, CIRCULAR_PROBE, READONLY); \
-    }                                                            \
-  }
-
-#define INVOKE_KERNEL_READ_ONLY(READONLY)            \
-  {                                                  \
-    if (circular_probe) {                            \
-      INVOKE_KERNEL_CIRCULAR_PROBE(true, READONLY);  \
-    } else {                                         \
-      INVOKE_KERNEL_CIRCULAR_PROBE(false, READONLY); \
-    }                                                \
+#define INVOKE_KERNEL_READ_ONLY(READONLY)                  \
+  {                                                        \
+    if (support_evict) {                                   \
+      INVOKE_KERNEL_METADATA_COUNT(1, READONLY);           \
+    } else {                                               \
+      INVOKE_KERNEL_METADATA_COUNT(0, READONLY);           \
+    }                                                      \
   }
 
   if (readonly) {
@@ -803,7 +782,6 @@ void _zero_collision_hash_cuda(
   }
 
 #undef INVOKE_KERNEL_READ_ONLY
-#undef INVOKE_KERNEL_CIRCULAR_PROBE
 #undef INVOKE_KERNEL_METADATA_COUNT
 #undef INVOKE_HASH_IDENTITY
 #undef INVOKE_KERNEL
@@ -840,7 +818,8 @@ std::tuple<Tensor, Tensor> zero_collision_hash_cuda(
   TORCH_CHECK(input.is_cuda());
   TORCH_CHECK(identities.dim() == 2);
 
-  int32_t hash_identity = _modulo_identity_DPRECATED ? 1 : 2;
+  TORCH_CHECK(!_modulo_identity_DPRECATED, "_modulo_identity_DPRECATED must be false");
+  int32_t hash_identity = 2;
   if (identities.dtype() == input.dtype()) {
     hash_identity = 0;
   }
@@ -927,19 +906,15 @@ std::tuple<Tensor, Tensor> zero_collision_hash_cuda(
     TORCH_CHECK(runtime_meta->size(1) == 1);
   }
 
+  TORCH_CHECK(!output_on_uvm, "output_on_uvm is no longer supported");
+  TORCH_CHECK(circular_probe, "circular_probe must be true");
+
   at::cuda::OptionalCUDAGuard device_guard;
   device_guard.set_index(input.get_device());
 
   int64_t output_size = input.size(0);
-  c10::TensorOptions options;
-
-  if (output_on_uvm) {
-    options =
-        c10::TensorOptions().dtype(at::kLong).device(at::kCPU).pinned_memory(
-            true);
-  } else {
-    options = c10::TensorOptions().dtype(at::kLong).device(input.device());
-  }
+  c10::TensorOptions options =
+      c10::TensorOptions().dtype(at::kLong).device(input.device());
 
   Tensor output = at::empty({output_size}, options);
 
@@ -969,7 +944,6 @@ std::tuple<Tensor, Tensor> zero_collision_hash_cuda(
                   input,
                   identities,
                   max_probe,
-                  circular_probe,
                   cur_hour,
                   readonly,
                   support_evict,
@@ -991,9 +965,6 @@ std::tuple<Tensor, Tensor> zero_collision_hash_cuda(
   if (support_evict) {
     evict_slots = std::get<0>(torch::_unique(
         evict_slots.masked_select(evict_slots != kDefaultTensor)));
-  }
-  if (output_on_uvm) {
-    C10_CUDA_CHECK(cudaDeviceSynchronize());
   }
   return {output, evict_slots};
 }

--- a/fbgemm_gpu/test/faster_hash_test.py
+++ b/fbgemm_gpu/test/faster_hash_test.py
@@ -148,50 +148,6 @@ class FasterHashTest(unittest.TestCase):
         )
         self.assertTrue(torch.equal(output_readonly.cpu(), output_readonly_cpu))
 
-        # no evict + no circular probe
-        identities, _ = torch.ops.fbgemm.create_zch_buffer(
-            100, device=torch.device("cuda")
-        )
-        output, evict_slots = torch.ops.fbgemm.zero_collision_hash(
-            numbers,
-            identities,
-            100,
-            circular_probe=False,
-        )
-        self.assertFalse(torch.all(identities != -1))
-        unique_indices = torch.unique(output)
-        all_indices = torch.arange(identities.size(0), device="cuda")
-        not_select_indices = torch.isin(all_indices, unique_indices, invert=True)
-        self.assertTrue(torch.all(identities[unique_indices] != -1))
-        self.assertTrue(torch.all(identities[not_select_indices] == -1))
-
-        unique_elements, counts = torch.unique(
-            identities[identities[:, 0] != -1][:, 0], return_counts=True
-        )
-        self.assertTrue(torch.all(counts == 1))
-
-        # readonly lookup.
-        output_readonly, evict_slots = torch.ops.fbgemm.zero_collision_hash(
-            numbers,
-            identities,
-            100,
-            circular_probe=False,
-            exp_hours=-1,
-            readonly=True,
-        )
-        self.assertTrue(torch.equal(output, output_readonly))
-
-        # CPU
-        output_readonly_cpu, _ = torch.ops.fbgemm.zero_collision_hash(
-            input=numbers.cpu(),
-            identities=identities.cpu(),
-            max_probe=100,
-            circular_probe=True,
-            exp_hours=-1,
-            readonly=True,
-        )
-        self.assertTrue(torch.equal(output_readonly.cpu(), output_readonly_cpu))
-
     @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     def test_simple_zch_no_evict_rand(self) -> None:
@@ -252,51 +208,6 @@ class FasterHashTest(unittest.TestCase):
             identities.cpu(),
             100,
             circular_probe=True,
-            exp_hours=-1,
-            readonly=True,
-        )
-        self.assertTrue(torch.equal(output.cpu(), output_readonly_cpu))
-
-        # no evict + no circular probe
-        identities, _ = torch.ops.fbgemm.create_zch_buffer(
-            100, device=torch.device("cuda")
-        )
-        output, evict_slots = torch.ops.fbgemm.zero_collision_hash(
-            random_numbers,
-            identities,
-            100,
-            circular_probe=False,
-        )
-        unique_indices_no_circular = torch.unique(output)
-        all_indices_no_circular = torch.arange(identities.size(0), device="cuda")
-        not_select_indices_no_circular = torch.isin(
-            all_indices_no_circular, unique_indices_no_circular, invert=True
-        )
-        self.assertTrue(torch.all(identities[unique_indices_no_circular] != -1))
-        self.assertTrue(torch.all(identities[not_select_indices_no_circular] == -1))
-        self.assertTrue(unique_indices_no_circular.size(0) <= unique_indices.size(0))
-        unique_elements, counts = torch.unique(
-            identities[identities[:, 0] != -1][:, 0], return_counts=True
-        )
-        self.assertTrue(torch.all(counts == 1))
-
-        # readonly lookup.
-        output_readonly, evict_slots = torch.ops.fbgemm.zero_collision_hash(
-            random_numbers,
-            identities,
-            100,
-            circular_probe=False,
-            exp_hours=-1,
-            readonly=True,
-        )
-        self.assertTrue(torch.equal(output, output_readonly))
-
-        # CPU
-        output_readonly_cpu, evict_slots = torch.ops.fbgemm.zero_collision_hash(
-            random_numbers.cpu(),
-            identities.cpu(),
-            100,
-            circular_probe=False,
             exp_hours=-1,
             readonly=True,
         )
@@ -372,73 +283,6 @@ class FasterHashTest(unittest.TestCase):
         )
         self.assertTrue(torch.equal(output, output_readonly))
 
-        # evict + no circular probe
-        identities, metadata = torch.ops.fbgemm.create_zch_buffer(
-            100, support_evict=True, device=torch.device("cuda")
-        )
-        output, evict_slots = torch.ops.fbgemm.zero_collision_hash(
-            numbers,
-            identities,
-            100,
-            circular_probe=False,
-            exp_hours=7 * 24,
-            metadata=metadata,
-        )
-        self.assertFalse(torch.all(identities != -1))
-        unique_indices = torch.unique(output)
-        all_indices = torch.arange(identities.size(0), device="cuda")
-        not_select_indices = torch.isin(all_indices, unique_indices, invert=True)
-        self.assertTrue(torch.all(identities[unique_indices] != -1))
-        self.assertTrue(torch.all(identities[not_select_indices] == -1))
-        unique_elements, counts = torch.unique(
-            identities[identities[:, 0] != -1][:, 0], return_counts=True
-        )
-        self.assertTrue(torch.all(counts == 1))
-
-        # readonly lookup.
-        output_readonly, evict_slots = torch.ops.fbgemm.zero_collision_hash(
-            numbers,
-            identities,
-            100,
-            circular_probe=False,
-            exp_hours=-1,
-            readonly=True,
-        )
-        self.assertTrue(torch.equal(output, output_readonly))
-
-        # evict with all expired hours + no circular probe
-        evict_slot_candidate_mask = metadata[:, 0] != -1
-        evict_slot_candidates = torch.nonzero(evict_slot_candidate_mask)
-        self.assertTrue(evict_slot_candidates.size(0) != 0)
-        metadata[evict_slot_candidate_mask, 0] -= 7 * 24 + 1
-        old_time_value = metadata[evict_slot_candidates[0], 0]
-        numbers_100_200 = torch.arange(100, 200, dtype=torch.int64, device="cuda")
-        output, evict_slots = torch.ops.fbgemm.zero_collision_hash(
-            numbers_100_200,
-            identities,
-            100,
-            circular_probe=False,
-            exp_hours=7 * 24,
-            metadata=metadata,
-        )
-        self.assertTrue(torch.all(torch.isin(evict_slots, evict_slot_candidates)))
-        self.assertTrue(torch.all(metadata[evict_slots][:, 0] != old_time_value))
-        unique_elements, counts = torch.unique(
-            identities[identities[:, 0] != -1][:, 0], return_counts=True
-        )
-        self.assertTrue(torch.all(counts == 1))
-
-        # readonly lookup.
-        output_readonly, evict_slots = torch.ops.fbgemm.zero_collision_hash(
-            numbers_100_200,
-            identities,
-            100,
-            circular_probe=False,
-            exp_hours=-1,
-            readonly=True,
-        )
-        self.assertTrue(torch.equal(output, output_readonly))
-
     @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     def test_simple_zch_evict_with_rand_unique_numbers(self) -> None:
@@ -494,86 +338,6 @@ class FasterHashTest(unittest.TestCase):
             readonly=True,
         )
         self.assertTrue(torch.equal(output, output_readonly))
-
-        # evict - rand number + no circular probe
-        identities, metadata = torch.ops.fbgemm.create_zch_buffer(
-            100, support_evict=True, device=torch.device("cuda")
-        )
-        output, evict_slots = torch.ops.fbgemm.zero_collision_hash(
-            random_numbers,
-            identities,
-            100,
-            circular_probe=False,
-            exp_hours=7 * 24,
-            metadata=metadata,
-        )
-
-        for i in range(100):
-            to_test = output[random_numbers == i]
-            if len(to_test) > 0:
-                self.assertTrue(torch.all(to_test == to_test[0]))
-
-        unique_indices_no_circular = torch.unique(output)
-        all_indices_no_circular = torch.arange(identities.size(0), device="cuda")
-        not_select_indices_no_circular = torch.isin(
-            all_indices_no_circular, unique_indices_no_circular, invert=True
-        )
-        self.assertTrue(torch.all(identities[unique_indices_no_circular] != -1))
-        self.assertTrue(torch.all(identities[not_select_indices_no_circular] == -1))
-        self.assertTrue(unique_indices_no_circular.size(0) <= unique_indices.size(0))
-        unique_elements, counts = torch.unique(
-            identities[identities[:, 0] != -1][:, 0], return_counts=True
-        )
-        self.assertTrue(torch.all(counts == 1))
-
-        # readonly lookup.
-        output_readonly, evict_slots = torch.ops.fbgemm.zero_collision_hash(
-            random_numbers,
-            identities,
-            100,
-            circular_probe=False,
-            exp_hours=-1,
-            readonly=True,
-        )
-        self.assertTrue(torch.equal(output, output_readonly))
-
-        # evict with all expired hours + no circular probe
-        evict_slot_candidate_mask = metadata[:, 0] != -1
-        evict_slot_candidates = torch.nonzero(evict_slot_candidate_mask)
-        self.assertTrue(evict_slot_candidates.size(0) != 0)
-        metadata[evict_slot_candidate_mask, 0] -= 7 * 24 + 1
-        old_time_value = metadata[evict_slot_candidates[0], 0]
-        random_numbers_100_200 = torch.unique(
-            torch.randint(100, 200, (100,), device="cuda")
-        )
-        output, evict_slots = torch.ops.fbgemm.zero_collision_hash(
-            random_numbers_100_200,
-            identities,
-            100,
-            circular_probe=False,
-            exp_hours=7 * 24,
-            metadata=metadata,
-        )
-        self.assertTrue(torch.all(torch.isin(evict_slots, evict_slot_candidates)))
-        self.assertTrue(torch.all(metadata[evict_slots][:, 0] != old_time_value))
-
-        unique_elements, counts = torch.unique(
-            identities[identities[:, 0] != -1][:, 0], return_counts=True
-        )
-        self.assertTrue(torch.all(counts == 1), counts)
-
-        # readonly lookup.
-        output_readonly, evict_slots = torch.ops.fbgemm.zero_collision_hash(
-            random_numbers_100_200,
-            identities[:, 0].unsqueeze(1),
-            100,
-            circular_probe=False,
-            exp_hours=-1,
-            readonly=True,
-        )
-        self.assertTrue(
-            torch.equal(output, output_readonly), f"{output=}, {output_readonly=}"
-        )
 
     @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
@@ -661,44 +425,6 @@ class FasterHashTest(unittest.TestCase):
             metadata=metadata,
         )
         self.assertTrue(evict_slots.numel() == 1)
-
-    @skipIfRocm("The CUDA kernel is not supported on ROCm")
-    @unittest.skipIf(*gpu_unavailable)
-    def test_zch_output_on_uvm(self) -> None:
-        """
-        Test the zero collision hash output on uvm.
-        It creates a identity table with 200 slots, and insert 100 numbers
-        with zero collision hash. Then it inserts 100 random numbers with zero
-        collision hash. The output should be on uvm (cpu).
-
-        Assertions:
-            1. The output is on cpu.
-            2. The output is correct.
-
-        Raises:
-            AssertionError: If the test detects a mismatch from the expected behavior.
-        """
-        # no evict
-        identities, _ = torch.ops.fbgemm.create_zch_buffer(
-            200, device=torch.device("cuda")
-        )
-        numbers = torch.arange(0, 100, dtype=torch.int64, device="cuda")
-
-        output, _ = torch.ops.fbgemm.zero_collision_hash(
-            input=numbers,
-            identities=identities,
-            max_probe=100,
-            circular_probe=True,
-            output_on_uvm=True,
-        )
-
-        self.assertTrue(output.device.type == "cpu")
-
-        add_on = torch.arange(100, 200, dtype=torch.int64)
-        self.assertTrue(
-            # pyre-fixme[6]: For 2nd argument expected `Tensor` but got `int`.
-            torch.equal(((output + add_on) + (output - add_on)), 2 * output)
-        )
 
     @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)


### PR DESCRIPTION
Summary:
Remove unused code paths and options from faster_hash CPU and CUDA kernels
in both caffe2/torch/fb/retrieval and fbgemm_gpu codebases.

All callers already use `circular_probe=True`, `_modulo_identity_DPRECATED=false`,
and `output_on_uvm=false`, making these options dead code. This change:

- Removes the `CIRCULAR_PROBE` template parameter and simplifies
  `next_output_index` from a template specialization pair to a single function,
  dropping the `max_probe_local` side-effect parameter
- Removes `output_on_uvm` support, including UVM tensor allocation and
  `cudaDeviceSynchronize` call
- Hardcodes `_modulo_identity_DPRECATED` to false, removing the conditional
  `hash_identity` assignment
- Adds TORCH_CHECK assertions at the API boundary to enforce these constraints
- Simplifies the macro dispatch chains by removing the `CIRCULAR_PROBE` dimension,
  reducing kernel binary bloat
- Removes all related test cases for `circular_probe=False` and
  `output_on_uvm=True`

Differential Revision: D95470985


