### PR TITLE
Optimize jagged_unique_indices_cuda (binary-search length + custom cub pipeline) (#5718)

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_unique_indices.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_unique_indices.cu
@@ -18,196 +18,482 @@
 
 #include "fbgemm_gpu/split_embeddings_utils.cuh"
 
+#include <climits>
+#include <cmath>
+
 using Tensor = at::Tensor;
 
 namespace fbgemm_gpu {
 
-// Linearzie the index with the cumsum of hash size so that linearized indices
-// can be sorted together.
-template <typename index_t>
-__global__ __launch_bounds__(kMaxThreads) void linearize_index_wo_infos_kernel(
+// Flat-grid linearize: one block per (t, b) sample. Replaces the old
+// warp-cooperative linearize_index_wo_infos_kernel which launched only
+// ⌈total_B/kMaxThreads⌉ blocks, severely underutilizing the SMs on
+// large-N workloads. Writes the linearized index directly in the target
+// key_t (int32 or int64), saving a subsequent cast pass.
+template <typename index_t, typename key_t>
+__global__ __launch_bounds__(256) void linearize_index_flat_kernel(
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         hash_size_cumsum,
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         indices,
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         offsets,
-    pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
-        linear_indices,
+    pta::PackedTensorAccessor32<key_t, 1, at::RestrictPtrTraits> linear_indices,
     FixedDivisor fd) {
-  const auto b_t = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto b_t = blockIdx.x;
   int32_t b;
   int32_t t;
-  const auto total_B = offsets.size(0) - 1;
-  const auto valid = b_t < total_B;
+  fd.DivMod(static_cast<int32_t>(b_t), &t, &b);
 
-  fd.DivMod(b_t, &t, &b);
+  const auto indices_start = offsets[b_t];
+  const auto L = offsets[b_t + 1] - indices_start;
+  if (L == 0) {
+    return;
+  }
+  const auto hash_offset = hash_size_cumsum[t];
 
-  const auto hash_offset = valid ? hash_size_cumsum[t] : -1;
-  const auto indices_start = valid ? offsets[b_t] : -1;
-  const int32_t L = valid ? offsets[b_t + 1] - indices_start : 0;
-  const auto lane_id = threadIdx.x % fbgemm_gpu::kWarpSize;
+  for (auto i = threadIdx.x; i < L; i += blockDim.x) {
+    const auto idx = __ldg(&indices[indices_start + i]);
+    linear_indices[indices_start + i] = static_cast<key_t>(hash_offset + idx);
+  }
+}
 
-  for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
-    const auto indices_start_warp = fbgemm_gpu::shfl_sync(indices_start, j);
-    const auto L_warp = fbgemm_gpu::shfl_sync(L, j);
-    const auto hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
-    for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
-      const auto idx = __ldg(&indices[indices_start_warp + i]);
-      linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
+// Adjacent-difference over sorted keys. Mirrors
+// caffe2/aten/src/ATen/native/cuda/UniqueCub.cu:24-31.
+// out[0] = 0; out[i] = (sorted[i] != sorted[i-1]) ? 1 : 0 for i > 0.
+template <typename key_t>
+__global__ __launch_bounds__(256) void jagged_unique_adjacent_diff_kernel(
+    const pta::PackedTensorAccessor32<key_t, 1, at::RestrictPtrTraits>
+        sorted_keys,
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> out) {
+  const auto n = sorted_keys.size(0);
+  const auto i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < static_cast<uint64_t>(n)) {
+    out[i] = (i > 0 && sorted_keys[i] != sorted_keys[i - 1]) ? 1 : 0;
+  }
+}
+
+// Scatter inv_loc_out into reverse_index via sorted_positions. Mirrors
+// caffe2/aten/src/ATen/native/cuda/UniqueCub.cu:33-41. Output is int64
+// to preserve the op's public contract (at::_unique returns int64 inverse).
+__global__ __launch_bounds__(256) void jagged_unique_scatter_kernel(
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        sorted_positions,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        inv_loc_out,
+    pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+        reverse_index) {
+  const auto n = sorted_positions.size(0);
+  const auto i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < static_cast<uint64_t>(n)) {
+    reverse_index[sorted_positions[i]] = static_cast<int64_t>(inv_loc_out[i]);
+  }
+}
+
+// Device-side lower_bound over a PackedTensorAccessor32<index_t, 1>.
+// Returns the first position whose value is >= `value`. Equivalent to
+// std::lower_bound.
+template <typename index_t>
+__device__ __forceinline__ int32_t device_lower_bound(
+    const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>& arr,
+    const index_t value) {
+  int32_t lo = 0;
+  int32_t hi = static_cast<int32_t>(arr.size(0));
+  while (lo < hi) {
+    const int32_t mid = lo + ((hi - lo) >> 1);
+    if (arr[mid] < value) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
     }
   }
+  return lo;
 }
 
