### PR TITLE
Normalize config-column names in benchmark reporting + analysis

### DIFF
--- a/fbgemm_gpu/bench/sparse_ops_benchmark.py
+++ b/fbgemm_gpu/bench/sparse_ops_benchmark.py
@@ -455,10 +455,11 @@ def jagged_index_select_2d_bench(
     logging.info(f"backward: fbgemm {time * 1e3:.3f} ms{ref_str}")
 
 
-def _gen_group_inputs(
-    row_size: int,
-    batch_size: int,
-    unique_batch_size: int,
+def _gen_group_inputs_uniform(
+    num_cols: int,
+    num_rows: int,
+    num_indices: int,
+    num_unique_indices: int,
     num_groups: int,
     dtype: torch.dtype,
     sort_indices: bool,
@@ -466,17 +467,17 @@ def _gen_group_inputs(
 ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
     """Generate homogeneous synthetic inputs for group_index_select_2d_bench.
 
-    Every group shares the same shape: a ``(batch_size, row_size)`` slice of a
-    single ``(num_groups * batch_size, row_size)`` tensor, with ``batch_size``
-    indices drawn from ``unique_batch_size`` distinct rows. Used by
+    Every group shares the same shape: a ``(num_rows, num_cols)`` slice of a
+    single ``(num_groups * num_rows, num_cols)`` tensor, with ``num_indices``
+    indices drawn from ``num_unique_indices`` distinct rows. Used by
     ``group-index-select-2d-bench`` when ``--input-dims`` is NOT provided.
     """
 
-    def gen_inverse_index(curr_size: int, final_size: int) -> np.ndarray:
-        inverse_index = list(range(curr_size))
+    def gen_inverse_index(num_unique: int, num_indices: int) -> np.ndarray:
+        inverse_index = list(range(num_unique))
         np_arr = np.array(inverse_index)
-        for _ in range(final_size - curr_size):
-            inverse_index.append(np.random.randint(0, curr_size))
+        for _ in range(num_indices - num_unique):
+            inverse_index.append(np.random.randint(0, num_unique))
             np_arr = np.array(inverse_index)
             np.random.shuffle(np_arr)
         return np_arr
@@ -484,7 +485,7 @@ def _gen_group_inputs(
     indices_group = []
     for _ in range(num_groups):
         indices = torch.tensor(
-            gen_inverse_index(unique_batch_size, batch_size),
+            gen_inverse_index(num_unique_indices, num_indices),
             dtype=torch.int32,
             device=device,
         )
@@ -493,28 +494,28 @@ def _gen_group_inputs(
         indices_group.append(indices)
 
     input = torch.rand(
-        num_groups * batch_size,
-        row_size,
+        num_groups * num_rows,
+        num_cols,
         dtype=dtype,
         device=device,
     )
     input.requires_grad = True
-    input_group = list(input.split(batch_size, 0))
+    input_group = list(input.split(num_rows, 0))
     return input_group, indices_group
 
 
-def _gen_group_inputs_with_spec(
+def _gen_group_inputs_jagged(
     input_dims: str,
     input_strides: str | None,
-    index_dim: int,
+    num_indices: int,
     dtype: torch.dtype,
     sort_indices: bool,
     device: str,
 ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
-    """Generate ragged inputs from explicit per-group shapes.
+    """Generate jagged inputs from explicit per-group shapes.
 
-    Each group gets its own ``[num_rows, row_size]`` tensor (groups may differ
-    in both row count and column width) with ``index_dim`` indices each, matching
+    Each group gets its own ``[num_rows, num_cols]`` tensor (groups may differ
+    in both row count and column width) with ``num_indices`` indices each, matching
     real-world / production shapes. Used by ``group-index-select-2d-bench`` when
     ``--input-dims`` is provided; ``--input-strides`` is optional and defaults to
     contiguous strides per group.
@@ -523,7 +524,7 @@ def _gen_group_inputs_with_spec(
     if input_strides is not None and input_strides.strip() != "":
         strides = json.loads(input_strides)
     else:
-        strides = [[rs, 1] for (_, rs) in dims]
+        strides = [[num_cols, 1] for (_, num_cols) in dims]
     if len(strides) != len(dims):
         raise ValueError(
             f"--input-strides length ({len(strides)}) must match "
@@ -541,7 +542,7 @@ def _gen_group_inputs_with_spec(
         idx = torch.randint(
             low=0,
             high=dim[0],
-            size=(index_dim,),
+            size=(num_indices,),
             dtype=torch.int32,
             device=device,
         )
@@ -553,12 +554,12 @@ def _gen_group_inputs_with_spec(
 
 
 @cli.command()
-@click.option("--row-size", default=512)
-@click.option("--batch-size", default=4096)
-@click.option("--unique-batch-size", default=1024)
+@click.option("--num-cols", type=int, default=None)
+@click.option("--num-rows", type=int, default=None)
+@click.option("--num-unique-indices", type=int, default=None)
 @click.option("--input-precision", type=str, default="fp32")
 @click.option("--sort-indices", type=bool, default=True)
-@click.option("--num-groups", default=32)
+@click.option("--num-groups", type=int, default=None)
 @click.option(
     "--device",
     type=str,
@@ -580,8 +581,8 @@ def _gen_group_inputs_with_spec(
     "--input-dims",
     type=str,
     default=None,
-    help="JSON list of [num_rows, row_size] per group, e.g. '[[27330,96],[4914,96]]'. "
-    "When provided, --row-size, --batch-size, --unique-batch-size, and --num-groups are ignored.",
+    help="JSON list of [num_rows, num_cols] per group, e.g. '[[27330,96],[4914,96]]'. "
+    "When provided, --num-cols, --num-rows, --num-unique-indices, and --num-groups are ignored.",
 )
 @click.option(
     "--input-strides",
@@ -590,7 +591,10 @@ def _gen_group_inputs_with_spec(
     help="JSON list of [stride0, stride1] per group. Defaults to contiguous strides if not provided.",
 )
 @click.option(
-    "--index-dim", type=int, default=None, help="Number of indices per group."
+    "--num-indices",
+    type=int,
+    default=None,
+    help="Number of indices per group (= output rows / effective batch L).",
 )
 @click.option(
     "--manual-seed/--skip-manual-seed",
@@ -598,27 +602,20 @@ def _gen_group_inputs_with_spec(
     help="Use manual seed for reproduction.",
 )
 def group_index_select_2d_bench(
-    row_size: int,
-    batch_size: int,
-    unique_batch_size: int,
+    num_cols: int | None,
+    num_rows: int | None,
+    num_unique_indices: int | None,
     input_precision: str,
     sort_indices: bool,
-    num_groups: int,
+    num_groups: int | None,
     device: str,
     export_trace: bool,
     trace_url: str,
     input_dims: str | None,
     input_strides: str | None,
-    index_dim: int | None,
+    num_indices: int | None,
     manual_seed: bool,
 ) -> None:
-    # Input validation (backported from tritonbench implementation)
-    if unique_batch_size > batch_size:
-        raise ValueError(
-            f"unique_batch_size ({unique_batch_size}) must be <= batch_size "
-            f"({batch_size})"
-        )
-
     # set manual seed for reproducibility
     if manual_seed:
         torch.manual_seed(42)
@@ -632,34 +629,56 @@ def group_index_select_2d_bench(
     else:
         raise RuntimeError(f"Does not support data type {input_precision}")
 
-    bench_kwargs = {"num_warmups": 10, "iters": 100}
-
-    def _kineto_trace_handler(p: profile, phase: str) -> None:
-        p.export_chrome_trace(trace_url.format(phase=phase, ospid=os.getpid()))
-
-    # pyre-ignore[3]
-    def context_factory(on_trace_ready: Callable[[profile], None]):
-        return profile(on_trace_ready=on_trace_ready) if export_trace else nullcontext()
-
-    # An empty/whitespace --input-dims is treated as NOT provided, so it falls
-    # back to the synthetic path. Checking input_dims directly (rather than via a
-    # bool) lets the type checker narrow it to a non-None str inside the branch.
+    # Two mutually-exclusive shape-specification modes:
+    #   uniform (synthetic): --num-groups + --num-rows + --num-cols
+    #   jagged  (prod/real): --input-dims + --input-strides
+    # --num-indices / --num-unique-indices / --input-precision / --sort-indices
+    # apply to both. The uniform scalar flags default to None so we can detect
+    # which mode the user selected and reject mixing the two. Checking input_dims
+    # directly (rather than via a bool) lets the type checker narrow it.
     if input_dims is not None and input_dims.strip() != "":
-        if index_dim is None:
-            raise ValueError("--index-dim is required when --input-dims is provided")
-        input_group, indices_group = _gen_group_inputs_with_spec(
-            input_dims, input_strides, index_dim, dtype, sort_indices, device
+        for name, val in [
+            ("--num-groups", num_groups),
+            ("--num-rows", num_rows),
+            ("--num-cols", num_cols),
+            ("--num-unique-indices", num_unique_indices),
+        ]:
+            if val is not None:
+                raise ValueError(
+                    f"{name} cannot be combined with --input-dims (jagged mode)"
+                )
+        if num_indices is None:
+            raise ValueError(
+                "--num-indices is required with --input-dims (jagged mode)"
+            )
+        input_group, indices_group = _gen_group_inputs_jagged(
+            input_dims, input_strides, num_indices, dtype, sort_indices, device
         )
         logging.info(
-            f"ragged: {len(input_group)} groups, "
+            f"jagged: {len(input_group)} groups, "
             f"cols={[t.shape[1] for t in input_group]}, "
-            f"index_dim={index_dim}, sort_indices={sort_indices}"
+            f"num_indices={num_indices}, sort_indices={sort_indices}"
         )
     else:
-        input_group, indices_group = _gen_group_inputs(
-            row_size,
-            batch_size,
-            unique_batch_size,
+        if input_strides is not None and input_strides.strip() != "":
+            raise ValueError("--input-strides requires --input-dims (jagged mode)")
+        # Apply uniform-mode effective defaults (preserve today's numbers).
+        num_groups = 32 if num_groups is None else num_groups
+        num_rows = 4096 if num_rows is None else num_rows
+        num_cols = 512 if num_cols is None else num_cols
+        num_unique_indices = 1024 if num_unique_indices is None else num_unique_indices
+        # Decoupled default: indices count falls back to the row count.
+        num_indices = num_rows if num_indices is None else num_indices
+        if num_unique_indices > min(num_rows, num_indices):
+            raise ValueError(
+                f"num_unique_indices ({num_unique_indices}) must be <= "
+                f"min(num_rows={num_rows}, num_indices={num_indices})"
+            )
+        input_group, indices_group = _gen_group_inputs_uniform(
+            num_cols,
+            num_rows,
+            num_indices,
+            num_unique_indices,
             num_groups,
             dtype,
             sort_indices,
@@ -670,9 +689,18 @@ def group_index_select_2d_bench(
         # reference fwd/bwd below to compare torch.index_select vs fbgemm.
         # input = torch.cat(input_group, dim=0)
         # offset_indices = torch.cat(
-        #     [idx + batch_size * i for i, idx in enumerate(indices_group)]
+        #     [idx + num_rows * i for i, idx in enumerate(indices_group)]
         # )
-        # num_bytes = 2 * batch_size * row_size * input.element_size() * num_groups
+        # num_bytes = 2 * num_rows * num_cols * input.element_size() * num_groups
+
+    bench_kwargs = {"num_warmups": 10, "iters": 100}
+
+    def _kineto_trace_handler(p: profile, phase: str) -> None:
+        p.export_chrome_trace(trace_url.format(phase=phase, ospid=os.getpid()))
+
+    # pyre-ignore[3]
+    def context_factory(on_trace_ready: Callable[[profile], None]):
+        return profile(on_trace_ready=on_trace_ready) if export_trace else nullcontext()
 
     # Benchmark forward
     with context_factory(lambda p: _kineto_trace_handler(p, "fwd")):

--- a/fbgemm_gpu/fbgemm_gpu/bench/analysis/aggregate_config_stats.py
+++ b/fbgemm_gpu/fbgemm_gpu/bench/analysis/aggregate_config_stats.py
@@ -55,6 +55,7 @@ import argparse
 import json
 import os
 import sys
+from collections import Counter
 from typing import Any
 
 from fbgemm_gpu.bench.analysis.kernel_grouping import base_name_of
@@ -64,6 +65,41 @@ from fbgemm_gpu.bench.analysis.types import KernelStats, write_config_stats_csv
 
 def _config_tuple(cfg: dict[str, Any], columns: list[str]) -> tuple:
     return tuple(cfg[c] for c in columns)
+
+
+def per_iteration_totals(
+    durations_by_kernel: dict[str, list[float]],
+) -> list[float] | None:
+    """Reconstruct the per-iteration TOTAL GPU time series from per-launch
+    durations.
+
+    Each kernel's ``durations_us`` must be in execution (iteration) order and
+    come from a SINGLE trace file. ``n_iter`` is the minimum launch count over
+    dispatched kernels (the primary op fires once per iteration; the rocprim
+    sort pre-pass kernels fire an integer multiple per iteration). Each kernel
+    is split into ``n_iter`` contiguous chunks, summed within each iteration,
+    then summed across kernels.
+
+    Returns the length-``n_iter`` per-iteration total series, or ``None`` when
+    there are no dispatched kernels or any kernel's launch count is not a
+    multiple of ``n_iter`` (the caller should warn and skip the total for that
+    config). The returned series feeds ``KernelStats`` so the ``(total)`` row
+    gets a REAL mean/median/stdev/min/max instead of a placeholder.
+    """
+    active = {k: d for k, d in durations_by_kernel.items() if d}
+    if not active:
+        return None
+    n_iter = min(len(d) for d in active.values())
+    if n_iter == 0:
+        return None
+    totals = [0.0] * n_iter
+    for durs in active.values():
+        if len(durs) % n_iter != 0:
+            return None
+        per_iter = len(durs) // n_iter
+        for i in range(n_iter):
+            totals[i] += sum(durs[i * per_iter : (i + 1) * per_iter])
+    return totals
 
 
 def _parse_pattern_spec(spec: str) -> tuple[str, str, str]:
@@ -111,6 +147,7 @@ def _collect_kernel_stats(
     config_map: list[dict[str, Any]],
     config_columns: list[str],
     patterns: list[tuple[str, str, str]],
+    emit_total: bool = False,
 ) -> list[tuple[dict[str, Any], str, str, KernelStats]]:
     """Extract durations and bucket by ``(config_tuple, kernel_name)``.
 
@@ -118,17 +155,25 @@ def _collect_kernel_stats(
     tuples, one per ``(config, kernel_name)`` combination. Includes
     explicit ``count=0`` rows when a config did not dispatch a kernel
     that other configs did.
+
+    When ``emit_total`` is set, an additional ``(total)`` row is appended
+    after each config's per-kernel rows, carrying the REAL per-iteration total
+    time series (see :func:`per_iteration_totals`). The total is skipped (with
+    a warning) for a config whose kernels span more than one trace file, or
+    whose launch counts are not integer multiples of ``n_iter``.
     """
     # bucket[cfg_tuple][kernel_name] -> list[float]
     bucket: dict[tuple, dict[str, list[float]]] = {}
     config_for: dict[tuple, dict[str, Any]] = {}
     all_kernels: set[str] = set()
+    entries_per_cfg: Counter[tuple] = Counter()
 
     for entry in config_map:
         cfg = entry["config"]
         cfg_tuple = _config_tuple(cfg, config_columns)
         config_for[cfg_tuple] = {c: cfg[c] for c in config_columns}
         bucket.setdefault(cfg_tuple, {})
+        entries_per_cfg[cfg_tuple] += 1
 
         trace_path = os.path.join(trace_dir, entry["trace_file"])
         if not os.path.exists(trace_path):
@@ -157,6 +202,32 @@ def _collect_kernel_stats(
             durs = kernel_durs.get(kname, [])
             stats = KernelStats(name=kname, durations_us=list(durs))
             rows.append((cfg_dict, base_name_of(kname), kname, stats))
+        if emit_total:
+            if entries_per_cfg[cfg_tuple] > 1:
+                print(
+                    f"warning: --emit-total skipped for config {cfg_tuple}: "
+                    f"{entries_per_cfg[cfg_tuple]} trace files (per-iteration "
+                    "order is not reconstructable across files)",
+                    file=sys.stderr,
+                )
+                continue
+            totals = per_iteration_totals(kernel_durs)
+            if totals is None:
+                print(
+                    f"warning: --emit-total could not build a (total) for config "
+                    f"{cfg_tuple} (no dispatched kernels, or launch counts are "
+                    "not integer multiples of n_iter)",
+                    file=sys.stderr,
+                )
+                continue
+            rows.append(
+                (
+                    cfg_dict,
+                    "(total)",
+                    "(total)",
+                    KernelStats(name="(total)", durations_us=totals),
+                )
+            )
     return rows
 
 
@@ -175,6 +246,13 @@ def main() -> int:
         "with :regex, :exact, or :startswith; default is contains.",
     )
     parser.add_argument("--output", required=True)
+    parser.add_argument(
+        "--emit-total",
+        action="store_true",
+        help="Append a per-config '(total)' row carrying the REAL per-iteration "
+        "total time series (mean/median/stdev/min/max) reconstructed from the "
+        "per-launch durations. Supersedes the rollup_per_config.py placeholder.",
+    )
     args = parser.parse_args()
 
     try:
@@ -184,7 +262,13 @@ def main() -> int:
         return 2
 
     patterns = [_parse_pattern_spec(s) for s in args.kernel_pattern]
-    rows = _collect_kernel_stats(args.trace_dir, entries, config_columns, patterns)
+    rows = _collect_kernel_stats(
+        args.trace_dir,
+        entries,
+        config_columns,
+        patterns,
+        emit_total=args.emit_total,
+    )
 
     if not rows:
         print(

--- a/fbgemm_gpu/fbgemm_gpu/bench/analysis/compute_stats.py
+++ b/fbgemm_gpu/fbgemm_gpu/bench/analysis/compute_stats.py
@@ -154,6 +154,7 @@ def main() -> int:
                         "label": label,
                         "n": 0,
                         "mean_us": None,
+                        "median_us": None,
                         "stdev_us": None,
                         "dispatched": False,
                     }
@@ -161,12 +162,14 @@ def main() -> int:
                 continue
             n = int(found.get("count", 0) or 0)
             mean_us = found.get("mean_us")
+            median_us = found.get("median_us")
             stdev_us = found.get("stdev_us")
             per_commit_entries.append(
                 {
                     "label": label,
                     "n": n,
                     "mean_us": mean_us if n > 0 else None,
+                    "median_us": median_us if n > 0 else None,
                     "stdev_us": stdev_us if n > 0 else None,
                     "dispatched": n > 0,
                 }

--- a/fbgemm_gpu/fbgemm_gpu/bench/analysis/tests/test_aggregate_config_stats.py
+++ b/fbgemm_gpu/fbgemm_gpu/bench/analysis/tests/test_aggregate_config_stats.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-ignore-all-errors
+"""Tests for the per-iteration total reconstruction used by
+``aggregate_config_stats --emit-total``."""
+
+from __future__ import annotations
+
+import unittest
+
+from fbgemm_gpu.bench.analysis.aggregate_config_stats import per_iteration_totals
+from fbgemm_gpu.bench.analysis.types import KernelStats
+
+
+class PerIterationTotalsTest(unittest.TestCase):
+    def test_primary_once_plus_sort_twice_per_iter(self) -> None:
+        # primary fires 1x/iter (3 iters); sort fires 2x/iter (6 launches).
+        totals = per_iteration_totals(
+            {"prim": [10.0, 12.0, 11.0], "sort": [1.0, 1.0, 2.0, 2.0, 3.0, 3.0]}
+        )
+        self.assertEqual(totals, [12.0, 16.0, 17.0])
+
+    def test_single_kernel_once_per_iter_is_identity(self) -> None:
+        self.assertEqual(
+            per_iteration_totals({"prim": [10.0, 12.0, 11.0]}), [10.0, 12.0, 11.0]
+        )
+
+    def test_empty_inputs_return_none(self) -> None:
+        self.assertIsNone(per_iteration_totals({}))
+        self.assertIsNone(per_iteration_totals({"a": []}))
+
+    def test_non_integer_launches_per_iter_returns_none(self) -> None:
+        # n_iter = 3 (min length); b has 5 launches (not a multiple of 3).
+        self.assertIsNone(
+            per_iteration_totals({"a": [1.0, 2.0, 3.0], "b": [1.0, 2.0, 3.0, 4.0, 5.0]})
+        )
+
+    def test_total_median_is_outlier_robust(self) -> None:
+        # A single huge outlier inflates the mean/stdev but not the median —
+        # exactly the property the report's median column surfaces.
+        totals = per_iteration_totals({"prim": [10.0, 100.0, 11.0, 12.0, 13.0]})
+        ks = KernelStats(name="(total)", durations_us=totals)
+        self.assertEqual(ks.count, 5)
+        self.assertEqual(ks.median_us, 12.0)
+        self.assertGreater(ks.mean_us, ks.median_us)


### PR DESCRIPTION
Summary:
Part of normalizing the group_index_select_2d benchmark nomenclature so the
report columns match what the operator actually does. Renames the config
columns row_size->num_cols, batch_size->num_rows,
unique_batch_size->num_unique_indices, index_dim->num_indices and rewrites the
gdoc glossary definitions + column widths. The analysis scripts
(aggregate_config_stats, compute_stats) are column-agnostic and unchanged in
logic; only test fixtures / docstrings are touched.

Reviewed By: henrylhtsang

Differential Revision: D108506191


