### PR TITLE
Wire metadata column family into existing EmbeddingRocksDB methods (#5920)

### DIFF
--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -639,6 +639,136 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
         /*snapshot_handle=*/nullptr);
   }
 
+  folly::SemiFuture<std::vector<folly::Unit>> get_kv_db_weights_only_async(
+      const at::Tensor& indices,
+      const at::Tensor& weights,
+      const at::Tensor& count) override {
+    return get_kv_db_single_cf_async(
+        indices, weights, count, /*use_metadata_cf=*/false);
+  }
+
+  folly::SemiFuture<std::vector<folly::Unit>> get_kv_db_metadata_only_async(
+      const at::Tensor& indices,
+      const at::Tensor& metadata,
+      const at::Tensor& count) override {
+    if (metadata_dim_ <= 0) {
+      return folly::makeSemiFuture(std::vector<folly::Unit>());
+    }
+    return get_kv_db_single_cf_async(
+        indices, metadata, count, /*use_metadata_cf=*/true);
+  }
+
+  folly::SemiFuture<std::vector<folly::Unit>> get_kv_db_single_cf_async(
+      const at::Tensor& indices,
+      const at::Tensor& output,
+      const at::Tensor& count,
+      bool use_metadata_cf) {
+    auto count_ = count.scalar_type() == at::ScalarType::Long
+        ? *(count.data_ptr<int64_t>())
+        : *(count.data_ptr<int32_t>());
+    auto D = output.size(1);
+    if (count_ <= 0) {
+      return folly::makeSemiFuture(std::vector<folly::Unit>());
+    }
+
+    std::vector<folly::Future<folly::Unit>> futures;
+    for (auto shard = 0; shard < dbs_.size(); ++shard) {
+      auto f =
+          folly::via(executor_.get())
+              .thenValue([=, this, &indices, &output](folly::Unit) {
+                FBGEMM_DISPATCH_FLOAT_HALF_AND_BYTE(
+                    output.scalar_type(), "get_single_cf", [&] {
+                      using value_t = scalar_t;
+                      CHECK(indices.is_contiguous());
+                      CHECK(output.is_contiguous());
+                      CHECK_EQ(indices.size(0), output.size(0));
+                      auto* indices_ptr = indices.data_ptr<int64_t>();
+                      auto* out_ptr = output.data_ptr<value_t>();
+                      FOLLY_DECLARE_REUSED(keys, std::vector<rocksdb::Slice>);
+                      FOLLY_DECLARE_REUSED(key_indices, std::vector<int32_t>);
+                      for (int64_t i = 0; i < count_; ++i) {
+                        if (indices_ptr[i] < 0) {
+                          continue;
+                        }
+                        if (kv_db_utils::hash_shard(
+                                indices_ptr[i], dbs_.size()) != shard) {
+                          continue;
+                        }
+                        key_indices.push_back(i);
+                      }
+                      if (key_indices.empty()) {
+                        return;
+                      }
+                      std::ranges::sort(
+                          key_indices, [&](int32_t lhs, int32_t rhs) {
+                            return indices_ptr[lhs] < indices_ptr[rhs];
+                          });
+                      keys.reserve(key_indices.size());
+                      for (const auto& i : key_indices) {
+                        keys.emplace_back(
+                            reinterpret_cast<const char*>(&indices_ptr[i]),
+                            sizeof(int64_t));
+                      }
+                      CHECK_EQ(key_indices.size(), keys.size());
+                      auto* cf_handle = use_metadata_cf
+                          ? metadata_cf_handles_[shard]
+                          : dbs_[shard]->DefaultColumnFamily();
+                      FOLLY_DECLARE_REUSED(
+                          cfs, std::vector<rocksdb::ColumnFamilyHandle*>);
+                      cfs.assign(keys.size(), cf_handle);
+                      FOLLY_DECLARE_REUSED(
+                          values, std::vector<rocksdb::PinnableSlice>);
+                      FOLLY_DECLARE_REUSED(
+                          statuses, std::vector<rocksdb::Status>);
+                      values.resize(keys.size());
+                      statuses.resize(keys.size());
+                      dbs_[shard]->MultiGet(
+                          ro_,
+                          keys.size(),
+                          cfs.data(),
+                          keys.data(),
+                          values.data(),
+                          statuses.data(),
+                          /*sorted_input=*/true);
+                      value_t* row_storage_data_ptr = nullptr;
+                      if (!disable_random_init_) {
+                        row_storage_data_ptr =
+                            initializers_[shard]
+                                ->row_storage_.data_ptr<value_t>();
+                      }
+                      for (size_t j = 0; j < keys.size(); ++j) {
+                        const auto& s = statuses[j];
+                        int64_t i = key_indices[j];
+                        const auto& value = values[j];
+                        if (s.ok()) {
+                          CHECK_GE(value.size(), D * sizeof(value_t));
+                          std::copy(
+                              reinterpret_cast<const value_t*>(value.data()),
+                              reinterpret_cast<const value_t*>(value.data()) +
+                                  D,
+                              &(out_ptr[i * D]));
+                        } else {
+                          CHECK(s.IsNotFound());
+                          auto weight_width =
+                              get_width_for_weights(keys[j], 0, D);
+                          fill_from_row_storage(
+                              shard,
+                              reinterpret_cast<unsigned char*>(out_ptr),
+                              i,
+                              reinterpret_cast<unsigned char*>(
+                                  row_storage_data_ptr),
+                              0,
+                              D,
+                              weight_width);
+                        }
+                      }
+                    });
+              });
+      futures.emplace_back(std::move(f));
+    }
+    return folly::collect(futures);
+  }
+
   folly::SemiFuture<std::vector<folly::Unit>> set_kv_db_async(
       const at::Tensor& indices,
       const at::Tensor& weights,
@@ -1174,6 +1304,117 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
     CHECK_GT(feature_dim, width_offset);
     auto feature_width = feature_dim - width_offset;
     return std::min(feature_width, row_width);
+  }
+
+  int64_t get_payload_start_offset() const {
+    return metadata_dim_ > 0 ? metadata_dim_ : 0;
+  }
+
+  template <typename VALUE_T>
+  void copy_logical_row_slice(
+      const rocksdb::PinnableSlice& value,
+      int64_t logical_start,
+      VALUE_T* row_data_ptr,
+      int64_t width_offset,
+      int64_t row_width) {
+    auto value_width = static_cast<int64_t>(value.size() / sizeof(VALUE_T));
+    auto logical_end = logical_start + value_width;
+    auto request_end = width_offset + row_width;
+    auto overlap_start = std::max(width_offset, logical_start);
+    auto overlap_end = std::min(request_end, logical_end);
+    if (overlap_start >= overlap_end) {
+      return;
+    }
+    auto overlap_width = overlap_end - overlap_start;
+    auto value_offset = overlap_start - logical_start;
+    auto row_offset = overlap_start - width_offset;
+    std::memcpy(
+        row_data_ptr + row_offset,
+        reinterpret_cast<const VALUE_T*>(value.data()) + value_offset,
+        overlap_width * sizeof(VALUE_T));
+  }
+
+  template <typename VALUE_T>
+  void ssd_get_weights_with_metadata_multi_get(
+      const std::vector<rocksdb::Slice>& keys,
+      const std::vector<int32_t>& key_indices,
+      VALUE_T* weights_data_ptr,
+      int shard_id,
+      rocksdb::ReadOptions local_ro,
+      VALUE_T* row_storage_data_ptr,
+      int64_t width_offset,
+      int64_t row_width) {
+    FOLLY_DECLARE_REUSED(payload_values, std::vector<rocksdb::PinnableSlice>);
+    FOLLY_DECLARE_REUSED(payload_statuses, std::vector<rocksdb::Status>);
+    payload_values.resize(keys.size());
+    payload_statuses.resize(keys.size());
+    auto* dcf = dbs_[shard_id]->DefaultColumnFamily();
+    std::vector<rocksdb::ColumnFamilyHandle*> payload_cfs(keys.size(), dcf);
+    dbs_[shard_id]->MultiGet(
+        local_ro,
+        keys.size(),
+        payload_cfs.data(),
+        keys.data(),
+        payload_values.data(),
+        payload_statuses.data(),
+        /*sorted_input=*/true);
+
+    FOLLY_DECLARE_REUSED(metadata_values, std::vector<rocksdb::PinnableSlice>);
+    FOLLY_DECLARE_REUSED(metadata_statuses, std::vector<rocksdb::Status>);
+    bool has_metadata_cf =
+        metadata_dim_ > 0 && metadata_cf_handles_[shard_id] != nullptr;
+    if (has_metadata_cf) {
+      metadata_values.resize(keys.size());
+      metadata_statuses.resize(keys.size());
+      std::vector<rocksdb::ColumnFamilyHandle*> metadata_cfs(
+          keys.size(), metadata_cf_handles_[shard_id]);
+      dbs_[shard_id]->MultiGet(
+          local_ro,
+          keys.size(),
+          metadata_cfs.data(),
+          keys.data(),
+          metadata_values.data(),
+          metadata_statuses.data(),
+          /*sorted_input=*/true);
+    }
+
+    for (auto j = 0; j < keys.size(); ++j) {
+      auto row_index = key_indices[j];
+      auto* row_ptr = &(weights_data_ptr[row_index * row_width]);
+      std::memset(row_ptr, 0, row_width * sizeof(VALUE_T));
+
+      const auto& payload_status = payload_statuses[j];
+      if (payload_status.ok()) {
+        copy_logical_row_slice<VALUE_T>(
+            payload_values[j],
+            get_payload_start_offset(),
+            row_ptr,
+            width_offset,
+            row_width);
+      } else {
+        CHECK(payload_status.IsNotFound());
+        fill_from_row_storage(
+            shard_id,
+            reinterpret_cast<unsigned char*>(weights_data_ptr),
+            row_index,
+            reinterpret_cast<unsigned char*>(row_storage_data_ptr),
+            width_offset,
+            row_width,
+            row_width);
+        continue;
+      }
+
+      if (has_metadata_cf && metadata_statuses[j].ok()) {
+        copy_logical_row_slice<VALUE_T>(
+            metadata_values[j], 0, row_ptr, width_offset, row_width);
+      } else if (has_metadata_cf && payload_status.ok()) {
+        LOG_IF(
+            WARNING,
+            !metadata_statuses[j].ok() && !metadata_statuses[j].IsNotFound())
+            << "metadata status: " << metadata_statuses[j].ToString()
+            << " ; payload status: " << payload_status.ToString();
+      }
+    }
   }
 
   void fill_from_row_storage(

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h
@@ -126,7 +126,9 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
       std::optional<at::Tensor> hash_size_cumsum = std::nullopt,
       int64_t flushing_block_size = 2000000000 /*2GB*/,
       bool disable_random_init = false,
-      bool enable_blob_db = false)
+      bool enable_blob_db = false,
+      bool enable_metadata_cf = false,
+      int64_t metadata_dim = 0)
       : kv_db::EmbeddingKVDB(
             num_shards,
             max_D,
@@ -141,8 +143,9 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
             std::move(table_offsets),
             table_sizes,
             flushing_block_size),
