### PR TITLE
Investigate OSS CI nightly failure: revert Python 3.10+ typing changes

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
@@ -9,7 +9,7 @@
 
 import enum
 import itertools
-from typing import Any
+from typing import Any, Dict  # noqa: F401
 
 import torch
 
@@ -276,7 +276,7 @@ class EmbOptimType(enum.Enum):
 # configs)
 class QuantizationConfig:
     def __init__(self) -> None:
-        self.config: dict[str, Any] = {}
+        self.config = {}  # type: Dict[str, Any]
 
     def get(self, name: str) -> int:
         return -1
@@ -286,17 +286,17 @@ class QuantizationConfig:
 # Compute necessary parameters in the constructor
 class FP8QuantizationConfig(QuantizationConfig):
     def __init__(self, exponent_bits: int, exponent_bias: int) -> None:
-        super().__init__()
-        self.config: dict[str, Any] = {
+        super(FP8QuantizationConfig, self).__init__()
+        self.config = {
             "exponent_bits": exponent_bits,
             "exponent_bias": exponent_bias,
             "max_position": (1 << ((1 << exponent_bits) - 2 - exponent_bias))
             * (2 - 2 ** (exponent_bits - 7)),
-        }
+        }  # type: Dict[str, Any]
 
     def get(self, name: str) -> int:
         if name not in self.config:
-            raise RuntimeError(f"{name} must be set in config")
+            raise RuntimeError("{} must be set in config".format(name))
         return self.config[name]
 
 

--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_inference_converter.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_inference_converter.py
@@ -10,7 +10,7 @@
 
 import logging
 import math
-from typing import cast
+from typing import cast, Optional
 
 import torch
 
@@ -35,13 +35,14 @@ from torch import Tensor  # usort:skip
 # TODO: add per-feature based converter option (based on embedding_specs during inference)
 # TODO: optimize embedding pruning and quantization latency.
 class SplitEmbInferenceConverter:
+    # pyre-fixme[3]: Return type must be annotated.
     def __init__(
         self,
         quantize_type: SparseType,
-        pruning_ratio: float | None,
+        pruning_ratio: Optional[float],
         use_array_for_index_remapping: bool = True,
-        quantization_config: QuantizationConfig | None = None,
-    ) -> None:
+        quantization_config: Optional[QuantizationConfig] = None,
+    ):
         self.quantize_type = quantize_type
         # TODO(yingz): Change the pruning ratio to per-table settings.
         self.pruning_ratio = pruning_ratio
@@ -52,9 +53,8 @@ class SplitEmbInferenceConverter:
         self._process_split_embs(model)
         return model
 
-    def _prune_by_weights_l2_norm(
-        self, new_num_rows: int, weights: Tensor
-    ) -> tuple[Tensor, float]:
+    # pyre-fixme[2]: Parameter must be annotated.
+    def _prune_by_weights_l2_norm(self, new_num_rows, weights) -> tuple[Tensor, float]:
         assert new_num_rows > 0
         from numpy.linalg import norm
 
@@ -76,13 +76,12 @@ class SplitEmbInferenceConverter:
         idx: int,
         num_rows: int,
         module: SplitTableBatchedEmbeddingBagsCodegen,
-    ) -> tuple[Tensor, Tensor | None]:
+    ) -> tuple[Tensor, Optional[Tensor]]:
         # TODO(yingz): Avoid DtoH / HtoD overhead.
         weights = module.split_embedding_weights()[idx].cpu()
-        pruning_ratio = self.pruning_ratio
-        if pruning_ratio is None:
+        if self.pruning_ratio is None:
             return (weights, None)
-        new_num_rows = int(math.ceil(num_rows * (1.0 - pruning_ratio)))
+        new_num_rows = int(math.ceil(num_rows * (1.0 - self.pruning_ratio)))  # type: ignore
         if new_num_rows == num_rows:
             return (weights, None)
 
@@ -92,7 +91,9 @@ class SplitEmbInferenceConverter:
             weights, indicators, threshold, torch.int32
         )
 
-    def _get_quantization_config(self, name: str) -> int:
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
+    def _get_quantization_config(self, name):
         quantization_config = self.quantization_config
         if quantization_config is None:
             raise RuntimeError("quantization_config must be set for FP8 weight")
@@ -100,7 +101,7 @@ class SplitEmbInferenceConverter:
 
     def _quantize_embs(
         self, weight: Tensor, weight_ty: SparseType
-    ) -> tuple[Tensor, Tensor | None]:
+    ) -> tuple[Tensor, Optional[Tensor]]:
         fp8_quant_config = cast(FP8QuantizationConfig, self.quantization_config)
         return quantize_embs(weight, weight_ty, fp8_quant_config)
 

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -11,7 +11,7 @@
 
 import enum
 from dataclasses import dataclass
-from typing import NamedTuple
+from typing import FrozenSet, NamedTuple, Optional, Tuple
 
 import torch
 from torch import Tensor
@@ -33,7 +33,8 @@ class EmbeddingLocation(enum.IntEnum):
     MTIA = 4
 
     @classmethod
-    def str_values(cls) -> list[str]:
+    # pyre-ignore[3]
+    def str_values(cls):
         return [
             "device",
             "managed",
@@ -43,7 +44,8 @@ class EmbeddingLocation(enum.IntEnum):
         ]
 
     @classmethod
