### PR TITLE
Remove legacy get_max_thread_blocks helper from cuda_utilities

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -1105,9 +1105,11 @@ Tensor {{ embedding_cuda_op }}(
                         used_shared_bytes
                     );
 
-                    const int32_t cta_per_row_grid_size = std::min(
-                        div_round_up(total_unique_indices, work_group_size),
-                        get_max_thread_blocks_());
+                    const auto cta_per_row_grid_size = utils::cuda::cap_grid_dim_x(
+                            cuda_calc_xblock_count(total_unique_indices, work_group_size),
+                            kThreadGroupSize * num_cta_per_row_groups, // block size
+                            at::cuda::getCurrentCUDAStream(),
+                            utils::cuda::BlockCapPolicy::Always);
 
                     FBGEMM_LAUNCH_KERNEL(
                         backward_cta_per_row_kernel,
@@ -1243,9 +1245,11 @@ Tensor {{ embedding_cuda_op }}(
 
                     auto blockSize = dim3(kThreadGroupSize, num_warp_per_row_groups);
 
-                    int32_t warp_per_row_grid_size = std::min(
-                        div_round_up(total_unique_indices, num_warp_per_row_groups),
-                        get_max_thread_blocks_());
+                    auto warp_per_row_grid_size = utils::cuda::cap_grid_dim_x(
+                        cuda_calc_xblock_count(total_unique_indices, num_warp_per_row_groups),
+                        kThreadGroupSize * num_warp_per_row_groups, // block size
+                        at::cuda::getCurrentCUDAStream(),
+                        utils::cuda::BlockCapPolicy::Always);
 
 #ifdef USE_ROCM
                     {%- if is_optimized_hip_kernel_supported_mode %}
@@ -1270,7 +1274,16 @@ Tensor {{ embedding_cuda_op }}(
                         {%- for kWeightDecayMode in [0, 1, 2] %}
                         if (max_D == {{ kDimSize }} && weight_decay_mode == {{ kWeightDecayMode }})
                         {
-                            warp_per_row_grid_size = div_round_up(sorted_linear_indices_num_runs[0].item<int32_t>(), segments_per_workgroup);
+                            // HIP kernel: Use OverflowOnly to match original behavior (no cap on CUDA,
+                            // cap only on ROCm when exceeding HIP 2^32 thread limit). The original code
+                            // did not apply get_max_thread_blocks_() cap.
+                            warp_per_row_grid_size = utils::cuda::cap_grid_dim_x(
+                                cuda_calc_xblock_count(
+                                    sorted_linear_indices_num_runs[0].item<int32_t>(),
+                                    segments_per_workgroup),
+                                256, // blockSize = dim3(256) = 256 threads
+                                at::cuda::getCurrentCUDAStream(),
+                                utils::cuda::BlockCapPolicy::OverflowOnly);
                             blockSize = dim3(256);
                             warp_per_row_smem_bytes = 0;
 

--- a/fbgemm_gpu/include/fbgemm_gpu/embedding_backward_template_helpers.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/embedding_backward_template_helpers.cuh
@@ -24,6 +24,7 @@
 #include <mutex>
 
 #include "fbgemm_gpu/embedding_common.h"
+#include "fbgemm_gpu/utils/cuda_utilities.cuh"
 #include "fbgemm_gpu/utils/dispatch_macros.h"
 #include "fbgemm_gpu/utils/find_qparams.cuh"
 #include "fbgemm_gpu/utils/fixed_divisor.cuh"
@@ -50,17 +51,3 @@ DEVICE_INLINE int64_t gpuAtomicIncrement(int64_t* p) {
       static_cast<unsigned long long int>(1)));
 #endif
 }
-
-namespace fbgemm_gpu {
-namespace {
-
-// Based on the empirical study, max grid size that is 64x larger than the
-// number of SMs gives good performance across the board
-constexpr int MAX_THREAD_BLOCKS_FACTOR = 64;
-
-inline int get_max_thread_blocks_() {
-  return MAX_THREAD_BLOCKS_FACTOR *
-      at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
-}
-} // namespace
-} // namespace fbgemm_gpu

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_utilities.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/cuda_utilities.cuh
@@ -25,18 +25,6 @@ namespace fbgemm_gpu::utils::cuda {
 /// kernels: `max_blocks = MAX_THREAD_BLOCKS_FACTOR * #SMs`.
 constexpr int32_t MAX_THREAD_BLOCKS_FACTOR = 64;
 
-/// Returns `MAX_THREAD_BLOCKS_FACTOR * #SMs` for the device backing
-/// `stream`. Legacy helper retained until all direct callers have migrated
-/// to `cap_grid_dim_x{,_from_workload}` below.
-///
-/// @param stream  Stream whose device supplies `#SMs`.
-/// @return  Grid-size cap to apply at kernel launch.
-inline auto get_max_thread_blocks(const c10::cuda::CUDAStream& stream) {
-  const auto device = stream.device_index();
-  return MAX_THREAD_BLOCKS_FACTOR *
-      at::cuda::getDeviceProperties(device)->multiProcessorCount;
-}
-
 /// Selects how `cap_grid_dim_x{,_from_workload}` clamps the requested grid.
 ///
 /// - `Always`: cap on both CUDA and ROCm at `MAX_THREAD_BLOCKS_FACTOR * #SMs`.
@@ -82,7 +70,10 @@ inline uint32_t cap_grid_dim_x(
     return blocks_uncapped;
   }
 
-  const auto max_blocks = static_cast<uint32_t>(get_max_thread_blocks(stream));
+  const auto max_blocks = static_cast<uint32_t>(
+      MAX_THREAD_BLOCKS_FACTOR *
+      at::cuda::getDeviceProperties(stream.device_index())
+          ->multiProcessorCount);
 
   if (policy == BlockCapPolicy::Always) {
     return std::min<uint32_t>(blocks_uncapped, max_blocks);


### PR DESCRIPTION
Summary:
Now that the TBE backward template (the last caller) has migrated to
`cap_grid_dim_x`, remove the legacy
`fbgemm_gpu::utils::cuda::get_max_thread_blocks(stream)` helper from
`include/fbgemm_gpu/utils/cuda_utilities.cuh` and inline its sole
remaining use inside `cap_grid_dim_x`.

Behavior-preserving: the inlined body computes
`MAX_THREAD_BLOCKS_FACTOR * #SMs` exactly as before.

Reviewed By: spcyppt

Differential Revision: D107317501


