### PR TITLE
Drop cu129 from the PyPI install test matrix

### DIFF
--- a/.github/scripts/generate_ci_matrix.py
+++ b/.github/scripts/generate_ci_matrix.py
@@ -296,6 +296,13 @@ class BuildConfigScheme:
             return ["gcc", "clang"]
 
     def cuda_versions(self) -> List[str]:
+        versions = self._cuda_versions()
+        if self.jobtype == JOBTYPE_INSTALL:
+            # cu129 is not exercised in the PyPI install tests
+            versions = [v for v in versions if v != "12.9.1"]
+        return versions
+
+    def _cuda_versions(self) -> List[str]:
         if GitRepo.ref() == REFS_MAIN and GitRepo.event_name() == EVENT_NAME_PUSH:
             return ["12.8.1"]
         if self.repo_owner != REPO_OWNER_PYTORCH:


### PR DESCRIPTION
Summary:
Remove CUDA 12.9.1 (cu129) from the CUDA matrix for the PyPI install
test jobs (`fbgemm_gpu_pip.yml`, jobtype=install). Build and test
matrices are unchanged — cu129 still builds and is tested per-PR.

Scoped in `generate_ci_matrix.py` by filtering `12.9.1` out of
`cuda_versions()` only when `jobtype == install`.

Differential Revision: D107178775


