### PR TITLE
Enable TBE nobag backward test for SGD on CPU (#5759)

### DIFF
--- a/fbgemm_gpu/test/tbe/training/backward_sgd_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_sgd_test.py
@@ -97,8 +97,8 @@ class BackwardSGDTest(unittest.TestCase):
             return
         if use_cpu and weights_precision == SparseType.FP16:
             return
-        # No bag ops only work on GPUs, no mixed, no weighted
-        if use_cpu and pooling_mode == PoolingMode.NONE:
+        # V1 API doesn't support nobag on CPU (only PT2 path does)
+        if use_cpu and pooling_mode == PoolingMode.NONE and use_api_v1:
             return
         if mixed and pooling_mode == PoolingMode.NONE:
             return
@@ -447,6 +447,47 @@ class BackwardSGDTest(unittest.TestCase):
             pooling_mode,
             use_cpu,
             SparseType.FP32,  # output_dtype
+        )
+
+    @given(
+        T=st.integers(min_value=1, max_value=3),
+        D=st.sampled_from([2, 4, 128, 256]),
+        B=st.integers(min_value=1, max_value=10),
+        log_E=st.integers(min_value=3, max_value=5),
+        L=st.integers(min_value=1, max_value=20),
+        long_segments=st.booleans(),
+    )
+    @settings(
+        verbosity=VERBOSITY,
+        max_examples=MAX_EXAMPLES,
+        deadline=None,
+        suppress_health_check=[HealthCheck.filter_too_much, HealthCheck.data_too_large],
+    )
+    def test_backward_sgd_fp32_pmNONE_cpu(
+        self,
+        T: int,
+        D: int,
+        B: int,
+        log_E: int,
+        L: int,
+        long_segments: bool,
+    ) -> None:
+        self.execute_backward_sgd_(
+            T,
+            D,
+            B,
+            log_E,
+            L,
+            weights_precision=SparseType.FP32,
+            weighted=False,
+            mixed=False,
+            mixed_B=False,
+            use_cache=False,
+            cache_algorithm=CacheAlgorithm.LRU,
+            long_segments=long_segments,
+            pooling_mode=PoolingMode.NONE,
+            use_cpu=True,
+            output_dtype=SparseType.FP32,
         )
 
     @given(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2690


The TBE (Table Batched Embedding) nobag CPU implementation was completed via the PT2 path (forward kernel in embedding_forward_split_nobag_cpu.cpp, backward kernel in embedding_backward_split_cpu_template.cpp, and PT2 dispatch wrappers) but the SGD backward test still had a vestigial filter that skipped CPU + nobag (PoolingMode.NONE) testing. The comment "No bag ops only work on GPUs" was outdated -- the adagrad backward test already exercises CPU + nobag successfully through the same infrastructure.

This diff:
1. Narrows the CPU + nobag filter in execute_backward_sgd_ to only apply when use_api_v1=True, since the V1 API path genuinely does not support nobag on CPU (only the PT2 path does).
2. Adds a dedicated test_backward_sgd_fp32_pmNONE_cpu test that explicitly exercises the SGD backward path with PoolingMode.NONE on CPU, similar to the existing test_backward_adagrad_fp32_pmNONE_cpu.

---

## Detailed Changes

This diff makes two narrowly scoped changes to `backward_sgd_test.py`. Specifically:

1. **Filter narrowing in `execute_backward_sgd_`**: Replaces the blanket `use_cpu and pooling_mode == PoolingMode.NONE` skip with `use_cpu and pooling_mode == PoolingMode.NONE and use_api_v1`. The original blanket skip predates PT2 nobag CPU support; only the V1 API still lacks it. This unblocks PT2 nobag CPU coverage for SGD without affecting V1 callers.

2. **New CPU-only nobag test method**: Adds `test_backward_sgd_fp32_pmNONE_cpu`, a hypothesis-parametrized test (T, D, B, log_E, L, long_segments) that drives `execute_backward_sgd_` with `weights_precision=FP32`, `pooling_mode=PoolingMode.NONE`, `use_cpu=True`, and `output_dtype=FP32`. This is the SGD analog of the existing `test_backward_adagrad_fp32_pmNONE_cpu`, ensuring symmetric coverage between the two optimizers on the PT2 nobag CPU path.

### fbcode/deeplearning/fbgemm/fbgemm_gpu/test/tbe/training/backward_sgd_test.py
- Updated the early-return guard inside `execute_backward_sgd_` so CPU + `PoolingMode.NONE` is only filtered out for the V1 API (`use_api_v1=True`); the PT2 path now flows through to the kernel.
- Updated the comment from "No bag ops only work on GPUs" to "V1 API doesn't support nobag on CPU (only PT2 path does)" to reflect current reality.
- Added a new `given` / `settings`-decorated `test_backward_sgd_fp32_pmNONE_cpu` method on `BackwardSGDTest`, mirroring the parametrization of the analogous Adagrad test.

Reviewed By: henrylhtsang

Differential Revision: D103496541


