### PR TITLE
Add KVZCH inference read-time hit rate metrics via fb303 ODS counters (#5730)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/cache/kv_embedding_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/cache/kv_embedding_ops_inference.py
@@ -341,6 +341,18 @@ class KVEmbeddingInference(IntNBitTableBatchedEmbeddingBagsCodegen):
         self.kv_embedding_cache.log_inplace_update_stats()
 
     @torch.jit.export
+    def get_read_hit_rate_stats(
+        self,
+    ) -> tuple[int, int, int]:
+        """
+        Get read-time (forward pass) hit rate stats from the DRAM KV cache.
+        Returns (hit_count, miss_count, total_count) since last call.
+        Counters are reset atomically on each call.
+        """
+        stats = self.kv_embedding_cache.get_read_hit_rate_stats()
+        return int(stats[0]), int(stats[1]), int(stats[2])
+
+    @torch.jit.export
     def embedding_trigger_evict(
         self,
         inplace_update_ts_sec: int,

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/InferenceSynchronizedShardedMap.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/InferenceSynchronizedShardedMap.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "SynchronizedShardedMap.h"
+#include "inference_fixed_block_pool.h"
+
+namespace kv_mem {
+
+/// @ingroup embedding-dram-kvstore
+///
+/// @brief Sharded synchronized hashmap for inference workloads.
+///
+/// Type alias for SynchronizedShardedMap using InferenceFixedBlockPool with
+/// 12-byte MetaHeader for memory efficiency. This saves 4 bytes per embedding
+/// compared to the standard SynchronizedShardedMap.
+///
+/// Example:
+///    InferenceSynchronizedShardedMap<std::string, int> map;
+///    wlmap = map.by(shard_id).wlock();
+///    wlmap[topic] = 19;
+///
+template <typename K, typename V, typename M = folly::SharedMutexWritePriority>
+using InferenceSynchronizedShardedMap =
+    SynchronizedShardedMap<K, V, M, InferenceFixedBlockPool>;
+
+} // namespace kv_mem

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/SynchronizedShardedMap.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/SynchronizedShardedMap.h
@@ -26,9 +26,24 @@ namespace kv_mem {
 //    wlmap = map.by(shard_id).wlock();
 //    wlmap[topic] = 19;
 //
-template <typename K, typename V, typename M = folly::SharedMutexWritePriority>
+// Template parameters:
+//   K - Key type
+//   V - Value type
+//   M - Mutex type (default: folly::SharedMutexWritePriority)
+//   PoolType - Memory pool type (default: FixedBlockPool). Use
+//              InferenceFixedBlockPool for inference workloads with 12-byte
+//              MetaHeader.
+//
+template <
+    typename K,
+    typename V,
+    typename M = folly::SharedMutexWritePriority,
+    typename PoolType = FixedBlockPool>
 class SynchronizedShardedMap {
  public:
+  using iterator = typename folly::F14FastMap<K, V>::const_iterator;
+  using pool_type = PoolType;
+
   explicit SynchronizedShardedMap(
       std::size_t numShards,
       std::size_t block_size,
@@ -37,7 +52,7 @@ class SynchronizedShardedMap {
       : shards_(numShards), mempools_(numShards) {
     // Init mempools_
     for (auto& pool : mempools_) {
-      pool = std::make_unique<kv_mem::FixedBlockPool>(
+      pool = std::make_unique<PoolType>(
           block_size, block_alignment, blocks_per_chunk);
     }
   }
@@ -48,7 +63,7 @@ class SynchronizedShardedMap {
   }
 
   // Get shard pool by index
-  auto* pool_by(int index) {
+  PoolType* pool_by(int index) {
     return mempools_.at(index % shards_.size()).get();
   }
 
@@ -87,8 +102,8 @@ class SynchronizedShardedMap {
     return num_rows;
   }
 
- private:
+ protected:
   std::vector<folly::Synchronized<folly::F14FastMap<K, V>, M>> shards_;
-  std::vector<std::unique_ptr<FixedBlockPool>> mempools_;
+  std::vector<std::unique_ptr<PoolType>> mempools_;
 };
 } // namespace kv_mem

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.cpp
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.cpp
@@ -142,6 +142,11 @@ void DramKVEmbeddingInferenceWrapper::log_inplace_update_stats() {
   kv_backend_->log_inplace_update_stats();
 }
 
+std::vector<int64_t>
+DramKVEmbeddingInferenceWrapper::get_read_hit_rate_stats() {
+  return kv_backend_->get_read_hit_rate_stats();
+}
+
 void DramKVEmbeddingInferenceWrapper::trigger_evict(
     int64_t inplace_update_ts_64b) {
   uint32_t inplace_update_ts_32b =
@@ -219,6 +224,10 @@ static auto dram_kv_embedding_inference_wrapper =
             "log_inplace_update_stats",
             &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::
                 log_inplace_update_stats)
+        .def(
+            "get_read_hit_rate_stats",
+            &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::
+                get_read_hit_rate_stats)
         .def(
             "serialize",
             &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::serialize)

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.h
@@ -43,6 +43,8 @@ class DramKVEmbeddingInferenceWrapper : public torch::jit::CustomClassHolder {
 
   void log_inplace_update_stats();
 
+  std::vector<int64_t> get_read_hit_rate_stats();
+
   void trigger_evict(int64_t inplace_update_ts_64b);
 
   void wait_evict_completion();

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_inference_embedding.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_inference_embedding.h
@@ -11,6 +11,7 @@
 #include <caffe2/torch/fb/distributed/wireSerializer/WireSerializer.h>
 #include <common/base/Proc.h>
 #include <common/stats/Stats.h>
+#include <fb303/ServiceData.h>
 #include <folly/SocketAddress.h>
 #include <folly/coro/BlockingWait.h>
 #include <folly/coro/Collect.h>
@@ -18,6 +19,7 @@
 #include <folly/coro/Task.h>
 #include <folly/executors/FunctionScheduler.h>
 #include <folly/logging/xlog.h>
+#include <folly/synchronization/CallOnce.h>
 #include <servicerouter/client/cpp2/ServiceRouter.h>
 #include <thrift/lib/cpp2/protocol/CompactProtocol.h>
 #include <thrift/lib/cpp2/protocol/Serializer.h>
@@ -154,6 +156,18 @@ class DramKVInferenceEmbedding
       feature_evict_ = create_inference_feature_evict(
           feature_evict_config_.value(), kv_store_, sub_table_hash_cumsum_);
     }
+    // Register fb303 export types once per process so the read hit-rate
+    // counters surface in ODS as time-series (e.g. *.sum.60) rather than
+    // raw values that ODS / fbagent will not scrape.
+    static folly::once_flag readHitRateExportFlag;
+    folly::call_once(readHitRateExportFlag, [] {
+      facebook::fb303::fbData->addStatExportType(
+          "kvzch.inference.read_hit_count", facebook::fb303::SUM);
+      facebook::fb303::fbData->addStatExportType(
+          "kvzch.inference.read_miss_count", facebook::fb303::SUM);
+      facebook::fb303::fbData->addStatExportType(
+          "kvzch.inference.read_total_count", facebook::fb303::SUM);
+    });
     LOG(INFO) << "DramKVInferenceEmbedding initialized: disable_random_init "
               << disable_random_init_;
   }
@@ -381,8 +395,8 @@ class DramKVInferenceEmbedding
     // iteration(excluding state_dict)
     auto start_ts = facebook::WallClockUtil::NowInUsecFast();
     pause_ongoing_eviction(); // noop calls, no impact if called multiple times
-    std::vector<
-        folly::Future<std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t>>>
+    std::vector<folly::Future<
+        std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t>>>
         futures;
     auto row_width = weights.size(1);
     auto copy_width = width_length.value_or(row_width);
@@ -408,6 +422,7 @@ class DramKVInferenceEmbedding
                 int64_t local_read_lookup_cache_total_duration = 0;
                 int64_t local_read_aquire_lock_duration = 0;
                 int64_t local_read_missing_load = 0;
+                int64_t local_read_hit_load = 0;
                 FBGEMM_DISPATCH_INTEGRAL_TYPES(
                     indices.scalar_type(),
                     "get_kv_db_async_impl",
@@ -422,7 +437,8 @@ class DramKVInferenceEmbedding
                      &local_read_fill_row_storage_total_duration,
                      &local_read_lookup_cache_total_duration,
                      &local_read_aquire_lock_duration,
-                     &local_read_missing_load] {
+                     &local_read_missing_load,
+                     &local_read_hit_load] {
                       using index_t = scalar_t;
                       CHECK(indices.is_contiguous());
                       CHECK(weights.is_contiguous());
@@ -501,6 +517,7 @@ class DramKVInferenceEmbedding
                           local_read_cache_hit_copy_total_duration +=
                               facebook::WallClockUtil::NowInUsecFast() -
                               before_cache_hit_copy_ts;
+                          local_read_hit_load++;
                         }
                       }
                     });
@@ -509,7 +526,8 @@ class DramKVInferenceEmbedding
                     local_read_fill_row_storage_total_duration,
                     local_read_cache_hit_copy_total_duration,
                     local_read_aquire_lock_duration,
-                    local_read_missing_load};
+                    local_read_missing_load,
+                    local_read_hit_load};
               }));
     }
 