-// Delinearize the unique indices from the reverse index info and the original
-// indices. For each element in the input indices, the value should equal to
-// the element from the unique indices according to the reverse index info.
-template <typename index_t>
-__global__ __launch_bounds__(kMaxThreads) void delinearize_unique_index_kernel(
+// Feature-lookup delinearize: iterates over num_unique (~millions) instead
+// of total_indices (~tens of millions). Each thread handles one sorted
+// unique key and recovers its feature-local index via binary search over
+// hash_size_cumsum. Replaces the old delinearize_unique_index_kernel's
+// total_indices-sized scatter.
+template <typename index_t, typename key_t>
+__global__ __launch_bounds__(256) void delinearize_unique_from_sorted_kernel(
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
-        indices,
-    const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
-        reverse_index,
+        hash_size_cumsum,
+    const pta::PackedTensorAccessor32<key_t, 1, at::RestrictPtrTraits>
+        unique_keys,
     pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         unique_indices) {
-  const auto total_indices = indices.size(0);
-  const auto b_t = blockIdx.x * blockDim.x + threadIdx.x;
-  if (b_t < total_indices) {
-    const auto original_index = indices[b_t];
-    const auto pos = reverse_index[b_t];
-    unique_indices[pos] = original_index;
+  const auto num_unique = unique_keys.size(0);
+  const auto i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= static_cast<uint64_t>(num_unique)) {
+    return;
   }
+  const index_t v = static_cast<index_t>(unique_keys[i]);
+  // Largest t such that hash_size_cumsum[t] <= v, i.e. the feature that
+  // owns this linearized value.
+  const int32_t t = device_lower_bound<index_t>(hash_size_cumsum, v + 1) - 1;
+  unique_indices[i] = v - hash_size_cumsum[t];
 }
 
-// Compute the lengths for each feature in the unique indices. The range of
-// indices for each feature equals to the difference between the max and min
-// values in the reverse index array.
-template <typename index_t, auto max_value, auto min_value>
-__global__ __launch_bounds__(kMaxThreads) void unique_indices_length_kernel(
+// Compute the lengths for each feature in the unique indices.
+//
+// Invariant leveraged: linearize_index_wo_infos_kernel prefixes every index
+// of feature t with hash_size_cumsum[t], so linearized values of feature t
+// lie in [hash_size_cumsum[t], hash_size_cumsum[t+1]). at::_unique is called
+// with sorted=true, therefore entries of feature t occupy a single
+// contiguous slice of `unique_indices`, namely
+//   [lower_bound(unique_indices, hash_size_cumsum[t]),
+//    lower_bound(unique_indices, hash_size_cumsum[t+1]))
+// and the slice length equals the previous kernel's (max - min + 1) over
+// reverse_index. This replaces an O(N) reduction over reverse_index with
+// two O(log U) binary searches per feature group.
+template <typename index_t>
+__global__ __launch_bounds__(256) void unique_indices_length_kernel(
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         hash_size_offsets,
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
-        reverse_index,
+        hash_size_cumsum,
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
-        offsets,
-    pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> lengths) {
-  typedef cub::BlockReduce<index_t, kMaxThreads> BlockReduce;
-  __shared__ typename BlockReduce::TempStorage temp_storage_max;
-  __shared__ typename BlockReduce::TempStorage temp_storage_min;
-  __shared__ index_t block_results[2];
-
+        unique_indices,
+    pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> lengths,
+    const int32_t batch_size) {
   const auto tid = threadIdx.x;
   const auto bid = blockIdx.x;
-  const auto num_blocks = gridDim.x;
-  const int32_t batch_size = (offsets.size(0) - 1) / num_blocks;
 
-  const auto offset_begin = hash_size_offsets[bid] * batch_size;
-  const auto offset_end = hash_size_offsets[bid + 1] * batch_size;
-  const auto num_lengths = (offset_end - offset_begin);
-
-  const auto reverse_index_begin = offsets[offset_begin];
-  const auto reverse_index_end = offsets[offset_end];
-
-  if (reverse_index_begin == reverse_index_end) {
+  const auto hash_begin = hash_size_offsets[bid];
+  const auto hash_end = hash_size_offsets[bid + 1];
+  const auto offset_begin = hash_begin * batch_size;
+  const auto offset_end = hash_end * batch_size;
+  const auto num_lengths = offset_end - offset_begin;
+  if (num_lengths == 0) {
     return;
   }
 
-  index_t t_max = min_value;
-  index_t t_min = max_value;
-  for (index_t i = (reverse_index_begin + tid); i < reverse_index_end;
-       i += kMaxThreads) {
-    const index_t value = reverse_index[i];
-    t_max = (value > t_max) ? value : t_max;
-    t_min = (value < t_min) ? value : t_min;
-  }
-
-  index_t block_max =
-      BlockReduce(temp_storage_max).Reduce(t_max, Max<index_t>());
-  index_t block_min =
-      BlockReduce(temp_storage_min).Reduce(t_min, Min<index_t>());
+  __shared__ index_t s_div_length;
+  __shared__ index_t s_r_length;
   if (tid == 0) {
-    block_results[0] = block_max;
-    block_results[1] = block_min;
+    const auto low = hash_size_cumsum[hash_begin];
+    const auto high = hash_size_cumsum[hash_end];
+    if (low == high) {
+      // Empty feature group. Output is pre-zeroed; nothing to do.
+      s_div_length = 0;
+      s_r_length = 0;
+    } else {
+      const int32_t lo_pos = device_lower_bound<index_t>(unique_indices, low);
+      const int32_t hi_pos = device_lower_bound<index_t>(unique_indices, high);
+      const index_t total_length = static_cast<index_t>(hi_pos - lo_pos);
+      s_div_length = total_length / static_cast<index_t>(num_lengths);
+      s_r_length = total_length % static_cast<index_t>(num_lengths);
+    }
   }
   __syncthreads();
 
-  t_max = block_results[0];
-  t_min = block_results[1];
-  const index_t total_length = (t_max - t_min) + 1;
-  const index_t div_length = total_length / num_lengths;
-  const index_t r_length = total_length % num_lengths;
-  for (int32_t i = tid; i < num_lengths; i += kMaxThreads) {
-    index_t seg_length = (i < r_length) ? (div_length + 1) : div_length;
+  const index_t div_length = s_div_length;
+  const index_t r_length = s_r_length;
+  if (div_length == 0 && r_length == 0) {
+    return;
+  }
+  for (int32_t i = tid; i < num_lengths; i += blockDim.x) {
+    const index_t seg_length =
+        (static_cast<index_t>(i) < r_length) ? (div_length + 1) : div_length;
     lengths[offset_begin + i] = seg_length;
   }
 }
 
+// Custom cub pipeline that replaces at::_unique: radix sort pairs (keys +
+// arange positions), run-length encode, adjacent-diff + inclusive-scan +
+// scatter to build the inverse index, then a feature-lookup delinearize
+// over num_unique. Exposes linear_unique_indices as index_t so that
+// unique_indices_length_kernel can be reused unchanged.
+template <typename index_t, typename key_t>
+static void jagged_unique_indices_pipeline(
+    const Tensor& hash_size_cumsum,
+    const Tensor& offsets,
+    const Tensor& indices,
+    const int total_hash_size_bits,
+    const int64_t total_B,
+    const int64_t T,
+    Tensor& linear_unique_indices,
+    Tensor& unique_indices,
+    Tensor& reverse_index) {
+  const int64_t N = indices.numel();
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  const auto key_opts = indices.options().dtype(
+      std::is_same<key_t, int32_t>::value ? at::kInt : at::kLong);
+  const auto int32_opts = indices.options().dtype(at::kInt);
+  const auto int64_opts = indices.options().dtype(at::kLong);
+  const auto byte_opts = indices.options().dtype(at::kByte);
+
+  // --- Step F: flat-grid linearize, writes key_t directly ---
+  Tensor linear_indices = at::empty({N}, key_opts);
+  FBGEMM_LAUNCH_KERNEL(
+      (linearize_index_flat_kernel<index_t, key_t>),
+      total_B,
+      256,
+      0,
+      stream,
+      PTA_B(hash_size_cumsum, index_t, 1, 32),
+      PTA_B(indices, index_t, 1, 32),
+      PTA_B(offsets, index_t, 1, 32),
+      PTA_B(linear_indices, key_t, 1, 32),
+      FixedDivisor(static_cast<int32_t>(total_B / T)));
+
+  // --- Step 3a: cub radix sort pairs with trimmed end_bit ---
+  Tensor sorted_keys = at::empty({N}, key_opts);
+  Tensor positions = at::arange(N, int32_opts);
+  Tensor sorted_positions = at::empty({N}, int32_opts);
+  {
+    size_t temp_storage_bytes = 0;
+    AT_CUDA_CHECK(radix_sort_pairs(
+        nullptr,
+        temp_storage_bytes,
+        linear_indices.const_data_ptr<key_t>(),
+        sorted_keys.data_ptr<key_t>(),
+        positions.const_data_ptr<int32_t>(),
+        sorted_positions.data_ptr<int32_t>(),
+        static_cast<int>(N),
+        0,
+        total_hash_size_bits,
+        stream));
+    Tensor temp_storage =
+        at::empty({static_cast<int64_t>(temp_storage_bytes)}, byte_opts);
+    AT_CUDA_CHECK(radix_sort_pairs(
+        temp_storage.data_ptr(),
+        temp_storage_bytes,
+        linear_indices.const_data_ptr<key_t>(),
+        sorted_keys.data_ptr<key_t>(),
+        positions.const_data_ptr<int32_t>(),
+        sorted_positions.data_ptr<int32_t>(),
+        static_cast<int>(N),
+        0,
+        total_hash_size_bits,
+        stream));
+  }
+
+  // --- Step 3b: cub run-length encode to extract unique keys ---
+  Tensor unique_keys = at::empty({N}, key_opts);
+  Tensor run_lengths = at::empty({N}, int32_opts); // required but unused
+  Tensor num_unique_d = at::empty({1}, int32_opts);
+  {
+    size_t temp_storage_bytes = 0;
+    AT_CUDA_CHECK(
+        FBGEMM_GPU_CUB_NS_PREFIX cub::DeviceRunLengthEncode::Encode(
+            nullptr,
+            temp_storage_bytes,
+            sorted_keys.const_data_ptr<key_t>(),
+            unique_keys.data_ptr<key_t>(),
+            run_lengths.data_ptr<int32_t>(),
+            num_unique_d.data_ptr<int32_t>(),
+            static_cast<int>(N),
+            stream));
+    Tensor temp_storage =
+        at::empty({static_cast<int64_t>(temp_storage_bytes)}, byte_opts);
+    AT_CUDA_CHECK(
+        FBGEMM_GPU_CUB_NS_PREFIX cub::DeviceRunLengthEncode::Encode(
+            temp_storage.data_ptr(),
+            temp_storage_bytes,
+            sorted_keys.const_data_ptr<key_t>(),
+            unique_keys.data_ptr<key_t>(),
+            run_lengths.data_ptr<int32_t>(),
+            num_unique_d.data_ptr<int32_t>(),
+            static_cast<int>(N),
+            stream));
+  }
+  const int32_t num_unique = num_unique_d.item<int32_t>();
+  unique_keys = unique_keys.narrow(0, 0, num_unique);
+
+  // --- Step 3c: inverse-index construction
+  //     (adjacent_diff + inclusive_sum + scatter) ---
+  Tensor inv_loc = at::empty({N}, int32_opts);
+  FBGEMM_LAUNCH_KERNEL(
+      (jagged_unique_adjacent_diff_kernel<key_t>),
+      div_round_up(static_cast<int32_t>(N), 256),
+      256,
+      0,
+      stream,
+      PTA_B(sorted_keys, key_t, 1, 32),
+      PTA_B(inv_loc, int32_t, 1, 32));
+
+  Tensor inv_loc_out = at::empty({N}, int32_opts);
+  {
+    size_t temp_storage_bytes = 0;
+    AT_CUDA_CHECK(
+        FBGEMM_GPU_CUB_NS_PREFIX cub::DeviceScan::InclusiveSum(
+            nullptr,
+            temp_storage_bytes,
+            inv_loc.const_data_ptr<int32_t>(),
+            inv_loc_out.data_ptr<int32_t>(),
+            static_cast<int>(N),
+            stream));
+    Tensor temp_storage =
+        at::empty({static_cast<int64_t>(temp_storage_bytes)}, byte_opts);
+    AT_CUDA_CHECK(
+        FBGEMM_GPU_CUB_NS_PREFIX cub::DeviceScan::InclusiveSum(
+            temp_storage.data_ptr(),
+            temp_storage_bytes,
+            inv_loc.const_data_ptr<int32_t>(),
+            inv_loc_out.data_ptr<int32_t>(),
+            static_cast<int>(N),
+            stream));
+  }
+
+  reverse_index = at::empty({N}, int64_opts);
+  FBGEMM_LAUNCH_KERNEL(
+      (jagged_unique_scatter_kernel),
+      div_round_up(static_cast<int32_t>(N), 256),
+      256,
+      0,
+      stream,
+      PTA_B(sorted_positions, int32_t, 1, 32),
+      PTA_B(inv_loc_out, int32_t, 1, 32),
+      PTA_B(reverse_index, int64_t, 1, 32));
+
+  // --- Step E: feature-lookup delinearize over num_unique ---
+  unique_indices = at::empty({num_unique}, indices.options());
+  if (num_unique > 0) {
+    FBGEMM_LAUNCH_KERNEL(
+        (delinearize_unique_from_sorted_kernel<index_t, key_t>),
+        div_round_up(num_unique, 256),
+        256,
+        0,
+        stream,
+        PTA_B(hash_size_cumsum, index_t, 1, 32),
+        PTA_B(unique_keys, key_t, 1, 32),
+        PTA_B(unique_indices, index_t, 1, 32));
+  }
+
+  // Provide linear_unique_indices as index_t for unique_indices_length_kernel.
+  if (std::is_same<key_t, index_t>::value) {
+    linear_unique_indices = unique_keys;
+  } else {
+    linear_unique_indices = unique_keys.to(indices.scalar_type());
+  }
+}
+
+// Preconditions enforced by the TORCH_CHECKs at the top of
+// jagged_unique_indices_cuda; trace each back to its downstream consumer.
+//
+//  - hash_size_cumsum.dtype() == indices.dtype()
+//      Required so AT_DISPATCH_INDEX_TYPES on indices.scalar_type() can
+//      bind a single index_t for both tensors inside the pipeline.
+//
+//  - hash_size_cumsum.numel() >= 2 (i.e. T = numel - 1 >= 1)
+//      T feeds three consumers that assume T >= 1:
+//        1. total_B / T — integer division below; UB if T == 0.
+//        2. FixedDivisor(total_B / T) — passed to
+//           linearize_index_flat_kernel to recover (t, b) from the flat
+//           block index; FixedDivisor with divisor 0 is undefined.
+//        3. unique_indices_length_kernel launches T blocks and reads
+//           hash_size_cumsum[bid+1], so it requires numel >= T + 1 = 2.
+//      We also dereference hash_size_cumsum[numel-1] just below to read
+//      total_hash_size, which independently needs numel >= 1.
+//
+//  - N = indices.numel() <= INT32_MAX
+//      N feeds three int32-typed consumers inside
+//      jagged_unique_indices_pipeline:
+//        1. positions = at::arange(N, int32_opts) — int32 value payload
+//           of the radix sort, must enumerate [0, N) in int32.
+//        2. sorted_positions / inv_loc / inv_loc_out — int32 scratch
+//           tensors sized N, indexed in [0, N).
+//        3. static_cast<int>(N) passed as num_items to
+//           cub::DeviceRadixSort, DeviceRunLengthEncode, and DeviceScan
+//           (FBGEMM's radix_sort_pairs wrapper takes `int num_items`;
+//           CUB's APIs likewise).
+//      If N exceeds INT32_MAX we would silently wrap and produce garbage
+//      sorts/uniques rather than fail.
+//
+//  - total_hash_size >= 0 and total_hash_size_bits <= 63
+//      Bounds the radix-sort end_bit; >63 would overflow CUB's pass count.
 std::tuple<Tensor, Tensor, Tensor, Tensor> jagged_unique_indices_cuda(
     const Tensor& hash_size_cumsum,
     const Tensor& hash_size_offsets,
     const Tensor& offsets,
     const Tensor& indices) {
+  TORCH_CHECK(hash_size_cumsum.dtype() == indices.dtype());
+  TORCH_CHECK(
+      hash_size_cumsum.numel() >= 2,
+      "jagged_unique_indices: hash_size_cumsum must have at least 2 entries "
+      "(T >= 1), got ",
+      hash_size_cumsum.numel());
+
   const auto total_B = offsets.size(0) - 1;
   const auto T = hash_size_cumsum.size(0) - 1;
+  const auto N = indices.numel();
+  TORCH_CHECK(
+      N <= static_cast<int64_t>(INT32_MAX),
+      "jagged_unique_indices: indices.numel() (",
+      N,
+      ") exceeds INT32_MAX");
 
-  Tensor linear_indices = at::empty_like(indices);
+  // One D→H sync to get total_hash_size for radix-sort end_bit trimming.
+  // at::_unique historically already did an implicit sync here for output
+  // allocation, so this is net-neutral.
+  const int64_t total_hash_size =
+      hash_size_cumsum[hash_size_cumsum.numel() - 1].item().toLong();
+  TORCH_CHECK(total_hash_size >= 0);
+  const int total_hash_size_bits = (total_hash_size > 0)
+      ? static_cast<int>(
+            std::log2(static_cast<double>(total_hash_size + 1)) + 1)
+      : 1;
+  TORCH_CHECK(total_hash_size_bits <= 63);
+  // int32 key path is safe when total_hash_size fits in int32: linearized
+  // values are bounded by total_hash_size - 1 < INT32_MAX.
+  const bool use_int32_keys = total_hash_size < static_cast<int64_t>(INT32_MAX);
 
-  using at::RestrictPtrTraits;
-
-  AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "linearize_index", ([&] {
-                            FBGEMM_LAUNCH_KERNEL(
-                                (linearize_index_wo_infos_kernel<index_t>),
-                                div_round_up(total_B, kMaxThreads),
-                                kMaxThreads,
-                                0,
-                                at::cuda::getCurrentCUDAStream(),
-                                PTA_B(hash_size_cumsum, index_t, 1, 32),
-                                PTA_B(indices, index_t, 1, 32),
-                                PTA_B(offsets, index_t, 1, 32),
-                                PTA_B(linear_indices, index_t, 1, 32),
-                                FixedDivisor(total_B / T));
-                          }));
-
-  Tensor linear_unique_indices;
+  Tensor unique_indices;
   Tensor reverse_index;
-  std::tie(linear_unique_indices, reverse_index) =
-      at::_unique(linear_indices, true, true);
+  Tensor linear_unique_indices;
 
-  const auto total_indices = indices.size(0);
-  Tensor unique_indices = at::empty_like(linear_unique_indices);
-
-  AT_DISPATCH_INDEX_TYPES(
-      indices.scalar_type(), "delinearize_unique_index", ([&] {
-        FBGEMM_LAUNCH_KERNEL(
-            (delinearize_unique_index_kernel<index_t>),
-            div_round_up(total_indices + 1, kMaxThreads),
-            kMaxThreads,
-            0,
-            at::cuda::getCurrentCUDAStream(),
-            PTA_B(indices, index_t, 1, 32),
-            PTA_B(reverse_index, index_t, 1, 32),
-            PTA_B(unique_indices, index_t, 1, 32));
-      }));
+  if (N == 0) {
+    unique_indices = at::empty({0}, indices.options());
+    reverse_index = at::empty({0}, indices.options().dtype(at::kLong));
+    linear_unique_indices = at::empty({0}, indices.options());
+  } else {
+    AT_DISPATCH_INDEX_TYPES(
+        indices.scalar_type(), "jagged_unique_indices_pipeline", ([&] {
+          if (use_int32_keys) {
+            jagged_unique_indices_pipeline<index_t, int32_t>(
+                hash_size_cumsum,
+                offsets,
+                indices,
+                total_hash_size_bits,
+                total_B,
+                T,
+                linear_unique_indices,
+                unique_indices,
+                reverse_index);
+          } else {
+            jagged_unique_indices_pipeline<index_t, index_t>(
+                hash_size_cumsum,
+                offsets,
+                indices,
+                total_hash_size_bits,
+                total_B,
+                T,
+                linear_unique_indices,
+                unique_indices,
+                reverse_index);
+          }
+        }));
+  }
 
   Tensor output_lengths = at::zeros({total_B}, offsets.options());
   AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "unique_indices_length", ([&] {
                             FBGEMM_LAUNCH_KERNEL(
-                                (unique_indices_length_kernel<
-                                    index_t,
-                                    std::numeric_limits<index_t>::max(),
-                                    std::numeric_limits<index_t>::min()>),
+                                (unique_indices_length_kernel<index_t>),
                                 T,
-                                kMaxThreads,
+                                256,
                                 0,
                                 at::cuda::getCurrentCUDAStream(),
                                 PTA_B(hash_size_offsets, index_t, 1, 32),
-                                PTA_B(reverse_index, index_t, 1, 32),
-                                PTA_B(offsets, index_t, 1, 32),
-                                PTA_B(output_lengths, index_t, 1, 32));
+                                PTA_B(hash_size_cumsum, index_t, 1, 32),
+                                PTA_B(linear_unique_indices, index_t, 1, 32),
+                                PTA_B(output_lengths, index_t, 1, 32),
+                                static_cast<int32_t>(total_B / T));
                           }));
 
-  Tensor output_offsets;
-  output_offsets = asynchronous_complete_cumsum_gpu(output_lengths);
+  Tensor output_offsets = asynchronous_complete_cumsum_gpu(output_lengths);
   return {output_lengths, output_offsets, unique_indices, reverse_index};
 }
 

--- a/fbgemm_gpu/test/jagged/failures_dict.json
+++ b/fbgemm_gpu/test/jagged/failures_dict.json
@@ -107,6 +107,10 @@
         "comment": "",
         "status": "xfail"
       },
