### PR TITLE
Remove erroneous NVIDIA proprietary block from BSD-3 LICENSE

### DIFF
--- a/fbgemm_gpu/experimental/hstu/LICENSE
+++ b/fbgemm_gpu/experimental/hstu/LICENSE
@@ -27,15 +27,3 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-/*
- * SPDX-FileCopyrightText: Copyright (c) <2024> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
- *
- * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
- * property and proprietary rights in and to this material, related
- * documentation and any modifications thereto. Any use, reproduction,
- * disclosure or distribution of this material and related documentation
- * without an express license agreement from NVIDIA CORPORATION or
- * its affiliates is strictly prohibited.
- */


### PR DESCRIPTION
Summary:
The LICENSE file at fbgemm_gpu/experimental/hstu/LICENSE is BSD-3-Clause,
but had 10 trailing comment lines (wrapped in C-style /* */) claiming the
content is proprietary to NVIDIA. This was a copy-paste error introduced in
pytorch/FBGEMM PR #4090 and conflicts with the BSD-3-Clause license declared
at the top of the file.

Because this LICENSE file is shipped inside PyTorch wheels, the bogus block
is user-visible and creates real licensing ambiguity for downstream consumers.

This removes the proprietary block (and the blank line preceding it), leaving
only the original BSD-3-Clause license text intact. Matches the upstream fix
in pytorch/FBGEMM PR #4998.

Fixes pytorch/FBGEMM#5757.

Differential Revision: D105016954


