### PR TITLE
Make tbe.cache.cache_config canonical for TBE cache types

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -10,8 +10,17 @@
 # pyre-ignore-all-errors[56]
 
 import enum
-from dataclasses import dataclass
 from typing import NamedTuple
+
+# Cache types are canonical in fbgemm_gpu.tbe.cache.cache_config; re-export here so
+# the legacy import path keeps working.
+from fbgemm_gpu.tbe.cache.cache_config import (  # noqa: F401
+    CacheAlgorithm,
+    CacheState,
+    MultiPassPrefetchConfig,
+)
+
+# Config types are canonical
 
 # Config types are canonical in fbgemm_gpu.tbe.config.embedding_config; re-export
 # them here so the legacy `from ...ops_common import <Name>` path keeps working.
@@ -327,65 +336,10 @@ class BackendType(enum.IntEnum):
             raise ValueError(f"Cannot parse value into BackendType: {key}")
 
 
-class CacheAlgorithm(enum.Enum):
-    LRU = 0
-    LFU = 1
-
-
-class MultiPassPrefetchConfig(NamedTuple):
-    # Number of passes to split indices tensor into. Actual number of passes may
-    # be less if indices tensor is too small to split.
-    num_passes: int = 12
-
-    # The minimal number of element in indices tensor to be able to split into
-    # two passes. This is useful to prevent too many prefetch kernels spamming
-    # the CUDA launch queue.
-    # The default 6M indices means 6M * 8 * 6 = approx. 300MB of memory overhead
-    # per pass.
-    min_splitable_pass_size: int = 6 * 1024 * 1024
-
-
-@dataclass
-class CacheState:
-    # T + 1 elements and cache_hash_size_cumsum[-1] == total_cache_hash_size
-    cache_hash_size_cumsum: list[int]
-    cache_index_table_map: list[int]
-    total_cache_hash_size: int
-
-
 def construct_cache_state(
     row_list: list[int],
     location_list: list[EmbeddingLocation],
     feature_table_map: list[int],
 ) -> CacheState:
-    _cache_hash_size_cumsum = [0]
-    total_cache_hash_size = 0
-    for num_embeddings, location in zip(row_list, location_list):
-        if location == EmbeddingLocation.MANAGED_CACHING:
-            total_cache_hash_size += num_embeddings
-        _cache_hash_size_cumsum.append(total_cache_hash_size)
-    # [T], -1: non-cached table
-    cache_hash_size_cumsum = []
-    # [total_cache_hash_size], linear cache index -> table index
-    cache_index_table_map = [-1] * total_cache_hash_size
-    unique_feature_table_map = {}
-    for t, t_ in enumerate(feature_table_map):
-        unique_feature_table_map[t_] = t
-    for t_, t in unique_feature_table_map.items():
-        start, end = _cache_hash_size_cumsum[t_], _cache_hash_size_cumsum[t_ + 1]
-        cache_index_table_map[start:end] = [t] * (end - start)
-    cache_hash_size_cumsum = [
-        (
-            _cache_hash_size_cumsum[t_]
-            if location_list[t_] == EmbeddingLocation.MANAGED_CACHING
-            else -1
-        )
-        for t_ in feature_table_map
-    ]
-    cache_hash_size_cumsum.append(total_cache_hash_size)
-    s = CacheState(
-        cache_hash_size_cumsum=cache_hash_size_cumsum,
-        cache_index_table_map=cache_index_table_map,
-        total_cache_hash_size=total_cache_hash_size,
-    )
-    return s
+    """Backward-compatible free-function form of CacheState.construct()."""
+    return CacheState.construct(row_list, location_list, feature_table_map)

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -13,48 +13,24 @@ import enum
 from dataclasses import dataclass
 from typing import NamedTuple
 
