### PR TITLE
Remove LEGACY parameter entirely from batch Quantize overload for API consistency

### DIFF
--- a/include/fbgemm/QuantUtils.h
+++ b/include/fbgemm/QuantUtils.h
@@ -63,14 +63,13 @@ T2 clamp(T1 src, int precision, bool is_signed = false) {
 
 /// Quantize src using zero_point and scale, clamp to the specified precision,
 /// and convert it to type T
-template <typename T, bool LEGACY = false>
+template <typename T>
 T Quantize(
     float src,
     std::int32_t zero_point,
     float scale,
     int result_precision,
     bool result_is_signed = std::is_signed_v<T>) {
-  static_assert(!LEGACY, "Legacy quantize is removed");
   // Note: We want to multiply with src with inv_scale instead of
   // dividing src by scale. The same is done in vector code and
   // at other places.
@@ -95,13 +94,12 @@ T Quantize(
   return clamp<double, T>(transformed_val, result_precision, result_is_signed);
 }
 
-template <typename T, bool LEGACY = false>
+template <typename T>
 T Quantize(float src, const TensorQuantizationParams& qparams) {
-  static_assert(!LEGACY, "Legacy quantize is removed");
   return Quantize<T>(src, qparams.zero_point, qparams.scale, qparams.precision);
 }
 
-template <typename T, bool LEGACY = false>
+template <typename T>
 FBGEMM_API void Quantize(
     const float* src,
     T* dst,

--- a/src/QuantUtils.cc
+++ b/src/QuantUtils.cc
@@ -198,7 +198,7 @@ void ChooseRequantizationMultiplier(
 
 #define FBGEMM_SPECIALIZED_QUANTIZE(T)                              \
   template <>                                                       \
-  FBGEMM_API void Quantize<T, false>(                               \
+  FBGEMM_API void Quantize<T>(                                      \
       const float* src,                                             \
       T* dst,                                                       \
       const int64_t len,                                            \
@@ -218,7 +218,7 @@ FBGEMM_SPECIALIZED_QUANTIZE(int32_t)
 
 #define FBGEMM_SPECIALIZED_QUANTIZE_AVX2(T)                                    \
   template <>                                                                  \
-  FBGEMM_API void Quantize<T, false>(                                          \
+  FBGEMM_API void Quantize<T>(                                                 \
       const float* src,                                                        \
       T* dst,                                                                  \
       int64_t len,                                                             \


### PR DESCRIPTION
Summary:
Remove the unused LEGACY template parameter from all three fbgemm::Quantize<T> overloads for API consistency

This diff removes the `LEGACY` bool template parameter from the `Quantize<T>` function templates in FBGEMM's `QuantUtils.h`. The `LEGACY` parameter was already dead code — it defaulted to `false` and was enforced by `static_assert(!LEGACY, "Legacy quantize is removed")`, meaning any caller passing `true` would fail at compile time. Removing it simplifies the API surface. Specifically:

1. **`Quantize<T>` scalar overload**: Removes `LEGACY` from `Quantize(float src, int32_t zero_point, float scale, int result_precision, ...)`
2. **`Quantize<T>` qparams overload**: Removes `LEGACY` from `Quantize(float src, const TensorQuantizationParams& qparams)`
3. **`Quantize<T>` batch overload**: Removes `LEGACY` from `Quantize(const float* src, T* dst, int64_t len, ...)`
4. **Explicit specializations**: Updates `FBGEMM_SPECIALIZED_QUANTIZE` and `FBGEMM_SPECIALIZED_QUANTIZE_AVX2` macros in `QuantUtils.cc`
5. **BUCK dependencies**: Adds missing dependencies to multiple library targets in both `fbcode/` and `xplat/` BUCK files

## Detailed Changes

### include/fbgemm/QuantUtils.h (fbcode + xplat)
- Changes `template <typename T, bool LEGACY = false>` → `template <typename T>` on all three `Quantize` overloads
- Removes the `static_assert(!LEGACY, "Legacy quantize is removed")` guards

### src/QuantUtils.cc (fbcode + xplat)
- Updates `FBGEMM_SPECIALIZED_QUANTIZE(T)` macro: `Quantize<T, false>` → `Quantize<T>`
- Updates `FBGEMM_SPECIALIZED_QUANTIZE_AVX2(T)` macro: `Quantize<T, false>` → `Quantize<T>`

### BUCK (fbcode + xplat)
- Adds `fbgemm`, `cpuinfo`, `gtest`, `mkl_lp64_omp` deps and `omp` external dep to multiple targets

Reviewed By: gchalump

Differential Revision: D100683749


