### PR TITLE
benchmarks + stats tooling for bf16 AVX2 8-bit / N-bit dequant (D100932926)

### DIFF
--- a/bench/EmbeddingQuantizeFloatToFloatOrHalfBenchmark.cc
+++ b/bench/EmbeddingQuantizeFloatToFloatOrHalfBenchmark.cc
@@ -79,6 +79,56 @@ static void performance_test() {
   } // for each rows
 } // performance_test
 
+static void performance_test_bf16() {
+  constexpr int NWARMUP = 4;
+  constexpr int NITER = 256;
+
+  cout << "With result as bfloat16" << '\n';
+  cout << setw(6) << "rows" << "," << setw(6) << "cols" << "," << setw(16)
+       << "elems_per_usec" << "," << setw(10) << "GB/Sec" << '\n';
+
+  for (int rowSize : {100, 120, 1000}) {
+    for (int colSize : {16, 64, 128, 256, 512, 1024, 2048}) {
+      aligned_vector<uint8_t> inpVec(rowSize * colSize);
+      randFill<uint8_t>(inpVec, 0, 20);
+
+      int output_columns = colSize - 2 * sizeof(float);
+      aligned_vector<float16> outVec(rowSize * output_columns);
+
+      double duration = 0.0f;
+
+      int constexpr kNumRepeats = 16;
+
+      duration = measureWithWarmup(
+          [&]() {
+            for (int i = 0; i < kNumRepeats; ++i) {
+              Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf<float16, true>(
+                  inpVec.data(), rowSize, colSize, outVec.data());
+            }
+          },
+          NWARMUP,
+          NITER,
+          [&]() {
+            cache_evict(inpVec);
+            cache_evict(outVec);
+          });
+
+      float elements_per_usec =
+          rowSize * output_columns * kNumRepeats / (duration * 1e6);
+
+      duration *= 1e9; // convert to ns
+      size_t bytes_read = static_cast<size_t>(rowSize) * colSize * kNumRepeats;
+      float gigabyes_per_sec = bytes_read / duration;
+
+      cout << setw(6) << rowSize << ", " << setw(6) << colSize << ",";
+      cout << setw(16) << std::fixed << std::setprecision(2)
+           << elements_per_usec << ", ";
+      cout << setw(10) << std::fixed << std::setprecision(2) << gigabyes_per_sec
+           << '\n';
+    } // for each cols
+  } // for each rows
+} // performance_test_bf16
+
 int main() {
 #ifdef _OPENMP
   // Use 1 thread unless OMP_NUM_THREADS is explicit set.
@@ -89,5 +139,6 @@ int main() {
 #endif
   performance_test<float16>();
   performance_test<float>();
+  performance_test_bf16();
   return 0;
 }

--- a/bench/EmbeddingQuantizeNBitToFloatOrHalfBenchmark.cc
+++ b/bench/EmbeddingQuantizeNBitToFloatOrHalfBenchmark.cc
@@ -89,6 +89,66 @@ static void performance_test() {
   } // for each bit_rate
 } // performance_test
 
