### PR TITLE
Add VBE batch size validation in TBE

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -4186,6 +4186,13 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
             metadata
         """
 
+        if batch_size_per_feature_per_rank is not None:
+            total_bs: int = sum([sum(b) for b in batch_size_per_feature_per_rank])
+            # Cannot use f-string here as dynamic shapes break PT2 compile
+            assert (
+                total_bs == offsets.numel() - 1
+            ), "Batch size mismatch: total batch size from batch_size_per_feature_per_rank does not match offsets"
+
         if vbe_output is not None or vbe_output_offsets is not None:
             assert (
                 not self.use_cpu


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2760

Add an assertion to verify that the total batch size derived from `batch_size_per_feature_per_rank` matches the batch size implied by `offsets` (i.e., `offsets.numel() - 1`). This catches mismatches early with a clear error message showing both values and the per-rank breakdown.

Reviewed By: q10

Differential Revision: D106610639


