### PR TITLE
Fix ROCm __syncthreads deadlock in quantize_float_to_mx4_kernel (#5857)

### DIFF
--- a/fbgemm_gpu/src/quantize_ops/quantize_mx.cuh
+++ b/fbgemm_gpu/src/quantize_ops/quantize_mx.cuh
@@ -108,14 +108,16 @@ __global__ void quantize_float_to_mx4_kernel(
     const uint32_t smem_stride) {
   const auto linear_group_id = (blockIdx.x * blockDim.y) + threadIdx.y;
   const auto linear_tid = linear_group_id * group_size + threadIdx.x;
-  if (linear_tid >= total_elems)
-    return;
+  // Do NOT early-return for out-of-range threads: every thread in the block
+  // must reach the __syncthreads() barriers below, otherwise the block
+  // deadlocks on ROCm/AMD. Mask per-thread work with `active` instead.
+  const bool active = linear_tid < total_elems;
 
   // MX4 values
   constexpr int scale_bits = 8;
   constexpr int elem_emax = 2;
 
-  const T elem = input[linear_tid];
+  const T elem = active ? input[linear_tid] : T(0);
 
   extern __shared__ __align__(16) float smem[];
   const uint32_t group_offset_in_block = threadIdx.y * smem_stride;
@@ -123,7 +125,9 @@ __global__ void quantize_float_to_mx4_kernel(
   int* smem_base = reinterpret_cast<int*>(smem + group_offset_in_block);
 
   // // allreduce to get the max value in each group size
-  int shared_exp = get_biased_exponent(elem);
+  // Inactive threads contribute the minimum biased exponent (0) so they do not
+  // perturb the max reductions below.
+  int shared_exp = active ? get_biased_exponent(elem) : 0;
 
   const uint32_t half_group_size = group_size / 2;
 
@@ -200,7 +204,7 @@ __global__ void quantize_float_to_mx4_kernel(
   const auto is_even_tid = threadIdx.x % 2 == 0;
 
   // even thread work on the left side
-  if (is_even_tid) {
+  if (active && is_even_tid) {
     // the 4 bits are on the rightmost, need to shift 4 bit
     // this becomes `xxxx 0000`
     *stored_8bit = (quantized_val << 4);
@@ -208,14 +212,14 @@ __global__ void quantize_float_to_mx4_kernel(
   __syncthreads();
 
   // odd threads work on the right side (position 0-3)
-  if (!is_even_tid) {
+  if (active && !is_even_tid) {
     // 4 bits are already on the rightmost, so just `bitwise OR` to combine
     *stored_8bit |= quantized_val;
   }
   __syncthreads();
 
   // Let each thread write 1 byte of output data
-  if (threadIdx.x < half_group_size) {
+  if (active && threadIdx.x < half_group_size) {
     // write data output using uint8_t (1 bytes)
 
     uint8_t* smem_ptr = reinterpret_cast<uint8_t*>(smem_base);


### PR DESCRIPTION
Summary:

Fixes a ROCm/AMD GPU deadlock in get_pruning_lengths-style barrier divergence,
found by auditing fbgemm_gpu for the same pattern fixed in D107554507.

In quantize_float_to_mx4_kernel (src/quantize_ops/quantize_mx.cuh), threads
whose linear_tid >= total_elems hit an early `return` before the block-wide
__syncthreads() calls. The kernel is launched with multiple groups per block
(blockDim.y = num_groups_per_block = MAX_THREADS / mx_group_size) and
gridDim_x = div_round_up(total_num_groups, num_groups_per_block), so when
total_num_groups is not a multiple of num_groups_per_block the last block
contains whole trailing groups whose threads all return early while the active
groups wait at __syncthreads() -> deadlock on ROCm (latent UB on NVIDIA).

This diff removes the early return and instead masks per-thread work with an
`active = linear_tid < total_elems` flag: the input load, the smem combine
writes, and the output write are guarded, while all threads fall through to
every __syncthreads(). Inactive lanes contribute the minimum biased exponent
(0) so the max reductions are unaffected. Behavior is identical for active
groups. The sibling dequantize_mx4_to_float_kernel has no barrier after its
early return and is left unchanged.

## Where the hanging barrier actually is (not apparent from the diff)

Unlike the gen_ai amax/quantize twin (D107946896), the barriers here are in the
kernel body, but which ones hang and under what condition is still subtle:

- Unconditional block-wide barriers: __syncthreads() at the even/odd 4-bit
  combine steps (post-fix lines ~205 and ~212). These are ALWAYS reached, so they
  are the primary hang points.
- Conditional block-wide barriers: __syncthreads() at lines ~141 and ~159 are
  only compiled in the has_multiple_warps_in_group == true template instantiation
  (mx_group_size > WARP_SIZE); for mx_group_size <= WARP_SIZE only the
  unconditional pair applies.
- (The fbgemm_gpu::syncwarp() at line ~148 is warp-scoped, not a block barrier,
  and is not the hang point.)

Why a subset of the block skips them (the deadlock condition):
- The block is 2D: blockDim = (mx_group_size, num_groups_per_block) with
  num_groups_per_block = MAX_THREADS / mx_group_size, so a block holds MULTIPLE
  groups along threadIdx.y. The __syncthreads() calls are block-wide (all
  mx_group_size * num_groups_per_block threads) even though they are only
  logically needed within a single group's smem region.
- Because total_elems = total_num_groups * mx_group_size, the early-return
  condition linear_tid >= total_elems is WHOLE-GROUP: an entire threadIdx.y row
  is either fully active or fully inactive (never partial).
- gridDim_x = div_round_up(total_num_groups, num_groups_per_block). When
  total_num_groups is not a multiple of num_groups_per_block, the LAST block
  contains whole trailing (inactive) groups whose threads all returned, while the
  active groups in the same block reach the block-wide __syncthreads() and wait
  forever -> ROCm hang.

Corollary / dependency: with num_groups_per_block == 1 (one group per block) the
bug would not trigger, since the early return would be block-uniform. It is the
multi-group-per-block launch that turns the per-group early return into a
partial-block barrier divergence.

Reviewed By: henrylhtsang

Differential Revision: D107946777


