### PR TITLE
Replace spin-wait polling with condition variable in EmbeddingKVDB fill queue (#5510)

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -115,24 +115,34 @@ EmbeddingKVDB::EmbeddingKVDB(
   if (enable_async_update_) {
     cache_filling_thread_ = std::make_unique<std::thread>([=, this] {
       while (!stop_) {
-        auto filling_item_ptr = weights_to_fill_queue_.try_peek();
-        if (!filling_item_ptr) {
-          // TODO: make it tunable interval for background thread
-          // only sleep on empty queue
-          std::this_thread::sleep_for(std::chrono::milliseconds(10));
-          continue;
+        // Wait for work to arrive using condition variable instead of polling
+        {
+          std::unique_lock<std::mutex> lk(fill_queue_mtx_);
+          fill_queue_cv_.wait(
+              lk, [this] { return !weights_to_fill_queue_.empty() || stop_; });
         }
-        if (stop_) {
-          return;
+
+        // Drain all available items
+        while (auto* filling_item_ptr = weights_to_fill_queue_.try_peek()) {
+          if (stop_) {
+            return;
+          }
+          auto& indices = filling_item_ptr->indices;
+          auto& weights = filling_item_ptr->weights;
+          auto& count = filling_item_ptr->count;
+          auto& rocksdb_wmode = filling_item_ptr->mode;
+
+          update_cache_and_storage(indices, weights, count, rocksdb_wmode);
+
+          weights_to_fill_queue_.dequeue();
         }
-        auto& indices = filling_item_ptr->indices;
-        auto& weights = filling_item_ptr->weights;
-        auto& count = filling_item_ptr->count;
-        auto& rocksdb_wmode = filling_item_ptr->mode;
-
-        update_cache_and_storage(indices, weights, count, rocksdb_wmode);
-
-        weights_to_fill_queue_.dequeue();
+        // Queue drained — notify waiters (e.g. wait_util_filling_work_done).
+        // Lock barrier prevents lost wakeups if a waiter is between its
+        // predicate check and entering the CV wait.
+        {
+          std::lock_guard<std::mutex> lk(fill_queue_mtx_);
+        }
+        fill_queue_cv_.notify_all();
       }
     });
   }
@@ -141,6 +151,13 @@ EmbeddingKVDB::EmbeddingKVDB(
 EmbeddingKVDB::~EmbeddingKVDB() {
   stop_ = true;
   if (enable_async_update_) {
+    // Lock barrier + notify to wake the background thread so it sees stop_.
+    // Without the lock barrier, the notify could arrive while the thread is
+    // between its predicate check and entering CV wait, causing a lost wakeup.
+    {
+      std::lock_guard<std::mutex> lk(fill_queue_mtx_);
+    }
+    fill_queue_cv_.notify_all();
     cache_filling_thread_->join();
   }
 }
@@ -417,6 +434,12 @@ void EmbeddingKVDB::set(
     auto tensor_copy_start_ts = facebook::WallClockUtil::NowInUsecFast();
     auto new_item = tensor_copy(indices, weights, count, write_mode);
     weights_to_fill_queue_.enqueue(new_item);
+    // Lock barrier ensures the background thread's CV wait has completed
+    // its atomic unlock-and-block before we notify, preventing lost wakeups.
+    {
+      std::lock_guard<std::mutex> lk(fill_queue_mtx_);
+    }
+    fill_queue_cv_.notify_one();
     set_tensor_copy_for_cache_update_ +=
         facebook::WallClockUtil::NowInUsecFast() - tensor_copy_start_ts;
   } else {
@@ -473,6 +496,13 @@ void EmbeddingKVDB::get(
         auto new_item = tensor_copy(
             indices, weights, count, kv_db::RocksdbWriteMode::FWD_ROCKSDB_READ);
         weights_to_fill_queue_.enqueue(new_item);
+        // Lock barrier ensures the background thread's CV wait has completed
+        // its atomic unlock-and-block before we notify, preventing lost
+        // wakeups.
+        {
+          std::lock_guard<std::mutex> lk(fill_queue_mtx_);
+        }
+        fill_queue_cv_.notify_one();
         get_tensor_copy_for_cache_update_ +=
             facebook::WallClockUtil::NowInUsecFast() - tensor_copy_start_ts;
       } else {
@@ -582,19 +612,9 @@ std::shared_ptr<CacheContext> EmbeddingKVDB::get_cache(
 void EmbeddingKVDB::wait_util_filling_work_done() {
   auto start_ts = facebook::WallClockUtil::NowInUsecFast();
   if (enable_async_update_) {
-    int total_wait_time_ms = 0;
-    while (!weights_to_fill_queue_.empty()) {
-      // need to wait until all the pending weight-filling actions to finish
-      // otherwise might get incorrect embeddings
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
-      total_wait_time_ms += 1;
-      if (total_wait_time_ms > 100) {
-        XLOG_EVERY_MS(ERR, 1000)
-            << "[TBE_ID" << unique_id_
-            << "]get_cache: waiting for L2 caching filling embeddings for "
-            << total_wait_time_ms << " ms, somethings is likely wrong";
-      }
-    }
+    std::unique_lock<std::mutex> lk(fill_queue_mtx_);
+    // Wait on CV instead of polling — wakes when background thread drains queue
+    fill_queue_cv_.wait(lk, [this] { return weights_to_fill_queue_.empty(); });
   }
   get_cache_lookup_wait_filling_thread_duration_ +=
       facebook::WallClockUtil::NowInUsecFast() - start_ts;

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
@@ -12,6 +12,8 @@
     (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86)))
 #include <mkl.h>
 #endif
+#include <condition_variable>
+#include <mutex>
 #include <random>
 
 #include <ATen/ATen.h>
@@ -513,6 +515,11 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
   bool enable_async_update_;
   std::unique_ptr<std::thread> cache_filling_thread_;
   std::atomic<bool> stop_{false};
+  // Condition variable for signaling between fill queue
+  // producer/consumer/waiter. Replaces the previous spin-wait polling pattern
+  // with proper CV notification.
+  std::mutex fill_queue_mtx_;
+  std::condition_variable fill_queue_cv_;
   // buffer queue that stores all the needed indices/weights/action_count to
   // fill up cache
   folly::USPSCQueue<QueueItem, true> weights_to_fill_queue_;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2484


Replace inefficient polling patterns in the EmbeddingKVDB background cache
filling thread with std::condition_variable for immediate wakeup on queue
state changes.

Before: Background thread polled `weights_to_fill_queue_.try_peek()` with
10ms sleep intervals. `wait_util_filling_work_done()` polled
`weights_to_fill_queue_.empty()` with 1ms sleep intervals.

After: Background thread blocks on CV `wait()` until items are enqueued or
`stop_` is set. `wait_util_filling_work_done()` blocks on CV `wait()` until
the background thread drains the queue. Both enqueue sites (`set()` and
`get()`) call `notify_one()` to wake the background thread. The background
thread calls `notify_all()` after draining the queue to wake any waiting
callers. The destructor calls `notify_all()` before joining to ensure clean
shutdown.

This eliminates wasted CPU cycles from busy-waiting and reduces latency from
the 1-10ms polling granularity to near-instant wakeup.

Reviewed By: royren622

Differential Revision: D96630505


