### PR TITLE
Add my_size > 0 guard and inference negative test for block_bucketize

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h
@@ -22,6 +22,10 @@ namespace fbgemm_gpu {
 inline void check_total_num_blocks_divisibility(
     const at::Tensor& total_num_blocks,
     int64_t my_size) {
+  TORCH_CHECK(
+      my_size > 0,
+      "block_bucketize_sparse_features: my_size must be > 0, got ",
+      my_size);
   const auto tnb = total_num_blocks.cpu();
   AT_DISPATCH_INDEX_TYPES(
       tnb.scalar_type(),

--- a/fbgemm_gpu/test/sparse/block_bucketize_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_test.py
@@ -2125,6 +2125,21 @@ class BlockBucketizeTest(unittest.TestCase):
                 total_num_blocks=torch.tensor([7, 6, 6], dtype=torch.int),
             )
 
+    def test_block_bucketize_sparse_features_inference_total_num_blocks_not_divisible(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(RuntimeError, "must be a multiple of my_size"):
+            torch.ops.fbgemm.block_bucketize_sparse_features_inference(
+                torch.tensor([0, 3, 2, 0, 1, 5], dtype=torch.int),
+                torch.tensor([1, 2, 10, 4, 16, 6, 7, 18, 19, 10, 0], dtype=torch.int),
+                False,
+                False,
+                torch.tensor([2, 3, 4], dtype=torch.int),
+                3,
+                None,
+                total_num_blocks=torch.tensor([7, 6, 6], dtype=torch.int),
+            )
+
 
 extend_test_class(BlockBucketizeTest)
 


### PR DESCRIPTION
Summary:
Followup to D101141810. Adds two small improvements:

1. **Defensive guard for my_size == 0**: Added `TORCH_CHECK(my_size > 0, ...)` at the top of `check_total_num_blocks_divisibility()` before the `.cpu()` call. This converts C++ undefined behavior (integer modulo by zero) into a clear error message.

2. **Inference variant negative test**: Added `test_block_bucketize_sparse_features_inference_total_num_blocks_not_divisible` which explicitly confirms the inference variant (`block_bucketize_sparse_features_inference`) inherits the divisibility validation from the shared helper.

Differential Revision: D101232858


