### PR TITLE
Use double in dequant ref/scalar to match FMA precision

### DIFF
--- a/fbgemm_gpu/cmake/Fbgemm.cmake
+++ b/fbgemm_gpu/cmake/Fbgemm.cmake
@@ -30,15 +30,27 @@ set(fbgemm_sources_avx512
   "${FBGEMM}/src/QuantUtilsAvx512.cc")
 
 if(CXX_AVX2_FOUND)
-  set_source_files_properties(${fbgemm_sources_avx2}
-    PROPERTIES COMPILE_OPTIONS
-    "${CXX_AVX2_FLAGS}")
+  if(MSVC)
+    set_source_files_properties(${fbgemm_sources_avx2}
+      PROPERTIES COMPILE_OPTIONS
+      "${CXX_AVX2_FLAGS}")
+  else()
+    set_source_files_properties(${fbgemm_sources_avx2}
+      PROPERTIES COMPILE_OPTIONS
+      "-mfma;${CXX_AVX2_FLAGS}")
+  endif()
 endif()
 
 if(CXX_AVX512_FOUND)
-  set_source_files_properties(${fbgemm_sources_avx512}
-    PROPERTIES COMPILE_OPTIONS
-    "${CXX_AVX512_FLAGS}")
+  if(MSVC)
+    set_source_files_properties(${fbgemm_sources_avx512}
+      PROPERTIES COMPILE_OPTIONS
+      "${CXX_AVX512_FLAGS}")
+  else()
+    set_source_files_properties(${fbgemm_sources_avx512}
+      PROPERTIES COMPILE_OPTIONS
+      "-mfma;${CXX_AVX512_FLAGS}")
+  endif()
 endif()
 
 set(fbgemm_sources ${fbgemm_sources_normal})

