### PR TITLE
Set manual seed for fbgemm benchmark

### DIFF
--- a/fbgemm_gpu/bench/batched_unary_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/batched_unary_embeddings_benchmark.py
@@ -92,8 +92,18 @@ class MyModule(torch.nn.Module):
 @click.option("--num-tables", default=2)
 @click.option("--num-tasks", default=3)
 @click.option("--repeats", default=100)
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=False,
+    help="Use manual seed for reproduction.",
+)
 # pyre-fixme[2]: Parameter must be annotated.
-def cli(batch_size, num_tables, num_tasks, repeats) -> None:
+def cli(batch_size, num_tables, num_tasks, repeats, manual_seed) -> None:
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(42)
+        np.random.seed(42)
+
     device = torch.device("cuda", 0)
     torch.cuda.set_device(device)
     hash_sizes = list(np.random.choice(range(50, 250), size=(num_tables)))

--- a/fbgemm_gpu/bench/histogram_binning_calibration_benchmark.py
+++ b/fbgemm_gpu/bench/histogram_binning_calibration_benchmark.py
@@ -49,10 +49,20 @@ def benchmark_hbc_function(
 @click.command()
 @click.option("--iters", default=100)
 @click.option("--warmup-runs", default=2)
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=False,
+    help="Use manual seed for reproduction.",
+)
 def cli(
     iters: int,
     warmup_runs: int,
+    manual_seed: bool,
 ) -> None:
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(42)
+
     data_types = [torch.half, torch.float]
 
     total_time = {

--- a/fbgemm_gpu/bench/jagged_tensor_benchmark.py
+++ b/fbgemm_gpu/bench/jagged_tensor_benchmark.py
@@ -379,12 +379,23 @@ def bench_dense_to_jagged_1d(jten: JaggedTensor) -> None:
 @click.option("--embedding-dim", type=int, default=128)
 @click.option("--max-len", type=int, default=128)
 @click.option("--elem-type", type=str, default="half")
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=False,
+    help="Use manual seed for reproduction.",
+)
 def device(
     batch_size: int,
     embedding_dim: int,
     max_len: int,
     elem_type: str,
+    manual_seed: bool,
 ) -> None:
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(42)
+        random.seed(42)
+
     jtensor = JaggedTensor.rand_2d(batch_size, embedding_dim, max_len, elem_type)
 
     bench_jagged_2d_to_dense(jtensor)
@@ -406,13 +417,24 @@ def device(
 @click.option("--embedding-dim", type=int, default=16)
 @click.option("--max-len", type=int, default=10)
 @click.option("--elem-type", type=str, default="half")
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=False,
+    help="Use manual seed for reproduction.",
+)
 def batched_dense_vec_jagged_2d_mul(
     batch_size: int,
     h_dim: int,
     embedding_dim: int,
     max_len: int,
     elem_type: str,
+    manual_seed: bool,
 ) -> None:
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(42)
+        random.seed(42)
+
     lengths = torch.randint(2 * max_len, size=(batch_size,))  # Allow for truncation
     total_lengths = lengths.sum().item()
     offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(lengths)
@@ -448,11 +470,22 @@ def batched_dense_vec_jagged_2d_mul(
 @click.option("--batch-size", type=int, default=1024)
 @click.option("--max-len", type=int, default=10)
 @click.option("--dtype", type=str, default="float")
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=False,
+    help="Use manual seed for reproduction.",
+)
 def jagged_1d_to_truncated_values(
     batch_size: int,
     max_len: int,
     dtype: str,
+    manual_seed: bool,
 ) -> None:
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(42)
+        random.seed(42)
+
     lengths = torch.randint(2 * max_len, size=(batch_size,))  # Allow for truncation
     total_lengths = lengths.sum().item()
     torch_dtype = torch.float16 if dtype in ["half", "float16"] else torch.float32
@@ -495,10 +528,21 @@ def jagged_1d_to_truncated_values(
 @cli.command()
 @click.option("--batch-size", type=int, default=1024)
 @click.option("--max-len", type=int, default=256)
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=False,
+    help="Use manual seed for reproduction.",
+)
 def masked_select_jagged_1d(
     batch_size: int,
     max_len: int,
+    manual_seed: bool,
 ) -> None:
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(42)
+        random.seed(42)
+
     lengths = torch.randint(2 * max_len, size=(batch_size,))  # Allow for truncation
     total_lengths = int(lengths.sum().item())
     dtype = torch.long
