### PR TITLE
Add FusedNBit metas + harden data-dependent metas + xfail harness-incompatible opcheck tests (#5918)

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
+++ b/fbgemm_gpu/fbgemm_gpu/sparse_ops.py
@@ -252,6 +252,9 @@ def repeat_arange_meta(lengths: Tensor) -> Tensor:
         # FakeTensor context: use dynamic sizing for proper shape tracking
         ctx = torch.library.get_ctx()
         output_size = ctx.new_dynamic_size()
+        # Size-oblivious guard resolution for the data-dependent output size,
+        # so test_aot_dispatch_dynamic does not fail on the unbacked SymInt.
+        torch._check_is_size(output_size)
         return torch.empty([output_size], dtype=lengths.dtype, device=lengths.device)
 
 
@@ -835,6 +838,8 @@ def batch_index_select_dim0_tensor_abstract(
     torch._check(input_num_indices.size(0) == input_rows.size(0))
     torch._check(input_num_indices.size(0) == input_columns.size(0))
     output_numel = torch.library.get_ctx().new_dynamic_size()
+    # Size-oblivious guard resolution for the data-dependent output numel.
+    torch._check_is_size(output_numel)
     return inputs.new_empty([output_numel])
 
 
@@ -1246,6 +1251,24 @@ def fused_nbit_rowwise_quantized_sb_half_to_float_or_half(
         )
 
 
+def fused_nbit_rowwise_quantized_sb_half_to_float(
+    input_t: Tensor,
+    bit_rate: int,
+) -> Tensor:
+    return fused_nbit_rowwise_quantized_sb_half_to_float_or_half(
+        input_t, bit_rate, SparseType.FP32.as_int()
+    )
+
+
+def fused_nbit_rowwise_quantized_sb_half_to_half(
+    input_t: Tensor,
+    bit_rate: int,
+) -> Tensor:
+    return fused_nbit_rowwise_quantized_sb_half_to_float_or_half(
+        input_t, bit_rate, SparseType.FP16.as_int()
+    )
+
+
 def fused_8_bit_rowwise_quantized_to_float_or_half(
     input_t: Tensor,
     output_dtype: int = 0,
@@ -1390,6 +1413,8 @@ def padded_fp8_rowwise_quantized_to_float(
         # When output_last_dim is not supplied the kernel reads per-row pad
         # values, making the output column count data-dependent.
         output_columns = torch.library.get_ctx().new_dynamic_size()
+        # Size-oblivious guard resolution for the data-dependent output cols.
+        torch._check_is_size(output_columns)
     output_shape: list[int | torch.SymInt] = [*input_t.shape]
     output_shape[last_dim] = output_columns
     if output_dtype == SparseType.FP32.as_int():
@@ -1659,6 +1684,22 @@ def _setup() -> None:
         impl_abstract(
             "fbgemm::FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf",
             fused_nbit_rowwise_quantized_sb_half_to_float_or_half,
+        )
+        impl_abstract(
+            "fbgemm::FloatToFusedNBitRowwiseQuantizedSBHalf",
+            float_or_half_to_fused_nbit_rowwise_quantized_sbhalf,
+        )
+        impl_abstract(
+            "fbgemm::HalfToFusedNBitRowwiseQuantizedSBHalf",
+            float_or_half_to_fused_nbit_rowwise_quantized_sbhalf,
+        )
+        impl_abstract(
+            "fbgemm::FusedNBitRowwiseQuantizedSBHalfToFloat",
+            fused_nbit_rowwise_quantized_sb_half_to_float,
+        )
+        impl_abstract(
+            "fbgemm::FusedNBitRowwiseQuantizedSBHalfToHalf",
+            fused_nbit_rowwise_quantized_sb_half_to_half,
         )
         impl_abstract(
             "fbgemm::Fused8BitRowwiseQuantizedToFloatOrHalf",

--- a/fbgemm_gpu/test/jagged/failures_dict.json
+++ b/fbgemm_gpu/test/jagged/failures_dict.json
@@ -4,6 +4,12 @@
   "data": {
     "fbgemm::dense_to_jagged": {},
     "fbgemm::expand_into_jagged_permute": {},
+    "fbgemm::get_source_mask": {
+      "GetSourceMaskTest.test_aot_dispatch_dynamic__test_python_wrapper_fx_tracing_and_jit_scripting": {
+        "comment": "Test runs torch.fx.symbolic_trace + torch.jit.script; incompatible with the opcheck aot_dispatch_dynamic harness. Meta impl is correct. T191384137",
+        "status": "xfail"
+      }
+    },
     "fbgemm::jagged_1d_to_dense": {},
     "fbgemm::jagged_1d_to_truncated_values": {
       "JaggedTensorOpsTest.test_aot_dispatch_dynamic__test_jagged_1d_to_truncated_values": {

--- a/fbgemm_gpu/test/quantize/failures_dict_fast.json
+++ b/fbgemm_gpu/test/quantize/failures_dict_fast.json
@@ -35,24 +35,7 @@
         "status": "xfail"
       }
     },
-    "fbgemm::FloatToFusedNBitRowwiseQuantizedSBHalf": {
-      "SplitTableBatchedEmbeddingsTest.test_faketensor__test_nbit_forward_fused_pooled_emb_quant": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "TestFusedNBitRowwiseQuantizationConversion.test_faketensor__test_quantize_and_dequantize_op": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "TestFusedNBitRowwiseQuantizationConversion.test_faketensor__test_quantize_and_dequantize_op_cuda_large_nrows": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "TestFusedNBitRowwiseQuantizationConversion.test_faketensor__test_quantize_op": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
+    "fbgemm::FloatToFusedNBitRowwiseQuantizedSBHalf": {},
     "fbgemm::FloatToHFP8Quantized": {},
     "fbgemm::Fused8BitRowwiseQuantizedToFloat": {
       "SplitTableBatchedEmbeddingsTest.test_faketensor__test_forward_cpu_int8": {
@@ -82,16 +65,7 @@
         "status": "xfail"
       }
     },
-    "fbgemm::FusedNBitRowwiseQuantizedSBHalfToFloat": {
-      "TestFusedNBitRowwiseQuantizationConversion.test_faketensor__test_quantize_and_dequantize_op": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "TestFusedNBitRowwiseQuantizationConversion.test_faketensor__test_quantize_and_dequantize_op_cuda_large_nrows": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
+    "fbgemm::FusedNBitRowwiseQuantizedSBHalfToFloat": {},
     "fbgemm::FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf": {
       "TestFusedNBitRowwiseQuantizationConversion.test_faketensor__test_quantize_and_dequantize_op": {
         "comment": "",
@@ -102,12 +76,7 @@
         "status": "xfail"
       }
     },
-    "fbgemm::FusedNBitRowwiseQuantizedSBHalfToHalf": {
-      "TestFusedNBitRowwiseQuantizationConversion.test_faketensor__test_quantize_and_dequantize_op": {
-        "comment": "",
-        "status": "xfail"
-      }
-    },
+    "fbgemm::FusedNBitRowwiseQuantizedSBHalfToHalf": {},
     "fbgemm::HFP8QuantizedToFloat": {},
     "fbgemm::HalfToFused8BitRowwiseQuantized": {
       "TestFused8BitRowwiseQuantizationConversion.test_faketensor__test_quantize_op": {
@@ -115,15 +84,6 @@
         "status": "xfail"
       }
     },
-    "fbgemm::HalfToFusedNBitRowwiseQuantizedSBHalf": {
-      "TestFusedNBitRowwiseQuantizationConversion.test_faketensor__test_quantize_and_dequantize_op": {
-        "comment": "",
-        "status": "xfail"
-      },
-      "TestFusedNBitRowwiseQuantizationConversion.test_faketensor__test_quantize_op": {
-        "comment": "",
-        "status": "xfail"
-      }
-    }
+    "fbgemm::HalfToFusedNBitRowwiseQuantizedSBHalf": {}
   }
 }

--- a/fbgemm_gpu/test/sparse/failures_dict.json
+++ b/fbgemm_gpu/test/sparse/failures_dict.json
@@ -12,6 +12,12 @@
         "status": "xfail"
       }
     },
+    "fbgemm::asynchronous_batched_complete_cumsum": {
+      "CumSumTest.test_aot_dispatch_dynamic__test_batched_complete_cumsum": {
+        "comment": "Test builds output via a dynamic Python loop + torch.stack; incompatible with aot_dispatch_dynamic. C++ symbolic meta is correct. T191384137",
+        "status": "xfail"
+      }
+    },
     "fbgemm::asynchronous_complete_cumsum": {},
     "fbgemm::asynchronous_exclusive_cumsum": {},
     "fbgemm::asynchronous_inclusive_cumsum": {},


### PR DESCRIPTION
Summary:

Residual opcheck FAILURE fixes for the fbgemm_dev OMH dashboard (T191384137),
following the landed 2a/2b meta work.

1. (A1) Register FakeTensor/meta impls for the 4 FusedNBit quantize ops that
   had none (only the generic FloatOrHalf variants were registered):
   FloatToFusedNBitRowwiseQuantizedSBHalf, HalfToFusedNBitRowwiseQuantizedSBHalf
   (reuse float_or_half_to_fused_nbit_rowwise_quantized_sbhalf), and
   FusedNBitRowwiseQuantizedSBHalfToFloat / ...ToHalf (fixed-dtype wrappers over
   the existing dequant helper). These were the cause of the 12 mis-tagged
   "flaky" fused_nbit_rowwise opcheck issues (NotImplementedError on the draws
   that hit the unregistered branch).
   NOTE: test/quantize/failures_dict_fast.json still has stale xfails for these
   ops; run PYTORCH_OPCHECK_ACCEPT=1 on NVIDIA to reconcile (they become XPASS).

2. (A2/A3) Add torch._check_is_size() to the remaining data-dependent metas so
   test_aot_dispatch_dynamic stops failing on unbacked-SymInt guards:
   repeat_arange_meta, batch_index_select_dim0_tensor_forward_cuda_impl_abstract,
   and padded_fp8_rowwise_quantized_to_float (the latter addresses the reviewer
   comment on D108658292). Mirrors the landed dense_to_jagged/jagged_index_select_2d fixes.

3. (A4) xfail two opcheck tests that are incompatible with the harness (the metas
   are correct): get_source_mask test_python_wrapper_fx_tracing_and_jit_scripting
   (uses fx.symbolic_trace + jit.script) and cumsum test_batched_complete_cumsum
   (dynamic Python loop + torch.stack).

Differential Revision: D108805717