--- a/src/QuantUtils.cc
+++ b/src/QuantUtils.cc
@@ -785,7 +785,8 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef(
       std::uint8_t quantized = nums[col / num_elem_per_byte];
       quantized >>= (col % num_elem_per_byte) * bit_rate;
       quantized &= (1 << bit_rate) - 1;
-      float output_value = scale * quantized + bias;
+      float output_value =
+          static_cast<float>(double(scale) * quantized + double(bias));
       if constexpr (std::is_same_v<OutputType, float>) {
         output_row[col] = output_value;
       } else {
@@ -888,7 +889,8 @@ void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfRef(
     }
 
     for (int col = 0; col < output_columns; ++col) {
-      float output_value = input_row[col] * scale + bias;
+      float output_value =
+          static_cast<float>(double(input_row[col]) * scale + double(bias));
       if constexpr (std::is_same_v<OutputType, float>) {
         output_row[col] = output_value;
       } else {

--- a/src/QuantUtilsAvx2.cc
+++ b/src/QuantUtilsAvx2.cc
@@ -36,7 +36,7 @@ void QuantizeAvx2(
     T* dst,
     int64_t len,
     const TensorQuantizationParams& qparams) {
-#if defined(__AVX2__) && (defined(__FMA__) || defined(_MSC_VER))
+#if defined(__AVX2__)
   constexpr int VLEN = 8;
   constexpr int32_t min_val = std::numeric_limits<T>::min();
   constexpr int32_t max_val = std::numeric_limits<T>::max();
@@ -171,7 +171,7 @@ void NO_SANITIZE("address") FusedQuantizeDequantizeAvx2(
   float inverse_scale [[maybe_unused]] = 1.f / qparams.scale;
   constexpr int32_t min_val [[maybe_unused]] = std::numeric_limits<T>::min();
   constexpr int32_t max_val [[maybe_unused]] = std::numeric_limits<T>::max();
-#if defined(__AVX2__) && (defined(__FMA__) || defined(_MSC_VER))
+#if defined(__AVX2__)
 
   constexpr int VLEN = 8;
   // This is the largest int32 value less than int32_max
@@ -2237,11 +2237,7 @@ void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfAvx2(
     for (col = 0; col < output_columns / VLEN * VLEN; col += VLEN) {
       __m256 in_v = _mm256_cvtepi32_ps(_mm256_cvtepu8_epi32(
           _mm_loadl_epi64(reinterpret_cast<const __m128i*>(input_row + col))));
-#ifdef __FMA__
       __m256 dequantzed_v = _mm256_fmadd_ps(in_v, scale_v, bias_v);
-#else
-      __m256 dequantzed_v = _mm256_add_ps(_mm256_mul_ps(in_v, scale_v), bias_v);
-#endif
       if constexpr (std::is_same_v<OutputType, float>) {
         float* output_row_float = reinterpret_cast<float*>(output_row);
         _mm256_storeu_ps(output_row_float + col, dequantzed_v);

--- a/src/QuantUtilsAvx2.cc
+++ b/src/QuantUtilsAvx2.cc
@@ -2186,7 +2186,8 @@ void FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfAvx2(
         std::uint8_t quantized = input_row[col / NUM_ELEM_PER_BYTE];
         quantized >>= (col % NUM_ELEM_PER_BYTE) * BIT_RATE;
         quantized &= (1 << BIT_RATE) - 1;
-        float output_value = scale * quantized + bias;
+        float output_value =
+            static_cast<float>(double(scale) * quantized + double(bias));
         if constexpr (std::is_same_v<OutputType, float>) {
           output_row[col] = output_value;
         } else {
@@ -2253,7 +2254,8 @@ void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfAvx2(
     }
 
     for (; col < output_columns; ++col) {
-      float output_value = input_row[col] * scale + bias;
+      float output_value =
+          static_cast<float>(double(input_row[col]) * scale + double(bias));
       if constexpr (std::is_same_v<OutputType, float>) {
         output_row[col] = output_value;
       } else {

--- a/src/QuantUtilsAvx512.cc
+++ b/src/QuantUtilsAvx512.cc
@@ -422,11 +422,7 @@ void Fused8BitRowwiseQuantizedSBFloatToBfloat16Avx512(
     for (col = 0; col < output_columns / VLEN * VLEN; col += VLEN) {
       __m256 in_v = _mm256_cvtepi32_ps(_mm256_cvtepu8_epi32(
           _mm_loadl_epi64(reinterpret_cast<const __m128i*>(input_row + col))));
-#ifdef __FMA__
       __m256 dequantzed_v = _mm256_fmadd_ps(in_v, scale_v, bias_v);
-#else
-      __m256 dequantzed_v = _mm256_add_ps(_mm256_mul_ps(in_v, scale_v), bias_v);
-#endif
       _mm_storeu_si128(
           reinterpret_cast<__m128i*>(output_row + col),
           (__m128i)(_mm256_cvtneps_pbh(dequantzed_v)));

--- a/src/QuantUtilsAvx512.cc
+++ b/src/QuantUtilsAvx512.cc
@@ -433,7 +433,8 @@ void Fused8BitRowwiseQuantizedSBFloatToBfloat16Avx512(
     }
 
     for (; col < output_columns; ++col) {
-      float output_value = input_row[col] * scale + bias;
+      float output_value =
+          static_cast<float>(double(input_row[col]) * scale + double(bias));
       output_row[col] = cpu_float2bfloat16(output_value);
     }
   } // for each row

--- a/test/QuantUtilsTest.cc
+++ b/test/QuantUtilsTest.cc
@@ -478,11 +478,11 @@ TEST_P(FusedQuantizeDequantizeTest, fusedQuantizeDequantizeTest) {
 
   runFusedQuantizeDequantizeTests<uint8_t>(
       inp, scale, zero_point_uint8, dstfloat, dstfloat_ref);
-  EXPECT_TRUE(floatCloseAll(dstfloat, dstfloat_ref));
+  EXPECT_EQ(dstfloat, dstfloat_ref);
 
   runFusedQuantizeDequantizeTests<int8_t>(
       inp, scale, zero_point_int8, dstfloat, dstfloat_ref);
-  EXPECT_TRUE(floatCloseAll(dstfloat, dstfloat_ref));
+  EXPECT_EQ(dstfloat, dstfloat_ref);
 }
 
 // vector and scalar code should have the same behavior
@@ -714,7 +714,7 @@ TEST_P(EmbeddingQuantizeTest, embeddingHalfTest) {
       bit_rate, outVecTest.data(), rows, out_cols, dequantOutRef.data());
   FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf<float>(
       bit_rate, outVecTest.data(), rows, out_cols, dequantOutTest.data());
-  EXPECT_TRUE(floatCloseAll(dequantOutRef, dequantOutTest, 1e-3));
+  EXPECT_EQ(dequantOutRef, dequantOutTest);
 
   generate(inpVec.begin(), inpVec.end(), [&, disFP]() mutable {
     return cpu_half2float(cpu_float2half_rn(disFP(gen)));
@@ -750,11 +750,7 @@ TEST_P(EmbeddingQuantizeTest, embeddingHalfTest) {
       dequantOutRef, dequantOutHalfRef, 1e-3, pow(2, NumberOfFP16Matissa)));
   FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf<float16>(
       bit_rate, outVecRef.data(), rows, out_cols, dequantOutHalfTest.data());
-  EXPECT_TRUE(floatCloseAll(
-      dequantOutHalfRef,
-      dequantOutHalfTest,
-      1e-3,
-      pow(2, NumberOfFP16Matissa)));
+  EXPECT_EQ(dequantOutHalfRef, dequantOutHalfTest);
 }
 
 // Scale and bias are of type float
@@ -792,7 +788,7 @@ TEST_P(EmbeddingQuantizeSBFloatTest, embeddingFloatTest) {
       outVecTest.data(), rows, out_cols, dequantOutRef.data());
   Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf<float>(
       outVecTest.data(), rows, out_cols, dequantOutTest.data());
-  EXPECT_TRUE(floatCloseAll(dequantOutRef, dequantOutTest, 1e-3));
+  EXPECT_EQ(dequantOutRef, dequantOutTest);
 
   generate(inpVec.begin(), inpVec.end(), [&, disFP]() mutable {
     return cpu_half2float(cpu_float2half_rn(disFP(gen)));
@@ -827,11 +823,7 @@ TEST_P(EmbeddingQuantizeSBFloatTest, embeddingFloatTest) {
       dequantOutRef, dequantOutHalfRef, 1e-3, pow(2, NumberOfFP16Matissa)));
   Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf<float16>(
       outVecRef.data(), rows, out_cols, dequantOutHalfTest.data());
-  EXPECT_TRUE(floatCloseAll(
-      dequantOutHalfRef,
-      dequantOutHalfTest,
-      1e-3,
-      pow(2, NumberOfFP16Matissa)));
+  EXPECT_EQ(dequantOutHalfRef, dequantOutHalfTest);
 }
 
 TEST_P(


### PR DESCRIPTION
This PR increase the precision of ref implementations so that the bit patterns of ref and real results match. The advantages of this optimisation is that it becomes possible to easily identify silent numerical errors in AVX code paths.