### PR TITLE
Add SVE-FP16 version of EmbeddingSpMDM8Bit

### DIFF
--- a/bench/EmbeddingSpMDM8BitBenchmark.cc
+++ b/bench/EmbeddingSpMDM8BitBenchmark.cc
@@ -49,6 +49,8 @@ static vector<vector<int>> GetInputs_() {
       {10, 4000000, 64, 100},
       {10, 4000000, 128, 100},
       {10, 4000000, 256, 100},
+      {10, 4000000, 512, 100},
+      {10, 4000000, 1024, 100},
       // Use these for debugging
       // {2, 16, 128, 10},
       // {10, 4000, 128, 100},
@@ -84,8 +86,18 @@ static int run_benchmark(
     float* scale_bias = reinterpret_cast<float*>(
         &fused_embedding_table[i * (embedding_dim + 2 * sizeof(float))] +
         embedding_dim);
-    scale_bias[0] = 2.0;
-    scale_bias[1] = 1.0;
+    // FP16 accumulation (eps ~= 9.77e-4) loses precision vs FP32
+    // (eps ~= 1.19e-7) when summing many embeddings. For a bag of L
+    // embeddings the worst-case relative error is O(L * eps_fp16);
+    // at L=100 that is ~10%. Use smaller scale/bias to keep the
+    // accumulated values in a range where fp16 precision is adequate.
+    if (is_sve_fp16_enabled()) {
+      scale_bias[0] = 0.5;
+      scale_bias[1] = 0.25;
+    } else {
+      scale_bias[0] = 2.0;
+      scale_bias[1] = 1.0;
+    }
   }
 
   // print_fused_table(num_rows, embedding_dim, fused_embedding_table);
@@ -125,8 +137,15 @@ static int run_benchmark(
 
   // Generate weights
   vector<float> weights(lengths_sum);
-  for (int i = 0; i < lengths_sum; ++i) {
-    weights[i] = embedding_distribution(generator);
+  if (is_sve_fp16_enabled()) {
+    uniform_real_distribution<float> pos_weight_dist(0.0f, 1.0f);
+    for (int i = 0; i < lengths_sum; ++i) {
+      weights[i] = pos_weight_dist(generator);
+    }
+  } else {
+    for (int i = 0; i < lengths_sum; ++i) {
+      weights[i] = embedding_distribution(generator);
+    }
   }
 
   vector<OutType> output_sls_ref(batch_size * embedding_dim);
@@ -275,6 +294,20 @@ static int run_benchmark(
             } else {
               assert(false && "ERROR: unsupported output type");
               cout << "ERROR: unsupported output type" << '\n';
+            }
+            if constexpr (std::is_same_v<OutType, uint16_t>) {
+              // FP16 accumulation introduces ~0.5-1% relative error vs
+              // the FP32 reference at avg_length=100. Use relaxed
+              // tolerance: atol=1e-2, rtol=1e-2.
+              if (!is_bf16_out && is_sve_fp16_enabled()) {
+                float tol =
+                    std::max(1e-2f, std::max(fabs(tmp1), fabs(tmp2)) * 1e-2f);
+                assert(fabs(tmp1 - tmp2) < tol);
+                if (fabs(tmp1 - tmp2) >= tol) {
+                  cout << i << " " << tmp1 << " " << tmp2 << '\n';
+                }
+                continue;
+              }
             }
             assert(fabs(tmp1 - tmp2) < 1e-3);
             if (fabs(tmp1 - tmp2) >= 1e-3) {

--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -414,6 +414,7 @@ FBGEMM_API bool is_autovec_disabled();
 FBGEMM_API bool is_autovec_forced();
 FBGEMM_API bool is_asmjit_disabled();
 FBGEMM_API bool is_stats_enabled();
+FBGEMM_API bool is_sve_fp16_enabled();
 
 FBGEMM_API void set_autovec_disabled(bool val);
 FBGEMM_API void set_autovec_forced(bool val);

--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -1140,6 +1140,35 @@ typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType, outType>::
                  const float*
                      weights, // optional, can be null for non-weighted sum
                  outType* out) {
+        if constexpr (std::is_same_v<outType, uint16_t>) {
+          // FP16 accumulation (eps ~= 9.77e-4) trades precision for
+          // throughput: ~0.5-1% relative error vs FP32 at typical bag
+          // sizes (L=100), worst-case O(L * eps_fp16) ~= 10%.
+          if (is_sve_fp16_enabled() && !is_bf16_out) {
+            return internal::EmbeddingSpMDM8Bit_Sve_Fp16<
+                indxType,
+                offsetType,
+                outType,
+                true,
+                true>(
+                block_size,
+                output_size,
+                index_size,
+                data_size,
+                input_u8,
+                indices,
+                offsets_or_lengths,
+                weights,
+                normalize_by_lengths,
+                out,
+                is_weight_positional,
+                use_offsets,
+                output_stride,
+                input_stride,
+                scale_bias_last,
+                is_bf16_out);
+          }
+        }
         return internal::
             EmbeddingSpMDM8Bit_Sve<indxType, offsetType, outType, true, true>(
                 block_size,
@@ -1169,6 +1198,35 @@ typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType, outType>::
                  const float* weights, // optional, can be null for
                                        // non-weighted sum
                  outType* out) {
+        if constexpr (std::is_same_v<outType, uint16_t>) {
+          // FP16 accumulation (eps ~= 9.77e-4) trades precision for
+          // throughput: ~0.5-1% relative error vs FP32 at typical bag
+          // sizes (L=100), worst-case O(L * eps_fp16) ~= 10%.
+          if (is_sve_fp16_enabled() && !is_bf16_out) {
+            return internal::EmbeddingSpMDM8Bit_Sve_Fp16<
+                indxType,
+                offsetType,
+                outType,
+                false,
+                true>(
+                block_size,
+                output_size,
+                index_size,
+                data_size,
+                input_u8,
+                indices,
+                offsets_or_lengths,
+                weights,
+                normalize_by_lengths,
+                out,
+                is_weight_positional,
+                use_offsets,
+                output_stride,
+                input_stride,
+                scale_bias_last,
+                is_bf16_out);
+          }
+        }
         return internal::
             EmbeddingSpMDM8Bit_Sve<indxType, offsetType, outType, false, true>(
                 block_size,

--- a/src/EmbeddingSpMDMSve.h
+++ b/src/EmbeddingSpMDMSve.h
@@ -631,6 +631,942 @@ bool EmbeddingSpMDM8Bit_Sve(
   return current == index_size;
 }
 
+template <bool FuseWithOutput>
+static inline void sve_fma_round_fp16(
+    const uint8_t* input_row,
+    float16_t* buf,
+    uint64_t iters,
+    float16_t scale_val,
+    float16_t bias_val,
+    svbool_t fullRowPred,
+    svbool_t lastPred) {
+  svfloat16_t scale = svdup_n_f16(scale_val);
+  svfloat16_t bias = svdup_n_f16(bias_val);
+
+  const uint64_t vec_len_h = svcnth();
+  const uint8_t* input_ptr = input_row;
+  float16_t* bufPtr = buf;
+
+  uint64_t pairs = iters / 2;
+  for (uint64_t i = 0; i < pairs; ++i) {
+    svuint16_t in_v_0 = svld1ub_u16(fullRowPred, input_ptr);
+    svuint16_t in_v_1 = svld1ub_u16(fullRowPred, input_ptr + vec_len_h);
+    input_ptr += 2 * vec_len_h;
+
+    svfloat16_t in_f_0 = svcvt_f16_u16_x(fullRowPred, in_v_0);
+    svfloat16_t in_f_1 = svcvt_f16_u16_x(fullRowPred, in_v_1);
+
+    if constexpr (FuseWithOutput) {
+      svfloat16_t buf_0 = svld1_f16(fullRowPred, bufPtr);
+      svfloat16_t buf_1 = svld1_f16(fullRowPred, bufPtr + vec_len_h);
+      buf_0 = svadd_f16_x(fullRowPred, buf_0, bias);
+      buf_1 = svadd_f16_x(fullRowPred, buf_1, bias);
+      in_f_0 = svmad_f16_m(fullRowPred, in_f_0, scale, buf_0);
+      in_f_1 = svmad_f16_m(fullRowPred, in_f_1, scale, buf_1);
+    } else {
+      in_f_0 = svmad_f16_m(fullRowPred, in_f_0, scale, bias);
+      in_f_1 = svmad_f16_m(fullRowPred, in_f_1, scale, bias);
+    }
+
+    svst1_f16(fullRowPred, bufPtr, in_f_0);
+    svst1_f16(fullRowPred, bufPtr + vec_len_h, in_f_1);
+    bufPtr += 2 * vec_len_h;
+  }
+
+  if (iters % 2 != 0) {
+    svuint16_t in_v = svld1ub_u16(fullRowPred, input_ptr);
+    input_ptr += vec_len_h;
+
+    svfloat16_t in_v_f = svcvt_f16_u16_x(fullRowPred, in_v);
+
+    if constexpr (FuseWithOutput) {
+      svfloat16_t buf_sv = svld1_f16(fullRowPred, bufPtr);
+      buf_sv = svadd_f16_x(fullRowPred, buf_sv, bias);
+      in_v_f = svmad_f16_m(fullRowPred, in_v_f, scale, buf_sv);
+    } else {
+      in_v_f = svmad_f16_m(fullRowPred, in_v_f, scale, bias);
+    }
+
+    svst1_f16(fullRowPred, bufPtr, in_v_f);
+    bufPtr += vec_len_h;
+  }
+
+  {
+    svuint16_t in_v = svld1ub_u16(lastPred, input_ptr);
+
+    svfloat16_t in_v_f = svcvt_f16_u16_x(lastPred, in_v);
+
+    if constexpr (FuseWithOutput) {
+      svfloat16_t buf_sv = svld1_f16(lastPred, bufPtr);
+      buf_sv = svadd_f16_x(lastPred, buf_sv, bias);
+      in_v_f = svmad_f16_m(lastPred, in_v_f, scale, buf_sv);
+    } else {
+      in_v_f = svmad_f16_m(lastPred, in_v_f, scale, bias);
+    }
+
+    svst1_f16(lastPred, bufPtr, in_v_f);
+  }
+}
+
+static inline void load_scale_bias_fp16(
+    const uint8_t* row_base,
+    int64_t scale_bias_offset,
+    bool scale_bias_last,
+    float16_t& scale,
+    float16_t& bias) {
+  if (scale_bias_last) {
+    const float* sb =
+        reinterpret_cast<const float*>(row_base + scale_bias_offset);
+    scale = static_cast<float16_t>(sb[0]);
+    bias = static_cast<float16_t>(sb[1]);
+  } else {
+    const float16_t* sb = reinterpret_cast<const float16_t*>(row_base);
+    scale = sb[0];
+    bias = sb[1];
+  }
+}
+
+template <
+    typename IndexType,
+    typename OffsetType,
+    typename OutType,
+    bool NoBag,
+    bool EnablePrefetching>
+bool EmbeddingSpMDM8Bit_Sve_Fp16(
+    const int64_t block_size,
+    const int64_t output_size,
+    const int64_t index_size,
+    const int64_t data_size,
+    const uint8_t* input,
+    const IndexType* indices,
+    const OffsetType* offsets_or_lengths,
+    const float* weights,
+    const bool normalize_by_lengths,
+    OutType* out,
+    const bool is_weight_positional,
+    const bool use_offsets,
+    const int64_t output_stride,
+    const int64_t input_stride,
+    const bool scale_bias_last,
+    const bool /*is_bf16_out*/) {
+  // This kernel is only dispatched for fp16 output (OutType == uint16_t,
+  // !is_bf16_out). All paths produce fp16 directly — no fp32 widening.
+  if constexpr (!std::is_same_v<OutType, uint16_t>) {
+    return false;
+  }
+
+  if (data_size < 0) {
+    return false;
+  }
+
+  // This kernel uses NEON fp16 intrinsics (128-bit fixed-width).
+  // Fall back to the baseline SVE kernel on wider SVE implementations.
+  if (svcnth() != 8) {
+    return false;
+  }
+
+  constexpr int64_t CACHE_LINE_SIZE = 64;
+  constexpr int64_t MAX_INITIAL_PREFETCH_ROWS = 16;
+  const int64_t prefetch_stride =
+      std::min(MAX_INITIAL_PREFETCH_ROWS, index_size);
+
+  if constexpr (EnablePrefetching) {
+    for (int64_t pf_idx = 0; pf_idx < prefetch_stride; ++pf_idx) {
+      const uint8_t* prefetch_addr = input + input_stride * indices[pf_idx];
+      for (int64_t offset = 0; offset < input_stride;
+           offset += CACHE_LINE_SIZE) {
+        do_prefetch(prefetch_addr + offset, 0, 0);
+      }
+    }
+  }
+
+  constexpr int64_t scale_bias_size = 2 * sizeof(float16);
+  const int64_t scale_bias_offset = scale_bias_last ? block_size : 0;
+  const int64_t input_offset = scale_bias_last ? 0 : scale_bias_size;
+
+  uint64_t iters_8 = ((uint64_t)std::max<int64_t>(block_size, 0)) / 8ull;
+  uint64_t block_size_mod_8 = block_size % 8;
+
+  svbool_t fullRowPred16 = svptrue_b16();
+  svbool_t lastPredC = svwhilelt_b16_u64(0, block_size_mod_8);
+  svbool_t lastPred16 = svwhilelt_b16_u64(0, block_size_mod_8);
+
+  if constexpr (NoBag) {
+    for (int64_t m = 0; m < output_size; ++m) {
+      const IndexType idx = indices[m];
+
+      if (idx < 0 || idx >= data_size) {
+        return false;
+      }
+
+      const uint8_t* input_row_base = input + input_stride * idx;
+      float16_t scale_val, bias_val;
+      load_scale_bias_fp16(
+          input_row_base,
+          scale_bias_offset,
+          scale_bias_last,
+          scale_val,
+          bias_val);
+      if (weights) {
+        float w = weights[m];
+        scale_val = static_cast<float16_t>(static_cast<float>(scale_val) * w);
+        bias_val = static_cast<float16_t>(static_cast<float>(bias_val) * w);
+      }
+
+      sve_fma_round_fp16<false>(
+          input_row_base + input_offset,
+          reinterpret_cast<float16_t*>(out),
+          iters_8,
+          scale_val,
+          bias_val,
+          fullRowPred16,
+          lastPred16);
+
+      out += output_stride;
+    } // m
+    EmbeddingStatsTracker::getInstance().recordPattern(
+        data_size,
+        block_size,
+        EmbeddingStatsTracker::DataType::INT8,
+        EmbeddingStatsTracker::DataType::FP16,
+        output_size,
+        1);
+    return true;
+  } // no_bag
+
+  // Accumulate entirely in NEON fp16 registers and store fp16 directly —
+  // no intermediate buffer, no fp32 widening needed.
+  // For ITERS <= 16 (dims <= 128), all accumulators fit in registers.
+  // For ITERS > 16, process in tiles of 16 chunks.
+  if (iters_8 <= 32) {
+    int64_t current = 0;
+    const float* weights_addr = weights;
+    int64_t outputSize = output_size;
+
+    // Process one output row using ITERS NEON-width (8 fp16) accumulator
+    // chunks.  ITERS == iters_8 for this invocation.
+    auto process_row = [&]<uint64_t ITERS>() -> bool {
+      // For ITERS <= 16: accumulators cover the full dim in registers.
+      // For ITERS > 16 (e.g. dim=256): process in tiles of CHUNK=16 chunks,
+      // re-iterating all embeddings per tile to keep register pressure at 16.
+      constexpr uint64_t CHUNK = ITERS <= 16 ? ITERS : 16;
+      constexpr uint64_t NUM_TILES = ITERS <= 16 ? 1 : (ITERS + 15) / 16;
+
+      float16x8_t acc[CHUNK < 1 ? 1 : CHUNK];
+      float16x8_t acc_b[ITERS <= 8 ? (CHUNK < 1 ? 1 : CHUNK) : 1];
+      float16x8_t acc_tail = vdupq_n_f16(0.0f);
+      float16x8_t acc_b_tail = vdupq_n_f16(0.0f);
+
+      const OffsetType raw_len = use_offsets
+          ? offsets_or_lengths[1] - offsets_or_lengths[0]
+          : offsets_or_lengths[0];
+      const int64_t end = current + raw_len;
+      if (end > index_size) {
+        return false;
+      }
+      EmbeddingStatsTracker::getInstance().recordPattern(
+          data_size,
+          block_size,
+          EmbeddingStatsTracker::DataType::INT8,
+          EmbeddingStatsTracker::DataType::FP16,
+          output_size,
+          raw_len);
+
+      const int64_t len =
+          normalize_by_lengths ? static_cast<int64_t>(raw_len) : 0;
+      if (is_weight_positional) {
+        weights_addr = weights;
+      }
+
+      bool oneIterationDone = false;
+
+      // ---- Tiled path for ITERS > 16 (e.g. dim=256) ----
+      // Process the dimension in tiles of CHUNK=16 chunks (128 elements).
+      // Each tile iterates all embeddings, accumulating in 16 NEON fp16
+      // registers, then optionally normalizes and writes to the output slice.
+      if constexpr (ITERS > 16) {
+        const int64_t current_start = current;
+        const float* weights_start = weights_addr;
+
+        const float16x8_t norm_fp16 = vdupq_n_f16(
+            len > 0 ? (float16_t)(1.0f / static_cast<float>(len))
+                    : (float16_t)1.0f);
+        const bool do_normalize = (len > 0);
+
+        for (uint64_t tile = 0; tile < NUM_TILES; ++tile) {
+          const uint64_t tile_offset = tile * CHUNK * 8;
+          // Number of full 8-element chunks in this tile
+          constexpr uint64_t LAST_TILE_ITERS =
+              ITERS % 16 == 0 ? 16 : (ITERS % 16);
+          const uint64_t tile_iters =
+              (tile == NUM_TILES - 1) ? LAST_TILE_ITERS : CHUNK;
+
+          for (uint64_t j = 0; j < tile_iters; ++j) {
+            acc[j] = vdupq_n_f16(0.0f);
+          }
+          acc_tail = vdupq_n_f16(0.0f);
+
+          // Reset to start of embedding list for each tile
+          // (last tile leaves current/weights_addr advanced past end)
+          int64_t tile_current =
+              (tile == NUM_TILES - 1) ? current : current_start;
+          const float* tile_weights = weights_start;
+
+          for (; tile_current < end; ++tile_current) {
+            const IndexType idx = indices[tile_current];
+
+            if constexpr (EnablePrefetching) {
+              const IndexType pidx = indices[std::min(
+                  tile_current + prefetch_stride, index_size - 1)];
+              const uint8_t* paddr = input + input_stride * pidx;
+              for (int64_t off = 0; off < input_stride;
+                   off += CACHE_LINE_SIZE) {
+                do_prefetch(paddr + off, 0, 0);
+              }
+            }
+
+            if (idx < 0 || idx >= data_size) {
+              if (!scale_bias_last && idx == -1) {
+                if (weights != nullptr) {
+                  ++tile_weights;
+                }
+                continue;
+              }
+              return false;
+            }
+
+            const uint8_t* input_row_base = input + input_stride * idx;
+            float16_t scale_val, bias_val;
+            load_scale_bias_fp16(
+                input_row_base,
+                scale_bias_offset,
+                scale_bias_last,
+                scale_val,
+                bias_val);
+            if (weights != nullptr) {
+              float w = *tile_weights;
+              scale_val =
+                  static_cast<float16_t>(static_cast<float>(scale_val) * w);
+              bias_val =
+                  static_cast<float16_t>(static_cast<float>(bias_val) * w);
+              ++tile_weights;
+            }
+
+            const float16x8_t scale_neon = vdupq_n_f16(scale_val);
+            const float16x8_t bias_neon = vdupq_n_f16(bias_val);
+            const uint8_t* input_row =
+                input_row_base + input_offset + tile_offset;
+
+            for (uint64_t j = 0; j < tile_iters; ++j) {
+              const float16x8_t in_f16 =
+                  vcvtq_f16_u16(vmovl_u8(vld1_u8(input_row + j * 8)));
+              acc[j] =
+                  vaddq_f16(acc[j], vfmaq_f16(bias_neon, in_f16, scale_neon));
+            }
+            // Tail only on last tile if block_size % 8 != 0
+            if (tile == NUM_TILES - 1 && block_size_mod_8 > 0) {
+              const svfloat16_t sc = svset_neonq_f16(svundef_f16(), scale_neon);
+              const svfloat16_t bs = svset_neonq_f16(svundef_f16(), bias_neon);
+              svuint16_t in_v =
+                  svld1ub_u16(lastPredC, input_row + tile_iters * 8);
+              svfloat16_t in_sv = svmad_f16_m(
+                  lastPredC, svcvt_f16_u16_x(lastPredC, in_v), sc, bs);
+              acc_tail = svget_neonq(svadd_f16_m(
+                  lastPredC, svset_neonq_f16(svundef_f16(), acc_tail), in_sv));
+            }
+            oneIterationDone = true;
+          }
+
+          // On last tile, advance current/weights_addr past end
+          if (tile == NUM_TILES - 1) {
+            current = tile_current;
+            weights_addr = tile_weights;
+          }
+
+          // Store fp16 accumulators directly to output slice
+          if (oneIterationDone) {
+            float16_t* outPtr = reinterpret_cast<float16_t*>(out) + tile_offset;
+            for (uint64_t j = 0; j < tile_iters; ++j) {
+              float16x8_t val = acc[j];
+              if (do_normalize) {
+                val = vmulq_f16(val, norm_fp16);
+              }
+              vst1q_f16(outPtr, val);
+              outPtr += 8;
+            }
+            if (tile == NUM_TILES - 1 && block_size_mod_8 > 0) {
+              float16x8_t tail = acc_tail;
+              if (do_normalize) {
+                tail = vmulq_f16(tail, norm_fp16);
+              }
+              svst1_f16(
+                  lastPredC, outPtr, svset_neonq_f16(svundef_f16(), tail));
+            }
+          }
+        } // tile loop
+
+        if (!oneIterationDone) {
+          memset(out, 0, sizeof(OutType) * block_size);
+        }
+        return true;
+      } // ITERS > 16 tiled path
+
+      // ---- Non-tiled path for ITERS <= 16 ----
+      // Initialize accumulators
+      for (uint64_t j = 0; j < CHUNK; ++j) {
+        acc[j] = vdupq_n_f16(0.0f);
+        if constexpr (ITERS <= 8) {
+          acc_b[j] = vdupq_n_f16(0.0f);
+        }
+      }
+
+      // Phase 1: paired loop — process two embeddings per iteration.
+      // Only used for ITERS <= 8: 2-way needs 2*ITERS accumulator registers,
+      // which fits within 32 Q-regs for ITERS <= 8 (plus temps).
+      // For ITERS > 8 (dim=128) Phase 1 is skipped entirely; all embeddings
+      // are handled by Phase 2 below.
+      if constexpr (ITERS <= 8) {
+        while (current + 1 < end) {
+          const IndexType idx_a = indices[current];
+          const IndexType idx_b = indices[current + 1];
+
+          if (idx_a < 0 || idx_b < 0) {
+            break;
+          }
+          if (idx_a >= data_size || idx_b >= data_size) {
+            return false;
+          }
+
+          if constexpr (EnablePrefetching) {
+            auto prefetch_row = [&](int64_t cur) {
+              const IndexType pidx =
+                  indices[std::min(cur + prefetch_stride, index_size - 1)];
+              const uint8_t* paddr = input + input_stride * pidx;
+              for (int64_t off = 0; off < input_stride;
+                   off += CACHE_LINE_SIZE) {
+                do_prefetch(paddr + off, 0, 0);
+              }
+            };
+            prefetch_row(current);
+            prefetch_row(current + 1);
+          }
+
+          const uint8_t* row_base_a = input + input_stride * idx_a;
+          float16_t scale_a, bias_a;
+          load_scale_bias_fp16(
+              row_base_a, scale_bias_offset, scale_bias_last, scale_a, bias_a);
+          if (weights != nullptr) {
+            float w = weights_addr[0];
+            scale_a = static_cast<float16_t>(static_cast<float>(scale_a) * w);
+            bias_a = static_cast<float16_t>(static_cast<float>(bias_a) * w);
+          }
+          const float16x8_t scale_a_neon = vdupq_n_f16(scale_a);
+          const float16x8_t bias_a_neon = vdupq_n_f16(bias_a);
+          const uint8_t* row_a = row_base_a + input_offset;
+
+          const uint8_t* row_base_b = input + input_stride * idx_b;
+          float16_t scale_b, bias_b;
+          load_scale_bias_fp16(
+              row_base_b, scale_bias_offset, scale_bias_last, scale_b, bias_b);
+          if (weights != nullptr) {
+            float w = weights_addr[1];
+            scale_b = static_cast<float16_t>(static_cast<float>(scale_b) * w);
+            bias_b = static_cast<float16_t>(static_cast<float>(bias_b) * w);
+          }
+          const float16x8_t scale_b_neon = vdupq_n_f16(scale_b);
+          const float16x8_t bias_b_neon = vdupq_n_f16(bias_b);
+          const uint8_t* row_b = row_base_b + input_offset;
+
+          for (uint64_t j = 0; j < ITERS; ++j) {
+            const float16x8_t in_a =
+                vcvtq_f16_u16(vmovl_u8(vld1_u8(row_a + j * 8)));
+            const float16x8_t in_b =
+                vcvtq_f16_u16(vmovl_u8(vld1_u8(row_b + j * 8)));
+            acc[j] =
+                vaddq_f16(acc[j], vfmaq_f16(bias_a_neon, in_a, scale_a_neon));
+            acc_b[j] =
+                vaddq_f16(acc_b[j], vfmaq_f16(bias_b_neon, in_b, scale_b_neon));
+          }
+          if (block_size_mod_8 > 0) {
+            const svfloat16_t sc_a =
+                svset_neonq_f16(svundef_f16(), scale_a_neon);
+            const svfloat16_t bs_a =
+                svset_neonq_f16(svundef_f16(), bias_a_neon);
+            svuint16_t in_v_a = svld1ub_u16(lastPredC, row_a + ITERS * 8);
+            svfloat16_t in_sv_a = svmad_f16_m(
+                lastPredC, svcvt_f16_u16_x(lastPredC, in_v_a), sc_a, bs_a);
+            acc_tail = svget_neonq(svadd_f16_m(
+                lastPredC, svset_neonq_f16(svundef_f16(), acc_tail), in_sv_a));
+
+            const svfloat16_t sc_b =
+                svset_neonq_f16(svundef_f16(), scale_b_neon);
+            const svfloat16_t bs_b =
+                svset_neonq_f16(svundef_f16(), bias_b_neon);
+            svuint16_t in_v_b = svld1ub_u16(lastPredC, row_b + ITERS * 8);
+            svfloat16_t in_sv_b = svmad_f16_m(
+                lastPredC, svcvt_f16_u16_x(lastPredC, in_v_b), sc_b, bs_b);
+            acc_b_tail = svget_neonq(svadd_f16_m(
+                lastPredC,
+                svset_neonq_f16(svundef_f16(), acc_b_tail),
+                in_sv_b));
+          }
+
+          current += 2;
+          if (weights != nullptr) {
+            weights_addr += 2;
+          }
+          oneIterationDone = true;
+        }
+      } // if constexpr (ITERS <= 8)
+
+      // Phase 2: scalar cleanup — handles the last odd embedding and any
+      // embedding after a -1 index that caused Phase 1 to break early.
+      for (; current < end; ++current) {
+        IndexType idx = indices[current];
+
+        if constexpr (EnablePrefetching) {
+          IndexType prefetch_idx =
+              indices[std::min(current + prefetch_stride, index_size - 1)];
+          const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
+          for (int64_t offset = 0; offset < input_stride;
+               offset += CACHE_LINE_SIZE) {
+            do_prefetch(prefetch_addr + offset, 0, 0);
+          }
+        }
+
+        if (idx < 0 || idx >= data_size) {
+          if (!scale_bias_last && idx == -1) {
+            if (weights != nullptr) {
+              ++weights_addr;
+            }
+            continue;
+          }
+          return false;
+        }
+
+        const uint8_t* input_row_base = input + input_stride * idx;
+        float16_t scale_val, bias_val;
+        load_scale_bias_fp16(
+            input_row_base,
+            scale_bias_offset,
+            scale_bias_last,
+            scale_val,
+            bias_val);
+        if (weights != nullptr) {
+          float w = *weights_addr;
+          scale_val = static_cast<float16_t>(static_cast<float>(scale_val) * w);
+          bias_val = static_cast<float16_t>(static_cast<float>(bias_val) * w);
+          ++weights_addr;
+        }
+
+        const float16x8_t scale_neon = vdupq_n_f16(scale_val);
+        const float16x8_t bias_neon = vdupq_n_f16(bias_val);
+        const uint8_t* input_row = input_row_base + input_offset;
+
+        for (uint64_t j = 0; j < ITERS; ++j) {
+          const float16x8_t in_f16 =
+              vcvtq_f16_u16(vmovl_u8(vld1_u8(input_row + j * 8)));
+          acc[j] = vaddq_f16(acc[j], vfmaq_f16(bias_neon, in_f16, scale_neon));
+        }
+        if (block_size_mod_8 > 0) {
+          const svfloat16_t sc = svset_neonq_f16(svundef_f16(), scale_neon);
+          const svfloat16_t bs = svset_neonq_f16(svundef_f16(), bias_neon);
+          svuint16_t in_v = svld1ub_u16(lastPredC, input_row + ITERS * 8);
+          svfloat16_t in_sv =
+              svmad_f16_m(lastPredC, svcvt_f16_u16_x(lastPredC, in_v), sc, bs);
+          acc_tail = svget_neonq(svadd_f16_m(
+              lastPredC, svset_neonq_f16(svundef_f16(), acc_tail), in_sv));
+        }
+        oneIterationDone = true;
+      }
+
+      // Store fp16 accumulators directly — no fp32 widening needed
+      if (oneIterationDone) {
+        const float16x8_t norm_fp16 = vdupq_n_f16(
+            len > 0 ? (float16_t)(1.0f / static_cast<float>(len))
+                    : (float16_t)1.0f);
+        const bool do_normalize = (len > 0);
+
+        float16_t* outPtr = reinterpret_cast<float16_t*>(out);
+        for (uint64_t j = 0; j < ITERS; ++j) {
+          float16x8_t combined;
+          if constexpr (ITERS <= 8) {
+            combined = vaddq_f16(acc[j], acc_b[j]);
+          } else {
+            combined = acc[j];
+          }
+          if (do_normalize) {
+            combined = vmulq_f16(combined, norm_fp16);
+          }
+          vst1q_f16(outPtr, combined);
+          outPtr += 8;
+        }
+        if (block_size_mod_8 > 0) {
+          float16x8_t tail;
+          if constexpr (ITERS <= 8) {
+            tail = vaddq_f16(acc_tail, acc_b_tail);
+          } else {
+            tail = acc_tail;
+          }
+          if (do_normalize) {
+            tail = vmulq_f16(tail, norm_fp16);
+          }
+          svst1_f16(lastPredC, outPtr, svset_neonq_f16(svundef_f16(), tail));
+        }
+      } else {
+        memset(out, 0, sizeof(OutType) * block_size);
+      }
+      return true;
+    };
+
+    for (; outputSize > 0;
+         ++offsets_or_lengths, --outputSize, out += output_stride) {
+      bool ok;
+      switch (iters_8) {
+        case 0:
+          ok = process_row.template operator()<0>();
+          break;
+        case 1:
+          ok = process_row.template operator()<1>();
+          break;
+        case 2:
+          ok = process_row.template operator()<2>();
+          break;
+        case 3:
+          ok = process_row.template operator()<3>();
+          break;
+        case 4:
+          ok = process_row.template operator()<4>();
+          break;
+        case 5:
+          ok = process_row.template operator()<5>();
+          break;
+        case 6:
+          ok = process_row.template operator()<6>();
+          break;
+        case 7:
+          ok = process_row.template operator()<7>();
+          break;
+        case 8:
+          ok = process_row.template operator()<8>();
+          break;
+        case 9:
+          ok = process_row.template operator()<9>();
+          break;
+        case 10:
+          ok = process_row.template operator()<10>();
+          break;
+        case 11:
+          ok = process_row.template operator()<11>();
+          break;
+        case 12:
+          ok = process_row.template operator()<12>();
+          break;
+        case 13:
+          ok = process_row.template operator()<13>();
+          break;
+        case 14:
+          ok = process_row.template operator()<14>();
+          break;
+        case 15:
+          ok = process_row.template operator()<15>();
+          break;
+        case 16:
+          ok = process_row.template operator()<16>();
+          break;
+        case 17:
+          ok = process_row.template operator()<17>();
+          break;
+        case 18:
+          ok = process_row.template operator()<18>();
+          break;
+        case 19:
+          ok = process_row.template operator()<19>();
+          break;
+        case 20:
+          ok = process_row.template operator()<20>();
+          break;
+        case 21:
+          ok = process_row.template operator()<21>();
+          break;
+        case 22:
+          ok = process_row.template operator()<22>();
+          break;
+        case 23:
+          ok = process_row.template operator()<23>();
+          break;
+        case 24:
+          ok = process_row.template operator()<24>();
+          break;
+        case 25:
+          ok = process_row.template operator()<25>();
+          break;
+        case 26:
+          ok = process_row.template operator()<26>();
+          break;
+        case 27:
+          ok = process_row.template operator()<27>();
+          break;
+        case 28:
+          ok = process_row.template operator()<28>();
+          break;
+        case 29:
+          ok = process_row.template operator()<29>();
+          break;
+        case 30:
+          ok = process_row.template operator()<30>();
+          break;
+        case 31:
+          ok = process_row.template operator()<31>();
+          break;
+        case 32:
+          ok = process_row.template operator()<32>();
+          break;
+        default:
+          ok = false;
+          break;
+      }
+      if (!ok) {
+        return false;
+      }
+    }
+    return current == index_size;
+  } // register-based fp16 path
+
+  // Fallback: buf-based fp16 accumulation for large dims (iters_8 > 32).
+  // Fully inlined FMA loop — no helper function calls.
+  // Mirrors EmbeddingSpMDM8Bit_Sve outer loop structure exactly.
+  uint64_t iters_16 = ((uint64_t)std::max<int64_t>(block_size, 0)) / 16ull;
+  uint64_t block_size_mod_16 = block_size % 16;
+  svbool_t fullRowPredH = svptrue_b16();
+  svbool_t lastPredAH = svwhilelt_b16_u64(0, block_size_mod_16);
+  svbool_t lastPredBH = svwhilelt_b16_u64(8, block_size_mod_16);
+
+  int64_t current = 0;
+  const float* weights_addr = weights;
+  int64_t outputSize = output_size;
+  for (; outputSize > 0;
+       ++offsets_or_lengths, --outputSize, out += output_stride) {
+    OffsetType len = use_offsets ? offsets_or_lengths[1] - offsets_or_lengths[0]
+                                 : offsets_or_lengths[0];
+    int64_t end = current + len;
+    if (end > index_size) {
+      return false;
+    }
+
+    EmbeddingStatsTracker::getInstance().recordPattern(
+        data_size,
+        block_size,
+        EmbeddingStatsTracker::DataType::INT8,
+        EmbeddingStatsTracker::DataType::FP16,
+        output_size,
+        len);
+
+    if (!normalize_by_lengths) {
+      len = 0;
+    }
+
+    float16x8x2_t* buf = reinterpret_cast<float16x8x2_t*>(out);
+
+    if (is_weight_positional) {
+      weights_addr = weights;
+    }
+    bool oneIterationDone = false;
+    for (; !oneIterationDone && current < end; ++current) {
+      IndexType idx = indices[current];
+
+      if constexpr (EnablePrefetching) {
+        IndexType prefetch_idx =
+            indices[std::min(current + prefetch_stride, index_size - 1)];
+        const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
+        for (int64_t offset = 0; offset < input_stride;
+             offset += CACHE_LINE_SIZE) {
+          do_prefetch(prefetch_addr + offset, 1);
+        }
+      }
+
+      if (idx < 0 || idx >= data_size) {
+        if (!scale_bias_last && idx == -1) {
+          if (weights != nullptr) {
+            ++weights_addr;
+          }
+          continue;
+        }
+        return false;
+      }
+
+      const uint8_t* input_row_base = input + input_stride * idx;
+      const float* scale_bias_addr =
+          reinterpret_cast<const float*>(input_row_base + scale_bias_offset);
+      svfloat16_t scale, bias;
+      if (scale_bias_last) {
+        scale = svdup_n_f16(static_cast<float16_t>(scale_bias_addr[0]));
+        bias = svdup_n_f16(static_cast<float16_t>(scale_bias_addr[1]));
+      } else {
+        const float16_t* sb_fp16 = reinterpret_cast<const float16_t*>(
+            input_row_base + scale_bias_offset);
+        scale = svdup_n_f16(sb_fp16[0]);
+        bias = svdup_n_f16(sb_fp16[1]);
+      }
+      if (weights != nullptr) {
+        svfloat16_t wt = svdup_n_f16(static_cast<float16_t>(*weights_addr));
+        scale = svmul_f16_x(fullRowPredH, scale, wt);
+        bias = svmul_f16_x(fullRowPredH, bias, wt);
+        ++weights_addr;
+      }
+
+      const uint8_t* input_row = input_row_base + input_offset;
+      float16x8x2_t* bptr = buf;
+      const uint64_t* iv0 = reinterpret_cast<const uint64_t*>(input_row);
+      const uint64_t* iv1 = reinterpret_cast<const uint64_t*>(input_row + 8);
+      const uint64_t* iend = iv0 + iters_16 * 2;
+      while (iv0 < iend) {
+        svuint16_t v0 =
+            svld1ub_u16(fullRowPredH, reinterpret_cast<const uint8_t*>(iv0));
+        svuint16_t v1 =
+            svld1ub_u16(fullRowPredH, reinterpret_cast<const uint8_t*>(iv1));
+        iv0 += 2;
+        iv1 += 2;
+        svfloat16_t f0 = svmad_f16_m(
+            fullRowPredH, svcvt_f16_u16_x(fullRowPredH, v0), scale, bias);
+        svfloat16_t f1 = svmad_f16_m(
+            fullRowPredH, svcvt_f16_u16_x(fullRowPredH, v1), scale, bias);
+        bptr->val[0] = svget_neonq(f0);
+        bptr->val[1] = svget_neonq(f1);
+        bptr += 1;
+      }
+      {
+        auto bp = reinterpret_cast<float16_t*>(bptr);
+        svuint16_t v0 =
+            svld1ub_u16(lastPredAH, reinterpret_cast<const uint8_t*>(iv0));
+        svuint16_t v1 =
+            svld1ub_u16(lastPredBH, reinterpret_cast<const uint8_t*>(iv1));
+        svfloat16_t f0 = svmad_f16_m(
+            lastPredAH, svcvt_f16_u16_x(lastPredAH, v0), scale, bias);
+        svfloat16_t f1 = svmad_f16_m(
+            lastPredBH, svcvt_f16_u16_x(lastPredBH, v1), scale, bias);
+        svst1_f16(lastPredAH, bp, f0);
+        svst1_f16(lastPredBH, bp + 8, f1);
+      }
+
+      oneIterationDone = true;
+    }
+
+    for (; current < end; ++current) {
+      IndexType idx = indices[current];
+
+      if constexpr (EnablePrefetching) {
+        IndexType prefetch_idx =
+            indices[std::min(current + prefetch_stride, index_size - 1)];
+        const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
+        for (int64_t offset = 0; offset < input_stride;
+             offset += CACHE_LINE_SIZE) {
+          do_prefetch(prefetch_addr + offset, 1);
+        }
+      }
+
+      if (idx < 0 || idx >= data_size) {
+        if (!scale_bias_last && idx == -1) {
+          if (weights != nullptr) {
+            ++weights_addr;
+          }
+          continue;
+        }
+        return false;
+      }
+
+      const uint8_t* input_row_base = input + input_stride * idx;
+      const float* scale_bias_addr =
+          reinterpret_cast<const float*>(input_row_base + scale_bias_offset);
+      svfloat16_t scale, bias;
+      if (scale_bias_last) {
+        scale = svdup_n_f16(static_cast<float16_t>(scale_bias_addr[0]));
+        bias = svdup_n_f16(static_cast<float16_t>(scale_bias_addr[1]));
+      } else {
+        const float16_t* sb_fp16 = reinterpret_cast<const float16_t*>(
+            input_row_base + scale_bias_offset);
+        scale = svdup_n_f16(sb_fp16[0]);
+        bias = svdup_n_f16(sb_fp16[1]);
+      }
+      if (weights != nullptr) {
+        svfloat16_t wt = svdup_n_f16(static_cast<float16_t>(*weights_addr));
+        scale = svmul_f16_x(fullRowPredH, scale, wt);
+        bias = svmul_f16_x(fullRowPredH, bias, wt);
+        ++weights_addr;
+      }
+
+      const uint8_t* input_row = input_row_base + input_offset;
+      float16x8x2_t* bptr = buf;
+      const uint64_t* iv0 = reinterpret_cast<const uint64_t*>(input_row);
+      const uint64_t* iv1 = reinterpret_cast<const uint64_t*>(input_row + 8);
+      const uint64_t* iend = iv0 + iters_16 * 2;
+      while (iv0 < iend) {
+        svuint16_t v0 =
+            svld1ub_u16(fullRowPredH, reinterpret_cast<const uint8_t*>(iv0));
+        svuint16_t v1 =
+            svld1ub_u16(fullRowPredH, reinterpret_cast<const uint8_t*>(iv1));
+        iv0 += 2;
+        iv1 += 2;
+        svfloat16_t cv0 = svcvt_f16_u16_x(fullRowPredH, v0);
+        svfloat16_t cv1 = svcvt_f16_u16_x(fullRowPredH, v1);
+        float16x8_t b0 = vaddq_f16(bptr->val[0], svget_neonq(bias));
+        float16x8_t b1 = vaddq_f16(bptr->val[1], svget_neonq(bias));
+        svfloat16_t f0 = svmad_f16_m(
+            fullRowPredH, cv0, scale, svset_neonq_f16(svundef_f16(), b0));
+        svfloat16_t f1 = svmad_f16_m(
+            fullRowPredH, cv1, scale, svset_neonq_f16(svundef_f16(), b1));
+        bptr->val[0] = svget_neonq(f0);
+        bptr->val[1] = svget_neonq(f1);
+        bptr += 1;
+      }
+      {
+        auto bp = reinterpret_cast<float16_t*>(bptr);
+        svuint16_t v0 =
+            svld1ub_u16(lastPredAH, reinterpret_cast<const uint8_t*>(iv0));
+        svuint16_t v1 =
+            svld1ub_u16(lastPredBH, reinterpret_cast<const uint8_t*>(iv1));
+        svfloat16_t cv0 = svcvt_f16_u16_x(lastPredAH, v0);
+        svfloat16_t cv1 = svcvt_f16_u16_x(lastPredBH, v1);
+        svfloat16_t sb0 = svld1_f16(lastPredAH, bp);
+        svfloat16_t sb1 = svld1_f16(lastPredBH, bp + 8);
+        sb0 = svadd_f16_x(lastPredAH, sb0, bias);
+        sb1 = svadd_f16_x(lastPredBH, sb1, bias);
+        svfloat16_t f0 = svmad_f16_m(lastPredAH, cv0, scale, sb0);
+        svfloat16_t f1 = svmad_f16_m(lastPredBH, cv1, scale, sb1);
+        svst1_f16(lastPredAH, bp, f0);
+        svst1_f16(lastPredBH, bp + 8, f1);
+      }
+    }
+    if (oneIterationDone) {
+      if (len) {
+        float16x8_t norm =
+            vdupq_n_f16(static_cast<float16_t>(1.0f / static_cast<float>(len)));
+        float16x8x2_t* bptr = buf;
+        float16x8x2_t* bend = bptr + iters_16;
+        for (; bptr < bend;) {
+          bptr->val[0] = vmulq_f16(bptr->val[0], norm);
+          bptr->val[1] = vmulq_f16(bptr->val[1], norm);
+          bptr += 1;
+        }
+        {
+          auto bp = reinterpret_cast<float16_t*>(bptr);
+          svfloat16_t t0 = svld1_f16(lastPredAH, bp);
+          svfloat16_t t1 = svld1_f16(lastPredBH, bp + 8);
+          t0 =
+              svmul_f16_x(lastPredAH, t0, svset_neonq_f16(svundef_f16(), norm));
+          t1 =
+              svmul_f16_x(lastPredBH, t1, svset_neonq_f16(svundef_f16(), norm));
+          svst1_f16(lastPredAH, bp, t0);
+          svst1_f16(lastPredBH, bp + 8, t1);
+        }
+      }
+    } else {
+      memset(out, 0, sizeof(OutType) * block_size);
+    }
+  }
+  return current == index_size;
+}
+
 } // namespace internal
 } // namespace fbgemm
 

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -825,4 +825,16 @@ bool is_stats_enabled() {
   return res;
 }
 
+bool is_sve_fp16_enabled() {
+  static bool res;
+  static bool called_once = false;
+  if (called_once) {
+    return res;
+  }
+  called_once = true;
+  char* env_val = std::getenv("FBGEMM_TBE_SVE_FP16_ACCUMULATOR");
+  res = (env_val != nullptr);
+  return res;
+}
+
 } // namespace fbgemm

--- a/test/EmbeddingSpMDM8BitTest.cc
+++ b/test/EmbeddingSpMDM8BitTest.cc
@@ -44,6 +44,14 @@ static vector<vector<int>> GetInputs_() {
 
 static vector<int> prefetch_distances{0, 16, 1000000};
 
+static float fp16_tolerance(int /*average_len*/, float expected) {
+  return 0.01f + 0.01f * abs(expected);
+}
+
+static float clamp_for_fp16(float val) {
+  return std::min(std::abs(val), 1.0f);
+}
+
 namespace {
 
 class Fused8BitRowwiseEmbeddingLookupTest : public testing::TestWithParam<tuple<
@@ -125,13 +133,23 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
           fused_embedding_table.data() + i * fused_embedding_dim +
           (scale_bias_last ? embedding_dim : 0));
       if (scale_bias_last) {
-        scale_bias[0] = embedding_distribution(generator);
-        scale_bias[1] = embedding_distribution(generator);
+        float s = embedding_distribution(generator);
+        float b = embedding_distribution(generator);
+        if (is_sve_fp16_enabled()) {
+          s = clamp_for_fp16(s);
+          b = clamp_for_fp16(b);
+        }
+        scale_bias[0] = s;
+        scale_bias[1] = b;
       } else {
-        reinterpret_cast<float16*>(scale_bias)[0] =
-            cpu_float2half_rn(embedding_distribution(generator));
-        reinterpret_cast<float16*>(scale_bias)[1] =
-            cpu_float2half_rn(embedding_distribution(generator));
+        float s = embedding_distribution(generator);
+        float b = embedding_distribution(generator);
+        if (is_sve_fp16_enabled()) {
+          s = clamp_for_fp16(s);
+          b = clamp_for_fp16(b);
+        }
+        reinterpret_cast<float16*>(scale_bias)[0] = cpu_float2half_rn(s);
+        reinterpret_cast<float16*>(scale_bias)[1] = cpu_float2half_rn(b);
       }
     }
 
@@ -154,6 +172,12 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
         (use_offsets ? offsets : lengths).data();
     const int32_t* offsets_or_lengths_32 =
         (use_offsets ? offsets_32 : lengths_32).data();
+
+    if (is_sve_fp16_enabled()) {
+      for (auto& w : weights) {
+        w = abs(w);
+      }
+    }
 
     if (!scale_bias_last && use_weight) {
       // When scale_bias_last == false, assume this is for table batched
@@ -295,15 +319,29 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
         float expected = (out_type == FLOAT)
             ? output_ref[i]
             : convert_to_float_ref(output_ref_16b[i], out_type == BFLOAT16);
-        EXPECT_EQ(actual, expected)
-            << "results differ at (" << i << ") from " << output.size()
-            << " reference: " << expected << ", FBGEMM: " << actual
-            << " emb dim :" << embedding_dim << " batch_size :" << batch_size
-            << " num_rows :" << num_rows << " lengths_sum :" << lengths_sum
-            << " corner_case :" << corner_case << " use_weight :" << use_weight
-            << " normalize_by_lengths :" << normalize_by_lengths
-            << " is_wt_pos " << is_wt_positional << " scale_bias_last "
-            << scale_bias_last << " out_type " << out_type;
+        if (is_sve_fp16_enabled() && out_type == FLOAT16) {
+          EXPECT_NEAR(actual, expected, fp16_tolerance(average_len, expected))
+              << "results differ at (" << i << ") from " << output.size()
+              << " reference: " << expected << ", FBGEMM: " << actual
+              << " emb dim :" << embedding_dim << " batch_size :" << batch_size
+              << " num_rows :" << num_rows << " lengths_sum :" << lengths_sum
+              << " corner_case :" << corner_case
+              << " use_weight :" << use_weight
+              << " normalize_by_lengths :" << normalize_by_lengths
+              << " is_wt_pos " << is_wt_positional << " scale_bias_last "
+              << scale_bias_last << " out_type " << out_type;
+        } else {
+          EXPECT_EQ(actual, expected)
+              << "results differ at (" << i << ") from " << output.size()
+              << " reference: " << expected << ", FBGEMM: " << actual
+              << " emb dim :" << embedding_dim << " batch_size :" << batch_size
+              << " num_rows :" << num_rows << " lengths_sum :" << lengths_sum
+              << " corner_case :" << corner_case
+              << " use_weight :" << use_weight
+              << " normalize_by_lengths :" << normalize_by_lengths
+              << " is_wt_pos " << is_wt_positional << " scale_bias_last "
+              << scale_bias_last << " out_type " << out_type;
+        }
       }
       for (int offset = output_size_wo_sentries;
            offset < output_size_wo_sentries + num_sentries;
@@ -315,14 +353,385 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, basicTest) {
             ? output_ref[offset]
             : convert_to_float_ref(
                   output_ref_16b[offset], out_type == BFLOAT16);
-        EXPECT_EQ(actual, expected)
-            << "results differ at (" << offset << ") from "
-            << output_size_wo_sentries + num_sentries
-            << " reference: " << expected << ", FBGEMM: " << actual
-            << " emb dim :" << embedding_dim;
+        if (is_sve_fp16_enabled() && out_type == FLOAT16) {
+          EXPECT_NEAR(actual, expected, fp16_tolerance(average_len, expected))
+              << "results differ at (" << offset << ") from "
+              << output_size_wo_sentries + num_sentries
+              << " reference: " << expected << ", FBGEMM: " << actual
+              << " emb dim :" << embedding_dim;
+        } else {
+          EXPECT_EQ(actual, expected)
+              << "results differ at (" << offset << ") from "
+              << output_size_wo_sentries + num_sentries
+              << " reference: " << expected << ", FBGEMM: " << actual
+              << " emb dim :" << embedding_dim;
+        }
       }
     }
   } // end for input
+}
+
+TEST_P(Fused8BitRowwiseEmbeddingLookupTest, fp16CorrectnessTest) {
+  // Skip unless SVE FP16 is enabled and output type is FLOAT16
+  auto [prefetch, weight_choice, corner_case, out_type, kernel_choice] =
+      GetParam();
+  if (!is_sve_fp16_enabled() || out_type != FLOAT16) {
+    return;
+  }
+  ScopedKernelOverride kernel_override(kernel_choice);
+  bool use_weight = weight_choice != UNWEIGHTED;
+  bool is_wt_positional = weight_choice == POSITIONAL_WEIGHTED;
+
+  // Test configurations: small (register) cases
+  vector<vector<int>> inputs = {
+      // {batch, rows, dim, avg_len}
+      {4, 100, 8, 4},
+      {4, 100, 9, 4},
+      {4, 100, 28, 4},
+      {4, 100, 32, 10},
+      {4, 100, 64, 10},
+      {4, 100, 128, 10},
+      {4, 100, 256, 4},
+      {4, 100, 512, 10},
+      {4, 100, 1024, 10},
+      {4, 100, 1, 4},
+      {4, 100, 4, 10},
+      {4, 100, 48, 10}, // non-multiple-of-8
+  };
+
+  random_device r;
+  default_random_engine generator(r());
+  uniform_int_distribution<int> entries(0, 16);
+
+  for (auto& input : inputs) {
+    int batch_size = input[0];
+    int num_rows = input[1];
+    int embedding_dim = input[2];
+    int average_len = input[3];
+
+    // ---- Test 1: Integer scale/bias (should be exact) ----
+    {
+      int fused_embedding_dim = embedding_dim + 2 * sizeof(float);
+      vector<uint8_t> fused_embedding_table(num_rows * fused_embedding_dim);
+      for (int i = 0; i < num_rows; i++) {
+        for (int ii = 0; ii < embedding_dim; ii++) {
+          fused_embedding_table[i * fused_embedding_dim + ii] =
+              entries(generator);
+        }
+        float* scale_bias = reinterpret_cast<float*>(
+            fused_embedding_table.data() + i * fused_embedding_dim +
+            embedding_dim);
+        scale_bias[0] = 1.0f; // scale = 1.0 (exact in fp16)
+        scale_bias[1] = 0.0f; // bias = 0.0 (exact in fp16)
+      }
+
+      vector<int64_t> lengths, offsets, indices;
+      vector<int32_t> lengths_32, offsets_32, indices_32;
+      vector<float> weights;
+      int lengths_sum = GenerateLengthsIndicesWeights(
+          lengths,
+          lengths_32,
+          offsets,
+          offsets_32,
+          indices,
+          indices_32,
+          weights,
+          batch_size,
+          num_rows,
+          average_len,
+          corner_case);
+
+      if (use_weight) {
+        for (auto& w : weights) {
+          w = 1.0f;
+        }
+      }
+      if (is_wt_positional) {
+        for (auto& w : weights) {
+          w = 1.0f;
+        }
+      }
+
+      int output_size = batch_size;
+      vector<float16> output_ref_16b(output_size * embedding_dim);
+      vector<float16> output_16b(output_size * embedding_dim);
+
+      bool success_ref = EmbeddingSpMDM_ref<uint8_t, int64_t, int64_t, float16>(
+          embedding_dim,
+          batch_size,
+          lengths_sum,
+          num_rows,
+          fused_embedding_table.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+          offsets.data(),
+          use_weight ? weights.data() : nullptr,
+          false, // normalize_by_lengths
+          output_ref_16b.data(),
+          is_wt_positional,
+          true, // use_offsets
+          -1, // output_stride
+          -1, // input_stride
+          true, // scale_bias_last
+          false); // is_bf16_out
+
+      auto kernel =
+          GenerateEmbeddingSpMDMWithStrides<uint8_t, int64_t, int64_t, float16>(
+              embedding_dim,
+              use_weight,
+              false, // normalize_by_lengths
+              prefetch,
+              is_wt_positional,
+              true, // use_offsets
+              -1, // output_stride
+              -1, // input_stride
+              true, // scale_bias_last
+              false); // is_bf16_out
+
+      bool success = kernel(
+          batch_size,
+          lengths_sum,
+          num_rows,
+          fused_embedding_table.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+          offsets.data(),
+          use_weight ? weights.data() : nullptr,
+          output_16b.data());
+
+      ASSERT_EQ(success, success_ref)
+          << "Integer test: ref and kernel disagree on success"
+          << " dim=" << embedding_dim << " avg_len=" << average_len;
+      if (corner_case == OUT_OF_BOUND_INDICES ||
+          corner_case == UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM) {
+        EXPECT_FALSE(success);
+      }
+
+      if (success) {
+        for (int i = 0; i < output_size * embedding_dim; ++i) {
+          float actual = cpu_half2float(output_16b[i]);
+          float expected = cpu_half2float(output_ref_16b[i]);
+          EXPECT_EQ(actual, expected)
+              << "Integer test MISMATCH at i=" << i << " dim=" << embedding_dim
+              << " avg_len=" << average_len << " expected=" << expected
+              << " actual=" << actual << " use_weight=" << use_weight;
+        }
+      }
+    }
+
+    // ---- Test 2: fp16-representable float scale/bias ----
+    {
+      int fused_embedding_dim = embedding_dim + 2 * sizeof(float);
+      vector<uint8_t> fused_embedding_table(num_rows * fused_embedding_dim);
+      for (int i = 0; i < num_rows; i++) {
+        for (int ii = 0; ii < embedding_dim; ii++) {
+          fused_embedding_table[i * fused_embedding_dim + ii] =
+              entries(generator);
+        }
+        float* scale_bias = reinterpret_cast<float*>(
+            fused_embedding_table.data() + i * fused_embedding_dim +
+            embedding_dim);
+        // Use values exactly representable in fp16
+        scale_bias[0] = 0.25f; // scale
+        scale_bias[1] = 0.5f; // bias
+      }
+
+      vector<int64_t> lengths, offsets, indices;
+      vector<int32_t> lengths_32, offsets_32, indices_32;
+      vector<float> weights;
+      int lengths_sum = GenerateLengthsIndicesWeights(
+          lengths,
+          lengths_32,
+          offsets,
+          offsets_32,
+          indices,
+          indices_32,
+          weights,
+          batch_size,
+          num_rows,
+          average_len,
+          corner_case);
+
+      if (use_weight) {
+        for (auto& w : weights) {
+          w = 1.0f;
+        }
+      }
+      if (is_wt_positional) {
+        for (auto& w : weights) {
+          w = 1.0f;
+        }
+      }
+
+      int output_size = batch_size;
+      vector<float16> output_ref_16b(output_size * embedding_dim);
+      vector<float16> output_16b(output_size * embedding_dim);
+
+      bool success_ref = EmbeddingSpMDM_ref<uint8_t, int64_t, int64_t, float16>(
+          embedding_dim,
+          batch_size,
+          lengths_sum,
+          num_rows,
+          fused_embedding_table.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+          offsets.data(),
+          use_weight ? weights.data() : nullptr,
+          false,
+          output_ref_16b.data(),
+          is_wt_positional,
+          true,
+          -1,
+          -1,
+          true,
+          false);
+
+      auto kernel =
+          GenerateEmbeddingSpMDMWithStrides<uint8_t, int64_t, int64_t, float16>(
+              embedding_dim,
+              use_weight,
+              false,
+              prefetch,
+              is_wt_positional,
+              true,
+              -1,
+              -1,
+              true,
+              false);
+
+      bool success = kernel(
+          batch_size,
+          lengths_sum,
+          num_rows,
+          fused_embedding_table.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+          offsets.data(),
+          use_weight ? weights.data() : nullptr,
+          output_16b.data());
+
+      ASSERT_EQ(success, success_ref);
+      if (corner_case == OUT_OF_BOUND_INDICES ||
+          corner_case == UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM) {
+        EXPECT_FALSE(success);
+      }
+
+      if (success) {
+        for (int i = 0; i < output_size * embedding_dim; ++i) {
+          float actual = cpu_half2float(output_16b[i]);
+          float expected = cpu_half2float(output_ref_16b[i]);
+          EXPECT_EQ(actual, expected)
+              << "FP16 representable test at i=" << i
+              << " dim=" << embedding_dim << " avg_len=" << average_len
+              << " expected=" << expected << " actual=" << actual;
+        }
+      }
+    }
+
+    // ---- Test 3: Random fp32 scale/bias with normalization (measure error) --
+    for (int norm = 0; norm <= 1; ++norm) {
+      bool normalize = (norm == 1);
+      normal_distribution<float> embedding_distribution;
+      int fused_embedding_dim = embedding_dim + 2 * sizeof(float);
+      vector<uint8_t> fused_embedding_table(num_rows * fused_embedding_dim);
+      for (int i = 0; i < num_rows; i++) {
+        for (int ii = 0; ii < embedding_dim; ii++) {
+          fused_embedding_table[i * fused_embedding_dim + ii] =
+              entries(generator);
+        }
+        float* scale_bias = reinterpret_cast<float*>(
+            fused_embedding_table.data() + i * fused_embedding_dim +
+            embedding_dim);
+        float s = embedding_distribution(generator);
+        float b = embedding_distribution(generator);
+        if (is_sve_fp16_enabled()) {
+          s = clamp_for_fp16(s);
+          b = clamp_for_fp16(b);
+        }
+        scale_bias[0] = s;
+        scale_bias[1] = b;
+      }
+
+      vector<int64_t> lengths, offsets, indices;
+      vector<int32_t> lengths_32, offsets_32, indices_32;
+      vector<float> weights;
+      int lengths_sum = GenerateLengthsIndicesWeights(
+          lengths,
+          lengths_32,
+          offsets,
+          offsets_32,
+          indices,
+          indices_32,
+          weights,
+          batch_size,
+          num_rows,
+          average_len,
+          corner_case);
+
+      for (auto& w : weights) {
+        w = abs(w);
+      }
+
+      int output_size = batch_size;
+      vector<float16> output_ref_16b(output_size * embedding_dim);
+      vector<float16> output_16b(output_size * embedding_dim);
+
+      bool success_ref = EmbeddingSpMDM_ref<uint8_t, int64_t, int64_t, float16>(
+          embedding_dim,
+          batch_size,
+          lengths_sum,
+          num_rows,
+          fused_embedding_table.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+          offsets.data(),
+          use_weight ? weights.data() : nullptr,
+          normalize,
+          output_ref_16b.data(),
+          is_wt_positional,
+          true,
+          -1,
+          -1,
+          true,
+          false,
+          false);
+
+      auto kernel =
+          GenerateEmbeddingSpMDMWithStrides<uint8_t, int64_t, int64_t, float16>(
+              embedding_dim,
+              use_weight,
+              normalize,
+              prefetch,
+              is_wt_positional,
+              true,
+              -1,
+              -1,
+              true,
+              false);
+
+      bool success = kernel(
+          batch_size,
+          lengths_sum,
+          num_rows,
+          fused_embedding_table.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+          offsets.data(),
+          use_weight ? weights.data() : nullptr,
+          output_16b.data());
+
+      ASSERT_EQ(success, success_ref);
+      if (corner_case == OUT_OF_BOUND_INDICES ||
+          corner_case == UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM) {
+        EXPECT_FALSE(success);
+      }
+
+      if (success) {
+        for (int i = 0; i < output_size * embedding_dim; ++i) {
+          float actual = cpu_half2float(output_16b[i]);
+          float expected = cpu_half2float(output_ref_16b[i]);
+          EXPECT_NEAR(actual, expected, fp16_tolerance(average_len, expected))
+              << "Random test at i=" << i << " dim=" << embedding_dim
+              << " avg_len=" << average_len << " norm=" << normalize
+              << " wt=" << use_weight;
+        }
+      }
+    }
+  }
 }
 
 TEST_P(Fused8BitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
@@ -376,8 +785,14 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
       float* scale_bias = reinterpret_cast<float*>(
           fused_embedding_table.data() + i * fused_embedding_dim +
           embedding_dim);
-      scale_bias[0] = embedding_distribution(generator);
-      scale_bias[1] = embedding_distribution(generator);
+      float s = embedding_distribution(generator);
+      float b = embedding_distribution(generator);
+      if (is_sve_fp16_enabled()) {
+        s = clamp_for_fp16(s);
+        b = clamp_for_fp16(b);
+      }
+      scale_bias[0] = s;
+      scale_bias[1] = b;
     }
 
     vector<int64_t> lengths, offsets, indices;
