### PR TITLE
Remove redundant CUDA_KERNEL_ASSERTs in keyed_jagged_index_select_dim1

### DIFF
--- a/fbgemm_gpu/bench/jagged_tensor_benchmark.py
+++ b/fbgemm_gpu/bench/jagged_tensor_benchmark.py
@@ -556,6 +556,8 @@ def masked_select_jagged_1d(
     type=str,
     default="keyed_jagged_index_select_dim1_{phase}_trace_{ospid}.json",
 )
+@click.option("--iters", type=int, default=1000)
+@click.option("--baseline/--skip-baseline", default=True)
 def keyed_jagged_index_select_dim1(
     num_batches: int,
     max_seq_length: int,
@@ -567,6 +569,8 @@ def keyed_jagged_index_select_dim1(
     use_selected_lengths_sum: bool,
     export_trace: bool,
     trace_url: str,
+    iters: int,
+    baseline: bool,
 ) -> None:
     jagged_tensor_types = {
         "float": torch.float,
@@ -586,6 +590,8 @@ def keyed_jagged_index_select_dim1(
     jagged_tensor_dtype = jagged_tensor_types[jagged_tensor_type]
     is_float = jagged_tensor_dtype in [torch.float, torch.half]
     weight_dtype = weight_types[weight_type]
+
+    torch.manual_seed(42)
 
     lengths = torch.randint(
         low=0,
@@ -657,7 +663,7 @@ def keyed_jagged_index_select_dim1(
                 weights,
                 selected_lengths_sum,
             ),
-            iters=1000,
+            iters=iters,
         )
         output = output[0]
 
@@ -698,13 +704,15 @@ def keyed_jagged_index_select_dim1(
             torch.concat(output_weights) if has_weights else torch.empty(0)
         )
 
-    time_ref, output_ref = benchmark_torch_function(
-        keyed_jagged_index_select_dim1_ref, (ref_inputs, has_weights)
-    )
-    output_ref = output_ref[0]
+    time_ref = None
+    if baseline:
+        time_ref, output_ref = benchmark_torch_function(
+            keyed_jagged_index_select_dim1_ref, (ref_inputs, has_weights), iters=iters
+        )
+        output_ref = output_ref[0]
 
     logging.info(
-        f"keyed_jagged_index_select_dim1 forward time: {time * 1e3} ms, ref {time_ref * 1e3}"
+        f"keyed_jagged_index_select_dim1 forward time: {time * 1e3} ms, ref {time_ref * 1e3 if time_ref is not None else 'N/A'}"
     )
 
     if not is_float:
@@ -714,14 +722,16 @@ def keyed_jagged_index_select_dim1(
 
     with context_factory(lambda p: _kineto_trace_handler(p, "bwd")):
         time, _ = benchmark_torch_function(
-            functools.partial(output.backward, retain_graph=True), (grad,), iters=1000
+            functools.partial(output.backward, retain_graph=True), (grad,), iters=iters
         )
-
-    time_ref, _ = benchmark_torch_function(
-        functools.partial(output_ref.backward, retain_graph=True), (grad,), iters=1000
-    )
+    if baseline:
+        time_ref, _ = benchmark_torch_function(
+            functools.partial(output_ref.backward, retain_graph=True),
+            (grad,),
+            iters=iters,
+        )
     logging.info(
-        f"keyed_jagged_index_select_dim1 backward time: {time * 1e3} ms, ref {time_ref * 1e3}"
+        f"keyed_jagged_index_select_dim1 backward time: {time * 1e3} ms, ref {time_ref * 1e3 if time_ref is not None else 'N/A'}"
     )
 
 

--- a/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
@@ -38,8 +38,6 @@ __global__ void index_select_scalar_cumsum_kernel(
 #ifdef USE_ROCM
   const int output_batch_size = indices.size(0);
   const int num_entries = num_batches * output_batch_size;
-  CUDA_KERNEL_ASSERT(
-      num_entries > 0 && "num_batches * output_batch_size should be > 0");
   const bool multi_block = gridDim.x > 1;
   const auto block_entries = blockIdx.x == gridDim.x - 1
       ? last_block_num_entries
@@ -119,9 +117,6 @@ __global__ void index_select_scalar_cumsum_kernel(
 
   // Load data
   acc_t local_data[1];
-  CUDA_KERNEL_ASSERT(
-      num_batches * output_batch_size > 0 &&
-      "num_batches * output_batch_size should be > 0");
   if (tid < num_batches * output_batch_size) {
     *local_data =
         input[bid * input_batch_size + indices[tid % output_batch_size]];
@@ -177,9 +172,6 @@ __global__ void keyed_jagged_index_select_dim1_kernel(
   if (tid < num_outputs) {
     // Each thread searches index position
     int index_pos;
-    CUDA_KERNEL_ASSERT(
-        num_batches * output_batch_size > 0 &&
-        "num_batches * output_batch_size should be > 0");
 
     binary_search_range(
         &index_pos,
@@ -226,9 +218,6 @@ __global__ void keyed_jagged_index_add_dim1_kernel(
   if (tid < num_inputs) {
     // Each thread searches index position
     int index_pos;
-    CUDA_KERNEL_ASSERT(
-        num_batches * input_batch_size > 0 &&
-        "num_batches * input_batch_size should be > 0");
     binary_search_range(
         &index_pos,
         &input_offsets[0],


### PR DESCRIPTION
Summary:
Remove 4 `CUDA_KERNEL_ASSERT(num_entries > 0)` checks from CUDA kernels
in keyed_jagged_index_select_dim1.cu. These assertions are redundant because
the host-side `TORCH_CHECK_VALUE` checks already validate the same conditions
before any kernel is launched:
- `TORCH_CHECK_VALUE(num_output_lengths > 0, ...)` at the function entry
- `TORCH_CHECK_VALUE(grid_size > 0, ...)`
- Forward kernel launch is additionally guarded by `if (grid_size != 0)`

The device-side assertions can never fire since the host will throw first.

Kernels affected:
- `index_select_scalar_cumsum_kernel` (ROCm path)
- `index_select_scalar_cumsum_kernel` (CUDA path)
- `keyed_jagged_index_select_dim1_kernel`
- `keyed_jagged_index_add_dim1_kernel`

Differential Revision: D98286012