-    def from_str(cls, key: str) -> "EmbeddingLocation":
+    # pyre-ignore[3]
+    def from_str(cls, key: str):
         lookup = {
             "device": EmbeddingLocation.DEVICE,
             "managed": EmbeddingLocation.MANAGED,
@@ -64,37 +66,37 @@ class EvictionPolicy(NamedTuple):
     eviction_strategy: int = (
         0  # 0: timestamp, 1: counter , 2: counter + timestamp, 3: feature l2 norm 4: timestamp threshold 5: feature score
     )
-    eviction_step_intervals: int | None = (
+    eviction_step_intervals: Optional[int] = (
         None  # trigger_step_interval if trigger mode is iteration
     )
-    eviction_mem_threshold_gb: int | None = (
+    eviction_mem_threshold_gb: Optional[int] = (
         None  # eviction trigger condition if trigger mode is mem_util
     )
-    counter_thresholds: list[int] | None = (
+    counter_thresholds: Optional[list[int]] = (
         None  # count_thresholds for each table if eviction strategy is counter
     )
-    ttls_in_mins: list[int] | None = (
+    ttls_in_mins: Optional[list[int]] = (
         None  # ttls_in_mins for each table if eviction strategy is timestamp
     )
-    counter_decay_rates: list[float] | None = (
+    counter_decay_rates: Optional[list[float]] = (
         None  # count_decay_rates for each table if eviction strategy is counter
     )
-    feature_score_counter_decay_rates: list[float] | None = (
+    feature_score_counter_decay_rates: Optional[list[float]] = (
         None  # feature_score_counter_decay_rates for each table if eviction strategy is feature score
     )
-    training_id_eviction_trigger_count: list[int] | None = (
+    training_id_eviction_trigger_count: Optional[list[int]] = (
         None  # Number of training IDs that, when exceeded, will trigger eviction for each table.
     )
-    training_id_keep_count: list[int] | None = (
+    training_id_keep_count: Optional[list[int]] = (
         None  # Target number of training IDs to retain in each table after eviction.
     )
-    l2_weight_thresholds: list[float] | None = (
+    l2_weight_thresholds: Optional[list[float]] = (
         None  # l2_weight_thresholds for each table if eviction strategy is feature l2 norm
     )
-    threshold_calculation_bucket_stride: float | None = (
+    threshold_calculation_bucket_stride: Optional[float] = (
         0.2  # The width of each feature score bucket used for threshold calculation in feature score-based eviction.
     )
-    threshold_calculation_bucket_num: int | None = (
+    threshold_calculation_bucket_num: Optional[int] = (
         1000000  # 1M, Total number of feature score buckets used for threshold calculation in feature score-based eviction.
     )
     interval_for_insufficient_eviction_s: int = (
@@ -110,14 +112,14 @@ class EvictionPolicy(NamedTuple):
     interval_for_feature_statistics_decay_s: int = (
         24 * 3600  # 1 day, interval for feature statistics decay
     )
-    meta_header_lens: list[int] | None = None  # metaheader length for each table
-    eviction_free_mem_threshold_gb: int | None = (
+    meta_header_lens: Optional[list[int]] = None  # metaheader length for each table
+    eviction_free_mem_threshold_gb: Optional[int] = (
         None  # Minimum free memory (in GB) required before triggering eviction when using free_mem trigger mode.
     )
-    eviction_free_mem_check_interval_batch: int | None = (
+    eviction_free_mem_check_interval_batch: Optional[int] = (
         None  # Number of batches between checks for free memory threshold when using free_mem trigger mode.
     )
-    enable_eviction_for_feature_score_eviction_policy: list[bool] | None = (
+    enable_eviction_for_feature_score_eviction_policy: Optional[list[bool]] = (
         None  # enable eviction if eviction policy is feature score, false means no eviction
     )
 
@@ -288,10 +290,10 @@ class KVZCHParams(NamedTuple):
     eviction_policy: EvictionPolicy = EvictionPolicy()
     embedding_cache_mode: bool = False
     load_ckpt_without_opt: bool = False
-    optimizer_type_for_st: str | None = None
-    optimizer_state_dtypes_for_st: frozenset[tuple[str, int]] | None = None
+    optimizer_type_for_st: Optional[str] = None
+    optimizer_state_dtypes_for_st: Optional[FrozenSet[Tuple[str, int]]] = None
     # Enrichment config for embedding cache enrichment from external sources
-    enrichment_policy: EnrichmentPolicy | None = None
+    enrichment_policy: Optional[EnrichmentPolicy] = None
     feature_score_collection_enabled: bool = False
 
     def validate(self) -> None:
@@ -315,15 +317,15 @@ class KVZCHTBEConfig(NamedTuple):
     # The width of each feature score bucket used for threshold calculation in feature score-based eviction.
     threshold_calculation_bucket_stride: float = 0.2
     # Total number of feature score buckets used for threshold calculation in feature score-based eviction.
-    threshold_calculation_bucket_num: int | None = 1000000  # 1M
+    threshold_calculation_bucket_num: Optional[int] = 1000000  # 1M
     # When true, we only save weight to kvzch backend and not optimizer state.
     load_ckpt_without_opt: bool = False
     # [DO NOT USE] This is for st publish only, do not set it in your config
-    optimizer_type_for_st: str | None = None
+    optimizer_type_for_st: Optional[str] = None
     # [DO NOT USE] This is for st publish only, do not set it in your config
-    optimizer_state_dtypes_for_st: frozenset[tuple[str, int]] | None = None
+    optimizer_state_dtypes_for_st: Optional[FrozenSet[Tuple[str, int]]] = None
     # Enrichment policy for embedding cache enrichment from external sources (e.g. Laser)
-    enrichment_policy: EnrichmentPolicy | None = None
+    enrichment_policy: Optional[EnrichmentPolicy] = None
 
 
 class BackendType(enum.IntEnum):
@@ -332,7 +334,8 @@ class BackendType(enum.IntEnum):
     PS = 2
 
     @classmethod
-    def from_str(cls, key: str) -> "BackendType":
+    # pyre-ignore[3]
+    def from_str(cls, key: str):
         lookup = {
             "ssd": BackendType.SSD,
             "dram": BackendType.DRAM,
@@ -370,7 +373,8 @@ class PoolingMode(enum.IntEnum):
         return self is not PoolingMode.NONE
 
     @classmethod
-    def from_str(cls, key: str) -> "PoolingMode":
+    # pyre-ignore[3]
+    def from_str(cls, key: str):
         lookup = {
             "sum": PoolingMode.SUM,
             "mean": PoolingMode.MEAN,

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
@@ -12,6 +12,7 @@
 import logging
 import uuid
 from itertools import accumulate
+from typing import Optional, Union
 
 import fbgemm_gpu  # noqa: F401
 import torch  # usort:skip
@@ -137,7 +138,7 @@ def nbit_construct_split_state(
 def random_quant_scaled_tensor(
     shape: torch.Size,
     device: torch.device,
-    output_tensor: torch.Tensor | None = None,
+    output_tensor: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     if output_tensor is not None:
         return torch.randint(
@@ -162,9 +163,9 @@ def random_quant_scaled_tensor(
 def inputs_to_device(
     indices: torch.Tensor,
     offsets: torch.Tensor,
-    per_sample_weights: torch.Tensor | None,
+    per_sample_weights: Optional[torch.Tensor],
     bounds_check_warning: torch.Tensor,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
     if bounds_check_warning.device.type == "meta":
         return indices, offsets, per_sample_weights
 
@@ -190,7 +191,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
     Inference version, with support for FP32/FP16/FP8/INT8/INT4/INT2 weights
 
     Args:
-        embedding_specs (list[tuple[int, int, EmbeddingLocation, ComputeDevice]]):
+        embedding_specs (List[Tuple[int, int, EmbeddingLocation, ComputeDevice]]):
             A list of embedding specifications. Each spec describes a
             specification of a physical embedding table. Each one is a tuple of
             number of embedding rows, embedding dimension (must be a multiple of
@@ -220,11 +221,11 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
             (3) `MTIA` = performing table lookup on MTIA
 
-        feature_table_map (list[int] | None = None): An optional list that
+        feature_table_map (Optional[List[int]] = None): An optional list that
             specifies feature-table mapping. feature_table_map[i] indicates the
             physical embedding table that feature i maps to.
 
-        index_remapping (list[Tensor] | None = None): Index remapping for pruning
+        index_remapping (Optional[List[Tensor]] = None): Index remapping for pruning
 
         pooling_mode (PoolingMode = PoolingMode.SUM): Pooling mode. Available
             `PoolingMode` options are
@@ -235,7 +236,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
             (3) `NONE` = No pooling (sequence embedding)
 
-        device (str | int | torch.device | None = None): The current
+        device (Optional[Union[str, int, torch.device]] = None): The current
             device to place tensors on
 
         bounds_check_mode (BoundsCheckMode = BoundsCheckMode.WARNING): Input
@@ -254,7 +255,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 invalid index to zero and adjusting an invalid offset to be
                 within the bound)
 
-        weight_lists (list[tuple[Tensor, Tensor | None]] | None = None):
+        weight_lists (Optional[List[Tuple[Tensor, Optional[Tensor]]]] = None):
             [T]
 
         pruning_hash_load_factor (float = 0.5):
@@ -289,21 +290,21 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         enforce_hbm (bool = False): If True, place all weights/momentums in HBM
             when using `EmbeddingLocation.MANAGED_CACHING`
 
-        record_cache_metrics (RecordCacheMetrics | None = None): Record
+        record_cache_metrics (Optional[RecordCacheMetrics] = None): Record
             a number of hits, a number of requests, etc if
             `RecordCacheMetrics.record_cache_miss_counter` is True and record
             the similar metrics table-wise if
             `RecordCacheMetrics.record_tablewise_cache_miss is True`
 
-        gather_uvm_cache_stats (bool | None = False): If True, collect the
+        gather_uvm_cache_stats (Optional[bool] = False): If True, collect the
             cache statistics when `EmbeddingLocation` is set to
             `MANAGED_CACHING`
 
-        row_alignment (int | None = None): Row alignment
+        row_alignment (Optional[int] = None): Row alignment
 
-        fp8_exponent_bits (int | None = None): Exponent bits when using FP8
+        fp8_exponent_bits (Optional[int] = None): Exponent bits when using FP8
 
-        fp8_exponent_bias (int | None = None): Exponent bias when using FP8
+        fp8_exponent_bias (Optional[int] = None): Exponent bias when using FP8
 
         cache_assoc (int = 32): Number of ways for cache
 
@@ -320,7 +321,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         reverse_qparam (bool = False): If True, load `qparams` at end of each
             row.  Otherwise, load `qparams` at begnning of each row.
 
-        feature_names_per_table (list[list[str]] | None = None): An optional
+        feature_names_per_table (Optional[List[List[str]]] = None): An optional
             list that specifies feature names per table. `feature_names_per_table[t]`
             indicates the feature names of table `t`.
 
@@ -348,12 +349,12 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         embedding_specs: list[
             tuple[str, int, int, SparseType, EmbeddingLocation]
         ],  # tuple of (feature_names, rows, dims, SparseType, EmbeddingLocation/placement)
-        feature_table_map: list[int] | None = None,  # [T]
-        index_remapping: list[Tensor] | None = None,
+        feature_table_map: Optional[list[int]] = None,  # [T]
+        index_remapping: Optional[list[Tensor]] = None,
         pooling_mode: PoolingMode = PoolingMode.SUM,
-        device: str | int | torch.device | None = None,
+        device: Optional[Union[str, int, torch.device]] = None,
         bounds_check_mode: BoundsCheckMode = BoundsCheckMode.WARNING,
-        weight_lists: list[tuple[Tensor, Tensor | None]] | None = None,
+        weight_lists: Optional[list[tuple[Tensor, Optional[Tensor]]]] = None,
         pruning_hash_load_factor: float = 0.5,
         use_array_for_index_remapping: bool = True,
         output_dtype: SparseType = SparseType.FP16,
@@ -362,20 +363,20 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         cache_sets: int = 0,
         cache_reserved_memory: float = 0.0,
         enforce_hbm: bool = False,  # place all weights/momentums in HBM when using cache
-        record_cache_metrics: RecordCacheMetrics | None = None,
-        gather_uvm_cache_stats: bool | None = False,
-        row_alignment: int | None = None,
-        fp8_exponent_bits: int | None = None,
-        fp8_exponent_bias: int | None = None,
+        record_cache_metrics: Optional[RecordCacheMetrics] = None,
+        gather_uvm_cache_stats: Optional[bool] = False,
+        row_alignment: Optional[int] = None,
+        fp8_exponent_bits: Optional[int] = None,
+        fp8_exponent_bias: Optional[int] = None,
         cache_assoc: int = 32,
         scale_bias_size_in_bytes: int = DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
         cacheline_alignment: bool = True,
         uvm_host_mapped: bool = False,  # True to use cudaHostAlloc; False to use cudaMallocManaged.
         reverse_qparam: bool = False,  # True to load qparams at end of each row; False to load qparam at begnning of each row.
-        feature_names_per_table: list[list[str]] | None = None,
+        feature_names_per_table: Optional[list[list[str]]] = None,
         indices_dtype: torch.dtype = torch.int32,  # Used for construction of the remap_indices tensors.  Should match the dtype of the indices passed in the forward() call (INT32 or INT64).
     ) -> None:  # noqa C901  # tuple of (rows, dims,)
-        super().__init__()
+        super(IntNBitTableBatchedEmbeddingBagsCodegen, self).__init__()
         self.uuid = str(uuid.uuid4())
         self.log(
             f"Feature Gates: {[(feature.name, feature.is_enabled()) for feature in FeatureGateName]}"
@@ -742,7 +743,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
     def prefetch(self, indices: Tensor, offsets: Tensor) -> None:
         self.timestep_counter.increment()
         self.timestep_prefetch_size.increment()
-        # pyre-fixme[29]: `(self: TensorBase) -> int | Module | Tensor` is not
+        # pyre-fixme[29]: `Union[(self: TensorBase) -> int, Module, Tensor]` is not
         #  a function.
         if not self.lxu_cache_weights.numel():
             return
@@ -926,8 +927,9 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         CACHE_MISS = torch.tensor([-1], device=self.current_device, dtype=torch.int32)
         CACHE_HIT = torch.tensor([-2], device=self.current_device, dtype=torch.int32)
 
-        cache_hash_size_cumsum: Tensor = self.cache_hash_size_cumsum  # pyre-fixme[9]
-        num_tables = len(cache_hash_size_cumsum) - 1
+        # pyre-fixme[6]: For 1st argument expected
+        #  `pyre_extensions.PyreReadOnly[Sized]` but got `Union[Module, Tensor]`.
+        num_tables = len(self.cache_hash_size_cumsum) - 1
         num_offsets_per_table = (len(offsets) - 1) // num_tables
         cache_missed_locations = torch.where(
             lxu_cache_locations == CACHE_MISS, linear_cache_indices, CACHE_HIT
@@ -949,7 +951,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self,
         indices: Tensor,
         offsets: Tensor,
-        per_sample_weights: Tensor | None = None,
+        per_sample_weights: Optional[Tensor] = None,
     ) -> Tensor:
         assert (
             self.weight_initialized
@@ -999,7 +1001,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 self.index_remappings_array,
                 self.index_remappings_array_offsets,
             )
-        # pyre-fixme[29]: `(self: TensorBase) -> int | Module | Tensor` is not
+        # pyre-fixme[29]: `Union[(self: TensorBase) -> int, Module, Tensor]` is not
         #  a function.
         if self.lxu_cache_weights.numel() > 0:
             if self.timestep_prefetch_size.get() <= 0:
@@ -1054,7 +1056,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self,
         indices: Tensor,
         offsets: Tensor,
-        per_sample_weights: Tensor | None = None,
+        per_sample_weights: Optional[Tensor] = None,
     ) -> Tensor:
         return self._forward_impl(
             indices=indices, offsets=offsets, per_sample_weights=per_sample_weights
@@ -1190,7 +1192,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         #  `lxu_cache_weights`.
         self.lxu_cache_weights = torch.empty_like(
             # pyre-fixme[6]: For 1st argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             self.lxu_cache_weights,
             device=self.current_device,
         )
@@ -1483,7 +1485,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
             self.reset_uvm_cache_stats()
 
     def reset_cache_states(self) -> None:
-        # pyre-fixme[29]: `(self: TensorBase) -> int | Module | Tensor` is not
+        # pyre-fixme[29]: `Union[(self: TensorBase) -> int, Module, Tensor]` is not
         #  a function.
         if not self.lxu_cache_weights.numel():
             return
@@ -1600,7 +1602,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
     @torch.jit.export
     def split_embedding_weights_with_scale_bias(
         self, split_scale_bias_mode: int = 1
-    ) -> list[tuple[Tensor, Tensor | None, Tensor | None]]:
+    ) -> list[tuple[Tensor, Optional[Tensor], Optional[Tensor]]]:
         """
         Returns a list of weights, split by table
         split_scale_bias_mode:
@@ -1609,7 +1611,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
             2: return weights, scale, bias.
         """
         assert self.weight_initialized
-        splits: list[tuple[Tensor, Tensor | None, Tensor | None]] = []
+        splits: list[tuple[Tensor, Optional[Tensor], Optional[Tensor]]] = []
         for t, (_, rows, dim, weight_ty, _) in enumerate(self.embedding_specs):
             placement = self.weights_physical_placements[t]
             if (
@@ -1734,12 +1736,12 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         # the second with scale_bias.
         # This should've been named as split_scale_bias.
         # Keep as is for backward compatibility.
-    ) -> list[tuple[Tensor, Tensor | None]]:
+    ) -> list[tuple[Tensor, Optional[Tensor]]]:
         """
         Returns a list of weights, split by table
         """
         # fmt: off
-        splits: list[tuple[Tensor, Tensor | None, Tensor | None]] = (
+        splits: list[tuple[Tensor, Optional[Tensor], Optional[Tensor]]] = (
             self.split_embedding_weights_with_scale_bias(
                 split_scale_bias_mode=(1 if split_scale_shifts else 0)
             )
@@ -1777,7 +1779,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
             )
 
     def assign_embedding_weights(
-        self, q_weight_list: list[tuple[Tensor, Tensor | None]]
+        self, q_weight_list: list[tuple[Tensor, Optional[Tensor]]]
     ) -> None:
         """
         Assigns self.split_embedding_weights() with values from the input list of weights and scale_shifts.
@@ -1920,7 +1922,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         row_size = len(update_row_indices)
         if row_size == 0:
             return
-        # pyre-fixme[9]: update_row_indices has type `list[int]`; used as `Tensor`.
+        # pyre-fixme[9]: update_row_indices has type `List[int]`; used as `Tensor`.
         update_row_indices = torch.tensor(
             update_row_indices,
             device=self.current_device,
@@ -1970,13 +1972,13 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
             update_offset += D_bytes
         update_offsets.append(update_offset)
 
-        # pyre-fixme[9]: update_table_indices has type `list[int]`; used as `Tensor`.
+        # pyre-fixme[9]: update_table_indices has type `List[int]`; used as `Tensor`.
         update_table_indices = torch.tensor(
             update_table_indices,
             device=self.current_device,
             dtype=torch.int32,
         )
-        # pyre-fixme[9]: update_row_indices has type `list[int]`; used as `Tensor`.
+        # pyre-fixme[9]: update_row_indices has type `List[int]`; used as `Tensor`.
         update_row_indices = torch.tensor(
             update_row_indices,
             device=self.current_device,
@@ -2002,7 +2004,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
             )
 
         lxu_cache_locations = None
-        # pyre-fixme[29]: `(self: TensorBase) -> int | Module | Tensor` is not
+        # pyre-fixme[29]: `Union[(self: TensorBase) -> int, Module, Tensor]` is not
         #  a function.
         if self.lxu_cache_weights.numel() > 0:
             linear_cache_indices = (

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -15,11 +15,10 @@ import logging
 import math
 import os
 import uuid
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from itertools import accumulate
 from math import log2
-from typing import Any
+from typing import Any, Callable, Optional, Union
 
 import torch  # usort:skip
 from torch import nn, Tensor  # usort:skip
@@ -217,8 +216,8 @@ class PrefetchedInfo:
         linear_unique_indices: torch.Tensor,
         linear_unique_cache_indices: torch.Tensor,
         linear_unique_indices_length: torch.Tensor,
-        hash_zch_identities: torch.Tensor | None,
-        hash_zch_runtime_meta: torch.Tensor | None,
+        hash_zch_identities: Optional[torch.Tensor],
+        hash_zch_runtime_meta: Optional[torch.Tensor],
     ) -> None:
         self.linear_unique_indices = linear_unique_indices
         self.linear_unique_cache_indices = linear_unique_cache_indices
@@ -233,7 +232,7 @@ def construct_split_state(
     cacheable: bool,
     precision: SparseType = SparseType.FP32,
     int8_emb_row_dim_offset: int = INT8_EMB_ROW_DIM_OFFSET,
-    placement: EmbeddingLocation | None = None,
+    placement: Optional[EmbeddingLocation] = None,
 ) -> SplitState:
     placements: list[EmbeddingLocation] = []
     offsets: list[int] = []
@@ -277,7 +276,9 @@ def construct_split_state(
 
 def apply_split_helper(
     persistent_state_fn: Callable[[str, Tensor], None],
-    set_attr_fn: Callable[[str, Tensor | list[int] | list[EmbeddingLocation]], None],
+    set_attr_fn: Callable[
+        [str, Union[Tensor, list[int], list[EmbeddingLocation]]], None
+    ],
     current_device: torch.device,
     use_cpu: bool,
     feature_table_map: list[int],
@@ -286,8 +287,8 @@ def apply_split_helper(
     dtype: type[torch.dtype],
     enforce_hbm: bool = False,
     make_dev_param: bool = False,
-    dev_reshape: tuple[int, ...] | None = None,
-    uvm_tensors_log: list[str] | None = None,
+    dev_reshape: Optional[tuple[int, ...]] = None,
+    uvm_tensors_log: Optional[list[str]] = None,
     uvm_host_mapped: bool = False,
     make_persistent: bool = False,
 ) -> None:
@@ -325,8 +326,8 @@ def apply_split_helper(
         host_buffer = torch.zeros(
             split.host_size,
             device=current_device,
-            # pyre-fixme[6]: Expected `type[torch._dtype] | None` for
-            #  3rd param but got `type[type[torch._dtype]]`.
+            # pyre-fixme[6]: Expected `Optional[Type[torch._dtype]]` for
+            #  3rd param but got `Type[Type[torch._dtype]]`.
             dtype=dtype,
         )
         if dtype == torch.uint8:
@@ -349,7 +350,7 @@ def apply_split_helper(
     else:
         persistent_state_fn(
             f"{prefix}_host",
-            # pyre-fixme[6]: For 3rd param expected `dtype` but got `type[dtype]`.
+            # pyre-fixme[6]: For 3rd param expected `dtype` but got `Type[dtype]`.
             torch.empty(0, device=current_device, dtype=dtype),
         )
     if split.uvm_size > 0:
@@ -361,8 +362,8 @@ def apply_split_helper(
                 torch.zeros(
                     split.uvm_size,
                     device=current_device,
-                    # pyre-fixme[6]: Expected `type[torch._dtype] | None` for
-                    #  3rd param but got `type[type[torch._dtype]]`.
+                    # pyre-fixme[6]: Expected `Optional[Type[torch._dtype]]` for
+                    #  3rd param but got `Type[Type[torch._dtype]]`.
                     dtype=dtype,
                 ),
             )
@@ -373,8 +374,8 @@ def apply_split_helper(
                     split.uvm_size,
                     device=current_device,
                     out=torch.ops.fbgemm.new_unified_tensor(
-                        # pyre-fixme[6]: Expected `type[torch._dtype] | None`
-                        #  for 3rd param but got `type[type[torch._dtype]]`.
+                        # pyre-fixme[6]: Expected `Optional[Type[torch._dtype]]`
+                        #  for 3rd param but got `Type[Type[torch._dtype]]`.
                         torch.zeros(1, device=current_device, dtype=dtype),
                         [split.uvm_size],
                         is_host_mapped=uvm_host_mapped,
@@ -386,7 +387,7 @@ def apply_split_helper(
     else:
         persistent_state_fn(
             f"{prefix}_uvm",
-            # pyre-fixme[6]: For 3rd param expected `dtype` but got `type[dtype]`.
+            # pyre-fixme[6]: For 3rd param expected `dtype` but got `Type[dtype]`.
             torch.empty(0, device=current_device, dtype=dtype),
         )
 
@@ -410,7 +411,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
     backward.
 
     Args:
-        embedding_specs (list[tuple[int, int, EmbeddingLocation, ComputeDevice]]):
+        embedding_specs (List[Tuple[int, int, EmbeddingLocation, ComputeDevice]]):
             A list of embedding specifications. Each spec describes a
             specification of a physical embedding table. Each one is a tuple of
             number of embedding rows, embedding dimension (must be a multiple of
@@ -440,7 +441,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
             (3) `MTIA` = performing table lookup on MTIA
 
-        feature_table_map (list[int] | None = None): An optional list that
+        feature_table_map (Optional[List[int]] = None): An optional list that
             specifies feature-table mapping. feature_table_map[i] indicates the
             physical embedding table that feature i maps to.
 
@@ -505,13 +506,13 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             (11) `NONE` = Not applying an optimizer update in the backward pass
                 and outputting a sparse weight gradient
 
-        record_cache_metrics (RecordCacheMetrics | None = None): Record
+        record_cache_metrics (Optional[RecordCacheMetrics] = None): Record
             a number of hits, a number of requests, etc if
             `RecordCacheMetrics.record_cache_miss_counter` is True and record
             the similar metrics table-wise if
             `RecordCacheMetrics.record_tablewise_cache_miss is True`
 
-        gather_uvm_cache_stats (bool | None = False): If True, collect the
+        gather_uvm_cache_stats (Optional[bool] = False): If True, collect the
             cache statistics when `EmbeddingLocation` is set to
             `MANAGED_CACHING`
 
@@ -553,16 +554,16 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
         beta2 (float = 0.999): The beta2 value used by LAMB and ADAM
 
-        ensemble_mode (EnsembleModeDefinition | None = None):
+        ensemble_mode (Optional[EnsembleModeDefinition] = None):
             Used by Ensemble Rowwise Adagrad
 
-        emainplace_mode (EmainplaceModeDefinition | None = None):
+        emainplace_mode (Optional[EmainplaceModeDefinition] = None):
             Used by EMA in-place Rowwise Adagrad
 
-        counter_based_regularization (CounterBasedRegularizationDefinition | None = None):
+        counter_based_regularization (Optional[CounterBasedRegularizationDefinition] = None):
             Used by Rowwise Adagrad
 
-        cowclip_regularization (CowClipDefinition | None = None): Used by
+        cowclip_regularization (Optional[CowClipDefinition] = None): Used by
             Rowwise Adagrad
 
         pooling_mode (PoolingMode = PoolingMode.SUM): Pooling mode. Available
@@ -574,7 +575,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
             (3) `NONE` = No pooling (sequence embedding)
 
-        device (str | int | torch.device | None = None): The current
+        device (Optional[Union[str, int, torch.device]] = None): The current
             device to place tensors on
 
         bounds_check_mode (BoundsCheckMode = BoundsCheckMode.WARNING): Input
@@ -606,28 +607,28 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             for prefetch, the optional `forward_stream` arg of prefetch
             function must be set.
 
-        stats_reporter_config (TBEStatsReporterConfig | None = None):
+        stats_reporter_config (Optional[TBEStatsReporterConfig] = None):
             A config for TBE stats reporter
 
-        table_names (list[str] | None = None): A list of embedding table
+        table_names (Optional[List[str]] = None): A list of embedding table
             names in this TBE
 
-        optimizer_state_dtypes (dict[str, SparseType] | None = None): A
+        optimizer_state_dtypes (Optional[Dict[str, SparseType]] = None): A
             optimizer state data types dict. Keys are the optimizer state names
             and values are their corresponding types
 
-        multipass_prefetch_config (MultiPassPrefetchConfig | None = None):
+        multipass_prefetch_config (Optional[MultiPassPrefetchConfig] = None):
             A config for multipass cache prefetching (when
             `EmbeddingLocation.MANAGED_CACHING` is used)
 
-        global_weight_decay (GlobalWeightDecayDefinition | None = None):
+        global_weight_decay (Optional[GlobalWeightDecayDefinition] = None):
             A config for global weight decay
 
         uvm_host_mapped (bool = False): If True, allocate every UVM tensor
             using `malloc` + `cudaHostRegister`. Otherwise use
             `cudaMallocManaged`
 
-        extra_optimizer_config UserEnabledConfigDefinition | None = None):
+        extra_optimizer_config Optional[UserEnabledConfigDefinition] = None):
             An extra config to enable certain modes for optimizer. These modes
             are not enabled by default.
             - `use_rowwise_bias_correction` is used in Adam to enable rowwise
@@ -641,7 +642,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             the embedding table offset tensor. Options are `torch.int32` and
             `torch.int64`
 
-        embedding_shard_info (list[tuple[int, int, int, int]] | None = None): the
+        embedding_shard_info (Optional[List[Tuple[int, int, int, int]]] = None): the
             information about shard position and pre-sharded table size. If not set,
             the table is not sharded.
             (preshard_table_height, preshard_table_dim, height_offset, dim_offset)
@@ -649,7 +650,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         enable_raw_embedding_streaming (bool = False): Whether to enable raw
             embedding streaming (RES) for streaming embedding table data.
 
-        res_params (RESParams | None = None): Parameters for raw embedding
+        res_params (Optional[RESParams] = None): Parameters for raw embedding
             streaming. If not provided and `enable_raw_embedding_streaming` is
             True, defaults to RESParams().
 
@@ -670,7 +671,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
     uuid: str
     # pyre-fixme[13]: Attribute `last_uvm_cache_print_state` is never initialized.
     last_uvm_cache_print_state: torch.Tensor
-    _vbe_B_offsets: torch.Tensor | None
+    _vbe_B_offsets: Optional[torch.Tensor]
     _vbe_max_B: int
 
     def __init__(  # noqa C901
@@ -678,18 +679,18 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         embedding_specs: list[
             tuple[int, int, EmbeddingLocation, ComputeDevice]
         ],  # tuple of (rows, dims, placements, compute_devices)
-        feature_table_map: list[int] | None = None,  # [T]
+        feature_table_map: Optional[list[int]] = None,  # [T]
         cache_algorithm: CacheAlgorithm = CacheAlgorithm.LRU,
         cache_load_factor: float = 0.2,
         cache_sets: int = 0,
         cache_reserved_memory: float = 0.0,
-        cache_precision: SparseType | None = None,
+        cache_precision: Optional[SparseType] = None,
         weights_precision: SparseType = SparseType.FP32,
         output_dtype: SparseType = SparseType.FP32,
         enforce_hbm: bool = False,
         optimizer: OptimType = OptimType.EXACT_SGD,
-        record_cache_metrics: RecordCacheMetrics | None = None,
-        gather_uvm_cache_stats: bool | None = False,
+        record_cache_metrics: Optional[RecordCacheMetrics] = None,
+        gather_uvm_cache_stats: Optional[bool] = False,
         # General Optimizer args
         stochastic_rounding: bool = True,
         gradient_clipping: bool = False,
@@ -703,34 +704,34 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         eta: float = 0.001,
         beta1: float = 0.9,
         beta2: float = 0.999,
-        ensemble_mode: EnsembleModeDefinition | None = None,
-        emainplace_mode: EmainplaceModeDefinition | None = None,
-        counter_based_regularization: None | (
+        ensemble_mode: Optional[EnsembleModeDefinition] = None,
+        emainplace_mode: Optional[EmainplaceModeDefinition] = None,
+        counter_based_regularization: Optional[
             CounterBasedRegularizationDefinition
-        ) = None,
-        cowclip_regularization: CowClipDefinition | None = None,
+        ] = None,
+        cowclip_regularization: Optional[CowClipDefinition] = None,
         pooling_mode: PoolingMode = PoolingMode.SUM,
-        device: str | int | torch.device | None = None,
+        device: Optional[Union[str, int, torch.device]] = None,
         bounds_check_mode: BoundsCheckMode = BoundsCheckMode.WARNING,
         uvm_non_rowwise_momentum: bool = False,
         use_experimental_tbe: bool = False,
         prefetch_pipeline: bool = False,
-        stats_reporter_config: TBEStatsReporterConfig | None = None,
-        table_names: list[str] | None = None,
-        optimizer_state_dtypes: dict[str, SparseType] | None = None,
-        multipass_prefetch_config: MultiPassPrefetchConfig | None = None,
-        global_weight_decay: GlobalWeightDecayDefinition | None = None,
+        stats_reporter_config: Optional[TBEStatsReporterConfig] = None,
+        table_names: Optional[list[str]] = None,
+        optimizer_state_dtypes: Optional[dict[str, SparseType]] = None,
+        multipass_prefetch_config: Optional[MultiPassPrefetchConfig] = None,
+        global_weight_decay: Optional[GlobalWeightDecayDefinition] = None,
         uvm_host_mapped: bool = False,
-        extra_optimizer_config: UserEnabledConfigDefinition | None = None,
-        tbe_input_multiplexer_config: TBEInputMultiplexerConfig | None = None,
+        extra_optimizer_config: Optional[UserEnabledConfigDefinition] = None,
+        tbe_input_multiplexer_config: Optional[TBEInputMultiplexerConfig] = None,
         embedding_table_index_type: torch.dtype = torch.int64,
         embedding_table_offset_type: torch.dtype = torch.int64,
-        embedding_shard_info: list[tuple[int, int, int, int]] | None = None,
+        embedding_shard_info: Optional[list[tuple[int, int, int, int]]] = None,
         enable_raw_embedding_streaming: bool = False,
-        res_params: RESParams | None = None,
+        res_params: Optional[RESParams] = None,
         is_qr_tbe: bool = False,
     ) -> None:
-        super().__init__()
+        super(SplitTableBatchedEmbeddingBagsCodegen, self).__init__()
         self.uuid = str(uuid.uuid4())
         self.log("SplitTableBatchedEmbeddingBagsCodegen API: V2")
         self.log(f"SplitTableBatchedEmbeddingBagsCodegen Arguments: {locals()}")
@@ -738,7 +739,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             f"Feature Gates: {[(feature.name, feature.is_enabled()) for feature in FeatureGateName]}"
         )
 
-        self.table_names: list[str] | None = table_names
+        self.table_names: Optional[list[str]] = table_names
         self.logging_table_name: str = self.get_table_name_for_logging(table_names)
         self.enable_raw_embedding_streaming: bool = enable_raw_embedding_streaming
         self.pooling_mode = pooling_mode
@@ -794,7 +795,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.prefetch_pipeline: bool = prefetch_pipeline
         self.lock_cache_line: bool = self.prefetch_pipeline
         self.use_uniq_cache_locations_bwd: bool = self.prefetch_pipeline
-        self.multipass_prefetch_config: MultiPassPrefetchConfig | None = (
+        self.multipass_prefetch_config: Optional[MultiPassPrefetchConfig] = (
             multipass_prefetch_config
         )
 
@@ -899,13 +900,13 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         # Reporter to collect runtime performance stats bottom-up. Reporter may
         # do aggregation across TBEs and publish results per training batch.
         # Example of stats include UVM cache hit rate, table I/O size, etc.
-        self.stats_reporter: TBEStatsReporter | None = (
+        self.stats_reporter: Optional[TBEStatsReporter] = (
             stats_reporter_config.create_reporter() if stats_reporter_config else None
         )
         self._uvm_tensors_log: list[str] = []
 
-        self.bwd_wait_prefetch_timer: AsyncSeriesTimer | None = None
-        self.prefetch_duration_timer: AsyncSeriesTimer | None = None
+        self.bwd_wait_prefetch_timer: Optional[AsyncSeriesTimer] = None
+        self.prefetch_duration_timer: Optional[AsyncSeriesTimer] = None
         if self.stats_reporter:
             # When stats_reporter is present, we set up async series timer to
             # measure the GPU time per tracked event accordingly. Each of them
@@ -943,7 +944,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             full_table_dims = dims
             row_offset = [0] * len(rows)
             col_offset = [0] * len(rows)
-        self.tbe_input_multiplexer: TBEInputMultiplexer | None = (
+        self.tbe_input_multiplexer: Optional[TBEInputMultiplexer] = (
             tbe_input_multiplexer_config.create_tbe_input_multiplexer(
                 tbe_info=TBEInfo(
                     table_names=(
@@ -1051,8 +1052,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self._apply_split(
             weight_split,
             prefix="weights",
-            # pyre-fixme[6]: For 3rd param expected `type[type[_dtype]]` but got
-            #  `type[_dtype]`.
+            # pyre-fixme[6]: For 3rd param expected `Type[Type[_dtype]]` but got
+            #  `Type[_dtype]`.
             dtype=table_embedding_dtype,
             enforce_hbm=enforce_hbm,
             make_dev_param=optimizer == OptimType.NONE,
@@ -1263,8 +1264,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                         ),
                     ),
                     prefix="momentum1",
-                    # pyre-fixme[6]: Expected `type[type[torch._dtype]]` for 3rd param
-                    #  but got `type[torch.float32]`.
+                    # pyre-fixme[6]: Expected `Type[Type[torch._dtype]]` for 3rd param
+                    #  but got `Type[torch.float32]`.
                     dtype=momentum1_dtype,
                     enforce_hbm=enforce_hbm,
                     uvm_host_mapped=self.uvm_host_mapped,
@@ -1300,8 +1301,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                         ),
                     ),
                     prefix="momentum2",
-                    # pyre-fixme[6]: Expected `type[type[torch._dtype]]` for 3rd param
-                    #  but got `type[torch.float32]`.
+                    # pyre-fixme[6]: Expected `Type[Type[torch._dtype]]` for 3rd param
+                    #  but got `Type[torch.float32]`.
                     dtype=momentum2_dtype,
                     uvm_host_mapped=self.uvm_host_mapped,
                 )
@@ -1319,8 +1320,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                     # TODO: ideally we should use int64 to track iter but it failed to compile.
                     # It may be related to low precision training code. Currently using float32
                     # as a workaround while investigating the issue.
-                    # pyre-fixme[6]: Expected `type[type[torch._dtype]]` for 3rd param
-                    #  but got `type[torch.float32]`.
+                    # pyre-fixme[6]: Expected `Type[Type[torch._dtype]]` for 3rd param
+                    #  but got `Type[torch.float32]`.
                     dtype=torch.float32,
                     uvm_host_mapped=self.uvm_host_mapped,
                 )
@@ -1331,8 +1332,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                         cacheable=False,
                     ),
                     prefix="row_counter",
-                    # pyre-fixme[6]: Expected `type[type[torch._dtype]]` for 3rd param
-                    #  but got `type[torch.float32]`.
+                    # pyre-fixme[6]: Expected `Type[Type[torch._dtype]]` for 3rd param
+                    #  but got `Type[torch.float32]`.
                     dtype=torch.float32,
                     uvm_host_mapped=self.uvm_host_mapped,
                 )
@@ -1350,8 +1351,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                     # TODO: ideally we should use int64 to track iter but it failed to compile.
                     # It may be related to low precision training code. Currently using float32
                     # as a workaround while investigating the issue.
-                    # pyre-fixme[6]: Expected `type[type[torch._dtype]]` for 3rd param
-                    #  but got `type[torch.float32]`.
+                    # pyre-fixme[6]: Expected `Type[Type[torch._dtype]]` for 3rd param
+                    #  but got `Type[torch.float32]`.
                     dtype=torch.float32,
                     uvm_host_mapped=self.uvm_host_mapped,
                 )
@@ -1369,8 +1370,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                         cacheable=False,
                     ),
                     prefix="row_counter",
-                    # pyre-fixme[6]: Expected `type[type[torch._dtype]]` for 3rd param
-                    #  but got `type[torch.float32]`.
+                    # pyre-fixme[6]: Expected `Type[Type[torch._dtype]]` for 3rd param
+                    #  but got `Type[torch.float32]`.
                     dtype=torch.float32,
                     uvm_host_mapped=self.uvm_host_mapped,
                 )
@@ -1476,7 +1477,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self._writeback_first_feature_only: bool = (
             extra_optimizer_config.writeback_first_feature_only
         )
-        self._writeback_precomputed_index: Tensor | None = None
+        self._writeback_precomputed_index: Optional[Tensor] = None
         self._precompute_writeback: bool = extra_optimizer_config.precompute_writeback
 
         # Get a debug function pointer
@@ -1494,7 +1495,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             self.log(
                 f"SplitTableBatchedEmbeddingBagsCodegen:  use_writeback_bwd_prehook is enabled with first feature only={self._writeback_first_feature_only}"
             )
-            # pyre-fixme[6]: Expected `typing.Callable[[Module, Tensor | typing.tuple[Tensor, ...]], None | Tensor | typing.tuple[Tensor, ...]]`
+            # pyre-fixme[6]: Expected `typing.Callable[[Module, Union[Tensor, typing.Tuple[Tensor, ...]]], Union[None, Tensor, typing.Tuple[Tensor, ...]]]`
             self.register_full_backward_pre_hook(self.writeback_hook)
 
         if embedding_table_index_type not in [torch.int32, torch.int64]:
@@ -1565,7 +1566,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 torch.zeros(
                     1,
                     device=self.current_device,
-                    # pyre-ignore Incompatible parameter type [6]: In call `torch._C._VariableFunctions.empty`, for argument `dtype`, expected `dtype | None` but got `Module | dtype | Tensor`
+                    # pyre-ignore Incompatible parameter type [6]: In call `torch._C._VariableFunctions.empty`, for argument `dtype`, expected `Optional[dtype]` but got `Union[Module, dtype, Tensor]`
                     dtype=self.lxu_cache_weights.dtype,
                 ),
                 self.lxu_cache_weights.shape,
@@ -1634,7 +1635,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 0,
                 0,
                 device=self.current_device,
-                # pyre-ignore Incompatible parameter type [6]: In call `torch._C._VariableFunctions.zeros`, for argument `dtype`, expected `dtype | None` but got `Module | dtype | Tensor`
+                # pyre-ignore Incompatible parameter type [6]: In call `torch._C._VariableFunctions.zeros`, for argument `dtype`, expected `Optional[dtype]` but got `Union[Module, dtype, Tensor]`
                 dtype=self.lxu_cache_weights.dtype,
             ),
         )
@@ -1699,14 +1700,14 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         )
 
     @staticmethod
-    def get_table_name_for_logging(table_names: list[str] | None) -> str:
+    def get_table_name_for_logging(table_names: Optional[list[str]]) -> str:
         """
         Given a list of all table names in the TBE, generate a string to
         represent them in logging. If there is more than one table, this method
         will count them than list them.
 
         Args:
-            table_names (list[str] | None): A list of table anmes in TBE
+            table_names (Optional[List[str]]): A list of table anmes in TBE
 
         Returns:
             A string that represents tables in logging
@@ -1722,7 +1723,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
     @staticmethod
     def get_prefetch_passes(
-        multipass_prefetch_config: MultiPassPrefetchConfig | None,
+        multipass_prefetch_config: Optional[MultiPassPrefetchConfig],
         input_tensor: Tensor,
         output_tensor: Tensor,
     ) -> list[tuple[Tensor, Tensor, int]]:
@@ -1739,7 +1740,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         itself.
 
         Args:
-            multipass_prefetch_config (MultiPassPrefetchConfig | None):
+            multipass_prefetch_config (Optional[MultiPassPrefetchConfig]):
                 A config for multi-pass cache prefetch. If None, multi-pass
                 prefetch is not used.
 
@@ -1748,7 +1749,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             output_tensor (Tensor): The output tensor to be partitioned
 
         Returns:
-            A list of partitioned inputs and outputs (list[tuple[Tensor,
+            A list of partitioned inputs and outputs (List[Tuple[Tensor,
                 Tensor, int]])
         """
         if multipass_prefetch_config is None:
@@ -1844,7 +1845,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         Returns:
             The cache miss counter
         """
-        # pyre-fixme[7]: Expected `Tensor` but got `Module | Tensor`.
+        # pyre-fixme[7]: Expected `Tensor` but got `Union[Module, Tensor]`.
         return self.cache_miss_counter
 
     @torch.jit.export
@@ -2187,9 +2188,9 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
     def _generate_vbe_metadata(
         self,
         offsets: Tensor,
-        batch_size_per_feature_per_rank: list[list[int]] | None,
-        vbe_output: Tensor | None = None,
-        vbe_output_offsets: Tensor | None = None,
+        batch_size_per_feature_per_rank: Optional[list[list[int]]],
+        vbe_output: Optional[Tensor] = None,
+        vbe_output_offsets: Optional[Tensor] = None,
     ) -> invokers.lookup_args.VBEMetadata:
         # Blocking D2H copy, but only runs at first call
         self.feature_dims = self.feature_dims.cpu()
@@ -2238,14 +2239,14 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self,
         indices: Tensor,
         offsets: Tensor,
-        per_sample_weights: Tensor | None = None,
-        feature_requires_grad: Tensor | None = None,
-        batch_size_per_feature_per_rank: list[list[int]] | None = None,
-        total_unique_indices: int | None = None,
-        hash_zch_identities: Tensor | None = None,
-        hash_zch_runtime_meta: Tensor | None = None,
-        vbe_output: Tensor | None = None,
-        vbe_output_offsets: Tensor | None = None,
+        per_sample_weights: Optional[Tensor] = None,
+        feature_requires_grad: Optional[Tensor] = None,
+        batch_size_per_feature_per_rank: Optional[list[list[int]]] = None,
+        total_unique_indices: Optional[int] = None,
+        hash_zch_identities: Optional[Tensor] = None,
+        hash_zch_runtime_meta: Optional[Tensor] = None,
+        vbe_output: Optional[Tensor] = None,
+        vbe_output_offsets: Optional[Tensor] = None,
     ) -> Tensor:
         """
         The forward pass function that
@@ -2271,7 +2272,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 of features.  `offsets[t * B + b + 1] - offsets[t * B + b]` is
                 the length of bag `b` of feature `t`
 
-            per_sample_weights (Tensor | None): An optional 1D-float-tensor that
+            per_sample_weights (Optional[Tensor]): An optional 1D-float-tensor that
                 contains per sample weights. If None, **unweighted** embedding
                 lookup will be perform. Otherwise, **weighted** will be used. The
                 length of this tensor must be the same as the length of the
@@ -2279,11 +2280,11 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 used to multiply with every element in the looked up row
                 `indices[i]`, where `0 <= i < len(per_sample_weights)`.
 
-            feature_requires_grad (Tensor | None): An optional 1D-tensor for
+            feature_requires_grad (Optional[Tensor]): An optional 1D-tensor for
                 indicating if `per_sample_weights` requires gradient. The
                 length of the tensor must be equal to the number of features
 
-            batch_size_per_feature_per_rank (list[list[int]] | None): An
+            batch_size_per_feature_per_rank (Optional[List[List[int]]]): An
                 optional 2D-tensor that contains batch sizes for every rank and
                 every feature. If None, TBE assumes that **every feature has the
                 same batch size** and computes the batch size from the `offsets`
@@ -2293,23 +2294,23 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 number of ranks). `batch_size_per_feature_per_rank[f][r]`
                 represents the batch size of feature `f` and rank `r`
 
-            total_unique_indices (int | None): An optional integer that
+            total_unique_indices (Optional[int]): An optional integer that
                 represents the total number of unique indices. This value must
                 be set when using `OptimType.NONE`. This is because TBE
                 requires this information for allocating the weight gradient
                 tensor in the backward pass.
-            hash_zch_identities (Tensor | None): The original raw IDs before
+            hash_zch_identities (Optional[Tensor]): The original raw IDs before
                 remapping to ZCH (Zero-Collision Hash) table slots. This tensor is
                 populated when using Multi-Probe Zero Collision Hash (MPZCH) modules
                 and is required for Raw Embedding Streaming (RES) to maintain
                 consistency between training and inference.
-            vbe_output (Tensor | None): An optional 2-D tensor of size that
+            vbe_output (Optional[Tensor]): An optional 2-D tensor of size that
                 contains output for TBE VBE. The shape of the tensor is
                 [1, total_vbe_output_size] where total_vbe_output_size is the
                 output size across all ranks and all embedding tables.
                 If this tensor is not None, the TBE VBE forward output is written
                 to this tensor at the locations specified by `vbe_output_offsets`.
-            vbe_output_offsets (Tensor | None): An optional 2-D tensor that
+            vbe_output_offsets (Optional[Tensor]): An optional 2-D tensor that
                 contains VBE output offsets to `vbe_output`. The shape of the
                 tensor is [num_ranks, num_features].
                 vbe_output_offsets[r][f] represents the starting offset for rank `r`
@@ -2474,22 +2475,22 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         common_args = invokers.lookup_args.CommonArgs(
             placeholder_autograd_tensor=self.placeholder_autograd_tensor,
             # pyre-fixme[6]: For 2nd argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             dev_weights=self.weights_dev,
             # pyre-fixme[6]: For 3rd argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             host_weights=self.weights_host,
             # pyre-fixme[6]: For 4th argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             uvm_weights=self.weights_uvm,
             # pyre-fixme[6]: For 5th argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             lxu_cache_weights=self.lxu_cache_weights,
             # pyre-fixme[6]: For 6th argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             weights_placements=self.weights_placements,
             # pyre-fixme[6]: For 7th argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             weights_offsets=self.weights_offsets,
             D_offsets=self.D_offsets,
             total_D=self.total_D,
@@ -2542,19 +2543,19 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
         momentum1 = invokers.lookup_args.Momentum(
             # pyre-fixme[6]: For 1st argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             dev=self.momentum1_dev,
             # pyre-fixme[6]: For 2nd argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             host=self.momentum1_host,
             # pyre-fixme[6]: For 3rd argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             uvm=self.momentum1_uvm,
             # pyre-fixme[6]: For 4th argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             offsets=self.momentum1_offsets,
             # pyre-fixme[6]: For 5th argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             placements=self.momentum1_placements,
         )
 
@@ -2575,19 +2576,19 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
         momentum2 = invokers.lookup_args.Momentum(
             # pyre-fixme[6]: For 1st argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             dev=self.momentum2_dev,
             # pyre-fixme[6]: For 2nd argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             host=self.momentum2_host,
             # pyre-fixme[6]: For 3rd argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             uvm=self.momentum2_uvm,
             # pyre-fixme[6]: For 4th argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             offsets=self.momentum2_offsets,
             # pyre-fixme[6]: For 5th argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             placements=self.momentum2_placements,
         )
 
@@ -2608,19 +2609,19 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
         row_counter = invokers.lookup_args.Momentum(
             # pyre-fixme[6]: For 1st argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             dev=self.row_counter_dev,
             # pyre-fixme[6]: For 2nd argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             host=self.row_counter_host,
             # pyre-fixme[6]: For 3rd argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             uvm=self.row_counter_uvm,
             # pyre-fixme[6]: For 4th argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             offsets=self.row_counter_offsets,
             # pyre-fixme[6]: For 5th argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             placements=self.row_counter_placements,
         )
 
@@ -2674,19 +2675,19 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
         prev_iter = invokers.lookup_args.Momentum(
             # pyre-fixme[6]: For 1st argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             dev=self.prev_iter_dev,
             # pyre-fixme[6]: For 2nd argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             host=self.prev_iter_host,
             # pyre-fixme[6]: For 3rd argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             uvm=self.prev_iter_uvm,
             # pyre-fixme[6]: For 4th argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             offsets=self.prev_iter_offsets,
             # pyre-fixme[6]: For 5th argument expected `Tensor` but got
-            #  `Module | Tensor`.
+            #  `Union[Module, Tensor]`.
             placements=self.prev_iter_placements,
         )
 
@@ -2758,7 +2759,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                         iter=iter_int,
                         apply_global_weight_decay=apply_global_weight_decay,
                         # pyre-fixme[6]: For 6th argument expected
-                        #  `Tensor | None` but got `Module | Tensor`.
+                        #  `Optional[Tensor]` but got `Union[Module, Tensor]`.
                         prev_iter_dev=self.prev_iter_dev,
                         gwd_lower_bound=self.gwd_lower_bound,
                         mixed_D=self.mixed_D,
@@ -2926,7 +2927,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             )
         self.last_reported_uvm_stats = uvm_cache_stats
 
-        # pyre-fixme[29]: `(self: TensorBase) -> int | Module | Tensor` is not
+        # pyre-fixme[29]: `Union[(self: TensorBase) -> int, Module, Tensor]` is not
         #  a function.
         element_size = self.lxu_cache_weights.element_size()
         for stat_index in UVMCacheStatsIndex:
@@ -2947,8 +2948,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self,
         indices: Tensor,
         offsets: Tensor,
-        forward_stream: torch.cuda.Stream | None = None,
-        batch_size_per_feature_per_rank: list[list[int]] | None = None,
+        forward_stream: Optional[torch.cuda.Stream] = None,
+        batch_size_per_feature_per_rank: Optional[list[list[int]]] = None,
     ) -> None:
         if self.prefetch_stream is None and forward_stream is not None:
             self.prefetch_stream = torch.cuda.current_stream()
@@ -2985,17 +2986,17 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self,
         indices: Tensor,
         offsets: Tensor,
-        vbe_metadata: invokers.lookup_args.VBEMetadata | None = None,
-        multipass_prefetch_config: MultiPassPrefetchConfig | None = None,
-        hash_zch_identities: Tensor | None = None,
-        hash_zch_runtime_meta: Tensor | None = None,
+        vbe_metadata: Optional[invokers.lookup_args.VBEMetadata] = None,
+        multipass_prefetch_config: Optional[MultiPassPrefetchConfig] = None,
+        hash_zch_identities: Optional[Tensor] = None,
+        hash_zch_runtime_meta: Optional[Tensor] = None,
     ) -> None:
         if not is_torchdynamo_compiling():
             # Mutations of nn.Module attr forces dynamo restart of Analysis which increases compilation time
             self.timestep += 1
             self.timesteps_prefetched.append(self.timestep)
 
-        # pyre-fixme[29]: `(self: TensorBase) -> int | Module | Tensor` is not
+        # pyre-fixme[29]: `Union[(self: TensorBase) -> int, Module, Tensor]` is not
         #  a function.
         if not self.lxu_cache_weights.numel():
             return
@@ -3173,8 +3174,9 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         CACHE_MISS = -1
         CACHE_HIT = -2
 
-        cache_hash_size_cumsum: Tensor = self.cache_hash_size_cumsum  # pyre-fixme[9]
-        num_tables = len(cache_hash_size_cumsum) - 1
+        # pyre-fixme[6]: For 1st argument expected
+        #  `pyre_extensions.PyreReadOnly[Sized]` but got `Union[Module, Tensor]`.
+        num_tables = len(self.cache_hash_size_cumsum) - 1
         num_offsets_per_table = (len(offsets) - 1) // num_tables
         cache_missed_locations = torch.where(
             lxu_cache_locations == CACHE_MISS, linear_cache_indices, CACHE_HIT
@@ -3253,7 +3255,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 weights = self.weights_host
             else:
                 weights = self.weights_uvm
-            # pyre-fixme[29]: `(self: TensorBase) -> int | Module | Tensor` is
+            # pyre-fixme[29]: `Union[(self: TensorBase) -> int, Module, Tensor]` is
             #  not a function.
             if weights.dim() == 2:
                 weights = weights.flatten()
@@ -3430,19 +3432,19 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             states.append(
                 get_optimizer_states(
                     # pyre-fixme[6]: For 1st argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.momentum1_dev,
                     # pyre-fixme[6]: For 2nd argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.momentum1_host,
                     # pyre-fixme[6]: For 3rd argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.momentum1_uvm,
                     # pyre-fixme[6]: For 4th argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.momentum1_physical_offsets,
                     # pyre-fixme[6]: For 5th argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.momentum1_physical_placements,
                     rowwise=self.optimizer
                     in [
@@ -3462,19 +3464,19 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             states.append(
                 get_optimizer_states(
                     # pyre-fixme[6]: For 1st argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.momentum2_dev,
                     # pyre-fixme[6]: For 2nd argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.momentum2_host,
                     # pyre-fixme[6]: For 3rd argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.momentum2_uvm,
                     # pyre-fixme[6]: For 4th argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.momentum2_physical_offsets,
                     # pyre-fixme[6]: For 5th argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.momentum2_physical_placements,
                     rowwise=self.optimizer
                     in (OptimType.PARTIAL_ROWWISE_ADAM, OptimType.PARTIAL_ROWWISE_LAMB),
@@ -3487,19 +3489,19 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             states.append(
                 get_optimizer_states(
                     # pyre-fixme[6]: For 1st argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.prev_iter_dev,
                     # pyre-fixme[6]: For 2nd argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.prev_iter_host,
                     # pyre-fixme[6]: For 3rd argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.prev_iter_uvm,
                     # pyre-fixme[6]: For 4th argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.prev_iter_physical_offsets,
                     # pyre-fixme[6]: For 5th argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.prev_iter_physical_placements,
                     rowwise=True,
                 )
@@ -3510,19 +3512,19 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             states.append(
                 get_optimizer_states(
                     # pyre-fixme[6]: For 1st argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.row_counter_dev,
                     # pyre-fixme[6]: For 2nd argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.row_counter_host,
                     # pyre-fixme[6]: For 3rd argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.row_counter_uvm,
                     # pyre-fixme[6]: For 4th argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.row_counter_physical_offsets,
                     # pyre-fixme[6]: For 5th argument expected `Tensor` but got
-                    #  `Module | Tensor`.
+                    #  `Union[Module, Tensor]`.
                     self.row_counter_physical_placements,
                     rowwise=True,
                 )
@@ -3556,7 +3558,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         Sets hyper-parameters from external control flow.
 
         Args:
-            params_dict (dict[str, float]): The dict that contains the
+            params_dict (Dict[str, float]): The dict that contains the
                 hyper-parameter names and their values
         """
         if self.optimizer == OptimType.NONE:
@@ -3607,7 +3609,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
     @torch.jit.export
     def flush(self) -> None:
-        # pyre-fixme[29]: `(self: TensorBase) -> int | Module | Tensor` is not
+        # pyre-fixme[29]: `Union[(self: TensorBase) -> int, Module, Tensor]` is not
         #  a function.
         if not self.lxu_cache_weights.numel():
             return
@@ -3630,7 +3632,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         dtype: type[torch.dtype],
         enforce_hbm: bool = False,
         make_dev_param: bool = False,
-        dev_reshape: tuple[int, ...] | None = None,
+        dev_reshape: Optional[tuple[int, ...]] = None,
         uvm_host_mapped: bool = False,
     ) -> None:
         apply_split_helper(
@@ -3674,7 +3676,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self._offsets = self.lxu_cache_locations_empty
         self._vbe_B_offsets = self.lxu_cache_locations_empty
         self._vbe_max_B = -1
-        self.prefetch_stream: torch.cuda.Stream | None = None
+        self.prefetch_stream: Optional[torch.cuda.Stream] = None
 
         self._init_uvm_cache_stats()
 
@@ -3847,7 +3849,9 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             )
 
     # pyre-ignore
-    def _recording_to_timer(self, timer: AsyncSeriesTimer | None, **kwargs: Any) -> Any:
+    def _recording_to_timer(
+        self, timer: Optional[AsyncSeriesTimer], **kwargs: Any
+    ) -> Any:
         if self.stats_reporter is not None and self.stats_reporter.should_report(
             self.step
         ):
@@ -3876,7 +3880,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
     def _update_cache_counter_and_locations(
         self,
         module: nn.Module,
-        grad_input: tuple[Tensor, ...] | Tensor,
+        grad_input: Union[tuple[Tensor, ...], Tensor],
     ) -> None:
         """
         Backward prehook function when prefetch_pipeline is enabled.
@@ -4016,7 +4020,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self.last_uvm_cache_print_state = torch.zeros_like(self.uvm_cache_stats)
 
     def reset_cache_states(self) -> None:
-        # pyre-fixme[29]: `(self: TensorBase) -> int | Module | Tensor` is not
+        # pyre-fixme[29]: `Union[(self: TensorBase) -> int, Module, Tensor]` is not
         #  a function.
         if not self.lxu_cache_weights.numel():
             return
@@ -4071,13 +4075,13 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self,
         indices: Tensor,
         offsets: Tensor,
-        per_sample_weights: Tensor | None = None,
-        batch_size_per_feature_per_rank: list[list[int]] | None = None,
+        per_sample_weights: Optional[Tensor] = None,
+        batch_size_per_feature_per_rank: Optional[list[list[int]]] = None,
         force_cast_input_types: bool = True,
         prefetch_pipeline: bool = False,
-        vbe_output: Tensor | None = None,
-        vbe_output_offsets: Tensor | None = None,
-    ) -> tuple[Tensor, Tensor, Tensor | None, invokers.lookup_args.VBEMetadata]:
+        vbe_output: Optional[Tensor] = None,
+        vbe_output_offsets: Optional[Tensor] = None,
+    ) -> tuple[Tensor, Tensor, Optional[Tensor], invokers.lookup_args.VBEMetadata]:
         """
         Prepare TBE inputs as follows:
 
@@ -4089,10 +4093,10 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         Args:
             indices (Tensor): Input indices
             offsets (Tensor): Input offsets
-            per_sample_weights (Tensor | None): Input per sample
+            per_sample_weights (Optional[Tensor]): Input per sample
                 weights
             batch_size_per_feature_per_rank
-                (list[list[int]] | None): A 2D tensor of batch size
+                (Optional[List[List[int]]]): A 2D tensor of batch size
                 for each rank and feature. Shape = (number of
                 features, number of ranks)
             force_cast_input_types (bool): A flag to force convert
@@ -4228,7 +4232,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         def _debug_print_input_stats_factory_impl(
             indices: Tensor,
             offsets: Tensor,
-            per_sample_weights: Tensor | None = None,
+            per_sample_weights: Optional[Tensor] = None,
         ) -> None:
             """
             Print input stats (for debugging purpose only)
@@ -4236,7 +4240,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             Args:
                 indices (Tensor): Input indices
                 offsets (Tensor): Input offsets
-                per_sample_weights (Tensor | None): Input per
+                per_sample_weights (Optional[Tensor]): Input per
                     sample weights
             """
             # pyre-fixme[29]: `Union[(self: TensorBase, other: Union[bool, complex,
@@ -4336,7 +4340,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         def _debug_print_input_stats_factory_null(
             indices: Tensor,
             offsets: Tensor,
-            per_sample_weights: Tensor | None = None,
+            per_sample_weights: Optional[Tensor] = None,
         ) -> None:
             pass
 
@@ -4364,7 +4368,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         if not len(self.prefetched_info_list) > (target_prev_iter - 1):
             return None
         with record_function(
-            f"## uvm_lookup_prefetched_rows {self.timestep} {self.uuid} ##"
+            "## uvm_lookup_prefetched_rows {} {} ##".format(self.timestep, self.uuid)
         ):
             if not self._res_sync_copy and self._res_require_copy:
                 self._raw_embedding_streamer.join_stream_tensor_copy_thread()
@@ -4390,14 +4394,14 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                 prefetched_info.linear_unique_indices,
                 -1,
             )
-            # pyre-ignore[29]: `...` is not a function.
+            # pyre-ignore[29]: `Union[...]` is not a function.
             self.res_indices[: prefetched_info.linear_unique_indices.size(0)].copy_(
                 linear_unique_hit_indices
             )
-            # pyre-ignore[29]: `...` is not a function.
+            # pyre-ignore[29]: `Union[...]` is not a function.
             self.res_count[:1].copy_(prefetched_info.linear_unique_indices_length)
             if prefetched_info.hash_zch_identities is not None:
-                # pyre-ignore[29]: `...` is not a function.
+                # pyre-ignore[29]: `Union[...]` is not a function.
                 self.res_identities[
                     : prefetched_info.hash_zch_identities.size(0)
                 ].copy_(prefetched_info.hash_zch_identities)
@@ -4432,7 +4436,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
                             ),
                             persistent=False,  # shape may change via lazy resize, exclude from checkpoints
                         )
-                    # pyre-ignore[29]: `...` is not a function.
+                    # pyre-ignore[29]: `Union[...]` is not a function.
                     self.res_runtime_meta[: runtime_meta.size(0)].copy_(runtime_meta)
 
             self.res_copy_done.fill_(1)
@@ -4463,8 +4467,8 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         linear_indices: torch.Tensor,
         linear_cache_indices_merged: torch.Tensor,
         total_cache_hash_size: int,
-        hash_zch_identities: torch.Tensor | None,
-        hash_zch_runtime_meta: torch.Tensor | None,
+        hash_zch_identities: Optional[torch.Tensor],
+        hash_zch_runtime_meta: Optional[torch.Tensor],
         max_indices_length: int,
     ) -> PrefetchedInfo:
         (
@@ -4535,11 +4539,11 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
         self,
         indices: torch.Tensor,
         offsets: torch.Tensor,
-        vbe_metadata: invokers.lookup_args.VBEMetadata | None,
+        vbe_metadata: Optional[invokers.lookup_args.VBEMetadata],
         linear_cache_indices_merged: torch.Tensor,
         final_lxu_cache_locations: torch.Tensor,
-        hash_zch_identities: torch.Tensor | None,
-        hash_zch_runtime_meta: torch.Tensor | None,
+        hash_zch_identities: Optional[torch.Tensor],
+        hash_zch_runtime_meta: Optional[torch.Tensor],
     ) -> None:
         """
         NOTE: this needs to be a method with jit.ignore as the identities tensor is conditional.
@@ -4549,7 +4553,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             return
 
         with record_function(
-            f"## uvm_save_prefetched_rows {self.timestep} {self.uuid} ##"
+            "## uvm_save_prefetched_rows {} {} ##".format(self.timestep, self.uuid)
         ):
             found_in_cache_mask = final_lxu_cache_locations != -1
             # only process the indices that are found in the cache
@@ -4587,7 +4591,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
     @torch.jit.ignore
     def __report_input_params_factory(
         self,
-    ) -> Callable[..., None] | None:
+    ) -> Optional[Callable[..., None]]:
         """
         This function returns a function pointer based on the environment variable `FBGEMM_REPORT_INPUT_PARAMS_INTERVAL`.
 
@@ -4628,14 +4632,14 @@ class DenseTableBatchedEmbeddingBagsCodegen(nn.Module):
     def __init__(
         self,
         embedding_specs: list[tuple[int, int]],  # tuple of (rows, dims)
-        feature_table_map: list[int] | None = None,  # [T]
+        feature_table_map: Optional[list[int]] = None,  # [T]
         weights_precision: SparseType = SparseType.FP32,
         pooling_mode: PoolingMode = PoolingMode.SUM,
         use_cpu: bool = False,
         output_dtype: SparseType = SparseType.FP32,
         use_mtia: bool = False,
     ) -> None:  # noqa C901  # tuple of (rows, dims,)
-        super().__init__()
+        super(DenseTableBatchedEmbeddingBagsCodegen, self).__init__()
         self.uuid = str(uuid.uuid4())
 
         self.log(
@@ -4659,7 +4663,7 @@ class DenseTableBatchedEmbeddingBagsCodegen(nn.Module):
                 SparseType.BF16,
             ], "Fused pooled embedding quantization only supported for cuda."
 
-        # pyre-fixme[8]: Attribute has type `device`; used as `int | device`.
+        # pyre-fixme[8]: Attribute has type `device`; used as `Union[int, device]`.
         self.current_device: torch.device = (
             torch.device("cpu")
             if self.use_cpu
@@ -4768,7 +4772,7 @@ class DenseTableBatchedEmbeddingBagsCodegen(nn.Module):
     def _generate_vbe_metadata(
         self,
         offsets: Tensor,
-        batch_size_per_feature_per_rank: list[list[int]] | None,
+        batch_size_per_feature_per_rank: Optional[list[list[int]]],
     ) -> invokers.lookup_args.VBEMetadata:
         # Blocking D2H copy, but only runs at first call
         self.feature_dims = self.feature_dims.cpu()
@@ -4784,9 +4788,9 @@ class DenseTableBatchedEmbeddingBagsCodegen(nn.Module):
         self,
         indices: Tensor,
         offsets: Tensor,
-        per_sample_weights: Tensor | None = None,
-        feature_requires_grad: Tensor | None = None,
-        batch_size_per_feature_per_rank: list[list[int]] | None = None,
+        per_sample_weights: Optional[Tensor] = None,
+        feature_requires_grad: Optional[Tensor] = None,
+        batch_size_per_feature_per_rank: Optional[list[list[int]]] = None,
     ) -> Tensor:
         # Generate VBE metadata
         vbe_metadata = self._generate_vbe_metadata(

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training_common.py
@@ -7,6 +7,7 @@
 
 # pyre-unsafe
 
+from typing import List, Optional
 
 import torch  # usort:skip
 from torch import Tensor  # usort:skip
@@ -20,12 +21,12 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_common import PoolingMode
 
 def generate_vbe_metadata(
     offsets: Tensor,
-    batch_size_per_feature_per_rank: list[list[int]] | None,
+    batch_size_per_feature_per_rank: Optional[list[list[int]]],
     pooling_mode: PoolingMode,
     feature_dims_cpu: Tensor,
     device: torch.device,
-    vbe_output: Tensor | None = None,
-    vbe_output_offsets: Tensor | None = None,
+    vbe_output: Optional[Tensor] = None,
+    vbe_output_offsets: Optional[Tensor] = None,
 ) -> invokers.lookup_args.VBEMetadata:
     """
     Generate VBE metadata based on batch_size_per_feature_per_rank.
@@ -138,9 +139,9 @@ def generate_vbe_metadata(
 
 def check_allocated_vbe_output(
     output_dtype: int,
-    batch_size_per_feature_per_rank: list[list[int]] | None,
-    vbe_output: Tensor | None = None,
-    vbe_output_offsets: Tensor | None = None,
+    batch_size_per_feature_per_rank: Optional[List[List[int]]],
+    vbe_output: Optional[Tensor] = None,
+    vbe_output_offsets: Optional[Tensor] = None,
 ) -> None:
     assert (
         batch_size_per_feature_per_rank is not None


### PR DESCRIPTION
Summary:
Investigating root cause of all-variant OSS CI nightly failures at the 'Install PyTorch (PIP) nightly' step.

This diff reverts the Python 3.10+ typing modernization (D101923786) to test whether it is correlated with the failures.

The symptom: torch nightly installs successfully via pip, but `import torch` fails with `ModuleNotFoundError: No module named 'torch'`.

Differential Revision: D102213210


