### PR TITLE
Add grid-stride loop and ROCm cap to _batched_complete_cumsum_kernel

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_async_batched_cumsum.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_async_batched_cumsum.cu
@@ -55,45 +55,61 @@ template <
     typename = std::enable_if_t<std::is_integral<val_t>::value>>
 __global__ __launch_bounds__(kMaxThreads) void _batched_complete_cumsum_kernel(
     const pta::PackedTensorAccessor64<val_t, 2, at::RestrictPtrTraits> values,
+    const uint32_t B,
     const uint32_t len,
     const uint32_t items_per_thread,
     pta::PackedTensorAccessor64<val_t, 2, at::RestrictPtrTraits> out) {
   using BlockScan = cub::BlockScan<val_t, nthreads_per_block>;
   __shared__ typename BlockScan::TempStorage temp_storage;
 
-  BlockPrefixCallbackOp<val_t> prefix_op(0);
-  if (threadIdx.x == 0) {
-    out[blockIdx.x][0] = 0;
-  }
-
-  for (uint32_t offset = 0; offset < items_per_thread; offset++) {
-    uint32_t i = offset * nthreads_per_block + threadIdx.x;
-    val_t data = 0;
-    if (i < len) {
-      data = (val_t)values[blockIdx.x][i];
+  // Grid-stride over rows so a capped grid (used on ROCm to avoid the 2^32
+  // launch-side limit) still covers all B rows.
+  for (uint32_t row = blockIdx.x; row < B; row += gridDim.x) {
+    // RESET prefix scan state at the top of each iteration: running total
+    // resets to 0 for each row.
+    BlockPrefixCallbackOp<val_t> prefix_op(0);
+    if (threadIdx.x == 0) {
+      out[row][0] = 0;
     }
-    BlockScan(temp_storage).InclusiveSum(data, data, prefix_op);
 
+    for (uint32_t offset = 0; offset < items_per_thread; offset++) {
+      uint32_t i = offset * nthreads_per_block + threadIdx.x;
+      val_t data = 0;
+      if (i < len) {
+        data = (val_t)values[row][i];
+      }
+      BlockScan(temp_storage).InclusiveSum(data, data, prefix_op);
+
+#if CUDA_VERSION >= 13000
+      __syncthreads();
+#else
+      cub::CTA_SYNC();
+#endif
+
+      if (i < len) {
+        out[row][i + 1] = data;
+      }
+    }
+
+    // Ensure all threads finished using temp_storage before the next
+    // outer-iteration's BlockScan overwrites it.
 #if CUDA_VERSION >= 13000
     __syncthreads();
 #else
     cub::CTA_SYNC();
 #endif
-
-    if (i < len) {
-      out[blockIdx.x][i + 1] = data;
-    }
   }
 }
 
 #define BATCHED_COMPLETE_CUMSUM_KERNEL(NTHREADS_PER_BLOCK)          \
   FBGEMM_LAUNCH_KERNEL(                                             \
       (_batched_complete_cumsum_kernel<val_t, NTHREADS_PER_BLOCK>), \
-      B,                                                            \
+      num_blocks,                                                   \
       NTHREADS_PER_BLOCK,                                           \
       0,                                                            \
       at::cuda::getCurrentCUDAStream(),                             \
       PTA_B(values, val_t, 2, 64),                                  \
+      B,                                                            \
       len,                                                          \
       items_per_thread,                                             \
       PTA_B(cumsum, val_t, 2, 64));
@@ -117,6 +133,13 @@ at::Tensor asynchronous_batched_complete_cumsum_gpu(const at::Tensor& values) {
   const uint32_t items_per_thread = div_round_up(len, nthreads_per_block);
 
   auto cumsum = at::empty({B, len + 1}, values.options());
+
+  // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
+  // which silently wraps). _batched_complete_cumsum_kernel grid-strides over
+  // rows, so capping is correctness-preserving.
+  // See: https://github.com/ROCm/hip/issues/2253
+  const uint32_t num_blocks = utils::cuda::cap_grid_dim_x(
+      B, nthreads_per_block, at::cuda::getCurrentCUDAStream());
 
   AT_DISPATCH_INTEGRAL_TYPES(
       values.scalar_type(), "batched_complete_cumsum_cuda_input1", [&] {

--- a/fbgemm_gpu/src/sparse_ops/sparse_block_bucketize_features.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_block_bucketize_features.cu
@@ -24,16 +24,27 @@ __launch_bounds__(kMaxThreads) void _populate_length_to_feature_id_inplace_kerne
     const offset_t* const __restrict__ batch_size_per_feature,
     const offset_t* const __restrict__ batch_size_offsets,
     offset_t* const __restrict__ length_to_feature_idx) {
-  const auto b_t = blockIdx.x * blockDim.x + threadIdx.x;
+  // Explicit int64_t grid-stride loop (instead of CUDA_KERNEL_LOOP_TYPE) so
+  // that the workload bound and the per-iteration thread stride are computed
+  // in 64-bit. CUDA_KERNEL_LOOP_TYPE increments by the 32-bit unsigned
+  // `blockDim.x * gridDim.x` product, which is implicitly widened to int64_t
+  // and trips facebook-security-vulnerable-integer-implicit-cast. Casting the
+  // first operand to int64_t keeps the multiply in 64-bit.
+  const int64_t b_t_total = static_cast<int64_t>(max_B) * T;
+  const int64_t b_t_stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (int64_t b_t =
+           static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       b_t < b_t_total;
+       b_t += b_t_stride) {
+    const auto t = b_t / max_B;
+    const auto b = b_t % max_B;
 
-  const auto t = b_t / max_B;
-  const auto b = b_t % max_B;
+    if (b >= batch_size_per_feature[t]) {
+      continue;
+    }
 
-  if (t >= T || b >= batch_size_per_feature[t]) {
-    return;
+    length_to_feature_idx[batch_size_offsets[t] + b] = t;
   }
-
-  length_to_feature_idx[batch_size_offsets[t] + b] = t;
 }
 
 void adjust_block_bucketize_sparse_features_kernel_launch_configs_based_on_smem(
@@ -428,79 +439,93 @@ __launch_bounds__(kMaxThreads) void _populate_bucketized_permute_warp_parallel_k
       my_size <= kWarpSize &&
       "my_size exceeds kWarpSize for warp-parallel kernel");
 
-  // Each warp processes one sequence
-  const auto warp_id = (blockIdx.x * blockDim.x + threadIdx.x) / kWarpSize;
+  // Each warp processes one sequence. Use a warp-stride loop so that a
+  // capped grid (used on ROCm to avoid the 2^32 launch-side limit) still
+  // covers all `lengths_size` rows. All lanes within a warp share the same
+  // warp_id, so __ballot_sync / __popc semantics are preserved across
+  // iterations.
+  //
+  // The init/stride are computed in int64_t: on CUDA the grid is not capped,
+  // so `gridDim.x * blockDim.x` overflows uint32_t once total threads reach
+  // 2^32. A 32-bit stride would wrap to a small value (redundant work) or to
+  // exactly 0 (infinite loop) when the product is a multiple of 2^32.
+  const int64_t warp_id_init =
+      (static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x) / kWarpSize;
+  const int64_t warp_stride =
+      (static_cast<int64_t>(gridDim.x) * blockDim.x) / kWarpSize;
 
-  if (warp_id >= lengths_size) {
-    return;
-  }
+  for (int64_t warp_id = warp_id_init; warp_id < lengths_size;
+       warp_id += warp_stride) {
+    const auto b_t = warp_id;
+    const auto length = length_data[b_t];
+    const auto row_offset = offset_data[b_t];
 
-  const auto b_t = warp_id;
-  const auto length = length_data[b_t];
-  const auto row_offset = offset_data[b_t];
+    // Early-skip for zero-length sequences (must be `continue`, not
+    // `return`, to keep all warps in lockstep across the outer stride loop).
+    if (length == 0) {
+      continue;
+    }
 
-  // Early exit for zero-length sequences
-  if (length == 0) {
-    return;
-  }
+    // RESET per-warp register state at the top of each iteration.
+    // Use registers for cumulative bucket counts (works for small my_size).
+    // Each thread tracks counts for all buckets across chunks.
+    offset_t cumulative_counts[kWarpSize] = {0};
 
-  // Use registers for cumulative bucket counts (works for small my_size)
-  // Each thread tracks counts for all buckets across chunks
-  offset_t cumulative_counts[kWarpSize] = {0};
+    // Load base offsets for each bucket
+    offset_t base_offsets[kWarpSize];
+    for (auto p = 0; p < my_size; p++) {
+      CUDA_KERNEL_ASSERT(
+          p * lengths_size + b_t >= 0 &&
+          "bucketized_offsets index out of bounds");
+      base_offsets[p] = bucketized_offsets_data[p * lengths_size + b_t];
+    }
 
-  // Load base offsets for each bucket
-  offset_t base_offsets[kWarpSize];
-  for (auto p = 0; p < my_size; p++) {
-    CUDA_KERNEL_ASSERT(
-        p * lengths_size + b_t >= 0 &&
-        "bucketized_offsets index out of bounds");
-    base_offsets[p] = bucketized_offsets_data[p * lengths_size + b_t];
-  }
+    // Process in warp-sized chunks
+    for (offset_t chunk_start = 0; chunk_start < length;
+         chunk_start += kWarpSize) {
+      const auto i = chunk_start + getLaneId();
+      const bool valid = (i < length);
 
-  // Process in warp-sized chunks
-  for (offset_t chunk_start = 0; chunk_start < length;
-       chunk_start += kWarpSize) {
-    const auto i = chunk_start + getLaneId();
-    const bool valid = (i < length);
+      // Load bucket for this element (-1 for invalid lanes)
+      const index_t my_bucket =
+          valid ? bucket_mapping_data[row_offset + i] : -1;
 
-    // Load bucket for this element (-1 for invalid lanes)
-    const index_t my_bucket = valid ? bucket_mapping_data[row_offset + i] : -1;
+      int preceding_count = 0;
 
-    int preceding_count = 0;
+      // Compute ballot for all buckets - no branch divergence!
+      // All threads execute the same loop iterations
+      for (int p = 0; p < my_size; p++) {
+        // ballot_sync() returns a width-correct mask (uint64_t on ROCm
+        // wavefront64, uint32_t on CUDA warp32). Pairing it with __popcll is
+        // required: a 32-bit mask + __popc would silently truncate lanes 32-63
+        // on AMD CDNA and undercount preceding elements.
+        const auto bucket_mask = ballot_sync(valid && (my_bucket == p));
 
-    // Compute ballot for all buckets - no branch divergence!
-    // All threads execute the same loop iterations
-    for (int p = 0; p < my_size; p++) {
-      // ballot_sync() returns a width-correct mask (uint64_t on ROCm
-      // wavefront64, uint32_t on CUDA warp32). Pairing it with __popcll is
-      // required: a 32-bit mask + __popc would silently truncate lanes 32-63
-      // on AMD CDNA and undercount preceding elements.
-      const auto bucket_mask = ballot_sync(valid && (my_bucket == p));
-
-      // Each thread checks if this is its bucket and stores the count
-      // This is a simple conditional assignment, not a divergent branch
-      if (my_bucket == p) {
-        preceding_count = __popcll(bucket_mask & getLaneMaskLt());
+        // Each thread checks if this is its bucket and stores the count
+        // This is a simple conditional assignment, not a divergent branch
+        if (my_bucket == p) {
+          preceding_count = __popcll(bucket_mask & getLaneMaskLt());
+        }
       }
-    }
 
-    // Write output for valid lanes
-    if (valid) {
-      bucketized_permute_data_out[row_offset + i] = base_offsets[my_bucket] +
-          cumulative_counts[my_bucket] + preceding_count;
-    }
+      // Write output for valid lanes
+      if (valid) {
+        bucketized_permute_data_out[row_offset + i] = base_offsets[my_bucket] +
+            cumulative_counts[my_bucket] + preceding_count;
+      }
 
-    // Update cumulative counts for all buckets for the next chunk.
-    // We call __ballot_sync again here instead of reusing the result from
-    // the preceding_count loop above because that result was consumed inside
-    // a per-bucket conditional (my_bucket == p) and not stored for all
-    // buckets. Each thread only captured the ballot for its own bucket,
-    // but here we need the popcount for every bucket to update all
-    // cumulative_counts entries.
-    for (int p = 0; p < my_size; p++) {
-      // Width-correct ballot + __popcll, same rationale as above.
-      const auto bucket_mask = ballot_sync(valid && (my_bucket == p));
-      cumulative_counts[p] += __popcll(bucket_mask);
+      // Update cumulative counts for all buckets for the next chunk.
+      // We call __ballot_sync again here instead of reusing the result from
+      // the preceding_count loop above because that result was consumed inside
+      // a per-bucket conditional (my_bucket == p) and not stored for all
+      // buckets. Each thread only captured the ballot for its own bucket,
+      // but here we need the popcount for every bucket to update all
+      // cumulative_counts entries.
+      for (int p = 0; p < my_size; p++) {
+        // Width-correct ballot + __popcll, same rationale as above.
+        const auto bucket_mask = ballot_sync(valid && (my_bucket == p));
+        cumulative_counts[p] += __popcll(bucket_mask);
+      }
     }
   }
 }
@@ -844,8 +869,13 @@ _block_bucketize_sparse_features_cuda(
   auto indices_to_lb = at::empty_like(indices);
   if (batch_size_per_feature.has_value()) {
     constexpr auto threads_per_block = 256;
-    const auto num_blocks =
-        cuda_calc_xblock_count(max_B * T, threads_per_block);
+    // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
+    // which silently wraps). _populate_length_to_feature_id_inplace_kernel
+    // uses CUDA_KERNEL_LOOP, which already grid-strides, so capping is
+    // correctness-preserving.
+    // See: https://github.com/ROCm/hip/issues/2253
+    const auto num_blocks = utils::cuda::cap_grid_dim_x_from_workload(
+        max_B * T, threads_per_block, at::cuda::getCurrentCUDAStream());
 
     AT_DISPATCH_INDEX_TYPES(
         offsets_contig.scalar_type(),
@@ -1177,8 +1207,16 @@ DLL_PUBLIC Tensor populate_bucketized_permute_cuda(
                       config::FeatureGateName::BUCKETIZED_PERMUTE_WARP_KERNEL);
               if (my_size <= kWarpSize && warp_kernel_enabled) {
                 const auto warps_per_block = kMaxThreads / kWarpSize;
-                const auto num_blocks =
-                    cuda_calc_xblock_count(lengths_size, warps_per_block);
+                // HIP enforces a hard limit of 2^32 total threads per launch
+                // (unlike CUDA, which silently wraps).
+                // _populate_bucketized_permute_warp_parallel_kernel
+                // grid-strides over warp_id, so capping is
+                // correctness-preserving. See:
+                // https://github.com/ROCm/hip/issues/2253
+                const auto num_blocks = utils::cuda::cap_grid_dim_x(
+                    cuda_calc_xblock_count(lengths_size, warps_per_block),
+                    kMaxThreads,
+                    stream);
                 FBGEMM_LAUNCH_KERNEL(
                     (_populate_bucketized_permute_warp_parallel_kernel<
                         offset_t,

--- a/fbgemm_gpu/src/sparse_ops/sparse_segment_sum_csr.cu
+++ b/fbgemm_gpu/src/sparse_ops/sparse_segment_sum_csr.cu
@@ -18,6 +18,7 @@ namespace fbgemm_gpu {
 // See https://moderngpu.github.io/segreduce.html
 template <typename values_t, typename index_t>
 __global__ __launch_bounds__(kMaxThreads) void _segment_sum_csr_cuda_kernel(
+    int num_segments,
     int64_t batch_size,
     const index_t* csr_seg_data,
     const values_t* values_data,
@@ -25,30 +26,43 @@ __global__ __launch_bounds__(kMaxThreads) void _segment_sum_csr_cuda_kernel(
   typedef FBGEMM_GPU_CUB_NS_PREFIX cub::BlockReduce<values_t, 256> BlockReduce;
 
   __shared__ typename BlockReduce::TempStorage temp_storage;
-  int64_t seg_start = csr_seg_data[blockIdx.x] * batch_size;
-  int64_t seg_end = csr_seg_data[blockIdx.x + 1] * batch_size;
-  values_t sum = 0;
 
-  for (int64_t i = seg_start; i < seg_end; i += blockDim.x) {
-    values_t thread_data;
-    if (threadIdx.x < seg_end - i) {
-      thread_data = values_data[i + threadIdx.x];
+  // Grid-stride over segments so a capped grid (used on ROCm to avoid the
+  // 2^32 launch-side limit) still covers all segments.
+  for (auto seg = blockIdx.x; seg < num_segments; seg += gridDim.x) {
+    // 64-bit segment offsets: csr_seg_data[seg] (index_t) * batch_size
+    // (int64_t) can exceed INT_MAX, so accumulate in int64_t to avoid
+    // truncation.
+    int64_t seg_start = csr_seg_data[seg] * batch_size;
+    int64_t seg_end = csr_seg_data[seg + 1] * batch_size;
+    values_t sum = 0;
+
+    for (int64_t i = seg_start; i < seg_end; i += blockDim.x) {
+      values_t thread_data;
+      if (threadIdx.x < seg_end - i) {
+        thread_data = values_data[i + threadIdx.x];
+      }
+
+      // cap at blockDim.x to fit cub's int num_valid without truncation
+      const int num_valid =
+          static_cast<int>(seg_end - i < blockDim.x ? seg_end - i : blockDim.x);
+      values_t aggregate =
+          BlockReduce(temp_storage).Sum(thread_data, num_valid);
+
+      __syncthreads();
+
+      if (threadIdx.x == 0) {
+        sum += aggregate;
+      }
     }
-
-    // cap at blockDim.x to fit cub's int num_valid without truncation
-    const int num_valid =
-        static_cast<int>(seg_end - i < blockDim.x ? seg_end - i : blockDim.x);
-    values_t aggregate = BlockReduce(temp_storage).Sum(thread_data, num_valid);
-
-    __syncthreads();
 
     if (threadIdx.x == 0) {
-      sum += aggregate;
+      output_data[seg] = sum;
     }
-  }
 
-  if (threadIdx.x == 0) {
-    output_data[blockIdx.x] = sum;
+    // Ensure all threads have finished using temp_storage before the next
+    // outer-iteration's BlockReduce overwrites it.
+    __syncthreads();
   }
 }
 
@@ -75,7 +89,14 @@ DLL_PUBLIC Tensor segment_sum_csr_cuda(
       "segment_sum_csr: number of segments (",
       num_segments,
       ") exceeds the maximum CUDA grid dimension");
-  const uint32_t num_blocks = static_cast<uint32_t>(num_segments);
+  // HIP enforces a hard limit of 2^32 total threads per launch (unlike CUDA,
+  // which silently wraps). _segment_sum_csr_cuda_kernel grid-strides over
+  // segments, so capping the launch grid is correctness-preserving.
+  // See: https://github.com/ROCm/hip/issues/2253
+  const uint32_t num_blocks = utils::cuda::cap_grid_dim_x(
+      static_cast<uint32_t>(num_segments),
+      threads_per_block,
+      at::cuda::getCurrentCUDAStream());
 
   FBGEMM_DISPATCH_ALL_TYPES(
       values.scalar_type(), "_segment_sum_csr_cuda_1", [&] {
@@ -88,6 +109,7 @@ DLL_PUBLIC Tensor segment_sum_csr_cuda(
                   threads_per_block,
                   0,
                   at::cuda::getCurrentCUDAStream(),
+                  static_cast<int32_t>(num_segments),
                   batch_size,
                   csr_seg.data_ptr<index_t>(),
                   values.data_ptr<values_t>(),

--- a/fbgemm_gpu/test/sparse/block_bucketize_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_test.py
@@ -20,10 +20,14 @@ from .common import extend_test_class, open_source
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import gpu_available
+    from test_utils import gpu_available, gpu_memory_lt_gb, gpu_unavailable
 else:
     import fbgemm_gpu.sparse_ops  # noqa: F401, E402  (registers FakeTensor/meta impls)
-    from fbgemm_gpu.test.test_utils import gpu_available
+    from fbgemm_gpu.test.test_utils import (
+        gpu_available,
+        gpu_memory_lt_gb,
+        gpu_unavailable,
+    )
 
 
 def unbucketize_indices_value(
@@ -2143,6 +2147,134 @@ class BlockBucketizeTest(unittest.TestCase):
                 None,
                 total_num_blocks=torch.tensor([7, 6, 6], dtype=torch.int),
             )
+
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(4))
+    def test_block_bucketize_sparse_features_populate_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in
+        _populate_length_to_feature_id_inplace_kernel for the variable-batch-size
+        code path of block_bucketize_sparse_features_cuda.
+
+        With threads_per_block=256, the launch grid is
+        cuda_calc_xblock_count(max_B*T, 256). For max_B*T > 2**32, total
+        threads exceed the HIP 2**32 limit, causing FBGEMM_LAUNCH_KERNEL ->
+        KernelLauncher::checkThreadCountNotExceeded to TORCH_CHECK-fail on
+        ROCm post-fix.
+
+        Verification strategy: this test exercises launch-survival and
+        non-trivial post-launch shape/sum invariants at the cap-trip
+        scale. Variable-batch-size element-wise correctness is covered by
+        ``test_block_bucketize_sparse_features_with_variable_batch_sizes``
+        in this file at small max_B (where the input layout invariants
+        are known to match between CPU and GPU dispatch).
+
+        ``batch_size_per_feature`` is sparse: only features 0 and 2 have
+        a single batch instance each; features 1 and 3 have zero. This
+        keeps HBM usage bounded while still exercising the kernel's
+        non-trivial path (writing length_to_feature_idx[0]=0 and
+        length_to_feature_idx[1]=2).
+        """
+
+        T = 4
+        max_B = (1 << 30) + 1  # max_B * T = 2**32 + 4
+
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+
+        # Sparse batch_size_per_feature: only features 0 and 2 have one
+        # batch instance each. total_B = 2.
+        batch_size_per_feature = torch.zeros(T, dtype=torch.int32, device=device)
+        batch_size_per_feature[0] = 1
+        batch_size_per_feature[2] = 1
+        # total_B = 2 batch instances. lengths and indices sized
+        # accordingly.
+        lengths = torch.tensor([2, 1], dtype=torch.int32, device=device)
+        indices = torch.tensor([3, 7, 11], dtype=torch.int32, device=device)
+        # Distinct block_sizes per feature surface any wrong feature_id
+        # mapping in length_to_feature_idx.
+        block_sizes = torch.tensor([10, 20, 30, 40], dtype=torch.int32, device=device)
+        my_size = 2
+
+        new_lengths, new_indices, new_weights, _new_pos, _unbucketize_permute = (
+            torch.ops.fbgemm.block_bucketize_sparse_features(
+                lengths,
+                indices,
+                False,  # bucketize_pos
+                True,  # sequence
+                block_sizes,
+                my_size,
+                None,  # weights
+                batch_size_per_feature=batch_size_per_feature,
+                max_B=max_B,
+            )
+        )
+
+        # Output shape invariants.
+        total_B = int(batch_size_per_feature.sum().item())
+        self.assertEqual(new_lengths.shape, (my_size * total_B,))
+        self.assertEqual(new_indices.shape, (indices.numel(),))
+        self.assertIsNone(new_weights)
+        # Per-bucket lengths sum to total input length.
+        self.assertEqual(int(new_lengths.sum().item()), int(lengths.sum().item()))
+
+    @unittest.skipIf(*gpu_unavailable)
+    # bucketized_lengths is int32[lengths_size * my_size] (~2.1 GiB at
+    # the chosen lengths_size); the output permutation is tiny.
+    @unittest.skipIf(*gpu_memory_lt_gb(8))
+    def test_populate_bucketized_permute_warp_parallel_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in
+        _populate_bucketized_permute_warp_parallel_kernel and verifies
+        output correctness against the CPU dispatch at the same scale.
+
+        With block size kMaxThreads=1024 (32 warps/block), the launch grid is
+        cuda_calc_xblock_count(lengths_size, warps_per_block=32). Total threads
+        ~= lengths_size * 32. For lengths_size > 2**27, total threads exceed
+        the HIP 2**32 limit. With the production fix in place, the kernel uses
+        a warp-stride loop so the capped grid still covers all rows.
+
+        ``lengths`` is sparse: zero everywhere except two sentinel rows
+        (start and end of the logical range). ``bucket_mapping`` is
+        constructed to be self-consistent with ``lengths`` and
+        ``bucketized_lengths``. The CPU dispatch produces the same
+        permutation; the GPU output must match it element-for-element.
+        """
+
+        # cuda_calc_xblock_count(N, 32) * 1024 ~= N * 32; need N > 2**27.
+        lengths_size = (1 << 27) + 1
+        my_size = 4  # <= kWarpSize so warp-parallel branch is taken
+
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+
+        # Sparse non-zero lengths at start and end. Total = 3.
+        lengths_cpu = torch.zeros(lengths_size, dtype=torch.int32)
+        lengths_cpu[0] = 2
+        lengths_cpu[lengths_size - 1] = 1
+
+        # bucketized_lengths: row r, bucket b is at index `b*lengths_size + r`.
+        # Place all of row 0's 2 indices in bucket 0, row last's 1 index in
+        # bucket 2. Other entries are zero.
+        bucketized_lengths_cpu = torch.zeros(lengths_size * my_size, dtype=torch.int32)
+        bucketized_lengths_cpu[0] = 2  # bucket 0, row 0
+        bucketized_lengths_cpu[2 * lengths_size + (lengths_size - 1)] = 1
+        # bucket_mapping: per-input-index, which bucket it goes to. Total
+        # input index count = sum(lengths) = 3.
+        bucket_mapping_cpu = torch.tensor([0, 0, 2], dtype=torch.int32)
+
+        # CPU reference oracle — same op, different dispatch.
+        bucketized_permute_cpu = torch.ops.fbgemm.populate_bucketized_permute(
+            lengths_cpu, bucketized_lengths_cpu, bucket_mapping_cpu
+        )
+
+        # GPU op under test. Pre-fix, this launch trips
+        # KernelLauncher::checkThreadCountNotExceeded on ROCm.
+        bucketized_permute_gpu = torch.ops.fbgemm.populate_bucketized_permute(
+            lengths_cpu.to(device),
+            bucketized_lengths_cpu.to(device),
+            bucket_mapping_cpu.to(device),
+        )
+
+        torch.testing.assert_close(bucketized_permute_gpu.cpu(), bucketized_permute_cpu)
 
 
 extend_test_class(BlockBucketizeTest)

--- a/fbgemm_gpu/test/sparse/cumsum_test.py
+++ b/fbgemm_gpu/test/sparse/cumsum_test.py
@@ -19,10 +19,14 @@ from .common import extend_test_class, open_source
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import cpu_and_maybe_gpu
+    from test_utils import cpu_and_maybe_gpu, gpu_memory_lt_gb, gpu_unavailable
 else:
     import fbgemm_gpu.sparse_ops  # noqa: F401, E402
-    from fbgemm_gpu.test.test_utils import cpu_and_maybe_gpu
+    from fbgemm_gpu.test.test_utils import (
+        cpu_and_maybe_gpu,
+        gpu_memory_lt_gb,
+        gpu_unavailable,
+    )
 
 
 class CumSumTest(unittest.TestCase):
@@ -49,7 +53,10 @@ class CumSumTest(unittest.TestCase):
         # The CPU variants of asynchronous_*_cumsum support floats, since some
         # downstream tests appear to be relying on this behavior.  As such, the
         # test is disabled for GPU + float test cases.
-        if device == torch.device("cuda") and pt_index_dtype is torch.float32:
+        if (
+            device == torch.accelerator.current_accelerator()
+            and pt_index_dtype is torch.float32
+        ):
             return
 
         # pyre-ignore-errors[16]
@@ -113,7 +120,10 @@ class CumSumTest(unittest.TestCase):
         # The CPU variants of asynchronous_*_cumsum support floats, since some
         # downstream tests appear to be relying on this behavior.  As such, the
         # test is disabled for GPU + float test cases.
-        if device == torch.device("cuda") and pt_index_dtype is torch.float32:
+        if (
+            device == torch.accelerator.current_accelerator()
+            and pt_index_dtype is torch.float32
+        ):
             return
 
         # pyre-ignore-errors[16]
@@ -161,6 +171,48 @@ class CumSumTest(unittest.TestCase):
         out = torch.ops.fbgemm.asynchronous_batched_complete_cumsum(values)
         out2 = cumsum_base(values)
         torch.testing.assert_close(out, out2)
+
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(4))
+    def test_asynchronous_batched_complete_cumsum_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in _batched_complete_cumsum_kernel
+        and verifies output correctness against the CPU dispatch at the same
+        scale.
+
+        With len=1, nthreads_per_block = max(next_power_of_2(1), 64) = 64.
+        Total threads = B * 64. For B > 2**26, total threads exceed the HIP
+        2**32 limit, causing FBGEMM_LAUNCH_KERNEL ->
+        KernelLauncher::checkThreadCountNotExceeded to TORCH_CHECK-fail on
+        ROCm pre-fix. With the production fix, the kernel grid-strides
+        over batches so the capped grid still covers all B rows.
+
+        ``values`` is sparse: zero everywhere except sentinel non-zero
+        entries at start / middle / end of the batch axis. Any "kernel
+        addressed wrong row" bug surfaces in the assertion below.
+        """
+
+        # B * 64 > 2**32 requires B > 2**26.
+        B = (1 << 26) + 1
+
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+
+        # Sparse non-zero values at sentinel positions.
+        values_cpu = torch.zeros((B, 1), dtype=torch.int32)
+        values_cpu[0, 0] = 1
+        values_cpu[B // 2, 0] = 2
+        values_cpu[B - 1, 0] = 3
+
+        # CPU reference oracle — same op, different dispatch.
+        cumsum_cpu = torch.ops.fbgemm.asynchronous_batched_complete_cumsum(values_cpu)
+
+        # GPU op under test. Pre-fix, this launch trips
+        # KernelLauncher::checkThreadCountNotExceeded on ROCm.
+        cumsum_gpu = torch.ops.fbgemm.asynchronous_batched_complete_cumsum(
+            values_cpu.to(device)
+        )
+
+        torch.testing.assert_close(cumsum_gpu.cpu(), cumsum_cpu)
 
 
 extend_test_class(CumSumTest)

--- a/fbgemm_gpu/test/sparse/misc_ops_test.py
+++ b/fbgemm_gpu/test/sparse/misc_ops_test.py
@@ -24,10 +24,14 @@ from .common import extend_test_class, open_source
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import gpu_available
+    from test_utils import gpu_available, gpu_memory_lt_gb, gpu_unavailable
 else:
     import fbgemm_gpu.sparse_ops  # noqa: F401, E402
-    from fbgemm_gpu.test.test_utils import gpu_available
+    from fbgemm_gpu.test.test_utils import (
+        gpu_available,
+        gpu_memory_lt_gb,
+        gpu_unavailable,
+    )
 
 
 class MiscOpsTest(unittest.TestCase):
@@ -194,6 +198,61 @@ class MiscOpsTest(unittest.TestCase):
             torch.testing.assert_close(
                 segment_sum_cuda.cpu().numel(), 0, rtol=0, atol=0
             )
+
+    @unittest.skipIf(*gpu_unavailable)
+    @unittest.skipIf(*gpu_memory_lt_gb(4))
+    def test_segment_sum_csr_large_grid(self) -> None:
+        """
+        Reproduces the HIP grid-overflow bug in _segment_sum_csr_cuda_kernel
+        and verifies output correctness against the CPU dispatch at the same
+        scale.
+
+        With threads_per_block=256, the launch grid is num_segments. Total
+        threads = num_segments * 256. For num_segments > 2**24, total threads
+        exceed the HIP 2**32 limit, causing FBGEMM_LAUNCH_KERNEL ->
+        KernelLauncher::checkThreadCountNotExceeded to TORCH_CHECK-fail on
+        ROCm pre-fix. With the production fix in place, the kernel
+        grid-strides over segments so the capped grid still covers all
+        ``num_segments`` rows.
+
+        ``csr_seg`` is sparse: most segments have length zero; sentinel
+        non-zero lengths at start / middle / end produce non-trivial,
+        position-dependent output that any "kernel addressed wrong row"
+        bug would surface.
+        """
+
+        # num_segments * 256 > 2**32 requires num_segments > 2**24.
+        num_segments = (1 << 24) + 1
+        mid = num_segments // 2
+
+        device = torch.device(torch.accelerator.current_accelerator() or "cuda")
+
+        # csr_seg[i+1] - csr_seg[i] = length of segment i. Non-zero
+        # lengths at sentinel positions only.
+        csr_seg_cpu = torch.empty(num_segments + 1, dtype=torch.int32)
+        csr_seg_cpu[0] = 0
+        csr_seg_cpu[1] = 2
+        csr_seg_cpu[2 : mid + 1] = 2
+        csr_seg_cpu[mid + 1] = 4
+        csr_seg_cpu[mid + 2 : num_segments] = 4
+        csr_seg_cpu[num_segments] = 5
+
+        # Distinct non-zero values so any bucket-misroute surfaces.
+        values_cpu = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], dtype=torch.float32)
+        batch_size = 1
+
+        # CPU reference oracle — same op, different dispatch.
+        output_cpu = torch.ops.fbgemm.segment_sum_csr(
+            batch_size, csr_seg_cpu, values_cpu
+        )
+
+        # GPU op under test. Pre-fix, this launch trips
+        # KernelLauncher::checkThreadCountNotExceeded on ROCm.
+        output_gpu = torch.ops.fbgemm.segment_sum_csr(
+            batch_size, csr_seg_cpu.to(device), values_cpu.to(device)
+        )
+
+        torch.testing.assert_close(output_gpu.cpu(), output_cpu)
 
     @given(
         batch_size=st.just(2),


### PR DESCRIPTION
Summary:
Tier-2 fix for HIP grid-overflow in `sparse_ops/sparse_async_batched_cumsum.cu`.

`_batched_complete_cumsum_kernel` previously used `blockIdx.x` directly to index rows. Capping the host-side grid without first adding a grid-stride loop would silently drop rows.

Changes:
- Add `const uint32_t B` as a new kernel parameter so the loop bound is explicit.
- Convert the kernel to a row-stride loop `for (uint32_t row = blockIdx.x; row < B; row += gridDim.x)` (Pattern C with CUB BlockScan).
- RESET per-row state at the top of each iteration: `BlockPrefixCallbackOp<val_t> prefix_op(0)` and `out[row][0] = 0`. Replace all `blockIdx.x` references with `row`.
- Add a trailing `__syncthreads()` (or `cub::CTA_SYNC()`) at the bottom of each row iteration so `temp_storage` is safe to reuse for the next BlockScan.
- Apply standard `#ifdef USE_ROCM min(B, get_max_thread_blocks(stream)) #else B #endif` cap. Update the `BATCHED_COMPLETE_CUMSUM_KERNEL` macro to take `num_blocks` as the grid arg and `B` as a new kernel arg.

Stacked on top of D105027063 (Tier-2 Diff 3/7). Plan:
`/home/bensonma415/.llms/plans/sparse_ops_rocm_grid_overflow_tier2_fix.plan.md` (Diff 4/7).

Reviewed By: henrylhtsang

Differential Revision: D105028336


