### PR TITLE
Make tbe.ssd.ssd_config canonical; ops_common is now a shim

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_common.py
@@ -9,22 +9,24 @@
 
 # pyre-ignore-all-errors[56]
 
-import enum
-from typing import NamedTuple
+"""
+Backward-compatible re-export shell for TBE common types.
 
-# Cache types are canonical in fbgemm_gpu.tbe.cache.cache_config; re-export here so
-# the legacy import path keeps working.
+Canonical definitions live in the ``fbgemm_gpu.tbe.*`` leaf modules
+(``tbe.config.embedding_config``, ``tbe.cache.cache_config``,
+``tbe.ssd.ssd_config``); this module re-exports them so the legacy
+``from fbgemm_gpu.split_table_batched_embeddings_ops_common import ...`` path keeps
+working. ``__module__`` is intentionally not pinned (pinning breaks
+``torch.jit.script``, which resolves a type's source via ``cls.__module__``).
+"""
+
+from typing import TYPE_CHECKING
+
 from fbgemm_gpu.tbe.cache.cache_config import (  # noqa: F401
     CacheAlgorithm,
     CacheState,
     MultiPassPrefetchConfig,
 )
-
-# Config types are canonical
-
-# Config types are canonical in fbgemm_gpu.tbe.config.embedding_config; re-export
-# them here so the legacy `from ...ops_common import <Name>` path keeps working.
-# (Cache/SSD types are still defined below; they migrate in follow-up diffs.)
 from fbgemm_gpu.tbe.config.embedding_config import (  # noqa: F401
     BoundsCheckMode,
     ComputeDevice,
@@ -41,299 +43,19 @@ from fbgemm_gpu.tbe.config.embedding_config import (  # noqa: F401
     tensor_to_device,
 )
 
-
-class EvictionPolicy(NamedTuple):
-    eviction_trigger_mode: int = (
-        0  # disabled, 0: disabled, 1: iteration, 2: mem_util, 3: manual 4: id count
+# SSD/KVZCH types are re-exported lazily (see ``__getattr__`` below). Importing
+# ``tbe.ssd.ssd_config`` eagerly here triggers a tbe.ssd -> .training -> ops_training
+# import cycle (D107684315); ``TYPE_CHECKING`` keeps static types without that import.
+if TYPE_CHECKING:
+    from fbgemm_gpu.tbe.ssd.ssd_config import (  # noqa: F401
+        BackendType,
+        EnrichmentPolicy,
+        EnrichmentResponseFormat,
+        EnrichmentType,
+        EvictionPolicy,
+        KVZCHParams,
+        KVZCHTBEConfig,
     )
-    eviction_strategy: int = (
-        0  # 0: timestamp, 1: counter , 2: counter + timestamp, 3: feature l2 norm 4: timestamp threshold 5: feature score
-    )
-    eviction_step_intervals: int | None = (
-        None  # trigger_step_interval if trigger mode is iteration
-    )
-    eviction_mem_threshold_gb: int | None = (
-        None  # eviction trigger condition if trigger mode is mem_util
-    )
-    counter_thresholds: list[int] | None = (
-        None  # count_thresholds for each table if eviction strategy is counter
-    )
-    ttls_in_mins: list[int] | None = (
-        None  # ttls_in_mins for each table if eviction strategy is timestamp
-    )
-    counter_decay_rates: list[float] | None = (
-        None  # count_decay_rates for each table if eviction strategy is counter
-    )
-    feature_score_counter_decay_rates: list[float] | None = (
-        None  # feature_score_counter_decay_rates for each table if eviction strategy is feature score
-    )
-    training_id_eviction_trigger_count: list[int] | None = (
-        None  # Number of training IDs that, when exceeded, will trigger eviction for each table.
-    )
-    training_id_keep_count: list[int] | None = (
-        None  # Target number of training IDs to retain in each table after eviction.
-    )
-    l2_weight_thresholds: list[float] | None = (
-        None  # l2_weight_thresholds for each table if eviction strategy is feature l2 norm
-    )
-    threshold_calculation_bucket_stride: float | None = (
-        0.2  # The width of each feature score bucket used for threshold calculation in feature score-based eviction.
-    )
-    threshold_calculation_bucket_num: int | None = (
-        1000000  # 1M, Total number of feature score buckets used for threshold calculation in feature score-based eviction.
-    )
-    interval_for_insufficient_eviction_s: int = (
-        # wait at least # seconds before trigger next round of eviction, if last finished eviction is insufficient
-        # insufficient means we didn't evict enough rows, so we want to wait longer time to
-        # avoid another insufficient eviction
-        600
-    )
-    interval_for_sufficient_eviction_s: int = (
-        # wait at least # seconds before trigger next round of eviction, if last finished eviction is sufficient
-        60
-    )
-    interval_for_feature_statistics_decay_s: int = (
-        24 * 3600  # 1 day, interval for feature statistics decay
-    )
-    meta_header_lens: list[int] | None = None  # metaheader length for each table
-    eviction_free_mem_threshold_gb: int | None = (
-        None  # Minimum free memory (in GB) required before triggering eviction when using free_mem trigger mode.
-    )
-    eviction_free_mem_check_interval_batch: int | None = (
-        None  # Number of batches between checks for free memory threshold when using free_mem trigger mode.
-    )
-    enable_eviction_for_feature_score_eviction_policy: list[bool] | None = (
-        None  # enable eviction if eviction policy is feature score, false means no eviction
-    )
-
-    def validate(self) -> None:
-        assert self.eviction_trigger_mode in [0, 1, 2, 3, 4, 5], (
-            "eviction_trigger_mode must be 0, 1, 2, 3, 4, 5"
-            f"actual {self.eviction_trigger_mode}"
-        )
-        if self.eviction_trigger_mode == 0:
-            return
-
-        assert self.eviction_strategy in [0, 1, 2, 3, 4, 5], (
-            "eviction_strategy must be 0, 1, 2, 3, 4 or 5, "
-            f"actual {self.eviction_strategy}"
-        )
-        if self.eviction_trigger_mode == 1:
-            assert (
-                self.eviction_step_intervals is not None
-                and self.eviction_step_intervals > 0
-            ), (
-                "eviction_step_intervals must be positive if eviction_trigger_mode is 1, "
-                f"actual {self.eviction_step_intervals}"
-            )
-        elif self.eviction_trigger_mode == 2:
-            assert (
-                self.eviction_mem_threshold_gb is not None
-            ), "eviction_mem_threshold_gb must be set if eviction_trigger_mode is 2"
-        elif self.eviction_trigger_mode == 4:
-            assert (
-                self.training_id_eviction_trigger_count is not None
-            ), "training_id_eviction_trigger_count must be set if eviction_trigger_mode is 4"
-        elif self.eviction_trigger_mode == 5:
-            assert (
-                self.eviction_free_mem_threshold_gb is not None
-            ), "eviction_free_mem_threshold_gb must be set if eviction_trigger_mode is 5"
-            assert (
-                self.eviction_free_mem_check_interval_batch is not None
-            ), "eviction_free_mem_check_interval_batch must be set if eviction_trigger_mode is 5"
-
-        if self.eviction_strategy == 0:
-            assert self.ttls_in_mins is not None, (
-                "ttls_in_mins must be set if eviction_strategy is 0, "
-                f"actual {self.ttls_in_mins}"
-            )
-        elif self.eviction_strategy == 1:
-            assert self.counter_thresholds is not None, (
-                "counter_thresholds must be set if eviction_strategy is 1, "
-                f"actual {self.counter_thresholds}"
-            )
-            assert self.counter_decay_rates is not None, (
-                "counter_decay_rates must be set if eviction_strategy is 1, "
-                f"actual {self.counter_decay_rates}"
-            )
-            assert len(self.counter_thresholds) == len(self.counter_decay_rates), (
-                "counter_thresholds and counter_decay_rates must have the same length, "
-                f"actual {self.counter_thresholds} vs {self.counter_decay_rates}"
-            )
-        elif self.eviction_strategy == 2:
-            assert self.counter_thresholds is not None, (
-                "counter_thresholds must be set if eviction_strategy is 2, "
-                f"actual {self.counter_thresholds}"
-            )
-            assert self.counter_decay_rates is not None, (
-                "counter_decay_rates must be set if eviction_strategy is 2, "
-                f"actual {self.counter_decay_rates}"
-            )
-            assert self.ttls_in_mins is not None, (
-                "ttls_in_mins must be set if eviction_strategy is 2, "
-                f"actual {self.ttls_in_mins}"
-            )
-            assert len(self.counter_thresholds) == len(self.counter_decay_rates), (
-                "counter_thresholds and counter_decay_rates must have the same length, "
-                f"actual {self.counter_thresholds} vs {self.counter_decay_rates}"
-            )
-            assert len(self.counter_thresholds) == len(self.ttls_in_mins), (
-                "counter_thresholds and ttls_in_mins must have the same length, "
-                f"actual {self.counter_thresholds} vs {self.ttls_in_mins}"
-            )
-        elif self.eviction_strategy == 5:
-            assert self.feature_score_counter_decay_rates is not None, (
-                "feature_score_counter_decay_rates must be set if eviction_strategy is 5, "
-                f"actual {self.feature_score_counter_decay_rates}"
-            )
-            assert self.training_id_eviction_trigger_count is not None, (
-                "training_id_eviction_trigger_count must be set if eviction_strategy is 5,"
-                f"actual {self.training_id_eviction_trigger_count}"
-            )
-            assert self.training_id_keep_count is not None, (
-                "training_id_keep_count must be set if eviction_strategy is 5,"
-                f"actual {self.training_id_keep_count}"
-            )
-            assert self.threshold_calculation_bucket_stride is not None, (
-                "threshold_calculation_bucket_stride must be set if eviction_strategy is 5,"
-                f"actual {self.threshold_calculation_bucket_stride}"
-            )
-            assert self.threshold_calculation_bucket_num is not None, (
-                "threshold_calculation_bucket_num must be set if eviction_strategy is 5,"
-                f"actual {self.threshold_calculation_bucket_num}"
-            )
-            assert self.enable_eviction_for_feature_score_eviction_policy is not None, (
-                "enable_eviction_for_feature_score_eviction_policy must be set if eviction_strategy is 5,"
-                f"actual {self.enable_eviction_for_feature_score_eviction_policy}"
-            )
-            assert (
-                len(self.enable_eviction_for_feature_score_eviction_policy)
-                == len(self.training_id_keep_count)
-                == len(self.feature_score_counter_decay_rates)
-            ), (
-                "feature_score_thresholds, enable_eviction_for_feature_score_eviction_policy, and training_id_keep_count must have the same length, "
-                f"actual {self.training_id_keep_count} vs {self.feature_score_counter_decay_rates} vs {self.enable_eviction_for_feature_score_eviction_policy}"
-            )
-
-
-class EnrichmentType(enum.IntEnum):
-    IGR_LASER_EMBEDDING = 0
-    IGR_LASER_SID = 1
-    ONEFLOW_OPENTAB_SID = 2
-    ONEFLOW_FEATURE_STORE_SID = 3
-    # Test-only: in-process fake that returns deterministic embeddings derived
-    # from the requested ID. Used by hermetic tests to exercise the
-    # enrichment + EC.write() round trip without a real Laser tier.
-    IN_MEMORY_TEST_ONLY = 4
-
-
-class EnrichmentResponseFormat(enum.IntEnum):
-    JSON = 0
-    THRIFT_FLOAT = 1
-    THRIFT_INT64 = 2
-
-
-class EnrichmentPolicy(NamedTuple):
-    # Model and method identifier
-    enrichment_type: EnrichmentType = EnrichmentType.IGR_LASER_EMBEDDING
-    # External provider name (e.g. Laser provider name)
-    provider_name: str = ""
-    # Client identifier for the external service
-    client_id: str = ""
-    # Dimension of data returned by the source
-    enrichment_dim: int = 0
-    # Deserialization format
-    response_format: EnrichmentResponseFormat = EnrichmentResponseFormat.JSON
-    # OpenTab/Maple configuration (used for ONEFLOW_OPENTAB_SID)
-    opentab_tier_name: str = ""
-    opentab_payload_ids: str = ""  # comma-separated, e.g. "31739"
-    opentab_payload_types: str = ""  # comma-separated, e.g. "2"
-    opentab_column_group_ids: str = ""  # comma-separated, e.g. "12"
-    opentab_vec_payload_indexes: str = ""  # comma-separated, e.g. "0"
-    opentab_timeout_ms: int = 5000
-    opentab_batch_size: int = 100
-    # Feature Store configuration (used for ONEFLOW_FEATURE_STORE_SID)
-    fs_tier: str = ""
-    fs_caller_id: str = ""
-    fs_timeout_ms: int = 5000
-    fs_batch_size: int = 500
-    fs_feature_group_id: int = 0
-    fs_feature_group_name: str = ""
-    fs_feature_name: str = ""
-    # Laser IGR batch size (0 = no batching, send all IDs in one RPC)
-    laser_batch_size: int = 0
-
-
-class KVZCHParams(NamedTuple):
-    # global bucket id start and global bucket id end offsets for each logical table,
-    # where start offset is inclusive and end offset is exclusive
-    bucket_offsets: list[tuple[int, int]] = []
-    # bucket size for each logical table
-    # the value indicates corresponding input space for each bucket id, e.g. 2^50 / total_num_buckets
-    bucket_sizes: list[int] = []
-    # enable optimizer offloading or not
-    enable_optimizer_offloading: bool = False
-    # when enabled, backend will return whole row(metaheader + weight + optimizer) instead of weight only
-    # can only be enabled when enable_optimizer_offloading is enabled
-    backend_return_whole_row: bool = False
-    eviction_policy: EvictionPolicy = EvictionPolicy()
-    embedding_cache_mode: bool = False
-    load_ckpt_without_opt: bool = False
-    optimizer_type_for_st: str | None = None
-    optimizer_state_dtypes_for_st: frozenset[tuple[str, int]] | None = None
-    # Enrichment config for embedding cache enrichment from external sources
-    enrichment_policy: EnrichmentPolicy | None = None
-    feature_score_collection_enabled: bool = False
-
-    def validate(self) -> None:
-        assert len(self.bucket_offsets) == len(self.bucket_sizes), (
-            "bucket_offsets and bucket_sizes must have the same length, "
-            f"actual {self.bucket_offsets} vs {self.bucket_sizes}"
-        )
-        self.eviction_policy.validate()
-        assert (
-            not self.backend_return_whole_row or self.enable_optimizer_offloading
-        ), "backend_return_whole_row can only be enabled when enable_optimizer_offloading is enabled"
-
-
-class KVZCHTBEConfig(NamedTuple):
-    # Eviction trigger model for kvzch table: 0: disabled, 1: iteration, 2: mem_util, 3: manual, 4: id count, 5: free_mem
-    kvzch_eviction_trigger_mode: int = 2  # mem_util
-    # Minimum free memory (in GB) required before triggering eviction when using free_mem trigger mode.
-    eviction_free_mem_threshold_gb: int = 200  # 200GB
-    # Number of batches between checks for free memory threshold when using free_mem trigger mode.
-    eviction_free_mem_check_interval_batch: int = 1000
-    # The width of each feature score bucket used for threshold calculation in feature score-based eviction.
-    threshold_calculation_bucket_stride: float = 0.2
-    # Total number of feature score buckets used for threshold calculation in feature score-based eviction.
-    threshold_calculation_bucket_num: int | None = 1000000  # 1M
-    # When true, we only save weight to kvzch backend and not optimizer state.
-    load_ckpt_without_opt: bool = False
-    # [DO NOT USE] This is for st publish only, do not set it in your config
-    optimizer_type_for_st: str | None = None
-    # [DO NOT USE] This is for st publish only, do not set it in your config
-    optimizer_state_dtypes_for_st: frozenset[tuple[str, int]] | None = None
-    # Enrichment policy for embedding cache enrichment from external sources (e.g. Laser)
-    enrichment_policy: EnrichmentPolicy | None = None
-
-
-class BackendType(enum.IntEnum):
-    SSD = 0
-    DRAM = 1
-    PS = 2
-    DRAM_SSD = 3
-
-    @classmethod
-    def from_str(cls, key: str) -> "BackendType":
-        lookup = {
-            "ssd": BackendType.SSD,
-            "dram": BackendType.DRAM,
-            "dram_ssd": BackendType.DRAM_SSD,
-        }
-        if key in lookup:
-            return lookup[key]
-        else:
-            raise ValueError(f"Cannot parse value into BackendType: {key}")
 
 
 def construct_cache_state(
@@ -343,3 +65,30 @@ def construct_cache_state(
 ) -> CacheState:
     """Backward-compatible free-function form of CacheState.construct()."""
     return CacheState.construct(row_list, location_list, feature_table_map)
+
+
+# Lazy re-export of the SSD/KVZCH config types (canonical in tbe.ssd.ssd_config);
+# deferring to first access avoids the import cycle noted above.
+_SSD_CONFIG_REEXPORTS: tuple[str, ...] = (
+    "BackendType",
+    "EnrichmentPolicy",
+    "EnrichmentResponseFormat",
+    "EnrichmentType",
+    "EvictionPolicy",
+    "KVZCHParams",
+    "KVZCHTBEConfig",
+)
+
+
+def __getattr__(name: str) -> object:
+    if name in _SSD_CONFIG_REEXPORTS:
+        from fbgemm_gpu.tbe.ssd import ssd_config
+
+        value = getattr(ssd_config, name)
+        globals()[name] = value  # cache; subsequent access bypasses __getattr__
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted({*globals(), *_SSD_CONFIG_REEXPORTS})

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/__init__.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/__init__.py
@@ -7,17 +7,8 @@
 
 # pyre-strict
 
-# Load the prelude
-from .common import ASSOC  # noqa: F401
-
-# Load the inference and training ops
-# pyre-ignore[21]: fbgemm_gpu C extensions are not analyzed by Pyre
-from .inference import SSDIntNBitTableBatchedEmbeddingBags  # noqa: F401
-
-# pyre-ignore[21]: fbgemm_gpu C extensions are not analyzed by Pyre
-from .inference_serving import TurboSSDInferenceModule  # noqa: F401
-
-# Load SSD/KVZCH config types
+# Re-export SSD/KVZCH config types from the canonical sub-module (lightweight,
+# always available via the :tbe_ssd_config target).
 from .ssd_config import (  # noqa: F401
     BackendType,
     EnrichmentPolicy,
@@ -28,5 +19,35 @@ from .ssd_config import (  # noqa: F401
     KVZCHTBEConfig,
 )
 
-# pyre-ignore[21]: fbgemm_gpu C extensions are not analyzed by Pyre
-from .training import DramKvPerfStat, SSDTableBatchedEmbeddingBags  # noqa: F401
+# `.common`, `.inference`, `.inference_serving`, `.training` ship only with the heavy
+# `:ssd_split_table_batched_embeddings_ops` target; the lightweight `:tbe_ssd_config`
+# omits them. Guard each import and re-raise anything other than the specific absent
+# submodule, so a real circular / "cannot import name" error isn't masked (D107684315).
+# Eager (not a lazy `__getattr__`) so the symbols resolve under torch.package.
+try:
+    # pyre-ignore[21]: `.common` is only present in the heavy target.
+    from .common import ASSOC  # noqa: F401
+except ModuleNotFoundError as e:
+    if e.name != "fbgemm_gpu.tbe.ssd.common":
+        raise
+
+try:
+    # pyre-ignore[21]: fbgemm_gpu C extensions are not analyzed by Pyre.
+    from .inference import SSDIntNBitTableBatchedEmbeddingBags  # noqa: F401
+except ModuleNotFoundError as e:
+    if e.name != "fbgemm_gpu.tbe.ssd.inference":
+        raise
+
+try:
+    # pyre-ignore[21]: fbgemm_gpu C extensions are not analyzed by Pyre.
+    from .inference_serving import TurboSSDInferenceModule  # noqa: F401
+except ModuleNotFoundError as e:
+    if e.name != "fbgemm_gpu.tbe.ssd.inference_serving":
+        raise
+
+try:
+    # pyre-ignore[21]: fbgemm_gpu C extensions are not analyzed by Pyre.
+    from .training import DramKvPerfStat, SSDTableBatchedEmbeddingBags  # noqa: F401
+except ModuleNotFoundError as e:
+    if e.name != "fbgemm_gpu.tbe.ssd.training":
+        raise

--- a/fbgemm_gpu/test/tbe/ssd/ssd_config_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_config_test.py
@@ -139,3 +139,47 @@ class BackendTypeFromStrTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             BackendType.from_str("invalid")
+
+
+class SsdImportCycleRegressionTest(unittest.TestCase):
+    """Regression test for the D107684315 import cycle: importing ops_training ->
+    ops_common used to eagerly trigger tbe.ssd.__init__ -> .training -> ops_training
+    (partial), leaving SSDTableBatchedEmbeddingBags unbound. buck build does not
+    execute imports, so only an import-time test catches this.
+    """
+
+    def test_heavy_symbols_bound_after_ops_training_import(self) -> None:
+        import importlib
+
+        # Importing ops_training first is the exact trigger of the cycle.
+        importlib.import_module(
+            "fbgemm_gpu.split_table_batched_embeddings_ops_training"
+        )
+        ssd = importlib.import_module("fbgemm_gpu.tbe.ssd")
+        for sym in ("ASSOC", "SSDTableBatchedEmbeddingBags", "DramKvPerfStat"):
+            self.assertTrue(
+                hasattr(ssd, sym),
+                f"fbgemm_gpu.tbe.ssd is missing {sym!r}: the tbe.ssd import cycle "
+                "regressed (see D107684315).",
+            )
+
+    def test_from_import_heavy_symbols(self) -> None:
+        from fbgemm_gpu.tbe.ssd import ASSOC, SSDTableBatchedEmbeddingBags  # noqa: F401
+
+        self.assertIsNotNone(ASSOC)
+        self.assertIsNotNone(SSDTableBatchedEmbeddingBags)
+
+    def test_ops_common_lazy_ssd_reexports_resolve(self) -> None:
+        # The lazy __getattr__ in ops_common must still resolve the SSD config
+        # types (legacy import path + old-pickle BC).
+        from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+            BackendType,
+            EvictionPolicy,
+            KVZCHParams,
+            KVZCHTBEConfig,
+        )
+
+        self.assertIsNotNone(BackendType)
+        self.assertIsNotNone(EvictionPolicy)
+        self.assertIsNotNone(KVZCHParams)
+        self.assertIsNotNone(KVZCHTBEConfig)


### PR DESCRIPTION
Summary:
Third foundational diff of the BC-safe TBE type migration: make tbe.ssd.ssd_config the
canonical home for the SSD/KVZCH types and turn ops_common into a pure re-export shim.

- tbe/ssd/ssd_config.py is canonical for BackendType, EvictionPolicy, EnrichmentType,
  EnrichmentResponseFormat, EnrichmentPolicy, KVZCHParams, KVZCHTBEConfig (init-time only;
  no __module__ pinning required).
- tbe/ssd/__init__.py guards the heavy .common/.inference/.inference_serving/.training
  imports (re-raising anything but the specific absent submodule) so the new lightweight
  :tbe_ssd_config target loads cleanly under torch.package.
- split_table_batched_embeddings_ops_common.py is now a pure re-export shim: config + cache
  types eager, SSD/KVZCH lazy via __getattr__ to avoid a tbe.ssd -> .training -> ops_training
  import cycle; plus the construct_cache_state() forwarder. Legacy import path preserved.
- BUCK: add lightweight :tbe_ssd_config; :ssd_split_table_batched_embeddings_ops drops
  ssd_config.py and deps :tbe_ssd_config. ops_common deps += :tbe_ssd_config and is marked
  autodeps-skip so the tbe leaf config deps (only reachable lazily) stay pinned into every
  publisher's torch.package closure (SEV-prevention hardening, S669532/S672649). Acyclic:
  ops_common -> {tbe_config, tbe_cache_config, tbe_ssd_config}.

Completes the acyclic, identity-preserving redo of D103477971 (SEV S669532) for the
foundational fbgemm-internal layer.

Reviewed By: henrylhtsang

Differential Revision: D107684315


