### PR TITLE
Create tbe/config/ package with foundational embedding types (#5742)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/config/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/config/__init__.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from fbgemm_gpu.tbe.config.embedding_config import (  # noqa: F401
+    BoundsCheckMode,
+    ComputeDevice,
+    DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
+    EmbeddingLocation,
+    EmbeddingSpecInfo,
+    get_bounds_check_version_for_platform,
+    INT8_EMB_ROW_DIM_OFFSET,
+    MAX_PREFETCH_DEPTH,
+    PoolingMode,
+    RecordCacheMetrics,
+    round_up,
+    SplitState,
+    tensor_to_device,
+)

--- a/fbgemm_gpu/fbgemm_gpu/tbe/config/embedding_config.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/config/embedding_config.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Foundational embedding, compute, and pooling type definitions for TBE.
+
+This module contains IntEnums, NamedTuples, constants, and utility functions
+that form the base vocabulary for Split Table Batched Embeddings (TBE).
+"""
+
+import enum
+from typing import NamedTuple
+
+import torch
+from torch import Tensor
+
+# Maximum number of times prefetch() can be called without
+# a corresponding forward() call
+MAX_PREFETCH_DEPTH: int = 100
+
+# GPU and CPU use 16-bit scale and bias for quantized embedding bags in TBE
+# The total size is 2 + 2 = 4 bytes
+DEFAULT_SCALE_BIAS_SIZE_IN_BYTES: int = 4
+
+# Row dimension offset for INT8 quantized embeddings
+INT8_EMB_ROW_DIM_OFFSET: int = 8
+
+
+class EmbeddingLocation(enum.IntEnum):
+    DEVICE = 0
+    MANAGED = 1
+    MANAGED_CACHING = 2
+    HOST = 3
+    MTIA = 4
+
+    @classmethod
+    def str_values(cls) -> list[str]:
+        return [
+            "device",
+            "managed",
+            "managed_caching",
+            "host",
+            "mtia",
+        ]
+
+    @classmethod
+    def from_str(cls, key: str) -> "EmbeddingLocation":
+        lookup = {
+            "device": EmbeddingLocation.DEVICE,
+            "managed": EmbeddingLocation.MANAGED,
+            "managed_caching": EmbeddingLocation.MANAGED_CACHING,
+            "host": EmbeddingLocation.HOST,
+            "mtia": EmbeddingLocation.MTIA,
+        }
+        if key in lookup:
+            return lookup[key]
+        else:
+            raise ValueError(f"Cannot parse value into EmbeddingLocation: {key}")
+
+    @classmethod
+    def from_device_and_clf(
+        cls, device: torch.device, cache_load_factor: float
+    ) -> "EmbeddingLocation":
+        """Determine embedding location from device type and cache load factor.
+
+        Formerly the free function get_new_embedding_location() in
+        split_table_batched_embeddings_ops_common.py.
+        """
+        # Only support CPU and GPU device
+        assert device.type == "cpu" or device.type == "cuda"
+        if cache_load_factor < 0 or cache_load_factor > 1:
+            raise ValueError(
+                f"cache_load_factor must be between 0.0 and 1.0, got {cache_load_factor}"
+            )
+
+        if device.type == "cpu":
+            return EmbeddingLocation.HOST
+        # UVM only
+        elif cache_load_factor == 0:
+            return EmbeddingLocation.MANAGED
+        # HBM only
+        elif cache_load_factor == 1.0:
+            return EmbeddingLocation.DEVICE
+        # UVM caching
+        else:
+            return EmbeddingLocation.MANAGED_CACHING
+
+
+class PoolingMode(enum.IntEnum):
+    SUM = 0
+    MEAN = 1
+    NONE = 2
+
+    def do_pooling(self) -> bool:
+        return self is not PoolingMode.NONE
+
+    @classmethod
+    def from_str(cls, key: str) -> "PoolingMode":
+        lookup = {
+            "sum": PoolingMode.SUM,
+            "mean": PoolingMode.MEAN,
+            "none": PoolingMode.NONE,
+        }
+        if key in lookup:
+            return lookup[key]
+        else:
+            raise ValueError(f"Cannot parse value into PoolingMode: {key}")
+
+
+class BoundsCheckMode(enum.IntEnum):
+    # Raise an exception (CPU) or device-side assert (CUDA)
+    FATAL = 0
+    # Log the first out-of-bounds instance per kernel, and set to zero.
+    WARNING = 1
+    # Set to zero.
+    IGNORE = 2
+    # No bounds checks.
+    NONE = 3
+    # IGNORE with V2 enabled
+    V2_IGNORE = 4
+    # WARNING with V2 enabled
+    V2_WARNING = 5
+    # FATAL with V2 enabled
+    V2_FATAL = 6
+
+
+class ComputeDevice(enum.IntEnum):
+    CPU = 0
+    CUDA = 1
+    MTIA = 2
+
+    @classmethod
+    def get_available(cls) -> "ComputeDevice":
+        """Return the best available compute device.
+
+        Formerly the free function get_available_compute_device() in
+        split_table_batched_embeddings_ops_training.py.
+        """
+        if torch.cuda.is_available():
+            return ComputeDevice.CUDA
+        elif torch.mtia.is_available():
+            return ComputeDevice.MTIA
+        else:
+            return ComputeDevice.CPU
+
+
+class EmbeddingSpecInfo(enum.IntEnum):
+    feature_names = 0
+    rows = 1
+    dims = 2
+    sparse_type = 3
+    embedding_location = 4
+
+
+RecordCacheMetrics: NamedTuple = NamedTuple(
+    "RecordCacheMetrics",
+    [("record_cache_miss_counter", bool), ("record_tablewise_cache_miss", bool)],
+)
+
+SplitState: NamedTuple = NamedTuple(
+    "SplitState",
+    [
+        ("dev_size", int),
+        ("host_size", int),
+        ("uvm_size", int),
+        ("placements", list[EmbeddingLocation]),
+        ("offsets", list[int]),
+    ],
+)
+
+
+# NOTE: This is also defined in fbgemm_gpu.tbe.utils, but declaring
+# target dependency on :split_embedding_utils will result in compatibility
+# breakage with Caffe2 module_factory because it will pull in numpy
+def round_up(a: int, b: int) -> int:
+    return int((a + b - 1) // b) * b
+
+
+def tensor_to_device(tensor: torch.Tensor, device: torch.device) -> Tensor:
+    if tensor.device == torch.device("meta"):
+        return torch.empty_like(tensor, device=device)
+    return tensor.to(device)
+
+
+def get_bounds_check_version_for_platform() -> int:
+    # NOTE: Use bounds_check_indices v2 on ROCm because ROCm has a
+    # constraint that the gridDim * blockDim has to be smaller than
+    # 2^32. The v1 kernel can be launched with gridDim * blockDim >
+    # 2^32 while the v2 kernel limits the gridDim size to 64 * # of
+    # SMs.  Thus, its gridDim * blockDim is guaranteed to be smaller
+    # than 2^32
+    return 2 if (torch.cuda.is_available() and torch.version.hip) else 1

--- a/fbgemm_gpu/test/tbe/config/__init__.py
+++ b/fbgemm_gpu/test/tbe/config/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict

--- a/fbgemm_gpu/test/tbe/config/embedding_config_test.py
+++ b/fbgemm_gpu/test/tbe/config/embedding_config_test.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Unit tests for fbgemm_gpu.tbe.config.embedding_config
+
+Tests cover:
+- Import path correctness
+- New classmethod behavior (ComputeDevice.get_available, EmbeddingLocation.from_device_and_clf)
+- Utility function correctness
+- JIT integration (torch.jit.script must still work on TBE)
+"""
+
+import enum
+import unittest
+from typing import Final
+
+import torch
+
+
+CUDA_NOT_AVAILABLE: Final[bool] = not torch.cuda.is_available()
+
+
+class EmbeddingConfigImportTest(unittest.TestCase):
+    """Verify all symbols are importable from tbe.config."""
+
+    def test_import_from_tbe_config_package(self) -> None:
+        from fbgemm_gpu.tbe.config import (  # noqa: F401
+            BoundsCheckMode,
+            ComputeDevice,
+            DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
+            EmbeddingLocation,
+            EmbeddingSpecInfo,
+            get_bounds_check_version_for_platform,
+            INT8_EMB_ROW_DIM_OFFSET,
+            MAX_PREFETCH_DEPTH,
+            PoolingMode,
+            RecordCacheMetrics,
+            round_up,
+            SplitState,
+            tensor_to_device,
+        )
+
+        self.assertTrue(issubclass(EmbeddingLocation, enum.IntEnum))
+        self.assertTrue(issubclass(ComputeDevice, enum.IntEnum))
+        self.assertTrue(issubclass(PoolingMode, enum.IntEnum))
+        self.assertTrue(issubclass(BoundsCheckMode, enum.IntEnum))
+        self.assertTrue(issubclass(EmbeddingSpecInfo, enum.IntEnum))
+
+
+class EmbeddingConfigClassmethodTest(unittest.TestCase):
+    """Test new classmethods added to existing enums."""
+
+    def test_compute_device_get_available(self) -> None:
+        from fbgemm_gpu.tbe.config import ComputeDevice
+
+        result = ComputeDevice.get_available()
+        self.assertIn(result, list(ComputeDevice))
+
+    def test_embedding_location_from_device_and_clf_cpu(self) -> None:
+        from fbgemm_gpu.tbe.config import EmbeddingLocation
+
+        self.assertEqual(
+            EmbeddingLocation.from_device_and_clf(torch.device("cpu"), 0.0),
+            EmbeddingLocation.HOST,
+        )
+
+    def test_embedding_location_from_device_and_clf_cuda_managed(self) -> None:
+        from fbgemm_gpu.tbe.config import EmbeddingLocation
+
+        self.assertEqual(
+            EmbeddingLocation.from_device_and_clf(torch.device("cuda"), 0.0),
+            EmbeddingLocation.MANAGED,
+        )
+
+    def test_embedding_location_from_device_and_clf_cuda_device(self) -> None:
+        from fbgemm_gpu.tbe.config import EmbeddingLocation
+
+        self.assertEqual(
+            EmbeddingLocation.from_device_and_clf(torch.device("cuda"), 1.0),
+            EmbeddingLocation.DEVICE,
+        )
+
+    def test_embedding_location_from_device_and_clf_cuda_caching(self) -> None:
+        from fbgemm_gpu.tbe.config import EmbeddingLocation
+
+        self.assertEqual(
+            EmbeddingLocation.from_device_and_clf(torch.device("cuda"), 0.5),
+            EmbeddingLocation.MANAGED_CACHING,
+        )
+
+    def test_embedding_location_from_device_and_clf_invalid_raises(self) -> None:
+        from fbgemm_gpu.tbe.config import EmbeddingLocation
+
+        with self.assertRaises(ValueError):
+            EmbeddingLocation.from_device_and_clf(torch.device("cuda"), 1.5)
+        with self.assertRaises(ValueError):
+            EmbeddingLocation.from_device_and_clf(torch.device("cuda"), -0.1)
+
+    def test_embedding_location_from_str_roundtrip(self) -> None:
+        from fbgemm_gpu.tbe.config import EmbeddingLocation
+
+        for loc in EmbeddingLocation:
+            self.assertEqual(EmbeddingLocation.from_str(loc.name.lower()), loc)
+
+    def test_pooling_mode_do_pooling(self) -> None:
+        from fbgemm_gpu.tbe.config import PoolingMode
+
+        self.assertTrue(PoolingMode.SUM.do_pooling())
+        self.assertTrue(PoolingMode.MEAN.do_pooling())
+        self.assertFalse(PoolingMode.NONE.do_pooling())
+
+
+class EmbeddingConfigUtilityTest(unittest.TestCase):
+    """Test utility functions."""
+
+    def test_round_up(self) -> None:
+        from fbgemm_gpu.tbe.config import round_up
+
+        self.assertEqual(round_up(5, 4), 8)
+        self.assertEqual(round_up(4, 4), 4)
+        self.assertEqual(round_up(0, 4), 0)
+        self.assertEqual(round_up(1, 1), 1)
+
+    def test_tensor_to_device(self) -> None:
+        from fbgemm_gpu.tbe.config import tensor_to_device
+
+        t = torch.tensor([1, 2, 3])
+        result = tensor_to_device(t, torch.device("cpu"))
+        self.assertEqual(result.device.type, "cpu")
+        self.assertTrue(torch.equal(result, t))
+
+    def test_get_bounds_check_version_for_platform(self) -> None:
+        from fbgemm_gpu.tbe.config import get_bounds_check_version_for_platform
+
+        result = get_bounds_check_version_for_platform()
+        self.assertIn(result, [1, 2])
+
+
+class EmbeddingConfigJITTest(unittest.TestCase):
+    """Verify types from tbe/config/ don't break torch.jit.script on the TBE module.
+
+    Guards against:
+    1. TorchScript failing to resolve IntEnum types at new import paths
+    2. Classmethods on IntEnum breaking JIT
+    3. Module-level references breaking due to import rewriting
+    """
+
+    @unittest.skipIf(CUDA_NOT_AVAILABLE, "CUDA required")
+    def test_tbe_jit_script_with_new_import_paths(self) -> None:
+        """Critical: Ensure TBE can still be JIT-scripted."""
+        from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
+            ComputeDevice,
+            EmbeddingLocation,
+            SplitTableBatchedEmbeddingBagsCodegen,
+        )
+
+        cc = SplitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (100, 16, EmbeddingLocation.DEVICE, ComputeDevice.CUDA),
+            ],
+        )
+        cc_scripted = torch.jit.script(cc)
+        indices = torch.randint(0, 100, (10,), device="cuda")
+        offsets = torch.tensor([0, 5, 10], device="cuda", dtype=torch.long)
+        output = cc_scripted(indices, offsets)
+        self.assertEqual(output.shape[0], 2)
+        self.assertEqual(output.shape[1], 16)


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2672

