### PR TITLE
Precompute writeback dedup indices in forward to eliminate GPU-CPU sync in backward (#5522)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -57,7 +57,10 @@ from fbgemm_gpu.tbe.monitoring import (
     TBEStatsReporterConfig,
 )
 from fbgemm_gpu.utils.loader import load_torch_module, load_torch_module_bc
-from fbgemm_gpu.utils.writeback_util import writeback_gradient
+from fbgemm_gpu.utils.writeback_util import (
+    compute_writeback_indices_dispatch,
+    writeback_gradient,
+)
 
 try:
     load_torch_module(
@@ -158,6 +161,7 @@ class UserEnabledConfigDefinition:
     use_rowwise_bias_correction: bool = False
     use_writeback_bwd_prehook: bool = False
     writeback_first_feature_only: bool = False
+    precompute_writeback: bool = False
 
 
 @dataclass(frozen=True)
@@ -1182,9 +1186,6 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             extra_optimizer_config.use_writeback_bwd_prehook
         )
 
-        writeback_first_feature_only: bool = (
-            extra_optimizer_config.writeback_first_feature_only
-        )
         self.log(f"self.extra_optimizer_config is {extra_optimizer_config}")
         if self.use_rowwise_bias_correction and not self.optimizer == OptimType.ADAM:
             raise AssertionError(
@@ -1473,7 +1474,11 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         #     self.log("TBE_V2 Knob is set to True; Using experimental TBE")
 
         self.is_experimental: bool = is_experimental
-        self._writeback_first_feature_only: bool = writeback_first_feature_only
+        self._writeback_first_feature_only: bool = (
+            extra_optimizer_config.writeback_first_feature_only
+        )
+        self._writeback_precomputed_index: Optional[Tensor] = None
+        self._precompute_writeback: bool = extra_optimizer_config.precompute_writeback
 
         # Get a debug function pointer
         self._debug_print_input_stats: Callable[..., None] = (
@@ -2218,15 +2223,14 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
     # pyre-fixme[2]: For 1st argument expected not ANY
     def writeback_hook(self, module: Any, grad: tuple[Tensor]) -> tuple[Tensor]:
-        indices = self._indices
-        offsets = self._offsets
         return writeback_gradient(
             grad,
-            indices,
-            offsets,
+            self._indices,
+            self._offsets,
             self.feature_table_map,
             self._writeback_first_feature_only,
             self.is_nobag,
+            self._writeback_precomputed_index,
         )
 
     def forward(  # noqa: C901
@@ -2416,6 +2420,19 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             # Storing tensors for linear_cache_indices recomputation
             self._indices = indices
             self._offsets = offsets
+            # Precompute writeback dedup indices (training-only, not TorchScript-compatible).
+            if (
+                not torch.jit.is_scripting()
+                and self.use_writeback_bwd_prehook
+                and self._precompute_writeback
+            ):
+                self._writeback_precomputed_index = compute_writeback_indices_dispatch(
+                    indices,
+                    offsets,
+                    self.feature_table_map,
+                    self._writeback_first_feature_only,
+                    self.is_nobag,
+                )
             self._vbe_B_offsets = vbe_metadata.B_offsets
             self._vbe_max_B = vbe_metadata.max_B
 

--- a/fbgemm_gpu/fbgemm_gpu/utils/writeback_util.py
+++ b/fbgemm_gpu/fbgemm_gpu/utils/writeback_util.py
@@ -4,8 +4,190 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Optional
 
 import torch
+
+# ---- Primitives: compute indices + apply mask ----
+
+
+def writeback_apply_mask(
+    grad: tuple[torch.Tensor],
+    keep_indices: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Apply precomputed dedup mask to gradient. No GPU→CPU sync.
+
+    Args:
+        grad: Gradient tensor tuple from backward hook
+        keep_indices: Precomputed indices of rows to keep
+
+    Returns:
+        Masked gradient tensor
+    """
+    grad_tensor = grad[0]
+    if keep_indices.numel() == 0:
+        return grad_tensor
+    mask = torch.zeros_like(grad_tensor)
+    mask[keep_indices] = grad_tensor[keep_indices]
+    return mask
+
+
+def compute_writeback_indices(
+    indices: torch.Tensor,
+    offsets: torch.Tensor,
+    feature_table_map: list[int],
+) -> torch.Tensor:
+    """
+    Compute the dedup index for writeback (bag mode) during forward pass.
+
+    Returns ``original_index`` — the gradient row indices to keep.
+
+    Args:
+        indices: Embedding indices tensor
+        offsets: Offsets tensor for batched embeddings
+        feature_table_map: Mapping from feature to table
+
+    Returns:
+        original_index tensor (GPU). Empty tensor if indices is empty.
+    """
+    if indices.numel() == 0:
+        return torch.empty(0, dtype=torch.long, device=indices.device)
+
+    num_of_tables = len(feature_table_map)
+    batch_size = offsets.shape[0] // num_of_tables
+    max_indices = indices.max()
+    torch._assert_async(
+        num_of_tables * max_indices < torch.iinfo(indices.dtype).max,
+        "num_of_tables * max_indices exceeds dtype max",
+    )
+    non_empty_index = (offsets[1:] - offsets[:-1]).nonzero().flatten()
+    # disable dedup across different table
+    indices = ((offsets[non_empty_index]) // batch_size) * (1 + max_indices) + indices
+    _, idx, counts = torch.unique(
+        indices, dim=0, sorted=True, return_inverse=True, return_counts=True
+    )
+    _, ind_sorted = torch.sort(idx, stable=True)
+    cum_sum = counts.cumsum(0)
+    cum_sum = torch.cat((torch.tensor([0]).to(indices.device), cum_sum[:-1]))
+    first_indices = ind_sorted[cum_sum]
+    original_index = non_empty_index[first_indices]
+
+    return original_index
+
+
+def compute_writeback_indices_first_feature_only(
+    indices: torch.Tensor,
+    offsets: torch.Tensor,
+    feature_table_map: list[int],
+) -> torch.Tensor:
+    """
+    Compute dedup index for the first-feature-only writeback case.
+
+    Args:
+        indices: Embedding indices tensor
+        offsets: Offsets tensor for batched embeddings
+        feature_table_map: Mapping from feature to table
+
+    Returns:
+        first_indices tensor (GPU). Empty tensor if indices is empty.
+    """
+    num_of_tables = len(feature_table_map)
+    batch_size = (offsets.shape[0] - 1) // num_of_tables
+    shrink_indices = indices[: offsets[batch_size]]
+    if shrink_indices.numel() == 0 or indices.numel() == 0:
+        return torch.empty(0, dtype=torch.long, device=indices.device)
+    torch._assert_async(
+        num_of_tables * indices.max() < torch.iinfo(indices.dtype).max,
+        "num_of_tables * max_indices exceeds dtype max",
+    )
+
+    _, idx, counts = torch.unique(
+        shrink_indices, dim=0, sorted=True, return_inverse=True, return_counts=True
+    )
+    _, ind_sorted = torch.sort(idx, stable=True)
+    cum_sum = counts.cumsum(0)
+    cum_sum = torch.cat((torch.tensor([0]).to(shrink_indices.device), cum_sum[:-1]))
+    first_indices = ind_sorted[cum_sum]
+
+    return first_indices
+
+
+def compute_writeback_indices_nobag(
+    indices: torch.Tensor,
+    offsets: torch.Tensor,
+    feature_table_map: list[int],
+) -> torch.Tensor:
+    """
+    Compute the dedup index for writeback (nobag/sequence mode) during forward pass.
+
+    Unlike bag mode, nobag mode uses first_indices directly as gradient row indices
+    (no mapping through non_empty_index) because each index maps 1:1 to a gradient row.
+
+    Args:
+        indices: Embedding indices tensor
+        offsets: Offsets tensor for batched embeddings
+        feature_table_map: Mapping from feature to table
+
+    Returns:
+        first_indices tensor (GPU). Empty tensor if indices is empty.
+    """
+    if indices.numel() == 0:
+        return torch.empty(0, dtype=torch.long, device=indices.device)
+
+    num_of_tables: int = len(feature_table_map)
+    batch_size = offsets.shape[0] // num_of_tables
+    max_indices = indices.max()
+    torch._assert_async(
+        num_of_tables * max_indices < torch.iinfo(indices.dtype).max,
+        "num_of_tables * max_indices exceeds dtype max",
+    )
+    non_empty_index = (offsets[1:] - offsets[:-1]).nonzero().flatten()
+    # disable dedup across different table
+    indices = ((offsets[non_empty_index]) // batch_size) * (1 + max_indices) + indices
+    # TODO: revisit if dedup is needed when EC dedup is enabled.
+    _, idx, counts = torch.unique(
+        indices, dim=0, sorted=True, return_inverse=True, return_counts=True
+    )
+    _, ind_sorted = torch.sort(idx, stable=True)
+    cum_sum = counts.cumsum(0)
+    cum_sum = torch.cat((torch.tensor([0]).to(indices.device), cum_sum[:-1]))
+    first_indices = ind_sorted[cum_sum]
+
+    return first_indices
+
+
+def compute_writeback_indices_dispatch(
+    indices: torch.Tensor,
+    offsets: torch.Tensor,
+    feature_table_map: list[int],
+    writeback_first_feature_only: bool = False,
+    nobag: bool = False,
+) -> torch.Tensor:
+    """
+    Dispatch to the appropriate compute_writeback_indices variant.
+
+    Args:
+        indices: Embedding indices tensor
+        offsets: Offsets tensor for batched embeddings
+        feature_table_map: Mapping from feature to table
+        writeback_first_feature_only: If True, use first-feature-only variant
+        nobag: If True, use nobag/sequence variant
+
+    Returns:
+        Precomputed dedup indices tensor
+    """
+    if writeback_first_feature_only:
+        return compute_writeback_indices_first_feature_only(
+            indices, offsets, feature_table_map
+        )
+    elif nobag:
+        return compute_writeback_indices_nobag(indices, offsets, feature_table_map)
+    else:
+        return compute_writeback_indices(indices, offsets, feature_table_map)
+
+
+# ---- Entry points: compute + apply in one call ----
 
 
 def writeback_update_gradient(
@@ -13,6 +195,7 @@ def writeback_update_gradient(
     offsets: torch.Tensor,
     grad: tuple[torch.Tensor],
     feature_table_map: list[int],
+    original_index: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     Update gradient tensor by deduplicating indices across all features/tables.
@@ -25,34 +208,15 @@ def writeback_update_gradient(
         offsets (torch.Tensor): Offsets tensor for batched embeddings
         grad (tuple[torch.Tensor]): Gradient tensor to be updated
         feature_table_map (list[int]): Mapping from feature to table
+        original_index (Optional[torch.Tensor]): Precomputed indices. If None, computed here.
 
     Returns:
         torch.Tensor: Updated gradient tensor with duplicates masked out
     """
-    if indices.numel() == 0:
-        return grad[0]
-    # grad[0] has the same size as offsets for EBC.
-    # get num of feature to estimate batch size
-    num_of_tables = len(feature_table_map)
-    assert num_of_tables * indices.max() < torch.iinfo(indices.dtype).max
-    batch_size = offsets.shape[0] // num_of_tables
-    max_indices = indices.max()
-    non_empty_index = (offsets[1:] - offsets[:-1]).nonzero().flatten()
-    # disable dedup across different table
-    indices = ((offsets[non_empty_index]) // batch_size) * (1 + max_indices) + indices
-    grad_tensor = grad[0]
-    _, idx, counts = torch.unique(
-        indices, dim=0, sorted=True, return_inverse=True, return_counts=True
-    )
-    _, ind_sorted = torch.sort(idx, stable=True)
-    cum_sum = counts.cumsum(0)
-    cum_sum = torch.cat((torch.tensor([0]).to(indices.device), cum_sum[:-1]))
-    first_indicies = ind_sorted[cum_sum]
-    mask = torch.zeros_like(grad_tensor, device=grad_tensor.device)
-    original_index = non_empty_index[first_indicies]
+    if original_index is None:
+        original_index = compute_writeback_indices(indices, offsets, feature_table_map)
 
-    mask[original_index] = grad_tensor[original_index]
-    return mask
+    return writeback_apply_mask(grad, original_index)
 
 
 def writeback_update_gradient_first_feature_only(
@@ -60,6 +224,7 @@ def writeback_update_gradient_first_feature_only(
     offsets: torch.Tensor,
     grad: tuple[torch.Tensor],
     feature_table_map: list[int],
+    first_indices: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     Special case of writeback_update_gradient where gradient only needs to be updated for the first feature. Other features will be forward-only
@@ -71,29 +236,17 @@ def writeback_update_gradient_first_feature_only(
         offsets (torch.Tensor): Offsets tensor for batched embeddings
         grad (tuple[torch.Tensor]): Gradient tensor to be updated
         feature_table_map (list[int]): Mapping from feature to table
+        first_indices (Optional[torch.Tensor]): Precomputed indices. If None, computed here.
 
     Returns:
         torch.Tensor: Updated gradient tensor with duplicates masked out
     """
-    num_of_tables = len(feature_table_map)
-    batch_size = (offsets.shape[0] - 1) // num_of_tables
-    shrink_indices = indices[: offsets[batch_size]]
-    if shrink_indices.numel() == 0 or indices.numel() == 0:
-        return grad[0]
-    assert num_of_tables * indices.max() < torch.iinfo(indices.dtype).max
+    if first_indices is None:
+        first_indices = compute_writeback_indices_first_feature_only(
+            indices, offsets, feature_table_map
+        )
 
-    grad_tensor = grad[0]
-    _, idx, counts = torch.unique(
-        shrink_indices, dim=0, sorted=True, return_inverse=True, return_counts=True
-    )
-    _, ind_sorted = torch.sort(idx, stable=True)
-    cum_sum = counts.cumsum(0)
-    cum_sum = torch.cat((torch.tensor([0]).to(shrink_indices.device), cum_sum[:-1]))
-    first_indices = ind_sorted[cum_sum]
-    mask = torch.zeros_like(grad_tensor, device=grad_tensor.device)
-
-    mask[first_indices] = grad_tensor[first_indices]
-    return mask
+    return writeback_apply_mask(grad, first_indices)
 
 
 def writeback_update_gradient_nobag(
@@ -101,9 +254,11 @@ def writeback_update_gradient_nobag(
     offsets: torch.Tensor,
     grad: tuple[torch.Tensor],
     feature_table_map: list[int],
+    first_indices: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
-    Hook for using TBE no bag to update gradient tensor by deduplicating indices (in one feature or across multiple features) across all features/tables.
+    Hook for using TBE no bag to update gradient tensor by deduplicating indices
+    (in one feature or across multiple features) across all features/tables.
     For duplicate indices, only the first occurrence receives the gradient to achieve the assign purpose via gradient update
 
     Args:
@@ -111,32 +266,20 @@ def writeback_update_gradient_nobag(
         offsets (torch.Tensor): Offsets tensor for batched embeddings
         grad (tuple[torch.Tensor]): Gradient tensor to be updated
         feature_table_map (list[int]): Mapping from feature to table
+        first_indices (Optional[torch.Tensor]): Precomputed indices. If None, computed here.
 
     Returns:
         torch.Tensor: Updated gradient tensor with duplicates masked out
     """
-    if indices.numel() == 0:
-        return grad[0]
-    # grad[0] has the same size as indices for EC.
-    num_of_tables: int = len(feature_table_map)
-    assert num_of_tables * indices.max() < torch.iinfo(indices.dtype).max
-    batch_size = offsets.shape[0] // num_of_tables
-    max_indices = indices.max()
-    non_empty_index = (offsets[1:] - offsets[:-1]).nonzero().flatten()
-    # disable dedup across different table
-    indices = ((offsets[non_empty_index]) // batch_size) * (1 + max_indices) + indices
-    grad_tensor = grad[0]
-    # TODO: revisit if dedup is needed when EC dedup is enabled.
-    _, idx, counts = torch.unique(
-        indices, dim=0, sorted=True, return_inverse=True, return_counts=True
-    )
-    _, ind_sorted = torch.sort(idx, stable=True)
-    cum_sum = counts.cumsum(0)
-    cum_sum = torch.cat((torch.tensor([0]).to(indices.device), cum_sum[:-1]))
-    first_indices = ind_sorted[cum_sum]
-    mask = torch.zeros_like(grad_tensor, device=grad_tensor.device)
-    mask[first_indices] = grad_tensor[first_indices]
-    return mask
+    if first_indices is None:
+        first_indices = compute_writeback_indices_nobag(
+            indices, offsets, feature_table_map
+        )
+
+    return writeback_apply_mask(grad, first_indices)
+
+
+# ---- Entry point ----
 
 
 def writeback_gradient(
@@ -146,6 +289,7 @@ def writeback_gradient(
     feature_table_map: list[int],
     writeback_first_feature_only: bool = False,
     nobag: bool = False,
+    precomputed_indices: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor]:
     """
     Compute deduplicated gradient for writeback operation.
@@ -157,6 +301,7 @@ def writeback_gradient(
         feature_table_map (list[int]): Mapping from feature to table
         writeback_first_feature_only (bool): If True, only first feature will apply gradient update, other features will be read-only
         nobag (bool): If True, we use TBE with sequence embeddings, otherwise we use TBE with pooled embeddings.
+        precomputed_indices (Optional[torch.Tensor]): Precomputed dedup indices from forward pass. If None, computed here.
 
     Returns:
         tuple[torch.Tensor]: Tuple containing the updated gradient tensor
@@ -164,12 +309,18 @@ def writeback_gradient(
     if writeback_first_feature_only:
         return (
             writeback_update_gradient_first_feature_only(
-                indices, offsets, grad, feature_table_map
+                indices, offsets, grad, feature_table_map, precomputed_indices
             ),
         )
     elif nobag:
         return (
-            writeback_update_gradient_nobag(indices, offsets, grad, feature_table_map),
+            writeback_update_gradient_nobag(
+                indices, offsets, grad, feature_table_map, precomputed_indices
+            ),
         )
     else:
-        return (writeback_update_gradient(indices, offsets, grad, feature_table_map),)
+        return (
+            writeback_update_gradient(
+                indices, offsets, grad, feature_table_map, precomputed_indices
+            ),
+        )

--- a/fbgemm_gpu/test/tbe/utils/writeback_util_test.py
+++ b/fbgemm_gpu/test/tbe/utils/writeback_util_test.py
@@ -13,6 +13,10 @@ import hypothesis.strategies as st
 import torch
 from fbgemm_gpu.tbe.utils import get_table_batched_offsets_from_dense
 from fbgemm_gpu.utils.writeback_util import (
+    compute_writeback_indices,
+    compute_writeback_indices_dispatch,
+    compute_writeback_indices_first_feature_only,
+    compute_writeback_indices_nobag,
     writeback_gradient,
     writeback_update_gradient_nobag,
 )
@@ -231,3 +235,71 @@ class WritebackUtilsTest(unittest.TestCase):
                 expected[i] = grad[0][i]
             # else: leave as zero (duplicate within the same table)
         self.assertTrue(torch.equal(result[0], expected))
+
+    # pyre-ignore[56]
+    @given(
+        T=st.integers(min_value=1, max_value=3),
+        D=st.integers(min_value=2, max_value=256),
+        B=st.integers(min_value=16, max_value=20),
+        log_E=st.integers(min_value=2, max_value=5),
+    )
+    def test_precomputed_writeback_all_modes(
+        self,
+        T: int,
+        D: int,
+        B: int,
+        log_E: int,
+    ) -> None:
+        """Property-based test: for all 3 writeback modes (bag, first_feature_only,
+        nobag), verify that:
+        1. compute_writeback_indices_dispatch routes to the correct compute fn
+        2. writeback_gradient with precomputed_indices matches without
+        """
+        L = 1
+        E = int(10**log_E)
+
+        xs = [torch.randint(low=0, high=E, size=(B, L)) for _ in range(T)]
+        x = torch.cat([xi.view(1, B, L) for xi in xs], dim=0)
+        indices, offsets = get_table_batched_offsets_from_dense(x, use_cpu=True)
+        grad = (torch.rand((indices.size(0), D)),)
+        feature_table_map = list(range(T))
+
+        configs = [
+            # (writeback_first_feature_only, nobag, expected_compute_fn)
+            (False, False, compute_writeback_indices),
+            (True, False, compute_writeback_indices_first_feature_only),
+            (False, True, compute_writeback_indices_nobag),
+        ]
+
+        for first_feature_only, nobag, compute_fn in configs:
+            with self.subTest(first_feature_only=first_feature_only, nobag=nobag):
+                # 1. Dispatch routes to the correct compute function
+                direct = compute_fn(indices, offsets, feature_table_map)
+                dispatched = compute_writeback_indices_dispatch(
+                    indices,
+                    offsets,
+                    feature_table_map,
+                    writeback_first_feature_only=first_feature_only,
+                    nobag=nobag,
+                )
+                self.assertTrue(torch.equal(direct, dispatched))
+
+                # 2. writeback_gradient with precomputed matches without
+                result_without = writeback_gradient(
+                    grad,
+                    indices,
+                    offsets,
+                    feature_table_map,
+                    writeback_first_feature_only=first_feature_only,
+                    nobag=nobag,
+                )
+                result_with = writeback_gradient(
+                    grad,
+                    indices,
+                    offsets,
+                    feature_table_map,
+                    writeback_first_feature_only=first_feature_only,
+                    nobag=nobag,
+                    precomputed_indices=dispatched,
+                )
+                self.assertTrue(torch.equal(result_without[0], result_with[0]))


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2494


The writeback backward hook (used by EXACT_SGD) performs dedup index computation
that triggers CPU-to-GPU synchronization (nonzero, unique, .to()) on every backward
pass. This stalls the GPU pipeline and degrades training QPS.

This diff splits the writeback logic into two phases:
1. **compute_writeback_indices** (forward): precomputes which gradient rows to keep,
   running all sync-causing ops during forward where they can overlap with other work.
2. **writeback_apply_mask** (backward): applies the precomputed mask to zero out
   duplicate gradient rows. This is fully sync-free.

The optimization is gated by env var `FBGEMM_PRECOMPUTE_WRITEBACK=1` (default off).
(Update: we ditched the env variable approached and now is using `extra_optimizer_config.precompute_writeback`, which also defaults to False)
When disabled, the legacy code path is used unchanged.

Covers all three writeback modes: bag, first-feature-only, and nobag.

Key changes:
- `writeback_util.py`: Refactored into composable primitives (`compute_writeback_indices`,
  `compute_writeback_indices_first_feature_only`, `compute_writeback_indices_nobag`,
  `writeback_apply_mask`). Added `compute_writeback_indices_dispatch` for unified dispatch.
  Update/gradient functions now delegate to these primitives.
- `split_table_batched_embeddings_ops_training.py`: Added `_writeback_precomputed_index`
  member variable and `_precompute_writeback` flag (cached from env var). Forward pass
  precomputes indices via `compute_writeback_indices_dispatch` when enabled. `writeback_hook`
  passes precomputed indices to `writeback_gradient`.
- `writeback_util_test.py`: Added property-based test (`test_precomputed_writeback_all_modes`)
  verifying dispatch routing and precomputed-vs-without equivalence across all 3 modes.

Differential Revision: D97415226
