### PR TITLE
Add cache config types to tbe/cache/ package

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/cache/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/cache/__init__.py
@@ -7,5 +7,12 @@
 
 # pyre-unsafe
 
+from .cache_config import (  # noqa: F401
+    CacheAlgorithm,
+    CacheState,
+    DEFAULT_ASSOC,
+    MultiPassPrefetchConfig,
+    UVMCacheStatsIndex,
+)
 from .kv_embedding_ops_inference import KVEmbeddingInference  # noqa: F401
 from .split_embeddings_cache_ops import get_unique_indices_v2  # noqa: F401

--- a/fbgemm_gpu/fbgemm_gpu/tbe/cache/cache_config.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/cache/cache_config.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Cache-related type definitions for TBE.
+
+Contains CacheAlgorithm, CacheState, MultiPassPrefetchConfig, UVMCacheStatsIndex,
+and the DEFAULT_ASSOC constant.
+
+These types are publicly accessible via ``fbgemm_gpu.tbe.cache.<Name>`` (eager
+re-export from ``fbgemm_gpu/tbe/cache/__init__.py``). Any new types added here
+that will be re-exported from the package ``__init__.py`` MUST avoid
+``@dataclass`` decoration to remain torch.package-safe under Python 3.12+:
+``dataclasses._is_type`` does ``sys.modules.get(cls.__module__).__dict__``
+while resolving annotations, and the ``<torch_package_0>`` sandbox does not
+register the mangled module name in ``sys.modules`` at decoration time, so the
+``__dict__`` access raises ``AttributeError``. ``NamedTuple`` (or a plain
+class) sidesteps this entirely. Re-evaluate this constraint when the
+upstream Python / torch.package interaction is fixed.
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import NamedTuple
+
+import torch
+from fbgemm_gpu.tbe.config import EmbeddingLocation
+
+
+# Default associativity for the UVM cache (32 for CUDA, 64 for ROCm)
+DEFAULT_ASSOC: int = 32 if torch.version.hip is None else 64
+
+
+class CacheAlgorithm(enum.Enum):
+    LRU = 0
+    LFU = 1
+
+
+class MultiPassPrefetchConfig(NamedTuple):
+    # Number of passes to split indices tensor into. Actual number of passes may
+    # be less if indices tensor is too small to split.
+    num_passes: int = 12
+
+    # The minimal number of element in indices tensor to be able to split into
+    # two passes. This is useful to prevent too many prefetch kernels spamming
+    # the CUDA launch queue.
+    # The default 6M indices means 6M * 8 * 6 = approx. 300MB of memory overhead
+    # per pass.
+    min_splitable_pass_size: int = 6 * 1024 * 1024
+
+
+# Keep in sync with fbgemm_gpu/include/fbgemm_gpu/split_embeddings_cache_cuda.cuh
+class UVMCacheStatsIndex(enum.IntEnum):
+    num_calls = 0
+    num_requested_indices = 1
+    num_unique_indices = 2
+    num_unique_misses = 3
+    num_conflict_unique_misses = 4
+    num_conflict_misses = 5
+
+
+class CacheState(NamedTuple):
+    # T + 1 elements and cache_hash_size_cumsum[-1] == total_cache_hash_size
+    cache_hash_size_cumsum: list[int]
+    cache_index_table_map: list[int]
+    total_cache_hash_size: int
+
+    @classmethod
+    def construct(
+        cls,
+        row_list: list[int],
+        location_list: list[EmbeddingLocation],
+        feature_table_map: list[int],
+    ) -> CacheState:
+        """Build CacheState from row/location lists and feature table map.
+
+        Formerly the free function construct_cache_state() in
+        split_table_batched_embeddings_ops_common.py.
+        """
+        _cache_hash_size_cumsum = [0]
+        total_cache_hash_size = 0
+        for num_embeddings, location in zip(row_list, location_list):
+            if location == EmbeddingLocation.MANAGED_CACHING:
+                total_cache_hash_size += num_embeddings
+            _cache_hash_size_cumsum.append(total_cache_hash_size)
+        # [T], -1: non-cached table
+        cache_hash_size_cumsum = []
+        # [total_cache_hash_size], linear cache index -> table index
+        cache_index_table_map = [-1] * total_cache_hash_size
+        unique_feature_table_map = {}
+        for t, t_ in enumerate(feature_table_map):
+            unique_feature_table_map[t_] = t
+        for t_, t in unique_feature_table_map.items():
+            start, end = _cache_hash_size_cumsum[t_], _cache_hash_size_cumsum[t_ + 1]
+            cache_index_table_map[start:end] = [t] * (end - start)
+        cache_hash_size_cumsum = [
+            (
+                _cache_hash_size_cumsum[t_]
+                if location_list[t_] == EmbeddingLocation.MANAGED_CACHING
+                else -1
+            )
+            for t_ in feature_table_map
+        ]
+        cache_hash_size_cumsum.append(total_cache_hash_size)
+        return cls(
+            cache_hash_size_cumsum=cache_hash_size_cumsum,
+            cache_index_table_map=cache_index_table_map,
+            total_cache_hash_size=total_cache_hash_size,
+        )

