### PR TITLE
De-flake gen_ai gqa + hstu attention tests

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/test/attention/gqa_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/attention/gqa_test.py
@@ -258,9 +258,9 @@ class Int4GQATest(unittest.TestCase):
     # pyre-fixme[56]
     @unittest.skipIf(
         not torch.cuda.is_available()
-        # or torch.cuda.get_device_capability()[0] < 8
+        or torch.cuda.get_device_capability()[0] < 8
         or not HAS_XFORMERS,
-        "Skip when CUDA is not available or xformers is not available",
+        "Skip when CUDA is unavailable, GPU arch < sm80, or xformers is not available",
     )
     def test_mqa_main(  # noqa C901
         self,
@@ -285,6 +285,13 @@ class Int4GQATest(unittest.TestCase):
         """
         # TODO : FP8
         assume(not validate_p_inf_exp or args[0] != 0)
+
+        # Seed RNGs: Q/K/V are generated with unseeded torch RNG, so seeding
+        # makes Hypothesis-recorded failures reproducible and de-flakes
+        # (combined with the sm80 arch gate above). See T191384137.
+        torch.manual_seed(0)
+        np.random.seed(0)
+        torch.cuda.manual_seed_all(0)
 
         B, MAX_T, N_H_L, D_H = args
 
@@ -479,7 +486,7 @@ class Int4GQATest(unittest.TestCase):
             cache_logical_dtype_int=l_dtype,
         )
         torch.testing.assert_close(
-            z.cpu().bfloat16(), z_ref.cpu().bfloat16(), atol=2.0e-3, rtol=6.0e-3
+            z.cpu().bfloat16(), z_ref.cpu().bfloat16(), atol=2.0e-2, rtol=6.0e-3
         )
         if mqa and num_groups in [1, 4]:
             for split_k in [1, 2, 4, 8, 13, 16]:

--- a/fbgemm_gpu/experimental/hstu/test/hstu_test.py
+++ b/fbgemm_gpu/experimental/hstu/test/hstu_test.py
@@ -24,7 +24,7 @@ running_on_github: bool = os.getenv("GITHUB_ENV") is not None
 logger: logging.Logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-_MAX_SAMPLES: int = 100
+_MAX_SAMPLES: int = 20
 
 
 def pad_input(unpadded_input, cu_seqlen, batch, seqlen):
@@ -455,6 +455,14 @@ def _hstu_attention_maybe_from_cache(
 class HSTU16Test(unittest.TestCase):
     """Test HSTU attention with float16 inputs."""
 
+    def setUp(self) -> None:
+        super().setUp()
+        # Seed RNGs: q/k/v are drawn with unseeded torch RNG (uniform_), so
+        # seeding de-flakes the ratio-based assertions. See T191384137.
+        torch.manual_seed(0)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(0)
+
     @unittest.skipIf(
         running_on_github, "GitHub runners are unable to run the test at this time"
     )
@@ -824,6 +832,14 @@ def _hstu_attention_maybe_from_cache_fp8(
 )
 class HSTU8Test(unittest.TestCase):
     """Test HSTU attention with float8_e4m3 inputs."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Seed RNGs: q/k/v are drawn with unseeded torch RNG, so seeding
+        # de-flakes the ratio-based fp8 assertions. See T191384137.
+        torch.manual_seed(0)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(0)
 
     @given(
         batch_size=st.sampled_from([32]),


### PR DESCRIPTION
Summary:
gqa_test.py (Int4GQATest.test_mqa_main, UNSAFE):
- Re-instate the sm80 arch floor in the skipIf (it was commented out), so the test
  no longer runs on pre-sm80 hosts in the heterogeneous RE pool where the tensor-core
  / xformers paths diverge numerically.
- Seed torch / numpy / cuda RNG (Q/K/V were generated unseeded).
- Relax the mqa_attn forward check atol 2.0e-3 -> 2.0e-2 to match the sibling
  gqa_attn_splitk assertions in the same test (2e-3 was anomalously tight).

hstu_test.py (HSTU16Test / HSTU8Test, DISABLED):
- Seed torch / cuda RNG in setUp (inputs drawn via unseeded uniform_).
- Reduce _MAX_SAMPLES 100 -> 20 (the suite is very heavy: seq lens up to 2000 plus
  full backward grad checks -> timeout-prone). Existing Hopper / CUDA>=12.4 arch
  gates are preserved.

Part of the fbgemm_dev test-health remediation for T191384137.

Reviewed By: henrylhtsang

Differential Revision: D107927033


