### PR TITLE
Fix optional TBE V1 codegen (#5842)

### DIFF
--- a/fbgemm_gpu/codegen/genscript/optimizer_args.py
+++ b/fbgemm_gpu/codegen/genscript/optimizer_args.py
@@ -904,9 +904,13 @@ class OptimizerArgs:
         # Create function args and schemas for V1 interface for backward compatibility
         # V1 interface refers to separate CPU/CUDA lookup functions
         # e.g., split_embedding_codegen_lookup_{}_funtion and split_embedding_codegen_lookup_{}_funtion_cpu)
+        # An optimizer opts out of V1 by either omitting `additional_spec` or
+        # setting an empty `v1` spec. Both are normalized to None here so the
+        # downstream templates (which gate V1 codegen on `split_function_args_v1
+        # is not none`) skip V1 entirely instead of emitting an empty arg list.
         split_function_args_v1 = None
         split_function_schemas_v1 = None
-        if additional_spec is not None:
+        if additional_spec is not None and additional_spec.get("v1"):
             if len(split_saved_tensors) > 0:
                 extended_args_str = extend_tensors_args_from_str(
                     additional_spec["v1"], split_saved_tensors[0]


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2762

Follow-up to D107331913, which made TBE backward V1 codegen conditional on `args.split_function_args_v1 is not none`. That guard handles an optimizer that omits `additional_spec` entirely, but not one that supplies an empty `v1` spec (`{"v1": ""}`) — a natural way to express "no V1 args".

With `{"v1": ""}`, `make_split_function_args_v1("")` returns `""`, which is not `None`, so the templates still emit the V1 lookup function but with an empty argument string. The generated CUDA and CPU host signatures end up with a bare `,` on its own line, which does not compile:

```cpp
    const bool stochastic_rounding,
    ,                                  // empty split_function_args_v1
    const int64_t output_dtype = ...
```

This diff normalizes both opt-out forms (omitted `additional_spec` and an empty `v1` spec) to `None` at the source in `OptimizerArgs.create()`, so `split_function_args_v1` and `split_function_schemas_v1` are consistently `None` and the existing `is not none` template guards skip V1 entirely.

Reviewed By: q10

Differential Revision: D107679228