--- a/fbgemm_gpu/fbgemm_gpu/tbe/config/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/config/__init__.py
@@ -22,3 +22,18 @@ from fbgemm_gpu.tbe.config.embedding_config import (  # noqa: F401
     SplitState,
     tensor_to_device,
 )
+from fbgemm_gpu.tbe.config.optimizer_config import (  # noqa: F401
+    CounterBasedRegularizationDefinition,
+    CounterWeightDecayMode,
+    CowClipDefinition,
+    DoesNotHavePrefix,
+    EmainplaceModeDefinition,
+    EnsembleModeDefinition,
+    GlobalWeightDecayDefinition,
+    GradSumDecay,
+    LearningRateMode,
+    StepMode,
+    TailIdThreshold,
+    UserEnabledConfigDefinition,
+    WeightDecayMode,
+)

--- a/fbgemm_gpu/fbgemm_gpu/tbe/config/optimizer_config.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/config/optimizer_config.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Optimizer-specific enums and frozen dataclasses for TBE.
+
+These types configure the optimizer behavior of Split Table Batched Embeddings.
+They are used exclusively at init-time — the __init__() method decomposes them
+into primitive scalar self.* attributes before JIT scripting.
+"""
+
+import enum
+from dataclasses import dataclass, field
+
+
+class DoesNotHavePrefix(Exception):
+    pass
+
+
+class WeightDecayMode(enum.IntEnum):
+    NONE = 0
+    L2 = 1
+    DECOUPLE = 2
+    COUNTER = 3
+    COWCLIP = 4
+    DECOUPLE_GLOBAL = 5
+
+
+class CounterWeightDecayMode(enum.IntEnum):
+    NONE = 0
+    L2 = 1
+    DECOUPLE = 2
+    ADAGRADW = 3
+
+
+class StepMode(enum.IntEnum):
+    NONE = 0
+    USE_COUNTER = 1
+    USE_ITER = 2
+
+
+class LearningRateMode(enum.IntEnum):
+    EQUAL = -1
+    TAIL_ID_LR_INCREASE = 0
+    TAIL_ID_LR_DECREASE = 1
+    COUNTER_SGD = 2
+
+
+class GradSumDecay(enum.IntEnum):
+    NO_DECAY = -1
+    CTR_DECAY = 0
+
+
+@dataclass(frozen=True)
+class TailIdThreshold:
+    val: float = 0
+    is_ratio: bool = False
+
+
+@dataclass(frozen=True)
+class CounterBasedRegularizationDefinition:
+    counter_weight_decay_mode: CounterWeightDecayMode = CounterWeightDecayMode.NONE
+    counter_halflife: int = -1
+    adjustment_iter: int = -1
+    adjustment_ub: float = 1.0
+    learning_rate_mode: LearningRateMode = LearningRateMode.EQUAL
+    grad_sum_decay: GradSumDecay = GradSumDecay.NO_DECAY
+    tail_id_threshold: TailIdThreshold = field(default_factory=TailIdThreshold)
+    max_counter_update_freq: int = 1000
+
+
+@dataclass(frozen=True)
+class CowClipDefinition:
+    counter_weight_decay_mode: CounterWeightDecayMode = CounterWeightDecayMode.NONE
+    counter_halflife: int = -1
+    weight_norm_coefficient: float = 0.0
+    lower_bound: float = 0.0
+
+
+@dataclass(frozen=True)
+class GlobalWeightDecayDefinition:
+    start_iter: int = 0
+    lower_bound: float = 0.0
+
+
+@dataclass(frozen=True)
+class UserEnabledConfigDefinition:
+    """
+    This class is used to configure whether certain modes are to be enabled
+    """
+
+    # This is used in Adam to perform rowwise bias correction using `row_counter`
+    # More details can be found in D64848802.
+    use_rowwise_bias_correction: bool = False
+    use_writeback_bwd_prehook: bool = False
+    writeback_first_feature_only: bool = False
+    precompute_writeback: bool = False
+
+
+@dataclass(frozen=True)
+class EnsembleModeDefinition:
+    step_ema: float = 10000
+    step_swap: float = 10000
+    step_start: float = 0
+    step_ema_coef: float = 0.6
+    step_mode: StepMode = StepMode.USE_ITER
+
+
+@dataclass(frozen=True)
+class EmainplaceModeDefinition:
+    step_ema: float = 10
+    step_start: float = 0
+    step_ema_coef: float = 0.6

--- a/fbgemm_gpu/test/tbe/cache/cache_config_test.py
+++ b/fbgemm_gpu/test/tbe/cache/cache_config_test.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Unit tests for fbgemm_gpu.tbe.cache.cache_config
+
+Tests cover:
+- CacheState.construct() parity with legacy construct_cache_state()
+- JIT integration (TBE with MANAGED_CACHING must still JIT-script)
+"""
+
+import unittest
+
+import torch
+
+
+class CacheStateConstructTest(unittest.TestCase):
+    """Test CacheState.construct() classmethod — must match legacy function exactly."""
+
+    def test_matches_legacy_construct_cache_state(self) -> None:
+        """CRITICAL: New classmethod must produce identical results to legacy function."""
+        from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+            construct_cache_state,
+            EmbeddingLocation as LegacyEmbeddingLocation,
+        )
+        from fbgemm_gpu.tbe.cache import CacheState
+        from fbgemm_gpu.tbe.config import EmbeddingLocation
+
+        row_list = [500, 1000, 750, 250, 2000]
+        location_list: list[EmbeddingLocation] = [
+            EmbeddingLocation.MANAGED_CACHING,
+            EmbeddingLocation.MANAGED_CACHING,
+            EmbeddingLocation.DEVICE,
+            EmbeddingLocation.MANAGED_CACHING,
+            EmbeddingLocation.HOST,
+        ]
+        legacy_location_list: list[LegacyEmbeddingLocation] = [
+            LegacyEmbeddingLocation(loc.value) for loc in location_list
+        ]
+        feature_table_map = [0, 1, 2, 3, 4]
+
+        legacy = construct_cache_state(
+            row_list, legacy_location_list, feature_table_map
+        )
+        new = CacheState.construct(row_list, location_list, feature_table_map)
+
+        self.assertEqual(legacy.total_cache_hash_size, new.total_cache_hash_size)
+        self.assertEqual(legacy.cache_hash_size_cumsum, new.cache_hash_size_cumsum)
+        self.assertEqual(legacy.cache_index_table_map, new.cache_index_table_map)
+
+    def test_matches_legacy_with_feature_sharing(self) -> None:
+        """Test with feature_table_map that has multiple features per table."""
+        from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+            construct_cache_state,
+            EmbeddingLocation as LegacyEmbeddingLocation,
+        )
+        from fbgemm_gpu.tbe.cache import CacheState
+        from fbgemm_gpu.tbe.config import EmbeddingLocation
+
+        row_list = [100, 200, 300]
+        location_list: list[EmbeddingLocation] = [
+            EmbeddingLocation.MANAGED_CACHING,
+            EmbeddingLocation.DEVICE,
+            EmbeddingLocation.MANAGED_CACHING,
+        ]
+        legacy_location_list: list[LegacyEmbeddingLocation] = [
+            LegacyEmbeddingLocation(loc.value) for loc in location_list
+        ]
+        feature_table_map = [0, 0, 1, 1, 2]
+
+        legacy = construct_cache_state(
+            row_list, legacy_location_list, feature_table_map
+        )
+        new = CacheState.construct(row_list, location_list, feature_table_map)
+
+        self.assertEqual(legacy.total_cache_hash_size, new.total_cache_hash_size)
+        self.assertEqual(legacy.cache_hash_size_cumsum, new.cache_hash_size_cumsum)
+        self.assertEqual(legacy.cache_index_table_map, new.cache_index_table_map)
+
+
+class CacheConfigJITTest(unittest.TestCase):
+    """Verify cache types don't break JIT scripting of TBE with caching."""
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    #  `not torch.cuda.is_available()` to decorator factory `unittest.skipIf`.
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA required")
+    def test_tbe_managed_caching_jit_script(self) -> None:
+        """TBE with MANAGED_CACHING must still JIT-script correctly."""
+        from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
+            CacheAlgorithm,
+            ComputeDevice,
+            EmbeddingLocation,
+            SplitTableBatchedEmbeddingBagsCodegen,
+        )
+
+        cc = SplitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (1000, 64, EmbeddingLocation.MANAGED_CACHING, ComputeDevice.CUDA),
+            ],
+            cache_algorithm=CacheAlgorithm.LRU,
+            cache_load_factor=0.5,
+        )
+        cc_scripted = torch.jit.script(cc)
+
+        indices = torch.randint(
+            0, 1000, (20,), device=torch.accelerator.current_accelerator()
+        )
+        offsets = torch.tensor(
+            [0, 10, 20],
+            device=torch.accelerator.current_accelerator(),
+            dtype=torch.long,
+        )
+        output = cc_scripted(indices, offsets)
+        self.assertEqual(output.shape, (2, 64))

