### PR TITLE
Fix uvm_to_cpu/uvm_to_device/uvm_get_guard_index for host-mapped tensors (#5816)

### DIFF
--- a/fbgemm_gpu/src/memory_utils/memory_utils.cu
+++ b/fbgemm_gpu/src/memory_utils/memory_utils.cu
@@ -79,6 +79,74 @@ struct CUDAManagedIndirectContext {
   }
 };
 
+// Same as CUDAManagedIndirectContext but for host-mapped (cudaHostRegister)
+// tensors. Prevents the underlying CUDAHostMappedContext from being freed
+// while a CPU-view or device-view tensor is still alive.
+struct CUDAHostMappedIndirectContext {
+  Storage storage_;
+
+  CUDAHostMappedIndirectContext(Storage storage)
+      : storage_(std::move(storage)) {};
+
+  static void release(void* ptr) {
+    delete static_cast<CUDAHostMappedIndirectContext*>(ptr);
+  }
+};
+
+// Build a new tensor view over a host-mapped storage with the requested
+// device tag, keeping `host_mapped_storage` (the Storage owning the
+// CUDAHostMappedContext) alive via CUDAHostMappedIndirectContext. Used by both
+// uvm_to_cpu (target_device=CPU, ptr=host pointer) and uvm_to_device_d
+// (target_device=CUDA, ptr=device pointer from cudaHostGetDevicePointer).
+// Passing the unwrapped direct-host-mapped Storage on chained calls keeps the
+// indirect chain flat instead of nesting one indirect inside another.
+Tensor make_host_mapped_view(
+    const Tensor& t,
+    Storage host_mapped_storage,
+    void* ptr,
+    const at::Device& target_device) {
+  auto storage = Storage(
+      Storage::use_byte_size_t(),
+      t.storage().nbytes(),
+      at::DataPtr(
+          ptr,
+          new CUDAHostMappedIndirectContext(std::move(host_mapped_storage)),
+          &CUDAHostMappedIndirectContext::release,
+          target_device),
+      nullptr, /* allocator */
+      /*resizable=*/false);
+  return at::empty({0}, t.options().device(target_device))
+      .set_(std::move(storage), t.storage_offset(), t.sizes(), t.strides());
+}
+
+// Resolve a tensor whose storage is either a direct CUDAHostMappedContext or
+// a CUDAHostMappedIndirectContext (the result of a previous uvm_to_cpu /
+// uvm_to_device_d call) back to the underlying host-mapped Storage and its
+// CUDAHostMappedContext. Returns {Storage(), nullptr} if `t` is not a
+// host-mapped tensor.
+std::pair<Storage, CUDAHostMappedContext*> resolve_host_mapped(
+    const Tensor& t) {
+  const auto deleter = t.storage().data_ptr().get_deleter();
+  if (deleter == &CUDAHostMappedContext::release) {
+    auto* hcontext = t.storage().data_ptr().cast_context<CUDAHostMappedContext>(
+        &CUDAHostMappedContext::release);
+    TORCH_CHECK(hcontext != nullptr);
+    return {t.storage(), hcontext};
+  }
+  if (deleter == &CUDAHostMappedIndirectContext::release) {
+    auto* hictx =
+        t.storage().data_ptr().cast_context<CUDAHostMappedIndirectContext>(
+            &CUDAHostMappedIndirectContext::release);
+    TORCH_CHECK(hictx != nullptr);
+    auto* hcontext =
+        hictx->storage_.data_ptr().cast_context<CUDAHostMappedContext>(
+            &CUDAHostMappedContext::release);
+    TORCH_CHECK(hcontext != nullptr);
+    return {hictx->storage_, hcontext};
+  }
+  return {Storage(), nullptr};
+}
+
 // Get the default strides from the input Tensor dimensions
 std::vector<int64_t> defaultStrides(IntArrayRef sizes) {
   std::vector<int64_t> strides(sizes.size());
@@ -326,7 +394,18 @@ Tensor new_unified_tensor(
 bool uvm_storage_cuda(const Tensor& t) {
   auto deleter = t.storage().data_ptr().get_deleter();
   return deleter == &CUDAManagedIndirectContext::release ||
-      deleter == &CUDAHostMappedContext::release;
+      deleter == &CUDAHostMappedContext::release ||
+      deleter == &CUDAHostMappedIndirectContext::release;
+}
+
+// True for tensors backed by malloc + cudaHostRegister (i.e. allocated via
+// new_host_mapped_tensor or new_unified_tensor(is_host_mapped=True)).
+// cudaMemAdvise / cudaMemPrefetchAsync only support cudaMallocManaged memory;
+// invoking them on host-mapped pointers returns cudaErrorInvalidValue.
+bool is_host_mapped_uvm(const Tensor& t) {
+  const auto deleter = t.storage().data_ptr().get_deleter();
+  return deleter == &CUDAHostMappedContext::release ||
+      deleter == &CUDAHostMappedIndirectContext::release;
 }
 
 bool is_uvm_tensor_cuda(const Tensor& t) {
@@ -338,11 +417,21 @@ bool is_uvm_tensor_cuda(const Tensor& t) {
 
 Tensor uvm_to_cpu_cuda(const Tensor& t) {
   TORCH_CHECK(is_uvm_tensor_cuda(t));
-  // Don't copy the storage - just keep a reference to the original storage
+
+  if (auto [host_mapped_storage, hcontext] = resolve_host_mapped(t);
+      hcontext != nullptr) {
+    return make_host_mapped_view(
+        t,
+        std::move(host_mapped_storage),
+        hcontext->ptr_,
+        {at::DeviceType::CPU});
+  }
+
+  // Managed memory path (original)
   auto* tcontext =
       t.storage().data_ptr().cast_context<CUDAManagedIndirectContext>(
           &CUDAManagedIndirectContext::release);
-  TORCH_CHECK(tcontext != nullptr)
+  TORCH_CHECK(tcontext != nullptr);
   auto* ocontext =
       tcontext->storage_.data_ptr().cast_context<CUDAManagedContext>(
           &CUDAManagedContext::release);
@@ -367,12 +456,23 @@ Tensor uvm_to_device(const Tensor& self, const Tensor& prototype) {
 
 Tensor uvm_to_device_d(const Tensor& t, const at::Device& device) {
   TORCH_CHECK(is_uvm_tensor_cuda(t));
-  // Don't copy the storage - just keep a reference to the original storage
+
+  if (auto [host_mapped_storage, hcontext] = resolve_host_mapped(t);
+      hcontext != nullptr) {
+    // Re-derive the device pointer from the host pointer rather than reusing
+    // t.storage().data_ptr().get(): for a tensor produced by a previous
+    // uvm_to_cpu call, that pointer is the *host* pointer, not the device one.
+    void* dev_ptr;
+    AT_CUDA_CHECK(cudaHostGetDevicePointer(&dev_ptr, hcontext->ptr_, 0));
+    return make_host_mapped_view(
+        t, std::move(host_mapped_storage), dev_ptr, device);
+  }
+
+  // Managed memory path (original)
   auto* tcontext =
       t.storage().data_ptr().cast_context<CUDAManagedIndirectContext>(
           &CUDAManagedIndirectContext::release);
-  TORCH_CHECK(tcontext != nullptr)
-
+  TORCH_CHECK(tcontext != nullptr);
   auto* ocontext =
       tcontext->storage_.data_ptr().cast_context<CUDAManagedContext>(
           &CUDAManagedContext::release);
@@ -395,14 +495,18 @@ int64_t uvm_get_guard_index(const Tensor& t) {
   TORCH_CHECK(uvm_storage_cuda(t));
   int cuda_device_index;
   if (t.is_cpu()) {
+    // Host-mapped CPU views never reach this function: both
+    // uvm_cuda_mem_advise and uvm_cuda_mem_prefetch_async early-return on
+    // is_host_mapped_uvm(t) above. The only CPU-tensor path that reaches
+    // uvm_get_guard_index is the managed-memory CPU view.
     auto* tcontext =
         t.storage().data_ptr().cast_context<CUDAManagedIndirectContext>(
             &CUDAManagedIndirectContext::release);
-    TORCH_CHECK(tcontext != nullptr)
+    TORCH_CHECK(tcontext != nullptr);
     auto* ocontext =
         tcontext->storage_.data_ptr().cast_context<CUDAManagedContext>(
             &CUDAManagedContext::release);
-    TORCH_CHECK(ocontext != nullptr)
+    TORCH_CHECK(ocontext != nullptr);
     cuda_device_index = static_cast<int64_t>(ocontext->cuda_device_);
   } else {
     TORCH_CHECK(t.is_cuda());
@@ -413,6 +517,13 @@ int64_t uvm_get_guard_index(const Tensor& t) {
 } // namespace
 
 void uvm_cuda_mem_advise(const Tensor& t, int64_t cuda_memory_advise) {
+  // cudaMemAdvise only applies to cudaMallocManaged memory. Host-mapped UVM
+  // tensors (malloc + cudaHostRegister) are statically PCIe-mapped, with no
+  // migration to advise on; the CUDA API returns cudaErrorInvalidValue. Treat
+  // this as a no-op so callers don't need to special-case the allocator.
+  if (is_host_mapped_uvm(t)) {
+    return;
+  }
   at::cuda::OptionalCUDAGuard device_guard;
   int64_t cuda_device_index = uvm_get_guard_index(t);
   int hint_device;
@@ -435,7 +546,12 @@ void uvm_cuda_mem_advise(const Tensor& t, int64_t cuda_memory_advise) {
       size_bytes,
       static_cast<enum cudaMemoryAdvise>(cuda_memory_advise),
 #if CUDART_VERSION >= 13000 || ROCM_VERSION >= 70100
-      new_mem_location_from_device(hint_device)
+      // Starting with CUDA 13, the deviceId arg (int) is replaced with a
+      // cudaMemLocation (struct). CPU advice targets must use a host location;
+      // wrapping cudaCpuDeviceId in a device-type location is invalid and the
+      // API returns cudaErrorInvalidValue.
+      t.is_cpu() ? new_mem_location_cpu()
+                 : new_mem_location_from_device(hint_device)
 #else
       hint_device
 #endif
@@ -446,6 +562,11 @@ void uvm_cuda_mem_advise(const Tensor& t, int64_t cuda_memory_advise) {
 void uvm_cuda_mem_prefetch_async(
     const Tensor& t,
     std::optional<Tensor> device_t) {
+  // cudaMemPrefetchAsync only applies to cudaMallocManaged memory; host-mapped
+  // tensors have no migration to prefetch. See uvm_cuda_mem_advise note above.
+  if (is_host_mapped_uvm(t)) {
+    return;
+  }
   // Call cudaMemPrefetchAsync on Tensor
   at::cuda::OptionalCUDAGuard device_guard;
   TORCH_CHECK(uvm_storage_cuda(t));

--- a/fbgemm_gpu/test/tbe/cache/host_mapped_test.py
+++ b/fbgemm_gpu/test/tbe/cache/host_mapped_test.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+# pyre-ignore-all-errors[56]
+
+"""
+Regression tests for `uvm_to_cpu`, `uvm_to_device`, and `uvm_get_guard_index`
+on *host-mapped* UVM tensors (created via `new_host_mapped_tensor` or
+`new_unified_tensor(..., is_host_mapped=True)`).
+
+These exercise the `CUDAHostMappedContext` branch added to memory_utils.cu.
+Before that fix, these ops unconditionally cast the storage context to
+`CUDAManagedIndirectContext`, which returns nullptr for host-mapped tensors
+and triggers `TORCH_CHECK(tcontext != nullptr)` — surfacing as
+"Expected tcontext != nullptr" during DCP checkpoint loading.
+
+The existing `copy_test.py` only covers the `CUDAManagedIndirectContext`
+path (`new_managed_tensor` / `new_vanilla_managed_tensor` /
+`new_unified_tensor(is_host_mapped=False)`); this file fills the host-mapped
+gap and also regresses the managed path.
+"""
+
+import unittest
+
+import fbgemm_gpu
+import hypothesis.strategies as st
+import torch
+from hypothesis import given, settings, Verbosity
+
+# pyre-fixme[16]: Module `fbgemm_gpu` has no attribute `open_source`.
+open_source: bool = getattr(fbgemm_gpu, "open_source", False)
+
+if open_source:
+    # pyre-ignore[21]
+    from test_utils import gpu_available, gpu_unavailable
+else:
+    from fbgemm_gpu.test.test_utils import gpu_available, gpu_unavailable
+
+if gpu_available:
+    import fbgemm_gpu.tbe.cache.uvm  # noqa: F401
+
+
+MAX_EXAMPLES = 20
+
+
+def _make_host_mapped(sizes: list[int]) -> torch.Tensor:
+    """Allocate a host-mapped UVM tensor on cuda:0."""
+    return torch.ops.fbgemm.new_host_mapped_tensor(
+        torch.empty(0, device="cuda:0", dtype=torch.float),
+        sizes,
+    )
+
+
+def _make_unified_host_mapped(sizes: list[int]) -> torch.Tensor:
+    """Allocate a host-mapped unified tensor on cuda:0."""
+    return torch.ops.fbgemm.new_unified_tensor(
+        torch.empty(0, device="cuda:0", dtype=torch.float),
+        sizes,
+        True,  # is_host_mapped
+    )
+
+
+def _make_managed(sizes: list[int]) -> torch.Tensor:
+    """Allocate a (managed) UVM tensor on cuda:0."""
+    return torch.ops.fbgemm.new_managed_tensor(
+        torch.empty(0, device="cuda:0", dtype=torch.float),
+        sizes,
+    )
+
+
+class HostMappedUvmOpsTest(unittest.TestCase):
+    """Tests for uvm_to_cpu / uvm_to_device / uvm_get_guard_index on
+    host-mapped tensors, plus regression coverage of the managed path."""
+
+    # ---------- uvm_to_cpu ----------
+
+    @unittest.skipIf(*gpu_unavailable)
+    @given(
+        sizes=st.lists(st.integers(min_value=1, max_value=8), min_size=1, max_size=3),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    def test_uvm_to_cpu_host_mapped(self, sizes: list[int]) -> None:
+        uvm_t = _make_host_mapped(sizes)
+        self.assertTrue(torch.ops.fbgemm.is_uvm_tensor(uvm_t))
+        self.assertTrue(torch.ops.fbgemm.uvm_storage(uvm_t))
+
+        # The bug pre-fix raised "Expected tcontext != nullptr" here.
+        cpu_t = torch.ops.fbgemm.uvm_to_cpu(uvm_t)
+
+        self.assertEqual(cpu_t.device.type, "cpu")
+        self.assertEqual(list(cpu_t.shape), sizes)
+        self.assertFalse(torch.ops.fbgemm.is_uvm_tensor(cpu_t))
+        # cpu_t should still report uvm_storage=True since it shares storage.
+        self.assertTrue(torch.ops.fbgemm.uvm_storage(cpu_t))
+
+        # Mutate via the CPU view; the change must be visible on the GPU view,
+        # confirming shared storage (no deep copy).
+        cpu_t.fill_(7.0)
+        torch.cuda.synchronize()
+        self.assertTrue(torch.all(uvm_t.cpu() == 7.0).item())
+
+        # CPU view must outlive the original UVM tensor (storage refcount).
+        del uvm_t
+        cpu_t.mul_(2)  # would segfault if storage was freed
+        self.assertTrue(torch.all(cpu_t == 14.0).item())
+
+    @unittest.skipIf(*gpu_unavailable)
+    @given(
+        sizes=st.lists(st.integers(min_value=1, max_value=8), min_size=1, max_size=3),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=MAX_EXAMPLES, deadline=None)
+    def test_uvm_to_cpu_unified_host_mapped(self, sizes: list[int]) -> None:
+        uvm_t = _make_unified_host_mapped(sizes)
+        self.assertTrue(torch.ops.fbgemm.is_uvm_tensor(uvm_t))
+        cpu_t = torch.ops.fbgemm.uvm_to_cpu(uvm_t)
+        self.assertEqual(cpu_t.device.type, "cpu")
+        self.assertEqual(list(cpu_t.shape), sizes)
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_uvm_to_cpu_managed_regression(self) -> None:
+        """Regression: ensure the managed path still works unchanged."""
+        uvm_t = _make_managed([4, 8])
+        cpu_t = torch.ops.fbgemm.uvm_to_cpu(uvm_t)
+        self.assertEqual(cpu_t.device.type, "cpu")
+        self.assertEqual(list(cpu_t.shape), [4, 8])
+        self.assertFalse(torch.ops.fbgemm.is_uvm_tensor(cpu_t))
+        self.assertTrue(torch.ops.fbgemm.uvm_storage(cpu_t))
+
+        cpu_t.fill_(3.0)
+        torch.cuda.synchronize()
+        self.assertTrue(torch.all(uvm_t.cpu() == 3.0).item())
+
+    # ---------- uvm_to_device ----------
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_uvm_to_device_host_mapped_same_device(self) -> None:
+        """Re-wrap a host-mapped tensor for the same CUDA device."""
+        uvm_t = _make_host_mapped([4, 4])
+        target_device = torch.device("cuda:0")
+        rewrapped = torch.ops.fbgemm.uvm_to_device_d(uvm_t, target_device)
+        self.assertEqual(rewrapped.device, target_device)
+        self.assertEqual(list(rewrapped.shape), [4, 4])
+        # Should still be considered a UVM tensor.
+        self.assertTrue(torch.ops.fbgemm.is_uvm_tensor(rewrapped))
+        self.assertTrue(torch.ops.fbgemm.uvm_storage(rewrapped))
+
+        # Shared storage: mutations propagate.
+        rewrapped.fill_(5.0)
+        torch.cuda.synchronize()
+        self.assertTrue(torch.all(uvm_t.cpu() == 5.0).item())
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        "Skip unless two CUDA devices are detected",
+    )
+    def test_uvm_to_device_host_mapped_cross_device(self) -> None:
+        """Re-wrap a host-mapped tensor for a *different* CUDA device."""
+        uvm_t = _make_host_mapped([8, 8])
+        prototype = torch.empty(0, device="cuda:1")
+        second_t = torch.ops.fbgemm.uvm_to_device(uvm_t, prototype)
+        self.assertEqual(second_t.device, prototype.device)
+        self.assertTrue(torch.ops.fbgemm.is_uvm_tensor(second_t))
+        self.assertTrue(torch.ops.fbgemm.uvm_storage(second_t))
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_uvm_to_device_managed_regression(self) -> None:
+        uvm_t = _make_managed([4, 4])
+        target_device = torch.device("cuda:0")
+        rewrapped = torch.ops.fbgemm.uvm_to_device_d(uvm_t, target_device)
+        self.assertEqual(rewrapped.device, target_device)
+        self.assertTrue(torch.ops.fbgemm.is_uvm_tensor(rewrapped))
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_uvm_to_device_host_mapped_chained(self) -> None:
+        """Chained call: the result of uvm_to_device_d is itself a uvm tensor
+        (deleter = CUDAHostMappedIndirectContext::release). A second
+        uvm_to_device_d must recognize that and not fall through to the
+        managed-memory path, where cast_context<CUDAManagedIndirectContext>
+        would return nullptr and trigger TORCH_CHECK."""
+        uvm_t = _make_host_mapped([8, 8])
+        target_device = torch.device("cuda:0")
+        first = torch.ops.fbgemm.uvm_to_device_d(uvm_t, target_device)
+        self.assertTrue(torch.ops.fbgemm.is_uvm_tensor(first))
+        # Must not raise.
+        second = torch.ops.fbgemm.uvm_to_device_d(first, target_device)
+        self.assertEqual(second.device, target_device)
+        self.assertTrue(torch.ops.fbgemm.is_uvm_tensor(second))
+
+        # Storage is still shared end-to-end.
+        second.fill_(9.0)
+        torch.cuda.synchronize()
+        self.assertTrue(torch.all(uvm_t.cpu() == 9.0).item())
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_uvm_to_cpu_after_uvm_to_device_host_mapped(self) -> None:
+        """uvm_to_cpu of an already-rewrapped (indirect-context) host-mapped
+        CUDA tensor must take the host-mapped branch, not fall through."""
+        uvm_t = _make_host_mapped([8, 8])
+        rewrapped = torch.ops.fbgemm.uvm_to_device_d(uvm_t, torch.device("cuda:0"))
+        cpu_t = torch.ops.fbgemm.uvm_to_cpu(rewrapped)
+        self.assertEqual(cpu_t.device.type, "cpu")
+        cpu_t.fill_(2.0)
+        torch.cuda.synchronize()
+        self.assertTrue(torch.all(uvm_t.cpu() == 2.0).item())
+
+    # ---------- uvm_get_guard_index (exercised via cuda_mem_advise) ----------
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_uvm_get_guard_index_host_mapped_cuda_view(self) -> None:
+        """CUDA-side path uses t.get_device(); host-mapped tensor's device
+        index should resolve correctly."""
+        uvm_t = _make_host_mapped([16, 16])
+        # Direct call on the cuda tensor goes through the t.is_cuda() branch,
+        # which is unchanged but still must not regress.
+        torch.ops.fbgemm.cuda_mem_advise(uvm_t, 5)
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_uvm_get_guard_index_managed_regression(self) -> None:
+        uvm_t = _make_managed([16, 16])
+        cpu_view = torch.ops.fbgemm.uvm_to_cpu(uvm_t)
+        torch.ops.fbgemm.cuda_mem_advise(cpu_view, 5)
+        torch.ops.fbgemm.cuda_mem_advise(uvm_t, 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2742

Three functions in fbgemm_gpu's memory_utils.cu unconditionally cast the storage context to `CUDAManagedIndirectContext`, which returns nullptr for tensors created via `new_host_mapped_tensor` / `new_unified_tensor(is_host_mapped=True)`. The nullptr triggers `TORCH_CHECK(tcontext != nullptr)` with the error message "Expected tcontext != nullptr", surfacing during DCP/Pyper checkpoint loading of TBE shards whenever the destination tensor is host-mapped.

Inference TBE already enables `uvm_host_mapped=True` (see `torchrec/distributed/quant_embedding_kernel.py:350,594`, originally landed in D42272528 for a NUMA OOM fix), so this crash is reachable in production today on any path that calls `fbgemm.uvm_to_cpu` / `uvm_to_device` / `cuda_mem_advise` on a host-mapped tensor (e.g. `aiplatform/modelstore/checkpointing/pyper/tensor_utils.py:74`).

The fix mirrors the existing managed-tensor pattern: a new `CUDAHostMappedIndirectContext` struct holds a refcount on the original `Storage`, and each of the three functions gains a `deleter == &CUDAHostMappedContext::release` branch that constructs the appropriate CPU/device view backed by the host-mapped pointer.

The original `CUDAManagedIndirectContext` code path is byte-for-byte unchanged (except a missing semicolon on one `TORCH_CHECK` that the compiler had been absorbing). All existing managed-tensor callers continue to work.

Motivating use case: OneFlow preranker publish jobs intermittently timeout (~6% failure rate) due to `torch.zeros(out=72GB_UVM_tensor)` triggering THP/UVM compact_stalls on fragmented hosts. A/B results showing the host-mapped fix eliminates the variance (max 85s vs 1330s baseline, 0 torch.zeros compact_stall across 20 nodes): P2349246996. Full root cause / fix design: P2343573171.

Reviewed By: q10

Differential Revision: D106211462


