### PR TITLE
[detailed][ops] Add `permute_2D_sparse_preallocated_out` with pre-allocated output buffers (#5461)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -143,13 +143,34 @@ def permute_2D_sparse_data_meta(
     weights: Tensor | None = None,
     permuted_lengths_sum: int | None = None,
 ) -> tuple[Tensor, Tensor, Tensor | None]:
+    # Functional (allocating) entry point; delegates to the shared
+    # implementation with no pre-allocated output buffers.
+    return permute_2D_sparse_preallocated_out_meta(
+        permute, lengths, values, weights, permuted_lengths_sum
+    )
+
+
+def permute_2D_sparse_preallocated_out_meta(
+    permute: Tensor,
+    lengths: Tensor,
+    values: Tensor,
+    weights: Tensor | None = None,
+    permuted_lengths_sum: int | None = None,
+    permuted_lengths_out: Tensor | None = None,
+    permuted_indices_out: Tensor | None = None,
+    permuted_weights_out: Tensor | None = None,
+) -> tuple[Tensor, Tensor, Tensor | None]:
     torch._check(
         lengths.dim() == 2, lambda: f"expected lengths.dim() == 2, got {lengths.dim()}"
     )
     T = permute.numel()
     B = lengths.size(1)
     indices = values
-    permuted_lengths = lengths.new_empty([T, B])
+    permuted_lengths = (
+        permuted_lengths_out
+        if permuted_lengths_out is not None
+        else lengths.new_empty([T, B])
+    )
     permuted_indices_size = 0
     if permuted_lengths_sum is not None:
         permuted_indices_size = permuted_lengths_sum
@@ -157,11 +178,19 @@ def permute_2D_sparse_data_meta(
         ctx = torch.library.get_ctx()
         permuted_indices_size = ctx.new_dynamic_size()
     # pyre-fixme
-    permuted_indices = indices.new_empty(permuted_indices_size)
+    permuted_indices = (
+        permuted_indices_out
+        if permuted_indices_out is not None
+        else indices.new_empty(permuted_indices_size)
+    )
     permuted_weights = None
     if weights is not None:
         # pyre-fixme
-        permuted_weights = weights.new_empty(permuted_indices_size)
+        permuted_weights = (
+            permuted_weights_out
+            if permuted_weights_out is not None
+            else weights.new_empty(permuted_indices_size)
+        )
     return permuted_lengths, permuted_indices, permuted_weights
 
 
@@ -1402,6 +1431,13 @@ def _setup() -> None:
         )
 
         impl_abstract("fbgemm::permute_2D_sparse_data", permute_2D_sparse_data_meta)
