### PR TITLE
Add SVE-FP16 version of EmbeddingSpMDMNbit (#5728)

### DIFF
--- a/bench/EmbeddingSpMDMNBitFp16Benchmark.cc
+++ b/bench/EmbeddingSpMDMNBitFp16Benchmark.cc
@@ -1,0 +1,387 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Benchmark for NBit embedding with fp16 output.
+// Compares SVE FP16 register path (via GenerateEmbeddingSpMDMNBitWithStrides)
+// against autovec baseline.
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <vector>
+
+#include "./BenchUtils.h"
+#include "fbgemm/Fbgemm.h"
+#include "fbgemm/FbgemmConvert.h"
+#include "src/EmbeddingSpMDMAutovec.h"
+
+using namespace std;
+using namespace fbgemm;
+
+static vector<vector<int>> GetInputs_() {
+  vector<vector<int>> input_dims = {
+      // batch size, number of rows of table, emb dim, avg length
+      {10, 4000000, 4, 100},
+      {10, 4000000, 7, 100},
+      {10, 4000000, 32, 100},
+      {10, 4000000, 33, 100},
+      {10, 4000000, 48, 100},
+      {10, 4000000, 56, 100},
+      {10, 4000000, 64, 100},
+      {10, 4000000, 65, 100},
+      {10, 4000000, 80, 100},
+      {10, 4000000, 96, 100},
+      {10, 4000000, 104, 100},
+      {10, 4000000, 128, 100},
+      {10, 4000000, 143, 100},
+      {10, 4000000, 192, 100},
+      {10, 4000000, 256, 100},
+      {10, 4000000, 263, 100},
+      {10, 4000000, 512, 100},
+      {10, 4000000, 1024, 100}};
+  return input_dims;
+}
+
+static int run_benchmark(
+    int bit_rate,
+    int batch_size,
+    int num_rows,
+    int embedding_dim,
+    int average_len,
+    bool normalize_by_lengths,
+    bool use_32_bit_indices = false,
+    bool prefetch = false) {
+  int num_elem_per_byte = 8 / bit_rate;
+  int fused_embedding_dim =
+      (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte +
+      2 * sizeof(float16);
+  default_random_engine generator;
+  normal_distribution<float> embedding_distribution;
+
+  vector<uint8_t> fused_embedding_table(
+      static_cast<size_t>(num_rows) * fused_embedding_dim);
+  for (int i = 0; i < num_rows; i++) {
+    for (int ii = 0;
+         ii < (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte;
+         ii++) {
+      fused_embedding_table[static_cast<size_t>(i) * fused_embedding_dim + ii] =
+          2;
+    }
+    float16* scale_bias = reinterpret_cast<float16*>(
+        &fused_embedding_table[static_cast<size_t>(i) * fused_embedding_dim] +
+        (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte);
+    float scale = 2.0f;
+    float bias = 1.0f;
+    FloatToFloat16_ref(&scale, scale_bias, 1, true);
+    FloatToFloat16_ref(&bias, scale_bias + 1, 1, true);
+  }
+
+  uniform_int_distribution<int> length_distribution(
+      1, std::min(2 * average_len + 1, num_rows));
+  vector<int> offsets(batch_size + 1);
+  offsets[0] = 0;
+  for (int i = 0; i < batch_size; ++i) {
+    offsets[i + 1] = offsets[i] + length_distribution(generator);
+  }
+  int lengths_sum = offsets[batch_size];
+  cout << "lengths_sum " << lengths_sum << '\n';
+
+  vector<int64_t> indices;
+  vector<int32_t> indices_32;
+  vector<int> container(num_rows);
+  for (int i = 0; i < batch_size; ++i) {
+    iota(container.begin(), container.end(), 0);
+    shuffle(container.begin(), container.end(), generator);
+    copy(
+        container.begin(),
+        container.begin() + (offsets[i + 1] - offsets[i]),
+        back_inserter(indices));
+  }
+  copy(begin(indices), end(indices), back_inserter(indices_32));
+
+  vector<float> weights(lengths_sum);
+  for (int i = 0; i < lengths_sum; ++i) {
+    weights[i] = embedding_distribution(generator);
+  }
+
+  using OutType = float16;
+  vector<OutType> output_ref(static_cast<size_t>(batch_size) * embedding_dim);
+  vector<OutType> output(output_ref.size());
+  vector<OutType> output_autovec(output_ref.size());
+
+  constexpr int NUM_WARMUP = 10;
+  constexpr int NUM_ITER = 100;
+  double bytes = static_cast<double>(lengths_sum) *
+          (fused_embedding_dim + (use_32_bit_indices ? 4 : 8)) +
+      batch_size * sizeof(int);
+  constexpr int CACHE_LINE_LEN = 64;
+  double bytes_padded = static_cast<double>(lengths_sum) *
+          (CACHE_LINE_LEN *
+               static_cast<int64_t>(
+                   (fused_embedding_dim + CACHE_LINE_LEN - 1) /
+                   CACHE_LINE_LEN) +
+           (use_32_bit_indices ? 4 : 8)) +
+      batch_size * sizeof(int);
+
+  for (bool has_weight : {false, true}) {
+    // Main kernel via GenerateEmbeddingSpMDMNBitWithStrides (includes SVE FP16
+    // dispatch when FBGEMM_SVE_FP16=1)
+    auto kernel_32 = GenerateEmbeddingSpMDMNBitWithStrides<
+        /*IndexType=*/int32_t,
+        /*OffsetType=*/int32_t,
+        /*OutType=*/OutType>(
+        bit_rate,
+        embedding_dim,
+        has_weight,
+        normalize_by_lengths,
+        prefetch ? 16 : 0,
+        /*is_weight_positional=*/false,
+        /*use_offsets=*/true,
+        /*output_stride=*/-1,
+        /*input_stride=*/-1,
+        /*scale_bias_last=*/true,
+        /*is_bf16_out=*/false);
+    auto kernel_64 = GenerateEmbeddingSpMDMNBitWithStrides<
+        /*IndexType=*/int64_t,
+        /*OffsetType=*/int32_t,
+        /*OutType=*/OutType>(
+        bit_rate,
+        embedding_dim,
+        has_weight,
+        normalize_by_lengths,
+        prefetch ? 16 : 0,
+        /*is_weight_positional=*/false,
+        /*use_offsets=*/true,
+        /*output_stride=*/-1,
+        /*input_stride=*/-1,
+        /*scale_bias_last=*/true,
+        /*is_bf16_out=*/false);
+
+#ifdef FBGEMM_AUTOVEC_AVAILABLE
+    auto kernel_32_autovec = GenerateEmbeddingSpMDMNBitWithStrides_autovec<
+        /*IndexType=*/int32_t,
+        /*OffsetType=*/int32_t,
+        /*OutType=*/OutType>(
+        bit_rate,
+        embedding_dim,
+        has_weight,
+        normalize_by_lengths,
+        prefetch ? 16 : 0,
+        /*is_weight_positional=*/false,
+        /*use_offsets=*/true,
+        /*output_stride=*/-1,
+        /*input_stride=*/-1,
+        /*scale_bias_last=*/true,
+        /*is_bf16_out=*/false,
+        /*no_bag=*/false,
+        /*output_bit_rate=*/-1);
+    auto kernel_64_autovec = GenerateEmbeddingSpMDMNBitWithStrides_autovec<
+        /*IndexType=*/int64_t,
+        /*OffsetType=*/int32_t,
+        /*OutType=*/OutType>(
+        bit_rate,
+        embedding_dim,
+        has_weight,
+        normalize_by_lengths,
+        prefetch ? 16 : 0,
+        /*is_weight_positional=*/false,
+        /*use_offsets=*/true,
+        /*output_stride=*/-1,
+        /*input_stride=*/-1,
+        /*scale_bias_last=*/true,
+        /*is_bf16_out=*/false,
+        /*no_bag=*/false,
+        /*output_bit_rate=*/-1);
+#endif
+
+    for (bool flush_cache : {false, true}) {
+      // Main kernel
+      double t = measureWithWarmup(
+          [&]() {
+            if (use_32_bit_indices) {
+              kernel_32(
+                  batch_size,
+                  lengths_sum,
+                  num_rows,
+                  fused_embedding_table.data(),
+                  indices_32.data(),
+                  offsets.data(),
+                  has_weight ? weights.data() : nullptr,
+                  output.data());
+            } else {
+              kernel_64(
+                  batch_size,
+                  lengths_sum,
+                  num_rows,
+                  fused_embedding_table.data(),
+                  indices.data(),
+                  offsets.data(),
+                  has_weight ? weights.data() : nullptr,
+                  output.data());
+            }
+          },
+          NUM_WARMUP,
+          NUM_ITER,
+          [&]() {
+            if (flush_cache) {
+              cache_evict(fused_embedding_table);
+              cache_evict(indices);
+              cache_evict(indices_32);
+              cache_evict(offsets);
+              cache_evict(weights);
+              cache_evict(output);
+            }
+          });
+
+#ifdef FBGEMM_AUTOVEC_AVAILABLE
+      // Autovec kernel
+      double t_autovec = measureWithWarmup(
+          [&]() {
+            if (use_32_bit_indices) {
+              kernel_32_autovec(
+                  batch_size,
+                  lengths_sum,
+                  num_rows,
+                  fused_embedding_table.data(),
+                  indices_32.data(),
+                  offsets.data(),
+                  has_weight ? weights.data() : nullptr,
+                  output_autovec.data());
+            } else {
+              kernel_64_autovec(
+                  batch_size,
+                  lengths_sum,
+                  num_rows,
+                  fused_embedding_table.data(),
+                  indices.data(),
+                  offsets.data(),
+                  has_weight ? weights.data() : nullptr,
+                  output_autovec.data());
+            }
+          },
+          NUM_WARMUP,
+          NUM_ITER,
+          [&]() {
+            if (flush_cache) {
+              cache_evict(fused_embedding_table);
+              cache_evict(indices);
+              cache_evict(indices_32);
+              cache_evict(offsets);
+              cache_evict(weights);
+              cache_evict(output_autovec);
+            }
+          });
+#endif
+
+      // Output
+      cout << "out type fp16, ";
+      if (has_weight) {
+        cout << "SLW(WEIGHTED), ";
+      } else {
+        cout << "SLS, ";
+      }
+      if (normalize_by_lengths) {
+        cout << "normalize, ";
+      }
+      if (flush_cache) {
+        cout << "cache flushed, ";
+      } else {
+        cout << "cache not flushed, ";
+      }
+      if (prefetch) {
+        cout << "prefetch on, ";
+      } else {
+        cout << "prefetch off, ";
+      }
+
+      cout << "b/w, " << bytes / 1e9 / t << ", GB/s, "
+           << "effective b/w, " << bytes_padded / 1e9 / t << ", GB/s, "
+           << "time, " << t;
+#ifdef FBGEMM_AUTOVEC_AVAILABLE
+      cout << ", autovec b/w, " << bytes / 1e9 / t_autovec << ", GB/s, "
+           << "autovec eff. b/w, " << bytes_padded / 1e9 / t_autovec
+           << ", GB/s, "
+           << "autovec time, " << t_autovec << ", speedup vs autovec, "
+           << t_autovec / t;
+#endif
+      cout << '\n';
+      cout.flush();
+    } // flush_cache
+  } // has_weight
+  return 0;
+}
+
+int main() {
+  vector<vector<int>> inputs(GetInputs_());
+
+  for (int bit_rate : {4, 2}) {
+    for (auto& input : inputs) {
+      assert(input.size() > 3);
+      int batch_size = input[0];
+      int num_rows = input[1];
+      int embedding_dim = input[2];
+      int average_len = input[3];
+
+      cout << "bit_rate, " << bit_rate << ", batch size, " << batch_size
+           << ", num rows, " << num_rows << ", emb dim, " << embedding_dim
+           << ", avg length, " << average_len << '\n';
+
+      for (bool normalize : {false, true}) {
+        // 64-bit indices, no prefetch
+        cout << "64 bit indices, ";
+        run_benchmark(
+            bit_rate,
+            batch_size,
+            num_rows,
+            embedding_dim,
+            average_len,
+            normalize);
+
+        // 64-bit indices, with prefetch
+        cout << "64 bit indices with prefetching, ";
+        run_benchmark(
+            bit_rate,
+            batch_size,
+            num_rows,
+            embedding_dim,
+            average_len,
+            normalize,
+            /*use_32_bit_indices=*/false,
+            /*prefetch=*/true);
+
+        // 32-bit indices, no prefetch
+        cout << "32 bit indices, ";
+        run_benchmark(
+            bit_rate,
+            batch_size,
+            num_rows,
+            embedding_dim,
+            average_len,
+            normalize,
+            /*use_32_bit_indices=*/true,
+            /*prefetch=*/false);
+
+        // 32-bit indices, with prefetch
+        cout << "32 bit indices with prefetching, ";
+        run_benchmark(
+            bit_rate,
+            batch_size,
+            num_rows,
+            embedding_dim,
+            average_len,
+            normalize,
+            /*use_32_bit_indices=*/true,
+            /*prefetch=*/true);
+      }
+    }
+  }
+  return 0;
+}

--- a/src/EmbeddingSpMDMNBit.cc
+++ b/src/EmbeddingSpMDMNBit.cc
@@ -17,6 +17,7 @@
 #include <tuple>
 #include "./CodeCache.h" // @manual
 #include "./EmbeddingSpMDMAutovec.h" // @manual
+#include "./EmbeddingSpMDMSve.h" // @manual
 #include "./MaskAvx2.h" // @manual
 #include "./RefImplementations.h" // @manual
 #include "fbgemm/SimdUtils.h"
@@ -1102,6 +1103,74 @@ typename EmbeddingSpMDMKernelSignature<uint8_t, indxType, offsetType, outType>::
     }
   }
 #endif // CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
+
+#if HAVE_SVE
+  if constexpr (std::is_same_v<outType, uint16_t>) {
+    // FP16 accumulation (eps ~= 9.77e-4) trades precision for
+    // throughput: ~0.5-1% relative error vs FP32 at typical bag
+    // sizes (L=100), worst-case O(L * eps_fp16) ~= 10%.
+    if (is_sve_fp16_enabled() && !is_bf16_out) {
+      return [=](int64_t output_size,
+                 int64_t index_size,
+                 int64_t data_size,
+                 const uint8_t* input,
+                 const indxType* indices,
+                 const offsetType* offsets_or_lengths,
+                 const float* weights,
+                 outType* out) {
+        if (no_bag) {
+          return internal::EmbeddingSpMDMNBit_Sve_Fp16<
+              indxType,
+              offsetType,
+              outType,
+              true,
+              true>(
+              input_bit_rate,
+              block_size,
+              output_size,
+              index_size,
+              data_size,
+              input,
+              indices,
+              offsets_or_lengths,
+              weights,
+              normalize_by_lengths,
+              out,
+              is_weight_positional,
+              use_offsets,
+              output_stride,
+              input_stride,
+              scale_bias_last,
+              is_bf16_out);
+        }
+        return internal::EmbeddingSpMDMNBit_Sve_Fp16<
+            indxType,
+            offsetType,
+            outType,
+            false,
+            true>(
+            input_bit_rate,
+            block_size,
+            output_size,
+            index_size,
+            data_size,
+            input,
+            indices,
+            offsets_or_lengths,
+            weights,
+            normalize_by_lengths,
+            out,
+            is_weight_positional,
+            use_offsets,
+            output_stride,
+            input_stride,
+            scale_bias_last,
+            is_bf16_out);
+      };
+    }
+  }
+
+#endif
 
 #ifdef FBGEMM_AUTOVEC_AVAILABLE
   if (!cpuinfo_initialize()) {

--- a/src/EmbeddingSpMDMSve.h
+++ b/src/EmbeddingSpMDMSve.h
@@ -708,19 +708,23 @@ static inline void sve_fma_round_fp16(
   }
 }
 
+// Loads per-row scale and bias as fp16. Two source formats:
+//   fp32_scale_bias=true  (8-bit): reads fp32 at row_base+offset, narrows
+//   fp32_scale_bias=false (NBit):  reads fp16 at row_base+offset directly
 static inline void load_scale_bias_fp16(
     const uint8_t* row_base,
     int64_t scale_bias_offset,
-    bool scale_bias_last,
+    bool fp32_scale_bias,
     float16_t& scale,
     float16_t& bias) {
-  if (scale_bias_last) {
+  if (fp32_scale_bias) {
     const float* sb =
         reinterpret_cast<const float*>(row_base + scale_bias_offset);
     scale = static_cast<float16_t>(sb[0]);
     bias = static_cast<float16_t>(sb[1]);
   } else {
-    const float16_t* sb = reinterpret_cast<const float16_t*>(row_base);
+    const float16_t* sb =
+        reinterpret_cast<const float16_t*>(row_base + scale_bias_offset);
     scale = sb[0];
     bias = sb[1];
   }
@@ -1558,6 +1562,973 @@ bool EmbeddingSpMDM8Bit_Sve_Fp16(
               svmul_f16_x(lastPredBH, t1, svset_neonq_f16(svundef_f16(), norm));
           svst1_f16(lastPredAH, bp, t0);
           svst1_f16(lastPredBH, bp + 8, t1);
+        }
+      }
+    } else {
+      memset(out, 0, sizeof(OutType) * block_size);
+    }
+  }
+  return current == index_size;
+}
+
+// Unpack 4-bit packed values (4 bytes -> 8 elements) to float16x8_t.
+// Uses SVE zip to split lo/hi nibbles and interleave into sequential order.
+// svld1ub_u16 loads 4 bytes (with predicate limiting to 4 active lanes),
+// widening each byte to u16. AND extracts low nibbles, LSR extracts high
+// nibbles, then svzip1 interleaves [lo0,hi0,lo1,hi1] into correct element
+// order.
+static inline float16x8_t unpack_4bit_to_fp16_neon(const uint8_t* ptr) {
+  const svbool_t pg4 = svwhilelt_b16_u64(0, 4);
+  svuint16_t raw = svld1ub_u16(pg4, ptr);
+  svuint16_t lo = svand_u16_x(pg4, raw, svdup_n_u16(0x0f));
+  svuint16_t hi = svlsr_n_u16_x(pg4, raw, 4);
+  // zip interleaves: [lo0,hi0,lo1,hi1,lo2,hi2,lo3,hi3] = 8 elements
+  svuint16_t zipped = svzip1_u16(lo, hi);
+  return svget_neonq(svcvt_f16_u16_x(svptrue_b16(), zipped));
+}
+
+// Unpack 2-bit packed values (2 bytes -> 8 elements) to float16x8_t using NEON
+static inline float16x8_t unpack_2bit_to_fp16_neon(const uint8_t* ptr) {
+  uint16_t tmp;
+  memcpy(&tmp, ptr, sizeof(tmp));
+  uint8x8_t raw = vreinterpret_u8_u16(vdup_n_u16(tmp));
+  // raw = [b0, b1, b0, b1, b0, b1, b0, b1]
+
+  // Replicate: [b0, b0, b0, b0, b1, b1, b1, b1]
+  static const uint8_t tbl_idx[8] = {0, 0, 0, 0, 1, 1, 1, 1};
+  uint8x8_t replicated = vtbl1_u8(raw, vld1_u8(tbl_idx));
+
+  // Shift each position to place the target 2-bit field in the low 2 bits
+  static const int8_t shifts[8] = {0, -2, -4, -6, 0, -2, -4, -6};
+  uint8x8_t shifted = vshl_u8(replicated, vld1_s8(shifts));
+
+  uint8x8_t masked = vand_u8(shifted, vdup_n_u8(0x03));
+  return vcvtq_f16_u16(vmovl_u8(masked));
+}
+
+template <
+    typename IndexType,
+    typename OffsetType,
+    typename OutType,
+    bool NoBag,
+    bool EnablePrefetching>
+bool EmbeddingSpMDMNBit_Sve_Fp16(
+    int bit_rate,
+    const int64_t block_size,
+    const int64_t output_size,
+    const int64_t index_size,
+    const int64_t data_size,
+    const uint8_t* input,
+    const IndexType* indices,
+    const OffsetType* offsets_or_lengths,
+    const float* weights,
+    const bool normalize_by_lengths,
+    OutType* out,
+    const bool is_weight_positional,
+    const bool use_offsets,
+    const int64_t output_stride,
+    const int64_t input_stride,
+    const bool scale_bias_last,
+    const bool /*is_bf16_out*/) {
+  // This kernel is only dispatched for fp16 output (OutType == uint16_t
+  // && !is_bf16_out). All paths produce fp16 directly — no fp32 widening.
+  if constexpr (!std::is_same_v<OutType, uint16_t>) {
+    return false;
+  }
+
+  if (data_size < 0 || block_size <= 0) {
+    return false;
+  }
+
+  // This kernel uses NEON fp16 intrinsics (128-bit fixed-width).
+  // Fall back to the baseline SVE kernel on wider SVE implementations.
+  if (svcnth() != 8) {
+    return false;
+  }
+
+  constexpr int64_t CACHE_LINE_SIZE = 64;
+  constexpr int64_t MAX_INITIAL_PREFETCH_ROWS = 16;
+  const int64_t prefetch_stride =
+      std::min(MAX_INITIAL_PREFETCH_ROWS, index_size);
+
+  if constexpr (EnablePrefetching) {
+    for (int64_t pf_idx = 0; pf_idx < prefetch_stride; ++pf_idx) {
+      const IndexType idx = indices[pf_idx];
+      if (idx < 0 || idx >= data_size) {
+        continue;
+      }
+      const uint8_t* prefetch_addr = input + input_stride * idx;
+      for (int64_t offset = 0; offset < input_stride;
+           offset += CACHE_LINE_SIZE) {
+        do_prefetch(prefetch_addr + offset, 0, 0);
+      }
+    }
+  }
+
+  const int num_elem_per_byte = 8 / bit_rate;
+  constexpr int64_t scale_bias_fp16_size =
+      2 * sizeof(float16_t); // only used when scale and bias is at the
+                             // beginning, in which case, they are fp16
+  const int64_t scale_bias_offset = scale_bias_last
+      ? ((block_size + num_elem_per_byte - 1) / num_elem_per_byte)
+      : 0;
+  const int64_t input_offset = scale_bias_last ? 0 : scale_bias_fp16_size;
+
+  // process 8 element at a time (processes one float16x8_t per iteration)
+  uint64_t iters = ((uint64_t)std::max<int64_t>(block_size, 0)) / 8ull;
+  uint64_t block_size_mod = block_size % 8;
+  // mask for procesing the remainning elements
+  svbool_t lastPred16 = svwhilelt_b16_u64(0, block_size_mod);
+
+  const int bytes_per_8elem = (bit_rate == 4) ? 4 : 2;
+  const int tail_packed_bytes =
+      (bit_rate == 4) ? (block_size_mod + 1) / 2 : (block_size_mod + 3) / 4;
+
+  if constexpr (NoBag) {
+    for (int64_t m = 0; m < output_size; ++m) {
+      const IndexType idx = indices[m];
+
+      if (idx < 0 || idx >= data_size) {
+        return false;
+      }
+
+      const uint8_t* input_row_base = input + input_stride * idx;
+      float16_t scale_val, bias_val;
+      load_scale_bias_fp16(
+          input_row_base, scale_bias_offset, false, scale_val, bias_val);
+      if (weights) {
+        float16_t w = static_cast<float16_t>(weights[m]);
+        scale_val *= w;
+        bias_val *= w;
+      }
+
+      const float16x8_t scale_neon = vdupq_n_f16(scale_val);
+      const float16x8_t bias_neon = vdupq_n_f16(bias_val);
+      const uint8_t* input_row = input_row_base + input_offset;
+      float16_t* outPtr = reinterpret_cast<float16_t*>(out);
+
+      for (uint64_t i = 0; i < iters; ++i) {
+        const float16x8_t in_f16 = (bit_rate == 4)
+            ? unpack_4bit_to_fp16_neon(input_row + i * bytes_per_8elem)
+            : unpack_2bit_to_fp16_neon(input_row + i * bytes_per_8elem);
+        vst1q_f16(outPtr, vfmaq_f16(bias_neon, in_f16, scale_neon));
+        outPtr += 8;
+      }
+
+      if (block_size_mod > 0) {
+        alignas(4) uint8_t tail_buf[4] = {0};
+        memcpy(
+            tail_buf, input_row + iters * bytes_per_8elem, tail_packed_bytes);
+        float16x8_t v = (bit_rate == 4) ? unpack_4bit_to_fp16_neon(tail_buf)
+                                        : unpack_2bit_to_fp16_neon(tail_buf);
+        svfloat16_t in_v_f = svset_neonq_f16(svundef_f16(), v);
+        svfloat16_t scale_sv = svdup_n_f16(scale_val);
+        svfloat16_t bias_sv = svdup_n_f16(bias_val);
+        in_v_f = svmad_f16_m(lastPred16, in_v_f, scale_sv, bias_sv);
+        svst1_f16(lastPred16, outPtr, in_v_f);
+      }
+
+      out += output_stride;
+    }
+    EmbeddingStatsTracker::getInstance().recordPattern(
+        data_size,
+        block_size,
+        bit_rate == 4 ? EmbeddingStatsTracker::DataType::INT4
+                      : EmbeddingStatsTracker::DataType::INT2,
+        EmbeddingStatsTracker::DataType::FP16,
+        output_size,
+        1);
+    return true;
+  } // NoBag
+
+  // Accumulate in NEON fp16 registers, store fp16 directly.
+
+  if (iters >= 1 && iters <= 32) {
+    int64_t current = 0;
+    const float* weights_addr = weights;
+    int64_t remaining_outputs = output_size;
+
+    auto unpack_tail_nbit = [&](const uint8_t* row) -> svfloat16_t {
+      alignas(4) uint8_t buf[4] = {0};
+      memcpy(buf, row + iters * bytes_per_8elem, tail_packed_bytes);
+      float16x8_t v = (bit_rate == 4) ? unpack_4bit_to_fp16_neon(buf)
+                                      : unpack_2bit_to_fp16_neon(buf);
+      return svset_neonq_f16(svundef_f16(), v);
+    };
+
+    auto process_row = [&]<uint64_t ITERS>() -> bool {
+      // each tile uses at most 16 float16x8_t accumulators -> 16 Q-regs
+      constexpr uint64_t CHUNK = 16;
+      constexpr uint64_t NUM_TILES = (ITERS + CHUNK - 1) / CHUNK;
+      float16x8_t acc[ITERS <= CHUNK ? ITERS : CHUNK];
+      float16x8_t acc_b[ITERS <= 8 ? ITERS : 1];
+      float16x8_t acc_tail = vdupq_n_f16(0.0f);
+      float16x8_t acc_b_tail = vdupq_n_f16(0.0f);
+
+      const OffsetType raw_len = use_offsets
+          ? offsets_or_lengths[1] - offsets_or_lengths[0]
+          : offsets_or_lengths[0];
+      const int64_t end = current + raw_len;
+      if (end > index_size) {
+        return false;
+      }
+      EmbeddingStatsTracker::getInstance().recordPattern(
+          data_size,
+          block_size,
+          bit_rate == 4 ? EmbeddingStatsTracker::DataType::INT4
+                        : EmbeddingStatsTracker::DataType::INT2,
+          EmbeddingStatsTracker::DataType::FP16,
+          output_size,
+          raw_len);
+
+      const int64_t len =
+          normalize_by_lengths ? static_cast<int64_t>(raw_len) : 0;
+      if (is_weight_positional) {
+        weights_addr = weights;
+      }
+
+      bool oneIterationDone = false;
+
+      // ---- Tiled path for ITERS > 16 (e.g. dim=256) ----
+      // Each embedding row is loaded once; acc state spills to the output
+      // buffer between tiles (L1-hot) instead of re-reading rows from DRAM.
+      if constexpr (ITERS > 16) {
+        const float16x8_t norm_fp16 = vdupq_n_f16(
+            len > 0 ? (float16_t)(1.0f / static_cast<float>(len))
+                    : (float16_t)1.0f);
+        const bool do_normalize = (len > 0);
+
+        memset(out, 0, sizeof(OutType) * block_size);
+
+        for (; current < end; ++current) {
+          const IndexType idx = indices[current];
+
+          if constexpr (EnablePrefetching) {
+            const IndexType pidx =
+                indices[std::min(current + prefetch_stride, index_size - 1)];
+            if (pidx >= 0 && pidx < data_size) {
+              const uint8_t* paddr = input + input_stride * pidx;
+              for (int64_t off = 0; off < input_stride;
+                   off += CACHE_LINE_SIZE) {
+                do_prefetch(paddr + off, 0, 0);
+              }
+            }
+          }
+
+          if (idx < 0 || idx >= data_size) {
+            if (!scale_bias_last && idx == -1) {
+              if (weights != nullptr) {
+                ++weights_addr;
+              }
+              continue;
+            }
+            return false;
+          }
+
+          const uint8_t* input_row_base = input + input_stride * idx;
+          float16_t scale_val, bias_val;
+          load_scale_bias_fp16(
+              input_row_base, scale_bias_offset, false, scale_val, bias_val);
+          if (weights != nullptr) {
+            float16_t w = static_cast<float16_t>(*weights_addr);
+            scale_val *= w;
+            bias_val *= w;
+            ++weights_addr;
+          }
+
+          const float16x8_t scale_neon = vdupq_n_f16(scale_val);
+          const float16x8_t bias_neon = vdupq_n_f16(bias_val);
+          const uint8_t* input_row = input_row_base + input_offset;
+
+          for (uint64_t tile = 0; tile < NUM_TILES; ++tile) {
+            const uint64_t tile_offset = tile * CHUNK * bytes_per_8elem;
+            const uint64_t tile_out_offset = tile * CHUNK * 8;
+            constexpr uint64_t LAST_TILE_ITERS =
+                ITERS % CHUNK == 0 ? CHUNK : (ITERS % CHUNK);
+            const uint64_t tile_iters =
+                (tile == NUM_TILES - 1) ? LAST_TILE_ITERS : CHUNK;
+
+            float16_t* outPtr =
+                reinterpret_cast<float16_t*>(out) + tile_out_offset;
+
+            for (uint64_t j = 0; j < tile_iters; ++j) {
+              acc[j] = vld1q_f16(outPtr + j * 8);
+              const float16x8_t in_f16 = (bit_rate == 4)
+                  ? unpack_4bit_to_fp16_neon(
+                        input_row + tile_offset + j * bytes_per_8elem)
+                  : unpack_2bit_to_fp16_neon(
+                        input_row + tile_offset + j * bytes_per_8elem);
+              acc[j] =
+                  vaddq_f16(acc[j], vfmaq_f16(bias_neon, in_f16, scale_neon));
+              vst1q_f16(outPtr + j * 8, acc[j]);
+            }
+          }
+          if (block_size_mod > 0) {
+            float16_t* tail_out = reinterpret_cast<float16_t*>(out) + ITERS * 8;
+            svfloat16_t tail_acc = svld1_f16(lastPred16, tail_out);
+            svfloat16_t in_sv = unpack_tail_nbit(input_row);
+            svfloat16_t sc = svdup_n_f16(scale_val);
+            svfloat16_t bs = svdup_n_f16(bias_val);
+            tail_acc = svadd_f16_m(
+                lastPred16, tail_acc, svmad_f16_m(lastPred16, in_sv, sc, bs));
+            svst1_f16(lastPred16, tail_out, tail_acc);
+          }
+          oneIterationDone = true;
+        }
+
+        if (oneIterationDone) {
+          if (do_normalize) {
+            float16_t* outPtr = reinterpret_cast<float16_t*>(out);
+            for (uint64_t j = 0; j < ITERS; ++j) {
+              float16x8_t val = vld1q_f16(outPtr + j * 8);
+              val = vmulq_f16(val, norm_fp16);
+              vst1q_f16(outPtr + j * 8, val);
+            }
+            if (block_size_mod > 0) {
+              float16_t* tail_out = outPtr + ITERS * 8;
+              svfloat16_t t = svld1_f16(lastPred16, tail_out);
+              t = svmul_f16_x(
+                  lastPred16, t, svset_neonq_f16(svundef_f16(), norm_fp16));
+              svst1_f16(lastPred16, tail_out, t);
+            }
+          }
+        }
+        return true;
+      } // ITERS > 16 tiled path
+
+      // ---- Non-tiled path for ITERS <= 16 ----
+      // Initialize accumulators
+      for (uint64_t j = 0; j < ITERS; ++j) {
+        acc[j] = vdupq_n_f16(0.0f);
+        if constexpr (ITERS <= 8) {
+          acc_b[j] = vdupq_n_f16(0.0f);
+        }
+      }
+
+      // Phase 1: 2-way unrolled paired loop (ITERS <= 8 only)
+      if constexpr (ITERS <= 8) {
+        while (current + 1 < end) {
+          const IndexType idx_a = indices[current];
+          const IndexType idx_b = indices[current + 1];
+
+          if (idx_a < 0 || idx_b < 0) {
+            for (int k = 0; k < 2; ++k) {
+              const IndexType idx = indices[current + k];
+              if (idx < 0 || idx >= data_size) {
+                if (!scale_bias_last && idx == -1) {
+                  if (weights != nullptr) {
+                    ++weights_addr;
+                  }
+                  continue;
+                }
+                return false;
+              }
+              const uint8_t* row_base = input + input_stride * idx;
+              float16_t s, b;
+              load_scale_bias_fp16(row_base, scale_bias_offset, false, s, b);
+              if (weights != nullptr) {
+                s = static_cast<float16_t>(
+                    static_cast<float>(s) * *weights_addr);
+                b = static_cast<float16_t>(
+                    static_cast<float>(b) * *weights_addr);
+                ++weights_addr;
+              }
+              const float16x8_t sc = vdupq_n_f16(s);
+              const float16x8_t bs = vdupq_n_f16(b);
+              const uint8_t* row = row_base + input_offset;
+              for (uint64_t j = 0; j < ITERS; ++j) {
+                const float16x8_t in_f16 = (bit_rate == 4)
+                    ? unpack_4bit_to_fp16_neon(row + j * bytes_per_8elem)
+                    : unpack_2bit_to_fp16_neon(row + j * bytes_per_8elem);
+                acc[j] = vaddq_f16(acc[j], vfmaq_f16(bs, in_f16, sc));
+              }
+              if (block_size_mod > 0) {
+                svfloat16_t sc_sv = svset_neonq_f16(svundef_f16(), sc);
+                svfloat16_t bs_sv = svset_neonq_f16(svundef_f16(), bs);
+                svfloat16_t in_sv = unpack_tail_nbit(row);
+                acc_tail = svget_neonq(svadd_f16_m(
+                    lastPred16,
+                    svset_neonq_f16(svundef_f16(), acc_tail),
+                    svmad_f16_m(lastPred16, in_sv, sc_sv, bs_sv)));
+              }
+              oneIterationDone = true;
+            }
+            current += 2;
+            continue;
+          }
+          if (idx_a >= data_size || idx_b >= data_size) {
+            return false;
+          }
+
+          if constexpr (EnablePrefetching) {
+            auto prefetch_row = [&](int64_t cur) {
+              const IndexType pidx =
+                  indices[std::min(cur + prefetch_stride, index_size - 1)];
+              if (pidx >= 0 && pidx < data_size) {
+                const uint8_t* paddr = input + input_stride * pidx;
+                for (int64_t off = 0; off < input_stride;
+                     off += CACHE_LINE_SIZE) {
+                  do_prefetch(paddr + off, 0, 0);
+                }
+              }
+            };
+            prefetch_row(current);
+            prefetch_row(current + 1);
+          }
+
+          const uint8_t* row_base_a = input + input_stride * idx_a;
+          float16_t scale_a, bias_a;
+          load_scale_bias_fp16(
+              row_base_a, scale_bias_offset, false, scale_a, bias_a);
+          if (weights != nullptr) {
+            scale_a = static_cast<float16_t>(
+                static_cast<float>(scale_a) * weights_addr[0]);
+            bias_a = static_cast<float16_t>(
+                static_cast<float>(bias_a) * weights_addr[0]);
+          }
+          const float16x8_t scale_a_neon = vdupq_n_f16(scale_a);
+          const float16x8_t bias_a_neon = vdupq_n_f16(bias_a);
+          const uint8_t* row_a = row_base_a + input_offset;
+
+          const uint8_t* row_base_b = input + input_stride * idx_b;
+          float16_t scale_b, bias_b;
+          load_scale_bias_fp16(
+              row_base_b, scale_bias_offset, false, scale_b, bias_b);
+          if (weights != nullptr) {
+            scale_b = static_cast<float16_t>(
+                static_cast<float>(scale_b) * weights_addr[1]);
+            bias_b = static_cast<float16_t>(
+                static_cast<float>(bias_b) * weights_addr[1]);
+          }
+          const float16x8_t scale_b_neon = vdupq_n_f16(scale_b);
+          const float16x8_t bias_b_neon = vdupq_n_f16(bias_b);
+          const uint8_t* row_b = row_base_b + input_offset;
+
+          for (uint64_t j = 0; j < ITERS; ++j) {
+            const float16x8_t in_a = (bit_rate == 4)
+                ? unpack_4bit_to_fp16_neon(row_a + j * bytes_per_8elem)
+                : unpack_2bit_to_fp16_neon(row_a + j * bytes_per_8elem);
+            const float16x8_t in_b = (bit_rate == 4)
+                ? unpack_4bit_to_fp16_neon(row_b + j * bytes_per_8elem)
+                : unpack_2bit_to_fp16_neon(row_b + j * bytes_per_8elem);
+            acc[j] =
+                vaddq_f16(acc[j], vfmaq_f16(bias_a_neon, in_a, scale_a_neon));
+            acc_b[j] =
+                vaddq_f16(acc_b[j], vfmaq_f16(bias_b_neon, in_b, scale_b_neon));
+          }
+          if (block_size_mod > 0) {
+            svfloat16_t sc_a = svset_neonq_f16(svundef_f16(), scale_a_neon);
+            svfloat16_t bs_a = svset_neonq_f16(svundef_f16(), bias_a_neon);
+            svfloat16_t in_sv_a = unpack_tail_nbit(row_a);
+            acc_tail = svget_neonq(svadd_f16_m(
+                lastPred16,
+                svset_neonq_f16(svundef_f16(), acc_tail),
+                svmad_f16_m(lastPred16, in_sv_a, sc_a, bs_a)));
+
+            svfloat16_t sc_b = svset_neonq_f16(svundef_f16(), scale_b_neon);
+            svfloat16_t bs_b = svset_neonq_f16(svundef_f16(), bias_b_neon);
+            svfloat16_t in_sv_b = unpack_tail_nbit(row_b);
+            acc_b_tail = svget_neonq(svadd_f16_m(
+                lastPred16,
+                svset_neonq_f16(svundef_f16(), acc_b_tail),
+                svmad_f16_m(lastPred16, in_sv_b, sc_b, bs_b)));
+          }
+
+          current += 2;
+          if (weights != nullptr) {
+            weights_addr += 2;
+          }
+          oneIterationDone = true;
+        }
+      } // if constexpr (ITERS <= 8)
+
+      // Phase 1b: 2-row batched loop (8 < ITERS <= 16)
+      // Touches both rows early to overlap DRAM latency (MLP),
+      // then accumulates sequentially into acc[].
+      if constexpr (ITERS > 8 && ITERS <= 16) {
+        while (current + 1 < end) {
+          const IndexType idx_a = indices[current];
+          const IndexType idx_b = indices[current + 1];
+
+          if (idx_a < 0 || idx_b < 0) {
+            for (int k = 0; k < 2; ++k) {
+              const IndexType idx = indices[current + k];
+              if (idx < 0 || idx >= data_size) {
+                if (!scale_bias_last && idx == -1) {
+                  if (weights != nullptr) {
+                    ++weights_addr;
+                  }
+                  continue;
+                }
+                return false;
+              }
+              const uint8_t* row_base = input + input_stride * idx;
+              float16_t s, b;
+              load_scale_bias_fp16(row_base, scale_bias_offset, false, s, b);
+              if (weights != nullptr) {
+                s = static_cast<float16_t>(
+                    static_cast<float>(s) * *weights_addr);
+                b = static_cast<float16_t>(
+                    static_cast<float>(b) * *weights_addr);
+                ++weights_addr;
+              }
+              const float16x8_t sc = vdupq_n_f16(s);
+              const float16x8_t bs = vdupq_n_f16(b);
+              const uint8_t* row = row_base + input_offset;
+              for (uint64_t j = 0; j < ITERS; ++j) {
+                const float16x8_t in_f16 = (bit_rate == 4)
+                    ? unpack_4bit_to_fp16_neon(row + j * bytes_per_8elem)
+                    : unpack_2bit_to_fp16_neon(row + j * bytes_per_8elem);
+                acc[j] = vaddq_f16(acc[j], vfmaq_f16(bs, in_f16, sc));
+              }
+              if (block_size_mod > 0) {
+                svfloat16_t sc_sv = svset_neonq_f16(svundef_f16(), sc);
+                svfloat16_t bs_sv = svset_neonq_f16(svundef_f16(), bs);
+                svfloat16_t in_sv = unpack_tail_nbit(row);
+                acc_tail = svget_neonq(svadd_f16_m(
+                    lastPred16,
+                    svset_neonq_f16(svundef_f16(), acc_tail),
+                    svmad_f16_m(lastPred16, in_sv, sc_sv, bs_sv)));
+              }
+              oneIterationDone = true;
+            }
+            current += 2;
+            continue;
+          }
+          if (idx_a >= data_size || idx_b >= data_size) {
+            return false;
+          }
+
+          if constexpr (EnablePrefetching) {
+            auto prefetch_row = [&](int64_t cur) {
+              const IndexType pidx =
+                  indices[std::min(cur + prefetch_stride, index_size - 1)];
+              if (pidx >= 0 && pidx < data_size) {
+                const uint8_t* paddr = input + input_stride * pidx;
+                for (int64_t off = 0; off < input_stride;
+                     off += CACHE_LINE_SIZE) {
+                  do_prefetch(paddr + off, 0, 0);
+                }
+              }
+            };
+            prefetch_row(current);
+            prefetch_row(current + 1);
+          }
+
+          const uint8_t* row_base_a = input + input_stride * idx_a;
+          const uint8_t* row_base_b = input + input_stride * idx_b;
+          float16_t scale_a, bias_a, scale_b, bias_b;
+          load_scale_bias_fp16(
+              row_base_a, scale_bias_offset, false, scale_a, bias_a);
+          load_scale_bias_fp16(
+              row_base_b, scale_bias_offset, false, scale_b, bias_b);
+          if (weights != nullptr) {
+            scale_a = static_cast<float16_t>(
+                static_cast<float>(scale_a) * weights_addr[0]);
+            bias_a = static_cast<float16_t>(
+                static_cast<float>(bias_a) * weights_addr[0]);
+            scale_b = static_cast<float16_t>(
+                static_cast<float>(scale_b) * weights_addr[1]);
+            bias_b = static_cast<float16_t>(
+                static_cast<float>(bias_b) * weights_addr[1]);
+          }
+
+          const float16x8_t scale_a_neon = vdupq_n_f16(scale_a);
+          const float16x8_t bias_a_neon = vdupq_n_f16(bias_a);
+          const uint8_t* row_a = row_base_a + input_offset;
+
+          const float16x8_t scale_b_neon = vdupq_n_f16(scale_b);
+          const float16x8_t bias_b_neon = vdupq_n_f16(bias_b);
+          const uint8_t* row_b = row_base_b + input_offset;
+
+          const uint64_t row_bytes = ITERS * bytes_per_8elem;
+          alignas(16) uint8_t row_buf_a[ITERS * 4];
+          alignas(16) uint8_t row_buf_b[ITERS * 4];
+          memcpy(row_buf_a, row_a, row_bytes);
+          memcpy(row_buf_b, row_b, row_bytes);
+
+          for (uint64_t j = 0; j < ITERS; ++j) {
+            const float16x8_t in_a = (bit_rate == 4)
+                ? unpack_4bit_to_fp16_neon(row_buf_a + j * bytes_per_8elem)
+                : unpack_2bit_to_fp16_neon(row_buf_a + j * bytes_per_8elem);
+            acc[j] =
+                vaddq_f16(acc[j], vfmaq_f16(bias_a_neon, in_a, scale_a_neon));
+          }
+          for (uint64_t j = 0; j < ITERS; ++j) {
+            const float16x8_t in_b = (bit_rate == 4)
+                ? unpack_4bit_to_fp16_neon(row_buf_b + j * bytes_per_8elem)
+                : unpack_2bit_to_fp16_neon(row_buf_b + j * bytes_per_8elem);
+            acc[j] =
+                vaddq_f16(acc[j], vfmaq_f16(bias_b_neon, in_b, scale_b_neon));
+          }
+          if (block_size_mod > 0) {
+            svfloat16_t sc_a = svset_neonq_f16(svundef_f16(), scale_a_neon);
+            svfloat16_t bs_a = svset_neonq_f16(svundef_f16(), bias_a_neon);
+            svfloat16_t in_sv_a = unpack_tail_nbit(row_a);
+            acc_tail = svget_neonq(svadd_f16_m(
+                lastPred16,
+                svset_neonq_f16(svundef_f16(), acc_tail),
+                svmad_f16_m(lastPred16, in_sv_a, sc_a, bs_a)));
+
+            svfloat16_t sc_b = svset_neonq_f16(svundef_f16(), scale_b_neon);
+            svfloat16_t bs_b = svset_neonq_f16(svundef_f16(), bias_b_neon);
+            svfloat16_t in_sv_b = unpack_tail_nbit(row_b);
+            acc_tail = svget_neonq(svadd_f16_m(
+                lastPred16,
+                svset_neonq_f16(svundef_f16(), acc_tail),
+                svmad_f16_m(lastPred16, in_sv_b, sc_b, bs_b)));
+          }
+
+          current += 2;
+          if (weights != nullptr) {
+            weights_addr += 2;
+          }
+          oneIterationDone = true;
+        }
+      } // if constexpr (ITERS > 8 && ITERS <= 16)
+
+      // Phase 2: single-embedding loop
+      for (; current < end; ++current) {
+        IndexType idx = indices[current];
+
+        if constexpr (EnablePrefetching) {
+          IndexType prefetch_idx =
+              indices[std::min(current + prefetch_stride, index_size - 1)];
+          if (prefetch_idx >= 0 && prefetch_idx < data_size) {
+            const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
+            for (int64_t offset = 0; offset < input_stride;
+                 offset += CACHE_LINE_SIZE) {
+              do_prefetch(prefetch_addr + offset, 0, 0);
+            }
+          }
+        }
+
+        if (idx < 0 || idx >= data_size) {
+          if (!scale_bias_last && idx == -1) {
+            if (weights != nullptr) {
+              ++weights_addr;
+            }
+            continue;
+          }
+          return false;
+        }
+
+        const uint8_t* input_row_base = input + input_stride * idx;
+        float16_t scale_val, bias_val;
+        load_scale_bias_fp16(
+            input_row_base, scale_bias_offset, false, scale_val, bias_val);
+        if (weights != nullptr) {
+          scale_val = static_cast<float16_t>(
+              static_cast<float>(scale_val) * *weights_addr);
+          bias_val = static_cast<float16_t>(
+              static_cast<float>(bias_val) * *weights_addr);
+          ++weights_addr;
+        }
+
+        const float16x8_t scale_neon = vdupq_n_f16(scale_val);
+        const float16x8_t bias_neon = vdupq_n_f16(bias_val);
+        const uint8_t* input_row = input_row_base + input_offset;
+
+        for (uint64_t j = 0; j < ITERS; ++j) {
+          const float16x8_t in_f16 = (bit_rate == 4)
+              ? unpack_4bit_to_fp16_neon(input_row + j * bytes_per_8elem)
+              : unpack_2bit_to_fp16_neon(input_row + j * bytes_per_8elem);
+          acc[j] = vaddq_f16(acc[j], vfmaq_f16(bias_neon, in_f16, scale_neon));
+        }
+        if (block_size_mod > 0) {
+          svfloat16_t sc = svset_neonq_f16(svundef_f16(), scale_neon);
+          svfloat16_t bs = svset_neonq_f16(svundef_f16(), bias_neon);
+          svfloat16_t in_sv = unpack_tail_nbit(input_row);
+          acc_tail = svget_neonq(svadd_f16_m(
+              lastPred16,
+              svset_neonq_f16(svundef_f16(), acc_tail),
+              svmad_f16_m(lastPred16, in_sv, sc, bs)));
+        }
+        oneIterationDone = true;
+      }
+
+      // Store fp16 accumulators directly — no fp32 widening
+      if (oneIterationDone) {
+        const float16x8_t norm_fp16 = vdupq_n_f16(
+            len > 0 ? (float16_t)(1.0f / static_cast<float>(len))
+                    : (float16_t)1.0f);
+        const bool do_normalize = (len > 0);
+
+        float16_t* outPtr = reinterpret_cast<float16_t*>(out);
+        for (uint64_t j = 0; j < ITERS; ++j) {
+          float16x8_t combined;
+          if constexpr (ITERS <= 8) {
+            combined = vaddq_f16(acc[j], acc_b[j]);
+          } else {
+            combined = acc[j];
+          }
+          if (do_normalize) {
+            combined = vmulq_f16(combined, norm_fp16);
+          }
+          vst1q_f16(outPtr, combined);
+          outPtr += 8;
+        }
+        if (block_size_mod > 0) {
+          float16x8_t tail;
+          if constexpr (ITERS <= 8) {
+            tail = vaddq_f16(acc_tail, acc_b_tail);
+          } else {
+            tail = acc_tail;
+          }
+          if (do_normalize) {
+            tail = vmulq_f16(tail, norm_fp16);
+          }
+          svst1_f16(lastPred16, outPtr, svset_neonq_f16(svundef_f16(), tail));
+        }
+      } else {
+        memset(out, 0, sizeof(OutType) * block_size);
+      }
+      return true;
+    };
+
+    for (; remaining_outputs > 0;
+         ++offsets_or_lengths, --remaining_outputs, out += output_stride) {
+      bool ok;
+      switch (iters) {
+        case 1:
+          ok = process_row.template operator()<1>();
+          break;
+        case 2:
+          ok = process_row.template operator()<2>();
+          break;
+        case 3:
+          ok = process_row.template operator()<3>();
+          break;
+        case 4:
+          ok = process_row.template operator()<4>();
+          break;
+        case 5:
+          ok = process_row.template operator()<5>();
+          break;
+        case 6:
+          ok = process_row.template operator()<6>();
+          break;
+        case 7:
+          ok = process_row.template operator()<7>();
+          break;
+        case 8:
+          ok = process_row.template operator()<8>();
+          break;
+        case 9:
+          ok = process_row.template operator()<9>();
+          break;
+        case 10:
+          ok = process_row.template operator()<10>();
+          break;
+        case 11:
+          ok = process_row.template operator()<11>();
+          break;
+        case 12:
+          ok = process_row.template operator()<12>();
+          break;
+        case 13:
+          ok = process_row.template operator()<13>();
+          break;
+        case 14:
+          ok = process_row.template operator()<14>();
+          break;
+        case 15:
+          ok = process_row.template operator()<15>();
+          break;
+        case 16:
+          ok = process_row.template operator()<16>();
+          break;
+        case 17:
+          ok = process_row.template operator()<17>();
+          break;
+        case 18:
+          ok = process_row.template operator()<18>();
+          break;
+        case 19:
+          ok = process_row.template operator()<19>();
+          break;
+        case 20:
+          ok = process_row.template operator()<20>();
+          break;
+        case 21:
+          ok = process_row.template operator()<21>();
+          break;
+        case 22:
+          ok = process_row.template operator()<22>();
+          break;
+        case 23:
+          ok = process_row.template operator()<23>();
+          break;
+        case 24:
+          ok = process_row.template operator()<24>();
+          break;
+        case 25:
+          ok = process_row.template operator()<25>();
+          break;
+        case 26:
+          ok = process_row.template operator()<26>();
+          break;
+        case 27:
+          ok = process_row.template operator()<27>();
+          break;
+        case 28:
+          ok = process_row.template operator()<28>();
+          break;
+        case 29:
+          ok = process_row.template operator()<29>();
+          break;
+        case 30:
+          ok = process_row.template operator()<30>();
+          break;
+        case 31:
+          ok = process_row.template operator()<31>();
+          break;
+        case 32:
+          ok = process_row.template operator()<32>();
+          break;
+        default:
+          ok = false;
+          break;
+      }
+      if (!ok) {
+        return false;
+      }
+    }
+    return current == index_size;
+  }
+
+  // Buf-based fp16 accumulation fallback (iters > 32).
+  svbool_t fullRowPred16 = svptrue_b16();
+
+  int64_t current = 0;
+  const float* weights_addr = weights;
+  int64_t outputSize = output_size;
+  for (; outputSize > 0;
+       ++offsets_or_lengths, --outputSize, out += output_stride) {
+    OffsetType len = use_offsets ? offsets_or_lengths[1] - offsets_or_lengths[0]
+                                 : offsets_or_lengths[0];
+    int64_t end = current + len;
+    if (end > index_size) {
+      return false;
+    }
+
+    EmbeddingStatsTracker::getInstance().recordPattern(
+        data_size,
+        block_size,
+        bit_rate == 4 ? EmbeddingStatsTracker::DataType::INT4
+                      : EmbeddingStatsTracker::DataType::INT2,
+        EmbeddingStatsTracker::DataType::FP16,
+        output_size,
+        len);
+
+    if (!normalize_by_lengths) {
+      len = 0;
+    }
+
+    float16x8_t* buf = reinterpret_cast<float16x8_t*>(out);
+
+    if (is_weight_positional) {
+      weights_addr = weights;
+    }
+
+    bool oneIterationDone = false;
+    for (; current < end; ++current) {
+      IndexType idx = indices[current];
+
+      if constexpr (EnablePrefetching) {
+        IndexType prefetch_idx =
+            indices[std::min(current + prefetch_stride, index_size - 1)];
+        if (prefetch_idx >= 0 && prefetch_idx < data_size) {
+          const uint8_t* prefetch_addr = input + input_stride * prefetch_idx;
+          for (int64_t offset = 0; offset < input_stride;
+               offset += CACHE_LINE_SIZE) {
+            do_prefetch(prefetch_addr + offset, 1);
+          }
+        }
+      }
+
+      if (idx < 0 || idx >= data_size) {
+        if (!scale_bias_last && idx == -1) {
+          if (weights != nullptr) {
+            ++weights_addr;
+          }
+          continue;
+        }
+        return false;
+      }
+
+      const uint8_t* input_row_base = input + input_stride * idx;
+      float16_t scale_val, bias_val;
+      load_scale_bias_fp16(
+          input_row_base, scale_bias_offset, false, scale_val, bias_val);
+      if (weights != nullptr) {
+        scale_val = static_cast<float16_t>(
+            static_cast<float>(scale_val) * *weights_addr);
+        bias_val = static_cast<float16_t>(
+            static_cast<float>(bias_val) * *weights_addr);
+        ++weights_addr;
+      }
+
+      svfloat16_t scale = svdup_n_f16(scale_val);
+      svfloat16_t bias = svdup_n_f16(bias_val);
+      const uint8_t* input_row = input_row_base + input_offset;
+      float16x8_t* bptr = buf;
+
+      for (uint64_t i = 0; i < iters; ++i) {
+        float16x8_t values = (bit_rate == 4)
+            ? unpack_4bit_to_fp16_neon(input_row + i * bytes_per_8elem)
+            : unpack_2bit_to_fp16_neon(input_row + i * bytes_per_8elem);
+        svfloat16_t in_v_f = svset_neonq_f16(svundef_f16(), values);
+
+        if (oneIterationDone) {
+          svfloat16_t buf_sv = svset_neonq_f16(svundef_f16(), *bptr);
+          buf_sv = svadd_f16_x(fullRowPred16, buf_sv, bias);
+          in_v_f = svmad_f16_m(fullRowPred16, in_v_f, scale, buf_sv);
+        } else {
+          in_v_f = svmad_f16_m(fullRowPred16, in_v_f, scale, bias);
+        }
+
+        *bptr = svget_neonq(in_v_f);
+        bptr += 1;
+      }
+
+      // Tail
+      if (block_size_mod > 0) {
+        auto tailBufPtr = reinterpret_cast<float16_t*>(bptr);
+        alignas(4) uint8_t tail_buf[4] = {0};
+        memcpy(
+            tail_buf, input_row + iters * bytes_per_8elem, tail_packed_bytes);
+        float16x8_t v = (bit_rate == 4) ? unpack_4bit_to_fp16_neon(tail_buf)
+                                        : unpack_2bit_to_fp16_neon(tail_buf);
+        svfloat16_t in_v_f = svset_neonq_f16(svundef_f16(), v);
+
+        if (oneIterationDone) {
+          svfloat16_t buf_sv = svld1_f16(lastPred16, tailBufPtr);
+          buf_sv = svadd_f16_x(lastPred16, buf_sv, bias);
+          in_v_f = svmad_f16_m(lastPred16, in_v_f, scale, buf_sv);
+        } else {
+          in_v_f = svmad_f16_m(lastPred16, in_v_f, scale, bias);
+        }
+        svst1_f16(lastPred16, tailBufPtr, in_v_f);
+      }
+
+      oneIterationDone = true;
+    }
+
+    if (oneIterationDone) {
+      if (len) {
+        float16x8_t norm =
+            vdupq_n_f16(static_cast<float16_t>(1.0f / static_cast<float>(len)));
+        float16x8_t* bptr = buf;
+        for (uint64_t i = 0; i < iters; ++i) {
+          *bptr = vmulq_f16(*bptr, norm);
+          bptr += 1;
+        }
+        if (block_size_mod > 0) {
+          auto bp = reinterpret_cast<float16_t*>(bptr);
+          svfloat16_t t = svld1_f16(lastPred16, bp);
+          t = svmul_f16_x(lastPred16, t, svset_neonq_f16(svundef_f16(), norm));
+          svst1_f16(lastPred16, bp, t);
         }
       }
     } else {

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -826,14 +826,10 @@ bool is_stats_enabled() {
 }
 
 bool is_sve_fp16_enabled() {
-  static bool res;
-  static bool called_once = false;
-  if (called_once) {
-    return res;
-  }
-  called_once = true;
-  char* env_val = std::getenv("FBGEMM_TBE_SVE_FP16_ACCUMULATOR");
-  res = (env_val != nullptr);
+  static bool res = [] {
+    char* env_val = std::getenv("FBGEMM_TBE_SVE_FP16_ACCUMULATOR");
+    return env_val != nullptr;
+  }();
   return res;
 }
 

--- a/test/EmbeddingSpMDMNBitTest.cc
+++ b/test/EmbeddingSpMDMNBitTest.cc
@@ -47,6 +47,19 @@ static vector<vector<int>> GetInputs_() {
 
 static vector<int> prefetch_distances{0, 16, 1000000};
 
+static float fp16_tolerance(int average_len, float expected) {
+  constexpr float eps = 9.77e-4f;
+  // NBit scale/bias are natively fp16 (no fp32 narrowing), so error
+  // is dominated by fp16 accumulation rounding. With random data,
+  // errors follow a random walk: O(sqrt(avg_len) * eps * |value|).
+  // 2x safety margin for tail distribution.
+  return eps + 2.0f * sqrtf(average_len) * eps * abs(expected);
+}
+
+static float clamp_for_fp16(float val) {
+  return std::min(std::abs(val), 1.0f);
+}
+
 namespace {
 
 class FusedNBitRowwiseEmbeddingLookupTest : public testing::TestWithParam<tuple<
@@ -144,6 +157,10 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
                : 0));
       float scale = embedding_distribution(generator);
       float bias = embedding_distribution(generator);
+      if (is_sve_fp16_enabled()) {
+        scale = clamp_for_fp16(scale);
+        bias = clamp_for_fp16(bias);
+      }
       FloatToFloat16_ref(&scale, scale_bias, 1, true /* clip */);
       FloatToFloat16_ref(&bias, scale_bias + 1, 1, true /* clip */);
     }
@@ -167,6 +184,12 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
         (use_offsets ? offsets : lengths).data();
     const int32_t* offsets_or_lengths_32 =
         (use_offsets ? offsets_32 : lengths_32).data();
+
+    if (is_sve_fp16_enabled()) {
+      for (auto& w : weights) {
+        w = abs(w);
+      }
+    }
 
     if (!scale_bias_last && use_weight) {
       // When scale_bias_last == false, assume this is for table batched
@@ -365,21 +388,843 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, basicTest) {
       for (size_t i = 0; i < output.size(); ++i) {
         float actual = get_actual(i);
         float expected = get_expected(i);
-        EXPECT_EQ(actual, expected)
-            << "results differ at (" << i << ") reference: " << expected
-            << ", FBGEMM: " << actual << " emb dim :" << embedding_dim;
+        if (is_sve_fp16_enabled() && out_type == FLOAT16) {
+          EXPECT_NEAR(actual, expected, fp16_tolerance(average_len, expected))
+              << "results differ at (" << i << ") reference: " << expected
+              << ", FBGEMM: " << actual << " emb dim :" << embedding_dim;
+        } else {
+          EXPECT_EQ(actual, expected)
+              << "results differ at (" << i << ") reference: " << expected
+              << ", FBGEMM: " << actual << " emb dim :" << embedding_dim;
+        }
       }
       for (int offset = output_size_wo_sentries;
            offset < output_size_wo_sentries + num_sentries;
            ++offset) {
         float actual = get_actual(offset);
         float expected = get_expected(offset);
-        EXPECT_EQ(actual, expected)
-            << "results differ at (" << offset << ") reference: " << expected
-            << ", FBGEMM: " << actual << " emb dim :" << embedding_dim;
+        if (is_sve_fp16_enabled() && out_type == FLOAT16) {
+          EXPECT_NEAR(actual, expected, fp16_tolerance(average_len, expected))
+              << "results differ at (" << offset << ") reference: " << expected
+              << ", FBGEMM: " << actual << " emb dim :" << embedding_dim;
+        } else {
+          EXPECT_EQ(actual, expected)
+              << "results differ at (" << offset << ") reference: " << expected
+              << ", FBGEMM: " << actual << " emb dim :" << embedding_dim;
+        }
       }
     }
   } // end for input
+}
+
+TEST_P(FusedNBitRowwiseEmbeddingLookupTest, fp16CorrectnessTest) {
+  auto
+      [bit_rate,
+       prefetch,
+       weight_choice,
+       corner_case,
+       out_type,
+       kernel_choice] = GetParam();
+  if (!is_sve_fp16_enabled() || out_type != FLOAT16) {
+    return;
+  }
+  ScopedKernelOverride kernel_override(kernel_choice);
+  bool use_weight = weight_choice != UNWEIGHTED;
+  bool is_wt_positional = weight_choice == POSITIONAL_WEIGHTED;
+  int num_elem_per_byte = 8 / bit_rate;
+
+  vector<vector<int>> inputs = {
+      // {batch, rows, dim, avg_len}
+      {4, 100, 2, 4},
+      {4, 100, 4, 10},
+      {4, 100, 7, 4},
+      {4, 100, 8, 4},
+      {4, 100, 9, 4},
+      {4, 100, 10, 4},
+      {4, 100, 16, 4},
+      {4, 100, 17, 4},
+      {4, 100, 19, 4},
+      {4, 100, 24, 10},
+      {4, 100, 32, 10},
+      {4, 100, 33, 10},
+      {4, 100, 48, 10},
+      {4, 100, 64, 10},
+      {4, 100, 65, 10},
+      {10, 40, 93, 10},
+      {10, 40, 95, 10},
+      {4, 100, 128, 10},
+      {4, 100, 256, 4},
+      {4, 100, 500, 4},
+      {4, 100, 512, 4},
+      {4, 100, 900, 4},
+      {4, 100, 1024, 4},
+      {4, 100, 40, 10}, // ITERS=5, no tail — Phase 1 fill-in
+      {4, 100, 56, 10}, // ITERS=7, no tail — Phase 1 fill-in
+      {4, 100, 72, 10}, // ITERS=9, no tail — Phase 1b lower boundary
+      {4, 100, 79, 10}, // ITERS=9, tail=7 — Phase 1b lower boundary + max tail
+      {4, 100, 136, 10}, // ITERS=17, no tail — Tiled lower boundary,
+      // LAST_TILE_ITERS=1
+      {4, 100, 143, 10}, // ITERS=17, tail=7 — Tiled lower boundary + tail
+      {4, 100, 192, 10}, // ITERS=24, no tail — Tiled interior,
+      // LAST_TILE_ITERS=8
+      {4, 100, 200, 4}, // ITERS=25, tail=0 — additional Tiled interior
+      {4, 100, 263, 4}, // ITERS=32, tail=7 — Tiled upper boundary with tail
+      {10, 4000, 32, 100}, // production-scale avg_len
+      {10, 4000, 64, 100}, // production-scale avg_len
+  };
+
+  random_device r;
+  default_random_engine generator(r());
+  uniform_int_distribution<int> entries(0, 16);
+
+  for (auto& input : inputs) {
+    int batch_size = input[0];
+    int num_rows = input[1];
+    int embedding_dim = input[2];
+    int average_len = input[3];
+
+    int fused_embedding_dim =
+        (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte +
+        2 * sizeof(float16);
+
+    // ---- Test 1: Integer scale/bias (should be exact) ----
+    {
+      vector<uint8_t> fused_embedding_table(num_rows * fused_embedding_dim);
+      for (int i = 0; i < num_rows; i++) {
+        for (int ii = 0;
+             ii < (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte;
+             ii++) {
+          fused_embedding_table[i * fused_embedding_dim + ii] =
+              entries(generator);
+        }
+        float16* scale_bias = reinterpret_cast<float16*>(
+            fused_embedding_table.data() + i * fused_embedding_dim +
+            (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte);
+        float scale = 1.0f;
+        float bias = 0.0f;
+        FloatToFloat16_ref(&scale, scale_bias, 1, true);
+        FloatToFloat16_ref(&bias, scale_bias + 1, 1, true);
+      }
+
+      vector<int64_t> lengths, offsets, indices;
+      vector<int32_t> lengths_32, offsets_32, indices_32;
+      vector<float> weights;
+      int lengths_sum = GenerateLengthsIndicesWeights(
+          lengths,
+          lengths_32,
+          offsets,
+          offsets_32,
+          indices,
+          indices_32,
+          weights,
+          batch_size,
+          num_rows,
+          average_len,
+          corner_case);
+
+      if (use_weight) {
+        for (auto& w : weights) {
+          w = 1.0f;
+        }
+      }
+
+      int output_size = batch_size;
+      vector<float16> output_ref_fp16(output_size * embedding_dim);
+      vector<float16> output_fp16(output_size * embedding_dim);
+
+      bool success_ref = EmbeddingSpMDMNBit_ref<int64_t, int64_t, float16>(
+          bit_rate,
+          embedding_dim,
+          batch_size,
+          lengths_sum,
+          num_rows,
+          fused_embedding_table.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+          offsets.data(),
+          use_weight ? weights.data() : nullptr,
+          false,
+          output_ref_fp16.data(),
+          is_wt_positional,
+          true,
+          -1,
+          -1,
+          true,
+          false);
+
+      auto kernel =
+          GenerateEmbeddingSpMDMNBitWithStrides<int64_t, int64_t, float16>(
+              bit_rate,
+              embedding_dim,
+              use_weight,
+              false,
+              prefetch,
+              is_wt_positional,
+              true,
+              -1,
+              -1,
+              true,
+              false);
+
+      bool success = kernel(
+          batch_size,
+          lengths_sum,
+          num_rows,
+          fused_embedding_table.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+          offsets.data(),
+          use_weight ? weights.data() : nullptr,
+          output_fp16.data());
+
+      ASSERT_EQ(success, success_ref)
+          << "Integer test: ref and kernel disagree"
+          << " bit_rate=" << bit_rate << " dim=" << embedding_dim;
+      if (corner_case == OUT_OF_BOUND_INDICES ||
+          corner_case == UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM) {
+        EXPECT_FALSE(success);
+      }
+
+      if (success) {
+        for (int i = 0; i < output_size * embedding_dim; ++i) {
+          float actual = cpu_half2float(output_fp16[i]);
+          float expected = cpu_half2float(output_ref_fp16[i]);
+          EXPECT_EQ(actual, expected)
+              << "Integer test MISMATCH at i=" << i << " bit_rate=" << bit_rate
+              << " dim=" << embedding_dim << " expected=" << expected
+              << " actual=" << actual;
+        }
+      }
+    }
+
+    // ---- Test 2: fp16-representable float scale/bias ----
+    {
+      vector<uint8_t> fused_embedding_table(num_rows * fused_embedding_dim);
+      for (int i = 0; i < num_rows; i++) {
+        for (int ii = 0;
+             ii < (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte;
+             ii++) {
+          fused_embedding_table[i * fused_embedding_dim + ii] =
+              entries(generator);
+        }
+        float16* scale_bias = reinterpret_cast<float16*>(
+            fused_embedding_table.data() + i * fused_embedding_dim +
+            (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte);
+        float scale = 0.25f;
+        float bias = 0.5f;
+        FloatToFloat16_ref(&scale, scale_bias, 1, true);
+        FloatToFloat16_ref(&bias, scale_bias + 1, 1, true);
+      }
+
+      vector<int64_t> lengths, offsets, indices;
+      vector<int32_t> lengths_32, offsets_32, indices_32;
+      vector<float> weights;
+      int lengths_sum = GenerateLengthsIndicesWeights(
+          lengths,
+          lengths_32,
+          offsets,
+          offsets_32,
+          indices,
+          indices_32,
+          weights,
+          batch_size,
+          num_rows,
+          average_len,
+          corner_case);
+
+      if (use_weight) {
+        for (auto& w : weights) {
+          w = 1.0f;
+        }
+      }
+
+      int output_size = batch_size;
+      vector<float16> output_ref_fp16(output_size * embedding_dim);
+      vector<float16> output_fp16(output_size * embedding_dim);
+
+      bool success_ref = EmbeddingSpMDMNBit_ref<int64_t, int64_t, float16>(
+          bit_rate,
+          embedding_dim,
+          batch_size,
+          lengths_sum,
+          num_rows,
+          fused_embedding_table.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+          offsets.data(),
+          use_weight ? weights.data() : nullptr,
+          false,
+          output_ref_fp16.data(),
+          is_wt_positional,
+          true,
+          -1,
+          -1,
+          true,
+          false);
+
+      auto kernel =
+          GenerateEmbeddingSpMDMNBitWithStrides<int64_t, int64_t, float16>(
+              bit_rate,
+              embedding_dim,
+              use_weight,
+              false,
+              prefetch,
+              is_wt_positional,
+              true,
+              -1,
+              -1,
+              true,
+              false);
+
+      bool success = kernel(
+          batch_size,
+          lengths_sum,
+          num_rows,
+          fused_embedding_table.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+          offsets.data(),
+          use_weight ? weights.data() : nullptr,
+          output_fp16.data());
+
+      ASSERT_EQ(success, success_ref);
+      if (corner_case == OUT_OF_BOUND_INDICES ||
+          corner_case == UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM) {
+        EXPECT_FALSE(success);
+      }
+
+      if (success) {
+        for (int i = 0; i < output_size * embedding_dim; ++i) {
+          float actual = cpu_half2float(output_fp16[i]);
+          float expected = cpu_half2float(output_ref_fp16[i]);
+          EXPECT_EQ(actual, expected)
+              << "FP16 representable test at i=" << i
+              << " bit_rate=" << bit_rate << " dim=" << embedding_dim
+              << " expected=" << expected << " actual=" << actual;
+        }
+      }
+    }
+
+    // ---- Test 3: Random scale/bias with normalization ----
+    for (int norm = 0; norm <= 1; ++norm) {
+      bool normalize = (norm == 1);
+      normal_distribution<float> embedding_distribution;
+
+      vector<uint8_t> fused_embedding_table(num_rows * fused_embedding_dim);
+      for (int i = 0; i < num_rows; i++) {
+        for (int ii = 0;
+             ii < (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte;
+             ii++) {
+          fused_embedding_table[i * fused_embedding_dim + ii] =
+              entries(generator);
+        }
+        float16* scale_bias = reinterpret_cast<float16*>(
+            fused_embedding_table.data() + i * fused_embedding_dim +
+            (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte);
+        float scale = embedding_distribution(generator);
+        float bias = embedding_distribution(generator);
+        if (is_sve_fp16_enabled()) {
+          scale = clamp_for_fp16(scale);
+          bias = clamp_for_fp16(bias);
+        }
+        FloatToFloat16_ref(&scale, scale_bias, 1, true);
+        FloatToFloat16_ref(&bias, scale_bias + 1, 1, true);
+      }
+
+      vector<int64_t> lengths, offsets, indices;
+      vector<int32_t> lengths_32, offsets_32, indices_32;
+      vector<float> weights;
+      int lengths_sum = GenerateLengthsIndicesWeights(
+          lengths,
+          lengths_32,
+          offsets,
+          offsets_32,
+          indices,
+          indices_32,
+          weights,
+          batch_size,
+          num_rows,
+          average_len,
+          corner_case);
+
+      if (is_sve_fp16_enabled()) {
+        for (auto& w : weights) {
+          w = abs(w);
+        }
+      }
+
+      int output_size = batch_size;
+      constexpr int num_sentries = 10;
+      const float16 sentry_value = cpu_float2half_rn(1.0f);
+      vector<float16> output_ref_fp16(
+          output_size * embedding_dim + num_sentries, sentry_value);
+      vector<float16> output_fp16(output_ref_fp16.size(), sentry_value);
+
+      bool success_ref = EmbeddingSpMDMNBit_ref<int64_t, int64_t, float16>(
+          bit_rate,
+          embedding_dim,
+          batch_size,
+          lengths_sum,
+          num_rows,
+          fused_embedding_table.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+          offsets.data(),
+          use_weight ? weights.data() : nullptr,
+          normalize,
+          output_ref_fp16.data(),
+          is_wt_positional,
+          true,
+          -1,
+          -1,
+          true,
+          false);
+
+      auto kernel =
+          GenerateEmbeddingSpMDMNBitWithStrides<int64_t, int64_t, float16>(
+              bit_rate,
+              embedding_dim,
+              use_weight,
+              normalize,
+              prefetch,
+              is_wt_positional,
+              true,
+              -1,
+              -1,
+              true,
+              false);
+
+      bool success = kernel(
+          batch_size,
+          lengths_sum,
+          num_rows,
+          fused_embedding_table.data(),
+          corner_case == EMPTY_INDICES ? nullptr : indices.data(),
+          offsets.data(),
+          use_weight ? weights.data() : nullptr,
+          output_fp16.data());
+
+      ASSERT_EQ(success, success_ref);
+      if (corner_case == OUT_OF_BOUND_INDICES ||
+          corner_case == UNMATCHED_NUM_INDICES_AND_LENGTHS_SUM) {
+        EXPECT_FALSE(success);
+      }
+
+      if (success) {
+        for (int i = 0; i < output_size * embedding_dim; ++i) {
+          float actual = cpu_half2float(output_fp16[i]);
+          float expected = cpu_half2float(output_ref_fp16[i]);
+          EXPECT_NEAR(actual, expected, fp16_tolerance(average_len, expected))
+              << "Random test at i=" << i << " bit_rate=" << bit_rate
+              << " dim=" << embedding_dim << " avg_len=" << average_len
+              << " norm=" << normalize << " wt=" << use_weight;
+        }
+        for (int i = output_size * embedding_dim;
+             i < output_size * embedding_dim + num_sentries;
+             ++i) {
+          EXPECT_EQ(output_fp16[i], sentry_value)
+              << "Sentry overwritten at i=" << i << " bit_rate=" << bit_rate
+              << " dim=" << embedding_dim;
+        }
+      }
+    }
+  }
+}
+
+TEST_P(FusedNBitRowwiseEmbeddingLookupTest, fp16ScaleBiasFirstTest) {
+  auto
+      [bit_rate,
+       prefetch,
+       weight_choice,
+       corner_case,
+       out_type,
+       kernel_choice] = GetParam();
+  if (!is_sve_fp16_enabled() || out_type != FLOAT16 || corner_case != NONE) {
+    return;
+  }
+  ScopedKernelOverride kernel_override(kernel_choice);
+  bool use_weight = weight_choice != UNWEIGHTED;
+  bool is_wt_positional = weight_choice == POSITIONAL_WEIGHTED;
+  int num_elem_per_byte = 8 / bit_rate;
+
+  vector<vector<int>> inputs = {
+      // {batch, rows, dim, avg_len}
+      {4, 100, 2, 4},
+      {4, 100, 4, 10},
+      {4, 100, 7, 4},
+      {4, 100, 8, 4},
+      {4, 100, 9, 4},
+      {4, 100, 10, 4},
+      {4, 100, 16, 4},
+      {4, 100, 17, 4},
+      {4, 100, 19, 4},
+      {4, 100, 24, 10},
+      {4, 100, 32, 10},
+      {4, 100, 33, 10},
+      {4, 100, 48, 10},
+      {4, 100, 64, 10},
+      {4, 100, 65, 10},
+      {10, 40, 93, 10},
+      {10, 40, 95, 10},
+      {4, 100, 128, 10},
+      {4, 100, 256, 4},
+      {4, 100, 500, 4},
+      {4, 100, 512, 4},
+      {4, 100, 900, 4},
+      {4, 100, 1024, 4},
+      {4, 100, 40, 10}, // ITERS=5, no tail — Phase 1 fill-in
+      {4, 100, 56, 10}, // ITERS=7, no tail — Phase 1 fill-in
+      {4, 100, 72, 10}, // ITERS=9, no tail — Phase 1b lower boundary
+      {4, 100, 79, 10}, // ITERS=9, tail=7 — Phase 1b lower boundary + max tail
+      {4, 100, 136, 10}, // ITERS=17, no tail — Tiled lower boundary,
+      // LAST_TILE_ITERS=1
+      {4, 100, 143, 10}, // ITERS=17, tail=7 — Tiled lower boundary + tail
+      {4, 100, 192, 10}, // ITERS=24, no tail — Tiled interior,
+      // LAST_TILE_ITERS=8
+      {4, 100, 200, 4}, // ITERS=25, tail=0 — additional Tiled interior
+      {4, 100, 263, 4}, // ITERS=32, tail=7 — Tiled upper boundary with tail
+      {10, 4000, 32, 100}, // production-scale avg_len
+      {10, 4000, 64, 100}, // production-scale avg_len
+  };
+
+  random_device r;
+  default_random_engine generator(r());
+  uniform_int_distribution<int> entries(0, 16);
+  normal_distribution<float> embedding_distribution;
+
+  for (auto& input : inputs) {
+    int batch_size = input[0];
+    int num_rows = input[1];
+    int embedding_dim = input[2];
+    int average_len = input[3];
+
+    int packed_dim =
+        (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte;
+    int fused_embedding_dim = packed_dim + 2 * sizeof(float16);
+
+    for (int norm = 0; norm <= 1; ++norm) {
+      bool normalize = (norm == 1);
+
+      vector<uint8_t> fused_embedding_table(num_rows * fused_embedding_dim);
+      for (int i = 0; i < num_rows; i++) {
+        for (int ii = 0; ii < packed_dim; ii++) {
+          fused_embedding_table
+              [i * fused_embedding_dim + 2 * sizeof(float16) + ii] =
+                  entries(generator);
+        }
+        float16* scale_bias = reinterpret_cast<float16*>(
+            fused_embedding_table.data() + i * fused_embedding_dim);
+        float scale = clamp_for_fp16(embedding_distribution(generator));
+        float bias = clamp_for_fp16(embedding_distribution(generator));
+        FloatToFloat16_ref(&scale, scale_bias, 1, true);
+        FloatToFloat16_ref(&bias, scale_bias + 1, 1, true);
+      }
+
+      vector<int64_t> lengths, offsets, indices;
+      vector<int32_t> lengths_32, offsets_32, indices_32;
+      vector<float> weights;
+      int lengths_sum = GenerateLengthsIndicesWeights(
+          lengths,
+          lengths_32,
+          offsets,
+          offsets_32,
+          indices,
+          indices_32,
+          weights,
+          batch_size,
+          num_rows,
+          average_len,
+          corner_case);
+
+      if (use_weight) {
+        for (auto& w : weights) {
+          w = abs(w);
+        }
+      }
+
+      // Inject pruned indices (idx=-1) for TBE format
+      uniform_int_distribution<int> pruned_dist(0, indices.size() - 1);
+      for (size_t i = 0; i < indices.size() * 0.1; ++i) {
+        auto idx = pruned_dist(generator);
+        indices[idx] = -1;
+      }
+
+      int output_size = batch_size;
+      vector<float16> output_ref_fp16(output_size * embedding_dim);
+      vector<float16> output_fp16(output_size * embedding_dim);
+
+      bool success_ref = EmbeddingSpMDMNBit_ref<int64_t, int64_t, float16>(
+          bit_rate,
+          embedding_dim,
+          batch_size,
+          lengths_sum,
+          num_rows,
+          fused_embedding_table.data(),
+          indices.data(),
+          offsets.data(),
+          use_weight ? weights.data() : nullptr,
+          normalize,
+          output_ref_fp16.data(),
+          is_wt_positional,
+          true,
+          -1,
+          -1,
+          false,
+          false);
+
+      auto kernel =
+          GenerateEmbeddingSpMDMNBitWithStrides<int64_t, int64_t, float16>(
+              bit_rate,
+              embedding_dim,
+              use_weight,
+              normalize,
+              prefetch,
+              is_wt_positional,
+              true,
+              -1,
+              -1,
+              false,
+              false);
+
+      bool success = kernel(
+          batch_size,
+          lengths_sum,
+          num_rows,
+          fused_embedding_table.data(),
+          indices.data(),
+          offsets.data(),
+          use_weight ? weights.data() : nullptr,
+          output_fp16.data());
+
+      ASSERT_EQ(success, success_ref)
+          << "scale_bias_first test: ref and kernel disagree"
+          << " bit_rate=" << bit_rate << " dim=" << embedding_dim
+          << " norm=" << normalize;
+
+      if (success) {
+        for (int i = 0; i < output_size * embedding_dim; ++i) {
+          float actual = cpu_half2float(output_fp16[i]);
+          float expected = cpu_half2float(output_ref_fp16[i]);
+          EXPECT_NEAR(actual, expected, fp16_tolerance(average_len, expected))
+              << "scale_bias_first test at i=" << i << " bit_rate=" << bit_rate
+              << " dim=" << embedding_dim << " norm=" << normalize
+              << " wt=" << use_weight;
+        }
+      }
+    }
+  }
+}
+
+TEST_P(FusedNBitRowwiseEmbeddingLookupTest, fp16NoBagTest) {
+  auto
+      [bit_rate,
+       prefetch,
+       weight_choice,
+       corner_case,
+       out_type,
+       kernel_choice] = GetParam();
+  if (!is_sve_fp16_enabled() || out_type != FLOAT16) {
+    return;
+  }
+  if (corner_case != NONE) {
+    return;
+  }
+  ScopedKernelOverride kernel_override(kernel_choice);
+  bool use_weight = weight_choice != UNWEIGHTED;
+  int num_elem_per_byte = 8 / bit_rate;
+
+  vector<vector<int>> inputs = {
+      // {output_size, rows, dim}
+      {10, 100, 8},
+      {10, 100, 9},
+      {10, 100, 16},
+      {10, 100, 17},
+      {10, 100, 32},
+      {10, 100, 33},
+      {10, 100, 48},
+      {10, 100, 64},
+      {10, 100, 65},
+      {10, 100, 128},
+      {10, 100, 256},
+  };
+
+  random_device r;
+  default_random_engine generator(r());
+  uniform_int_distribution<int> entries(0, 16);
+
+  for (auto& input : inputs) {
+    int output_size = input[0];
+    int num_rows = input[1];
+    int embedding_dim = input[2];
+
+    int packed_dim =
+        (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte;
+    int fused_embedding_dim = packed_dim + 2 * sizeof(float16);
+
+    for (bool scale_bias_last : {true, false}) {
+      vector<uint8_t> fused_embedding_table(num_rows * fused_embedding_dim);
+      for (int i = 0; i < num_rows; i++) {
+        int data_offset = scale_bias_last ? 0 : 2 * sizeof(float16);
+        for (int ii = 0; ii < packed_dim; ii++) {
+          fused_embedding_table[i * fused_embedding_dim + data_offset + ii] =
+              entries(generator);
+        }
+        int sb_offset = scale_bias_last ? packed_dim : 0;
+        float16* scale_bias = reinterpret_cast<float16*>(
+            fused_embedding_table.data() + i * fused_embedding_dim + sb_offset);
+        float scale = 0.25f;
+        float bias = 0.5f;
+        FloatToFloat16_ref(&scale, scale_bias, 1, true);
+        FloatToFloat16_ref(&bias, scale_bias + 1, 1, true);
+      }
+
+      uniform_int_distribution<int> idx_dist(0, num_rows - 1);
+      vector<int64_t> indices(output_size);
+      for (int i = 0; i < output_size; ++i) {
+        indices[i] = idx_dist(generator);
+      }
+
+      vector<float> weights(output_size);
+      for (int i = 0; i < output_size; ++i) {
+        weights[i] = use_weight ? 1.0f : 0.0f;
+      }
+
+      auto kernel_nobag =
+          GenerateEmbeddingSpMDMNBitWithStrides<int64_t, int64_t, float16>(
+              bit_rate,
+              embedding_dim,
+              use_weight,
+              false,
+              prefetch,
+              false,
+              true,
+              -1,
+              -1,
+              scale_bias_last,
+              false,
+              /*no_bag=*/true);
+
+      auto kernel_bag =
+          GenerateEmbeddingSpMDMNBitWithStrides<int64_t, int64_t, float16>(
+              bit_rate,
+              embedding_dim,
+              use_weight,
+              false,
+              prefetch,
+              false,
+              true,
+              -1,
+              -1,
+              scale_bias_last,
+              false,
+              /*no_bag=*/false);
+
+      vector<int64_t> offsets(output_size + 1);
+      for (int i = 0; i <= output_size; ++i) {
+        offsets[i] = i;
+      }
+
+      vector<float16> output_nobag(output_size * embedding_dim);
+      vector<float16> output_bag(output_size * embedding_dim);
+
+      bool success_nobag = kernel_nobag(
+          output_size,
+          output_size,
+          num_rows,
+          fused_embedding_table.data(),
+          indices.data(),
+          offsets.data(),
+          use_weight ? weights.data() : nullptr,
+          output_nobag.data());
+
+      bool success_bag = kernel_bag(
+          output_size,
+          output_size,
+          num_rows,
+          fused_embedding_table.data(),
+          indices.data(),
+          offsets.data(),
+          use_weight ? weights.data() : nullptr,
+          output_bag.data());
+
+      ASSERT_TRUE(success_nobag)
+          << "NoBag kernel failed bit_rate=" << bit_rate
+          << " dim=" << embedding_dim << " scale_bias_last=" << scale_bias_last;
+      ASSERT_TRUE(success_bag)
+          << "Bag-of-1 kernel failed bit_rate=" << bit_rate
+          << " dim=" << embedding_dim << " scale_bias_last=" << scale_bias_last;
+
+      for (int i = 0; i < output_size * embedding_dim; ++i) {
+        float actual = cpu_half2float(output_nobag[i]);
+        float expected = cpu_half2float(output_bag[i]);
+        EXPECT_EQ(actual, expected)
+            << "NoBag vs bag-of-1 mismatch at i=" << i
+            << " bit_rate=" << bit_rate << " dim=" << embedding_dim
+            << " scale_bias_last=" << scale_bias_last;
+      }
+    }
+  }
+}
+
+TEST_P(FusedNBitRowwiseEmbeddingLookupTest, fp16NoBagNegativeIndexTest) {
+  auto
+      [bit_rate,
+       prefetch,
+       weight_choice,
+       corner_case,
+       out_type,
+       kernel_choice] = GetParam();
+  if (!is_sve_fp16_enabled() || out_type != FLOAT16 || corner_case != NONE ||
+      weight_choice != UNWEIGHTED) {
+    return;
+  }
+  ScopedKernelOverride kernel_override(kernel_choice);
+  int num_elem_per_byte = 8 / bit_rate;
+
+  int output_size = 10;
+  int num_rows = 100;
+  int embedding_dim = 32;
+  int packed_dim = (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte;
+  int fused_embedding_dim = packed_dim + 2 * sizeof(float16);
+
+  vector<uint8_t> fused_embedding_table(num_rows * fused_embedding_dim, 1);
+  for (int i = 0; i < num_rows; i++) {
+    float16* scale_bias = reinterpret_cast<float16*>(
+        fused_embedding_table.data() + i * fused_embedding_dim + packed_dim);
+    float scale = 1.0f, bias = 0.0f;
+    FloatToFloat16_ref(&scale, scale_bias, 1, true);
+    FloatToFloat16_ref(&bias, scale_bias + 1, 1, true);
+  }
+
+  vector<int64_t> indices(output_size, 0);
+  indices[5] = -1;
+  vector<int64_t> offsets(output_size + 1);
+  iota(offsets.begin(), offsets.end(), 0);
+
+  vector<float16> output(output_size * embedding_dim);
+
+  auto kernel =
+      GenerateEmbeddingSpMDMNBitWithStrides<int64_t, int64_t, float16>(
+          bit_rate,
+          embedding_dim,
+          false,
+          false,
+          prefetch,
+          false,
+          true,
+          -1,
+          -1,
+          true,
+          false,
+          /*no_bag=*/true);
+
+  bool success = kernel(
+      output_size,
+      output_size,
+      num_rows,
+      fused_embedding_table.data(),
+      indices.data(),
+      offsets.data(),
+      nullptr,
+      output.data());
+
+  EXPECT_FALSE(success) << "NoBag kernel should return false for negative index"
+                        << " bit_rate=" << bit_rate;
 }
 
 TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
@@ -445,6 +1290,10 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
           (embedding_dim + num_elem_per_byte - 1) / num_elem_per_byte);
       float scale = embedding_distribution(generator);
       float bias = embedding_distribution(generator);
+      if (is_sve_fp16_enabled()) {
+        scale = clamp_for_fp16(scale);
+        bias = clamp_for_fp16(bias);
+      }
       FloatToFloat16_ref(&scale, scale_bias, 1, true /* clip */);
       FloatToFloat16_ref(&bias, scale_bias + 1, 1, true /* clip */);
     }
@@ -468,6 +1317,12 @@ TEST_P(FusedNBitRowwiseEmbeddingLookupTest, rowwiseSparseTest) {
         (use_offsets ? offsets : lengths).data();
     const int32_t* offsets_or_lengths_32 =
         (use_offsets ? offsets_32 : lengths_32).data();
+
+    if (is_sve_fp16_enabled()) {
+      for (auto& w : weights) {
+        w = abs(w);
+      }
+    }
 
     vector<float> output_sls_ref(batch_size * embedding_dim);
     vector<float> output_slws_ref(output_sls_ref.size()),


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2658


## Overview

Add an SVE/NEON FP16 kernel for N-bit (2-bit/4-bit) quantized sparse embedding lookup on ARM, gated behind the `FBGEMM_TBE_SVE_FP16_ACCUMULATOR=1` runtime flag. The kernel is dispatched only when the output type is fp16 (OutType == uint16_t, !is_bf16_out), where fp16 accumulation precision is acceptable.

For `dims ≤ 64 (iters <= 8)`, accumulates entirely in NEON fp16 registers with 2-way unrolling (two embeddings per iteration), then stores directly via `vst1q_f16` — no intermediate buffer, no fp32 widening. `dims < 8 (iters == 0)` fall through to the buf-based path which handles sub-8-element tails correctly.

NBit values are unpacked via `unpack_4bit_to_fp16_neon` (SVE zip-based) and `unpack_2bit_to_fp16_neon` (NEON table-based) before the FMA.


## Result
## N-Bit Kernel with FP16 Output: Autovec vs SVE FP16 Register (direct store)

**Output type:** fp16 (`-DOUT_TYPE_FLOAT16`)

The autovec baseline accumulates in fp16 via a scratch buffer with fp16→fp32→fp16
round-trip for output. The SVE FP16 register path accumulates in NEON fp16
registers and stores directly with `vst1q_f16`.

### 4-Bit Results

#### SLS

| Dim | Cache | Prefetch | Autovec | FP16 Reg | Speedup |
|-----|-------|----------|---------|----------|---------|
| 32 | Hot | Off | 2.22 | 5.40 | **2.44x** |
| 32 | Hot | On | 2.18 | 5.31 | **2.44x** |
| 32 | Cold | Off | 0.67 | 1.01 | **1.51x** |
| 32 | Cold | On | 0.72 | 0.98 | **1.37x** |
| 48 | Hot | Off | 2.83 | 4.99 | **1.76x** |
| 48 | Hot | On | 2.83 | 4.86 | **1.72x** |
| 48 | Cold | Off | 1.04 | 1.20 | **1.15x** |
| 48 | Cold | On | 1.05 | 1.19 | **1.14x** |
| 56 | Hot | Off | 4.06 | 5.14 | **1.27x** |
| 56 | Hot | On | 4.06 | 5.16 | **1.27x** |
| 56 | Cold | Off | 2.29 | 2.09 | 0.91x |
| 56 | Cold | On | 0.85 | 2.08 | **2.45x** |
| 64 | Hot | Off | 3.05 | 5.16 | **1.69x** |
| 64 | Hot | On | 3.04 | 5.13 | **1.68x** |
| 64 | Cold | Off | 1.37 | 1.48 | 1.08x |
| 64 | Cold | On | 1.23 | 1.44 | **1.16x** |
| 80 | Hot | Off | 2.93 | 3.78 | **1.29x** |
| 80 | Hot | On | 2.99 | 3.85 | **1.29x** |
| 80 | Cold | Off | 1.34 | 1.63 | **1.22x** |
| 80 | Cold | On | 1.16 | 1.61 | **1.38x** |
| 96 | Hot | Off | 3.03 | 3.81 | **1.26x** |
| 96 | Hot | On | 3.04 | 3.81 | **1.25x** |
| 96 | Cold | Off | 1.58 | 2.55 | **1.61x** |
| 96 | Cold | On | 1.45 | 1.88 | **1.29x** |
| 104 | Hot | Off | 2.79 | 3.67 | **1.31x** |
| 104 | Hot | On | 2.79 | 3.64 | **1.31x** |
| 104 | Cold | Off | 1.47 | 1.98 | **1.35x** |
| 104 | Cold | On | 1.54 | 2.01 | **1.31x** |
| 128 | Hot | Off | 3.80 | 4.19 | **1.10x** |
| 128 | Hot | On | 3.80 | 4.19 | **1.10x** |
| 128 | Cold | Off | 1.82 | 1.64 | 0.90x |
| 128 | Cold | On | 1.79 | 1.64 | 0.92x |
| 192 | Hot | Off | 3.02 | 3.54 | **1.17x** |
| 192 | Hot | On | 3.02 | 3.54 | **1.17x** |
| 192 | Cold | Off | 2.59 | 2.79 | 1.07x |
| 192 | Cold | On | 2.57 | 2.89 | **1.12x** |
| 256 | Hot | Off | 3.05 | 3.57 | **1.17x** |
| 256 | Hot | On | 3.06 | 3.58 | **1.17x** |
| 256 | Cold | Off | 2.83 | 2.97 | 1.05x |
| 256 | Cold | On | 2.79 | 2.93 | 1.05x |
| 512 | Hot | Off | 3.04 | 5.53 | **1.82x** |
| 512 | Hot | On | 3.02 | 5.52 | **1.83x** |
| 512 | Cold | Off | 2.89 | 3.31 | **1.15x** |
| 512 | Cold | On | 2.89 | 3.31 | **1.14x** |
| 1024 | Hot | Off | 3.01 | 5.18 | **1.72x** |
| 1024 | Hot | On | 3.01 | 5.43 | **1.81x** |
| 1024 | Cold | Off | 2.84 | 3.69 | **1.30x** |
| 1024 | Cold | On | 2.74 | 3.65 | **1.33x** |

### 4-Bit Results

#### SLW

| Dim | Cache | Prefetch | Autovec | FP16 Reg | Speedup |
|-----|-------|----------|---------|----------|---------|
| 32 | Hot | Off | 2.03 | 4.41 | **2.17x** |
| 32 | Hot | On | 2.04 | 4.52 | **2.22x** |
| 32 | Cold | Off | 0.70 | 0.98 | **1.39x** |
| 32 | Cold | On | 0.67 | 1.01 | **1.50x** |
| 48 | Hot | Off | 2.75 | 4.52 | **1.64x** |
| 48 | Hot | On | 2.75 | 4.51 | **1.64x** |
| 48 | Cold | Off | 0.97 | 1.18 | **1.22x** |
| 48 | Cold | On | 0.97 | 1.30 | **1.34x** |
| 56 | Hot | Off | 3.71 | 4.77 | **1.29x** |
| 56 | Hot | On | 3.73 | 4.80 | **1.29x** |
| 56 | Cold | Off | 2.11 | 2.02 | 0.95x |
| 56 | Cold | On | 2.08 | 2.02 | 0.97x |
| 64 | Hot | Off | 2.90 | 4.65 | **1.60x** |
| 64 | Hot | On | 2.90 | 4.65 | **1.60x** |
| 64 | Cold | Off | 1.41 | 1.60 | **1.13x** |
| 64 | Cold | On | 1.30 | 1.58 | **1.21x** |
| 80 | Hot | Off | 2.87 | 3.69 | **1.29x** |
| 80 | Hot | On | 2.87 | 3.70 | **1.29x** |
| 80 | Cold | Off | 1.37 | 1.68 | **1.23x** |
| 80 | Cold | On | 1.48 | 1.65 | **1.12x** |
| 96 | Hot | Off | 2.93 | 3.79 | **1.29x** |
| 96 | Hot | On | 2.94 | 3.80 | **1.29x** |
| 96 | Cold | Off | 1.74 | 2.39 | **1.37x** |
| 96 | Cold | On | 1.41 | 2.32 | **1.65x** |
| 104 | Hot | Off | 2.76 | 3.63 | **1.31x** |
| 104  | Hot | On | 2.77 | 3.61 | **1.31x** |
| 104| Cold | Off | 1.33 | 1.94 | **1.46x** |
| 104 | Cold | On | 1.44 | 2.07 | **1.43x** |
| 128 | Hot | Off | 3.85 | 4.08 | 1.06x |
| 128 | Hot | On | 3.85 | 4.07 | 1.06x |
| 128 | Cold | Off | 1.68 | 1.64 | 0.98x |
| 128 | Cold | On | 1.67 | 1.64 | 0.98x |
| 192 | Hot | Off | 2.95 | 3.51 | **1.19x** |
| 192 | Hot | On | 2.95 | 3.51 | **1.19x** |
| 192 | Cold | Off | 2.49 | 2.87 | **1.15x** |
| 192 | Cold | On | 2.47 | 2.68 | 1.08x |
| 256 | Hot | Off | 3.05 | 3.44 | **1.13x** |
| 256 | Hot | On | 3.03 | 3.42 | **1.13x** |
| 256 | Cold | Off | 2.77 | 3.00 | 1.08x |
| 256 | Cold | On | 2.75 | 2.98 | 1.09x |
| 512 | Hot | Off | 3.03 | 5.36 | **1.77x** |
| 512 | Hot | On | 3.03 | 5.33 | **1.76x** |
| 512 | Cold | Off | 2.85 | 3.43 | **1.21x** |
| 512 | Cold | On | 2.86 | 3.45 | **1.21x** |
| 1024 | Hot | Off | 2.99 | 5.13 | **1.71x** |
| 1024  | Hot | On | 3.00 | 5.34 | **1.78x** |
| 1024  | Cold | Off | 2.80 | 3.70 | **1.32x** |
| 1024  | Cold | On | 2.79 | 3.66 | **1.31x** |

### 2-Bit Results

#### SLS

| Dim | Cache | Prefetch | Autovec | FP16 Reg | Speedup |
|-----|-------|----------|---------|----------|---------|
| 32 | Hot | Off | 0.97 | 2.40 | **2.49x** |
| 32 | Hot | On | 0.98 | 2.39 | **2.45x** |
| 32 | Cold | Off | 0.43 | 0.59 | **1.37x** |
| 32 | Cold | On | 0.46 | 0.62 | **1.33x** |
| 48  | Hot | Off | 0.93 | 2.46 | **2.66x** |
| 48  | Hot | On | 0.89 | 2.46 | **2.77x** |
| 48  | Cold | Off | 0.87 | 1.00 | **1.16x** |
| 48  | Cold | On | 0.88 | 1.01 | **1.14x** |
| 56 | Hot | Off | 0.93 | 2.40 | **2.60x** |
| 56 | Hot | On | 0.93 | 2.39 | **2.58x** |
| 56 | Cold | Off | 0.48 | 0.72 | **1.52x** |
| 56 | Cold | On | 0.44 | 0.73 | **1.64x** |
| 64 | Hot | Off | 0.90 | 2.41 | **2.69x** |
| 64 | Hot | On | 0.90 | 2.43 | **2.70x** |
| 64 | Cold | Off | 0.44 | 0.75 | **1.68x** |
| 64 | Cold | On | 0.51 | 0.83 | **1.63x** |
| 80  | Hot | Off | 0.88 | 1.65 | **1.87x** |
| 80 | Hot | On | 0.88 | 1.64 | **1.87x** |
| 80  | Cold | Off | 0.44 | 0.80 | **1.85x** |
| 80  | Cold | On | 0.54 | 0.74 | **1.39x** |
| 96 | Hot | Off | 0.87 | 1.60 | **1.84x** |
| 96 | Hot | On | 0.87 | 1.59 | **1.83x** |
| 96 | Cold | Off | 0.56 | 0.75 | **1.34x** |
| 96 | Cold | On | 0.63 | 0.85 | **1.36x** |
| 104  | Hot | Off | 0.83 | 1.66 | **2.00x** |
| 104  | Hot | On | 0.85 | 1.66 | **1.95x** |
| 104  | Cold | Off | 0.57 | 0.89 | **1.57x** |
| 104  | Cold | On | 0.68 | 0.88 | **1.29x** |
| 128 | Hot | Off | 0.85 | 1.40 | **1.65x** |
| 128 | Hot | On | 0.86 | 1.41 | **1.64x** |
| 128 | Cold | Off | 0.69 | 0.96 | **1.40x** |
| 128 | Cold | On | 0.66 | 0.96 | **1.44x** |
| 192  | Hot | Off | 0.80 | 1.64 | **2.05x** |
| 192  | Hot | On | 0.82 | 1.65 | **2.02x** |
| 192  | Cold | Off | 0.76 | 1.38 | **1.82x** |
| 192  | Cold | On | 0.71 | 1.20 | **1.70x** |
| 256 | Hot | Off | 0.83 | 1.60 | **1.93x** |
| 256 | Hot | On | 0.83 | 1.61 | **1.93x** |
| 256 | Cold | Off | 0.81 | 1.50 | **1.85x** |
| 256 | Cold | On | 0.82 | 1.50 | **1.84x** |
| 512 | Hot | Off | 0.80 | 1.96 | **2.45x** |
| 512 | Hot | On | 0.80 | 1.95 | **2.45x** |
| 512 | Cold | Off | 0.81 | 1.85 | **2.30x** |
| 512 | Cold | On | 0.81 | 1.89 | **2.33x** |
| 1024 | Hot | Off | 0.78 | 1.94 | **2.48x** |
| 1024 | Hot | On | 0.79 | 1.93 | **2.43x** |
| 1024 | Cold | Off | 0.80 | 1.87 | **2.33x** |
| 1024 | Cold | On | 0.80 | 1.87 | **2.33x** |

### 2-Bit Results

#### SLW

| Dim | Cache | Prefetch | Autovec | FP16 Reg | Speedup |
|-----|-------|----------|---------|----------|---------|
| 32 | Hot | Off | 0.97 | 2.15 | **2.22x** |
| 32 | Hot | On | 0.96 | 2.14 | **2.22x** |
| 32 | Cold | Off | 0.42 | 0.55 | **1.30x** |
| 32 | Cold | On | 0.43 | 0.58 | **1.34x** |
| 48 | Hot | Off | 0.92 | 2.21 | **2.40x** |
| 48 | Hot | On | 0.93 | 2.20 | **2.37x** |
| 48 | Cold | Off | 0.88 | 1.02 | **1.16x** |
| 48 | Cold | On | 0.88 | 1.00 | **1.14x** |
| 56 | Hot | Off | 0.91 | 2.22 | **2.43x** |
| 56 | Hot | On | 0.91 | 2.22 | **2.43x** |
| 56 | Cold | Off | 0.46 | 0.73 | **1.57x** |
| 56 | Cold | On | 0.43 | 0.66 | **1.51x** |
| 64 | Hot | Off | 0.90 | 2.27 | **2.54x** |
| 64 | Hot | On | 0.88 | 2.26 | **2.59x** |
| 64 | Cold | Off | 0.48 | 0.71 | **1.47x** |
| 64 | Cold | On | 0.14 | 0.71 | **5.25x** |
| 80 | Hot | Off | 0.88 | 1.61 | **1.83x** |
| 80 | Hot | On | 0.89 | 1.61 | **1.82x** |
| 80 | Cold | Off | 0.49 | 0.72 | **1.48x** |
| 80 | Cold | On | 0.52 | 0.73 | **1.41x** |
| 96 | Hot | Off | 0.88 | 1.56 | **1.78x** |
| 96 | Hot | On | 0.87 | 1.54 | **1.78x** |
| 96 | Cold | Off | 0.58 | 0.81 | **1.39x** |
| 96 | Cold | On | 0.60 | 0.85 | **1.41x** |
| 104 | Hot | Off | 0.85 | 1.60 | **1.88x** |
| 104 | Hot | On | 0.87 | 1.61 | **1.85x** |
| 104 | Cold | Off | 0.61 | 0.84 | **1.38x** |
| 104 | Cold | On | 0.65 | 0.91 | **1.40x** |
| 128 | Hot | Off | 0.84 | 1.40 | **1.66x** |
| 128 | Hot | On | 0.86 | 1.39 | **1.62x** |
| 128 | Cold | Off | 0.62 | 0.91 | **1.48x** |
| 128 | Cold | On | 0.67 | 1.03 | **1.54x** |
| 192 | Hot | Off | 0.82 | 1.60 | **1.96x** |
| 192 | Hot | On | 0.84 | 1.60 | **1.91x** |
| 192 | Cold | Off | 0.74 | 1.24 | **1.66x** |
| 192 | Cold | On | 0.69 | 1.26 | **1.84x** |
| 256 | Hot | Off | 0.80 | 1.58 | **1.99x** |
| 256 | Hot | On | 0.78 | 1.56 | **2.01x** |
| 256 | Cold | Off | 0.81 | 1.47 | **1.82x** |
| 256 | Cold | On | 0.81 | 1.48 | **1.83x** |
| 512 | Hot | Off | 0.81 | 1.93 | **2.38x** |
| 512 | Hot | On | 0.80 | 1.93 | **2.40x** |
| 512 | Cold | Off | 0.81 | 1.85 | **2.29x** |
| 512 | Cold | On | 0.81 | 1.84 | **2.28x** |
| 1024 | Hot | Off | 0.78 | 1.92 | **2.46x** |
| 1024 | Hot | On | 0.78 | 1.92 | **2.46x** |
| 1024 | Cold | Off | 0.80 | 1.86 | **2.32x** |
| 1024 | Cold | On | 0.79 | 1.86 | **2.34x** |

### N-Bit FP16 Output Average Speedup (SVE FP16 vs Autovec)

| Bit Rate | Cache | SLS | SLW |
|----------|-------|-----|-----|
| 4 | Hot | **1.50x** | **1.46x** |
| 4 | Cold | **1.25x** | **1.22x** |
| 2 | Hot | **2.22x** | **2.12x** |
| 2 | Cold | **1.59x** | **1.78x** |

Reviewed By: helloguo

Differential Revision: D99165466


