### PR TITLE
Auto-size RocksDB block cache and expose L2 cache hit rate (#5513)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference.py
@@ -220,6 +220,18 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
         self.register_buffer(
             "lru_state", torch.zeros(cache_sets, ASSOC, dtype=torch.int64)
         )
+        # Cache locking counter: prevents eviction of cache lines that are
+        # currently being read by forward(). Without this, a concurrent
+        # prefetch() can evict a cache line that forward() is still using.
+        self.register_buffer(
+            "lxu_cache_locking_counter",
+            torch.zeros(
+                cache_sets,
+                ASSOC,
+                device=self.current_device,
+                dtype=torch.int32,
+            ),
+        )
 
         assert ssd_cache_location in (
             EmbeddingLocation.MANAGED,
@@ -308,8 +320,12 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
         # pyre-fixme[20]: Argument `self` expected.
         low_priority, high_priority = torch.cuda.Stream.priority_range()
         self.ssd_stream = torch.cuda.Stream(priority=low_priority)
+        # Dedicated stream for D2H memory copies (overlaps with compute)
+        self.ssd_memcpy_stream = torch.cuda.Stream(priority=low_priority)
         self.ssd_set_start = torch.cuda.Event()
         self.ssd_set_end = torch.cuda.Event()
+        # Event for D2H copy completion
+        self.ssd_event_memcpy = torch.cuda.Event()
 
         # pyre-fixme[4]: Attribute must be annotated.
         # pyre-ignore[16]
@@ -393,11 +409,24 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
             self.timestep_counter.get(),
             1,  # for now assume prefetch_dist == 1
             self.lru_state,
+            lock_cache_line=True,
+            lxu_cache_locking_counter=self.lxu_cache_locking_counter,
         )
+        current_stream = torch.cuda.current_stream()
+        # D2H copies on dedicated memcpy stream (overlaps with compute on
+        # default stream)
         actions_count_cpu = torch.empty(
             actions_count_gpu.shape, pin_memory=True, dtype=actions_count_gpu.dtype
         )
-        actions_count_cpu.copy_(actions_count_gpu, non_blocking=True)
+        inserted_indices_cpu = torch.empty(
+            inserted_indices.shape, pin_memory=True, dtype=inserted_indices.dtype
+        )
+        with torch.cuda.stream(self.ssd_memcpy_stream):
+            self.ssd_memcpy_stream.wait_stream(current_stream)
+            actions_count_cpu.copy_(actions_count_gpu, non_blocking=True)
+            inserted_indices_cpu.copy_(inserted_indices, non_blocking=True)
+            self.ssd_memcpy_stream.record_event(self.ssd_event_memcpy)
+
         assigned_cache_slots = assigned_cache_slots.long()
         evicted_rows = self.lxu_cache_weights[
             assigned_cache_slots.clamp_(min=0).long(), :
@@ -408,14 +437,10 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
             pin_memory=True,
         )
 
-        current_stream = torch.cuda.current_stream()
-
         # Ensure the previous iterations l3_db.set(..) has completed.
         current_stream.wait_event(self.ssd_set_end)
-        inserted_indices_cpu = torch.empty(
-            inserted_indices.shape, pin_memory=True, dtype=inserted_indices.dtype
-        )
-        inserted_indices_cpu.copy_(inserted_indices, non_blocking=True)
+        # Wait for D2H copies to complete before get_cuda
+        current_stream.wait_event(self.ssd_event_memcpy)
         self.ssd_db.get_cuda(
             inserted_indices_cpu,
             inserted_rows,
@@ -477,6 +502,14 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
             linear_cache_indices,
             self.lxu_cache_state,
             self.total_hash_size,
+        )
+
+        # Decrement cache locking counter — signals that these cache lines
+        # are no longer pinned by this forward() call, allowing future
+        # prefetch() calls to evict them if needed.
+        torch.ops.fbgemm.lxu_cache_locking_counter_decrement(
+            self.lxu_cache_locking_counter,
+            lxu_cache_locations,
         )
 
         self.timestep_prefetch_size.decrement()

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -485,14 +485,19 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 * self.lxu_cache_weights.element_size()
             ), "The precomputed cache_size does not match the actual cache size"
 
-        # Buffers for cache eviction
+        # Buffers for cache eviction — double-buffered to allow pipelining.
+        # While iteration N's eviction runs asynchronously on buffer[0],
+        # iteration N+1 can immediately populate buffer[1] without waiting.
         # For storing weights to evict
         # The max number of rows to be evicted is limited by the number of
         # slots in the cache. Thus, we allocate `lxu_cache_evicted_weights` to
         # be the same shape as the L1 cache (lxu_cache_weights)
-        self.register_buffer(
-            "lxu_cache_evicted_weights",
-            torch.ops.fbgemm.new_unified_tensor(
+        self.lxu_cache_evicted_weights_list = []
+        self.lxu_cache_evicted_indices_list = []
+        self.lxu_cache_evicted_slots_list = []
+        self.lxu_cache_evicted_count_list = []
+        for buf_idx in range(2):
+            evicted_weights = torch.ops.fbgemm.new_unified_tensor(
                 torch.zeros(
                     1,
                     device=self.current_device,
@@ -500,13 +505,14 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 ),
                 self.lxu_cache_weights.shape,
                 is_host_mapped=self.uvm_host_mapped,
-            ),
-        )
+            )
+            self.register_buffer(
+                f"lxu_cache_evicted_weights_{buf_idx}",
+                evicted_weights,
+            )
+            self.lxu_cache_evicted_weights_list.append(evicted_weights)
 
