### PR TITLE
Fix wavefront64 ballot truncation in populate_bucketized_permute warp kernel (#5830)

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_block_bucketize_features.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_block_bucketize_features.cu
@@ -409,8 +409,9 @@ __launch_bounds__(kMaxThreads) void _populate_bucketized_permute_cuda_kernel(
 // Uses ballot_sync + popc to count preceding elements with same bucket,
 // which preserves the original ordering within each bucket.
 // All threads execute the same instructions (no branch divergence).
-// Note: my_size is limited to kWarpSize (32) because we use warp-level ballot
-// operations and store per-bucket counts in registers.
+// Note: my_size is limited to kWarpSize (32 on CUDA warp32, 64 on ROCm
+// wavefront64) because we use warp-level ballot operations and store per-bucket
+// counts in registers.
 
 template <typename offset_t, typename index_t>
 __global__
@@ -470,13 +471,16 @@ __launch_bounds__(kMaxThreads) void _populate_bucketized_permute_warp_parallel_k
     // Compute ballot for all buckets - no branch divergence!
     // All threads execute the same loop iterations
     for (int p = 0; p < my_size; p++) {
-      const unsigned int bucket_mask =
-          __ballot_sync(kFullWarpMask, valid && (my_bucket == p));
+      // ballot_sync() returns a width-correct mask (uint64_t on ROCm
+      // wavefront64, uint32_t on CUDA warp32). Pairing it with __popcll is
+      // required: a 32-bit mask + __popc would silently truncate lanes 32-63
+      // on AMD CDNA and undercount preceding elements.
+      const auto bucket_mask = ballot_sync(valid && (my_bucket == p));
 
       // Each thread checks if this is its bucket and stores the count
       // This is a simple conditional assignment, not a divergent branch
       if (my_bucket == p) {
-        preceding_count = __popc(bucket_mask & getLaneMaskLt());
+        preceding_count = __popcll(bucket_mask & getLaneMaskLt());
       }
     }
 
@@ -494,9 +498,9 @@ __launch_bounds__(kMaxThreads) void _populate_bucketized_permute_warp_parallel_k
     // but here we need the popcount for every bucket to update all
     // cumulative_counts entries.
     for (int p = 0; p < my_size; p++) {
-      const unsigned int bucket_mask =
-          __ballot_sync(kFullWarpMask, valid && (my_bucket == p));
-      cumulative_counts[p] += __popc(bucket_mask);
+      // Width-correct ballot + __popcll, same rationale as above.
+      const auto bucket_mask = ballot_sync(valid && (my_bucket == p));
+      cumulative_counts[p] += __popcll(bucket_mask);
     }
   }
 }

