### PR TITLE
Use atomicAdd for lxu_cache_locking_counter increments/decrements (#5509)

### DIFF
--- a/fbgemm_gpu/src/split_embeddings_cache/lru_cache_find.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lru_cache_find.cu
@@ -127,7 +127,7 @@ __global__ __launch_bounds__(kMaxThreads) void lru_cache_find_uncached_kernel(
       // Don't lock the line one more time if we have locked it in the same
       // batch (timestamp)
       if (lock_cache_line && !already_locked) {
-        lxu_cache_locking_counter[cache_set][slot] += 1;
+        atomicAdd(&lxu_cache_locking_counter[cache_set][slot], 1);
       }
     }
 

--- a/fbgemm_gpu/src/split_embeddings_cache/lru_cache_populate.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lru_cache_populate.cu
@@ -149,7 +149,7 @@ __global__ __launch_bounds__(kMaxThreads) void lru_cache_insert_kernel(
         lxu_cache_state[cache_set][insert_slot] = insert_idx;
         lru_state[cache_set][insert_slot] = time_stamp;
         if (lock_cache_line) {
-          lxu_cache_locking_counter[cache_set][insert_slot] += 1;
+          atomicAdd(&lxu_cache_locking_counter[cache_set][insert_slot], 1);
         }
       }
 

--- a/fbgemm_gpu/src/split_embeddings_cache/lxu_cache.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lxu_cache.cu
@@ -176,7 +176,7 @@ __launch_bounds__(kMaxThreads) void lxu_cache_locking_counter_decrement_kernel(
        i += gridDim.x * blockDim.y) {
     const auto j = threadIdx.x;
     if (count[i][j] > 0) {
-      lxu_cache_locking_counter[i][j] -= 1;
+      atomicAdd(&lxu_cache_locking_counter[i][j], -1);
     }
   }
 }

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_embeddings_cache_cuda.cu
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_embeddings_cache_cuda.cu
@@ -317,7 +317,7 @@ __global__ __launch_bounds__(kMaxThreads) void ssd_cache_actions_insert_kernel(
 
       // Lock cache line
       if (lock_cache_line) {
-        lxu_cache_locking_counter[cache_set][insert_slot] += 1;
+        atomicAdd(&lxu_cache_locking_counter[cache_set][insert_slot], 1);
       }
     }
   }

--- a/fbgemm_gpu/test/tbe/cache/cache_common.py
+++ b/fbgemm_gpu/test/tbe/cache/cache_common.py
@@ -65,6 +65,7 @@ class TestingStatsReporter(TBEStatsReporter):
         embedding_id: str = "",
         tbe_id: str = "",
         time_unit: str = "ms",
+        enable_tb_metrics: bool = False,
     ) -> None:
         self.reported_data.setdefault(event_name, [])
         self.reported_data[event_name].append(
@@ -78,6 +79,7 @@ class TestingStatsReporter(TBEStatsReporter):
         data_bytes: int,
         embedding_id: str = "",
         tbe_id: str = "",
+        enable_tb_metrics: bool = False,
     ) -> None:
         self.reported_data.setdefault(event_name, [])
         self.reported_data[event_name].append(

--- a/fbgemm_gpu/test/tbe/cache/lxu_cache_test.py
+++ b/fbgemm_gpu/test/tbe/cache/lxu_cache_test.py
@@ -16,18 +16,14 @@ from itertools import accumulate
 import hypothesis.strategies as st
 import numpy as np
 import torch
+from fbgemm_gpu.split_table_batched_embeddings_ops_common import CacheAlgorithm
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import DEFAULT_ASSOC
-from fbgemm_gpu.tbe.utils import to_device
+from fbgemm_gpu.tbe.utils import generate_requests, TBERequest, to_device
 from hypothesis import given, settings, Verbosity
 from torch import Tensor
 
-from ..common import MAX_EXAMPLES, open_source
-
-if open_source:
-    # pyre-ignore[21]
-    from test_utils import gpu_unavailable, optests
-else:
-    from fbgemm_gpu.test.test_utils import gpu_unavailable, optests
+from ..common import MAX_EXAMPLES  # noqa E402
+from .cache_common import generate_cache_tbes, gpu_unavailable, optests
 
 
 VERBOSITY: Verbosity = Verbosity.verbose
@@ -141,6 +137,95 @@ class LXUCacheTest(unittest.TestCase):
             lxu_cache_locking_counter, lxu_cache_locations
         )
         self.assertTrue(torch.equal(lxu_cache_locking_counter, counter_ref))
