### PR TITLE
enable feature score auto collection in EBC (#5459)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -294,6 +294,7 @@ class KVZCHParams(NamedTuple):
     optimizer_state_dtypes_for_st: Optional[FrozenSet[Tuple[str, int]]] = None
     # Enrichment config for embedding cache enrichment from external sources
     enrichment_policy: Optional[EnrichmentPolicy] = None
+    feature_score_collection_enabled: bool = False
 
     def validate(self) -> None:
         assert len(self.bucket_offsets) == len(self.bucket_sizes), (


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2436


X-link: https://github.com/meta-pytorch/torchrec/pull/3841

This diff is a redo of D85017179 which was reverted due to test failure

**Summary**
This diff enables automatic feature score collection in EmbeddingBagCollection (EBC) for virtual table eviction policies. It integrates the existing feature score utilities into the EBC forward pass, allowing automatic collection of feature scores during inference.

Reviewed By: kausv

Differential Revision: D95503524
