### PR TITLE
Improve error validation and guard int32 overflow in dense_to_jagged

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/dense_to_jagged_forward.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/dense_to_jagged_forward.cu
@@ -18,20 +18,54 @@ Tensor dense_to_jagged_forward(
     std::optional<at::SymInt> total_L) {
   // D is the embedding dimension
   auto D = dense.size(-1);
+  TORCH_CHECK(D >= 0, "D must be >= 0, but got ", D);
 
   // If total_L is not given then compute it
-  at::SymInt total_L_computed;
+  int64_t total_L_computed;
   if (total_L.has_value()) {
-    total_L_computed = total_L.value();
+    total_L_computed = total_L.value().expect_int();
+    TORCH_CHECK_VALUE(
+        total_L_computed >= 0,
+        "total_L passed to dense_to_jagged_forward must be >= 0, but got ",
+        total_L_computed,
+        ". This indicates total_L is corrupted somewhere prior to dense_to_jagged.");
   } else {
-    total_L_computed = (int64_t)offsets.back().max().item<int64_t>();
+    total_L_computed = offsets.back().max().item<int64_t>();
+    TORCH_CHECK_VALUE(
+        total_L_computed >= 0,
+        "total_L must be >= 0, but got ",
+        total_L_computed,
+        ". This indicates corrupted offsets (offsets.back() contains a garbage/negative value).",
+        " offsets.size() = ",
+        offsets.size(),
+        " offsets.back().size(-1) = ",
+        offsets.back().size(-1),
+        " offsets.back()[-1] = ",
+        offsets.back()[offsets.back().size(-1) - 1].item<int64_t>());
   }
+  constexpr int64_t kInt32Max = std::numeric_limits<int32_t>::max();
   TORCH_CHECK_VALUE(
-      total_L_computed >= 0,
-      "dense_to_jagged_forward: total_L must be non-negative but got ",
+      D == 0 || total_L_computed <= kInt32Max / D,
+      "total_L_computed * D overflows int32 max. total_L_computed = ",
       total_L_computed,
-      ". This typically indicates corrupted offsets (offsets.back() contains a "
-      "garbage/negative value).");
+      " D = ",
+      D,
+      ". `values` is defined as PTA32. Contact FBGEMM team for int64 support.");
+  TORCH_CHECK_VALUE(
+      dense.numel() <= kInt32Max,
+      "Expect dense.numel() <= int32 max, but got ",
+      dense.numel(),
+      ". y_0/y_1/y_reshaped is defined as PTA32. Contact FBGEMM team for int64 support.");
+  // offsets are int32-indexed in the binary search (the non-opt kernel handles
+  // num_jagged_dim up to kStackArrayMaxDims), so each offsets tensor's numel
+  // must fit int32.
+  for (const auto& off : offsets) {
+    TORCH_CHECK_VALUE(
+        off.numel() <= kInt32Max,
+        "offsets numel must be <= int32 max, but got ",
+        off.numel(),
+        ". offsets are int32-indexed. Contact FBGEMM team for int64 support.");
+  }
   auto values = at::empty_symint({total_L_computed, D}, dense.options());
   auto output = at::empty_like(values);
 

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -466,21 +466,30 @@ Tensor dense_to_jagged_forward(
     std::optional<at::SymInt> total_L) {
   // D is the embedding dimension
   auto D = dense.size(-1);
+  TORCH_CHECK(D >= 0, "D must be >= 0, but got ", D);
 
   // If total_L is not given then compute it
   at::SymInt total_L_computed;
   if (total_L.has_value()) {
     total_L_computed = total_L.value();
+    TORCH_CHECK_VALUE(
+        total_L_computed >= 0,
+        "total_L passed to dense_to_jagged_forward must be >= 0, but got ",
+        total_L_computed);
   } else {
     total_L_computed =
         static_cast<int64_t>(offsets.back().max().item<int64_t>());
+    TORCH_CHECK_VALUE(
+        total_L_computed >= 0,
+        "total_L must be >= 0, but got ",
+        total_L_computed,
+        " offsets.size() = ",
+        offsets.size(),
+        " offsets.back().size(-1) = ",
+        offsets.back().size(-1),
+        " offsets.back()[-1] = ",
+        offsets.back()[offsets.back().size(-1) - 1].item<int64_t>());
   }
-  TORCH_CHECK_VALUE(
-      total_L_computed >= 0,
-      "dense_to_jagged_forward: total_L must be non-negative but got ",
-      total_L_computed,
-      ". This typically indicates corrupted offsets (offsets.back() contains a "
-      "garbage/negative value).");
   auto values = at::empty_symint({total_L_computed, D}, dense.options());
   auto output = at::zeros_symint({total_L_computed, D}, dense.options());
 

--- a/fbgemm_gpu/test/jagged/dense_to_jagged_test.py
+++ b/fbgemm_gpu/test/jagged/dense_to_jagged_test.py
@@ -175,12 +175,17 @@ class DenseToJaggedTest(unittest.TestCase):
         opaque "Trying to create tensor with negative dimension" error. The
         TORCH_CHECK_VALUE guard in dense_to_jagged_forward now rejects it.
         """
-        device = torch.device("cpu")
+        device: torch.device = torch.device(
+            "cuda" if torch.cuda.is_available() else "cpu"
+        )
         dense = torch.zeros((1, 4), dtype=torch.float, device=device)
         # Last (and only) offsets tensor has a negative max -> negative total_L.
         offsets = [torch.tensor([-5, -1], dtype=torch.long, device=device)]
-        with self.assertRaisesRegex(ValueError, "total_L must be non-negative"):
+        with self.assertRaisesRegex(ValueError, "must be >= 0"):
             torch.ops.fbgemm.dense_to_jagged(dense, offsets)
+        offsets = [torch.tensor([0, 2], dtype=torch.long, device=device)]
+        with self.assertRaisesRegex(ValueError, "must be >= 0"):
+            torch.ops.fbgemm.dense_to_jagged(dense, offsets, total_L=-1)
 
     @optests.dontGenerateOpCheckTests("regression test, not an op-shape check")
     @unittest.skipIf(*gpu_unavailable)


### PR DESCRIPTION
Summary:
This hardens `dense_to_jagged_forward` (CUDA and CPU) in two ways: clearer validation messages for corrupted inputs, and host-side guards that prevent silent int32 overflow inside the CUDA kernels.

Previously the op derived the output's leading dim `total_L` from the caller-provided value or from `offsets.back().max()` with no validation, then handed the resulting tensors to kernels that index with `PackedTensorAccessor32` (PTA32) and `int` loop/index variables. Two failure modes resulted:

- A corrupted/garbage `total_L` — negative, or a huge positive such as `6737232377933725696` — flowed straight into `at::empty`, producing an opaque "Trying to create tensor with negative dimension" or "Storage size calculation overflowed" error with no indication of the real cause.
- A large shape whose `total_L * D` or `dense.numel()` exceeds `INT32_MAX` silently overflowed the int32 stride/index arithmetic in the kernels and scribbled outside the destination buffer (no kernel launch error), surfacing as NaN/garbage downstream.

This change adds:
- A `total_L >= 0` check in both the caller-provided and `offsets.back().max()`-computed branches, with diagnostics (`offsets.size()`, `offsets.back()[-1]`) to pinpoint corrupted offsets, plus a `D >= 0` check.
- Three overflow guards that reject shapes the int32-indexed kernels cannot handle, failing fast with a clear message instead of silent corruption or an opaque allocator/storage error. The `total_L * D` guard is evaluated as `total_L <= INT32_MAX / D` (division, never multiplication) so the check itself cannot overflow int64 for garbage `total_L`.

How each guard maps to the int32 index/stride sites in the kernels (opt search+gather kernels and the non-opt kernel):

| Guard | Kernel site it protects |
|-------|-------------------------|
| `total_L * D <= INT32_MAX` (via `total_L <= INT32_MAX / D`) | `values`/`x_values`/`output` PTA32 row index `real_row * D`; also bounds `nnz`/`row`/`real_row` and the offset value, all `<= total_L`, and the `rows`/`cols` scratch of length `total_L` |
| `dense.numel() <= INT32_MAX` | `y0`/`y1` PTA32 dense index `dense_row * (max_L * E)` |
| `offsets[d].numel() <= INT32_MAX` | the int32 binary-search index into `x_offsets[d]` in the non-opt kernel, which handles `num_jagged_dim` up to `kStackArrayMaxDims` |

These guards are required (not redundant with accessor construction): FBGEMM's `PTA_B(...)` builds accessors via `generic_packed_accessor`, which bypasses the `numel <= INT32_MAX` `TORCH_CHECK` in `packed_accessor32()`, so an oversized tensor silently yields an int32 accessor. The offsets are additionally passed to the non-opt kernel as raw `int*` pointers (no accessor at all), so only the host-side `offsets[d].numel()` check covers the binary search. `D == 0` is short-circuited — `values` numel is 0 and the kernels early-return on empty input. Full int64 indexing support in the kernels is left as a follow-up; these guards convert the silent/opaque failures into actionable errors in the meantime.

Reviewed By: q10

Differential Revision: D108335337


