### PR TITLE
Fix V2 bounds check printf: add __syncthreads() after tree reduction

### DIFF
--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_v2.cu
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_v2.cu
@@ -173,6 +173,7 @@ __global__ __launch_bounds__(kMaxThreads) void bounds_check_indices_kernel_v2(
       gpuAtomicAdd(&warning[0], block_warning_sum);
     }
   }
+  __syncthreads();
 #else
   if (warning_inc > 0) {
     gpuAtomicAdd(&warning[0], warning_inc);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2744

D104480161 removed a necessary `__syncthreads()`, causing a race condition between **thread 0 of warp 0’s write** and **other threads’ reads**.

- **Only** thread 0 of warp 0 (`linear_tid = 0`) runs lines **170–175**.
- All other threads can jump directly to **line 181**
  - possibly reaches the `atomicAdd` read **before** warp 0 completes the `gpuAtomicAdd` write at **line 173**.
- As a result, they observe `warning[0] == 0` and print.

This leads to **massive printing** - any threads in the block that reads before the `gpuAtomicAdd` write completes will print. 

This causes **significant regression when OOB occurs and WARNING mode is used**.

The diff adds back the `__syncthreads()`.

Differential Revision: D107199267


