### PR TITLE
Add configurable IGR enrichment support for DRAM KV embedding cache (#5463)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -233,6 +233,19 @@ class EvictionPolicy(NamedTuple):
             )
 
 
+class EnrichmentPolicy(NamedTuple):
+    # Model and method identifier, e.g. "igr_laser_embedding", "igr_laser_sid"
+    enrichment_type: str = ""
+    # External provider name (e.g. Laser provider name)
+    provider_name: str = ""
+    # Client identifier for the external service
+    client_id: str = ""
+    # Dimension of data returned by the source
+    enrichment_dim: int = 0
+    # Deserialization format: "json", "thrift_float", "thrift_int64"
+    response_format: str = "json"
+
+
 class KVZCHParams(NamedTuple):
     # global bucket id start and global bucket id end offsets for each logical table,
     # where start offset is inclusive and end offset is exclusive
@@ -250,6 +263,8 @@ class KVZCHParams(NamedTuple):
     load_ckpt_without_opt: bool = False
     optimizer_type_for_st: Optional[str] = None
     optimizer_state_dtypes_for_st: Optional[FrozenSet[Tuple[str, int]]] = None
+    # Enrichment config for embedding cache enrichment from external sources
+    enrichment_policy: Optional[EnrichmentPolicy] = None
 
     def validate(self) -> None:
         assert len(self.bucket_offsets) == len(self.bucket_sizes), (

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -217,6 +217,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         self.enable_optimizer_offloading: bool = False
         self.backend_return_whole_row: bool = False
         self._embedding_cache_mode: bool = False
+        self._enrichment_enabled: bool = False
         self.load_ckpt_without_opt: bool = False
         if self.kv_zch_params:
             self.kv_zch_params.validate()
@@ -249,6 +250,8 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 assert self.optimizer in [
                     OptimType.EXACT_ROWWISE_ADAGRAD
                 ], f"only EXACT_ROWWISE_ADAGRAD supports embedding cache mode, but got {self.optimizer}"
+            # pyre-ignore [16]
+            self._enrichment_enabled = self.kv_zch_params.enrichment_policy is not None
             if self.load_ckpt_without_opt:
                 if (
                     # pyre-ignore [16]
@@ -766,6 +769,21 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                     eviction_policy.interval_for_sufficient_eviction_s,
                     eviction_policy.interval_for_feature_statistics_decay_s,
                 )
+            enrichment_config = None
+            if self.kv_zch_params and self.kv_zch_params.enrichment_policy is not None:
+                ep = self.kv_zch_params.enrichment_policy
+                if ep.enrichment_type is None:
+                    raise ValueError(
+                        "enrichment_policy is set but enrichment_type is None. "
+                        "Please specify a valid EnrichmentType."
+                    )
+                enrichment_config = torch.classes.fbgemm.EnrichmentConfig(
+                    ep.enrichment_type,
+                    ep.provider_name,
+                    ep.client_id,
+                    ep.enrichment_dim,
+                    ep.response_format,
+                )
             self._ssd_db = torch.classes.fbgemm.DramKVEmbeddingCacheWrapper(
                 self.cache_row_dim,
                 ssd_uniform_init_lower,
@@ -789,6 +807,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 self.res_params.table_names,
                 self.res_params.table_offsets,
                 self.res_params.table_sizes,
+                enrichment_config,  # enrichment_config
             )
         else:
             raise AssertionError(f"Invalid backend type {self.backend_type}")
@@ -801,6 +820,8 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         self.ssd_memcpy_stream = torch.cuda.Stream(priority=low_priority)
         # GPU stream for async metadata operation
         self.feature_score_stream = torch.cuda.Stream(priority=low_priority)
+        # GPU stream for embedding cache
+        self.enrichment_query_stream = torch.cuda.Stream(priority=low_priority)
 
         # SSD get completion event
         self.ssd_event_get = torch.cuda.Event()
@@ -1231,7 +1252,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             row_count,
             self.cache_row_dim,
             dtype=self.weights_precision.as_dtype(),
-            device="cuda",
+            device=torch.accelerator.current_accelerator(),
         )
         cpu_tensor = torch.empty_like(chunk_tensor, device="cpu")
         for row_offset in range(0, total_dim0, row_count):
@@ -1595,16 +1616,19 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                     blocking_tensor_copy=True,
                     name="scratch_pad",
                 )
-            self.evict(
-                rows=inserted_rows,
-                indices_cpu=post_bwd_evicted_indices_cpu,
-                actions_count_cpu=actions_count_cpu,
-                stream=self.ssd_eviction_stream,
-                pre_event=self.ssd_event_backward,
-                post_event=self.ssd_event_sp_evict,
-                is_rows_uvm=True,
-                name="scratch_pad",
-            )
+            # Embedding cache mode skips eviction since DRAM cache handles
+            # its own lifecycle; eviction only applies to RocksDB-backed TBE.
+            if not self._embedding_cache_mode:
+                self.evict(
+                    rows=inserted_rows,
+                    indices_cpu=post_bwd_evicted_indices_cpu,
+                    actions_count_cpu=actions_count_cpu,
+                    stream=self.ssd_eviction_stream,
+                    pre_event=self.ssd_event_backward,
+                    post_event=self.ssd_event_sp_evict,
+                    is_rows_uvm=True,
+                    name="scratch_pad",
+                )
 
             if self.prefetch_stream:
                 self.prefetch_stream.wait_stream(current_stream)
@@ -1881,7 +1905,11 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             # number of rows in `lxu_cache_evicted_weights` might be smaller
             # than the number of elements in `evicted_indices`. Without this
             # step, we can run into the index out of bound issue
