### PR TITLE
Fix backward regression in PR #5712

### DIFF
--- a/fbgemm_gpu/codegen/genscript/optimizers.py
+++ b/fbgemm_gpu/codegen/genscript/optimizers.py
@@ -197,37 +197,46 @@ def rowwise_adagrad() -> dict[str, Any]:
 
     at::acc_type<cache_t, true> multiplier = 0.0;
     at::acc_type<cache_t, true> correction = 0.0;
-    if (threadIdx.x == 0) {
+    """
+    split_precomputation_preload = split_precomputation
+    split_precomputation_common = """
+    if (threadIdx.x == 0) {{
         auto new_sum_square_grads = g_avg_square;
 
         // Update the optimizer state.  Use optimizer state offloading only if
         // SSD and if enabled by the user
-        if (enable_optimizer_offloading) {
+        if (enable_optimizer_offloading) {{
             // Fetch the pointer to the optimizer state along the cache row
             auto* optimizer = weight_row_template.template optimizer_state_ptr<OptimizerState>();
             new_sum_square_grads += optimizer->momentum;
             optimizer->momentum = new_sum_square_grads;
 
-        } else {
-            new_sum_square_grads += momentum1[idx];
+        }} else {{
+            new_sum_square_grads += {momentum1_read};
             momentum1[idx] = new_sum_square_grads;
-        }
+        }}
 
         multiplier = learning_rate / (sqrtf(new_sum_square_grads) + eps);
-        if (weight_decay_mode == 1) {
+        if (weight_decay_mode == 1) {{
             // L2 regularization
             correction = 1.0 - multiplier * weight_decay;
-        } else if (weight_decay_mode == 2 || weight_decay_mode == 5) {
+        }} else if (weight_decay_mode == 2 || weight_decay_mode == 5) {{
             // Decoupled weight decay
             correction = 1.0 - learning_rate * weight_decay;
-        } else {
+        }} else {{
             // default value
             correction = 1.0;
-        }
-    }
+        }}
+    }}
     multiplier = SHFL_SYNC(multiplier, 0);
     correction = SHFL_SYNC(correction, 0);
     """
+    split_precomputation += split_precomputation_common.format(
+        momentum1_read="momentum1[idx]"
+    )
+    split_precomputation_preload += split_precomputation_common.format(
+        momentum1_read="momentum1_val"
+    )
     split_weight_update_cpu = """
         at::acc_type<grad_t, true> g_local_sum_square = 0.0;
         for (int64_t d = 0; d < D; ++d) {
@@ -275,6 +284,7 @@ def rowwise_adagrad() -> dict[str, Any]:
             },
         ),
         "split_precomputation": split_precomputation,
+        "split_precomputation_preload": split_precomputation_preload,
         "split_weight_update": split_weight_update,
         "split_post_update": split_post_update,
         "split_weight_update_cpu": split_weight_update_cpu,

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
@@ -625,7 +625,11 @@ batch_index_select_dim0_codegen_backward_kernel_cta_per_row
     codegen/embedding_common_code_generator.py for more details
 */ #}
 
+{%- if is_rocm %}
+{{ instantiate_templates(use_subwarp_shuffle=True) }}
+{%- else %}
 {{ instantiate_templates(use_subwarp_shuffle=False) }}
+{%- endif %}
 
 ////////////////////////////////////////////////////////////////////////////////
 #endif

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -671,11 +671,6 @@ hip_mixed_d_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc
             {{ args.split_tensor_types[tensor] }} {{tensor}}_val = SUBWARP_SHFL_SYNC(s_{{ tensor }}_val, i);
             {%- endfor %}
 
-            // const int64_t momentum1_offset = SHFL_SYNC(s_momentum1_offset, i);
-            // const auto momentum1_placement = static_cast<PlacementType>(SHFL_SYNC(s_momentum1_placement, i));
-            // auto momentum1 = reinterpret_cast<at::acc_type<cache_t, true>*>(SHFL_SYNC(reinterpret_cast<uint64_t>(s_momentum1), i));
-            // auto momentum1_val = momentum1[idx];
-
             // now, each segment corresponds to exactly one table `t` and row in
             // that table (`idx`). Thus, we can hoist out some of the book-keeping.
 

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -447,6 +447,162 @@ hip_mixed_d_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc
       ? smem.getPointer() + threadIdx.y * grad_sum_stride
       : nullptr;
 
+    const int32_t hip_num_unique_runs = sorted_linear_indices_num_runs[0];
+    const int32_t hip_total_L =
+        sorted_linear_indices_cumulative_run_lengths[hip_num_unique_runs];
+    if (!(hip_num_unique_runs > 0 && hip_total_L <= 2 * hip_num_unique_runs)) {
+        for (uint32_t run_id = start_run_id;
+             run_id < sorted_linear_indices_run.size(0) && run_id < hip_num_unique_runs;
+                 run_id += gridDim.x * blockDim.y) {
+
+            const int64_t linear_index = sorted_linear_indices_run[run_id];
+            const int32_t segment_start =
+                sorted_linear_indices_cumulative_run_lengths[run_id];
+            const int32_t segment_end =
+                sorted_linear_indices_cumulative_run_lengths[run_id + 1];
+            const int32_t SL = segment_end - segment_start;
+
+            if (SL >= max_segment_length_per_warp) {
+                continue;
+            }
+
+            {%- if not nobag %}
+            const auto info_0 = reinterpret_cast<const uint32_t*>(&sorted_infos[0])[segment_start];
+            const auto t_0 = info_0 >> info_B_num_bits;
+            {%- else %}
+            const auto info_0 = sorted_infos[segment_start];
+            int32_t t_0 = info_0 % T;
+            {%- endif %}
+
+            int64_t hash_size = hash_size_cumsum[t_0];
+            {%- if not nobag or is_index_select %}
+            const auto D_start_t0 = D_offsets[t_0];
+            const int32_t D = D_offsets[t_0 + 1] - D_start_t0;
+            {%- if is_index_select %}
+            const auto grad_offset = permute_output_dim_0_1 ? D_start_t0 : grad_offsets[t_0];
+            const auto grad_stride = permute_output_dim_0_1 ? D_offsets[T] : D;
+            {%- endif %}
+            {%- endif %}
+            int64_t idx = linear_index - hash_size;
+
+            {{ compute_global_weight_decay(is_gwd_kernel) }}
+
+            const int32_t SL_per_warp = div_round_up(SL, blockDim.y);
+            const int32_t sl_start = 0;
+            const int32_t sl_end = SL;
+            Vec4TAcc<cache_t> grad_sum[kFixedMaxVecsPerThread];
+            constexpr int32_t kGroupVecWidth = kThreadGroupSize * VEC_WIDTH;
+            const int32_t num_vecs = (D + kGroupVecWidth - 1) / kGroupVecWidth;
+
+            compute_grad_sum_{{ kdesc }}<
+              grad_t,
+              cache_t,
+              kFixedMaxVecsPerThread,
+              kThreadGroupSize,
+              VEC_WIDTH,
+              kUseVecBlocking>(
+                grad_sum,
+                smem_grad_sum,
+                grad_output,
+                {%- if not nobag or is_index_select %}
+                D_offsets,
+                {%- endif %}
+                D,
+                T,
+                sorted_infos,
+                {%- if weighted %}
+                sorted_indice_weights,
+                {%- endif %}
+                {%- if not nobag and vbe %}
+                B_offsets,
+                row_output_offsets,
+                {%- endif %}
+                {%- if is_index_select %}
+                grad_offset,
+                grad_stride,
+                {%- endif %}
+                {%- if not nobag %}
+                info_B_num_bits,
+                info_B_mask,
+                {%- endif %}
+                segment_start,
+                sl_start,
+                sl_end,
+                shfl_sync_mask,
+                num_vecs
+            );
+
+            const int32_t max_vecs =
+                kUseVecBlocking ? max_vecs_per_thread : kFixedMaxVecsPerThread;
+
+            {%- if not dense and optimizer != "none" %}
+            {{ mdesc }}_{{ optimizer }}_table_update_kernel<
+              emb_t,
+              cache_t,
+              {%- for ph_name in args.placeholder_tensor_names %}
+              {{ ph_name + "_ph_t" }},
+              {%- endfor %}
+              kFixedMaxVecsPerThread,
+              kThreadGroupSize,
+              VEC_WIDTH,
+              kUseVecBlocking>(
+                  dev_weights,
+                  uvm_weights,
+                  lxu_cache_weights,
+                  weights_placements,
+                  weights_offsets,
+                  sorted_{{ locs_or_addrs_tensor }},
+                  grad_sum,
+                  smem_grad_sum,
+                  smem_grad_sum, // shared_weight_update_row (reuse smem_grad_sum)
+                  stochastic_rounding,
+                  stochastic_rounding_philox_args,
+                  run_id,
+                  use_uniq_cache_locations
+                      ? (run_id - table_unique_indices_offsets[t_0])
+                      : segment_start,
+                  D,
+                  t_0,
+                  idx,
+                  {%- if is_gwd_kernel %}
+                  global_weight_decay,
+                  {%- elif has_global_weight_decay_support %}
+                  1, // global_weight_decay
+                  {%- endif %}
+                  shfl_sync_mask,
+                  max_vecs,
+                  {%- if ssd %}
+                  enable_optimizer_offloading,
+                  {%- endif %}
+                  {{ args.split_kernel_arg_names | join(", ") }}
+            );
+            {%- else %}
+            {%- if dense %}
+            const int64_t weights_offset = weights_offsets[t_0];
+            {%- else %}
+            const int64_t weights_offset = run_id * max_D;
+            idx = 0;
+            {%- endif %}
+            store_grad_sum<
+                emb_t,
+                cache_t,
+                kFixedMaxVecsPerThread,
+                kThreadGroupSize,
+                VEC_WIDTH,
+                kUseVecBlocking>(
+                  grad_dev_weights,
+                  grad_sum,
+                  kUseVecBlocking ? smem_grad_sum : nullptr,
+                  D,
+                  weights_offset,
+                  idx,
+                  max_vecs
+            );
+            {%- endif %} // if not dense and optimizer != "none"
+        }
+        return;
+    }
+
     constexpr int num_unroll = kThreadGroupSize;
 
     auto num_run_id = min(sorted_linear_indices_run.size(0), sorted_linear_indices_num_runs[0]);

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -41,6 +41,14 @@
                                                  not vbe and
                                                  not ssd %}
 
