### PR TITLE
TBE EEG for Inference

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
@@ -12,12 +12,13 @@
 import logging
 import uuid
 from itertools import accumulate
+from typing import Callable, Optional
 
 import fbgemm_gpu  # noqa: F401
 import torch  # usort:skip
 from torch import nn, Tensor  # usort:skip
 
-from fbgemm_gpu.config import FeatureGateName
+from fbgemm_gpu.config import FeatureGate, FeatureGateName
 from fbgemm_gpu.split_embedding_configs import sparse_type_to_int, SparseType
 from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
     BoundsCheckMode,
@@ -637,6 +638,12 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
         self.bounds_check_version: int = get_bounds_check_version_for_platform()
 
+        # Get a reporter function pointer
+        self._report_input_params: Optional[Callable[..., None]] = (
+            self.__report_input_params_factory()
+        )
+        self._eeg_step: int = 0
+
     @torch.jit.ignore
     def log(self, msg: str) -> None:
         """
@@ -650,6 +657,78 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
             None
         """
         logging.info(f"[TBE={self.uuid}] {msg}")
+
+    @torch.jit.ignore
+    def _feature_is_enabled(self, feature: FeatureGateName) -> bool:
+        # Define proxy method so that it can be marked with @torch.jit.ignore
+        # This allows models using this class to compile correctly
+        return FeatureGate.is_enabled(feature)
+
+    @torch.jit.ignore
+    def __report_input_params_factory(
+        self,
+    ) -> Optional[Callable[..., None]]:
+        """
+        Returns a function pointer for reporting input parameters (TBEDataConfig)
+        if the TBE_REPORT_INPUT_PARAMS feature gate is enabled, otherwise None.
+        """
+        # The reporter requires the TBEBenchmarkParamsReporter C++ backend
+        # (torch.ops.fbgemm.*) which may not be available in all build
+        # configurations (e.g. OSS builds without the C++ extensions).
+        try:
+            if self._feature_is_enabled(FeatureGateName.TBE_REPORT_INPUT_PARAMS):
+                from fbgemm_gpu.tbe.monitoring.bench_params_reporter import (
+                    TBEBenchmarkParamsReporter,
+                )
+
+                reporter = TBEBenchmarkParamsReporter.create()
+                return reporter.report_stats
+        except Exception as e:
+            logging.warning(
+                f"[TBE={self.uuid}] TBEBenchmarkParamsReporter is skipped "
+                f"due to: {e}"
+            )
+            return None
+
+        return None
+
+    @torch.jit.ignore
+    def _maybe_report_eeg(
+        self,
+        indices: Tensor,
+        offsets: Tensor,
+        per_sample_weights: Optional[Tensor] = None,
+    ) -> None:
+        """
+        Extract and write input stats if enabled.
+        """
+        # Use getattr to guard against the attribute not existing when the
+        # module is loaded from a checkpoint that predates the EEG fields.
+        report_fn = getattr(self, "_report_input_params", None)
+        if report_fn is None:
+            return
+
+        dims = [e[2] for e in self.embedding_specs]
+        feature_dims = torch.tensor(
+            [dims[t] for t in self.feature_table_map],
+            device="cpu",
+            dtype=torch.int64,
+        )
+
+        report_fn(
+            feature_rows=self.rows_per_table,
+            feature_dims=feature_dims,
+            iteration=self._eeg_step,
+            indices=indices,
+            offsets=offsets,
+            op_id=self.uuid,
+            per_sample_weights=per_sample_weights,
+            batch_size_per_feature_per_rank=None,
+            embedding_specs=[(s[1], s[2]) for s in self.embedding_specs],
+            feature_table_map=self.feature_table_map,
+        )
+
+        self._eeg_step += 1
 
     def get_cache_miss_counter(self) -> Tensor:
         # cache_miss_counter[0]: cache_miss_forward_count which records the total number of forwards which has at least one cache miss
@@ -1056,6 +1135,9 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         offsets: Tensor,
         per_sample_weights: Tensor | None = None,
     ) -> Tensor:
+        # Extract and write input stats if enabled
+        if not torch.jit.is_scripting():
+            self._maybe_report_eeg(indices, offsets, per_sample_weights)
         return self._forward_impl(
             indices=indices, offsets=offsets, per_sample_weights=per_sample_weights
         )

