### PR TITLE
Fix test_lxu_cache_lookup: only test kWarpSize associativity

### DIFF
--- a/fbgemm_gpu/test/tbe/cache/cache_test.py
+++ b/fbgemm_gpu/test/tbe/cache/cache_test.py
@@ -24,6 +24,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
 )
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
+    DEFAULT_ASSOC,
     MultiPassPrefetchConfig,
     SplitTableBatchedEmbeddingBagsCodegen,
 )
@@ -1041,10 +1042,12 @@ class CacheTest(unittest.TestCase):
         (split_embeddings_cache/lru_cache_populate.cu, lock_cache_line=False
         branch).
 
-        Block: dim3(kWarpSize=32, kMaxThreads/kWarpSize=32) = 1024 threads.
-        Grid: div_round_up(N, kMaxThreads / kWarpSize) = ceil(N / 32).
-        Total threads ~= N * kWarpSize = 32 * N. For N >= 2**27, total
-        threads exceed the HIP 2**32 limit, causing FBGEMM_LAUNCH_KERNEL ->
+        Block: dim3(kWarpSize, kMaxThreads/kWarpSize) = 1024 threads
+        (kWarpSize = 32 on NVIDIA, 64 on AMD; cache associativity ==
+        kWarpSize == DEFAULT_ASSOC).
+        Grid: div_round_up(N, kMaxThreads / kWarpSize). Total threads
+        ~= N * kWarpSize. For N >= 2**27 this exceeds the HIP 2**32 limit
+        on both warp sizes, causing FBGEMM_LAUNCH_KERNEL ->
         KernelLauncher::checkThreadCountNotExceeded to TORCH_CHECK-fail
         on ROCm.
 
