### PR TITLE
Remove stale opcheck xsuccess entries (jagged/sparse/quantize)

### DIFF
--- a/fbgemm_gpu/test/jagged/failures_dict.json
+++ b/fbgemm_gpu/test/jagged/failures_dict.json
@@ -66,16 +66,7 @@
         "status": "xfail"
       }
     },
-    "fbgemm::jagged_index_select": {
-      "KeyedJaggedIndexSelectTest.test_aot_dispatch_dynamic__test_keyed_jagged_index_select_dim1": {
-        "comment": "",
-        "status": "xsuccess"
-      },
-      "KeyedJaggedIndexSelectTest.test_faketensor__test_keyed_jagged_index_select_dim1": {
-        "comment": "",
-        "status": "xsuccess"
-      }
-    },
+    "fbgemm::jagged_index_select": {},
     "fbgemm::jagged_jagged_bmm": {},
     "fbgemm::jagged_slice": {
       "JaggedSliceTest.test_aot_dispatch_dynamic__test_jagged_slice": {

--- a/fbgemm_gpu/test/quantize/failures_dict.json
+++ b/fbgemm_gpu/test/quantize/failures_dict.json
@@ -3,16 +3,7 @@
   "_version": 1,
   "data": {
     "fbgemm::FP8RowwiseQuantizedToFloat": {},
-    "fbgemm::FloatToFP8RowwiseQuantized": {
-      "TestFP8RowwiseQuantizationConversion.test_aot_dispatch_dynamic__test_quantize_and_dequantize_op_fp8_rowwise": {
-        "comment": "",
-        "status": "xsuccess"
-      },
-      "TestFP8RowwiseQuantizationConversion.test_faketensor__test_quantize_and_dequantize_op_fp8_rowwise": {
-        "comment": "",
-        "status": "xsuccess"
-      }
-    },
+    "fbgemm::FloatToFP8RowwiseQuantized": {},
     "fbgemm::FloatToPaddedFP8RowwiseQuantized": {
       "TestFP8RowwiseQuantizationConversion.test_aot_dispatch_dynamic__test_quantize_and_dequantize_op_padded_fp8_rowwise": {
         "comment": "",

--- a/fbgemm_gpu/test/sparse/failures_dict.json
+++ b/fbgemm_gpu/test/sparse/failures_dict.json
@@ -211,34 +211,8 @@
         "status": "xfail"
       }
     },
-    "fbgemm::generic_histogram_binning_calibration_by_feature": {
-      "HistogramBinningCalibrationTest.test_aot_dispatch_dynamic__test_generic_histogram_binning_calibration_by_feature": {
-        "comment": "",
-        "status": "xsuccess"
-      },
-      "HistogramBinningCalibrationTest.test_aot_dispatch_dynamic__test_generic_histogram_binning_calibration_by_feature_cpu_gpu": {
-        "comment": "",
-        "status": "xsuccess"
-      },
-      "HistogramBinningCalibrationTest.test_faketensor__test_generic_histogram_binning_calibration_by_feature": {
-        "comment": "",
-        "status": "xsuccess"
-      },
-      "HistogramBinningCalibrationTest.test_faketensor__test_generic_histogram_binning_calibration_by_feature_cpu_gpu": {
-        "comment": "",
-        "status": "xsuccess"
-      }
-    },
-    "fbgemm::group_index_select_dim0": {
-      "IndexSelectTest.test_autograd_registration__test_group_index_select_dim0": {
-        "comment": "",
-        "status": "xsuccess"
-      },
-      "IndexSelectTest.test_faketensor__test_group_index_select_dim0": {
-        "comment": "",
-        "status": "xsuccess"
-      }
-    },
+    "fbgemm::generic_histogram_binning_calibration_by_feature": {},
+    "fbgemm::group_index_select_dim0": {},
     "fbgemm::histogram_binning_calibration": {
       "HistogramBinningCalibrationTest.test_faketensor__test_histogram_binning_calibration": {
         "comment": "",
@@ -425,15 +399,6 @@
         "status": "xfail"
       }
     },
-    "fbgemm::segment_sum_csr": {
-      "MiscOpsTest.test_aot_dispatch_dynamic__test_segment_sum_csr": {
-        "comment": "",
-        "status": "xsuccess"
-      },
-      "MiscOpsTest.test_faketensor__test_segment_sum_csr": {
-        "comment": "",
-        "status": "xsuccess"
-      }
-    }
+    "fbgemm::segment_sum_csr": {}
   }
 }


### PR DESCRIPTION
Summary:
generate_opcheck_tests records a "xsuccess" status when a previously-failing opcheck
variant now passes -- i.e. the entry is stale and should be removed. Removing these
de-clutters the failures dicts and drops the problematic-test count with zero
behavioral risk (the tests already pass). 12 stale xsuccess entries removed:

- jagged: fbgemm::jagged_index_select (KeyedJaggedIndexSelectTest aot_dispatch_dynamic
  + faketensor for test_keyed_jagged_index_select_dim1) -> {}
- sparse: fbgemm::generic_histogram_binning_calibration_by_feature (4),
  fbgemm::group_index_select_dim0 (2), fbgemm::segment_sum_csr (2) -> {}
- quantize: fbgemm::FloatToFP8RowwiseQuantized (2) -> {}

Emptied keys are left as {} per the existing convention for healthy ops. Legitimate
xfail entries (data-dependent / dynamic-output-shape variants) are untouched.

Part of the fbgemm_dev test-health remediation for T191384137.

Reviewed By: henrylhtsang

Differential Revision: D107927030


