### PR TITLE
Support input data not most recent in MP-ZCH (#5567)

### DIFF
--- a/fbgemm_gpu/src/faster_hash_ops/faster_hash.cu
+++ b/fbgemm_gpu/src/faster_hash_ops/faster_hash.cu
@@ -115,7 +115,7 @@ __device__ __inline__ void update_metadata_lru<1>(
     int32_t val,
     int32_t* process_lock) {
   // These should be atomic as we release process lock as last step
-  atomicExch(metadata + output_index, val);
+  atomicMax(metadata + output_index, val);
   // Release process lock from index
   atomicExch(process_lock + output_index, kDefaultTensor);
 }
@@ -137,7 +137,8 @@ __device__ __inline__ int64_t check_min(
         2,
         at::RestrictPtrTraits> /* identities */,
     TIdentity& /* min_slot_identity */,
-    int32_t /* eviction_threshold */) {
+    int32_t /* eviction_threshold */,
+    int32_t /* metadata_input_val */) {
   static_assert(METADATA_COUNT == 0);
   // For inference, we keep the same min_index until the ID is found.
   return min_index;
@@ -157,7 +158,8 @@ __device__ __inline__ int64_t check_min(
     int32_t* process_lock,
     at::PackedTensorAccessor64<TIdentity, 2, at::RestrictPtrTraits> identities,
     TIdentity& min_slot_identity,
-    int32_t eviction_threshold) {
+    int32_t eviction_threshold,
+    int32_t metadata_input_val) {
   static_assert(METADATA_COUNT == 1);
   // There could be a case, one id has already occupy the slot,
   // and last update hour is not written yet, while the other id checking the
@@ -174,7 +176,10 @@ __device__ __inline__ int64_t check_min(
   }
 
   // only check those expired slots
-  if (eviction_threshold > last_seen && min_hours > last_seen) {
+  bool threshold_met = (eviction_threshold > last_seen);
+  bool is_oldest_in_probe = (min_hours > last_seen);
+  bool is_input_more_recent = (last_seen < metadata_input_val);
+  if (threshold_met && is_oldest_in_probe && is_input_more_recent) {
     // Try to lock index for thread
     auto old_pid =
         atomicCAS(process_lock + insert_idx, kDefaultTensor, process_index);
@@ -204,7 +209,8 @@ template <int32_t METADATA_COUNT>
 __device__ __inline__ bool check_evict(
     int32_t* /* metadata */,
     int64_t /* output_index */,
-    int32_t /* eviction_threshold */) {
+    int32_t /* eviction_threshold */,
+    int32_t /* metadata_val */) {
   static_assert(METADATA_COUNT != 1);
   return false;
 }
@@ -213,7 +219,8 @@ template <>
 __device__ __inline__ bool check_evict<1>(
     int32_t* metadata,
     int64_t output_index,
-    int32_t eviction_threshold) {
+    int32_t eviction_threshold,
+    int32_t metadata_val) {
   // In rare case, one id may have already occupied the slot but its metadata
   // has not been written yet, while the other id checking the slot's eviction
   // status. Therefore, wait until the metadata is not -1.
@@ -225,8 +232,9 @@ __device__ __inline__ bool check_evict<1>(
       break;
     }
   }
-
-  return eviction_threshold > identity_metadata;
+  bool is_more_recent = (identity_metadata < metadata_val);
+  bool threshold_met = (eviction_threshold > identity_metadata);
+  return threshold_met && is_more_recent;
 }
 
 template <bool READONLY, typename TIdentity>
@@ -399,7 +407,7 @@ __global__ void process_item_zch(
 
       if (identity_slot == -1 &&
           check_evict<METADATA_COUNT>(
-              metadata, insert_idx, eviction_threshold)) {
+              metadata, insert_idx, eviction_threshold, metadata_val)) {
         auto current_slot_value =
             CAS<TIdentity>(&identities[insert_idx][0], old_value, identity);
         if (current_slot_value == old_value || current_slot_value == identity) {
@@ -545,7 +553,8 @@ __global__ void process_item_zch(
           process_lock,
           identities,
           min_slot_identity,
-          eviction_threshold);
+          eviction_threshold,
+          metadata_val);
 
       output_index = next_output_index(output_index, opt_in_block_size);
     }
@@ -558,6 +567,7 @@ __global__ void process_item_zch(
         //  1. Hashes are concentrated in a probing distance
         //  2. Probing distance is too small
         //  3. in eval mode, can't find the identity in probing distance
+        //  4. if incoming item is more stale than entire probe distance
         if constexpr (DISABLE_FALLBACK) {
           output_index = -1;
           offset = 0;

--- a/fbgemm_gpu/test/faster_hash_test.py
+++ b/fbgemm_gpu/test/faster_hash_test.py
@@ -12,6 +12,7 @@ from enum import IntEnum
 # pyre-ignore[21]
 import fbgemm_gpu  # noqa: F401
 import torch
+from hypothesis import given, settings, strategies as st
 
 # check if we are in open source env to decide how to import necessary modules
 try:
@@ -1636,3 +1637,79 @@ class FasterHashTest(unittest.TestCase):
         output_item_first_round = torch.ops.fbgemm.murmur_hash3(input_item, 0, 0)
         output_item_second_round = torch.ops.fbgemm.murmur_hash3(input_item, 0, 0)
         self.assertTrue(torch.equal(output_item_first_round, output_item_second_round))
+
+    @skipIfRocm("The CUDA kernel is not supported on ROCm")
+    @unittest.skipIf(*gpu_unavailable)
+    @settings(deadline=None)
+    # pyre-ignore [56]
+    @given(
+        eviction_policy=st.sampled_from(
+            [
+                HashZchKernelEvictionPolicy.LRU_EVICTION,
+                HashZchKernelEvictionPolicy.THRESHOLD_EVICTION,
+            ]
+        )
+    )
+    def test_eviction_updates_most_recent(self, eviction_policy: int) -> None:
+        """
+        This test is to verify that when the input/input_metadata is not the most recent,
+        then it doesn't overwrite the most recent from identities/metadata.
+
+        This test creates a simple example to do this.
+        """
+        max_probe = 2
+        identities, metadata = torch.ops.fbgemm.create_zch_buffer(
+            10,
+            support_evict=True,
+            long_type=True,
+            device=torch.accelerator.current_accelerator(),
+        )
+        # The input to be looked
+        input_ids = torch.tensor(
+            [10, 4, 8, 83, 42, 14, 12, 26, 0, 6],
+            dtype=torch.int64,
+            device=torch.accelerator.current_accelerator(),
+        )
+        input_md = torch.tensor(
+            [2, 14, 9, 1, 20, 10, 2, 4, 103, 203],
+            dtype=torch.int32,
+            device=torch.accelerator.current_accelerator(),
+        )
+        # Replace 83 in input_ids with 20000 with high metadata val
+        #   so when inserting 83 it can either replace 20000 or 42, but
+        #   their metadata (491802 & 20) is greater than metadata 1 of 83.
+        #   so 83 should not be added
+        # In addition, replace index 0 [10] metadata to [200], to make
+        #   sure that the above input [10] with MD [2] doesn't replace 200.
+        identities = torch.tensor(
+            [[10], [4], [8], [20000], [42], [14], [12], [26], [0], [6]],
+            dtype=torch.int64,
+            device=torch.accelerator.current_accelerator(),
+        )
+        metadata = torch.tensor(
+            [[200], [14], [9], [491802], [20], [10], [2], [4], [103], [203]],
+            dtype=torch.int32,
+            device=torch.accelerator.current_accelerator(),
+        )
+        old_metadata = metadata.clone()
+
+        remapped_ids, evictions = torch.ops.fbgemm.zero_collision_hash(
+            input=input_ids,
+            input_metadata=input_md,
+            identities=identities,
+            metadata=metadata,
+            max_probe=max_probe,
+            circular_probe=True,
+            exp_hours=-1,
+            readonly=False,
+            disable_fallback=True,
+            eviction_threshold=100,
+            eviction_policy=eviction_policy,
+        )
+
+        # Assert that 83 should not be in identities
+        self.assertTrue(torch.any(remapped_ids == -1))
+        self.assertTrue(torch.all(identities != 83))
+        # Assert that the metadata got updated to be the most recent, e.g. for id=10
+        self.assertTrue(torch.all(metadata >= old_metadata))
+        self.assertTrue(evictions.numel() == 0)


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2371


Context
---------
MP-ZCH kernels assume that the input (and their metadata) is the most recent, and so it will always try to evict within the hash table if eviction threshold is met. This is reasonable for its prevous use-case.

However, when enabling MP-ZCH with 2D-sharding, we need to support cases when the input (and their metadata) is not the most recent, and should only evict if their metadata is actually more recent.

In addition, LRU eviction overwrites the slot's metadata with the input metadata when it is found inside the hash-table. Similar to Threshold eviction, it now updates metadata to be the maximum.

Implementation
------------------
- `update_metadata_lru` is now doing `atomicMax` instead of `atomicExch` so that the metadata gets updated to either the input or identity (i.e. the one with max metadata).
- Now checks for eviction if the input metadata is greater than the hash-table metadata.
    - For LRU policy, changes are in `check_min`  
    - For Threshold policy, changes are in `check_evict`

Although this adds maybe couple more FLOPS, the performance, and number of registers shouldn't be too different. Also, cpu version does not utilize any metadata so not applicable.

NOTE: When index is not found, the output, with both Eviction policies, will depend on whether disable_fallback=T/F.  If True, then it will return a `-1` meaning it was not found. If it were false, then it returns the first index it started with, signifying it should be replaced there. It's important for our use-case to have `disable_fallback `set to True. See code-pointer [1](https://www.internalfb.com/code/fbsource/[3c10e674c12a3fe1af5b0af107bfcc8d8860a303]/fbcode/deeplearning/fbgemm/fbgemm_gpu/src/faster_hash_ops/faster_hash.cu?lines=505-520) and [2](https://www.internalfb.com/code/fbsource/[e8f5ab1d973526981753310653c86a2fd510f26d]/fbcode/deeplearning/fbgemm/fbgemm_gpu/src/faster_hash_ops/faster_hash.cu?lines=388-398)

NOTE: These changes do not affect Eviction during training since eviction happens when `eviction_threshold < cache_slot_metadata`. The eviction_threshold is equal to the time `zero_collision_hashing` is called, and the `cache_slot_metadata =prev_hour + TTL`. In addition, our change of adding `cache_slot_metadata < metadata_val` would be equivalent to `prev_hour + TTL < curr_hour + TTL <=> prev_hour < curr_hour`.

Reviewed By: kausv

Differential Revision: D92659052


