### PR TITLE
Fix block_bucketize_sparse_features meta optional-output semantics

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -575,7 +575,11 @@ def block_bucketize_sparse_features_meta(
         indices.new_empty([num_values]),
         weights.new_empty(weights.shape) if weights is not None else None,
         indices.new_empty([num_values]) if bucketize_pos else None,
-        indices.new_empty([num_values]),
+        # The real CPU/CUDA kernels only return unbucketize_permute when
+        # `sequence` is set; otherwise the output is None. Match that so the
+        # FakeTensor opcheck variant no longer sees a Tensor-vs-None mismatch.
+        # See T191384137.
+        indices.new_empty([num_values]) if sequence else None,
     )
 
 


### PR DESCRIPTION
Summary:
block_bucketize_sparse_features_meta unconditionally returned a Tensor for the 5th
output (unbucketize_permute), but the real CPU/CUDA kernels return it only when
`sequence` is True (CPU sparse_ops_cpu.cpp:1175/1262/1280; CUDA
sparse_block_bucketize_features.cu:831-833/956-957; schema sparse_ops_cpu.cpp:3822
-> (Tensor, Tensor, Tensor?, Tensor?, Tensor?)). This Tensor-vs-None mismatch is the
root cause behind the block_bucketize test_faketensor__* opcheck xfails.

Gate output 5 on `sequence` (the param is already in scope) so the meta matches real
kernel semantics. outputs 3 (weights) and 4 (pos) were already correct.

The corresponding block_bucketize test_faketensor__* xfails in
sparse/failures_dict.json are intentionally left in place: once GPU CI confirms they
now pass they will surface as (tolerated) xsuccess and can be removed in a follow-up
cleanup. Removing them pre-emptively would hard-fail if any variant still mismatches.

Part of the fbgemm_dev test-health remediation for T191384137.

Reviewed By: henrylhtsang

Differential Revision: D107927031