-            current_stream.wait_event(self.ssd_event_cache_evict)
+            # NOTE: In embedding_cache_mode, evict() is skipped (see below), so
+            # ssd_event_cache_evict is never recorded. Skip waiting for it to
+            # avoid latency accumulation.
+            if not self._embedding_cache_mode:
+                current_stream.wait_event(self.ssd_event_cache_evict)
             torch.ops.fbgemm.compact_indices(
                 compact_indices=[
                     self.lxu_cache_evicted_indices,
@@ -2179,8 +2207,23 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 use_pipeline=self.prefetch_pipeline,
             )
 
+            # When enrichment is enabled, invalidate L1 slots that received all-zero
+            # rows from DRAM so they will be re-fetched next prefetch
+            if self._enrichment_enabled:
+                n = actions_count_gpu.item()
+                if n > 0:
+                    slots = assigned_cache_slots[:n]
+                    valid_mask = slots >= 0
+                    if valid_mask.any():
+                        valid_slots = slots[valid_mask]
+                        rows = self.lxu_cache_weights[valid_slots]
+                        zero_rows = (rows == 0).all(dim=1)
+                        if zero_rows.any():
+                            zero_slots = valid_slots[zero_rows]
+                            self.lxu_cache_state.view(-1)[zero_slots] = -1
+
             if self.training:
-                if linear_cache_indices.numel() > 0:
+                if linear_cache_indices.numel() > 0 and not self._embedding_cache_mode:
                     # Evict rows from cache to SSD
                     self.evict(
                         rows=self.lxu_cache_evicted_weights,
@@ -3687,6 +3730,38 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             # for eval mode, we should not write anything to embedding
             return
 
+        if self._enrichment_enabled:
+            # When enrichment is enabled, reset cache state for slots where weights are all zeros
+            active_slots_mask = self.lxu_cache_state != -1
+            if active_slots_mask.any():
+                # Get flat indices of active slots
+                active_flat_indices = active_slots_mask.view(-1).nonzero(as_tuple=True)[
+                    0
+                ]
+                # Get weights for active slots
+                active_weights_for_check = self.lxu_cache_weights[
+                    active_flat_indices
+                ].view(-1, self.cache_row_dim)
+                # Defensive check: zero-weight rows can appear when an async
+                # enrichment write hasn't completed yet, or when a cache slot
+                # was allocated but the backend returned no data. The -1 index
+                # guards against empty slots, but occupied slots may still
+                # hold stale all-zero weights that need invalidation.
+                zero_weight_mask = (active_weights_for_check == 0).all(dim=1)
+
+                if zero_weight_mask.any():
+                    # Get indices of slots with zero weights
+                    zero_weight_indices = active_flat_indices[zero_weight_mask]
+                    num_reset = zero_weight_indices.numel()
+                    logging.info(
+                        f"[flush] Resetting {num_reset} cache slots with zero weights"
+                    )
+                    # Reset state to -1 for zero weight entries
+                    self.lxu_cache_state.view(-1)[zero_weight_indices] = -1
+                    # Reset weights to 0 (already zero, but ensure consistency)
+                    self.lxu_cache_weights[zero_weight_indices] = 0
+            return
+
         if self.step == self.last_flush_step and not force:
             logging.info(
                 f"SSD TBE has been flushed at {self.last_flush_step=} already for tbe:{self.tbe_unique_id}"
@@ -4950,3 +5025,66 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         Reset the inference mode
         """
         self.eval()
+
+    def enrichment_query_id(
+        self,
+        indices: torch.Tensor,
+        offsets: torch.Tensor,
+        weights: torch.Tensor,
+    ) -> None:
+        assert (
+            self._enrichment_enabled
+        ), "Must be in _enrichment_enabled to support direct_write_embedding method."
+        with record_function(f"## enrichment_query_id_{self.tbe_unique_id} ##"):
+            with torch.no_grad():
+                # Run all GPU operations on enrichment_query_stream to avoid
+                # CUDA driver mutex contention with the main training stream
+                with torch.cuda.stream(self.enrichment_query_stream):
+                    self.enrichment_query_stream.wait_stream(
+                        torch.cuda.current_stream()
+                    )  # wait for input tensors to be ready
+
+                    B_offsets = None
+                    max_B = -1
+
+                    # Step 1: Linearize original indices first (with correct offsets)
+                    linear_cache_indices = torch.ops.fbgemm.linearize_cache_indices(
+                        self.hash_size_cumsum,
+                        indices,
+                        offsets,
+                        B_offsets,
+                        max_B,
+                    )
+                    weights_flat = weights.contiguous().view(torch.int64).flatten()
+
+                    # Step 2: Dedup on linearized indices
+                    sorted_linear_indices, idx = torch.sort(linear_cache_indices)
+                    sorted_weights = weights_flat[idx]
+                    mask = torch.ones_like(sorted_linear_indices, dtype=torch.bool)
+                    mask[1:] = sorted_linear_indices[1:] != sorted_linear_indices[:-1]
+                    dedup_linear_indices = sorted_linear_indices[mask]
+                    dedup_weights = sorted_weights[mask]
+
+                    if len(self.ssd_scratch_pad_eviction_data) > 0:
+                        # IMPORTANT: Clear ALL accumulated scratch pad data, not just one!
+                        # _prefetch appends one element per forward, but enrichment_query_id
+                        # may not be called every forward. This prevents memory leak from
+                        # accumulated GPU tensors (inserted_rows is a UVA tensor).
+                        self.ssd_scratch_pad_eviction_data.clear()
+
+                    # D2H copy on the same stream (already on enrichment_query_stream)
+                    linear_cache_indices_cpu = self.to_pinned_cpu(dedup_linear_indices)
+                    dedup_weights_cpu = self.to_pinned_cpu(dedup_weights)
+
+                    with record_function("## set_embedding_cache_enrich_query_id ##"):
+                        self.record_function_via_dummy_profile(
+                            "## set_embedding_cache_enrich_query_id ##",
+                            self.ssd_db.set_embedding_cache_enrich_query_id_cuda,
+                            linear_cache_indices_cpu,
+                            dedup_weights_cpu,
+                            torch.tensor(
+                                [linear_cache_indices_cpu.shape[0]],
+                                device="cpu",
+                                dtype=torch.long,
+                            ),
+                        )

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
@@ -17,19 +17,24 @@
 #include <folly/coro/Invoke.h>
 #include <folly/coro/Task.h>
 #include <folly/executors/FunctionScheduler.h>
+#include <folly/gen/Base.h>
 #include <folly/logging/xlog.h>
 #include <servicerouter/client/cpp2/ServiceRouter.h>
-#include <thrift/lib/cpp2/protocol/CompactProtocol.h>
 #include <thrift/lib/cpp2/protocol/Serializer.h>
 #include <torch/script.h>
+#include <cmath>
+#include <random>
+#include <string_view>
 #include "common/time/Time.h"
 
 #include "../ssd_split_embeddings_cache/initializer.h"
 #include "../ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h"
 #include "SynchronizedShardedMap.h"
+#include "enrichment_config.h"
 #include "fbgemm_gpu/split_embeddings_cache/kv_db_cpp_utils.h"
 #include "feature_evict.h"
 #include "fixed_block_pool.h"
+#include "igr_enrichment.h"
 
 namespace kv_mem {
 
@@ -116,7 +121,9 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
       int64_t res_server_port = 0,
       std::vector<std::string> table_names = {},
       std::vector<int64_t> table_offsets = {},
-      std::vector<int64_t> table_sizes = {})
+      std::vector<int64_t> table_sizes = {},
+      std::optional<c10::intrusive_ptr<kv_mem::EnrichmentConfig>>
+          enrichment_config = std::nullopt)
       : kv_db::EmbeddingKVDB(
             num_shards,
             max_D,
@@ -147,6 +154,20 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
         is_training_(is_training) {
     executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(std::max<size_t>(
         num_threads, facebook::Proc::getCpuInfo().numCpuCores));
+    // Dedicated executor for enrichment (low priority, won't affect
+    // forward/backward). Only created when enrichment is configured.
+    if (enrichment_config.has_value()) {
+      enrichment_config_ = enrichment_config;
+      enrichment_executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(4);
+      // Pre-initialize LaserClient for IGR enrichment types
+      if (enrichment_config_.value()->enrichment_type_ ==
+              kv_mem::EnrichmentType::IGR_LASER_EMBEDDING ||
+          enrichment_config_.value()->enrichment_type_ ==
+              kv_mem::EnrichmentType::IGR_LASER_SID) {
+        laser_client_ =
+            igr_enrichment::initializeLaserClient(*enrichment_config_.value());
+      }
+    }
     initialize_initializers(
         num_shards,
         max_D,
@@ -532,6 +553,102 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
         });
   }
 
+  /// Separate write path for enrichment that runs on enrichment_executor_
+  /// instead of the main executor_. This avoids competing with forward/backward
+  /// for thread pool resources. Uses pause/resume to yield to fwd/bwd —
+  /// removing this and reusing the main write path causes QPS regression.
+  folly::SemiFuture<std::vector<folly::Unit>>
+  set_kv_db_async_on_enrichment_executor(
+      const at::Tensor& indices,
+      const at::Tensor& weights,
+      const at::Tensor& count) {
+    auto start_ts = facebook::WallClockUtil::NowInUsecFast();
+    std::vector<folly::Future<folly::Unit>> futures;
+    auto shardid_to_indexes = shard_input(indices, count);
+
+    for (auto iter = shardid_to_indexes.begin();
+         iter != shardid_to_indexes.end();
+         iter++) {
+      const auto shard_id = iter->first;
+      const auto indexes = iter->second;
+      futures.emplace_back(
+          folly::via(enrichment_executor_.get())
+              .thenValue([this, shard_id, indexes, indices, weights](
+                             folly::Unit) {
+                FBGEMM_DISPATCH_INTEGRAL_TYPES(
+                    indices.scalar_type(),
+                    "dram_kv_set_laser",
+                    [this, shard_id, indexes, &indices, &weights] {
+                      using index_t = scalar_t;
+                      CHECK(indices.is_contiguous());
+                      CHECK(weights.is_contiguous());
+                      CHECK_EQ(indices.size(0), weights.size(0));
+                      int64_t stride = weights.size(1);
+                      auto indices_data_ptr = indices.data_ptr<index_t>();
+                      auto weights_data_ptr = weights.data_ptr<weight_type>();
+
+                      // Two-level loop like eviction pattern:
+                      // Outer loop: check pause/resume
+                      // Inner loop: process batch while holding lock
+                      size_t cursor = 0;
+                      size_t total = indexes.size();
+                      while (cursor < total) {
+                        // Wait until resume if paused (like eviction pattern)
+                        wait_until_laser_write_resume();
+
+                        // Process batch while holding lock
+                        {
+                          auto wlmap = kv_store_.by(shard_id).wlock();
+                          auto* pool = kv_store_.pool_by(shard_id);
+                          while (cursor < total) {
+                            const auto& id_index = indexes[cursor];
+                            auto id = int64_t(indices_data_ptr[id_index]);
+                            weight_type* block = nullptr;
+                            auto it = wlmap->find(id);
+                            if (it != wlmap->end()) {
+                              block = it->second;
+                            } else {
+                              // Key doesn't exist, allocate new block and
+                              // insert
+                              block = pool->template allocate_t<weight_type>();
+                              if (block == nullptr) {
+                                cursor++;
+                                continue; // Skip if allocation fails
+                              }
+                              FixedBlockPool::set_key(block, id);
+                              wlmap->insert({id, block});
+                            }
+                            auto* data_ptr =
+                                FixedBlockPool::data_ptr<weight_type>(block);
+                            std::copy(
+                                weights_data_ptr + id_index * stride,
+                                weights_data_ptr + (id_index + 1) * stride,
+                                data_ptr);
+                            cursor++;
+                            // Check if we should pause and yield lock
+                            if (is_laser_write_interrupted()) {
+                              break;
+                            }
+                          }
+                        }
+                        // Lock released here, forward/backward can proceed
+                      }
+                    });
+                return folly::Unit{};
+              }));
+    }
+    return folly::collect(std::move(futures))
+        .via(enrichment_executor_.get())
+        .thenValue([start_ts](const std::vector<folly::Unit>& results) {
+          auto latency_ms =
+              (facebook::WallClockUtil::NowInUsecFast() - start_ts) / 1000;
+          XLOG(INFO)
+              << "[EmbeddingCacheEnrich] set_kv_db_async_on_enrichment_executor "
+              << "completed, latency_ms=" << latency_ms;
+          return results;
+        });
+  }
+
   folly::SemiFuture<std::vector<folly::Unit>> inference_set_kv_db_async(
       const at::Tensor& indices,
       const at::Tensor& weights,
@@ -679,6 +796,277 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
               }
               return std::vector<folly::Unit>(tuples.size());
             });
+  }
+
+  void set_embedding_cache_enrich_query_id_async(
+      at::Tensor hashed_indices,
+      at::Tensor unhashed_indices,
+      at::Tensor count) override {
+    if (!enrichment_config_.has_value()) {
+      return;
+    }
+    // Drop mechanism: atomically check-and-set to ensure only one request
+    // proceeds. This prevents task accumulation and keeps QPS stable.
+    // Using compare_exchange_strong to atomically set flag at function entry,
+    // not inside lambda (which would be too late and cause race condition).
+    bool expected = false;
+    if (!laser_write_in_progress_.compare_exchange_strong(expected, true)) {
+      XLOG(INFO)
+          << "[EmbeddingCacheEnrich] skipping - laser write already in progress";
+      return;
+    }
+    // Now laser_write_in_progress_ = true, other requests will be dropped
+
+    // Fire and forget - run entire operation in background using dedicated
+    // enrichment_executor_ This ensures Laser enrichment doesn't compete with
+    // forward/backward for threads
+    folly::via(
+        enrichment_executor_.get(),
+        [this,
+         hashed_indices = std::move(hashed_indices),
+         unhashed_indices = std::move(unhashed_indices),
+         count = std::move(count)]() {
+          std::vector<folly::Future<
+              std::tuple<int64_t, std::vector<int64_t>, std::vector<int64_t>>>>
+              futures;
+          auto shardid_to_indexes = shard_input(hashed_indices, count);
+          for (auto iter = shardid_to_indexes.begin();
+               iter != shardid_to_indexes.end();
+               iter++) {
+            const auto shard_id = iter->first;
+            const auto indexes = iter->second;
+            auto f =
+                folly::via(enrichment_executor_.get())
+                    .thenValue([this,
+                                shard_id,
+                                indexes,
+                                hashed_indices,
+                                unhashed_indices](folly::Unit) {
+                      int64_t zero_id_count = 0;
+                      std::vector<int64_t> zero_weight_hashed_ids;
+                      std::vector<int64_t> zero_weight_unhashed_ids;
+                      FBGEMM_DISPATCH_INTEGRAL_TYPES(
+                          hashed_indices.scalar_type(),
+                          "dram_set_embedding_cache_enrich_query_id",
+                          [this,
+                           shard_id,
+                           indexes,
+                           hashed_indices,
+                           unhashed_indices,
+                           &zero_id_count,
+                           &zero_weight_hashed_ids,
+                           &zero_weight_unhashed_ids] {
+                            using index_t = scalar_t;
+                            CHECK(hashed_indices.is_contiguous());
+                            CHECK(unhashed_indices.is_contiguous());
+                            CHECK_EQ(
+                                hashed_indices.size(0),
+                                unhashed_indices.size(0));
+                            auto hashed_indices_data_ptr =
+                                hashed_indices.data_ptr<index_t>();
+                            auto unhashed_indices_data_ptr =
+                                unhashed_indices.data_ptr<index_t>();
+                            int64_t in_cache_zero_count = 0;
+                            int64_t not_in_cache_count = 0;
+                            {
+                              auto rlmap = kv_store_.by(shard_id).rlock();
+
+                              for (auto index_iter = indexes.begin();
+                                   index_iter != indexes.end();
+                                   index_iter++) {
+                                const auto& id_index = *index_iter;
+                                auto hashed_id =
+                                    int64_t(hashed_indices_data_ptr[id_index]);
+                                auto unhashed_id = int64_t(
+                                    unhashed_indices_data_ptr[id_index]);
+                                auto it = rlmap->find(hashed_id);
+                                if (it != rlmap->end()) {
+                                  weight_type* block = it->second;
+                                  if (FixedBlockPool::is_weights_all_zero(
+                                          block, block_size_)) {
+                                    zero_weight_hashed_ids.push_back(hashed_id);
+                                    zero_weight_unhashed_ids.push_back(
+                                        unhashed_id);
+                                    zero_id_count++;
+                                    in_cache_zero_count++;
+                                  }
+                                } else {
+                                  // Id not in kv_store (was filled from
+                                  // row_storage in get_kv_db_async)
+                                  zero_weight_hashed_ids.push_back(hashed_id);
+                                  zero_weight_unhashed_ids.push_back(
+                                      unhashed_id);
+                                  zero_id_count++;
+                                  not_in_cache_count++;
+                                }
+                              }
+                            }
+                            if (shard_id == 0) {
+                              XLOG(INFO)
+                                  << "[EmbeddingCacheEnrich] shard_0: "
+                                  << "total=" << indexes.size()
+                                  << ", in_cache_zero=" << in_cache_zero_count
+                                  << ", not_in_cache=" << not_in_cache_count;
+                            }
+                          });
+                      return std::make_tuple(
+                          zero_id_count,
+                          std::move(zero_weight_hashed_ids),
+                          std::move(zero_weight_unhashed_ids));
+                    });
+            futures.push_back(std::move(f));
+          }
+          folly::collect(std::move(futures))
+              .via(enrichment_executor_.get())
+              .thenValue([this](
+                             const std::vector<std::tuple<
+                                 int64_t,
+                                 std::vector<int64_t>,
+                                 std::vector<int64_t>>>& results) {
+                // Aggregate results from all shards
+                std::vector<int64_t> all_zero_weight_hashed_ids;
+                std::vector<int64_t> all_zero_weight_unhashed_ids;
+                for (const auto& result : results) {
+                  const auto& hashed_ids = std::get<1>(result);
+                  const auto& unhashed_ids = std::get<2>(result);
+                  all_zero_weight_hashed_ids.insert(
+                      all_zero_weight_hashed_ids.end(),
+                      hashed_ids.begin(),
+                      hashed_ids.end());
+                  all_zero_weight_unhashed_ids.insert(
+                      all_zero_weight_unhashed_ids.end(),
+                      unhashed_ids.begin(),
+                      unhashed_ids.end());
+                }
+
+                XLOG(INFO) << "[EmbeddingCacheEnrich] found "
+                           << all_zero_weight_unhashed_ids.size()
+                           << " zero_weight_ids, enrichment_type: "
+                           << static_cast<int64_t>(
+                                  enrichment_config_.value()->enrichment_type_)
+                           << ", pending_laser_requests: "
+                           << pending_laser_requests_.load();
+
+                // Skip if too many pending requests (avoid overwhelming
+                // the external source)
+                constexpr int64_t kMaxPendingLaserRequests = 2;
+                if (pending_laser_requests_.load() >=
+                    kMaxPendingLaserRequests) {
+                  XLOG(INFO)
+                      << "[EmbeddingCacheEnrich] skipping fetch, too many pending requests: "
+                      << pending_laser_requests_.load();
+                  laser_write_in_progress_.store(false);
+                  return;
+                }
+
+                // Fetch from external source for zero-weight IDs
+                if (!all_zero_weight_unhashed_ids.empty() &&
+                    enrichment_config_.has_value()) {
+                  XLOG(INFO) << "[EmbeddingCacheEnrich] starting fetch for "
+                             << all_zero_weight_unhashed_ids.size() << " IDs";
+
+                  pending_laser_requests_.fetch_add(1);
+
+                  // Dispatch to model-specific enrichment handler
+                  const auto enrichment_type =
+                      enrichment_config_.value()->enrichment_type_;
+
+                  if (enrichment_type ==
+                      kv_mem::EnrichmentType::IGR_LASER_EMBEDDING) {
+                    folly::coro::co_invoke(
+                        [this,
+                         hashed_ids = std::move(all_zero_weight_hashed_ids),
+                         unhashed_ids =
+                             std::move(all_zero_weight_unhashed_ids)]() mutable
+                            -> folly::coro::Task<void> {
+                          auto start_time =
+                              facebook::WallClockUtil::NowInUsecFast();
+                          auto embeddings =
+                              co_await igr_enrichment::fetchEmbeddingsFromLaser(
+                                  laser_client_,
+                                  *enrichment_config_.value(),
+                                  unhashed_ids);
+                          auto laser_latency_ms =
+                              (facebook::WallClockUtil::NowInUsecFast() -
+                               start_time) /
+                              1000;
+                          XLOG(INFO)
+                              << "[EmbeddingCacheEnrich] laser_hit: "
+                              << embeddings.size() << "/" << unhashed_ids.size()
+                              << ", latency_ms: " << laser_latency_ms;
+                          if (!embeddings.empty()) {
+                            auto result =
+                                igr_enrichment::prepareCacheWriteTensors<
+                                    weight_type>(
+                                    hashed_ids,
+                                    unhashed_ids,
+                                    embeddings,
+                                    max_D_);
+                            if (result.has_value()) {
+                              set_kv_db_async_on_enrichment_executor(
+                                  result->indices,
+                                  result->weights,
+                                  result->count);
+                            }
+                          }
+                          pending_laser_requests_.fetch_sub(1);
+                          laser_write_in_progress_.store(false);
+                        })
+                        .scheduleOn(enrichment_executor_.get())
+                        .start();
+                  } else if (
+                      enrichment_type ==
+                      kv_mem::EnrichmentType::IGR_LASER_SID) {
+                    folly::coro::co_invoke(
+                        [this,
+                         hashed_ids = std::move(all_zero_weight_hashed_ids),
+                         unhashed_ids =
+                             std::move(all_zero_weight_unhashed_ids)]() mutable
+                            -> folly::coro::Task<void> {
+                          auto start_time =
+                              facebook::WallClockUtil::NowInUsecFast();
+                          auto sid_map =
+                              co_await igr_enrichment::fetchSIDsFromLaser(
+                                  laser_client_,
+                                  *enrichment_config_.value(),
+                                  unhashed_ids);
+                          auto laser_latency_ms =
+                              (facebook::WallClockUtil::NowInUsecFast() -
+                               start_time) /
+                              1000;
+                          XLOG(INFO)
+                              << "[EmbeddingCacheEnrich] sid_hit: "
+                              << sid_map.size() << "/" << unhashed_ids.size()
+                              << ", latency_ms: " << laser_latency_ms;
+                          if (!sid_map.empty()) {
+                            auto result =
+                                igr_enrichment::prepareSIDCacheWriteTensors(
+                                    hashed_ids, unhashed_ids, sid_map, max_D_);
+                            if (result.has_value()) {
+                              set_kv_db_async_on_enrichment_executor(
+                                  result->indices,
+                                  result->weights,
+                                  result->count);
+                            }
+                          }
+                          pending_laser_requests_.fetch_sub(1);
+                          laser_write_in_progress_.store(false);
+                        })
+                        .scheduleOn(enrichment_executor_.get())
+                        .start();
+                  } else {
+                    XLOG(WARN)
+                        << "[EmbeddingCacheEnrich] unknown enrichment_type: "
+                        << static_cast<int64_t>(enrichment_type);
+                    pending_laser_requests_.fetch_sub(1);
+                    laser_write_in_progress_.store(false);
+                  }
+                } else {
+                  // No zero-weight IDs or no laser providers, clear flag
+                  laser_write_in_progress_.store(false);
+                }
+              });
+        });
   }
 
   /// Update feature scores metadata into kvstore.
@@ -1015,6 +1403,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                            int64_t,
                            int64_t,
                            int64_t>>& results) {
+          resume_laser_write();
           int64_t read_lookup_cache_total_duration = 0;
           int64_t read_fill_row_storage_total_duration = 0;
           int64_t read_cache_hit_copy_total_duration = 0;
@@ -1222,6 +1611,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
     if (!is_training_ && !force_resume) {
       return;
     }
+    resume_laser_write(); // Also resume laser write
     if (feature_evict_) {
       feature_evict_->resume();
     }
@@ -1234,6 +1624,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
     if (!feature_evict_config_.has_value()) {
       return;
     }
+    pause_laser_write(); // Also pause laser write
     if (feature_evict_config_.value()->trigger_mode_ !=
         EvictTriggerMode::DISABLED) {
       if (feature_evict_) {
@@ -1247,6 +1638,35 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
       return feature_evict_->is_evicting();
     }
     return false;
+  }
+
+  /// Pause laser write operations (called before forward/backward)
+  void pause_laser_write() {
+    std::unique_lock<std::mutex> lock(laser_write_mutex_);
+    laser_write_interrupt_.store(true);
+  }
+
+  /// Resume laser write operations (called after forward/backward)
+  void resume_laser_write() {
+    std::unique_lock<std::mutex> lock(laser_write_mutex_);
+    laser_write_interrupt_.store(false);
+    laser_write_cv_.notify_all();
+  }
+
+  /// Wait until laser write is resumed if paused (like eviction pattern)
+  /// Returns immediately if not interrupted, otherwise waits for resume
+  void wait_until_laser_write_resume() {
+    std::unique_lock<std::mutex> lock(laser_write_mutex_);
+    if (!laser_write_interrupt_.load()) {
+      return; // Not interrupted, continue immediately
+    }
+    laser_write_cv_.wait(
+        lock, [this] { return !laser_write_interrupt_.load(); });
+  }
+
+  /// Check if laser write is interrupted (used in inner loop)
+  bool is_laser_write_interrupted() const {
+    return laser_write_interrupt_.load();
   }
 
   // for inference only, this logs the total hit/miss count
@@ -1794,6 +2214,26 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
   std::atomic<int64_t> read_num_counts_{0};
 
   bool disable_random_init_;
+
+  // Enrichment configuration (passed from Python, replaces hardcoded laser
+  // config)
+  std::optional<c10::intrusive_ptr<kv_mem::EnrichmentConfig>>
+      enrichment_config_;
+
+  // Enrichment rate limiting
+  std::atomic<int64_t> pending_laser_requests_{0};
+  std::atomic<bool> laser_write_in_progress_{false};
+
+  // Enrichment write pause/resume mechanism (similar to eviction)
+  std::atomic<bool> laser_write_interrupt_{false};
+  std::mutex laser_write_mutex_;
+  std::condition_variable laser_write_cv_;
+
+  // Dedicated executor for enrichment (separate from main executor)
+  std::unique_ptr<folly::CPUThreadPoolExecutor> enrichment_executor_;
+
+  // Pre-initialized LaserClient for IGR enrichment (reused across fetches)
+  std::shared_ptr<facebook::laser::LaserClient> laser_client_;
 }; // class DramKVEmbeddingCache
 
 } // namespace kv_mem

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h
@@ -39,7 +39,9 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
       int64_t res_server_port = 0,
       std::vector<std::string> table_names = {},
       std::vector<int64_t> table_offsets = {},
-      std::vector<int64_t> table_sizes = {}) {
+      std::vector<int64_t> table_sizes = {},
+      std::optional<c10::intrusive_ptr<kv_mem::EnrichmentConfig>>
+          enrichment_config = std::nullopt) {
     if (row_storage_bitwidth == 16) {
       impl_ = std::make_shared<kv_mem::DramKVEmbeddingCache<at::Half>>(
           max_D,
@@ -60,7 +62,8 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
           res_server_port,
           std::move(table_names),
           std::move(table_offsets),
-          std::move(table_sizes));
+          std::move(table_sizes),
+          enrichment_config);
     } else if (row_storage_bitwidth == 32) {
       impl_ = std::make_shared<kv_mem::DramKVEmbeddingCache<float>>(
           max_D,
@@ -81,7 +84,8 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
           res_server_port,
           std::move(table_names),
           std::move(table_offsets),
-          std::move(table_sizes));
+          std::move(table_sizes),
+          enrichment_config);
     } else {
       throw std::runtime_error("Failed to create recording device");
     }
@@ -204,6 +208,14 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
       at::Tensor count,
       at::Tensor engage_show_count) {
     impl_->set_feature_score_metadata_cuda(indices, count, engage_show_count);
+  }
+
+  void set_embedding_cache_enrich_query_id_cuda(
+      at::Tensor hashed_indices,
+      at::Tensor unhashed_indices,
+      at::Tensor count) {
+    impl_->set_embedding_cache_enrich_query_id_cuda(
+        hashed_indices, unhashed_indices, count);
   }
 
  private:

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/enrichment_config.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/enrichment_config.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <torch/script.h>
+#include <string>
+
+namespace kv_mem {
+
+// TODO(xiujinl): Define these enums in Thrift to avoid maintaining duplicate
+// definitions between Python and C++.
+
+/// Must match Python EnrichmentType(IntEnum) in
+/// split_table_batched_embeddings_ops_common.py
+enum class EnrichmentType : int64_t {
+  IGR_LASER_EMBEDDING = 0,
+  IGR_LASER_SID = 1,
+};
+
+/// Must match Python EnrichmentResponseFormat(IntEnum) in
+/// split_table_batched_embeddings_ops_common.py
+enum class EnrichmentResponseFormat : int64_t {
+  JSON = 0,
+  THRIFT_FLOAT = 1,
+  THRIFT_INT64 = 2,
+};
+
+/// Configuration for embedding enrichment from external sources.
+/// Passed from Python as a TorchScript custom class so that switching
+/// providers or enrichment methods requires no C++ rebuild.
+struct EnrichmentConfig : public torch::jit::CustomClassHolder {
+  /// @param enrichment_type EnrichmentType int value
+  /// @param provider_name External provider name (e.g. Laser provider)
+  /// @param client_id Client identifier for the external service
+  /// @param enrichment_dim Dimension of data returned by the source
+  /// @param response_format EnrichmentResponseFormat int value
+  explicit EnrichmentConfig(
+      int64_t enrichment_type,
+      std::string provider_name,
+      std::string client_id,
+      int64_t enrichment_dim,
+      int64_t response_format)
+      : enrichment_type_(static_cast<EnrichmentType>(enrichment_type)),
+        provider_name_(std::move(provider_name)),
+        client_id_(std::move(client_id)),
+        enrichment_dim_(enrichment_dim),
+        response_format_(
+            static_cast<EnrichmentResponseFormat>(response_format)) {}
+
+  EnrichmentType enrichment_type_;
+  std::string provider_name_;
+  std::string client_id_;
+  int64_t enrichment_dim_;
+  EnrichmentResponseFormat response_format_;
+};
+
+} // namespace kv_mem

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/fixed_block_pool.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/fixed_block_pool.h
@@ -172,6 +172,20 @@ class FixedBlockPool : public std::pmr::memory_resource {
             [](scalar_t sum, scalar_t val) { return sum + val * val; }));
   }
 
+  // Check if all weights in the block are zero
+  // Uses memcmp against a static zero buffer for efficiency
+  template <typename scalar_t>
+  static bool is_weights_all_zero(const scalar_t* block, size_t block_size) {
+    const scalar_t* data = FixedBlockPool::data_ptr(block);
+    const size_t data_byte_size = block_size - sizeof(MetaHeader);
+    // Use a thread-local zero buffer to avoid allocation overhead
+    thread_local std::vector<char> zero_buffer;
+    if (zero_buffer.size() < data_byte_size) {
+      zero_buffer.resize(data_byte_size, 0);
+    }
+    return std::memcmp(data, zero_buffer.data(), data_byte_size) == 0;
+  }
+
   explicit FixedBlockPool(
       std::size_t block_size, // Size of each memory block
       std::size_t block_alignment, // Memory block alignment requirement

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/igr_enrichment.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/igr_enrichment.h
@@ -1,0 +1,503 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include <folly/coro/Task.h>
+#include <folly/io/IOBuf.h>
+#include <folly/logging/xlog.h>
+#include <laser/client/cpp2/LaserClient.h>
+#include <thrift/lib/cpp2/protocol/CompactProtocol.h>
+#include <torch/torch.h>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "enrichment_config.h"
+
+namespace igr_enrichment {
+
+/// Tensors ready to be written into the embedding cache.
+struct EnrichmentResult {
+  at::Tensor indices; // [N] int64 hashed IDs
+  at::Tensor weights; // [N, max_D]
+  at::Tensor count; // [1]
+};
+
+/// Generic thrift parser: extract list<float> from Compact Protocol bytes.
+/// Works for any thrift struct of the form { 1: optional list<float> field }.
+/// No generated thrift header is needed.
+inline std::optional<std::vector<float>> parseThriftListFloat(
+    const std::string& raw) {
+  if (raw.empty()) {
+    return std::nullopt;
+  }
+  try {
+    auto buf = folly::IOBuf::wrapBuffer(raw.data(), raw.size());
+    apache::thrift::CompactProtocolReader reader;
+    reader.setInput(buf.get());
+
+    std::string name;
+    reader.readStructBegin(name);
+
+    std::string fieldName;
+    int16_t fieldId;
+    apache::thrift::protocol::TType fieldType;
+    reader.readFieldBegin(fieldName, fieldType, fieldId);
+
+    if (fieldId == 1 && fieldType == apache::thrift::protocol::TType::T_LIST) {
+      apache::thrift::protocol::TType elemType;
+      uint32_t listSize;
+      reader.readListBegin(elemType, listSize);
+      std::vector<float> result(listSize);
+      for (uint32_t i = 0; i < listSize; ++i) {
+        if (elemType == apache::thrift::protocol::TType::T_FLOAT) {
+          reader.readFloat(result[i]);
+        } else if (elemType == apache::thrift::protocol::TType::T_DOUBLE) {
+          double d;
+          reader.readDouble(d);
+          result[i] = static_cast<float>(d);
+        } else {
+          return std::nullopt;
+        }
+      }
+      reader.readListEnd();
+      return result;
+    }
+  } catch (const std::exception& e) {
+    XLOGF_EVERY_MS(
+        ERR,
+        6000,
+        "Exception in parseThriftListFloat: {}",
+        folly::exceptionStr(e));
+  }
+  return std::nullopt;
+}
+
+/// Parse embedding from text format "[v1,v2,v3]" with comma or \x02 delimiters.
+inline void parseEmbeddingJson(
+    std::string_view json,
+    std::vector<float>& embedding,
+    int64_t dim) {
+  static constexpr char kScribeDelim = '\x02';
+  static constexpr char kHiveDelim = ',';
+
+  embedding.reserve(dim);
+
+  if (!json.empty() && json.front() == '[') {
+    json.remove_prefix(1);
+  }
+  if (!json.empty() && json.back() == ']') {
+    json.remove_suffix(1);
+  }
+
+  char delim = kHiveDelim;
+  if (json.find(kScribeDelim) != std::string_view::npos) {
+    delim = kScribeDelim;
+  }
+
+  folly::split(delim, json, embedding);
+}
+
+/// Generic thrift parser: extract list<i64> from Compact Protocol bytes.
+/// Works for any thrift struct of the form { 1: optional list<i64> field }.
+inline std::optional<std::vector<int64_t>> parseThriftListInt64(
+    const std::string& raw) {
+  if (raw.empty()) {
+    return std::nullopt;
+  }
+  try {
+    auto buf = folly::IOBuf::wrapBuffer(raw.data(), raw.size());
+    apache::thrift::CompactProtocolReader reader;
+    reader.setInput(buf.get());
+
+    std::string name;
+    reader.readStructBegin(name);
+
+    std::string fieldName;
+    int16_t fieldId;
+    apache::thrift::protocol::TType fieldType;
+    reader.readFieldBegin(fieldName, fieldType, fieldId);
+
+    if (fieldId == 1 && fieldType == apache::thrift::protocol::TType::T_LIST) {
+      apache::thrift::protocol::TType elemType;
+      uint32_t listSize;
+      reader.readListBegin(elemType, listSize);
+      std::vector<int64_t> result(listSize);
+      for (uint32_t i = 0; i < listSize; ++i) {
+        reader.readI64(result[i]);
+      }
+      reader.readListEnd();
+      return result;
+    }
+  } catch (const std::exception& e) {
+    XLOGF_EVERY_MS(
+        ERR,
+        6000,
+        "Exception in parseThriftListInt64: {}",
+        folly::exceptionStr(e));
+  }
+  return std::nullopt;
+}
+
+/// Parse SID from text format "[v1,v2,v3]" with comma or \x02 delimiters.
+/// Each value is an int64_t.
+inline void parseSIDJson(
+    std::string_view json,
+    std::vector<int64_t>& sids,
+    int64_t expected_count) {
+  static constexpr char kScribeDelim = '\x02';
+  static constexpr char kHiveDelim = ',';
+
+  sids.reserve(expected_count);
+
+  if (!json.empty() && json.front() == '[') {
+    json.remove_prefix(1);
+  }
+  if (!json.empty() && json.back() == ']') {
+    json.remove_suffix(1);
+  }
+
+  char delim = kHiveDelim;
+  if (json.find(kScribeDelim) != std::string_view::npos) {
+    delim = kScribeDelim;
+  }
+
+  folly::split(delim, json, sids);
+}
+
+/// Fetch SIDs (int64 values) from Laser for given object IDs.
+/// Uses config.response_format_ to choose deserialization:
+///   THRIFT_INT64 — generic CompactProtocol reader for list<i64>
+///   JSON — text "[v1,v2,v3,v4]" format
+inline folly::coro::Task<folly::F14FastMap<int64_t, std::vector<int64_t>>>
+fetchSIDsFromLaser(
+    const std::shared_ptr<facebook::laser::LaserClient>& laserClient,
+    const kv_mem::EnrichmentConfig& config,
+    const std::vector<int64_t>& objectIds) {
+  folly::F14FastMap<int64_t, std::vector<int64_t>> objectIdToSIDMap;
+  if (!laserClient || objectIds.empty()) {
+    co_return objectIdToSIDMap;
+  }
+
+  // enrichment_dim is total FP16 count; each int64 = 4 FP16, so
+  // expected SID count = enrichment_dim / 4
+  const int64_t expectedSIDCount = config.enrichment_dim_ / 4;
+
+  std::vector<std::string> laserKeys;
+  laserKeys.reserve(objectIds.size());
+  for (const auto& id : objectIds) {
+    laserKeys.push_back(std::to_string(id));
+  }
+
+  try {
+    auto laserMultiRet = co_await laserClient->coMultiget(std::move(laserKeys));
+
+    if (laserMultiRet.empty()) {
+      co_return objectIdToSIDMap;
+    }
+
+    for (size_t i = 0; i < laserMultiRet.size(); ++i) {
+      const auto& laserRet = laserMultiRet[i];
+      const int64_t objectId = objectIds[i];
+
+      if (!laserRet.valueExists()) {
+        continue;
+      }
+
+      if (config.response_format_ ==
+          kv_mem::EnrichmentResponseFormat::THRIFT_INT64) {
+        auto parsed = parseThriftListInt64(laserRet.getValue());
+        if (parsed.has_value() &&
+            static_cast<int64_t>(parsed->size()) == expectedSIDCount) {
+          objectIdToSIDMap[objectId] = std::move(*parsed);
+        } else {
+          XLOGF_EVERY_MS(
+              WARN,
+              6000,
+              "SID count mismatch for objectId {}: expected {}, got {} "
+              "(thrift_int64 format)",
+              objectId,
+              expectedSIDCount,
+              parsed.has_value() ? parsed->size() : 0);
+        }
+      } else {
+        // Default: JSON/text format "[v1,v2,v3,v4]"
+        std::vector<int64_t> sids;
+        parseSIDJson(laserRet.getValue(), sids, expectedSIDCount);
+        if (static_cast<int64_t>(sids.size()) == expectedSIDCount) {
+          objectIdToSIDMap.emplace(objectId, std::move(sids));
+        } else {
+          XLOGF_EVERY_MS(
+              WARN,
+              6000,
+              "SID count mismatch for objectId {}: expected {}, got {} "
+              "(JSON format)",
+              objectId,
+              expectedSIDCount,
+              sids.size());
+        }
+      }
+    }
+  } catch (const std::exception& e) {
+    XLOGF_EVERY_MS(
+        ERR,
+        6000,
+        "Exception when fetching SIDs from laser for provider {} "
+        "client {}: {}",
+        config.provider_name_,
+        config.client_id_,
+        folly::exceptionStr(e));
+  }
+
+  co_return objectIdToSIDMap;
+}
+
+/// Prepare tensors for writing SIDs into the cache.
+/// Each int64_t SID is bit-cast to 4 x at::Half (FP16), preserving exact bits
+/// for lossless round-trip. The output tensor is always kHalf regardless of
+/// weight_type, since we need exact bit representation.
+inline std::optional<EnrichmentResult> prepareSIDCacheWriteTensors(
+    const std::vector<int64_t>& hashed_ids,
+    const std::vector<int64_t>& unhashed_ids,
+    const folly::F14FastMap<int64_t, std::vector<int64_t>>& sid_map,
+    int64_t max_D) {
+  if (hashed_ids.size() != unhashed_ids.size()) {
+    XLOG(ERR) << "hashed_ids and unhashed_ids size mismatch: "
+              << hashed_ids.size() << " vs " << unhashed_ids.size();
+    return std::nullopt;
+  }
+
+  std::vector<int64_t> indices_vec;
+  std::vector<at::Half> weights_vec;
+  indices_vec.reserve(sid_map.size());
+
+  for (size_t i = 0; i < unhashed_ids.size(); ++i) {
+    int64_t unhashed_id = unhashed_ids[i];
+    int64_t hashed_id = hashed_ids[i];
+
+    auto it = sid_map.find(unhashed_id);
+    if (it == sid_map.end()) {
+      continue;
+    }
+
+    const auto& sids = it->second;
+    if (sids.empty()) {
+      continue;
+    }
+
+    indices_vec.push_back(hashed_id);
+
+    // Each int64 SID → 4 x FP16 via bit-cast (memcpy)
+    // Total FP16 values = sids.size() * 4
+    int64_t fp16_written = 0;
+    for (const auto& sid : sids) {
+      at::Half fp16_vals[4];
+      std::memcpy(fp16_vals, &sid, sizeof(int64_t));
+      for (int k = 0; k < 4; ++k) {
+        if (fp16_written < max_D) {
+          weights_vec.push_back(fp16_vals[k]);
+          ++fp16_written;
+        }
+      }
+    }
+    // Pad remaining slots to max_D
+    for (; fp16_written < max_D; ++fp16_written) {
+      weights_vec.push_back(at::Half(0));
+    }
+  }
+
+  if (indices_vec.empty()) {
+    return std::nullopt;
+  }
+
+  int64_t num_embeddings = indices_vec.size();
+
+  auto indices_tensor = std::make_shared<at::Tensor>(
+      torch::from_blob(indices_vec.data(), {num_embeddings}, torch::kInt64)
+          .clone());
+  auto weights_tensor = std::make_shared<at::Tensor>(
+      torch::from_blob(
+          weights_vec.data(), {num_embeddings, max_D}, torch::kHalf)
+          .clone());
+
+  auto count_tensor = std::make_shared<at::Tensor>(
+      torch::tensor({num_embeddings}, torch::kLong));
+
+  XLOG(INFO) << "[EmbeddingCacheEnrich] prepareSIDCacheWriteTensors: "
+             << "num_embeddings=" << num_embeddings;
+
+  return EnrichmentResult{
+      *indices_tensor,
+      *weights_tensor,
+      *count_tensor,
+  };
+}
+
+/// Create a reusable LaserClient from enrichment config.
+/// Called once in the constructor so the client is shared across all fetches.
+inline std::shared_ptr<facebook::laser::LaserClient> initializeLaserClient(
+    const kv_mem::EnrichmentConfig& config) {
+  return std::make_shared<facebook::laser::LaserClient>(
+      config.provider_name_,
+      nullptr /* executor */,
+      facebook::laser::LaserClient::Options().setClientId(config.client_id_));
+}
+
+/// Fetch embeddings from Laser for given object IDs.
+/// Uses config.response_format_ to choose deserialization:
+///   "thrift_float" — generic CompactProtocol reader (no generated header)
+///   "json" — text "[v1,v2,v3]" format
+inline folly::coro::Task<folly::F14FastMap<int64_t, std::vector<float>>>
+fetchEmbeddingsFromLaser(
+    const std::shared_ptr<facebook::laser::LaserClient>& laserClient,
+    const kv_mem::EnrichmentConfig& config,
+    const std::vector<int64_t>& objectIds) {
+  folly::F14FastMap<int64_t, std::vector<float>> objectIdToEmbeddingMap;
+  if (!laserClient || objectIds.empty()) {
+    co_return objectIdToEmbeddingMap;
+  }
+
+  std::vector<std::string> laserKeys;
+  laserKeys.reserve(objectIds.size());
+  for (const auto& id : objectIds) {
+    laserKeys.push_back(std::to_string(id));
+  }
+
+  try {
+    auto laserMultiRet = co_await laserClient->coMultiget(std::move(laserKeys));
+
+    if (laserMultiRet.empty()) {
+      co_return objectIdToEmbeddingMap;
+    }
+
+    for (size_t i = 0; i < laserMultiRet.size(); ++i) {
+      const auto& laserRet = laserMultiRet[i];
+      const int64_t objectId = objectIds[i];
+
+      if (!laserRet.valueExists()) {
+        continue;
+      }
+
+      std::vector<float> embedding;
+
+      if (config.response_format_ ==
+          kv_mem::EnrichmentResponseFormat::THRIFT_FLOAT) {
+        auto parsed = parseThriftListFloat(laserRet.getValue());
+        if (parsed.has_value() &&
+            parsed->size() == static_cast<size_t>(config.enrichment_dim_)) {
+          objectIdToEmbeddingMap[objectId] = std::move(*parsed);
+        }
+      } else {
+        // Default: JSON/text format
+        parseEmbeddingJson(
+            laserRet.getValue(), embedding, config.enrichment_dim_);
+        if (embedding.size() == static_cast<size_t>(config.enrichment_dim_)) {
+          objectIdToEmbeddingMap.emplace(objectId, std::move(embedding));
+        }
+      }
+    }
+  } catch (const std::exception& e) {
+    XLOGF_EVERY_MS(
+        ERR,
+        6000,
+        "Exception when fetching embeddings from laser for provider {} "
+        "client {}: {}",
+        config.provider_name_,
+        config.client_id_,
+        folly::exceptionStr(e));
+  }
+
+  co_return objectIdToEmbeddingMap;
+}
+
+/// Prepare tensors for writing embeddings into the cache.
+/// Pads or truncates each embedding to max_D and converts to weight_type.
+template <typename weight_type>
+inline std::optional<EnrichmentResult> prepareCacheWriteTensors(
+    const std::vector<int64_t>& hashed_ids,
+    const std::vector<int64_t>& unhashed_ids,
+    const folly::F14FastMap<int64_t, std::vector<float>>& embeddings,
+    int64_t max_D) {
+  if (hashed_ids.size() != unhashed_ids.size()) {
+    XLOG(ERR) << "hashed_ids and unhashed_ids size mismatch: "
+              << hashed_ids.size() << " vs " << unhashed_ids.size();
+    return std::nullopt;
+  }
+
+  std::vector<int64_t> indices_vec;
+  std::vector<float> weights_vec;
+  indices_vec.reserve(embeddings.size());
+
+  for (size_t i = 0; i < unhashed_ids.size(); ++i) {
+    int64_t unhashed_id = unhashed_ids[i];
+    int64_t hashed_id = hashed_ids[i];
+
+    auto it = embeddings.find(unhashed_id);
+    if (it == embeddings.end()) {
+      continue;
+    }
+
+    const auto& embedding = it->second;
+    if (embedding.empty()) {
+      continue;
+    }
+
+    indices_vec.push_back(hashed_id);
+
+    // Pad or truncate to max_D
+    for (int64_t j = 0; j < max_D; ++j) {
+      if (j < static_cast<int64_t>(embedding.size())) {
+        weights_vec.push_back(embedding[j]);
+      } else {
+        weights_vec.push_back(0.0f);
+      }
+    }
+  }
+
+  if (indices_vec.empty()) {
+    return std::nullopt;
+  }
+
+  int64_t num_embeddings = indices_vec.size();
+
+  auto indices_tensor = std::make_shared<at::Tensor>(
+      torch::from_blob(indices_vec.data(), {num_embeddings}, torch::kInt64)
+          .clone());
+  auto weights_tensor = std::make_shared<at::Tensor>(
+      torch::from_blob(
+          weights_vec.data(), {num_embeddings, max_D}, torch::kFloat32)
+          .clone());
+
+  // Convert to weight_type if needed
+  if constexpr (!std::is_same_v<weight_type, float>) {
+    *weights_tensor =
+        weights_tensor->to(torch::CppTypeToScalarType<weight_type>());
+  }
+
+  auto count_tensor = std::make_shared<at::Tensor>(
+      torch::tensor({num_embeddings}, torch::kLong));
+
+  XLOG(INFO) << "[EmbeddingCacheEnrich] prepareCacheWriteTensors: "
+             << "num_embeddings=" << num_embeddings;
+
+  // Return by value; the shared_ptrs ensure tensor data survives
+  // until the caller (set_kv_db_async_on_laser_executor) clones or
+  // finishes consuming them.  We move into the result struct so
+  // the caller can capture the shared_ptrs in the continuation.
+  return EnrichmentResult{
+      *indices_tensor,
+      *weights_tensor,
+      *count_tensor,
+  };
+}
+
+} // namespace igr_enrichment

--- a/fbgemm_gpu/src/ps_split_embeddings_cache/ps_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ps_split_embeddings_cache/ps_split_table_batched_embeddings.cpp
@@ -59,6 +59,14 @@ class EmbeddingParameterServerWrapper : public torch::jit::CustomClassHolder {
     impl_->set_feature_score_metadata_cuda(indices, count, engage_show_count);
   }
 
+  void set_embedding_cache_enrich_query_id_cuda(
+      const Tensor& hashed_indices,
+      const Tensor& unhashed_indices,
+      const Tensor& count) {
+    impl_->set_embedding_cache_enrich_query_id_cuda(
+        hashed_indices, unhashed_indices, count);
+  }
+
   void stream_cuda(
       const Tensor& indices,
       const Tensor& weights,
@@ -118,6 +126,10 @@ static auto embedding_parameter_server_wrapper =
         .def(
             "set_feature_score_metadata_cuda",
             &EmbeddingParameterServerWrapper::set_feature_score_metadata_cuda)
+        .def(
+            "set_embedding_cache_enrich_query_id_cuda",
+            &EmbeddingParameterServerWrapper::
+                set_embedding_cache_enrich_query_id_cuda)
         .def("stream_cuda", &EmbeddingParameterServerWrapper::stream_cuda)
         .def(
             "stream_sync_cuda",

--- a/fbgemm_gpu/src/ps_split_embeddings_cache/ps_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ps_split_embeddings_cache/ps_table_batched_embeddings.h
@@ -67,6 +67,12 @@ class EmbeddingParameterServer : public kv_db::EmbeddingKVDB {
       at::Tensor engage_show_count) override {
     return std::vector<folly::Unit>(1);
   }
+
+  void set_embedding_cache_enrich_query_id_async(
+      at::Tensor hashed_indices,
+      at::Tensor unhashed_indices,
+      at::Tensor count) override {}
+
   void flush() {}
   void compact() override {}
   // cleanup cached results in server side

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
@@ -107,6 +107,15 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
     impl_->set_feature_score_metadata_cuda(indices, count, engage_show_count);
   }
 
+  void set_embedding_cache_enrich_query_id_cuda(
+      const at::Tensor& hashed_indices,
+      const at::Tensor& unhashed_indices,
+      const at::Tensor& count) {
+    LOG(INFO) << "set_embedding_cache_enrich_query_id_cuda";
+    impl_->set_embedding_cache_enrich_query_id_cuda(
+        hashed_indices, unhashed_indices, count);
+  }
+
   void stream_sync_cuda() {
     return impl_->stream_sync_cuda();
   }

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_cuda_utils.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_cuda_utils.cpp
@@ -27,13 +27,8 @@ void host_async_threadpool_executor(void (*f)(void*), void* userData) {
 
 }; // namespace
 
-void cuda_callback_func(
-    cudaStream_t /*stream*/,
-    cudaError_t status,
-    void* functor) {
-  AT_CUDA_CHECK(status);
+void cuda_host_func(void* functor) {
   auto* f = reinterpret_cast<std::function<void()>*>(functor);
-  AT_CUDA_CHECK(cudaGetLastError());
   (*f)();
   // delete f; // unfortunately, this invoke destructors that call CUDA
   // API functions (e.g. caching host allocators issue cudaGetDevice(..),

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_cuda_utils.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_cuda_utils.h
@@ -14,18 +14,19 @@ namespace kv_db_utils {
 
 /// @ingroup embedding-ssd
 ///
-/// @brief A callback function for `cudaStreamAddCallback`
+/// @brief A host function for `cudaLaunchHostFunc`
 ///
-/// A common callback function for `cudaStreamAddCallback`, i.e.,
-/// `cudaStreamCallback_t callback`. This function casts `functor`
-/// into a void function, invokes it and then delete it (the deletion
-/// occurs in another thread)
+/// A common host function for `cudaLaunchHostFunc`, i.e.,
+/// `cudaHostFn_t`. This function casts `functor` into a void function,
+/// invokes it and then deletes it (the deletion occurs in another thread).
 ///
-/// @param stream CUDA stream that `cudaStreamAddCallback` operates on
-/// @param status CUDA status
+/// Unlike `cudaStreamAddCallback`, `cudaLaunchHostFunc` does not hold the
+/// CUDA driver mutex during execution, allowing concurrent CUDA API calls
+/// from other threads (e.g., NCCL kernel launches on other streams).
+///
 /// @param functor A functor that will be called
 ///
 /// @return None
-void cuda_callback_func(cudaStream_t stream, cudaError_t status, void* functor);
+void cuda_host_func(void* functor);
 
 }; // namespace kv_db_utils

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -228,11 +228,8 @@ void EmbeddingKVDB::get_cuda(
   auto self = shared_from_this();
   std::function<void()>* functor =
       new std::function<void()>([=]() { self->get(indices, weights, count); });
-  AT_CUDA_CHECK(cudaStreamAddCallback(
-      at::cuda::getCurrentCUDAStream(),
-      kv_db_utils::cuda_callback_func,
-      functor,
-      0));
+  AT_CUDA_CHECK(cudaLaunchHostFunc(
+      at::cuda::getCurrentCUDAStream(), kv_db_utils::cuda_host_func, functor));
   rec->record.end();
 }
 
@@ -251,11 +248,8 @@ void EmbeddingKVDB::set_cuda(
     self->set(indices, weights, count, is_bwd);
     self->flush_or_compact(timestep);
   });
-  AT_CUDA_CHECK(cudaStreamAddCallback(
-      at::cuda::getCurrentCUDAStream(),
-      kv_db_utils::cuda_callback_func,
-      functor,
-      0));
+  AT_CUDA_CHECK(cudaLaunchHostFunc(
+      at::cuda::getCurrentCUDAStream(), kv_db_utils::cuda_host_func, functor));
   rec->record.end();
 }
 
@@ -270,11 +264,8 @@ void EmbeddingKVDB::set_feature_score_metadata_cuda(
     set_kv_zch_eviction_metadata_async(
         std::move(indices), std::move(count), std::move(engage_show_count));
   });
-  AT_CUDA_CHECK(cudaStreamAddCallback(
-      at::cuda::getCurrentCUDAStream(),
-      kv_db_utils::cuda_callback_func,
-      functor,
-      0));
+  AT_CUDA_CHECK(cudaLaunchHostFunc(
+      at::cuda::getCurrentCUDAStream(), kv_db_utils::cuda_host_func, functor));
   rec->record.end();
 }
 
@@ -298,11 +289,8 @@ void EmbeddingKVDB::stream_cuda(
         true, /*require_tensor_copy*/
         blocking_tensor_copy);
   });
-  AT_CUDA_CHECK(cudaStreamAddCallback(
-      at::cuda::getCurrentCUDAStream(),
-      kv_db_utils::cuda_callback_func,
-      functor,
-      0));
+  AT_CUDA_CHECK(cudaLaunchHostFunc(
+      at::cuda::getCurrentCUDAStream(), kv_db_utils::cuda_host_func, functor));
   rec->record.end();
 }
 
@@ -314,11 +302,8 @@ void EmbeddingKVDB::stream_sync_cuda() {
   std::function<void()>* functor = new std::function<void()>([=]() {
     self->raw_embedding_streamer_->join_stream_tensor_copy_thread();
   });
-  AT_CUDA_CHECK(cudaStreamAddCallback(
-      at::cuda::getCurrentCUDAStream(),
-      kv_db_utils::cuda_callback_func,
-      functor,
-      0));
+  AT_CUDA_CHECK(cudaLaunchHostFunc(
+      at::cuda::getCurrentCUDAStream(), kv_db_utils::cuda_host_func, functor));
   rec->record.end();
 }
 

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -269,6 +269,22 @@ void EmbeddingKVDB::set_feature_score_metadata_cuda(
   rec->record.end();
 }
 
+void EmbeddingKVDB::set_embedding_cache_enrich_query_id_cuda(
+    const at::Tensor& hashed_indices,
+    const at::Tensor& unhashed_indices,
+    const at::Tensor& count) {
+  auto rec = torch::autograd::profiler::record_function_enter_new(
+      "## EmbeddingKVDB::set_embedding_cache_enrich_query_id_cuda ##");
+  // take reference to self to avoid lifetime issues.
+  std::function<void()>* functor = new std::function<void()>([=, this]() {
+    set_embedding_cache_enrich_query_id_async(
+        hashed_indices, unhashed_indices, count);
+  });
+  AT_CUDA_CHECK(cudaLaunchHostFunc(
+      at::cuda::getCurrentCUDAStream(), kv_db_utils::cuda_host_func, functor));
+  rec->record.end();
+}
+
 void EmbeddingKVDB::stream_cuda(
     const at::Tensor& indices,
     const at::Tensor& weights,

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
@@ -220,6 +220,11 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
       at::Tensor count,
       at::Tensor engage_show_count) = 0;
 
+  virtual void set_embedding_cache_enrich_query_id_async(
+      at::Tensor hashed_indices,
+      at::Tensor unhashed_indices,
+      at::Tensor count) = 0;
+
   virtual void compact() = 0;
 
   /// Flush L2 cache into backend storage
@@ -249,6 +254,11 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
       const at::Tensor& indices,
       const at::Tensor& count,
       const at::Tensor& engage_show_count);
+
+  void set_embedding_cache_enrich_query_id_cuda(
+      const at::Tensor& hashed_indices,
+      const at::Tensor& unhashed_indices,
+      const at::Tensor& count);
 
   void stream_cuda(
       const at::Tensor& indices,

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_scratch_pad_indices_queue.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_scratch_pad_indices_queue.cpp
@@ -45,11 +45,10 @@ class SSDScratchPadIndicesQueueImpl
     auto self = shared_from_this();
     std::function<void()>* functor =
         new std::function<void()>([=]() { self->insert(indices, count); });
-    AT_CUDA_CHECK(cudaStreamAddCallback(
+    AT_CUDA_CHECK(cudaLaunchHostFunc(
         at::cuda::getCurrentCUDAStream(),
-        kv_db_utils::cuda_callback_func,
-        functor,
-        0));
+        kv_db_utils::cuda_host_func,
+        functor));
   }
 
   void lookup_mask_and_pop_front_cuda(
@@ -68,11 +67,10 @@ class SSDScratchPadIndicesQueueImpl
           inserted_indices_curr,
           count_curr);
     });
-    AT_CUDA_CHECK(cudaStreamAddCallback(
+    AT_CUDA_CHECK(cudaLaunchHostFunc(
         at::cuda::getCurrentCUDAStream(),
-        kv_db_utils::cuda_callback_func,
-        functor,
-        0));
+        kv_db_utils::cuda_host_func,
+        functor));
   }
 
   int64_t size() {

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -977,6 +977,15 @@ static auto embedding_rocks_db_wrapper =
                 torch::arg("engage_rates"),
             })
         .def(
+            "set_embedding_cache_enrich_query_id_cuda",
+            &EmbeddingRocksDBWrapper::set_embedding_cache_enrich_query_id_cuda,
+            "",
+            {
+                torch::arg("hashed_indices"),
+                torch::arg("unhashed_indices"),
+                torch::arg("count"),
+            })
+        .def(
             "stream_cuda",
             &EmbeddingRocksDBWrapper::stream_cuda,
             "",
@@ -1048,6 +1057,19 @@ static auto embedding_rocks_db_wrapper =
             "get_active_checkpoint_uuid",
             &EmbeddingRocksDBWrapper::get_active_checkpoint_uuid);
 
+auto enrichment_config =
+    torch::class_<kv_mem::EnrichmentConfig>("fbgemm", "EnrichmentConfig")
+        .def(
+            torch::init<int64_t, std::string, std::string, int64_t, int64_t>(),
+            "",
+            {
+                torch::arg("enrichment_type"),
+                torch::arg("provider_name"),
+                torch::arg("client_id"),
+                torch::arg("enrichment_dim"),
+                torch::arg("response_format"),
+            });
+
 static auto dram_kv_embedding_cache_wrapper =
     torch::class_<DramKVEmbeddingCacheWrapper>(
         "fbgemm",
@@ -1071,7 +1093,8 @@ static auto dram_kv_embedding_cache_wrapper =
                 int64_t,
                 std::vector<std::string>,
                 std::vector<int64_t>,
-                std::vector<int64_t>>(),
+                std::vector<int64_t>,
+                std::optional<c10::intrusive_ptr<kv_mem::EnrichmentConfig>>>(),
             "",
             {
                 torch::arg("max_D"),
@@ -1092,6 +1115,7 @@ static auto dram_kv_embedding_cache_wrapper =
                 torch::arg("table_names") = std::vector<std::string>{},
                 torch::arg("table_offsets") = std::vector<int64_t>{},
                 torch::arg("table_sizes") = std::vector<int64_t>{},
+                torch::arg("enrichment_config") = std::nullopt,
             })
         .def(
             "set_cuda",
@@ -1152,6 +1176,16 @@ static auto dram_kv_embedding_cache_wrapper =
                 torch::arg("indices"),
                 torch::arg("count"),
                 torch::arg("engage_rates"),
+            })
+        .def(
+            "set_embedding_cache_enrich_query_id_cuda",
+            &DramKVEmbeddingCacheWrapper::
+                set_embedding_cache_enrich_query_id_cuda,
+            "",
+            {
+                torch::arg("hashed_indices"),
+                torch::arg("unhashed_indices"),
+                torch::arg("count"),
             })
         .def("flush", &DramKVEmbeddingCacheWrapper::flush)
         .def(

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -517,6 +517,13 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
         std::vector<folly::Unit>{});
   }
 
+  void set_embedding_cache_enrich_query_id_async(
+      at::Tensor hashed_indices,
+      at::Tensor unhashed_indices,
+      at::Tensor count) override {
+    return;
+  }
+
   folly::SemiFuture<std::vector<folly::Unit>> get_kv_db_async(
       const at::Tensor& indices,
       const at::Tensor& weights,


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2438

CONTEXT: DRAM KV embedding cache currently only stores cached embeddings without enrichment from external sources. This limits the cache's ability to leverage pre-trained embeddings or external knowledge sources like IGR (Identity Graph Resolution) data from Laser, resulting in cold-start issues and lower quality for sparse features.

WHAT: This diff introduces a configurable enrichment system that asynchronously fetches embeddings from external sources (e.g., IGR via Laser) to populate the DRAM cache for missing IDs.
- Added Python configuration layer: EnrichmentPolicy NamedTuple in split_table_batched_embeddings_ops_common.py with fields for enrichment_type, provider_name, client_id, enrichment_dim, and response_format
- Added C++ configuration layer: EnrichmentConfig TorchScript custom class in enrichment_config.h with EnrichmentType enum and EnrichmentResponseFormat enum
- Implemented IGR enrichment infrastructure in new igr_enrichment.h: LaserClient initialization, async coroutine-based Laser queries, generic thrift parsing, and tensor preparation utilities
- Added enrichment orchestration in DramKVEmbeddingCache: dedicated laser_executor_ thread pool (4 threads), pause/resume mechanism for laser writes to yield to forward/backward passes, rate limiting via pending_laser_requests_ counter
- Implemented enrichment_query_id() in training.py: runs on dedicated enrichment_query_stream CUDA stream, performs deduplication on linearized indices, async D2H copy of query IDs
- Added zero-weight detection and invalidation logic: detects cache slots with all-zero weights during prefetch/flush, invalidates L1 cache state for zero-weight rows to trigger re-fetch
- Updated BUCK dependencies: added laser/client, thrift protocol, and folly/io:iobuf

Reviewed By: emlin

Differential Revision: D95873233


