### PR TITLE
Apply proper grid striding on forward V2 kernel for ROCm (#5447)

### DIFF
--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_v2_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_v2_template.cu
@@ -777,14 +777,32 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel(
     __shared__ long smem[NUM_PARAMS * NUM_WARPS + kForwardMaxThreads];
     const uint32_t params_offset = NUM_PARAMS * threadIdx.y;
 
-    const auto global_warp_id = blockIdx.x * blockDim.y + threadIdx.y;
-    int32_t t;
-    int32_t table_warp_id;
-    fd_num_warps_per_table.DivMod(global_warp_id, &t, &table_warp_id);
+#if defined(USE_ROCM)
+    for (
+        auto global_warp_id = blockIdx.x * blockDim.y + threadIdx.y;
+        ;
+        global_warp_id += blockDim.y * gridDim.x) {
+#else
+      const auto global_warp_id = blockIdx.x * blockDim.y + threadIdx.y;
+#endif
 
-    if (t >= T) {
-      return;
-    }
+      int32_t t;
+      int32_t table_warp_id;
+      fd_num_warps_per_table.DivMod(global_warp_id, &t, &table_warp_id);
+
+      if (t >= T) {
+#if defined(USE_ROCM)
+        break;
+#else
+        return;
+#endif
+      }
+
+#if defined(USE_ROCM)
+#define GO_NEXT continue
+#else
+#define GO_NEXT return
+#endif
 
     const auto total_L = offsets[(t + 1) * B] - offsets[t * B];
     const auto is_zero_total_L = total_L == 0;
@@ -795,7 +813,7 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel(
       const uint32_t load_D = (D_offsets[t + 1] / VEC_WIDTH) - D_start;
       const uint32_t num_warps_per_row = DIV_ROUND_UP(load_D, kWarpSize);
       if (table_warp_id >= num_warps_per_row * B) {
-        return;
+        GO_NEXT;
       }
       const uint32_t load_d = (table_warp_id % num_warps_per_row) * kWarpSize;
       if (load_d + threadIdx.x < load_D) {
@@ -809,7 +827,7 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel(
         Vec4StepT<1, emb_t> accumulator;
         accumulator.store(output_ptr);
       }
-      return;
+      GO_NEXT;
     }
 
     // Use the small-L optimization if average L <= 8
@@ -819,7 +837,7 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel(
     // Early exit for small-L to avoid D_offsets reads.
     const uint32_t max_num_warps_per_row = DIV_ROUND_UP(max_D / VEC_WIDTH, kWarpSize);
     if (is_small_L && table_warp_id >= num_warps_for_small_L * max_num_warps_per_row) {
-      return;
+      GO_NEXT;
     }
 
     uint32_t load_D = 0;
@@ -835,7 +853,7 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel(
     const uint32_t num_warps_per_row = DIV_ROUND_UP(load_D, kWarpSize);
 
     if (table_warp_id >= num_warps_per_row * (is_small_L ? num_warps_for_small_L : B)) {
-      return;
+      GO_NEXT;
     }
 
     // Compute d (same for all Ls)
@@ -926,7 +944,7 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel(
 
     if (is_small_L) {
       INVOKE_PROCESS_ALL_INDICES(small_Ls, kWarpSize, 0xf)
-      return;
+      GO_NEXT;
     }
 
     // Special cases
@@ -971,7 +989,7 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel(
           accumulator.store(output_ptr);
         }
       }
-      return;
+      GO_NEXT;
     }
 
     // Tail warp
@@ -1003,6 +1021,11 @@ __global__ void split_embedding_codegen_forward_{{ wdesc }}_v2_kernel(
     INVOKE_PROCESS_ALL_INDICES(large_Ls, kWarpSize, 0xf)
     {% endif %}
 
+#if defined(USE_ROCM)
+  }
+#endif
+
+#undef GO_NEXT
 #undef INVOKE_PROCESS_ALL_INDICES_HELPER
 #undef INVOKE_PROCESS_ALL_INDICES
 

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
@@ -608,7 +608,8 @@ batch_index_select_dim0_codegen_forward_cuda(
 
         {%- if has_experimental %}
         const bool is_experimental_ = (
-            is_experimental && !(std::is_same_v<emb_t, uint8_t> || std::is_same_v<output_t, uint8_t>)
+            is_experimental
+            && !(std::is_same_v<emb_t, uint8_t> || std::is_same_v<output_t, uint8_t>)
         );
         // if max_D > {{ legacy_max_embedding_dim }}, use TBE v2
         if (!is_experimental_ && max_D <= {{ legacy_max_embedding_dim }}) {
@@ -809,14 +810,27 @@ batch_index_select_dim0_codegen_forward_cuda(
         // if (!is_experimental)
         } else {
             // Allocate num warps per table based on max_D
-            
+
             const int num_warps_per_table = B * div_round_up(max_D, kWarpSize * 4);
             #ifdef USE_ROCM
               const uint32_t num_warps_per_threadblock = kForwardMaxThreads / (kWarpSize * 2);
+              const auto num_threadblocks =
+                  div_round_up(T * num_warps_per_table, num_warps_per_threadblock);
+              const uint64_t num_threads =
+                  static_cast<uint64_t>(num_threadblocks)
+                  * kWarpSize * num_warps_per_threadblock;
+              // Cap the grid only when total threads exceed uint32 limits;
+              // the kernel's grid-striding loop handles the overflow.
+              const auto grid = num_threads >= std::numeric_limits<uint32_t>::max()
+                  ? min(
+                        num_threadblocks,
+                        utils::cuda::get_max_thread_blocks(at::cuda::getCurrentCUDAStream()))
+                  : num_threadblocks;
             #else
               const uint32_t num_warps_per_threadblock = kForwardMaxThreads / kWarpSize;
+              const auto grid = div_round_up(T * num_warps_per_table, num_warps_per_threadblock);
             #endif
-            
+
             const auto kernel_func =
               (use_lxu_cache ? split_embedding_codegen_forward_{{ wdesc }}_v2_kernel<
                                   emb_t, cache_t, output_t, index_t, true>
@@ -825,7 +839,7 @@ batch_index_select_dim0_codegen_forward_cuda(
 
             FBGEMM_LAUNCH_KERNEL(
               kernel_func,
-              div_round_up(T * num_warps_per_table, num_warps_per_threadblock),
+              grid,
               dim3(kWarpSize, num_warps_per_threadblock),
               0,
               at::cuda::getCurrentCUDAStream(),

--- a/fbgemm_gpu/test/tbe/training/forward_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_test.py
@@ -697,9 +697,6 @@ class ForwardTest(unittest.TestCase):
             use_experimental_tbe,
         )
 
-    @unittest.skip(
-        "Test will be un-skipped with https://github.com/pytorch/FBGEMM/pull/5447"
-    )
     @unittest.skipIf(*gpu_unavailable)
     @unittest.skipIf(
         not torch.version.hip,


### PR DESCRIPTION
Summary:
Avoid run-time error when the number of threads is greater than `2^32 - 1` on the V2 forward kernel for ROCm


Test Plan:
Imported from GitHub, without a `Test Plan:` line.

```
# Run unit test
HIP_VISIBLE_DEVICES=0 buck run fbcode//mode/opt-amd-gpu   -c fbcode.enable_gpu_sections=true   -c fbcode.rocm_arch=mi350   -c fbcode.platform=platform010   -m rocm70   //deeplearning/fbgemm/fbgemm_gpu/test/tbe:forward   -- -r test_forward_gpu_v2_kernel_large_grid_rocm

# Run benchmark
cd ~/fbsource/fbcode/ai_codesign/nonprod/bensonma415/scripts/D94944619
bash run_benchmark.sh 2>&1 | pastry
```

https://docs.google.com/document/d/16RLq-DQhzNAf-mrMu6ijY_CMwtJETexod4uHAL3nh-k/edit?tab=t.0#heading=h.dj2x1okp2jd4

https://docs.google.com/document/d/1Lf34K4XlQMdwiR7pmkZIPOMV4TlJjNb7MCY9Msl7sfM/edit?tab=t.0

https://www.internalfb.com/agent-home?session_id=007362ba-d8ad-49fd-a339-62a21a341971

Reviewed By: spcyppt

Differential Revision: D94944619

Pulled By: q10