@@ -399,6 +814,12 @@ TEST_P(Fused8BitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
         (use_offsets ? offsets : lengths).data();
     const int32_t* offsets_or_lengths_32 =
         (use_offsets ? offsets_32 : lengths_32).data();
+
+    if (is_sve_fp16_enabled()) {
+      for (auto& w : weights) {
+        w = abs(w);
+      }
+    }
 
     vector<float> output_sls_ref(batch_size * embedding_dim);
     vector<float> output_slws_ref(output_sls_ref.size()),


### PR DESCRIPTION
Summary:
## Summary
Adds a new FP16 version of the EmbeddingSpMDM8Bit kernel for ARM SVE using intrinsics, gated behind a runtime flag `FBGEMM_SVE_FP16`. The existing SVE kernel accumulates dequantized uint8 embeddings in FP32; this new path accumulates in FP16, doubling SIMD throughput (8 elements per instruction vs 4) at the cost of reduced intermediate precision.

## Benchmark Comparison: Baseline (FP32) vs FP16

## Variants Tested

| Variant | Description | Build flags |
|---------|-------------|-------------|
| **Baseline** | Default SVE FP32 kernel | `fbcode//mode/opt` |
| **Autovec** | Auto-vectorized path (no ASMJIT) | Baseline binary + `FBGEMM_NO_ASMJIT=1 FBGEMM_FORCE_AUTOVEC=1` env vars |
| **FP16** | Native SVE FP16 accumulation kernel | Baseline binary + `FBGEMM_TBE_SVE_FP16_ACCUMULATOR=1` env vars  |

The FP16 kernel processes **8 elements per iteration** vs 4 for FP32 (128-bit SVE),
and the intermediate buffer is half the size, improving cache utilization.

## 8-Bit Kernel with FP16 Output: Baseline vs SVE FP16 Register (direct store)

**Output type:** fp16 (`-DOUT_TYPE_FLOAT16`)

The baseline accumulates in fp16 via a scratch buffer, then widens to fp32 and
narrows back to fp16 for output. The SVE FP16 register path accumulates in
NEON fp16 registers and stores directly with `vst1q_f16` — eliminating the
intermediate buffer and the fp16→fp32→fp16 conversion entirely.

### SLS (Sparse Lengths Sum)

| Dim | Cache | Prefetch | Baseline | FP16 Reg | vs Baseline |
|-----|-------|----------|----------|----------|-------------|
| 32 | Hot | Off | 8.26 | 13.65 | **+65.2%** |
| 32 | Hot | On | 8.33 | 13.78 | **+65.5%** |
| 32 | Cold | Off | 1.83 | 2.49 | **+35.7%** |
| 32 | Cold | On | 1.81 | 2.39 | **+32.3%** |
| 64 | Hot | Off | 9.19 | 13.10 | **+42.5%** |
| 64 | Hot | On | 9.19 | 13.24 | **+44.1%** |
| 64 | Cold | Off | 2.12 | 2.60 | **+22.6%** |
| 64 | Cold | On | 2.10 | 2.59 | **+23.0%** |
| 128 | Hot | Off | 9.11 | 11.65 | **+27.8%** |
| 128 | Hot | On | 9.09 | 11.59 | **+27.5%** |
| 128 | Cold | Off | 2.19 | 2.42 | **+10.7%** |
| 128 | Cold | On | 2.19 | 2.39 | +8.9% |
| 256 | Hot | Off | 9.14 | 12.45 | **+36.1%** |
| 256 | Hot | On | 9.45 | 12.45 | **+31.8%** |
| 256 | Cold | Off | 3.14 | 3.45 | +9.7% |
| 256 | Cold | On | 3.15 | 3.49 | **+10.8%** |

### SLW (Sparse Lengths Weighted)

| Dim | Cache | Prefetch | Baseline | FP16 Reg | vs Baseline |
|-----|-------|----------|----------|----------|-------------|
| 32 | Hot | Off | 8.14 | 12.93 | **+58.8%** |
| 32 | Hot | On | 8.05 | 13.16 | **+63.6%** |
| 32 | Cold | Off | 1.85 | 2.32 | **+25.5%** |
| 32 | Cold | On | 1.88 | 2.47 | **+31.3%** |
| 64 | Hot | Off | 9.02 | 12.59 | **+39.6%** |
| 64 | Hot | On | 9.07 | 12.72 | **+40.4%** |
| 64 | Cold | Off | 2.13 | 2.58 | **+21.6%** |
| 64 | Cold | On | 2.11 | 2.57 | **+21.4%** |
| 128 | Hot | Off | 8.99 | 11.29 | **+25.5%** |
| 128 | Hot | On | 9.03 | 11.25 | **+24.6%** |
| 128 | Cold | Off | 2.27 | 2.40 | +5.9% |
| 128 | Cold | On | 2.30 | 2.39 | +3.7% |
| 256 | Hot | Off | 9.34 | 12.25 | **+31.2%** |
| 256 | Hot | On | 9.31 | 12.21 | **+31.2%** |
| 256 | Cold | Off | 2.61 | 3.44 | **+31.9%** |
| 256 | Cold | On | 3.20 | 3.49 | +9.1% |

### FP16 Output Average Speedup

| Mode | Cache | FP16 Reg vs Baseline |
|------|-------|----------------------|
| SLS | Hot | **+42.6%** |
| SLS | Cold | **+19.2%** |
| SLW | Hot | **+39.4%** |
| SLW | Cold | **+18.8%** |

Reviewed By: excelle08, helloguo

Differential Revision: D97560784
