### PR TITLE
Guard repeat_arange against negative output_size

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/dense_to_jagged_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/dense_to_jagged_forward.cu
@@ -26,6 +26,12 @@ Tensor dense_to_jagged_forward(
   } else {
     total_L_computed = (int64_t)offsets.back().max().item<int64_t>();
   }
+  TORCH_CHECK_VALUE(
+      total_L_computed >= 0,
+      "dense_to_jagged_forward: total_L must be non-negative but got ",
+      total_L_computed,
+      ". This typically indicates corrupted offsets (offsets.back() contains a "
+      "garbage/negative value).");
   auto values = at::empty_symint({total_L_computed, D}, dense.options());
   auto output = at::empty_like(values);
 

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_index_add_2d_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_index_add_2d_forward.cu
@@ -84,6 +84,11 @@ Tensor jagged_index_add_2d_forward_cuda(
 
   auto num_cols = values.size(1);
 
+  TORCH_CHECK_VALUE(
+      num_output_rows >= 0,
+      "jagged_index_add_2d_forward: num_output_rows must be non-negative, got ",
+      num_output_rows);
+
   const int64_t max_num_blocks = 1024; // Arbitrarily set to this number of now
   const int64_t num_blocks = std::min(max_num_blocks, num_dense_input_rows);
   Tensor output = at::zeros({num_output_rows, num_cols}, values.options());

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_index_select_2d_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_index_select_2d_forward.cu
@@ -93,6 +93,12 @@ Tensor jagged_index_select_2d_forward_cuda(
 
   auto num_cols = values.size(1);
 
+  TORCH_CHECK_VALUE(
+      num_dense_output_rows >= 0,
+      "jagged_index_select_2d_forward: num_dense_output_rows must be "
+      "non-negative, got ",
+      num_dense_output_rows);
+
   const int64_t max_num_blocks = 1024; // Arbitrarily set to this number of now
   const int64_t num_blocks = std::min(max_num_blocks, num_dense_output_rows);
   Tensor output =

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -475,6 +475,12 @@ Tensor dense_to_jagged_forward(
     total_L_computed =
         static_cast<int64_t>(offsets.back().max().item<int64_t>());
   }
+  TORCH_CHECK_VALUE(
+      total_L_computed >= 0,
+      "dense_to_jagged_forward: total_L must be non-negative but got ",
+      total_L_computed,
+      ". This typically indicates corrupted offsets (offsets.back() contains a "
+      "garbage/negative value).");
   auto values = at::empty_symint({total_L_computed, D}, dense.options());
   auto output = at::zeros_symint({total_L_computed, D}, dense.options());
 

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -1203,6 +1203,11 @@ Tensor jagged_index_select_2d_forward_cpu(
       values.dim() == 2,
       "jagged_index_select_2d_forward_cpu supports only 2D inputs");
   auto num_cols = values.size(1);
+  TORCH_CHECK_VALUE(
+      num_dense_output_rows >= 0,
+      "jagged_index_select_2d_forward: num_dense_output_rows must be "
+      "non-negative, got ",
+      num_dense_output_rows);
   Tensor output =
       at::empty({num_dense_output_rows, num_cols}, values.options());
 
@@ -1242,6 +1247,13 @@ Tensor jagged_index_select_2d_forward_v2_impl(
   const auto num_dense_output_rows = optional_num_dense_output_rows.has_value()
       ? optional_num_dense_output_rows.value()
       : output_offsets[output_offsets.numel() - 1].item<int64_t>();
+  TORCH_CHECK_VALUE(
+      num_dense_output_rows >= 0,
+      "jagged_index_select_2d_forward_v2: num_dense_output_rows must be "
+      "non-negative, got ",
+      num_dense_output_rows,
+      ". This typically indicates corrupted output_offsets (last element is "
+      "negative).");
   static auto v1_op =
       c10::Dispatcher::singleton()
           .findSchemaOrThrow("fbgemm::jagged_index_select_2d_forward", "")

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -1364,6 +1364,10 @@ Tensor jagged_index_add_2d_forward_cpu(
       values.dim() == 2,
       "jagged_index_add_2d_forward_cpu supports only 2D inputs");
   auto num_cols = values.size(1);
+  TORCH_CHECK_VALUE(
+      num_output_rows >= 0,
+      "jagged_index_add_2d_forward: num_output_rows must be non-negative, got ",
+      num_output_rows);
   Tensor output = at::zeros({num_output_rows, num_cols}, values.options());
   FBGEMM_DISPATCH_ALL_TYPES(
       values.scalar_type(), "jagged_index_add_2d_kernel_wrapper_1", [&] {

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -1767,6 +1767,12 @@ static Tensor repeat_arange_cpu(const Tensor& lengths) {
     }
   });
 
+  TORCH_CHECK_VALUE(
+      output_size >= 0,
+      "repeat_arange: output_size (sum of lengths) must be non-negative, got ",
+      output_size,
+      ". This typically indicates corrupted/negative lengths.");
+
   if (output_size == 0) {
     return at::empty({0}, lengths.options());
   }

--- a/fbgemm_gpu/src/jagged_tensor_ops/repeat_arange.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/repeat_arange.cu
@@ -89,6 +89,13 @@ Tensor repeat_arange_cuda(const Tensor& lengths) {
         output_size = static_cast<int64_t>(last_offset);
       }));
 
+  TORCH_CHECK_VALUE(
+      output_size >= 0,
+      "repeat_arange: output_size (cumsum of lengths) must be non-negative, "
+      "got ",
+      output_size,
+      ". This typically indicates corrupted/negative lengths.");
+
   if (output_size == 0) {
     return at::empty({0}, lengths.options());
   }

--- a/fbgemm_gpu/test/jagged/dense_to_jagged_test.py
+++ b/fbgemm_gpu/test/jagged/dense_to_jagged_test.py
@@ -165,6 +165,23 @@ class DenseToJaggedTest(unittest.TestCase):
             precompute_total_L,
         )
 