-        auto_compaction_enabled_(true),
+        enable_metadata_cf_(enable_metadata_cf),
         max_D_(max_D),
+        metadata_dim_(metadata_dim),
         elem_size_(row_storage_bitwidth / 8) {
     class Int64Comparator : public rocksdb::Comparator {
      public:
@@ -277,6 +280,7 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
         std::max<int64_t>(num_threads / 4, 1), rocksdb::Env::LOW);
     options.max_open_files = -1;
 
+    cf_options_ = rocksdb::ColumnFamilyOptions(options);
     initialize_dbs(num_shards, path, options, use_passed_in_path);
     initialize_initializers(
         num_shards,
@@ -344,6 +348,10 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
     }
     snapshots_.clear();
     for (auto shard = 0; shard < dbs_.size(); ++shard) {
+      if (shard < metadata_cf_handles_.size() && metadata_cf_handles_[shard]) {
+        dbs_[shard]->DestroyColumnFamilyHandle(metadata_cf_handles_[shard]);
+        LOG(INFO) << "deleting metadata column family handle";
+      }
       dbs_[shard]->Close();
       kv_db_utils::remove_dir(db_paths_[shard]);
       LOG(INFO) << "deleting rocksdb shard path:" << db_paths_[shard];
@@ -417,6 +425,7 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
     db_paths_.reserve(num_shards);
     std::string all_shards_path;
 #endif
+    metadata_cf_handles_.resize(num_shards, nullptr);
     for (auto i = 0; i < num_shards; ++i) {
       path_ = paths_[i % paths_.size()];
 #ifdef FBGEMM_FBCODE
@@ -430,30 +439,45 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
       auto shard_path = path + std::string("/shard_") + std::to_string(i);
 #endif
       rocksdb::DB* db;
+      rocksdb::Status s;
 
-#ifdef FBGEMM_FBCODE
-      auto s = facebook::fb_rocksdb::openRocksDB(
-          options,
-          shard_path,
-          &db,
-          serviceInfo,
-          facebook::fb_rocksdb::getDefaultProfileOptions(),
-          db_monitor_options);
-#else
-      std::unique_ptr<rocksdb::DB> db_ptr;
-      auto s = rocksdb::DB::Open(options, shard_path, &db_ptr);
-      db = db_ptr.release();
-#endif
-      if (!s.ok() && s.code() == rocksdb::Status::kInvalidArgument &&
-          (options.use_direct_reads ||
-           options.use_direct_io_for_flush_and_compaction)) {
-        LOG(WARNING)
-            << "Warning, Requested DirectIO, but not supported on destination: "
-            << shard_path;
-        options.use_direct_reads = false;
-        options.use_direct_io_for_flush_and_compaction = false;
-        LOG(WARNING)
-            << "Trying again, any subsequent failures will be fatal...";
+      // The metadata column family is controlled solely by
+      // enable_metadata_cf_. When enabled, open the metadata CF (creating it if
+      // missing) alongside the default CF; otherwise open the default CF only.
+      if (enable_metadata_cf_) {
+        CHECK_GT(metadata_dim_, 0)
+            << "enable_metadata_cf_ is true but metadata_dim_ is not positive: " +
+                std::to_string(metadata_dim_);
+
+        std::vector<rocksdb::ColumnFamilyDescriptor> cf_descs;
+        cf_descs.emplace_back(
+            rocksdb::kDefaultColumnFamilyName,
+            rocksdb::ColumnFamilyOptions(options));
+        cf_descs.emplace_back(
+            "metadata", rocksdb::ColumnFamilyOptions(options));
+        std::vector<rocksdb::ColumnFamilyHandle*> cf_handles;
+        std::unique_ptr<rocksdb::DB> db_ptr;
+        rocksdb::DBOptions db_options(options);
+        db_options.create_missing_column_families = true;
+        s = rocksdb::DB::Open(
+            db_options, shard_path, cf_descs, &cf_handles, &db_ptr);
+        if (!s.ok() && s.code() == rocksdb::Status::kInvalidArgument &&
+            (options.use_direct_reads ||
+             options.use_direct_io_for_flush_and_compaction)) {
+          options.use_direct_reads = false;
+          options.use_direct_io_for_flush_and_compaction = false;
+          rocksdb::DBOptions retry_db_options(options);
+          retry_db_options.create_missing_column_families = true;
+          s = rocksdb::DB::Open(
+              retry_db_options, shard_path, cf_descs, &cf_handles, &db_ptr);
+        }
+        CHECK(s.ok()) << s.ToString();
+        db = db_ptr.release();
+        LOG(INFO) << "Opened RocksDB shard " << i << " at " << shard_path
+                  << " with metadata CF via unique_ptr, db=" << db;
+        db->DestroyColumnFamilyHandle(cf_handles[0]);
+        metadata_cf_handles_[i] = cf_handles[1];
+      } else {
 #ifdef FBGEMM_FBCODE
         s = facebook::fb_rocksdb::openRocksDB(
             options,
@@ -463,11 +487,35 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
             facebook::fb_rocksdb::getDefaultProfileOptions(),
             db_monitor_options);
 #else
+        std::unique_ptr<rocksdb::DB> db_ptr;
         s = rocksdb::DB::Open(options, shard_path, &db_ptr);
         db = db_ptr.release();
 #endif
+        if (!s.ok() && s.code() == rocksdb::Status::kInvalidArgument &&
+            (options.use_direct_reads ||
+             options.use_direct_io_for_flush_and_compaction)) {
+          LOG(WARNING)
+              << "Warning, Requested DirectIO, but not supported on destination: "
+              << shard_path;
+          options.use_direct_reads = false;
+          options.use_direct_io_for_flush_and_compaction = false;
+          LOG(WARNING)
+              << "Trying again, any subsequent failures will be fatal...";
+#ifdef FBGEMM_FBCODE
+          s = facebook::fb_rocksdb::openRocksDB(
+              options,
+              shard_path,
+              &db,
+              serviceInfo,
+              facebook::fb_rocksdb::getDefaultProfileOptions(),
+              db_monitor_options);
+#else
+          s = rocksdb::DB::Open(options, shard_path, &db_ptr);
+          db = db_ptr.release();
+#endif
+        }
+        CHECK(s.ok()) << s.ToString();
       }
-      CHECK(s.ok()) << s.ToString();
       dbs_.emplace_back(db);
     }
 #ifdef FBGEMM_FBCODE
@@ -476,28 +524,13 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
 #endif
   }
 
-  /// Create the metadata column family on shards that don't have it yet.
-  /// Called by DRAM_SSD composite backend only — pure SSD tables don't need
-  /// CF2.
-  void ensure_metadata_cf() {
-    for (size_t i = 0; i < dbs_.size(); ++i) {
-      if (metadata_cf_handles_[i] == nullptr) {
-        rocksdb::ColumnFamilyHandle* md_handle = nullptr;
-        auto s =
-            dbs_[i]->CreateColumnFamily(cf_options_, "metadata", &md_handle);
-        CHECK(s.ok()) << "Failed to create metadata CF: " << s.ToString();
-        metadata_cf_handles_[i] = md_handle;
-      }
-    }
-  }
-
-  void set_metadata_dim(int64_t dim) {
-    metadata_dim_ = dim;
-    LOG(INFO) << "EmbeddingRocksDB::set_metadata_dim=" << metadata_dim_;
-  }
-
   int64_t get_metadata_dim() const {
     return metadata_dim_;
+  }
+
+  bool is_metadata_cf_initialized(int64_t shard) const {
+    return shard >= 0 && shard < std::ssize(metadata_cf_handles_) &&
+        metadata_cf_handles_[shard] != nullptr;
   }
 
   void initialize_initializers(
@@ -558,11 +591,10 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
     auto count_ = count.scalar_type() == at::ScalarType::Long
         ? *(count.data_ptr<int64_t>())
         : *(count.data_ptr<int32_t>());
-    if (count_ <= 0 || metadata_dim_ <= 0) {
+    if (!enable_metadata_cf_ || count_ <= 0 || metadata_dim_ <= 0) {
       return folly::makeSemiFuture(std::vector<folly::Unit>());
     }
 
-    ensure_metadata_cf();
     CHECK(indices.is_contiguous());
     CHECK(metadata.is_contiguous());
     CHECK_EQ(indices.size(0), metadata.size(0));
@@ -651,7 +683,7 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
       const at::Tensor& indices,
       const at::Tensor& metadata,
       const at::Tensor& count) override {
-    if (metadata_dim_ <= 0) {
+    if (!enable_metadata_cf_ || metadata_dim_ <= 0) {
       return folly::makeSemiFuture(std::vector<folly::Unit>());
     }
     return get_kv_db_single_cf_async(
@@ -798,12 +830,21 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
                             CHECK(weights.is_contiguous());
                             auto indices_acc = indices.accessor<index_t, 1>();
                             auto D = weights.size(1);
+                            auto payload_D = D;
+                            auto payload_offset = 0;
+                            if (enable_metadata_cf_) {
+                              CHECK_GE(D, metadata_dim_);
+                              payload_offset = metadata_dim_;
+                              payload_D = D - metadata_dim_;
+                            }
+                            CHECK_EQ(payload_D + payload_offset, D);
                             CHECK_EQ(indices.size(0), weights.size(0));
                             {
                               rocksdb::WriteBatch batch(
                                   (2 * (count_ + dbs_.size() - 1) /
                                    dbs_.size()) *
                                   (sizeof(index_t) + sizeof(value_t) * D));
+                              int64_t shard_rows_written = 0;
                               for (auto i = 0; i < count_; ++i) {
                                 if (indices_acc[i] < 0) {
                                   continue;
@@ -812,21 +853,49 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
                                         indices_acc[i], dbs_.size()) != shard) {
                                   continue;
                                 }
-                                batch.Put(
-                                    rocksdb::Slice(
-                                        reinterpret_cast<const char*>(
-                                            &(indices.data_ptr<index_t>()[i])),
-                                        sizeof(index_t)),
-                                    rocksdb::Slice(
-                                        reinterpret_cast<const char*>(
-                                            &(weights
+                                ++shard_rows_written;
+                                if (!enable_metadata_cf_) {
+                                  batch.Put(
+                                      rocksdb::Slice(
+                                          reinterpret_cast<const char*>(&(
+                                              indices.data_ptr<index_t>()[i])),
+                                          sizeof(index_t)),
+                                      rocksdb::Slice(
+                                          reinterpret_cast<const char*>(&(
+                                              weights
                                                   .data_ptr<value_t>()[i * D])),
-                                        D * sizeof(value_t)));
+                                          D * sizeof(value_t)));
+                                } else {
+                                  batch.Put(
+                                      rocksdb::Slice(
+                                          reinterpret_cast<const char*>(&(
+                                              indices.data_ptr<index_t>()[i])),
+                                          sizeof(index_t)),
+                                      rocksdb::Slice(
+                                          reinterpret_cast<const char*>(
+                                              &(weights.data_ptr<value_t>()
+                                                    [i * D + payload_offset])),
+                                          payload_D * sizeof(value_t)));
+                                  batch.Put(
+                                      metadata_cf_handles_[shard],
+                                      rocksdb::Slice(
+                                          reinterpret_cast<const char*>(&(
+                                              indices.data_ptr<index_t>()[i])),
+                                          sizeof(index_t)),
+                                      rocksdb::Slice(
+                                          reinterpret_cast<const char*>(&(
+                                              weights
+                                                  .data_ptr<value_t>()[i * D])),
+                                          payload_offset * sizeof(value_t)));
+                                }
                               }
                               auto s = dbs_[shard]->Write(wo_, &batch);
                               CHECK(s.ok())
                                   << "Failed to write batch to db, error: "
                                   << s.ToString();
+                              total_rows_written_.fetch_add(
+                                  shard_rows_written,
+                                  std::memory_order_relaxed);
                             }
                           });
                     });
@@ -1053,8 +1122,89 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
       const at::Tensor& indices,
       const at::Tensor& count,
       const SnapshotHandle* snapshot_handle) {
-    // no op for ssd embedding now, default value is 0
-    return at::zeros_like(indices, at::kLong);
+    if (!enable_metadata_cf_) {
+      // no op for the case when metadata cf is not enable, i.e. non DRAM_SSD
+      // ZCH
+      return at::zeros_like(indices, at::kLong);
+    }
+    auto count_ = count.scalar_type() == at::ScalarType::Long
+        ? *(count.data_ptr<int64_t>())
+        : *(count.data_ptr<int32_t>());
+    auto numel = indices.size(0);
+    auto metadata = at::zeros({numel}, at::kLong);
+    if (count_ <= 0 || metadata_dim_ <= 0) {
+      LOG(INFO) << "get_kv_zch_eviction_metadata_by_snapshot: early return,"
+                << " count=" << count_ << ", metadata_dim_=" << metadata_dim_
+                << ", max_D_=" << max_D_;
+      return metadata;
+    }
+    auto* idx_ptr = indices.data_ptr<int64_t>();
+    auto* md_ptr = metadata.mutable_data_ptr<int64_t>();
+
+    std::vector<folly::Future<folly::Unit>> futures;
+    for (auto shard = 0; shard < dbs_.size(); ++shard) {
+      snapshot_ptr_t snapshot = snapshot_handle == nullptr
+          ? nullptr
+          : snapshot_handle->get_snapshot_for_shard(shard);
+      auto local_ro = ro_;
+      local_ro.snapshot = snapshot;
+      auto f = folly::via(executor_.get()).thenValue([=, this](folly::Unit) {
+        std::vector<rocksdb::Slice> keys;
+        std::vector<int32_t> key_pos;
+        for (int64_t i = 0; i < count_; ++i) {
+          if (idx_ptr[i] < 0) {
+            continue;
+          }
+          if (kv_db_utils::hash_shard(idx_ptr[i], dbs_.size()) != shard) {
+            continue;
+          }
+          key_pos.push_back(i);
+        }
+        if (key_pos.empty()) {
+          return;
+        }
+        std::ranges::sort(key_pos, [&](int32_t lhs, int32_t rhs) {
+          return idx_ptr[lhs] < idx_ptr[rhs];
+        });
+        keys.reserve(key_pos.size());
+        for (const auto& i : key_pos) {
+          keys.emplace_back(
+              reinterpret_cast<const char*>(&idx_ptr[i]), sizeof(int64_t));
+        }
+        std::vector<rocksdb::ColumnFamilyHandle*> cfs(
+            keys.size(), metadata_cf_handles_[shard]);
+        std::vector<rocksdb::PinnableSlice> values(keys.size());
+        std::vector<rocksdb::Status> statuses(keys.size());
+        dbs_[shard]->MultiGet(
+            local_ro,
+            keys.size(),
+            cfs.data(),
+            keys.data(),
+            values.data(),
+            statuses.data(),
+            /*sorted_input=*/true);
+        int64_t metadata_read_found = 0;
+        int64_t metadata_read_missing = 0;
+        for (size_t j = 0; j < keys.size(); ++j) {
+          if (statuses[j].ok() && values[j].size() >= 16) {
+            memcpy(
+                &md_ptr[key_pos[j]],
+                values[j].data() + sizeof(int64_t),
+                sizeof(int64_t));
+            ++metadata_read_found;
+          } else {
+            ++metadata_read_missing;
+          }
+        }
+        LOG(INFO) << "Metadata CF read: shard=" << shard
+                  << ", keys_queried=" << keys.size()
+                  << ", found=" << metadata_read_found
+                  << ", missing=" << metadata_read_missing;
+      });
+      futures.emplace_back(std::move(f));
+    }
+    folly::collect(futures).wait();
+    return metadata;
   }
 
   void get_range_from_snapshot(
@@ -1081,6 +1231,10 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
   void set_kv_to_storage(const at::Tensor& ids, const at::Tensor& weights) {
     const auto count = at::tensor({ids.size(0)}, at::ScalarType::Long);
     set_kv_db_async(ids, weights, count).wait();
+  }
+
+  int64_t get_metaheader_width_in_front() override {
+    return metadata_dim_;
   }
 
   void get_kv_from_storage_by_snapshot(
@@ -1344,6 +1498,13 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
       VALUE_T* row_storage_data_ptr,
       int64_t width_offset,
       int64_t row_width) {
+    CHECK(metadata_cf_handles_[shard_id] != nullptr)
+        << "Metadata CF handle is null for shard: " + std::to_string(shard_id);
+
+    if (metadata_dim_ <= 0) {
+      return;
+    }
+
     FOLLY_DECLARE_REUSED(payload_values, std::vector<rocksdb::PinnableSlice>);
     FOLLY_DECLARE_REUSED(payload_statuses, std::vector<rocksdb::Status>);
     payload_values.resize(keys.size());
@@ -1361,22 +1522,19 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
 
     FOLLY_DECLARE_REUSED(metadata_values, std::vector<rocksdb::PinnableSlice>);
     FOLLY_DECLARE_REUSED(metadata_statuses, std::vector<rocksdb::Status>);
-    bool has_metadata_cf =
-        metadata_dim_ > 0 && metadata_cf_handles_[shard_id] != nullptr;
-    if (has_metadata_cf) {
-      metadata_values.resize(keys.size());
-      metadata_statuses.resize(keys.size());
-      std::vector<rocksdb::ColumnFamilyHandle*> metadata_cfs(
-          keys.size(), metadata_cf_handles_[shard_id]);
-      dbs_[shard_id]->MultiGet(
-          local_ro,
-          keys.size(),
-          metadata_cfs.data(),
-          keys.data(),
-          metadata_values.data(),
-          metadata_statuses.data(),
-          /*sorted_input=*/true);
-    }
+
+    metadata_values.resize(keys.size());
+    metadata_statuses.resize(keys.size());
+    std::vector<rocksdb::ColumnFamilyHandle*> metadata_cfs(
+        keys.size(), metadata_cf_handles_[shard_id]);
+    dbs_[shard_id]->MultiGet(
+        local_ro,
+        keys.size(),
+        metadata_cfs.data(),
+        keys.data(),
+        metadata_values.data(),
+        metadata_statuses.data(),
+        /*sorted_input=*/true);
 
     for (auto j = 0; j < keys.size(); ++j) {
       auto row_index = key_indices[j];
@@ -1404,10 +1562,10 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
         continue;
       }
 
-      if (has_metadata_cf && metadata_statuses[j].ok()) {
+      if (metadata_statuses[j].ok()) {
         copy_logical_row_slice<VALUE_T>(
             metadata_values[j], 0, row_ptr, width_offset, row_width);
-      } else if (has_metadata_cf && payload_status.ok()) {
+      } else if (payload_status.ok()) {
         LOG_IF(
             WARNING,
             !metadata_statuses[j].ok() && !metadata_statuses[j].IsNotFound())
@@ -1604,7 +1762,11 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
 
     auto D = weights.size(1);
     auto copy_width = width_length.value_or(D);
-    CHECK_LE(D, max_D_);
+    if (!enable_metadata_cf_) {
+      CHECK_LE(D, max_D_);
+    } else {
+      CHECK_LE(D, max_D_ + metadata_dim_);
+    }
     CHECK_EQ(copy_width, D);
 
     for (auto shard = 0; shard < dbs_.size(); ++shard) {
@@ -1690,7 +1852,17 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
                               row_storage_data_ptr =
                                   init_storage.data_ptr<value_t>();
                             }
-                            if (use_iterator) {
+                            if (enable_metadata_cf_) {
+                              ssd_get_weights_with_metadata_multi_get(
+                                  keys,
+                                  key_indices,
+                                  weights_data_ptr,
+                                  shard,
+                                  local_ro,
+                                  row_storage_data_ptr,
+                                  width_offset,
+                                  D);
+                            } else if (use_iterator) {
                               ssd_get_weights_iterator(
                                   keys,
                                   key_indices,
@@ -1742,7 +1914,8 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
   int64_t memtable_flush_period_;
   int64_t compaction_period_;
   int64_t l0_files_per_compact_;
-  bool auto_compaction_enabled_;
+  bool auto_compaction_enabled_{true};
+  bool enable_metadata_cf_{false};
 
   // break down on rocksdb write duration for details checkout
   // RocksdbWriteMode
@@ -1756,7 +1929,7 @@ class EmbeddingRocksDB : public kv_db::EmbeddingKVDB {
   std::unordered_map<const SnapshotHandle*, std::unique_ptr<SnapshotHandle>>
       snapshots_;
   int64_t max_D_;
-  int64_t metadata_dim_;
+  int64_t metadata_dim_{0};
   int64_t elem_size_;
   std::vector<int64_t> sub_table_dims_;
   std::vector<int64_t> sub_table_hash_cumsum_;

--- a/fbgemm_gpu/src/ssd_split_embeddings_cache/test/ssd_table_batched_embeddings_test.cpp
+++ b/fbgemm_gpu/src/ssd_split_embeddings_cache/test/ssd_table_batched_embeddings_test.cpp
@@ -8,6 +8,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <cstring>
 #include <filesystem>
 #include "deeplearning/fbgemm/fbgemm_gpu/src/ssd_split_embeddings_cache/ssd_table_batched_embeddings.h"
 
@@ -42,7 +43,9 @@ class MockEmbeddingRocksDB : public ssd::EmbeddingRocksDB {
       int64_t res_server_port = 0,
       std::vector<std::string> table_names = {},
       std::vector<int64_t> table_offsets = {},
-      const std::vector<int64_t>& table_sizes = {})
+      const std::vector<int64_t>& table_sizes = {},
+      bool enable_metadata_cf = false,
+      int64_t metadata_dim = 0)
       : ssd::EmbeddingRocksDB(
             path,
             num_shards,
@@ -69,7 +72,14 @@ class MockEmbeddingRocksDB : public ssd::EmbeddingRocksDB {
             res_server_port,
             std::move(table_names),
             std::move(table_offsets),
-            table_sizes) {}
+            table_sizes,
+            /*table_dims=*/std::nullopt,
+            /*hash_size_cumsum=*/std::nullopt,
+            /*flushing_block_size=*/2000000000,
+            /*disable_random_init=*/false,
+            /*enable_blob_db=*/false,
+            /*enable_metadata_cf=*/enable_metadata_cf,
+            /*metadata_dim=*/metadata_dim) {}
   MOCK_METHOD(
       rocksdb::Status,
       set_rocksdb_option,
@@ -83,7 +93,9 @@ std::unique_ptr<MockEmbeddingRocksDB> getMockEmbeddingRocksDB(
     bool enable_raw_embedding_streaming = false,
     const std::vector<std::string>& table_names = {},
     const std::vector<int64_t>& table_offsets = {},
-    const std::vector<int64_t>& table_sizes = {}) {
+    const std::vector<int64_t>& table_sizes = {},
+    bool enable_metadata_cf = false,
+    int64_t metadata_dim = 0) {
   std::filesystem::path temp_dir = std::filesystem::temp_directory_path();
   std::filesystem::path rocksdb_dir = temp_dir / dir;
   std::filesystem::create_directories(rocksdb_dir);
@@ -114,8 +126,54 @@ std::unique_ptr<MockEmbeddingRocksDB> getMockEmbeddingRocksDB(
       0, // res_server_port
       table_names, // table_names
       table_offsets, // table_offsets
-      table_sizes); // table_sizes);
+      table_sizes, // table_sizes
+      enable_metadata_cf, // enable_metadata_cf
+      metadata_dim); // metadata_dim
 }
+
+namespace {
+constexpr int64_t kMetadataDimFp32 = 4;
+
+// Local mirror of the production MetaHeader layout (see fixed_block_pool.h),
+// kept simple for the test. 16 bytes:
+// [int64 key][uint32 timestamp][uint32 count:31][bool used:1].
+// The feature score is stored in the `count` field as its raw float bits.
+struct alignas(8) MetaHeader {
+  int64_t key;
+  uint32_t timestamp;
+  uint32_t count : 31;
+  bool used : 1;
+};
+static_assert(sizeof(MetaHeader) == kMetadataDimFp32 * sizeof(float));
+
+void create_metaheader_row(
+    float* row,
+    int64_t row_dim,
+    int64_t key,
+    uint32_t timestamp,
+    float feature_score) {
+  std::memset(row, 0, row_dim * sizeof(float));
+  uint32_t score_bits = 0;
+  std::memcpy(&score_bits, &feature_score, sizeof(score_bits));
+
+  MetaHeader header{};
+  header.key = key;
+  header.timestamp = timestamp;
+  header.count = score_bits & 0x7FFFFFFF; // clear sign bit, keep 31 bits
+  header.used = true;
+  std::memcpy(row, &header, sizeof(header));
+}
+
+float decode_feature_score(int64_t raw_metadata) {
+  uint32_t count_used =
+      static_cast<uint32_t>(static_cast<uint64_t>(raw_metadata) >> 32);
+  uint32_t score_bits = count_used & 0x7FFFFFFF;
+  float score = 0.0f;
+  std::memcpy(&score, &score_bits, sizeof(score));
+  return score;
+}
+} // namespace
+
 TEST(SSDTableBatchedEmbeddingsTest, TestToggleCompactionSuccess) {
   int num_shards = 8;
   auto mock_embedding_rocks = getMockEmbeddingRocksDB(num_shards, "success");
@@ -165,4 +223,421 @@ TEST(SSDTableBatchedEmbeddingsTest, TestToggleCompactionFailOnThronw) {
   EXPECT_DEATH(
       { mock_embedding_rocks->toggle_compaction(true); },
       "Failed to toggle compaction to 1 with exception std::runtime_error: some error message");
+}
+
+TEST(SSDTableBatchedEmbeddingsTest, TestMetadataCfInitialization) {
+  constexpr int64_t kNumShards = 2;
+
+  // Case 1: Metadata CF is correctly initialized.
+  auto mock_embedding_rocks = getMockEmbeddingRocksDB(
+      /*num_shards=*/kNumShards,
+      "metadataCfInit",
+      /*enable_raw_embedding_streaming=*/false,
+      /*table_names=*/{},
+      /*table_offsets=*/{},
+      /*table_sizes=*/{},
+      /*enable_metadata_cf=*/true,
+      /*metadata_dim=*/kMetadataDimFp32);
+
+  for (int64_t shard = 0; shard < kNumShards; ++shard) {
+    EXPECT_TRUE(mock_embedding_rocks->is_metadata_cf_initialized(shard));
+  }
+  EXPECT_EQ(mock_embedding_rocks->get_metadata_dim(), kMetadataDimFp32);
+
+  // Case 2: Metadata CF is not initialized when enable_metadata_cf = false or
+  // by default.
+  mock_embedding_rocks = getMockEmbeddingRocksDB(
+      /*num_shards=*/kNumShards,
+      "metadataCfInit",
+      /*enable_raw_embedding_streaming=*/false,
+      /*table_names=*/{},
+      /*table_offsets=*/{},
+      /*table_sizes=*/{},
+      /*enable_metadata_cf=*/false,
+      /*metadata_dim=*/kMetadataDimFp32);
+
+  for (int64_t shard = 0; shard < kNumShards; ++shard) {
+    EXPECT_FALSE(mock_embedding_rocks->is_metadata_cf_initialized(shard));
+  }
+  // get_metadata_dim reflects constructor param even when CF disabled
+  EXPECT_EQ(mock_embedding_rocks->get_metadata_dim(), kMetadataDimFp32);
+
+  mock_embedding_rocks = getMockEmbeddingRocksDB(
+      /*num_shards=*/kNumShards, "metadataCfInit");
+
+  for (int64_t shard = 0; shard < kNumShards; ++shard) {
+    EXPECT_FALSE(mock_embedding_rocks->is_metadata_cf_initialized(shard));
+  }
+  EXPECT_EQ(mock_embedding_rocks->get_metadata_dim(), 0);
+
+  // Case 3: Metadata CF is not correctly initialized when metadata dim = 0.
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+  EXPECT_DEATH(
+      {
+        getMockEmbeddingRocksDB(
+            /*num_shards=*/1,
+            "metadataCfZeroDim",
+            /*enable_raw_embedding_streaming=*/false,
+            /*table_names=*/{},
+            /*table_offsets=*/{},
+            /*table_sizes=*/{},
+            /*enable_metadata_cf=*/true,
+            /*metadata_dim=*/0);
+      },
+      "enable_metadata_cf_ is true but metadata_dim_ is not positive");
+}
+
+TEST(SSDTableBatchedEmbeddingsTest, TestGetKvZchEvictionMetadataBySnapshot) {
+  auto mock_embedding_rocks = getMockEmbeddingRocksDB(
+      /*num_shards=*/1,
+      "metadataCfWrite",
+      /*enable_raw_embedding_streaming=*/false,
+      /*table_names=*/{},
+      /*table_offsets=*/{},
+      /*table_sizes=*/{},
+      /*enable_metadata_cf=*/true,
+      /*metadata_dim=*/kMetadataDimFp32);
+
+  auto indices = at::tensor({11L, 22L}, at::TensorOptions().dtype(at::kLong));
+  auto metadata =
+      at::zeros({2, kMetadataDimFp32}, at::TensorOptions().dtype(at::kFloat));
+  create_metaheader_row(
+      metadata.data_ptr<float>() + 0 * kMetadataDimFp32,
+      kMetadataDimFp32,
+      11,
+      7,
+      1.75f);
+  create_metaheader_row(
+      metadata.data_ptr<float>() + 1 * kMetadataDimFp32,
+      kMetadataDimFp32,
+      22,
+      13,
+      3.0f);
+  auto count = at::tensor({2L}, at::TensorOptions().dtype(at::kLong));
+
+  mock_embedding_rocks->set_kv_metadata_async(indices, metadata, count).wait();
+
+  auto metadata_out =
+      mock_embedding_rocks->get_kv_zch_eviction_metadata_by_snapshot(
+          indices, count, /*snapshot_handle=*/nullptr);
+  ASSERT_EQ(metadata_out.numel(), 2);
+
+  auto* raw_ptr = metadata_out.data_ptr<int64_t>();
+  EXPECT_EQ(static_cast<uint32_t>(raw_ptr[0] & 0xFFFFFFFFu), 7u);
+  EXPECT_EQ(static_cast<uint32_t>(raw_ptr[1] & 0xFFFFFFFFu), 13u);
+  EXPECT_FLOAT_EQ(decode_feature_score(raw_ptr[0]), 1.75f);
+  EXPECT_FLOAT_EQ(decode_feature_score(raw_ptr[1]), 3.0f);
+
+  uint32_t count_used_0 =
+      static_cast<uint32_t>(static_cast<uint64_t>(raw_ptr[0]) >> 32);
+  uint32_t count_used_1 =
+      static_cast<uint32_t>(static_cast<uint64_t>(raw_ptr[1]) >> 32);
+  EXPECT_TRUE((count_used_0 & 0x80000000u) != 0);
+  EXPECT_TRUE((count_used_1 & 0x80000000u) != 0);
+}
+
+TEST(
+    SSDTableBatchedEmbeddingsTest,
+    TestGetKvDbMetadataOnlyReadsMetadataColumnFamily) {
+  auto mock_embedding_rocks = getMockEmbeddingRocksDB(
+      /*num_shards=*/1,
+      "metadataCfReadOnly",
+      /*enable_raw_embedding_streaming=*/false,
+      /*table_names=*/{},
+      /*table_offsets=*/{},
+      /*table_sizes=*/{},
+      /*enable_metadata_cf=*/true,
+      /*metadata_dim=*/kMetadataDimFp32);
+
+  auto indices = at::tensor({11L, 22L}, at::TensorOptions().dtype(at::kLong));
+  auto metadata =
+      at::zeros({2, kMetadataDimFp32}, at::TensorOptions().dtype(at::kFloat));
+  create_metaheader_row(
+      metadata.data_ptr<float>() + 0 * kMetadataDimFp32,
+      kMetadataDimFp32,
+      11,
+      7,
+      1.75f);
+  create_metaheader_row(
+      metadata.data_ptr<float>() + 1 * kMetadataDimFp32,
+      kMetadataDimFp32,
+      22,
+      13,
+      3.0f);
+  auto count = at::tensor({2L}, at::TensorOptions().dtype(at::kLong));
+
+  mock_embedding_rocks->set_kv_metadata_async(indices, metadata, count).wait();
+
+  // Read back only the metadata rows (shape {N, metadata_dim}, same dtype as
+  // the provided out-tensor) and verify they round-trip byte-for-byte.
+  auto metadata_only =
+      at::zeros({2, kMetadataDimFp32}, at::TensorOptions().dtype(at::kFloat));
+  mock_embedding_rocks
+      ->get_kv_db_metadata_only_async(indices, metadata_only, count)
+      .wait();
+
+  EXPECT_TRUE(at::equal(metadata_only, metadata));
+}
+
+TEST(
+    SSDTableBatchedEmbeddingsTest,
+    TestSetKvDbReconstructsWholeRowFromSplitMetadataStorage) {
+  auto mock_embedding_rocks = getMockEmbeddingRocksDB(
+      /*num_shards=*/1,
+      "splitMetadataWholeRow",
+      /*enable_raw_embedding_streaming=*/false,
+      /*table_names=*/{},
+      /*table_offsets=*/{},
+      /*table_sizes=*/{},
+      /*enable_metadata_cf=*/true,
+      /*metadata_dim=*/kMetadataDimFp32);
+
+  auto indices = at::tensor({33L, 44L}, at::TensorOptions().dtype(at::kLong));
+  auto rows = at::zeros(
+      {2, kMetadataDimFp32 + EMBEDDING_DIMENSION},
+      at::TensorOptions().dtype(at::kFloat));
+  auto* rows_ptr = rows.data_ptr<float>();
+  create_metaheader_row(
+      rows_ptr + 0 * (kMetadataDimFp32 + EMBEDDING_DIMENSION),
+      kMetadataDimFp32 + EMBEDDING_DIMENSION,
+      33,
+      19,
+      2.5f);
+  create_metaheader_row(
+      rows_ptr + 1 * (kMetadataDimFp32 + EMBEDDING_DIMENSION),
+      kMetadataDimFp32 + EMBEDDING_DIMENSION,
+      44,
+      23,
+      4.5f);
+  for (int64_t i = 0; i < EMBEDDING_DIMENSION; ++i) {
+    rows_ptr[kMetadataDimFp32 + i] = static_cast<float>(100 + i);
+    rows_ptr[(kMetadataDimFp32 + EMBEDDING_DIMENSION) + kMetadataDimFp32 + i] =
+        static_cast<float>(200 + i);
+  }
+  auto count = at::tensor({2L}, at::TensorOptions().dtype(at::kLong));
+
+  mock_embedding_rocks->set_kv_db_async(indices, rows, count).wait();
+
+  auto full_rows = at::zeros(
+      {2, kMetadataDimFp32 + EMBEDDING_DIMENSION},
+      at::TensorOptions().dtype(at::kFloat));
+  mock_embedding_rocks->get_kv_from_storage_by_snapshot(
+      indices, full_rows, /*snapshot_handle=*/nullptr);
+
+  EXPECT_EQ(
+      std::memcmp(
+          full_rows.data_ptr<float>(),
+          rows.data_ptr<float>(),
+          rows.numel() * sizeof(float)),
+      0);
+
+  auto payload = at::zeros(
+      {2, EMBEDDING_DIMENSION}, at::TensorOptions().dtype(at::kFloat));
+  mock_embedding_rocks->get_kv_from_storage_by_snapshot(
+      indices,
+      payload,
+      /*snapshot_handle=*/nullptr,
+      /*width_offset=*/kMetadataDimFp32,
+      /*width_length=*/EMBEDDING_DIMENSION);
+
+  auto* payload_ptr = payload.data_ptr<float>();
+  for (int64_t i = 0; i < EMBEDDING_DIMENSION; ++i) {
+    EXPECT_FLOAT_EQ(payload_ptr[i], static_cast<float>(100 + i));
+    EXPECT_FLOAT_EQ(
+        payload_ptr[EMBEDDING_DIMENSION + i], static_cast<float>(200 + i));
+  }
+
+  auto metadata_out =
+      mock_embedding_rocks->get_kv_zch_eviction_metadata_by_snapshot(
+          indices, count, /*snapshot_handle=*/nullptr);
+  auto* raw_ptr = metadata_out.data_ptr<int64_t>();
+  EXPECT_EQ(static_cast<uint32_t>(raw_ptr[0] & 0xFFFFFFFFu), 19u);
+  EXPECT_EQ(static_cast<uint32_t>(raw_ptr[1] & 0xFFFFFFFFu), 23u);
+  EXPECT_FLOAT_EQ(decode_feature_score(raw_ptr[0]), 2.5f);
+  EXPECT_FLOAT_EQ(decode_feature_score(raw_ptr[1]), 4.5f);
+}
+
+TEST(SSDTableBatchedEmbeddingsTest, TestGetKvDbWeightsOnlyReadsPayload) {
+  auto mock_embedding_rocks = getMockEmbeddingRocksDB(
+      /*num_shards=*/1,
+      "weightsOnlyRead",
+      /*enable_raw_embedding_streaming=*/false,
+      /*table_names=*/{},
+      /*table_offsets=*/{},
+      /*table_sizes=*/{},
+      /*enable_metadata_cf=*/true,
+      /*metadata_dim=*/kMetadataDimFp32);
+
+  auto indices = at::tensor({33L, 44L}, at::TensorOptions().dtype(at::kLong));
+  auto rows = at::zeros(
+      {2, kMetadataDimFp32 + EMBEDDING_DIMENSION},
+      at::TensorOptions().dtype(at::kFloat));
+  auto* rows_ptr = rows.data_ptr<float>();
+  create_metaheader_row(
+      rows_ptr + 0 * (kMetadataDimFp32 + EMBEDDING_DIMENSION),
+      kMetadataDimFp32 + EMBEDDING_DIMENSION,
+      33,
+      19,
+      2.5f);
+  create_metaheader_row(
+      rows_ptr + 1 * (kMetadataDimFp32 + EMBEDDING_DIMENSION),
+      kMetadataDimFp32 + EMBEDDING_DIMENSION,
+      44,
+      23,
+      4.5f);
+  for (int64_t i = 0; i < EMBEDDING_DIMENSION; ++i) {
+    rows_ptr[kMetadataDimFp32 + i] = static_cast<float>(100 + i);
+    rows_ptr[(kMetadataDimFp32 + EMBEDDING_DIMENSION) + kMetadataDimFp32 + i] =
+        static_cast<float>(200 + i);
+  }
+  auto count = at::tensor({2L}, at::TensorOptions().dtype(at::kLong));
+
+  mock_embedding_rocks->set_kv_db_async(indices, rows, count).wait();
+
+  // Read back only the embedding payload; the metaheader prefix is skipped.
+  // Output shape is {N, stride} with stride = weights.size(1).
+  auto weights_only = at::zeros(
+      {2, EMBEDDING_DIMENSION}, at::TensorOptions().dtype(at::kFloat));
+  mock_embedding_rocks
+      ->get_kv_db_weights_only_async(indices, weights_only, count)
+      .wait();
+
+  auto* payload_ptr = weights_only.data_ptr<float>();
+  for (int64_t i = 0; i < EMBEDDING_DIMENSION; ++i) {
+    EXPECT_FLOAT_EQ(payload_ptr[i], static_cast<float>(100 + i));
+    EXPECT_FLOAT_EQ(
+        payload_ptr[EMBEDDING_DIMENSION + i], static_cast<float>(200 + i));
+  }
+}
+
+TEST(SSDTableBatchedEmbeddingsTest, TestSetKvDbAsyncWithoutMetadataCf) {
+  // Verify set_kv_db_async payload-only path when metadata CF is disabled.
+  // This complements TestSetKvDbReconstructsWholeRowFromSplitMetadataStorage
+  // which covers the enable_metadata_cf=true split path.
+  auto mock_embedding_rocks = getMockEmbeddingRocksDB(
+      /*num_shards=*/1, "setKvNoMetadata");
+
+  EXPECT_EQ(mock_embedding_rocks->get_metadata_dim(), 0);
+  EXPECT_FALSE(mock_embedding_rocks->is_metadata_cf_initialized(0));
+
+  auto indices = at::tensor({11L, 22L}, at::TensorOptions().dtype(at::kLong));
+  auto rows = at::zeros(
+      {2, EMBEDDING_DIMENSION}, at::TensorOptions().dtype(at::kFloat));
+  auto* rows_ptr = rows.data_ptr<float>();
+  for (int64_t i = 0; i < EMBEDDING_DIMENSION; ++i) {
+    rows_ptr[i] = static_cast<float>(10 + i);
+    rows_ptr[EMBEDDING_DIMENSION + i] = static_cast<float>(20 + i);
+  }
+  auto count = at::tensor({2L}, at::TensorOptions().dtype(at::kLong));
+
+  // Write via default CF only path
+  mock_embedding_rocks->set_kv_db_async(indices, rows, count).wait();
+
+  // Read back full rows via standard get path (no metadata CF involved)
+  auto out = at::zeros(
+      {2, EMBEDDING_DIMENSION}, at::TensorOptions().dtype(at::kFloat));
+  mock_embedding_rocks->get_kv_from_storage_by_snapshot(
+      indices, out, /*snapshot_handle=*/nullptr);
+
+  EXPECT_TRUE(at::equal(out, rows));
+
+  // Weights-only async should also work and match same payload when CF disabled
+  auto weights_only = at::zeros(
+      {2, EMBEDDING_DIMENSION}, at::TensorOptions().dtype(at::kFloat));
+  mock_embedding_rocks
+      ->get_kv_db_weights_only_async(indices, weights_only, count)
+      .wait();
+  EXPECT_TRUE(at::equal(weights_only, rows));
+
+  // Metadata-only async should no-op and return empty or unchanged when
+  // disabled
+  auto metadata_out =
+      at::zeros({2, kMetadataDimFp32}, at::TensorOptions().dtype(at::kFloat));
+  mock_embedding_rocks
+      ->get_kv_db_metadata_only_async(indices, metadata_out, count)
+      .wait();
+  // Expect zeros since CF disabled path returns early without modifying output
+  // or at least not equal to non-zero pattern; we just verify no crash and
+  // metadata dim is 0 on DB side.
+  EXPECT_EQ(mock_embedding_rocks->get_metadata_dim(), 0);
+}
+
+TEST(
+    SSDTableBatchedEmbeddingsTest,
+    TestGetKvDbAsyncImplWithAndWithoutMetadataCf) {
+  // Test get_kv_db_async_impl via public get_kv_db_async wrapper for both
+  // paths. Path 1: without metadata CF – exercises ssd_get_weights_multi_get
+  // branch.
+  {
+    auto mock = getMockEmbeddingRocksDB(
+        /*num_shards=*/1, "getKvAsyncNoMeta");
+    auto indices = at::tensor({5L, 6L}, at::TensorOptions().dtype(at::kLong));
+    auto rows = at::zeros(
+        {2, EMBEDDING_DIMENSION}, at::TensorOptions().dtype(at::kFloat));
+    auto* p = rows.data_ptr<float>();
+    for (int i = 0; i < EMBEDDING_DIMENSION; ++i) {
+      p[i] = 1.0f * i;
+      p[EMBEDDING_DIMENSION + i] = 2.0f * i;
+    }
+    auto count = at::tensor({2L}, at::TensorOptions().dtype(at::kLong));
+    mock->set_kv_db_async(indices, rows, count).wait();
+
+    auto out = at::zeros(
+        {2, EMBEDDING_DIMENSION}, at::TensorOptions().dtype(at::kFloat));
+    // get_kv_db_async calls get_kv_db_async_impl<false> internally
+    mock->get_kv_db_async(indices, out, count).wait();
+    EXPECT_TRUE(at::equal(out, rows));
+    EXPECT_EQ(mock->get_metadata_dim(), 0);
+  }
+
+  // Path 2: with metadata CF – exercises
+  // ssd_get_weights_with_metadata_multi_get branch inside get_kv_db_async_impl.
+  {
+    auto mock = getMockEmbeddingRocksDB(
+        /*num_shards=*/1,
+        "getKvAsyncWithMeta",
+        /*enable_raw_embedding_streaming=*/false,
+        /*table_names=*/{},
+        /*table_offsets=*/{},
+        /*table_sizes=*/{},
+        /*enable_metadata_cf=*/true,
+        /*metadata_dim=*/kMetadataDimFp32);
+    auto indices = at::tensor({7L, 8L}, at::TensorOptions().dtype(at::kLong));
+    auto rows = at::zeros(
+        {2, kMetadataDimFp32 + EMBEDDING_DIMENSION},
+        at::TensorOptions().dtype(at::kFloat));
+    auto* rp = rows.data_ptr<float>();
+    create_metaheader_row(
+        rp + 0 * (kMetadataDimFp32 + EMBEDDING_DIMENSION),
+        kMetadataDimFp32 + EMBEDDING_DIMENSION,
+        7,
+        11,
+        1.5f);
+    create_metaheader_row(
+        rp + 1 * (kMetadataDimFp32 + EMBEDDING_DIMENSION),
+        kMetadataDimFp32 + EMBEDDING_DIMENSION,
+        8,
+        13,
+        2.5f);
+    for (int64_t i = 0; i < EMBEDDING_DIMENSION; ++i) {
+      rp[kMetadataDimFp32 + i] = 30.0f + i;
+      rp[(kMetadataDimFp32 + EMBEDDING_DIMENSION) + kMetadataDimFp32 + i] =
+          40.0f + i;
+    }
+    auto count = at::tensor({2L}, at::TensorOptions().dtype(at::kLong));
+    mock->set_kv_db_async(indices, rows, count).wait();
+
+    auto out = at::zeros(
+        {2, kMetadataDimFp32 + EMBEDDING_DIMENSION},
+        at::TensorOptions().dtype(at::kFloat));
+    mock->get_kv_db_async(indices, out, count).wait();
+    EXPECT_EQ(
+        std::memcmp(
+            out.data_ptr<float>(),
+            rows.data_ptr<float>(),
+            rows.numel() * sizeof(float)),
+        0);
+    EXPECT_EQ(mock->get_metadata_dim(), kMetadataDimFp32);
+    EXPECT_TRUE(mock->is_metadata_cf_initialized(0));
+  }
 }


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2837

Wire the metadata column family into existing EmbeddingRocksDB methods to support storing and managing KVZCH metadata separately from the main embedding data in SSD.

Differential Revision: D108793458


