### PR TITLE
Add OSS benchmark scripts for TBE training benchmarks

### DIFF
--- a/fbgemm_gpu/bench/utils_script/run_tbe_benchmark_oss.sh
+++ b/fbgemm_gpu/bench/utils_script/run_tbe_benchmark_oss.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# OSS version of run_tbe_benchmark.sh
+# Runs the TBE benchmark Python script directly instead of building with buck2.
+#
+# Requires one of these environment variables:
+#   FBGEMM_REPO_ROOT   - root of the fbgemm repository checkout
+#   FBGEMM_BENCH_SCRIPT - direct path to split_table_batched_embeddings_benchmark.py
+#
+# Usage:
+#   FBGEMM_REPO_ROOT=~/fbgemm bash run_tbe_benchmark_oss.sh [options]
+#
+# Examples:
+#   FBGEMM_REPO_ROOT=~/fbgemm bash run_tbe_benchmark_oss.sh -b 2048 -t 10 -d "128 256 512"
+#   FBGEMM_REPO_ROOT=~/fbgemm bash run_tbe_benchmark_oss.sh -b 4096 -t 1 -d "8 128 256" -e
+#   FBGEMM_REPO_ROOT=~/fbgemm bash run_tbe_benchmark_oss.sh -n --ncu-filter "forward"
+
+set -euo pipefail
+
+if [[ -n "${FBGEMM_BENCH_SCRIPT:-}" ]]; then
+    BENCH_SCRIPT="${FBGEMM_BENCH_SCRIPT}"
+elif [[ -n "${FBGEMM_REPO_ROOT:-}" ]]; then
+    BENCH_SCRIPT="${FBGEMM_REPO_ROOT}/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py"
+else
+    echo "Error: Set FBGEMM_BENCH_SCRIPT or FBGEMM_REPO_ROOT to locate the benchmark script"
+    echo "  FBGEMM_BENCH_SCRIPT: direct path to split_table_batched_embeddings_benchmark.py"
+    echo "  FBGEMM_REPO_ROOT:   root of the fbgemm repository checkout"
+    exit 1
+fi
+
+if [[ ! -f "$BENCH_SCRIPT" ]]; then
+    echo "Error: Benchmark script not found at ${BENCH_SCRIPT}"
+    exit 1
+fi
+
+with_ncu=False
+ncu_bin=/usr/local/cuda/bin/ncu
+bench=device
+log_suffix=""
+opts=""
+export_trace=""
+batch_size=131072
+num_tables=1
+weights_precision="fp32"
+output_dtype="fp32"
+a=1.15
+L=55
+iters=100
+ncu_filter=""
+dims="4 8 12 20 32 64 96 160 192 200 240 256 320 384 512 640 800 1024"
+v2=""
+
+_print_help() {
+  echo "Usage: FBGEMM_REPO_ROOT=<path> $0 [options]"
+  echo ""
+  echo "OSS version of run_tbe_benchmark.sh (runs Python script directly)"
+  echo ""
+  echo "Environment variables (one required):"
+  echo "  FBGEMM_REPO_ROOT          root of the fbgemm repository checkout"
+  echo "  FBGEMM_BENCH_SCRIPT       direct path to split_table_batched_embeddings_benchmark.py"
+  echo ""
+  echo "Options:"
+  echo "  -h|--help                 print this help message"
+  echo "  -n|--ncu                  run with NCU profiler"
+  echo "  -df|--defuse-bwd          defuse backward"
+  echo "  -a|--alpha                set alpha value"
+  echo "  -w|--weights-precision    set weight precision (e.g., fp32, fp16)"
+  echo "  -o|--output-dtype         set output dtype (e.g., fp32, fp16)"
+  echo "  -t|--num-tables           set number of tables"
+  echo "  -b|--batch-size           set batch size"
+  echo '  -d|--dims                 set embedding dims (e.g., -d "4 8 12 20")'
+  echo "  -l|--bag-size             set bag size (pooling factor)"
+  echo "  -e|--export-trace         export trace"
+  echo "  -v2|--v2                  enable TBE forward v2 kernel"
+  echo "  -i|--iter                 set number of iterations (NCU always uses 2)"
+  echo "  -bench|--bench            select benchmark (e.g., device, device_with_spec)"
+  echo "  --log-suffix SUFFIX       append suffix to log file name"
+  echo '  --ncu-filter FILTER       NCU kernel filter regex'
+  exit 0
+}
+
+while true; do
+  case "${1-}" in
+    -h | --help ) _print_help ;;
+    -n | --ncu ) with_ncu=True; shift ;;
+    -df | --defuse-bwd ) opts="$opts --defuse-bwd"; shift ;;
+    -c | --arch ) shift 2 ;;
+    -cu | --cuda ) shift 2 ;;
+    --buck-config ) shift 2 ;;
+    -a | --alpha ) a="${2}"; shift 2 ;;
+    -w | --weights-precision ) weights_precision="${2}"; shift 2 ;;
+    -o | --output-dtype ) output_dtype="${2}"; shift 2 ;;
+    -t | --num-tables ) num_tables="${2}"; shift 2 ;;
+    -b | --batch-size ) batch_size="${2}"; shift 2 ;;
+    -d | --dims ) dims="${2}"; shift 2 ;;
+    -l | --bag-size ) L="${2}"; shift 2 ;;
+    -e | --export-trace ) export_trace="--export-trace"; shift ;;
+    -v2 | --v2 ) v2="v2"; shift ;;
+    -i | --iter ) iters="${2}"; shift 2 ;;
+    -bench | --bench ) bench="${2}"; shift 2 ;;
+    --log-suffix ) log_suffix="_${2}"; shift 2 ;;
+    --ncu-filter ) ncu_filter="${2}"; shift 2 ;;
+    * ) break ;;
+  esac
+done
+
+if [[ $with_ncu == "True" ]]; then
+  iters=2
+  ncu="_ncu"
+else
+  ncu=""
+  opts="$opts \
+    --flush-gpu-cache-size-mb 40 \
+    --warmup-runs 10"
+fi
+
+if [[ "${v2:-}" != "" ]]; then
+  echo "Using TBE v2"
+  export FBGEMM_NO_JK=1
+  export FBGEMM_TBE_V2=1
+fi
+
+echo "Benchmark script: $BENCH_SCRIPT"
+echo "Embedding dims to bench: ${dims}"
+echo "---------------------------------"
+
+log_name="${num_tables}_${weights_precision}_${output_dtype}_${a}_B_${batch_size}_L_${L}${ncu}"
+# shellcheck disable=SC2086  # Intentional: dims is space-separated and needs word splitting
+for D in $dims; do
+  if [[ $with_ncu == "True" ]]; then
+    ncu_cmd="$ncu_bin \
+      --set full \
+      -o ncu_tbe_bench_${bench}_L_${L}_D_${D}_B_${batch_size}${log_suffix} \
+      -k regex:\".$ncu_filter.\" \
+      --target-processes all -f"
+    echo "$ncu_cmd"
+  else
+    ncu_cmd=""
+  fi
+
+  echo "Running ${bench} ${v2:-} ${export_trace} ${ncu} : D = ${D}, batch_size = ${batch_size}, iters = ${iters}, alpha = ${a}, num_tables = ${num_tables}, weights_precision = ${weights_precision}, output_dtype = ${output_dtype}"
+
+  # shellcheck disable=SC2086
+  CUDA_INJECTION64_PATH=none \
+    timeout 10m \
+    $ncu_cmd \
+    python3 "$BENCH_SCRIPT" \
+    $bench \
+    --batch-size ${batch_size} \
+    --embedding-dim $D \
+    --iters $iters \
+    --alpha ${a} \
+    --bag-size ${L} \
+    --weights-precision=${weights_precision} \
+    --output-dtype=${output_dtype} \
+    --num-embeddings 10000000 \
+    --num-tables ${num_tables} \
+    ${export_trace} \
+    --trace-url="{tbe_type}_tbe_{phase}_${log_name}_D_${D}.json" \
+    $opts
+done 2>&1 | tee "log_tbe_${log_name}.log"
+
+if [[ $with_ncu == "True" ]]; then
+  echo "NCU profiling complete"
+fi
+
+unset FBGEMM_NO_JK
+unset FBGEMM_TBE_V2

