### PR TITLE
TLX IKBO FA benchmarking with latest commit hash + bug fix (#5734)

### DIFF
--- a/fbgemm_gpu/experimental/ikbo/README.md
+++ b/fbgemm_gpu/experimental/ikbo/README.md
@@ -19,7 +19,7 @@ pip install -e . --no-build-isolation
 ```bash
 # Install the source code
 git clone https://github.com/pytorch/FBGEMM.git
-cd fbgemm/fbgemm_gpu/experimental/ikbo
+cd FBGEMM/fbgemm_gpu/experimental/ikbo
 pip install -e .
 ```
 
@@ -44,12 +44,18 @@ user_flag = create_user_flag(W_user, E_user)
 output = tlx_ikbo_lce(W_cand, W_user, E_cand, E_user, cand_to_user_index, user_flag)
 ```
 
-## Testing
+## Accuracy Testing
 ```bash
 FAST_TUNE=1 python -m pytest tests/ -v
 ```
 
 ## Benchmarks
+Command to boost GPU power and clock to its max with persistent mode (700W, 1980MHz is for H100 SXM5 version):
 ```bash
-python benchmarks/ikbo_lce_bench.py
+sudo nvidia-smi -i {GPU_ID} -pm 1 && sudo nvidia-smi --power-limit={GPU_max_power} -i 6 && MAX_SM_CLOCK=$(nvidia-smi --query-gpu=clocks.max.graphics --format=csv,noheader,nounits -i {GPU_ID}) && sudo nvidia-smi -lgc $MAX_SM_CLOCK -i {GPU_ID}
+```
+Run benchmark with the dedicate GPU ID and corresponding NUMA node:
+```bash
+CUDA_VISIBLE_DEVICES={GPU_ID} numactl -m {NUMA_node} -c {NUMA_node} python benchmarks/ikbo_lce_bench.py
+CUDA_VISIBLE_DEVICES={GPU_ID} numactl -m {NUMA_node} -c {NUMA_node} python benchmarks/ikbo_fa_bench.py
 ```

--- a/fbgemm_gpu/experimental/ikbo/ikbo/ops/tlx_ikbo_fa_ws.py
+++ b/fbgemm_gpu/experimental/ikbo/ikbo/ops/tlx_ikbo_fa_ws.py
@@ -48,7 +48,7 @@ configs_tlx_persistent = [
             "NUM_MMA_GROUPS": 2,
         },
         num_warps=4,
-        num_stages=0,
+        num_stages=1,
         pre_hook=_host_descriptor_pre_hook_tlx_persistent,
     ),
 ]

--- a/fbgemm_gpu/experimental/ikbo/tests/ikbo_fa_test.py
+++ b/fbgemm_gpu/experimental/ikbo/tests/ikbo_fa_test.py
@@ -5,19 +5,93 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import random
 import sys
 
 import pytest
 import torch
-from ikbo.benchmarks.ikbo_fa_bench import broadcast_sdpa, prepare_inputs_by_config
 from ikbo.ops.tlx_ikbo_fa_ws import tlx_flash_attn_ikbo_tma_persistent
 from ikbo.ops.triton_ikbo_fa import triton_flash_attn_ikbo_tma
 
 DEVICE = "cuda"
 DTYPE = torch.float16
+DEFAULT_CAND_TO_USER_RATIO = 64
 
 
-@pytest.mark.parametrize("B", [512, 102, 2048])
+def pytorch_sdpa(query, key, value):
+    return torch.nn.functional.scaled_dot_product_attention(
+        query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False
+    )
+
+
+def broadcast_sdpa(
+    query, key, value, cand_to_user_index, n_seed, num_heads, d_head, max_seq_len
+):
+    # for accuracy check
+    query_sdpa = query.view(-1, n_seed, num_heads, d_head).permute(0, 2, 1, 3)
+    key_sdpa = key.view(-1, max_seq_len, num_heads, d_head)
+    key_sdpa_broadcast = torch.index_select(
+        key_sdpa, dim=0, index=cand_to_user_index
+    ).permute(0, 2, 1, 3)
+    value_sdpa = value.view(-1, max_seq_len, num_heads, d_head)
+    value_sdpa_broadcast = torch.index_select(
+        value_sdpa, dim=0, index=cand_to_user_index
+    ).permute(0, 2, 1, 3)
+    return pytorch_sdpa(query_sdpa, key_sdpa_broadcast, value_sdpa_broadcast)
+
+
+def prepare_inputs_by_config(
+    B: int,
+    n_seed: int,
+    num_heads: int,
+    d_head: int,
+    max_seq_len: int,
+    low_num_cands_per_user: int = DEFAULT_CAND_TO_USER_RATIO,
+    high_num_cands_per_user: int = DEFAULT_CAND_TO_USER_RATIO,
+):
+    def _generate_num_cands_per_user():
+        res = []
+        cum_sum = 0
+        cand_grid = []
+        while True:
+            # Odd and even number of candidates per user got even chance
+            cur = random.randint(
+                low_num_cands_per_user, high_num_cands_per_user
+            ) + random.randint(0, 1)
+            for grid in range(cum_sum, min(cum_sum + cur, B), 2):
+                cand_grid.append(grid)
+            if cum_sum + cur >= B:
+                res.append(B - cum_sum)
+                break
+            cum_sum += cur
+            res.append(cur)
+        return res, cand_grid
+
+    res = _generate_num_cands_per_user()
+    num_cands_per_user_tensor = torch.tensor(res[0])
+    cand_grid = torch.tensor(res[1], dtype=torch.int32, device=DEVICE)
+
+    cand_to_user_index = torch.repeat_interleave(
+        torch.arange(num_cands_per_user_tensor.size(0)),
+        num_cands_per_user_tensor,
+    ).to(dtype=torch.int32, device=DEVICE)
+    Bu = num_cands_per_user_tensor.size(0)
+
+    query = torch.randn((B * n_seed, num_heads, d_head), device=DEVICE, dtype=DTYPE)
+    key = torch.randn((Bu * max_seq_len, num_heads, d_head), device=DEVICE, dtype=DTYPE)
+    value = torch.randn(
+        (Bu * max_seq_len, num_heads, d_head), device=DEVICE, dtype=DTYPE
+    )
+    return (
+        query,
+        key,
+        value,
+        cand_to_user_index,
+        cand_grid,
+    )
+
+
+@pytest.mark.parametrize("B", [512, 1024, 2048])
 @pytest.mark.parametrize("n_seed", [64])
 @pytest.mark.parametrize("num_heads", [1, 2, 4, 6])
 @pytest.mark.parametrize("d_head", [128])
@@ -46,7 +120,7 @@ def test_triton_ikbo_fa(B, n_seed, num_heads, d_head, max_seq_len, cand_to_user_
     torch.testing.assert_close(torch_output, triton_output, atol=1e-3, rtol=1e-4)
 
 
-@pytest.mark.parametrize("B", [512, 102, 2048])
+@pytest.mark.parametrize("B", [512, 1024, 2048])
 @pytest.mark.parametrize("n_seed", [64])
 @pytest.mark.parametrize("num_heads", [1, 2, 4, 6])
 @pytest.mark.parametrize("d_head", [128])


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2667

After 2f4eea63c for fbexperimental/triton, num_stage >=1 is enforced by third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp. Change the num_stage = 1 to turn off compiler optimization.

Reviewed By: jianj01

Differential Revision: D103791854


