### PR TITLE
Add device-side bounds checks to `permute_multi_embs_kernel`

### DIFF
--- a/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
+++ b/fbgemm_gpu/src/permute_multi_embedding_ops/permute_multi_embedding_ops.cu
@@ -67,6 +67,12 @@ __global__ void permute_multi_embs_kernel(
   length = pp[PermuteParam::length];
   next = pp[PermuteParam::next];
 
+  if (in_tensor < 0 || in_tensor >= static_cast<int32_t>(in_lengths.size(0)) ||
+      out_tensor < 0 ||
+      out_tensor >= static_cast<int32_t>(out_lengths.size(0))) {
+    return;
+  }
+
   if (worker_id >= length) {
     return;
   }
@@ -108,12 +114,19 @@ __global__ void permute_multi_embs_kernel(
   }
 
   // for reverse_permute (backward) with next
-  while (reverse_permute && next > 0 && next < permute_size) {
+  int32_t loop_guard = permute_size;
+  while (reverse_permute && next > 0 && next < permute_size &&
+         --loop_guard > 0) {
     int32_t* __restrict__ pp = permutes[next].data();
     in_tensor = pp[PermuteParam::out_tensor];
     in_offset = pp[PermuteParam::out_offset];
     length = pp[PermuteParam::length];
     next = -pp[PermuteParam::next];
+
+    if (in_tensor < 0 ||
+        in_tensor >= static_cast<int32_t>(in_lengths.size(0))) {
+      return;
+    }
 
     const auto in_length = in_lengths[in_tensor];
     const scalar_t* input_ptr =


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2732

Add device-side safety checks to `permute_multi_embs_kernel` to prevent CUDA illegal memory access crashes when permute arguments are stale or corrupt:

1. **Forward-path bounds check**: After parsing the permutes table, validate that `in_tensor` and `out_tensor` indices are within the bounds of `in_lengths` and `out_lengths` before dereferencing device pointers. Threads with invalid indices return early instead of crashing.

2. **Reverse-permute loop guard**: Add an iteration counter capped at `permute_size` to prevent infinite loops when the permutes linked-list `next` chain is corrupt. Also add an `in_tensor` bounds check inside the loop body to bail on corrupt data rather than performing OOB device memory access.

Differential Revision: D107013820


