### PR TITLE
Use 256-thread blocks for jagged dense-output kernel (#5848)

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/common.cuh
+++ b/fbgemm_gpu/src/jagged_tensor_ops/common.cuh
@@ -268,6 +268,12 @@ void jagged_dense_elementwise_dense_output_(
   StackArray<int64_t> jagged_dims_tensor;
   std::tie(threads, blocks, jagged_dims_tensor) =
       check_shape_and_partition_(x_values, x_offsets, y);
+#ifdef USE_ROCM
+  // AMD: ~256-thread blocks improve wavefront packing for common D=1 shapes.
+  constexpr int kDenseOutputTargetBlockThreads = 256;
+  threads.y = kDenseOutputTargetBlockThreads / threads.x;
+  blocks.x = div_round_up(y.numel() / y.size(-1), threads.y);
+#endif
 
   // Canonicalize y and output to 3D, collapsing jagged dimensions.
   const Tensor y_reshaped = y.view({y.size(0), -1, y.size(-1)});


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2766

Initial Rocm profiler thread tracing shows pretty poor utilization for jagged_1d_to_dense.
Prev was setting it to use 16 threads only which is only 25% util of a wavefront when D=1 for 1d. 


For 2d (large D) values it seems OK to just consistently use 256. Alternative could be coding special path for just the D=1 (1d case). Open to suggestions. Generally this will shift them from using 1024 threads to 256. 

These changes impacts jagged_1d_to_dense, jagged_2d_to_dense, and jagged_to_padded_dense_forward. Mostly focused on jagged_1d_to_dense.

Reviewed By: q10

Differential Revision: D107571746


