### PR TITLE
Add grid-stride loop and ROCm cap to _populate_length_to_feature_id_inplace_kernel (2D weights)

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_block_bucketize_features_2d_weights.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_block_bucketize_features_2d_weights.cu
@@ -22,16 +22,27 @@ __launch_bounds__(kMaxThreads) void _populate_length_to_feature_id_inplace_kerne
     const offset_t* const __restrict__ batch_size_per_feature,
     const offset_t* const __restrict__ batch_size_offsets,
     offset_t* const __restrict__ length_to_feature_idx) {
-  const auto b_t = blockIdx.x * blockDim.x + threadIdx.x;
+  // Use explicit int64_t arithmetic for the grid-stride loop so that
+  // max_B * T (which may exceed INT_MAX) and the per-iteration thread stride
+  // are computed in 64-bit. Casting the first operand avoids the 32-bit
+  // unsigned `blockDim.x * gridDim.x` product that CUDA_KERNEL_LOOP_TYPE would
+  // overflow before widening
+  // (facebook-security-vulnerable-integer-implicit-cast).
+  const int64_t b_t_total = static_cast<int64_t>(max_B) * T;
+  const int64_t b_t_stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (int64_t b_t =
+           static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       b_t < b_t_total;
+       b_t += b_t_stride) {
+    const auto t = b_t / max_B;
+    const auto b = b_t % max_B;
 
-  const auto t = b_t / max_B;
-  const auto b = b_t % max_B;
+    if (b >= batch_size_per_feature[t]) {
+      continue;
+    }
 
-  if (t >= T || b >= batch_size_per_feature[t]) {
-    return;
+    length_to_feature_idx[batch_size_offsets[t] + b] = t;
   }
-
-  length_to_feature_idx[batch_size_offsets[t] + b] = t;
 }
 
 void adjust_block_bucketize_sparse_features_2d_weights_kernel_launch_configs_based_on_smem(
@@ -316,7 +327,17 @@ __launch_bounds__(kMaxThreads) void _block_bucketize_sequence_sparse_features_2d
     const bool* const __restrict__ keep_orig_idx_per_feature) {
   using uindex_t = std::make_unsigned_t<index_t>;
   using uoffset_t = std::make_unsigned_t<offset_t>;
-  CUDA_KERNEL_LOOP(b_t, lengths_size) {
+  // Explicit grid-stride loop replicating CUDA_KERNEL_LOOP, whose internal
+  // int64_t counter is incremented by the 32-bit `blockDim.x * gridDim.x`
+  // product and trips facebook-security-vulnerable-integer-implicit-cast.
+  // Cast the stride to int64_t; b_t stays int so the index arithmetic below
+  // is unchanged.
+  const int64_t b_t_stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (int64_t b_t_idx =
+           static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       b_t_idx < lengths_size;
+       b_t_idx += b_t_stride) {
+    const int b_t = static_cast<int>(b_t_idx);
     const auto t = length_to_feature_idx ? length_to_feature_idx[b_t] : b_t / B;
     index_t blk_size = block_sizes_data[t];
     const index_t local_num_blks =
@@ -400,7 +421,15 @@ __launch_bounds__(kMaxThreads) void _populate_bucketized_permute_cuda_kernel(
     const index_t* const bucket_mapping_data,
     index_t* const bucketized_permute_data_out,
     int32_t lengths_size) {
-  CUDA_KERNEL_LOOP(b_t, lengths_size) {
+  // Explicit grid-stride loop (see note above): cast the stride to int64_t to
+  // avoid the implicit-cast security lint in CUDA_KERNEL_LOOP; b_t stays int
+  // so the index arithmetic below is unchanged.
+  const int64_t b_t_stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (int64_t b_t_idx =
+           static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       b_t_idx < lengths_size;
+       b_t_idx += b_t_stride) {
+    const int b_t = static_cast<int>(b_t_idx);
     const auto length = length_data[b_t];
     const auto offset = offset_data[b_t];
     for (size_t i = 0; i < length; i++) {
@@ -623,25 +652,30 @@ _block_bucketize_sparse_features_2d_weights_cuda(
   auto indices_to_lb = at::empty_like(indices);
   if (batch_size_per_feature.has_value()) {
     constexpr auto threads_per_block = 256;
-    const auto num_blocks =
-        cuda_calc_xblock_count(max_B * T, threads_per_block);
+    // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
+    // which silently wraps). _populate_length_to_feature_id_inplace_kernel
+    // uses an explicit int64_t grid-stride loop, so capping the grid dimension
+    // is correctness-preserving (the loop iterates over all work items).
+    // See: https://github.com/ROCm/hip/issues/2253
+    const auto num_blocks = utils::cuda::cap_grid_dim_x_from_workload(
+        max_B * T, threads_per_block, at::cuda::getCurrentCUDAStream());
 
     AT_DISPATCH_INDEX_TYPES(
         offsets_contig.scalar_type(),
         "_populate_length_to_feature_id_inplace_kernel",
         [&] {
           using offset_t = index_t;
-          _populate_length_to_feature_id_inplace_kernel<<<
+          FBGEMM_LAUNCH_KERNEL(
+              (_populate_length_to_feature_id_inplace_kernel<offset_t>),
               num_blocks,
               threads_per_block,
               0,
-              at::cuda::getCurrentCUDAStream()>>>(
+              at::cuda::getCurrentCUDAStream(),
               max_B,
               T,
               batch_sizes_contig.data_ptr<offset_t>(),
               batch_sizes_offsets_contig.data_ptr<offset_t>(),
               length_to_feature_idx.data_ptr<offset_t>());
-          C10_CUDA_KERNEL_LAUNCH_CHECK();
         });
   }
 

--- a/fbgemm_gpu/test/sparse/block_bucketize_2d_weights_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_2d_weights_test.py
@@ -19,10 +19,14 @@ from .common import extend_test_class, open_source
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import gpu_available
+    from test_utils import gpu_available, gpu_memory_lt_gb, gpu_unavailable
 else:
     import fbgemm_gpu.sparse_ops  # noqa: F401, E402  (registers FakeTensor/meta impls)
-    from fbgemm_gpu.test.test_utils import gpu_available
+    from fbgemm_gpu.test.test_utils import (
+        gpu_available,
+        gpu_memory_lt_gb,
+        gpu_unavailable,
+    )
 
 
 class BlockBucketize2DWeightsTest(unittest.TestCase):
@@ -1014,6 +1018,103 @@ class BlockBucketize2DWeightsTest(unittest.TestCase):
                 torch.rand(indices.numel(), 3),
                 total_num_blocks=torch.tensor([7, 6, 6], dtype=torch.int),
             )
+
+    @unittest.skipIf(*gpu_unavailable)
+    # Skip on GPUs with insufficient HBM (this test requires only small
+    # tensors, but the kernel launch itself triggers the check).
+    @unittest.skipIf(*gpu_memory_lt_gb(4))
+    def test_populate_length_to_feature_id_inplace_2d_weights_large_grid(
+        self,
+    ) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in
+        _populate_length_to_feature_id_inplace_kernel for the 2D-weights
+        variable-batch-size code path of
+        block_bucketize_sparse_features_2d_weights_cuda.
+
+        With threads_per_block=256, the launch grid is
+        cuda_calc_xblock_count(max_B*T, 256). For max_B*T > 2**32, total
+        threads exceed the HIP 2**32 limit, causing FBGEMM_LAUNCH_KERNEL ->
+        KernelLauncher::checkThreadCountNotExceeded to TORCH_CHECK-fail on
+        ROCm. _populate_length_to_feature_id_inplace_kernel uses
+        CUDA_KERNEL_LOOP_TYPE with int64_t after the fix, so capping the
+        grid is correctness-preserving.
+
+        Verification strategy: this test exercises launch-survival and a
+        non-trivial post-launch shape invariant at the cap-trip scale.
+        Variable-batch-size correctness (CPU vs GPU element-wise
+        comparison) is covered by the hypothesis-parameterized
+        ``test_block_bucketize_sparse_features_2d_weights_with_variable_batch_sizes``
+        test in this file at small max_B (where the input layout
+        invariants are known to match between CPU and GPU dispatch).
+
+        ``batch_size_per_feature`` is sparse: only features 0 and 2 have
+        a single batch instance each; features 1 and 3 have zero. This
+        keeps HBM usage bounded while still exercising the kernel's
+        non-trivial path (writing length_to_feature_idx[0]=0 and
+        length_to_feature_idx[1]=2).
+
+        Note: The kernel also safely handles the edge case where all
+        features have batch_size=0 (total_B=0). In this case, the kernel
+        launches but all threads hit the `continue` early-exit (since
+        b >= 0 is always true when batch_size_per_feature[t]=0), resulting
+        in no writes to length_to_feature_idx. This is safe and correct.
+        """
+
+        # Choose max_B*T so that total threads strictly exceeds 2**32:
+        # cuda_calc_xblock_count(max_B*T, 256) * 256 >= max_B*T; need
+        # max_B*T > 2**32.
+        T = 4
+        max_B = (1 << 30) + 1  # max_B * T = 2**32 + 4
+
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+
+        # Sparse batch_size_per_feature: only features 0 and 2 have
+        # one batch instance each. total_B = 2.
+        batch_size_per_feature = torch.zeros(T, dtype=torch.int32, device=device)
+        batch_size_per_feature[0] = 1
+        batch_size_per_feature[2] = 1
+        # total_B = 2 batch instances. lengths and indices sized
+        # accordingly.
+        lengths = torch.tensor([2, 1], dtype=torch.int32, device=device)
+        indices = torch.tensor([3, 7, 11], dtype=torch.int32, device=device)
+        block_sizes = torch.tensor([10, 20, 30, 40], dtype=torch.int32, device=device)
+        my_size = 2
+        weights_dim = 1
+        weights = torch.tensor(
+            [[0.1], [0.2], [0.3]], dtype=torch.float32, device=device
+        )
+
+        # GPU op under test. Pre-fix, this launch trips
+        # KernelLauncher::checkThreadCountNotExceeded on ROCm.
+        (
+            new_lengths,
+            new_indices,
+            new_weights,
+            _new_pos,
+            _unbucketize_permute,
+        ) = torch.ops.fbgemm.block_bucketize_sparse_features_2d_weights(
+            lengths,
+            indices,
+            False,  # bucketize_pos
+            True,  # sequence
+            block_sizes,
+            my_size,
+            weights,
+            weights_dim,
+            batch_size_per_feature=batch_size_per_feature,
+            max_B=max_B,
+        )
+
+        # Output shape invariants: every input index lands in exactly
+        # one bucket, so total new_indices == indices.numel().
+        total_B = int(batch_size_per_feature.sum().item())
+        self.assertEqual(new_lengths.shape, (my_size * total_B,))
+        self.assertEqual(new_indices.shape, (indices.numel(),))
+        self.assertEqual(new_weights.shape, (indices.numel(), weights_dim))
+        # Per-bucket lengths sum to per-feature input length: total
+        # output length == total input length.
+        self.assertEqual(int(new_lengths.sum().item()), int(lengths.sum().item()))
 
 
 extend_test_class(BlockBucketize2DWeightsTest)


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2826

Tier-2 fix for HIP grid-overflow in sparse_ops/sparse_block_bucketize_features_2d_weights.cu, plus the CLANGSECURITY implicit-cast lint it surfaced.

The kernel _populate_length_to_feature_id_inplace_kernel previously used blockIdx.x * blockDim.x + threadIdx.x directly as the work index with an early-return on out-of-range. Capping the host-side grid without first adding a grid-stride loop would silently drop input items, producing wrong outputs.

This diff:
- Rewrites _populate_length_to_feature_id_inplace_kernel as an explicit int64_t grid-stride loop (init/stride cast via static_cast<int64_t>) so it iterates safely past INT_MAX. Replaced the t >= T early-return with the loop bound and the b >= batch_size_per_feature[t] early-return with continue.
- Adds the standard ROCm grid cap (utils::cuda::cap_grid_dim_x_from_workload) to the launch site, and migrates the raw <<<...>>> launch to FBGEMM_LAUNCH_KERNEL (which provides the ROCm-only KernelLauncher::checkThreadCountNotExceeded assertion).

Security lint (facebook-security-vulnerable-integer-implicit-cast, LAND_BLOCKING):
- The ATen CUDA_KERNEL_LOOP[_TYPE] macros keep an internal int64_t counter that is incremented by the 32-bit unsigned `blockDim.x * gridDim.x` product, which overflows before being widened -> trips the security lint. The new explicit-cast int64_t stride avoids this.
- Fixing the new kernel surfaces the same lint on the two pre-existing CUDA_KERNEL_LOOP sites in this file (_block_bucketize_sequence_..._cuda_kernel2 and _populate_bucketized_permute_cuda_kernel). Converted both to the same explicit int64_t-cast grid-stride loop. b_t is kept as int in those bodies so the existing 32-bit index arithmetic is byte-for-byte unchanged (behavior-preserving); only the loop stride is widened.

Follows the Tier-1 pattern established in D104903707, D104937969.

Note: The new repro test exercises max_B * T = 2^32 + 4, which strictly overflows the original int b_t loop counter. cuda_calc_xblock_count(max_B * T, 256) casts to uint64_t internally so the host arithmetic is overflow-safe.

Reviewed By: henrylhtsang

Differential Revision: D105024770


