### PR TITLE
Add metadata_dim_ and total_rows_written_ members to EmbeddingRocksDB (#5883)

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -1396,10 +1396,12 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
   std::atomic<int64_t> fwd_l1_eviction_dur_{0};
   std::atomic<int64_t> bwd_l1_cnflct_miss_write_back_dur_{0};
   std::atomic<int64_t> flush_write_dur_{0};
+  std::atomic<int64_t> total_rows_written_{0}; // cumulative actual rows written
 
   std::unordered_map<const SnapshotHandle*, std::unique_ptr<SnapshotHandle>>
       snapshots_;
   int64_t max_D_;
+  int64_t metadata_dim_;
   int64_t elem_size_;
   std::vector<int64_t> sub_table_dims_;
   std::vector<int64_t> sub_table_hash_cumsum_;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2802


Declare two new EmbeddingRocksDB member fields used by the metadata column
family feature later in the stack:
- metadata_dim_: width of the metaheader stored in the separate metadata CF
- total_rows_written_: cumulative count of rows written

Reviewed By: EddyLXJ

Differential Revision: D108342270


