### PR TITLE
IKBO LCE kernel in fbgemm (#5521)

### DIFF
--- a/fbgemm_gpu/experimental/ikbo/README.md
+++ b/fbgemm_gpu/experimental/ikbo/README.md
@@ -1,0 +1,55 @@
+# In-Kernel Broadcast Optimization (IKBO)
+
+High-performance GPU kernels for following operations (at the moment) with In-Kernel Broadcast Optimization
+- Linear Compression Embedding (LCE)
+- Flash Attention
+
+The Deep Dive Blog: (to add)
+
+## Installation
+
+Install `triton` TLX from: https://github.com/facebookexperimental/triton/tree/main
+
+```bash
+git clone -b tlx https://github.com/facebookexperimental/triton.git
+cd triton
+pip install -e . --no-build-isolation
+```
+
+```bash
+# Install the source code
+git clone https://github.com/pytorch/FBGEMM.git
+cd fbgemm/fbgemm_gpu/experimental/ikbo
+pip install -e .
+```
+
+## Quick Start
+
+### PyTorch Reference
+```python
+from ikbo.ops.torch_lce import torch_decomposed_lce
+output = torch_decomposed_lce(W_cand, W_user, E_cand, E_user, cand_to_user_index)
+```
+
+### Triton Kernel
+```python
+from ikbo.ops.triton_ikbo_lce import triton_ikbo_lce
+output = triton_ikbo_lce(W_cand, W_user, E_cand, E_user, cand_to_user_index)
+```
+
+### TLX Kernel
+```python
+from ikbo.ops.tlx_ikbo_lce import tlx_ikbo_lce, create_user_flag
+user_flag = create_user_flag(W_user, E_user)
+output = tlx_ikbo_lce(W_cand, W_user, E_cand, E_user, cand_to_user_index, user_flag)
+```
+
+## Testing
+```bash
+FAST_TUNE=1 python -m pytest tests/ -v
+```
+
+## Benchmarks
+```bash
+python benchmarks/ikbo_lce_bench.py
+```

--- a/fbgemm_gpu/experimental/ikbo/benchmarks/ikbo_lce_bench.py
+++ b/fbgemm_gpu/experimental/ikbo/benchmarks/ikbo_lce_bench.py
@@ -1,0 +1,193 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import random
+from functools import partial
+
+import torch
+import triton
+from ikbo.ops.tlx_ikbo_lce import create_user_flag, tlx_ikbo_lce
+from ikbo.ops.torch_lce import torch_decomposed_lce, torch_lce
+from ikbo.ops.triton_ikbo_lce import triton_ikbo_lce
+from torch._inductor.utils import do_bench_using_profiling
+
+DEVICE = "cuda"
+DTYPE = torch.float16
+PAD_UNIT = 8  # for fp16/bf16
+
+# Representative realistic dimensions.
+# M is non-round because torch.compile fuses multiple LCE modules (with output
+# sizes like 128, 64, 32, ...) into one batched matmul; M is their sum.
+M, N, K_USER, K_CAND = 433, 256, 1178, 866
+DEFAULT_B = 1024
+DEFAULT_CAND_TO_USER_RATIO = 70
+
+PROVIDERS = [
+    "baseline",
+    "opt_1_decomposition",
+    "opt_2_k_dim_alignment",
+    "opt_3_kernel_fusion",
+    "opt_4_tlx",
+]
+PROVIDER_NAMES = [
+    "Baseline",
+    "Opt 1 Decomposition",
+    "Opt 2 K-dim Alignment",
+    "Opt 3 Kernel Fusion",
+    "Opt 4 TLX",
+]
+
+
+def prepare_inputs_by_config(
+    B: int,
+    M: int,
+    N: int,
+    K_USER: int,
+    K_CAND: int,
+    low_num_cands_per_user: int = DEFAULT_CAND_TO_USER_RATIO,
+    high_num_cands_per_user: int = DEFAULT_CAND_TO_USER_RATIO,
+    pad_k: bool = False,
+):
+    def _generate_num_cands_per_user():
+        res = []
+        cum_sum = 0
+        while True:
+            cur = random.randint(low_num_cands_per_user, high_num_cands_per_user)
+            if cum_sum + cur >= B:
+                res.append(B - cum_sum)
+                break
+            cum_sum += cur
+            res.append(cur)
+        return res
+
+    if pad_k:
+        K_USER = ((K_USER + PAD_UNIT - 1) // PAD_UNIT) * PAD_UNIT
+        K_CAND = ((K_CAND + PAD_UNIT - 1) // PAD_UNIT) * PAD_UNIT
+
+    num_cands_per_user_tensor = torch.tensor(_generate_num_cands_per_user())
+    user_batch_size = num_cands_per_user_tensor.size(0)
+    cand_to_user_index = (
+        torch.repeat_interleave(
+            torch.arange(user_batch_size),
+            num_cands_per_user_tensor,
+        )
+        .int()
+        .to(DEVICE)
+    )
+    compression_w_cand = torch.randn(
+        (M, K_CAND), device=DEVICE, dtype=DTYPE
+    ).requires_grad_(False)
+    compression_w_user = torch.randn(
+        (M, K_USER), device=DEVICE, dtype=DTYPE
+    ).requires_grad_(False)
+    embeddings_cand = torch.randn(
+        (B, K_CAND, N), device=DEVICE, dtype=DTYPE
+    ).requires_grad_(False)
+    embeddings_user = torch.randn(
+        (user_batch_size, K_USER, N), device=DEVICE, dtype=DTYPE
+    ).requires_grad_(False)
+
+    # Concatenated inputs for baseline LCE
+    compression_w = torch.cat((compression_w_user, compression_w_cand), dim=1)
+    embeddings_user_broadcast = torch.index_select(
+        embeddings_user, 0, cand_to_user_index
+    )
+    embeddings = torch.cat((embeddings_user_broadcast, embeddings_cand), dim=1)
+
+    return (
+        compression_w_cand,
+        compression_w_user,
+        embeddings_cand,
+        embeddings_user,
+        cand_to_user_index,
+        compression_w,
+        embeddings,
+    )
+
+
+def prepare_default_inputs(pad_k: bool = False):
+    return prepare_inputs_by_config(DEFAULT_B, M, N, K_USER, K_CAND, pad_k=pad_k)
+
+
+def _run_provider(provider, B, num_cands_per_user):
+    torch.manual_seed(0)
+    # Fixed ratio ensures fair comparison across providers
+    kwargs = dict(
+        low_num_cands_per_user=num_cands_per_user,
+        high_num_cands_per_user=num_cands_per_user,
+    )
+
+    if provider == "baseline":
+        *_, compression_w, embeddings = prepare_inputs_by_config(
+            B, M, N, K_USER, K_CAND, **kwargs
+        )
+        fn = partial(torch_lce, compression_w, embeddings)
+    elif provider == "opt_1_decomposition":
+        cw_c, cw_u, e_c, e_u, idx, _, _ = prepare_inputs_by_config(
+            B, M, N, K_USER, K_CAND, **kwargs
+        )
+        fn = partial(torch_decomposed_lce, cw_c, cw_u, e_c, e_u, idx)
+    elif provider == "opt_2_k_dim_alignment":
+        cw_c, cw_u, e_c, e_u, idx, _, _ = prepare_inputs_by_config(
+            B, M, N, K_USER, K_CAND, **kwargs, pad_k=True
+        )
+        fn = partial(torch_decomposed_lce, cw_c, cw_u, e_c, e_u, idx)
+    elif provider == "opt_3_kernel_fusion":
+        cw_c, cw_u, e_c, e_u, idx, _, _ = prepare_inputs_by_config(
+            B, M, N, K_USER, K_CAND, **kwargs, pad_k=True
+        )
+        fn = partial(triton_ikbo_lce, cw_c, cw_u, e_c, e_u, idx)
+    elif provider == "opt_4_tlx":
+        cw_c, cw_u, e_c, e_u, idx, _, _ = prepare_inputs_by_config(
+            B, M, N, K_USER, K_CAND, **kwargs, pad_k=True
+        )
+        user_flag = create_user_flag(cw_u, e_u)
+        fn = partial(tlx_ikbo_lce, cw_c, cw_u, e_c, e_u, idx, user_flag)
+    else:
+        return 100
+
+    return do_bench_using_profiling(fn)
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["B"],
+        x_vals=[b * 512 for b in range(1, 7)],
+        line_arg="provider",
+        line_vals=PROVIDERS,
+        line_names=PROVIDER_NAMES,
+        ylabel="Latency (ms)",
+        plot_name="IKBO LCE - Vary Batch Size",
+        args={},
+    )
+)
+def benchmark_vary_batch(B, provider):
+    return _run_provider(provider, B, DEFAULT_CAND_TO_USER_RATIO)
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["cand_to_user_ratio"],
+        x_vals=[2, 5, 10, 50, 100, 1000],
+        line_arg="provider",
+        line_vals=PROVIDERS,
+        line_names=PROVIDER_NAMES,
+        ylabel="Latency (ms)",
+        plot_name="IKBO LCE - Vary Candidate-to-User Ratio",
+        args={},
+    )
+)
+def benchmark_vary_ratio(cand_to_user_ratio, provider):
+    return _run_provider(provider, DEFAULT_B, cand_to_user_ratio)
+
+
+def main():
+    benchmark_vary_batch.run(show_plots=False, print_data=True)
+    benchmark_vary_ratio.run(show_plots=False, print_data=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/fbgemm_gpu/experimental/ikbo/ikbo/__init__.py
+++ b/fbgemm_gpu/experimental/ikbo/ikbo/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/fbgemm_gpu/experimental/ikbo/ikbo/ops/__init__.py
+++ b/fbgemm_gpu/experimental/ikbo/ikbo/ops/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/fbgemm_gpu/experimental/ikbo/ikbo/ops/tlx_ikbo_lce.py
+++ b/fbgemm_gpu/experimental/ikbo/ikbo/ops/tlx_ikbo_lce.py
@@ -1,0 +1,617 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# TLX warp-specialized persistent IKBO LCE kernel (Hopper H100).
+#
+# Architecture: 1 producer + 2 consumer warp groups per CTA.
+#   - Producer:  issues TMA loads into a circular SMEM buffer.
+#   - Consumers: perform GEMM accumulation via WGMMA, ping-ponging
+#                tiles so one consumer's epilogue overlaps the other's compute.
+#
+# The kernel fuses both matmul stages into a single persistent launch:
+#   Stage 1 (user):      user_res[u] = W_user @ E_user[u]
+#   Stage 2 (candidate): out[b]      = W_cand @ E_cand[b] + user_res[u(b)]
+#
+# Three synchronization mechanisms:
+#   1. Producer-consumer mbarriers gate the circular SMEM buffer.
+#   2. Named barriers alternate two consumer replicas (ping-pong).
+#   3. Per-tile atomic flags signal user-result readiness across CTAs.
+#
+# Tile dispatch: ascending for user phase, descending for candidate phase,
+# balancing per-SM workload across partial waves.
+
+import os
+
+import torch
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# Ping-pong barrier pair: each consumer replica waits on one and signals the other.
+PINGPONG_BARRIER_0 = tl.constexpr(9)
+PINGPONG_BARRIER_1 = tl.constexpr(10)
+# Syncs warp group after single-thread flag polling completes.
+POLL_SYNC_BARRIER = tl.constexpr(12)
+
+# Thread counts for named barrier participation.
+NUM_CONSUMER_THREADS = tl.constexpr(256)  # 2 warp groups × 4 warps × 32 threads/warp
+NUM_WARPGROUP_THREADS = tl.constexpr(128)  # 1 warp group × 4 warps × 32 threads/warp
+
+
+@triton.jit
+def swizzle_tile(
+    tile_id,
+    num_pids_per_batch: tl.constexpr,
+    num_pid_m_per_batch: tl.constexpr,
+    num_pid_n: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    """Map a linear tile_id to (pid_batch, pid_m, pid_n) with grouped ordering for L2 cache reuse."""
+    pid_batch = tile_id // num_pids_per_batch
+    local_tile = tile_id % num_pids_per_batch
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = local_tile // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m_per_batch - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + ((local_tile % num_pid_in_group) % group_size_m)
+    pid_n = (local_tile % num_pid_in_group) // group_size_m
+    return pid_batch, pid_m, pid_n
+
+
+def _block_size_hook(nargs):
+    """Set TMA descriptor block shapes from autotuned tile sizes."""
+    BM = nargs["BM"]
+    BN = nargs["BN"]
+    BK = nargs["BK"]
+    nargs["user_a_desc"].block_shape = [BM, BK]
+    nargs["cand_a_desc"].block_shape = [BM, BK]
+    nargs["user_b_desc"].block_shape = [BK, BN]
+    nargs["cand_b_desc"].block_shape = [BK, BN]
+    nargs["out_desc"].block_shape = [BM, BN // 2]
+
+
+def _tlx_autotune_configs():
+    if os.environ.get("FAST_TUNE"):
+        return [
+            triton.Config(
+                {"BM": 64, "BN": 128, "BK": 64, "NUM_STAGES": 6, "GROUP_SIZE_M": 8},
+                num_stages=1,
+                num_warps=4,
+                pre_hook=_block_size_hook,
+            )
+        ]
+    return [
+        triton.Config(
+            {"BM": bm, "BN": bn, "BK": bk, "NUM_STAGES": ns, "GROUP_SIZE_M": 8},
+            num_stages=1,
+            num_warps=4,
+            pre_hook=_block_size_hook,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128]
+        for bk in [64, 128]
+        for ns in [3, 4, 5, 6]
+    ]
+
+
+@triton.autotune(
+    configs=_tlx_autotune_configs(),
+    key=["M", "N", "K_USER", "K_CAND"],
+)
+@triton.jit
+def tlx_ikbo_lce_kernel(
+    user_a_desc,  # W_user [M, K_user]
+    user_b_desc,  # E_user [num_users * K_user, N]
+    cand_a_desc,  # W_cand [M, K_cand]
+    cand_b_desc,  # E_cand [B * K_cand, N]
+    cand_to_user_ptr,  # [B], int32
+    user_flag_ptr,  # [num_users, M_tiles, N_tiles], int32
+    user_res_ptr,  # [num_users, M, N]
+    out_desc,  # [B * M_padded, N]
+    user_flag_stride_a: tl.constexpr,
+    user_flag_stride_b: tl.constexpr,
+    user_flag_stride_c: tl.constexpr,
+    user_res_stride_a: tl.constexpr,
+    user_res_stride_b: tl.constexpr,
+    user_res_stride_c: tl.constexpr,
+    NUM_USERS,
+    B,
+    NUM_SMS: tl.constexpr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K_USER: tl.constexpr,
+    K_CAND: tl.constexpr,
+    M_PADDED: tl.constexpr,
+    BM: tl.constexpr,
+    BN: tl.constexpr,
+    BK: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    """Warp-specialized persistent IKBO LCE kernel.
+
+    Fuses user GEMM (Stage 1) and candidate GEMM + broadcast (Stage 2) into
+    a single persistent launch with 1 producer + 2 consumer warp groups.
+    """
+    # Allocate SMEM buffers: circular buffer for A/B tiles
+    a = tlx.local_alloc((BM, BK), tlx.dtype_of(cand_a_desc), NUM_STAGES)
+    b = tlx.local_alloc((BK, BN), tlx.dtype_of(cand_b_desc), NUM_STAGES)
+
+    # Producer-consumer mbarriers for the circular buffer
+    mainloop_empty_bar = tlx.alloc_barriers(num_barriers=NUM_STAGES, arrive_count=1)
+    mainloop_full_bar = tlx.alloc_barriers(num_barriers=NUM_STAGES, arrive_count=1)
+
+    with tlx.async_tasks():
+
+        ###########################
+        # Producer
+        ###########################
+        with tlx.async_task("default"):
+            pid = tl.program_id(axis=0)
+            num_pid_m_per_batch = tl.cdiv(M, BM)
+            num_pid_n = tl.cdiv(N, BN)
+            num_pids_per_batch = num_pid_m_per_batch * num_pid_n
+            num_user_pids = NUM_USERS * num_pids_per_batch
+            num_cand_pids = B * num_pids_per_batch
+
+            p = 1
+            buf = 0
+
+            ###########################
+            # Producer: User Phase
+            ###########################
+            # Ascending tile dispatch (start at pid)
+            user_start_pid = pid
+            for tile_id in range(user_start_pid, num_user_pids, NUM_SMS):
+                pid_batch, pid_m, pid_n = swizzle_tile(
+                    tile_id,
+                    num_pids_per_batch,
+                    num_pid_m_per_batch,
+                    num_pid_n,
+                    GROUP_SIZE_M,
+                )
+
+                offset_am = pid_m * BM
+                offset_bn = pid_n * BN
+                offset_k_base = pid_batch * K_USER
+                for offset_k in range(0, K_USER, BK):
+                    empty = tlx.local_view(mainloop_empty_bar, buf)
+                    full = tlx.local_view(mainloop_full_bar, buf)
+                    tlx.barrier_wait(bar=empty, phase=p)
+                    tlx.barrier_expect_bytes(full, BM * BK * 2 + BK * BN * 2)
+                    data_a = tlx.local_view(a, buf)
+                    tlx.async_descriptor_load(
+                        user_a_desc, data_a, [offset_am, offset_k], full
+                    )
+                    data_b = tlx.local_view(b, buf)
+                    tlx.async_descriptor_load(
+                        user_b_desc,
+                        data_b,
+                        [offset_k_base + offset_k, offset_bn],
+                        full,
+                    )
+                    p = p ^ (buf == (NUM_STAGES - 1))
+                    buf = (buf + 1) % NUM_STAGES
+
+            ###########################
+            # Producer: Candidate Phase
+            ###########################
+            # Descending tile dispatch (start at NUM_SMS-1-pid)
+            # to balance per-SM workload across partial waves
+            for tile_id in range(NUM_SMS - 1 - pid, num_cand_pids, NUM_SMS):
+                pid_batch, pid_m, pid_n = swizzle_tile(
+                    tile_id,
+                    num_pids_per_batch,
+                    num_pid_m_per_batch,
+                    num_pid_n,
+                    GROUP_SIZE_M,
+                )
+
+                offset_am = pid_m * BM
+                offset_bn = pid_n * BN
+                offset_k_base = pid_batch * K_CAND
+                for offset_k in range(0, K_CAND, BK):
+                    empty = tlx.local_view(mainloop_empty_bar, buf)
+                    full = tlx.local_view(mainloop_full_bar, buf)
+                    tlx.barrier_wait(bar=empty, phase=p)
+                    tlx.barrier_expect_bytes(full, BM * BK * 2 + BK * BN * 2)
+                    data_a = tlx.local_view(a, buf)
+                    tlx.async_descriptor_load(
+                        cand_a_desc, data_a, [offset_am, offset_k], full
+                    )
+                    data_b = tlx.local_view(b, buf)
+                    tlx.async_descriptor_load(
+                        cand_b_desc,
+                        data_b,
+                        [offset_k_base + offset_k, offset_bn],
+                        full,
+                    )
+
+                    p = p ^ (buf == (NUM_STAGES - 1))
+                    buf = (buf + 1) % NUM_STAGES
+
+        ###########################
+        # Consumer
+        ###########################
+        # Two replicas ping-pong tiles: one's epilogue overlaps the other's GEMM.
+        with tlx.async_task(num_warps=4, replicate=2, registers=232):
+            pid = tl.program_id(axis=0)
+            cid: tl.constexpr = tlx.async_task_replica_id()
+            num_pid_m_per_batch = tl.cdiv(M, BM)
+            num_pid_n = tl.cdiv(N, BN)
+            num_pids_per_batch = num_pid_m_per_batch * num_pid_n
+            num_user_pids = NUM_USERS * num_pids_per_batch
+            num_cand_pids = B * num_pids_per_batch
+            k_user_tiles = tl.cdiv(K_USER, BK)
+            k_cand_tiles = tl.cdiv(K_CAND, BK)
+
+            ###########################
+            # Consumer: User Phase
+            ###########################
+            # Ping-pong via named barriers.
+            # Consumer 0 enters first (consumer 1 pre-seeds its barrier).
+            if cid == 1:
+                tlx.named_barrier_arrive(PINGPONG_BARRIER_0, NUM_CONSUMER_THREADS)
+            total_k_offset = cid * k_user_tiles
+            user_start_pid = pid + cid * NUM_SMS
+            for tile_id in range(user_start_pid, num_user_pids, NUM_SMS * 2):
+                buf = total_k_offset % NUM_STAGES
+                p = (total_k_offset // NUM_STAGES) % 2
+                total_k_offset += 2 * k_user_tiles
+
+                last_buf = buf
+
+                pid_batch, pid_m, pid_n = swizzle_tile(
+                    tile_id,
+                    num_pids_per_batch,
+                    num_pid_m_per_batch,
+                    num_pid_n,
+                    GROUP_SIZE_M,
+                )
+                acc = tl.zeros([BM, BN], dtype=tl.float32)
+
+                # Wait for the other replica's GEMM to finish
+                if cid == 0:
+                    tlx.named_barrier_wait(PINGPONG_BARRIER_0, NUM_CONSUMER_THREADS)
+                else:
+                    tlx.named_barrier_wait(PINGPONG_BARRIER_1, NUM_CONSUMER_THREADS)
+
+                # K-loop round 0
+                full = tlx.local_view(mainloop_full_bar, buf)
+                tlx.barrier_wait(bar=full, phase=p)
+                data_a = tlx.local_view(a, buf)
+                data_b = tlx.local_view(b, buf)
+                acc = tlx.async_dot(data_a, data_b, acc)
+                p = p ^ (buf == (NUM_STAGES - 1))
+                buf = (buf + 1) % NUM_STAGES
+                # K-loop body
+                for _ in range(1, k_user_tiles):
+                    full = tlx.local_view(mainloop_full_bar, buf)
+                    tlx.barrier_wait(bar=full, phase=p)
+                    data_a = tlx.local_view(a, buf)
+                    data_b = tlx.local_view(b, buf)
+                    acc = tlx.async_dot(data_a, data_b, acc)
+                    acc = tlx.async_dot_wait(1, acc)
+                    empty = tlx.local_view(mainloop_empty_bar, last_buf)
+                    tlx.barrier_arrive(empty)
+
+                    last_buf = buf
+                    p = p ^ (buf == (NUM_STAGES - 1))
+                    buf = (buf + 1) % NUM_STAGES
+
+                # Signal the other replica to start its next tile
+                if cid == 0:
+                    tlx.named_barrier_arrive(PINGPONG_BARRIER_1, NUM_CONSUMER_THREADS)
+                else:
+                    tlx.named_barrier_arrive(PINGPONG_BARRIER_0, NUM_CONSUMER_THREADS)
+
+                acc = tlx.async_dot_wait(0, acc)
+                empty = tlx.local_view(mainloop_empty_bar, last_buf)
+                tlx.barrier_arrive(empty)
+                acc = acc.to(tl.float16)
+
+                # Store user result to global memory
+                offs_m = pid_m * BM + tl.arange(0, BM)
+                offs_n = pid_n * BN + tl.arange(0, BN)
+                idx_m = offs_m[:, None]
+                idx_n = offs_n[None, :]
+                mask = (idx_m < M) & (idx_n < N)
+                user_res_ptrs = (
+                    user_res_ptr
+                    + pid_batch * user_res_stride_a
+                    + idx_m * user_res_stride_b
+                    + idx_n * user_res_stride_c
+                )
+                tl.store(user_res_ptrs, acc, mask)
+
+                # Signal tile readiness for cross-CTA candidate consumers
+                uf_off = (
+                    pid_batch * user_flag_stride_a
+                    + pid_m * user_flag_stride_b
+                    + pid_n * user_flag_stride_c
+                )
+                tl.atomic_add(user_flag_ptr + uf_off, 1, sem="release", scope="gpu")
+
+            ###########################
+            # Consumer: Candidate Phase
+            ###########################
+            # Ping-pong flows naturally from user phase. Whichever replica
+            # finished last in the user phase arrives second, so the OTHER
+            # replica enters the candidate phase first.  Swap tile/buffer
+            # assignment so the first-to-enter replica gets producer tile 0.
+            user_tiles_for_sm = (num_user_pids + NUM_SMS - 1 - pid) // NUM_SMS
+            swap = user_tiles_for_sm % 2
+
+            if cid == 0:
+                cand_cid_offset = swap * k_cand_tiles
+                cand_start_pid = NUM_SMS - 1 - pid + swap * NUM_SMS
+            else:
+                cand_cid_offset = (1 - swap) * k_cand_tiles
+                cand_start_pid = NUM_SMS - 1 - pid + (1 - swap) * NUM_SMS
+
+            total_k_offset = user_tiles_for_sm * k_user_tiles + cand_cid_offset
+            k_cand_stride = 2 * k_cand_tiles
+            for tile_id in range(cand_start_pid, num_cand_pids, NUM_SMS * 2):
+                buf = total_k_offset % NUM_STAGES
+                p = (total_k_offset // NUM_STAGES) % 2
+                total_k_offset += k_cand_stride
+
+                last_buf = buf
+
+                pid_batch, pid_m, pid_n = swizzle_tile(
+                    tile_id,
+                    num_pids_per_batch,
+                    num_pid_m_per_batch,
+                    num_pid_n,
+                    GROUP_SIZE_M,
+                )
+
+                acc = tl.zeros([BM, BN], dtype=tl.float32)
+
+                # Wait for the other replica's GEMM to finish
+                if cid == 0:
+                    tlx.named_barrier_wait(PINGPONG_BARRIER_0, NUM_CONSUMER_THREADS)
+                else:
+                    tlx.named_barrier_wait(PINGPONG_BARRIER_1, NUM_CONSUMER_THREADS)
+                # K-loop round 0
+                full = tlx.local_view(mainloop_full_bar, buf)
+                tlx.barrier_wait(bar=full, phase=p)
+                data_a = tlx.local_view(a, buf)
+                data_b = tlx.local_view(b, buf)
+                acc = tlx.async_dot(data_a, data_b, acc)
+                p = p ^ (buf == (NUM_STAGES - 1))
+                buf = (buf + 1) % NUM_STAGES
+                # K-loop body
+                for _ in range(1, k_cand_tiles):
+                    full = tlx.local_view(mainloop_full_bar, buf)
+                    tlx.barrier_wait(bar=full, phase=p)
+                    data_a = tlx.local_view(a, buf)
+                    data_b = tlx.local_view(b, buf)
+                    acc = tlx.async_dot(data_a, data_b, acc)
+                    acc = tlx.async_dot_wait(1, acc)
+                    empty = tlx.local_view(mainloop_empty_bar, last_buf)
+                    tlx.barrier_arrive(empty)
+
+                    last_buf = buf
+                    p = p ^ (buf == (NUM_STAGES - 1))
+                    buf = (buf + 1) % NUM_STAGES
+
+                # Signal the other replica to start its next tile
+                if cid == 0:
+                    tlx.named_barrier_arrive(PINGPONG_BARRIER_1, NUM_CONSUMER_THREADS)
+                else:
+                    tlx.named_barrier_arrive(PINGPONG_BARRIER_0, NUM_CONSUMER_THREADS)
+
+                acc = tlx.async_dot_wait(0, acc)
+                empty = tlx.local_view(mainloop_empty_bar, last_buf)
+                tlx.barrier_arrive(empty)
+
+                # Cross-CTA sync: wait for user result readiness.
+                # One thread per warp group polls (relaxed spin -> acquire),
+                # then all threads rendezvous at POLL_SYNC_BARRIER.
+                user_pid_batch = tl.load(
+                    cand_to_user_ptr + pid_batch, eviction_policy="evict_last"
+                )
+                if tlx.thread_id(axis=0) % NUM_WARPGROUP_THREADS == 0:
+                    user_flag_pid_ptr = (
+                        user_flag_ptr
+                        + user_pid_batch * user_flag_stride_a
+                        + pid_m * user_flag_stride_b
+                        + pid_n * user_flag_stride_c
+                    )
+                    # Initial relaxed load (no ordering guarantees)
+                    ready = tl.inline_asm_elementwise(
+                        "ld.relaxed.gpu.global.b32 $0, [$1];",
+                        "=r,l",
+                        [user_flag_pid_ptr],
+                        dtype=tl.int32,
+                        is_pure=False,
+                        pack=1,
+                    )
+                    # Spin with nanosleep until flag is set
+                    while ready == 0:
+                        ready = tl.inline_asm_elementwise(
+                            "nanosleep.u32 50; ld.relaxed.gpu.global.b32 $0, [$1];",
+                            "=r,l",
+                            [user_flag_pid_ptr],
+                            dtype=tl.int32,
+                            is_pure=False,
+                            pack=1,
+                        )
+                    # Acquire load to establish happens-before
+                    tl.inline_asm_elementwise(
+                        "ld.acquire.gpu.global.b32 $0, [$1];",
+                        "=r,l",
+                        [user_flag_pid_ptr],
+                        dtype=tl.int32,
+                        is_pure=False,
+                        pack=1,
+                    )
+                tlx.named_barrier_wait(POLL_SYNC_BARRIER, NUM_WARPGROUP_THREADS)
+
+                # Epilogue: load user result and combine with candidate GEMM output
+                offs_m = (pid_m * BM + tl.arange(0, BM)) % M
+                offs_n = (pid_n * BN + tl.arange(0, BN)) % N
+                user_res_ptrs = (
+                    user_res_ptr
+                    + user_pid_batch * user_res_stride_a
+                    + offs_m[:, None] * user_res_stride_b
+                    + offs_n[None, :] * user_res_stride_c
+                )
+                # Boundary is handled by TMA store; skip mask for speed
+                user_res_rmem = tl.load(user_res_ptrs, eviction_policy="evict_last")
+                acc = acc.to(tl.float16) + user_res_rmem
+
+                # TMA store: split into two BN/2 subtiles to spare SMEM to allow more circular buffers
+                offset_cm = pid_m * BM + pid_batch * M_PADDED
+                offset_cn = pid_n * BN
+                acc = tl.reshape(acc, (BM, 2, BN // 2))
+                acc = tl.permute(acc, (0, 2, 1))
+                acc0, acc1 = tl.split(acc)
+                out_desc.store(
+                    [offset_cm, offset_cn],
+                    acc0.to(tlx.dtype_of(out_desc)),
+                )
+                out_desc.store(
+                    [offset_cm, offset_cn + BN // 2],
+                    acc1.to(tlx.dtype_of(out_desc)),
+                )
+
+
+def create_user_flag(compression_w_user, embeddings_user):
+    """Allocate per-tile readiness flags for cross-CTA synchronization.
+
+    Returns a zero-initialized [num_users, M_tiles, N_tiles] int32 tensor.
+    User-phase consumers atomically increment flags after storing each tile;
+    candidate-phase consumers spin on them before the epilogue add.
+    """
+    configs = tlx_ikbo_lce_kernel.configs
+    MIN_BM = min(c.kwargs["BM"] for c in configs)
+    MIN_BN = min(c.kwargs["BN"] for c in configs)
+    num_users = embeddings_user.shape[0]
+    m_tiles = triton.cdiv(compression_w_user.shape[0], MIN_BM)
+    n_tiles = triton.cdiv(embeddings_user.shape[2], MIN_BN)
+    return torch.zeros(
+        (num_users, m_tiles, n_tiles),
+        device=compression_w_user.device,
+        dtype=torch.int32,
+    ).requires_grad_(False)
+
+
+def tlx_ikbo_lce(
+    compression_w_cand: torch.Tensor,
+    compression_w_user: torch.Tensor,
+    embeddings_cand: torch.Tensor,
+    embeddings_user: torch.Tensor,
+    cand_to_user_index: torch.Tensor,
+    user_flag: torch.Tensor,
+) -> torch.Tensor:
+    """Warp-specialized persistent IKBO LCE.
+
+    Fuses both matmul stages into a single persistent kernel:
+      Stage 1: user_res[u] = W_user @ E_user[u]
+      Stage 2: out[b]      = W_cand @ E_cand[b] + user_res[u(b)]
+
+    Uses TMA for global-to-SMEM transfers, WGMMA for tensor core compute,
+    and cross-CTA atomic flags for user-result readiness signaling.
+
+    Args:
+        compression_w_cand: Candidate compression weights [M, K_cand].
+        compression_w_user: User compression weights [M, K_user].
+        embeddings_cand: Candidate embeddings [B, K_cand, N].
+        embeddings_user: User embeddings [num_users, K_user, N].
+        cand_to_user_index: Maps candidate index to user index [B], int32.
+        user_flag: Per-tile readiness flags from create_user_flag().
+    """
+    B = embeddings_cand.shape[0]
+    M = compression_w_cand.shape[0]
+    K_USER = compression_w_user.shape[1]
+    K_CAND = compression_w_cand.shape[1]
+    N = embeddings_cand.shape[2]
+    NUM_USERS = embeddings_user.shape[0]
+
+    user_res = torch.empty(
+        (NUM_USERS, M, N), device=embeddings_cand.device, dtype=embeddings_cand.dtype
+    )
+    user_flag.zero_()
+
+    MAX_BM = max(c.kwargs["BM"] for c in tlx_ikbo_lce_kernel.configs)
+    M_padded = triton.cdiv(M, MAX_BM) * MAX_BM
+    out = torch.empty(
+        (B, M_padded, N), dtype=torch.float16, device=embeddings_cand.device
+    )
+    NUM_SMS = torch.cuda.get_device_properties(
+        embeddings_cand.device
+    ).multi_processor_count
+
+    # TMA descriptors for user-side tensors
+    compression_w_user_desc = TensorDescriptor(
+        compression_w_user,
+        shape=[M, K_USER],
+        strides=[K_USER, 1],
+        block_shape=[1, 1],
+    )
+    embeddings_user_desc = TensorDescriptor(
+        embeddings_user,
+        shape=[NUM_USERS * K_USER, N],
+        strides=[N, 1],
+        block_shape=[1, 1],
+    )
+
+    # TMA descriptors for candidate-side tensors
+    compression_w_cand_desc = TensorDescriptor(
+        compression_w_cand,
+        shape=[M, K_CAND],
+        strides=[K_CAND, 1],
+        block_shape=[1, 1],
+    )
+    embeddings_cand_desc = TensorDescriptor(
+        embeddings_cand,
+        shape=[B * K_CAND, N],
+        strides=[N, 1],
+        block_shape=[1, 1],
+    )
+
+    # TMA descriptor for output
+    out_desc = TensorDescriptor(
+        out,
+        shape=[B * M_padded, N],
+        strides=[N, 1],
+        block_shape=[1, 1],
+    )
+
+    def grid(META):
+        num_m_blocks = triton.cdiv(M, META["BM"])
+        num_n_blocks = triton.cdiv(N, META["BN"])
+        total_blocks = B * num_m_blocks * num_n_blocks
+        return (min(NUM_SMS, total_blocks),)
+
+    tlx_ikbo_lce_kernel[grid](
+        compression_w_user_desc,
+        embeddings_user_desc,
+        compression_w_cand_desc,
+        embeddings_cand_desc,
+        cand_to_user_index,
+        user_flag,
+        user_res,
+        out_desc,
+        user_flag.stride(0),
+        user_flag.stride(1),
+        user_flag.stride(2),
+        user_res.stride(0),
+        user_res.stride(1),
+        user_res.stride(2),
+        NUM_USERS,
+        B,
+        NUM_SMS,
+        M,
+        N,
+        K_USER,
+        K_CAND,
+        M_padded,
+    )
+    return out[:, :M, :]

--- a/fbgemm_gpu/experimental/ikbo/ikbo/ops/torch_lce.py
+++ b/fbgemm_gpu/experimental/ikbo/ikbo/ops/torch_lce.py
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# PyTorch reference implementations for Linear Compression Embedding (LCE).
+#
+# Standard LCE: output[b] = W @ E[b]
+# Decomposed:   output[b] = W_cand @ E_cand[b] + W_user @ E_user[u(b)]
+#
+# The decomposition exploits the many-to-one mapping u(b) from candidates
+# to users: W_user @ E_user is computed once per unique user and broadcast,
+# reducing redundant work proportional to the candidate-to-user ratio.
+
+import torch
+
+
+def torch_lce(compression_w: torch.Tensor, embeddings: torch.Tensor) -> torch.Tensor:
+    """Baseline LCE: output[b] = W @ E[b].
+
+    Args:
+        compression_w: compression weights [M, K_user + K_cand].
+        embeddings: All embeddings [B, K_user + K_cand, N],
+            with user embeddings pre-broadcast to match each candidate.
+    """
+    return compression_w @ embeddings
+
+
+def torch_decomposed_lce(
+    compression_w_cand: torch.Tensor,
+    compression_w_user: torch.Tensor,
+    embeddings_cand: torch.Tensor,
+    embeddings_user: torch.Tensor,
+    cand_to_user_index: torch.Tensor,
+) -> torch.Tensor:
+    """Decomposed LCE: output[b] = W_cand @ E_cand[b] + W_user @ E_user[u(b)].
+
+    Avoids redundant computation by factoring the user contribution:
+    W_user @ E_user is computed once per unique user (num_users < B),
+    then broadcast to each user's candidates via cand_to_user_index.
+
+    Args:
+        compression_w_cand: Candidate compression weights [M, K_cand].
+        compression_w_user: User compression weights [M, K_user].
+        embeddings_cand: Candidate embeddings [B, K_cand, N].
+        embeddings_user: User embeddings [num_users, K_user, N].
+        cand_to_user_index: Maps candidate index to user index [B], int32.
+    """
+    cand_res = compression_w_cand @ embeddings_cand
+    user_res = compression_w_user @ embeddings_user
+    return cand_res + torch.index_select(user_res, dim=0, index=cand_to_user_index)

--- a/fbgemm_gpu/experimental/ikbo/ikbo/ops/triton_ikbo_lce.py
+++ b/fbgemm_gpu/experimental/ikbo/ikbo/ops/triton_ikbo_lce.py
@@ -1,0 +1,179 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Triton fused IKBO (In-Kernel Broadcast Optimization) LCE kernel.
+
+import os
+
+import torch
+import triton
+import triton.language as tl
+
+from .tlx_ikbo_lce import swizzle_tile
+
+
+def _triton_autotune_configs():
+    if os.environ.get("FAST_TUNE"):
+        return [
+            triton.Config(
+                {"BM": 128, "BN": 128, "BK": 64, "GROUP_SIZE_M": 8},
+                num_stages=3,
+                num_warps=4,
+            )
+        ]
+    return [
+        triton.Config(
+            {"BM": bm, "BN": bn, "BK": bk, "GROUP_SIZE_M": 8},
+            num_stages=ns,
+            num_warps=nw,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128]
+        for bk in [64, 128]
+        for ns in [3, 4, 5, 6]
+        for nw in [4, 8]
+    ]
+
+
+@triton.autotune(
+    configs=_triton_autotune_configs(),
+    key=["M", "N", "K"],
+)
+@triton.jit
+def triton_ikbo_lce_kernel(
+    a_ptr,  # [M, K]
+    b_ptr,  # [B, K, N]
+    cand_to_user_index_ptr,  # [B]
+    user_res_ptr,  # [num_users, M, N]
+    out_ptr,  # [B, M, N]
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    a_stride_a: tl.constexpr,
+    a_stride_b: tl.constexpr,
+    b_stride_a: tl.constexpr,
+    b_stride_b: tl.constexpr,
+    b_stride_c: tl.constexpr,
+    out_stride_a: tl.constexpr,
+    out_stride_b: tl.constexpr,
+    out_stride_c: tl.constexpr,
+    BM: tl.constexpr,
+    BN: tl.constexpr,
+    BK: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    """Fused IKBO LCE kernel.
+
+    Computes the candidate GEMM and adds pre-computed user results:
+        out[b] = W_cand @ E_cand[b] + user_res[u(b)]
+
+    Grid: one program per (batch, M-tile, N-tile) with grouped ordering
+    for L2 cache locality.
+    """
+    pid = tl.program_id(0)
+    num_pid_m = tl.cdiv(M, BM)
+    num_pid_n = tl.cdiv(N, BN)
+    num_pids_per_batch = num_pid_m * num_pid_n
+
+    pid_batch, pid_m, pid_n = swizzle_tile(
+        pid, num_pids_per_batch, num_pid_m, num_pid_n, GROUP_SIZE_M
+    )
+
+    offs_m = pid_m * BM + tl.arange(0, BM)
+    offs_n = pid_n * BN + tl.arange(0, BN)
+
+    ram = offs_m % M
+    rbn = offs_n % N
+    rk = tl.arange(0, BK)
+
+    a_ptrs = a_ptr + (ram[:, None] * a_stride_a + rk[None, :] * a_stride_b)
+    b_ptrs = (
+        b_ptr
+        + pid_batch * b_stride_a
+        + rk[:, None] * b_stride_b
+        + rbn[None, :] * b_stride_c
+    )
+
+    # Candidate GEMM: W_cand[BM, BK] @ E_cand[BK, BN] -> acc[BM, BN]
+    acc = tl.zeros((BM, BN), dtype=tl.float32)
+    for k in range(K, 0, -BK):
+        a = tl.load(a_ptrs, mask=rk[None, :] < k, other=0.0)  # [BM, BK]
+        b = tl.load(b_ptrs, mask=rk[:, None] < k, other=0.0)  # [BK, BN]
+
+        acc += tl.dot(a, b)
+        a_ptrs += BK * a_stride_b
+        b_ptrs += BK * b_stride_b
+
+    # In-batch broadcast: look up pre-computed user_res[u(b)] and add
+    user_idx = tl.load(cand_to_user_index_ptr + pid_batch, eviction_policy="evict_last")
+    idx_m = offs_m[:, None]
+    idx_n = offs_n[None, :]
+    mask = (idx_m < M) & (idx_n < N)
+    in_batch_offset = out_stride_c * idx_n + out_stride_b * idx_m
+    user_res_val = tl.load(
+        user_res_ptr + (in_batch_offset + out_stride_a * user_idx),
+        mask,
+        eviction_policy="evict_last",
+    )  # [BM, BN]
+
+    # Store fused result
+    output_val = acc.to(a_ptr.dtype.element_ty) + user_res_val
+    out_ptrs = out_ptr + in_batch_offset + out_stride_a * pid_batch
+    tl.store(out_ptrs, output_val, mask)
+
+
+def triton_ikbo_lce(
+    compression_w_cand: torch.Tensor,
+    compression_w_user: torch.Tensor,
+    embeddings_cand: torch.Tensor,
+    embeddings_user: torch.Tensor,
+    cand_to_user_index: torch.Tensor,
+) -> torch.Tensor:
+    """Fused IKBO LCE: candidate GEMM + in-batch user broadcast in one kernel.
+
+    Two-phase computation:
+      1. User: user_res = W_user @ E_user           [num_users, M, N]
+      2. Final: out[b] = W_cand @ E_cand[b] + user_res[u(b)]   [B, M, N]
+
+    The kernel reads user_res via cand_to_user_index for in-batch broadcast,
+    avoiding the memory cost of materializing the full broadcast tensor.
+
+    Args:
+        compression_w_cand: Candidate compression weights [M, K_cand].
+        compression_w_user: User compression weights [M, K_user].
+        embeddings_cand: Candidate embeddings [B, K_cand, N].
+        embeddings_user: User embeddings [num_users, K_user, N].
+        cand_to_user_index: Maps candidate index to user index [B], int32.
+    """
+    B, K, N = embeddings_cand.shape
+    M = compression_w_cand.size(0)
+    user_res = compression_w_user @ embeddings_user  # [num_users, M, N]
+    out = torch.empty(
+        (B, M, N), device=embeddings_cand.device, dtype=embeddings_cand.dtype
+    )
+
+    grid = lambda META: (B * triton.cdiv(M, META["BM"]) * triton.cdiv(N, META["BN"]),)  # noqa: E731
+
+    triton_ikbo_lce_kernel[grid](
+        compression_w_cand,
+        embeddings_cand,
+        cand_to_user_index,
+        user_res,
+        out,
+        M,
+        N,
+        K,
+        compression_w_cand.stride(0),
+        compression_w_cand.stride(1),
+        embeddings_cand.stride(0),
+        embeddings_cand.stride(1),
+        embeddings_cand.stride(2),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+    )
+
+    return out

--- a/fbgemm_gpu/experimental/ikbo/setup.py
+++ b/fbgemm_gpu/experimental/ikbo/setup.py
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from setuptools import find_packages, setup
+
+setup(
+    name="ikbo",
+    version="0.1.0",
+    packages=find_packages(include=["ikbo"]),
+)

--- a/fbgemm_gpu/experimental/ikbo/tests/ikbo_lce_test.py
+++ b/fbgemm_gpu/experimental/ikbo/tests/ikbo_lce_test.py
@@ -1,0 +1,123 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Accuracy testing philosophy:
+#
+# fp16 matmul implementations (cublass/cutlass, Triton, TLX WGMMA) all accumulate
+# K products in fp32 but with different tiling and reduction orders. This
+# means two correct fp16 kernels can produce results that differ at the
+# last few bits of fp16 precision — comparing them directly with tight fp16
+# tolerances produces false failures that are purely accumulation-order
+# artifacts, not kernel bugs.
+#
+# Instead we measure error against a fp32 ground truth (same inputs promoted
+# to fp32 before matmul). cuBLAS fp16's error vs fp32 establishes the
+# baseline — any correct fp16 kernel should have error in the same ballpark.
+# We assert the kernel's error is within a small multiplier of this baseline.
+
+import sys
+
+import pytest
+import torch
+from ikbo.ops.tlx_ikbo_lce import create_user_flag, tlx_ikbo_lce
+from ikbo.ops.torch_lce import torch_decomposed_lce
+from ikbo.ops.triton_ikbo_lce import triton_ikbo_lce
+
+DEVICE = "cuda"
+DTYPE = torch.float16
+PAD_UNIT = 8
+
+# Allow kernel error up to a certain range of fp16 baseline error.
+# Small absolute floor handles cases where cuBLAS is near-exact.
+ERROR_MULTIPLIER = 1.0
+ERROR_FLOOR = 1e-4
+
+
+def _prepare_inputs(B, M, N, K_USER, K_CAND, cand_to_user_ratio):
+    """Create padded test inputs with a fixed candidate-to-user ratio."""
+    k_user = ((K_USER + PAD_UNIT - 1) // PAD_UNIT) * PAD_UNIT
+    k_cand = ((K_CAND + PAD_UNIT - 1) // PAD_UNIT) * PAD_UNIT
+
+    num_users = (B + cand_to_user_ratio - 1) // cand_to_user_ratio
+    cand_to_user_index = (torch.arange(B, device=DEVICE) // cand_to_user_ratio).int()
+
+    cw_cand = torch.randn((M, k_cand), device=DEVICE, dtype=DTYPE)
+    cw_user = torch.randn((M, k_user), device=DEVICE, dtype=DTYPE)
+    e_cand = torch.randn((B, k_cand, N), device=DEVICE, dtype=DTYPE)
+    e_user = torch.randn((num_users, k_user, N), device=DEVICE, dtype=DTYPE)
+
+    return cw_cand, cw_user, e_cand, e_user, cand_to_user_index
+
+
+def _check_vs_fp32(name, out, ref_fp16, ref_fp32):
+    """Assert kernel error vs fp32 is comparable to cuBLAS fp16 error vs fp32.
+
+    Measures both cuBLAS fp16 and the kernel against the fp32 ground truth,
+    then asserts the kernel's max error does not significantly exceed the
+    cuBLAS baseline. This avoids false failures from accumulation-order
+    differences between two correct fp16 implementations.
+    """
+    baseline_err = (ref_fp16.float() - ref_fp32).abs().max().item()
+    kernel_err = (out.float() - ref_fp32).abs().max().item()
+    threshold = max(ERROR_MULTIPLIER * baseline_err, ERROR_FLOOR)
+    ratio = kernel_err / baseline_err if baseline_err > 0 else float("inf")
+
+    assert kernel_err <= threshold, (
+        f"{name} error exceeds {ERROR_MULTIPLIER}x cuBLAS fp16 baseline: "
+        f"kernel={kernel_err:.4e}, baseline={baseline_err:.4e}, ratio={ratio:.2f}x"
+    )
+
+
+@pytest.fixture(autouse=True)
+def deterministic_seed():
+    """Ensure reproducibility for every test."""
+    torch.manual_seed(0)
+
+
+@pytest.mark.parametrize("B", [512, 1024])
+@pytest.mark.parametrize("M", [128, 433])
+@pytest.mark.parametrize("N", [256])
+@pytest.mark.parametrize("K_USER", [1024, 1025])
+@pytest.mark.parametrize("K_CAND", [1024, 1023])
+@pytest.mark.parametrize("cand_to_user_ratio", [10, 70])
+def test_triton_ikbo_lce(B, M, N, K_USER, K_CAND, cand_to_user_ratio):
+    cw_c, cw_u, e_c, e_u, idx = _prepare_inputs(
+        B, M, N, K_USER, K_CAND, cand_to_user_ratio
+    )
+
+    ref_fp32 = torch_decomposed_lce(
+        cw_c.float(), cw_u.float(), e_c.float(), e_u.float(), idx
+    )
+    ref_fp16 = torch_decomposed_lce(cw_c, cw_u, e_c, e_u, idx)
+    out = triton_ikbo_lce(cw_c, cw_u, e_c, e_u, idx)
+
+    _check_vs_fp32("triton", out, ref_fp16, ref_fp32)
+
+
+@pytest.mark.parametrize("B", [512, 1024])
+@pytest.mark.parametrize("M", [128, 433])
+@pytest.mark.parametrize("N", [256])
+@pytest.mark.parametrize("K_USER", [1024, 1184])
+@pytest.mark.parametrize("K_CAND", [1024, 872])
+@pytest.mark.parametrize("cand_to_user_ratio", [100, 1000])
+def test_tlx_ikbo_lce(B, M, N, K_USER, K_CAND, cand_to_user_ratio):
+    cw_c, cw_u, e_c, e_u, idx = _prepare_inputs(
+        B, M, N, K_USER, K_CAND, cand_to_user_ratio
+    )
+
+    ref_fp32 = torch_decomposed_lce(
+        cw_c.float(), cw_u.float(), e_c.float(), e_u.float(), idx
+    )
+    ref_fp16 = torch_decomposed_lce(cw_c, cw_u, e_c, e_u, idx)
+
+    user_flag = create_user_flag(cw_u, e_u)
+    out = tlx_ikbo_lce(cw_c, cw_u, e_c, e_u, idx, user_flag)
+
+    _check_vs_fp32("tlx", out, ref_fp16, ref_fp32)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/fbgemm_gpu/experimental/ikbo/utility/ikbo_lce_analysis.py
+++ b/fbgemm_gpu/experimental/ikbo/utility/ikbo_lce_analysis.py
@@ -1,0 +1,239 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# FLOPs and memory traffic analysis for IKBO LCE kernel variants.
+#
+# Optimization progression:
+#   Baseline:        W @ E, single batched matmul with pre-broadcast user embeddings
+#   Decomposition:   W_cand @ E_cand + W_user @ E_user[u(b)], avoids redundant user compute
+#   K-dim alignment: Same as decomposition but K padded to tile boundary
+#   Kernel fusion:   Triton kernel fuses cand matmul + user broadcast add (user matmul still cuBLAS)
+#   TLX:             Single persistent kernel fuses both matmuls + broadcast add via warp specialization
+
+import torch
+
+DEVICE = "cuda"
+DTYPE = torch.float16
+
+# Representative realistic dimensions.
+B, M, N, K_USER, K_CAND = 1024, 433, 256, 1178, 866
+CAND_TO_USER_RATIO = 70
+
+
+def _prepare_default_inputs():
+    """Create default test inputs with fixed candidate-to-user ratio."""
+    num_users = (B + CAND_TO_USER_RATIO - 1) // CAND_TO_USER_RATIO
+    cand_to_user_index = (torch.arange(B, device=DEVICE) // CAND_TO_USER_RATIO).int()
+
+    cw_cand = torch.randn((M, K_CAND), device=DEVICE, dtype=DTYPE)
+    cw_user = torch.randn((M, K_USER), device=DEVICE, dtype=DTYPE)
+    e_cand = torch.randn((B, K_CAND, N), device=DEVICE, dtype=DTYPE)
+    e_user = torch.randn((num_users, K_USER, N), device=DEVICE, dtype=DTYPE)
+
+    cw = torch.cat((cw_user, cw_cand), dim=1)
+    e = torch.cat((torch.index_select(e_user, 0, cand_to_user_index), e_cand), dim=1)
+
+    return cw_cand, cw_user, e_cand, e_user, cand_to_user_index, cw, e
+
+
+# ============================================================
+# FLOPs utilities (unit: GFLOPS, rounded to 0.01)
+# ============================================================
+# All variants perform the same arithmetic: two matmuls + one element-wise add.
+# FLOPs are identical across variants; only memory access patterns differ.
+
+
+def get_lce_flops(compression_w, embeddings):
+    """Baseline: W[M,K] @ E[B,K,N] -> 2*B*M*K*N FLOPs."""
+    M, K = compression_w.shape
+    B, K2, N = embeddings.shape
+    assert K == K2
+    return round(2 * B * M * K * N / 1e9, 2)
+
+
+def get_decomposed_lce_flops(
+    compression_w_cand, compression_w_user, embeddings_cand, embeddings_user
+):
+    """Decomposed: cand matmul + user matmul + element-wise add.
+
+    Returns (cand_gflops, user_gflops, add_gflops, total_gflops).
+    """
+    M, K_CAND = compression_w_cand.shape
+    B, K_CAND2, N = embeddings_cand.shape
+    assert K_CAND == K_CAND2
+    K_USER = compression_w_user.shape[1]
+    U = embeddings_user.shape[0]
+
+    cand_matmul_gflops = round(2 * B * M * K_CAND * N / 1e9, 2)
+    user_matmul_gflops = round(2 * U * M * K_USER * N / 1e9, 2)
+    add_gflops = round(B * M * N / 1e9, 2)
+    total_gflops = round(cand_matmul_gflops + user_matmul_gflops + add_gflops, 2)
+    return cand_matmul_gflops, user_matmul_gflops, add_gflops, total_gflops
+
+
+# ============================================================
+# Bytes utilities (unit: MB, integer)
+# ============================================================
+# Memory traffic differs across variants due to intermediate buffers
+# and kernel fusion boundaries.
+
+
+def get_lce_bytes(compression_w, embeddings):
+    """Baseline: single batched matmul.
+
+    Read:  W[M,K] + E[B,K,N]
+    Write: out[B,M,N]
+    """
+    M, K = compression_w.shape
+    B, K2, N = embeddings.shape
+    assert K == K2
+    read = (M * K + B * K2 * N) * 2 // 1024**2
+    write = B * M * N * 2 // 1024**2
+    return read, write, read + write
+
+
+def get_decomposed_lce_bytes(
+    compression_w_cand,
+    compression_w_user,
+    embeddings_cand,
+    embeddings_user,
+    cand_to_user_index,
+):
+    """Decomposed: four separate PyTorch ops, each a distinct kernel launch.
+
+    Op 1 (cand matmul):  read W_cand + E_cand,            write cand_res[B,M,N]
+    Op 2 (user matmul):  read W_user + E_user,             write user_res[U,M,N]
+    Op 3 (index_select): read user_res[U,M,N] + idx[B],    write broadcast[B,M,N]
+    Op 4 (add):          read cand_res[B,M,N] + broadcast,  write out[B,M,N]
+    """
+    M = compression_w_cand.shape[0]
+    B = embeddings_cand.shape[0]
+    N = embeddings_cand.shape[2]
+    U = embeddings_user.shape[0]
+
+    cand_read, cand_write, _ = get_lce_bytes(compression_w_cand, embeddings_cand)
+    user_read, user_write, _ = get_lce_bytes(compression_w_user, embeddings_user)
+
+    index_select_read = (U * M * N * 2 + B * 4) // 1024**2
+    index_select_write = (B * M * N * 2) // 1024**2
+
+    add_read = (2 * B * M * N * 2) // 1024**2
+    add_write = (B * M * N * 2) // 1024**2
+
+    total_read = cand_read + user_read + index_select_read + add_read
+    total_write = cand_write + user_write + index_select_write + add_write
+    return total_read, total_write, total_read + total_write
+
+
+def get_kernel_fusion_bytes(
+    compression_w_cand,
+    compression_w_user,
+    embeddings_cand,
+    embeddings_user,
+    cand_to_user_index,
+):
+    """Kernel fusion (triton_ikbo_lce): user matmul via cuBLAS, cand+add fused in Triton.
+
+    cuBLAS:  read W_user + E_user,                  write user_res[U,M,N]
+    Triton:  read W_cand + E_cand + user_res + idx,  write out[B,M,N]
+
+    Saves index_select + add intermediate traffic vs decomposed.
+    Still materializes user_res[U,M,N] between cuBLAS and Triton.
+    """
+    M, K_CAND = compression_w_cand.shape
+    K_USER = compression_w_user.shape[1]
+    B, _, N = embeddings_cand.shape
+    U = embeddings_user.shape[0]
+
+    read = (
+        M * K_CAND + M * K_USER + B * K_CAND * N + U * K_USER * N + U * M * N
+    ) * 2 + B * 4
+    write = (U * M * N + B * M * N) * 2
+    read_mb = read // 1024**2
+    write_mb = write // 1024**2
+    return read_mb, write_mb, read_mb + write_mb
+
+
+def _fmt_bytes(label, read, write, total):
+    return f"  {label:<20s}  read={read:>5d} MB  write={write:>5d} MB  total={total:>5d} MB"
+
+
+def _fmt_flops(label, breakdown):
+    if isinstance(breakdown, tuple):
+        cand, user, add, total = breakdown
+        return f"  {label:<20s}  cand={cand:>7.2f}  user={user:>7.2f}  add={add:>7.2f}  total={total:>7.2f} GFLOPS"
+    return f"  {label:<20s}  total={breakdown:>7.2f} GFLOPS"
+
+
+def print_flops_bytes():
+    torch.manual_seed(0)
+    (
+        compression_w_cand,
+        compression_w_user,
+        embeddings_cand,
+        embeddings_user,
+        cand_to_user_index,
+        compression_w,
+        embeddings,
+    ) = _prepare_default_inputs()
+
+    M = compression_w_cand.shape[0]
+    B = embeddings_cand.shape[0]
+    N = embeddings_cand.shape[2]
+    U = embeddings_user.shape[0]
+    K_CAND = compression_w_cand.shape[1]
+    K_USER = compression_w_user.shape[1]
+    K_TOTAL = compression_w.shape[1]
+
+    print(
+        f"Dimensions: B={B}, M={M}, N={N}, K_cand={K_CAND}, K_user={K_USER}, K_total={K_TOTAL}, U={U}"
+    )
+    print()
+    print("Memory traffic:")
+    print(_fmt_bytes("Baseline", *get_lce_bytes(compression_w, embeddings)))
+    print(
+        _fmt_bytes(
+            "Decomposed",
+            *get_decomposed_lce_bytes(
+                compression_w_cand,
+                compression_w_user,
+                embeddings_cand,
+                embeddings_user,
+                cand_to_user_index,
+            ),
+        )
+    )
+    print(
+        _fmt_bytes(
+            "Kernel fusion",
+            *get_kernel_fusion_bytes(
+                compression_w_cand,
+                compression_w_user,
+                embeddings_cand,
+                embeddings_user,
+                cand_to_user_index,
+            ),
+        )
+    )
+    print()
+    print("FLOPs:")
+    print(_fmt_flops("Baseline", get_lce_flops(compression_w, embeddings)))
+    print(
+        _fmt_flops(
+            "Decomposed",
+            get_decomposed_lce_flops(
+                compression_w_cand, compression_w_user, embeddings_cand, embeddings_user
+            ),
+        )
+    )
+
+
+def main():
+    print_flops_bytes()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2493

This diff adds IKBO (In-Kernel Broadcast Optimization) kernels for Linear Compression Embedding (LCE) to `fbgemm_gpu/experimental/`.

*Note: A comprehensive introduction will be published as a blog post and linked in the README later.*

Linear Compress Embedding (LCE) compresses input embeddings via a learned projection `(M, K) @ (B, K, N) → (B, M, N)`. The kernels implement a progression of 3 optimizations:
- Opt 1 (`torch_lce.py`): Broadcast decomposition in PyTorch.
- Opt 2 (`triton_ikbo_lce.py`): Fused broadcast kernel in Triton.
- **Opt 3 (`tlx_ikbo_lce.py`)**: Warp-specialized kernel in TLX that fuses both user and candidate GEMM stages into a single launch with producer-consumer pipelining and cross-CTA synchronization.

The final kernel (tlx_ikbo_lce.py) subsumes all prior optimizations.

Reviewed By: fywkevin, htyu

Differential Revision: D96879328
