### PR TITLE
Add optimizer config types to tbe/config/ package

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/config/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/config/__init__.py
@@ -22,3 +22,18 @@ from fbgemm_gpu.tbe.config.embedding_config import (  # noqa: F401
     SplitState,
     tensor_to_device,
 )
+from fbgemm_gpu.tbe.config.optimizer_config import (  # noqa: F401
+    CounterBasedRegularizationDefinition,
+    CounterWeightDecayMode,
+    CowClipDefinition,
+    DoesNotHavePrefix,
+    EmainplaceModeDefinition,
+    EnsembleModeDefinition,
+    GlobalWeightDecayDefinition,
+    GradSumDecay,
+    LearningRateMode,
+    StepMode,
+    TailIdThreshold,
+    UserEnabledConfigDefinition,
+    WeightDecayMode,
+)

--- a/fbgemm_gpu/fbgemm_gpu/tbe/config/optimizer_config.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/config/optimizer_config.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Optimizer-specific enums and frozen dataclasses for TBE.
+
+These types configure the optimizer behavior of Split Table Batched Embeddings.
+They are used exclusively at init-time — the __init__() method decomposes them
+into primitive scalar self.* attributes before JIT scripting.
+"""
+
+import enum
+from dataclasses import dataclass, field
+
+
+class DoesNotHavePrefix(Exception):
+    pass
+
+
+class WeightDecayMode(enum.IntEnum):
+    NONE = 0
+    L2 = 1
+    DECOUPLE = 2
+    COUNTER = 3
+    COWCLIP = 4
+    DECOUPLE_GLOBAL = 5
+
+
+class CounterWeightDecayMode(enum.IntEnum):
+    NONE = 0
+    L2 = 1
+    DECOUPLE = 2
+    ADAGRADW = 3
+
+
+class StepMode(enum.IntEnum):
+    NONE = 0
+    USE_COUNTER = 1
+    USE_ITER = 2
+
+
+class LearningRateMode(enum.IntEnum):
+    EQUAL = -1
+    TAIL_ID_LR_INCREASE = 0
+    TAIL_ID_LR_DECREASE = 1
+    COUNTER_SGD = 2
+
+
+class GradSumDecay(enum.IntEnum):
+    NO_DECAY = -1
+    CTR_DECAY = 0
+
+
+@dataclass(frozen=True)
+class TailIdThreshold:
+    val: float = 0
+    is_ratio: bool = False
+
+
+@dataclass(frozen=True)
+class CounterBasedRegularizationDefinition:
+    counter_weight_decay_mode: CounterWeightDecayMode = CounterWeightDecayMode.NONE
+    counter_halflife: int = -1
+    adjustment_iter: int = -1
+    adjustment_ub: float = 1.0
+    learning_rate_mode: LearningRateMode = LearningRateMode.EQUAL
+    grad_sum_decay: GradSumDecay = GradSumDecay.NO_DECAY
+    tail_id_threshold: TailIdThreshold = field(default_factory=TailIdThreshold)
+    max_counter_update_freq: int = 1000
+
+
+@dataclass(frozen=True)
+class CowClipDefinition:
+    counter_weight_decay_mode: CounterWeightDecayMode = CounterWeightDecayMode.NONE
+    counter_halflife: int = -1
+    weight_norm_coefficient: float = 0.0
+    lower_bound: float = 0.0
+
+
+@dataclass(frozen=True)
+class GlobalWeightDecayDefinition:
+    start_iter: int = 0
+    lower_bound: float = 0.0
+
+
+@dataclass(frozen=True)
+class UserEnabledConfigDefinition:
+    """
+    This class is used to configure whether certain modes are to be enabled
+    """
+
+    # This is used in Adam to perform rowwise bias correction using `row_counter`
+    # More details can be found in D64848802.
+    use_rowwise_bias_correction: bool = False
+    use_writeback_bwd_prehook: bool = False
+    writeback_first_feature_only: bool = False
+    precompute_writeback: bool = False
+
+
+@dataclass(frozen=True)
+class EnsembleModeDefinition:
+    step_ema: float = 10000
+    step_swap: float = 10000
+    step_start: float = 0
+    step_ema_coef: float = 0.6
+    step_mode: StepMode = StepMode.USE_ITER
+
+
+@dataclass(frozen=True)
+class EmainplaceModeDefinition:
+    step_ema: float = 10
+    step_start: float = 0
+    step_ema_coef: float = 0.6

--- a/fbgemm_gpu/test/tbe/config/optimizer_config_test.py
+++ b/fbgemm_gpu/test/tbe/config/optimizer_config_test.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Unit tests for fbgemm_gpu.tbe.config.optimizer_config
+
+Tests cover:
+- Import path correctness
+- JIT integration (TBE with various optimizer configs must still JIT-script)
+"""
+
+import enum
+import unittest
+from typing import Final
+
+import torch
+
+CUDA_NOT_AVAILABLE: Final[bool] = not torch.cuda.is_available()
+
+
+class OptimizerConfigImportTest(unittest.TestCase):
+    """Verify all optimizer types importable from tbe.config."""
+
+    def test_import_all_optimizer_types(self) -> None:
+        from fbgemm_gpu.tbe.config import (
+            CounterBasedRegularizationDefinition,
+            CounterWeightDecayMode,
+            CowClipDefinition,
+            DoesNotHavePrefix,
+            EmainplaceModeDefinition,
+            EnsembleModeDefinition,
+            GlobalWeightDecayDefinition,
+            GradSumDecay,
+            LearningRateMode,
+            StepMode,
+            TailIdThreshold,
+            UserEnabledConfigDefinition,
+            WeightDecayMode,
+        )
+
+        self.assertTrue(issubclass(WeightDecayMode, enum.IntEnum))
+        self.assertTrue(issubclass(CounterWeightDecayMode, enum.IntEnum))
+        self.assertTrue(issubclass(StepMode, enum.IntEnum))
+        self.assertTrue(issubclass(LearningRateMode, enum.IntEnum))
+        self.assertTrue(issubclass(GradSumDecay, enum.IntEnum))
+        self.assertTrue(issubclass(DoesNotHavePrefix, Exception))
+        self.assertEqual(CounterBasedRegularizationDefinition().counter_halflife, -1)
+        self.assertEqual(CowClipDefinition().weight_norm_coefficient, 0.0)
+        self.assertEqual(GlobalWeightDecayDefinition().start_iter, 0)
+        self.assertFalse(UserEnabledConfigDefinition().use_rowwise_bias_correction)
+        self.assertEqual(EnsembleModeDefinition().step_ema, 10000)
+        self.assertEqual(EmainplaceModeDefinition().step_ema, 10)
+        self.assertEqual(TailIdThreshold().val, 0)
+
+
+class OptimizerConfigJITTest(unittest.TestCase):
+    """Verify optimizer types don't interfere with TBE JIT scripting."""
+
+    @unittest.skipIf(CUDA_NOT_AVAILABLE, "CUDA required")
+    def test_tbe_jit_script_with_weight_decay_l2(self) -> None:
+        from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType
+        from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
+            ComputeDevice,
+            EmbeddingLocation,
+            SplitTableBatchedEmbeddingBagsCodegen,
+            WeightDecayMode,
+        )
+
+        cc = SplitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (100, 16, EmbeddingLocation.DEVICE, ComputeDevice.CUDA),
+            ],
+            optimizer=OptimType.EXACT_SGD,
+            learning_rate=0.01,
+            weight_decay_mode=WeightDecayMode.L2,
+            weight_decay=0.001,
+        )
+        cc_scripted = torch.jit.script(cc)
+        device = torch.accelerator.current_accelerator()
+        indices = torch.randint(0, 100, (10,), device=device)
+        offsets = torch.tensor([0, 5, 10], device=device, dtype=torch.long)
+        output = cc_scripted(indices, offsets)
+        self.assertEqual(output.shape, (2, 16))
+
+    @unittest.skipIf(CUDA_NOT_AVAILABLE, "CUDA required")
+    def test_tbe_jit_script_with_counter_regularization(self) -> None:
+        """Counter-based regularization exercises the most complex dataclass path."""
+        from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType
+        from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
+            ComputeDevice,
+            CounterBasedRegularizationDefinition,
+            EmbeddingLocation,
+            SplitTableBatchedEmbeddingBagsCodegen,
+            WeightDecayMode,
+        )
+
+        cc = SplitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (100, 16, EmbeddingLocation.DEVICE, ComputeDevice.CUDA),
+            ],
+            optimizer=OptimType.EXACT_ROWWISE_ADAGRAD,
+            learning_rate=0.01,
+            weight_decay_mode=WeightDecayMode.COUNTER,
+            counter_based_regularization=CounterBasedRegularizationDefinition(
+                counter_halflife=100,
+            ),
+        )
+        cc_scripted = torch.jit.script(cc)
+        device = torch.accelerator.current_accelerator()
+        indices = torch.randint(0, 100, (10,), device=device)
+        offsets = torch.tensor([0, 5, 10], device=device, dtype=torch.long)
+        output = cc_scripted(indices, offsets)
+        self.assertEqual(output.shape, (2, 16))


### PR DESCRIPTION
Summary:
Add `tbe/config/optimizer_config.py` with all optimizer-related enums and frozen dataclasses from `training.py`. Purely additive — definitions are duplicated, not moved.

Types added:
- **IntEnums**: `WeightDecayMode`, `CounterWeightDecayMode`, `StepMode`, `LearningRateMode`, `GradSumDecay`
- **Frozen dataclasses**: `TailIdThreshold`, `CounterBasedRegularizationDefinition`, `CowClipDefinition`, `GlobalWeightDecayDefinition`, `UserEnabledConfigDefinition`, `EnsembleModeDefinition`, `EmainplaceModeDefinition`
- **Exception**: `DoesNotHavePrefix`

These types are used exclusively at init-time — the `__init__()` method decomposes them into primitive scalar `self.*` attributes before JIT scripting. They are NOT visible to TorchScript directly.

Part of Chunk H series (TBE modularization): H.2 of 6 diffs. Stacked on D103253546.

Reviewed By: henrylhtsang

Differential Revision: D103256501


