### PR TITLE
Migrate sparse_permute_1d to cap_grid_dim_x_from_workload

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_permute_1d.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_permute_1d.cu
@@ -233,19 +233,16 @@ permute_1D_sparse_data_cuda(
   permuted_lengths = at::empty({permuted_lengths_size}, lengths.options());
 
   constexpr int32_t threads_1 = kMaxThreads;
-  const auto blocks_1_uncapped =
-      cuda_calc_xblock_count(permuted_lengths_size, threads_1);
-#ifdef USE_ROCM
   // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
-  // which silently wraps). Cap the grid unconditionally on ROCm;
-  // permute_1D_lengths_kernel uses CUDA_KERNEL_LOOP, which already
-  // grid-strides, so capping is correctness-preserving.
-  const auto blocks_1 = std::min<uint32_t>(
-      blocks_1_uncapped,
-      utils::cuda::get_max_thread_blocks(at::cuda::getCurrentCUDAStream()));
-#else
-  const auto blocks_1 = blocks_1_uncapped;
-#endif
+  // which silently wraps). permute_1D_lengths_kernel uses CUDA_KERNEL_LOOP,
+  // which already grid-strides, so capping on ROCm overflow is
+  // correctness-preserving. OverflowOnly leaves the CUDA launch uncapped.
+  // See: https://github.com/ROCm/hip/issues/2253
+  const auto blocks_1 = utils::cuda::cap_grid_dim_x_from_workload(
+      permuted_lengths_size,
+      threads_1,
+      at::cuda::getCurrentCUDAStream(),
+      utils::cuda::BlockCapPolicy::OverflowOnly);
   AT_DISPATCH_INDEX_TYPES(
       lengths.scalar_type(), "permute_1D_lengths_kernel", [&] {
         FBGEMM_LAUNCH_KERNEL(
@@ -273,19 +270,22 @@ permute_1D_sparse_data_cuda(
 
   constexpr int32_t BT_blocks = 16;
   dim3 threads_2(64, BT_blocks);
-  const auto blocks_2_uncapped =
-      cuda_calc_xblock_count(permuted_lengths_size, BT_blocks);
-#ifdef USE_ROCM
   // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
-  // which silently wraps). Cap the grid unconditionally on ROCm; the
-  // kernel's grid-striding loop over b_t handles the overflow, so capping is
-  // correctness-preserving.
-  const auto blocks_2 = std::min<uint32_t>(
-      blocks_2_uncapped,
-      utils::cuda::get_max_thread_blocks(at::cuda::getCurrentCUDAStream()));
-#else
-  const auto blocks_2 = blocks_2_uncapped;
-#endif
+  // which silently wraps). The kernel's grid-striding loop over b_t handles
+  // the overflow, so capping on ROCm overflow is correctness-preserving.
+  // OverflowOnly leaves the CUDA launch uncapped.
+  // See: https://github.com/ROCm/hip/issues/2253
+  //
+  // gridDim.x is sized by the BT_blocks (blockDim.y) work dimension, i.e.
+  // ceil(N / BT_blocks) -- NOT the full 64 * BT_blocks block size. Use the
+  // lower-level cap_grid_dim_x with the pre-computed block count so the grid
+  // size is preserved; 64 * BT_blocks is passed only as the per-block thread
+  // count for the OverflowOnly overflow-threshold check.
+  const auto blocks_2 = utils::cuda::cap_grid_dim_x(
+      cuda_calc_xblock_count(permuted_lengths_size, BT_blocks),
+      BT_blocks * 64,
+      at::cuda::getCurrentCUDAStream(),
+      utils::cuda::BlockCapPolicy::OverflowOnly);
   permuted_indices = at::empty(permuted_indices_size, indices.options());
 
   AT_DISPATCH_INDEX_TYPES(


### PR DESCRIPTION
Summary:
Migrates the two host-side cap sites in `src/sparse_ops/sparse_permute_1d.cu` (`blocks_1` and `blocks_2`) from the legacy `std::min(blocks_uncapped, get_max_thread_blocks(...))` form to the threshold-guarded `BlockCapPolicy::OverflowOnly` helpers in `fbgemm_gpu::utils::cuda`.

- `blocks_1`: the block-count divisor equals the full block size (`threads_1`), so it uses `cap_grid_dim_x_from_workload`.
- `blocks_2`: the launch is `dim3(64, BT_blocks)` and `gridDim.x` is sized by the `BT_blocks` (blockDim.y) work dimension (`ceil(N / BT_blocks)`), which differs from the full `64 * BT_blocks` block size. It therefore uses the lower-level `cap_grid_dim_x` with a pre-computed `cuda_calc_xblock_count(N, BT_blocks)` block count, passing `64 * BT_blocks` only as the per-block thread count for the overflow-threshold check. This preserves the original grid size and avoids a 64x reduction in `gridDim.x`.

`OverflowOnly` caps only on ROCm when the unguarded launch would exceed the HIP 2^32 thread-per-launch limit; the CUDA launch is left uncapped. Both kernels grid-stride over their saturating dimension, so the cap is correctness-preserving.

Reviewed By: spcyppt

Differential Revision: D106453383


