### PR TITLE
Test OSS CI resource hypothesis: cu13.2-only build matrix

### DIFF
--- a/.github/workflows/build_wheels_linux_x86.yml
+++ b/.github/workflows/build_wheels_linux_x86.yml
@@ -49,13 +49,26 @@ jobs:
       id: filter
       env:
         MAT: ${{ needs.generate-matrix.outputs.matrix }}
-      # Nova Coordinate Filters:
-      # rocm/3.13t: causes segfaults at runtime
+      # DRAFT — DO NOT LAND.
+      # Restrict matrix to ONLY cuda 13.2 builds to test the hypothesis that
+      # `upload-manywheel-py3_10-cuda13_2` failures are due to OSS CI runner
+      # resource starvation when many CUDA/ROCm/CPU jobs run in parallel.
+      # If cu13.2 passes in isolation -> resource issue.
+      # If cu13.2 still fails -> real bug in cu13.2 build/upload path.
       run: |
         set -ex
         pwd
         ls
-        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_type:rocm;python_version:3.13t' )"
+        MATRIX_BLOB="$( python -c '
+        import json, os
+        m = json.loads(os.environ["MAT"])
+        entries = [
+            c for c in m["include"]
+            if c.get("gpu_arch_type") == "cuda"
+            and c.get("gpu_arch_version") == "13.2"
+        ]
+        print(json.dumps({"include": entries}))
+        ' )"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
Summary:
EXPERIMENT — DO NOT LAND.

Restrict the OSS Linux x86 wheel build matrix to ONLY cuda 13.2 entries to
test the hypothesis that the recurring `upload-manywheel-py3_10-cuda13_2`
failures on master are caused by OSS CI runner resource starvation when
many CUDA / ROCm / CPU jobs run in parallel, not by a real bug in the
cu13.2 build path.

Evidence motivating this experiment:
- `upload-manywheel-py3_10-cuda13_2` is failing on multiple recent
  unrelated diffs (D102946299 / D103694673 / D103791854 / D103795044).
- D103795044 even shows the upstream `build-manywheel-py3_10-cuda13_2`
  failing, suggesting the cu13.2 pipeline can't reliably complete in
  current OSS CI conditions.

Interpretation:
- If cu13.2 passes when run in isolation -> resource starvation confirmed,
  and the fix lives in CI infra (runner sizing / job concurrency limits).
- If cu13.2 still fails in isolation -> real bug in the cu13.2 build or
  upload path; needs code-level investigation.

Differential Revision: D104063431


