### PR TITLE
Implement asynchronous LDS loads for MI350 (#5858)

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
@@ -165,10 +165,10 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
 
       #pragma unroll
       for (uint32_t outer_i = 0; outer_i < OutputRowsPerThread - OutputRowsPerThread % kRowUnroll; outer_i += kRowUnroll) {
-        uint4 row_data_v[kRowUnroll];
         const uint4* row_v[kRowUnroll];
         int32_t idx_v[kRowUnroll];
         int32_t cache_idx_v[kRowUnroll];
+        bool row_valid_v[kRowUnroll];
         #pragma unroll
         for (uint32_t inner_i = 0; inner_i < kRowUnroll; ++inner_i) {
           uint32_t i = outer_i + inner_i;
@@ -176,35 +176,69 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
           bool cache_valid = !DeviceOnly && (placement == PlacementType::MANAGED_CACHING && valid);
           idx_v[inner_i] = valid ? indices_[indices_starts[i] + L_start + input_row_idx] : -1;
           cache_idx_v[inner_i] = (!DeviceOnly && cache_valid) ? lxu_cache_locations[indices_starts[i] + L_start + input_row_idx] : -1;
+          row_valid_v[inner_i] = valid;
         }
 
 
         #pragma unroll
         for (uint32_t inner_i = 0; inner_i < kRowUnroll; ++inner_i) {
           uint32_t i = outer_i + inner_i;
-          bool valid = load_idx_valid && L_start + input_row_idx < Ls[i];
-          bool cache_valid = !DeviceOnly && (placement == PlacementType::MANAGED_CACHING && valid);
-          valid = valid && (idx_v[inner_i] != -1);
+          bool cache_valid = !DeviceOnly && (placement == PlacementType::MANAGED_CACHING && row_valid_v[inner_i]);
+          bool final_valid = row_valid_v[inner_i] && (idx_v[inner_i] != -1);
           if (!DeviceOnly && cache_valid && cache_idx_v[inner_i] != kCacheLocationMissing) {
             row_v[inner_i] = reinterpret_cast<const uint4*>(&lxu_cache_weights[static_cast<int64_t>(cache_idx_v[inner_i])][0]);
-          } else
-          if (valid) {
+          } else if (final_valid) {
             row_v[inner_i] = reinterpret_cast<const uint4*>(&weights[static_cast<int64_t>(idx_v[inner_i]) * D_bytes]);
           } else {
             row_v[inner_i] = reinterpret_cast<const uint4*>(&weights[0]);
           }
+          row_valid_v[inner_i] = final_valid;
         }
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800) || (defined(USE_ROCM) && defined(__gfx950__))
         #pragma unroll
         for (uint32_t inner_i = 0; inner_i < kRowUnroll; inner_i++) {
           uint32_t i = outer_i + inner_i;
+          bool final_valid = row_valid_v[inner_i];
+          if constexpr (PackedMode) {
+            // Store row data with uint4_loads_per_row offset
+            cp_async_zfill_cg<sizeof(uint4)>(
+                &buffers[warp_idx][i][input_row_idx][row_load_idx + uint4_loads_per_row * packed_bag_load_idx],
+                &row_v[inner_i][row_load_idx],
+                final_valid);
+          } else {
+            cp_async_zfill_cg<sizeof(uint4)>(
+                &buffers[warp_idx][i][input_row_idx][row_load_idx],
+                &row_v[inner_i][row_load_idx],
+                final_valid);
+          }
+        }
+        {% if weighted %}
+        #pragma unroll
+        for (uint32_t inner_i = 0; inner_i < kRowUnroll; inner_i++) {
+          uint32_t i = outer_i + inner_i;
+          bool final_valid = row_valid_v[inner_i] && (idx_v[inner_i] != -1);
+          if (row_load_idx == 0)  {
+            // Use only one thread to load the index weight to prevent a race
+            // condition when writing to the shared memory
+            buffers_indice_weights[warp_idx][i][input_row_idx][packed_bag_load_idx] =
+              final_valid ? indice_weights[indices_starts[i] + L_start + input_row_idx] : 0.0;
+          }
+        }
+        {% endif %}
+#else
+        // Maintain pipelining of load and store operations when async shared memory/lds
+        // loads are not available.
+        uint4 row_data_v[kRowUnroll];
+        #pragma unroll
+        for (uint32_t inner_i = 0; inner_i < kRowUnroll; inner_i++) {
           row_data_v[inner_i] = row_v[inner_i][row_load_idx];
         }
         uint4 zeros = {0, 0, 0, 0};
         #pragma unroll
         for (uint32_t inner_i = 0; inner_i < kRowUnroll; inner_i++) {
           uint32_t i = outer_i + inner_i;
-          bool valid = load_idx_valid && (L_start + input_row_idx < Ls[i]) && (idx_v[inner_i] != -1);
-          uint4 data = valid ? row_data_v[inner_i] : zeros;
+          bool final_valid = row_valid_v[inner_i];
+          uint4 data = final_valid ? row_data_v[inner_i] : zeros;
           if constexpr (PackedMode) {
             // Store row data with uint4_loads_per_row offset
             buffers[warp_idx][i][input_row_idx][row_load_idx + uint4_loads_per_row * packed_bag_load_idx] = data;
@@ -216,10 +250,11 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
             // Use only one thread to load the index weight to prevent a race
             // condition when writing to the shared memory
             buffers_indice_weights[warp_idx][i][input_row_idx][packed_bag_load_idx] =
-              valid ? indice_weights[indices_starts[i] + L_start + input_row_idx] : 0.0;
+              final_valid ? indice_weights[indices_starts[i] + L_start + input_row_idx] : 0.0;
           }
           {% endif %}
         }
+#endif
       }
       {%- endif %}
 

