### PR TITLE
Add OneFlow Feature Store enrichment backend and refactor dispatch

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -237,6 +237,7 @@ class EnrichmentType(enum.IntEnum):
     IGR_LASER_EMBEDDING = 0
     IGR_LASER_SID = 1
     ONEFLOW_OPENTAB_SID = 2
+    ONEFLOW_FEATURE_STORE_SID = 3
 
 
 class EnrichmentResponseFormat(enum.IntEnum):
@@ -264,6 +265,14 @@ class EnrichmentPolicy(NamedTuple):
     opentab_vec_payload_indexes: str = ""  # comma-separated, e.g. "0"
     opentab_timeout_ms: int = 5000
     opentab_batch_size: int = 100
+    # Feature Store configuration (used for ONEFLOW_FEATURE_STORE_SID)
+    fs_tier: str = ""
+    fs_caller_id: str = ""
+    fs_timeout_ms: int = 5000
+    fs_batch_size: int = 500
+    fs_feature_group_id: int = 0
+    fs_feature_group_name: str = ""
+    fs_feature_name: str = ""
 
 
 class KVZCHParams(NamedTuple):

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -236,6 +236,7 @@ class EvictionPolicy(NamedTuple):
 class EnrichmentType(enum.IntEnum):
     IGR_LASER_EMBEDDING = 0
     IGR_LASER_SID = 1
+    ONEFLOW_OPENTAB_SID = 2
 
 
 class EnrichmentResponseFormat(enum.IntEnum):
@@ -255,6 +256,14 @@ class EnrichmentPolicy(NamedTuple):
     enrichment_dim: int = 0
     # Deserialization format
     response_format: EnrichmentResponseFormat = EnrichmentResponseFormat.JSON
+    # OpenTab/Maple configuration (used for ONEFLOW_OPENTAB_SID)
+    opentab_tier_name: str = ""
+    opentab_payload_ids: str = ""  # comma-separated, e.g. "31739"
+    opentab_payload_types: str = ""  # comma-separated, e.g. "2"
+    opentab_column_group_ids: str = ""  # comma-separated, e.g. "12"
+    opentab_vec_payload_indexes: str = ""  # comma-separated, e.g. "0"
+    opentab_timeout_ms: int = 5000
+    opentab_batch_size: int = 100
 
 
 class KVZCHParams(NamedTuple):

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -790,6 +790,13 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                     ep.opentab_vec_payload_indexes,
                     ep.opentab_timeout_ms,
                     ep.opentab_batch_size,
+                    ep.fs_tier,
+                    ep.fs_caller_id,
+                    ep.fs_timeout_ms,
+                    ep.fs_batch_size,
+                    ep.fs_feature_group_id,
+                    ep.fs_feature_group_name,
+                    ep.fs_feature_name,
                 )
             self._ssd_db = torch.classes.fbgemm.DramKVEmbeddingCacheWrapper(
                 self.cache_row_dim,

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -783,6 +783,13 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                     ep.client_id,
                     ep.enrichment_dim,
                     ep.response_format.value,
+                    ep.opentab_tier_name,
+                    ep.opentab_payload_ids,
+                    ep.opentab_payload_types,
+                    ep.opentab_column_group_ids,
+                    ep.opentab_vec_payload_indexes,
+                    ep.opentab_timeout_ms,
+                    ep.opentab_batch_size,
                 )
             self._ssd_db = torch.classes.fbgemm.DramKVEmbeddingCacheWrapper(
                 self.cache_row_dim,

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
@@ -33,6 +33,7 @@
 #include "enrichment_config.h"
 #include "fbgemm_gpu/split_embeddings_cache/kv_db_cpp_utils.h"
 #include "feature_evict.h"
+#include "feature_store_enrichment.h"
 #include "fixed_block_pool.h"
 #include "igr_enrichment.h"
 #include "oneflow_enrichment.h"
@@ -806,6 +807,49 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
             });
   }
 
