### PR TITLE
Add DRAM KV cache and L1 hit rate metrics for training (#5633)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -1134,6 +1134,19 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             f"dram_kv.mem.tbe_id{tbe_unique_id}.num_rows"
         )
 
+        self.dram_kv_hit_rate_stats_name: str = (
+            f"dram_kv.tbe_id{tbe_unique_id}.hit_rate_pct"
+        )
+        self.dram_kv_hit_count_stats_name: str = (
+            f"dram_kv.perf.get.tbe_id{tbe_unique_id}.dram_read_hit_count"
+        )
+        self.dram_kv_miss_count_stats_name: str = (
+            f"dram_kv.perf.get.tbe_id{tbe_unique_id}.dram_read_miss_count"
+        )
+        self.l1_hit_rate_stats_name: str = (
+            f"ssd_tbe.prefetch.tbe_id{tbe_unique_id}.l1_hit_rate_pct"
+        )
+
         self.eviction_sum_evicted_counts_stats_name: str = (
             f"eviction.tbe_id.{tbe_unique_id}.sum_evicted_counts"
         )
@@ -1179,6 +1192,10 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 self.eviction_sum_processed_counts_stats_name
             )
             self.stats_reporter.register_stats(self.eviction_evict_rate_stats_name)
+            self.stats_reporter.register_stats(self.dram_kv_hit_rate_stats_name)
+            self.stats_reporter.register_stats(self.dram_kv_hit_count_stats_name)
+            self.stats_reporter.register_stats(self.dram_kv_miss_count_stats_name)
+            self.stats_reporter.register_stats(self.l1_hit_rate_stats_name)
             for t in self.feature_table_map:
                 self.stats_reporter.register_stats(
                     f"eviction.feature_table.{t}.evicted_counts"
@@ -3984,6 +4001,26 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 data_bytes=int(ssd_cache_stats_delta[stat_index.value] / passed_steps),
             )
 
