### PR TITLE
Register Meta and Autograd dispatch keys for dense TBE op (#5886)

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_host_template.cpp
@@ -360,7 +360,7 @@ enum SSDTensor {
           use_homogeneous_placements,
           {%- if ssd %}
           enable_optimizer_offloading,
-          {%- endif %}      
+          {%- endif %}
           {%- if is_gwd %}
           {%- if "prev_iter_dev" not in args.split_function_arg_names %}
           prev_iter_dev,
@@ -929,9 +929,9 @@ class {{ autograd_func }} :
     const auto use_homogeneous_placements =
       ctx->saved_data["use_homogeneous_placements"].toBool();
     {%- endif %}
-    
+
     {%- if ssd %}
-    const auto enable_optimizer_offloading = 
+    const auto enable_optimizer_offloading =
       ctx->saved_data["enable_optimizer_offloading"].toBool();
     {%- endif %}
 
@@ -1125,8 +1125,8 @@ Tensor {{ bwd_mdesc }}_embedding_codegen_lookup_{{ optimizer }}_function(
   {%- if has_gpu_support %}
 
     {%- if "learning_rate_tensor" in args.split_function_arg_names %}
-    // `learning rate` is changed to tensor to prevent recompilation. 
-    // This interface (V1) still accepts learning rate as float for backward compatibility, 
+    // `learning rate` is changed to tensor to prevent recompilation.
+    // This interface (V1) still accepts learning rate as float for backward compatibility,
     // We convert learning rate to tensor here to work with the backend
     // The unified PT2 interface already accepts learning rate as tensor.
     auto learning_rate_tensor = at::empty({1}, at::TensorOptions().dtype(at::kFloat).device(at::kCPU));
@@ -1264,6 +1264,20 @@ TORCH_LIBRARY_FRAGMENT({{ lib_name }}, m) {
     {%- endif %} {#/* if not dense */#}
 
     {%- if dense or args.split_function_args_v1 is not none %}
+
+    {%- if dense %}
+    m.impl(
+        "dense_embedding_codegen_lookup_function",
+        torch::dispatch(
+          c10::DispatchKey::AutogradCUDA,
+          TORCH_FN({{ op_name }})));
+    m.impl(
+        "dense_embedding_codegen_lookup_function",
+        torch::dispatch(
+          c10::DispatchKey::Meta,
+          TORCH_FN({{ op_name }})));
+    {%- endif %}
+
     DISPATCH_TO_CUDA(
         {%- if not dense %}
         "{{ op_name }}",

--- a/fbgemm_gpu/test/tbe/training/backward_determinism_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_determinism_test.py
@@ -47,13 +47,9 @@ from ..common import open_source
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import additional_decorators, gpu_unavailable, optests
+    from test_utils import gpu_unavailable, optests
 else:
-    from fbgemm_gpu.test.test_utils import (
-        additional_decorators,
-        gpu_unavailable,
-        optests,
-    )
+    from fbgemm_gpu.test.test_utils import gpu_unavailable, optests
 
 
 VERBOSITY: Verbosity = Verbosity.verbose
@@ -65,7 +61,7 @@ SUPPRESS_HEALTH_CHECKS: list[HealthCheck] = [
 ]
 
 
-@optests.generate_opcheck_tests(fast=True, additional_decorators=additional_decorators)
+@optests.generate_opcheck_tests(fast=True)
 class BackwardDeterminismTest(unittest.TestCase):
     """Verify backward determinism for all TBE optimizer types.
 

--- a/fbgemm_gpu/test/tbe/training/failures_dict_fast.json
+++ b/fbgemm_gpu/test/tbe/training/failures_dict_fast.json
@@ -8,19 +8,7 @@
     "fbgemm::bounds_check_indices": {},
     "fbgemm::check_feature_gate_key": {},
     "fbgemm::dense_embedding_codegen_lookup_function": {
-      "BackwardDenseTest.test_autograd_registration__test_backward_dense": {
-        "comment": "",
-        "status": "xfail"
-      },
       "BackwardDenseTest.test_faketensor__test_backward_dense": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardDeterminismTest.test_autograd_registration__test_backward_determinism_dense": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "BackwardDeterminismTest.test_faketensor__test_backward_determinism_dense": {
         "comment": "",
         "status": "xfail"
       }


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2807

Register `DispatchKey::Autograd` and `DispatchKey::Meta` for `dense_embedding_codegen_lookup_function` in the codegen template. Previously, the `{% if not dense %}` guard in `embedding_backward_split_host_template.cpp` skipped these registrations for the dense variant, causing `test_autograd_registration` and `test_faketensor` opcheck tests to fail.

The non-dense split ops already register the same function at both Autograd and Meta dispatch keys (the autograd.Function works even without autograd enabled, and redispatches to lower-level ops that have their own Meta kernels). The dense variant uses the same pattern.

This also reverts the `failures_dict_fast.json` xfail entries and `additional_decorators` workaround from `BackwardDeterminismTest` since they are no longer needed.

Reviewed By: q10

Differential Revision: D107814730


