### PR TITLE
Add DRAM_SSD backend type to BackendType enum

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/ssd_config.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/ssd_config.py
@@ -314,6 +314,7 @@ class BackendType(enum.IntEnum):
     SSD = 0
     DRAM = 1
     PS = 2
+    DRAM_SSD = 3
 
     @classmethod
     def from_str(cls, key: str) -> "BackendType":
@@ -321,6 +322,7 @@ class BackendType(enum.IntEnum):
             "ssd": BackendType.SSD,
             "dram": BackendType.DRAM,
             "ps": BackendType.PS,
+            "dram_ssd": BackendType.DRAM_SSD,
         }
         if key in lookup:
             return lookup[key]

--- a/fbgemm_gpu/test/tbe/ssd/ssd_config_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_config_test.py
@@ -123,6 +123,17 @@ class BackendTypeFromStrTest(unittest.TestCase):
 
         self.assertEqual(BackendType.from_str("dram"), BackendType.DRAM)
 
+    def test_ps(self) -> None:
+        from fbgemm_gpu.tbe.ssd import BackendType
+
+        self.assertEqual(BackendType.from_str("ps"), BackendType.PS)
+
+    def test_dram_ssd(self) -> None:
+        from fbgemm_gpu.tbe.ssd import BackendType
+
+        self.assertEqual(BackendType.from_str("dram_ssd"), BackendType.DRAM_SSD)
+        self.assertEqual(BackendType.DRAM_SSD.value, 3)
+
     def test_invalid_raises(self) -> None:
         from fbgemm_gpu.tbe.ssd import BackendType
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2730

Add `DRAM_SSD` as a new backend type to the fbgemm `BackendType` enum in
`fbgemm_gpu/tbe/ssd/ssd_config.py`. `DRAM_SSD` represents a composite DRAM + SSD
KV backend for KVZCH virtual tables and is required by the
`DRAM_SSD_VIRTUAL_TABLE` compute kernel, which references `BackendType.DRAM_SSD`.

- Add `DRAM_SSD = 3` to `BackendType`.
- Add `"dram_ssd"` mapping to `BackendType.from_str`.

Differential Revision: D106733255


