### PR TITLE
fix a device unmatched errors in benchmark

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/utils/requests.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/utils/requests.py
@@ -267,7 +267,7 @@ def generate_indices_uniform(
                 L_t = int(table_lengths.max().item())
                 if L_t == 0:
                     all_table_indices.append(
-                        torch.empty(iters, 0, dtype=torch.int).to(device)
+                        torch.empty(iters, 0, dtype=torch.int).to(dev)
                     )
                     continue
                 tbl_indices = torch.randint(


### PR DESCRIPTION
Summary: It seems when there is L=0 entry, it will cause dtype mismatch

Reviewed By: JChunX

Differential Revision: D97034859


