### PR TITLE
Migrate fbgemm internals off the ops_common shim to leaf imports

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -14,7 +14,7 @@ import torch
 
 # fmt:skip
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import PoolingMode
+from fbgemm_gpu.tbe.config.embedding_config import PoolingMode
 from fbgemm_gpu.utils.loader import load_torch_module
 
 try:

--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_configs.py
@@ -14,10 +14,7 @@ from typing import Any
 import torch
 
 # fmt:skip
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    EmbeddingLocation,
-    SplitState,
-)
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, SplitState
 
 
 def pad4(value: int) -> int:

--- a/fbgemm_gpu/fbgemm_gpu/split_embedding_inference_converter.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_embedding_inference_converter.py
@@ -20,7 +20,6 @@ from fbgemm_gpu.split_embedding_configs import (
     QuantizationConfig,
     SparseType,
 )
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import EmbeddingLocation
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
@@ -28,6 +27,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     SplitTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation
 from fbgemm_gpu.tbe.utils import quantize_embs
 from torch import Tensor  # usort:skip
 

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
@@ -20,11 +20,9 @@ from torch import nn, Tensor  # usort:skip
 
 from fbgemm_gpu.config import FeatureGate, FeatureGateName
 from fbgemm_gpu.split_embedding_configs import sparse_type_to_int, SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+from fbgemm_gpu.tbe.cache.cache_config import CacheAlgorithm, CacheState
+from fbgemm_gpu.tbe.config.embedding_config import (
     BoundsCheckMode,
-    CacheAlgorithm,
-    CacheState,
-    construct_cache_state,
     DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
     EmbeddingLocation,
     EmbeddingSpecInfo,
@@ -588,7 +586,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
         # Currently only support cache_precision == embedding_precision.
         # Both are represented as uint8_t
-        cache_state = construct_cache_state(rows, locations, self.feature_table_map)
+        cache_state = CacheState.construct(rows, locations, self.feature_table_map)
 
         if self.record_cache_metrics.record_tablewise_cache_miss:
             num_tables = len(cache_state.cache_hash_size_cumsum) - 1
@@ -1655,7 +1653,7 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
             for embedding_spec in self.embedding_specs
         ]
         # pyre-ignore[6]
-        cache_state = construct_cache_state(rows, locations, self.feature_table_map)
+        cache_state = CacheState.construct(rows, locations, self.feature_table_map)
 
         cached_dims = [
             rounded_row_size_in_bytes(

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -29,24 +29,25 @@ from torch.autograd.profiler import record_function  # usort:skip
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers as invokers
 from fbgemm_gpu.config import FeatureGate, FeatureGateName
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    BoundsCheckMode,
-    CacheAlgorithm,
-    CacheState,
-    ComputeDevice,
-    construct_cache_state,
-    EmbeddingLocation,
-    get_bounds_check_version_for_platform,
-    MAX_PREFETCH_DEPTH,
-    MultiPassPrefetchConfig,
-    PoolingMode,
-    RecordCacheMetrics,
-    SplitState,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training_common import (
     check_allocated_vbe_output,
     generate_vbe_metadata,
     is_torchdynamo_compiling,
+)
+from fbgemm_gpu.tbe.cache.cache_config import (
+    CacheAlgorithm,
+    CacheState,
+    MultiPassPrefetchConfig,
+)
+from fbgemm_gpu.tbe.config.embedding_config import (
+    BoundsCheckMode,
+    ComputeDevice,
+    EmbeddingLocation,
+    get_bounds_check_version_for_platform,
+    MAX_PREFETCH_DEPTH,
+    PoolingMode,
+    RecordCacheMetrics,
+    SplitState,
 )
 from fbgemm_gpu.tbe.monitoring import (
     AsyncSeriesTimer,
@@ -1481,7 +1482,7 @@ class SplitTableBatchedEmbeddingBagsCodegen(nn.Module):
 
         self.iter_cpu: torch.Tensor = torch.zeros(1, dtype=torch.int64, device="cpu")
 
-        cache_state = construct_cache_state(rows, locations, self.feature_table_map)
+        cache_state = CacheState.construct(rows, locations, self.feature_table_map)
 
         # Add table-wise cache miss counter
         if self.record_cache_metrics.record_tablewise_cache_miss:

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training_common.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training_common.py
@@ -16,7 +16,7 @@ from torch.compiler import is_compiling as is_torchdynamo_compiling  # usort:ski
 # @manual=//deeplearning/fbgemm/fbgemm_gpu/codegen:split_embedding_codegen_lookup_invokers
 import fbgemm_gpu.split_embedding_codegen_lookup_invokers as invokers
 from fbgemm_gpu.split_embedding_configs import sparse_type_int_to_dtype
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import PoolingMode
+from fbgemm_gpu.tbe.config.embedding_config import PoolingMode
 
 
 def generate_vbe_metadata(

--- a/fbgemm_gpu/fbgemm_gpu/tbe/bench/benchmark_click_interface.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/bench/benchmark_click_interface.py
@@ -11,7 +11,7 @@ import click
 
 # fmt:skip
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import BoundsCheckMode
+from fbgemm_gpu.tbe.config.embedding_config import BoundsCheckMode
 
 # fmt:skip
 from .bench_config import TBEBenchmarkingHelperText  # usort:skip

--- a/fbgemm_gpu/fbgemm_gpu/tbe/bench/embedding_ops_common_config.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/bench/embedding_ops_common_config.py
@@ -15,7 +15,7 @@ import torch
 
 # fmt:skip
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+from fbgemm_gpu.tbe.config.embedding_config import (
     BoundsCheckMode,
     EmbeddingLocation,
     PoolingMode,


### PR DESCRIPTION
Summary:
Fourth foundational diff: point fbgemm-internal modules at the canonical tbe.*
leaf modules instead of the split_table_batched_embeddings_ops_common shim.

This breaks the latent import cycle the shim would otherwise create
(ops_training -> ops_common shim -> tbe.ssd.ssd_config -> tbe.ssd.__init__ ->
.training -> ops_training): with internals importing from the leaves directly,
importing ops_training no longer pulls the shim, so the ssd package __init__ is
not re-entered mid-import.

Migrated to leaf imports (tbe.config.embedding_config / tbe.cache.cache_config):
- split_table_batched_embeddings_ops_training.py (+ construct_cache_state ->
  CacheState.construct)
- split_table_batched_embeddings_ops_inference.py (+ construct_cache_state ->
  CacheState.construct, 2 call sites)
- split_embedding_configs.py (EmbeddingLocation, SplitState)
- split_table_batched_embeddings_ops_training_common.py (PoolingMode)
- split_embedding_inference_converter.py (EmbeddingLocation)
- sparse_ops.py (PoolingMode)
- tbe/bench/embedding_ops_common_config.py, tbe/bench/benchmark_click_interface.py

The ops_common shim remains for external BC. autodeps updated BUCK deps.

Reviewed By: cthi

Differential Revision: D107684316


