### PR TITLE
Remove CUDA 12.9.1 support from FBGEMM, following PyTorch

### DIFF
--- a/.github/scripts/fbgemm_gpu_integration.bash
+++ b/.github/scripts/fbgemm_gpu_integration.bash
@@ -27,7 +27,7 @@ integration_setup_conda_environment_base () {
   #   COMPILER         - Compiler to use (gcc or clang)
   #   PYTHON_VERSION   - Python version to install (e.g., 3.12)
   #   VARIANT_TYPE     - Build variant type: cuda, rocm, or cpu
-  #   VARIANT_VERSION  - Version of the variant (e.g., 12.9.1 for CUDA, 7.0 for ROCm, "none" for CPU)
+  #   VARIANT_VERSION  - Version of the variant (e.g., 13.0.2 for CUDA, 7.0 for ROCm, "none" for CPU)
   #
   local env_name="$1"
   local compiler="$2"
@@ -37,7 +37,7 @@ integration_setup_conda_environment_base () {
   if [ "$variant_type" == "" ]; then
     echo "Usage: ${FUNCNAME[0]} ENV_NAME COMPILER PYTHON_VERSION VARIANT_TYPE VARIANT_VERSION"
     echo "Example(s):"
-    echo "    ${FUNCNAME[0]} build_env gcc 3.12 cuda 12.9.1   # Setup environment for GCC + Python 3.12 + CUDA 12.9.1"
+    echo "    ${FUNCNAME[0]} build_env gcc 3.12 cuda 13.0.2   # Setup environment for GCC + Python 3.12 + CUDA 13.0.2"
     echo "    ${FUNCNAME[0]} build_env gcc 3.12 rocm 7.0      # Setup environment for GCC + Python 3.12 + ROCm 7.0"
     echo "    ${FUNCNAME[0]} build_env gcc 3.12 cpu none      # Setup environment for GCC + Python 3.12 (CPU only)"
     return 1
@@ -91,7 +91,7 @@ integration_setup_conda_environment () {
   #   COMPILER                       - Compiler to use (gcc or clang)
   #   PYTHON_VERSION                 - Python version to install (e.g., 3.12)
   #   PYTORCH_CHANNEL_VERSION        - PyTorch channel/version (e.g., nightly, test/2.1.0)
-  #   PYTORCH_VARIANT_TYPE_VERSION   - Variant type/version (e.g., cuda/12.9.1, rocm/7.0)
+  #   PYTORCH_VARIANT_TYPE_VERSION   - Variant type/version (e.g., cuda/13.0.2, rocm/7.0)
   #   PYTORCH_INSTALLER              - Installer to use: pip or conda (default: pip)
   #
   local env_name="$1"
@@ -282,7 +282,7 @@ integration_fbgemm_gpu_install_matrix_run () {
     local variant_versions=(
       12.6.3
       12.8.1
-      12.9.1
+      13.0.2
       13.0.2
     )
   elif [ "$variant_type" == "genai" ]; then

--- a/.github/scripts/generate_ci_matrix.py
+++ b/.github/scripts/generate_ci_matrix.py
@@ -304,10 +304,10 @@ class BuildConfigScheme:
             # FBGEMM HSTU is expensive, so conserve CI resources
             return ["12.8.1"]
         elif self.target == TARGET_GENAI:
-            return ["12.6.3", "12.8.1", "12.9.1", "13.0.2"]
+            return ["12.6.3", "12.8.1", "13.0.2"]
         else:
             # GenAI is unable to support 11.8.0 anymore as of https://github.com/pytorch/FBGEMM/pull/4138
-            return ["12.6.3", "12.8.1", "12.9.1", "13.0.2"]
+            return ["12.6.3", "12.8.1", "13.0.2"]
 
     def rocm_versions(self) -> list[str]:
         if GitRepo.ref() == REFS_MAIN and GitRepo.event_name() == EVENT_NAME_PUSH:

--- a/.github/workflows/fbgemm_gpu_release_cuda.yml
+++ b/.github/workflows/fbgemm_gpu_release_cuda.yml
@@ -34,7 +34,7 @@ on:
         description: CUDA Version to Use for Building Artifact
         type: choice
         required: false
-        options: [ "12.6.3", "12.8.1", "12.9.1", "13.0.2" ]
+        options: [ "12.6.3", "12.8.1", "13.0.2" ]
         default: "13.0.2"
       publish-to-pypi:
         description: Publish Artifact to PyPI

--- a/.github/workflows/fbgemm_gpu_release_genai.yml
+++ b/.github/workflows/fbgemm_gpu_release_genai.yml
@@ -34,7 +34,7 @@ on:
         description: CUDA Version to Use for Building Artifact
         type: choice
         required: false
-        options: [ "12.6.3", "12.8.1", "12.9.1", "13.0.2" ]
+        options: [ "12.6.3", "12.8.1", "13.0.2" ]
         default: "13.0.2"
       publish-to-pypi:
         description: Publish Artifact to PyPI

--- a/ci/integration/fbgemm_gpu_oss_build.bash
+++ b/ci/integration/fbgemm_gpu_oss_build.bash
@@ -16,7 +16,7 @@
 #   PYTHON_VERSION        - Python version (e.g., 3.14)
 #   PYTORCH_VERSION       - PyTorch version or git SHA (e.g., nightly, 2.1.0, abc123def)
 #   BUILD_VARIANT         - Build variant: cuda, rocm, or cpu
-#   BUILD_VARIANT_VERSION - Version for the variant (e.g., 12.9.1 for CUDA)
+#   BUILD_VARIANT_VERSION - Version for the variant (e.g., 13.0.2 for CUDA)
 #
 # Returns:
 #   Prints the generated environment name to stdout
@@ -50,7 +50,7 @@ PYTHON_VERSION="${PYTHON_VERSION:-3.14}"
 PYTORCH_VERSION="${PYTORCH_VERSION:-nightly}"
 PYTORCH_VERSION="${PYTORCH_VERSION/#\~/$HOME}"  # Expand ~ to $HOME
 BUILD_VARIANT="${BUILD_VARIANT:-cuda}"
-BUILD_CUDA_VERSION="${BUILD_CUDA_VERSION:-12.9.1}"
+BUILD_CUDA_VERSION="${BUILD_CUDA_VERSION:-13.0.2}"
 BUILD_ROCM_VERSION="${BUILD_ROCM_VERSION:-7.0}"
 BUILD_TARGET="${BUILD_TARGET:-default}"
 BUILD_SCRIPTS_INIT="${BUILD_SCRIPTS_INIT:-${REPO_ROOT}/.github/scripts/setup_env.bash}"

--- a/ci/integration/pytorch_oss_build.bash
+++ b/ci/integration/pytorch_oss_build.bash
@@ -17,7 +17,7 @@
 # Environment Variables:
 #   PYTHON_VERSION      - Python version (default: 3.12)
 #   BUILD_VARIANT       - cuda, rocm, or cpu (default: cuda)
-#   BUILD_CUDA_VERSION  - CUDA version (default: 12.9.1)
+#   BUILD_CUDA_VERSION  - CUDA version (default: 13.0.2)
 #   BUILD_ROCM_VERSION  - ROCm version (default: 7.0)
 #   PYTORCH_REPO_URL    - Repository URL (default: https://github.com/pytorch/pytorch)
 #   PYTORCH_CLONE_DIR   - Clone directory (default: /tmp/pytorch)
@@ -237,7 +237,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   # Configuration
   PYTHON_VERSION="${PYTHON_VERSION:-3.12}"
   BUILD_VARIANT="${BUILD_VARIANT:-cuda}"
-  BUILD_CUDA_VERSION="${BUILD_CUDA_VERSION:-12.9.1}"
+  BUILD_CUDA_VERSION="${BUILD_CUDA_VERSION:-13.0.2}"
   BUILD_ROCM_VERSION="${BUILD_ROCM_VERSION:-7.0}"
   PYTORCH_REPO_URL="${PYTORCH_REPO_URL:-https://github.com/pytorch/pytorch}"
   PYTORCH_CLONE_DIR="${PYTORCH_CLONE_DIR:-/tmp/pytorch}"


### PR DESCRIPTION
Summary: - Remove CUDA 12.9.1 support from FBGEMM, following PyTorch

Reviewed By: cthi

Differential Revision: D107971273