--- a/fbgemm_gpu/test/sparse/block_bucketize_warp_amd_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_warp_amd_test.py
@@ -1,0 +1,126 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+# AMD/ROCm wavefront64 regression guard for the warp-parallel
+# populate_bucketized_permute kernel.
+#
+# This is a deliberately *minimal* test module: it does NOT call
+# generate_opcheck_tests / extend_test_class, so no faketensor / aot_dispatch
+# opcheck variants are generated. That keeps this target free of the
+# pre-existing abstract-kernel/failures_dict coverage gaps and lets it gate
+# purely on numerical correctness of the warp kernel on wavefront64 hardware.
+#
+# The owning BUCK target forces the warp-parallel kernel on via
+# FBGEMM_NO_JK=1 + FBGEMM_BUCKETIZED_PERMUTE_WARP_KERNEL=1 and runs on the
+# amd-gpu (MI300) platform. With my_size <= kWarpSize and sequences longer than
+# 32 elements, lanes 32-63 of the 64-bit ballot are exercised; the pre-fix
+# 32-bit __popc truncated them, producing colliding output offsets. The fix
+# (width-correct ballot_sync + __popcll) makes the GPU warp kernel match the
+# CPU reference exactly.
+
+import unittest
+
+import fbgemm_gpu  # noqa: F401  # registers torch.ops.fbgemm operators
+import torch
+
+
+class BlockBucketizeWarpAmdTest(unittest.TestCase):
+    def test_warp_parallel_vs_reference_wavefront64(self) -> None:
+        """Warp-parallel populate_bucketized_permute must match the CPU
+        reference for sequences longer than 32 elements, which is the only
+        regime that exercises lanes 32-63 on wavefront64 (MI300/MI350)."""
+        if not torch.cuda.is_available():
+            self.skipTest("No GPU available")
+        torch.manual_seed(42)
+
+        # (my_size, block_size, lengths). Every config includes at least one
+        # sequence with length > 32 so lanes 32-63 are active; lengths > 64
+        # additionally exercise multi-chunk cumulative counting.
+        test_configs = [
+            # Canonical serving case: my_size=2, single length-64 sequence
+            # (one full wavefront, lanes 0-63 active) plus multi-chunk 128.
+            (2, 50, torch.tensor([64, 128, 33, 0, 1, 40])),
+            # Moderate bucket count, varied lengths spanning the boundary.
+            (8, 10, torch.tensor([33, 64, 65, 100, 0, 32])),
+            # Larger bucket count, multi-chunk.
+            (16, 5, torch.tensor([48, 96, 0, 17, 65])),
+            # Boundary my_size for the warp path, lengths past 32 and 64.
+            (32, 1, torch.tensor([33, 64, 65, 0, 128])),
+            # Many sequences to stress grid-level parallelism, all > 32.
+            (4, 10, torch.randint(33, 129, (256,))),
+        ]
+
+        for index_type in (torch.int, torch.long):
+            for my_size, block_size, lengths in test_configs:
+                lengths = lengths.to(index_type)
+                block_sizes = torch.tensor([block_size], dtype=index_type)
+                total = int(lengths.sum().item())
+                indices = torch.randint(
+                    0, my_size * block_size, (total,), dtype=index_type
+                )
+
+                # Ground truth + CPU reference (serial kernel).
+                (
+                    new_lengths_cpu,
+                    _,
+                    _,
+                    _,
+                    unbucketize_permute_ref,
+                    bucket_mapping_cpu,
+                ) = torch.ops.fbgemm.block_bucketize_sparse_features_inference(
+                    lengths,
+                    indices,
+                    False,
+                    True,
+                    block_sizes,
+                    my_size,
+                    None,
+                    return_bucket_mapping=True,
+                )
+                permute_cpu = torch.ops.fbgemm.populate_bucketized_permute(
+                    lengths,
+                    new_lengths_cpu,
+                    bucket_mapping_cpu,
+                )
+
+                # GPU warp-parallel kernel (forced on via the target's env).
+                (
+                    new_lengths_gpu,
+                    _,
+                    _,
+                    _,
+                    _,
+                    bucket_mapping_gpu,
+                ) = torch.ops.fbgemm.block_bucketize_sparse_features_inference(
+                    lengths.to(torch.accelerator.current_accelerator()),
+                    indices.to(torch.accelerator.current_accelerator()),
+                    False,
+                    True,
+                    block_sizes.to(torch.accelerator.current_accelerator()),
+                    my_size,
+                    None,
+                    return_bucket_mapping=True,
+                )
+                permute_gpu = torch.ops.fbgemm.populate_bucketized_permute(
+                    lengths.to(torch.accelerator.current_accelerator()),
+                    new_lengths_gpu,
+                    bucket_mapping_gpu,
+                ).cpu()
+
+                msg = (
+                    f"warp-parallel populate_bucketized_permute mismatch for "
+                    f"my_size={my_size}, block_size={block_size}, "
+                    f"index_type={index_type}, lengths={lengths.tolist()}"
+                )
+                # Output must be a permutation identical to the CPU paths.
+                torch.testing.assert_close(
+                    permute_gpu, permute_cpu, rtol=0, atol=0, msg=msg
+                )
+                torch.testing.assert_close(
+                    permute_gpu, unbucketize_permute_ref, rtol=0, atol=0, msg=msg
+                )


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2753

D88522379 added `_populate_bucketized_permute_warp_parallel_kernel`, which stores a warp ballot into a 32-bit `unsigned int` and counts with 32-bit `__popc`. On AMD CDNA (gfx9, wavefront64 — both MI300/gfx942 and MI350/gfx950, where `kWarpSize=64`), `__ballot_sync` returns a 64-bit mask, so lanes 32-63 are silently truncated on assignment and `__popc` ignores the upper 32 bits regardless. For any sequence longer than 32 elements this undercounts the preceding same-bucket elements, producing colliding output offsets in `bucketized_permute` — a non-bijective permute that scrambles sequence embeddings and shows up as an NE regression. NVIDIA (warp32) is unaffected because the mask fits in 32 bits and there are no lanes 32-63.

The fix uses the width-correct `fbgemm_gpu::ballot_sync()` wrapper (uint64_t on ROCm, uint32_t on CUDA; see `include/fbgemm_gpu/utils/cuda_prelude.cuh`) together with `__popcll` at both ballot sites in the kernel. The wrapper alone is insufficient — `__popc` would still truncate to 32 bits — so both changes are required. `getLaneMaskLt()` is already 64-bit on ROCm, so `bucket_mask & getLaneMaskLt()` stays width-correct on both platforms. Convention precedent: `fb/src/programmable_kernel/*.cuh` (ballot + `__popcll` under `__HIP_PLATFORM_AMD__`).

Why CI missed it: the warp kernel is gated behind the `BUCKETIZED_PERMUTE_WARP_KERNEL` feature gate, forced on only in the `block_bucketize` python test target, which runs `remote_execution` on `gpu-remote-execution` (NVIDIA) only. The `skipIfRocm` decorators on the new tests were removed by D98170856, but with no AMD remote-execution branch the forced-on warp path never executed on wavefront64. This diff adds a dedicated, opcheck-free `block_bucketize_warp_amd` target that runs the warp-vs-CPU correctness comparison (sequences > 32 so lanes 32-63 are exercised) on `amd-gpu`/MI300 with the gate forced on. It is intentionally separate from the shared `block_bucketize` suite so it does not inherit that suite's pre-existing abstract-kernel/`failures_dict.json` opcheck coverage gaps on AMD (tracked separately).

Differential Revision: D107425842


