### PR TITLE
Fix OSS CI nightly failures: setuptools downgrade + cu128 deprecation

### DIFF
--- a/.github/scripts/generate_ci_matrix.py
+++ b/.github/scripts/generate_ci_matrix.py
@@ -297,17 +297,18 @@ class BuildConfigScheme:
 
     def cuda_versions(self) -> List[str]:
         if GitRepo.ref() == REFS_MAIN and GitRepo.event_name() == EVENT_NAME_PUSH:
-            return ["12.8.1"]
+            return ["12.6.3"]
         if self.repo_owner != REPO_OWNER_PYTORCH:
-            return ["12.8.1"]
+            return ["12.6.3"]
         if self.target == TARGET_HSTU:
             # FBGEMM HSTU is expensive, so conserve CI resources
-            return ["12.8.1"]
+            return ["12.6.3"]
         elif self.target == TARGET_GENAI:
-            return ["12.6.3", "12.8.1", "12.9.1", "13.0.2", "13.2.0"]
+            # CUDA 12.8 (cu128) nightly builds deprecated in PyTorch 2.12+
+            return ["12.6.3", "12.9.1", "13.0.2", "13.2.0"]
         else:
-            # GenAI is unable to support 11.8.0 anymore as of https://github.com/pytorch/FBGEMM/pull/4138
-            return ["12.6.3", "12.8.1", "12.9.1", "13.0.2", "13.2.0"]
+            # CUDA 12.8 (cu128) nightly builds deprecated in PyTorch 2.12+
+            return ["12.6.3", "12.9.1", "13.0.2", "13.2.0"]
 
     def rocm_versions(self) -> List[str]:
         if GitRepo.ref() == REFS_MAIN and GitRepo.event_name() == EVENT_NAME_PUSH:

--- a/.github/scripts/utils_pytorch.bash
+++ b/.github/scripts/utils_pytorch.bash
@@ -169,6 +169,13 @@ install_pytorch_pip () {
   # Install the torch package from PyTorch PIP (not PyPI)
   install_from_pytorch_pip "${env_name}" torch "${pytorch_channel_version}" "${pytorch_variant_type_version}" || return 1
 
+  # Workaround: The torch nightly wheel downgrades setuptools (e.g. 82 -> 78),
+  # which can break Python's package discovery and make torch un-importable.
+  # Reinstall setuptools to restore a working version.  Also install packaging,
+  # which is an undeclared dependency of torch nightly (T263209424).
+  # shellcheck disable=SC2086
+  conda run ${env_prefix} pip install --upgrade setuptools packaging || true
+
   # Check that PyTorch is importable
   (test_python_import_package "${env_name}" torch.distributed) || return 1
 


### PR DESCRIPTION
Summary:
All FBGEMM OSS CI variants are failing at the 'Install PyTorch (PIP) nightly'
step. Root causes:

1. **Torch nightly downgrades setuptools** (82 -> 78), breaking Python's package
   discovery. After pip install succeeds, `import torch` fails with
   `ModuleNotFoundError: No module named 'torch'`. Fix: reinstall setuptools
   and install packaging (undeclared torch dep, T263209424) after torch install.

2. **CUDA 12.8 (cu128) deprecated** in PyTorch 2.12+. Nightly wheels no longer
   published for cu128. Fix: replace 12.8.1 with 12.6.3 in CI matrix.

Differential Revision: D102202782