-        # For storing embedding indices to evict to
-        self.register_buffer(
-            "lxu_cache_evicted_indices",
-            torch.ops.fbgemm.new_unified_tensor(
+            evicted_indices = torch.ops.fbgemm.new_unified_tensor(
                 torch.zeros(
                     1,
                     device=self.current_device,
@@ -514,13 +520,14 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 ),
                 (self.lxu_cache_weights.shape[0],),
                 is_host_mapped=self.uvm_host_mapped,
-            ),
-        )
+            )
+            self.register_buffer(
+                f"lxu_cache_evicted_indices_{buf_idx}",
+                evicted_indices,
+            )
+            self.lxu_cache_evicted_indices_list.append(evicted_indices)
 
-        # For storing cache slots to evict
-        self.register_buffer(
-            "lxu_cache_evicted_slots",
-            torch.ops.fbgemm.new_unified_tensor(
+            evicted_slots = torch.ops.fbgemm.new_unified_tensor(
                 torch.zeros(
                     1,
                     device=self.current_device,
@@ -528,13 +535,14 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 ),
                 (self.lxu_cache_weights.shape[0],),
                 is_host_mapped=self.uvm_host_mapped,
-            ),
-        )
+            )
+            self.register_buffer(
+                f"lxu_cache_evicted_slots_{buf_idx}",
+                evicted_slots,
+            )
+            self.lxu_cache_evicted_slots_list.append(evicted_slots)
 
-        # For storing the number of evicted rows
-        self.register_buffer(
-            "lxu_cache_evicted_count",
-            torch.ops.fbgemm.new_unified_tensor(
+            evicted_count = torch.ops.fbgemm.new_unified_tensor(
                 torch.zeros(
                     1,
                     device=self.current_device,
@@ -542,8 +550,15 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 ),
                 (1,),
                 is_host_mapped=self.uvm_host_mapped,
-            ),
-        )
+            )
+            self.register_buffer(
+                f"lxu_cache_evicted_count_{buf_idx}",
+                evicted_count,
+            )
+            self.lxu_cache_evicted_count_list.append(evicted_count)
+
+        # Ping-pong index for double-buffered eviction
+        self._evict_buf_idx = 0
 
         self.timestep = 0
 
@@ -844,8 +859,11 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         self.ssd_event_get = torch.cuda.Event()
         # SSD scratch pad eviction completion event
         self.ssd_event_sp_evict = torch.cuda.Event()
-        # SSD cache eviction completion event
-        self.ssd_event_cache_evict = torch.cuda.Event()
+        # SSD cache eviction completion events (double-buffered)
+        self.ssd_event_cache_evict = [
+            torch.cuda.Event(),
+            torch.cuda.Event(),
+        ]
         # SSD backward completion event
         self.ssd_event_backward = torch.cuda.Event()
         # SSD get's input copy completion event
@@ -1922,17 +1940,23 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             # number of rows in `lxu_cache_evicted_weights` might be smaller
             # than the number of elements in `evicted_indices`. Without this
             # step, we can run into the index out of bound issue
+            #
+            # Double-buffering: wait on the CURRENT buffer's event (from 2
+            # iterations ago) before overwriting it. The OTHER buffer's
+            # eviction from the previous iteration can still be in-flight.
+            #
             # NOTE: In embedding_cache_mode, evict() is skipped (see below), so
             # ssd_event_cache_evict is never recorded. Skip waiting for it to
             # avoid latency accumulation.
+            evict_idx = self._evict_buf_idx
             if not self._embedding_cache_mode:
