### PR TITLE
Fix residual fbgemm_dev OMH test-health issues (#5931)

### DIFF
--- a/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
+++ b/fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp
@@ -3039,7 +3039,10 @@ std::tuple<Tensor, Tensor, std::optional<Tensor>> permute_sparse_features_cpu(
   permuted_indices = at::empty(permuted_lengths_sum, indices.options());
   AT_DISPATCH_INDEX_TYPES(
       input_offsets.scalar_type(), "permute_data_kernel_1", ([&] {
-        FBGEMM_DISPATCH_FLOAT_AND_DOUBLE(
+        // Include Half to match permute_2D_sparse_data_cuda
+        // (FBGEMM_DISPATCH_ALL_TYPES_AND_DOUBLE), so half weights are supported
+        // on CPU as well and CPU/CUDA stay at dtype parity. T191384137
+        FBGEMM_DISPATCH_FLOAT_HALF_AND_DOUBLE(
             weights.has_value() ? weights.value().scalar_type()
                                 : at::ScalarType::Float,
             "permute_data_kernel_2",

--- a/fbgemm_gpu/test/quantize/hfp8_test.py
+++ b/fbgemm_gpu/test/quantize/hfp8_test.py
@@ -92,7 +92,12 @@ class TestHFP8QuantizationConversion(unittest.TestCase):
             exponent_bias,
             max_pos[exponent_bias],
             rtol=(2 ** (-mbits - 1)),
-            atol=0,
+            # rtol is exactly the half-ULP relative bound; with atol=0 there is
+            # zero absolute slack, so inputs landing on a representable-value
+            # boundary can round-trip a hair past the bound (flaky across
+            # hypothesis seeds). Use the denormal ULP as an absolute floor,
+            # matching the denormal-range branches below (T191384137).
+            atol=(2 ** (1 - exponent_bias - mbits)),
         )
 
         # test positive denormal range
@@ -120,7 +125,10 @@ class TestHFP8QuantizationConversion(unittest.TestCase):
             exponent_bias,
             max_pos[exponent_bias],
             rtol=(2 ** (-mbits - 1)),
-            atol=0,
+            # See the positive-normal branch: add an absolute ULP floor so the
+            # half-ULP relative bound is not flaky on boundary inputs
+            # (T191384137).
+            atol=(2 ** (1 - exponent_bias - mbits)),
         )
 
         # test negative denormal range

--- a/fbgemm_gpu/test/sparse/failures_dict.json
+++ b/fbgemm_gpu/test/sparse/failures_dict.json
@@ -22,6 +22,7 @@
     "fbgemm::asynchronous_exclusive_cumsum": {},
     "fbgemm::asynchronous_inclusive_cumsum": {},
     "fbgemm::batch_index_select_dim0": {},
+    "fbgemm::batch_index_select_dim0_tensor": {},
     "fbgemm::block_bucketize_sparse_features": {},
     "fbgemm::block_bucketize_sparse_features_2d_weights": {},
     "fbgemm::block_bucketize_sparse_features_inference": {},
@@ -108,6 +109,10 @@
     },
     "fbgemm::permute_1D_sparse_data": {},
     "fbgemm::permute_2D_sparse_data": {
+      "PermuteEmbeddingsTest.test_aot_dispatch_dynamic__test_permute_2D_sparse_data_weights_dtype": {
+        "comment": "Not an op bug. Same aot_autograd_check int64+float loss-cast issue as test_permute_indices_backward: this op returns (int64 lengths, int64 indices, float weights), so the harness loss `sm += o.sum().abs()` raises 'result type Float can't be cast to Long'. Real torch.compile/autograd is unaffected. T191384137",
+        "status": "skip"
+      },
       "PermuteIndicesTest.test_aot_dispatch_dynamic__test_permute_indices_backward": {
         "comment": "Not an op bug. The aot_autograd_check harness builds its test loss as `sm = 0; for o in outputs: sm += o.sum().abs()`. This op returns (int64 lengths, int64 indices, float weights) in that order, so sm becomes an int64 tensor from the integer outputs and the final `sm += weights.sum()` raises 'result type Float can't be cast to Long'. The op's backward is never reached, and real torch.compile/autograd (which sums only the user's float loss) is unaffected. Marked skip (not xfail) so it does not falsely flag the forward-PT2-compliant op via test_pt2_compliant_tag. Eager backward correctness is covered by test_permute_indices_backward.",
         "status": "skip"

--- a/fbgemm_gpu/test/sparse/permute_indices_test.py
+++ b/fbgemm_gpu/test/sparse/permute_indices_test.py
@@ -31,6 +31,7 @@ if open_source:
         gpu_memory_lt_gb,
         gpu_unavailable,
         on_oss_clang,
+        optests,
     )
 else:
     import fbgemm_gpu.sparse_ops  # noqa: F401, E402
@@ -39,6 +40,7 @@ else:
         gpu_memory_lt_gb,
         gpu_unavailable,
         on_oss_clang,
+        optests,
     )
 
 
@@ -799,6 +801,12 @@ class PermuteIndicesTest(unittest.TestCase):
     # Skip on GPUs with insufficient HBM (need a few hundred MB for the
     # int32 N-element tensors).
     @unittest.skipIf(*gpu_memory_lt_gb(4))
+    # GPU-memory-gated ROCm grid-overflow stress repro: the generated opcheck
+    # variants add no op-schema coverage and only produce SKIPPING test-health
+    # records on CPU/small-GPU runs (T191384137).
+    @optests.dontGenerateOpCheckTests(
+        "large-grid ROCm overflow stress repro; opcheck variants add no coverage"
+    )
     def test_permute_1D_sparse_data_large_grid(self) -> None:
         """
         Reproduces the HIP grid-overflow bug in permute_1D_sparse_data_cuda
@@ -870,6 +878,9 @@ class PermuteIndicesTest(unittest.TestCase):
     # Skip on GPUs with insufficient HBM (need ~512 MB for the int32
     # lengths tensor at the chosen B).
     @unittest.skipIf(*gpu_memory_lt_gb(4))
+    @optests.dontGenerateOpCheckTests(
+        "large-grid ROCm overflow stress repro; opcheck variants add no coverage (T191384137)"
+    )
     def test_permute_2D_sparse_data_large_grid(self) -> None:
         """
         Reproduces the HIP grid-overflow bug in permute_2D_sparse_data_cuda
@@ -946,6 +957,9 @@ class PermuteIndicesTest(unittest.TestCase):
     # Skip on GPUs with insufficient HBM (need ~512 MB for the int32
     # lengths tensor at the chosen B).
     @unittest.skipIf(*gpu_memory_lt_gb(4))
+    @optests.dontGenerateOpCheckTests(
+        "large-grid ROCm overflow stress repro; opcheck variants add no coverage (T191384137)"
+    )
     def test_permute_sparse_features_large_grid(self) -> None:
         """
         Reproduces the HIP grid-overflow bug in permute_sparse_features_cuda


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookresearch/FBGEMM/pull/2849

Durable fixes for the remaining fbgemm_dev OMH dashboard residuals after the
landed opcheck/flaky cleanup stack (T191384137). After reaping the stale
records whose fixes already landed in trunk, these were the genuine residuals:

- (kmeans) test_batched_kmeans_compute_l2distances compared the euclidean
  distance (||x||^2+||c||^2-2xc then sqrt) bit-exact vs cdist; GPU reduction
  order diverges. Widen fp32 to rtol/atol=1e-4/1e-3 and bf16 to 1e-2 (mirrors
  the squared-distance and fp16 paths).
- (hfp8) test_quantize_and_dequantize_op normal-range branches asserted with
  atol=0 and rtol = half-ULP; boundary inputs round-tripped a hair past the
  bound (flaky). Add an absolute ULP floor atol=2^(1-bias-mbits), matching the
  denormal branches.
- (permute_2D_sparse_data) the CPU kernel dispatched weights with
  FBGEMM_DISPATCH_FLOAT_AND_DOUBLE (no Half) while CUDA supports Half, so the
  random half draw in test_permute_2D_sparse_data_weights_dtype raised on CPU
  (flaky). Switch CPU to FBGEMM_DISPATCH_FLOAT_HALF_AND_DOUBLE for CPU/CUDA
  parity, and skip the aot_dispatch_dynamic opcheck variant (same int64+float
  aot_autograd_check loss-cast as test_permute_indices_backward).
- (batch_index_select_dim0_tensor) the tensor-arg variant has a value-dependent
  output numel (new_dynamic_size); CrossRefFakeMode/SchemaCheckMode cannot
  reconcile the unbacked SymInt with the concrete shape. xfail the faketensor +
  schema opcheck variants (the meta is correct; aot already passes via the
  landed _check_is_size).
- (layer_norm) test_swish_layer_norm drew device=cpu/cuda; the two paths
  decompose into different op sets so the single aot opcheck test flipped which
  per-op xfails were satisfied across draws. Make the device deterministic.
- (preproc) idscorelist_scores (floats from SCORE_SUM/MAX/MIN) compared with
  torch.equal, and sigrid float_features compared with default allclose
  (atol=1e-8); GPU-vs-legacy/CPU reduction order diverges. Use rtol/atol=1e-4.
- (permute_indices large_grid) the GPU-memory-gated ROCm grid-overflow stress
  repros generated opcheck variants that only SKIP on CPU/small-GPU runs (no op
  coverage). Mark them optests.dontGenerateOpCheckTests so no SKIPPING
  test-health records are produced.

Reviewed By: cthi

Differential Revision: D108979354


