### PR TITLE
Skip opcheck for pack_segments_large_grid stress test

### DIFF
--- a/fbgemm_gpu/test/sparse/pack_segments_test.py
+++ b/fbgemm_gpu/test/sparse/pack_segments_test.py
@@ -10,6 +10,8 @@
 # pyre-ignore-all-errors[56]
 
 import unittest
+from collections.abc import Callable
+from typing import Any
 
 import hypothesis.strategies as st
 import numpy as np
@@ -724,7 +726,25 @@ class PackedSegmentsTest(unittest.TestCase):
         torch.testing.assert_close(small_packed_gpu_v2.cpu(), small_packed_cpu_v2)
 
 
-extend_test_class(PackedSegmentsTest)
+# The opcheck harness (generate_opcheck_tests) re-executes the op for each
+# generated variant. test_pack_segments_large_grid deliberately drives
+# max_length = 2**31 + 1 (an ~8 GiB fp16 output) to exercise the HIP grid cap,
+# and intentionally asserts shape only at full scale because v1's
+# CUDA_KERNEL_LOOP uses an int32 index that overflows past 2**31. Re-running the
+# op in the generated variants hits that overflow -> illegal memory access ->
+# FATAL crash (not catchable by xfail), so skip opcheck for this stress test.
+# T191384137
+_LARGE_GRID_SKIP: list[Callable[..., Any]] = [
+    unittest.skip("large-grid stress test is incompatible with opcheck re-execution")
+]
+additional_decorators: dict[str, list[Callable[..., Any]]] = {
+    "test_schema__test_pack_segments_large_grid": _LARGE_GRID_SKIP,
+    "test_autograd_registration__test_pack_segments_large_grid": _LARGE_GRID_SKIP,
+    "test_faketensor__test_pack_segments_large_grid": _LARGE_GRID_SKIP,
+    "test_aot_dispatch_dynamic__test_pack_segments_large_grid": _LARGE_GRID_SKIP,
+}
+
+extend_test_class(PackedSegmentsTest, additional_decorators)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
De-flake follow-up for the fbgemm_dev OMH dashboard (T191384137).

PackedSegmentsTest.test_aot_dispatch_dynamic__test_pack_segments_large_grid
fails FATAL (a hard CUDA crash) in CI, surfacing as a LAND_BLOCKING signal on
any diff touching test/sparse.

Root cause: test_pack_segments_large_grid (added in D104950916 to repro the HIP
grid-overflow cap) deliberately drives max_length = 2**31 + 1, an ~8 GiB fp16
output. It intentionally asserts shape only at full scale because the v1 kernel
uses a CUDA_KERNEL_LOOP int32 index that overflows past 2**31 (a known,
out-of-scope kernel bug). The opcheck harness (generate_opcheck_tests) does not
honor the base method semantics: it re-executes the op for each generated
variant, hitting the int32 overflow -> illegal memory access -> FATAL process
crash, which is not catchable by an xfail entry in failures_dict.json.

Fix: skip the generated opcheck variants (test_schema / test_autograd_registration
/ test_faketensor / test_aot_dispatch_dynamic) for this one stress test via
extend_test_class additional_decorators, mirroring the established pattern in
nbit_forward_test.py. The base test_pack_segments_large_grid (gated on
gpu_memory_lt_gb(12)) continues to run and exercise the grid cap + downsampled
CPU-oracle correctness check.

Differential Revision: D108922750


