### PR TITLE
Exclude free-threaded py3.14t + ROCm wheel builds

### DIFF
--- a/.github/workflows/build_wheels_genai_linux_x86.yml
+++ b/.github/workflows/build_wheels_genai_linux_x86.yml
@@ -57,7 +57,7 @@ jobs:
         set -ex
         pwd
         ls
-        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter gpu_arch_version:11.8 --filter 'gpu_arch_type:rocm;python_version:3.13t' )"
+        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter gpu_arch_version:11.8 --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' )"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/build_wheels_linux_aarch64.yml
+++ b/.github/workflows/build_wheels_linux_aarch64.yml
@@ -53,7 +53,7 @@ jobs:
         set -ex
         pwd
         ls
-        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_type:rocm;python_version:3.13t' )"
+        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' )"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/build_wheels_linux_x86.yml
+++ b/.github/workflows/build_wheels_linux_x86.yml
@@ -55,7 +55,7 @@ jobs:
         set -ex
         pwd
         ls
-        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_type:rocm;python_version:3.13t' )"
+        MATRIX_BLOB="$( python .github/scripts/filter_nova_matrix.py --filter 'gpu_arch_type:rocm;python_version:3.13t,3.14t' )"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 

--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -575,7 +575,11 @@ def block_bucketize_sparse_features_meta(
         indices.new_empty([num_values]),
         weights.new_empty(weights.shape) if weights is not None else None,
         indices.new_empty([num_values]) if bucketize_pos else None,
-        indices.new_empty([num_values]),
+        # The real CPU/CUDA kernels only return unbucketize_permute when
+        # `sequence` is set; otherwise the output is None. Match that so the
+        # FakeTensor opcheck variant no longer sees a Tensor-vs-None mismatch.
+        # See T191384137.
+        indices.new_empty([num_values]) if sequence else None,
     )
 
 


### PR DESCRIPTION
Summary:
The py3_14t-rocm7_2 manywheel build/upload legs were failing in OSS CI (3 FAILING
signals on the fbgemm_dev surface, T191384137). Free-threaded Python 3.14 is not yet
supported for the ROCm wheel build, mirroring the already-excluded 3.13t+rocm combo.

Extend the existing Nova matrix exclusion from
  gpu_arch_type:rocm;python_version:3.13t
to
  gpu_arch_type:rocm;python_version:3.13t,3.14t
in the three wheel workflows that build ROCm (build_wheels_linux_x86,
build_wheels_genai_linux_x86, build_wheels_linux_aarch64). This drops the failing
py3.14t ROCm legs until upstream free-threaded ROCm support lands.

Reviewed By: henrylhtsang

Differential Revision: D107927032