--- a/fbgemm_gpu/bench/utils_script/run_tbe_benchmark_sweep_oss.sh
+++ b/fbgemm_gpu/bench/utils_script/run_tbe_benchmark_sweep_oss.sh
@@ -1,0 +1,316 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# OSS version of run_tbe_benchmark_sweep.sh
+# Uses python3 directly instead of buck2-built binary.
+#
+# Requires one of these environment variables:
+#   FBGEMM_REPO_ROOT   - root of the fbgemm repository checkout
+#   FBGEMM_BENCH_SCRIPT - direct path to split_table_batched_embeddings_benchmark.py
+#
+# Usage:
+#   FBGEMM_REPO_ROOT=~/fbgemm bash run_tbe_benchmark_sweep_oss.sh [--run-5|--run-10] [--export]
+#
+# Examples:
+#   FBGEMM_REPO_ROOT=~/fbgemm bash run_tbe_benchmark_sweep_oss.sh --run-10 --export
+#   FBGEMM_REPO_ROOT=~/fbgemm bash run_tbe_benchmark_sweep_oss.sh --run-5
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BENCHMARK_SCRIPT="${SCRIPT_DIR}/run_tbe_benchmark_oss.sh"
+VBE_BENCHMARK_SCRIPT="${SCRIPT_DIR}/run_vbe_benchmark_oss.sh"
+
+if [[ -n "${FBGEMM_BENCH_SCRIPT:-}" ]]; then
+    BENCH_SCRIPT="${FBGEMM_BENCH_SCRIPT}"
+elif [[ -n "${FBGEMM_REPO_ROOT:-}" ]]; then
+    BENCH_SCRIPT="${FBGEMM_REPO_ROOT}/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py"
+else
+    echo "Error: Set FBGEMM_BENCH_SCRIPT or FBGEMM_REPO_ROOT to locate the benchmark script"
+    echo "  FBGEMM_BENCH_SCRIPT: direct path to split_table_batched_embeddings_benchmark.py"
+    echo "  FBGEMM_REPO_ROOT:   root of the fbgemm repository checkout"
+    exit 1
+fi
+
+if [[ ! -f "$BENCH_SCRIPT" ]]; then
+    echo "Error: Benchmark script not found at ${BENCH_SCRIPT}"
+    exit 1
+fi
+
+batch_sizes=(2048 4096 131072)
+num_tables=(1 10)
+dims="8 128 256 512 1024"
+
+run_mode=""
+export_flag=""
+export_trace=""
+
+_print_help() {
+  echo "Usage: $0 [--run-5|--run-10] [options]"
+  echo ""
+  echo "OSS version of run_tbe_benchmark_sweep.sh"
+  echo ""
+  echo "Modes:"
+  echo "  --run-5      Run 5 representative benchmarks"
+  echo "  --run-10     Run 10 representative benchmarks"
+  echo ""
+  echo "Default sweep and VBE benchmarks always run."
+  echo ""
+  echo "Options:"
+  echo "  -h|--help     Print this help message"
+  echo "  --export      Export traces (--run-5/--run-10 only)"
+  exit 0
+}
+
+while true; do
+  case "${1-}" in
+    -h | --help ) _print_help ;;
+    --run-5 ) run_mode="5"; shift ;;
+    --run-10 ) run_mode="10"; shift ;;
+    --export ) export_flag="true"; export_trace="true"; shift ;;
+    -c | --arch ) shift 2 ;;
+    -cu | --cuda ) shift 2 ;;
+    --buck-config ) shift 2 ;;
+    * ) break ;;
+  esac
+done
+
+extra_args=("$@")
+
+# ============================================================
+# Representative benchmarks (from production TBE configs)
+# All use: batch_size=2048, FP16 weights, FP32 output,
+#          sum pooling, bag_size=20, iters=100, warmup_runs=10
+# ============================================================
+
+_export_opts() {
+  if [[ "$export_trace" == "true" ]]; then
+    echo "--export-trace --trace-url=bench_${1}.json"
+  fi
+}
+
+# Benchmark 103: T=2, dim=8
+run_benchmark_103() {
+  # shellcheck disable=SC2046
+  python3 "$BENCH_SCRIPT" device-with-spec \
+    --batch-size 2048 \
+    --num-embeddings-list 20072405,633 \
+    --embedding-dim-list 8,8 \
+    --bag-size-list 20,20 \
+    --weights-precision fp16 \
+    --output-dtype fp32 \
+    --pooling sum \
+    --iters 100 \
+    --warmup-runs 10 \
+    $(_export_opts 103)
+}
+
+# Benchmark 50: T=2, dim=128
+run_benchmark_50() {
+  # shellcheck disable=SC2046
+  python3 "$BENCH_SCRIPT" device-with-spec \
+    --batch-size 2048 \
+    --num-embeddings-list 2,11899818 \
+    --embedding-dim-list 128,128 \
+    --bag-size-list 20,20 \
+    --weights-precision fp16 \
+    --output-dtype fp32 \
+    --pooling sum \
+    --iters 100 \
+    --warmup-runs 10 \
+    $(_export_opts 50)
+}
+
+# Benchmark 61: T=6, dim=128
+run_benchmark_61() {
+  # shellcheck disable=SC2046
+  python3 "$BENCH_SCRIPT" device-with-spec \
+    --batch-size 2048 \
+    --num-embeddings-list 3519,7529582,155,5797,2737037,66450 \
+    --embedding-dim-list 128,128,128,128,128,128 \
+    --bag-size-list 20,20,20,20,20,20 \
+    --weights-precision fp16 \
+    --output-dtype fp32 \
+    --pooling sum \
+    --iters 100 \
+    --warmup-runs 10 \
+    $(_export_opts 61)
+}
+
+# Benchmark 0: T=10, dim=128
+run_benchmark_0() {
+  # shellcheck disable=SC2046
+  python3 "$BENCH_SCRIPT" device-with-spec \
+    --batch-size 2048 \
+    --num-embeddings-list 2,284285,4,30000000,4348658,6784913,642110,236,278,3618081 \
+    --embedding-dim-list 128,128,128,128,128,128,128,128,128,128 \
+    --bag-size-list 20,20,20,20,20,20,20,20,20,20 \
+    --weights-precision fp16 \
+    --output-dtype fp32 \
+    --pooling sum \
+    --iters 100 \
+    --warmup-runs 10 \
+    $(_export_opts 0)
+}
+
+# Benchmark 5: T=10, dims=20/128
+run_benchmark_5() {
+  # shellcheck disable=SC2046
+  python3 "$BENCH_SCRIPT" device-with-spec \
+    --batch-size 2048 \
+    --num-embeddings-list 426463,8171523,5587,2,30000000,1943,107153,424,6442728,4062956 \
+    --embedding-dim-list 128,128,128,20,128,128,128,128,128,128 \
+    --bag-size-list 20,20,20,20,20,20,20,20,20,20 \
+    --weights-precision fp16 \
+    --output-dtype fp32 \
+    --pooling sum \
+    --iters 100 \
+    --warmup-runs 10 \
+    $(_export_opts 5)
+}
+
+# Benchmark 13: T=12, dims=24/128
+run_benchmark_13() {
+  # shellcheck disable=SC2046
+  python3 "$BENCH_SCRIPT" device-with-spec \
+    --batch-size 2048 \
+    --num-embeddings-list 2,14451,714,5,30000000,6784941,4364852,257,2,6171979,758,257 \
+    --embedding-dim-list 128,128,128,24,128,128,128,128,128,128,24,24 \
+    --bag-size-list 20,20,20,20,20,20,20,20,20,20,20,20 \
+    --weights-precision fp16 \
+    --output-dtype fp32 \
+    --pooling sum \
+    --iters 100 \
+    --warmup-runs 10 \
+    $(_export_opts 13)
+}
+
+# Benchmark 2: T=14, dims=12/24/128
+run_benchmark_2() {
+  # shellcheck disable=SC2046
+  python3 "$BENCH_SCRIPT" device-with-spec \
+    --batch-size 2048 \
+    --num-embeddings-list 227,2,1605631,31,2,642,2,30000000,6783150,478,237,4539974,5755862,690 \
+    --embedding-dim-list 128,128,128,128,128,24,24,128,128,128,128,128,128,12 \
+    --bag-size-list 20,20,20,20,20,20,20,20,20,20,20,20,20,20 \
+    --weights-precision fp16 \
+    --output-dtype fp32 \
+    --pooling sum \
+    --iters 100 \
+    --warmup-runs 10 \
+    $(_export_opts 2)
+}
+
+# Benchmark 1: T=18, dims=20/128
+run_benchmark_1() {
+  # shellcheck disable=SC2046
+  python3 "$BENCH_SCRIPT" device-with-spec \
+    --batch-size 2048 \
+    --num-embeddings-list 661,48,5801,653,30,224,612,710,30000000,6784921,375,11,2658,5376992,296,236,760,763 \
+    --embedding-dim-list 128,128,128,128,128,20,20,20,128,128,128,128,128,128,20,20,20,20 \
+    --bag-size-list 20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20 \
+    --weights-precision fp16 \
+    --output-dtype fp32 \
+    --pooling sum \
+    --iters 100 \
+    --warmup-runs 10 \
+    $(_export_opts 1)
+}
+
+# Benchmark 3: T=20, dims=20/24/128
+run_benchmark_3() {
+  # shellcheck disable=SC2046
+  python3 "$BENCH_SCRIPT" device-with-spec \
+    --batch-size 2048 \
+    --num-embeddings-list 4,2,301571,26077834,2,2,4,6,752,5287864,2307981,518,613,7677271,3489261,313,3,484,773,504 \
+    --embedding-dim-list 128,128,128,128,128,24,20,20,20,128,128,128,128,128,128,24,24,20,20,20 \
+    --bag-size-list 20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20 \
+    --weights-precision fp16 \
+    --output-dtype fp32 \
+    --pooling sum \
+    --iters 100 \
+    --warmup-runs 10 \
+    $(_export_opts 3)
+}
+
+# Benchmark 27: T=22, dims=20/24/128
+run_benchmark_27() {
+  # shellcheck disable=SC2046
+  python3 "$BENCH_SCRIPT" device-with-spec \
+    --batch-size 2048 \
+    --num-embeddings-list 2,2,61787,144013,4,2,685,603,692,30000000,1776198,6784906,11,729,16,6561149,3086,420,507,3,22,613 \
+    --embedding-dim-list 128,128,128,128,128,24,20,20,20,128,128,128,128,128,128,128,128,24,24,20,20,20 \
+    --bag-size-list 20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20 \
+    --weights-precision fp16 \
+    --output-dtype fp32 \
+    --pooling sum \
+    --iters 100 \
+    --warmup-runs 10 \
+    $(_export_opts 27)
+}
+
+# ============================================================
+# Run representative benchmarks
+# ============================================================
+
+if [[ "$run_mode" == "5" ]]; then
+  echo "Running 5 representative benchmarks"
+  echo "=========================================="
+  run_benchmark_103
+  run_benchmark_0
+  run_benchmark_2
+  run_benchmark_1
+  run_benchmark_27
+
+elif [[ "$run_mode" == "10" ]]; then
+  echo "Running 10 representative benchmarks"
+  echo "=========================================="
+  run_benchmark_103
+  run_benchmark_50
+  run_benchmark_61
+  run_benchmark_0
+  run_benchmark_5
+  run_benchmark_13
+  run_benchmark_2
+  run_benchmark_1
+  run_benchmark_3
+  run_benchmark_27
+
+fi
+
+# ============================================================
+# Default sweep over batch size, num tables, dims
+# ============================================================
+
+echo ""
+echo "Running default sweep"
+echo "Embedding dims: ${dims}"
+
+for B in "${batch_sizes[@]}"; do
+  for T in "${num_tables[@]}"; do
+    echo "=========================================="
+    echo "Running: B=${B}, T=${T}, D=[${dims}]"
+    echo "=========================================="
+    cmd_args=(-b "${B}" -t "${T}" -d "${dims}")
+    if [[ "$export_flag" == "true" ]]; then
+      cmd_args+=(-e)
+    fi
+    cmd_args+=("${extra_args[@]}")
+    bash "${BENCHMARK_SCRIPT}" "${cmd_args[@]}"
+  done
+done
+
+# ============================================================
+# VBE benchmarks
+# ============================================================
+
+echo ""
+echo "Running VBE benchmarks"
+echo "=========================================="
+vbe_args=("${extra_args[@]}")
+if [[ "$export_flag" == "true" ]]; then
+  vbe_args+=(-e)
+fi
+bash "${VBE_BENCHMARK_SCRIPT}" "${vbe_args[@]}"

