### PR TITLE
Fix lint (#5611)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference_serving.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference_serving.py
@@ -24,13 +24,13 @@ Key differences from raw SSD TBE:
 import logging
 from typing import Optional
 
-import torch
+import torch  # usort:skip
 from fbgemm_gpu.split_embedding_configs import SparseType
 from fbgemm_gpu.split_table_batched_embeddings_ops_common import PoolingMode
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     rounded_row_size_in_bytes,
 )
-from torch import nn, Tensor
+from torch import nn, Tensor  # usort:skip
 
 from .common import ASSOC
 from .inference import SSDIntNBitTableBatchedEmbeddingBags

--- a/fbgemm_gpu/test/tbe/ssd/ssd_rwlock_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_rwlock_test.py
@@ -39,7 +39,6 @@ from fbgemm_gpu.tbe.utils import get_table_batched_offsets_from_dense
 from .. import common  # noqa E402
 from ..common import gpu_unavailable, running_in_oss
 
-
 # ═══════════════════════════════════════════════════════════════════════
 #  Part 1: _RWLock Unit Tests (no GPU needed)
 # ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2564


Fix ufmt lint issues in OSS CI for inference_serving.py and ssd_rwlock_test.py.

- Add `# usort:skip` to `from torch import nn, Tensor` in inference_serving.py to resolve conflict between internal arc lint (BLACK) and OSS ufmt import ordering.
- Remove extra blank line in ssd_rwlock_test.py between imports and comment block.

Differential Revision: D100360016