+        # L1 cache hit rate
+        num_unique = ssd_cache_stats_delta[UVMCacheStatsIndex.num_unique_indices]
+        num_misses = ssd_cache_stats_delta[UVMCacheStatsIndex.num_unique_misses]
+        if num_unique > 0:
+            l1_hit_rate_pct = 100.0 * (num_unique - num_misses) / num_unique
+            # Per-TBE L1 hit rate
+            self.stats_reporter.report_data_amount(
+                iteration_step=self.step,
+                event_name=self.l1_hit_rate_stats_name,
+                data_bytes=l1_hit_rate_pct,
+                enable_tb_metrics=True,
+            )
+            # Aggregate L1 hit rate (kept for backward compat)
+            self.stats_reporter.report_data_amount(
+                iteration_step=self.step,
+                event_name="ssd_tbe.prefetch.l1_hit_rate_pct",
+                data_bytes=l1_hit_rate_pct,
+                enable_tb_metrics=True,
+            )
+
     @torch.jit.ignore
     def _report_ssd_io_stats(self) -> None:
         """
@@ -4324,8 +4361,11 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             self.step, stats_reporter.report_interval  # pyre-ignore
         )
 
-        if len(dram_kv_perf_stats) != 36:
-            logging.error("dram cache perf stats should have 36 elements")
+        if len(dram_kv_perf_stats) < 36:
+            logging.error(
+                "dram cache perf stats should have at least 36 elements, got %d",
+                len(dram_kv_perf_stats),
+            )
             return
 
         dram_read_duration = dram_kv_perf_stats[0]
@@ -4616,6 +4656,41 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
             data_bytes=dram_read_read_metadata_load_size,
             enable_tb_metrics=True,
         )
+
+        # DRAM KV cache hit rate metrics (indices 36-37)
+        if len(dram_kv_perf_stats) >= 38:
+            dram_read_hit_count = dram_kv_perf_stats[36]
+            dram_read_miss_count = dram_kv_perf_stats[37]
+            dram_read_total = dram_read_hit_count + dram_read_miss_count
+            # Per-TBE hit/miss counts
+            stats_reporter.report_data_amount(
+                iteration_step=self.step,
+                event_name=self.dram_kv_hit_count_stats_name,
+                data_bytes=dram_read_hit_count,
+                enable_tb_metrics=True,
+            )
+            stats_reporter.report_data_amount(
+                iteration_step=self.step,
+                event_name=self.dram_kv_miss_count_stats_name,
+                data_bytes=dram_read_miss_count,
+                enable_tb_metrics=True,
+            )
+            if dram_read_total > 0:
+                hit_rate_pct = 100.0 * dram_read_hit_count / dram_read_total
+                # Per-TBE hit rate
+                stats_reporter.report_data_amount(
+                    iteration_step=self.step,
+                    event_name=self.dram_kv_hit_rate_stats_name,
+                    data_bytes=hit_rate_pct,
+                    enable_tb_metrics=True,
+                )
+                # Aggregate hit rate (kept for backward compat)
+                stats_reporter.report_data_amount(
+                    iteration_step=self.step,
+                    event_name="dram_kv.hit_rate_pct",
+                    data_bytes=hit_rate_pct,
+                    enable_tb_metrics=True,
+                )
 
     def _recording_to_timer(
         self, timer: Optional[AsyncSeriesTimer], **kwargs: Any

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_cache.h
@@ -1464,8 +1464,8 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
     // iteration(excluding state_dict)
     auto start_ts = facebook::WallClockUtil::NowInUsecFast();
     pause_ongoing_eviction(); // noop calls, no impact if called multiple times
-    std::vector<
-        folly::Future<std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t>>>
+    std::vector<folly::Future<
+        std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t>>>
         futures;
     auto row_width = weights.size(1);
     auto copy_width = width_length.value_or(row_width);
@@ -1491,6 +1491,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                 int64_t local_read_lookup_cache_total_duration = 0;
                 int64_t local_read_aquire_lock_duration = 0;
                 int64_t local_read_missing_load = 0;
+                int64_t local_read_hit_load = 0;
                 FBGEMM_DISPATCH_INTEGRAL_TYPES(
                     indices.scalar_type(),
                     "dram_kvstore_set",
@@ -1505,7 +1506,8 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                      &local_read_fill_row_storage_total_duration,
                      &local_read_lookup_cache_total_duration,
                      &local_read_aquire_lock_duration,
-                     &local_read_missing_load] {
+                     &local_read_missing_load,
+                     &local_read_hit_load] {
                       using index_t = scalar_t;
                       CHECK(indices.is_contiguous());
                       CHECK(weights.is_contiguous());
@@ -1584,6 +1586,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                           local_read_cache_hit_copy_total_duration +=
                               facebook::WallClockUtil::NowInUsecFast() -
                               before_cache_hit_copy_ts;
+                          local_read_hit_load++;
                         }
                       }
                     });
@@ -1592,7 +1595,8 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                     local_read_fill_row_storage_total_duration,
                     local_read_cache_hit_copy_total_duration,
                     local_read_aquire_lock_duration,
-                    local_read_missing_load};
+                    local_read_missing_load,
+                    local_read_hit_load};
               }));
     }
 
@@ -1604,6 +1608,7 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
                            int64_t,
                            int64_t,
                            int64_t,
+                           int64_t,
                            int64_t>>& results) {
           resume_laser_write();
           int64_t read_lookup_cache_total_duration = 0;
@@ -1611,14 +1616,16 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
           int64_t read_cache_hit_copy_total_duration = 0;
           int64_t read_acquire_lock_total_duration = 0;
           int64_t read_missing_load = 0;
+          int64_t read_hit_load = 0;
           for (
-              const auto& [lookup_cache_dur, fill_row_storage_dur, cache_hit_copy_dur, acquire_lock_dur, missing_load] :
+              const auto& [lookup_cache_dur, fill_row_storage_dur, cache_hit_copy_dur, acquire_lock_dur, missing_load, hit_load] :
               results) {
             read_lookup_cache_total_duration += lookup_cache_dur;
             read_fill_row_storage_total_duration += fill_row_storage_dur;
             read_cache_hit_copy_total_duration += cache_hit_copy_dur;
             read_acquire_lock_total_duration += acquire_lock_dur;
             read_missing_load += missing_load;
+            read_hit_load += hit_load;
           }
           auto duration = facebook::WallClockUtil::NowInUsecFast() - start_ts;
           read_total_duration_ += duration;
@@ -1631,6 +1638,8 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
           read_acquire_lock_avg_duration_ +=
               read_acquire_lock_total_duration / num_shards_;
           read_missing_load_avg_ += read_missing_load / num_shards_;
+          read_hit_count_ += read_hit_load;
+          read_miss_count_ += read_missing_load;
           return std::vector<folly::Unit>(results.size());
         });
   };
@@ -2040,8 +2049,9 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
   std::vector<double> get_dram_kv_perf(
       const int64_t step,
       const int64_t interval) {
-    std::vector<double> ret(36, 0); // num metrics
+    std::vector<double> ret(38, 0); // num metrics
     if (step > 0 && step % interval == 0) {
+      const double d_interval = static_cast<double>(interval);
       int reset_val = 0;
 
       auto dram_read_total_duration = read_total_duration_.exchange(reset_val);
@@ -2113,49 +2123,56 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
           bwd_l1_cnflct_miss_write_missing_load_avg_.exchange(reset_val);
 
       auto read_num_counts = read_num_counts_.exchange(reset_val);
+      auto read_hit_count = read_hit_count_.exchange(reset_val);
+      auto read_miss_count = read_miss_count_.exchange(reset_val);
 
-      ret[0] = dram_read_total_duration / interval;
-      ret[1] = dram_read_sharding_total_duration / interval;
-      ret[2] = dram_read_cache_hit_copy_duration / interval;
-      ret[3] = dram_read_fill_row_storage_duration / interval;
-      ret[4] = dram_read_lookup_cache_duration / interval;
-      ret[5] = dram_read_acquire_lock_duration / interval;
-      ret[6] = dram_read_missing_load / interval;
-      ret[7] = dram_write_sharding_total_duration / interval;
+      ret[0] = dram_read_total_duration / d_interval;
+      ret[1] = dram_read_sharding_total_duration / d_interval;
+      ret[2] = dram_read_cache_hit_copy_duration / d_interval;
+      ret[3] = dram_read_fill_row_storage_duration / d_interval;
+      ret[4] = dram_read_lookup_cache_duration / d_interval;
+      ret[5] = dram_read_acquire_lock_duration / d_interval;
+      ret[6] = dram_read_missing_load / d_interval;
+      ret[7] = dram_write_sharding_total_duration / d_interval;
 
-      ret[8] = dram_fwd_l1_eviction_write_total_duration / interval;
-      ret[9] = dram_fwd_l1_eviction_write_allocate_duration / interval;
-      ret[10] = dram_fwd_l1_eviction_write_cache_copy_duration / interval;
-      ret[11] = dram_fwd_l1_eviction_write_lookup_cache_duration / interval;
-      ret[12] = dram_fwd_l1_eviction_write_acquire_lock_duration_ / interval;
-      ret[13] = dram_fwd_l1_eviction_write_missing_load_ / interval;
+      ret[8] = dram_fwd_l1_eviction_write_total_duration / d_interval;
+      ret[9] = dram_fwd_l1_eviction_write_allocate_duration / d_interval;
+      ret[10] = dram_fwd_l1_eviction_write_cache_copy_duration / d_interval;
+      ret[11] = dram_fwd_l1_eviction_write_lookup_cache_duration / d_interval;
+      ret[12] = dram_fwd_l1_eviction_write_acquire_lock_duration_ / d_interval;
+      ret[13] = dram_fwd_l1_eviction_write_missing_load_ / d_interval;
 
-      ret[14] = dram_bwd_l1_cnflct_miss_write_total_duration / interval;
-      ret[15] = dram_bwd_l1_cnflct_miss_write_allocate_duration / interval;
-      ret[16] = dram_bwd_l1_cnflct_miss_write_cache_copy_duration / interval;
-      ret[17] = dram_bwd_l1_cnflct_miss_write_lookup_cache_duration / interval;
-      ret[18] = dram_bwd_l1_cnflct_miss_write_acquire_lock_duration_ / interval;
-      ret[19] = dram_bwd_l1_cnflct_miss_write_missing_load_ / interval;
+      ret[14] = dram_bwd_l1_cnflct_miss_write_total_duration / d_interval;
+      ret[15] = dram_bwd_l1_cnflct_miss_write_allocate_duration / d_interval;
+      ret[16] = dram_bwd_l1_cnflct_miss_write_cache_copy_duration / d_interval;
+      ret[17] =
+          dram_bwd_l1_cnflct_miss_write_lookup_cache_duration / d_interval;
+      ret[18] =
+          dram_bwd_l1_cnflct_miss_write_acquire_lock_duration_ / d_interval;
+      ret[19] = dram_bwd_l1_cnflct_miss_write_missing_load_ / d_interval;
 
       ret[20] = get_map_used_memsize_in_bytes();
       ret[21] = get_map_actual_used_chunk_in_bytes();
 
       ret[22] = get_num_rows();
-      ret[23] = read_num_counts / interval;
+      ret[23] = read_num_counts / d_interval;
 
-      ret[24] = metadata_write_sharding_total_duration / interval;
-      ret[25] = metadata_write_total_duration / interval;
-      ret[26] = metadata_write_allocate_avg_duration / interval;
-      ret[27] = metadata_write_lookup_cache_avg_duration / interval;
-      ret[28] = metadata_write_acquire_lock_avg_duration / interval;
-      ret[29] = metadata_write_cache_miss_avg_count / interval;
+      ret[24] = metadata_write_sharding_total_duration / d_interval;
+      ret[25] = metadata_write_total_duration / d_interval;
+      ret[26] = metadata_write_allocate_avg_duration / d_interval;
+      ret[27] = metadata_write_lookup_cache_avg_duration / d_interval;
+      ret[28] = metadata_write_acquire_lock_avg_duration / d_interval;
+      ret[29] = metadata_write_cache_miss_avg_count / d_interval;
 
-      ret[30] = read_metadata_total_duration / interval;
-      ret[31] = read_metadata_sharding_total_duration / interval;
-      ret[32] = read_metadata_cache_hit_copy_avg_duration / interval;
-      ret[33] = read_metadata_lookup_cache_total_avg_duration / interval;
-      ret[34] = read_metadata_acquire_lock_avg_duration / interval;
-      ret[35] = read_metadata_load_size / interval;
+      ret[30] = read_metadata_total_duration / d_interval;
+      ret[31] = read_metadata_sharding_total_duration / d_interval;
+      ret[32] = read_metadata_cache_hit_copy_avg_duration / d_interval;
+      ret[33] = read_metadata_lookup_cache_total_avg_duration / d_interval;
+      ret[34] = read_metadata_acquire_lock_avg_duration / d_interval;
+      ret[35] = read_metadata_load_size / d_interval;
+
+      ret[36] = read_hit_count;
+      ret[37] = read_miss_count;
     }
     return ret;
   }
@@ -2414,6 +2431,10 @@ class DramKVEmbeddingCache : public kv_db::EmbeddingKVDB {
   std::atomic<int64_t> inplace_update_miss_cnt_{0};
 
   std::atomic<int64_t> read_num_counts_{0};
+
+  // DRAM KV cache hit/miss raw counters (not averaged per shard)
+  std::atomic<int64_t> read_hit_count_{0};
+  std::atomic<int64_t> read_miss_count_{0};
 
   bool disable_random_init_;
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2584

CONTEXT: DRAM KV embedding cache lacked hit/miss rate metrics during training, making it hard to monitor cache effectiveness. The SSD backend had `l2_cache.hit_rate_pct`, but the DRAM backend only tracked `read_missing_load_avg_` (averaged per-shard miss count), which was not accurate for hit rate computation. L1 cache stats had raw counts but never computed a hit rate percentage. Additionally, when multiple TBEs exist on a single trainer, their metrics were mixed together in TensorBoard, making it impossible to tell which table has good/bad cache performance.

WHAT:
- C++ (`dram_kv_embedding_cache.h`): Add atomic `read_hit_count_` and `read_miss_count_` counters in the read path (`get_kv_db_async_impl`). Extend the `get_dram_kv_perf()` vector from 36 to 38 elements to expose raw hit/miss counts (not averaged per shard).
- Python (`training.py`): Parse new perf vector indices, compute `hit_rate_pct = 100 * hits / (hits + misses)`, and report both aggregate and per-TBE metrics via `stats_reporter`. Per-TBE metrics use `tbe_id{N}` in the name and are dynamically registered via `register_stats()`. Also add L1 hit rate computed from existing `num_unique_indices` and `num_unique_misses`.
- Stats reporter (`tbe_stats_reporters.py`): Register aggregate `dram_kv.hit_rate_pct` and `ssd_tbe.prefetch.l1_hit_rate_pct` in the allowlist.

New TensorBoard/ODS metrics:
- `dram_kv.tbe_id{N}.hit_rate_pct` — per-TBE DRAM cache hit rate (0-100%)
- `dram_kv.perf.get.tbe_id{N}.dram_read_hit_count` — per-TBE raw hit count
- `dram_kv.perf.get.tbe_id{N}.dram_read_miss_count` — per-TBE raw miss count
- `ssd_tbe.prefetch.tbe_id{N}.l1_hit_rate_pct` — per-TBE L1 GPU HBM cache hit rate
- `dram_kv.hit_rate_pct` — aggregate DRAM hit rate
- `ssd_tbe.prefetch.l1_hit_rate_pct` — aggregate L1 hit rate

Differential Revision: D100903024
