### PR TITLE
Fix block_bucketize 2DWeightsTest opcheck faketensor failures

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -615,7 +615,11 @@ def block_bucketize_sparse_features_inference_meta(
         indices.new_empty([num_values]),
         weights.new_empty(weights.shape) if weights is not None else None,
         indices.new_empty([num_values]) if bucketize_pos else None,
-        indices.new_empty([num_values]),
+        # The real CPU/CUDA inference kernels only return unbucketize_permute
+        # when `sequence` is set (sparse_block_bucketize_features.cu:956); match
+        # that so the FakeTensor opcheck variant no longer sees a Tensor-vs-None
+        # mismatch. See T191384137.
+        indices.new_empty([num_values]) if sequence else None,
         indices.new_empty([num_values]) if return_bucket_mapping else None,
     )
 
@@ -651,8 +655,22 @@ def block_bucketize_sparse_features_2d_weights_meta(
         indices.new_empty([num_values]),
         weights.new_empty([num_values, weights_dim]),
         indices.new_empty([num_values]) if bucketize_pos else None,
-        indices.new_empty([num_values]),
+        # Match the real kernel: unbucketize_permute is only returned when
+        # `sequence` is set (sparse_block_bucketize_features.cu:956). T191384137.
+        indices.new_empty([num_values]) if sequence else None,
     )
