### PR TITLE
Add FP8 rowwise padding to quantized AllToAll pooled embeddings (#5673)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/quantize_comm.py
+++ b/fbgemm_gpu/fbgemm_gpu/quantize_comm.py
@@ -13,6 +13,7 @@
 
 
 import logging
+import os
 from dataclasses import dataclass
 from typing import TypeVar
 
@@ -54,6 +55,10 @@ def none_throws(
     if optional is None:
         raise AssertionError(message)
     return optional
+
+
+def _is_fp8_rowwise_padding_enabled() -> bool:
+    return bool(int(os.environ.get("TORCHREC_ENABLE_FP8_ROWWISE_PADDING", 0)))
 
 
 @dataclass
@@ -292,6 +297,31 @@ class QuantizedCommCodec:
             padding_size_per_rank = [
                 group_size - (t if (t := dim_sum % group_size) > 0 else group_size)
                 for dim_sum in dim_per_rank
+            ]
+            padded_dim_sum_per_rank = [
+                a + b for a, b in zip(dim_per_rank, padding_size_per_rank)
+            ]
+            dim_sum, padding_size = (
+                dim_per_rank[my_rank],
+                padding_size_per_rank[my_rank],
+            )
+            assert input_tensor.ndim == 2 and input_tensor.shape[1] == dim_sum
+            qcomm_ctx.padded_dim_sum_per_rank = padded_dim_sum_per_rank
+            padded_dim_sum = padding_size + dim_sum
+            return padded_dim_sum, padding_size
+
+        elif (
+            self._comm_precision == SparseType.FP8
+            and self._row_dim > 0
+            and _is_fp8_rowwise_padding_enabled()
+        ):
+            # FP8 rowwise quantization requires input_len % row_dim == 0.
+            # Pad each rank's dim_sum to be a multiple of row_dim so that
+            # B * padded_dim_sum is always divisible, preventing misalignment
+            # errors during AllToAll with non-standard batch sizes (e.g. eval).
+            row_dim = qcomm_ctx.row_dim
+            padding_size_per_rank = [
+                (row_dim - dim_sum % row_dim) % row_dim for dim_sum in dim_per_rank
             ]
             padded_dim_sum_per_rank = [
                 a + b for a, b in zip(dim_per_rank, padding_size_per_rank)


### PR DESCRIPTION
Summary:

X-link: https://github.com/meta-pytorch/torchrec/pull/4153

X-link: https://github.com/facebookresearch/FBGEMM/pull/2615

FP8 rowwise quantization requires `input_len % row_dim == 0` for the per-row reshape. This crashes during eval when `B_local * D_rank_sum` is not divisible by `fp8_quantize_row_dim` (typically 256) caused by small eval batch sizes combined with irregular per-rank embedding dimension sums from column-based sharding.

Here is an example of failed job = f1068622657

The fix adds FP8 padding mirroring the existing MX4 padding pattern:

1. `quantize_comm.py`: Extend `padded_size`() with an FP8 branch that pads each rank's `D_rank_sum` to the next multiple of row_dim.
1. `comm_ops.py` (fixed-batch paths): Wire `padded_size()` into `all2all_pooled_sync()` (which was missing it) and fix `All2All_Pooled_Req.forward()`. Both paths now pad the 2D tensor with `F.pad(input_embeddings, (0, padding_size))` before encoding, use `padded_dim_sum_per_rank` for split sizes, and strip padding after decoding.
1. `comm_ops.py` (variable-batch paths): Add per-split padding to `variable_batch_all2all_pooled_sync()` and `Variable_Batch_All2All_Pooled_Req.forward()`. Each split is padded to the next multiple of `row_dim`, the 1D tensor is padded to match, and the output is truncated after decoding.

Padding is zero-filled before communication and stripped after. No impact on model output.

Reviewed By: spcyppt

Differential Revision: D100069631


