### PR TITLE
Add parametrized NaN-poison zero-fill test for async embedding loads

### DIFF
--- a/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_forward_test.py
@@ -55,6 +55,22 @@ else:
 VERBOSITY: Verbosity = Verbosity.verbose
 
 
+# Cases for ``test_nbit_forward_nan_zero_fill``. Each tuple is
+# (name, weights_ty, D, output_dtype, weighted). The axes are chosen to
+# exercise the async global->shared-memory zero-fill path added in D91496421
+# (cp.async on CUDA sm80+; global_load_lds on ROCm gfx950/MI350):
+#   - weighted=True also covers the indice-weights zero-fill branch
+#   - weights_ty changes bytes-per-row => NumUint4LoadsPerRow
+#   - large D forces >1 uint4 load per row (multi-iteration row-load loop)
+NAN_ZERO_FILL_CASES: list[tuple[str, SparseType, int, SparseType, bool]] = [
+    ("int4_small_weighted", SparseType.INT4, 160, SparseType.FP16, True),
+    ("int4_small_unweighted", SparseType.INT4, 160, SparseType.FP16, False),
+    ("int4_large_weighted", SparseType.INT4, 1024, SparseType.FP16, True),
+    ("int8_large_unweighted", SparseType.INT8, 1024, SparseType.FP16, False),
+    ("fp16_large_weighted", SparseType.FP16, 2048, SparseType.FP16, True),
+]
+
+
 # pyre-ignore
 additional_decorators: dict[str, list[Callable[..., Any]]] = {
     "test_faketensor__test_nbit_forward_uvm_cache": [
@@ -124,6 +140,9 @@ additional_decorators: dict[str, list[Callable[..., Any]]] = {
         ),
     ],
     "test_faketensor__test_nbit_forward_fused_pooled_emb_quant_nan_weighted": [
+        unittest.skip("Operator not implemented for fake tensors"),
+    ],
+    "test_faketensor__test_nbit_forward_nan_zero_fill": [
         unittest.skip("Operator not implemented for fake tensors"),
     ],
 }
@@ -456,6 +475,108 @@ class NBitFowardTest(NBitFowardTestCommon):
 
         # Expect the outputs to be bit-wise equivalent
         assert torch.equal(output_ref, output)
