### PR TITLE
Fix VBE batch sizes not passed to request builder (#5653)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/bench/tbe_data_config_bench_helper.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/bench/tbe_data_config_bench_helper.py
@@ -35,9 +35,7 @@ except Exception:
 def _generate_batch_sizes(
     tbe_data_config: TBEDataConfig,
 ) -> tuple[list[int], list[list[int]] | None]:
-    logging.info(
-        f"DEBUG_TBE: [_generate_batch_sizes] VBE tbe_data_config.variable_B()={tbe_data_config.variable_B()}"
-    )
+    logging.debug(f"[_generate_batch_sizes] variable_B={tbe_data_config.variable_B()}")
     if tbe_data_config.variable_B():
         assert (
             tbe_data_config.batch_params.vbe_num_ranks is not None
@@ -121,7 +119,7 @@ def _generate_indices(
             start_offset = L_offsets_list[it * total_B]
             end_offset = L_offsets_list[(it + 1) * total_B]
 
-            logging.info(f"DEBUG_TBE: _generate_indices E={tbe_data_config.E}")
+            logging.debug(f"_generate_indices E={tbe_data_config.E}")
 
             indices_list.append(
                 torch.ops.fbgemm.tbe_generate_indices_from_distribution(
@@ -215,14 +213,16 @@ def generate_requests(
     # Generate batch sizes
     if batch_size_per_feature_per_rank:
         Bs = tbe_data_config.batch_params.Bs
+        Bs_feature_rank = batch_size_per_feature_per_rank
     else:
-        Bs, _ = _generate_batch_sizes(tbe_data_config)
-
-    logging.info(
-        f"DEBUG_TBE: VBE [generate_requests] batch_size_per_feature_per_rank={batch_size_per_feature_per_rank} Bs={Bs}"
-    )
+        Bs, Bs_feature_rank = _generate_batch_sizes(tbe_data_config)
 
     assert Bs is not None, "Batch sizes (Bs) must be set"
+
+    logging.debug(
+        f"[generate_requests] Bs_len={len(Bs)}"
+        f" Bs_feature_rank={Bs_feature_rank is not None}"
+    )
 
     # Generate pooling info
     L_offsets = _generate_pooling_info(tbe_data_config, iters, Bs)
@@ -233,24 +233,14 @@ def generate_requests(
 
     # Build TBE requests
     if tbe_data_config.variable_B() or tbe_data_config.variable_L():
-        if batch_size_per_feature_per_rank:
-            return _build_requests_jagged(
-                tbe_data_config,
-                iters,
-                Bs,
-                batch_size_per_feature_per_rank,
-                L_offsets,
-                all_indices,
-            )
-        else:
-            return _build_requests_jagged(
-                tbe_data_config,
-                iters,
-                Bs,
-                batch_size_per_feature_per_rank,
-                L_offsets,
-                all_indices,
-            )
+        return _build_requests_jagged(
+            tbe_data_config,
+            iters,
+            Bs,
+            Bs_feature_rank,
+            L_offsets,
+            all_indices,
+        )
     else:
         return _build_requests_dense(tbe_data_config, iters, all_indices)
 
@@ -309,6 +299,8 @@ def generate_requests_with_Llist(
     all_indices = all_indices.to(get_device())
 
     # Build TBE requests
+    # batch_size_per_feature_per_rank is passed through directly
+    # from the caller (no _generate_batch_sizes call here).
     if tbe_data_config.variable_B() or tbe_data_config.variable_L():
         return _build_requests_jagged(
             tbe_data_config,


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2626

When `batch_size_per_feature_per_rank` is provided externally (e.g. from a
sharding plan), it was not being forwarded to `_build_requests_jagged`.
Both branches of the VBE/non-VBE conditional were passing the raw
`batch_size_per_feature_per_rank` parameter (which could be None in the else
branch) instead of the resolved `Bs_feature_rank` from `_generate_batch_sizes`.

This fix:
1. Captures the externally-provided batch sizes into `Bs_feature_rank` when
   `batch_size_per_feature_per_rank` is set
2. Uses `_generate_batch_sizes` return value otherwise
3. Removes the duplicate if/else branches that were doing the same thing
4. Passes the resolved `Bs_feature_rank` to `_build_requests_jagged`

Reviewed By: q10

Differential Revision: D94380814


