### PR TITLE
Remove usage of aarch64 compatibility layers (#5921)

### DIFF
--- a/bench/BenchUtils.h
+++ b/bench/BenchUtils.h
@@ -33,7 +33,13 @@
 #endif
 
 #ifdef USE_MKL
+#if !defined(FBGEMM_FBCODE) || defined(__x86_64__)
 #include <mkl.h>
+#else
+#include <armpl_int.h>
+#include <cblas.h> // @manual=third-party//Arm-Performance-Libraries:armpl_lp64_mp
+#include <openrng.h>
+#endif
 #endif
 
 #include "./AlignedVec.h" // @manual
@@ -219,7 +225,7 @@ void performance_test(
     bool flush,
     int repetitions,
     bool is_mkl [[maybe_unused]]) {
-#ifdef USE_MKL
+#if defined(USE_MKL) && (!defined(FBGEMM_FBCODE) || defined(__x86_64__))
   mkl_set_xerbla((XerblaEntry)test_xerbla);
 #endif
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2838


Remove dependency on aarch64 compatibility layers. No x86 code had to be migrated, just mkl gets replaced by armpl

Reviewed By: dtolnay, mcfi

Differential Revision: D108898899


