### PR TITLE
Add weight_init_device support for both Split and Dense TBE kernels

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -291,7 +291,17 @@ def apply_split_helper(
     uvm_tensors_log: Optional[list[str]] = None,
     uvm_host_mapped: bool = False,
     make_persistent: bool = False,
+    dev_weight_init_device: Optional[torch.device] = None,
 ) -> None:
+    dev_device = (
+        dev_weight_init_device if dev_weight_init_device is not None else current_device
+    )
+    if dev_weight_init_device is not None and dev_weight_init_device != current_device:
+        logging.info(
+            f"[FBGEMM TBE] Allocating {prefix}_dev buffer on {dev_device} "
+            f"instead of {current_device} (dev_size={split.dev_size})"
+        )
+
     set_attr_fn(f"{prefix}_physical_placements", split.placements)
     set_attr_fn(f"{prefix}_physical_offsets", split.offsets)
 
@@ -308,7 +318,7 @@ def apply_split_helper(
     if split.dev_size > 0:
         dev_buffer = torch.zeros(
             split.dev_size,
-            device=current_device,
+            device=dev_device,
             # pyre-fixme[6]
             dtype=dtype,
         )
@@ -655,6 +665,13 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             True, defaults to RESParams().
 
         is_qr_tbe (bool = False): Whether this is a QRSplitTableBatchedEmbeddingBagsCodegen.
+
+        weight_init_device (Optional[torch.device] = None): When set, allocate
+            the dev weight buffer on this device instead of `current_device`.
+            Metadata tensors (`weights_offsets`, `weights_placements`) remain on
+            `current_device`. The caller is responsible for moving weights to the
+            compute device before any forward pass. Only affects the `weights`
+            prefix `_apply_split` call, not optimizer states.
     """
 
     embedding_specs: list[tuple[int, int, EmbeddingLocation, ComputeDevice]]
@@ -730,6 +747,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         enable_raw_embedding_streaming: bool = False,
         res_params: Optional[RESParams] = None,
         is_qr_tbe: bool = False,
+        weight_init_device: Optional[torch.device] = None,
     ) -> None:
         super(SplitTableBatchedEmbeddingBagsCodegen, self).__init__()
         self.uuid = str(uuid.uuid4())
@@ -1059,6 +1077,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             make_dev_param=optimizer == OptimType.NONE,
             dev_reshape=(-1, self.max_D) if optimizer == OptimType.NONE else None,
             uvm_host_mapped=self.uvm_host_mapped,
+            dev_weight_init_device=weight_init_device,
         )
 
         assert optimizer not in (
@@ -3634,6 +3653,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         make_dev_param: bool = False,
         dev_reshape: Optional[tuple[int, ...]] = None,
         uvm_host_mapped: bool = False,
+        dev_weight_init_device: Optional[torch.device] = None,
     ) -> None:
         apply_split_helper(
             self.register_buffer,
@@ -3651,6 +3671,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             uvm_host_mapped=uvm_host_mapped,
             # Only force persistent for Split TBE on MTIA, see D97971757 for details.
             make_persistent=(self.use_mtia and not self.is_qr_tbe),
+            dev_weight_init_device=dev_weight_init_device,
         )
 
     def _apply_cache_state(
@@ -4638,7 +4659,15 @@ class DenseTableBatchedEmbeddingBagsCodegen(nn.Module):
         use_cpu: bool = False,
         output_dtype: SparseType = SparseType.FP32,
         use_mtia: bool = False,
-    ) -> None:  # noqa C901  # tuple of (rows, dims,)
+        weight_init_device: Optional[torch.device] = None,
+    ) -> None:  # noqa C901
+        """
+        Args:
+            weight_init_device: When set, allocate the embedding weight tensor
+                on this device instead of the compute device. The caller is
+                responsible for moving weights to the compute device before
+                any forward pass.
+        """
         super(DenseTableBatchedEmbeddingBagsCodegen, self).__init__()
         self.uuid = str(uuid.uuid4())
 
@@ -4720,10 +4749,20 @@ class DenseTableBatchedEmbeddingBagsCodegen(nn.Module):
         weights_offsets = [0] + list(
             accumulate([row * dim for (row, dim) in embedding_specs])
         )
+        weights_device = (
+            weight_init_device
+            if weight_init_device is not None
+            else self.current_device
+        )
+        if weight_init_device is not None and weight_init_device != self.current_device:
+            logging.info(
+                f"[FBGEMM DenseTBE] Allocating weights on {weights_device} "
+                f"instead of {self.current_device} (size={weights_offsets[-1]})"
+            )
         self.weights = nn.Parameter(
             torch.randn(
                 weights_offsets[-1],
-                device=self.current_device,
+                device=weights_device,
                 dtype=table_embedding_dtype,
             )
         )

--- a/fbgemm_gpu/test/tbe/training/weight_init_device_test.py
+++ b/fbgemm_gpu/test/tbe/training/weight_init_device_test.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+# pyre-ignore-all-errors[56]
+
+import unittest
+
+import torch
+from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
+from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+    EmbeddingLocation,
+    PoolingMode,
+)
+from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
+    ComputeDevice,
+    DenseTableBatchedEmbeddingBagsCodegen,
+    SplitTableBatchedEmbeddingBagsCodegen,
+)
+
+from .. import common  # noqa E402
+from ..common import open_source
+
+if open_source:
+    # pyre-ignore[21]
+    from test_utils import gpu_unavailable
+else:
+    from fbgemm_gpu.test.test_utils import gpu_unavailable
+
+
+class WeightInitDeviceTest(unittest.TestCase):
+    @unittest.skipIf(*gpu_unavailable)
+    def test_split_tbe_weight_init_device_cpu(self) -> None:
+        T = 3
+        E = 100
+        D = 32
+        cc = SplitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (E, D, EmbeddingLocation.DEVICE, ComputeDevice.CUDA) for _ in range(T)
+            ],
+            weights_precision=SparseType.FP32,
+            optimizer=OptimType.NONE,
+            pooling_mode=PoolingMode.SUM,
+            weight_init_device=torch.device("cpu"),
+        )
+        # weights_dev should be on CPU
+        # pyre-ignore[29]: weights_dev is a Tensor
+        self.assertEqual(cc.weights_dev.device.type, "cpu")
+        # pyre-ignore[29]: weights_dev is a Tensor
+        self.assertEqual(cc.weights_dev.numel(), T * E * D)
+        # metadata should remain on CUDA
+        self.assertEqual(cc.weights_offsets.device.type, "cuda")
+        self.assertEqual(cc.weights_placements.device.type, "cuda")
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_split_tbe_weight_init_device_none(self) -> None:
+        T = 2
+        E = 64
+        D = 16
+        cc = SplitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (E, D, EmbeddingLocation.DEVICE, ComputeDevice.CUDA) for _ in range(T)
+            ],
+            weights_precision=SparseType.FP32,
+            optimizer=OptimType.NONE,
+            pooling_mode=PoolingMode.SUM,
+            weight_init_device=None,
+        )
+        # default: weights_dev should be on CUDA
+        self.assertEqual(cc.weights_dev.device.type, "cuda")
+        self.assertEqual(cc.weights_offsets.device.type, "cuda")
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_split_tbe_weight_init_device_does_not_affect_optimizer_states(
+        self,
+    ) -> None:
+        T = 2
+        E = 64
+        D = 16
+        cc = SplitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (E, D, EmbeddingLocation.DEVICE, ComputeDevice.CUDA) for _ in range(T)
+            ],
+            weights_precision=SparseType.FP32,
+            optimizer=OptimType.EXACT_ROWWISE_ADAGRAD,
+            learning_rate=0.01,
+            pooling_mode=PoolingMode.SUM,
+            weight_init_device=torch.device("cpu"),
+        )
+        # weights_dev on CPU
+        self.assertEqual(cc.weights_dev.device.type, "cpu")
+        # optimizer state (momentum1) should remain on CUDA
+        self.assertEqual(cc.momentum1_dev.device.type, "cuda")
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_dense_tbe_weight_init_device_cpu(self) -> None:
+        E = 100
+        D = 32
+        T = 3
+        cc = DenseTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[(E, D) for _ in range(T)],
+            pooling_mode=PoolingMode.SUM,
+            weight_init_device=torch.device("cpu"),
+        )
+        # weights should be on CPU
+        self.assertEqual(cc.weights.device.type, "cpu")
+        self.assertEqual(cc.weights.numel(), T * E * D)
+        # metadata should remain on CUDA
+        self.assertEqual(cc.D_offsets.device.type, "cuda")
+        self.assertEqual(cc.hash_size_cumsum.device.type, "cuda")
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_dense_tbe_weight_init_device_none(self) -> None:
+        E = 64
+        D = 16
+        T = 2
+        cc = DenseTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[(E, D) for _ in range(T)],
+            pooling_mode=PoolingMode.SUM,
+            weight_init_device=None,
+        )
+        # default: weights on CUDA
+        self.assertEqual(cc.weights.device.type, "cuda")
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_split_tbe_weight_init_device_cpu_move_to_cuda(self) -> None:
+        T = 2
+        E = 64
+        D = 16
+        cc = SplitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (E, D, EmbeddingLocation.DEVICE, ComputeDevice.CUDA) for _ in range(T)
+            ],
+            weights_precision=SparseType.FP32,
+            optimizer=OptimType.NONE,
+            pooling_mode=PoolingMode.SUM,
+            weight_init_device=torch.device("cpu"),
+        )
+        self.assertEqual(cc.weights_dev.device.type, "cpu")
+        # Simulate user moving weights to CUDA after init
+        # pyre-ignore[16, 6]: weights_dev is a Tensor
+        cc.weights_dev = torch.nn.Parameter(cc.weights_dev.data.cuda())
+        self.assertEqual(cc.weights_dev.device.type, "cuda")
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_dense_tbe_weight_init_device_cpu_move_to_cuda(self) -> None:
+        E = 64
+        D = 16
+        T = 2
+        cc = DenseTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[(E, D) for _ in range(T)],
+            pooling_mode=PoolingMode.SUM,
+            weight_init_device=torch.device("cpu"),
+        )
+        self.assertEqual(cc.weights.device.type, "cpu")
+        # Simulate user moving weights to CUDA after init
+        cc.weights = torch.nn.Parameter(cc.weights.cuda())
+        self.assertEqual(cc.weights.device.type, "cuda")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
## 1. Context

The main purpose of this diff is to allow TBE weights to be initialized on a given device (CPU/meta) that differs from the originally assigned compute device (`current_device`, which is also used for metadata like `D_offsets`, `hash_size_cumsum`, `weights_placements`, `weights_offsets`, etc.). The user is responsible for handling the actual allocation and placement of the TBE weights after initialization — such as quantization, shared memory mapping, checkpoint loading, or any other post-processing before moving weights to the compute device for forward passes.

This enables eval workflows where temporary FP32 weights cause an HBM peak during model initialization, but are only needed briefly before being quantized, loaded from shared memory, or otherwise transformed. Example use cases:

1. **Checkpoint eval with quantization**: Init weights on CPU, load FP32 checkpoint to CPU, quantize to NFP8 on CPU, move only the smaller quantized weights to GPU — FP32 never touches HBM.
2. **Shared memory eval**: Init weights on meta device (zero allocation), then replace with a UVM tensor backed by POSIX shared memory (`/dev/shm`). Multiple eval workers share the same physical memory for read-only embedding lookups without per-process HBM copies.

## 2. Approach

1. **Unified `weight_init_device` parameter**: Add `weight_init_device: Optional[torch.device]` to both `SplitTableBatchedEmbeddingBagsCodegen` and `DenseTableBatchedEmbeddingBagsCodegen`. When set, weight buffers are allocated on the specified device instead of `current_device`. Metadata tensors (`D_offsets`, `hash_size_cumsum`, `weights_offsets`, `weights_placements`) remain on `current_device`.

2. **Split TBE (`dev_weight_init_device`)**: In `apply_split_helper`, the new `dev_weight_init_device` parameter overrides the allocation device for `dev_buffer` only. Metadata tensors stay on `current_device` (GPU) so the CUDA forward kernel can read them once weights are moved back.

3. **Dense TBE**: `weight_init_device` directly controls the device for `self.weights = nn.Parameter(torch.randn(..., device=weights_device))`.

TorchRec wiring (`BatchedFusedEmbeddingBag`, `BatchedDenseEmbeddingBag`, `ShardingEnv`, `DistributedModelParallel`) is in the dependent diff D99947880.

## 3. Analysis

1. **Backward compatibility**: All new parameters default to `None`, preserving existing behavior.
2. **Device mismatch risk**: When `weight_init_device` is set, the TBE weight buffers live on a different device than `current_device`. This creates a device mismatch that will cause runtime errors if the user attempts a forward pass before moving weights to the compute device. Downstream processes (checkpoint loading, state dict operations, `TableBatchedEmbeddingSlice` view creation) will also see weights on the init device. The user is responsible for ensuring weights are on the correct device before any operation that requires them on the compute device.
3. **Caller responsibility**: `weight_init_device` is an init-only setting. The caller must handle moving weights to the compute device before forward passes — whether via quantization, shared memory registration, or explicit `.to()`.
4. **Scope for Split TBE**: `dev_weight_init_device` only affects the `weights` prefix `_apply_split` call, not optimizer state `_apply_split` calls.
5. **Metadata separation**: All metadata tensors (`D_offsets`, `hash_size_cumsum`, `weights_offsets`, `weights_placements`, etc.) remain on `current_device` regardless of `weight_init_device`. Only the weight data buffers are placed on the init device.

## 4. Changes

1. **`apply_split_helper`**: Added `dev_weight_init_device` parameter. When set, `dev_buffer` is allocated on this device instead of `current_device`. Metadata tensors (`{prefix}_offsets`, `{prefix}_placements`) are unaffected.
2. **`SplitTableBatchedEmbeddingBagsCodegen._apply_split`**: Threads `dev_weight_init_device` to `apply_split_helper`.
3. **`SplitTableBatchedEmbeddingBagsCodegen.__init__`**: Added `weight_init_device` parameter, passed to `_apply_split` for the `weights` prefix only (not optimizer states).
4. **`DenseTableBatchedEmbeddingBagsCodegen.__init__`**: Added `weight_init_device` parameter. `self.weights` is allocated on `weights_device` instead of `self.current_device`.
5. Added logging when device override is active for both Split and Dense TBE.

Differential Revision: D101011345


