### PR TITLE
Add heterogeneous per-group input shapes support to group_index_select_2d_bench (#5487)

### DIFF
--- a/fbgemm_gpu/bench/sparse_ops_benchmark.py
+++ b/fbgemm_gpu/bench/sparse_ops_benchmark.py
@@ -8,12 +8,13 @@
 
 import contextlib
 import functools
+import json
 import logging
 import math
 import os
 import random
 from contextlib import nullcontext
-from typing import Callable
+from typing import Callable, List, Optional, Tuple
 
 import click
 import fbgemm_gpu
@@ -149,7 +150,12 @@ def batch_reuse_index_select_device(
     # pyre-fixme[16]: Module `cuda` has no attribute `IntTensor`.
     indices = torch.cuda.IntTensor(gen_inverse_index(unique_batch_size, batch_size))
 
-    input = torch.rand(unique_batch_size, row_size, dtype=dtype, device="cuda")
+    input = torch.rand(
+        unique_batch_size,
+        row_size,
+        dtype=dtype,
+        device=torch.accelerator.current_accelerator(),
+    )
     input.requires_grad = True
     num_bytes = 2 * batch_size * row_size * input.element_size()
 
@@ -168,7 +174,9 @@ def batch_reuse_index_select_device(
         f"index_select_dim0 forward: {dtype}, {num_bytes} bytes read/write, {time * 1e3} ms, {num_bytes / time / 1e9} GB/s"
     )
 
-    grad = torch.rand_like(output, dtype=dtype, device="cuda")
+    grad = torch.rand_like(
+        output, dtype=dtype, device=torch.accelerator.current_accelerator()
+    )
     num_bytes = (input.numel() + output.numel()) * input.element_size()
     with context_factory(lambda p: _kineto_trace_handler(p, "bwd")):
         time, _ = benchmark_torch_function(
@@ -224,7 +232,11 @@ def jagged_index_select_2d_bench(
 
         to_be_merged_tensors = []
         for row in index_ranges:
-            to_be_merged_tensors.append(torch.arange(row[0], row[1], device="cuda"))
+            to_be_merged_tensors.append(
+                torch.arange(
+                    row[0], row[1], device=torch.accelerator.current_accelerator()
+                )
+            )
         all_indices = torch.cat(to_be_merged_tensors, dim=0)
         new_embeddings = torch.index_select(values, 0, all_indices)
         return new_embeddings
@@ -237,7 +249,7 @@ def jagged_index_select_2d_bench(
         high=max_seq_length,
         size=(num_jagged_tensor_rows,),
         dtype=index_t,
-        device="cuda",
+        device=torch.accelerator.current_accelerator(),
     )
     indices, _ = torch.sort(
         torch.randint(
@@ -245,11 +257,14 @@ def jagged_index_select_2d_bench(
             high=num_jagged_tensor_rows,
             size=(batch_size,),
             dtype=index_t,
-            device="cuda",
+            device=torch.accelerator.current_accelerator(),
         )
     )
     values = torch.rand(
-        int(lengths.sum().item()), num_cols, dtype=scalar_t, device="cuda"
+        int(lengths.sum().item()),
+        num_cols,
+        dtype=scalar_t,
+        device=torch.accelerator.current_accelerator(),
     )
     values.requires_grad = True
 
@@ -322,6 +337,22 @@ def jagged_index_select_2d_bench(
     type=str,
     default="group_index_select_2d_{phase}_trace_{ospid}.json",
 )
+@click.option(
+    "--input-dims",
+    type=str,
+    default=None,
+    help="JSON list of [num_rows, row_size] per group, e.g. '[[27330,96],[4914,96]]'. "
+    "When provided, --row-size, --batch-size, --unique-batch-size, and --num-groups are ignored.",
+)
+@click.option(
+    "--input-strides",
+    type=str,
+    default=None,
+    help="JSON list of [stride0, stride1] per group. Defaults to contiguous strides if not provided.",
+)
+@click.option(
+    "--index-dim", type=int, default=None, help="Number of indices per group."
+)
 def group_index_select_2d_bench(
     row_size: int,
     batch_size: int,
@@ -331,6 +362,9 @@ def group_index_select_2d_bench(
     num_groups: int,
     export_trace: bool,
     trace_url: str,
+    input_dims: Optional[str],
+    input_strides: Optional[str],
+    index_dim: Optional[int],
 ) -> None:
     def gen_inverse_index(curr_size: int, final_size: int) -> np.array:
         inverse_index = list(range(curr_size))
@@ -349,25 +383,123 @@ def group_index_select_2d_bench(
     else:
         raise RuntimeError(f"Does not support data type {input_precision}")
 
-    offset_indices_group = []
+    bench_kwargs: dict[str, int] = {"num_warmups": 10, "iters": 100}
+
+    def bench_ref_forward(
+        input: torch.Tensor, indices: torch.Tensor, bench_kwargs: dict[str, int]
+    ) -> Tuple[float, torch.Tensor]:
+
+        time_ref, output_ref = benchmark_torch_function(
+            # pyre-fixme[6]: For 3rd argument expected `bool` but got `int`.
+            # pyre-fixme[6]: For 3rd argument expected `str` but got `int`.
+            torch.index_select,
+            (input, 0, indices),
+            # pyre-fixme[6]: For 3rd argument expected `bool` but got `int`.
+            # pyre-fixme[6]: For 3rd argument expected `str` but got `int`.
+            **bench_kwargs,
+        )
+        return time_ref, output_ref
+
+    def bench_ref_backward(output_ref: torch.Tensor, grad: torch.Tensor) -> float:
+        time_ref, _ = benchmark_torch_function(
+            functools.partial(output_ref.backward, retain_graph=True),
+            (grad,),
+            # pyre-fixme[6]: For 3rd argument expected `bool` but got `int`.
+            # pyre-fixme[6]: For 3rd argument expected `str` but got `int`.
+            **bench_kwargs,
+        )
+        return time_ref
+
+    input_group = []
     indices_group = []
-    for i in range(num_groups):
-        # pyre-fixme[16]: Module `cuda` has no attribute `IntTensor`.
-        indices = torch.cuda.IntTensor(gen_inverse_index(unique_batch_size, batch_size))
-        if sort_indices:
-            indices, _ = indices.sort()
-        indices_group.append(indices)
-        indices = torch.add(indices, batch_size * i)
-        offset_indices_group.append(indices)
+    num_bytes: int = 0
+    time_ref_fwd: float = 0
+    time_ref_bwd: float = 0
+    grad: torch.Tensor
+    if input_dims:
+        # Heterogeneous per-group shapes
+        parsed_dims: List[List[int]] = json.loads(input_dims)
+        if input_strides is not None:
+            parsed_strides: List[List[int]] = json.loads(input_strides)
+        else:
+            parsed_strides = [[dim[1], 1] for dim in parsed_dims]
+        if index_dim is None:
+            raise click.UsageError("--index-dim is required when using --input-dims")
 
-    offset_indices = torch.concat(offset_indices_group)
+        for dim, stride in zip(parsed_dims, parsed_strides):
+            inp = torch.rand(
+                dim, dtype=dtype, device=torch.accelerator.current_accelerator()
+            ).as_strided(dim, stride)
+            inp.requires_grad = True
+            input_group.append(inp)
 
-    input = torch.rand(num_groups * batch_size, row_size, dtype=dtype, device="cuda")
-    input.requires_grad = True
+            index = torch.randint(
+                low=0,
+                high=dim[0],
+                size=(index_dim,),
+                dtype=torch.int,
+                device=torch.accelerator.current_accelerator(),
+            )
+            indices_group.append(index)
 
-    num_bytes = 2 * batch_size * row_size * input.element_size() * num_groups
+        num_bytes = sum(
+            2 * index_dim * dim[1] * input_group[0].element_size()
+            for dim in parsed_dims
+        )
 
-    bench_kwargs = {"num_warmups": 10, "iters": 100}
+        # Run reference benchmark
+        time_ref_group = []
+        output_ref_group = []
+        for inp, idx in zip(input_group, indices_group):
+            time_ref, output_ref = bench_ref_forward(inp, idx, bench_kwargs)
+            time_ref_group.append(time_ref)
+            output_ref_group.append(output_ref)
+        time_ref_fwd = sum(time_ref_group)
+        print(f"Pytorch forward time ({len(time_ref_group)}): {time_ref_group}")
+        time_ref_group = []
+        grad_group = []
+        for out in output_ref_group:
+            grad = torch.rand_like(out)
+            time_ref = bench_ref_backward(out, grad)
+            time_ref_group.append(time_ref)
+            grad_group.append(grad)
+        print(f"Pytorch backward time ({len(time_ref_group)}): {time_ref_group}")
+        time_ref_bwd = sum(time_ref_group)
+        grad = torch.cat(grad_group, dim=1)
+    else:
+        # Uniform shapes
+        offset_indices_group = []
+        indices_group = []
+        for i in range(num_groups):
+            # pyre-fixme[16]: Module `cuda` has no attribute `IntTensor`.
+            indices = torch.cuda.IntTensor(
+                gen_inverse_index(unique_batch_size, batch_size)
+            )
+            if sort_indices:
+                indices, _ = indices.sort()
+            indices_group.append(indices)
+            indices = torch.add(indices, batch_size * i)
+            offset_indices_group.append(indices)
+
+        offset_indices = torch.concat(offset_indices_group)
+
+        input = torch.rand(
+            num_groups * batch_size,
+            row_size,
+            dtype=dtype,
+            device=torch.accelerator.current_accelerator(),
+        )
+        input.requires_grad = True
+
+        num_bytes = 2 * batch_size * row_size * input.element_size() * num_groups
+        input_group = input.split(batch_size, 0)
+
+        # Run reference benchmark
+        time_ref_fwd, output_ref = bench_ref_forward(
+            input, offset_indices, bench_kwargs
+        )
+        grad = torch.rand_like(output_ref)
+        time_ref_bwd = bench_ref_backward(output_ref, grad)
 
     def _kineto_trace_handler(p: profile, phase: str) -> None:
         p.export_chrome_trace(trace_url.format(phase=phase, ospid=os.getpid()))
@@ -377,17 +509,6 @@ def group_index_select_2d_bench(
         return profile(on_trace_ready=on_trace_ready) if export_trace else nullcontext()
 
     # Benchmark forward
-    time_ref, output_ref = benchmark_torch_function(
-        # pyre-fixme[6]: For 3rd argument expected `bool` but got `int`.
-        # pyre-fixme[6]: For 3rd argument expected `str` but got `int`.
-        torch.index_select,
-        (input, 0, offset_indices),
-        # pyre-fixme[6]: For 3rd argument expected `bool` but got `int`.
-        # pyre-fixme[6]: For 3rd argument expected `str` but got `int`.
-        **bench_kwargs,
-    )
-
-    input_group = input.split(batch_size, 0)
     with context_factory(lambda p: _kineto_trace_handler(p, "fwd")):
         time, output_group = benchmark_torch_function(
             torch.ops.fbgemm.group_index_select_dim0,
@@ -397,23 +518,14 @@ def group_index_select_2d_bench(
             **bench_kwargs,
         )
     logging.info(
-        f"forward: PyTorch batch {time_ref:.5f} sec ({num_bytes / time_ref / 1e9:.5f} GB/s), "
+        f"forward: PyTorch batch {time_ref_fwd:.5f} sec ({num_bytes / time_ref_fwd / 1e9:.5f} GB/s), "
         f"fbgemm group {time:5f} sec ({num_bytes / time / 1e9:.5f} GB/s)"
     )
 
     # Benchmark backward
-    grad = torch.rand_like(output_ref)
-    time_ref, _ = benchmark_torch_function(
-        functools.partial(output_ref.backward, retain_graph=True),
-        (grad,),
-        # pyre-fixme[6]: For 3rd argument expected `bool` but got `int`.
-        # pyre-fixme[6]: For 3rd argument expected `str` but got `int`.
-        **bench_kwargs,
-    )
-
     # pyre-fixme[6]: For 1st argument expected `Union[List[Tensor],
     #  typing.Tuple[Tensor, ...]]` but got `Tensor`.
-    cat_output = torch.cat(output_group)
+    cat_output = torch.cat(output_group, dim=1 if input_dims else 0)
     with context_factory(lambda p: _kineto_trace_handler(p, "bwd")):
         time, _ = benchmark_torch_function(
             functools.partial(cat_output.backward, retain_graph=True),
@@ -423,7 +535,7 @@ def group_index_select_2d_bench(
             **bench_kwargs,
         )
     logging.info(
-        f"backward: PyTorch batch {time_ref:.5f} sec ({num_bytes / time_ref / 1e9:.5f} GB/s), "
+        f"backward: PyTorch batch {time_ref_bwd:.5f} sec ({num_bytes / time_ref_bwd / 1e9:.5f} GB/s), "
         f"fbgemm group {time:.5f} sec ({num_bytes / time / 1e9:.5f} GB/s)"
     )
 
@@ -838,13 +950,24 @@ def index_select_bench(
     input_columns = [columns] * num_inputs
     input_num_indices = [num_indices] * num_inputs
     inputs = [
-        torch.rand(rows, cols, dtype=torch.float, device="cuda")
+        torch.rand(
+            rows,
+            cols,
+            dtype=torch.float,
+            device=torch.accelerator.current_accelerator(),
+        )
         for rows, cols in zip(input_rows, input_columns)
     ]
     for i in range(len(inputs)):
         inputs[i].requires_grad = True
     indices = [
-        torch.randint(low=0, high=rows, size=(num,), dtype=torch.long, device="cuda")
+        torch.randint(
+            low=0,
+            high=rows,
+            size=(num,),
+            dtype=torch.long,
+            device=torch.accelerator.current_accelerator(),
+        )
         for num, rows in zip(input_num_indices, input_rows)
     ]
 
@@ -1064,9 +1187,15 @@ def cat_reorder_batched_ad_indices_bench(
 
     # pyre-ignore
     def pass_1(ad_indices, ad_lengths, batch_offsets, num_ads_in_batch):
-        cat_ad_lengths = torch.cat(ad_lengths, 0).to("cuda", non_blocking=True)
-        cat_ad_indices = torch.cat(ad_indices, 0).to("cuda", non_blocking=True)
-        batch_offsets = batch_offsets.to("cuda", non_blocking=True)
+        cat_ad_lengths = torch.cat(ad_lengths, 0).to(
+            torch.accelerator.current_accelerator(), non_blocking=True
+        )
+        cat_ad_indices = torch.cat(ad_indices, 0).to(
+            torch.accelerator.current_accelerator(), non_blocking=True
+        )
+        batch_offsets = batch_offsets.to(
+            torch.accelerator.current_accelerator(), non_blocking=True
+        )
         reordered_cat_ad_lengths = torch.ops.fbgemm.reorder_batched_ad_lengths(
             cat_ad_lengths, batch_offsets, num_ads_in_batch, broadcast_indices
         )
@@ -1101,17 +1230,25 @@ def cat_reorder_batched_ad_indices_bench(
         cat_ad_indices = torch.cat(ad_indices, 0)
 
         reordered_cat_ad_indices = torch.ops.fbgemm.reorder_batched_ad_indices(
-            cat_ad_offsets.to("cuda", non_blocking=True),
-            cat_ad_indices.to("cuda", non_blocking=True),
-            reordered_cat_ad_offsets.to("cuda", non_blocking=True),
-            batch_offsets.to("cuda", non_blocking=True),
+            cat_ad_offsets.to(
+                torch.accelerator.current_accelerator(), non_blocking=True
+            ),
+            cat_ad_indices.to(
+                torch.accelerator.current_accelerator(), non_blocking=True
+            ),
+            reordered_cat_ad_offsets.to(
+                torch.accelerator.current_accelerator(), non_blocking=True
+            ),
+            batch_offsets.to(
+                torch.accelerator.current_accelerator(), non_blocking=True
+            ),
             num_ads_in_batch,
             broadcast_indices,
             batch_size * table_size * num_ads * length,
         )
 
         return reordered_cat_ad_indices, reordered_cat_ad_lengths.to(
-            "cuda", non_blocking=True
+            torch.accelerator.current_accelerator(), non_blocking=True
         )
 
     # minimize GPU workload + unfused cat + reorder
@@ -1139,8 +1276,10 @@ def cat_reorder_batched_ad_indices_bench(
         )
 
         return reordered_cat_ad_indices.to(
-            "cuda", non_blocking=True
-        ), reordered_cat_ad_lengths.to("cuda", non_blocking=True)
+            torch.accelerator.current_accelerator(), non_blocking=True
+        ), reordered_cat_ad_lengths.to(
+            torch.accelerator.current_accelerator(), non_blocking=True
+        )
 
     # minimize GPU workload + fuse cat + reorder
     # pyre-ignore
@@ -1166,8 +1305,10 @@ def cat_reorder_batched_ad_indices_bench(
         )
 
         return reordered_cat_ad_indices.to(
-            "cuda", non_blocking=True
-        ), reordered_cat_ad_lengths.to("cuda", non_blocking=True)
+            torch.accelerator.current_accelerator(), non_blocking=True
+        ), reordered_cat_ad_lengths.to(
+            torch.accelerator.current_accelerator(), non_blocking=True
+        )
 
     num_bytes = batch_size * table_size * (num_ads + 1) * length * data_size
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2460

Add support for benchmarking `group_index_select_dim0` with heterogeneous per-group input shapes (matching the input configurations from `scripts/echen40/amd/benchmark/fbgemm/group_index_select/group_index_select_benchmark_{1,2,3}.py`).

Changes:

1. **`bench/sparse_ops_benchmark.py`** (modified): Add `--input-dims`, `--input-strides`, and `--index-dim` CLI options to `group_index_select_2d_bench` so it can accept per-group heterogeneous `[num_rows, row_size]` shapes. Extract `bench_ref_forward()` and `bench_ref_backward()` helpers to avoid code duplication between uniform and heterogeneous paths. Replace hardcoded `"cuda"` with `torch.accelerator.current_accelerator()` throughout.

   Usage:
   ```
   # Default uniform shapes (original behavior)
   buck run @//mode/opt //deeplearning/fbgemm/fbgemm_gpu/bench:sparse_ops -- group-index-select-2d-bench

   # Heterogeneous per-group shapes with custom index dim
   buck run @//mode/opt //deeplearning/fbgemm/fbgemm_gpu/bench:sparse_ops -- \
     group-index-select-2d-bench \
     --input-dims '[[27330,96],[288841,96],[4914,96]]' \
     --index-dim 1019100

   # With export trace
   buck run @//mode/opt //deeplearning/fbgemm/fbgemm_gpu/bench:sparse_ops -- \
     group-index-select-2d-bench --export-trace
   ```

2. **`scripts/fbgemm/run_sparse_benchmark.py`** (modified): Replace `--gpu nvidia/amd` flag with `-c`/`--arch` flag and add `resolve_arch()` function to handle arch/mode resolution consistently with `run_tbe_benchmark.sh` (supports h100, b200a, mi300, mi350).

   Usage:
   ```
   # Run all sparse ops benchmarks with export trace on H100
   python run_sparse_benchmark.py -c h100

   # Run a specific benchmark on MI300
   python run_sparse_benchmark.py -c mi300 --benchmark device

   # Keep trace files after test
   python run_sparse_benchmark.py -c h100 --keep-traces
   ```

3. **`scripts/fbgemm/run_group_index_select_benchmarks.sh`** (added): Runner script that builds the `sparse_ops` binary once via `buck2 build` and runs `group_index_select_2d_bench` with four benchmark configurations (default + 3 from echen40 scripts). Supports `--arch`, `--buck-config`, and `--export-trace` options.

   Usage:
   ```
   # Run on H100
   ./run_group_index_select_benchmarks.sh -c h100

   # Run on MI300 with trace export
   ./run_group_index_select_benchmarks.sh -c mi300 --export-trace

   # Run on B200A
   ./run_group_index_select_benchmarks.sh -c b200a
   ```

4. **`scripts/fbgemm/extract_gis_bench_from_log.py`** (added): Log extraction script that parses benchmark results from two log formats (full format with PyTorch reference + bandwidth, and fbgemm-only format) into a summary table with optional CSV output.

   Usage:
   ```
   # Extract results from a log file
   python extract_gis_bench_from_log.py logfile

   # Extract from multiple log files
   python extract_gis_bench_from_log.py log1 log2

   # Write results to CSV
   python extract_gis_bench_from_log.py --csv output.csv logfile

   # Read from stdin
   cat logfile | python extract_gis_bench_from_log.py
   ```

Reviewed By: q10

Differential Revision: D96882334
