### PR TITLE
Wrap `.item()` args to `torch._check*` helpers in `cast` for stricter typing (#5834)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training_common.py
@@ -9,6 +9,7 @@
 
 
 import torch  # usort:skip
+from typing import cast
 from torch import Tensor  # usort:skip
 from torch.compiler import is_compiling as is_torchdynamo_compiling  # usort:skip
 
@@ -56,7 +57,7 @@ def generate_vbe_metadata(
 
         max_B = total_batch_size_per_feature.max().item()
         if not torch.jit.is_scripting() and is_torchdynamo_compiling():
-            torch._check_is_size(max_B)
+            torch._check_is_size(cast(int, max_B))
             torch._check(max_B < offsets.numel())
 
         Bs = torch.concat([zero_tensor, total_batch_size_per_feature])
@@ -70,7 +71,7 @@ def generate_vbe_metadata(
         )
         max_B_feature_rank = B_feature_rank.max().item()
         if not torch.jit.is_scripting() and is_torchdynamo_compiling():
-            torch._check_is_size(max_B_feature_rank)
+            torch._check_is_size(cast(int, max_B_feature_rank))
             torch._check(max_B_feature_rank <= offsets.size(0))
         output_sizes_feature_rank = B_feature_rank.transpose(
             0, 1
@@ -83,7 +84,7 @@ def generate_vbe_metadata(
         )
         output_size = output_offsets_feature_rank[-1].item()
         if not torch.jit.is_scripting() and is_torchdynamo_compiling():
-            torch._check_is_size(output_size)
+            torch._check_is_size(cast(int, output_size))
 
         # TODO: Support INT8 output
         # B_offsets_rank_per_feature is for rank and (b, t) mapping


### PR DESCRIPTION
Summary:

X-link: https://github.com/meta-pytorch/torchrec/pull/4320

X-link: https://github.com/facebookresearch/FBGEMM/pull/2757

The SymInt magic-method typing change added strict annotations to the previously-untyped `torch._check`, `torch._check_is_size`, and `torch._constrain_as_size` helpers (`cond: bool | SymBool`, `i`/`symbol: IntLikeType`). Call sites that pass a `Tensor.item()` result into these helpers now fail type checking, because `Tensor.item()` is typed `bool | float | int`, which is not assignable to `IntLikeType` or `bool | SymBool`. The values are genuinely int/bool-like here (tensor sizes and boolean comparison results); the error comes purely from `item()`'s necessarily-broad return type.

This wraps the offending arguments in `typing.cast(int, ...)` / `typing.cast(bool, ...)`. `typing.cast` is erased at runtime, so behavior is unchanged. We deliberately do not use `int(...)` / `bool(...)`: under `torch.compile` / `torch.export` these `.item()` values are unbacked `SymInt` / `SymBool`, and forcing `int()` / `bool()` would trigger `GuardOnDataDependentSymNode` and alter runtime behavior.

Reviewed By: bobrenjc93

Differential Revision: D107556825