+static void performance_test_bf16() {
+  constexpr int NWARMUP = 4;
+  constexpr int NITER = 256;
+
+  cout << "With result as bfloat16" << '\n';
+  cout << setw(8) << "bit_rate" << ", " << setw(6) << "rows" << "," << setw(6)
+       << "cols" << "," << setw(16) << "elems_per_usec" << "," << setw(10)
+       << "GB/Sec" << '\n';
+  std::vector<int> bit_rates = {2, 4, 8};
+  for (int bit_rate : bit_rates) {
+    for (int rowSize : {100, 120, 1000}) {
+      for (int colSize : {16, 64, 128, 256, 512, 1024, 2048}) {
+        int elem_per_byte = 8 / bit_rate;
+        int bytes_per_row = colSize / elem_per_byte + 2 * sizeof(float16);
+
+        aligned_vector<uint8_t> inpVec(rowSize * bytes_per_row);
+        randFill<uint8_t>(inpVec, 0, 20);
+
+        aligned_vector<float16> outVec(rowSize * colSize);
+
+        double duration = 0.0f;
+
+        int constexpr kNumRepeats = 4;
+
+        duration = measureWithWarmup(
+            [&]() {
+              for (int i = 0; i < kNumRepeats; ++i) {
+                FusedNBitRowwiseQuantizedSBHalfToFloatOrHalfRef<float16, true>(
+                    bit_rate,
+                    inpVec.data(),
+                    rowSize,
+                    bytes_per_row,
+                    outVec.data());
+              }
+            },
+            NWARMUP,
+            NITER,
+            [&]() {
+              cache_evict(inpVec);
+              cache_evict(outVec);
+            });
+
+        float elements_per_usec =
+            rowSize * colSize * kNumRepeats / (duration * 1e6);
+
+        duration *= 1e9; // convert to ns
+        long bytes_read = rowSize * colSize * sizeof(float) * kNumRepeats;
+        float gigabyes_per_sec = bytes_read / duration;
+
+        cout << setw(8) << bit_rate << "," << setw(6) << rowSize << ", "
+             << setw(6) << colSize << ",";
+        cout << setw(16) << std::fixed << std::setprecision(2)
+             << elements_per_usec << ", ";
+        cout << setw(10) << std::fixed << std::setprecision(2)
+             << gigabyes_per_sec << '\n';
+      } // for each cols
+    } // for each rows
+  } // for each bit_rate
+} // performance_test_bf16
+
 int main() {
 #ifdef _OPENMP
   // Use 1 thread unless OMP_NUM_THREADS is explicit set.
@@ -99,5 +159,6 @@ int main() {
 #endif
   performance_test<float16>();
   performance_test<float>();
+  performance_test_bf16();
   return 0;
 }


### PR DESCRIPTION
Summary:
Extends the FBGEMM CPU dequant benchmarks to measure the bf16 AVX2 paths introduced by D100932926, and ships a reusable stats/compare tool for before-after performance evaluation.

This diff adds pure performance instrumentation — no product/kernel behavior changes. Specifically:

1. **bf16 benchmark coverage in `EmbeddingQuantizeFloatToFloatOrHalfBenchmark`**: Adds a `performance_test_bf16()` function and a matching call-site in `main()`, mirroring the existing fp32/fp16 paths so the new bf16 AVX2 8-bit dequant kernel from D100932926 is exercised at the same shapes as its siblings. Applied to both `fbcode/` and `xplat/` copies.
2. **bf16 benchmark coverage in `EmbeddingQuantizeNBitToFloatOrHalfBenchmark`**: Same treatment for the N-bit (2/4-bit) dequant path so the bf16 variant of `FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf` is measured alongside the fp16/fp32 variants. Applied to both `fbcode/` and `xplat/` copies.
3. **`extract_kernel_stats.py` log parser**: ~342-line Python tool with three modes (`stats`, `compare`, `list`) that parses the CSV-like output of all four FBGEMM bench binaries (`EmbeddingQuantizeNBitToFloatOrHalfBenchmark`, `EmbeddingQuantizeFloatToFloatOrHalfBenchmark`, `EmbeddingQuantizeBenchmark`, `ConvertBenchmark`). Rows are keyed by `(benchmark, dtype, bit_rate, rows, cols)`, enabling side-by-side diff against a baseline log.
4. **`run_benchmark.sh` internal driver**: Buck2-driven runner that sweeps 6 benchmark configurations (x86_64 N-bit dequant, fp32↔fp16 convert, 8-bit quantize regression guard, x86_64 8-bit dequant, plus aarch64 cross-compile builds of both dequant benchmarks). Logs to `/tmp/d100932926_bench_$(date +%Y%m%d_%H%M%S)/`, optionally uploads the combined log to pastry, and dispatches the extractor in `stats` and (optionally) `compare` mode.
5. **`run_benchmark_oss.sh` cmake mirror**: OSS-facing variant of the runner for reviewers without buck2. Reads pre-built binaries from `<fbgemm-root>/build/`, pins `OMP_NUM_THREADS=1`, drops the aarch64 cross-compile leg, and invokes the extractor via `python3`.
6. **`BUCK` registration**: Adds `extract_kernel_stats` as a `python_binary` under oncall `fbgemm_dev` with `autodeps-skip`, so the stats tool is runnable via `buck2 run`.

## Detailed Changes

### `fbcode/deeplearning/fbgemm/bench/EmbeddingQuantizeFloatToFloatOrHalfBenchmark.cc`
- Adds `performance_test_bf16()` closely mirroring the existing fp16 path.
- Adds `performance_test_bf16()` call in `main()` next to the fp32/fp16 call-sites.

### `xplat/deeplearning/fbgemm/bench/EmbeddingQuantizeFloatToFloatOrHalfBenchmark.cc`
- Synced with the `fbcode/` copy — same bf16 function + call-site.

### `fbcode/deeplearning/fbgemm/bench/EmbeddingQuantizeNBitToFloatOrHalfBenchmark.cc`
- Adds `performance_test_bf16()` for the N-bit (2/4-bit) dequant kernel.
- Wires the new function into `main()` alongside the fp32/fp16 runs.

### `xplat/deeplearning/fbgemm/bench/EmbeddingQuantizeNBitToFloatOrHalfBenchmark.cc`
- Synced with the `fbcode/` copy.

### `fbcode/ai_codesign/nonprod/bensonma415/diffs/D100932926/extract_kernel_stats.py`
- New log parser for all four FBGEMM bench binaries.
- `stats` mode: aggregates per `(benchmark, dtype, bit_rate, rows, cols)` key.
- `compare` mode: diffs the current log against a baseline and reports speedup/regression.
- `list` mode: enumerates the parsed keys for debugging.

### `fbcode/ai_codesign/nonprod/bensonma415/diffs/D100932926/run_benchmark.sh`
- Internal buck2 driver covering: x86_64 N-bit dequant, fp32↔fp16 convert, 8-bit quantize regression guard, x86_64 8-bit dequant, and aarch64 cross-compile builds of both dequant binaries.
- Logs to timestamped `/tmp/d100932926_bench_*` directory.
- `--no-pastry` flag skips upload; `--compare <baseline.log>` invokes the extractor in compare mode.

### `fbcode/ai_codesign/nonprod/bensonma415/diffs/D100932926/run_benchmark_oss.sh`
- Cmake-based OSS mirror of `run_benchmark.sh`.
- Reads binaries from `<fbgemm-root>/build/`, pins `OMP_NUM_THREADS=1`, no buck2 / no aarch64 cross-compile leg.
- Calls the extractor via plain `python3`.

### `fbcode/ai_codesign/nonprod/bensonma415/diffs/D100932926/BUCK`
- Registers `extract_kernel_stats` as a `python_binary` under `oncall("fbgemm_dev")` with `autodeps-skip`.

Reviewed By: henrylhtsang

Differential Revision: D102891137


