### PR TITLE
Guard jagged_index_select against negative output rows (#5880)

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/dense_to_jagged_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/dense_to_jagged_forward.cu
@@ -26,6 +26,12 @@ Tensor dense_to_jagged_forward(
   } else {
     total_L_computed = (int64_t)offsets.back().max().item<int64_t>();
   }
+  TORCH_CHECK_VALUE(
+      total_L_computed >= 0,
+      "dense_to_jagged_forward: total_L must be non-negative but got ",
+      total_L_computed,
+      ". This typically indicates corrupted offsets (offsets.back() contains a "
+      "garbage/negative value).");
   auto values = at::empty_symint({total_L_computed, D}, dense.options());
   auto output = at::empty_like(values);
 

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_index_select_2d_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_index_select_2d_forward.cu
@@ -93,6 +93,12 @@ Tensor jagged_index_select_2d_forward_cuda(
 
   auto num_cols = values.size(1);
 
+  TORCH_CHECK_VALUE(
+      num_dense_output_rows >= 0,
+      "jagged_index_select_2d_forward: num_dense_output_rows must be "
+      "non-negative, got ",
+      num_dense_output_rows);
+
   const int64_t max_num_blocks = 1024; // Arbitrarily set to this number of now
   const int64_t num_blocks = std::min(max_num_blocks, num_dense_output_rows);
   Tensor output =

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -475,6 +475,12 @@ Tensor dense_to_jagged_forward(
     total_L_computed =
         static_cast<int64_t>(offsets.back().max().item<int64_t>());
   }
+  TORCH_CHECK_VALUE(
+      total_L_computed >= 0,
+      "dense_to_jagged_forward: total_L must be non-negative but got ",
+      total_L_computed,
+      ". This typically indicates corrupted offsets (offsets.back() contains a "
+      "garbage/negative value).");
   auto values = at::empty_symint({total_L_computed, D}, dense.options());
   auto output = at::zeros_symint({total_L_computed, D}, dense.options());
 

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -1203,6 +1203,11 @@ Tensor jagged_index_select_2d_forward_cpu(
       values.dim() == 2,
       "jagged_index_select_2d_forward_cpu supports only 2D inputs");
   auto num_cols = values.size(1);
+  TORCH_CHECK_VALUE(
+      num_dense_output_rows >= 0,
+      "jagged_index_select_2d_forward: num_dense_output_rows must be "
+      "non-negative, got ",
+      num_dense_output_rows);
   Tensor output =
       at::empty({num_dense_output_rows, num_cols}, values.options());
 
@@ -1242,6 +1247,13 @@ Tensor jagged_index_select_2d_forward_v2_impl(
   const auto num_dense_output_rows = optional_num_dense_output_rows.has_value()
       ? optional_num_dense_output_rows.value()
       : output_offsets[output_offsets.numel() - 1].item<int64_t>();
+  TORCH_CHECK_VALUE(
+      num_dense_output_rows >= 0,
+      "jagged_index_select_2d_forward_v2: num_dense_output_rows must be "
+      "non-negative, got ",
+      num_dense_output_rows,
+      ". This typically indicates corrupted output_offsets (last element is "
+      "negative).");
   static auto v1_op =
       c10::Dispatcher::singleton()
           .findSchemaOrThrow("fbgemm::jagged_index_select_2d_forward", "")

--- a/fbgemm_gpu/test/jagged/dense_to_jagged_test.py
+++ b/fbgemm_gpu/test/jagged/dense_to_jagged_test.py
@@ -165,6 +165,23 @@ class DenseToJaggedTest(unittest.TestCase):
             precompute_total_L,
         )
 
+    @optests.dontGenerateOpCheckTests("regression test for negative-size guard")
+    def test_dense_to_jagged_negative_total_L_errors(self) -> None:
+        """Regression: corrupted offsets must fail fast, not allocate a tensor
+        with a negative dimension.
+
+        total_L is derived from offsets.back().max(); a negative value there
+        used to flow straight into at::empty({total_L, D}) and produce the
+        opaque "Trying to create tensor with negative dimension" error. The
+        TORCH_CHECK_VALUE guard in dense_to_jagged_forward now rejects it.
+        """
+        device = torch.device("cpu")
+        dense = torch.zeros((1, 4), dtype=torch.float, device=device)
+        # Last (and only) offsets tensor has a negative max -> negative total_L.
+        offsets = [torch.tensor([-5, -1], dtype=torch.long, device=device)]
+        with self.assertRaisesRegex(ValueError, "total_L must be non-negative"):
+            torch.ops.fbgemm.dense_to_jagged(dense, offsets)
+
     @optests.dontGenerateOpCheckTests("regression test, not an op-shape check")
     @unittest.skipIf(*gpu_unavailable)
     @unittest.skipIf(*gpu_memory_lt_gb(16))


### PR DESCRIPTION
Summary:

jagged_index_select derives num_dense_output_rows from output_offsets[-1] (in the
v2 PT2 path) and feeds it into at::empty in the v1 CPU and CUDA forward kernels
with no validation. A corrupted offset would produce a negative allocation size
and an opaque "negative dimension" abort.

Add TORCH_CHECK_VALUE guards at the v2 chokepoint (where output_offsets[-1] is
read) and at the v1 CPU/CUDA allocation sinks (defense in depth), mirroring the
existing num_outputs guard in keyed_jagged_index_select_dim1.

Differential Revision: D108330676


