### PR TITLE
Make V1 codegen conditional on `split_function_args_v1`

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_cpu_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_cpu_template.cpp
@@ -41,7 +41,7 @@ void split_embedding_backward_codegen_{{ optimizer }}_cpu(
 
 namespace {
 
-{% if has_cpu_support %}
+{% if has_cpu_support and args.split_function_args_v1 is not none %}
 class SplitLookupFunction_{{ optimizer }}_Op : public torch::autograd::Function<SplitLookupFunction_{{ optimizer }}_Op> {
  public:
   static constexpr bool is_traceable = true;
@@ -196,8 +196,9 @@ class SplitLookupFunction_{{ optimizer }}_Op : public torch::autograd::Function<
     };
   }
 };
-{% endif %} // if has_cpu_support
+{% endif %} // if has_cpu_support and args.split_function_args_v1 is not none
 
+{%- if args.split_function_args_v1 is not none %}
 ///@ingroup embedding-cpu
 Tensor split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(
     Tensor host_weights,
@@ -220,8 +221,8 @@ Tensor split_embedding_codegen_lookup_{{ optimizer }}_function_cpu(
     int64_t output_dtype = static_cast<int64_t>(SparseType::FP32)) {
   {% if has_cpu_support %}
   {%- if "learning_rate_tensor" in args.split_function_arg_names %}
-  // `learning rate` is changed to tensor to prevent recompilation. 
-  // This interface (V1) still accepts learning rate as float for backward compatibility, 
+  // `learning rate` is changed to tensor to prevent recompilation.
+  // This interface (V1) still accepts learning rate as float for backward compatibility,
   // We convert learning rate to tensor here to work with the backend
   // The unified PT2 interface already accepts learning rate as tensor.
   const auto learning_rate_tensor = at::tensor({learning_rate}, at::TensorOptions().dtype(at::kFloat).device(at::kCPU));
@@ -269,6 +270,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
           c10::DispatchKey::Autograd,
           TORCH_FN(split_embedding_codegen_lookup_{{ optimizer }}_function_cpu)));
 }
+{%- endif %} {#-/* if args.split_function_args_v1 is not none */#}
 
 } // namespace
 // clang-format on

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
@@ -552,8 +552,9 @@ Tensor
     {{ args.split_function_args | join(", ") }});
 {%- endfor %} {#-/* for weighted*/#}
 
+{%- if args.split_function_args_v1 is not none %}
 ////////////////////////////////////////////////////////////////////////////////
-// Autograd Function Declarations
+// Autograd Function Declarations (V1)
 ////////////////////////////////////////////////////////////////////////////////
 
 {#- /* Generate a separate autograd function for global weight decay */ #}
@@ -1051,11 +1052,13 @@ class {{ autograd_func }} :
     {%- endif %}
   }
 };
+{%- endif %} {#-/* if args.split_function_args_v1 is not none (V1 autograd) */#}
 {%- endfor %} {#-/* for is_gwd */#}
 {%- endfor %} {#-/* for nobag */#}
 {%- endfor %} {#-/* for vbe */#}
 {%- endif %} {#-/* if has_gpu_support */#}
 
+{%- if args.split_function_args_v1 is not none %}
 ///@ingroup embedding-cuda
 Tensor {{ bwd_mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function(
     {%- if dense %}
@@ -1181,12 +1184,14 @@ Tensor {{ bwd_mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function(
   return Tensor();
   {%- endif %} {#-/* if has_gpu_support */#}
 }
+{%- endif %} {#-/* if args.split_function_args_v1 is not none */#}
 
 // Deprecated for fb namespace! Please use fbgemm namespace instead!
 {%- for lib_name in ["fb", "fbgemm"] %}
 TORCH_LIBRARY_FRAGMENT({{ lib_name }}, m) {
     {%- set op_name = "{}_embedding_codegen_lookup_{}_function".format(bwd_mdesc, optimizer) %}
     {%- if not dense %}
+    {%- if args.split_function_args_v1 is not none %}
     m.def("{{ op_name }}("
           "    Tensor placeholder_autograd_tensor, "
           "    Tensor(a!) dev_weights, "
@@ -1255,8 +1260,10 @@ TORCH_LIBRARY_FRAGMENT({{ lib_name }}, m) {
         torch::dispatch(
           c10::DispatchKey::Meta,
           TORCH_FN({{ op_name }})));
+    {%- endif %} {#-/* if args.split_function_args_v1 is not none */#}
     {%- endif %} {#/* if not dense */#}
 
+    {%- if dense or args.split_function_args_v1 is not none %}
     DISPATCH_TO_CUDA(
         {%- if not dense %}
         "{{ op_name }}",
@@ -1264,6 +1271,7 @@ TORCH_LIBRARY_FRAGMENT({{ lib_name }}, m) {
         "dense_embedding_codegen_lookup_function",
         {%- endif %}
         {{ op_name }});
+    {%- endif %} {#-/* if dense or args.split_function_args_v1 is not none */#}
 }
 {%- endfor %} {#-/* for lib_name */#}
     // clang-format on


### PR DESCRIPTION
Summary:
The TBE backward codegen templates unconditionally generate V1 (legacy) lookup functions, autograd classes, and `TORCH_LIBRARY` registrations for every optimizer. This means new optimizers that only need the PT2 interface are forced to provide a v1 schema even though V1 is unused — the Python invoker already calls only the `_function_pt2` path.

This diff adds `{% if args.split_function_args_v1 is not none %}` guards around all V1-specific generated code in both GPU and CPU host templates:
- V1 autograd classes (`SplitLookupFunction_{optimizer}_Op`)
- V1 function definitions (`split_embedding_codegen_lookup_{optimizer}_function`)
- V1 `TORCH_LIBRARY` schema registrations and `DISPATCH_TO_CUDA`

All existing optimizers provide a v1 schema, so this is a no-op for them. Future optimizers can opt out of V1 by omitting the `additional_spec` dict in `OptimizerArgsSet.create()`.

Differential Revision: D107331913