-import torch
-from torch import Tensor
-
-# Maximum number of times prefetch() can be called without
-# a corresponding forward() call
-MAX_PREFETCH_DEPTH = 100
-
-# GPU and CPU use 16-bit scale and bias for quantized embedding bags in TBE
-# The total size is 2 + 2 = 4 bytes
-DEFAULT_SCALE_BIAS_SIZE_IN_BYTES = 4
-
-
-class EmbeddingLocation(enum.IntEnum):
-    DEVICE = 0
-    MANAGED = 1
-    MANAGED_CACHING = 2
-    HOST = 3
-    MTIA = 4
-
-    @classmethod
-    def str_values(cls) -> list[str]:
-        return [
-            "device",
-            "managed",
-            "managed_caching",
-            "host",
-            "mtia",
-        ]
-
-    @classmethod
-    def from_str(cls, key: str) -> "EmbeddingLocation":
-        lookup = {
-            "device": EmbeddingLocation.DEVICE,
-            "managed": EmbeddingLocation.MANAGED,
-            "managed_caching": EmbeddingLocation.MANAGED_CACHING,
-            "host": EmbeddingLocation.HOST,
-            "mtia": EmbeddingLocation.MTIA,
-        }
-        if key in lookup:
-            return lookup[key]
-        else:
-            raise ValueError(f"Cannot parse value into EmbeddingLocation: {key}")
+# Config types are canonical in fbgemm_gpu.tbe.config.embedding_config; re-export
+# them here so the legacy `from ...ops_common import <Name>` path keeps working.
+# (Cache/SSD types are still defined below; they migrate in follow-up diffs.)
+from fbgemm_gpu.tbe.config.embedding_config import (  # noqa: F401
+    BoundsCheckMode,
+    ComputeDevice,
+    DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
+    EmbeddingLocation,
+    EmbeddingSpecInfo,
+    get_bounds_check_version_for_platform,
+    get_new_embedding_location,
+    MAX_PREFETCH_DEPTH,
+    PoolingMode,
+    RecordCacheMetrics,
+    round_up,
+    SplitState,
+    tensor_to_device,
+)
 
 
 class EvictionPolicy(NamedTuple):
@@ -369,75 +345,6 @@ class MultiPassPrefetchConfig(NamedTuple):
     min_splitable_pass_size: int = 6 * 1024 * 1024
 
 
-class PoolingMode(enum.IntEnum):
-    SUM = 0
-    MEAN = 1
-    NONE = 2
-
-    def do_pooling(self) -> bool:
-        return self is not PoolingMode.NONE
-
-    @classmethod
-    def from_str(cls, key: str) -> "PoolingMode":
-        lookup = {
-            "sum": PoolingMode.SUM,
-            "mean": PoolingMode.MEAN,
-            "none": PoolingMode.NONE,
-        }
-        if key in lookup:
-            return lookup[key]
-        else:
-            raise ValueError(f"Cannot parse value into PoolingMode: {key}")
-
-
-class BoundsCheckMode(enum.IntEnum):
-    # Raise an exception (CPU) or device-side assert (CUDA)
-    FATAL = 0
-    # Log the first out-of-bounds instance per kernel, and set to zero.
-    WARNING = 1
-    # Set to zero.
-    IGNORE = 2
-    # No bounds checks.
-    NONE = 3
-    # IGNORE with V2 enabled
-    V2_IGNORE = 4
-    # WARNING with V2 enabled
-    V2_WARNING = 5
-    # FATAL with V2 enabled
-    V2_FATAL = 6
-
-
-class ComputeDevice(enum.IntEnum):
-    CPU = 0
-    CUDA = 1
-    MTIA = 2
-
-
-class EmbeddingSpecInfo(enum.IntEnum):
-    feature_names = 0
-    rows = 1
-    dims = 2
-    sparse_type = 3
-    embedding_location = 4
-
-
-RecordCacheMetrics: NamedTuple = NamedTuple(
-    "RecordCacheMetrics",
-    [("record_cache_miss_counter", bool), ("record_tablewise_cache_miss", bool)],
-)
-
-SplitState: NamedTuple = NamedTuple(
-    "SplitState",
-    [
-        ("dev_size", int),
-        ("host_size", int),
-        ("uvm_size", int),
-        ("placements", list[EmbeddingLocation]),
-        ("offsets", list[int]),
-    ],
-)
-
-
 @dataclass
 class CacheState:
     # T + 1 elements and cache_hash_size_cumsum[-1] == total_cache_hash_size
@@ -482,53 +389,3 @@ def construct_cache_state(
         total_cache_hash_size=total_cache_hash_size,
     )
     return s
