### PR TITLE
Upgrade macOS CI runner from macos-13 to macos-14

### DIFF
--- a/.github/workflows/fbgemm_ci.yml
+++ b/.github/workflows/fbgemm_ci.yml
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-13 ]
+        os: [ macos-14 ]
         library-type: [ static, shared ]
 
     steps:


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2715

The `build-macos` job in `fbgemm_ci.yml` was using `macos-13`, which has
been deprecated by GitHub Actions. The hosted runner pool for `macos-13`
is effectively exhausted — every macOS job in this workflow has been
failing with:

  "The job has exceeded the maximum execution time while awaiting a
   runner for 24h0m0s"

Jobs queue 24h and never start. No compute is billed (no runner = no
cost), but every PR shows a broken macOS check, polluting CI signal.

Upgrading to `macos-14` (Apple Silicon, GitHub-hosted) restores
runnable macOS coverage on PR + main. Note: `macos-14` is a more
expensive runner per minute than `macos-13` was; if cost becomes a
concern, this job can be moved behind a label gate or dropped entirely.

Stacks on top of D106405302 (windows removal).

Differential Revision: D106423883


