### PR TITLE
Fix output_type=BF16 test_backward_adagrad_large_dims failure (#5531)

### DIFF
--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_v2_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_v2_template.cu
@@ -82,10 +82,22 @@ struct Vec4Type<at::Half> {
   using type = float2;
 };
 
+// Use bfloat16_4 instead of float2 to distinguish BF16 from FP16 at the
+// store call site: both would otherwise resolve to float2 and incorrectly
+// use __float22half2_rn (FP16) instead of __float2bfloat16_rn (BF16).
+// bfloat16_4 is only available on ROCm or CUDA >= 11 / SM80+; fall back
+// to float2 (broken but unchanged) on legacy platforms.
+#if USE_ROCM_OR_CUDA_SM80_PLUS
+template <>
+struct Vec4Type<at::BFloat16> {
+  using type = bfloat16_4;
+};
+#else
 template <>
 struct Vec4Type<at::BFloat16> {
   using type = float2;
 };
+#endif
 
 template <>
 struct Vec4Type<uint8_t> {

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_prelude.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_prelude.cuh
@@ -36,6 +36,14 @@ inline int get_device_sm_cnt_() {
 
 namespace fbgemm_gpu {
 
+#if defined(USE_ROCM) ||                                  \
+    !(((defined(CUDA_VERSION) && CUDA_VERSION < 11000) || \
+       (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))))
+#define USE_ROCM_OR_CUDA_SM80_PLUS 1
+#else
+#define USE_ROCM_OR_CUDA_SM80_PLUS 0
+#endif
+
 #if !defined(USE_ROCM) && defined(CUDA_VERSION)
 #define FBGEMM_USE_SUBWARP_SHUFFLE
 #endif

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/vec4acc.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/vec4acc.cuh
@@ -10,6 +10,7 @@
 
 #include <ATen/ATen.h>
 #include "fbgemm_gpu/utils/cuda_prelude.cuh"
+#include "fbgemm_gpu/utils/float.cuh"
 
 namespace fbgemm_gpu {
 
@@ -69,6 +70,12 @@ struct Vec4AccT {
     *dst = *reinterpret_cast<float2*>(vals_h);
   }
 
+#if USE_ROCM_OR_CUDA_SM80_PLUS
+  DEVICE_INLINE void store_(const float4* src, bfloat16_4* dst) {
+    *dst = to_bfloat16_4(*src);
+  }
+#endif
+
   DEVICE_INLINE void store(float4* ptr) {
     this->store_(reinterpret_cast<float4*>(acc), ptr);
   }
@@ -77,6 +84,13 @@ struct Vec4AccT {
   DEVICE_INLINE void store(float2* ptr) {
     this->store_(reinterpret_cast<const float4*>(acc), ptr);
   }
+
+#if USE_ROCM_OR_CUDA_SM80_PLUS
+  // Store to bfloat16
+  DEVICE_INLINE void store(bfloat16_4* ptr) {
+    this->store_(reinterpret_cast<const float4*>(acc), ptr);
+  }
+#endif
 
   DEVICE_INLINE void store(uint8_t* ptr) {
     CUDA_KERNEL_ASSERT(false);
@@ -188,6 +202,12 @@ struct Vec4StepT<STEP, float> : Vec4AccT {
     this->store_(&loaded_vals[idx], ptr);
   }
 
+#if USE_ROCM_OR_CUDA_SM80_PLUS
+  DEVICE_INLINE void index_store(uint32_t idx, bfloat16_4* ptr) {
+    this->store_(reinterpret_cast<const float4*>(&loaded_vals[idx]), ptr);
+  }
+#endif
+
   DEVICE_INLINE void index_store(uint32_t idx, uint8_t* ptr) {
     CUDA_KERNEL_ASSERT(false);
   }
@@ -212,6 +232,19 @@ struct Vec4StepT<STEP, float> : Vec4AccT {
     vals_f[3] = __fmul_rn(vals[3], weight);
     this->store_(reinterpret_cast<float4*>(vals_f), ptr);
   }
+
+#if USE_ROCM_OR_CUDA_SM80_PLUS
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, bfloat16_4* ptr, const float weight) {
+    const float* vals = reinterpret_cast<const float*>(&loaded_vals[idx]);
+    float4 vals_f = make_float4(
+        __fmul_rn(vals[0], weight),
+        __fmul_rn(vals[1], weight),
+        __fmul_rn(vals[2], weight),
+        __fmul_rn(vals[3], weight));
+    this->store_(&vals_f, ptr);
+  }
+#endif
 
   DEVICE_INLINE void
   index_weighted_store(uint32_t idx, uint8_t* ptr, const float weight) {
@@ -297,6 +330,16 @@ struct Vec4StepT<STEP, at::Half> : Vec4AccT {
     *ptr = *reinterpret_cast<float2*>(&loaded_vals[idx]);
   }
 
+#if USE_ROCM_OR_CUDA_SM80_PLUS
+  DEVICE_INLINE void index_store(uint32_t idx, bfloat16_4* ptr) {
+    const half2* vals_h = reinterpret_cast<const half2*>(&loaded_vals[idx]);
+    float2 vals_f[2];
+    vals_f[0] = __half22float2(vals_h[0]);
+    vals_f[1] = __half22float2(vals_h[1]);
+    this->store_(reinterpret_cast<const float4*>(vals_f), ptr);
+  }
+#endif
+
   DEVICE_INLINE void index_store(uint32_t idx, uint8_t* ptr) {
     CUDA_KERNEL_ASSERT(false);
   }
@@ -321,6 +364,19 @@ struct Vec4StepT<STEP, at::Half> : Vec4AccT {
     vals_f[3] = __fmul_rn(vals[3], weight);
     this->store_(reinterpret_cast<float4*>(vals_f), ptr);
   }
+
+#if USE_ROCM_OR_CUDA_SM80_PLUS
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, bfloat16_4* ptr, const float weight) {
+    const half* vals = reinterpret_cast<const half*>(&loaded_vals[idx]);
+    float4 vals_f = make_float4(
+        __fmul_rn(__half2float(vals[0]), weight),
+        __fmul_rn(__half2float(vals[1]), weight),
+        __fmul_rn(__half2float(vals[2]), weight),
+        __fmul_rn(__half2float(vals[3]), weight));
+    this->store_(&vals_f, ptr);
+  }
+#endif
 
   DEVICE_INLINE void
   index_weighted_store(uint32_t idx, uint8_t* ptr, const float weight) {
@@ -383,6 +439,17 @@ struct Vec4StepT<STEP, uint8_t> : Vec4AccT {
   index_weighted_store(uint32_t idx, uint8_t* ptr, const float weight) {
     CUDA_KERNEL_ASSERT(false);
   }
+
+#if USE_ROCM_OR_CUDA_SM80_PLUS
+  DEVICE_INLINE void index_store(uint32_t idx, bfloat16_4* ptr) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, bfloat16_4* ptr, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+#endif
 };
 
 template <uint32_t STEP>
@@ -447,6 +514,17 @@ struct Vec4StepT<STEP, c10::Float8_e4m3fn> : Vec4AccT {
       const float weight) {
     CUDA_KERNEL_ASSERT(false);
   }
+
+#if USE_ROCM_OR_CUDA_SM80_PLUS
+  DEVICE_INLINE void index_store(uint32_t idx, bfloat16_4* ptr) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, bfloat16_4* ptr, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+#endif
 };
 
 template <uint32_t STEP>
@@ -511,6 +589,17 @@ struct Vec4StepT<STEP, c10::Float8_e4m3fnuz> : Vec4AccT {
       const float weight) {
     CUDA_KERNEL_ASSERT(false);
   }
+
+#if USE_ROCM_OR_CUDA_SM80_PLUS
+  DEVICE_INLINE void index_store(uint32_t idx, bfloat16_4* ptr) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+
+  DEVICE_INLINE void
+  index_weighted_store(uint32_t idx, bfloat16_4* ptr, const float weight) {
+    CUDA_KERNEL_ASSERT(false);
+  }
+#endif
 };
 
 } // namespace fbgemm_gpu


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2500

Currently, `vec4acc.cuh` stores don't account for `bf16` outputs, treating them as FP16 during conversion from FP32. That makes `test_backward_adagrad_large_dims` test to fail in some specific cases when D>1024 (or D>256 in the context of unit-test parameters) and `forward_v2` kernel is called. The way to reproduce the failure is to add `reproduce_failure('6.151.9', b'AEEAAEEAQQFCAQFBAUEDQQFBAQAAAAAAQQBBAg==')` decorator to `test_backward_adagrad_large_dims` test and run on current main branch.


Test Plan:
```
CUDA_VISIBLE_DEVICES=4 buck run fbcode//mode/opt-amd-gpu \
  -c fbcode.enable_gpu_sections=true \
  -c fbcode.rocm_arch=mi350 \
  -c fbcode.platform=platform010 \
  -m rocm70 \
  fbcode//deeplearning/fbgemm/fbgemm_gpu/test/tbe:backward_adagrad_large_dim \
  -- -r test_backward_adagrad_large_dims
```

Reviewed By: sryap

Differential Revision: D98170783

Pulled By: q10
