### PR TITLE
Fix int32 overflow in keyed_jagged_index_select_dim1

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/binary_search_range.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/binary_search_range.cuh
@@ -10,24 +10,24 @@
 
 namespace fbgemm_gpu {
 
-template <typename scalar_t>
+template <typename scalar_t, typename found_t, typename index_t>
 __device__ __forceinline__ void binary_search_range(
-    int* found,
+    found_t* found,
     const scalar_t* arr,
     const scalar_t target,
-    const int num_entries) {
-  const int last_entry = num_entries - 1;
-  int start = 0, end = last_entry;
-  int found_ = -1;
+    const index_t num_entries) {
+  const index_t last_entry = num_entries - 1;
+  index_t start = 0, end = last_entry;
+  found_t found_ = -1;
   while (start <= end) {
-    int mid = start + (end - start) / 2;
+    index_t mid = start + (end - start) / 2;
     scalar_t mid_offset = arr[mid];
     if (target == mid_offset) {
       if (mid != last_entry && target != arr[last_entry]) {
         // Do linear scan in case of duplicate data (We assume that the
         // number of duplicates is small.  This can we very bad if the
         // number of duplicates is large)
-        for (int i = mid + 1; i < num_entries; i++) {
+        for (index_t i = mid + 1; i < num_entries; i++) {
           if (target != arr[i]) {
             found_ = i;
             break;

--- a/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
@@ -20,8 +20,8 @@ template <
     int MAX_ENTRIES_PER_BLOCK,
     int ENTRIES_PER_THREAD>
 __global__ void index_select_scalar_cumsum_kernel(
-    pta::PackedTensorAccessor32<scalar_t, 1, at::RestrictPtrTraits> output,
-    pta::PackedTensorAccessor32<acc_t, 1, at::RestrictPtrTraits> output_cumsum,
+    pta::PackedTensorAccessor64<scalar_t, 1, at::RestrictPtrTraits> output,
+    pta::PackedTensorAccessor64<acc_t, 1, at::RestrictPtrTraits> output_cumsum,
     const pta::PackedTensorAccessor32<scalar_t, 1, at::RestrictPtrTraits> input,
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         indices,
@@ -37,14 +37,15 @@ __global__ void index_select_scalar_cumsum_kernel(
 // ROCm path
 #ifdef USE_ROCM
   const int output_batch_size = indices.size(0);
-  const int num_entries = num_batches * output_batch_size;
+  const int64_t num_entries =
+      static_cast<int64_t>(num_batches) * output_batch_size;
   const bool multi_block = gridDim.x > 1;
   const auto block_entries = blockIdx.x == gridDim.x - 1
       ? last_block_num_entries
       : MAX_ENTRIES_PER_BLOCK;
   const auto block_entry_start = blockIdx.x * MAX_ENTRIES_PER_BLOCK;
-  const int remaining_entries = num_entries - block_entry_start;
-  const int num_entries_per_block = remaining_entries > 0
+  const auto remaining_entries = num_entries - block_entry_start;
+  const auto num_entries_per_block = remaining_entries > 0
       ? (remaining_entries < block_entries ? remaining_entries : block_entries)
       : 0;
 
@@ -53,11 +54,11 @@ __global__ void index_select_scalar_cumsum_kernel(
 
 #pragma unroll
   for (int i = 0; i < ENTRIES_PER_THREAD; ++i) {
-    const int entry = base_entry + i;
+    const auto entry = base_entry + i;
     if (entry < num_entries) {
-      const int bid = entry / output_batch_size;
-      const int idx_in_batch = entry - bid * output_batch_size;
-      const int bid_base = bid * input_batch_size;
+      const auto bid = entry / output_batch_size;
+      const auto idx_in_batch = entry - bid * output_batch_size;
+      const auto bid_base = bid * input_batch_size;
       const index_t sel_idx = indices[idx_in_batch];
       local_data[i] = __builtin_nontemporal_load(&input[bid_base + sel_idx]);
       output[entry] = local_data[i];
@@ -74,7 +75,7 @@ __global__ void index_select_scalar_cumsum_kernel(
     if (base_entry < num_entries) {
 #pragma unroll
       for (int i = 0; i < ENTRIES_PER_THREAD; ++i) {
-        const int entry = base_entry + i;
+        const auto entry = base_entry + i;
         if (entry < num_entries) {
           output_cumsum[entry] = local_data[i];
         }
@@ -99,7 +100,7 @@ __global__ void index_select_scalar_cumsum_kernel(
   if (base_entry < num_entries) {
 #pragma unroll
     for (int i = 0; i < ENTRIES_PER_THREAD; ++i) {
-      const int entry = base_entry + i;
+      const auto entry = base_entry + i;
       if (entry < num_entries) {
         output_cumsum[entry] = local_data[i];
       }
@@ -117,7 +118,9 @@ __global__ void index_select_scalar_cumsum_kernel(
 
   // Load data
   acc_t local_data[1];
-  if (tid < num_batches * output_batch_size) {
+  // assertion to check overflow is done in host
+  int64_t num_entries = static_cast<int64_t>(num_batches) * output_batch_size;
+  if (tid < num_entries) {
     *local_data =
         input[bid * input_batch_size + indices[tid % output_batch_size]];
     output[tid] = *local_data;
@@ -138,7 +141,7 @@ __global__ void index_select_scalar_cumsum_kernel(
       1);
 
   // Store data
-  if (tid < num_batches * output_batch_size) {
+  if (tid < num_entries) {
     output_cumsum[tid] = *local_data;
   }
 #endif
@@ -149,7 +152,8 @@ template <
     typename index_t,
     typename offset_t,
     typename weight_t,
-    bool has_weights>
+    bool has_weights,
+    typename entry_t>
 __global__ void keyed_jagged_index_select_dim1_kernel(
     pta::PackedTensorAccessor64<scalar_t, 1, at::RestrictPtrTraits> output,
     pta::PackedTensorAccessor64<weight_t, 1, at::RestrictPtrTraits>
@@ -161,7 +165,7 @@ __global__ void keyed_jagged_index_select_dim1_kernel(
         input_offsets,
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         indices,
-    const pta::PackedTensorAccessor32<offset_t, 1, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor64<offset_t, 1, at::RestrictPtrTraits>
         output_offsets,
     const int num_batches,
     const int input_batch_size) {
@@ -170,14 +174,15 @@ __global__ void keyed_jagged_index_select_dim1_kernel(
   const int64_t num_outputs = output.size(0);
 
   if (tid < num_outputs) {
-    // Each thread searches index position
-    int index_pos;
+    entry_t index_pos;
+    const entry_t num_entries =
+        static_cast<entry_t>(num_batches) * output_batch_size;
 
     binary_search_range(
         &index_pos,
         &output_offsets[0],
         static_cast<offset_t>(tid),
-        num_batches * output_batch_size);
+        num_entries);
 
     const offset_t rel_index =
         tid - (index_pos == 0 ? 0 : output_offsets[index_pos - 1]);
@@ -199,15 +204,19 @@ __global__ void keyed_jagged_index_select_dim1_kernel(
   }
 }
 
-template <typename scalar_t, typename index_t, typename offset_t>
+template <
+    typename scalar_t,
+    typename index_t,
+    typename offset_t,
+    typename entry_t>
 __global__ void keyed_jagged_index_add_dim1_kernel(
     pta::PackedTensorAccessor64<scalar_t, 1, at::RestrictPtrTraits> output,
     const pta::PackedTensorAccessor64<scalar_t, 1, at::RestrictPtrTraits> input,
-    const pta::PackedTensorAccessor32<offset_t, 1, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor64<offset_t, 1, at::RestrictPtrTraits>
         input_offsets,
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         indices,
-    const pta::PackedTensorAccessor32<offset_t, 1, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor64<offset_t, 1, at::RestrictPtrTraits>
         output_offsets,
     const int num_batches,
     const int output_batch_size) {
@@ -216,13 +225,11 @@ __global__ void keyed_jagged_index_add_dim1_kernel(
   const int64_t num_inputs = input.size(0);
 
   if (tid < num_inputs) {
-    // Each thread searches index position
-    int index_pos;
+    entry_t index_pos;
+    const entry_t num_entries =
+        static_cast<entry_t>(num_batches) * input_batch_size;
     binary_search_range(
-        &index_pos,
-        &input_offsets[0],
-        static_cast<offset_t>(tid),
-        num_batches * input_batch_size);
+        &index_pos, &input_offsets[0], static_cast<offset_t>(tid), num_entries);
 
     const offset_t rel_index =
         tid - (index_pos == 0 ? 0 : input_offsets[index_pos - 1]);
@@ -259,7 +266,8 @@ class KeyedJaggedIndexSelectDim1GPUOp
 
     const auto batch_size = _batch_size.guard_int(__FILE__, __LINE__);
     const int num_batches = lengths.numel() / batch_size;
-    const int num_output_lengths = num_batches * indices.numel();
+    const int64_t num_output_lengths =
+        static_cast<int64_t>(num_batches) * indices.numel();
     const int MAX_CUMSUM_ENTRIES_PER_BLOCK = 256;
     TORCH_CHECK_VALUE(
         num_output_lengths > 0,
@@ -347,8 +355,8 @@ class KeyedJaggedIndexSelectDim1GPUOp
                             MAX_CUMSUM_ENTRIES_PER_BLOCK,
                             0,
                             at::cuda::getCurrentCUDAStream(),
-                            PTA_B(output_lengths, length_t, 1, 32),
-                            PTA_B(output_offsets, offset_t, 1, 32),
+                            PTA_B(output_lengths, length_t, 1, 64),
+                            PTA_B(output_offsets, offset_t, 1, 64),
                             PTA_B(lengths, length_t, 1, 32),
                             PTA_B(indices, index_t, 1, 32),
                             num_batches,
@@ -408,8 +416,8 @@ class KeyedJaggedIndexSelectDim1GPUOp
                           MAX_CUMSUM_ENTRIES_PER_BLOCK,
                           0,
                           at::cuda::getCurrentCUDAStream(),
-                          PTA_B(output_lengths, length_t, 1, 32),
-                          PTA_B(output_offsets, offset_t, 1, 32),
+                          PTA_B(output_lengths, length_t, 1, 64),
+                          PTA_B(output_offsets, offset_t, 1, 64),
                           PTA_B(lengths, length_t, 1, 32),
                           PTA_B(indices, index_t, 1, 32),
                           num_batches,
@@ -452,50 +460,64 @@ class KeyedJaggedIndexSelectDim1GPUOp
     const auto output_offsets_contig = output_offsets.expect_contiguous();
 
     if (grid_size != 0) {
+#define LAUNCH_KERNEL_WITH_ENTRY_T(                          \
+    WEIGHTED, WEIGHT_TYPE, OUTPUT_WEIGHTS, WEIGHTS, ENTRY_T) \
+  {                                                          \
+    FBGEMM_LAUNCH_KERNEL(                                    \
+        (keyed_jagged_index_select_dim1_kernel<              \
+            value_t,                                         \
+            index_t,                                         \
+            offset_t,                                        \
+            WEIGHT_TYPE,                                     \
+            WEIGHTED,                                        \
+            ENTRY_T>),                                       \
+        grid_size,                                           \
+        kMaxThreads,                                         \
+        0,                                                   \
+        at::cuda::getCurrentCUDAStream(),                    \
+        PTA_B(output, value_t, 1, 64),                       \
+        PTA_B(OUTPUT_WEIGHTS, WEIGHT_TYPE, 1, 64),           \
+        PTA_B(values, value_t, 1, 64),                       \
+        PTA_B(WEIGHTS, WEIGHT_TYPE, 1, 64),                  \
+        PTA_B(offsets, offset_t, 1, 32),                     \
+        PTA_B(indices, index_t, 1, 32),                      \
+        PTA_B(*output_offsets_contig, offset_t, 1, 64),      \
+        num_batches,                                         \
+        batch_size);                                         \
+  }
+
 #define LAUNCH_KERNEL(WEIGHTED, WEIGHT_TYPE, OUTPUT_WEIGHTS, WEIGHTS) \
   {                                                                   \
-    FBGEMM_LAUNCH_KERNEL(                                             \
-        (keyed_jagged_index_select_dim1_kernel<                       \
-            value_t,                                                  \
-            index_t,                                                  \
-            offset_t,                                                 \
-            WEIGHT_TYPE,                                              \
-            WEIGHTED>),                                               \
-        grid_size,                                                    \
-        kMaxThreads,                                                  \
-        0,                                                            \
-        at::cuda::getCurrentCUDAStream(),                             \
-        PTA_B(output, value_t, 1, 64),                                \
-        PTA_B(OUTPUT_WEIGHTS, WEIGHT_TYPE, 1, 64),                    \
-        PTA_B(values, value_t, 1, 64),                                \
-        PTA_B(WEIGHTS, WEIGHT_TYPE, 1, 64),                           \
-        PTA_B(offsets, offset_t, 1, 32),                              \
-        PTA_B(indices, index_t, 1, 32),                               \
-        PTA_B(*output_offsets_contig, offset_t, 1, 32),               \
-        num_batches,                                                  \
-        batch_size);                                                  \
+    if (num_output_lengths >                                          \
+        static_cast<int64_t>(std::numeric_limits<int32_t>::max())) {  \
+      LAUNCH_KERNEL_WITH_ENTRY_T(                                     \
+          WEIGHTED, WEIGHT_TYPE, OUTPUT_WEIGHTS, WEIGHTS, int64_t)    \
+    } else {                                                          \
+      LAUNCH_KERNEL_WITH_ENTRY_T(                                     \
+          WEIGHTED, WEIGHT_TYPE, OUTPUT_WEIGHTS, WEIGHTS, int)        \
+    }                                                                 \
   }
 
       AT_DISPATCH_ALL_TYPES_AND2(
           at::ScalarType::Half,
           at::ScalarType::BFloat16,
           values.scalar_type(),
-          "keyed_jagged_index_select_dim1_warpper_1",
+          "keyed_jagged_index_select_dim1_wrapper_1",
           [&] {
             using value_t = scalar_t;
             AT_DISPATCH_INDEX_TYPES(
                 offsets.scalar_type(),
-                "keyed_jagged_index_select_dim1_warpper_2",
+                "keyed_jagged_index_select_dim1_wrapper_2",
                 [&] {
                   using offset_t = index_t;
                   AT_DISPATCH_INDEX_TYPES(
                       indices.scalar_type(),
-                      "keyed_jagged_index_select_dim1_warpper_3",
+                      "keyed_jagged_index_select_dim1_wrapper_3",
                       [&] {
                         if (weights.has_value()) {
                           FBGEMM_DISPATCH_FLOAT_AND_HALF(
                               weights.value().scalar_type(),
-                              "keyed_jagged_index_select_dim1_warpper_4",
+                              "keyed_jagged_index_select_dim1_wrapper_4",
                               [&] {
                                 using weight_t = scalar_t;
                                 LAUNCH_KERNEL(
@@ -515,6 +537,7 @@ class KeyedJaggedIndexSelectDim1GPUOp
     }
 
 #undef LAUNCH_KERNEL
+#undef LAUNCH_KERNEL_WITH_ENTRY_T
 
     int64_t saved_data[] = {
         num_outputs,
@@ -611,11 +634,47 @@ class KeyedJaggedIndexSelectDim1GPUOp
 
     Tensor grad_input = at::zeros({num_outputs}, grad.options());
     auto grid_size = cuda_calc_xblock_count(grad.numel(), kMaxThreads);
-    // grad_offsetshas to be contiguous because it is passed to
+    // grad_offsets has to be contiguous because it is passed to
     // binary_search_range which takes raw pointers as arguments
     const auto grad_offsets_contig = grad_offsets.expect_contiguous();
 
     if (grid_size != 0) {
+      // Backward kernel uses num_batches * input_batch_size where
+      // input_batch_size = indices.numel() (forward's output_batch_size)
+      const int64_t num_input_lengths =
+          static_cast<int64_t>(num_batches) * indices.numel();
+      // Sanity check since we also compute this in the kernel
+      TORCH_CHECK_VALUE(
+          num_input_lengths > 0,
+          "Expected num_input_lengths > 0, got ",
+          num_input_lengths,
+          ". Check if num_batches=",
+          num_batches,
+          " * indices.numel()=",
+          indices.numel(),
+          " causes overflow.");
+      const bool use_int64_bwd = num_input_lengths >
+          static_cast<int64_t>(std::numeric_limits<int32_t>::max());
+
+#define LAUNCH_BWD_KERNEL(ENTRY_T)                  \
+  FBGEMM_LAUNCH_KERNEL(                             \
+      (keyed_jagged_index_add_dim1_kernel<          \
+          scalar_t,                                 \
+          index_t,                                  \
+          offset_t,                                 \
+          ENTRY_T>),                                \
+      grid_size,                                    \
+      kMaxThreads,                                  \
+      0,                                            \
+      at::cuda::getCurrentCUDAStream(),             \
+      PTA_B(grad_input, scalar_t, 1, 64),           \
+      PTA_B(grad, scalar_t, 1, 64),                 \
+      PTA_B(*grad_offsets_contig, offset_t, 1, 64), \
+      PTA_B(indices, index_t, 1, 32),               \
+      PTA_B(output_offsets, offset_t, 1, 64),       \
+      num_batches,                                  \
+      output_batch_size);
+
       AT_DISPATCH_ALL_TYPES_AND2(
           at::ScalarType::Half,
           at::ScalarType::BFloat16,
@@ -631,25 +690,15 @@ class KeyedJaggedIndexSelectDim1GPUOp
                       indices.scalar_type(),
                       "keyed_jagged_index_add_dim1_wrapper_3",
                       [&] {
-                        FBGEMM_LAUNCH_KERNEL(
-                            (keyed_jagged_index_add_dim1_kernel<
-                                scalar_t,
-                                index_t,
-                                offset_t>),
-                            grid_size,
-                            kMaxThreads,
-                            0,
-                            at::cuda::getCurrentCUDAStream(),
-                            PTA_B(grad_input, scalar_t, 1, 64),
-                            PTA_B(grad, scalar_t, 1, 64),
-                            PTA_B(*grad_offsets_contig, offset_t, 1, 32),
-                            PTA_B(indices, index_t, 1, 32),
-                            PTA_B(output_offsets, offset_t, 1, 32),
-                            num_batches,
-                            output_batch_size);
+                        if (use_int64_bwd) {
+                          LAUNCH_BWD_KERNEL(int64_t)
+                        } else {
+                          LAUNCH_BWD_KERNEL(int)
+                        }
                       });
                 });
           });
+#undef LAUNCH_BWD_KERNEL
     }
     return grad_input;
   }

--- a/fbgemm_gpu/test/jagged/keyed_jagged_index_select_test.py
+++ b/fbgemm_gpu/test/jagged/keyed_jagged_index_select_test.py
@@ -20,34 +20,19 @@ from .common import additional_decorators, open_source
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import gpu_unavailable, optests, running_in_oss
+    from test_utils import gpu_memory_lt_gb, gpu_unavailable, optests, running_in_oss
 else:
-    from fbgemm_gpu.test.test_utils import gpu_unavailable, optests, running_in_oss
+    from fbgemm_gpu.test.test_utils import (
+        gpu_memory_lt_gb,
+        gpu_unavailable,
+        optests,
+        running_in_oss,
+    )
 
 
 @optests.generate_opcheck_tests(additional_decorators=additional_decorators)
 class KeyedJaggedIndexSelectTest(unittest.TestCase):
-    @unittest.skipIf(*gpu_unavailable)
-    @given(
-        max_seq_length=st.integers(5, 10),
-        input_batch_size=st.integers(1, 128),
-        output_batch_size=st.integers(1, 128),
-        num_batches=st.integers(1, 3),
-        index_dtype=st.sampled_from([torch.int, torch.long]),
-        jagged_tensor_dtype=st.sampled_from(
-            [
-                torch.float,
-                torch.half,
-                torch.int,
-                torch.long,
-            ]  # Disable torch.bfloat16 due to large error bound
-        ),
-        has_weights=st.booleans(),
-        check_non_contiguous=st.booleans(),
-        use_selected_lengths_sum=st.booleans(),
-    )
-    @settings(max_examples=20, deadline=None)
-    def test_keyed_jagged_index_select_dim1(
+    def _execute_keyed_jagged_index_select_dim1(
         self,
         max_seq_length: int,
         input_batch_size: int,
@@ -60,22 +45,23 @@ class KeyedJaggedIndexSelectTest(unittest.TestCase):
         use_selected_lengths_sum: bool,
     ) -> None:
         is_float = jagged_tensor_dtype in [torch.float, torch.half, torch.bfloat16]
+        device = torch.accelerator.current_accelerator()
         lengths = torch.randint(
             low=0,
             high=max_seq_length,
             size=(input_batch_size * num_batches,),
             dtype=index_dtype,
-            device="cuda",
+            device=device,
         )
         offsets = torch.concat(
-            [torch.zeros(1, dtype=torch.long, device="cuda"), lengths.cumsum(0)]
+            [torch.zeros(1, dtype=torch.long, device=device), lengths.cumsum(0)]
         )
         indices = torch.randint(
             low=0,
             high=input_batch_size,
             size=(output_batch_size,),
             dtype=index_dtype,
-            device="cuda",
+            device=device,
         )
 
         # If check_non_contiguous=True, create a tensor that is twice as big
@@ -87,14 +73,14 @@ class KeyedJaggedIndexSelectTest(unittest.TestCase):
             values = torch.rand(
                 values_numel,
                 dtype=jagged_tensor_dtype,
-                device="cuda",
+                device=device,
             )
         else:
             values = torch.randint(
                 2**16,
                 (values_numel,),
                 dtype=jagged_tensor_dtype,
-                device="cuda",
+                device=device,
             )
         values_ref = values.detach().clone()
 
@@ -106,7 +92,7 @@ class KeyedJaggedIndexSelectTest(unittest.TestCase):
             weights = torch.rand(
                 int(offsets[-1].item()),
                 dtype=random.choice([torch.float, torch.half]),
-                device="cuda",
+                device=device,
             )
         else:
             weights = None
@@ -195,61 +181,167 @@ class KeyedJaggedIndexSelectTest(unittest.TestCase):
 
     @unittest.skipIf(*gpu_unavailable)
     @unittest.skipIf(*running_in_oss)
-    def test_keyed_jagged_index_select_dim1_num_output_lengths_overflow(
+    @given(
+        max_seq_length=st.integers(5, 10),
+        input_batch_size=st.integers(1, 128),
+        output_batch_size=st.integers(1, 128),
+        num_batches=st.integers(1, 3),
+        index_dtype=st.sampled_from([torch.int, torch.long]),
+        jagged_tensor_dtype=st.sampled_from(
+            [
+                torch.float,
+                torch.half,
+                torch.int,
+                torch.long,
+            ]  # Disable torch.bfloat16 due to large error bound
+        ),
+        has_weights=st.booleans(),
+        check_non_contiguous=st.booleans(),
+        use_selected_lengths_sum=st.booleans(),
+    )
+    @settings(max_examples=20, deadline=None)
+    def test_keyed_jagged_index_select_dim1(
         self,
+        max_seq_length: int,
+        input_batch_size: int,
+        output_batch_size: int,
+        num_batches: int,
+        index_dtype: torch.dtype,
+        jagged_tensor_dtype: torch.dtype,
+        has_weights: bool,
+        check_non_contiguous: bool,
+        use_selected_lengths_sum: bool,
     ) -> None:
-        # num_output_lengths = num_batches * indices.numel() overflows int32
-        # INT32_MAX = 2,147,483,647
-        overflow_cases = [
-            # (num_batches, output_batch_size)
-            # 46341 * 46341 = 2,147,488,281 (just over INT32_MAX)
-            (46341, 46341),
-            # 100000 * 30000 = 3,000,000,000 (overflows int32)
-            (100000, 30000),
-            # 85000 * 85000 = 7,225,000,000 (overflows both int32 and uint32)
-            (85000, 85000),
-        ]
-        device = torch.accelerator.current_accelerator()
-        for num_batches, output_batch_size in overflow_cases:
-            with self.subTest(
-                num_batches=num_batches,
-                output_batch_size=output_batch_size,
-            ):
-                input_batch_size = 1
+        self._execute_keyed_jagged_index_select_dim1(
+            max_seq_length,
+            input_batch_size,
+            output_batch_size,
+            num_batches,
+            index_dtype,
+            jagged_tensor_dtype,
+            has_weights,
+            check_non_contiguous,
+            use_selected_lengths_sum,
+        )
 
-                lengths = torch.zeros(
-                    num_batches * input_batch_size,
-                    dtype=torch.int,
-                    device=device,
-                )
-                offsets = torch.zeros(
-                    num_batches * input_batch_size + 1,
-                    dtype=torch.long,
-                    device=device,
-                )
-                indices = torch.zeros(
-                    output_batch_size,
-                    dtype=torch.int,
-                    device=device,
-                )
-                values = torch.empty(
-                    0,
-                    dtype=torch.float,
-                    device=device,
-                )
-                with self.assertRaisesRegex(
-                    ValueError,
-                    "Expected num_output_lengths > 0",
-                ):
-                    torch.ops.fbgemm.keyed_jagged_index_select_dim1(
-                        values,
-                        lengths,
-                        offsets,
-                        indices,
-                        input_batch_size,
-                        None,
-                        None,
-                    )
+    @given(
+        index_dtype=st.sampled_from([torch.int, torch.long]),
+        jagged_tensor_dtype=st.sampled_from(
+            [
+                torch.float,
+                torch.half,
+                torch.int,
+                torch.long,
+            ]  # Disable torch.bfloat16 due to large error bound
+        ),
+        has_weights=st.booleans(),
+    )
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(40))
+    @settings(max_examples=20, deadline=None)
+    def test_keyed_jagged_index_select_dim1_int32_overflow(
+        self,
+        index_dtype: torch.dtype,
+        jagged_tensor_dtype: torch.dtype,
+        has_weights: bool,
+    ) -> None:
+        """Test keyed_jagged_index_select_dim1 with num_output_lengths > INT32_MAX.
+
+        Verifies that keyed_jagged_index_select_dim1's forward and backward kernels
+        compute correctly when num_output_lengths = num_batches * output_batch_size
+        overflows int32.
+        Uses num_batches=16,777,216 (2^24) and output_batch_size=128 (2^7)
+        so their product = 2^31 = INT32_MAX + 1.
+
+        A small output_batch_size (128) ensures backward has only 128
+        gpuAtomicAdd operations per value, matching the regular test and
+        avoiding non-deterministic floating-point accumulation errors.
+
+        Only the first batch has length=1 (rest are 0) with
+        input_batch_size=1 to minimize output memory. Each non-zero length
+        contributes output_batch_size elements to the output tensor, so
+        keeping only one non-zero length limits output to 128 elements
+        (~512 bytes for float32) while output_offsets and output_lengths
+        still have 2.1B entries each to exercise the int64 indexing paths.
+
+        Peak GPU memory (dominated by output_offsets and output_lengths):
+            index_dtype=int32: ~24 GB (output_offsets 16 GB + output_lengths 8 GB)
+            index_dtype=int64: ~32 GB (output_offsets 16 GB + output_lengths 16 GB)
+        This test requires a GPU with at least 40 GB memory.
+        """
+        num_batches = 16777216
+        output_batch_size = 128
+        input_batch_size = 1
+        device = torch.accelerator.current_accelerator()
+        is_float = jagged_tensor_dtype in [
+            torch.float,
+            torch.half,
+            torch.bfloat16,
+        ]
+
+        lengths = torch.zeros(num_batches, dtype=index_dtype, device=device)
+        lengths[0] = 1
+        offsets = torch.cat(
+            [torch.zeros(1, dtype=torch.long, device=device), lengths.cumsum(0)]
+        )
+        indices = torch.zeros(output_batch_size, dtype=index_dtype, device=device)
+
+        if is_float:
+            values = torch.rand(1, dtype=jagged_tensor_dtype, device=device)
+        else:
+            values = torch.randint(
+                2**16, (1,), dtype=jagged_tensor_dtype, device=device
+            )
+
+        if has_weights:
+            weights = torch.rand(1, dtype=torch.float, device=device)
+        else:
+            weights = None
+
+        if is_float:
+            values.requires_grad = True
+
+        result = torch.ops.fbgemm.keyed_jagged_index_select_dim1(
+            values, lengths, offsets, indices, input_batch_size, weights, None
+        )
+
+        output = result[0]
+        output_lengths = result[1]
+
+        # Verify output_lengths: batch 0 has length=1 repeated output_batch_size
+        # times, all other batches have length=0. Use sum to avoid allocating
+        # a 2.1B bool tensor.
+        self.assertEqual(output_lengths.numel(), num_batches * output_batch_size)
+        self.assertEqual(output_lengths.sum().item(), output_batch_size)
+
+        # Verify output values: output_batch_size copies of values[0]
+        self.assertEqual(output.numel(), output_batch_size)
+        assert torch.all(output == values.detach()[0])
+
+        if has_weights:
+            output_weights = result[2]
+            # pyre-ignore[16]
+            assert torch.all(output_weights == weights[0])
+
+        # Free output_lengths before backward to reduce peak memory
+        del output_lengths, result
+        torch.cuda.empty_cache()
+
+        if not is_float:
+            return
+
+        # Backward: all output elements come from values[0],
+        # so grad_values[0] = sum(grad)
+        grad = torch.rand(output_batch_size, dtype=output.dtype, device=device)
+        output.backward(grad)
+
+        expected_grad = grad.sum().unsqueeze(0)
+        torch.testing.assert_close(
+            values.grad,
+            expected_grad,
+            rtol=1e-2 if jagged_tensor_dtype in [torch.half, torch.bfloat16] else None,
+            atol=1e-2 if jagged_tensor_dtype in [torch.half, torch.bfloat16] else None,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2511

Fix int32 overflow in `keyed_jagged_index_select_dim1` when `num_output_lengths = num_batches * output_batch_size` exceeds `INT32_MAX`.

**`binary_search_range.cuh`**
- Add `found_t` template parameter to decouple the found-index type from the array-index type. This allows callers to use `int64_t` for the found position while keeping `int64_t` for array indexing. Backward compatible since `found_t` is deduced from the `found` pointer argument.

**`keyed_jagged_index_select_dim1.cu`**
- Add `typename entry_t` template parameter to forward (`keyed_jagged_index_select_dim1_kernel`) and backward (`keyed_jagged_index_add_dim1_kernel`) kernels. At launch time, dispatch `int` (common case) or `int64_t` (when `num_entries > INT32_MAX`) to avoid 64-bit arithmetic overhead for the common case.
- Use `static_cast<int64_t>` before multiplication of `num_batches * batch_size` in `index_select_scalar_cumsum_kernel` and `forward_impl` to prevent int32 overflow.
- Upgrade `PackedTensorAccessor32` to `PackedTensorAccessor64` for output tensors whose sizes can exceed `INT32_MAX`: `output_lengths`, `output_offsets` (forward), `input_offsets`, `output_offsets` (backward).
- Add `TORCH_CHECK_VALUE` for `num_output_lengths > 0`, `num_input_lengths > 0`, `grid_size > 0`, and `indices`/`lengths` sizes <= `INT32_MAX`.
- Fix typos

**`keyed_jagged_index_select_test.py`**
- Add `test_keyed_jagged_index_select_dim1_int32_overflow` that verifies forward and backward correctness when `num_output_lengths` overflows int32 (`num_batches=2^24 * output_batch_size=2^7 = 2^31 = INT32_MAX + 1`).
- Test uses `input_batch_size=1` with one non-zero length to minimize output memory (~512 bytes) while `output_offsets` and `output_lengths` have 2.1B entries each (~24-32 GB). Skipped on GPUs with < 40 GB memory.

Reviewed By: q10

Differential Revision: D97439598


