### PR TITLE
Remove legacy quantize path 

### DIFF
--- a/include/fbgemm/QuantUtils.h
+++ b/include/fbgemm/QuantUtils.h
@@ -63,13 +63,14 @@ T2 clamp(T1 src, int precision, bool is_signed = false) {
 
 /// Quantize src using zero_point and scale, clamp to the specified precision,
 /// and convert it to type T
-template <typename T, bool LEGACY = true>
+template <typename T, bool LEGACY = false>
 T Quantize(
     float src,
     std::int32_t zero_point,
     float scale,
     int result_precision,
     bool result_is_signed = std::is_signed_v<T>) {
+  static_assert(!LEGACY, "Legacy quantize is removed");
   // Note: We want to multiply with src with inv_scale instead of
   // dividing src by scale. The same is done in vector code and
   // at other places.
@@ -86,26 +87,22 @@ T Quantize(
   // default rounding mode.
   // For example, nearbyint(1.4) is 1.0, nearbyint(1.5) is 2.0
   // and nearbyint(2.5) is 2.0
-  // Adding zero_point before or after rounding can make a difference
-  // in exactly halfway cases.
-  if constexpr (LEGACY) {
-    transformed_val = std::nearbyint(zero_point + transformed_val);
-  } else {
-    transformed_val = zero_point + std::nearbyint(transformed_val);
-  }
+  // Adding zero_point after rounding matches PyTorch behavior.
+  transformed_val = zero_point + std::nearbyint(transformed_val);
   // Please note the use of double. Unlike float, a double can represent
   // all int32 values exactly. Using a float results in a float value >
   // INT32_MAX conversion to int32 in clamp function and hence an UBSAN error.
   return clamp<double, T>(transformed_val, result_precision, result_is_signed);
 }
 
-template <typename T, bool LEGACY = true>
+template <typename T, bool LEGACY = false>
 T Quantize(float src, const TensorQuantizationParams& qparams) {
-  return Quantize<T, LEGACY>(
+  static_assert(!LEGACY, "Legacy quantize is removed");
+  return Quantize<T>(
       src, qparams.zero_point, qparams.scale, qparams.precision);
 }
 
-template <typename T, bool LEGACY = true>
+template <typename T, bool LEGACY = false>
 FBGEMM_API void Quantize(
     const float* src,
     T* dst,
@@ -174,7 +171,7 @@ template <typename T>
 float FusedQuantizeDequantize(
     float src,
     const TensorQuantizationParams& qparams) {
-  T q = Quantize<T, false>(
+  T q = Quantize<T>(
       src, qparams.zero_point, qparams.scale, qparams.precision);
   return Dequantize<T>(q, qparams);
 }

--- a/include/fbgemm/QuantUtilsAvx2.h
+++ b/include/fbgemm/QuantUtilsAvx2.h
@@ -63,7 +63,7 @@ void FBGEMM_API FindMinMax(const float* m, float* min, float* max, int64_t len);
 // Utility functions
 ////////////////////////////////////////////////////////////////////////////////
 
-template <typename T = std::uint8_t, bool LEGACY = true>
+template <typename T = std::uint8_t>
 void QuantizeAvx2(
     const float* src,
     T* dst,

--- a/src/QuantUtils.cc
+++ b/src/QuantUtils.cc
@@ -196,9 +196,9 @@ void ChooseRequantizationMultiplier(
 ////////////////////////////////////////////////////////////////////////////////
 // Utility functions
 
-#define FBGEMM_SPECIALIZED_QUANTIZE(T, LEGACY)                      \
+#define FBGEMM_SPECIALIZED_QUANTIZE(T)                              \
   template <>                                                       \
-  FBGEMM_API void Quantize<T, LEGACY>(                              \
+  FBGEMM_API void Quantize<T, false>(                               \
       const float* src,                                             \
       T* dst,                                                       \
       const int64_t len,                                            \
@@ -208,20 +208,17 @@ void ChooseRequantizationMultiplier(
     int64_t i_begin, i_end;                                         \
     fbgemmPartition1D(thread_id, num_threads, len, i_begin, i_end); \
     for (int64_t i = i_begin; i < i_end; ++i) {                     \
-      dst[i] = Quantize<T, LEGACY>(src[i], qparams);                \
+      dst[i] = Quantize<T>(src[i], qparams);                        \
     }                                                               \
   }
 
-FBGEMM_SPECIALIZED_QUANTIZE(uint16_t, true)
-FBGEMM_SPECIALIZED_QUANTIZE(int16_t, true)
-FBGEMM_SPECIALIZED_QUANTIZE(int32_t, true)
-FBGEMM_SPECIALIZED_QUANTIZE(uint16_t, false)
-FBGEMM_SPECIALIZED_QUANTIZE(int16_t, false)
-FBGEMM_SPECIALIZED_QUANTIZE(int32_t, false)
+FBGEMM_SPECIALIZED_QUANTIZE(uint16_t)
+FBGEMM_SPECIALIZED_QUANTIZE(int16_t)
+FBGEMM_SPECIALIZED_QUANTIZE(int32_t)
 
-#define FBGEMM_SPECIALIZED_QUANTIZE_AVX2(T, LEGACY)                     \
+#define FBGEMM_SPECIALIZED_QUANTIZE_AVX2(T)                             \
   template <>                                                           \
-  FBGEMM_API void Quantize<T, LEGACY>(                                  \
+  FBGEMM_API void Quantize<T, false>(                                   \
       const float* src,                                                 \
       T* dst,                                                           \
       int64_t len,                                                      \
@@ -234,25 +231,21 @@ FBGEMM_SPECIALIZED_QUANTIZE(int32_t, false)
     fbgemmPartition1D(thread_id, num_threads, len, i_begin, i_end);     \
     if (avx2_support && fma_support && qparams.precision == 8) {        \
       /* fast path  */                                                  \
-      QuantizeAvx2<T, LEGACY>(                                          \
+      QuantizeAvx2<T>(                                                  \
           &src[i_begin], &dst[i_begin], i_end - i_begin, qparams);      \
     } else {                                                            \
       for (int64_t i = i_begin; i < i_end; ++i) {                       \
-        dst[i] = Quantize<T, LEGACY>(src[i], qparams);                  \
+        dst[i] = Quantize<T>(src[i], qparams);                          \
       }                                                                 \
     }                                                                   \
   }
 
 #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
-FBGEMM_SPECIALIZED_QUANTIZE_AVX2(int8_t, true)
-FBGEMM_SPECIALIZED_QUANTIZE_AVX2(uint8_t, true)
-FBGEMM_SPECIALIZED_QUANTIZE_AVX2(int8_t, false)
-FBGEMM_SPECIALIZED_QUANTIZE_AVX2(uint8_t, false)
+FBGEMM_SPECIALIZED_QUANTIZE_AVX2(int8_t)
+FBGEMM_SPECIALIZED_QUANTIZE_AVX2(uint8_t)
 #else
-FBGEMM_SPECIALIZED_QUANTIZE(int8_t, true)
-FBGEMM_SPECIALIZED_QUANTIZE(uint8_t, true)
-FBGEMM_SPECIALIZED_QUANTIZE(int8_t, false)
-FBGEMM_SPECIALIZED_QUANTIZE(uint8_t, false)
+FBGEMM_SPECIALIZED_QUANTIZE(int8_t)
+FBGEMM_SPECIALIZED_QUANTIZE(uint8_t)
 #endif
 
 #undef FBGEMM_SPECIALIZED_QUANTIZE

--- a/src/QuantUtilsAvx2.cc
+++ b/src/QuantUtilsAvx2.cc
@@ -30,7 +30,7 @@ using namespace std;
 ////////////////////////////////////////////////////////////////////////////////
 // Utility functions
 
-template <typename T, bool LEGACY>
+template <typename T>
 void QuantizeAvx2(
     const float* src,
     T* dst,
@@ -60,17 +60,10 @@ void QuantizeAvx2(
   // clang-format on
   __m256i permute_mask_v =
       _mm256_set_epi32(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00);
-  const auto zero_point_v_legacy = _mm256_set1_ps(qparams.zero_point);
-  const auto zero_point_v_non_legacy = _mm256_set1_epi32(qparams.zero_point);
+  const auto zero_point_v = _mm256_set1_epi32(qparams.zero_point);
   for (; i < len / VLEN * VLEN; i += VLEN) {
     __m256 src_v = _mm256_loadu_ps(src + i);
-    __m256 transformed_v;
-    if constexpr (LEGACY) { // static if
-      transformed_v =
-          _mm256_fmadd_ps(src_v, inverse_scale_v, zero_point_v_legacy);
-    } else {
-      transformed_v = _mm256_mul_ps(src_v, inverse_scale_v);
-    }
+    __m256 transformed_v = _mm256_mul_ps(src_v, inverse_scale_v);
     // If the floating point value is greater than int32_max,
     // _mm256_cvtps_epi32 converts them to negative. Clip at int32_float_max_val
     // to avoid this.
@@ -78,9 +71,7 @@ void QuantizeAvx2(
         _mm256_min_ps(transformed_v, _mm256_set1_ps(int32_float_max_val));
 
     __m256i rounded_v = _mm256_cvtps_epi32(transformed_v);
-    if constexpr (!LEGACY) {
-      rounded_v = _mm256_add_epi32(rounded_v, zero_point_v_non_legacy);
-    }
+    rounded_v = _mm256_add_epi32(rounded_v, zero_point_v);
     __m256i clipped_v = _mm256_min_epi32(
         _mm256_max_epi32(rounded_v, _mm256_set1_epi32(min_val)),
         _mm256_set1_epi32(max_val));
@@ -102,20 +93,12 @@ void QuantizeAvx2(
     // __m128i store_mask_v = _mm_load_si128(
     // reinterpret_cast<const __m128i*>(internal::sse_epi8_masks[rem]));
     __m256 src_v = _mm256_maskload_ps(src + i, mask_v);
-    __m256 transformed_v;
-    if constexpr (LEGACY) {
-      transformed_v =
-          _mm256_fmadd_ps(src_v, inverse_scale_v, zero_point_v_legacy);
-    } else {
-      transformed_v = _mm256_mul_ps(src_v, inverse_scale_v);
-    }
+    __m256 transformed_v = _mm256_mul_ps(src_v, inverse_scale_v);
     transformed_v =
         _mm256_min_ps(transformed_v, _mm256_set1_ps(int32_float_max_val));
 
     __m256i rounded_v = _mm256_cvtps_epi32(transformed_v);
-    if constexpr (!LEGACY) {
-      rounded_v = _mm256_add_epi32(rounded_v, zero_point_v_non_legacy);
-    }
+    rounded_v = _mm256_add_epi32(rounded_v, zero_point_v);
     __m256i clipped_v = _mm256_min_epi32(
         _mm256_max_epi32(rounded_v, _mm256_set1_epi32(min_val)),
         _mm256_set1_epi32(max_val));
@@ -149,16 +132,14 @@ uint32_t Xor128() {
 }
 
 // Instantiate QuantizeAvx2 for known datatypes
-#define SPECIALIZE_QUANTIZEAVX2(T, LEGACY) \
-  template void QuantizeAvx2<T, LEGACY>(   \
-      const float* src,                    \
-      T* dst,                              \
-      int64_t len,                         \
+#define SPECIALIZE_QUANTIZEAVX2(T)    \
+  template void QuantizeAvx2<T>(      \
+      const float* src,               \
+      T* dst,                         \
+      int64_t len,                    \
       const TensorQuantizationParams& qparams);
-SPECIALIZE_QUANTIZEAVX2(uint8_t, true)
-SPECIALIZE_QUANTIZEAVX2(int8_t, true)
-SPECIALIZE_QUANTIZEAVX2(uint8_t, false)
-SPECIALIZE_QUANTIZEAVX2(int8_t, false)
+SPECIALIZE_QUANTIZEAVX2(uint8_t)
+SPECIALIZE_QUANTIZEAVX2(int8_t)
 #undef SPECIALIZE_QUANTIZEAVX2
 
 template <typename T>


### PR DESCRIPTION
The legacy mode was used in Caffe2. PyTorch doesn't use it now.