### PR TITLE
Enable RES for DRAM KV embedding cache (#5488)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -288,6 +288,9 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         self.current_device: torch.device = torch.cuda.current_device()
 
         self.enable_raw_embedding_streaming = enable_raw_embedding_streaming
+        self._enable_ssd_raw_embedding_streaming = (
+            self.enable_raw_embedding_streaming and not self._embedding_cache_mode
+        )
         # initialize the raw embedding streaming related variables
         self.res_params: RESParams = res_params or RESParams()
         if self.enable_raw_embedding_streaming:
@@ -1618,7 +1621,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             if not do_evict:
                 return
 
-            if self.enable_raw_embedding_streaming:
+            if self._enable_ssd_raw_embedding_streaming:
                 self.raw_embedding_stream(
                     rows=inserted_rows,
                     indices_cpu=post_bwd_evicted_indices_cpu,
@@ -1935,7 +1938,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 count=actions_count_gpu,
             )
             has_raw_embedding_streaming = False
-            if self.enable_raw_embedding_streaming:
+            if self._enable_ssd_raw_embedding_streaming:
                 # when pipelining is enabled
                 # prefetch in iter i happens before the backward sparse in iter i - 1
                 # so embeddings for iter i - 1's changed ids are not updated.
@@ -2151,7 +2154,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             # Ensure that D2H is done
             current_stream.wait_event(self.ssd_event_get_inputs_cpy)
 
-            if self.enable_raw_embedding_streaming and has_raw_embedding_streaming:
+            if self._enable_ssd_raw_embedding_streaming and has_raw_embedding_streaming:
                 current_stream.wait_event(self.ssd_event_sp_streamed)
                 with record_function(
                     "## ssd_compute_updated_rows {} {} ##".format(

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
@@ -153,7 +153,8 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
         elem_size_(row_storage_bitwidth / 8),
         backend_return_whole_row_(backend_return_whole_row),
         feature_evict_config_(std::move(feature_evict_config)),
-        is_training_(is_training) {
+        is_training_(is_training),
+        enable_raw_embedding_streaming_(enable_raw_embedding_streaming) {
     executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(std::max<size_t>(
         num_threads, facebook::Proc::getCpuInfo().numCpuCores));
     // Dedicated executor for enrichment (low priority, won't affect
@@ -839,7 +840,23 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
             auto result = prepareFn(hashed_ids, unhashed_ids, payloads);
             if (result.has_value()) {
               set_kv_db_async_on_enrichment_executor(
-                  result->indices, result->weights, result->count);
+                  result->indices, result->weights, result->count)
+                  .via(enrichment_executor_.get())
+                  .thenValue([this, result](const std::vector<folly::Unit>&) {
+                    // Stream enriched embeddings to TrainingPsProcess for
+                    // delta publishing.
+                    if (enable_raw_embedding_streaming_) {
+                      raw_embedding_streamer_->stream(
+                          result->indices,
+                          result->weights,
+                          std::nullopt, /*identities*/
+                          std::nullopt, /*runtime_meta*/
+                          result->count,
+                          false, /*require_tensor_copy - tensors already on
+                                    CPU*/
+                          false /*blocking_tensor_copy*/);
+                    }
+                  });
             }
           }
           pending_laser_requests_.fetch_sub(1);
@@ -2398,6 +2415,9 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
   std::atomic<int64_t> read_num_counts_{0};
 
   bool disable_random_init_;
+
+  // Whether raw embedding streaming (RES) is enabled for this cache
+  bool enable_raw_embedding_streaming_ = false;
 
   // Enrichment configuration (passed from Python, replaces hardcoded laser
   // config)


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2461

Enable RES (Raw Embedding Streaming)
Key changes:

- Make raw_embedding_streamer_ protected for subclass access
- Change .deferValue() to .via(laser_executor_).thenValue()
  so the streaming callback actually executes
- Add raw_embedding_streamer_->stream() call in writeEmbeddingsToCacheAsync
- Guard SSD-path RES with `not self._embedding_cache_mode` to avoid
  double-streaming when DRAM cache handles its own RES flow

Reviewed By: FriedCosey

Differential Revision: D94287838
