### PR TITLE
Migrate fb-exported to meta-exported where possible (best effort)

### DIFF
--- a/.github/metrics/datatypes.py
+++ b/.github/metrics/datatypes.py
@@ -79,7 +79,7 @@ class GHPullRequest:
         """
         Remove the labels that are common to the PR.
         """
-        misc = ["fb-exported", "cla signed", "ci-no-td", "Merged"]
+        misc = ["meta-exported", "fb-exported", "cla signed", "ci-no-td", "Merged"]
         new_labels = [x for x in self.labels if x not in misc]
         return dataclasses.replace(self, labels=new_labels)
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2735

I'm about to remove fb-exported, so let's do this first.

Reviewed By: ndmitchell

Differential Revision: D107150080


