### PR TITLE
Remove torch_compiled

### DIFF
--- a/fbgemm_gpu/test/batched_unary_embeddings_test.py
+++ b/fbgemm_gpu/test/batched_unary_embeddings_test.py
@@ -9,10 +9,8 @@
 
 
 import random
-import sys
 import unittest
 from math import sqrt
-from typing import Callable
 
 import fbgemm_gpu.batched_unary_embeddings_ops as batched_unary_embeddings_ops
 import numpy as np
@@ -46,15 +44,6 @@ TOLERANCE_ABS = {
     torch.float16: 1e-2,
     torch.bfloat16: 1e-2,
 }
-
-
-# pyre-fixme[2]
-# pyre-fixme[24]
-def torch_compiled(model: Callable, **kwargs) -> Callable:
-    if sys.version_info < (3, 12, 0):
-        return torch.compile(model, **kwargs)
-    else:
-        return model
 
 
 class TableBatchedEmbeddingsTest(unittest.TestCase):
@@ -161,7 +150,7 @@ class TableBatchedEmbeddingsTest(unittest.TestCase):
             param.detach().copy_(ref_emb.emb_modules[i].weight)
         output_ref = ref_emb(offsets, indices)
         if torch_compile:
-            unary_emb = torch_compiled(unary_emb, dynamic=True, fullgraph=True)
+            unary_emb = torch.compile(unary_emb, dynamic=True, fullgraph=True)
         output = unary_emb(offsets_tensor, indices_tensor)
         torch.testing.assert_close(
             output_ref,
@@ -183,7 +172,7 @@ class TableBatchedEmbeddingsTest(unittest.TestCase):
             param.detach().copy_(ref_emb.emb_modules[i].weight)
         output_ref = ref_emb(offsets, indices)
         if torch_compile:
-            unary_emb = torch_compiled(unary_emb, dynamic=True, fullgraph=True)
+            unary_emb = torch.compile(unary_emb, dynamic=True, fullgraph=True)
         output = unary_emb(offsets_tensor.long(), indices_tensor.long())
         torch.testing.assert_close(
             output_ref,

--- a/fbgemm_gpu/test/jagged/1d_to_dense_test.py
+++ b/fbgemm_gpu/test/jagged/1d_to_dense_test.py
@@ -16,12 +16,7 @@ import torch
 import torch._dynamo
 from hypothesis import given, settings, Verbosity
 
-from .common import (
-    additional_decorators,
-    open_source,
-    torch_compiled,
-    var_list_to_coo_1d,
-)
+from .common import additional_decorators, open_source, var_list_to_coo_1d
 
 if open_source:
     # pyre-ignore[21]
@@ -189,7 +184,7 @@ class Jagged1DToDenseTest(unittest.TestCase):
         values = ref_values.clone().detach().requires_grad_(False)
         offsets = offsets.to(device)
         ref_output_values = ref_output_values.to(device)
-        output_values = torch_compiled(
+        output_values = torch.compile(
             torch.ops.fbgemm.jagged_1d_to_dense, dynamic=True, fullgraph=True
         )(
             values=values,

--- a/fbgemm_gpu/test/jagged/2d_to_dense_test.py
+++ b/fbgemm_gpu/test/jagged/2d_to_dense_test.py
@@ -16,7 +16,7 @@ import torch
 import torch._dynamo
 from hypothesis import given, settings, Verbosity
 
-from .common import additional_decorators, open_source, torch_compiled, var_list_to_coo
+from .common import additional_decorators, open_source, var_list_to_coo
 
 if open_source:
     # pyre-ignore[21]
@@ -187,7 +187,7 @@ class Jagged2DToDenseTest(unittest.TestCase):
         values = ref_values.clone().to(dtype).detach().requires_grad_(True)
         offsets = offsets.to(device)
         ref_output_values = ref_output_values.to(device)
-        output_values = torch_compiled(
+        output_values = torch.compile(
             torch.ops.fbgemm.jagged_2d_to_dense, dynamic=True, fullgraph=True
         )(
             values=values,

--- a/fbgemm_gpu/test/jagged/batched_dense_vec_jagged_2d_mul_test.py
+++ b/fbgemm_gpu/test/jagged/batched_dense_vec_jagged_2d_mul_test.py
@@ -15,7 +15,7 @@ import torch
 import torch._dynamo
 from hypothesis import assume, given, settings, Verbosity
 
-from .common import additional_decorators, open_source, torch_compiled
+from .common import additional_decorators, open_source
 
 if open_source:
     # pyre-ignore[21]
@@ -237,7 +237,7 @@ class BatchedDenseVecJagged2DMulTest(unittest.TestCase):
         torch._dynamo.mark_dynamic(values, 1)
         torch._dynamo.mark_dynamic(offsets, 0)
 
-        output = torch_compiled(
+        output = torch.compile(
             torch.ops.fbgemm.batched_dense_vec_jagged_2d_mul,
             fullgraph=True,
             dynamic=True,

--- a/fbgemm_gpu/test/jagged/common.py
+++ b/fbgemm_gpu/test/jagged/common.py
@@ -9,7 +9,6 @@
 # pyre-ignore-all-errors[56]
 
 import itertools
-import sys
 from typing import Callable
 
 import fbgemm_gpu
@@ -189,12 +188,3 @@ def to_padded_dense(
                 else values[cur_offset]
             )
     return dense.squeeze(-1) if values.ndim == 1 else dense
-
-
-# pyre-fixme[2]
-# pyre-fixme[24]
-def torch_compiled(model: Callable, **kwargs) -> Callable:
-    if sys.version_info < (3, 12, 0):
-        return torch.compile(model, **kwargs)
-    else:
-        return model

--- a/fbgemm_gpu/test/jagged/dense_bmm_test.py
+++ b/fbgemm_gpu/test/jagged/dense_bmm_test.py
@@ -15,7 +15,7 @@ import torch
 import torch._dynamo
 from hypothesis import assume, given, settings, Verbosity
 
-from .common import additional_decorators, open_source, torch_compiled
+from .common import additional_decorators, open_source
 
 if open_source:
     # pyre-ignore[21]
@@ -200,7 +200,7 @@ class DenseBmmTest(unittest.TestCase):
         torch._dynamo.mark_dynamic(x_values, 1)
         torch._dynamo.mark_dynamic(lengths, 0)  # offsets = lengths + 1
 
-        output, _ = torch_compiled(
+        output, _ = torch.compile(
             torch.ops.fbgemm.jagged_dense_bmm, fullgraph=True, dynamic=True
         )(
             x_values,

--- a/fbgemm_gpu/test/jagged/dense_dense_elementwise_add_test.py
+++ b/fbgemm_gpu/test/jagged/dense_dense_elementwise_add_test.py
@@ -21,7 +21,6 @@ from .common import (
     generate_jagged_tensor,
     open_source,
     to_padded_dense,
-    torch_compiled,
 )
 
 if open_source:
@@ -275,7 +274,7 @@ class DenseDenseElementwiseAddTest(unittest.TestCase):
         )
         output_ref = x_padded + y_0 + y_1
         x_values.to(device_type)
-        output, output_offsets = torch_compiled(
+        output, output_offsets = torch.compile(
             torch.ops.fbgemm.jagged_dense_dense_elementwise_add_jagged_output,
             fullgraph=True,
             dynamic=True,

--- a/fbgemm_gpu/test/quantize/fp8_rowwise_test.py
+++ b/fbgemm_gpu/test/quantize/fp8_rowwise_test.py
@@ -8,7 +8,6 @@
 
 import logging
 import os
-import sys
 import unittest
 
 import hypothesis.strategies as st
@@ -97,7 +96,7 @@ class TestFP8RowwiseQuantizationConversion(unittest.TestCase):
                 dynamic=True,
                 fullgraph=True,
             )
-            if test_compile and sys.version_info < (3, 12, 0)
+            if test_compile
             else torch.ops.fbgemm.FP8RowwiseQuantizedToFloat
         )
 

--- a/fbgemm_gpu/test/sparse/pack_segments_test.py
+++ b/fbgemm_gpu/test/sparse/pack_segments_test.py
@@ -9,9 +9,8 @@
 
 # pyre-ignore-all-errors[56]
 
-import sys
 import unittest
-from typing import Callable, Optional
+from typing import Optional
 
 import hypothesis.strategies as st
 import numpy as np
@@ -42,24 +41,6 @@ def get_n_rand_num_summing_to_k(n: int, k: int) -> npt.NDArray:
     if n == 0:
         return np.array([])
     return np.random.multinomial(k, np.ones(n) / n, size=1)[0]
-
-
-# pyre-fixme[2]
-# pyre-fixme[24]
-def torch_compiled(model: Callable, **kwargs) -> Callable:
-    """A helper function to apply torch.compile if python < 3.12.
-
-    Args:
-        model: The model to be compiled.
-        kwargs: The arguments to be passed to torch.compile.
-
-    Returns:
-        The model.
-    """
-    if sys.version_info < (3, 12, 0):
-        return torch.compile(model, **kwargs)
-    else:
-        return model
 
 
 class PackedSegmentsTest(unittest.TestCase):
@@ -181,7 +162,7 @@ class PackedSegmentsTest(unittest.TestCase):
             pack_segments_fun = torch.ops.fbgemm.pack_segments
 
             if torch_compile:
-                pack_segments_fun = torch_compiled(pack_segments_fun, dynamic=True)
+                pack_segments_fun = torch.compile(pack_segments_fun, dynamic=True)
 
             packed_cuda = pack_segments_fun(
                 t_in=input_data.cuda(),
@@ -192,9 +173,7 @@ class PackedSegmentsTest(unittest.TestCase):
             pack_segments_fun_v2 = torch.ops.fbgemm.pack_segments_v2
 
             if torch_compile:
-                pack_segments_fun_v2 = torch_compiled(
-                    pack_segments_fun_v2, dynamic=True
-                )
+                pack_segments_fun_v2 = torch.compile(pack_segments_fun_v2, dynamic=True)
 
             packed_cuda_v2, _ = pack_segments_fun_v2(
                 t_in=input_data.cuda(),
@@ -337,7 +316,7 @@ class PackedSegmentsTest(unittest.TestCase):
         if gpu_available:
             pack_segments_fun = torch.ops.fbgemm.pack_segments
             if torch_compile:
-                pack_segments_fun = torch_compiled(pack_segments_fun)
+                pack_segments_fun = torch.compile(pack_segments_fun)
 
             packed_cuda = pack_segments_fun(
                 t_in=input_data.cuda(),
@@ -347,7 +326,7 @@ class PackedSegmentsTest(unittest.TestCase):
             self.assertTrue(torch.equal(packed_tensor, packed_cuda.cpu()))
             pack_segments_fun = torch.ops.fbgemm.pack_segments_v2
             if torch_compile:
-                pack_segments_fun = torch_compiled(pack_segments_fun)
+                pack_segments_fun = torch.compile(pack_segments_fun)
 
             packed_cuda_v2, _ = pack_segments_fun(
                 t_in=input_data.cuda(),

--- a/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
+++ b/fbgemm_gpu/test/tbe/training/backward_adagrad_common.py
@@ -7,7 +7,6 @@
 
 # pyre-strict
 
-import sys
 from typing import Any
 
 import hypothesis.strategies as st
@@ -285,8 +284,7 @@ def execute_backward_adagrad(  # noqa C901
         )
     )
     # TODO: make it compile for CPU and unweighted
-    # FIXME: remove once dynamo is supported by 3.12
-    if sys.version_info < (3, 12, 0) and compile and not use_cpu and weighted:
+    if compile and not use_cpu and weighted:
         cc = torch.compile(cc, fullgraph=True)
 
     # Copy weights from reference modules to TBE (ensures both have same weights)


### PR DESCRIPTION
This PR removes torch_compiled because recent PyTorch versions can support Python 3.12.