+      "UniqueIndicesTest.test_aot_dispatch_dynamic__test_jagged_unique_indices_randomized_differential": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with dynamic dispatch.",
+        "status": "xfail"
+      },
       "UniqueIndicesTest.test_faketensor__test_jagged_unique_indices": {
         "comment": "",
         "status": "xfail"
@@ -117,6 +121,10 @@
       },
       "UniqueIndicesTest.test_faketensor__test_jagged_unique_indices_multi_keys": {
         "comment": "",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_faketensor__test_jagged_unique_indices_randomized_differential": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with fake tensors.",
         "status": "xfail"
       }
     },

--- a/fbgemm_gpu/test/jagged/unique_indices_test.py
+++ b/fbgemm_gpu/test/jagged/unique_indices_test.py
@@ -269,6 +269,123 @@ class UniqueIndicesTest(unittest.TestCase):
         self.assertEqual(torch.sum(output_lengths).item(), 0)
         self.assertEqual(torch.sum(output_offsets).item(), 0)
 
+    @unittest.skipIf(*gpu_unavailable)
+    @given(
+        B=st.integers(min_value=32, max_value=128),
+        F=st.integers(min_value=2, max_value=32),
+        max_length=st.integers(min_value=2, max_value=12),
+        # Drives both int32-path (small) and int64-path (large) branches.
+        # hash_size_bits <= 30 keeps int32 path when F*hash_size < INT32_MAX;
+        # larger values exercise the int64 path.
+        per_feature_hash_bits=st.integers(min_value=3, max_value=30),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    def test_jagged_unique_indices_randomized_differential(
+        self,
+        B: int,
+        F: int,
+        max_length: int,
+        per_feature_hash_bits: int,
+    ) -> None:
+        """Differential test against torch.unique(linear_indices,
+        return_inverse=True).
+
+        Checks that the op's (output_lengths, output_offsets, unique_indices
+        sorted, and the set of (input_idx, reverse_idx) pairs) match the
+        reference derived from torch.unique on the equivalent linearized
+        indices. Covers both int32-key and int64-key pipelines via
+        per_feature_hash_bits sweep.
+        """
+        # Build per-feature hash sizes. Use a non-uniform schedule so that
+        # hash_size_cumsum[T] spans both small and large ranges.
+        per_feature_hash = 1 << per_feature_hash_bits
+        hash_size_list = [per_feature_hash] * F
+        # Randomize each feature's length per sample.
+        lengths_list: list[int] = []
+        indices_list: list[int] = []
+        for t in range(F):
+            hs = hash_size_list[t]
+            for _ in range(B):
+                L = random.randint(0, max_length)
+                lengths_list.append(L)
+                if L > 0:
+                    indices_list.extend(np.random.randint(0, hs, size=L).tolist())
+
+        device = torch.device("cuda")
+        dtype = torch.int64
+        hash_size = torch.as_tensor(hash_size_list, dtype=dtype, device=device)
+        lengths = torch.as_tensor(lengths_list, dtype=dtype, device=device)
+        indices = torch.as_tensor(indices_list, dtype=dtype, device=device)
+
+        hash_size_cum_sum = torch.zeros(F + 1, dtype=dtype, device=device)
+        hash_size_cum_sum[1:] = torch.cumsum(hash_size, dim=0)
+        offsets = torch.zeros(F * B + 1, dtype=dtype, device=device)
+        offsets[1:] = torch.cumsum(lengths, dim=0)
+        hash_size_offsets_list = hash_size_cumsum_to_offsets(hash_size_cum_sum.tolist())
+        hash_size_offsets = torch.as_tensor(
+            hash_size_offsets_list, dtype=dtype, device=device
+        )
+
+        (
+            output_lengths,
+            output_offsets,
+            unique_indices,
+            reverse_index,
+        ) = torch.ops.fbgemm.jagged_unique_indices(
+            hash_size_cum_sum, hash_size_offsets, offsets, indices
+        )
+
+        # Compute reference via torch.unique on the host-linearized indices.
+        linear_indices_list: list[int] = []
+        for t in range(F):
+            hs_off = int(hash_size_cum_sum[t].item())
+            start = int(offsets[t * B].item())
+            end = int(offsets[(t + 1) * B].item())
+            for pos in range(start, end):
+                linear_indices_list.append(int(indices[pos].item()) + hs_off)
+
+        # Cardinality check.
+        if len(linear_indices_list) == 0:
+            self.assertEqual(unique_indices.numel(), 0)
+            self.assertEqual(reverse_index.numel(), 0)
+            return
+
+        linear_indices_tensor = torch.as_tensor(
+            linear_indices_list, dtype=dtype, device=device
+        )
+        ref_unique, ref_inverse = torch.unique(
+            linear_indices_tensor, sorted=True, return_inverse=True
+        )
+        self.assertEqual(unique_indices.numel(), ref_unique.numel())
+
+        # Check the (input_index, reverse_index) mapping: for each input
+        # position i, unique_indices[reverse_index[i]] must equal indices[i].
+        rev_list = reverse_index.tolist()
+        uniq_list = unique_indices.tolist()
+        idx_list = indices.tolist()
+        self.assertEqual(len(rev_list), len(idx_list))
+        for i, rev in enumerate(rev_list):
+            self.assertTrue(0 <= rev < len(uniq_list))
+            self.assertEqual(uniq_list[rev], idx_list[i])
+
+        # Check output_lengths: sum should equal num unique.
+        self.assertEqual(int(torch.sum(output_lengths).item()), unique_indices.numel())
+        # Each feature slice of unique_indices must lie within its hash
+        # range [0, hash_size[t]).
+        output_offsets_list = output_offsets.tolist()
+        for t in range(F):
+            lo = output_offsets_list[t * B]
+            hi = (
+                output_offsets_list[(t + 1) * B]
+                if t + 1 < F
+                else (
+                    output_offsets_list[t * B]
+                    + int(torch.sum(output_lengths[t * B : (t + 1) * B]).item())
+                )
+            )
+            for u in uniq_list[lo:hi]:
+                self.assertTrue(0 <= u < hash_size_list[t])
+
     @given(
         num_elements=st.integers(min_value=100, max_value=10000),
         num_unique_indices=st.integers(min_value=5, max_value=100),


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2651

Set of optimizations to fbgemm::jagged_unique_indices on H100, bundled
into a single diff.

Changes:

1) Rewrite unique_indices_length_kernel with binary search.
   - Add device_lower_bound helper.
   - Replace the O(N) BlockReduce-based min/max scan over reverse_index
     with two O(log U) binary searches on the sorted unique_indices
     (leveraging the invariant that entries of feature t occupy a
     contiguous slice of the sorted unique linearized values).
   - Block size 1024 -> 256 (no reduction; just output writes).
   - Launch site now takes hash_size_cumsum + linear_unique_indices and
     drops reverse_index + offsets + max/min template args.
   - Removes the ~800 MB reverse_index scan entirely.

2) Replace linearize_index_wo_infos_kernel with
   linearize_index_flat_kernel.
   - Grid = total_B (one block per (t, b) sample) instead of
     ⌈total_B / kMaxThreads⌉ (which launched only ~5 blocks on the prod
     shape, leaving ~96% of SMs idle).
   - Templated on key_t so it writes linearized values directly in int32
     or int64, avoiding a later cast pass.

