### PR TITLE
Add seed_all() deterministic-seed test helper

### DIFF
--- a/fbgemm_gpu/test/test_utils.py
+++ b/fbgemm_gpu/test/test_utils.py
@@ -8,6 +8,7 @@
 
 import inspect
 import os
+import random
 import subprocess
 import unittest
 from collections.abc import Callable, Generator
@@ -66,6 +67,27 @@ running_in_oss: tuple[bool, str] = (
     "Test is currently known to fail in OSS mode",
 )
 
+
+def seed_all(seed: int = 0) -> None:
+    """Seed all RNGs used by FBGEMM tests for deterministic behavior.
+
+    Many legacy tests draw split points / weights / indices from global RNGs
+    inside the test body (not via Hypothesis), which makes Hypothesis-recorded
+    failures non-reproducible and the tests flaky. Call this in ``setUp`` (or at
+    the top of a test) to make those draws deterministic.
+    """
+    random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+    try:
+        import numpy as np
+
+        np.random.seed(seed)
+    except ImportError:
+        pass
+
+
 running_on_rocm: tuple[bool, str] = (
     TEST_WITH_ROCM,
     "Test currently doesn't work on the ROCm stack",
@@ -98,9 +120,10 @@ def cpu_and_maybe_gpu() -> st.SearchStrategy[list[torch.device]]:
     # If st.sampled_from contains >100 items or if it's used in conjunction with other strategies
     # then it may not test all values; however, for smaller tests it may work fine.
     # This is still a stopgap solution until we figure out a way to parameterize UnitTestCase.
-    return st.sampled_from(
-        [torch.device("cpu")] + ([torch.device("cuda")] if gpu_available else [])
-    )
+    # lint-fixme: TorchDeviceCuda, TorchFunctionCallCudaDevice
+    # CUDA specifically required: GPU device strategy for FBGEMM tests
+    gpu_devices = [torch.device("cuda")] if gpu_available else []
+    return st.sampled_from([torch.device("cpu")] + gpu_devices)
 
 
 class optests:


### PR DESCRIPTION
Summary:
Adds a shared seed_all(seed=0) helper to fbgemm_gpu test utils that seeds
torch, torch.cuda, random, and numpy. Many legacy fbgemm_dev tests draw split
points / weights / indices from global RNGs inside the test body (not via
Hypothesis), making Hypothesis-recorded failures non-reproducible and the tests
flaky. This is the stack base for the de-flake diffs that follow (preproc,
kmeans, group_linear, STBE QR, gqa, intraining pruning, mem_share, triton
jagged).

Part of the fbgemm_dev test-health remediation for T191384137.

Reviewed By: henrylhtsang

Differential Revision: D107927035