--- a/fbgemm_gpu/test/tbe/config/optimizer_config_test.py
+++ b/fbgemm_gpu/test/tbe/config/optimizer_config_test.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Unit tests for fbgemm_gpu.tbe.config.optimizer_config
+
+Tests cover:
+- Import path correctness
+- JIT integration (TBE with various optimizer configs must still JIT-script)
+"""
+
+import enum
+import unittest
+from typing import Final
+
+import torch
+
+CUDA_NOT_AVAILABLE: Final[bool] = not torch.cuda.is_available()
+
+
+class OptimizerConfigImportTest(unittest.TestCase):
+    """Verify all optimizer types importable from tbe.config."""
+
+    def test_import_all_optimizer_types(self) -> None:
+        from fbgemm_gpu.tbe.config import (
+            CounterBasedRegularizationDefinition,
+            CounterWeightDecayMode,
+            CowClipDefinition,
+            DoesNotHavePrefix,
+            EmainplaceModeDefinition,
+            EnsembleModeDefinition,
+            GlobalWeightDecayDefinition,
+            GradSumDecay,
+            LearningRateMode,
+            StepMode,
+            TailIdThreshold,
+            UserEnabledConfigDefinition,
+            WeightDecayMode,
+        )
+
+        self.assertTrue(issubclass(WeightDecayMode, enum.IntEnum))
+        self.assertTrue(issubclass(CounterWeightDecayMode, enum.IntEnum))
+        self.assertTrue(issubclass(StepMode, enum.IntEnum))
+        self.assertTrue(issubclass(LearningRateMode, enum.IntEnum))
+        self.assertTrue(issubclass(GradSumDecay, enum.IntEnum))
+        self.assertTrue(issubclass(DoesNotHavePrefix, Exception))
+        self.assertEqual(CounterBasedRegularizationDefinition().counter_halflife, -1)
+        self.assertEqual(CowClipDefinition().weight_norm_coefficient, 0.0)
+        self.assertEqual(GlobalWeightDecayDefinition().start_iter, 0)
+        self.assertFalse(UserEnabledConfigDefinition().use_rowwise_bias_correction)
+        self.assertEqual(EnsembleModeDefinition().step_ema, 10000)
+        self.assertEqual(EmainplaceModeDefinition().step_ema, 10)
+        self.assertEqual(TailIdThreshold().val, 0)
+
+
+class OptimizerConfigJITTest(unittest.TestCase):
+    """Verify optimizer types don't interfere with TBE JIT scripting."""
+
+    @unittest.skipIf(CUDA_NOT_AVAILABLE, "CUDA required")
+    def test_tbe_jit_script_with_weight_decay_l2(self) -> None:
+        from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType
+        from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
+            ComputeDevice,
+            EmbeddingLocation,
+            SplitTableBatchedEmbeddingBagsCodegen,
+            WeightDecayMode,
+        )
+
+        cc = SplitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (100, 16, EmbeddingLocation.DEVICE, ComputeDevice.CUDA),
+            ],
+            optimizer=OptimType.EXACT_SGD,
+            learning_rate=0.01,
+            weight_decay_mode=WeightDecayMode.L2,
+            weight_decay=0.001,
+        )
+        cc_scripted = torch.jit.script(cc)
+        device = torch.accelerator.current_accelerator()
+        indices = torch.randint(0, 100, (10,), device=device)
+        offsets = torch.tensor([0, 5, 10], device=device, dtype=torch.long)
+        output = cc_scripted(indices, offsets)
+        self.assertEqual(output.shape, (2, 16))
+
+    @unittest.skipIf(CUDA_NOT_AVAILABLE, "CUDA required")
+    def test_tbe_jit_script_with_counter_regularization(self) -> None:
+        """Counter-based regularization exercises the most complex dataclass path."""
+        from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType
+        from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
+            ComputeDevice,
+            CounterBasedRegularizationDefinition,
+            EmbeddingLocation,
+            SplitTableBatchedEmbeddingBagsCodegen,
+            WeightDecayMode,
+        )
+
+        cc = SplitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (100, 16, EmbeddingLocation.DEVICE, ComputeDevice.CUDA),
+            ],
+            optimizer=OptimType.EXACT_ROWWISE_ADAGRAD,
+            learning_rate=0.01,
+            weight_decay_mode=WeightDecayMode.COUNTER,
+            counter_based_regularization=CounterBasedRegularizationDefinition(
+                counter_halflife=100,
+            ),
+        )
+        cc_scripted = torch.jit.script(cc)
+        device = torch.accelerator.current_accelerator()
+        indices = torch.randint(0, 100, (10,), device=device)
+        offsets = torch.tensor([0, 5, 10], device=device, dtype=torch.long)
+        output = cc_scripted(indices, offsets)
+        self.assertEqual(output.shape, (2, 16))


### PR DESCRIPTION
Summary:
Add `tbe/cache/cache_config.py` with cache-related types to the existing `tbe/cache/` package. Purely additive.

Types added:
- **`CacheAlgorithm`** (Enum): LRU/LFU cache replacement policy
- **`MultiPassPrefetchConfig`** (NamedTuple): multi-pass prefetch tuning knobs
- **`UVMCacheStatsIndex`** (IntEnum): indices into UVM cache statistics tensor (used in `torch.jit.export` methods)
- **`DEFAULT_ASSOC`** (constant): 32 for CUDA, 64 for ROCm
- **`CacheState`** (dataclass): cache hash size mappings, with new `construct()` classmethod

`CacheState.construct()` is byte-for-byte equivalent to the existing `construct_cache_state()` free function — verified by parity test.

Part of Chunk H series (TBE modularization): H.3 of 6 diffs. Stacked on D103256501.

Reviewed By: henrylhtsang

Differential Revision: D103267726


