### PR TITLE
Update default CUDA version to 13.0.2

### DIFF
--- a/.github/workflows/fbgemm_gpu_benchmark_cuda.yml
+++ b/.github/workflows/fbgemm_gpu_benchmark_cuda.yml
@@ -40,7 +40,7 @@ jobs:
             { "arch": "x86", "instance": "linux.24xlarge" },
           ],
           "python-version": [ "3.14" ],
-          "cuda-version": [ "12.8.1" ],
+          "cuda-version": [ "13.0.2" ],
           "compiler": [ "gcc" ],
         }
       repo-ref: ${{ github.ref }}
@@ -57,7 +57,7 @@ jobs:
             { "arch": "x86", "instance": "linux.g5.4xlarge.nvidia.gpu" },
           ],
           "python-version": [ "3.14" ],
-          "cuda-version": [ "12.8.1" ],
+          "cuda-version": [ "13.0.2" ],
           "compiler": [ "gcc" ],
         }
       repo-ref: ${{ github.ref }}

--- a/.github/workflows/fbgemm_gpu_ci_cuda.yml
+++ b/.github/workflows/fbgemm_gpu_ci_cuda.yml
@@ -85,7 +85,7 @@ jobs:
       repo-ref: ${{ (github.event_name == 'schedule' && 'nightly') || github.ref }}
       pytorch-channel-version: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.pytorch-channel-version) || 'nightly' }}
       publish-to-pypi: ${{ (github.event_name == 'schedule') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-to-pypi == 'true') }}
-      cuda-version-publish: 12.8.1
+      cuda-version-publish: 13.0.2
       extra-env: >-
         {
           "ENFORCE_CUDA_DEVICE": 1

--- a/.github/workflows/fbgemm_gpu_release_cuda.yml
+++ b/.github/workflows/fbgemm_gpu_release_cuda.yml
@@ -35,7 +35,7 @@ on:
         type: choice
         required: false
         options: [ "12.6.3", "12.8.1", "12.9.1", "13.0.2" ]
-        default: "12.8.1"
+        default: "13.0.2"
       publish-to-pypi:
         description: Publish Artifact to PyPI
         type: boolean

--- a/.github/workflows/fbgemm_gpu_release_genai.yml
+++ b/.github/workflows/fbgemm_gpu_release_genai.yml
@@ -35,7 +35,7 @@ on:
         type: choice
         required: false
         options: [ "12.6.3", "12.8.1", "12.9.1", "13.0.2" ]
-        default: "12.8.1"
+        default: "13.0.2"
       publish-to-pypi:
         description: Publish Artifact to PyPI
         type: boolean


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2497

Updates the default cuda-version-publish value to 13.0.2

Differential Revision: D98022998


