### PR TITLE
Fix Vec2/Vec4 UVM performance regression with vectorized at::BFloat16 loads/stores (#5489)

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/rocm/vec2.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/rocm/vec2.h
@@ -112,8 +112,13 @@ struct Vec2T<float> : public Vec2BaseT<float> {
   }
 
   DEVICE_INLINE void load(const at::BFloat16* p) {
-    acc.x = p[0];
-    acc.y = p[1];
+    union {
+      at::BFloat16 bf[2];
+      unsigned int ui;
+    } tmp;
+    tmp.ui = *reinterpret_cast<const unsigned int*>(p);
+    acc.x = tmp.bf[0];
+    acc.y = tmp.bf[1];
   }
 
   DEVICE_INLINE void load(const at::Float8_e4m3fnuz* p) {
@@ -150,8 +155,13 @@ struct Vec2T<float> : public Vec2BaseT<float> {
   }
 
   DEVICE_INLINE void store(at::BFloat16* p) const {
-    p[0] = acc.x;
-    p[1] = acc.y;
+    union {
+      at::BFloat16 bf[2];
+      unsigned int ui;
+    } tmp;
+    tmp.bf[0] = acc.x;
+    tmp.bf[1] = acc.y;
+    *reinterpret_cast<unsigned int*>(p) = tmp.ui;
   }
 
   DEVICE_INLINE void store(at::Float8_e4m3fnuz* p) const {
@@ -233,8 +243,13 @@ struct Vec2T<at::Half> : public Vec2BaseT<at::Half> {
   }
 
   DEVICE_INLINE void load(const at::BFloat16* p) {
-    acc.x = p[0];
-    acc.y = p[1];
+    union {
+      at::BFloat16 bf[2];
+      unsigned int ui;
+    } tmp;
+    tmp.ui = *reinterpret_cast<const unsigned int*>(p);
+    acc.x = tmp.bf[0];
+    acc.y = tmp.bf[1];
   }
 
   DEVICE_INLINE void load(const float* p) {
@@ -256,8 +271,13 @@ struct Vec2T<at::Half> : public Vec2BaseT<at::Half> {
   }
 
   DEVICE_INLINE void store(at::BFloat16* p) const {
-    p[0] = acc.x;
-    p[1] = acc.y;
+    union {
+      at::BFloat16 bf[2];
+      unsigned int ui;
+    } tmp;
+    tmp.bf[0] = acc.x;
+    tmp.bf[1] = acc.y;
+    *reinterpret_cast<unsigned int*>(p) = tmp.ui;
   }
 
   DEVICE_INLINE void store(float* p) const {
@@ -336,8 +356,13 @@ struct Vec2T<at::BFloat16> : public Vec2BaseT<at::BFloat16> {
   }
 
   DEVICE_INLINE void load(const at::BFloat16* p) {
-    acc.x = p[0];
-    acc.y = p[1];
+    union {
+      at::BFloat16 bf[2];
+      unsigned int ui;
+    } tmp;
+    tmp.ui = *reinterpret_cast<const unsigned int*>(p);
+    acc.x = tmp.bf[0];
+    acc.y = tmp.bf[1];
   }
 
   DEVICE_INLINE void load(const at::Half* p) {
@@ -374,8 +399,13 @@ struct Vec2T<at::BFloat16> : public Vec2BaseT<at::BFloat16> {
   }
 
   DEVICE_INLINE void store(at::BFloat16* p) const {
-    p[0] = acc.x;
-    p[1] = acc.y;
+    union {
+      at::BFloat16 bf[2];
+      unsigned int ui;
+    } tmp;
+    tmp.bf[0] = acc.x;
+    tmp.bf[1] = acc.y;
+    *reinterpret_cast<unsigned int*>(p) = tmp.ui;
   }
 
   DEVICE_INLINE void store(float* p) const {
@@ -387,8 +417,8 @@ struct Vec2T<at::BFloat16> : public Vec2BaseT<at::BFloat16> {
   }
 
   DEVICE_INLINE static void copy(const at::BFloat16* src, at::BFloat16* dst) {
-    dst[0] = src[0];
-    dst[1] = src[1];
+    *reinterpret_cast<unsigned int*>(dst) =
+        *reinterpret_cast<const unsigned int*>(src);
   }
 
   // this <- this + a * b

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/vec4.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/vec4.cuh
@@ -112,10 +112,22 @@ struct Vec4T<float> : public Vec4BaseT<float> {
   }
 
   DEVICE_INLINE void load(const at::BFloat16* p) {
+#ifdef USE_ROCM
+    union {
+      at::BFloat16 bf[4];
+      uint2 ui;
+    } tmp;
+    tmp.ui = *reinterpret_cast<const uint2*>(p);
+    acc.x = tmp.bf[0];
+    acc.y = tmp.bf[1];
+    acc.z = tmp.bf[2];
+    acc.w = tmp.bf[3];
+#else
     acc.x = p[0];
     acc.y = p[1];
     acc.z = p[2];
     acc.w = p[3];
+#endif
   }
 
   DEVICE_INLINE void load(const at::Float8_e4m3fnuz* p) {
@@ -168,10 +180,22 @@ struct Vec4T<float> : public Vec4BaseT<float> {
   }
 
   DEVICE_INLINE void store(at::BFloat16* p) const {
+#ifdef USE_ROCM
+    union {
+      at::BFloat16 bf[4];
+      uint2 ui;
+    } tmp;
+    tmp.bf[0] = acc.x;
+    tmp.bf[1] = acc.y;
+    tmp.bf[2] = acc.z;
+    tmp.bf[3] = acc.w;
+    *reinterpret_cast<uint2*>(p) = tmp.ui;
+#else
     p[0] = acc.x;
     p[1] = acc.y;
     p[2] = acc.z;
     p[3] = acc.w;
+#endif
   }
 
   DEVICE_INLINE void store(at::Float8_e4m3fn* p) const {
@@ -296,10 +320,22 @@ struct Vec4T<at::Half> : public Vec4BaseT<at::Half> {
   }
 
   DEVICE_INLINE void load(const at::BFloat16* p) {
+#ifdef USE_ROCM
+    union {
+      at::BFloat16 bf[4];
+      uint2 ui;
+    } tmp;
+    tmp.ui = *reinterpret_cast<const uint2*>(p);
+    acc.x = tmp.bf[0];
+    acc.y = tmp.bf[1];
+    acc.z = tmp.bf[2];
+    acc.w = tmp.bf[3];
+#else
     acc.x = p[0];
     acc.y = p[1];
     acc.z = p[2];
     acc.w = p[3];
+#endif
   }
 
   DEVICE_INLINE void load(const float* p) {
@@ -326,10 +362,22 @@ struct Vec4T<at::Half> : public Vec4BaseT<at::Half> {
   }
 
   DEVICE_INLINE void store(at::BFloat16* p) const {
+#ifdef USE_ROCM
+    union {
+      at::BFloat16 bf[4];
+      uint2 ui;
+    } tmp;
+    tmp.bf[0] = acc.x;
+    tmp.bf[1] = acc.y;
+    tmp.bf[2] = acc.z;
+    tmp.bf[3] = acc.w;
+    *reinterpret_cast<uint2*>(p) = tmp.ui;
+#else
     p[0] = acc.x;
     p[1] = acc.y;
     p[2] = acc.z;
     p[3] = acc.w;
+#endif
   }
 
   DEVICE_INLINE void store(float* p) const {
@@ -441,10 +489,22 @@ struct Vec4T<at::BFloat16> : public Vec4BaseT<at::BFloat16> {
   }
 
   DEVICE_INLINE void load(const at::BFloat16* p) {
+#ifdef USE_ROCM
+    union {
+      at::BFloat16 bf[4];
+      uint2 ui;
+    } tmp;
+    tmp.ui = *reinterpret_cast<const uint2*>(p);
+    acc.x = tmp.bf[0];
+    acc.y = tmp.bf[1];
+    acc.z = tmp.bf[2];
+    acc.w = tmp.bf[3];
+#else
     acc.x = p[0];
     acc.y = p[1];
     acc.z = p[2];
     acc.w = p[3];
+#endif
   }
 
   DEVICE_INLINE void load(const at::Half* p) {
@@ -504,10 +564,22 @@ struct Vec4T<at::BFloat16> : public Vec4BaseT<at::BFloat16> {
   }
 
   DEVICE_INLINE void store(at::BFloat16* p) const {
+#ifdef USE_ROCM
+    union {
+      at::BFloat16 bf[4];
+      uint2 ui;
+    } tmp;
+    tmp.bf[0] = acc.x;
+    tmp.bf[1] = acc.y;
+    tmp.bf[2] = acc.z;
+    tmp.bf[3] = acc.w;
+    *reinterpret_cast<uint2*>(p) = tmp.ui;
+#else
     p[0] = acc.x;
     p[1] = acc.y;
     p[2] = acc.z;
     p[3] = acc.w;
+#endif
   }
 
   DEVICE_INLINE void store(float* p) const {
@@ -519,10 +591,14 @@ struct Vec4T<at::BFloat16> : public Vec4BaseT<at::BFloat16> {
   }
 
   DEVICE_INLINE static void copy(const at::BFloat16* src, at::BFloat16* dst) {
+#ifdef USE_ROCM
+    *reinterpret_cast<uint2*>(dst) = *reinterpret_cast<const uint2*>(src);
+#else
     dst[0] = src[0];
     dst[1] = src[1];
     dst[2] = src[2];
     dst[3] = src[3];
+#endif
   }
 
   // this <- this + a * b


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2462


Apply vectorized load/store optimization pattern for at::BFloat16 types in Vec2 and Vec4 classes for ROCm. This ensures BFloat16 vector types use efficient 32-bit or 64-bit memory operations instead of scalar element-by-element access.

With UVM (managed memory), each separate load/store can trigger a page fault, causing significant slowdown. Using vectorized operations reduces this overhead.

Reviewed By: henrylhtsang

Differential Revision: D96381301
