### PR TITLE
Add populate_bucketized_permute meta + fix block_bucketize opcheck

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -615,7 +615,11 @@ def block_bucketize_sparse_features_inference_meta(
         indices.new_empty([num_values]),
         weights.new_empty(weights.shape) if weights is not None else None,
         indices.new_empty([num_values]) if bucketize_pos else None,
-        indices.new_empty([num_values]),
+        # The real CPU/CUDA inference kernels only return unbucketize_permute
+        # when `sequence` is set (sparse_block_bucketize_features.cu:956); match
+        # that so the FakeTensor opcheck variant no longer sees a Tensor-vs-None
+        # mismatch. See T191384137.
+        indices.new_empty([num_values]) if sequence else None,
         indices.new_empty([num_values]) if return_bucket_mapping else None,
     )
 
@@ -651,8 +655,22 @@ def block_bucketize_sparse_features_2d_weights_meta(
         indices.new_empty([num_values]),
         weights.new_empty([num_values, weights_dim]),
         indices.new_empty([num_values]) if bucketize_pos else None,
-        indices.new_empty([num_values]),
+        # Match the real kernel: unbucketize_permute is only returned when
+        # `sequence` is set (sparse_block_bucketize_features.cu:956). T191384137.
+        indices.new_empty([num_values]) if sequence else None,
     )
+
+
+def populate_bucketized_permute_meta(
+    lengths: torch.Tensor,
+    bucketized_lengths: torch.Tensor,
+    bucket_mapping: torch.Tensor,
+) -> torch.Tensor:
+    # The real CPU/CUDA kernels return native_empty_like(bucket_mapping), i.e. an
+    # output with the same shape/dtype as bucket_mapping
+    # (sparse_ops_cpu.cpp:1117). Without this meta, the op has no abstract impl
+    # and all of its FakeTensor / aot_dispatch opcheck variants fail. T191384137.
+    return torch.empty_like(bucket_mapping)
 
 
 def merge_pooled_embeddings(
@@ -1425,6 +1443,10 @@ def _setup() -> None:
         impl_abstract(
             "fbgemm::block_bucketize_sparse_features_2d_weights",
             block_bucketize_sparse_features_2d_weights_meta,
+        )
+        impl_abstract(
+            "fbgemm::populate_bucketized_permute",
+            populate_bucketized_permute_meta,
         )
         impl_abstract("fbgemm::merge_pooled_embeddings", merge_pooled_embeddings)
         impl_abstract(

--- a/fbgemm_gpu/test/sparse/block_bucketize_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_test.py
@@ -22,6 +22,7 @@ if open_source:
     # pyre-ignore[21]
     from test_utils import gpu_available
 else:
+    import fbgemm_gpu.sparse_ops  # noqa: F401, E402  (registers FakeTensor/meta impls)
     from fbgemm_gpu.test.test_utils import gpu_available
 
 

--- a/fbgemm_gpu/test/sparse/failures_dict.json
+++ b/fbgemm_gpu/test/sparse/failures_dict.json
@@ -24,94 +24,6 @@
       "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights_vs_original": {
         "comment": "",
         "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_float64_weights": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_keep_orig_idx_per_feature": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_large": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_long_indices": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_total_num_blocks": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_total_num_blocks_raw_ids": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_total_num_blocks_uneven": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_total_num_blocks_uneven_raw_ids": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_with_block_bucketize_pos": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_with_variable_batch_sizes": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_float64_weights": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_keep_orig_idx_per_feature": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_large": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_long_indices": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_total_num_blocks": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_total_num_blocks_raw_ids": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_total_num_blocks_uneven": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_total_num_blocks_uneven_raw_ids": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_with_block_bucketize_pos": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_with_variable_batch_sizes": {
-        "comment": "",
-        "status": "xfail"
       }
     },
     "fbgemm::block_bucketize_sparse_features_2d_weights": {
@@ -279,16 +191,7 @@
         "status": "xfail"
       }
     },
-    "fbgemm::populate_bucketized_permute": {
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_populate_bucketized_permute": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_populate_bucketized_permute": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
+    "fbgemm::populate_bucketized_permute": {},
     "fbgemm::reorder_batched_ad_indices": {
       "ReorderBatchedTest.test_aot_dispatch_dynamic__test_reorder_batched_ad_indices": {
         "comment": "",


### PR DESCRIPTION
Summary:
block_bucketize_test had 14+ FAILING test_faketensor__ / test_aot_dispatch_dynamic__
opcheck variants (populate_bucketized_permute*, block_bucketize_sparse_features_inference).
Two root causes:

1. block_bucketize_test.py was MISSING `import fbgemm_gpu.sparse_ops` -- every sibling
   sparse test file has it, and fbgemm_gpu/__init__ only imports it in OSS. Without it
   the Python meta/FakeTensor impls in sparse_ops.py were never registered in the test
   process, so every faketensor/aot_dispatch opcheck variant errored
   ("could not find the abstract impl ... import fbgemm_gpu.sparse_ops"). The xfail'd
   variants "passed" via that error; the non-xfail'd ones (populate, inference) failed.
2. populate_bucketized_permute had NO meta at all, and the inference / 2d_weights metas
   returned unbucketize_permute (output 5) unconditionally, but the real CPU/CUDA kernels
   only return it when `sequence` is set (sparse_block_bucketize_features.cu:956).

Fixes:
- Add `import fbgemm_gpu.sparse_ops` to block_bucketize_test.py so the metas load.
- Add populate_bucketized_permute_meta (returns empty_like(bucket_mapping), matching
  native_empty_like in sparse_ops_cpu.cpp:1117) and register it via impl_abstract.
- Gate output 5 on `sequence` in block_bucketize_sparse_features_inference_meta and
  block_bucketize_sparse_features_2d_weights_meta (same fix as D107927031 for the base op).
- With the metas now correctly loaded, 22 previously-xfail'd block_bucketize_sparse_features
  faketensor/aot_dispatch entries became unexpected successes -> removed them from
  sparse/failures_dict.json (kept the 2 BlockBucketize2DWeightsTest *_vs_original entries
  that still genuinely fail).

Part of the fbgemm_dev test-health remediation for T191384137.

Reviewed By: henrylhtsang

Differential Revision: D108108673