-
-
-# NOTE: This is also defined in fbgemm_gpu.tbe.utils, but declaring
-# target dependency on :split_embedding_utils will result in compatibility
-# breakage with Caffe2 module_factory because it will pull in numpy
-def round_up(a: int, b: int) -> int:
-    return int((a + b - 1) // b) * b
-
-
-def tensor_to_device(tensor: torch.Tensor, device: torch.device) -> Tensor:
-    if tensor.device == torch.device("meta"):
-        return torch.empty_like(tensor, device=device)
-    return tensor.to(device)
-
-
-def get_new_embedding_location(
-    device: torch.device, cache_load_factor: float
-) -> EmbeddingLocation:
-    """
-    Based on the cache_load_factor and device, return the embedding location intended
-    for the TBE weights.
-    """
-    # Only support CPU and GPU device
-    assert device.type == "cpu" or device.type == "cuda"
-    if cache_load_factor < 0 or cache_load_factor > 1:
-        raise ValueError(
-            f"cache_load_factor must be between 0.0 and 1.0, got {cache_load_factor}"
-        )
-
-    if device.type == "cpu":
-        return EmbeddingLocation.HOST
-    # UVM only
-    elif cache_load_factor == 0:
-        return EmbeddingLocation.MANAGED
-    # HBM only
-    elif cache_load_factor == 1.0:
-        return EmbeddingLocation.DEVICE
-    # UVM caching
-    else:
-        return EmbeddingLocation.MANAGED_CACHING
-
-
-def get_bounds_check_version_for_platform() -> int:
-    # NOTE: Use bounds_check_indices v2 on ROCm because ROCm has a
-    # constraint that the gridDim * blockDim has to be smaller than
-    # 2^32. The v1 kernel can be launched with gridDim * blockDim >
-    # 2^32 while the v2 kernel limits the gridDim size to 64 * # of
-    # SMs.  Thus, its gridDim * blockDim is guaranteed to be smaller
-    # than 2^32
-    return 2 if (torch.cuda.is_available() and torch.version.hip) else 1

--- a/fbgemm_gpu/fbgemm_gpu/tbe/cache/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/cache/__init__.py
@@ -14,4 +14,14 @@ from .cache_config import (  # noqa: F401
     MultiPassPrefetchConfig,
     UVMCacheStatsIndex,
 )
-from .split_embeddings_cache_ops import get_unique_indices_v2  # noqa: F401
+
+# `.split_embeddings_cache_ops` ships only with the heavy `:tbe_cache_ops` BUCK
+# target. The lightweight `:tbe_cache_config` target legitimately omits it; guard
+# the import so the lightweight target loads cleanly. Eager (not PEP 562 lazy) so
+# the symbol resolves under torch.package, whose importer does not honor
+# importlib.import_module calls inside a module-level __getattr__.
+try:
+    # pyre-ignore[21]: `.split_embeddings_cache_ops` is only present in heavy target.
+    from .split_embeddings_cache_ops import get_unique_indices_v2  # noqa: F401
+except ImportError:
+    pass

--- a/fbgemm_gpu/fbgemm_gpu/tbe/config/embedding_config.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/config/embedding_config.py
@@ -196,3 +196,10 @@ def get_bounds_check_version_for_platform() -> int:
     # SMs.  Thus, its gridDim * blockDim is guaranteed to be smaller
     # than 2^32
     return 2 if (torch.cuda.is_available() and torch.version.hip) else 1
+
+
+def get_new_embedding_location(
+    device: torch.device, cache_load_factor: float
+) -> EmbeddingLocation:
+    """Backward-compatible free-function form of EmbeddingLocation.from_device_and_clf()."""
+    return EmbeddingLocation.from_device_and_clf(device, cache_load_factor)


### PR DESCRIPTION
Summary:
Second foundational diff of the BC-safe TBE type migration (cache types).

- tbe/cache/cache_config.py is the canonical home for CacheAlgorithm, CacheState,
  MultiPassPrefetchConfig, UVMCacheStatsIndex, DEFAULT_ASSOC. Pins
  CacheAlgorithm.__module__ back to split_table_batched_embeddings_ops_common so
  already-published scripted TorchScript graphs / torchrec CacheParams pickles
  still resolve and repackage (torch.package never rewrites a class __module__).
- tbe/cache/__init__.py guards the heavy .split_embeddings_cache_ops import with
  try/except so the new lightweight :tbe_cache_config target loads cleanly.
- split_table_batched_embeddings_ops_common.py drops its duplicate cache-type
  definitions and re-exports them from the leaf; construct_cache_state becomes a
  thin forwarder to CacheState.construct(). Legacy import path preserved.
- BUCK: add lightweight :tbe_cache_config (cache __init__ + cache_config.py);
  :tbe_cache_ops now omits cache_config.py and deps :tbe_cache_config;
  ops_common deps += :tbe_cache_config. Acyclic (leaf-or-shim -> tbe_cache_config
  -> tbe_config; ops_common -> tbe_cache_config).

Safe, acyclic, identity-preserving version of the cache portion of D103477971
(which caused SEV S669532). See plan fbgemm_tbe_type_migration_bc_safe A.2/A.4.

Reviewed By: henrylhtsang

Differential Revision: D107684313