@@ -521,20 +539,23 @@ class DramKVInferenceEmbedding
                            int64_t,
                            int64_t,
                            int64_t,
+                           int64_t,
                            int64_t>>& results) {
           int64_t read_lookup_cache_total_duration = 0;
           int64_t read_fill_row_storage_total_duration = 0;
           int64_t read_cache_hit_copy_total_duration = 0;
           int64_t read_acquire_lock_total_duration = 0;
           int64_t read_missing_load = 0;
+          int64_t read_hit_load = 0;
           for (
-              const auto& [lookup_cache_dur, fill_row_storage_dur, cache_hit_copy_dur, acquire_lock_dur, missing_load] :
+              const auto& [lookup_cache_dur, fill_row_storage_dur, cache_hit_copy_dur, acquire_lock_dur, missing_load, hit_load] :
               results) {
             read_lookup_cache_total_duration += lookup_cache_dur;
             read_fill_row_storage_total_duration += fill_row_storage_dur;
             read_cache_hit_copy_total_duration += cache_hit_copy_dur;
             read_acquire_lock_total_duration += acquire_lock_dur;
             read_missing_load += missing_load;
+            read_hit_load += hit_load;
           }
           auto duration = facebook::WallClockUtil::NowInUsecFast() - start_ts;
           read_total_duration_ += duration;
@@ -547,6 +568,15 @@ class DramKVInferenceEmbedding
           read_acquire_lock_avg_duration_ +=
               read_acquire_lock_total_duration / num_shards_;
           read_missing_load_avg_ += read_missing_load / num_shards_;
+          read_hit_count_ += read_hit_load;
+          read_miss_count_ += read_missing_load;
+          facebook::fb303::fbData->addStatValue(
+              "kvzch.inference.read_hit_count", read_hit_load);
+          facebook::fb303::fbData->addStatValue(
+              "kvzch.inference.read_miss_count", read_missing_load);
+          facebook::fb303::fbData->addStatValue(
+              "kvzch.inference.read_total_count",
+              read_hit_load + read_missing_load);
           return std::vector<folly::Unit>(results.size());
         });
   };