3) Replace at::_unique with a custom cub pipeline.
   - cub::DeviceRadixSort::SortPairs with end_bit trimmed to
     ceil(log2(total_hash_size + 1) + 1). Uses int32 keys when
     total_hash_size < INT32_MAX (near-always in practice), cutting
     sort-kernel work substantially.
   - cub::DeviceRunLengthEncode::Encode to extract sorted unique keys.
   - Inverse-index construction via jagged_unique_adjacent_diff_kernel
     + cub::DeviceScan::InclusiveSum + jagged_unique_scatter_kernel,
     mirroring pytorch's UniqueCub.cu.
   - Dispatch between int32- and int64-key paths based on
     total_hash_size (one D->H sync, net-neutral vs at::_unique's own
     implicit sync).

4) Replace delinearize_unique_index_kernel with
   delinearize_unique_from_sorted_kernel.
   - Iterates over num_unique (~millions) instead of total_indices
     (~tens of millions). Each thread recovers its feature via binary
     search over hash_size_cumsum — no 24M-element scatter.

5) Added a randomized differential test in unique_indices_test.py that
   compares the op output against torch.unique(linear_indices,
   return_inverse=True) on randomized (T, B, avg_len, hash_size) inputs
   and exercises both the int32- and int64-key paths via a
   per_feature_hash_bits hypothesis sweep. Registered the expected
   test_faketensor__* / test_aot_dispatch_dynamic__* xfails in
   failures_dict.json (the new test uses .item()/.tolist() for
   host-side comparison, matching the pattern of the pre-existing tests
   in this class).

Public contract preserved: op still returns
(output_lengths, output_offsets, unique_indices, reverse_index) with
the same dtypes; reverse_index remains int64 to match at::_unique's
historical behavior. unique_indices_length_kernel works unchanged; the
pipeline exposes linear_unique_indices as index_t for it (cast from
int32 when needed).

Reviewed By: q10

Differential Revision: D103207899