+    @optests.dontGenerateOpCheckTests("regression test for negative-size guard")
+    def test_dense_to_jagged_negative_total_L_errors(self) -> None:
+        """Regression: corrupted offsets must fail fast, not allocate a tensor
+        with a negative dimension.
+
+        total_L is derived from offsets.back().max(); a negative value there
+        used to flow straight into at::empty({total_L, D}) and produce the
+        opaque "Trying to create tensor with negative dimension" error. The
+        TORCH_CHECK_VALUE guard in dense_to_jagged_forward now rejects it.
+        """
+        device = torch.device("cpu")
+        dense = torch.zeros((1, 4), dtype=torch.float, device=device)
+        # Last (and only) offsets tensor has a negative max -> negative total_L.
+        offsets = [torch.tensor([-5, -1], dtype=torch.long, device=device)]
+        with self.assertRaisesRegex(ValueError, "total_L must be non-negative"):
+            torch.ops.fbgemm.dense_to_jagged(dense, offsets)
+
     @optests.dontGenerateOpCheckTests("regression test, not an op-shape check")
     @unittest.skipIf(*gpu_unavailable)
     @unittest.skipIf(*gpu_memory_lt_gb(16))

--- a/fbgemm_gpu/test/jagged/jagged_index_select_2d_test.py
+++ b/fbgemm_gpu/test/jagged/jagged_index_select_2d_test.py
@@ -247,6 +247,20 @@ class JaggedIndexSelect2DTest(unittest.TestCase):
             )
             assert torch.equal(output, output_ref)
 
+    @optests.dontGenerateOpCheckTests("regression test for negative-size guard")
+    def test_jagged_index_add_2d_forward_negative_rows_errors(self) -> None:
+        """Regression: a negative num_output_rows must fail fast instead of
+        allocating a tensor with a negative dimension."""
+        device = torch.device("cpu")
+        values = torch.zeros((2, 3), dtype=torch.float, device=device)
+        indices = torch.tensor([0], dtype=torch.long, device=device)
+        input_offsets = torch.tensor([0, 1, 2], dtype=torch.long, device=device)
+        output_offsets = torch.tensor([0, 1], dtype=torch.long, device=device)
+        with self.assertRaisesRegex(ValueError, "num_output_rows must be non-negative"):
+            torch.ops.fbgemm.jagged_index_add_2d_forward(
+                values, indices, input_offsets, output_offsets, 1, -1
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/fbgemm_gpu/test/jagged/repeat_arange_test.py
+++ b/fbgemm_gpu/test/jagged/repeat_arange_test.py
@@ -91,6 +91,15 @@ class RepeatArangeTest(unittest.TestCase):
         expected = torch.tensor([0, 1, 2, 0, 1, 2, 3, 4, 0, 1])
         torch.testing.assert_close(result, expected)
 
+    @optests.dontGenerateOpCheckTests("regression test for negative-size guard")
+    def test_repeat_arange_negative_length_errors(self) -> None:
+        """Regression: negative/corrupted lengths make the summed output_size
+        negative; the guard must reject it instead of allocating a tensor with
+        a negative dimension."""
+        lengths = torch.tensor([-5], dtype=torch.int64)
+        with self.assertRaisesRegex(ValueError, "output_size .* must be non-negative"):
+            torch.ops.fbgemm.repeat_arange(lengths)
+
     @given(
         batch_size=st.integers(1, 20),
         dtype=st.sampled_from([torch.int32, torch.int64]),


### PR DESCRIPTION
Summary:
repeat_arange computes output_size from the cumsum/sum of lengths and feeds it
into at::empty (CUDA reads the cumsum's last element via cudaMemcpy; CPU sums on
host). Corrupted/negative lengths produce a negative size and an opaque allocator
abort. Add a TORCH_CHECK_VALUE guard in both the CPU and CUDA paths.

Reviewed By: henrylhtsang

Differential Revision: D108330674


