### PR TITLE
Add BackendType.DRAM_SSD enum value and DRAM_SSD_VIRTUAL_TABLE enum to torchrec and sparsenn_configs (#5774)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -336,12 +336,14 @@ class BackendType(enum.IntEnum):
     SSD = 0
     DRAM = 1
     PS = 2
+    DRAM_SSD = 3
 
     @classmethod
     def from_str(cls, key: str) -> "BackendType":
         lookup = {
             "ssd": BackendType.SSD,
             "dram": BackendType.DRAM,
+            "dram_ssd": BackendType.DRAM_SSD,
         }
         if key in lookup:
             return lookup[key]


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2702

X-link: https://github.com/meta-pytorch/torchrec/pull/4273

Introduces the `DRAM_SSD` backend type to support a composite DRAM and SSD storage hierarchy for virtual embedding tables. This expands the available backend storage options to enable multi-tier caching configurations in TorchRec and FBGEMM.

Reviewed By: EddyLXJ

Differential Revision: D105646650