@@ -558,6 +602,11 @@ def masked_select_jagged_1d(
 )
 @click.option("--iters", type=int, default=1000)
 @click.option("--baseline/--skip-baseline", default=True)
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=False,
+    help="Use manual seed for reproduction.",
+)
 def keyed_jagged_index_select_dim1(
     num_batches: int,
     max_seq_length: int,
@@ -571,7 +620,13 @@ def keyed_jagged_index_select_dim1(
     trace_url: str,
     iters: int,
     baseline: bool,
+    manual_seed: bool,
 ) -> None:
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(42)
+        random.seed(42)
+
     jagged_tensor_types = {
         "float": torch.float,
         "half": torch.half,
@@ -740,12 +795,23 @@ def keyed_jagged_index_select_dim1(
 @click.option("--input-batch-size", type=int, default=1024)
 @click.option("--slice-length", type=int, default=10)
 @click.option("--jagged-tensor-type", type=str, default="float")
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=False,
+    help="Use manual seed for reproduction.",
+)
 def jagged_slice_cpu(
     max_seq_length: int,
     input_batch_size: int,
     slice_length: int,
     jagged_tensor_type: str,
+    manual_seed: bool,
 ) -> None:
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(42)
+        random.seed(42)
+
     jagged_tensor_types = {
         "float": torch.float,
         "half": torch.half,
@@ -852,12 +918,23 @@ def jagged_slice_cpu(
 @click.option("--num-of-features", type=int, default=256)
 @click.option("--num-of-tensors", type=int, default=4)
 @click.option("--device", type=click.Choice(["cpu", "cuda"]), default="cuda")
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=False,
+    help="Use manual seed for reproduction.",
+)
 def permute_pooled_embs_bench(
     num_of_features: int,
     num_of_tensors: int,
     batch_size: int,
     device: str,
+    manual_seed: bool,
 ) -> None:
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(42)
+        random.seed(42)
+
     in_lengths = []
     out_lengths = []
     permute_list = []
@@ -953,14 +1030,25 @@ def permute_pooled_embs_bench(
 @click.option("--weight-dim", type=int, default=64)
 @click.option("--num-iterations", type=int, default=10)
 @click.option("--num-warmup", type=int, default=5)
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=False,
+    help="Use manual seed for reproduction.",
+)
 def jagged_acc_weights_and_counts_bench(
     num_elements: int,
     num_unique_indices: int,
     weight_dim: int,
     num_iterations: int,
     num_warmup: int,
+    manual_seed: bool,
 ) -> None:
     """Performance comparison benchmark for jagged_acc_weights_and_counts."""
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(42)
+        random.seed(42)
+
     logging.info("######## Jagged Accumulate Weights and Counts Performance ########")
 
     if not torch.cuda.is_available():

--- a/fbgemm_gpu/bench/merge_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/merge_embeddings_benchmark.py
@@ -514,6 +514,11 @@ def benchmark(  # noqa C901
 @click.option("--pooling_factor", default=25, type=int)
 @click.option("--sweep", is_flag=True, default=False)
 @click.option("--use_pitched", is_flag=True, default=False)
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=False,
+    help="Use manual seed for reproduction.",
+)
 def cli(
     all_to_one_only: bool,
     sum_reduce_to_one_only: bool,
@@ -530,7 +535,13 @@ def cli(
     pooling_factor: int,
     sweep: bool,
     use_pitched: bool,
+    manual_seed: bool,
 ) -> None:
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(42)
+        np.random.seed(42)
+
     csv_header = (
         "mode, data_type, num_ads, embedding_dimension, ads_tables, num_gpus, dst_device, all_to_one_only, "
         "number of elements (Million), number of elements per GPU (Million), throughput (billion elements per sec), "

--- a/fbgemm_gpu/bench/quantize_ops_benchmark.py
+++ b/fbgemm_gpu/bench/quantize_ops_benchmark.py
@@ -201,6 +201,11 @@ def bench_spectrum(
 @click.option("--enable-trace-profile", is_flag=True, default=False)
 @click.option("--trace-cuda-only", is_flag=True, default=False)
 @click.option("--power-input-size", default=0, help="power of the input size")
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=False,
+    help="Use manual seed for reproduction.",
+)
 def bench_mx4(
     flush_gpu_cache_size_mb: int,
     iters: int,
@@ -210,6 +215,7 @@ def bench_mx4(
     enable_trace_profile: bool,
     trace_cuda_only: bool,
     power_input_size: int,
+    manual_seed: bool,
 ) -> None:
     """
     This function benchmarks performance of MX4 and FP8 quant/dequantization ops.
@@ -234,6 +240,11 @@ def bench_mx4(
     Returns:
         None
     """
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(42)
+        random.seed(42)
+
     assert group_size > 0, "group_size needs to be > 0"
     assert group_size % 32 == 0, "group_size needs to be multiple of 32"
     assert torch.cuda.is_available(), "NO GPUs available"
@@ -376,13 +387,24 @@ def bench_mx4(
 @click.option("--num-columns", default=-1)
 @click.option("--num-rows", default=-1)
 @click.option("--warmup-runs", default=2)
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=False,
+    help="Use manual seed for reproduction.",
+)
 def bench(
     flush_gpu_cache_size_mb: int,
     iters: int,
     num_columns: int,
     num_rows: int,
     warmup_runs: int,
+    manual_seed: bool,
 ) -> None:
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(42)
+        random.seed(42)
+
     if num_columns == -1 or num_rows == -1:
         bench_spectrum(
             flush_gpu_cache_size_mb=flush_gpu_cache_size_mb,
@@ -407,6 +429,11 @@ def bench(
 @click.option("--min_dim", default=1)
 @click.option("--max_dim", default=128)
 @click.option("--warmup-runs", default=2)
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=True,
+    help="Use manual seed for reproduction.",
+)
 def mixdim(
     flush_gpu_cache_size_mb: int,
     iters: int,
@@ -415,11 +442,16 @@ def mixdim(
     min_dim: int,
     max_dim: int,
     warmup_runs: int,
+    manual_seed: bool,
 ) -> None:
     if not torch.cuda.is_available():
         raise RuntimeError("CUDA is not available.")
 
-    random.seed(0)
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(0)
+        random.seed(0)
+
     table_dims = [
         random.randint(min_dim, max_dim) * 8 for _ in range(num_tables)
     ]  # assume table dimensions are multiples of 8

--- a/fbgemm_gpu/bench/repeat_arange_benchmark.py
+++ b/fbgemm_gpu/bench/repeat_arange_benchmark.py
@@ -216,15 +216,25 @@ def cli() -> None:
     default=100,
     help="Number of iterations for timing",
 )
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=False,
+    help="Use manual seed for reproduction.",
+)
 def bench_repeat_arange(
     batch_sizes: str,
     max_lengths: str,
     device: str,
     iters: int,
+    manual_seed: bool,
 ) -> None:
     """
     Run repeat_arange benchmarks across different configurations.
     """
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(42)
+
     batch_size_list = [int(x) for x in batch_sizes.split(",")]
     max_length_list = [int(x) for x in max_lengths.split(",")]
 
@@ -251,10 +261,19 @@ def bench_repeat_arange(
     default="cuda",
     help="Device to run benchmark on (cpu or cuda)",
 )
-def bench_repeat_arange_quick(device: str) -> None:
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=False,
+    help="Use manual seed for reproduction.",
+)
+def bench_repeat_arange_quick(device: str, manual_seed: bool) -> None:
     """
     Quick benchmark with representative configurations.
     """
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(42)
+
     print("\n" + "=" * 70)
     print("REPEAT_ARANGE QUICK BENCHMARK")
     print("=" * 70 + "\n")
@@ -282,10 +301,19 @@ def bench_repeat_arange_quick(device: str) -> None:
     default="cuda",
     help="Device to run benchmark on (cpu or cuda)",
 )
-def bench_repeat_arange_scaling(device: str) -> None:
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=False,
+    help="Use manual seed for reproduction.",
+)
+def bench_repeat_arange_scaling(device: str, manual_seed: bool) -> None:
     """
     Benchmark scaling behavior with increasing batch sizes.
     """
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(42)
+
     print("\n" + "=" * 70)
     print("REPEAT_ARANGE SCALING BENCHMARK")
     print("=" * 70 + "\n")

--- a/fbgemm_gpu/bench/sparse_ops_benchmark.py
+++ b/fbgemm_gpu/bench/sparse_ops_benchmark.py
@@ -13,7 +13,7 @@ import math
 import os
 import random
 from contextlib import nullcontext
-from typing import Callable
+from typing import Callable, Optional
 
 import click
 import fbgemm_gpu
@@ -342,6 +342,27 @@ def jagged_index_select_2d_bench(
     type=str,
     default="group_index_select_2d_{phase}_trace_{ospid}.json",
 )
+@click.option(
+    "--input-dims",
+    type=str,
+    default=None,
+    help="JSON list of [num_rows, row_size] per group, e.g. '[[27330,96],[4914,96]]'. "
+    "When provided, --row-size, --batch-size, --unique-batch-size, and --num-groups are ignored.",
+)
+@click.option(
+    "--input-strides",
+    type=str,
+    default=None,
+    help="JSON list of [stride0, stride1] per group. Defaults to contiguous strides if not provided.",
+)
+@click.option(
+    "--index-dim", type=int, default=None, help="Number of indices per group."
+)
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=True,
+    help="Use manual seed for reproduction.",
+)
 def group_index_select_2d_bench(
     row_size: int,
     batch_size: int,
@@ -352,6 +373,10 @@ def group_index_select_2d_bench(
     device: str,
     export_trace: bool,
     trace_url: str,
+    input_dims: Optional[str],
+    input_strides: Optional[str],
+    index_dim: Optional[int],
+    manual_seed: bool,
 ) -> None:
     # Input validation (backported from tritonbench implementation)
     if unique_batch_size > batch_size:
@@ -359,6 +384,11 @@ def group_index_select_2d_bench(
             f"unique_batch_size ({unique_batch_size}) must be <= batch_size "
             f"({batch_size})"
         )
+
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(42)
+        np.random.seed(42)
 
     def gen_inverse_index(curr_size: int, final_size: int) -> np.array:
         inverse_index = list(range(curr_size))

--- a/fbgemm_gpu/bench/stride_gemm_benchmark.py
+++ b/fbgemm_gpu/bench/stride_gemm_benchmark.py
@@ -36,6 +36,11 @@ def cli() -> None:
 @click.option("--n", default=100)
 @click.option("--k", default=256)
 @click.option("--num_warmups", default=2)
+@click.option(
+    "--manual-seed/--skip-manual-seed",
+    default=False,
+    help="Use manual seed for reproduction.",
+)
 def stride_gemm(
     flush_gpu_cache_size_mb: int,
     iters: int,
@@ -44,7 +49,12 @@ def stride_gemm(
     n: int,
     k: int,
     num_warmups: int,
+    manual_seed: bool,
 ) -> None:
+    # set manual seed for reproducibility
+    if manual_seed:
+        torch.manual_seed(42)
+
     A = torch.rand(m, batch_size, k).half().cuda()
     B = torch.rand(batch_size, k, n).half().cuda()
     bias = torch.rand(batch_size, n).half().cuda()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2507

Add `--manual-seed/--skip-manual-seed` click option to all fbgemm_gpu benchmarks for reproducibility. When enabled, sets `torch.manual_seed()` and the relevant random seeds (`np.random.seed()`, `random.seed()`) before data generation.

For benchmarks that did not previously set a seed, the option defaults to `False` (no behavior change). For benchmarks that already had a seed (e.g., `quantize_ops mixdim` had `random.seed(0)`), the option defaults to `True` and uses the same seed value, preserving existing behavior while also adding `torch.manual_seed()`.

Files modified:
- `batched_unary_embeddings_benchmark.py` (default=False)
- `histogram_binning_calibration_benchmark.py` (default=False)
- `jagged_tensor_benchmark.py` - 8 subcommands (default=False)
- `merge_embeddings_benchmark.py` (default=False)
- `quantize_ops_benchmark.py` - `bench_mx4` and `bench` (default=False), `mixdim` (default=True, seed=0)
- `repeat_arange_benchmark.py` - 3 subcommands (default=False)
- `stride_gemm_benchmark.py` (default=False)
- `sparse_ops_benchmark.py` - already in prior commit (default=True, seed=42)

Reviewed By: q10

Differential Revision: D98332549