+
+
+def populate_bucketized_permute_meta(
+    lengths: torch.Tensor,
+    bucketized_lengths: torch.Tensor,
+    bucket_mapping: torch.Tensor,
+) -> torch.Tensor:
+    # The real CPU/CUDA kernels return native_empty_like(bucket_mapping), i.e. an
+    # output with the same shape/dtype as bucket_mapping
+    # (sparse_ops_cpu.cpp:1117). Without this meta, the op has no abstract impl
+    # and all of its FakeTensor / aot_dispatch opcheck variants fail. T191384137.
+    return torch.empty_like(bucket_mapping)
 
 
 def merge_pooled_embeddings(
@@ -1425,6 +1443,10 @@ def _setup() -> None:
         impl_abstract(
             "fbgemm::block_bucketize_sparse_features_2d_weights",
             block_bucketize_sparse_features_2d_weights_meta,
+        )
+        impl_abstract(
+            "fbgemm::populate_bucketized_permute",
+            populate_bucketized_permute_meta,
         )
         impl_abstract("fbgemm::merge_pooled_embeddings", merge_pooled_embeddings)
         impl_abstract(

--- a/fbgemm_gpu/test/sparse/block_bucketize_2d_weights_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_2d_weights_test.py
@@ -21,6 +21,7 @@ if open_source:
     # pyre-ignore[21]
     from test_utils import gpu_available
 else:
+    import fbgemm_gpu.sparse_ops  # noqa: F401, E402  (registers FakeTensor/meta impls)
     from fbgemm_gpu.test.test_utils import gpu_available
 
 

--- a/fbgemm_gpu/test/sparse/block_bucketize_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_test.py
@@ -22,6 +22,7 @@ if open_source:
     # pyre-ignore[21]
     from test_utils import gpu_available
 else:
+    import fbgemm_gpu.sparse_ops  # noqa: F401, E402  (registers FakeTensor/meta impls)
     from fbgemm_gpu.test.test_utils import gpu_available
 
 

--- a/fbgemm_gpu/test/sparse/failures_dict.json
+++ b/fbgemm_gpu/test/sparse/failures_dict.json
@@ -16,82 +16,8 @@
     "fbgemm::asynchronous_exclusive_cumsum": {},
     "fbgemm::asynchronous_inclusive_cumsum": {},
     "fbgemm::batch_index_select_dim0": {},
-    "fbgemm::block_bucketize_sparse_features": {
-      "BlockBucketize2DWeightsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_2d_weights_vs_original": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights_vs_original": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
-    "fbgemm::block_bucketize_sparse_features_2d_weights": {
-      "BlockBucketize2DWeightsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_2d_weights": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketize2DWeightsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_2d_weights_block_bucketize_pos": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketize2DWeightsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_2d_weights_keep_orig_idx": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketize2DWeightsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_2d_weights_keep_orig_idx_per_feature": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketize2DWeightsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_2d_weights_pooled_vs_sequence": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketize2DWeightsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_2d_weights_total_num_blocks": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketize2DWeightsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_2d_weights_vs_original": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketize2DWeightsTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_2d_weights_with_variable_batch_sizes": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights_block_bucketize_pos": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights_keep_orig_idx": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights_keep_orig_idx_per_feature": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights_pooled_vs_sequence": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights_total_num_blocks": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights_vs_original": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights_with_variable_batch_sizes": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
+    "fbgemm::block_bucketize_sparse_features": {},
+    "fbgemm::block_bucketize_sparse_features_2d_weights": {},
     "fbgemm::block_bucketize_sparse_features_inference": {},
     "fbgemm::bottom_k_per_row": {
       "MiscOpsTest.test_aot_dispatch_dynamic__test_bottom_unique_k_per_row": {

--- a/fbgemm_gpu/test/sparse/failures_dict.json
+++ b/fbgemm_gpu/test/sparse/failures_dict.json
@@ -24,94 +24,6 @@
       "BlockBucketize2DWeightsTest.test_faketensor__test_block_bucketize_sparse_features_2d_weights_vs_original": {
         "comment": "",
         "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_float64_weights": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_keep_orig_idx_per_feature": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_large": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_long_indices": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_total_num_blocks": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_total_num_blocks_raw_ids": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_total_num_blocks_uneven": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_total_num_blocks_uneven_raw_ids": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_with_block_bucketize_pos": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_block_bucketize_sparse_features_with_variable_batch_sizes": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_float64_weights": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_keep_orig_idx_per_feature": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_large": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_long_indices": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_total_num_blocks": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_total_num_blocks_raw_ids": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_total_num_blocks_uneven": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_total_num_blocks_uneven_raw_ids": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_with_block_bucketize_pos": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_block_bucketize_sparse_features_with_variable_batch_sizes": {
-        "comment": "",
-        "status": "xfail"
       }
     },
     "fbgemm::block_bucketize_sparse_features_2d_weights": {
@@ -279,16 +191,7 @@
         "status": "xfail"
       }
     },
-    "fbgemm::populate_bucketized_permute": {
-      "BlockBucketizeTest.test_aot_dispatch_dynamic__test_populate_bucketized_permute": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BlockBucketizeTest.test_faketensor__test_populate_bucketized_permute": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
+    "fbgemm::populate_bucketized_permute": {},
     "fbgemm::reorder_batched_ad_indices": {
       "ReorderBatchedTest.test_aot_dispatch_dynamic__test_reorder_batched_ad_indices": {
         "comment": "",


### PR DESCRIPTION
Summary:
Same root cause as D108108673: block_bucketize_2d_weights_test.py was missing
`import fbgemm_gpu.sparse_ops`, so the Python meta/FakeTensor impls were never
registered for that test process and every faketensor/aot_dispatch opcheck variant
errored ("could not find the abstract impl"). The xfail'd variants "passed" via the
error; the genuine ones failed.

Adding the import (which all sibling sparse test files already have) loads the metas --
including the block_bucketize_sparse_features_2d_weights_meta sequence-gating fix from
D108108673. With the metas loaded, all 16 previously-xfail'd BlockBucketize2DWeightsTest
faketensor/aot_dispatch entries became unexpected successes, so they are removed from
sparse/failures_dict.json:
- fbgemm::block_bucketize_sparse_features_2d_weights: 16 -> 0
- fbgemm::block_bucketize_sparse_features: 2 -> 0 (the *_2d_weights_vs_original entries,
  which opcheck the base op from the 2DWeights test, also now pass)

Part of the fbgemm_dev test-health remediation for T191384137.

Differential Revision: D108114892


