### PR TITLE
Add --device and --export-trace flags to stride_gemm_benchmark

### DIFF
--- a/fbgemm_gpu/bench/stride_gemm_benchmark.py
+++ b/fbgemm_gpu/bench/stride_gemm_benchmark.py
@@ -41,6 +41,12 @@ def cli() -> None:
     default=False,
     help="Use manual seed for reproduction.",
 )
+@click.option("--device", default="cuda", help="Device type (default: cuda).")
+@click.option(
+    "--export-trace/--no-export-trace",
+    default=False,
+    help="Export Kineto trace to JSON file.",
+)
 def stride_gemm(
     flush_gpu_cache_size_mb: int,
     iters: int,
@@ -50,21 +56,23 @@ def stride_gemm(
     k: int,
     num_warmups: int,
     manual_seed: bool,
+    device: str,
+    export_trace: bool,
 ) -> None:
     # set manual seed for reproducibility
     if manual_seed:
         torch.manual_seed(42)
 
-    A = torch.rand(m, batch_size, k).half().cuda()
-    B = torch.rand(batch_size, k, n).half().cuda()
-    bias = torch.rand(batch_size, n).half().cuda()
+    A = torch.rand(m, batch_size, k, device=device).half()
+    B = torch.rand(batch_size, k, n, device=device).half()
+    bias = torch.rand(batch_size, n, device=device).half()
     bias_permute102 = bias.unsqueeze(1)
 
     # A100 40MB L2 cache
     elapse, _ = benchmark_torch_function(
         torch.ops.fbgemm.permute102_baddbmm_permute102,
         (bias, A, B),
-        flush_gpu_cache_size_mb,
+        flush_gpu_cache_size_mb=flush_gpu_cache_size_mb,
         iters=iters,
         num_warmups=num_warmups,
     )
@@ -84,13 +92,27 @@ def stride_gemm(
     elapse_ref, _ = benchmark_torch_function(
         ref_stride_gemm,
         (bias_permute102, A, B),
-        flush_gpu_cache_size_mb,
+        flush_gpu_cache_size_mb=flush_gpu_cache_size_mb,
         iters=iters,
         num_warmups=num_warmups,
     )
     logging.info(
         f"stride gemm unfused: time: {elapse_ref}, TFLOPS/sec: {2.0 * batch_size * m * n * k / elapse_ref / 1.0e12: .2f}"
     )
+
+    if export_trace and device == "cuda":
+        trace_name = f"stride_gemm_m{m}_b{batch_size}_n{n}_k{k}"
+        with torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,  # pyre-ignore[16]
+                torch.profiler.ProfilerActivity.CUDA,  # pyre-ignore[16]
+            ],
+            record_shapes=True,
+        ) as prof:
+            torch.ops.fbgemm.permute102_baddbmm_permute102(bias, A, B)
+            ref_stride_gemm(bias_permute102, A, B)
+        prof.export_chrome_trace(f"{trace_name}_trace.json")
+        logging.info(f"Exported trace to {trace_name}_trace.json")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Add --device and --export-trace flags to the legacy stride GEMM benchmark and fix a positional arg bug.

This diff enhances `stride_gemm_benchmark.py` with device portability, trace export support, and a bug fix. Specifically:

1. **`--device` flag** (default: `"cuda"`): Replaces hardcoded `.half().cuda()` with `.half().to(device)`, enabling the benchmark to run on CPU in addition to CUDA.
2. **`--export-trace` flag**: When enabled on CUDA, wraps a single profiled run of both fused and unfused kernels in `torch.profiler.profile` and exports a Chrome trace JSON file (`stride_gemm_m{M}_b{B}_n{N}_k{K}_trace.json`) for kernel-level comparison analysis.
3. **Keyword arg fix**: Changes two `benchmark_torch_function(... flush_gpu_cache_size_mb, ...)` calls from positional to keyword (`flush_gpu_cache_size_mb=flush_gpu_cache_size_mb`). The third positional parameter of `benchmark_torch_function` is `kwargs` (a dict), so passing an `int` positionally was a latent bug.

Reviewed By: henrylhtsang

Differential Revision: D101842778


