### PR TITLE
Harden rowwise quantize benchmark with Kineto trace export

### DIFF
--- a/fbgemm_gpu/bench/quantize_ops_benchmark.py
+++ b/fbgemm_gpu/bench/quantize_ops_benchmark.py
@@ -392,6 +392,18 @@ def bench_mx4(
     default=False,
     help="Use manual seed for reproduction.",
 )
+@click.option(
+    "--export-trace",
+    is_flag=True,
+    default=False,
+    help="Enable export of kineto trace for profiling. Default is False.",
+)
+@click.option(
+    "--trace-url",
+    type=str,
+    default="bench_rowwise_{ospid}.json",
+    help="Trace output filename template ({ospid} replaced with PID).",
+)
 def bench(
     flush_gpu_cache_size_mb: int,
     iters: int,
@@ -399,11 +411,22 @@ def bench(
     num_rows: int,
     warmup_runs: int,
     manual_seed: bool,
+    export_trace: bool,
+    trace_url: str,
 ) -> None:
     # set manual seed for reproducibility
     if manual_seed:
         torch.manual_seed(42)
         random.seed(42)
+
+    def _kineto_trace_handler(p: profile) -> None:
+        import os
+
+        p.export_chrome_trace(trace_url.format(ospid=os.getpid()))
+
+    # pyre-ignore[3]
+    def context_factory(on_trace_ready: Callable[[profile], None]):
+        return profile(on_trace_ready=on_trace_ready) if export_trace else nullcontext()
 
     if num_columns == -1 or num_rows == -1:
         bench_spectrum(
@@ -412,13 +435,14 @@ def bench(
             warmup_runs=warmup_runs,
         )
     else:
-        bench_impl(
-            flush_gpu_cache_size_mb=flush_gpu_cache_size_mb,
-            iters=iters,
-            num_columns=num_columns,
-            num_rows=num_rows,
-            warmup_runs=warmup_runs,
-        )
+        with context_factory(_kineto_trace_handler):
+            bench_impl(
+                flush_gpu_cache_size_mb=flush_gpu_cache_size_mb,
+                iters=iters,
+                num_columns=num_columns,
+                num_rows=num_rows,
+                warmup_runs=warmup_runs,
+            )
 
 
 @cli.command()


### PR DESCRIPTION
Summary:
Add Kineto trace export support to the `quantize_ops_benchmark bench` subcommand for profiling rowwise quantize/dequantize operations.

This diff extends the existing `bench` CLI with two new options that enable GPU profiling via Kineto trace capture. Specifically:

1. `--export-trace` flag: Enables wrapping `bench_impl` in a `torch.profiler.profile` context to capture GPU kernel timings
2. `--trace-url` template: Configurable output filename with `{ospid}` placeholder for PID-based deduplication (default: `bench_rowwise_{ospid}.json`)
3. `context_factory` pattern: Conditional profiler context — returns a `profile(on_trace_ready=...)` when tracing is enabled, otherwise a `nullcontext()` for zero overhead
4. `_kineto_trace_handler`: Callback that exports Chrome-format traces to the templated path

The trace export is used downstream by the tritonbench comparison infrastructure (D102107187) to compare kernel-level timings between the old and new benchmark implementations.

Reviewed By: henrylhtsang

Differential Revision: D102080026