--- a/fbgemm_gpu/test/tbe/stats/tbe_bench_params_reporter_test.py
+++ b/fbgemm_gpu/test/tbe/stats/tbe_bench_params_reporter_test.py
@@ -9,15 +9,19 @@
 
 import unittest
 from typing import Optional
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import fbgemm_gpu
 import hypothesis.strategies as st
 import torch
 from fbgemm_gpu.config import FeatureGateName
+from fbgemm_gpu.split_embedding_configs import SparseType
 from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
     ComputeDevice,
     EmbeddingLocation,
+)
+from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
+    IntNBitTableBatchedEmbeddingBagsCodegen,
 )
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     SplitTableBatchedEmbeddingBagsCodegen,
@@ -244,6 +248,147 @@ class TestTBEBenchmarkParamsReporter(unittest.TestCase):
 
             # Clenaup, delete the file
             store.remove(path)
+
+
+class TestInferenceTBEBenchmarkParamsReporter(unittest.TestCase):
+    def test_inference_report_stats(self) -> None:
+        """Test that the reporter can extract a valid config from inference TBE."""
+        T = 3
+        E = 1000
+        D = 64
+        L = 5
+        B = 32
+
+        use_cpu = not torch.cuda.is_available() or torch.version.hip is not None
+        embedding_location = (
+            EmbeddingLocation.HOST if use_cpu else EmbeddingLocation.DEVICE
+        )
+
+        embedding_specs = [
+            ("", E, D, SparseType.FP16, embedding_location) for _ in range(T)
+        ]
+
+        cc = IntNBitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=embedding_specs,
+            indices_dtype=torch.int64,
+            device=torch.device("cpu") if use_cpu else None,
+        )
+        cc.fill_random_weights()
+
+        reporter = TBEBenchmarkParamsReporter(report_interval=1)
+
+        # Generate test indices and offsets (int64 required by tbe_estimate_indices_distribution)
+        indices = torch.randint(0, E, (T * B * L,), dtype=torch.int64)
+        offsets = torch.arange(0, T * B * L + 1, L, dtype=torch.int64)
+
+        feature_dims = torch.tensor([D] * T, device="cpu", dtype=torch.int64)
+
+        extracted_config = reporter.extract_params(
+            feature_rows=cc.rows_per_table,
+            feature_dims=feature_dims,
+            indices=indices,
+            offsets=offsets,
+        )
+
+        self.assertEqual(extracted_config.T, T)
+        self.assertEqual(extracted_config.E, E)
+        self.assertEqual(extracted_config.D, D)
+        self.assertEqual(extracted_config.pooling_params.L, L)
+        self.assertEqual(extracted_config.batch_params.B, B)
+
+    def test_inference_jit_script_with_eeg(self) -> None:
+        """Confirm TorchScript compatibility is preserved when EEG is initialized."""
+        T = 2
+        E = 100
+        D = 32
+        B = 4
+        L = 3
+
+        use_cpu = not torch.cuda.is_available() or torch.version.hip is not None
+        embedding_location = (
+            EmbeddingLocation.HOST if use_cpu else EmbeddingLocation.DEVICE
+        )
+
+        with patch(
+            "torch.ops.fbgemm.check_feature_gate_key"
+        ) as mock_check_feature_gate_key:
+
+            def side_effect(feature_name: str) -> Optional[bool]:
+                if feature_name == FeatureGateName.TBE_REPORT_INPUT_PARAMS.name:
+                    return True
+
+            mock_check_feature_gate_key.side_effect = side_effect
+
+            embedding_specs = [
+                ("", E, D, SparseType.FP16, embedding_location) for _ in range(T)
+            ]
+
+            cc = IntNBitTableBatchedEmbeddingBagsCodegen(
+                embedding_specs=embedding_specs,
+                device=torch.device("cpu") if use_cpu else None,
+            )
+            cc.fill_random_weights()
+
+            # TorchScript should succeed
+            scripted = torch.jit.script(cc)
+
+            indices = torch.randint(0, E, (T * B * L,), dtype=torch.int32)
+            offsets = torch.arange(0, T * B * L + 1, L, dtype=torch.int32)
+
+            # Forward should succeed on scripted module
+            output = scripted(indices, offsets)
+            self.assertEqual(output.shape, (B, T * D))
+
+    def test_inference_eeg_forward_reports(self) -> None:
+        """Test that forward() calls report_stats when EEG is enabled."""
+        T = 2
+        E = 100
+        D = 32
+        B = 4
+        L = 3
+
+        use_cpu = not torch.cuda.is_available() or torch.version.hip is not None
+        embedding_location = (
+            EmbeddingLocation.HOST if use_cpu else EmbeddingLocation.DEVICE
+        )
+
+        with patch(
+            "torch.ops.fbgemm.check_feature_gate_key"
+        ) as mock_check_feature_gate_key:
+
+            def side_effect(feature_name: str) -> Optional[bool]:
+                if feature_name == FeatureGateName.TBE_REPORT_INPUT_PARAMS.name:
+                    return True
+
+            mock_check_feature_gate_key.side_effect = side_effect
+
+            embedding_specs = [
+                ("", E, D, SparseType.FP16, embedding_location) for _ in range(T)
+            ]
+
+            cc = IntNBitTableBatchedEmbeddingBagsCodegen(
+                embedding_specs=embedding_specs,
+                indices_dtype=torch.int64,
+                device=torch.device("cpu") if use_cpu else None,
+            )
+            cc.fill_random_weights()
+
+            # Replace the report function with a mock to verify it's called
+            report_mock = MagicMock()
+            cc._report_input_params = report_mock
+
+            indices = torch.randint(0, E, (T * B * L,), dtype=torch.int64)
+            offsets = torch.arange(0, T * B * L + 1, L, dtype=torch.int64)
+
+            # Forward should trigger reporting
+            cc.forward(indices, offsets)
+
+            # Verify the report function was called
+            report_mock.assert_called_once()
+            call_kwargs = report_mock.call_args[1]
+            self.assertEqual(call_kwargs["op_id"], cc.uuid)
+            self.assertEqual(len(call_kwargs["feature_rows"]), T)
+            self.assertEqual(call_kwargs["feature_dims"].shape[0], T)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Add EEG input parameter reporting to the inference TBE operator.