+{%- set enable_optimized_hip_mixed_D_kernel  = is_rocm and
+                                               optimizer == "rowwise_adagrad" and
+                                               not dense and
+                                               not is_index_select and
+                                               not is_gwd_kernel and
+                                               not nobag and 
+                                               not ssd %}
+
 #include "fbgemm_gpu/embedding_backward_template_helpers.cuh"
 #include "fbgemm_gpu/utils/tensor_accessor_builder.h"
 #include "fbgemm_gpu/split_embeddings_utils.cuh"
@@ -341,6 +349,307 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row(
     }
 }
 
+{%- if enable_optimized_hip_mixed_D_kernel  %}
+template <
+    typename emb_t,
+    typename grad_t,
+    typename cache_t,
+    typename index_t,
+    {%- for ph_name in args.placeholder_tensor_names %}
+    typename {{ ph_name + "_ph_t"}},
+    {%- endfor %}
+    int32_t kFixedMaxVecsPerThread,
+    int32_t kThreadGroupSize,
+    bool kUseVecBlocking>
+__global__ __launch_bounds__(kBackwardMaxThreads) void
+hip_mixed_d_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc }}_kernel_warp_per_row_1(
+    const pta::PackedTensorAccessor64<grad_t, {{ "1" if is_index_select else "2" }}, at::RestrictPtrTraits> grad_output,
+    {%- if optimizer != "none" %}
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
+    {%- if not dense %}
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> uvm_weights,
+    pta::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
+    {%- endif %}
+    {%- endif %}
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
+    {%- if not nobag or is_index_select %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
+    {%- else %}
+    int64_t D,
+    {%- endif %}
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> hash_size_cumsum,
+    const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> sorted_linear_indices_run,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_cumulative_run_lengths,
+    {%- if not nobag %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_infos,
+    {%- else %}
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_infos,
+    {%- endif %}
+    {%- if not dense %}
+    const pta::PackedTensorAccessor32<{{ locs_or_addrs_type }}, 1, at::RestrictPtrTraits> sorted_{{ locs_or_addrs_tensor }},
+    const bool use_uniq_cache_locations,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> table_unique_indices_offsets,
+    {%- endif %}
+    {%- if weighted %}
+    const pta::PackedTensorAccessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits> sorted_indice_weights,
+    {%- endif %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_num_runs,
+    int32_t max_segment_length_per_warp,
+    {%- if not dense and optimizer != "none" %}
+    bool stochastic_rounding,
+    at::PhiloxCudaState stochastic_rounding_philox_args,
+    {%- else %}
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> grad_dev_weights,
+    {%- endif %} // if not dense and optimizer != "none"
+    {%- if not nobag and vbe %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> B_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> row_output_offsets,
+    {%- endif %}
+    {%- if not nobag %}
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask,
+    {%- endif %}
+    const int32_t max_D,
+    const int32_t max_vecs_per_thread,
+    {%- if is_index_select %}
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> grad_offsets,
+    const bool permute_output_dim_0_1
+    {%- else %}
+    {{ args.split_kernel_args | replace_pta_namespace() | join(",\n    ") }}
+    {%- endif %}
+) {
+    {%- if not nobag %}
+    int32_t T = D_offsets.size(0) - 1;
+    {%- else %}
+    int32_t T = weights_offsets.size(0);
+    {%- endif %}
+    const auto start_run_id = blockIdx.x * blockDim.y + threadIdx.y;
+
+#define SUBWARP_SHFL_SYNC(val, srcLane) __shfl_sync(UINT64_MAX, val, srcLane, kThreadGroupSize)
+
+#ifdef FBGEMM_USE_SUBWARP_SHUFFLE
+    const unsigned int shfl_sync_mask =
+        ((1L << kThreadGroupSize) - 1) <<
+        (threadIdx.y % (kWarpSize / kThreadGroupSize) * kThreadGroupSize);
+#else
+    const unsigned int shfl_sync_mask = 0xffffffffu;
+#endif
+
+#define BROADCAST(val, srcLane) __builtin_amdgcn_readlane(val,srcLane)
+
+    constexpr int VEC_WIDTH = 4;
+    constexpr auto kIsInt8 = std::is_same<emb_t, uint8_t>::value;
+
+    struct SharedMemory<Vec4TAcc<cache_t>> smem;
+    const int32_t grad_sum_stride = max_D / VEC_WIDTH;
+    auto* smem_grad_sum = (kUseVecBlocking || kIsInt8)
+      ? smem.getPointer() + threadIdx.y * grad_sum_stride
+      : nullptr;
+
+    constexpr int num_unroll = kThreadGroupSize;
+
+    auto num_run_id = min(sorted_linear_indices_run.size(0), sorted_linear_indices_num_runs[0]);
+
+    for (uint32_t out_run_id = start_run_id * num_unroll; out_run_id < num_run_id; out_run_id += gridDim.x * blockDim.y * num_unroll) {
+        auto num_valid_id = min(num_unroll, num_run_id - out_run_id);
+        auto is_valid = threadIdx.x < num_valid_id;
+
+        int32_t s_segment_start = is_valid? sorted_linear_indices_cumulative_run_lengths[(out_run_id + threadIdx.x)] : -1;
+        int32_t s_segment_end = is_valid? sorted_linear_indices_cumulative_run_lengths[(out_run_id + threadIdx.x + 1)] : -1;
+        int64_t s_idx = is_valid? sorted_linear_indices_run[out_run_id + threadIdx.x] : -1;
+
+        {%- if not nobag %}
+        uint32_t s_t_0 = is_valid? reinterpret_cast<const uint32_t*>(&sorted_infos[0])[s_segment_start] : -1;
+        s_t_0 = s_t_0 >> info_B_num_bits;
+        {%- else %}
+        auto s_t_0 = is_valid? sorted_infos[s_segment_start] : -1;
+        s_t_0 = s_t_0 % T;
+        {%- endif %}
+
+        int64_t s_hash_size = is_valid? hash_size_cumsum[s_t_0] : -1;
+        s_idx -= s_hash_size;
+        {%- if not nobag %}
+        int32_t s_D_offsets_0 = is_valid? D_offsets[s_t_0] : 0;
+        int32_t s_D_offsets_1 = is_valid? D_offsets[s_t_0 + 1] : 0;
+        auto s_D = s_D_offsets_1 - s_D_offsets_0;
+        {%- endif %}
+
+        int32_t s_table_unique_indice_offset = is_valid? table_unique_indices_offsets[s_t_0] : 0;
+        int64_t s_weights_offset = is_valid? weights_offsets[s_t_0] : 0;
+        int32_t s_weights_placement = is_valid? weights_placements[s_t_0] : 0;
+
+        {%- for tensor in args.split_tensors %}
+        {{ args.split_tensor_types[tensor] }}* __restrict__ s_{{ tensor }};
+        const auto s_{{ tensor }}_placement = {{ tensor }}_placements[s_t_0];
+        const int64_t s_{{ tensor }}_offset = {{ tensor }}_offsets[s_t_0];
+        if (static_cast<PlacementType>(s_{{ tensor }}_placement) == PlacementType::DEVICE) {
+            s_{{ tensor }} = &{{ tensor }}_dev[s_{{ tensor }}_offset];
+        } else {
+            s_{{ tensor }} = &{{ tensor }}_uvm[s_{{ tensor }}_offset];
+        }
+        {{ args.split_tensor_types[tensor] }} s_{{tensor}}_val = is_valid? s_{{tensor}}[s_idx] : 0;
+
+        {%- endfor %}
+
+        for (auto i = 0; i < num_valid_id; ++i) {
+            auto segment_start = SUBWARP_SHFL_SYNC(s_segment_start, i);
+            auto segment_end = SUBWARP_SHFL_SYNC(s_segment_end, i);
+            const int32_t SL = segment_end - segment_start;
+            if (SL >= max_segment_length_per_warp) {
+                continue;
+            }
+
+            auto run_id = out_run_id + i;
+            auto t_0 = SUBWARP_SHFL_SYNC(s_t_0, i);
+            auto idx = SUBWARP_SHFL_SYNC(s_idx, i);
+
+            {%- if not nobag %}
+            auto D = SUBWARP_SHFL_SYNC(s_D, i);
+            {%- endif %}
+            int32_t table_unique_indice_offset = SUBWARP_SHFL_SYNC(s_table_unique_indice_offset, i);
+
+            {%- for tensor in args.split_tensors %}
+            const auto {{ tensor }}_placement = SUBWARP_SHFL_SYNC(s_{{ tensor }}_placement, i);
+            const int64_t {{ tensor }}_offset = SUBWARP_SHFL_SYNC(s_{{ tensor }}_offset, i);
+            {{ args.split_tensor_types[tensor] }} {{tensor}}_val = SUBWARP_SHFL_SYNC(s_{{ tensor }}_val, i);
+            {%- endfor %}
+
+            // const int64_t momentum1_offset = SHFL_SYNC(s_momentum1_offset, i);
+            // const auto momentum1_placement = static_cast<PlacementType>(SHFL_SYNC(s_momentum1_placement, i));
+            // auto momentum1 = reinterpret_cast<at::acc_type<cache_t, true>*>(SHFL_SYNC(reinterpret_cast<uint64_t>(s_momentum1), i));
+            // auto momentum1_val = momentum1[idx];
+
+            // now, each segment corresponds to exactly one table `t` and row in
+            // that table (`idx`). Thus, we can hoist out some of the book-keeping.
+
+            const int32_t SL_per_warp = div_round_up(SL, blockDim.y);
+            const int32_t sl_start = 0;
+            const int32_t sl_end = SL;
+
+            Vec4TAcc<cache_t> grad_sum[kFixedMaxVecsPerThread];
+            constexpr int32_t kGroupVecWidth = kThreadGroupSize * VEC_WIDTH;
+            const int32_t num_vecs = (D + kGroupVecWidth - 1) / kGroupVecWidth;
+
+            compute_grad_sum_{{ kdesc }}<
+            grad_t,
+            cache_t,
+            kFixedMaxVecsPerThread,
+            kThreadGroupSize,
+            VEC_WIDTH,
+            kUseVecBlocking>(
+                grad_sum,
+                smem_grad_sum,
+                grad_output,
+                {%- if not nobag or is_index_select %}
+                D_offsets,
+                {%- endif %}
+                D,
+                T,
+                sorted_infos,
+                {%- if weighted %}
+                sorted_indice_weights,
+                {%- endif %}
+                {%- if not nobag and vbe %}
+                B_offsets,
+                row_output_offsets,
+                {%- endif %}
+                {%- if not nobag %}
+                info_B_num_bits,
+                info_B_mask,
+                {%- endif %}
+                segment_start,
+                sl_start,
+                sl_end,
+                shfl_sync_mask,
+                num_vecs
+            );
+
+            // Copy value to max_vecs to make max_vecs_per_thread known at compile time
+            // when kUseVecBlocking == false
+            const int32_t max_vecs =
+                kUseVecBlocking ? max_vecs_per_thread : kFixedMaxVecsPerThread;
+
+            {%- if not dense and optimizer != "none" %}
+            const int64_t weights_offset = SUBWARP_SHFL_SYNC(s_weights_offset, i);
+            const int32_t weights_placement = SUBWARP_SHFL_SYNC(s_weights_placement, i);
+            {{ mdesc }}_{{ optimizer }}_table_update_kernel<
+              emb_t,
+              cache_t,
+              {%- for ph_name in args.placeholder_tensor_names %}
+              {{ ph_name + "_ph_t" }},
+              {%- endfor %}
+              kFixedMaxVecsPerThread,
+              kThreadGroupSize,
+              VEC_WIDTH,
+              kUseVecBlocking>(
+                  dev_weights,
+                  uvm_weights,
+                  lxu_cache_weights,
+                  weights_placement,
+                  weights_offset,
+                  sorted_{{ locs_or_addrs_tensor }},
+                  grad_sum,
+                  smem_grad_sum,
+                  smem_grad_sum, // shared_weight_update_row (reuse smem_grad_sum)
+                  stochastic_rounding,
+                  stochastic_rounding_philox_args,
+                  run_id,
+                  use_uniq_cache_locations
+                      ? (run_id - table_unique_indices_offsets[t_0])
+                      : segment_start,
+                  D,
+                  t_0,
+                  idx,
+                  {%- if is_gwd_kernel %}
+                  global_weight_decay,
+                  {%- elif has_global_weight_decay_support %}
+                  {# /* cases where gwd is not enabled/supported */ #}
+                  1, // global_weight_decay
+                  {%- endif %}
+                  shfl_sync_mask,
+                  max_vecs,
+                  {%- if ssd %}
+                  enable_optimizer_offloading,
+                  {%- endif %}
+                  {%- for tensor in args.split_tensors %}
+                  {{ tensor }}_placement,
+                  {{ tensor }}_offset,
+                  {{ tensor }}_val,
+                  {%- endfor %}
+                  {{ args.split_kernel_arg_names | join(", ") }}
+            );
+            {%- else %}
+            // Write deduplicated gradient to grad_dev_weights gradient is sparse
+            // for split_embedding and dense for dense_embedding
+            {%- if dense %}
+            const int64_t weights_offset = weights_offsets[t_0];
+            {%- else %}
+            // Compute offset of sparse gradient
+            const int64_t weights_offset = run_id * max_D;
+            idx = 0;
+            {%- endif %}
+            store_grad_sum<
+                emb_t,
+                cache_t,
+                kFixedMaxVecsPerThread,
+                kThreadGroupSize,
+                VEC_WIDTH,
+                kUseVecBlocking>(
+                  grad_dev_weights,
+                  grad_sum,
+                  kUseVecBlocking ? smem_grad_sum : nullptr,
+                  D,
+                  weights_offset,
+                  idx,
+                  max_vecs
+            );
+            {%- endif %} // if not dense and optimizer != "none"
+        }
+    }
+}
+{%- endif %}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 // Explicit Template Instantiations
@@ -460,6 +769,85 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row
     }}
     {%- endif %}
 );
+
+{%- if enable_optimized_hip_mixed_D_kernel  %}
+
+template __global__ __launch_bounds__(kBackwardMaxThreads) void
+hip_mixed_d_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc }}_kernel_warp_per_row_1
+< {{ emb_type }},
+  {{ grad_type }},
+  {{ cache_type }},
+  {{ index_type }},
+  {%- for ph_name in args.placeholder_tensor_names %}
+  {{ ph_type_combo[ph_name].primitive_type }},
+  {%- endfor %}
+  {{ kFixedMaxVecsPerThread }},
+  {{ kThreadGroupSize }},
+  {{ kUseVecBlocking }}
+> (
+    const pta::PackedTensorAccessor64<{{ grad_type }}, {{ "1" if is_index_select else "2" }}, at::RestrictPtrTraits> grad_output,
+    {%- if optimizer != "none" %}
+    pta::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> dev_weights,
+    {%- if not dense %}
+    pta::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> uvm_weights,
+    pta::PackedTensorAccessor64<{{ cache_type }}, 2, at::RestrictPtrTraits> lxu_cache_weights,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
+    {%- endif %}
+    {%- endif %}
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
+    {%- if not nobag or is_index_select %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
+    {%- else %}
+    int64_t D,
+    {%- endif %}
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> hash_size_cumsum,
+    const pta::PackedTensorAccessor32<{{ index_type }}, 1, at::RestrictPtrTraits> sorted_linear_indices_run,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_cumulative_run_lengths,
+    {%- if not nobag %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_infos,
+    {%- else %}
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_infos,
+    {%- endif %}
+    {%- if not dense %}
+    const pta::PackedTensorAccessor32<{{ locs_or_addrs_type }}, 1, at::RestrictPtrTraits> sorted_{{ locs_or_addrs_tensor }},
+    const bool use_uniq_cache_locations,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> table_unique_indices_offsets,
+    {%- endif %}
+    {%- if weighted %}
+    const pta::PackedTensorAccessor32<at::acc_type<{{ cache_type }}, true>, 1, at::RestrictPtrTraits> sorted_indice_weights,
+    {%- endif %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_num_runs,
+    int32_t max_segment_length_per_warp,
+    {%- if not dense and optimizer != "none" %}
+    bool stochastic_rounding,
+    at::PhiloxCudaState stochastic_rounding_philox_args,
+    {%- else %}
+    pta::PackedTensorAccessor64<{{ emb_type }}, 1, at::RestrictPtrTraits> grad_dev_weights,
+    {%- endif %} // if not dense and optimizer != "none"
+    {%- if not nobag and vbe %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> B_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> row_output_offsets,
+    {%- endif %}
+    {%- if not nobag %}
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask,
+    {%- endif %}
+    const int32_t max_D,
+    const int32_t max_vecs_per_thread,
+    {%- if is_index_select %}
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> grad_offsets,
+    const bool permute_output_dim_0_1
+    {%- else %}
+    {{ args.split_kernel_args_no_defaults |
+         replace_pta_namespace() |
+         replace_placeholder_types(ph_type_combo) |
+         join(",\n    ") |
+         replace("cache_t", cache_type)
+    }}
+    {%- endif %}
+);
+
+{%- endif %}
 {%- endmacro %}
 
 {%- macro bulk_template_instantiations(kFixedMaxVecsPerThread, kThreadGroupSize, kUseVecBlocking) %}
@@ -543,7 +931,7 @@ batch_index_select_dim0_codegen_backward_kernel_warp_per_row
     codegen/embedding_common_code_generator.py for more details
 */ #}
 
-{{ instantiate_templates(use_subwarp_shuffle=False) }}
+{{ instantiate_templates(use_subwarp_shuffle=True) }}
 
 ////////////////////////////////////////////////////////////////////////////////
 #endif

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -315,6 +315,75 @@ hip_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vd
     {%- endif %}
 );
 {%- endif %}
+
+{%- if enable_optimized_hip_mixed_D_kernel  %}
+
+template <
+    typename emb_t,
+    typename grad_t,
+    typename cache_t,
+    typename index_t,
+    {%- for ph_name in args.placeholder_tensor_names %}
+    typename {{ ph_name + "_ph_t" }},
+    {%- endfor %}
+    int32_t kFixedMaxVecsPerThread,
+    int32_t kThreadGroupSize,
+    bool kUseVecBlocking>
+__global__ __launch_bounds__(kBackwardMaxThreads) void
+hip_mixed_d_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc }}_kernel_warp_per_row_1(
+    const pta::PackedTensorAccessor64<grad_t, {{ "1" if is_index_select else "2" }}, at::RestrictPtrTraits> grad_output,
+    {%- if optimizer != "none" %}
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
+    {%- if not dense %}
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> uvm_weights,
+    pta::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
+    {%- endif %}
+    {%- endif %}
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
+    {%- if not nobag or is_index_select %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
+    {%- else %}
+    int64_t D,
+    {%- endif %}
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> hash_size_cumsum,
+    const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> sorted_linear_indices_run,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_cumulative_run_lengths,
+    {%- if not nobag %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_infos,
+    {%- else %}
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_infos,
+    {%- endif %}
+    {%- if not dense %}
+    const pta::PackedTensorAccessor32<{{ locs_or_addrs_type }}, 1, at::RestrictPtrTraits> sorted_{{ locs_or_addrs_tensor }},
+    const bool use_uniq_cache_locations,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> table_unique_indices_offsets,
+    {%- endif %}
+    {%- if weighted %}
+    const pta::PackedTensorAccessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits> sorted_indice_weights,
+    {%- endif %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_num_runs,
+    int32_t max_segment_length_per_warp,
+    {%- if not dense and optimizer != "none" %}
+    bool stochastic_rounding,
+    at::PhiloxCudaState stochastic_rounding_philox_args,
+    {%- else %}
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> grad_dev_weights,
+    {%- endif %} // if not dense and optimizer != "none"
+    {%- if vbe %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> B_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> row_output_offsets,
+    {%- endif %}
+    {%- if not nobag %}
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask,
+    {%- endif %}
+    const int32_t max_D,
+    const int32_t max_vecs_per_thread,
+    {{ args.split_kernel_args | replace_pta_namespace() | join(",\n    ") }}
+);
+{%- endif %}
+
 {% if is_index_select %}
 namespace index_select {
 {% else %}
@@ -886,7 +955,17 @@ Tensor {{ embedding_cuda_op }}(
             wdesc,
             vdesc,
             )
-     %}
+    %}
+    {%- endif %}
+
+    {%- if enable_optimized_hip_mixed_D_kernel  %}
+    {%- set hip_mixed_d_warp_kernel = "hip_mixed_d_split_embedding{}_backward_codegen_{}_{}{}_kernel_warp_per_row_1".format(
+            ndesc,
+            optimizer,
+            wdesc,
+            vdesc,
+            )
+    %}
     {%- endif %}
 
     AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "{{ embedding_cuda_op }}_2", [&] {
@@ -1053,6 +1132,10 @@ Tensor {{ embedding_cuda_op }}(
                 auto temp_grad_accum = at::zeros(
                     {use_deterministic_algorithms ? 0 : grad_accum_counter.numel(), max_D},
                     aligned_grad_output.options().dtype(std::is_same_v<cache_t, double> ? at::kDouble : at::kFloat));
+
+                {%- if enable_optimized_hip_mixed_D_kernel  %}
+                const static auto use_hip_kernel = fbgemm_gpu::config::is_feature_enabled(fbgemm_gpu::config::FeatureGateName::TBE_ROCM_HIP_BACKWARD_KERNEL);
+                {%- endif %}
 
                 DISPATCH_PLACEHOLDER_TYPES(
                   {%- for ph_name in args.placeholder_tensor_names %}
@@ -1233,6 +1316,7 @@ Tensor {{ embedding_cuda_op }}(
                             desc_suffix,
                         )
                     %}
+                    // When 'enable_optimized_hip_mixed_D_kernel' and 'is_optimized_hip_kernel_supported_mode' is False, we use the default kernel.
                     auto backward_warp_per_row_kernel =
                         {{ warp_kernel }}
                             <emb_t,
@@ -1246,7 +1330,6 @@ Tensor {{ embedding_cuda_op }}(
                              kThreadGroupSize,
                              kUseVecBlocking>;
 
-                    // Compute shared memory size for warp_per_row
                     {%- if is_rocm %}
                         int32_t num_warp_per_row_groups;
                         if (total_L/total_B > 1){
@@ -1257,6 +1340,50 @@ Tensor {{ embedding_cuda_op }}(
                         }
                     {%- else %}
                         int32_t num_warp_per_row_groups = kBackwardMaxThreads / kThreadGroupSize;
+                    {%- endif %}
+                    auto blockSize = dim3(kThreadGroupSize, num_warp_per_row_groups);
+                    // We made targeted performance optimizations for certain backward kernels. These optimizations take effect when 'enable_optimized_hip_mixed_D_kernel' is True.
+                    {%- if enable_optimized_hip_mixed_D_kernel %}
+                    // Currently, 'hip_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc }}_kernel_warp_per_row_1' kernel
+                    // don`t support vbe==True and mixed_D==True, so we use 'hip_mixed_d_split_embedding{}_backward_codegen_{}_{}{}_kernel_warp_per_row_1'
+                    // kernel as a fallback for vbe==True and mixed_D==True cases when 'use_hip_kernel' is True. For !vbe and !mixed_D cases, we use
+                    // 'hip_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc }}_kernel_warp_per_row_1' kernel when the
+                    // condition 'use_hip_kernel' is True and "is_optimized_hip_kernel_supported_mode" is True. If no optimization is available for current
+                    // condition , it will fallback to the default kernel.
+                    {%- if vbe %}
+                    if (use_hip_kernel) {
+                    {%- else %}
+                    if (use_hip_kernel && mixed_D) {
+                    {%- endif %}
+                        backward_warp_per_row_kernel =
+                        {{ hip_mixed_d_warp_kernel }}
+                            <emb_t,
+                             grad_t,
+                             cache_t,
+                             index_t,
+                             {%- for ph_name in args.placeholder_tensor_names %}
+                             {{ ph_name + "_ph_t" }},
+                             {%- endfor %}
+                             kFixedMaxVecsPerThread,
+                             kThreadGroupSize,
+                             kUseVecBlocking>;
+                        if (max_D <= 128) {
+                            backward_warp_per_row_kernel =
+                            {{ hip_mixed_d_warp_kernel }}
+                                <emb_t,
+                                grad_t,
+                                cache_t,
+                                index_t,
+                                {%- for ph_name in args.placeholder_tensor_names %}
+                                {{ ph_name + "_ph_t" }},
+                                {%- endfor %}
+                                1,
+                                32,
+                                false>;
+                            blockSize = dim3(32, num_warp_per_row_groups);
+                            // Notice that, kThreadGroupSize * kFixedMaxVecsPerThread * vec_width should >= max_D
+                        }
+                    }
                     {%- endif %}
                     int32_t warp_per_row_smem_bytes = 0;
 
@@ -1272,9 +1399,6 @@ Tensor {{ embedding_cuda_op }}(
                           backward_warp_per_row_kernel,
                           used_shared_bytes);
                     }
-
-                    auto blockSize = dim3(kThreadGroupSize, num_warp_per_row_groups);
-
                     auto warp_per_row_grid_size = utils::cuda::cap_grid_dim_x(
                         cuda_calc_xblock_count(total_unique_indices, num_warp_per_row_groups),
                         kThreadGroupSize * num_warp_per_row_groups, // block size
@@ -1514,4 +1638,4 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
     );
 }
 {%- endif %} {#-/* if not is_index_select */#}
-// clang-format on
+    // clang-format on

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -1251,7 +1251,7 @@ Tensor {{ embedding_cuda_op }}(
                              32,
                              false>;
 
-                        cta_blockSize = dim3(32, num_cta_per_row_groups);
+                        cta_blockSize = dim3(32, num_cta_per_row_groups * 2);
                         // Notice that, kThreadGroupSize * kFixedMaxVecsPerThread * vec_width should >= max_D
                     }
                     {%- endif %}

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -57,6 +57,14 @@ using namespace fbgemm_gpu;
                                                  not vbe and
                                                  not ssd %}
 
+{%- set enable_optimized_hip_mixed_D_kernel  = is_rocm and
+                                               optimizer == "rowwise_adagrad" and
+                                               not dense and
+                                               not is_index_select and
+                                               not is_gwd_kernel and
+                                               not nobag and
+                                               not ssd %}
+
 template <
     typename emb_t,
     typename grad_t,
@@ -1064,7 +1072,7 @@ Tensor {{ embedding_cuda_op }}(
                         )
                     %}
 
-                    const auto backward_cta_per_row_kernel =
+                    auto backward_cta_per_row_kernel =
                         {{ cta_kernel }}
                             <emb_t,
                              grad_t,
@@ -1095,7 +1103,9 @@ Tensor {{ embedding_cuda_op }}(
                     {%- else %}
                     int32_t num_cta_per_row_groups = kMaxThreads / cta_warp_size;
                     const int32_t work_group_size = kMaxThreads;
-                    {%- endif %}
+                    {%- endif %}{# /*if is_rocm*/ #}
+
+                    // Compute shared memory size for cta_per_row
                     const size_t cta_per_row_smem_bytes = compute_num_groups_and_dynamic_smem_bytes(
                         &num_cta_per_row_groups,
                         [&] (int num_groups) {
@@ -1104,6 +1114,26 @@ Tensor {{ embedding_cuda_op }}(
                         backward_cta_per_row_kernel,
                         used_shared_bytes
                     );
+                    auto cta_blockSize = dim3(kThreadGroupSize, num_cta_per_row_groups);
+                    {%- if enable_optimized_hip_mixed_D_kernel  %}
+                    if (max_D <= 128) {
+                        backward_cta_per_row_kernel =
+                        {{ cta_kernel }}
+                            <emb_t,
+                             grad_t,
+                             cache_t,
+                             index_t,
+                             {%- for ph_name in args.placeholder_tensor_names %}
+                             {{ ph_name + "_ph_t" }},
+                             {%- endfor %}
+                             1,
+                             32,
+                             false>;
+
+                        cta_blockSize = dim3(32, num_cta_per_row_groups);
+                        // Notice that, kThreadGroupSize * kFixedMaxVecsPerThread * vec_width should >= max_D
+                    }
+                    {%- endif %}
 
                     const auto cta_per_row_grid_size = utils::cuda::cap_grid_dim_x(
                             cuda_calc_xblock_count(total_unique_indices, work_group_size),
@@ -1114,7 +1144,7 @@ Tensor {{ embedding_cuda_op }}(
                     FBGEMM_LAUNCH_KERNEL(
                         backward_cta_per_row_kernel,
                         cta_per_row_grid_size,
-                        dim3(kThreadGroupSize, num_cta_per_row_groups),
+                        cta_blockSize,
                         cta_per_row_smem_bytes,
                         at::cuda::getCurrentCUDAStream(),
                         grad_output_accessor,

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -1351,9 +1351,15 @@ Tensor {{ embedding_cuda_op }}(
                     // condition 'use_hip_kernel' is True and "is_optimized_hip_kernel_supported_mode" is True. If no optimization is available for current
                     // condition , it will fallback to the default kernel.
                     {%- if vbe %}
-                    if (use_hip_kernel) {
+                    // Apply the same avg_SL threshold as the non-VBE mixed_D path.
+                    if (use_hip_kernel &&
+                        total_L <= 2 * static_cast<int64_t>(sorted_linear_indices_num_runs[0].item<int32_t>())) {
                     {%- else %}
-                    if (use_hip_kernel && mixed_D) {
+                    // Use hip_mixed_d only when avg segment length <= 2
+                    // (total_L / num_unique_rows <= 2), i.e. when the momentum preload
+                    // benefit outweighs the serial inner-loop serialization cost.
+                    if (use_hip_kernel && mixed_D &&
+                        total_L <= 2 * static_cast<int64_t>(sorted_linear_indices_num_runs[0].item<int32_t>())) {
                     {%- endif %}
                         backward_warp_per_row_kernel =
                         {{ hip_mixed_d_warp_kernel }}
@@ -1380,8 +1386,12 @@ Tensor {{ embedding_cuda_op }}(
                                 1,
                                 32,
                                 false>;
-                            blockSize = dim3(32, num_warp_per_row_groups);
+                            blockSize = dim3(32, (kBackwardMaxThreads / 2) / 32);
                             // Notice that, kThreadGroupSize * kFixedMaxVecsPerThread * vec_width should >= max_D
+                            // Use (kBackwardMaxThreads/2)/32 instead of num_warp_per_row_groups to maintain
+                            // 4 AMD wavefronts per block (kThreadGroupSize=32 is half a wavefront, so we need
+                            // 8 warp groups to fill 4 physical wavefronts, matching the baseline blockDim.y=4
+                            // with kThreadGroupSize=64)
                         }
                     }
                     {%- endif %}

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -1422,7 +1422,8 @@ Tensor {{ embedding_cuda_op }}(
                                 1,
                                 32,
                                 false>;
-                            blockSize = dim3(32, (kBackwardMaxThreads / 2) / 32);
+                            num_warp_per_row_groups = (kBackwardMaxThreads / 2) / 32;
+                            blockSize = dim3(32, num_warp_per_row_groups);
                             // Notice that, kThreadGroupSize * kFixedMaxVecsPerThread * vec_width should >= max_D
                             // Use (kBackwardMaxThreads/2)/32 instead of num_warp_per_row_groups to maintain
                             // 4 AMD wavefronts per block (kThreadGroupSize=32 is half a wavefront, so we need
@@ -1447,7 +1448,7 @@ Tensor {{ embedding_cuda_op }}(
                     }
                     auto warp_per_row_grid_size = utils::cuda::cap_grid_dim_x(
                         cuda_calc_xblock_count(total_unique_indices, num_warp_per_row_groups),
-                        kThreadGroupSize * num_warp_per_row_groups, // block size
+                        blockSize.x * blockSize.y, // block size
                         at::cuda::getCurrentCUDAStream(),
                         utils::cuda::BlockCapPolicy::Always);
 

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -834,6 +834,19 @@ Tensor {{ embedding_cuda_op }}(
 #endif
     const int used_shared_bytes = used_shared_kb << 10;
 
+#ifdef USE_ROCM
+    {%- if enable_optimized_hip_mixed_D_kernel %}
+    const bool use_hip_kernel_flag = fbgemm_gpu::config::is_feature_enabled(
+        fbgemm_gpu::config::FeatureGateName::TBE_ROCM_HIP_BACKWARD_KERNEL);
+    // Declared here so the dispatch lambdas below can capture it.
+    // Populated from the pinned buffer after transpose_embedding_input().
+    struct NumUniqueEntry { at::Tensor pinned_buf; };
+    static thread_local std::unordered_map<const void*, NumUniqueEntry>
+        s_num_unique_cache;
+    int64_t num_unique_prev = 0;
+    {%- endif %}
+#endif // USE_ROCM
+
     Tensor linear_indices, linear_indices_sorted, infos_sorted,
         sorted_linear_indices_run, sorted_linear_indices_run_lengths,
         sorted_linear_indices_num_runs,
@@ -865,6 +878,31 @@ Tensor {{ embedding_cuda_op }}(
             false // is_index_select
             {%- endif %}
         );
+
+#ifdef USE_ROCM
+    {%- if enable_optimized_hip_mixed_D_kernel %}
+    if (use_hip_kernel_flag) {
+        auto& entry = s_num_unique_cache[hash_size_cumsum.data_ptr()];
+        if (entry.pinned_buf.defined()) {
+            // Read the exact num_unique from the previous backward call.
+            num_unique_prev =
+                static_cast<int64_t>(entry.pinned_buf.data_ptr<int32_t>()[0]);
+        } else {
+            // First call: allocate pinned buffer.
+            entry.pinned_buf = at::empty(
+                {1},
+                at::TensorOptions()
+                    .dtype(at::kInt)
+                    .device(at::kCPU)
+                    .pinned_memory(true));
+        }
+        // Schedule async D2H copy for the next backward call.
+        entry.pinned_buf.copy_(
+            sorted_linear_indices_num_runs.slice(0, 0, 1),
+            /*non_blocking=*/true);
+    }
+    {%- endif %}
+#endif // USE_ROCM
 
     {%- if not dense %}
     Tensor {{ locs_or_addrs_tensor }}_sorted = {{ locs_or_addrs_tensor }};
@@ -1351,15 +1389,13 @@ Tensor {{ embedding_cuda_op }}(
                     // condition 'use_hip_kernel' is True and "is_optimized_hip_kernel_supported_mode" is True. If no optimization is available for current
                     // condition , it will fallback to the default kernel.
                     {%- if vbe %}
-                    // Apply the same avg_SL threshold as the non-VBE mixed_D path.
                     if (use_hip_kernel &&
-                        total_L <= 2 * static_cast<int64_t>(sorted_linear_indices_num_runs[0].item<int32_t>())) {
+                        num_unique_prev > 0 &&
+                        total_L <= 2 * num_unique_prev) {
                     {%- else %}
-                    // Use hip_mixed_d only when avg segment length <= 2
-                    // (total_L / num_unique_rows <= 2), i.e. when the momentum preload
-                    // benefit outweighs the serial inner-loop serialization cost.
                     if (use_hip_kernel && mixed_D &&
-                        total_L <= 2 * static_cast<int64_t>(sorted_linear_indices_num_runs[0].item<int32_t>())) {
+                        num_unique_prev > 0 &&
+                        total_L <= 2 * num_unique_prev) {
                     {%- endif %}
                         backward_warp_per_row_kernel =
                         {{ hip_mixed_d_warp_kernel }}

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -843,6 +843,19 @@ Tensor {{ embedding_cuda_op }}(
 #endif
     const int used_shared_bytes = used_shared_kb << 10;
 
+#ifdef USE_ROCM
+    {%- if enable_optimized_hip_mixed_D_kernel %}
+    const bool use_hip_kernel_flag = fbgemm_gpu::config::is_feature_enabled(
+        fbgemm_gpu::config::FeatureGateName::TBE_ROCM_HIP_BACKWARD_KERNEL);
+    // Declared here so the dispatch lambdas below can capture it.
+    // Populated from the pinned buffer after transpose_embedding_input().
+    struct NumUniqueEntry { at::Tensor pinned_buf; };
+    static thread_local std::unordered_map<const void*, NumUniqueEntry>
+        s_num_unique_cache;
+    int64_t num_unique_prev = 0;
+    {%- endif %}
+#endif // USE_ROCM
+
     Tensor linear_indices, linear_indices_sorted, infos_sorted,
         sorted_linear_indices_run, sorted_linear_indices_run_lengths,
         sorted_linear_indices_num_runs,
@@ -874,6 +887,31 @@ Tensor {{ embedding_cuda_op }}(
             false // is_index_select
             {%- endif %}
         );
+
+#ifdef USE_ROCM
+    {%- if enable_optimized_hip_mixed_D_kernel %}
+    if (use_hip_kernel_flag) {
+        auto& entry = s_num_unique_cache[hash_size_cumsum.data_ptr()];
+        if (entry.pinned_buf.defined()) {
+            // Read the exact num_unique from the previous backward call.
+            num_unique_prev =
+                static_cast<int64_t>(entry.pinned_buf.data_ptr<int32_t>()[0]);
+        } else {
+            // First call: allocate pinned buffer.
+            entry.pinned_buf = at::empty(
+                {1},
+                at::TensorOptions()
+                    .dtype(at::kInt)
+                    .device(at::kCPU)
+                    .pinned_memory(true));
+        }
+        // Schedule async D2H copy for the next backward call.
+        entry.pinned_buf.copy_(
+            sorted_linear_indices_num_runs.slice(0, 0, 1),
+            /*non_blocking=*/true);
+    }
+    {%- endif %}
+#endif // USE_ROCM
 
     {%- if not dense %}
     Tensor {{ locs_or_addrs_tensor }}_sorted = {{ locs_or_addrs_tensor }};
@@ -1371,15 +1409,13 @@ Tensor {{ embedding_cuda_op }}(
                     // condition 'use_hip_kernel' is True and "is_optimized_hip_kernel_supported_mode" is True. If no optimization is available for current
                     // condition , it will fallback to the default kernel.
                     {%- if vbe %}
-                    // Apply the same avg_SL threshold as the non-VBE mixed_D path.
                     if (use_hip_kernel &&
-                        total_L <= 2 * static_cast<int64_t>(sorted_linear_indices_num_runs[0].item<int32_t>())) {
+                        num_unique_prev > 0 &&
+                        total_L <= 2 * num_unique_prev) {
                     {%- else %}
-                    // Use hip_mixed_d only when avg segment length <= 2
-                    // (total_L / num_unique_rows <= 2), i.e. when the momentum preload
-                    // benefit outweighs the serial inner-loop serialization cost.
                     if (use_hip_kernel && mixed_D &&
-                        total_L <= 2 * static_cast<int64_t>(sorted_linear_indices_num_runs[0].item<int32_t>())) {
+                        num_unique_prev > 0 &&
+                        total_L <= 2 * num_unique_prev) {
                     {%- endif %}
                         backward_warp_per_row_kernel =
                         {{ hip_mixed_d_warp_kernel }}

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -843,18 +843,6 @@ Tensor {{ embedding_cuda_op }}(
 #endif
     const int used_shared_bytes = used_shared_kb << 10;
 
-#ifdef USE_ROCM
-    {%- if enable_optimized_hip_mixed_D_kernel %}
-    const bool use_hip_kernel_flag = fbgemm_gpu::config::is_feature_enabled(
-        fbgemm_gpu::config::FeatureGateName::TBE_ROCM_HIP_BACKWARD_KERNEL);
-    // Declared here so the dispatch lambdas below can capture it.
-    // Populated from the pinned buffer after transpose_embedding_input().
-    struct NumUniqueEntry { at::Tensor pinned_buf; };
-    static thread_local std::unordered_map<const void*, NumUniqueEntry>
-        s_num_unique_cache;
-    int64_t num_unique_prev = 0;
-    {%- endif %}
-#endif // USE_ROCM
 
     Tensor linear_indices, linear_indices_sorted, infos_sorted,
         sorted_linear_indices_run, sorted_linear_indices_run_lengths,
@@ -887,31 +875,6 @@ Tensor {{ embedding_cuda_op }}(
             false // is_index_select
             {%- endif %}
         );
-
-#ifdef USE_ROCM
-    {%- if enable_optimized_hip_mixed_D_kernel %}
-    if (use_hip_kernel_flag) {
-        auto& entry = s_num_unique_cache[hash_size_cumsum.data_ptr()];
-        if (entry.pinned_buf.defined()) {
-            // Read the exact num_unique from the previous backward call.
-            num_unique_prev =
-                static_cast<int64_t>(entry.pinned_buf.data_ptr<int32_t>()[0]);
-        } else {
-            // First call: allocate pinned buffer.
-            entry.pinned_buf = at::empty(
-                {1},
-                at::TensorOptions()
-                    .dtype(at::kInt)
-                    .device(at::kCPU)
-                    .pinned_memory(true));
-        }
-        // Schedule async D2H copy for the next backward call.
-        entry.pinned_buf.copy_(
-            sorted_linear_indices_num_runs.slice(0, 0, 1),
-            /*non_blocking=*/true);
-    }
-    {%- endif %}
-#endif // USE_ROCM
 
     {%- if not dense %}
     Tensor {{ locs_or_addrs_tensor }}_sorted = {{ locs_or_addrs_tensor }};
@@ -1409,13 +1372,9 @@ Tensor {{ embedding_cuda_op }}(
                     // condition 'use_hip_kernel' is True and "is_optimized_hip_kernel_supported_mode" is True. If no optimization is available for current
                     // condition , it will fallback to the default kernel.
                     {%- if vbe %}
-                    if (use_hip_kernel &&
-                        num_unique_prev > 0 &&
-                        total_L <= 2 * num_unique_prev) {
+                    if (use_hip_kernel) {
                     {%- else %}
-                    if (use_hip_kernel && mixed_D &&
-                        num_unique_prev > 0 &&
-                        total_L <= 2 * num_unique_prev) {
+                    if (use_hip_kernel && mixed_D) {
                     {%- endif %}
                         backward_warp_per_row_kernel =
                         {{ hip_mixed_d_warp_kernel }}
@@ -1500,7 +1459,7 @@ Tensor {{ embedding_cuda_op }}(
                             // did not apply get_max_thread_blocks_() cap.
                             warp_per_row_grid_size = utils::cuda::cap_grid_dim_x(
                                 cuda_calc_xblock_count(
-                                    sorted_linear_indices_num_runs[0].item<int32_t>(),
+                                    total_unique_indices,
                                     segments_per_workgroup),
                                 256, // blockSize = dim3(256) = 256 threads
                                 at::cuda::getCurrentCUDAStream(),

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -65,6 +65,14 @@ using namespace fbgemm_gpu;
                                                not nobag and
                                                not ssd %}
 
+{%- set enable_optimized_hip_mixed_D_kernel  = is_rocm and
+                                               optimizer == "rowwise_adagrad" and
+                                               not dense and
+                                               not is_index_select and
+                                               not is_gwd_kernel and
+                                               not nobag and
+                                               not ssd %}
+
 template <
     typename emb_t,
     typename grad_t,

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -323,6 +323,75 @@ hip_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vd
     {%- endif %}
 );
 {%- endif %}
+
+{%- if enable_optimized_hip_mixed_D_kernel  %}
+
+template <
+    typename emb_t,
+    typename grad_t,
+    typename cache_t,
+    typename index_t,
+    {%- for ph_name in args.placeholder_tensor_names %}
+    typename {{ ph_name + "_ph_t" }},
+    {%- endfor %}
+    int32_t kFixedMaxVecsPerThread,
+    int32_t kThreadGroupSize,
+    bool kUseVecBlocking>
+__global__ __launch_bounds__(kBackwardMaxThreads) void
+hip_mixed_d_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc }}_kernel_warp_per_row_1(
+    const pta::PackedTensorAccessor64<grad_t, {{ "1" if is_index_select else "2" }}, at::RestrictPtrTraits> grad_output,
+    {%- if optimizer != "none" %}
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> dev_weights,
+    {%- if not dense %}
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> uvm_weights,
+    pta::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits> lxu_cache_weights,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> weights_placements,
+    {%- endif %}
+    {%- endif %}
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> weights_offsets,
+    {%- if not nobag or is_index_select %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> D_offsets,
+    {%- else %}
+    int64_t D,
+    {%- endif %}
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> hash_size_cumsum,
+    const pta::PackedTensorAccessor32<index_t, 1, at::RestrictPtrTraits> sorted_linear_indices_run,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_cumulative_run_lengths,
+    {%- if not nobag %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_infos,
+    {%- else %}
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> sorted_infos,
+    {%- endif %}
+    {%- if not dense %}
+    const pta::PackedTensorAccessor32<{{ locs_or_addrs_type }}, 1, at::RestrictPtrTraits> sorted_{{ locs_or_addrs_tensor }},
+    const bool use_uniq_cache_locations,
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> table_unique_indices_offsets,
+    {%- endif %}
+    {%- if weighted %}
+    const pta::PackedTensorAccessor32<at::acc_type<cache_t, true>, 1, at::RestrictPtrTraits> sorted_indice_weights,
+    {%- endif %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> sorted_linear_indices_num_runs,
+    int32_t max_segment_length_per_warp,
+    {%- if not dense and optimizer != "none" %}
+    bool stochastic_rounding,
+    at::PhiloxCudaState stochastic_rounding_philox_args,
+    {%- else %}
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits> grad_dev_weights,
+    {%- endif %} // if not dense and optimizer != "none"
+    {%- if vbe %}
+    const pta::PackedTensorAccessor32<int32_t, 1, at::RestrictPtrTraits> B_offsets,
+    const pta::PackedTensorAccessor32<int64_t, 1, at::RestrictPtrTraits> row_output_offsets,
+    {%- endif %}
+    {%- if not nobag %}
+    const int32_t info_B_num_bits,
+    const uint32_t info_B_mask,
+    {%- endif %}
+    const int32_t max_D,
+    const int32_t max_vecs_per_thread,
+    {{ args.split_kernel_args | replace_pta_namespace() | join(",\n    ") }}
+);
+{%- endif %}
+
 {% if is_index_select %}
 namespace index_select {
 {% else %}
@@ -896,7 +965,17 @@ Tensor {{ embedding_cuda_op }}(
             wdesc,
             vdesc,
             )
-     %}
+    %}
+    {%- endif %}
+
+    {%- if enable_optimized_hip_mixed_D_kernel  %}
+    {%- set hip_mixed_d_warp_kernel = "hip_mixed_d_split_embedding{}_backward_codegen_{}_{}{}_kernel_warp_per_row_1".format(
+            ndesc,
+            optimizer,
+            wdesc,
+            vdesc,
+            )
+    %}
     {%- endif %}
 
     fbgemm_gpu::dispatch_index_types(indices.scalar_type(), "{{ embedding_cuda_op }}_2", [&]<typename index_t>() {
@@ -1067,6 +1146,10 @@ Tensor {{ embedding_cuda_op }}(
                 auto temp_grad_accum = at::zeros(
                     {use_deterministic_algorithms ? 0 : grad_accum_counter.numel(), max_D},
                     aligned_grad_output.options().dtype(std::is_same_v<cache_t, double> ? at::kDouble : at::kFloat));
+
+                {%- if enable_optimized_hip_mixed_D_kernel  %}
+                const static auto use_hip_kernel = fbgemm_gpu::config::is_feature_enabled(fbgemm_gpu::config::FeatureGateName::TBE_ROCM_HIP_BACKWARD_KERNEL);
+                {%- endif %}
 
                 DISPATCH_PLACEHOLDER_TYPES(
                   {%- for ph_name in args.placeholder_tensor_names %}
@@ -1253,6 +1336,7 @@ Tensor {{ embedding_cuda_op }}(
                             desc_suffix,
                         )
                     %}
+                    // When 'enable_optimized_hip_mixed_D_kernel' and 'is_optimized_hip_kernel_supported_mode' is False, we use the default kernel.
                     auto backward_warp_per_row_kernel =
                         {{ warp_kernel }}
                             <emb_t,
@@ -1266,7 +1350,6 @@ Tensor {{ embedding_cuda_op }}(
                              kThreadGroupSize,
                              kUseVecBlocking>;
 
-                    // Compute shared memory size for warp_per_row
                     {%- if is_rocm %}
                         int32_t num_warp_per_row_groups;
                         if (total_L/total_B > 1){
@@ -1277,6 +1360,50 @@ Tensor {{ embedding_cuda_op }}(
                         }
                     {%- else %}
                         int32_t num_warp_per_row_groups = kBackwardMaxThreads / kThreadGroupSize;
+                    {%- endif %}
+                    auto blockSize = dim3(kThreadGroupSize, num_warp_per_row_groups);
+                    // We made targeted performance optimizations for certain backward kernels. These optimizations take effect when 'enable_optimized_hip_mixed_D_kernel' is True.
+                    {%- if enable_optimized_hip_mixed_D_kernel %}
+                    // Currently, 'hip_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc }}_kernel_warp_per_row_1' kernel
+                    // don`t support vbe==True and mixed_D==True, so we use 'hip_mixed_d_split_embedding{}_backward_codegen_{}_{}{}_kernel_warp_per_row_1'
+                    // kernel as a fallback for vbe==True and mixed_D==True cases when 'use_hip_kernel' is True. For !vbe and !mixed_D cases, we use
+                    // 'hip_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vdesc }}_kernel_warp_per_row_1' kernel when the
+                    // condition 'use_hip_kernel' is True and "is_optimized_hip_kernel_supported_mode" is True. If no optimization is available for current
+                    // condition , it will fallback to the default kernel.
+                    {%- if vbe %}
+                    if (use_hip_kernel) {
+                    {%- else %}
+                    if (use_hip_kernel && mixed_D) {
+                    {%- endif %}
+                        backward_warp_per_row_kernel =
+                        {{ hip_mixed_d_warp_kernel }}
+                            <emb_t,
+                             grad_t,
+                             cache_t,
+                             index_t,
+                             {%- for ph_name in args.placeholder_tensor_names %}
+                             {{ ph_name + "_ph_t" }},
+                             {%- endfor %}
+                             kFixedMaxVecsPerThread,
+                             kThreadGroupSize,
+                             kUseVecBlocking>;
+                        if (max_D <= 128) {
+                            backward_warp_per_row_kernel =
+                            {{ hip_mixed_d_warp_kernel }}
+                                <emb_t,
+                                grad_t,
+                                cache_t,
+                                index_t,
+                                {%- for ph_name in args.placeholder_tensor_names %}
+                                {{ ph_name + "_ph_t" }},
+                                {%- endfor %}
+                                1,
+                                32,
+                                false>;
+                            blockSize = dim3(32, num_warp_per_row_groups);
+                            // Notice that, kThreadGroupSize * kFixedMaxVecsPerThread * vec_width should >= max_D
+                        }
+                    }
                     {%- endif %}
                     int32_t warp_per_row_smem_bytes = 0;
 
@@ -1292,9 +1419,6 @@ Tensor {{ embedding_cuda_op }}(
                           backward_warp_per_row_kernel,
                           used_shared_bytes);
                     }
-
-                    auto blockSize = dim3(kThreadGroupSize, num_warp_per_row_groups);
-
                     auto warp_per_row_grid_size = utils::cuda::cap_grid_dim_x(
                         cuda_calc_xblock_count(total_unique_indices, num_warp_per_row_groups),
                         kThreadGroupSize * num_warp_per_row_groups, // block size
@@ -1534,4 +1658,4 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
     );
 }
 {%- endif %} {#-/* if not is_index_select */#}
-// clang-format on
+    // clang-format on

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -1442,7 +1442,8 @@ Tensor {{ embedding_cuda_op }}(
                                 1,
                                 32,
                                 false>;
-                            blockSize = dim3(32, (kBackwardMaxThreads / 2) / 32);
+                            num_warp_per_row_groups = (kBackwardMaxThreads / 2) / 32;
+                            blockSize = dim3(32, num_warp_per_row_groups);
                             // Notice that, kThreadGroupSize * kFixedMaxVecsPerThread * vec_width should >= max_D
                             // Use (kBackwardMaxThreads/2)/32 instead of num_warp_per_row_groups to maintain
                             // 4 AMD wavefronts per block (kThreadGroupSize=32 is half a wavefront, so we need
@@ -1467,7 +1468,7 @@ Tensor {{ embedding_cuda_op }}(
                     }
                     auto warp_per_row_grid_size = utils::cuda::cap_grid_dim_x(
                         cuda_calc_xblock_count(total_unique_indices, num_warp_per_row_groups),
-                        kThreadGroupSize * num_warp_per_row_groups, // block size
+                        blockSize.x * blockSize.y, // block size
                         at::cuda::getCurrentCUDAStream(),
                         utils::cuda::BlockCapPolicy::Always);
 

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -1371,9 +1371,15 @@ Tensor {{ embedding_cuda_op }}(
                     // condition 'use_hip_kernel' is True and "is_optimized_hip_kernel_supported_mode" is True. If no optimization is available for current
                     // condition , it will fallback to the default kernel.
                     {%- if vbe %}
-                    if (use_hip_kernel) {
+                    // Apply the same avg_SL threshold as the non-VBE mixed_D path.
+                    if (use_hip_kernel &&
+                        total_L <= 2 * static_cast<int64_t>(sorted_linear_indices_num_runs[0].item<int32_t>())) {
                     {%- else %}
-                    if (use_hip_kernel && mixed_D) {
+                    // Use hip_mixed_d only when avg segment length <= 2
+                    // (total_L / num_unique_rows <= 2), i.e. when the momentum preload
+                    // benefit outweighs the serial inner-loop serialization cost.
+                    if (use_hip_kernel && mixed_D &&
+                        total_L <= 2 * static_cast<int64_t>(sorted_linear_indices_num_runs[0].item<int32_t>())) {
                     {%- endif %}
                         backward_warp_per_row_kernel =
                         {{ hip_mixed_d_warp_kernel }}
@@ -1400,8 +1406,12 @@ Tensor {{ embedding_cuda_op }}(
                                 1,
                                 32,
                                 false>;
-                            blockSize = dim3(32, num_warp_per_row_groups);
+                            blockSize = dim3(32, (kBackwardMaxThreads / 2) / 32);
                             // Notice that, kThreadGroupSize * kFixedMaxVecsPerThread * vec_width should >= max_D
+                            // Use (kBackwardMaxThreads/2)/32 instead of num_warp_per_row_groups to maintain
+                            // 4 AMD wavefronts per block (kThreadGroupSize=32 is half a wavefront, so we need
+                            // 8 warp groups to fill 4 physical wavefronts, matching the baseline blockDim.y=4
+                            // with kThreadGroupSize=64)
                         }
                     }
                     {%- endif %}

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_device_kernel_template.cuh
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_device_kernel_template.cuh
@@ -11,6 +11,13 @@
 #include "fbgemm_gpu/utils/tensor_accessor_builder.h"
 #include "fbgemm_gpu/split_embeddings_utils.cuh"
 
+{%- set enable_optimized_hip_mixed_D_kernel  = is_rocm and
+                                               optimizer == "rowwise_adagrad" and
+                                               not dense and
+                                               not is_index_select and
+                                               not is_gwd_kernel and
+                                               not nobag and
+                                               not ssd %}
 {%- if is_rocm %}
 template<int32_t kThreadGroupSize, typename T>
 DEVICE_INLINE __device__ T subwarp_reduce_add(T value) {
@@ -211,5 +218,165 @@ DEVICE_INLINE void {{ mdesc }}_{{ optimizer }}_table_update_kernel(
 
     {{ split_post_update }}
 }
+
+{%- if enable_optimized_hip_mixed_D_kernel  %}
+template <
+    typename emb_t,
+    typename cache_t,
+    {%- for ph_name in args.placeholder_tensor_names %}
+    {%- set ph_type = "{}_ph_t".format(ph_name) %}
+    typename {{ ph_type }},
+    {%- endfor %}
+    int32_t kFixedMaxVecsPerThread,
+    int32_t kThreadGroupSize = kWarpSize,
+    int32_t VEC_WIDTH,
+    bool kUseVecBlocking
+>
+DEVICE_INLINE void {{ mdesc }}_{{ optimizer }}_table_update_kernel(
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits>& dev_weights,
+    pta::PackedTensorAccessor64<emb_t, 1, at::RestrictPtrTraits>& uvm_weights,
+    pta::PackedTensorAccessor64<cache_t, 2, at::RestrictPtrTraits>& lxu_cache_weights,
+    const int32_t weights_placement,
+    const int64_t weights_offset,
+    const pta::PackedTensorAccessor32<{{ locs_or_addrs_type }}, 1, at::RestrictPtrTraits>& sorted_{{ locs_or_addrs_tensor }},
+    Vec4TAcc<cache_t>* grad_sum,
+    Vec4TAcc<cache_t>* smem_grad_sum,
+    Vec4TAcc<cache_t>* shared_weight_update_row,
+    const bool stochastic_rounding,
+    const at::PhiloxCudaState& stochastic_rounding_philox_args,
+    const uint32_t run_id,
+    const uint32_t cache_loc_run_id,
+    const int32_t D,
+    const int32_t t,
+    const int64_t idx,
+    {%- if has_global_weight_decay_support %}
+    const float global_weight_decay,
+    {%- endif %}
+    const uint32_t shfl_sync_mask,
+    const int32_t max_vecs_per_thread,
+    {%- if ssd %}
+    const bool enable_optimizer_offloading,
+    {%- endif %}
+    {%- for tensor in args.split_tensors %}
+    const int32_t {{ tensor }}_placement,
+    const int64_t {{ tensor }}_offset,
+    const {{ args.split_tensor_types[tensor] }} {{ tensor }}_val,
+    {%- endfor %}
+    {{ args.split_ref_kernel_args | replace_pta_namespace() | join(",\n    ") }}
+) {
+    constexpr auto kIsInt8 = std::is_same_v<emb_t, uint8_t>;
+    // Copy value to max_vecs to make max_vecs_per_thread known at compile time
+    // when kUseVecBlocking == false
+    const int32_t max_vecs =
+        kUseVecBlocking ? max_vecs_per_thread : kFixedMaxVecsPerThread;
+    emb_t* __restrict__ weights {nullptr};
+    cache_t* __restrict__ cache_weights {nullptr};
+    int32_t D_emb = D;
+    if constexpr (kIsInt8) {
+        D_emb += kINT8QparamsBytes;
+    }
+    if (static_cast<PlacementType>(weights_placement) == PlacementType::DEVICE) {
+        weights = &dev_weights[weights_offset + idx * D_emb];
+    } else {
+        weights = {{ "nullptr" if ssd else "&uvm_weights[weights_offset + idx * D_emb]" }};
+    }
+    if (static_cast<PlacementType>(weights_placement) == PlacementType::MANAGED_CACHING) {
+        const auto {{ locs_or_addrs_idx }} = sorted_{{ locs_or_addrs_tensor }}[cache_loc_run_id];
+        {%- if ssd %}
+        cache_weights = reinterpret_cast<cache_t*>(
+            *reinterpret_cast<const uint64_t*>(&{{ locs_or_addrs_idx }}));
+        {%- else %}
+        if ({{ locs_or_addrs_idx }} != kCacheLocationMissing) {
+          cache_weights = &lxu_cache_weights[{{ locs_or_addrs_idx }}][0];
+        }
+        {%- endif %}
+    }
+    {%- for tensor in args.split_tensors %}
+    {{ args.split_tensor_types[tensor] }}* __restrict__ {{ tensor }};
+    // const auto {{ tensor }}_placement = static_cast<PlacementType>({{ tensor }}_placements[t]);
+    // const int64_t {{ tensor }}_offset = {{ tensor }}_offsets[t];
+    if (static_cast<PlacementType>({{ tensor }}_placement) == PlacementType::DEVICE) {
+        {{ tensor }} = &{{ tensor }}_dev[{{ tensor }}_offset];
+    } else {
+        {{ tensor }} = &{{ tensor }}_uvm[{{ tensor }}_offset];
+    }
+    {%- endfor %}
+
+    auto weight_row_template =
+        WeightRow<emb_t, cache_t, at::acc_type<cache_t, true>>(
+            weights,
+            cache_weights,
+            D,
+            stochastic_rounding,
+            &stochastic_rounding_philox_args,
+            threadIdx.x + run_id * blockDim.x);
+
+    float2 qparams_template;
+    if constexpr (kIsInt8) {
+        if (!cache_weights) {
+            qparams_template = weight_row_template.load_qparams();
+        }
+    }
+
+    {%- if not ssd %}
+    [[maybe_unused]] constexpr auto enable_optimizer_offloading = false;
+    {%- endif %}
+
+    {{ split_precomputation_preload }}
+
+    {# /* Note: technically, global weight decay (gwd) compensation should be done before
+    `split_precomputation`). But since decouple mode in `rowwise_adagrad` only computes correction,
+    the order of applying gwd does not matter. We perform gwd update before `split_weight_update`
+    below to minimize number of times to load weights.
+    So, note that the behavior may be different if you want to enable gwd for other optimizers
+    such as `lamb` or `partial_rowwise_lamb`.
+    */#}
+    float2 qparams_new;
+    {{
+       generate_optimized_grad_sum_loop_access(
+           """
+           Vec4TAcc<cache_t> weight_new = weight_row_template.load(d, qparams_template);
+           Vec4TAcc<cache_t>& grad = {grad_vec};
+           {global_weight_decay_update}
+           {split_weight_update}
+           if (kIsInt8 && !cache_weights) {
+               shared_weight_update_row[d_vec] = weight_new;
+           } else {
+               // qparams_new not used if type is not int8
+               weight_row_template.store(weight_new, d, qparams_new);
+           }
+           """,
+           other_formats={
+               "split_weight_update": split_weight_update,
+               "global_weight_decay_update": "weight_new.mul_(global_weight_decay);" if has_global_weight_decay_support else ""
+            },
+       )
+    }}
+
+    if constexpr (kIsInt8) {
+        if (!cache_weights) {
+            // Calculate new qparams after row update
+            qparams_new = thrust_find_qparams<at::acc_type<cache_t, true>>(
+                shared_weight_update_row, D);
+            weight_row_template.store_qparams(qparams_new);
+
+            // Fetch cached updated row from shared mem and quantize on-the-fly
+            // when saving to lowp embedding
+            for (int32_t vec = 0;
+                (vec * kThreadGroupSize + threadIdx.x) * VEC_WIDTH < D;
+                ++vec) {
+                const auto d_vec = vec * kThreadGroupSize + threadIdx.x;
+                const int32_t d = d_vec * VEC_WIDTH;
+                weight_row_template.store(
+                    shared_weight_update_row[d_vec],
+                    d,
+                    qparams_new);
+            }
+        }
+    }
+
+    {{ split_post_update }}
+}
+{%- endif %}
 
 // clang-format on

--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_device_kernel_template.cuh
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_device_kernel_template.cuh
@@ -293,8 +293,6 @@ DEVICE_INLINE void {{ mdesc }}_{{ optimizer }}_table_update_kernel(
     }
     {%- for tensor in args.split_tensors %}
     {{ args.split_tensor_types[tensor] }}* __restrict__ {{ tensor }};
-    // const auto {{ tensor }}_placement = static_cast<PlacementType>({{ tensor }}_placements[t]);
-    // const int64_t {{ tensor }}_offset = {{ tensor }}_offsets[t];
     if (static_cast<PlacementType>({{ tensor }}_placement) == PlacementType::DEVICE) {
         {{ tensor }} = &{{ tensor }}_dev[{{ tensor }}_offset];
     } else {


### PR DESCRIPTION
Guarded short segments cases to skip optimized kernel launch. New warp_per_row kernel dispatch logic (`FBGEMM_TBE_ROCM_HIP_BACKWARD_KERNEL=1`):

```
if  (vbe || mixed_D) && num_unique_prev > 0 && total_L <= 2*num_unique_prev
  → launch hip_mixed_d_warp (introduced in the PR)
else !mixed_D && D in [64, 128, 160, 192, 256, 320] && weights_dtype == output_dtype && weights_on_HBM
  → launch hip_warp (introduced previously - no change for this PR)
else 
  → regular split_warp kernel
```