+  /// Helper: schedule a fetch+prepare+write coroutine on enrichment_executor_.
+  /// Eliminates boilerplate duplication across enrichment type branches.
+  /// FetchFn: (const vector<int64_t>&) -> Task<PayloadMap>
+  /// PrepareFn: (const vector<int64_t>&, const vector<int64_t>&,
+  ///             const PayloadMap&) -> optional<EnrichmentResult>
+  template <typename FetchFn, typename PrepareFn>
+  void dispatchEnrichmentAsync(
+      std::vector<int64_t> hashed_ids,
+      std::vector<int64_t> unhashed_ids,
+      const char* log_prefix,
+      FetchFn fetchFn,
+      PrepareFn prepareFn) {
+    folly::coro::co_invoke(
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
+        [this,
+         hashed_ids = std::move(hashed_ids),
+         unhashed_ids = std::move(unhashed_ids),
+         log_prefix,
+         fetchFn = std::move(fetchFn),
+         prepareFn =
+             std::move(prepareFn)]() mutable -> folly::coro::Task<void> {
+          auto start_time = facebook::WallClockUtil::NowInUsecFast();
+          auto payloads = co_await fetchFn(unhashed_ids);
+          auto latency_ms =
+              (facebook::WallClockUtil::NowInUsecFast() - start_time) / 1000;
+          XLOG(INFO) << "[EmbeddingCacheEnrich] " << log_prefix
+                     << payloads.size() << "/" << unhashed_ids.size()
+                     << ", latency_ms: " << latency_ms;
+          if (!payloads.empty()) {
+            auto result = prepareFn(hashed_ids, unhashed_ids, payloads);
+            if (result.has_value()) {
+              set_kv_db_async_on_enrichment_executor(
+                  result->indices, result->weights, result->count);
+            }
+          }
+          pending_laser_requests_.fetch_sub(1);
+          laser_write_in_progress_.store(false);
+        })
+        // NOLINTNEXTLINE(readability-redundant-smartptr-get)
+        .scheduleOn(enrichment_executor_.get())
+        .start();
+  }
+
   void set_embedding_cache_enrich_query_id_async(
       at::Tensor hashed_indices,
       at::Tensor unhashed_indices,
@@ -981,128 +1025,78 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
 
                   if (enrichment_type ==
                       kv_mem::EnrichmentType::IGR_LASER_EMBEDDING) {
-                    folly::coro::co_invoke(
-                        [this,
-                         hashed_ids = std::move(all_zero_weight_hashed_ids),
-                         unhashed_ids =
-                             std::move(all_zero_weight_unhashed_ids)]() mutable
-                            -> folly::coro::Task<void> {
-                          auto start_time =
-                              facebook::WallClockUtil::NowInUsecFast();
-                          auto embeddings =
-                              co_await igr_enrichment::fetchEmbeddingsFromLaser(
-                                  laser_client_,
-                                  *enrichment_config_.value(),
-                                  unhashed_ids);
-                          auto laser_latency_ms =
-                              (facebook::WallClockUtil::NowInUsecFast() -
-                               start_time) /
-                              1000;
-                          XLOG(INFO)
-                              << "[EmbeddingCacheEnrich] laser_hit: "
-                              << embeddings.size() << "/" << unhashed_ids.size()
-                              << ", latency_ms: " << laser_latency_ms;
-                          if (!embeddings.empty()) {
-                            auto result =
-                                igr_enrichment::prepareCacheWriteTensors<
-                                    weight_type>(
-                                    hashed_ids,
-                                    unhashed_ids,
-                                    embeddings,
-                                    max_D_);
-                            if (result.has_value()) {
-                              set_kv_db_async_on_enrichment_executor(
-                                  result->indices,
-                                  result->weights,
-                                  result->count);
-                            }
-                          }
-                          pending_laser_requests_.fetch_sub(1);
-                          laser_write_in_progress_.store(false);
-                        })
-                        .scheduleOn(enrichment_executor_.get())
-                        .start();
+                    dispatchEnrichmentAsync(
+                        std::move(all_zero_weight_hashed_ids),
+                        std::move(all_zero_weight_unhashed_ids),
+                        "laser_hit: ",
+                        [this](const std::vector<int64_t>& ids) {
+                          return igr_enrichment::fetchEmbeddingsFromLaser(
+                              laser_client_, *enrichment_config_.value(), ids);
+                        },
+                        [this](
+                            const std::vector<int64_t>& h,
+                            const std::vector<int64_t>& u,
+                            const auto& data) {
+                          return igr_enrichment::prepareCacheWriteTensors<
+                              weight_type>(h, u, data, max_D_);
+                        });
                   } else if (
                       enrichment_type ==
                       kv_mem::EnrichmentType::IGR_LASER_SID) {
-                    folly::coro::co_invoke(
-                        [this,
-                         hashed_ids = std::move(all_zero_weight_hashed_ids),
-                         unhashed_ids =
-                             std::move(all_zero_weight_unhashed_ids)]() mutable
-                            -> folly::coro::Task<void> {
-                          auto start_time =
-                              facebook::WallClockUtil::NowInUsecFast();
-                          auto sid_map =
-                              co_await igr_enrichment::fetchSIDsFromLaser(
-                                  laser_client_,
-                                  *enrichment_config_.value(),
-                                  unhashed_ids);
-                          auto laser_latency_ms =
-                              (facebook::WallClockUtil::NowInUsecFast() -
-                               start_time) /
-                              1000;
-                          XLOG(INFO)
-                              << "[EmbeddingCacheEnrich] sid_hit: "
-                              << sid_map.size() << "/" << unhashed_ids.size()
-                              << ", latency_ms: " << laser_latency_ms;
-                          if (!sid_map.empty()) {
-                            auto result =
-                                igr_enrichment::prepareSIDCacheWriteTensors(
-                                    hashed_ids, unhashed_ids, sid_map, max_D_);
-                            if (result.has_value()) {
-                              set_kv_db_async_on_enrichment_executor(
-                                  result->indices,
-                                  result->weights,
-                                  result->count);
-                            }
-                          }
-                          pending_laser_requests_.fetch_sub(1);
-                          laser_write_in_progress_.store(false);
-                        })
-                        .scheduleOn(enrichment_executor_.get())
-                        .start();
+                    dispatchEnrichmentAsync(
+                        std::move(all_zero_weight_hashed_ids),
+                        std::move(all_zero_weight_unhashed_ids),
+                        "sid_hit: ",
+                        [this](const std::vector<int64_t>& ids) {
+                          return igr_enrichment::fetchSIDsFromLaser(
+                              laser_client_, *enrichment_config_.value(), ids);
+                        },
+                        [this](
+                            const std::vector<int64_t>& h,
+                            const std::vector<int64_t>& u,
+                            const auto& data) {
+                          return igr_enrichment::prepareSIDCacheWriteTensors(
+                              h, u, data, max_D_);
+                        });
                   } else if (
                       enrichment_type ==
                       kv_mem::EnrichmentType::ONEFLOW_OPENTAB_SID) {
-                    folly::coro::co_invoke(
-                        [this,
-                         hashed_ids = std::move(all_zero_weight_hashed_ids),
-                         unhashed_ids =
-                             std::move(all_zero_weight_unhashed_ids)]() mutable
-                            -> folly::coro::Task<void> {
-                          auto start_time =
-                              facebook::WallClockUtil::NowInUsecFast();
-                          auto payloads =
-                              co_await oneflow_enrichment::fetchFromOpenTab(
-                                  open_tab_reader_,
-                                  *enrichment_config_.value(),
-                                  unhashed_ids);
-                          auto opentab_latency_ms =
-                              (facebook::WallClockUtil::NowInUsecFast() -
-                               start_time) /
-                              1000;
-                          XLOG(INFO)
-                              << "[EmbeddingCacheEnrich] opentab_hit: "
-                              << payloads.size() << "/" << unhashed_ids.size()
-                              << ", latency_ms: " << opentab_latency_ms;
-                          if (!payloads.empty()) {
-                            auto result =
-                                oneflow_enrichment::prepareInt64PayloadTensors<
-                                    weight_type>(
-                                    hashed_ids, unhashed_ids, payloads, max_D_);
-                            if (result.has_value()) {
-                              set_kv_db_async_on_enrichment_executor(
-                                  result->indices,
-                                  result->weights,
-                                  result->count);
-                            }
-                          }
-                          pending_laser_requests_.fetch_sub(1);
-                          laser_write_in_progress_.store(false);
-                        })
-                        .scheduleOn(enrichment_executor_.get())
-                        .start();
+                    dispatchEnrichmentAsync(
+                        std::move(all_zero_weight_hashed_ids),
+                        std::move(all_zero_weight_unhashed_ids),
+                        "opentab_hit: ",
+                        [this](const std::vector<int64_t>& ids) {
+                          return oneflow_enrichment::fetchFromOpenTab(
+                              open_tab_reader_,
+                              *enrichment_config_.value(),
+                              ids);
+                        },
+                        [this](
+                            const std::vector<int64_t>& h,
+                            const std::vector<int64_t>& u,
+                            const auto& data) {
+                          return oneflow_enrichment::prepareInt64PayloadTensors<
+                              weight_type>(h, u, data, max_D_);
+                        });
+                  } else if (
+                      enrichment_type ==
+                      kv_mem::EnrichmentType::ONEFLOW_FEATURE_STORE_SID) {
+                    dispatchEnrichmentAsync(
+                        std::move(all_zero_weight_hashed_ids),
+                        std::move(all_zero_weight_unhashed_ids),
+                        "feature_store_hit: ",
+                        [this](const std::vector<int64_t>& ids) {
+                          return feature_store_enrichment::
+                              fetchSIDFromFeatureStore(
+                                  *enrichment_config_.value(), ids);
+                        },
+                        [this](
+                            const std::vector<int64_t>& h,
+                            const std::vector<int64_t>& u,
+                            const auto& data) {
+                          return oneflow_enrichment::prepareInt64PayloadTensors<
+                              weight_type>(h, u, data, max_D_);
+                        });
                   } else {
                     XLOG(WARN)
                         << "[EmbeddingCacheEnrich] unknown enrichment_type: "

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
@@ -35,6 +35,7 @@
 #include "feature_evict.h"
 #include "fixed_block_pool.h"
 #include "igr_enrichment.h"
+#include "oneflow_enrichment.h"
 
 namespace kv_mem {
 
@@ -166,6 +167,13 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
               kv_mem::EnrichmentType::IGR_LASER_SID) {
         laser_client_ =
             igr_enrichment::initializeLaserClient(*enrichment_config_.value());
+      }
+
+      // Initialize OpenTab reader if type is ONEFLOW_OPENTAB_SID
+      if (enrichment_config_.value()->enrichment_type_ ==
+          kv_mem::EnrichmentType::ONEFLOW_OPENTAB_SID) {
+        open_tab_reader_ = oneflow_enrichment::initializeOpenTabReader(
+            *enrichment_config_.value());
       }
     }
     initialize_initializers(
@@ -1042,6 +1050,47 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                             auto result =
                                 igr_enrichment::prepareSIDCacheWriteTensors(
                                     hashed_ids, unhashed_ids, sid_map, max_D_);
+                            if (result.has_value()) {
+                              set_kv_db_async_on_enrichment_executor(
+                                  result->indices,
+                                  result->weights,
+                                  result->count);
+                            }
+                          }
+                          pending_laser_requests_.fetch_sub(1);
+                          laser_write_in_progress_.store(false);
+                        })
+                        .scheduleOn(enrichment_executor_.get())
+                        .start();
+                  } else if (
+                      enrichment_type ==
+                      kv_mem::EnrichmentType::ONEFLOW_OPENTAB_SID) {
+                    folly::coro::co_invoke(
+                        [this,
+                         hashed_ids = std::move(all_zero_weight_hashed_ids),
+                         unhashed_ids =
+                             std::move(all_zero_weight_unhashed_ids)]() mutable
+                            -> folly::coro::Task<void> {
+                          auto start_time =
+                              facebook::WallClockUtil::NowInUsecFast();
+                          auto payloads =
+                              co_await oneflow_enrichment::fetchFromOpenTab(
+                                  open_tab_reader_,
+                                  *enrichment_config_.value(),
+                                  unhashed_ids);
+                          auto opentab_latency_ms =
+                              (facebook::WallClockUtil::NowInUsecFast() -
+                               start_time) /
+                              1000;
+                          XLOG(INFO)
+                              << "[EmbeddingCacheEnrich] opentab_hit: "
+                              << payloads.size() << "/" << unhashed_ids.size()
+                              << ", latency_ms: " << opentab_latency_ms;
+                          if (!payloads.empty()) {
+                            auto result =
+                                oneflow_enrichment::prepareInt64PayloadTensors<
+                                    weight_type>(
+                                    hashed_ids, unhashed_ids, payloads, max_D_);
                             if (result.has_value()) {
                               set_kv_db_async_on_enrichment_executor(
                                   result->indices,
@@ -2234,6 +2283,9 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
 
   // Pre-initialized LaserClient for IGR enrichment (reused across fetches)
   std::shared_ptr<facebook::laser::LaserClient> laser_client_;
+
+  // OpenTab/Maple reader for ONEFLOW_OPENTAB_SID enrichment (type-erased)
+  oneflow_enrichment::ReaderPtr open_tab_reader_;
 }; // class DramKVEmbeddingCache
 
 } // namespace kv_mem

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/enrichment_config.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/enrichment_config.h
@@ -22,6 +22,7 @@ enum class EnrichmentType : int64_t {
   IGR_LASER_EMBEDDING = 0,
   IGR_LASER_SID = 1,
   ONEFLOW_OPENTAB_SID = 2,
+  ONEFLOW_FEATURE_STORE_SID = 3,
 };
 
 /// Must match Python EnrichmentResponseFormat(IntEnum) in
@@ -60,7 +61,14 @@ struct EnrichmentConfig : public torch::jit::CustomClassHolder {
       std::string opentab_column_group_ids = "",
       std::string opentab_vec_payload_indexes = "",
       int64_t opentab_timeout_ms = 5000,
-      int64_t opentab_batch_size = 100)
+      int64_t opentab_batch_size = 100,
+      std::string fs_tier = "",
+      std::string fs_caller_id = "",
+      int64_t fs_timeout_ms = 5000,
+      int64_t fs_batch_size = 500,
+      int64_t fs_feature_group_id = 0,
+      std::string fs_feature_group_name = "",
+      std::string fs_feature_name = "")
       : enrichment_type_(static_cast<EnrichmentType>(enrichment_type)),
         provider_name_(std::move(provider_name)),
         client_id_(std::move(client_id)),
@@ -73,7 +81,14 @@ struct EnrichmentConfig : public torch::jit::CustomClassHolder {
         opentab_column_group_ids_(std::move(opentab_column_group_ids)),
         opentab_vec_payload_indexes_(std::move(opentab_vec_payload_indexes)),
         opentab_timeout_ms_(opentab_timeout_ms),
-        opentab_batch_size_(opentab_batch_size) {}
+        opentab_batch_size_(opentab_batch_size),
+        fs_tier_(std::move(fs_tier)),
+        fs_caller_id_(std::move(fs_caller_id)),
+        fs_timeout_ms_(fs_timeout_ms),
+        fs_batch_size_(fs_batch_size),
+        fs_feature_group_id_(fs_feature_group_id),
+        fs_feature_group_name_(std::move(fs_feature_group_name)),
+        fs_feature_name_(std::move(fs_feature_name)) {}
 
   EnrichmentType enrichment_type_;
   std::string provider_name_;
@@ -90,6 +105,16 @@ struct EnrichmentConfig : public torch::jit::CustomClassHolder {
   std::string opentab_vec_payload_indexes_;
   int64_t opentab_timeout_ms_;
   int64_t opentab_batch_size_;
+
+  // Feature Store configuration (used when enrichment_type_ ==
+  // ONEFLOW_FEATURE_STORE_SID)
+  std::string fs_tier_;
+  std::string fs_caller_id_;
+  int64_t fs_timeout_ms_;
+  int64_t fs_batch_size_;
+  int64_t fs_feature_group_id_;
+  std::string fs_feature_group_name_;
+  std::string fs_feature_name_;
 };
 
 } // namespace kv_mem

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/enrichment_config.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/enrichment_config.h
@@ -21,6 +21,7 @@ namespace kv_mem {
 enum class EnrichmentType : int64_t {
   IGR_LASER_EMBEDDING = 0,
   IGR_LASER_SID = 1,
+  ONEFLOW_OPENTAB_SID = 2,
 };
 
 /// Must match Python EnrichmentResponseFormat(IntEnum) in
@@ -40,24 +41,55 @@ struct EnrichmentConfig : public torch::jit::CustomClassHolder {
   /// @param client_id Client identifier for the external service
   /// @param enrichment_dim Dimension of data returned by the source
   /// @param response_format EnrichmentResponseFormat int value
+  /// @param opentab_tier_name OpenTab/Maple tier name
+  /// @param opentab_payload_ids Comma-separated payload IDs
+  /// @param opentab_payload_types Comma-separated payload types (0=INT, 2=VEC)
+  /// @param opentab_column_group_ids Comma-separated column group IDs
+  /// @param opentab_vec_payload_indexes Comma-separated vec payload indexes
+  /// @param opentab_timeout_ms OpenTab request timeout in ms
+  /// @param opentab_batch_size OpenTab batch size
   explicit EnrichmentConfig(
       int64_t enrichment_type,
       std::string provider_name,
       std::string client_id,
       int64_t enrichment_dim,
-      int64_t response_format)
+      int64_t response_format,
+      std::string opentab_tier_name = "",
+      std::string opentab_payload_ids = "",
+      std::string opentab_payload_types = "",
+      std::string opentab_column_group_ids = "",
+      std::string opentab_vec_payload_indexes = "",
+      int64_t opentab_timeout_ms = 5000,
+      int64_t opentab_batch_size = 100)
       : enrichment_type_(static_cast<EnrichmentType>(enrichment_type)),
         provider_name_(std::move(provider_name)),
         client_id_(std::move(client_id)),
         enrichment_dim_(enrichment_dim),
         response_format_(
-            static_cast<EnrichmentResponseFormat>(response_format)) {}
+            static_cast<EnrichmentResponseFormat>(response_format)),
+        opentab_tier_name_(std::move(opentab_tier_name)),
+        opentab_payload_ids_(std::move(opentab_payload_ids)),
+        opentab_payload_types_(std::move(opentab_payload_types)),
+        opentab_column_group_ids_(std::move(opentab_column_group_ids)),
+        opentab_vec_payload_indexes_(std::move(opentab_vec_payload_indexes)),
+        opentab_timeout_ms_(opentab_timeout_ms),
+        opentab_batch_size_(opentab_batch_size) {}
 
   EnrichmentType enrichment_type_;
   std::string provider_name_;
   std::string client_id_;
   int64_t enrichment_dim_;
   EnrichmentResponseFormat response_format_;
+
+  // OpenTab/Maple configuration (used when enrichment_type_ ==
+  // ONEFLOW_OPENTAB_SID)
+  std::string opentab_tier_name_;
+  std::string opentab_payload_ids_;
+  std::string opentab_payload_types_;
+  std::string opentab_column_group_ids_;
+  std::string opentab_vec_payload_indexes_;
+  int64_t opentab_timeout_ms_;
+  int64_t opentab_batch_size_;
 };
 
 } // namespace kv_mem

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/feature_store_enrichment.cpp
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/feature_store_enrichment.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "feature_store_enrichment.h"
+
+#include <folly/container/F14Set.h>
+#include <folly/logging/xlog.h>
+#include <servicerouter/client/cpp2/ServiceRouter.h>
+
+#include "fblearner/feature_store/thrift/gen-cpp2/FeatureStoreComputeServiceAsyncClient.h"
+#include "fblearner/feature_store/thrift/gen-cpp2/computation_input_types.h"
+#include "fblearner/feature_store/thrift/gen-cpp2/compute_service_types.h"
+#include "fblearner/feature_store/thrift/gen-cpp2/example_types.h"
+
+namespace feature_store_enrichment {
+
+// Knowledge Feature API context field IDs
+// (from KnowledgeFeatureAPIFeatureStoreGeneratorSchema)
+static constexpr int64_t kObjectIdField = 19766576;
+static constexpr int64_t kFeatureGroupNameField = 19767797;
+static constexpr int64_t kFeatureNamesField = 1138923261;
+static constexpr int64_t kApiField = 1138923262;
+static constexpr int64_t kSidFieldId = 1138923263;
+
+folly::coro::Task<folly::F14FastMap<int64_t, int64_t>> fetchSIDFromFeatureStore(
+    const kv_mem::EnrichmentConfig& config,
+    const std::vector<int64_t>& objectIds) {
+  folly::F14FastMap<int64_t, int64_t> objectIdToSidMap;
+  if (objectIds.empty() || config.fs_tier_.empty()) {
+    co_return objectIdToSidMap;
+  }
+
+  // Dedupe object IDs
+  folly::F14FastSet<int64_t> dedupedIds(objectIds.begin(), objectIds.end());
+
+  // Split into batches
+  std::vector<std::vector<int64_t>> batches;
+  {
+    std::vector<int64_t> currentBatch;
+    currentBatch.reserve(config.fs_batch_size_);
+    for (auto id : dedupedIds) {
+      currentBatch.push_back(id);
+      if (static_cast<int64_t>(currentBatch.size()) >= config.fs_batch_size_) {
+        batches.push_back(std::move(currentBatch));
+        currentBatch = {};
+        currentBatch.reserve(config.fs_batch_size_);
+      }
+    }
+    if (!currentBatch.empty()) {
+      batches.push_back(std::move(currentBatch));
+    }
+  }
+
+  XLOG(INFO) << "[EmbeddingCacheEnrich] FeatureStore fetching "
+             << dedupedIds.size() << " unique IDs in " << batches.size()
+             << " batches";
+
+  // Create client params
+  auto clientParams = facebook::servicerouter::ClientParams();
+  clientParams
+      .setProcessingTimeoutMs(std::chrono::milliseconds(config.fs_timeout_ms_))
+      .setOverallTimeoutMs(std::chrono::milliseconds(config.fs_timeout_ms_))
+      .setClientId(config.fs_caller_id_);
+
+  int64_t totalHits = 0;
+  int64_t totalErrors = 0;
+
+  for (const auto& batch : batches) {
+    using namespace facebook::fblearner::feature_store::thrift;
+
+    // Build one Example per object ID
+    std::vector<example::Example> examples;
+    examples.reserve(batch.size());
+
+    for (auto objectId : batch) {
+      example::Example ex;
+      (*ex.int_single_categorical_features())[kObjectIdField] = objectId;
+      (*ex.string_single_categorical_features())[kFeatureGroupNameField] =
+          config.fs_feature_group_name_;
+      (*ex.string_single_categorical_features())[kFeatureNamesField] =
+          config.fs_feature_name_;
+      (*ex.string_single_categorical_features())[kApiField] = "read";
+      examples.push_back(std::move(ex));
+    }
+
+    // Build request
+    computation_input::ComputationInput input;
+    input.typed_contexts() = std::move(examples);
+
+    compute_service::Request request;
+    (*request.group_id_to_input())[config.fs_feature_group_id_] =
+        std::move(input);
+    request.request_context()->caller_id() = config.fs_caller_id_;
+
+    // Send request
+    try {
+      auto client = facebook::servicerouter::cpp2::getClientFactory()
+                        .getSRClientUnique<apache::thrift::Client<
+                            compute_service::FeatureStoreComputeService>>(
+                            config.fs_tier_, clientParams);
+
+      auto response = co_await client->co_compute(request);
+
+      // Parse results
+      if (response.group_id_to_examples().has_value()) {
+        auto groupIt =
+            response.group_id_to_examples()->find(config.fs_feature_group_id_);
+        if (groupIt != response.group_id_to_examples()->end()) {
+          const auto& results = groupIt->second;
+          for (size_t i = 0; i < results.size() && i < batch.size(); ++i) {
+            if (results[i].getType() ==
+                compute_service::ValueOrError::Type::value) {
+              const auto& outputExample = results[i].get_value();
+              int64_t sidValue = -1;
+
+              // Try int_tensor_features first
+              if (outputExample.int_tensor_features().has_value()) {
+                auto it =
+                    outputExample.int_tensor_features()->find(kSidFieldId);
+                if (it != outputExample.int_tensor_features()->end() &&
+                    !it->second.empty()) {
+                  sidValue = it->second[0];
+                }
+              }
+              // Fallback: try int_features
+              if (sidValue == -1 && outputExample.int_features().has_value()) {
+                for (const auto& [fid, val] : *outputExample.int_features()) {
+                  sidValue = val;
+                  break;
+                }
+              }
+              // Fallback: try int_single_categorical_features
+              if (sidValue == -1 &&
+                  outputExample.int_single_categorical_features().has_value()) {
+                for (const auto& [fid, val] :
+                     *outputExample.int_single_categorical_features()) {
+                  if (fid != kObjectIdField) {
+                    sidValue = val;
+                    break;
+                  }
+                }
+              }
+
+              if (sidValue != -1 && sidValue != 0) {
+                objectIdToSidMap[batch[i]] = sidValue;
+                totalHits++;
+              }
+            } else {
+              totalErrors++;
+            }
+          }
+        }
+      }
+    } catch (const std::exception& e) {
+      XLOG(WARNING)
+          << "[EmbeddingCacheEnrich] FeatureStore batch query failed: "
+          << e.what();
+      totalErrors += batch.size();
+    }
+  }
+
+  XLOG(INFO) << "[EmbeddingCacheEnrich] FeatureStore result: hits=" << totalHits
+             << ", errors=" << totalErrors
+             << ", total_deduped=" << dedupedIds.size();
+
+  co_return objectIdToSidMap;
+}
+
+} // namespace feature_store_enrichment

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/feature_store_enrichment.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/feature_store_enrichment.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include <folly/coro/Task.h>
+#include <vector>
+
+#include "enrichment_config.h"
+
+namespace feature_store_enrichment {
+
+/// Fetch SID from Feature Store (Knowledge Feature API) for given object IDs.
+/// Returns map from objectId to int64_t SID payload value.
+folly::coro::Task<folly::F14FastMap<int64_t, int64_t>> fetchSIDFromFeatureStore(
+    const kv_mem::EnrichmentConfig& config,
+    const std::vector<int64_t>& objectIds);
+
+} // namespace feature_store_enrichment

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/oneflow_enrichment.cpp
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/oneflow_enrichment.cpp
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "enrichment_config.h"
+#include "opentab_backend_registry.h"
+
+#include <folly/String.h>
+#include <folly/container/F14Set.h>
+#include <folly/coro/Collect.h>
+#include <folly/coro/Timeout.h>
+#include <folly/logging/xlog.h>
+
+#include "multifeed/leaf5/maple/client/coro/MapleClient.h"
+#include "multifeed/opentab/db/reader/MapleReader.h"
+#include "multifeed/opentab/db/reader/ObjectReaderImpl.h"
+#include "multifeed/opentab/schema/ConfiguratorSchemaManagerProvider.h"
+
+namespace oneflow_enrichment {
+namespace {
+
+std::vector<int32_t> parseCommaSeparatedInts(const std::string& s) {
+  std::vector<int32_t> result;
+  if (s.empty()) {
+    return result;
+  }
+  std::vector<folly::StringPiece> parts;
+  folly::split(',', s, parts);
+  result.reserve(parts.size());
+  for (const auto& part : parts) {
+    result.push_back(folly::to<int32_t>(folly::trimWhitespace(part)));
+  }
+  return result;
+}
+ReaderPtr initializeOpenTabReaderImpl(const kv_mem::EnrichmentConfig& config) {
+  auto reader = std::make_shared<
+      facebook::multifeed::opentab::SimpleObjectReader>(
+      folly::make_not_null_unique<facebook::multifeed::opentab::MapleReader>(
+          folly::make_not_null_unique<facebook::maple::MapleClient>(
+              config.opentab_tier_name_)),
+      facebook::multifeed::opentab::schema::ConfiguratorSchemaManagerProvider::
+          getInstance());
+
+  XLOG(INFO) << "[EmbeddingCacheEnrich] OpenTab reader initialized: "
+             << "tier=" << config.opentab_tier_name_
+             << ", client_id=" << config.client_id_
+             << ", timeout_ms=" << config.opentab_timeout_ms_
+             << ", batch_size=" << config.opentab_batch_size_
+             << ", payload_ids=" << config.opentab_payload_ids_
+             << ", column_group_ids=" << config.opentab_column_group_ids_;
+
+  return reader;
+}
+
+folly::coro::Task<folly::F14FastMap<int64_t, int64_t>> fetchFromOpenTabImpl(
+    const ReaderPtr& readerPtr,
+    const kv_mem::EnrichmentConfig& config,
+    const std::vector<int64_t>& objectIds) {
+  auto reader =
+      std::static_pointer_cast<facebook::multifeed::opentab::ObjectReader>(
+          readerPtr);
+  folly::F14FastMap<int64_t, int64_t> objectIdToPayloadMap;
+
+  auto column_group_ids =
+      parseCommaSeparatedInts(config.opentab_column_group_ids_);
+  auto payload_ids = parseCommaSeparatedInts(config.opentab_payload_ids_);
+  auto payload_types = parseCommaSeparatedInts(config.opentab_payload_types_);
+  auto vec_payload_indexes =
+      parseCommaSeparatedInts(config.opentab_vec_payload_indexes_);
+
+  if (!reader || objectIds.empty() || column_group_ids.empty()) {
+    co_return objectIdToPayloadMap;
+  }
+
+  // Dedupe object IDs
+  folly::F14FastSet<int64_t> dedupedIds(objectIds.begin(), objectIds.end());
+
+  // Create batches of OpenTabKeys
+  std::vector<std::vector<facebook::multifeed::opentab::OpenTabKey>> keyBatches;
+  const size_t batchSize = static_cast<size_t>(config.opentab_batch_size_);
+  const size_t numBatches = (dedupedIds.size() + batchSize - 1) / batchSize;
+  keyBatches.reserve(numBatches);
+
+  auto it = dedupedIds.begin();
+  const auto end = dedupedIds.end();
+
+  while (it != end) {
+    std::vector<facebook::multifeed::opentab::OpenTabKey> batch;
+    const size_t keysInThisBatch =
+        std::min(batchSize, static_cast<size_t>(std::distance(it, end)));
+    batch.reserve(keysInThisBatch * column_group_ids.size());
+
+    for (size_t count = 0; count < batchSize && it != end; ++count, ++it) {
+      const int64_t objectId = *it;
+      for (int32_t columnGroupId : column_group_ids) {
+        batch.emplace_back(objectId, columnGroupId);
+      }
+    }
+    keyBatches.push_back(std::move(batch));
+  }
+
+  XLOG(INFO) << "[EmbeddingCacheEnrich] OpenTab fetching " << dedupedIds.size()
+             << " unique IDs in " << keyBatches.size() << " batches";
+
+  // Create futures for all batch requests
+  std::vector<folly::coro::Task<
+      facebook::multifeed::opentab::ObjectReadObjectSummariesResult>>
+      batchTasks;
+  batchTasks.reserve(keyBatches.size());
+
+  for (auto&& batch : keyBatches) {
+    batchTasks.push_back(reader->coReadIntoObjectSummaries(
+        std::move(batch),
+        0 /* retention */,
+        0 /* queryTimepoint */,
+        config.client_id_,
+        column_group_ids.size(),
+        std::nullopt /* tierName */,
+        {} /* batchConfig */));
+  }
+
+  // Collect all results with timeout
+  std::vector<
+      folly::Try<facebook::multifeed::opentab::ObjectReadObjectSummariesResult>>
+      batchResults;
+  try {
+    batchResults = co_await folly::coro::co_withCancellation(
+        folly::CancellationToken{},
+        folly::coro::timeout(
+            folly::coro::collectAllTryRange(std::move(batchTasks)),
+            std::chrono::milliseconds(config.opentab_timeout_ms_)));
+  } catch (const folly::FutureTimeout&) {
+    XLOG(WARNING) << "[EmbeddingCacheEnrich] OpenTab fetch timeout after "
+                  << config.opentab_timeout_ms_ << "ms";
+    co_return objectIdToPayloadMap;
+  }
+
+  // Merge results from all batches
+  folly::F14FastMap<
+      int64_t,
+      std::shared_ptr<const facebook::multifeed::ObjectSummary>>
+      objectSummaryMap;
+  int64_t missingObjectCount = 0;
+
+  for (auto& batchResult : batchResults) {
+    if (batchResult.hasException()) {
+      XLOG(WARNING) << "[EmbeddingCacheEnrich] OpenTab batch failed: "
+                    << batchResult.exception().what();
+      continue;
+    }
+    for (const auto& osPtr : batchResult.value().values) {
+      if (osPtr != nullptr && osPtr->object_id().value() > 0) {
+        objectSummaryMap.emplace(osPtr->object_id().value(), osPtr);
+      } else {
+        missingObjectCount++;
+      }
+    }
+  }
+
+  XLOG(INFO) << "[EmbeddingCacheEnrich] OpenTab fetched "
+             << objectSummaryMap.size() << " objects, " << missingObjectCount
+             << " missing";
+
+  // Extract single payload value for each object
+  for (const auto& [objectId, os] : objectSummaryMap) {
+    int64_t payloadValue = -1; // default to -1 (will be skipped during write)
+
+    if (!payload_ids.empty()) {
+      int32_t payloadId = payload_ids[0];
+      int32_t payloadType = payload_types.empty() ? 0 : payload_types[0];
+      int32_t vecPayloadIndex =
+          vec_payload_indexes.empty() ? 0 : vec_payload_indexes[0];
+
+      if (payloadType == 0) {
+        // INT payload type
+        auto pit = os->intPayload()->find(payloadId);
+        if (pit != os->intPayload()->end()) {
+          payloadValue = pit->second;
+        }
+      } else if (payloadType == 1 || payloadType == 2) {
+        // VEC payload type (1 or 2)
+        auto pit = os->vecPayload()->find(payloadId);
+        if (pit != os->vecPayload()->end() &&
+            static_cast<size_t>(vecPayloadIndex) < pit->second.size()) {
+          payloadValue = pit->second.at(vecPayloadIndex);
+        }
+      } else {
+        XLOG_EVERY_MS(WARNING, 5000)
+            << "[EmbeddingCacheEnrich] Unsupported payload type: "
+            << payloadType;
+      }
+    }
+
+    objectIdToPayloadMap.emplace(objectId, payloadValue);
+  }
+
+  co_return objectIdToPayloadMap;
+}
+
+} // anonymous namespace
+
+// Static registration: register the maple-backed implementation into the
+// global OpenTabBackend registry. This runs when the library is loaded.
+static auto _opentab_registration = []() {
+  auto& backend = OpenTabBackend::instance();
+  backend.initReader = initializeOpenTabReaderImpl;
+  backend.fetchPayloads = fetchFromOpenTabImpl;
+  XLOG(INFO) << "[EmbeddingCacheEnrich] OpenTab backend registered";
+  return 0;
+}();
+
+} // namespace oneflow_enrichment

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/oneflow_enrichment.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/oneflow_enrichment.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <torch/torch.h>
+#include <optional>
+
+#include "enrichment_config.h"
+#include "igr_enrichment.h"
+#include "opentab_backend_registry.h"
+
+namespace oneflow_enrichment {
+
+/// Prepare tensors for writing int64 payloads into the cache.
+/// Each int64 payload is encoded as 16 nibbles -> power-of-2 float32 (FP8-safe
+/// encoding). Each 4-bit nibble n maps to: pow(2, n>>1) * (-1 if n&1 else 1)
+/// All encoded values are exact in FP8 E4M3 after per-row scaling.
+template <typename weight_type>
+inline std::optional<igr_enrichment::EnrichmentResult>
+prepareInt64PayloadTensors(
+    const std::vector<int64_t>& hashed_ids,
+    const std::vector<int64_t>& unhashed_ids,
+    const folly::F14FastMap<int64_t, int64_t>& payloads,
+    int64_t /*max_D*/) {
+  if (hashed_ids.size() != unhashed_ids.size()) {
+    XLOG(ERR) << "[EmbeddingCacheEnrich] hashed_ids and unhashed_ids size "
+                 "mismatch: "
+              << hashed_ids.size() << " vs " << unhashed_ids.size();
+    return std::nullopt;
+  }
+
+  std::vector<int64_t> indices_vec;
+  std::vector<float> weights_vec;
+
+  for (size_t idx = 0; idx < unhashed_ids.size(); ++idx) {
+    int64_t unhashed_id = unhashed_ids[idx];
+    int64_t hashed_id = hashed_ids[idx];
+
+    auto it = payloads.find(unhashed_id);
+    if (it == payloads.end()) {
+      continue;
+    }
+
+    int64_t payload_value = it->second;
+
+    // Skip if payload is -1 or 0 (missing data)
+    if (payload_value == -1 || payload_value == 0) {
+      continue;
+    }
+
+    indices_vec.push_back(hashed_id);
+
+    // Encode int64_t as 16 nibbles -> power-of-2 float32 (FP8-safe encoding)
+    // Each 4-bit nibble n maps to: pow(2, n>>1) * (-1 if n&1 else 1)
+    // All encoded values are exact in FP8 E4M3 after per-row scaling
+    // (they map to ±3.5×2^k which are exact E4M3 representable values)
+    static constexpr float kNibbleToFloat[16] = {
+        1.0f,
+        -1.0f,
+        2.0f,
+        -2.0f,
+        4.0f,
+        -4.0f,
+        8.0f,
+        -8.0f,
+        16.0f,
+        -16.0f,
+        32.0f,
+        -32.0f,
+        64.0f,
+        -64.0f,
+        128.0f,
+        -128.0f};
+    uint64_t uval = static_cast<uint64_t>(payload_value);
+    for (int i = 0; i < 16; ++i) {
+      uint8_t nibble = (uval >> (i * 4)) & 0xF;
+      weights_vec.push_back(kNibbleToFloat[nibble]);
+    }
+  }
+
+  if (indices_vec.empty()) {
+    XLOG(INFO) << "[EmbeddingCacheEnrich] prepareInt64PayloadTensors: "
+               << "no valid payloads to write (all -1 or missing)";
+    return std::nullopt;
+  }
+
+  int64_t num_embeddings = indices_vec.size();
+  constexpr int64_t kEmbeddingDim = 16;
+
+  auto indices_tensor =
+      torch::from_blob(indices_vec.data(), {num_embeddings}, torch::kInt64)
+          .clone();
+  auto weights_tensor =
+      torch::from_blob(
+          weights_vec.data(), {num_embeddings, kEmbeddingDim}, torch::kFloat32)
+          .clone();
+
+  // Convert to weight_type if needed
+  if constexpr (!std::is_same_v<weight_type, float>) {
+    weights_tensor =
+        weights_tensor.to(torch::CppTypeToScalarType<weight_type>());
+  }
+
+  auto count_tensor = torch::tensor({num_embeddings}, torch::kLong);
+
+  XLOG(INFO) << "[EmbeddingCacheEnrich] prepareInt64PayloadTensors: "
+             << "num_embeddings=" << num_embeddings
+             << ", embedding_dim=" << kEmbeddingDim
+             << ", total_payloads=" << payloads.size()
+             << ", skipped=" << (payloads.size() - num_embeddings);
+
+  return igr_enrichment::EnrichmentResult{
+      indices_tensor,
+      weights_tensor,
+      count_tensor,
+  };
+}
+
+} // namespace oneflow_enrichment

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/opentab_backend_registry.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/opentab_backend_registry.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include <folly/coro/Task.h>
+#include <folly/logging/xlog.h>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+// Forward declaration — avoids pulling in torch/script.h
+namespace kv_mem {
+struct EnrichmentConfig;
+} // namespace kv_mem
+
+namespace oneflow_enrichment {
+
+/// Type-erased reader pointer (actual type is ObjectReader, resolved at
+/// runtime by the registered backend).
+using ReaderPtr = std::shared_ptr<void>;
+
+/// Registry for OpenTab backend implementation.
+/// The actual maple/opentab implementation is registered at static-init time
+/// by the oneflow_enrichment_backend library, which carries the heavy deps.
+/// This decouples the main ssd_split_table_batched_embeddings target from
+/// instagram/ranking transitive dependencies.
+struct OpenTabBackend {
+  using InitFn = std::function<ReaderPtr(const kv_mem::EnrichmentConfig&)>;
+  using FetchFn =
+      std::function<folly::coro::Task<folly::F14FastMap<int64_t, int64_t>>(
+          const ReaderPtr&,
+          const kv_mem::EnrichmentConfig&,
+          const std::vector<int64_t>&)>;
+
+  InitFn initReader;
+  FetchFn fetchPayloads;
+
+  static OpenTabBackend& instance() {
+    static OpenTabBackend backend;
+    return backend;
+  }
+
+  bool isRegistered() const {
+    return initReader != nullptr && fetchPayloads != nullptr;
+  }
+};
+
+/// Initialize OpenTab/Maple reader (calls through registered backend).
+inline ReaderPtr initializeOpenTabReader(
+    const kv_mem::EnrichmentConfig& config) {
+  auto& backend = OpenTabBackend::instance();
+  if (!backend.isRegistered()) {
+    XLOG(ERR) << "[EmbeddingCacheEnrich] OpenTab backend not registered. "
+              << "Ensure oneflow_enrichment_backend library is linked.";
+    return nullptr;
+  }
+  return backend.initReader(config);
+}
+
+/// Fetch payloads from OpenTab/Maple (calls through registered backend).
+inline folly::coro::Task<folly::F14FastMap<int64_t, int64_t>> fetchFromOpenTab(
+    const ReaderPtr& reader,
+    const kv_mem::EnrichmentConfig& config,
+    const std::vector<int64_t>& objectIds) {
+  auto& backend = OpenTabBackend::instance();
+  if (!backend.isRegistered() || !reader) {
+    co_return folly::F14FastMap<int64_t, int64_t>{};
+  }
+  co_return co_await backend.fetchPayloads(reader, config, objectIds);
+}
+
+} // namespace oneflow_enrichment

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -1072,7 +1072,14 @@ auto enrichment_config =
                 std::string,
                 std::string,
                 int64_t,
-                int64_t>(),
+                int64_t,
+                std::string,
+                std::string,
+                int64_t,
+                int64_t,
+                int64_t,
+                std::string,
+                std::string>(),
             "",
             {
                 torch::arg("enrichment_type"),
@@ -1087,6 +1094,13 @@ auto enrichment_config =
                 torch::arg("opentab_vec_payload_indexes") = "",
                 torch::arg("opentab_timeout_ms") = 5000,
                 torch::arg("opentab_batch_size") = 100,
+                torch::arg("fs_tier") = "",
+                torch::arg("fs_caller_id") = "",
+                torch::arg("fs_timeout_ms") = 5000,
+                torch::arg("fs_batch_size") = 500,
+                torch::arg("fs_feature_group_id") = 0,
+                torch::arg("fs_feature_group_name") = "",
+                torch::arg("fs_feature_name") = "",
             });
 
 static auto dram_kv_embedding_cache_wrapper =

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -594,7 +594,7 @@ at::Tensor KVTensorWrapper::narrow(int64_t dim, int64_t start, int64_t length) {
         << "ReadOnlyEmbeddingKVDB pointer must be valid to read tensor";
     CHECK_GE(readonly_db_->get_max_D(), shape_[1]);
     CHECK_EQ(width_offset_, 0)
-        << "Width offset must be 0 for ro_rdb becuase the functionality is not supported yet";
+        << "Width offset must be 0 for ro_rdb because the functionality is not supported yet";
     auto t = at::empty(c10::IntArrayRef({length, shape_[1]}), options_);
     readonly_db_->get_range_from_rdb_checkpoint(
         t, start + row_offset_, length, width_offset_);
@@ -1060,7 +1060,19 @@ static auto embedding_rocks_db_wrapper =
 auto enrichment_config =
     torch::class_<kv_mem::EnrichmentConfig>("fbgemm", "EnrichmentConfig")
         .def(
-            torch::init<int64_t, std::string, std::string, int64_t, int64_t>(),
+            torch::init<
+                int64_t,
+                std::string,
+                std::string,
+                int64_t,
+                int64_t,
+                std::string,
+                std::string,
+                std::string,
+                std::string,
+                std::string,
+                int64_t,
+                int64_t>(),
             "",
             {
                 torch::arg("enrichment_type"),
@@ -1068,6 +1080,13 @@ auto enrichment_config =
                 torch::arg("client_id"),
                 torch::arg("enrichment_dim"),
                 torch::arg("response_format"),
+                torch::arg("opentab_tier_name") = "",
+                torch::arg("opentab_payload_ids") = "",
+                torch::arg("opentab_payload_types") = "",
+                torch::arg("opentab_column_group_ids") = "",
+                torch::arg("opentab_vec_payload_indexes") = "",
+                torch::arg("opentab_timeout_ms") = 5000,
+                torch::arg("opentab_batch_size") = 100,
             });
 
 static auto dram_kv_embedding_cache_wrapper =


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2467

CONTEXT: In addition to OpenTab, OneFlow also needs Feature Store (Knowledge Feature API) as an enrichment data source. The existing enrichment dispatch code in `dram_kv_embedding_cache.h` has significant boilerplate duplication across enrichment type branches.

WHAT:
- Add `ONEFLOW_FEATURE_STORE_SID` enrichment type enum (value=3) in both Python and C++
- Create `feature_store_enrichment.h/.cpp` implementing Feature Store client integration via ServiceRouter, batch compute requests, and SID extraction from response examples
- Extend `EnrichmentConfig` with Feature Store parameters (fs_tier, fs_caller_id, fs_timeout_ms, fs_batch_size, fs_feature_group_id, fs_feature_group_name, fs_feature_name)
- Wire Feature Store parameters through Python `EnrichmentPolicy` → `training.py` → TorchScript registration
- Refactor: extract `dispatchEnrichmentAsync()` helper template to eliminate fetch→prepare→write boilerplate across all 4 enrichment types (IGR_LASER_EMBEDDING, IGR_LASER_SID, ONEFLOW_OPENTAB_SID, ONEFLOW_FEATURE_STORE_SID)

NOTE ON DEPS: Feature Store thrift deps (`fblearner/feature_store/thrift:*`) are added directly to `ssd_split_table_batched_embeddings` (unlike OpenTab which uses a separate target). This is intentional — Feature Store thrift types are lightweight generated stubs without heavy transitive deps like instagram/ranking, so they don't cause pg_deps audit failures.

NOTE: Reland of D95887684, which was reverted together with D95888898 due to unrelated BUCK changes in the parent diff. No code changes from the original diff.

Differential Revision: D96876677


