### PR TITLE
Add streaming_update() and load_snapshot() for inference (#5554)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference.py
@@ -12,8 +12,10 @@ import itertools
 import logging
 import os
 import tempfile
+import threading
+from contextlib import contextmanager
 from math import log2
-from typing import Optional
+from typing import Generator, Optional
 
 import torch  # usort:skip
 
@@ -35,11 +37,88 @@ from torch.autograd.profiler import record_function
 
 from .common import ASSOC
 
+IS_ROCM: bool = hasattr(torch.version, "hip") and torch.version.hip is not None
+
+
+class _RWLock:
+    """
+    Lightweight read-write lock for concurrent inference + rare updates.
+
+    Multiple readers (prefetch/forward) can proceed concurrently.
+    A writer (streaming_update/load_snapshot) gets exclusive access,
+    blocking new readers and waiting for in-flight readers to finish.
+
+    Writer-priority: once any writer is waiting, new readers block until
+    all waiting writers have completed. Uses a counter (not a bool) so
+    that multiple queued writers don't starve each other.
+    """
+
+    def __init__(self) -> None:
+        self._cond: threading.Condition = threading.Condition(threading.Lock())
+        self._readers: int = 0
+        self._writers_waiting: int = 0
+        self._writer_active: bool = False
+
+    def acquire_read(self) -> None:
+        with self._cond:
+            while self._writer_active or self._writers_waiting > 0:
+                self._cond.wait()
+            self._readers += 1
+
+    def release_read(self) -> None:
+        with self._cond:
+            self._readers -= 1
+            if self._readers == 0:
+                self._cond.notify_all()
+
+    def acquire_write(self) -> None:
+        with self._cond:
+            self._writers_waiting += 1
+            while self._readers > 0 or self._writer_active:
+                self._cond.wait()
+            self._writers_waiting -= 1
+            self._writer_active = True
+
+    def release_write(self) -> None:
+        with self._cond:
+            self._writer_active = False
+            self._cond.notify_all()
+
+    @contextmanager
+    def read_lock(self) -> Generator[None, None, None]:
+        self.acquire_read()
+        try:
+            yield
+        finally:
+            self.release_read()
+
+    @contextmanager
+    def write_lock(
+        self, cuda_device: Optional[torch.device] = None
+    ) -> Generator[None, None, None]:
+        self.acquire_write()
+        try:
+            if cuda_device is not None:
+                torch.cuda.synchronize(cuda_device)
+            yield
+            if cuda_device is not None:
+                torch.cuda.synchronize(cuda_device)
+        finally:
+            self.release_write()
+
 
 class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
     """
     SSD Table-batched version of nn.EmbeddingBag(sparse=False)
     Inference version, with FP32/FP16/FP8/INT8/INT4/INT2 supports
+
+    AMD/ROCm support status:
+        - streaming_update() and load_snapshot(): fully supported (standard
+          PyTorch tensor ops, no device-specific kernels)
+        - prefetch() and forward(): NVIDIA-only. The C++ kernels
+          (ssd_cache_populate_actions, masked_index_put, etc.) have not been
+          ported to HIP. On ROCm, the warp size is 64 but cache associativity
+          (ASSOC) is hardcoded to 32, causing memory access issues.
     """
 
     embedding_specs: list[tuple[str, int, int, SparseType]]
@@ -269,6 +348,7 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
         ssd_directory = tempfile.mkdtemp(
             prefix="ssd_table_batched_embeddings", dir=ssd_storage_directory
         )
+        self.use_ps_backend: bool = bool(ps_hosts)
         if not ps_hosts:
             # pyre-fixme[4]: Attribute must be annotated.
             # pyre-ignore[16]
@@ -385,8 +465,24 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
             self.fp8_exponent_bits = -1
             self.fp8_exponent_bias = -1
 
+        if IS_ROCM:
+            logging.warning(
+                "SSD TBE inference running on ROCm: streaming_update() and "
+                "load_snapshot() are supported, but prefetch()/forward() "
+                "require NVIDIA CUDA kernels that are not yet ported to HIP."
+            )
+
+        # Read-write lock for concurrent inference + streaming updates.
+        # prefetch/forward take shared read locks; streaming_update/load_snapshot
+        # take exclusive write locks with CUDA synchronization.
+        self._rw_lock: _RWLock = _RWLock()
+
     @torch.jit.export
     def prefetch(self, indices: Tensor, offsets: Tensor) -> Tensor:
+        with self._rw_lock.read_lock():
+            return self._prefetch_impl(indices, offsets)
+
+    def _prefetch_impl(self, indices: Tensor, offsets: Tensor) -> Tensor:
         indices, offsets = indices.long(), offsets.long()
         linear_cache_indices = torch.ops.fbgemm.linearize_cache_indices(
             self.hash_size_cumsum,
@@ -491,9 +587,18 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
         offsets: Tensor,
         per_sample_weights: Optional[Tensor] = None,
     ) -> Tensor:
+        with self._rw_lock.read_lock():
+            return self._forward_impl(indices, offsets, per_sample_weights)
+
+    def _forward_impl(
+        self,
+        indices: Tensor,
+        offsets: Tensor,
+        per_sample_weights: Optional[Tensor] = None,
+    ) -> Tensor:
         if self.timestep_prefetch_size.get() <= 0:
             with record_function("## prefetch ##"):
-                linear_cache_indices = self.prefetch(indices, offsets)
+                linear_cache_indices = self._prefetch_impl(indices, offsets)
         else:
             linear_cache_indices = torch.ops.fbgemm.linearize_cache_indices(
                 self.hash_size_cumsum,
@@ -620,3 +725,130 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
 
         torch.cuda.synchronize(self.current_device)
         return splits
+
+    @torch.jit.export
+    def streaming_update(
+        self,
+        indices: Tensor,
+        weights: Tensor,
+    ) -> None:
+        """
+        Apply streaming embedding updates during inference.
+
+        Writes new embedding values to RocksDB for the given indices and
+        invalidates corresponding HBM cache entries so that the next
+        prefetch() reloads the fresh values.
+
+        Thread-safe: acquires an exclusive write lock and synchronizes
+        all CUDA streams before and after modifying shared state.
+
+        Args:
+            indices: 1D int64 tensor of linear embedding indices to update.
+            weights: 2D uint8 tensor of shape [len(indices), max_D_cache]
+                     containing the new embedding bytes (including scale/bias).
+        """
+        assert indices.dim() == 1, "indices must be 1D"
+        assert weights.dim() == 2, "weights must be 2D"
+        assert indices.shape[0] == weights.shape[0], (
+            f"indices and weights must have the same number of rows, "
+            f"got {indices.shape[0]} and {weights.shape[0]}"
+        )
+        if indices.shape[0] == 0:
+            return
+
+        with self._rw_lock.write_lock(self.current_device):
+            # 1. Write updated embeddings to RocksDB.
+            count = torch.tensor([indices.shape[0]], dtype=torch.int64)
+            self.ssd_db.set(indices.cpu(), weights.cpu(), count)
+
+            # 2. Invalidate HBM cache entries for updated indices.
+            self._invalidate_cache(indices)
+
+    def _invalidate_cache(self, indices: Tensor) -> None:
+        """Invalidate HBM cache entries for the given linear indices."""
+        indices = indices.to(self.current_device)
+        max_cache_sets = self.lxu_cache_state.shape[0]
+        cache_set_ids = indices % max_cache_sets  # [N]
+
+        # Gather the ASSOC slots for each relevant cache set: [N, ASSOC]
+        relevant_states = self.lxu_cache_state[cache_set_ids]
+
+        # Find which slots hold the updated indices: [N, ASSOC] bool
+        matches = relevant_states == indices.unsqueeze(1)
+
+        if matches.any():
+            # Get (row_in_batch, slot) pairs for all matches
+            n_idx, slot_idx = matches.nonzero(as_tuple=True)
+            # Convert to flat indices into lxu_cache_state
+            flat_idx = cache_set_ids[n_idx] * ASSOC + slot_idx
+            self.lxu_cache_state.view(-1)[flat_idx] = -1
+
+    @torch.jit.export
+    def load_snapshot(
+        self,
+        ssd_storage_directory: str,
+        ssd_shards: int = 1,
+        ssd_memtable_flush_period: int = -1,
+        ssd_memtable_flush_offset: int = -1,
+        ssd_l0_files_per_compact: int = 4,
+        ssd_rate_limit_mbps: int = 0,
+        ssd_size_ratio: int = 10,
+        ssd_compaction_trigger: int = 8,
+        ssd_write_buffer_size: int = 2 * 1024 * 1024 * 1024,
+        ssd_max_write_buffer_num: int = 16,
+        ssd_uniform_init_lower: float = -0.01,
+        ssd_uniform_init_upper: float = 0.01,
+    ) -> None:
+        """
+        Swap to a new RocksDB snapshot without downtime.
+
+        Opens a new EmbeddingRocksDB at the given directory and replaces
+        the current ssd_db. Invalidates the entire HBM cache so that
+        subsequent prefetch() calls reload from the new snapshot.
+
+        Args:
+            ssd_storage_directory: Path to the new RocksDB snapshot.
+            Other args: RocksDB configuration (same as constructor).
+
+        Raises:
+            RuntimeError: If the instance uses a parameter server backend
+                (ps_hosts was provided at construction time).
+        """
+        if self.use_ps_backend:
+            raise RuntimeError(
+                "load_snapshot() is only supported with the local RocksDB backend. "
+                "This instance was initialized with ps_hosts (parameter server)."
+            )
+
+        with self._rw_lock.write_lock(self.current_device):
+            # 1. Flush any pending writes to the old DB.
+            self.ssd_db.flush()
+
+            # 2. Open a new RocksDB instance at the new snapshot path.
+            # pyre-ignore[16]
+            self.ssd_db = torch.classes.fbgemm.EmbeddingRocksDBWrapper(
+                ssd_storage_directory,
+                ssd_shards,
+                ssd_shards,
+                ssd_memtable_flush_period,
+                ssd_memtable_flush_offset,
+                ssd_l0_files_per_compact,
+                self.max_D_cache,
+                ssd_rate_limit_mbps,
+                ssd_size_ratio,
+                ssd_compaction_trigger,
+                ssd_write_buffer_size,
+                ssd_max_write_buffer_num,
+                ssd_uniform_init_lower,
+                ssd_uniform_init_upper,
+                8,  # row_storage_bitwidth
+                0,  # ssd_block_cache_size
+            )
+
+            # 3. Invalidate entire HBM cache — all entries are from old snapshot.
+            self.lxu_cache_state.fill_(-1)
+
+            logging.info(
+                f"Loaded new snapshot from {ssd_storage_directory}, "
+                f"HBM cache fully invalidated"
+            )

--- a/fbgemm_gpu/test/tbe/ssd/ssd_rwlock_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_rwlock_test.py
@@ -1,0 +1,1177 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+# pyre-ignore-all-errors[3,6,56]
+
+"""
+Tests and microbenchmarks for the _RWLock in SSD TBE inference.
+
+Tests verify:
+  1. No deadlocks under all concurrent access patterns
+  2. Correctness of mutual exclusion (writers are exclusive)
+  3. Writer-priority fairness (writers don't starve)
+  4. No performance regression from lock overhead
+
+Run:
+  buck2 test fbcode//deeplearning/fbgemm/fbgemm_gpu/test/tbe:ssd_rwlock_test
+"""
+
+import statistics
+import tempfile
+import threading
+import time
+import unittest
+
+import torch
+from fbgemm_gpu.split_embedding_configs import SparseType
+from fbgemm_gpu.split_table_batched_embeddings_ops_common import PoolingMode
+from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
+    rounded_row_size_in_bytes,
+)
+from fbgemm_gpu.tbe.ssd import SSDIntNBitTableBatchedEmbeddingBags
+from fbgemm_gpu.tbe.ssd.inference import _RWLock
+from fbgemm_gpu.tbe.utils import get_table_batched_offsets_from_dense
+
+from .. import common  # noqa E402
+from ..common import gpu_unavailable, running_in_oss
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Part 1: _RWLock Unit Tests (no GPU needed)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class RWLockCorrectnessTest(unittest.TestCase):
+    """Pure-Python tests for _RWLock correctness and deadlock freedom."""
+
+    TIMEOUT: float = 10.0  # seconds — any test hanging past this is a deadlock
+
+    # ─── Basic lock/unlock ───────────────────────────────────────────────
+
+    def test_single_reader(self) -> None:
+        """Single reader acquires and releases without issue."""
+        lock = _RWLock()
+        lock.acquire_read()
+        lock.release_read()
+
+    def test_single_writer(self) -> None:
+        """Single writer acquires and releases without issue."""
+        lock = _RWLock()
+        lock.acquire_write()
+        lock.release_write()
+
+    def test_read_then_write(self) -> None:
+        """Sequential read then write — no deadlock."""
+        lock = _RWLock()
+        lock.acquire_read()
+        lock.release_read()
+        lock.acquire_write()
+        lock.release_write()
+
+    def test_write_then_read(self) -> None:
+        """Sequential write then read — no deadlock."""
+        lock = _RWLock()
+        lock.acquire_write()
+        lock.release_write()
+        lock.acquire_read()
+        lock.release_read()
+
+    # ─── Concurrent readers ──────────────────────────────────────────────
+
+    def test_concurrent_readers_no_block(self) -> None:
+        """Multiple readers can hold the lock simultaneously."""
+        lock: _RWLock = _RWLock()
+        N = 16
+        barrier: threading.Barrier = threading.Barrier(N, timeout=self.TIMEOUT)
+        errors: list[str] = []
+
+        def reader(i: int) -> None:
+            try:
+                lock.acquire_read()
+                barrier.wait()  # all N readers must be holding lock simultaneously
+                lock.release_read()
+            except Exception as e:
+                errors.append(f"reader {i}: {e}")
+
+        threads = [threading.Thread(target=reader, args=(i,)) for i in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=self.TIMEOUT)
+            self.assertFalse(t.is_alive(), "Reader thread deadlocked")
+
+        self.assertEqual(errors, [], f"Errors in readers: {errors}")
+
+    # ─── Writer exclusion ────────────────────────────────────────────────
+
+    def test_writer_excludes_readers(self) -> None:
+        """While writer holds lock, readers must wait."""
+        lock: _RWLock = _RWLock()
+        writer_done: threading.Event = threading.Event()
+        reader_entered: threading.Event = threading.Event()
+
+        def writer() -> None:
+            lock.acquire_write()
+            time.sleep(0.1)  # hold lock for 100ms
+            writer_done.set()
+            lock.release_write()
+
+        def reader() -> None:
+            lock.acquire_read()
+            reader_entered.set()
+            lock.release_read()
+
+        wt = threading.Thread(target=writer)
+        wt.start()
+        time.sleep(0.02)  # let writer grab lock first
+
+        rt = threading.Thread(target=reader)
+        rt.start()
+
+        # Reader should NOT have entered while writer holds lock
+        time.sleep(0.03)
+        self.assertFalse(
+            reader_entered.is_set(),
+            "Reader entered while writer held lock",
+        )
+
+        # After writer releases, reader should proceed
+        wt.join(timeout=self.TIMEOUT)
+        rt.join(timeout=self.TIMEOUT)
+        self.assertTrue(writer_done.is_set())
+        self.assertTrue(reader_entered.is_set())
+
+    def test_writer_excludes_other_writers(self) -> None:
+        """Two writers cannot hold lock simultaneously."""
+        lock: _RWLock = _RWLock()
+        held_concurrently: threading.Event = threading.Event()
+        writer_count: list[int] = [0]
+        count_lock: threading.Lock = threading.Lock()
+
+        def writer() -> None:
+            lock.acquire_write()
+            with count_lock:
+                writer_count[0] += 1
+                if writer_count[0] > 1:
+                    held_concurrently.set()
+            time.sleep(0.05)
+            with count_lock:
+                writer_count[0] -= 1
+            lock.release_write()
+
+        threads = [threading.Thread(target=writer) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=self.TIMEOUT)
+            self.assertFalse(t.is_alive(), "Writer thread deadlocked")
+
+        self.assertFalse(
+            held_concurrently.is_set(),
+            "Two writers held lock at the same time",
+        )
+
+    # ─── Writer priority ────────────────────────────────────────────────
+
+    def test_writer_priority_blocks_new_readers(self) -> None:
+        """
+        Once a writer is waiting, new readers must block — even if
+        existing readers are still active. This prevents writer starvation.
+        """
+        lock: _RWLock = _RWLock()
+        events: list[str] = []
+        events_lock: threading.Lock = threading.Lock()
+
+        def log(msg: str) -> None:
+            with events_lock:
+                events.append(msg)
+
+        # Phase 1: reader grabs lock
+        lock.acquire_read()
+        log("reader1_acquired")
+
+        # Phase 2: writer starts waiting
+        writer_waiting: threading.Event = threading.Event()
+
+        def writer() -> None:
+            writer_waiting.set()
+            lock.acquire_write()
+            log("writer_acquired")
+            lock.release_write()
+            log("writer_released")
+
+        wt = threading.Thread(target=writer)
+        wt.start()
+        writer_waiting.wait(timeout=self.TIMEOUT)
+        time.sleep(0.05)  # let writer actually block on cond.wait()
+
+        # Phase 3: new reader tries to acquire — should block because writer is waiting
+        reader2_acquired: threading.Event = threading.Event()
+
+        def reader2() -> None:
+            lock.acquire_read()
+            reader2_acquired.set()
+            log("reader2_acquired")
+            lock.release_read()
+
+        rt2 = threading.Thread(target=reader2)
+        rt2.start()
+        time.sleep(0.1)
+
+        # reader2 should NOT have acquired yet (writer-priority blocks it)
+        self.assertFalse(
+            reader2_acquired.is_set(),
+            "New reader acquired lock while writer was waiting — writer-priority violated",
+        )
+
+        # Phase 4: release reader1 → writer should go next, then reader2
+        lock.release_read()
+        log("reader1_released")
+
+        wt.join(timeout=self.TIMEOUT)
+        rt2.join(timeout=self.TIMEOUT)
+
+        # Verify ordering: writer acquired BEFORE reader2
+        with events_lock:
+            wi = events.index("writer_acquired")
+            r2i = events.index("reader2_acquired")
+        self.assertLess(
+            wi,
+            r2i,
+            f"Writer should acquire before reader2, but order was: {events}",
+        )
+
+    # ─── Deadlock detection via timeout ──────────────────────────────────
+
+    def test_no_deadlock_readers_then_writer(self) -> None:
+        """N readers finish, then writer proceeds — no deadlock."""
+        lock: _RWLock = _RWLock()
+        N = 8
+
+        def reader() -> None:
+            lock.acquire_read()
+            time.sleep(0.01)
+            lock.release_read()
+
+        def writer() -> None:
+            lock.acquire_write()
+            lock.release_write()
+
+        threads = [threading.Thread(target=reader) for _ in range(N)]
+        threads.append(threading.Thread(target=writer))
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=self.TIMEOUT)
+            self.assertFalse(t.is_alive(), "Thread deadlocked")
+
+    def test_no_deadlock_interleaved_reads_writes(self) -> None:
+        """Interleaved reader and writer threads — no deadlock."""
+        lock: _RWLock = _RWLock()
+        N = 20
+        completed: list[int] = [0]
+        mu: threading.Lock = threading.Lock()
+
+        def worker(i: int) -> None:
+            for _ in range(50):
+                if i % 3 == 0:
+                    lock.acquire_write()
+                    lock.release_write()
+                else:
+                    lock.acquire_read()
+                    lock.release_read()
+            with mu:
+                completed[0] += 1
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=self.TIMEOUT)
+            self.assertFalse(t.is_alive(), "Thread deadlocked")
+
+        self.assertEqual(completed[0], N, "Not all threads completed")
+
+    def test_no_deadlock_rapid_write_read_cycling(self) -> None:
+        """
+        Rapid cycling between write and read on the same thread — no deadlock.
+        Simulates the pattern where streaming_update completes, then
+        immediately the same thread does a prefetch.
+        """
+        lock = _RWLock()
+        for _ in range(1000):
+            lock.acquire_write()
+            lock.release_write()
+            lock.acquire_read()
+            lock.release_read()
+
+    def test_no_deadlock_writer_while_many_readers_drain(self) -> None:
+        """
+        Start 32 readers, then request a write. All readers must drain,
+        writer proceeds, no deadlock.
+        """
+        lock: _RWLock = _RWLock()
+        N = 32
+        reader_acquired: threading.Barrier = threading.Barrier(N, timeout=self.TIMEOUT)
+        writer_can_wait: threading.Event = threading.Event()
+        reader_release: threading.Event = threading.Event()
+
+        def reader() -> None:
+            lock.acquire_read()
+            reader_acquired.wait()
+            writer_can_wait.set()
+            reader_release.wait(timeout=self.TIMEOUT)
+            lock.release_read()
+
+        def writer() -> None:
+            writer_can_wait.wait(timeout=self.TIMEOUT)
+            time.sleep(0.02)  # small delay to ensure all readers are holding
+            lock.acquire_write()
+            lock.release_write()
+
+        threads = [threading.Thread(target=reader) for _ in range(N)]
+        wt = threading.Thread(target=writer)
+        for t in threads:
+            t.start()
+        wt.start()
+
+        time.sleep(0.2)
+        reader_release.set()  # release all readers
+
+        for t in threads:
+            t.join(timeout=self.TIMEOUT)
+            self.assertFalse(t.is_alive(), "Reader deadlocked")
+        wt.join(timeout=self.TIMEOUT)
+        self.assertFalse(wt.is_alive(), "Writer deadlocked")
+
+    # ─── Mutual exclusion stress test ────────────────────────────────────
+
+    def test_shared_counter_integrity(self) -> None:
+        """
+        Use the lock to protect a shared counter. Readers read, writers
+        increment. Final value must be exactly N_WRITES — proves
+        writers are truly exclusive and readers don't corrupt state.
+        """
+        lock: _RWLock = _RWLock()
+        counter: list[int] = [0]
+        N_WRITES: int = 200
+        N_READERS = 8
+        N_READ_ITERS: int = 500
+        reader_saw_partial: threading.Event = threading.Event()
+
+        def writer() -> None:
+            for _ in range(N_WRITES):
+                lock.acquire_write()
+                # Non-atomic increment: read, sleep, write back
+                val = counter[0]
+                time.sleep(0.0001)  # yield to expose races
+                counter[0] = val + 1
+                lock.release_write()
+
+        def reader() -> None:
+            for _ in range(N_READ_ITERS):
+                lock.acquire_read()
+                val = counter[0]
+                time.sleep(0.0001)
+                # A partial write would show up as a value != counter[0]
+                if val != counter[0]:
+                    reader_saw_partial.set()
+                lock.release_read()
+
+        wt = threading.Thread(target=writer)
+        rts = [threading.Thread(target=reader) for _ in range(N_READERS)]
+        wt.start()
+        for r in rts:
+            r.start()
+
+        wt.join(timeout=30.0)
+        for r in rts:
+            r.join(timeout=30.0)
+
+        self.assertEqual(
+            counter[0], N_WRITES, "Counter mismatch — writer exclusion broken"
+        )
+        self.assertFalse(
+            reader_saw_partial.is_set(),
+            "Reader saw partial write — mutual exclusion violated",
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Part 2: _RWLock Microbenchmarks (no GPU needed)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class RWLockBenchmarkTest(unittest.TestCase):
+    """
+    Microbenchmarks for _RWLock overhead.
+
+    These tests measure lock acquisition latency and throughput, then
+    assert that overhead stays within acceptable bounds:
+    - Uncontended read lock: < 5 µs per acquire/release
+    - Uncontended write lock: < 5 µs per acquire/release
+
+    Note on contended benchmarks: Python GIL contention inflates numbers
+    for pure-lock-operation benchmarks. In production, each thread does
+    substantial GPU work (100+ µs) between lock operations, releasing the
+    GIL during CUDA kernels. The uncontended latency (~2 µs) is the
+    relevant metric for real overhead.
+    """
+
+    def test_uncontended_read_lock_latency(self) -> None:
+        """Measure uncontended read lock acquire+release latency."""
+        lock = _RWLock()
+        N = 100_000
+
+        # Warmup
+        for _ in range(1000):
+            lock.acquire_read()
+            lock.release_read()
+
+        start = time.perf_counter()
+        for _ in range(N):
+            lock.acquire_read()
+            lock.release_read()
+        elapsed = time.perf_counter() - start
+
+        latency_us = (elapsed / N) * 1e6
+        print(
+            f"\n  Uncontended read lock: {latency_us:.2f} µs/op ({N} ops in {elapsed:.3f}s)"
+        )
+        self.assertLess(
+            latency_us,
+            5.0,
+            f"Uncontended read lock too slow: {latency_us:.2f} µs (limit 5 µs)",
+        )
+
+    def test_uncontended_write_lock_latency(self) -> None:
+        """Measure uncontended write lock acquire+release latency."""
+        lock = _RWLock()
+        N = 100_000
+
+        for _ in range(1000):
+            lock.acquire_write()
+            lock.release_write()
+
+        start = time.perf_counter()
+        for _ in range(N):
+            lock.acquire_write()
+            lock.release_write()
+        elapsed = time.perf_counter() - start
+
+        latency_us = (elapsed / N) * 1e6
+        print(
+            f"\n  Uncontended write lock: {latency_us:.2f} µs/op ({N} ops in {elapsed:.3f}s)"
+        )
+        self.assertLess(
+            latency_us,
+            5.0,
+            f"Uncontended write lock too slow: {latency_us:.2f} µs (limit 5 µs)",
+        )
+
+    def test_contended_read_lock_throughput(self) -> None:
+        """
+        16 threads all acquiring/releasing read locks concurrently.
+        Measures throughput under contention — this simulates the
+        inference hot path where many threads call prefetch/forward.
+        """
+        lock: _RWLock = _RWLock()
+        N_THREADS = 16
+        OPS_PER_THREAD: int = 50_000
+        barrier: threading.Barrier = threading.Barrier(N_THREADS)
+
+        thread_times: list[float] = []
+        times_lock: threading.Lock = threading.Lock()
+
+        def worker() -> None:
+            barrier.wait()
+            start = time.perf_counter()
+            for _ in range(OPS_PER_THREAD):
+                lock.acquire_read()
+                lock.release_read()
+            elapsed = time.perf_counter() - start
+            with times_lock:
+                thread_times.append(elapsed)
+
+        threads = [threading.Thread(target=worker) for _ in range(N_THREADS)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30.0)
+
+        # Report per-op latency (wall time / ops for each thread)
+        latencies = [(t / OPS_PER_THREAD) * 1e6 for t in thread_times]
+        avg_us = statistics.mean(latencies)
+        p99_us = sorted(latencies)[int(0.99 * len(latencies))]
+        total_ops = N_THREADS * OPS_PER_THREAD
+        wall_time = max(thread_times)
+        throughput = total_ops / wall_time
+
+        print(
+            f"\n  Contended read lock ({N_THREADS} threads):"
+            f"\n    Avg: {avg_us:.2f} µs/op, P99: {p99_us:.2f} µs/op"
+            f"\n    Throughput: {throughput:,.0f} ops/sec"
+            f"\n    Total: {total_ops:,} ops in {wall_time:.3f}s"
+        )
+        # Under Python GIL, contended read-lock latency is dominated by
+        # GIL context-switching, not the lock itself. In production, threads
+        # release GIL during CUDA kernels. We use a lenient bound here.
+        self.assertLess(
+            avg_us,
+            500.0,
+            f"Contended read lock too slow: {avg_us:.2f} µs (limit 500 µs)",
+        )
+
+    def test_read_lock_with_rare_writer_throughput(self) -> None:
+        """
+        Simulates production pattern: 15 reader threads + 1 writer thread
+        that writes every 1000 reader ops. Measures reader throughput
+        degradation from occasional writers.
+        """
+        lock: _RWLock = _RWLock()
+        N_READERS = 15
+        WRITE_INTERVAL_MS: int = 50  # writer fires every 50ms
+        TEST_DURATION_S = 3.0  # run for 3 seconds
+
+        reader_ops: list[int] = [0] * N_READERS
+        writer_ops: list[int] = [0]
+        stop: threading.Event = threading.Event()
+        barrier: threading.Barrier = threading.Barrier(N_READERS + 1)
+
+        def reader(idx: int) -> None:
+            barrier.wait()
+            while not stop.is_set():
+                lock.acquire_read()
+                lock.release_read()
+                reader_ops[idx] += 1
+
+        def writer() -> None:
+            barrier.wait()
+            while not stop.is_set():
+                time.sleep(WRITE_INTERVAL_MS / 1000.0)
+                lock.acquire_write()
+                time.sleep(0.001)  # simulate 1ms of write work
+                lock.release_write()
+                writer_ops[0] += 1
+
+        threads = [threading.Thread(target=reader, args=(i,)) for i in range(N_READERS)]
+        wt = threading.Thread(target=writer)
+        for t in threads:
+            t.start()
+        wt.start()
+
+        time.sleep(TEST_DURATION_S)
+        stop.set()
+
+        for t in threads:
+            t.join(timeout=5.0)
+        wt.join(timeout=5.0)
+
+        total_reads = sum(reader_ops)
+        total_writes = writer_ops[0]
+        read_throughput = total_reads / TEST_DURATION_S
+        per_thread_avg = read_throughput / N_READERS
+
+        print(
+            f"\n  Read+Write mixed ({N_READERS}R + 1W, {WRITE_INTERVAL_MS}ms write interval):"
+            f"\n    Reader throughput: {read_throughput:,.0f} total ops/sec"
+            f"\n    Per-thread avg: {per_thread_avg:,.0f} ops/sec"
+            f"\n    Writer ops: {total_writes} ({total_writes / TEST_DURATION_S:.1f}/sec)"
+            f"\n    Total reads: {total_reads:,}"
+        )
+        # Even with occasional writers, reader throughput should be reasonable.
+        # Under GIL, pure-lock throughput is limited. Production threads do
+        # CUDA work between lock ops, so effective throughput is much higher.
+        self.assertGreater(
+            per_thread_avg,
+            1_000,
+            f"Reader throughput too low with writers: {per_thread_avg:.0f} ops/sec",
+        )
+
+    def test_writer_wait_time_with_active_readers(self) -> None:
+        """
+        Measure how long a writer waits for N active readers to drain.
+        Readers hold the lock for a known duration, writer measures wait time.
+        """
+        lock: _RWLock = _RWLock()
+        N_READERS = 8
+        HOLD_MS: int = 10  # each reader holds for 10ms
+
+        # All readers grab lock simultaneously
+        all_acquired: threading.Barrier = threading.Barrier(N_READERS)
+
+        def reader() -> None:
+            lock.acquire_read()
+            all_acquired.wait()
+            time.sleep(HOLD_MS / 1000.0)
+            lock.release_read()
+
+        threads = [threading.Thread(target=reader) for _ in range(N_READERS)]
+        for t in threads:
+            t.start()
+        time.sleep(0.02)  # let readers acquire
+
+        # Writer measures wait time
+        start = time.perf_counter()
+        lock.acquire_write()
+        wait_time = (time.perf_counter() - start) * 1000
+        lock.release_write()
+
+        for t in threads:
+            t.join(timeout=5.0)
+
+        print(
+            f"\n  Writer wait for {N_READERS} readers (each holding {HOLD_MS}ms):"
+            f"\n    Wait time: {wait_time:.1f}ms"
+        )
+        # Writer should wait roughly HOLD_MS (not N * HOLD_MS — readers overlap)
+        self.assertLess(
+            wait_time,
+            HOLD_MS * 3,  # generous 3x budget for thread scheduling
+            f"Writer waited too long: {wait_time:.1f}ms",
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Part 3: SSD TBE Integration Tests (GPU required)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@unittest.skipIf(*running_in_oss)
+@unittest.skipIf(*gpu_unavailable)
+class SSDTBEConcurrencyTest(unittest.TestCase):
+    """
+    Integration tests for the RWLock inside SSD TBE.
+    Verifies no deadlocks and correct behavior when prefetch/forward
+    run concurrently with streaming_update/load_snapshot.
+    """
+
+    TIMEOUT: float = 30.0
+
+    def _create_emb(
+        self,
+        E: int = 5000,
+        D: int = 64,
+        T: int = 1,
+        cache_sets: int = 64,
+        weights_ty: SparseType = SparseType.FP32,
+    ) -> SSDIntNBitTableBatchedEmbeddingBags:
+        return SSDIntNBitTableBatchedEmbeddingBags(
+            embedding_specs=[("", E, D, weights_ty)] * T,
+            feature_table_map=list(range(T)),
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=cache_sets,
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            pooling_mode=PoolingMode.SUM,
+        ).cuda()
+
+    def _init_table(
+        self,
+        emb: SSDIntNBitTableBatchedEmbeddingBags,
+        E: int,
+        D_bytes: int,
+    ) -> torch.Tensor:
+        weights = torch.randint(0, 255, (E, D_bytes), dtype=torch.uint8)
+        emb.ssd_db.set_cuda(
+            torch.arange(E, dtype=torch.int64),
+            weights,
+            torch.tensor([E]),
+            0,
+        )
+        torch.cuda.synchronize()
+        return weights
+
+    # ─── Concurrent prefetch/forward (readers only) ──────────────────────
+
+    def test_concurrent_prefetch_forward_no_deadlock(self) -> None:
+        """
+        Multiple threads calling prefetch+forward concurrently.
+        This is the serving hot path — must not deadlock.
+        """
+        E: int = 2000
+        D: int = 64
+        B: int = 4
+        L: int = 5
+        weights_ty = SparseType.FP32
+        D_bytes: int = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb: SSDIntNBitTableBatchedEmbeddingBags = self._create_emb(
+            E=E, D=D, cache_sets=max(B * L, 1), weights_ty=weights_ty
+        )
+        self._init_table(emb, E, D_bytes)
+
+        errors: list[str] = []
+        N_THREADS = 4
+        N_ITERS: int = 20
+
+        def inference_worker(thread_id: int) -> None:
+            try:
+                for _i in range(N_ITERS):
+                    xs = torch.randint(0, E, (B, L)).cuda()
+                    x = xs.view(1, B, L)
+                    indices, offsets = get_table_batched_offsets_from_dense(x)
+                    indices, offsets = indices.cuda(), offsets.cuda()
+                    emb.prefetch(indices, offsets)
+                    emb(indices.int(), offsets.int())
+            except Exception as e:
+                errors.append(f"thread {thread_id}: {e}")
+
+        threads = [
+            threading.Thread(target=inference_worker, args=(i,))
+            for i in range(N_THREADS)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=self.TIMEOUT)
+            self.assertFalse(t.is_alive(), "Inference thread deadlocked")
+
+        self.assertEqual(errors, [], f"Errors during concurrent inference: {errors}")
+
+    # ─── Concurrent readers + streaming_update writer ────────────────────
+
+    def test_concurrent_inference_and_streaming_update(self) -> None:
+        """
+        Readers (prefetch+forward) running concurrently with a writer
+        (streaming_update). Must not deadlock, and updated weights must
+        eventually be visible.
+        """
+        E: int = 2000
+        D: int = 64
+        B: int = 4
+        L: int = 5
+        weights_ty = SparseType.FP32
+        D_bytes: int = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb: SSDIntNBitTableBatchedEmbeddingBags = self._create_emb(
+            E=E, D=D, cache_sets=max(B * L * 2, 1), weights_ty=weights_ty
+        )
+        self._init_table(emb, E, D_bytes)
+
+        errors: list[str] = []
+        stop: threading.Event = threading.Event()
+        reader_ops: list[int] = [0]
+        writer_ops: list[int] = [0]
+
+        def reader_loop() -> None:
+            try:
+                while not stop.is_set():
+                    xs = torch.randint(0, E, (B, L)).cuda()
+                    x = xs.view(1, B, L)
+                    indices, offsets = get_table_batched_offsets_from_dense(x)
+                    indices, offsets = indices.cuda(), offsets.cuda()
+                    emb.prefetch(indices, offsets)
+                    emb(indices.int(), offsets.int())
+                    reader_ops[0] += 1
+            except Exception as e:
+                errors.append(f"reader: {e}")
+
+        def writer_loop() -> None:
+            try:
+                while not stop.is_set():
+                    idx = torch.randint(0, E, (10,), dtype=torch.int64)
+                    w = torch.randint(0, 255, (10, D_bytes), dtype=torch.uint8)
+                    emb.streaming_update(idx, w)
+                    writer_ops[0] += 1
+                    time.sleep(0.05)  # 50ms between writes (like production)
+            except Exception as e:
+                errors.append(f"writer: {e}")
+
+        # Start 3 readers + 1 writer
+        readers = [threading.Thread(target=reader_loop) for _ in range(3)]
+        writer = threading.Thread(target=writer_loop)
+        for r in readers:
+            r.start()
+        writer.start()
+
+        time.sleep(3.0)  # run for 3 seconds
+        stop.set()
+
+        writer.join(timeout=self.TIMEOUT)
+        for r in readers:
+            r.join(timeout=self.TIMEOUT)
+            self.assertFalse(r.is_alive(), "Reader deadlocked")
+        self.assertFalse(writer.is_alive(), "Writer deadlocked")
+
+        self.assertEqual(errors, [], f"Errors: {errors}")
+        print(
+            f"\n  Concurrent R+W: {reader_ops[0]} reads, {writer_ops[0]} writes in 3s"
+        )
+        self.assertGreater(reader_ops[0], 0, "No reader ops completed")
+        self.assertGreater(writer_ops[0], 0, "No writer ops completed")
+
+    # ─── Concurrent readers + load_snapshot writer ───────────────────────
+
+    def test_concurrent_inference_and_load_snapshot(self) -> None:
+        """
+        Readers + load_snapshot writer. Snapshot swap invalidates entire
+        cache — must not corrupt in-flight reads.
+        """
+        E: int = 1000
+        D: int = 64
+        B: int = 2
+        L: int = 3
+        weights_ty = SparseType.FP32
+        D_bytes: int = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb: SSDIntNBitTableBatchedEmbeddingBags = self._create_emb(
+            E=E, D=D, cache_sets=max(B * L, 1), weights_ty=weights_ty
+        )
+        self._init_table(emb, E, D_bytes)
+
+        errors: list[str] = []
+        stop: threading.Event = threading.Event()
+
+        def reader_loop() -> None:
+            try:
+                while not stop.is_set():
+                    xs = torch.randint(0, E, (B, L)).cuda()
+                    x = xs.view(1, B, L)
+                    indices, offsets = get_table_batched_offsets_from_dense(x)
+                    indices, offsets = indices.cuda(), offsets.cuda()
+                    emb.prefetch(indices, offsets)
+                    result = emb(indices.int(), offsets.int())
+                    # Note: after load_snapshot() swaps to an empty DB,
+                    # forward output may contain uninitialized data (NaN/Inf).
+                    # This is expected — the test verifies no deadlocks or
+                    # crashes during concurrent snapshot swaps, not output
+                    # correctness.
+                    self.assertIsNotNone(result, "forward returned None")
+            except Exception as e:
+                errors.append(f"reader: {e}")
+
+        def snapshot_loop() -> None:
+            try:
+                for _ in range(3):  # do 3 snapshot swaps
+                    if stop.is_set():
+                        break
+                    time.sleep(0.3)
+                    new_dir = tempfile.mkdtemp()
+                    emb.load_snapshot(new_dir)
+            except Exception as e:
+                errors.append(f"snapshot: {e}")
+
+        readers = [threading.Thread(target=reader_loop) for _ in range(2)]
+        writer = threading.Thread(target=snapshot_loop)
+        for r in readers:
+            r.start()
+        writer.start()
+
+        writer.join(timeout=self.TIMEOUT)
+        stop.set()
+        for r in readers:
+            r.join(timeout=self.TIMEOUT)
+            self.assertFalse(r.is_alive(), "Reader deadlocked during snapshot")
+
+        self.assertEqual(errors, [], f"Errors: {errors}")
+
+    # ─── Streaming update correctness under concurrency ──────────────────
+
+    def test_streaming_update_correctness_under_concurrent_reads(self) -> None:
+        """
+        While readers are running, do a streaming_update. Then verify
+        that after all threads stop, the updated values are in RocksDB.
+        """
+        E: int = 1000
+        D: int = 64
+        B: int = 2
+        L: int = 3
+        weights_ty = SparseType.FP32
+        D_bytes: int = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb: SSDIntNBitTableBatchedEmbeddingBags = self._create_emb(
+            E=E, D=D, cache_sets=max(B * L, 1), weights_ty=weights_ty
+        )
+        self._init_table(emb, E, D_bytes)
+
+        stop: threading.Event = threading.Event()
+        errors: list[str] = []
+
+        def reader_loop() -> None:
+            try:
+                while not stop.is_set():
+                    xs = torch.randint(0, E, (B, L)).cuda()
+                    x = xs.view(1, B, L)
+                    indices, offsets = get_table_batched_offsets_from_dense(x)
+                    indices, offsets = indices.cuda(), offsets.cuda()
+                    emb.prefetch(indices, offsets)
+                    emb(indices.int(), offsets.int())
+            except Exception as e:
+                errors.append(f"reader: {e}")
+
+        # Start readers
+        readers = [threading.Thread(target=reader_loop) for _ in range(2)]
+        for r in readers:
+            r.start()
+
+        # Do some updates while readers are running
+        update_indices = torch.tensor([0, 100, 500, 999], dtype=torch.int64)
+        new_weights = torch.randint(0, 255, (4, D_bytes), dtype=torch.uint8)
+        time.sleep(0.5)  # let readers warm up
+        emb.streaming_update(update_indices, new_weights)
+
+        # Stop readers and wait for them to finish
+        stop.set()
+        for r in readers:
+            r.join(timeout=self.TIMEOUT)
+            self.assertFalse(r.is_alive(), "Reader deadlocked")
+
+        self.assertEqual(errors, [], f"Errors: {errors}")
+
+        # After all concurrent activity stops, do a fresh streaming_update
+        # to ensure the final state is correct (concurrent readers may have
+        # evicted cache entries, so we re-write and verify)
+        emb.streaming_update(update_indices, new_weights)
+        torch.cuda.synchronize()
+
+        # Verify correctness — the updated values should be in RocksDB
+        output = torch.empty(4, D_bytes, dtype=torch.uint8)
+        emb.ssd_db.get_cuda(update_indices.cpu(), output, torch.tensor([4]))
+        torch.cuda.synchronize()
+        torch.testing.assert_close(output, new_weights)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Part 4: SSD TBE Lock Overhead Benchmarks (GPU required)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@unittest.skipIf(*running_in_oss)
+@unittest.skipIf(*gpu_unavailable)
+class SSDTBELockOverheadBenchmarkTest(unittest.TestCase):
+    """
+    Measures the overhead of adding RWLock to prefetch/forward.
+    Compares locked vs direct (bypass lock) call times.
+    """
+
+    def _create_emb(
+        self,
+        E: int = 5000,
+        D: int = 64,
+        cache_sets: int = 64,
+    ) -> SSDIntNBitTableBatchedEmbeddingBags:
+        return SSDIntNBitTableBatchedEmbeddingBags(
+            embedding_specs=[("", E, D, SparseType.FP32)],
+            feature_table_map=[0],
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=cache_sets,
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            pooling_mode=PoolingMode.SUM,
+        ).cuda()
+
+    def _init_and_warmup(
+        self,
+        emb: SSDIntNBitTableBatchedEmbeddingBags,
+        E: int,
+        D: int,
+        B: int,
+        L: int,
+    ) -> tuple[int, SparseType]:
+        """Initialize table and do warmup iterations."""
+        weights_ty = SparseType.FP32
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+        weights = torch.randint(0, 255, (E, D_bytes), dtype=torch.uint8)
+        emb.ssd_db.set_cuda(
+            torch.arange(E, dtype=torch.int64),
+            weights,
+            torch.tensor([E]),
+            0,
+        )
+        torch.cuda.synchronize()
+
+        # Warmup
+        for _ in range(5):
+            xs = torch.randint(0, E, (B, L)).cuda()
+            x = xs.view(1, B, L)
+            indices, offsets = get_table_batched_offsets_from_dense(x)
+            indices, offsets = indices.cuda(), offsets.cuda()
+            emb.prefetch(indices, offsets)
+            emb(indices.int(), offsets.int())
+        torch.cuda.synchronize()
+        return D_bytes, weights_ty
+
+    def test_prefetch_lock_overhead(self) -> None:
+        """
+        Compare prefetch() (with lock) vs _prefetch_impl() (bypass lock).
+        The difference is the lock overhead.
+        """
+        E = 5000
+        D = 64
+        B = 8
+        L = 10
+        N_ITERS = 100
+
+        emb = self._create_emb(E=E, D=D, cache_sets=max(B * L, 1))
+        self._init_and_warmup(emb, E, D, B, L)
+
+        # Generate test data
+        all_data = []
+        for _ in range(N_ITERS):
+            xs = torch.randint(0, E, (B, L)).cuda()
+            x = xs.view(1, B, L)
+            indices, offsets = get_table_batched_offsets_from_dense(x)
+            all_data.append((indices.cuda(), offsets.cuda()))
+
+        # Measure locked (public API)
+        torch.cuda.synchronize()
+        locked_times = []
+        for indices, offsets in all_data:
+            start = time.perf_counter()
+            emb.prefetch(indices, offsets)
+            torch.cuda.synchronize()
+            locked_times.append(time.perf_counter() - start)
+            # Reset prefetch counter
+            emb.timestep_prefetch_size.decrement()
+
+        # Measure unlocked (bypass lock via _prefetch_impl)
+        torch.cuda.synchronize()
+        unlocked_times = []
+        for indices, offsets in all_data:
+            start = time.perf_counter()
+            emb._prefetch_impl(indices, offsets)
+            torch.cuda.synchronize()
+            unlocked_times.append(time.perf_counter() - start)
+            emb.timestep_prefetch_size.decrement()
+
+        locked_avg_us = statistics.mean(locked_times) * 1e6
+        unlocked_avg_us = statistics.mean(unlocked_times) * 1e6
+        overhead_us = locked_avg_us - unlocked_avg_us
+        overhead_pct = (
+            (overhead_us / unlocked_avg_us) * 100 if unlocked_avg_us > 0 else 0
+        )
+
+        locked_p50 = sorted(locked_times)[len(locked_times) // 2] * 1e6
+        unlocked_p50 = sorted(unlocked_times)[len(unlocked_times) // 2] * 1e6
+
+        print(
+            f"\n  Prefetch lock overhead (E={E}, B={B}, L={L}):"
+            f"\n    Locked avg:   {locked_avg_us:.1f} µs  (p50: {locked_p50:.1f} µs)"
+            f"\n    Unlocked avg: {unlocked_avg_us:.1f} µs  (p50: {unlocked_p50:.1f} µs)"
+            f"\n    Overhead:     {overhead_us:.1f} µs ({overhead_pct:.2f}%)"
+        )
+
+        # Lock overhead should be small relative to total prefetch time.
+        # Use 200 µs threshold to account for RE machine noise.
+        self.assertLess(
+            overhead_us,
+            200.0,
+            f"Lock overhead too high: {overhead_us:.1f} µs (limit 200 µs)",
+        )
+
+    def test_forward_lock_overhead(self) -> None:
+        """
+        Compare forward() (with lock) vs _forward_impl() (bypass lock).
+        """
+        E = 5000
+        D = 64
+        B = 8
+        L = 10
+        N_ITERS = 100
+
+        emb = self._create_emb(E=E, D=D, cache_sets=max(B * L, 1))
+        self._init_and_warmup(emb, E, D, B, L)
+
+        all_data = []
+        for _ in range(N_ITERS):
+            xs = torch.randint(0, E, (B, L)).cuda()
+            x = xs.view(1, B, L)
+            indices, offsets = get_table_batched_offsets_from_dense(x)
+            all_data.append((indices.cuda(), offsets.cuda()))
+
+        # Measure locked forward
+        torch.cuda.synchronize()
+        locked_times = []
+        for indices, offsets in all_data:
+            emb.prefetch(indices, offsets)
+            torch.cuda.synchronize()
+            start = time.perf_counter()
+            emb(indices.int(), offsets.int())
+            torch.cuda.synchronize()
+            locked_times.append(time.perf_counter() - start)
+
+        # Measure unlocked forward
+        torch.cuda.synchronize()
+        unlocked_times = []
+        for indices, offsets in all_data:
+            emb._prefetch_impl(indices, offsets)
+            torch.cuda.synchronize()
+            start = time.perf_counter()
+            emb._forward_impl(indices.int(), offsets.int())
+            torch.cuda.synchronize()
+            unlocked_times.append(time.perf_counter() - start)
+
+        locked_avg_us = statistics.mean(locked_times) * 1e6
+        unlocked_avg_us = statistics.mean(unlocked_times) * 1e6
+        overhead_us = locked_avg_us - unlocked_avg_us
+        overhead_pct = (
+            (overhead_us / unlocked_avg_us) * 100 if unlocked_avg_us > 0 else 0
+        )
+
+        print(
+            f"\n  Forward lock overhead (E={E}, B={B}, L={L}):"
+            f"\n    Locked avg:   {locked_avg_us:.1f} µs"
+            f"\n    Unlocked avg: {unlocked_avg_us:.1f} µs"
+            f"\n    Overhead:     {overhead_us:.1f} µs ({overhead_pct:.2f}%)"
+        )
+
+        self.assertLess(
+            overhead_us,
+            200.0,
+            f"Forward lock overhead too high: {overhead_us:.1f} µs (limit 200 µs)",
+        )
+
+    def test_streaming_update_latency(self) -> None:
+        """
+        Measure streaming_update() latency (includes write lock + CUDA sync).
+        This runs alone (no contention) — measures the cost of the lock
+        machinery + double CUDA sync.
+        """
+        E = 5000
+        D = 64
+        weights_ty = SparseType.FP32
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+        N_ITERS = 50
+
+        emb = self._create_emb(E=E, D=D, cache_sets=64)
+        weights = torch.randint(0, 255, (E, D_bytes), dtype=torch.uint8)
+        emb.ssd_db.set_cuda(
+            torch.arange(E, dtype=torch.int64),
+            weights,
+            torch.tensor([E]),
+            0,
+        )
+        torch.cuda.synchronize()
+
+        # Warmup
+        for _ in range(3):
+            idx = torch.randint(0, E, (10,), dtype=torch.int64)
+            w = torch.randint(0, 255, (10, D_bytes), dtype=torch.uint8)
+            emb.streaming_update(idx, w)
+
+        # Measure
+        times = []
+        for _ in range(N_ITERS):
+            idx = torch.randint(0, E, (10,), dtype=torch.int64)
+            w = torch.randint(0, 255, (10, D_bytes), dtype=torch.uint8)
+            start = time.perf_counter()
+            emb.streaming_update(idx, w)
+            times.append(time.perf_counter() - start)
+
+        avg_ms = statistics.mean(times) * 1000
+        p50_ms = sorted(times)[len(times) // 2] * 1000
+        p99_ms = sorted(times)[int(0.99 * len(times))] * 1000
+
+        print(
+            f"\n  streaming_update latency (10 rows, uncontended):"
+            f"\n    Avg: {avg_ms:.2f} ms, P50: {p50_ms:.2f} ms, P99: {p99_ms:.2f} ms"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_inference_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_inference_test.py
@@ -645,3 +645,703 @@ class SSDInferenceCacheLockingTest(unittest.TestCase):
             f"Cache locking counter should be all zeros when disabled, "
             f"but max={counter.max().item()}",
         )
+
+
+@unittest.skipIf(*running_in_oss)
+@unittest.skipIf(*gpu_unavailable)
+class SSDInferenceStreamingTest(unittest.TestCase):
+    """
+    Tests for streaming_update() and load_snapshot() in SSD TBE inference.
+    """
+
+    def _create_emb(
+        self,
+        E: int = 10000,
+        D: int = 128,
+        T: int = 1,
+        cache_sets: int = 64,
+        weights_ty: SparseType = SparseType.FP32,
+    ) -> "SSDIntNBitTableBatchedEmbeddingBags":
+        import tempfile
+
+        return SSDIntNBitTableBatchedEmbeddingBags(
+            embedding_specs=[("", E, D, weights_ty)] * T,
+            feature_table_map=list(range(T)),
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=cache_sets,
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            pooling_mode=PoolingMode.SUM,
+        ).cuda()
+
+    def _init_table(
+        self,
+        emb: "SSDIntNBitTableBatchedEmbeddingBags",
+        E: int,
+        D_bytes: int,
+        T: int = 1,
+    ) -> torch.Tensor:
+        """Initialize all tables with random data and return the weight tensor."""
+        weights = torch.randint(0, 255, (T * E, D_bytes), dtype=torch.uint8)
+        for t in range(T):
+            emb.ssd_db.set_cuda(
+                torch.arange(t * E, (t + 1) * E, dtype=torch.int64),
+                weights[t * E : (t + 1) * E],
+                torch.tensor([E]),
+                t,
+            )
+        torch.cuda.synchronize()
+        return weights
+
+    # ─── Basic streaming_update tests ───────────────────────────────────
+
+    def test_streaming_update_writes_to_ssd(self) -> None:
+        """Verify streaming_update() writes to RocksDB."""
+        E = 1000
+        D = 128
+        weights_ty = SparseType.FP32
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb = self._create_emb(E=E, D=D, cache_sets=128, weights_ty=weights_ty)
+        self._init_table(emb, E, D_bytes)
+
+        update_indices = torch.tensor([0, 10, 100, 999], dtype=torch.int64)
+        N = update_indices.shape[0]
+        new_weights = torch.randint(0, 255, (N, D_bytes), dtype=torch.uint8)
+        emb.streaming_update(update_indices, new_weights)
+
+        output = torch.empty(N, D_bytes, dtype=torch.uint8)
+        emb.ssd_db.get_cuda(update_indices.cpu(), output, torch.tensor([N]))
+        torch.cuda.synchronize()
+        torch.testing.assert_close(output, new_weights)
+
+    def test_streaming_update_invalidates_cache(self) -> None:
+        """Verify streaming_update() invalidates HBM cache entries."""
+        E = 1000
+        D = 128
+        T = 1
+        B = 4
+        L = 5
+        weights_ty = SparseType.FP32
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb = self._create_emb(
+            E=E,
+            D=D,
+            T=T,
+            cache_sets=max(T * B * L, 1),
+            weights_ty=weights_ty,
+        )
+        self._init_table(emb, E, D_bytes)
+
+        # Prefetch to populate cache.
+        xs = torch.randint(low=0, high=E, size=(B, L)).cuda()
+        x = xs.view(1, B, L)
+        indices, offsets = get_table_batched_offsets_from_dense(x)
+        indices, offsets = indices.cuda(), offsets.cuda()
+        emb.prefetch(indices, offsets)
+
+        # Find which indices are cached.
+        linear_indices = torch.ops.fbgemm.linearize_cache_indices(
+            emb.hash_size_cumsum, indices, offsets
+        )
+        cache_state = emb.lxu_cache_state.cpu()
+        cached_indices = set(cache_state[cache_state >= 0].tolist())
+        requested_indices = set(linear_indices.cpu().tolist())
+        cached_from_request = cached_indices & requested_indices
+        self.assertGreater(len(cached_from_request), 0)
+
+        # streaming_update those cached indices.
+        update_list = sorted(cached_from_request)[:4]
+        update_indices = torch.tensor(update_list, dtype=torch.int64)
+        N = update_indices.shape[0]
+        new_weights = torch.randint(0, 255, (N, D_bytes), dtype=torch.uint8)
+        emb.streaming_update(update_indices, new_weights)
+
+        # Verify invalidation.
+        cache_state_after = emb.lxu_cache_state.cpu()
+        for idx in update_list:
+            cache_set = idx % cache_state_after.shape[0]
+            slots = cache_state_after[cache_set]
+            self.assertFalse(
+                (slots == idx).any().item(),
+                f"Index {idx} should have been invalidated from cache",
+            )
+
+    def test_streaming_update_empty(self) -> None:
+        """Empty update is a no-op."""
+        emb = self._create_emb()
+        emb.streaming_update(
+            torch.tensor([], dtype=torch.int64),
+            torch.empty(0, emb.max_D_cache, dtype=torch.uint8),
+        )
+
+    # ─── Edge cases and corner cases ────────────────────────────────────
+
+    def test_streaming_update_single_row(self) -> None:
+        """Update a single row."""
+        E = 100
+        D = 64
+        weights_ty = SparseType.FP32
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb = self._create_emb(E=E, D=D, cache_sets=32, weights_ty=weights_ty)
+        self._init_table(emb, E, D_bytes)
+
+        idx = torch.tensor([42], dtype=torch.int64)
+        new_w = torch.randint(0, 255, (1, D_bytes), dtype=torch.uint8)
+        emb.streaming_update(idx, new_w)
+
+        out = torch.empty(1, D_bytes, dtype=torch.uint8)
+        emb.ssd_db.get_cuda(idx, out, torch.tensor([1]))
+        torch.cuda.synchronize()
+        torch.testing.assert_close(out, new_w)
+
+    def test_streaming_update_first_and_last_index(self) -> None:
+        """Update the first (0) and last (E-1) indices."""
+        E = 500
+        D = 128
+        weights_ty = SparseType.FP32
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb = self._create_emb(E=E, D=D, cache_sets=32, weights_ty=weights_ty)
+        self._init_table(emb, E, D_bytes)
+
+        indices = torch.tensor([0, E - 1], dtype=torch.int64)
+        new_w = torch.randint(0, 255, (2, D_bytes), dtype=torch.uint8)
+        emb.streaming_update(indices, new_w)
+
+        out = torch.empty(2, D_bytes, dtype=torch.uint8)
+        emb.ssd_db.get_cuda(indices, out, torch.tensor([2]))
+        torch.cuda.synchronize()
+        torch.testing.assert_close(out, new_w)
+
+    def test_streaming_update_duplicate_indices(self) -> None:
+        """
+        Duplicate indices: last write wins for RocksDB, both cache entries
+        should be invalidated.
+        """
+        E = 1000
+        D = 128
+        weights_ty = SparseType.FP32
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb = self._create_emb(E=E, D=D, cache_sets=64, weights_ty=weights_ty)
+        self._init_table(emb, E, D_bytes)
+
+        # Same index appears twice with different values.
+        indices = torch.tensor([42, 42], dtype=torch.int64)
+        w1 = torch.randint(0, 255, (1, D_bytes), dtype=torch.uint8)
+        w2 = torch.randint(0, 255, (1, D_bytes), dtype=torch.uint8)
+        both = torch.cat([w1, w2], dim=0)
+        emb.streaming_update(indices, both)
+
+        # Read back — should get w2 (last write).
+        out = torch.empty(1, D_bytes, dtype=torch.uint8)
+        emb.ssd_db.get_cuda(
+            torch.tensor([42], dtype=torch.int64), out, torch.tensor([1])
+        )
+        torch.cuda.synchronize()
+        torch.testing.assert_close(out, w2)
+
+    def test_streaming_update_large_batch(self) -> None:
+        """Update 1000 rows at once."""
+        E = 5000
+        D = 128
+        weights_ty = SparseType.FP32
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb = self._create_emb(E=E, D=D, cache_sets=128, weights_ty=weights_ty)
+        self._init_table(emb, E, D_bytes)
+
+        N = 1000
+        indices = torch.randperm(E)[:N].to(torch.int64)
+        new_w = torch.randint(0, 255, (N, D_bytes), dtype=torch.uint8)
+        emb.streaming_update(indices, new_w)
+
+        out = torch.empty(N, D_bytes, dtype=torch.uint8)
+        emb.ssd_db.get_cuda(indices, out, torch.tensor([N]))
+        torch.cuda.synchronize()
+        torch.testing.assert_close(out, new_w)
+
+    def test_streaming_update_preserves_non_updated_rows(self) -> None:
+        """Rows not included in the update remain unchanged."""
+        E = 200
+        D = 64
+        weights_ty = SparseType.FP32
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb = self._create_emb(E=E, D=D, cache_sets=32, weights_ty=weights_ty)
+        original = self._init_table(emb, E, D_bytes)
+
+        # Update only index 0.
+        emb.streaming_update(
+            torch.tensor([0], dtype=torch.int64),
+            torch.randint(0, 255, (1, D_bytes), dtype=torch.uint8),
+        )
+
+        # Check that index 1 still has original data.
+        out = torch.empty(1, D_bytes, dtype=torch.uint8)
+        emb.ssd_db.get_cuda(
+            torch.tensor([1], dtype=torch.int64), out, torch.tensor([1])
+        )
+        torch.cuda.synchronize()
+        torch.testing.assert_close(out, original[1:2])
+
+    def test_streaming_update_sequential_updates(self) -> None:
+        """Multiple sequential updates to the same index; last one wins."""
+        E = 100
+        D = 64
+        weights_ty = SparseType.FP32
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb = self._create_emb(E=E, D=D, cache_sets=32, weights_ty=weights_ty)
+        self._init_table(emb, E, D_bytes)
+
+        idx = torch.tensor([5], dtype=torch.int64)
+        final_w = None
+        for _ in range(10):
+            final_w = torch.randint(0, 255, (1, D_bytes), dtype=torch.uint8)
+            emb.streaming_update(idx, final_w)
+
+        out = torch.empty(1, D_bytes, dtype=torch.uint8)
+        emb.ssd_db.get_cuda(idx, out, torch.tensor([1]))
+        torch.cuda.synchronize()
+        assert final_w is not None
+        torch.testing.assert_close(out, final_w)
+
+    def test_streaming_update_preserves_non_updated_cache(self) -> None:
+        """
+        Updating index A should NOT invalidate unrelated index B in the cache,
+        even if they map to the same cache set.
+        """
+        E = 1000
+        D = 128
+        T = 1
+        B = 8
+        L = 10
+        weights_ty = SparseType.FP32
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+        cache_sets = max(T * B * L, 1)
+
+        emb = self._create_emb(
+            E=E,
+            D=D,
+            T=T,
+            cache_sets=cache_sets,
+            weights_ty=weights_ty,
+        )
+        self._init_table(emb, E, D_bytes)
+
+        # Prefetch to populate cache.
+        xs = torch.randint(low=0, high=E, size=(B, L)).cuda()
+        x = xs.view(1, B, L)
+        indices, offsets = get_table_batched_offsets_from_dense(x)
+        indices, offsets = indices.cuda(), offsets.cuda()
+        emb.prefetch(indices, offsets)
+
+        cache_state_before = emb.lxu_cache_state.cpu()
+        all_cached = set(cache_state_before[cache_state_before >= 0].tolist())
+
+        if len(all_cached) < 2:
+            return  # Not enough cached entries to test.
+
+        # Pick one index to update, count the rest.
+        update_idx = sorted(all_cached)[0]
+        remaining = all_cached - {update_idx}
+
+        emb.streaming_update(
+            torch.tensor([update_idx], dtype=torch.int64),
+            torch.randint(0, 255, (1, D_bytes), dtype=torch.uint8),
+        )
+
+        # Verify all non-updated cached indices are still in the cache.
+        cache_state_after = emb.lxu_cache_state.cpu()
+        still_cached = set(cache_state_after[cache_state_after >= 0].tolist())
+        for idx in remaining:
+            self.assertIn(
+                idx,
+                still_cached,
+                f"Non-updated index {idx} should still be in cache",
+            )
+
+    # ─── Different sparse types ─────────────────────────────────────────
+
+    def test_streaming_update_int8(self) -> None:
+        """streaming_update with INT8 embeddings."""
+        E = 500
+        D = 128
+        weights_ty = SparseType.INT8
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb = self._create_emb(E=E, D=D, cache_sets=32, weights_ty=weights_ty)
+        self._init_table(emb, E, D_bytes)
+
+        indices = torch.tensor([0, 50, 499], dtype=torch.int64)
+        new_w = torch.randint(0, 255, (3, D_bytes), dtype=torch.uint8)
+        emb.streaming_update(indices, new_w)
+
+        out = torch.empty(3, D_bytes, dtype=torch.uint8)
+        emb.ssd_db.get_cuda(indices, out, torch.tensor([3]))
+        torch.cuda.synchronize()
+        torch.testing.assert_close(out, new_w)
+
+    def test_streaming_update_int4(self) -> None:
+        """streaming_update with INT4 embeddings."""
+        E = 500
+        D = 128
+        weights_ty = SparseType.INT4
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb = self._create_emb(E=E, D=D, cache_sets=32, weights_ty=weights_ty)
+        self._init_table(emb, E, D_bytes)
+
+        indices = torch.tensor([0, 250, 499], dtype=torch.int64)
+        new_w = torch.randint(0, 255, (3, D_bytes), dtype=torch.uint8)
+        emb.streaming_update(indices, new_w)
+
+        out = torch.empty(3, D_bytes, dtype=torch.uint8)
+        emb.ssd_db.get_cuda(indices, out, torch.tensor([3]))
+        torch.cuda.synchronize()
+        torch.testing.assert_close(out, new_w)
+
+    def test_streaming_update_fp16(self) -> None:
+        """streaming_update with FP16 embeddings."""
+        E = 500
+        D = 128
+        weights_ty = SparseType.FP16
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb = self._create_emb(E=E, D=D, cache_sets=32, weights_ty=weights_ty)
+        self._init_table(emb, E, D_bytes)
+
+        indices = torch.tensor([0, 100, 499], dtype=torch.int64)
+        new_w = torch.randint(0, 255, (3, D_bytes), dtype=torch.uint8)
+        emb.streaming_update(indices, new_w)
+
+        out = torch.empty(3, D_bytes, dtype=torch.uint8)
+        emb.ssd_db.get_cuda(indices, out, torch.tensor([3]))
+        torch.cuda.synchronize()
+        torch.testing.assert_close(out, new_w)
+
+    # ─── End-to-end forward correctness after streaming_update ──────────
+
+    def test_streaming_update_forward_correctness(self) -> None:
+        """
+        End-to-end: update some rows via streaming_update, then verify
+        that prefetch + forward produces correct output using the updated
+        weights.
+        """
+        import tempfile
+
+        E = 1000
+        D = 128
+        T = 1
+        B = 4
+        L = 5
+        weights_ty = SparseType.FP32
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb = SSDIntNBitTableBatchedEmbeddingBags(
+            embedding_specs=[("", E, D, weights_ty)],
+            feature_table_map=[0],
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=max(T * B * L, 1),
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            pooling_mode=PoolingMode.SUM,
+        ).cuda()
+
+        # Create reference FP32 EmbeddingBag.
+        ref = torch.nn.EmbeddingBag(E, D, mode="sum", sparse=True).cuda()
+        torch.manual_seed(42)
+
+        # Write quantized weights to SSD TBE.
+        weights, scale_shift = emb.split_embedding_weights()[0]
+        fake_quantize_embs(
+            weights,
+            scale_shift,
+            ref.weight.detach(),
+            weights_ty,
+            use_cpu=False,
+        )
+        copy_byte_tensor = torch.empty([E, D_bytes], dtype=torch.uint8)
+        copy_byte_tensor[:, : unpadded_row_size_in_bytes(D, weights_ty)] = weights
+        emb.ssd_db.set_cuda(
+            torch.arange(E, dtype=torch.int64),
+            copy_byte_tensor,
+            torch.tensor([E]),
+            0,
+        )
+        torch.cuda.synchronize()
+
+        # Update some rows in the reference, then streaming_update TBE.
+        update_indices = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int64)
+        new_ref_weights = torch.randn(5, D).cuda()
+        ref.weight.data[update_indices] = new_ref_weights
+
+        # Re-quantize updated rows.
+        updated_weights, updated_ss = emb.split_embedding_weights()[0]
+        fake_quantize_embs(
+            updated_weights,
+            updated_ss,
+            ref.weight.detach(),
+            weights_ty,
+            use_cpu=False,
+        )
+        updated_copy = torch.empty([E, D_bytes], dtype=torch.uint8)
+        updated_copy[:, : unpadded_row_size_in_bytes(D, weights_ty)] = updated_weights
+        # Only streaming_update the changed rows.
+        emb.streaming_update(update_indices, updated_copy[update_indices])
+
+        # Now query indices that include updated rows.
+        xs = torch.tensor([[0, 1, 2, 3, 4]], dtype=torch.long).cuda()  # [1, B=1, L=5]
+        x = xs.view(1, 1, 5)
+        indices, offsets = get_table_batched_offsets_from_dense(x)
+        indices, offsets = indices.cuda(), offsets.cuda()
+        emb.prefetch(indices, offsets)
+        result = emb(indices.int(), offsets.int())
+
+        expected = b_indices(ref, xs.view(1, 5))
+        torch.testing.assert_close(
+            result.float(),
+            expected.float(),
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+    # ─── Multi-table tests ──────────────────────────────────────────────
+
+    def test_streaming_update_multi_table(self) -> None:
+        """streaming_update on a multi-table TBE with linear index offsets."""
+        import tempfile
+
+        E = 500
+        D = 64
+        T = 3
+        weights_ty = SparseType.FP32
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb = SSDIntNBitTableBatchedEmbeddingBags(
+            embedding_specs=[("", E, D, weights_ty)] * T,
+            feature_table_map=list(range(T)),
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=64,
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            pooling_mode=PoolingMode.SUM,
+        ).cuda()
+        self._init_table(emb, E, D_bytes, T=T)
+
+        # Update row 0 of table 2 (linear index = 2*E + 0 = 1000).
+        linear_idx = 2 * E
+        idx = torch.tensor([linear_idx], dtype=torch.int64)
+        new_w = torch.randint(0, 255, (1, D_bytes), dtype=torch.uint8)
+        emb.streaming_update(idx, new_w)
+
+        out = torch.empty(1, D_bytes, dtype=torch.uint8)
+        emb.ssd_db.get_cuda(idx, out, torch.tensor([1]))
+        torch.cuda.synchronize()
+        torch.testing.assert_close(out, new_w)
+
+    # ─── load_snapshot tests ────────────────────────────────────────────
+
+    def test_load_snapshot(self) -> None:
+        """load_snapshot() swaps RocksDB and clears HBM cache."""
+        import tempfile
+
+        E = 1000
+        D = 128
+        T = 1
+        B = 4
+        L = 5
+        weights_ty = SparseType.FP32
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb = self._create_emb(
+            E=E,
+            D=D,
+            T=T,
+            cache_sets=max(T * B * L, 1),
+            weights_ty=weights_ty,
+        )
+        initial_weights = self._init_table(emb, E, D_bytes)
+
+        # Prefetch to populate cache.
+        xs = torch.randint(low=0, high=E, size=(B, L)).cuda()
+        x = xs.view(1, B, L)
+        indices, offsets = get_table_batched_offsets_from_dense(x)
+        indices, offsets = indices.cuda(), offsets.cuda()
+        emb.prefetch(indices, offsets)
+
+        cache_state_before = emb.lxu_cache_state.cpu()
+        self.assertTrue((cache_state_before >= 0).any().item())
+
+        # Load new snapshot.
+        new_snapshot_dir = tempfile.mkdtemp()
+        emb.load_snapshot(new_snapshot_dir)
+
+        # Cache fully invalidated.
+        cache_state_after = emb.lxu_cache_state.cpu()
+        self.assertTrue((cache_state_after == -1).all().item())
+
+        # Old data gone.
+        check_indices = torch.tensor([0, 10, 100, 999], dtype=torch.int64)
+        N = check_indices.shape[0]
+        output = torch.empty(N, D_bytes, dtype=torch.uint8)
+        emb.ssd_db.get_cuda(check_indices, output, torch.tensor([N]))
+        torch.cuda.synchronize()
+        old_data = initial_weights[check_indices]
+        self.assertFalse(torch.equal(output, old_data))
+
+        # Writes to new DB work.
+        new_weights = torch.randint(0, 255, (N, D_bytes), dtype=torch.uint8)
+        emb.streaming_update(check_indices, new_weights)
+        output2 = torch.empty(N, D_bytes, dtype=torch.uint8)
+        emb.ssd_db.get_cuda(check_indices, output2, torch.tensor([N]))
+        torch.cuda.synchronize()
+        torch.testing.assert_close(output2, new_weights)
+
+    def test_load_snapshot_then_forward(self) -> None:
+        """
+        After load_snapshot + streaming_update, prefetch + forward returns
+        correct results from the new data.
+        """
+        import tempfile
+
+        E = 500
+        D = 64
+        T = 1
+        B = 2
+        L = 3
+        weights_ty = SparseType.FP32
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb = SSDIntNBitTableBatchedEmbeddingBags(
+            embedding_specs=[("", E, D, weights_ty)],
+            feature_table_map=[0],
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=max(T * B * L, 1),
+            ssd_uniform_init_lower=-0.1,
+            ssd_uniform_init_upper=0.1,
+            pooling_mode=PoolingMode.SUM,
+        ).cuda()
+
+        # Initial data + forward.
+        ref = torch.nn.EmbeddingBag(E, D, mode="sum", sparse=True).cuda()
+        torch.manual_seed(99)
+
+        weights, scale_shift = emb.split_embedding_weights()[0]
+        fake_quantize_embs(
+            weights,
+            scale_shift,
+            ref.weight.detach(),
+            weights_ty,
+            use_cpu=False,
+        )
+        copy_bytes = torch.empty([E, D_bytes], dtype=torch.uint8)
+        copy_bytes[:, : unpadded_row_size_in_bytes(D, weights_ty)] = weights
+        emb.ssd_db.set_cuda(
+            torch.arange(E, dtype=torch.int64),
+            copy_bytes,
+            torch.tensor([E]),
+            0,
+        )
+        torch.cuda.synchronize()
+
+        # Swap to new snapshot.
+        new_dir = tempfile.mkdtemp()
+        emb.load_snapshot(new_dir)
+
+        # Write new reference data.
+        ref2 = torch.nn.EmbeddingBag(E, D, mode="sum", sparse=True).cuda()
+        torch.manual_seed(123)
+        ref2.weight.data = torch.randn_like(ref2.weight.data)
+
+        weights2, ss2 = emb.split_embedding_weights()[0]
+        fake_quantize_embs(
+            weights2,
+            ss2,
+            ref2.weight.detach(),
+            weights_ty,
+            use_cpu=False,
+        )
+        copy_bytes2 = torch.empty([E, D_bytes], dtype=torch.uint8)
+        copy_bytes2[:, : unpadded_row_size_in_bytes(D, weights_ty)] = weights2
+        # Populate new snapshot via streaming_update in batches.
+        batch_size = 100
+        for start in range(0, E, batch_size):
+            end = min(start + batch_size, E)
+            idx = torch.arange(start, end, dtype=torch.int64)
+            emb.streaming_update(idx, copy_bytes2[start:end])
+
+        # Forward and verify against new reference.
+        xs = torch.randint(0, E, (B, L)).cuda()
+        x = xs.view(1, B, L)
+        indices, offsets = get_table_batched_offsets_from_dense(x)
+        indices, offsets = indices.cuda(), offsets.cuda()
+        emb.prefetch(indices, offsets)
+        result = emb(indices.int(), offsets.int())
+
+        expected = b_indices(ref2, xs)
+        torch.testing.assert_close(
+            result.float(),
+            expected.float(),
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+    def test_load_snapshot_multiple_swaps(self) -> None:
+        """Multiple sequential load_snapshot calls work correctly."""
+        import tempfile
+
+        E = 200
+        D = 64
+        weights_ty = SparseType.FP32
+        D_bytes = rounded_row_size_in_bytes(D, weights_ty, 16)
+
+        emb = self._create_emb(E=E, D=D, cache_sets=32, weights_ty=weights_ty)
+
+        for i in range(3):
+            snap_dir = tempfile.mkdtemp()
+            emb.load_snapshot(snap_dir)
+
+            # Write data specific to this snapshot.
+            marker = torch.full((1, D_bytes), fill_value=i + 1, dtype=torch.uint8)
+            emb.streaming_update(torch.tensor([0], dtype=torch.int64), marker)
+
+            out = torch.empty(1, D_bytes, dtype=torch.uint8)
+            emb.ssd_db.get_cuda(
+                torch.tensor([0], dtype=torch.int64), out, torch.tensor([1])
+            )
+            torch.cuda.synchronize()
+            torch.testing.assert_close(out, marker)
+
+    # ─── Assertion / validation tests ───────────────────────────────────
+
+    def test_streaming_update_asserts_1d_indices(self) -> None:
+        """streaming_update rejects 2D indices."""
+        emb = self._create_emb(E=100, D=64)
+        with self.assertRaises(AssertionError):
+            emb.streaming_update(
+                torch.zeros(2, 2, dtype=torch.int64),
+                torch.empty(4, emb.max_D_cache, dtype=torch.uint8),
+            )
+
+    def test_streaming_update_asserts_2d_weights(self) -> None:
+        """streaming_update rejects 1D weights."""
+        emb = self._create_emb(E=100, D=64)
+        with self.assertRaises(AssertionError):
+            emb.streaming_update(
+                torch.tensor([0], dtype=torch.int64),
+                torch.empty(emb.max_D_cache, dtype=torch.uint8),
+            )
+
+    def test_streaming_update_asserts_shape_mismatch(self) -> None:
+        """streaming_update rejects mismatched indices/weights counts."""
+        emb = self._create_emb(E=100, D=64)
+        with self.assertRaises(AssertionError):
+            emb.streaming_update(
+                torch.tensor([0, 1], dtype=torch.int64),
+                torch.empty(3, emb.max_D_cache, dtype=torch.uint8),
+            )


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2521

Add streaming delta update support to the SSD TBE inference operator
(SSDIntNBitTableBatchedEmbeddingBags), closing the gap with EmbeddingDB's
streaming delta table feature.

Two new public methods:

1. streaming_update(indices, weights) — writes updated embedding rows to
   RocksDB and invalidates corresponding HBM cache entries so subsequent
   prefetch() calls reload from SSD. Uses vectorized set-associative
   cache invalidation.

2. load_snapshot(ssd_storage_directory, ...) — flushes the current
   RocksDB, opens a new instance at a fresh directory, and fully
   invalidates the HBM cache. Enables zero-downtime snapshot transitions.

Also adds a writer-priority _RWLock for concurrent inference + rare updates:
- prefetch()/forward() take shared read locks (~2 µs overhead)
- streaming_update()/load_snapshot() take exclusive write locks with CUDA sync
- Writer-priority prevents starvation under sustained read load

Also adds AMD/ROCm awareness:
- IS_ROCM detection flag
- Constructor warns when running on ROCm (streaming API works but
  prefetch/forward C++ kernels are NVIDIA-only due to ASSOC=32 vs
  kWarpSize=64 mismatch)
- Docstring documents AMD support status per method

These are the minimal primitives needed for online training models with
streaming embedding updates (e.g., 45-min publish intervals).

Reviewed By: royren622, q10

Differential Revision: D98827795