+        # No autograd formula: the pre-allocated output buffers alias the
+        # returned tensors, so this op is intentionally non-functional and
+        # non-differentiable (the buffers are write-only outputs).
+        impl_abstract(
+            "fbgemm::permute_2D_sparse_preallocated_out",
+            permute_2D_sparse_preallocated_out_meta,
+        )
         impl_abstract("fbgemm::get_source_mask", get_source_mask_meta)
         impl_abstract("fbgemm::repeat_arange", repeat_arange_meta)
         impl_abstract(

--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -158,6 +158,20 @@ permute_2D_sparse_data_cuda(
     const std::optional<at::Tensor>& weights,
     const std::optional<int64_t>& permuted_lengths_sum);
 
+// Variant of permute_2D_sparse_data_cuda that writes into optional
+// pre-allocated output buffers; the returned tensors alias those buffers when
+// provided. Not differentiable (no autograd formula registered).
+std::tuple<at::Tensor, at::Tensor, std::optional<at::Tensor>>
+permute_2D_sparse_preallocated_out_cuda(
+    const at::Tensor& permute,
+    const at::Tensor& lengths,
+    const at::Tensor& indices,
+    const std::optional<at::Tensor>& weights,
+    const std::optional<int64_t>& permuted_lengths_sum,
+    const std::optional<at::Tensor>& permuted_lengths_out,
+    const std::optional<at::Tensor>& permuted_indices_out,
+    const std::optional<at::Tensor>& permuted_weights_out);
+
 std::tuple<at::Tensor, at::Tensor, std::optional<at::Tensor>>
 permute_1D_sparse_data_cuda(
     const at::Tensor& permute,
@@ -390,6 +404,20 @@ permute_2D_sparse_data_cpu(
     const at::Tensor& indices,
     const std::optional<at::Tensor>& weights,
     const std::optional<int64_t>& permuted_lengths_sum);
+
+// Variant of permute_2D_sparse_data_cpu that writes into optional pre-allocated
+// output buffers; the returned tensors alias those buffers when provided. Not
+// differentiable (no autograd formula registered).
+std::tuple<at::Tensor, at::Tensor, std::optional<at::Tensor>>
+permute_2D_sparse_preallocated_out_cpu(
+    const at::Tensor& permute,
+    const at::Tensor& lengths,
+    const at::Tensor& indices,
+    const std::optional<at::Tensor>& weights,
+    const std::optional<int64_t>& permuted_lengths_sum,
+    const std::optional<at::Tensor>& permuted_lengths_out,
+    const std::optional<at::Tensor>& permuted_indices_out,
+    const std::optional<at::Tensor>& permuted_weights_out);
 
 ///@ingroup sparse-data-cpu
 std::tuple<at::Tensor, at::Tensor, std::optional<at::Tensor>>

--- a/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
@@ -730,12 +730,16 @@ permute_2D_sparse_data_input1D_cpu(
   return {permuted_lengths.view(-1), permuted_indices, permuted_weights};
 }
 
-std::tuple<Tensor, Tensor, std::optional<Tensor>> permute_2D_sparse_data_cpu(
+std::tuple<Tensor, Tensor, std::optional<Tensor>>
+permute_2D_sparse_preallocated_out_cpu(
     const Tensor& permute,
     const Tensor& lengths,
     const Tensor& indices,
     const std::optional<Tensor>& weights,
-    const std::optional<int64_t>& permuted_lengths_sum) {
+    const std::optional<int64_t>& permuted_lengths_sum,
+    const std::optional<Tensor>& permuted_lengths_out,
+    const std::optional<Tensor>& permuted_indices_out,
+    const std::optional<Tensor>& permuted_weights_out) {
   TENSOR_ON_CPU(permute);
   TENSOR_ON_CPU(lengths);
   TENSOR_ON_CPU(indices);
@@ -756,7 +760,9 @@ std::tuple<Tensor, Tensor, std::optional<Tensor>> permute_2D_sparse_data_cpu(
   Tensor permuted_indices;
   std::optional<Tensor> permuted_weights;
 
-  permuted_lengths = at::empty({T, B}, lengths.options());
+  permuted_lengths = permuted_lengths_out.has_value()
+      ? permuted_lengths_out.value()
+      : at::empty({T, B}, lengths.options());
 
   const auto lengths_size = lengths.numel();
   auto input_offsets = at::empty({lengths_size + 1}, lengths.options());
@@ -785,7 +791,9 @@ std::tuple<Tensor, Tensor, std::optional<Tensor>> permute_2D_sparse_data_cpu(
     permuted_indices_size =
         output_offsets_per_thread_cumsum[num_threads * FALSE_SHARING_PAD];
   }
-  permuted_indices = at::empty(permuted_indices_size, indices.options());
+  permuted_indices = permuted_indices_out.has_value()
+      ? permuted_indices_out.value()
+      : at::empty(permuted_indices_size, indices.options());
   AT_DISPATCH_INDEX_TYPES(
       input_offsets.scalar_type(), "permute_2D_indices_weights_kernel_1", [&] {
         using offsets_t = index_t;
@@ -801,8 +809,11 @@ std::tuple<Tensor, Tensor, std::optional<Tensor>> permute_2D_sparse_data_cpu(
                     if (weights.has_value()) {
                       const auto weights_value_contig =
                           weights.value().expect_contiguous();
-                      permuted_weights = at::empty(
-                          permuted_indices_size, weights.value().options());
+                      permuted_weights = permuted_weights_out.has_value()
+                          ? permuted_weights_out.value()
+                          : at::empty(
+                                permuted_indices_size,
+                                weights.value().options());
                       _permute_2D_indices_weights_kernel_cpu<
                           true,
                           index_t,
@@ -839,6 +850,25 @@ std::tuple<Tensor, Tensor, std::optional<Tensor>> permute_2D_sparse_data_cpu(
             }); // for each indices_t
       }); // for each offsets_t
   return {permuted_lengths, permuted_indices, permuted_weights};
+}
+
+// Functional (allocating) entry point. Delegates to the shared implementation
+// with no pre-allocated output buffers.
+std::tuple<Tensor, Tensor, std::optional<Tensor>> permute_2D_sparse_data_cpu(
+    const Tensor& permute,
+    const Tensor& lengths,
+    const Tensor& indices,
+    const std::optional<Tensor>& weights,
+    const std::optional<int64_t>& permuted_lengths_sum) {
+  return permute_2D_sparse_preallocated_out_cpu(
+      permute,
+      lengths,
+      indices,
+      weights,
+      permuted_lengths_sum,
+      std::nullopt,
+      std::nullopt,
+      std::nullopt);
 }
 
 // specialization for variable B and T,
@@ -3807,6 +3837,13 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
   m.def(
       "permute_2D_sparse_data(Tensor permute, Tensor lengths, Tensor values, Tensor? weights=None, SymInt? permuted_lengths_sum=None) -> (Tensor, Tensor, Tensor?)",
       {PT2_COMPLIANT_TAG});
+  // Non-differentiable variant that writes into optional pre-allocated output
+  // buffers. The output tensors alias the corresponding buffers when provided,
+  // which is declared via the (a!)/(b!)/(c!) annotations. This cannot live on
+  // permute_2D_sparse_data because that op has a registered autograd formula
+  // and register_autograd requires a functional (non-aliasing) operator.
+  m.def(
+      "permute_2D_sparse_preallocated_out(Tensor permute, Tensor lengths, Tensor values, Tensor? weights=None, SymInt? permuted_lengths_sum=None, Tensor(a!)? permuted_lengths_out=None, Tensor(b!)? permuted_indices_out=None, Tensor(c!)? permuted_weights_out=None) -> (Tensor(a!), Tensor(b!), Tensor(c!)?)");
   m.def(
       "permute_2D_sparse_data_input1D(Tensor permute, Tensor lengths, Tensor values, SymInt stride, Tensor? weights=None, SymInt? permuted_lengths_sum=None) -> (Tensor, Tensor, Tensor?)");
   m.def(
@@ -3915,6 +3952,9 @@ TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
       "permute_sparse_data", fbgemm_gpu::permute_2D_sparse_data_cpu);
   DISPATCH_TO_CPU(
       "permute_2D_sparse_data", fbgemm_gpu::permute_2D_sparse_data_cpu);
+  DISPATCH_TO_CPU(
+      "permute_2D_sparse_preallocated_out",
+      fbgemm_gpu::permute_2D_sparse_preallocated_out_cpu);
   DISPATCH_TO_CPU(
       "permute_2D_sparse_data_input1D",
       fbgemm_gpu::permute_2D_sparse_data_input1D_cpu);

--- a/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu
@@ -184,12 +184,15 @@ __global__ __launch_bounds__(kMaxThreads) void permute_2D_lengths_kernel(
 }
 
 DLL_PUBLIC std::tuple<Tensor, Tensor, std::optional<Tensor>>
-permute_2D_sparse_data_cuda(
+permute_2D_sparse_preallocated_out_cuda(
     const Tensor& permute,
     const Tensor& lengths,
     const Tensor& indices,
     const std::optional<Tensor>& weights,
-    const std::optional<int64_t>& permuted_lengths_sum) {
+    const std::optional<int64_t>& permuted_lengths_sum,
+    const std::optional<Tensor>& permuted_lengths_out,
+    const std::optional<Tensor>& permuted_indices_out,
+    const std::optional<Tensor>& permuted_weights_out) {
   TENSORS_ON_SAME_CUDA_GPU_IF_NOT_OPTIONAL(permute, lengths, indices, weights);
   TORCH_CHECK(lengths.dim() == 2);
 
@@ -218,7 +221,9 @@ permute_2D_sparse_data_cuda(
   Tensor permuted_indices;
   Tensor permuted_weights;
 
-  permuted_lengths = at::empty({T, B}, lengths.options());
+  permuted_lengths = permuted_lengths_out.has_value()
+      ? permuted_lengths_out.value()
+      : at::empty({T, B}, lengths.options());
 
   constexpr int32_t threads_1 = 256;
   // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
@@ -264,7 +269,9 @@ permute_2D_sparse_data_cuda(
       cuda_calc_xblock_count(B * T, BT_blocks),
       BT_blocks * 32,
       at::cuda::getCurrentCUDAStream());
-  permuted_indices = at::empty(permuted_indices_size, indices.options());
+  permuted_indices = permuted_indices_out.has_value()
+      ? permuted_indices_out.value()
+      : at::empty(permuted_indices_size, indices.options());
 
   AT_DISPATCH_INDEX_TYPES(
       input_offsets.scalar_type(), "permute_2D_data_kernel_1", [&] {
@@ -278,12 +285,16 @@ permute_2D_sparse_data_cuda(
                 int32_t weights_columns = 1;
                 if (weights_value.dense_dim() > 1) {
                   weights_columns = weights_value.size(1);
-                  permuted_weights = at::empty(
-                      {permuted_indices_size, weights_columns},
-                      weights_value.options());
+                  permuted_weights = permuted_weights_out.has_value()
+                      ? permuted_weights_out.value()
+                      : at::empty(
+                            {permuted_indices_size, weights_columns},
+                            weights_value.options());
                 } else {
-                  permuted_weights =
-                      at::empty(permuted_indices_size, weights_value.options());
+                  permuted_weights = permuted_weights_out.has_value()
+                      ? permuted_weights_out.value()
+                      : at::empty(
+                            permuted_indices_size, weights_value.options());
                 }
                 FBGEMM_DISPATCH_ALL_TYPES_AND_DOUBLE(
                     weights_value.scalar_type(),
@@ -360,6 +371,26 @@ permute_2D_sparse_data_cuda(
             }); // for each indices_t
       }); // for each offsets_t
   return {permuted_lengths, permuted_indices, permuted_weights};
+}
+
+// Functional (allocating) entry point. Delegates to the shared implementation
+// with no pre-allocated output buffers.
+DLL_PUBLIC std::tuple<Tensor, Tensor, std::optional<Tensor>>
+permute_2D_sparse_data_cuda(
+    const Tensor& permute,
+    const Tensor& lengths,
+    const Tensor& indices,
+    const std::optional<Tensor>& weights,
+    const std::optional<int64_t>& permuted_lengths_sum) {
+  return permute_2D_sparse_preallocated_out_cuda(
+      permute,
+      lengths,
+      indices,
+      weights,
+      permuted_lengths_sum,
+      std::nullopt,
+      std::nullopt,
+      std::nullopt);
 }
 
 // Kernel for permuting the indices and weights. Used for permutation of
@@ -557,6 +588,10 @@ FBGEMM_OP_DISPATCH(
     CUDA,
     "permute_2D_sparse_data",
     fbgemm_gpu::permute_2D_sparse_data_cuda);
+FBGEMM_OP_DISPATCH(
+    CUDA,
+    "permute_2D_sparse_preallocated_out",
+    fbgemm_gpu::permute_2D_sparse_preallocated_out_cuda);
 FBGEMM_OP_DISPATCH(
     CUDA,
     "permute_2D_sparse_data_input1D",

--- a/fbgemm_gpu/test/sparse/failures_dict.json
+++ b/fbgemm_gpu/test/sparse/failures_dict.json
@@ -106,7 +106,18 @@
       }
     },
     "fbgemm::permute_1D_sparse_data": {},
-    "fbgemm::permute_2D_sparse_data": {},
+    "fbgemm::permute_2D_sparse_data": {
+      "PermuteIndicesTest.test_aot_dispatch_dynamic__test_permute_indices_backward": {
+        "comment": "Not an op bug. The aot_autograd_check harness builds its test loss as `sm = 0; for o in outputs: sm += o.sum().abs()`. This op returns (int64 lengths, int64 indices, float weights) in that order, so sm becomes an int64 tensor from the integer outputs and the final `sm += weights.sum()` raises 'result type Float can't be cast to Long'. The op's backward is never reached, and real torch.compile/autograd (which sums only the user's float loss) is unaffected. Marked skip (not xfail) so it does not falsely flag the forward-PT2-compliant op via test_pt2_compliant_tag. Eager backward correctness is covered by test_permute_indices_backward.",
+        "status": "skip"
+      }
+    },
+    "fbgemm::permute_2D_sparse_preallocated_out": {
+      "PermuteIndicesTest.test_aot_dispatch_dynamic__test_permute_indices_with_preallocated_output": {
+        "comment": "Functionalization (AOTAutograd / torch.compile) does not support custom ops whose outputs carry alias annotations; here the returned tensors alias the pre-allocated input buffers (Tensor(a!)/(b!)/(c!)). This op targets the eager input-distribution path, not torch.compile, consistent with other fbgemm ops that xfail test_aot_dispatch_dynamic.",
+        "status": "xfail"
+      }
+    },
     "fbgemm::permute_sequence_embeddings": {
       "PermuteEmbeddingsTest.test_aot_dispatch_dynamic__test_permute_embeddings": {
         "comment": "",

--- a/fbgemm_gpu/test/sparse/permute_indices_test.py
+++ b/fbgemm_gpu/test/sparse/permute_indices_test.py
@@ -1016,6 +1016,239 @@ class PermuteIndicesTest(unittest.TestCase):
         torch.testing.assert_close(permuted_indices_gpu.cpu(), permuted_indices_cpu)
         self.assertIsNone(permuted_weights_gpu)
 
+    @given(
+        B=st.integers(min_value=1, max_value=20),
+        T=st.integers(min_value=1, max_value=20),
+        L=st.integers(min_value=2, max_value=20),
+        long_index=st.booleans(),
+        has_weight=st.booleans(),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    def test_permute_indices_with_preallocated_output(
+        self,
+        B: int,
+        T: int,
+        L: int,
+        long_index: bool,
+        has_weight: bool,
+    ) -> None:
+        """
+        Test permute_2D_sparse_preallocated_out with pre-allocated output tensors.
+
+        Verifies that passing pre-allocated output buffers via the optional
+        permuted_lengths_out, permuted_indices_out, and permuted_weights_out
+        parameters produces the same results as the default allocation path
+        (permute_2D_sparse_data), and that the returned tensors share storage
+        with the pre-allocated buffers.
+        """
+        index_dtype = torch.int64 if long_index else torch.int32
+        lengths = torch.randint(low=1, high=L, size=(T, B)).type(index_dtype)
+        total = int(lengths.sum().item())
+        weights = torch.rand(total).float() if has_weight else None
+        indices = torch.randint(
+            low=1,
+            high=int(1e5),
+            size=(total,),
+        ).type(index_dtype)
+
+        permute_list = list(range(T))
+        random.shuffle(permute_list)
+        permute = torch.IntTensor(permute_list)
+
+        # Reference: default allocation path (no pre-allocated outputs)
+        (
+            permuted_lengths_ref,
+            permuted_indices_ref,
+            permuted_weights_ref,
+        ) = torch.ops.fbgemm.permute_2D_sparse_data(
+            permute, lengths, indices, weights, None
+        )
+
+        # Pre-allocate output tensors on CPU
+        permuted_lengths_out = torch.empty(T, B, dtype=index_dtype)
+        permuted_indices_out = torch.empty(total, dtype=index_dtype)
+        permuted_weights_out = (
+            torch.empty(total, dtype=torch.float) if has_weight else None
+        )
+
+        (
+            permuted_lengths_cpu,
+            permuted_indices_cpu,
+            permuted_weights_cpu,
+        ) = torch.ops.fbgemm.permute_2D_sparse_preallocated_out(
+            permute,
+            lengths,
+            indices,
+            weights,
+            None,
+            permuted_lengths_out,
+            permuted_indices_out,
+            permuted_weights_out,
+        )
+
+        # Verify correctness
+        torch.testing.assert_close(permuted_lengths_cpu, permuted_lengths_ref)
+        torch.testing.assert_close(permuted_indices_cpu, permuted_indices_ref)
+        if has_weight:
+            torch.testing.assert_close(permuted_weights_cpu, permuted_weights_ref)
+        else:
+            self.assertIsNone(permuted_weights_cpu)
+
+        # Verify returned tensors share storage with pre-allocated buffers
+        self.assertTrue(
+            permuted_lengths_cpu.data_ptr() == permuted_lengths_out.data_ptr()
+        )
+        self.assertTrue(
+            permuted_indices_cpu.data_ptr() == permuted_indices_out.data_ptr()
+        )
+        if has_weight:
+            self.assertIsNotNone(permuted_weights_cpu)
+            # pyre-ignore[16]
+            self.assertTrue(
+                permuted_weights_cpu.data_ptr()
+                # pyre-ignore[16]
+                == permuted_weights_out.data_ptr()
+            )
+
+        # GPU test
+        if gpu_available:
+            weights_cuda = (
+                weights.cuda() if (has_weight and weights is not None) else None
+            )
+            permuted_lengths_out_gpu = torch.empty(
+                T, B, dtype=index_dtype, device=torch.accelerator.current_accelerator()
+            )
+            permuted_indices_out_gpu = torch.empty(
+                total, dtype=index_dtype, device=torch.accelerator.current_accelerator()
+            )
+            permuted_weights_out_gpu = (
+                torch.empty(
+                    total,
+                    dtype=torch.float,
+                    device=torch.accelerator.current_accelerator(),
+                )
+                if has_weight
+                else None
+            )
+
+            (
+                permuted_lengths_gpu,
+                permuted_indices_gpu,
+                permuted_weights_gpu,
+            ) = torch.ops.fbgemm.permute_2D_sparse_preallocated_out(
+                permute.cuda(),
+                lengths.cuda(),
+                indices.cuda(),
+                weights_cuda,
+                None,
+                permuted_lengths_out_gpu,
+                permuted_indices_out_gpu,
+                permuted_weights_out_gpu,
+            )
+
+            # Verify correctness
+            torch.testing.assert_close(permuted_lengths_gpu.cpu(), permuted_lengths_ref)
+            torch.testing.assert_close(permuted_indices_gpu.cpu(), permuted_indices_ref)
+            if has_weight:
+                torch.testing.assert_close(
+                    permuted_weights_gpu.cpu(), permuted_weights_ref
+                )
+            else:
+                self.assertIsNone(permuted_weights_gpu)
+
+            # Verify returned tensors share storage with pre-allocated buffers
+            self.assertTrue(
+                permuted_lengths_gpu.data_ptr() == permuted_lengths_out_gpu.data_ptr()
+            )
+            self.assertTrue(
+                permuted_indices_gpu.data_ptr() == permuted_indices_out_gpu.data_ptr()
+            )
+            if has_weight:
+                self.assertIsNotNone(permuted_weights_gpu)
+                # pyre-ignore[16]
+                self.assertTrue(
+                    permuted_weights_gpu.data_ptr()
+                    # pyre-ignore[16]
+                    == permuted_weights_out_gpu.data_ptr()
+                )
+
+    @given(
+        B=st.integers(min_value=1, max_value=20),
+        T=st.integers(min_value=1, max_value=20),
+        L=st.integers(min_value=2, max_value=20),
+        long_index=st.booleans(),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    def test_permute_indices_backward(
+        self,
+        B: int,
+        T: int,
+        L: int,
+        long_index: bool,
+    ) -> None:
+        """
+        Verify autograd flows through permute_2D_sparse_data to the float
+        `weights` input on both CPU and GPU.
+
+        The op is a per-feature segment permutation, i.e. linear in `weights`,
+        so the gradient w.r.t. `weights` is the inverse permutation applied to
+        the upstream gradient. The expected gradient is computed independently
+        via permute_indices_ref_ with the inverse permute (not via the op's own
+        registered backward), so this also guards the wrapper refactor that
+        routes permute_2D_sparse_data through the shared implementation.
+        """
+        index_dtype = torch.int64 if long_index else torch.int32
+        lengths: torch.Tensor = torch.randint(low=1, high=L, size=(T, B)).type(
+            index_dtype
+        )
+        total: int = int(lengths.sum().item())
+        indices: torch.Tensor = torch.randint(low=1, high=int(1e5), size=(total,)).type(
+            index_dtype
+        )
+
+        permute_list = list(range(T))
+        random.shuffle(permute_list)
+        permute: torch.Tensor = torch.IntTensor(permute_list)
+
+        # Independent inverse permutation (not torch.ops.fbgemm.invert_permute).
+        inv_permute: torch.Tensor = torch.empty_like(permute)
+        inv_permute[permute.long()] = torch.arange(T, dtype=permute.dtype)
+
+        def check(device: str) -> None:
+            weights = torch.rand(
+                total, dtype=torch.float, device=device, requires_grad=True
+            )
+            (
+                permuted_lengths,
+                permuted_indices,
+                permuted_weights,
+            ) = torch.ops.fbgemm.permute_2D_sparse_data(
+                permute.to(device),
+                lengths.to(device),
+                indices.to(device),
+                weights,
+                None,
+            )
+            upstream = torch.rand_like(permuted_weights)
+            permuted_weights.backward(upstream)
+
+            # Reference grad: inverse-permute the upstream gradient back to the
+            # original `weights` layout.
+            _, _, expected_grad = permute_indices_ref_(
+                permuted_lengths.cpu(),
+                permuted_indices.cpu(),
+                upstream.cpu(),
+                # pyre-ignore[6]
+                inv_permute.long(),
+            )
+            self.assertIsNotNone(weights.grad)
+            # pyre-ignore[16]
+            torch.testing.assert_close(weights.grad.cpu(), expected_grad)
+
+        check("cpu")
+        if gpu_available:
+            check("cuda")
+
 
 extend_test_class(PermuteIndicesTest)
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/meta-pytorch/torchrec/pull/3846

X-link: https://github.com/facebookresearch/FBGEMM/pull/2435

## 1. Context

In TrainPipelineSparseDist, input distribution runs on a separate data_dist_stream. Memory snapshot analysis revealed that KJT allocations happen inside `permute_2D_sparse_data` (called from jagged_tensor.py). These allocations on data_dist_stream require record_stream when the tensors are later consumed on the default stream, which delays memory reclamation by the CUDA caching allocator.

By letting callers pass in pre-allocated output buffers (allocated on the main stream before switching to data_dist_stream), we eliminate the cross-stream allocation and the need for record_stream, so the output's memory can be reused by other ops on the main stream.

<img width="1862" height="918" alt="image" src="https://github.com/user-attachments/assets/c16b55f2-7b1c-47d9-8f17-93649e9e2ed7" />

## 2. Approach

The zero-copy path needs the operator's returned tensors to alias the caller's pre-allocated buffers. That aliasing cannot be added to `permute_2D_sparse_data` itself: it has a registered autograd formula, and register_autograd requires a functional (non-mutating, non-aliasing) operator -- declaring Tensor(a!) aliasing on it fails at import. So instead of overloading the existing differentiable op, this diff adds a separate, non-differentiable operator.

1. **New op `permute_2D_sparse_preallocated_out`**: takes three optional buffers (permuted_lengths_out, permuted_indices_out, permuted_weights_out). When provided, the op writes into them and returns tensors aliasing them; when omitted it allocates as usual. The schema declares the aliasing honestly with Tensor(a!) / Tensor(b!) / Tensor(c!) annotations on both the optional buffers and the corresponding returns. No autograd formula is registered.
2. **The existing op is unchanged**: `permute_2D_sparse_data` keeps the same functional 5-arg schema, autograd, and behavior as before.
3. **Shared implementation (no duplicated logic)**: the existing kernel bodies (CPU, CUDA, meta) were renamed to the preallocated-out variants and now hold the use-buffer-if-provided logic. The original entry points became thin wrappers that delegate to them with no buffers, so the permutation logic lives in exactly one place.
4. **No torch.compile support for the new op**: functionalization (AOTAutograd) does not support custom ops whose outputs carry alias annotations, so its aot dispatch opcheck is marked xfail (the new op targets the eager input-distribution path, consistent with many other FBGEMM ops). The schema opcheck passes for real.
5. **CPU only / CUDA only**: the new op is registered for CPU and CUDA; no MTIA backend is added.

## 3. Results

* benchmark (H100, num_features=170, batch_size=128, mean_pooling_factor=50): the microbenchmark runs single-stream, so it does not exercise the multi-stream data_dist_stream scenario where the memory saving materializes; run-to-run runtime variation is also too large to draw a runtime conclusion. It confirms the new op produces the same results as the existing op, and the memory snapshots below show the allocation-pattern difference.

* repro command
```
buck2 run @fbcode//mode/opt fbcode//torchrec/sparse/tests:permute_2d_benchmark -- \
  --num_features=170 --batch_size=128 --mean_pooling_factor=50
```

<img width="4782" height="1948" alt="image" src="https://github.com/user-attachments/assets/b446f44b-0105-4274-a546-4372abc5459a" />

Top: `permute_2D_sparse_data`; bottom: `permute_2D_sparse_preallocated_out`. The traces are intentionally identical -- the GPU kernel is unchanged. The optimization is host-side allocation and cross-stream memory lifetime (dropping record_stream), which a single-stream kernel trace does not capture.

<img width="5078" height="1630" alt="image" src="https://github.com/user-attachments/assets/cb5a65dd-20a4-4477-a28f-d01822285d18" />

<img width="5098" height="1638" alt="image" src="https://github.com/user-attachments/assets/1eab8366-b2a0-42be-adad-47c012d623bf" />

Memory snapshots over the 10 benchmark iterations (single-stream). Top (`permute_2D_sparse_data`): the output buffer is allocated and freed on every iteration -- the repeated transient blocks. Bottom (`permute_2D_sparse_preallocated_out`): the buffer is allocated once and persists, reused across all iterations -- no per-iteration allocation. Single-stream peak memory is comparable; in the multi-stream path the per-iteration allocation is what forces record_stream and blocks reuse, which the persistent buffer avoids.

## 4. Analysis

1. **Backward compatibility**: `permute_2D_sparse_data` (and its legacy alias, the input1D variant, permute_sequence_embeddings, and all TorchRec call sites) are untouched. The optimization is purely additive via the new op.
2. **Why a separate op**: aliasing plus mutation on an op that has a registered autograd formula is rejected by PyTorch (autograd registration requires a functional schema). The buffers are write-only outputs that never participate in gradients, so a dedicated non-differentiable op is the correct model rather than a compromise.
3. **Refactor is autograd-safe**: `permute_2D_sparse_data` now delegates to the shared implementation, but its autograd is registered at the op level (unchanged) and its forward is verified by the existing tests. A new backward test additionally checks that gradients still flow correctly to the weights on CPU and GPU, against an independent inverse-permute reference.
4. **GPU runtime unchanged**: the CUDA kernel is identical -- only the host-side allocation is skipped.
5. **No validation on pre-allocated buffers**: the op trusts callers to provide correctly sized buffers, consistent with other out-variant patterns in PyTorch/FBGEMM, avoiding runtime overhead.

## 5. Changes

1. **sparse_ops_cpu.cpp**: Added the `permute_2D_sparse_preallocated_out` schema (with the alias annotations) and CPU dispatch. Renamed the implementation body to the preallocated-out variant; the original CPU entry point is now a thin wrapper that delegates with no buffers.
2. **sparse_permute_2d.cu**: Same split on the CUDA side -- the preallocated-out variant holds the logic, the original entry point delegates; added the CUDA dispatch for the new op.
3. **sparse_ops.h**: Added declarations for the new CPU/CUDA entry points; the original declarations are back to the 5-arg form.
4. **sparse_ops.py**: Added the meta implementation for the new op (conditional allocation) and registered its fake impl; the original meta delegates to it. No autograd registered for the new op.
5. **permute_indices_test.py**: Added test_permute_indices_with_preallocated_output (correctness + zero-copy verification on CPU/GPU against the new op) and test_permute_indices_backward (gradient check for `permute_2D_sparse_data` on CPU/GPU against an independent inverse-permute reference).
6. **failures_dict.json**: two entries -- (a) xfail for the new op's aot dispatch opcheck (functionalization does not support alias-annotated custom-op outputs); (b) skip for the backward test's aot dispatch opcheck. The latter is not an op bug: the aot_autograd_check harness builds its loss by summing all outputs, so the op's leading int64 outputs make the accumulator int64 and the trailing add of the float weights raises "result type Float can't be cast to Long"; the op's backward is never reached and real torch.compile/autograd is unaffected. Skip (not xfail) is used so it does not falsely flag the forward-PT2-compliant op.
7. **permute_2d_benchmark.py** (new) and **torchrec/sparse/tests/BUCK**: benchmark comparing default vs pre-allocated paths (calls the new op), plus its python_binary target.

Reviewed By: q10

Differential Revision: D95757955


