### PR TITLE
Fix x86 CPU CI OOM by capping Inductor compile threads

### DIFF
--- a/.github/workflows/fbgemm_gpu_ci_cpu.yml
+++ b/.github/workflows/fbgemm_gpu_ci_cpu.yml
@@ -203,6 +203,14 @@ jobs:
 
     - name: Test with PyTest
       timeout-minutes: ${{ matrix.host-machine.timeout }}
+      env:
+        # Serialize Inductor's C++ compile workers. By default Inductor spawns
+        # one worker per vCPU (16 on these runners), and the torch.compile-heavy
+        # TBE tests blow past the 32 GB RAM on x86 linux.4xlarge (c5.4xlarge),
+        # OOM-killing the runner agent ("lost communication"). The arm
+        # linux.arm64.m7g.4xlarge (64 GB) survives. Capping to 1 keeps peak
+        # memory in budget without changing test coverage or runner cost.
+        TORCHINDUCTOR_COMPILE_THREADS: 1
       run: . $PRELUDE; test_all_fbgemm_gpu_modules $BUILD_ENV
 
     - name: Push Wheel to PyPI


### PR DESCRIPTION
Summary:
The FBGEMM_GPU-CPU CI (fbgemm_gpu_ci_cpu.yml) test job dies on every x86
`linux.4xlarge` matrix cell with "The self-hosted runner lost communication
with the server", while every arm `linux.arm64.m7g.4xlarge` cell passes the
identical tests.

Root cause is memory, not a code bug:
- x86 linux.4xlarge is a c5.4xlarge: 16 vCPU / 32 GB RAM.
- arm linux.arm64.m7g.4xlarge is an m7g.4xlarge: 16 vCPU / 64 GB RAM.
- The torch.compile-heavy TBE tests (e.g. test_backward_adagrad_*, compile=True)
  trigger TorchInductor, which by default spawns one C++ compile worker per
  vCPU (16). Peak memory blows past 32 GB on x86 and the kernel OOM-killer
  takes down the runner agent, so the job log cuts off mid-test with no error
  and the server later reports "lost communication". The 64 GB arm box
  absorbs the same spike and passes.

Job log evidence: the log terminates mid-hypothesis-example during
test_backward_adagrad_fp32_pmNONE_cpu (~16 min into PyTest, before the 20 min
step timeout), with zero error/OOM/traceback markers -- the signature of an
abrupt host death.

Fix: set TORCHINDUCTOR_COMPILE_THREADS=1 on the "Test with PyTest" step to
serialize Inductor's compile workers. This keeps peak memory within the 32 GB
budget without changing test coverage, the matrix, or the runner instance type
(so no CI cost increase). If build time on the compile tests becomes a concern,
the value can be tuned up (e.g. 2-4) as long as it stays under the OOM
threshold.

Differential Revision: D109038088


