### PR TITLE
Fix find_long_segments kernel launch failure for batch index select

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -1020,19 +1020,20 @@ Tensor {{ embedding_cuda_op }}(
                     use_deterministic_algorithms ? 0 : (indices.numel() / max_segment_length_per_cta),
                     indices.options().dtype(at::kInt));
 
+                constexpr auto fls_ctx = "find_long_segments";
                 FBGEMM_LAUNCH_KERNEL(
                     split_embedding_backward_codegen_find_long_segments,
                     div_round_up(total_unique_indices, kMaxThreads),
                     kMaxThreads,
                     0,
                     at::cuda::getCurrentCUDAStream(),
-                    PTA_B(sorted_linear_indices_num_runs, int32_t, 1, 32),
-                    PTA_B(sorted_linear_indices_run_lengths, int32_t, 1, 32),
-                    PTA_B(long_run_ids, int32_t, 1, 32),
-                    PTA_B(num_long_run_ids, int32_t, 1, 32),
-                    PTA_B(long_run_id_to_really_long_run_ids, int32_t, 1, 32),
-                    PTA_B(num_really_long_run_ids, int32_t, 1, 32),
-                    PTA_B(grad_accum_counter, int32_t, 1, 32),
+                    PTA_B(sorted_linear_indices_num_runs, int32_t, 1, 32).build(fls_ctx),
+                    PTA_B(sorted_linear_indices_run_lengths, int32_t, 1, 32).build(fls_ctx),
+                    PTA_B(long_run_ids, int32_t, 1, 32).build(fls_ctx),
+                    PTA_B(num_long_run_ids, int32_t, 1, 32).build(fls_ctx),
+                    PTA_B(long_run_id_to_really_long_run_ids, int32_t, 1, 32).build(fls_ctx),
+                    PTA_B(num_really_long_run_ids, int32_t, 1, 32).build(fls_ctx),
+                    PTA_B(grad_accum_counter, int32_t, 1, 32).build(fls_ctx),
                     max_segment_length_per_warp,
                     max_segment_length_per_cta,
                     use_deterministic_algorithms


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2665

The `find_long_segments` kernel in `batch_index_select_dim0` backward silently failed to launch on H100 (sm_90) and B200 (sm_100) with CUDA 12.8, producing zero gradients for runs with length >= 32. The error `__global__ function call is not configured` was returned by `__cudaPopCallConfiguration` after `cudaDeviceSynchronize`.

Root cause: CUDA 12.8 on sm_90+ generates a per-instantiation device stub for each unique `<<<>>>` call in a template function. `KernelLauncher::launch_kernel` was instantiated with `TensorAccessorBuilder` types (from `PTA_B` macros), but the kernel's registered device stub expected `PackedTensorAccessor32` types. The mismatch caused `__cudaPopCallConfiguration` to fail silently because nvcc commits to template argument types for stub generation before the runtime `transform_kernel_arg` conversion happens.

Solution: Explicitly call `.build()` on each `PTA_B` macro argument at the `find_long_segments` call site to convert `TensorAccessorBuilder` to `PackedTensorAccessor32` before passing to `FBGEMM_LAUNCH_KERNEL`. This ensures the `<<<>>>` inside `launch_kernel` is instantiated with the final kernel argument types, without requiring changes to `KernelLauncher` or the launch macros.

Differential Revision: D103575890


