### PR TITLE
ci: declare workflow-level `contents: read` on 11 workflows

### DIFF
--- a/.github/workflows/fbgemm_ci.yml
+++ b/.github/workflows/fbgemm_ci.yml
@@ -23,6 +23,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     if: ${{ github.repository_owner == 'pytorch' }}

--- a/.github/workflows/fbgemm_gpu_benchmark_cpu.yml
+++ b/.github/workflows/fbgemm_gpu_benchmark_cpu.yml
@@ -29,6 +29,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Build on CPU hosts, run tests, and upload to GHA
   build_artifact:

--- a/.github/workflows/fbgemm_gpu_benchmark_cuda.yml
+++ b/.github/workflows/fbgemm_gpu_benchmark_cuda.yml
@@ -28,6 +28,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: ${{ github.repository_owner == 'pytorch' }}

--- a/.github/workflows/fbgemm_gpu_benchmark_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_benchmark_rocm.yml
@@ -28,6 +28,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Build on CPU hosts and upload to GHA
   build_artifact:

--- a/.github/workflows/fbgemm_gpu_ci_cpu.yml
+++ b/.github/workflows/fbgemm_gpu_ci_cpu.yml
@@ -49,6 +49,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Build on CPU hosts, run tests, and upload to GHA
   build_artifact:

--- a/.github/workflows/fbgemm_gpu_ci_cuda.yml
+++ b/.github/workflows/fbgemm_gpu_ci_cuda.yml
@@ -48,6 +48,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   generate-build-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}

--- a/.github/workflows/fbgemm_gpu_ci_genai_generic_infra.yml
+++ b/.github/workflows/fbgemm_gpu_ci_genai_generic_infra.yml
@@ -33,6 +33,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   generate-build-matrix:
     if: ${{ github.repository_owner != 'pytorch' }}

--- a/.github/workflows/fbgemm_gpu_ci_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_ci_rocm.yml
@@ -48,6 +48,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Build on CPU hosts and upload to GHA
   build_artifact:

--- a/.github/workflows/fbgemm_gpu_lint.yml
+++ b/.github/workflows/fbgemm_gpu_lint.yml
@@ -27,6 +27,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   run-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/fbgemm_gpu_pip.yml
+++ b/.github/workflows/fbgemm_gpu_pip.yml
@@ -48,6 +48,8 @@ on:
         options: [ "cpu", "cuda", "rocm" ]
         default: "cpu"
 
+permissions:
+  contents: read
 
 jobs:
   generate-test-matrix-cuda:

--- a/.github/workflows/fbgemm_gpu_torchrec_ci_cpu.yml
+++ b/.github/workflows/fbgemm_gpu_torchrec_ci_cpu.yml
@@ -49,6 +49,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Build on CPU hosts, run tests, and upload to GHA
   build_artifact:


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 11 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.