### PR TITLE
Add KVZCH inference read-time hit rate metrics via fb303 ODS counters

### DIFF
--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.cpp
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.cpp
@@ -142,6 +142,11 @@ void DramKVEmbeddingInferenceWrapper::log_inplace_update_stats() {
   kv_backend_->log_inplace_update_stats();
 }
 
+std::vector<int64_t>
+DramKVEmbeddingInferenceWrapper::get_read_hit_rate_stats() {
+  return kv_backend_->get_read_hit_rate_stats();
+}
+
 void DramKVEmbeddingInferenceWrapper::trigger_evict(
     int64_t inplace_update_ts_64b) {
   uint32_t inplace_update_ts_32b =
@@ -219,6 +224,10 @@ static auto dram_kv_embedding_inference_wrapper =
             "log_inplace_update_stats",
             &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::
                 log_inplace_update_stats)
+        .def(
+            "get_read_hit_rate_stats",
+            &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::
+                get_read_hit_rate_stats)
         .def(
             "serialize",
             &fbgemm_gpu::DramKVEmbeddingInferenceWrapper::serialize)

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_embedding_inference_wrapper.h
@@ -43,6 +43,8 @@ class DramKVEmbeddingInferenceWrapper : public torch::jit::CustomClassHolder {
 
   void log_inplace_update_stats();
 
+  std::vector<int64_t> get_read_hit_rate_stats();
+
   void trigger_evict(int64_t inplace_update_ts_64b);
 
   void wait_evict_completion();

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_inference_embedding.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_kv_inference_embedding.h
@@ -11,6 +11,7 @@
 #include <caffe2/torch/fb/distributed/wireSerializer/WireSerializer.h>
 #include <common/base/Proc.h>
 #include <common/stats/Stats.h>
+#include <fb303/ServiceData.h>
 #include <folly/SocketAddress.h>
 #include <folly/coro/BlockingWait.h>
 #include <folly/coro/Collect.h>
@@ -18,6 +19,7 @@
 #include <folly/coro/Task.h>
 #include <folly/executors/FunctionScheduler.h>
 #include <folly/logging/xlog.h>
+#include <folly/synchronization/CallOnce.h>
 #include <servicerouter/client/cpp2/ServiceRouter.h>
 #include <thrift/lib/cpp2/protocol/CompactProtocol.h>
 #include <thrift/lib/cpp2/protocol/Serializer.h>
@@ -154,6 +156,18 @@ class DramKVInferenceEmbedding
       feature_evict_ = create_inference_feature_evict(
           feature_evict_config_.value(), kv_store_, sub_table_hash_cumsum_);
     }
+    // Register fb303 export types once per process so the read hit-rate
+    // counters surface in ODS as time-series (e.g. *.sum.60) rather than
+    // raw values that ODS / fbagent will not scrape.
+    static folly::once_flag readHitRateExportFlag;
+    folly::call_once(readHitRateExportFlag, [] {
+      facebook::fb303::fbData->addStatExportType(
+          "kvzch.inference.read_hit_count", facebook::fb303::SUM);
+      facebook::fb303::fbData->addStatExportType(
+          "kvzch.inference.read_miss_count", facebook::fb303::SUM);
+      facebook::fb303::fbData->addStatExportType(
+          "kvzch.inference.read_total_count", facebook::fb303::SUM);
+    });
     LOG(INFO) << "DramKVInferenceEmbedding initialized: disable_random_init "
               << disable_random_init_;
   }
@@ -381,8 +395,8 @@ class DramKVInferenceEmbedding
     // iteration(excluding state_dict)
     auto start_ts = facebook::WallClockUtil::NowInUsecFast();
     pause_ongoing_eviction(); // noop calls, no impact if called multiple times
-    std::vector<
-        folly::Future<std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t>>>
+    std::vector<folly::Future<
+        std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t>>>
         futures;
     auto row_width = weights.size(1);
     auto copy_width = width_length.value_or(row_width);
@@ -408,6 +422,7 @@ class DramKVInferenceEmbedding
                 int64_t local_read_lookup_cache_total_duration = 0;
                 int64_t local_read_aquire_lock_duration = 0;
                 int64_t local_read_missing_load = 0;
+                int64_t local_read_hit_load = 0;
                 FBGEMM_DISPATCH_INTEGRAL_TYPES(
                     indices.scalar_type(),
                     "get_kv_db_async_impl",
@@ -422,7 +437,8 @@ class DramKVInferenceEmbedding
                      &local_read_fill_row_storage_total_duration,
                      &local_read_lookup_cache_total_duration,
                      &local_read_aquire_lock_duration,
-                     &local_read_missing_load] {
+                     &local_read_missing_load,
+                     &local_read_hit_load] {
                       using index_t = scalar_t;
                       CHECK(indices.is_contiguous());
                       CHECK(weights.is_contiguous());
@@ -501,6 +517,7 @@ class DramKVInferenceEmbedding
                           local_read_cache_hit_copy_total_duration +=
                               facebook::WallClockUtil::NowInUsecFast() -
                               before_cache_hit_copy_ts;
+                          local_read_hit_load++;
                         }
                       }
                     });
