### PR TITLE
Fix int64 key truncation in DramKV inference eviction loop

### DIFF
--- a/fbgemm_gpu/src/dram_kv_embedding_cache/feature_evict.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/feature_evict.h
@@ -689,7 +689,7 @@ class FeatureEvict {
     auto* pool = kv_store_.pool_by(shard_id);
     auto mem_pool_lock = pool->acquire_lock();
 
-    std::vector<int> evicting_keys;
+    std::vector<int64_t> evicting_keys;
     evicting_keys.reserve(block_nums_snapshot_[shard_id] / 100);
     while (!should_exit_evict_loop(shard_id)) {
       auto* block =


### PR DESCRIPTION
`FeatureEvict::start_inference_eviction_loop` collected evicted keys into a `std::vector<int>`, but embedding keys are `int64_t`. Pushing a 64-bit key into an `int` vector truncates it to 32 bits.