--- a/fbgemm_gpu/include/fbgemm_gpu/embedding_forward_template_helpers.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/embedding_forward_template_helpers.cuh
@@ -148,6 +148,12 @@ __device__ __forceinline__ void cp_async_wait() {
 #if __CUDA_ARCH__ >= 800
 
   asm volatile("cp.async.wait_group %0;\n" ::"n"(N));
+#elif defined(USE_ROCM) &&                                   \
+    (ROCM_VERSION_MAJOR < 7 ||                               \
+     (ROCM_VERSION_MAJOR == 7 && ROCM_VERSION_MINOR < 2)) && \
+    defined(__gfx950__)
+
+  __builtin_amdgcn_s_waitcnt(0);
 #endif
 }
 
@@ -157,13 +163,42 @@ __device__ __forceinline__ void cp_async_wait<0>() {
 #if __CUDA_ARCH__ >= 800
 
   asm volatile("cp.async.wait_all;\n" ::);
+#elif defined(USE_ROCM) &&                                   \
+    (ROCM_VERSION_MAJOR < 7 ||                               \
+     (ROCM_VERSION_MAJOR == 7 && ROCM_VERSION_MINOR < 2)) && \
+    defined(__gfx950__)
+
+  __builtin_amdgcn_s_waitcnt(0);
 #endif
 }
 
+#if defined(USE_ROCM)
+template <typename T>
+__device__ __forceinline__ uint32_t hip_cvta_to_shared_address(const T* ptr) {
+  // Use clang's address-space-qualified cast (generic AS=0 → group/LDS AS=3)
+  // so the compiler emits the proper aperture subtraction. The 32-bit LDS
+  // offset is then well-defined regardless of how `SH_MEM_BASES` is
+  // configured. This is the canonical Clang/HIP idiom — analogous to
+  // `__cvta_generic_to_shared` on CUDA paths (see `cutlass_get_smem_pointer`
+  // earlier in this file).
+  //
+  // This replaces a `reinterpret_cast<size_t>(ptr) & 0xFFFFFFFF` form that
+  // relied on the undocumented invariant `flat_lo == lds_offset`. That
+  // invariant happens to hold on current CDNA hardware but is not
+  // architecturally guaranteed across firmware revisions or future
+  // generations.
+  __attribute__((address_space(3))) const T* lds_ptr =
+      (__attribute__((address_space(3))) const T*)ptr;
+  return static_cast<uint32_t>(reinterpret_cast<uintptr_t>(lds_ptr));
+}
+#endif
+
 /// Partial specialization
 template <int SizeInBytes>
