### PR TITLE
Fix ufmt lint: remove extra blank line in lxu_cache_test.py (#5535)

### DIFF
--- a/fbgemm_gpu/test/tbe/cache/lxu_cache_test.py
+++ b/fbgemm_gpu/test/tbe/cache/lxu_cache_test.py
@@ -25,7 +25,6 @@ from torch import Tensor
 from ..common import MAX_EXAMPLES  # noqa E402
 from .cache_common import generate_cache_tbes, gpu_unavailable, optests
 
-
 VERBOSITY: Verbosity = Verbosity.verbose
 
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2503

Remove extra blank line between imports and VERBOSITY constant in
lxu_cache_test.py. This was introduced in D96676696 and causes ufmt
lint failure in the OSS CI (pytorch/FBGEMM).

Reviewed By: gchalump

Differential Revision: D98237251


