### PR TITLE
Enable `use_subwarp_shuffle=True` for CTA kernel on ROCm (#5917)

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_cta_template.cu
@@ -625,7 +625,11 @@ batch_index_select_dim0_codegen_backward_kernel_cta_per_row
     codegen/embedding_common_code_generator.py for more details
 */ #}
 
+{%- if is_rocm %}
+{{ instantiate_templates(use_subwarp_shuffle=True) }}
+{%- else %}
 {{ instantiate_templates(use_subwarp_shuffle=False) }}
+{%- endif %}
 
 ////////////////////////////////////////////////////////////////////////////////
 #endif


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2998


### TLDR
- Instantiate the CTA backward kernel template with `use_subwarp_shuffle=True` on ROCm — subwarp shuffle-based reductions instead of shared-memory reductions.
- CTA-only: the warp kernel template is unchanged (`use_subwarp_shuffle=False`).
- Perf-neutral on its own; it is the enabler that the small-D CTA specialization (D102946299) builds on.

### Changes
- `embedding_backward_split_kernel_cta_template.cu`: instantiate the CTA templates with `use_subwarp_shuffle=True` (was `False`) on ROCm.

### Benchmark results
MI350 (gfx950), median (us). Standalone effect of this diff (baseline vs this diff) is within run-to-run noise.

| config | CTA base | CTA this | Δ | Total base | Total this | Δ |
| --- | --- | --- | --- | --- | --- | --- |
| bench_50 T=2 Ds=128 | 126 | 125 | +0.8% | 183 | 182 | +0.5% |
| bench_0 T=10 Ds=128 | 140 | 142 | -1.4% | 408 | 410 | -0.5% |
| bench_5 T=10 Ds=20/128 | 131 | 131 | +0.0% | 420 | 420 | +0.0% |
| bench_13 T=12 Ds=24/128 | 144 | 144 | +0.0% | 378 | 377 | +0.3% |
| bench_2 T=14 Ds=12/24/128 | 135 | 136 | -0.7% | 397 | 398 | -0.3% |
| bench_1 T=18 Ds=20/128 | 141 | 141 | +0.0% | 341 | 342 | -0.3% |
| bench_3 T=20 Ds=20/24/128 | 148 | 150 | -1.4% | 463 | 464 | -0.2% |
| bench_27 T=22 Ds=20/24/128 | 153 | 154 | -0.7% | 460 | 461 | -0.2% |

Differential Revision: D108830772


