### PR TITLE
Remove NCCLX one-sided comm code from fbgemm

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/gen_ai/CMakeLists.txt
@@ -78,14 +78,6 @@ if(USE_FB_ONLY
     BLOCK_PRINT(
       "[FBPKG] FBGEMM_FBPKG_BUILD is NOT set,"
       "certain FB-internal sources will be excluded from the build.")
-
-    # NOTE: Some FB-internal code explicitly require an FB-internal
-    # environment to build, such as code that depends on NCCLX
-    list(FILTER fb_only_sources_cpu
-      EXCLUDE REGEX "fb/src/tensor_parallel(/.*)*\\.cpp$")
-
-    list(FILTER fb_only_sources_gpu
-      EXCLUDE REGEX "fb/src/tensor_parallel(/.*)*\\.cu$")
   endif()
 
   list(APPEND experimental_gen_ai_cpp_source_files_cpu ${fb_only_sources_cpu})


### PR DESCRIPTION
Summary:
Remove the NCCLX one-sided communication-computation overlap
code from fbgemm's experimental/gen_ai. This includes the
FusedCommComp class (comm_comp_overlap.cpp) that depended on
NCCLX one-sided APIs (ncclPutSignal, ncclWaitSignal,
ncclWinAllocate, etc.) and its test. Also remove the
now-dead CMake EXCLUDE REGEX filters for tensor_parallel
sources.

Reviewed By: GD06

Differential Revision: D96163960


