### PR TITLE
Add OneFlow OpenTab enrichment backend support (#5493)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -236,6 +236,7 @@ class EvictionPolicy(NamedTuple):
 class EnrichmentType(enum.IntEnum):
     IGR_LASER_EMBEDDING = 0
     IGR_LASER_SID = 1
+    ONEFLOW_OPENTAB_SID = 2
 
 
 class EnrichmentResponseFormat(enum.IntEnum):
@@ -255,6 +256,14 @@ class EnrichmentPolicy(NamedTuple):
     enrichment_dim: int = 0
     # Deserialization format
     response_format: EnrichmentResponseFormat = EnrichmentResponseFormat.JSON
+    # OpenTab/Maple configuration (used for ONEFLOW_OPENTAB_SID)
+    opentab_tier_name: str = ""
+    opentab_payload_ids: str = ""  # comma-separated, e.g. "31739"
+    opentab_payload_types: str = ""  # comma-separated, e.g. "2"
+    opentab_column_group_ids: str = ""  # comma-separated, e.g. "12"
+    opentab_vec_payload_indexes: str = ""  # comma-separated, e.g. "0"
+    opentab_timeout_ms: int = 5000
+    opentab_batch_size: int = 100
 
 
 class KVZCHParams(NamedTuple):

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -783,6 +783,13 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                     ep.client_id,
                     ep.enrichment_dim,
                     ep.response_format.value,
+                    ep.opentab_tier_name,
+                    ep.opentab_payload_ids,
+                    ep.opentab_payload_types,
+                    ep.opentab_column_group_ids,
+                    ep.opentab_vec_payload_indexes,
+                    ep.opentab_timeout_ms,
+                    ep.opentab_batch_size,
                 )
             self._ssd_db = torch.classes.fbgemm.DramKVEmbeddingCacheWrapper(
                 self.cache_row_dim,

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
@@ -35,6 +35,7 @@
 #include "feature_evict.h"
 #include "fixed_block_pool.h"
 #include "igr_enrichment.h"
+#include "oneflow_enrichment.h"
 
 namespace kv_mem {
 
@@ -166,6 +167,13 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
               kv_mem::EnrichmentType::IGR_LASER_SID) {
         laser_client_ =
             igr_enrichment::initializeLaserClient(*enrichment_config_.value());
+      }
+
+      // Initialize OpenTab reader if type is ONEFLOW_OPENTAB_SID
+      if (enrichment_config_.value()->enrichment_type_ ==
+          kv_mem::EnrichmentType::ONEFLOW_OPENTAB_SID) {
+        open_tab_reader_ = oneflow_enrichment::initializeOpenTabReader(
+            *enrichment_config_.value());
       }
     }
     initialize_initializers(
@@ -1042,6 +1050,47 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                             auto result =
                                 igr_enrichment::prepareSIDCacheWriteTensors(
                                     hashed_ids, unhashed_ids, sid_map, max_D_);
+                            if (result.has_value()) {
+                              set_kv_db_async_on_enrichment_executor(
+                                  result->indices,
+                                  result->weights,
+                                  result->count);
+                            }
+                          }
+                          pending_laser_requests_.fetch_sub(1);
+                          laser_write_in_progress_.store(false);
+                        })
+                        .scheduleOn(enrichment_executor_.get())
+                        .start();
+                  } else if (
+                      enrichment_type ==
+                      kv_mem::EnrichmentType::ONEFLOW_OPENTAB_SID) {
+                    folly::coro::co_invoke(
+                        [this,
+                         hashed_ids = std::move(all_zero_weight_hashed_ids),
+                         unhashed_ids =
+                             std::move(all_zero_weight_unhashed_ids)]() mutable
+                            -> folly::coro::Task<void> {
+                          auto start_time =
+                              facebook::WallClockUtil::NowInUsecFast();
+                          auto payloads =
+                              co_await oneflow_enrichment::fetchFromOpenTab(
+                                  open_tab_reader_,
+                                  *enrichment_config_.value(),
+                                  unhashed_ids);
+                          auto opentab_latency_ms =
+                              (facebook::WallClockUtil::NowInUsecFast() -
+                               start_time) /
+                              1000;
+                          XLOG(INFO)
+                              << "[EmbeddingCacheEnrich] opentab_hit: "
+                              << payloads.size() << "/" << unhashed_ids.size()
+                              << ", latency_ms: " << opentab_latency_ms;
+                          if (!payloads.empty()) {
+                            auto result =
+                                oneflow_enrichment::prepareInt64PayloadTensors<
+                                    weight_type>(
+                                    hashed_ids, unhashed_ids, payloads, max_D_);
                             if (result.has_value()) {
                               set_kv_db_async_on_enrichment_executor(
                                   result->indices,
@@ -2234,6 +2283,9 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
 
   // Pre-initialized LaserClient for IGR enrichment (reused across fetches)
   std::shared_ptr<facebook::laser::LaserClient> laser_client_;
+
+  // OpenTab/Maple reader for ONEFLOW_OPENTAB_SID enrichment (type-erased)
+  oneflow_enrichment::ReaderPtr open_tab_reader_;
 }; // class DramKVEmbeddingCache
 
 } // namespace kv_mem

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/enrichment_config.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/enrichment_config.h
@@ -21,6 +21,7 @@ namespace kv_mem {
 enum class EnrichmentType : int64_t {
   IGR_LASER_EMBEDDING = 0,
   IGR_LASER_SID = 1,
+  ONEFLOW_OPENTAB_SID = 2,
 };
 
 /// Must match Python EnrichmentResponseFormat(IntEnum) in
@@ -40,24 +41,55 @@ struct EnrichmentConfig : public torch::jit::CustomClassHolder {
   /// @param client_id Client identifier for the external service
   /// @param enrichment_dim Dimension of data returned by the source
   /// @param response_format EnrichmentResponseFormat int value
+  /// @param opentab_tier_name OpenTab/Maple tier name
+  /// @param opentab_payload_ids Comma-separated payload IDs
+  /// @param opentab_payload_types Comma-separated payload types (0=INT, 2=VEC)
+  /// @param opentab_column_group_ids Comma-separated column group IDs
+  /// @param opentab_vec_payload_indexes Comma-separated vec payload indexes
+  /// @param opentab_timeout_ms OpenTab request timeout in ms
+  /// @param opentab_batch_size OpenTab batch size
   explicit EnrichmentConfig(
       int64_t enrichment_type,
       std::string provider_name,
       std::string client_id,
       int64_t enrichment_dim,
-      int64_t response_format)
+      int64_t response_format,
+      std::string opentab_tier_name = "",
+      std::string opentab_payload_ids = "",
+      std::string opentab_payload_types = "",
+      std::string opentab_column_group_ids = "",
+      std::string opentab_vec_payload_indexes = "",
+      int64_t opentab_timeout_ms = 5000,
+      int64_t opentab_batch_size = 100)
       : enrichment_type_(static_cast<EnrichmentType>(enrichment_type)),
         provider_name_(std::move(provider_name)),
         client_id_(std::move(client_id)),
         enrichment_dim_(enrichment_dim),
         response_format_(
-            static_cast<EnrichmentResponseFormat>(response_format)) {}
+            static_cast<EnrichmentResponseFormat>(response_format)),
+        opentab_tier_name_(std::move(opentab_tier_name)),
+        opentab_payload_ids_(std::move(opentab_payload_ids)),
+        opentab_payload_types_(std::move(opentab_payload_types)),
+        opentab_column_group_ids_(std::move(opentab_column_group_ids)),
+        opentab_vec_payload_indexes_(std::move(opentab_vec_payload_indexes)),
+        opentab_timeout_ms_(opentab_timeout_ms),
+        opentab_batch_size_(opentab_batch_size) {}
 
   EnrichmentType enrichment_type_;
   std::string provider_name_;
   std::string client_id_;
   int64_t enrichment_dim_;
   EnrichmentResponseFormat response_format_;
+
+  // OpenTab/Maple configuration (used when enrichment_type_ ==
+  // ONEFLOW_OPENTAB_SID)
+  std::string opentab_tier_name_;
+  std::string opentab_payload_ids_;
+  std::string opentab_payload_types_;
+  std::string opentab_column_group_ids_;
+  std::string opentab_vec_payload_indexes_;
+  int64_t opentab_timeout_ms_;
+  int64_t opentab_batch_size_;
 };
 
 } // namespace kv_mem

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/oneflow_enrichment.cpp
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/oneflow_enrichment.cpp
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "enrichment_config.h"
+#include "opentab_backend_registry.h"
+
+#include <folly/String.h>
+#include <folly/container/F14Set.h>
+#include <folly/coro/Collect.h>
+#include <folly/coro/Timeout.h>
+#include <folly/logging/xlog.h>
+
+#include "multifeed/leaf5/maple/client/coro/MapleClient.h"
+#include "multifeed/opentab/db/reader/MapleReader.h"
+#include "multifeed/opentab/db/reader/ObjectReaderImpl.h"
+#include "multifeed/opentab/schema/ConfiguratorSchemaManagerProvider.h"
+
+namespace oneflow_enrichment {
+namespace {
+
+std::vector<int32_t> parseCommaSeparatedInts(const std::string& s) {
+  std::vector<int32_t> result;
+  if (s.empty()) {
+    return result;
+  }
+  std::vector<folly::StringPiece> parts;
+  folly::split(',', s, parts);
+  result.reserve(parts.size());
+  for (const auto& part : parts) {
+    result.push_back(folly::to<int32_t>(folly::trimWhitespace(part)));
+  }
+  return result;
+}
+ReaderPtr initializeOpenTabReaderImpl(const kv_mem::EnrichmentConfig& config) {
+  auto reader = std::make_shared<
+      facebook::multifeed::opentab::SimpleObjectReader>(
+      folly::make_not_null_unique<facebook::multifeed::opentab::MapleReader>(
+          folly::make_not_null_unique<facebook::maple::MapleClient>(
+              config.opentab_tier_name_)),
+      facebook::multifeed::opentab::schema::ConfiguratorSchemaManagerProvider::
+          getInstance());
+
+  XLOG(INFO) << "[EmbeddingCacheEnrich] OpenTab reader initialized: "
+             << "tier=" << config.opentab_tier_name_
+             << ", client_id=" << config.client_id_
+             << ", timeout_ms=" << config.opentab_timeout_ms_
+             << ", batch_size=" << config.opentab_batch_size_
+             << ", payload_ids=" << config.opentab_payload_ids_
+             << ", column_group_ids=" << config.opentab_column_group_ids_;
+
+  return reader;
+}
+
+folly::coro::Task<folly::F14FastMap<int64_t, int64_t>> fetchFromOpenTabImpl(
+    const ReaderPtr& readerPtr,
+    const kv_mem::EnrichmentConfig& config,
+    const std::vector<int64_t>& objectIds) {
+  auto reader =
+      std::static_pointer_cast<facebook::multifeed::opentab::ObjectReader>(
+          readerPtr);
+  folly::F14FastMap<int64_t, int64_t> objectIdToPayloadMap;
+
+  auto column_group_ids =
+      parseCommaSeparatedInts(config.opentab_column_group_ids_);
+  auto payload_ids = parseCommaSeparatedInts(config.opentab_payload_ids_);
+  auto payload_types = parseCommaSeparatedInts(config.opentab_payload_types_);
+  auto vec_payload_indexes =
+      parseCommaSeparatedInts(config.opentab_vec_payload_indexes_);
+
+  if (!reader || objectIds.empty() || column_group_ids.empty()) {
+    co_return objectIdToPayloadMap;
+  }
+
+  // Dedupe object IDs
+  folly::F14FastSet<int64_t> dedupedIds(objectIds.begin(), objectIds.end());
+
+  // Create batches of OpenTabKeys
+  std::vector<std::vector<facebook::multifeed::opentab::OpenTabKey>> keyBatches;
+  const size_t batchSize = static_cast<size_t>(config.opentab_batch_size_);
+  const size_t numBatches = (dedupedIds.size() + batchSize - 1) / batchSize;
+  keyBatches.reserve(numBatches);
+
+  auto it = dedupedIds.begin();
+  const auto end = dedupedIds.end();
+
+  while (it != end) {
+    std::vector<facebook::multifeed::opentab::OpenTabKey> batch;
+    const size_t keysInThisBatch =
+        std::min(batchSize, static_cast<size_t>(std::distance(it, end)));
+    batch.reserve(keysInThisBatch * column_group_ids.size());
+
+    for (size_t count = 0; count < batchSize && it != end; ++count, ++it) {
+      const int64_t objectId = *it;
+      for (int32_t columnGroupId : column_group_ids) {
+        batch.emplace_back(objectId, columnGroupId);
+      }
+    }
+    keyBatches.push_back(std::move(batch));
+  }
+
+  XLOG(INFO) << "[EmbeddingCacheEnrich] OpenTab fetching " << dedupedIds.size()
+             << " unique IDs in " << keyBatches.size() << " batches";
+
+  // Create futures for all batch requests
+  std::vector<folly::coro::Task<
+      facebook::multifeed::opentab::ObjectReadObjectSummariesResult>>
+      batchTasks;
+  batchTasks.reserve(keyBatches.size());
+
+  for (auto&& batch : keyBatches) {
+    batchTasks.push_back(reader->coReadIntoObjectSummaries(
+        std::move(batch),
+        0 /* retention */,
+        0 /* queryTimepoint */,
+        config.client_id_,
+        column_group_ids.size(),
+        std::nullopt /* tierName */,
+        {} /* batchConfig */));
+  }
+
+  // Collect all results with timeout
+  std::vector<
+      folly::Try<facebook::multifeed::opentab::ObjectReadObjectSummariesResult>>
+      batchResults;
+  try {
+    batchResults = co_await folly::coro::co_withCancellation(
+        folly::CancellationToken{},
+        folly::coro::timeout(
+            folly::coro::collectAllTryRange(std::move(batchTasks)),
+            std::chrono::milliseconds(config.opentab_timeout_ms_)));
+  } catch (const folly::FutureTimeout&) {
+    XLOG(WARNING) << "[EmbeddingCacheEnrich] OpenTab fetch timeout after "
+                  << config.opentab_timeout_ms_ << "ms";
+    co_return objectIdToPayloadMap;
+  }
+
+  // Merge results from all batches
+  folly::F14FastMap<
+      int64_t,
+      std::shared_ptr<const facebook::multifeed::ObjectSummary>>
+      objectSummaryMap;
+  int64_t missingObjectCount = 0;
+
+  for (auto& batchResult : batchResults) {
+    if (batchResult.hasException()) {
+      XLOG(WARNING) << "[EmbeddingCacheEnrich] OpenTab batch failed: "
+                    << batchResult.exception().what();
+      continue;
+    }
+    for (const auto& osPtr : batchResult.value().values) {
+      if (osPtr != nullptr && osPtr->object_id().value() > 0) {
+        objectSummaryMap.emplace(osPtr->object_id().value(), osPtr);
+      } else {
+        missingObjectCount++;
+      }
+    }
+  }
+
+  XLOG(INFO) << "[EmbeddingCacheEnrich] OpenTab fetched "
+             << objectSummaryMap.size() << " objects, " << missingObjectCount
+             << " missing";
+
+  // Extract single payload value for each object
+  for (const auto& [objectId, os] : objectSummaryMap) {
+    int64_t payloadValue = -1; // default to -1 (will be skipped during write)
+
+    if (!payload_ids.empty()) {
+      int32_t payloadId = payload_ids[0];
+      int32_t payloadType = payload_types.empty() ? 0 : payload_types[0];
+      int32_t vecPayloadIndex =
+          vec_payload_indexes.empty() ? 0 : vec_payload_indexes[0];
+
+      if (payloadType == 0) {
+        // INT payload type
+        auto pit = os->intPayload()->find(payloadId);
+        if (pit != os->intPayload()->end()) {
+          payloadValue = pit->second;
+        }
+      } else if (payloadType == 1 || payloadType == 2) {
+        // VEC payload type (1 or 2)
+        auto pit = os->vecPayload()->find(payloadId);
+        if (pit != os->vecPayload()->end() &&
+            static_cast<size_t>(vecPayloadIndex) < pit->second.size()) {
+          payloadValue = pit->second.at(vecPayloadIndex);
+        }
+      } else {
+        XLOG_EVERY_MS(WARNING, 5000)
+            << "[EmbeddingCacheEnrich] Unsupported payload type: "
+            << payloadType;
+      }
+    }
+
+    objectIdToPayloadMap.emplace(objectId, payloadValue);
+  }
+
+  co_return objectIdToPayloadMap;
+}
+
+} // anonymous namespace
+
+// Static registration: register the maple-backed implementation into the
+// global OpenTabBackend registry. This runs when the library is loaded.
+static auto _opentab_registration = []() {
+  auto& backend = OpenTabBackend::instance();
+  backend.initReader = initializeOpenTabReaderImpl;
+  backend.fetchPayloads = fetchFromOpenTabImpl;
+  XLOG(INFO) << "[EmbeddingCacheEnrich] OpenTab backend registered";
+  return 0;
+}();
+
+} // namespace oneflow_enrichment

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/oneflow_enrichment.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/oneflow_enrichment.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <torch/torch.h>
+#include <optional>
+
+#include "enrichment_config.h"
+#include "igr_enrichment.h"
+#include "opentab_backend_registry.h"
+
+namespace oneflow_enrichment {
+
+/// Prepare tensors for writing int64 payloads into the cache.
+/// Each int64 payload is encoded as 16 nibbles -> power-of-2 float32 (FP8-safe
+/// encoding). Each 4-bit nibble n maps to: pow(2, n>>1) * (-1 if n&1 else 1)
+/// All encoded values are exact in FP8 E4M3 after per-row scaling.
+template <typename weight_type>
+inline std::optional<igr_enrichment::EnrichmentResult>
+prepareInt64PayloadTensors(
+    const std::vector<int64_t>& hashed_ids,
+    const std::vector<int64_t>& unhashed_ids,
+    const folly::F14FastMap<int64_t, int64_t>& payloads,
+    int64_t /*max_D*/) {
+  if (hashed_ids.size() != unhashed_ids.size()) {
+    XLOG(ERR) << "[EmbeddingCacheEnrich] hashed_ids and unhashed_ids size "
+                 "mismatch: "
+              << hashed_ids.size() << " vs " << unhashed_ids.size();
+    return std::nullopt;
+  }
+
+  std::vector<int64_t> indices_vec;
+  std::vector<float> weights_vec;
+
+  for (size_t idx = 0; idx < unhashed_ids.size(); ++idx) {
+    int64_t unhashed_id = unhashed_ids[idx];
+    int64_t hashed_id = hashed_ids[idx];
+
+    auto it = payloads.find(unhashed_id);
+    if (it == payloads.end()) {
+      continue;
+    }
+
+    int64_t payload_value = it->second;
+
+    // Skip if payload is -1 or 0 (missing data)
+    if (payload_value == -1 || payload_value == 0) {
+      continue;
+    }
+
+    indices_vec.push_back(hashed_id);
+
+    // Encode int64_t as 16 nibbles -> power-of-2 float32 (FP8-safe encoding)
+    // Each 4-bit nibble n maps to: pow(2, n>>1) * (-1 if n&1 else 1)
+    // All encoded values are exact in FP8 E4M3 after per-row scaling
+    // (they map to ±3.5×2^k which are exact E4M3 representable values)
+    static constexpr float kNibbleToFloat[16] = {
+        1.0f,
+        -1.0f,
+        2.0f,
+        -2.0f,
+        4.0f,
+        -4.0f,
+        8.0f,
+        -8.0f,
+        16.0f,
+        -16.0f,
+        32.0f,
+        -32.0f,
+        64.0f,
+        -64.0f,
+        128.0f,
+        -128.0f};
+    uint64_t uval = static_cast<uint64_t>(payload_value);
+    for (int i = 0; i < 16; ++i) {
+      uint8_t nibble = (uval >> (i * 4)) & 0xF;
+      weights_vec.push_back(kNibbleToFloat[nibble]);
+    }
+  }
+
+  if (indices_vec.empty()) {
+    XLOG(INFO) << "[EmbeddingCacheEnrich] prepareInt64PayloadTensors: "
+               << "no valid payloads to write (all -1 or missing)";
+    return std::nullopt;
+  }
+
+  int64_t num_embeddings = indices_vec.size();
+  constexpr int64_t kEmbeddingDim = 16;
+
+  auto indices_tensor =
+      torch::from_blob(indices_vec.data(), {num_embeddings}, torch::kInt64)
+          .clone();
+  auto weights_tensor =
+      torch::from_blob(
+          weights_vec.data(), {num_embeddings, kEmbeddingDim}, torch::kFloat32)
+          .clone();
+
+  // Convert to weight_type if needed
+  if constexpr (!std::is_same_v<weight_type, float>) {
+    weights_tensor =
+        weights_tensor.to(torch::CppTypeToScalarType<weight_type>());
+  }
+
+  auto count_tensor = torch::tensor({num_embeddings}, torch::kLong);
+
+  XLOG(INFO) << "[EmbeddingCacheEnrich] prepareInt64PayloadTensors: "
+             << "num_embeddings=" << num_embeddings
+             << ", embedding_dim=" << kEmbeddingDim
+             << ", total_payloads=" << payloads.size()
+             << ", skipped=" << (payloads.size() - num_embeddings);
+
+  return igr_enrichment::EnrichmentResult{
+      indices_tensor,
+      weights_tensor,
+      count_tensor,
+  };
+}
+
+} // namespace oneflow_enrichment

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/opentab_backend_registry.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/opentab_backend_registry.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include <folly/coro/Task.h>
+#include <folly/logging/xlog.h>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+// Forward declaration — avoids pulling in torch/script.h
+namespace kv_mem {
+struct EnrichmentConfig;
+} // namespace kv_mem
+
+namespace oneflow_enrichment {
+
+/// Type-erased reader pointer (actual type is ObjectReader, resolved at
+/// runtime by the registered backend).
+using ReaderPtr = std::shared_ptr<void>;
+
+/// Registry for OpenTab backend implementation.
+/// The actual maple/opentab implementation is registered at static-init time
+/// by the oneflow_enrichment_backend library, which carries the heavy deps.
+/// This decouples the main ssd_split_table_batched_embeddings target from
+/// instagram/ranking transitive dependencies.
+struct OpenTabBackend {
+  using InitFn = std::function<ReaderPtr(const kv_mem::EnrichmentConfig&)>;
+  using FetchFn =
+      std::function<folly::coro::Task<folly::F14FastMap<int64_t, int64_t>>(
+          const ReaderPtr&,
+          const kv_mem::EnrichmentConfig&,
+          const std::vector<int64_t>&)>;
+
+  InitFn initReader;
+  FetchFn fetchPayloads;
+
+  static OpenTabBackend& instance() {
+    static OpenTabBackend backend;
+    return backend;
+  }
+
+  bool isRegistered() const {
+    return initReader != nullptr && fetchPayloads != nullptr;
+  }
+};
+
+/// Initialize OpenTab/Maple reader (calls through registered backend).
+inline ReaderPtr initializeOpenTabReader(
+    const kv_mem::EnrichmentConfig& config) {
+  auto& backend = OpenTabBackend::instance();
+  if (!backend.isRegistered()) {
+    XLOG(ERR) << "[EmbeddingCacheEnrich] OpenTab backend not registered. "
+              << "Ensure oneflow_enrichment_backend library is linked.";
+    return nullptr;
+  }
+  return backend.initReader(config);
+}
+
+/// Fetch payloads from OpenTab/Maple (calls through registered backend).
+inline folly::coro::Task<folly::F14FastMap<int64_t, int64_t>> fetchFromOpenTab(
+    const ReaderPtr& reader,
+    const kv_mem::EnrichmentConfig& config,
+    const std::vector<int64_t>& objectIds) {
+  auto& backend = OpenTabBackend::instance();
+  if (!backend.isRegistered() || !reader) {
+    co_return folly::F14FastMap<int64_t, int64_t>{};
+  }
+  co_return co_await backend.fetchPayloads(reader, config, objectIds);
+}
+
+} // namespace oneflow_enrichment

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -594,7 +594,7 @@ at::Tensor KVTensorWrapper::narrow(int64_t dim, int64_t start, int64_t length) {
         << "ReadOnlyEmbeddingKVDB pointer must be valid to read tensor";
     CHECK_GE(readonly_db_->get_max_D(), shape_[1]);
     CHECK_EQ(width_offset_, 0)
-        << "Width offset must be 0 for ro_rdb becuase the functionality is not supported yet";
+        << "Width offset must be 0 for ro_rdb because the functionality is not supported yet";
     auto t = at::empty(c10::IntArrayRef({length, shape_[1]}), options_);
     readonly_db_->get_range_from_rdb_checkpoint(
         t, start + row_offset_, length, width_offset_);
@@ -1060,7 +1060,19 @@ static auto embedding_rocks_db_wrapper =
 auto enrichment_config =
     torch::class_<kv_mem::EnrichmentConfig>("fbgemm", "EnrichmentConfig")
         .def(
-            torch::init<int64_t, std::string, std::string, int64_t, int64_t>(),
+            torch::init<
+                int64_t,
+                std::string,
+                std::string,
+                int64_t,
+                int64_t,
+                std::string,
+                std::string,
+                std::string,
+                std::string,
+                std::string,
+                int64_t,
+                int64_t>(),
             "",
             {
                 torch::arg("enrichment_type"),
@@ -1068,6 +1080,13 @@ auto enrichment_config =
                 torch::arg("client_id"),
                 torch::arg("enrichment_dim"),
                 torch::arg("response_format"),
+                torch::arg("opentab_tier_name") = "",
+                torch::arg("opentab_payload_ids") = "",
+                torch::arg("opentab_payload_types") = "",
+                torch::arg("opentab_column_group_ids") = "",
+                torch::arg("opentab_vec_payload_indexes") = "",
+                torch::arg("opentab_timeout_ms") = 5000,
+                torch::arg("opentab_batch_size") = 100,
             });
 
 static auto dram_kv_embedding_cache_wrapper =


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2466


CONTEXT: The enrichment framework currently only supports IGR/Laser as a data source. We need to support OneFlow's OpenTab/Maple as an additional enrichment backend to fetch side info (e.g., SID payloads) from the Maple distributed KV store.

WHAT:
- Add `ONEFLOW_OPENTAB_SID` enrichment type enum in both Python and C++
- Create `oneflow_enrichment.h` implementing OpenTab/Maple reader initialization, batch fetching with timeout, and int64 payload → tensor preparation
- Create `opentab_backend_registry.h` with type-erased `OpenTabBackend` singleton for dependency isolation
- Create separate `oneflow_enrichment_backend` Buck target carrying maple deps
- Extend `EnrichmentConfig` with OpenTab-specific parameters (tier_name, payload_ids, payload_types, column_group_ids, vec_payload_indexes, timeout_ms, batch_size)
- Wire OpenTab parameters through Python `EnrichmentPolicy` → `training.py` → TorchScript registration
- Add dispatch branch in `dram_kv_embedding_cache.h` for `ONEFLOW_OPENTAB_SID` enrichment type
- Fix typo: "becuase" → "because" in error message

DEPENDENCY ISOLATION:
- The maple/opentab deps transitively pull in `instagram/ranking`, which breaks `pg_deps` audits for `aiplatform/modelstore` targets that depend on `ssd_split_table_batched_embeddings`.
- Introduced a registration/factory pattern: `opentab_backend_registry.h` defines a type-erased `OpenTabBackend` singleton with `InitFn`/`FetchFn` function pointers.
- The actual maple implementation lives in `oneflow_enrichment.cpp`, compiled into a separate `oneflow_enrichment_backend` Buck target.
- At static-init time, the backend library registers its implementation into the singleton.
- The main `ssd_split_table_batched_embeddings` target only depends on the lightweight registry header (no maple deps).
- Training binaries that need OpenTab enrichment add `oneflow_enrichment_backend` to their own deps.

USAGE:
To enable OpenTab enrichment in your training binary:

1. Add the Buck dependency to your training target's TARGETS/BUCK file:
```
deps = [
    ...
    "fbcode//deeplearning/fbgemm/fbgemm_gpu:oneflow_enrichment_backend",
]
```
This is required because the OpenTab/Maple implementation is isolated in a separate library to avoid transitive `instagram/ranking` deps polluting downstream targets.

2. Configure `EnrichmentPolicy` in Python:
```python
from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
    EnrichmentPolicy,
    EnrichmentType,
)

enrichment_policy = EnrichmentPolicy(
    enrichment_type=EnrichmentType.ONEFLOW_OPENTAB_SID,
    client_id="your_client_id",
    opentab_tier_name="your.maple.tier",
    opentab_payload_ids="31739",           # comma-separated payload IDs
    opentab_payload_types="2",             # 0=INT, 1/2=VEC
    opentab_column_group_ids="12",         # comma-separated column group IDs
    opentab_vec_payload_indexes="0",       # comma-separated vec indexes
    opentab_timeout_ms=5000,               # request timeout in ms
    opentab_batch_size=100,                # batch size per RPC
)
```

3. Pass `enrichment_policy` to `SSDTableBatchedEmbeddingBags` as usual. The OpenTab backend is auto-registered at static-init time when the library is linked.

NOTE: Reland of D95888898 — removed unrelated `//caffe2:torch` → `//caffe2:_torch` BUCK changes that broke downstream targets.

Differential Revision: D96876695


