### PR TITLE
Fix SVE no_bag uint8 overflow (#5810)

### DIFF
--- a/src/EmbeddingSpMDMSve.h
+++ b/src/EmbeddingSpMDMSve.h
@@ -393,7 +393,9 @@ bool EmbeddingSpMDM8Bit_Sve(
 
       const uint8_t* input_row_base = input + input_stride * idx;
       if constexpr (isOutput8bit) {
-        memcpy(out, input_row_base, sizeof(uint8_t) * input_stride);
+        // In edge cases input_stride can be larger than output_stride
+        const int64_t copy_width = std::min(output_stride, input_stride);
+        memcpy(out, input_row_base, sizeof(uint8_t) * copy_width);
       } else {
         svfloat32_t scale;
         svfloat32_t bias;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2736


**Real bug fix:** `EmbeddingSpMDM8Bit_Sve` (no_bag, uint8 output) called `memcpy(out, input_row_base, input_stride)` per output row but only advanced `out` by `output_stride`. When `input_stride > output_stride` (which the `noBagUint8Test` exercises by setting `input_stride = 2 * embedding_dim + 3`) each iteration over-writes into the next row's slot and the last iteration overruns the buffer entirely. The autovec and reference paths already use `min(output_stride, input_stride)` for exactly this reason — the SVE path was missed. Switch the SVE path to the same `copy_width` to match.

Reviewed By: mcfi

Differential Revision: D107156596


