### PR TITLE
Fix TBE v2 forward kernel for embedding dim > 1024 (#5326) (#5569)

### DIFF
--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_v2_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_v2_template.cu
@@ -749,6 +749,7 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel(
     const uint32_t T,
     const bool mean_pooling,
     const uint32_t max_D_cache,
+    const uint32_t max_D,
     const FixedDivisor fd_num_warps_per_table,
     const index_t* __restrict__ const indices,
     {%- if weighted %}
@@ -815,12 +816,9 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel(
     const auto is_small_L = total_L <= (static_cast<index_t>(B) * 8);
     const uint32_t num_warps_for_small_L = DIV_ROUND_UP(B, NUM_OFFSETS_PER_WARP);
 
-    // Early exit for small-L to avoid D_offsets reads
-    // if table_warp_id > B * max(num_warps_per_row) / NUM_OFFSETS_PER_WARP
-    // max(num_warps_per_row) = 8 (for D = 1024)
-    // NUM_OFFSETS_PER_WARP = 32
-    // Return if table_warp_id > ceil(B / 32) * 8
-    if (is_small_L && table_warp_id >= num_warps_for_small_L * 8) {
+    // Early exit for small-L to avoid D_offsets reads.
+    const uint32_t max_num_warps_per_row = DIV_ROUND_UP(max_D / VEC_WIDTH, kWarpSize);
+    if (is_small_L && table_warp_id >= num_warps_for_small_L * max_num_warps_per_row) {
       return;
     }
 
@@ -1039,6 +1037,7 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel
     const uint32_t T,
     const bool mean_pooling,
     const uint32_t max_D_cache,
+    const uint32_t max_D,
     const FixedDivisor fd_num_warps_per_table,
     const {{ index_type }}* __restrict__ const indices,
     {%- if weighted %}

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
@@ -116,6 +116,7 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel(
     const uint32_t T,
     const bool mean_pooling,
     const uint32_t max_D_cache,
+    const uint32_t max_D,
     const FixedDivisor fd_num_warps_per_table,
     const index_t* __restrict__ const indices,
     {%- if weighted %}
@@ -836,6 +837,7 @@ batch_index_select_dim0_codegen_forward_cuda(
               T,
               static_cast<PoolingMode>(pooling_mode) == PoolingMode::MEAN,
               use_lxu_cache ? lxu_cache_weights.size(1) : 0,
+              static_cast<uint32_t>(max_D),
               FixedDivisor(num_warps_per_table),
               indices.data_ptr<index_t>(),
               {%- if weighted %}

--- a/fbgemm_gpu/test/tbe/training/forward_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_test.py
@@ -586,7 +586,13 @@ class ForwardTest(unittest.TestCase):
     ) -> None:
         weights_precision = SparseType.FP16
         use_cpu = False
-        D = random.randint(2, 256)
+        # Include large D values to exercise the TBE v2 kernel path (D > 1024)
+        D = random.choice(list(range(2, 257, 16)) + [1024, 1280, 1536, 2048])
+        # Scale down T, B, L for large D to avoid OOM
+        if D > 256:
+            T = min(T, 2)
+            B = min(B, 16)
+            L = min(L, 4)
         log_E = random.randint(3, 5)
 
         use_cache = False
@@ -884,10 +890,13 @@ class ForwardTest(unittest.TestCase):
     ) -> None:
         weights_precision = SparseType.FP32
         use_cpu = False
-        T = random.randint(1, 10)
-        D = random.randint(2, 256)
-        B = random.randint(1, 128)
-        L = random.randint(0, 20)
+        # Include large D values to exercise the TBE v2 kernel path (D > 1024)
+        D = random.choice(list(range(2, 257, 16)) + [1024, 1280, 1536, 2048])
+        # Scale down T, B, L for large D to avoid OOM
+        max_TBL = max(1, int(2048 / max(D, 1)))
+        T = random.randint(1, min(10, max_TBL))
+        B = random.randint(1, min(128, max_TBL // T))
+        L = random.randint(0, min(20, max_TBL // max(T * B, 1)))
         log_E = random.randint(3, 5)
 
         use_cache = False


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/pytorch/FBGEMM/pull/5569

Test Plan:
## Test Commands

buck2 test fbcode//deeplearning/fbgemm/fbgemm_gpu/test/tbe:forward -- ForwardTest.test_forward_gpu_no_cache_fp16
buck2 test fbcode//deeplearning/fbgemm/fbgemm_gpu/test/tbe:forward -- ForwardTest.test_forward_gpu_no_cache_fp32

## What Is Tested

1. **test_forward_gpu_no_cache_fp16** - Exercises the v2 forward kernel (when use_experimental_tbe=True, generated by Hypothesis) with D in {2..256 step 16, 1024, 1280, 1536, 2048}. Validates FP16 forward correctness for both the small-L and large-L paths with the dynamic early exit fix. T, B, L are capped (T<=2, B<=16, L<=4) for D > 256 to prevent OOM.

2. **test_forward_gpu_no_cache_fp32** - Same D range as above with FP32 weights. Uses proportional max_TBL = max(1, 2048/D) scaling for large D to prevent OOM while still exercising the v2 kernel max_num_warps_per_row computation.

Both tests use Hypothesis-generated use_experimental_tbe in {True, False}, covering both the v1 (legacy) and v2 (experimental) kernel paths.

BUCK target: fbcode//deeplearning/fbgemm/fbgemm_gpu/test/tbe:forward

Reviewed By: henrylhtsang

Differential Revision: D99746894

Pulled By: q10