--- a/fbgemm_gpu/bench/utils_script/run_vbe_benchmark_oss.sh
+++ b/fbgemm_gpu/bench/utils_script/run_vbe_benchmark_oss.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# OSS version of run_vbe_benchmark.sh
+# Runs the VBE benchmark Python script directly instead of building with buck2.
+#
+# Requires one of these environment variables:
+#   FBGEMM_REPO_ROOT   - root of the fbgemm repository checkout
+#   FBGEMM_BENCH_SCRIPT - direct path to split_table_batched_embeddings_benchmark.py
+#
+# Usage:
+#   FBGEMM_REPO_ROOT=~/fbgemm bash run_vbe_benchmark_oss.sh [options]
+#
+# Examples:
+#   FBGEMM_REPO_ROOT=~/fbgemm bash run_vbe_benchmark_oss.sh -e
+#   FBGEMM_REPO_ROOT=~/fbgemm bash run_vbe_benchmark_oss.sh -t 3 --batch-size-list 2048,4096,2048 -e
+#   FBGEMM_REPO_ROOT=~/fbgemm bash run_vbe_benchmark_oss.sh -n --ncu-filter "forward"
+
+set -euo pipefail
+
+if [[ -n "${FBGEMM_BENCH_SCRIPT:-}" ]]; then
+    BENCH_SCRIPT="${FBGEMM_BENCH_SCRIPT}"
+elif [[ -n "${FBGEMM_REPO_ROOT:-}" ]]; then
+    BENCH_SCRIPT="${FBGEMM_REPO_ROOT}/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py"
+else
+    echo "Error: Set FBGEMM_BENCH_SCRIPT or FBGEMM_REPO_ROOT to locate the benchmark script"
+    echo "  FBGEMM_BENCH_SCRIPT: direct path to split_table_batched_embeddings_benchmark.py"
+    echo "  FBGEMM_REPO_ROOT:   root of the fbgemm repository checkout"
+    exit 1
+fi
+
+if [[ ! -f "$BENCH_SCRIPT" ]]; then
+    echo "Error: Benchmark script not found at ${BENCH_SCRIPT}"
+    exit 1
+fi
+
+with_ncu=False
+ncu_bin=/usr/local/cuda/bin/ncu
+log_suffix=""
+export_trace=""
+num_tables=3
+weights_precision="fp32"
+output_dtype="fp32"
+iters=100
+ncu_filter=""
+batch_size_list="2048,4096,1024"
+embedding_dim_list="128,128,64"
+bag_size_list="20,20,20"
+num_embeddings_list="10000000,5000000,1000000"
+alpha_list=""
+merge_output=""
+
+_print_help() {
+  echo "Usage: FBGEMM_REPO_ROOT=<path> $0 [options]"
+  echo ""
+  echo "OSS VBE (Variable Batch-size Embedding) Benchmark"
+  echo ""
+  echo "Environment variables (one required):"
+  echo "  FBGEMM_REPO_ROOT          root of the fbgemm repository checkout"
+  echo "  FBGEMM_BENCH_SCRIPT       direct path to split_table_batched_embeddings_benchmark.py"
+  echo ""
+  echo "VBE parameters (comma-separated, one value per table):"
+  echo "  -t|--num-tables N         Number of tables (default: 3)"
+  echo '  --batch-size-list LIST    Batch sizes per table (default: "2048,4096,1024")'
+  echo '  --embedding-dim-list LIST Embedding dims per table (default: "128,128,64")'
+  echo '  --bag-size-list LIST      Bag sizes per table (default: "20,20,20")'
+  echo '  --num-embeddings-list LIST Num embeddings per table (default: "10000000,5000000,1000000")'
+  echo '  --alpha-list LIST         ZipF alpha per table (default: "None"=uniform)'
+  echo ""
+  echo "Precision:"
+  echo "  -w|--weights-precision P  Weight precision (default: fp32)"
+  echo "  -o|--output-dtype P       Output dtype (default: fp32)"
+  echo ""
+  echo "Benchmarking:"
+  echo "  -i|--iter N               Number of iterations (default: 100)"
+  echo "  -e|--export-trace         Export kineto trace"
+  echo "  --merge-output            Enable merged output mode"
+  echo "  -n|--ncu                  Run with NCU profiler (sets iters=2)"
+  echo '  --ncu-filter FILTER       NCU kernel filter regex'
+  echo "  --log-suffix SUFFIX       Append suffix to log file name"
+  exit 0
+}
+
+while true; do
+  case "${1-}" in
+    -h | --help ) _print_help ;;
+    -n | --ncu ) with_ncu=True; shift ;;
+    -c | --arch ) shift 2 ;;
+    -cu | --cuda ) shift 2 ;;
+    --buck-config ) shift 2 ;;
+    -t | --num-tables ) num_tables="${2}"; shift 2 ;;
+    -w | --weights-precision ) weights_precision="${2}"; shift 2 ;;
+    -o | --output-dtype ) output_dtype="${2}"; shift 2 ;;
+    -i | --iter ) iters="${2}"; shift 2 ;;
+    -e | --export-trace ) export_trace="true"; shift ;;
+    --batch-size-list ) batch_size_list="${2}"; shift 2 ;;
+    --embedding-dim-list ) embedding_dim_list="${2}"; shift 2 ;;
+    --bag-size-list ) bag_size_list="${2}"; shift 2 ;;
+    --num-embeddings-list ) num_embeddings_list="${2}"; shift 2 ;;
+    --alpha-list ) alpha_list="${2}"; shift 2 ;;
+    --merge-output ) merge_output="--merge-output"; shift ;;
+    --log-suffix ) log_suffix="_${2}"; shift 2 ;;
+    --ncu-filter ) ncu_filter="${2}"; shift 2 ;;
+    * ) break ;;
+  esac
+done
+
+if [[ $with_ncu == "True" ]]; then
+  iters=2
+  ncu="_ncu"
+else
+  ncu=""
+fi
+
+echo "Benchmark script: $BENCH_SCRIPT"
+
+warmup_opts=""
+if [[ $with_ncu != "True" ]]; then
+  warmup_opts="--bench-warmup-iterations 10"
+fi
+
+run_vbe() {
+  local a="$1"
+  local log_name="${num_tables}_${weights_precision}_${output_dtype}_${a}_B_${batch_size_list}_L_${bag_size_list}${ncu}"
+  log_name="${log_name//,/-}"
+
+  local trace_opts=""
+  if [[ "$export_trace" == "true" ]]; then
+    trace_opts="--bench-export-trace --bench-trace-url={emb_op_type}_${log_name}.json"
+  fi
+
+  echo "---------------------------------"
+  echo "VBE benchmark:"
+  echo "  num_tables=${num_tables}, batch_size_list=${batch_size_list}"
+  echo "  embedding_dim_list=${embedding_dim_list}, bag_size_list=${bag_size_list}"
+  echo "  num_embeddings_list=${num_embeddings_list}, alpha_list=${a}"
+  echo "  weights_precision=${weights_precision}, output_dtype=${output_dtype}"
+  echo "  iters=${iters}"
+  echo "---------------------------------"
+
+  if [[ $with_ncu == "True" ]]; then
+    ncu_cmd="$ncu_bin \
+      --set full \
+      -o ncu_vbe_${log_name}${log_suffix} \
+      -k regex:\".$ncu_filter.\" \
+      --target-processes all -f"
+    echo "$ncu_cmd"
+  else
+    ncu_cmd=""
+  fi
+
+  # shellcheck disable=SC2086
+  CUDA_INJECTION64_PATH=none \
+    timeout 10m \
+    $ncu_cmd \
+    python3 "$BENCH_SCRIPT" \
+    vbe \
+    --num-tables ${num_tables} \
+    --batch-size-list ${batch_size_list} \
+    --embedding-dim-list ${embedding_dim_list} \
+    --bag-size-list ${bag_size_list} \
+    --num-embeddings-list ${num_embeddings_list} \
+    --alpha-list ${a} \
+    --bench-iterations ${iters} \
+    --emb-weights-dtype=${weights_precision} \
+    --emb-output-dtype=${output_dtype} \
+    ${trace_opts} \
+    ${warmup_opts} \
+    ${merge_output} \
+    2>&1 | tee "log_vbe_${log_name}.log"
+}
+
+if [[ -z "$alpha_list" ]]; then
+  run_vbe "1"
+  run_vbe "1.15"
+else
+  run_vbe "${alpha_list}"
+fi


### PR DESCRIPTION
Summary:
Add OSS-compatible versions of the TBE benchmark scripts that run the benchmark Python script directly with python3, instead of requiring buck2 to build a binary. These scripts are intended for use outside the Meta-internal environment (e.g., on AMD GPU machines with fbgemm_gpu installed from source).

Three scripts are added:
- `run_tbe_benchmark_oss.sh`: runs a single TBE benchmark sweep over embedding dims
- `run_vbe_benchmark_oss.sh`: runs VBE (variable batch-size embedding) benchmarks
- `run_tbe_benchmark_sweep_oss.sh`: orchestrates the full sweep including 
  - 5/10 representative TBE configs (const batch, same/mixed D)
  - TBE default dim sweep (constant batch, same D)
  - VBE benchmarks (variable batch, mixed D)

Users set `FBGEMM_REPO_ROOT` (or `FBGEMM_BENCH_SCRIPT`) to point to the fbgemm repo checkout.

Differential Revision: D102946096


