### PR TITLE
Add `PROCESS_BLOCK` macro for grad accumulation loop unrolling (#5835)

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_device_kernel_template.cuh
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_device_kernel_template.cuh
@@ -14,6 +14,103 @@
 
 using namespace fbgemm_gpu;
 
+{#- /* These helper macros are only used by `compute_grad_sum` below, which is
+    rendered multiple times  based on TBE config variants.
+    `#undef` block is set later after the calls. */ #}
+{%- if is_rocm and not gen_once %}
+// Helper macro: Generate block_size grad_offset_j_i variables (i from 1 to block_size-1)
+#define GRAD_OFFSET(i, j) const auto grad_offset_j_##i = SHFL_SYNC(grad_offset, j + i);
+#define L(i, j) int32_t l_j_##i = SHFL_SYNC(l, j + i);
+#define B(i, j) int32_t b_j_##i = SHFL_SYNC(b, j + i);
+#define D_START(i, j) int32_t D_start_j_##i = SHFL_SYNC(D_start, j + i);
+#define IDX_WEIGHT(i, j) at::acc_type<cache_t, true> idx_weight_j_##i = SHFL_SYNC(idx_weight, j + i);
+
+#define REPEAT_8(X, j) X(1, j); X(2, j); X(3, j); X(4, j); X(5, j); X(6, j); X(7, j);
+#define REPEAT_4(X, j) X(1, j); X(2, j); X(3, j);
+#define REPEAT_2(X, j) X(1, j);
+#define REPEAT_1(X, j)  // No additional variables needed for block size 1
+
+#define REPEAT_I_S_8(X, j, m, n) X(1, j, m, n); X(2, j, m, n); X(3, j, m, n); X(4, j, m, n); X(5, j, m, n); X(6, j, m, n); X(7, j, m, n);
+#define REPEAT_I_S_4(X, j, m, n) X(1, j, m, n); X(2, j, m, n); X(3, j, m, n);
+#define REPEAT_I_S_2(X, j, m, n) X(1, j, m, n);
+#define REPEAT_I_S_1(X, j, m, n)  // No additional variables needed for block size 1
+
+// Helper macro: Generate block_size Vec4TAcc objects (i from 1 to block_size-1)
+// if nobag and is_index_select
+#define GRAD_VEC_N_I(i, grad_offset, grad_stride, d) Vec4TAcc<grad_t> grad_out_vec_##i(&grad_output[grad_offset + l_j_##i * grad_stride + d]);
+// elif nobag
+#define GRAD_VEC_N(i, d) Vec4TAcc<grad_t> grad_out_vec_##i(&grad_output[l_j_##i][d]);
+// elif vbe
+#define GRAD_VEC_V(i, d) Vec4TAcc<grad_t> grad_out_vec_##i(&grad_output[0][grad_offset_j_##i + d]);
+// else
+#define GRAD_VEC(i, d) Vec4TAcc<grad_t> grad_out_vec_##i(&grad_output[b_j_##i][0] + D_start_j_##i + d);
+
+// Helper macro: Generate block_size fma_ calls (i from 1 to block_size-1)
+#define FMA_GRAD(i, vec) grad_sum[vec].fma_(grad_out_vec_##i, idx_weight_j_##i);
+// Helper macro: Generate block_size add_ calls (i from 1 to block_size-1)
+#define ADD_GRAD(i, vec) grad_sum[vec].add_(grad_out_vec_##i);
+
+// Core macro: Process blocks of specified size (block_size = 8/4/2/1)
+// Parameters:
+// - block_size: Size of each block to process
+// - unroll_count: Number of unroll iterations for the inner loop
+#define PROCESS_BLOCK(block_size, unroll_count, grad_sum, grad_output, grad_offset, vec_start, kThreadGroupSize, threadIdx_x, VEC_WIDTH, D, j, sl, sl_end) \
+    for (; j + (block_size - 1) < kThreadGroupSize && sl + j + (block_size - 1) < sl_end; j += block_size) { \
+        {%- if nobag %}
+        int32_t l_j_0 = SHFL_SYNC(l, j); \
+        REPEAT_##block_size(L, j) \
+        {%- elif vbe %}
+        /* Generate block_size grad_offset_j_0 ~ grad_offset_j_(block_size-1) */ \
+        const auto grad_offset_j_0 = SHFL_SYNC(grad_offset, j); \
+        /* Generate subsequent grad_offset_j_1 ~ grad_offset_j_(block_size-1) based on block size */ \
+        REPEAT_##block_size(GRAD_OFFSET, j) \
+        {%- else %}
+        int32_t b_j_0 = SHFL_SYNC(b, j); \
+        REPEAT_##block_size(B, j) \
+        int32_t D_start_j_0 = SHFL_SYNC(D_start, j); \
+        REPEAT_##block_size(D_START, j) \
+        {%- endif %}
+        {%- if weighted %}
+        at::acc_type<cache_t, true> idx_weight_j_0 = SHFL_SYNC(idx_weight, j); \
+        REPEAT_##block_size(IDX_WEIGHT, j) \
+        {%- endif %}
+        {%- set d = "(((vec + vec_start) * kThreadGroupSize + threadIdx.x) * VEC_WIDTH)" %}
+        \
+        for (int32_t vec = 0; vec < unroll_count && (((vec + vec_start) * kThreadGroupSize + threadIdx_x) * VEC_WIDTH) < D; ++vec) { \
+            const int32_t d = (((vec + vec_start) * kThreadGroupSize + threadIdx_x) * VEC_WIDTH); \
+            /* Generate block_size Vec4TAcc objects and accumulate them */ \
+            Vec4TAcc<grad_t> grad_out_vec_0( \
+                {%- if nobag and is_index_select %}
+                &grad_output[grad_offset + l_j_0 * grad_stride + d] \
+                {%- elif nobag %}
+                &grad_output[l_j_0][d] \
+                {%- elif vbe %}
+                &grad_output[0][grad_offset_j_0 + d] \
+                {%- else %}
+                &grad_output[b_j_0][0] + D_start_j_0 + d \
+                {%- endif %}
+            ); \
+            {%- if nobag and is_index_select %}
+            REPEAT_I_S_##block_size(GRAD_VEC_N_I, grad_offset, grad_stride, d) \
+            {%- elif nobag %}
+            REPEAT_##block_size(GRAD_VEC_N, d) \
+            {%- elif vbe %}
+            REPEAT_##block_size(GRAD_VEC_V, d) \
+            {%- else %}
+            REPEAT_##block_size(GRAD_VEC, d) \
+            {%- endif %}
+            \
+            {%- if weighted %}
+            grad_sum[vec].fma_(grad_out_vec_0, idx_weight_j_0); \
+            REPEAT_##block_size(FMA_GRAD, vec) \
+            {%- else %}
+            grad_sum[vec].add_(grad_out_vec_0); \
+            REPEAT_##block_size(ADD_GRAD, vec) \
+            {%- endif %}
+        } \
+    }
+{%- endif %}
+
 {%- if gen_once %}
 {#- /*
     The kernels in this section will be generated only once for all TBE configs
@@ -141,7 +238,44 @@ DEVICE_INLINE void compute_grad_sum_{{ kdesc }}(
                 ? sorted_indice_weights[segment_start + sl_j]
                 : 0.0;
             {%- endif %}
-            for (int32_t j = 0; j < kThreadGroupSize && sl + j < sl_end; ++j) {
+            int32_t j = 0;
+
+            {%- if is_rocm %}
+            // Process blocks of different sizes with loop unrolling
+            if constexpr (sizeof(grad_t) <= 2) {
+                PROCESS_BLOCK(8, kFixedMaxVecsPerThread, grad_sum, grad_output, grad_offset, \
+                    vec_start, kThreadGroupSize, threadIdx.x, VEC_WIDTH, D, j, sl, sl_end)
+            }
+            PROCESS_BLOCK(4, kFixedMaxVecsPerThread, grad_sum, grad_output, grad_offset, \
+                vec_start, kThreadGroupSize, threadIdx.x, VEC_WIDTH, D, j, sl, sl_end)
+            PROCESS_BLOCK(2, kFixedMaxVecsPerThread, grad_sum, grad_output, grad_offset, \
+                vec_start, kThreadGroupSize, threadIdx.x, VEC_WIDTH, D, j, sl, sl_end)
+            PROCESS_BLOCK(1, kFixedMaxVecsPerThread, grad_sum, grad_output, grad_offset, \
+                vec_start, kThreadGroupSize, threadIdx.x, VEC_WIDTH, D, j, sl, sl_end)
+
+#undef PROCESS_BLOCK
+#undef GRAD_OFFSET
+#undef L
+#undef B
+#undef D_START
+#undef IDX_WEIGHT
+#undef REPEAT_8
+#undef REPEAT_4
+#undef REPEAT_2
+#undef REPEAT_1
+#undef REPEAT_I_S_8
+#undef REPEAT_I_S_4
+#undef REPEAT_I_S_2
+#undef REPEAT_I_S_1
+#undef GRAD_VEC_N_I
+#undef GRAD_VEC_N
+#undef GRAD_VEC_V
+#undef GRAD_VEC
+#undef FMA_GRAD
+#undef ADD_GRAD
+
+            {%- else %}
+            for (; j < kThreadGroupSize && sl + j < sl_end; ++j) {
                 {%- if nobag %}
                 int32_t l_j = SHFL_SYNC(l, j);
                 {%- elif vbe %}
@@ -180,6 +314,7 @@ DEVICE_INLINE void compute_grad_sum_{{ kdesc }}(
                     {%- endif %}
                 }
             }
+            {%- endif %}
         }
         {%- set d_vec = "((vec + vec_start) * kThreadGroupSize + threadIdx.x)" %}
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2758

On ROCm, replace the single-element gradient accumulation loop in `compute_grad_sum` with a cascading block-size unrolling scheme (`PROCESS_BLOCK` with block sizes 8/4/2/1) that processes multiple segment elements per iteration. Each block manually unrolls the per-element `SHFL_SYNC` metadata broadcasts and `Vec4TAcc` gradient loads, so several independent `grad_output` loads are issued before accumulation. This increases instruction-level parallelism, hides global-memory latency across the block, and reduces loop/branch overhead. The 8-wide block is gated on `sizeof(grad_t) <= 2` (fp16) to bound register pressure.

`compute_grad_sum` lives in the shared `embedding_backward_split_device_kernel_template.cuh`, which is `#include`d by both the CTA and warp backward kernels, so both benefit. The CTA kernel processes long, high-collision segments (many loop iterations to amortize the unrolling over) and gains the most; the warp kernel processes short segments and sees a smaller but consistent gain. The NVIDIA code path is unchanged. The helper macros are gated on `not gen_once` (they are only used by `compute_grad_sum`) and `#undef`'d after use, so they never leak into downstream translation units.

Benchmarks on MI350 (fp32 weights/output, `rowwise_adagrad`, no flag), backward kernel time in us, positive = faster.

## TBE sweep over T, D, B

Backward CTA kernel:
```
   T      D        B    baseline   optimized   speedup
   1      8     2048         103          60      +42.4%
   1      8     4096         201         113      +43.8%
   1      8   131072         527         299      +43.3%
   1    128     2048         844          67      +92.1%
   1    128     4096        1195         124      +89.6%
   1    128   131072         697         402      +42.4%
   1    256     2048         n/a          67       (*)
   1    256     4096         259         126      +51.3%
   1    256   131072         834         725      +13.1%
   1    512     2048         339          76      +77.5%
   1    512     4096         375         163      +56.6%
   1    512   131072        1435        1427       +0.6%
   1   1024     2048         398         172      +56.9%
   1   1024     4096         828         341      +58.9%
   1   1024   131072        2942        3092       -5.1%
  10      8     2048         367          71      +80.6%
  10      8     4096        1466         145      +90.1%
  10      8   131072        4835        2404      +50.3%
  10    128     2048         605          89      +85.2%
  10    128     4096           5(*)      184       (*)
  10    128   131072        6323        3694      +41.6%
  10    256     2048         207         106      +48.9%
  10    256     4096         431         228      +47.0%
  10    256   131072        8241        7047      +14.5%
  10    512     2048         252         178      +29.2%
  10    512     4096         540         383      +29.0%
  10    512   131072       17449       14523      +16.8%
```

Backward warp kernel:
```
   T      D        B    baseline   optimized   speedup
   1      8     2048          48          43      +10.4%
   1      8     4096          75          70       +6.0%
   1      8   131072        1353        1196      +11.6%
   1    128     2048         544          47      +91.4%
   1    128     4096         284          78      +72.6%
   1    128   131072        1457        1398       +4.0%
   1    256     2048         n/a          49       (*)
   1    256     4096          95          86       +9.2%
   1    256   131072        1772        1688       +4.7%
   1    512     2048          76          65      +14.3%
   1    512     4096         134         119      +11.1%
   1    512   131072        2462        2353       +4.4%
   1   1024     2048         146         119      +18.5%
   1   1024     4096         254         219      +14.0%
   1   1024   131072        4412        4242       +3.9%
  10      8     2048         899         349      +61.2%
  10      8     4096         696         666       +4.3%
  10      8   131072       12261       11890       +3.0%
  10    128     2048        4461         423      +90.5%
  10    128     4096        2069         773      +62.7%
  10    128   131072       15498       15427       +0.5%
  10    256     2048         513         492       +4.1%
  10    256     4096         921         892       +3.1%
  10    256   131072       23360       17836      +23.6%
  10    512     2048         686         648       +5.5%
  10    512     4096        1236        1183       +4.3%
  10    512   131072       25658       29404      -14.6%
```

## bench_list (representative production mixed-D configs)

Backward CTA kernel:
```
      bench    T          Ds    baseline   optimized   speedup
  bench_103    2           8          18          15      +18.1%
    bench_0   10         128         488         140      +71.3%
    bench_2   14   12/24/128         256         138      +46.3%
    bench_1   18      20/128         400         142      +64.6%
   bench_27   22   20/24/128         311         154      +50.4%
      TOTAL                         1474         588      +60.1%
```

Backward warp kernel:
```
      bench    T          Ds    baseline   optimized   speedup
  bench_103    2           8          57          51       +9.8%
    bench_0   10         128         364         252      +30.6%
    bench_2   14   12/24/128         236         237       -0.5%
    bench_1   18      20/128         173         167       +3.5%
   bench_27   22   20/24/128         276         270       +2.2%
      TOTAL                         1106         978      +11.6%
```

## VBE (variable batch size, by alpha skew)

```
kernel    a       baseline   optimized   speedup
CTA       1              4           4       -0.1%
CTA       1.15         299         130      +56.6%
warp      1            126         129       -2.4%
warp      1.15          65          58      +11.5%
```

(*) Two CTA sweep baseline cells are measurement artifacts on this run and have no meaningful speedup: `T=1 D=256 B=2048` has no baseline sample, and `T=10 D=128 B=4096` recorded a spurious 5us baseline. The few negative outliers (e.g. CTA `T=1 D=1024 B=131072`, warp `T=10 D=512 B=131072`, VBE `a=1`) are within the cross-run measurement noise observed on this setup; `a=1` VBE is ~4us where noise dominates. CTA gains are largest for high-collision configs (long segments); warp gains are smaller but broadly positive.

Reviewed By: q10

Differential Revision: D107551685


