### PR TITLE
Exclude transient RES streaming buffers from checkpoints by setting persistent=False (#5674)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -1632,6 +1632,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 (cache_size,),
                 is_host_mapped=self.uvm_host_mapped,
             ),
+            persistent=False,  # RES buffer is not checkpointed since it is used as intermediate buffer for copying
         )
         self.register_buffer(
             "res_weights",
@@ -1645,6 +1646,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 self.lxu_cache_weights.shape,
                 is_host_mapped=self.uvm_host_mapped,
             ),
+            persistent=False,  # RES buffer is not checkpointed since it is used as intermediate buffer for copying
         )
         self.register_buffer(
             "res_identities",
@@ -1657,6 +1659,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 (cache_size, 1),
                 is_host_mapped=self.uvm_host_mapped,
             ),
+            persistent=False,  # RES buffer is not checkpointed since it is used as intermediate buffer for copying
         )
         self.register_buffer(
             "res_runtime_meta",
@@ -1682,6 +1685,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 (1,),
                 is_host_mapped=self.uvm_host_mapped,
             ),
+            persistent=False,  # RES buffer is not checkpointed since it is used as intermediate buffer for copying
         )
         self.register_buffer(
             "res_copy_done",
@@ -1694,6 +1698,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 (1,),
                 is_host_mapped=self.uvm_host_mapped,
             ),
+            persistent=False,  # RES buffer is not checkpointed since it is used as intermediate buffer for copying
         )
 
     def _register_empty_res_buffers(self) -> None:
@@ -1701,6 +1706,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.register_buffer(
             "res_indices",
             torch.zeros(0, device=self.current_device, dtype=torch.long),
+            persistent=False,  # RES buffer is not checkpointed since it is used as intermediate buffer for copying
         )
         self.register_buffer(
             "res_weights",
@@ -1711,10 +1717,12 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 # pyre-ignore Incompatible parameter type [6]: In call `torch._C._VariableFunctions.zeros`, for argument `dtype`, expected `dtype | None` but got `Module | dtype | Tensor`
                 dtype=self.lxu_cache_weights.dtype,
             ),
+            persistent=False,  # RES buffer is not checkpointed since it is used as intermediate buffer for copying
         )
         self.register_buffer(
             "res_identities",
             torch.zeros(0, 1, device=self.current_device, dtype=torch.long),
+            persistent=False,  # RES buffer is not checkpointed since it is used as intermediate buffer for copying
         )
         self.register_buffer(
             "res_runtime_meta",
@@ -1724,10 +1732,12 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.register_buffer(
             "res_count",
             torch.zeros(1, device=self.current_device, dtype=torch.int),
+            persistent=False,  # RES buffer is not checkpointed since it is used as intermediate buffer for copying
         )
         self.register_buffer(
             "res_copy_done",
             torch.zeros(1, device=self.current_device, dtype=torch.int32),
+            persistent=False,  # RES buffer is not checkpointed since it is used as intermediate buffer for copying
         )
 
     @torch.jit.ignore


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2616

RES (Raw Embedding Streaming) buffers (`res_indices`, `res_weights`, `res_identities`, `res_runtime_meta`, `res_count`, `res_copy_done`) are transient intermediate buffers used for copying embedding updates from the TBE L1 cache during the prefetch pipeline. They are initialized on construction and hold no trained state that needs to be persisted across checkpoints.

Setting `persistent=False` on all 12 `register_buffer()` calls (across `_register_res_buffers` and `_register_empty_res_buffers`) excludes them from `state_dict()`, which:
- Reduces checkpoint size (these buffers can be large — sized to `cache_size` or `lxu_cache_weights.shape`)
- Eliminates unnecessary memory copies during checkpoint save/restore
- Resolves the MB6.5 memory neutral regression where checkpointing these large UVM-backed buffers inflated RSS

Backward compatible: TorchRec's `_load_state_dict` in `embedding_lookup.py` handles unexpected keys gracefully — old checkpoints containing these keys will simply skip them without error.

Reviewed By: chouxi

Differential Revision: D101045065


