### PR TITLE
Fix autovec EmbeddingSpMDMNBit to handle pruned (-1) indices (#5543)

### DIFF
--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -464,6 +464,10 @@ FBGEMM_API bool is_autovec_forced();
 FBGEMM_API bool is_asmjit_disabled();
 FBGEMM_API bool is_stats_enabled();
 
+FBGEMM_API void set_autovec_disabled(bool val);
+FBGEMM_API void set_autovec_forced(bool val);
+FBGEMM_API void set_asmjit_disabled(bool val);
+
 /**
  * @brief A function to check if the input parameter in the nbit CPU TBE kernel
  * is valid.

--- a/src/EmbeddingSpMDMAutovec.cc
+++ b/src/EmbeddingSpMDMAutovec.cc
@@ -153,10 +153,6 @@ static bool ALWAYS_INLINE EmbeddingSpMDM8Bit_autovec(
   if (data_size < 0) {
     return false;
   }
-  if constexpr (isOutput8bit) {
-    assert(input_stride == output_stride);
-  }
-
   constexpr int64_t CACHE_LINE_SIZE = 64;
   constexpr int64_t MAX_INITIAL_PREFETCH_ROWS = 16;
   const int64_t prefetch_stride =
@@ -183,6 +179,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDM8Bit_autovec(
   }
 
   if (no_bag) {
+    const int64_t copy_width = std::min(output_stride, input_stride);
     for (int64_t m = 0; m < output_size; ++m) {
       const IndexType idx = indices[m];
 
@@ -192,7 +189,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDM8Bit_autovec(
 
       const uint8_t* input_row_base = input + input_stride * idx;
       if constexpr (isOutput8bit) {
-        memcpy(out, input_row_base, sizeof(uint8_t) * input_stride);
+        memcpy(out, input_row_base, sizeof(uint8_t) * copy_width);
       } else {
         float scale = NAN;
         float bias = NAN;
@@ -275,10 +272,11 @@ static bool ALWAYS_INLINE EmbeddingSpMDM8Bit_autovec(
         do_prefetch(prefetch_addr + offset, 1);
       }
       if (idx < 0 || idx >= data_size) {
-        if (!scale_bias_last && idx == -1) {
-          // When scale_bias_last == false, assume this is for table batched
-          // embedding (TBE) that can get -1 for pruned rows.
-          weights_addr++;
+        // Skip pruned rows.
+        if (idx == -1 && !scale_bias_last) {
+          if (weights_addr != nullptr) {
+            weights_addr++;
+          }
           continue;
         }
         return false;
@@ -451,6 +449,13 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBit_autovec(
     for (; current < end; ++current) {
       int64_t idx = indices[current];
       if (idx < 0 || idx >= data_size) {
+        // Skip pruned rows.
+        if (idx == -1 && !scale_bias_last) {
+          if (weights_addr != nullptr) {
+            weights_addr++;
+          }
+          continue;
+        }
         return false;
       }
       int64_t prefetch_idx =
@@ -589,8 +594,11 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBitRowWiseSparse_autovec(
         return false;
       }
       int64_t idx = compressed_indices_table[uncompressed_idx];
+      // Skip pruned rows.
       if (idx == -1) {
-        weights_addr++;
+        if (weights_addr != nullptr) {
+          weights_addr++;
+        }
         continue;
       }
 
@@ -621,12 +629,18 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBitRowWiseSparse_autovec(
           buf[j + 1] = std::fma(scale, quantized2, buf[j + 1] + bias);
         }
 #endif
-        for (; j < block_size; j += 2) {
+        for (; j < block_size - (block_size % 2); j += 2) {
           uint8_t tmp = *input_row++;
           float quantized1 = float(tmp & 0xf);
           float quantized2 = float(tmp >> 4);
           buf[j] = std::fma(scale, quantized1, buf[j] + bias);
           buf[j + 1] = std::fma(scale, quantized2, buf[j + 1] + bias);
+        }
+        for (; j < block_size; ++j) {
+          uint8_t quantized = input_row_base[j / num_elem_per_byte] >>
+              ((j % num_elem_per_byte) * bit_rate);
+          quantized &= (1 << bit_rate) - 1;
+          buf[j] = std::fma(scale, float(quantized), buf[j] + bias);
         }
       } else if (bit_rate == 2) {
         int64_t j = 0;
@@ -644,7 +658,7 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBitRowWiseSparse_autovec(
           buf[j + 3] = std::fma(scale, quantized4, buf[j + 3] + bias);
         }
 #endif
-        for (; j < block_size; j += 4) {
+        for (; j < block_size - (block_size % 4); j += 4) {
           uint8_t tmp = *input_row++;
           float quantized1 = float(tmp & 0x3);
           float quantized2 = float((tmp & 0xC) >> 2);
@@ -654,6 +668,12 @@ static bool ALWAYS_INLINE EmbeddingSpMDMNBitRowWiseSparse_autovec(
           buf[j + 1] = std::fma(scale, quantized2, buf[j + 1] + bias);
           buf[j + 2] = std::fma(scale, quantized3, buf[j + 2] + bias);
           buf[j + 3] = std::fma(scale, quantized4, buf[j + 3] + bias);
+        }
+        for (; j < block_size; ++j) {
+          uint8_t quantized = input_row_base[j / num_elem_per_byte] >>
+              ((j % num_elem_per_byte) * bit_rate);
+          quantized &= (1 << bit_rate) - 1;
+          buf[j] = std::fma(scale, float(quantized), buf[j] + bias);
         }
       }
     }
@@ -938,8 +958,11 @@ static bool ALWAYS_INLINE EmbeddingSpMDMRowWiseSparse_autovec(
           return false;
         }
         IndexType idx = compressed_indices_table[uncompressed_idx];
+        // Skip pruned rows.
         if (idx == -1) {
-          weights_addr++;
+          if (weights_addr != nullptr) {
+            weights_addr++;
+          }
           continue;
         }
         // if (idx < 0 || idx >= compressed_data_size) {
@@ -1011,8 +1034,11 @@ static bool ALWAYS_INLINE EmbeddingSpMDMRowWiseSparse_autovec(
           return false;
         }
         IndexType idx = compressed_indices_table[uncompressed_idx];
+        // Skip pruned rows.
         if (idx == -1) {
-          weights_addr++;
+          if (weights_addr != nullptr) {
+            weights_addr++;
+          }
           continue;
         }
 

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -793,40 +793,54 @@ bool is_radix_sort_accelerated_with_openmp() {
 #endif
 }
 
-bool is_autovec_disabled() {
-  static bool res;
-  static bool called_once = false;
-  if (called_once) {
-    return res;
-  }
-  called_once = true;
-  char* env_val = std::getenv("FBGEMM_NO_AUTOVEC");
-  res = (env_val != nullptr);
+namespace {
+bool& autovec_disabled_val() {
+  static bool res = [] {
+    char* env_val = std::getenv("FBGEMM_NO_AUTOVEC");
+    return env_val != nullptr;
+  }();
   return res;
+}
+
+bool& autovec_forced_val() {
+  static bool res = [] {
+    char* env_val = std::getenv("FBGEMM_FORCE_AUTOVEC");
+    return env_val != nullptr;
+  }();
+  return res;
+}
+
+bool& asmjit_disabled_val() {
+  static bool res = [] {
+    char* env_val = std::getenv("FBGEMM_NO_ASMJIT");
+    return env_val != nullptr;
+  }();
+  return res;
+}
+} // namespace
+
+bool is_autovec_disabled() {
+  return autovec_disabled_val();
 }
 
 bool is_autovec_forced() {
-  static bool res;
-  static bool called_once = false;
-  if (called_once) {
-    return res;
-  }
-  called_once = true;
-  char* env_val = std::getenv("FBGEMM_FORCE_AUTOVEC");
-  res = (env_val != nullptr);
-  return res;
+  return autovec_forced_val();
 }
 
 bool is_asmjit_disabled() {
-  static bool res;
-  static bool called_once = false;
-  if (called_once) {
-    return res;
-  }
-  called_once = true;
-  char* env_val = std::getenv("FBGEMM_NO_ASMJIT");
-  res = (env_val != nullptr);
-  return res;
+  return asmjit_disabled_val();
+}
+
+void set_autovec_disabled(bool val) {
+  autovec_disabled_val() = val;
+}
+
+void set_autovec_forced(bool val) {
+  autovec_forced_val() = val;
+}
+
+void set_asmjit_disabled(bool val) {
+  asmjit_disabled_val() = val;
 }
 
 bool is_stats_enabled() {

--- a/test/EmbeddingSpMDM8BitTest.cc
+++ b/test/EmbeddingSpMDM8BitTest.cc
@@ -46,12 +46,12 @@ static vector<int> prefetch_distances{0, 16, 1000000};
 
 namespace {
 
-class Fused8BitRowwiseEmbeddingLookupTest
-    : public testing::TestWithParam<tuple<
-          int,
-          EmbeddingSpMDMWeightChoice,
-          EmbeddingSpMDMCornerCase,
-          EmbeddingSpMDMOutputDtypeChoice>> {};
+class Fused8BitRowwiseEmbeddingLookupTest : public testing::TestWithParam<tuple<
+                                                int,
+                                                EmbeddingSpMDMWeightChoice,
+                                                EmbeddingSpMDMCornerCase,
+                                                EmbeddingSpMDMOutputDtypeChoice,
+                                                EmbeddingSpMDMKernelChoice>> {};
 }; // namespace
 
 INSTANTIATE_TEST_SUITE_P(
@@ -68,7 +68,8 @@ INSTANTIATE_TEST_SUITE_P(
             EMPTY_INDICES,
             OUT_OF_BOUND_INDICES,
             UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM),
-        ::testing::Values(FLOAT, FLOAT16, BFLOAT16)));
+        ::testing::Values(FLOAT, FLOAT16, BFLOAT16),
+        ::testing::Values(DISPATCH_DEFAULT, DISPATCH_AUTOVEC)));
 
 TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
   vector<vector<int>> inputs(GetInputs_());
@@ -83,7 +84,9 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
   bool use_offsets = bool_dist(generator);
   bool scale_bias_last = bool_dist(generator);
 
-  auto [prefetch, weight_choice, corner_case, out_type] = GetParam();
+  auto [prefetch, weight_choice, corner_case, out_type, kernel_choice] =
+      GetParam();
+  ScopedKernelOverride kernel_override(kernel_choice);
   bool is_wt_positional = weight_choice == POSITIONAL_WEIGHTED;
   bool use_weight = weight_choice != UNWEIGHTED;
 
@@ -335,7 +338,9 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
   bool use_offsets = bool_dist(generator);
   bool scale_bias_last = bool_dist(generator);
 
-  auto [prefetch, weight_choice, corner_case, out_type] = GetParam();
+  auto [prefetch, weight_choice, corner_case, out_type, kernel_choice] =
+      GetParam();
+  ScopedKernelOverride kernel_override(kernel_choice);
   bool is_wt_positional = weight_choice == POSITIONAL_WEIGHTED;
   bool use_weight = weight_choice != UNWEIGHTED;
 

--- a/test/EmbeddingSpMDMNBitTest.cc
+++ b/test/EmbeddingSpMDMNBitTest.cc
@@ -54,7 +54,8 @@ class FusedNBitRowwiseEmbeddingLookupTest : public testing::TestWithParam<tuple<
                                                 int,
                                                 EmbeddingSpMDMWeightChoice,
                                                 EmbeddingSpMDMCornerCase,
-                                                EmbeddingSpMDMDtypeChoice>> {};
+                                                EmbeddingSpMDMDtypeChoice,
+                                                EmbeddingSpMDMKernelChoice>> {};
 }; // namespace
 
 INSTANTIATE_TEST_SUITE_P(
@@ -72,7 +73,8 @@ INSTANTIATE_TEST_SUITE_P(
             EMPTY_INDICES,
             OUT_OF_BOUND_INDICES,
             UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM),
-        ::testing::Values(FLOAT, FLOAT16, BFLOAT16)));
+        ::testing::Values(FLOAT, FLOAT16, BFLOAT16),
+        ::testing::Values(DISPATCH_DEFAULT, DISPATCH_AUTOVEC)));
 
 TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
   vector<vector<int>> inputs(GetInputs_());
@@ -91,7 +93,10 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
   EmbeddingSpMDMWeightChoice weight_choice{};
   EmbeddingSpMDMCornerCase corner_case{};
   EmbeddingSpMDMDtypeChoice out_type{};
-  tie(bit_rate, prefetch, weight_choice, corner_case, out_type) = GetParam();
+  EmbeddingSpMDMKernelChoice kernel_choice{};
+  tie(bit_rate, prefetch, weight_choice, corner_case, out_type, kernel_choice) =
+      GetParam();
+  ScopedKernelOverride kernel_override(kernel_choice);
   bool is_wt_positional = weight_choice == POSITIONAL_WEIGHTED;
   bool use_weight = weight_choice != UNWEIGHTED;
   bool is_bf16_out = out_type == BFLOAT16;
@@ -394,7 +399,10 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
   EmbeddingSpMDMWeightChoice weight_choice{};
   EmbeddingSpMDMCornerCase corner_case{};
   EmbeddingSpMDMDtypeChoice out_type{};
-  tie(bit_rate, prefetch, weight_choice, corner_case, out_type) = GetParam();
+  EmbeddingSpMDMKernelChoice kernel_choice{};
+  tie(bit_rate, prefetch, weight_choice, corner_case, out_type, kernel_choice) =
+      GetParam();
+  ScopedKernelOverride kernel_override(kernel_choice);
   bool is_wt_positional = weight_choice == POSITIONAL_WEIGHTED;
   bool use_weight = weight_choice != UNWEIGHTED;
 

--- a/test/EmbeddingSpMDMTest.cc
+++ b/test/EmbeddingSpMDMTest.cc
@@ -51,11 +51,14 @@ class EmbeddingSpMDMTest : public testing::TestWithParam<tuple<
                                EmbeddingSpMDMWeightChoice,
                                EmbeddingSpMDMCornerCase,
                                EmbeddingSpMDMInputDtypeChoice,
-                               EmbeddingSpMDMOutputDtypeChoice>> {};
+                               EmbeddingSpMDMOutputDtypeChoice,
+                               EmbeddingSpMDMKernelChoice>> {};
 
-class rowwiseSparseEmbeddingSpMDMTest
-    : public testing::TestWithParam<
-          tuple<int, EmbeddingSpMDMWeightChoice, EmbeddingSpMDMCornerCase>> {};
+class rowwiseSparseEmbeddingSpMDMTest : public testing::TestWithParam<tuple<
+                                            int,
+                                            EmbeddingSpMDMWeightChoice,
+                                            EmbeddingSpMDMCornerCase,
+                                            EmbeddingSpMDMKernelChoice>> {};
 
 class IndexRemapTest
     : public testing::TestWithParam<tuple<int, int, int, bool, bool>> {};
@@ -78,7 +81,8 @@ INSTANTIATE_TEST_SUITE_P(
             OUT_OF_BOUND_INDICES,
             UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM),
         ::testing::Values(FLOAT, FLOAT16, BFLOAT16),
-        ::testing::Values(FLOAT, FLOAT16, BFLOAT16)));
+        ::testing::Values(FLOAT, FLOAT16, BFLOAT16),
+        ::testing::Values(DISPATCH_DEFAULT, DISPATCH_AUTOVEC)));
 
 INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
@@ -93,7 +97,8 @@ INSTANTIATE_TEST_SUITE_P(
             NONE,
             EMPTY_INDICES,
             OUT_OF_BOUND_INDICES,
-            UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM)));
+            UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM),
+        ::testing::Values(DISPATCH_DEFAULT, DISPATCH_AUTOVEC)));
 
 INSTANTIATE_TEST_SUITE_P(
     InstantiationName,
@@ -118,7 +123,10 @@ TEST_P(EmbeddingSpMDMTest, basicTest) {
   bool use_offsets = bool_dist(generator);
   bool use_output_input_stride = bool_dist(generator);
   bool test_thread_local = bool_dist(generator);
-  auto [prefetch, weight_choice, corner_case, in_type, out_type] = GetParam();
+  auto
+      [prefetch, weight_choice, corner_case, in_type, out_type, kernel_choice] =
+          GetParam();
+  ScopedKernelOverride kernel_override(kernel_choice);
   bool is_wt_positional = weight_choice == POSITIONAL_WEIGHTED;
   bool use_weight = weight_choice != UNWEIGHTED;
   bool isFp16 = in_type == FLOAT16;
@@ -443,7 +451,9 @@ TEST_P(EmbeddingSpMDMTest, noBagUint8Test) {
   bool isIndex64b = bool_dist(generator);
   bool isOffset64b = bool_dist(generator);
   bool use_offsets = bool_dist(generator);
-  auto [prefetch, weight_choice, corner_case, _tmp1, _tmp2] = GetParam();
+  auto [prefetch, weight_choice, corner_case, _tmp1, _tmp2, kernel_choice] =
+      GetParam();
+  ScopedKernelOverride kernel_override(kernel_choice);
 
   // Fix the input and output types to be uint8_t
   const auto in_type = QINT8, out_type = QINT8;
@@ -662,7 +672,8 @@ TEST_P(rowwiseSparseEmbeddingSpMDMTest, rowwiseSparseTest) {
   bool normalize_by_lengths = bool_dist(generator);
   bool use_offsets = bool_dist(generator);
   bool is_output_float = bool_dist(generator);
-  auto [prefetch, weight_choice, corner_case] = GetParam();
+  auto [prefetch, weight_choice, corner_case, kernel_choice] = GetParam();
+  ScopedKernelOverride kernel_override(kernel_choice);
   bool is_wt_positional = weight_choice == POSITIONAL_WEIGHTED;
   bool use_weight = weight_choice != UNWEIGHTED;
 

--- a/test/EmbeddingSpMDMTestUtils.h
+++ b/test/EmbeddingSpMDMTestUtils.h
@@ -11,7 +11,41 @@
 #include <cstdint>
 #include <vector>
 
+#include "fbgemm/Utils.h"
+
 namespace fbgemm {
+
+enum EmbeddingSpMDMKernelChoice {
+  // Use the default dispatch (asmjit on x86, autovec on ARM)
+  DISPATCH_DEFAULT,
+  // Force the autovec implementation
+  DISPATCH_AUTOVEC,
+};
+
+// RAII guard to temporarily override kernel dispatch settings.
+// Forces the dispatch to use autovec when choice == DISPATCH_AUTOVEC,
+// and restores the original settings on destruction.
+class ScopedKernelOverride {
+ public:
+  explicit ScopedKernelOverride(EmbeddingSpMDMKernelChoice choice)
+      : prev_autovec_forced_(is_autovec_forced()),
+        prev_asmjit_disabled_(is_asmjit_disabled()) {
+    if (choice == DISPATCH_AUTOVEC) {
+      set_autovec_forced(true);
+      set_asmjit_disabled(true);
+    }
+  }
+  ~ScopedKernelOverride() {
+    set_autovec_forced(prev_autovec_forced_);
+    set_asmjit_disabled(prev_asmjit_disabled_);
+  }
+  ScopedKernelOverride(const ScopedKernelOverride&) = delete;
+  ScopedKernelOverride& operator=(const ScopedKernelOverride&) = delete;
+
+ private:
+  bool prev_autovec_forced_;
+  bool prev_asmjit_disabled_;
+};
 
 enum EmbeddingSpMDMCornerCase {
   NONE,


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2510

Fix Bugs:
- When scale_bias_last=false (TBE mode), indices can be -1 to indicate pruned rows that should be skipped.
- Fix `EmbeddingSpMDMNBitRowWiseSparse_autovec` overflow when `block_size` is not a multiple of 2/4 (contrary to the other functions this one writes directly into `out` rather than using a temporary buffer with rounded-up size.
- Allow `GenerateEmbeddingSpMDMWithStrides_autovec` with `input_stride != output_stride` to match reference implementation.
- Use `if (weights_addr != nullptr) weights_addr++;` pattern instead of plain `weights_addr++`: Incrementing a `nullptr` is technically UB (though works fine in practice). Expecting branch to not affect perf so rather appease UBSAN.

Improved Testing:
- Add an option to force autovectorized code paths programmatically.
- Enabled UBSAN + ASAN testing in fbcode
- Have tests check "normal" TBE disaptch and forced autovectorized dispatch.

Note for people familiar with "no_bag" variants (I don't have context): There is  > vs >= bounds check difference between no_bag and bag paths that exists in both reference and autovec variant.

Reviewed By: beginner137

Differential Revision: D98356088
