### PR TITLE
Fix sorted_ids None issue in SSD TBE optimizer state fetching

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -2916,6 +2916,15 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             should_flush=should_flush,
         )
 
+        # If sorted_ids is None, create empty tensors per table so that
+        # _fetch_offloaded_optimizer_states can still handle the
+        # local_weight_counts > 0 case (filling with zeros).
+        if sorted_ids is None:
+            sorted_ids = [
+                torch.empty(0, 1, device=torch.device("cpu"), dtype=torch.int64)
+                for _ in dims_
+            ]
+
         # pyre-ignore[53]
         def _fetch_offloaded_optimizer_states(
             t: int,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2496

CONTEXT: In SSD TBE training, when `sorted_ids` is None (e.g., no cache activity), `_fetch_offloaded_optimizer_states` fails because it tries to index into None. This causes crashes when optimizer states need to be fetched for tables with `local_weight_counts > 0`.

WHAT: Add a guard that creates empty tensors (one per table) when `sorted_ids` is None, so `_fetch_offloaded_optimizer_states` can still handle the `local_weight_counts > 0` case by filling with zeros instead of crashing.

Differential Revision: D97982772