+
+    def _execute_nan_zero_fill(
+        self,
+        weights_ty: SparseType,
+        D: int,
+        output_dtype: SparseType,
+        weighted: bool,
+    ) -> None:
+        device = torch.cuda.current_device()
+        E = 100
+        D_alignment = (
+            1 if weights_ty.bit_rate() % 8 == 0 else int(8 / weights_ty.bit_rate())
+        )
+        D = round_up(D, D_alignment)
+
+        op = IntNBitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[("", E, D, weights_ty, EmbeddingLocation.DEVICE)],
+            output_dtype=output_dtype,
+            pooling_mode=PoolingMode.SUM,
+            device=device,
+        )
+        op.fill_random_weights()
+
+        # Overwrite every row with 1.0 (dequant of 1.0 is exact for these types).
+        quant_weights, quant_scale_shift = quantize_embs(torch.ones(E, D), weights_ty)
+        weights, scale_shift = op.split_embedding_weights()[0]
+        weights.copy_(quant_weights)
+        if quant_scale_shift is not None:
+            self.assertIsNotNone(scale_shift)
+            scale_shift.copy_(quant_scale_shift)
+
+        # Ragged bag lengths: include values not divisible by kRowUnroll (=4)
+        # and a long tail, so padding rows (input_row_idx >= Ls[i]) drive the
+        # predicate false in addition to pruning.
+        Ls = [1, 3, 4, 7, 8, 11, 63, 64]
+        B = len(Ls)
+        total = sum(Ls)
+        offsets = torch.tensor([0, *np.cumsum(Ls)], dtype=torch.int, device=device)
+        indices = torch.randint(0, E, (total,), dtype=torch.int, device=device)
+        per_sample_weights = (
+            torch.arange(total, dtype=torch.float, device=device) if weighted else None
+        )
+
+        # Prune every 3rd position to -1 (idx == -1 => predicate false).
+        prune_mask = torch.arange(total) % 3 == 0
+        pruned_indices = indices.clone()
+        pruned_indices[prune_mask.to(device)] = -1
+
+        # Analytic expected output: per bag, every dim is identical.
+        kept = (~prune_mask).float()
+        if weighted:
+            assert per_sample_weights is not None
+            contrib = per_sample_weights.cpu() * kept
+        else:
+            contrib = kept
+        expected = torch.zeros(B, D, dtype=torch.float)
+        for b in range(B):
+            start, end = int(offsets[b]), int(offsets[b + 1])
+            expected[b, :] = contrib[start:end].sum()
+
+        # Poison shared memory so a missed zero-fill surfaces as a NaN.
+        torch.ops.fbgemm.initialize_nan_shared_mem(device)
+        output = op(
+            indices=pruned_indices,
+            offsets=offsets,
+            per_sample_weights=per_sample_weights,
+        )
+
+        torch.testing.assert_close(
+            output.float().cpu(),
+            expected,
+            atol=1.0e-2,
+            rtol=1.0e-2,
+            equal_nan=False,  # NaN leak from a broken zero-fill must fail
+        )
+
+    @unittest.skipIf(*gpu_unavailable)
+    def test_nbit_forward_nan_zero_fill(self) -> None:
+        """Verify async global->shared-memory zero-fill (D91496421) for predicate-false rows.
+
+        Every embedding row is set to 1.0, so a SUM bag has an analytic value
+        that is independent of the kernel: the count of non-pruned indices
+        (unweighted) or the sum of per-sample weights at non-pruned positions
+        (weighted). Shared memory is pre-poisoned with NaNs, so if the zero-fill
+        path (pred_guard=false for pruned idx==-1 and for padding rows where
+        input_row_idx >= Ls[i]) fails to write zeros, the NaNs leak into the
+        output and break the comparison (equal_nan=False).
+
+        Cases are run in a deterministic loop (not ``parameterized``) because
+        the test target uses static listing, which rejects runtime-generated
+        tests.
+
+        The test itself is hardware agnostic and passes on any GPU. The real
+        async path is compiled on CUDA sm80+ (cp.async); on all other NVIDIA
+        and AMD hardware it falls back to a behavior-identical synchronous
+        copy. NOTE (MI350-specific): on ROCm the async path is compiled only on
+        gfx950/MI350 (global_load_lds) -- other AMD GPUs (e.g. gfx942/MI300)
+        take the synchronous fallback.
+        """
+        for name, weights_ty, D, output_dtype, weighted in NAN_ZERO_FILL_CASES:
+            with self.subTest(case=name):
+                self._execute_nan_zero_fill(weights_ty, D, output_dtype, weighted)
 
     @unittest.skipIf(*gpu_unavailable)
     @given(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2808

D91496421 adds an async global->shared-memory load path to the quantized n-bit TBE inference kernel: `cp.async` on CUDA sm80+ and `global_load_lds` on ROCm gfx950 (MI350). On a false predicate (pruned `idx == -1`, or a padding row where `input_row_idx >= Ls[i]`) the load must zero-fill the destination row via the `zero_tile` fallback so that row contributes 0 to the pooled sum.

This adds `test_nbit_forward_nan_zero_fill`, a parametrized regression test that pins down that zero-fill behavior deterministically. The existing `test_nbit_forward_fused_pooled_emb_quant_nan_weighted` covers only a single config (INT4 / `D=160` / weighted); this extends the same NaN-poison technique across weighted and unweighted bags, INT4/INT8/FP16 weights, small and large `D` (large `D` forces more than one uint4 load per row), and ragged bag lengths not divisible by `kRowUnroll` (forcing padding rows in the unrolled async loop).

Mechanism: every embedding row is set to 1.0, so a SUM bag has an analytic expected value independent of the kernel — the count of non-pruned indices (unweighted) or the sum of per-sample weights at non-pruned positions (weighted). Shared memory is pre-poisoned with NaNs via `initialize_nan_shared_mem`, so if the zero-fill path fails to write zeros the NaN leaks into the output and fails the comparison (`equal_nan=False`).

The test is hardware agnostic and passes on any GPU. The real async path under test is compiled on CUDA sm80+ (`cp.async`), so it exercises the new code on the vast majority of NVIDIA GPUs (verified on B200/sm_100). MI350-specific note: on ROCm the async path is compiled only on gfx950/MI350 (`global_load_lds`); other AMD GPUs (e.g. gfx942/MI300) and pre-sm80 NVIDIA take the behavior-identical synchronous fallback, so a green run there validates the test itself while new-path coverage on AMD requires an MI350 node.

This change also sets `FBGEMM_NO_JK=2` (EnvFirstThenJk) in the `test/tbe` BUCK env so the target's existing `FBGEMM_TBE_CPU_OUTPUT_DISABLE_PINNED_MEMORY=1` is actually honored. Without it, fbcode defaults to JkOnly mode and that env var is ignored, so the output-pinning gate resolves via JustKnobs and `test_nbit_forward_cpu_seq_int8`'s `is_pinned()` assertion fails on any host where the knob is not enabled (e.g. this devserver). All other feature gates still fall back to JustKnobs.

___

Differential Revision: D108045962


