### PR TITLE
Add deterministic GPU coverage for INT-weight nobag aligned-D (D106106843 fast-path trigger)

### DIFF
--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -72,6 +72,9 @@ additional_decorators: dict[str, list[Callable[..., Any]]] = {
     "test_faketensor__test_nbit_forward_gpu_no_cache_fp8_2048": [
         unittest.skip("Operator not implemented for Meta tensors"),
     ],
+    "test_faketensor__test_nbit_forward_gpu_no_cache_nobag_aligned_D": [
+        unittest.skip("Operator not implemented for Meta tensors"),
+    ],
     "test_faketensor__test_nbit_forward_cpu_seq_int8": [
         unittest.skip("Operator not implemented for Meta tensors"),
     ],
@@ -805,6 +808,65 @@ class NBitFowardTest(NBitFowardTestCommon):
             mixed_weights_ty=False,
             indices_dtype=indices_dtype,
             output_dtype=SparseType.FP16,
+        )
+
+    @unittest.skipIf(*gpu_unavailable)
+    @given(
+        weights_ty=st.sampled_from([SparseType.INT2, SparseType.INT4, SparseType.INT8]),
+        D=st.sampled_from([256, 512, 1024]),
+        output_dtype=st.sampled_from([SparseType.FP32, SparseType.FP16]),
+    )
+    @settings(
+        verbosity=VERBOSITY,
+        max_examples=MAX_EXAMPLES,
+        deadline=None,
+        # `optests.generate_opcheck_tests` wraps this method with multiple
+        # opcheck variants (faketensor / schema / autograd / aot_dispatch_*),
+        # which Hypothesis sees as differing executors. Suppress the resulting
+        # health check — see precedent in
+        # `fbgemm_gpu/test/tbe/training/backward_determinism_test.py`.
+        suppress_health_check=[HealthCheck.differing_executors],
+    )
+    def test_nbit_forward_gpu_no_cache_nobag_aligned_D(
+        self,
+        weights_ty: SparseType,
+        D: int,
+        output_dtype: SparseType,
+    ) -> None:
+        # Deterministic coverage for the D106106843 ROCm fast-path trigger:
+        # ``D % (kWarpSize * kOutputsPerThread) == 0`` for INT-weight nobag.
+        #
+        # On wave-64 ROCm with kOutputsPerThread = 32 // bit_width, the
+        # runtime gate fires when D is divisible by 256 (INT8), 512 (INT4),
+        # or 1024 (INT2). The pinned matrix below covers all three INT
+        # primitive types across ``D in {256, 512, 1024}`` for the
+        # float-output store branch.
+        #
+        # On master and on CUDA the fast path is not rendered (the codegen
+        # gate is false), so this test exercises the slow path. After
+        # D106106843 lands, the same divisibility-aligned cases additionally
+        # hit the fast path on ROCm — without changing the assertions.
+        if weights_ty == SparseType.INT2 and output_dtype == SparseType.FP32:
+            self.skipTest("INT2 weight + FP32 output combination is not supported")
+
+        self.execute_nbit_forward_(
+            T=1,
+            D=D,
+            B=4,
+            log_E=2,
+            L=4,
+            weighted=False,
+            mixed=False,
+            pooling_mode=PoolingMode.NONE,
+            weights_ty=weights_ty,
+            use_cache=False,
+            cache_algorithm=CacheAlgorithm.LRU,
+            use_cpu=False,
+            use_array_for_index_remapping=True,
+            do_pruning=False,
+            mixed_weights_ty=False,
+            indices_dtype=torch.int32,
+            output_dtype=output_dtype,
         )
 
     @unittest.skipIf(*gpu_unavailable)


### PR DESCRIPTION
Summary:
Adds `test_nbit_forward_gpu_no_cache_nobag_aligned_D` to `NBitFowardTest` in
`fbcode/deeplearning/fbgemm/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py`,
covering the matrix `D ∈ {256, 512, 1024} × weights_ty ∈ {INT2, INT4, INT8} ×
output_dtype ∈ {FP32, FP16}` with `pooling_mode = PoolingMode.NONE`.

Motivation: D106106843 (TBE inference INT-weight nobag shifted-index store fast
path) is gated at codegen on `INT and is_rocm` and at runtime on
`D % (kWarpSize * kOutputsPerThread) == 0 && D_padding > 0`. Today's only
nobag-capable GPU test, `test_nbit_forward_gpu_no_cache`, draws `D` from
`random.randint(2, 2048)` and `pooling_mode` from a 3-way random choice — so the
joint probability of rolling a fast-path-aligned D and `pooling_mode == NONE` and
the right INT primitive type within the small `MAX_EXAMPLES_LONG_RUNNING` budget
is effectively zero. Result: trunk CI does not exercise the fast path.

This test pins the matrix deterministically so:

- On master and on CUDA, the fast path is not rendered (codegen gate is false) and
  the test exercises the existing slow path. Passes today.
- After D106106843 lands, the divisibility-aligned cases additionally hit the new
  ROCm fast path. The same correctness assertions apply (slow vs fast path are
  designed to be bit-equivalent).

The test is independent of D106106843 and lands cleanly on master.

Coverage:

- `D ∈ {256, 512, 1024}` covers the wave-64 ROCm runtime gate for INT8
  (`D mod 256 == 0`), INT4 (`D mod 512 == 0`), and INT2 (`D mod 1024 == 0`).
- `(INT2, FP32)` is skipped to match the existing combinator skip in
  `test_nbit_forward_gpu_no_cache`.
- The float-output store branch of the fast path is exercised; the uint8_t
  (INT8 output) branch is left for a follow-up since the existing
  `execute_nbit_forward_` driver does `fc2.float()` which is not a correct
  dequantization for INT8 output.

Reuses `NBitFowardTestCommon.execute_nbit_forward_` verbatim — its existing
`b_indices` + `fake_quantize_embs` reference flow already handles
`pooling_mode == PoolingMode.NONE` (picks `nn.Embedding` over `nn.EmbeddingBag`
and produces the nobag `(B*L, D)` reference layout).

Reviewed By: cthi

Differential Revision: D106732758


