### PR TITLE
Guard dense_to_jagged_forward against negative total_L

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/dense_to_jagged_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/dense_to_jagged_forward.cu
@@ -26,6 +26,12 @@ Tensor dense_to_jagged_forward(
   } else {
     total_L_computed = (int64_t)offsets.back().max().item<int64_t>();
   }
+  TORCH_CHECK_VALUE(
+      total_L_computed >= 0,
+      "dense_to_jagged_forward: total_L must be non-negative but got ",
+      total_L_computed,
+      ". This typically indicates corrupted offsets (offsets.back() contains a "
+      "garbage/negative value).");
   auto values = at::empty_symint({total_L_computed, D}, dense.options());
   auto output = at::empty_like(values);
 

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -475,6 +475,12 @@ Tensor dense_to_jagged_forward(
     total_L_computed =
         static_cast<int64_t>(offsets.back().max().item<int64_t>());
   }
+  TORCH_CHECK_VALUE(
+      total_L_computed >= 0,
+      "dense_to_jagged_forward: total_L must be non-negative but got ",
+      total_L_computed,
+      ". This typically indicates corrupted offsets (offsets.back() contains a "
+      "garbage/negative value).");
   auto values = at::empty_symint({total_L_computed, D}, dense.options());
   auto output = at::zeros_symint({total_L_computed, D}, dense.options());
 

--- a/fbgemm_gpu/test/jagged/dense_to_jagged_test.py
+++ b/fbgemm_gpu/test/jagged/dense_to_jagged_test.py
@@ -165,6 +165,23 @@ class DenseToJaggedTest(unittest.TestCase):
             precompute_total_L,
         )
 
+    @optests.dontGenerateOpCheckTests("regression test for negative-size guard")
+    def test_dense_to_jagged_negative_total_L_errors(self) -> None:
+        """Regression: corrupted offsets must fail fast, not allocate a tensor
+        with a negative dimension.
+
+        total_L is derived from offsets.back().max(); a negative value there
+        used to flow straight into at::empty({total_L, D}) and produce the
+        opaque "Trying to create tensor with negative dimension" error. The
+        TORCH_CHECK_VALUE guard in dense_to_jagged_forward now rejects it.
+        """
+        device = torch.device("cpu")
+        dense = torch.zeros((1, 4), dtype=torch.float, device=device)
+        # Last (and only) offsets tensor has a negative max -> negative total_L.
+        offsets = [torch.tensor([-5, -1], dtype=torch.long, device=device)]
+        with self.assertRaisesRegex(ValueError, "total_L must be non-negative"):
+            torch.ops.fbgemm.dense_to_jagged(dense, offsets)
+
     @optests.dontGenerateOpCheckTests("regression test, not an op-shape check")
     @unittest.skipIf(*gpu_unavailable)
     @unittest.skipIf(*gpu_memory_lt_gb(16))


### PR DESCRIPTION
Summary:
dense_to_jagged_forward derives the output's leading dim (total_L) from
offsets.back().max() with no validation. A corrupted/garbage offset produced a
huge negative value (~-1.4e18) that flowed straight into at::empty and aborted
with an opaque "Trying to create tensor with negative dimension" error, seen in a
real ROCm training crash through fbgemm_gpu::dense_to_jagged.

Add a TORCH_CHECK_VALUE guard in the CPU and CUDA forward paths so the op fails
fast with the offending value and a clear message instead of an allocator abort.
The guard runs only in the concrete kernels; symbolic/torch.export tracing still
uses the Python abstract impl.

Reviewed By: haoyuz

Differential Revision: D108330675


