### PR TITLE
Fix bf16 rounding to IEEE 754 ties-to-even

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,12 +156,18 @@ if(NOT MSVC)
 endif()
 
 set(fbgemm_arm_defs)
+set(fbgemm_arm_bf16_flags)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64|arm64")
   set(fbgemm_arm_defs
       FBGEMM_FP16_FALLBACK_TO_REF_KERNEL
       FBGEMM_FP32_FALLBACK_TO_REF_KERNEL)
   if(NOT APPLE)
     list(APPEND fbgemm_arm_defs FBGEMM_ENABLE_KLEIDIAI)
+  endif()
+  check_cxx_compiler_flag("-march=armv8.6-a+bf16+fp16fml" COMPILER_SUPPORTS_BF16)
+  if(COMPILER_SUPPORTS_BF16)
+    set(fbgemm_arm_bf16_flags "-march=armv8.6-a+bf16+fp16fml")
+    message(STATUS "Enabling hardware BF16 (BFCVT) for aarch64")
   endif()
 endif()
 
@@ -196,6 +202,8 @@ cpp_library(
     $<BUILD_INTERFACE:${FBGEMM_SOURCE_DIR}/bench>
   MSVC_FLAGS
     /wd4717 /bigobj
+  CC_FLAGS
+    ${fbgemm_arm_bf16_flags}
   SANITIZER_OPTIONS
     "${FBGEMM_USE_SANITIZER}"
   DEFINITIONS
@@ -293,6 +301,10 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64|arm64")
 
   if(NOT COMPILER_SUPPORTS_FP16FML)
     message(FATAL_ERROR "The current compiler does not support building FP16FML code")
+  endif()
+
+  if(COMPILER_SUPPORTS_BF16)
+    set(fbgemm_fml_flags "${fbgemm_arm_bf16_flags}")
   endif()
 
   message(STATUS "Processor is ${CMAKE_SYSTEM_PROCESSOR}; will build Neon target")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,12 +156,17 @@ if(NOT MSVC)
 endif()
 
 set(fbgemm_arm_defs)
+set(fbgemm_arm_bf16_flags)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64|arm64")
   set(fbgemm_arm_defs
       FBGEMM_FP16_FALLBACK_TO_REF_KERNEL
       FBGEMM_FP32_FALLBACK_TO_REF_KERNEL)
   if(NOT APPLE)
     list(APPEND fbgemm_arm_defs FBGEMM_ENABLE_KLEIDIAI)
+  endif()
+  check_cxx_compiler_flag("-march=armv8.6-a+bf16+fp16fml" COMPILER_SUPPORTS_BF16)
+  if(COMPILER_SUPPORTS_BF16)
+    set(fbgemm_arm_bf16_flags "-march=armv8.6-a+bf16+fp16fml")
   endif()
 endif()
 
@@ -177,6 +182,10 @@ endif()
 set(fbgemm_generic_defs "${fbgemm_arm_defs}")
 if(FBGEMM_LIBRARY_TYPE STREQUAL STATIC)
   list(APPEND fbgemm_generic_defs FBGEMM_STATIC)
+endif()
+# Gates the BFCVT dispatch in FbgemmBfloat16Convert.cc.
+if(COMPILER_SUPPORTS_BF16)
+  list(APPEND fbgemm_generic_defs FBGEMM_HAVE_BF16_BFCVT)
 endif()
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64|arm64")
@@ -320,6 +329,29 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64|arm64")
 
 else()
   message(STATUS "Processor is ${CMAKE_SYSTEM_PROCESSOR}; will NOT build Neon target")
+endif()
+
+################################################################################
+# FBGEMM BFCVT Target
+################################################################################
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64|arm64" AND COMPILER_SUPPORTS_BF16)
+  message(STATUS "Processor is ${CMAKE_SYSTEM_PROCESSOR}; will build BFCVT target")
+  cpp_library(
+    PREFIX
+      fbgemm_bfcvt
+    TYPE
+      OBJECT
+    SRCS
+      src/FbgemmBfloat16ConvertBfcvt.cc
+    CC_FLAGS
+      ${fbgemm_arm_bf16_flags}
+    DEPS
+      $<BUILD_INTERFACE:cpuinfo>
+      fbgemm_generic
+  )
+
+  list(APPEND fbgemm_targets fbgemm_bfcvt)
 endif()
 
 ################################################################################

--- a/include/fbgemm/FbgemmConvert.h
+++ b/include/fbgemm/FbgemmConvert.h
@@ -47,6 +47,24 @@ FloatToBfloat16_simd(const float* src, bfloat16* dst, size_t size);
 FBGEMM_API void
 Bfloat16ToFloat_simd(const bfloat16* src, float* dst, size_t size);
 
+#if defined(__aarch64__)
+/**
+ * @brief BFCVT (hardware bf16) implementation to convert fp32 numbers to
+ * bf16 numbers.
+ *
+ */
+FBGEMM_API void
+FloatToBfloat16_bfcvt(const float* src, bfloat16* dst, size_t size);
+
+/**
+ * @brief BFCVT (hardware bf16) implementation to convert bf16 numbers to
+ * fp32 numbers.
+ *
+ */
+FBGEMM_API void
+Bfloat16ToFloat_bfcvt(const bfloat16* src, float* dst, size_t size);
+#endif
+
 #if !defined(__aarch64__)
 /**
  * @brief AVX2 implementation to convert fp32 numbers to bf16 numbers.

--- a/include/fbgemm/FloatConversion.h
+++ b/include/fbgemm/FloatConversion.h
@@ -29,6 +29,12 @@
 // instructions for scalar fp16<->fp32 conversion.
 // - GCC/Clang: __F16C__ is defined by -mf16c or -march=haswell+
 // - MSVC: never defines __F16C__, but /arch:AVX2 implies F16C hardware
+// ARMv8.6-A BF16 extension: hardware BFCVT with IEEE 754 ties-to-even
+#if defined(__aarch64__) && defined(__ARM_FEATURE_BF16)
+#define HAS_NATIVE_BF16_TYPE
+#include <arm_neon.h>
+#endif
+
 #if defined(__F16C__) || (defined(_MSC_VER) && defined(__AVX2__))
 #define HAS_F16C
 #include <immintrin.h>
@@ -305,13 +311,22 @@ inline float16 cpu_float2half(const float f) {
 }
 
 inline float cpu_bf162float(bfloat16 src) {
+#ifdef HAS_NATIVE_BF16_TYPE
+  return vcvtah_f32_bf16(std::bit_cast<bfloat16_t>(src));
+#else
   uint32_t val_fp32 = static_cast<uint32_t>(src) << 16;
   return std::bit_cast<float>(val_fp32);
+#endif
 }
 
 inline bfloat16 cpu_float2bfloat16(float src) {
-  uint32_t temp = std::bit_cast<uint32_t>(src);
-  return (temp + (1u << 15)) >> 16;
+#ifdef HAS_NATIVE_BF16_TYPE
+  return std::bit_cast<bfloat16>(vcvth_bf16_f32(src));
+#else
+  // IEEE 754 round-to-nearest-even
+  uint32_t bits = std::bit_cast<uint32_t>(src);
+  return (bits + ((bits >> 16) & 1) + 0x7FFFu) >> 16;
+#endif
 }
 
 } // namespace fbgemm

--- a/include/fbgemm/FloatConversion.h
+++ b/include/fbgemm/FloatConversion.h
@@ -304,14 +304,14 @@ inline float16 cpu_float2half(const float f) {
 #endif
 }
 
-inline float cpu_bf162float(bfloat16 src) {
-  uint32_t val_fp32 = static_cast<uint32_t>(src.val) << 16;
-  return std::bit_cast<float>(val_fp32);
+constexpr float cpu_bf162float(bfloat16 src) {
+  return std::bit_cast<float>(static_cast<uint32_t>(src.val) << 16);
 }
 
-inline bfloat16 cpu_float2bfloat16(float src) {
-  uint32_t temp = std::bit_cast<uint32_t>(src);
-  return {static_cast<uint16_t>((temp + (1u << 15)) >> 16)};
+constexpr bfloat16 cpu_float2bfloat16(float src) {
+  uint32_t bits = std::bit_cast<uint32_t>(src);
+  bits += ((bits >> 16) & 1) + 0x7FFFu; // round to nearest, ties to even
+  return {static_cast<uint16_t>(bits >> 16)};
 }
 
 } // namespace fbgemm

--- a/src/Bf16ConvertAvx2.h
+++ b/src/Bf16ConvertAvx2.h
@@ -13,22 +13,13 @@
 
 namespace fbgemm::internal {
 
-// fp32->bf16 conversion via the "val + 0x8000, take high 16 bits" trick.
-//
-// NOTE: This rounds half values *away from zero*, NOT round-to-nearest-even
-// (RNE). It therefore differs from:
-//   - the scalar reference cpu_float2bfloat16(), which uses RNE, and
-//   - the AVX-512 path (Fused8BitRowwiseQuantizedSBFloatToBfloat16Avx512),
-//     which uses the hardware vcvtneps2bf16 (RNE).
-// As a result, the same logical dequant can produce bf16 bit patterns that
-// differ by up to 1 ULP depending on which backend runs (AVX-512-BF16 vs AVX2
-// vs scalar Ref). Callers that need bit-exact agreement with
-// cpu_float2bfloat16() must not use these helpers. Additionally, a NaN whose
-// upper 7 mantissa bits are all 1 can carry into the exponent and become
-// +/-inf.
+// fp32->bf16, round-to-nearest-even (matches scalar and AVX-512 paths).
 inline __m256i cvt_fp32_to_bf16x8(__m256i val) {
+  __m256i lsb =
+      _mm256_and_si256(_mm256_srli_epi32(val, 16), _mm256_set1_epi32(1));
   return _mm256_srli_epi32(
-      _mm256_add_epi32(val, _mm256_set1_epi32(0x8000)), 16);
+      _mm256_add_epi32(val, _mm256_add_epi32(lsb, _mm256_set1_epi32(0x7FFF))),
+      16);
 }
 
 // Convert 2x8 fp32 to 16 packed bf16

--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <concepts>
 #include <cstdint>
 #include <memory>
 #include <stdexcept>
@@ -382,6 +383,7 @@ GenEmbeddingSpMDMLookup<
         Ymm mask_vreg; // mask for avx2
         Xmm mask_fp16_vreg; // mask for loading fp16 in avx2
         vec_reg_t bf16_bias_vreg; // 0x7FFF for bf16 ties-to-even rounding
+        vec_reg_t bf16_one_vreg;  // set1(1) for LSB mask
         vec_reg_t bf16_tmp_vreg;  // scratch for bf16 rounding
 
         if constexpr (is_8bit_in) {
@@ -400,8 +402,27 @@ GenEmbeddingSpMDMLookup<
                      0);
           a->vpbroadcastd(bf16_bias_vreg, bf16_bias_vreg.xmm());
           --unroll_factor;
+          bf16_one_vreg = vec_reg_t(unroll_factor);
+          a->mov(scratchReg2_, 1);
+          a->vpinsrd(bf16_one_vreg.xmm(), bf16_one_vreg.xmm(), scratchReg2_, 0);
+          a->vpbroadcastd(bf16_one_vreg, bf16_one_vreg.xmm());
+          --unroll_factor;
           bf16_tmp_vreg = vec_reg_t(unroll_factor);
         }
+
+        // Emit fp32->bf16 round-to-nearest-even on `out`. Ops are reordered
+        // so `out + bias` runs in parallel with the LSB extraction, giving
+        // a 4-deep dependency chain instead of 5 (same 5 ops, same regs).
+        // `emitPred` is invoked per instruction and returns the assembler,
+        // optionally with an AVX-512 write-mask applied.
+        auto emit_bf16_rne = [&]<std::invocable Pred>(
+                                 const vec_reg_t& out, Pred&& emitPred) {
+          emitPred().vpsrld(bf16_tmp_vreg, out, 16);            // tmp = v >> 16
+          emitPred().vpaddd(out, out, bf16_bias_vreg);          // out = v + 0x7FFF  (parallel)
+          emitPred().vpand(bf16_tmp_vreg, bf16_tmp_vreg, bf16_one_vreg);   // tmp = (v>>16) & 1
+          emitPred().vpaddd(out, out, bf16_tmp_vreg);           // out += tmp
+          emitPred().vpsrld(out, out, 16);                      // out >>= 16
+        };
 
         if (is_8bit_in || is_16bit_in ||
             (remainder && instSet == inst_set_t::avx2)) {
@@ -842,14 +863,7 @@ GenEmbeddingSpMDMLookup<
                 if (is_fp16_out) {
                   a->vcvtps2ph(out_vreg.xmm(), out_vreg, 8);
                 } else if (is_bf16_out) {
-                  // Round to nearest, ties to even:
-                  // rounding_bias = ((val >> 16) & 1) + 0x7FFF
-                  a->vpsrld(bf16_tmp_vreg, out_vreg, 16);
-                  a->vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
-                  a->vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
-                  a->vpaddd(bf16_tmp_vreg, bf16_tmp_vreg, bf16_bias_vreg);
-                  a->vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
-                  a->vpsrld(out_vreg, out_vreg, 16);
+                  emit_bf16_rne(out_vreg, [&]() -> auto& { return *a; });
                   a->vpackusdw(out_vreg, out_vreg, out_vreg);
                   a->vpermq(out_vreg, out_vreg, 0xd8);
                 }
@@ -878,27 +892,15 @@ GenEmbeddingSpMDMLookup<
                   if (is_fp16_out) {
                     a->k(x86::k(1)).vcvtps2ph(dst_addr, out_vreg, 8);
                   } else if (is_bf16_out) {
-                    // Round to nearest, ties to even
-                    a->k(x86::k(1)).vpsrld(bf16_tmp_vreg, out_vreg, 16);
-                    a->k(x86::k(1)).vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
-                    a->k(x86::k(1)).vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
-                    a->k(x86::k(1)).vpaddd(bf16_tmp_vreg, bf16_tmp_vreg,
-                                           bf16_bias_vreg);
-                    a->k(x86::k(1)).vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
-                    a->k(x86::k(1)).vpsrld(out_vreg, out_vreg, 16);
+                    emit_bf16_rne(
+                        out_vreg, [&]() -> auto& { return a->k(x86::k(1)); });
                     a->k(x86::k(1)).vpmovdw(dst_addr, out_vreg);
                   }
                 } else {
                   if (is_fp16_out) {
                     a->vcvtps2ph(dst_addr, out_vreg, 8);
                   } else if (is_bf16_out) {
-                    // Round to nearest, ties to even
-                    a->vpsrld(bf16_tmp_vreg, out_vreg, 16);
-                    a->vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
-                    a->vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
-                    a->vpaddd(bf16_tmp_vreg, bf16_tmp_vreg, bf16_bias_vreg);
-                    a->vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
-                    a->vpsrld(out_vreg, out_vreg, 16);
+                    emit_bf16_rne(out_vreg, [&]() -> auto& { return *a; });
                     a->vpmovdw(dst_addr, out_vreg);
                   }
                 }

--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -381,7 +381,8 @@ GenEmbeddingSpMDMLookup<
         vec_reg_t src_vreg; // for holding embedding value temporarily
         Ymm mask_vreg; // mask for avx2
         Xmm mask_fp16_vreg; // mask for loading fp16 in avx2
-        vec_reg_t ones_vreg; // 2^15 for bf16_2_fp32_rn
+        vec_reg_t bf16_bias_vreg; // 0x7FFF for bf16 ties-to-even rounding
+        vec_reg_t bf16_tmp_vreg;  // scratch for bf16 rounding
 
         if constexpr (is_8bit_in) {
           // We need 2 vec registers for 1. scale 2. bias
@@ -393,10 +394,13 @@ GenEmbeddingSpMDMLookup<
 
         if (is_bf16_out) {
           --unroll_factor;
-          ones_vreg = vec_reg_t(unroll_factor);
-          a->mov(scratchReg2_, 1 << 15);
-          a->vpinsrd(ones_vreg.xmm(), ones_vreg.xmm(), scratchReg2_, 0);
-          a->vpbroadcastd(ones_vreg, ones_vreg.xmm());
+          bf16_bias_vreg = vec_reg_t(unroll_factor);
+          a->mov(scratchReg2_, 0x7FFF);
+          a->vpinsrd(bf16_bias_vreg.xmm(), bf16_bias_vreg.xmm(), scratchReg2_,
+                     0);
+          a->vpbroadcastd(bf16_bias_vreg, bf16_bias_vreg.xmm());
+          --unroll_factor;
+          bf16_tmp_vreg = vec_reg_t(unroll_factor);
         }
 
         if (is_8bit_in || is_16bit_in ||
@@ -838,7 +842,13 @@ GenEmbeddingSpMDMLookup<
                 if (is_fp16_out) {
                   a->vcvtps2ph(out_vreg.xmm(), out_vreg, 8);
                 } else if (is_bf16_out) {
-                  a->vpaddd(out_vreg, out_vreg, ones_vreg);
+                  // Round to nearest, ties to even:
+                  // rounding_bias = ((val >> 16) & 1) + 0x7FFF
+                  a->vpsrld(bf16_tmp_vreg, out_vreg, 16);
+                  a->vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                  a->vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                  a->vpaddd(bf16_tmp_vreg, bf16_tmp_vreg, bf16_bias_vreg);
+                  a->vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
                   a->vpsrld(out_vreg, out_vreg, 16);
                   a->vpackusdw(out_vreg, out_vreg, out_vreg);
                   a->vpermq(out_vreg, out_vreg, 0xd8);
@@ -868,8 +878,13 @@ GenEmbeddingSpMDMLookup<
                   if (is_fp16_out) {
                     a->k(x86::k(1)).vcvtps2ph(dst_addr, out_vreg, 8);
                   } else if (is_bf16_out) {
-                    // bf16
-                    a->k(x86::k(1)).vpaddd(out_vreg, out_vreg, ones_vreg);
+                    // Round to nearest, ties to even
+                    a->k(x86::k(1)).vpsrld(bf16_tmp_vreg, out_vreg, 16);
+                    a->k(x86::k(1)).vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->k(x86::k(1)).vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->k(x86::k(1)).vpaddd(bf16_tmp_vreg, bf16_tmp_vreg,
+                                           bf16_bias_vreg);
+                    a->k(x86::k(1)).vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
                     a->k(x86::k(1)).vpsrld(out_vreg, out_vreg, 16);
                     a->k(x86::k(1)).vpmovdw(dst_addr, out_vreg);
                   }
@@ -877,8 +892,12 @@ GenEmbeddingSpMDMLookup<
                   if (is_fp16_out) {
                     a->vcvtps2ph(dst_addr, out_vreg, 8);
                   } else if (is_bf16_out) {
-                    // bf16
-                    a->vpaddd(out_vreg, out_vreg, ones_vreg);
+                    // Round to nearest, ties to even
+                    a->vpsrld(bf16_tmp_vreg, out_vreg, 16);
+                    a->vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->vpaddd(bf16_tmp_vreg, bf16_tmp_vreg, bf16_bias_vreg);
+                    a->vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
                     a->vpsrld(out_vreg, out_vreg, 16);
                     a->vpmovdw(dst_addr, out_vreg);
                   }

--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -384,7 +384,8 @@ GenEmbeddingSpMDMLookup<
         vec_reg_t src_vreg; // for holding embedding value temporarily
         Ymm mask_vreg; // mask for avx2
         Xmm mask_fp16_vreg; // mask for loading fp16 in avx2
-        vec_reg_t ones_vreg; // 2^15 for bf16_2_fp32_rn
+        vec_reg_t bf16_bias_vreg;
+        vec_reg_t bf16_tmp_vreg;
 
         if constexpr (is_8bit_in) {
           // We need 2 vec registers for 1. scale 2. bias
@@ -396,10 +397,13 @@ GenEmbeddingSpMDMLookup<
 
         if (is_bf16_out) {
           --unroll_factor;
-          ones_vreg = vec_reg_t(unroll_factor);
-          a->mov(scratchReg2_, 1 << 15);
-          a->vpinsrd(ones_vreg.xmm(), ones_vreg.xmm(), scratchReg2_, 0);
-          a->vpbroadcastd(ones_vreg, ones_vreg.xmm());
+          bf16_bias_vreg = vec_reg_t(unroll_factor);
+          a->mov(scratchReg2_, 0x7FFF);
+          a->vpinsrd(bf16_bias_vreg.xmm(), bf16_bias_vreg.xmm(), scratchReg2_,
+                     0);
+          a->vpbroadcastd(bf16_bias_vreg, bf16_bias_vreg.xmm());
+          --unroll_factor;
+          bf16_tmp_vreg = vec_reg_t(unroll_factor);
         }
 
         if (is_8bit_in || is_16bit_in ||
@@ -841,7 +845,11 @@ GenEmbeddingSpMDMLookup<
                 if (is_fp16_out) {
                   a->vcvtps2ph(out_vreg.xmm(), out_vreg, 8);
                 } else if (is_bf16_out) {
-                  a->vpaddd(out_vreg, out_vreg, ones_vreg);
+                  a->vpsrld(bf16_tmp_vreg, out_vreg, 16);
+                  a->vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                  a->vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                  a->vpaddd(bf16_tmp_vreg, bf16_tmp_vreg, bf16_bias_vreg);
+                  a->vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
                   a->vpsrld(out_vreg, out_vreg, 16);
                   a->vpackusdw(out_vreg, out_vreg, out_vreg);
                   a->vpermq(out_vreg, out_vreg, 0xd8);
@@ -871,8 +879,12 @@ GenEmbeddingSpMDMLookup<
                   if (is_fp16_out) {
                     a->k(x86::k(1)).vcvtps2ph(dst_addr, out_vreg, 8);
                   } else if (is_bf16_out) {
-                    // bf16
-                    a->k(x86::k(1)).vpaddd(out_vreg, out_vreg, ones_vreg);
+                    a->k(x86::k(1)).vpsrld(bf16_tmp_vreg, out_vreg, 16);
+                    a->k(x86::k(1)).vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->k(x86::k(1)).vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->k(x86::k(1)).vpaddd(bf16_tmp_vreg, bf16_tmp_vreg,
+                                           bf16_bias_vreg);
+                    a->k(x86::k(1)).vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
                     a->k(x86::k(1)).vpsrld(out_vreg, out_vreg, 16);
                     a->k(x86::k(1)).vpmovdw(dst_addr, out_vreg);
                   }
@@ -880,8 +892,11 @@ GenEmbeddingSpMDMLookup<
                   if (is_fp16_out) {
                     a->vcvtps2ph(dst_addr, out_vreg, 8);
                   } else if (is_bf16_out) {
-                    // bf16
-                    a->vpaddd(out_vreg, out_vreg, ones_vreg);
+                    a->vpsrld(bf16_tmp_vreg, out_vreg, 16);
+                    a->vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->vpaddd(bf16_tmp_vreg, bf16_tmp_vreg, bf16_bias_vreg);
+                    a->vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
                     a->vpsrld(out_vreg, out_vreg, 16);
                     a->vpmovdw(dst_addr, out_vreg);
                   }

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -356,7 +356,8 @@ GenEmbeddingSpMDMNBitLookup<
         Ymm mask_vreg; // mask for avx2
         Xmm mask2_vreg;
         Xmm mask_fp16_vreg;
-        vec_reg_t ones_vreg;
+        vec_reg_t bf16_bias_vreg; // 0x7FFF for bf16 ties-to-even rounding
+        vec_reg_t bf16_tmp_vreg;  // scratch for bf16 rounding
 
         // We need 2 vec registers for 1. scale 2. bias
         --unroll_factor;
@@ -366,10 +367,13 @@ GenEmbeddingSpMDMNBitLookup<
 
         if (is_bf16_out) {
           --unroll_factor;
-          ones_vreg = vec_reg_t(unroll_factor);
-          a->mov(scratchReg2_, 1 << 15);
-          a->vpinsrd(ones_vreg.xmm(), ones_vreg.xmm(), scratchReg2_, 0);
-          a->vpbroadcastd(ones_vreg, ones_vreg.xmm());
+          bf16_bias_vreg = vec_reg_t(unroll_factor);
+          a->mov(scratchReg2_, 0x7FFF);
+          a->vpinsrd(bf16_bias_vreg.xmm(), bf16_bias_vreg.xmm(), scratchReg2_,
+                     0);
+          a->vpbroadcastd(bf16_bias_vreg, bf16_bias_vreg.xmm());
+          --unroll_factor;
+          bf16_tmp_vreg = vec_reg_t(unroll_factor);
         }
 
         --unroll_factor;
@@ -838,7 +842,12 @@ GenEmbeddingSpMDMNBitLookup<
               // 16-bit output
               if constexpr (instSet == inst_set_t::avx2) {
                 if (is_bf16_out) {
-                  a->vpaddd(out_vreg, out_vreg, ones_vreg);
+                  // Round to nearest, ties to even
+                  a->vpsrld(bf16_tmp_vreg, out_vreg, 16);
+                  a->vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                  a->vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                  a->vpaddd(bf16_tmp_vreg, bf16_tmp_vreg, bf16_bias_vreg);
+                  a->vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
                   a->vpsrld(out_vreg, out_vreg, 16);
                   a->vpackusdw(out_vreg, out_vreg, out_vreg);
                   a->vpermq(out_vreg, out_vreg, 0xd8);
@@ -869,8 +878,13 @@ GenEmbeddingSpMDMNBitLookup<
               } else {
                 if (remainder && vec_idx + v == num_vec_regs_per_block - 1) {
                   if (is_bf16_out) {
-                    // bf16
-                    a->k(x86::k(1)).vpaddd(out_vreg, out_vreg, ones_vreg);
+                    // Round to nearest, ties to even
+                    a->k(x86::k(1)).vpsrld(bf16_tmp_vreg, out_vreg, 16);
+                    a->k(x86::k(1)).vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->k(x86::k(1)).vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->k(x86::k(1)).vpaddd(bf16_tmp_vreg, bf16_tmp_vreg,
+                                           bf16_bias_vreg);
+                    a->k(x86::k(1)).vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
                     a->k(x86::k(1)).vpsrld(out_vreg, out_vreg, 16);
                     a->k(x86::k(1)).vpmovdw(dst_addr, out_vreg);
                   } else {
@@ -878,8 +892,12 @@ GenEmbeddingSpMDMNBitLookup<
                   }
                 } else {
                   if (is_bf16_out) {
-                    // bf16
-                    a->vpaddd(out_vreg, out_vreg, ones_vreg);
+                    // Round to nearest, ties to even
+                    a->vpsrld(bf16_tmp_vreg, out_vreg, 16);
+                    a->vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->vpaddd(bf16_tmp_vreg, bf16_tmp_vreg, bf16_bias_vreg);
+                    a->vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
                     a->vpsrld(out_vreg, out_vreg, 16);
                     a->vpmovdw(dst_addr, out_vreg);
                   } else {

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -12,6 +12,7 @@
 
 #include <cpuinfo.h>
 #include <cassert>
+#include <concepts>
 #include <iostream>
 #include <mutex>
 #include <tuple>
@@ -357,6 +358,7 @@ GenEmbeddingSpMDMNBitLookup<
         Xmm mask2_vreg;
         Xmm mask_fp16_vreg;
         vec_reg_t bf16_bias_vreg; // 0x7FFF for bf16 ties-to-even rounding
+        vec_reg_t bf16_one_vreg;  // set1(1) for LSB mask
         vec_reg_t bf16_tmp_vreg;  // scratch for bf16 rounding
 
         // We need 2 vec registers for 1. scale 2. bias
@@ -373,8 +375,23 @@ GenEmbeddingSpMDMNBitLookup<
                      0);
           a->vpbroadcastd(bf16_bias_vreg, bf16_bias_vreg.xmm());
           --unroll_factor;
+          bf16_one_vreg = vec_reg_t(unroll_factor);
+          a->mov(scratchReg2_, 1);
+          a->vpinsrd(bf16_one_vreg.xmm(), bf16_one_vreg.xmm(), scratchReg2_, 0);
+          a->vpbroadcastd(bf16_one_vreg, bf16_one_vreg.xmm());
+          --unroll_factor;
           bf16_tmp_vreg = vec_reg_t(unroll_factor);
         }
+
+        // See EmbeddingSpMDM.cc for rationale; 4-deep critical path form.
+        auto emit_bf16_rne = [&]<std::invocable Pred>(
+                                 const vec_reg_t& out, Pred&& emitPred) {
+          emitPred().vpsrld(bf16_tmp_vreg, out, 16);
+          emitPred().vpaddd(out, out, bf16_bias_vreg);
+          emitPred().vpand(bf16_tmp_vreg, bf16_tmp_vreg, bf16_one_vreg);
+          emitPred().vpaddd(out, out, bf16_tmp_vreg);
+          emitPred().vpsrld(out, out, 16);
+        };
 
         --unroll_factor;
         src_vreg = vec_reg_t(unroll_factor);
@@ -842,13 +859,7 @@ GenEmbeddingSpMDMNBitLookup<
               // 16-bit output
               if constexpr (instSet == inst_set_t::avx2) {
                 if (is_bf16_out) {
-                  // Round to nearest, ties to even
-                  a->vpsrld(bf16_tmp_vreg, out_vreg, 16);
-                  a->vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
-                  a->vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
-                  a->vpaddd(bf16_tmp_vreg, bf16_tmp_vreg, bf16_bias_vreg);
-                  a->vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
-                  a->vpsrld(out_vreg, out_vreg, 16);
+                  emit_bf16_rne(out_vreg, [&]() -> auto& { return *a; });
                   a->vpackusdw(out_vreg, out_vreg, out_vreg);
                   a->vpermq(out_vreg, out_vreg, 0xd8);
                 } else {
@@ -878,27 +889,15 @@ GenEmbeddingSpMDMNBitLookup<
               } else {
                 if (remainder && vec_idx + v == num_vec_regs_per_block - 1) {
                   if (is_bf16_out) {
-                    // Round to nearest, ties to even
-                    a->k(x86::k(1)).vpsrld(bf16_tmp_vreg, out_vreg, 16);
-                    a->k(x86::k(1)).vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
-                    a->k(x86::k(1)).vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
-                    a->k(x86::k(1)).vpaddd(bf16_tmp_vreg, bf16_tmp_vreg,
-                                           bf16_bias_vreg);
-                    a->k(x86::k(1)).vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
-                    a->k(x86::k(1)).vpsrld(out_vreg, out_vreg, 16);
+                    emit_bf16_rne(
+                        out_vreg, [&]() -> auto& { return a->k(x86::k(1)); });
                     a->k(x86::k(1)).vpmovdw(dst_addr, out_vreg);
                   } else {
                     a->k(x86::k(1)).vcvtps2ph(dst_addr, out_vreg, 8);
                   }
                 } else {
                   if (is_bf16_out) {
-                    // Round to nearest, ties to even
-                    a->vpsrld(bf16_tmp_vreg, out_vreg, 16);
-                    a->vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
-                    a->vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
-                    a->vpaddd(bf16_tmp_vreg, bf16_tmp_vreg, bf16_bias_vreg);
-                    a->vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
-                    a->vpsrld(out_vreg, out_vreg, 16);
+                    emit_bf16_rne(out_vreg, [&]() -> auto& { return *a; });
                     a->vpmovdw(dst_addr, out_vreg);
                   } else {
                     a->vcvtps2ph(dst_addr, out_vreg, 8);

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -357,7 +357,8 @@ GenEmbeddingSpMDMNBitLookup<
         Ymm mask_vreg; // mask for avx2
         Xmm mask2_vreg;
         Xmm mask_fp16_vreg;
-        vec_reg_t ones_vreg;
+        vec_reg_t bf16_bias_vreg; // 0x7FFF for bf16 ties-to-even rounding
+        vec_reg_t bf16_tmp_vreg;  // scratch for bf16 rounding
 
         // We need 2 vec registers for 1. scale 2. bias
         --unroll_factor;
@@ -367,10 +368,13 @@ GenEmbeddingSpMDMNBitLookup<
 
         if (is_bf16_out) {
           --unroll_factor;
-          ones_vreg = vec_reg_t(unroll_factor);
-          a->mov(scratchReg2_, 1 << 15);
-          a->vpinsrd(ones_vreg.xmm(), ones_vreg.xmm(), scratchReg2_, 0);
-          a->vpbroadcastd(ones_vreg, ones_vreg.xmm());
+          bf16_bias_vreg = vec_reg_t(unroll_factor);
+          a->mov(scratchReg2_, 0x7FFF);
+          a->vpinsrd(bf16_bias_vreg.xmm(), bf16_bias_vreg.xmm(), scratchReg2_,
+                     0);
+          a->vpbroadcastd(bf16_bias_vreg, bf16_bias_vreg.xmm());
+          --unroll_factor;
+          bf16_tmp_vreg = vec_reg_t(unroll_factor);
         }
 
         --unroll_factor;
@@ -839,7 +843,12 @@ GenEmbeddingSpMDMNBitLookup<
               // 16-bit output
               if constexpr (instSet == inst_set_t::avx2) {
                 if (is_bf16_out) {
-                  a->vpaddd(out_vreg, out_vreg, ones_vreg);
+                  // Round to nearest, ties to even
+                  a->vpsrld(bf16_tmp_vreg, out_vreg, 16);
+                  a->vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                  a->vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                  a->vpaddd(bf16_tmp_vreg, bf16_tmp_vreg, bf16_bias_vreg);
+                  a->vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
                   a->vpsrld(out_vreg, out_vreg, 16);
                   a->vpackusdw(out_vreg, out_vreg, out_vreg);
                   a->vpermq(out_vreg, out_vreg, 0xd8);
@@ -870,8 +879,13 @@ GenEmbeddingSpMDMNBitLookup<
               } else {
                 if (remainder && vec_idx + v == num_vec_regs_per_block - 1) {
                   if (is_bf16_out) {
-                    // bf16
-                    a->k(x86::k(1)).vpaddd(out_vreg, out_vreg, ones_vreg);
+                    // Round to nearest, ties to even
+                    a->k(x86::k(1)).vpsrld(bf16_tmp_vreg, out_vreg, 16);
+                    a->k(x86::k(1)).vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->k(x86::k(1)).vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->k(x86::k(1)).vpaddd(bf16_tmp_vreg, bf16_tmp_vreg,
+                                           bf16_bias_vreg);
+                    a->k(x86::k(1)).vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
                     a->k(x86::k(1)).vpsrld(out_vreg, out_vreg, 16);
                     a->k(x86::k(1)).vpmovdw(dst_addr, out_vreg);
                   } else {
@@ -879,8 +893,12 @@ GenEmbeddingSpMDMNBitLookup<
                   }
                 } else {
                   if (is_bf16_out) {
-                    // bf16
-                    a->vpaddd(out_vreg, out_vreg, ones_vreg);
+                    // Round to nearest, ties to even
+                    a->vpsrld(bf16_tmp_vreg, out_vreg, 16);
+                    a->vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->vpaddd(bf16_tmp_vreg, bf16_tmp_vreg, bf16_bias_vreg);
+                    a->vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
                     a->vpsrld(out_vreg, out_vreg, 16);
                     a->vpmovdw(dst_addr, out_vreg);
                   } else {

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -357,7 +357,8 @@ GenEmbeddingSpMDMNBitLookup<
         Ymm mask_vreg; // mask for avx2
         Xmm mask2_vreg;
         Xmm mask_fp16_vreg;
-        vec_reg_t ones_vreg;
+        vec_reg_t bf16_bias_vreg;
+        vec_reg_t bf16_tmp_vreg;
 
         // We need 2 vec registers for 1. scale 2. bias
         --unroll_factor;
@@ -367,10 +368,13 @@ GenEmbeddingSpMDMNBitLookup<
 
         if (is_bf16_out) {
           --unroll_factor;
-          ones_vreg = vec_reg_t(unroll_factor);
-          a->mov(scratchReg2_, 1 << 15);
-          a->vpinsrd(ones_vreg.xmm(), ones_vreg.xmm(), scratchReg2_, 0);
-          a->vpbroadcastd(ones_vreg, ones_vreg.xmm());
+          bf16_bias_vreg = vec_reg_t(unroll_factor);
+          a->mov(scratchReg2_, 0x7FFF);
+          a->vpinsrd(bf16_bias_vreg.xmm(), bf16_bias_vreg.xmm(), scratchReg2_,
+                     0);
+          a->vpbroadcastd(bf16_bias_vreg, bf16_bias_vreg.xmm());
+          --unroll_factor;
+          bf16_tmp_vreg = vec_reg_t(unroll_factor);
         }
 
         --unroll_factor;
@@ -839,7 +843,11 @@ GenEmbeddingSpMDMNBitLookup<
               // 16-bit output
               if constexpr (instSet == inst_set_t::avx2) {
                 if (is_bf16_out) {
-                  a->vpaddd(out_vreg, out_vreg, ones_vreg);
+                  a->vpsrld(bf16_tmp_vreg, out_vreg, 16);
+                  a->vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                  a->vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                  a->vpaddd(bf16_tmp_vreg, bf16_tmp_vreg, bf16_bias_vreg);
+                  a->vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
                   a->vpsrld(out_vreg, out_vreg, 16);
                   a->vpackusdw(out_vreg, out_vreg, out_vreg);
                   a->vpermq(out_vreg, out_vreg, 0xd8);
@@ -870,8 +878,12 @@ GenEmbeddingSpMDMNBitLookup<
               } else {
                 if (remainder && vec_idx + v == num_vec_regs_per_block - 1) {
                   if (is_bf16_out) {
-                    // bf16
-                    a->k(x86::k(1)).vpaddd(out_vreg, out_vreg, ones_vreg);
+                    a->k(x86::k(1)).vpsrld(bf16_tmp_vreg, out_vreg, 16);
+                    a->k(x86::k(1)).vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->k(x86::k(1)).vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->k(x86::k(1)).vpaddd(bf16_tmp_vreg, bf16_tmp_vreg,
+                                           bf16_bias_vreg);
+                    a->k(x86::k(1)).vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
                     a->k(x86::k(1)).vpsrld(out_vreg, out_vreg, 16);
                     a->k(x86::k(1)).vpmovdw(dst_addr, out_vreg);
                   } else {
@@ -879,8 +891,11 @@ GenEmbeddingSpMDMNBitLookup<
                   }
                 } else {
                   if (is_bf16_out) {
-                    // bf16
-                    a->vpaddd(out_vreg, out_vreg, ones_vreg);
+                    a->vpsrld(bf16_tmp_vreg, out_vreg, 16);
+                    a->vpslld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->vpsrld(bf16_tmp_vreg, bf16_tmp_vreg, 31);
+                    a->vpaddd(bf16_tmp_vreg, bf16_tmp_vreg, bf16_bias_vreg);
+                    a->vpaddd(out_vreg, out_vreg, bf16_tmp_vreg);
                     a->vpsrld(out_vreg, out_vreg, 16);
                     a->vpmovdw(dst_addr, out_vreg);
                   } else {

--- a/src/EmbeddingSpMDMSve.h
+++ b/src/EmbeddingSpMDMSve.h
@@ -37,13 +37,18 @@
 namespace fbgemm {
 namespace internal {
 
-// Round-to-nearest, ties-to-even: float32 -> bf16 (as uint32 with value in
-// lower 16 bits). Replaces svrshrnb_n_u32 which uses round-half-up.
+// RNE fp32 -> bf16, returned as u32 with the bf16 value in the low 16 bits
+// so that svst1h_u32 narrow-stores it. On Armv8.6-A BF16 this collapses to
+// a single BFCVT; otherwise we use the integer round-to-even formula.
 static inline svuint32_t rne_fp32_to_bf16_sve(svbool_t pg, svfloat32_t val) {
-  svuint32_t bits = svreinterpret_u32_f32(val);
-  svuint32_t lsb = svand_n_u32_x(pg, svlsr_n_u32_x(pg, bits, 16), 1);
-  svuint32_t rounded = svadd_u32_x(pg, bits, svadd_n_u32_x(pg, lsb, 0x7FFF));
+#if defined(__ARM_FEATURE_BF16)
+  return svreinterpret_u32_bf16(svcvt_bf16_f32_x(pg, val));
+#else
+  const auto bits = svreinterpret_u32_f32(val);
+  const auto lsb = svand_n_u32_x(pg, svlsr_n_u32_x(pg, bits, 16), 1);
+  const auto rounded = svadd_u32_x(pg, bits, svadd_n_u32_x(pg, lsb, 0x7FFF));
   return svlsr_n_u32_x(pg, rounded, 16);
+#endif
 }
 
 static constexpr size_t LOCAL_STORAGE_SIZE = 512;

--- a/src/EmbeddingSpMDMSve.h
+++ b/src/EmbeddingSpMDMSve.h
@@ -37,6 +37,15 @@
 namespace fbgemm {
 namespace internal {
 
+// Round-to-nearest, ties-to-even: float32 -> bf16 (as uint32 with value in
+// lower 16 bits). Replaces svrshrnb_n_u32 which uses round-half-up.
+static inline svuint32_t rne_fp32_to_bf16_sve(svbool_t pg, svfloat32_t val) {
+  svuint32_t bits = svreinterpret_u32_f32(val);
+  svuint32_t lsb = svand_n_u32_x(pg, svlsr_n_u32_x(pg, bits, 16), 1);
+  svuint32_t rounded = svadd_u32_x(pg, bits, svadd_n_u32_x(pg, lsb, 0x7FFF));
+  return svlsr_n_u32_x(pg, rounded, 16);
+}
+
 static constexpr size_t LOCAL_STORAGE_SIZE = 512;
 
 template <typename OutType>
@@ -112,10 +121,10 @@ static inline void fill_output_sve(
           row_1 = vmulq_f32(row_1, scale);
         }
 
-        auto svrow_0 = svreinterpret_u32_u16(svrshrnb_n_u32(
-            svreinterpret_u32_f32(svset_neonq_f32(svundef_f32(), row_0)), 16));
-        auto svrow_1 = svreinterpret_u32_u16(svrshrnb_n_u32(
-            svreinterpret_u32_f32(svset_neonq_f32(svundef_f32(), row_1)), 16));
+        auto svrow_0 = rne_fp32_to_bf16_sve(
+            svptrue_b32(), svset_neonq_f32(svundef_f32(), row_0));
+        auto svrow_1 = rne_fp32_to_bf16_sve(
+            svptrue_b32(), svset_neonq_f32(svundef_f32(), row_1));
 
         svst1h_u32(svptrue_b8(), ptrOut, svrow_0);
         svst1h_u32(svptrue_b8(), ptrOut + 4, svrow_1);
@@ -136,10 +145,10 @@ static inline void fill_output_sve(
               lastPredB, trailing_row_1, svset_neonq_f32(svundef_f32(), scale));
         }
 
-        auto trailing_row_0_u32 = svreinterpret_u32_u16(
-            svrshrnb_n_u32(svreinterpret_u32_f32(trailing_row_0), 16));
-        auto trailing_row_1_u32 = svreinterpret_u32_u16(
-            svrshrnb_n_u32(svreinterpret_u32_f32(trailing_row_1), 16));
+        auto trailing_row_0_u32 =
+            rne_fp32_to_bf16_sve(lastPredA, trailing_row_0);
+        auto trailing_row_1_u32 =
+            rne_fp32_to_bf16_sve(lastPredB, trailing_row_1);
 
         svst1h_u32(lastPredA, ptrOut, trailing_row_0_u32);
         svst1h_u32(lastPredB, ptrOut + 4, trailing_row_1_u32);
@@ -251,10 +260,8 @@ static inline void sve_fma_round(
       buf += 1;
     } else if constexpr (std::is_same_v<OutType, uint16_t>) {
       if (is_bf16_out) {
-        auto svrow_0 = svreinterpret_u32_u16(
-            svrshrnb_n_u32(svreinterpret_u32_f32(in_v_0_f), 16));
-        auto svrow_1 = svreinterpret_u32_u16(
-            svrshrnb_n_u32(svreinterpret_u32_f32(in_v_1_f), 16));
+        auto svrow_0 = rne_fp32_to_bf16_sve(svptrue_b32(), in_v_0_f);
+        auto svrow_1 = rne_fp32_to_bf16_sve(svptrue_b32(), in_v_1_f);
 
         svst1h_u32(svptrue_b8(), outBf16, svrow_0);
         svst1h_u32(svptrue_b8(), outBf16 + 4, svrow_1);
@@ -301,10 +308,8 @@ static inline void sve_fma_round(
       svst1_f32(lastPredB, bufPtr + 4, in_v_1_f);
     } else if constexpr (std::is_same_v<OutType, uint16_t>) {
       if (is_bf16_out) {
-        auto trailing_row_0_u32 = svreinterpret_u32_u16(
-            svrshrnb_n_u32(svreinterpret_u32_f32(in_v_0_f), 16));
-        auto trailing_row_1_u32 = svreinterpret_u32_u16(
-            svrshrnb_n_u32(svreinterpret_u32_f32(in_v_1_f), 16));
+        auto trailing_row_0_u32 = rne_fp32_to_bf16_sve(lastPredA, in_v_0_f);
+        auto trailing_row_1_u32 = rne_fp32_to_bf16_sve(lastPredB, in_v_1_f);
 
         svst1h_u32(lastPredA, outBf16, trailing_row_0_u32);
         svst1h_u32(lastPredB, outBf16 + 4, trailing_row_1_u32);

--- a/src/EmbeddingSpMDMSve.h
+++ b/src/EmbeddingSpMDMSve.h
@@ -39,6 +39,15 @@
 namespace fbgemm {
 namespace internal {
 
+// float32 -> bf16 (lower 16 bits), round-to-nearest-even; svrshrnb_n_u32
+// rounds half-up.
+static inline svuint32_t rne_fp32_to_bf16_sve(svbool_t pg, svfloat32_t val) {
+  svuint32_t bits = svreinterpret_u32_f32(val);
+  svuint32_t lsb = svand_n_u32_x(pg, svlsr_n_u32_x(pg, bits, 16), 1);
+  svuint32_t rounded = svadd_u32_x(pg, bits, svadd_n_u32_x(pg, lsb, 0x7FFF));
+  return svlsr_n_u32_x(pg, rounded, 16);
+}
+
 static constexpr size_t LOCAL_STORAGE_SIZE = 512;
 
 template <typename OutType>
@@ -114,10 +123,10 @@ static inline void fill_output_sve(
           row_1 = vmulq_f32(row_1, scale);
         }
 
-        auto svrow_0 = svreinterpret_u32_u16(svrshrnb_n_u32(
-            svreinterpret_u32_f32(svset_neonq_f32(svundef_f32(), row_0)), 16));
-        auto svrow_1 = svreinterpret_u32_u16(svrshrnb_n_u32(
-            svreinterpret_u32_f32(svset_neonq_f32(svundef_f32(), row_1)), 16));
+        auto svrow_0 = rne_fp32_to_bf16_sve(
+            svptrue_b32(), svset_neonq_f32(svundef_f32(), row_0));
+        auto svrow_1 = rne_fp32_to_bf16_sve(
+            svptrue_b32(), svset_neonq_f32(svundef_f32(), row_1));
 
         svst1h_u32(svptrue_b8(), ptrOut, svrow_0);
         svst1h_u32(svptrue_b8(), ptrOut + 4, svrow_1);
@@ -138,10 +147,10 @@ static inline void fill_output_sve(
               lastPredB, trailing_row_1, svset_neonq_f32(svundef_f32(), scale));
         }
 
-        auto trailing_row_0_u32 = svreinterpret_u32_u16(
-            svrshrnb_n_u32(svreinterpret_u32_f32(trailing_row_0), 16));
-        auto trailing_row_1_u32 = svreinterpret_u32_u16(
-            svrshrnb_n_u32(svreinterpret_u32_f32(trailing_row_1), 16));
+        auto trailing_row_0_u32 =
+            rne_fp32_to_bf16_sve(lastPredA, trailing_row_0);
+        auto trailing_row_1_u32 =
+            rne_fp32_to_bf16_sve(lastPredB, trailing_row_1);
 
         svst1h_u32(lastPredA, ptrOut, trailing_row_0_u32);
         svst1h_u32(lastPredB, ptrOut + 4, trailing_row_1_u32);
@@ -253,10 +262,8 @@ static inline void sve_fma_round(
       buf += 1;
     } else if constexpr (std::is_same_v<OutType, uint16_t>) {
       if (is_bf16_out) {
-        auto svrow_0 = svreinterpret_u32_u16(
-            svrshrnb_n_u32(svreinterpret_u32_f32(in_v_0_f), 16));
-        auto svrow_1 = svreinterpret_u32_u16(
-            svrshrnb_n_u32(svreinterpret_u32_f32(in_v_1_f), 16));
+        auto svrow_0 = rne_fp32_to_bf16_sve(svptrue_b32(), in_v_0_f);
+        auto svrow_1 = rne_fp32_to_bf16_sve(svptrue_b32(), in_v_1_f);
 
         svst1h_u32(svptrue_b8(), outBf16, svrow_0);
         svst1h_u32(svptrue_b8(), outBf16 + 4, svrow_1);
@@ -303,10 +310,8 @@ static inline void sve_fma_round(
       svst1_f32(lastPredB, bufPtr + 4, in_v_1_f);
     } else if constexpr (std::is_same_v<OutType, uint16_t>) {
       if (is_bf16_out) {
-        auto trailing_row_0_u32 = svreinterpret_u32_u16(
-            svrshrnb_n_u32(svreinterpret_u32_f32(in_v_0_f), 16));
-        auto trailing_row_1_u32 = svreinterpret_u32_u16(
-            svrshrnb_n_u32(svreinterpret_u32_f32(in_v_1_f), 16));
+        auto trailing_row_0_u32 = rne_fp32_to_bf16_sve(lastPredA, in_v_0_f);
+        auto trailing_row_1_u32 = rne_fp32_to_bf16_sve(lastPredB, in_v_1_f);
 
         svst1h_u32(lastPredA, outBf16, trailing_row_0_u32);
         svst1h_u32(lastPredB, outBf16 + 4, trailing_row_1_u32);

--- a/src/FbgemmBfloat16Convert.cc
+++ b/src/FbgemmBfloat16Convert.cc
@@ -29,7 +29,12 @@ namespace fbgemm {
 void FloatToBfloat16_simd(const float* src, bfloat16* dst, size_t size) {
   // Run time CPU detection
   if (cpuinfo_initialize()) {
-#if !defined(__aarch64__)
+#if defined(__aarch64__) && defined(FBGEMM_HAVE_BF16_BFCVT)
+    if (cpuinfo_has_arm_bf16()) {
+      FloatToBfloat16_bfcvt(src, dst, size);
+      return;
+    }
+#elif !defined(__aarch64__)
     if (fbgemmHasAvx512Support()) {
       FloatToBfloat16_avx512(src, dst, size);
     } else if (fbgemmHasAvx2Support()) {
@@ -48,7 +53,12 @@ void FloatToBfloat16_simd(const float* src, bfloat16* dst, size_t size) {
 void Bfloat16ToFloat_simd(const bfloat16* src, float* dst, size_t size) {
   // Run time CPU detection
   if (cpuinfo_initialize()) {
-#if !defined(__aarch64__)
+#if defined(__aarch64__) && defined(FBGEMM_HAVE_BF16_BFCVT)
+    if (cpuinfo_has_arm_bf16()) {
+      Bfloat16ToFloat_bfcvt(src, dst, size);
+      return;
+    }
+#elif !defined(__aarch64__)
     if (fbgemmHasAvx512Support()) {
       Bfloat16ToFloat_avx512(src, dst, size);
     } else if (fbgemmHasAvx2Support()) {

--- a/src/FbgemmBfloat16ConvertAvx2.cc
+++ b/src/FbgemmBfloat16ConvertAvx2.cc
@@ -17,16 +17,18 @@ namespace fbgemm {
 
 namespace {
 
-inline __m256i QuantizeBfloat16Avx2(const __m256& x0, const __m256& x1) {
-  // Add 2^15 and right shift 16 to do round-nearest
-  __m256i y0 = _mm256_srli_epi32(
-      _mm256_add_epi32(_mm256_castps_si256(x0), _mm256_set1_epi32(1 << 15)),
+// Round to nearest, ties to even
+inline __m256i rne_fp32_to_bf16x8(__m256i val) {
+  __m256i lsb =
+      _mm256_and_si256(_mm256_srli_epi32(val, 16), _mm256_set1_epi32(1));
+  return _mm256_srli_epi32(
+      _mm256_add_epi32(val, _mm256_add_epi32(lsb, _mm256_set1_epi32(0x7FFF))),
       16);
-  __m256i y1 = _mm256_srli_epi32(
-      _mm256_add_epi32(_mm256_castps_si256(x1), _mm256_set1_epi32(1 << 15)),
-      16);
-  // AVX2 doesn't have _mm256_cvtepi32_epi16 so we need this instruction
-  // sequence.
+}
+
+inline __m256i QuantizeBfloat16Avx2(const __m256 &x0, const __m256 &x1) {
+  __m256i y0 = rne_fp32_to_bf16x8(_mm256_castps_si256(x0));
+  __m256i y1 = rne_fp32_to_bf16x8(_mm256_castps_si256(x1));
   return _mm256_permute4x64_epi64(_mm256_packus_epi32(y0, y1), 0xd8);
 }
 

--- a/src/FbgemmBfloat16ConvertAvx512.cc
+++ b/src/FbgemmBfloat16ConvertAvx512.cc
@@ -17,12 +17,14 @@ namespace fbgemm {
 
 namespace {
 
+// Round to nearest, ties to even
 inline __m256i QuantizeBfloat16Avx512(const __m512& x0) {
-  // Add 2^15 and right shift 16 to do round-nearest
-  __m512i y0 = _mm512_srli_epi32(
-      _mm512_add_epi32(_mm512_castps_si512(x0), _mm512_set1_epi32(1 << 15)),
-      16);
-  return _mm512_cvtepi32_epi16(y0);
+  __m512i val = _mm512_castps_si512(x0);
+  __m512i lsb =
+      _mm512_and_si512(_mm512_srli_epi32(val, 16), _mm512_set1_epi32(1));
+  __m512i rnd =
+      _mm512_add_epi32(val, _mm512_add_epi32(lsb, _mm512_set1_epi32(0x7FFF)));
+  return _mm512_cvtepi32_epi16(_mm512_srli_epi32(rnd, 16));
 }
 
 inline void FloatToBfloat16KernelAvx512(const float* src, bfloat16* dst) {

--- a/src/FbgemmBfloat16ConvertAvx512.cc
+++ b/src/FbgemmBfloat16ConvertAvx512.cc
@@ -12,12 +12,13 @@
 #endif
 #define FBGEMM_EXPORTS
 #include "fbgemm/FbgemmConvert.h"
+#include "fbgemm/Utils.h"
 
 namespace fbgemm {
 
 namespace {
 
-// Round to nearest, ties to even
+// Emulated ties-to-even; used when AVX-512-BF16 is not present.
 inline __m256i QuantizeBfloat16Avx512(const __m512& x0) {
   __m512i val = _mm512_castps_si512(x0);
   __m512i lsb =
@@ -27,10 +28,21 @@ inline __m256i QuantizeBfloat16Avx512(const __m512& x0) {
   return _mm512_cvtepi32_epi16(_mm512_srli_epi32(rnd, 16));
 }
 
+// Hardware vcvtneps2bf16; requires AVX-512-BF16.
+inline __m256i QuantizeBfloat16Avx512Bf16(const __m512& x0) {
+  return (__m256i)_mm512_cvtneps_pbh(x0);
+}
+
 inline void FloatToBfloat16KernelAvx512(const float* src, bfloat16* dst) {
   // One float m512i -> One bfloat16 m256i
   const __m512 src_reg0 = _mm512_loadu_ps(src);
   __m256i dst_reg0 = QuantizeBfloat16Avx512(src_reg0);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst), dst_reg0);
+}
+
+inline void FloatToBfloat16KernelAvx512Bf16(const float* src, bfloat16* dst) {
+  const __m512 src_reg0 = _mm512_loadu_ps(src);
+  __m256i dst_reg0 = QuantizeBfloat16Avx512Bf16(src_reg0);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst), dst_reg0);
 }
 
@@ -46,9 +58,16 @@ inline void Bfloat16ToFloatKernelAvx512(const bfloat16* src, float* dst) {
 } // namespace
 
 void FloatToBfloat16_avx512(const float* src, bfloat16* dst, size_t size) {
+  static const bool has_bf16 = fbgemmHasAvx512Bf16Support();
   size_t i = 0;
-  for (i = 0; i + 16 <= size; i += 16) {
-    FloatToBfloat16KernelAvx512(src + i, dst + i);
+  if (has_bf16) {
+    for (; i + 16 <= size; i += 16) {
+      FloatToBfloat16KernelAvx512Bf16(src + i, dst + i);
+    }
+  } else {
+    for (; i + 16 <= size; i += 16) {
+      FloatToBfloat16KernelAvx512(src + i, dst + i);
+    }
   }
   FloatToBfloat16_avx2(src + i, dst + i, size - i);
 }

--- a/src/FbgemmBfloat16ConvertBfcvt.cc
+++ b/src/FbgemmBfloat16ConvertBfcvt.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Compiled with -march=...+bf16 by the fbgemm_bfcvt target; BFCVT must not
+// leak into code runnable without FEAT_BF16 (dispatch: cpuinfo_has_arm_bf16).
+#if defined(__aarch64__) && defined(__ARM_FEATURE_BF16)
+
+#include <arm_neon.h>
+
+#define FBGEMM_EXPORTS
+#include "fbgemm/FbgemmConvert.h"
+
+namespace fbgemm {
+
+namespace {
+
+inline void FloatToBfloat16KernelBfcvt(const float* src, bfloat16* dst) {
+  const float32x4_t src_reg0 = vld1q_f32(src);
+  const float32x4_t src_reg1 = vld1q_f32(src + 4);
+  bfloat16x8_t dst_reg = vcvtq_low_bf16_f32(src_reg0);
+  dst_reg = vcvtq_high_bf16_f32(dst_reg, src_reg1);
+  vst1q_u16(reinterpret_cast<uint16_t*>(dst), vreinterpretq_u16_bf16(dst_reg));
+}
+
+inline void Bfloat16ToFloatKernelBfcvt(const bfloat16* src, float* dst) {
+  const bfloat16x8_t src_reg = vreinterpretq_bf16_u16(
+      vld1q_u16(reinterpret_cast<const uint16_t*>(src)));
+  vst1q_f32(dst, vcvtq_low_f32_bf16(src_reg));
+  vst1q_f32(dst + 4, vcvtq_high_f32_bf16(src_reg));
+}
+
+} // namespace
+
+void FloatToBfloat16_bfcvt(const float* src, bfloat16* dst, size_t size) {
+  size_t i = 0;
+  for (; i + 8 <= size; i += 8) {
+    FloatToBfloat16KernelBfcvt(src + i, dst + i);
+  }
+  FloatToBfloat16_ref(src + i, dst + i, size - i);
+}
+
+void Bfloat16ToFloat_bfcvt(const bfloat16* src, float* dst, size_t size) {
+  size_t i = 0;
+  for (; i + 8 <= size; i += 8) {
+    Bfloat16ToFloatKernelBfcvt(src + i, dst + i);
+  }
+  Bfloat16ToFloat_ref(src + i, dst + i, size - i);
+}
+
+} // namespace fbgemm
+
+#endif

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -109,8 +109,9 @@ void Float16ToFloat_ref(const float16* src, float* dst, size_t size) {
 
 void FloatToBfloat16_ref(const float* src, bfloat16* dst, size_t size) {
   for (size_t i = 0; i < size; i++) {
-    // Add 2^15 and right shift 16 to do round-nearest
-    dst[i] = (*reinterpret_cast<const uint32_t*>(src + i) + (1 << 15)) >> 16;
+    // IEEE 754 round-to-nearest-even
+    uint32_t bits = std::bit_cast<uint32_t>(src[i]);
+    dst[i] = (bits + ((bits >> 16) & 1) + 0x7FFFu) >> 16;
   }
 }
 

--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -109,9 +109,10 @@ void Float16ToFloat_ref(const float16* src, float* dst, size_t size) {
 
 void FloatToBfloat16_ref(const float* src, bfloat16* dst, size_t size) {
   for (size_t i = 0; i < size; i++) {
-    // Add 2^15 and right shift 16 to do round-nearest
-    dst[i] = bfloat16{static_cast<uint16_t>(
-        (*reinterpret_cast<const uint32_t*>(src + i) + (1 << 15)) >> 16)};
+    // IEEE 754 round-to-nearest-even
+    uint32_t bits = std::bit_cast<uint32_t>(src[i]);
+    dst[i] = bfloat16{
+        static_cast<uint16_t>((bits + ((bits >> 16) & 1) + 0x7FFFu) >> 16)};
   }
 }
 

--- a/test/Bfloat16ConvertTest.cc
+++ b/test/Bfloat16ConvertTest.cc
@@ -7,6 +7,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <bit>
 #include <cmath>
 #include <random>
 
@@ -17,36 +18,39 @@ using namespace std;
 using namespace fbgemm;
 
 TEST(FBGemmBfloat16Test, Conversion) {
-  float a[100]; // fp32 type
+  float a[100];
   for (int i = 0; i < 100; ++i) {
     a[i] = i + 1.25;
   }
-  bfloat16 b[100]; // bfloat16 type
-  float c[100]; // fp32 type
+  bfloat16 b[100];
+  float c[100];
   FloatToBfloat16_ref(a, b, 100);
   Bfloat16ToFloat_ref(b, c, 100);
   for (int i = 0; i < 100; ++i) {
-    // The relative error should be less than 1/(2^7) since bfloat16
-    // has 7 bits mantissa.
+    EXPECT_EQ(b[i], cpu_float2bfloat16(a[i]))
+        << "ref conversion differs from scalar at i=" << i;
     EXPECT_LE(fabs(c[i] - a[i]) / a[i], 1.0 / 128);
   }
 }
 
 TEST(FBGemmBfloat16Test, Conversion_simd) {
-  float a[100]; // fp32 type
+  float a[100];
   for (int i = 0; i < 100; ++i) {
     a[i] = i + 1.25;
   }
-  bfloat16 b[100]; // bfloat16 type
-  float c[100]; // fp32 type
-  FloatToBfloat16_simd(a, b, 100);
-  Bfloat16ToFloat_simd(b, c, 100);
+  bfloat16 b_ref[100];
+  bfloat16 b_simd[100];
+  float c[100];
+  FloatToBfloat16_ref(a, b_ref, 100);
+  FloatToBfloat16_simd(a, b_simd, 100);
+  Bfloat16ToFloat_simd(b_simd, c, 100);
   for (int i = 0; i < 100; ++i) {
-    // The relative error should be less than 1/(2^7) since bfloat16
-    // has 7 bits mantissa.
-    EXPECT_LE(fabs(c[i] - a[i]) / a[i], 1.0 / 128)
-        << "Conversion results differ at (" << i << " ). ref: " << a[i]
-        << " conversion: " << c[i];
+    EXPECT_EQ(b_simd[i], b_ref[i])
+        << "simd and ref differ at i=" << i
+        << " input=0x" << std::hex << std::bit_cast<uint32_t>(a[i]);
+    EXPECT_EQ(b_simd[i], cpu_float2bfloat16(a[i]))
+        << "simd differs from scalar at i=" << i;
+    EXPECT_LE(fabs(c[i] - a[i]) / a[i], 1.0 / 128);
   }
 }
 
@@ -67,24 +71,23 @@ TEST(FBGemmBfloat16Test, Conversion_simd2) {
     int m = s[0];
     int n = s[1];
 
-    cerr << "m = " << m << " n = " << n << '\n';
-    aligned_vector<float> A_fp32_ref(m * n); // fp32 type
-    aligned_vector<bfloat16> A_bfloat16(m * n); // bfloat16 type
-    aligned_vector<float> A_fp32_final(m * n); // fp32 type
-    // randFill(A_fp32_ref, 0.0f, 4.0f);
+    aligned_vector<float> A_fp32_ref(m * n);
+    aligned_vector<bfloat16> A_bf16_ref(m * n);
+    aligned_vector<bfloat16> A_bf16_simd(m * n);
+    aligned_vector<float> A_fp32_final(m * n);
     for (int i = 0; i < m * n; ++i) {
       A_fp32_ref[i] = i + 1.25;
     }
 
-    FloatToBfloat16_simd(A_fp32_ref.data(), A_bfloat16.data(), m * n);
-    Bfloat16ToFloat_simd(A_bfloat16.data(), A_fp32_final.data(), m * n);
+    FloatToBfloat16_ref(A_fp32_ref.data(), A_bf16_ref.data(), m * n);
+    FloatToBfloat16_simd(A_fp32_ref.data(), A_bf16_simd.data(), m * n);
+    Bfloat16ToFloat_simd(A_bf16_simd.data(), A_fp32_final.data(), m * n);
     for (int i = 0; i < m * n; ++i) {
-      // The relative error should be less than 1/(2^7) since bfloat16
-      // has 7 bits mantissa.
-      // printf( "A_fp32_final[%d]: %f; A_fp32_ref[%d]: %f\n", i,
-      // A_fp32_final[i], i, A_fp32_ref[i]);
+      EXPECT_EQ(A_bf16_simd[i], A_bf16_ref[i])
+          << "m=" << m << " n=" << n << " i=" << i;
       EXPECT_LE(
           fabs(A_fp32_final[i] - A_fp32_ref[i]) / A_fp32_ref[i], 1.0 / 128);
     }
   }
 }
+


### PR DESCRIPTION
Fix fp32→bf16 rounding to round-to-nearest, ties-to-even everywhere: scalar, AVX2, AVX512, SVE, and JIT kernels (previously halves rounded away from zero, differing per backend). aarch64 BFCVT is dispatched at runtime via cpuinfo_has_arm_bf16().