### PR TITLE
Fix OSS CI ModuleNotFoundError: explicit `pip` in conda env

### DIFF
--- a/.github/scripts/utils_conda.bash
+++ b/.github/scripts/utils_conda.bash
@@ -192,13 +192,18 @@ create_conda_environment () {
   local env_prefix=$(env_name_or_prefix "${env_name}")
 
   # The `-y` flag removes any existing Conda environment with the same name
+  # NOTE: `pip` is requested explicitly because the conda-forge `python` package
+  # no longer pulls it in as a hard dependency starting with Python 3.13. Without
+  # this, `conda run env pip ...` falls back to base conda's pip and installs to
+  # the wrong site-packages, causing later `import` checks to fail with
+  # ModuleNotFoundError.
   echo "[SETUP] Creating new Conda environment (Python ${python_version}) ..."
   # shellcheck disable=SC2086
-  (exec_with_retries 3 conda create ${env_prefix} -c conda-forge -y python="${python_version}") || return 1
+  (exec_with_retries 3 conda create ${env_prefix} -c conda-forge -y python="${python_version}" pip) || return 1
 
   echo "[SETUP] Upgrading PIP to latest ..."
   # shellcheck disable=SC2086
-  (exec_with_retries 3 conda run ${env_prefix} pip install --upgrade pip) || return 1
+  (exec_with_retries 3 conda run ${env_prefix} python -m pip install --upgrade pip) || return 1
 
   # Handle pyOpenSSL version issue
   __handle_pyopenssl_version_issue "${env_name}"

--- a/.github/scripts/utils_pip.bash
+++ b/.github/scripts/utils_pip.bash
@@ -239,7 +239,9 @@ install_from_pytorch_pip () {
 
   echo "[INSTALL] Attempting to install [${package_name}, ${package_version:-LATEST}] from PyTorch PIP using channel ${pip_channel} ..."
   # shellcheck disable=SC2086
-  (exec_with_retries 3 conda run ${env_prefix} pip install ${pip_package} --index-url ${pip_channel}) || return 1
+  # NOTE: `python -m pip` (not bare `pip`) ensures we install into the env's own
+  # site-packages even if its `pip` resolution falls back to base conda's pip.
+  (exec_with_retries 3 conda run ${env_prefix} python -m pip install ${pip_package} --index-url ${pip_channel}) || return 1
 
   # Ensure that the correct package variant has been installed
   __check_package_variant || return 1


### PR DESCRIPTION
Summary:
The OSS CI install-pytorch-nightly step fails with `ModuleNotFoundError: No
module named 'torch'` for both CPU and GPU jobs across all CUDA versions
(including 13.2). Root cause is in conda env creation, not the PyTorch wheel
index.

`conda create -c conda-forge -y python=3.14` no longer pulls `pip` as a hard
dependency (conda-forge unbundled pip from the python package starting around
3.13). The created env therefore has python but no pip.

Subsequent calls of the form `conda run -n env pip install ...` activate the
env, fail to find `pip` in env's `bin/`, and fall back to base conda's pip via
PATH. PyTorch (and any other wheels) then land in **base**'s site-packages, not
env's. The later check `conda run -n env python -c "import torch.distributed"`
uses env's python, finds nothing, and dies with ModuleNotFoundError.

For GPU jobs `__check_package_variant` runs `conda run -n env pip list` against
the same wrong (base) pip, sees torch+cu1XX, and erroneously reports the
variant check as passed — masking the real failure until the python import.

Fixes:
1. `utils_conda.bash`: request `pip` explicitly in `conda create`, so the env
   gets its own pip binary.
2. `utils_conda.bash` + `utils_pip.bash`: switch the bare `pip install` calls
   on the env-creation and torch-install paths to `python -m pip install`,
   which is invoked by the env's python interpreter and is therefore guaranteed
   to install into the env regardless of PATH-based pip resolution.

The other bare `pip` callsites (`pip list` for variant checks, `pip download`,
ROCm/util install paths) are unaffected by this fix because, with `pip` now
present in the env, conda-run will resolve to env's pip in all cases.

Differential Revision: D102356515


