### PR TITLE
Fix Vec2/Vec4 UVM performance regression with vectorized at::Half copy

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/rocm/vec2.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/rocm/vec2.h
@@ -289,8 +289,12 @@ struct Vec2T<at::Half> : public Vec2BaseT<at::Half> {
   }
 
   DEVICE_INLINE static void copy(const at::Half* src, at::Half* dst) {
-    dst[0] = src[0];
-    dst[1] = src[1];
+    // CRITICAL PERFORMANCE FIX: Use single 32-bit store instead of two scalar
+    // 16-bit copies. With UVM (managed memory), each scalar copy can trigger
+    // a separate page fault, causing significant slowdown.
+    //
+    // See: D95586869, internal doc "FBGEMM TBE UVM Regression on AMD MI300x"
+    *reinterpret_cast<half2*>(dst) = *reinterpret_cast<const half2*>(src);
   }
 
   // this <- this + a * b

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/vec4.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/vec4.cuh
@@ -390,10 +390,7 @@ struct Vec4T<at::Half> : public Vec4BaseT<at::Half> {
 
   DEVICE_INLINE static void copy(const at::Half* src, at::Half* dst) {
 #ifdef USE_ROCM
-    dst[0] = src[0];
-    dst[1] = src[1];
-    dst[2] = src[2];
-    dst[3] = src[3];
+    *reinterpret_cast<uint2*>(dst) = *reinterpret_cast<const uint2*>(src);
 #else
     Half4 out;
     asm("ld.global.v2.u32 {%0, %1}, [%2];"


### PR DESCRIPTION
Summary:
Apply vectorized copy optimization pattern for at::Half types in Vec2 and Vec4 classes for ROCm. This ensures at::Half copy operations use efficient 32-bit or 64-bit memory operations instead of scalar element-by-element access.

With UVM (managed memory), each separate copy can trigger a page fault, causing significant slowdown. Using vectorized operations reduces this overhead.

Reviewed By: spcyppt

Differential Revision: D96381299


