### PR TITLE
Replace at::_unique with cub pipeline + end_bit trim (#5769)

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_unique_indices.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_unique_indices.cu
@@ -22,6 +22,11 @@ using Tensor = at::Tensor;
 
 namespace fbgemm_gpu {
 
+// Block size for the flat-grid kernels in this file. 256 = 8 warps, chosen
+// so the SM scheduler can pack ~4-8 blocks per SM on H100 given the
+// flat-grid launches with grid = total_B (or num_unique).
+static constexpr int32_t kFlatBlockSize = 256;
+
 // Linearzie the index with the cumsum of hash size so that linearized indices
 // can be sorted together.
 template <typename index_t>
@@ -79,69 +84,112 @@ __global__ __launch_bounds__(kMaxThreads) void delinearize_unique_index_kernel(
   }
 }
 
-// Compute the lengths for each feature in the unique indices. The range of
-// indices for each feature equals to the difference between the max and min
-// values in the reverse index array.
-template <typename index_t, auto max_value, auto min_value>
-__global__ __launch_bounds__(kMaxThreads) void unique_indices_length_kernel(
+// Device-side lower_bound over a PackedTensorAccessor32<index_t, 1>.
+// Returns the first position whose value is >= `value`, equivalent to
+// std::lower_bound on the underlying sorted array.
+template <typename index_t>
+__device__ __forceinline__ int32_t device_lower_bound(
+    const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>& arr,
+    const index_t value) {
+  int32_t lo = 0;
+  int32_t hi = arr.size(0);
+  while (lo < hi) {
+    const int32_t mid = lo + ((hi - lo) >> 1);
+    if (arr[mid] < value) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+}
+
+// Compute the per-(feature, batch) lengths for the unique indices.
+//
+// Caller-provided invariant (see jagged_unique_indices_cuda for the
+// pipeline contract that establishes it): `linear_unique_indices` is
+// sorted ascending, and feature t's values occupy a contiguous slice
+//   [lower_bound(linear_unique_indices, hash_size_cumsum[t]),
+//    lower_bound(linear_unique_indices, hash_size_cumsum[t+1])).
+// The slice length equals num_unique_t for feature t.
+template <typename index_t>
+__global__ __launch_bounds__(kFlatBlockSize) void unique_indices_length_kernel(
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         hash_size_offsets,
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
-        reverse_index,
+        hash_size_cumsum,
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
-        offsets,
-    pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> lengths) {
-  typedef cub::BlockReduce<index_t, kMaxThreads> BlockReduce;
-  __shared__ typename BlockReduce::TempStorage temp_storage_max;
-  __shared__ typename BlockReduce::TempStorage temp_storage_min;
-  __shared__ index_t block_results[2];
-
+        linear_unique_indices,
+    pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> lengths,
+    const int32_t batch_size) {
   const auto tid = threadIdx.x;
   const auto bid = blockIdx.x;
-  const auto num_blocks = gridDim.x;
-  const int32_t batch_size = (offsets.size(0) - 1) / num_blocks;
 
-  const auto offset_begin = hash_size_offsets[bid] * batch_size;
-  const auto offset_end = hash_size_offsets[bid + 1] * batch_size;
-  const auto num_lengths = (offset_end - offset_begin);
-
-  const auto reverse_index_begin = offsets[offset_begin];
-  const auto reverse_index_end = offsets[offset_end];
-
-  if (reverse_index_begin == reverse_index_end) {
+  const auto hash_begin = hash_size_offsets[bid];
+  const auto hash_end = hash_size_offsets[bid + 1];
+  const auto offset_begin = hash_begin * batch_size;
+  const auto offset_end = hash_end * batch_size;
+  const auto num_lengths = offset_end - offset_begin;
+  if (num_lengths == 0) {
     return;
   }
 
-  index_t t_max = min_value;
-  index_t t_min = max_value;
-  for (index_t i = (reverse_index_begin + tid); i < reverse_index_end;
-       i += kMaxThreads) {
-    const index_t value = reverse_index[i];
-    t_max = (value > t_max) ? value : t_max;
-    t_min = (value < t_min) ? value : t_min;
-  }
-
-  index_t block_max =
-      BlockReduce(temp_storage_max).Reduce(t_max, Max<index_t>());
-  index_t block_min =
-      BlockReduce(temp_storage_min).Reduce(t_min, Min<index_t>());
+  __shared__ index_t s_div_length;
+  __shared__ index_t s_r_length;
   if (tid == 0) {
-    block_results[0] = block_max;
-    block_results[1] = block_min;
+    const auto low = hash_size_cumsum[hash_begin];
+    const auto high = hash_size_cumsum[hash_end];
+    if (low == high) {
+      // Empty feature group. Output is pre-zeroed by at::zeros at the
+      // launch site; nothing to write.
+      s_div_length = 0;
+      s_r_length = 0;
+    } else {
+      const int32_t lo_pos =
+          device_lower_bound<index_t>(linear_unique_indices, low);
+      const int32_t hi_pos =
+          device_lower_bound<index_t>(linear_unique_indices, high);
+      const index_t total_length = static_cast<index_t>(hi_pos - lo_pos);
+      s_div_length = total_length / static_cast<index_t>(num_lengths);
+      s_r_length = total_length % static_cast<index_t>(num_lengths);
+    }
   }
   __syncthreads();
 
-  t_max = block_results[0];
-  t_min = block_results[1];
-  const index_t total_length = (t_max - t_min) + 1;
-  const index_t div_length = total_length / num_lengths;
-  const index_t r_length = total_length % num_lengths;
-  for (int32_t i = tid; i < num_lengths; i += kMaxThreads) {
-    index_t seg_length = (i < r_length) ? (div_length + 1) : div_length;
+  const index_t div_length = s_div_length;
+  const index_t r_length = s_r_length;
+  if (div_length == 0 && r_length == 0) {
+    return;
+  }
+  for (int32_t i = tid; i < num_lengths; i += blockDim.x) {
+    const index_t seg_length =
+        (static_cast<index_t>(i) < r_length) ? (div_length + 1) : div_length;
     lengths[offset_begin + i] = seg_length;
   }
 }
 
+// Pipeline (cross-kernel data flow that ties the four steps together):
+//
+//   1. linearize_index_wo_infos_kernel writes
+//        linear_indices[i] = hash_size_cumsum[t] + indices[i]
+//      so feature t's linearized values lie in
+//        [hash_size_cumsum[t], hash_size_cumsum[t+1]).
+//
+//   2. at::_unique(linear_indices, sorted=True, return_inverse=True)
+//      returns (linear_unique_indices, reverse_index) where
+//      linear_unique_indices is sorted ascending. Combined with (1), this
+//      means feature t's unique linearized values occupy a contiguous
+//      slice of linear_unique_indices.
+//
+//   3. delinearize_unique_index_kernel scatters the original
+//      (pre-linearization) per-feature index values back into
+//      unique_indices via reverse_index.
+//
+//   4. unique_indices_length_kernel relies on (1)+(2) to compute
+//      num_unique per feature group via two binary searches over
+//      linear_unique_indices, instead of an O(N) reduction over
+//      reverse_index. See the kernel's docstring for the local form of
+//      the invariant.
 std::tuple<Tensor, Tensor, Tensor, Tensor> jagged_unique_indices_cuda(
     const Tensor& hash_size_cumsum,
     const Tensor& hash_size_offsets,
@@ -192,18 +240,16 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> jagged_unique_indices_cuda(
   Tensor output_lengths = at::zeros({total_B}, offsets.options());
   AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "unique_indices_length", ([&] {
                             FBGEMM_LAUNCH_KERNEL(
-                                (unique_indices_length_kernel<
-                                    index_t,
-                                    std::numeric_limits<index_t>::max(),
-                                    std::numeric_limits<index_t>::min()>),
+                                (unique_indices_length_kernel<index_t>),
                                 T,
-                                kMaxThreads,
+                                kFlatBlockSize,
                                 0,
                                 at::cuda::getCurrentCUDAStream(),
                                 PTA_B(hash_size_offsets, index_t, 1, 32),
-                                PTA_B(reverse_index, index_t, 1, 32),
-                                PTA_B(offsets, index_t, 1, 32),
-                                PTA_B(output_lengths, index_t, 1, 32));
+                                PTA_B(hash_size_cumsum, index_t, 1, 32),
+                                PTA_B(linear_unique_indices, index_t, 1, 32),
+                                PTA_B(output_lengths, index_t, 1, 32),
+                                static_cast<int32_t>(total_B / T));
                           }));
 
   Tensor output_offsets;

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_unique_indices.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_unique_indices.cu
@@ -27,10 +27,17 @@ namespace fbgemm_gpu {
 // flat-grid launches with grid = total_B (or num_unique).
 static constexpr int32_t kFlatBlockSize = 256;
 
-// Linearzie the index with the cumsum of hash size so that linearized indices
-// can be sorted together.
+// Linearize the index with the cumsum of hash size so that linearized indices
+// can be sorted together. Flat-grid: one block per (t, b) sample.
+//
+// Replaces the prior warp-cooperative kernel which was launched as
+//   grid = ceil(total_B / kMaxThreads)
+// On production shapes total_B is in the low thousands and kMaxThreads = 1024,
+// so the prior launch consumed only ~5 SMs out of 132 on H100 with each warp
+// shuffling work between lanes. The flat grid uses one block per sample,
+// dispatching all SMs and removing the intra-warp shuffle dance.
 template <typename index_t>
-__global__ __launch_bounds__(kMaxThreads) void linearize_index_wo_infos_kernel(
+__global__ __launch_bounds__(kFlatBlockSize) void linearize_index_flat_kernel(
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         hash_size_cumsum,
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
@@ -40,27 +47,21 @@ __global__ __launch_bounds__(kMaxThreads) void linearize_index_wo_infos_kernel(
     pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         linear_indices,
     FixedDivisor fd) {
-  const auto b_t = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto b_t = blockIdx.x;
   int32_t b;
   int32_t t;
-  const auto total_B = offsets.size(0) - 1;
-  const auto valid = b_t < total_B;
+  fd.DivMod(static_cast<int32_t>(b_t), &t, &b);
 
-  fd.DivMod(b_t, &t, &b);
+  const auto indices_start = offsets[b_t];
+  const auto L = offsets[b_t + 1] - indices_start;
+  if (L == 0) {
+    return;
+  }
+  const auto hash_offset = hash_size_cumsum[t];
 
-  const auto hash_offset = valid ? hash_size_cumsum[t] : -1;
-  const auto indices_start = valid ? offsets[b_t] : -1;
-  const int32_t L = valid ? offsets[b_t + 1] - indices_start : 0;
-  const auto lane_id = threadIdx.x % fbgemm_gpu::kWarpSize;
-
-  for (int32_t j = 0; j < fbgemm_gpu::kWarpSize; ++j) {
-    const auto indices_start_warp = fbgemm_gpu::shfl_sync(indices_start, j);
-    const auto L_warp = fbgemm_gpu::shfl_sync(L, j);
-    const auto hash_offset_warp = fbgemm_gpu::shfl_sync(hash_offset, j);
-    for (int32_t i = lane_id; i < L_warp; i += fbgemm_gpu::kWarpSize) {
-      const auto idx = __ldg(&indices[indices_start_warp + i]);
-      linear_indices[indices_start_warp + i] = hash_offset_warp + idx;
-    }
+  for (auto i = threadIdx.x; i < L; i += blockDim.x) {
+    const auto idx = __ldg(&indices[indices_start + i]);
+    linear_indices[indices_start + i] = hash_offset + idx;
   }
 }
 
@@ -170,7 +171,7 @@ __global__ __launch_bounds__(kFlatBlockSize) void unique_indices_length_kernel(
 
 // Pipeline (cross-kernel data flow that ties the four steps together):
 //
-//   1. linearize_index_wo_infos_kernel writes
+//   1. linearize_index_flat_kernel writes
 //        linear_indices[i] = hash_size_cumsum[t] + indices[i]
 //      so feature t's linearized values lie in
 //        [hash_size_cumsum[t], hash_size_cumsum[t+1]).
@@ -204,9 +205,9 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> jagged_unique_indices_cuda(
 
   AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "linearize_index", ([&] {
                             FBGEMM_LAUNCH_KERNEL(
-                                (linearize_index_wo_infos_kernel<index_t>),
-                                div_round_up(total_B, kMaxThreads),
-                                kMaxThreads,
+                                (linearize_index_flat_kernel<index_t>),
+                                total_B,
+                                kFlatBlockSize,
                                 0,
                                 at::cuda::getCurrentCUDAStream(),
                                 PTA_B(hash_size_cumsum, index_t, 1, 32),

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_unique_indices.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_unique_indices.cu
@@ -18,6 +18,8 @@
 
 #include "fbgemm_gpu/split_embeddings_utils.cuh"
 
+#include <climits>
+
 using Tensor = at::Tensor;
 
 namespace fbgemm_gpu {
@@ -68,11 +70,17 @@ __global__ __launch_bounds__(kFlatBlockSize) void linearize_index_flat_kernel(
 // Delinearize the unique indices from the reverse index info and the original
 // indices. For each element in the input indices, the value should equal to
 // the element from the unique indices according to the reverse index info.
+//
+// reverse_index is always int64 to match the public contract of
+// jagged_unique_indices (see jagged_unique_scatter_kernel), independent of
+// indices.scalar_type(); typing it as int64_t here (instead of reusing
+// index_t) keeps PTA_B's runtime dtype check from firing when index_t is
+// int32_t.
 template <typename index_t>
 __global__ __launch_bounds__(kMaxThreads) void delinearize_unique_index_kernel(
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         indices,
-    const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
         reverse_index,
     pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         unique_indices) {
@@ -83,6 +91,177 @@ __global__ __launch_bounds__(kMaxThreads) void delinearize_unique_index_kernel(
     const auto pos = reverse_index[b_t];
     unique_indices[pos] = original_index;
   }
+}
+
+// Adjacent-difference over sorted keys. out[0] = 0; out[i > 0] = 1 if
+// sorted[i] != sorted[i-1] else 0. Mirrors
+// caffe2/aten/src/ATen/native/cuda/UniqueCub.cu.
+template <typename index_t>
+__global__
+__launch_bounds__(kFlatBlockSize) void jagged_unique_adjacent_diff_kernel(
+    const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
+        sorted_keys,
+    pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> out) {
+  const auto n = sorted_keys.size(0);
+  const auto i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < static_cast<uint64_t>(n)) {
+    out[i] = (i > 0 && sorted_keys[i] != sorted_keys[i - 1]) ? 1 : 0;
+  }
+}
+
+// Scatter inv_loc_out[i] -> reverse_index[sorted_positions[i]] to recover the
+// inverse-index in the original input order. Output is int64 to preserve the
+// public contract of jagged_unique_indices (matches at::_unique's historical
+// inverse-index dtype).
+__global__ __launch_bounds__(kFlatBlockSize) void jagged_unique_scatter_kernel(
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        sorted_positions,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits>
+        inv_loc_out,
+    pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+        reverse_index) {
+  const auto n = sorted_positions.size(0);
+  const auto i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < static_cast<uint64_t>(n)) {
+    reverse_index[sorted_positions[i]] = static_cast<int64_t>(inv_loc_out[i]);
+  }
+}
+
+// Cub-based replacement for at::_unique(linear_indices, sorted=true,
+// return_inverse=true). Returns sorted unique linearized keys and an
+// int64 inverse-index in the original input order.
+//
+// Pipeline:
+//   1. cub::DeviceRadixSort::SortPairs on (linear_indices, arange-positions)
+//      with end_bit trimmed to the bit-width of total_hash_size, cutting
+//      radix-sort passes from ceil(64/8)=8 to ceil(bit_width/8) (e.g. 3
+//      passes for hash_size=1M).
+//   2. cub::DeviceRunLengthEncode::Encode to extract the sorted unique keys.
+//   3. adjacent_diff -> inclusive_scan -> scatter to recover the inverse
+//      index in the original (pre-sort) input order, mirroring pytorch's
+//      UniqueCub.cu pattern.
+template <typename index_t>
+static void jagged_unique_indices_pipeline(
+    const Tensor& linear_indices,
+    const int total_hash_size_bits,
+    Tensor& linear_unique_indices,
+    Tensor& reverse_index) {
+  const int64_t N = linear_indices.numel();
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  const auto int32_opts = linear_indices.options().dtype(at::kInt);
+  const auto int64_opts = linear_indices.options().dtype(at::kLong);
+  const auto byte_opts = linear_indices.options().dtype(at::kByte);
+
+  // --- Step 1: radix sort pairs ---
+  Tensor sorted_keys = at::empty({N}, linear_indices.options());
+  Tensor positions = at::arange(N, int32_opts);
+  Tensor sorted_positions = at::empty({N}, int32_opts);
+  {
+    size_t temp_storage_bytes = 0;
+    AT_CUDA_CHECK(radix_sort_pairs(
+        nullptr,
+        temp_storage_bytes,
+        linear_indices.const_data_ptr<index_t>(),
+        sorted_keys.data_ptr<index_t>(),
+        positions.const_data_ptr<int32_t>(),
+        sorted_positions.data_ptr<int32_t>(),
+        static_cast<int>(N),
+        0,
+        total_hash_size_bits,
+        stream));
+    Tensor temp_storage =
+        at::empty({static_cast<int64_t>(temp_storage_bytes)}, byte_opts);
+    AT_CUDA_CHECK(radix_sort_pairs(
+        temp_storage.data_ptr(),
+        temp_storage_bytes,
+        linear_indices.const_data_ptr<index_t>(),
+        sorted_keys.data_ptr<index_t>(),
+        positions.const_data_ptr<int32_t>(),
+        sorted_positions.data_ptr<int32_t>(),
+        static_cast<int>(N),
+        0,
+        total_hash_size_bits,
+        stream));
+  }
+
+  // --- Step 2: run-length encode to extract sorted unique keys ---
+  Tensor unique_keys = at::empty({N}, linear_indices.options());
+  Tensor run_lengths = at::empty({N}, int32_opts);
+  Tensor num_unique_d = at::empty({1}, int32_opts);
+  {
+    size_t temp_storage_bytes = 0;
+    AT_CUDA_CHECK(
+        FBGEMM_GPU_CUB_NS_PREFIX cub::DeviceRunLengthEncode::Encode(
+            nullptr,
+            temp_storage_bytes,
+            sorted_keys.const_data_ptr<index_t>(),
+            unique_keys.data_ptr<index_t>(),
+            run_lengths.data_ptr<int32_t>(),
+            num_unique_d.data_ptr<int32_t>(),
+            static_cast<int>(N),
+            stream));
+    Tensor temp_storage =
+        at::empty({static_cast<int64_t>(temp_storage_bytes)}, byte_opts);
+    AT_CUDA_CHECK(
+        FBGEMM_GPU_CUB_NS_PREFIX cub::DeviceRunLengthEncode::Encode(
+            temp_storage.data_ptr(),
+            temp_storage_bytes,
+            sorted_keys.const_data_ptr<index_t>(),
+            unique_keys.data_ptr<index_t>(),
+            run_lengths.data_ptr<int32_t>(),
+            num_unique_d.data_ptr<int32_t>(),
+            static_cast<int>(N),
+            stream));
+  }
+  const int32_t num_unique = num_unique_d.item<int32_t>();
+  linear_unique_indices = unique_keys.narrow(0, 0, num_unique);
+
+  // --- Step 3: build inverse-index (adjacent_diff + inclusive_scan + scatter)
+  // ---
+  Tensor inv_loc = at::empty({N}, int32_opts);
+  FBGEMM_LAUNCH_KERNEL(
+      (jagged_unique_adjacent_diff_kernel<index_t>),
+      static_cast<int32_t>((N + kFlatBlockSize - 1) / kFlatBlockSize),
+      kFlatBlockSize,
+      0,
+      stream,
+      PTA_B(sorted_keys, index_t, 1, 32),
+      PTA_B(inv_loc, int32_t, 1, 32));
+
+  Tensor inv_loc_out = at::empty({N}, int32_opts);
+  {
+    size_t temp_storage_bytes = 0;
+    AT_CUDA_CHECK(
+        FBGEMM_GPU_CUB_NS_PREFIX cub::DeviceScan::InclusiveSum(
+            nullptr,
+            temp_storage_bytes,
+            inv_loc.const_data_ptr<int32_t>(),
+            inv_loc_out.data_ptr<int32_t>(),
+            static_cast<int>(N),
+            stream));
+    Tensor temp_storage =
+        at::empty({static_cast<int64_t>(temp_storage_bytes)}, byte_opts);
+    AT_CUDA_CHECK(
+        FBGEMM_GPU_CUB_NS_PREFIX cub::DeviceScan::InclusiveSum(
+            temp_storage.data_ptr(),
+            temp_storage_bytes,
+            inv_loc.const_data_ptr<int32_t>(),
+            inv_loc_out.data_ptr<int32_t>(),
+            static_cast<int>(N),
+            stream));
+  }
+
+  reverse_index = at::empty({N}, int64_opts);
+  FBGEMM_LAUNCH_KERNEL(
+      (jagged_unique_scatter_kernel),
+      static_cast<int32_t>((N + kFlatBlockSize - 1) / kFlatBlockSize),
+      kFlatBlockSize,
+      0,
+      stream,
+      PTA_B(sorted_positions, int32_t, 1, 32),
+      PTA_B(inv_loc_out, int32_t, 1, 32),
+      PTA_B(reverse_index, int64_t, 1, 32));
 }
 
 // Device-side lower_bound over a PackedTensorAccessor32<index_t, 1>.
@@ -169,18 +348,21 @@ __global__ __launch_bounds__(kFlatBlockSize) void unique_indices_length_kernel(
   }
 }
 
-// Pipeline (cross-kernel data flow that ties the four steps together):
+// Pipeline (cross-kernel data flow that ties the steps together):
 //
 //   1. linearize_index_flat_kernel writes
 //        linear_indices[i] = hash_size_cumsum[t] + indices[i]
 //      so feature t's linearized values lie in
 //        [hash_size_cumsum[t], hash_size_cumsum[t+1]).
 //
-//   2. at::_unique(linear_indices, sorted=True, return_inverse=True)
-//      returns (linear_unique_indices, reverse_index) where
-//      linear_unique_indices is sorted ascending. Combined with (1), this
-//      means feature t's unique linearized values occupy a contiguous
-//      slice of linear_unique_indices.
+//   2. jagged_unique_indices_pipeline replaces at::_unique with an
+//      explicit cub radix sort + RLE + inverse-index scatter, returning
+//      (linear_unique_indices, reverse_index). linear_unique_indices is
+//      sorted ascending. Combined with (1), this means feature t's unique
+//      linearized values occupy a contiguous slice of linear_unique_indices.
+//      The radix sort end_bit is trimmed to bit_width(total_hash_size),
+//      which on production shapes (hash_size ~1M) reduces 8 radix passes
+//      to ~3.
 //
 //   3. delinearize_unique_index_kernel scatters the original
 //      (pre-linearization) per-feature index values back into
@@ -196,8 +378,25 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> jagged_unique_indices_cuda(
     const Tensor& hash_size_offsets,
     const Tensor& offsets,
     const Tensor& indices) {
+  TORCH_CHECK(hash_size_cumsum.dtype() == indices.dtype());
+  TORCH_CHECK(
+      hash_size_cumsum.numel() >= 2,
+      "jagged_unique_indices: hash_size_cumsum must have at least 2 entries "
+      "(T >= 1), got ",
+      hash_size_cumsum.numel());
+
   const auto total_B = offsets.size(0) - 1;
   const auto T = hash_size_cumsum.size(0) - 1;
+  const auto N = indices.numel();
+  // The cub pipeline uses int32 positions and an int32 num_items argument
+  // for radix sort, RLE, and scan, so N must fit in int32. In practice this
+  // is enforced upstream by the int32 PackedTensorAccessor on indices, but
+  // we make it explicit here to fail loudly rather than silently truncating.
+  TORCH_CHECK(
+      N < static_cast<int64_t>(INT32_MAX),
+      "jagged_unique_indices: indices.numel() (",
+      N,
+      ") exceeds INT32_MAX");
 
   Tensor linear_indices = at::empty_like(indices);
 
@@ -219,8 +418,46 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> jagged_unique_indices_cuda(
 
   Tensor linear_unique_indices;
   Tensor reverse_index;
-  std::tie(linear_unique_indices, reverse_index) =
-      at::_unique(linear_indices, true, true);
+  if (N == 0) {
+    linear_unique_indices = at::empty({0}, indices.options());
+    reverse_index = at::empty({0}, indices.options().dtype(at::kLong));
+  } else {
+    // Read total_hash_size to trim radix-sort end_bit. at::_unique
+    // historically performed an implicit D->H sync to allocate its outputs,
+    // so this sync is net-neutral.
+    const int64_t total_hash_size =
+        hash_size_cumsum[hash_size_cumsum.numel() - 1].item().toLong();
+    TORCH_CHECK(
+        total_hash_size >= 0,
+        "jagged_unique_indices: hash_size_cumsum[-1] must be non-negative, got ",
+        total_hash_size);
+    // Bit-width of total_hash_size via integer math. __builtin_clzll is
+    // defined for any positive uint64_t, so this expression is total over
+    // the entire [0, INT64_MAX] range and never invokes UB. (Unlike the
+    // float-log2 formulation, which produces NaN at INT64_MAX due to
+    // signed overflow in `total_hash_size + 1`.)
+    AT_DISPATCH_INDEX_TYPES(
+        indices.scalar_type(), "jagged_unique_indices_pipeline", ([&] {
+          const int max_bits = static_cast<int>(sizeof(index_t) * 8);
+          int total_hash_size_bits;
+          if (total_hash_size <= 0) {
+            total_hash_size_bits = 1;
+          } else {
+            total_hash_size_bits =
+                64 - __builtin_clzll(static_cast<uint64_t>(total_hash_size));
+          }
+          total_hash_size_bits = std::min(total_hash_size_bits, max_bits);
+          TORCH_CHECK(
+              total_hash_size_bits >= 1 && total_hash_size_bits <= max_bits,
+              "jagged_unique_indices: bad end_bit=",
+              total_hash_size_bits);
+          jagged_unique_indices_pipeline<index_t>(
+              linear_indices,
+              total_hash_size_bits,
+              linear_unique_indices,
+              reverse_index);
+        }));
+  }
 
   const auto total_indices = indices.size(0);
   Tensor unique_indices = at::empty_like(linear_unique_indices);
@@ -234,7 +471,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> jagged_unique_indices_cuda(
             0,
             at::cuda::getCurrentCUDAStream(),
             PTA_B(indices, index_t, 1, 32),
-            PTA_B(reverse_index, index_t, 1, 32),
+            PTA_B(reverse_index, int64_t, 1, 32),
             PTA_B(unique_indices, index_t, 1, 32));
       }));
 

--- a/fbgemm_gpu/test/jagged/failures_dict.json
+++ b/fbgemm_gpu/test/jagged/failures_dict.json
@@ -107,6 +107,10 @@
         "comment": "",
         "status": "xfail"
       },
+      "UniqueIndicesTest.test_aot_dispatch_dynamic__test_jagged_unique_indices_zch_huge_hash_size": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with dynamic dispatch.",
+        "status": "xfail"
+      },
       "UniqueIndicesTest.test_faketensor__test_jagged_unique_indices": {
         "comment": "",
         "status": "xfail"
@@ -117,6 +121,10 @@
       },
       "UniqueIndicesTest.test_faketensor__test_jagged_unique_indices_multi_keys": {
         "comment": "",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_faketensor__test_jagged_unique_indices_zch_huge_hash_size": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with fake tensors.",
         "status": "xfail"
       }
     },

--- a/fbgemm_gpu/test/jagged/unique_indices_test.py
+++ b/fbgemm_gpu/test/jagged/unique_indices_test.py
@@ -269,6 +269,74 @@ class UniqueIndicesTest(unittest.TestCase):
         self.assertEqual(torch.sum(output_lengths).item(), 0)
         self.assertEqual(torch.sum(output_offsets).item(), 0)
 
+    @unittest.skipIf(*gpu_unavailable)
+    def test_jagged_unique_indices_zch_huge_hash_size(self) -> None:
+        """Exercise the op with a hash_size_cumsum entry at INT64_MAX -
+        the shape produced by ZCH callers that leave per-feature hash size
+        unbounded. The op must handle hash boundaries spanning the full
+        int64 range without overflow in any internal arithmetic.
+        """
+        T = 2
+        B = 64
+        max_length = 5
+        int64_max = torch.iinfo(torch.int64).max
+        hash_size_cumsum_list = [0, 0, int64_max]
+        hash_size_offsets_list = [0, 0, 2]
+        # Per-feature linearized values lie in [0, INT64_MAX). The kernels
+        # under test are boundary-value-sensitive on hash_size_cumsum, not
+        # on the indices themselves, so a small index range is sufficient
+        # and keeps the reference comparison fast.
+        per_feature_value_cap = 1024
+        lengths_list: list[int] = []
+        indices_list: list[int] = []
+        for _ in range(T):
+            for _ in range(B):
+                length = random.randint(0, max_length)
+                lengths_list.append(length)
+                if length > 0:
+                    indices_list.extend(
+                        np.random.randint(
+                            0, per_feature_value_cap, size=length
+                        ).tolist()
+                    )
+
+        device = torch.accelerator.current_accelerator()
+        assert device is not None
+        dtype = torch.int64
+        hash_size_cumsum = torch.as_tensor(
+            hash_size_cumsum_list, dtype=dtype, device=device
+        )
+        hash_size_offsets = torch.as_tensor(
+            hash_size_offsets_list, dtype=dtype, device=device
+        )
+        lengths = torch.as_tensor(lengths_list, dtype=dtype, device=device)
+        indices = torch.as_tensor(indices_list, dtype=dtype, device=device)
+        offsets = torch.zeros(T * B + 1, dtype=dtype, device=device)
+        offsets[1:] = torch.cumsum(lengths, dim=0)
+
+        (
+            output_lengths,
+            output_offsets,
+            unique_indices,
+            reverse_index,
+        ) = torch.ops.fbgemm.jagged_unique_indices(
+            hash_size_cumsum, hash_size_offsets, offsets, indices
+        )
+
+        # Both features share the same hash space (hash_offset = 0 for
+        # both, since hash_size_cumsum[0] == hash_size_cumsum[1] == 0),
+        # so the global unique set is the union of all input indices.
+        expected_unique = sorted(set(indices_list))
+        self.assertEqual(unique_indices.numel(), len(expected_unique))
+        self.assertEqual(int(torch.sum(output_lengths).item()), unique_indices.numel())
+        # Inverse-index round-trip: unique_indices[reverse_index[i]] == indices[i].
+        rev_list = reverse_index.tolist()
+        uniq_list = unique_indices.tolist()
+        self.assertEqual(len(rev_list), len(indices_list))
+        for i, rev in enumerate(rev_list):
+            self.assertTrue(0 <= rev < len(uniq_list))
+            self.assertEqual(uniq_list[rev], indices_list[i])
+
     @given(
         num_elements=st.integers(min_value=100, max_value=10000),
         num_unique_indices=st.integers(min_value=5, max_value=100),

--- a/fbgemm_gpu/test/jagged/unique_indices_test.py
+++ b/fbgemm_gpu/test/jagged/unique_indices_test.py
@@ -55,6 +55,7 @@ class UniqueIndicesTest(unittest.TestCase):
         B=st.integers(min_value=100, max_value=200),
         F=st.integers(min_value=50, max_value=100),
         max_length=st.integers(min_value=5, max_value=10),
+        dtype=st.sampled_from([torch.int32, torch.int64]),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
     def test_jagged_unique_indices(
@@ -62,6 +63,7 @@ class UniqueIndicesTest(unittest.TestCase):
         B: int,  # Batch size
         F: int,  # The number of features
         max_length: int,  # The maximum value of pooling factor
+        dtype: torch.dtype,
     ) -> None:
         hash_size_list = []
         lengths_list = []
@@ -83,8 +85,8 @@ class UniqueIndicesTest(unittest.TestCase):
                     indices_list.extend(indices)
                     linearized_indices_list.extend(linearized_indices)
 
-        device = torch.device("cuda")
-        dtype = torch.int64
+        device = torch.accelerator.current_accelerator()
+        assert device is not None
         hash_size = torch.as_tensor(hash_size_list, dtype=dtype, device=device)
         hash_size_offsets = torch.as_tensor(
             hash_size_offsets_list, dtype=dtype, device=device
@@ -159,6 +161,7 @@ class UniqueIndicesTest(unittest.TestCase):
         B=st.integers(min_value=100, max_value=200),
         F=st.integers(min_value=50, max_value=100),
         max_length=st.integers(min_value=5, max_value=10),
+        dtype=st.sampled_from([torch.int32, torch.int64]),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
     def test_jagged_unique_indices_multi_keys(
@@ -166,6 +169,7 @@ class UniqueIndicesTest(unittest.TestCase):
         B: int,  # Batch size
         F: int,  # The number of features
         max_length: int,  # The maximum value of pooling factor
+        dtype: torch.dtype,
     ) -> None:
         hash_size_list = []
         lengths_list = []
@@ -187,8 +191,8 @@ class UniqueIndicesTest(unittest.TestCase):
                     indices_list.extend(indices)
                     linearized_indices_list.extend(linearized_indices)
 
-        device = torch.device("cuda")
-        dtype = torch.int64
+        device = torch.accelerator.current_accelerator()
+        assert device is not None
         hash_size = torch.as_tensor(hash_size_list, dtype=dtype, device=device)
         lengths = torch.as_tensor(lengths_list, dtype=dtype, device=device)
         indices = torch.as_tensor(indices_list, dtype=dtype, device=device)
@@ -231,20 +235,22 @@ class UniqueIndicesTest(unittest.TestCase):
     @given(
         B=st.integers(min_value=100, max_value=200),
         F=st.integers(min_value=50, max_value=100),
+        dtype=st.sampled_from([torch.int32, torch.int64]),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
     def test_jagged_unique_indices_empty(
         self,
         B: int,  # Batch size
         F: int,  # The number of features
+        dtype: torch.dtype,
     ) -> None:
         hash_size_cumsum_list = [0] + list(itertools.accumulate([10] * F))
         hash_size_offsets_list = [0] + list(itertools.accumulate([1] * F))
         offsets_list = [0] * (B * F + 1)
         indices_list = []
 
-        device = torch.device("cuda")
-        dtype = torch.int64
+        device = torch.accelerator.current_accelerator()
+        assert device is not None
         hash_size_cumsum = torch.as_tensor(
             hash_size_cumsum_list, device=device, dtype=dtype
         )


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2698

at::_unique(linear_indices, sorted=True, return_inverse=True) was the largest single contributor to jagged_unique_indices_cuda after D-1+D-2: 5.87 ms / call on the prod IFR-MTML mc7 shape, of which ~2.96 ms is the underlying int64 radix sort (8 passes) and ~2.16 ms is an internal scatter for the inverse-index.

Replace with an explicit cub pipeline:
  1. cub::DeviceRadixSort::SortPairs on (linear_indices, arange-positions),
     with end_bit trimmed to bit_width(total_hash_size). For hash_size=1M this
     reduces 8 radix passes to 3.
  2. cub::DeviceRunLengthEncode::Encode to extract the sorted unique keys.
  3. adjacent_diff -> inclusive_scan -> scatter to recover the inverse index
     in original-input order (mirrors caffe2/aten/src/ATen/native/cuda/UniqueCub.cu).

Bench delta on the prod shape (T=2, B=2560, ~23M int64 indices, hash=1M):

```
                              D-2     D-3
fbgemm::jagged_unique_indices 8.32 ms 5.4 ms  (expected)
  aten::_unique radix sort    2.96 ms gone
  aten::_unique scatter       2.16 ms ~2.0 ms (now jagged_unique_scatter_kernel)
  cub radix sort + RLE         -       ~1.0 ms  (3 passes int64)
```

Bit-width math uses __builtin_clzll, not float log2. The float-log2 path
(prior reverted attempt D103207899) silently produced UB at INT64_MAX:
  total_hash_size + 1 -> signed overflow at INT64_MAX
  -> static_cast<double>(INT64_MIN) -> finite negative
  -> std::log2(negative) -> NaN
  -> static_cast<int>(NaN) -> UB (typically INT_MIN)
  -> cub end_bit < 0, kernel UB, CUDA illegal instruction (S660690).

The integer formulation `64 - __builtin_clzll(total_hash_size)` is total
over [1, INT64_MAX] and clamps via std::min to sizeof(index_t)*8. The ZCH
regression test added in D-1 (test_jagged_unique_indices_zch_huge_hash_size,
hash_size_cumsum[-1] = INT64_MAX) exercises this boundary directly.

Adds preconditions:
  - hash_size_cumsum.dtype() == indices.dtype()
  - hash_size_cumsum.numel() >= 2 (T >= 1)
  - indices.numel() <= INT32_MAX (positions / num_items are int32 inside cub)
  - total_hash_size >= 0

No public API change. Outputs are bit-identical to at::_unique's output for
all valid inputs (verified by all existing unit + opcheck tests).

Reviewed By: q10

Differential Revision: D105005625


