### PR TITLE
Disable build-macos to confirm cost driver

### DIFF
--- a/.github/workflows/fbgemm_ci.yml
+++ b/.github/workflows/fbgemm_ci.yml
@@ -94,6 +94,7 @@ jobs:
 
 
   build-macos:
+    if: false
     runs-on: ${{ matrix.os }}
     defaults:
       run:


### PR DESCRIPTION
Summary:
Disable `build-macos` in fbgemm_ci.yml to confirm it is the sole remaining
OSS CI cost driver. `build-linux` and `build-bazel` continue to run.

Background: scuba `opensource_ci_jobs` attributes ~$2,600/wk to
`build-macos (macos-13, *)` while `build-linux` and `build-bazel` show
$0/wk. D106405302 (Windows removed) and D106423883 (macos-13 -> macos-14)
have landed, but macos-13 jobs are still billing today (~$880 so far)
from PRs that haven't rebased.

Cutting `build-macos` entirely confirms (a) the cost attribution is
correct and (b) `build-linux` / `build-bazel` carry no hidden cost. Once
the dashboard goes flat (~48h), re-enable `build-macos` in a follow-up
diff that either gates it behind a label (e.g., `ci:macos`) or limits the
runner pool.

Surgical form: single-line `if: false` added to the `build-macos` block.
Re-enable is a 1-line revert.

Differential Revision: D106822515


