### PR TITLE
Add laser_batch_size to IGR enrichment, Add sleep for enrichemnt

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -271,6 +271,8 @@ class EnrichmentPolicy(NamedTuple):
     fs_feature_group_id: int = 0
     fs_feature_group_name: str = ""
     fs_feature_name: str = ""
+    # Laser IGR batch size (0 = no batching, send all IDs in one RPC)
+    laser_batch_size: int = 0
 
 
 class KVZCHParams(NamedTuple):

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -833,6 +833,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                     ep.fs_feature_group_id,
                     ep.fs_feature_group_name,
                     ep.fs_feature_name,
+                    ep.laser_batch_size,
                 )
             self._ssd_db = torch.classes.fbgemm.DramKVEmbeddingCacheWrapper(
                 self.cache_row_dim,

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/enrichment_config.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/enrichment_config.h
@@ -68,7 +68,8 @@ struct EnrichmentConfig : public torch::jit::CustomClassHolder {
       int64_t fs_batch_size = 500,
       int64_t fs_feature_group_id = 0,
       std::string fs_feature_group_name = "",
-      std::string fs_feature_name = "")
+      std::string fs_feature_name = "",
+      int64_t laser_batch_size = 0)
       : enrichment_type_(static_cast<EnrichmentType>(enrichment_type)),
         provider_name_(std::move(provider_name)),
         client_id_(std::move(client_id)),
@@ -88,7 +89,8 @@ struct EnrichmentConfig : public torch::jit::CustomClassHolder {
         fs_batch_size_(fs_batch_size),
         fs_feature_group_id_(fs_feature_group_id),
         fs_feature_group_name_(std::move(fs_feature_group_name)),
-        fs_feature_name_(std::move(fs_feature_name)) {}
+        fs_feature_name_(std::move(fs_feature_name)),
+        laser_batch_size_(laser_batch_size) {}
 
   EnrichmentType enrichment_type_;
   std::string provider_name_;
@@ -115,6 +117,9 @@ struct EnrichmentConfig : public torch::jit::CustomClassHolder {
   int64_t fs_feature_group_id_;
   std::string fs_feature_group_name_;
   std::string fs_feature_name_;
+
+  // Laser IGR batch size (0 = no batching, send all IDs in one RPC)
+  int64_t laser_batch_size_;
 };
 
 } // namespace kv_mem

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -1082,7 +1082,8 @@ auto enrichment_config =
                 int64_t,
                 int64_t,
                 std::string,
-                std::string>(),
+                std::string,
+                int64_t>(),
             "",
             {
                 torch::arg("enrichment_type"),
@@ -1104,6 +1105,7 @@ auto enrichment_config =
                 torch::arg("fs_feature_group_id") = 0,
                 torch::arg("fs_feature_group_name") = "",
                 torch::arg("fs_feature_name") = "",
+                torch::arg("laser_batch_size") = 0,
             });
 
 static auto dram_kv_embedding_cache_wrapper =


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2635

CONTEXT: ig_reels_tab_mtml KVZCH training jobs fail with gloo TCP read timeout (kernel ETIMEDOUT) in checkpoint_scheduler.py:893. Root cause is that IGR Laser enrichment ships 1-2M zero-weight IDs in a single coMultiget RPC; the resulting 100s-MB-to-GB response saturates the NIC for 12-26s, causing concurrent gloo broadcast traffic to hit kernel TCP retransmit failures. A reference job using the same KVZCH+enrichment configuration but with smaller per-fetch payloads (~80K IDs, ~32MB response, 1-2s latency) runs to completion.

WHAT: Adds laser_batch_size knob to EnrichmentConfig (default 0 = no-op) and wires it into fetchEmbeddingsFromLaser to chunk requests serially with 200ms sleep between batches, mirroring the existing FeatureStore (fs_batch_size) and OpenTab (opentab_batch_size) batching pattern. Reduces per-RPC NIC/incast peak duration and gives concurrent gloo collectives a chance to slip through during sleep windows.

Differential Revision: D102007202


