### PR TITLE
Make lengths tensor contiguous in pack_segments CUDA kernels

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_pack_segments_backward.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_pack_segments_backward.cu
@@ -63,11 +63,12 @@ DLL_PUBLIC Tensor pack_segments_backward_cuda(
   CUDA_DEVICE_GUARD(data);
 
   const auto data_contig = data.expect_contiguous();
+  const auto lengths_c = lengths.contiguous();
 
   Tensor unpacked_tensor; // The output tensor
 
-  AT_DISPATCH_INDEX_TYPES(lengths.scalar_type(), "unpack_segments_cuda", [&] {
-    const auto* const lengths_data = lengths.const_data_ptr<index_t>();
+  AT_DISPATCH_INDEX_TYPES(lengths_c.scalar_type(), "unpack_segments_cuda", [&] {
+    const auto* const lengths_data = lengths_c.const_data_ptr<index_t>();
 
     // Create output tensor of appropriate dimensions
     auto shape = data_contig->sizes().vec();
@@ -81,12 +82,12 @@ DLL_PUBLIC Tensor pack_segments_backward_cuda(
     }
 
     auto lengths_prefix_sum =
-        fbgemm_gpu::asynchronous_exclusive_cumsum_gpu(lengths);
+        fbgemm_gpu::asynchronous_exclusive_cumsum_gpu(lengths_c);
     auto lps_data = lengths_prefix_sum.data_ptr<index_t>();
 
     FBGEMM_DISPATCH_ALL_TYPES(
         data_contig->scalar_type(), "unpack_segments_cuda-unpacking", [&] {
-          const auto num_seq = lengths.size(0);
+          const auto num_seq = lengths_c.size(0);
           const auto cell_size = data_contig->numel() /
               (data_contig->size(0) * data_contig->size(1));
           const auto* const data_ptr = data_contig->const_data_ptr<scalar_t>();

--- a/fbgemm_gpu/src/sparse_ops/sparse_pack_segments_forward.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_pack_segments_forward.cu
@@ -107,32 +107,33 @@ DLL_PUBLIC Tensor pack_segments_forward_cuda(
   CUDA_DEVICE_GUARD(t_in);
 
   const auto t_in_c = t_in.contiguous();
+  const auto lengths_c = lengths.contiguous();
 
   Tensor packed_tensor;
 
-  AT_DISPATCH_INDEX_TYPES(lengths.scalar_type(), "pack_segments_cuda", [&] {
-    const auto* const lengths_data = lengths.const_data_ptr<index_t>();
+  AT_DISPATCH_INDEX_TYPES(lengths_c.scalar_type(), "pack_segments_cuda", [&] {
+    const auto* const lengths_data = lengths_c.const_data_ptr<index_t>();
 
     // Shape of output is batch_size x max_len x ...
     auto shape = t_in_c.sizes().vec(); // Get copy of current shape
     shape[0] = max_length; // Set first element to max_len
     shape.insert(
-        shape.begin(), lengths.numel()); // Insert batch size at beginning
+        shape.begin(), lengths_c.numel()); // Insert batch size at beginning
     packed_tensor = at::zeros(shape, t_in_c.options());
 
-    if (t_in_c.size(0) == 0 || lengths.size(0) == 0) {
+    if (t_in_c.size(0) == 0 || lengths_c.size(0) == 0) {
       return; // Return empty output (with the proper shape)
     }
 
     auto lengths_prefix_sum =
-        fbgemm_gpu::asynchronous_exclusive_cumsum_gpu(lengths);
+        fbgemm_gpu::asynchronous_exclusive_cumsum_gpu(lengths_c);
     auto lps_data = lengths_prefix_sum.data_ptr<index_t>();
 
     FBGEMM_DISPATCH_ALL_TYPES(
         t_in_c.scalar_type(), "pack_segments_cuda-packing", [&] {
           const auto* const data_ptr = t_in_c.const_data_ptr<scalar_t>();
           auto* const out_data = packed_tensor.mutable_data_ptr<scalar_t>();
-          const auto num_seq = lengths.size(0);
+          const auto num_seq = lengths_c.size(0);
           const auto cell_size = t_in_c.numel() / t_in_c.size(0);
 
           FBGEMM_LAUNCH_DSA_KERNEL(
@@ -188,22 +189,22 @@ pack_segments_forward_cuda_v2(
   CUDA_DEVICE_GUARD(t_in);
 
   const auto t_in_c = t_in.contiguous();
+  const auto lengths_c = lengths.contiguous();
 
   Tensor packed_tensor;
   std::optional<Tensor> presence_mask;
 
-  AT_DISPATCH_INDEX_TYPES(lengths.scalar_type(), "pack_segments_cuda", [&] {
-    const auto* const lengths_data = lengths.const_data_ptr<index_t>();
+  AT_DISPATCH_INDEX_TYPES(lengths_c.scalar_type(), "pack_segments_cuda", [&] {
+    const auto* const lengths_data = lengths_c.const_data_ptr<index_t>();
 
     // Shape of output is batch_size x max_len x ...
     auto shape = t_in_c.sizes().vec(); // Get copy of current shape
     shape[0] = max_length; // Set first element to max_len
     shape.insert(
-        shape.begin(), lengths.numel()); // Insert batch size at beginning
+        shape.begin(), lengths_c.numel()); // Insert batch size at beginning
     packed_tensor = at::zeros(shape, t_in_c.options());
 
     if (pad_minf) {
-      // Downcasting double infinity to float should still give infinity
       packed_tensor = at::full(
           shape, -std::numeric_limits<double>::infinity(), t_in_c.options());
     } else {
@@ -212,25 +213,24 @@ pack_segments_forward_cuda_v2(
 
     bool* presence_mask_data = nullptr;
     if (return_presence_mask) {
-      // Shape of presence is batch_size x max_len
       presence_mask = at::zeros(
-          {lengths.numel(), max_length}, t_in_c.options().dtype(at::kBool));
+          {lengths_c.numel(), max_length}, t_in_c.options().dtype(at::kBool));
       presence_mask_data = presence_mask->mutable_data_ptr<bool>();
     }
 
-    if (t_in_c.size(0) == 0 || lengths.size(0) == 0) {
+    if (t_in_c.size(0) == 0 || lengths_c.size(0) == 0) {
       return; // Return empty output (with the proper shape)
     }
 
     auto lengths_prefix_sum =
-        fbgemm_gpu::asynchronous_exclusive_cumsum_gpu(lengths);
+        fbgemm_gpu::asynchronous_exclusive_cumsum_gpu(lengths_c);
     auto lps_data = lengths_prefix_sum.data_ptr<index_t>();
 
     FBGEMM_DISPATCH_ALL_TYPES(
         t_in_c.scalar_type(), "pack_segments_cuda-packing", [&] {
           const auto* const data_ptr = t_in_c.const_data_ptr<scalar_t>();
           auto* const out_data = packed_tensor.mutable_data_ptr<scalar_t>();
-          const auto num_seq = lengths.size(0);
+          const auto num_seq = lengths_c.size(0);
           const auto cell_size = t_in_c.numel() / t_in_c.size(0);
 
           FBGEMM_LAUNCH_DSA_KERNEL(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2687

https://fb.workplace.com/groups/gpuinference/permalink/3542202645928378/

The pack_segments CUDA forward kernels (v1 and v2) and backward kernel
pass the `lengths` tensor directly to `asynchronous_exclusive_cumsum_gpu`,
which asserts `TORCH_CHECK(t_in.is_contiguous())`. When `lengths` is
non-contiguous (e.g. from a squeeze op), this crashes with a misleading
error: "Expected t_in.is_contiguous() to be true, but got false."

The `t_in` (data) tensor was already made contiguous via `.contiguous()`,
but `lengths` was not — its raw data pointer was also accessed directly
via `const_data_ptr`, which produces incorrect results for non-contiguous
tensors.

This fix adds `lengths.contiguous()` in all three CUDA kernels, consistent
with how `t_in` is already handled.

Reviewed By: q10

Differential Revision: D104683021


