### PR TITLE
Add periodic logging for L2 cache fill wait time

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/kv_db_table_batched_embeddings.cpp
@@ -626,8 +626,11 @@ void EmbeddingKVDB::wait_util_filling_work_done() {
     // Wait on CV instead of polling — wakes when background thread drains queue
     fill_queue_cv_.wait(lk, [this] { return weights_to_fill_queue_.empty(); });
   }
-  get_cache_lookup_wait_filling_thread_duration_ +=
-      facebook::WallClockUtil::NowInUsecFast() - start_ts;
+  auto wait_dur = facebook::WallClockUtil::NowInUsecFast() - start_ts;
+  get_cache_lookup_wait_filling_thread_duration_ += wait_dur;
+  XLOG_EVERY_MS(INFO, 60000)
+      << "[TBE_ID" << unique_id_ << "]L2 cache fill wait time: " << wait_dur
+      << " us";
 }
 
 folly::Optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>>


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2515

Add XLOG_EVERY_MS logging in wait_util_filling_work_done() to report the
L2 cache fill wait duration. This helps understand how long the training
step blocks waiting for the background fill thread to drain the queue.

The log fires at most once per 60 seconds (XLOG_EVERY_MS with 60000ms
interval), matching existing logging patterns in the file, so there is
no measurable hot-path overhead.

Follow-up to D96630505 (CV fill queue optimization), addressing inline
review comment requesting fill wait time visibility.

Differential Revision: D98700871


