### PR TITLE
Add unit tests for warp primitives, bitonic sort, and ROCm warpSize guards (#5715)

### DIFF
--- a/fbgemm_gpu/test/tbe/cache/lxu_cache_test.py
+++ b/fbgemm_gpu/test/tbe/cache/lxu_cache_test.py
@@ -386,6 +386,59 @@ class LXUCacheTest(unittest.TestCase):
 
         assert torch.equal(expanded_lxu_cache_locations, duplicate_lookup_output)
 
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(
+        torch.version.hip is None,
+        "Only relevant on ROCm (TBE cache kernels require warpSize == 64)",
+    )
+    def test_warp_size_guard_positive_path_rocm(self) -> None:
+        """
+        Positive-path smoke test for the ROCm TBE cache ops. On warpSize 64
+        CDNA hosts (the only AMD hardware currently in CI), LRU/LFU prefetch
+        and forward cache lookup must succeed without raising. Exercises:
+          * LRU populate via prefetch() -> lru_cache_populate_cuda
+          * LFU populate via prefetch() -> lfu_cache_populate_cuda
+          * Cache lookup via forward() -> lxu_cache_lookup_cuda
+
+        These ops each hold a runtime check requiring warpSize == 64 on
+        ROCm; this test is the regression guard that the check stays a
+        no-op on CDNA. Negative-path testing (raising on warpSize != 64)
+        requires either RDNA hardware or an injectable
+        at::cuda::warp_size() indirection; defer until gfx11xx lands in CI.
+        """
+        T = 2
+        D = 4
+        B = 4
+        L = 4
+        log_E = 3
+
+        for cache_algorithm in (CacheAlgorithm.LRU, CacheAlgorithm.LFU):
+            cc, _, min_Es, _ = generate_cache_tbes(
+                T,
+                D,
+                log_E,
+                mixed=False,
+                cache_algorithm=cache_algorithm,
+                use_int_weight=True,
+            )
+
+            requests = generate_requests(1, B, T, L, min_Es, reuse=0.1)
+            indices, offsets, _, _ = requests[0].unpack_4()
+            indices = indices.long()
+            offsets = offsets.long()
+
+            # Exercises {lru,lfu}_cache_populate_cuda via prefetch — hits
+            # the TORCH_CHECK(warp_size == 64) guard.
+            cc.prefetch(indices, offsets)
+
+            # Exercises lxu_cache_lookup_cuda via the forward lookup path —
+            # hits the TORCH_CHECK(warp_size == 64) guard.
+            output = cc(indices, offsets)
+
+            # Reaching this line means all three guards passed on CDNA.
+            self.assertIsInstance(output, torch.Tensor)
+            self.assertGreater(output.numel(), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/fbgemm_gpu/test/tbe/common.py
+++ b/fbgemm_gpu/test/tbe/common.py
@@ -120,42 +120,56 @@ def get_v2_kernel_overflow_params() -> tuple[int, int, int]:
     on the V2 forward kernel for ROCm.
 
     The V2 forward kernel launch parameters on ROCm:
-        kWarpSize = 64 (AMD wavefront size)
+        kWarpSize = active device's hardware warp size (64 on CDNA, 32 on RDNA)
         kForwardMaxThreads = 1024
-        num_warps_per_threadblock = kForwardMaxThreads / (kWarpSize * 2) = 8
+        num_warps_per_threadblock = kForwardMaxThreads / (kWarpSize * 2)
         threads_per_block = kWarpSize * num_warps_per_threadblock = 512
 
     Grid calculation:
-        num_warps_per_table = B * ceil(D / (kWarpSize * 4)) = B * ceil(D / 256)
+        num_warps_per_table = B * ceil(D / (kWarpSize * 4))
         grid = ceil(T * num_warps_per_table / num_warps_per_threadblock)
-             = ceil(T * B * ceil(D / 256) / 8)
 
     Overflow condition:
-        grid * 512 > 2^32 - 1
-        grid >= 8,388,608
+        grid * threads_per_block > 2^32 - 1
+        grid >= 8,388,609
 
-    To trigger overflow:
-        T * B * ceil(D / 256) >= 67,108,864
+    With D <= kWarpSize * 4, ceil(D / (kWarpSize * 4)) == 1, so:
+        grid = ceil(T * B / num_warps_per_threadblock)
+    To trigger overflow we need:
+        T * B >= 8,388,609 * num_warps_per_threadblock
 
-    Memory optimization:
-        D only affects memory, NOT grid calculation when D <= 256 (ceil(D/256)=1)
-        Using D=64 requires T*B >= 67,108,864 and uses only ~8.6 GB output
-        This is 2x smaller than D=128 (~17.2 GB) and 4x smaller than D=256
+    This function adapts to the active device's warp size at runtime so the
+    same test parameters trigger overflow on both warpSize 64 (CDNA) and
+    warpSize 32 (RDNA) AMD GPUs. Must mirror whatever the V2 forward kernel
+    uses for kWarpSize at launch time (either the compile-time constexpr or
+    the runtime at::cuda::warp_size() query, depending on the build).
 
     Returns:
-        Tuple of (T, B, D) that triggers overflow on ROCm V2 kernel
-        while fitting in memory on most GPUs
+        Tuple of (T, B, D) that triggers overflow on the V2 kernel for the
+        active device while fitting in memory on most GPUs.
     """
-    # Memory-efficient parameters that trigger overflow on V2 kernel
-    # T=8400, B=8000, D=64 => ceil(64/256)=1
-    # num_warps_per_table = 8000 * 1 = 8,000
-    # total_warps = 8400 * 8,000 = 67,200,000
-    # grid = ceil(67,200,000 / 8) = 8,400,000
-    # total_threads = 8,400,000 * 512 = 4,300,800,000 > 2^32 ✓
-    # Output tensor: 8000 * 8400 * 64 * 2 = 8.6 GB (fits on most GPUs)
+    # Query the hardware warp size at runtime rather than relying on a
+    # compile-time host-side constant — this keeps the helper correct
+    # whether the kernel launches use kWarpSize or at::cuda::warp_size().
+    device = torch.cuda.current_device()
+    warp_size = torch.cuda.get_device_properties(device).warp_size
+
+    k_forward_max_threads = 1024
+    num_warps_per_threadblock = k_forward_max_threads // (warp_size * 2)
+
+    # D <= warp_size*4 keeps ceil(D/(warp_size*4)) == 1, saving memory.
+    # On warpSize 64 this is D=64 (matching the pre-existing parameters).
+    # On warpSize 32 this is D=32.
+    D = warp_size
+
+    # Required T*B to cross the grid * threads_per_block > 2^32 - 1 threshold.
+    # On warpSize 64: 8,388,609 * 8 = 67,108,872 (e.g. T=8400, B=8000 -> 67.2M).
+    # On warpSize 32: 8,388,609 * 16 = 134,217,744 (twice as much).
+    required_TB = 8_388_609 * num_warps_per_threadblock
+
+    # Keep T fixed at 8400 (the original value); scale B.
     T = 8400
-    B = 8000
-    D = 64
+    B = (required_TB + T - 1) // T + 64  # +64 slack to clear the threshold
 
     return T, B, D
 

--- a/fbgemm_gpu/test/tbe/training/forward_test.py
+++ b/fbgemm_gpu/test/tbe/training/forward_test.py
@@ -734,12 +734,23 @@ class ForwardTest(unittest.TestCase):
         # Get parameters that trigger the overflow condition
         T, B, D = get_v2_kernel_overflow_params()
 
-        # Verify the parameters would trigger overflow
-        # For ROCm: kWarpSize=64, num_warps_per_threadblock=8, threads_per_block=512
-        num_warps_per_table = B * ((D + 255) // 256)  # ceil(D / 256)
+        # Verify the parameters would trigger overflow. These V2 kernel
+        # constants must track the runtime warp size: warpSize 64 (CDNA)
+        # gives num_warps_per_threadblock=8 and per-table divisor 256;
+        # warpSize 32 (RDNA) gives 16 and 128 respectively.
+        device = torch.cuda.current_device()
+        warp_size = torch.cuda.get_device_properties(device).warp_size
+        k_forward_max_threads = 1024
+        num_warps_per_threadblock = k_forward_max_threads // (warp_size * 2)
+        threads_per_block = warp_size * num_warps_per_threadblock
+        per_table_divisor = warp_size * 4
+
+        num_warps_per_table = B * ((D + per_table_divisor - 1) // per_table_divisor)
         total_warps = T * num_warps_per_table
-        grid = (total_warps + 7) // 8  # ceil(total_warps / 8)
-        total_threads = grid * 512
+        grid = (
+            total_warps + num_warps_per_threadblock - 1
+        ) // num_warps_per_threadblock
+        total_threads = grid * threads_per_block
 
         assert total_threads > 2**32 - 1, (
             f"Test parameters should trigger overflow: "

--- a/fbgemm_gpu/test/utils/bitonic_sort_test.cu
+++ b/fbgemm_gpu/test/utils/bitonic_sort_test.cu
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/core/ScalarType.h>
+#include <cuda.h>
+#include <gtest/gtest.h>
+#include <torch/types.h> // @manual=//caffe2:torch-cpp-cpu
+
+#include "fbgemm_gpu/utils/bitonic_sort.cuh"
+#include "fbgemm_gpu/utils/kernel_launcher.cuh"
+
+namespace fbgemm_gpu::utils {
+
+////////////////////////////////////////////////////////////////////////////////
+// Warp-wide single-register bitonic sort kernel.
+//
+// Each lane seeds a single K/V pair; after BitonicSort::sort, lane `l` holds
+// the `l`-th element in sorted order across the warp. The kernel writes
+// each lane's post-sort value to out_k / out_v for host-side verification.
+//
+// When launched with blockDim.x == at::cuda::warp_size(), this exercises the
+// full bitonic sort network: the L=16 stage covers warpSize 32 archs, and
+// the warpSize 64 (gfx9xx) path additionally runs the L=32 merge stage
+// required to fully sort all 64 elements.
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename K, typename V, bool Dir>
+__global__ void
+warp_bitonic_sort_kernel(K* out_k, V* out_v, K* seed_keys, V* seed_vals) {
+  const auto lane = threadIdx.x;
+
+  K k[1];
+  V v[1];
+  k[0] = seed_keys[lane];
+  v[0] = seed_vals[lane];
+
+  fbgemm_gpu::BitonicSort<K, V, Dir, fbgemm_gpu::Comparator<K>>::sort(k, v);
+
+  out_k[lane] = k[0];
+  out_v[lane] = v[0];
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Helpers
+////////////////////////////////////////////////////////////////////////////////
+
+// Run one warp-wide sort and verify the result. Seeds lane `l` with
+// k = (W - 1 - l), v = l. Expected post-sort (ascending, Dir=true):
+//   k[l] == l and v[l] == (W - 1 - l).
+// Descending (Dir=false) yields the original reversed seed, unchanged.
+template <typename K, typename V, bool Dir>
+void run_and_check_sort() {
+  const int32_t W = at::cuda::warp_size();
+  const auto device = torch::Device(torch::kCUDA, at::cuda::current_device());
+
+  // Seed lane l with k = (W - 1 - l), v = l on host, then push to device.
+  auto seed_k_cpu =
+      torch::empty({W}, torch::dtype(c10::CppTypeToScalarType<K>::value));
+  auto seed_v_cpu =
+      torch::empty({W}, torch::dtype(c10::CppTypeToScalarType<V>::value));
+  auto* seed_k_host = seed_k_cpu.template data_ptr<K>();
+  auto* seed_v_host = seed_v_cpu.template data_ptr<V>();
+  for (int32_t i = 0; i < W; ++i) {
+    seed_k_host[i] = static_cast<K>(W - 1 - i);
+    seed_v_host[i] = static_cast<V>(i);
+  }
+  const auto seed_k = seed_k_cpu.to(device);
+  const auto seed_v = seed_v_cpu.to(device);
+
+  auto out_k = torch::zeros(
+      {W}, torch::dtype(c10::CppTypeToScalarType<K>::value).device(device));
+  auto out_v = torch::zeros(
+      {W}, torch::dtype(c10::CppTypeToScalarType<V>::value).device(device));
+
+  FBGEMM_LAUNCH_KERNEL(
+      (warp_bitonic_sort_kernel<K, V, Dir>),
+      1,
+      W,
+      0,
+      at::cuda::getCurrentCUDAStream(),
+      out_k.template data_ptr<K>(),
+      out_v.template data_ptr<V>(),
+      seed_k.template data_ptr<K>(),
+      seed_v.template data_ptr<V>());
+
+  const auto out_k_cpu = out_k.cpu();
+  const auto out_v_cpu = out_v.cpu();
+  const auto* out_k_host = out_k_cpu.template data_ptr<K>();
+  const auto* out_v_host = out_v_cpu.template data_ptr<V>();
+
+  for (int32_t i = 0; i < W; ++i) {
+    if (Dir) {
+      // Ascending: k[i] == i, v[i] == W - 1 - i.
+      EXPECT_EQ(out_k_host[i], static_cast<K>(i)) << "lane=" << i;
+      EXPECT_EQ(out_v_host[i], static_cast<V>(W - 1 - i)) << "lane=" << i;
+    } else {
+      // Descending: input was already reverse-sorted, so output is unchanged.
+      EXPECT_EQ(out_k_host[i], static_cast<K>(W - 1 - i)) << "lane=" << i;
+      EXPECT_EQ(out_v_host[i], static_cast<V>(i)) << "lane=" << i;
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////////////
+
+// Covers the LRU/LFU populate instantiation
+// (src/split_embeddings_cache/lru_cache_populate.cu,
+// lfu_cache_populate.cu). Key/val types match the production callsites.
+TEST(BitonicSortTest, int64_uint32_ascending) {
+  run_and_check_sort<int64_t, uint32_t, /*Dir=*/true>();
+}
+
+TEST(BitonicSortTest, int64_uint32_descending) {
+  run_and_check_sort<int64_t, uint32_t, /*Dir=*/false>();
+}
+
+// Covers the SSD cache instantiation
+// (src/ssd_split_embeddings_cache/ssd_split_embeddings_cache_cuda.cu).
+TEST(BitonicSortTest, int64_int64_ascending) {
+  run_and_check_sort<int64_t, int64_t, /*Dir=*/true>();
+}
+
+TEST(BitonicSortTest, int64_int64_descending) {
+  run_and_check_sort<int64_t, int64_t, /*Dir=*/false>();
+}
+
+} // namespace fbgemm_gpu::utils

--- a/fbgemm_gpu/test/utils/warp_primitives_test.cu
+++ b/fbgemm_gpu/test/utils/warp_primitives_test.cu
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda.h>
+#include <gtest/gtest.h>
+#include <torch/types.h> // @manual=//caffe2:torch-cpp-cpu
+
+#include "fbgemm_gpu/utils/cuda_prelude.cuh"
+#include "fbgemm_gpu/utils/kernel_launcher.cuh"
+
+namespace fbgemm_gpu::utils {
+
+////////////////////////////////////////////////////////////////////////////////
+// Compile-time contract checks for cuda_prelude.cuh
+//
+// These static_asserts pin the public header-only contract: kWarpSize and
+// kFullWarpMask must have the right type and value for each platform.
+// Regressions here would break warpSize 32/64 dual-build support on ROCm.
+////////////////////////////////////////////////////////////////////////////////
+
+// kWarpSize type: always int32_t.
+static_assert(
+    std::is_same_v<std::remove_cv_t<decltype(fbgemm_gpu::kWarpSize)>, int32_t>,
+    "kWarpSize must be int32_t");
+
+#if defined(USE_ROCM)
+// kFullWarpMask on ROCm: uint64_t because HIP's __ballot_sync / __any_sync /
+// __all_sync templates statically require a 64-bit mask type. Narrowing
+// would break compilation on both warpSize 32 and warpSize 64 archs.
+static_assert(
+    std::is_same_v<
+        std::remove_cv_t<decltype(fbgemm_gpu::kFullWarpMask)>,
+        uint64_t>,
+    "kFullWarpMask on ROCm must be uint64_t");
+static_assert(
+    fbgemm_gpu::kFullWarpMask == 0xffffffffffffffffull,
+    "kFullWarpMask on ROCm must be 0xFFFFFFFFFFFFFFFF");
+#else
+// kFullWarpMask on CUDA: uint32_t (the NVIDIA ballot mask width).
+static_assert(
+    std::is_same_v<
+        std::remove_cv_t<decltype(fbgemm_gpu::kFullWarpMask)>,
+        uint32_t>,
+    "kFullWarpMask on CUDA must be uint32_t");
+static_assert(
+    fbgemm_gpu::kFullWarpMask == 0xffffffffu,
+    "kFullWarpMask on CUDA must be 0xFFFFFFFF");
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+// Test Kernels
+////////////////////////////////////////////////////////////////////////////////
+
+// Writes the device-side value of fbgemm_gpu::kWarpSize from thread 0 into
+// the output buffer. Used to verify that the device-side per-arch resolution
+// of kWarpSize matches the host's at::cuda::warp_size() on the active
+// device.
+__global__ void write_device_kWarpSize(int32_t* out) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    out[0] = fbgemm_gpu::kWarpSize;
+  }
+}
+
+// For lane l in [0, warp_size), evaluates `(l < n)` as the predicate to
+// fbgemm_gpu::ballot_sync, then thread 0 writes the returned bitmap into
+// out[n-1]. With a single warp launch the expected bitmap is
+// ((1ULL << n) - 1ULL) for n in [1, warp_size].
+__global__ void ballot_roundtrip_kernel(uint64_t* out, int32_t n) {
+  const auto lane = threadIdx.x;
+  const bool pred = lane < static_cast<uint32_t>(n);
+#if defined(USE_ROCM)
+  const uint64_t bitmap = fbgemm_gpu::ballot_sync(pred);
+#else
+  const uint64_t bitmap = static_cast<uint64_t>(fbgemm_gpu::ballot_sync(pred));
+#endif
+  if (lane == 0) {
+    out[0] = bitmap;
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(WarpPrimitivesTest, device_kWarpSize_matches_at_cuda_warp_size) {
+  // at::cuda::warp_size() is the host-side source of truth for the active
+  // device's warpSize. The device-side kWarpSize is resolved per-arch at
+  // compile time (__GFX9__ => 64, else 32 on ROCm; always 32 on CUDA).
+  // For the arch the test runs on, they must agree.
+  auto out = torch::full(
+      {1},
+      -1,
+      torch::dtype(torch::kInt32)
+          .device(torch::kCUDA, at::cuda::current_device()));
+  FBGEMM_LAUNCH_KERNEL(
+      write_device_kWarpSize,
+      1,
+      1,
+      0,
+      at::cuda::getCurrentCUDAStream(),
+      out.data_ptr<int32_t>());
+
+  const int32_t device_warp_size = out.cpu().item<int32_t>();
+  const int32_t host_warp_size = at::cuda::warp_size();
+  EXPECT_EQ(device_warp_size, host_warp_size);
+  // And the runtime-known warpSize must be one of the two supported values.
+  EXPECT_TRUE(host_warp_size == 32 || host_warp_size == 64)
+      << "Unsupported warpSize: " << host_warp_size;
+}
+
+TEST(WarpPrimitivesTest, ballot_sync_roundtrip) {
+  const int32_t warp_size = at::cuda::warp_size();
+  auto out = torch::zeros(
+      {1},
+      torch::dtype(torch::kUInt64)
+          .device(torch::kCUDA, at::cuda::current_device()));
+
+  // For each n in [1, warp_size], check the returned bitmap has exactly the
+  // low n bits set. This exercises both the CUDA (__ballot_sync) and HIP
+  // (__ballot) wrappers and — on ROCm — transitively the __any_sync shim
+  // defined in cuda_prelude.cuh (which is implemented via __ballot).
+  for (int32_t n = 1; n <= warp_size; ++n) {
+    FBGEMM_LAUNCH_KERNEL(
+        ballot_roundtrip_kernel,
+        1,
+        warp_size,
+        0,
+        at::cuda::getCurrentCUDAStream(),
+        out.data_ptr<uint64_t>(),
+        n);
+
+    const uint64_t expected =
+        n == 64 ? 0xffffffffffffffffull : ((1ULL << n) - 1ULL);
+    const auto out_cpu = out.cpu();
+    EXPECT_EQ(out_cpu.data_ptr<uint64_t>()[0], expected) << "n=" << n;
+  }
+}
+
+} // namespace fbgemm_gpu::utils


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2648


Adds unit-test coverage for the ROCm warpSize 32 / 64 dual-build migration in `fbgemm_gpu`.

This diff adds two new C++ gtests and one new Python test, and generalizes two existing Python tests to query the active device's warp size at runtime so they run unmodified on both warpSize 64 (CDNA / gfx9xx) and warpSize 32 (RDNA / gfx11xx) AMD GPUs. Specifically:

1. **Bitonic sort gtest (`bitonic_sort_test.cu`)**: Exercises `fbgemm_gpu::BitonicSort` (from `utils/bitonic_sort.cuh`) across both production instantiations — `<int64_t, uint32_t>` (LRU/LFU cache populate) and `<int64_t, int64_t>` (SSD cache). Runs a full warp-wide sort network; on warpSize 64 this additionally covers the `L=32` merge stage required to fully sort 64 elements.
2. **Warp primitives gtest (`warp_primitives_test.cu`)**: Pins the public `cuda_prelude.cuh` contract with `static_assert`s on the type + value of `kWarpSize` (int32_t) and `kFullWarpMask` (uint64_t on ROCm, uint32_t on CUDA, with the correct all-ones bit pattern). Adds runtime checks that (a) the device-side `kWarpSize` matches the host's `at::cuda::warp_size()` on the active device, and (b) `ballot_sync` returns the correct low-`n`-bits bitmap for every `n ∈ [1, warp_size]`, exercising both the CUDA `__ballot_sync` and HIP `__ballot` wrappers (and transitively the `__any_sync` shim that `cuda_prelude.cuh` implements via `__ballot` on ROCm).
3. **Runtime-warp_size generalization for V2 forward-kernel overflow test**: Rewrites `get_v2_kernel_overflow_params()` in `test/tbe/common.py` to query `torch.cuda.get_device_properties(device).warp_size` and derive `num_warps_per_threadblock`, `per_table_divisor`, and the required `T*B` threshold from it. `test_forward_gpu_v2_kernel_large_grid_rocm` in `forward_test.py` is updated to mirror the same runtime computation so its overflow assertion holds on both warpSize 32 and 64 archs.
4. **Positive-path ROCm cache smoke test (`test_warp_size_guard_positive_path_rocm` in `lxu_cache_test.py`)**: Exercises LRU populate, LFU populate, and `lxu_cache_lookup` on CDNA via `cc.prefetch(...)` and `cc(...)`. Each op carries a `TORCH_CHECK(warp_size == 64)` guard on ROCm; this test is the regression guard that the guard stays a no-op on the warpSize-64 hardware currently in CI. Negative-path (raising on warpSize != 64) is deferred until RDNA CI or an injectable `at::cuda::warp_size()` indirection is available.
5. **BUCK registrations (`test/utils/BUCK`)**: Registers the two new `gpu_cpp_unittest` targets (`bitonic_sort`, `warp_primitives`), each with a `//caffe2:ATen` dep.

## Detailed Changes

### `test/utils/bitonic_sort_test.cu` (new)
- Adds a warp-wide single-register `warp_bitonic_sort_kernel<K, V, Dir>` launched with `blockDim.x == at::cuda::warp_size()`.
- `run_and_check_sort<K, V, Dir>` seeds lane `l` with `k = W - 1 - l, v = l` and verifies the ascending / descending post-sort layout.
- Four `TEST`s: `int64_uint32_ascending`, `int64_uint32_descending`, `int64_int64_ascending`, `int64_int64_descending`.

### `test/utils/warp_primitives_test.cu` (new)
- `static_assert`s for `kWarpSize` type and `kFullWarpMask` type + value, guarded by `#if defined(USE_ROCM)`.
- `write_device_kWarpSize` kernel + `device_kWarpSize_matches_at_cuda_warp_size` test: verifies device-side `kWarpSize` matches `at::cuda::warp_size()` and that the value is one of 32 / 64.
- `ballot_roundtrip_kernel` + `ballot_sync_roundtrip` test: verifies `ballot_sync((lane < n))` returns `((1ULL << n) - 1)` (or `0xFFFF_FFFF_FFFF_FFFF` at `n == 64`) for every `n ∈ [1, warp_size]`.

### `test/utils/BUCK`
- Appends `("bitonic_sort", ["//caffe2:ATen"])` and `("warp_primitives", ["//caffe2:ATen"])` to the `gpu_cpp_unittest` registration list.

### `test/tbe/common.py`
- Replaces the hard-coded warpSize-64 parameters (`T=8400, B=8000, D=64`) in `get_v2_kernel_overflow_params()` with a runtime-derived computation:
  - Queries `warp_size` via `torch.cuda.get_device_properties(device).warp_size`.
  - Derives `num_warps_per_threadblock = 1024 // (warp_size * 2)` and `D = warp_size` (keeps `ceil(D / (warp_size*4)) == 1`).
  - Computes `required_TB = 8_388_609 * num_warps_per_threadblock` and sets `B = (required_TB + T - 1) // T + 64` for slack.
- Updates the docstring to reflect dual-warpSize support and the generalized overflow condition.

### `test/tbe/training/forward_test.py`
- Updates `test_forward_gpu_v2_kernel_large_grid_rocm` to compute `num_warps_per_threadblock`, `threads_per_block`, and `per_table_divisor` from the runtime `warp_size` so the overflow assertion on `total_threads > 2**32 - 1` holds on both warpSize 32 and 64 archs.

### `test/tbe/cache/lxu_cache_test.py`
- Adds `test_warp_size_guard_positive_path_rocm` (guarded on `torch.version.hip is not None`). For each of `CacheAlgorithm.LRU` and `CacheAlgorithm.LFU`, generates a TBE + request batch, calls `cc.prefetch(indices, offsets)` (exercises `{lru,lfu}_cache_populate_cuda`) then `cc(indices, offsets)` (exercises `lxu_cache_lookup_cuda`), and asserts the forward output is a non-empty `torch.Tensor`.

Reviewed By: henrylhtsang

Differential Revision: D103072708


