### PR TITLE
Add FBGEMM_NO_JK=2 (EnvFirstThenJk) policy; refactor feature-gate lookup into singleton (#5748)

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp
@@ -195,7 +195,7 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
     {% else %}
     TORCH_CHECK(D > 0);
     {% endif %}
-    const static bool disablePinnedMemory = fbgemm_gpu::config::is_feature_enabled_from_env(fbgemm_gpu::config::FeatureGateName::TBE_CPU_OUTPUT_DISABLE_PINNED_MEMORY);
+    const static bool disablePinnedMemory = fbgemm_gpu::config::is_feature_enabled(fbgemm_gpu::config::FeatureGateName::TBE_CPU_OUTPUT_DISABLE_PINNED_MEMORY);
     bool pinned_memory = false;
     if (!disablePinnedMemory && at::Context::hasCUDA() && at::getNumGPUs() > 0) {
       pinned_memory = true;

--- a/fbgemm_gpu/include/fbgemm_gpu/config/feature_gates.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/config/feature_gates.h
@@ -94,12 +94,6 @@ bool check_feature_gate_key(const std::string& key);
 /// is enabled.
 bool is_feature_enabled(const FeatureGateName& feature);
 
-/// @ingroup fbgemm-gpu-config
-///
-/// @brief For the given `FeatureGateName`, check if the corresponding
-/// feature is enabled in the env vars only.
-bool is_feature_enabled_from_env(const FeatureGateName& feature);
-
 #ifdef FBGEMM_FBCODE
 bool is_feature_enabled(const FbFeatureGateName& feature);
 #endif

--- a/fbgemm_gpu/src/config/feature_gates.cpp
+++ b/fbgemm_gpu/src/config/feature_gates.cpp
@@ -13,6 +13,7 @@
 #include "fbgemm_gpu/config/feature_gates_fb.h"
 #endif
 
+#include <cstdint>
 #include <cstdlib>
 #include <stdexcept>
 #include <string>
@@ -31,6 +32,15 @@ std::string to_string(const FeatureGateName& value) {
   return "UNKNOWN";
 }
 
+namespace {
+
+// Returns true iff the env var "FBGEMM_<key>" is set (regardless of value).
+bool env_has_key(const std::string& key) {
+  const auto env_var = "FBGEMM_" + key;
+  return std::getenv(env_var.c_str()) != nullptr;
+}
+
+// Reads the env var "FBGEMM_<key>" and returns true iff it is set to "1".
 bool ev_check_key(const std::string& key) {
   const auto env_var = "FBGEMM_" + key;
 
@@ -46,48 +56,105 @@ bool ev_check_key(const std::string& key) {
   }
 }
 
-static bool check_feature_gate_key_impl(
-    const std::string& key,
-    bool check_env_vars_only [[maybe_unused]]) {
-  // Cache feature flags to avoid repeated JK and env var checks
-  static std::unordered_map<std::string, bool> feature_flags_cache;
-  if (const auto search = feature_flags_cache.find(key);
-      search != feature_flags_cache.end()) {
-    return search->second;
-  }
 #ifdef FBGEMM_FBCODE
-  const auto value =
-      check_env_vars_only ? ev_check_key(key) : jk_check_key(key);
+// Lookup policy controlled by the FBGEMM_NO_JK env var.
+//   unset or "0" -> JkOnly
+//   "1"          -> EnvOnly
+//   "2"          -> EnvFirstThenJk
+class NoJkMode {
+ public:
+  enum Value : uint8_t { JkOnly, EnvOnly, EnvFirstThenJk };
+
+  constexpr NoJkMode(Value value) : value_(value) {}
+
+  constexpr operator Value() const {
+    return value_;
+  }
+
+  explicit operator bool() const = delete;
+
+  static NoJkMode from_env() {
+    const auto value = std::getenv("FBGEMM_NO_JK");
+    if (!value) {
+      return NoJkMode::JkOnly;
+    }
+
+    try {
+      const auto parsed = std::stoi(value);
+      if (parsed == 1) {
+        return NoJkMode::EnvOnly;
+      } else if (parsed == 2) {
+        return NoJkMode::EnvFirstThenJk;
+      } else {
+        return NoJkMode::JkOnly;
+      }
+    } catch (const std::exception&) {
+      // Best-effort parse: fall back to JkOnly on any parse failure
+      // (std::invalid_argument for non-numeric input,
+      //  std::out_of_range for values that overflow int).
+      return NoJkMode::JkOnly;
+    }
+  }
+
+ private:
+  Value value_;
+};
+#endif // FBGEMM_FBCODE
+
+class FeatureGate {
+ public:
+  static FeatureGate& instance() {
+    static FeatureGate gate;
+    return gate;
+  }
+
+  FeatureGate(const FeatureGate&) = delete;
+  FeatureGate& operator=(const FeatureGate&) = delete;
+  FeatureGate(FeatureGate&&) = delete;
+  FeatureGate& operator=(FeatureGate&&) = delete;
+
+  bool lookup(const std::string& key) {
+    if (const auto search = cache_.find(key); search != cache_.end()) {
+      return search->second;
+    }
+
+    bool value = false;
+#ifdef FBGEMM_FBCODE
+    static const NoJkMode mode = NoJkMode::from_env();
+    if (mode == NoJkMode::EnvOnly) {
+      value = ev_check_key(key);
+    } else if (mode == NoJkMode::EnvFirstThenJk) {
+      value = env_has_key(key) ? ev_check_key(key) : jk_check_key(key);
+    } else /* NoJkMode::JkOnly */ {
+      value = jk_check_key(key);
+    }
 #else
-  const auto value = ev_check_key(key);
+    value = ev_check_key(key);
 #endif
 
-  feature_flags_cache.insert({key, value});
-  return value;
-}
+    cache_.insert({key, value});
+    return value;
+  }
+
+ private:
+  FeatureGate() = default;
+
+  std::unordered_map<std::string, bool> cache_;
+};
+
+} // namespace
 
 DLL_PUBLIC bool check_feature_gate_key(const std::string& key) {
-#ifdef FBGEMM_FBCODE
-  static const auto no_jk = ev_check_key("NO_JK");
-#else
-  static const auto no_jk = false;
-#endif
-
-  return check_feature_gate_key_impl(key, no_jk);
+  return FeatureGate::instance().lookup(key);
 }
 
 DLL_PUBLIC bool is_feature_enabled(const FeatureGateName& feature) {
-  return check_feature_gate_key(to_string(feature));
-}
-
-DLL_PUBLIC bool is_feature_enabled_from_env(const FeatureGateName& feature) {
-  return check_feature_gate_key_impl(
-      to_string(feature), /* check_env_vars_only */ true);
+  return FeatureGate::instance().lookup(to_string(feature));
 }
 
 #ifdef FBGEMM_FBCODE
 DLL_PUBLIC bool is_feature_enabled(const FbFeatureGateName& feature) {
-  return check_feature_gate_key(to_string(feature));
+  return FeatureGate::instance().lookup(to_string(feature));
 }
 #endif // FBGEMM_FBCODE
 

--- a/fbgemm_gpu/test/config/feature_gate_no_jk_cpp_test.cpp
+++ b/fbgemm_gpu/test/config/feature_gate_no_jk_cpp_test.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include "fbgemm_gpu/config/feature_gates.h"
+
+namespace config = fbgemm_gpu::config;
+
+// These tests run in a binary launched with the following environment
+// (set by the BUCK target):
+//
+//   FBGEMM_NO_JK=2                          -> EnvFirstThenJk policy (FBCODE)
+//   FBGEMM_TBE_V2=1                         -> feature is "enabled" via env
+//   FBGEMM_BOUNDS_CHECK_INDICES_V2=0        -> feature is "set but disabled"
+//
+// In FBCODE builds, these exercise the new EnvFirstThenJk path: env_has_key
+// returning true must short-circuit the JustKnobs lookup, so the value comes
+// from ev_check_key alone.
+//
+// In OSS builds, the same env values flow through the unconditional env-only
+// path (FBGEMM_NO_JK is ignored), and the assertions still hold by
+// construction.
+//
+// Each test uses a distinct FeatureGateName because the FeatureGate
+// singleton's per-key cache is process-lifetime: the first lookup for a
+// given key freezes its result.
+
+TEST(FeatureGateNoJkTest, env_set_to_one_returns_enabled) {
+  EXPECT_TRUE(config::is_feature_enabled(config::FeatureGateName::TBE_V2));
+}
+
+TEST(FeatureGateNoJkTest, env_set_to_zero_returns_disabled) {
+  EXPECT_FALSE(
+      config::is_feature_enabled(
+          config::FeatureGateName::BOUNDS_CHECK_INDICES_V2));
+}

--- a/fbgemm_gpu/test/config/feature_gate_no_jk_test.py
+++ b/fbgemm_gpu/test/config/feature_gate_no_jk_test.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+import unittest
+
+# pyre-fixme[21]
+import fbgemm_gpu
+from fbgemm_gpu.config import FeatureGate, FeatureGateName
+
+# pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
+open_source: bool = getattr(fbgemm_gpu, "open_source", False)
+
+if open_source:
+    # pyre-ignore[21]
+    from test_utils import TestSuite
+else:
+    from fbgemm_gpu.test.test_utils import TestSuite
+
+
+# This test runs in a binary launched with the following environment
+# (set by the BUCK target):
+#
+#   FBGEMM_NO_JK=2                       -> EnvFirstThenJk policy (FBCODE)
+#   FBGEMM_TBE_V2=1                      -> feature is "enabled" via env
+#   FBGEMM_BOUNDS_CHECK_INDICES_V2=0     -> feature is "set but disabled"
+#
+# Each assertion uses a distinct FeatureGateName because the underlying C++
+# FeatureGate singleton's per-key cache is process-lifetime.
+@unittest.skipIf(open_source, "FBGEMM_NO_JK is FBCODE-only behavior")
+class FeatureGateNoJkTest(TestSuite):  # pyre-ignore[11]
+    def test_env_set_to_one_returns_enabled(self) -> None:
+        self.assertTrue(FeatureGate.is_enabled(FeatureGateName.TBE_V2))
+
+    def test_env_set_to_zero_returns_disabled(self) -> None:
+        self.assertFalse(
+            FeatureGate.is_enabled(FeatureGateName.BOUNDS_CHECK_INDICES_V2)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2678

Adds a new `FBGEMM_NO_JK=2` policy (`EnvFirstThenJk`) to FBGEMM-GPU's feature-gate subsystem, refactors the implementation behind a singleton, and prunes the now-redundant public `is_feature_enabled_from_env` API.

This diff extends and tightens the feature-gate machinery in `fbgemm_gpu/config`. Specifically:

1. **New `NoJkMode` policy with three modes**: Introduces an `enum class NoJkMode { JkOnly, EnvOnly, EnvFirstThenJk }` (anonymous-namespace) selected at process start by parsing `FBGEMM_NO_JK`. Unset / `0` / unparseable → `JkOnly` (status quo: query JK, env-vars used only as overrides). `1` → `EnvOnly` (status quo for OSS / no-JK builds). `2` → `EnvFirstThenJk` (NEW: consult per-feature env-var first, fall back to JK if the env-var is unset).
2. **`FeatureGate` singleton**: Collapses the previous function-local-static cache plus several free functions into a single `FeatureGate` class (anonymous namespace) that owns the parsed `NoJkMode`, the per-key result cache, and the cache mutex. Lookups go through `FeatureGate::instance().is_enabled(...)`, replacing the previous `check_feature_gate_key_impl` + ad-hoc cache.
3. **`env_has_key` helper**: Adds a small helper that distinguishes "env-var unset" from "env-var set to 0" — required for `EnvFirstThenJk` to know when to fall back to JK rather than treating absence as "disabled".
4. **API surface reduction**: Removes the public `is_feature_enabled_from_env(FeatureGateName)` from `feature_gates.h`. All policy decisions now flow through the single `is_feature_enabled` entry point, which honors the active `NoJkMode`.
5. **Codegen call-site migration**: `embedding_forward_quantized_cpu_template.cpp` (the only in-tree caller of the removed API, looking up `TBE_CPU_OUTPUT_DISABLE_PINNED_MEMORY`) is migrated to `is_feature_enabled`. Behavioral note: under the default `JkOnly` policy this lookup now goes through JK first; env-driven users that previously relied on env-only semantics (e.g. Sigrid Predictor's `disablePinnedMemoryOnRemoteROByDefault()`) will need to either run with `FBGEMM_NO_JK=2` (env-first-then-JK) or rely on JK plumbing — flagging here so reviewers / downstream owners can decide which is appropriate.
6. **New env-driven test targets**: Adds `feature_gate_no_jk_cpp_test.cpp` (gtest) and `feature_gate_no_jk_test.py` (Python) under `test/config/`, plus matching BUCK targets `:feature_gate_no_jk_cpp` and `:feature_gate_no_jk` that set `FBGEMM_NO_JK=2`, `FBGEMM_TBE_V2=1`, `FBGEMM_BOUNDS_CHECK_INDICES_V2=0` in their target `env`. Two cases each: env-set-to-`1` → enabled; env-set-to-`0` → disabled.

## Detailed Changes

### `fbgemm_gpu/include/fbgemm_gpu/config/feature_gates.h`
- Removes the public declaration of `is_feature_enabled_from_env(FeatureGateName)`. Single entry point is now `is_feature_enabled`.

### `fbgemm_gpu/src/config/feature_gates.cpp`
- Adds `<cstdint>` include.
- Introduces `enum class NoJkMode { JkOnly, EnvOnly, EnvFirstThenJk }` in an anonymous namespace.
- Adds `NoJkMode::from_env()` reading `FBGEMM_NO_JK`: unset/`0`/unparseable → `JkOnly`; `1` → `EnvOnly`; `2` → `EnvFirstThenJk`.
- Adds `env_has_key(const std::string&)` to distinguish "unset" from "set to 0".
- Replaces the function-local-static cache + `check_feature_gate_key_impl` + `is_feature_enabled_from_env` with a `FeatureGate` singleton owning the mode and the per-key cache; exposes `FeatureGate::instance().lookup(...)`.
- `is_feature_enabled` and `check_feature_gate_key` now dispatch through the singleton and honor the active `NoJkMode`.

### `fbgemm_gpu/codegen/inference/embedding_forward_quantized_cpu_template.cpp`
- Migrates the single `TBE_CPU_OUTPUT_DISABLE_PINNED_MEMORY` lookup from `is_feature_enabled_from_env` to `is_feature_enabled` (the former no longer exists). Behavioral implication noted above.

### `fbgemm_gpu/test/config/feature_gate_no_jk_cpp_test.cpp` (new)
- gtest with two cases exercising `FBGEMM_NO_JK=2` / `EnvFirstThenJk`: env-set-to-`1` returns enabled (`TBE_V2`); env-set-to-`0` returns disabled (`BOUNDS_CHECK_INDICES_V2`).

### `fbgemm_gpu/test/config/feature_gate_no_jk_test.py` (new)
- Python mirror of the C++ NO_JK=2 cases; skipped in OSS.

### `fbgemm_gpu/test/config/BUCK`
- Adds two new targets `:feature_gate_no_jk_cpp` and `:feature_gate_no_jk` with target-level `env = {"FBGEMM_NO_JK": "2", "FBGEMM_TBE_V2": "1", "FBGEMM_BOUNDS_CHECK_INDICES_V2": "0"}`.

Reviewed By: henrylhtsang

Differential Revision: D104335038


