### PR TITLE
Use Python 3.10+ typing in tests (#5788)

### DIFF
--- a/fbgemm_gpu/test/combine/common.py
+++ b/fbgemm_gpu/test/combine/common.py
@@ -6,7 +6,6 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-from typing import Optional
 
 import fbgemm_gpu
 import torch
@@ -33,8 +32,8 @@ class TBEInputPrepareReference(torch.nn.Module):
         indices_list: list[torch.Tensor],
         offsets_list: list[torch.Tensor],
         per_sample_weights_list: list[torch.Tensor],
-        batch_size: Optional[int] = None,
-    ) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+        batch_size: int | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         size = 0
         assert len(indices_list) > 0
         assert len(indices_list) == len(offsets_list)
@@ -103,7 +102,7 @@ class TBEInputPrepareReference(torch.nn.Module):
                         indices_list[i].numel() + offsets_accs[i]
                     )
         combined_offsets[-1] = offsets_accs[-1]
-        per_sample_weights: Optional[torch.Tensor] = None
+        per_sample_weights: torch.Tensor | None = None
         for i in range(len(self.include_last_offsets)):
             if per_sample_weights_list[i].size(0) > 0:
                 per_sample_weights = torch.ones(

--- a/fbgemm_gpu/test/jagged/common.py
+++ b/fbgemm_gpu/test/jagged/common.py
@@ -9,7 +9,8 @@
 # pyre-ignore-all-errors[56]
 
 import itertools
-from typing import Callable
+from collections.abc import Callable
+from typing import Any
 
 import fbgemm_gpu
 import fbgemm_gpu.sparse_ops
@@ -40,8 +41,7 @@ settings.load_profile("suppress_differing_executors_check")
 # e.g. "test_faketensor__test_cumsum": [unittest.expectedFailure]
 # Please avoid putting tests here, you should put operator-specific
 # skips and failures in deeplearning/fbgemm/fbgemm_gpu/test/failures_dict.json
-# pyre-ignore[24]: Generic type `Callable` expects 2 type parameters.
-additional_decorators: dict[str, list[Callable]] = {}
+additional_decorators: dict[str, list[Callable[..., Any]]] = {}
 
 
 def lengths_to_segment_ids(lengths: torch.Tensor) -> torch.Tensor:
@@ -120,8 +120,8 @@ def generate_jagged_tensor(
             # not 0/1 anyway (if so, they'll be recompiled)
             low=0 if not mark_dynamic else 1,
             high=max_lengths[d] * 2,
-            # pyre-fixme[6]: For 3rd param expected `Union[List[int], Size,
-            #  typing.Tuple[int, ...]]` but got `Tuple[Union[bool, float, int]]`.
+            # pyre-fixme[6]: For 3rd param expected `list[int] | Size |
+            #  tuple[int, ...]` but got `tuple[bool | float | int]`.
             size=(num_lengths,),
             device=device,
         )
@@ -132,14 +132,14 @@ def generate_jagged_tensor(
         num_lengths = x_offsets[-1][-1].item()
 
     x_values = torch.rand(
-        # pyre-fixme[6]: For 1st param expected `Union[List[int], Size,
-        #  typing.Tuple[int, ...]]` but got `Tensor`.
+        # pyre-fixme[6]: For 1st param expected `list[int] | Size |
+        #  tuple[int, ...]` but got `Tensor`.
         x_offsets[-1][-1] * inner_dense_size,
         dtype=dtype,
         device=device,
     )
     if inner_dense_size != 1 or not fold_inner_dense:
-        # pyre-fixme[6]: For 1st param expected `int` but got `Union[bool, float, int]`.
+        # pyre-fixme[6]: For 1st param expected `int` but got `bool | float | int`.
         x_values = x_values.reshape(x_offsets[-1][-1].item(), inner_dense_size)
 
     if mark_dynamic:
@@ -176,7 +176,7 @@ def to_padded_dense(
                 # pyre-fixme[6]: For 1st argument expected `Union[None, _NestedSe...
                 end = offsets[d][cur_offset + 1].item()
                 # pyre-fixme[6]: For 1st param expected `int` but got
-                #  `Union[bool, float, int]`.
+                #  `bool | float | int`.
                 if jagged_coord[d] >= end - begin:
                     is_zero = True
                     break

--- a/fbgemm_gpu/test/permute/common.py
+++ b/fbgemm_gpu/test/permute/common.py
@@ -84,7 +84,7 @@ class PermutePooledEmbeddingsFwdOnly(PermutePooledEmbeddings):
 
 class Net(torch.nn.Module):
     def __init__(self, fwd_only: bool = False) -> None:
-        super(Net, self).__init__()
+        super().__init__()
         self.fc1 = torch.nn.Linear(1, 10, bias=False)
         op_cls = PermutePooledEmbeddingsFwdOnly if fwd_only else PermutePooledEmbeddings
         self.permute_pooled_embeddings: PermutePooledEmbeddings = op_cls(

--- a/fbgemm_gpu/test/quantize/comm_codec_test.py
+++ b/fbgemm_gpu/test/quantize/comm_codec_test.py
@@ -8,7 +8,6 @@
 # pyre-strict
 
 import unittest
-from typing import Optional
 
 import hypothesis.strategies as st
 import torch
@@ -45,7 +44,7 @@ class QuantizedCommCodecTest(unittest.TestCase):
     )
     def test_quantized_comm_codec(
         self,
-        comm_precisions_loss_scale: tuple[SparseType, Optional[float]],
+        comm_precisions_loss_scale: tuple[SparseType, float | None],
         row_size: int,
         col_size: int,
         rand_seed: int,

--- a/fbgemm_gpu/test/quantize/common.py
+++ b/fbgemm_gpu/test/quantize/common.py
@@ -8,7 +8,7 @@
 
 import math
 import struct
-from typing import Callable
+from collections.abc import Callable
 
 import fbgemm_gpu
 import numpy as np

--- a/fbgemm_gpu/test/quantize/mx/common.py
+++ b/fbgemm_gpu/test/quantize/mx/common.py
@@ -10,7 +10,6 @@
 
 import struct
 from enum import Enum, IntEnum
-from typing import Optional, Union
 
 import numpy as np
 import torch
@@ -77,7 +76,7 @@ _FORMAT_CACHE: dict[ElemFormat, tuple[int, int, int, float, float]] = {}
 
 
 def _get_format_params(  # noqa
-    fmt: Union[ElemFormat, str, None],
+    fmt: ElemFormat | str | None,
 ) -> tuple[int, int, int, float, float]:
     """Allowed formats:
     - intX:         2 <= X <= 32, assume sign-magnitude, 1.xxx representation
@@ -309,9 +308,9 @@ def check_diff_quantize(
         raise IndexError
 
     # Convert to numpy
-    # pyre-fixme[9]: x has type `Tensor`; used as `Union[ndarray, Tensor]`.
+    # pyre-fixme[9]: x has type `Tensor`; used as `ndarray | Tensor`.
     x = np.array(x) if type(x) is list else x
-    # pyre-fixme[9]: x has type `Tensor`; used as `Union[ndarray[Any, Any], Tensor]`.
+    # pyre-fixme[9]: x has type `Tensor`; used as `ndarray[Any, Any] | Tensor`.
     x = x.cpu().numpy() if type(x) is torch.Tensor else x
     y1 = y1.detach().cpu().numpy()
     y2 = y2.detach().cpu().numpy()
@@ -356,14 +355,14 @@ def check_diff_quantize(
 
 # Never explicitly compute 2**(-exp) since subnorm numbers have
 # exponents smaller than -126
-def _safe_lshift(x: torch.Tensor, bits: int, exp: Optional[int]) -> torch.Tensor:
+def _safe_lshift(x: torch.Tensor, bits: int, exp: int | None) -> torch.Tensor:
     if exp is None:
         return x * (2**bits)
     else:
         return x / (2**exp) * (2**bits)
 
 
-def _safe_rshift(x: torch.Tensor, bits: int, exp: Optional[int]) -> torch.Tensor:
+def _safe_rshift(x: torch.Tensor, bits: int, exp: int | None) -> torch.Tensor:
     if exp is None:
         return x / (2**bits)
     else:
@@ -410,7 +409,7 @@ def _shared_exponents(
     A: torch.Tensor,
     method: str = "max",
     rounding_mode: str = "even",
-    axes: Optional[list[int]] = None,
+    axes: list[int] | None = None,
     ebits: int = 0,
 ) -> torch.Tensor:
     """
@@ -538,16 +537,16 @@ def _quantize_elemwise_core(
         private_exp = None
 
     # Scale up so appropriate number of bits are in the integer portion of the number
-    # pyre-fixme[6]: For 3rd argument expected `Optional[int]` but got
-    #  `Optional[Tensor]`.
+    # pyre-fixme[6]: For 3rd argument expected `int | None` but got
+    #  `Tensor | None`.
     out = _safe_lshift(out, bits - 2, private_exp)
 
     # pyre-fixme[6]: For 3rd argument expected `RoundingMode` but got `str`.
     out = _round_mantissa(out, bits, round, clamp=False)
 
     # Undo scaling
-    # pyre-fixme[6]: For 3rd argument expected `Optional[int]` but got
-    #  `Optional[Tensor]`.
+    # pyre-fixme[6]: For 3rd argument expected `int | None` but got
+    #  `Tensor | None`.
     out = _safe_rshift(out, bits - 2, private_exp)
 
     # Set values > max_norm to Inf if desired, else clamp them
@@ -579,7 +578,7 @@ def _quantize_elemwise_core(
 
 def _quantize_elemwise(
     A: torch.Tensor,
-    elem_format: Union[ElemFormat, None],
+    elem_format: ElemFormat | None,
     round: str = "nearest",
     custom_cuda: bool = False,
     saturate_normals: bool = False,

--- a/fbgemm_gpu/test/release/stable_release_test.py
+++ b/fbgemm_gpu/test/release/stable_release_test.py
@@ -10,7 +10,8 @@
 import json
 import os
 import unittest
-from typing import Callable
+from collections.abc import Callable
+from typing import Any
 
 import fbgemm_gpu
 import fbgemm_gpu.permute_pooled_embedding_modules
@@ -62,7 +63,7 @@ def _check_schema_compatibility(
 
 
 def check_schema_compatibility(
-    op: Callable,
+    op: Callable[..., Any],
     ref_schema: str,
 ) -> None:
     """
@@ -71,7 +72,7 @@ def check_schema_compatibility(
     For ops registered via torch.ops.fbgemm and ops with *args and **kwargs, please use check_schema_compatibility_from_op_name.
 
     Args:
-        op (Callable): The operator to check.
+        op (Callable[..., Any]): The operator to check.
         ref_schema (str): The reference schema in string format.
     Returns:
         None
@@ -99,7 +100,7 @@ def check_schema_compatibility_from_op_name(
     This function will raise an Exception error if the schema is not compatible.
 
     Args:
-        namespace (Callable): The namespace of the operator e.g., torch.ops.fbgemm.
+        namespace: The namespace of the operator e.g., torch.ops.fbgemm.
         op_name (str): The name of the operator.
         ref_schema_str (str): The reference schema in string format.
     Returns:

--- a/fbgemm_gpu/test/release/utils.py
+++ b/fbgemm_gpu/test/release/utils.py
@@ -9,7 +9,6 @@
 import inspect
 import typing
 from collections.abc import Iterable, Sequence  # noqa: F401
-from typing import Optional, Union
 
 import torch
 from torch import device, dtype, Tensor, types
@@ -31,7 +30,7 @@ from torch._library.infer_schema import (
 # TO DO: clean up and remove this when we implement our own
 
 
-def error_fn(what: str, sig: Optional[inspect.Signature] = None):
+def error_fn(what: str, sig: inspect.Signature | None = None):
     raise ValueError(f"infer_schema(func): {what} " f"Got func with signature {sig})")
 
 
@@ -107,7 +106,7 @@ def check_param_annotation(name: str, annotation: type, sig: inspect.Signature):
 
 def get_schema_type(
     schema_type: str,
-    mutates_args: Union[str, Iterable[str]],
+    mutates_args: str | Iterable[str],
     name: str,
     sig: inspect.Signature,
     idx: int,
@@ -130,7 +129,7 @@ def get_schema_type(
 
 
 def check_mutates_args(
-    mutates_args: Union[str, Iterable[str]], sig: inspect.Signature, seen_args: set
+    mutates_args: str | Iterable[str], sig: inspect.Signature, seen_args: set
 ):
     if mutates_args != "unknown":
         mutates_args_not_seen = set(mutates_args) - seen_args
@@ -153,11 +152,11 @@ def get_return_annonation(
 
 
 def infer_schema(
-    prototype_function: typing.Callable,
+    prototype_function: typing.Callable[..., typing.Any],
     /,
     *,
     mutates_args,
-    op_name: Optional[str] = None,
+    op_name: str | None = None,
 ) -> str:
     r"""
     This is modified from torch._library.infer_schema.infer_schema.
@@ -178,7 +177,7 @@ def infer_schema(
 
     Args:
         prototype_function: The function from which to infer a schema for from its type annotations.
-        op_name (Optional[str]): The name of the operator in the schema. If ``name`` is None, then the
+        op_name (str | None): The name of the operator in the schema. If ``name`` is None, then the
             name is not included in the inferred schema. Note that the input schema to
             ``torch.library.Library.define`` requires a operator name.
         mutates_args ("unknown" | Iterable[str]): The arguments that are mutated in the function.

--- a/fbgemm_gpu/test/sparse/block_bucketize_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_test.py
@@ -11,7 +11,6 @@
 
 import random
 import unittest
-from typing import Optional
 
 import hypothesis.strategies as st
 import torch
@@ -1587,7 +1586,7 @@ class BlockBucketizeTest(unittest.TestCase):
     @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_with_variable_batch_sizes(
         self,
-        index_type: Optional[torch.dtype],
+        index_type: torch.dtype | None,
         has_weight: bool,
         bucketize_pos: bool,
         sequence: bool,
@@ -1679,7 +1678,7 @@ class BlockBucketizeTest(unittest.TestCase):
     @settings(verbosity=Verbosity.verbose, max_examples=16, deadline=None)
     def test_block_bucketize_sparse_features_with_block_bucketize_pos(
         self,
-        index_type: Optional[torch.dtype],
+        index_type: torch.dtype | None,
         has_weight: bool,
         bucketize_pos: bool,
         sequence: bool,

--- a/fbgemm_gpu/test/sparse/common.py
+++ b/fbgemm_gpu/test/sparse/common.py
@@ -10,8 +10,9 @@
 
 import os
 import unittest
+from collections.abc import Callable
 from itertools import accumulate
-from typing import Callable, Optional
+from typing import Any
 
 import fbgemm_gpu
 import torch
@@ -42,10 +43,10 @@ settings.load_profile("suppress_differing_executors_check")
 def permute_indices_ref_(
     lengths: torch.Tensor,
     indices: torch.Tensor,
-    weights: Optional[torch.Tensor],
+    weights: torch.Tensor | None,
     permute: torch.LongTensor,
     is_1D: bool = False,
-) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
     T = lengths.size(0)
     B = lengths.size(1)
     if T == 0 or B == 0:
@@ -102,7 +103,7 @@ def permute_indices_ref_(
 @torch.jit.script
 def permute_scripted(
     permute: torch.Tensor, lengths: torch.Tensor, indices: torch.Tensor
-) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
     (
         permuted_lengths_cpu,
         permuted_indices_cpu,
@@ -120,8 +121,7 @@ def extend_test_class(
     # e.g. "test_faketensor__test_cumsum": [unittest.expectedFailure]
     # Please avoid putting tests here, you should put operator-specific
     # skips and failures in deeplearning/fbgemm/fbgemm_gpu/test/failures_dict.json
-    # pyre-ignore[24]: Generic type `Callable` expects 2 type parameters.
-    additional_decorators: Optional[dict[str, list[Callable]]] = None,
+    additional_decorators: dict[str, list[Callable[..., Any]]] | None = None,
 ) -> None:
     failures_dict_path: str = get_file_path_2(
         "", os.path.dirname(__file__), "failures_dict.json"

--- a/fbgemm_gpu/test/sparse/index_select_test.py
+++ b/fbgemm_gpu/test/sparse/index_select_test.py
@@ -14,7 +14,8 @@ import functools
 import logging
 import random
 import unittest
-from typing import Callable
+from collections.abc import Callable
+from typing import Any
 
 import hypothesis.strategies as st
 import numpy as np
@@ -542,8 +543,7 @@ class IndexSelectTest(unittest.TestCase):
 # e.g. "test_faketensor__test_cumsum": [unittest.expectedFailure]
 # Please avoid putting tests here, you should put operator-specific
 # skips and failures in deeplearning/fbgemm/fbgemm_gpu/test/failures_dict.json
-# pyre-ignore[24]: Generic type `Callable` expects 2 type parameters.
-additional_decorators: dict[str, list[Callable]] = {
+additional_decorators: dict[str, list[Callable[..., Any]]] = {
     "test_aot_dispatch_dynamic__test_index_select_dim0": [unittest.skip("hangs")],
     "test_aot_dispatch_static__test_index_select_dim0": [unittest.skip("hangs")],
     "test_faketensor__test_index_select_dim0": [unittest.skip("hangs")],

--- a/fbgemm_gpu/test/sparse/pack_segments_test.py
+++ b/fbgemm_gpu/test/sparse/pack_segments_test.py
@@ -10,7 +10,6 @@
 # pyre-ignore-all-errors[56]
 
 import unittest
-from typing import Optional
 
 import hypothesis.strategies as st
 import numpy as np
@@ -48,7 +47,7 @@ class PackedSegmentsTest(unittest.TestCase):
         self,
         lengths: torch.Tensor,
         tensor: torch.Tensor,
-        max_length: Optional[int] = None,
+        max_length: int | None = None,
     ) -> npt.NDArray:
         """
         This function is a reference implementation of pack_segments.
@@ -56,7 +55,7 @@ class PackedSegmentsTest(unittest.TestCase):
         Args:
             lengths (Tensor): The lengths of tensor.
             tensor (Tensor): The tensor to be packed.
-            max_length (Optional[int]): The maximum length of the packed tensor.
+            max_length (int | None): The maximum length of the packed tensor.
 
         Returns:
             The packed tensor.
@@ -399,7 +398,6 @@ class PackedSegmentsTest(unittest.TestCase):
             return_presence_mask=True,
         )
 
-        # pyre-fixme[6]: In call `tuple.__new__`, for 1st positional argument, expected `Iterable[int]` but got `Iterable[Union[bool, float, int]]`.
         assert presence_mask.size() == torch.Size([lengths.numel(), max_length])
 
     @unittest.skipIf(*gpu_unavailable)

--- a/fbgemm_gpu/test/sparse/permute_embeddings_test.py
+++ b/fbgemm_gpu/test/sparse/permute_embeddings_test.py
@@ -11,7 +11,8 @@
 
 import random
 import unittest
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import hypothesis.strategies as st
 import torch
@@ -63,8 +64,6 @@ class PermuteEmbeddingsTest(unittest.TestCase):
     ) -> None:
         index_dtype = torch.int64 if long_index else torch.int32
         lengths = torch.randint(low=1, high=L, size=(T, B)).type(index_dtype)
-        # pyre-fixme[6]: For 1st param expected `Union[List[int], Size,
-        #  typing.Tuple[int, ...]]` but got `Union[bool, float, int]`.
         embeddings = torch.rand(lengths.sum().item()).float()
         permute_list = list(range(T))
         random.shuffle(permute_list)

--- a/fbgemm_gpu/test/sparse/permute_indices_test.py
+++ b/fbgemm_gpu/test/sparse/permute_indices_test.py
@@ -12,7 +12,6 @@
 import random
 import unittest
 from itertools import accumulate
-from typing import Optional
 
 import hypothesis.strategies as st
 import torch
@@ -65,7 +64,7 @@ class PermuteIndicesTest(unittest.TestCase):
         W: int,
     ) -> None:
         index_dtype = torch.int64 if long_index else torch.int32
-        length_splits: Optional[list[torch.Tensor]] = None
+        length_splits: list[torch.Tensor] | None = None
         if is_1D:
             if B == 0:
                 batch_sizes = [0] * W
@@ -78,14 +77,10 @@ class PermuteIndicesTest(unittest.TestCase):
             lengths = torch.cat(length_splits, dim=1)
         else:
             lengths = torch.randint(low=1, high=L, size=(T, B)).type(index_dtype)
-        # pyre-fixme[6]: For 1st param expected `Union[List[int], Size,
-        #  typing.Tuple[int, ...]]` but got `Union[bool, float, int]`.
         weights = torch.rand(lengths.sum().item()).float() if has_weight else None
         indices = torch.randint(
             low=1,
             high=int(1e5),
-            # pyre-fixme[6]: Expected `Union[int, typing.Tuple[int, ...]]` for 3rd
-            #  param but got `Tuple[typing.Union[float, int]]`.
             size=(lengths.sum().item(),),
         ).type(index_dtype)
         if is_1D:
@@ -194,8 +189,6 @@ class PermuteIndicesTest(unittest.TestCase):
         indices = torch.randint(
             low=1,
             high=int(1e5),
-            # pyre-fixme[6]: Expected `Union[int, typing.Tuple[int, ...]]` for 3rd
-            #  param but got `Tuple[typing.Union[float, int]]`.
             size=(lengths.sum().item(),),
         ).type(index_dtype)
 
@@ -254,8 +247,6 @@ class PermuteIndicesTest(unittest.TestCase):
         indices = torch.randint(
             low=1,
             high=int(1e5),
-            # pyre-fixme[6]: Expected `Union[int, typing.Tuple[int, ...]]` for 3rd
-            #  param but got `Tuple[typing.Union[float, int]]`.
             size=(lengths.sum().item(),),
         ).type(index_dtype)
         permute_list = list(range(1))
@@ -293,14 +284,10 @@ class PermuteIndicesTest(unittest.TestCase):
     ) -> None:
         index_dtype = torch.int64 if long_index else torch.int32
         lengths = torch.randint(low=1, high=L, size=(T, B)).type(index_dtype)
-        # pyre-fixme[6]: For 1st param expected `Union[List[int], Size,
-        #  typing.Tuple[int, ...]]` but got `Union[bool, float, int]`.
         weights = torch.rand(lengths.sum().item()).float() if has_weight else None
         indices = torch.randint(
             low=1,
             high=int(1e5),
-            # pyre-fixme[6]: Expected `Union[int, typing.Tuple[int, ...]]` for 3rd
-            #  param but got `Tuple[typing.Union[float, int]]`.
             size=(lengths.sum().item(),),
         ).type(index_dtype)
         permute_list = list(range(T))

--- a/fbgemm_gpu/test/sparse/permute_sparse_features_test.py
+++ b/fbgemm_gpu/test/sparse/permute_sparse_features_test.py
@@ -11,7 +11,7 @@
 
 import random
 import unittest
-from typing import cast, Optional
+from typing import cast
 
 import hypothesis.strategies as st
 import torch
@@ -37,9 +37,9 @@ class PermuteSparseFeaturesTest(unittest.TestCase):
         self,
         lengths: torch.Tensor,
         indices: torch.Tensor,
-        weights: Optional[torch.Tensor],
+        weights: torch.Tensor | None,
         permute: torch.LongTensor,
-    ) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         T = lengths.size(0)
         B = lengths.size(1)
         permuted_lengths = torch.index_select(lengths.view(T, B), 0, permute)

--- a/fbgemm_gpu/test/tbe/cache/cache_common.py
+++ b/fbgemm_gpu/test/tbe/cache/cache_common.py
@@ -10,7 +10,6 @@
 # pyre-ignore-all-errors[56]
 
 from dataclasses import dataclass
-from typing import Optional, Union
 
 import numpy as np
 import torch
@@ -48,7 +47,7 @@ VERBOSITY: Verbosity = Verbosity.verbose
 class TestingStatsReporter(TBEStatsReporter):
     def __init__(self, reporting_interval: int = 1) -> None:
         # Event -> args for that call
-        self.reported_data: dict[str, list[list[Union[int, str, float]]]] = {}
+        self.reported_data: dict[str, list[list[int | str | float]]] = {}
         self.reporting_interval = reporting_interval
 
     def should_report(self, iteration_step: int) -> bool:
@@ -89,7 +88,7 @@ class TestingStatsReporter(TBEStatsReporter):
 
 @dataclass(frozen=True)
 class TestingStatsReporterConfig(TBEStatsReporterConfig):
-    def create_reporter(self) -> Optional[TBEStatsReporter]:
+    def create_reporter(self) -> TBEStatsReporter | None:
         return TestingStatsReporter(reporting_interval=self.interval)
 
 
@@ -105,8 +104,8 @@ def generate_cache_tbes(
     weights_cache_precision: SparseType = SparseType.FP32,
     stochastic_rounding: bool = False,
     gather_uvm_cache_stats: bool = False,
-    reporter_config: Optional[TestingStatsReporterConfig] = None,
-    multipass_prefetch_config: Optional[MultiPassPrefetchConfig] = None,
+    reporter_config: TestingStatsReporterConfig | None = None,
+    multipass_prefetch_config: MultiPassPrefetchConfig | None = None,
 ) -> tuple[
     SplitTableBatchedEmbeddingBagsCodegen,
     SplitTableBatchedEmbeddingBagsCodegen,

--- a/fbgemm_gpu/test/tbe/cache/cache_test.py
+++ b/fbgemm_gpu/test/tbe/cache/cache_test.py
@@ -11,7 +11,7 @@
 
 import random
 import unittest
-from typing import Any, cast, Optional
+from typing import Any, cast
 
 import hypothesis.strategies as st
 import numpy as np
@@ -56,7 +56,7 @@ class CacheTest(unittest.TestCase):
         B: int,
         D_offsets: list[int],
         mixed_B: bool,
-        Bs_feature_rank: Optional[list[list[int]]] = None,
+        Bs_feature_rank: list[list[int]] | None = None,
     ) -> tuple[int, ...]:
         """
         Compute output gradient shape
@@ -170,13 +170,13 @@ class CacheTest(unittest.TestCase):
         L: int,
         mixed: bool,
         prefetch_location: str,
-        prefetch_stream: Optional[torch.cuda.Stream],
+        prefetch_stream: torch.cuda.Stream | None,
         weights_cache_precision: SparseType,
         stochastic_rounding: bool,
         gather_uvm_cache_stats: bool,
         mixed_B: bool = False,
-        mpp_n_passes: Optional[int] = None,
-        mpp_min_size: Optional[int] = None,
+        mpp_n_passes: int | None = None,
+        mpp_min_size: int | None = None,
         trigger_bounds_check: bool = False,
     ) -> None:
         """
@@ -194,7 +194,7 @@ class CacheTest(unittest.TestCase):
         assert prefetch_location in ["before_fwd", "between_fwd_bwd"]
         reporter = TestingStatsReporterConfig(interval=2)
 
-        mpp_conf: Optional[MultiPassPrefetchConfig] = None
+        mpp_conf: MultiPassPrefetchConfig | None = None
         if mpp_n_passes or mpp_min_size:
             mpp_conf = MultiPassPrefetchConfig()
             if mpp_n_passes:
@@ -277,7 +277,7 @@ class CacheTest(unittest.TestCase):
 
         def _prefetch(
             cc: SplitTableBatchedEmbeddingBagsCodegen,
-            batch: Optional[TBERequest],
+            batch: TBERequest | None,
         ) -> None:
             if not batch:
                 return
@@ -360,7 +360,7 @@ class CacheTest(unittest.TestCase):
             def assert_event_exist(
                 event_name: str,
                 steps: list[int],
-                expected_value: Optional[list[int]] = None,
+                expected_value: list[int] | None = None,
             ) -> None:
                 self.assertEqual(
                     len(stats_reporter.reported_data[event_name]), len(steps)
@@ -544,9 +544,9 @@ class CacheTest(unittest.TestCase):
     )
     @settings(verbosity=VERBOSITY, max_examples=MAX_EXAMPLES, deadline=None)
     def test_get_prefetch_passes(
-        self, S: int, mpp_n_passes: Optional[int], mpp_min_size: Optional[int]
+        self, S: int, mpp_n_passes: int | None, mpp_min_size: int | None
     ) -> None:
-        mpp_conf: Optional[MultiPassPrefetchConfig] = None
+        mpp_conf: MultiPassPrefetchConfig | None = None
         if mpp_n_passes or mpp_min_size:
             mpp_conf = MultiPassPrefetchConfig()
             if mpp_n_passes:
@@ -653,9 +653,7 @@ class CacheTest(unittest.TestCase):
         max_indices: int,
         compute_count: bool,
         compute_inverse_indices: bool,
-    ) -> tuple[
-        torch.Tensor, torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]
-    ]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
         """Python reference implementation for validating get_unique_indices operations.
 
         This function provides an independent baseline for testing CPU and GPU implementations
@@ -683,8 +681,8 @@ class CacheTest(unittest.TestCase):
             A tuple containing:
             - unique_indices (Tensor): Tensor of size `linear_indices` that stores unique values in sorted order (i.e., unique values padded to input size)
             - unique_indices_length (Tensor): Tensor of size 1 containing number of unique values
-            - unique_indices_count (Optional[Tensor]): If compute_count=True, tensor of size `linear_indices` that contains an occurrence count for each unique value, else None.
-            - linear_index_positions_sorted (Optional[Tensor]): If compute_inverse_indices=True, tensor of size `linear_indices` that contains original positions such that linear_indices[linear_index_positions_sorted] produces sorted indices. Otherwise, None.
+            - unique_indices_count (Tensor | None): If compute_count=True, tensor of size `linear_indices` that contains an occurrence count for each unique value, else None.
+            - linear_index_positions_sorted (Tensor | None): If compute_inverse_indices=True, tensor of size `linear_indices` that contains original positions such that linear_indices[linear_index_positions_sorted] produces sorted indices. Otherwise, None.
         """
         N = linear_indices.numel()
 
@@ -830,10 +828,10 @@ class CacheTest(unittest.TestCase):
             unique2: torch.Tensor,
             compute_count: bool,
             compute_inverse_indices: bool,
-            count1: Optional[torch.Tensor] = None,
-            count2: Optional[torch.Tensor] = None,
-            positions1: Optional[torch.Tensor] = None,
-            positions2: Optional[torch.Tensor] = None,
+            count1: torch.Tensor | None = None,
+            count2: torch.Tensor | None = None,
+            positions1: torch.Tensor | None = None,
+            positions2: torch.Tensor | None = None,
         ):
             self.assertEqual(
                 length1,

--- a/fbgemm_gpu/test/tbe/cache/linearize_cache_indices_test.py
+++ b/fbgemm_gpu/test/tbe/cache/linearize_cache_indices_test.py
@@ -11,7 +11,6 @@
 
 import random
 import unittest
-from typing import Optional
 
 import torch
 from hypothesis import Verbosity
@@ -35,7 +34,7 @@ class LinearizeCacheIndicesTest(unittest.TestCase):
         hash_size_cumsum: torch.Tensor,
         indices: torch.Tensor,
         offsets: torch.Tensor,
-        B_offsets: Optional[torch.Tensor] = None,
+        B_offsets: torch.Tensor | None = None,
         max_B: int = -1,
     ) -> torch.Tensor:
         T = hash_size_cumsum.numel() - 1

--- a/fbgemm_gpu/test/tbe/common.py
+++ b/fbgemm_gpu/test/tbe/common.py
@@ -8,7 +8,7 @@
 # pyre-strict
 
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import fbgemm_gpu
 import numpy as np
@@ -64,7 +64,7 @@ VERBOSITY: Verbosity = Verbosity.verbose
 
 
 def gen_mixed_B_batch_sizes(
-    B: int, T: int, num_ranks: Optional[int] = None
+    B: int, T: int, num_ranks: int | None = None
 ) -> tuple[list[list[int]], list[int]]:
     if num_ranks is None:
         num_ranks = np.random.randint(low=1, high=4)
@@ -255,8 +255,8 @@ def recompute_output_vbe_cpu(
 
 def invoke_v1_cpu(
     optimizer: OptimType,
-    common_kwargs: Dict[str, Any],
-    optim_kwargs: Dict[str, Any],
+    common_kwargs: dict[str, Any],
+    optim_kwargs: dict[str, Any],
     vbe_metadata: invokers.lookup_args.VBEMetadata,
 ) -> torch.Tensor:
     """
@@ -322,8 +322,8 @@ def invoke_v1_cpu(
 
 def invoke_v1_cuda(
     optimizer: OptimType,
-    common_kwargs: Dict[str, Any],
-    optim_kwargs: Dict[str, Any],
+    common_kwargs: dict[str, Any],
+    optim_kwargs: dict[str, Any],
     vbe_metadata: invokers.lookup_args.VBEMetadata,
 ) -> torch.Tensor:
     """
@@ -488,10 +488,10 @@ def v1_lookup(
     indices: torch.Tensor,
     offsets: torch.Tensor,
     use_cpu: bool,
-    per_sample_weights: Optional[torch.Tensor] = None,
-    batch_size_per_feature_per_rank: Optional[List[List[int]]] = None,
-    feature_requires_grad: Optional[torch.Tensor] = None,
-    total_unique_indices: Optional[int] = None,
+    per_sample_weights: torch.Tensor | None = None,
+    batch_size_per_feature_per_rank: list[list[int]] | None = None,
+    feature_requires_grad: torch.Tensor | None = None,
+    total_unique_indices: int | None = None,
 ) -> torch.Tensor:
     """
     This function prepares inputs and invokes TBE V1 lookup function for the given optimizer on CPU or CUDA.
@@ -501,10 +501,10 @@ def v1_lookup(
         indices (torch.Tensor): indices tensor
         offsets (torch.Tensor): offsets tensor
         use_cpu (bool): whether to use CPU or CUDA
-        per_sample_weights (Optional[torch.Tensor]): per sample weights tensor
-        batch_size_per_feature_per_rank (Optional[List[List[int]]]): batch size per feature per rank
-        feature_requires_grad (Optional[torch.Tensor]): feature requires grad tensor
-        total_unique_indices (Optional[int]): total unique indices, this is for NONE optimizer
+        per_sample_weights (torch.Tensor | None): per sample weights tensor
+        batch_size_per_feature_per_rank (list[list[int]] | None): batch size per feature per rank
+        feature_requires_grad (torch.Tensor | None): feature requires grad tensor
+        total_unique_indices (int | None): total unique indices, this is for NONE optimizer
 
     Returns:
         output tensor (torch.Tensor)
@@ -573,7 +573,7 @@ def v1_lookup(
                 else:
                     emb_op.max_counter[0] = 1
 
-    common_kwargs: Dict[str, Any] = {
+    common_kwargs: dict[str, Any] = {
         "weights_placements": emb_op.weights_placements,
         "weights_offsets": emb_op.weights_offsets,
         "D_offsets": emb_op.D_offsets,
@@ -640,7 +640,7 @@ def v1_lookup(
         )
 
     if optimizer != OptimType.NONE:
-        optim_kwargs: Dict[str, Any] = {
+        optim_kwargs: dict[str, Any] = {
             "momentum1_dev": emb_op.momentum1_dev,
             "momentum1_host": emb_op.momentum1_host,
             "momentum1_uvm": emb_op.momentum1_uvm,
@@ -819,7 +819,7 @@ def load_tbe_configs_from_file(
     Returns:
         Tuple of (batch_size, total_ranks, common_config dict, list of TBE config dicts)
     """
-    with open(config_path, "r") as f:
+    with open(config_path) as f:
         data = json.load(f)
 
     batch_size = data.get("batch_size", 2048)

--- a/fbgemm_gpu/test/tbe/inference/common.py
+++ b/fbgemm_gpu/test/tbe/inference/common.py
@@ -10,7 +10,6 @@
 
 import random
 import unittest
-from typing import Optional
 
 import hypothesis.strategies as st
 import numpy as np
@@ -37,7 +36,7 @@ from hypothesis.strategies import composite
 
 @composite
 # pyre-ignore
-def get_nbit_weights_ty(draw) -> Optional[SparseType]:
+def get_nbit_weights_ty(draw) -> SparseType | None:
     """
     Returns None if mixed weights ty should be used, otherwise, returns specific SparseType.
     """

--- a/fbgemm_gpu/test/tbe/inference/inference_converter_test.py
+++ b/fbgemm_gpu/test/tbe/inference/inference_converter_test.py
@@ -12,7 +12,6 @@ import logging
 import math
 import random
 import unittest
-from typing import Optional
 
 import hypothesis.strategies as st
 import numpy as np
@@ -163,7 +162,7 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
         L: int,
         pooling_mode: PoolingMode,
         quantize_type: SparseType,
-        pruning_ratio: Optional[float],
+        pruning_ratio: float | None,
         use_cpu: bool,
     ) -> None:
         E = int(10**log_E)
@@ -289,11 +288,11 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
         ]
 
         # Start to test.
-        logging.info("use cpu = {}".format(use_cpu))
+        logging.info(f"use cpu = {use_cpu}")
         for pruning_ratio, remapped_index, remapped_offset in zip(
             pruning_ratios, remapped_indices, remapped_offsets
         ):
-            logging.info("pruning ratio = {}.".format(pruning_ratio))
+            logging.info(f"pruning ratio = {pruning_ratio}.")
             sparse_arch = SparseArch(
                 emb_dim=D, num_tables=T, num_rows=E, use_cpu=use_cpu
             )
@@ -345,7 +344,7 @@ class QuantizedSplitEmbeddingsTest(unittest.TestCase):
         T: int,
         D: int,
         log_E: int,
-        pruning_ratio: Optional[float],
+        pruning_ratio: float | None,
         use_cpu: bool,
         use_array_for_index_remapping: bool,
     ) -> None:

--- a/fbgemm_gpu/test/tbe/inference/nbit_cache_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_cache_test.py
@@ -10,7 +10,8 @@
 # pyre-ignore-all-errors[56]
 
 import unittest
-from typing import Callable
+from collections.abc import Callable
+from typing import Any
 
 import hypothesis.strategies as st
 import numpy as np
@@ -43,8 +44,7 @@ else:
 VERBOSITY: Verbosity = Verbosity.verbose
 
 
-# pyre-ignore
-additional_decorators: dict[str, list[Callable]] = {
+additional_decorators: dict[str, list[Callable[..., Any]]] = {
     "test_faketensor__test_nbit_uvm_cache_stats": [
         unittest.skip("very slow"),
     ],

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_autovec_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_autovec_test.py
@@ -11,7 +11,6 @@
 import os
 import random
 import unittest
-from typing import Optional
 
 import hypothesis.strategies as st
 import torch
@@ -50,7 +49,7 @@ class NBitFowardAutovecTest(NBitFowardTestCommon):
     )
     def test_nbit_forward_cpu_autovec(
         self,
-        nbit_weights_ty: Optional[SparseType],
+        nbit_weights_ty: SparseType | None,
         pooling_mode: PoolingMode,
         indices_dtype: torch.dtype,
         output_dtype: SparseType,

--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -11,7 +11,8 @@
 import os
 import random
 import unittest
-from typing import Any, Callable, Optional, Union
+from collections.abc import Callable
+from typing import Any
 
 import hypothesis.strategies as st
 import numpy as np
@@ -55,7 +56,7 @@ VERBOSITY: Verbosity = Verbosity.verbose
 
 
 # pyre-ignore
-additional_decorators: dict[str, list[Callable]] = {
+additional_decorators: dict[str, list[Callable[..., Any]]] = {
     "test_faketensor__test_nbit_forward_uvm_cache": [
         unittest.skip("CUDA Assert"),
     ],
@@ -143,10 +144,10 @@ class NBitFowardTest(NBitFowardTestCommon):
         weights_ty: SparseType,
         output_dtype: SparseType,
         weighted: bool,
-        ref_module: Union[
-            IntNBitTableBatchedEmbeddingBagsCodegen,
-            SplitTableBatchedEmbeddingBagsCodegen,
-        ],
+        ref_module: (
+            IntNBitTableBatchedEmbeddingBagsCodegen
+            | SplitTableBatchedEmbeddingBagsCodegen
+        ),
     ) -> None:
         D_alignment = max(weights_ty.align_size() for t in range(T))
         D_alignment = max(D_alignment, output_dtype.align_size())
@@ -529,7 +530,7 @@ class NBitFowardTest(NBitFowardTestCommon):
     )
     def test_nbit_forward_cpu(
         self,
-        nbit_weights_ty: Optional[SparseType],
+        nbit_weights_ty: SparseType | None,
         use_array_for_index_remapping: bool,
         do_pruning: bool,
         pooling_mode: PoolingMode,
@@ -821,7 +822,7 @@ class NBitFowardTest(NBitFowardTestCommon):
     )
     def test_nbit_forward_gpu_no_cache(
         self,
-        nbit_weights_ty: Optional[SparseType],
+        nbit_weights_ty: SparseType | None,
         use_array_for_index_remapping: bool,
         indices_dtype: torch.dtype,
         do_pruning: bool,
@@ -1072,7 +1073,7 @@ class NBitFowardTest(NBitFowardTestCommon):
         quant_cc.fill_random_weights()
         raw_embedding_weights = quant_cc.split_embedding_weights()
         # we mimic 1.0 scale, 0.0 bias for better results comparison
-        embedding_weights: list[tuple[torch.Tensor, Optional[torch.Tensor]]] = [
+        embedding_weights: list[tuple[torch.Tensor, torch.Tensor | None]] = [
             (table_weight, torch.tensor([1, 0], dtype=torch.float16).view(torch.uint8))
             for table_weight, _ in raw_embedding_weights
         ]

--- a/fbgemm_gpu/test/tbe/inference/nbit_split_embeddings_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_split_embeddings_test.py
@@ -11,7 +11,8 @@
 
 import random
 import unittest
-from typing import Callable
+from collections.abc import Callable
+from typing import Any
 
 import hypothesis.strategies as st
 import numpy as np
@@ -40,7 +41,7 @@ else:
 VERBOSITY: Verbosity = Verbosity.verbose
 
 # pyre-ignore
-additional_decorators: dict[str, list[Callable]] = {
+additional_decorators: dict[str, list[Callable[..., Any]]] = {
     "test_faketensor__test_nbit_forward_cpu_seq_int4": {
         unittest.skip(
             "Operator outputs int4 tensors which do not support opcheck tests"
@@ -311,12 +312,12 @@ class NBitSplitEmbeddingsTest(unittest.TestCase):
             # arbitrary. We compare sum along ways in each set, instead of expecting exact tensor match.
             cache_weights_ref = torch.reshape(
                 # pyre-fixme[6]: For 1st argument expected `Tensor` but got
-                #  `Union[Tensor, Module]`.
+                #  `Tensor | Module`.
                 cc_ref.lxu_cache_weights,
                 [-1, associativity],
             )
             # pyre-fixme[6]: For 1st argument expected `Tensor` but got
-            #  `Union[Tensor, Module]`.
+            #  `Tensor | Module`.
             cache_weights = torch.reshape(cc.lxu_cache_weights, [-1, associativity])
             torch.testing.assert_close(
                 torch.sum(cache_weights_ref, 1),
@@ -325,20 +326,20 @@ class NBitSplitEmbeddingsTest(unittest.TestCase):
             )
             torch.testing.assert_close(
                 # pyre-fixme[6]: For 1st argument expected `Tensor` but got
-                #  `Union[Tensor, Module]`.
+                #  `Tensor | Module`.
                 torch.sum(cc.lxu_cache_state, 1),
                 # pyre-fixme[6]: For 1st argument expected `Tensor` but got
-                #  `Union[Tensor, Module]`.
+                #  `Tensor | Module`.
                 torch.sum(cc_ref.lxu_cache_state, 1),
                 equal_nan=True,
             )
             # lxu_state can be different as time_stamp values can be different.
             # we check the entries with max value.
             # pyre-fixme[6]: For 1st argument expected `Tensor` but got
-            #  `Union[Tensor, Module]`.
+            #  `Tensor | Module`.
             max_timestamp_ref = torch.max(cc_ref.lxu_state)
             # pyre-fixme[6]: For 1st argument expected `Tensor` but got
-            #  `Union[Tensor, Module]`.
+            #  `Tensor | Module`.
             max_timestamp_uvm_caching = torch.max(cc.lxu_state)
             x = cc_ref.lxu_state == max_timestamp_ref
             y = cc.lxu_state == max_timestamp_uvm_caching

--- a/fbgemm_gpu/test/tbe/ssd/kv_backend_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/kv_backend_test.py
@@ -13,7 +13,7 @@ import tempfile
 import threading
 import time
 import unittest
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import patch
 
 import hypothesis.strategies as st
@@ -61,12 +61,12 @@ class SSDCheckpointTest(unittest.TestCase):
         max_D: int,
         weight_precision: SparseType,
         enable_l2: bool = True,
-        feature_dims: Optional[torch.Tensor] = None,
-        hash_size_cumsum: Optional[torch.Tensor] = None,
+        feature_dims: torch.Tensor | None = None,
+        hash_size_cumsum: torch.Tensor | None = None,
         backend_type: BackendType = BackendType.SSD,
         flushing_block_size: int = 1000,
-        ssd_directory: Optional[str] = None,
-        eviction_policy: Optional[EvictionPolicy] = None,
+        ssd_directory: str | None = None,
+        eviction_policy: EvictionPolicy | None = None,
         disable_random_init: bool = False,
         enable_blob_db: bool = False,
     ) -> object:
@@ -152,7 +152,7 @@ class SSDCheckpointTest(unittest.TestCase):
         mixed: bool,
         enable_l2: bool = True,
         ssd_rocksdb_shards: int = 1,
-        kv_zch_params: Optional[KVZCHParams] = None,
+        kv_zch_params: KVZCHParams | None = None,
         backend_type: BackendType = BackendType.SSD,
         flushing_block_size: int = 1000,
     ) -> tuple[SSDTableBatchedEmbeddingBags, list[int], list[int]]:

--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py
@@ -9,7 +9,7 @@
 
 import tempfile
 import unittest
-from typing import Any, Optional
+from typing import Any
 
 import hypothesis.strategies as st
 import numpy as np
@@ -205,9 +205,9 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
         prefetch_pipeline: bool,
         # If True, prefetch will be invoked by the user.
         explicit_prefetch: bool,
-        prefetch_location: Optional[PrefetchLocation],
+        prefetch_location: PrefetchLocation | None,
         use_prefetch_stream: bool,
-        flush_location: Optional[FlushLocation],
+        flush_location: FlushLocation | None,
         trigger_bounds_check: bool,
         mixed_B: bool = False,
         enable_raw_embedding_streaming: bool = False,
@@ -913,8 +913,8 @@ class SSDSplitTableBatchedEmbeddingsTest(SSDSplitTableBatchedEmbeddingsTestCommo
     @staticmethod
     def _record_event_mock(
         stream: torch.cuda.Stream,
-        pre_event: Optional[torch.cuda.Event],
-        post_event: Optional[torch.cuda.Event],
+        pre_event: torch.cuda.Event | None,
+        post_event: torch.cuda.Event | None,
         **kwargs_: Any,
     ) -> None:
         with torch.cuda.stream(stream):

--- a/fbgemm_gpu/test/tbe/ssd/ssd_utils_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_utils_test.py
@@ -9,7 +9,7 @@
 
 import random
 import unittest
-from typing import Callable
+from collections.abc import Callable
 
 import fbgemm_gpu.tbe.ssd  # noqa F401
 import hypothesis.strategies as st

--- a/fbgemm_gpu/test/tbe/ssd/training_common.py
+++ b/fbgemm_gpu/test/tbe/ssd/training_common.py
@@ -10,7 +10,7 @@
 import math
 import unittest
 from enum import Enum
-from typing import Any, Optional, Union
+from typing import Any
 
 import hypothesis.strategies as st
 import numpy as np
@@ -38,7 +38,7 @@ def find_different_rows(
     atol: float = 1.0e-4,
     rtol: float = 1.0e-4,
     return_values: bool = False,
-) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Find the indices of rows that are different between two tensors.
 
@@ -251,15 +251,15 @@ class SSDSplitTableBatchedEmbeddingsTestCommon(unittest.TestCase):
         trigger_bounds_check: bool = False,
         mixed_B: bool = False,
         is_kv_tbes: bool = False,
-        bucket_offsets: Optional[list[tuple[int, int]]] = None,
-        bucket_sizes: Optional[list[int]] = None,
+        bucket_offsets: list[tuple[int, int]] | None = None,
+        bucket_sizes: list[int] | None = None,
     ) -> tuple[
         list[torch.Tensor],
         list[torch.Tensor],
         torch.Tensor,
         torch.Tensor,
         torch.Tensor,
-        Optional[list[list[int]]],
+        list[list[int]] | None,
     ]:
         """
         Generate indices and per sample weights
@@ -617,7 +617,7 @@ class SSDSplitTableBatchedEmbeddingsTestCommon(unittest.TestCase):
             emb_ref.insert(table_to_replicate, emb_ref[table_to_replicate])
 
         cache_sets = max(int(max(T * B * L, 1) * cache_set_scale), 1)
-        res_params: Optional[RESParams] = None
+        res_params: RESParams | None = None
         if enable_raw_embedding_streaming:
             res_params = RESParams(
                 res_server_port=0,
@@ -693,10 +693,10 @@ class SSDSplitTableBatchedEmbeddingsTestCommon(unittest.TestCase):
         if weights_precision == SparseType.FP16:
             emb_ref = [emb.float() for emb in emb_ref]
 
-        # pyre-fixme[7]: Expected `Tuple[SSDTableBatchedEmbeddingBags,
-        #  List[EmbeddingBag]]` but got `Tuple[SSDTableBatchedEmbeddingBags,
-        #  Union[List[Union[Embedding, EmbeddingBag]], List[Embedding],
-        #  List[EmbeddingBag]]]`.
+        # pyre-fixme[7]: Expected `tuple[SSDTableBatchedEmbeddingBags,
+        #  list[EmbeddingBag]]` but got `tuple[SSDTableBatchedEmbeddingBags,
+        #  list[Embedding | EmbeddingBag] | list[Embedding] |
+        #  list[EmbeddingBag]]`.
         return emb, emb_ref
 
     def concat_ref_tensors(
@@ -719,8 +719,8 @@ class SSDSplitTableBatchedEmbeddingsTestCommon(unittest.TestCase):
         rearrange tensors into VBE format and concat them into one tensor
 
         Parameters:
-            tensors (List[torch.Tensor]): List of tensors
-            batch_size_per_feature_per_rank (List[List[int]]): List of batch sizes per feature per rank
+            tensors (list[torch.Tensor]): List of tensors
+            batch_size_per_feature_per_rank (list[list[int]]): List of batch sizes per feature per rank
 
         Returns:
             concatenated tensor in VBE output format
@@ -750,9 +750,9 @@ class SSDSplitTableBatchedEmbeddingsTestCommon(unittest.TestCase):
         B: int,
         L: int,
         weighted: bool,
-        tolerance: Optional[float] = None,
+        tolerance: float | None = None,
         it: int = -1,
-        batch_size_per_feature_per_rank: Optional[list[list[int]]] = None,
+        batch_size_per_feature_per_rank: list[list[int]] | None = None,
     ) -> tuple[list[torch.Tensor], torch.Tensor]:
         """
         Execute the forward functions of SSDTableBatchedEmbeddingBags and
@@ -841,7 +841,7 @@ class SSDSplitTableBatchedEmbeddingsTestCommon(unittest.TestCase):
         B: int,
         D: int,
         pooling_mode: PoolingMode,
-        batch_size_per_feature_per_rank: Optional[list[list[int]]] = None,
+        batch_size_per_feature_per_rank: list[list[int]] | None = None,
     ) -> None:
         # Generate output gradient
         output_grad_list = [torch.randn_like(out) for out in output_ref_list]

--- a/fbgemm_gpu/test/tbe/stats/tbe_bench_params_reporter_test.py
+++ b/fbgemm_gpu/test/tbe/stats/tbe_bench_params_reporter_test.py
@@ -210,7 +210,7 @@ class TestTBEBenchmarkParamsReporter(unittest.TestCase):
             "torch.ops.fbgemm.check_feature_gate_key"
         ) as mock_check_feature_gate_key:
             # Mock the return value for TBE_REPORT_INPUT_PARAMS
-            def side_effect(feature_name: str) -> Optional[bool]:
+            def side_effect(feature_name: str) -> bool | None:
                 if feature_name == FeatureGateName.TBE_REPORT_INPUT_PARAMS.name:
                     return True
 

--- a/fbgemm_gpu/test/tbe/training/backward_none_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_none_test.py
@@ -11,7 +11,7 @@
 
 import random
 import unittest
-from typing import Any, Optional, Union
+from typing import Any
 
 import hypothesis.strategies as st
 import numpy as np
@@ -204,7 +204,7 @@ class BackwardNoneTest(unittest.TestCase):
         long_segments: bool,
         pooling_mode: PoolingMode,
         output_dtype: SparseType,
-        optimizer: Optional[OptimType] = None,
+        optimizer: OptimType | None = None,
         use_api_v1: bool = False,
     ) -> None:
         use_cpu = False
@@ -348,7 +348,7 @@ class BackwardNoneTest(unittest.TestCase):
             # as weight
             if weights_precision != output_dtype:
                 fs = [f.to(output_dtype.as_dtype()) for f in fs]
-            gos: Union[list[Tensor], Tensor] = [torch.randn_like(f) for f in fs]
+            gos: list[Tensor] | Tensor = [torch.randn_like(f) for f in fs]
             [f.backward(go) for (f, go) in zip(fs, gos)]
         else:
             bs_ = SplitTableBatchedEmbeddingBagsCodegen(
@@ -375,7 +375,7 @@ class BackwardNoneTest(unittest.TestCase):
                     to_device(xw.contiguous().view(-1), use_cpu),
                 )
             )
-            gos: Union[list[Tensor], Tensor] = torch.rand_like(fs)
+            gos: list[Tensor] | Tensor = torch.rand_like(fs)
             fs.backward(gos)
 
         cc = SplitTableBatchedEmbeddingBagsCodegen(
@@ -430,14 +430,14 @@ class BackwardNoneTest(unittest.TestCase):
 
         if optimizer is not None:
             # pyre-fixme[6]: For 1st argument expected `Parameter` but got
-            #  `Union[Tensor, Module]`.
+            #  `Tensor | Module`.
             params = SplitEmbeddingOptimizerParams(weights_dev=cc.weights_dev)
             embedding_args = SplitEmbeddingArgs(
                 # pyre-fixme[6]: For 1st argument expected `Tensor` but got
-                #  `Union[Tensor, Module]`.
+                #  `Tensor | Module`.
                 weights_placements=cc.weights_placements,
                 # pyre-fixme[6]: For 2nd argument expected `Tensor` but got
-                #  `Union[Tensor, Module]`.
+                #  `Tensor | Module`.
                 weights_offsets=cc.weights_offsets,
                 max_D=cc.max_D,
             )

--- a/fbgemm_gpu/test/tbe/training/backward_optimizers_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_optimizers_test.py
@@ -11,7 +11,7 @@
 
 import math
 import unittest
-from typing import Any, Optional, Union
+from typing import Any
 
 import hypothesis.strategies as st
 import numpy as np
@@ -107,9 +107,9 @@ class BackwardOptimizersTest(unittest.TestCase):
         use_cpu: bool,
         weight_decay_mode: WeightDecayMode = WeightDecayMode.NONE,
         uvm_non_rowwise_momentum: bool = False,
-        optimizer_state_dtypes: Optional[dict[str, SparseType]] = None,
+        optimizer_state_dtypes: dict[str, SparseType] | None = None,
         use_rowwise_bias_correction: bool = False,
-        counter_weight_decay_mode: Optional[CounterWeightDecayMode] = None,
+        counter_weight_decay_mode: CounterWeightDecayMode | None = None,
         counter_halflife: int = -1,
         use_api_v1: bool = False,
     ) -> None:
@@ -476,8 +476,8 @@ class BackwardOptimizersTest(unittest.TestCase):
         if exact_adagrad:
             rowwise = optimizer == OptimType.EXACT_ROWWISE_ADAGRAD
             for t in range(T):
-                row_counter: Optional[torch.Tensor] = None
-                freq: Optional[torch.Tensor] = None
+                row_counter: torch.Tensor | None = None
+                freq: torch.Tensor | None = None
                 iter_: int = -1
 
                 if rowwise and weight_decay_mode in (
@@ -550,7 +550,7 @@ class BackwardOptimizersTest(unittest.TestCase):
                             denom,
                             counter_based_regularization,
                             row_counter,
-                            # pyre-fixme[6]: Expected `Tensor` for 6th param but got `Optional[Tensor]`
+                            # pyre-fixme[6]: Expected `Tensor` for 6th param but got `Tensor | None`
                             freq,
                             max_counter,
                             iter_,
@@ -601,7 +601,7 @@ class BackwardOptimizersTest(unittest.TestCase):
 
         if optimizer in (OptimType.PARTIAL_ROWWISE_ADAM, OptimType.ADAM):
             rowwise = optimizer == OptimType.PARTIAL_ROWWISE_ADAM
-            row_counter: Optional[torch.Tensor] = None
+            row_counter: torch.Tensor | None = None
             for t in range(T):
                 if rowwise or not use_rowwise_bias_correction:
                     m1, m2 = split_optimizer_states[t]
@@ -816,7 +816,7 @@ class BackwardOptimizersTest(unittest.TestCase):
         self,
         dense_cpu_grad: torch.Tensor,
         weights: torch.Tensor,
-        regularization: Union[CounterBasedRegularizationDefinition, CowClipDefinition],
+        regularization: CounterBasedRegularizationDefinition | CowClipDefinition,
         row_counter: torch.Tensor,
         prev_iter: torch.Tensor,
         iter_: int,

--- a/fbgemm_gpu/test/tbe/training/merge_vbe_test.py
+++ b/fbgemm_gpu/test/tbe/training/merge_vbe_test.py
@@ -12,7 +12,7 @@
 
 import tempfile
 import unittest
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 import numpy as np
 import torch
@@ -51,7 +51,7 @@ else:
     from fbgemm_gpu.test.test_utils import running_in_oss
 
 # Set up test strategy
-test_st: Dict[str, Any] = {
+test_st: dict[str, Any] = {
     "num_embeddings": st.integers(min_value=2, max_value=5),
     "num_ranks": st.integers(min_value=2, max_value=8),
     "T": st.integers(min_value=1, max_value=5),
@@ -67,22 +67,22 @@ test_st: Dict[str, Any] = {
 
 class EmbeddingBag:
     T: int
-    rows: List[int]
-    dims: List[int]
+    rows: list[int]
+    dims: list[int]
     is_ssd: bool
-    op: Union[SplitTableBatchedEmbeddingBagsCodegen, SSDTableBatchedEmbeddingBags]
+    op: SplitTableBatchedEmbeddingBagsCodegen | SSDTableBatchedEmbeddingBags
 
     def __init__(
         self,
-        embedding_specs: Union[
-            List[Tuple[int, int, EmbeddingLocation, ComputeDevice]],
-            List[Tuple[int, int]],
-        ],
+        embedding_specs: (
+            list[tuple[int, int, EmbeddingLocation, ComputeDevice]]
+            | list[tuple[int, int]]
+        ),
         optimizer: OptimType,
         output_dtype: SparseType,
         pooling_mode: PoolingMode,
         weights_precision: SparseType,
-        feature_table_map: Optional[List[int]],
+        feature_table_map: list[int] | None,
         is_ssd: bool = False,
     ):
         self.T = (
@@ -91,7 +91,7 @@ class EmbeddingBag:
             else len(feature_table_map)
         )
         self.is_ssd = is_ssd
-        kwargs: Dict[str, Any] = {}
+        kwargs: dict[str, Any] = {}
         if is_ssd:
             emb_op = SSDTableBatchedEmbeddingBags
             kwargs["cache_sets"] = 1
@@ -133,9 +133,9 @@ class EmbeddingBag:
 
 
 def _merge_variable_batch_embeddings(
-    embeddings: List[torch.Tensor],
-    features: List[int],
-    splits: List[List[int]],
+    embeddings: list[torch.Tensor],
+    features: list[int],
+    splits: list[list[int]],
     num_ranks: int,
 ) -> torch.Tensor:
     assert (
@@ -162,7 +162,7 @@ def create_embedding(
     weights_precision: SparseType,
     output_dtype: SparseType,
     pooling_mode: PoolingMode,
-    feature_table_map: Optional[List[int]] = None,
+    feature_table_map: list[int] | None = None,
     use_cpu: bool = False,
     use_cache: bool = False,
     mixed_uvm: bool = False,
@@ -225,17 +225,17 @@ class MergeVBETest(unittest.TestCase):
 
     def get_vbe_splits_and_offsets(
         self,
-        embedding_list: List[EmbeddingBag],
-        Bs_feature_rank_list: List[List[List[int]]],
+        embedding_list: list[EmbeddingBag],
+        Bs_feature_rank_list: list[list[list[int]]],
         num_ranks: int,
-    ) -> Tuple[int, List[List[int]], List[List[List[int]]]]:
+    ) -> tuple[int, list[list[int]], list[list[list[int]]]]:
         """
         Calculate split size list, total VBE output size and offsets.
 
         Args:
-            embedding_list (List[EmbeddingBag]):
+            embedding_list (list[EmbeddingBag]):
                 List of TBEs/SSD TBEs
-            Bs_feature_rank_list (List[List[List[int]]]):
+            Bs_feature_rank_list (list[list[list[int]]]):
                 List of batch_size_per_feature_per_rank where Bs_feature_rank_list[i]
                 is batch_size_per_feature_per_rank of the ith embedding table
             num_ranks (int):
@@ -243,10 +243,10 @@ class MergeVBETest(unittest.TestCase):
         Return:
             total_output_size (int):
                 total VBE output size for all embeddings
-            splits_list (List[List[int]]):
+            splits_list (list[list[int]]):
                 list of split size where splits_list[i] contains output size for each
                 batch in embedding table i
-            vbe_output_offset_list List[List[int]]):
+            vbe_output_offset_list list[list[int]]):
                 list of vbe_output_offset where vbe_output_offset_list[i] contains
                 offsets for embedding table i. vbe_output_offset has a shape of
                 [num_ranks, num_features].
@@ -304,9 +304,9 @@ class MergeVBETest(unittest.TestCase):
         output_dtype: SparseType,
         pooling_mode: PoolingMode,
         use_cpu: bool = False,
-        features_list: Optional[list[int]] = None,
-        dims_list: Optional[list[int]] = None,
-        Bs_feature_rank_list: Optional[List[List[List[int]]]] = None,
+        features_list: list[int] | None = None,
+        dims_list: list[int] | None = None,
+        Bs_feature_rank_list: list[list[list[int]]] | None = None,
     ):
         """
         Execute merge VBE

--- a/fbgemm_gpu/test/tbe/utils/split_embeddings_test.py
+++ b/fbgemm_gpu/test/tbe/utils/split_embeddings_test.py
@@ -11,7 +11,8 @@
 
 import random
 import unittest
-from typing import Callable
+from collections.abc import Callable
+from typing import Any
 
 import hypothesis.strategies as st
 import numpy as np
@@ -50,8 +51,7 @@ else:
 VERBOSITY: Verbosity = Verbosity.verbose
 
 
-# pyre-ignore
-additional_decorators: dict[str, list[Callable]] = {}
+additional_decorators: dict[str, list[Callable[..., Any]]] = {}
 
 
 @optests.generate_opcheck_tests(fast=True, additional_decorators=additional_decorators)
@@ -520,8 +520,8 @@ class SplitTableBatchedEmbeddingsTest(unittest.TestCase):
 
         momentum1: list[Tensor] = [
             s for (s,) in cc.split_optimizer_states()
-        ]  # List[rows]
-        weight: list[Tensor] = cc.split_embedding_weights()  # List[(rows, dim)]
+        ]  # list[rows]
+        weight: list[Tensor] = cc.split_embedding_weights()  # list[(rows, dim)]
         for t in range(T):
             momentum1[t].fill_(1)
             weight[t].fill_(1)

--- a/fbgemm_gpu/test/tbe/utils/writeback_util_test.py
+++ b/fbgemm_gpu/test/tbe/utils/writeback_util_test.py
@@ -7,7 +7,7 @@
 # pyre-strict
 
 import unittest
-from typing import cast, Set, Tuple
+from typing import cast
 
 import hypothesis.strategies as st
 import torch
@@ -225,7 +225,7 @@ class WritebackUtilsTest(unittest.TestCase):
         # only keep the gradient for the first occurrence of each (table, index)
         # pair. Duplicate occurrences get zeroed out.
         expected = torch.zeros_like(grad[0], device=grad[0].device)
-        seen: Set[Tuple[int, int]] = set()
+        seen: set[tuple[int, int]] = set()
         for i in range(indices.size(0)):
             # Determine which table this index belongs to based on position
             table_idx = i // B

--- a/fbgemm_gpu/test/utils/filestore_test.py
+++ b/fbgemm_gpu/test/utils/filestore_test.py
@@ -13,7 +13,7 @@ import string
 import tempfile
 import unittest
 from pathlib import Path
-from typing import BinaryIO, Optional, Union
+from typing import BinaryIO
 
 import fbgemm_gpu
 import torch
@@ -27,8 +27,8 @@ class FileStoreTest(unittest.TestCase):
         self,
         # pyre-fixme[2]
         store,  # FileStore
-        input: Union[BinaryIO, torch.Tensor, Path],
-        path: Optional[str] = None,
+        input: BinaryIO | torch.Tensor | Path,
+        path: str | None = None,
     ) -> None:
         """
         Generic FileStore routines to test reading and writing data
@@ -66,7 +66,7 @@ class FileStoreTest(unittest.TestCase):
         self,
         # pyre-fixme[2]
         store,  # FileStore
-        root_dir: Optional[str] = None,
+        root_dir: str | None = None,
     ) -> None:
         """
         Generic FileStore routines to test creating and removing directories


### PR DESCRIPTION
Summary:
Replace Optional[X]/Dict[X]/List[X] with X | None, dict[X], list[X] across fbgemm_gpu/test/ to line up with the 3.10 baseline.


Reviewed By: henrylhtsang

Differential Revision: D106570032

Pulled By: q10