Create the `tbe/config/` package with foundational embedding types extracted from `split_table_batched_embeddings_ops_common.py`.

This diff introduces the `fbgemm_gpu.tbe.config` Python package as the new canonical home for foundational TBE type definitions. Purely additive — no existing definitions are removed or modified.

1. **`tbe/config/embedding_config.py`**: Core IntEnums (`EmbeddingLocation`, `ComputeDevice`, `PoolingMode`, `BoundsCheckMode`, `EmbeddingSpecInfo`), NamedTuples (`RecordCacheMetrics`, `SplitState`), constants, and utility functions
2. **`tbe/config/__init__.py`**: Re-exports all public symbols for clean `from fbgemm_gpu.tbe.config import ...` usage
3. **New classmethods**: `ComputeDevice.get_available()` (from `get_available_compute_device()`) and `EmbeddingLocation.from_device_and_clf()` (from `get_new_embedding_location()`)
4. **`:tbe_config` BUCK target**: New `python_library` in `tbe/BUCK`
5. **`embedding_config_test.py`**: Unit tests covering import correctness, classmethod behavior, utility functions, and TBE JIT-script compatibility

Part of Chunk H series (TBE modularization): this is H.1 of 6 diffs.

Reviewed By: henrylhtsang

Differential Revision: D103253546


