### PR TITLE
Refactor bounds_check_indices offset checks to condition-first (Phase 1) (#5682)

### DIFF
--- a/fbgemm_gpu/bench/tbe/tbe_utils_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/tbe_utils_benchmark.py
@@ -284,6 +284,14 @@ def pruned_array_lookup(  # noqa C901
     f"IGNORE={BoundsCheckMode.IGNORE.value}, "
     f"NONE={BoundsCheckMode.NONE.value}",
 )
+@click.option(
+    "--bounds-check-version",
+    type=int,
+    default=1,
+    help="Kernel version dispatched by bounds_check_indices: 1 (default) or 2. "
+    "v2 is also gated globally by JK BOUNDS_CHECK_INDICES_V2; passing 2 here "
+    "forces v2 regardless of the JK gate.",
+)
 @click.option("--requests_data_file", type=str, default=None)
 @click.option("--tables", type=str, default=None)
 @click.option(
@@ -307,6 +315,7 @@ def bounds_check_indices(  # noqa C901
     num_embeddings: int,
     num_tables: int,
     bounds_check_mode: int,
+    bounds_check_version: int,
     requests_data_file: Optional[str],
     tables: Optional[str],
     batch_sizes: str,
@@ -418,6 +427,7 @@ def bounds_check_indices(  # noqa C901
                 b_t_map=b_t_map,
                 info_B_num_bits=info_B_num_bits,
                 info_B_mask=info_B_mask,
+                bounds_check_version=bounds_check_version,
             ),
             num_warmups=warmup_runs,
         )

--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_v1.cu
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_v1.cu
@@ -55,30 +55,33 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel_v1(
   auto indices_end = offsets[b_t + 1];
   const index_t num_indices = indices.size(0);
 
-  if (bounds_check_mode == BoundsCheckMode::FATAL) {
-    CUDA_KERNEL_ASSERT(
-        indices_start >= 0 && "indices_start must be non-negative");
-    CUDA_KERNEL_ASSERT(
-        indices_start <= indices_end &&
-        "indices_start must not exceed indices_end");
-    CUDA_KERNEL_ASSERT(
-        indices_end <= num_indices &&
-        "indices_end must not exceed num_indices");
-  } else if (bounds_check_mode == BoundsCheckMode::WARNING) {
-    if (indices_start < 0 || indices_start > indices_end ||
-        indices_end > num_indices) {
-      if (gpuAtomicIncrement(&warning[0]) == 0) {
-        printf(
-            "EmbeddingBoundsCheck (VBE %s): (at least one) Out of bounds access for "
-            "batch: %d, table: %d, indices_start: %lld, indices_end: %lld,"
-            " num_indices: %lld. Setting indices_start and indices_end within "
-            "the range.\n",
-            vbe ? "true" : "false",
-            b,
-            t,
-            static_cast<int64_t>(indices_start),
-            static_cast<int64_t>(indices_end),
-            static_cast<int64_t>(num_indices));
+  // Condition first, then branch on mode.
+  if (indices_start < 0 || indices_start > indices_end ||
+      indices_end > num_indices) {
+    if (bounds_check_mode == BoundsCheckMode::FATAL) {
+      CUDA_KERNEL_ASSERT(
+          indices_start >= 0 && "indices_start must be non-negative");
+      CUDA_KERNEL_ASSERT(
+          indices_start <= indices_end &&
+          "indices_start must not exceed indices_end");
+      CUDA_KERNEL_ASSERT(
+          indices_end <= num_indices &&
+          "indices_end must not exceed num_indices");
+    } else {
+      if (bounds_check_mode == BoundsCheckMode::WARNING) {
+        if (gpuAtomicIncrement(&warning[0]) == 0) {
+          printf(
+              "EmbeddingBoundsCheck (VBE %s): (at least one) Out of bounds access for "
+              "batch: %d, table: %d, indices_start: %lld, indices_end: %lld,"
+              " num_indices: %lld. Setting indices_start and indices_end within "
+              "the range.\n",
+              vbe ? "true" : "false",
+              b,
+              t,
+              static_cast<int64_t>(indices_start),
+              static_cast<int64_t>(indices_end),
+              static_cast<int64_t>(num_indices));
+        }
       }
       adjust_offset_kernel(
           indices_start,
@@ -87,13 +90,6 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel_v1(
           &offsets[b_t],
           &offsets[b_t + 1]);
     }
-  } else if (bounds_check_mode == BoundsCheckMode::IGNORE) {
-    adjust_offset_kernel(
-        indices_start,
-        indices_end,
-        num_indices,
-        &offsets[b_t],
-        &offsets[b_t + 1]);
   }
 
   const auto L = indices_end - indices_start;

--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_v2.cu
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_v2.cu
@@ -85,30 +85,33 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel_v2(
     auto indices_start = offsets[b_t];
     auto indices_end = offsets[b_t + 1];
 
-    if (bounds_check_mode == BoundsCheckMode::FATAL) {
-      CUDA_KERNEL_ASSERT(
-          indices_start >= 0 && "indices_start must be non-negative");
-      CUDA_KERNEL_ASSERT(
-          indices_start <= indices_end &&
-          "indices_start must not exceed indices_end");
-      CUDA_KERNEL_ASSERT(
-          indices_end <= num_indices &&
-          "indices_end must not exceed num_indices");
-    } else if (bounds_check_mode == BoundsCheckMode::WARNING) {
-      if (indices_start < 0 || indices_start > indices_end ||
-          indices_end > num_indices) {
-        if (threadIdx.x == 0 && gpuAtomicIncrement(&warning[0]) == 0) {
-          printf(
-              "EmbeddingBoundsCheck (VBE %s): (at least one) Out of bounds access for "
-              "batch: %d, table: %d, indices_start: %lld, indices_end: %lld,"
-              " num_indices: %lld. Setting indices_start and indices_end within "
-              "the range.\n",
-              vbe ? "true" : "false",
-              b,
-              t,
-              static_cast<int64_t>(indices_start),
-              static_cast<int64_t>(indices_end),
-              static_cast<int64_t>(num_indices));
+    // Condition first, then branch on mode.
+    if (indices_start < 0 || indices_start > indices_end ||
+        indices_end > num_indices) {
+      if (bounds_check_mode == BoundsCheckMode::FATAL) {
+        CUDA_KERNEL_ASSERT(
+            indices_start >= 0 && "indices_start must be non-negative");
+        CUDA_KERNEL_ASSERT(
+            indices_start <= indices_end &&
+            "indices_start must not exceed indices_end");
+        CUDA_KERNEL_ASSERT(
+            indices_end <= num_indices &&
+            "indices_end must not exceed num_indices");
+      } else {
+        if (bounds_check_mode == BoundsCheckMode::WARNING) {
+          if (threadIdx.x == 0 && gpuAtomicIncrement(&warning[0]) == 0) {
+            printf(
+                "EmbeddingBoundsCheck (VBE %s): (at least one) Out of bounds access for "
+                "batch: %d, table: %d, indices_start: %lld, indices_end: %lld,"
+                " num_indices: %lld. Setting indices_start and indices_end within "
+                "the range.\n",
+                vbe ? "true" : "false",
+                b,
+                t,
+                static_cast<int64_t>(indices_start),
+                static_cast<int64_t>(indices_end),
+                static_cast<int64_t>(num_indices));
+          }
         }
         adjust_offset_kernel(
             indices_start,
@@ -117,13 +120,6 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel_v2(
             &offsets[b_t],
             &offsets[b_t + 1]);
       }
-    } else if (bounds_check_mode == BoundsCheckMode::IGNORE) {
-      adjust_offset_kernel(
-          indices_start,
-          indices_end,
-          num_indices,
-          &offsets[b_t],
-          &offsets[b_t + 1]);
     }
 
     const auto L = indices_end - indices_start;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2624


Phase 1 of the bounds_check_indices race-condition cleanup stack.

This is a pure refactor — no behavior change. The per-b_t offset validation in both v1 and v2 CUDA kernels is rewritten from mode-first to condition-first.

**Before (mode-first):**
```
if (FATAL) { asserts }
else if (WARNING) { if (bad) { warn + adjust } }
else if (IGNORE) { adjust unconditionally }
```

**After (condition-first):**
```
if (bad) {
  if (FATAL) { asserts }
  else { if (WARNING) { warn } adjust }
}
```

**Why**: the mode-first form had IGNORE call `adjust_offset_kernel` on every (b, t) pair, even when offsets were valid — wasted writes plus needless contention on the offsets buffer. Condition-first runs adjustment only when bounds are actually violated.

**Stack:**
- (this) Phase 1 — Condition-first refactor
- Phase 1.5 — Gate offset correction on lane 0 + shfl_sync broadcast
- Phase 2 — Make bad offsets unconditionally fatal

Reviewed By: q10

Differential Revision: D101718260


