### PR TITLE
Add eviction writeback callback to FeatureEvict (#5832)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/ssd_config.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/ssd_config.py
@@ -83,6 +83,9 @@ class EvictionPolicy(NamedTuple):
     enable_eviction_for_feature_score_eviction_policy: list[bool] | None = (
         None  # enable eviction if eviction policy is feature score, false means no eviction
     )
+    enable_ssd_writeback: bool = (
+        False  # when True, evicted dirty blocks are written back to SSD via callback; when False, eviction deletes blocks directly
+    )
 
     def validate(self) -> None:
         assert self.eviction_trigger_mode in [0, 1, 2, 3, 4, 5], (

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/training.py
@@ -956,6 +956,7 @@ class SSDTableBatchedEmbeddingBags(nn.Module):
                     eviction_policy.interval_for_insufficient_eviction_s,
                     eviction_policy.interval_for_sufficient_eviction_s,
                     eviction_policy.interval_for_feature_statistics_decay_s,
+                    eviction_policy.enable_ssd_writeback,
                 )
             enrichment_config = None
             if (

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/feature_evict.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/feature_evict.h
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <functional>
 #include <memory_resource>
 #include <stdexcept>
 #include <vector>
@@ -28,6 +29,11 @@
 #include "SynchronizedShardedMap.h"
 
 namespace kv_mem {
+
+// Callback for writing evicted dirty blocks to SSD.
+// Parameters: vector of (key, serialized_block_data) pairs.
+using EvictionWritebackCallback =
+    std::function<void(std::vector<std::pair<int64_t, std::string>>)>;
 
 enum class EvictTriggerMode {
   DISABLED, // Do not use feature evict
@@ -119,7 +125,8 @@ struct FeatureEvictConfig : public torch::jit::CustomClassHolder {
       std::optional<int64_t> threshold_calculation_bucket_num = 1000000, // 1M
       int64_t interval_for_insufficient_eviction_s = 600, // 10 min
       int64_t interval_for_sufficient_eviction_s = 60, // 1 min
-      int64_t interval_for_feature_statistics_decay_s = 24 * 3600) // 1 day
+      int64_t interval_for_feature_statistics_decay_s = 24 * 3600, // 1 day
+      bool enable_ssd_writeback = false)
       : trigger_mode_(static_cast<EvictTriggerMode>(trigger_mode)),
         trigger_strategy_(static_cast<EvictTriggerStrategy>(trigger_strategy)),
         trigger_step_interval_(trigger_step_interval),
@@ -143,7 +150,8 @@ struct FeatureEvictConfig : public torch::jit::CustomClassHolder {
             interval_for_insufficient_eviction_s),
         interval_for_sufficient_eviction_s_(interval_for_sufficient_eviction_s),
         interval_for_feature_statistics_decay_s_(
-            interval_for_feature_statistics_decay_s) {
+            interval_for_feature_statistics_decay_s),
+        enable_ssd_writeback_(enable_ssd_writeback) {
     // verification
     if (trigger_mode_ == EvictTriggerMode::DISABLED) {
       LOG(INFO) << "eviction config, trigger mode is disabled";
@@ -214,7 +222,8 @@ struct FeatureEvictConfig : public torch::jit::CustomClassHolder {
                   << to_string(trigger_mode_) << eviction_trigger_stats_log
                   << ", strategy: " << to_string(trigger_strategy_)
                   << ", counter_thresholds: " << counter_thresholds_.value()
-                  << ", counter_decay_rates: " << counter_decay_rates_.value();
+                  << ", counter_decay_rates: " << counter_decay_rates_.value()
+                  << ", enable_ssd_writeback: " << enable_ssd_writeback_;
         return;
       }
 
@@ -238,7 +247,8 @@ struct FeatureEvictConfig : public torch::jit::CustomClassHolder {
                   << ", feature_score_counter_decay_rates: "
                   << feature_score_counter_decay_rates_.value()
                   << ", enable_eviction_for_feature_score_eviction_policy: "
-                  << enable_eviction_for_feature_score_eviction_policy_.value();
+                  << enable_eviction_for_feature_score_eviction_policy_.value()
+                  << ", enable_ssd_writeback: " << enable_ssd_writeback_;
         return;
       }
 
@@ -247,7 +257,8 @@ struct FeatureEvictConfig : public torch::jit::CustomClassHolder {
         LOG(INFO) << "eviction config, trigger mode:"
                   << to_string(trigger_mode_) << eviction_trigger_stats_log
                   << ", strategy: " << to_string(trigger_strategy_)
-                  << ", ttls_in_mins: " << ttls_in_mins_.value();
+                  << ", ttls_in_mins: " << ttls_in_mins_.value()
+                  << ", enable_ssd_writeback: " << enable_ssd_writeback_;
         return;
       }
 
@@ -260,7 +271,8 @@ struct FeatureEvictConfig : public torch::jit::CustomClassHolder {
                   << ", strategy: " << to_string(trigger_strategy_)
                   << ", counter_thresholds: " << counter_thresholds_.value()
                   << ", counter_decay_rates: " << counter_decay_rates_.value()
-                  << ", ttls_in_mins: " << ttls_in_mins_.value();
+                  << ", ttls_in_mins: " << ttls_in_mins_.value()
+                  << ", enable_ssd_writeback: " << enable_ssd_writeback_;
         return;
       }
 
@@ -271,14 +283,16 @@ struct FeatureEvictConfig : public torch::jit::CustomClassHolder {
                   << to_string(trigger_mode_) << eviction_trigger_stats_log
                   << ", strategy: " << to_string(trigger_strategy_)
                   << ", l2_weight_thresholds: " << l2_weight_thresholds_.value()
-                  << ", embedding_dims: " << embedding_dims_.value();
+                  << ", embedding_dims: " << embedding_dims_.value()
+                  << ", enable_ssd_writeback: " << enable_ssd_writeback_;
         return;
       }
 
       case EvictTriggerStrategy::BY_TIMESTAMP_THRESHOLD: {
         LOG(INFO) << "eviction config, trigger mode:"
                   << to_string(trigger_mode_) << eviction_trigger_stats_log
-                  << ", strategy: " << to_string(trigger_strategy_);
+                  << ", strategy: " << to_string(trigger_strategy_)
+                  << ", enable_ssd_writeback: " << enable_ssd_writeback_;
         break;
       }
 
@@ -306,6 +320,7 @@ struct FeatureEvictConfig : public torch::jit::CustomClassHolder {
   int64_t interval_for_insufficient_eviction_s_;
   int64_t interval_for_sufficient_eviction_s_;
   int64_t interval_for_feature_statistics_decay_s_;
+  bool enable_ssd_writeback_;
 };
 
 struct FeatureEvictMetrics {
@@ -415,6 +430,7 @@ class FeatureEvict {
       int64_t interval_for_sufficient_eviction_s,
       int64_t interval_for_feature_statistics_decay_s,
       bool is_training = true,
+      bool enable_ssd_writeback = false,
       TestMode test_mode = TestMode::DISABLED)
       : kv_store_(kv_store),
         evict_state_(EvictState::Idle),
@@ -430,7 +446,8 @@ class FeatureEvict {
         interval_for_feature_statistics_decay_s_(
             interval_for_feature_statistics_decay_s),
         is_training_(is_training),
-        test_mode_(test_mode) {
+        test_mode_(test_mode),
+        enable_ssd_writeback_(enable_ssd_writeback) {
     executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(num_shards_);
 
     init_shard_status();
@@ -554,6 +571,35 @@ class FeatureEvict {
     futures_.clear();
   }
 
+  // Set the writeback callback for eviction-to-SSD writeback.
+  // Must be public so the composite backend (DramSsdKVEmbeddingCache)
+  // can wire this callback.
+  // Precondition: must be called once during setup, before any eviction
+  // is triggered. `writeback_callback_` is read without synchronization
+  // from worker threads in the eviction loops, so concurrent mutation
+  // would be a data race (`std::function` is not safe for concurrent
+  // read/write).
+  void set_writeback_callback(kv_mem::EvictionWritebackCallback cb) {
+    CHECK(!is_evicting())
+        << "set_writeback_callback must be called before any eviction is triggered";
+    writeback_callback_ = std::move(cb);
+  }
+
+  // Set whether SSD writeback is enabled for evicted dirty blocks.
+  // When false, eviction simply deletes blocks without invoking callback,
+  // even if callback is set. When true, dirty evicted blocks are serialized
+  // and passed to writeback_callback_.
+  // Must be called before any eviction is triggered.
+  void set_enable_ssd_writeback(bool enable) {
+    CHECK(!is_evicting())
+        << "set_enable_ssd_writeback must be called before any eviction is triggered";
+    enable_ssd_writeback_.store(enable);
+  }
+
+  bool get_enable_ssd_writeback() const {
+    return enable_ssd_writeback_.load();
+  }
+
  protected:
   void sanity_check_before_new_round() {
     CHECK_EQ(num_waiting_evicts_.load(), 0)
@@ -648,36 +694,69 @@ class FeatureEvict {
       int shard_id,
       std::vector<int64_t>& evicted_counts,
       std::vector<int64_t>& processed_counts) {
-    auto wlock = kv_store_.by(shard_id).wlock();
-    auto* pool = kv_store_.pool_by(shard_id);
+    // Capture the callback and SSD flag once into locals.
+    // `set_writeback_callback` and `set_enable_ssd_writeback` are required to
+    // be called before any eviction is triggered, but capturing locally also
+    // avoids any TOCTOU between the truthiness check and the post-lock
+    // invocation below.
+    auto writeback_callback = writeback_callback_;
+    bool enable_ssd_writeback = enable_ssd_writeback_.load();
 
-    while (!should_exit_evict_loop(shard_id)) {
-      auto* block =
-          pool->template get_block<weight_type>(block_cursors_[shard_id]++);
-      if (block == nullptr) {
-        continue;
-      }
-      int64_t key = FixedBlockPool::get_key(block);
-      int sub_table_id = get_sub_table_id(key);
-      processed_counts[sub_table_id]++;
-      if (evict_block(block, sub_table_id, shard_id)) {
-        auto it = wlock->find(key);
-        if (it != wlock->end() && block == it->second) {
-          auto time_elapsed = FixedBlockPool::current_timestamp() -
-              FixedBlockPool::get_timestamp(block);
-          if (time_elapsed < 1800) { // 30 mins
-            LOG_EVERY_N(WARNING, 1000)
-                << "Evicting key:" << key << " with " << time_elapsed
-                << " seconds, less than 30 mins elapsed since first seen,"
-                << " make sure this is expected";
-          }
-          wlock->erase(key);
-          pool->template deallocate_t<weight_type>(block);
-          evicted_counts[sub_table_id]++;
+    // Collect dirty evicted blocks for writeback to SSD.
+    // Collection happens while holding wlock (to access block data),
+    // but the callback is invoked after releasing wlock to avoid
+    // holding DRAM locks during SSD I/O.
+    std::vector<std::pair<int64_t, std::string>> writeback_batch;
+
+    {
+      auto wlock = kv_store_.by(shard_id).wlock();
+      auto* pool = kv_store_.pool_by(shard_id);
+
+      while (!should_exit_evict_loop(shard_id)) {
+        auto* block =
+            pool->template get_block<weight_type>(block_cursors_[shard_id]++);
+        if (block == nullptr) {
+          continue;
         }
-      } else {
-        rebuild_block_histogram(block, sub_table_id, shard_id);
+        int64_t key = FixedBlockPool::get_key(block);
+        int sub_table_id = get_sub_table_id(key);
+        processed_counts[sub_table_id]++;
+        if (evict_block(block, sub_table_id, shard_id)) {
+          auto it = wlock->find(key);
+          if (it != wlock->end() && block == it->second) {
+            auto time_elapsed = FixedBlockPool::current_timestamp() -
+                FixedBlockPool::get_timestamp(block);
+            if (time_elapsed < 1800) { // 30 mins
+              LOG_EVERY_N(WARNING, 1000)
+                  << "Evicting key:" << key << " with " << time_elapsed
+                  << " seconds, less than 30 mins elapsed since first seen,"
+                  << " make sure this is expected";
+            }
+            // Serialize dirty block data before erase+deallocate
+            if (pool->get_dirty(block) && enable_ssd_writeback &&
+                writeback_callback) {
+              size_t block_size = pool->get_block_size();
+              std::string block_data(
+                  reinterpret_cast<const char*>(block), block_size);
+              writeback_batch.emplace_back(key, std::move(block_data));
+            }
+            wlock->erase(key);
+            pool->template deallocate_t<weight_type>(block);
+            evicted_counts[sub_table_id]++;
+          }
+        } else {
+          rebuild_block_histogram(block, sub_table_id, shard_id);
+        }
       }
+    } // wlock released here
+
+    // Invoke writeback callback after releasing wlock
+    if (enable_ssd_writeback && writeback_callback &&
+        !writeback_batch.empty()) {
+      LOG(INFO) << "[FeatureEvict] training eviction shard " << shard_id << ": "
+                << writeback_batch.size()
+                << " dirty blocks sent to SSD writeback";
+      writeback_callback(std::move(writeback_batch));
     }
   }
 
@@ -688,6 +767,14 @@ class FeatureEvict {
       std::vector<int64_t>& processed_counts) {
     auto* pool = kv_store_.pool_by(shard_id);
     auto mem_pool_lock = pool->acquire_lock();
+
+    // Capture the callback and SSD flag once into locals; see comment in
+    // start_training_eviction_loop.
+    auto writeback_callback = writeback_callback_;
+    bool enable_ssd_writeback = enable_ssd_writeback_.load();
+
+    // Collect dirty evicted blocks for writeback to SSD.
+    std::vector<std::pair<int64_t, std::string>> writeback_batch;
 
     std::vector<int64_t> evicting_keys;
     evicting_keys.reserve(block_nums_snapshot_[shard_id] / 100);
@@ -701,6 +788,14 @@ class FeatureEvict {
       int sub_table_id = get_sub_table_id(key);
       processed_counts[sub_table_id]++;
       if (evict_block(block, sub_table_id, shard_id)) {
+        // Serialize dirty block data before deallocate
+        if (pool->get_dirty(block) && enable_ssd_writeback &&
+            writeback_callback) {
+          size_t block_size = pool->get_block_size();
+          std::string block_data(
+              reinterpret_cast<const char*>(block), block_size);
+          writeback_batch.emplace_back(key, std::move(block_data));
+        }
         pool->template deallocate_t<weight_type>(block);
         evicted_counts[sub_table_id]++;
         evicting_keys.push_back(key);
@@ -714,6 +809,13 @@ class FeatureEvict {
     auto shard_map_wlock = kv_store_.by(shard_id).wlock();
     for (auto& key : evicting_keys) {
       shard_map_wlock->erase(key);
+    }
+    shard_map_wlock.unlock();
+
+    // Invoke writeback callback after releasing all locks
+    if (enable_ssd_writeback && writeback_callback &&
+        !writeback_batch.empty()) {
+      writeback_callback(std::move(writeback_batch));
     }
   }
 
@@ -957,9 +1059,20 @@ class FeatureEvict {
   std::atomic<bool> should_call_ = false;
   std::vector<std::unique_ptr<std::atomic<bool>>> last_iter_shards_;
 
+  // Flag to control SSD writeback behavior for evicted dirty blocks.
+  // When true, dirty blocks are serialized and passed to writeback_callback_.
+  // When false, eviction deletes blocks directly without SSD interaction.
+  std::atomic<bool> enable_ssd_writeback_{false};
+
+  // Callback for writing dirty evicted blocks to SSD.
+  EvictionWritebackCallback writeback_callback_;
+
   FRIEND_TEST(FeatureEvictTest, DupAPINoOpCheck);
   FRIEND_TEST(FeatureEvictTest, EdgeCase_NoPause);
   FRIEND_TEST(FeatureEvictTest, EdgeCase_PauseOnLastIter);
+  FRIEND_TEST(FeatureEvictTest, WritebackCallbackDirtyBlocks);
+  FRIEND_TEST(FeatureEvictTest, WritebackCallbackNonDirtyBlocks);
+  FRIEND_TEST(FeatureEvictTest, WritebackCallbackInferenceEviction);
 };
 
 template <typename weight_type>
@@ -974,6 +1087,7 @@ class CounterBasedEvict : public FeatureEvict<weight_type> {
       int64_t interval_for_sufficient_eviction_s,
       int64_t interval_for_feature_statistics_decay_s,
       bool is_training,
+      bool enable_ssd_writeback = false,
       TestMode test_mode = TestMode::DISABLED)
       : FeatureEvict<weight_type>(
             kv_store,
@@ -982,6 +1096,7 @@ class CounterBasedEvict : public FeatureEvict<weight_type> {
             interval_for_sufficient_eviction_s,
             interval_for_feature_statistics_decay_s,
             is_training,
+            enable_ssd_writeback,
             test_mode),
         decay_rates_(decay_rates),
         thresholds_(thresholds) {
@@ -1029,6 +1144,7 @@ class FeatureScoreBasedEvict : public FeatureEvict<weight_type> {
       int64_t interval_for_sufficient_eviction_s,
       int64_t interval_for_feature_statistics_decay_s,
       bool is_training,
+      bool enable_ssd_writeback = false,
       TestMode test_mode = TestMode::DISABLED)
       : FeatureEvict<weight_type>(
             kv_store,
@@ -1037,6 +1153,7 @@ class FeatureScoreBasedEvict : public FeatureEvict<weight_type> {
             interval_for_sufficient_eviction_s,
             interval_for_feature_statistics_decay_s,
             is_training,
+            enable_ssd_writeback,
             test_mode),
         decay_rates_(decay_rates),
         training_id_eviction_trigger_count_(training_id_eviction_trigger_count),
@@ -1338,14 +1455,16 @@ class TimeBasedEvict : public FeatureEvict<weight_type> {
       int64_t interval_for_insufficient_eviction_s,
       int64_t interval_for_sufficient_eviction_s,
       int64_t interval_for_feature_statistics_decay_s,
-      bool is_training)
+      bool is_training,
+      bool enable_ssd_writeback = false)
       : FeatureEvict<weight_type>(
             kv_store,
             sub_table_hash_cumsum,
             interval_for_insufficient_eviction_s,
             interval_for_sufficient_eviction_s,
             interval_for_feature_statistics_decay_s,
-            is_training),
+            is_training,
+            enable_ssd_writeback),
         ttls_in_mins_(ttls_in_mins) {}
 
   void update_feature_statistics(weight_type* block) override {
@@ -1377,14 +1496,16 @@ class TimeThresholdBasedEvict : public FeatureEvict<weight_type> {
       int64_t interval_for_insufficient_eviction_s,
       int64_t interval_for_sufficient_eviction_s,
       int64_t interval_for_feature_statistics_decay_s,
-      bool is_training)
+      bool is_training,
+      bool enable_ssd_writeback = false)
       : FeatureEvict<weight_type>(
             kv_store,
             sub_table_hash_cumsum,
             interval_for_insufficient_eviction_s,
             interval_for_sufficient_eviction_s,
             interval_for_feature_statistics_decay_s,
-            is_training) {}
+            is_training,
+            enable_ssd_writeback) {}
 
   void update_feature_statistics(weight_type* block) override {
     FixedBlockPool::update_timestamp(block);
@@ -1415,14 +1536,16 @@ class TimeCounterBasedEvict : public FeatureEvict<weight_type> {
       int64_t interval_for_insufficient_eviction_s,
       int64_t interval_for_sufficient_eviction_s,
       int64_t interval_for_feature_statistics_decay_s,
-      bool is_training)
+      bool is_training,
+      bool enable_ssd_writeback = false)
       : FeatureEvict<weight_type>(
             kv_store,
             sub_table_hash_cumsum,
             interval_for_insufficient_eviction_s,
             interval_for_sufficient_eviction_s,
             interval_for_feature_statistics_decay_s,
-            is_training),
+            is_training,
+            enable_ssd_writeback),
         ttls_in_mins_(ttls_in_mins),
         decay_rates_(decay_rates),
         thresholds_(thresholds) {}
@@ -1473,14 +1596,16 @@ class L2WeightBasedEvict : public FeatureEvict<weight_type> {
       int64_t interval_for_insufficient_eviction_s,
       int64_t interval_for_sufficient_eviction_s,
       int64_t interval_for_feature_statistics_decay_s,
-      bool is_training)
+      bool is_training,
+      bool enable_ssd_writeback = false)
       : FeatureEvict<weight_type>(
             kv_store,
             sub_table_hash_cumsum,
             interval_for_insufficient_eviction_s,
             interval_for_sufficient_eviction_s,
             interval_for_feature_statistics_decay_s,
-            is_training),
+            is_training,
+            enable_ssd_writeback),
         thresholds_(thresholds),
         sub_table_dims_(sub_table_dims) {}
 
@@ -1521,7 +1646,8 @@ std::unique_ptr<FeatureEvict<weight_type>> create_feature_evict(
           config->interval_for_insufficient_eviction_s_,
           config->interval_for_sufficient_eviction_s_,
           config->interval_for_feature_statistics_decay_s_,
-          is_training);
+          is_training,
+          config->enable_ssd_writeback_);
     }
 
     case EvictTriggerStrategy::BY_COUNTER: {
@@ -1540,6 +1666,7 @@ std::unique_ptr<FeatureEvict<weight_type>> create_feature_evict(
           config->interval_for_sufficient_eviction_s_,
           config->interval_for_feature_statistics_decay_s_,
           is_training,
+          config->enable_ssd_writeback_,
           test_mode);
     }
 
@@ -1565,6 +1692,7 @@ std::unique_ptr<FeatureEvict<weight_type>> create_feature_evict(
           config->interval_for_sufficient_eviction_s_,
           config->interval_for_feature_statistics_decay_s_,
           is_training,
+          config->enable_ssd_writeback_,
           test_mode);
     }
 
@@ -1584,7 +1712,8 @@ std::unique_ptr<FeatureEvict<weight_type>> create_feature_evict(
           config->interval_for_insufficient_eviction_s_,
           config->interval_for_sufficient_eviction_s_,
           config->interval_for_feature_statistics_decay_s_,
-          is_training);
+          is_training,
+          config->enable_ssd_writeback_);
     }
 
     case EvictTriggerStrategy::BY_L2WEIGHT: {
@@ -1607,7 +1736,8 @@ std::unique_ptr<FeatureEvict<weight_type>> create_feature_evict(
           config->interval_for_insufficient_eviction_s_,
           config->interval_for_sufficient_eviction_s_,
           config->interval_for_feature_statistics_decay_s_,
-          is_training);
+          is_training,
+          config->enable_ssd_writeback_);
     }
 
     case EvictTriggerStrategy::BY_TIMESTAMP_THRESHOLD: {
@@ -1617,7 +1747,8 @@ std::unique_ptr<FeatureEvict<weight_type>> create_feature_evict(
           config->interval_for_insufficient_eviction_s_,
           config->interval_for_sufficient_eviction_s_,
           config->interval_for_feature_statistics_decay_s_,
-          is_training);
+          is_training,
+          config->enable_ssd_writeback_);
     }
 
     default:

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_split_table_batched_embeddings.cpp
@@ -851,7 +851,8 @@ static auto feature_evict_config =
                 std::optional<int64_t>,
                 int64_t,
                 int64_t,
-                int64_t>(),
+                int64_t,
+                bool>(),
             "",
             {
                 torch::arg("trigger_mode"),
@@ -875,6 +876,7 @@ static auto feature_evict_config =
                 torch::arg("interval_for_sufficient_eviction_s") = 60,
                 torch::arg("interval_for_feature_statistics_decay_s") =
                     24 * 3600,
+                torch::arg("enable_ssd_writeback") = false,
             });
 
 static auto embedding_snapshot_handle_wrapper =

--- a/fbgemm_gpu/test/dram_kv_embedding_cache/feature_evict_test.cpp
+++ b/fbgemm_gpu/test/dram_kv_embedding_cache/feature_evict_test.cpp
@@ -12,6 +12,7 @@
 #include <cstdio>
 #include <iostream>
 #include <limits>
+#include <set>
 
 #include <fmt/format.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
@@ -748,6 +749,7 @@ TEST(FeatureEvictTest, PerformanceTest) {
         0,
         0,
         true, // is training
+        false, // enable_ssd_writeback
         TestMode::NORMAL);
 
     auto start_time = std::chrono::high_resolution_clock::now();
@@ -1166,4 +1168,352 @@ TEST(FeatureEvictTest, EdgeCase_PauseOnLastIter) {
   // for executors to finish
   std::this_thread::sleep_for(std::chrono::milliseconds(5));
 }
+// Test that dirty blocks trigger the writeback callback during training
+// eviction
+TEST(FeatureEvictTest, WritebackCallbackDirtyBlocks) {
+  static constexpr int NUM_SHARDS = 8;
+  auto kv_store_ = std::make_unique<SynchronizedShardedMap<int64_t, float*>>(
+      NUM_SHARDS,
+      BLOCK_SIZE,
+      BLOCK_ALIGNMENT,
+      /*blocks_per_chunk=*/8192,
+      /*enable_dirty_tracking=*/true);
+
+  std::vector<int64_t> sub_table_hash_cumsum = {1000};
+
+  // Insert blocks: keys 0-399 with count=1 (will be evicted, threshold=1),
+  // keys 400-999 with count=2 (will NOT be evicted).
+  // Mark keys 0-199 as dirty, keys 200-399 as not dirty.
+  for (int i = 0; i < 1000; ++i) {
+    int shard_id = i % NUM_SHARDS;
+    auto wlock = kv_store_->by(shard_id).wlock();
+    auto* pool = kv_store_->pool_by(shard_id);
+    auto* block = pool->allocate_t<float>();
+    FixedBlockPool::set_key(block, i);
+    FixedBlockPool::set_count(block, i < 400 ? 1 : 2);
+    FixedBlockPool::set_used(block, true);
+    if (i < 200) {
+      pool->set_dirty(block, true);
+    } else {
+      pool->set_dirty(block, false);
+    }
+    wlock->insert({i, block});
+  }
+
+  // Track writeback callback invocations
+  std::mutex cb_mutex;
+  std::vector<std::pair<int64_t, std::string>> all_writeback_pairs;
+
+  std::vector<int64_t> counter_thresholds = {1};
+  std::vector<double> counter_decay_rates = {0.5};
+  c10::intrusive_ptr<FeatureEvictConfig> feature_evict_config =
+      c10::make_intrusive<FeatureEvictConfig>(
+          2,
+          1,
+          std::nullopt,
+          2,
+          std::nullopt,
+          counter_thresholds,
+          counter_decay_rates,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          0,
+          0,
+          0,
+          true);
+
+  auto feature_evict = create_feature_evict(
+      feature_evict_config,
+      *kv_store_.get(),
+      sub_table_hash_cumsum,
+      true,
+      TestMode::NORMAL);
+
+  // Set writeback callback
+  feature_evict->set_writeback_callback(
+      [&](std::vector<std::pair<int64_t, std::string>> batch) {
+        std::lock_guard<std::mutex> lock(cb_mutex);
+        for (auto& pair : batch) {
+          all_writeback_pairs.push_back(std::move(pair));
+        }
+      });
+
+  // Trigger and run eviction
+  feature_evict->trigger_evict();
+  feature_evict->resume();
+  feature_evict->wait_until_eviction_done();
+
+  // Verify: only dirty evicted blocks (keys 0-199) should be in writeback
+  std::set<int64_t> writeback_keys;
+  {
+    std::lock_guard<std::mutex> lock(cb_mutex);
+    for (const auto& [key, data] : all_writeback_pairs) {
+      writeback_keys.insert(key);
+      // Verify block data size matches expected block size
+      EXPECT_EQ(data.size(), BLOCK_SIZE);
+    }
+  }
+
+  // Only dirty evicted keys (0-199) should be written back; non-dirty
+  // evicted keys (200-399) and non-evicted keys (400-999) should not.
+  std::set<int64_t> expected_writeback_keys;
+  for (int i = 0; i < 200; ++i) {
+    expected_writeback_keys.insert(i);
+  }
+  EXPECT_EQ(writeback_keys, expected_writeback_keys);
+}
+
+// Test that non-dirty blocks do NOT trigger writeback callback
+TEST(FeatureEvictTest, WritebackCallbackNonDirtyBlocks) {
+  static constexpr int NUM_SHARDS = 8;
+  // Dirty tracking must be enabled so that set_dirty/get_dirty are honored;
+  // otherwise get_dirty always returns false and the test would pass even if
+  // the dirty-gating logic were broken.
+  auto kv_store_ = std::make_unique<SynchronizedShardedMap<int64_t, float*>>(
+      NUM_SHARDS,
+      BLOCK_SIZE,
+      BLOCK_ALIGNMENT,
+      /*blocks_per_chunk=*/8192,
+      /*enable_dirty_tracking=*/true);
+
+  std::vector<int64_t> sub_table_hash_cumsum = {1000};
+
+  // Insert blocks: all with count=1 (will be evicted), none dirty
+  for (int i = 0; i < 1000; ++i) {
+    int shard_id = i % NUM_SHARDS;
+    auto wlock = kv_store_->by(shard_id).wlock();
+    auto* pool = kv_store_->pool_by(shard_id);
+    auto* block = pool->allocate_t<float>();
+    FixedBlockPool::set_key(block, i);
+    FixedBlockPool::set_count(block, 1);
+    FixedBlockPool::set_used(block, true);
+    pool->set_dirty(block, false);
+    wlock->insert({i, block});
+  }
+
+  bool callback_invoked = false;
+
+  std::vector<int64_t> counter_thresholds = {1};
+  std::vector<double> counter_decay_rates = {0.5};
+  c10::intrusive_ptr<FeatureEvictConfig> feature_evict_config =
+      c10::make_intrusive<FeatureEvictConfig>(
+          2,
+          1,
+          std::nullopt,
+          2,
+          std::nullopt,
+          counter_thresholds,
+          counter_decay_rates,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          0,
+          0,
+          0,
+          true);
+
+  auto feature_evict = create_feature_evict(
+      feature_evict_config,
+      *kv_store_.get(),
+      sub_table_hash_cumsum,
+      true,
+      TestMode::NORMAL);
+
+  // Set writeback callback — should never be called
+  feature_evict->set_writeback_callback(
+      [&](std::vector<std::pair<int64_t, std::string>> batch) {
+        callback_invoked = true;
+      });
+
+  feature_evict->trigger_evict();
+  feature_evict->resume();
+  feature_evict->wait_until_eviction_done();
+
+  // No dirty blocks means callback should never be invoked
+  EXPECT_FALSE(callback_invoked);
+}
+
+// Test writeback callback for inference eviction path
+TEST(FeatureEvictTest, WritebackCallbackInferenceEviction) {
+  static constexpr int NUM_SHARDS = 8;
+  auto kv_store_ = std::make_unique<SynchronizedShardedMap<int64_t, float*>>(
+      NUM_SHARDS,
+      BLOCK_SIZE,
+      BLOCK_ALIGNMENT,
+      /*blocks_per_chunk=*/8192,
+      /*enable_dirty_tracking=*/true);
+
+  std::vector<int64_t> sub_table_hash_cumsum = {1000};
+
+  // Insert blocks: keys 0-399 with count=1 (will be evicted),
+  // keys 400-999 with count=2 (will NOT be evicted).
+  // Mark keys 0-99 as dirty.
+  for (int i = 0; i < 1000; ++i) {
+    int shard_id = i % NUM_SHARDS;
+    auto wlock = kv_store_->by(shard_id).wlock();
+    auto* pool = kv_store_->pool_by(shard_id);
+    auto* block = pool->allocate_t<float>();
+    FixedBlockPool::set_key(block, i);
+    FixedBlockPool::set_count(block, i < 400 ? 1 : 2);
+    FixedBlockPool::set_used(block, true);
+    if (i < 100) {
+      pool->set_dirty(block, true);
+    } else {
+      pool->set_dirty(block, false);
+    }
+    wlock->insert({i, block});
+  }
+
+  std::mutex cb_mutex;
+  std::vector<std::pair<int64_t, std::string>> all_writeback_pairs;
+
+  std::vector<int64_t> counter_thresholds = {1};
+  std::vector<double> counter_decay_rates = {0.5};
+  c10::intrusive_ptr<FeatureEvictConfig> feature_evict_config =
+      c10::make_intrusive<FeatureEvictConfig>(
+          2,
+          1,
+          std::nullopt,
+          2,
+          std::nullopt,
+          counter_thresholds,
+          counter_decay_rates,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          0,
+          0,
+          0,
+          true);
+
+  // Create with is_training=false to use inference eviction path
+  auto feature_evict = create_feature_evict(
+      feature_evict_config,
+      *kv_store_.get(),
+      sub_table_hash_cumsum,
+      false,
+      TestMode::NORMAL);
+
+  feature_evict->set_writeback_callback(
+      [&](std::vector<std::pair<int64_t, std::string>> batch) {
+        std::lock_guard<std::mutex> lock(cb_mutex);
+        for (auto& pair : batch) {
+          all_writeback_pairs.push_back(std::move(pair));
+        }
+      });
+
+  feature_evict->trigger_evict();
+  feature_evict->resume();
+  feature_evict->wait_until_eviction_done();
+
+  // Verify: only dirty evicted blocks (keys 0-99) should be in writeback
+  std::set<int64_t> writeback_keys;
+  {
+    std::lock_guard<std::mutex> lock(cb_mutex);
+    for (const auto& [key, data] : all_writeback_pairs) {
+      writeback_keys.insert(key);
+      EXPECT_EQ(data.size(), BLOCK_SIZE);
+    }
+  }
+
+  // Only dirty evicted keys (0-99) should be written back.
+  std::set<int64_t> expected_writeback_keys;
+  for (int i = 0; i < 100; ++i) {
+    expected_writeback_keys.insert(i);
+  }
+  EXPECT_EQ(writeback_keys, expected_writeback_keys);
+}
+
+// Test that when enable_ssd_writeback flag is false, callback is not invoked
+// even if dirty blocks are evicted and callback is set.
+TEST(FeatureEvictTest, WritebackDisabledByFlag) {
+  static constexpr int NUM_SHARDS = 8;
+  // Dirty tracking must be enabled so the inserted blocks are actually marked
+  // dirty. Without it, get_dirty always returns false and the eviction
+  // predicate short-circuits before the enable_ssd_writeback flag is checked,
+  // so the test would pass even if the flag were ignored.
+  auto kv_store_ = std::make_unique<SynchronizedShardedMap<int64_t, float*>>(
+      NUM_SHARDS,
+      BLOCK_SIZE,
+      BLOCK_ALIGNMENT,
+      /*blocks_per_chunk=*/8192,
+      /*enable_dirty_tracking=*/true);
+
+  std::vector<int64_t> sub_table_hash_cumsum = {1000};
+
+  // Insert dirty blocks that will be evicted
+  for (int i = 0; i < 1000; ++i) {
+    int shard_id = i % NUM_SHARDS;
+    auto wlock = kv_store_->by(shard_id).wlock();
+    auto* pool = kv_store_->pool_by(shard_id);
+    auto* block = pool->allocate_t<float>();
+    FixedBlockPool::set_key(block, i);
+    FixedBlockPool::set_count(block, 1);
+    FixedBlockPool::set_used(block, true);
+    pool->set_dirty(block, true);
+    wlock->insert({i, block});
+  }
+
+  bool callback_invoked = false;
+
+  std::vector<int64_t> counter_thresholds = {1};
+  std::vector<double> counter_decay_rates = {0.5};
+  c10::intrusive_ptr<FeatureEvictConfig> feature_evict_config =
+      c10::make_intrusive<FeatureEvictConfig>(
+          2,
+          1,
+          std::nullopt,
+          2,
+          std::nullopt,
+          counter_thresholds,
+          counter_decay_rates,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          0,
+          0,
+          0,
+          false); // SSD writeback disabled
+
+  auto feature_evict = create_feature_evict(
+      feature_evict_config,
+      *kv_store_.get(),
+      sub_table_hash_cumsum,
+      true,
+      TestMode::NORMAL);
+
+  // Set writeback callback — should never be called because flag is false
+  feature_evict->set_writeback_callback(
+      [&](std::vector<std::pair<int64_t, std::string>> batch) {
+        callback_invoked = true;
+      });
+
+  feature_evict->trigger_evict();
+  feature_evict->resume();
+  feature_evict->wait_until_eviction_done();
+
+  EXPECT_FALSE(callback_invoked);
+}
+
 } // namespace kv_mem


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2754

Add EvictionWritebackCallback type and wire it through FeatureEvict eviction loops. When a dirty block is evicted from DRAM, its data is serialized and passed to the callback for writeback to SSD. The callback is invoked after releasing the DRAM shard lock to avoid holding locks during SSD I/O.

Reviewed By: EddyLXJ

Differential Revision: D107491725


