### PR TITLE
Add DramSsdKVEmbeddingCache composite backend (DRAM forwarding) (#5926)

### DIFF
--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_ssd_kv_embedding_cache.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_ssd_kv_embedding_cache.h
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/futures/Future.h>
+
+#include "dram_kv_embedding_cache.h"
+
+namespace kv_db {
+
+/// @ingroup KVMemEmbedding
+///
+/// @brief Composite backend that wraps the DRAM (L2) embedding cache.
+///
+/// This is the forwarding skeleton: every EmbeddingKVDB method delegates to
+/// the wrapped DRAM cache. The SSD (L3) tier and its orchestration (two-phase
+/// lookup, async backfill, eviction writeback, flush-to-SSD, and checkpoint
+/// reads) are layered on top in a follow-up.
+///
+template <typename weight_type>
+class DramSsdKVEmbeddingCache : public EmbeddingKVDB {
+ public:
+  /// Construct the composite backend over the DRAM tier (L2).
+  ///
+  /// @param dram_cache The DRAM tier (L2)
+  explicit DramSsdKVEmbeddingCache(
+      std::shared_ptr<kv_mem::DramKVEmbeddingCache<weight_type>> dram_cache)
+      : EmbeddingKVDB(
+            require_dram_cache(dram_cache)->get_num_shards(),
+            require_dram_cache(dram_cache)->get_max_D(),
+            /*cache_size_gb=*/0,
+            /*unique_id=*/0,
+            /*ele_size_bytes=*/sizeof(weight_type)),
+        dram_cache_(std::move(dram_cache)) {}
+
+  ~DramSsdKVEmbeddingCache() override = default;
+
+  // --- Core EmbeddingKVDB interface (forwarded to DRAM) ---
+
+  folly::SemiFuture<std::vector<folly::Unit>> get_kv_db_async(
+      const at::Tensor& indices,
+      const at::Tensor& weights,
+      const at::Tensor& count) override {
+    return dram_cache_->get_kv_db_async(indices, weights, count);
+  }
+
+  void set_range_to_storage(
+      const at::Tensor& weights_with_metaheader,
+      const int64_t start,
+      const int64_t length) override {
+    dram_cache_->set_range_to_storage(weights_with_metaheader, start, length);
+  }
+
+  folly::SemiFuture<std::vector<folly::Unit>> set_kv_db_async(
+      const at::Tensor& indices,
+      const at::Tensor& weights,
+      const at::Tensor& count,
+      const RocksdbWriteMode w_mode =
+          RocksdbWriteMode::FWD_ROCKSDB_READ) override {
+    return dram_cache_->set_kv_db_async(indices, weights, count, w_mode);
+  }
+
+  /// Delegate enrichment metadata to DRAM cache.
+  folly::SemiFuture<std::vector<folly::Unit>>
+  set_kv_zch_eviction_metadata_async(
+      at::Tensor indices,
+      at::Tensor count,
+      at::Tensor engage_show_count) override {
+    return dram_cache_->set_kv_zch_eviction_metadata_async(
+        std::move(indices), std::move(count), std::move(engage_show_count));
+  }
+
+  /// Delegate enrichment query ID processing to DRAM cache.
+  void set_embedding_cache_enrich_query_id_async(
+      at::Tensor hashed_indices,
+      at::Tensor unhashed_indices,
+      at::Tensor count) override {
+    dram_cache_->set_embedding_cache_enrich_query_id_async(
+        std::move(hashed_indices),
+        std::move(unhashed_indices),
+        std::move(count));
+  }
+
+  void compact() override {
+    dram_cache_->compact();
+  }
+
+  /// Delegate sync SID fetch to the DRAM cache. Without this override the
+  /// composite would fall back to the base-class no-op and silently return
+  /// empty tensors.
+  std::tuple<at::Tensor, at::Tensor> fetch_sids_sync(
+      at::Tensor hashed_indices,
+      at::Tensor unhashed_indices,
+      at::Tensor count) override {
+    return dram_cache_->fetch_sids_sync(
+        std::move(hashed_indices),
+        std::move(unhashed_indices),
+        std::move(count));
+  }
+
+  // --- Eviction delegation ---
+
+  void maybe_evict() override {
+    dram_cache_->maybe_evict();
+  }
+
+  void trigger_feature_evict() override {
+    dram_cache_->trigger_feature_evict();
+  }
+
+  bool is_evicting() override {
+    return dram_cache_->is_evicting();
+  }
+
+  void set_backend_return_whole_row(bool backend_return_whole_row) override {
+    dram_cache_->set_backend_return_whole_row(backend_return_whole_row);
+  }
+
+  size_t get_map_used_memsize_in_bytes() const override {
+    return dram_cache_->get_map_used_memsize_in_bytes();
+  }
+
+  void pause_ongoing_eviction(bool force_resume = false) override {
+    dram_cache_->pause_ongoing_eviction(force_resume);
+  }
+
+  void resume_ongoing_eviction(bool force_pause = false) override {
+    dram_cache_->resume_ongoing_eviction(force_pause);
+  }
+
+  void wait_until_eviction_done() override {
+    dram_cache_->wait_until_eviction_done();
+  }
+
+  std::optional<kv_mem::FeatureEvictMetricTensors> get_feature_evict_metric()
+      const override {
+    return dram_cache_->get_feature_evict_metric();
+  }
+
+  std::vector<double> get_dram_kv_perf(
+      const int64_t step,
+      const int64_t interval) override {
+    // Call through base class pointer to access the private override via
+    // virtual dispatch.
+    EmbeddingKVDB* base = dram_cache_.get();
+    return base->get_dram_kv_perf(step, interval);
+  }
+
+  /// Delegate to the DRAM cache via base-class pointer to dispatch through the
+  /// virtual interface (the override is private in DramKVEmbeddingCache).
+  bool get_backend_return_whole_row() override {
+    EmbeddingKVDB* base = dram_cache_.get();
+    return base->get_backend_return_whole_row();
+  }
+
+  int64_t get_metaheader_width_in_front() override {
+    EmbeddingKVDB* base = dram_cache_.get();
+    return base->get_metaheader_width_in_front();
+  }
+
+  void get_range_from_snapshot(
+      const at::Tensor& weights,
+      const int64_t start,
+      const int64_t length,
+      const ssd::SnapshotHandle* snapshot_handle,
+      int64_t width_offset = 0,
+      std::optional<int64_t> width_length = std::nullopt) override {
+    dram_cache_->get_range_from_snapshot(
+        weights, start, length, snapshot_handle, width_offset, width_length);
+  }
+
+  void get_kv_from_storage_by_snapshot(
+      const at::Tensor& ids,
+      const at::Tensor& weights,
+      const ssd::SnapshotHandle* snapshot_handle,
+      int64_t width_offset = 0,
+      std::optional<int64_t> width_length = std::nullopt) override {
+    dram_cache_->get_kv_from_storage_by_snapshot(
+        ids, weights, snapshot_handle, width_offset, width_length);
+  }
+
+  // --- Key range and metadata ---
+
+  at::Tensor get_keys_in_range_impl(
+      int64_t start,
+      int64_t end,
+      std::optional<int64_t> offset = std::nullopt) override {
+    return dram_cache_->get_keys_in_range_impl(start, end, offset);
+  }
+
+  at::Tensor get_kv_zch_eviction_metadata_impl(
+      const at::Tensor& indices,
+      const at::Tensor& count) override {
+    return dram_cache_->get_kv_zch_eviction_metadata_impl(indices, count);
+  }
+
+  // --- Accessors ---
+
+  const std::shared_ptr<kv_mem::DramKVEmbeddingCache<weight_type>>& dram_cache()
+      const {
+    return dram_cache_;
+  }
+
+ private:
+  static const std::shared_ptr<kv_mem::DramKVEmbeddingCache<weight_type>>&
+  require_dram_cache(
+      const std::shared_ptr<kv_mem::DramKVEmbeddingCache<weight_type>>&
+          dram_cache) {
+    TORCH_CHECK(dram_cache != nullptr, "dram_cache must not be null");
+    return dram_cache;
+  }
+
+  void flush_or_compact(const int64_t /*timestep*/) override {
+    // No-op; flush is explicit and added with the SSD tier.
+  }
+
+  std::shared_ptr<kv_mem::DramKVEmbeddingCache<weight_type>> dram_cache_;
+}; // class DramSsdKVEmbeddingCache
+
+} // namespace kv_db

--- a/fbgemm_gpu/src/dram_kv_embedding_cache/dram_ssd_kv_embedding_cache_wrapper.h
+++ b/fbgemm_gpu/src/dram_kv_embedding_cache/dram_ssd_kv_embedding_cache_wrapper.h
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ATen/ATen.h>
+#include <fmt/format.h>
+#include "../ssd_split_embeddings_cache/kv_tensor_wrapper.h"
+#include "dram_kv_embedding_cache.h"
+#include "dram_ssd_kv_embedding_cache.h"
+
+namespace ssd {
+struct EmbeddingSnapshotHandleWrapper;
+}
+
+namespace kv_mem {
+
+/// @brief TorchScript wrapper for DramSsdKVEmbeddingCache composite backend.
+///
+/// Forwarding skeleton: constructs the DRAM cache, wraps it in a
+/// DramSsdKVEmbeddingCache, and forwards all calls to it. The SSD (L3) backend
+/// wiring is added in a follow-up.
+class DramSsdKVEmbeddingCacheWrapper : public torch::jit::CustomClassHolder {
+ public:
+  DramSsdKVEmbeddingCacheWrapper(
+      int64_t max_D,
+      double uniform_init_lower,
+      double uniform_init_upper,
+      std::optional<c10::intrusive_ptr<kv_mem::FeatureEvictConfig>>
+          feature_evict_config,
+      int64_t num_shards = 8,
+      int64_t num_threads = 32,
+      int64_t row_storage_bitwidth = 32,
+      const std::optional<at::Tensor>& table_dims = std::nullopt,
+      const std::optional<at::Tensor>& hash_size_cumsum = std::nullopt,
+      bool backend_return_whole_row = false,
+      bool enable_async_update = false,
+      bool disable_random_init = false,
+      bool enable_raw_embedding_streaming = false,
+      int64_t res_store_shards = 0,
+      int64_t res_server_port = 0,
+      std::vector<std::string> table_names = {},
+      std::vector<int64_t> table_offsets = {},
+      std::vector<int64_t> table_sizes = {},
+      std::optional<c10::intrusive_ptr<kv_mem::EnrichmentConfig>>
+          enrichment_config = std::nullopt) {
+    if (row_storage_bitwidth == 16) {
+      auto dram_cache =
+          std::make_shared<kv_mem::DramKVEmbeddingCache<at::Half>>(
+              max_D,
+              uniform_init_lower,
+              uniform_init_upper,
+              feature_evict_config,
+              num_shards,
+              num_threads,
+              row_storage_bitwidth,
+              backend_return_whole_row,
+              enable_async_update,
+              table_dims,
+              hash_size_cumsum,
+              true, // is_training
+              disable_random_init,
+              enable_raw_embedding_streaming,
+              res_store_shards,
+              res_server_port,
+              std::move(table_names),
+              std::move(table_offsets),
+              std::move(table_sizes),
+              enrichment_config,
+              /*enable_ssd_backend=*/true);
+      impl_ = std::make_shared<kv_db::DramSsdKVEmbeddingCache<at::Half>>(
+          std::move(dram_cache));
+    } else if (row_storage_bitwidth == 32) {
+      auto dram_cache = std::make_shared<kv_mem::DramKVEmbeddingCache<float>>(
+          max_D,
+          uniform_init_lower,
+          uniform_init_upper,
+          feature_evict_config,
+          num_shards,
+          num_threads,
+          row_storage_bitwidth,
+          backend_return_whole_row,
+          enable_async_update,
+          table_dims,
+          hash_size_cumsum,
+          true, // is_training
+          disable_random_init,
+          enable_raw_embedding_streaming,
+          res_store_shards,
+          res_server_port,
+          std::move(table_names),
+          std::move(table_offsets),
+          std::move(table_sizes),
+          enrichment_config,
+          /*enable_ssd_backend=*/true);
+      impl_ = std::make_shared<kv_db::DramSsdKVEmbeddingCache<float>>(
+          std::move(dram_cache));
+    } else {
+      throw std::runtime_error(
+          fmt::format(
+              "Unsupported row_storage_bitwidth={}; expected 16 or 32",
+              row_storage_bitwidth));
+    }
+  }
+
+  // --- Core methods (forwarded to composite backend) ---
+
+  void set_cuda(
+      at::Tensor indices,
+      at::Tensor weights,
+      at::Tensor count,
+      int64_t timestep,
+      bool is_bwd) {
+    impl_->set_cuda(indices, weights, count, timestep, is_bwd);
+  }
+
+  void get_cuda(at::Tensor indices, at::Tensor weights, at::Tensor count) {
+    impl_->get_cuda(indices, weights, count);
+  }
+
+  void set(at::Tensor indices, at::Tensor weights, at::Tensor count) {
+    impl_->set(indices, weights, count);
+  }
+
+  void flush() {
+    impl_->flush();
+  }
+
+  void set_range_to_storage(
+      const at::Tensor& weights,
+      const int64_t start,
+      const int64_t length) {
+    impl_->set_range_to_storage(weights, start, length);
+  }
+
+  at::Tensor get_keys_in_range_by_snapshot(
+      int64_t start_id,
+      int64_t end_id,
+      int64_t id_offset,
+      const std::optional<
+          c10::intrusive_ptr<ssd::EmbeddingSnapshotHandleWrapper>>&
+      /*snapshot_handle*/) {
+    return impl_->get_keys_in_range_impl(start_id, end_id, id_offset);
+  }
+
+  at::Tensor get_kv_zch_eviction_metadata_by_snapshot(
+      const at::Tensor& indices,
+      const at::Tensor& count,
+      const std::optional<
+          c10::intrusive_ptr<ssd::EmbeddingSnapshotHandleWrapper>>&
+      /*snapshot_handle*/) {
+    return impl_->get_kv_zch_eviction_metadata_impl(indices, count);
+  }
+
+  void get(
+      at::Tensor indices,
+      at::Tensor weights,
+      at::Tensor count,
+      int64_t sleep_ms) {
+    impl_->get(indices, weights, count, sleep_ms);
+  }
+
+  void wait_util_filling_work_done() {
+    impl_->wait_util_filling_work_done();
+  }
+
+  at::Tensor get_keys_in_range(int64_t start, int64_t end) {
+    return impl_->get_keys_in_range_impl(start, end, std::nullopt);
+  }
+
+  size_t get_map_used_memsize_in_bytes() const {
+    return impl_->get_map_used_memsize_in_bytes();
+  }
+
+  std::vector<double> get_dram_kv_perf(
+      const int64_t step,
+      const int64_t interval) {
+    return impl_->get_dram_kv_perf(step, interval);
+  }
+
+  void get_feature_evict_metric(
+      at::Tensor evicted_counts,
+      at::Tensor processed_counts,
+      at::Tensor eviction_threshold_with_dry_run,
+      at::Tensor full_duration_ms,
+      at::Tensor exec_duration_ms) {
+    auto metrics = impl_->get_feature_evict_metric();
+    if (metrics.has_value()) {
+      evicted_counts.copy_(metrics.value().evicted_counts);
+      processed_counts.copy_(metrics.value().processed_counts);
+      eviction_threshold_with_dry_run.copy_(
+          metrics.value().eviction_threshold_with_dry_run);
+      full_duration_ms.copy_(metrics.value().full_duration_ms);
+      exec_duration_ms.copy_(metrics.value().exec_duration_ms);
+    }
+  }
+
+  void wait_until_eviction_done() {
+    impl_->wait_until_eviction_done();
+  }
+
+  void set_backend_return_whole_row(bool backend_return_whole_row) {
+    impl_->set_backend_return_whole_row(backend_return_whole_row);
+  }
+
+  void trigger_feature_evict() {
+    impl_->trigger_feature_evict();
+  }
+
+  bool is_evicting() {
+    return impl_->is_evicting();
+  }
+
+  void set_feature_score_metadata_cuda(
+      at::Tensor indices,
+      at::Tensor count,
+      at::Tensor engage_show_count) {
+    impl_->set_feature_score_metadata_cuda(indices, count, engage_show_count);
+  }
+
+  void set_embedding_cache_enrich_query_id_cuda(
+      at::Tensor hashed_indices,
+      at::Tensor unhashed_indices,
+      at::Tensor count) {
+    impl_->set_embedding_cache_enrich_query_id_cuda(
+        hashed_indices, unhashed_indices, count);
+  }
+
+  std::tuple<at::Tensor, at::Tensor> fetch_sids_sync(
+      at::Tensor hashed_indices,
+      at::Tensor unhashed_indices,
+      at::Tensor count) {
+    return impl_->fetch_sids_sync(
+        std::move(hashed_indices),
+        std::move(unhashed_indices),
+        std::move(count));
+  }
+
+ private:
+  friend class ssd::KVTensorWrapper;
+
+  std::shared_ptr<kv_db::EmbeddingKVDB> impl_;
+};
+
+} // namespace kv_mem


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2844


Introduce the DramSsdKVEmbeddingCache composite backend and its
TorchScript wrapper as a forwarding skeleton: every EmbeddingKVDB method
delegates to the wrapped DRAM (L2) cache. This establishes the class and
build wiring; the SSD (L3) tier and its orchestration are added in the
follow-up.

- DramSsdKVEmbeddingCache: wraps DramKVEmbeddingCache and forwards all calls
- DramSsdKVEmbeddingCacheWrapper: TorchScript wrapper that builds the DRAM
  cache, wraps it in the composite, and forwards calls
- BUCK: register the two new headers

Differential Revision: D108964307


