### PR TITLE
Fix pyspark_deps.par crash (coredump f160mb8e201359l3) (#5713)

### DIFF
--- a/src/EmbeddingSpMDM.cc
+++ b/src/EmbeddingSpMDM.cc
@@ -1255,7 +1255,8 @@ typename EmbeddingSpMDMKernelSignature<inType, indxType, offsetType, outType>::
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
   if ((is_autovec_forced() || fbgemmHasArmSve2Support()) &&
-      !is_autovec_disabled()) {
+      !is_autovec_disabled() &&
+      (!CPUINFO_ARCH_X86_64 || fbgemmHasAvx512Support())) {
     return GenerateEmbeddingSpMDMWithStrides_autovec<
         /*InType=*/inType,
         /*IndexType=*/indxType,
@@ -1371,7 +1372,8 @@ typename EmbeddingSpMDMKernelSignature<uint8_t, indxType, offsetType, outType>::
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
   if ((is_autovec_forced() || fbgemmHasArmSve2Support()) &&
-      !is_autovec_disabled()) {
+      !is_autovec_disabled() &&
+      (!CPUINFO_ARCH_X86_64 || fbgemmHasAvx512Support())) {
     return GenerateEmbeddingSpMDMFP8WithStrides_autovec<
         /*IndexType=*/indxType,
         /*OffsetType=*/offsetType,
@@ -1537,7 +1539,8 @@ GenerateEmbeddingSpMDMRowWiseSparse(
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
   if ((is_autovec_forced() || fbgemmHasArmSve2Support()) &&
-      !is_autovec_disabled()) {
+      !is_autovec_disabled() &&
+      (!CPUINFO_ARCH_X86_64 || fbgemmHasAvx512Support())) {
     return GenerateEmbeddingSpMDMRowWiseSparse_autovec<
         /*InType=*/inType,
         /*IndexType=*/indxType,

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -1108,7 +1108,8 @@ typename EmbeddingSpMDMKernelSignature<uint8_t, indxType, offsetType, outType>::
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
   if ((fbgemmHasArmSve2Support() && !is_autovec_disabled()) ||
-      is_autovec_forced()) {
+      (is_autovec_forced() &&
+       (!CPUINFO_ARCH_X86_64 || fbgemmHasAvx512Support()))) {
     return GenerateEmbeddingSpMDMNBitWithStrides_autovec<
         /*IndexType=*/indxType,
         /*OffsetType=*/offsetType,
@@ -1301,7 +1302,8 @@ GenerateEmbeddingSpMDMNBitRowWiseSparse(
     throw std::runtime_error("Failed to initialize cpuinfo!");
   }
   if ((fbgemmHasArmSve2Support() && !is_autovec_disabled()) ||
-      is_autovec_forced()) {
+      (is_autovec_forced() &&
+       (!CPUINFO_ARCH_X86_64 || fbgemmHasAvx512Support()))) {
     return GenerateEmbeddingSpMDMNBitRowWiseSparse_autovec<
         /*IndexType=*/indxType,
         /*OffsetType=*/offsetType>(


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2646

Reviewed By: excelle08

Differential Revision: D102767098


