### PR TITLE
Guard jagged_slice against negative row counts

### DIFF
--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_autograd.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_autograd.cpp
@@ -659,6 +659,13 @@ class JaggedSliceOp : public torch::autograd::Function<JaggedSliceOp> {
     // D2H sync here
     const int64_t num_output_rows = output_lengths.sum().item<int64_t>();
     const int64_t num_input_rows = lengths.sum().item<int64_t>();
+    TORCH_CHECK_VALUE(
+        num_output_rows >= 0 && num_input_rows >= 0,
+        "jagged_slice: row counts must be non-negative, got num_output_rows=",
+        num_output_rows,
+        ", num_input_rows=",
+        num_input_rows,
+        ". This typically indicates corrupted/negative lengths.");
 
     Tensor tgt_start = at::zeros_like(lengths);
 

--- a/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
+++ b/fbgemm_gpu/src/jagged_tensor_ops/jagged_tensor_ops_cpu.cpp
@@ -1776,6 +1776,12 @@ static Tensor repeat_arange_cpu(const Tensor& lengths) {
     }
   });
 
+  TORCH_CHECK_VALUE(
+      output_size >= 0,
+      "repeat_arange: output_size (sum of lengths) must be non-negative, got ",
+      output_size,
+      ". This typically indicates corrupted/negative lengths.");
+
   if (output_size == 0) {
     return at::empty({0}, lengths.options());
   }

--- a/fbgemm_gpu/src/jagged_tensor_ops/repeat_arange.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/repeat_arange.cu
@@ -89,6 +89,13 @@ Tensor repeat_arange_cuda(const Tensor& lengths) {
         output_size = static_cast<int64_t>(last_offset);
       }));
 
+  TORCH_CHECK_VALUE(
+      output_size >= 0,
+      "repeat_arange: output_size (cumsum of lengths) must be non-negative, "
+      "got ",
+      output_size,
+      ". This typically indicates corrupted/negative lengths.");
+
   if (output_size == 0) {
     return at::empty({0}, lengths.options());
   }

--- a/fbgemm_gpu/test/jagged/repeat_arange_test.py
+++ b/fbgemm_gpu/test/jagged/repeat_arange_test.py
@@ -91,6 +91,15 @@ class RepeatArangeTest(unittest.TestCase):
         expected = torch.tensor([0, 1, 2, 0, 1, 2, 3, 4, 0, 1])
         torch.testing.assert_close(result, expected)
 
+    @optests.dontGenerateOpCheckTests("regression test for negative-size guard")
+    def test_repeat_arange_negative_length_errors(self) -> None:
+        """Regression: negative/corrupted lengths make the summed output_size
+        negative; the guard must reject it instead of allocating a tensor with
+        a negative dimension."""
+        lengths = torch.tensor([-5], dtype=torch.int64)
+        with self.assertRaisesRegex(ValueError, "output_size .* must be non-negative"):
+            torch.ops.fbgemm.repeat_arange(lengths)
+
     @given(
         batch_size=st.integers(1, 20),
         dtype=st.sampled_from([torch.int32, torch.int64]),


### PR DESCRIPTION
Summary:
Defense-in-depth: JaggedSliceOp::forward derives num_output_rows and
num_input_rows from output_lengths.sum().item() / lengths.sum().item(). Add a
TORCH_CHECK_VALUE guard so corrupted/negative lengths fail fast rather than
flowing into a negative-size allocation in jagged_slice_forward.

Note: this is not reachable from the public jagged_slice API today because the
existing TORCH_CHECK_TENSOR_ALL(start >= 0) and (start <= lengths) checks already
constrain lengths to be non-negative; the guard hardens the data-dependent
derivation against future callers.

Reviewed By: spcyppt

Differential Revision: D108330677


