### PR TITLE
[ROCm] support warpSize 32 and 64 in the same build

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_lookup.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_lookup.cu
@@ -63,6 +63,7 @@ __launch_bounds__(kMaxThreads) void int_nbit_split_embedding_codegen_forward_pru
   const uint32_t subwarp_id = threadIdx.x / 4;
   const uint32_t subwarp_tid = threadIdx.x % 4;
 #ifdef USE_ROCM
+  // HIP __any_sync / __ballot_sync statically require a 64-bit mask type.
   const uint64_t subwarp_mask = static_cast<uint64_t>(0xF) << (4 * subwarp_id);
 #else
   const uint32_t subwarp_mask = static_cast<uint32_t>(0xF) << (4 * subwarp_id);

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -947,10 +947,11 @@ Tensor {{ embedding_cuda_op }}(
             if (static_cast<PoolingMode>(pooling_mode) == PoolingMode::MEAN) {
                 grad_output_mean = at::empty_like(grad_output_reshaped);
 
+                const int grad_mean_warp_size = at::cuda::warp_size();
                 FBGEMM_LAUNCH_KERNEL(
                     (grad_mean{{ vdesc }}_kernel<grad_t, index_t>),
-                    div_round_up(total_B, kMaxThreads / kWarpSize),
-                    dim3(kWarpSize, kMaxThreads / kWarpSize),
+                    div_round_up(total_B, kMaxThreads / grad_mean_warp_size),
+                    dim3(grad_mean_warp_size, kMaxThreads / grad_mean_warp_size),
                     0,
                     at::cuda::getCurrentCUDAStream(),
                     PTA_B(grad_output_mean, grad_t, 2, 64),
@@ -1076,26 +1077,27 @@ Tensor {{ embedding_cuda_op }}(
 
                     // Compute shared memory size for cta_per_row
                     constexpr auto kCacheAccBytes = sizeof(at::acc_type<cache_t, true>);
+                    const int cta_warp_size = at::cuda::warp_size();
                     {% if is_rocm %}
                     int32_t total_L = indices.numel();
                     int32_t num_cta_per_row_groups;
                     int32_t work_group_size;
                     if (total_L/total_B > 1) {
-                        num_cta_per_row_groups = (kMaxThreads/4) / kWarpSize;
+                        num_cta_per_row_groups = (kMaxThreads/4) / cta_warp_size;
                         work_group_size = (kMaxThreads/4);
                     }
                     else {
-                        num_cta_per_row_groups = kMaxThreads / kWarpSize;
+                        num_cta_per_row_groups = kMaxThreads / cta_warp_size;
                         work_group_size = kMaxThreads;
                     }
                     {%- else %}
-                    int32_t num_cta_per_row_groups = kMaxThreads / kWarpSize;
+                    int32_t num_cta_per_row_groups = kMaxThreads / cta_warp_size;
                     const int32_t work_group_size = kMaxThreads;
                     {%- endif %}
                     const size_t cta_per_row_smem_bytes = compute_num_groups_and_dynamic_smem_bytes(
                         &num_cta_per_row_groups,
                         [&] (int num_groups) {
-                          return num_groups * kCacheAccBytes * 4 * kWarpSize * max_vecs_per_thread;
+                          return num_groups * kCacheAccBytes * 4 * cta_warp_size * max_vecs_per_thread;
                         },
                         backward_cta_per_row_kernel,
                         used_shared_bytes
@@ -1254,7 +1256,13 @@ Tensor {{ embedding_cuda_op }}(
 
                     constexpr bool same_precision = std::is_same_v<emb_t, grad_t>;
 
-                    if (use_hip_kernel && !mixed_D && !cached && supported_weights_type && supported_grad_type && same_precision && rocm::is_supported_cdna())
+                    // The optimized HIP backward kernel uses warpSize-64-only
+                    // intrinsics; it must only be dispatched on warpSize 64
+                    // devices. warpSize 32 devices fall through to the generic
+                    // shuffle-based backward kernel.
+                    const bool dev_is_warp64 = at::cuda::warp_size() == 64;
+
+                    if (use_hip_kernel && dev_is_warp64 && !mixed_D && !cached && supported_weights_type && supported_grad_type && same_precision && rocm::is_supported_cdna())
                     {
                         constexpr int segments_per_workgroup = 4;
                         {%- for kDimSize in [64, 128, 160, 192, 256, 320] %}

--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_template.cu
@@ -811,14 +811,15 @@ batch_index_select_dim0_codegen_forward_cuda(
         } else {
             // Allocate num warps per table based on max_D
 
-            const int num_warps_per_table = B * div_round_up(max_D, kWarpSize * 4);
+            const int warp_size = at::cuda::warp_size();
+            const int num_warps_per_table = B * div_round_up(max_D, warp_size * 4);
             #ifdef USE_ROCM
-              const uint32_t num_warps_per_threadblock = kForwardMaxThreads / (kWarpSize * 2);
+              const uint32_t num_warps_per_threadblock = kForwardMaxThreads / (warp_size * 2);
               const auto num_threadblocks =
                   div_round_up(T * num_warps_per_table, num_warps_per_threadblock);
               const uint64_t num_threads =
                   static_cast<uint64_t>(num_threadblocks)
-                  * kWarpSize * num_warps_per_threadblock;
+                  * warp_size * num_warps_per_threadblock;
               // Cap the grid only when total threads exceed uint32 limits;
               // the kernel's grid-striding loop handles the overflow.
               const auto grid = num_threads >= std::numeric_limits<uint32_t>::max()
@@ -827,7 +828,7 @@ batch_index_select_dim0_codegen_forward_cuda(
                         utils::cuda::get_max_thread_blocks(at::cuda::getCurrentCUDAStream()))
                   : num_threadblocks;
             #else
-              const uint32_t num_warps_per_threadblock = kForwardMaxThreads / kWarpSize;
+              const uint32_t num_warps_per_threadblock = kForwardMaxThreads / warp_size;
               const auto grid = div_round_up(T * num_warps_per_table, num_warps_per_threadblock);
             #endif
 
@@ -840,7 +841,7 @@ batch_index_select_dim0_codegen_forward_cuda(
             FBGEMM_LAUNCH_KERNEL(
               kernel_func,
               grid,
-              dim3(kWarpSize, num_warps_per_threadblock),
+              dim3(warp_size, num_warps_per_threadblock),
               0,
               at::cuda::getCurrentCUDAStream(),
               dev_weights.data_ptr<emb_t>(),

--- a/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
+++ b/fbgemm_gpu/codegen/training/pt2/embedding_split_host_pt2_autograd_template.cpp
@@ -1078,9 +1078,9 @@ static torch::autograd::variable_list backward(
 
     TORCH_CHECK_EQ(grad_outputs.size(), 1);
 
+    const int32_t BT_block_size = at::cuda::warp_size();
+    int32_t max_segment_length_per_warp = at::cuda::warp_size();
 #ifdef USE_ROCM
-    constexpr int32_t BT_block_size = 64;
-    int32_t max_segment_length_per_warp = 64;
     {%- if (not nobag) and
            (optimizer == "rowwise_adagrad") and
            (not vbe) and
@@ -1110,9 +1110,6 @@ static torch::autograd::variable_list backward(
     }
     {%- endfor %}
     {%- endif %}
-#else
-    constexpr int32_t BT_block_size = 32;
-    constexpr int32_t max_segment_length_per_warp = 32;
 #endif
     using torch::autograd::Variable;
 

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/bitonic_sort.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/bitonic_sort.cuh
@@ -89,19 +89,16 @@ inline __device__ void warpBitonicMergeLE16(K& k, V& v) {
 template <typename K, typename V, bool Dir, typename Comp>
 struct BitonicSort {
   static inline __device__ void sort(K k[1], V v[1]) {
-#ifdef USE_ROCM
-    static_assert(fbgemm_gpu::kWarpSize == 64, "unexpected warp size");
-#else
-    static_assert(fbgemm_gpu::kWarpSize == 32, "unexpected warp size");
-#endif
     warpBitonicMergeLE16<K, V, 1, Dir, Comp, false>(k[0], v[0]);
     warpBitonicMergeLE16<K, V, 2, Dir, Comp, false>(k[0], v[0]);
     warpBitonicMergeLE16<K, V, 4, Dir, Comp, false>(k[0], v[0]);
     warpBitonicMergeLE16<K, V, 8, Dir, Comp, false>(k[0], v[0]);
     warpBitonicMergeLE16<K, V, 16, Dir, Comp, false>(k[0], v[0]);
-#ifdef USE_ROCM
-    // AMD wavefronts are 64-wide, so we need a 6th merge stage (L=32)
-    // to fully sort all 64 elements. L=32 <= kWarpSize/2 = 32. ✓
+#if defined(USE_ROCM) && defined(__GFX9__)
+    // warpSize 64 archs need a 6th merge stage (L=32) to fully sort all 64
+    // elements. On warpSize 32 archs the L=16 stage already covered the
+    // sort. Per-arch device compilation means the same source produces the
+    // right code for each offload arch.
     warpBitonicMergeLE16<K, V, 32, Dir, Comp, false>(k[0], v[0]);
 #endif
   }

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_prelude.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_prelude.cuh
@@ -61,10 +61,23 @@ namespace fbgemm_gpu {
 #define DIV_ROUND_UP(a, b) (a + b - 1) / b
 
 // Warp size
-#ifdef USE_ROCM
-static constexpr int32_t kWarpSize = 64;
-#else
+//
+// Device code: per-arch constexpr. __GFX9__ is defined by HIP-Clang during
+// device compilation for gfx9xx targets (warpSize 64); it is undefined for
+// warpSize 32 targets. HIP-Clang runs the device-code backend once per
+// --offload-arch, so the same source produces correct per-arch device code.
+//
+// Host code on ROCm: warpSize is only known at runtime. This 64 is a
+// stop-gap constexpr. Host-side launches that must size thread blocks for
+// the active device should call at::cuda::warp_size() directly.
+#if !defined(USE_ROCM)
 static constexpr int32_t kWarpSize = 32;
+#elif defined(__GFX9__)
+static constexpr int32_t kWarpSize = 64;
+#elif defined(__HIP_DEVICE_COMPILE__)
+static constexpr int32_t kWarpSize = 32;
+#else
+static constexpr int32_t kWarpSize = 64;
 #endif
 
 // Max thread num in one thread block
@@ -77,10 +90,15 @@ static constexpr int32_t kMaxBlockYDim = 65535;
 static constexpr int32_t kMaxBlockZDim = 65535;
 
 // Full warp mask
+//
+// On ROCm this is always uint64_t regardless of warpSize. HIP's
+// __ballot_sync / __any_sync / __all_sync statically require a 64-bit mask
+// type and internally truncate on warpSize 32 archs, so narrowing
+// kFullWarpMask would break compilation.
 #if defined(USE_ROCM)
-static constexpr uint64_t kFullWarpMask = 0xff'ff'ff'ff'ff'ff'ff'ff;
+static constexpr uint64_t kFullWarpMask = 0xff'ff'ff'ff'ff'ff'ff'ffull;
 #else
-static constexpr uint32_t kFullWarpMask = 0xff'ff'ff'ff;
+static constexpr uint32_t kFullWarpMask = 0xff'ff'ff'ffu;
 #endif
 
 static constexpr float kQParamEps = 1e-8f;
@@ -176,11 +194,12 @@ DEVICE_INLINE void syncwarp() {
 #endif
 }
 
-// ROCm does not natively support __any_sync(). Using __ballot()
-// (https://rocmdocs.amd.com/en/latest/Programming_Guides/Kernel_language.html)
-// to implement __any_sync(). Note: the "warp-size" of AMD GPU is 64.
+// ROCm does not natively support __any_sync() on older HIP versions. Using
+// __ballot() to implement __any_sync(). The mask is uint64_t to match
+// kFullWarpMask and the HIP warp-sync function signatures; on warpSize 32
+// archs only the low 32 bits of the ballot and the mask are meaningful.
 #ifdef USE_ROCM
-__device__ int __any_sync(uint64_t mask, int predicate) {
+__device__ inline int __any_sync(uint64_t mask, int predicate) {
   uint64_t predicate_bit_pattern = __ballot(predicate);
   return (predicate_bit_pattern & mask) > 0;
 }

--- a/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_find.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lfu_cache_find.cu
@@ -53,11 +53,7 @@ __global__ __launch_bounds__(kMaxThreads) void lfu_cache_find_uncached_kernel(
     const auto slot = threadIdx.x;
     const bool found = ::__ldg((&lxu_cache_state[cache_set][0]) + slot) == idx;
 
-#ifdef USE_ROCM
-    if (!__any_sync(0xFFFFFFFFFFFFFFFF, found)) {
-#else
-    if (!__any_sync(0xFFFFFFFF, found)) {
-#endif
+    if (!__any_sync(kFullWarpMask, found)) {
       if (threadIdx.x == 0) {
         // sort so the highest LFUs come first in the segment.
         // assume lfu_state[idx] <= 2^40 - 1 and cache_set < 2^24 -1

--- a/fbgemm_gpu/src/split_embeddings_cache/lru_cache_find.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lru_cache_find.cu
@@ -131,11 +131,7 @@ __global__ __launch_bounds__(kMaxThreads) void lru_cache_find_uncached_kernel(
       }
     }
 
-#ifdef USE_ROCM
-    if (!__any_sync(0xFFFFFFFFFFFFFFFF, found)) {
-#else
-    if (!__any_sync(0xFFFFFFFF, found)) {
-#endif
+    if (!__any_sync(kFullWarpMask, found)) {
       if (threadIdx.x == 0) {
         cache_sets[n] = cache_set;
         n_misses++;

--- a/fbgemm_gpu/src/split_embeddings_cache/lxu_cache.cu
+++ b/fbgemm_gpu/src/split_embeddings_cache/lxu_cache.cu
@@ -294,19 +294,13 @@ __global__ __launch_bounds__(kMaxThreads) void lxu_cache_lookup_kernel(
     n_indices++;
     const bool found =
         (::__ldg((&lxu_cache_state[cache_set][0]) + slot) == idx);
-#ifdef USE_ROCM
-    // HIP does not support __ballot_sync with mask; use __ballot instead.
-    // AMD wavefronts execute in lockstep, so no explicit sync is needed.
-    // __ballot returns uint64_t on ROCm (64-wide wavefront).
-    const auto bitmap = __ballot(found);
-    if (bitmap) {
-      const auto way = __ffsll(bitmap) - 1;
-#else
-    const auto bitmap = __ballot_sync(0xFFFFFFFF, found);
+    // fbgemm_gpu::ballot_sync wraps __ballot (ROCm, unsynchronized) vs
+    // __ballot_sync (CUDA). Return type is uint64_t on ROCm and uint32_t
+    // on CUDA, so __ffsll handles both via implicit promotion.
+    const auto bitmap = fbgemm_gpu::ballot_sync(found);
     if (bitmap) {
       // LSB == 1 hence we need to subtract one to get lane ID.
-      const auto way = __ffs(bitmap) - 1;
-#endif
+      const auto way = __ffsll(static_cast<long long>(bitmap)) - 1;
       if (i == threadIdx.x) {
         cache_location = cache_set * kWarpSize + way;
       }


### PR DESCRIPTION
fbgemm_gpu previously hardcoded warpSize=64 under USE_ROCM, which broke warpSize 32 archs either at compile time or at runtime. This change makes the ROCm build warpSize-neutral so a single wheel built with multiple archs in PYTORCH_ROCM_ARCH (e.g. "gfx90a;gfx1100") runs correctly on both warpSize 64 and warpSize 32 devices.

Header changes (cuda_prelude.cuh):
- kWarpSize now resolves to 64 only when __GFX9__ is defined during the device pass, 32 otherwise (warpSize 32 device, NVIDIA), and 64 as a host-side stop-gap. Per-arch device compilation means the same source produces correct per-arch device code.
- kFullWarpMask is uint64_t on ROCm regardless of warpSize: HIP's __ballot_sync / __any_sync / __all_sync templates statically require a 64-bit mask and adjust internally on warpSize 32, so a uint32_t kFullWarpMask on warpSize 32 archs would fail to compile.
- ballot_sync wrapper returns uint64_t on ROCm; __any_sync shim takes uint64_t mask; both match HIP signatures.

Bitonic sort: the L=32 extra merge stage is now gated on __GFX9__ rather than USE_ROCM, so warpSize 32 archs skip it. The unconditional static_assert is removed.

Cache code: lru/lfu_cache_find and lxu_cache use kFullWarpMask and the fbgemm_gpu::ballot_sync wrapper instead of hardcoded 0xFFFFFFFF / 0xFFFFFFFFFFFFFFFF literals.

Inference: embedding_forward_quantized_split_lookup's subwarp_mask is now uint64_t on ROCm to match HIP's warp-sync mask requirement.

Host-side launch configs: embedding_forward_split_template, embedding_backward_split_template, and embedding_split_host_pt2_autograd read the active device's warpSize via at::cuda::warp_size() instead of the compile-time kWarpSize.

Optimized HIP backward kernel: dispatch is now runtime-gated on at::cuda::warp_size() == 64 && rocm::is_supported_cdna(). On warpSize 32 devices the host wrapper falls through to the generic shuffle-based backward kernel that the main Jinja codegen already emits and that becomes warpSize-correct via the device-side kWarpSize.

Verification on a warpSize 64 (gfx90a) host:
- PYTORCH_ROCM_ARCH=gfx90a regression build: clean
- PYTORCH_ROCM_ARCH="gfx90a;gfx1100" mixed-arch build: clean; both hipv4-amdgcn-amd-amdhsa--gfx90a and hipv4-amdgcn-amd-amdhsa--gfx1100 device-code bundles are present in every shared library.
- TBE forward / backward adagrad / backward dense pytest suites: all green

Out of scope (deferred follow-ups): the experimental gen_ai / moe / sparse sweep, the codegen items_per_warp dual-warpSize dispatch tables, SPIR-V support, and a warpSize 32-tuned equivalent of the optimized HIP backward kernel.

Co-Authored-By: Claude Opus 4.7 (1M context)