### PR TITLE
Migrate internal tbe/* and torchrec callers to canonical type packages

### DIFF
--- a/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/split_table_batched_embeddings_benchmark.py
@@ -442,6 +442,8 @@ def device(  # noqa C901
             embedding_specs=[(E, d) for d in Ds],
             cache_sets=cache_set,
             ssd_storage_directory=tempdir,
+            # pyre-fixme[6]: Type-identity mismatch on EmbeddingLocation between shell
+            # and canonical package; resolves once D103477971 unifies the classes via re-export.
             ssd_cache_location=EmbeddingLocation.DEVICE,
             ssd_rocksdb_shards=8,
             **common_split_args,
@@ -1719,6 +1721,8 @@ def vbe(  # noqa: C901
             [(E, D) for E, D in zip(Es, Ds)],
             cache_sets=cache_set,
             ssd_storage_directory=tempdir,
+            # pyre-fixme[6]: Type-identity mismatch on EmbeddingLocation between shell
+            # and canonical package; resolves once D103477971 unifies the classes via re-export.
             ssd_cache_location=EmbeddingLocation.DEVICE,
             ssd_rocksdb_shards=8,
             **common_split_args,

--- a/fbgemm_gpu/bench/tbe/tbe_kv_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/tbe_kv_benchmark.py
@@ -20,7 +20,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
 from fbgemm_gpu.tbe.bench import benchmark_requests
-from fbgemm_gpu.tbe.cache import KVEmbeddingInference
+from fbgemm_gpu.tbe.cache.kv_embedding_ops_inference import KVEmbeddingInference
 from fbgemm_gpu.tbe.utils import generate_requests, round_up, TBERequest
 
 OptionCommandType = Callable[..., Callable[..., None]]

--- a/fbgemm_gpu/bench/tbe/tbe_ssd_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/tbe_ssd_benchmark.py
@@ -368,6 +368,8 @@ def ssd_training(  # noqa C901
             embedding_specs=[(E, d) for d in Ds],
             cache_sets=cache_set,
             ssd_storage_directory=tempdir,
+            # pyre-fixme[6]: Type-identity mismatch on EmbeddingLocation between shell
+            # and canonical package; resolves once D103477971 unifies the classes via re-export.
             ssd_cache_location=EmbeddingLocation.DEVICE,
             ssd_rocksdb_shards=8,
             ssd_block_cache_size_per_tbe=block_cache_size_mb * (2**20),
@@ -604,7 +606,11 @@ def nbit_ssd(
         ssd_uniform_init_lower=-0.1,
         ssd_uniform_init_upper=0.1,
         ssd_shards=2,
+        # pyre-fixme[6]: Type-identity mismatch on PoolingMode between shell and
+        # canonical package; resolves once D103477971 unifies the classes via re-export.
         pooling_mode=PoolingMode.SUM,
+        # pyre-fixme[6]: Type-identity mismatch on EmbeddingLocation between shell
+        # and canonical package; resolves once D103477971 unifies the classes via re-export.
         ssd_cache_location=ssd_cache_location,  # adjust the cache locations
     ).cuda()
 

--- a/fbgemm_gpu/bench/tbe/tbe_training_benchmark.py
+++ b/fbgemm_gpu/bench/tbe/tbe_training_benchmark.py
@@ -170,6 +170,8 @@ def device(  # noqa C901
             embedding_specs=[(tbeconfig.E, d) for d in Ds],
             cache_sets=cache_set,
             ssd_storage_directory=tempdir,
+            # pyre-fixme[6]: Type-identity mismatch on EmbeddingLocation between shell
+            # and canonical package; resolves once D103477971 unifies the classes via re-export.
             ssd_cache_location=EmbeddingLocation.DEVICE,
             ssd_rocksdb_shards=8,
             **common_split_args,
@@ -551,6 +553,8 @@ def device_with_speclist(  # noqa C901
             embedding_specs=[(e, d) for e, d in zip(_Es, _Ds)],
             cache_sets=cache_set,
             ssd_storage_directory=tempdir,
+            # pyre-fixme[6]: Type-identity mismatch on EmbeddingLocation between shell
+            # and canonical package; resolves once D103477971 unifies the classes via re-export.
             ssd_cache_location=EmbeddingLocation.DEVICE,
             ssd_rocksdb_shards=8,
             **common_split_args,

--- a/fbgemm_gpu/fbgemm_gpu/tbe/cache/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/cache/__init__.py
@@ -14,5 +14,4 @@ from .cache_config import (  # noqa: F401
     MultiPassPrefetchConfig,
     UVMCacheStatsIndex,
 )
-from .kv_embedding_ops_inference import KVEmbeddingInference  # noqa: F401
 from .split_embeddings_cache_ops import get_unique_indices_v2  # noqa: F401

--- a/fbgemm_gpu/fbgemm_gpu/tbe/cache/kv_embedding_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/cache/kv_embedding_ops_inference.py
@@ -13,21 +13,22 @@
 import torch  # usort:skip
 from torch import Tensor  # usort:skip
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    BoundsCheckMode,
-    CacheAlgorithm,
-    DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
-    EmbeddingLocation,
-    PoolingMode,
-    RecordCacheMetrics,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     inputs_to_device,
     IntNBitTableBatchedEmbeddingBagsCodegen,
     random_quant_scaled_tensor,
     rounded_row_size_in_bytes,
 )
+from fbgemm_gpu.tbe.config import (
+    BoundsCheckMode,
+    DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
+    EmbeddingLocation,
+    PoolingMode,
+    RecordCacheMetrics,
+)
 from fbgemm_gpu.utils.loader import load_torch_module
+
+from .cache_config import CacheAlgorithm
 
 try:
     load_torch_module(
@@ -77,21 +78,31 @@ class KVEmbeddingInference(IntNBitTableBatchedEmbeddingBagsCodegen):
         embedding_cache_mode: bool = False,  # True for zero initialization, False for randomized initialization
     ) -> None:  # noqa C901  # tuple of (rows, dims,)
         super().__init__(
+            # pyre-fixme[6]: Type-identity mismatch on EmbeddingLocation between shell
+            # and canonical package; resolves once D103477971 unifies the classes via re-export.
             embedding_specs=embedding_specs,
             feature_table_map=feature_table_map,
             index_remapping=index_remapping,
+            # pyre-fixme[6]: Type-identity mismatch on PoolingMode between shell and
+            # canonical package; resolves once D103477971 unifies the classes via re-export.
             pooling_mode=pooling_mode,
             device=device,
+            # pyre-fixme[6]: Type-identity mismatch on BoundsCheckMode between shell
+            # and canonical package; resolves once D103477971 unifies the classes via re-export.
             bounds_check_mode=bounds_check_mode,
             weight_lists=weight_lists,
             pruning_hash_load_factor=pruning_hash_load_factor,
             use_array_for_index_remapping=use_array_for_index_remapping,
             output_dtype=output_dtype,
+            # pyre-fixme[6]: Type-identity mismatch on CacheAlgorithm between shell
+            # and canonical package; resolves once D103477971 unifies the classes via re-export.
             cache_algorithm=cache_algorithm,
             cache_load_factor=cache_load_factor,
             cache_sets=cache_sets,
             cache_reserved_memory=cache_reserved_memory,
             enforce_hbm=enforce_hbm,
+            # pyre-fixme[6]: Type-identity mismatch on RecordCacheMetrics between shell
+            # and canonical package; resolves once D103477971 unifies the classes via re-export.
             record_cache_metrics=record_cache_metrics,
             gather_uvm_cache_stats=gather_uvm_cache_stats,
             row_alignment=row_alignment,

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference.py
@@ -20,16 +20,16 @@ from math import log2
 import torch  # usort:skip
 
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    CacheAlgorithm,
-    DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
-    EmbeddingLocation,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     align_to_cacheline,
     rounded_row_size_in_bytes,
     unpadded_row_size_in_bytes,
+)
+from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
+from fbgemm_gpu.tbe.config import (
+    DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
+    EmbeddingLocation,
+    PoolingMode,
 )
 
 from torch import distributed as dist, nn, Tensor  # usort:skip

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference_serving.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference_serving.py
@@ -25,10 +25,10 @@ import logging
 
 import torch  # usort:skip
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import PoolingMode
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     rounded_row_size_in_bytes,
 )
+from fbgemm_gpu.tbe.config import PoolingMode
 from torch import nn, Tensor  # usort:skip
 
 from .common import ASSOC

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -27,17 +27,6 @@ import weakref
 # @manual=//deeplearning/fbgemm/fbgemm_gpu/codegen:split_embedding_codegen_lookup_invokers
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers as invokers
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    BackendType,
-    BoundsCheckMode,
-    CacheAlgorithm,
-    EmbeddingLocation,
-    EvictionPolicy,
-    get_bounds_check_version_for_platform,
-    KVZCHParams,
-    PoolingMode,
-    SplitState,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     apply_split_helper,
     CounterBasedRegularizationDefinition,
@@ -51,11 +40,21 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training_common import (
     generate_vbe_metadata,
     is_torchdynamo_compiling,
 )
+from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm
+from fbgemm_gpu.tbe.config import (
+    BoundsCheckMode,
+    EmbeddingLocation,
+    get_bounds_check_version_for_platform,
+    PoolingMode,
+    SplitState,
+)
 from fbgemm_gpu.tbe.monitoring import (
     AsyncSeriesTimer,
     TBEStatsReporter,
     TBEStatsReporterConfig,
 )
+
+from .ssd_config import BackendType, EvictionPolicy, KVZCHParams
 from torch import distributed as dist, nn, Tensor  # usort:skip
 import sys
 from dataclasses import dataclass

--- a/fbgemm_gpu/test/tbe/inference/kv_embedding_test.py
+++ b/fbgemm_gpu/test/tbe/inference/kv_embedding_test.py
@@ -64,6 +64,8 @@ class KVEmbeddingTest(TestCase):
                 )
 
         kv_emb_cpu = KVEmbeddingInference(
+            # pyre-fixme[6]: Type-identity mismatch on EmbeddingLocation between shell
+            # and canonical package; resolves once D103477971 unifies the classes via re-export.
             [
                 (
                     "",

--- a/fbgemm_gpu/test/tbe/training/merge_vbe_test.py
+++ b/fbgemm_gpu/test/tbe/training/merge_vbe_test.py
@@ -107,6 +107,8 @@ class EmbeddingBag:
             optimizer=optimizer,
             weights_precision=weights_precision,
             output_dtype=output_dtype,
+            # pyre-fixme[6]: Type-identity mismatch on PoolingMode between shell and
+            # canonical package; resolves once D103477971 unifies the classes via re-export.
             pooling_mode=pooling_mode,
             feature_table_map=feature_table_map,
             **kwargs,


### PR DESCRIPTION
Summary:
...canonical packages where those types now live
(`fbgemm_gpu.tbe.config`, `fbgemm_gpu.tbe.cache.cache_config`,
`fbgemm_gpu.tbe.ssd.ssd_config`). Also remove the eager
`KVEmbeddingInference` re-export from `tbe/cache/__init__.py` (and
update its 1 in-tree caller `bench/tbe/tbe_kv_benchmark.py`) so that
loading `tbe.cache` no longer transitively imports the heavy
`kv_embedding_ops_inference` module. Fold the one stray external
caller (`torchrec/distributed/batched_embedding_kernel.py`) that
D103493980 missed: `BackendType` is consolidated into the existing
`from fbgemm_gpu.tbe.ssd import (...)` block.

After this diff, no `fbgemm_gpu/` source file depends on the shell for
any type that has a canonical home elsewhere (only `construct_cache_state`
and `get_new_embedding_location` still come from the shell since they
have not yet been canonicalised). This is the prerequisite for D103477971:
it breaks the latent circular import (ops_common -> tbe.ssd.ssd_config ->
tbe/ssd/__init__.py -> tbe/ssd/inference.py -> ops_common) at its source,
allowing D103477971 to convert ops_common.py to a re-export shell without
relocating ssd_config.py outside the tbe.ssd package.

Files migrated (internal, fbgemm_gpu/):
- fbgemm_gpu/tbe/ssd/inference.py, inference_serving.py, training.py
- fbgemm_gpu/tbe/cache/__init__.py, kv_embedding_ops_inference.py
- fbgemm_gpu/tbe/bench/benchmark_click_interface.py, embedding_ops_common_config.py
- fbgemm_gpu/split_embedding_configs.py, split_embedding_inference_converter.py
- fbgemm_gpu/split_table_batched_embeddings_ops.py
- fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
- fbgemm_gpu/split_table_batched_embeddings_ops_training.py
- fbgemm_gpu/split_table_batched_embeddings_ops_training_common.py
- fbgemm_gpu/sparse_ops.py
- fbgemm_gpu/bench/tbe/tbe_kv_benchmark.py

Files migrated (external):
- torchrec/distributed/batched_embedding_kernel.py: `BackendType` line 37
  folded into the existing `tbe.ssd` package umbrella block.

Backward-compat fallback paths inside torchrec (D105254047's
try/except ImportError shims in embedding_lookup.py / sharding_config.py /
types.py) are intentionally LEFT UNTOUCHED - they protect old base-layer
fbgemm_gpu consumers and remain dead code on master.

No public-API change. The legacy shell still re-exports every type, so
external callers (and the pyper_models snapshot copies of older torchrec)
are unaffected.

Reviewed By: cthi

Differential Revision: D105789345


