### PR TITLE
Install libdw (#5495)

### DIFF
--- a/.github/scripts/utils_rocm.bash
+++ b/.github/scripts/utils_rocm.bash
@@ -25,6 +25,7 @@ install_rocm_amdsmi_ubuntu () {
 
   echo "[INSTALL] Installing roctracer-dev and amd-smi-lib ..."
   (apt-get install -y --allow-unauthenticated \
+      libdw-dev \
       roctracer-dev \
       amd-smi-lib) || return 1
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2468


- Install libdw, which is needed by torch-rocm

Differential Revision: D97330843


