### PR TITLE
Fix backward_dense health-check regression under the ci profile

### DIFF
--- a/fbgemm_gpu/test/tbe/training/backward_dense_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_dense_test.py
@@ -32,6 +32,7 @@ from ..common import (
     format_ref_tensors_in_mixed_B_layout,
     gen_mixed_B_batch_sizes,
     open_source,
+    suppressed_list,
 )
 
 if open_source:
@@ -78,6 +79,7 @@ class BackwardDenseTest(unittest.TestCase):
         verbosity=VERBOSITY,
         max_examples=10,
         deadline=None,
+        suppress_health_check=suppressed_list,
     )
     def test_backward_dense(  # noqa C901
         self,


### PR DESCRIPTION
Summary:
test_backward_dense regressed in OSS CI on 2026-06-15 (green before). D108096684
removed the per-test suppress_health_check from backward_dense_test.py and moved
it into the "derandomize" Hypothesis profile. OSS CI runs under the "ci"
profile, not "derandomize", so the suppression never applied -- the job log
shows `hypothesis profile 'ci' -> suppress_health_check=(HealthCheck.too_slow,)`.
The test's heavy assume() usage then trips HealthCheck.filter_too_much and fails.

Fix: apply suppress_health_check explicitly in settings via the centralized
suppressed_list from tbe/common.py, making it independent of the active profile
while keeping a single source of truth.

Differential Revision: D109164907


