### PR TITLE
Add missing headers and use std::min and std::max

### DIFF
--- a/fbgemm_gpu/codegen/utils/embedding_bounds_check_v2.cu
+++ b/fbgemm_gpu/codegen/utils/embedding_bounds_check_v2.cu
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <algorithm>
 #include "fbgemm_gpu/utils/embedding_bounds_check_common.cuh"
 
 template <typename index_t, bool vbe, BoundsCheckMode bounds_check_mode>
@@ -246,7 +247,7 @@ void _bounds_check_indices_cuda_v2(
     // Limit the grid size to PREFETCH_KERNEL_MAX_BLOCKS if running this kernel
     // on the prefetch stream
     constexpr int PREFETCH_KERNEL_MAX_BLOCKS = 8;
-    grid_dim = min(grid_dim, PREFETCH_KERNEL_MAX_BLOCKS);
+    grid_dim = std::min<uint32_t>(grid_dim, PREFETCH_KERNEL_MAX_BLOCKS);
   }
 
 #define INVOKE_BOUNDS_CHECK_INDICES(MODE)                                      \

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/types.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/types.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace fbgemm_gpu {
 
 using fint32 = union fint32 {

--- a/fbgemm_gpu/src/sparse_ops/sparse_async_batched_cumsum.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_async_batched_cumsum.cu
@@ -12,6 +12,7 @@
 #include <cub/block/block_scan.cuh>
 #endif
 #include "common.cuh"
+#include <algorithm>
 
 static constexpr uint32_t kMaxThreads = 1024;
 
@@ -112,7 +113,7 @@ at::Tensor asynchronous_batched_complete_cumsum_gpu(const at::Tensor& values) {
   const uint32_t B = values.size(0);
   const uint32_t len = values.size(1);
   const uint32_t nthreads_per_block =
-      min(max(next_power_of_2(len), 64), kMaxThreads);
+      std::min<uint32_t>(std::max<uint32_t>(next_power_of_2(len), 64), kMaxThreads);
   const uint32_t items_per_thread = div_round_up(len, nthreads_per_block);
 
   auto cumsum = at::empty({B, len + 1}, values.options());


### PR DESCRIPTION
This tidies up some namespaces and includes that can cause problems with stricter compilers.