@@ -509,7 +526,8 @@ class DramKVInferenceEmbedding
                     local_read_fill_row_storage_total_duration,
                     local_read_cache_hit_copy_total_duration,
                     local_read_aquire_lock_duration,
-                    local_read_missing_load};
+                    local_read_missing_load,
+                    local_read_hit_load};
               }));
     }
 
@@ -521,20 +539,23 @@ class DramKVInferenceEmbedding
                            int64_t,
                            int64_t,
                            int64_t,
+                           int64_t,
                            int64_t>>& results) {
           int64_t read_lookup_cache_total_duration = 0;
           int64_t read_fill_row_storage_total_duration = 0;
           int64_t read_cache_hit_copy_total_duration = 0;
           int64_t read_acquire_lock_total_duration = 0;
           int64_t read_missing_load = 0;
+          int64_t read_hit_load = 0;
           for (
-              const auto& [lookup_cache_dur, fill_row_storage_dur, cache_hit_copy_dur, acquire_lock_dur, missing_load] :
+              const auto& [lookup_cache_dur, fill_row_storage_dur, cache_hit_copy_dur, acquire_lock_dur, missing_load, hit_load] :
               results) {
             read_lookup_cache_total_duration += lookup_cache_dur;
             read_fill_row_storage_total_duration += fill_row_storage_dur;
             read_cache_hit_copy_total_duration += cache_hit_copy_dur;
             read_acquire_lock_total_duration += acquire_lock_dur;
             read_missing_load += missing_load;
+            read_hit_load += hit_load;
           }
           auto duration = facebook::WallClockUtil::NowInUsecFast() - start_ts;
           read_total_duration_ += duration;
@@ -547,6 +568,15 @@ class DramKVInferenceEmbedding
           read_acquire_lock_avg_duration_ +=
               read_acquire_lock_total_duration / num_shards_;
           read_missing_load_avg_ += read_missing_load / num_shards_;
+          read_hit_count_ += read_hit_load;
+          read_miss_count_ += read_missing_load;
+          facebook::fb303::fbData->addStatValue(
+              "kvzch.inference.read_hit_count", read_hit_load);
+          facebook::fb303::fbData->addStatValue(
+              "kvzch.inference.read_miss_count", read_missing_load);
+          facebook::fb303::fbData->addStatValue(
+              "kvzch.inference.read_total_count",
+              read_hit_load + read_missing_load);
           return std::vector<folly::Unit>(results.size());
         });
   };
@@ -661,6 +691,18 @@ class DramKVInferenceEmbedding
         << ", miss count: " << inplace_update_miss_cnt
         << ", total count: " << total_cnt << ", hit ratio: "
         << (total_cnt > 0 ? (double)inplace_update_hit_cnt / total_cnt : 0.0);
+  }
+
+  // Returns {hit_count, miss_count, total_count} accumulated since the last
+  // call to this method. Each counter is individually reset atomically with
+  // exchange(0); the pair is NOT snapshotted together, so under concurrent
+  // batch traffic the returned hit and miss values may correspond to
+  // slightly different time windows.
+  std::vector<int64_t> get_read_hit_rate_stats() override {
+    int reset_val = 0;
+    auto hit = read_hit_count_.exchange(reset_val);
+    auto miss = read_miss_count_.exchange(reset_val);
+    return {hit, miss, hit + miss};
   }
 
   std::optional<FeatureEvictMetricTensors> get_feature_evict_metric()
@@ -916,6 +958,9 @@ class DramKVInferenceEmbedding
 
   std::atomic<int64_t> inplace_update_hit_cnt_{0};
   std::atomic<int64_t> inplace_update_miss_cnt_{0};
