### PR TITLE
Add small-D CTA kernel specialization for `max_D <= 128` (#5711)

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
@@ -625,7 +625,11 @@ batch_index_select_dim0_codegen_backward_kernel_cta_per_row
     codegen/embedding_common_code_generator.py for more details
 */ #}
 
+{%- if is_rocm %}
+{{ instantiate_templates(use_subwarp_shuffle=True) }}
+{%- else %}
 {{ instantiate_templates(use_subwarp_shuffle=False) }}
+{%- endif %}
 
 ////////////////////////////////////////////////////////////////////////////////
 #endif

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -48,7 +48,7 @@ using namespace fbgemm_gpu;
     has_global_weight_decay_support,
     ssd) %}
 {%- set desc_suffix = get_desc_suffix(is_gwd_kernel) %}
-{%- set is_optimized_hip_kernel_supported_mode = is_rocm and
+{%- set has_hip_optimized_nonvbe_support = is_rocm and
                                                  optimizer == "rowwise_adagrad" and
                                                  not dense and
                                                  not nobag and
@@ -56,6 +56,14 @@ using namespace fbgemm_gpu;
                                                  not is_gwd_kernel and
                                                  not vbe and
                                                  not ssd %}
+
+{%- set has_hip_optimized_support  = is_rocm and
+                                               optimizer == "rowwise_adagrad" and
+                                               not dense and
+                                               not is_index_select and
+                                               not is_gwd_kernel and
+                                               not nobag and
+                                               not ssd %}
 
 template <
     typename emb_t,
@@ -236,7 +244,7 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row(
     {%- endif %}
 );
 
-{%- if is_optimized_hip_kernel_supported_mode %}
+{%- if has_hip_optimized_nonvbe_support %}
 #include "fbgemm_gpu/rocm/split_embeddings_common.h"
 template <
     typename emb_t,
@@ -873,7 +881,7 @@ Tensor {{ embedding_cuda_op }}(
     }
     {%- endif %}
 
-    {%- if is_optimized_hip_kernel_supported_mode %}
+    {%- if has_hip_optimized_nonvbe_support %}
     {%- set hip_kernel = "hip_split_embedding{}_backward_codegen_{}_{}{}_kernel_warp_per_row_1".format(
             ndesc,
             optimizer,
@@ -1070,7 +1078,7 @@ Tensor {{ embedding_cuda_op }}(
                         )
                     %}
 
-                    const auto backward_cta_per_row_kernel =
+                    auto backward_cta_per_row_kernel =
                         {{ cta_kernel }}
                             <emb_t,
                              grad_t,
@@ -1083,8 +1091,8 @@ Tensor {{ embedding_cuda_op }}(
                              kThreadGroupSize,
                              kUseVecBlocking>;
 
-                    // Compute shared memory size for cta_per_row
                     constexpr auto kCacheAccBytes = sizeof(at::acc_type<cache_t, true>);
+                    auto thread_group_size = kThreadGroupSize;
                     const int cta_warp_size = at::cuda::warp_size();
                     {% if is_rocm %}
                     int32_t total_L = indices.numel();
@@ -1101,26 +1109,54 @@ Tensor {{ embedding_cuda_op }}(
                     {%- else %}
                     int32_t num_cta_per_row_groups = kMaxThreads / cta_warp_size;
                     const int32_t work_group_size = kMaxThreads;
+                    {%- endif %}{# /*if is_rocm*/ #}
+
+                    // Compute shared memory size for cta_per_row. These smem-sizing
+                    // params default to the launched kernel's (cta_warp_size, max_vecs_per_thread);
+                    // the max_D <= 128 override below re-instantiates a smaller kernel and updates them.
+                    int cta_smem_group_size = cta_warp_size;
+                    int cta_smem_vecs = max_vecs_per_thread;
+                    {%- if has_hip_optimized_support  %}
+                    if (max_D <= 128) {
+                        backward_cta_per_row_kernel =
+                        {{ cta_kernel }}
+                            <emb_t,
+                             grad_t,
+                             cache_t,
+                             index_t,
+                             {%- for ph_name in args.placeholder_tensor_names %}
+                             {{ ph_name + "_ph_t" }},
+                             {%- endfor %}
+                             1,
+                             32,
+                             false>;
+                        num_cta_per_row_groups = num_cta_per_row_groups * 2;
+                        thread_group_size = 32;
+                        cta_smem_group_size = 32;
+                        cta_smem_vecs = 1;
+                        // Notice that, kThreadGroupSize * kFixedMaxVecsPerThread * vec_width should >= max_D
+                    }
                     {%- endif %}
                     const size_t cta_per_row_smem_bytes = compute_num_groups_and_dynamic_smem_bytes(
                         &num_cta_per_row_groups,
                         [&] (int num_groups) {
-                          return num_groups * kCacheAccBytes * 4 * cta_warp_size * max_vecs_per_thread;
+                          return num_groups * kCacheAccBytes * 4 * cta_smem_group_size * cta_smem_vecs;
                         },
                         backward_cta_per_row_kernel,
                         used_shared_bytes
                     );
+                    const auto cta_blockSize = dim3(thread_group_size, num_cta_per_row_groups);
 
                     const auto cta_per_row_grid_size = utils::cuda::cap_grid_dim_x(
                             cuda_calc_xblock_count(total_unique_indices, work_group_size),
-                            kThreadGroupSize * num_cta_per_row_groups, // block size
+                            thread_group_size * num_cta_per_row_groups, // block size
                             at::cuda::getCurrentCUDAStream(),
                             utils::cuda::BlockCapPolicy::Always);
 
                     FBGEMM_LAUNCH_KERNEL(
                         backward_cta_per_row_kernel,
                         cta_per_row_grid_size,
-                        dim3(kThreadGroupSize, num_cta_per_row_groups),
+                        cta_blockSize,
                         cta_per_row_smem_bytes,
                         at::cuda::getCurrentCUDAStream(),
                         grad_output_accessor,
@@ -1258,7 +1294,7 @@ Tensor {{ embedding_cuda_op }}(
                         utils::cuda::BlockCapPolicy::Always);
 
 #ifdef USE_ROCM
-                    {%- if is_optimized_hip_kernel_supported_mode %}
+                    {%- if has_hip_optimized_nonvbe_support %}
 
                     const static auto use_hip_kernel = fbgemm_gpu::config::is_feature_enabled(fbgemm_gpu::config::FeatureGateName::TBE_ROCM_HIP_BACKWARD_KERNEL);
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2656

### TLDR
- Compile-time CTA-kernel specialization for `max_D <= 128` on ROCm (`rowwise_adagrad`), gated by the `has_hip_optimized_support` Jinja flag — there is no runtime feature gate.
- CTA-only; the warp kernel path is unchanged.

### Changes
- When `max_D <= 128`, instantiate `backward_cta_per_row_kernel` with `kFixedMaxVecsPerThread=1, kThreadGroupSize=32, kUseVecBlocking=false` for tighter compiler codegen (`32 * 1 * 4 = 128` exactly covers `D <= 128`).
- In the override, set `thread_group_size=32` and double `num_cta_per_row_groups` to keep the total thread count.
- Compute `compute_num_groups_and_dynamic_smem_bytes` and `cta_blockSize` (`dim3(thread_group_size, num_cta_per_row_groups)`) *after* the override, so the dynamic shared-memory size and the launch block dim match the actually-selected kernel (and stay consistent with the grid-size calc, which also uses `thread_group_size`).
- `max_D > 128`: override not taken; unchanged path.

### Benchmark results
MI350 (gfx950), median, CTA+Warp backward-total kernel time (us). The specialization is compile-time, so the win appears with the runtime flag both off and on.

| config | base (no flag) | this (no flag) | Δ | base (flag) | this (flag) | Δ |
| --- | --- | --- | --- | --- | --- | --- |
| bench_50 T=2 Ds=128 | 173 | 126 | +27.2% | 174 | 126 | +27.6% |
| bench_61 T=6 Ds=128 | 135 | 132 | +2.2% | 138 | 133 | +3.6% |
| bench_0 T=10 Ds=128 | 378 | 321 | +15.1% | 378 | 317 | +16.1% |
| bench_5 T=10 Ds=20/128 | 388 | 336 | +13.4% | 387 | 329 | +15.0% |
| bench_13 T=12 Ds=24/128 | 342 | 276 | +19.3% | 335 | 276 | +17.6% |
| bench_2 T=14 Ds=12/24/128 | 359 | 301 | +16.2% | 362 | 303 | +16.3% |
| bench_1 T=18 Ds=20/128 | 299 | 240 | +19.7% | 300 | 236 | +21.3% |
| bench_3 T=20 Ds=20/24/128 | 419 | 357 | +14.8% | 408 | 347 | +15.0% |
| bench_27 T=22 Ds=20/24/128 | 402 | 346 | +13.9% | 404 | 337 | +16.6% |
| **TOTAL** | 2961 | 2498 | **+15.6%** | 2952 | 2467 | **+16.4%** |

CTA+Warp = backward CTA kernel + backward warp kernel (net backward device time). The win is driven by the CTA kernel (+~39% on its own); the warp kernel is unchanged (within noise). `max_D > 128`: override not taken, within noise of baseline.

Full per-config perf (both flags) perf link in the test plan

Reviewed By: q10

Differential Revision: D102946299


