### PR TITLE
FindAVX: probe AVX support via compile-only check

### DIFF
--- a/cmake/modules/FindAVX.cmake
+++ b/cmake/modules/FindAVX.cmake
@@ -11,7 +11,7 @@
 ################################################################################
 
 include(CheckCompilerFlag)
-INCLUDE(CheckSourceRuns)
+INCLUDE(CheckSourceCompiles)
 INCLUDE(CMakePushCheckState)
 
 SET(AVX_CODE "
@@ -80,7 +80,7 @@ MACRO(CHECK_SSE lang type flags)
       cmake_push_check_state(RESET)
       unset(${lang}_HAS_${type}_${__FLAG_I} CACHE)
       SET(CMAKE_REQUIRED_FLAGS ${__FLAG})
-      CHECK_SOURCE_RUNS(${lang} "${${type}_CODE}" ${lang}_HAS_${type}_${__FLAG_I})
+      CHECK_SOURCE_COMPILES(${lang} "${${type}_CODE}" ${lang}_HAS_${type}_${__FLAG_I})
       IF(${lang}_HAS_${type}_${__FLAG_I})
         SET(${lang}_${type}_FOUND TRUE CACHE BOOL "${lang} ${type} support")
         string(REPLACE " " ";" __FLAG "${__FLAG}")


### PR DESCRIPTION
Switch from CHECK_SOURCE_RUNS to CHECK_SOURCE_COMPILES so CXX_AVX*_FOUND reflects compiler capability rather than build-host execution capability. Runtime dispatch (fbgemmHasAvx512Support / isZmm) already gates execution on the target CPU, so the runs-based probe was over-strict and skipped the AVX-512 sources on builders without AVX-512+BF16 hardware, leaving fbgemm_gpu's fbgemm.so with an unresolved FloatToFloat16_avx512 at load time.