### PR TITLE
Add per-feature pooling factors support (#5690)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/bench/tbe_data_config_bench_helper.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/bench/tbe_data_config_bench_helper.py
@@ -56,7 +56,18 @@ def _generate_batch_sizes(
 def _generate_pooling_info(
     tbe_data_config: TBEDataConfig, iters: int, Bs: list[int]
 ) -> torch.Tensor:
-    if tbe_data_config.variable_L():
+    if tbe_data_config.pooling_params.Ls is not None:
+        # Per-feature pooling factors: each feature has its own L value.
+        # Bs has one entry per feature (length T, which equals F for data generation).
+        # For non-VBE, all Bs entries are the same B.
+        Ls_per_feature = tbe_data_config.pooling_params.Ls
+        Ls_expanded = []
+        for i, B_i in enumerate(Bs):
+            Ls_expanded.extend([int(Ls_per_feature[i])] * B_i)
+        # Replicate across iterations
+        Ls_all = Ls_expanded * iters
+        L_offsets = torch.tensor([0] + Ls_all, dtype=torch.long).cumsum(0)
+    elif tbe_data_config.variable_L():
         # Generate L from stats
         _, L_offsets = generate_pooling_factors_from_stats(
             iters,
@@ -232,7 +243,11 @@ def generate_requests(
     all_indices = all_indices.to(get_device())
 
     # Build TBE requests
-    if tbe_data_config.variable_B() or tbe_data_config.variable_L():
+    if (
+        tbe_data_config.variable_B()
+        or tbe_data_config.variable_L()
+        or tbe_data_config.pooling_params.Ls is not None
+    ):
         return _build_requests_jagged(
             tbe_data_config,
             iters,
@@ -301,7 +316,11 @@ def generate_requests_with_Llist(
     # Build TBE requests
     # batch_size_per_feature_per_rank is passed through directly
     # from the caller (no _generate_batch_sizes call here).
-    if tbe_data_config.variable_B() or tbe_data_config.variable_L():
+    if (
+        tbe_data_config.variable_B()
+        or tbe_data_config.variable_L()
+        or tbe_data_config.pooling_params.Ls is not None
+    ):
         return _build_requests_jagged(
             tbe_data_config,
             iters,

--- a/fbgemm_gpu/fbgemm_gpu/tbe/bench/tbe_data_config_bench_helper.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/bench/tbe_data_config_bench_helper.py
@@ -35,9 +35,7 @@ except Exception:
 def _generate_batch_sizes(
     tbe_data_config: TBEDataConfig,
 ) -> tuple[list[int], list[list[int]] | None]:
-    logging.info(
-        f"DEBUG_TBE: [_generate_batch_sizes] VBE tbe_data_config.variable_B()={tbe_data_config.variable_B()}"
-    )
+    logging.debug(f"[_generate_batch_sizes] variable_B={tbe_data_config.variable_B()}")
     if tbe_data_config.variable_B():
         assert (
             tbe_data_config.batch_params.vbe_num_ranks is not None
@@ -121,7 +119,7 @@ def _generate_indices(
             start_offset = L_offsets_list[it * total_B]
             end_offset = L_offsets_list[(it + 1) * total_B]
 
-            logging.info(f"DEBUG_TBE: _generate_indices E={tbe_data_config.E}")
+            logging.debug(f"_generate_indices E={tbe_data_config.E}")
 
             indices_list.append(
                 torch.ops.fbgemm.tbe_generate_indices_from_distribution(
@@ -215,14 +213,16 @@ def generate_requests(
     # Generate batch sizes
     if batch_size_per_feature_per_rank:
         Bs = tbe_data_config.batch_params.Bs
+        Bs_feature_rank = batch_size_per_feature_per_rank
     else:
-        Bs, _ = _generate_batch_sizes(tbe_data_config)
-
-    logging.info(
-        f"DEBUG_TBE: VBE [generate_requests] batch_size_per_feature_per_rank={batch_size_per_feature_per_rank} Bs={Bs}"
-    )
+        Bs, Bs_feature_rank = _generate_batch_sizes(tbe_data_config)
 
     assert Bs is not None, "Batch sizes (Bs) must be set"
+
+    logging.debug(
+        f"[generate_requests] Bs_len={len(Bs)}"
+        f" Bs_feature_rank={Bs_feature_rank is not None}"
+    )
 
     # Generate pooling info
     L_offsets = _generate_pooling_info(tbe_data_config, iters, Bs)
@@ -233,24 +233,14 @@ def generate_requests(
 
     # Build TBE requests
     if tbe_data_config.variable_B() or tbe_data_config.variable_L():
-        if batch_size_per_feature_per_rank:
-            return _build_requests_jagged(
-                tbe_data_config,
-                iters,
-                Bs,
-                batch_size_per_feature_per_rank,
-                L_offsets,
-                all_indices,
-            )
-        else:
-            return _build_requests_jagged(
-                tbe_data_config,
-                iters,
-                Bs,
-                batch_size_per_feature_per_rank,
-                L_offsets,
-                all_indices,
-            )
+        return _build_requests_jagged(
+            tbe_data_config,
+            iters,
+            Bs,
+            Bs_feature_rank,
+            L_offsets,
+            all_indices,
+        )
     else:
         return _build_requests_dense(tbe_data_config, iters, all_indices)
 
@@ -309,6 +299,8 @@ def generate_requests_with_Llist(
     all_indices = all_indices.to(get_device())
 
     # Build TBE requests
+    # batch_size_per_feature_per_rank is passed through directly
+    # from the caller (no _generate_batch_sizes call here).
     if tbe_data_config.variable_B() or tbe_data_config.variable_L():
         return _build_requests_jagged(
             tbe_data_config,


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2627

Adds support for per-feature pooling factors (Ls) in TBE benchmark data
generation. Previously, all features shared the same pooling factor
distribution. With this change, when `TBEDataConfig.pooling_params.Ls` is
set (a list with one L value per feature), each feature uses its own
pooling factor to generate lookup offsets.

This is needed to accurately benchmark production workloads where different
embedding tables have different pooling factors (e.g., user history tables
have much larger L values than context features).

The change also updates the jagged request builder condition to trigger
when per-feature Ls are set, even if VBE/variable-L modes are not active.

Reviewed By: q10

Differential Revision: D94380849


