### PR TITLE
Migrate embedding_bounds_check_v2 to cap_grid_dim_x

### DIFF
--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_v2.cu
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_v2.cu
@@ -236,9 +236,11 @@ void _bounds_check_indices_cuda_v2(
   }
 
   constexpr size_t kNumThreads = 1024;
-  auto grid_dim =
-      min(div_round_up(total_B, kNumThreads / fbgemm_gpu::kWarpSize),
-          get_max_thread_blocks_());
+  auto grid_dim = fbgemm_gpu::utils::cuda::cap_grid_dim_x(
+      cuda_calc_xblock_count(total_B, kNumThreads / fbgemm_gpu::kWarpSize),
+      kNumThreads,
+      at::cuda::getCurrentCUDAStream(),
+      fbgemm_gpu::utils::cuda::BlockCapPolicy::Always);
   if (prefetch_pipeline) {
     // Limit the grid size to PREFETCH_KERNEL_MAX_BLOCKS if running this kernel
     // on the prefetch stream

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/embedding_bounds_check_common.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/embedding_bounds_check_common.cuh
@@ -7,6 +7,7 @@
  */
 
 #include "fbgemm_gpu/embedding_backward_template_helpers.cuh"
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
 #include "fbgemm_gpu/utils/kernel_launcher.cuh"
 #include "fbgemm_gpu/utils/tensor_accessor_builder.h"
 


### PR DESCRIPTION
Summary:
Migrates the host-side cap site in
`codegen/utils/embedding_bounds_check_v2.cu` from the legacy
`std::min(blocks_uncapped, get_max_thread_blocks_(...))` form to the
new threshold-guarded helper
`fbgemm_gpu::utils::cuda::determine_grid_blocks_from_blocks(...,
BlockCapPolicy::Always)`.

Behavior-preserving: the policy `Always` matches the prior
unconditional ROCm cap exactly. No change in dispatched grid count
on either NVIDIA or AMD MI300 across all input regimes.

Reviewed By: spcyppt

Differential Revision: D106451648


