### PR TITLE
Fix race conditions: make shared mutable state atomic

### DIFF
--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
@@ -2351,7 +2351,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
   std::vector<int64_t> sub_table_hash_cumsum_;
   std::optional<c10::intrusive_ptr<FeatureEvictConfig>> feature_evict_config_;
   std::unique_ptr<FeatureEvict<weight_type>> feature_evict_;
-  int current_iter_ = 0;
+  std::atomic<int> current_iter_{0};
   const bool is_training_;
 
   // perf stats

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_inference_embedding.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_inference_embedding.h
@@ -887,7 +887,7 @@ class DramKVInferenceEmbedding
   std::vector<int64_t> sub_table_hash_cumsum_;
   std::optional<c10::intrusive_ptr<FeatureEvictConfig>> feature_evict_config_;
   std::unique_ptr<FeatureEvict<weight_type>> feature_evict_;
-  int current_iter_ = 0;
+  std::atomic<int> current_iter_{0};
   bool disable_random_init_ = false;
 
   // perf stats

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/feature_evict.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/feature_evict.h
@@ -1406,7 +1406,7 @@ class TimeThresholdBasedEvict : public FeatureEvict<weight_type> {
   }
 
  private:
-  uint32_t eviction_timestamp_threshold_ = 0;
+  std::atomic<uint32_t> eviction_timestamp_threshold_{0};
 };
 
 template <typename weight_type>


### PR DESCRIPTION
Make current_iter_ in DramKVEmbeddingCache and DramKVInferenceEmbedding, and eviction_timestamp_threshold_ in TimeThresholdBasedEvict, atomic to prevent data races when accessed from multiple threads.