### PR TITLE
Fix jagged_unique_indices OOB regression from D104827588 (#5799)

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_unique_indices.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_unique_indices.cu
@@ -38,6 +38,16 @@ static constexpr int32_t kFlatBlockSize = 256;
 // so the prior launch consumed only ~5 SMs out of 132 on H100 with each warp
 // shuffling work between lanes. The flat grid uses one block per sample,
 // dispatching all SMs and removing the intra-warp shuffle dance.
+//
+// Contract: indices[i] must satisfy `idx < per_feature_hash_size[t]` for any
+// feature `t < T - 1` (intermediate features). Violating this causes
+// `hash_offset + idx` to overflow into feature `t + 1`'s hash range, which
+// silently mis-attributes the value's count in unique_indices_length_kernel
+// (counts leak from t to t+1; total is preserved). The last feature is
+// explicitly exempt: its OOB tail is supported via the clamp in the length
+// kernel and the scatter-form delinearize. The assert below catches the
+// intermediate-feature case in debug builds; CUDA_KERNEL_ASSERT also fires
+// in release builds (by design — see torch/headeronly/macros/Macros.h).
 template <typename index_t>
 __global__ __launch_bounds__(kFlatBlockSize) void linearize_index_flat_kernel(
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
@@ -60,9 +70,21 @@ __global__ __launch_bounds__(kFlatBlockSize) void linearize_index_flat_kernel(
     return;
   }
   const auto hash_offset = hash_size_cumsum[t];
+  // OOB check exemptions:
+  //   - is_last_feature: the last feature's OOB tail is explicitly supported.
+  //   - is_merged_feature (per_feature_hash == 0): the caller is grouping
+  //     this feature with another via the hash_size_offsets indirection;
+  //     consecutive-zero entries in hash_size_cumsum mean the two features
+  //     share the same hash space, so any local index value is valid.
+  const bool is_last_feature = (t == hash_size_cumsum.size(0) - 2);
+  const auto per_feature_hash =
+      is_last_feature ? index_t{0} : (hash_size_cumsum[t + 1] - hash_offset);
+  const bool is_merged_feature = !is_last_feature && (per_feature_hash == 0);
 
   for (auto i = threadIdx.x; i < L; i += blockDim.x) {
     const auto idx = __ldg(&indices[indices_start + i]);
+    CUDA_KERNEL_ASSERT(
+        is_last_feature || is_merged_feature || idx < per_feature_hash);
     linear_indices[indices_start + i] = hash_offset + idx;
   }
 }
@@ -107,9 +129,11 @@ __global__ __launch_bounds__(kFlatBlockSize) void jagged_unique_scatter_kernel(
 //
 // Pipeline:
 //   1. cub::DeviceRadixSort::SortPairs on (linear_indices, arange-positions)
-//      with end_bit trimmed to the bit-width of total_hash_size, cutting
-//      radix-sort passes from ceil(64/8)=8 to ceil(bit_width/8) (e.g. 3
-//      passes for hash_size=1M).
+//      with end_bit trimmed to the bit-width of the maximum linearized key,
+//      cutting radix-sort passes from ceil(64/8)=8 to ceil(bit_width/8) (e.g.
+//      3 passes for hash_size=1M). end_bit must cover the real max key (not
+//      just total_hash_size) so last-feature OOB keys are fully ordered; see
+//      the caller for why.
 //   2. cub::DeviceRunLengthEncode::Encode to extract the sorted unique keys.
 //   3. adjacent_diff -> inclusive_scan -> scatter to recover the inverse
 //      index in the original (pre-sort) input order, mirroring pytorch's
@@ -117,7 +141,7 @@ __global__ __launch_bounds__(kFlatBlockSize) void jagged_unique_scatter_kernel(
 template <typename index_t>
 static void jagged_unique_indices_pipeline(
     const Tensor& linear_indices,
-    const int total_hash_size_bits,
+    const int end_bit,
     Tensor& linear_unique_indices,
     Tensor& reverse_index) {
   const int64_t N = linear_indices.numel();
@@ -142,7 +166,7 @@ static void jagged_unique_indices_pipeline(
         sorted_positions.data_ptr<int32_t>(),
         static_cast<int>(N),
         0,
-        total_hash_size_bits,
+        end_bit,
         stream));
     Tensor temp_storage =
         at::empty({static_cast<int64_t>(temp_storage_bytes)}, byte_opts);
@@ -155,7 +179,7 @@ static void jagged_unique_indices_pipeline(
         sorted_positions.data_ptr<int32_t>(),
         static_cast<int>(N),
         0,
-        total_hash_size_bits,
+        end_bit,
         stream));
   }
 
@@ -258,35 +282,30 @@ __device__ __forceinline__ int32_t device_lower_bound(
   return lo;
 }
 
-// Delinearize the unique indices via per-feature lookup over hash_size_cumsum.
-// Each thread handles one sorted unique key v: locate its feature t via
-// device_lower_bound(hash_size_cumsum, v + 1) - 1 (largest t with
-// hash_size_cumsum[t] <= v) and emit unique_indices[i] = v -
-// hash_size_cumsum[t].
+// Delinearize the unique indices via scatter over the original input indices.
+// For each input position i, write the original (pre-linearization) per-feature
+// index value into unique_indices at the position designated by reverse_index.
 //
-// Replaces delinearize_unique_index_kernel which iterated over total_indices
-// (~24M on the prod IFR-MTML mc7 shape) and scatter-wrote via reverse_index.
-// The new form iterates over num_unique (~1-2M) with a small O(log T) probe
-// per thread - 24x fewer threads, and the writes are sequential.
+// This is index-bound-agnostic by construction: the original indices[i] value
+// is preserved exactly, regardless of whether it exceeds the per-feature
+// hash_size. A gather form that recovers the per-feature index from the
+// linearized key (v - hash_size_cumsum[t]) misattributes out-of-bound values
+// whose linearized form exceeds hash_size_cumsum[T] to a phantom feature
+// index and loses the original value.
 template <typename index_t>
 __global__
-__launch_bounds__(kFlatBlockSize) void delinearize_unique_from_sorted_kernel(
+__launch_bounds__(kFlatBlockSize) void delinearize_unique_index_kernel(
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
-        hash_size_cumsum,
-    const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
-        unique_keys,
+        indices,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits>
+        reverse_index,
     pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
         unique_indices) {
-  const auto num_unique = unique_keys.size(0);
+  const auto total_indices = indices.size(0);
   const auto i = blockIdx.x * blockDim.x + threadIdx.x;
-  if (i >= static_cast<uint64_t>(num_unique)) {
-    return;
+  if (i < static_cast<uint64_t>(total_indices)) {
+    unique_indices[reverse_index[i]] = indices[i];
   }
-  const index_t v = unique_keys[i];
-  // unique_keys[i] < hash_size_cumsum[T] <= total_hash_size, so v + 1
-  // does not overflow even at the ZCH boundary (total_hash_size = INT64_MAX).
-  const int32_t t = device_lower_bound<index_t>(hash_size_cumsum, v + 1) - 1;
-  unique_indices[i] = v - hash_size_cumsum[t];
 }
 
 // Compute the per-(feature, batch) lengths for the unique indices.
@@ -297,6 +316,18 @@ __launch_bounds__(kFlatBlockSize) void delinearize_unique_from_sorted_kernel(
 //   [lower_bound(linear_unique_indices, hash_size_cumsum[t]),
 //    lower_bound(linear_unique_indices, hash_size_cumsum[t+1])).
 // The slice length equals num_unique_t for feature t.
+//
+// Out-of-bound carve-out: when the last feature has indices exceeding its
+// per-feature hash_size, their linearized form `hash_size_cumsum[T-1] + idx`
+// can exceed hash_size_cumsum[T] and sort past the upper-bound binary
+// search. For the last feature group only, clamp hi_pos to
+// linear_unique_indices.size(0) so those tail values are still counted.
+// This also covers the degenerate case where the last feature has size 0
+// (consecutive equal entries at the tail of hash_size_cumsum): low == high
+// would otherwise short-circuit to length=0 and drop the OOB tail.
+// Without these carve-outs, sum(output_lengths) < unique_indices.numel(),
+// which produces an inconsistent KJT and crashes downstream
+// all_to_all_single with a "Split sizes doesn't match total dim 0 size".
 template <typename index_t>
 __global__ __launch_bounds__(kFlatBlockSize) void unique_indices_length_kernel(
     const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits>
@@ -324,16 +355,18 @@ __global__ __launch_bounds__(kFlatBlockSize) void unique_indices_length_kernel(
   if (tid == 0) {
     const auto low = hash_size_cumsum[hash_begin];
     const auto high = hash_size_cumsum[hash_end];
-    if (low == high) {
-      // Empty feature group. Output is pre-zeroed by at::zeros at the
-      // launch site; nothing to write.
+    const bool is_last_group = (hash_end == hash_size_cumsum.size(0) - 1);
+    if (low == high && !is_last_group) {
+      // Empty intermediate feature group. Output is pre-zeroed by
+      // at::zeros at the launch site; nothing to write.
       s_div_length = 0;
       s_r_length = 0;
     } else {
       const int32_t lo_pos =
           device_lower_bound<index_t>(linear_unique_indices, low);
-      const int32_t hi_pos =
-          device_lower_bound<index_t>(linear_unique_indices, high);
+      const int32_t hi_pos = is_last_group
+          ? linear_unique_indices.size(0)
+          : device_lower_bound<index_t>(linear_unique_indices, high);
       const index_t total_length = static_cast<index_t>(hi_pos - lo_pos);
       s_div_length = total_length / static_cast<index_t>(num_lengths);
       s_r_length = total_length % static_cast<index_t>(num_lengths);
@@ -355,26 +388,43 @@ __global__ __launch_bounds__(kFlatBlockSize) void unique_indices_length_kernel(
 
 // Pipeline (cross-kernel data flow that ties the steps together):
 //
+// Caller contract on indices:
+//   - For intermediate features (t < T - 1) with per_feature_hash > 0:
+//     indices[i] < per_feature_hash[t]. Violations are detected by a
+//     CUDA_KERNEL_ASSERT in linearize_index_flat_kernel. The op cannot
+//     produce correct per-feature output_lengths under intermediate-feature
+//     OOB (counts leak into the next feature group), but the total count and
+//     unique_indices values are still correct.
+//   - For merged/masked features (per_feature_hash == 0, i.e. consecutive
+//     equal entries in hash_size_cumsum): any indices[i] is valid. The
+//     feature shares hash space with another via the hash_size_offsets
+//     indirection.
+//   - For the last feature (t == T - 1): indices may exceed per_feature_hash.
+//     Supported via the hi_pos clamp in unique_indices_length_kernel and the
+//     scatter-form delinearize_unique_index_kernel.
+//
 //   1. linearize_index_flat_kernel writes
 //        linear_indices[i] = hash_size_cumsum[t] + indices[i]
 //      so feature t's linearized values lie in
-//        [hash_size_cumsum[t], hash_size_cumsum[t+1]).
+//        [hash_size_cumsum[t], hash_size_cumsum[t+1])
+//      under the contract above (last-feature OOB extends the upper end).
 //
 //   2. jagged_unique_indices_pipeline replaces at::_unique with an
 //      explicit cub radix sort + RLE + inverse-index scatter, returning
 //      (linear_unique_indices, reverse_index). linear_unique_indices is
 //      sorted ascending. Combined with (1), this means feature t's unique
 //      linearized values occupy a contiguous slice of linear_unique_indices.
-//      The radix sort end_bit is trimmed to bit_width(total_hash_size),
+//      The radix sort end_bit is trimmed to bit_width(max linearized key),
 //      which on production shapes (hash_size ~1M) reduces 8 radix passes
-//      to ~3.
+//      to ~3. Deriving end_bit from the real max (rather than
+//      total_hash_size) keeps last-feature OOB keys fully ordered.
 //
-//   3. delinearize_unique_from_sorted_kernel iterates over num_unique
-//      (~1-2M) instead of total_indices (~24M). Each thread reads one
-//      sorted unique key v and recovers its (feature, per-feature index)
-//      via a binary search on hash_size_cumsum. Writes are sequential
-//      over the num_unique output, eliminating the scatter-via-
-//      reverse_index pattern of the prior kernel.
+//   3. delinearize_unique_index_kernel scatters the original
+//      (pre-linearization) per-feature index values back into
+//      unique_indices via reverse_index. This is index-bound-agnostic:
+//      out-of-bound indices on any feature round-trip exactly, because
+//      the scatter writes the original indices[i] value rather than
+//      recovering it from the linearized key.
 //
 //   4. unique_indices_length_kernel relies on (1)+(2) to compute
 //      num_unique per feature group via two binary searches over
@@ -430,40 +480,48 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> jagged_unique_indices_cuda(
     linear_unique_indices = at::empty({0}, indices.options());
     reverse_index = at::empty({0}, indices.options().dtype(at::kLong));
   } else {
-    // Read total_hash_size to trim radix-sort end_bit. at::_unique
-    // historically performed an implicit D->H sync to allocate its outputs,
-    // so this sync is net-neutral.
-    const int64_t total_hash_size =
-        hash_size_cumsum[hash_size_cumsum.numel() - 1].item().toLong();
+    // Derive the radix-sort end_bit from the actual maximum linearized key,
+    // not from total_hash_size = hash_size_cumsum[T]. cub::DeviceRadixSort
+    // ignores key bits >= end_bit, and this op supports last-feature OOB
+    // indices whose linearized key `hash_size_cumsum[T-1] + idx` can exceed
+    // total_hash_size. Trimming end_bit to bit_width(total_hash_size) would
+    // drop those high bits, leaving linear_unique_indices sorted only by its
+    // low bits -- which silently mis-attributes per-feature output_lengths
+    // (the length kernel's binary searches assume a fully sorted array) and
+    // can over-count num_unique (the full-value RLE dedup sees equal keys
+    // separated by low-bit-colliding distinct keys). Reducing over the real
+    // max keeps the radix-pass win in the common in-bound case (max ~
+    // total_hash_size) while staying correct under OOB. The max-reduction
+    // replaces at::_unique's historical implicit D->H sync, so the single
+    // sync below is net-neutral (plus one cheap reduce kernel over N).
+    const int64_t max_linear_index = linear_indices.max().item().toLong();
     TORCH_CHECK(
-        total_hash_size >= 0,
-        "jagged_unique_indices: hash_size_cumsum[-1] must be non-negative, got ",
-        total_hash_size);
-    // Bit-width of total_hash_size via integer math. __builtin_clzll is
+        max_linear_index >= 0,
+        "jagged_unique_indices: linearized indices must be non-negative, got "
+        "max ",
+        max_linear_index);
+    // Bit-width of max_linear_index via integer math. __builtin_clzll is
     // defined for any positive uint64_t, so this expression is total over
     // the entire [0, INT64_MAX] range and never invokes UB. (Unlike the
     // float-log2 formulation, which produces NaN at INT64_MAX due to
-    // signed overflow in `total_hash_size + 1`.)
+    // signed overflow in `max_linear_index + 1`.)
     AT_DISPATCH_INDEX_TYPES(
         indices.scalar_type(), "jagged_unique_indices_pipeline", ([&] {
           const int max_bits = static_cast<int>(sizeof(index_t) * 8);
-          int total_hash_size_bits;
-          if (total_hash_size <= 0) {
-            total_hash_size_bits = 1;
+          int end_bit;
+          if (max_linear_index <= 0) {
+            end_bit = 1;
           } else {
-            total_hash_size_bits =
-                64 - __builtin_clzll(static_cast<uint64_t>(total_hash_size));
+            end_bit =
+                64 - __builtin_clzll(static_cast<uint64_t>(max_linear_index));
           }
-          total_hash_size_bits = std::min(total_hash_size_bits, max_bits);
+          end_bit = std::min(end_bit, max_bits);
           TORCH_CHECK(
-              total_hash_size_bits >= 1 && total_hash_size_bits <= max_bits,
+              end_bit >= 1 && end_bit <= max_bits,
               "jagged_unique_indices: bad end_bit=",
-              total_hash_size_bits);
+              end_bit);
           jagged_unique_indices_pipeline<index_t>(
-              linear_indices,
-              total_hash_size_bits,
-              linear_unique_indices,
-              reverse_index);
+              linear_indices, end_bit, linear_unique_indices, reverse_index);
         }));
   }
 
@@ -474,15 +532,14 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> jagged_unique_indices_cuda(
     AT_DISPATCH_INDEX_TYPES(
         indices.scalar_type(), "delinearize_unique_index", ([&] {
           FBGEMM_LAUNCH_KERNEL(
-              (delinearize_unique_from_sorted_kernel<index_t>),
+              (delinearize_unique_index_kernel<index_t>),
               static_cast<int32_t>(
-                  (unique_indices.numel() + kFlatBlockSize - 1) /
-                  kFlatBlockSize),
+                  (total_indices + kFlatBlockSize - 1) / kFlatBlockSize),
               kFlatBlockSize,
               0,
               at::cuda::getCurrentCUDAStream(),
-              PTA_B(hash_size_cumsum, index_t, 1, 32),
-              PTA_B(linear_unique_indices, index_t, 1, 32),
+              PTA_B(indices, index_t, 1, 32),
+              PTA_B(reverse_index, int64_t, 1, 32),
               PTA_B(unique_indices, index_t, 1, 32));
         }));
   }

--- a/fbgemm_gpu/test/jagged/failures_dict.json
+++ b/fbgemm_gpu/test/jagged/failures_dict.json
@@ -103,8 +103,40 @@
         "comment": "",
         "status": "xfail"
       },
+      "UniqueIndicesTest.test_aot_dispatch_dynamic__test_jagged_unique_indices_merged_intermediate_oob": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with dynamic dispatch.",
+        "status": "xfail"
+      },
       "UniqueIndicesTest.test_aot_dispatch_dynamic__test_jagged_unique_indices_multi_keys": {
         "comment": "",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_aot_dispatch_dynamic__test_jagged_unique_indices_oob_all_values_last_feature": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with dynamic dispatch.",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_aot_dispatch_dynamic__test_jagged_unique_indices_oob_attributed_to_last_group": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with dynamic dispatch.",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_aot_dispatch_dynamic__test_jagged_unique_indices_oob_duplicates": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with dynamic dispatch.",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_aot_dispatch_dynamic__test_jagged_unique_indices_oob_last_feature": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with dynamic dispatch.",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_aot_dispatch_dynamic__test_jagged_unique_indices_oob_low_bit_collision_last_feature": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with dynamic dispatch.",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_aot_dispatch_dynamic__test_jagged_unique_indices_oob_low_bit_collision_overcount": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with dynamic dispatch.",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_aot_dispatch_dynamic__test_jagged_unique_indices_oob_size_zero_last_feature": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with dynamic dispatch.",
         "status": "xfail"
       },
       "UniqueIndicesTest.test_aot_dispatch_dynamic__test_jagged_unique_indices_zch_huge_hash_size": {
@@ -119,8 +151,40 @@
         "comment": "",
         "status": "xfail"
       },
+      "UniqueIndicesTest.test_faketensor__test_jagged_unique_indices_merged_intermediate_oob": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with fake tensors.",
+        "status": "xfail"
+      },
       "UniqueIndicesTest.test_faketensor__test_jagged_unique_indices_multi_keys": {
         "comment": "",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_faketensor__test_jagged_unique_indices_oob_all_values_last_feature": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with fake tensors.",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_faketensor__test_jagged_unique_indices_oob_attributed_to_last_group": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with fake tensors.",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_faketensor__test_jagged_unique_indices_oob_duplicates": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with fake tensors.",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_faketensor__test_jagged_unique_indices_oob_last_feature": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with fake tensors.",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_faketensor__test_jagged_unique_indices_oob_low_bit_collision_last_feature": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with fake tensors.",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_faketensor__test_jagged_unique_indices_oob_low_bit_collision_overcount": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with fake tensors.",
+        "status": "xfail"
+      },
+      "UniqueIndicesTest.test_faketensor__test_jagged_unique_indices_oob_size_zero_last_feature": {
+        "comment": "Test uses .item()/.tolist() for host-side comparison; incompatible with fake tensors.",
         "status": "xfail"
       },
       "UniqueIndicesTest.test_faketensor__test_jagged_unique_indices_zch_huge_hash_size": {

--- a/fbgemm_gpu/test/jagged/unique_indices_test.py
+++ b/fbgemm_gpu/test/jagged/unique_indices_test.py
@@ -50,6 +50,49 @@ class UniqueIndicesTest(unittest.TestCase):
         # Turn off static assumption for auto-dynamic
         torch._dynamo.config.assume_static_by_default = False
 
+    def _run_op(
+        self,
+        hash_size_cumsum_list: list[int],
+        hash_size_offsets_list: list[int],
+        lengths_list: list[int],
+        indices_list: list[int],
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Build tensors from Python lists and invoke jagged_unique_indices."""
+        device = torch.accelerator.current_accelerator()
+        assert device is not None
+        hash_size_cumsum = torch.as_tensor(
+            hash_size_cumsum_list, dtype=dtype, device=device
+        )
+        hash_size_offsets = torch.as_tensor(
+            hash_size_offsets_list, dtype=dtype, device=device
+        )
+        lengths = torch.as_tensor(lengths_list, dtype=dtype, device=device)
+        indices = torch.as_tensor(indices_list, dtype=dtype, device=device)
+        offsets = torch.zeros(len(lengths_list) + 1, dtype=dtype, device=device)
+        offsets[1:] = torch.cumsum(lengths, dim=0)
+        return torch.ops.fbgemm.jagged_unique_indices(
+            hash_size_cumsum, hash_size_offsets, offsets, indices
+        )
+
+    def _check_sum_and_roundtrip(
+        self,
+        outputs: tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+        indices_list: list[int],
+    ) -> None:
+        """Standard cross-kernel invariants:
+        (a) sum(output_lengths) accounts for every unique key.
+        (b) unique_indices[reverse_index[i]] == indices[i] for every input i.
+        """
+        output_lengths, _, unique_indices, reverse_index = outputs
+        self.assertEqual(int(torch.sum(output_lengths).item()), unique_indices.numel())
+        rev_list = reverse_index.tolist()
+        uniq_list = unique_indices.tolist()
+        self.assertEqual(len(rev_list), len(indices_list))
+        for i, rev in enumerate(rev_list):
+            self.assertTrue(0 <= rev < len(uniq_list))
+            self.assertEqual(uniq_list[rev], indices_list[i])
+
     @unittest.skipIf(*gpu_unavailable)
     @given(
         B=st.integers(min_value=100, max_value=200),
@@ -274,6 +317,323 @@ class UniqueIndicesTest(unittest.TestCase):
         self.assertEqual(reverse_index.numel(), 0)
         self.assertEqual(torch.sum(output_lengths).item(), 0)
         self.assertEqual(torch.sum(output_offsets).item(), 0)
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_jagged_unique_indices_oob_last_feature(self) -> None:
+        """Exercise the op when the last feature has indices exceeding its
+        per-feature hash_size. The linearized form
+        `hash_size_cumsum[T-1] + idx` then exceeds hash_size_cumsum[T], which
+        sorts past the length kernel's upper binary-search boundary.
+        Regressing here causes sum(output_lengths) < unique_indices.numel(),
+        producing an inconsistent KJT that crashes downstream
+        all_to_all_single with "Split sizes doesn't match total dim 0 size".
+
+        Also asserts the inverse-index round-trip
+        unique_indices[reverse_index[i]] == indices[i] for the OOB values,
+        which fails for a gather-based delinearize that derives the
+        per-feature index from the linearized key.
+
+        Sweeps several T values so the carve-out is exercised both at the
+        T=2 boundary and with intermediate in-bound features preceding the
+        OOB last feature, and both index dtypes (int32, int64) so the
+        templated kernel paths are both covered.
+        """
+        for T, dtype in itertools.product((2, 3, 5, 8), (torch.int32, torch.int64)):
+            with self.subTest(T=T, dtype=dtype):
+                self._run_oob_last_feature(T, dtype)
+
+    def _run_oob_last_feature(self, T: int, dtype: torch.dtype) -> None:
+        random.seed(T)
+        np.random.seed(T)
+        B = 64
+        max_length = 5
+        per_feature_hash_size = 100
+        # Last feature's OOB indices land far above
+        # hash_size_cumsum[T]=T*per_feature_hash_size.
+        oob_value_cap = 100_000
+        hash_size_cumsum_list = [t * per_feature_hash_size for t in range(T + 1)]
+        hash_size_offsets_list = list(range(T + 1))
+        lengths_list: list[int] = []
+        indices_list: list[int] = []
+        for t in range(T):
+            value_cap = oob_value_cap if t == T - 1 else per_feature_hash_size
+            for _ in range(B):
+                length = random.randint(0, max_length)
+                lengths_list.append(length)
+                if length > 0:
+                    indices_list.extend(
+                        np.random.randint(0, value_cap, size=length).tolist()
+                    )
+        # Force at least one OOB value on the last feature so the test
+        # exercises the carve-out even if the random draw happened to stay
+        # in range.
+        if lengths_list[-1] == 0:
+            lengths_list[-1] = 1
+            indices_list.append(oob_value_cap - 1)
+        else:
+            indices_list[-1] = oob_value_cap - 1
+
+        outputs = self._run_op(
+            hash_size_cumsum_list,
+            hash_size_offsets_list,
+            lengths_list,
+            indices_list,
+            dtype,
+        )
+        self._check_sum_and_roundtrip(outputs, indices_list)
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_jagged_unique_indices_oob_duplicates(self) -> None:
+        """Identical OOB values on the last feature must collapse to a
+        single unique slot. The scatter form of delinearize has multiple
+        threads write to the same unique_indices[reverse_index[i]];
+        correctness relies on every writer for a given slot writing the
+        same value (true here because the inputs are literal duplicates).
+        """
+        B = 32
+        per_hash = 100
+        oob_value = 99_999
+        hash_size_cumsum_list = [0, per_hash, 2 * per_hash]
+        hash_size_offsets_list = [0, 1, 2]
+        # Feature 0: one distinct in-bound value per batch.
+        # Feature 1: B identical copies of oob_value across batches.
+        lengths_list = [1] * (2 * B)
+        indices_list: list[int] = list(range(B)) + [oob_value] * B
+        outputs = self._run_op(
+            hash_size_cumsum_list,
+            hash_size_offsets_list,
+            lengths_list,
+            indices_list,
+            torch.int64,
+        )
+        self._check_sum_and_roundtrip(outputs, indices_list)
+        _, _, unique_indices, reverse_index = outputs
+        # B distinct in-bound values + 1 OOB unique slot.
+        self.assertEqual(unique_indices.numel(), B + 1)
+        last_feature_revs = reverse_index[B : 2 * B].tolist()
+        self.assertEqual(len(set(last_feature_revs)), 1)
+        self.assertEqual(unique_indices[last_feature_revs[0]].item(), oob_value)
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_jagged_unique_indices_oob_all_values_last_feature(self) -> None:
+        """Every value on the last feature is strictly OOB
+        (idx >= per_feature_hash_size, no in-bound mix). Exercises the
+        boundary where lo_pos lands past any in-bound values for the last
+        group, and the clamp captures the full OOB tail.
+        """
+        random.seed(0)
+        np.random.seed(0)
+        B = 32
+        per_hash = 100
+        hash_size_cumsum_list = [0, per_hash, 2 * per_hash]
+        hash_size_offsets_list = [0, 1, 2]
+        lengths_list: list[int] = []
+        indices_list: list[int] = []
+        for _ in range(B):  # feature 0: in-bound
+            length = random.randint(1, 4)
+            lengths_list.append(length)
+            indices_list.extend(np.random.randint(0, per_hash, size=length).tolist())
+        for _ in range(B):  # feature 1: strictly OOB (>= per_hash)
+            length = random.randint(1, 4)
+            lengths_list.append(length)
+            indices_list.extend(
+                np.random.randint(per_hash, per_hash * 1000, size=length).tolist()
+            )
+        outputs = self._run_op(
+            hash_size_cumsum_list,
+            hash_size_offsets_list,
+            lengths_list,
+            indices_list,
+            torch.int64,
+        )
+        self._check_sum_and_roundtrip(outputs, indices_list)
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_jagged_unique_indices_oob_size_zero_last_feature(self) -> None:
+        """Last feature has per_feature_hash_size == 0 (consecutive equal
+        cumsum entries at the tail); any positive value on it is OOB by
+        construction. The length kernel's `low == high` shortcut must not
+        drop the OOB tail for the last group.
+        """
+        random.seed(0)
+        np.random.seed(0)
+        B = 32
+        per_hash = 100
+        hash_size_cumsum_list = [0, per_hash, per_hash]
+        hash_size_offsets_list = [0, 1, 2]
+        lengths_list: list[int] = []
+        indices_list: list[int] = []
+        for _ in range(B):  # feature 0: in-bound
+            length = random.randint(1, 4)
+            lengths_list.append(length)
+            indices_list.extend(np.random.randint(0, per_hash, size=length).tolist())
+        for _ in range(B):  # feature 1: all values OOB (last feature, size 0)
+            length = random.randint(1, 4)
+            lengths_list.append(length)
+            indices_list.extend(np.random.randint(1, 10_000, size=length).tolist())
+        outputs = self._run_op(
+            hash_size_cumsum_list,
+            hash_size_offsets_list,
+            lengths_list,
+            indices_list,
+            torch.int64,
+        )
+        self._check_sum_and_roundtrip(outputs, indices_list)
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_jagged_unique_indices_oob_attributed_to_last_group(self) -> None:
+        """The OOB tail must be counted into the last feature group's
+        output_lengths slice, not an earlier one. A regression that
+        applied the clamp to non-last groups would still pass the sum
+        invariant but would mis-attribute the tail to the wrong feature.
+        Earlier groups can hold at most `per_feature_hash_size` unique
+        values each; the rest must land in the last group.
+        """
+        random.seed(0)
+        np.random.seed(0)
+        T = 3
+        B = 16
+        per_hash = 100
+        hash_size_cumsum_list = [t * per_hash for t in range(T + 1)]
+        hash_size_offsets_list = list(range(T + 1))
+        lengths_list: list[int] = []
+        indices_list: list[int] = []
+        for t in range(T):
+            cap = 100_000 if t == T - 1 else per_hash
+            for _ in range(B):
+                length = random.randint(1, 4)
+                lengths_list.append(length)
+                indices_list.extend(np.random.randint(0, cap, size=length).tolist())
+        outputs = self._run_op(
+            hash_size_cumsum_list,
+            hash_size_offsets_list,
+            lengths_list,
+            indices_list,
+            torch.int64,
+        )
+        self._check_sum_and_roundtrip(outputs, indices_list)
+        output_lengths = outputs[0]
+        for t in range(T - 1):
+            group_total = int(torch.sum(output_lengths[t * B : (t + 1) * B]).item())
+            self.assertLessEqual(group_total, per_hash)
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_jagged_unique_indices_oob_low_bit_collision_last_feature(
+        self,
+    ) -> None:
+        """A last-feature OOB key whose low bits collide with an in-bound key
+        in an earlier feature must still be ordered by its full value.
+
+        The radix-sort end_bit is derived from the maximum linearized key. If
+        it were instead trimmed to bit_width(total_hash_size), cub would
+        ignore the OOB key's high bits and sort only by the low bits. Here
+        total_hash_size = 200 (bit_width 8, i.e. the low byte). The last
+        feature's hash_offset is 100, so the OOB value 180 linearizes to
+        100 + 180 = 280, and 280 % 256 == 24 -- smaller than the in-bound
+        feature-0 key 50. A low-byte-only sort would place the OOB key
+        *before* the in-bound key, so the length kernel's binary searches
+        mis-attribute the OOB unique to feature 0: output_lengths becomes
+        [2, 0] instead of [1, 1]. sum(output_lengths) == num_unique
+        telescopes either way, so only the exact per-feature counts catch
+        the regression. Swept over both index dtypes.
+        """
+        per_hash = 100  # total_hash_size = 200 -> trimmed end_bit would be 8
+        inbound_feature0 = 50
+        oob_last_feature = 180  # 100 + 180 = 280; 280 % 256 == 24 < 50
+        for dtype in (torch.int32, torch.int64):
+            with self.subTest(dtype=dtype):
+                outputs = self._run_op(
+                    hash_size_cumsum_list=[0, per_hash, 2 * per_hash],
+                    hash_size_offsets_list=[0, 1, 2],
+                    lengths_list=[1, 1],  # one sample per feature
+                    indices_list=[inbound_feature0, oob_last_feature],
+                    dtype=dtype,
+                )
+                self._check_sum_and_roundtrip(
+                    outputs, [inbound_feature0, oob_last_feature]
+                )
+                output_lengths, _, unique_indices, _ = outputs
+                # Exactly one unique per feature, attributed correctly.
+                self.assertEqual(output_lengths.tolist(), [1, 1])
+                self.assertCountEqual(
+                    unique_indices.tolist(),
+                    [inbound_feature0, oob_last_feature],
+                )
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_jagged_unique_indices_oob_low_bit_collision_overcount(self) -> None:
+        """Duplicate OOB keys separated by a low-bit-colliding distinct key
+        must still dedup to a single unique slot.
+
+        The adjacent-diff + RLE dedup compares full key values, so it only
+        collapses duplicates that the radix sort placed adjacently. With
+        total_hash_size = 200 (trimmed end_bit 8), the last feature's keys
+        100 + {180, 436, 180} = {280, 536, 280} all share low byte 24, and a
+        low-byte-only sort preserves their input order [280, 536, 280] -- so
+        the two copies of 280 are split by 536 and counted as two distinct
+        uniques, over-counting num_unique (6 instead of 5). Deriving end_bit
+        from the real max key (536, bit_width 10) sorts them to [280, 280,
+        536] and the dedup collapses correctly.
+        """
+        per_hash = 100  # total_hash_size = 200 -> trimmed end_bit would be 8
+        # Feature 0: three distinct in-bound values (low bytes 10/11/12).
+        # Feature 1 (last): 100 + {180, 436, 180} = {280, 536, 280}, all low
+        # byte 24; 180 appears twice and must collapse to one unique.
+        feature0 = [10, 11, 12]
+        last_feature = [180, 436, 180]
+        outputs = self._run_op(
+            hash_size_cumsum_list=[0, per_hash, 2 * per_hash],
+            hash_size_offsets_list=[0, 1, 2],
+            lengths_list=[1] * 6,  # batch_size 3 per feature
+            indices_list=feature0 + last_feature,
+            dtype=torch.int64,
+        )
+        self._check_sum_and_roundtrip(outputs, feature0 + last_feature)
+        _, _, unique_indices, _ = outputs
+        # True unique set: {10, 11, 12} + {180, 436} = 5 distinct values.
+        self.assertEqual(unique_indices.numel(), 5)
+        self.assertCountEqual(set(unique_indices.tolist()), {10, 11, 12, 180, 436})
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_jagged_unique_indices_merged_intermediate_oob(self) -> None:
+        """Intermediate feature with per_feature_hash == 0 is part of a
+        merged group (consecutive equal entries in hash_size_cumsum). The
+        contract assert exempts these; index values up to the shared
+        group's total hash space are valid. Verify the op handles the
+        merged group end-to-end: round-trip preserves the original
+        per-feature value, and the merged group's total length equals the
+        merged unique count.
+        """
+        random.seed(0)
+        np.random.seed(0)
+        B = 16
+        # Feature 1 merged with feature 2: shared hash space [100, 200).
+        # hash_size_offsets maps groups [0, 1) and [1, 3) -> features {0}
+        # and {1, 2} respectively.
+        hash_size_cumsum_list = [0, 100, 100, 200]
+        hash_size_offsets_list = [0, 1, 1, 3]
+        lengths_list: list[int] = []
+        indices_list: list[int] = []
+        for _ in range(B):  # feature 0: in-bound [0, 100)
+            length = random.randint(1, 4)
+            lengths_list.append(length)
+            indices_list.extend(np.random.randint(0, 100, size=length).tolist())
+        for _ in range(B):  # feature 1: merged intermediate, [0, 100)
+            length = random.randint(1, 4)
+            lengths_list.append(length)
+            indices_list.extend(np.random.randint(0, 100, size=length).tolist())
+        for _ in range(B):  # feature 2: last in merged group, [0, 100)
+            length = random.randint(1, 4)
+            lengths_list.append(length)
+            indices_list.extend(np.random.randint(0, 100, size=length).tolist())
+        outputs = self._run_op(
+            hash_size_cumsum_list,
+            hash_size_offsets_list,
+            lengths_list,
+            indices_list,
+            torch.int64,
+        )
+        self._check_sum_and_roundtrip(outputs, indices_list)
 
     @unittest.skipIf(*gpu_unavailable)
     def test_jagged_unique_indices_zch_huge_hash_size(self) -> None:


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2727

D104827588 (length kernel) and f2e9cba2e279 (delinearize kernel) both introduced an unstated "indices must lie in [0, per_feature_hash)" assumption that the op never enforced before. ZCH callers that pass raw IDs to `jagged_unique_indices` (dedup runs before the hash-to-bucket remap) tripped this on the last feature in prod, producing `sum(output_lengths) < unique_indices.numel()` and crashing downstream `dist.all_to_all_single` with "Split sizes doesn't match total dim 0 size".

Two fixes in `jagged_unique_indices.cu`:

1. `unique_indices_length_kernel`: when the group's `hash_end == hash_size_cumsum.size(0) - 1` (last feature), set `hi_pos = linear_unique_indices.size(0)` instead of doing the upper-bound binary search. The OOB tail of the last feature sorts past `hash_size_cumsum[T]` and the binary search would otherwise stop short of it.

2. Replace `delinearize_unique_from_sorted_kernel` (gather: `unique_indices[i] = v - hash_size_cumsum[t]`) with the original `delinearize_unique_index_kernel` (scatter: `unique_indices[reverse_index[i]] = indices[i]`). The gather form misattributes OOB values whose linearized key exceeds `hash_size_cumsum[T]` to a phantom feature `t = T` and emits `v - hash_size_cumsum[T]` instead of the original index value. The scatter form is index-bound-agnostic by construction. Note `reverse_index` is `int64_t` (from the cub pipeline) rather than templated `index_t` (which was the case under `at::_unique`).

Contract enforcement: added a `CUDA_KERNEL_ASSERT` in `linearize_index_flat_kernel` that fires when an intermediate feature (`t < T - 1`) with `per_feature_hash > 0` has `idx >= per_feature_hash`. Intermediate-feature OOB causes silent per-feature count drift (counts leak from `t` to `t+1` while the total is preserved) — this has been broken since the op was written, but no caller hit it, so the assert surfaces violations rather than silently corrupting downstream embedding lookups. The assert exempts (a) the last feature (legitimately supported) and (b) merged/masked features with `per_feature_hash == 0` (the `hash_size_offsets` indirection pattern used by `multi_keys` and `zch_huge_hash_size`).

The pipeline contract doc comment above `jagged_unique_indices_cuda` is updated to enumerate the three cases.

Reviewed By: q10

Differential Revision: D106305472