@@ -661,6 +691,13 @@ class DramKVInferenceEmbedding
         << ", miss count: " << inplace_update_miss_cnt
         << ", total count: " << total_cnt << ", hit ratio: "
         << (total_cnt > 0 ? (double)inplace_update_hit_cnt / total_cnt : 0.0);
+  }
+
+  std::vector<int64_t> get_read_hit_rate_stats() override {
+    int reset_val = 0;
+    auto hit = read_hit_count_.exchange(reset_val);
+    auto miss = read_miss_count_.exchange(reset_val);
+    return {hit, miss, hit + miss};
   }
 
   std::optional<FeatureEvictMetricTensors> get_feature_evict_metric()
@@ -916,6 +953,9 @@ class DramKVInferenceEmbedding
 
   std::atomic<int64_t> inplace_update_hit_cnt_{0};
   std::atomic<int64_t> inplace_update_miss_cnt_{0};
+
+  std::atomic<int64_t> read_hit_count_{0};
+  std::atomic<int64_t> read_miss_count_{0};
 }; // class DramKVInferenceEmbedding
 
 } // namespace kv_mem

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_inference_embedding.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_inference_embedding.h
@@ -25,11 +25,11 @@
 #include "common/time/Time.h"
 
 #include "../ssd_split_embeddings_cache/initializer.h"
-#include "SynchronizedShardedMap.h"
+#include "InferenceSynchronizedShardedMap.h"
 #include "fbgemm_gpu/split_embeddings_cache/kv_db_cpp_utils.h"
 #include "fbgemm_gpu/utils/dispatch_macros.h"
-#include "feature_evict.h"
-#include "fixed_block_pool.h"
+#include "inference_feature_evict.h"
+#include "inference_fixed_block_pool.h"
 #include "kv_inference_embedding_interface.h"
 
 namespace kv_mem {
@@ -113,11 +113,12 @@ class DramKVInferenceEmbedding
       bool disable_random_init = false)
       : max_D_(max_D),
         num_shards_(num_shards),
