### PR TITLE
Add spin-loop termination to for AMD GPU hang on MP-ZCH (#5714)

### DIFF
--- a/fbgemm_gpu/src/faster_hash_ops/faster_hash.cu
+++ b/fbgemm_gpu/src/faster_hash_ops/faster_hash.cu
@@ -32,6 +32,7 @@ static constexpr int32_t kDefaultTensor = -1;
 static constexpr int64_t kMaxIdentityNum = INT32_MAX;
 static constexpr int64_t kMaxHours = INT32_MAX;
 static constexpr int64_t kSecondsInHour = 60 * 60;
+static constexpr int32_t kMaxSpinCount = 10 * 1000;
 
 template <typename T>
 __device__ __inline__ T CAS(T* data, T cmp, T val) {
@@ -167,12 +168,20 @@ __device__ __inline__ int64_t check_min(
   // wait.
   auto insert_idx = output_index + offset;
   int32_t last_seen = kDefaultTensor;
+  int32_t spin_count = 0;
   while (true) {
     last_seen =
         atomicCAS(metadata + insert_idx, kDefaultTensor, kDefaultTensor);
     if (last_seen != kDefaultTensor) {
       break;
     }
+#ifdef USE_ROCM
+    if (++spin_count > kMaxSpinCount) {
+      // Metadata write may not be visible yet due to atomic contention.
+      // Slot not considered, keep original min_index, move to next slot
+      return min_index;
+    }
+#endif
   }
 
   // only check those expired slots
@@ -225,12 +234,20 @@ __device__ __inline__ bool check_evict<1>(
   // has not been written yet, while the other id checking the slot's eviction
   // status. Therefore, wait until the metadata is not -1.
   int32_t identity_metadata = kDefaultTensor;
+  int32_t spin_counter = 0;
   while (true) {
     identity_metadata =
         atomicCAS(metadata + output_index, kDefaultTensor, kDefaultTensor);
     if (identity_metadata != kDefaultTensor) {
       break;
     }
+#ifdef USE_ROCM
+    if (++spin_counter > kMaxSpinCount) {
+      // Metadata write may not be visible yet due to atomic contention.
+      // Slot not considered, return false, and move to next slot
+      return false;
+    }
+#endif
   }
   bool is_more_recent = (identity_metadata < metadata_val);
   bool threshold_met = (eviction_threshold > identity_metadata);


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2647

Context
---------

Running MPZCH on AMD hardware causes a CPU-to-GPU hang. This was identified to be the ZCH GPU kernel during the spin-wait loop that occurs.

TorchRec creates metadata and sets its default values to -1. This is then provided to the FBGEMM kernel. Note if an identity slot is -1, then its metadata is also -1, and the metadata for that slot is never -1 again when it gets updated.

Suppose thread A writes in slot i, and updates the identity slot with its item.  Suppose thread B was late and is also trying to write in slot i. While the metadata is being updated from thread A, thread B runs a spin-wait loop waiting for the metadata to be updated. This creates many atomic calls just to see if the metadata was updated from thread A.

AMD MI3X handles atomics differently than NVIDIA GPU. Due to this, the latency is incredibly slow, and atomic contention can occur when many threads are reading the atomic value . This ultimately looks like a hang that occurs.

NOTE: this only impacts when identities are first inserted when their metadata is -1, and explains why the hang occurs during the first few batches. WIP to reducing the amount of atomics in ZCH.

Implementation
------------------

Added a spin counter (SC ) to the spin-wait loop in check_evict and check_min. The value is determined through benchmarking

Reviewed By: kaanbaloglu

Differential Revision: D102424864


