### PR TITLE
Add `subwarp_reduce_add` for `GROUP_REDUCE_ALL_SUM` on ROCm

### DIFF
--- a/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_device_kernel_template.cuh
+++ b/fbgemm_gpu/codegen/training/optimizer/embedding_optimizer_split_device_kernel_template.cuh
@@ -11,8 +11,44 @@
 #include "fbgemm_gpu/utils/tensor_accessor_builder.h"
 #include "fbgemm_gpu/split_embeddings_utils.cuh"
 
+{%- if is_rocm %}
+template<int32_t kThreadGroupSize, typename T>
+DEVICE_INLINE __device__ T subwarp_reduce_add(T value) {
+    static_assert(kThreadGroupSize == 8 || kThreadGroupSize == 16 || kThreadGroupSize == 32 || kThreadGroupSize == 64, "Wavefront size must be 8/16/32/64");
+    if (kThreadGroupSize == 8) {
+        // Reduce across 8 groups of 8 threads
+        value += __shfl_xor(value, 1, 8);
+        value += __shfl_xor(value, 2, 8);
+        value += __shfl_xor(value, 4, 8);
+    } else if (kThreadGroupSize == 16) {
+        // Reduce across 4 groups of 16 threads
+        value += __shfl_xor(value, 1, 16);
+        value += __shfl_xor(value, 2, 16);
+        value += __shfl_xor(value, 4, 16);
+        value += __shfl_xor(value, 8, 16);
+    } else if (kThreadGroupSize == 32) {
+        // Reduce across 2 groups of 32 threads
+        value += __shfl_xor(value, 1, 32);
+        value += __shfl_xor(value, 2, 32);
+        value += __shfl_xor(value, 4, 32);
+        value += __shfl_xor(value, 8, 32);
+        value += __shfl_xor(value, 16, 32);
+    } else if (kThreadGroupSize == 64) {
+        value += __shfl_xor(value, 1, 64);
+        value += __shfl_xor(value, 2, 64);
+        value += __shfl_xor(value, 4, 64);
+        value += __shfl_xor(value, 8, 64);
+        value += __shfl_xor(value, 16, 64);
+        value += __shfl_xor(value, 32, 64);
+    }
+    return value;
+}
+
+#define GROUP_REDUCE_ALL_SUM(val, ...) subwarp_reduce_add<kThreadGroupSize>(val)
+{%- else %}
 #define GROUP_REDUCE_ALL_SUM(val, ...) \
   warpReduceAllSum<__VA_ARGS__, kThreadGroupSize>(val, shfl_sync_mask)
+{%- endif %}
 
 {%- set mdesc = "ssd" if ssd else "split" %}
 {%- set locs_or_addrs_tensor = "ssd_row_addrs" if ssd else "lxu_cache_locations" %}


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2794

Add ROCm-specific `subwarp_reduce_add` template function using `__shfl_xor` intrinsics for subwarp reductions, and redefine `GROUP_REDUCE_ALL_SUM` to use it on ROCm. This replaces the NVIDIA `warpReduceAllSum` path which requires `shfl_sync_mask` not available on AMD GPUs. Affects both warp and CTA backward kernels via the shared optimizer device kernel template.


| T | Ds / D | B | Baseline (No flag) | This diff (No flag) | Δ % (No flag) | Baseline (With flag) | Diff (With flag) | Δ % (With flag)  
| 2 | 8 | — | 65 | 65 | 0.00% | 65 | 65 | 0.00%  
| 10 | 128 | — | 394 | 376 | 5.00% | 394 | 376 | 5.00%  
| 14 | 12/24/128 | — | 373 | 360 | 3.00% | 374 | 357 | 5.00%  
| 18 | 20/128 | — | 309 | 298 | 4.00% | 308 | 298 | 3.00%  
| 22 | 20/24/128 | — | 424 | 405 | 4.00% | 425 | 405 | 5.00%  
| 1 | 8 | 2048 | 102 | 100 | 2.00% | 103 | 101 | 2.00%  
| 1 | 8 | 4096 | 180 | 177 | 2.00% | 181 | 177 | 2.00%  
| 1 | 8 | 131072 | 1485 | 1492 | 0.00% | 1483 | 1487 | 0.00%  
| 1 | 128 | 2048 | 115 | 112 | 3.00% | 114 | 114 | 0.00%  
| 1 | 128 | 4096 | 203 | 200 | 1.00% | 222 | 217 | 2.00%  
| 1 | 128 | 131072 | 1800 | 1790 | 1.00% | 1900 | 1738 | 9.00%

Reviewed By: q10

Differential Revision: D107779306


