### PR TITLE
Gate enrichment_policy by per-TBE embedding_cache_mode (#5698)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -251,8 +251,19 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                 assert self.optimizer in [
                     OptimType.EXACT_ROWWISE_ADAGRAD
                 ], f"only EXACT_ROWWISE_ADAGRAD supports embedding cache mode, but got {self.optimizer}"
-            # pyre-ignore [16]
-            self._enrichment_enabled = self.kv_zch_params.enrichment_policy is not None
+            # enrichment_policy is plumbed globally from KVZCHTBEConfig and reaches
+            # every TBE that shares the params, but enrichment is only meaningful
+            # when this TBE is acting as an external-write cache. Gate it on
+            # embedding_cache_mode (which is already populated per-TBE by the
+            # ZeroCollision*Cache wrappers in batched_embedding_kernel.py) so a
+            # regular gradient-trained KVZCH TBE does not run the enrichment-only
+            # paths (early-return flush, async enrichment writeback) that would
+            # otherwise cause fp16 weight overflow on unrelated tables.
+            self._enrichment_enabled = (
+                # pyre-ignore [16]
+                self.kv_zch_params.enrichment_policy is not None
+                and self._embedding_cache_mode
+            )
             if self.load_ckpt_without_opt:
                 if (
                     # pyre-ignore [16]
@@ -806,7 +817,11 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                     eviction_policy.interval_for_feature_statistics_decay_s,
                 )
             enrichment_config = None
-            if self.kv_zch_params and self.kv_zch_params.enrichment_policy is not None:
+            if (
+                self.kv_zch_params
+                and self.kv_zch_params.enrichment_policy is not None
+                and self._embedding_cache_mode
+            ):
                 ep = self.kv_zch_params.enrichment_policy
                 if ep.enrichment_type is None:
                     raise ValueError(


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2637

CONTEXT: KVZCHTBEConfig.enrichment_policy is plumbed globally through
KVZCHParams (batched_embedding_kernel.py:543-555) and reaches every
KVZCH TBE that shares the params. embedding_cache_mode is already
populated per-TBE (the ZeroCollisionEmbeddingCache /
ZeroCollisionEmbeddingEnrichmentCache wrappers hardcode True; the
plain ZeroCollisionKeyValueEmbedding path leaves it False), but
enrichment_policy is not. As a result, regular gradient-trained KVZCH
TBEs incorrectly get _enrichment_enabled=True and a C++
EnrichmentConfig wired into their DramKVEmbeddingCacheWrapper. They
then run the enrichment-only paths (early-return flush, async
enrichment writeback, special cache slot management) instead of the
standard evict / SSD-cache backward paths, which has been observed to
cause fp16 weight overflow on unrelated tables (the 4 suspect tables
nonpooled_post_id_duplicate, nonpooled_responsiveness_post_id,
nonpooled_responsiveness_author_id, sparse_query_viewer_rid).

WHAT (training.py only):
- Gate self._enrichment_enabled on self._embedding_cache_mode in
  addition to enrichment_policy presence. Enrichment is meaningful
  only when this TBE is acting as an external-write cache; tying it
  to the already per-TBE embedding_cache_mode flag keeps the two
  switches consistent without introducing any new schema or model
  config field.
- Apply the same gate when constructing the C++ EnrichmentConfig that
  is handed to DramKVEmbeddingCacheWrapper, so the backend wrapper of
  a regular KVZCH TBE no longer receives an enrichment_config.

No caller / KVZCHTBEConfig / EnrichmentPolicy schema changes are
required. Existing callers that had only one TBE under the same
KVZCHParams continue to behave identically because their TBE has
embedding_cache_mode=True.

Reviewed By: emlin

Differential Revision: D102632450
