### PR TITLE
Add Portions Copyright headers to modified third-party files

### DIFF
--- a/fbgemm_gpu/experimental/gemm/triton_gemm/matmul_perf_model.py
+++ b/fbgemm_gpu/experimental/gemm/triton_gemm/matmul_perf_model.py
@@ -1,3 +1,9 @@
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 # Source: https://github.com/triton-lang/kernels/blob/8821ef322394ee2d3c58a859780ee1e2e10b5c79/kernels/matmul_perf_model.py
 
 # This file is taken from the upstream triton-lang/kernels repo.

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_lite.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_lite.cu
@@ -1,4 +1,12 @@
 /*
+ * Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
  * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/rocm/half2.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/rocm/half2.h
@@ -1,3 +1,10 @@
+/*
+ * Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 /*******************************************************************************
  * Copyright (c) 2016 - 2024 Advanced Micro Devices, Inc. All rights reserved.


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2512

Add "Portions Copyright" Meta BSD header to files originally from third
parties (NVIDIA, AMD, Triton) that have been modified by Meta engineers.
These files were missing the required Meta copyright header.

Files modified:
- `fbgemm_gpu/experimental/gemm/triton_gemm/matmul_perf_model.py` (from triton-lang/kernels)
- `fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_lite.cu` (from NVIDIA)
- `fbgemm_gpu/include/fbgemm_gpu/utils/rocm/half2.h` (from AMD)

Reviewed By: gchalump, q10

Differential Revision: D98453024


