### PR TITLE
Fix bf16 dequant: SVE 8-bit fallback, rounding docs, robust test

### DIFF
--- a/src/Bf16ConvertAvx2.h
+++ b/src/Bf16ConvertAvx2.h
@@ -13,7 +13,19 @@
 
 namespace fbgemm::internal {
 
-// Round-nearest fp32→bf16: val + 0x8000, take high 16 bits.
+// fp32->bf16 conversion via the "val + 0x8000, take high 16 bits" trick.
+//
+// NOTE: This rounds half values *away from zero*, NOT round-to-nearest-even
+// (RNE). It therefore differs from:
+//   - the scalar reference cpu_float2bfloat16(), which uses RNE, and
+//   - the AVX-512 path (Fused8BitRowwiseQuantizedSBFloatToBfloat16Avx512),
+//     which uses the hardware vcvtneps2bf16 (RNE).
+// As a result, the same logical dequant can produce bf16 bit patterns that
+// differ by up to 1 ULP depending on which backend runs (AVX-512-BF16 vs AVX2
+// vs scalar Ref). Callers that need bit-exact agreement with
+// cpu_float2bfloat16() must not use these helpers. Additionally, a NaN whose
+// upper 7 mantissa bits are all 1 can carry into the exponent and become
+// +/-inf.
 inline __m256i cvt_fp32_to_bf16x8(__m256i val) {
   return _mm256_srli_epi32(
       _mm256_add_epi32(val, _mm256_set1_epi32(0x8000)), 16);

--- a/src/QuantUtils.cc
+++ b/src/QuantUtils.cc
@@ -920,8 +920,24 @@ void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf(
     const bool scale_bias_last [[maybe_unused]],
     const bool quant_padding_float_type [[maybe_unused]]) {
 #if HAVE_SVE
-  Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfNeon<OutputType>(
-      input, input_rows, input_columns, output);
+  // The SVE/NEON 8-bit dequant kernel does not support bf16 output. Falling
+  // through to it would silently drop is_uint16_t_of_type_bf16 and write fp16
+  // bit patterns into a buffer the caller interprets as bf16, so route bf16
+  // output to the scalar Ref kernel instead.
+  if constexpr (is_uint16_t_of_type_bf16) {
+    Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfRef<
+        OutputType,
+        is_uint16_t_of_type_bf16>(
+        input,
+        input_rows,
+        input_columns,
+        output,
+        scale_bias_last,
+        quant_padding_float_type);
+  } else {
+    Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfNeon<OutputType>(
+        input, input_rows, input_columns, output);
+  }
 #else
   if (cpuinfo_initialize() && fbgemmHasAvx2Support()) {
 #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64

--- a/src/QuantUtilsNeon.cc
+++ b/src/QuantUtilsNeon.cc
@@ -587,7 +587,10 @@ void Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfNeon(
   } // for each row
 }
 
-// fp32→bf16; matches Bf16ConvertAvx2.h (val + 0x8000, take high 16 bits).
+// fp32->bf16; matches Bf16ConvertAvx2.h (val + 0x8000, take high 16 bits).
+// NOTE: This rounds half values away from zero, NOT round-to-nearest-even, so
+// results can differ by up to 1 ULP from the scalar cpu_float2bfloat16() (RNE).
+// See Bf16ConvertAvx2.h for the full rounding/NaN caveats.
 static inline uint16x4_t cvt_fp32x4_to_bf16x4(float32x4_t v) {
   const uint32x4_t u = vreinterpretq_u32_f32(v);
   const uint32x4_t rounded = vaddq_u32(u, vdupq_n_u32(0x8000));

--- a/test/QuantUtilsTest.cc
+++ b/test/QuantUtilsTest.cc
@@ -749,8 +749,14 @@ TEST_P(EmbeddingQuantizeTest, embeddingHalfTest) {
     float r = cpu_bf162float(static_cast<bfloat16>(dequantBf16Ref[i]));
     float t = cpu_bf162float(static_cast<bfloat16>(dequantBf16Test[i]));
     EXPECT_NEAR(r, t, std::max(1e-3f, 1.6e-2f * std::abs(r)));
+    // Independently verify the bf16 reference against cpu_float2bfloat16()
+    // applied to the fp32 reference, rather than asserting bf16 != fp16 bit
+    // patterns (which can spuriously fail when every value is representable
+    // identically in both formats). double->fp32->bf16 vs double->bf16
+    // double-rounding can differ by ~1 bf16 ULP, so use a tolerance.
+    float expected = cpu_bf162float(cpu_float2bfloat16(dequantOutRef[i]));
+    EXPECT_NEAR(r, expected, std::max(1e-3f, 1.6e-2f * std::abs(expected)));
   }
-  EXPECT_NE(dequantBf16Ref, dequantOutHalfRef);
 }
 
 // Scale and bias are of type float
@@ -833,8 +839,14 @@ TEST_P(EmbeddingQuantizeSBFloatTest, embeddingFloatTest) {
     float r = cpu_bf162float(static_cast<bfloat16>(dequantBf16Ref[i]));
     float t = cpu_bf162float(static_cast<bfloat16>(dequantBf16Test[i]));
     EXPECT_NEAR(r, t, std::max(1e-3f, 1.6e-2f * std::abs(r)));
+    // Independently verify the bf16 reference against cpu_float2bfloat16()
+    // applied to the fp32 reference, rather than asserting bf16 != fp16 bit
+    // patterns (which can spuriously fail when every value is representable
+    // identically in both formats). double->fp32->bf16 vs double->bf16
+    // double-rounding can differ by ~1 bf16 ULP, so use a tolerance.
+    float expected = cpu_bf162float(cpu_float2bfloat16(dequantOutRef[i]));
+    EXPECT_NEAR(r, expected, std::max(1e-3f, 1.6e-2f * std::abs(expected)));
   }
-  EXPECT_NE(dequantBf16Ref, dequantOutHalfRef);
 }
 
 TEST_P(


### PR DESCRIPTION
Summary:
Follow-up to D100932926 (bf16 AVX2 8-bit and N-bit dequant) addressing three
review findings:

1. (Critical) The HAVE_SVE branch of Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf
   silently dropped the is_uint16_t_of_type_bf16 template parameter. The NEON
   8-bit kernel (Fused8BitRowwiseQuantizedSBFloatToFloatOrHalfNeon) has no bf16
   support, so bf16 callers on aarch64+SVE hosts received fp16 bit patterns
   written into a buffer they interpret as bf16. Now route bf16 output to the
   scalar Ref kernel on SVE instead of falling through to the fp16 NEON kernel.

2. Document that the AVX2/NEON fp32->bf16 helpers round half values away from
   zero (not round-to-nearest-even), so results can differ by up to 1 ULP from
   the scalar cpu_float2bfloat16() and the AVX-512 vcvtneps2bf16 paths. Added
   NaN caveat in Bf16ConvertAvx2.h and a cross-reference in QuantUtilsNeon.cc.

3. Replace the fragile EXPECT_NE(dequantBf16Ref, dequantOutHalfRef) bit-pattern
   assertion (which can spuriously fail when every value is representable
   identically in bf16 and fp16) with an independent verification of the bf16
   reference against cpu_float2bfloat16() applied to the fp32 reference.

All changes are mirrored across the fbcode and xplat copies.

Differential Revision: D107598944


