### PR TITLE
Remove _test suffix from package name for test channel builds (#5502)

### DIFF
--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -153,7 +153,8 @@ class FbgemmGpuBuild:
         if self.nova_flag() is None:
             # If running outside of Nova workflow context, append the channel
             # and variant to the package name as needed
-            if self.args.package_channel != "release":
+            if self.args.package_channel not in ["release", "test"]:
+                # Append the package channel to the package name
                 pkg_name += f"_{self.args.package_channel}"
 
             if self.variant() != "cuda":


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2474

When building FBGEMM_GPU with the "test" package channel (e.g. for PyPI release
validation), the package name incorrectly included a `_test` suffix
(e.g. `fbgemm_gpu_test-1.6.0rc1-cp310-cp310-manylinux_2_28_x86_64.whl`).

This changes the condition in `setup.py` `package_name()` so that only the
"nightly" channel appends a channel suffix (`_nightly`). Both "test" and
"release" channels now produce the clean package name `fbgemm_gpu`.

Reviewed By: spcyppt, q10

Differential Revision: D97372813
