### PR TITLE
Use sym_numel() instead of numel() in TBE pt2 backward codegen

### DIFF
--- a/fbgemm_gpu/codegen/genscript/optimizer_args.py
+++ b/fbgemm_gpu/codegen/genscript/optimizer_args.py
@@ -674,7 +674,7 @@ class PT2ArgsSet:
                     split_variables.append(
                         f"ret.push_back(Variable()); // {s.name}_offsets"
                     )
-                    split_variables.append("if (" + name + "_host.numel() == 0) {")
+                    split_variables.append("if (" + name + "_host.sym_numel() == 0) {")
                     split_variables.append(
                         f"ret.push_back(Variable()); // {s.name}_uvm"
                     )


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2528

The generated pt2 autograd backward function used `.numel()` on optimizer
state tensors (momentum1_host, prev_iter_host, row_counter_host) when
building the return gradient list. During AOT autograd tracing with
symbolic shapes (e.g., mtia_afg backend), this fails with
"Cannot call numel() on tensor with symbolic sizes/strides".

Fix: use `.sym_numel()` which returns a `c10::SymInt` that works with
both concrete and symbolic tensors.

Reviewed By: sryap

Differential Revision: D98822028


