### PR TITLE
Fix OOM (exit code 137) in CI builds for CUDA 13.2+ (#5679)

### DIFF
--- a/.github/scripts/fbgemm_build.bash
+++ b/.github/scripts/fbgemm_build.bash
@@ -73,7 +73,7 @@ __build_fbgemm_library_cmake () {
   echo "[BUILD] Running the build ..."
   # shellcheck disable=SC2086
   (print_exec conda run --no-capture-output ${env_prefix} \
-    make -j VERBOSE=1) || return 1
+    make -j "$(nproc)" VERBOSE=1) || return 1
 
   cd - || return 1
 }

--- a/.github/scripts/fbgemm_gpu_build.bash
+++ b/.github/scripts/fbgemm_gpu_build.bash
@@ -536,8 +536,9 @@ __build_fbgemm_gpu_set_run_multicore () {
       fi
 
       if [[ $mem_gb -gt 0 ]]; then
-        # Allow ~4 GB per parallel compilation job
-        local mem_jobs=$((mem_gb / 4))
+        # Allow ~5 GB per parallel compilation job.  NVCC jobs targeting
+        # multiple GPU architectures can use 4-6 GB for large translation units.
+        local mem_jobs=$((mem_gb / 5))
         if [[ $mem_jobs -lt 1 ]]; then
           mem_jobs=1
         fi

--- a/.github/scripts/nova_prescript.bash
+++ b/.github/scripts/nova_prescript.bash
@@ -141,6 +141,39 @@ if [[ ${CHANNEL} == "" ]]; then
   export CHANNEL="nightly"
 fi
 
+# Cap build parallelism for multi-arch CUDA builds (cu128+) that target 4+
+# GPU architectures (8.0;9.0a;10.0a;12.0a) to prevent OOM (exit code 137).
+# This performs memory-based capping similar to setup.py, but acts as a safety
+# net that setup.py can further reduce if needed.
+if [[ "${fbgemm_build_variant}" == "cuda" ]]; then
+  if [[ "$CU_VERSION" == "cu132" ]] ||
+     [[ "$CU_VERSION" == "cu130" ]] ||
+     [[ "$CU_VERSION" == "cu129" ]] ||
+     [[ "$CU_VERSION" == "cu128" ]]; then
+    if [[ -z "${CMAKE_BUILD_PARALLEL_LEVEL:-}" ]]; then
+      # Compute memory-aware parallelism: ~5 GB per NVCC job for multi-arch builds
+      _nova_parallel=4
+      if [ -f /proc/meminfo ]; then
+        _nova_mem_gb=$(awk '/MemAvailable/ {printf "%d", $2/1024/1024}' /proc/meminfo 2>/dev/null || echo "0")
+        if [[ $_nova_mem_gb -gt 0 ]]; then
+          _nova_mem_jobs=$((_nova_mem_gb / 5))
+          if [[ $_nova_mem_jobs -lt 1 ]]; then
+            _nova_mem_jobs=1
+          fi
+          if [[ $_nova_mem_jobs -lt $_nova_parallel ]]; then
+            echo "[NOVA] Capping parallelism from ${_nova_parallel} to ${_nova_mem_jobs} (available memory: ~${_nova_mem_gb} GB)"
+            _nova_parallel=$_nova_mem_jobs
+          fi
+        fi
+      fi
+      export CMAKE_BUILD_PARALLEL_LEVEL=$_nova_parallel
+      echo "[NOVA] Set CMAKE_BUILD_PARALLEL_LEVEL=${CMAKE_BUILD_PARALLEL_LEVEL} for multi-arch CUDA build (${CU_VERSION})"
+    else
+      echo "[NOVA] CMAKE_BUILD_PARALLEL_LEVEL already set to ${CMAKE_BUILD_PARALLEL_LEVEL}"
+    fi
+  fi
+fi
+
 # Build the wheel
 build_fbgemm_gpu_package "${BUILD_ENV_NAME}" "${CHANNEL}" "${fbgemm_build_target}/${fbgemm_build_variant}"
 end_time=$(date +%s)

--- a/.github/workflows/_fbgemm_gpu_cuda_build.yml
+++ b/.github/workflows/_fbgemm_gpu_cuda_build.yml
@@ -128,6 +128,20 @@ jobs:
         . $PRELUDE
         cd fbgemm_gpu
 
+        # Cap build parallelism for multi-arch CUDA builds to prevent OOM
+        # (exit code 137). CUDA 12.8+ targets 3-4 GPU architectures and each
+        # NVCC job can use 4-6 GB when compiling large translation units.
+        if [ -f /proc/meminfo ]; then
+          MEM_GB=$(awk '/MemAvailable/ {printf "%d", $2/1024/1024}' /proc/meminfo)
+          # Allow ~5 GB per parallel compilation job (conservative for multi-arch)
+          MEM_JOBS=$((MEM_GB / 5))
+          CPU_JOBS=$(( $(nproc) / 2 ))
+          if [ "$MEM_JOBS" -lt "$CPU_JOBS" ] && [ "$MEM_JOBS" -gt 0 ]; then
+            export CMAKE_BUILD_PARALLEL_LEVEL=$MEM_JOBS
+            echo "[BUILD] Set CMAKE_BUILD_PARALLEL_LEVEL=${MEM_JOBS} (memory-capped: ~${MEM_GB} GB available)"
+          fi
+        fi
+
         # Extract channel from channel/version string
         PYTORCH_CHANNEL_VERSION="${{ inputs.pytorch-channel-version }}"
         PYTORCH_CHANNEL_ONLY="${PYTORCH_CHANNEL_VERSION%%/*}"

--- a/.github/workflows/fbgemm_ci.yml
+++ b/.github/workflows/fbgemm_ci.yml
@@ -120,7 +120,7 @@ jobs:
         mkdir $BUILD_DIR; cd $BUILD_DIR
         cmake --version
         cmake -DFBGEMM_USE_SANITIZER=address -DFBGEMM_LIBRARY_TYPE=${{ matrix.library-type }} ..
-        make -j VERBOSE=1
+        make -j $(sysctl -n hw.ncpu) VERBOSE=1
 
 
   build-bazel:
@@ -210,7 +210,7 @@ jobs:
         echo "STARTING CMAKE"
         cmake --version
         cmake -G Ninja -DFBGEMM_BUILD_BENCHMARKS=OFF -DFBGEMM_LIBRARY_TYPE=${{ matrix.library-type }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" ..
-        ninja -v all
+        ninja -j %NUMBER_OF_PROCESSORS% -v all
         echo "Build Success"
 
     - name: Test FBGEMM Library (${{ matrix.library-type }})

--- a/fbgemm_gpu/setup.py
+++ b/fbgemm_gpu/setup.py
@@ -274,7 +274,33 @@ class FbgemmGpuBuild:
             return f"-D_GLIBCXX_USE_CXX11_ABI={value}"
 
         torch_root = os.path.dirname(torch.__file__)
-        os.environ["CMAKE_BUILD_PARALLEL_LEVEL"] = str((os.cpu_count() or 4) // 2)
+
+        # Set build parallelism: respect externally-set value, otherwise
+        # auto-detect based on CPU count and available memory to avoid OOM
+        # (exit code 137) on memory-constrained CI runners.
+        if "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:
+            parallel_level = (os.cpu_count() or 4) // 2
+            try:
+                with open("/proc/meminfo") as f:
+                    for line in f:
+                        if line.startswith("MemAvailable:"):
+                            mem_kb = int(line.split()[1])
+                            # Allow ~5 GB per parallel compilation job.
+                            # NVCC jobs targeting multiple GPU architectures
+                            # (e.g. 8.0;9.0a;10.0a;12.0a for cu132) can use
+                            # 4-6 GB for large translation units.
+                            mem_jobs = max(1, mem_kb // (5 * 1024 * 1024))
+                            if mem_jobs < parallel_level:
+                                print(
+                                    f"[FBGEMM] Capping build parallelism from"
+                                    f" {parallel_level} to {mem_jobs} based on"
+                                    f" available memory (~{mem_kb // 1024 // 1024} GB)"
+                                )
+                                parallel_level = mem_jobs
+                            break
+            except (OSError, ValueError):
+                pass
+            os.environ["CMAKE_BUILD_PARALLEL_LEVEL"] = str(parallel_level)
 
         cmake_args = [
             f"-DCMAKE_PREFIX_PATH={torch_root}",


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2621


CUDA 13.2+ (cu128-cu132) targets 4 GPU architectures (8.0;9.0a;10.0a;12.0a), doubling memory pressure compared to cu126 (8.0;9.0a). The build system had no memory-aware parallelism capping for the wheel build path, causing OOM kills (exit code 137) on CI runners.

**Root cause:** `setup.py` unconditionally set `CMAKE_BUILD_PARALLEL_LEVEL` to `cpu_count() // 2`, ignoring available memory. On a 16-core runner with 32 GB RAM, this launched 8 parallel NVCC jobs each using 4-6 GB for multi-arch builds, exceeding available memory.

**Changes:**
- **setup.py**: Add memory-aware auto-capping (~5 GB/job estimate from `/proc/meminfo`), respect externally-set `CMAKE_BUILD_PARALLEL_LEVEL`
- **nova_prescript.bash**: Add memory-aware parallelism cap for cu128+ Nova wheel builds as a safety net before `setup.py` runs
- **_fbgemm_gpu_cuda_build.yml**: Add memory-aware cap for CI/release/benchmark CUDA builds that bypass the Nova prescript
- **fbgemm_gpu_build.bash**: Update memory estimate from 4 GB to 5 GB per job in `__build_fbgemm_gpu_set_run_multicore()` for consistency
- **fbgemm_build.bash**: Bound `make -j` to `nproc` (was unbounded)
- **fbgemm_ci.yml**: Bound `make`/`ninja` parallelism on macOS and Windows

Differential Revision: D102179859


