### PR TITLE
Phase 0.5 — bench --bounds-check-version flag + portable bench tooling

### DIFF
--- a/fbgemm_gpu/bench/tbe/tbe_utils_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/tbe_utils_benchmark.py
@@ -284,6 +284,14 @@ def pruned_array_lookup(  # noqa C901
     f"IGNORE={BoundsCheckMode.IGNORE.value}, "
     f"NONE={BoundsCheckMode.NONE.value}",
 )
+@click.option(
+    "--bounds-check-version",
+    type=int,
+    default=1,
+    help="Kernel version dispatched by bounds_check_indices: 1 (default) or 2. "
+    "v2 is also gated globally by JK BOUNDS_CHECK_INDICES_V2; passing 2 here "
+    "forces v2 regardless of the JK gate.",
+)
 @click.option("--requests_data_file", type=str, default=None)
 @click.option("--tables", type=str, default=None)
 @click.option(
@@ -307,6 +315,7 @@ def bounds_check_indices(  # noqa C901
     num_embeddings: int,
     num_tables: int,
     bounds_check_mode: int,
+    bounds_check_version: int,
     requests_data_file: Optional[str],
     tables: Optional[str],
     batch_sizes: str,
@@ -418,6 +427,7 @@ def bounds_check_indices(  # noqa C901
                 b_t_map=b_t_map,
                 info_B_num_bits=info_B_num_bits,
                 info_B_mask=info_B_mask,
+                bounds_check_version=bounds_check_version,
             ),
             num_warmups=warmup_runs,
         )


### PR DESCRIPTION
Summary:
This diff bundles the two pieces needed to benchmark the
bounds_check_indices stack across architectures, so a single diff
number can be forwarded to collaborators (NVIDIA A100/H100/B200,
AMD MI300/MI350) for cross-arch perf testing before any of the
stack lands.

# Part 1: --bounds-check-version flag

Adds a `--bounds-check-version` CLI flag to the
`bounds-check-indices` subcommand of
`fbcode/deeplearning/fbgemm/fbgemm_gpu/bench/tbe/tbe_utils_benchmark.py`,
plumbed through to `torch.ops.fbgemm.bounds_check_indices` as the
`bounds_check_version` kwarg (which already exists in the C++ op
signature).

Without this, v2 was only reachable by either flipping the
`BOUNDS_CHECK_INDICES_V2` JK gate (requires JK perms; not
available to OSS/external runners) or manually editing the bench
file inline (fragile, doesn't survive `sl goto`).

Default `1` preserves existing bench behavior (no behavior change
for any current caller).

# Part 2: portable bench tooling

Three bash scripts in
`fbcode/ai_codesign/nonprod/gchalump/scripts/fbgemm/`:

1. **run_bounds_check_indices_bench.sh** — inner runner. Sweeps
   {modes} × {versions} × {trials} on the currently-checked-out
   commit. Captures `system.json` (GPU/driver/CUDA/host/checkout).
   Mirrors the arch dispatch (`-c h100`/`-c mi350`/`-c b200`) and
   `--gpu N` (sets both `CUDA_VISIBLE_DEVICES` and
   `HIP_VISIBLE_DEVICES`) conventions from supadchaya's existing
   TBE bench scripts. Auto-falls-back to v1-only on checkouts
   that predate Part 1.

2. **run_bounds_check_indices_on_stack.sh** — outer driver. Loops
   `sl goto` across {Baseline, Phase 0.5, 1, 1.5, 2, 3}, runs
   the inner per phase, restores original checkout via EXIT trap.
   Forwards all bench flags. Pre-pulls all diffs to avoid
   mid-sweep network calls. Auto-runs the analyzer at the end.

3. **analyze_bounds_check_results.sh** — log parser + reporter
   (pure bash). Emits `results.csv` and `summary.md` (median per
   cell with Δ T vs Baseline, per kernel version). Uploads both
   to pastry by default.

# Why folded into one diff

Originally Part 1 was the bottom of the bounds_check stack and
Part 2 was a parallel branch off master (D102682427, now
abandoned). Folded into one diff so collaborators only need to
remember one diff number to reproduce the full benchmark.

Reviewed By: q10

Differential Revision: D102675932


