### PR TITLE
Add BackendType.DRAM_SSD enum value (#5756)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -336,12 +336,14 @@ class BackendType(enum.IntEnum):
     SSD = 0
     DRAM = 1
     PS = 2
+    DRAM_SSD = 3
 
     @classmethod
     def from_str(cls, key: str) -> "BackendType":
         lookup = {
             "ssd": BackendType.SSD,
             "dram": BackendType.DRAM,
+            "dram_ssd": BackendType.DRAM_SSD,
         }
         if key in lookup:
             return lookup[key]


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2688


Provides foundational support for the new DRAM+SSD composite backend by introducing the necessary `DRAM_SSD` backend enum.

Differential Revision: D103941058


