### PR TITLE
Fix AMD GPU hang of MP-ZCH (#5708)

### DIFF
--- a/fbgemm_gpu/src/faster_hash_ops/faster_hash.cu
+++ b/fbgemm_gpu/src/faster_hash_ops/faster_hash.cu
@@ -32,6 +32,7 @@ static constexpr int32_t kDefaultTensor = -1;
 static constexpr int64_t kMaxIdentityNum = INT32_MAX;
 static constexpr int64_t kMaxHours = INT32_MAX;
 static constexpr int64_t kSecondsInHour = 60 * 60;
+static constexpr int32_t kMaxSpinCount = 1000 * 1000;
 
 template <typename T>
 __device__ __inline__ T CAS(T* data, T cmp, T val) {
@@ -167,12 +168,23 @@ __device__ __inline__ int64_t check_min(
   // wait.
   auto insert_idx = output_index + offset;
   int32_t last_seen = kDefaultTensor;
+  int32_t spin_count = 0;
   while (true) {
     last_seen =
         atomicCAS(metadata + insert_idx, kDefaultTensor, kDefaultTensor);
     if (last_seen != kDefaultTensor) {
       break;
     }
+    if (++spin_count == kMaxSpinCount) {
+      break;
+    }
+  }
+  if (spin_count == kMaxSpinCount) {
+    CUDA_KERNEL_ASSERT(
+        false &&
+        "MPZCH Exception: Max spin-count was achieved, possible GPU hang has "
+        "occurred due to atomic contention. Please reach out to oncall "
+        "torchrec");
   }
 
   // only check those expired slots
@@ -225,12 +237,23 @@ __device__ __inline__ bool check_evict<1>(
   // has not been written yet, while the other id checking the slot's eviction
   // status. Therefore, wait until the metadata is not -1.
   int32_t identity_metadata = kDefaultTensor;
+  int32_t spin_count = 0;
   while (true) {
     identity_metadata =
         atomicCAS(metadata + output_index, kDefaultTensor, kDefaultTensor);
     if (identity_metadata != kDefaultTensor) {
       break;
     }
+    if (++spin_count == kMaxSpinCount) {
+      break;
+    }
+  }
+  if (spin_count == kMaxSpinCount) {
+    CUDA_KERNEL_ASSERT(
+        false &&
+        "MPZCH Exception: Max spin-count was achieved, possible GPU hang has "
+        "occurred due to atomic contention. Please reach out to oncall "
+        "torchrec");
   }
   bool is_more_recent = (identity_metadata < metadata_val);
   bool threshold_met = (eviction_threshold > identity_metadata);
@@ -242,6 +265,8 @@ __device__ __inline__ bool check_and_maybe_update_slot(
     TIdentity* identities_slot,
     TIdentity identity,
     TIdentity& old_value,
+    int32_t* metadata_slot = nullptr,
+    int32_t metadata_val = 0,
     std::enable_if_t<READONLY == true>* = nullptr) {
   static_assert(READONLY);
   old_value = *identities_slot;
@@ -256,12 +281,21 @@ __device__ __inline__ bool check_and_maybe_update_slot(
     TIdentity* identities_slot,
     TIdentity identity,
     TIdentity& old_value,
+    int32_t* metadata_slot = nullptr,
+    int32_t metadata_val = 0,
     std::enable_if_t<READONLY == false>* = nullptr) {
   static_assert(!READONLY);
   old_value =
       CAS(identities_slot, static_cast<TIdentity>(kDefaultTensor), identity);
   if ((old_value == identity) ||
       (old_value == static_cast<TIdentity>(kDefaultTensor))) {
+    if (metadata_slot != nullptr &&
+        old_value == static_cast<TIdentity>(kDefaultTensor)) {
+      // Add an extra metadata write for AMD MI3X hardware,
+      // This removes the GPU-hang by moving the write closer toidentity
+      // reducing the window but not increasing the atomic contention.
+      atomicMax(metadata_slot, metadata_val);
+    }
     return true;
   }
   return false;
@@ -399,7 +433,15 @@ __global__ void process_item_zch(
     while (max_probe_local-- > 0 && opt_in) {
       auto insert_idx = output_index + offset;
       if (check_and_maybe_update_slot<READONLY, TIdentity>(
-              &identities[insert_idx][0], identity, old_value)) {
+              &identities[insert_idx][0],
+              identity,
+              old_value,
+              metadata ? metadata + insert_idx : nullptr,
+              metadata_val)) {
+        // Although check_and_maybe_update_slot also updates metadata
+        // when slot is empty, we need a extra call here, and placed here
+        // due to GPU hang that occurs with AMD MI3X hardware, i.e.
+        //  moving this call inside the check function does not mitigate it.
         update_metadata<METADATA_COUNT>(metadata, insert_idx, metadata_val);
         increment_freq_counter<ID_FREQ>(runtime_meta, insert_idx);
         break;
@@ -536,7 +578,15 @@ __global__ void process_item_zch(
     while (max_probe_local-- > 0 && opt_in) {
       auto insert_idx = output_index + offset;
       if (check_and_maybe_update_slot<READONLY, TIdentity>(
-              &identities[insert_idx][0], identity, old_value)) {
+              &identities[insert_idx][0],
+              identity,
+              old_value,
+              metadata ? metadata + insert_idx : nullptr,
+              metadata_val)) {
+        // Although check_and_maybe_update_slot also updates metadata
+        // when slot is empty, we need a extra call here, and placed here
+        // due to GPU hang that occurs with AMD MI3X hardware, i.e.
+        //  moving this call inside the check function does not mitigate it.
         update_metadata_lru<METADATA_COUNT>(
             metadata, insert_idx, metadata_val, process_lock);
         increment_freq_counter<ID_FREQ>(runtime_meta, insert_idx);

--- a/fbgemm_gpu/test/faster_hash_test.py
+++ b/fbgemm_gpu/test/faster_hash_test.py
@@ -22,10 +22,9 @@ try:
     # pyre-ignore[21]
     from test_utils import (  # @manual=//deeplearning/fbgemm/fbgemm_gpu:test_utils
         gpu_unavailable,
-        skipIfRocm,
     )
 except Exception:
-    from fbgemm_gpu.test.test_utils import gpu_unavailable, skipIfRocm
+    from fbgemm_gpu.test.test_utils import gpu_unavailable
 
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:faster_hash_ops")
 
@@ -36,7 +35,6 @@ class HashZchKernelEvictionPolicy(IntEnum):
 
 
 class FasterHashTest(unittest.TestCase):
-    @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     def test_simple_zch_no_evict(self) -> None:
         """
@@ -149,7 +147,6 @@ class FasterHashTest(unittest.TestCase):
         )
         self.assertTrue(torch.equal(output_readonly.cpu(), output_readonly_cpu))
 
-    @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     def test_simple_zch_no_evict_rand(self) -> None:
         """
@@ -214,7 +211,6 @@ class FasterHashTest(unittest.TestCase):
         )
         self.assertTrue(torch.equal(output.cpu(), output_readonly_cpu))
 
-    @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     def test_simple_zch_evict(self) -> None:
         """
@@ -284,7 +280,6 @@ class FasterHashTest(unittest.TestCase):
         )
         self.assertTrue(torch.equal(output, output_readonly))
 
-    @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     def test_simple_zch_evict_with_rand_unique_numbers(self) -> None:
         """
@@ -340,7 +335,6 @@ class FasterHashTest(unittest.TestCase):
         )
         self.assertTrue(torch.equal(output, output_readonly))
 
-    @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     def test_eviction_during_lookup(self) -> None:
         """
@@ -427,7 +421,6 @@ class FasterHashTest(unittest.TestCase):
         )
         self.assertTrue(evict_slots.numel() == 1)
 
-    @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     def test_zch_int64_nohash_identity(self) -> None:
         """
@@ -491,7 +484,6 @@ class FasterHashTest(unittest.TestCase):
             f"{identities=} vs {numbers_100_200=}",
         )
 
-    @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     def test_zch_int32_nohash_identity(self) -> None:
         """
@@ -555,7 +547,6 @@ class FasterHashTest(unittest.TestCase):
             f"{identities=} vs {numbers_100_200=}",
         )
 
-    @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     def test_fallback(self) -> None:
         """
@@ -654,7 +645,6 @@ class FasterHashTest(unittest.TestCase):
         )
         self.assertTrue(torch.all(remapped_ids[-20:] == -1))
 
-    @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     def test_simple_zch_individual_score_evict(self) -> None:
         """
@@ -759,7 +749,6 @@ class FasterHashTest(unittest.TestCase):
         # metadata should not be overwritten
         self.assertTrue(torch.equal(metadata, metadata0))
 
-    @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     def test_zch_lru_evict(self) -> None:
         """
@@ -908,7 +897,6 @@ class FasterHashTest(unittest.TestCase):
             f"{output_readonly_cpu=} v.s {output_readonly.cpu()=}",
         )
 
-    @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     def test_zch_lru_evict_with_unexpired_slots(self) -> None:
         """
@@ -1048,7 +1036,6 @@ class FasterHashTest(unittest.TestCase):
             f"{output_readonly_cpu=} v.s {output_readonly.cpu()=}",
         )
 
-    @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     def test_rand_numbers_zch_lru_evict(self) -> None:
         """
@@ -1154,7 +1141,6 @@ class FasterHashTest(unittest.TestCase):
             f"{output_readonly_cpu=} v.s {output_readonly.cpu()=}",
         )
 
-    @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     def test_zch_lru_evict_with_offsets(self) -> None:
         """
@@ -1325,7 +1311,6 @@ class FasterHashTest(unittest.TestCase):
             f"{set(second_half[second_half >= 300].tolist())=}, {set(random_numbers_300_350.tolist())=}",
         )
 
-    @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     def test_opt_in_with_prob(self) -> None:
         """
@@ -1525,7 +1510,6 @@ class FasterHashTest(unittest.TestCase):
         )
         self.assertTrue(torch.equal(output_readonly_cpu, output_readonly.cpu()))
 
-    @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     def test_zch_lru_evict_train_eval(self) -> None:
         """
@@ -1614,7 +1598,6 @@ class FasterHashTest(unittest.TestCase):
             f"{output_readonly_cpu=} v.s {output_readonly=}",
         )
 
-    @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     def test_murmur_hash(self) -> None:
         """
@@ -1638,7 +1621,6 @@ class FasterHashTest(unittest.TestCase):
         output_item_second_round = torch.ops.fbgemm.murmur_hash3(input_item, 0, 0)
         self.assertTrue(torch.equal(output_item_first_round, output_item_second_round))
 
-    @skipIfRocm("The CUDA kernel is not supported on ROCm")
     @unittest.skipIf(*gpu_unavailable)
     @settings(deadline=None)
     # pyre-ignore [56]


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2644


Context
---------

Running MPZCH on AMD hardware causes a CPU-to-GPU hang. This was identified to be the ZCH GPU kernel during the spin-wait loop that occurs.

Rather than adding spin-counter termination. We tried many different options to mitigate this issue:
- reducing occupency
- specialized HIP atomic loads/writes with sleep inside the spin-loop
- Refactoring when the loads happen, with adding thread fences to ensure the data was properly added, or to prevent compiler form -re-ordering them.

Solution
----------
The solution was to reduce the gap between writing the identity slot, and updating the metadata, while not increasing the amount of atomics to occur.

The latter point arises because if we move updating metadata entirely within check, we still get a GPU hang (see 89387c10e16ef27573ad7fcd47d1331cfc6f5421), and ( 35d297d9c5b07895bb68b08bc17612dab6e95bf2).

Implementation
------------------
- For spin-wait loops, we use hip atomic reads directly to L2 cache with cache coherence to reduce pressure
- To catch future GPU hangs that arises from ZCH kernel, we added a termination to spin-wait loop.
- Moved metadata update to be closer to the identity write, only **when** the identity slot is first empty.
- Removed skipIfRoCM to ZCH tests

Understanding the issue
---------------------------
Suppose thread A writes in slot i, and updates the identity slot with its item.  Suppose thread B was late and is also trying to write in slot i. While the metadata is being updated from thread A, thread B runs a spin-wait loop waiting for the metadata to be updated. This creates many atomic calls just to see if the metadata was updated from thread A.

AMD MI3X handles atomics differently than NVIDIA GPU. Due to this, the latency is incredibly slow, compiler may have re-ordered the atomics, AMD still uses stack-based thread scheduling, and atomic contention can occur when many threads are reading the atomic value . This all could cause a hang.

NOTE: this only impacts when identities are first inserted when their metadata is -1, and explains why the hang occurs during the first few batches.

NOTE: This is a temporary fix for AMD hardware, looking to re-write the kernel to adopt newer features, and reduce the amount of atomics.

Differential Revision: D102834662