-        block_size_(FixedBlockPool::calculate_block_size<weight_type>(max_D)),
+        block_size_(
+            InferenceFixedBlockPool::calculate_block_size<weight_type>(max_D)),
         block_alignment_(
-            FixedBlockPool::calculate_block_alignment<weight_type>()),
+            InferenceFixedBlockPool::calculate_block_alignment<weight_type>()),
         kv_store_(
-            SynchronizedShardedMap<int64_t, weight_type*>(
+            InferenceSynchronizedShardedMap<int64_t, weight_type*>(
                 num_shards_,
                 block_size_,
                 block_alignment_,
@@ -150,11 +151,8 @@ class DramKVInferenceEmbedding
         feature_evict_config_.value()->trigger_mode_ !=
             EvictTriggerMode::DISABLED) {
       TORCH_CHECK(hash_size_cumsum.has_value());
-      feature_evict_ = create_feature_evict(
-          feature_evict_config_.value(),
-          kv_store_,
-          sub_table_hash_cumsum_,
-          false /* is_train */);
+      feature_evict_ = create_inference_feature_evict(
+          feature_evict_config_.value(), kv_store_, sub_table_hash_cumsum_);
     }
     LOG(INFO) << "DramKVInferenceEmbedding initialized: disable_random_init "
               << disable_random_init_;
@@ -269,7 +267,8 @@ class DramKVInferenceEmbedding
                         // we find QE regress during inplace update
                         for (auto& [tensor_offset, block] : hit_info) {
                           auto* data_ptr =
-                              FixedBlockPool::data_ptr<weight_type>(block);
+                              InferenceFixedBlockPool::data_ptr<weight_type>(
+                                  block);
                           std::copy(
                               weights_data_ptr + tensor_offset * stride,
                               weights_data_ptr + (tensor_offset + 1) * stride,
@@ -279,7 +278,7 @@ class DramKVInferenceEmbedding
                               feature_evict_config_.value()->trigger_mode_ !=
                                   EvictTriggerMode::DISABLED &&
                               feature_evict_ && inplace_update_ts.has_value()) {
-                            FixedBlockPool::set_timestamp(
+                            InferenceFixedBlockPool::set_timestamp(
                                 block, inplace_update_ts.value());
                           }
                         }
@@ -294,11 +293,12 @@ class DramKVInferenceEmbedding
                         auto mem_pool_lock = pool->acquire_lock();
                         for (auto& [id, tensor_offset] : miss_info) {
                           auto block = pool->template allocate_t<weight_type>();
-                          FixedBlockPool::set_key(block, id);
+                          InferenceFixedBlockPool::set_key(block, id);
                           temp_kv.insert({id, block});
 
                           auto* data_ptr =
-                              FixedBlockPool::data_ptr<weight_type>(block);
+                              InferenceFixedBlockPool::data_ptr<weight_type>(
+                                  block);
                           std::copy(
                               weights_data_ptr + tensor_offset * stride,
                               weights_data_ptr + (tensor_offset + 1) * stride,
@@ -310,7 +310,7 @@ class DramKVInferenceEmbedding
                                   EvictTriggerMode::DISABLED &&
                               feature_evict_) {
                             if (inplace_update_ts.has_value()) {
-                              FixedBlockPool::set_timestamp(
+                              InferenceFixedBlockPool::set_timestamp(
                                   block, inplace_update_ts.value());
                             } else {
                               // inplace_update_ts is nullopt for delta publish
@@ -440,7 +440,7 @@ class DramKVInferenceEmbedding
 
                       if (!wlmap->empty() && !disable_random_init_) {
                         row_storage_data_ptr =
-                            FixedBlockPool::data_ptr<weight_type>(
+                            InferenceFixedBlockPool::data_ptr<weight_type>(
                                 wlmap->begin()->second);
                       } else {
                         const auto& init_storage =
@@ -488,7 +488,7 @@ class DramKVInferenceEmbedding
                           }
                           // use mempool
                           const auto* data_ptr =
-                              FixedBlockPool::data_ptr<weight_type>(
+                              InferenceFixedBlockPool::data_ptr<weight_type>(
                                   cached_iter->second);
                           auto before_cache_hit_copy_ts =
                               facebook::WallClockUtil::NowInUsecFast();
@@ -879,7 +879,7 @@ class DramKVInferenceEmbedding
   // mempool params
   size_t block_size_;
   size_t block_alignment_;
-  SynchronizedShardedMap<int64_t, weight_type*> kv_store_;
+  InferenceSynchronizedShardedMap<int64_t, weight_type*> kv_store_;
   std::atomic_bool is_eviction_ongoing_ = false;
   std::vector<std::unique_ptr<ssd::Initializer>> initializers_;
   int64_t elem_size_;

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/feature_evict.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/feature_evict.h
@@ -684,7 +684,7 @@ class FeatureEvict {
   }
 
   // the inner loop of each evict that can be paused
-  void start_inference_eviction_loop(
+  virtual void start_inference_eviction_loop(
       int shard_id,
       std::vector<int64_t>& evicted_counts,
       std::vector<int64_t>& processed_counts) {
@@ -1405,7 +1405,6 @@ class TimeThresholdBasedEvict : public FeatureEvict<weight_type> {
     return FixedBlockPool::get_timestamp(block) < eviction_timestamp_threshold_;
   }
 
- private:
   std::atomic<uint32_t> eviction_timestamp_threshold_{0};
 };
 

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/fixed_block_pool.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/fixed_block_pool.h
@@ -163,7 +163,7 @@ class FixedBlockPool : public std::pmr::memory_resource {
 
   template <typename scalar_t>
   static scalar_t get_l2weight(scalar_t* block, size_t dimension) {
-    scalar_t* data = FixedBlockPool::data_ptr(block);
+    scalar_t* data = data_ptr(block);
     return std::sqrt(
         std::accumulate(
             data,
@@ -250,7 +250,7 @@ class FixedBlockPool : public std::pmr::memory_resource {
     char* current_chunk =
         static_cast<char*>(chunks_[index / blocks_per_chunk_].ptr);
     char* block = current_chunk + block_size_ * (index % blocks_per_chunk_);
-    if (FixedBlockPool::get_used(block)) {
+    if (get_used(block)) {
       return reinterpret_cast<scalar_t*>(block);
     } else {
       return nullptr;
@@ -299,9 +299,9 @@ class FixedBlockPool : public std::pmr::memory_resource {
     // Take a block from the head of the free list
     void* result = free_list_;
     free_list_ = *static_cast<void**>(free_list_);
-    FixedBlockPool::set_used(result, true);
-    FixedBlockPool::set_count(result, 0);
-    FixedBlockPool::update_timestamp(result);
+    set_used(result, true);
+    set_count(result, 0);
+    update_timestamp(result);
     return result;
   }
 
@@ -313,7 +313,7 @@ class FixedBlockPool : public std::pmr::memory_resource {
     // Insert memory block back to the head of free list
     *static_cast<void**>(p) = free_list_;
     free_list_ = p;
-    FixedBlockPool::set_used(free_list_, false);
+    set_used(free_list_, false);
   }
 
   // Resource equality comparison (only the same object is equal)
@@ -322,9 +322,9 @@ class FixedBlockPool : public std::pmr::memory_resource {
     return this == &other;
   }
 
- private:
-  // Allocate a new memory chunk
-  void allocate_chunk() {
+  // Allocate a new memory chunk (virtual to allow subclasses to customize
+  // block initialization)
+  virtual void allocate_chunk() {
     const std::size_t chunk_size = block_size_ * blocks_per_chunk_;
 
     // Allocate aligned memory through upstream resource
@@ -342,12 +342,12 @@ class FixedBlockPool : public std::pmr::memory_resource {
     for (std::size_t i = 0; i < blocks_per_chunk_; ++i) {
       current -= block_size_;
       *reinterpret_cast<void**>(current) = free_list_;
-      FixedBlockPool::set_used(current, false);
+      set_used(current, false);
       free_list_ = current;
     }
   }
 
-  // Member variables
+  // Member variables (protected for subclass access in allocate_chunk override)
   const std::size_t block_size_; // Block size (not less than pointer size)
   const std::size_t block_alignment_; // Block alignment requirement
   const std::size_t blocks_per_chunk_; // Number of blocks per chunk
@@ -356,6 +356,7 @@ class FixedBlockPool : public std::pmr::memory_resource {
   void* free_list_ = nullptr; // Free block list head pointer
   mutable std::mutex chunks_mutex_; // Mutex for chunks_
 
+ private:
   // block pool lock, only used on the inference side to guard in-place update
   // and eviction exclusive update, this is needed to reduce locking time for
   // better inference qps

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/inference_feature_evict.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/inference_feature_evict.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "InferenceSynchronizedShardedMap.h"
+#include "feature_evict.h"
+#include "inference_fixed_block_pool.h"
+
+namespace kv_mem {
+
+/// @brief TimeThresholdBasedEvict specialized for inference with 12-byte header
+///
+/// Extends TimeThresholdBasedEvict but overrides methods to work with
+/// InferenceFixedBlockPool's 12-byte header layout.
+template <typename weight_type>
+class InferenceTimeThresholdBasedEvict
+    : public TimeThresholdBasedEvict<weight_type> {
+ public:
+  using InferenceKVStore = InferenceSynchronizedShardedMap<
+      int64_t,
+      weight_type*,
+      folly::SharedMutexWritePriority>;
+
+  InferenceTimeThresholdBasedEvict(
+      InferenceKVStore& kv_store,
+      const std::vector<int64_t>& sub_table_hash_cumsum,
+      int64_t interval_for_insufficient_eviction_s,
+      int64_t interval_for_sufficient_eviction_s,
+      int64_t interval_for_feature_statistics_decay_s)
+      : TimeThresholdBasedEvict<weight_type>(
+            reinterpret_cast<SynchronizedShardedMap<int64_t, weight_type*>&>(
+                kv_store),
+            sub_table_hash_cumsum,
+            interval_for_insufficient_eviction_s,
+            interval_for_sufficient_eviction_s,
+            interval_for_feature_statistics_decay_s,
+            /*is_training=*/false),
+        inference_kv_store_(&kv_store) {}
+
+  // Override to use 12-byte header's timestamp field (not 16-byte layout)
+  // Using FixedBlockPool::update_timestamp would overwrite the used bit!
+  void update_feature_statistics(weight_type* block) override {
+    InferenceFixedBlockPool::update_timestamp(block);
+  }
+
+ protected:
+  // Override to use 12-byte header's timestamp field
+  bool evict_block(weight_type* block, int sub_table_id, int shard_id)
+      override {
+    return InferenceFixedBlockPool::get_timestamp(block) <
+        this->eviction_timestamp_threshold_;
+  }
+
+  // Override to use InferenceFixedBlockPool's get_block with 12-byte header
+  void start_inference_eviction_loop(
+      int shard_id,
+      std::vector<int64_t>& evicted_counts,
+      std::vector<int64_t>& processed_counts) override {
+    auto* pool = inference_kv_store_->pool_by(shard_id);
+    auto mem_pool_lock = pool->acquire_lock();
+
+    std::vector<int64_t> evicting_keys;
+    evicting_keys.reserve(this->block_nums_snapshot_[shard_id] / 100);
+    while (!this->should_exit_evict_loop(shard_id)) {
+      auto* block = pool->template get_block<weight_type>(
+          this->block_cursors_[shard_id]++);
+      if (block == nullptr) {
+        continue;
+      }
+      int64_t key = InferenceFixedBlockPool::get_key(block);
+      int sub_table_id = this->get_sub_table_id(key);
+      processed_counts[sub_table_id]++;
+      if (this->evict_block(block, sub_table_id, shard_id)) {
+        pool->template deallocate_t<weight_type>(block);
+        evicted_counts[sub_table_id]++;
+        evicting_keys.push_back(key);
+      }
+    }
+    mem_pool_lock.unlock();
+
+    // lock dram kv shard hash map to remove evicted blocks in the map
+    // dedicate map update in a wlock to reduce the blocking time for
+    // inference read
+    auto shard_map_wlock = this->kv_store_.by(shard_id).wlock();
+    for (auto& key : evicting_keys) {
+      shard_map_wlock->erase(key);
+    }
+  }
+
+ private:
+  InferenceKVStore* inference_kv_store_;
+};
+
+/// @brief Factory function for creating FeatureEvict with
+/// InferenceSynchronizedShardedMap
+///
+/// Only supports BY_TIMESTAMP_THRESHOLD strategy for inference.
+/// Creates InferenceTimeThresholdBasedEvict to work with 12-byte headers.
+template <typename weight_type>
+std::unique_ptr<FeatureEvict<weight_type>> create_inference_feature_evict(
+    c10::intrusive_ptr<FeatureEvictConfig> config,
+    InferenceSynchronizedShardedMap<
+        int64_t,
+        weight_type*,
+        folly::SharedMutexWritePriority>& kv_store,
+    const std::vector<int64_t>& sub_table_hash_cumsum,
+    TestMode test_mode = TestMode::DISABLED) {
+  if (config->trigger_strategy_ !=
+      EvictTriggerStrategy::BY_TIMESTAMP_THRESHOLD) {
+    throw std::runtime_error(
+        "Only BY_TIMESTAMP_THRESHOLD is supported for inference with InferenceSynchronizedShardedMap");
+  }
+  return std::make_unique<InferenceTimeThresholdBasedEvict<weight_type>>(
+      kv_store,
+      sub_table_hash_cumsum,
+      config->interval_for_insufficient_eviction_s_,
+      config->interval_for_sufficient_eviction_s_,
+      config->interval_for_feature_statistics_decay_s_);
+}
+
+} // namespace kv_mem

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/inference_fixed_block_pool.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/inference_fixed_block_pool.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fixed_block_pool.h"
+
+namespace kv_mem {
+
+/// @brief A memory pool optimized for inference workloads.
+///
+/// Uses a compact 12-byte MetaHeader (vs 16-byte in base class) to save
+/// 4 bytes per embedding. Only supports timestamp-based TTL eviction
+/// (no count field for LFU eviction).
+///
+/// Memory layout per block:
+/// ┌──────────────────────────────────────────────────────────────────┐
+/// │ MetaHeader (12 bytes)          │ Embedding weights (D × scalar)  │
+/// ├────────────┬───────────────────┼──────────────────────────────────┤
+/// │ key (8B)   │ timestamp:31 + used:1 (4B) │ weight_type[max_D]      │
+/// └────────────┴───────────────────┴──────────────────────────────────┘
+///
+class InferenceFixedBlockPool : public FixedBlockPool {
+ public:
+  // 12-byte header (uses #pragma pack to avoid padding to 16 bytes)
+#pragma pack(push, 4)
+  struct MetaHeader {
+    int64_t key; // Feature key (8 bytes)
+    uint32_t timestamp : 31; // Last update time in seconds (~68 years range)
+    bool used : 1; // Block in-use flag
+  };
+#pragma pack(pop)
+  static_assert(
+      sizeof(MetaHeader) == 12,
+      "InferenceFixedBlockPool::MetaHeader must be exactly 12 bytes");
+
+  // Key operations - reuse from base class (key is at offset 0 in both)
+  using FixedBlockPool::get_key;
+  using FixedBlockPool::set_key;
+
+  // Used flag operations
+  static bool get_used(const void* block) {
+    return reinterpret_cast<const MetaHeader*>(block)->used;
+  }
+  static void set_used(void* block, bool used) {
+    reinterpret_cast<MetaHeader*>(block)->used = used;
+  }
+
+  // Timestamp operations
+  static uint32_t get_timestamp(const void* block) {
+    return reinterpret_cast<const MetaHeader*>(block)->timestamp;
+  }
+  static void set_timestamp(void* block, uint32_t time) {
+    reinterpret_cast<MetaHeader*>(block)->timestamp = time;
+  }
+  static void update_timestamp(void* block) {
+    reinterpret_cast<MetaHeader*>(block)->timestamp = current_timestamp();
+  }
+
+  // Block size: 12-byte header + embedding data
+  template <typename scalar_t>
+  static size_t calculate_block_size(size_t dimension) {
+    return sizeof(MetaHeader) + dimension * sizeof(scalar_t);
+  }
+
+  template <typename scalar_t>
+  static size_t calculate_block_alignment() {
+    return std::max(alignof(MetaHeader), alignof(scalar_t));
+  }
+
+  // Get pointer to embedding data (skips 12-byte MetaHeader)
+  template <typename scalar_t>
+  static scalar_t* data_ptr(scalar_t* block) {
+    return reinterpret_cast<scalar_t*>(
+        reinterpret_cast<char*>(block) + sizeof(MetaHeader));
+  }
+
+  template <typename scalar_t>
+  static const scalar_t* data_ptr(const scalar_t* block) {
+    return reinterpret_cast<const scalar_t*>(
+        reinterpret_cast<const char*>(block) + sizeof(MetaHeader));
+  }
+
+  explicit InferenceFixedBlockPool(
+      std::size_t block_size,
+      std::size_t block_alignment,
+      std::size_t blocks_per_chunk = 8192,
+      std::pmr::memory_resource* upstream = std::pmr::new_delete_resource())
+      : FixedBlockPool(
+            block_size,
+            block_alignment,
+            blocks_per_chunk,
+            upstream) {}
+
+  // Get block by index (used for eviction traversal)
+  // Uses InferenceFixedBlockPool::get_used for 12-byte header layout
+  template <typename scalar_t>
+  scalar_t* get_block(size_t index) {
+    std::lock_guard<std::mutex> guard(chunks_mutex_);
+    char* current_chunk =
+        static_cast<char*>(chunks_[index / blocks_per_chunk_].ptr);
+    char* block = current_chunk + block_size_ * (index % blocks_per_chunk_);
+    if (get_used(block)) {
+      return reinterpret_cast<scalar_t*>(block);
+    } else {
+      return nullptr;
+    }
+  }
+
+ protected:
+  // Override to initialize block with 12-byte MetaHeader layout only
+  void* do_allocate(std::size_t bytes, std::size_t alignment) override {
+    if (bytes != block_size_ || alignment != block_alignment_) {
+      throw std::bad_alloc();
+    }
+
+    if (!free_list_) {
+      allocate_chunk();
+    }
+
+    void* result = free_list_;
+    free_list_ = *static_cast<void**>(free_list_);
+    set_used(result, true);
+    update_timestamp(result);
+    return result;
+  }
+
+  void do_deallocate(
+      void* p,
+      [[maybe_unused]] std::size_t bytes,
+      [[maybe_unused]] std::size_t alignment) override {
+    *static_cast<void**>(p) = free_list_;
+    free_list_ = p;
+    set_used(p, false);
+  }
+
+  // Override to initialize 12-byte header's used flag to false
+  void allocate_chunk() override {
+    const std::size_t chunk_size = block_size_ * blocks_per_chunk_;
+
+    // Allocate aligned memory through upstream resource
+    void* chunk_ptr = upstream_->allocate(chunk_size, block_alignment_);
+
+    // Record chunk information for later release
+    {
+      std::lock_guard<std::mutex> guard(chunks_mutex_);
+      chunks_.push_back({chunk_ptr, chunk_size, block_alignment_});
+    }
+
+    // Initialize free list: link blocks in reverse order from chunk end to
+    // beginning (improves locality)
+    char* current = static_cast<char*>(chunk_ptr) + chunk_size;
+    for (std::size_t i = 0; i < blocks_per_chunk_; ++i) {
+      current -= block_size_;
+      *reinterpret_cast<void**>(current) = free_list_;
+      set_used(current, false);
+      free_list_ = current;
+    }
+  }
+};
+
+} // namespace kv_mem

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/kv_inference_embedding_interface.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/kv_inference_embedding_interface.h
@@ -134,6 +134,10 @@ class KVInferenceEmbeddingInterface {
   /// Log statistics for inplace update (inference only)
   virtual void log_inplace_update_stats() = 0;
 
+  /// Get read-time (forward pass) hit rate stats and reset counters.
+  /// Returns {hit_count, miss_count, total_count}.
+  virtual std::vector<int64_t> get_read_hit_rate_stats() = 0;
+
   /// Get feature eviction metrics
   ///
   /// @return Optional metrics tensors

--- a/fbgemm_gpu/test/tbe/dram_kv/dram_kv_inference_test.py
+++ b/fbgemm_gpu/test/tbe/dram_kv/dram_kv_inference_test.py
@@ -125,6 +125,51 @@ class DramKvInferenceTest(unittest.TestCase):
         self.assertTrue(equal_one_of(embs[4, :4], possible_embs))
         self.assertTrue(equal_one_of(embs[5, :4], possible_embs))
 
+    def test_read_hit_rate_stats(self) -> None:
+        num_shards = 32
+        uniform_init_lower: float = 0.0
+        uniform_init_upper: float = 0.0
+
+        kv_embedding_cache = torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper(
+            num_shards,
+            uniform_init_lower,
+            uniform_init_upper,
+            True,  # disable_random_init (zero init for predictable misses)
+        )
+        kv_embedding_cache.init(
+            [(20, 4, SparseType.INT8.as_int())],
+            8,
+            4,
+            torch.tensor([0, 20], dtype=torch.int64),
+        )
+
+        # Set embeddings for indices 0-3
+        kv_embedding_cache.set_embeddings(
+            torch.tensor([0, 1, 2, 3], dtype=torch.int64),
+            torch.tensor(
+                [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]],
+                dtype=torch.uint8,
+            ),
+        )
+
+        # Read with a mix of present (0-3) and absent (4-7) indices
+        _ = kv_embedding_cache.get_embeddings(
+            torch.tensor([0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.int64),
+        )
+
+        stats = kv_embedding_cache.get_read_hit_rate_stats()
+        self.assertEqual(len(stats), 3)
+        hit_count, miss_count, total_count = stats[0], stats[1], stats[2]
+        self.assertEqual(hit_count, 4)
+        self.assertEqual(miss_count, 4)
+        self.assertEqual(total_count, 8)
+
+        # Verify counters reset after read
+        stats2 = kv_embedding_cache.get_read_hit_rate_stats()
+        self.assertEqual(stats2[0], 0)
+        self.assertEqual(stats2[1], 0)
+        self.assertEqual(stats2[2], 0)
+
     def test_inplace_update(self) -> None:
         num_shards = 1
         uniform_init_lower: float = 0.0


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2659

KVZCH embedding cache on the serving/inference side lacked structured metrics for read-time (forward pass) hit rate. The C++ backend already tracked per-shard miss counts internally but never emitted them as ODS counters, and there was no total read count, making hit rate calculation impossible.

This diff adds:
- Atomic `read_hit_count_` / `read_miss_count_` counters in `DramKVInferenceEmbedding`
- Per-batch fb303 ODS counter emission (`kvzch.inference.read_hit_count`, `kvzch.inference.read_miss_count`, `kvzch.inference.read_total_count`) in the `get_kv_db_async_impl` aggregation callback
- `get_read_hit_rate_stats()` API exposed through the C++ wrapper and Python `KVEmbeddingInference` class for programmatic access
- `fb303:service_data` BUCK dependency for the `dram_kv_embedding_inference` target

Performance impact is minimal: one stack increment per lookup in the hit branch, two atomic fetch-adds and three `addStatValue` calls per batch.

Reviewed By: emlin

Differential Revision: D101879296


