### PR TITLE
Fix AMD build incompatibility and incorrect main_module paths

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/test/kv_cache/kv_cache_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/kv_cache/kv_cache_test.py
@@ -88,7 +88,7 @@ class KVCacheTests(unittest.TestCase):
                 torch.tensor(0, device=cls.device)
             )
             cls.compile_backend = "inductor"
-        except torch._dynamo.exc.BackendCompilerFailed:
+        except Exception:
             cls.compile_backend = "eager"
 
     @settings(deadline=None)


### PR DESCRIPTION
Summary:
Fix 6 build failures tracked in T191384137:

1. group_gemm_ops_cuda_split_sm80/sm70: These CUDA-only targets (using
   CUTLASS and nvcc) were failing when built with opt-amd-gpu mode because
   their transitive dep c10_cuda is incompatible with AMD. Added
   target_incompatible_with_amd() to explicitly declare CUDA-only
   compatibility.

2. ads_mkl ck_extensions and common/scripts targets: After code was moved
   from deeplearning/fbgemm/fbgemm_gpu/experimental/gen_ai/src/quantize/
   to ads_mkl/ops/cuda/gen_ai/src/quantize/, the main_module and
   main_function paths in the BUCK files were not updated. Fixed all 4
   python_binary targets to use the correct ads_mkl module paths.

Reviewed By: cthi

Differential Revision: D101726114


