### PR TITLE
dense_to_jagged_forward: realize total_L SymInt before empty

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/dense_to_jagged_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/dense_to_jagged_forward.cu
@@ -19,14 +19,21 @@ Tensor dense_to_jagged_forward(
   // D is the embedding dimension
   auto D = dense.size(-1);
 
-  // If total_L is not given then compute it
-  at::SymInt total_L_computed;
+  // If total_L is not given then compute it. We realize total_L to a
+  // concrete int64 here (via guard_int) instead of forwarding the raw
+  // SymInt to at::empty_symint. The aten empty.memory_format CUDA/HIP
+  // wrapper calls C10_AS_INTARRAYREF_SLOW on its size argument, which
+  // TORCH_CHECKs that no SymInt in the array is heap-allocated -- so a
+  // heap SymInt that arrives here (e.g. an unbacked SymInt produced
+  // inside a torch.compile region) would crash with
+  //   "SymIntArrayRef expected to contain only concrete integers".
+  int64_t total_L_computed;
   if (total_L.has_value()) {
-    total_L_computed = total_L.value();
+    total_L_computed = total_L.value().guard_int(__FILE__, __LINE__);
   } else {
-    total_L_computed = (int64_t)offsets.back().max().item<int64_t>();
+    total_L_computed = offsets.back().max().item<int64_t>();
   }
-  auto values = at::empty_symint({total_L_computed, D}, dense.options());
+  auto values = at::empty({total_L_computed, D}, dense.options());
   auto output = at::empty_like(values);
 
   CUDA_DEVICE_GUARD(dense);

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -467,16 +467,17 @@ Tensor dense_to_jagged_forward(
   // D is the embedding dimension
   auto D = dense.size(-1);
 
-  // If total_L is not given then compute it
-  at::SymInt total_L_computed;
+  // Realize total_L to a concrete int64 (see CUDA variant for the full
+  // explanation -- forwarding a heap SymInt to empty/zeros_symint crashes
+  // in the empty.memory_format wrapper's C10_AS_INTARRAYREF_SLOW).
+  int64_t total_L_computed;
   if (total_L.has_value()) {
-    total_L_computed = total_L.value();
+    total_L_computed = total_L.value().guard_int(__FILE__, __LINE__);
   } else {
-    total_L_computed =
-        static_cast<int64_t>(offsets.back().max().item<int64_t>());
+    total_L_computed = offsets.back().max().item<int64_t>();
   }
-  auto values = at::empty_symint({total_L_computed, D}, dense.options());
-  auto output = at::zeros_symint({total_L_computed, D}, dense.options());
+  auto values = at::empty({total_L_computed, D}, dense.options());
+  auto output = at::zeros({total_L_computed, D}, dense.options());
 
   FBGEMM_DISPATCH_ALL_TYPES(values.scalar_type(), "jagged_scalars", [&] {
     jagged_dense_elementwise_jagged_output_<scalar_t>(

--- a/fbgemm_gpu/test/jagged/dense_to_jagged_test.py
+++ b/fbgemm_gpu/test/jagged/dense_to_jagged_test.py
@@ -368,6 +368,79 @@ class DenseToJaggedTest(unittest.TestCase):
         # verify forward
         assert dense.size() == dense2.size()
 
+    @optests.dontGenerateOpCheckTests("regression test, not an op-shape check")
+    @unittest.skipIf(*gpu_unavailable)
+    def test_dense_to_jagged_heap_symint_total_L(self) -> None:
+        """Regression: dense_to_jagged_forward crashes on AMD/HIP when the
+        total_L argument is a heap-allocated SymInt rather than an inline
+        concrete int.
+
+        Production failure (Stories LSR on MI350X, MAST f1096341099): the
+        outer forward is wrapped by torch.compile; downstream a Python int
+        num_events was symbolicalized into a heap SymInt and forwarded to
+        torch.ops.fbgemm.dense_to_jagged. dense_to_jagged_forward.cu then
+        calls
+            at::empty_symint({total_L_computed, D}, ...)
+        with the heap SymInt. On the hipified empty.memory_format dispatcher
+        the shape array goes through asIntArrayRefSlow which raises
+            "SymIntArrayRef expected to contain only concrete integers"
+        or, when the SymNode pointer slips through unchecked, lands in
+        empty_generic with the pointer reinterpreted as int64, producing
+            "Trying to create tensor with negative dimension <huge negative>".
+
+        This test bypasses dynamo and constructs the heap SymInt directly
+        via ShapeEnv.create_unbacked_symint(), then calls the real op with
+        a real CUDA/HIP tensor. That reproduces the exact kernel-level
+        condition without depending on which torch.compile backend / version
+        chooses to preserve vs. realize the SymInt.
+
+        Fix: dense_to_jagged_forward must realize the total_L SymInt to a
+        concrete int64 (via .guard_int(__FILE__, __LINE__)) before
+        constructing the empty output, instead of forwarding the raw SymInt
+        to empty_symint.
+        """
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        device = torch.accelerator.current_accelerator()
+
+        B = 4
+        D = 8
+        max_L = 16
+        total_L_concrete = 17
+
+        lengths = torch.tensor([3, 5, 2, 7], dtype=torch.long, device=device)
+        offsets = torch.zeros(B + 1, dtype=torch.long, device=device)
+        offsets[1:] = lengths.cumsum(0)
+        self.assertEqual(int(offsets[-1].item()), total_L_concrete)
+
+        dense = torch.randn(B, max_L, D, dtype=torch.float32, device=device)
+
+        # Construct an unbacked, heap-allocated SymInt with no hint. The
+        # IValue(c10::SymInt) constructor only preserves heap-ness when the
+        # SymNode's maybe_as_int() returns None -- i.e. when the SymInt is
+        # truly unbacked (no hint, no constant simplification). A SymInt
+        # with a hint is collapsed to Tag::Int (inline) by IValue and would
+        # not exercise the kernel-level crash path.
+        shape_env = ShapeEnv()
+        total_L_sym = shape_env.create_unbacked_symint()
+
+        # Pre-fix kernel forwards this heap SymInt to at::empty_symint,
+        # which crashes in the empty.memory_format HIP wrapper at
+        #   "SymIntArrayRef expected to contain only concrete integers".
+        # Post-fix the kernel realizes total_L via guard_int(__FILE__, __LINE__)
+        # before constructing the empty output. guard_int on a truly
+        # unbacked SymNode (no hint, no runtime guard) raises a clean
+        # GuardOnDataDependentSymNode -- which is the correct user-visible
+        # behavior: "the kernel cannot allocate without a concrete size."
+        # That clean error is what we assert here. The buggy pre-fix path
+        # raised the low-level SymIntArrayRef error from inside the empty
+        # wrapper, which fails this regex match.
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"Could not extract specialized integer from data-dependent expression",
+        ):
+            torch.ops.fbgemm.dense_to_jagged(dense, [offsets], total_L_sym)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2793

CONTEXT: On AMD MI350X (HIP), MAST job `fire-fandw06-f1096341099` (Stories LSR
train_eval) crashed inside `fbgemm::dense_to_jagged` during the forward pass
of `UhmEventTokenizer.get_position_encoding`. Two related symptoms appeared
across ranks:
  - `RuntimeError: ...RegisterCUDA_0.cpp:7563: SymIntArrayRef expected to
    contain only concrete integers` (asIntArrayRefSlow check fired)
  - `RuntimeError: Trying to create tensor with negative dimension
    -1409625905161306112: [-1409625905161306112, 8]` (heap SymNode pointer
    reinterpreted as int64 in `at::detail::empty_generic`)

`dense_to_jagged_forward.cu` and the CPU variant forward an
`std::optional<at::SymInt> total_L` straight into
`at::empty_symint({total_L, D}, ...)`. The aten `empty.memory_format` CUDA/HIP
wrapper at `RegisterCUDA_0.cpp` calls `C10_AS_INTARRAYREF_SLOW` on the size
array, which `TORCH_CHECK`s that no `SymInt` in the array is
`is_heap_allocated()`. Any heap-allocated `SymInt` arriving here (e.g. an
unbacked SymInt produced inside a `torch.compile` region in production)
trips that check, or - depending on how the dispatcher walked the array -
leaks the `SymNode` pointer through as a raw `int64_t` dimension.

WHAT: Realize `total_L` to a concrete `int64_t` via `guard_int(__FILE__,
__LINE__)` before constructing the output tensor, and switch the allocation
from `at::empty_symint` / `at::zeros_symint` (SymInt-shape) to `at::empty` /
`at::zeros` (`int64_t` shape). For heap SymInts with a hint or a runtime
guard `guard_int` resolves cleanly to the concrete value; for truly unbacked
SymInts with no value the kernel now produces a clean
`"Could not extract specialized integer from data-dependent expression"`
error instead of the low-level memory crash.

Same fix applied to both the CUDA/HIP kernel
(`src/jagged_tensor_ops/dense_to_jagged_forward.cu`) and the CPU kernel
(`src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp`).

Adds a regression test `test_dense_to_jagged_heap_symint_total_L` that
constructs an unbacked, heap-allocated SymInt via
`ShapeEnv.create_unbacked_symint()` and calls
`torch.ops.fbgemm.dense_to_jagged` directly. Pre-fix the test fails with the
`SymIntArrayRef` crash; post-fix it passes (asserting the clean `guard_int`
error path).

Differential Revision: D108236923


