### PR TITLE
Add embedding cache support to oneflow base model (#5552)

### DIFF
--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
@@ -868,16 +868,17 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
   }
 
   /// Decode int64 SID from cache weights.
-  /// Reverse of prepareInt64PayloadTensors nibble encoding:
-  /// 16 nibbles → uint64 → int64
-  /// nibble n = (exponent << 1) | sign_bit, float = pow(2, exponent) * sign
+  /// Reverse of prepareInt64PayloadTensors dibit encoding:
+  /// 32 dibits -> uint64 -> int64
+  /// dibit d encodes as float: {0: 0.5, 1: 1.0, 2: 1.5, 3: 2.0}
+  /// Decode: dibit = round(fval * 2 - 1)
   static int64_t decodeSIDFromWeights(const weight_type* weights_ptr) {
     uint64_t uval = 0;
-    for (int i = 0; i < 16; ++i) {
+    for (int i = 0; i < 32; ++i) {
       float fval = static_cast<float>(weights_ptr[i]);
-      int exp = std::ilogb(std::abs(fval));
-      uint8_t nibble = static_cast<uint8_t>((exp << 1) | (fval < 0.0f ? 1 : 0));
-      uval |= (static_cast<uint64_t>(nibble & 0xF) << (i * 4));
+      uint8_t dibit =
+          static_cast<uint8_t>(std::lround(fval * 2.0f - 1.0f)) & 0x3;
+      uval |= (static_cast<uint64_t>(dibit) << (i * 2));
     }
     return static_cast<int64_t>(uval);
   }


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2519

CONTEXT: Port embedding cache changes from blue_reels_umia_v1_exp_hstu_simplified_v5_base_model.py to the oneflow base model. All embedding cache related configs are gated behind SID_INJECTION_MODE_V5 == PRETRAIN_MAP_EMBEDDING_CACHE so the base model remains unchanged when the mode is not active.

WHAT:
- Gate all embedding cache configs behind PRETRAIN_MAP_EMBEDDING_CACHE:
  - sparse_object_id_for_embedding_cache feature and replication config
  - zch_embedding_cache_item_fb_public embedding table (MX4-safe dibit encoding, 32x2bit)
  - emb_cache_item_ec EmbeddingCollection initialization
  - KVZCHTBEConfig with OneFlow feature store enrichment
  - TBE SSD/cache params (prefetch_pipeline, rocksdb, l2_cache, etc.)
  - QComms fp8_quantize_dim=32
- Simplify forward path using build_embedding_cache_write_kjt from kvzch_utils
- Extract decode_dibits_to_int64 utility to kvzch_utils.py for reuse
- Update C++ encode/decode from FP8 nibbles (16x4bit) to MX4-safe dibits (32x2bit)

Reviewed By: xinzhang-nac

Differential Revision: D98399416
