### PR TITLE
Fix Hypothesis differing_executors health check failure in index select

### DIFF
--- a/fbgemm_gpu/test/sparse/common.py
+++ b/fbgemm_gpu/test/sparse/common.py
@@ -32,6 +32,11 @@ suppressed_list: list[HealthCheck] = (
     else []
 )
 
+settings.register_profile(
+    "suppress_differing_executors_check", suppress_health_check=suppressed_list
+)
+settings.load_profile("suppress_differing_executors_check")
+
 
 @settings(suppress_health_check=suppressed_list)
 def permute_indices_ref_(

--- a/fbgemm_gpu/test/sparse/index_select_test.py
+++ b/fbgemm_gpu/test/sparse/index_select_test.py
@@ -288,7 +288,11 @@ class IndexSelectTest(unittest.TestCase):
             ]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=20, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=20,
+        deadline=None,
+    )
     def test_batch_index_select_dim0(  # noqa: C901
         self,
         num_inputs: int,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2654

The optest framework generates multiple test variants (test_schema, test_autograd_registration, test_faketensor, test_aot_dispatch_dynamic) that all call the same Hypothesis-decorated test_batch_index_select_dim0 method. Hypothesis detects this as differing executors sharing a database key, which can cause flaky example replays. Suppress this specific health check since the multiple-executor pattern is intentional and the root cause is in PyTorch's optest framework, not fixable from FBGEMM side.

Differential Revision: D103267454