This diff extends the `IntNBitTableBatchedEmbeddingBagsCodegen` inference TBE to optionally report input parameters (indices, offsets, embedding specs) via the `TBEBenchmarkParamsReporter` when the `TBE_REPORT_INPUT_PARAMS` feature gate is enabled. This mirrors the existing EEG support in the training TBE. Specifically:

1. **Feature-gated EEG reporter initialization**: A factory method (`__report_input_params_factory`) lazily creates and caches a `TBEBenchmarkParamsReporter.report_stats` function pointer at construction time, only when the feature gate is enabled.
2. **Forward-path integration**: The `forward()` method calls `_maybe_report_eeg()` to extract and report input stats (feature rows, dims, indices, offsets, per-sample weights, embedding specs, feature table map) on each forward pass when EEG is active.
3. **TorchScript compatibility**: All EEG-related methods are decorated with `torch.jit.ignore` and the `forward()` call is guarded by `torch.jit.is_scripting()`, ensuring JIT compilation is unaffected.
4. **Tests**: Three new tests in `TestInferenceTBEBenchmarkParamsReporter` validate config extraction, TorchScript compatibility, and forward-path reporting.

## Feature Gate — Just Knobs (JK) Enablement

The reporter is gated behind the `TBE_REPORT_INPUT_PARAMS` feature gate ([`fbgemm_gpu/features:TBE_REPORT_INPUT_PARAMS`](https://www.internalfb.com/intern/justknobs/?name=fbgemm_gpu%2Ffeatures)).

- **Default**: `False` (reporter is disabled)
- **To enable locally via JK canary**:
  ```
  jk canary set fbgemm_gpu/features:TBE_REPORT_INPUT_PARAMS --on --ttl 600
  ```

### No-JK Fallback (Environment Variable)

When Just Knobs is unavailable (e.g. OSS builds, or when `FBGEMM_NO_JK=1` is set), the feature gate falls back to checking an environment variable named `FBGEMM_<ENUM>`:

| Environment Variable | Description | Example |
|---|---|---|
| `FBGEMM_TBE_REPORT_INPUT_PARAMS` | Enable/disable the EEG reporter when JK is unavailable. Set to `1` to enable. | `FBGEMM_TBE_REPORT_INPUT_PARAMS=1` |
| `FBGEMM_NO_JK` | Skip all JK lookups and use only environment variables for **all** feature gates. Set to `1` to enable. | `FBGEMM_NO_JK=1` |

## Reporter Environment Variables

Once the feature gate is enabled, the `TBEBenchmarkParamsReporter` is instantiated via the `TBEBenchmarkParamsReporter.create()` factory method, which reads the following environment variables to configure reporting behavior:

| Environment Variable | Description | Default |
|---|---|---|
| `FBGEMM_REPORT_INPUT_PARAMS_INTERVAL` | Reporting interval in iterations. A report is generated every N iterations (within the configured range). | `1` (every iteration) |
| `FBGEMM_REPORT_INPUT_PARAMS_ITER_START` | Start of the iteration range to capture. Only iterations >= this value are reported. | `0` |
| `FBGEMM_REPORT_INPUT_PARAMS_ITER_END` | End of the iteration range to capture. Use `-1` to report until the last iteration. | `-1` (no end limit) |
| `FBGEMM_REPORT_INPUT_PARAMS_BUCKET` | Manifold bucket (internal) or local directory (OSS) where report JSON files are saved. | `tlparse_reports` (internal) / `/tmp` (OSS) |
| `FBGEMM_REPORT_INPUT_PARAMS_PATH_PREFIX` | Path prefix within the bucket for report file storage. | `""` (empty) |
| `FBGEMM_TBE_REPORTING_BUCKET` | Fallback bucket used by the `TBEBenchmarkParamsReporter.__init__` if no bucket is passed as an argument. | `tlparse_reports` (internal) / `/tmp` (OSS) |

### Example Usage

```bash
FBGEMM_REPORT_INPUT_PARAMS_INTERVAL=2 \
FBGEMM_REPORT_INPUT_PARAMS_ITER_START=3 \
FBGEMM_REPORT_INPUT_PARAMS_ITER_END=11 \
FBGEMM_REPORT_INPUT_PARAMS_BUCKET=tlparse_reports \
FBGEMM_REPORT_INPUT_PARAMS_PATH_PREFIX=tree/tests/ \
buck2 run mode/opt //deeplearning/fbgemm/fbgemm_gpu/bench:tbe_inference -- nbit-device
```

This captures iterations **3, 5, 7, 9** (every 2 iterations starting from 3, up to 11).

### Output

Each report is written as a JSON file at:
```
<bucket>/<path_prefix>/tbe-<op_id>-config-estimation-<iteration>.json
```

The JSON contains a `TBEDataConfig` with: T (tables), E (rows), D (dims), L (pooling length), B (batch size), indices distribution parameters (Zipf q/s, heavy hitters), per-table stats, and embedding specs.

## Detailed Changes

### split_table_batched_embeddings_ops_inference.py
- Imports `Callable` (typing) and `FeatureGate` (config) for feature gate checking and type annotations
- Adds `_feature_is_enabled()` — a `torch.jit.ignore` proxy for `FeatureGate.is_enabled()` to avoid JIT compilation issues
- Adds `__report_input_params_factory()` — returns a `TBEBenchmarkParamsReporter.report_stats` function pointer if `TBE_REPORT_INPUT_PARAMS` is enabled, otherwise `None`
- Initializes `self._report_input_params` in `__init__` via the factory method
- Adds `_maybe_report_eeg()` — extracts `feature_rows`, `feature_dims`, `embedding_specs`, and `feature_table_map` from the TBE instance and calls the reporter with indices/offsets/per_sample_weights; increments `_eeg_step` each call
- Modifies `forward()` to call `_maybe_report_eeg()` guarded by `not torch.jit.is_scripting()`

### BUCK (fbgemm_gpu)
- Adds `//deeplearning/fbgemm/fbgemm_gpu/fbgemm_gpu/tbe:bench_params_reporter` as a dependency of the inference ops target

### test/tbe/BUCK
- Adds `//deeplearning/fbgemm/fbgemm_gpu:split_table_batched_embeddings_ops_inference` as a dependency for the `tbe_bench_params_reporter` test target

### test/tbe/stats/tbe_bench_params_reporter_test.py
- Adds `TestInferenceTBEBenchmarkParamsReporter` test class with three tests:
  - `test_inference_report_stats`: Validates that `TBEBenchmarkParamsReporter.extract_params` correctly extracts T, E, D, L, B from an inference TBE
  - `test_inference_jit_script_with_eeg`: Confirms `torch.jit.script()` succeeds and produces valid output when EEG is initialized
  - `test_inference_eeg_forward_reports`: Verifies that `forward()` invokes the report function with correct kwargs (`op_id`, `feature_rows`, `feature_dims`)

Reviewed By: spcyppt

Differential Revision: D101907351