+
+  std::atomic<int64_t> read_hit_count_{0};
+  std::atomic<int64_t> read_miss_count_{0};
 }; // class DramKVInferenceEmbedding
 
 } // namespace kv_mem

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/kv_inference_embedding_interface.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/kv_inference_embedding_interface.h
@@ -134,6 +134,10 @@ class KVInferenceEmbeddingInterface {
   /// Log statistics for inplace update (inference only)
   virtual void log_inplace_update_stats() = 0;
 
+  /// Get read-time (forward pass) hit rate stats and reset counters.
+  /// Returns {hit_count, miss_count, total_count}.
+  virtual std::vector<int64_t> get_read_hit_rate_stats() = 0;
+
   /// Get feature eviction metrics
   ///
   /// @return Optional metrics tensors


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2675

Re-land of D101879296 (reverted by D104116880 — see S659921), C++-only this time.

## Summary

KVZCH embedding cache on the serving/inference side lacked structured metrics for
read-time (forward pass) hit rate. The C++ backend already tracked per-shard miss
counts internally but never emitted them as ODS counters, and there was no total
read count, making hit rate calculation impossible.

This diff adds:
- Atomic `read_hit_count_` / `read_miss_count_` counters in `DramKVInferenceEmbedding`
- Per-batch fb303 ODS counter emission (`kvzch.inference.read_hit_count`,
  `kvzch.inference.read_miss_count`, `kvzch.inference.read_total_count`) in the
  `get_kv_db_async_impl` aggregation callback
- `get_read_hit_rate_stats()` virtual method on `KVInferenceEmbeddingInterface`,
  implemented in `DramKVInferenceEmbedding`, no-op stub on `SSDKVInferenceEmbedding`
- `DramKVEmbeddingInferenceWrapper::get_read_hit_rate_stats` C++ method + TorchScript
  registration so the predictor binary recognizes any model that exports the method
- `kvzch.inference.*` regex added to `PredictorXUtils.cpp` fb303Collector allowlist
  so ODS scrapes the new counters
- `//fb303:service_data` BUCK dep on `dram_kv_embedding_inference`
- One-time `addStatExportType(SUM)` registration via `folly::call_once` so counters
  surface in ODS as `*.sum.60` time-series

Performance impact is minimal: one stack increment per lookup in the hit branch,
two atomic fetch-adds and three `addStatValue` calls per batch.

## Why this is C++-only (vs original D101879296)

Original D101879296 also added a Python `torch.jit.export def get_read_hit_rate_stats(...)`
on `KVEmbeddingInference`. Models trained after the diff baked the method into their
TorchScript graph, but stale predictor binaries on `vg_worker_byoc_t16_gti_mrs_trunk_health_prod`
(and `sigrid_predictor_gpu.persistent:prod` from Apr 22) lacked the C++ TorchScript
registration. Models loaded against those predictors crashed with:

  `torch::jit::ErrorReport: torch.torch.classes.fbgemm.DramKVEmbeddingInferenceWrapper
   object has no attribute or method get_read_hit_rate_stats`

Root cause: `D101879296` shipped the Python TorchScript-export side and the C++
TorchScript-registration side in a single diff with no coordinated predictor-binary
rollout. Newly-trained models required the new C++ class registration, but no
predictor binary anywhere had it yet — neither `:prod` (v5529, Apr 22) nor `:LATEST`
(v5704, Apr 29) of `sigrid_predictor_gpu.persistent` was built at a revision >= the
landing commit. This caused S659921 (mvai/video_udd_lsr serving_eval blocked on
R5449-R5450).

This re-land drops the Python `torch.jit.export` side entirely. ODS counter
emission lives in C++ unconditionally — it does NOT depend on any Python caller
invoking `get_read_hit_rate_stats()`. The fb303 `addStatValue` calls fire on every
batch automatically. So:

- ODS gets the metrics — same end goal as the original diff
- No model TorchScript graph changes — no stale-predictor crash possible
- No predictor-binary wait gate needed — even predictor binaries built before
  this diff will load every existing and future model normally, because no model
  exports a new method that requires the new C++ registration

If a Python `get_read_hit_rate_stats()` programmatic API is ever needed, it can
ship in a follow-up diff AFTER predictor binaries on every KVZCH serving tier
are rolled out at a revision >= this diff's landing commit.

## Note on counter consistency (per AI reviewer feedback on D101879296)

The two `exchange(0)` calls on `read_hit_count_` and `read_miss_count_` in
`get_read_hit_rate_stats()` are not a combined snapshot — between the two
exchanges, a concurrent batch callback may add to `read_miss_count_` before it is
exchanged, so the returned hit and miss values may correspond to slightly different
time windows. This is acceptable for ODS hit-rate aggregation (where individual
sub-second slices don't matter) and is now documented in code. If a strict snapshot
is needed in the future, both exchanges can be wrapped in a small mutex.



Build verification:
- buck build fbcode//deeplearning/fbgemm/fbgemm_gpu:dram_kv_embedding_inference
- buck build fbcode//caffe2/caffe2/fb/predictor/embedding_db/kv_embedding_table:SSDKVInferenceEmbedding
- buck build fbcode//fblearner/predictor/model_publishing_service/deployment:predictor_x_utils

S659921 regression check:
- After landing, run a Vanguard serving_eval against
  vg_worker_byoc_t16_gti_mrs_trunk_health_prod on a freshly-trained model and
  confirm no TorchScript crash on the previously-failing test case:
  https://www.internalfb.com/vanguard/serving_test_cases/1302024888565107

## Related

- Original (reverted): D101879296
- Revert: D104116880
- SEV: S659921 — [mvai/video_udd_lsr] Vanguard serving_eval predictor crash —
  DramKVEmbeddingInferenceWrapper missing get_read_hit_rate_stats on trunk health
  predictor
- Pull Request resolved: https://github.com/pytorch/FBGEMM/pull/5730
- Pull Request resolved: https://github.com/facebookresearch/FBGEMM/pull/2659

Reviewed By: EddyLXJ, emlin

Differential Revision: D104246537