@@ -1055,7 +1058,7 @@ class CacheTest(unittest.TestCase):
         """
         N = (1 << 27) + 1
         D = 4
-        device = torch.accelerator.current_accelerator("cuda")
+        device = torch.accelerator.current_accelerator()
 
         # T=1 table with E = N entries so all unique linear cache indices
         # are valid hash keys. cache_hash_size_cumsum has shape (T+1,).
@@ -1071,16 +1074,22 @@ class CacheTest(unittest.TestCase):
         # kernel grid size.
         linear_cache_indices = torch.arange(N, dtype=torch.int64, device=device)
         # Small cache -> tiny lxu_cache_state / weights / lru_state.
+        # Cache associativity == warp size (DEFAULT_ASSOC: 32 on NVIDIA,
+        # 64 on AMD). The insert kernel strides cache rows by kWarpSize, so
+        # the slot dimension MUST match or the kernel indexes out of bounds
+        # on wavefront-64 hardware.
         num_cache_sets = 1024
         lxu_cache_state = torch.full(
-            (num_cache_sets, 32), -1, dtype=torch.int64, device=device
+            (num_cache_sets, DEFAULT_ASSOC), -1, dtype=torch.int64, device=device
         )
         # Flat weights tensor for the single table.
         weights = torch.zeros(N * D, dtype=torch.float32, device=device)
         lxu_cache_weights = torch.zeros(
-            (num_cache_sets * 32, D), dtype=torch.float32, device=device
+            (num_cache_sets * DEFAULT_ASSOC, D), dtype=torch.float32, device=device
         )
-        lru_state = torch.zeros((num_cache_sets, 32), dtype=torch.int64, device=device)
+        lru_state = torch.zeros(
+            (num_cache_sets, DEFAULT_ASSOC), dtype=torch.int64, device=device
+        )
 
         torch.ops.fbgemm.lru_cache_populate(
             weights,
@@ -1102,14 +1111,14 @@ class CacheTest(unittest.TestCase):
         )
         # Tier C structural invariants on the populated cache:
         # 1. shape preserved.
-        self.assertEqual(lxu_cache_state.shape, (num_cache_sets, 32))
-        # 2. Cache is fully populated. With N >> num_cache_sets * 32 = 32K,
+        self.assertEqual(lxu_cache_state.shape, (num_cache_sets, DEFAULT_ASSOC))
+        # 2. Cache is fully populated. With N >> num_cache_sets * DEFAULT_ASSOC,
         #    every cache slot should hold a valid key (not the -1 sentinel)
         #    after the insert kernel runs. Pre-fix the kernel never runs;
         #    post-fix it grid-strides over all N indices and populates
         #    every slot.
         num_filled = int((lxu_cache_state != -1).sum().item())
-        self.assertEqual(num_filled, num_cache_sets * 32)
+        self.assertEqual(num_filled, num_cache_sets * DEFAULT_ASSOC)
         # 3. Every populated slot holds a valid linear cache index in
         #    [0, N). This catches "kernel wrote wrong key" bugs.
         populated = lxu_cache_state[lxu_cache_state != -1]

--- a/fbgemm_gpu/test/tbe/cache/lxu_cache_test.py
+++ b/fbgemm_gpu/test/tbe/cache/lxu_cache_test.py
@@ -32,7 +32,14 @@ VERBOSITY: Verbosity = Verbosity.verbose
 class LXUCacheTest(unittest.TestCase):
     @unittest.skipIf(*gpu_unavailable)
     @given(
-        associativity=st.sampled_from([1, DEFAULT_ASSOC]),
+        # lxu_cache_lookup is a set-associative lookup whose kernel reads
+        # exactly kWarpSize (== DEFAULT_ASSOC) ways per set. Any other
+        # associativity makes the kernel read past the cache state row
+        # (out of bounds), which on ROCm wavefront64 yields spurious hits.
+        # The direct-mapped (associativity 1) path is a separate op,
+        # direct_mapped_lxu_cache_lookup, exercised end-to-end (cache_assoc=1)
+        # by nbit_cache_test.test_nbit_direct_mapped_uvm_cache_stats.
+        associativity=st.sampled_from([DEFAULT_ASSOC]),
     )
     @settings(deadline=None)
     def test_lxu_cache_lookup(self, associativity: int) -> None:

--- a/fbgemm_gpu/test/tbe/cache/lxu_cache_test.py
+++ b/fbgemm_gpu/test/tbe/cache/lxu_cache_test.py
@@ -23,12 +23,7 @@ from hypothesis import given, settings, Verbosity
 from torch import Tensor
 
 from ..common import MAX_EXAMPLES  # noqa E402
-from .cache_common import (
-    generate_cache_tbes,
-    gpu_memory_lt_gb,
-    gpu_unavailable,
-    optests,
-)
+from .cache_common import generate_cache_tbes, gpu_unavailable, optests
 
 VERBOSITY: Verbosity = Verbosity.verbose
 
@@ -451,53 +446,6 @@ class LXUCacheTest(unittest.TestCase):
             # Reaching this line means all three guards passed on CDNA.
             self.assertIsInstance(output, torch.Tensor)
             self.assertGreater(output.numel(), 0)
-
-    @optests.dontGenerateOpCheckTests("Large grid HIP regression — uses ~32 GB HBM")
-    @unittest.skipIf(*gpu_unavailable)
-    @unittest.skipIf(*gpu_memory_lt_gb(40))
-    def test_direct_mapped_lxu_cache_lookup_large_grid(self) -> None:
-        """
-        Reproduces the HIP grid-overflow bug in
-        direct_mapped_lxu_cache_lookup_kernel
-        (split_embeddings_cache/lxu_cache.cu line ~511).
-
-        Block: kMaxThreads = 1024. Grid: div_round_up(N, kMaxThreads) =
-        ceil(N / 1024). Total threads ~= N. For N >= 2**32, total threads
-        meet HIP's 2**32 hard limit, causing FBGEMM_LAUNCH_KERNEL ->
-        KernelLauncher::checkThreadCountNotExceeded to TORCH_CHECK-fail
-        on ROCm.
-
-        Drives torch.ops.fbgemm.direct_mapped_lxu_cache_lookup with N
-        linear cache indices. HBM ~= N * 8 B = 32 GiB for the int64
-        linear_cache_indices tensor; gate at gpu_memory_lt_gb(40).
-        """
-        N = (1 << 32) + 1
-        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
-
-        # All-zero linear cache indices keep the kernel work cheap; the
-        # test exercises only the host-side launch grid bound.
-        linear_cache_indices = torch.zeros(N, dtype=torch.int64, device=device)
-        # Tiny direct-mapped cache: shape (num_cache_lines, 1).
-        num_cache_lines = 1024
-        lxu_cache_state = torch.full(
-            (num_cache_lines, 1), -1, dtype=torch.int64, device=device
-        )
-        invalid_index = -1
-
-        lxu_cache_locations = torch.ops.fbgemm.direct_mapped_lxu_cache_lookup(
-            linear_cache_indices,
-            lxu_cache_state,
-            invalid_index,
-        )
-        # Tier C structural invariants on the lookup result:
-        # 1. Output shape matches input.
-        self.assertEqual(lxu_cache_locations.numel(), N)
-        # 2. With an empty cache (all -1) and key 0 looked up N times,
-        #    every result must equal `invalid_index`. Pre-fix the kernel
-        #    never runs (TORCH_CHECK fires); post-fix it grid-strides
-        #    over all N indices and writes invalid_index to each slot.
-        all_invalid = (lxu_cache_locations == invalid_index).all().item()
-        self.assertTrue(bool(all_invalid))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
`test_lxu_cache_lookup` parametrizes associativity over
`[1, DEFAULT_ASSOC]`, but the `lxu_cache_lookup` kernel only supports
associativity == kWarpSize (== DEFAULT_ASSOC). The kernel reads exactly
`kWarpSize` ways per set:

  const auto slot = threadIdx.x;                        // [0, kWarpSize)
  found = (__ldg((&lxu_cache_state[cache_set][0]) + slot) == idx);

With associativity == 1 the `lxu_cache_state` row has a single column,
so lanes 1..kWarpSize-1 read past the row (out of bounds). On ROCm
wavefront64 that adjacent memory intermittently equals a lookup index,
producing spurious hits and a flaky failure (see OSS ROCm CI
P2379451085):

  AssertionError: Tensor-likes are not equal!
  Mismatched elements: 5 / 8 ... Greatest absolute difference: 37
  Falsifying example: test_lxu_cache_lookup(associativity=1)

associativity == 1 (direct-mapped) is a different op
(`direct_mapped_lxu_cache_lookup`) with its own coverage, so it should
never have been exercised through `lxu_cache_lookup`. Drop the
unsupported value from the sampled set (only DEFAULT_ASSOC, which is 32
on CUDA / 64 on ROCm — the kWarpSize the kernel actually reads). No
production change.

Differential Revision: D108637397


