### PR TITLE
Fix ROCm __syncthreads deadlock in gemv_quantized_fp8_fp8

### DIFF
--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/fast_gemv.cuh
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/fast_gemv/include/fast_gemv.cuh
@@ -196,8 +196,12 @@ __global__ void gemv_quantized_fp8_fp8(
           res[row + mi * n + offset] = __float2bfloat16(sum[ni][mi]);
         }
       }
-      return;
     }
+    // All threads in a single-warp block must return together; otherwise the
+    // non-zero lanes would reach the __syncthreads() below while tid==0 has
+    // already exited, deadlocking the block on ROCm/AMD. (Matches the sibling
+    // gemv_* kernels in this file.)
+    return;
   }
 
   __syncthreads();


### PR DESCRIPTION
Summary:
Fixes a ROCm/AMD GPU deadlock in gemv_quantized_fp8_fp8
(experimental/gen_ai/src/quantize/fast_gemv/include/fast_gemv.cuh), found by
auditing fbgemm_gpu for the same barrier-divergence pattern fixed in D107554507.

In the single-warp branch (blockDim.x <= WARP_SIZE), the `return` was nested
inside `if (tid == 0)`, so only thread 0 exited while lanes 1..N-1 fell through
to the block-wide __syncthreads(). On ROCm (WARP_SIZE=64) the blockDim.x in
{32,64} instantiations take this branch, so the waiting lanes deadlock (latent
UB on NVIDIA).

This diff moves the `return` out of the `if (tid == 0)` block so all threads in
a single-warp block return together and none reach __syncthreads() -- matching
the sibling gemv_bf16 / gemv_quantized_bf16_fp8 / gemv_quantized_int4 kernels in
the same file. The multi-warp path is unchanged.

Differential Revision: D107947000