+
+    @unittest.skipIf(*gpu_unavailable)
+    @given(
+        T=st.integers(min_value=1, max_value=3),
+        D=st.integers(min_value=2, max_value=32),
+        B=st.integers(min_value=1, max_value=32),
+        log_E=st.integers(min_value=3, max_value=4),
+        L=st.integers(min_value=1, max_value=10),
+    )
+    @settings(verbosity=VERBOSITY, max_examples=MAX_EXAMPLES, deadline=None)
+    def test_lxu_cache_locking_counter_increment(
+        self,
+        T: int,
+        D: int,
+        B: int,
+        log_E: int,
+        L: int,
+    ) -> None:
+        """
+        Test that lxu_cache_locking_counter is correctly incremented during
+        cache prefetch (lru_cache_populate with lock_cache_line=True) and
+        correctly decremented back to zero after forward+backward.
+        """
+        cc, _, min_Es, _ = generate_cache_tbes(
+            T,
+            D,
+            log_E,
+            mixed=False,
+            cache_algorithm=CacheAlgorithm.LRU,
+            prefetch_pipeline=True,
+            use_int_weight=True,
+        )
+
+        requests = generate_requests(2, B, T, L, min_Es, reuse=0.1)
+        # Cast to long to match TBE expectations
+        for i, req in enumerate(requests):
+            indices, offsets, weights, Bs_feature_rank = req.unpack_4()
+            requests[i] = TBERequest(
+                indices.long(), offsets.long(), weights, Bs_feature_rank
+            )
+
+        # Verify counter starts at zero
+        counter = cc.lxu_cache_locking_counter
+        assert isinstance(counter, Tensor)
+        self.assertTrue(
+            torch.all(counter == 0),
+            "Counter should be zero initially",
+        )
+
+        # Prefetch first batch (calls lru_cache_populate with lock_cache_line=True)
+        indices_0, offsets_0, _, _ = requests[0].unpack_4()
+        cc.prefetch(indices_0, offsets_0)
+
+        # After prefetch, some counters should be incremented (> 0)
+        counter = cc.lxu_cache_locking_counter
+        assert isinstance(counter, Tensor)
+        self.assertTrue(
+            torch.any(counter > 0),
+            "After prefetch with lock_cache_line=True, "
+            "some counters should be incremented",
+        )
+
+        # All counter values should be non-negative
+        self.assertTrue(
+            torch.all(counter >= 0),
+            "All counter values should be non-negative after increment",
+        )
+
+        # Prefetch second batch (this also decrements counters for batch 0)
+        indices_1, offsets_1, _, _ = requests[1].unpack_4()
+        cc.prefetch(indices_1, offsets_1)
+
+        # Run forward + backward for both batches
+        output_0 = cc(indices_0, offsets_0)
+        output_0.backward(torch.randn_like(output_0))
+
+        output_1 = cc(indices_1, offsets_1)
+        output_1.backward(torch.randn_like(output_1))
+
+        # Flush to finalize
+        cc.flush()
+
+        # After full cycle, counter should be back to zero
+        counter = cc.lxu_cache_locking_counter
+        assert isinstance(counter, Tensor)
+        self.assertTrue(
+            torch.all(counter == 0),
+            "Counter should be zero after full prefetch-forward-backward cycle",
+        )
 
     @unittest.skipIf(*gpu_unavailable)
     @given(


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2481

Replace non-atomic `+= 1` and `-= 1` operations on `lxu_cache_locking_counter`
with `atomicAdd` in 4 CUDA kernels. While current code paths are safe by
construction (unique_indices guarantee single-writer per cache slot, and
segment guards prevent warp divergence), using atomicAdd is the correct CUDA
idiom for shared memory writes and provides defensive hardening against future
code changes that might introduce concurrent access.

Changed sites:
- `lru_cache_find_uncached_kernel` (lru_cache_find.cu): counter increment on cache hit
- `lru_cache_insert_kernel` (lru_cache_populate.cu): counter increment on cache insert
- `ssd_cache_actions_insert_kernel` (ssd_split_embeddings_cache_cuda.cu): counter increment
- `lxu_cache_locking_counter_decrement_kernel` (lxu_cache.cu): counter decrement

Reviewed By: q10

Differential Revision: D96676696


