### PR TITLE
Restore pyre-fixme comments removed by D106570032 typing migration

### DIFF
--- a/fbgemm_gpu/test/sparse/pack_segments_test.py
+++ b/fbgemm_gpu/test/sparse/pack_segments_test.py
@@ -398,6 +398,7 @@ class PackedSegmentsTest(unittest.TestCase):
             return_presence_mask=True,
         )
 
+        # pyre-fixme[6]: In call `tuple.__new__`, for 1st positional argument, expected `Iterable[int]` but got `Iterable[bool | float | int]`.
         assert presence_mask.size() == torch.Size([lengths.numel(), max_length])
 
     @unittest.skipIf(*gpu_unavailable)

--- a/fbgemm_gpu/test/sparse/permute_indices_test.py
+++ b/fbgemm_gpu/test/sparse/permute_indices_test.py
@@ -77,10 +77,14 @@ class PermuteIndicesTest(unittest.TestCase):
             lengths = torch.cat(length_splits, dim=1)
         else:
             lengths = torch.randint(low=1, high=L, size=(T, B)).type(index_dtype)
+        # pyre-fixme[6]: For 1st param expected `list[int] | Size |
+        #  tuple[int, ...]` but got `bool | float | int`.
         weights = torch.rand(lengths.sum().item()).float() if has_weight else None
         indices = torch.randint(
             low=1,
             high=int(1e5),
+            # pyre-fixme[6]: Expected `int | tuple[int, ...]` for 3rd
+            #  param but got `tuple[float | int]`.
             size=(lengths.sum().item(),),
         ).type(index_dtype)
         if is_1D:
@@ -189,6 +193,8 @@ class PermuteIndicesTest(unittest.TestCase):
         indices = torch.randint(
             low=1,
             high=int(1e5),
+            # pyre-fixme[6]: Expected `int | tuple[int, ...]` for 3rd
+            #  param but got `tuple[float | int]`.
             size=(lengths.sum().item(),),
         ).type(index_dtype)
 
@@ -247,6 +253,8 @@ class PermuteIndicesTest(unittest.TestCase):
         indices = torch.randint(
             low=1,
             high=int(1e5),
+            # pyre-fixme[6]: Expected `int | tuple[int, ...]` for 3rd
+            #  param but got `tuple[float | int]`.
             size=(lengths.sum().item(),),
         ).type(index_dtype)
         permute_list = list(range(1))
@@ -284,10 +292,14 @@ class PermuteIndicesTest(unittest.TestCase):
     ) -> None:
         index_dtype = torch.int64 if long_index else torch.int32
         lengths = torch.randint(low=1, high=L, size=(T, B)).type(index_dtype)
+        # pyre-fixme[6]: For 1st param expected `list[int] | Size |
+        #  tuple[int, ...]` but got `bool | float | int`.
         weights = torch.rand(lengths.sum().item()).float() if has_weight else None
         indices = torch.randint(
             low=1,
             high=int(1e5),
+            # pyre-fixme[6]: Expected `int | tuple[int, ...]` for 3rd
+            #  param but got `tuple[float | int]`.
             size=(lengths.sum().item(),),
         ).type(index_dtype)
         permute_list = list(range(T))


### PR DESCRIPTION
Summary:
D106570032 migrated `fbgemm_gpu/test/` to Python 3.10+ typing (Optional/Dict/List → `| None`, `dict`, `list`). While doing so, several `pyre-fixme[6]` comments were removed in `permute_indices_test.py` and `pack_segments_test.py`, but the underlying type errors were not actually fixed by the migration. This caused the `permute_indices-library-type-checking` and `pack_segments-library-type-checking` tests to fail.

This change restores the `pyre-fixme[6]` suppressions, updated to use the new pipe-union syntax to stay consistent with the rest of the migration. No production behavior is changed — only test-file type suppressions.

Linked task: T273406771.

[Session trajectory link](https://www.internalfb.com/intern/devai/devmate/inspector/?id=7dfd7c17-c5ce-4697-bcad-d6b45ed32aad)

Reviewed By: cthi

Differential Revision: D107411329


