### PR TITLE
Add DRAM_SSD to BackendType enum in tbe/ssd/ssd_config.py

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/ssd_config.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/ssd_config.py
@@ -312,6 +312,7 @@ class BackendType(enum.IntEnum):
     SSD = 0
     DRAM = 1
     PS = 2
+    DRAM_SSD = 3
 
     @classmethod
     def from_str(cls, key: str) -> "BackendType":
@@ -319,6 +320,7 @@ class BackendType(enum.IntEnum):
             "ssd": BackendType.SSD,
             "dram": BackendType.DRAM,
             "ps": BackendType.PS,
+            "dram_ssd": BackendType.DRAM_SSD,
         }
         if key in lookup:
             return lookup[key]


### PR DESCRIPTION
Summary:
The BackendType enum in tbe/ssd/ssd_config.py was missing the DRAM_SSD variant
(value=3) that already exists in split_table_batched_embeddings_ops_common.py.
Since torchrec's embedding_lookup.py imports BackendType from fbgemm_gpu.tbe.ssd
first, using EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE would fail with
AttributeError: type object 'BackendType' has no attribute 'DRAM_SSD'.

Added DRAM_SSD = 3 and updated from_str() to include the dram_ssd mapping.

Differential Revision: D106438433


