### PR TITLE
Fix int32 truncation of 64-bit ssd_row_addrs in unrolled forward path

### DIFF
--- a/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_template.cu
+++ b/fbgemm_gpu/codegen/training/forward/embedding_forward_split_kernel_template.cu
@@ -327,7 +327,11 @@ using namespace fbgemm_gpu;
 
             {%- if not dense and lxu_miss_rate != "cache_conflict_miss_rate::all" %}
             // Load cache's index from thread j in the group
-            [[maybe_unused]] int32_t {{ locs_or_addrs_idx }}_j_[kManualUnrollLength];
+            // NOTE: Use {{ locs_or_addrs_type }} here. For SSD path, this is int64_t
+            // (raw row pointer). Hardcoding int32_t silently truncates 64-bit
+            // pointers to 32 bits and sign-extends on reload, producing garbage
+            // pointer dereferences (HSA Memory access fault on AMD MI350X).
+            [[maybe_unused]] {{ locs_or_addrs_type }} {{ locs_or_addrs_idx }}_j_[kManualUnrollLength];
             for (auto inner_j = 0; inner_j < kManualUnrollLength; ++inner_j)
             {
                 {{ locs_or_addrs_idx }}_j_[inner_j] = use_lxu_cache ? SHFL_SYNC({{ locs_or_addrs_idx }}, outer_j + inner_j) : 0;
@@ -415,7 +419,7 @@ using namespace fbgemm_gpu;
                 [[maybe_unused]] auto offset_idx_j = offset_idx_j_[inner_j];
                 {%- endif %}
                 {%- if not dense and lxu_miss_rate != "cache_conflict_miss_rate::all" %}
-                [[maybe_unused]] int32_t {{ locs_or_addrs_idx }}_j = {{ locs_or_addrs_idx }}_j_[inner_j];
+                [[maybe_unused]] {{ locs_or_addrs_type }} {{ locs_or_addrs_idx }}_j = {{ locs_or_addrs_idx }}_j_[inner_j];
                 {%- endif %}
                 {%- if weighted %}
                 at::acc_type<cache_t, true> idx_weight_j = idx_weight_j_[inner_j];


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2674

CONTEXT: KVZCH SSD TBE forward kernel deterministically page-faults on AMD MI350X with HSA Memory access faults at addresses showing a bimodal distribution: low (e.g., 0x4989000, 0x670ac000) AND sign-extended high (e.g., 0xfffff5295000, 0xffffe62d4000). Reproduced in 7+ MAST jobs.

ROOT CAUSE: In the ROCm-only unrolled outer loop in embedding_forward_split_kernel_template.cu, the per-thread cache-index staging array was hardcoded as int32_t at lines 330 and 422. For SSD path, locs_or_addrs_type is int64_t (the array entries are raw 64-bit row pointers from ssd_row_addrs). SHFL_SYNC returns the full int64_t value, but writing it to int32_t silently truncates the upper 32 bits. On reload, sign-extension of the low 32 bits reconstructs a corrupted pointer:
- Low-32 with bit 31 = 0 -> small positive value (matches low fault addresses)
- Low-32 with bit 31 = 1 -> sign-extended 0xFFFF... (matches high fault addresses)
The dereference at load_and_accumulate / load_weights macros (lines 78, 173) reads through this corrupted pointer -> HSA fault.

The non-unrolled tail loop at line 482 already uses {{ locs_or_addrs_type }} correctly. CUDA path uses the non-unrolled path so never hits this bug.

WHAT:
Replace the hardcoded int32_t with the jinja {{ locs_or_addrs_type }} template variable at both sites (line 330 staging array and line 422 reload), matching the type used elsewhere in the same template. Add an explanatory comment at the staging array site.

Differential Revision: D104181076