-__device__ __forceinline__ void
-cp_async_zfill_cg(void* smem_ptr, void const* global_ptr, bool pred_guard) {
+__device__ __forceinline__ void cp_async_zfill_cg(
+    __shared__ void* smem_ptr,
+    void const* global_ptr,
+    bool pred_guard) {
 #if __CUDA_ARCH__ >= 800
   static_assert(
       SizeInBytes == 16,
@@ -177,6 +212,40 @@ cp_async_zfill_cg(void* smem_ptr, void const* global_ptr, bool pred_guard) {
       "n"(SizeInBytes),
       "r"(src_in_bytes));
 
+// if ROCm version >= 7.2 and MI350
+#elif defined(USE_ROCM) &&                                    \
+    (ROCM_VERSION_MAJOR > 7 ||                                \
+     (ROCM_VERSION_MAJOR == 7 && ROCM_VERSION_MINOR >= 2)) && \
+    defined(__gfx950__)
+  static __device__ __constant__ uint4 zero_tile = {0, 0, 0, 0};
+  static_assert(
+      SizeInBytes == 16,
+      "cp_async_zfill_cg() function is implemented for 16B inputs only");
+  // Due to LLVM bug, we can't use SizeInBytes directly
+  // in __builtin_amdgcn_global_load_lds intrinsic until
+  // ROCm 7.11:
+  // https://github.com/llvm/llvm-project/pull/175767
+  //
+  // Make sure you modify this #if branch if SizeInBytes
+  // support range is extended
+  const void* src_ptr = (pred_guard) ? global_ptr : &zero_tile;
+  __builtin_amdgcn_global_load_lds(
+      const_cast<void*>(src_ptr), smem_ptr, 16, 0, 0);
+// if MI350
+#elif defined(USE_ROCM) && defined(__gfx950__)
+  static __device__ __constant__ uint4 zero_tile = {0, 0, 0, 0};
+  static_assert(
+      SizeInBytes == 16,
+      "cp_async_zfill_cg() function is implemented for 16B inputs only");
+
+  uint32_t smem =
+      __builtin_amdgcn_readfirstlane(hip_cvta_to_shared_address(smem_ptr));
+  const void* src_ptr = (pred_guard) ? global_ptr : &zero_tile;
+  asm volatile(
+      "s_mov_b32 m0, %0\n"
+      "global_load_lds_dwordx4 %1, off\n" ::"s"(smem),
+      "v"(static_cast<const uint32_t*>(src_ptr))
+      :);
 #else
   static_assert(SizeInBytes == 16, "");
   using AccessType = uint4;


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2773

This PR implements direct HBM->LDS stores in tbe inference kernel. There are 2 major changes:

1. Rows data isn't loaded in-place, instead we store pointers to global memory and store the actual data w.r.t. the predicate into LDS. In case predicate is false, we pre-allocate small chunk of static device memory of 16B once, fill it with zeros, and fallback to this chunk
2. HBM->LDS 16B loads are implemented for ROCm >= 7.0 and MI350. We can expand the support range to MI30* through 4B loads, however it doesn't bring any performance benefits because we'll have to introduce an overhead of addresses transposition and 4x more load operations. You can find out the reference implementation here: https://github.com/pytorch/FBGEMM/commit/fe525574deeb550ab50660fef5a8fbdbedbfc718.

Due to pre-7.2 ROCm features, we are forced to used assembly inline to get 16B loads to work, so manual synchronization was added. In case of ROCm >= 7.2, we use proper intrinsics to handle memory synchronization.

This change brings ~10% performance boost on average for weighted and unweighted cases. We may try to push it further by doing async loads for indices weights.


Reviewed By: spcyppt

Differential Revision: D91496421

Pulled By: q10