-                current_stream.wait_event(self.ssd_event_cache_evict)
+                current_stream.wait_event(self.ssd_event_cache_evict[evict_idx])
             torch.ops.fbgemm.compact_indices(
                 compact_indices=[
-                    self.lxu_cache_evicted_indices,
-                    self.lxu_cache_evicted_slots,
+                    self.lxu_cache_evicted_indices_list[evict_idx],
+                    self.lxu_cache_evicted_slots_list[evict_idx],
                 ],
-                compact_count=self.lxu_cache_evicted_count,
+                compact_count=self.lxu_cache_evicted_count_list[evict_idx],
                 indices=[evicted_indices, assigned_cache_slots],
                 masks=torch.where(evicted_indices != -1, 1, 0),
                 count=actions_count_gpu,
@@ -2030,10 +2054,10 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             # later in the prefetch step)
             with record_function("## ssd_compute_evicted_rows ##"):
                 torch.ops.fbgemm.masked_index_select(
-                    self.lxu_cache_evicted_weights,
-                    self.lxu_cache_evicted_slots,
+                    self.lxu_cache_evicted_weights_list[evict_idx],
+                    self.lxu_cache_evicted_slots_list[evict_idx],
                     self.lxu_cache_weights,
-                    self.lxu_cache_evicted_count,
+                    self.lxu_cache_evicted_count_list[evict_idx],
                 )
 
             # Allocation a scratch pad for the current iteration. The scratch
@@ -2243,14 +2267,14 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 if linear_cache_indices.numel() > 0 and not self._embedding_cache_mode:
                     # Evict rows from cache to SSD
                     self.evict(
-                        rows=self.lxu_cache_evicted_weights,
-                        indices_cpu=self.lxu_cache_evicted_indices,
-                        actions_count_cpu=self.lxu_cache_evicted_count,
+                        rows=self.lxu_cache_evicted_weights_list[evict_idx],
+                        indices_cpu=self.lxu_cache_evicted_indices_list[evict_idx],
+                        actions_count_cpu=self.lxu_cache_evicted_count_list[evict_idx],
                         stream=self.ssd_eviction_stream,
                         pre_event=self.ssd_event_get,
                         # Record completion event after scratch pad eviction
                         # instead since that happens after L1 eviction
-                        post_event=self.ssd_event_cache_evict,
+                        post_event=self.ssd_event_cache_evict[evict_idx],
                         is_rows_uvm=True,
                         name="cache",
                         is_bwd=False,
@@ -2266,8 +2290,11 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                         weights=weights,
                         d2h_stream=self.ssd_memcpy_stream,
                         write_stream=self.feature_score_stream,
-                        pre_event_for_write=self.ssd_event_cache_evict,
+                        pre_event_for_write=self.ssd_event_cache_evict[evict_idx],
                     )
+
+            # Flip the double-buffer index for the next iteration
+            self._evict_buf_idx = 1 - evict_idx
 
             # Generate row addresses (pointing to either L1 or the current
             # iteration's scratch pad)

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -646,6 +646,23 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
         self.tbe_unique_id = tbe_unique_id
         self.l2_cache_size = l2_cache_size
         logging.info(f"tbe_unique_id: {tbe_unique_id}")
+
+        # Auto-size RocksDB block cache: -1 means 10% of total embedding table size
+        if ssd_block_cache_size_per_tbe == -1:
+            element_size = weights_precision.bit_rate() // 8
+            total_embedding_bytes = sum(
+                r * d * element_size for r, d in embedding_specs
+            )
+            ssd_block_cache_size_per_tbe = max(
+                total_embedding_bytes // 10,
+                16 * 1024 * 1024,  # minimum 16MB
+            )
+            logging.info(
+                f"Auto-sized RocksDB block cache to "
+                f"{ssd_block_cache_size_per_tbe / 1024 / 1024:.0f}MB "
+                f"(10% of {total_embedding_bytes / 1024 / 1024 / 1024:.2f}GB total embedding table)"
+            )
+
         self.enable_free_mem_trigger_eviction: bool = False
         if self.backend_type == BackendType.SSD:
             logging.info(
@@ -1245,6 +1262,15 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             )
 
         self._ssd_db = value
+
+    @property
+    def l2_cache_hit_rate(self) -> float:
+        """Returns the L2 cache hit rate as a percentage (0-100).
+
+        Reads counters without resetting them, unlike the stats reported
+        through get_l2cache_perf(). Useful for ad-hoc monitoring.
+        """
+        return self.ssd_db.get_l2_cache_hit_rate()
 
     def _lazy_initialize_ssd_tbe(self) -> None:
         """
@@ -4117,6 +4143,15 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             event_name=self.l2_cache_free_mem_stats_name,
             data_bytes=l2_cache_free_bytes,
         )
+
+        # Report computed hit rate
+        if num_lookups > 0:
+            hit_rate = 100.0 * (num_lookups - num_cache_misses) / num_lookups
+            stats_reporter.report_data_amount(
+                iteration_step=self.step,
+                event_name="l2_cache.hit_rate_pct",
+                data_bytes=hit_rate,
+            )
 
         stats_reporter.report_duration(
             iteration_step=self.step,

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache_wrapper.h
@@ -150,6 +150,10 @@ class DramKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
     return impl_->wait_util_filling_work_done();
   }
 
+  double get_l2_cache_hit_rate() {
+    return impl_->get_l2_cache_hit_rate();
+  }
+
   at::Tensor get_keys_in_range(int64_t start, int64_t end) {
     return impl_->get_keys_in_range_impl(start, end, std::nullopt);
   }

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/embedding_rocksdb_wrapper.h
@@ -213,6 +213,10 @@ class EmbeddingRocksDBWrapper : public torch::jit::CustomClassHolder {
     return impl_->wait_util_filling_work_done();
   }
 
+  double get_l2_cache_hit_rate() {
+    return impl_->get_l2_cache_hit_rate();
+  }
+
   c10::intrusive_ptr<EmbeddingSnapshotHandleWrapper> create_snapshot() {
     auto handle = impl_->create_snapshot();
     return c10::make_intrusive<EmbeddingSnapshotHandleWrapper>(handle, impl_);

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -383,6 +383,16 @@ std::vector<double> EmbeddingKVDB::get_l2cache_perf(
   return ret;
 }
 
+double EmbeddingKVDB::get_l2_cache_hit_rate() const {
+  const auto total = num_lookups_.load(std::memory_order_relaxed);
+  if (total == 0) {
+    return 100.0;
+  }
+  const auto misses = num_cache_misses_.load(std::memory_order_relaxed);
+  return 100.0 * static_cast<double>(total - misses) /
+      static_cast<double>(total);
+}
+
 void EmbeddingKVDB::reset_l2_cache() {
   l2_cache_ = nullptr;
 }

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -115,24 +115,29 @@ EmbeddingKVDB::EmbeddingKVDB(
   if (enable_async_update_) {
     cache_filling_thread_ = std::make_unique<std::thread>([=, this] {
       while (!stop_) {
-        auto filling_item_ptr = weights_to_fill_queue_.try_peek();
-        if (!filling_item_ptr) {
-          // TODO: make it tunable interval for background thread
-          // only sleep on empty queue
-          std::this_thread::sleep_for(std::chrono::milliseconds(10));
-          continue;
+        // Wait for work to arrive using condition variable instead of polling
+        {
+          std::unique_lock<std::mutex> lk(fill_queue_mtx_);
+          fill_queue_cv_.wait(
+              lk, [this] { return !weights_to_fill_queue_.empty() || stop_; });
         }
-        if (stop_) {
-          return;
+
+        // Drain all available items
+        while (auto* filling_item_ptr = weights_to_fill_queue_.try_peek()) {
+          if (stop_) {
+            return;
+          }
+          auto& indices = filling_item_ptr->indices;
+          auto& weights = filling_item_ptr->weights;
+          auto& count = filling_item_ptr->count;
+          auto& rocksdb_wmode = filling_item_ptr->mode;
+
+          update_cache_and_storage(indices, weights, count, rocksdb_wmode);
+
+          weights_to_fill_queue_.dequeue();
         }
-        auto& indices = filling_item_ptr->indices;
-        auto& weights = filling_item_ptr->weights;
-        auto& count = filling_item_ptr->count;
-        auto& rocksdb_wmode = filling_item_ptr->mode;
-
-        update_cache_and_storage(indices, weights, count, rocksdb_wmode);
-
-        weights_to_fill_queue_.dequeue();
+        // Queue drained — notify any waiting get() calls
+        fill_queue_cv_.notify_all();
       }
     });
   }
@@ -141,6 +146,8 @@ EmbeddingKVDB::EmbeddingKVDB(
 EmbeddingKVDB::~EmbeddingKVDB() {
   stop_ = true;
   if (enable_async_update_) {
+    // Wake the background thread so it can see stop_ and exit
+    fill_queue_cv_.notify_all();
     cache_filling_thread_->join();
   }
 }
@@ -417,6 +424,8 @@ void EmbeddingKVDB::set(
     auto tensor_copy_start_ts = facebook::WallClockUtil::NowInUsecFast();
     auto new_item = tensor_copy(indices, weights, count, write_mode);
     weights_to_fill_queue_.enqueue(new_item);
+    // Notify background thread that work is available
+    fill_queue_cv_.notify_one();
     set_tensor_copy_for_cache_update_ +=
         facebook::WallClockUtil::NowInUsecFast() - tensor_copy_start_ts;
   } else {
@@ -473,6 +482,8 @@ void EmbeddingKVDB::get(
         auto new_item = tensor_copy(
             indices, weights, count, kv_db::RocksdbWriteMode::FWD_ROCKSDB_READ);
         weights_to_fill_queue_.enqueue(new_item);
+        // Notify background thread that work is available
+        fill_queue_cv_.notify_one();
         get_tensor_copy_for_cache_update_ +=
             facebook::WallClockUtil::NowInUsecFast() - tensor_copy_start_ts;
       } else {
@@ -582,19 +593,9 @@ std::shared_ptr<CacheContext> EmbeddingKVDB::get_cache(
 void EmbeddingKVDB::wait_util_filling_work_done() {
   auto start_ts = facebook::WallClockUtil::NowInUsecFast();
   if (enable_async_update_) {
-    int total_wait_time_ms = 0;
-    while (!weights_to_fill_queue_.empty()) {
-      // need to wait until all the pending weight-filling actions to finish
-      // otherwise might get incorrect embeddings
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
-      total_wait_time_ms += 1;
-      if (total_wait_time_ms > 100) {
-        XLOG_EVERY_MS(ERR, 1000)
-            << "[TBE_ID" << unique_id_
-            << "]get_cache: waiting for L2 caching filling embeddings for "
-            << total_wait_time_ms << " ms, somethings is likely wrong";
-      }
-    }
+    std::unique_lock<std::mutex> lk(fill_queue_mtx_);
+    // Wait on CV instead of polling — wakes when background thread drains queue
+    fill_queue_cv_.wait(lk, [this] { return weights_to_fill_queue_.empty(); });
   }
   get_cache_lookup_wait_filling_thread_duration_ +=
       facebook::WallClockUtil::NowInUsecFast() - start_ts;

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
@@ -12,6 +12,8 @@
     (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86)))
 #include <mkl.h>
 #endif
+#include <condition_variable>
+#include <mutex>
 #include <random>
 
 #include <ATen/ATen.h>
@@ -513,6 +515,11 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
   bool enable_async_update_;
   std::unique_ptr<std::thread> cache_filling_thread_;
   std::atomic<bool> stop_{false};
+  // Condition variable for signaling between fill queue
+  // producer/consumer/waiter. Replaces the previous spin-wait polling pattern
+  // with proper CV notification.
+  std::mutex fill_queue_mtx_;
+  std::condition_variable fill_queue_cv_;
   // buffer queue that stores all the needed indices/weights/action_count to
   // fill up cache
   folly::USPSCQueue<QueueItem, true> weights_to_fill_queue_;

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.h
@@ -353,6 +353,10 @@ class EmbeddingKVDB : public std::enable_shared_from_this<EmbeddingKVDB> {
   // finished, it could also be called in unitest to sync
   void wait_util_filling_work_done();
 
+  // Returns the L2 cache hit rate as a percentage (0-100).
+  // Reads counters without resetting them, unlike get_l2cache_perf().
+  double get_l2_cache_hit_rate() const;
+
   virtual at::Tensor get_keys_in_range_impl(
       int64_t /* start */,
       int64_t /* end */,

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -1015,6 +1015,9 @@ static auto embedding_rocks_db_wrapper =
             "get_rocksdb_io_duration",
             &EmbeddingRocksDBWrapper::get_rocksdb_io_duration)
         .def("get_l2cache_perf", &EmbeddingRocksDBWrapper::get_l2cache_perf)
+        .def(
+            "get_l2_cache_hit_rate",
+            &EmbeddingRocksDBWrapper::get_l2_cache_hit_rate)
         .def("set", &EmbeddingRocksDBWrapper::set)
         .def("set_kv_to_storage", &EmbeddingRocksDBWrapper::set_kv_to_storage)
         .def(
@@ -1190,6 +1193,9 @@ static auto dram_kv_embedding_cache_wrapper =
         .def(
             "wait_util_filling_work_done",
             &DramKVEmbeddingCacheWrapper::wait_util_filling_work_done)
+        .def(
+            "get_l2_cache_hit_rate",
+            &DramKVEmbeddingCacheWrapper::get_l2_cache_hit_rate)
         .def(
             "wait_until_eviction_done",
             &DramKVEmbeddingCacheWrapper::wait_until_eviction_done)

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -255,7 +255,9 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
     table_options.format_version = 5;
     table_options.read_amp_bytes_per_bit = 1;
 
-    table_options.filter_policy.reset(rocksdb::NewBloomFilterPolicy(16));
+    // 10 bits/key gives ~1% false positive rate, sufficient for point lookups.
+    // 16 bits/key wastes ~37% more memory for marginal gain (0.01% FPR).
+    table_options.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10));
     options.table_factory.reset(
         rocksdb::NewBlockBasedTableFactory(table_options));
     options.memtable_prefix_bloom_size_ratio = 0.05;
@@ -263,8 +265,13 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
     options.max_background_jobs = num_threads;
     // maximum number of concurrent flush operations
     options.max_background_flushes = num_threads;
-    options.env->SetBackgroundThreads(4, rocksdb::Env::HIGH);
-    options.env->SetBackgroundThreads(1, rocksdb::Env::LOW);
+    // Scale background thread pools with num_threads (set from
+    // ssd_rocksdb_shards in Python). HIGH-priority handles flushes,
+    // LOW-priority handles compactions.
+    options.env->SetBackgroundThreads(
+        std::max<int64_t>(num_threads, 4), rocksdb::Env::HIGH);
+    options.env->SetBackgroundThreads(
+        std::max<int64_t>(num_threads / 4, 1), rocksdb::Env::LOW);
     options.max_open_files = -1;
 
     initialize_dbs(num_shards, path, options, use_passed_in_path);
@@ -1514,12 +1521,16 @@ class ReadOnlyEmbeddingKVDB : public torch::jit::CustomClassHolder {
     table_options.format_version = 5;
     table_options.read_amp_bytes_per_bit = 1;
 
-    table_options.filter_policy.reset(rocksdb::NewBloomFilterPolicy(16));
+    // 10 bits/key gives ~1% false positive rate, sufficient for point lookups.
+    // 16 bits/key wastes ~37% more memory for marginal gain (0.01% FPR).
+    table_options.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10));
     options.table_factory.reset(
         rocksdb::NewBlockBasedTableFactory(table_options));
     options.max_background_jobs = num_threads;
-    options.env->SetBackgroundThreads(4, rocksdb::Env::HIGH);
-    options.env->SetBackgroundThreads(1, rocksdb::Env::LOW);
+    options.env->SetBackgroundThreads(
+        std::max<int64_t>(num_threads, 4), rocksdb::Env::HIGH);
+    options.env->SetBackgroundThreads(
+        std::max<int64_t>(num_threads / 4, 1), rocksdb::Env::LOW);
 
     options.max_open_files = -1;
 

--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_inference_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_inference_test.py
@@ -446,3 +446,138 @@ class SSDIntNBitTableBatchedEmbeddingsTest(unittest.TestCase):
                 rtol=1.0e-2,
             )
         time.sleep(0.1)
+
+
+@unittest.skipIf(*running_in_oss)
+@unittest.skipIf(*gpu_unavailable)
+class SSDInferenceCacheLockingTest(unittest.TestCase):
+    """
+    Tests for D96632292: Cache locking and memcpy stream in inference path.
+    Separated from the broken test class above so these actually run.
+    """
+
+    def test_lxu_cache_locking_counter_registered(self) -> None:
+        """
+        Test D96632292: Verify lxu_cache_locking_counter buffer is registered
+        with correct shape (cache_sets, ASSOC) and dtype int32.
+        """
+        import tempfile
+
+        E = int(1e4)
+        D = 128
+        cache_sets = 64
+        ASSOC = 32  # hardcoded in FBGEMM
+
+        emb = SSDIntNBitTableBatchedEmbeddingBags(
+            embedding_specs=[("", E, D, SparseType.FP32)],
+            feature_table_map=[0],
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=cache_sets,
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            pooling_mode=PoolingMode.SUM,
+        ).cuda()
+
+        self.assertTrue(
+            hasattr(emb, "lxu_cache_locking_counter"),
+            "lxu_cache_locking_counter should be registered as a buffer",
+        )
+        self.assertEqual(
+            emb.lxu_cache_locking_counter.shape,
+            (cache_sets, ASSOC),
+            f"Expected shape ({cache_sets}, {ASSOC}), "
+            f"got {emb.lxu_cache_locking_counter.shape}",
+        )
+        self.assertEqual(
+            emb.lxu_cache_locking_counter.dtype,
+            torch.int32,
+            "lxu_cache_locking_counter should be int32",
+        )
+        # Initially all zeros
+        self.assertTrue(
+            (emb.lxu_cache_locking_counter == 0).all().item(),
+            "lxu_cache_locking_counter should be initialized to zeros",
+        )
+
+    def test_ssd_memcpy_stream_created(self) -> None:
+        """
+        Test D96632292: Verify ssd_memcpy_stream is created as a CUDA stream.
+        """
+        import tempfile
+
+        emb = SSDIntNBitTableBatchedEmbeddingBags(
+            embedding_specs=[("", int(1e4), 128, SparseType.FP32)],
+            feature_table_map=[0],
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=64,
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            pooling_mode=PoolingMode.SUM,
+        ).cuda()
+
+        self.assertTrue(
+            hasattr(emb, "ssd_memcpy_stream"),
+            "ssd_memcpy_stream should exist",
+        )
+        self.assertIsInstance(
+            emb.ssd_memcpy_stream,
+            torch.cuda.Stream,
+            "ssd_memcpy_stream should be a CUDA stream",
+        )
+
+    def test_cache_locking_prefetch_forward_cycle(self) -> None:
+        """
+        Test D96632292: Verify cache locking counter increments during prefetch
+        and decrements during forward, with no negative values after completion.
+        """
+        import tempfile
+
+        E = int(1e4)
+        D = 128
+        T = 2
+        B = 8
+        L = 5
+
+        weights_ty = SparseType.FP32
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb = SSDIntNBitTableBatchedEmbeddingBags(
+            embedding_specs=[("", E, D, weights_ty)] * T,
+            feature_table_map=list(range(T)),
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=max(T * B * L, 1),
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            pooling_mode=PoolingMode.SUM,
+        ).cuda()
+
+        # Initialize embeddings in SSD
+        for t in range(T):
+            copy_byte_tensor = torch.empty([E, D_bytes], dtype=torch.uint8)
+            emb.ssd_db.set_cuda(
+                torch.arange(t * E, (t + 1) * E).to(torch.int64),
+                copy_byte_tensor,
+                torch.as_tensor([E]),
+                t,
+            )
+        torch.cuda.synchronize()
+
+        # Run prefetch + forward cycles
+        for _ in range(10):
+            xs = [torch.randint(low=0, high=E, size=(B, L)).cuda() for _ in range(T)]
+            x = torch.cat([x.view(1, B, L) for x in xs], dim=0)
+            indices, offsets = get_table_batched_offsets_from_dense(x)
+            indices, offsets = indices.cuda(), offsets.cuda()
+
+            emb.prefetch(indices, offsets)
+            emb(indices.int(), offsets.int())
+
+        torch.cuda.synchronize()
+
+        # After all cycles complete, counter should be non-negative
+        counter = emb.lxu_cache_locking_counter.cpu()
+        self.assertTrue(
+            (counter >= 0).all().item(),
+            f"Cache locking counter has negatives after cycles: "
+            f"min={counter.min().item()}",
+        )

--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
@@ -1765,3 +1765,402 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
                 rtol=1e-2 if weights_precision == SparseType.FP16 else 1e-4,
                 atol=1e-2 if weights_precision == SparseType.FP16 else 1e-4,
             )
+
+    # ---- Tests for SSD TBE latency reduction diffs ----
+
+    def test_l2_cache_hit_rate_api(self) -> None:
+        """
+        Test D96753686: Verify l2_cache_hit_rate property returns a valid
+        percentage and is non-resetting (reading it twice returns consistent
+        results without clearing counters).
+        """
+        import tempfile
+
+        T = 2
+        D = 64
+        B = 16
+        E = int(1e4)
+        L = 10
+
+        emb = SSDTableBatchedEmbeddingBags(
+            embedding_specs=[(E, D)] * T,
+            feature_table_map=list(range(T)),
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=max(T * B * L, 1),
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            l2_cache_size=8,
+        ).cuda()
+
+        # Before any lookups, hit rate should be a valid number (0-100)
+        hit_rate_initial = emb.l2_cache_hit_rate
+        self.assertGreaterEqual(hit_rate_initial, 0.0)
+        self.assertLessEqual(hit_rate_initial, 100.0)
+
+        # Run a few iterations to generate cache activity
+        for _ in range(5):
+            indices = torch.randint(0, E, (B * T * L,)).cuda()
+            offsets = torch.arange(0, B * T + 1, dtype=torch.long).cuda() * L
+            emb.prefetch(indices, offsets)
+            emb(indices, offsets)
+        torch.cuda.synchronize()
+
+        # After lookups, hit rate should still be valid
+        hit_rate_after = emb.l2_cache_hit_rate
+        self.assertGreaterEqual(hit_rate_after, 0.0)
+        self.assertLessEqual(hit_rate_after, 100.0)
+
+        # Non-resetting: reading again should return the same or higher value
+        # (not reset to 0)
+        hit_rate_again = emb.l2_cache_hit_rate
+        self.assertEqual(hit_rate_after, hit_rate_again)
+
+    @given(
+        weights_precision=st.sampled_from([SparseType.FP32, SparseType.FP16]),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
+    def test_auto_size_block_cache(
+        self,
+        weights_precision: SparseType,
+    ) -> None:
+        """
+        Test D96753686: Verify auto-sizing of RocksDB block cache when
+        ssd_block_cache_size_per_tbe=-1. The TBE should initialize successfully
+        and be functionally correct (prefetch + forward produce valid outputs).
+        """
+        import tempfile
+
+        T = 2
+        D = 128
+        B = 8
+        E = int(1e4)
+        L = 5
+
+        # Create TBE with auto-sizing sentinel (-1)
+        emb = SSDTableBatchedEmbeddingBags(
+            embedding_specs=[(E, D)] * T,
+            feature_table_map=list(range(T)),
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=max(T * B * L, 1),
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            ssd_block_cache_size_per_tbe=-1,
+            weights_precision=weights_precision,
+            l2_cache_size=0,
+        ).cuda()
+
+        # Verify the TBE is functional with auto-sized block cache
+        indices = torch.randint(0, E, (B * T * L,)).cuda()
+        offsets = torch.arange(0, B * T + 1, dtype=torch.long).cuda() * L
+        emb.prefetch(indices, offsets)
+        output = emb(indices, offsets)
+        self.assertFalse(torch.isnan(output).any().item())
+        self.assertFalse(torch.isinf(output).any().item())
+
+    def test_auto_size_block_cache_minimum(self) -> None:
+        """
+        Test D96753686: Verify auto-sizing works for very small tables
+        (the 16MB minimum floor should apply).
+        """
+        import tempfile
+
+        T = 1
+        D = 16
+        B = 4
+        E = 100  # Very small table: 100 * 16 * 4 = 6400 bytes
+        L = 5
+
+        # This should auto-size to 16MB minimum, not 10% of 6400 bytes
+        emb = SSDTableBatchedEmbeddingBags(
+            embedding_specs=[(E, D)] * T,
+            feature_table_map=list(range(T)),
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=max(T * B * L, 1),
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            ssd_block_cache_size_per_tbe=-1,
+            weights_precision=SparseType.FP32,
+            l2_cache_size=0,
+        ).cuda()
+
+        # Verify functional correctness with minimum block cache
+        indices = torch.randint(0, E, (B * T * L,)).cuda()
+        offsets = torch.arange(0, B * T + 1, dtype=torch.long).cuda() * L
+        emb.prefetch(indices, offsets)
+        output = emb(indices, offsets)
+        self.assertFalse(torch.isnan(output).any().item())
+
+    @given(
+        ssd_rocksdb_shards=st.sampled_from([1, 4, 8]),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=3, deadline=None)
+    def test_rocksdb_tuning_thread_pool_scaling(
+        self,
+        ssd_rocksdb_shards: int,
+    ) -> None:
+        """
+        Test D96631135: Verify RocksDB initializes correctly with different
+        shard/thread counts. The thread pool scaling (HIGH = max(N, 4),
+        LOW = max(N/4, 1)) is configured at RocksDB level, so we verify
+        the TBE initializes and functions correctly with varied shard counts.
+        """
+        import tempfile
+
+        T = 2
+        D = 64
+        B = 8
+        E = int(1e4)
+        L = 5
+
+        emb = SSDTableBatchedEmbeddingBags(
+            embedding_specs=[(E, D)] * T,
+            feature_table_map=list(range(T)),
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=max(T * B * L, 1),
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            ssd_rocksdb_shards=ssd_rocksdb_shards,
+            l2_cache_size=0,
+        ).cuda()
+
+        # Verify functional correctness across shard counts
+        for _ in range(5):
+            indices = torch.randint(0, E, (B * T * L,)).cuda()
+            offsets = torch.arange(0, B * T + 1, dtype=torch.long).cuda() * L
+            emb.prefetch(indices, offsets)
+            output = emb(indices, offsets)
+            self.assertFalse(torch.isnan(output).any().item())
+            self.assertFalse(torch.isinf(output).any().item())
+
+        torch.cuda.synchronize()
+
+    def test_rocksdb_bloom_filter_functional(self) -> None:
+        """
+        Test D96631135: Verify RocksDB with optimized bloom filter (10 bits/key)
+        functions correctly. The bloom filter optimization reduces memory usage
+        while maintaining point-lookup correctness.
+        """
+        import tempfile
+
+        T = 2
+        D = 64
+        B = 16
+        E = int(1e4)
+        L = 10
+
+        emb = SSDTableBatchedEmbeddingBags(
+            embedding_specs=[(E, D)] * T,
+            feature_table_map=list(range(T)),
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=max(T * B * L, 1),
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            l2_cache_size=0,
+        ).cuda()
+
+        # Run enough iterations to flush memtable to SST (triggers bloom filter)
+        for _ in range(20):
+            indices = torch.randint(0, E, (B * T * L,)).cuda()
+            offsets = torch.arange(0, B * T + 1, dtype=torch.long).cuda() * L
+            emb.prefetch(indices, offsets)
+            output = emb(indices, offsets)
+            self.assertFalse(torch.isnan(output).any().item())
+
+        # Verify same indices produce same results (bloom filter not causing
+        # false negatives — they only cause false positives)
+        fixed_indices = torch.randint(0, E, (B * T * L,)).cuda()
+        fixed_offsets = torch.arange(0, B * T + 1, dtype=torch.long).cuda() * L
+        emb.prefetch(fixed_indices, fixed_offsets)
+        out1 = emb(fixed_indices, fixed_offsets).clone()
+        emb.prefetch(fixed_indices, fixed_offsets)
+        out2 = emb(fixed_indices, fixed_offsets)
+        torch.testing.assert_close(out1, out2)
+
+    def test_double_buffer_eviction_initialization(self) -> None:
+        """
+        Test D96631608: Verify double-buffer eviction buffers are initialized
+        correctly — two buffers, two events, starting index 0.
+        """
+        import tempfile
+
+        T = 2
+        D = 64
+        E = int(1e4)
+
+        emb = SSDTableBatchedEmbeddingBags(
+            embedding_specs=[(E, D)] * T,
+            feature_table_map=list(range(T)),
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=max(T * 10, 1),
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            prefetch_pipeline=True,
+            l2_cache_size=8,
+        ).cuda()
+
+        # Verify double buffers exist with 2 entries each
+        self.assertEqual(
+            len(emb.lxu_cache_evicted_weights_list),
+            2,
+            "Should have 2 eviction weight buffers",
+        )
+        self.assertEqual(
+            len(emb.lxu_cache_evicted_indices_list),
+            2,
+            "Should have 2 eviction index buffers",
+        )
+        self.assertEqual(
+            len(emb.lxu_cache_evicted_slots_list),
+            2,
+            "Should have 2 eviction slot buffers",
+        )
+        self.assertEqual(
+            len(emb.lxu_cache_evicted_count_list),
+            2,
+            "Should have 2 eviction count buffers",
+        )
+
+        # Verify two CUDA events for eviction
+        self.assertEqual(
+            len(emb.ssd_event_cache_evict),
+            2,
+            "Should have 2 eviction events",
+        )
+
+        # Verify initial buffer index is 0
+        self.assertEqual(
+            emb._evict_buf_idx, 0, "Initial eviction buffer index should be 0"
+        )
+
+        # Verify the two buffers are distinct objects (not aliased)
+        self.assertIsNot(
+            emb.lxu_cache_evicted_weights_list[0],
+            emb.lxu_cache_evicted_weights_list[1],
+            "Double buffers should be distinct tensors",
+        )
+
+    @given(
+        use_prefetch_stream=st.booleans(),
+    )
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=2,
+        deadline=None,
+    )
+    def test_double_buffer_eviction_pipeline_correctness(
+        self,
+        use_prefetch_stream: bool,
+    ) -> None:
+        """
+        Test D96631608: Verify that double-buffer eviction maintains correctness
+        during the prefetch pipeline. After multiple iterations, forward/backward
+        results should match reference nn.EmbeddingBag.
+        """
+        self.execute_ssd_cache_pipeline_(
+            T=2,
+            D=4,
+            B=2,
+            log_E=2,
+            L=4,
+            weighted=False,
+            cache_set_scale=0.5,
+            pooling_mode=PoolingMode.SUM,
+            weights_precision=SparseType.FP32,
+            output_dtype=SparseType.FP32,
+            share_table=False,
+            prefetch_pipeline=True,
+            explicit_prefetch=True,
+            prefetch_location=PrefetchLocation.BEFORE_FWD,
+            use_prefetch_stream=use_prefetch_stream,
+            flush_location=None,
+            trigger_bounds_check=False,
+            num_iterations=15,  # More iterations to exercise buffer ping-pong
+        )
+
+    def test_atomicadd_cache_locking_counter(self) -> None:
+        """
+        Test D96676696: Verify lxu_cache_locking_counter correctness with
+        atomicAdd. Run prefetch + forward pipeline and check counter state.
+        """
+        import tempfile
+
+        T = 2
+        D = 64
+        B = 16
+        E = int(1e4)
+        L = 10
+
+        emb = SSDTableBatchedEmbeddingBags(
+            embedding_specs=[(E, D)] * T,
+            feature_table_map=list(range(T)),
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=max(T * B * L, 1),
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            prefetch_pipeline=True,
+            l2_cache_size=8,
+        ).cuda()
+
+        # Run several iterations of prefetch + forward
+        for _ in range(5):
+            indices = torch.randint(0, E, (B * T * L,)).cuda()
+            offsets = torch.arange(0, B * T + 1, dtype=torch.long).cuda() * L
+            emb.prefetch(indices, offsets)
+            emb(indices, offsets)
+        torch.cuda.synchronize()
+
+        # After all operations complete, locking counter should be non-negative
+        # (atomicAdd ensures no underflow from race conditions)
+        counter = emb.lxu_cache_locking_counter.cpu()
+        self.assertTrue(
+            (counter >= 0).all().item(),
+            f"Cache locking counter has negative values: min={counter.min().item()}",
+        )
+
+    def test_cv_fill_queue_pipeline_correctness(self) -> None:
+        """
+        Test D96630505: Verify condition variable fill queue doesn't deadlock
+        or lose notifications. Run pipeline with enough iterations to exercise
+        CV wake/sleep cycles.
+        """
+        import tempfile
+
+        T = 2
+        D = 64
+        B = 16
+        E = int(1e4)
+        L = 10
+
+        emb = SSDTableBatchedEmbeddingBags(
+            embedding_specs=[(E, D)] * T,
+            feature_table_map=list(range(T)),
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=max(T * B * L, 1),
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            prefetch_pipeline=True,
+            l2_cache_size=8,
+        ).cuda()
+
+        # Run many iterations to stress the CV-based fill queue
+        for i in range(20):
+            indices = torch.randint(0, E, (B * T * L,)).cuda()
+            offsets = torch.arange(0, B * T + 1, dtype=torch.long).cuda() * L
+            emb.prefetch(indices, offsets)
+            output = emb(indices, offsets)
+            # Verify output is valid (not NaN/Inf)
+            self.assertFalse(
+                torch.isnan(output).any().item(),
+                f"NaN detected in output at iteration {i}",
+            )
+            self.assertFalse(
+                torch.isinf(output).any().item(),
+                f"Inf detected in output at iteration {i}",
+            )
+
+        torch.cuda.synchronize()
+
+        # Verify clean shutdown — emb destructor should not hang
+        # (the CV-based fill queue must properly notify on stop)
+        del emb
+        torch.cuda.synchronize()


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2483

Two improvements for SSD TBE L2 cache observability and RocksDB tuning:

1. **Auto-size RocksDB block cache** (`ssd_block_cache_size_per_tbe=-1`):
   When the sentinel value -1 is passed, automatically set the block cache
   to 10% of total embedding table size (minimum 16MB). This provides a
   reasonable default without requiring manual tuning per model. The
   existing default (0 = RocksDB builtin default) is unchanged for
   backward compatibility.

2. **Expose L2 cache hit rate**: Add `get_l2_cache_hit_rate()` as a
   non-resetting read of the existing `num_cache_misses_` and
   `num_lookups_` atomic counters. Unlike `get_l2cache_perf()` which
   resets counters on read, this returns a simple percentage suitable for
   ad-hoc monitoring and stats reporting. Wired through:
   - C++ base class (`EmbeddingKVDB`) with relaxed atomic loads
   - TorchScript wrappers (`EmbeddingRocksDBWrapper`, `DramKVEmbeddingCacheWrapper`)
   - Python property (`SSDTableBatchedEmbeddingBags.l2_cache_hit_rate`)
   - Stats reporter integration (`l2_cache.hit_rate_pct`)

Reviewed By: royren622

Differential Revision: D96753686
