### PR TITLE
Make bad offsets fatal in bounds_check_indices (Part 2) (#5741)

### DIFF
--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_v1.cu
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_v1.cu
@@ -51,45 +51,21 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel_v1(
   }
 
   const auto num_rows = rows_per_table[t];
-  auto indices_start = offsets[b_t];
-  auto indices_end = offsets[b_t + 1];
+  const auto indices_start = offsets[b_t];
+  const auto indices_end = offsets[b_t + 1];
   const index_t num_indices = indices.size(0);
 
-  // Condition first, then branch on mode.
-  if (indices_start < 0 || indices_start > indices_end ||
-      indices_end > num_indices) {
-    if (bounds_check_mode == BoundsCheckMode::FATAL) {
-      CUDA_KERNEL_ASSERT(
-          indices_start >= 0 && "indices_start must be non-negative");
-      CUDA_KERNEL_ASSERT(
-          indices_start <= indices_end &&
-          "indices_start must not exceed indices_end");
-      CUDA_KERNEL_ASSERT(
-          indices_end <= num_indices &&
-          "indices_end must not exceed num_indices");
-    } else {
-      if (bounds_check_mode == BoundsCheckMode::WARNING) {
-        if (gpuAtomicIncrement(&warning[0]) == 0) {
-          printf(
-              "EmbeddingBoundsCheck (VBE %s): (at least one) Out of bounds access for "
-              "batch: %d, table: %d, indices_start: %lld, indices_end: %lld,"
-              " num_indices: %lld. Setting indices_start and indices_end within "
-              "the range.\n",
-              vbe ? "true" : "false",
-              b,
-              t,
-              static_cast<int64_t>(indices_start),
-              static_cast<int64_t>(indices_end),
-              static_cast<int64_t>(num_indices));
-        }
-      }
-      adjust_offset_kernel(
-          indices_start,
-          indices_end,
-          num_indices,
-          &offsets[b_t],
-          &offsets[b_t + 1]);
-    }
+  // Always throw assertion for bad offsets
+  // Only lane 0 asserts to avoid 32x assertions;
+  if (threadIdx.x == 0) {
+    CUDA_KERNEL_ASSERT(
+        indices_start >= 0 && "indices_start must be non-negative");
+    CUDA_KERNEL_ASSERT(
+        indices_start <= indices_end &&
+        "indices_start must not exceed indices_end");
+    CUDA_KERNEL_ASSERT(
+        indices_end <= num_indices &&
+        "indices_end must not exceed num_indices");
   }
 
   const auto L = indices_end - indices_start;
@@ -130,31 +106,11 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel_v1(
     }
   }
 
-  if (bounds_check_mode == BoundsCheckMode::FATAL) {
+  // Last-element check; one thread only.
+  if (b_t == 0 && threadIdx.x == 0) {
     CUDA_KERNEL_ASSERT(
         num_indices == offsets[total_B] &&
         "num_indices must match the last element in offsets");
-  } else if (bounds_check_mode == BoundsCheckMode::WARNING) {
-    if (num_indices != offsets[total_B]) {
-      if (gpuAtomicIncrement(&warning[0]) == 0) {
-        printf(
-            "EmbeddingBoundsCheck (VBE %s): the last element in offsets is incorrect for "
-            "total batch size %s: %d, total table num T: %d, "
-            " last element in offsets: %lld, indices size: %lld. "
-            " Setting the last element in offsets to be indices size.\n",
-            vbe ? "true" : "false",
-            vbe ? "total_B" : "B",
-            vbe ? total_B : B,
-            T,
-            static_cast<int64_t>(offsets[total_B]),
-            static_cast<int64_t>(num_indices));
-      }
-      offsets[total_B] = num_indices;
-    }
-  } else if (bounds_check_mode == BoundsCheckMode::IGNORE) {
-    if (num_indices != offsets[total_B]) {
-      offsets[total_B] = num_indices;
-    }
   }
 }
 

--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_v2.cu
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_v2.cu
@@ -38,34 +38,11 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel_v2(
   const uint32_t active_threads = blockDim.x * blockDim.y * blockDim.z;
 #endif
 
-  // Check the last element
+  // Last-element check; one thread only.
   if (b_t_start == 0 && threadIdx.x == 0) {
-    if (bounds_check_mode == BoundsCheckMode::FATAL) {
-      CUDA_KERNEL_ASSERT(
-          num_indices == offsets[total_B] &&
-          "num_indices must match the last element in offsets");
-    } else if (bounds_check_mode == BoundsCheckMode::WARNING) {
-      if (num_indices != offsets[total_B]) {
-        if (gpuAtomicIncrement(&warning[0]) == 0) {
-          printf(
-              "EmbeddingBoundsCheck (VBE %s): the last element in offsets is incorrect for "
-              "total batch size %s: %d, total table num T: %d, "
-              " last element in offsets: %lld, indices size: %lld. "
-              " Setting the last element in offsets to be indices size.\n",
-              vbe ? "true" : "false",
-              vbe ? "total_B" : "B",
-              vbe ? total_B : B,
-              T,
-              static_cast<int64_t>(offsets[total_B]),
-              static_cast<int64_t>(num_indices));
-        }
-        offsets[total_B] = num_indices;
-      }
-    } else if (bounds_check_mode == BoundsCheckMode::IGNORE) {
-      if (num_indices != offsets[total_B]) {
-        offsets[total_B] = num_indices;
-      }
-    }
+    CUDA_KERNEL_ASSERT(
+        num_indices == offsets[total_B] &&
+        "num_indices must match the last element in offsets");
   }
 
   for (auto b_t = blockIdx.x * blockDim.y + threadIdx.y; b_t < total_B;
@@ -82,44 +59,20 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel_v2(
     }
 
     const auto num_rows = rows_per_table[t];
-    auto indices_start = offsets[b_t];
-    auto indices_end = offsets[b_t + 1];
+    const auto indices_start = offsets[b_t];
+    const auto indices_end = offsets[b_t + 1];
 
-    // Condition first, then branch on mode.
-    if (indices_start < 0 || indices_start > indices_end ||
-        indices_end > num_indices) {
-      if (bounds_check_mode == BoundsCheckMode::FATAL) {
-        CUDA_KERNEL_ASSERT(
-            indices_start >= 0 && "indices_start must be non-negative");
-        CUDA_KERNEL_ASSERT(
-            indices_start <= indices_end &&
-            "indices_start must not exceed indices_end");
-        CUDA_KERNEL_ASSERT(
-            indices_end <= num_indices &&
-            "indices_end must not exceed num_indices");
-      } else {
-        if (bounds_check_mode == BoundsCheckMode::WARNING) {
-          if (threadIdx.x == 0 && gpuAtomicIncrement(&warning[0]) == 0) {
-            printf(
-                "EmbeddingBoundsCheck (VBE %s): (at least one) Out of bounds access for "
-                "batch: %d, table: %d, indices_start: %lld, indices_end: %lld,"
-                " num_indices: %lld. Setting indices_start and indices_end within "
-                "the range.\n",
-                vbe ? "true" : "false",
-                b,
-                t,
-                static_cast<int64_t>(indices_start),
-                static_cast<int64_t>(indices_end),
-                static_cast<int64_t>(num_indices));
-          }
-        }
-        adjust_offset_kernel(
-            indices_start,
-            indices_end,
-            num_indices,
-            &offsets[b_t],
-            &offsets[b_t + 1]);
-      }
+    // Always throw assertion for bad offsets
+    // Only lane 0 asserts to avoid 32x assertions
+    if (threadIdx.x == 0) {
+      CUDA_KERNEL_ASSERT(
+          indices_start >= 0 && "indices_start must be non-negative");
+      CUDA_KERNEL_ASSERT(
+          indices_start <= indices_end &&
+          "indices_start must not exceed indices_end");
+      CUDA_KERNEL_ASSERT(
+          indices_end <= num_indices &&
+          "indices_end must not exceed num_indices");
     }
 
     const auto L = indices_end - indices_start;

--- a/fbgemm_gpu/test/tbe/utils/split_embeddings_utils_test.py
+++ b/fbgemm_gpu/test/tbe/utils/split_embeddings_utils_test.py
@@ -391,7 +391,9 @@ class SplitEmbeddingsUtilsTest(unittest.TestCase):
             offsets[0] = -100
         if offsets.numel() > 1:
             offsets[-1] += 100
-        if bounds_check_mode != BoundsCheckMode.FATAL:
+        # CUDA asserts on bad offsets in all modes (kills context); only CPU
+        # silently corrects, so only exercise the silent-correction path on CPU.
+        if bounds_check_mode != BoundsCheckMode.FATAL and use_cpu:
             torch.ops.fbgemm.bounds_check_indices(
                 rows_per_table,
                 indices,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2671


Phase 2 of the bounds_check_indices race-condition cleanup stack.

**Behavior change**: previously, malformed offsets (indices_start < 0, indices_start > indices_end, or indices_end > num_indices) were silently "fixed" in-place on the GPU under WARNING/IGNORE modes. After this diff, bad offsets unconditionally trigger CUDA_KERNEL_ASSERT in all modes — they are no longer swallowed.

**Why**: the in-kernel write-back via adjust_offset_kernel was the root cause of several race conditions (intra-warp races on the offsets buffer, inconsistent L computed across warp lanes, etc.) and, worse, it masked real bugs in upstream code that produced the bad offsets in the first place. Treating bad offsets as fatal surfaces those upstream bugs instead of papering over them.

**What changed**:
- Per-b_t offset check collapses to three CUDA_KERNEL_ASSERTs guarded by `threadIdx.x == 0` (only lane 0 asserts; all 32 lanes loaded the same values, so 32x redundant asserts are wasteful).
- Last-element check (`num_indices == offsets[total_B]`) collapses to a single unconditional CUDA_KERNEL_ASSERT.
- adjust_offset_kernel calls, offsets[] write-backs, the WARNING/IGNORE printf branches for offset correction, and the per-lane indices_start/indices_end clamping/broadcast scaffolding (introduced in Phase 1.5) are all removed.

Applies to both v1 and v2 kernels.

Differential Revision: D101843208


